### PR TITLE
DOC: Fix documentation for ``predecessors`` matrix in ``shortest_path``, ``bellman_ford``, ``johnson`` and ``dijkstra``

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -116,9 +116,11 @@ def shortest_path(csgraph, method='auto',
     dist_matrix : ndarray
         The N x N matrix of distances between graph nodes. dist_matrix[i,j]
         gives the shortest distance from point i to point j along the graph.
-    predecessors : ndarray
+    predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
-        The N x N matrix of predecessors, which can be used to reconstruct
+        If indices is None then n_indices = n_nodes and the shape of
+        the matrix becomes (n_nodes, n_nodes)
+        The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry
         predecessors[i, j] gives the index of the previous node in the
@@ -488,6 +490,8 @@ def dijkstra(csgraph, directed=True, indices=None,
     predecessors : ndarray, shape ([n_indices, ]n_nodes,)
         If min_only=False, this has shape (n_indices, n_nodes),
         otherwise it has shape (n_nodes,).
+        If indices is None and min_only=False then n_indices = n_nodes
+        and the shape of the matrix becomes (n_nodes, n_nodes)
         Returned only if return_predecessors == True.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
@@ -853,9 +857,11 @@ def bellman_ford(csgraph, directed=True, indices=None,
         The N x N matrix of distances between graph nodes. dist_matrix[i,j]
         gives the shortest distance from point i to point j along the graph.
 
-    predecessors : ndarray
+    predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
-        The N x N matrix of predecessors, which can be used to reconstruct
+        If indices is None then n_indices = n_nodes and the shape of
+        the matrix becomes (n_nodes, n_nodes)
+        The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry
         predecessors[i, j] gives the index of the previous node in the
@@ -1094,9 +1100,11 @@ def johnson(csgraph, directed=True, indices=None,
         The N x N matrix of distances between graph nodes. dist_matrix[i,j]
         gives the shortest distance from point i to point j along the graph.
 
-    predecessors : ndarray
+    predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
-        The N x N matrix of predecessors, which can be used to reconstruct
+        If indices is None then n_indices = n_nodes and the shape of
+        the matrix becomes (n_nodes, n_nodes)
+        The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry
         predecessors[i, j] gives the index of the previous node in the

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -118,7 +118,7 @@ def shortest_path(csgraph, method='auto',
         gives the shortest distance from point i to point j along the graph.
     predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
-        If indices is None then ``n_indices = n_nodes`` and the shape of
+        If `indices` is None then ``n_indices = n_nodes`` and the shape of
         the matrix becomes ``(n_nodes, n_nodes)``.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
@@ -490,7 +490,7 @@ def dijkstra(csgraph, directed=True, indices=None,
     predecessors : ndarray, shape ([n_indices, ]n_nodes,)
         If ``min_only=False``, this has shape ``(n_indices, n_nodes)``,
         otherwise it has shape ``(n_nodes,)``.
-        If indices is None and ``min_only=False`` then ``n_indices = n_nodes``
+        If `indices` is None and ``min_only=False`` then ``n_indices = n_nodes``
         and the shape of the matrix becomes ``(n_nodes, n_nodes)``.
         Returned only if return_predecessors == True.
         The matrix of predecessors, which can be used to reconstruct
@@ -858,8 +858,8 @@ def bellman_ford(csgraph, directed=True, indices=None,
         gives the shortest distance from point i to point j along the graph.
 
     predecessors : ndarray, shape (n_indices, n_nodes,)
-        Returned only if return_predecessors == True.
-        If indices is None then ``n_indices = n_nodes`` and the shape of
+        Returned only if ``return_predecessors=True``.
+        If `indices` is None then ``n_indices = n_nodes`` and the shape of
         the matrix becomes ``(n_nodes, n_nodes)``.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
@@ -1102,7 +1102,7 @@ def johnson(csgraph, directed=True, indices=None,
 
     predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
-        If indices is None then ``n_indices = n_nodes`` and the shape of
+        If `indices` is None then ``n_indices = n_nodes`` and the shape of
         the matrix becomes ``(n_nodes, n_nodes)``.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -119,7 +119,7 @@ def shortest_path(csgraph, method='auto',
     predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
         If indices is None then n_indices = n_nodes and the shape of
-        the matrix becomes (n_nodes, n_nodes)
+        the matrix becomes (n_nodes, n_nodes).
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry
@@ -491,7 +491,7 @@ def dijkstra(csgraph, directed=True, indices=None,
         If min_only=False, this has shape (n_indices, n_nodes),
         otherwise it has shape (n_nodes,).
         If indices is None and min_only=False then n_indices = n_nodes
-        and the shape of the matrix becomes (n_nodes, n_nodes)
+        and the shape of the matrix becomes (n_nodes, n_nodes).
         Returned only if return_predecessors == True.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
@@ -860,7 +860,7 @@ def bellman_ford(csgraph, directed=True, indices=None,
     predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
         If indices is None then n_indices = n_nodes and the shape of
-        the matrix becomes (n_nodes, n_nodes)
+        the matrix becomes (n_nodes, n_nodes).
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry
@@ -1103,7 +1103,7 @@ def johnson(csgraph, directed=True, indices=None,
     predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
         If indices is None then n_indices = n_nodes and the shape of
-        the matrix becomes (n_nodes, n_nodes)
+        the matrix becomes (n_nodes, n_nodes).
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -118,8 +118,8 @@ def shortest_path(csgraph, method='auto',
         gives the shortest distance from point i to point j along the graph.
     predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
-        If indices is None then n_indices = n_nodes and the shape of
-        the matrix becomes (n_nodes, n_nodes).
+        If indices is None then ``n_indices = n_nodes`` and the shape of
+        the matrix becomes ``(n_nodes, n_nodes)``.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry
@@ -490,8 +490,8 @@ def dijkstra(csgraph, directed=True, indices=None,
     predecessors : ndarray, shape ([n_indices, ]n_nodes,)
         If min_only=False, this has shape (n_indices, n_nodes),
         otherwise it has shape (n_nodes,).
-        If indices is None and min_only=False then n_indices = n_nodes
-        and the shape of the matrix becomes (n_nodes, n_nodes).
+        If indices is None and min_only=False then ``n_indices = n_nodes``
+        and the shape of the matrix becomes ``(n_nodes, n_nodes)``.
         Returned only if return_predecessors == True.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
@@ -859,8 +859,8 @@ def bellman_ford(csgraph, directed=True, indices=None,
 
     predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
-        If indices is None then n_indices = n_nodes and the shape of
-        the matrix becomes (n_nodes, n_nodes).
+        If indices is None then ``n_indices = n_nodes`` and the shape of
+        the matrix becomes ``(n_nodes, n_nodes)``.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry
@@ -1102,8 +1102,8 @@ def johnson(csgraph, directed=True, indices=None,
 
     predecessors : ndarray, shape (n_indices, n_nodes,)
         Returned only if return_predecessors == True.
-        If indices is None then n_indices = n_nodes and the shape of
-        the matrix becomes (n_nodes, n_nodes).
+        If indices is None then ``n_indices = n_nodes`` and the shape of
+        the matrix becomes ``(n_nodes, n_nodes)``.
         The matrix of predecessors, which can be used to reconstruct
         the shortest paths.  Row i of the predecessor matrix contains
         information on the shortest paths from point i: each entry

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -488,9 +488,9 @@ def dijkstra(csgraph, directed=True, indices=None,
         a given node the shortest path to that node from any of the nodes
         in indices.
     predecessors : ndarray, shape ([n_indices, ]n_nodes,)
-        If min_only=False, this has shape (n_indices, n_nodes),
-        otherwise it has shape (n_nodes,).
-        If indices is None and min_only=False then ``n_indices = n_nodes``
+        If ``min_only=False``, this has shape ``(n_indices, n_nodes)``,
+        otherwise it has shape ``(n_nodes,)``.
+        If indices is None and ``min_only=False`` then ``n_indices = n_nodes``
         and the shape of the matrix becomes ``(n_nodes, n_nodes)``.
         Returned only if return_predecessors == True.
         The matrix of predecessors, which can be used to reconstruct


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/13914#issuecomment-2605308851

#### What does this implement/fix?
<!--Please explain your changes.-->

Here's the code which shows the shape of ``predecessors`` matrix when ``indices`` is present and absent respectively,

```python
from scipy.sparse.csgraph import shortest_path, bellman_ford, johnson, dijkstra
from scipy.sparse import csr_array

graph = [
 [0, 0, 7, 0],
 [0, 0, 8, 5],
 [7, 8, 0, 0],
 [0, 5, 0, 0]
]

graph = csr_array(graph)
print(graph)

sources = [0, 2]
dist_matrix1, predecessors1 = shortest_path(csgraph=graph, directed=False, indices=sources, return_predecessors=True)
dist_matrix2, predecessors2 = bellman_ford(csgraph=graph, directed=False, indices=sources, return_predecessors=True)
dist_matrix3, predecessors3 = johnson(csgraph=graph, directed=False, indices=sources, return_predecessors=True)
dist_matrix4, predecessors4 = dijkstra(csgraph=graph, directed=False, indices=sources, return_predecessors=True, min_only=False)

print("indices=sources: ", predecessors1.shape, predecessors2.shape, predecessors3.shape, predecessors4.shape, (len(sources), graph.shape[0]))
assert((predecessors1 == predecessors2).all())
assert((predecessors1 == predecessors3).all())
assert((predecessors1 == predecessors4).all())

dist_matrix1, predecessors1 = shortest_path(csgraph=graph, directed=False, indices=None, return_predecessors=True)
dist_matrix2, predecessors2 = bellman_ford(csgraph=graph, directed=False, indices=None, return_predecessors=True)
dist_matrix3, predecessors3 = johnson(csgraph=graph, directed=False, indices=None, return_predecessors=True)
dist_matrix4, predecessors4 = dijkstra(csgraph=graph, directed=False, indices=None, return_predecessors=True, min_only=False)

print("indices=None: ", predecessors1.shape, predecessors2.shape, predecessors3.shape, predecessors4.shape, graph.shape)
assert((predecessors1 == predecessors2).all())
assert((predecessors1 == predecessors3).all())
assert((predecessors1 == predecessors4).all())
```

**Output**

```zsh
<Compressed Sparse Row sparse array of dtype 'int64'
        with 6 stored elements and shape (4, 4)>
  Coords        Values
  (0, 2)        7
  (1, 2)        8
  (1, 3)        5
  (2, 0)        7
  (2, 1)        8
  (3, 1)        5
indices=sources:  (2, 4) (2, 4) (2, 4) (2, 4) (2, 4) # size of indices was 2 and number of nodes was 4. So (2, 4) is the shape of the predecessors matrix. This is the update I made in the docs.
indices=None:  (4, 4) (4, 4) (4, 4) (4, 4) (4, 4) # indices was None and number of nodes was 4. So (4, 4) is the shape of the predecessors matrix. Covered in the doc changes I made. 
```

The output clearly highlights the updates I made in docs. When `indices=sources`, then the output shape is `(len(sources), n_nodes)`. And when `indices=None`, the shape is `(n_nodes, n_nodes)`.

#### Additional information
<!--Any additional information you think is important.-->
