### PR TITLE
DOC: signal: Use where='post' when plotting discrete response #21020

### DIFF
--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -3192,7 +3192,7 @@ def dimpulse(system, x0=None, t=None, n=None):
 
     >>> butter = signal.dlti(*signal.butter(3, 0.5))
     >>> t, y = signal.dimpulse(butter, n=25)
-    >>> plt.step(t, np.squeeze(y))
+    >>> plt.step(t, np.squeeze(y), where='post', label='(where="post")')
     >>> plt.grid()
     >>> plt.xlabel('n [samples]')
     >>> plt.ylabel('Amplitude')
@@ -3279,7 +3279,7 @@ def dstep(system, x0=None, t=None, n=None):
 
     >>> butter = signal.dlti(*signal.butter(3, 0.5))
     >>> t, y = signal.dstep(butter, n=25)
-    >>> plt.step(t, np.squeeze(y))
+    >>> plt.step(t, np.squeeze(y), where='post', label='(where="post")')
     >>> plt.grid()
     >>> plt.xlabel('n [samples]')
     >>> plt.ylabel('Amplitude')

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -3192,7 +3192,7 @@ def dimpulse(system, x0=None, t=None, n=None):
 
     >>> butter = signal.dlti(*signal.butter(3, 0.5))
     >>> t, y = signal.dimpulse(butter, n=25)
-    >>> plt.step(t, np.squeeze(y), where='post', label='(where="post")')
+    >>> plt.step(t, np.squeeze(y), where='post')
     >>> plt.grid()
     >>> plt.xlabel('n [samples]')
     >>> plt.ylabel('Amplitude')
@@ -3279,7 +3279,7 @@ def dstep(system, x0=None, t=None, n=None):
 
     >>> butter = signal.dlti(*signal.butter(3, 0.5))
     >>> t, y = signal.dstep(butter, n=25)
-    >>> plt.step(t, np.squeeze(y), where='post', label='(where="post")')
+    >>> plt.step(t, np.squeeze(y), where='post')
     >>> plt.grid()
     >>> plt.xlabel('n [samples]')
     >>> plt.ylabel('Amplitude')


### PR DESCRIPTION
#### Reference issue
Closes #21020.

#### What does this implement/fix?
This pull request updates the documentation for the `dstep` and `dimpulse` functions in the `scipy.signal` module to use `where='post'` when plotting discrete responses. This change ensures that the plots accurately represent the behavior of discrete-time systems, where the value at each sample point should hold until the next sample.

#### Additional information
This change addresses the issue raised in [#21020](https://github.com/scipy/scipy/issues/21020), where the default behavior of using `where='pre'` was found to be incorrect for discrete-time signals.