### PR TITLE
DOC: spatial: Added mention of Davenport Angles to Rotation class documentation

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -554,6 +554,7 @@ cdef class Rotation:
     - Rotation Vectors
     - Modified Rodrigues Parameters
     - Euler Angles
+    - Davenport Angles (Generalized Euler Angles)
 
     The following operations on rotations are supported:
 


### PR DESCRIPTION
Added line mentioning "Davenport Angles (Generalized Euler Angles)"

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
No Issue

#### What does this implement/fix?
Simply added missing line in documentation

