### PR TITLE
TST: remove thread-unsafe skips for a now fixed Cython fused types issue

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -183,7 +183,6 @@ class TestSolveBanded:
         x = solve_banded((l, u), ab, b)
         assert_array_almost_equal(dot(a, x), b)
 
-    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#6506
     @pytest.mark.parametrize('dt_ab', [int, float, np.float32, complex, np.complex64])
     @pytest.mark.parametrize('dt_b', [int, float, np.float32, complex, np.complex64])
     def test_empty(self, dt_ab, dt_b):

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -162,7 +162,6 @@ def test_label02(xp):
     assert n == 0
 
 
-@pytest.mark.thread_unsafe  # due to Cython fused types, see cython#6506
 def test_label03(xp):
     data = xp.ones([1])
     out, n = ndimage.label(data)

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -13,7 +13,6 @@ from scipy.signal import tf2ss, impulse, dimpulse, step, dstep
 
 
 class TestC2D:
-    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#6506
     def test_zoh(self):
         ac = np.eye(2, dtype=np.float64)
         bc = np.full((2, 1), 0.5, dtype=np.float64)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1429,7 +1429,6 @@ class TestResample:
         y = signal.resample(x, ny)
         xp_assert_close(y, np.asarray([1] * ny, dtype=y.dtype))
 
-    @pytest.mark.thread_unsafe  # due to Cython fused types, see cython#6506
     @pytest.mark.parametrize('padtype', padtype_options)
     def test_mutable_window(self, padtype, xp):
         # Test that a mutable window is not modified


### PR DESCRIPTION
This was Cython issue 6506, fixed a while back. The Cython nightly wheels and the latest conda-forge package (3.1.0a2.dev0) contain the fix.

[skip ci]