### PR TITLE
TYP: Runtime-subscriptable ``sparray`` and ``spmatrix`` types

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1394,6 +1394,29 @@ class _spbase:
 class sparray:
     """A namespace class to separate sparray from spmatrix"""
 
+    @classmethod
+    def __class_getitem__(cls, arg, /):
+        """
+        Return a parametrized wrapper around the `~scipy.sparse.sparray` type.
+
+        .. versionadded:: 1.16.0
+
+        Returns
+        -------
+        alias : types.GenericAlias
+            A parametrized `~scipy.sparse.sparray` type.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from scipy.sparse import coo_array
+
+        >>> coo_array[np.int8, tuple[int]]
+        scipy.sparse._coo.coo_array[numpy.int8, tuple[int]]
+        """
+        from types import GenericAlias
+        return GenericAlias(cls, arg)
+
 
 sparray.__doc__ = _spbase.__doc__
 

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -144,3 +144,26 @@ class spmatrix:
             `numpy.matrix` object that shares the same memory.
         """
         return super().todense(order, out)
+
+    @classmethod
+    def __class_getitem__(cls, arg, /):
+        """
+        Return a parametrized wrapper around the `~scipy.sparse.spmatrix` type.
+
+        .. versionadded:: 1.16.0
+
+        Returns
+        -------
+        alias : types.GenericAlias
+            A parametrized `~scipy.sparse.spmatrix` type.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from scipy.sparse import coo_matrix
+
+        >>> coo_matrix[np.int8]
+        scipy.sparse._coo.coo_matrix[numpy.int8]
+        """
+        from types import GenericAlias
+        return GenericAlias(cls, arg)


### PR DESCRIPTION
This makes it possible to use the `scipy.sparse` arrays and matrices as generic types within runtime annotations, dual to their generic definitions in [`scipy-stubs`](https://github.com/jorenham/scipy-stubs).

Prior to this change, this required either a `from __future__ import annotations`, or the manual "stringification" of the generic type annotation. Because otherwise, the following would have raised a `TypeError`, even though static type-checkers will accept this (when using the upcoming `scipy-stubs == 1.15.1.1` release).

```py
import numpy as np
from typing import Any, TypeIs
from scipy.sparse import sparray, spmatrix

def is_sp_int_1d(a: sparray | sparray, /) -> TypeIs[sparray[np.integer, tuple[int]]]:
    return x.ndim == 1 and x.dtype.kind in "iu"
```

<details>
<summary>In <code>scipy-stubs</code>, the <code>sparray</code> and <code>spmatrix</code> types are annotated using the following generic type signatures:</summary>

- `sparray[+ScalarT: Numeric = ..., +ShapeT: AtLeast1D = ...]`
- `spmatrix[+ScalarT: Numeric = ...]`

The `= ...` indicates that the type-parameters are optional (PEP 696), and the `+` prefix denotes covariance. The upper bounds are defined as follows (using PEP 695 syntax and with `numpy >=2.2`):

```py
import numpy as np

type Numeric = (
    np.bool 
    | np.integer 
    | np.float32 | np.float64 | np.longdouble
    | np.complexfloating
)
type AtLeast1D = tuple[int, *tuple[int, ...]]
```

Note that `Numeric | np.float16` is (almost always) equivalent to `np.number`.

In `scipy-stubs`, the `sparse._base._spbase` type is also generic, and it uses the same parametrization as `sparray`. But since it's not part of the public API, I chose to not include `_spbase` in this PR. But if anyone wants me to, then I'd be happy to also include it as well.

Relevant code:

- `_spbase`: https://github.com/jorenham/scipy-stubs/blob/9afa8e39345120c54b7310715fac27713bcbe812/scipy-stubs/sparse/_base.pyi#L113
- `sparray`: https://github.com/jorenham/scipy-stubs/blob/9afa8e39345120c54b7310715fac27713bcbe812/scipy-stubs/sparse/_base.pyi#L1036
- `spmatrix`: https://github.com/jorenham/scipy-stubs/blob/9afa8e39345120c54b7310715fac27713bcbe812/scipy-stubs/sparse/_matrix.pyi#L52
- `Numeric`: https://github.com/jorenham/scipy-stubs/blob/9afa8e39345120c54b7310715fac27713bcbe812/scipy-stubs/sparse/_typing.pyi#L26-L29
- `AtLeast1D`: https://github.com/jorenham/optype/blob/660e970d88bf3a7f147cba39639cf8d51220b41b/optype/numpy/_shape.py#L42-L46

</details>