### PR TITLE
BUG: wrap median_filter stability

### DIFF
--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -155,6 +155,7 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
                   int mode, T cval, int origin) {
   int i, arr_len_thresh, lim = (win_len - 1) / 2 - origin;
   int lim2 = arr_len - lim;
+  int offset;
   Mediator *m = MediatorNew(win_len, rank);
   T *data = new T[win_len];
 
@@ -180,7 +181,13 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
     }
     break;
   case WRAP:
-    for (i = arr_len - lim - 1 - 2 * origin; i < arr_len; i++) {
+    if (win_len % 2 == 0) {
+        offset = 2;
+    }
+    else {
+        offset = 0;
+    }
+    for (i = arr_len - lim - offset - 2 * origin; i < arr_len; i++) {
       MediatorInsert(data, m, in_arr[i]);
     }
     break;
@@ -222,7 +229,7 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
     }
     break;
   case WRAP:
-    for (i = 0; i < win_len; i++) {
+    for (i = 0; i < lim; i++) {
       MediatorInsert(data, m, in_arr[i]);
       out_arr[lim2 + i] = data[m->heap[0]];
     }

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -158,6 +158,10 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
   int offset;
   Mediator *m = MediatorNew(win_len, rank);
   T *data = new T[win_len];
+  for (int i = 0; i < win_len; ++i) {
+    data[i] = 0;
+  }
+
 
   switch (mode) {
   case REFLECT:

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -5,7 +5,7 @@ import re
 
 import numpy as np
 import pytest
-from numpy.testing import suppress_warnings
+from numpy.testing import suppress_warnings, assert_allclose
 from pytest import raises as assert_raises
 from scipy import ndimage
 from scipy._lib._array_api import (
@@ -2812,3 +2812,42 @@ def test_byte_order_median(xp):
     b = xp.arange(9, dtype='>f4').reshape(3, 3)
     t = ndimage.median_filter(b, (3, 3))
     assert_array_almost_equal(ref, t)
+
+
+
+@pytest.mark.parametrize("filter_size, exp", [
+    # expected results from SciPy 1.14.1
+    (20, 0.25754605),
+    (10,
+     np.array([0.25266576, 0.27894721, 0.30445588, 0.30958242, 0.30445588, 0.30445588,
+               0.27894721, 0.30445588, 0.27894721, 0.30445588, 0.30445588, 0.25754605,
+               0.22183391, 0.18015438, 0.22183391, 0.25266576, 0.25754605, 0.25266576,
+               0.25266576, 0.25266576]),
+     ),
+     # a median filter size of 1 is just an identity operation
+     (1,
+      np.array([0.30958242, 0.17555138, 0.34343917, 0.27894721, 0.03767094, 0.39024894,
+                0.30445588, 0.31442572, 0.05124545, 0.18015438, 0.14831921, 0.370706,
+                0.25754605, 0.32910465, 0.17736568, 0.09089549, 0.22183391, 0.0255269,
+                0.33105247, 0.25266576]),
+     ),
+     # testing odd-sized filters >1 makes sense too
+     (3,
+      np.array([0.25266576, 0.30958242, 0.27894721, 0.27894721, 0.27894721, 0.30445588,
+                0.31442572, 0.30445588, 0.18015438, 0.14831921, 0.18015438, 0.25754605,
+                0.32910465, 0.25754605, 0.17736568, 0.17736568, 0.09089549, 0.22183391,
+                0.25266576, 0.30958242]),
+     ),
+     (15,
+      np.array([0.27894721, 0.25266576, 0.25266576, 0.25266576, 0.27894721, 0.27894721,
+                0.27894721, 0.27894721, 0.25754605, 0.25754605, 0.22183391, 0.22183391,
+                0.25266576, 0.25266576, 0.22183391, 0.22183391, 0.25266576, 0.25266576,
+                0.25754605, 0.25754605]),
+     ),
+])
+def test_gh_22250(filter_size, exp):
+    rng = np.random.default_rng(42)
+    image = np.zeros((20,))
+    noisy_image = image + 0.4 * rng.random(image.shape)
+    result = ndimage.median_filter(noisy_image, size=filter_size, mode='wrap')
+    assert_allclose(result, exp)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -5,7 +5,7 @@ import re
 
 import numpy as np
 import pytest
-from numpy.testing import suppress_warnings, assert_allclose
+from numpy.testing import suppress_warnings, assert_allclose, assert_array_equal
 from pytest import raises as assert_raises
 from scipy import ndimage
 from scipy._lib._array_api import (
@@ -2814,7 +2814,6 @@ def test_byte_order_median(xp):
     assert_array_almost_equal(ref, t)
 
 
-
 @pytest.mark.parametrize("filter_size, exp", [
     # expected results from SciPy 1.14.1
     (20, 0.25754605),
@@ -2851,3 +2850,10 @@ def test_gh_22250(filter_size, exp):
     noisy_image = image + 0.4 * rng.random(image.shape)
     result = ndimage.median_filter(noisy_image, size=filter_size, mode='wrap')
     assert_allclose(result, exp)
+
+
+def test_gh_22333():
+    x = np.array([272, 58, 67, 163, 463, 608, 87, 108, 1378])
+    expected = [58, 67, 87, 108, 163, 108, 108, 108, 87]
+    actual = ndimage.median_filter(x, size=9, mode='constant')
+    assert_array_equal(actual, expected)


### PR DESCRIPTION
* Fixes gh-22250
* Fixes gh-22325
* Fixes gh-22333

* The shims in this branch ~seem to substantially improve the probability of the new~ allow `test_gh_22250` to pass under high repeat counts with `pytest-repeat` on Linux. ~There still seems to be a memory instability that leads to stochastically incorrect results between test incantations though.~

* ~I wonder if any of the memory issues Warren mentions at gh-22365 might be related to the instability (Warren suggests the *crashes* are not related, but I'm no longer seeing crashes on Linux on this branch).~ (kind of, Warren mentioned unchecked memory for `data`, but it was specifically the lack of *initialization*/zeroing out that was causing algorithmic problems on Linux, separate from the index segfault).

~[ci skip] [skip cirrus]~

