### PR TITLE
ENH: linalg: Rewrite `sqrtm` in C with low-level nD support

### DIFF
--- a/benchmarks/benchmarks/linalg_sqrtm.py
+++ b/benchmarks/benchmarks/linalg_sqrtm.py
@@ -12,22 +12,18 @@ with safe_import():
 class Sqrtm(Benchmark):
     params = [
         ['float64', 'complex128'],
-        [64, 256],
-        [32, 64, 256]
+        [16, 32, 64, 256, 512],
     ]
-    param_names = ['dtype', 'n', 'blocksize']
+    param_names = ['dtype', 'n']
 
-    def setup(self, dtype, n, blocksize):
+    def setup(self, dtype, n):
         n = int(n)
+        rng = np.random.default_rng(1742808411247533)
         dtype = np.dtype(dtype)
-        blocksize = int(blocksize)
-        A = np.random.rand(n, n)
+        A = rng.uniform(size=[n, n])
         if dtype == np.complex128:
-            A = A + 1j*np.random.rand(n, n)
+            A = A + 1j*rng.uniform(size=[n, n])
         self.A = A
 
-        if blocksize > n:
-            raise NotImplementedError()
-
-    def time_sqrtm(self, dtype, n, blocksize):
-        scipy.linalg.sqrtm(self.A, disp=False, blocksize=blocksize)
+    def time_sqrtm(self, dtype, n):
+        scipy.linalg.sqrtm(self.A, disp=False)

--- a/mypy.ini
+++ b/mypy.ini
@@ -150,6 +150,9 @@ ignore_missing_imports = True
 [mypy-scipy.linalg._decomp_interpolative]
 ignore_missing_imports = True
 
+[mypy-scipy.linalg._matfuncs_schur_sqrtm]
+ignore_missing_imports = True
+
 [mypy-scipy.optimize._group_columns]
 ignore_missing_imports = True
 

--- a/scipy/linalg/_common_array_utils.h
+++ b/scipy/linalg/_common_array_utils.h
@@ -1,0 +1,314 @@
+#ifndef _SCIPY_COMMON_ARRAY_UTILS_H
+#define _SCIPY_COMMON_ARRAY_UTILS_H
+
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+#include <math.h>
+#include "numpy/arrayobject.h"
+
+#if defined(_MSC_VER)
+    #include <complex.h>
+    #define SCIPY_Z _Dcomplex
+    #define SCIPY_C _Fcomplex
+    #define CPLX_Z(real, imag) (_Cbuild(real, imag))
+    #define CPLX_C(real, imag) (_FCbuild(real, imag))
+#else
+    #include <complex.h>
+    #define SCIPY_Z double complex
+    #define SCIPY_C float complex
+    #define CPLX_Z(real, imag) (real + imag*I)
+    #define CPLX_C(real, imag) (real + imag*I)
+#endif
+
+// BLAS and LAPACK functions used
+void saxpy_(int* n, float* sa, float* sx, int* incx, float* sy, int* incy);
+void scopy_(int* n, float* dx, int* incx, float* dy, int* incy);
+void sgees_(char* jobvs, char* sort, int (*select)(float*, float*), int* n, float* a, int* lda, int* sdim, float* wr, float* wi, float* vs, int* ldvs, float* work, int* lwork, int* bwork, int* info);
+void sgemm_(char* transa, char* transb, int* m, int* n, int* k, float* alpha, float* a, int* lda, float* b, int* ldb, float* beta, float* c, int* ldc);
+void sgemv_(char* trans, int* m, int* n, float* alpha, float* a, int* lda, float* x, int* incx, float* beta, float* y, int* incy);
+void sgetrf_(int* m, int* n, float* a, int* lda, int* ipiv, int* info);
+void sgetrs_(char* trans, int* n, int* nrhs, float* a, int* lda, int* ipiv, float* b, int* ldb, int* info);
+void slacn2_(int* n, float* v, float* x, int* isgn, float* est, int* kase, int* isave);
+void slanv2_(float* a, float* b, float* c, float* d, float* rt1r, float* rt1i, float* rt2r, float* rt2i, float* cs, float* sn);
+void sscal_(int* n, float* sa, float* sx, int* incx);
+void strsyl_(char* trana, char* tranb, int* isgn, int* m, int* n, float* a, int* lda, float* b, int* ldb, float* c, int* ldc, float* scale, int* info);
+// void strsyl3_(char* trana, char* tranb, int* isgn, int* m, int* n, float* a, int* lda, float* b, int* ldb, float* c, int* ldc, float* scale, int* iwork, int* liwork, float* swork, int* ldswork, int* info);
+
+void daxpy_(int* n, double* sa, double* sx, int* incx, double* sy, int* incy);
+void dcopy_(int* n, double* dx, int* incx, double* dy, int* incy);
+void dgees_(char* jobvs, char* sort, int (*select)(double*, double*), int* n, double* a, int* lda, int* sdim, double* wr, double* wi, double* vs, int* ldvs, double* work, int* lwork, int* bwork, int* info);
+void dgemm_(char* transa, char* transb, int* m, int* n, int* k, double* alpha, double* a, int* lda, double* b, int* ldb, double* beta, double* c, int* ldc);
+void dgemv_(char* trans, int* m, int* n, double* alpha, double* a, int* lda, double* x, int* incx, double* beta, double* y, int* incy);
+void dgetrf_(int* m, int* n, double* a, int* lda, int* ipiv, int* info);
+void dgetrs_(char* trans, int* n, int* nrhs, double* a, int* lda, int* ipiv, double* b, int* ldb, int* info);
+void dlacn2_(int* n, double* v, double* x, int* isgn, double* est, int* kase, int* isave);
+void dlanv2_(double* a, double* b, double* c, double* d, double* rt1r, double* rt1i, double* rt2r, double* rt2i, double* cs, double* sn);
+void dscal_(int* n, double* sa, double* sx, int* incx);
+void dtrsyl_(char* trana, char* tranb, int* isgn, int* m, int* n, double* a, int* lda, double* b, int* ldb, double* c, int* ldc, double* scale, int* info);
+// void dtrsyl3_(char* trana, char* tranb, int* isgn, int* m, int* n, double* a, int* lda, double* b, int* ldb, double* c, int* ldc, double* scale, int* iwork, int* liwork, double* swork, int* ldswork, int* info);
+
+void caxpy_(int* n, SCIPY_C* sa, SCIPY_C* sx, int* incx, SCIPY_C* sy, int* incy);
+void ccopy_(int* n, SCIPY_C* dx, int* incx, SCIPY_C* dy, int* incy);
+void cgees_(char* jobvs, char* sort, int (*select)(SCIPY_C), int* n, SCIPY_C* a, int* lda, int* sdim, SCIPY_C* w, SCIPY_C* vs, int* ldvs, SCIPY_C* work, int* lwork, float* rwork, int* bwork, int* info);
+void cgemm_(char* transa, char* transb, int* m, int* n, int* k, SCIPY_C* alpha, SCIPY_C* a, int* lda, SCIPY_C* b, int* ldb, SCIPY_C* beta, SCIPY_C* c, int* ldc);
+void cgemv_(char* trans, int* m, int* n, SCIPY_C* alpha, SCIPY_C* a, int* lda, SCIPY_C* x, int* incx, SCIPY_C* beta, SCIPY_C* y, int* incy);
+void cgetrf_(int* m, int* n, SCIPY_C* a, int* lda, int* ipiv, int* info);
+void cgetrs_(char* trans, int* n, int* nrhs, SCIPY_C* a, int* lda, int* ipiv, SCIPY_C* b, int* ldb, int* info);
+void clacn2_(int* n, SCIPY_C* v, SCIPY_C* x, float* est, int* kase, int* isave);
+void crot_(int* n, SCIPY_C* cx, int* incx, SCIPY_C* cy, int* incy, float* c, SCIPY_C* s);
+void csscal_(int* n, float* sa, SCIPY_C* sx, int* incx);
+void ctrsyl_(char* trana, char* tranb, int* isgn, int* m, int* n, SCIPY_C* a, int* lda, SCIPY_C* b, int* ldb, SCIPY_C* c, int* ldc, float* scale, int* info);
+// void ctrsyl3_(char* trana, char* tranb, int* isgn, int* m, int* n, SCIPY_C* a, int* lda, SCIPY_C* b, int* ldb, SCIPY_C* c, int* ldc, float* scale, float* swork, int* ldswork, int* info);
+
+void zaxpy_(int* n, SCIPY_Z* sa, SCIPY_Z* sx, int* incx, SCIPY_Z* sy, int* incy);
+void zcopy_(int* n, SCIPY_Z* dx, int* incx, SCIPY_Z* dy, int* incy);
+void zgees_(char* jobvs, char* sort, int (*select)(SCIPY_Z), int* n, SCIPY_Z* a, int* lda, int* sdim, SCIPY_Z* w, SCIPY_Z* vs, int* ldvs, SCIPY_Z* work, int* lwork, double* rwork, int* bwork, int* info);
+void zgemm_(char* transa, char* transb, int* m, int* n, int* k, SCIPY_Z* alpha, SCIPY_Z* a, int* lda, SCIPY_Z* b, int* ldb, SCIPY_Z* beta, SCIPY_Z* c, int* ldc);
+void zgemv_(char* trans, int* m, int* n, SCIPY_Z* alpha, SCIPY_Z* a, int* lda, SCIPY_Z* x, int* incx, SCIPY_Z* beta, SCIPY_Z* y, int* incy);
+void zgetrf_(int* m, int* n, SCIPY_Z* a, int* lda, int* ipiv, int* info);
+void zgetrs_(char* trans, int* n, int* nrhs, SCIPY_Z* a, int* lda, int* ipiv, SCIPY_Z* b, int* ldb, int* info);
+void zlacn2_(int* n, SCIPY_Z* v, SCIPY_Z* x, double* est, int* kase, int* isave);
+void zrot_(int* n, SCIPY_Z* cx, int* incx, SCIPY_Z* cy, int* incy, double* c, SCIPY_Z* s);
+void zdscal_(int* n, double* sa, SCIPY_Z* sx, int* incx);
+void ztrsyl_(char* trana, char* tranb, int* isgn, int* m, int* n, SCIPY_Z* a, int* lda, SCIPY_Z* b, int* ldb, SCIPY_Z* c, int* ldc, double* scale, int* info);
+// void ztrsyl3_(char* trana, char* tranb, int* isgn, int* m, int* n, SCIPY_Z* a, int* lda, SCIPY_Z* b, int* ldb, SCIPY_Z* c, int* ldc, double* scale, double* swork, int* ldswork, int* info);
+
+
+static inline void
+swap_cf_s(float* restrict a, float* restrict b, const Py_ssize_t r, const Py_ssize_t c, const Py_ssize_t n)
+{
+    Py_ssize_t i, j, ith_row, r2, c2;
+    float *bb = b;
+    float *aa = a;
+    if (r < 16) {
+        for (j = 0; j < c; j++)
+        {
+            ith_row = 0;
+            for (i = 0; i < r; i++) {
+                bb[ith_row] = aa[i];
+                ith_row += n;
+            }
+            aa += n;
+            bb += 1;
+        }
+    } else {
+        // If tall
+        if (r > c)
+        {
+            r2 = r/2;
+            swap_cf_s(a, b, r2, c, n);
+            swap_cf_s(a + r2, b+(r2)*n, r-r2, c, n);
+        } else {  // Nope
+            c2 = c/2;
+            swap_cf_s(a, b, r, c2, n);
+            swap_cf_s(a+(c2)*n, b+c2, r, c-c2, n);
+        }
+    }
+}
+
+
+static inline void
+swap_cf_d(double* restrict a, double* restrict b, const Py_ssize_t r, const Py_ssize_t c, const Py_ssize_t n)
+{
+    Py_ssize_t i, j, ith_row, r2, c2;
+    double *bb = b;
+    double *aa = a;
+    if (r < 16) {
+        for (j = 0; j < c; j++)
+        {
+            ith_row = 0;
+            for (i = 0; i < r; i++) {
+                bb[ith_row] = aa[i];
+                ith_row += n;
+            }
+            aa += n;
+            bb += 1;
+        }
+    } else {
+        // If tall
+        if (r > c)
+        {
+            r2 = r/2;
+            swap_cf_d(a, b, r2, c, n);
+            swap_cf_d(a + r2, b+(r2)*n, r-r2, c, n);
+        } else {  // Nope
+            c2 = c/2;
+            swap_cf_d(a, b, r, c2, n);
+            swap_cf_d(a+(c2)*n, b+c2, r, c-c2, n);
+        }
+    }
+}
+
+
+static inline void
+swap_cf_c(SCIPY_C* restrict a, SCIPY_C* restrict b, const Py_ssize_t r, const Py_ssize_t c, const Py_ssize_t n)
+{
+    Py_ssize_t i, j, ith_row, r2, c2;
+    SCIPY_C *bb = b;
+    SCIPY_C *aa = a;
+    if (r < 16) {
+        for (j = 0; j < c; j++)
+        {
+            ith_row = 0;
+            for (i = 0; i < r; i++) {
+                bb[ith_row] = aa[i];
+                ith_row += n;
+            }
+            aa += n;
+            bb += 1;
+        }
+    } else {
+        // If tall
+        if (r > c)
+        {
+            r2 = r/2;
+            swap_cf_c(a, b, r2, c, n);
+            swap_cf_c(a + r2, b+(r2)*n, r-r2, c, n);
+        } else {  // Nope
+            c2 = c/2;
+            swap_cf_c(a, b, r, c2, n);
+            swap_cf_c(a+(c2)*n, b+c2, r, c-c2, n);
+        }
+    }
+}
+
+
+static inline void
+swap_cf_z(SCIPY_Z* restrict a, SCIPY_Z* restrict b, const Py_ssize_t r, const Py_ssize_t c, const Py_ssize_t n)
+{
+    Py_ssize_t i, j, ith_row, r2, c2;
+    SCIPY_Z *bb = b;
+    SCIPY_Z *aa = a;
+    if (r < 16) {
+        for (j = 0; j < c; j++)
+        {
+            ith_row = 0;
+            for (i = 0; i < r; i++) {
+                bb[ith_row] = aa[i];
+                ith_row += n;
+            }
+            aa += n;
+            bb += 1;
+        }
+    } else {
+        // If tall
+        if (r > c)
+        {
+            r2 = r/2;
+            swap_cf_z(a, b, r2, c, n);
+            swap_cf_z(a + r2, b+(r2)*n, r-r2, c, n);
+        } else {  // Nope
+            c2 = c/2;
+            swap_cf_z(a, b, r, c2, n);
+            swap_cf_z(a+(c2)*n, b+c2, r, c-c2, n);
+        }
+    }
+}
+
+/*
+ * Function:  isschur/isschurf
+ * ---------------------------
+ * checks whether a square array is (quasi)upper triangular and if any 2x2 blocks
+ * are present whether these block are in the form of [[a, b], [c, a]] where b*c < 0.
+ * This is to check that the 2x2 blocks have actually complex eigenvalues needed
+ * for various algorithms.
+ *
+ *  data: the float/double array to be checked (in Fortran-contiguous layout)
+ *  n: the size of the array
+ *
+ *  returns: a int value indicating it is Schur (1) or not (0).
+ *
+ * For complex arrays, being Schur is equivalent to being upper triangular.
+ */
+int
+isschurf(const float* restrict data, const size_t n)
+{
+    float prev_a, prev_b;
+    int isSchur = 1;
+    int expect_zero = 0;
+    for (size_t j = 0; j < n; j++) {
+        if (data[j*n + j+1] == 0.0f) {
+            // Subdiagonal is zero
+            if (expect_zero) {
+                // Previous column had a non-zero entry and this marks the 2x2
+                // block. Check the [[a, b], [c, a]] form with b*c < 0.
+                if ((prev_a == data[j*n + j]) && (prev_b*data[j*n + j-1] < 0.0))
+                {
+                    expect_zero = 0; // All good, reset the flag
+                } else {
+                    // Broken 2x2 form
+                    return 0;
+                }
+            }
+            expect_zero = 0;
+        } else {
+            // Subdiagonal is non-zero. Either first column of 2x2 or not Schur
+            if (expect_zero)
+            {
+                // Already nonzero in the previous col so not Schur.
+                return 0;
+            } else {
+                // First column of 2x2 block
+                prev_a = data[j*n + j];
+                prev_b = data[j*n + j+1];
+                expect_zero = 1; // Next should be zero
+            }
+        }
+
+        // Check the remaining entries in the col for zero.
+        if (j < n - 2)
+        {
+            for (size_t i = j+2; i < n; i++) {
+                if (data[j*n + i] != 0.0f) {
+                    // Nonzero value below the subdiagonal
+                    return 0;
+                }
+            }
+        }
+        if (!isSchur) { break; }
+    }
+    return isSchur;
+}
+
+
+int
+isschur(const double* restrict data, const size_t n)
+{
+    double prev_a, prev_b;
+    int isSchur = 1;
+    int expect_zero = 0;
+    for (size_t j = 0; j < n; j++) {
+        if (data[j*n + j+1] == 0.0) {
+            if (expect_zero) {
+                if ((prev_a == data[j*n + j]) && (prev_b*data[j*n + j-1] < 0.0))
+                {
+                    expect_zero = 0;
+                } else {
+                    return 0;
+                }
+            }
+            expect_zero = 0;
+        } else {
+            if (expect_zero)
+            {
+                return 0;
+            } else {
+                prev_a = data[j*n + j];
+                prev_b = data[j*n + j+1];
+                expect_zero = 1;
+            }
+        }
+        if (j < n - 2)
+        {
+            for (size_t i = j+2; i < n; i++) {
+                if (data[j*n + i] != 0.0) {
+                    return 0;
+                }
+            }
+        }
+        if (!isSchur) { break; }
+    }
+    return isSchur;
+}
+
+#endif

--- a/scipy/linalg/_common_array_utils.h
+++ b/scipy/linalg/_common_array_utils.h
@@ -221,12 +221,12 @@ swap_cf_z(SCIPY_Z* restrict a, SCIPY_Z* restrict b, const Py_ssize_t r, const Py
  * For complex arrays, being Schur is equivalent to being upper triangular.
  */
 int
-isschurf(const float* restrict data, const size_t n)
+isschurf(const float* restrict data, const Py_ssize_t n)
 {
     float prev_a, prev_b;
     int isSchur = 1;
     int expect_zero = 0;
-    for (size_t j = 0; j < n; j++) {
+    for (Py_ssize_t j = 0; j < n; j++) {
         if (data[j*n + j+1] == 0.0f) {
             // Subdiagonal is zero
             if (expect_zero) {
@@ -258,7 +258,7 @@ isschurf(const float* restrict data, const size_t n)
         // Check the remaining entries in the col for zero.
         if (j < n - 2)
         {
-            for (size_t i = j+2; i < n; i++) {
+            for (Py_ssize_t i = j+2; i < n; i++) {
                 if (data[j*n + i] != 0.0f) {
                     // Nonzero value below the subdiagonal
                     return 0;
@@ -272,12 +272,12 @@ isschurf(const float* restrict data, const size_t n)
 
 
 int
-isschur(const double* restrict data, const size_t n)
+isschur(const double* restrict data, const Py_ssize_t n)
 {
     double prev_a, prev_b;
     int isSchur = 1;
     int expect_zero = 0;
-    for (size_t j = 0; j < n; j++) {
+    for (Py_ssize_t j = 0; j < n; j++) {
         if (data[j*n + j+1] == 0.0) {
             if (expect_zero) {
                 if ((prev_a == data[j*n + j]) && (prev_b*data[j*n + j-1] < 0.0))
@@ -300,7 +300,7 @@ isschur(const double* restrict data, const size_t n)
         }
         if (j < n - 2)
         {
-            for (size_t i = j+2; i < n; i++) {
+            for (Py_ssize_t i = j+2; i < n; i++) {
                 if (data[j*n + i] != 0.0) {
                     return 0;
                 }

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -9,7 +9,7 @@ from numpy import (dot, diag, prod, logical_not, ravel, transpose,
                    conjugate, absolute, amax, sign, isfinite, triu)
 
 from scipy._lib._util import _apply_over_batch
-from scipy._lib.deprecation import _deprecate_positional_args, _NoValue
+from scipy._lib.deprecation import _NoValue
 
 # Local imports
 from scipy.linalg import LinAlgError, bandwidth, LinAlgWarning
@@ -395,10 +395,8 @@ def _exp_sinch(x):
     lexp_diff[mask_z] = np.exp(x[:-1][mask_z])
     return lexp_diff
 
-# Don't forget to decrement the stacklevel as the deprecation decorators are removed
-@_deprecate_positional_args(version='1.20.0', deprecated_args={'disp'})
-@_deprecate_positional_args(version='1.18.0', deprecated_args={'blocksize'})
-def sqrtm(A, *, disp=_NoValue, blocksize=_NoValue):
+
+def sqrtm(A, disp=_NoValue, blocksize=_NoValue):
     """
     Compute, if exists, the matrix square root.
 
@@ -443,8 +441,8 @@ def sqrtm(A, *, disp=_NoValue, blocksize=_NoValue):
     that, there exist matrices that have square roots that are not polynomials
     in ``A``. For a classical example from [2]_, the matrix satisfies
 
-        [ a, a**2 + 1]**2     [-1,  0]
-        [-1,       -a]     =  [ 0, -1]
+            [ a, a**2 + 1]**2     [-1,  0]
+            [-1,       -a]     =  [ 0, -1]
 
     for any scalar ``a`` but is not a polynomial in ``-I``.
 
@@ -514,7 +512,7 @@ def sqrtm(A, *, disp=_NoValue, blocksize=_NoValue):
         else:
             msg = ("Matrix is ill-conditioned. The result might be inaccurate"
                    " or the array might not have a square root.")
-        warnings.warn(msg, LinAlgWarning, stacklevel=4)
+        warnings.warn(msg, LinAlgWarning, stacklevel=2)
 
     if disp is False:
         try:

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -496,6 +496,8 @@ def sqrtm(A, *, disp=_NoValue, blocksize=_NoValue):
         a = a.astype(np.float32)
     elif a.dtype.char in 'G':
         a = a.astype(np.complex128)
+    elif a.dtype.char in 'g':
+        a = a.astype(np.float64)
 
     if a.dtype.char not in 'fdFD':
         raise TypeError("scipy.linalg.sqrtm is not supported for the data type"

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -9,15 +9,16 @@ from numpy import (dot, diag, prod, logical_not, ravel, transpose,
                    conjugate, absolute, amax, sign, isfinite, triu)
 
 from scipy._lib._util import _apply_over_batch
+from scipy._lib.deprecation import _deprecate_positional_args, _NoValue
 
 # Local imports
-from scipy.linalg import LinAlgError, bandwidth
+from scipy.linalg import LinAlgError, bandwidth, LinAlgWarning
 from ._misc import norm
 from ._basic import solve, inv
 from ._decomp_svd import svd
 from ._decomp_schur import schur, rsf2csf
 from ._expm_frechet import expm_frechet, expm_cond
-from ._matfuncs_sqrtm import sqrtm
+from ._matfuncs_schur_sqrtm import recursive_schur_sqrtm
 from ._matfuncs_expm import pick_pade_structure, pade_UV_calc
 from ._linalg_pythran import _funm_loops  # type: ignore[import-not-found]
 
@@ -393,6 +394,135 @@ def _exp_sinch(x):
     lexp_diff[~mask_z] /= l_diff[~mask_z]
     lexp_diff[mask_z] = np.exp(x[:-1][mask_z])
     return lexp_diff
+
+# Don't forget to decrement the stacklevel as the deprecation decorators are removed
+@_deprecate_positional_args(version='1.20.0', deprecated_args={'disp'})
+@_deprecate_positional_args(version='1.18.0', deprecated_args={'blocksize'})
+def sqrtm(A, *, disp=_NoValue, blocksize=_NoValue):
+    """
+    Compute, if exists, the matrix square root.
+
+    The matrix square root of ``A`` is a matrix ``X`` such that ``X @ X = A``.
+    Every square matrix is not guaranteed to have a matrix square root, for
+    example, the array ``[[0, 1], [0, 0]]`` does not have a square root.
+
+    Moreover, not every real matrix has a real square root. Hence, for
+    real-valued matrices the return type can be complex if, numerically, there
+    is an eigenvalue on the negative real axis.
+
+    Parameters
+    ----------
+    A : ndarray
+        Input with last two dimensions are square ``(..., n, n)``.
+    disp : bool, optional
+        Deprecated keyword. It will be removed in 1.20.0.
+
+        .. deprecated:: 1.16.0
+
+    blocksize : integer, optional
+        Deprecated keyword. It has no effect and will be removed in 1.18.0.
+
+        .. deprecated:: 1.16.0
+
+    Returns
+    -------
+    sqrtm : ndarray
+        Computed matrix squareroot of `A` with same size ``(..., n, n)``.
+
+    errest : float
+        Frobenius norm of the estimated error, ||err||_F / ||A||_F. Only
+        returned, if ``disp`` is set to ``False``. This return argument will be
+        removed in version 1.20.0 and only the sqrtm result will be returned.
+
+        .. deprecated:: 1.16.0
+
+    Notes
+    -----
+    This function uses the Schur decomposition method to compute the matrix
+    square root following [1]_ and for real matrices [2]_. Moreover, note
+    that, there exist matrices that have square roots that are not polynomials
+    in ``A``. For a classical example from [2]_, the matrix satisfies
+
+        [ a, a**2 + 1]**2     [-1,  0]
+        [-1,       -a]     =  [ 0, -1]
+
+    for any scalar ``a`` but is not a polynomial in ``-I``.
+
+    References
+    ----------
+    .. [1] Edvin Deadman, Nicholas J. Higham, Rui Ralha (2013)
+           "Blocked Schur Algorithms for Computing the Matrix Square Root,
+           Lecture Notes in Computer Science, 7782. pp. 171-182.
+           :doi:`10.1016/0024-3795(87)90118-2`
+    .. [2] Nicholas J. Higham (1987) "Computing real square roots of a real
+           matrix", Linear Algebra and its Applications, 88/89:405-430.
+           :doi:`10.1016/0024-3795(87)90118-2`
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.linalg import sqrtm
+    >>> a = np.array([[1.0, 3.0], [1.0, 4.0]])
+    >>> r = sqrtm(a)
+    >>> r
+    array([[ 0.75592895,  1.13389342],
+           [ 0.37796447,  1.88982237]])
+    >>> r.dot(r)
+    array([[ 1.,  3.],
+           [ 1.,  4.]])
+
+    """
+    a = np.asarray(A)
+    if a.size == 1 and a.ndim < 2:
+        return np.array([[np.exp(a.item())]])
+
+    if a.ndim < 2:
+        raise LinAlgError('The input array must be at least two-dimensional')
+    if a.shape[-1] != a.shape[-2]:
+        raise LinAlgError('Last 2 dimensions of the array must be square')
+
+    # Empty array
+    if min(*a.shape) == 0:
+        dtype = sqrtm(np.eye(2, dtype=a.dtype)).dtype
+        return np.empty_like(a, dtype=dtype)
+
+    # Scalar case
+    if a.shape[-2:] == (1, 1):
+        return np.emath.sqrt(a)
+
+    if not np.issubdtype(a.dtype, np.inexact):
+        a = a.astype(np.float64)
+    elif a.dtype == np.float16:
+        a = a.astype(np.float32)
+    elif a.dtype.char in 'G':
+        a = a.astype(np.complex128)
+
+    if a.dtype.char not in 'fdFD':
+        raise TypeError("scipy.linalg.sqrtm is not supported for the data type"
+                        f" {a.dtype}")
+
+    res, isIllconditioned, isSingular, info = recursive_schur_sqrtm(a)
+    if info < 0:
+        raise LinAlgError(f"Internal error in scipy.linalg.sqrtm: {info}")
+
+    if isSingular or isIllconditioned:
+        if isSingular:
+            msg = ("Matrix is singular. The result might be inaccurate or the"
+                   " array might not have a square root.")
+        else:
+            msg = ("Matrix is ill-conditioned. The result might be inaccurate"
+                   " or the array might not have a square root.")
+        warnings.warn(msg, LinAlgWarning, stacklevel=4)
+
+    if disp is False:
+        try:
+            arg2 = norm(res @ res - A, 'fro')**2 / norm(A, 'fro')
+        except ValueError:
+            # NaNs in matrix
+            arg2 = np.inf
+        return res, arg2
+    else:
+        return res
 
 
 @_apply_over_batch(('A', 2))

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -439,12 +439,13 @@ def sqrtm(A, disp=_NoValue, blocksize=_NoValue):
     This function uses the Schur decomposition method to compute the matrix
     square root following [1]_ and for real matrices [2]_. Moreover, note
     that, there exist matrices that have square roots that are not polynomials
-    in ``A``. For a classical example from [2]_, the matrix satisfies
+    in ``A``. For a classical example from [2]_, the matrix satisfies::
 
             [ a, a**2 + 1]**2     [-1,  0]
             [-1,       -a]     =  [ 0, -1]
 
-    for any scalar ``a`` but is not a polynomial in ``-I``.
+    for any scalar ``a`` but it is not a polynomial in ``-I``. Thus, they will
+    not be found by this function.
 
     References
     ----------

--- a/scipy/linalg/_matfuncs_sqrtm.c
+++ b/scipy/linalg/_matfuncs_sqrtm.c
@@ -740,6 +740,7 @@ sqrtm_recursion_s(float* T, npy_intp bign, npy_intp n)
         {
             // Triangular 2x2 block
             if ((a == 0.0) && (d == 0.0) && (b == 0.0)) { return 0; }
+            if ((a == 0.0) && (d == 0.0)) { T[bign] = INFINITY; return 0; }
             T[0] = sqrtf(a);
             T[bign + 1] = sqrtf(d);
             T[bign] = T[bign] / (T[0] + T[bign + 1]);
@@ -815,6 +816,7 @@ sqrtm_recursion_d(double* T, npy_intp bign, npy_intp n)
         {
             // Triangular 2x2 block
             if ((a == 0.0) && (d == 0.0) && (b == 0.0)) { return 0; }
+            if ((a == 0.0) && (d == 0.0)) { T[bign] = INFINITY; return 0; }
             T[0] = sqrt(a);
             T[bign + 1] = sqrt(d);
             T[bign] = T[bign] / (T[0] + T[bign + 1]);

--- a/scipy/linalg/_matfuncs_sqrtm.c
+++ b/scipy/linalg/_matfuncs_sqrtm.c
@@ -1,0 +1,788 @@
+#include "_matfuncs_sqrtm.h"
+
+static int sqrtm_recursion_s(float* T, int bign, int n);
+static int sqrtm_recursion_d(double* T, int bign, int n);
+static int sqrtm_recursion_c(SCIPY_C* T, int bign, int n);
+static int sqrtm_recursion_z(SCIPY_Z* T, int bign, int n);
+static inline void zebra_pattern_s(float* restrict data, const npy_intp n) {for (npy_intp i=n-1; i>=0; i--) { data[2*i] = data[i]; data[2*i + 1] = 0.0f; }}
+static inline void zebra_pattern_d(double* restrict data, const npy_intp n) {for (npy_intp i=n-1; i>=0; i--) { data[2*i] = data[i]; data[2*i + 1] = 0.0; }}
+
+void
+matrix_squareroot_s(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* view_as_complex, int* isIllconditioned, int* isSingular, int* sq_info)
+{
+    float aa, bb, cc, dd, cs, sn;
+    // Setting indicators to False.
+    // isComplex is set to True if the square-root turns out to be complex-valued (if exists)
+    // isIllconditioned is set to True if the solution of the Sylvester equation is ill-conditioned
+    // isSingular is set to True if the input is exactly singular
+    *view_as_complex = 0;
+    *isIllconditioned = 0;
+    *isSingular = 0;
+    int isComplex = 0;
+    int upcasted_to_complex = 0;
+
+    // --------------------------------------------------------------------
+    // Input Array Attributes
+    // --------------------------------------------------------------------
+    float* restrict Am_data = (float*)PyArray_DATA(ap_Am);
+    float* restrict ret_data = (float*)PyArray_DATA(ap_ret);
+    int ndim = PyArray_NDIM(ap_Am);              // Number of dimensions
+    npy_intp* shape = PyArray_SHAPE(ap_Am);      // Array shape
+    npy_intp n = shape[ndim - 1];                // Slice size
+    npy_intp* restrict strides = PyArray_STRIDES(ap_Am);
+    // Get the number of slices to traverse if more than one; np.prod(shape[:-2])
+    npy_intp outer_size = 1;
+    if (ndim > 2)
+    {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
+    }
+
+    // --------------------------------------------------------------------
+    // Workspace computation and allocation
+    // --------------------------------------------------------------------
+    int info = 0, sdim = 0, lwork = -1, intn = (int)n;
+    float tmp_float = 0.0f, one = 1.0f, zero = 0.0f;
+    sgees_("V", "N", NULL, &intn, NULL, &intn, &sdim, NULL, NULL, NULL, &intn, &tmp_float, &lwork, NULL, &info);
+    // Improbable to fail at lwork query but check anyway
+    if (info != 0) { *sq_info = -100; }
+    lwork = (int)tmp_float;
+    // 2n*n + 2n*n for data and vs for potentially converting to complex if needed
+    // n + n for wr, wi (needed for gees calls)
+    // lwork for work
+    size_t buffer_size = 4*n*n + 2*n + lwork;
+    float* restrict buffer = malloc(buffer_size*sizeof(float));
+    if (buffer == NULL) { *sq_info = -101; return; }
+
+    // --------------------------------------------------------------------
+    // Pointers to the variables inside the buffer for easy access
+    // --------------------------------------------------------------------
+    float* restrict data = &buffer[0];
+    float* restrict data2 = &buffer[n*n];
+    float* restrict vs = &buffer[2*n*n];
+    float* restrict wr = &buffer[4*n*n];
+    float* restrict wi = &buffer[4*n*n + n];
+    float* restrict work = &buffer[4*n*n + 2*n];
+    // Cover the first 2n*n and vs area with a complex pointer just in case
+    SCIPY_C* complex_data = &((SCIPY_C*)buffer)[0];
+    SCIPY_C* complex_vs = &((SCIPY_C*)buffer)[n*n];
+
+
+    /*====================================================================
+    |                    MAIN nxn SLICE LOOP                             |
+    ====================================================================*/
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+        /*------------------------------------------------------------------
+        Copy the current slice into buffer in F-layout for LAPACK calls. Note
+        that the input can be in C or F layout and not necessarily contiguous.
+        Since the input is predominantly C contiguous, we copy the data in
+        C-layout first and then transpose it to F-layout.
+
+        The output is always a C contiguous array hence we visit slices in
+        C-order for easy insertion to the output array; by just offsetting
+        idx*n*n * sizeof(dtype). For this reason, we  start the offset
+        calculation from the inner-most outer dimension.
+        ------------------------------------------------------------------*/
+        npy_intp offset = 0;
+        npy_intp temp_idx = idx;
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset += (temp_idx % shape[i]) * strides[i];
+            temp_idx /= shape[i];
+        }
+        float* restrict slice_ptr = (float*)(Am_data + (offset/sizeof(float)));
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                data2[i * n + j] = *(slice_ptr + (i*strides[ndim - 2]/sizeof(float)) + (j*strides[ndim - 1]/sizeof(float)));
+            }
+        }
+        swap_cf_s(data2, data, n, n, n);
+
+        isComplex = 0;
+        // ------------------------------------------------------------------------
+        // Check if array is (quasi)upper triangular.
+        // ------------------------------------------------------------------------
+        int isSchur = isschurf(data, n);
+
+        if (!isSchur)
+        {
+            sgees_("V", "N", NULL, &intn, data, &intn, &sdim, wr, wi, vs, &intn, work, &lwork, NULL, &info);
+            if (info != 0)
+            {
+                free(buffer);
+                *sq_info = -102;
+                return;
+            }
+        } else {
+            // Manually get the eigenvalues with possible 2x2 blocks on the diagonal
+            for (int col = 0; col < n; col++)
+            {
+                if (col == n - 1)
+                {
+                    // Last column 1x1 block
+                    wr[col] = data[col*n + col];
+                    wi[col] = 0.0f;
+                } else if (data[col*n + col + 1] == 0.0f) {
+                    // Real eigenvalue
+                    wr[col] = data[col*n + col];
+                    wi[col] = 0.0f;
+                } else {
+                    // 2x2 block
+                    aa = data[col*n + col];
+                    bb = data[(col + 1)*n + col];
+                    cc = data[col*n + col + 1];
+                    dd = data[(col + 1)*n + col + 1];
+                    slanv2_(&aa, &bb, &cc, &dd, &wr[col], &wi[col], &wr[col+1], &wi[col+1], &cs, &sn);
+                    col++;
+                }
+            }
+        }
+
+        // Check for singularity and negative eigenvalues on the real axis
+        for (int i = 0; i < n; i++)
+        {
+            if (wi[i] == 0.0f) {
+                if (wr[i] < 0.0f) { isComplex = 1; }
+                if (wr[i] == 0.0f) { *isSingular = 1; }
+            }
+        }
+
+        // Compute the square root of the Schur form
+        if (isComplex)
+        {
+            // -- Convert real to complex
+            // The squareroot is determined to be complex valued.
+            // The data is already in F-layout so we need to insert a zero
+            // between each float to make it complex-valued array with imaginary
+            // part as zero. Same is true for the Schur vectors in vs.
+
+            // Hence data n*n will become 2n*n with the zebra pattern
+            // [real, real, real, ...] --> [real, 0, real, 0, ...]
+            // We start from the end of the 2n*n array and insert zeros.
+            zebra_pattern_s(buffer, n*n);
+            // If needed, do the same for the Schur vectors
+            if (!isSchur) { zebra_pattern_s(vs, n*n); }
+
+            // Convert real schur form to complex schur form in float arithmetic
+            for (int col = 0; col < (n - 1); col++)
+            {
+                if (data[2*(col*n + col + 1)] == 0.0f)
+                {
+                    // Real eigenvalue
+                    continue;
+                } else {
+                    // The only guarantee we have is c != 0, hence we use
+                    // [lambda - d, c] eigenvector for triangularization as
+                    // [b, \lambda - a] might become 0.
+
+                    // 2x2-block eigenvalues are still in wr and wi. So we can
+                    // avoid complex arithmetic.
+                    float u2 = data[2*(col*n + col + 1)];                       // c
+                    float d_term = data[2*((col+1)*n + col + 1)];               // d
+                    float mag = hypotf(hypotf(wr[col] - d_term, wi[col]), u2);  // ||[lambda - d, c]||
+                    float u1re = (wr[col] - d_term) / mag;                      // (lambda - d).real / ||lambda - d||
+                    float u1im = wi[col] / mag;                                 // (lambda - d).imag / ||lambda - d||
+                    u2 /= mag;                                                  // c / ||lambda - d||
+
+                    // Apply conjugate from left
+                    // [u1', u2] @ [temp1] = [temp1*u1' + temp2*u2]
+                    // [-u2, u1]   [temp2]   [-temp1*u2 + temp2*u1]
+                    for (Py_ssize_t i = col; i < n; i++)
+                    {
+                        float temp1 = data[2*i*n + 2*col];
+                        float temp2 = data[2*i*n + 2*col + 2];
+                        data[2*i*n + 2*col    ] =  u1re*temp1 + u2*temp2;
+                        data[2*i*n + 2*col + 1] = -u1im*temp1;
+                        data[2*i*n + 2*col + 2] = -u2*temp1   + u1re*temp2;
+                        data[2*i*n + 2*col + 3] =  u1im*temp2;
+                    }
+
+                    // Apply from right both to data and vs, temps are complex valued
+                    // [temp1, temp2] @ [u1, -u2] = [temp1*u1 + temp2*u2, -temp1*u2 + temp2*u1']
+                    //                  [u2, u1']
+
+                    // (x + yi) (w - zi) = (xw + yz) + (yw - xz)i
+                    for (Py_ssize_t i = 0; i <= col + 1; i++)
+                    {
+                        float temp1re = data[2*n*col       + 2*i];
+                        float temp1im = data[2*n*col       + 2*i + 1];
+                        float temp2re = data[2*n*(col + 1) + 2*i];
+                        float temp2im = data[2*n*(col + 1) + 2*i + 1];
+                        data[2*n*col       + 2*i    ] =  temp1re*u1re - temp1im*u1im + temp2re*u2;
+                        data[2*n*col       + 2*i + 1] =  temp1re*u1im + temp1im*u1re + temp2im*u2;
+                        data[2*n*(col + 1) + 2*i    ] = -temp1re*u2   + temp2re*u1re + temp2im*u1im;
+                        data[2*n*(col + 1) + 2*i + 1] = -temp1im*u2   - temp2re*u1im + temp2im*u1re;
+                    }
+
+                    // Clean up the noise
+                    data[2*n*col + 2*col + 2] = 0.0f;
+                    data[2*n*col + 2*col + 3] = 0.0f;
+
+                    if (!isSchur)
+                    {
+                        for (Py_ssize_t i = 0; i < n; i++)
+                        {
+                            float temp1 = vs[2*n*col       + 2*i];
+                            float temp2 = vs[2*n*(col + 1) + 2*i];
+                            vs[2*n*col       + 2*i    ] =  u1re*temp1 + u2*temp2;
+                            vs[2*n*col       + 2*i + 1] =  u1im*temp1;
+                            vs[2*n*(col + 1) + 2*i    ] = -u2*temp1   + u1re*temp2;
+                            vs[2*n*(col + 1) + 2*i + 1] = -u1im*temp2;
+                        }
+                    }
+                    // Skip next column
+                    col++;
+                }
+            }
+
+            // Compute the complex square root
+            info = sqrtm_recursion_c(complex_data, n, n);
+            // Unapply the Schur decomposition, use the return array current
+            // slice as scratch space for the matrix multiplications
+            if (!isSchur)
+            {
+                // ret_data = vs * data
+                // data = ret_data * vs^H
+                SCIPY_C c_one = CPLX_C(1.0f, 0.0f);
+                SCIPY_C c_zero = CPLX_C(0.0f, 0.0f);
+                cgemm_("N", "N", &intn, &intn, &intn, &c_one, complex_vs, &intn, complex_data, &intn, &c_zero, &((SCIPY_C*)ret_data)[idx*n*n], &intn);
+                cgemm_("N", "C", &intn, &intn, &intn, &c_one, &((SCIPY_C*)ret_data)[idx*n*n], &intn, complex_vs, &intn, &c_zero, complex_data, &intn);
+            }
+
+        } else {
+            // Compute the square root
+            info = sqrtm_recursion_s(data, n, n);
+            if (!isSchur)
+            {
+                // Apply the Schur decomposition, use the return array, current
+                // slice as scratch space for the matrix multiplication.
+                sgemm_("N", "N", &intn, &intn, &intn, &one, vs, &intn, data, &intn, &zero, &ret_data[idx*n*n], &intn);
+                sgemm_("N", "T", &intn, &intn, &intn, &one, &ret_data[idx*n*n], &intn, vs, &intn, &zero, data, &intn);
+            }
+        }
+
+        // Set the isIllconditioned flag if the Sylvester solver failed
+        if (info != 0) { *isIllconditioned = 1; }
+        // Now that we have the result, if this is the first result with complex
+        // values, we need to upcast the return array too hence it gets the zebra
+        // pattern too.
+        if (isComplex)
+        {
+            if (!upcasted_to_complex)
+            {
+                // Signal the caller to view the return array as complex and
+                // avoid doing this multiple times.
+                *view_as_complex = 1;
+
+                // Introduce zebra pattern until current slice (idx+1)*n*n by going
+                // backwards.
+                zebra_pattern_s(ret_data, n*n*(idx + 1));
+                // Avoid doing this multiple times
+                upcasted_to_complex = 1;
+            }
+            // Copy the complex result to the return array in C layout
+            swap_cf_c(complex_data, &((SCIPY_C*)ret_data)[idx*n*n], n, n, n);
+        } else {
+            // Copy the real result to the return array in C layout
+            swap_cf_s(data, &ret_data[idx*n*n], n, n, n);
+        }
+    }
+    /*====================================================================
+    |                  END OF nxn SLICE LOOP                             |
+    ====================================================================*/
+    free(buffer);
+    return;
+}
+
+
+void
+matrix_squareroot_d(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* view_as_complex, int* isIllconditioned, int* isSingular, int* sq_info)
+{
+    double aa, bb, cc, dd, cs, sn;
+    *view_as_complex = 0;
+    *isIllconditioned = 0;
+    *isSingular = 0;
+    int isComplex = 0;
+    int upcasted_to_complex = 0;
+
+    double* restrict Am_data = (double*)PyArray_DATA(ap_Am);
+    double* restrict ret_data = (double*)PyArray_DATA(ap_ret);
+    int ndim = PyArray_NDIM(ap_Am);
+    npy_intp* shape = PyArray_SHAPE(ap_Am);
+    npy_intp n = shape[ndim - 1];
+    npy_intp* restrict strides = PyArray_STRIDES(ap_Am);
+
+    npy_intp outer_size = 1;
+    if (ndim > 2)
+    {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
+    }
+    int info = 0, sdim = 0, lwork = -1, intn = (int)n;
+    double tmp_float = 0.0, one = 1.0, zero = 0.0;
+    dgees_("V", "N", NULL, &intn, NULL, &intn, &sdim, NULL, NULL, NULL, &intn, &tmp_float, &lwork, NULL, &info);
+    if (info != 0) { *sq_info = -100; }
+    lwork = (int)tmp_float;
+    size_t buffer_size = 4*n*n + 2*n + lwork;
+    double* restrict buffer = malloc(buffer_size*sizeof(double));
+    if (buffer == NULL) { *sq_info = -101; return; }
+
+    double* restrict data = &buffer[0];
+    double* restrict data2 = &buffer[n*n];
+    double* restrict vs = &buffer[2*n*n];
+    double* restrict wr = &buffer[4*n*n];
+    double* restrict wi = &buffer[4*n*n + n];
+    double* restrict work = &buffer[4*n*n + 2*n];
+    SCIPY_Z* complex_data = &((SCIPY_Z*)buffer)[0];
+    SCIPY_Z* complex_vs = &((SCIPY_Z*)buffer)[n*n];
+
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+        npy_intp offset = 0;
+        npy_intp temp_idx = idx;
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset += (temp_idx % shape[i]) * strides[i];
+            temp_idx /= shape[i];
+        }
+        double* restrict slice_ptr = (double*)(Am_data + (offset/sizeof(double)));
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                data2[i * n + j] = *(slice_ptr + (i*strides[ndim - 2]/sizeof(double)) + (j*strides[ndim - 1]/sizeof(double)));
+            }
+        }
+        swap_cf_d(data2, data, n, n, n);
+
+        isComplex = 0;
+        int isSchur = isschur(data, n);
+
+        if (!isSchur)
+        {
+            dgees_("V", "N", NULL, &intn, data, &intn, &sdim, wr, wi, vs, &intn, work, &lwork, NULL, &info);
+            if (info != 0)
+            {
+                free(buffer);
+                *sq_info = -102;
+                return;
+            }
+        } else {
+
+            for (int col = 0; col < n; col++)
+            {
+                if (col == n - 1)
+                {
+                    wr[col] = data[col*n + col];
+                    wi[col] = 0.0;
+                } else if (data[col*n + col + 1] == 0.0) {
+                    wr[col] = data[col*n + col];
+                    wi[col] = 0.0;
+                } else {
+                    aa = data[col*n + col];
+                    bb = data[(col + 1)*n + col];
+                    cc = data[col*n + col + 1];
+                    dd = data[(col + 1)*n + col + 1];
+                    dlanv2_(&aa, &bb, &cc, &dd, &wr[col], &wi[col], &wr[col+1], &wi[col+1], &cs, &sn);
+                    col++;
+                }
+            }
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            if (wi[i] == 0.0) {
+                if (wr[i] < 0.0) { isComplex = 1; }
+                if (wr[i] == 0.0) { *isSingular = 1; }
+            }
+        }
+
+        if (isComplex)
+        {
+            zebra_pattern_d(buffer, n*n);
+            if (!isSchur) { zebra_pattern_d(vs, n*n); }
+
+            for (int col = 0; col < (n - 1); col++)
+            {
+                if (data[2*(col*n + col + 1)] == 0.0)
+                {
+                    continue;
+                } else {
+                    double u2 = data[2*(col*n + col + 1)];
+                    double d_term = data[2*((col+1)*n + col + 1)];
+                    double mag = hypot(hypot(wr[col] - d_term, wi[col]), u2);
+                    double u1re = (wr[col] - d_term) / mag;
+                    double u1im = wi[col] / mag;
+                    u2 /= mag;
+
+                    for (Py_ssize_t i = col; i < n; i++)
+                    {
+                        double temp1 = data[2*i*n + 2*col];
+                        double temp2 = data[2*i*n + 2*col + 2];
+                        data[2*i*n + 2*col    ] =  u1re*temp1 + u2*temp2;
+                        data[2*i*n + 2*col + 1] = -u1im*temp1;
+                        data[2*i*n + 2*col + 2] = -u2*temp1   + u1re*temp2;
+                        data[2*i*n + 2*col + 3] =  u1im*temp2;
+                    }
+
+                    for (Py_ssize_t i = 0; i <= col + 1; i++)
+                    {
+                        double temp1re = data[2*n*col       + 2*i];
+                        double temp1im = data[2*n*col       + 2*i + 1];
+                        double temp2re = data[2*n*(col + 1) + 2*i];
+                        double temp2im = data[2*n*(col + 1) + 2*i + 1];
+                        data[2*n*col       + 2*i    ] =  temp1re*u1re - temp1im*u1im + temp2re*u2;
+                        data[2*n*col       + 2*i + 1] =  temp1re*u1im + temp1im*u1re + temp2im*u2;
+                        data[2*n*(col + 1) + 2*i    ] = -temp1re*u2   + temp2re*u1re + temp2im*u1im;
+                        data[2*n*(col + 1) + 2*i + 1] = -temp1im*u2   - temp2re*u1im + temp2im*u1re;
+                    }
+
+                    data[2*n*col + 2*col + 2] = 0.0;
+                    data[2*n*col + 2*col + 3] = 0.0;
+
+                    if (!isSchur)
+                    {
+                        for (Py_ssize_t i = 0; i < n; i++)
+                        {
+                            float temp1 = vs[2*n*col       + 2*i];
+                            float temp2 = vs[2*n*(col + 1) + 2*i];
+                            vs[2*n*col       + 2*i    ] =  u1re*temp1 + u2*temp2;
+                            vs[2*n*col       + 2*i + 1] =  u1im*temp1;
+                            vs[2*n*(col + 1) + 2*i    ] = -u2*temp1   + u1re*temp2;
+                            vs[2*n*(col + 1) + 2*i + 1] = -u1im*temp2;
+                        }
+                    }
+                    col++;
+                }
+            }
+            info = sqrtm_recursion_z(complex_data, n, n);
+
+            if (!isSchur)
+            {
+                SCIPY_Z c_one = CPLX_Z(1.0, 0.0);
+                SCIPY_Z c_zero = CPLX_Z(0.0, 0.0);
+                zgemm_("N", "N", &intn, &intn, &intn, &c_one, complex_vs, &intn, complex_data, &intn, &c_zero, &((SCIPY_Z*)ret_data)[idx*n*n], &intn);
+                zgemm_("N", "C", &intn, &intn, &intn, &c_one, &((SCIPY_Z*)ret_data)[idx*n*n], &intn, complex_vs, &intn, &c_zero, complex_data, &intn);
+            }
+
+        } else {
+            info = sqrtm_recursion_d(data, n, n);
+            if (!isSchur)
+            {
+                dgemm_("N", "N", &intn, &intn, &intn, &one, vs, &intn, data, &intn, &zero, &ret_data[idx*n*n], &intn);
+                dgemm_("N", "T", &intn, &intn, &intn, &one, &ret_data[idx*n*n], &intn, vs, &intn, &zero, data, &intn);
+            }
+        }
+
+        if (info != 0) { *isIllconditioned = 1; }
+        if (isComplex)
+        {
+            if (!upcasted_to_complex)
+            {
+                *view_as_complex = 1;
+                zebra_pattern_d(ret_data, n*n*(idx + 1));
+                upcasted_to_complex = 1;
+            }
+            swap_cf_z(complex_data, &((SCIPY_Z*)ret_data)[idx*n*n], n, n, n);
+        } else {
+            swap_cf_d(data, &ret_data[idx*n*n], n, n, n);
+        }
+    }
+    free(buffer);
+    return;
+}
+
+
+/*
+ * sqrtm_recursion_(s|d|c|z) are functions that compute the square root of a
+ * Fortran-ordered Schur matrix by recursion.
+ * For triangular Schur form arrays, the method described in [1] is used.
+ * For real valued quasi-upper triangular arrays, the method described in [2]
+ * is integrated into the method of [1].
+ *
+ * [1] : https://doi.org/10.1007/978-3-642-36803-5_12
+ * [2] : https://doi.org/10.1016/0024-3795(87)90118-2
+ *
+ * Input:
+ * T : Pointer to the Schur array in Fortran layout
+ * bign : Overall leading dimension of the input array
+ * n : Current recursion size of the partial array
+ *
+ * Output:
+ * info: 0 if successful, 1 if the Sylvester solver returned nonzero info.
+ *
+ */
+int
+sqrtm_recursion_s(float* T, int bign, int n)
+{
+    int i, i1 = 0, i2 = 0, info = 0, j, halfn, otherhalfn, int1 = 1;
+    float scale = 0.0, a, b, c, d, alpha, theta, mu;
+    if (n == 1)
+    {
+        // Scalar block
+        T[0] = sqrtf(T[0]);
+        return 0;
+    } else if (n == 2) {
+        a = T[0];
+        c = T[1];
+        b = T[bign];
+        d = T[bign + 1];
+        if (c == 0.0)
+        {
+            // Triangular 2x2 block
+            if ((a == 0.0) && (d == 0.0) && (b == 0.0)) { return 0; }
+            T[0] = sqrtf(a);
+            T[bign + 1] = sqrtf(d);
+            T[bign] = T[bign] / (T[0] + T[bign + 1]);
+            return 0;
+        } else {
+            // Complex eigenvalues
+            theta = a;            // since a == d
+            mu = sqrtf(-b*c);     // since b*c < 0
+            if ((theta == 0.0) && (mu == 0.0)) { return 0; }
+            if (theta > 0.0)
+            {
+                alpha = sqrtf((theta + hypotf(theta, mu)) / 2);
+            } else {
+                alpha = mu / sqrtf(2 * (-theta + hypotf(theta, mu)));
+            }
+            T[0] = alpha;
+            T[1] = T[1] / (2*alpha);
+            T[bign] = T[bign] / (2*alpha);
+            T[bign + 1] = alpha;
+            return 0;
+        }
+    } else {
+        // Recursion
+        halfn = n / 2;
+        // Don't split the 2x2 block, check if the entry under separation is zero
+        if (T[(halfn-1)*bign + halfn] != 0.0) { halfn++; }
+        otherhalfn = n - halfn;
+
+        // Top left block
+        i1 = sqrtm_recursion_s(T, bign, halfn);
+        // Bottom right block
+        i2 = sqrtm_recursion_s(&T[halfn*(bign + 1)], bign, otherhalfn);
+
+        // Solve the Sylvester equation for the top right block
+        strsyl_("N", "N", &int1, &halfn, &otherhalfn, T, &bign, &T[halfn*(bign + 1)], &bign, &T[halfn*bign], &bign, &scale, &info);
+        if (scale != 1.0)
+        {
+            for (i = 0; i < otherhalfn; i++)
+            {
+                for (j = 0; j < halfn; j++)
+                {
+                    T[(halfn + i)*bign + j] *= scale;
+                }
+            }
+        }
+    }
+    // Propagate the Sylvester solver info up the recursion stack
+    if (i1 || i2 || info)
+    {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+
+int
+sqrtm_recursion_d(double* T, int bign, int n)
+{
+    int i, i1 = 0, i2 = 0, info = 0, j, halfn, otherhalfn, int1 = 1;
+    double scale = 0.0, a, b, c, d, alpha, theta, mu;
+    if (n == 1)
+    {
+        // Scalar block
+        T[0] = sqrt(T[0]);
+        return 0;
+    } else if (n == 2) {
+        a = T[0];
+        c = T[1];
+        b = T[bign];
+        d = T[bign + 1];
+        if (c == 0.0)
+        {
+            // Triangular 2x2 block
+            if ((a == 0.0) && (d == 0.0) && (b == 0.0)) { return 0; }
+            T[0] = sqrt(a);
+            T[bign + 1] = sqrt(d);
+            T[bign] = T[bign] / (T[0] + T[bign + 1]);
+            return 0;
+        } else {
+            // Complex eigenvalues
+            theta = a;            // since a == d
+            mu = sqrt(-b*c);     // since b*c < 0
+            if ((theta == 0.0) && (mu == 0.0)) { return 0; }
+            if (theta > 0.0)
+            {
+                alpha = sqrt((theta + hypot(theta, mu)) / 2);
+            } else {
+                alpha = mu / sqrt(2 * (-theta + hypot(theta, mu)));
+            }
+            T[0] = alpha;
+            T[1] = T[1] / (2*alpha);
+            T[bign] = T[bign] / (2*alpha);
+            T[bign + 1] = alpha;
+            return 0;
+        }
+    } else {
+        // Recursion
+        halfn = n / 2;
+        // Don't split the 2x2 block, check if the entry under separation is zero
+        if (T[(halfn-1)*bign + halfn] != 0.0) { halfn++; }
+        otherhalfn = n - halfn;
+
+        // Top left block
+        i1 = sqrtm_recursion_d(T, bign, halfn);
+        // Bottom right block
+        i2 = sqrtm_recursion_d(&T[halfn*(bign + 1)], bign, otherhalfn);
+
+        // Solve the Sylvester equation for the top right block
+        dtrsyl_("N", "N", &int1, &halfn, &otherhalfn, T, &bign, &T[halfn*(bign + 1)], &bign, &T[halfn*bign], &bign, &scale, &info);
+
+        if (scale != 1.0)
+        {
+            for (i = 0; i < otherhalfn; i++)
+            {
+                for (j = 0; j < halfn; j++)
+                {
+                    T[(halfn + i)*bign + j] *= scale;
+                }
+            }
+        }
+    }
+    // Propagate the Sylvester solver info up the recursion stack
+    if (i1 || i2 || info)
+    {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+
+int
+sqrtm_recursion_c(SCIPY_C* T, int bign, int n)
+{
+    int i, i1 = 0, i2 = 0, info = 0, j, halfn, otherhalfn, int1 = 1;
+    float scale = 0.0;
+    if (n == 1)
+    {
+        // Scalar block
+        T[0] = csqrtf(T[0]);
+        return 0;
+    } else if (n == 2) {
+        // 2x2 upper triangular special case
+
+        // Check if the 2x2 block is exactly 0.0 and if so do nothing.
+        if ((cabsf(T[0]) == 0.0) && (cabsf(T[bign + 1]) == 0.0) && (cabsf(T[bign]) == 0.0)) { return 0; }
+
+        T[0] = csqrtf(T[0]);
+        // n + 1 is the next diagonal from T[0]
+        T[bign + 1] = csqrtf(T[bign + 1]);
+#if defined(_MSC_VER)
+        // MSVC does not support complex division
+        SCIPY_C tt = CPLX_C(crealf(T[0]) + crealf(T[bign + 1]), cimagf(T[0]) + cimagf(T[bign + 1]));
+        float cc = powf(cabsf(tt), -2);
+        T[bign] = _FCmulcr(_FCmulcc(T[bign], conjf(tt)), cc);
+#else
+        T[bign] = T[bign] / (T[0] + T[bign + 1]);
+#endif
+        return 0;
+    } else {
+        halfn = n / 2;
+        otherhalfn = n - halfn;
+        SCIPY_C* T11 = T;
+        SCIPY_C* T22 = &T[halfn*(bign + 1)];
+        SCIPY_C* T12 = &T[halfn*n];
+        i1 = sqrtm_recursion_c(T11, bign, halfn);
+        i2 = sqrtm_recursion_c(T22, bign, otherhalfn);
+
+        ctrsyl_("N", "N", &int1, &halfn, &otherhalfn, T11, &bign, T22, &bign, T12, &bign, &scale, &info);
+        if (scale != 1.0)
+        {
+            for (i = 0; i < otherhalfn; i++)
+            {
+                for (j = 0; j < halfn; j++)
+                {
+#if defined(_MSC_VER)
+                    T[(halfn + i)*n + j] = _FCmulcr(T[(halfn + i)*n + j], scale);
+#else
+                    T[(halfn + i)*n + j] *= scale;
+#endif
+                }
+            }
+        }
+    }
+    // Propagate the Sylvester solver info up the recursion stack
+    if (i1 || i2 || info)
+    {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+
+int
+sqrtm_recursion_z(SCIPY_Z* T, int bign, int n)
+{
+    int i, i1 = 0, i2 = 0, info = 0, j, halfn, otherhalfn, int1 = 1;
+    double scale = 0.0;
+    if (n == 1)
+    {
+        // Scalar block
+        T[0] = csqrt(T[0]);
+        return 0;
+    } else if (n == 2) {
+        // 2x2 upper triangular special case
+
+        // Check if the 2x2 block is exactly 0.0 and if so do nothing.
+        if ((cabs(T[0]) == 0.0) && (cabs(T[bign + 1]) == 0.0) && (cabs(T[bign]) == 0.0)) { return 0; }
+
+        T[0] = csqrt(T[0]);
+        // n + 1 is the next diagonal from T[0]
+        T[bign + 1] = csqrt(T[bign + 1]);
+#if defined(_MSC_VER)
+        // MSVC does not support complex division
+        SCIPY_Z tt = CPLX_Z(creal(T[0]) + creal(T[bign + 1]), cimag(T[0]) + cimag(T[bign + 1]));
+        double cc = pow(cabs(tt), -2);
+        T[bign] = _Cmulcr(_Cmulcc(T[bign], conj(tt)), cc);
+#else
+        T[bign] = T[bign] / (T[0] + T[bign + 1]);
+#endif
+        return 0;
+    } else {
+        halfn = n / 2;
+        otherhalfn = n - halfn;
+        SCIPY_Z* T11 = T;
+        SCIPY_Z* T22 = &T[halfn*(bign + 1)];
+        SCIPY_Z* T12 = &T[halfn*n];
+        i1 = sqrtm_recursion_z(T11, bign, halfn);
+        i2 = sqrtm_recursion_z(T22, bign, otherhalfn);
+        ztrsyl_("N", "N", &int1, &halfn, &otherhalfn, T11, &bign, T22, &bign, T12, &bign, &scale, &info);
+        if (scale != 1.0)
+        {
+            for (i = 0; i < otherhalfn; i++)
+            {
+                for (j = 0; j < halfn; j++)
+                {
+#if defined(_MSC_VER)
+                    T[(halfn + i)*n + j] = _Cmulcr(T[(halfn + i)*n + j], scale);
+#else
+                    T[(halfn + i)*n + j] *= scale;
+#endif
+                }
+            }
+        }
+    }
+    if (i1 || i2 || info)
+    {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+
+#undef SCIPY_Z
+#undef SCIPY_C
+#undef CPLX_Z
+#undef CPLX_C
+

--- a/scipy/linalg/_matfuncs_sqrtm.c
+++ b/scipy/linalg/_matfuncs_sqrtm.c
@@ -43,7 +43,7 @@ matrix_squareroot_s(const PyArrayObject* ap_Am, float* restrict ret_data, int* i
     float tmp_float = 0.0f, one = 1.0f, zero = 0.0f;
     sgees_("V", "N", NULL, &intn, NULL, &intn, &sdim, NULL, NULL, NULL, &intn, &tmp_float, &lwork, NULL, &info);
     // Improbable to fail at lwork query but check anyway
-    if (info != 0) { *sq_info = -100; }
+    if (info != 0) { *sq_info = -100; return;}
     lwork = (int)tmp_float;
     // 2n*n + 2n*n for data and vs for potentially converting to complex if needed
     // n + n for wr, wi (needed for gees calls)
@@ -55,6 +55,9 @@ matrix_squareroot_s(const PyArrayObject* ap_Am, float* restrict ret_data, int* i
     // --------------------------------------------------------------------
     // Pointers to the variables inside the buffer for easy access
     // --------------------------------------------------------------------
+
+    // Since we already allocated n*2n for the input, we can use the first and
+    // second n*n for C to F conversion when needed.
     float* restrict data = &buffer[0];
     float* restrict data2 = &buffer[n*n];
     float* restrict vs = &buffer[2*n*n];
@@ -329,7 +332,7 @@ matrix_squareroot_d(const PyArrayObject* ap_Am, double* restrict ret_data, int* 
     int info = 0, sdim = 0, lwork = -1, intn = (int)n;
     double tmp_float = 0.0, one = 1.0, zero = 0.0;
     dgees_("V", "N", NULL, &intn, NULL, &intn, &sdim, NULL, NULL, NULL, &intn, &tmp_float, &lwork, NULL, &info);
-    if (info != 0) { *sq_info = -100; }
+    if (info != 0) { *sq_info = -100; return; }
     lwork = (int)tmp_float;
     size_t buffer_size = 4*n*n + 2*n + lwork;
     double* restrict buffer = malloc(buffer_size*sizeof(double));
@@ -519,7 +522,7 @@ matrix_squareroot_c(const PyArrayObject* ap_Am, SCIPY_C* restrict ret_data, int*
     int info = 0, sdim = 0, lwork = -1, intn = (int)n;
     SCIPY_C tmp_float = CPLX_C(0.0f, 0.0f), cone = CPLX_C(1.0f, 0.0f), czero = CPLX_C(0.0f, 0.0f);
     cgees_("V", "N", NULL, &intn, NULL, &intn, &sdim, NULL, NULL, &intn, &tmp_float, &lwork, NULL, NULL, &info);
-    if (info != 0) { *sq_info = -100; }
+    if (info != 0) { *sq_info = -100; return; }
 
     lwork = (int)crealf(tmp_float);
     size_t buffer_size = 2*n*n + 2*n + lwork;
@@ -621,7 +624,7 @@ matrix_squareroot_z(const PyArrayObject* ap_Am, SCIPY_Z* restrict ret_data, int*
     int info = 0, sdim = 0, lwork = -1, intn = (int)n;
     SCIPY_Z tmp_float = CPLX_Z(0.0f, 0.0f), cone = CPLX_Z(1.0f, 0.0f), czero = CPLX_Z(0.0f, 0.0f);
     zgees_("V", "N", NULL, &intn, NULL, &intn, &sdim, NULL, NULL, &intn, &tmp_float, &lwork, NULL, NULL, &info);
-    if (info != 0) { *sq_info = -100; }
+    if (info != 0) { *sq_info = -100; return; }
 
     lwork = (int)creal(tmp_float);
     size_t buffer_size = 2*n*n + 2*n + lwork;

--- a/scipy/linalg/_matfuncs_sqrtm.c
+++ b/scipy/linalg/_matfuncs_sqrtm.c
@@ -551,9 +551,9 @@ matrix_squareroot_c(const PyArrayObject* ap_Am, SCIPY_C* restrict ret_data, int*
 
         // Check if array is upper triangular
         int isSchur = 1;
-        for (Py_ssize_t i = 1; i < n; i++)
+        for (Py_ssize_t i = 0; i < n - 1; i++)
         {
-            for (Py_ssize_t j = 0; j < i; j++)
+            for (Py_ssize_t j = i + 1; j < n; j++)
             {
                 if ((crealf(data[i*n + j]) != 0.0f) || (cimagf(data[i*n + j]) != 0.0f))
                 {
@@ -653,9 +653,9 @@ matrix_squareroot_z(const PyArrayObject* ap_Am, SCIPY_Z* restrict ret_data, int*
 
         // Check if array is upper triangular
         int isSchur = 1;
-        for (Py_ssize_t i = 1; i < n; i++)
+        for (Py_ssize_t i = 0; i < n - 1; i++)
         {
-            for (Py_ssize_t j = 0; j < i; j++)
+            for (Py_ssize_t j = i + 1; j < n; j++)
             {
                 if ((creal(data[i*n + j]) != 0.0f) || (cimag(data[i*n + j]) != 0.0f))
                 {

--- a/scipy/linalg/_matfuncs_sqrtm.h
+++ b/scipy/linalg/_matfuncs_sqrtm.h
@@ -108,7 +108,8 @@ recursive_schur_sqrtm(PyObject *dummy, PyObject *args) {
     if (!isComplex)
     {
         // Input and output is real, truncate the extra space at the end
-        void* mem_ret_half = realloc(mem_ret, n*n*ret_dims);
+        npy_intp new_size = (ret_dims/2)*(input_type == NPY_FLOAT32 ? sizeof(float) : sizeof(double));
+        void* mem_ret_half = realloc(mem_ret, new_size);
         // Quite unlikely but still allowed to fail
         if (!mem_ret_half) { PYERR(sqrtm_error, "Memory reallocation failed."); }
         PyArrayObject* ap_ret = (PyArrayObject*)PyArray_SimpleNewFromData(ndim, shape, input_type, mem_ret_half);

--- a/scipy/linalg/_matfuncs_sqrtm.h
+++ b/scipy/linalg/_matfuncs_sqrtm.h
@@ -1,0 +1,159 @@
+#ifndef _MATFUNCS_SQRTM_H
+#define _MATFUNCS_SQRTM_H
+
+#include "_common_array_utils.h"
+
+void matrix_squareroot_s(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* view_as_complex, int* isIllconditioned, int* isSingular, int* sq_info);
+void matrix_squareroot_d(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* view_as_complex, int* isIllconditioned, int* isSingular, int* sq_info);
+
+
+#define PYERR(errobj,message) {PyErr_SetString(errobj,message); return NULL;}
+
+static PyObject* sqrtm_error;
+
+/*
+This function accepts an nD NumPy array of size (..., n, n) and, if possible,
+computes the matrix square root for each (n, n) slice. The input must be at
+least 2-dimensional.
+
+Real valued input has the possibility of resulting in a complex-valued result
+and this is tracked internally and hence depending on the resulting flag the
+caller should view the resulting single/double (n, 2n) array as (n, n)
+single/double complex array.
+
+This function tests for the dtypes to be LAPACK compatible and for squareness.
+
+This function does not test for 0-dimensional, or nD arrays where some dimensions
+are 0. It is expected to have this case caught by the caller.
+*/
+static PyObject*
+recursive_schur_sqrtm(PyObject *dummy, PyObject *args) {
+    int isComplex = 0, isIllconditioned = 0, isSingular = 0, info;
+    PyArrayObject *ap_Am=NULL;
+    // Get the input array
+    if (!PyArg_ParseTuple(args, ("O!"), &PyArray_Type, (PyObject **)&ap_Am))
+    {
+        return NULL;
+    }
+
+    // Check for dtype compatibility
+    if ((PyArray_TYPE(ap_Am) != NPY_FLOAT64) &&
+         (PyArray_TYPE(ap_Am) != NPY_FLOAT32) &&
+         (PyArray_TYPE(ap_Am) != NPY_COMPLEX64) &&
+         (PyArray_TYPE(ap_Am) != NPY_COMPLEX128)
+       )
+    {
+        PYERR(sqrtm_error, "Input must be nD array of type "
+              "float32, float64, complex64, or complex128.");
+    }
+
+    int ndim = PyArray_NDIM(ap_Am);              // Number of dimensions
+    npy_intp* shape = PyArray_SHAPE(ap_Am);      // Array shape
+    npy_intp n = shape[ndim - 1];                // Slice size
+    // Compare last two dimensions for squareness
+    if (n != shape[ndim - 2])
+    {
+        PYERR(sqrtm_error, "Last two dimensions of the input must be the same.");
+    }
+
+    npy_intp ret_dims[1] = {1};
+    for (int i = 0; i < ndim; i++) { ret_dims[0] *= shape[i]; }
+
+    // Create the output array with the same shape as the input with twice the
+    // number of entries to accomodate for potential complex-valued data from
+    // real data which will be cast to complex e.g., "ret.asview(complex128)"
+    // Example, (3, 3) -> (18), (4, 5, 5) -> (4, 50)
+    if ((PyArray_TYPE(ap_Am) == NPY_FLOAT32) || (PyArray_TYPE(ap_Am) == NPY_FLOAT64))
+    {
+        ret_dims[0] *= 2;
+    }
+
+    // Create the return array
+    PyArrayObject* ap_ret = (PyArrayObject*)PyArray_ZEROS(1, ret_dims, PyArray_TYPE(ap_Am), 0);
+
+    switch (PyArray_TYPE(ap_Am))
+    {
+        case (NPY_FLOAT32):
+        {
+            matrix_squareroot_s(ap_Am, ap_ret, &isComplex, &isIllconditioned, &isSingular, &info);
+        }
+        break;
+        case (NPY_FLOAT64):
+        {
+            matrix_squareroot_d(ap_Am, ap_ret, &isComplex, &isIllconditioned, &isSingular, &info);
+        }
+        break;
+/*
+        case (NPY_COMPLEX64):
+        {
+            matrix_squareroot_c(ap_Am, ap_ret, &isComplex, &isIllconditioned, &isSingular);
+        }
+        case (NPY_COMPLEX128):
+        {
+            matrix_squareroot_z(ap_Am, ap_ret, &isComplex, &isIllconditioned, &isSingular);
+        }
+*/
+        default:
+        {
+            PYERR(sqrtm_error, "Unsupported data type.");
+        }
+    }
+
+    // Return the result
+    return Py_BuildValue("Niiii",PyArray_Return(ap_ret), isComplex, isIllconditioned, isSingular, info);
+}
+
+static struct PyMethodDef sqrtm_module_methods[] = {
+  {"recursive_schur_sqrtm", recursive_schur_sqrtm, METH_VARARGS, "Compute the matrix square root by recursion."},
+  {NULL, NULL, 0, NULL}
+};
+
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "_matfuncs_schur_sqrtm",
+    NULL,
+    -1,
+    sqrtm_module_methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC
+PyInit__matfuncs_schur_sqrtm(void)
+{
+    PyObject *module, *mdict;
+
+    import_array();
+
+    module = PyModule_Create(&moduledef);
+    if (module == NULL) {
+        return NULL;
+    }
+
+    mdict = PyModule_GetDict(module);
+    if (mdict == NULL) {
+        return NULL;
+    }
+    sqrtm_error = PyErr_NewException("_matfuncs_schur_sqrtm.error", NULL, NULL);
+    if (sqrtm_error == NULL) {
+        return NULL;
+    }
+    if (PyDict_SetItemString(mdict, "error", sqrtm_error)) {
+        return NULL;
+    }
+
+#if Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
+    return module;
+}
+
+
+#undef SQRTM_C
+#undef SQRTM_Z
+
+#endif // _MATFUNCS_SQRTM_H

--- a/scipy/linalg/_matfuncs_sqrtm.h
+++ b/scipy/linalg/_matfuncs_sqrtm.h
@@ -3,8 +3,10 @@
 
 #include "_common_array_utils.h"
 
-void matrix_squareroot_s(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* view_as_complex, int* isIllconditioned, int* isSingular, int* sq_info);
-void matrix_squareroot_d(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* view_as_complex, int* isIllconditioned, int* isSingular, int* sq_info);
+void matrix_squareroot_s(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* isIllconditioned, int* isSingular, int* sq_info, int* view_as_complex);
+void matrix_squareroot_d(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* isIllconditioned, int* isSingular, int* sq_info, int* view_as_complex);
+void matrix_squareroot_c(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* isIllconditioned, int* isSingular, int* sq_info, int* unused         );
+void matrix_squareroot_z(const PyArrayObject* ap_Am, const PyArrayObject* ap_ret, int* isIllconditioned, int* isSingular, int* sq_info, int* unused         );
 
 
 #define PYERR(errobj,message) {PyErr_SetString(errobj,message); return NULL;}
@@ -75,24 +77,26 @@ recursive_schur_sqrtm(PyObject *dummy, PyObject *args) {
     {
         case (NPY_FLOAT32):
         {
-            matrix_squareroot_s(ap_Am, ap_ret, &isComplex, &isIllconditioned, &isSingular, &info);
+            matrix_squareroot_s(ap_Am, ap_ret, &isIllconditioned, &isSingular, &info, &isComplex);
+            break;
         }
-        break;
         case (NPY_FLOAT64):
         {
-            matrix_squareroot_d(ap_Am, ap_ret, &isComplex, &isIllconditioned, &isSingular, &info);
+            matrix_squareroot_d(ap_Am, ap_ret, &isIllconditioned, &isSingular, &info, &isComplex);
+            break;
         }
-        break;
-/*
         case (NPY_COMPLEX64):
         {
-            matrix_squareroot_c(ap_Am, ap_ret, &isComplex, &isIllconditioned, &isSingular);
+            matrix_squareroot_c(ap_Am, ap_ret, &isIllconditioned, &isSingular, &info, &isComplex);
+            isComplex = 1;
+            break;
         }
         case (NPY_COMPLEX128):
         {
-            matrix_squareroot_z(ap_Am, ap_ret, &isComplex, &isIllconditioned, &isSingular);
+            matrix_squareroot_z(ap_Am, ap_ret, &isIllconditioned, &isSingular, &info, &isComplex);
+            isComplex = 1;
+            break;
         }
-*/
         default:
         {
             PYERR(sqrtm_error, "Unsupported data type.");

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -4,23 +4,15 @@ Matrix square root for general matrices and for upper triangular matrices.
 This module exists to avoid cyclic imports.
 
 """
-__all__ = ['sqrtm']
+__all__ = []
 
 import numpy as np
 
-from scipy._lib._util import _asarray_validated, _apply_over_batch
-
 # Local imports
-from ._misc import norm
 from .lapack import ztrsyl, dtrsyl
-from ._decomp_schur import schur, rsf2csf
-from ._basic import _ensure_dtype_cdsz
-
-
 
 class SqrtmError(np.linalg.LinAlgError):
     pass
-
 
 from ._matfuncs_sqrtm_triu import within_block_loop  # noqa: E402
 
@@ -113,94 +105,3 @@ def _sqrtm_triu(T, blocksize=64):
 
     # Return the matrix square root.
     return R
-
-
-@_apply_over_batch(('A', 2))
-def sqrtm(A, disp=True, blocksize=64):
-    """
-    Matrix square root.
-
-    Parameters
-    ----------
-    A : (N, N) array_like
-        Matrix whose square root to evaluate
-    disp : bool, optional
-        Print warning if error in the result is estimated large
-        instead of returning estimated error. (Default: True)
-    blocksize : integer, optional
-        If the blocksize is not degenerate with respect to the
-        size of the input array, then use a blocked algorithm. (Default: 64)
-
-    Returns
-    -------
-    sqrtm : (N, N) ndarray
-        Value of the sqrt function at `A`. The dtype is float or complex.
-        The precision (data size) is determined based on the precision of
-        input `A`.
-
-    errest : float
-        (if disp == False)
-
-        Frobenius norm of the estimated error, ||err||_F / ||A||_F
-
-    References
-    ----------
-    .. [1] Edvin Deadman, Nicholas J. Higham, Rui Ralha (2013)
-           "Blocked Schur Algorithms for Computing the Matrix Square Root,
-           Lecture Notes in Computer Science, 7782. pp. 171-182.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from scipy.linalg import sqrtm
-    >>> a = np.array([[1.0, 3.0], [1.0, 4.0]])
-    >>> r = sqrtm(a)
-    >>> r
-    array([[ 0.75592895,  1.13389342],
-           [ 0.37796447,  1.88982237]])
-    >>> r.dot(r)
-    array([[ 1.,  3.],
-           [ 1.,  4.]])
-
-    """
-    A = _asarray_validated(A, check_finite=True, as_inexact=True)
-    if len(A.shape) != 2:
-        raise ValueError("Non-matrix input to matrix function.")
-    if blocksize < 1:
-        raise ValueError("The blocksize should be at least 1.")
-    A, = _ensure_dtype_cdsz(A)
-    keep_it_real = np.isrealobj(A)
-    if keep_it_real:
-        T, Z = schur(A)
-        d0 = np.diagonal(T)
-        d1 = np.diagonal(T, -1)
-        eps = np.finfo(T.dtype).eps
-        needs_conversion = abs(d1) > eps * (abs(d0[1:]) + abs(d0[:-1]))
-        if needs_conversion.any():
-            T, Z = rsf2csf(T, Z)
-    else:
-        T, Z = schur(A, output='complex')
-    failflag = False
-    try:
-        R = _sqrtm_triu(T, blocksize=blocksize)
-        ZH = np.conjugate(Z).T
-        X = Z.dot(R).dot(ZH)
-        dtype = np.result_type(A.dtype, 1j if np.iscomplexobj(X) else 1)
-        X = X.astype(dtype, copy=False)
-    except SqrtmError:
-        failflag = True
-        X = np.empty_like(A)
-        X.fill(np.nan)
-
-    if disp:
-        if failflag:
-            print("Failed to find a square root.")
-        return X
-    else:
-        try:
-            arg2 = norm(X.dot(X) - A, 'fro')**2 / norm(A, 'fro')
-        except ValueError:
-            # NaNs in matrix
-            arg2 = np.inf
-
-        return X, arg2

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -193,6 +193,17 @@ py3.extension_module('_matfuncs_expm',
   subdir: 'scipy/linalg'
 )
 
+py3.extension_module('_matfuncs_schur_sqrtm',
+  [
+    '_common_array_utils.h',
+    '_matfuncs_sqrtm.h',
+    '_matfuncs_sqrtm.c',
+  ],
+  dependencies: [np_dep, lapack_dep, blas_dep],
+  install: true,
+  subdir: 'scipy/linalg'
+)
+
 _cythonized_array_utils = py3.extension_module('_cythonized_array_utils',
   linalg_init_utils_cython_gen.process('_cythonized_array_utils.pyx'),
   c_args: [cython_c_args, Wno_maybe_uninitialized],

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -113,6 +113,12 @@ class TestBatch:
     def test_matmat(self, fun, dtype):  # matrix in, matrix out
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
+
+        # sqrtm can return complex output for real input resulting in i/o type
+        # mismatch. Nudge the eigenvalues to positive side to avoid this.
+        if fun == linalg.sqrtm:
+            A = A + 3*np.eye(4, dtype=dtype)
+
         self.batch_test(fun, A)
 
     @pytest.mark.parametrize('dtype', floating)

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -532,7 +532,7 @@ class TestSqrtM:
     def test_cf_noncontig_nd_inputs(self):
         # Check that non-contiguous arrays are handled correctly.
         # Generate an L, U pair for invertible random matrix.
-        rng = np.random.default_rng(1738151906092735)
+        rng = np.random.default_rng(1738151906092737)
         n = 13
         A = rng.uniform(size=(3, 2*n, 2*n))
         L, U = np.tril(A, k=-1) + np.eye(2*n), np.triu(A)
@@ -545,8 +545,22 @@ class TestSqrtM:
 
     def test_empty_sizes(self):
         A = np.empty(shape=[4, 0, 5, 5], dtype=float)
-        sqA = sqrtm(A)
         assert_array_equal(sqrtm(A), A)
+
+    def test_negative_strides(self):
+        rng = np.random.default_rng(1738151906092738)
+        A = rng.uniform(size=(3, 5, 5))
+        A_negneg_orig = A[:, ::-1, ::-1]
+        A_negneg_copy = A[:, ::-1, ::-1].copy()
+        assert_allclose(sqrtm(A_negneg_orig), sqrtm(A_negneg_copy))
+
+        A_posneg_orig = A[:, :, ::-1]
+        A_posneg_copy = A[:, :, ::-1].copy()
+        assert_allclose(sqrtm(A_posneg_orig), sqrtm(A_posneg_copy))
+
+        A_negpos_orig = A[:, ::-1, :]
+        A_negpos_copy = A[:, ::-1, :].copy()
+        assert_allclose(sqrtm(A_negpos_orig), sqrtm(A_negpos_copy))
 
 
 class TestFractionalMatrixPower:

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -452,7 +452,6 @@ class TestSqrtM:
 
             assert_allclose(sqrtm(M), R, atol=1e-14)
 
-    @pytest.mark.xfail(reason="failing on macOS after gh-20212")
     def test_gh17918(self):
         M = np.empty((19, 19))
         M.fill(0.94)


### PR DESCRIPTION
This PR rewrites the `linalg.sqrtm` matrix function in C to remedy a few long-standing shortcomings; 

 - most importantly, returning real valued square roots for real valued input data where available (with an explicit check for negative real eigenvalues).
 - recursive square root algorithm instead of the current block size dependent blocked algorithm
 - includes a fast real to complex Schur form conversion
 - looping batch input at the lower level, independent of the memory layout, instead of slow python copies.
 - works on a single allocated memory area to avoid unnecessary malloc/free calls.
 - now works with complex64 and float32 datatypes
 - substantial speed up for small arrays

Closes #12994 (since now checking for Schur form is built-in and the check cost is marginal to the actual algorithm)
Closes #19415
Closes #20219 