### PR TITLE
MAINT: remove `_lib`->`sparse` dependency

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -29,6 +29,7 @@ from scipy._lib.array_api_compat import (
     is_jax_namespace as is_jax,
     is_array_api_strict_namespace as is_array_api_strict
 )
+from scipy._lib._sparse import issparse
 
 __all__ = [
     '_asarray', 'array_namespace', 'assert_almost_equal', 'assert_array_almost_equal',
@@ -70,7 +71,6 @@ def _compliance_scipy(arrays):
     for i in range(len(arrays)):
         array = arrays[i]
 
-        from scipy.sparse import issparse
         # this comes from `_util._asarray_validated`
         if issparse(array):
             msg = ('Sparse arrays/matrices are not supported by this function. '

--- a/scipy/_lib/_sparse.py
+++ b/scipy/_lib/_sparse.py
@@ -1,9 +1,9 @@
-from abc import ABCMeta
+from abc import ABC
 
-__all__ = ["SparseBase", "issparse"]
+__all__ = ["SparseABC", "issparse"]
 
 
-class SparseBase(metaclass=ABCMeta):
+class SparseABC(ABC):
     pass
 
 
@@ -38,4 +38,4 @@ def issparse(x):
     >>> issparse(5)
     False
     """
-    return isinstance(x, SparseBase)
+    return isinstance(x, SparseABC)

--- a/scipy/_lib/_sparse.py
+++ b/scipy/_lib/_sparse.py
@@ -1,0 +1,41 @@
+from abc import ABCMeta
+
+__all__ = ["SparseBase", "issparse"]
+
+
+class SparseBase(metaclass=ABCMeta):
+    pass
+
+
+def issparse(x):
+    """Is `x` of a sparse array or sparse matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a sparse array or sparse matrix
+
+    Returns
+    -------
+    bool
+        True if `x` is a sparse array or a sparse matrix, False otherwise
+
+    Notes
+    -----
+    Use `isinstance(x, sp.sparse.sparray)` to check between an array or matrix.
+    Use `a.format` to check the sparse format, e.g. `a.format == 'csr'`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.sparse import csr_array, csr_matrix, issparse
+    >>> issparse(csr_matrix([[5]]))
+    True
+    >>> issparse(csr_array([[5]]))
+    True
+    >>> issparse(np.array([[5]]))
+    False
+    >>> issparse(5)
+    False
+    """
+    return isinstance(x, SparseBase)

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -13,6 +13,7 @@ from typing import Literal, TypeAlias, TypeVar
 import numpy as np
 from scipy._lib._array_api import Array, array_namespace, is_numpy, xp_size
 from scipy._lib._docscrape import FunctionDoc, Parameter
+from scipy._lib._sparse import issparse
 import scipy._lib.array_api_extra as xpx
 
 
@@ -526,8 +527,7 @@ def _asarray_validated(a, check_finite=True,
 
     """
     if not sparse_ok:
-        import scipy.sparse
-        if scipy.sparse.issparse(a):
+        if issparse(a):
             msg = ('Sparse arrays/matrices are not supported by this function. '
                    'Perhaps one of the `scipy.sparse.linalg` functions '
                    'would work instead.')

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -124,6 +124,7 @@ python_sources = [
   '_gcutils.py',
   '_lazy_testing.py',
   '_pep440.py',
+  '_sparse.py',
   '_testutils.py',
   '_threadsafety.py',
   '_tmpdirs.py',

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -1,11 +1,15 @@
 """Constraints definition for minimize."""
-import numpy as np
-from ._hessian_update_strategy import BFGS
-from ._differentiable_functions import (
-    VectorFunction, LinearVectorFunction, IdentityVectorFunction)
-from ._optimize import OptimizeWarning
 from warnings import warn, catch_warnings, simplefilter, filterwarnings
-from scipy.sparse import issparse
+
+import numpy as np
+
+from ._differentiable_functions import (
+    VectorFunction, LinearVectorFunction, IdentityVectorFunction
+)
+from ._hessian_update_strategy import BFGS
+from ._optimize import OptimizeWarning
+
+from scipy._lib._sparse import issparse
 
 
 def _arr_to_scalar(x):

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -5,14 +5,15 @@ Added by Andrew Nelson 2014
 import warnings
 
 import numpy as np
+
 from scipy.optimize import OptimizeResult, minimize
+from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
+                                         NonlinearConstraint, LinearConstraint)
 from scipy.optimize._optimize import _status_message, _wrap_callback
 from scipy._lib._util import (check_random_state, MapWrapper, _FunctionWrapper,
                               rng_integers, _transition_to_rng)
+from scipy._lib._sparse import issparse
 
-from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
-                                         NonlinearConstraint, LinearConstraint)
-from scipy.sparse import issparse
 
 __all__ = ['differential_evolution']
 

--- a/scipy/optimize/_lsq/common.py
+++ b/scipy/optimize/_lsq/common.py
@@ -5,8 +5,8 @@ import numpy as np
 from numpy.linalg import norm
 
 from scipy.linalg import cho_factor, cho_solve, LinAlgError
-from scipy.sparse import issparse
 from scipy.sparse.linalg import LinearOperator, aslinearoperator
+from scipy._lib._sparse import issparse
 
 
 EPS = np.finfo(float).eps

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -4,11 +4,11 @@ from warnings import warn
 import numpy as np
 from numpy.linalg import norm
 
-from scipy.sparse import issparse
 from scipy.sparse.linalg import LinearOperator
 from scipy.optimize import _minpack, OptimizeResult
 from scipy.optimize._numdiff import approx_derivative, group_columns
 from scipy.optimize._minimize import Bounds
+from scipy._lib._sparse import issparse
 
 from .trf import trf
 from .dogbox import dogbox

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -5,7 +5,7 @@ import numpy as np
 from ._sputils import (asmatrix, check_reshape_kwargs, check_shape,
                        get_sum_dtype, isdense, isscalarlike,
                        matrix, validateaxis, getdtype)
-from scipy._lib._sparse import SparseBase, issparse
+from scipy._lib._sparse import SparseABC, issparse
 
 from ._matrix import spmatrix
 
@@ -59,7 +59,11 @@ _ufuncs_with_fixed_point_at_zero = frozenset([
 MAXPRINT = 50
 
 
-class _spbase:
+# `_spbase` is a subclass of `SparseABC`.
+# This allows other submodules to check for instances of sparse subclasses
+# via `scipy._lib._sparse.issparse`, without introducing
+# an import dependency on `scipy.sparse`.
+class _spbase(SparseABC):
     """ This class provides a base class for all sparse arrays.  It
     cannot be instantiated.  Most of the work is provided by subclasses.
     """
@@ -1390,13 +1394,6 @@ class _spbase:
         return get_index_dtype(arrays,
                                maxval,
                                (check_contents and not isinstance(self, sparray)))
-
-
-# `_spbase`` is a "virtual subclass" of `SparseBase`.
-# This allows other submodules to check for sparse subclasses
-# via `scipy._lib._sparse.issparse`, without introducing
-# an import dependency on `scipy.sparse`.
-SparseBase.register(_spbase)
 
 
 class sparray:

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -5,6 +5,7 @@ import numpy as np
 from ._sputils import (asmatrix, check_reshape_kwargs, check_shape,
                        get_sum_dtype, isdense, isscalarlike,
                        matrix, validateaxis, getdtype)
+from scipy._lib._sparse import SparseBase, issparse
 
 from ._matrix import spmatrix
 
@@ -1391,6 +1392,13 @@ class _spbase:
                                (check_contents and not isinstance(self, sparray)))
 
 
+# `_spbase`` is a "virtual subclass" of `SparseBase`.
+# This allows other submodules to check for sparse subclasses
+# via `scipy._lib._sparse.issparse`, without introducing
+# an import dependency on `scipy.sparse`.
+SparseBase.register(_spbase)
+
+
 class sparray:
     """A namespace class to separate sparray from spmatrix"""
 
@@ -1419,40 +1427,6 @@ class sparray:
 
 
 sparray.__doc__ = _spbase.__doc__
-
-
-def issparse(x):
-    """Is `x` of a sparse array or sparse matrix type?
-
-    Parameters
-    ----------
-    x
-        object to check for being a sparse array or sparse matrix
-
-    Returns
-    -------
-    bool
-        True if `x` is a sparse array or a sparse matrix, False otherwise
-
-    Notes
-    -----
-    Use `isinstance(x, sp.sparse.sparray)` to check between an array or matrix.
-    Use `a.format` to check the sparse format, e.g. `a.format == 'csr'`.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from scipy.sparse import csr_array, csr_matrix, issparse
-    >>> issparse(csr_matrix([[5]]))
-    True
-    >>> issparse(csr_array([[5]]))
-    True
-    >>> issparse(np.array([[5]]))
-    False
-    >>> issparse(5)
-    False
-    """
-    return isinstance(x, _spbase)
 
 
 def isspmatrix(x):


### PR DESCRIPTION
#### Reference issue
x-ref gh-22382

#### What does this implement/fix?
With your config @rgommers:
```
scipy on 🎋 issparse [$!+?] is 📦 v1.16.0.dev0 via 🐍 v3.13.1 via 🐚 scipy:tach took 2s 
❯ tach check --exact
❌: Found unused dependencies: 
	'scipy._lib' does not depend on: ['scipy.sparse']

Remove the unused dependencies from tach.toml, or consider running 'tach sync' to update module configuration and remove all unused dependencies.
```

- new ABC `SparseBase` for sparse arrays/matrices which can live in `_lib`
- `_spbase` is registered as a virtual subclass in `sparse`

#### Additional information
FYI @jorenham not sure if this interacts with the new `sparray` you added at all.

This doesn't address the `fft`->`sparse` dependency: see https://github.com/scipy/scipy/issues/22412 
