### PR TITLE
MAINT: integrate.cumulative_simpson: bump test tolerance

### DIFF
--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -659,7 +659,7 @@ class TestCumulativeSimpson:
             y, x=np.arange(y.shape[-1])
         )
         np.testing.assert_allclose(
-            res[..., 1:], ref[..., 1:] + theoretical_difference[..., 1:]
+            res[..., 1:], ref[..., 1:] + theoretical_difference[..., 1:], atol=1e-16
         )
 
     @pytest.mark.thread_unsafe


### PR DESCRIPTION
#### Reference issue
gh-22298, gh-22405

#### What does this implement/fix?
There seems to be a new failure in main on some platforms:

```
================================== FAILURES ===================================
_ TestCumulativeSimpson.test_cumulative_simpson_against_simpson_with_default_dx _
[gw0] win32 -- Python 3.10.11 C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe
scipy\integrate\tests\test_quadrature.py:635: in test_cumulative_simpson_against_simpson_with_default_dx
    @pytest.mark.slow
        f          = <function given.<locals>.run_test_as_given.<locals>.wrapped_test at 0x000002158CBAFA30>
        self       = <scipy.integrate.tests.test_quadrature.TestCumulativeSimpson object at 0x000002158CBF5450>
scipy\integrate\tests\test_quadrature.py:661: in test_cumulative_simpson_against_simpson_with_default_dx
    np.testing.assert_allclose(
E   AssertionError: 
E   Not equal to tolerance rtol=1e-07, atol=0
E   
E   Mismatched elements: 1 / 1 (100%)
E   Max absolute difference: 2.18370741e-17
E   Max relative difference: 1.
E    x: array([0.])
E    y: array([-2.183707e-17])
E   Falsifying example: test_cumulative_simpson_against_simpson_with_default_dx(
E       self=<scipy.integrate.tests.test_quadrature.TestCumulativeSimpson object at 0x000002158CBF5450>,
E       y=array([-2.00001e+00,  5.00000e-01,  1.00000e-05]),
E   )
E   Explanation:
E       These lines were always and only run by failing examples:
E           C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\numpy\core\_ufunc_config.py:119
E           C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\numpy\core\arrayprint.py:942
E           C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\numpy\core\arrayprint.py:943
E           C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\numpy\core\arrayprint.py:944
E           C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\numpy\core\arrayprint.py:949
E           (and 6 more with settings.verbosity >= verbose)
E   
E   You can reproduce this example by temporarily adding @reproduce_failure('6.124.7', b'AAFBAwAowAAABT4tYjkoP+AAAAAAAAAoPuT4tYjjaPE=') as a decorator on your test case
        ref        = array([-7.50005000e-01, -2.18370741e-17])
        res        = array([-0.500005,  0.      ])
        self       = <scipy.integrate.tests.test_quadrature.TestCumulativeSimpson object at 0x000002158CBF5450>
        simpson_reference = <function TestCumulativeSimpson.test_cumulative_simpson_against_simpson_with_default_dx.<locals>.simpson_reference at 0x00000215B531C700>
        theoretical_difference = array([0., 0.])
        y          = array([-2.00001e+00,  5.00000e-01,  1.00000e-05])
```

This adds an `atol` to avoid the failure.

