### PR TITLE
DOC: stats.gaussian_kde: clarify Silverman method

### DIFF
--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -119,13 +119,18 @@ class gaussian_kde:
         neff**(-1./(d+4)),
 
     with ``neff`` the effective number of datapoints.
-    Silverman's Rule [2]_, implemented as `silverman_factor`, is::
+    Silverman's suggestion for *multivariate* data [2]_, implemented as
+    `silverman_factor`, is::
 
         (n * (d + 2) / 4.)**(-1. / (d + 4)).
 
     or in the case of unequally weighted points::
 
         (neff * (d + 2) / 4.)**(-1. / (d + 4)).
+
+    Note that this is not the same as "Silverman's rule of thumb" [6]_, which
+    may be more robust in the univariate case; see documentation of the
+    ``set_bandwidth`` method for implementing a custom bandwidth rule.
 
     Good general descriptions of kernel density estimation can be found in [1]_
     and [2]_, the mathematics for this multi-dimensional implementation can be
@@ -157,6 +162,8 @@ class gaussian_kde:
            Analysis, Vol. 36, pp. 279-298, 2001.
     .. [5] Gray P. G., 1969, Journal of the Royal Statistical Society.
            Series A (General), 132, 272
+    .. [6] Kernel density estimation. *Wikipedia.*
+           https://en.wikipedia.org/wiki/Kernel_density_estimation
 
     Examples
     --------


### PR DESCRIPTION
#### Reference issue
Closes gh-22403

#### What does this implement/fix?
gh-22403 noted that "Silverman's method" does not refer to a unique rule for KDE bandwidth selection. This attempts to disambiguate between Silverman's suggestion in the multivariate case and the "Silverman's rule of thumb" for the univariate case.