### PR TITLE
TST: linalg: bump tolerances in two TestBatch tests

### DIFF
--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -410,7 +410,7 @@ class TestBatch:
         if len(bdim) == 1:
             x = x[..., np.newaxis]
             b = b[..., np.newaxis]
-        assert_allclose(A @ x - b, 0, atol=1e-6)
+        assert_allclose(A @ x - b, 0, atol=1.5e-6)
         assert_allclose(x, np.linalg.solve(A, b), atol=2e-6)
 
     @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
@@ -423,7 +423,7 @@ class TestBatch:
         if len(bdim) == 1:
             x = x[..., np.newaxis]
             b = b[..., np.newaxis]
-        assert_allclose(A @ x - b, 0, atol=1e-6)
+        assert_allclose(A @ x - b, 0, atol=1.5e-6)
         assert_allclose(x, np.linalg.solve(A, b), atol=2e-6)
 
     @pytest.mark.parametrize('l_and_u', [(1, 1), ([2, 1, 0], [0, 1 , 2])])


### PR DESCRIPTION
Closes gh-22415

Skipping CI since there's no relevant signal - tested that this fixes the problem on my fork ([CI log](https://github.com/rgommers/scipy/actions/runs/12997762804/job/36249439214)).
