### PR TITLE
BUG: scipy.spatial: Fix inaccurate orthonormalization in `Rotation.from_matrix()`

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -1008,7 +1008,10 @@ cdef class Rotation:
 
         Rotations in 3 dimensions can be represented with 3 x 3 proper
         orthogonal matrices [1]_. If the input is not proper orthogonal,
-        an approximation is created using the method described in [2]_.
+        an approximation is created by orthonormalizing the input matrix
+        using the method described in [2]_, and then converting the
+        orthonormal rotation matrices to quaternions using the algorithm
+        described in [3]_. Matrices must be right-handed.
 
         Parameters
         ----------
@@ -1025,7 +1028,8 @@ cdef class Rotation:
         References
         ----------
         .. [1] https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
-        .. [2] F. Landis Markley, "Unit Quaternion from Rotation Matrix",
+        .. [2] https://en.wikipedia.org/wiki/Orthogonal_Procrustes_problem
+        .. [3] F. Landis Markley, "Unit Quaternion from Rotation Matrix",
                Journal of guidance, control, and dynamics vol. 31.2, pp.
                440-442, 2008.
 
@@ -1040,6 +1044,8 @@ cdef class Rotation:
         ... [0, -1, 0],
         ... [1, 0, 0],
         ... [0, 0, 1]])
+        >>> r.single
+        True
         >>> r.as_matrix().shape
         (3, 3)
 
@@ -1058,6 +1064,10 @@ cdef class Rotation:
         ... ]])
         >>> r.as_matrix().shape
         (2, 3, 3)
+        >>> r.single
+        False
+        >>> len(r)
+        2
 
         If input matrices are not special orthogonal (orthogonal with
         determinant equal to +1), then a special orthogonal estimate is stored:
@@ -1067,15 +1077,15 @@ cdef class Rotation:
         ... [0.5, 0, 0],
         ... [0, 0, 0.5]])
         >>> np.linalg.det(a)
-        0.12500000000000003
+        0.125
         >>> r = R.from_matrix(a)
         >>> matrix = r.as_matrix()
         >>> matrix
-        array([[-0.38461538, -0.92307692,  0.        ],
-               [ 0.92307692, -0.38461538,  0.        ],
-               [ 0.        ,  0.        ,  1.        ]])
+        array([[ 0., -1.,  0.],
+               [ 1.,  0.,  0.],
+               [ 0.,  0.,  1.]])
         >>> np.linalg.det(matrix)
-        1.0000000000000002
+        1.0
 
         It is also possible to have a stack containing a single rotation:
 
@@ -1097,7 +1107,7 @@ cdef class Rotation:
         .. versionadded:: 1.4.0
         """
         is_single = False
-        matrix = np.asarray(matrix, dtype=float)
+        matrix = np.array(matrix, dtype=float)
 
         if (matrix.ndim not in [2, 3] or
             matrix.shape[len(matrix.shape)-2:] != (3, 3)):
@@ -1107,13 +1117,35 @@ cdef class Rotation:
         # If a single matrix is given, convert it to 3D 1 x 3 x 3 matrix but
         # set self._single to True so that we can return appropriate objects in
         # the `to_...` methods
-        cdef double[:, :, :] cmatrix
         if matrix.shape == (3, 3):
-            cmatrix = matrix[None, :, :]
+            matrix = matrix[np.newaxis, :, :]
             is_single = True
-        else:
-            cmatrix = matrix
 
+        # Calculate the determinant of the rotation matrix
+        # (should be positive for right-handed rotations)
+        dets = np.linalg.det(matrix)
+        if np.any(dets <= 0):
+            ind = np.where(dets <= 0)[0][0]
+            raise ValueError("Non-positive determinant (left-handed or null "
+                             f"coordinate frame) in rotation matrix {ind}: "
+                             f"{matrix[ind]}.")
+
+        # Gramian orthonormality check
+        # (should be the identity matrix for orthonormal matrices)
+        grams = matrix @ np.swapaxes(matrix, 1, 2)
+        orthonormal_ok = np.all(np.isclose(grams, np.eye(3), atol=1e-12), axis=(1, 2))
+        idxs = np.where(~orthonormal_ok | ~np.isclose(dets, 1, atol=1e-12))[0]
+
+        # Orthonormalize the rotation matrices where necessary
+        if len(idxs) > 0:
+            # Exact solution to the orthogonal Procrustes problem using SVD
+            U, _, Vt = np.linalg.svd(matrix[idxs, :, :])
+            matrix[idxs, :, :] = U @ Vt
+
+        # Convert the orthonormal rotation matrices to quaternions using the
+        # algorithm described in [3]_.
+        cdef double[:, :, :] cmatrix
+        cmatrix = matrix
         cdef Py_ssize_t num_rotations = cmatrix.shape[0]
         cdef Py_ssize_t i, j, k
         cdef double[:] decision = _empty1(4)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -308,6 +308,11 @@ def test_matrix_calculation_pipeline():
 def test_from_matrix_ortho_output():
     rnd = np.random.RandomState(0)
     mat = rnd.random_sample((100, 3, 3))
+    dets = np.linalg.det(mat)
+    for i in range(len(dets)):
+        # Make sure we have a right-handed rotation matrix
+        if dets[i] < 0:
+            mat[i] = -mat[i]
     ortho_mat = Rotation.from_matrix(mat).as_matrix()
 
     mult_result = np.einsum('...ij,...jk->...ik', ortho_mat,
@@ -318,6 +323,37 @@ def test_from_matrix_ortho_output():
         eye3d[:, i, i] = 1.0
 
     assert_array_almost_equal(mult_result, eye3d)
+
+
+def test_from_matrix_normalize():
+    mat = np.array([
+        [1, 1, 0],
+        [0, 1, 0],
+        [0, 0, 1]])
+    expected = np.array([[ 0.894427, 0.447214, 0.0],
+                         [-0.447214, 0.894427, 0.0],
+                         [ 0.0,      0.0,      1.0]])
+    assert_allclose(Rotation.from_matrix(mat).as_matrix(), expected, atol=1e-6)
+
+    mat = np.array([
+        [0,  -0.5, 0  ],
+        [0.5, 0  , 0  ],
+        [0,   0  , 0.5]])
+    expected = np.array([[ 0, -1, 0],
+                         [ 1,  0, 0],
+                         [ 0,  0, 1]])
+    assert_allclose(Rotation.from_matrix(mat).as_matrix(), expected, atol=1e-6)
+
+
+def test_from_matrix_non_positive_determinant():
+    mat = np.eye(3)
+    mat[0, 0] = 0
+    with pytest.raises(ValueError, match='Non-positive determinant'):
+        Rotation.from_matrix(mat)
+
+    mat[0, 0] = -1
+    with pytest.raises(ValueError, match='Non-positive determinant'):
+        Rotation.from_matrix(mat)
 
 
 def test_from_1d_single_rotvec():


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/22417

#### What does this implement/fix?
The existing algorithm to orthonormalize rotation matrices only works for matrices that are already near orthonormal, and was designed to correct for round-off error. This can lead to large errors when handling arbitrary user inputs - indeed the existing example in the [`Rotation.from_matrix()`](https://docs.scipy.org/doc/scipy-1.15.1/reference/generated/scipy.spatial.transform.Rotation.from_matrix.html) docs shows an extremely poor result which is 22.6 degrees (!!) off the exact solution.

This updates the algorithm to correctly solve the orthogonal Procrustes problem using a singular value decomposition method. The existing algorithm is still used to convert the orthonormal result to a unit quaternion.

This also disallows left-handed rotation matrices, which return even worse results:

```python
import numpy as np
from scipy.spatial.transform import Rotation as R

# left-handed rotation matrix
m = np.eye(3)
m[0, 0] = -1
print(m)

r = R.from_matrix(m)
print(r.as_matrix())

"""
[[-1.  0.  0.]
 [ 0.  1.  0.]
 [ 0.  0.  1.]]

[[-1.  0.  0.]
 [ 0.  1.  0.]
 [ 0.  0. -1.]]  # note negative sign
"""
```

#### Additional information
We may want to use Davenport's q method or Shuster's QUEST instead, but these seem less readable and not necessarily faster to me:  https://ahrs.readthedocs.io/en/latest/filters/davenport.html https://ahrs.readthedocs.io/en/latest/filters/quest.html

@nmayorov FYI