### PR TITLE
BUG: ndimage: `binary_erosion` vs. broadcasted input

### DIFF
--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -220,7 +220,8 @@ def _binary_erosion(input, structure, iterations, mask, output,
     except TypeError as e:
         raise TypeError('iterations parameter should be an integer') from e
 
-    input = np.asarray(input)
+    # The Cython code can't cope with broadcasted inputs
+    input = np.asarray(input, order="C")
     ndim = input.ndim
     if np.iscomplexobj(input):
         raise TypeError('Complex type not supported')

--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -220,8 +220,11 @@ def _binary_erosion(input, structure, iterations, mask, output,
     except TypeError as e:
         raise TypeError('iterations parameter should be an integer') from e
 
+    input = np.asarray(input)
     # The Cython code can't cope with broadcasted inputs
-    input = np.asarray(input, order="C")
+    if not input.flags.c_contiguous and not input.flags.f_contiguous:
+        input = np.ascontiguousarray(input)
+
     ndim = input.ndim
     if np.iscomplexobj(input):
         raise TypeError('Complex type not supported')

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -782,6 +782,15 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([0, 1, 0]))
 
     @pytest.mark.parametrize('dtype', types)
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/8912")
+    def test_binary_erosion05_broadcasted(self, dtype, xp):
+        dtype = getattr(xp, dtype)
+        data = xp.ones((1, ), dtype=dtype)
+        data = xp.broadcast_to(data, (3, ))
+        out = ndimage.binary_erosion(data)
+        assert_array_almost_equal(out, xp.asarray([0, 1, 0]))
+
+    @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion06(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones([3], dtype=dtype)
@@ -1498,6 +1507,14 @@ class TestNdimageMorphology:
     def test_binary_dilation05(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones([3], dtype=dtype)
+        out = ndimage.binary_dilation(data)
+        assert_array_almost_equal(out, xp.asarray([1, 1, 1]))
+
+    @pytest.mark.parametrize('dtype', types)
+    def test_binary_dilation05_broadcasted(self, dtype, xp):
+        dtype = getattr(xp, dtype)
+        data = xp.ones((1, ), dtype=dtype)
+        data = xp.broadcast_to(data, (3,))
         out = ndimage.binary_dilation(data)
         assert_array_almost_equal(out, xp.asarray([1, 1, 1]))
 


### PR DESCRIPTION
binary_erosion and binary_dilation return incorrect results when the input is a broadcasted zero-dimensional array of ones.