### PR TITLE
MAINT: `_lib`: adapt `array_namespace` to accept scalars with arrays

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -151,12 +151,12 @@ def array_namespace(*arrays: Array) -> ModuleType:
         # here we could wrap the namespace if needed
         return np_compat
 
-    arrays = list(_compliance_scipy(arrays))
+    api_arrays = list(_compliance_scipy(arrays))
     # In case of a mix of array API compliant arrays and scalars, return
     # the array API namespace. If there are only ArrayLikes (e.g. lists),
     # return NumPy (wrapped by array-api-compat).
-    if arrays:
-        return array_api_compat.array_namespace(*arrays)
+    if api_arrays:
+        return array_api_compat.array_namespace(*api_arrays)
     return np_compat
 
 

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -50,11 +50,31 @@ class TestArrayAPI:
         with pytest.raises(TypeError, match=msg):
             array_namespace('abc')
 
-    def test_array_likes(self):
-        # should be no exceptions
-        array_namespace([0, 1, 2])
-        array_namespace(1, 2, 3)
-        array_namespace(1)
+    @pytest.mark.skip_xp_backends(np_only=True, reason="Array-likes")
+    def test_array_likes(self, xp):
+        """Test that if all parameters of array_namespace are Array-likes,
+        the output is array_api_compat.numpy
+        """
+        assert array_namespace([0, 1, 2]) is xp
+        assert array_namespace((0, 1, 2)) is xp
+        assert array_namespace(1, 2, 3) is xp
+        assert array_namespace(1) is xp
+        assert array_namespace([0, 1, 2], 3) is xp
+        assert array_namespace() is xp
+        assert array_namespace(None) is xp
+        assert array_namespace(1, None) is xp
+        assert array_namespace(None, 1) is xp
+
+    def test_array_and_array_likes_mix(self, xp):
+        """Test that if there is at least one Array API object among
+        the parameters of array_namespace, the output is its namespace
+        """
+        x = xp.asarray(1)
+        assert array_namespace(x) is xp
+        assert array_namespace(x, 1) is xp
+        assert array_namespace(1, x) is xp
+        assert array_namespace(x, [1, 2]) is xp
+        assert array_namespace(None, x) is xp
 
     def test_array_api_extra_hook(self):
         """Test that the `array_namespace` function used by

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -59,22 +59,35 @@ class TestArrayAPI:
         assert array_namespace((0, 1, 2)) is xp
         assert array_namespace(1, 2, 3) is xp
         assert array_namespace(1) is xp
+        assert array_namespace(np.int64(1)) is xp
         assert array_namespace([0, 1, 2], 3) is xp
         assert array_namespace() is xp
         assert array_namespace(None) is xp
         assert array_namespace(1, None) is xp
         assert array_namespace(None, 1) is xp
 
+        # This only works when xp is numpy!
+        assert array_namespace(np.asarray([1, 2]), [3, 4]) is xp
+        assert array_namespace(np.int64(1), [3, 4]) is xp
+
     def test_array_and_array_likes_mix(self, xp):
         """Test that if there is at least one Array API object among
-        the parameters of array_namespace, the output is its namespace
+        the parameters of array_namespace, and all other parameters
+        are scalars, the output is its namespace.
+
+        If there are non-scalar Array-Likes, raise as in array-api-compat.
         """
         x = xp.asarray(1)
         assert array_namespace(x) is xp
         assert array_namespace(x, 1) is xp
         assert array_namespace(1, x) is xp
-        assert array_namespace(x, [1, 2]) is xp
         assert array_namespace(None, x) is xp
+
+        if not is_numpy(xp):
+            with pytest.raises(TypeError, match="Multiple namespaces"):
+                array_namespace(x, [1, 2])
+            with pytest.raises(TypeError, match="Multiple namespaces"):
+                array_namespace(x, np.int64(1))
 
     def test_array_api_extra_hook(self):
         """Test that the `array_namespace` function used by


### PR DESCRIPTION
Fix bug, that was introduced by scipy's override of `array_namespace`, where a mixture of Array API objects and array-likes - including scalars - in a function's parameters would raise.