### PR TITLE
DEP: linalg: deprecate disp argument for signm, logm, sqrtm

### DIFF
--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -874,7 +874,7 @@ def funm(A, func, disp=True):
 
 
 @_apply_over_batch(('A', 2))
-def signm(A, disp=True):
+def signm(A, disp=_NoValue):
     """
     Matrix sign function.
 
@@ -887,6 +887,10 @@ def signm(A, disp=True):
     disp : bool, optional
         Print warning if error in the result is estimated large
         instead of returning estimated error. (Default: True)
+        .. deprecated:: 1.16.0
+            The `disp` argument is deprecated and will be
+            removed in SciPy 1.18.0. The previously returned error estimate
+            can be computed as ``norm(signm @ signm - signm, 1)``.
 
     Returns
     -------
@@ -907,6 +911,13 @@ def signm(A, disp=True):
     array([-1.+0.j,  1.+0.j,  1.+0.j])
 
     """
+    if disp is _NoValue:
+        disp = True
+    else:
+        warnings.warn("The `disp` argument is deprecated "
+                      "and will be removed in SciPy 1.18.0.",
+                      DeprecationWarning, stacklevel=2)
+
     A = _asarray_square(A)
 
     def rounded_sign(x):

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -423,14 +423,17 @@ def sqrtm(A, disp=_NoValue, blocksize=_NoValue):
     A : ndarray
         Input with last two dimensions are square ``(..., n, n)``.
     disp : bool, optional
-        Deprecated keyword. It will be removed in 1.20.0.
-
+        Print warning if error in the result is estimated large
+        instead of returning estimated error. (Default: True)
         .. deprecated:: 1.16.0
+            The `disp` argument is deprecated and will be
+            removed in SciPy 1.18.0. The previously returned error estimate
+            can be computed as ``norm(X @ X - A, 'fro')**2 / norm(A, 'fro')``
 
     blocksize : integer, optional
-        Deprecated keyword. It has no effect and will be removed in 1.18.0.
-
         .. deprecated:: 1.16.0
+            The `blocksize` argument is deprecated as it is unused by the algorithm
+            and will be removed in SciPy 1.18.0.
 
     Returns
     -------
@@ -481,6 +484,17 @@ def sqrtm(A, disp=_NoValue, blocksize=_NoValue):
            [ 1.,  4.]])
 
     """
+    if disp is _NoValue:
+        disp = True
+    else:
+        warnings.warn("The `disp` argument is deprecated and will be removed in SciPy "
+                      "1.18.0.",
+                      DeprecationWarning, stacklevel=2)
+    if blocksize is not _NoValue:
+        warnings.warn("The `blocksize` argument is deprecated and will be removed in "
+                      "SciPy 1.18.0.",
+                      DeprecationWarning, stacklevel=2)
+
     a = np.asarray(A)
     if a.size == 1 and a.ndim < 2:
         return np.array([[np.exp(a.item())]])

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -160,6 +160,7 @@ def logm(A, disp=_NoValue):
     disp : bool, optional
         Emit warning if error in the result is estimated large
         instead of returning estimated error. (Default: True)
+
         .. deprecated:: 1.16.0
             The `disp` argument is deprecated and will be
             removed in SciPy 1.18.0. The previously returned error estimate
@@ -425,12 +426,14 @@ def sqrtm(A, disp=_NoValue, blocksize=_NoValue):
     disp : bool, optional
         Print warning if error in the result is estimated large
         instead of returning estimated error. (Default: True)
+
         .. deprecated:: 1.16.0
             The `disp` argument is deprecated and will be
             removed in SciPy 1.18.0. The previously returned error estimate
             can be computed as ``norm(X @ X - A, 'fro')**2 / norm(A, 'fro')``
 
     blocksize : integer, optional
+
         .. deprecated:: 1.16.0
             The `blocksize` argument is deprecated as it is unused by the algorithm
             and will be removed in SciPy 1.18.0.
@@ -901,6 +904,7 @@ def signm(A, disp=_NoValue):
     disp : bool, optional
         Print warning if error in the result is estimated large
         instead of returning estimated error. (Default: True)
+
         .. deprecated:: 1.16.0
             The `disp` argument is deprecated and will be
             removed in SciPy 1.18.0. The previously returned error estimate

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -146,7 +146,7 @@ def fractional_matrix_power(A, t):
 
 
 @_apply_over_batch(('A', 2))
-def logm(A, disp=True):
+def logm(A, disp=_NoValue):
     """
     Compute matrix logarithm.
 
@@ -160,6 +160,10 @@ def logm(A, disp=True):
     disp : bool, optional
         Emit warning if error in the result is estimated large
         instead of returning estimated error. (Default: True)
+        .. deprecated:: 1.16.0
+            The `disp` argument is deprecated and will be
+            removed in SciPy 1.18.0. The previously returned error estimate
+            can be computed as ``norm(expm(logm(A)) - A, 1) / norm(A, 1)``.
 
     Returns
     -------
@@ -201,6 +205,12 @@ def logm(A, disp=True):
            [ 1.,  4.]])
 
     """
+    if disp is _NoValue:
+        disp = True
+    else:
+        warnings.warn("The `disp` argument is deprecated "
+                      "and will be removed in SciPy 1.18.0.",
+                      DeprecationWarning, stacklevel=2)
     A = np.asarray(A)  # squareness checked in `_logm`
     # Avoid circular import ... this is OK, right?
     import scipy.linalg._matfuncs_inv_ssq

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -142,17 +142,15 @@ class TestBatch:
         res2 = linalg.fractional_matrix_power(A, 1.5)
         np.testing.assert_equal(res1, res2)
 
-    @pytest.mark.parametrize('disp', [False, True])
     @pytest.mark.parametrize('dtype', floating)
-    def test_logm(self, dtype, disp):
+    def test_logm(self, dtype):
         # One test failed absolute tolerance with default random seed
         rng = np.random.default_rng(89940026998903887141749720079406074936)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         A = A + 3*np.eye(4)  # avoid complex output for real input
-        n_out = 1 if disp else 2
-        res1 = self.batch_test(linalg.logm, A, n_out=n_out, kwargs=dict(disp=disp))
+        res1 = self.batch_test(linalg.logm, A)
         # test that `disp` can be passed by position
-        res2 = linalg.logm(A, disp)
+        res2 = linalg.logm(A)
         for res1i, res2i in zip(res1, res2):
             np.testing.assert_equal(res1i, res2i)
 

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -1106,3 +1106,13 @@ class TestKhatriRao:
         b = np.empty((5, 0))
         res = khatri_rao(a, b)
         assert_allclose(res, np.empty((15, 0)))
+
+@pytest.mark.parametrize('func',
+                         [logm, sqrtm, signm])
+def test_disp_dep(func):
+    with pytest.deprecated_call():
+        func(np.eye(2), disp=False)
+
+def test_blocksize_dep():
+    with pytest.deprecated_call():
+        sqrtm(np.eye(2), blocksize=10)

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -65,7 +65,7 @@ class TestSignM:
 
     def test_defective1(self):
         a = array([[0.0,1,0,0],[1,0,1,0],[0,0,0,1],[0,0,1,0]])
-        signm(a, disp=False)
+        signm(a)
         #XXX: what would be the correct result?
 
     def test_defective2(self):
@@ -75,7 +75,7 @@ class TestSignM:
             [-10.0,6.0,-20.0,-18.0,-2.0],
             [-9.6,9.6,-25.5,-15.4,-2.0],
             [9.8,-4.8,18.0,18.2,2.0]))
-        signm(a, disp=False)
+        signm(a)
         #XXX: what would be the correct result?
 
     def test_defective3(self):
@@ -86,7 +86,7 @@ class TestSignM:
                    [0., 0., 0., 0., 3., 10., 0.],
                    [0., 0., 0., 0., 0., -2., 25.],
                    [0., 0., 0., 0., 0., 0., -3.]])
-        signm(a, disp=False)
+        signm(a)
         #XXX: what would be the correct result?
 
 

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -94,6 +94,7 @@ class TestLogM:
     def setup_method(self):
         self.rng = np.random.default_rng(1738098768840254)
 
+    @pytest.mark.filterwarnings("ignore:.*inaccurate.*:RuntimeWarning")
     def test_nils(self):
         a = array([[-2., 25., 0., 0., 0., 0., 0.],
                    [0., -3., 10., 3., 3., 3., 0.],
@@ -103,14 +104,15 @@ class TestLogM:
                    [0., 0., 0., 0., 0., -2., 25.],
                    [0., 0., 0., 0., 0., 0., -3.]])
         m = (identity(7)*3.1+0j)-a
-        logm(m, disp=False)
+        logm(m)
         #XXX: what would be the correct result?
 
+    @pytest.mark.filterwarnings("ignore:.*inaccurate.*:RuntimeWarning")
     def test_al_mohy_higham_2012_experiment_1_logm(self):
         # The logm completes the round trip successfully.
         # Note that the expm leg of the round trip is badly conditioned.
         A = _get_al_mohy_higham_2012_experiment_1()
-        A_logm, info = logm(A, disp=False)
+        A_logm = logm(A)
         A_round_trip = expm(A_logm)
         assert_allclose(A_round_trip, A, rtol=5e-5, atol=1e-14)
 
@@ -118,7 +120,7 @@ class TestLogM:
         # The raw funm with np.log does not complete the round trip.
         # Note that the expm leg of the round trip is badly conditioned.
         A = _get_al_mohy_higham_2012_experiment_1()
-        A_funm_log, info = funm(A, np.log, disp=False)
+        A_funm_log = funm(A, np.log)
         A_round_trip = expm(A_funm_log)
         assert_(not np.allclose(A_round_trip, A, rtol=1e-5, atol=1e-14))
 
@@ -152,7 +154,7 @@ class TestLogM:
                           1j*self.rng.standard_normal((n, n)))
             for scale in np.logspace(-4, 4, 9):
                 M = M_unscaled * scale
-                M_logm, info = logm(M, disp=False)
+                M_logm = logm(M)
                 M_round_trip = expm(M_logm)
                 assert_allclose(M_round_trip, M)
 
@@ -173,17 +175,17 @@ class TestLogM:
 
             # check float type preservation
             A = np.array(matrix_as_list, dtype=float)
-            A_logm, info = logm(A, disp=False)
+            A_logm = logm(A)
             assert_(A_logm.dtype.char not in complex_dtype_chars)
 
             # check complex type preservation
             A = np.array(matrix_as_list, dtype=complex)
-            A_logm, info = logm(A, disp=False)
+            A_logm = logm(A)
             assert_(A_logm.dtype.char in complex_dtype_chars)
 
             # check float->complex type conversion for the matrix negation
             A = -np.array(matrix_as_list, dtype=float)
-            A_logm, info = logm(A, disp=False)
+            A_logm = logm(A)
             assert_(A_logm.dtype.char in complex_dtype_chars)
 
     def test_complex_spectrum_real_logm(self):
@@ -194,7 +196,7 @@ class TestLogM:
             X = np.array(M, dtype=dt)
             w = scipy.linalg.eigvals(X)
             assert_(1e-2 < np.absolute(w.imag).sum())
-            Y, info = logm(X, disp=False)
+            Y = logm(X)
             assert_(np.issubdtype(Y.dtype, np.inexact))
             assert_allclose(expm(Y), X)
 
@@ -206,7 +208,7 @@ class TestLogM:
                 [[0, 1], [1, 0]]):
             for dt in float, complex:
                 A = np.array(M, dtype=dt)
-                A_logm, info = logm(A, disp=False)
+                A_logm, info = logm(A)
                 assert_(np.issubdtype(A_logm.dtype, np.complexfloating))
 
     @pytest.mark.thread_unsafe
@@ -215,7 +217,7 @@ class TestLogM:
         B = np.asarray([[1, 1], [0, 0]])
         for M in A, A.T, B, B.T:
             expected_warning = _matfuncs_inv_ssq.LogmExactlySingularWarning
-            L, info = assert_warns(expected_warning, logm, M, disp=False)
+            L = assert_warns(expected_warning, logm, M)
             E = expm(L)
             assert_allclose(E, M, atol=1e-14)
 
@@ -223,7 +225,7 @@ class TestLogM:
     def test_nearly_singular(self):
         M = np.array([[1e-100]])
         expected_warning = _matfuncs_inv_ssq.LogmNearlySingularWarning
-        L, info = assert_warns(expected_warning, logm, M, disp=False)
+        L = assert_warns(expected_warning, logm, M)
         E = expm(L)
         assert_allclose(E, M, atol=1e-14)
 
@@ -629,7 +631,7 @@ class TestFractionalMatrixPower:
             # to compute the fractional matrix power.
             # These can be compared because they both use the principal branch.
             A_power = fractional_matrix_power(A, p)
-            A_logm, info = logm(A, disp=False)
+            A_logm = logm(A)
             A_power_expm_logm = expm(A_logm * p)
             assert_allclose(A_power, A_power_expm_logm)
 
@@ -638,7 +640,7 @@ class TestFractionalMatrixPower:
         A = _get_al_mohy_higham_2012_experiment_1()
 
         # Test remainder matrix power.
-        A_funm_sqrt, info = funm(A, np.sqrt, disp=False)
+        A_funm_sqrt = funm(A, np.sqrt)
         A_sqrtm = sqrtm(A)
         A_rem_power = _matfuncs_inv_ssq._remainder_matrix_power(A, 0.5)
         A_power = fractional_matrix_power(A, 0.5)


### PR DESCRIPTION
In #22406 it was decided that the `disp` argument for various matrix functions should be deprecated.  This is so the function has a constant return type and because the error estimate was trivial.

`funm` has been left for another pr as it's error estimate is actually used.