### PR TITLE
BUG: interpolate.RectBivariateSpline: fix `NaN` output when smoothing large arrays

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1157,7 +1157,8 @@ Weighted sum of squared residuals does not satisfy abs(fp-s)/s < tol.""",
 the maximal number of iterations maxit (set to 20 by the program)
 allowed for finding a smoothing spline with fp=s has been reached:
 s too small.
-Weighted sum of squared residuals does not satisfy abs(fp-s)/s < tol.""",
+Weighted sum of squared residuals does not satisfy abs(fp-s)/s < tol.
+Try increasing maxit by passing it as a keyword argument.""",
                     4: """
 No more knots can be added because the number of b-spline coefficients
 (nx-kx-1)*(ny-ky-1) already exceeds the number of data points m:
@@ -1574,6 +1575,9 @@ class RectBivariateSpline(BivariateSpline):
         Positive smoothing factor defined for estimation condition:
         ``sum((z[i]-f(x[i], y[i]))**2, axis=0) <= s`` where f is a spline
         function. Default is ``s=0``, which is for interpolation.
+    maxit : int, optional
+        The maximal number of iterations maxit allowed for finding a
+        smoothing spline with fp=s. Default is ``maxit=20``.
 
     See Also
     --------

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1606,7 +1606,7 @@ class RectBivariateSpline(BivariateSpline):
 
     """
 
-    def __init__(self, x, y, z, bbox=[None] * 4, kx=3, ky=3, s=0):
+    def __init__(self, x, y, z, bbox=[None] * 4, kx=3, ky=3, s=0, maxit=20):
         x, y, bbox = ravel(x), ravel(y), ravel(bbox)
         z = np.asarray(z)
         if not np.all(diff(x) > 0.0):
@@ -1628,7 +1628,7 @@ class RectBivariateSpline(BivariateSpline):
         xb, xe, yb, ye = bbox
         with FITPACK_LOCK:
             nx, tx, ny, ty, c, fp, ier = dfitpack.regrid_smth(x, y, z, xb, xe, yb,
-                                                            ye, kx, ky, s)
+                                                            ye, kx, ky, s, maxit)
 
         if ier not in [0, -1, -2]:
             msg = _surfit_messages.get(ier, f'ier={ier}')

--- a/scipy/interpolate/fitpack/fpregr.f
+++ b/scipy/interpolate/fitpack/fpregr.f
@@ -21,6 +21,8 @@ c  ..local scalars
 c  ..function references..
       real*8 abs,fprati
       integer max0,min0
+      logical onlyxknots
+      onlyxknots = .false.
 c  ..subroutine references..
 c    fpgrre,fpknot
 c  ..
@@ -88,6 +90,10 @@ c  test whether the required storage space exceeds the available one.
       if(ny.gt.nyest .or. nx.gt.nxest) go to 420
 c  find the position of the interior knots in case of interpolation.
 c  the knots in the x-direction.
+      if(onlyxknots) then
+        onlyxknots = .false.
+        goto 120
+      end if
   10  mk1 = mx-kx1
       if(mk1.eq.0) go to 60
       k3 = kx/2
@@ -267,7 +273,10 @@ c  add a new knot in the x-direction
           call fpknot(x,mx,tx,nx,fpintx,nrdatx,nrintx,nxest,1)
 c  test whether we cannot further increase the number of knots in the
 c  x-direction.
-          if(nx.eq.nmaxx) go to 10
+          if(nx.eq.nmaxx) then
+            onlyxknots = .true.
+            go to 10
+          end if
           if(nx.eq.nxe) go to 250
  220    continue
         go to 250

--- a/scipy/interpolate/fitpack/fpregr.f
+++ b/scipy/interpolate/fitpack/fpregr.f
@@ -90,10 +90,6 @@ c  test whether the required storage space exceeds the available one.
       if(ny.gt.nyest .or. nx.gt.nxest) go to 420
 c  find the position of the interior knots in case of interpolation.
 c  the knots in the x-direction.
-      if(onlyxknots) then
-        onlyxknots = .false.
-        goto 120
-      end if
   10  mk1 = mx-kx1
       if(mk1.eq.0) go to 60
       k3 = kx/2
@@ -111,6 +107,10 @@ c  the knots in the x-direction.
         i = i+1
         j = j+1
   50  continue
+      if(onlyxknots) then
+        onlyxknots = .false.
+        goto 120
+      end if
 c  the knots in the y-direction.
   60  mk1 = my-ky1
       if(mk1.eq.0) go to 120
@@ -376,4 +376,3 @@ c  error codes and messages.
       fp = 0.
  440  return
       end
-

--- a/scipy/interpolate/fitpack/fpregr.f
+++ b/scipy/interpolate/fitpack/fpregr.f
@@ -88,7 +88,7 @@ c  test whether the required storage space exceeds the available one.
       if(ny.gt.nyest .or. nx.gt.nxest) go to 420
 c  find the position of the interior knots in case of interpolation.
 c  the knots in the x-direction.
-      mk1 = mx-kx1
+  10  mk1 = mx-kx1
       if(mk1.eq.0) go to 60
       k3 = kx/2
       i = kx1+1
@@ -267,6 +267,7 @@ c  add a new knot in the x-direction
           call fpknot(x,mx,tx,nx,fpintx,nrdatx,nrintx,nxest,1)
 c  test whether we cannot further increase the number of knots in the
 c  x-direction.
+          if(nx.eq.nmaxx) go to 10
           if(nx.eq.nxe) go to 250
  220    continue
         go to 250
@@ -280,6 +281,7 @@ c  add a new knot in the y-direction.
           call fpknot(y,my,ty,ny,fpinty,nrdaty,nrinty,nyest,1)
 c  test whether we cannot further increase the number of knots in the
 c  y-direction.
+          if(ny.eq.nmaxy) go to 60
           if(ny.eq.nye) go to 250
  240    continue
 c  restart the computations with the new set of knots.

--- a/scipy/interpolate/fitpack/regrid.f
+++ b/scipy/interpolate/fitpack/regrid.f
@@ -1,5 +1,5 @@
       recursive subroutine regrid(iopt,mx,x,my,y,z,xb,xe,yb,ye,kx,ky,s,
-     * nxest,nyest,nx,tx,ny,ty,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+     * nxest,nyest,maxit,nx,tx,ny,ty,c,fp,wrk,lwrk,iwrk,kwrk,ier)
       implicit none
 c given the set of values z(i,j) on the rectangular grid (x(i),y(j)),
 c i=1,...,mx;j=1,...,my, subroutine regrid determines a smooth bivar-
@@ -267,7 +267,7 @@ c
 c  ..
 c  ..scalar arguments..
       real*8 xb,xe,yb,ye,s,fp
-      integer iopt,mx,my,kx,ky,nxest,nyest,nx,ny,lwrk,kwrk,ier
+      integer iopt,mx,my,kx,ky,nxest,nyest,maxit,nx,ny,lwrk,kwrk,ier
 c  ..array arguments..
       real*8 x(mx),y(my),z(mx*my),tx(nxest),ty(nyest),
      * c((nxest-kx-1)*(nyest-ky-1)),wrk(lwrk)
@@ -275,14 +275,13 @@ c  ..array arguments..
 c  ..local scalars..
       real*8 tol
       integer i,j,jwrk,kndx,kndy,knrx,knry,kwest,kx1,kx2,ky1,ky2,
-     * lfpx,lfpy,lwest,lww,maxit,nc,nminx,nminy,mz
+     * lfpx,lfpy,lwest,lww,nc,nminx,nminy,mz
 c  ..function references..
       integer max0
 c  ..subroutine references..
 c    fpregr,fpchec
 c  ..
 c  we set up the parameters tol and maxit.
-      maxit = 20
       tol = 0.1e-02
 c  before starting computations a data check is made. if the input data
 c  are invalid, control is immediately repassed to the calling program.
@@ -351,4 +350,3 @@ c  we partition the working space and determine the spline approximation
      * iwrk(knry),iwrk(kndx),iwrk(kndy),wrk(lww),jwrk,ier)
   70  return
       end
-

--- a/scipy/interpolate/src/dfitpack.pyf
+++ b/scipy/interpolate/src/dfitpack.pyf
@@ -630,8 +630,8 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
      end subroutine spherfit_lsq
 
      subroutine regrid_smth(iopt,mx,x,my,y,z,xb,xe,yb,ye,kx,ky,s,&
-        nxest,nyest,nx,tx,ny,ty,c,fp,wrk,lwrk,iwrk,kwrk,ier)
-       !  nx,tx,ny,ty,c,fp,ier = regrid_smth(x,y,z,[xb,xe,yb,ye,kx,ky,s])
+        nxest,nyest,maxit,nx,tx,ny,ty,c,fp,wrk,lwrk,iwrk,kwrk,ier)
+       !  nx,tx,ny,ty,c,fp,ier = regrid_smth(x,y,z,[xb,xe,yb,ye,kx,ky,s,maxit])
 
        fortranname regrid
        threadsafe
@@ -653,6 +653,7 @@ static F_INT calc_regrid_lwrk(F_INT mx, F_INT my, F_INT kx, F_INT ky,
             :: nxest = mx+kx+1
        integer intent(hide),depend(ky,my),check(nyest>=2*(ky+1)) &
             :: nyest = my+ky+1
+       integer optional :: maxit = 20
        integer intent(out) :: nx
        real*8 dimension(nxest),intent(out),depend(nxest) :: tx
        integer intent(out) :: ny

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1140,6 +1140,7 @@ class TestRectBivariateSpline:
 
         return x, y, z.astype(np.float64)
 
+    @pytest.mark.slow()
     @pytest.mark.parametrize('shape', [(350, 850), (2000, 170)])
     @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
                                         (1, 7e-3, 1e-4),
@@ -1155,6 +1156,7 @@ class TestRectBivariateSpline:
         assert(not np.isnan(z_spl).any())
         xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
 
+    @pytest.mark.slow()
     @pytest.mark.skipif(sys.maxsize <= 2**32, reason="Segfaults on 32-bit system "
                                                      "due to large input data")
     def test_spline_large_2d_maxit(self):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1,5 +1,6 @@
 # Created by Pearu Peterson, June 2003
 import itertools
+import sys
 import numpy as np
 from numpy.testing import suppress_warnings
 import pytest
@@ -1154,6 +1155,8 @@ class TestRectBivariateSpline:
         assert(not np.isnan(z_spl).any())
         xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
 
+    @pytest.mark.skipif(sys.maxsize <= 2**32, reason="Segfaults on 32-bit system "
+                                                     "due to large input data")
     def test_spline_large_2d_maxit(self):
         # Reference - for https://github.com/scipy/scipy/issues/17787
         nx, ny = 1000, 1700

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1131,6 +1131,40 @@ class TestRectBivariateSpline:
             Interpolator(GridPosLats, nonGridPosLons)
         assert "y must be strictly increasing" in str(exc_info.value)
 
+    def _sample_large_2d_data(self, nx, ny):
+        rng = np.random.default_rng(1)
+        x = np.arange(nx)
+        y = np.arange(ny)
+        z = rng.integers(0, 100, (nx, ny))
+
+        return x, y, z.astype(np.float64)
+
+    @pytest.mark.parametrize('shape', [(350, 850), (2000, 170)])
+    @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
+                                        (1, 7e-3, 1e-4),
+                                        (3, 2e-2, 1e-4)])
+    def test_spline_large_2d(self, shape, s_tols):
+        # Reference - https://github.com/scipy/scipy/issues/17787
+        nx, ny = shape
+        s, atol, rtol = s_tols
+        x, y, z = self._sample_large_2d_data(nx, ny)
+
+        spl = RectBivariateSpline(x, y, z, s=s)
+        z_spl = spl(x, y)
+        assert(not np.isnan(z_spl).any())
+        xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
+
+    def test_spline_large_2d_maxit(self):
+        # Reference - for https://github.com/scipy/scipy/issues/17787
+        nx, ny = 1000, 1700
+        s, atol, rtol = 2, 2e-2, 1e-12
+        x, y, z = self._sample_large_2d_data(nx, ny)
+
+        spl = RectBivariateSpline(x, y, z, s=s, maxit=25)
+        z_spl = spl(x, y)
+        assert(not np.isnan(z_spl).any())
+        xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
+
 
 class TestRectSphereBivariateSpline:
     def test_defaults(self):

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -792,38 +792,6 @@ class TestInterpN:
         assert_raises(ValueError, interpn, (x, y), z, xi, method="splinef2d",
                       bounds_error=False, fill_value=None)
 
-    def _sample_large_2d_data(self, nx, ny):
-        rng = np.random.default_rng(1)
-        x = np.arange(nx)
-        y = np.arange(ny)
-        z = rng.integers(0, 100, (nx, ny))
-
-        return x, y, z.astype(np.float64)
-
-    @pytest.mark.parametrize('shape', [(350, 850), (2000, 170)])
-    @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
-                                        (1, 7e-3, 1e-4),
-                                        (3, 2e-2, 1e-4)])
-    def test_spline_large_2d(self, shape, s_tols):
-        nx, ny = shape
-        s, atol, rtol = s_tols
-        x, y, z = self._sample_large_2d_data(nx, ny)
-
-        spl = RectBivariateSpline(x, y, z, s=s)
-        z_spl = spl(x, y)
-        assert_(not np.isnan(z_spl).any())
-        xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
-
-    def test_spline_large_2d_maxit(self):
-        nx, ny = 1000, 1700
-        s, atol, rtol = 2, 2e-2, 1e-12
-        x, y, z = self._sample_large_2d_data(nx, ny)
-
-        spl = RectBivariateSpline(x, y, z, s=s, maxit=25)
-        z_spl = spl(x, y)
-        assert_(not np.isnan(z_spl).any())
-        xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
-
     def _sample_4d_data(self):
         points = [(0., .5, 1.)] * 2 + [(0., 5., 10.)] * 2
         values = np.asarray([0., .5, 1.])

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -3,7 +3,7 @@ import itertools
 import pytest
 import numpy as np
 
-from numpy.testing import assert_warns, assert_
+from numpy.testing import assert_warns
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, assert_array_almost_equal
 )

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -814,6 +814,16 @@ class TestInterpN:
         assert_(not np.isnan(z_spl).any())
         xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
 
+    def test_spline_large_2d_maxit(self):
+        nx, ny = 1000, 1700
+        s, atol, rtol = 2, 2e-2, 1e-12
+        x, y, z = self._sample_large_2d_data(nx, ny)
+
+        spl = RectBivariateSpline(x, y, z, s=s, maxit=25)
+        z_spl = spl(x, y)
+        assert_(not np.isnan(z_spl).any())
+        xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
+
     def _sample_4d_data(self):
         points = [(0., .5, 1.)] * 2 + [(0., 5., 10.)] * 2
         values = np.asarray([0., .5, 1.])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/17787

#### What does this implement/fix?
<!--Please explain your changes.-->

The fix contains two parts,

1. When knots are maximised in a direction then recomputing of knots as per interpolation in that direction is done.

This is implemented in b278464a85c1aa8e69fc54b5029ea3c1c790b878 and the test is added in b93ba4085af8d096fec17ba94b85a52128ede9d3. The tests check for two things, a) the output is non-NaN, and b) the output is within a tolerance value (for larger `s`, the tolerance increases, which is expected from my point of view).

2. Increasing the maximal iterations for large arrays - In case of large arrays, for some values of `s`, we need higher iterations to converge to an acceptable solution.

This is implemented by exposing `maxit` parameter as optional keyword argument and then passing higher values for `maxit`. This way `maxit` becomes configurable and users can increase it according to their needs. It's better than hardcoding `maxit` to pass the tests I added.

1dfcd52e1113db19546378720d5fd1ed598cf712 exposes the `maxit` as optional keyword argument. 708519d3ca1f7eb8b3ce2dbdbd79b75d72e3c34f updates the documentation for `maxit` and the error message is updated to suggest increasing `maxit`. 48dc2e746c14ead1a6a04e07933bea366e0fdfc2 adds test to make sure the fix works (the pattern for this test is same as above).

#### Additional information
<!--Any additional information you think is important.-->
