### PR TITLE
DOC: Fix year of publication in `_dual_annealing.py`

### DIFF
--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -599,7 +599,7 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
     References
     ----------
     .. [1] Tsallis C. Possible generalization of Boltzmann-Gibbs
-        statistics. Journal of Statistical Physics, 52, 479-487 (1998).
+        statistics. Journal of Statistical Physics, 52, 479-487 (1988).
     .. [2] Tsallis C, Stariolo DA. Generalized Simulated Annealing.
         Physica A, 233, 395-406 (1996).
     .. [3] Xiang Y, Sun DY, Fan W, Gong XG. Generalized Simulated


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
This is a small PR that corrects the year of publication of an article in the documentation of `_dual_annealing.py` from 1998 to 1988. You can check the year of publication of the article [here](https://link.springer.com/article/10.1007/BF01016429#citeas).

#### Additional information
This change is a minor documentation fix and does not affect the functionality of any code.