### PR TITLE
BUG: special: Fix incorrect handling of `nan` input in `gammainc` and `gammaincc`

### DIFF
--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -4316,6 +4316,26 @@ def test_ch2_inf():
     assert_equal(special.chdtr(0.7,np.inf), 1.0)
 
 
+@pytest.mark.parametrize("x", [-np.inf, -1.0, -0.0, 0.0, np.inf, np.nan])
+def test_chi2_v_nan(x):
+    assert np.isnan(special.chdtr(np.nan, x))
+
+
+@pytest.mark.parametrize("v", [-np.inf, -1.0, -0.0, 0.0, np.inf, np.nan])
+def test_chi2_x_nan(v):
+    assert np.isnan(special.chdtr(v, np.nan))
+
+
+@pytest.mark.parametrize("x", [-np.inf, -1.0, -0.0, 0.0, np.inf, np.nan])
+def test_chi2c_v_nan(x):
+    assert np.isnan(special.chdtrc(np.nan, x))
+
+
+@pytest.mark.parametrize("v", [-np.inf, -1.0, -0.0, 0.0, np.inf, np.nan])
+def test_chi2c_x_nan(v):
+    assert np.isnan(special.chdtrc(v, np.nan))
+
+
 def test_chi2c_smalldf():
     assert_almost_equal(special.chdtrc(0.6,3), 1-0.957890536704110)
 

--- a/scipy/special/tests/test_gammainc.py
+++ b/scipy/special/tests/test_gammainc.py
@@ -38,6 +38,14 @@ class TestGammainc:
         else:
             assert result == desired
 
+    @pytest.mark.parametrize("x", [-np.inf, -1.0, -0.0, 0.0, np.inf, np.nan])
+    def test_a_nan(self, x):
+        assert np.isnan(sc.gammainc(np.nan, x))
+
+    @pytest.mark.parametrize("a", [-np.inf, -1.0, -0.0, 0.0, np.inf, np.nan])
+    def test_x_nan(self, a):
+        assert np.isnan(sc.gammainc(a, np.nan))
+
     def test_infinite_limits(self):
         # Test that large arguments converge to the hard-coded limits
         # at infinity.
@@ -107,6 +115,14 @@ class TestGammaincc:
             assert np.isnan(result)
         else:
             assert result == desired
+
+    @pytest.mark.parametrize("x", [-np.inf, -1.0, -0.0, 0.0, np.inf, np.nan])
+    def test_a_nan(self, x):
+        assert np.isnan(sc.gammaincc(np.nan, x))
+
+    @pytest.mark.parametrize("a", [-np.inf, -1.0, -0.0, 0.0, np.inf, np.nan])
+    def test_x_nan(self, a):
+        assert np.isnan(sc.gammaincc(a, np.nan))
 
     def test_infinite_limits(self):
         # Test that large arguments converge to the hard-coded limits

--- a/scipy/special/xsf/cephes/chdtr.h
+++ b/scipy/special/xsf/cephes/chdtr.h
@@ -162,9 +162,10 @@ namespace xsf {
 namespace cephes {
 
     XSF_HOST_DEVICE inline double chdtrc(double df, double x) {
-
-        if (x < 0.0)
-            return 1.0; /* modified by T. Oliphant */
+        if (x < 0.0) {
+            set_error("chdtr", SF_ERROR_DOMAIN, NULL);
+            return (std::numeric_limits<double>::quiet_NaN());
+	}
         return (igamc(df / 2.0, x / 2.0));
     }
 

--- a/scipy/special/xsf/cephes/igam.h
+++ b/scipy/special/xsf/cephes/igam.h
@@ -328,6 +328,10 @@ namespace cephes {
     XSF_HOST_DEVICE inline double igam(double a, double x) {
         double absxma_a;
 
+	if (std::isnan(a) || std::isnan(x)) {
+	    return std::numeric_limits<double>::quiet_NaN();
+	}
+
         if (x < 0 || a < 0) {
             set_error("gammainc", SF_ERROR_DOMAIN, NULL);
             return std::numeric_limits<double>::quiet_NaN();
@@ -366,6 +370,10 @@ namespace cephes {
 
     XSF_HOST_DEVICE double igamc(double a, double x) {
         double absxma_a;
+
+	if (std::isnan(a) || std::isnan(x)) {
+	    return std::numeric_limits<double>::quiet_NaN();
+	}
 
         if (x < 0 || a < 0) {
             set_error("gammaincc", SF_ERROR_DOMAIN, NULL);


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr


Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #21317

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds `nan` checks to the scalar kernels for `gammainc` and `gammaincc`. As observed by @mdhaber in #21317, there were some cases where non-`nan` output was being returned despite `nan` values of `a` or `x`. These were not cases like `pow(1, nan)` where a constant partial function remains constant for `nan` input. The output should be `nan`.

#### Additional information
<!--Any additional information you think is important.-->
This will also fix the same problem for `chdtr` and `chdtrc` also pointed out in #21317, since these wrap the same `cephes` function which has been fixed here. I haven't added test cases confirming the fix for `chdtr` and `chdtrc` but can if desired.
