### PR TITLE
DOC: Modified Link for code of conduct documentation

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,7 +1,7 @@
 SciPy Code of Conduct
 ======
 
-You can read our Code of Conduct by following [this link](../doc/source/dev/conduct/code_of_conduct.rst). 
+You can read our Code of Conduct by following [this link](../main/source/dev/conduct/code_of_conduct.rst). 
 
 
 Alternatively, you can find it under `scipy/doc/source/dev/conduct/code_of_conduct.rst`. 


### PR DESCRIPTION
[docs only]

Resolve #22437 
Modified the link from  [../doc/source/dev/conduct/code_of_conduct.rst](https://github.com/scipy/scipy/blob/doc/source/dev/conduct/code_of_conduct.rst) to [../main/source/dev/conduct/code_of_conduct.rst](https://github.com/scipy/scipy/blob/main/doc/source/dev/conduct/code_of_conduct.rst)
