### PR TITLE
CI: avoid mpmath pre-release version that's failing in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -321,7 +321,10 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install cython pythran ninja meson-python pybind11 click rich_click pydevtool
-        python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis matplotlib
+        python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist gmpy2 threadpoolctl pooch hypothesis matplotlib
+        # Move mpmath back into `install --pre` above once mpmath 1.4.0 with
+        # the fix is out (xref gh-22395)
+        python -m pip install mpmath
         python -m pip install -r requirements/openblas.txt
         # Install numpy last, to ensure we get nightly (avoid possible <2.0 constraints).
         python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy


### PR DESCRIPTION
xref gh-22395