### PR TITLE
BUG: io.loadmat: throw error on file containing all zeros

### DIFF
--- a/scipy/io/matlab/_miobase.py
+++ b/scipy/io/matlab/_miobase.py
@@ -225,13 +225,19 @@ def matfile_version(file_name, *, appendmat=True):
 get_matfile_version = matfile_version
 
 
+_HDR_N_BYTES = 20
+
+
 def _get_matfile_version(fileobj):
     # Mat4 files have a zero somewhere in first 4 bytes
     fileobj.seek(0)
-    mopt_bytes = fileobj.read(4)
-    if len(mopt_bytes) == 0:
-        raise MatReadError("Mat file appears to be empty")
-    mopt_ints = np.ndarray(shape=(4,), dtype=np.uint8, buffer=mopt_bytes)
+    hdr_bytes = fileobj.read(_HDR_N_BYTES)
+    if len(hdr_bytes) < _HDR_N_BYTES:
+        raise MatReadError("Mat file appears to be truncated")
+    if hdr_bytes.count(0) == _HDR_N_BYTES:
+        raise MatReadError("Mat file appears to be corrupt "
+                           f"(first {_HDR_N_BYTES} bytes == 0)")
+    mopt_ints = np.ndarray(shape=(4,), dtype=np.uint8, buffer=hdr_bytes[:4])
     if 0 in mopt_ints:
         fileobj.seek(0)
         return (0,0)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1364,6 +1364,7 @@ def test_large_m4():
     with pytest.raises(ValueError, match=match):
         loadmat(truncated_mat)
 
+
 def test_gh_19223():
     from scipy.io.matlab import varmats_from_mat  # noqa: F401
 
@@ -1390,3 +1391,13 @@ def check_mat_write_warning(names_vars):
     with pytest.warns(MatWriteWarning, match='Starting field name with'):
         savemat(stream, C())
 
+
+def test_corrupt_files():
+    # Test we can detect truncated or corrupt (all zero) files.
+    for n in (2, 4, 10, 19):
+        with pytest.raises(MatReadError,
+                           match="Mat file appears to be truncated"):
+            loadmat(BytesIO(b'\x00' * n))
+    with pytest.raises(MatReadError,
+                       match="Mat file appears to be corrupt"):
+        loadmat(BytesIO(b'\x00' * 20))


### PR DESCRIPTION
Closes gh-22444.


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->