### PR TITLE
ENH: linalg.eigh_tridiagonal: add stevd as a driver and make it the default 

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -1172,9 +1172,9 @@ def eigvalsh_tridiagonal(d, e, select='a', select_range=None,
         and ``|a|`` is the 1-norm of the matrix ``a``.
     lapack_driver : str
         LAPACK function to use, can be 'auto', 'stemr', 'stebz',  'sterf',
-        or 'stev'. When 'auto' (default), it will use 'stemr' if ``select='a'``
-        and 'stebz' otherwise. 'sterf' and 'stev' can only be used when
-        ``select='a'``.
+        'stev', or 'stevd'. When 'auto' (default), it will use 'stemr' if
+        ``select='a'`` and 'stebz' otherwise. 'sterf' and 'stev' can only
+        be used when ``select='a'``.
 
     Returns
     -------
@@ -1257,7 +1257,7 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
         and ``|a|`` is the 1-norm of the matrix ``a``.
     lapack_driver : str
         LAPACK function to use, can be 'auto', 'stemr', 'stebz', 'sterf',
-        or 'stev'. When 'auto' (default), it will use 'stemr' if ``select='a'``
+        'stev', or 'stevd'. When 'auto' (default), it will use 'stemr' if ``select='a'``
         and 'stebz' otherwise. When 'stebz' is used to find the eigenvalues and
         ``eigvals_only=False``, then a second LAPACK call (to ``?STEIN``) is
         used to find the corresponding eigenvectors. 'sterf' can only be
@@ -1315,7 +1315,7 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
         select, select_range, 0, d.size)
     if not isinstance(lapack_driver, str):
         raise TypeError('lapack_driver must be str')
-    drivers = ('auto', 'stemr', 'sterf', 'stebz', 'stev')
+    drivers = ('auto', 'stemr', 'sterf', 'stebz', 'stev', 'stevd')
     if lapack_driver not in drivers:
         raise ValueError(f'lapack_driver must be one of {drivers}, '
                          f'got {lapack_driver}')
@@ -1349,6 +1349,11 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
     elif lapack_driver == 'stev':
         if select != 0:
             raise ValueError('stev can only be used when select == "a"')
+        w, v, info = func(d, e, compute_v=compute_v)
+        m = len(w)
+    elif lapack_driver == 'stevd':
+        if select != 0:
+            raise ValueError('stevd can only be used when select == "a"')
         w, v, info = func(d, e, compute_v=compute_v)
         m = len(w)
     elif lapack_driver == 'stebz':

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -1172,7 +1172,7 @@ def eigvalsh_tridiagonal(d, e, select='a', select_range=None,
         and ``|a|`` is the 1-norm of the matrix ``a``.
     lapack_driver : str
         LAPACK function to use, can be 'auto', 'stemr', 'stebz',  'sterf',
-        'stev', or 'stevd'. When 'auto' (default), it will use 'stemr' if
+        'stev', or 'stevd'. When 'auto' (default), it will use 'stevd' if
         ``select='a'`` and 'stebz' otherwise. 'sterf' and 'stev' can only
         be used when ``select='a'``.
 
@@ -1257,7 +1257,7 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
         and ``|a|`` is the 1-norm of the matrix ``a``.
     lapack_driver : str
         LAPACK function to use, can be 'auto', 'stemr', 'stebz', 'sterf',
-        'stev', or 'stevd'. When 'auto' (default), it will use 'stemr' if ``select='a'``
+        'stev', or 'stevd'. When 'auto' (default), it will use 'stevd' if ``select='a'``
         and 'stebz' otherwise. When 'stebz' is used to find the eigenvalues and
         ``eigvals_only=False``, then a second LAPACK call (to ``?STEIN``) is
         used to find the corresponding eigenvectors. 'sterf' can only be
@@ -1320,7 +1320,7 @@ def eigh_tridiagonal(d, e, eigvals_only=False, select='a', select_range=None,
         raise ValueError(f'lapack_driver must be one of {drivers}, '
                          f'got {lapack_driver}')
     if lapack_driver == 'auto':
-        lapack_driver = 'stemr' if select == 0 else 'stebz'
+        lapack_driver = 'stevd' if select == 0 else 'stebz'
 
     # Quick exit for 1x1 case
     if len(d) == 1:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -769,11 +769,11 @@ class TestEigTridiagonal:
     def test_eigvalsh_tridiagonal(self):
         """Compare eigenvalues of eigvalsh_tridiagonal with those of eig."""
         # can't use ?STERF with subselection
-        for driver in ('sterf', 'stev', 'stebz', 'stemr', 'auto'):
+        for driver in ('sterf', 'stev', 'stevd', 'stebz', 'stemr', 'auto'):
             w = eigvalsh_tridiagonal(self.d, self.e, lapack_driver=driver)
             assert_array_almost_equal(sort(w), self.w)
 
-        for driver in ('sterf', 'stev'):
+        for driver in ('sterf', 'stev', 'stevd'):
             assert_raises(ValueError, eigvalsh_tridiagonal, self.d, self.e,
                           lapack_driver=driver, select='i',
                           select_range=(0, 1))
@@ -806,7 +806,7 @@ class TestEigTridiagonal:
         # can't use ?STERF when eigenvectors are requested
         assert_raises(ValueError, eigh_tridiagonal, self.d, self.e,
                       lapack_driver='sterf')
-        for driver in ('stebz', 'stev', 'stemr', 'auto'):
+        for driver in ('stebz', 'stev', 'stevd', 'stemr', 'auto'):
             w, evec = eigh_tridiagonal(self.d, self.e, lapack_driver=driver)
             evec_ = evec[:, argsort(w)]
             assert_array_almost_equal(sort(w), self.w)


### PR DESCRIPTION
Closes #13982

The first commit exposes `stevd` as a driver. This should hopefully be an uncontroversial improvement.

The second commit set `stevd` as the default driver when all eigenvalues are requested.