### PR TITLE
DOC: ndimage: fix wrong return type doc for `ndimage.minimum` and `nimage.maximum`

### DIFF
--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -1053,7 +1053,7 @@ def minimum(input, labels=None, index=None):
 
     Returns
     -------
-    output : a scalor or list of integer or float based on input type.
+    output : a scalar or list of integers or floats based on input type.
         List of minima of `input` over the regions determined by `labels` and
         whose index is in `index`. If `index` or `labels` are not specified, a
         float is returned: the minimal value of `input` if `labels` is None,
@@ -1116,7 +1116,7 @@ def maximum(input, labels=None, index=None):
 
     Returns
     -------
-    output : a scalor or list of integer or float based on input type.
+    output : a scalar or list of integers or floats based on input type.
         List of maxima of `input` over the regions determined by `labels` and
         whose index is in `index`. If `index` or `labels` are not specified, a
         float is returned: the maximal value of `input` if `labels` is None,

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -1053,7 +1053,7 @@ def minimum(input, labels=None, index=None):
 
     Returns
     -------
-    minimum : float or list of floats
+    output : a scalor or list of integer or float based on input type.
         List of minima of `input` over the regions determined by `labels` and
         whose index is in `index`. If `index` or `labels` are not specified, a
         float is returned: the minimal value of `input` if `labels` is None,
@@ -1116,7 +1116,7 @@ def maximum(input, labels=None, index=None):
 
     Returns
     -------
-    output : float or list of floats
+    output : a scalor or list of integer or float based on input type.
         List of maxima of `input` over the regions determined by `labels` and
         whose index is in `index`. If `index` or `labels` are not specified, a
         float is returned: the maximal value of `input` if `labels` is None,


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Fix #22055 

#### What does this implement/fix?
<!--Please explain your changes.-->
Fixed fix wrong return type doc for `ndimage.minimum` and `nimage.maximum`.
These functions return different output types depending on the input type:

```
In [5]: type(ndimage.minimum([1,2,3]))
Out[5]: numpy.int64

In [6]: type(ndimage.maximum([1,2,3]))
Out[6]: numpy.int64

In [7]: type(ndimage.minimum([1.0,2.0,3.0]))
Out[7]: numpy.float64

In [8]: type(ndimage.maximum([1.0,2.0,3.0]))
Out[8]: numpy.float64
```


