### PR TITLE
MAINT: signal.csd: port away from using `_spectral_helper`

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -378,8 +378,8 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the power spectral density ('density')
-        where `Pxx` has units of V**2/Hz and computing the squared magnitude
-        spectrum ('spectrum') where `Pxx` has units of V**2, if `x`
+        where `Pxx` has units of V²/Hz and computing the squared magnitude
+        spectrum ('spectrum') where `Pxx` has units of V², if `x`
         is measured in V and `fs` is measured in Hz. Defaults to
         'density'
     axis : int, optional
@@ -400,6 +400,12 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
 
     Notes
     -----
+    The ratio of the squared magnitude (``scaling='spectrum'``) divided the spectral
+    power density (``scaling='density'``) is the constant factor of
+    ``sum(abs(window)**2)*fs / abs(sum(window))**2``.
+    If `return_onesided` is ``True``, the values of the negative frequencies are added
+    to values of the corresponding positive ones.
+
     Consult the :ref:`tutorial_SpectralAnalysis` section of the :ref:`user_guide`
     for a discussion of the scalings of the power spectral density and
     the magnitude (squared) spectrum.

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -555,6 +555,7 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
     See Also
     --------
+    csd: Cross power spectral density using Welch's method
     periodogram: Simple, optionally modified periodogram
     lombscargle: Lomb-Scargle periodogram for unevenly sampled data
 
@@ -562,12 +563,16 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     -----
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements. For the default Hann window an overlap of
-    50% is a reasonable trade off between accurately estimating the
+    50% is a reasonable trade-off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
-    windows may require a larger overlap.
+    windows may require a larger overlap. If `noverlap` is 0, this
+    method is equivalent to Bartlett's method [2]_.
 
-    If `noverlap` is 0, this method is equivalent to Bartlett's method
-    [2]_.
+    The ratio of the squared magnitude (``scaling='spectrum'``) divided the spectral
+    power density (``scaling='density'``) is the constant factor of
+    ``sum(abs(window)**2)*fs / abs(sum(window))**2``.
+    If `return_onesided` is ``True``, the values of the negative frequencies are added
+    to values of the corresponding positive ones.
 
     Consult the :ref:`tutorial_SpectralAnalysis` section of the :ref:`user_guide`
     for a discussion of the scalings of the power spectral density and
@@ -744,6 +749,12 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     50% is a reasonable trade-off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
+
+    The ratio of the cross spectrum (``scaling='spectrum'``) divided by the cross
+    spectral density (``scaling='density'``) is the constant factor of
+    ``sum(abs(window)**2)*fs / abs(sum(window))**2``.
+    If `return_onesided` is ``True``, the values of the negative frequencies are added
+    to values of the corresponding positive ones.
 
     Consult the :ref:`tutorial_SpectralAnalysis` section of the :ref:`user_guide`
     for a discussion of the scalings of a spectral density and an (amplitude) spectrum.
@@ -1935,7 +1946,7 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     -----
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements. For the default Hann window an overlap of
-    50% is a reasonable trade off between accurately estimating the
+    50% is a reasonable trade-off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -2019,7 +2019,7 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     .. legacy:: function
 
         This function is soley used by the legacy functions `spectrogram` and `stft`
-        (which are also in this file).
+        (which are also in this same source file `scipy/signal/_spectral_py.py`).
 
     This is a helper function that implements the commonality between
     the stft, psd, csd, and spectrogram functions. It is not designed to

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -4,10 +4,11 @@ import numpy as np
 import numpy.typing as npt
 from scipy import fft as sp_fft
 from . import _signaltools
+from ._short_time_fft import ShortTimeFFT, FFT_MODE_TYPE
 from .windows import get_window
 from ._arraytools import const_ext, even_ext, odd_ext, zero_ext
 import warnings
-from typing import Literal
+from typing import cast, Literal
 
 
 __all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
@@ -685,7 +686,8 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         length of the window.
     noverlap: int, optional
         Number of points to overlap between segments. If `None`,
-        ``noverlap = nperseg // 2``. Defaults to `None`.
+        ``noverlap = nperseg // 2``. Defaults to `None` and may
+        not be greater than `nperseg`.
     nfft : int, optional
         Length of the FFT used, if a zero padded FFT is desired. If
         `None`, the FFT length is `nperseg`. Defaults to `None`.
@@ -739,7 +741,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
     An appropriate amount of overlap will depend on the choice of window
     and on your requirements. For the default Hann window an overlap of
-    50% is a reasonable trade off between accurately estimating the
+    50% is a reasonable trade-off between accurately estimating the
     signal power, while not over counting any of the data. Narrower
     windows may require a larger overlap.
 
@@ -759,17 +761,17 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
 
     Examples
     --------
+    The following example plots the cross power spectral density of two signals with
+    some common features:
+
     >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
     >>> rng = np.random.default_rng()
-
-    Generate two test signals with some common features.
-
-    >>> fs = 10e3
-    >>> N = 1e5
-    >>> amp = 20
-    >>> freq = 1234.0
+    ...
+    ... # Generate two test signals with some common features:
+    >>> N, fs = 100_000, 10e3  # number of samples and sampling frequency
+    >>> amp, freq = 20, 1234.0  # amplitude and frequency of utilized sine signal
     >>> noise_power = 0.001 * fs / 2
     >>> time = np.arange(N) / fs
     >>> b, a = signal.butter(2, 0.25, 'low')
@@ -777,40 +779,147 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     >>> y = signal.lfilter(b, a, x)
     >>> x += amp*np.sin(2*np.pi*freq*time)
     >>> y += rng.normal(scale=0.1*np.sqrt(noise_power), size=time.shape)
-
-    Compute and plot the magnitude of the cross spectral density.
-
-    >>> f, Pxy = signal.csd(x, y, fs, nperseg=1024)
-    >>> plt.semilogy(f, np.abs(Pxy))
-    >>> plt.xlabel('frequency [Hz]')
-    >>> plt.ylabel('CSD [V**2/Hz]')
+    ...
+    ... # Compute and plot the magnitude of the cross spectral density:
+    >>> nperseg, noverlap, win = 1024, 512, 'hann'
+    >>> f, Pxy = signal.csd(x, y, fs, win, nperseg, noverlap)
+    >>> fig0, ax0 = plt.subplots(tight_layout=True)
+    >>> ax0.set_title(f"CSD ({win.title()}-window, {nperseg=}, {noverlap=})")
+    >>> ax0.set(xlabel="Frequency $f$ in kHz", ylabel="CSD Magnitude in V²/Hz")
+    >>> ax0.semilogy(f/1e3, np.abs(Pxy))
+    >>> ax0.grid()
     >>> plt.show()
 
+    The cross spectral density is calculated by taking the average over the time slices
+    of a spectrogram:
+
+    >>> SFT = signal.ShortTimeFFT.from_window('hann', fs, nperseg, noverlap,
+    ...                                       scale_to='psd', fft_mode='onesided2X',
+    ...                                       phase_shift=None)
+    >>> Sxy1 = SFT.spectrogram(y, x, detr='constant', k_offset=nperseg//2,
+    ...                        p0=0, p1=(N-noverlap) // SFT.hop)
+    >>> Pxy1 = Sxy1.mean(axis=-1)
+    >>> np.allclose(Pxy, Pxy1)  # same result as with csd()
+    True
+
+    Allthough this function uses the `ShortTimeFFT` internally, the results of using an
+    approach analog to the code snippet above and the `csd()` function may deviate due
+    to implementation details. Notable differences are:
+
+    * There is no direct `ShortTimeFFT` equivalent for the `csd()` parameter
+      combination ``return_onesided=True, scaling='density'``, since
+      ``fft_mode='onesided2X'`` requires ``'psd'`` scaling. The is due to `csd()`
+      returning the doubled squared magnitude in this case, which does not have a
+      sensible interpretation.
+    * `ShortTimeFFT` uses `float64` / `complex128` internally, which is due to the
+      behavior of the utilized `~scipy.fft` module. Thus, those are the dtypes being
+      returned. The `csd` function casts the return values to `float32` / `complex64`
+      if the input is `float32` / `complex64` as well.
+    * The `csd` function calculates ``np.conj(Sx[q,p]) * Sy[q,p]``, whereas
+      `~ShortTimeFFT.spectrogram` calculates ``Sx[q,p] * np.conj(Sy[q,p])`` where
+      ``Sx[q,p]``, ``Sy[q,p]`` are the STFTs of `x` and `y`. Also, the window
+      positioning is different (consult the code snippet above).
+
+    Note that the code snippet above can be easily adapted to determine other
+    statistical properties than the mean value.
     """
-    freqs, _, Pxy = _spectral_helper(x, y, fs, window, nperseg, noverlap,
-                                     nfft, detrend, return_onesided, scaling,
-                                     axis, mode='psd')
+    # The following lines are resembling the behavior of the originally utilized
+    # `_spectral_helper()` function:
+    same_data, axis = y is x, int(axis)
+    x = np.asarray(x)
+
+    if not same_data:
+        y = np.asarray(y)
+        # Check if we can broadcast the outer axes together
+        x_outer, y_outer  = list(x.shape), list(y.shape)
+        x_outer.pop(axis)
+        y_outer.pop(axis)
+        try:
+            outer_shape = np.broadcast(np.empty(x_outer), np.empty(y_outer)).shape
+        except ValueError as e:
+            raise ValueError('x and y cannot be broadcast together.') from e
+        if x.size == 0 or y.size == 0:
+            out_shape = outer_shape + (min([x.shape[axis], y.shape[axis]]),)
+            empty_out = np.moveaxis(np.empty(out_shape), -1, axis)
+            return empty_out, empty_out
+        out_dtype = np.result_type(x, y, np.complex64)
+    else:  # x is y:
+        if x.size == 0:
+            return np.empty(x.shape), np.empty(x.shape)
+        out_dtype = np.result_type(x, np.complex64)
+
+    n = x.shape[axis] if same_data else max(x.shape[axis], y.shape[axis])
+    if isinstance(window, str) or isinstance(window, tuple):
+        nperseg = int(nperseg) if nperseg is not None else 256
+        if nperseg < 1:
+            raise ValueError(f"Parameter {nperseg=} is not a positive integer!")
+        elif n < nperseg:
+            warnings.warn(f"{nperseg=} is greater than signal length max(len(x), " +
+                          f"len(y)) = {n}, using nperseg = {n}", stacklevel=3)
+            nperseg = n
+        win = get_window(window, nperseg)
+    else:
+        win = np.asarray(window)
+        if nperseg is None:
+            nperseg = len(win)
+    if nperseg != len(win):
+        raise ValueError(f"{nperseg=} does not equal {len(win)=}")
+
+    nfft = int(nfft) if nfft is not None else nperseg
+    if nfft < nperseg:
+        raise ValueError(f"{nfft=} must be greater than or equal to {nperseg=}!")
+    noverlap = int(noverlap) if noverlap is not None else nperseg // 2
+    if noverlap >= nperseg:
+        raise ValueError(f"{noverlap=} must be less than {nperseg=}!")
+    if np.iscomplexobj(x) and return_onesided:
+        return_onesided = False
+
+    # using cast() to make mypy happy:
+    fft_mode = cast(FFT_MODE_TYPE, 'onesided' if return_onesided else 'twosided')
+    if scaling not in (scales := {'spectrum': 'magnitude', 'density': 'psd'}):
+        raise ValueError(f"Parameter {scaling=} not in {scales}!")
+
+    SFT = ShortTimeFFT(win, nperseg - noverlap, fs, fft_mode=fft_mode, mfft=nfft,
+                       scale_to=scales[scaling], phase_shift=None)
+    # csd() calculates X.conj()*Y instead of X*Y.conj():
+    Pxy = SFT.spectrogram(y, x, detr=None if detrend is False else detrend,
+                          p0=0, p1=(n - noverlap) // SFT.hop, k_offset=nperseg // 2,
+                          axis=axis)
+
+    # Note:
+    # 'onesided2X' scaling of ShortTimeFFT conflicts with the
+    # scaling='spectrum' parameter, since it doubles the squared magnitude,
+    # which in the view of the ShortTimeFFT implementation does not make sense.
+    # Hence, the doubling of the square is implemented here:
+    if return_onesided:
+        f_axis = Pxy.ndim - 1 + axis if axis < 0 else axis
+        Pxy = np.moveaxis(Pxy, f_axis, -1)
+        Pxy[..., 1:-1 if SFT.mfft % 2 == 0 else None] *= 2
+        Pxy = np.moveaxis(Pxy, -1, f_axis)
 
     # Average over windows.
-    if len(Pxy.shape) >= 2 and Pxy.size > 0:
-        if Pxy.shape[-1] > 1:
-            if average == 'median':
-                # np.median must be passed real arrays for the desired result
-                bias = _median_bias(Pxy.shape[-1])
-                if np.iscomplexobj(Pxy):
-                    Pxy = (np.median(np.real(Pxy), axis=-1)
-                           + 1j * np.median(np.imag(Pxy), axis=-1))
-                else:
-                    Pxy = np.median(Pxy, axis=-1)
-                Pxy /= bias
-            elif average == 'mean':
-                Pxy = Pxy.mean(axis=-1)
+    if Pxy.shape[-1] > 1:
+        if average == 'median':
+            # np.median must be passed real arrays for the desired result
+            bias = _median_bias(Pxy.shape[-1])
+            if np.iscomplexobj(Pxy):
+                Pxy = (np.median(np.real(Pxy), axis=-1) +
+                       np.median(np.imag(Pxy), axis=-1) * 1j)
             else:
-                raise ValueError(f'average must be "median" or "mean", got {average}')
+                Pxy = np.median(Pxy, axis=-1)
+            Pxy /= bias
+        elif average == 'mean':
+            Pxy = Pxy.mean(axis=-1)
         else:
-            Pxy = np.reshape(Pxy, Pxy.shape[:-1])
+            raise ValueError(f"Parameter {average=} must be 'median' or 'mean'!")
+    else:
+        Pxy = np.reshape(Pxy, Pxy.shape[:-1])
 
-    return freqs, Pxy
+    # cast output type;
+    Pxy = Pxy.astype(out_dtype)
+    if same_data:
+        Pxy = Pxy.real
+    return SFT.f, Pxy
 
 
 def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
@@ -1890,6 +1999,11 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
                      padded=False):
     """Calculate various forms of windowed FFTs for PSD, CSD, etc.
 
+    .. legacy:: function
+
+        This function is soley used by the legacy functions `spectrogram` and `stft`
+        (which are also in this file).
+
     This is a helper function that implements the commonality between
     the stft, psd, csd, and spectrogram functions. It is not designed to
     be called externally. The windows are not averaged over; the result
@@ -1934,8 +2048,8 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         complex data, a two-sided spectrum is always returned.
     scaling : { 'density', 'spectrum' }, optional
         Selects between computing the cross spectral density ('density')
-        where `Pxy` has units of V**2/Hz and computing the cross
-        spectrum ('spectrum') where `Pxy` has units of V**2, if `x`
+        where `Pxy` has units of V²/Hz and computing the cross
+        spectrum ('spectrum') where `Pxy` has units of V², if `x`
         and `y` are measured in V and `fs` is measured in Hz.
         Defaults to 'density'
     axis : int, optional
@@ -2184,6 +2298,11 @@ def _fft_helper(x, win, detrend_func, nperseg, noverlap, nfft, sides):
     Calculate windowed FFT, for internal use by
     `scipy.signal._spectral_helper`.
 
+    .. legacy:: function
+
+        This function is solely used by the legacy `_spectral_helper` function,
+        which s located also in this file.
+
     This is a helper function that does the main FFT calculation for
     `_spectral helper`. All input validation is performed there, and the
     data axis is assumed to be the last axis of x. It is not designed to
@@ -2232,6 +2351,11 @@ def _triage_segments(window, nperseg, input_length):
     """
     Parses window and nperseg arguments for spectrogram and _spectral_helper.
     This is a helper function, not meant to be called externally.
+
+    .. legacy:: function
+
+        This function is soley used by the legacy functions `spectrogram` and
+        `_spectral_helper` (which are also in this file).
 
     Parameters
     ----------

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -835,7 +835,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         x_outer.pop(axis)
         y_outer.pop(axis)
         try:
-            outer_shape = np.broadcast(np.empty(x_outer), np.empty(y_outer)).shape
+            outer_shape = np.broadcast_shapes(x_outer, y_outer)
         except ValueError as e:
             raise ValueError('x and y cannot be broadcast together.') from e
         if x.size == 0 or y.size == 0:

--- a/scipy/signal/tests/_scipy_spectral_test_shim.py
+++ b/scipy/signal/tests/_scipy_spectral_test_shim.py
@@ -24,11 +24,10 @@ import numpy as np
 from numpy.testing import assert_allclose
 
 from scipy.signal import ShortTimeFFT
-from scipy.signal import csd, get_window, stft, istft
+from scipy.signal import get_window, stft, istft
 from scipy.signal._arraytools import const_ext, even_ext, odd_ext, zero_ext
 from scipy.signal._short_time_fft import FFT_MODE_TYPE
-from scipy.signal._spectral_py import _spectral_helper, _triage_segments, \
-    _median_bias
+from scipy.signal._spectral_py import _triage_segments
 
 
 def _stft_wrapper(x, fs=1.0, window='hann', nperseg=256, noverlap=None,
@@ -234,156 +233,6 @@ def _istft_wrapper(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None,
     return t, x, (ST.lower_border_end[0], k_hi)
 
 
-def _csd_wrapper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
-                 nfft=None, detrend='constant', return_onesided=True,
-                 scaling='density', axis=-1, average='mean'):
-    """Wrapper for the `csd()` function based on `ShortTimeFFT` for
-        unit testing.
-    """
-    freqs, _, Pxy = _csd_test_shim(x, y, fs, window, nperseg, noverlap, nfft,
-                                   detrend, return_onesided, scaling, axis)
-
-    # The following code is taken from csd():
-    if len(Pxy.shape) >= 2 and Pxy.size > 0:
-        if Pxy.shape[-1] > 1:
-            if average == 'median':
-                # np.median must be passed real arrays for the desired result
-                bias = _median_bias(Pxy.shape[-1])
-                if np.iscomplexobj(Pxy):
-                    Pxy = (np.median(np.real(Pxy), axis=-1)
-                           + 1j * np.median(np.imag(Pxy), axis=-1))
-                else:
-                    Pxy = np.median(Pxy, axis=-1)
-                Pxy /= bias
-            elif average == 'mean':
-                Pxy = Pxy.mean(axis=-1)
-            else:
-                raise ValueError(f'average must be "median" or "mean", got {average}')
-        else:
-            Pxy = np.reshape(Pxy, Pxy.shape[:-1])
-
-    return freqs, Pxy
-
-
-def _csd_test_shim(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
-                   nfft=None, detrend='constant', return_onesided=True,
-                   scaling='density', axis=-1):
-    """Compare output of  _spectral_helper() and ShortTimeFFT, more
-    precisely _spect_helper_csd() for used in csd_wrapper().
-
-   The motivation of this function is to test if the ShortTimeFFT-based
-   wrapper `_spect_helper_csd()` returns the same values as `_spectral_helper`.
-   This function should only be usd by csd() in (unit) testing.
-   """
-    freqs, t, Pxy = _spectral_helper(x, y, fs, window, nperseg, noverlap, nfft,
-                                     detrend, return_onesided, scaling, axis,
-                                     mode='psd')
-    freqs1, Pxy1 = _spect_helper_csd(x, y, fs, window, nperseg, noverlap, nfft,
-                                     detrend, return_onesided, scaling, axis)
-
-    np.testing.assert_allclose(freqs1, freqs)
-    amax_Pxy = max(np.abs(Pxy).max(), 1) if Pxy.size else 1
-    atol = np.finfo(Pxy.dtype).resolution * amax_Pxy  # needed for large Pxy
-    # for c_ in range(Pxy.shape[-1]):
-    #    np.testing.assert_allclose(Pxy1[:, c_], Pxy[:, c_], atol=atol)
-    np.testing.assert_allclose(Pxy1, Pxy, atol=atol)
-    return freqs, t, Pxy
-
-
-def _spect_helper_csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
-                      nfft=None, detrend='constant', return_onesided=True,
-                      scaling='density', axis=-1):
-    """Wrapper for replacing _spectral_helper() by using the ShortTimeFFT
-      for use by csd().
-
-    This function should be only used by _csd_test_shim() and is only useful
-    for testing the ShortTimeFFT implementation.
-    """
-
-    # The following lines are taken from the original _spectral_helper():
-    same_data = y is x
-    axis = int(axis)
-
-    # Ensure we have np.arrays, get outdtype
-    x = np.asarray(x)
-    if not same_data:
-        y = np.asarray(y)
-    #     outdtype = np.result_type(x, y, np.complex64)
-    # else:
-    #     outdtype = np.result_type(x, np.complex64)
-
-    if not same_data:
-        # Check if we can broadcast the outer axes together
-        xouter = list(x.shape)
-        youter = list(y.shape)
-        xouter.pop(axis)
-        youter.pop(axis)
-        try:
-            outershape = np.broadcast(np.empty(xouter), np.empty(youter)).shape
-        except ValueError as e:
-            raise ValueError('x and y cannot be broadcast together.') from e
-
-    if same_data:
-        if x.size == 0:
-            return np.empty(x.shape), np.empty(x.shape)
-    else:
-        if x.size == 0 or y.size == 0:
-            outshape = outershape + (min([x.shape[axis], y.shape[axis]]),)
-            emptyout = np.moveaxis(np.empty(outshape), -1, axis)
-            return emptyout, emptyout
-
-    if nperseg is not None:  # if specified by user
-        nperseg = int(nperseg)
-        if nperseg < 1:
-            raise ValueError('nperseg must be a positive integer')
-
-    # parse window; if array like, then set nperseg = win.shape
-    n = x.shape[axis] if same_data else max(x.shape[axis], y.shape[axis])
-    win, nperseg = _triage_segments(window, nperseg, input_length=n)
-
-    if nfft is None:
-        nfft = nperseg
-    elif nfft < nperseg:
-        raise ValueError('nfft must be greater than or equal to nperseg.')
-    else:
-        nfft = int(nfft)
-
-    if noverlap is None:
-        noverlap = nperseg // 2
-    else:
-        noverlap = int(noverlap)
-    if noverlap >= nperseg:
-        raise ValueError('noverlap must be less than nperseg.')
-    nstep = nperseg - noverlap
-
-    if np.iscomplexobj(x) and return_onesided:
-        return_onesided = False
-
-    # using cast() to make mypy happy:
-    fft_mode = cast(FFT_MODE_TYPE, 'onesided' if return_onesided
-                    else 'twosided')
-    scale = {'spectrum': 'magnitude', 'density': 'psd'}[scaling]
-    SFT = ShortTimeFFT(win, nstep, fs, fft_mode=fft_mode, mfft=nfft,
-                       scale_to=scale, phase_shift=None)
-
-    # _spectral_helper() calculates X.conj()*Y instead of X*Y.conj():
-    Pxy = SFT.spectrogram(y, x, detr=None if detrend is False else detrend,
-                          p0=0, p1=(n-noverlap)//SFT.hop, k_offset=nperseg//2,
-                          axis=axis).conj()
-    # Note:
-    # 'onesided2X' scaling of ShortTimeFFT conflicts with the
-    # scaling='spectrum' parameter, since it doubles the squared magnitude,
-    # which in the view of the ShortTimeFFT implementation does not make sense.
-    # Hence, the doubling of the square is implemented here:
-    if return_onesided:
-        f_axis = Pxy.ndim - 1 + axis if axis < 0 else axis
-        Pxy = np.moveaxis(Pxy, f_axis, -1)
-        Pxy[..., 1:-1 if SFT.mfft % 2 == 0 else None] *= 2
-        Pxy = np.moveaxis(Pxy, -1, f_axis)
-
-    return SFT.f, Pxy
-
-
 def stft_compare(x, fs=1.0, window='hann', nperseg=256, noverlap=None,
                  nfft=None, detrend=False, return_onesided=True,
                  boundary='zeros', padded=True, axis=-1, scaling='spectrum'):
@@ -468,21 +317,3 @@ def istft_compare(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None,
     assert_allclose(x_wrapper[k_lo:k_hi], x[k_lo:k_hi], atol=atol, rtol=rtol,
                     err_msg=f"Signal values {e_msg_part}")
     return t, x
-
-
-def csd_compare(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
-                nfft=None, detrend='constant', return_onesided=True,
-                scaling='density', axis=-1, average='mean'):
-    """Assert that the results from the existing `csd()` and `_csd_wrapper()`
-    are close to each other. """
-    kw = dict(x=x, y=y, fs=fs, window=window, nperseg=nperseg,
-              noverlap=noverlap, nfft=nfft, detrend=detrend,
-              return_onesided=return_onesided, scaling=scaling, axis=axis,
-              average=average)
-    freqs0, Pxy0 = csd(**kw)
-    freqs1, Pxy1 = _csd_wrapper(**kw)
-
-    assert_allclose(freqs1, freqs0)
-    assert_allclose(Pxy1, Pxy0)
-    assert_allclose(freqs1, freqs0)
-    return freqs0, Pxy0

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -558,6 +558,15 @@ class TestWelch:
         assert_raises(ValueError, welch, x, nperseg=8,
                       average='unrecognised-average')
 
+    def test_ratio_scale_to(self):
+        """Verify the factor of ``sum(abs(window)**2)*fs / abs(sum(window))**2``
+        used in the `welch`  and `csd` docstrs. """
+        x, win, fs = np.array([1., 0, 0, 0]), np.ones(4), 12
+        params = dict(fs=fs, window=win, return_onesided=False, detrend=None)
+        p_dens = welch(x, scaling='density', **params)[1]
+        p_spec = welch(x, scaling='spectrum', **params)[1]
+        p_fac = sum(win**2)*fs / abs(sum(win))**2
+        assert_allclose(p_spec / p_dens, p_fac)
 
 class TestCSD:
     def test_pad_shorter_x(self):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -10,7 +10,7 @@ from pytest import raises as assert_raises
 from scipy import signal
 from scipy.fft import fftfreq, rfftfreq, fft, irfft
 from scipy.integrate import trapezoid
-from scipy.signal import (periodogram, welch, lombscargle, coherence,
+from scipy.signal import (periodogram, welch, lombscargle, coherence, csd,
                           spectrogram, check_COLA, check_NOLA)
 from scipy.signal.windows import hann
 from scipy.signal._spectral_py import _spectral_helper
@@ -18,7 +18,6 @@ from scipy.signal._spectral_py import _spectral_helper
 # Compare ShortTimeFFT.stft() / ShortTimeFFT.istft() with stft() / istft():
 from scipy.signal.tests._scipy_spectral_test_shim import stft_compare as stft
 from scipy.signal.tests._scipy_spectral_test_shim import istft_compare as istft
-from scipy.signal.tests._scipy_spectral_test_shim import csd_compare as csd
 
 
 class TestPeriodogram:
@@ -416,8 +415,7 @@ class TestWelch:
         #for string-like window, input signal length < nperseg value gives
         #UserWarning, sets nperseg to x.shape[-1]
         with suppress_warnings() as sup:
-            msg = "nperseg = 256 is greater than input length  = 8, using nperseg = 8"
-            sup.filter(UserWarning, msg)
+            sup.filter(UserWarning, "nperseg=256 is greater than signal.*")
             f, p = welch(x,window='hann')  # default nperseg
             f1, p1 = welch(x,window='hann', nperseg=256)  # user-specified nperseg
         f2, p2 = welch(x, nperseg=8)  # valid nperseg, doesn't give warning
@@ -735,6 +733,8 @@ class TestCSD:
         win_err = signal.get_window('hann', 32)
         assert_raises(ValueError, csd, x, x,
               10, win_err, nperseg=None)  # because win longer than signal
+        with pytest.raises(ValueError, match="Parameter nperseg=0.*"):
+            csd(x, x, 0, nperseg=0)
 
     def test_empty_input(self):
         f, p = csd([],np.zeros(10))
@@ -779,8 +779,7 @@ class TestCSD:
         #for string-like window, input signal length < nperseg value gives
         #UserWarning, sets nperseg to x.shape[-1]
         with suppress_warnings() as sup:
-            msg = "nperseg = 256 is greater than input length  = 8, using nperseg = 8"
-            sup.filter(UserWarning, msg)
+            sup.filter(UserWarning, "nperseg=256 is greater than signal length.*")
             f, p = csd(x, x, window='hann')  # default nperseg
             f1, p1 = csd(x, x, window='hann', nperseg=256)  # user-specified nperseg
         f2, p2 = csd(x, x, nperseg=8)  # valid nperseg, doesn't give warning
@@ -810,6 +809,11 @@ class TestCSD:
     def test_nfft_too_short(self):
         assert_raises(ValueError, csd, np.ones(12), np.zeros(12), nfft=3,
                       nperseg=4)
+
+    def test_incompatible_inputs(self):
+        with pytest.raises(ValueError, match='x and y cannot be broadcast.*'):
+            csd(np.ones((1, 8, 1)), np.ones((2, 8)), nperseg=4)
+
 
     def test_real_onesided_even_32(self):
         x = np.zeros(16, 'f')


### PR DESCRIPTION
This allows to mark the internal functions `_spectral_helper`, `fft_helper` and `_triage_segements` as legacy, since they are only used by the legacy functions `spectrogram` and `stft` now. Further changes:

* Some small additions to the unit tests to achieve 100% coverage for `csd()`.
* Remove csd related functions from file `_scipy_spectral_tst_shim.py`
* An explanation of the `ShortTimeFFT` usage was added to the `csd()` docstr.

### Related Issues and PRs:

#12544: Close as wont fix, since only `_triage_segements` is affected.
#13577: Close as wont fix, since only `_spectral_helper` is affected . Furthermore, `ShortTimeFFT` supports "chunking".
#15593: Close, since only `_triage_segements` is changed.
#15587: Close as wont fix, since only `_triage_segements` is affected.
#19001: Edits relevant parts of `spectral_py.py`


~~Closes~~ ~~#22674 (check comment).~~