### PR TITLE
ENH: stats.pearsonr: two simple (but substantial) efficiency improvements

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4564,7 +4564,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
         raise ValueError('`x` and `y` must have length at least 2.')
 
     try:
-        x, y = xp.broadcast_arrays(x, y)
+        np.broadcast_shapes(x.shape, y.shape)
     except (ValueError, RuntimeError) as e:
         message = '`x` and `y` must be broadcastable.'
         raise ValueError(message) from e
@@ -4658,7 +4658,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
         warnings.warn(stats.NearConstantInputWarning(msg), stacklevel=2)
 
     with np.errstate(invalid='ignore', divide='ignore'):
-        r = xp.sum(xm/normxm * ym/normym, axis=axis)
+        r = xp.linalg.vecdot(xm / normxm, ym / normym, axis=axis)
 
     # Presumably, if abs(r) > 1, then it is only some small artifact of
     # floating point arithmetic.


### PR DESCRIPTION
#### What does this implement/fix?
This makes two simple efficiency improvements to `stats.pearsonr` that are important for the use cases of pairwise calculations.
- Avoid broadcasting the arrays until necessary. A lot of work is done on the arrays separately before they are brought together, so don't potentially increase their sizes prematurely.
- Use `linalg.vecdot`. It is available in the standard, and it's a lot faster than `*` and `sum`.

#### Additional information
Consider pairwise correlation of 500 samples, each with 500 observations:
```python3
import numpy as np
from scipy import stats
rng = np.random.default_rng(2785487287265)

m, n = 500, 500
x = rng.random((m, n))
stats.pearsonr(x, x[:, np.newaxis, :], axis=-1)
```
Timing and profiling:
```
# %timeit stats.pearsonr(x, x[:, np.newaxis, :], axis=-1)
# before: 4.3 s ± 263 ms per loop (mean ± std. dev. of 7 runs, 1 loop each), ~5% of time getting pvalue
# after: 238 ms ± 2.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each), ~85% of time getting pvalue
```

There is one problem as-written: like other `stats` functions (and unlike NumPy gufuncs, unfortunately) `axis` is interpreted after matching the number of dimensions in the two arrays. (This is something we might consider changing for SciPy 2.0.) So if the arrays are of different dimensionality and positive indices are used, this would change the behavior. To be backward compatible and consistent with other stats functions, I would need to add something like:
```python3
ndim = max(x.ndim, y.ndim)
x = x.reshape((1,)*(ndim - x.ndim) + x.shape)
y = y.reshape((1,)*(ndim - y.ndim) + y.shape)
```
This would make the PR look a little more complex than it is, so I wanted to wait to add that until it looks good otherwise.