### PR TITLE
DOC: update Halton docs

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1117,7 +1117,7 @@ class Halton(QMCEngine):
     Pseudo-random number generator that generalize the Van der Corput sequence
     for multiple dimensions. The Halton sequence uses the base-two Van der
     Corput sequence for the first dimension, base-three for its second and
-    base-:math:`n` for its :math:`n`-dimension, with :math:`n` the
+    base-:math:`p` for its :math:`n`-dimension, with :math:`p` the
     :math:`n`'th prime.
 
     Parameters

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1117,14 +1117,16 @@ class Halton(QMCEngine):
     Pseudo-random number generator that generalize the Van der Corput sequence
     for multiple dimensions. The Halton sequence uses the base-two Van der
     Corput sequence for the first dimension, base-three for its second and
-    base-:math:`n` for its n-dimension.
+    base-:math:`n` for its :math:`n`-dimension, with :math:`n` the :math:`n`'th
+    prime.
 
     Parameters
     ----------
     d : int
         Dimension of the parameter space.
     scramble : bool, optional
-        If True, use Owen scrambling. Otherwise no scrambling is done.
+        If True, use random scrambling from Owen. Otherwise no scrambling
+        is done.
         Default is True.
     optimization : {None, "random-cd", "lloyd"}, optional
         Whether to use an optimization scheme to improve the quality after

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1125,7 +1125,7 @@ class Halton(QMCEngine):
     d : int
         Dimension of the parameter space.
     scramble : bool, optional
-        If True, use random scrambling from Owen. Otherwise no scrambling
+        If True, use random scrambling from [2]_. Otherwise no scrambling
         is done.
         Default is True.
     optimization : {None, "random-cd", "lloyd"}, optional

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1117,8 +1117,8 @@ class Halton(QMCEngine):
     Pseudo-random number generator that generalize the Van der Corput sequence
     for multiple dimensions. The Halton sequence uses the base-two Van der
     Corput sequence for the first dimension, base-three for its second and
-    base-:math:`n` for its :math:`n`-dimension, with :math:`n` the :math:`n`'th
-    prime.
+    base-:math:`n` for its :math:`n`-dimension, with :math:`n` the
+    :math:`n`'th prime.
 
     Parameters
     ----------


### PR DESCRIPTION
To account for some comments from Art Owen.

1. `n` could be misinterpreted as any integer while it is to be a prime number. (Not something user have control over as part of the VDC construction.)
2. The mention to Owen scrambling could be confused with Owen's nested uniform scrambling from 1995. We do reference the paper from 2017 but this would clarify a bit more in the params.