### PR TITLE
BUG: sparse: fix spmatrix indexing with None and implicit padding to match matrix behavior

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -233,8 +233,9 @@ class IndexMixin:
         ellip_slices = (self.ndim - prelim_ndim) * [slice(None)]
         if ellip_slices:
             if ellps_pos is None:
-                ellps_pos = prelim_ndim
-            index_1st = index_1st[:ellps_pos] + ellip_slices + index_1st[ellps_pos:]
+                index_1st.extend(ellip_slices)
+            else:
+                index_1st = index_1st[:ellps_pos] + ellip_slices + index_1st[ellps_pos:]
 
         # second pass (have processed ellipsis and preprocessed arrays)
         idx_shape = []

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -102,14 +102,14 @@ class IndexMixin:
 
         # handle spmatrix (must be 2d, dont let 1d new_shape start reshape)
         if not isinstance(self, sparray):
-            if len(new_shape) == 2:
-                # need this for A[:, 1] vs A[1, :]
-                return res.reshape(new_shape)
-            elif len(new_shape) == 1:
-                if res.ndim == 2:
-                    return res
-                return res.reshape((1,) + new_shape)
-            return res
+            if new_shape == () or (len(new_shape) == 1 and res.ndim != 0):
+                # res handles cases not inflated by None
+                return res
+            if len(new_shape) == 1:
+                # shape inflated to 1D by None in index. Make 2D
+                new_shape = (1,) + new_shape
+            # reshape if needed (when None changes shape, e.g. A[1,:,None])
+            return res if new_shape == res.shape else res.reshape(new_shape)
 
         # package the result and return
         if res.shape != new_shape:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2773,6 +2773,42 @@ class _TestSlicing:
             check_2(a, -2)
             check_2(-2, a)
 
+    def test_None_slicing(self):
+        B = self.asdense(arange(50).reshape(5,10))
+        A = self.spcreator(B)
+
+        assert A[1, 2].ndim == 0
+        assert A[None, 1, 2:4].shape == (1, 2)
+        assert A[None, 1, 2, None].shape == (1, 1)
+
+        # see gh-22458
+        assert A[None, 1].shape == (1, 10)
+        assert A[1, None].shape == (1, 10)
+        assert A[None, 1, :].shape == (1, 10)
+        assert A[1, None, :].shape == (1, 10)
+        assert A[1, :, None].shape == (10, 1)
+
+        assert A[None, 1:3, 2].shape == B[None, 1:3, 2].shape == (1, 2)
+        assert A[1:3, None, 2].shape == B[1:3, None, 2].shape == (2, 1)
+        assert A[1:3, 2, None].shape == B[1:3, 2, None].shape == (2, 1)
+        assert A[None, 1, 2:4].shape == B[None, 1, 2:4].shape == (1, 2)
+        assert A[1, None, 2:4].shape == B[1, None, 2:4].shape == (1, 2)
+        assert A[1, 2:4, None].shape == B[1, 2:4, None].shape == (2, 1)
+
+        # different for spmatrix
+        if self.is_array_test:
+            assert A[1:3, 2].shape == B[1:3, 2].shape == (2,)
+            assert A[1, 2:4].shape == B[1, 2:4].shape == (2,)
+            assert A[None, 1, 2].shape == B[None, 1, 2].shape == (1,)
+            assert A[1, None, 2].shape == B[1, None, 2].shape == (1,)
+            assert A[1, 2, None].shape == B[1, 2, None].shape == (1,)
+        else:
+            assert A[1, 2:4].shape == B[1, 2:4].shape == (1, 2)
+            assert A[1:3, 2].shape == B[1:3, 2].shape == (2, 1)
+            assert A[None, 1, 2].shape == B[None, 1, 2].shape == (1, 1)
+            assert A[1, None, 2].shape == B[1, None, 2].shape == (1, 1)
+            assert A[1, 2, None].shape == B[1, 2, None].shape == (1, 1)
+
     def test_ellipsis_slicing(self):
         b = self.asdense(arange(50).reshape(5,10))
         a = self.spcreator(b)

--- a/scipy/sparse/tests/test_indexing1d.py
+++ b/scipy/sparse/tests/test_indexing1d.py
@@ -42,6 +42,13 @@ class TestGetSet1D:
         assert A[None, 1, 2].shape == (1,)
         assert A[None, 1, 2, None].shape == (1, 1)
 
+        # see gh-22458
+        assert A[None, 1].shape == (1, 4)
+        assert A[1, None].shape == (1, 4)
+        assert A[None, 1, :].shape == (1, 4)
+        assert A[1, None, :].shape == (1, 4)
+        assert A[1, :, None].shape == (4, 1)
+
         with pytest.raises(IndexError, match='Only 1D or 2D arrays'):
             A[None, 2, 1, None, None]
         with pytest.raises(IndexError, match='Only 1D or 2D arrays'):


### PR DESCRIPTION
Fixes #22458 

The bug involved an index using both `None` and implicit (padding) colons. Adding tests for this case revealed a separate bug for indexing spmatrix as it makes 2D results from indexing that for an array would be 1D. It should match the np.matrix output not the np.array output.

Tests for these and other indexing cases are added.

This should be backported.
