### PR TITLE
BUG: optimize.shgo: delegate `options['jac']` to `minimizer_kwargs['jac']`

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -496,6 +496,12 @@ class SHGO:
             raise ValueError(("Unknown sampling_method specified."
                               " Valid methods: {}").format(', '.join(methods)))
 
+        if options is not None and options.get('jac', None) is True:
+            if minimizer_kwargs is None:
+                minimizer_kwargs = {}
+            minimizer_kwargs['jac'] = True
+            options.pop('jac')
+
         # Split obj func if given with Jac
         try:
             if ((minimizer_kwargs['jac'] is True) and

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -856,6 +856,14 @@ class TestShgoArguments:
         assert_allclose(res.fun, ref.fun)
         assert_allclose(res.x, ref.x, atol=1e-15)
 
+        # Testing the passing of jac via options dict
+        res = shgo(func, bounds=bounds, sampling_method="sobol",
+                   minimizer_kwargs={'method': 'SLSQP'},
+                   options={'jac': True})
+        assert res.success
+        assert_allclose(res.fun, ref.fun)
+        assert_allclose(res.x, ref.x, atol=1e-15)
+
     @pytest.mark.parametrize('derivative', ['jac', 'hess', 'hessp'])
     def test_21_2_derivative_options(self, derivative):
         """shgo used to raise an error when passing `options` with 'jac'


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/21692

#### What does this implement/fix?
<!--Please explain your changes.-->

As far as I have noticed there are two ways to pass `jac` option,

1. First is via `minimizer_kwargs` dict - this works and is tested with `shgo` option. It is taken into account at the beginning of the call to `SHGO.__init__`. 
2. Second is via `options` dict - this is not taken account in `SHGO` class and hence input function is left untouched. This leads to the error in #21692.

My fix simply checks if `options['jac']` is `True` and then populates `minimizer_kwargs['jac
']` accordingly. It also deletes `options['jac']` to avoid duplication.

The fix works with existing tests and additional test I added.  

#### Additional information
<!--Any additional information you think is important.-->
