### PR TITLE
ENH: optimize: add `workers` kwarg to BFGS, SLSQP, trust-constr

### DIFF
--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -345,7 +345,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         possibly adjusted to fit into the bounds. For ``method='3-point'``
         the sign of `h` is ignored. If None (default) then step is selected
         automatically.
-    workers : map-like callable, optional
+    workers : int, map-like callable, optional
         A map-like callable, such as `multiprocessing.Pool.map` for evaluating
         any numerical differentiation in parallel.
         This evaluation is carried out as ``workers(fun, iterable)``.

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1994,7 +1994,7 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
 
 def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
                        callback=None, xtol=1e-5, eps=_epsilon, maxiter=None,
-                       disp=False, return_all=False, c1=1e-4, c2=0.9,
+                       disp=False, return_all=False, c1=1e-4, c2=0.9, workers=None,
                        **unknown_options):
     """
     Minimization of scalar function of one or more variables using the
@@ -2020,6 +2020,12 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
         Parameter for Armijo condition rule.
     c2 : float, default: 0.9
         Parameter for curvature condition rule.
+    workers : int, map-like callable, optional
+        A map-like callable, such as `multiprocessing.Pool.map` for evaluating
+        any numerical differentiation in parallel.
+        This evaluation is carried out as ``workers(fun, iterable)``.
+
+        .. versionadded:: 1.16.0
 
     Notes
     -----
@@ -2037,7 +2043,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     x0 = asarray(x0).flatten()
     # TODO: add hessp (callable or FD) to ScalarFunction?
     sf = _prepare_scalar_function(
-        fun, x0, jac, args=args, epsilon=eps, hess=hess
+        fun, x0, jac, args=args, epsilon=eps, hess=hess, workers=workers
     )
     f = sf.fun
     fprime = sf.grad

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1348,7 +1348,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
                    gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
                    disp=False, return_all=False, finite_diff_rel_step=None,
                    xrtol=0, c1=1e-4, c2=0.9,
-                   hess_inv0=None, **unknown_options):
+                   hess_inv0=None, workers=None, **unknown_options):
     """
     Minimization of scalar function of one or more variables using the
     BFGS algorithm.
@@ -1386,6 +1386,10 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     hess_inv0 : None or ndarray, optional
         Initial inverse hessian estimate, shape (n, n). If None (default) then
         the identity matrix is used.
+    workers : map-like callable, optional
+        A map-like callable, such as `multiprocessing.Pool.map` for evaluating
+        any numerical differentiation in parallel.
+        This evaluation is carried out as ``workers(fun, iterable)``.
 
     Notes
     -----
@@ -1410,7 +1414,8 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         maxiter = len(x0) * 200
 
     sf = _prepare_scalar_function(fun, x0, jac, args=args, epsilon=eps,
-                                  finite_diff_rel_step=finite_diff_rel_step)
+                                  finite_diff_rel_step=finite_diff_rel_step,
+                                  workers=workers)
 
     f = sf.fun
     myfprime = sf.grad

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1721,7 +1721,8 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
 def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
                  gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
                  disp=False, return_all=False, finite_diff_rel_step=None,
-                 c1=1e-4, c2=0.4, **unknown_options):
+                 c1=1e-4, c2=0.4, workers=None,
+                 **unknown_options):
     """
     Minimization of scalar function of one or more variables using the
     conjugate gradient algorithm.
@@ -1754,6 +1755,12 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         Parameter for Armijo condition rule.
     c2 : float, default: 0.4
         Parameter for curvature condition rule.
+    workers : int, map-like callable, optional
+        A map-like callable, such as `multiprocessing.Pool.map` for evaluating
+        any numerical differentiation in parallel.
+        This evaluation is carried out as ``workers(fun, iterable)``.
+
+        .. versionadded:: 1.16.0
 
     Notes
     -----
@@ -1768,7 +1775,8 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         maxiter = len(x0) * 200
 
     sf = _prepare_scalar_function(fun, x0, jac=jac, args=args, epsilon=eps,
-                                  finite_diff_rel_step=finite_diff_rel_step)
+                                  finite_diff_rel_step=finite_diff_rel_step,
+                                  workers=workers)
 
     f = sf.fun
     myfprime = sf.grad

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1386,10 +1386,12 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     hess_inv0 : None or ndarray, optional
         Initial inverse hessian estimate, shape (n, n). If None (default) then
         the identity matrix is used.
-    workers : map-like callable, optional
+    workers : int, map-like callable, optional
         A map-like callable, such as `multiprocessing.Pool.map` for evaluating
         any numerical differentiation in parallel.
         This evaluation is carried out as ``workers(fun, iterable)``.
+
+        .. versionadded:: 1.16.0
 
     Notes
     -----

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -217,7 +217,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
                     constraints=(),
                     maxiter=100, ftol=1.0E-6, iprint=1, disp=False,
                     eps=_epsilon, callback=None, finite_diff_rel_step=None,
-                    **unknown_options):
+                    workers=None, **unknown_options):
     """
     Minimize a scalar function of one or more variables using Sequential
     Least Squares Programming (SLSQP).
@@ -240,6 +240,10 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         possibly adjusted to fit into the bounds. For ``method='3-point'``
         the sign of `h` is ignored. If None (default) then step is selected
         automatically.
+    workers : map-like callable, optional
+        A map-like callable, such as `multiprocessing.Pool.map` for evaluating
+        any numerical differentiation in parallel.
+        This evaluation is carried out as ``workers(fun, iterable)``.
     """
     _check_unknown_options(unknown_options)
     iter = maxiter - 1
@@ -380,7 +384,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
     # ScalarFunction provides function and gradient evaluation
     sf = _prepare_scalar_function(func, x, jac=jac, args=args, epsilon=eps,
                                   finite_diff_rel_step=finite_diff_rel_step,
-                                  bounds=new_bounds)
+                                  bounds=new_bounds, workers=workers)
     # gh11403 SLSQP sometimes exceeds bounds by 1 or 2 ULP, make sure this
     # doesn't get sent to the func/grad evaluator.
     wrapped_fun = _clip_x_for_func(sf.fun, new_bounds)

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -240,10 +240,13 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         possibly adjusted to fit into the bounds. For ``method='3-point'``
         the sign of `h` is ignored. If None (default) then step is selected
         automatically.
-    workers : map-like callable, optional
+    workers : int, map-like callable, optional
         A map-like callable, such as `multiprocessing.Pool.map` for evaluating
         any numerical differentiation in parallel.
         This evaluation is carried out as ``workers(fun, iterable)``.
+
+        .. versionadded:: 1.16.0
+
     """
     _check_unknown_options(unknown_options)
     iter = maxiter - 1

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -287,6 +287,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
                   maxCGit=-1, eta=-1, stepmx=0, accuracy=0,
                   minfev=0, ftol=-1, xtol=-1, gtol=-1, rescale=-1, disp=False,
                   callback=None, finite_diff_rel_step=None, maxfun=None,
+                  workers=None,
                   **unknown_options):
     """
     Minimize a scalar function of one or more variables using a truncated
@@ -351,6 +352,12 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
     maxfun : int
         Maximum number of function evaluations. If None, `maxfun` is
         set to max(100, 10*len(x0)). Defaults to None.
+    workers : int, map-like callable, optional
+        A map-like callable, such as `multiprocessing.Pool.map` for evaluating
+        any numerical differentiation in parallel.
+        This evaluation is carried out as ``workers(fun, iterable)``.
+
+        .. versionadded:: 1.16.0
     """
     _check_unknown_options(unknown_options)
     fmin = minfev
@@ -381,7 +388,7 @@ def _minimize_tnc(fun, x0, args=(), jac=None, bounds=None,
 
     sf = _prepare_scalar_function(fun, x0, jac=jac, args=args, epsilon=eps,
                                   finite_diff_rel_step=finite_diff_rel_step,
-                                  bounds=new_bounds)
+                                  bounds=new_bounds, workers=workers)
     func_and_grad = sf.fun_and_grad
 
     """

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -119,7 +119,8 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
                            subproblem=None, initial_trust_radius=1.0,
                            max_trust_radius=1000.0, eta=0.15, gtol=1e-4,
                            maxiter=None, disp=False, return_all=False,
-                           callback=None, inexact=True, **unknown_options):
+                           callback=None, inexact=True, workers=None,
+                           **unknown_options):
     """
     Minimization of scalar function of one or more variables using a
     trust-region algorithm.
@@ -142,6 +143,13 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
             Accuracy to solve subproblems. If True requires less nonlinear
             iterations, but more vector products. Only effective for method
             trust-krylov.
+        workers : int, map-like callable, optional
+            A map-like callable, such as `multiprocessing.Pool.map` for evaluating
+            any numerical differentiation in parallel.
+            This evaluation is carried out as ``workers(fun, iterable)``.
+            Only for 'trust-krylov', 'trust-ncg'.
+
+            .. versionadded:: 1.16.0
 
     This function is called by the `minimize` function.
     It is not supposed to be called directly.
@@ -172,7 +180,13 @@ def _minimize_trust_region(fun, x0, args=(), jac=None, hess=None, hessp=None,
 
     # A ScalarFunction representing the problem. This caches calls to fun, jac,
     # hess.
-    sf = _prepare_scalar_function(fun, x0, jac=jac, hess=hess, args=args)
+    # the workers kwd only has an effect for trust-ncg, trust-krylov when
+    # estimating the Hessian with finite-differences. It's never used
+    # during calculation of jacobian, because callables are required for all
+    # methods.
+    sf = _prepare_scalar_function(
+        fun, x0, jac=jac, hess=hess, args=args, workers=workers
+    )
     fun = sf.fun
     jac = sf.grad
     if callable(hess):

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -125,7 +125,8 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
                                  initial_barrier_parameter=0.1,
                                  initial_barrier_tolerance=0.1,
                                  factorization_method=None,
-                                 disp=False):
+                                 disp=False,
+                                 workers=None):
     """Minimize a scalar function subject to constraints.
 
     Parameters
@@ -223,7 +224,12 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         * 3 : display progress during iterations (more complete report).
 
     disp : bool, optional
+    workers : map-like
         If True (default), then `verbose` will be set to 1 if it was 0.
+        workers : map-like callable, optional
+        A map-like callable, such as `multiprocessing.Pool.map` for evaluating
+        any numerical differentiation in parallel.
+        This evaluation is carried out as ``workers(fun, iterable)``.
 
     Returns
     -------
@@ -343,7 +349,8 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
 
     # Define Objective Function
     objective = ScalarFunction(fun, x0, args, grad, hess,
-                               finite_diff_rel_step, finite_diff_bounds)
+                               finite_diff_rel_step, finite_diff_bounds,
+                               workers=workers)
 
     # Put constraints in list format when needed.
     if isinstance(constraints, (NonlinearConstraint | LinearConstraint)):

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -224,12 +224,13 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         * 3 : display progress during iterations (more complete report).
 
     disp : bool, optional
-    workers : map-like
         If True (default), then `verbose` will be set to 1 if it was 0.
-        workers : map-like callable, optional
+    workers : int, map-like callable, optional
         A map-like callable, such as `multiprocessing.Pool.map` for evaluating
         any numerical differentiation in parallel.
         This evaluation is carried out as ``workers(fun, iterable)``.
+
+        .. versionadded:: 1.16.0
 
     Returns
     -------

--- a/scipy/optimize/_trustregion_exact.py
+++ b/scipy/optimize/_trustregion_exact.py
@@ -29,7 +29,6 @@ def _minimize_trustregion_exact(fun, x0, args=(), jac=None, hess=None,
         Gradient norm must be less than ``gtol`` before successful
         termination.
     """
-
     if jac is None:
         raise ValueError('Jacobian is required for trust region '
                          'exact minimization.')

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3257,7 +3257,15 @@ def test_sparse_hessian(method, sparse_type):
 @pytest.mark.parametrize('workers', [None, 2])
 @pytest.mark.parametrize(
     'method',
-    ['l-bfgs-b', 'bfgs', 'slsqp', 'trust-constr', 'Newton-CG', 'CG', 'tnc'])
+    ['l-bfgs-b',
+     'bfgs',
+     'slsqp',
+     'trust-constr',
+     'Newton-CG',
+     'CG',
+     'tnc',
+     'trust-ncg',
+     'trust-krylov'])
 class TestWorkers:
 
     def setup_method(self):
@@ -3267,16 +3275,18 @@ class TestWorkers:
         # checks parallelised optimization output is same as serial
         workers = workers or map
 
-        jac = None
-        if method in ['Newton-CG']:
-            jac = rosen_der
+        kwds = {'jac': None, 'hess': None}
+        if method in ['Newton-CG', 'trust-ncg', 'trust-krylov']:
+            #  methods that require a callable jac
+            kwds['jac'] = rosen_der
+            kwds['hess'] = '2-point'
 
         with MapWrapper(workers) as mf:
             res = optimize.minimize(
-                rosen, self.x0, jac=jac, options={"workers":mf}, method=method
+                rosen, self.x0, options={"workers":mf}, method=method, **kwds
             )
         res_default = optimize.minimize(
-            rosen, self.x0, method=method, jac=jac
+            rosen, self.x0, method=method, **kwds
         )
         assert_equal(res.x, res_default.x)
         assert_equal(res.nfev, res_default.nfev)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3257,7 +3257,7 @@ def test_sparse_hessian(method, sparse_type):
 @pytest.mark.parametrize('workers', [None, 2])
 @pytest.mark.parametrize(
     'method',
-    ['l-bfgs-b', 'bfgs', 'slsqp', 'trust-constr', 'Newton-CG', 'CG'])
+    ['l-bfgs-b', 'bfgs', 'slsqp', 'trust-constr', 'Newton-CG', 'CG', 'tnc'])
 class TestWorkers:
 
     def setup_method(self):
@@ -3283,7 +3283,7 @@ class TestWorkers:
 
     def test_equal_bounds(self, workers, method):
         workers = workers or map
-        if method not in ['l-bfgs-b', 'slsqp', 'trust-constr']:
+        if method not in ['l-bfgs-b', 'slsqp', 'trust-constr', 'tnc']:
             pytest.skip(f"{method} cannot use bounds")
 
         bounds = Bounds([0, 2.0, 0.], [10., 2.0, 10.])

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3257,7 +3257,7 @@ def test_sparse_hessian(method, sparse_type):
 @pytest.mark.parametrize('workers', [None, 2])
 @pytest.mark.parametrize(
     'method',
-    ['l-bfgs-b', 'bfgs', 'slsqp', 'trust-constr', 'Newton-CG'])
+    ['l-bfgs-b', 'bfgs', 'slsqp', 'trust-constr', 'Newton-CG', 'CG'])
 class TestWorkers:
 
     def setup_method(self):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3255,7 +3255,9 @@ def test_sparse_hessian(method, sparse_type):
 
 
 @pytest.mark.parametrize('workers', [None, 2])
-@pytest.mark.parametrize('method', ['l-bfgs-b'])
+@pytest.mark.parametrize(
+    'method',
+    ['l-bfgs-b', 'bfgs', 'slsqp', 'trust-constr'])
 class TestWorkers:
 
     def setup_method(self):


### PR DESCRIPTION
Builds on #22141.
Covers: BFGS, Newton-CG, CG, SLSQP, TNC, trust-constr.

Only parallelises the gradient of the objective function, doesn't cover the gradient of any constraints (SLSQP, trust-constr) yet.