### PR TITLE
CI: use mpmath pre-release again

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -321,10 +321,7 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install cython pythran ninja meson-python pybind11 click rich_click pydevtool
-        python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist gmpy2 threadpoolctl pooch hypothesis matplotlib
-        # Move mpmath back into `install --pre` above once mpmath 1.4.0 with
-        # the fix is out (xref gh-22395)
-        python -m pip install mpmath
+        python -m pip install --pre --upgrade pytest pytest-cov pytest-xdist mpmath gmpy2 threadpoolctl pooch hypothesis matplotlib
         python -m pip install -r requirements/openblas.txt
         # Install numpy last, to ensure we get nightly (avoid possible <2.0 constraints).
         python -m pip install --pre --upgrade --timeout=60 -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy


### PR DESCRIPTION
#### Reference issue
Close gh-22395

#### What does this implement/fix?
Now that mpmath has the fix for gh-22395 in the 1.4.0a4 prerelease, I think we can test against the prerelease version again.
