### PR TITLE
MAINT: stats: pearsonr SIMD-related shim

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -4650,7 +4650,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
     # use np.linalg.norm.
     xmax = xp.max(xp.abs(xm), axis=axis, keepdims=True)
     ymax = xp.max(xp.abs(ym), axis=axis, keepdims=True)
-    with np.errstate(invalid='ignore'):
+    with np.errstate(invalid='ignore', divide='ignore'):
         normxm = xmax * xp_vector_norm(xm/xmax, axis=axis, keepdims=True)
         normym = ymax * xp_vector_norm(ym/ymax, axis=axis, keepdims=True)
 


### PR DESCRIPTION
* Fixes #22479.

* This small patch allows `test_stats.py::TestRegression::test_regressZEROX` to pass on x86_64 Linux instead of failing due to an extra division by zero warning over a fairly narrow range of NumPy versions near `1.25.2` where SIMD implementation details appear to have been slightly different.

[skip circle]