### PR TITLE
MAINT: spatial: missing Cython type in build

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -1106,6 +1106,8 @@ cdef class Rotation:
 
         .. versionadded:: 1.4.0
         """
+        cdef int ind
+
         is_single = False
         matrix = np.array(matrix, dtype=float)
 


### PR DESCRIPTION
* This small patch prevents the latest stable release of Cython from complaining about a failure to type a loop variable, which otherwise generates some annoying build spam on x86_64 Linux for example:

<details>

```
[1422/1463] Generating 'scipy/spatial/transform/_rotation.cpython-311-x86_64-linux-gnu.so.p/_rotation.c'
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1162:34: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1163:34: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1164:34: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1165:34: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1165:55: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1166:34: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1174:61: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1174:21: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1175:39: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1175:60: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1175:21: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1176:39: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1176:60: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1176:21: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1177:39: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1177:60: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1177:21: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1179:39: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1179:60: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1179:21: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1180:39: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1180:60: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1180:21: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1181:39: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1181:60: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1181:21: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1182:21: Index should be typed for more efficient access
performance hint: /home/treddy/github_projects/scipy/scipy/spatial/transform/_rotation.pyx:1185:29: Index should be typed for more efficient access
```

</details>

[skip circle]

I'm almost certain it is just an oversight in a recent merge rather than a Cython issue.