### PR TITLE
ENH: allow batching in `make_smoothing_spline`

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2359,7 +2359,7 @@ def make_smoothing_spline(x, y, w=None, lam=None, *, axis=0):
             c[:, i] = solve_banded((2, 2), X + lam[i] * wE, y[:, i])
     else:
         # this should not happen, ever
-        raise RuntimeError("Internal error, please report it to SciPy developes.")
+        raise RuntimeError("Internal error, please report it to SciPy developers.")
     c = c.reshape((c.shape[0], *y_shape1))
 
     # hack: these are c[0], c[1] etc, shape-compatible with np.r_ below

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -1527,26 +1527,6 @@ class TestInterp:
         b = make_interp_spline(x, y, k, bc_type=(d_l, d_r))
         assert b.c.shape == (n + k - 1, 5, 6, 7)
 
-    @pytest.mark.parametrize("axis", range(1, 4))
-    def test_shapes_axis(self, axis):
-        rng = np.random.RandomState(1234)
-        n = 11
-        shp_extra = (5, 6, 7)
-        x = np.arange(n)
-        y = rng.random(size=(n,) + shp_extra)
-        spl = make_interp_spline(x, y)
-
-        y1 = np.moveaxis(y.copy(), 0, axis)
-        spl1 = make_interp_spline(x, y1, axis=axis)
-
-        assert spl(3).shape == shp_extra
-        assert spl([3]).shape == (1,) + shp_extra
-        assert spl([2, 3]).shape == (2,) + shp_extra
-
-        assert spl1(3).shape == shp_extra
-        assert spl1([3]).shape == shp_extra[:axis] + (1,) + shp_extra[axis:]
-        assert spl1([2, 3]).shape == shp_extra[:axis] + (2,) + shp_extra[axis:]
-
     def test_string_aliases(self):
         yy = np.sin(self.xx)
 
@@ -1776,28 +1756,6 @@ class TestLSQ:
         b_qr = make_lsq_spline(x, y, t, k, method="qr")
         b_neq = make_lsq_spline(x, y, t, k, method="norm-eq")
         xp_assert_close(b_qr.c, b_neq.c, atol=1e-15)
-
-    @parametrize_lsq_methods
-    @pytest.mark.parametrize("axis", range(1, 4))
-    def test_shapes_axis(self, axis, method):
-        rng = np.random.RandomState(1234)
-        k, n = 3, 11
-        shp_extra = (5, 6, 7)
-        x = np.arange(n)
-        t = (x[0],) * (k+1) + (x[-1],)*(k+1)
-        y = rng.random(size=(n,) + shp_extra)
-        spl = make_lsq_spline(x, y, t=t, method=method)
-
-        y1 = np.moveaxis(y.copy(), 0, axis)
-        spl1 = make_lsq_spline(x, y1, t=t, axis=axis, method=method)
-
-        assert spl(3).shape == shp_extra
-        assert spl([3]).shape == (1,) + shp_extra
-        assert spl([2, 3]).shape == (2,) + shp_extra
-
-        assert spl1(3).shape == shp_extra
-        assert spl1([3]).shape == shp_extra[:axis] + (1,) + shp_extra[axis:]
-        assert spl1([2, 3]).shape == shp_extra[:axis] + (2,) + shp_extra[axis:]
 
     @parametrize_lsq_methods
     def test_complex(self, method):
@@ -2256,27 +2214,6 @@ class TestSmoothingSpline:
                 raise ValueError(f'Spline with weights should be closer to the'
                                  f' points than the original one: {orig:.4} < '
                                  f'{weighted:.4}')
-
-    @pytest.mark.parametrize("lam", [1.0, None])
-    @pytest.mark.parametrize("axis", range(1, 4))
-    def test_shapes_axis(self, axis, lam):
-        rng = np.random.RandomState(1234)
-        n = 11
-        shp_extra = (2, 3, 4)
-        x = np.arange(n)
-        y = rng.random(size=(n,) + shp_extra)
-        spl = make_smoothing_spline(x, y, lam=lam)
-
-        assert spl(3).shape == shp_extra
-        assert spl([3]).shape == (1,) + shp_extra
-        assert spl([2, 3]).shape == (2,) + shp_extra
-
-        y1 = np.moveaxis(y.copy(), 0, axis)
-        spl1 = make_smoothing_spline(x, y1, lam=lam, axis=axis)
-
-        assert spl1(3).shape == shp_extra
-        assert spl1([3]).shape == shp_extra[:axis] + (1,) + shp_extra[axis:]
-        assert spl1([2, 3]).shape == shp_extra[:axis] + (2,) + shp_extra[axis:]
 
 
 ################################

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3,6 +3,7 @@ import operator
 import itertools
 import math
 import threading
+import copy
 
 import numpy as np
 from numpy.testing import suppress_warnings
@@ -3720,3 +3721,69 @@ class TestMakeSplprep:
         assert spl(u).shape == (1, 8)
         xp_assert_close(spl(u), [x], atol=1e-15)
 
+
+class BatchSpline:
+    # BSpline-line class with reference batch behavior
+    def __init__(self, x, y, axis, *, spline, **kwargs):
+        y = np.moveaxis(y, axis, -1)
+        self._batch_shape = y.shape[:-1]
+        self._splines = [spline(x, yi, **kwargs) for yi in y.reshape(-1, y.shape[-1])]
+        self._axis = axis
+
+    def __call__(self, x):
+        y = [spline(x) for spline in self._splines]
+        y = np.reshape(y, self._batch_shape + x.shape)
+        return np.moveaxis(y, -1, self._axis) if x.shape else y
+
+    def integrate(self, a, b, extrapolate=None):
+        y = [spline.integrate(a, b, extrapolate) for spline in self._splines]
+        return np.reshape(y, self._batch_shape)
+
+    def derivative(self, nu):
+        res = copy.deepcopy(self)
+        res._splines = [spline.derivative(nu) for spline in res._splines]
+        return res
+
+    def antiderivative(self, nu):
+        res = copy.deepcopy(self)
+        res._splines = [spline.antiderivative(nu) for spline in res._splines]
+        return res
+
+
+class TestBatch:
+    @pytest.mark.parametrize('make_spline, kwargs',
+        [(make_interp_spline, {}),
+         (make_smoothing_spline, {}),
+         (make_smoothing_spline, {'lam': 1.0}),
+         (make_lsq_spline, {'method': "norm-eq"}),
+         (make_lsq_spline, {'method': "qr"}),
+         ])
+    @pytest.mark.parametrize('eval_shape', [(), (1,), (3,)])
+    @pytest.mark.parametrize('axis', [-1, 0, 1])
+    def test_batch(self, make_spline, kwargs, axis, eval_shape):
+        rng = np.random.default_rng(4329872134985134)
+        n = 10
+        shape = (2, 3, 4, n)
+        domain = (0, 10)
+
+        x = np.linspace(*domain, n)
+        y = np.moveaxis(rng.random(shape), -1, axis)
+
+        if make_spline == make_lsq_spline:
+            k = 3  # spline degree, if needed
+            t = (x[0],) * (k + 1) + (x[-1],) * (k + 1)  # valid knots, if needed
+            kwargs = kwargs | dict(t=t, k=k)
+
+        res = make_spline(x, y, axis=axis, **kwargs)
+        ref = BatchSpline(x, y, axis=axis, spline=make_spline, **kwargs)
+
+        x = rng.uniform(*domain, size=eval_shape)
+        np.testing.assert_allclose(res(x), ref(x))
+
+        res, ref = res.antiderivative(1), ref.antiderivative(1)
+        np.testing.assert_allclose(res(x), ref(x))
+
+        res, ref = res.derivative(2), ref.derivative(2)
+        np.testing.assert_allclose(res(x), ref(x))
+
+        np.testing.assert_allclose(res.integrate(*domain), ref.integrate(*domain))

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -671,6 +671,7 @@ class TestBSpline:
 
         xp_assert_close(b(xx), expected)
 
+
 class TestInsert:
 
     @pytest.mark.parametrize('xval', [0.0, 1.0, 2.5, 4, 6.5, 7.0])
@@ -2255,15 +2256,12 @@ class TestSmoothingSpline:
                                  f' points than the original one: {orig:.4} < '
                                  f'{weighted:.4}')
 
-# TODO
-#  2. y.ndim > 1 in GCV linear algebra computations
-#  4. Can `lam` to be an array for y.ndim > 1, is it even useful?
     @pytest.mark.parametrize("lam", [1.0, None])
     @pytest.mark.parametrize("axis", range(1, 4))
     def test_shapes_axis(self, axis, lam):
         rng = np.random.RandomState(1234)
         n = 11
-        shp_extra = (5, 6, 7)
+        shp_extra = (2, 3, 4)
         x = np.arange(n)
         y = rng.random(size=(n,) + shp_extra)
         spl = make_smoothing_spline(x, y, lam=lam)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2255,6 +2255,30 @@ class TestSmoothingSpline:
                                  f' points than the original one: {orig:.4} < '
                                  f'{weighted:.4}')
 
+# TODO
+#  2. y.ndim > 1 in GCV linear algebra computations
+#  4. Can `lam` to be an array for y.ndim > 1, is it even useful?
+    @pytest.mark.parametrize("lam", [1.0, None])
+    @pytest.mark.parametrize("axis", range(1, 4))
+    def test_shapes_axis(self, axis, lam):
+        rng = np.random.RandomState(1234)
+        n = 11
+        shp_extra = (5, 6, 7)
+        x = np.arange(n)
+        y = rng.random(size=(n,) + shp_extra)
+        spl = make_smoothing_spline(x, y, lam=lam)
+
+        assert spl(3).shape == shp_extra
+        assert spl([3]).shape == (1,) + shp_extra
+        assert spl([2, 3]).shape == (2,) + shp_extra
+
+        y1 = np.moveaxis(y.copy(), 0, axis)
+        spl1 = make_smoothing_spline(x, y1, lam=lam, axis=axis)
+
+        assert spl1(3).shape == shp_extra
+        assert spl1([3]).shape == shp_extra[:axis] + (1,) + shp_extra[axis:]
+        assert spl1([2, 3]).shape == shp_extra[:axis] + (2,) + shp_extra[axis:]
+
 
 ################################
 # NdBSpline tests


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->


#### What does this implement/fix?
<!--Please explain your changes.-->

Add batching/axis support to `make_smoothing_spline`.

TODO:
- [x] add batching support to a fixed-penalty case, `lam is not None`
- [x] add batching support to the GCV computation.

#### Additional information
<!--Any additional information you think is important.-->
