### PR TITLE
MAINT: simplifications related to NumPy bounds

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -17,15 +17,13 @@ from scipy._lib._docscrape import FunctionDoc, Parameter
 from scipy._lib._sparse import issparse
 import scipy._lib.array_api_extra as xpx
 
-
-AxisError: type[Exception]
-ComplexWarning: type[Warning]
-VisibleDeprecationWarning: type[Warning]
-
 from numpy.exceptions import (
     AxisError, ComplexWarning, VisibleDeprecationWarning,
     DTypePromotionError
 )
+
+__all__ = ['ComplexWarning', 'VisibleDeprecationWarning']
+
 
 np_long: type
 np_ulong: type

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -22,16 +22,10 @@ AxisError: type[Exception]
 ComplexWarning: type[Warning]
 VisibleDeprecationWarning: type[Warning]
 
-if np.lib.NumpyVersion(np.__version__) >= '1.25.0':
-    from numpy.exceptions import (
-        AxisError, ComplexWarning, VisibleDeprecationWarning,
-        DTypePromotionError
-    )
-else:
-    from numpy import (  # type: ignore[attr-defined, no-redef]
-        AxisError, ComplexWarning, VisibleDeprecationWarning  # noqa: F401
-    )
-    DTypePromotionError = TypeError  # type: ignore
+from numpy.exceptions import (
+    AxisError, ComplexWarning, VisibleDeprecationWarning,
+    DTypePromotionError
+)
 
 np_long: type
 np_ulong: type

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -17,12 +17,7 @@ from scipy._lib._docscrape import FunctionDoc, Parameter
 from scipy._lib._sparse import issparse
 import scipy._lib.array_api_extra as xpx
 
-from numpy.exceptions import (
-    AxisError, ComplexWarning, VisibleDeprecationWarning,
-    DTypePromotionError
-)
-
-__all__ = ['ComplexWarning', 'VisibleDeprecationWarning']
+from numpy.exceptions import AxisError, DTypePromotionError
 
 
 np_long: type

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -4,6 +4,8 @@ import pytest
 import numpy as np
 
 from numpy.testing import assert_warns
+from numpy.exceptions import ComplexWarning
+
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, assert_array_almost_equal
 )
@@ -16,7 +18,6 @@ from scipy.interpolate import (RegularGridInterpolator, interpn,
                                NearestNDInterpolator, LinearNDInterpolator)
 
 from scipy.sparse._sputils import matrix
-from scipy._lib._util import ComplexWarning
 from scipy._lib._testutils import _run_concurrent_barrier
 
 

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -29,7 +29,6 @@ from scipy.io.matlab._mio5 import (
     MatFile5Writer, MatFile5Reader, varmats_from_mat, to_writeable,
     EmptyStructMarker)
 import scipy.io.matlab._mio5_params as mio5p
-from scipy._lib._util import VisibleDeprecationWarning
 
 
 test_data_path = pjoin(dirname(__file__), 'data')
@@ -1324,13 +1323,10 @@ def test_gh_17992(tmp_path):
     array_one = rng.random((5,3))
     array_two = rng.random((6,3))
     list_of_arrays = [array_one, array_two]
-    # warning suppression only needed for NumPy < 1.24.0
-    with np.testing.suppress_warnings() as sup:
-        sup.filter(VisibleDeprecationWarning)
-        savemat(outfile,
-                {'data': list_of_arrays},
-                long_field_names=True,
-                do_compression=True)
+    savemat(outfile,
+            {'data': list_of_arrays},
+            long_field_names=True,
+            do_compression=True)
     # round trip check
     new_dict = {}
     loadmat(outfile,

--- a/scipy/linalg/_decomp_ldl.py
+++ b/scipy/linalg/_decomp_ldl.py
@@ -3,7 +3,9 @@ from warnings import warn
 import numpy as np
 from numpy import (atleast_2d, arange, zeros_like, imag, diag,
                    iscomplexobj, tril, triu, argsort, empty_like)
-from scipy._lib._util import ComplexWarning, _apply_over_batch
+from numpy.exceptions import ComplexWarning
+
+from scipy._lib._util import _apply_over_batch
 from ._decomp import _asarray_validated
 from .lapack import get_lapack_funcs, _compute_lwork
 

--- a/scipy/linalg/tests/test_decomp_ldl.py
+++ b/scipy/linalg/tests/test_decomp_ldl.py
@@ -2,9 +2,9 @@ from numpy.testing import assert_array_almost_equal, assert_allclose, assert_
 from numpy import (array, eye, zeros, empty_like, empty, tril_indices_from,
                    tril, triu_indices_from, spacing, float32, float64,
                    complex64, complex128)
+from numpy.exceptions import ComplexWarning
 from numpy.random import rand, randint, seed
 from scipy.linalg import ldl
-from scipy._lib._util import ComplexWarning
 import pytest
 from pytest import raises as assert_raises, warns
 

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -1,7 +1,9 @@
 import warnings
+
 import numpy as np
+from numpy.exceptions import VisibleDeprecationWarning
+
 from scipy.sparse import csc_array, vstack, issparse
-from scipy._lib._util import VisibleDeprecationWarning
 from ._highspy._highs_wrapper import _highs_wrapper  # type: ignore[import-not-found,import-untyped]
 from ._constraints import LinearConstraint, Bounds
 from ._optimize import OptimizeResult

--- a/scipy/optimize/tests/test__linprog_clean_inputs.py
+++ b/scipy/optimize/tests/test__linprog_clean_inputs.py
@@ -1,13 +1,15 @@
 """
 Unit test for Linear Programming via Simplex Algorithm.
 """
-import numpy as np
-from numpy.testing import assert_, assert_allclose, assert_equal
-from pytest import raises as assert_raises
-from scipy.optimize._linprog_util import _clean_inputs, _LPProblem
-from scipy._lib._util import VisibleDeprecationWarning
 from copy import deepcopy
 from datetime import date
+
+import numpy as np
+from numpy.testing import assert_, assert_allclose, assert_equal
+from numpy.exceptions import VisibleDeprecationWarning
+from pytest import raises as assert_raises
+
+from scipy.optimize._linprog_util import _clean_inputs, _LPProblem
 
 
 def test_aliasing():

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -5,6 +5,7 @@ import sys
 import platform
 
 import numpy as np
+from numpy.exceptions import VisibleDeprecationWarning
 from numpy.testing import (assert_, assert_allclose, assert_equal,
                            assert_array_less, assert_warns, suppress_warnings)
 from pytest import raises as assert_raises
@@ -12,7 +13,6 @@ from scipy.optimize import linprog, OptimizeWarning
 from scipy.optimize._numdiff import approx_derivative
 from scipy.sparse.linalg import MatrixRankWarning
 from scipy.linalg import LinAlgWarning
-from scipy._lib._util import VisibleDeprecationWarning
 import scipy.sparse
 import pytest
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -12,6 +12,7 @@ from numpy.testing import (
     assert_allclose,    # until object arrays are gone
     suppress_warnings)
 import numpy as np
+from numpy.exceptions import ComplexWarning
 
 from scipy import fft as sp_fft
 from scipy.ndimage import correlate1d
@@ -29,7 +30,6 @@ from scipy.signal._signaltools import (_filtfilt_gust, _compute_factors,
                                       _group_poles)
 from scipy.signal._upfirdn import _upfirdn_modes
 from scipy._lib import _testutils
-from scipy._lib._util import ComplexWarning
 
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, is_numpy, is_torch, is_jax, is_cupy,

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -3,6 +3,7 @@ import threading
 
 import numpy as np
 from numpy import array, finfo, arange, eye, all, unique, ones, dot
+from numpy.exceptions import ComplexWarning
 import numpy.random as random
 from numpy.testing import (
         assert_array_almost_equal, assert_almost_equal,
@@ -22,7 +23,6 @@ from scipy.sparse.linalg._dsolve import (spsolve, use_solver, splu, spilu,
 import scipy.sparse
 
 from scipy._lib._testutils import check_free_memory
-from scipy._lib._util import ComplexWarning
 
 
 sup_sparse_efficiency = suppress_warnings()

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1685,13 +1685,7 @@ class _TestCommon:
         B = self.spcreator(A)
 
         if self.is_array_test:  # sparrays use element-wise power
-            # Todo: Add 1+3j to tested exponent list when np1.24 is no longer supported
-            #    Complex exponents of 0 (our implicit fill value) change in numpy-1.25
-            #    from `(nan+nanj)` to `0`. Old value makes array element-wise result
-            #    dense and is hard to check for without any `isnan` method.
-            # So while untested here, element-wise complex exponents work with np>=1.25.
-            # for exponent in [1, 2, 2.2, 3, 1+3j]:
-            for exponent in [1, 2, 2.2, 3]:
+            for exponent in [1, 2, 2.2, 3, 1+3j]:
                 ret_sp = B**exponent
                 ret_np = A**exponent
                 assert_array_equal(ret_sp.toarray(), ret_np)
@@ -2356,20 +2350,14 @@ class _TestInplaceArithmetic:
 
         # Matrix multiply from __rmatmul__
         y = a.copy()
-        # skip this test if numpy doesn't support __imatmul__ yet.
-        # move out of the try/except once numpy 1.24 is no longer supported.
-        try:
-            y @= b.T
-        except TypeError:
-            pass
-        else:
-            x = a.copy()
-            y = a.copy()
-            with assert_raises(ValueError, match="dimension mismatch"):
-                x @= b
-            x = x.dot(a.T)
-            y @= b.T
-            assert_array_equal(x, y)
+        y @= b.T
+        x = a.copy()
+        y = a.copy()
+        with assert_raises(ValueError, match="dimension mismatch"):
+            x @= b
+        x = x.dot(a.T)
+        y @= b.T
+        assert_array_equal(x, y)
 
         # Floor division is not supported
         with assert_raises(TypeError, match="unsupported operand"):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -28,6 +28,7 @@ import random
 from numpy.testing import (assert_equal, assert_array_equal,
         assert_array_almost_equal, assert_almost_equal, assert_,
         assert_allclose, suppress_warnings)
+from numpy.exceptions import ComplexWarning
 
 from types import GenericAlias
 
@@ -45,7 +46,6 @@ from scipy.sparse._sputils import (supported_dtypes, isscalarlike,
 from scipy.sparse.linalg import splu, expm, inv
 
 from scipy._lib.decorator import decorator
-from scipy._lib._util import ComplexWarning
 
 IS_COLAB = ('google.colab' in sys.modules)
 

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -4,13 +4,13 @@ import pytest
 
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
+from numpy.exceptions import ComplexWarning
 
 from scipy.sparse import (
         bsr_array, csc_array, dia_array, lil_array,
         coo_array, csr_array, dok_array,
     )
 from scipy.sparse._sputils import supported_dtypes, matrix
-from scipy._lib._util import ComplexWarning
 
 
 sup_complex = np.testing.suppress_warnings()


### PR DESCRIPTION
* A few simplifications are empowered by the bump in lower NumPy version bound to `1.25.2`. I suspect there are others, but these are the ones I found from some initial `git grep` work.

[skip circle]
