### PR TITLE
ENH: _lib._make_tuple_bunch: pretend to be namedtuple even more

### DIFF
--- a/scipy/_lib/_bunch.py
+++ b/scipy/_lib/_bunch.py
@@ -194,6 +194,10 @@ def __setattr__(self, key, val):
         '_asdict': _asdict,
         '_extra_fields': extra_field_names,
         '__getnewargs_ex__': __getnewargs_ex__,
+        # _field_defaults and _replace are added to get Polars to detect
+        # a bunch object as a namedtuple. See gh-22450
+        '_field_defaults': {},
+        '_replace': None,
     }
     for index, name in enumerate(field_names):
 

--- a/scipy/_lib/tests/test_bunch.py
+++ b/scipy/_lib/tests/test_bunch.py
@@ -127,6 +127,13 @@ class TestMakeTupleBunch:
         assert_equal(Foo.__module__, m)
         assert_equal(foo.__module__, m)
 
+    def test_passes_polars_checks(self):
+        # gh-22450
+        Square = _make_tuple_bunch('Square', ['width', 'height'])
+        assert hasattr(Square, '_replace')
+        assert hasattr(Square, '_field_defaults')
+
+
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     # Argument validation
     # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Polars has a feature where it can unwrap various kinds of objects, such as namedtuples, into a polars.Struct. This doesn't work well for SciPy bunches, because they are just different enough from namedtuples to not get this treatment.

#### Reference issue

Closes #22450 

#### What does this implement/fix?

Polars checks if an object is a namedtuple like this:

```
@lru_cache(64)
def is_namedtuple(cls: Any, *, annotated: bool = False) -> bool:
    """Check whether given class derives from NamedTuple."""
    if all(hasattr(cls, attr) for attr in ("_fields", "_field_defaults", "_replace")):
        if not isinstance(cls._fields, property):
            if not annotated or len(cls.__annotations__) == len(cls._fields):
                return all(isinstance(fld, str) for fld in cls._fields)
    return False
```

This is checking that the `_fields`, `_field_defaults`, and `_replace` attributes exist. [Polars appears to make no other use of `_field_defaults` and `_replace`.](https://github.com/scipy/scipy/issues/22450#issuecomment-2628353133)

#### Additional information

`_field_defaults` is set to `{}` because that is what a namedtuple without field defaults uses.

`_replace` is set to None. I considered writing a `_replace()` method that works like namedtuple, but decided not to because it seemed like a lot of work to write and test.
