### PR TITLE
MAINT: `stats.invgauss`: return correct result when `mu=inf`

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5018,10 +5018,10 @@ class invgauss_gen(rv_continuous):
     def _pdf(self, x, mu):
         # invgauss.pdf(x, mu) =
         #                  1 / sqrt(2*pi*x**3) * exp(-(x-mu)**2/(2*x*mu**2))
-        return 1.0/np.sqrt(2*np.pi*x**3.0)*np.exp(-1.0/(2*x)*((x-mu)/mu)**2)
+        return 1.0/np.sqrt(2*np.pi*x**3.0)*np.exp(-1.0/(2*x)*(x/mu - 1)**2)
 
     def _logpdf(self, x, mu):
-        return -0.5*np.log(2*np.pi) - 1.5*np.log(x) - ((x-mu)/mu)**2/(2*x)
+        return -0.5*np.log(2*np.pi) - 1.5*np.log(x) - (x/mu - 1)**2/(2*x)
 
     # approach adapted from equations in
     # https://journal.r-project.org/archive/2016-1/giner-smyth.pdf,
@@ -5029,14 +5029,14 @@ class invgauss_gen(rv_continuous):
 
     def _logcdf(self, x, mu):
         fac = 1 / np.sqrt(x)
-        a = _norm_logcdf(fac * ((x / mu) - 1))
-        b = 2 / mu + _norm_logcdf(-fac * ((x / mu) + 1))
+        a = _norm_logcdf(fac * (x/mu - 1))
+        b = 2 / mu + _norm_logcdf(-fac * (x/mu + 1))
         return a + np.log1p(np.exp(b - a))
 
     def _logsf(self, x, mu):
         fac = 1 / np.sqrt(x)
-        a = _norm_logsf(fac * ((x / mu) - 1))
-        b = 2 / mu + _norm_logcdf(-fac * (x + mu) / mu)
+        a = _norm_logsf(fac * (x/mu - 1))
+        b = 2 / mu + _norm_logcdf(-fac * (x/mu + 1))
         return a + np.log1p(-np.exp(b - a))
 
     def _sf(self, x, mu):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3345,6 +3345,20 @@ class TestInvgauss:
     def test_entropy(self, mu, ref):
         assert_allclose(stats.invgauss.entropy(mu), ref, rtol=5e-14)
 
+    def test_mu_inf_gh13666(self):
+        # invgauss methods should return correct result when mu=inf
+        dist = stats.invgauss(mu=np.inf)
+        dist0 = stats.invgamma(0.5, scale=0.5)
+        x, p = 1., 0.5
+        assert_allclose(dist.logpdf(x), dist0.logpdf(x))
+        assert_allclose(dist.pdf(x), dist0.pdf(x))
+        assert_allclose(dist.logcdf(x), dist0.logcdf(x))
+        assert_allclose(dist.cdf(x), dist0.cdf(x))
+        assert_allclose(dist.logsf(x), dist0.logsf(x))
+        assert_allclose(dist.sf(x), dist0.sf(x))
+        assert_allclose(dist.ppf(p), dist0.ppf(p))
+        assert_allclose(dist.isf(p), dist0.isf(p))
+
 
 class TestLandau:
     @pytest.mark.parametrize('name', ['pdf', 'cdf', 'sf', 'ppf', 'isf'])

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -3347,6 +3347,8 @@ class TestInvgauss:
 
     def test_mu_inf_gh13666(self):
         # invgauss methods should return correct result when mu=inf
+        # invgauss as mu -> oo is invgamma with shape and scale 0.5;
+        # see gh-13666 and gh-22496
         dist = stats.invgauss(mu=np.inf)
         dist0 = stats.invgamma(0.5, scale=0.5)
         x, p = 1., 0.5


### PR DESCRIPTION
#### Reference issue
Closes gh-13666

#### What does this implement/fix?
When `mu=inf`, some `invgauss` methods returned NaN. The formulas produce the result of the limiting distribution if we simplify some `mu/mu -> 1`, so this does that.

#### Additional information
The claim in gh-13666 was that the limiting distribution of the [inverse Gaussian](https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution) as $\mu \rightarrow \infty$ is [inverse chi-squared](https://en.wikipedia.org/wiki/Inverse-chi-squared_distribution) with one degree of freedom. I verified that using the PDF formulas from Wikipedia.

```python3
from sympy import symbols, sqrt, pi, exp, limit, oo, gamma, Rational, simplify, Symbol, expand
x, u = symbols('x, u')
invgauss = limit(sqrt(1/(2*pi*x**3)) * exp(-(x-u)**2/(2*u**2*x)), u, oo)
v_2 = Rational(1, 2)
invchi2 = 2**(-v_2)/gamma(v_2) * x**(-v_2 - 1) * exp(-1/(2*x))
simplify(invgauss/invchi2)
# x**(3/2)*sqrt(x**(-3)), which humans recognize as unity under reasonable assumptions
```
The relationship between inverse chi squared and the inverse gamma is also noted on the Wikipedia page for inverse chi-squared.