### PR TITLE
DOC: remove links to the reference guide in the tutorials page

### DIFF
--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -25,23 +25,23 @@ linked in the Description column:
 ==================  ========================================
 Subpackage          Description and User Guide
 ==================  ========================================
-`cluster`           Clustering algorithms
-`constants`         Physical and mathematical constants
-`differentiate`     Finite difference differentiation tools
-`fft`               :doc:`./fft`
-`fftpack`           Fast Fourier Transform routines (legacy)
-`integrate`         :doc:`./integrate`
-`interpolate`       :doc:`./interpolate`
-`io`                :doc:`./io`
-`linalg`            :doc:`./linalg`
-`ndimage`           :doc:`./ndimage`
-`odr`               Orthogonal distance regression
-`optimize`          :doc:`./optimize`
-`signal`            :doc:`./signal`
-`sparse`            :doc:`./sparse`
-`spatial`           :doc:`./spatial`
-`special`           :doc:`./special`
-`stats`             :doc:`./stats`
+``cluster``           Clustering algorithms
+``constants``         Physical and mathematical constants
+``differentiate``     Finite difference differentiation tools
+``fft``               :doc:`./fft`
+``fftpack``           Fast Fourier Transform routines (legacy)
+``integrate``         :doc:`./integrate`
+``interpolate``       :doc:`./interpolate`
+``io``                :doc:`./io`
+``linalg``            :doc:`./linalg`
+``ndimage``           :doc:`./ndimage`
+``odr``               Orthogonal distance regression
+``optimize``          :doc:`./optimize`
+``signal``            :doc:`./signal`
+``sparse``            :doc:`./sparse`
+``spatial``           :doc:`./spatial`
+``special``           :doc:`./special`
+``stats``             :doc:`./stats`
 ==================  ========================================
 
 There are also additional user guides for these topics:

--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -19,8 +19,7 @@ Subpackages and User Guides
 
 SciPy is organized into subpackages covering different scientific
 computing domains. These are summarized in the following table, with
-their API reference linked in the Subpackage column, and user guide (if available)
-linked in the Description column:
+their user guide linked in the Description and User Guide column (if available):
 
 ==================    ========================================
 Subpackage            Description and User Guide

--- a/doc/source/tutorial/index.rst
+++ b/doc/source/tutorial/index.rst
@@ -22,9 +22,9 @@ computing domains. These are summarized in the following table, with
 their API reference linked in the Subpackage column, and user guide (if available)
 linked in the Description column:
 
-==================  ========================================
-Subpackage          Description and User Guide
-==================  ========================================
+==================    ========================================
+Subpackage            Description and User Guide
+==================    ========================================
 ``cluster``           Clustering algorithms
 ``constants``         Physical and mathematical constants
 ``differentiate``     Finite difference differentiation tools
@@ -42,7 +42,7 @@ Subpackage          Description and User Guide
 ``spatial``           :doc:`./spatial`
 ``special``           :doc:`./special`
 ``stats``             :doc:`./stats`
-==================  ========================================
+==================    ========================================
 
 There are also additional user guides for these topics:
 


### PR DESCRIPTION
…ex.rst

Since doc/source/conf.py makes text marked up by single backticks into auto-hyperlinks, I've modified the subpackages column to use double backticks.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #22485

#### What does this implement/fix?
<!-- On the landing page of the scipy user guide, the subpackages column has a confusing set of hyperlinks that lead to module API references. On its own, this wouldn't be an issue, but for line items such as integrate, it's confusing for a doc user on the 'user guide' landing page to be directed to a module API reference instead of scipy.integrate linked in the Description and User guide column, which is what they're likely to actually want. As such, decision per consensus is to just remove all the hyperlinks in the subpackage list column. -->

#### Additional information
<!-- doc/source/conf.py sets up the markup in the RST files such that writing text contained within single backticks becomes an automatic hyperlink activated by the toctree. It's not clear if this was intentional functionality from the start or an unintentional inconsistency given that when building this fork, warnings are thrown about the non-usage of any of the module API reference RST files in the doc/source/tutorial directory. In any case, double backticks have been used as inspired by similar implementation in ./fft.rst to side-step that inconsistency. That auto-hyperlink capability should be addressed at some point if we want it removed and not to conflict with normal code-block markup using single backticks. -->
