### PR TITLE
BLD: bump min version of Clang to 15.0, and macOS min version to 10.14

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -83,7 +83,7 @@ jobs:
         - [ubuntu-22.04, musllinux, x86_64, "", ""]
         - [ubuntu-24.04-arm, manylinux, aarch64, "", ""]
         - [ubuntu-24.04-arm, musllinux, aarch64, "", ""]
-        - [macos-13, macosx, x86_64, openblas, "10.13"]
+        - [macos-13, macosx, x86_64, openblas, "10.14"]
         - [macos-13, macosx, x86_64, accelerate, "14.0"]
         - [macos-14, macosx, arm64, openblas, "12.3"]
         - [macos-14, macosx, arm64, accelerate, "14.0"]

--- a/meson.build
+++ b/meson.build
@@ -41,8 +41,8 @@ if cc.get_id() == 'gcc'
     error('SciPy requires GCC >= 9.1')
   endif
 elif cc.get_id() == 'clang' or cc.get_id() == 'clang-cl'
-  if not cc.version().version_compare('>=12.0')
-    error('SciPy requires clang >= 12.0')
+  if not cc.version().version_compare('>=15.0')
+    error('SciPy requires clang >= 15.0')
   endif
 elif cc.get_id() == 'msvc'
   if not cc.version().version_compare('>=19.20')


### PR DESCRIPTION
Addresses the wheel build failures reported for macOS x86-64 in gh-22487.

macOS 10.14 is from 2018, so is still a very loose lower bound, we don't expect issues as a result.

The Clang >=15 is probably also reasonable, since it's rare to see a version below 16 being used. Targeting macOS 10.13 causes cibuildwheel to pull in XCode 14.1 with Clang 14.0, while macOS 10.14 pulls in XCode 15.2 and Clang 15.0.

I verified the fix on my fork: https://github.com/rgommers/scipy/actions/runs/13241617566.