### PR TITLE
ENH: stats.quantile: add discontinuous (HF 1-3) and Harrell-Davis methods; add `marray` support

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -565,7 +565,7 @@ def xp_take_along_axis(arr: Array,
     elif is_array_api_strict(xp):
         raise NotImplementedError("Array API standard does not define take_along_axis")
     else:
-        return xp.take_along_axis(arr, indices, axis)
+        return xp.take_along_axis(arr, indices, axis=axis)
 
 
 # utility to broadcast arrays and promote to common dtype

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -3,6 +3,7 @@ from scipy.special import betainc
 from scipy._lib._array_api import (xp_take_along_axis, xp_default_dtype,
                                    xp_ravel, array_namespace)
 from scipy.stats._axis_nan_policy import _broadcast_arrays, _contains_nan
+from scipy.stats._stats_py import _length_nonmasked
 
 
 def _quantile_iv(x, p, method, axis, nan_policy, keepdims):
@@ -68,7 +69,8 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims):
     y = xp.moveaxis(y, axis, -1)
     p = xp.moveaxis(p, axis, -1)
 
-    n = xp.astype(xp.asarray(y.shape[-1]), dtype)
+    n = _length_nonmasked(y, -1, xp=xp, keepdims=True)
+    n = xp.asarray(n, dtype=dtype)
     if contains_nans:
         nans = xp.isnan(y)
 

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -332,6 +332,6 @@ def _quantile_hd(y, p, n, xp):
     # There will be edge case bugs with a == 0 or b == 0 due to gh-8411
     w = betainc(a, b, i / n)
     w = w[..., 1:] - w[..., :-1]
-    w[np.isnan(w)] = 0
+    w[xp.isnan(w)] = 0
     res = xp.vecdot(w, y, axis=-1)
     return xp.moveaxis(res, 0, -1)

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -89,7 +89,7 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims):
             y[nan_out] = np.nan
         elif xp.any(nans) and method == 'harrell-davis':
             y = xp.asarray(y, copy=True)  # ensure writable
-            y[nans] = 0
+            y[nans] = 0  # any non-nan will prevent NaN from propagating
 
     p_mask = (p > 1) | (p < 0) | xp.isnan(p)
     if xp.any(p_mask):

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -232,7 +232,8 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
     :math:`i` are the indices :math:`1, 2, ..., n-1, n` of the sorted elements,
     :math:`a = p (n + 1)`, :math:`b = (1 - p)(n + 1)`,
     :math:`p` is the probability of the quantile, and
-    :math:`I` is the regularized, lower incomplete beta function (`special.betainc`).
+    :math:`I` is the regularized, lower incomplete beta function
+    (`scipy.special.betainc`).
 
     Examples
     --------

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 
 from scipy import stats
-from scipy._lib._array_api import xp_default_dtype, is_numpy
+from scipy._lib._array_api import xp_default_dtype, is_numpy, is_torch
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 from scipy._lib._util import _apply_over_batch
 
@@ -39,7 +39,6 @@ def quantile_reference(x, p, *, axis, nan_policy, keepdims, method):
 
 @skip_xp_backends('dask.array', reason="No take_along_axis yet.")
 @skip_xp_backends('array_api_strict', reason="No take_along_axis yet.")
-@skip_xp_backends('dask.array', reason="No take_along_axis yet.")
 @skip_xp_backends('jax.numpy', reason="No mutation.")
 class TestQuantile:
 
@@ -130,6 +129,9 @@ class TestQuantile:
         if nan_policy == 'marray':
             if method == 'harrell-davis':
                 pytest.skip("Needs gh-22490")
+            if is_torch(xp):
+                pytest.skip("sum_cpu not implemented for UInt64, see "
+                            "data-apis/array-api-compat#242")
             marray = pytest.importorskip('marray')
             kwargs = dict(axis=axis, keepdims=keepdims, method=method)
             mxp = marray._get_namespace(xp)

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -101,6 +101,7 @@ class TestQuantile:
 
         xp_assert_close(res, xp.asarray(ref, dtype=dtype))
 
+    @skip_xp_backends(cpu_only=True, reason="PyTorch doesn't have `betainc`.")
     @pytest.mark.parametrize('axis', [0, 1])
     @pytest.mark.parametrize('keepdims', [False, True])
     @pytest.mark.parametrize('nan_policy', ['omit', 'propagate', 'marray'])
@@ -185,7 +186,7 @@ class TestQuantile:
         # test that values of discontinuous estimators are correct when
         # p*n + m - 1 is integral.
         x = np.arange(8., dtype=np.float64)
-        p = np.arange(0, 1.125, 0.125)
+        p = np.arange(0, 1.0625, 0.0625)
         res = stats.quantile(xp.asarray(x), xp.asarray(p), method=method)
         ref = np.quantile(x, p, method=method)
         xp_assert_equal(res, xp.asarray(ref, dtype=xp.float64))

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -185,6 +185,8 @@ class TestQuantile:
     def test_transition(self, method, xp):
         # test that values of discontinuous estimators are correct when
         # p*n + m - 1 is integral.
+        if method == 'closest_observation' and np.__version__ < '2.0.1':
+            pytest.skip('Bug in np.quantile (numpy/numpy#26656) fixed in 2.0.1')
         x = np.arange(8., dtype=np.float64)
         p = np.arange(0, 1.0625, 0.0625)
         res = stats.quantile(xp.asarray(x), xp.asarray(p), method=method)

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -118,7 +118,8 @@ class TestQuantile:
             p = np.mean(p, axis=axis, keepdims=True)
 
         # inject p = 0 and p = 1 to test edge cases
-        # Currently would fail with CuPy/JAX (cupy/cupy#8934, jax-ml/jax#21900)
+        # Currently would fail with CuPy/JAX (cupy/cupy#8934, jax-ml/jax#21900);
+        # remove the `if` when those are resolved.
         if is_numpy(xp):
             p0 = p.ravel()
             p0[1] = 0.
@@ -183,8 +184,8 @@ class TestQuantile:
     def test_transition(self, method, xp):
         # test that values of discontinuous estimators are correct when
         # p*n + m - 1 is integral.
-        x = np.arange(5., dtype=np.float64)
-        p = np.arange(0, 1.1, 0.1)
+        x = np.arange(8., dtype=np.float64)
+        p = np.arange(0, 1.125, 0.125)
         res = stats.quantile(xp.asarray(x), xp.asarray(p), method=method)
         ref = np.quantile(x, p, method=method)
         xp_assert_equal(res, xp.asarray(ref, dtype=xp.float64))


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-feature

#### What does this implement/fix?
This adds the following capabilities to the new `scipy.stats.quantile`:
- the discontinuous estimators (1-3) from [1]: `inverted_cdf`, `averaged_inverted_cdf`, and `closest_observation`
- the Harrell-Davis estimator (as `method='harrell-davis') to replace `mstats.hdmedian` and `mstats.hdquantile`
- support for `marray`s + associated tests
