### PR TITLE
BUG: sparse.csgraph: Added support for casting coo array to csc/csr array in ``min_weight_full_bipartite_matching``

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -32,7 +32,7 @@ SciPy 2-D sparse array package for numeric data.
    - Sparse arrays use array style *slicing* operations, returning scalars,
      1D, or 2D sparse arrays. If you need 2D results, use an appropriate index.
      E.g. ``A[:, i, None]`` or ``A[:, [i]]``.
-   - All index arrays for a given sparse array should be of same type.
+   - All index arrays for a given sparse array should be of same dtype.
      For example, for CSR format, ``indices`` and ``indptr`` should have
      the same dtype. For COO, each array in `coords` should have same dtype.
 

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -32,6 +32,9 @@ SciPy 2-D sparse array package for numeric data.
    - Sparse arrays use array style *slicing* operations, returning scalars,
      1D, or 2D sparse arrays. If you need 2D results, use an appropriate index.
      E.g. ``A[:, i, None]`` or ``A[:, [i]]``.
+   - All index arrays for a given sparse array should be of same type.
+     For example, for CSR format, ``indices`` and ``indptr`` should have
+     the same dtype. For COO, each array in `coords` should have same dtype.
 
    The construction utilities (`eye`, `kron`, `random`, `diags`, etc.)
    have appropriate replacements (see :ref:`sparse-construction-functions`).

--- a/scipy/sparse/csgraph/_matching.pyx
+++ b/scipy/sparse/csgraph/_matching.pyx
@@ -6,7 +6,7 @@ cimport numpy as np
 from libc.math cimport INFINITY
 
 
-from scipy.sparse import issparse, csr_array, coo_array
+from scipy.sparse import issparse, csr_array
 from scipy.sparse._sputils import (convert_pydata_sparse_to_scipy,
                                    safely_cast_index_arrays)
 
@@ -482,15 +482,14 @@ def min_weight_full_bipartite_matching(biadjacency, maximize=False):
 
     a = np.arange(np.min(biadjacency.shape))
 
-    if biadjacency.format != "coo":
-        indices, indptr = safely_cast_index_arrays(biadjacency, ITYPE, msg="csgraph")
-        if indices is not biadjacency.indices:
-            # create a new object without copying data
-            biadjacency = csr_array((biadjacency.data, indices, indptr),
-                                    shape=biadjacency.shape, dtype=biadjacency.dtype)
-    else:
-        row, col = safely_cast_index_arrays(biadjacency, ITYPE, msg="csgraph")
-        biadjacency = coo_array((biadjacency.data, (row, col)), shape=biadjacency.shape)
+    if biadjacency.format not in ("csc", "csr"):
+        biadjacency = biadjacency.tocsc(copy=False) if j < i else biadjacency.tocsr(copy=False)
+
+    indices, indptr = safely_cast_index_arrays(biadjacency, ITYPE, msg="csgraph")
+    if indices is not biadjacency.indices:
+        # create a new object without copying data
+        biadjacency = csr_array((biadjacency.data, indices, indptr),
+                                shape=biadjacency.shape, dtype=biadjacency.dtype)
 
     # The algorithm expects more columns than rows in the graph, so
     # we use the transpose if that is not already the case. We also

--- a/scipy/sparse/csgraph/tests/test_pydata_sparse.py
+++ b/scipy/sparse/csgraph/tests/test_pydata_sparse.py
@@ -154,8 +154,9 @@ def test_min_weight_full_bipartite_matching(graphs):
     func = spgraph.min_weight_full_bipartite_matching
 
     actual = func(A_sparse[0:2, 1:3])
-    desired = func(sp.csc_array(A_dense)[0:2, 1:3])
-    desired1 = func(sp.coo_array(A_dense)[0:2, 1:3])
+    A_csc = sp.csc_array(A_dense)
+    desired = func(A_csc[0:2, 1:3])
+    desired1 = func(A_csc[0:2, 1:3].tocoo())
 
     assert_equal(actual, desired)
     assert_equal(actual, desired1)

--- a/scipy/sparse/csgraph/tests/test_pydata_sparse.py
+++ b/scipy/sparse/csgraph/tests/test_pydata_sparse.py
@@ -155,8 +155,10 @@ def test_min_weight_full_bipartite_matching(graphs):
 
     actual = func(A_sparse[0:2, 1:3])
     desired = func(sp.csc_array(A_dense)[0:2, 1:3])
+    desired1 = func(sp.coo_array(A_dense)[0:2, 1:3])
 
     assert_equal(actual, desired)
+    assert_equal(actual, desired1)
 
 
 @check_sparse_version("0.15.4")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/22501

#### What does this implement/fix?
<!--Please explain your changes.-->

The fix involves casting ``row`` and ``col`` for ``coo_array``. The original code in `main` branch assumes that the input to ``min_weight_full_bipartite_matching`` is in ``csr`` format. However, ``coo`` format is also allowed. I am handling ``coo`` format in my fix.

Added tests for ``coo`` format. They are not there in ``main``.

#### Additional information
<!--Any additional information you think is important.-->
