### PR TITLE
STY: enable lint rule UP038 and fix instances in violation of it

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -481,7 +481,7 @@ def linkcode_resolve(domain, info):
         obj = obj.__wrapped__
     # SciPy's distributions are instances of *_gen. Point to this
     # class since it contains the implementation of all the methods.
-    if isinstance(obj, (rv_generic, multi_rv_generic)):
+    if isinstance(obj, rv_generic | multi_rv_generic):
         obj = obj.__class__
     try:
         fn = inspect.getsourcefile(obj)

--- a/scipy/_build_utils/system_info.py
+++ b/scipy/_build_utils/system_info.py
@@ -23,8 +23,8 @@ def combine_dict(*dicts, **kw):
         for key, value in d.items():
             if new_dict.get(key, None) is not None:
                 old_value = new_dict[key]
-                if isinstance(value, (list, tuple)):
-                    if isinstance(old_value, (list, tuple)):
+                if isinstance(value, list | tuple):
+                    if isinstance(old_value, list | tuple):
                         new_dict[key] = list(old_value) + list(value)
                         continue
                 elif value == old_value:

--- a/scipy/_lib/_docscrape.py
+++ b/scipy/_lib/_docscrape.py
@@ -703,7 +703,7 @@ class ClassDoc(NumpyDocString):
                 and not self._should_skip_member(name, self._cls)
                 and (
                     func is None
-                    or isinstance(func, (property, cached_property))
+                    or isinstance(func, property | cached_property)
                     or inspect.isdatadescriptor(func)
                 )
                 and self._is_show_member(name)

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -2956,7 +2956,7 @@ def set_link_color_palette(palette):
     if palette is None:
         # reset to its default
         palette = _link_line_colors_default
-    elif not isinstance(palette, (list, tuple)):
+    elif not isinstance(palette, list | tuple):
         raise TypeError("palette must be a list or tuple")
     _ptypes = [isinstance(p, str) for p in palette]
 
@@ -3260,7 +3260,7 @@ def dendrogram(Z, p=30, truncate_mode=None, color_threshold=None,
     is_valid_linkage(Z, throw=True, name='Z')
     Zs = Z.shape
     n = Zs[0] + 1
-    if isinstance(p, (int, float)):
+    if isinstance(p, int | float):
         p = int(p)
     else:
         raise TypeError('The second argument must be a number')

--- a/scipy/datasets/_utils.py
+++ b/scipy/datasets/_utils.py
@@ -29,7 +29,7 @@ def _clear_cache(datasets, cache_dir=None, method_map=None):
         print(f"Cleaning the cache directory {cache_dir}!")
         shutil.rmtree(cache_dir)
     else:
-        if not isinstance(datasets, (list, tuple)):
+        if not isinstance(datasets, list | tuple):
             # single dataset method passed should be converted to list
             datasets = [datasets, ]
         for dataset in datasets:

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -339,7 +339,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
         neval += _quadrature.num_eval
 
         if global_integral is None:
-            if isinstance(ig, (float, complex)):
+            if isinstance(ig, float | complex):
                 # Specialize for scalars
                 if norm_func in (_max_norm, np.linalg.norm):
                     norm_func = abs

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -2316,7 +2316,7 @@ class RectSphereBivariateSpline(SphereBivariateSpline):
         ider = np.array([-1, 0, -1, 0], dtype=dfitpack_int)
         if pole_values is None:
             pole_values = (None, None)
-        elif isinstance(pole_values, (float, np.float32, np.float64)):
+        elif isinstance(pole_values, float | np.float32 | np.float64):
             pole_values = (pole_values, pole_values)
         if isinstance(pole_continuity, bool):
             pole_continuity = (pole_continuity, pole_continuity)

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1649,7 +1649,7 @@ class BPoly(_PPolyBase):
         if orders is None:
             orders = [None] * m
         else:
-            if isinstance(orders, (int, np.integer)):
+            if isinstance(orders, int | np.integer):
                 orders = [orders] * m
             k = max(k, max(orders))
 

--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -563,7 +563,7 @@ class netcdf_file:
             types = [(int, NC_INT), (float, NC_FLOAT), (str, NC_CHAR)]
 
             # bytes index into scalars in py3k. Check for "string" types
-            if isinstance(values, (str, bytes)):
+            if isinstance(values, str | bytes):
                 sample = values
             else:
                 try:

--- a/scipy/ndimage/_ni_support.py
+++ b/scipy/ndimage/_ni_support.py
@@ -84,7 +84,7 @@ def _get_output(output, input, shape=None, complex_output=False):
         else:
             complex_type = np.promote_types(input.dtype, np.complex64)
             output = np.zeros(shape, dtype=complex_type)
-    elif isinstance(output, (type, np.dtype)):
+    elif isinstance(output, type | np.dtype):
         # Classes (like `np.float32`) and dtypes are interpreted as dtype
         if complex_output and np.dtype(output).kind != 'c':
             warnings.warn("promoting specified output dtype to complex", stacklevel=3)

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -15,9 +15,9 @@ MODULE_NAME = 'ndimage'
 
 def _maybe_convert_arg(arg, xp):
     """Convert arrays/scalars hiding in the sequence `arg`."""
-    if isinstance(arg, (np.ndarray, np.generic)):
+    if isinstance(arg, np.ndarray | np.generic):
         return xp.asarray(arg)
-    elif isinstance(arg, (list, tuple)):
+    elif isinstance(arg, list | tuple):
         return type(arg)(_maybe_convert_arg(x, xp) for x in arg)
     else:
         return arg

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -936,7 +936,7 @@ def curve_fit(f, xdata, ydata, p0=None, sigma=None, absolute_sigma=False,
     else:
         ydata = np.asarray(ydata, float)
 
-    if isinstance(xdata, (list, tuple, np.ndarray)):
+    if isinstance(xdata, list | tuple | np.ndarray):
         # `xdata` is passed straight to the user-defined `f`, so allow
         # non-array_like `xdata`.
         if check_finite:

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -278,7 +278,7 @@ def root_scalar(f, args=(), method=None, bracket=None,
         raise ValueError(f'Unknown solver {meth}') from e
 
     if meth in ['bisect', 'ridder', 'brentq', 'brenth', 'toms748']:
-        if not isinstance(bracket, (list, tuple, np.ndarray)):
+        if not isinstance(bracket, list | tuple | np.ndarray):
             raise ValueError(f'Bracket needed for {method}')
 
         a, b = bracket[:2]

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -137,7 +137,7 @@ class Complex:
             self.min_cons = constraints
             self.g_cons = []
             self.g_args = []
-            if not isinstance(constraints, (tuple, list)):
+            if not isinstance(constraints, tuple | list):
                 constraints = (constraints,)
 
             for cons in constraints:

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -26,7 +26,7 @@ class StructTestFunction:
 def wrap_constraints(g):
     cons = []
     if g is not None:
-        if not isinstance(g, (tuple, list)):
+        if not isinstance(g, tuple | list):
             g = (g,)
         else:
             pass

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -1354,8 +1354,8 @@ class StateSpace(LinearTimeInvariant):
         )
 
     def _check_binop_other(self, other):
-        return isinstance(other, (StateSpace, np.ndarray, float, complex,
-                                  np.number, int))
+        return isinstance(other, StateSpace | np.ndarray | float | complex |
+                                  np.number | int)
 
     def __mul__(self, other):
         """
@@ -1895,7 +1895,7 @@ def lsim(system, U, T, X0=None, interp=True):
         raise ValueError("Initial time must be nonnegative")
 
     no_input = (U is None or
-                (isinstance(U, (int, float)) and U == 0.) or
+                (isinstance(U, int | float) and U == 0.) or
                 not np.any(U))
 
     if n_steps == 1:
@@ -2260,7 +2260,7 @@ def freqresp(system, w=None, n=10000):
     >>> plt.show()
     """
     if isinstance(system, lti):
-        if isinstance(system, (TransferFunction, ZerosPolesGain)):
+        if isinstance(system, TransferFunction | ZerosPolesGain):
             sys = system
         else:
             sys = system._as_zpk()
@@ -3423,7 +3423,7 @@ def dfreqresp(system, w=None, n=10000, whole=False):
         # No SS->ZPK code exists right now, just SS->TF->ZPK
         system = system._as_tf()
 
-    if not isinstance(system, (TransferFunction, ZerosPolesGain)):
+    if not isinstance(system, TransferFunction | ZerosPolesGain):
         raise ValueError('Unknown system type')
 
     if system.inputs != 1 or system.outputs != 1:

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -1332,7 +1332,7 @@ def _process_axes(ndim_a, ndim_b, axes):
             raise ValueError("axes integer is out of bounds for input arrays")
         axes_a = list(range(ndim_a - axes, ndim_a))
         axes_b = list(range(axes))
-    elif isinstance(axes, (tuple, list)):
+    elif isinstance(axes, tuple | list):
         if len(axes) != 2:
             raise ValueError("axes must be a tuple/list of length 2")
         axes_a, axes_b = axes

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -509,7 +509,7 @@ def broadcast_shapes(*shapes):
     """
     if not shapes:
         return ()
-    shapes = [shp if isinstance(shp, (tuple, list)) else (shp,) for shp in shapes]
+    shapes = [shp if isinstance(shp, tuple | list) else (shp,) for shp in shapes]
     big_shp = max(shapes, key=len)
     out = list(big_shp)
     for shp in shapes:

--- a/scipy/sparse/linalg/_matfuncs.py
+++ b/scipy/sparse/linalg/_matfuncs.py
@@ -596,7 +596,7 @@ def _expm(A, use_exact_onenorm):
     # algorithms.
 
     # Avoid indiscriminate asarray() to allow sparse or other strange arrays.
-    if isinstance(A, (list, tuple, np.matrix)):
+    if isinstance(A, list | tuple | np.matrix):
         A = np.asarray(A)
     if len(A.shape) != 2 or A.shape[0] != A.shape[1]:
         raise ValueError('expected a square matrix')

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -76,9 +76,9 @@ def check_random_state(seed=None):
         Random number generator.
 
     """
-    if seed is None or isinstance(seed, (numbers.Integral, np.integer)):
+    if seed is None or isinstance(seed, numbers.Integral | np.integer):
         return np.random.default_rng(seed)
-    elif isinstance(seed, (np.random.RandomState, np.random.Generator)):
+    elif isinstance(seed, np.random.RandomState | np.random.Generator):
         return seed
     else:
         raise ValueError(f'{seed!r} cannot be used to seed a'

--- a/scipy/stats/_sampling.py
+++ b/scipy/stats/_sampling.py
@@ -1028,7 +1028,7 @@ class FastGeneratorInversion:
         4.507068014335139e-07  # may vary
 
         """
-        if not isinstance(size, (numbers.Integral, np.integer)):
+        if not isinstance(size, numbers.Integral | np.integer):
             raise ValueError("size must be an integer.")
         # urng will be used to draw the samples for testing the error
         # it must not interfere with self.random_state. therefore, do not

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -457,7 +457,7 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
     2.80668351922014
 
     """
-    if not isinstance(p, (int, float)):
+    if not isinstance(p, int | float):
         raise ValueError("Power mean only defined for exponent of type int or "
                          "float.")
     if p == 0:

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -20,7 +20,7 @@ target-version = "py311"
 # `ICN001` added in gh-20382 to enforce common conventions for import.
 # `W292` added in gh-21023 to enforce newlines at end of files.
 select = ["E", "F", "PGH004", "UP", "B006", "B008", "B028", "ICN001", "W292"]
-ignore = ["E741", "UP038"]
+ignore = ["E741"]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Resolves #21547 

#### What does this implement/fix?
Update all isInstance(var, (X, Y)) to isInstance(var, X | Y) in accordance with UP038.

Update lint.toml to no longer ignore UP038

This syntax is more clear on the intended type being checked, and uses modern python type hinting.
ex: (int,float) could be interpreted as a tuple of an int and float, but int | float is very clear 

#### Additional information
This syntax is supported since python 3.10

[lint only]
