### PR TITLE
CI: Use actions/cache 4.2.0

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -88,7 +88,7 @@ jobs:
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
 
     - name: Setup compiler cache
-      uses:  actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      uses:  actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id:    cache-ccache
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,7 +85,7 @@ jobs:
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
 
     - name: Setup compiler cache
-      uses:  actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      uses:  actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id:    cache-ccache
       # Reference: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
       # NOTE: The caching strategy is modeled in a way that it will always have a unique cache key for each workflow run
@@ -312,7 +312,7 @@ jobs:
         sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev ccache gfortran lcov
 
     - name: Caching Python dependencies
-      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: cache
       with:
         path: ~/.cache/pip
@@ -336,7 +336,7 @@ jobs:
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
 
     - name: Setup compiler cache
-      uses:  actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      uses:  actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id:    cache-ccache
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}

--- a/.github/workflows/linux_intel_oneAPI.yml
+++ b/.github/workflows/linux_intel_oneAPI.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: cache install
         id: cache-install
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
               /opt/intel/oneapi/

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -57,7 +57,7 @@ jobs:
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
 
     - name: Setup compiler cache
-      uses:  actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      uses:  actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id:    cache-ccache
       # Reference: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
       # NOTE: The caching strategy is modeled in a way that it will always have
@@ -92,7 +92,7 @@ jobs:
       shell: bash
 
     - name: Cache conda
-      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       env:
         # Increase this value to reset cache if environment.yml has not changed
         CACHE_NUMBER: 1

--- a/.github/workflows/windows_intel_oneAPI.yml
+++ b/.github/workflows/windows_intel_oneAPI.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: cache install
         id: cache-install
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
               C:\Program Files (x86)\Intel\oneAPI\compiler


### PR DESCRIPTION
4.1.2 is deprecated, see https://github.com/scipy/scipy/issues/22515

#### Reference issue
Closes gh-22515

#### What does this implement/fix?
See above

#### Additional information
N/A
