### PR TITLE
ENH: add workers to least_squares

### DIFF
--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -394,10 +394,14 @@ class BaseMixin:
 
         reses = []
         for workers in [None, 2]:
-            res = least_squares(fun_trivial, 2.0, method=self.method, workers=workers)
+            res = least_squares(
+                fun_trivial, 2.0, method=self.method, workers=workers
+            )
             reses.append(res)
         with Pool() as workers:
-            res = least_squares(fun_trivial, 2.0, method=self.method, workers=workers.map)
+            res = least_squares(
+                fun_trivial, 2.0, method=self.method, workers=workers.map
+            )
             reses.append(res)
         for res in reses:
             assert res.success

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -390,6 +390,8 @@ class BaseMixin:
             assert_allclose(res.x, x_opt)
 
     def test_workers(self):
+        serial = least_squares(fun_trivial, 2.0, method=self.method)
+
         reses = []
         for workers in [None, 2]:
             res = least_squares(fun_trivial, 2.0, method=self.method, workers=workers)
@@ -399,6 +401,9 @@ class BaseMixin:
             reses.append(res)
         for res in reses:
             assert res.success
+            assert_equal(res.x, serial.x)
+            assert_equal(res.nfev, serial.nfev)
+            assert_equal(res.njev, serial.njev)
 
 
 class BoundsMixin:

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -1,4 +1,5 @@
 from itertools import product
+from multiprocessing import Pool
 
 import numpy as np
 from numpy.linalg import norm
@@ -387,6 +388,17 @@ class BaseMixin:
                                 ftol=ftol, gtol=gtol, xtol=xtol,
                                 method=self.method)
             assert_allclose(res.x, x_opt)
+
+    def test_workers(self):
+        reses = []
+        for workers in [None, 2]:
+            res = least_squares(fun_trivial, 2.0, method=self.method, workers=workers)
+            reses.append(res)
+        with Pool() as workers:
+            res = least_squares(fun_trivial, 2.0, method=self.method, workers=workers.map)
+            reses.append(res)
+        for res in reses:
+            assert res.success
 
 
 class BoundsMixin:

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -389,6 +389,7 @@ class BaseMixin:
                                 method=self.method)
             assert_allclose(res.x, x_opt)
 
+    @pytest.mark.fail_slow(5.0)
     def test_workers(self):
         serial = least_squares(fun_trivial, 2.0, method=self.method)
 


### PR DESCRIPTION
Adds a `workers` keyword to `least_squares`, to enable parallelisation of numerical differentiation during jacobian estimation.

This keyword will only have an effect for `'dogbox'` or `'trf'`, as `'lm'` carries out numerical differentiation inside `minpack->lmdif`.

It might be possible to apply to `'lm'`, but this would require that the numerical differentiation be handled by Python. I think that means `minpack-->lmder` is used instead. This might lead to a slowdown in the serial case (flow of numerical differentiation is handled by Python instead of C), but would hopefully prove faster in the parallel case. 

In addition I am not sure if that change would be substantially identical in behaviour to what we currently have. 
i.e. is `lmder` with a numerical estimation of the jacobian (2-point forward differences) equivalent to `lmdif` with 2-point forward differences?  If `lmder` assumes that it's Jacobian is analytic it might work differently.