### PR TITLE
MAINT: Remove an extraneous dtype check in `scipy/signal/_waveforms.py`

### DIFF
--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -55,11 +55,7 @@ def sawtooth(t, width=1):
     t, w = asarray(t), asarray(width)
     w = asarray(w + (t - t))
     t = asarray(t + (w - w))
-    if t.dtype.char in ['fFdD']:
-        ytype = t.dtype.char
-    else:
-        ytype = 'd'
-    y = zeros(t.shape, ytype)
+    y = zeros(t.shape, dtype="d")
 
     # width must be between 0 and 1 inclusive
     mask1 = (w > 1) | (w < 0)
@@ -137,12 +133,7 @@ def square(t, duty=0.5):
     t, w = asarray(t), asarray(duty)
     w = asarray(w + (t - t))
     t = asarray(t + (w - w))
-    if t.dtype.char in ['fFdD']:
-        ytype = t.dtype.char
-    else:
-        ytype = 'd'
-
-    y = zeros(t.shape, ytype)
+    y = zeros(t.shape, dtype="d")
 
     # width must be between 0 and 1 inclusive
     mask1 = (w > 1) | (w < 0)

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -378,3 +378,23 @@ class TestUnitImpulse:
 
         imp = waveforms.unit_impulse((5, 2), (3, 1), dtype=complex)
         assert np.issubdtype(imp.dtype, np.complexfloating)
+
+
+class TestSawtoothWaveform:
+    def test_dtype(self):
+        waveform = waveforms.sawtooth(
+            np.array(1, dtype=np.float32), width=np.float32(1)
+        )
+        assert waveform.dtype == np.float64
+
+        waveform = waveforms.sawtooth(1)
+        assert waveform.dtype == np.float64
+
+
+class TestSquareWaveform:
+    def test_dtype(self):
+        waveform = waveforms.square(np.array(1, dtype=np.float32), duty=np.float32(0.5))
+        assert waveform.dtype == np.float64
+
+        waveform = waveforms.square(1)
+        assert waveform.dtype == np.float64


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #22252.

#### What does this implement/fix?
<!--Please explain your changes.-->
Instead of the PR #22253 which fixes the dtype check so that float32 arrays result in float32 output arrays, this PR just removes the extraneous check entirely and now returns only float64 arrays.

This is a backwards compatible change in contrast to #22253 which does change behaviour.

#### Additional information
<!--Any additional information you think is important.-->
I have additionally added tests to make sure that float32 and float64 array inputs result only in float64 array outputs.
