### PR TITLE
ENH: Improve `cdist` Minkowski performance for `p != 0, 1, 2, np.inf`…

### DIFF
--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -547,6 +547,37 @@ py::array cdist(const py::object& out_obj, const py::object& x_obj,
     return out;
 }
 
+py::array_t<double> compute_abs_difference(const py::array_t<double>& a, const py::array_t<double>& b) {
+    const auto buf_a = a.request(), buf_b = b.request();
+    if (buf_a.ndim != 2 || buf_b.ndim != 2) {
+        throw std::runtime_error("Input should be 2-D NumPy arrays");
+    }
+    if (buf_a.shape[1] != buf_b.shape[1]) {
+        throw std::runtime_error("The inner dimensions must match");
+    }
+
+    Py_ssize_t rows_a = buf_a.shape[0], cols_a = buf_a.shape[1];
+    Py_ssize_t rows_b = buf_b.shape[0];
+
+    auto result = py::array_t<double>({rows_a, rows_b, cols_a});
+    const auto buf_result = result.request();
+
+    const auto *a_ptr = static_cast<double *>(buf_a.ptr);
+    const auto *b_ptr = static_cast<double *>(buf_b.ptr);
+    const auto result_ptr = static_cast<double *>(buf_result.ptr);
+
+#pragma omp parallel for
+    for (Py_ssize_t i = 0; i < rows_a; ++i) {
+        for (Py_ssize_t j = 0; j < rows_b; ++j) {
+            for (Py_ssize_t k = 0; k < cols_a; ++k) {
+                result_ptr[i * rows_b * cols_a + j * cols_a + k] = std::abs(a_ptr[i * cols_a + k] - b_ptr[j * cols_a + k]);
+            }
+        }
+    }
+
+    return result;
+}
+
 PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
     if (_import_array() != 0) {
         throw py::error_already_set();
@@ -729,6 +760,7 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
               return cdist(out, x, y, w, BraycurtisDistance{});
           },
           "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
+    m.def("compute_abs_difference", &compute_abs_difference, "Compute the absolute differences between two ndarrays");
 }
 
 }  // namespace (anonymous)


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
Optimized the `cdist` computation for Minkowski distance when `p` is not 0, 1, 2, or `np.inf`, improving performance by approximately 3x. 

Changes include:
- Introduced `compute_abs_difference` in `_distance_pybind` using OpenMP for parallel computation.
- - Implemented `arrayPrepper` to offload absolute difference computation to a C++ extension via `compute_abs_difference` (`_distance_pybind`).
- Created `lp_norm_v2_pList` to call `arrayPrepper` and leverage  efficient NumPy operations (einsum).
- Added a shortcut in `_cdist_callable` to call `lp_norm_v2_pList` when applicable.


#### Additional information
First time making a contribution and I don't have too much formal background in CS. I have a degree in math and just really like CS. I apologize if there's any formality or things I missed. This passed all my tests though. I can also provide an external tester file I made if necessary/desired.
