### PR TITLE
DOC: sparse: add returns sections to some `_construct.py` functions

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -28,6 +28,12 @@ def spdiags(data, diags, m=None, n=None, format=None):
     """
     Return a sparse matrix from diagonals.
 
+    .. warning::
+
+        This function returns a sparse matrix -- not a sparse array.
+        You are encouraged to use ``dia_array`` to take advantage
+        of the sparse array functionality.
+
     Parameters
     ----------
     data : array_like
@@ -50,12 +56,6 @@ def spdiags(data, diags, m=None, n=None, format=None):
     -------
     new_matrix : sparse matrix
         dia_matrix format with values in ``data`` on diagonals from ``diags``.
-
-    .. warning::
-
-        This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``dia_array`` to take advantage
-        of the sparse array functionality.
 
     Notes
     -----
@@ -137,6 +137,10 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
     Each value in the input ``diagonals`` is used.
 
     .. versionadded:: 1.11
+
+    See Also
+    --------
+    dia_array : constructor for the sparse DIAgonal format.
 
     Examples
     --------
@@ -258,11 +262,6 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
         dia_matrix holding the values in `diagonals` offset from the main diagonal
         as indicated in `offsets`.
 
-    See Also
-    --------
-    spdiags : construct matrix from diagonals
-    diags_array : construct sparse array instead of sparse matrix
-
     Notes
     -----
     Repeated diagonal offsets are disallowed.
@@ -280,6 +279,11 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     Each value in the input ``diagonals`` is used.
 
     .. versionadded:: 0.11
+
+    See Also
+    --------
+    spdiags : construct matrix from diagonals
+    diags_array : construct sparse array instead of sparse matrix
 
     Examples
     --------
@@ -452,6 +456,12 @@ def eye(m, n=None, k=0, dtype=float, format=None):
     Returns a sparse matrix (m x n) where the kth diagonal
     is all ones and everything else is zeros.
 
+    .. warning::
+
+        This function returns a sparse matrix -- not a sparse array.
+        You are encouraged to use ``eye_array`` to take advantage
+        of the sparse array functionality.
+
     Parameters
     ----------
     m : int
@@ -465,16 +475,14 @@ def eye(m, n=None, k=0, dtype=float, format=None):
     format : str, optional
         Sparse format of the result, e.g., format="csr", etc.
 
-    .. warning::
-
-        This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``eye_array`` to take advantage
-        of the sparse array functionality.
-
     Returns
     -------
     new_matrix : sparse matrix
         Sparse matrix of chosen shape with ones on the kth diagonaland zeros elsewhere.
+
+    See Also
+    --------
+    eye_array : Sparse array of chosen shape with ones on a specified diagonal.
 
     Examples
     --------

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -124,13 +124,13 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
     -----
     Repeated diagonal offsets are disallowed.
 
-    The result from `diags_array` is the sparse equivalent of::
+    The result from ``diags_array`` is the sparse equivalent of::
 
         np.diag(diagonals[0], offsets[0])
         + ...
         + np.diag(diagonals[k], offsets[k])
 
-    ``diags_array`` differs from ``dia_array`` in the way it handles off-diagonals.
+    ``diags_array`` differs from `dia_array` in the way it handles off-diagonals.
     Specifically, `dia_array` assumes the data input includes padding
     (ignored values) at the start/end of the rows for positive/negative
     offset, while ``diags_array`` assumes the input data has no padding.
@@ -323,7 +323,7 @@ def identity(n, dtype='d', format=None):
     """Identity matrix in sparse format
 
     Returns an identity matrix with shape ``(n, n)`` using a given
-    sparse format and dtype. This differs from ``eye_array`` in
+    sparse format and dtype. This differs from `eye_array` in
     that it has a square shape with ones only on the main diagonal.
     It is thus the multiplicative identity. ``eye_array`` allows
     rectangular shapes and the diagonal can be offset from the main one.
@@ -1164,11 +1164,11 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
         operating system. Types other than `numpy.random.Generator` are
         passed to `numpy.random.default_rng` to instantiate a ``Generator``.
 
-        This random state will be used for sampling `indices` (the sparsity
+        This random state will be used for sampling ``indices`` (the sparsity
         structure), and by default for the data values too (see `data_sampler`).
     data_sampler : callable, optional (default depends on dtype)
-        Sampler of random data values with keyword arg `size`.
-        This function should take a single keyword argument `size` specifying
+        Sampler of random data values with keyword arg ``size``.
+        This function should take a single keyword argument ``size`` specifying
         the length of its returned ndarray. It is used to generate the nonzero
         values in the matrix after the locations of those values are chosen.
         By default, uniform [0, 1) random values are used unless `dtype` is

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -47,7 +47,7 @@ def spdiags(data, diags, m=None, n=None, format=None):
     m, n : int, tuple, optional
         Shape of the result. If `n` is None and `m` is a given tuple,
         the shape is this tuple. If omitted, the matrix is square and
-        its shape is len(data[0]).
+        its shape is ``len(data[0])``.
     format : str, optional
         Format of the result. By default (format=None) an appropriate sparse
         matrix format is returned. This choice is subject to change.
@@ -55,7 +55,7 @@ def spdiags(data, diags, m=None, n=None, format=None):
     Returns
     -------
     new_matrix : sparse matrix
-        `dia_matrix` format with values in `data` on diagonals from `diags`.
+        `dia_matrix` format with values in ``data`` on diagonals from ``diags``.
 
     Notes
     -----

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -46,6 +46,11 @@ def spdiags(data, diags, m=None, n=None, format=None):
         Format of the result. By default (format=None) an appropriate sparse
         matrix format is returned. This choice is subject to change.
 
+    Returns
+    -------
+    new_matrix : sparse matrix
+        dia_matrix format with values in ``data`` on diagonals from ``diags``.
+
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
@@ -109,6 +114,12 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
     dtype : dtype, optional
         Data type of the array.
 
+    Returns
+    -------
+    new_array : dia_array
+        dia_array holding the values in `diagonals` offset from the main diagonal
+        as indicated in `offsets`.
+
     Notes
     -----
     Repeated diagonal offsets are disallowed.
@@ -119,10 +130,10 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
         + ...
         + np.diag(diagonals[k], offsets[k])
 
-    ``diags_array`` differs from `dia_array` in the way it handles off-diagonals.
+    ``diags_array`` differs from ``dia_array`` in the way it handles off-diagonals.
     Specifically, `dia_array` assumes the data input includes padding
     (ignored values) at the start/end of the rows for positive/negative
-    offset, while ``diags_array` assumes the input data has no padding.
+    offset, while ``diags_array`` assumes the input data has no padding.
     Each value in the input ``diagonals`` is used.
 
     .. versionadded:: 1.11
@@ -241,6 +252,12 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     dtype : dtype, optional
         Data type of the matrix.
 
+    Returns
+    -------
+    new_matrix : dia_matrix
+        dia_matrix holding the values in `diagonals` offset from the main diagonal
+        as indicated in `offsets`.
+
     See Also
     --------
     spdiags : construct matrix from diagonals
@@ -259,7 +276,7 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     ``diags`` differs from ``dia_matrix`` in the way it handles off-diagonals.
     Specifically, `dia_matrix` assumes the data input includes padding
     (ignored values) at the start/end of the rows for positive/negative
-    offset, while ``diags` assumes the input data has no padding.
+    offset, while ``diags`` assumes the input data has no padding.
     Each value in the input ``diagonals`` is used.
 
     .. versionadded:: 0.11
@@ -301,16 +318,16 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
 def identity(n, dtype='d', format=None):
     """Identity matrix in sparse format
 
-    Returns an identity matrix with shape (n,n) using a given
+    Returns an identity matrix with shape ``(n, n)`` using a given
     sparse format and dtype. This differs from `eye_array` in
     that it has a square shape with ones only on the main diagonal.
-    It is thus the multiplicative identity. `eye_array` allows
+    It is thus the multiplicative identity. ``eye_array`` allows
     rectangular shapes and the diagonal can be offset from the main one.
 
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``eye_array`` to take advantage
+        You are encouraged to use `eye_array` to take advantage
         of the sparse array functionality.
 
     Parameters
@@ -321,6 +338,16 @@ def identity(n, dtype='d', format=None):
         Data type of the matrix
     format : str, optional
         Sparse format of the result, e.g., format="csr", etc.
+
+    Returns
+    -------
+    new_matrix : sparse matrix
+        A square sparse matrix with ones on (and zeros off) the main diagonal.
+
+    See Also
+    --------
+    eye_array : Sparse array with ones on (and zeros off) the specified diagonal
+    eye : Sparse matrix with ones on (and zeros off) the specified diagonal
 
     Examples
     --------
@@ -341,7 +368,7 @@ def identity(n, dtype='d', format=None):
 
 
 def eye_array(m, n=None, *, k=0, dtype=float, format=None):
-    """Identity matrix in sparse array format
+    """Sparse array with ones on (and zeros off) the specified diagonal
 
     Return a sparse array with ones on diagonal.
     Specifically a sparse array (m x n) where the kth diagonal
@@ -359,6 +386,11 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
         Data type of the array
     format : str, optional (default: "dia")
         Sparse format of the result, e.g., format="csr", etc.
+
+    Returns
+    -------
+    new_array : sparse array
+        A sparse array with ones on (and zeros off) the kth diagonal.
 
     Examples
     --------
@@ -415,7 +447,7 @@ def _eye(m, n, k, dtype, format, as_sparray=True):
 
 
 def eye(m, n=None, k=0, dtype=float, format=None):
-    """Sparse matrix with ones on diagonal
+    """Sparse matrix with ones on (and zeros off) the specified diagonal
 
     Returns a sparse matrix (m x n) where the kth diagonal
     is all ones and everything else is zeros.
@@ -438,6 +470,11 @@ def eye(m, n=None, k=0, dtype=float, format=None):
         This function returns a sparse matrix -- not a sparse array.
         You are encouraged to use ``eye_array`` to take advantage
         of the sparse array functionality.
+
+    Returns
+    -------
+    new_matrix : sparse matrix
+        A sparse matrix with ones on (and zeros off) the kth diagonal.
 
     Examples
     --------

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -31,8 +31,8 @@ def spdiags(data, diags, m=None, n=None, format=None):
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``dia_array`` to take advantage
-        of the sparse array functionality.
+        You are encouraged to use `dia_array` to take advantage
+        of the sparse array functionality. (See Notes below.)
 
     Parameters
     ----------
@@ -59,7 +59,7 @@ def spdiags(data, diags, m=None, n=None, format=None):
 
     Notes
     -----
-    This function can be replaced by an equivalent call to ``dia_matrix``
+    This function can be replaced by an equivalent call to `dia_matrix`
     as::
 
         dia_matrix((data, diags), shape=(m, n)).asformat(format)
@@ -134,7 +134,7 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
     Specifically, `dia_array` assumes the data input includes padding
     (ignored values) at the start/end of the rows for positive/negative
     offset, while ``diags_array`` assumes the input data has no padding.
-    Each value in the input ``diagonals`` is used.
+    Each value in the input `diagonals` is used.
 
     .. versionadded:: 1.11
 
@@ -233,7 +233,7 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``diags_array`` to take advantage
+        You are encouraged to use `diags_array` to take advantage
         of the sparse array functionality.
 
     Parameters
@@ -272,11 +272,11 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
         + ...
         + np.diag(diagonals[k], offsets[k])
 
-    ``diags`` differs from ``dia_matrix`` in the way it handles off-diagonals.
-    Specifically, ``dia_matrix`` assumes the data input includes padding
+    ``diags`` differs from `dia_matrix` in the way it handles off-diagonals.
+    Specifically, `dia_matrix` assumes the data input includes padding
     (ignored values) at the start/end of the rows for positive/negative
     offset, while ``diags`` assumes the input data has no padding.
-    Each value in the input ``diagonals`` is used.
+    Each value in the input `diagonals` is used.
 
     .. versionadded:: 0.11
 
@@ -325,13 +325,13 @@ def identity(n, dtype='d', format=None):
     Returns an identity matrix with shape ``(n, n)`` using a given
     sparse format and dtype. This differs from `eye_array` in
     that it has a square shape with ones only on the main diagonal.
-    It is thus the multiplicative identity. ``eye_array`` allows
+    It is thus the multiplicative identity. `eye_array` allows
     rectangular shapes and the diagonal can be offset from the main one.
 
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``eye_array`` to take advantage
+        You are encouraged to use `eye_array` to take advantage
         of the sparse array functionality.
 
     Parameters
@@ -459,7 +459,7 @@ def eye(m, n=None, k=0, dtype=float, format=None):
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``eye_array`` to take advantage
+        You are encouraged to use `eye_array` to take advantage
         of the sparse array functionality.
 
     Parameters
@@ -825,7 +825,7 @@ def vstack(blocks, format=None, dtype=None):
 
         If you want a sparse array built from blocks that are not sparse
         arrays, use ``block(vstack(blocks))`` or convert one block
-        e.g. `blocks[0] = csr_array(blocks[0])`.
+        e.g. ``blocks[0] = csr_array(blocks[0])``.
 
     See Also
     --------
@@ -853,14 +853,14 @@ def bmat(blocks, format=None, dtype=None):
     """
     Build a sparse array or matrix from sparse sub-blocks
 
-    Note: `block_array` is preferred over `bmat`. They are the same function
-    except that `bmat` can return a deprecated sparse matrix.
-    `bmat` returns a coo_matrix if none of the inputs are a sparse array.
+    Note: `block_array` is preferred over ``bmat``. They are the same function
+    except that ``bmat`` returns a deprecated sparse matrix when none of the
+    inputs are sparse arrays.
 
     .. warning::
 
-        This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``block_array`` to take advantage
+        This function returns a sparse matrix when no inputs are sparse arrays.
+        You are encouraged to use `block_array` to take advantage
         of the sparse array functionality.
 
     Parameters
@@ -1300,7 +1300,7 @@ def random(m, n, density=0.01, format='coo', dtype=None,
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``random_array`` to take advantage of the
+        You are encouraged to use `random_array` to take advantage of the
         sparse array functionality.
 
     Parameters
@@ -1405,7 +1405,7 @@ def rand(m, n, density=0.01, format="coo", dtype=None, rng=None):
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use ``random_array`` to take advantage
+        You are encouraged to use `random_array` to take advantage
         of the sparse array functionality.
 
     Parameters

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -255,8 +255,8 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     Returns
     -------
     new_matrix : dia_matrix
-        dia_matrix holding the values in ``diagonals`` offset from the main diagonal
-        as indicated in ``offsets``.
+        dia_matrix holding the values in `diagonals` offset from the main diagonal
+        as indicated in `offsets`.
 
     See Also
     --------

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -255,8 +255,8 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     Returns
     -------
     new_matrix : dia_matrix
-        dia_matrix holding the values in `diagonals` offset from the main diagonal
-        as indicated in `offsets`.
+        dia_matrix holding the values in ``diagonals`` offset from the main diagonal
+        as indicated in ``offsets``.
 
     See Also
     --------
@@ -267,14 +267,14 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     -----
     Repeated diagonal offsets are disallowed.
 
-    The result from `diags` is the sparse equivalent of::
+    The result from ``diags`` is the sparse equivalent of::
 
         np.diag(diagonals[0], offsets[0])
         + ...
         + np.diag(diagonals[k], offsets[k])
 
     ``diags`` differs from ``dia_matrix`` in the way it handles off-diagonals.
-    Specifically, `dia_matrix` assumes the data input includes padding
+    Specifically, ``dia_matrix`` assumes the data input includes padding
     (ignored values) at the start/end of the rows for positive/negative
     offset, while ``diags`` assumes the input data has no padding.
     Each value in the input ``diagonals`` is used.
@@ -319,7 +319,7 @@ def identity(n, dtype='d', format=None):
     """Identity matrix in sparse format
 
     Returns an identity matrix with shape ``(n, n)`` using a given
-    sparse format and dtype. This differs from `eye_array` in
+    sparse format and dtype. This differs from ``eye_array`` in
     that it has a square shape with ones only on the main diagonal.
     It is thus the multiplicative identity. ``eye_array`` allows
     rectangular shapes and the diagonal can be offset from the main one.
@@ -327,7 +327,7 @@ def identity(n, dtype='d', format=None):
     .. warning::
 
         This function returns a sparse matrix -- not a sparse array.
-        You are encouraged to use `eye_array` to take advantage
+        You are encouraged to use ``eye_array`` to take advantage
         of the sparse array functionality.
 
     Parameters
@@ -342,12 +342,12 @@ def identity(n, dtype='d', format=None):
     Returns
     -------
     new_matrix : sparse matrix
-        A square sparse matrix with ones on (and zeros off) the main diagonal.
+        A square sparse matrix with ones on the main diagonal and zeros elsewhere.
 
     See Also
     --------
-    eye_array : Sparse array with ones on (and zeros off) the specified diagonal
-    eye : Sparse matrix with ones on (and zeros off) the specified diagonal
+    eye_array : Sparse array of chosen shape with ones on a specified diagonal.
+    eye : Sparse matrix of chosen shape with ones on a specified diagonal.
 
     Examples
     --------
@@ -368,7 +368,7 @@ def identity(n, dtype='d', format=None):
 
 
 def eye_array(m, n=None, *, k=0, dtype=float, format=None):
-    """Sparse array with ones on (and zeros off) the specified diagonal
+    """Sparse array of chosen shape with ones on the kth diagonal and zeros elsewhere.
 
     Return a sparse array with ones on diagonal.
     Specifically a sparse array (m x n) where the kth diagonal
@@ -390,7 +390,7 @@ def eye_array(m, n=None, *, k=0, dtype=float, format=None):
     Returns
     -------
     new_array : sparse array
-        A sparse array with ones on (and zeros off) the kth diagonal.
+        Sparse array of chosen shape with ones on the kth diagonal and zeros elsewhere.
 
     Examples
     --------
@@ -447,7 +447,7 @@ def _eye(m, n, k, dtype, format, as_sparray=True):
 
 
 def eye(m, n=None, k=0, dtype=float, format=None):
-    """Sparse matrix with ones on (and zeros off) the specified diagonal
+    """Sparse matrix of chosen shape with ones on the kth diagonal and zeros elsewhere.
 
     Returns a sparse matrix (m x n) where the kth diagonal
     is all ones and everything else is zeros.
@@ -474,7 +474,7 @@ def eye(m, n=None, k=0, dtype=float, format=None):
     Returns
     -------
     new_matrix : sparse matrix
-        A sparse matrix with ones on (and zeros off) the kth diagonal.
+        Sparse matrix of chosen shape with ones on the kth diagonaland zeros elsewhere.
 
     Examples
     --------

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -55,7 +55,7 @@ def spdiags(data, diags, m=None, n=None, format=None):
     Returns
     -------
     new_matrix : sparse matrix
-        dia_matrix format with values in ``data`` on diagonals from ``diags``.
+        `dia_matrix` format with values in `data` on diagonals from `diags`.
 
     Notes
     -----
@@ -117,7 +117,7 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None)
     Returns
     -------
     new_array : dia_array
-        dia_array holding the values in `diagonals` offset from the main diagonal
+        `dia_array` holding the values in `diagonals` offset from the main diagonal
         as indicated in `offsets`.
 
     Notes
@@ -259,7 +259,7 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     Returns
     -------
     new_matrix : dia_matrix
-        dia_matrix holding the values in `diagonals` offset from the main diagonal
+        `dia_matrix` holding the values in `diagonals` offset from the main diagonal
         as indicated in `offsets`.
 
     Notes


### PR DESCRIPTION
This adds `Returns` sections to the docs as noted in #22065.  The discussion there branched into how to monitor and gradually implement `Returns` sections in all functions across SciPy. But this PR sticks to the original post in #22065 which noted that a number of functions in `sparse._construct.py` don't have `Returns` sections.

I did not add that section for `save_npz` because it returns None (doesn't have a return statement).

I also cleaned up some backticks and changed a few words:
- added See Also section to `identity()`
- changed the first line of `eye` and `eye_array` to remove the word Identity and also state that the diagonal of ones could be controlled.  Now reads: `Sparse array with ones on (and zeros off) the specified diagonal`

I'm not sure that this closes #22065 because of the larger discussion there. But maybe @WarrenWeckesser can make a judgement for whether to close that when this is merged.