### PR TITLE
DOC: interpolate: improve visibility of univariate interpolator method documentation

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -560,7 +560,7 @@ class BSpline:
 
         Returns
         -------
-        b : BSpline object
+        b : `BSpline` object
             A new instance representing the derivative.
 
         See Also
@@ -587,7 +587,7 @@ class BSpline:
 
         Returns
         -------
-        b : BSpline object
+        b : `BSpline` object
             A new instance representing the antiderivative.
 
         Notes
@@ -768,7 +768,7 @@ class BSpline:
 
         Returns
         -------
-        b : BSpline object
+        b : `BSpline` object
             A new instance representing the initial polynomial
             in the B-spline basis.
 
@@ -870,8 +870,8 @@ class BSpline:
 
         Returns
         -------
-        spl : BSpline object
-            A new BSpline object with the new knot inserted.
+        spl : `BSpline` object
+            A new `BSpline` object with the new knot inserted.
 
         Notes
         -----
@@ -1292,7 +1292,8 @@ def _make_periodic_spline(x, y, t, k, axis):
 
     Returns
     -------
-    b : a BSpline object of the degree ``k`` and with knots ``t``.
+    b : `BSpline` object
+        A `BSpline` object of the degree ``k`` and with knots ``t``.
 
     Notes
     -----
@@ -1412,7 +1413,8 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     Returns
     -------
-    b : a BSpline object of the degree ``k`` and with knots ``t``.
+    b : `BSpline` object
+        A `BSpline` object of the degree ``k`` and with knots ``t``.
 
     See Also
     --------
@@ -1687,7 +1689,8 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True, *, method="
 
     Returns
     -------
-    b : a BSpline object of the degree ``k`` with knots ``t``.
+    b : `BSpline` object
+        A `BSpline` object of the degree ``k`` with knots ``t``.
 
     See Also
     --------
@@ -2203,8 +2206,8 @@ def make_smoothing_spline(x, y, w=None, lam=None, *, axis=0):
 
     Returns
     -------
-    func : a BSpline object.
-        A callable representing a spline in the B-spline basis
+    func : `BSpline` object
+        An object representing a spline in the B-spline basis
         as a solution of the problem of smoothing splines using
         the GCV criteria [1] in case ``lam`` is None, otherwise using the
         given parameter ``lam``.

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -109,6 +109,15 @@ class CubicHermiteSpline(PPoly):
         Interpolation axis. The same axis which was passed to the
         constructor.
 
+    Methods
+    -------
+    __call__
+    derivative
+    antiderivative
+    integrate
+    solve
+    roots
+
     See Also
     --------
     Akima1DInterpolator : Akima 1D interpolator.
@@ -171,6 +180,16 @@ class PchipInterpolator(CubicHermiteSpline):
     extrapolate : bool, optional
         Whether to extrapolate to out-of-bounds points based on first
         and last intervals, or to return NaNs.
+
+    Methods
+    -------
+    __call__
+    derivative
+    antiderivative
+    integrate
+    solve
+    roots
+
 
     See Also
     --------
@@ -392,6 +411,15 @@ class Akima1DInterpolator(CubicHermiteSpline):
         If bool, determines whether to extrapolate to out-of-bounds points
         based on first and last intervals, or to return NaNs. If None,
         ``extrapolate`` is set to False.
+
+    Methods
+    -------
+    __call__
+    derivative
+    antiderivative
+    integrate
+    solve
+    roots
 
     See Also
     --------
@@ -615,6 +643,15 @@ class CubicSpline(CubicHermiteSpline):
     axis : int
         Interpolation axis. The same axis which was passed to the
         constructor.
+
+    Methods
+    -------
+    __call__
+    derivative
+    antiderivative
+    integrate
+    solve
+    roots
 
     See Also
     --------

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -109,14 +109,6 @@ class CubicHermiteSpline(PPoly):
         Interpolation axis. The same axis which was passed to the
         constructor.
 
-    Methods
-    -------
-    __call__
-    derivative
-    antiderivative
-    integrate
-    roots
-
     See Also
     --------
     Akima1DInterpolator : Akima 1D interpolator.
@@ -179,14 +171,6 @@ class PchipInterpolator(CubicHermiteSpline):
     extrapolate : bool, optional
         Whether to extrapolate to out-of-bounds points based on first
         and last intervals, or to return NaNs.
-
-    Methods
-    -------
-    __call__
-    derivative
-    antiderivative
-    integrate
-    roots
 
     See Also
     --------
@@ -408,14 +392,6 @@ class Akima1DInterpolator(CubicHermiteSpline):
         If bool, determines whether to extrapolate to out-of-bounds points
         based on first and last intervals, or to return NaNs. If None,
         ``extrapolate`` is set to False.
-
-    Methods
-    -------
-    __call__
-    derivative
-    antiderivative
-    integrate
-    roots
 
     See Also
     --------
@@ -639,14 +615,6 @@ class CubicSpline(CubicHermiteSpline):
     axis : int
         Interpolation axis. The same axis which was passed to the
         constructor.
-
-    Methods
-    -------
-    __call__
-    derivative
-    antiderivative
-    integrate
-    roots
 
     See Also
     --------


### PR DESCRIPTION
#### What does this implement/fix?

This makes two adjustments to improve the visibility of univariate interpolator method documentation:

- Adds backticks to appearances of "BSpline" in the return section of functions/methods, making it easier to get to the `BSpline` documentation and its method list.
- Removes the "Methods" documentation section of some `PPoly` subclasses to ensure that all available methods are visible.

There might be similar issues to fix elsewhere (e.g. multivariate interpolator docs), but this is what I chose to target in this PR. Feel free to push commits, though.

#### Additional information
Let's be sure to check how the Methods sections render before merging : ) Sphinx works in mysterious ways.
