### PR TITLE
DOC: update roadmap sparse

### DIFF
--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -349,20 +349,24 @@ some point).
 
 What we want is sparse arrays that act like ``numpy.ndarray``. Initial
 support for a new set of classes (``csr_array`` et al.) was added in SciPy
-``1.8.0`` and stabilized in ``1.12.0`` when construction functions for
-arrays were added. Support for 1-D array is expected in ``1.13.0``.
+``1.8.0`` and stabilized in ``1.12.0`` with construction functions for
+arrays, ``1.14.0`` with 1D array support and ``1.15.0`` with 1D indexing.
+The sparse array codebase now supports all sparse matrix features and in
+addition supports 1D arrays and the first steps toward nD arrays.
+There is a transition guide to help users and libraries convert their code
+to sparse arrays.
 
-Next steps toward sparse array support:
+Next steps toward sparse array conversion:
 
-- Extend sparse array API to 1-D arrays.
+- Extend sparse array API to nD arrays.
     - Support for COO, CSR and DOK formats.
-    - CSR 1D support for min-max, indexing, arithmetic.
+    - Some COO features exist in 1.15.
+- Introduce support for broadcasting in operations where sparse formats
+  can effectively do that.
 - Help other libraries convert to sparse arrays from sparse matrices.
-  Create transition guide and helpful scripts to flag code that needs
-  further examination. NetworkX, scikit-learn and scikit-image are in
+  NetworkX, dipy, scikit-image, pyamg, cvxpy and scikit-learn are in
   progress or have completed conversion to sparse arrays.
-- After sparse array code is mature (~1 release cycle?) add deprecation
-  warnings for sparse matrix.
+- Add deprecation warnings for sparse matrix.
 - Work with NumPy on deprecation/removal of ``numpy.matrix``.
 - Deprecate and then remove sparse matrix in favor of sparse array.
 - Start API shift of construction function names (``diags``, ``block``, etc.)

--- a/doc/source/dev/roadmap.rst
+++ b/doc/source/dev/roadmap.rst
@@ -63,18 +63,25 @@ possible then.  Finally, resolving open AIX build issues would help users.
 Implement sparse arrays in addition to sparse matrices
 ------------------------------------------------------
 
-The sparse matrix formats are mostly feature-complete, however the main issue
+SciPy sparse matrices are being replaced by sparse arrays.
+The sparse matrix formats are mostly feature-complete, however their main issue
 is that they act like ``numpy.matrix`` (which will be deprecated in NumPy at
 some point). What we want is sparse *arrays* that act like ``numpy.ndarray``
 (See discussion at `gh-18915 <https://github.com/scipy/scipy/issues/18915>`_).
-Sparse arrays have largely been implemented in ``scipy.sparse`` at this time.
-Some functionality is still being completed. The future plan is:
+Sparse arrays support all features of sparse matrices as of 1.15.
+In addition to 2D arrays, 1D sparse arrays are supported in DOK, COO, CSR formats.
+Further functionality e.g. nD array support and broadcasting for some operations
+is being developed.  The future plan is:
 
-- Provide a feature-complete sparse array API (including 1D-array).
-    - Extend sparse array API to 1D arrays:
-        - COO, CSR and DOK formats.
-        - The CSR 1D format uses 2D CSR code to do 1D things like
-          indexing/min-max/arithmetic.
+- Extend sparse array API to nD arrays:
+    - COO, CSR and DOK formats. COO format already partially in place.
+    - The nD formats use 2D CSR code to do nD things like
+      indexing/min-max/arithmetic.
+- Sparse array binary operations will support broadcasting in some settings.
+  Broadcasting is tricky for sparse arrays because it leans heavily on the strided
+  memory model of dense arrays, and so does not always fit sparse data formats.
+  Our optimistic goal is to support broadcasting for all operations where that
+  makes sense for sparse data structures. We start with binary operations like `A + B`.
 - Help other libraries convert to sparse arrays from sparse matrices.
   Create transition guide and helpful scripts to flag code that needs changing.
 - Deprecate and then remove "sparse matrix" in favor of "sparse array".


### PR DESCRIPTION
In support of #22209 and because the sparse roadmap descriptions are out of date:
this PR updates the sparse portions of the scipy roadmap and the detailed roadmap documents.

Suggestions welcome.