### PR TITLE
DOC: io: link to netcdf4-python

### DIFF
--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -132,9 +132,13 @@ class netcdf_file:
 
     Notes
     -----
+    This module is derived from
+    `pupynere <https://bitbucket.org/robertodealmeida/pupynere/>`_.
     The major advantage of this module over other modules is that it doesn't
-    require the code to be linked to the NetCDF libraries. This module is
-    derived from `pupynere <https://bitbucket.org/robertodealmeida/pupynere/>`_.
+    require the code to be linked to the NetCDF libraries. However, for a more
+    recent version of the NetCDF standard and additional features, please consider
+    the permissively-licensed
+    `netcdf4-python <https://unidata.github.io/netcdf4-python/>`_.
 
     NetCDF files are a self-describing binary data format. The file contains
     metadata that describes the dimensions and variables in the file. More
@@ -855,6 +859,12 @@ class netcdf_variable:
     See also
     --------
     isrec, shape
+
+    Notes
+    -----
+    For a more recent version of the NetCDF standard and additional features, please
+    consider the permissively-licensed
+    `netcdf4-python <https://unidata.github.io/netcdf4-python/>`_.
 
     """
     def __init__(self, data, typecode, size, shape, dimensions,


### PR DESCRIPTION
#### Reference issue
gh-9157

#### What does this implement/fix?
The conclusion of gh-9157 was that while improvements to our NetCDF features would be appreciated, it would be a good idea to refer users to [netcdf4-python](https://github.com/Unidata/netcdf4-python) in the meantime. This adds a link to the Notes sections of our two NetCDF features.