### PR TITLE
DOC: Add docstring for QhullError in _qhull.pyx [docs only]

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -219,6 +219,10 @@ qhull_misc_lib_check()
 
 
 class QhullError(RuntimeError):
+    """
+    Raised when Qhull encounters an error condition, such as 
+    geometrical degeneracy when options to resolve are not enabled.
+    """
     pass
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Add docstring for QhullError in _qhull.pyx:
"Raised when Qhull encounters an error condition, such as geometrical degeneracy when options to resolve are not enabled."


#### Additional information
<!--Any additional information you think is important.-->
