### PR TITLE
DOC: interpolate.lagrange: add notes / references; recommend `BarycentricInterpolator`

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -38,6 +38,23 @@ def lagrange(x, w):
     lagrange : `numpy.poly1d` instance
         The Lagrange interpolating polynomial.
 
+    Notes
+    -----
+    The name of this function refers to the fact that the returned object represents
+    a Lagrange polynomial, the unique polynomial of lowest degree that interpolates
+    a given set of data [1]_. It computes the polynomial using Newton's divided
+    differences formula [2]_; that is, it works with Newton basis polynomials rather
+    than Lagrange basis polynomials. For numerical calculations, the barycentric form
+    of Lagrange interpolation (`scipy.interpolate.BarycentricInterpolator`) is
+    typically more appropriate.
+
+    References
+    ----------
+    .. [1] Lagrange polynomial. *Wikipedia*.
+           https://en.wikipedia.org/wiki/Lagrange_polynomial
+    .. [2] Newton polynomial. *Wikipedia*.
+           https://en.wikipedia.org/wiki/Newton_polynomial
+
     Examples
     --------
     Interpolate :math:`f(x) = x^3` by 3 points.
@@ -48,7 +65,7 @@ def lagrange(x, w):
     >>> y = x**3
     >>> poly = lagrange(x, y)
 
-    Since there are only 3 points, Lagrange polynomial has degree 2. Explicitly,
+    Since there are only 3 points, the Lagrange polynomial has degree 2. Explicitly,
     it is given by
 
     .. math::


### PR DESCRIPTION
#### Reference issue
Closes gh-22488

#### What does this implement/fix?
gh-22488 notes that `scipy.interpolate.lagrange` works with Newton basis polynomials rather than Lagrange basis polynomials via "Newton's divided differences formula" and that the barycentric form of Lagrange interpolation is typically preferred. This PR adds this information to the function documentation.
