### PR TITLE
ENH: use `workers` keyword in `optimize._differentiable_functions.VectorFunction`

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -481,7 +481,10 @@ class VectorFunction:
             finite_diff_options["method"] = hess
             finite_diff_options["rel_step"] = finite_diff_rel_step
             finite_diff_options["as_linear_operator"] = True
-
+            # workers is not useful for evaluation of the LinearOperator
+            # produced by approx_derivative. Only two/three function
+            # evaluations are used, and the LinearOperator may persist
+            # outside the scope that workers is valid in.
             self.x_diff = np.copy(self.x)
         if jac in FD_METHODS and hess in FD_METHODS:
             raise ValueError("Whenever the Jacobian is estimated via "
@@ -602,9 +605,9 @@ class VectorFunction:
             def update_hess():
                 self._update_jac()
                 self.H = approx_derivative(jac_dot_v, self.x,
-                                          f0=self.J.T.dot(self.v),
-                                          args=(self.v,),
-                                          **finite_diff_options)
+                                           f0=self.J.T.dot(self.v),
+                                           args=(self.v,),
+                                           **finite_diff_options)
 
             update_hess()
             self.H_updated = True

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -12,7 +12,7 @@ from scipy._lib._util import _ScalarFunctionWrapper
 FD_METHODS = ('2-point', '3-point', 'cs')
 
 
-class _GradWrapper:
+class _ScalarGradWrapper:
     """
     Wrapper class for gradient calculation
     """
@@ -49,7 +49,7 @@ class _GradWrapper:
         return g
 
 
-class _HessWrapper:
+class _ScalarHessWrapper:
     """
     Wrapper class for hess calculation via finite differences
     """
@@ -273,7 +273,7 @@ class ScalarFunction:
         self._update_fun()
 
         # Initial gradient evaluation
-        self._wrapped_grad = _GradWrapper(
+        self._wrapped_grad = _ScalarGradWrapper(
             grad,
             fun=self._wrapped_fun,
             args=args,
@@ -292,7 +292,7 @@ class ScalarFunction:
             self._wrapped_hess = _FakeCounter(ngev=0, nhev=0)
         else:
             if callable(hess):
-                self._wrapped_hess = _HessWrapper(
+                self._wrapped_hess = _ScalarHessWrapper(
                     hess,
                     x0=x0,
                     args=args,
@@ -301,7 +301,7 @@ class ScalarFunction:
                 self.H = self._wrapped_hess.H
                 self.H_updated = True
             elif hess in FD_METHODS:
-                self._wrapped_hess = _HessWrapper(
+                self._wrapped_hess = _ScalarHessWrapper(
                     hess,
                     x0=x0,
                     args=args,

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -481,8 +481,6 @@ class VectorFunction:
             finite_diff_options["method"] = hess
             finite_diff_options["rel_step"] = finite_diff_rel_step
             finite_diff_options["as_linear_operator"] = True
-            finite_diff_options["workers"] = workers
-            finite_diff_options["full_output"] = True
 
             self.x_diff = np.copy(self.x)
         if jac in FD_METHODS and hess in FD_METHODS:
@@ -603,10 +601,10 @@ class VectorFunction:
 
             def update_hess():
                 self._update_jac()
-                self.H, dct = approx_derivative(jac_dot_v, self.x,
-                                                f0=self.J.T.dot(self.v),
-                                                args=(self.v,),
-                                                **finite_diff_options)
+                self.H = approx_derivative(jac_dot_v, self.x,
+                                          f0=self.J.T.dot(self.v),
+                                          args=(self.v,),
+                                          **finite_diff_options)
 
             update_hess()
             self.H_updated = True

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -207,8 +207,8 @@ class ScalarFunction:
            will be set. However, a subsequent call with a different argument
            of *any* of the methods may overwrite the attribute.
     """
-    def __init__(self, fun, x0, args, grad, hess, finite_diff_rel_step,
-                 finite_diff_bounds, epsilon=None, workers=None):
+    def __init__(self, fun, x0, args, grad, hess, finite_diff_rel_step=None,
+                 finite_diff_bounds=(-np.inf, np.inf), epsilon=None, workers=None):
 
         if not callable(grad) and grad not in FD_METHODS:
             raise ValueError(
@@ -428,8 +428,8 @@ class VectorFunction:
            of *any* of the methods may overwrite the attribute.
     """
     def __init__(self, fun, x0, jac, hess,
-                 finite_diff_rel_step, finite_diff_jac_sparsity,
-                 finite_diff_bounds, sparse_jacobian, workers=None):
+                 finite_diff_rel_step=None, finite_diff_jac_sparsity=None,
+                 finite_diff_bounds=None, sparse_jacobian=None, workers=None):
         if not callable(jac) and jac not in FD_METHODS:
             raise ValueError(f"`jac` must be either callable or one of {FD_METHODS}.")
 

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -390,7 +390,10 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         Dictionary containing extra information about the calculation. The
         keys include:
 
-        - `nfev`, number of function evaluations.
+        - `nfev`, number of function evaluations. If `as_linear_operator` is True
+           then `fun` is expected to track the number of evaluations itself.
+           This is because multiple calls may be made to the linear operator which
+           are not trackable here.
 
     See Also
     --------
@@ -555,8 +558,8 @@ def approx_derivative(fun, x0, method='3-point', rel_step=None, abs_step=None,
         if rel_step is None:
             rel_step = _eps_for_method(x0.dtype, f0.dtype, method)
 
-        J, _nfev = _linear_operator_difference(fun_wrapped, x0,
-                                               f0, rel_step, method)
+        J, _ = _linear_operator_difference(fun_wrapped, x0,
+                                           f0, rel_step, method)
     else:
         # by default we use rel_step
         if abs_step is None:
@@ -619,7 +622,7 @@ def _linear_operator_difference(fun, x0, f0, h, method):
     n = x0.size
 
     if method == '2-point':
-        nfev = 1
+        # nfev = 1
         def matvec(p):
             if np.array_equal(p, np.zeros_like(p)):
                 return np.zeros(m)
@@ -629,7 +632,7 @@ def _linear_operator_difference(fun, x0, f0, h, method):
             return df / dx
 
     elif method == '3-point':
-        nfev = 2
+        # nfev = 2
         def matvec(p):
             if np.array_equal(p, np.zeros_like(p)):
                 return np.zeros(m)
@@ -642,7 +645,7 @@ def _linear_operator_difference(fun, x0, f0, h, method):
             return df / dx
 
     elif method == 'cs':
-        nfev = 1
+        # nfev = 1
         def matvec(p):
             if np.array_equal(p, np.zeros_like(p)):
                 return np.zeros(m)
@@ -651,11 +654,10 @@ def _linear_operator_difference(fun, x0, f0, h, method):
             f1 = fun(x)
             df = f1.imag
             return df / dx
-
     else:
         raise RuntimeError("Never be here.")
 
-    return LinearOperator((m, n), matvec), nfev
+    return LinearOperator((m, n), matvec), 0
 
 
 def _dense_difference(fun, x0, f0, h, use_one_sided, method, workers):

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -607,6 +607,9 @@ class TestVectorialFunction(TestCase):
             assert_equal(approx.nhev, approx_series.nhev)
             assert_equal(approx_series.nhev, ex2.nhev)
 
+            # The following tests are somewhat redundant because the LinearOperator
+            # produced by VectorFunction.hess does not use any parallelisation.
+            # The tests are left for completeness, in case that situation changes.
             ex.nfev = ex.njev = ex.nhev = 0
             ex2.nfev = ex2.njev = ex2.nhev = 0
             approx = VectorFunction(ex.fun, x0, ex.jac,

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -568,7 +568,6 @@ class TestVectorialFunction(TestCase):
         x0 = np.array([2.5, 3.0])
         ex = ExVectorialFunction()
         ex2 = ExVectorialFunction()
-        ana = ExVectorialFunction()
         v = np.array([1.0, 2.0])
 
         with MapWrapper(2) as mapper:

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -563,6 +563,74 @@ class TestVectorialFunction(TestCase):
         assert_array_almost_equal(f_analit, f_approx)
         assert_array_almost_equal(J_analit, J_approx)
 
+    @pytest.mark.fail_slow(5.0)
+    def test_workers(self):
+        x0 = np.array([2.5, 3.0])
+        ex = ExVectorialFunction()
+        ex2 = ExVectorialFunction()
+        ana = ExVectorialFunction()
+        v = np.array([1.0, 2.0])
+
+        with MapWrapper(2) as mapper:
+            approx = VectorFunction(ex.fun, x0, '2-point',
+                                    ex.hess, None, None, (-np.inf, np.inf),
+                                    False, workers=mapper)
+            approx_series = VectorFunction(ex2.fun, x0, '2-point',
+                                           ex2.hess, None, None, (-np.inf, np.inf),
+                                           False)
+
+            assert_allclose(approx.jac(x0), ex.jac(x0))
+            assert_allclose(approx_series.jac(x0), ex.jac(x0))
+            assert_allclose(approx_series.hess(x0, v), ex.hess(x0, v))
+            assert_allclose(approx.hess(x0, v), ex.hess(x0, v))
+            assert_equal(approx.nfev, approx_series.nfev)
+            assert_equal(approx_series.nfev, ex2.nfev)
+            assert_equal(approx.njev, approx_series.njev)
+            assert_equal(approx.nhev, approx_series.nhev)
+            assert_equal(approx_series.nhev, ex2.nhev)
+
+            ex.nfev = ex.njev = ex.nhev = 0
+            ex2.nfev = ex2.njev = ex2.nhev = 0
+            approx = VectorFunction(ex.fun, x0, '3-point',
+                                    ex.hess, None, None, (-np.inf, np.inf),
+                                    False, workers=mapper)
+            approx_series = VectorFunction(ex2.fun, x0, '3-point',
+                                           ex2.hess, None, None, (-np.inf, np.inf),
+                                           False)
+            assert_allclose(approx.jac(x0), ex.jac(x0))
+            assert_allclose(approx_series.jac(x0), ex.jac(x0))
+            assert_allclose(approx_series.hess(x0, v), ex.hess(x0, v))
+            assert_allclose(approx.hess(x0, v), ex.hess(x0, v))
+
+            assert_equal(approx.nfev, approx_series.nfev)
+            assert_equal(approx_series.nfev, ex2.nfev)
+            assert_equal(approx.njev, approx_series.njev)
+            assert_equal(approx.nhev, approx_series.nhev)
+            assert_equal(approx_series.nhev, ex2.nhev)
+
+            ex.nfev = ex.njev = ex.nhev = 0
+            ex2.nfev = ex2.njev = ex2.nhev = 0
+            approx = VectorFunction(ex.fun, x0, ex.jac,
+                                    '2-point', None, None, (-np.inf, np.inf),
+                                    False, workers=mapper)
+            approx_series = VectorFunction(ex2.fun, x0, ex2.jac,
+                                           '2-point', None, None, (-np.inf, np.inf),
+                                           False)
+            assert_allclose(approx.jac(x0), ex.jac(x0))
+            assert_allclose(approx_series.jac(x0), ex.jac(x0))
+
+            H_analit = ex2.hess(x0, v)
+            H_approx_series = approx_series.hess(x0, v)
+            H_approx = approx.hess(x0, v)
+            x = [5, 2.0]
+            assert_allclose(H_approx.dot(x), H_analit.dot(x))
+            assert_allclose(H_approx_series.dot(x), H_analit.dot(x))
+
+            assert_equal(approx.nfev, approx_series.nfev)
+            assert_equal(approx_series.nfev, ex2.nfev)
+            assert_equal(approx.njev, approx_series.njev)
+            assert_equal(approx.nhev, approx_series.nhev)
+
     def test_finite_difference_hess_linear_operator(self):
         ex = ExVectorialFunction()
         nfev = 0


### PR DESCRIPTION
This PR adds the `workers` keyword to `VectorFunction`. The workers aid parallel evaluation of the jacobian when using finite differences. The keyword has no effect on the finite difference estimation of the hessian as this is carried out with a `LinearOperator` that only uses a small number of function evaluations.

Parallelising `VectorFunction` is a precursor step to using it in `optimize.least_squares` where its memoisation will reduce the number of function evaluations, as well as allowing the parallelisation of the `lm` method. 