### PR TITLE
MAINT: optimize: remove unnecessary `not_first_iteration` boolean variable in `scalar_search_wolfe2`

### DIFF
--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -390,10 +390,10 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
     if derphi0 is None:
         derphi0 = derphi(0.)
     if derphi0 == 0.0:
-       alpha_star = 0.0
-       phi_star = phi0
-       derphi_star = derphi0
-       return alpha_star, phi_star, phi0, derphi_star
+        alpha_star = 0.0
+        phi_star = phi0
+        derphi_star = derphi0
+        return alpha_star, phi_star, phi0, derphi_star
 
     alpha0 = 0
     if old_phi0 is not None and derphi0 != 0:

--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -450,7 +450,7 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
                 derphi_star = derphi_a1
                 break
 
-        if (derphi_a1 >= 0):
+        if derphi_a1 > 0:
             alpha_star, phi_star, derphi_star = \
                         _zoom(alpha1, alpha0, phi_a1,
                               phi_a0, derphi_a1, phi, derphi,

--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -389,6 +389,11 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
 
     if derphi0 is None:
         derphi0 = derphi(0.)
+    if derphi0 == 0.0:
+       alpha_star = 0.0
+       phi_star = phi0
+       derphi_star = derphi0
+       return alpha_star, phi_star, phi0, derphi_star
 
     alpha0 = 0
     if old_phi0 is not None and derphi0 != 0:

--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -430,9 +430,7 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
             warn(msg, LineSearchWarning, stacklevel=2)
             break
 
-        not_first_iteration = i > 0
-        if (phi_a1 > phi0 + c1 * alpha1 * derphi0) or \
-           ((phi_a1 >= phi_a0) and not_first_iteration):
+        if (phi_a1 > phi0 + c1 * alpha1 * derphi0) or (phi_a1 >= phi_a0):
             alpha_star, phi_star, derphi_star = \
                         _zoom(alpha0, alpha1, phi_a0,
                               phi_a1, derphi_a0, phi, derphi,


### PR DESCRIPTION
remove unnecessary `not_first_iteration` boolean variable in scalar_search_wolfe2

#### Reference issue
https://github.com/scipy/scipy/issues/22550

#### What does this implement/fix?
<!--Please explain your changes.-->
fixes https://github.com/scipy/scipy/issues/22550
