### PR TITLE
MAINT: sparse.csgraph: Raise error if ``predecessors.dtype != ITYPE`` in ``construct_dist_matrix``

### DIFF
--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -557,14 +557,14 @@ def construct_dist_matrix(graph,
 
     Notes
     -----
-    The predecessor matrix is of the form returned by
+    The predecessor matrix is of the form optionally returned by
     `shortest_path`.  Row i of the predecessor matrix contains
     information on the shortest paths from point i: each entry
     predecessors[i, j] gives the index of the previous node in the path from
     point i to point j.  If no path exists between point i and j, then
     predecessors[i, j] = -9999
 
-    It should be noted that `shortest_path` also returns distance matrix
+    It should be noted that `shortest_path` only returns distance matrix
     by default. With `return_predecessors=True`, it returns a tuple with
     distance matrix as its first element and predecessors array as second
     element.

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -564,6 +564,11 @@ def construct_dist_matrix(graph,
     point i to point j.  If no path exists between point i and j, then
     predecessors[i, j] = -9999
 
+    It should be noted that `shortest_path` also returns distance matrix
+    by default. With `return_predecessors=True`, it returns a tuple with
+    distance matrix as its first element and predecessors array as second
+    element.
+
     Examples
     --------
     >>> import numpy as np

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -565,7 +565,7 @@ def construct_dist_matrix(graph,
     predecessors[i, j] = -9999
 
     It should be noted that `shortest_path` only returns distance matrix
-    by default. With `return_predecessors=True`, it returns a tuple with
+    by default. With ``return_predecessors=True``, it returns a tuple with
     distance matrix as its first element and predecessors array as second
     element.
 

--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -609,6 +609,9 @@ def construct_dist_matrix(graph,
                            copy_if_dense=not directed)
     predecessors = np.asarray(predecessors)
 
+    if predecessors.dtype != ITYPE:
+        raise TypeError("Type of predecessors array should be np.int32")
+
     if predecessors.shape != graph.shape:
         raise ValueError("graph and predecessors must have the same shape")
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -333,6 +333,15 @@ def test_construct_shortest_path():
         for directed in (True, False):
             check(method, directed)
 
+@pytest.mark.parametrize("directed", [True, False])
+def test_construct_dist_matrix_predecessors_error(directed):
+    SP1, pred = shortest_path(directed_G,
+                                directed=directed,
+                                overwrite=False,
+                                return_predecessors=True)
+    assert_raises(TypeError, construct_dist_matrix,
+                  directed_G, pred.astype(np.int64), directed)
+
 
 def test_unweighted_path():
     def check(method, directed):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/22449

#### What does this implement/fix?
<!--Please explain your changes.-->

As the diff suggests I have added a `TypeError` if ``predecessors.dtype != ITYPE`` in ``construct_dist_matrix``. This is inline with https://github.com/scipy/scipy/issues/22449#issuecomment-2660889544. 

A documentation improvement has also been made to avoid confusion in the API of ``construct_dist_matrix``.

A single PR is being made because both are very small changes. If you want me to fork out one change in another PR, let me know, I will do so.

#### Additional information
<!--Any additional information you think is important.-->
