### PR TITLE
ENH: sparse: add `__binsparse__` protocol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,3 +29,5 @@ scipy/special/tests/data/*/*/*.txt binary
 
 # Release notes, reduce number of conflicts.
 doc/release/*.rst merge=union
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -323,3 +323,7 @@ scipy/optimize/_group_columns.c
 scipy/optimize/cython_optimize/_zeros.c
 scipy/optimize/cython_optimize/_zeros.pyx
 scipy/optimize/lbfgsb/_lbfgsbmodule.c
+
+# pixi environments
+.pixi
+*.egg-info

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -1464,6 +1464,42 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             indices = np.tile(np.arange(N), len(self.data))
             indptr = self.indptr * N
         return self.__class__((data, indices, indptr), shape=shape, copy=False)
+    
+    def __binsparse_descriptor__(self) -> dict:
+        """Return a `dict` equivalent to a parsed JSON [`binsparse` descriptor](https://graphblas.org/binsparse-specification/#descriptor)
+        of this array.
+
+        Returns
+        -------
+        dict
+            Parsed `binsparse` descriptor.
+        """
+        from scipy import __version__
+
+        data_dt = str(self.data.dtype)
+        if np.issubdtype(data_dt, np.complexfloating):
+            data_dt = f"complex[float{self.data.dtype.itemsize * 4}]"
+        return {
+            "binsparse": {
+                "version": "0.1",
+                "format": self.format.upper(),
+                "shape": list(self.shape),
+                "number_of_stored_values": self.nnz,
+                "data_types": {
+                    "pointers_to_1": str(self.indices.dtype),
+                    "indices_1": str(self.indptr.dtype),
+                    "values": data_dt,
+                },
+            },
+            "original_source": f"`scipy.sparse`, version {__version__}",
+        }
+
+    def __binsparse__(self) -> dict[str, np.ndarray]:
+        return {
+            "pointers_to_1": self.indptr,
+            "indices_1": self.indices,
+            "values": self.data,
+        }
 
 
 def _make_diagonal_csr(data, is_array=False):

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -6,7 +6,8 @@ from pytest import raises as assert_raises
 from numpy.testing import assert_equal, assert_
 
 from scipy.sparse import (sparray, csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
-                          coo_matrix, dok_matrix, csr_array, save_npz, load_npz)
+                          coo_matrix, dok_matrix, csr_array, save_npz, load_npz,
+                          from_binsparse)
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -107,3 +108,18 @@ def test_implemented_error():
     x[0,1] = 1
 
     assert_raises(NotImplementedError, save_npz, 'x.npz', x)
+
+def test_round_trip_binsparse() -> None:
+    N = 10
+    np.random.seed(0)
+    dense_matrix = np.random.random((N, N))
+    dense_matrix[dense_matrix > 0.7] = 0
+
+    for matrix_class in [csr_array, csc_matrix]:
+        sp_mat = matrix_class(dense_matrix)
+        sp_mat_rt = from_binsparse(sp_mat)
+        assert_(sp_mat.dtype == sp_mat_rt.dtype)
+        assert_(sp_mat.shape == sp_mat_rt.shape)
+        assert_equal(sp_mat.data, sp_mat_rt.data, strict=True)
+        assert_equal(sp_mat.indices, sp_mat_rt.indices, strict=True)
+        assert_equal(sp_mat.indptr, sp_mat_rt.indptr, strict=True)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/data-apis/array-api/issues/840

#### What does this implement/fix?
Implements the `__binsparse__` protocol as described in the above issue. For context, this is the equivalent of `__dlpack__` for sparse arrays

#### Additional information
~~Binsparse currently doesn't support the structure-of-array format for COO; hence COO support is missing for the moment.~~

It doesn't have array-of-structures support for COO. A discussion was carried out, and support for that is coming. This turns out to be important for PyTorch and PyData/Sparse.

