### PR TITLE
BUG: `lfiltic`'s handling of `a[0] != 1` differs from `lfilter`'s 

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2359,11 +2359,14 @@ def lfiltic(b, a, y, x=None):
         if x is not None:
             _reject_objects(x, 'lfiltic')
 
-    a = xp.asarray(a)
-    b = xp.asarray(b)
-
-    N = xp_size(a) - 1
-    M = xp_size(b) - 1
+    a = xpx.atleast_nd(xp.asarray(a), ndim=1, xp=xp)
+    b = xpx.atleast_nd(xp.asarray(b), ndim=1, xp=xp)
+    if a.ndim > 1:
+        raise ValueError('Filter coefficients `a` must be 1-D.')
+    if b.ndim > 1:
+        raise ValueError('Filter coefficients `b` must be 1-D.')
+    N = a.shape[0] - 1
+    M = b.shape[0] - 1
     K = max(M, N)
     y = xp.asarray(y)
 
@@ -2402,11 +2405,10 @@ def lfiltic(b, a, y, x=None):
     for m in range(N):
         zi[m] -= xp.sum(a[m + 1:] * y[:N - m], axis=0)
 
-    a0 = a[0] if N > 0 else a
-    if a0 != 1.:
-        if a0 == 0.:
+    if a[0] != 1.:
+        if a[0] == 0.:
             raise ValueError("First `a` filter coefficient must be non-zero.")
-        zi /= a0
+        zi /= a[0]
 
     return zi
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2386,11 +2386,9 @@ def lfiltic(b, a, y, x=None):
             result_type = xp.float64
         x = xp.astype(x, result_type)
 
-        concat = array_namespace(a).concat
-
         L = xp_size(x)
         if L < M:
-            x = concat((x, xp.zeros(M - L)))
+            x = xp.concat((x, xp.zeros(M - L)))
 
     y = xp.astype(y, result_type)
     zi = xp.zeros(K, dtype=result_type)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2367,6 +2367,9 @@ def lfiltic(b, a, y, x=None):
     K = max(M, N)
     y = xp.asarray(y)
 
+    if N < 0:
+        raise ValueError("There must be at least one `a` coefficient.")
+
     if x is None:
         result_type = xp.result_type(b, a, y)
         if xp.isdtype(result_type, ('bool', 'integral')):  #'bui':
@@ -2391,13 +2394,19 @@ def lfiltic(b, a, y, x=None):
 
     L = xp_size(y)
     if L < N:
-        y = xp.concat((y, np.zeros(N - L)))
+        y = xp.concat((y, xp.zeros(N - L)))
 
     for m in range(M):
         zi[m] = xp.sum(b[m + 1:] * x[:M - m], axis=0)
 
     for m in range(N):
         zi[m] -= xp.sum(a[m + 1:] * y[:N - m], axis=0)
+
+    a0 = a[0] if N > 0 else a
+    if a0 != 1.:
+        if a0 == 0.:
+            raise ValueError("First `a` filter coefficient must be non-zero.")
+        zi /= a0
 
     return zi
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2018,7 +2018,7 @@ class _TestLinearFilter:
     def test_lfiltic(self, a, xp):
         # Test for #22470: lfiltic does not handle `a[0] != 1`
         # and, more in general, test that lfiltic behaves consistently with lfilter
-        if is_cupy(xp) and isinstance(a, (int, float)):
+        if is_cupy(xp) and isinstance(a, int | float):
             pytest.skip('cupy does not supoprt scalar filter coefficients')
         x = self.generate(6, xp)  # arbitrary input
         b = self.convert_dtype([.5, 1., .2], xp)  # arbitrary b

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2012,17 +2012,22 @@ class _TestLinearFilter:
                             else self.dtype)
         assert xp_size(zf) == 0
 
-    @skip_xp_backends('cupy', reason="Cupy's lfilter/lfiltic use zi differently")
+    @skip_xp_backends('jax.numpy', reason='jax does not support inplace ops')
     @pytest.mark.parametrize('a', (1, [1], [1, .5, 1.5], 2, [2], [2, 1, 3]),
                              ids=str)
     def test_lfiltic(self, a, xp):
         # Test for #22470: lfiltic does not handle `a[0] != 1`
         # and, more in general, test that lfiltic behaves consistently with lfilter
+        if is_cupy(xp) and isinstance(a, (int, float)):
+            pytest.skip('cupy does not supoprt scalar filter coefficients')
         x = self.generate(6, xp)  # arbitrary input
         b = self.convert_dtype([.5, 1., .2], xp)  # arbitrary b
         a = self.convert_dtype(a, xp)
+        N = xp_size(a) - 1
+        M = xp_size(b) - 1
+        K = M + N if is_cupy(xp) else max(N, M)
         # compute reference initial conditions as final conditions of lfilter
-        y1, zi_1 = lfilter(b, a, x, zi=self.convert_dtype([0, 0], xp))
+        y1, zi_1 = lfilter(b, a, x, zi=self.generate(K, xp))
         # copute initial conditions from lfiltic
         zi_2 = lfiltic(b, a, xp.flip(y1), xp.flip(x))
         # compare lfiltic's output with reference

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2027,6 +2027,13 @@ class _TestLinearFilter:
         # compare lfiltic's output with reference
         self.assert_array_almost_equal(zi_1, zi_2)
 
+    def test_lfiltic_bad_coeffs(xp):
+        # Test for invalid filter coefficients (wrong shape or zero `a[0]`)
+        assert_raises(ValueError, lfiltic, [1, 2], [], [0, 0], [0, 1])
+        assert_raises(ValueError, lfiltic, [1, 2], [0, 2], [0, 0], [0, 1])
+        assert_raises(ValueError, lfiltic, [1, 2], [[1], [2]], [0, 0], [0, 1])
+        assert_raises(ValueError, lfiltic, [[1], [2]], [1], [0, 0], [0, 1])
+
     @skip_xp_backends(
         'array_api_strict', reason='int64 and float64 cannot be promoted together'
     )

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2012,6 +2012,21 @@ class _TestLinearFilter:
                             else self.dtype)
         assert xp_size(zf) == 0
 
+    @pytest.mark.parametrize('a', (1, [1], [1, .5, 1.5], 2, [2], [2, 1, 3]),
+                             ids=str)
+    def test_lfiltic(self, a, xp):
+        # Test for #22470: lfiltic does not handle `a[0] != 1`
+        # and, more in general, test that lfiltic behaves consistently with lfilter
+        x = self.generate(6, xp)  # arbitrary input
+        b = self.convert_dtype([.5, 1., .2], xp)  # arbitrary b
+        a = self.convert_dtype(a, xp)
+        # compute reference initial conditions as final conditions of lfilter
+        y1, zi_1 = lfilter(b, a, x, zi=self.convert_dtype([0, 0], xp))
+        # copute initial conditions from lfiltic
+        zi_2 = lfiltic(b, a, y1[::-1], x[::-1])
+        # compare lfiltic's output with reference
+        self.assert_array_almost_equal(zi_1, zi_2)
+
     @skip_xp_backends(
         'array_api_strict', reason='int64 and float64 cannot be promoted together'
     )

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2012,6 +2012,7 @@ class _TestLinearFilter:
                             else self.dtype)
         assert xp_size(zf) == 0
 
+    @skip_xp_backends('cupy', reason="Cupy's lfilter/lfiltic use zi differently")
     @pytest.mark.parametrize('a', (1, [1], [1, .5, 1.5], 2, [2], [2, 1, 3]),
                              ids=str)
     def test_lfiltic(self, a, xp):
@@ -2023,7 +2024,7 @@ class _TestLinearFilter:
         # compute reference initial conditions as final conditions of lfilter
         y1, zi_1 = lfilter(b, a, x, zi=self.convert_dtype([0, 0], xp))
         # copute initial conditions from lfiltic
-        zi_2 = lfiltic(b, a, y1[::-1], x[::-1])
+        zi_2 = lfiltic(b, a, xp.flip(y1), xp.flip(x))
         # compare lfiltic's output with reference
         self.assert_array_almost_equal(zi_1, zi_2)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #22470.

#### What does this implement/fix?
Fixes 22470 by dividing the resulting `zi` by `a[0]`.
Also added checks that `a` is non-empty and its first element is non-zero.
Added tests to test the issue before and after the fix (also added additional test cases for `lfiltic`).

#### Additional information
<!--Any additional information you think is important.-->
None