### PR TITLE
ENH: optimize: speed up `LbfgsInvHessProduct.todense` on large matrices

### DIFF
--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -586,18 +586,17 @@ class LbfgsInvHessProduct(LinearOperator):
         """
         s, y, n_corrs, rho = self.sk, self.yk, self.n_corrs, self.rho
         Q = np.array(X, dtype=self.dtype, copy=True)
-        assert Q.ndim == 2
 
         alpha = np.empty((n_corrs, Q.shape[1]))
 
         for i in range(n_corrs-1, -1, -1):
             alpha[i] = rho[i] * np.dot(s[i], Q)
-            Q = Q - alpha[i]*y[i][:, np.newaxis]
+            Q -= alpha[i]*y[i][:, np.newaxis]
 
         R = Q
         for i in range(n_corrs):
             beta = rho[i] * np.dot(y[i], R)
-            R = R + s[i][:, np.newaxis] * (alpha[i] - beta)
+            R += s[i][:, np.newaxis] * (alpha[i] - beta)
 
         return R
 

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -563,6 +563,44 @@ class LbfgsInvHessProduct(LinearOperator):
 
         return r
 
+    def _matmat(self, X):
+        """Efficient matrix-matrix multiply with the BFGS matrices.
+
+        This calculation is described in Section (4) of [1].
+
+        Parameters
+        ----------
+        X : ndarray
+            An array with shape (n,m)
+
+        Returns
+        -------
+        Y : ndarray
+            The matrix-matrix product
+
+        Notes
+        -----
+        This implementation is written starting from _matvec and broadcasting
+        all expressions along the second axis of X.
+
+        """
+        s, y, n_corrs, rho = self.sk, self.yk, self.n_corrs, self.rho
+        Q = np.array(X, dtype=self.dtype, copy=True)
+        assert Q.ndim == 2
+
+        alpha = np.empty((n_corrs, Q.shape[1]))
+
+        for i in range(n_corrs-1, -1, -1):
+            alpha[i] = rho[i] * np.dot(s[i], Q)
+            Q = Q - alpha[i]*y[i][:, np.newaxis]
+
+        R = Q
+        for i in range(n_corrs):
+            beta = rho[i] * np.dot(y[i], R)
+            R = R + s[i][:, np.newaxis] * (alpha[i] - beta)
+
+        return R
+
     def todense(self):
         """Return a dense array representation of this operator.
 
@@ -573,14 +611,5 @@ class LbfgsInvHessProduct(LinearOperator):
             the same data represented by this `LinearOperator`.
 
         """
-        s, y, n_corrs, rho = self.sk, self.yk, self.n_corrs, self.rho
         I_arr = np.eye(*self.shape, dtype=self.dtype)
-        Hk = I_arr
-
-        for i in range(n_corrs):
-            A1 = I_arr - s[i][:, np.newaxis] * y[i][np.newaxis, :] * rho[i]
-            A2 = I_arr - y[i][:, np.newaxis] * s[i][np.newaxis, :] * rho[i]
-
-            Hk = np.dot(A1, np.dot(Hk, A2)) + (rho[i] * s[i][:, np.newaxis] *
-                                                        s[i][np.newaxis, :])
-        return Hk
+        return self._matmat(I_arr)

--- a/scipy/optimize/tests/test_lbfgsb_hessinv.py
+++ b/scipy/optimize/tests/test_lbfgsb_hessinv.py
@@ -41,3 +41,25 @@ def test_2():
     assert_allclose(H1, result2.hess_inv, rtol=1e-2, atol=0.03)
 
 
+def test_3():
+
+    def todense_old_impl(self):
+        s, y, n_corrs, rho = self.sk, self.yk, self.n_corrs, self.rho
+        I_arr = np.eye(*self.shape, dtype=self.dtype)
+        Hk = I_arr
+
+        for i in range(n_corrs):
+            A1 = I_arr - s[i][:, np.newaxis] * y[i][np.newaxis, :] * rho[i]
+            A2 = I_arr - y[i][:, np.newaxis] * s[i][np.newaxis, :] * rho[i]
+
+            Hk = np.dot(A1, np.dot(Hk, A2)) + (rho[i] * s[i][:, np.newaxis] *
+                                                        s[i][np.newaxis, :])
+        return Hk
+
+    H0 = [[3, 0], [1, 2]]
+
+    def f(x):
+        return np.dot(x, np.dot(scipy.linalg.inv(H0), x))
+
+    result1 = minimize(fun=f, method='L-BFGS-B', x0=[10, 20])
+    assert_allclose(result1.hess_inv.todense(), todense_old_impl(result1.hess_inv))


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-18105

#### What does this implement/fix?
An `LbfgsInvHessProduct` (subclass of `LinearOperator`) object represents the running inverse Hessian estimate used by LBFGS. The method `todense()` converts it to the numpy array representation of the matrix (internally, no actual matrix is stored). I re-implemented `todense()` to make it faster.

#### Additional information
The current implementation has computational complexity $O(n^3)$, where the matrix is $n\times n$, while the new version is $O(n^2)$, so it's much faster on large matrices. I also took care to check it's efficient on very small matrices.