### PR TITLE
BUG: _lib: Fix data race found by TSAN, use SCIPY_TLS.

### DIFF
--- a/scipy/_lib/src/ccallback.h
+++ b/scipy/_lib/src/ccallback.h
@@ -244,7 +244,7 @@ fail:
 static int ccallback_prepare(ccallback_t *callback, ccallback_signature_t *signatures,
                              PyObject *callback_obj, int flags)
 {
-    static PyTypeObject *lowlevelcallable_type = NULL;
+    static SCIPY_TLS PyTypeObject *lowlevelcallable_type = NULL;
     PyObject *callback_obj2 = NULL;
     PyObject *capsule = NULL;
 


### PR DESCRIPTION
The `lowlevelcallable_type` static variable should be thread-local to avoid
races for free-threaded Python.  Closes gh-22547.
