### PR TITLE
TST: add missing custom markers to pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -30,3 +30,7 @@ markers =
     array_api_backends: test iterates on all array API backends
     skip_xp_backends(backends, reason=None, np_only=False, cpu_only=False, exceptions=None): mark the desired skip configuration for the `skip_xp_backends` fixture
     xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, exceptions=None): mark the desired xfail configuration for the `xfail_xp_backends` fixture
+    timeout: mark a test for a non-default timeout
+    parallel_threads(n): run the given test function in parallel
+    thread_unsafe: mark the test function as single-threaded
+    iterations(n): run the given test function `n` times in each thread


### PR DESCRIPTION
This is needed to avoid warnings when running tests on an installed `scipy` with `pytest --pyargs scipy`.