### PR TITLE
TST: `skip_xp_backends(eager_only=True)`

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -241,11 +241,11 @@ which is valued to the currently tested array namespace.
 
 The following pytest markers are available:
 
-* ``skip_xp_backends(backend=None, reason=None, np_only=False, cpu_only=False, exceptions=None)``:
+* ``skip_xp_backends(backend=None, reason=None, np_only=False, cpu_only=False, eager_only=False, exceptions=None)``:
   skip certain backends or categories of backends.
   See docstring of ``scipy.conftest.skip_or_xfail_xp_backends`` for information on how
   to use this marker to skip tests.
-* ``xfail_xp_backends(backend=None, reason=None, np_only=False, cpu_only=False, exceptions=None)``:
+* ``xfail_xp_backends(backend=None, reason=None, np_only=False, cpu_only=False, eager_only=False, exceptions=None)``:
   xfail certain backends or categories of backends.
   See docstring of ``scipy.conftest.skip_or_xfail_xp_backends`` for information on how
   to use this marker to xfail tests.
@@ -296,20 +296,15 @@ The following examples demonstrate how to use the markers::
   def test_toto_masked_array(self):
       ...
 
-Passing a custom reason to ``reason`` when ``cpu_only=True`` is unsupported
-since ``cpu_only=True`` can be used alongside passing ``backends``. Also,
-the reason for using ``cpu_only`` is likely just that compiled code is used
-in the function(s) being tested.
-
 Passing names of backends into ``exceptions`` means that they will not be skipped
-by ``cpu_only=True``. This is useful when delegation is implemented for some,
-but not all, non-CPU backends, and the CPU code path requires conversion to NumPy
-for compiled code::
+by ``cpu_only=True`` or ``eager_only=True``. This is useful when delegation
+is implemented for some, but not all, non-CPU backends, and the CPU code path 
+requires conversion to NumPy for compiled code::
 
   # array-api-strict and CuPy will always be skipped, for the given reasons.
   # All libraries using a non-CPU device will also be skipped, apart from
   # JAX, for which delegation is implemented (hence non-CPU execution is supported).
-  @pytest.mark.skip_xp_backends(cpu_only, exceptions=['jax.numpy'])
+  @pytest.mark.skip_xp_backends(cpu_only=True, exceptions=['jax.numpy'])
   @pytest.mark.skip_xp_backends('array_api_strict', reason='skip reason 1')
   @pytest.mark.skip_xp_backends('cupy', reason='skip reason 2')
   def test_toto(self, xp):

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,8 +28,8 @@ markers =
     xslow: mark test as extremely slow (not run unless explicitly requested)
     xfail_on_32bit: mark test as failing on 32-bit platforms
     array_api_backends: test iterates on all array API backends
-    skip_xp_backends(backends, reason=None, np_only=False, cpu_only=False, exceptions=None): mark the desired skip configuration for the `skip_xp_backends` fixture
-    xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, exceptions=None): mark the desired xfail configuration for the `xfail_xp_backends` fixture
+    skip_xp_backends(backends, reason=None, np_only=False, cpu_only=False, eager_only=False, exceptions=None): mark the desired skip configuration for the `skip_xp_backends` fixture
+    xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, eager_only=False, exceptions=None): mark the desired xfail configuration for the `xfail_xp_backends` fixture
     timeout: mark a test for a non-default timeout
     fail_slow: mark a test for a non-default timeout failure
     parallel_threads(n): run the given test function in parallel

--- a/scipy/_lib/tests/test__util.py
+++ b/scipy/_lib/tests/test__util.py
@@ -381,10 +381,8 @@ class TestContainsNaN:
         data4 = np.array([["1", 2], [3, np.nan]], dtype='object')
         assert _contains_nan(data4)
 
-    @pytest.mark.skip_xp_backends(
-        "dask.array", reason="lazy backends tested separately"
-    )
-    @pytest.mark.skip_xp_backends("jax.numpy", reason="lazy backends tested separately")
+    @pytest.mark.skip_xp_backends(eager_only=True,
+                                  reason="lazy backends tested separately")
     @pytest.mark.parametrize("nan_policy", ['propagate', 'omit', 'raise'])
     def test_array_api(self, xp, nan_policy):
         rng = np.random.default_rng(932347235892482)

--- a/scipy/cluster/tests/test_hierarchy.py
+++ b/scipy/cluster/tests/test_hierarchy.py
@@ -336,8 +336,6 @@ class TestLeaders:
                   reason='`is_isomorphic` only supports NumPy backend')
 class TestIsIsomorphic:
 
-    @skip_xp_backends(np_only=True,
-                      reason='array-likes only supported for NumPy backend')
     def test_array_like(self, xp):
         assert is_isomorphic([1, 1, 1], [2, 2, 2])
         assert is_isomorphic([], [])
@@ -417,8 +415,6 @@ class TestIsIsomorphic:
                 Q = np.random.permutation(nobs)
                 b[Q[0:nerrors]] += 1
                 b[Q[0:nerrors]] %= nclusters
-            a = xp.asarray(a)
-            b = xp.asarray(b)
             assert is_isomorphic(a, b) == (not noniso)
             assert is_isomorphic(b, a) == (not noniso)
 

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -2924,7 +2924,7 @@ def test_binary_input_as_output(function, iterations, brute_force, xp):
     xp_assert_equal(data, expected)
 
 
-@skip_xp_backends(np_only=True, exception=["cupy"],
+@skip_xp_backends(np_only=True, exceptions=["cupy"],
                   reason="inplace output= is numpy-specific")
 def test_binary_hit_or_miss_input_as_output(xp):
     rstate = np.random.RandomState(123)


### PR DESCRIPTION
xref https://github.com/scipy/scipy/pull/22469#discussion_r1963936773

- Add `skip_xp_backends(eager_only=True, reason=...)` and `xfail_xp_backends(eager_only=True, reason=...)`
- general cleanup of the backends skip mechanics
