### PR TITLE
BUG: optimize: Fix `bracket_root` termination check and default initial bracket.

### DIFF
--- a/scipy/optimize/_bracket.py
+++ b/scipy/optimize/_bracket.py
@@ -55,7 +55,8 @@ def _bracket_root_iv(func, xl0, xr0, xmin, xmax, factor, args, maxiter):
     # Calculate the default value of xr0 if a value has not been supplied.
     # Be careful to ensure xr0 is not larger than xmax.
     if xr0_not_supplied:
-        xr0 = xl0 + xp.minimum((xmax - xl0)/ 8, xp.asarray(1.0, dtype=xl0.dtype))
+        xr0 = xl0 + xp.minimum((xmax - xl0)/ 8, xp.asarray(1.0))
+        xr0 = xp.astype(xr0, xl0.dtype, copy=False)
 
     maxiter = xp.asarray(maxiter)
     message = '`maxiter` must be a non-negative integer.'
@@ -476,9 +477,11 @@ def _bracket_minimum_iv(func, xm0, xl0, xr0, xmin, xmax, factor, args, maxiter):
     # by the user. We need to be careful to ensure xl0 and xr0 are not outside
     # of (xmin, xmax).
     if xl0_not_supplied:
-        xl0 = xm0 - xp.minimum((xm0 - xmin)/16, xp.asarray(0.5, dtype=xm0.dtype))
+        xl0 = xm0 - xp.minimum((xm0 - xmin)/16, xp.asarray(0.5))
+        xl0 = xp.astype(xl0, xm0.dtype, copy=False)
     if xr0_not_supplied:
-        xr0 = xm0 + xp.minimum((xmax - xm0)/16, xp.asarray(0.5, dtype=xm0.dtype))
+        xr0 = xm0 + xp.minimum((xmax - xm0)/16, xp.asarray(0.5))
+        xr0 = xp.astype(xr0, xm0.dtype, copy=False)
 
     maxiter = xp.asarray(maxiter)
     message = '`maxiter` must be a non-negative integer.'

--- a/scipy/optimize/_bracket.py
+++ b/scipy/optimize/_bracket.py
@@ -289,7 +289,10 @@ def _bracket_root(func, xl0, xr0=None, *, xmin=None, xmax=None, factor=None,
         # not there.
         j = j[j < work.active.shape[0]]
         # Check whether they are still there.
-        j = j[also_stop == work.active[j]]
+        if j.size:
+            # If j is empty, there's nothing to check and following line could
+            # result in an error.
+            j = j[also_stop == work.active[j]]
         # Now convert these to boolean indices to use with `work.status`.
         i = xp.zeros_like(stop)
         i[j] = True  # boolean indices of elements that can also stop

--- a/scipy/optimize/_bracket.py
+++ b/scipy/optimize/_bracket.py
@@ -55,7 +55,7 @@ def _bracket_root_iv(func, xl0, xr0, xmin, xmax, factor, args, maxiter):
     # Calculate the default value of xr0 if a value has not been supplied.
     # Be careful to ensure xr0 is not larger than xmax.
     if xr0_not_supplied:
-        xr0 = xl0 + xp.minimum((xmax - xl0)/ 8, xp.asarray(1.0))
+        xr0 = xl0 + xp.minimum((xmax - xl0)/ 8, xp.asarray(1.0, dtype=xl0.dtype))
 
     maxiter = xp.asarray(maxiter)
     message = '`maxiter` must be a non-negative integer.'
@@ -476,9 +476,9 @@ def _bracket_minimum_iv(func, xm0, xl0, xr0, xmin, xmax, factor, args, maxiter):
     # by the user. We need to be careful to ensure xl0 and xr0 are not outside
     # of (xmin, xmax).
     if xl0_not_supplied:
-        xl0 = xm0 - xp.minimum((xm0 - xmin)/16, xp.asarray(0.5))
+        xl0 = xm0 - xp.minimum((xm0 - xmin)/16, xp.asarray(0.5, dtype=xm0.dtype))
     if xr0_not_supplied:
-        xr0 = xm0 + xp.minimum((xmax - xm0)/16, xp.asarray(0.5))
+        xr0 = xm0 + xp.minimum((xmax - xm0)/16, xp.asarray(0.5, dtype=xm0.dtype))
 
     maxiter = xp.asarray(maxiter)
     message = '`maxiter` must be a non-negative integer.'

--- a/scipy/optimize/_bracket.py
+++ b/scipy/optimize/_bracket.py
@@ -1,7 +1,7 @@
 import numpy as np
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
-from scipy._lib._array_api import array_namespace, xp_ravel
+from scipy._lib._array_api import array_namespace, xp_ravel, xp_default_dtype
 
 _ELIMITS = -1  # used in _bracket_root
 _ESTOPONESIDE = 2  # used in _bracket_root
@@ -19,6 +19,8 @@ def _bracket_root_iv(func, xl0, xr0, xmin, xmax, factor, args, maxiter):
     if (not xp.isdtype(xl0.dtype, "numeric")
         or xp.isdtype(xl0.dtype, "complex floating")):
         raise ValueError('`xl0` must be numeric and real.')
+    if not xp.isdtype(xl0.dtype, "real floating"):
+        xl0 = xp.asarray(xl0, dtype=xp_default_dtype(xp))
 
     # If xr0 is not supplied, fill with a dummy value for the sake of
     # broadcasting. We need to wait until xmax has been validated to
@@ -428,6 +430,8 @@ def _bracket_minimum_iv(func, xm0, xl0, xr0, xmin, xmax, factor, args, maxiter):
     if (not xp.isdtype(xm0.dtype, "numeric")
         or xp.isdtype(xm0.dtype, "complex floating")):
         raise ValueError('`xm0` must be numeric and real.')
+    if not xp.isdtype(xm0.dtype, "real floating"):
+        xm0 = xp.asarray(xm0, dtype=xp_default_dtype(xp))
 
     xmin = -xp.inf if xmin is None else xmin
     xmax = xp.inf if xmax is None else xmax

--- a/scipy/optimize/_bracket.py
+++ b/scipy/optimize/_bracket.py
@@ -20,7 +20,14 @@ def _bracket_root_iv(func, xl0, xr0, xmin, xmax, factor, args, maxiter):
         or xp.isdtype(xl0.dtype, "complex floating")):
         raise ValueError('`xl0` must be numeric and real.')
 
-    xr0 = xl0 + 1 if xr0 is None else xr0
+    # If xr0 is not supplied, fill with a dummy value for the sake of
+    # broadcasting. We need to wait until xmax has been validated to
+    # compute the default value.
+    xr0_not_supplied = False
+    if xr0 is None:
+        xr0 = xp.nan
+        xr0_not_supplied = True
+
     xmin = -xp.inf if xmin is None else xmin
     xmax = xp.inf if xmax is None else xmax
     factor = 2. if factor is None else factor
@@ -44,6 +51,11 @@ def _bracket_root_iv(func, xl0, xr0, xmin, xmax, factor, args, maxiter):
         raise ValueError('`factor` must be numeric and real.')
     if not xp.all(factor > 1):
         raise ValueError('All elements of `factor` must be greater than 1.')
+
+    # Calculate the default value of xr0 if a value has not been supplied.
+    # Be careful to ensure xr0 is not larger than xmax.
+    if xr0_not_supplied:
+        xr0 = xl0 + xp.minimum((xmax - xl0)/ 8, xp.asarray(1.0))
 
     maxiter = xp.asarray(maxiter)
     message = '`maxiter` must be a non-negative integer.'

--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -345,6 +345,18 @@ class TestBracketRoot:
                                 xmin=1)
         assert not res.success
 
+        # 5. Edge case. Multiple searches in same direction terminate
+        # simultaneously in some iteration after the corresponding searches
+        # in the other direction terminated without finding a root.
+
+        # Example based on that in
+        # https://github.com/scipy/scipy/pull/22560#discussion_r1962853839
+        def f(x, p):
+            return np.exp(x) - p
+
+        p = np.asarray([0.29, 0.35])
+        res = _bracket_root(f, xl0=-1, xmin=-np.inf, xmax=0, args=(p, ))
+
 
 @pytest.mark.skip_xp_backends('array_api_strict', reason=array_api_strict_skip_reason)
 @pytest.mark.skip_xp_backends('jax.numpy', reason=boolean_index_skip_reason)

--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -374,6 +374,11 @@ class TestBracketRoot:
 
         res = _bracket_root(f, xl0=xl0, xr0=xr0, xmin=xmin, xmax=xmax, args=(p, c))
 
+        # 7. Default xl0 + 1 for xr0 exceeds xmax.
+        # https://github.com/scipy/scipy/pull/22560#discussion_r1962947434
+        res = _bracket_root(lambda x: x + 0.25, xl0=-0.5, xmin=-np.inf, xmax=0)
+        assert res.success
+
 
 @pytest.mark.skip_xp_backends('array_api_strict', reason=array_api_strict_skip_reason)
 @pytest.mark.skip_xp_backends('jax.numpy', reason=boolean_index_skip_reason)

--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -345,11 +345,12 @@ class TestBracketRoot:
                                 xmin=1)
         assert not res.success
 
-        # 5. Multiple searches in same direction terminate
-        # simultaneously in some iteration after the corresponding searches
-        # in the other direction terminated without finding a root.
+    def test_bug_fixes(self):
+        # 1. Bug in double sided bracket search.
+        # Happened in some cases where there are terminations on one side
+        # after corresponding searches on other side failed due to reaching the
+        # boundary.
 
-        # Example based on that in
         # https://github.com/scipy/scipy/pull/22560#discussion_r1962853839
         def f(x, p):
             return np.exp(x) - p
@@ -357,7 +358,7 @@ class TestBracketRoot:
         p = np.asarray([0.29, 0.35])
         res = _bracket_root(f, xl0=-1, xmin=-np.inf, xmax=0, args=(p, ))
 
-        # 6. https://github.com/scipy/scipy/pull/22560/files#r1962952517
+        # https://github.com/scipy/scipy/pull/22560/files#r1962952517
         def f(x, p, c):
             return np.exp(x*c) - p
 
@@ -374,7 +375,7 @@ class TestBracketRoot:
 
         res = _bracket_root(f, xl0=xl0, xr0=xr0, xmin=xmin, xmax=xmax, args=(p, c))
 
-        # 7. Default xl0 + 1 for xr0 exceeds xmax.
+        # 2. Default xl0 + 1 for xr0 exceeds xmax.
         # https://github.com/scipy/scipy/pull/22560#discussion_r1962947434
         res = _bracket_root(lambda x: x + 0.25, xl0=-0.5, xmin=-np.inf, xmax=0)
         assert res.success

--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -345,7 +345,7 @@ class TestBracketRoot:
                                 xmin=1)
         assert not res.success
 
-        # 5. Edge case. Multiple searches in same direction terminate
+        # 5. Multiple searches in same direction terminate
         # simultaneously in some iteration after the corresponding searches
         # in the other direction terminated without finding a root.
 
@@ -357,7 +357,7 @@ class TestBracketRoot:
         p = np.asarray([0.29, 0.35])
         res = _bracket_root(f, xl0=-1, xmin=-np.inf, xmax=0, args=(p, ))
 
-        # 6. Edge case: https://github.com/scipy/scipy/pull/22560/files#r1962952517
+        # 6. https://github.com/scipy/scipy/pull/22560/files#r1962952517
         def f(x, p, c):
             return np.exp(x*c) - p
 

--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -357,6 +357,23 @@ class TestBracketRoot:
         p = np.asarray([0.29, 0.35])
         res = _bracket_root(f, xl0=-1, xmin=-np.inf, xmax=0, args=(p, ))
 
+        # 6. Edge case: https://github.com/scipy/scipy/pull/22560/files#r1962952517
+        def f(x, p, c):
+            return np.exp(x*c) - p
+
+        p = [0.32061201, 0.39175242, 0.40047535, 0.50527218, 0.55654373,
+             0.11911647, 0.37507896, 0.66554191]
+        c = [1., -1., 1., 1., -1., 1., 1., 1.]
+        xl0 = [-7.63108551,  3.27840947, -8.36968526, -1.78124372,
+               0.92201295, -2.48930123, -0.66733533, -0.44606749]
+        xr0 = [-6.63108551,  4.27840947, -7.36968526, -0.78124372,
+               1.92201295, -1.48930123, 0., 0.]
+        xmin = [-np.inf, 0., -np.inf, -np.inf, 0., -np.inf, -np.inf,
+                -np.inf]
+        xmax = [0., np.inf, 0., 0., np.inf, 0., 0., 0.]
+
+        res = _bracket_root(f, xl0=xl0, xr0=xr0, xmin=xmin, xmax=xmax, args=(p, c))
+
 
 @pytest.mark.skip_xp_backends('array_api_strict', reason=array_api_strict_skip_reason)
 @pytest.mark.skip_xp_backends('jax.numpy', reason=boolean_index_skip_reason)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This fixes I bug I discovered while working on #22560.

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR is fixes a~n edgecase~ bug in the elementwise root bracket finder `scipy.optimize.bracket_root`. For context, this bracket finder starts with an initial bracket and simultaneously searches for valid brackets by expanding this initial bracket to the left and right. If multiple searches in one direction terminate at the same time, in an iteration after all corresponding searches in the other direction have already terminated unsuccessfully (by reaching a boundary point in the search space), currently a `ValueError` will occur due to `==` comparision between two arrays, one of which is empty and one of which is not.

Update:
I've also fixed a bug @mdhaber identified here, https://github.com/scipy/scipy/pull/22560#discussion_r1962947434, involving the choice of the default initial bracket.

#### Additional information
<!--Any additional information you think is important.-->
I'd originally fixed this directly in #22560, but am moving to a separate PR since this is the principled thing to do and @mdhaber helped identify a minimal reproducible example for use in a test case.