### PR TITLE
CI: fix dev-deps job by not testing Meson master

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -71,9 +71,10 @@ jobs:
       if: matrix.python-version == '3.13-dev' # this run will use python dev versions when available
       run: |
         python -m pip install git+https://github.com/numpy/numpy.git
-        python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis "setuptools<67.3"
+        python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout click rich-click doit pydevtool pooch hypothesis "setuptools<67.3" meson
         python -m pip install git+https://github.com/serge-sans-paille/pythran.git
-        python -m pip install git+https://github.com/mesonbuild/meson.git
+        # Disable Meson master testing until upstream option handling is fixed, see scipy#22534
+        # python -m pip install git+https://github.com/mesonbuild/meson.git
 
     - name:  Prepare compiler cache
       id:    prep-ccache


### PR DESCRIPTION
The failures happened in `test_extending.py::test_cython`, as reported in gh-22534.

Tyler already fixed this in the 1.15.x branch in gh-22471, but the job has been failing on `main` for the last few days.