### PR TITLE
BUG: ``integrate.solve_ivp``: Avoid duplicate time stamps in `ts` when `dense_output=True`

### DIFF
--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -65,7 +65,7 @@ def norm(x):
     return np.linalg.norm(x) / x.size ** 0.5
 
 
-def select_initial_step(fun, t0, y0, t_bound, 
+def select_initial_step(fun, t0, y0, t_bound,
                         max_step, f0, direction, order, rtol, atol):
     """Empirically select a good initial step.
 
@@ -80,7 +80,7 @@ def select_initial_step(fun, t0, y0, t_bound,
     y0 : ndarray, shape (n,)
         Initial value of the dependent variable.
     t_bound : float
-        End-point of integration interval; used to ensure that t0+step<=tbound 
+        End-point of integration interval; used to ensure that t0+step<=tbound
         and that fun is only evaluated in the interval [t0,tbound]
     max_step : float
         Maximum allowable step size.
@@ -112,7 +112,7 @@ def select_initial_step(fun, t0, y0, t_bound,
     interval_length = abs(t_bound - t0)
     if interval_length == 0.0:
         return 0.0
-    
+
     scale = atol + np.abs(y0) * rtol
     d0 = norm(y0 / scale)
     d1 = norm(f0 / scale)

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -694,8 +694,15 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
             g = g_new
 
         if t_eval is None:
-            ts.append(t)
-            ys.append(y)
+            donot_append = (len(ts) > 1 and
+                            ts[-1] == t and
+                            dense_output)
+            if not donot_append:
+                ts.append(t)
+                ys.append(y)
+            else:
+                if len(interpolants) > 0:
+                    interpolants.pop()
         else:
             # The value in t_eval equal to t will be included.
             if solver.direction > 0:

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -167,8 +167,8 @@ def test_duplicate_timestamps():
     assert_allclose(sol.sol(0.01), np.asarray([-0.00039033, -0.08806632]),
                     rtol=1e-5, atol=1e-8)
     assert_allclose(sol.t_events, np.asarray([[0.00203943]]), rtol=1e-5, atol=1e-8)
-    assert_allclose(sol.y_events, [np.asarray([[ 8.5808408e-20, -1.0000000e-02 ]])])
-    assert_(sol.success)
+    assert_allclose(sol.y_events, [np.asarray([[ 0.0, -0.01 ]])], atol=1e-9)
+    assert sol.success
     assert_equal(sol.status, 1)
 
 @pytest.mark.thread_unsafe

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -151,6 +151,25 @@ def compute_error(y, y_true, rtol, atol):
     e = (y - y_true) / (atol + rtol * np.abs(y_true))
     return np.linalg.norm(e, axis=0) / np.sqrt(e.shape[0])
 
+def test_duplicate_timestamps():
+    def upward_cannon(t, y):
+        return [y[1], -9.80665]
+
+    def hit_ground(t, y):
+        return y[0]
+
+    hit_ground.terminal = True
+    hit_ground.direction = -1
+
+    sol = solve_ivp(upward_cannon, [0, np.inf], [0, 0.01],
+                    max_step=0.05 * 0.001 / 9.80665,
+                    events=hit_ground, dense_output=True)
+    assert_allclose(sol.sol(0.01), np.asarray([-0.00039033, -0.08806632]),
+                    rtol=1e-5, atol=1e-8)
+    assert_allclose(sol.t_events, np.asarray([[0.00203943]]), rtol=1e-5, atol=1e-8)
+    assert_allclose(sol.y_events, [np.asarray([[ 8.5808408e-20, -1.0000000e-02 ]])])
+    assert_(sol.success)
+    assert_equal(sol.status, 1)
 
 @pytest.mark.thread_unsafe
 def test_integration():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/19418

#### What does this implement/fix?
<!--Please explain your changes.-->

I verified that indeed `ts` has duplicate values as pointed in https://github.com/scipy/scipy/issues/19418. I added a check to avoid it. Last `interpolant` is also removed because if `ts[-1] == ts[-2]` then there shouldn't be a point in keeping it. It should be noted that for `len(ts) == 2` duplicates are allowed (so that condition is kept preserved here). 

I also added a regression test. 

Let me know if the fix is making sense. :-)

@ericjwhitney

#### Additional information
<!--Any additional information you think is important.-->