### PR TITLE
MAINT: stats.multinomial: `FutureWarning` about normalization of `p`

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3282,7 +3282,8 @@ class multinomial_gen(multi_rv_generic):
         """
         p = np.array(p, dtype=np.float64, copy=True)
         p_adjusted = 1. - p[..., :-1].sum(axis=-1)
-        i_adjusted = np.abs(p_adjusted) > eps
+        # only make adjustment when it's significant
+        i_adjusted = np.abs(1 - p.sum(axis=-1)) > eps
         p[i_adjusted, -1] = p_adjusted[i_adjusted]
 
         # true for bad p

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2,6 +2,7 @@
 # Author: Joris Vankerschaver 2013
 #
 import math
+import warnings
 import threading
 import numpy as np
 import scipy.linalg
@@ -3285,6 +3286,14 @@ class multinomial_gen(multi_rv_generic):
         # only make adjustment when it's significant
         i_adjusted = np.abs(1 - p.sum(axis=-1)) > eps
         p[i_adjusted, -1] = p_adjusted[i_adjusted]
+
+        if np.any(i_adjusted):
+            message = ("Some rows of `p` do not sum to 1.0 within tolerance of "
+                       f"{eps=}. Currently, the last element of these rows is adjusted "
+                       "to compensate, but this condition will produce NaNs "
+                       "beginning in SciPy 1.18.0. Please ensure that rows of `p` sum "
+                       "to 1.0 to avoid futher disruption.")
+            warnings.warn(message, FutureWarning, stacklevel=3)
 
         # true for bad p
         pcond = np.any(p < 0, axis=-1)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -2056,6 +2056,16 @@ class TestMultinomial:
         logpmf = multinomial.logpmf(x, n, p)
         assert np.isfinite(logpmf)
 
+    def test_gh_22565(self):
+        # Same issue as gh-11860 above, essentially, but the original
+        # fix didn't completely solve the problem.
+        n = 19
+        p = [0.2, 0.2, 0.2, 0.2, 0.2]
+        res1 = multinomial.pmf(x=[1, 2, 5, 7, 4], n=n, p=p)
+        res2 = multinomial.pmf(x=[1, 2, 4, 5, 7], n=n, p=p)
+        np.testing.assert_allclose(res1, res2, rtol=1e-15)
+
+
 class TestInvwishart:
     def test_frozen(self):
         # Test that the frozen and non-frozen inverse Wishart gives the same

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1929,10 +1929,17 @@ class TestMultinomial:
     @pytest.mark.parametrize("n", [0, 3])
     def test_rvs_np(self, n):
         # test that .rvs agrees w/numpy
-        sc_rvs = multinomial.rvs(n, [1/4.]*3, size=7, random_state=123)
-        rndm = np.random.RandomState(123)
-        np_rvs = rndm.multinomial(n, [1/4.]*3, size=7)
-        assert_equal(sc_rvs, np_rvs)
+        message = "Some rows of `p` do not sum to 1.0 within..."
+        with pytest.warns(FutureWarning, match=message):
+            rndm = np.random.RandomState(123)
+            sc_rvs = multinomial.rvs(n, [1/4.]*3, size=7, random_state=123)
+            np_rvs = rndm.multinomial(n, [1/4.]*3, size=7)
+            assert_equal(sc_rvs, np_rvs)
+        with pytest.warns(FutureWarning, match=message):
+            rndm = np.random.RandomState(123)
+            sc_rvs = multinomial.rvs(n, [1/4.]*5, size=7, random_state=123)
+            np_rvs = rndm.multinomial(n, [1/4.]*5, size=7)
+            assert_equal(sc_rvs, np_rvs)
 
     def test_pmf(self):
         vals0 = multinomial.pmf((5,), 5, (1,))
@@ -2007,7 +2014,7 @@ class TestMultinomial:
         assert_allclose(ent0, binom.entropy(n, .2), rtol=1e-8)
 
     def test_entropy_broadcasting(self):
-        ent0 = multinomial.entropy([2, 3], [.2, .3])
+        ent0 = multinomial.entropy([2, 3], [.2, .8])
         assert_allclose(ent0, [binom.entropy(2, .2), binom.entropy(3, .2)],
                         rtol=1e-8)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-22565

#### What does this implement/fix?
The `multinomial` distribution currently changes the last element in rows of the user-provided `p` without warning to ensure that rows sum to 1.0.
```python3
import numpy as np
from scipy import stats
res = stats.multinomial.entropy(10, [0.25, 75])
ref = stats.multinomial.entropy(10, [0.25, 0.75])
np.testing.assert_equal(res, ref)  # passes, no warning
```
This is documented, but has led to issues like gh-12575 and gh-11860. This PR proposes to warn:
```python3
res = stats.multinomial.entropy(10, [0.25, 75])
# <ipython-input-2-5540b560d502>:3: FutureWarning: Some rows of `p` do not sum to 1.0 within tolerance of eps=1e-15. Currently, the last element of these rows is adjusted to compensate, but this condition will produce NaNs beginning in SciPy 1.18.0. Please ensure that rows of `p` sum to 1.0 to avoid futher disruption.
#   res = stats.multinomial.entropy(10, [0.25, 75])
```
and produce NaNs beginning in SciPy 1.18.0. This is consistent with the behavior of other distributions in which invalid shape parameters produce a NaN, e.g.
```python3
stats.binom(n=10, p=-1).entropy()  # nan
```

#### Additional information
Forum post [here](https://discuss.scientific-python.org/t/maint-stats-multinomial-futurewarning-about-normalization-of-p/1748).


The documentation currently says:
> Each element of `p` should be in the interval $[0, 1]$ and the elements should sum to `1`. If they do not sum to `1`, the last element of the `p` array is not used and is replaced with the remaining probability left over from the earlier elements.

Presumably "should" will change to "must" in 1.18.0 and the second sentence would be removed. How should we change it here?

In such cases:
- Mathematica emits a warning that the probabilities must sum to 1 and does not produce a numerical result.
- R normalizes `p` to sum to 1.0 by dividing by `p /= p.sum()`. This behavior was proposed in gh-12575, but not accepted.
- Matlab raises.
