### PR TITLE
BUG: Pin jupyterlite-sphinx to >= 0.19.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -48,7 +48,7 @@ dependencies:
   - jupytext
   - myst-nb>=1.2.0
   - linkify-it-py
-  - jupyterlite-sphinx>=0.17.1
+  - jupyterlite-sphinx>=0.19.1
   - jupyterlite-pyodide-kernel
   # Some optional test dependencies
   - mpmath

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ doc = [
     "jupytext",
     "myst-nb>=1.2.0",
     "pooch",
-    "jupyterlite-sphinx>=0.17.1",
+    "jupyterlite-sphinx>=0.19.1",
     "jupyterlite-pyodide-kernel",
     "linkify-it-py"
 ]

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -10,6 +10,6 @@ numpydoc
 jupytext
 myst-nb>=1.2.0
 pooch
-jupyterlite-sphinx>=0.17.1
+jupyterlite-sphinx>=0.19.1
 jupyterlite-pyodide-kernel
 linkify-it-py


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Reference issue: https://github.com/scipy/scipy/issues/22241., but merging this is not enough to close that, since the docs will also need to be rebuilt and re-uploaded.

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR pins `jupyterlite-sphinx` to greater than or equal to version `0.19.1` to incorporate the fix https://github.com/jupyterlite/jupyterlite-sphinx/pull/271, which should fix the problem that caused  #22241. The issue was that `jupyterlite-sphinx` called `jupyter` using `subprocess.run`, and in the `make dist` doc workflow, the relevant virtual environment was not active in this `subprocess`. 

#### Additional information
<!--Any additional information you think is important.-->
@tylerjereddy, I've marked this as a backport candidate. If there is a `0.15.3`, I think there's minimal risk in backporting the dependency bump here.
