### PR TITLE
BUG/BLD: xsf: force defining the mdspan parenthesis operator even with C++ >= 23

### DIFF
--- a/scipy/special/xsf/numpy.h
+++ b/scipy/special/xsf/numpy.h
@@ -19,6 +19,9 @@
 
 #include "dual.h"
 #include "error.h"
+// Force defining the parenthesis operator even when compiling with a compiler
+// defaulting to C++ >= 23.
+#define MDSPAN_USE_PAREN_OPERATOR 1
 #include "third_party/kokkos/mdspan.hpp"
 
 /* PyUFunc_getfperr gets bits for current floating point error (fpe) status codes so we


### PR DESCRIPTION
This allows to keep the same code, independently of the compiler C++ dialect being used. The default behavior of kokkos mdspan is the following:
 - if __cpp_multidimensional_subscript is defined (ie C++ >= 23), then enable by default the square bracket operator to access elements, and disable by default the parenthesis operator.
 - otherwise (C++ < 23), disable the square bracket operator which cannot work, and replace it by the parenthesis operator instead.

The current xsf code always uses the parenthesis operator. To avoid having to always write the two possibilities, force the kokkos mdspan implementation to always define the parenthesis operator for now.

If this fix is accepted, I guess it is worth backporting it in the 1.15 release branch (as we do hit this issue on our side with release 1.15.2).