### PR TITLE
TST: add one more missing custom marker (`fail_slow`) to pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -31,6 +31,7 @@ markers =
     skip_xp_backends(backends, reason=None, np_only=False, cpu_only=False, exceptions=None): mark the desired skip configuration for the `skip_xp_backends` fixture
     xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, exceptions=None): mark the desired xfail configuration for the `xfail_xp_backends` fixture
     timeout: mark a test for a non-default timeout
+    fail_slow: mark a test for a non-default timeout failure
     parallel_threads(n): run the given test function in parallel
     thread_unsafe: mark the test function as single-threaded
     iterations(n): run the given test function `n` times in each thread


### PR DESCRIPTION
This is a follow-up to PR gh-22564. Avoids verbose warnings from Pytest.