### PR TITLE
MAINT: stats.bootstrap: broadcast like other stats functions

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -42,6 +42,7 @@ def _broadcast_arrays(arrays, axis=None, xp=None):
     """
     Broadcast shapes of arrays, ignoring incompatibility of specified axes
     """
+    arrays = tuple(arrays)
     if not arrays:
         return arrays
     xp = array_namespace(*arrays) if xp is None else xp

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -183,20 +183,7 @@ def _bootstrap_iv(data, statistic, vectorized, paired, axis, confidence_level,
     if n_samples == 0:
         raise ValueError("`data` must contain at least one sample.")
 
-    message = ("Ignoring the dimension specified by `axis`, arrays in `data` do not "
-               "have the same shape. Beginning in SciPy 1.16.0, `bootstrap` will "
-               "explicitly broadcast elements of `data` to the same shape (ignoring "
-               "`axis`) before performing the calculation. To avoid this warning in "
-               "the meantime, ensure that all samples have the same shape (except "
-               "potentially along `axis`).")
-    data = [np.atleast_1d(sample) for sample in data]
-    reduced_shapes = set()
-    for sample in data:
-        reduced_shape = list(sample.shape)
-        reduced_shape.pop(axis)
-        reduced_shapes.add(tuple(reduced_shape))
-    if len(reduced_shapes) != 1:
-        warnings.warn(message, FutureWarning, stacklevel=3)
+    data = _broadcast_arrays(data, axis_int)
 
     data_iv = []
     for sample in data:
@@ -331,15 +318,6 @@ def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
          Each element of `data` is a sample containing scalar observations from an
          underlying distribution. Elements of `data` must be broadcastable to the
          same shape (with the possible exception of the dimension specified by `axis`).
-
-         .. versionchanged:: 1.14.0
-             `bootstrap` will now emit a ``FutureWarning`` if the shapes of the
-             elements of `data` are not the same (with the exception of the dimension
-             specified by `axis`).
-             Beginning in SciPy 1.16.0, `bootstrap` will explicitly broadcast the
-             elements to the same shape (except along `axis`) before performing
-             the calculation.
-
     statistic : callable
         Statistic for which the confidence interval is to be calculated.
         `statistic` must be a callable that accepts ``len(data)`` samples

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -745,13 +745,11 @@ def test_gh_20850():
     stats.bootstrap((x.T, y.T), statistic, axis=1)
     # But even when the shapes *are* the same along axis, the lengths
     # along other dimensions have to be the same (or `bootstrap` warns).
-    message = "Ignoring the dimension specified by `axis`..."
-    with pytest.warns(FutureWarning, match=message):
+    message = "Array shapes are incompatible for broadcasting."
+    with pytest.raises(ValueError, match=message):
         stats.bootstrap((x, y[:10, 0]), statistic)  # this won't work after 1.16
-    with pytest.warns(FutureWarning, match=message):
-        stats.bootstrap((x, y[:10, 0:1]), statistic)  # this will
-    with pytest.warns(FutureWarning, match=message):
-        stats.bootstrap((x.T, y.T[0:1, :10]), statistic, axis=1)  # this will
+    stats.bootstrap((x, y[:10, 0:1]), statistic)  # this will
+    stats.bootstrap((x.T, y.T[0:1, :10]), statistic, axis=1)  # this will
 
 
 # --- Test Monte Carlo Hypothesis Test --- #


### PR DESCRIPTION
#### Reference issue
gh-20858

#### What does this implement/fix?
This PR implements the change discussed in gh-20858. I see that the change didn't get highlighted explicitly in the release notes (although the PR is in the change log), but it has been in the rendered documentation, there was a `FutureWarning`, and the impact is probably small - it only makes a difference when a multi-sample statistic is bootstrapped in batch and the arrays have different numbers of dimensions.
