### PR TITLE
DOC: Ignore dict subclass docstring warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -131,6 +131,7 @@ nitpick_ignore = [
     ("py:class", "None.  Remove all items from D."),
     ("py:class", "(k, v), remove and return some (key, value) pair as a"),
     ("py:class", "None.  Update D from dict/iterable E and F."),
+    ("py:class", "None.  Update D from mapping/iterable E and F."),
     ("py:class", "v, remove specified key and return the corresponding value."),
 ]
 


### PR DESCRIPTION
#### Reference issue
Addresses https://github.com/scipy/scipy/issues/22178#issuecomment-2578136965

#### What does this implement/fix?
Some subclasses of dicts raise a Sphinx warning when the docs are built with Python 3.12. The warning is `WARNING: py:class reference target not found: None.  Update D from mapping/iterable E and F.`

#### Additional information
Doesn't affect CI since it's still running Python 3.11.
