### PR TITLE
BUG: ndimage.median_filter: fix segfault when using `mode='mirror'`

### DIFF
--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -155,6 +155,7 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
                   int mode, T cval, int origin) {
   int i, arr_len_thresh, lim = (win_len - 1) / 2 - origin;
   int lim2 = arr_len - lim;
+  if (lim2 < 0) return;
   int offset;
   Mediator *m = MediatorNew(win_len, rank);
   T *data = new T[win_len]();
@@ -200,7 +201,6 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
     MediatorInsert(data, m, in_arr[i]);
     out_arr[i - lim] = data[m->heap[0]];
   }
-
   switch (mode) {
   case REFLECT:
     arr_len_thresh = arr_len - 1;

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -157,11 +157,7 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
   int lim2 = arr_len - lim;
   int offset;
   Mediator *m = MediatorNew(win_len, rank);
-  T *data = new T[win_len];
-  for (int i = 0; i < win_len; ++i) {
-    data[i] = 0;
-  }
-
+  T *data = new T[win_len]();
 
   switch (mode) {
   case REFLECT:
@@ -204,6 +200,7 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
     MediatorInsert(data, m, in_arr[i]);
     out_arr[i - lim] = data[m->heap[0]];
   }
+
   switch (mode) {
   case REFLECT:
     arr_len_thresh = arr_len - 1;
@@ -227,7 +224,7 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
     break;
   case MIRROR:
     arr_len_thresh = arr_len - 2;
-    for (i = 0; i < lim + 1; i++) {
+    for (i = 0; i < lim; i++) {
       MediatorInsert(data, m, in_arr[arr_len_thresh - i]);
       out_arr[lim2 + i] = data[m->heap[0]];
     }

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2982,3 +2982,40 @@ class TestVectorizedFilter:
         res = ndimage.vectorized_filter(input, function, size=21)
         ref = ndimage.vectorized_filter(input, function, size=21)
         xp_assert_close(res, ref)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize('length', range(1, 1000, 50))
+@pytest.mark.parametrize('size', range(1, 25))
+@pytest.mark.parametrize('mode', ['reflect', 'constant', 'nearest', 'mirror', 'wrap'])
+def test_gh_22586_median_filter_no_segfault_and_1d_matches_nd(
+    length: int,
+    size: int,
+    mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    size = min(size, length)
+    arr = np.random.random(length)
+    mf = functools.partial(
+        ndimage.median_filter,
+        size=size,
+        mode=mode,
+    )
+    actual = mf(arr)
+
+    # Monkeypatch _rank_filter_1d.rank_filter() to actually call
+    # _nd_image.rank_filter() so that 1D results from the optimized
+    # implementation can be compared to the general ND implementation
+
+    def _1d_to_nd_rank_filter(i, r, s, *args):
+        from scipy.ndimage import _nd_image
+        return _nd_image.rank_filter(i, r, np.ones(s, dtype=bool), *args)
+
+    with monkeypatch.context():
+        monkeypatch.setattr(
+            'scipy.ndimage._rank_filter_1d.rank_filter',
+            _1d_to_nd_rank_filter,
+        )
+        desired = mf(arr)
+
+    np.testing.assert_array_almost_equal(actual, desired)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3018,4 +3018,4 @@ def test_gh_22586_median_filter_no_segfault_and_1d_matches_nd(
         )
         desired = mf(arr)
 
-    np.testing.assert_array_almost_equal(actual, desired)
+    np.testing.assert_allclose(actual, desired)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-22586

#### What does this implement/fix?
Fixed an off-by-one error in the 1D optimized implementation of `ndimage.median_filter()` when `mode='mirror'` is selected, which was resulting in segfaults down the line.

#### Additional information
- Added a test case that compares the 1D implementation to the general ND implementation
  - This test also reliably reproduced the segfault
- Updated the initialization of the working `data` array to use the C++ zerod syntax: `new T[len]();`

Please let me know if you need anything else!
