### PR TITLE
ENH: _lib.doccer: Simplify and optimize indentation loop

### DIFF
--- a/scipy/_lib/doccer.py
+++ b/scipy/_lib/doccer.py
@@ -75,13 +75,7 @@ def docformat(docstring: str, docdict: Mapping[str, str] | None = None) -> str:
     indented = {}
     for name, dstr in docdict.items():
         lines = dstr.expandtabs().splitlines()
-        try:
-            newlines = [lines[0]]
-            for line in lines[1:]:
-                newlines.append(indent + line)
-            indented[name] = "\n".join(newlines)
-        except IndexError:
-            indented[name] = dstr
+        indented[name] = ("\n" + indent).join(lines)
     return docstring % indented
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Related to #22510

#### What does this implement/fix?

Within `scipy._lib.doccer.docformat()`, there is a loop. The purpose of this loop is to make the indentation level of each piece of substituted text match the indentation level of the entire docstring.

According to profiling via line_profiler, docformat can spend 52% of its time in this loop.

<details>

```plain
Timer unit: 1e-09 s

Total time: 0.785777 s
File: /home/nodell/scipy/build-install/lib/python3.13/site-packages/scipy/_lib/doccer.py
Function: docformat at line 30

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    30                                           @profile
    31                                           def docformat(docstring: str, docdict: Mapping[str, str] | None = None) -> str:
    32                                               """Fill a function docstring from variables in dictionary.
    33                                           
    34                                               Adapt the indent of the inserted docs
    35                                           
    36                                               Parameters
    37                                               ----------
    38                                               docstring : str
    39                                                   A docstring from a function, possibly with dict formatting strings.
    40                                               docdict : dict[str, str], optional
    41                                                   A dictionary with keys that match the dict formatting strings
    42                                                   and values that are docstring fragments to be inserted. The
    43                                                   indentation of the inserted docstrings is set to match the
    44                                                   minimum indentation of the ``docstring`` by adding this
    45                                                   indentation to all lines of the inserted string, except the
    46                                                   first.
    47                                           
    48                                               Returns
    49                                               -------
    50                                               docstring : str
    51                                                   string with requested ``docdict`` strings inserted.
    52                                           
    53                                               Examples
    54                                               --------
    55                                               >>> docformat(' Test string with %(value)s', {'value':'inserted value'})
    56                                               ' Test string with inserted value'
    57                                               >>> docstring = 'First line\\n    Second line\\n    %(value)s'
    58                                               >>> inserted_string = "indented\\nstring"
    59                                               >>> docdict = {'value': inserted_string}
    60                                               >>> docformat(docstring, docdict)
    61                                               'First line\\n    Second line\\n    indented\\n    string'
    62                                               """
    63      2429    2082402.0    857.3      0.3      if not docstring:
    64         1        441.0    441.0      0.0          return docstring
    65      2428    1183288.0    487.4      0.2      if docdict is None:
    66         5       1455.0    291.0      0.0          docdict = {}
    67      2428    1070446.0    440.9      0.1      if not docdict:
    68         5       3080.0    616.0      0.0          return docstring
    69      2423   31892366.0  13162.3      4.1      lines = docstring.expandtabs().splitlines()
    70                                               # Find the minimum indent of the main docstring, after first line
    71      2423    1836674.0    758.0      0.2      if len(lines) < 2:
    72                                                   icount = 0
    73                                               else:
    74      2423  100775874.0  41591.4     12.8          icount = indentcount_lines(lines[1:])
    75      2423    1366147.0    563.8      0.2      indent = " " * icount
    76                                               # Insert this indent to dictionary docstrings
    77      2423     805929.0    332.6      0.1      indented = {}
    78     73372   26625393.0    362.9      3.4      for name, dstr in docdict.items():
    79     70949  159164798.0   2243.4     20.3          lines = dstr.expandtabs().splitlines()
    80     70949   15544738.0    219.1      2.0          try:
    81     70949   39910529.0    562.5      5.1              newlines = [lines[0]]
    82    672483  180067488.0    267.8     22.9              for line in lines[1:]:
    83    605813  145010155.0    239.4     18.5                  newlines.append(indent + line)
    84     66670   50202881.0    753.0      6.4              indented[name] = "\n".join(newlines)
    85      4279    1804861.0    421.8      0.2          except IndexError:
    86      4279    1990186.0    465.1      0.3              indented[name] = dstr
    87      2423   24438219.0  10085.9      3.1      return docstring % indented

  0.79 seconds - /home/nodell/scipy/build-install/lib/python3.13/site-packages/scipy/_lib/doccer.py:30 - docformat
```

</details> 

The way it accomplishes this is:

 * For the first line, no indent is added.
 * For the second line onward, an indent discovered from the main docstring is added to the beginning of the line.
 * The lines are joined together with newlines.

The key thing to observe about the first two steps is that adding text before every second line onwards is the same thing as adding text between each line. This is what `str.join()` already does. Since we are already using join, we can add the text that we want to go between each line to the join string. This does 1 concatenation operation, rather than 1 per line of text in the replacement.

Also, this cannot trigger IndexError anymore, so I removed the try-except here.

#### Benchmarking

First, I re-ran the line_profiler on the new code with the same settings as I used above.

<details>

```
Timer unit: 1e-09 s

Total time: 0.39992 s
File: /home/nodell/scipy/build-install/lib/python3.13/site-packages/scipy/_lib/doccer.py
Function: docformat at line 30

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    30                                           @profile
    31                                           def docformat(docstring: str, docdict: Mapping[str, str] | None = None) -> str:
    32                                               """Fill a function docstring from variables in dictionary.
    33                                           
    34                                               Adapt the indent of the inserted docs
    35                                           
    36                                               Parameters
    37                                               ----------
    38                                               docstring : str
    39                                                   A docstring from a function, possibly with dict formatting strings.
    40                                               docdict : dict[str, str], optional
    41                                                   A dictionary with keys that match the dict formatting strings
    42                                                   and values that are docstring fragments to be inserted. The
    43                                                   indentation of the inserted docstrings is set to match the
    44                                                   minimum indentation of the ``docstring`` by adding this
    45                                                   indentation to all lines of the inserted string, except the
    46                                                   first.
    47                                           
    48                                               Returns
    49                                               -------
    50                                               docstring : str
    51                                                   string with requested ``docdict`` strings inserted.
    52                                           
    53                                               Examples
    54                                               --------
    55                                               >>> docformat(' Test string with %(value)s', {'value':'inserted value'})
    56                                               ' Test string with inserted value'
    57                                               >>> docstring = 'First line\\n    Second line\\n    %(value)s'
    58                                               >>> inserted_string = "indented\\nstring"
    59                                               >>> docdict = {'value': inserted_string}
    60                                               >>> docformat(docstring, docdict)
    61                                               'First line\\n    Second line\\n    indented\\n    string'
    62                                               """
    63      2429    1808695.0    744.6      0.5      if not docstring:
    64         1        406.0    406.0      0.0          return docstring
    65      2428    1150214.0    473.7      0.3      if docdict is None:
    66         5       1292.0    258.4      0.0          docdict = {}
    67      2428    1000179.0    411.9      0.3      if not docdict:
    68         5       2734.0    546.8      0.0          return docstring
    69      2423   31472606.0  12989.1      7.9      lines = docstring.expandtabs().splitlines()
    70                                               # Find the minimum indent of the main docstring, after first line
    71      2423    1806219.0    745.4      0.5      if len(lines) < 2:
    72                                                   icount = 0
    73                                               else:
    74      2423   99171596.0  40929.3     24.8          icount = indentcount_lines(lines[1:])
    75      2423    1366392.0    563.9      0.3      indent = " " * icount
    76                                               # Insert this indent to dictionary docstrings
    77      2423     726530.0    299.8      0.2      indented = {}
    78     73372   22405207.0    305.4      5.6      for name, dstr in docdict.items():
    79     70949  166560444.0   2347.6     41.6          lines = dstr.expandtabs().splitlines()
    80     70949   49440320.0    696.8     12.4          indented[name] = ("\n" + indent).join(lines)
    81      2423   23007068.0   9495.3      5.8      return docstring % indented

  0.40 seconds - /home/nodell/scipy/build-install/lib/python3.13/site-packages/scipy/_lib/doccer.py:30 - docformat

```

</details>

The result is that it spends only 12% of its time executing the replacement line, versus 52% originally.

I also wrote a benchmark which aims to test how a real user would use frozen distributions. It creates several frozen distributions, then runs some statistical functions on them, and does that in a loop. This benchmark does not include any profiling, to avoid biases caused by profiler overhead.

```python
import numpy
import scipy.stats
import time


def main():
    df = 10
    mean = 0
    std = 1
    start = time.perf_counter()
    for i in range(500):
        # Create T-distribution and Normal distribution objects
        rv_t = scipy.stats.t(df, mean, std)
        rv_n = scipy.stats.norm(mean, std)

        # Evaluate their PDFs on a grid of x-values
        x_vals = numpy.linspace(-3, 3, 100)
        t_pdf = rv_t.pdf(x_vals)
        n_pdf = rv_n.pdf(x_vals)
    end = time.perf_counter()
    print(f"Duration: {end - start:.2f}")

if __name__ == '__main__':
    main()
```

Benchmark results:

Before change: 0.97s  
After change: 0.91s

This is about 7% faster on a real-world benchmark.

#### Additional information

Testing notes:

I tested this in two ways:

1. docformat has a testcase with a replacement string which contains multiple lines with indentation already. This test passes.
2. I changed the code so that it ran both the old code and the new code, and asserted that the docstring that each of them produced was equivalent. I then imported scipy.stats, which freezes all of the distributions. These asserts pass.
