### PR TITLE
MAINT: linalg: fix cython lint failures in build output

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -47,7 +47,7 @@ cimport cython
 cimport libc.stdlib
 cimport libc.limits
 cimport libc.float
-from libc.math cimport sqrt, fabs, hypot, M_SQRT1_2
+from libc.math cimport sqrt, M_SQRT1_2
 from libc.string cimport memset
 
 cimport numpy as cnp
@@ -289,7 +289,7 @@ cdef int to_lwork(blas_t a, blas_t b) noexcept nogil:
 
 cdef bint reorthx(int m, int n, blas_t* q, int* qs, bint qisF, int j, blas_t* u, blas_t* s) noexcept nogil:
     # U should be all zeros on entry., and m > 1
-    cdef blas_t unorm, snorm, wnorm, wpnorm, sigma_max, sigma_min, rc
+    cdef blas_t wnorm, wpnorm
     cdef char* T = 'T'
     cdef char* N = 'N'
     cdef char* C = 'C'
@@ -353,7 +353,6 @@ cdef int thin_qr_row_delete(int m, int n, blas_t* q, int* qs, bint qisF,
     cdef size_t usize = (m + 3*n + 1) * sizeof(blas_t)
     cdef blas_t* s
     cdef blas_t* u
-    cdef blas_t* s1
     cdef int us[2]
     cdef int ss[2]
     cdef blas_t c, sn, min_row_norm, row_norm
@@ -686,8 +685,7 @@ cdef int thin_qr_col_insert(int m, int n, blas_t* q, int* qs, blas_t* r,
 cdef void qr_col_insert(int m, int n, blas_t* q, int* qs, blas_t* r, int* rs,
                         int k) noexcept nogil:
     cdef int j
-    cdef blas_t c, s, temp, tau
-    cdef blas_t* work
+    cdef blas_t c, s
 
     for j in range(m-2, k-1, -1):
         lartg(index2(r, rs, j, k), index2(r, rs, j+1, k), &c, &s)
@@ -1194,7 +1192,6 @@ cdef form_qTu(cnp.ndarray q, cnp.ndarray u, void* qTuvoid, int* qTus, int k):
     cdef int m = q.shape[0]
     cdef int n = q.shape[1]
     cdef int typecode = cnp.PyArray_TYPE(q)
-    cdef cnp.ndarray qTu
     cdef char* T = 'T'
     cdef char* C = 'C'
     cdef char* N = 'N'
@@ -1881,8 +1878,6 @@ cdef qr_insert_row(Q, R, u, int k, bint overwrite_qru, bint check_finite):
 
 cdef qr_insert_col(Q, R, u, int k, rcond, bint overwrite_qru, bint check_finite):
     cdef cnp.ndarray q1, r1, u1, qnew, rnew
-    cdef int j
-    cdef int q_flags = ARRAY_ANYORDER
     cdef int u_flags = cnp.NPY_ARRAY_BEHAVED_NS | cnp.NPY_ARRAY_ELEMENTSTRIDES
     cdef int typecode, m, n, p, info, p_eco, p_full
     cdef void* qptr


### PR DESCRIPTION
This change removes unused variables in cython linalg component. 
See ticket #22053