### PR TITLE
BUG: Fix dual quaternion normalization procedure

### DIFF
--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -3,6 +3,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_allclose
 from scipy.spatial.transform import Rotation, RigidTransform
+from scipy.spatial.transform._rigid_transform import normalize_dual_quaternion
 
 
 def test_repr():
@@ -896,3 +897,12 @@ def test_copy_flag():
     tf = RigidTransform(matrix, normalize=False, copy=False)
     matrix[0, 0] = 2
     assert tf.as_matrix()[0, 0] == 2
+
+
+def test_normalize_dual_quaternion():
+    rng = np.random.default_rng(103213650)
+    dual_quat = rng.normal(size=(1000, 8))
+    dual_quat = normalize_dual_quaternion(dual_quat)
+    assert_allclose(np.linalg.norm(dual_quat[:, :4], axis=1), 1.0, atol=1e-12)
+    assert_allclose(np.einsum("ij,ij->i", dual_quat[:, :4], dual_quat[:, 4:]),
+                    0.0, atol=1e-12)

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -900,6 +900,10 @@ def test_copy_flag():
 
 
 def test_normalize_dual_quaternion():
+    dual_quat = normalize_dual_quaternion(np.zeros((1, 8)))
+    assert_allclose(np.linalg.norm(dual_quat[0, :4]), 1.0, atol=1e-12)
+    assert_allclose(dual_quat[0, :4] @ dual_quat[0, 4:], 0.0, atol=1e-12)
+
     rng = np.random.default_rng(103213650)
     dual_quat = rng.normal(size=(1000, 8))
     dual_quat = normalize_dual_quaternion(dual_quat)


### PR DESCRIPTION
The dual quaternion normalization procedure introduced with https://github.com/scipy/scipy/pull/22267 seems to be incorrect and slightly inefficient. This PR fixes these issues.

It is incorrect because it uses np.linalg.norm on a quaternion with only a scalar part where it should use np.sqrt for the scalar part, which means that the component of the normalization factor is $\sqrt{r^2} = r$, when it should actually be $\sqrt{r}$. In addition, there was an issue with the real part being updated and then used to compute the dual part while the old real part should be used in the update.

Furthermore, there were some inefficiencies because quaternion multiplication was used at places where a scalar multiplication was sufficient.

So far this bug did not cause any problems because dual quaternions are converted to valid transformation matrices internally.

Ping @scottshambaugh @nmayorov who were involved in the PR that added this module.
