### PR TITLE
ENH: signal.convolve2d: Performance Enhancement on WoA

### DIFF
--- a/scipy/signal/_firfilter.cc
+++ b/scipy/signal/_firfilter.cc
@@ -29,7 +29,18 @@ typedef void (OneMultAddFunction) (char *, char *, int64_t, char **, int64_t);
 #define MAKE_ONEMULTADD(fname, type) \
 static void fname ## _onemultadd(char *sum, char *term1, int64_t str, char **pvals, int64_t n) { \
         type dsum = *(type*)sum; \
-        for (int64_t k=0; k < n; k++) { \
+        int64_t k = 0; \
+        for (; k <= n - 4; k += 4) { \
+          type tmp0 = *(type*)(term1 + (k + 0) * str); \
+          type tmp1 = *(type*)(term1 + (k + 1) * str); \
+          type tmp2 = *(type*)(term1 + (k + 2) * str); \
+          type tmp3 = *(type*)(term1 + (k + 3) * str); \
+          dsum += tmp0 * *(type*)pvals[k + 0] + \
+                  tmp1 * *(type*)pvals[k + 1] + \
+                  tmp2 * *(type*)pvals[k + 2] + \
+                  tmp3 * *(type*)pvals[k + 3]; \
+        } \
+        for (; k < n; k++) { \
           type tmp = *(type*)(term1 + k * str); \
           dsum += tmp * *(type*)pvals[k]; \
         } \


### PR DESCRIPTION
The PR improves the performance of the Convolve2d functions on WoA devices.
The ONE_MULTADD function, used by Convolve2d, performs poorly on WoA, causing a performance gap between ARM and X64. 
By implementing loop unrolling for the ONE_MULTADD function, there is a significant performance improvement on WoA. 
However, these optimizations did not affect X64, and the performance remained the same as the previous implementation.
<img width="515" alt="Convolve2d Benchmarks" src="https://github.com/user-attachments/assets/cc378ba2-52db-4be5-b9ae-2e616b779cb5" />
