### PR TITLE
MAINT: stats.tmin/tmax: ensure exact results with unreasonably large integers

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -263,6 +263,12 @@ class TestTrimmedStats:
         xp_assert_close(y, xp.std(y_ref, correction=1) / xp_size(y_ref)**0.5)
         xp_assert_close(stats.tsem(x, limits=[-1, 10]), stats.tsem(x, limits=None))
 
+    def test_gh_22626(self, xp):
+        # Test that `tmin`/`tmax` returns exact result with outrageously large integers
+        x = xp.arange(2**62, 2**62+10)
+        xp_assert_equal(stats.tmin(x[None, :]), x)
+        xp_assert_equal(stats.tmax(x[None, :]), x)
+
 
 class TestPearsonrWilkinson:
     """ W.II.D. Compute a correlation matrix on all the variables.


### PR DESCRIPTION
#### Reference issue
Closes gh-22626

#### What does this implement/fix?
gh-22626 noted that the results of `tmin`/`tmax` could produce results with relative errors as high as ~`1e-16` when the calculation could have been exact. This avoids the problem and ensures exact results for integer input by ensuring that the calculations remain integral throughout.

@crusaderky