### PR TITLE
MAINT: stats: tmin/tmax tweaks

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -778,14 +778,15 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
     """
     xp = array_namespace(a)
 
-    max = xp.iinfo(a.dtype).max if xp.isdtype(a.dtype, 'integral') else xp.inf
+    max_ = xp.iinfo(a.dtype).max if xp.isdtype(a.dtype, 'integral') else xp.inf
     a, mask = _put_val_to_limits(a, (lowerlimit, None), (inclusive, None),
-                                 val=max, xp=xp)
+                                 val=max_, xp=xp)
 
-    min = xp.min(a, axis=axis)
-    n = xp.sum(xp.asarray(~mask, dtype=a.dtype), axis=axis)
-    res = xp.where(n != 0, min, xp.nan) if xp.any(n == 0) else min
-
+    min_ = xp.min(a, axis=axis)
+    mask = ~xp.all(mask, axis=axis)  # At least one element above lowerlimit
+    # Output dtype is data-dependent
+    # Possible loss of precision for int types
+    res = min_ if xp.all(mask) else xp.where(mask, min_, xp.nan)
     return res[()] if res.ndim == 0 else res
 
 
@@ -835,14 +836,15 @@ def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
     """
     xp = array_namespace(a)
 
-    min = xp.iinfo(a.dtype).min if xp.isdtype(a.dtype, 'integral') else -xp.inf
+    min_ = xp.iinfo(a.dtype).min if xp.isdtype(a.dtype, 'integral') else -xp.inf
     a, mask = _put_val_to_limits(a, (None, upperlimit), (None, inclusive),
-                                 val=min, xp=xp)
+                                 val=min_, xp=xp)
 
-    max = xp.max(a, axis=axis)
-    n = xp.sum(xp.asarray(~mask, dtype=a.dtype), axis=axis)
-    res = xp.where(n != 0, max, xp.nan) if xp.any(n == 0) else max
-
+    max_ = xp.max(a, axis=axis)
+    mask = ~xp.all(mask, axis=axis)  # At least one element below upperlimit
+    # Output dtype is data-dependent
+    # Possible loss of precision for int types
+    res = max_ if xp.all(mask) else xp.where(mask, max_, xp.nan)
     return res[()] if res.ndim == 0 else res
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -783,10 +783,10 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
                                  val=max_, xp=xp)
 
     min_ = xp.min(a, axis=axis)
-    mask = ~xp.all(mask, axis=axis)  # At least one element above lowerlimit
+    valid = ~xp.all(mask, axis=axis)  # At least one element above lowerlimit
     # Output dtype is data-dependent
     # Possible loss of precision for int types
-    res = min_ if xp.all(mask) else xp.where(mask, min_, xp.nan)
+    res = min_ if xp.all(valid) else xp.where(valid, min_, xp.nan)
     return res[()] if res.ndim == 0 else res
 
 
@@ -841,10 +841,10 @@ def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
                                  val=min_, xp=xp)
 
     max_ = xp.max(a, axis=axis)
-    mask = ~xp.all(mask, axis=axis)  # At least one element below upperlimit
+    valid = ~xp.all(mask, axis=axis)  # At least one element below upperlimit
     # Output dtype is data-dependent
     # Possible loss of precision for int types
-    res = max_ if xp.all(mask) else xp.where(mask, max_, xp.nan)
+    res = max_ if xp.all(valid) else xp.where(valid, max_, xp.nan)
     return res[()] if res.ndim == 0 else res
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -40,9 +40,10 @@ from scipy.stats._stats_py import (_permutation_distribution_t, _chk_asarray, _m
                                    LinregressResult, _xp_mean, _xp_var, _SimpleChi2)
 from scipy._lib._util import AxisError
 from scipy.conftest import skip_xp_invalid_arg
-from scipy._lib._array_api import (array_namespace, xp_copy, is_lazy_array, is_numpy,
+from scipy._lib._array_api import (array_namespace, is_lazy_array, is_numpy,
                                    is_torch, xp_default_dtype, xp_size, SCIPY_ARRAY_API)
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
+import scipy._lib.array_api_extra as xpx
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 boolean_index_skip_reason = 'JAX/Dask arrays do not support boolean assignment.'
@@ -73,7 +74,6 @@ TINY = array([1e-12,2e-12,3e-12,4e-12,5e-12,6e-12,7e-12,8e-12,9e-12], float)
 ROUND = array([0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5], float)
 
 
-@skip_xp_backends('jax.numpy', reason="JAX doesn't allow item assignment.")
 # TODO: re-check whether this works after lazywhere moved to array-api-extra
 @skip_xp_backends("dask.array", reason="lazywhere doesn't work with dask")
 class TestTrimmedStats:
@@ -114,8 +114,7 @@ class TestTrimmedStats:
         y_true = [10.5, 11.5, 9, 10, 11, 12, 13]
         xp_assert_close(y, xp.asarray(y_true))
 
-        x_2d_with_nan = xp_copy(x_2d)
-        x_2d_with_nan[-1, -3:] = xp.nan
+        x_2d_with_nan = xpx.at(x_2d)[-1, -3:].set(xp.nan, copy=True)
         y = stats.tmean(x_2d_with_nan, limits=(1, 13), axis=0)
         y_true = [7, 4.5, 5.5, 6.5, xp.nan, xp.nan, xp.nan]
         xp_assert_close(y, xp.asarray(y_true))
@@ -185,8 +184,7 @@ class TestTrimmedStats:
         xp_assert_equal(stats.tmin(x, axis=1), xp.asarray([0, 2, 4, 6, 8]))
         xp_assert_equal(stats.tmin(x, axis=None), xp.asarray(0))
 
-        x = xp.arange(10.)
-        x[9] = xp.nan
+        x = xpx.at(xp.arange(10.), 9).set(xp.nan)
         xp_assert_equal(stats.tmin(x), xp.asarray(xp.nan))
 
         # check that if a full slice is masked, the output returns a
@@ -226,8 +224,7 @@ class TestTrimmedStats:
         xp_assert_equal(stats.tmax(x, axis=1), xp.asarray([1, 3, 5, 7, 9]))
         xp_assert_equal(stats.tmax(x, axis=None), xp.asarray(9))
 
-        x = xp.arange(10.)
-        x[9] = xp.nan
+        x = xpx.at(xp.arange(10.), 9).set(xp.nan)
         xp_assert_equal(stats.tmax(x), xp.asarray(xp.nan))
 
         # check that if a full slice is masked, the output returns a
@@ -240,7 +237,7 @@ class TestTrimmedStats:
 
     @skip_xp_backends(np_only=True,
                       reason="Only NumPy arrays support scalar input/`nan_policy`.")
-    def test_tax_scalar_and_nanpolicy(self, xp):
+    def test_tmax_scalar_and_nanpolicy(self, xp):
         assert_equal(stats.tmax(4), 4)
 
         x = np.arange(10.)
@@ -747,8 +744,7 @@ class TestPearsonr:
 
         message = 'An input array is constant'
         with pytest.warns(stats.ConstantInputWarning, match=message):
-            x = xp_copy(x0)
-            x[0, ...] = 1
+            x = xpx.at(x0)[0, ...].set(1, copy=True)
             res = stats.pearsonr(x, y0, axis=1)
             ci = res.confidence_interval()
             nan = xp.asarray(xp.nan, dtype=xp.float64)


### PR DESCRIPTION
- Simplify and possibly slightly speed up algorithm of tmin and tmax
- ~~Unskip JAX tests~~

~~**Note:** downstream of this PR + #22557, Dask and JAX will work on trimmed stats *however* JAX will only work in eager mode and Dask will compute the graph multiple times. Making them fully lazy is non-trivial and the target of a later PR.~~
