### PR TITLE
MAINT: stats.multinomial: use dtype-dependent tolerance

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3275,12 +3275,13 @@ class multinomial_gen(multi_rv_generic):
         """
         return multinomial_frozen(n, p, seed)
 
-    def _process_parameters(self, n, p, eps=1e-15):
+    def _process_parameters(self, n, p):
         """Returns: n_, p_, npcond.
 
         n_ and p_ are arrays of the correct shape; npcond is a boolean array
         flagging values out of the domain.
         """
+        eps = np.finfo(np.result_type(np.asarray(p), np.float32)).eps * 10
         p = np.array(p, dtype=np.float64, copy=True)
         p_adjusted = 1. - p[..., :-1].sum(axis=-1)
         # only make adjustment when it's significant

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -2063,11 +2063,12 @@ class TestMultinomial:
         logpmf = multinomial.logpmf(x, n, p)
         assert np.isfinite(logpmf)
 
-    def test_gh_22565(self):
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    def test_gh_22565(self, dtype):
         # Same issue as gh-11860 above, essentially, but the original
         # fix didn't completely solve the problem.
         n = 19
-        p = [0.2, 0.2, 0.2, 0.2, 0.2]
+        p = np.asarray([0.2, 0.2, 0.2, 0.2, 0.2], dtype=dtype)
         res1 = multinomial.pmf(x=[1, 2, 5, 7, 4], n=n, p=p)
         res2 = multinomial.pmf(x=[1, 2, 4, 5, 7], n=n, p=p)
         np.testing.assert_allclose(res1, res2, rtol=1e-15)


### PR DESCRIPTION
#### Reference issue
gh-22585

#### What does this implement/fix?
gh-22585 adjusted the condition under which `p` is normalized in `scipy.stats.multinomial`. `multinomial` has converted `p` to `float64` internally since it was introduced, but users have been allowed to pass in input with other dtypes, and the change did not take this into account. This compensates by making the tolerance dtype-dependent.