### PR TITLE
MAINT: fix domain check for `ncfdtri`

### DIFF
--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -880,7 +880,7 @@ ncf_ppf_wrap(const Real v1, const Real v2, const Real l, const Real x)
 	return NAN;
     }
     if ((v1 <= 0) || (v2 <= 0) || (l < 0) || (x < 0) || (x > 1)) {
-	sf_error("ncfdtr", SF_ERROR_DOMAIN, NULL);
+	sf_error("ncfdtri", SF_ERROR_DOMAIN, NULL);
 	return NAN;
     }
     Real y;

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -551,6 +551,18 @@ def test_ncfdtr(dfn, dfd, nc, f, expected):
     assert_allclose(sp.ncfdtr(dfn, dfd, nc, f), expected, rtol=1e-13, atol=0)
 
 
+@pytest.mark.parametrize(
+    "args",
+    [(-1.0, 0.1, 0.1, 0.5),
+     (1, -1.0, 0.1, 0.5),
+     (1, 1, -1.0, 0.5),
+     (1, 1, 1, 100)]
+)
+def test_ncfdtri_domain_error(args):
+    with sp.errstate(domain="raise"):
+        with pytest.raises(sp.SpecialFunctionError, match="domain"):
+            sp.ncfdtri(*args)
+
 class TestNoncentralTFunctions:
 
     # Reference values computed with mpmath with the following script

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -556,7 +556,8 @@ def test_ncfdtr(dfn, dfd, nc, f, expected):
     [(-1.0, 0.1, 0.1, 0.5),
      (1, -1.0, 0.1, 0.5),
      (1, 1, -1.0, 0.5),
-     (1, 1, 1, 100)]
+     (1, 1, 1, 100),
+     (1, 1, 1, -1)]
 )
 def test_ncfdtri_domain_error(args):
     with sp.errstate(domain="raise"):


### PR DESCRIPTION
#### What does this implement/fix?
#21505 introduced a small typo: if parameters were outside of the correct domain, `ncfdtri` would raise the error for `ncfdtr` instead. Noticed this while working on #22539 .
