### PR TITLE
BUG: sparse: sparse sum/mean out parameter shape not enforced for 1D

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1150,13 +1150,8 @@ class _spbase(SparseABC):
         if self.ndim == 1:
             if axis not in (None, -1, 0):
                 raise ValueError("axis must be None, -1 or 0")
-            ret = (self @ np.ones(self.shape, dtype=res_dtype)).astype(dtype)
-
-            if out is not None:
-                if any(dim != 1 for dim in out.shape):
-                    raise ValueError("dimensions do not match")
-                out[...] = ret
-            return ret
+            res = self @ np.ones(self.shape, dtype=res_dtype)
+            return res.sum(dtype=dtype, out=out)
 
         # We use multiplication by a matrix of ones to achieve this.
         # For some sparse array formats more efficient methods are
@@ -1183,14 +1178,6 @@ class _spbase(SparseABC):
             ret = self @ self._ascontainer(
                 np.ones((N, 1), dtype=res_dtype)
             )
-
-        if out is not None:
-            if isinstance(self, sparray):
-                ret_shape = ret.shape[:axis] + ret.shape[axis + 1:]
-            else:
-                ret_shape = ret.shape
-            if out.shape != ret_shape:
-                raise ValueError("dimensions do not match")
 
         return ret.sum(axis=axis, dtype=dtype, out=out)
 

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -677,9 +677,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             if axis % 2 == 1:
                 ret = ret.T
 
-            if out is not None and out.shape != ret.shape:
-                raise ValueError('dimensions do not match')
-
             return ret.sum(axis=(), dtype=dtype, out=out)
         else:
             # _spbase handles the situations when axis is in {None, -2, -1, 0, 1}

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -174,9 +174,6 @@ class _dia_base(_data_matrix):
 
             ret = self._ascontainer(row_sums.sum(axis=axis))
 
-        if out is not None and out.shape != ret.shape:
-            raise ValueError("dimensions do not match")
-
         return ret.sum(axis=(), dtype=dtype, out=out)
 
     sum.__doc__ = _spbase.sum.__doc__

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1089,6 +1089,12 @@ class _TestCommon:
         datsp.sum(axis=1, out=datsp_out)
         assert_array_almost_equal(dat_out, datsp_out)
 
+        # check that wrong shape out parameter raises
+        with assert_raises(ValueError, match="output parameter.*wrong.*dimension"):
+            datsp.sum(out=array([0]))
+        with assert_raises(ValueError, match="output parameter.*wrong.*dimension"):
+            datsp.sum(out=array([[0]] if self.is_array_test else 0))
+
     def test_numpy_sum(self):
         # See gh-5987
         dat = array([[0, 1, 2],
@@ -1185,6 +1191,12 @@ class _TestCommon:
         dat.mean(axis=1, out=dat_out, keepdims=keep)
         datsp.mean(axis=1, out=datsp_out)
         assert_array_almost_equal(dat_out, datsp_out)
+
+        # check that wrong shape out parameter raises
+        with assert_raises(ValueError, match="output parameter.*wrong.*dimension"):
+            datsp.mean(out=array([0]))
+        with assert_raises(ValueError, match="output parameter.*wrong.*dimension"):
+            datsp.mean(out=array([[0]] if self.is_array_test else 0))
 
     def test_numpy_mean(self):
         # See gh-5987

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -142,7 +142,7 @@ class TestCommon1D:
             datsp.sum(axis=(0, 1))
         with pytest.raises(TypeError, match='axis must be an integer'):
             datsp.sum(axis=1.5)
-        with pytest.raises(ValueError, match='dimensions do not match'):
+        with pytest.raises(ValueError, match='output parameter.*wrong.*dimension'):
             datsp.sum(axis=0, out=out)
 
     def test_numpy_sum(self, spcreator):
@@ -180,7 +180,7 @@ class TestCommon1D:
             datsp.mean(axis=(0, 1))
         with pytest.raises(TypeError, match='axis must be an integer'):
             datsp.mean(axis=1.5)
-        with pytest.raises(ValueError, match='dimensions do not match'):
+        with pytest.raises(ValueError, match='output parameter.*wrong.*dimension'):
             datsp.mean(axis=1, out=out)
 
     def test_sum_dtype(self, spcreator):
@@ -209,16 +209,21 @@ class TestCommon1D:
         dat = np.array([0, 1, 2])
         datsp = spcreator(dat)
 
-        dat_out = np.array([0])
-        datsp_out = np.array([0])
+        dat_out = np.array(0)
+        datsp_out = np.array(0)
 
-        dat.mean(out=dat_out, keepdims=True)
+        dat.mean(out=dat_out)
         datsp.mean(out=datsp_out)
         assert_allclose(dat_out, datsp_out)
 
-        dat.mean(axis=0, out=dat_out, keepdims=True)
+        dat.mean(axis=0, out=dat_out)
         datsp.mean(axis=0, out=datsp_out)
         assert_allclose(dat_out, datsp_out)
+
+        with pytest.raises(ValueError, match="output parameter.*dimension"):
+            datsp.mean(out=np.array([0]))
+        with pytest.raises(ValueError, match="output parameter.*dimension"):
+            datsp.mean(out=np.array([[0]]))
 
     def test_numpy_mean(self, spcreator):
         dat = np.array([0, 1, 2])


### PR DESCRIPTION
I found that for 1D sparse arrays, the `sum` and `mean` methods do not enforce their `out` parameters to be the right size. Specifically, `A.sum(out=out)` works for `out` with shape in `[(), (1,), (1,1)]`. The tests make sure it works for `(1,)` but don't test cases that shouldn't work. And the case it makes sure works, shouldn't work if we want to match numpy.

Fixed test and added new tests of invalid input and fixed sum/mean methods. While putting in the fix, I noticed that both 1D and 2D code attempts to check the `out` parameter, but we can let numpy do that instead (nice error message, ensures same behavior as numpy, probably faster, etc.). This also simplifies the code for our `sum` method in a few modules.

I doubt anyone is counting on the lack of enforcement of 1D out parameters for sum and mean, yet. But they eventually would. And this cleans up sum/mean code a little too.

@perimosocordiae this is a side-track on the way toward an improved `validateaxes` method.