### PR TITLE
BUG: spatial.transform.Rotation: support 0-length rotations

### DIFF
--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -3762,7 +3762,7 @@ class Slerp:
         if not isinstance(rotations, Rotation):
             raise TypeError("`rotations` must be a `Rotation` instance.")
 
-        if rotations.single or len(rotations) == 1:
+        if rotations.single or len(rotations) <= 1:
             raise ValueError("`rotations` must be a sequence of at least 2 rotations.")
 
         times = np.asarray(times)

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -456,7 +456,12 @@ cdef inline void _compose_quat_single( # calculate p * q into r
 cdef inline double[:, :] _compose_quat(
     const double[:, :] p, const double[:, :] q
 ) noexcept:
-    cdef Py_ssize_t n = max(p.shape[0], q.shape[0])
+    cdef Py_ssize_t n
+    if p.shape[0] == 1:
+        n = q.shape[0]
+    else:
+        n = p.shape[0]
+         
     cdef double[:, :] product = _empty2(n, 4)
 
     # dealing with broadcasting

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -850,8 +850,7 @@ cdef class Rotation:
         quat = np.asarray(quat, dtype=float)
 
         if (quat.ndim not in [1, 2]
-            or quat.shape[len(quat.shape) - 1] != 4
-            or quat.shape[0] == 0):
+            or quat.shape[len(quat.shape) - 1] != 4):
             raise ValueError("Expected `quat` to have shape (4,) or (N, 4), "
                              f"got {quat.shape}.")
 

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -456,11 +456,7 @@ cdef inline void _compose_quat_single( # calculate p * q into r
 cdef inline double[:, :] _compose_quat(
     const double[:, :] p, const double[:, :] q
 ) noexcept:
-    cdef Py_ssize_t n
-    if p.shape[0] == 1:
-        n = q.shape[0]
-    else:
-        n = p.shape[0]
+    cdef Py_ssize_t n = q.shape[0] if p.shape[0] == 1 else p.shape[0]
          
     cdef double[:, :] product = _empty2(n, 4)
 

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2958,7 +2958,7 @@ cdef class Rotation:
         array([0.24945696, 0.25054542, 0.24945696])
         """
         if self._quat.shape[0] == 0:
-            raise ValueError("Mean of empty rotation.")
+            raise ValueError("Mean of an empty rotation set is undefined.")
             
         if weights is None:
             weights = np.ones(len(self))

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2958,7 +2958,7 @@ cdef class Rotation:
         array([0.24945696, 0.25054542, 0.24945696])
         """
         if self._quat.shape[0] == 0:
-            raise RuntimeWarning("Mean of empty rotation.")
+            raise ValueError("Mean of empty rotation.")
             
         if weights is None:
             weights = np.ones(len(self))

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -15,12 +15,20 @@ np.import_array()
 
 # utilities for empty array initialization
 cdef inline double[:] _empty1(int n) noexcept:
+    if n == 0:
+        return array(shape=(1,), itemsize=sizeof(double), format=b"d")[:0]
     return array(shape=(n,), itemsize=sizeof(double), format=b"d")
 cdef inline double[:, :] _empty2(int n1, int n2) noexcept :
+    if n1 == 0:
+        return array( shape=(1, n2), itemsize=sizeof(double), format=b"d" )[:0]
     return array(shape=(n1, n2), itemsize=sizeof(double), format=b"d")
 cdef inline double[:, :, :] _empty3(int n1, int n2, int n3) noexcept:
+    if n1 == 0:
+        return array(shape=(1, n2, n3), itemsize=sizeof(double), format=b"d" )[:0]
     return array(shape=(n1, n2, n3), itemsize=sizeof(double), format=b"d")
 cdef inline double[:, :] _zeros2(int n1, int n2) noexcept:
+    if n1 == 0:
+        return array(shape=(1, n2), itemsize=sizeof(double), format=b"d")[:0]
     cdef double[:, :] arr = array(shape=(n1, n2),
         itemsize=sizeof(double), format=b"d")
     arr[:, :] = 0

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -20,11 +20,11 @@ cdef inline double[:] _empty1(int n) noexcept:
     return array(shape=(n,), itemsize=sizeof(double), format=b"d")
 cdef inline double[:, :] _empty2(int n1, int n2) noexcept :
     if n1 == 0:
-        return array( shape=(1, n2), itemsize=sizeof(double), format=b"d" )[:0]
+        return array( shape=(1, n2), itemsize=sizeof(double), format=b"d")[:0]
     return array(shape=(n1, n2), itemsize=sizeof(double), format=b"d")
 cdef inline double[:, :, :] _empty3(int n1, int n2, int n3) noexcept:
     if n1 == 0:
-        return array(shape=(1, n2, n3), itemsize=sizeof(double), format=b"d" )[:0]
+        return array(shape=(1, n2, n3), itemsize=sizeof(double), format=b"d")[:0]
     return array(shape=(n1, n2, n3), itemsize=sizeof(double), format=b"d")
 cdef inline double[:, :] _zeros2(int n1, int n2) noexcept:
     if n1 == 0:

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -20,7 +20,7 @@ cdef inline double[:] _empty1(int n) noexcept:
     return array(shape=(n,), itemsize=sizeof(double), format=b"d")
 cdef inline double[:, :] _empty2(int n1, int n2) noexcept :
     if n1 == 0:
-        return array( shape=(1, n2), itemsize=sizeof(double), format=b"d")[:0]
+        return array(shape=(1, n2), itemsize=sizeof(double), format=b"d")[:0]
     return array(shape=(n1, n2), itemsize=sizeof(double), format=b"d")
 cdef inline double[:, :, :] _empty3(int n1, int n2, int n3) noexcept:
     if n1 == 0:

--- a/scipy/spatial/transform/_rotation.pyx
+++ b/scipy/spatial/transform/_rotation.pyx
@@ -2957,6 +2957,9 @@ cdef class Rotation:
         >>> r.mean().as_euler('zyx', degrees=True)
         array([0.24945696, 0.25054542, 0.24945696])
         """
+        if self._quat.shape[0] == 0:
+            raise RuntimeWarning("Mean of empty rotation.")
+            
         if weights is None:
             weights = np.ones(len(self))
         else:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2133,7 +2133,7 @@ def test_zero_rotation_concatentation():
     assert len(r4) == 4
 
     for pp in [-1.5, -1, 0, 1, 1.5]:
-        pow0 = r0**0
+        pow0 = r**pp
         assert len(pow0) == 0
 
     # Methods

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1631,18 +1631,23 @@ def test_slerp_rot_is_rotation():
         t = np.array([0, 1])
         Slerp(t, r)
 
+SLERP_MESSAGE = "must be a sequence of at least 2 rotations"
 
 def test_slerp_single_rot():
-    msg = "must be a sequence of at least 2 rotations"
-    with pytest.raises(ValueError, match=msg):
-        r = Rotation.from_quat([1, 2, 3, 4])
+    r = Rotation.from_quat([1, 2, 3, 4])
+    with pytest.raises(ValueError, match=SLERP_MESSAGE):
         Slerp([1], r)
 
 
+def test_slerp_rot_len0():
+    r = Rotation.random()
+    with pytest.raises(ValueError, match=SLERP_MESSAGE):
+        Slerp([], r)
+
+
 def test_slerp_rot_len1():
-    msg = "must be a sequence of at least 2 rotations"
-    with pytest.raises(ValueError, match=msg):
-        r = Rotation.from_quat([[1, 2, 3, 4]])
+    r = Rotation.random(1)
+    with pytest.raises(ValueError, match=SLERP_MESSAGE):
         Slerp([1], r)
 
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2111,9 +2111,6 @@ def test_zero_rotation_multiplication():
     r_mult = r * r0
     assert len(r_mult) == 0
 
-    r0_mult = r0 * r0
-    assert len(r0_mult) == 0
-
     msg_rotation_error = "Expected equal number of rotations"
     r2 = Rotation.random(2)
     with pytest.raises(ValueError, match=msg_rotation_error):

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2093,7 +2093,7 @@ def test_zero_length_array():
     assert v0_rot.shape == (0, 3)
 
     v2 = np.ones((2, 3))
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Expected equal numbers of rotations and vectors"):
         r.apply(v2)
 
     # Multiplication
@@ -2108,11 +2108,12 @@ def test_zero_length_array():
     r0_mult = r * r0
     assert len(r0_mult) == 0
 
+    msg_rotation_error = "Expected equal number of rotations"
     r2 = Rotation.random(2)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg_rotation_error):
         r0 * r2
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=msg_rotation_error):
         r2 * r0
 
 
@@ -2142,18 +2143,20 @@ def test_zero_rotation_concatentation():
     magnitude = r.magnitude()
     assert magnitude.shape == (0,)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Mean of an empty rotation set is undefined."):
         r.mean()
 
     # Comparison
     assert r.approx_equal(Rotation.random(0)).shape == (0,)
     assert r.approx_equal(Rotation.random()).shape == (0,)
 
+    approx_msg = "Expected equal number of rotations in both or a single rotation in either object"
     r3 = Rotation.random(2)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=approx_msg):
         r.approx_equal(r3)
 
-    # Get / set
+    with pytest.raises(ValueError, match=approx_msg):
+        r3.approx_equal(r)
     r_get = r[[]]
     assert len(r_get) == 0
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2115,17 +2115,22 @@ def test_zero_length_array():
     with pytest.raises(ValueError):
         r2 * r0
 
-    # Concatenate
-    p_con = r.concatenate(Rotation.random(0))
-    assert len(p_con) == 0
 
-    p_con = r.concatenate(Rotation.random(1))
-    assert len(p_con) == 1
+def test_zero_rotation_concatentation():
+    r = Rotation.random(num=0)
 
-    p_con = r.concatenate(Rotation.random(3))
-    assert len(p_con) == 3
+    r0 = Rotation.concatenate([r, r])
+    assert len(r0) == 0
 
-    # Power
+    r1 = r.concatenate([Rotation.random(), r])
+    assert len(r1) == 1
+
+    r3 = r.concatenate([Rotation.random(3), r])
+    assert len(r3) == 3
+
+    r4 = r.concatenate([r, Rotation.random(4)])
+    assert len(r4) == 4
+
     for pp in [-1.5, -1, 0, 1, 1.5]:
         pow0 = r0**0
         assert len(pow0) == 0

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2072,7 +2072,7 @@ def test_zero_length_rotation():
     magnitude = r.magnitude()
     assert magnitude.shape == (0,)
 
-    with pytest.raises(RuntimeWarning):
+    with pytest.raises(ValueError):
         r.mean()
 
     # Comparison

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2039,3 +2039,48 @@ def test_compare_as_davenport_as_euler():
             eul = rot.as_euler(seq)
             dav = rot.as_davenport(ax, order)
             assert_allclose(eul, dav, rtol=1e-12)
+
+
+def test_zero_length_rotation():
+    r = Rotation.random(num=0)
+    assert len(r) == 0
+
+    # Quaternion
+    r_quat = Rotation.from_quat(np.zeros((0, 4)))
+    assert len(r_quat) == 0
+    assert r.as_quat().shape == (0, 4)
+
+    # Matrix
+    r_matrix = Rotation.from_matrix(np.zeros((0, 3, 3)))
+    assert len(r_matrix) == 0
+    assert r.as_matrix().shape == (0, 3, 3)
+
+    # Euler
+    r_euler = Rotation.from_euler("xyz", np.zeros((0, 3)))
+    assert len(r_euler) == 0
+    assert r.as_euler("xyz").shape == (0, 3)
+
+    # Vector rotation
+    v = np.array([1, 2, 3])
+    v_rotated = r.apply(v)
+    assert v_rotated.shape == (0, 3)
+
+    # Multiplication
+    r_single = Rotation.random()
+    r_mult = r * r_single
+    assert len(r_mult) == 0
+
+    r_inv = r.inv()
+    assert len(r_inv) == 0
+
+    magnitude = r.magnitude()
+    assert magnitude.shape == (0,)
+
+    with pytest.raises(RuntimeWarning):
+        r.mean()
+
+    # Comparison
+    assert r.approx_equal(Rotation.random(0)).shape == (0,)
+    r3 = Rotation.random(2)
+    with pytest.raises(ValueError):
+        r.approx_equal(r3)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2042,35 +2042,95 @@ def test_compare_as_davenport_as_euler():
             assert_allclose(eul, dav, rtol=1e-12)
 
 
-def test_zero_length_rotation():
+def test_zero_length_rotation_construction():
     r = Rotation.random(num=0)
     assert len(r) == 0
 
-    # Quaternion
+    r_ide = Rotation.identity(num=0)
+    assert len(r_ide) == 0
+
+    r_get = Rotation.random(num=3)[[]]
+    assert len(r_get) == 0
+
+    # Representations
+    assert r.as_quat().shape == (0, 4)
+    assert r.as_matrix().shape == (0, 3, 3)
+    assert r.as_euler("xyz").shape == (0, 3)
+    assert r.as_rotvec().shape == (0, 3)
+    assert r.as_mrp().shape == (0, 3)
+    assert r.as_davenport(np.eye(3), "extrinsic").shape == (0, 3)
+
+    # Construction
     r_quat = Rotation.from_quat(np.zeros((0, 4)))
     assert len(r_quat) == 0
-    assert r.as_quat().shape == (0, 4)
 
-    # Matrix
     r_matrix = Rotation.from_matrix(np.zeros((0, 3, 3)))
     assert len(r_matrix) == 0
-    assert r.as_matrix().shape == (0, 3, 3)
 
-    # Euler
     r_euler = Rotation.from_euler("xyz", np.zeros((0, 3)))
     assert len(r_euler) == 0
-    assert r.as_euler("xyz").shape == (0, 3)
+
+    r_vec = Rotation.from_rotvec(np.zeros((0, 3)))
+    assert len(r_vec) == 0
+
+    r_dav = Rotation.from_davenport(np.eye(3), "extrinsic", np.zeros((0, 3)))
+    assert len(r_dav) == 0
+
+    r_mrp = Rotation.from_mrp(np.zeros((0, 3)))
+    assert len(r_mrp) == 0
+
+
+def test_zero_length_array():
+    r = Rotation.random(num=0)
 
     # Vector rotation
     v = np.array([1, 2, 3])
     v_rotated = r.apply(v)
     assert v_rotated.shape == (0, 3)
 
+    v0 = np.zeros((0, 3))
+    v0_rot = r.apply(v0)
+    assert v0_rot.shape == (0, 3)
+
+    v2 = np.ones((2, 3))
+    with pytest.raises(ValueError):
+        r.apply(v2)
+
     # Multiplication
     r_single = Rotation.random()
-    r_mult = r * r_single
-    assert len(r_mult) == 0
+    r_mult_left = r * r_single
+    assert len(r_mult_left) == 0
 
+    r_mult_right = r_single * r
+    assert len(r_mult_right) == 0
+
+    r0 = Rotation.random(0)
+    r0_mult = r * r0
+    assert len(r0_mult) == 0
+
+    r2 = Rotation.random(2)
+    with pytest.raises(ValueError):
+        r0 * r2
+
+    with pytest.raises(ValueError):
+        r2 * r0
+
+    # Concatenate
+    p_con = r.concatenate(Rotation.random(0))
+    assert len(p_con) == 0
+
+    p_con = r.concatenate(Rotation.random(1))
+    assert len(p_con) == 1
+
+    p_con = r.concatenate(Rotation.random(3))
+    assert len(p_con) == 3
+
+    # Power
+    for pp in [-1.5, -1, 0, 1, 1.5]:
+        pow0 = r0**0
+        assert len(pow0) == 0
+
+    # Methods
     r_inv = r.inv()
     assert len(r_inv) == 0
 
@@ -2082,6 +2142,21 @@ def test_zero_length_rotation():
 
     # Comparison
     assert r.approx_equal(Rotation.random(0)).shape == (0,)
+    assert r.approx_equal(Rotation.random()).shape == (0,)
+
     r3 = Rotation.random(2)
     with pytest.raises(ValueError):
         r.approx_equal(r3)
+
+    # Get / set
+    r_get = r[[]]
+    assert len(r_get) == 0
+
+    with pytest.raises(IndexError):
+        r[[0]]
+
+    with pytest.raises(IndexError):
+        r[[True]]
+
+    with pytest.raises(IndexError):
+        r[0] = Rotation.random()

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2093,7 +2093,8 @@ def test_zero_rotation_array_rotation():
     assert v0_rot.shape == (0, 3)
 
     v2 = np.ones((2, 3))
-    with pytest.raises(ValueError, match="Expected equal numbers of rotations and vectors"):
+    with pytest.raises(
+        ValueError, match="Expected equal numbers of rotations and vectors"):
         r.apply(v2)
 
 
@@ -2167,7 +2168,7 @@ def test_zero_rotation_approx_equal():
     assert r.approx_equal(Rotation.random()).shape == (0,)
     assert Rotation.random().approx_equal(r).shape == (0,)
 
-    approx_msg = "Expected equal number of rotations in both or a single rotation in either object"
+    approx_msg = "Expected equal number of rotations"
     r3 = Rotation.random(2)
     with pytest.raises(ValueError, match=approx_msg):
         r.approx_equal(r3)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -168,10 +168,6 @@ def test_from_quat_wrong_shape():
             [[4, 5, 6, 7]]
             ]))
 
-    # 0-length 2d array
-    with pytest.raises(ValueError, match='Expected `quat` to have shape'):
-        Rotation.from_quat(np.array([]).reshape((0, 4)))
-
 
 def test_zero_norms_from_quat():
     x = np.array([

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2042,7 +2042,7 @@ def test_compare_as_davenport_as_euler():
             assert_allclose(eul, dav, rtol=1e-12)
 
 
-def test_zero_length_rotation_construction():
+def test_zero_rotation_construction():
     r = Rotation.random(num=0)
     assert len(r) == 0
 
@@ -2052,15 +2052,6 @@ def test_zero_length_rotation_construction():
     r_get = Rotation.random(num=3)[[]]
     assert len(r_get) == 0
 
-    # Representations
-    assert r.as_quat().shape == (0, 4)
-    assert r.as_matrix().shape == (0, 3, 3)
-    assert r.as_euler("xyz").shape == (0, 3)
-    assert r.as_rotvec().shape == (0, 3)
-    assert r.as_mrp().shape == (0, 3)
-    assert r.as_davenport(np.eye(3), "extrinsic").shape == (0, 3)
-
-    # Construction
     r_quat = Rotation.from_quat(np.zeros((0, 4)))
     assert len(r_quat) == 0
 
@@ -2080,10 +2071,19 @@ def test_zero_length_rotation_construction():
     assert len(r_mrp) == 0
 
 
-def test_zero_length_array():
+def test_zero_rotation_representation():
+    r = Rotation.random(num=0)
+    assert r.as_quat().shape == (0, 4)
+    assert r.as_matrix().shape == (0, 3, 3)
+    assert r.as_euler("xyz").shape == (0, 3)
+    assert r.as_rotvec().shape == (0, 3)
+    assert r.as_mrp().shape == (0, 3)
+    assert r.as_davenport(np.eye(3), "extrinsic").shape == (0, 3)
+
+
+def test_zero_rotation_array_rotation():
     r = Rotation.random(num=0)
 
-    # Vector rotation
     v = np.array([1, 2, 3])
     v_rotated = r.apply(v)
     assert v_rotated.shape == (0, 3)
@@ -2096,7 +2096,10 @@ def test_zero_length_array():
     with pytest.raises(ValueError, match="Expected equal numbers of rotations and vectors"):
         r.apply(v2)
 
-    # Multiplication
+
+def test_zero_rotation_multiplication():
+    r = Rotation.random(num=0)
+
     r_single = Rotation.random()
     r_mult_left = r * r_single
     assert len(r_mult_left) == 0
@@ -2105,7 +2108,10 @@ def test_zero_length_array():
     assert len(r_mult_right) == 0
 
     r0 = Rotation.random(0)
-    r0_mult = r * r0
+    r_mult = r * r0
+    assert len(r_mult) == 0
+
+    r0_mult = r0 * r0
     assert len(r0_mult) == 0
 
     msg_rotation_error = "Expected equal number of rotations"
@@ -2132,23 +2138,38 @@ def test_zero_rotation_concatentation():
     r4 = r.concatenate([r, Rotation.random(4)])
     assert len(r4) == 4
 
+
+def test_zero_rotation_power():
+    r = Rotation.random(num=0)
     for pp in [-1.5, -1, 0, 1, 1.5]:
         pow0 = r**pp
         assert len(pow0) == 0
 
-    # Methods
+
+def test_zero_rotation_inverse():
+    r = Rotation.random(num=0)
     r_inv = r.inv()
     assert len(r_inv) == 0
 
+
+def test_zero_rotation_magnitude():
+    r = Rotation.random(num=0)
     magnitude = r.magnitude()
     assert magnitude.shape == (0,)
 
+
+def test_zero_rotation_mean():
+    r = Rotation.random(num=0)
     with pytest.raises(ValueError, match="Mean of an empty rotation set is undefined."):
         r.mean()
 
-    # Comparison
+
+def test_zero_rotation_approx_equal():
+    r = Rotation.random(0)
     assert r.approx_equal(Rotation.random(0)).shape == (0,)
     assert r.approx_equal(Rotation.random()).shape == (0,)
+    assert Rotation.random(0).approx_equal(r).shape == (0,)
+    assert Rotation.random().approx_equal(r).shape == (0,)
 
     approx_msg = "Expected equal number of rotations in both or a single rotation in either object"
     r3 = Rotation.random(2)
@@ -2157,8 +2178,16 @@ def test_zero_rotation_concatentation():
 
     with pytest.raises(ValueError, match=approx_msg):
         r3.approx_equal(r)
+
+
+def test_zero_rotation_get_set():
+    r = Rotation.random(0)
+
     r_get = r[[]]
     assert len(r_get) == 0
+
+    r_slice = r[:0]
+    assert len(r_slice) == 0
 
     with pytest.raises(IndexError):
         r[[0]]

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2165,7 +2165,6 @@ def test_zero_rotation_approx_equal():
     r = Rotation.random(0)
     assert r.approx_equal(Rotation.random(0)).shape == (0,)
     assert r.approx_equal(Rotation.random()).shape == (0,)
-    assert Rotation.random(0).approx_equal(r).shape == (0,)
     assert Rotation.random().approx_equal(r).shape == (0,)
 
     approx_msg = "Expected equal number of rotations in both or a single rotation in either object"

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2160,3 +2160,19 @@ def test_zero_length_array():
 
     with pytest.raises(IndexError):
         r[0] = Rotation.random()
+
+
+def test_boolean_indexes():
+    r = Rotation.random(3)
+
+    r0 = r[[False, False, False]]
+    assert len(r0) == 0
+
+    r1 = r[[False, True, False]]
+    assert len(r1) == 1
+
+    r3 = r[[True, True, True]]
+    assert len(r3) == 3
+
+    with pytest.raises(IndexError):
+        r[[True, True]]

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1631,23 +1631,23 @@ def test_slerp_rot_is_rotation():
         t = np.array([0, 1])
         Slerp(t, r)
 
-SLERP_MESSAGE = "must be a sequence of at least 2 rotations"
+SLERP_EXCEPTION_MESSAGE = "must be a sequence of at least 2 rotations"
 
 def test_slerp_single_rot():
     r = Rotation.from_quat([1, 2, 3, 4])
-    with pytest.raises(ValueError, match=SLERP_MESSAGE):
+    with pytest.raises(ValueError, match=SLERP_EXCEPTION_MESSAGE):
         Slerp([1], r)
 
 
 def test_slerp_rot_len0():
     r = Rotation.random()
-    with pytest.raises(ValueError, match=SLERP_MESSAGE):
+    with pytest.raises(ValueError, match=SLERP_EXCEPTION_MESSAGE):
         Slerp([], r)
 
 
 def test_slerp_rot_len1():
     r = Rotation.random(1)
-    with pytest.raises(ValueError, match=SLERP_MESSAGE):
+    with pytest.raises(ValueError, match=SLERP_EXCEPTION_MESSAGE):
         Slerp([1], r)
 
 


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/22589

#### What does this implement/fix?
Enable 0-length Rotation.
A `Rotation` with `self_single = False` should support any number of rotations from 0 ... infinity. 
Similarly to how numpy is able to handle arrays with dimension of size 0. 

#### Additional information
I created a single test to check all the zero-Rotation functionalities (but could be split among existing test, if that is preferred).
The tests for the creation methods include so far quaternion, euler and rotation matrix. I do not expect other methods to fail, since the modification was mostly on the cython.view.array creation.

Please point out if other methods need explicit checking!