### PR TITLE
MAINT: sparse: rewrite `sparse._sputils.validateaxis` to centralize axis arg processing

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1,10 +1,11 @@
 """Base class for sparse matrices"""
 
+import math
 import numpy as np
 
 from ._sputils import (asmatrix, check_reshape_kwargs, check_shape,
                        get_sum_dtype, isdense, isscalarlike,
-                       matrix, validateaxis, getdtype)
+                       matrix, validateaxis, getdtype, isintlike)
 from scipy._lib._sparse import SparseABC, issparse
 
 from ._matrix import spmatrix
@@ -1142,43 +1143,29 @@ class _spbase(SparseABC):
         numpy.matrix.sum : NumPy's implementation of 'sum' for matrices
 
         """
-        validateaxis(axis)
+        vaxis = validateaxis(axis, ndim=self.ndim)
 
         # Mimic numpy's casting.
         res_dtype = get_sum_dtype(self.dtype)
 
-        if self.ndim == 1:
-            if axis not in (None, -1, 0):
-                raise ValueError("axis must be None, -1 or 0")
-            res = self @ np.ones(self.shape, dtype=res_dtype)
-            return res.sum(dtype=dtype, out=out)
+        # Note: all valid 1D axis values are canonically `None` so use this code.
+        if vaxis is None:
+            ones = self._ascontainer(np.ones((self.shape[-1], 1), dtype=res_dtype))
+            return (self @ ones).sum(dtype=dtype, out=out)
 
         # We use multiplication by a matrix of ones to achieve this.
         # For some sparse array formats more efficient methods are
         # possible -- these should override this function.
-        M, N = self.shape
-
-        if axis is None:
-            # sum over rows and columns
-            return (
-                self @ self._ascontainer(np.ones((N, 1), dtype=res_dtype))
-            ).sum(dtype=dtype, out=out)
-
-        if axis < 0:
-            axis += 2
-
-        # axis = 0 or 1 now
-        if axis == 0:
+        if vaxis == 0:
             # sum over columns
-            ret = self._ascontainer(
-                np.ones((1, M), dtype=res_dtype)
-            ) @ self
-        else:
+            ones = self._ascontainer(np.ones((1, self.shape[0]), dtype=res_dtype))
+            ret = ones @ self
+        else:  # vaxis == 1:
             # sum over rows
-            ret = self @ self._ascontainer(
-                np.ones((N, 1), dtype=res_dtype)
-            )
+            ones = self._ascontainer(np.ones((self.shape[1], 1), dtype=res_dtype))
+            ret = self @ ones
 
+        # This doesn't sum anything. It handles dtype and out.
         return ret.sum(axis=axis, dtype=dtype, out=out)
 
     def mean(self, axis=None, dtype=None, out=None):
@@ -1218,7 +1205,7 @@ class _spbase(SparseABC):
         numpy.matrix.mean : NumPy's implementation of 'mean' for matrices
 
         """
-        validateaxis(axis)
+        axis = validateaxis(axis, ndim=self.ndim)
 
         res_dtype = self.dtype.type
         integral = (np.issubdtype(self.dtype, np.integer) or
@@ -1235,26 +1222,18 @@ class _spbase(SparseABC):
         inter_dtype = np.float64 if integral else res_dtype
         inter_self = self.astype(inter_dtype)
 
-        if self.ndim == 1:
-            if axis not in (None, -1, 0):
-                raise ValueError("axis must be None, -1 or 0")
-            res = inter_self / self.shape[-1]
-            return res.sum(dtype=res_dtype, out=out)
-
         if axis is None:
-            return (inter_self / (self.shape[0] * self.shape[1]))\
-                .sum(dtype=res_dtype, out=out)
-
-        if axis < 0:
-            axis += 2
-
-        # axis = 0 or 1 now
-        if axis == 0:
-            return (inter_self * (1.0 / self.shape[0])).sum(
-                axis=0, dtype=res_dtype, out=out)
+            denom = math.prod(self.shape)
+        elif isintlike(axis):
+            denom = self.shape[axis]
         else:
-            return (inter_self * (1.0 / self.shape[1])).sum(
-                axis=1, dtype=res_dtype, out=out)
+            denom = math.prod(self.shape[ax] for ax in axis)
+        res = (inter_self * (1.0 / denom)).sum(axis=axis, dtype=inter_dtype)
+        if out is None:
+            return res.sum(axis=(), dtype=dtype)
+        # out is handled differently by matrix and ndarray so use as_container
+        return self._ascontainer(res).sum(axis=(), dtype=dtype, out=out)
+
 
     def diagonal(self, k=0):
         """Returns the kth diagonal of the array/matrix.

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1143,24 +1143,24 @@ class _spbase(SparseABC):
         numpy.matrix.sum : NumPy's implementation of 'sum' for matrices
 
         """
-        vaxis = validateaxis(axis, ndim=self.ndim)
+        axis = validateaxis(axis, ndim=self.ndim)
 
         # Mimic numpy's casting.
         res_dtype = get_sum_dtype(self.dtype)
 
         # Note: all valid 1D axis values are canonically `None` so use this code.
-        if vaxis is None:
+        if axis is None:
             ones = self._ascontainer(np.ones((self.shape[-1], 1), dtype=res_dtype))
             return (self @ ones).sum(dtype=dtype, out=out)
 
         # We use multiplication by a matrix of ones to achieve this.
         # For some sparse array formats more efficient methods are
         # possible -- these should override this function.
-        if vaxis == 0:
+        if axis == 0:
             # sum over columns
             ones = self._ascontainer(np.ones((1, self.shape[0]), dtype=res_dtype))
             ret = ones @ self
-        else:  # vaxis == 1:
+        else:  # axis == 1:
             # sum over rows
             ones = self._ascontainer(np.ones((self.shape[1], 1), dtype=res_dtype))
             ret = self @ ones

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -663,8 +663,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         """Sum the array/matrix over the given axis.  If the axis is None, sum
         over both rows and columns, returning a scalar.
         """
-        # The _spbase base class already does axis=0 and axis=1 efficiently
-        # so we only do the case axis=None here
+        # The _spbase base class already does axis=None and major axis efficiently
+        # so we only do the case axis= minor axis
         if (self.ndim == 2 and not hasattr(self, 'blocksize') and
                 axis in self._swap(((1, -1), (0, -2)))[0]):
             # faster than multiplication for large minor axis in CSC/CSR
@@ -679,7 +679,6 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
 
             return ret.sum(axis=(), dtype=dtype, out=out)
         else:
-            # _spbase handles the situations when axis is in {None, -2, -1, 0, 1}
             return _spbase.sum(self, axis=axis, dtype=dtype, out=out)
 
     sum.__doc__ = _spbase.sum.__doc__

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -210,11 +210,7 @@ class _minmax_mixin:
         if out is not None:
             raise ValueError("Sparse arrays do not support an 'out' parameter.")
 
-        validateaxis(axis)
-        if self.ndim == 1:
-            if axis not in (None, 0, -1):
-                raise ValueError("axis out of range")
-            axis = None  # avoid calling special axis case. no impact on 1d
+        axis = validateaxis(axis, ndim=self.ndim)
 
         if axis is None:
             if 0 in self.shape:
@@ -228,20 +224,11 @@ class _minmax_mixin:
                 m = min_or_max(zero, m)
             return m
 
-        if axis < 0:
-            axis += 2
-
-        if (axis == 0) or (axis == 1):
-            return self._min_or_max_axis(axis, min_or_max, explicit)
-        else:
-            raise ValueError("axis out of range")
+        return self._min_or_max_axis(axis, min_or_max, explicit)
 
     def _arg_min_or_max_axis(self, axis, argmin_or_argmax, compare, explicit):
         if self.shape[axis] == 0:
             raise ValueError("Cannot apply the operation along a zero-sized dimension.")
-
-        if axis < 0:
-            axis += 2
 
         zero = self.dtype.type(0)
 
@@ -283,12 +270,7 @@ class _minmax_mixin:
         if out is not None:
             raise ValueError("Sparse types do not support an 'out' parameter.")
 
-        validateaxis(axis)
-
-        if self.ndim == 1:
-            if axis not in (None, 0, -1):
-                raise ValueError("axis out of range")
-            axis = None  # avoid calling special axis case. no impact on 1d
+        axis = validateaxis(axis, ndim=self.ndim)
 
         if axis is not None:
             return self._arg_min_or_max_axis(axis, argmin_or_argmax, compare, explicit)

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -142,10 +142,7 @@ class _dia_base(_data_matrix):
     _getnnz.__doc__ = _spbase._getnnz.__doc__
 
     def sum(self, axis=None, dtype=None, out=None):
-        validateaxis(axis)
-
-        if axis is not None and axis < 0:
-            axis += 2
+        axis = validateaxis(axis)
 
         res_dtype = get_sum_dtype(self.dtype)
         num_rows, num_cols = self.shape

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -403,27 +403,44 @@ def isdense(x) -> bool:
     return isinstance(x, np.ndarray)
 
 
-def validateaxis(axis) -> None:
+def validateaxis(axis, *, ndim=2) -> int | tuple[int, ...]:
     if axis is None:
-        return
-    axis_type = type(axis)
+        return None
 
-    # In NumPy, you can pass in tuples for 'axis', but they are
-    # not very useful for sparse matrices given their limited
-    # dimensions, so let's make it explicit that they are not
-    # allowed to be passed in
-    if isinstance(axis, tuple):
-        raise TypeError("Tuples are not accepted for the 'axis' parameter. "
-                        "Please pass in one of the following: "
-                        "{-2, -1, 0, 1, None}.")
+    if axis == ():
+        raise ValueError(
+            "sparse does not accept 0D axis (). Either use toarray (for dense) "
+            "or copy (for sparse)."
+        )
 
-    # If not a tuple, check that the provided axis is actually
-    # an integer and raise a TypeError similar to NumPy's
-    if not np.issubdtype(np.dtype(axis_type), np.integer):
-        raise TypeError(f"axis must be an integer, not {axis_type.__name__}")
+    if not isinstance(axis, tuple):
+        # If not a tuple, check that the provided axis is actually
+        # an integer and raise a TypeError similar to NumPy's
+        if not np.issubdtype(np.dtype(type(axis)), np.integer):
+            raise TypeError(f'axis must be an integer/tuple of ints, not {type(axis)}')
+        axis = (axis,)
 
-    if not (-2 <= axis <= 1):
-        raise ValueError("axis out of range")
+    canon_axis = []
+    for ax in axis:
+        if not isintlike(ax):
+            raise TypeError(f"axis must be an integer. (given {ax})")
+        if ax < 0:
+            ax += ndim
+        if ax < 0 or ax >= ndim:
+            raise ValueError("axis out of range for ndim")
+        canon_axis.append(ax)
+
+    len_axis = len(canon_axis)
+    if len_axis != len(set(canon_axis)):
+        raise ValueError("duplicate value in axis")
+    elif len_axis > ndim:
+        raise ValueError("axis tuple has too many elements")
+    elif len_axis == ndim:
+        return None
+    elif len_axis == 1:
+        return canon_axis[0]
+    else:
+        return tuple(canon_axis)
 
 
 def check_shape(args, current_shape=None, *, allow_nd=(2,)) -> tuple[int, ...]:

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1023,10 +1023,8 @@ class _TestCommon:
                 assert_array_almost_equal(dat.sum(), datsp.sum())
                 assert_equal(dat.sum().dtype, datsp.sum().dtype)
                 assert_(np.isscalar(datsp.sum(axis=None)))
-                assert_array_almost_equal(dat.sum(axis=None),
-                                          datsp.sum(axis=None))
-                assert_equal(dat.sum(axis=None).dtype,
-                             datsp.sum(axis=None).dtype)
+                assert_array_almost_equal(dat.sum(axis=None), datsp.sum(axis=None))
+                assert_equal(dat.sum(axis=None).dtype, datsp.sum(axis=None).dtype)
                 assert_array_almost_equal(dat.sum(axis=0), datsp.sum(axis=0))
                 assert_equal(dat.sum(axis=0).dtype, datsp.sum(axis=0).dtype)
                 assert_array_almost_equal(dat.sum(axis=1), datsp.sum(axis=1))
@@ -1035,6 +1033,8 @@ class _TestCommon:
                 assert_equal(dat.sum(axis=-2).dtype, datsp.sum(axis=-2).dtype)
                 assert_array_almost_equal(dat.sum(axis=-1), datsp.sum(axis=-1))
                 assert_equal(dat.sum(axis=-1).dtype, datsp.sum(axis=-1).dtype)
+                assert_array_almost_equal(dat.sum(axis=(0, 1)), datsp.sum(axis=(0, 1)))
+                assert_equal(dat.sum(axis=(0, 1)).dtype, datsp.sum(axis=(0, 1)).dtype)
 
         for dtype in self.checked_dtypes:
             for j in range(len(matrices)):
@@ -1047,9 +1047,12 @@ class _TestCommon:
                      [-6, 7, 9]])
         datsp = self.spcreator(dat)
 
-        assert_raises(ValueError, datsp.sum, axis=3)
-        assert_raises(TypeError, datsp.sum, axis=(0, 1))
-        assert_raises(TypeError, datsp.sum, axis=1.5)
+        with assert_raises(ValueError, match="axis out of range"):
+            datsp.sum(axis=3)
+        with assert_raises(ValueError, match="axis out of range"):
+            datsp.sum(axis=(0, 3))
+        with assert_raises(TypeError, match="axis must be an integer"):
+            datsp.sum(axis=1.5)
         assert_raises(ValueError, datsp.sum, axis=1, out=out)
 
     def test_sum_dtype(self):
@@ -1090,9 +1093,9 @@ class _TestCommon:
         assert_array_almost_equal(dat_out, datsp_out)
 
         # check that wrong shape out parameter raises
-        with assert_raises(ValueError, match="output parameter.*wrong.*dimension"):
+        with assert_raises(ValueError, match="output parameter"):
             datsp.sum(out=array([0]))
-        with assert_raises(ValueError, match="output parameter.*wrong.*dimension"):
+        with assert_raises(ValueError, match="output parameter"):
             datsp.sum(out=array([[0]] if self.is_array_test else 0))
 
     def test_numpy_sum(self):
@@ -1139,6 +1142,11 @@ class _TestCommon:
                 dat.mean(axis=-1, keepdims=keep), datsp.mean(axis=-1)
             )
             assert_equal(dat.mean(axis=-1).dtype, datsp.mean(axis=-1).dtype)
+            assert_array_almost_equal(
+                dat.mean(axis=(0, 1), keepdims=keep), datsp.mean(axis=(0, 1))
+            )
+            assert_equal(dat.mean(axis=(0, 1)).dtype, datsp.mean(axis=(0, 1)).dtype)
+
 
         for dtype in self.checked_dtypes:
             check(dtype)
@@ -1150,10 +1158,14 @@ class _TestCommon:
                      [-6, 7, 9]])
         datsp = self.spcreator(dat)
 
-        assert_raises(ValueError, datsp.mean, axis=3)
-        assert_raises(TypeError, datsp.mean, axis=(0, 1))
-        assert_raises(TypeError, datsp.mean, axis=1.5)
-        assert_raises(ValueError, datsp.mean, axis=1, out=out)
+        with assert_raises(ValueError, match="axis out of range"):
+            datsp.mean(axis=3)
+        with assert_raises(ValueError, match="axis out of range"):
+            datsp.mean(axis=(0, 3))
+        with assert_raises(TypeError, match="axis must be an integer"):
+            datsp.mean(axis=1.5)
+        with assert_raises(ValueError, match="doesn't match.*shape|wrong.*dimensions"):
+            datsp.mean(axis=1, out=out)
 
     def test_mean_dtype(self):
         dat = array([[0, 1, 2],
@@ -3787,6 +3799,7 @@ class _TestMinMax:
             assert_array_equal(
                 X.min(axis=axis).toarray(), D.min(axis=axis, keepdims=keep)
             )
+        assert_equal(X.max(axis=(0, 1)), D.max(axis=(0, 1), keepdims=keep))
 
         for axis in axes_even:
             expected_max = D[-1, :]
@@ -3852,6 +3865,10 @@ class _TestMinMax:
         assert np.isscalar(X_nan_minimum)
         assert X_nan_minimum == np.nanmin(D)
 
+        X_nan_minimum = X.nanmin(axis=(0, 1))
+        assert np.isscalar(X_nan_minimum)
+        assert X_nan_minimum == np.nanmin(D, axis=(0, 1))
+
         axes = [-2, -1, 0, 1]
         for axis in axes:
             X_nan_maxima = X.nanmax(axis=axis)
@@ -3871,7 +3888,6 @@ class _TestMinMax:
         for fname in ('min', 'max'):
             func = getattr(datsp, fname)
             assert_raises(ValueError, func, axis=3)
-            assert_raises(TypeError, func, axis=(0, 1))
             assert_raises(TypeError, func, axis=1.5)
             assert_raises(ValueError, func, axis=1, out=1)
 

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -136,10 +136,10 @@ class TestCommon1D:
         dat = np.array([0, 1, 2])
         datsp = spcreator(dat)
 
-        with pytest.raises(ValueError, match='axis must be None, -1 or 0'):
+        with pytest.raises(ValueError, match='axis out of range'):
             datsp.sum(axis=1)
-        with pytest.raises(TypeError, match='Tuples are not accepted'):
-            datsp.sum(axis=(0, 1))
+        with pytest.raises(ValueError, match='axis out of range'):
+            datsp.sum(axis=(0, 3))
         with pytest.raises(TypeError, match='axis must be an integer'):
             datsp.sum(axis=1.5)
         with pytest.raises(ValueError, match='output parameter.*wrong.*dimension'):
@@ -176,8 +176,8 @@ class TestCommon1D:
         datsp = spcreator(dat)
         with pytest.raises(ValueError, match='axis out of range'):
             datsp.mean(axis=3)
-        with pytest.raises(TypeError, match='Tuples are not accepted'):
-            datsp.mean(axis=(0, 1))
+        with pytest.raises(ValueError, match='axis out of range'):
+            datsp.mean(axis=(0, 3))
         with pytest.raises(TypeError, match='axis must be an integer'):
             datsp.mean(axis=1.5)
         with pytest.raises(ValueError, match='output parameter.*wrong.*dimension'):

--- a/scipy/sparse/tests/test_sputils.py
+++ b/scipy/sparse/tests/test_sputils.py
@@ -107,13 +107,43 @@ class TestSparseUtils:
         assert_equal(sputils.isdense(matrix([1])), True)
 
     def test_validateaxis(self):
-        assert_raises(TypeError, sputils.validateaxis, (0, 1))
-        assert_raises(TypeError, sputils.validateaxis, 1.5)
-        assert_raises(ValueError, sputils.validateaxis, 3)
+        with assert_raises(ValueError, match="does not accept 0D axis"):
+            sputils.validateaxis(())
 
-        # These function calls should not raise errors
-        for axis in (-2, -1, 0, 1, None):
-            sputils.validateaxis(axis)
+        for ax in [1.5, (0, 1.5), (1.5, 0)]:
+            with assert_raises(TypeError, match="must be an integer"):
+                sputils.validateaxis(ax)
+        for ax in [(1, 1), (1, -1), (0, -2)]:
+            with assert_raises(ValueError, match="duplicate value in axis"):
+                sputils.validateaxis(ax)
+
+        # ndim 1
+        for ax in [1, -2, (0, 1), (1, -1)]:
+            with assert_raises(ValueError, match="out of range"):
+                sputils.validateaxis(ax, ndim=1)
+        with assert_raises(ValueError, match="duplicate value in axis"):
+            sputils.validateaxis((0, -1), ndim=1)
+        # all valid axis values lead to None when canonical
+        for axis in (0, -1, None, (0,), (-1,)):
+            assert sputils.validateaxis(axis, ndim=1) is None
+
+        # ndim 2
+        for ax in [5, -5, (0, 5), (-5, 0)]:
+            with assert_raises(ValueError, match="out of range"):
+                sputils.validateaxis(ax, ndim=2)
+        for axis in (0, 1, None):
+            assert sputils.validateaxis(axis, ndim=2) == axis
+        convert_axis_2d = {-2: 0, -1: 1, (0, 1): None, (0, -1): None}
+        for axis, canonical_axis in convert_axis_2d.items():
+            assert sputils.validateaxis(axis, ndim=2) == canonical_axis
+
+        # ndim 4
+        for axis in (2, 3, (2, 3), (2, 1), (0, 3)):
+            assert sputils.validateaxis(axis, ndim=4) == axis
+        convert_axis_4d = {-4: 0, -3: 1, (3, -4): (3, 0)}
+        for axis, canonical_axis in convert_axis_4d.items():
+            sputils.validateaxis(axis, ndim=4) == canonical_axis
+
 
     @pytest.mark.parametrize("container", [csr_array, bsr_array])
     def test_safely_cast_index_compressed(self, container):


### PR DESCRIPTION
The `sum/mean/min/max` methods take an`axis` parameter that needs validation. The various sparse formats and methods duplicate validation code in non-uniform ways. We'd like to centralize the checking and conversion of `axis` into the current `_sputils.validateaxis` function.  That involves:
- making the function return the axis with everything checked and converted to nonnegative integers.
- add a parameter `ndim` to allow conversion to nonnegative integers.
- unify the error messages across methods and formats.
- capture the return value in the various users of this helper function.
- clean up the axis processing from the various formats and methods.

This function `validateaxis` is private because it is accessible only via `sparse._sputils.validateaxis`. But just in case someone is using it, I gave the second argument a default `ndim=2`, and the new version performs all the previous checks plus more. I don't think any deprecation should be needed.

This also prepares the axis validation for nD processing!

~~This is built on top of #22642 (which adds/corrects testing of invalid `out` parameters), so there might be conflicts if that gets changed. I'll keep up with rebasing as needed.~~

