### PR TITLE
MAINT: stats.quantile: fixup quantile for p < minimum plotting position

### DIFF
--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -205,8 +205,9 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
 
     Note that indices ``j`` and ``j + 1`` are clipped to the range ``0`` to
     ``n - 1`` when the results of the formula would be outside the allowed
-    range of non-negative indices. The ``-1`` in the formulas for ``j`` and
-    ``g`` accounts for Python's 0-based indexing.
+    range of non-negative indices. When ``j`` is clipped to zero, ``g`` is
+    set to zero as well. The ``-1`` in the formulas for ``j`` and ``g``
+    accounts for Python's 0-based indexing.
 
     The table above includes only the estimators from [1]_ that are continuous
     functions of probability `p` (estimators 4-9). SciPy also provides the
@@ -313,6 +314,8 @@ def _quantile_hf(y, p, n, method, xp):
     if method in {'inverted_cdf', 'averaged_inverted_cdf', 'closest_observation'}:
         g = xp.asarray(g)
         g = xpx.at(g, jg < 0).set(0)
+
+    g[j < 0] = 0
     j = xp.clip(j, 0., n - 1)
     jp1 = xp.clip(j + 1, 0., n - 1)
 

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -86,8 +86,8 @@ class TestQuantile:
           'hazen', 'interpolated_inverted_cdf', 'linear',
           'median_unbiased', 'normal_unbiased', 'weibull'])
     @pytest.mark.parametrize('shape_x, shape_p, axis',
-         [(10, None, -1), (10, 3, -1), (10, (2, 3), -1),
-          ((10, 2), None, 0), ((10, 2), None, 0)])
+         [(10, None, -1), (10, 10, -1), (10, (2, 3), -1),
+          ((10, 2), None, 0), ((10, 2), None, 0),])
     def test_against_numpy(self, method, shape_x, shape_p, axis, xp):
         dtype = xp_default_dtype(xp)
         rng = np.random.default_rng(23458924568734956)


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
For some `method`s, `quantile` produced incorrect results for *nonzero* `p` less than the minimum plotting position (probabilty corresponding with the minimum observation). Tests catch it when the number of points checked is bumped up slightly. The fix is simple: when `p` is less than the minimum plotting position, the output is supposed to be clipped to the minimum observation, so we just need to set `g` - the parameter that controls linear interpolation between two adjacent values - to zero.