### PR TITLE
DOC, CI: Fix legend warning for CloughTocher2DInterpolator docstring

### DIFF
--- a/scipy/interpolate/_interpnd.pyx
+++ b/scipy/interpolate/_interpnd.pyx
@@ -884,7 +884,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     >>> Z = interp(X, Y)
     >>> plt.pcolormesh(X, Y, Z, shading='auto')
     >>> plt.plot(x, y, "ok", label="input point")
-    >>> plt.legend()
+    >>> plt.legend(loc="upper right")
     >>> plt.colorbar()
     >>> plt.axis("equal")
     >>> plt.show()


### PR DESCRIPTION
#### Reference issue
Closes #22646

#### What does this implement/fix?
Manually set location for legend in example plot to prevent `UserWarning: Creating legend with loc="best" can be slow with large amounts of data.` when building docs in CI.

#### Additional information
The only caveat of doing this manually is that since the example is random, the legend may overlap the plot in some situations. Other options are to fix the example and then manually place the legend, or use a more complicated way of sizing the canvas so that the legend is always placed far from the plot.