### PR TITLE
TST: stats: mark `nct` fit xslow

### DIFF
--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -42,7 +42,8 @@ mle_failing_fits = [
 
 # these pass but are XSLOW (>1s)
 mle_Xslow_fits = ['betaprime', 'crystalball', 'exponweib', 'f', 'geninvgauss',
-                  'jf_skew_t', 'recipinvgauss', 'rel_breitwigner', 'vonmises_line']
+                  'jf_skew_t', 'nct', 'recipinvgauss', 'rel_breitwigner',
+                  'vonmises_line']
 
 # The MLE fit method of these distributions doesn't perform well when all
 # parameters are fit, so test them with the location fixed at 0.


### PR DESCRIPTION
#### Reference issue
gh-22648
gh-22647
gh-22645

#### What does this implement/fix?
`scipy\stats\tests\test_fit.py::test_cont_fit[MLE-nct-arg78]` is consistently failing as too slow now, so marking `xslow`.