### PR TITLE
ENH/MAINT: add support for `args` as list in `optimize.minimize`

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -560,8 +560,11 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     if x0.dtype.kind in np.typecodes["AllInteger"]:
         x0 = np.asarray(x0, dtype=float)
 
+    if isinstance(args, list):
+        args = tuple(args)
+
     if not isinstance(args, tuple):
-        args = (args,)
+        args = (args, )
 
     if method is None:
         # Select automatically

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3265,6 +3265,61 @@ def test_sparse_hessian(method, sparse_type):
     assert res_dense.nhev == res_sparse.nhev
 
 
+class TestFunctionArguments:
+
+    def fun_one_arg(self, x, a):
+        return rosen(x) + a
+    
+    def fun_grad_one_arg(self, x, a):
+        return rosen_der(x)
+    
+    def fun_hess_one_arg(self, x, a):
+        return rosen_hess(x)
+    
+    def fun_two_args(self, x, a, b):
+        return rosen(x) + a + b
+
+    def fun_grad_two_args(self, x, a, b):
+        return rosen_der(x)
+    
+    def fun_hess_two_args(self, x, a, b):
+        return rosen_hess(x)
+
+    @pytest.mark.parametrize("method", ["powell", "nelder-mead", "cobyla", "cobyqa"])
+    def test_one_arg_derivative_free(self, method):
+        test_args = [-1.0]
+        x0 = [-1.0, 1.0]
+
+        res_tuple_args = optimize.minimize(self.fun_one_arg, x0=x0,
+                                           args=tuple(test_args), method=method)
+        res_list_args = optimize.minimize(self.fun_one_arg, x0=x0, args=test_args, method=method)
+        assert_allclose(res_tuple_args.x, res_list_args.x)
+        assert res_tuple_args.nfev == res_list_args.nfev
+    
+    @pytest.mark.parametrize("method", ["slsqp", "bfgs", "l-bfgs-b", "tnc", "newton-cg"])
+    def test_one_arg_with_gradient(self, method):
+        test_args = [-1.0]
+        x0 = [-1.0, 1.0]
+
+        res_tuple_args = optimize.minimize(self.fun_one_arg, x0=x0, jac=self.fun_grad_one_arg,
+                                           args=tuple(test_args), method=method)
+        res_list_args = optimize.minimize(self.fun_one_arg, x0=x0, jac=self.fun_grad_one_arg, args=test_args, method=method)
+        assert_allclose(res_tuple_args.x, res_list_args.x)
+        assert res_tuple_args.nfev == res_list_args.nfev
+    
+    @pytest.mark.parametrize("method", ["slsqp", "bfgs", "l-bfgs-b", "tnc", "newton-cg"])
+    def test_two_args_with_gradient(self, method):
+        test_args = [-1.0, -1.0]
+        x0 = [-1.0, 1.0]
+
+        res_tuple_args = optimize.minimize(self.fun_two_args, x0=x0, jac=self.fun_grad_two_args,
+                                          args=tuple(test_args), method=method)
+        res_list_args = optimize.minimize(self.fun_two_args, x0=x0, jac=self.fun_grad_two_args,
+                                          args=test_args, method=method)
+        assert_allclose(res_tuple_args.x, res_list_args.x)
+        assert res_tuple_args.nfev == res_list_args.nfev
+
+
 @pytest.mark.parametrize('workers', [None, 2])
 @pytest.mark.parametrize(
     'method',


### PR DESCRIPTION
#### Reference issue
Closes #3816

#### What does this implement/fix?
With this change, `args` can be supplied as list to `minimize`. I am not sure if that was meant to work before, as there was somehow a cast to tuple via `args = (args, )` but that did not work.

#### Additional information
There might be some history involved here. Simply rejecting list input and erroring out could also be a valid solution. Open for opinions here :).