### PR TITLE
DOC: add COBYQA to local optimizer comparison table

### DIFF
--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -878,6 +878,12 @@ meet your needs (e.g. execution time, objective function value).
      -
      -
      -
+   * - COBYQA
+     - ✓
+     - ✓
+     -
+     -
+     -
    * - SLSQP
      - ✓
      - ✓


### PR DESCRIPTION
#### What does this implement/fix?
Adds the recently added COBYQA solver to the local optimizer comparison table in the tutorial.
