### PR TITLE
ENH: signal: New functions `sawtooth_rfft` and `square_rfft` for creating band-limited sawtooth and square signals.

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -218,13 +218,15 @@ Waveforms
 .. autosummary::
    :toctree: generated/
 
-   chirp        -- Frequency swept cosine signal, with several freq functions.
-   gausspulse   -- Gaussian modulated sinusoid.
-   max_len_seq  -- Maximum length sequence.
-   sawtooth     -- Periodic sawtooth.
-   square       -- Square wave.
-   sweep_poly   -- Frequency swept cosine signal; freq is arbitrary polynomial.
-   unit_impulse -- Discrete unit impulse.
+   chirp         -- Frequency swept cosine signal, with several freq functions.
+   gausspulse    -- Gaussian modulated sinusoid.
+   max_len_seq   -- Maximum length sequence.
+   sawtooth      -- Periodic sawtooth.
+   sawtooth_rfft -- Onesided FFT of a sawtooth or triangle wave signal.
+   square        -- Square wave.
+   square_rfft   -- Onesided FFT of a square wave signal.
+   sweep_poly    -- Frequency swept cosine signal; freq is arbitrary polynomial.
+   unit_impulse  -- Discrete unit impulse.
 
 Window functions
 ================

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -147,8 +147,8 @@ def sawtooth_rfft(n: int, m_cyc: int, duty: float = 0.5, *,
                0 &\text{ for } l = 0\ ,\\
                -\frac{\mathbb{j}\tau}{\pi l} &\text{ for } l \neq 0 \wedge d = 0 \ ,\\
                +\frac{\mathbb{j}\tau}{\pi l} &\text{ for } l \neq 0 \wedge d = 1 \ ,\\
-               \frac{\tau}{2\pi^2 l^2 d (d-1)}
-               \left(1 - \operatorname{e}^{\mathbb{j}2\pi d l}\right)
+               \frac{\tau \left(1 - \operatorname{e}^{\mathbb{j}2\pi d l}\right)}{
+                     2\pi^2 l^2 d (d-1)}
                &\text{ for } l \neq 0 \wedge 0 < d < 1 \ .
             \end{cases}
 
@@ -166,8 +166,8 @@ def sawtooth_rfft(n: int, m_cyc: int, duty: float = 0.5, *,
 
     Examples
     --------
-    The following cade generates a plot of 1 Hz square wave and its Magnitude
-    spectrum:
+    The following code generates a plot of 1 Hz square wave and its Magnitude spectrum
+    (Consult the `square_rfft` examples on creating a signal with varying frequency):
 
     >>> import numpy as np
     >>> from matplotlib import pyplot as plt
@@ -368,7 +368,7 @@ def square_rfft(n: int, m_cyc: int, duty: float = 0.5,  *,
             \end{cases}
 
     The close relationship between Fourier series and the discrete Fourier transform
-    allows to utilize :math:`c[l]` to obtain a closed-form llexpression for `X`. I.e.,
+    allows to utilize :math:`c[l]` to obtain a closed-form expression for `X`. I.e.,
     ``X[m_cyc*l] = s * c[l] / tau``, with ``tau = n * T / m_cyc`` being the duration of
     one cycle. The scaling factor ``s`` has a value of ``n`` for parameter
     `norm` = ``'backward'``, ``sqrt(n)`` for `norm` = ``'ortho'``, or ``1`` for
@@ -380,7 +380,7 @@ def square_rfft(n: int, m_cyc: int, duty: float = 0.5,  *,
 
     Examples
     --------
-    The following cade generates a plot of 1 Hz square wave and its Magnitude
+    The following code generates a plot of 1 Hz square wave and its Magnitude
     spectrum:
 
     >>> import numpy as np

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -9,6 +9,8 @@ from typing import Literal
 import numpy as np
 from numpy import asarray, zeros, place, nan, mod, pi, extract, log, sqrt, \
     exp, cos, sin, polyval, polyint
+
+from scipy._lib._array_api import array_namespace
 from scipy.fft import rfft
 
 __all__ = ['sawtooth', 'sawtooth_rfft', 'square', 'square_rfft', 'gausspulse', 'chirp',
@@ -197,28 +199,29 @@ def sawtooth_rfft(n: int, m_cyc: int, duty: float = 0.5, *,
     ...    ax_.grid()
     >>> plt.show()
     """
-    if not (isinstance(n, int | np.integer) and n > 0):
+    xp = array_namespace()
+    if not (xp.result_type(n, xp.int64) == xp.int64 and n > 0):
         raise ValueError(f"Parameter {n=} is not a positive integer!")
-    if not (isinstance(m_cyc, int | np.integer) and 0 < m_cyc < n // 2):
+    if not (xp.result_type(m_cyc, xp.int64) == xp.int64 and 0 < m_cyc < n // 2):
         raise ValueError(f"Parameter {m_cyc=} is not a positive integer < {n//2=}!")
     if not (0 <= duty <= 1):
         raise ValueError(f"0 <= duty <= 1 does not hold for parameter {duty=}!")
 
-    scale_factors = {'backward': n, 'ortho': np.sqrt(n), 'forward': 1}
+    scale_factors = {'backward': n, 'ortho': xp.sqrt(n), 'forward': 1}
     if norm not in scale_factors:
         raise ValueError(f"Parameter {norm=} not in {list(scale_factors)}!")
 
     n_X = n // 2 + 1  # number of bins produced by rfft for signal of n samples
     X_dtype = rfft([0., ], norm=norm).dtype  # Use same dtype as rfft produces
-    X = np.zeros((n_X,), dtype=X_dtype)
+    X = xp.zeros((n_X,), dtype=X_dtype)
 
-    ll = np.arange(1, (n_X + m_cyc - 1) // m_cyc) * np.pi
+    ll = xp.arange(1, (n_X + m_cyc - 1) // m_cyc) * xp.pi
     if duty == 0:
         X[m_cyc::m_cyc] = -scale_factors[norm] * 1j / ll
     elif duty == 1:
         X[m_cyc::m_cyc] = scale_factors[norm] * 1j / ll
     else:
-        exponent, denominator = np.exp(-2j * duty * ll), 2 * ll**2 * duty * (duty - 1)
+        exponent, denominator = xp.exp(-2j * duty * ll), 2 * ll**2 * duty * (duty - 1)
         X[m_cyc::m_cyc] = scale_factors[norm] * (1 - exponent) / denominator
     return X
 
@@ -440,25 +443,26 @@ def square_rfft(n: int, m_cyc: int, duty: float = 0.5,  *,
     >>> ax0.grid()
     >>> plt.show()
     """
-    if not (isinstance(n, int | np.integer) and n > 0):
+    xp = array_namespace()
+    if not (xp.result_type(n, xp.int64) == xp.int64 and n > 0):
         raise ValueError(f"Parameter {n=} is not a positive integer!")
-    if not (isinstance(m_cyc, int | np.integer) and 0 < m_cyc < n // 2):
+    if not (xp.result_type(m_cyc, xp.int64) == xp.int64 and 0 < m_cyc < n // 2):
         raise ValueError(f"Parameter {m_cyc=} is not a positive integer < {n//2=}!")
     if not (0 < duty < 1):
         raise ValueError(f"0 < duty < 1 does not hold for parameter {duty=}!")
 
-    scale_factors = {'backward': n, 'ortho': np.sqrt(n), 'forward': 1}
+    scale_factors = {'backward': n, 'ortho': xp.sqrt(n), 'forward': 1}
     if norm not in scale_factors:
         raise ValueError(f"Parameter {norm=} not in {list(scale_factors)}!")
 
     n_X = n // 2 + 1  # number of bins produced by rfft for signal of n samples
     X_dtype = rfft([0., ], norm=norm).dtype  # Use same dtype as rfft produces
-    X = np.zeros((n_X,), dtype=X_dtype)
+    X = xp.zeros((n_X,), dtype=X_dtype)
 
-    fac0, fac1 = scale_factors[norm], scale_factors[norm] * 1j / np.pi
+    fac0, fac1 = scale_factors[norm], scale_factors[norm] * 1j / xp.pi
     X[0] = fac0 * (2 * duty - 1)  # zeroth Fourier coefficient
-    ll = np.arange(1, (n_X + m_cyc - 1) // m_cyc)
-    X[m_cyc::m_cyc] = fac1 * (np.exp(-2j * np.pi * duty * ll) - 1) / ll
+    ll = xp.arange(1, (n_X + m_cyc - 1) // m_cyc)
+    X[m_cyc::m_cyc] = fac1 * (xp.exp(-2j * xp.pi * duty * ll) - 1) / ll
     return X
 
 

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -4,13 +4,15 @@
 # Feb. 2010: Updated by Warren Weckesser:
 #   Rewrote much of chirp()
 #   Added sweep_poly()
+from typing import Literal
+
 import numpy as np
 from numpy import asarray, zeros, place, nan, mod, pi, extract, log, sqrt, \
     exp, cos, sin, polyval, polyint
+from scipy.fft import rfft
 
-
-__all__ = ['sawtooth', 'square', 'gausspulse', 'chirp', 'sweep_poly',
-           'unit_impulse']
+__all__ = ['sawtooth', 'sawtooth_rfft', 'square', 'square_rfft', 'gausspulse', 'chirp',
+           'sweep_poly', 'unit_impulse']
 
 
 def sawtooth(t, width=1):
@@ -21,9 +23,8 @@ def sawtooth(t, width=1):
     interval 0 to ``width*2*pi``, then drops from 1 to -1 on the interval
     ``width*2*pi`` to ``2*pi``. `width` must be in the interval [0, 1].
 
-    Note that this is not band-limited.  It produces an infinite number
-    of harmonics, which are aliased back and forth across the frequency
-    spectrum.
+    Note that the created signal is not band-limited. Consult the example of
+    `sawtooth_rfft` on how to create a waveform bandlimited by the Nyquist frequency.
 
     Parameters
     ----------
@@ -41,16 +42,32 @@ def sawtooth(t, width=1):
     y : ndarray
         Output array containing the sawtooth waveform.
 
+    See Also
+    --------
+    sawtooth_rfft: Onesided FFT of a sawtooth or triangle waveform.
+    square: Create periodic square-wave waveform.
+    square_rfft: Onesided FFT of a square-wave waveform.
+
     Examples
     --------
-    A 5 Hz waveform sampled at 500 Hz for 1 second:
+    The following example depicts 5 Hz waveforms with various `width` parameters:
 
     >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
+    ...
     >>> t = np.linspace(0, 1, 500)
-    >>> plt.plot(t, signal.sawtooth(2 * np.pi * 5 * t))
-
+    >>> fg0, axx = plt.subplots(5, 1, sharex='all', figsize=(5, 5), tight_layout=True)
+    >>> axx[0].set_title("Triangle signals with various width parameters")
+    >>> for i_, ax_ in enumerate(axx):
+    ...     w_ = i_ / (len(axx) - 1)
+    ...     y_ = signal.sawtooth(2 * np.pi * 5 * t, width=w_)
+    ...     ax_.plot(t, y_, f'C{i_}', label=f"width={w_}")
+    ...     ax_.legend(loc='upper right', framealpha=1)
+    ...     ax_.grid(True)
+    ...     ax_.set_ylabel("Ampl.")
+    >>> axx[-1].set(xlabel="Time in seconds")
+    >>> plt.show()
     """
     t, w = asarray(t), asarray(width)
     w = asarray(w + (t - t))
@@ -81,6 +98,130 @@ def sawtooth(t, width=1):
     return y
 
 
+def sawtooth_rfft(n: int, m_cyc: int, duty: float = 0.5, *,
+                  norm: Literal['backward', 'ortho', 'forward'] = 'backward'):
+    r"""Onesided FFT of a sawtooth or triangle wave which is band-limited by the
+    Nyquist frequency.
+
+    This function returns the result of applying the :func:`~scipy.fft.rfft` function
+    to a virtual sawtooth wave signal of `n` samples which had an ideal low-pass filter
+    applied to remove spectral components above the Nyquist frequency ``0.5/T``. Here,
+    ``T`` is assumed to be the sampling interval.
+
+    Parameters
+    ----------
+    n : int
+        Number of samples of the virtual input signal.
+    m_cyc : int
+        Number of full cycles for `n` samples (``0 < m_cyc < n // 2`` must hold).
+        The frequency of the sawtooth wave is ``m_cyc / (n*T)``.
+    duty : float
+        Duty cycle, i.e., the ratio of the duration of the first part with positive
+        slope divided by the duration of a complete cycle. Note that ``0 <= duty <= 1``
+        must hold. Default: ``1``
+    norm :  Literal['backward', 'ortho', 'forward']
+        Scaling factor. Same as in :func:`~scipy.fft.rfft`. Default: ``'backward'``
+
+    Returns
+    -------
+    X: np.ndarray
+        A complex-valued array of length ``(n+1)//2`` containing the spectral values.
+        ``scipy.fft.rfftfreq(n, T)`` determines the corresponding frequency values of
+        `X`. The signal is calculated with ``scipy.fft.irfft(X, n, norm=norm)``.
+
+    See Also
+    --------
+    sawtooth: Create a periodic sawtooth or triangle waveform.
+    square: Create periodic square-wave waveform.
+    square_rfft: Onesided FFT of a square-wave waveform.
+
+    Notes
+    -----
+    A sawtooth wave :math:`x(t)` of frequency :math:`1/\tau` and duty cycle `d` can be
+    expressed as the Fourier series
+
+    .. math::
+
+        x(t) = \sum_{l=-\infty}^\infty c[l] \exp\{\mathbb{j}2\pi l t /\tau\}\ ,\quad
+        c[l] = \begin{cases}
+               0 &\text{ for } l = 0\ ,\\
+               -\frac{\mathbb{j}\tau}{\pi l} &\text{ for } l \neq 0 \wedge d = 0 \ ,\\
+               +\frac{\mathbb{j}\tau}{\pi l} &\text{ for } l \neq 0 \wedge d = 1 \ ,\\
+               \frac{\tau}{2\pi^2 l^2 d (d-1)}
+               \left(1 - \operatorname{e}^{\mathbb{j}2\pi d l}\right)
+               &\text{ for } l \neq 0 \wedge 0 < d < 1 \ .
+            \end{cases}
+
+    The close relationship between Fourier series and the discrete Fourier transform
+    allows to utilize :math:`c[l]` to obtain a closed-form expression for `X`. I.e.,
+    ``X[m_cyc*l] = s * c[l] / tau``, with ``tau = n * T / m_cyc`` being the duration of
+    one cycle. The scaling factor ``s`` has a value of ``n`` for parameter
+    `norm` = ``'backward'``, ``sqrt(n)`` for `norm` = ``'ortho'``, or ``1`` for
+    `norm` = ``'forward'``. All other values of `X` are zero.
+
+    Note that the magnitude :math:`|c[l]|` decreases proportionally to :math:`1/l^2`
+    if :math:`0 < d < 1` holds, else proportionally to :math:`1/|l|`. Hence, an ideal
+    sawtooth wave is not band-limited. The function :func:`~scipy.signal.sawtooth` can
+    be used to sample non-band-limited sawtooth waves.
+
+    Examples
+    --------
+    The following cade generates a plot of 1 Hz square wave and its Magnitude
+    spectrum:
+
+    >>> import numpy as np
+    >>> from matplotlib import pyplot as plt
+    >>> from scipy.fft import irfft, rfftfreq
+    >>> from scipy.signal import sawtooth_rfft
+    ...
+    >>> n, T = 500, 1e-2  # number of samples and sampling interval
+    >>> m_cyc, d = 5, 1  # number of full cycles and duty cycle
+    ...
+    >>> X = sawtooth_rfft(n, m_cyc, duty=d)
+    >>> x, t = irfft(X, n), np.arange(n) * T  # signal and time stamps
+    ...
+    >>> f = rfftfreq(n, T)  # frequencies of X
+    >>> df = f[1] - f[0]  # frequency resolution
+    ...
+    >>> fg, axx = plt.subplots(2, 1, tight_layout=True)
+    >>> axx[0].set_title(f"{m_cyc*df:g} Hz Sawtooth Wave ({100*d:g}% duty cycle)")
+    >>> axx[0].set(xlabel=rf"Time $t$ in seconds ($T={1e3*T:g}\,$ms, ${n=}$ samples)",
+    ...            ylabel="Amplitude $x(t)$", xlim=t[[0, -1]])
+    >>> axx[1].set_title(f"Magnitude Spectrum of $x(t)$")
+    >>> axx[1].set(ylabel="Magnitude $|X(f)| / (nT)$", xlim=f[[0, -1]],
+    ...            xlabel=rf"Frequency $f$ in hertz ($\Delta f={df:g}\,$Hz)")
+    >>> axx[0].plot(t, x, 'C0-')
+    >>> axx[1].plot(f, abs(X)/n, 'C1-')
+    ...
+    >>> for ax_ in axx:
+    ...    ax_.grid()
+    >>> plt.show()
+    """
+    if not (isinstance(n, int | np.integer) and n > 0):
+        raise ValueError(f"Parameter {n=} is not a positive integer!")
+    if not (isinstance(m_cyc, int | np.integer) and 0 < m_cyc < n // 2):
+        raise ValueError(f"Parameter {m_cyc=} is not a positive integer < {n//2=}!")
+    if not (0 <= duty <= 1):
+        raise ValueError(f"0 <= duty <= 1 does not hold for parameter {duty=}!")
+
+    scale_factors = {'backward': n, 'ortho': np.sqrt(n), 'forward': 1}
+    if norm not in scale_factors:
+        raise ValueError(f"Parameter {norm=} not in {list(scale_factors)}!")
+
+    n_X = n // 2 + 1  # number of bins produced by rfft for signal of n samples
+    X_dtype = rfft([0., ], norm=norm).dtype  # Use same dtype as rfft produces
+    X = np.zeros((n_X,), dtype=X_dtype)
+
+    ll = np.arange(1, (n_X + m_cyc - 1) // m_cyc) * np.pi
+    if duty == 0:
+        X[m_cyc::m_cyc] = -scale_factors[norm] * 1j / ll
+    elif duty == 1:
+        X[m_cyc::m_cyc] = scale_factors[norm] * 1j / ll
+    else:
+        exponent, denominator = np.exp(-2j * duty * ll), 2 * ll**2 * duty * (duty - 1)
+        X[m_cyc::m_cyc] = scale_factors[norm] * (1 - exponent) / denominator
+    return X
+
 def square(t, duty=0.5):
     """
     Return a periodic square-wave waveform.
@@ -89,9 +230,8 @@ def square(t, duty=0.5):
     ``2*pi*duty`` and -1 from ``2*pi*duty`` to ``2*pi``. `duty` must be in
     the interval [0,1].
 
-    Note that this is not band-limited.  It produces an infinite number
-    of harmonics, which are aliased back and forth across the frequency
-    spectrum.
+    Note that the created signal is not band-limited. Consult the example of
+    `square_rfft` on how to create a waveform bandlimited by the Nyquist frequency.
 
     Parameters
     ----------
@@ -107,28 +247,50 @@ def square(t, duty=0.5):
     y : ndarray
         Output array containing the square waveform.
 
+    See Also
+    --------
+    square_rfft: Onesided FFT of a square-wave waveform.
+    sawtooth: Create a periodic sawtooth or triangle waveform.
+    sawtooth_rfft: Onesided FFT of a sawtooth or triangle waveform.
+
     Examples
     --------
-    A 5 Hz waveform sampled at 500 Hz for 1 second:
+    The following example shows a 5 Hz waveform sampled at 500 Hz for 1 second:
 
     >>> import numpy as np
     >>> from scipy import signal
     >>> import matplotlib.pyplot as plt
+    ...
     >>> t = np.linspace(0, 1, 500, endpoint=False)
-    >>> plt.plot(t, signal.square(2 * np.pi * 5 * t))
-    >>> plt.ylim(-2, 2)
+    >>> x = signal.square(2 * np.pi * 5 * t)
+    >>>
+    ...
+    >>> fg0, ax0 = plt.subplots(tight_layout=True)
+    >>> ax0.set_title("5 Hz Square Wave signal")
+    >>> ax0.set(xlabel="Time in seconds", ylabel="Amplitude")
+    >>> ax0.plot(t, x)
+    >>> plt.show()
 
-    A pulse-width modulated sine wave:
 
-    >>> plt.figure()
+    The second example shows how to generate a pulse-width modulated square wave
+    signal:
+
+    >>> import numpy as np
+    >>> from scipy import signal
+    >>> import matplotlib.pyplot as plt
+    ...
+    >>> t = np.linspace(0, 1, 500, endpoint=False)
     >>> sig = np.sin(2 * np.pi * t)
     >>> pwm = signal.square(2 * np.pi * 30 * t, duty=(sig + 1)/2)
-    >>> plt.subplot(2, 1, 1)
-    >>> plt.plot(t, sig)
-    >>> plt.subplot(2, 1, 2)
-    >>> plt.plot(t, pwm)
-    >>> plt.ylim(-1.5, 1.5)
-
+    ...
+    >>> fg1, (ax10, ax11) = plt.subplots(2, 1, sharex='all', tight_layout=True)
+    >>> ax10.set_title("1 Hz Sine wave")
+    >>> ax10.set_ylabel("Amplitude")
+    >>> ax10.plot(t, sig, 'C1-')
+    >>> ax11.set_title("Pulse-width modulated Square Wave")
+    >>> ax11.set(xlabel="Time in seconds", ylabel="Amplitude")
+    >>> ax11.plot(t, pwm, 'C0-')
+    >>> plt.show()
     """
     t, w = asarray(t), asarray(duty)
     w = asarray(w + (t - t))
@@ -149,6 +311,156 @@ def square(t, duty=0.5):
     mask3 = (1 - mask1) & (1 - mask2)
     place(y, mask3, -1)
     return y
+
+
+def square_rfft(n: int, m_cyc: int, duty: float = 0.5,  *,
+                norm: Literal['backward', 'ortho', 'forward'] = 'backward'):
+    r"""Onesided FFT of a square wave which is band-limited by the Nyquist frequency.
+
+    This function returns the result of applying the :func:`~scipy.fft.rfft` function
+    to a virtual square wave signal of `n` samples which had an ideal low-pass filter
+    applied to remove spectral components above the Nyquist frequency ``0.5/T``. Here,
+    ``T`` is assumed to be the sampling interval.
+
+    Parameters
+    ----------
+    n : int
+        Number of samples of the virtual input signal.
+    m_cyc : int
+        Number of full cycles for `n` samples (``0 < m_cyc < n // 2`` must hold).
+        The frequency of the square wave is ``m_cyc / (n*T)``.
+    duty : float
+        Duty cycle, i.e., the ratio of the duration of the positive part divided by the
+        duration of a complete cycle. Note that ``0 < duty < 1`` must hold.
+        Default: ``0.5``
+    norm :  Literal['backward', 'ortho', 'forward']
+        Scaling factor. Same as in :func:`~scipy.fft.rfft`. Default: ``'backward'``
+
+    Returns
+    -------
+    X: np.ndarray
+        A complex-valued array of length ``(n+1)//2`` containing the spectral values.
+        ``scipy.fft.rfftfreq(n, T)`` determines the corresponding frequency values of
+        `X`. The signal is calculated with ``scipy.fft.irfft(X, n, norm=norm)``.
+
+    .. versionadded:: 1.16.0
+
+    See Also
+    --------
+    square: Create periodic square-wave waveform.
+    sawtooth: Create a periodic sawtooth or triangle waveform.
+    sawtooth_rfft: Onesided FFT of a sawtooth or triangle waveform.
+
+
+    Notes
+    -----
+    A square wave :math:`x(t)` of frequency :math:`1/\tau` and duty cycle `d` can be
+    expressed as the Fourier series
+
+    .. math::
+
+        x(t) = \sum_{l=-\infty}^\infty c[l] \exp\{\mathbb{j}2\pi l t /\tau\}\ ,\quad
+        c[l] = \begin{cases}
+               \tau (2 d - 1) &\text{ for } l = 0\ ,\\
+               \frac{\mathbb{j}\tau}{\pi l}
+               \left(\operatorname{e}^{\mathbb{j}2\pi d l} - 1 \right)
+               &\text{ for } l \neq 0\ .
+            \end{cases}
+
+    The close relationship between Fourier series and the discrete Fourier transform
+    allows to utilize :math:`c[l]` to obtain a closed-form llexpression for `X`. I.e.,
+    ``X[m_cyc*l] = s * c[l] / tau``, with ``tau = n * T / m_cyc`` being the duration of
+    one cycle. The scaling factor ``s`` has a value of ``n`` for parameter
+    `norm` = ``'backward'``, ``sqrt(n)`` for `norm` = ``'ortho'``, or ``1`` for
+    `norm` = ``'forward'``. All other values of `X` are zero.
+
+    Note that the magnitude :math:`|c[l]|` decreases proportionally to :math:`1/|l|`.
+    Hence, an ideal square wave is not band-limited. The function
+    :func:`~scipy.signal.square` can be used to sample non-band-limited square waves.
+
+    Examples
+    --------
+    The following cade generates a plot of 1 Hz square wave and its Magnitude
+    spectrum:
+
+    >>> import numpy as np
+    >>> from matplotlib import pyplot as plt
+    >>> from scipy.fft import irfft, rfftfreq
+    >>> from scipy.signal import square_rfft
+    ...
+    >>> n, T = 500, 1e-2  # number of samples and sampling interval
+    >>> m_cyc, d = 5, 0.5  # number of full cycles and duty cycle
+    ...
+    >>> X = square_rfft(n, m_cyc, duty=d)
+    >>> x, t = irfft(X, n), np.arange(n) * T  # signal and time stamps
+    ...
+    >>> f = rfftfreq(n, T)  # frequencies of X
+    >>> df = f[1] - f[0]  # frequency resolution
+    ...
+    >>> fg, axx = plt.subplots(2, 1, tight_layout=True)
+    >>> axx[0].set_title(f"{m_cyc*df:g} Hz Square Wave ({100*d:g}% duty cycle)")
+    >>> axx[0].set(xlabel=rf"Time $t$ in seconds ($T={1e3*T:g}\,$ms, ${n=}$ samples)",
+    ...            ylabel="Amplitude", xlim=t[[0, -1]])
+    >>> axx[1].set_title(f"Magnitude Spectrum")
+    >>> axx[1].set(ylabel="Magnitude", xlim=f[[0, -1]],
+    ...            xlabel=rf"Frequency $f$ in hertz ($\Delta f={df:g}\,$Hz)")
+    >>> axx[0].plot(t, x, 'C0-')
+    >>> axx[1].plot(f, abs(X)/n, 'C1-')
+    ...
+    >>> for ax_ in axx:
+    ...     ax_.grid()
+    >>> plt.show()
+
+    The second example illustrates how to create a square wave with varying frequency.
+    This is achieved by creating the signal directly from the Fourier series with the
+    caveat that the complex exponential :math:`\exp\{\mathbb{j}2\pi l t /\tau\}` is
+    replaced with a sinuoisod function with varying in frequency.
+
+    >>> from matplotlib import pyplot as plt
+    >>> from scipy.signal import chirp
+    >>> from scipy.signal import square_rfft
+    ...
+    >>> n, T = 500, 1/500  # number of samples and sampling interval
+    >>> m = 20  # number of Fourier coefficients
+    >>> f0, f1 = 3, 10  # start and stop frequency of sweep
+    ...
+    >>> X = square_rfft(m, 1, duty=0.5, norm='forward') * n*T  # Fourier coefficients
+    >>> t = np.arange(n) * T  # timestamps
+    >>> x = np.ones(n) * X[0].real  # signal of zeroth Fourier coefficient
+    >>> for l_, X_ in enumerate(X[1:], start=1):
+    ...     x_ =  X_* chirp(t, f0*l_, n*T, f1*l_, method='linear', complex=True)
+    ...     x += (x_ + np.conj(x_)).real  # since x is real, X[-l] == conj(X[l]) holds
+    ...
+    >>> fg0, ax0 = plt.subplots()
+    >>> ax0.set_title(f"{m} Coefficient Fourier Series sweeping from " +
+    ...               rf"${f0}\,$Hz to ${f1}\,$Hz ")
+    >>> ax0.set(xlabel=rf"Time $t$ in seconds ({n} samples, $T={T*1e3:g}\,$ms)",
+    ...         ylabel="Amplitude", xlim=(0, t[-1]))
+    >>> ax0.plot(np.arange(n) * T, x)
+    >>> ax0.grid()
+    >>> plt.show()
+    """
+    if not (isinstance(n, int | np.integer) and n > 0):
+        raise ValueError(f"Parameter {n=} is not a positive integer!")
+    if not (isinstance(m_cyc, int | np.integer) and 0 < m_cyc < n // 2):
+        raise ValueError(f"Parameter {m_cyc=} is not a positive integer < {n//2=}!")
+    if not (0 < duty < 1):
+        raise ValueError(f"0 < duty < 1 does not hold for parameter {duty=}!")
+
+    scale_factors = {'backward': n, 'ortho': np.sqrt(n), 'forward': 1}
+    if norm not in scale_factors:
+        raise ValueError(f"Parameter {norm=} not in {list(scale_factors)}!")
+
+    n_X = n // 2 + 1  # number of bins produced by rfft for signal of n samples
+    X_dtype = rfft([0., ], norm=norm).dtype  # Use same dtype as rfft produces
+    X = np.zeros((n_X,), dtype=X_dtype)
+
+    fac0, fac1 = scale_factors[norm], scale_factors[norm] * 1j / np.pi
+    X[0] = fac0 * (2 * duty - 1)  # zeroth Fourier coefficient
+    ll = np.arange(1, (n_X + m_cyc - 1) // m_cyc)
+    X[m_cyc::m_cyc] = fac1 * (np.exp(-2j * np.pi * duty * ll) - 1) / ll
+    return X
+
 
 
 def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
@@ -244,8 +556,7 @@ def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
         return yI, yenv
     if retquad and not retenv:
         return yI, yQ
-    if retquad and retenv:
-        return yI, yQ, yenv
+    return yI, yQ, yenv  # if retquad and retenv
 
 
 def chirp(t, f0, t1, f1, method='linear', phi=0, vertex_zero=True, *,

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -1,10 +1,11 @@
+import math
 from typing import Literal
 
 import numpy as np
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._array_api import (
-    assert_almost_equal, xp_assert_equal, xp_assert_close
+    array_namespace, assert_almost_equal, xp_assert_equal, xp_assert_close
 )
 
 import scipy.signal._waveforms as waveforms
@@ -488,20 +489,21 @@ class TestSawtoothRFFT:
 
     def setup_class(self):
         """Reference values are calculated here. """
+        xp = array_namespace()
         # For self.test_values():
-        vv0 = -8 / 3 * np.array([1 + 1j, 2., 1 - 1j, 0, 1 + 1j])
-        self.Xa_ref = np.zeros((6,), dtype=vv0.dtype)
-        self.Xa_ref[1:] = vv0 / (np.arange(1, 6) * np.pi) ** 2
-        self.Xb_ref = np.zeros_like(self.Xa_ref)
+        vv0 = -8 / 3 * xp.array([1 + 1j, 2., 1 - 1j, 0, 1 + 1j])
+        self.Xa_ref = xp.zeros((6,), dtype=vv0.dtype)
+        self.Xa_ref[1:] = vv0 / (xp.arange(1, 6) * xp.pi) ** 2
+        self.Xb_ref = xp.zeros_like(self.Xa_ref)
         self.Xb_ref[2::2] = self.Xa_ref[1:3]
 
         # For self.test_norm_parameter():
         self.x0_ref = irfft(self.Xa_ref, norm='forward')
 
         # For self.test_duty01():
-        self.X01a_ref = np.zeros(6, dtype=complex)
-        self.X01a_ref[1:] = 1j / np.pi / np.arange(1, 6)
-        self.X01b_ref = np.zeros_like(self.X01a_ref)
+        self.X01a_ref = xp.zeros(6, dtype=complex)
+        self.X01a_ref[1:] = 1j / xp.pi / xp.arange(1, 6)
+        self.X01b_ref = xp.zeros_like(self.X01a_ref)
         self.X01b_ref[2::2] = self.X01a_ref[1:3]
 
     def test_exceptions(self):
@@ -540,7 +542,7 @@ class TestSawtoothRFFT:
     @pytest.mark.parametrize('n', (10, 11))
     def test_duty01(self, n, norm: Literal['backward', 'ortho', 'forward']):
         """Test for parameter ``duty=0`` and ``duty=1``. """
-        s = {'backward': n, 'ortho': np.sqrt(n), 'forward': 1}[norm]
+        s = {'backward': n, 'ortho': math.sqrt(n), 'forward': 1}[norm]
 
         X0a = waveforms.sawtooth_rfft(n, 1, duty=0, norm=norm)
         xp_assert_close(X0a, -s * self.X01a_ref, atol=1e-12)
@@ -583,11 +585,12 @@ class TestSquareRFFT:
     def setup_class(self):
         """Reference values are calculated here. """
         # For self.test_values():
-        self.X0 = np.array([0, 1 - 1j, -1j, -(1 + 1j) / 3, 0., (1 - 1j) / 5]) / np.pi
+        xp = array_namespace()
+        self.X0 = xp.array([0, 1 - 1j, -1j, -(1 + 1j) / 3, 0., (1 - 1j) / 5]) / xp.pi
         self.X0[0] = -0.5
 
         # For self.test_norm_parameter():
-        X_ref = np.asarray([4., 0., -(8 + 8j) / np.pi, 0., -8j / np.pi])
+        X_ref = xp.asarray([4., 0., -(8 + 8j) / xp.pi, 0., -8j / xp.pi])
         self.x_ref = irfft(X_ref, norm='backward')
 
     def test_exceptions(self):

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -1,10 +1,14 @@
+from typing import Literal
+
 import numpy as np
+import pytest
 from pytest import raises as assert_raises
 from scipy._lib._array_api import (
     assert_almost_equal, xp_assert_equal, xp_assert_close
 )
 
 import scipy.signal._waveforms as waveforms
+from scipy.fft import irfft
 
 
 # These chirp_* functions are the instantaneous frequencies of the signals
@@ -46,6 +50,17 @@ def compute_frequency(t, theta):
 
 
 class TestChirp:
+
+    def test_exceptions(self):
+        """Raise all exceptions in used functions. """
+        t = np.arange(3)
+        with pytest.raises(ValueError, match="^For a logarithmic chirp, f0 and f1 "):
+            waveforms._chirp_phase(t, f0=-1, t1=2, f1=1, method='log')
+        for f0, f1 in [(0, 1), (1, 0)]:
+            with pytest.raises(ValueError, match="^For a hyperbolic chirp, f0 and f1"):
+                waveforms._chirp_phase(t, f0=f0, t1=2, f1=f1, method='hyp')
+        with pytest.raises(ValueError, match="^method must be 'linear', 'quadratic',"):
+            waveforms._chirp_phase(t, f0=f0, t1=2, f1=f1, method='INVALID')
 
     def test_linear_at_zero(self):
         w = waveforms.chirp(t=0, f0=1.0, f1=2.0, t1=1.0, method='linear')
@@ -195,6 +210,16 @@ class TestChirp:
         assert_raises(ValueError, waveforms.chirp, t, 0, t1, 1, method)
         assert_raises(ValueError, waveforms.chirp, t, 1, t1, 0, method)
 
+    def test_hyperbolic_const_freq(self):
+        """Test case parameter f1 == f2.
+
+        This test is required to achieve 100% coverage.
+        """
+        t, x_ref = np.arange(3), np.array([1., 1., 1.])
+
+        x = waveforms.chirp(t, f0=2, t1=2, f1=2, method='hyp')
+        xp_assert_close(x, x_ref)
+
     def test_unknown_method(self):
         method = "foo"
         f0 = 10.0
@@ -248,6 +273,15 @@ class TestChirp:
 
 
 class TestSweepPoly:
+
+    def test_sweep_poly(self):
+        """This test ensures that function `sweep_poly` has 100% coverage. """
+        t, p = np.arange(3), np.ones(2)
+        x_ref = np.array([1., -1., 1.])
+
+        x = waveforms.sweep_poly(t, p)
+        xp_assert_close(x, x_ref)
+
 
     def test_sweep_poly_quad1(self):
         p = np.poly1d([1.0, 0.0, 1.0])
@@ -317,6 +351,19 @@ class TestSweepPoly:
 
 class TestGaussPulse:
 
+    def test_exceptions(self):
+        """Raise all exceptions in function. """
+        with pytest.raises(ValueError, match="^Center frequency "):
+             waveforms.gausspulse('cutoff', fc=-1.0)
+        with pytest.raises(ValueError, match="^Fractional bandwidth "):
+            waveforms.gausspulse('cutoff', fc=1000.0, bw=-0.5)
+        with pytest.raises(ValueError, match="^Reference level for bandwidth "):
+            waveforms.gausspulse('cutoff', bwr=1.0)
+        with pytest.raises(ValueError, match="^Reference level for time cutoff must"):
+            waveforms.gausspulse('cutoff', tpr=1.0)
+        with pytest.raises(ValueError, match="^If `t` is a string, it must be "):
+            waveforms.gausspulse('INVALID')
+
     def test_integer_fc(self):
         float_result = waveforms.gausspulse('cutoff', fc=1000.0)
         int_result = waveforms.gausspulse('cutoff', fc=1000)
@@ -341,6 +388,40 @@ class TestGaussPulse:
         err_msg = "Integer input 'tpr=-60' gives wrong result"
         xp_assert_equal(int_result, float_result, err_msg=err_msg)
 
+    def test_parameter_t_values(self):
+        """Pass numeric array instead of string "cutoff". """
+        t = np.array([-0.5, 0, 0.5])
+        x0_ref = np.array([-0.7999183981317266, 1, -0.7999183981317266])
+        e0_ref = np.array([0.7999183981317266, 1, 0.7999183981317266])
+        y0_ref = np.array([-9.796175058510971e-17, 0, 9.796175058510971e-17])
+
+
+        x = waveforms.gausspulse(t, fc=1, retquad=False, retenv=False)
+        print(f"{x[0]=:0.16f}")
+        xp_assert_close(x, x0_ref, rtol=1e-8,
+                        err_msg="Invalid result x for retquad=False, retenv=False)")
+
+        x, e = waveforms.gausspulse(t, fc=1, retquad=False, retenv=True)
+        xp_assert_close(x, x0_ref, rtol=1e-8,
+                        err_msg="Invalid result x for retquad=False, retenv=True)")
+        xp_assert_close(e, e0_ref, rtol=1e-8,
+                        err_msg="Invalid result e for retquad=False, retenv=True)")
+
+        x, y = waveforms.gausspulse(t, fc=1, retquad=True, retenv=False)
+        print(f"{y[0]=:.16g}")
+        xp_assert_close(x, x0_ref, rtol=1e-8,
+                        err_msg="Invalid result x for retquad=True, retenv=False)")
+        xp_assert_close(y, y0_ref, rtol=1e-8,
+                        err_msg="Invalid result y for retquad=True, retenv=False)")
+
+        x, y, e = waveforms.gausspulse(t, fc=1, retquad=True, retenv=True)
+        print(f"{y[0]=:.16g}")
+        xp_assert_close(x, x0_ref, rtol=1e-8,
+                        err_msg="Invalid result x for retquad=True, retenv=True)")
+        xp_assert_close(y, y0_ref, rtol=1e-8,
+                        err_msg="Invalid result y for retquad=True, retenv=True)")
+        xp_assert_close(e, e0_ref, rtol=1e-8,
+                        err_msg="Invalid result e for retquad=True, retenv=True)")
 
 class TestUnitImpulse:
 
@@ -390,11 +471,150 @@ class TestSawtoothWaveform:
         waveform = waveforms.sawtooth(1)
         assert waveform.dtype == np.float64
 
+    @pytest.mark.parametrize("width, x_ref", ([
+                              (   0, [ 1,  1/2,   0, -1/2]),
+                              (0.25, [-1,    1, 1/3, -1/3]),
+                              ( 0.5, [-1,    0,   1,    0]),
+                              (0.75, [-1, -1/3, 1/3,    1]),
+                              (   1, [-1, -1/2,   0,  1/2])]))
+    def test_values(self, width, x_ref):
+        t = np.linspace(0, 2 * np.pi, 4, endpoint=False)
+        x = waveforms.sawtooth(t, width)
+        xp_assert_close(x, np.asarray(x_ref, dtype=float), atol=1e-12)
+
+
+class TestSawtoothRFFT:
+    """Unit tests for function `signal.sawtooth_rfft`. """
+
+    def setup_class(self):
+        """Reference values are calculated here. """
+        # For self.test_values():
+        vv0 = -8 / 3 * np.array([1 + 1j, 2., 1 - 1j, 0, 1 + 1j])
+        self.Xa_ref = np.zeros((6,), dtype=vv0.dtype)
+        self.Xa_ref[1:] = vv0 / (np.arange(1, 6) * np.pi) ** 2
+        self.Xb_ref = np.zeros_like(self.Xa_ref)
+        self.Xb_ref[2::2] = self.Xa_ref[1:3]
+
+        # For self.test_norm_parameter():
+        self.x0_ref = irfft(self.Xa_ref, norm='forward')
+
+        # For self.test_duty01():
+        self.X01a_ref = np.zeros(6, dtype=complex)
+        self.X01a_ref[1:] = 1j / np.pi / np.arange(1, 6)
+        self.X01b_ref = np.zeros_like(self.X01a_ref)
+        self.X01b_ref[2::2] = self.X01a_ref[1:3]
+
+    def test_exceptions(self):
+        """Raise all exceptions in function. """
+        for n in (10.5, -10):
+            with pytest.raises(ValueError, match=f"^Parameter {n=} is not a positive"):
+                waveforms.sawtooth_rfft(n, 1, 0.5)
+        for m_cyc in (5.5, 0, 10):
+            with pytest.raises(ValueError, match=f"^Parameter {m_cyc=} is not a "):
+                waveforms.sawtooth_rfft(10, m_cyc, 0.5)
+        for duty in (-0.1, 1.1):
+            with pytest.raises(ValueError, match="^0 <= duty <= 1 does not hold for "):
+                waveforms.sawtooth_rfft(10, 1, duty)
+        norm = 'INVALID'
+        with pytest.raises(ValueError, match=f"^Parameter {norm=} not in "):
+            # noinspection PyTypeChecker
+            waveforms.sawtooth_rfft(10, 1, 0.5, norm=norm)
+
+    @pytest.mark.parametrize('n', (10, 11))
+    def test_values(self, n):
+        """Test output against reference values. """
+        Xa = waveforms.sawtooth_rfft(n, 1, duty=0.25)
+        xp_assert_close(Xa, n * self.Xa_ref, atol=1e-12)
+
+        Xb = waveforms.sawtooth_rfft(n, 2, duty=0.25)
+        xp_assert_close(Xb, n * self.Xb_ref, atol=1e-12)
+
+    @pytest.mark.parametrize('norm', ('backward', 'ortho', 'forward'))
+    def test_norm_parameter(self, norm: Literal['backward', 'ortho', 'forward']):
+        """Verify that parameter `norm` is compatible with `scipy.fft.irfft`. """
+        X0 = waveforms.sawtooth_rfft(10, 1, duty=0.25, norm=norm)
+        x0 = irfft(X0, norm=norm)
+        xp_assert_close(x0, self.x0_ref, atol=1e-12)
+
+    @pytest.mark.parametrize('norm', ('backward', 'ortho', 'forward'))
+    @pytest.mark.parametrize('n', (10, 11))
+    def test_duty01(self, n, norm: Literal['backward', 'ortho', 'forward']):
+        """Test for parameter ``duty=0`` and ``duty=1``. """
+        s = {'backward': n, 'ortho': np.sqrt(n), 'forward': 1}[norm]
+
+        X0a = waveforms.sawtooth_rfft(n, 1, duty=0, norm=norm)
+        xp_assert_close(X0a, -s * self.X01a_ref, atol=1e-12)
+
+        X0b = waveforms.sawtooth_rfft(n, 2, duty=0, norm=norm)
+        xp_assert_close(X0b, -s * self.X01b_ref, atol=1e-12)
+
+        X1a = waveforms.sawtooth_rfft(n, 1, duty=1, norm=norm)
+        xp_assert_close(X1a, s * self.X01a_ref, atol=1e-12)
+
+        X1b = waveforms.sawtooth_rfft(n, 2, duty=1, norm=norm)
+        xp_assert_close(X1b, s * self.X01b_ref, atol=1e-12)
+
+
 
 class TestSquareWaveform:
     def test_dtype(self):
-        waveform = waveforms.square(np.array(1, dtype=np.float32), duty=np.float32(0.5))
+        waveform = waveforms.square(np.array(1, dtype=np.float32),
+                                    duty=np.float32(0.5))
         assert waveform.dtype == np.float64
 
         waveform = waveforms.square(1)
         assert waveform.dtype == np.float64
+
+    @pytest.mark.parametrize('duty, x_ref', ([
+                             (   0, [-1, -1, -1, -1]),
+                             (0.25, [ 1, -1, -1, -1]),
+                             ( 0.5, [ 1,  1, -1, -1]),
+                             (0.75, [ 1,  1,  1, -1]),
+                             (   1, [ 1,  1,  1,  1])]))
+    def test_values(self, duty, x_ref):
+        t = np.linspace(0, 2 * np.pi, 4, endpoint=False)
+        x = waveforms.square(t, duty)
+        xp_assert_equal(x, np.asarray(x_ref, dtype=np.float64))
+
+
+class TestSquareRFFT:
+    """Unit tests for function `signal.square_rfft`. """
+
+    def setup_class(self):
+        """Reference values are calculated here. """
+        # For self.test_values():
+        self.X0 = np.array([0, 1 - 1j, -1j, -(1 + 1j) / 3, 0., (1 - 1j) / 5]) / np.pi
+        self.X0[0] = -0.5
+
+        # For self.test_norm_parameter():
+        X_ref = np.asarray([4., 0., -(8 + 8j) / np.pi, 0., -8j / np.pi])
+        self.x_ref = irfft(X_ref, norm='backward')
+
+    def test_exceptions(self):
+        """Raise all exceptions in function. """
+        for n in (10.5, -10):
+            with pytest.raises(ValueError, match=f"^Parameter {n=} is not a positive"):
+                waveforms.square_rfft(n, 1, 0.5)
+        for m_cyc in (5.5, 0, 10):
+            with pytest.raises(ValueError, match=f"^Parameter {m_cyc=} is not a "):
+                waveforms.square_rfft(10, m_cyc, 0.5)
+        for duty in (0, 1):
+            with pytest.raises(ValueError, match="^0 < duty < 1 does not hold for "):
+                waveforms.square_rfft(10, 1, duty)
+        norm = 'INVALID'
+        with pytest.raises(ValueError, match=f"^Parameter {norm=} not in "):
+            # noinspection PyTypeChecker
+            waveforms.square_rfft(10, 1, 0.5, norm=norm)
+
+    @pytest.mark.parametrize('n', (10, 11))
+    def test_values(self, n):
+        """Test output against reference values. """
+        X = waveforms.square_rfft(n, 1, 0.25)
+        xp_assert_close(X, self.X0 * n, atol=1e-12)
+
+    @pytest.mark.parametrize('norm', ('backward', 'ortho', 'forward'))
+    def test_norm_parameter(self, norm: Literal['backward', 'ortho', 'forward']):
+        """Test that parameter `norm` is compatible with `scipy.fft.irfft`. """
+        X = waveforms.square_rfft(8, 2, 0.75, norm=norm)
+        x = irfft(X, norm=norm)
+        xp_assert_close(x, self.x_ref, atol=1e-12)

--- a/scipy/signal/waveforms.py
+++ b/scipy/signal/waveforms.py
@@ -5,8 +5,8 @@
 from scipy._lib.deprecation import _sub_module_deprecation
 
 __all__ = [  # noqa: F822
-    'sawtooth', 'square', 'gausspulse', 'chirp', 'sweep_poly',
-    'unit_impulse',
+    'sawtooth', 'sawtooth_rfft', 'square', 'square_rfft', 'gausspulse', 'chirp',
+    'sweep_poly', 'unit_impulse',
 ]
 
 


### PR DESCRIPTION
This is a shot at resolving the oldest open issue in the signal module, namely #1507. It provides the new functions [sawtooth_rfft] and [square_rfft], which return the one-sided discrete Fourier transform of a sawtooth and a square waveform. This allows to efficiently create signals by utilizing the [irfft] function.

I chose not to integrate band-limited version into the original [sawtooth] and [square] functions, but to provide the one-sided FFTs because:
*  [sawtooth] and [square] allow arbitrary time stamps—band-limited signals are closely related to equidistant sample intervals. Hence, the existing parameters are not suited to enforce equidistant time stamps.
* Being able to use the efficient [irfft] function comes with some limitations: Only signals with complete cycles can be created. By letting the users apply the [irfft] function themselves, reasoning about those limitations becomes much easier.
* When one cares about band-limited signals, one is probably also interested in the corresponding spectrum.
* Having the explicit Fourier coefficients is beneficial when creating signals with varying frequency (as illustrated in the second example of [square_rfft]).

Additional Changes:
* Some unit tests were added to achieve 100% coverage of file `signal/_waveforms.py`.
* New unit tests for `signal.square` and `signal.sawtooth` were added to check for correct values.
* Beautified plots of in docs of  [square] and [sawtooth].


Notes:
* Links to rendered docs:  [square_rfft], [sawtooth_rfft], [square], [sawtooth]
* The error in CI (``test_hermitian``) seems to be unrelated
* I tried to incorporate the array API standard, but could come up with a good way to implement this without mutating arrays (as demanded by JAX).
* ~~Closes~~ ~~#1507~~ (due to this [comment] below).

[square_rfft]: https://output.circle-artifacts.com/output/job/78c70132-73f0-4811-89dd-4bd5bbafb99a/artifacts/0/html/reference/generated/scipy.signal.square_rfft.html
[sawtooth_rfft]: https://output.circle-artifacts.com/output/job/78c70132-73f0-4811-89dd-4bd5bbafb99a/artifacts/0/html/reference/generated/scipy.signal.sawtooth_rfft.html#scipy.signal.sawtooth_rfft
[sawtooth]: https://output.circle-artifacts.com/output/job/78c70132-73f0-4811-89dd-4bd5bbafb99a/artifacts/0/html/reference/generated/scipy.signal.sawtooth.html#scipy.signal.sawtooth
[square]: https://output.circle-artifacts.com/output/job/78c70132-73f0-4811-89dd-4bd5bbafb99a/artifacts/0/html/reference/generated/scipy.signal.square.html#scipy.signal.square
[irfft]: https://scipy.github.io/devdocs/reference/generated/scipy.fft.irfft.html
 [comment]: https://github.com/scipy/scipy/pull/22656#issuecomment-2886890141
