### PR TITLE
CI: clean up free-threading job, add new job using pytest-run-parallel

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -455,9 +455,7 @@ jobs:
     needs: get_commit_message
     strategy:
       matrix:
-        # Restore once parallel testing passes in CI
-        # parallel: ['0', '1']
-        parallel: ['0']
+        parallel: ['0', '1']
 
     runs-on: ubuntu-latest
     if: >
@@ -475,35 +473,64 @@ jobs:
     - name: Install Ubuntu dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev gfortran
+        sudo apt-get install -y gfortran
+
     - name: Install nightly Cython
       run: |
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
+
     - name: Install Python dependencies
       run: |
-        pip install numpy ninja meson-python pybind11 click rich_click pydevtool
-        pip install --pre --upgrade pytest pytest-xdist gmpy2 threadpoolctl pooch hypothesis
+        pip install numpy ninja meson-python pybind11 click rich_click pydevtool pytest pytest-xdist threadpoolctl pooch hypothesis
         pip install -r requirements/openblas.txt
-        echo "N_TEST_WORKERS=2" >> "$GITHUB_ENV"
+
     - name: Install Pythran master
       run: |
         # 0.17.0 doesn't support free-threading, update once the next release is out
         python -m pip install git+https://github.com/serge-sans-paille/pythran.git
+
     - name: Install pytest-run-parallel
       if: ${{ matrix.parallel == '1'}}
       run: |
         pip install pytest-run-parallel
-        echo "EXTRA_PYTEST_ARGS=--parallel-threads=5" >> "$GITHUB_ENV"
-        echo "N_TEST_WORKERS=1" >> "$GITHUB_ENV"
-    - name: Build and run tests
-      env:
-        TODO_TEST_SELECTION: 0
-      # TODO: For some reason the Meson installation path points to
-      # python3/site-packages as opposed to python3.13/site-packages,
-      # then the dev.py scripts do not work as expected.
+        pip uninstall --yes pytest-xdist
+
+    - name: Build SciPy
       run: |
         python dev.py build --with-scipy-openblas
-        python dev.py --no-build test -m full -j$N_TEST_WORKERS --durations=10 $EXTRA_PYTEST_ARGS
+
+    - name: Run tests (full)
+      if: ${{ matrix.parallel == '0'}}
+      run: |
+        python dev.py --no-build test -j2 -m full --durations=10
+
+    - name: Run tests (fast, with pytest-run-parallel)
+      if: ${{ matrix.parallel == '1'}}
+      env:
+        # Excluded modules:
+        # - scipy.special and scipy.stats are waiting on special.errstate being made thread-safe
+        # - scipy.spatial has multiple issues  in kdtree/qhull, and gh-20655 is pending.
+        TEST_SUBMODULES: >-
+          -t scipy.cluster
+          -t scipy.constants
+          -t scipy.datasets
+          -t scipy.differentiate
+          -t scipy.fft
+          -t scipy.fftpack
+          -t scipy.integrate
+          -t scipy.interpolate
+          -t scipy.io
+          -t scipy.linalg
+          -t scipy.misc
+          -t scipy.ndimage
+          -t scipy.odr
+          -t scipy.optimize
+          -t scipy.signal
+          -t scipy.sparse
+      run: |
+        # Note: only fast tests; full test suite is unlikely to uncover anything more,
+        #       and it'll be quite slow with pytest-run-parallel
+        python dev.py --no-build test $TEST_SUBMODULES -- --parallel-threads=4
 
   #################################################################################
   clang-17-build-only:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -468,28 +468,27 @@ jobs:
       with:
         submodules: recursive
         fetch-tags: true
-    # TODO: replace with setup-python when there is support
-    - uses: Quansight-Labs/setup-python@b9ab292c751a42bcd2bb465b7fa202ea2c3f5796 # v5.3.1
+    - uses: actions/setup-python@9e62be81b28222addecf85e47571213eb7680449 # v5.5.0-dev
       with:
         python-version: '3.13t'
 
     - name: Install Ubuntu dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev ccache gfortran
-    # TODO: remove pip pre-release install after Python 3.13 release
-    - name: Install pre-release pip
+        sudo apt-get install -y libgmp-dev libmpfr-dev libmpc-dev gfortran
+    - name: Install nightly Cython
       run: |
-        pip install -U --pre pip
-    - name: Install nightly NumPy and Cython
-      run: |
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython numpy
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple cython
     - name: Install Python dependencies
       run: |
-        pip install pythran ninja meson-python pybind11 click rich_click pydevtool
+        pip install numpy ninja meson-python pybind11 click rich_click pydevtool
         pip install --pre --upgrade pytest pytest-xdist gmpy2 threadpoolctl pooch hypothesis
         pip install -r requirements/openblas.txt
         echo "N_TEST_WORKERS=2" >> "$GITHUB_ENV"
+    - name: Install Pythran master
+      run: |
+        # 0.17.0 doesn't support free-threading, update once the next release is out
+        python -m pip install git+https://github.com/serge-sans-paille/pythran.git
     - name: Install pytest-run-parallel
       if: ${{ matrix.parallel == '1'}}
       run: |
@@ -498,17 +497,13 @@ jobs:
         echo "N_TEST_WORKERS=1" >> "$GITHUB_ENV"
     - name: Build and run tests
       env:
-        PYTHON_GIL: 0
+        TODO_TEST_SELECTION: 0
       # TODO: For some reason the Meson installation path points to
       # python3/site-packages as opposed to python3.13/site-packages,
       # then the dev.py scripts do not work as expected.
       run: |
-        # python dev.py build --with-scipy-openblas
-        # python dev.py --no-build test -j2 --mode full
-        python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > scipy-openblas.pc
-        PKG_CONFIG_PATH="$PWD" pip install . -vv --no-build-isolation
-        pushd $RUNNER_TEMP
-        PYTHON_GIL=0 python -m pytest --pyargs scipy -n$N_TEST_WORKERS --durations=10 $EXTRA_PYTEST_ARGS
+        python dev.py build --with-scipy-openblas
+        python dev.py --no-build test -m full -j$N_TEST_WORKERS --durations=10 $EXTRA_PYTEST_ARGS
 
   #################################################################################
   clang-17-build-only:

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -251,6 +251,7 @@ def banded_stiff_jac(t, y):
         [0,  0.04,           3e7*2*y[2],         0, 0]
     ])
 
+@pytest.mark.thread_unsafe
 def test_banded_lsoda():
     # expected solution is given by problem with full jacobian
     tfull, yfull = _solve_robertson_lsoda(use_jac=True, banded=False)

--- a/scipy/linalg/tests/_cython_examples/meson.build
+++ b/scipy/linalg/tests/_cython_examples/meson.build
@@ -10,10 +10,16 @@ if not cy.version().version_compare('>=3.0.8')
   error('tests requires Cython >= 3.0.8')
 endif
 
+cython_args = []
+if cy.version().version_compare('>=3.1.0')
+  cython_args += ['-Xfreethreading_compatible=True']
+endif
+
 py3.extension_module(
   'extending',
   'extending.pyx',
   install: false,
+  cython_args: cython_args,
   c_args: ['-DCYTHON_CCOMPLEX=0'] # see gh-18975 for why we need this
 )
 
@@ -23,5 +29,6 @@ py3.extension_module(
   extending_cpp,
   install: false,
   override_options : ['cython_language=cpp'],
+  cython_args: cython_args,
   cpp_args: ['-DCYTHON_CCOMPLEX=0'] # see gh-18975 for why we need this
 )

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -74,31 +74,31 @@ class TestBatch:
 
         return res2  # return original, non-tuplized result
 
-    @pytest.fixture
-    def rng(self):
-        return np.random.default_rng(8342310302941288912051)
-
     @pytest.mark.parametrize('dtype', floating)
-    def test_expm_cond(self, dtype, rng):
+    def test_expm_cond(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = rng.random((5, 3, 4, 4)).astype(dtype)
         self.batch_test(linalg.expm_cond, A)
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_issymmetric(self, dtype, rng):
+    def test_issymmetric(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_nearly_hermitian((5, 3, 4, 4), dtype, 3e-4, rng)
         res = self.batch_test(linalg.issymmetric, A, kwargs=dict(atol=1e-3))
         assert not np.all(res)  # ensure test is not trivial: not all True or False;
         assert np.any(res)      # also confirms that `atol` is passed to issymmetric
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_ishermitian(self, dtype, rng):
+    def test_ishermitian(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_nearly_hermitian((5, 3, 4, 4), dtype, 3e-4, rng)
         res = self.batch_test(linalg.ishermitian, A, kwargs=dict(atol=1e-3))
         assert not np.all(res)  # ensure test is not trivial: not all True or False;
         assert np.any(res)      # also confirms that `atol` is passed to ishermitian
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_diagsvd(self, dtype, rng):
+    def test_diagsvd(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = rng.random((5, 3, 4)).astype(dtype)
         res1 = self.batch_test(linalg.diagsvd, A, kwargs=dict(M=6, N=4), core_dim=1)
         # test that `M, N` can be passed by position
@@ -110,22 +110,26 @@ class TestBatch:
                                      linalg.sinhm, linalg.coshm, linalg.tanhm,
                                      linalg.pinv, linalg.pinvh, linalg.orth])
     @pytest.mark.parametrize('dtype', floating)
-    def test_matmat(self, fun, dtype, rng):  # matrix in, matrix out
+    def test_matmat(self, fun, dtype):  # matrix in, matrix out
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, A)
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_null_space(self, dtype, rng):
+    def test_null_space(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 6), dtype=dtype, rng=rng)
         self.batch_test(linalg.null_space, A)
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_funm(self, dtype, rng):
+    def test_funm(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 4, 3, 3), dtype=dtype, rng=rng)
         self.batch_test(linalg.funm, A, kwargs=dict(func=np.sin))
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_fractional_matrix_power(self, dtype, rng):
+    def test_fractional_matrix_power(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 4, 3, 3), dtype=dtype, rng=rng)
         res1 = self.batch_test(linalg.fractional_matrix_power, A, kwargs={'t':1.5})
         # test that `t` can be passed by position
@@ -147,18 +151,21 @@ class TestBatch:
             np.testing.assert_equal(res1i, res2i)
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_pinv(self, dtype, rng):
+    def test_pinv(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(linalg.pinv, A, n_out=2, kwargs=dict(return_rank=True))
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_matrix_balance(self, dtype, rng):
+    def test_matrix_balance(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(linalg.matrix_balance, A, n_out=2)
         self.batch_test(linalg.matrix_balance, A, n_out=2, kwargs={'separate':True})
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_bandwidth(self, dtype, rng):
+    def test_bandwidth(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((4, 4), dtype=dtype, rng=rng)
         A = np.asarray([np.triu(A, k) for k in range(-3, 3)]).reshape((2, 3, 4, 4))
         self.batch_test(linalg.bandwidth, A, n_out=2)
@@ -166,7 +173,8 @@ class TestBatch:
     @pytest.mark.parametrize('fun_n_out', [(linalg.cholesky, 1), (linalg.ldl, 3),
                                            (linalg.cho_factor, 2)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_ldl_cholesky(self, fun_n_out, dtype, rng):
+    def test_ldl_cholesky(self, fun_n_out, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         fun, n_out = fun_n_out
         A = get_nearly_hermitian((5, 3, 4, 4), dtype, 0, rng)  # exactly Hermitian
         A = A + 4*np.eye(4, dtype=dtype)  # ensure positive definite for Cholesky
@@ -174,20 +182,23 @@ class TestBatch:
 
     @pytest.mark.parametrize('compute_uv', [False, True])
     @pytest.mark.parametrize('dtype', floating)
-    def test_svd(self, compute_uv, dtype, rng):
+    def test_svd(self, compute_uv, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
         n_out = 3 if compute_uv else 1
         self.batch_test(linalg.svd, A, n_out=n_out, kwargs=dict(compute_uv=compute_uv))
 
     @pytest.mark.parametrize('fun', [linalg.polar, linalg.qr, linalg.rq])
     @pytest.mark.parametrize('dtype', floating)
-    def test_polar_qr_rq(self, fun, dtype, rng):
+    def test_polar_qr_rq(self, fun, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, A, n_out=2)
 
     @pytest.mark.parametrize('cdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_qr_multiply(self, cdim, dtype, rng):
+    def test_qr_multiply(self, cdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         c = get_random(cdim, dtype=dtype, rng=rng)
         res = linalg.qr_multiply(A, c, mode='left')
@@ -199,7 +210,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('uvdim', [[(5,), (3,)], [(4, 5, 2), (4, 3, 2)]])
     @pytest.mark.parametrize('dtype', floating)
-    def test_qr_update(self, uvdim, dtype, rng):
+    def test_qr_update(self, uvdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         udim, vdim = uvdim
         A = get_random((4, 5, 3), dtype=dtype, rng=rng)
         u = get_random(udim, dtype=dtype, rng=rng)
@@ -216,7 +228,8 @@ class TestBatch:
     @pytest.mark.parametrize('udim', [(5,), (4, 3, 5)])
     @pytest.mark.parametrize('kdim', [(), (4,)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_qr_insert(self, udim, kdim, dtype, rng):
+    def test_qr_insert(self, udim, kdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((4, 5, 5), dtype=dtype, rng=rng)
         u = get_random(udim, dtype=dtype, rng=rng)
         k = rng.integers(0, 5, size=kdim)
@@ -232,7 +245,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('kdim', [(), (4,)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_qr_delete(self, kdim, dtype, rng):
+    def test_qr_delete(self, kdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((4, 5, 5), dtype=dtype, rng=rng)
         k = rng.integers(0, 4, size=kdim)
         q, r = linalg.qr(A)
@@ -246,27 +260,31 @@ class TestBatch:
 
     @pytest.mark.parametrize('fun', [linalg.schur, linalg.lu_factor])
     @pytest.mark.parametrize('dtype', floating)
-    def test_schur_lu(self, fun, dtype, rng):
+    def test_schur_lu(self, fun, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, A, n_out=2)
 
     @pytest.mark.parametrize('calc_q', [False, True])
     @pytest.mark.parametrize('dtype', floating)
-    def test_hessenberg(self, calc_q, dtype, rng):
+    def test_hessenberg(self, calc_q, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         n_out = 2 if calc_q else 1
         self.batch_test(linalg.hessenberg, A, n_out=n_out, kwargs=dict(calc_q=calc_q))
 
     @pytest.mark.parametrize('eigvals_only', [False, True])
     @pytest.mark.parametrize('dtype', floating)
-    def test_eig_banded(self, eigvals_only, dtype, rng):
+    def test_eig_banded(self, eigvals_only, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         n_out = 1 if eigvals_only else 2
         self.batch_test(linalg.eig_banded, A, n_out=n_out,
                         kwargs=dict(eigvals_only=eigvals_only))
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_eigvals_banded(self, dtype, rng):
+    def test_eigvals_banded(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(linalg.eigvals_banded, A)
 
@@ -274,7 +292,8 @@ class TestBatch:
     @pytest.mark.parametrize('fun_n_nout', [(linalg.eigh, 1), (linalg.eigh, 2),
                                             (linalg.eigvalsh, 1), (linalg.eigvals, 1)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_eigh(self, two_in, fun_n_nout, dtype, rng):
+    def test_eigh(self, two_in, fun_n_nout, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         fun, n_out = fun_n_nout
         A = get_nearly_hermitian((1, 3, 4, 4), dtype, 0, rng)  # exactly Hermitian
         B = get_nearly_hermitian((2, 1, 4, 4), dtype, 0, rng)  # exactly Hermitian
@@ -285,7 +304,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('compute_expm', [False, True])
     @pytest.mark.parametrize('dtype', floating)
-    def test_expm_frechet(self, compute_expm, dtype, rng):
+    def test_expm_frechet(self, compute_expm, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((1, 3, 4, 4), dtype=dtype, rng=rng)
         E = get_random((2, 1, 4, 4), dtype=dtype, rng=rng)
         n_out = 2 if compute_expm else 1
@@ -293,7 +313,8 @@ class TestBatch:
                         kwargs=dict(compute_expm=compute_expm))
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_subspace_angles(self, dtype, rng):
+    def test_subspace_angles(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((1, 3, 4, 3), dtype=dtype, rng=rng)
         B = get_random((2, 1, 4, 3), dtype=dtype, rng=rng)
         self.batch_test(linalg.subspace_angles, (A, B))
@@ -305,7 +326,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('fun', [linalg.svdvals])
     @pytest.mark.parametrize('dtype', floating)
-    def test_svdvals(self, fun, dtype, rng):
+    def test_svdvals(self, fun, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
         self.batch_test(fun, A)
 
@@ -316,14 +338,16 @@ class TestBatch:
                                            (linalg.qz, 4),
                                            (linalg.ordqz, 6)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_two_generic_matrix_inputs(self, fun_n_out, dtype, rng):
+    def test_two_generic_matrix_inputs(self, fun_n_out, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         fun, n_out = fun_n_out
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         B = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, (A, B), n_out=n_out)
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_cossin(self, dtype, rng):
+    def test_cossin(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         p, q = 3, 4
         X = get_random((2, 3, 10, 10), dtype=dtype, rng=rng)
         x11, x12, x21, x22 = (X[..., :p, :q], X[..., :p, q:],
@@ -340,7 +364,8 @@ class TestBatch:
                     np.testing.assert_equal(res_i[j, k], ref_ijk)
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_sylvester(self, dtype, rng):
+    def test_sylvester(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         B = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         C = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
@@ -349,7 +374,8 @@ class TestBatch:
     @pytest.mark.parametrize('fun', [linalg.solve_continuous_are,
                                      linalg.solve_discrete_are])
     @pytest.mark.parametrize('dtype', floating)
-    def test_are(self, fun, dtype, rng):
+    def test_are(self, fun, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         a = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         b = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         q = get_nearly_hermitian((2, 3, 5, 5), dtype=dtype, atol=0, rng=rng)
@@ -362,19 +388,22 @@ class TestBatch:
         self.batch_test(fun, (a, b, q, r))
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_rsf2cs(self, dtype, rng):
+    def test_rsf2cs(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 4, 4), dtype=dtype, rng=rng)
         T, Z = linalg.schur(A)
         self.batch_test(linalg.rsf2csf, (T, Z), n_out=2)
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_cholesky_banded(self, dtype, rng):
+    def test_cholesky_banded(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         ab = get_random((5, 4, 3, 6), dtype=dtype, rng=rng)
         ab[..., -1, :] = 10  # make diagonal dominant
         self.batch_test(linalg.cholesky_banded, ab)
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_block_diag(self, dtype, rng):
+    def test_block_diag(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         a = get_random((1, 3, 1, 3), dtype=dtype, rng=rng)
         b = get_random((2, 1, 3, 6), dtype=dtype, rng=rng)
         c = get_random((1, 1, 3, 2), dtype=dtype, rng=rng)
@@ -395,7 +424,8 @@ class TestBatch:
                                            (linalg.eigvalsh_tridiagonal, 1)])
     @pytest.mark.parametrize('dtype', real_floating)
     # "Only real arrays currently supported"
-    def test_eigh_tridiagonal(self, fun_n_out, dtype, rng):
+    def test_eigh_tridiagonal(self, fun_n_out, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         fun, n_out = fun_n_out
         d = get_random((3, 4, 5), dtype=dtype, rng=rng)
         e = get_random((3, 4, 4), dtype=dtype, rng=rng)
@@ -403,7 +433,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_solve(self, bdim, dtype, rng):
+    def test_solve(self, bdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         b = get_random(bdim, dtype=dtype, rng=rng)
         x = linalg.solve(A, b)
@@ -415,7 +446,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_lu_solve(self, bdim, dtype, rng):
+    def test_lu_solve(self, bdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         b = get_random(bdim, dtype=dtype, rng=rng)
         lu_and_piv = linalg.lu_factor(A)
@@ -429,7 +461,8 @@ class TestBatch:
     @pytest.mark.parametrize('l_and_u', [(1, 1), ([2, 1, 0], [0, 1 , 2])])
     @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_solve_banded(self, l_and_u, bdim, dtype, rng):
+    def test_solve_banded(self, l_and_u, bdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         l, u = l_and_u
         ab = get_random((2, 3, 3, 5), dtype=dtype, rng=rng)
         b = get_random(bdim, dtype=dtype, rng=rng)
@@ -446,7 +479,8 @@ class TestBatch:
     # @pytest.mark.parametrize('separate_r', [False, True])
     # @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
     # @pytest.mark.parametrize('dtype', floating)
-    # def test_solve_toeplitz(self, separate_r, bdim, dtype, rng):
+    # def test_solve_toeplitz(self, separate_r, bdim, dtype):
+    #     rng = np.random.default_rng(8342310302941288912051)
     #     c = get_random((2, 3, 5), dtype=dtype, rng=rng)
     #     r = get_random((2, 3, 5), dtype=dtype, rng=rng)
     #     c_or_cr = (c, r) if separate_r else c
@@ -461,7 +495,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_cho_solve(self, bdim, dtype, rng):
+    def test_cho_solve(self, bdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_nearly_hermitian((2, 3, 5, 5), dtype=dtype, atol=0, rng=rng)
         A = A + 5*np.eye(5)
         c_and_lower = linalg.cho_factor(A)
@@ -476,7 +511,8 @@ class TestBatch:
     @pytest.mark.parametrize('lower', [False, True])
     @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_cho_solve_banded(self, lower, bdim, dtype, rng):
+    def test_cho_solve_banded(self, lower, bdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 3, 5), dtype=dtype, rng=rng)
         row_diag = 0 if lower else -1
         A[:, :, row_diag] = 10
@@ -491,7 +527,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_solveh_banded(self, bdim, dtype, rng):
+    def test_solveh_banded(self, bdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 3, 5), dtype=dtype, rng=rng)
         A[:, :, -1] = 10
         b = get_random(bdim, dtype=dtype, rng=rng)
@@ -504,7 +541,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('bdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_solve_triangular(self, bdim, dtype, rng):
+    def test_solve_triangular(self, bdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 5, 5), dtype=dtype, rng=rng)
         A = np.tril(A)
         b = get_random(bdim, dtype=dtype, rng=rng)
@@ -518,7 +556,8 @@ class TestBatch:
 
     @pytest.mark.parametrize('bdim', [(4,), (4, 3), (2, 3, 4, 3)])
     @pytest.mark.parametrize('dtype', floating)
-    def test_lstsq(self, bdim, dtype, rng):
+    def test_lstsq(self, bdim, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((2, 3, 4, 5), dtype=dtype, rng=rng)
         b = get_random(bdim, dtype=dtype, rng=rng)
         res = linalg.lstsq(A, b)
@@ -530,12 +569,14 @@ class TestBatch:
         assert len(res) == 4
 
     @pytest.mark.parametrize('dtype', floating)
-    def test_clarkson_woodruff_transform(self, dtype, rng):
+    def test_clarkson_woodruff_transform(self, dtype):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 6), dtype=dtype, rng=rng)
         self.batch_test(linalg.clarkson_woodruff_transform, A,
                         kwargs=dict(sketch_size=3, rng=311224))
 
-    def test_clarkson_woodruff_transform_sparse(self, rng):
+    def test_clarkson_woodruff_transform_sparse(self):
+        rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 4, 6), dtype=np.float64, rng=rng)
         A = sparse.coo_array(A)
         message = "Batch support for sparse arrays is not available."

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -68,6 +68,7 @@ def test_regression_std_vector_dtypes():
 
 
 @pytest.mark.slow
+@pytest.mark.thread_unsafe
 @pytest.mark.xfail_on_32bit("Can't create large array for test")
 def test_nnz_overflow():
     # Regression test for gh-7230 / gh-7871, checking that coo_toarray
@@ -88,6 +89,7 @@ def test_nnz_overflow():
     assert_allclose(d, [[4]])
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.skipif(
     not (sys.platform.startswith('linux') and np.dtype(np.intp).itemsize >= 8),
     reason="test requires 64-bit Linux"
@@ -270,6 +272,7 @@ class TestInt32Overflow:
         m2.dot(m)  # shouldn't SIGSEGV
 
 
+@pytest.mark.thread_unsafe
 @pytest.mark.skip(reason="64-bit indices in sparse matrices not available")
 def test_csr_matmat_int64_overflow():
     n = 3037000500

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -428,6 +428,10 @@ class TestDelaunay:
         masked_array = np.ma.masked_all(1)
         assert_raises(ValueError, qhull.Delaunay, masked_array)
 
+    # Shouldn't be inherently unsafe; retry with cpython 3.14 once traceback
+    # thread safety issues are fixed (also goes for other test with same name
+    # further down)
+    @pytest.mark.thread_unsafe
     def test_array_with_nans_fails(self):
         points_with_nan = np.array([(0,0), (0,1), (1,1), (1,np.nan)], dtype=np.float64)
         assert_raises(ValueError, qhull.Delaunay, points_with_nan)
@@ -607,6 +611,7 @@ class TestConvexHull:
         masked_array = np.ma.masked_all(1)
         assert_raises(ValueError, qhull.ConvexHull, masked_array)
 
+    @pytest.mark.thread_unsafe
     def test_array_with_nans_fails(self):
         points_with_nan = np.array([(0,0), (1,1), (2,np.nan)], dtype=np.float64)
         assert_raises(ValueError, qhull.ConvexHull, points_with_nan)

--- a/scipy/special/tests/_cython_examples/meson.build
+++ b/scipy/special/tests/_cython_examples/meson.build
@@ -10,10 +10,16 @@ if not cy.version().version_compare('>=3.0.8')
   error('tests requires Cython >= 3.0.8')
 endif
 
+cython_args = []
+if cy.version().version_compare('>=3.1.0')
+  cython_args += ['-Xfreethreading_compatible=True']
+endif
+
 py3.extension_module(
   'extending',
   'extending.pyx',
   install: false,
+  cython_args: cython_args,
 )
 
 extending_cpp = fs.copyfile('extending.pyx', 'extending_cpp.pyx')
@@ -21,5 +27,6 @@ py3.extension_module(
   'extending_cpp',
   extending_cpp,
   install: false,
-  override_options : ['cython_language=cpp']
+  override_options : ['cython_language=cpp'],
+  cython_args: cython_args,
 )


### PR DESCRIPTION
Takes care of a task in gh-20669, prevents new issues with testing under `pytest-run-parallel` to come in, and may uncover hiccups that are happening with low frequency.

Other changes:
- switch back to `actions/setup-python` now that support for free-threading is merged there
- other cleanups and improvements in the free-threading CI job, including removal of `PYTHON_GIL=0` to ensure all extension modules have actually declared support, and removing `gmpy2` because that isn't used in the job and doesn't have `cp313t` wheels yet
- add free-threading support to test extensions for `cython_blas`, `cython_lapack`, `cython_special`
- remove `rng` fixture that isn't thread-safe (same as in https://github.com/scipy/scipy/pull/22125#discussion_r1894504471)
- mark a number of tests as thread-unsafe (nothing out of the ordinary there)

Cc @andfoy for visibility