### PR TITLE
BUG: optimize: avoid expensive access of `basis.col_status` in `_highs_wrapper`

### DIFF
--- a/scipy/optimize/_highspy/_highs_wrapper.py
+++ b/scipy/optimize/_highspy/_highs_wrapper.py
@@ -264,11 +264,13 @@ def _highs_wrapper(c, indptr, indices, data, lhs, rhs, lb, ub, integrality, opti
 
     # Lagrangians for bounds based on column statuses
     marg_bnds = np.zeros((2, numcol))
+    basis_col_status = basis.col_status
+    solution_col_dual = solution.col_dual
     for ii in range(numcol):
-        if basis.col_status[ii] == _h.HighsBasisStatus.kLower:
-            marg_bnds[0, ii] = solution.col_dual[ii]
-        elif basis.col_status[ii] == _h.HighsBasisStatus.kUpper:
-            marg_bnds[1, ii] = solution.col_dual[ii]
+        if basis_col_status[ii] == _h.HighsBasisStatus.kLower:
+            marg_bnds[0, ii] = solution_col_dual[ii]
+        elif basis_col_status[ii] == _h.HighsBasisStatus.kUpper:
+            marg_bnds[1, ii] = solution_col_dual[ii]
 
     res.update(
         {


### PR DESCRIPTION
#### Reference issue

Issue #22655

#### What does this implement/fix?

Profiling shows that the loop inside `_highs_wrapper()` is very slow.

```
Timer unit: 1e-09 s

Total time: 66.009 s
File: /home/jupyter-njodell/.local/lib/python3.10/site-packages/scipy/optimize/_highspy/_highs_wrapper.py
Function: _highs_wrapper at line 9

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
     9                                           def _highs_wrapper(c, indptr, indices, data, lhs, rhs, lb, ub, integrality, options):

...

   265                                               # Lagrangians for bounds based on column statuses
   266         1      15086.0  15086.0      0.0      marg_bnds = np.zeros((2, numcol))
   267      9091    5026302.0    552.9      0.0      for ii in range(numcol):
   268      9090        4e+10    5e+06     64.1          if basis.col_status[ii] == _h.HighsBasisStatus.kLower:
   269      4505  966209742.0 214475.0      1.5              marg_bnds[0, ii] = solution.col_dual[ii]
   270      4585        2e+10    5e+06     32.3          elif basis.col_status[ii] == _h.HighsBasisStatus.kUpper:
   271                                                       marg_bnds[1, ii] = solution.col_dual[ii]
```

Splitting the line `basis.col_status[ii] == _h.HighsBasisStatus.kLower` line onto multiple lines, the slow part appears to be `basis.col_status`. It appears to create a new list object every time it is accessed, which I believe makes this an O(N^2) loop.

Therefore, hoist it out of the loop. I also did the same thing to `solution.col_dual`. The speedup for that is only 30%, but it is still worth doing.

Benchmark results for the reproducer script from #22655:

Before:

```
$ python3 dev.py python ../foo/bug-22655.py
...
Solved in 86.03856664300838s 
```

After:

```
$ python3 dev.py python ../foo/bug-22655.py 
...
Solved in 1.9350838370010024s
```

#### Additional information

Profiler output, post change:

```
Timer unit: 1e-09 s

Total time: 2.04816 s
File: /home/nodell/scipy/build-install/lib/python3.13/site-packages/scipy/optimize/_highspy/_highs_wrapper.py
Function: _highs_wrapper at line 10

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
...

   267                                               # Lagrangians for bounds based on column statuses
   268         1      26315.0  26315.0      0.0      marg_bnds = np.zeros((2, numcol))
   269         1    4876641.0    5e+06      0.2      basis_col_status = basis.col_status
   270         1     380845.0 380845.0      0.0      solution_col_dual = solution.col_dual
   271      9091   30801192.0   3388.1      1.5      for ii in range(numcol):
   272      9090   56996708.0   6270.3      2.8          if basis_col_status[ii] == _h.HighsBasisStatus.kLower:
   273      4505   31335851.0   6955.8      1.5              marg_bnds[0, ii] = solution_col_dual[ii]
   274      4585   36366063.0   7931.5      1.8          elif basis_col_status[ii] == _h.HighsBasisStatus.kUpper:
   275                                                       marg_bnds[1, ii] = solution_col_dual[ii]
```

(Warning: Absolute timings are not precisely comparable to the line profiler trace from before, as this was run on a different computer.)

It unfortunately still spends 7.6% of its time in this benchmark reading the col_status in the loop. This could potentially be improved by replacing the loop using NumPy vectorization, or a Cython function.

