### PR TITLE
TST: constants: tidy up tests

### DIFF
--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -2,7 +2,6 @@ import pytest
 
 import scipy.constants as sc
 from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
-from numpy.testing import assert_allclose
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
@@ -49,14 +48,12 @@ class TestConvertTemperature:
                                                'rankine', 'kelvin'),
                         xp.asarray([273.15, 0.], dtype=xp.float64), rtol=0., atol=1e-13)
 
-    @skip_xp_backends(np_only=True, reason='Python list input uses NumPy backend')
-    def test_convert_temperature_array_like(self, xp):
-        assert_allclose(sc.convert_temperature([491.67, 0.], 'rankine', 'kelvin'),
+    def test_convert_temperature_array_like(self):
+        xp_assert_close(sc.convert_temperature([491.67, 0.], 'rankine', 'kelvin'),
                         [273.15, 0.], rtol=0., atol=1e-13)
 
 
-    @skip_xp_backends(np_only=True, reason='Python int input uses NumPy backend')
-    def test_convert_temperature_errors(self, xp):
+    def test_convert_temperature_errors(self):
         with pytest.raises(NotImplementedError, match="old_scale="):
             sc.convert_temperature(1, old_scale="cheddar", new_scale="kelvin")
         with pytest.raises(NotImplementedError, match="new_scale="):
@@ -69,10 +66,8 @@ class TestLambdaToNu:
                         xp.asarray([1, sc.speed_of_light]))
 
 
-    @skip_xp_backends(np_only=True, reason='Python list input uses NumPy backend')
-    def test_lambda_to_nu_array_like(self, xp):
-        assert_allclose(sc.lambda2nu([sc.speed_of_light, 1]),
-                        [1, sc.speed_of_light])
+    def test_lambda_to_nu_array_like(self):
+        xp_assert_close(sc.lambda2nu([sc.speed_of_light, 1]), [1, sc.speed_of_light])
 
 
 class TestNuToLambda:
@@ -80,8 +75,5 @@ class TestNuToLambda:
         xp_assert_equal(sc.nu2lambda(xp.asarray([sc.speed_of_light, 1])),
                         xp.asarray([1, sc.speed_of_light]))
 
-    @skip_xp_backends(np_only=True, reason='Python list input uses NumPy backend')
-    def test_nu_to_lambda_array_like(self, xp):
-        assert_allclose(sc.nu2lambda([sc.speed_of_light, 1]),
-                        [1, sc.speed_of_light])
-
+    def test_nu_to_lambda_array_like(self):
+        xp_assert_close(sc.nu2lambda([sc.speed_of_light, 1]), [1, sc.speed_of_light])


### PR DESCRIPTION
Removes unneeded skips by removing `xp` arg to test.