### PR TITLE
MAINT: enforce modularity with `tach`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install ruff cython-lint packaging
+        python -m pip install ruff cython-lint packaging tach
 
     - name: Lint
       run: |
@@ -52,3 +52,7 @@ jobs:
       shell: bash
       run: |
         python tools/check_python_h_first.py 
+
+    - name: Check module interdependencies
+      run: |
+        tach check --exact

--- a/scipy/_lib/meson.build
+++ b/scipy/_lib/meson.build
@@ -120,7 +120,6 @@ python_sources = [
   '_disjoint_set.py',
   '_docscrape.py',
   '_elementwise_iterative_method.py',
-  '_finite_differences.py',
   '_gcutils.py',
   '_pep440.py',
   '_sparse.py',

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -26,7 +26,7 @@ from scipy import optimize
 from scipy import integrate
 
 # to approximate the pdf of a continuous distribution given its cdf
-from scipy._lib._finite_differences import _derivative
+from scipy.stats._finite_differences import _derivative
 
 # for scipy.stats.entropy. Attempts to import just that function or file
 # have cause import problems

--- a/scipy/stats/_finite_differences.py
+++ b/scipy/stats/_finite_differences.py
@@ -1,4 +1,5 @@
 from numpy import arange, newaxis, hstack, prod, array
+from scipy import linalg
 
 
 def _central_diff_weights(Np, ndiv=1):
@@ -54,7 +55,6 @@ def _central_diff_weights(Np, ndiv=1):
         )
     if Np % 2 == 0:
         raise ValueError("The number of points must be odd.")
-    from scipy import linalg
 
     ho = Np >> 1
     x = arange(-ho, ho + 1.0)

--- a/scipy/stats/_ksstats.py
+++ b/scipy/stats/_ksstats.py
@@ -68,7 +68,7 @@
 import numpy as np
 import scipy.special
 import scipy.special._ufuncs as scu
-from scipy._lib._finite_differences import _derivative
+from scipy.stats._finite_differences import _derivative
 
 _E128 = 128
 _EP128 = np.ldexp(np.longdouble(1), _E128)

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -120,6 +120,7 @@ py3.install_sources([
     '_distribution_infrastructure.py',
     '_distr_params.py',
     '_entropy.py',
+    '_finite_differences.py',
     '_fit.py',
     '_hypotests.py',
     '_kde.py',

--- a/tach.toml
+++ b/tach.toml
@@ -28,7 +28,7 @@ depends_on = ["scipy._lib"]
 
 [[modules]]
 path = "scipy._lib"
-depends_on = ["scipy", "scipy.linalg"]
+depends_on = ["scipy"]
 
 [[modules]]
 path = "scipy._lib.cobyqa"

--- a/tach.toml
+++ b/tach.toml
@@ -1,0 +1,218 @@
+interfaces = []
+exclude = [
+    "**/*__pycache__",
+    "**/*egg-info",
+    "**/docs",
+    "**/tests",
+    "**/venv",
+    "benchmarks",
+    "build*",
+    "doc",
+    "dev.py",
+    "subprojects",
+    "tools",
+    "scipy/_build_utils",
+    "scipy/_lib/cobyqa/doc",
+    "scipy/_lib/cobyqa/examples",
+    "scipy/_lib/cobyqa/pyproject.toml",
+    "scipy/conftest.py",
+    "scipy/special/_precompute/*",
+]
+source_roots = [
+    ".",
+]
+
+[[modules]]
+path = "scipy"
+depends_on = ["scipy._lib"]
+
+[[modules]]
+path = "scipy._lib"
+depends_on = ["scipy", "scipy.linalg"]
+
+[[modules]]
+path = "scipy._lib.cobyqa"
+unchecked = true
+
+[[modules]]
+path = "scipy.cluster"
+depends_on = ["scipy.cluster.vq", "scipy.cluster.hierarchy", "scipy._lib"]
+
+[[modules]]
+path = "scipy.cluster.hierarchy"
+depends_on = ["scipy._lib", "scipy.spatial.distance", "scipy.cluster"]
+
+[[modules]]
+path = "scipy.cluster.vq"
+depends_on = ["scipy.cluster", "scipy._lib", "scipy.spatial.distance"]
+
+[[modules]]
+path = "scipy.constants"
+depends_on = ["scipy._lib"]
+
+[[modules]]
+path = "scipy.datasets"
+depends_on = ["scipy._lib"]
+
+[[modules]]
+path = "scipy.differentiate"
+depends_on = ["scipy._lib"]
+
+[[modules]]
+path = "scipy.fft"
+depends_on = ["scipy.special", "scipy._lib"]
+
+[[modules]]
+path = "scipy.fftpack"
+depends_on = ["scipy._lib", "scipy.fft"]
+
+[[modules]]
+path = "scipy.integrate"
+depends_on = ["scipy._lib", "scipy.interpolate", "scipy.sparse", "scipy.stats", "scipy.sparse.linalg", "scipy.special", "scipy.linalg", "scipy.optimize"]
+
+[[modules]]
+path = "scipy.interpolate"
+depends_on = ["scipy._lib", "scipy.special", "scipy.spatial.distance", "scipy.linalg", "scipy.optimize", "scipy.spatial", "scipy.linalg.lapack", "scipy.sparse.linalg", "scipy.sparse", "scipy"]
+
+[[modules]]
+path = "scipy.io"
+depends_on = ["scipy.sparse", "scipy.io.wavfile", "scipy.io.arff", "scipy.io.matlab", "scipy._lib"]
+
+[[modules]]
+path = "scipy.io.arff"
+depends_on = ["scipy._lib"]
+
+[[modules]]
+path = "scipy.io.matlab"
+depends_on = ["scipy.sparse", "scipy._lib"]
+
+[[modules]]
+path = "scipy.io.wavfile"
+depends_on = []
+
+[[modules]]
+path = "scipy.linalg"
+depends_on = ["scipy._lib", "scipy.sparse", "scipy.special", "scipy.sparse.linalg", "scipy.linalg.blas", "scipy.linalg.lapack", "scipy.fft"]
+
+[[modules]]
+path = "scipy.linalg.blas"
+depends_on = ["scipy.linalg"]
+
+[[modules]]
+path = "scipy.linalg.interpolative"
+depends_on = ["scipy.linalg", "scipy.sparse.linalg"]
+
+[[modules]]
+path = "scipy.linalg.lapack"
+depends_on = ["scipy.linalg", "scipy.linalg.blas"]
+
+[[modules]]
+path = "scipy.misc"
+depends_on = []
+
+[[modules]]
+path = "scipy.ndimage"
+depends_on = ["scipy.special", "scipy._lib"]
+
+[[modules]]
+path = "scipy.odr"
+depends_on = ["scipy.linalg", "scipy._lib"]
+
+[[modules]]
+path = "scipy.optimize"
+depends_on = ["scipy.linalg", "scipy.spatial", "scipy._lib", "scipy.sparse", "scipy.sparse.linalg", "scipy.stats.qmc", "scipy.linalg.blas", "scipy.special", "scipy.linalg.interpolative", "scipy"]
+
+[[modules]]
+path = "scipy.signal"
+depends_on = ["scipy.interpolate", "scipy.fft", "scipy.signal.windows", "scipy.ndimage", "scipy.special", "scipy.optimize", "scipy._lib", "scipy.stats", "scipy.spatial", "scipy.linalg"]
+
+[[modules]]
+path = "scipy.signal.windows"
+depends_on = ["scipy.linalg", "scipy.special", "scipy._lib", "scipy.fft"]
+
+[[modules]]
+path = "scipy.sparse"
+depends_on = ["scipy", "scipy._lib", "scipy.sparse.csgraph", "scipy.sparse.linalg"]
+
+[[modules]]
+path = "scipy.sparse.csgraph"
+depends_on = ["scipy._lib", "scipy.sparse", "scipy.sparse.linalg"]
+
+[[modules]]
+path = "scipy.sparse.linalg"
+depends_on = ["scipy._lib", "scipy.linalg", "scipy.sparse"]
+
+[[modules]]
+path = "scipy.spatial"
+depends_on = ["scipy._lib", "scipy.linalg", "scipy.spatial.transform", "scipy", "scipy.spatial.distance"]
+
+[[modules]]
+path = "scipy.spatial.distance"
+depends_on = ["scipy.spatial", "scipy._lib", "scipy.linalg", "scipy.special"]
+
+[[modules]]
+path = "scipy.spatial.transform"
+depends_on = ["scipy.constants", "scipy.linalg", "scipy._lib", "scipy.interpolate"]
+
+[[modules]]
+path = "scipy.special"
+depends_on = ["scipy.optimize", "scipy.linalg", "scipy._lib"]
+
+[[modules]]
+path = "scipy.stats"
+depends_on = [
+    "scipy.linalg.blas",
+    "scipy.stats.distributions",
+    "scipy.fft",
+    "scipy.spatial.distance",
+    "scipy.stats.contingency",
+    "scipy.special",
+    "scipy._lib",
+    "scipy.sparse.csgraph",
+    "scipy.spatial",
+    "scipy.linalg",
+    "scipy.stats.qmc",
+    "scipy.integrate",
+    "scipy.optimize",
+    "scipy.stats.mstats",
+    "scipy.ndimage",
+    "scipy.interpolate",
+    "scipy.sparse",
+]
+
+[[modules]]
+path = "scipy.stats.contingency"
+depends_on = ["scipy.stats", "scipy._lib"]
+
+[[modules]]
+path = "scipy.stats.distributions"
+depends_on = ["scipy.stats"]
+
+[[modules]]
+path = "scipy.stats.mstats"
+depends_on = ["scipy.stats"]
+
+[[modules]]
+path = "scipy.stats.qmc"
+depends_on = ["scipy.stats"]
+
+[[modules]]
+path = "scipy.stats.sampling"
+depends_on = ["scipy.stats"]
+
+
+# Optional dependencies don't seem to be handled by tach yet
+[external]
+exclude = [
+    "array-api-compat",
+    "array-api-extra",
+    "cupy",
+    "cupyx",
+    "dask",
+    "jax",
+    "matplotlib",
+    "ndonnx",
+    "sparse",
+    "torch",
+    "uarray",
+]


### PR DESCRIPTION
Related to discussion in gh-22382, the bulk of the work here in setting up the initial `tach` config was done by @rgommers there.

This PR follows from a conversation on the Scientific Python Discord @mdhaber. Ideally we can enforce this in CI to stop new dependencies between submodules from being created accidentally.

Here we remove the dependency of `_lib` on `linalg`.