### PR TITLE
ENH: stats: Improvements to support/domain endpoints in custom distributions in new infrastructure

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3631,12 +3631,10 @@ def make_distribution(dist):
     ...     @property
     ...     def support(self):
     ...         def left(*, a, b):
-    ...             a = np.asarray(a)
-    ...             return (a**3)[()]
+    ...             return a**3
     ...
     ...         def right(*, a, b):
-    ...             b = np.asarray(b)
-    ...             return (b**3)[()]
+    ...             return b**3
     ...         return (left, right)
     ...
     ...     def pdf(self, x, *, a, b):

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3618,57 +3618,38 @@ def make_distribution(dist):
 
     Create a custom distribution with variable support.
 
-    >>> class MyGenExtreme:
+    >>> class MyUniformCube:
     ...     @property
     ...     def __make_distribution_version__(self):
     ...         return "1.16.0"
     ...
     ...     @property
     ...     def parameters(self):
-    ...         return {"c": {}, "mu": {}, "sigma": (0, np.inf)}
+    ...         return {"a": (-np.inf, np.inf), "b": (-np.inf, np.inf)}
     ...
     ...     @property
     ...     def support(self):
-    ...         def left(*, c, mu, sigma):
-    ...             c, mu, sigma = np.broadcast_arrays(c, mu, sigma)
-    ...             result = np.empty_like(c)
-    ...             result[c >= 0] = -np.inf
-    ...             result[c < 0] = mu[c < 0] + sigma[c < 0] / c[c < 0]
-    ...             return result[()]
+    ...         def left(*, a, b):
+    ...             a = np.asarray(a)
+    ...             return (a**3)[()]
     ...
-    ...         def right(*, c, mu, sigma):
-    ...             c, mu, sigma = np.broadcast_arrays(c, mu, sigma)
-    ...             result = np.empty_like(c)
-    ...             result[c <= 0] = np.inf
-    ...             result[c > 0] = mu[c > 0] + sigma[c > 0] / c[c > 0]
-    ...             return result[()]
+    ...         def right(*, a, b):
+    ...             b = np.asarray(b)
+    ...             return (b**3)[()]
+    ...         return (left, right)
     ...
-    ...     def pdf(self, x, *, c, mu, sigma):
-    ...         x, c, mu, sigma = np.broadcast_arrays(x, c, mu, sigma)
-    ...         t = np.empty_like(x)
-    ...         mask = (c == 0)
-    ...         t[mask] = np.exp(-(x[mask] - mu[mask])/sigma[mask])
-    ...         t[~mask] = (
-    ...             1  - c[~mask]*(x[~mask] - mu[~mask])/sigma[~mask]
-    ...         )**(1/c[~mask])
-    ...         return np.exp(-t)[()]
+    ...     def pdf(self, x, *, a, b):
+    ...         return 1 / (3*(b - a)*np.cbrt(x)**2)
     ...
-    ...     def cdf(self, x, *, c, mu, sigma):
-    ...         x, c, mu, sigma = np.broadcast_arrays(x, c, mu, sigma)
-    ...         t = np.empty_like(x)
-    ...         mask = (c == 0)
-    ...         t[mask] = np.exp(-(x[mask] - mu[mask])/sigma[mask])
-    ...         t[~mask] = (
-    ...             1  - c[~mask]*(x[~mask] - mu[~mask])/sigma[~mask]
-    ...         )**(1/c[~mask])
-    ...         return np.exp(-t)[()]
+    ...     def cdf(self, x, *, a, b):
+    ...         return (np.cbrt(x) - a) / (b - a)
     >>>
-    >>> MyGenExtreme = stats.make_distribution(MyGenExtreme())
-    >>> Y = MyGenExtreme(c=1, mu=0, sigma=1)
-
-    >>> GenExtreme = stats.make_distribution(stats.genextreme)
-    >>> X = GenExtreme(c=1)
-    >>> np.isclose(Y.cdf(0.1), X.cdf(0.1))
+    >>> MyUniformCube = stats.make_distribution(MyUniformCube())
+    >>> X = MyUniformCube(a=-2, b=2)
+    >>> Y = stats.Uniform(a=-2, b=-2)**3
+    >>> X.support()
+    (-8.0, 8.0)
+    >>> np.isclose(X.cdf(2.1), Y.cdf(2.1))
     np.True_
 
     """

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3810,7 +3810,7 @@ def _make_distribution_rv_generic(dist):
 
 def _get_domain_info(info):
     domain_info = {"endpoints": info} if isinstance(info, tuple) else info
-    typical = info.pop("typical", None)
+    typical = domain_info.pop("typical", None)
     return domain_info, typical
 
 

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3809,22 +3809,22 @@ def _make_distribution_rv_generic(dist):
 
 
 def _get_domain_info(info):
-    support_info = {"endpoints": info} if isinstance(info, tuple) else info
+    domain_info = {"endpoints": info} if isinstance(info, tuple) else info
     typical = info.pop("typical", None)
-    return support_info, typical
+    return domain_info, typical
 
 
 def _make_distribution_custom(dist):
     parameters = []
 
     for name, info in dist.parameters.items():
-        support_info, typical = _get_domain_info(info)
-        domain = _RealDomain(**support_info)
+        domain_info, typical = _get_domain_info(info)
+        domain = _RealDomain(**domain_info)
         param = _RealParameter(name, domain=domain, typical=typical)
         parameters.append(param)
 
-    support_info, _ = _get_domain_info(dist.support)
-    _x_support = _RealDomain(**support_info)
+    domain_info, _ = _get_domain_info(dist.support)
+    _x_support = _RealDomain(**domain_info)
     _x_param = _RealParameter('x', domain=_x_support)
     repr_str = dist.__class__.__name__
 

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3646,7 +3646,7 @@ def make_distribution(dist):
     >>>
     >>> MyUniformCube = stats.make_distribution(MyUniformCube())
     >>> X = MyUniformCube(a=-2, b=2)
-    >>> Y = stats.Uniform(a=-2, b=-2)**3
+    >>> Y = stats.Uniform(a=-2, b=2)**3
     >>> X.support()
     (-8.0, 8.0)
     >>> np.isclose(X.cdf(2.1), Y.cdf(2.1))

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3513,27 +3513,26 @@ def make_distribution(dist):
         parameters : dict
             Each key is the name of a parameter,
             and the corresponding value is either a dictionary or tuple.
-            If a dictionary, it may have the following items.
+            If a dictionary, it may have the following items, with default
+            values used for entries which aren't present.
 
-            endpoints : tuple
+            endpoints : tuple, default: (-inf, inf)
                 A tuple defining the lower and upper endpoints of the domain of the
                 parameter; allowable values are floats, the name (string) of another
                 parameter, or a callable taking parameters as keyword only
                 arguments and returning the numerical value of an endpoint for
                 given parameter values.
 
-            inclusive : tuple of bool
+            inclusive : tuple of bool, default: (False, False)
                 A tuple specifying whether the endpoints are included within the domain
                 of the parameter.
 
-            typical : tuple
+            typical : tuple, default: ``endpoints``
                 Defining endpoints of a typical range of values of a parameter. Can be
                 used for sampling parameter values for testing. Behaves like the
                 ``endpoints`` tuple above, and should define a subinterval of the
                 domain given by ``endpoints``.
 
-            Missing keys in inner dictionaries will receive default values,
-            ``endpoints=(-inf, inf)`` and ``inclusive=(False, False)``.
             A ``tuple`` value ``(a, b)`` is equivalent to ``{endpoints: (a, b)}``.
 
         support : dict or tuple

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3625,7 +3625,8 @@ def make_distribution(dist):
     ...
     ...     @property
     ...     def parameters(self):
-    ...         return {"a": (-np.inf, np.inf), "b": (-np.inf, np.inf)}
+    ...         return {"a": (-np.inf, np.inf), 
+    ...                 "b": {'endpoints':('a', np.inf), 'inclusive':(True, False)}}
     ...
     ...     @property
     ...     def support(self):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -100,9 +100,9 @@ class Test_RealDomain:
         assert numerical_endpoints == domain.get_numerical_endpoints(dict(a=a, b=b))
         alpha, beta = numerical_endpoints
 
-        left_comparison = '<=' if inclusive[0] else '<'
-        right_comparison = '<=' if inclusive[1] else '<'
-        ref = eval(f'(alpha {left_comparison} x) & (x {right_comparison} beta)')
+        above_left = alpha <= x if inclusive[0] else alpha < x
+        below_right = x <= beta if inclusive[1] else x < beta
+        ref = above_left & below_right
         assert_equal(res, ref)
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This is a follow-up to #22560.

#### What does this implement/fix?
<!--Please explain your changes.-->
In https://github.com/scipy/scipy/pull/22560#issuecomment-2676153771, @mdhaber gave a list of useful follow-ups to #22560, which was a PR for allowing variable support in custom distributions in the new infrastructure. The list is:

> * example in documentation
> 
> * tests of some of the new `_SimpleDomain` behavior
> 
> * ~default values of `endpoints` and `inclusive`~ ah, looks like `inclusive`, at least, already has a default. In this case, we _could_ consider allowing `support` to just return a tuple, and that is assumed to be the `endpoints` tuple. In fact, the same goes for the parameters dictionary: the value for each parameter could be a tuple instead of the full-blown dictionary. To add a little more value to the full-blown dictionary, it could also accept the `typical` attribute of a `_RealParameter`. Then basically what we've done is created a simpler interface to the object oriented zoo of domain, parameter, and parameterization classes. I think that's good because while they are useful abstractions for the distribution infrastructure, developers creating actual distributions don't really need their methods. I'm thinking this interface might be how distributions are defined in `scikit-stats`.
> 
> * `parameters` could be allowed to return a tuple of dictionaries like the one it returns now. Each would simply become a separate `_Parameterization`. That would be very easy, but it would also require a way to specify the `_process_parameters` method. Actually, that is probably quite easy, too, it's just something I haven't looked at for a long time, so it is a little unfamiliar now.

This PR completes all but the final bullet point above. An example with variable support has been to the `make_distribution` docstring.  A new test has been added for `_RealDomain` using functions for the domain endpoints. In `make_distribution`, parameters dictionaries can now have tuples as values instead of just inner dictionaries, where a tuple `(a, b)` is equivalent to the value `{'endpoints': (a, b)}`. Any key missing from the inner dictionary is assigned the default value. Inner dictionaries can now also have `typical` as a key which is passed to `_RealParameter`. The `support` dictionary in `make_distribution` has been given similar behavior, with the only exception being that the `typical` entry would be ignored.

I've documented all of this new behavior.

I'm leaving allowing multiple parameterizations in custom distributions by passing a tuple of dictionaries of dictionaries or tuples for a follow-up to keep too many things from creeping into this PR. I agree with @mdhaber that it shouldn't be too hard to implement though.


#### Additional information
<!--Any additional information you think is important.-->
