### PR TITLE
ENH: stats.mode: vectorize implementation

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -579,6 +579,11 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=False):
         NaN = _get_nan(a)
         return ModeResult(*np.array([NaN, 0], dtype=NaN.dtype))
 
+    if a.ndim == 1:
+        vals, cnts = np.unique(a, return_counts=True)
+        modes, counts = vals[cnts.argmax()], cnts.max()
+        return ModeResult(modes[()], counts[()])
+
     # `axis` is always -1 after the `_axis_nan_policy` decorator
     y = np.sort(a, axis=-1)
     # Get boolean array of elements that are different from the previous element


### PR DESCRIPTION
#### Reference issue
Toward gh-14651, gh-20544 
Together with the new `vectorized_filter` (gh-22575), this makes gh-9873 much easier.

#### What does this implement/fix?
`scipy.stats.mode` natively works only with 1-D slices; the `_axis_nan_policy` decorator loops over slices to add `axis` support. This PR replaces the implementation with one that is natively vectorized.

#### Additional information
The upside is ~90x speed improvement in cases where we have many short slices; the downside is 2x slowdown when we have a few long slices.

```python3
import numpy as np
from scipy import stats

rng = np.random.default_rng(23458924958234563)

# times are:
# main
# PR

x = rng.integers(0, 10, size=1_000_000)
# %timeit stats.mode(x)
# 5.53 ms ± 208 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# 11.6 ms ± 137 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

y = x.reshape(100, 10000)
# %timeit stats.mode(y, axis=-1)
# 8.61 ms ± 24 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
# 16 ms ± 1.54 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)

y = x.reshape(10000, 100)
# %timeit stats.mode(y, axis=-1)
# 333 ms ± 3.34 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# 18.6 ms ± 164 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

y = x.reshape(100000, 10)
# %timeit stats.mode(y, axis=-1)
# 3.33 s ± 38.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
# 36.8 ms ± 320 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

It would be simple to use the old implementation when the input is 1-D.
As an enhancement, we could also add a heuristic to loop when looping is expected to be faster.