### PR TITLE
MAINT: use function handles rather than custom strings in `xp_capabilities_table`

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -734,8 +734,7 @@ def xp_capabilities(capabilities_table=None, **kwargs):
         def wrapper(*args, **kwargs):
             return f(*args, **kwargs)
 
-        if wrapper not in capabilities_table:
-            capabilities_table[wrapper] = kwargs
+        capabilities_table[wrapper] = kwargs
         capabilities = _make_capabilities(**capabilities_table[wrapper])
 
         note = _make_capabilities_note(f.__name__, capabilities)
@@ -755,21 +754,21 @@ def make_skip_xp_backends(*funs, capabilities_table=None):
 
     skip_backends = []
     cpu_only = False
-    cpu_only_reason = ""
+    cpu_only_reason = set()
     np_only = False
     exceptions = []
 
     for fun in funs:
         skip_backends += capabilities_table[fun].get('skip_backends', [])
         cpu_only |= capabilities_table[fun].get('cpu_only', False)
-        cpu_only_reason += capabilities_table[fun].get('reason', "")
+        cpu_only_reason.add(capabilities_table[fun].get('reason', ""))
         np_only |= capabilities_table[fun].get('np_only', False)
         exceptions += capabilities_table[fun].get('exceptions', [])
 
     decorators = []
     if cpu_only:
         kwargs = dict(cpu_only=True, exceptions=exceptions)
-        kwargs |= {'reason': cpu_only_reason}
+        kwargs |= {'reason': "\n".join(cpu_only_reason)}
         decorators.append(pytest.mark.skip_xp_backends(**kwargs))
 
     if np_only:

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -717,7 +717,8 @@ def make_skip_xp_backends(*funs, capabilities_table=None):
     for fun in funs:
         skip_backends += capabilities_table[fun].get('skip_backends', [])
         cpu_only |= capabilities_table[fun].get('cpu_only', False)
-        cpu_only_reason.add(capabilities_table[fun].get('reason', ""))
+        # Empty reason causes the decorator to have no effect
+        cpu_only_reason.add(capabilities_table[fun].get('reason', "No reason given."))
         np_only |= capabilities_table[fun].get('np_only', False)
         exceptions += capabilities_table[fun].get('exceptions', [])
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -693,7 +693,7 @@ def _make_capabilities_table(capabilities):
             val += " " * (len('{numpy.}') + len(attr) - 1)
             setattr(backend, attr, val)
 
-    table = f"""                
+    table = f"""
     +---------+-------------+-------------+
     | Library | CPU         | GPU         |
     +=========+=============+=============+
@@ -725,22 +725,20 @@ def _make_capabilities_note(fun_name, capabilities):
     return textwrap.dedent(note)
 
 
-def xp_capabilities(name=None, capabilities_table=None, **kwargs):
+def xp_capabilities(capabilities_table=None, **kwargs):
     capabilities_table = (xp_capabilities_table if capabilities_table is None
                           else capabilities_table)
 
     def decorator(f):
-        fun_name = f.__name__
-        table_entry = name or fun_name
-        if table_entry not in capabilities_table:
-            capabilities_table[table_entry] = kwargs
-        capabilities = _make_capabilities(**capabilities_table[table_entry])
-
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
             return f(*args, **kwargs)
 
-        note = _make_capabilities_note(fun_name, capabilities)
+        if wrapper not in capabilities_table:
+            capabilities_table[wrapper] = kwargs
+        capabilities = _make_capabilities(**capabilities_table[wrapper])
+
+        note = _make_capabilities_note(f.__name__, capabilities)
         doc = FunctionDoc(wrapper)
         doc['Notes'].append(note)
         wrapper.__doc__ = str(doc).split("\n", 1)[1]  # remove signature
@@ -749,23 +747,29 @@ def xp_capabilities(name=None, capabilities_table=None, **kwargs):
     return decorator
 
 
-def make_skip_xp_backends(fun_name, capabilities_table=None):
+def make_skip_xp_backends(*funs, capabilities_table=None):
     capabilities_table = (xp_capabilities_table if capabilities_table is None
                           else capabilities_table)
 
     import pytest
 
-    skip_backends = capabilities_table[fun_name].get('skip_backends', [])
-    cpu_only = capabilities_table[fun_name].get('cpu_only', None)
-    np_only = capabilities_table[fun_name].get('np_only', None)
-    exceptions = capabilities_table[fun_name].get('exceptions', None)
-    reason = capabilities_table[fun_name].get('reason', None)
+    skip_backends = []
+    cpu_only = False
+    cpu_only_reason = ""
+    np_only = False
+    exceptions = []
+
+    for fun in funs:
+        skip_backends += capabilities_table[fun].get('skip_backends', [])
+        cpu_only |= capabilities_table[fun].get('cpu_only', False)
+        cpu_only_reason += capabilities_table[fun].get('reason', "")
+        np_only |= capabilities_table[fun].get('np_only', False)
+        exceptions += capabilities_table[fun].get('exceptions', [])
 
     decorators = []
     if cpu_only:
         kwargs = dict(cpu_only=True, exceptions=exceptions)
-        # if we pass `reason=None`, it doesn't work
-        kwargs |= {'reason': reason} if reason is not None else {}
+        kwargs |= {'reason': cpu_only_reason}
         decorators.append(pytest.mark.skip_xp_backends(**kwargs))
 
     if np_only:

--- a/scipy/constants/tests/test_constants.py
+++ b/scipy/constants/tests/test_constants.py
@@ -7,7 +7,7 @@ from scipy._lib._array_api import make_skip_xp_backends
 skip_xp_backends = pytest.mark.skip_xp_backends
 
 
-@make_skip_xp_backends("convert_temperature")
+@make_skip_xp_backends(sc.convert_temperature)
 class TestConvertTemperature:
     def test_convert_temperature(self, xp):
         xp_assert_equal(sc.convert_temperature(xp.asarray(32.), 'f', 'Celsius'),
@@ -62,7 +62,7 @@ class TestConvertTemperature:
             sc.convert_temperature(1, old_scale="kelvin", new_scale="brie")
 
 
-@make_skip_xp_backends("lambda2nu")
+@make_skip_xp_backends(sc.lambda2nu)
 class TestLambdaToNu:
     def test_lambda_to_nu(self, xp):
         xp_assert_equal(sc.lambda2nu(xp.asarray([sc.speed_of_light, 1])),
@@ -73,7 +73,7 @@ class TestLambdaToNu:
         xp_assert_close(sc.lambda2nu([sc.speed_of_light, 1]), [1, sc.speed_of_light])
 
 
-@make_skip_xp_backends("nu2lambda")
+@make_skip_xp_backends(sc.nu2lambda)
 class TestNuToLambda:
     def test_nu_to_lambda(self, xp):
         xp_assert_equal(sc.nu2lambda(xp.asarray([sc.speed_of_light, 1])),

--- a/scipy/optimize/tests/test_chandrupatla.py
+++ b/scipy/optimize/tests/test_chandrupatla.py
@@ -550,8 +550,6 @@ class TestChandrupatlaMinimize:
                               reason='Currently uses fancy indexing assignment.')
 @pytest.mark.skip_xp_backends('jax.numpy',
                               reason='JAX arrays do not support item assignment.')
-@pytest.mark.skip_xp_backends('cupy',
-                              reason='cupy/cupy#8391')
 class TestFindRoot:
 
     def f(self, q, p):

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -2456,20 +2456,20 @@ def test_powell_output():
 
 
 class TestRosen:
-    @make_skip_xp_backends("rosen")
+    @make_skip_xp_backends(optimize.rosen)
     def test_rosen(self, xp):
         # integer input should be promoted to the default floating type
         x = xp.asarray([1, 1, 1])
         xp_assert_equal(optimize.rosen(x),
                         xp.asarray(0.))
 
-    @make_skip_xp_backends("rosen_der")
+    @make_skip_xp_backends(optimize.rosen_der)
     def test_rosen_der(self, xp):
         x = xp.asarray([1, 1, 1, 1])
         xp_assert_equal(optimize.rosen_der(x),
                         xp.zeros_like(x, dtype=xp.asarray(1.).dtype))
 
-    @make_skip_xp_backends("rosen_hess_prod")
+    @make_skip_xp_backends(optimize.rosen_hess, optimize.rosen_hess_prod)
     def test_hess_prod(self, xp):
         one = xp.asarray(1.)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -621,7 +621,7 @@ def _put_val_to_limits(a, limits, inclusive, val=np.nan, xp=None):
     return a, mask
 
 
-@xp_capabilities("trimmed statistics", skip_backends=[
+@xp_capabilities(skip_backends=[
     ('jax', "JAX doesn't allow item assignment."),
     ("dask", "lazywhere doesn't work with dask"),
 ])
@@ -680,7 +680,10 @@ def tmean(a, limits=None, inclusive=(True, True), axis=None):
     return mean[()] if mean.ndim == 0 else mean
 
 
-@xp_capabilities("trimmed statistics")
+@xp_capabilities(skip_backends=[
+    ('jax', "JAX doesn't allow item assignment."),
+    ("dask", "lazywhere doesn't work with dask"),
+])
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
 )
@@ -740,7 +743,10 @@ def tvar(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
         return _xp_var(a, correction=ddof, axis=axis, nan_policy='omit', xp=xp)
 
 
-@xp_capabilities("trimmed statistics")
+@xp_capabilities(skip_backends=[
+    ('jax', "JAX doesn't allow item assignment."),
+    ("dask", "lazywhere doesn't work with dask"),
+])
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
 )
@@ -800,7 +806,10 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
     return res[()] if res.ndim == 0 else res
 
 
-@xp_capabilities("trimmed statistics")
+@xp_capabilities(skip_backends=[
+    ('jax', "JAX doesn't allow item assignment."),
+    ("dask", "lazywhere doesn't work with dask"),
+])
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
 )
@@ -859,7 +868,10 @@ def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
     return res[()] if res.ndim == 0 else res
 
 
-@xp_capabilities("trimmed statistics")
+@xp_capabilities(skip_backends=[
+    ('jax', "JAX doesn't allow item assignment."),
+    ("dask", "lazywhere doesn't work with dask"),
+])
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
 )
@@ -912,7 +924,10 @@ def tstd(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     return tvar(a, limits, inclusive, axis, ddof, _no_deco=True)**0.5
 
 
-@xp_capabilities("trimmed statistics")
+@xp_capabilities(skip_backends=[
+    ('jax', "JAX doesn't allow item assignment."),
+    ("dask", "lazywhere doesn't work with dask"),
+])
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
 )
@@ -2673,7 +2688,7 @@ def _isconst(x):
         return (y[0] == y).all(keepdims=True)
 
 
-@xp_capabilities('zmap_zscore', skip_backends=[
+@xp_capabilities(skip_backends=[
     ("dask", "lazywhere doesn't work for dask.array"),
     ("jax", "JAX can't do item assignment")])
 def zscore(a, axis=0, ddof=0, nan_policy='propagate'):
@@ -2761,7 +2776,9 @@ def zscore(a, axis=0, ddof=0, nan_policy='propagate'):
     return zmap(a, a, axis=axis, ddof=ddof, nan_policy=nan_policy)
 
 
-@xp_capabilities('zmap_zscore')
+@xp_capabilities(skip_backends=[
+    ("dask", "lazywhere doesn't work for dask.array"),
+    ("jax", "JAX can't do item assignment")])
 def gzscore(a, *, axis=0, ddof=0, nan_policy='propagate'):
     """
     Compute the geometric standard score.
@@ -2856,7 +2873,9 @@ def gzscore(a, *, axis=0, ddof=0, nan_policy='propagate'):
     return zscore(log(a), axis=axis, ddof=ddof, nan_policy=nan_policy)
 
 
-@xp_capabilities('zmap_zscore')
+@xp_capabilities(skip_backends=[
+    ("dask", "lazywhere doesn't work for dask.array"),
+    ("jax", "JAX can't do item assignment")])
 def zmap(scores, compare, axis=0, ddof=0, nan_policy='propagate'):
     """
     Calculate the relative z-scores.
@@ -6031,7 +6050,7 @@ def unpack_TtestResult(res):
             res._standard_error, res._estimate)
 
 
-@xp_capabilities('ttests', cpu_only=True, exceptions=["cupy", "jax.numpy"])
+@xp_capabilities(cpu_only=True, exceptions=["cupy", "jax.numpy"])
 @_axis_nan_policy_factory(pack_TtestResult, default_axis=0, n_samples=2,
                           result_to_tuple=unpack_TtestResult, n_outputs=6)
 # nan_policy handled by `_axis_nan_policy`, but needs to be left
@@ -6321,7 +6340,7 @@ def _equal_var_ttest_denom(v1, n1, v2, n2, xp=None):
 Ttest_indResult = namedtuple('Ttest_indResult', ('statistic', 'pvalue'))
 
 
-@xp_capabilities('ttests')
+@xp_capabilities(cpu_only=True, exceptions=["cupy", "jax.numpy"])
 def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
                          equal_var=True, alternative="two-sided"):
     r"""
@@ -6467,7 +6486,7 @@ def ttest_ind_from_stats(mean1, std1, nobs1, mean2, std2, nobs2,
 _ttest_ind_dep_msg = "Use ``method`` to perform a permutation test."
 
 
-@xp_capabilities('ttests')
+@xp_capabilities(cpu_only=True, exceptions=["cupy", "jax.numpy"])
 @_deprecate_positional_args(version='1.17.0',
                             deprecated_args={'permutations', 'random_state'},
                             custom_message=_ttest_ind_dep_msg)
@@ -7433,7 +7452,7 @@ def _power_divergence(f_obs, f_exp, ddof, axis, lambda_, sum_check=True):
 
 
 
-@xp_capabilities('power_divergence')
+@xp_capabilities()
 @_axis_nan_policy_factory(Power_divergenceResult, paired=True, n_samples=_pd_nsamples,
                           too_small=-1)
 def chisquare(f_obs, f_exp=None, ddof=0, axis=0, *, sum_check=True):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2744,7 +2744,6 @@ class TestCircFuncs:
         x = xp.asarray([355, 5, 2, 359, 10, 350, np.nan])
         xp_assert_equal(test_func(x, high=360), xp.asarray(xp.nan))
 
-    @skip_xp_backends('cupy', reason='cupy/cupy#8391')
     @pytest.mark.parametrize("test_func,expected",
                              [(stats.circmean,
                                {None: np.nan, 0: 355.66582264, 1: 0.28725053}),

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3643,7 +3643,8 @@ class SkewKurtosisTest:
 
 @make_skip_xp_backends(stats.skew)
 class TestSkew(SkewKurtosisTest):
-    stat_fun = stats.skew
+    def stat_fun(self, x):
+        return stats.skew(x)
 
     @pytest.mark.filterwarnings(
         "ignore:invalid value encountered in scalar divide:RuntimeWarning:dask"
@@ -3740,7 +3741,8 @@ class TestSkew(SkewKurtosisTest):
 
 @make_skip_xp_backends(stats.kurtosis)
 class TestKurtosis(SkewKurtosisTest):
-    stat_fun = stats.kurtosis
+    def stat_fun(self, x):
+        return stats.kurtosis(x)
 
     @pytest.mark.filterwarnings("ignore:invalid value encountered in scalar divide")
     def test_kurtosis(self, xp):


### PR DESCRIPTION
Follow up to #22609

Originally in #22609 the keys in `xp_capabilities_table` are a custom string of the developers choosing. Subsequently we have discussed a few reasons why we might want to standardise this:

> My personal opinion is that each function should have its own entry (ideally key being either `"module.function"` or the function handle itself), for the following reason:
>- Once Array API support is not experimental we may want to expose the compatibility data to users
>- It would allow for per module compatibility tables or lists
>- Sharing keys may lead to unintended changes; in comparison having individual entries doesn't seem like that much more effort

https://github.com/scipy/scipy/pull/22668#issuecomment-2715427331

This PR changes the key from being a custom string to a reference to the function. This should also help prevent the keys from becoming a jumble of different naming conventions and prevent collisions.