### PR TITLE
DOC: optimize.root: include default values for method args

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -199,31 +199,31 @@ def _root_hybr(func, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, default: 0
         Specify whether the Jacobian function computes derivatives down
         the columns (faster, because there is no transpose operation).
-    xtol : float
+    xtol : float, default: 1.49012e-08
         The calculation will terminate if the relative error between two
         consecutive iterates is at most `xtol`.
-    maxfev : int
+    maxfev : int, default: 0
         The maximum number of calls to the function. If zero, then
         ``100*(N+1)`` is the maximum where N is the number of elements
         in `x0`.
-    band : tuple
+    band : tuple, default: None
         If set to a two-sequence containing the number of sub- and
         super-diagonals within the band of the Jacobi matrix, the
         Jacobi matrix is considered banded (only for ``jac=None``).
-    eps : float
+    eps : float, default: None
         A suitable step length for the forward-difference
         approximation of the Jacobian (for ``jac=None``). If
         `eps` is less than the machine precision, it is assumed
         that the relative errors in the functions are of the order of
         the machine precision.
-    factor : float
+    factor : float, default: 100
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in the interval
         ``(0.1, 100)``.
-    diag : sequence
+    diag : sequence, default: None
         N positive entries that serve as a scale factors for the
         variables.
 

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -285,28 +285,28 @@ def _root_leastsq(fun, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, default: 0
         non-zero to specify that the Jacobian function computes derivatives
         down the columns (faster, because there is no transpose operation).
-    ftol : float
+    ftol : float, default: 1.49012e-08
         Relative error desired in the sum of squares.
-    xtol : float
+    xtol : float, default: 1.49012e-08
         Relative error desired in the approximate solution.
-    gtol : float
+    gtol : float, default: 0.0
         Orthogonality desired between the function vector and the columns
         of the Jacobian.
-    maxiter : int
+    maxiter : int, default: 0
         The maximum number of calls to the function. If zero, then
         100*(N+1) is the maximum where N is the number of elements in x0.
-    eps : float
+    eps : float, default: 0.0
         A suitable step length for the forward-difference approximation of
         the Jacobian (for Dfun=None). If `eps` is less than the machine
         precision, it is assumed that the relative errors in the functions
         are of the order of the machine precision.
-    factor : float
+    factor : float, default: 100
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in interval ``(0.1, 100)``.
-    diag : sequence
+    diag : sequence, default: None
         N positive entries that serve as a scale factors for the variables.
     """
     nfev = 0

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -20,33 +20,33 @@ def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
 
     Options
     -------
-    ftol : float, optional
+    ftol : float, optional, default: 1e-8
         Relative norm tolerance.
-    fatol : float, optional
+    fatol : float, optional, default: 1e-300
         Absolute norm tolerance.
         Algorithm terminates when ``||func(x)|| < fatol + ftol ||func(x_0)||``.
-    fnorm : callable, optional
+    fnorm : callable, optional, default: None
         Norm to use in the convergence check. If None, 2-norm is used.
-    maxfev : int, optional
+    maxfev : int, optional, default: 1000
         Maximum number of function evaluations.
-    disp : bool, optional
+    disp : bool, optional, default: False
         Whether to print convergence process to stdout.
-    eta_strategy : callable, optional
+    eta_strategy : callable, optional, default: None
         Choice of the ``eta_k`` parameter, which gives slack for growth
         of ``||F||**2``.  Called as ``eta_k = eta_strategy(k, x, F)`` with
         `k` the iteration number, `x` the current iterate and `F` the current
         residual. Should satisfy ``eta_k > 0`` and ``sum(eta, k=0..inf) < inf``.
         Default: ``||F||**2 / (1 + k)**2``.
-    sigma_eps : float, optional
+    sigma_eps : float, optional, default: 1e-10
         The spectral coefficient is constrained to ``sigma_eps < sigma < 1/sigma_eps``.
         Default: 1e-10
-    sigma_0 : float, optional
+    sigma_0 : float, optional, default: 1.0
         Initial spectral coefficient.
         Default: 1.0
-    M : int, optional
+    M : int, optional, default: 10
         Number of iterates to include in the nonmonotonic line search.
         Default: 10
-    line_search : {'cruz', 'cheng'}
+    line_search : {'cruz', 'cheng'}, default: 'cruz'
         Type of line search to employ. 'cruz' is the original one defined in
         [Martinez & Raydan. Math. Comp. 75, 1429 (2006)], 'cheng' is
         a modified search defined in [Cheng & Li. IMA J. Numer. Anal. 29, 814 (2009)].


### PR DESCRIPTION
#### Reference issue
Closes #22635

#### What does this implement/fix?
Updated docstrings to include default values for optional parameters for methods within `scipy.optimize.root`

#### Additional information
The PR only updates docstrings of method: `hybr`, `lm` and `df-sane` within `scipy.optimize.root`
