### PR TITLE
MAINT: remove outdated `xp_` functions, `xp.asarray` on elementwise function args

### DIFF
--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
-from scipy._lib._array_api import array_namespace, xp_sign, xp_copy
+from scipy._lib._array_api import array_namespace, xp_copy
 
 _EERRORINCREASE = -1  # used in derivative
 
@@ -400,7 +400,7 @@ def derivative(f, x, *, args=(), tolerances=None, maxiter=10,
     # that `hdir` can be broadcasted to the final shape. Same with `h0`.
     hdir = xp.broadcast_to(hdir, shape)
     hdir = xp.reshape(hdir, (-1,))
-    hdir = xp.astype(xp_sign(hdir), dtype)
+    hdir = xp.astype(xp.sign(hdir), dtype)
     h0 = xp.broadcast_to(h0, shape)
     h0 = xp.reshape(h0, (-1,))
     h0 = xp.astype(h0, dtype)

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -746,6 +746,7 @@ class TestTanhSinh:
         _tanhsinh(np.sin, 1, x)
 
 
+@pytest.mark.skip_xp_backends('torch', reason='data-apis/array-api-compat#271')
 @pytest.mark.skip_xp_backends('array_api_strict', reason='No fancy indexing.')
 @pytest.mark.skip_xp_backends('jax.numpy', reason='No mutation.')
 @pytest.mark.skip_xp_backends(

--- a/scipy/optimize/_bracket.py
+++ b/scipy/optimize/_bracket.py
@@ -57,7 +57,7 @@ def _bracket_root_iv(func, xl0, xr0, xmin, xmax, factor, args, maxiter):
     # Calculate the default value of xr0 if a value has not been supplied.
     # Be careful to ensure xr0 is not larger than xmax.
     if xr0_not_supplied:
-        xr0 = xl0 + xp.minimum((xmax - xl0)/ 8, xp.asarray(1.0))
+        xr0 = xl0 + xp.minimum((xmax - xl0)/ 8, 1.0)
         xr0 = xp.astype(xr0, xl0.dtype, copy=False)
 
     maxiter = xp.asarray(maxiter)
@@ -481,10 +481,10 @@ def _bracket_minimum_iv(func, xm0, xl0, xr0, xmin, xmax, factor, args, maxiter):
     # by the user. We need to be careful to ensure xl0 and xr0 are not outside
     # of (xmin, xmax).
     if xl0_not_supplied:
-        xl0 = xm0 - xp.minimum((xm0 - xmin)/16, xp.asarray(0.5))
+        xl0 = xm0 - xp.minimum((xm0 - xmin)/16, 0.5)
         xl0 = xp.astype(xl0, xm0.dtype, copy=False)
     if xr0_not_supplied:
-        xr0 = xm0 + xp.minimum((xmax - xm0)/16, xp.asarray(0.5))
+        xr0 = xm0 + xp.minimum((xmax - xm0)/16, 0.5)
         xr0 = xp.astype(xr0, xm0.dtype, copy=False)
 
     maxiter = xp.asarray(maxiter)

--- a/scipy/optimize/_chandrupatla.py
+++ b/scipy/optimize/_chandrupatla.py
@@ -2,7 +2,7 @@ import math
 import numpy as np
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
-from scipy._lib._array_api import xp_sign, xp_copy
+from scipy._lib._array_api import xp_copy
 
 # TODO:
 # - (maybe?) don't use fancy indexing assignment
@@ -187,7 +187,7 @@ def _chandrupatla(func, a, b, *, args=(), xatol=None, xrtol=None,
 
         # If the bracket is no longer valid, report failure (unless a function
         # tolerance is met, as detected above).
-        i = (xp_sign(work.f1) == xp_sign(work.f2)) & ~stop
+        i = (xp.sign(work.f1) == xp.sign(work.f2)) & ~stop
         NaN = xp.asarray(xp.nan, dtype=work.xmin.dtype)
         work.xmin[i], work.fmin[i], work.status[i] = NaN, NaN, eim._ESIGNERR
         stop[i] = True
@@ -448,7 +448,7 @@ def _chandrupatla_minimize(func, x1, x2, x3, *, args=(), xatol=None,
         # tol away from x2."
         # See also QBASIC code after "Accept Ql adjust if close to X2".
         j = xp.abs(q1[i] - work.x2[i]) <= work.xtol[i]
-        xi[j] = work.x2[i][j] + xp_sign(x32[i][j]) * work.xtol[i][j]
+        xi[j] = work.x2[i][j] + xp.sign(x32[i][j]) * work.xtol[i][j]
 
         # "If condition (7) is not satisfied, golden sectioning of the larger
         # interval is carried out to introduce the new point."
@@ -466,7 +466,7 @@ def _chandrupatla_minimize(func, x1, x2, x3, *, args=(), xatol=None,
         # point. In QBASIC code, see "IF SGN(X-X2) = SGN(X3-X2) THEN...".
         # There is an awful lot of data copying going on here; this would
         # probably benefit from code optimization or implementation in Pythran.
-        i = xp_sign(x - work.x2) == xp_sign(work.x3 - work.x2)
+        i = xp.sign(x - work.x2) == xp.sign(work.x3 - work.x2)
         xi, x1i, x2i, x3i = x[i], work.x1[i], work.x2[i], work.x3[i],
         fi, f1i, f2i, f3i = f[i], work.f1[i], work.f2[i], work.f3[i]
         j = fi > f2i

--- a/scipy/optimize/tests/test_bracket.py
+++ b/scipy/optimize/tests/test_bracket.py
@@ -381,6 +381,7 @@ class TestBracketRoot:
         assert res.success
 
 
+@pytest.mark.skip_xp_backends('torch', reason='data-apis/array-api-compat#271')
 @pytest.mark.skip_xp_backends('array_api_strict', reason=array_api_strict_skip_reason)
 @pytest.mark.skip_xp_backends('jax.numpy', reason=boolean_index_skip_reason)
 @pytest.mark.skip_xp_backends('dask.array', reason=boolean_index_skip_reason)

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -3,7 +3,6 @@ from scipy._lib._array_api import (
     array_namespace,
     xp_size,
     xp_broadcast_promote,
-    xp_real,
     xp_float_to_complex,
 )
 from scipy._lib import array_api_extra as xpx
@@ -171,8 +170,7 @@ def _elements_and_indices_with_max_real(a, axis=-1, xp=None):
         i = xpx.at(i, ~mask).set(-1)
         max_i = xp.max(i, axis=axis, keepdims=True)
         mask = i == max_i
-        # FIXME https://github.com/data-apis/array-api/pull/860
-        a = xp.where(mask, a, xp.zeros((), dtype=a.dtype))
+        a = xp.where(mask, a, 0.)
         max = xp.sum(a, axis=axis, dtype=a.dtype, keepdims=True)
     else:
         max = xp.max(a, axis=axis, keepdims=True)
@@ -182,7 +180,7 @@ def _elements_and_indices_with_max_real(a, axis=-1, xp=None):
 
 
 def _sign(x, xp):
-    return x / xp.where(x == 0, xp.asarray(1, dtype=x.dtype), xp.abs(x))
+    return x / xp.where(x == 0, 1., xp.abs(x))
 
 
 def _logsumexp(a, b, axis, return_sign, xp):
@@ -207,7 +205,7 @@ def _logsumexp(a, b, axis, return_sign, xp):
 
     # Arithmetic between infinities will introduce NaNs.
     # `+ a_max` at the end naturally corrects for removing them here.
-    shift = xp.where(xp.isfinite(a_max), a_max, xp.asarray(0, dtype=a_max.dtype))
+    shift = xp.where(xp.isfinite(a_max), a_max, 0.)
 
     # Shift, exponentiate, scale, and sum
     exp = b * xp.exp(a - shift) if b is not None else xp.exp(a - shift)
@@ -233,7 +231,7 @@ def _logsumexp(a, b, axis, return_sign, xp):
     # Take log and undo shift
     out = xp.log1p(s) + xp.log(m) + a_max
 
-    out = xp_real(out) if return_sign else out
+    out = xp.real(out) if return_sign else out
 
     return out, sgn
 

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -79,7 +79,7 @@ def _xlogy(xp, spx):
     def __xlogy(x, y, *, xp=xp):
         with np.errstate(divide='ignore', invalid='ignore'):
             temp = x * xp.log(y)
-        return xp.where(x == 0., xp.asarray(0., dtype=temp.dtype), temp)
+        return xp.where(x == 0., 0., temp)
     return __xlogy
 
 

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -12,6 +12,9 @@ from scipy.special._logsumexp import _wrap_radians
 from scipy._lib.array_api_extra.testing import lazy_xp_function
 
 
+skip_xp_backends = pytest.mark.skip_xp_backends
+
+
 dtypes = ['float32', 'float64', 'int32', 'int64', 'complex64', 'complex128']
 integral_dtypes = ['int32', 'int64']
 
@@ -179,6 +182,7 @@ class TestLogSumExp:
         desired = np.asarray(1000.0 + math.log(2.0))
         xp_assert_close(logsumexp(a), desired)
 
+    @skip_xp_backends('array_api_strict', reason='data-apis/array-api-strict#131')
     @pytest.mark.parametrize('dtype', dtypes)
     def test_dtypes_a(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -188,6 +192,7 @@ class TestLogSumExp:
         desired = xp.asarray(1000.0 + math.log(2.0), dtype=desired_dtype)
         xp_assert_close(logsumexp(a), desired)
 
+    @skip_xp_backends('array_api_strict', reason='data-apis/array-api-strict#131')
     @pytest.mark.parametrize('dtype_a', dtypes)
     @pytest.mark.parametrize('dtype_b', dtypes)
     def test_dtypes_ab(self, dtype_a, dtype_b, xp):
@@ -218,6 +223,7 @@ class TestLogSumExp:
         ref = xp.logaddexp(a[0], a[1])
         xp_assert_close(res, ref)
 
+    @skip_xp_backends('array_api_strict', reason='data-apis/array-api-strict#131')
     @pytest.mark.filterwarnings(
         "ignore:The `numpy.copyto` function is not implemented:FutureWarning:dask"
     )

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -4,7 +4,8 @@ from scipy.special._support_alternative_backends import (get_array_special_func,
                                                          array_special_func_map)
 from scipy import special
 from scipy._lib._array_api_no_0d import xp_assert_close
-from scipy._lib._array_api import is_cupy, is_dask, is_jax, is_torch, SCIPY_DEVICE
+from scipy._lib._array_api import (is_cupy, is_dask, is_jax, is_torch,
+                                   is_array_api_strict, SCIPY_DEVICE)
 from scipy._lib.array_api_compat import numpy as np
 
 
@@ -57,6 +58,8 @@ def test_support_alternative_backends(xp, f_name, n_args, dtype, shapes):
         pytest.skip("boolean index assignment")
     if is_jax(xp) and f_name == "stdtrit":
         pytest.skip(f"`{f_name}` requires scipy.optimize support for immutable arrays")
+    if is_array_api_strict(xp) and f_name == "xlogy":
+        pytest.skip(f"`{f_name}` needs data-apis/array-api-strict#131 to be resolved")
 
     shapes = shapes[:n_args]
     f = getattr(special, f_name)

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -8,7 +8,7 @@ import math
 import numpy as np
 from scipy import special
 from ._axis_nan_policy import _axis_nan_policy_factory, _broadcast_arrays
-from scipy._lib._array_api import array_namespace, xp_moveaxis_to_end
+from scipy._lib._array_api import array_namespace
 from scipy._lib import array_api_extra as xpx
 
 __all__ = ['entropy', 'differential_entropy']
@@ -321,7 +321,7 @@ def differential_entropy(
     values = xp.asarray(values)
     if xp.isdtype(values.dtype, "integral"):  # type: ignore[union-attr]
         values = xp.astype(values, xp.asarray(1.).dtype)
-    values = xp_moveaxis_to_end(values, axis, xp=xp)
+    values = xp.moveaxis(values, axis, -1)
     n = values.shape[-1]  # type: ignore[union-attr]
 
     if window_length is None:

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -15,7 +15,6 @@ from scipy._lib._util import _rename_parameter, _contains_nan, _get_nan
 from scipy._lib._array_api import (
     array_namespace,
     xp_size,
-    xp_moveaxis_to_end,
     xp_vector_norm,
 )
 
@@ -2884,7 +2883,7 @@ def bartlett(*samples, axis=0):
         raise ValueError("Must enter at least two input sample vectors.")
 
     samples = _broadcast_arrays(samples, axis=axis, xp=xp)
-    samples = [xp_moveaxis_to_end(sample, axis, xp=xp) for sample in samples]
+    samples = [xp.moveaxis(sample, axis, -1) for sample in samples]
 
     Ni = [xp.asarray(sample.shape[-1], dtype=sample.dtype) for sample in samples]
     Ni = [xp.broadcast_to(N, samples[0].shape[:-1]) for N in Ni]

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -7,7 +7,7 @@ import inspect
 
 from scipy._lib._util import (check_random_state, _rename_parameter, rng_integers,
                               _transition_to_rng)
-from scipy._lib._array_api import array_namespace, is_numpy, xp_moveaxis_to_end
+from scipy._lib._array_api import array_namespace, is_numpy
 from scipy.special import ndtr, ndtri, comb, factorial
 
 from ._common import ConfidenceInterval
@@ -713,7 +713,7 @@ def _monte_carlo_test_iv(data, rvs, statistic, vectorized, n_resamples,
     data_iv = []
     for sample in data:
         sample = xp.broadcast_to(sample, (1,)) if sample.ndim == 0 else sample
-        sample = xp_moveaxis_to_end(sample, axis_int, xp=xp)
+        sample = xp.moveaxis(sample, axis_int, -1)
         data_iv.append(sample)
 
     n_resamples_int = int(n_resamples)

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from scipy._lib._util import _get_nan
-from scipy._lib._array_api import array_namespace, xp_copysign
+from scipy._lib._array_api import array_namespace
 
 from ._axis_nan_policy import _axis_nan_policy_factory
 
@@ -118,7 +118,7 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
     if ddof == n:
         # Another special case.  Result is either inf or nan.
         std_a = xp.std(a, axis=axis, correction=0)
-        result = xp.where(std_a > 0, xp_copysign(xp.asarray(xp.inf), mean_a), NaN)
+        result = xp.where(std_a > 0, xp.copysign(xp.inf, mean_a), NaN)
         return result[()] if result.ndim == 0 else result
 
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -28,7 +28,7 @@ class TestEntropy:
         xp_assert_less(xp.abs(S - 4.), xp.asarray(1.e-5))
 
         qk = xp.ones(16)
-        qk = xp.where(xp.arange(16) < 8, xp.asarray(2.), qk)
+        qk = xp.where(xp.arange(16) < 8, 2., qk)
         S = stats.entropy(pk, qk)
         S2 = stats.entropy(pk, qk, base=2.)
         xp_assert_less(xp.abs(S/S2 - math.log(2.)), xp.asarray(1.e-5))

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1825,7 +1825,7 @@ class TestKstat:
 
     def test_nan_input(self, xp):
         data = xp.arange(10.)
-        data = xp.where(data == 6, xp.asarray(xp.nan), data)
+        data = xp.where(data == 6, xp.nan, data)
 
         xp_assert_equal(stats.kstat(data), xp.asarray(xp.nan))
 
@@ -1869,7 +1869,7 @@ class TestKstatVar:
 
     def test_nan_input(self, xp):
         data = xp.arange(10.)
-        data = xp.where(data == 6, xp.asarray(xp.nan), data)
+        data = xp.where(data == 6, xp.nan, data)
 
         xp_assert_equal(stats.kstat(data), xp.asarray(xp.nan))
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2842,7 +2842,7 @@ class TestSEM:
                         stats.sem(testcase, ddof=2))
 
         x = xp.arange(10.)
-        x = xp.where(x == 9, xp.asarray(xp.nan), x)
+        x = xp.where(x == 9, xp.nan, x)
         xp_assert_equal(stats.sem(x), xp.asarray(xp.nan))
 
     @skip_xp_backends(np_only=True,
@@ -3780,7 +3780,7 @@ class TestKurtosis(SkewKurtosisTest):
         xp_assert_close(y, xp.asarray(1.64))
 
         x = xp.arange(10.)
-        x = xp.where(x == 8, xp.asarray(xp.nan), x)
+        x = xp.where(x == 8, xp.nan, x)
         xp_assert_equal(stats.kurtosis(x), xp.asarray(xp.nan))
 
     def test_kurtosis_nan_policy(self):
@@ -6406,7 +6406,7 @@ class TestDescribe:
 
     def test_describe_nan_policy_other(self, xp):
         x = xp.arange(10.)
-        x = xp.where(x==9, xp.asarray(xp.nan), x)
+        x = xp.where(x==9, xp.nan, x)
 
         if is_lazy_array(x):
             with pytest.raises(TypeError, match='not supported for lazy arrays'):
@@ -9467,7 +9467,7 @@ class TestXP_Mean:
     def test_nan_policy(self, xp):
         x = xp.arange(10.)
         mask = (x == 3)
-        x = xp.where(mask, xp.asarray(xp.nan), x)
+        x = xp.where(mask, xp.nan, x)
 
         # nan_policy='raise' raises an error
         if is_lazy_array(x):
@@ -9491,7 +9491,7 @@ class TestXP_Mean:
 
         # `nan_policy='omit'` omits NaNs in `weights`, too
         weights = xp.ones(10)
-        weights = xp.where(mask, xp.asarray(xp.nan), weights)
+        weights = xp.where(mask, xp.nan, weights)
         res = _xp_mean(xp.arange(10.), weights=weights, nan_policy='omit')
         ref = xp.mean(x[~mask])
         xp_assert_close(res, ref)
@@ -9590,7 +9590,7 @@ class TestXP_Var:
     def test_nan_policy(self, xp):
         x = xp.arange(10.)
         mask = (x == 3)
-        x = xp.where(mask, xp.asarray(xp.nan), x)
+        x = xp.where(mask, xp.nan, x)
 
         # `nan_policy='propagate'` is the default, and the result is NaN
         res1 = _xp_var(x)

--- a/scipy/stats/tests/test_variation.py
+++ b/scipy/stats/tests/test_variation.py
@@ -14,6 +14,7 @@ from scipy.stats._axis_nan_policy import (too_small_nd_omit, too_small_nd_not_om
 skip_xp_backends = pytest.mark.skip_xp_backends
 
 
+@skip_xp_backends('torch', reason='data-apis/array-api-compat#271')
 class TestVariation:
     """
     Test class for scipy.stats.variation


### PR DESCRIPTION
#### Reference issue
gh-22680

#### What does this implement/fix?
Now that the 2024.12 standard is out and array-api-compat supports it, I thought it was time for a cleanup of some artifacts from the old days of array API translations. 

One of the things we used to have to do was convert arguments to `xp.where`, `xp.minimum`, etc., into arrays rather than leaving them as scalars. Even if we were careful to use the correct `dtype`, I don't think anyone ensured that the array ended up on the correct device. Use of a Python scalar avoids both of these gotchas.

This cleans up most of the now-unnecessary array conversions in the context of `xp.where`, `xp.minimum`, `xp.clip`, and some other elementwise functions mentioned in https://github.com/data-apis/array-api/issues/807#issuecomment-2639477476. I also noticed some old custom `xp_` functions that we no longer need since they are provided by array-api-compat.

Lots of lines and files are changed, but it should be pretty straightforward.

#### Additional information
Based on gh-22680, I think that anywhere we create an array within a function, we need to pay attention to the device. This only avoids some of those places. To resolve that issue, we really should test with non-default devices (and make the required changes).

There may be some test skips we can remove now. I think we can do that as part of follow-up to gh-22609/gh-22677.

Use of `result_type` needs very special attention; see https://github.com/data-apis/array-api-compat/issues/223#issuecomment-2628684979. Now that it's possible, we need to make sure we pass the arguments to `result_type` before they become arrays.
