### PR TITLE
BUG: signal.resample_poly: fix dtype preservation

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3865,7 +3865,10 @@ def resample_poly(x, up, down, axis=0, window=('kaiser', 5.0),
         max_rate = max(up, down)
         f_c = 1. / max_rate  # cutoff of FIR filter (rel. to Nyquist)
         half_len = 10 * max_rate  # reasonable cutoff for sinc-like function
-        if np.issubdtype(x.dtype, np.floating):
+        if np.issubdtype(x.dtype, np.complexfloating):
+            h = firwin(2 * half_len + 1, f_c,
+                       window=window).astype(x.dtype)  # match dtype of x
+        elif np.issubdtype(x.dtype, np.floating):
             h = firwin(2 * half_len + 1, f_c,
                        window=window).astype(x.dtype)  # match dtype of x
         else:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -4467,3 +4467,8 @@ class TestUniqueRoots:
         unique, multiplicity = unique_roots(p, 2)
         assert_almost_equal(unique, [np.min(p)], decimal=15)
         xp_assert_equal(multiplicity, [100])
+
+
+def test_gh_22684():
+    actual = signal.resample_poly(np.arange(2000, dtype=np.complex64), 6, 4)
+    assert actual.dtype == np.complex64


### PR DESCRIPTION
* Fixes gh-22684.

* Fix a scenario where `resample_poly` did not preserve input `dtype`.

My patch is only slightly more complicated than the suggestion from Matti (a few other `dtype` preservation tests failed if I just did the change he suggested, but it was basically correct). Note that I'm not an expert on this code--just assuming we want the type preservation here.
