### PR TITLE
DOC: signal: fix `freqz_sos` and `sosfreqz` docstrings

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -92,7 +92,7 @@ Filter design
    freqs         -- Analog filter frequency response from TF coefficients.
    freqs_zpk     -- Analog filter frequency response from ZPK coefficients.
    freqz         -- Digital filter frequency response from TF coefficients.
-   sosfreqz      -- Digital filter frequency response for SOS format filter.
+   sosfreqz      -- Digital filter frequency response for SOS format filter (legacy).
    freqz_sos     -- Digital filter frequency response for SOS format filter.
    freqz_zpk     -- Digital filter frequency response from ZPK coefficients.
    gammatone     -- FIR and IIR gammatone filter design.

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -92,6 +92,7 @@ Filter design
    freqs         -- Analog filter frequency response from TF coefficients.
    freqs_zpk     -- Analog filter frequency response from ZPK coefficients.
    freqz         -- Digital filter frequency response from TF coefficients.
+   sosfreqz      -- Digital filter frequency response for SOS format filter.
    freqz_sos     -- Digital filter frequency response for SOS format filter.
    freqz_zpk     -- Digital filter frequency response from ZPK coefficients.
    gammatone     -- FIR and IIR gammatone filter design.

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -792,8 +792,10 @@ def freqz_sos(sos, worN=512, whole=False, fs=2*pi):
 
     Notes
     -----
+    This function used to be called ``sosfreqz`` in older versions (≥ 0.19.0)
+    
     .. versionadded:: 1.15.0
-    This function used to be called sosfreqz in older versions (>=0.19.0)
+    
 
     Examples
     --------

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -870,10 +870,12 @@ def sosfreqz(*args, **kwargs):
     """
     Compute the frequency response of a digital filter in SOS format.
 
-    .. warning:: This function is an alias, provided for backward
-                 compatibility. New code should use the function
-                 :func:`scipy.signal.freqz_sos`.
-                 This function became obsolete from version 1.15.0.
+   .. legacy:: function
+        
+        This function is an alias, provided for backward compatibility. 
+        New code should use the function :func:`scipy.signal.freqz_sos`.
+        This function became obsolete from version 1.15.0.
+        
     """
     return freqz_sos(*args, **kwargs)
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -867,7 +867,7 @@ def freqz_sos(sos, worN=512, whole=False, fs=2*pi):
 
 def sosfreqz(*args, **kwargs):
     """
-    Compute the frequency response of a digital filter in SOS format.
+    Compute the frequency response of a digital filter in SOS format (legacy).
 
    .. legacy:: function
         

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -793,7 +793,7 @@ def freqz_sos(sos, worN=512, whole=False, fs=2*pi):
     Notes
     -----
     .. versionadded:: 1.15.0
-    .. This function used to be called sosfreqz in versions in older versions (>=0.19.0)
+    .. This function used to be called sosfreqz in older versions (>=0.19.0)
 
     Examples
     --------

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -793,7 +793,7 @@ def freqz_sos(sos, worN=512, whole=False, fs=2*pi):
     Notes
     -----
     .. versionadded:: 1.15.0
-    .. This function used to be called sosfreqz in older versions (>=0.19.0)
+    This function used to be called sosfreqz in older versions (>=0.19.0)
 
     Examples
     --------

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -788,11 +788,12 @@ def freqz_sos(sos, worN=512, whole=False, fs=2*pi):
 
     See Also
     --------
-    freqz, sosfilt
+    freqz, sosfilt, sosfreqz
 
     Notes
     -----
-    .. versionadded:: 0.19.0
+    .. versionadded:: 1.15.0
+    .. This function used to be called sosfreqz in versions in older versions (>=0.19.0)
 
     Examples
     --------
@@ -870,6 +871,7 @@ def sosfreqz(*args, **kwargs):
     .. warning:: This function is an alias, provided for backward
                  compatibility. New code should use the function
                  :func:`scipy.signal.freqz_sos`.
+                 This function became obsolete from version 1.15.0.
     """
     return freqz_sos(*args, **kwargs)
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -795,8 +795,7 @@ def freqz_sos(sos, worN=512, whole=False, fs=2*pi):
     This function used to be called ``sosfreqz`` in older versions (≥ 0.19.0)
     
     .. versionadded:: 1.15.0
-    
-
+        
     Examples
     --------
     Design a 15th-order bandpass filter in SOS format.

--- a/tools/refguide_check.py
+++ b/tools/refguide_check.py
@@ -102,7 +102,6 @@ REFGUIDE_AUTOSUMMARY_SKIPLIST = [
     r'scipy\.special\.jn',  # alias for jv
     r'scipy\.ndimage\.sum',   # alias for sum_labels
     r'scipy\.linalg\.solve_lyapunov',  # deprecated name
-    r'scipy\.signal\.sosfreqz',  # alias for freqz_sos
     r'scipy\.stats\.contingency\.chi2_contingency',
     r'scipy\.stats\.contingency\.expected_freq',
     r'scipy\.stats\.contingency\.margins',


### PR DESCRIPTION
closes https://github.com/scipy/scipy/issues/22461

Changes:
1) Amended the freqz_sos Docstring. 
2) Amended the sosfreqz Docstring.
3) Removed sosfreqz from SKIPLIST so that it shows up in the online documentation.

