### PR TITLE
BUG: spatial.HalfspaceIntersection: fix `add_halfspaces` batch size support

### DIFF
--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2909,9 +2909,12 @@ class HalfspaceIntersection(_QhullUser):
 
         Parameters
         ----------
-        halfspaces : ndarray
-            New halfspaces to add. The dimensionality should match that of the
-            initial halfspaces.
+        halfspaces : ndarray of double, shape (n_new_ineq, ndim+1)
+        Input halfspaces.
+            New halfspaces to add. The dimensionality (ndim) should match that of the
+            initial halfspaces. Like in the constructor, these are stacked 
+            inequalites of the form Ax + b <= 0 in format [A; b]. The original
+            feasible point must also be feasible for these new inequalities.
         restart : bool, optional
             Whether to restart processing from scratch, rather than
             adding halfspaces incrementally.

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2910,7 +2910,6 @@ class HalfspaceIntersection(_QhullUser):
         Parameters
         ----------
         halfspaces : ndarray of double, shape (n_new_ineq, ndim+1)
-        Input halfspaces.
             New halfspaces to add. The dimensionality (ndim) should match that of the
             initial halfspaces. Like in the constructor, these are stacked 
             inequalites of the form Ax + b <= 0 in format [A; b]. The original

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -457,7 +457,7 @@ cdef class _Qhull:
                 #Store the halfspaces in _points and the dual points in _dual_points later
                 self._point_arrays.append(np.array(points, copy=True))
                 dists = points[:, :-1].dot(interior_point)+points[:, -1]
-                arr = np.array(-points[:, :-1]/dists, dtype=np.double, order="C", copy=True)
+                arr = np.array(-points[:, :-1]/dists[:, np.newaxis], dtype=np.double, order="C", copy=True)
             else:
                 arr = np.array(points, dtype=np.double, order="C", copy=True)
 

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1203,7 +1203,21 @@ class Test_HalfspaceIntersection:
         hs.add_halfspaces(small_square[0:k,:])
         hs.add_halfspaces(small_square[k:4,:])
         hs.close()
-        # TODO: add correctness test here.
+
+        # Check the intersections are correct (they are the corners of the small square)
+        expected_intersections = np.array([[1., 1.],
+                                           [1., -1.],
+                                           [-1., 1.],
+                                           [-1., -1.]])
+        actual_intersections = hs.intersections
+        # They may be in any order, so just check that under some permutation 
+        # expected=actual.
+        close = np.isclose(actual_intersections[np.newaxis],
+                           expected_intersections[:, np.newaxis])
+        close = np.all(close, axis=-1)
+
+        assert (np.count_nonzero(close, axis=0) == 1).all()
+        assert (np.count_nonzero(close, axis=1) == 1).all()
 
 @pytest.mark.parametrize("diagram_type", [Voronoi, qhull.Delaunay])
 def test_gh_20623(diagram_type):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1199,7 +1199,10 @@ class Test_HalfspaceIntersection:
                                  [ 0.,  1., -1.],
                                  [ 0., -1., -1.]])
 
-        hs = qhull.HalfspaceIntersection(big_square, np.zeros((2,)), incremental=True)
+        hs = qhull.HalfspaceIntersection(big_square,
+                                         np.array([0.3141, 0.2718]),
+                                         incremental=True)
+
         hs.add_halfspaces(small_square[0:k,:])
         hs.add_halfspaces(small_square[k:4,:])
         hs.close()

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1215,12 +1215,10 @@ class Test_HalfspaceIntersection:
         actual_intersections = hs.intersections
         # They may be in any order, so just check that under some permutation 
         # expected=actual.
-        close = np.isclose(actual_intersections[np.newaxis],
-                           expected_intersections[:, np.newaxis])
-        close = np.all(close, axis=-1)
 
-        assert (np.count_nonzero(close, axis=0) == 1).all()
-        assert (np.count_nonzero(close, axis=1) == 1).all()
+        ind1 = np.lexsort((actual_intersections[:, 1], actual_intersections[:, 0]))
+        ind2 = np.lexsort((expected_intersections[:, 1], expected_intersections[:, 0]))
+        assert_allclose(actual_intersections[ind1], expected_intersections[ind2])
 
 @pytest.mark.parametrize("diagram_type", [Voronoi, qhull.Delaunay])
 def test_gh_20623(diagram_type):

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -1186,6 +1186,24 @@ class Test_HalfspaceIntersection:
 
         assert_allclose(hs.dual_points, qhalf_points)
 
+    @pytest.mark.parametrize("k", range(1,4))
+    def test_halfspace_batch(self, k):
+        # Test that we can add halfspaces a few at a time
+        big_square = np.array([[ 1.,  0., -2.],
+                               [-1.,  0., -2.],
+                               [ 0.,  1., -2.],
+                               [ 0., -1., -2.]])
+
+        small_square = np.array([[ 1.,  0., -1.],
+                                 [-1.,  0., -1.],
+                                 [ 0.,  1., -1.],
+                                 [ 0., -1., -1.]])
+
+        hs = qhull.HalfspaceIntersection(big_square, np.zeros((2,)), incremental=True)
+        hs.add_halfspaces(small_square[0:k,:])
+        hs.add_halfspaces(small_square[k:4,:])
+        hs.close()
+        # TODO: add correctness test here.
 
 @pytest.mark.parametrize("diagram_type", [Voronoi, qhull.Delaunay])
 def test_gh_20623(diagram_type):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
This [stemmed](https://github.com/scipy/scipy/pull/20035#discussion_r1951830860) from the investigation of, but does not close, https://github.com/scipy/scipy/issues/19865. Please let me know if I should also file a separate bug for this issue.

#### What does this implement/fix?
`add_halfspaces` fails with an array-size issue unless the number of halfspaces being added is `1`, or (I think) `ndim`.  The only places this function was tested is [here](https://github.com/scipy/scipy/blob/main/scipy/spatial/tests/test_qhull.py#L1135), where only a single halfspace is added at a time. I added a simple test and fixed the broadcasting.

#### Additional information
This is my first PR to scipy or indeed to any open source project with this much complexity. Please LMK if I have missed anything.
