### PR TITLE
MAINT: spatial: support empty case in `RigidTransform`

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.pyx
+++ b/scipy/spatial/transform/_rigid_transform.pyx
@@ -1542,7 +1542,7 @@ cdef class RigidTransform:
         len_self = len(self._matrix)
         len_other = len(other._matrix)
         if not(len_self == 1 or len_other == 1 or len_self == len_other):
-            raise ValueError("Expected equal number of transforms in both or a"
+            raise ValueError("Expected equal number of transforms in both or a "
                              "single transform in either object, got "
                              f"{len_self} transforms in first and {len_other}"
                              "transforms in second object.")

--- a/scipy/spatial/transform/_rigid_transform.pyx
+++ b/scipy/spatial/transform/_rigid_transform.pyx
@@ -474,7 +474,6 @@ cdef class RigidTransform:
         matrix = np.asarray(matrix, dtype=float)
 
         if (matrix.ndim not in [2, 3]
-                or matrix.shape[0] == 0
                 or matrix.shape[-1] != 4
                 or matrix.shape[-2] != 4):
             raise ValueError("Expected `matrix` to have shape (4, 4), or (N, 4, 4), "
@@ -735,9 +734,7 @@ cdef class RigidTransform:
         """
         translation = np.asarray(translation, dtype=float)
 
-        if (translation.ndim not in [1, 2]
-                or translation.shape[0] == 0
-                or translation.shape[-1] != 3):
+        if translation.ndim not in [1, 2] or translation.shape[-1] != 3:
             raise ValueError("Expected `translation` to have shape (3,), or (N, 3), "
                              f"got {translation.shape}.")
 
@@ -908,8 +905,7 @@ cdef class RigidTransform:
         """
         exp_coords = np.asarray(exp_coords, dtype=float)
 
-        if (exp_coords.ndim not in [1, 2] or exp_coords.shape[0] == 0
-                or exp_coords.shape[-1] != 6):
+        if exp_coords.ndim not in [1, 2] or exp_coords.shape[-1] != 6:
             raise ValueError(
                 "Expected `exp_coords` to have shape (6,), or (N, 6), "
                 f"got {exp_coords.shape}.")
@@ -978,8 +974,7 @@ cdef class RigidTransform:
         """
         dual_quat = np.asarray(dual_quat, dtype=float)
 
-        if (dual_quat.ndim not in [1, 2] or dual_quat.shape[0] == 0
-                or dual_quat.shape[-1] != 8):
+        if dual_quat.ndim not in [1, 2] or dual_quat.shape[-1] != 8:
             raise ValueError(
                 "Expected `dual_quat` to have shape (8,), or (N, 8), "
                 f"got {dual_quat.shape}.")

--- a/scipy/spatial/transform/_rigid_transform.pyx
+++ b/scipy/spatial/transform/_rigid_transform.pyx
@@ -1820,9 +1820,7 @@ cdef class RigidTransform:
         array([-1.73205081, -1.        , -3.        ])
         """
         vector = np.asarray(vector, dtype=float)
-        if (vector.ndim not in [1, 2]
-                or vector.shape[-1] != 3
-                or vector.shape[0] == 0):
+        if vector.ndim not in [1, 2] or vector.shape[-1] != 3:
             raise ValueError("Expected vector to have shape (N, 3), or (3,), "
                              f"got {vector.shape}.")
 

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -948,3 +948,13 @@ def test_empty_transform_representation():
     assert tf.as_matrix().shape == (0, 4, 4)
     assert tf.as_exp_coords().shape == (0, 6)
     assert tf.as_dual_quat().shape == (0, 8)
+
+
+def test_empty_transform_application():
+    tf = RigidTransform.identity(0)
+
+    assert tf.apply(np.zeros((3,))).shape == (0, 3)
+    assert tf.apply(np.empty((0, 3))).shape == (0, 3)
+
+    with pytest.raises(ValueError, match="operands could not be broadcast together"):
+        tf.apply(np.zeros((2, 3)))

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -751,10 +751,17 @@ def test_indexing():
     assert_allclose(tf_slice.as_matrix()[:, :3, 3], t[0:2], atol=atol)
 
     # Test boolean indexing
+    tf_masked = tf[[True, True]]
+    assert_allclose(tf_masked.as_matrix()[:, :3, :3], r.as_matrix(), atol=atol)
+    assert_allclose(tf_masked.as_matrix()[:, :3, 3], t, atol=atol)
+
     tf_masked = tf[[False, True]]
     assert_allclose(tf_masked.as_matrix()[:, :3, :3], r[[False, True]].as_matrix(),
                     atol=atol)
     assert_allclose(tf_masked.as_matrix()[:, :3, 3], t[[False, True]], atol=atol)
+
+    tf_masked = tf[[False, False]]
+    assert len(tf_masked) == 0
 
 
 def test_concatenate():

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -993,3 +993,22 @@ def test_empty_transform_inv_and_pow():
     tf = RigidTransform.identity(0)
     assert len(tf.inv()) == 0
     assert len(tf ** 0.5) == 0
+
+
+def test_empty_transform_indexing():
+    tf_many = RigidTransform.identity(3)
+    tf_zero = tf_many[[]]
+    assert len(tf_zero) == 0
+
+    assert len(tf_zero[[]]) == 0
+    assert len(tf_zero[:5]) == 0  # Slices can go out of bounds.
+
+    with pytest.raises(IndexError):
+        tf_zero[0]
+
+    with pytest.raises(IndexError):
+        tf_zero[[0, 2]]
+
+    with pytest.raises(IndexError):
+        tf_zero[[False, True]]
+

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -783,8 +783,7 @@ def test_concatenate():
 
 def test_input_validation():
     # Test invalid matrix shapes
-    inputs = [np.eye(3), np.zeros((4, 3)), [],
-              np.zeros((0, 4, 4)), np.zeros((1, 1, 4, 4))]
+    inputs = [np.eye(3), np.zeros((4, 3)), [], np.zeros((1, 1, 4, 4))]
     for input in inputs:
         with pytest.raises(ValueError, match="Expected `matrix` to have shape"):
             RigidTransform.from_matrix(input)
@@ -822,9 +821,6 @@ def test_translation_validation():
         RigidTransform.from_translation(np.zeros((2, 2)))
 
     with pytest.raises(ValueError, match="Expected `translation` to have shape"):
-        RigidTransform.from_translation(np.zeros((0, 3)))
-
-    with pytest.raises(ValueError, match="Expected `translation` to have shape"):
         RigidTransform.from_translation(np.zeros((1, 1, 3)))
 
 
@@ -837,9 +833,6 @@ def test_vector_validation():
 
     with pytest.raises(ValueError, match="Expected vector to have shape"):
         tf.apply(np.zeros((2, 2)))
-
-    with pytest.raises(ValueError, match="Expected vector to have shape"):
-        tf.apply(np.zeros((0, 3)))
 
     with pytest.raises(ValueError, match="Expected vector to have shape"):
         tf.apply(np.zeros((1, 1, 3)))

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -958,3 +958,19 @@ def test_empty_transform_application():
 
     with pytest.raises(ValueError, match="operands could not be broadcast together"):
         tf.apply(np.zeros((2, 3)))
+
+
+def test_empty_transform_composition():
+    tf_empty = RigidTransform.identity(0)
+    tf_single = RigidTransform.identity()
+    tf_many = RigidTransform.identity(3)
+
+    assert len(tf_empty * tf_empty) == 0
+    assert len(tf_empty * tf_single) == 0
+    assert len(tf_single * tf_empty) == 0
+
+    with pytest.raises(ValueError, match="Expected equal number of transforms"):
+        tf_many * tf_empty
+
+    with pytest.raises(ValueError, match="Expected equal number of transforms"):
+        tf_empty * tf_many

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -910,3 +910,26 @@ def test_normalize_dual_quaternion():
     assert_allclose(np.linalg.norm(dual_quat[:, :4], axis=1), 1.0, atol=1e-12)
     assert_allclose(np.einsum("ij,ij->i", dual_quat[:, :4], dual_quat[:, 4:]),
                     0.0, atol=1e-12)
+
+
+def test_empty_transform_construction():
+    tf = RigidTransform.from_matrix(np.empty((0, 4, 4)))
+    assert len(tf) == 0
+
+    tf = RigidTransform.from_rotation(Rotation.random(0))
+    assert len(tf) == 0
+
+    tf = RigidTransform.from_translation(np.empty((0, 3)))
+    assert len(tf) == 0
+
+    tf = RigidTransform.from_components(np.empty((0, 3)), Rotation.random(0))
+    assert len(tf) == 0
+
+    tf = RigidTransform.from_exp_coords(np.empty((0, 6)))
+    assert len(tf) == 0
+
+    tf = RigidTransform.from_dual_quat(np.empty((0, 8)))
+    assert len(tf) == 0
+
+    tf = RigidTransform.identity(0)
+    assert len(tf) == 0

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -750,6 +750,12 @@ def test_indexing():
     assert_allclose(tf_slice.as_matrix()[:, :3, :3], r[0:2].as_matrix(), atol=atol)
     assert_allclose(tf_slice.as_matrix()[:, :3, 3], t[0:2], atol=atol)
 
+    # Test boolean indexing
+    tf_masked = tf[[False, True]]
+    assert_allclose(tf_masked.as_matrix()[:, :3, :3], r[[False, True]].as_matrix(),
+                    atol=atol)
+    assert_allclose(tf_masked.as_matrix()[:, :3, 3], t[[False, True]], atol=atol)
+
 
 def test_concatenate():
     atol = 1e-12
@@ -1011,4 +1017,3 @@ def test_empty_transform_indexing():
 
     with pytest.raises(IndexError):
         tf_zero[[False, True]]
-

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -933,3 +933,18 @@ def test_empty_transform_construction():
 
     tf = RigidTransform.identity(0)
     assert len(tf) == 0
+
+
+def test_empty_transform_representation():
+    tf = RigidTransform.identity(0)
+
+    assert len(tf.rotation) == 0
+    assert tf.translation.shape == (0, 3)
+
+    t, r = tf.as_components()
+    assert t.shape == (0, 3)
+    assert len(r) == 0
+
+    assert tf.as_matrix().shape == (0, 4, 4)
+    assert tf.as_exp_coords().shape == (0, 6)
+    assert tf.as_dual_quat().shape == (0, 8)

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -991,6 +991,9 @@ def test_empty_transform_concatenation():
 def test_empty_transform_inv_and_pow():
     tf = RigidTransform.identity(0)
     assert len(tf.inv()) == 0
+    assert len(tf ** 0) == 0
+    assert len(tf ** 1) == 0
+    assert len(tf ** -1) == 0
     assert len(tf ** 0.5) == 0
 
 

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -921,24 +921,31 @@ def test_normalize_dual_quaternion():
 def test_empty_transform_construction():
     tf = RigidTransform.from_matrix(np.empty((0, 4, 4)))
     assert len(tf) == 0
+    assert not tf.single
 
     tf = RigidTransform.from_rotation(Rotation.random(0))
     assert len(tf) == 0
+    assert not tf.single
 
     tf = RigidTransform.from_translation(np.empty((0, 3)))
     assert len(tf) == 0
+    assert not tf.single
 
     tf = RigidTransform.from_components(np.empty((0, 3)), Rotation.random(0))
     assert len(tf) == 0
+    assert not tf.single
 
     tf = RigidTransform.from_exp_coords(np.empty((0, 6)))
     assert len(tf) == 0
+    assert not tf.single
 
     tf = RigidTransform.from_dual_quat(np.empty((0, 8)))
     assert len(tf) == 0
+    assert not tf.single
 
     tf = RigidTransform.identity(0)
     assert len(tf) == 0
+    assert not tf.single
 
 
 def test_empty_transform_representation():

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -987,3 +987,9 @@ def test_empty_transform_concatenation():
     assert len(RigidTransform.concatenate([tf_empty, tf_many])) == 2
     assert len(RigidTransform.concatenate([tf_many, tf_empty])) == 2
     assert len(RigidTransform.concatenate([tf_many, tf_empty, tf_single])) == 3
+
+
+def test_empty_transform_inv_and_pow():
+    tf = RigidTransform.identity(0)
+    assert len(tf.inv()) == 0
+    assert len(tf ** 0.5) == 0

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -974,3 +974,16 @@ def test_empty_transform_composition():
 
     with pytest.raises(ValueError, match="Expected equal number of transforms"):
         tf_empty * tf_many
+
+
+def test_empty_transform_concatenation():
+    tf_empty = RigidTransform.identity(0)
+    tf_single = RigidTransform.identity()
+    tf_many = RigidTransform.identity(2)
+
+    assert len(RigidTransform.concatenate([tf_empty, tf_empty])) == 0
+    assert len(RigidTransform.concatenate([tf_empty, tf_single])) == 1
+    assert len(RigidTransform.concatenate([tf_single, tf_empty])) == 1
+    assert len(RigidTransform.concatenate([tf_empty, tf_many])) == 2
+    assert len(RigidTransform.concatenate([tf_many, tf_empty])) == 2
+    assert len(RigidTransform.concatenate([tf_many, tf_empty, tf_single])) == 3


### PR DESCRIPTION
#### Reference issue

#22659

#### What does this implement/fix?

It makes empty (zero length) transformations naturally supported by `RigidTransfrom` class.

#### Additional information

It follows the same approach to implementation (only necessary to remove checks against this case) and testing as #22643


-----

@hubernikus wellcome to review as well.
