### PR TITLE
ENH: optimize.linprog: vectorize `marg_bnds` loop

### DIFF
--- a/scipy/optimize/_highspy/_highs_wrapper.py
+++ b/scipy/optimize/_highspy/_highs_wrapper.py
@@ -332,7 +332,6 @@ def check_option(highs_inst, option, value):
 
 def _get_marg_bnds(solution_col_dual, basis_col_status):
     numcol = len(basis_col_status)
-    marg_bnds = np.zeros((2, numcol))
     basis_col_status_values = np.array(
         [status.value for status in basis_col_status],
         dtype='uint8'

--- a/scipy/optimize/_highspy/_highs_wrapper.py
+++ b/scipy/optimize/_highspy/_highs_wrapper.py
@@ -333,9 +333,16 @@ def check_option(highs_inst, option, value):
 def _get_marg_bnds(solution_col_dual, basis_col_status):
     numcol = len(basis_col_status)
     marg_bnds = np.zeros((2, numcol))
-    for ii in range(numcol):
-        if basis_col_status[ii] == _h.HighsBasisStatus.kLower:
-            marg_bnds[0, ii] = solution_col_dual[ii]
-        elif basis_col_status[ii] == _h.HighsBasisStatus.kUpper:
-            marg_bnds[1, ii] = solution_col_dual[ii]
+    basis_col_status_values = np.array(
+        [status.value for status in basis_col_status],
+        dtype='uint8'
+    )
+    solution_col_dual_array = np.array(solution_col_dual, dtype='float64')
+    is_lower = basis_col_status_values == _h.HighsBasisStatus.kLower.value
+    is_upper = basis_col_status_values == _h.HighsBasisStatus.kUpper.value
+    # If is_lower, write to row 0. If is_upper, write to row 1. If neither, write
+    # nothing. Note that is_lower and is_upper cannot be True at the same index.
+    marg_bnds = np.zeros((2, numcol))
+    marg_bnds[0, is_lower] = solution_col_dual_array[is_lower]
+    marg_bnds[1, is_upper] = solution_col_dual_array[is_upper]
     return marg_bnds

--- a/scipy/optimize/_highspy/_highs_wrapper.py
+++ b/scipy/optimize/_highspy/_highs_wrapper.py
@@ -263,14 +263,7 @@ def _highs_wrapper(c, indptr, indices, data, lhs, rhs, lb, ub, integrality, opti
     basis = highs.getBasis()
 
     # Lagrangians for bounds based on column statuses
-    marg_bnds = np.zeros((2, numcol))
-    basis_col_status = basis.col_status
-    solution_col_dual = solution.col_dual
-    for ii in range(numcol):
-        if basis_col_status[ii] == _h.HighsBasisStatus.kLower:
-            marg_bnds[0, ii] = solution_col_dual[ii]
-        elif basis_col_status[ii] == _h.HighsBasisStatus.kUpper:
-            marg_bnds[1, ii] = solution_col_dual[ii]
+    marg_bnds = _get_marg_bnds(solution.col_dual, basis.col_status)
 
     res.update(
         {
@@ -336,3 +329,13 @@ def check_option(highs_inst, option, value):
     if status != _h.HighsStatus.kOk:
         return 4, "Failed to validate option value."
     return 0, "Check option succeeded."
+
+def _get_marg_bnds(solution_col_dual, basis_col_status):
+    numcol = len(basis_col_status)
+    marg_bnds = np.zeros((2, numcol))
+    for ii in range(numcol):
+        if basis_col_status[ii] == _h.HighsBasisStatus.kLower:
+            marg_bnds[0, ii] = solution_col_dual[ii]
+        elif basis_col_status[ii] == _h.HighsBasisStatus.kUpper:
+            marg_bnds[1, ii] = solution_col_dual[ii]
+    return marg_bnds

--- a/scipy/optimize/tests/meson.build
+++ b/scipy/optimize/tests/meson.build
@@ -20,6 +20,7 @@ py3.install_sources([
     'test_direct.py',
     'test_extending.py',
     'test_hessian_update_strategy.py',
+    'test_highs_wrapper.py',
     'test_isotonic_regression.py',
     'test_lbfgsb_hessinv.py',
     'test_lbfgsb_setulb.py',

--- a/scipy/optimize/tests/test_highs_wrapper.py
+++ b/scipy/optimize/tests/test_highs_wrapper.py
@@ -1,0 +1,33 @@
+"""
+Unit test for the highspy wrapper
+"""
+
+import numpy as np
+import scipy.optimize._highspy._core as _h # type: ignore[import-not-found]
+from scipy.optimize._highspy import _highs_wrapper
+from numpy.testing import assert_allclose
+
+
+def test_get_marg_bnd():
+    col_dual = [1, 2, 3, 4, 5]
+    # Make one of each possible value
+    col_status = [
+        _h.HighsBasisStatus.kLower,
+        _h.HighsBasisStatus.kUpper,
+        _h.HighsBasisStatus.kBasic,
+        _h.HighsBasisStatus.kZero,
+        _h.HighsBasisStatus.kNonbasic,
+    ]
+    desired = np.array([
+        [1, 0, 0, 0, 0],
+        [0, 2, 0, 0, 0],
+    ])
+    actual = _highs_wrapper._get_marg_bnds(col_dual, col_status)
+    assert_allclose(actual, desired)
+
+    # In actual code, this function gets called with lists.
+    # But let's try arrays too.
+    col_dual_np = np.array(col_dual)
+    col_status_np = np.array(col_status)
+    actual = _highs_wrapper._get_marg_bnds(col_dual_np, col_status_np)
+    assert_allclose(actual, desired)


### PR DESCRIPTION
As a follow up to #22660, I have been looking into other places where the highs wrapper code spends a lot of time. I started looking at this Python loop:

```python
    basis_col_status = basis.col_status
    solution_col_dual = solution.col_dual
    for ii in range(numcol):
        if basis_col_status[ii] == _h.HighsBasisStatus.kLower:
            marg_bnds[0, ii] = solution_col_dual[ii]
        elif basis_col_status[ii] == _h.HighsBasisStatus.kUpper:
            marg_bnds[1, ii] = solution_col_dual[ii]
```

In my prior PR, I noted that even after the change I made, it was still spending 6.8% of its time in the loop. As it turns out, this was actually a profiler artifact. The true number is closer to ~1%. The profiler I used, line_profiler, has per-line overhead, and so can overestimate time spent in functions which execute many lines of Python.

Still, it is possible to achieve a speedup for `linprog()` of 0.83% (+/- a 0.075% CI) by vectorizing it and avoiding as much contact with Pybind11 as possible, at least on the reprex found in #22655.

I'm not sure if SciPy would consider the juice worth the squeeze here, but I thought I'd throw this out there and see what people think.

#### Reference issue

Follow up to #22655

#### What does this implement/fix?

This PR does two things.

First, it moves `_get_marg_bnds()` into its own function so that it can be tested separately. Then, it adds a test. (I put this in its own file, as it didn't seem appropriate to put with the `linprog` or `milp` tests.)

Second, it finds the value of `marg_bnds` in the following way:

 * It converts each `HighsBasisStatus` into an integer, then converts the list into an array. I found that `HighsBasisStatus.value` was faster than `HighsBasisStatus.__eq__`, plus we only need to convert into an integer once to handle both the `kLower` and `kUpper` cases.
 * Then, it uses NumPy integer comparisons to check if each column has a status of kLower or kUpper.
 * For row 0, it writes the col_dual into the array using a mask.
 * Similarly for row 1.

#### Additional information

Reprex used to benchmark this change:

<details>

```python
from time import perf_counter
import time
import csv

import numpy as np
from scipy import sparse
from scipy.optimize import linprog
from scipy.sparse import csr_matrix
import functools
import scipy
import os


def coherent_linear_quantile_regression(
    X,
    y,
    *,
    quantiles,
    sample_weight = None,
    coherence_buffer = 3,
):
    """Solve a Coherent Linear Quantile Regression problem.

    Minimizes the quantile loss:

        ∑ᵢ,ⱼ {
                 qⱼ (yᵢ - ŷ⁽ʲ⁾ᵢ) : yᵢ ≥ ŷ⁽ʲ⁾ᵢ,
            (1 - qⱼ)(ŷ⁽ʲ⁾ᵢ - yᵢ) : ŷ⁽ʲ⁾ᵢ > yᵢ
        }

    for the linear model ŷ⁽ʲ⁾ := Xβ⁽ʲ⁾, given an input dataset X, target y, and quantile ranks qⱼ.

    We achieve so-called 'coherent' quantiles by enforcing monotonicity of the predicted quantiles
    with the constraint Xβ⁽ʲ⁾ ≤ Xβ⁽ʲ⁺¹⁾ for each consecutive pair of quantile ranks in an extended
    set of quantile ranks that comprises the requested quantile ranks and a number of auxiliary
    quantile ranks in between.

    The optimization problem is formulated as a linear program by introducing the auxiliary residual
    vectors Δ⁽ʲ⁾⁺, Δ⁽ʲ⁾⁻ ≥ 0 so that Xβ⁽ʲ⁾ - y = Δ⁽ʲ⁾⁺ - Δ⁽ʲ⁾⁻. The objective then becomes
    ∑ᵢ,ⱼ qⱼΔ⁽ʲ⁾⁻ᵢ + (1 - qⱼ)Δ⁽ʲ⁾⁺ᵢ + αt⁽ʲ⁾ᵢ for t⁽ʲ⁾ := |β⁽ʲ⁾|. The L1 regularization parameter α is
    automatically determined to minimize the impact on the solution β.

    Parameters
    ----------
    X
        The feature matrix.
    y
        The target values.
    quantiles
        The quantiles to estimate (between 0 and 1).
    sample_weight
        The optional sample weight to use for each sample.
    coherence_buffer
        The number of auxiliary quantiles to introduce. Smaller is faster, larger yields more
        coherent quantiles.

    Returns
    -------
    β
        The estimated regression coefficients so that Xβ produces quantile predictions ŷ.
    β_full
        The estimated regression coefficients including all auxiliary quantiles.
    """
    # Learn the input dimensions.
    num_samples, num_features = X.shape
    # Add buffer quantile ranks in between the given quantile ranks so that we have an even stronger
    # guarantee on the monotonicity of the predicted quantiles.
    quantiles = np.interp(
        x=np.linspace(0, len(quantiles) - 1, (len(quantiles) - 1) * (1 + coherence_buffer) + 1),
        xp=np.arange(len(quantiles)),
        fp=quantiles,
    ).astype(quantiles.dtype)
    num_quantiles = len(quantiles)
    # Validate the input.
    assert np.array_equal(quantiles, np.sort(quantiles)), "Quantile ranks must be sorted."
    assert sample_weight is None or np.all(sample_weight >= 0), "Sample weights must be >= 0."
    # Normalise the sample weights.
    sample_weight = np.ones(num_samples, dtype=y.dtype) if sample_weight is None else sample_weight
    sample_weight /= np.sum(sample_weight)
    eps = np.finfo(y.dtype).eps
    α = eps**0.25 / (num_quantiles * num_features)
    # Construct the objective function ∑ᵢ,ⱼ qⱼΔ⁽ʲ⁾⁻ᵢ + (1 - qⱼ)Δ⁽ʲ⁾⁺ᵢ + αt⁽ʲ⁾ᵢ for t⁽ʲ⁾ := |β⁽ʲ⁾|.
    c = np.hstack(
        [
            np.zeros(num_quantiles * num_features, dtype=y.dtype),  # β⁽ʲ⁾ for each qⱼ
            α * np.ones(num_quantiles * num_features, dtype=y.dtype),  # t⁽ʲ⁾ for each qⱼ
            np.kron((1 - quantiles) / num_quantiles, sample_weight),  # Δ⁽ʲ⁾⁺ for each qⱼ
            np.kron(quantiles / num_quantiles, sample_weight),  # Δ⁽ʲ⁾⁻ for each qⱼ
        ]
    )
    # Construct the equalities Xβ⁽ʲ⁾ - y = Δ⁽ʲ⁾⁺ - Δ⁽ʲ⁾⁻ for each quantile rank qⱼ.
    A_eq = sparse.hstack(
        [
            # Xβ⁽ʲ⁾ for each qⱼ (block diagonal matrix)
            sparse.kron(sparse.eye(num_quantiles, dtype=X.dtype), X),
            # t⁽ʲ⁾ not used in this constraint
            csr_matrix((num_quantiles * num_samples, num_quantiles * num_features), dtype=X.dtype),
            # -Δ⁽ʲ⁾⁺ for each qⱼ (block diagonal matrix)
            -sparse.eye(num_quantiles * num_samples, dtype=X.dtype),
            # Δ⁽ʲ⁾⁻ for each qⱼ (block diagonal matrix)
            sparse.eye(num_quantiles * num_samples, dtype=X.dtype),
        ]
    )
    b_eq = np.tile(y, num_quantiles)
    # Construct the inequalities -t⁽ʲ⁾ <= β⁽ʲ⁾ <= t⁽ʲ⁾ for each quantile rank qⱼ so that
    # t⁽ʲ⁾ := |β⁽ʲ⁾|. Also construct the monotonicity constraint Xβ⁽ʲ⁾ <= Xβ⁽ʲ⁺¹⁾ for each qⱼ,
    # equivalent to Δ⁽ʲ⁾⁺ - Δ⁽ʲ⁾⁻ <= Δ⁽ʲ⁺¹⁾⁺ - Δ⁽ʲ⁺¹⁾⁻.
    zeros_Δ = csr_matrix(
        (num_quantiles * num_features, 2 * num_quantiles * num_samples), dtype=X.dtype
    )
    zeros_βt = csr_matrix(
        ((num_quantiles - 1) * num_samples, 2 * num_quantiles * num_features), dtype=X.dtype
    )
    A_ub = sparse.vstack(
        [
            sparse.hstack(
                [
                    sparse.eye(num_quantiles * num_features, dtype=X.dtype),  # β⁽ʲ⁾
                    -sparse.eye(num_quantiles * num_features, dtype=X.dtype),  # -t⁽ʲ⁾
                    zeros_Δ,  # Δ⁽ʲ⁾⁺ and Δ⁽ʲ⁾⁺ not used for this constraint
                ]
            ),
            sparse.hstack(
                [
                    -sparse.eye(num_quantiles * num_features, dtype=X.dtype),  # -β⁽ʲ⁾
                    -sparse.eye(num_quantiles * num_features, dtype=X.dtype),  # -t⁽ʲ⁾
                    zeros_Δ,  # Δ⁽ʲ⁾⁺ and Δ⁽ʲ⁾⁺ not used for this constraint
                ]
            ),
            sparse.hstack(
                [
                    zeros_βt,
                    sparse.kron(
                        sparse.diags(
                            diagonals=[1, -1],  # Δ⁽ʲ⁾⁺ - Δ⁽ʲ⁺¹⁾⁺
                            offsets=[0, 1],
                            shape=(num_quantiles - 1, num_quantiles),
                            dtype=X.dtype,
                        ),
                        sparse.eye(num_samples, dtype=X.dtype),
                    ),
                    sparse.kron(
                        sparse.diags(
                            diagonals=[-1, 1],  # -Δ⁽ʲ⁾⁻ + Δ⁽ʲ⁺¹⁾⁻
                            offsets=[0, 1],
                            shape=(num_quantiles - 1, num_quantiles),
                            dtype=X.dtype,
                        ),
                        sparse.eye(num_samples, dtype=X.dtype),
                    ),
                ]
            ),
        ]
    )
    b_ub = np.zeros(A_ub.shape[0], dtype=X.dtype)
    # Construct the bounds.
    bounds = (
        ([(None, None)] * num_quantiles * num_features)  # β⁽ʲ⁾ for each qⱼ
        + ([(0, None)] * num_quantiles * num_features)  # t⁽ʲ⁾ for each qⱼ
        + ([(0, None)] * num_quantiles * num_samples)  # Δ⁽ʲ⁾⁺ for each qⱼ
        + ([(0, None)] * num_quantiles * num_samples)  # Δ⁽ʲ⁾⁻ for each qⱼ
    )
    # Solve the Coherent Quantile Regression LP.
    t0 = perf_counter()
    result = linprog(c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq, bounds=bounds, method="highs")
    t1 = perf_counter()
    # Extract the solution.
    β_full = result.x[: num_quantiles * num_features].astype(y.dtype)
    β_full = β_full.reshape(num_quantiles, num_features).T
    # Drop the buffer quantile ranks we introduced earlier.
    β = β_full[:, 0 :: (coherence_buffer + 1)]
    return β, β_full, t1 - t0


# Construct a problem instance.
np.random.seed(42)
n, d = 500, 5
X = np.random.randn(n, d)
y = np.random.randn(n)
quantiles = np.asarray((0.25, 0.5, 0.75))
#timings = {}

# Not used by benchmark
def time_func_transparent(func, name):
    @functools.wraps(func)
    def func(*args, **kwargs):
        print(f'in {name}')
        t0 = perf_counter()
        ret = func(*args, **kwargs)
        t1 = perf_counter()
        duration = t1 - t0
        timings['name'].append(duration)
        return ret
    if name not in timings:
        timings[name] = []
    return func


from scipy.optimize._highspy import _highs_wrapper
#if hasattr(_highs_wrapper, '_get_marg_bnds'):
#    _get_marg_bnds = _highs_wrapper._get_marg_bnds
#    _highs_wrapper._get_marg_bnds = time_func_transparent(_get_marg_bnds, '_get_marg_bnds')
#    print(id(_get_marg_bnds))
#    print(id(_highs_wrapper._get_marg_bnds))
#_highs_wrapper._highs_wrapper = time_func_transparent(_highs_wrapper._highs_wrapper, 'wrapper')

# Time how long it takes to solve the instance.
durations = []
run_id = os.getpid()
for i in range(7):
    _, _, duration = coherent_linear_quantile_regression(X, y, quantiles=quantiles)
    durations.append(duration)

print("version", scipy.__version__)
print(f"Solved in {min(durations)}s")
path = os.path.expanduser('~/scipy/bench-results.csv')
with open('bench-results.csv', 'at') as f:
    for duration in durations:
        line = ",".join((str(run_id), scipy.__version__, str(duration)))
        f.write(line + '\n')
```

</details>

Output of benchmark program, lower is better:

```
summary stats without filtering
                     mean       std       sem
version                                      
1.14.1           1.570627  0.009306  0.001329
loop with func   1.916735  0.013079  0.000706
main             1.918645  0.012619  0.000681
numpy with func  1.904207  0.013091  0.000707
numpy+operator   1.905540  0.012783  0.000690
Dropping all but min()
                     mean       std       sem
version                                      
1.14.1           1.563484  0.005320  0.002011
loop with func   1.906295  0.006383  0.000912
main             1.909204  0.005652  0.000807
numpy with func  1.893368  0.005159  0.000737
numpy+operator   1.894948  0.005898  0.000843
From now on, express timings as % faster or slower than mean of main branch
                     mean      std      sem           t  plus_minus
version                                                            
1.14.1          -18.10808  0.27865  0.10532 -171.933916    0.206427
loop with func   -0.15237  0.33435  0.04776   -3.190327    0.093610
main              0.00000  0.29604  0.04229    0.000000    0.082888
numpy with func  -0.82947  0.27022  0.03860  -21.488860    0.075656
numpy+operator   -0.74667  0.30890  0.04413  -16.919782    0.086495
```

Details of versions tested:

 * 'main' is commit cf073e0.
 * 'loop with func' is the commit after moving _get_marg_bnds into its own function.
 * 'numpy with func' is the commit after vectorizing _get_marg_bnds.
 * 'numpy+operator' was an attempt at speeding up the list comprehension in _get_marg_bnds using `operator.attrgetter`. It is slower and not included in this PR.
 * '1.14.1' is the prior version of SciPy. It is roughly 18% faster right now, but someday that's going to change...

Source code of benchmark program:

https://gist.github.com/nickodell/3571fbd84cad3739358a69b5d33698d1
