### PR TITLE
DOC: linalg.solve: clarify symmetry requirement

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -85,17 +85,17 @@ def solve(a, b, lower=False, overwrite_a=False,
     corresponding string to ``assume_a`` key chooses the dedicated solver.
     The available options are
 
-    ===================  ================================
-     diagonal             'diagonal'
-     tridiagonal          'tridiagonal'
-     banded               'banded'
-     upper triangular     'upper triangular'
-     lower triangular     'lower triangular'
-     symmetric            'symmetric' (or 'sym')
-     hermitian            'hermitian' (or 'her')
-     positive definite    'positive definite' (or 'pos')
-     general              'general' (or 'gen')
-    ===================  ================================
+    =============================  ================================
+     diagonal                       'diagonal'
+     tridiagonal                    'tridiagonal'
+     banded                         'banded'
+     upper triangular               'upper triangular'
+     lower triangular               'lower triangular'
+     symmetric                      'symmetric' (or 'sym')
+     hermitian                      'hermitian' (or 'her')
+     symmetric positive definite    'positive definite' (or 'pos')
+     general                        'general' (or 'gen')
+    =============================  ================================
 
     Parameters
     ----------
@@ -208,7 +208,8 @@ def solve(a, b, lower=False, overwrite_a=False,
 
     if assume_a not in {None, 'diagonal', 'tridiagonal', 'banded', 'lower triangular',
                         'upper triangular', 'symmetric', 'hermitian',
-                        'positive definite', 'general', 'sym', 'her', 'pos', 'gen'}:
+                        'positive definite', 'symmetric positive definite', 'general',
+                        'sym', 'her', 'pos', 'gen'}:
         raise ValueError(f'{assume_a} is not a recognized matrix structure')
 
     # for a real matrix, describe it as "symmetric", not "hermitian"
@@ -243,7 +244,7 @@ def solve(a, b, lower=False, overwrite_a=False,
     else:
         trans = 0
         norm = '1'
-    
+
     # Currently we do not have the other forms of the norm calculators
     #   lansy, lanpo, lanhe.
     # However, in any case they only reduce computations slightly...

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -208,8 +208,7 @@ def solve(a, b, lower=False, overwrite_a=False,
 
     if assume_a not in {None, 'diagonal', 'tridiagonal', 'banded', 'lower triangular',
                         'upper triangular', 'symmetric', 'hermitian',
-                        'positive definite', 'symmetric positive definite', 'general',
-                        'sym', 'her', 'pos', 'gen'}:
+                        'positive definite', 'general',  'sym', 'her', 'pos', 'gen'}:
         raise ValueError(f'{assume_a} is not a recognized matrix structure')
 
     # for a real matrix, describe it as "symmetric", not "hermitian"

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -208,7 +208,7 @@ def solve(a, b, lower=False, overwrite_a=False,
 
     if assume_a not in {None, 'diagonal', 'tridiagonal', 'banded', 'lower triangular',
                         'upper triangular', 'symmetric', 'hermitian',
-                        'positive definite', 'general',  'sym', 'her', 'pos', 'gen'}:
+                        'positive definite', 'general', 'sym', 'her', 'pos', 'gen'}:
         raise ValueError(f'{assume_a} is not a recognized matrix structure')
 
     # for a real matrix, describe it as "symmetric", not "hermitian"


### PR DESCRIPTION
The `assume_a` argument in `scipy.linalg.solve` allows to specify that a matrix is positive definite.
It then assumes that the matrix is symmetric as well. Some authors (for instance the English wikipedia) define "positive definite" such that it is always symmetric, but others (for instance the German wikipedia, but I think also many other English sources) do not.

I added "symmetric" to the description in table to avoid ambiguity.

I also changed the code so that it accepts `assume_a="symmetric positive definite"`.