### PR TITLE
MAINT: ndimage.maximum_filter: recommend `vectorized_filter` for NaN control

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1861,6 +1861,8 @@ def maximum_filter(input, size=None, footprint=None, output=None,
     A sequence of modes (one per axis) is only supported when the footprint is
     separable. Otherwise, a single mode string must be provided.
 
+    %(nan)s
+
     Examples
     --------
     >>> from scipy import ndimage, datasets


### PR DESCRIPTION
#### Reference issue
Closes gh-9077

#### What does this implement/fix?
gh-9077 (and the recently closed gh-7818) note issues with `ndimage` filters when there are NaNs present in the data. This adds the following to the Notes of `maximum_filter`[^1].

> The behavior of this function with NaN elements is undefined. To control behavior in the presence of NaNs, consider using [vectorized_filter](https://scipy.github.io/devdocs/reference/generated/scipy.ndimage.vectorized_filter.html#scipy.ndimage.vectorized_filter).

If desired, it would be easy to add this consistently to the rest of the filter functions since it uses the existing docfiller machinery. LMK either way, and once that's addressed, I can mark this ready for review.

[^1]: Already added to [`uniform_filter`](https://scipy.github.io/devdocs/reference/generated/scipy.ndimage.uniform_filter.html#scipy.ndimage.uniform_filter).