### PR TITLE
DOC: optimize: Clarify use of `xtol` in 1D rootfinder docstrings

### DIFF
--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -513,11 +513,11 @@ def bisect(f, a, b, args=(),
     b : scalar
         The other end of the bracketing interval [a,b].
     xtol : number, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter must be positive.
     rtol : number, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter cannot be smaller than its default value of
         ``4*np.finfo(float).eps``.
@@ -595,11 +595,11 @@ def ridder(f, a, b, args=(),
     b : scalar
         The other end of the bracketing interval [a,b].
     xtol : number, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter must be positive.
     rtol : number, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter cannot be smaller than its default value of
         ``4*np.finfo(float).eps``.
@@ -710,13 +710,13 @@ def brentq(f, a, b, args=(),
     b : scalar
         The other end of the bracketing interval :math:`[a, b]`.
     xtol : number, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter must be positive. For nice functions, Brent's
         method will often satisfy the above condition with ``xtol/2``
         and ``rtol/2``. [Brent1973]_
     rtol : number, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter cannot be smaller than its default value of
         ``4*np.finfo(float).eps``. For nice functions, Brent's
@@ -828,13 +828,13 @@ def brenth(f, a, b, args=(),
     b : scalar
         The other end of the bracketing interval [a,b].
     xtol : number, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter must be positive. As with `brentq`, for nice
         functions the method will often satisfy the above condition
         with ``xtol/2`` and ``rtol/2``.
     rtol : number, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter cannot be smaller than its default value of
         ``4*np.finfo(float).eps``. As with `brentq`, for nice functions
@@ -1292,11 +1292,11 @@ def toms748(f, a, b, args=(), k=1,
         The number of Newton quadratic steps to perform each
         iteration. ``k>=1``.
     xtol : scalar, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
         parameter must be positive.
     rtol : scalar, optional
-        The computed root ``x0`` will satisfy ``np.allclose(x, x0,
+        The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root.
     maxiter : int, optional
         If convergence is not achieved in `maxiter` iterations, an error is

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -544,6 +544,21 @@ def bisect(f, a, b, args=(),
         Object containing information about the convergence. In particular,
         ``r.converged`` is True if the routine converged.
 
+    Notes
+    -----
+    As mentioned in the parameter documentation, the computed root ``x0`` will
+    satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
+    exact root. In equation form, this terminating condition is ``abs(x - x0)
+    <= xtol + rtol * abs(x)``.
+
+    A nonzero value of `xtol` may be useful for saving function evaluations
+    when a root is near zero in applications where the tiny absolute
+    differences available between floating point numbers near zero are not
+    meaningful. The default value ``xtol=2e-12`` may lead to surprising
+    behavior if one expects `bisect` to always compute roots with relative
+    error near machine precision. Care should be taken to select `xtol` for the
+    use case at hand.
+
     Examples
     --------
 
@@ -641,6 +656,19 @@ def ridder(f, a, b, args=(),
 
     The routine used here diverges slightly from standard presentations in
     order to be a bit more careful of tolerance.
+
+    As mentioned in the parameter documentation, the computed root ``x0`` will
+    satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
+    exact root. In equation form, this terminating condition is ``abs(x - x0)
+    <= xtol + rtol * abs(x)``.
+
+    A nonzero value of `xtol` may be useful for saving function evaluations
+    when a root is near zero in applications where the tiny absolute
+    differences available between floating point numbers near zero are not
+    meaningful. The default value ``xtol=2e-12`` may lead to surprising
+    behavior if one expects `ridder` to always compute roots with relative
+    error near machine precision. Care should be taken to select `xtol` for the
+    use case at hand.
 
     References
     ----------
@@ -760,6 +788,19 @@ def brentq(f, a, b, args=(),
     -----
     `f` must be continuous.  f(a) and f(b) must have opposite signs.
 
+    As mentioned in the parameter documentation, the computed root ``x0`` will
+    satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
+    exact root. In equation form, this terminating condition is ``abs(x - x0)
+    <= xtol + rtol * abs(x)``.
+
+    A nonzero value of `xtol` may be useful for saving function evaluations
+    when a root is near zero in applications where the tiny absolute
+    differences available between floating point numbers near zero are not
+    meaningful. The default value ``xtol=2e-12`` may lead to surprising
+    behavior if one expects `brentq` to always compute roots with relative
+    error near machine precision. Care should be taken to select `xtol` for the
+    use case at hand.
+
     References
     ----------
     .. [Brent1973]
@@ -873,6 +914,20 @@ def brenth(f, a, b, args=(),
     fsolve : N-D root-finding
     brentq, ridder, bisect, newton : 1-D root-finding
     fixed_point : scalar fixed-point finder
+    Notes
+    -----
+    As mentioned in the parameter documentation, the computed root ``x0`` will
+    satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
+    exact root. In equation form, this terminating condition is ``abs(x - x0)
+    <= xtol + rtol * abs(x)``.
+
+    A nonzero value of `xtol` may be useful for saving function evaluations
+    when a root is near zero in applications where the tiny absolute
+    differences available between floating point numbers near zero are not
+    meaningful. The default value ``xtol=2e-12`` may lead to surprising
+    behavior if one expects `brenth` to always compute roots with relative
+    error near machine precision. Care should be taken to select `brenth` for the
+    use case at hand.
 
     References
     ----------
@@ -1343,6 +1398,19 @@ def toms748(f, a, b, args=(), k=1,
     For higher values of `k`, the efficiency index approaches
     the kth root of ``(3k-2)``, hence ``k=1`` or ``k=2`` are
     usually appropriate.
+
+    As mentioned in the parameter documentation, the computed root ``x0`` will
+    satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
+    exact root. In equation form, this terminating condition is ``abs(x - x0)
+    <= xtol + rtol * abs(x)``.
+
+    A nonzero value of `xtol` may be useful for saving function evaluations
+    when a root is near zero in applications where the tiny absolute
+    differences available between floating point numbers near zero are not
+    meaningful. The default value ``xtol=2e-12`` may lead to surprising
+    behavior if one expects `toms748` to always compute roots with relative
+    error near machine precision. Care should be taken to select `xtol` for the
+    use case at hand.
 
     References
     ----------

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -549,7 +549,7 @@ def bisect(f, a, b, args=(),
     As mentioned in the parameter documentation, the computed root ``x0`` will
     satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
     exact root. In equation form, this terminating condition is ``abs(x - x0)
-    <= xtol + rtol * abs(x)``.
+    <= xtol + rtol * abs(x0)``.
 
     The default value ``xtol=2e-12`` may lead to surprising behavior if one
     expects `bisect` to always compute roots with relative error near machine

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -663,7 +663,7 @@ def ridder(f, a, b, args=(),
     As mentioned in the parameter documentation, the computed root ``x0`` will
     satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
     exact root. In equation form, this terminating condition is ``abs(x - x0)
-    <= xtol + rtol * abs(x)``.
+    <= xtol + rtol * abs(x0)``.
 
     The default value ``xtol=2e-12`` may lead to surprising behavior if one
     expects `ridder` to always compute roots with relative error near machine
@@ -796,7 +796,7 @@ def brentq(f, a, b, args=(),
     As mentioned in the parameter documentation, the computed root ``x0`` will
     satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
     exact root. In equation form, this terminating condition is ``abs(x - x0)
-    <= xtol + rtol * abs(x)``.
+    <= xtol + rtol * abs(x0)``.
 
     The default value ``xtol=2e-12`` may lead to surprising behavior if one
     expects `brentq` to always compute roots with relative error near machine
@@ -927,7 +927,7 @@ def brenth(f, a, b, args=(),
     As mentioned in the parameter documentation, the computed root ``x0`` will
     satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
     exact root. In equation form, this terminating condition is ``abs(x - x0)
-    <= xtol + rtol * abs(x)``.
+    <= xtol + rtol * abs(x0)``.
 
     The default value ``xtol=2e-12`` may lead to surprising behavior if one
     expects `brenth` to always compute roots with relative error near machine
@@ -1412,7 +1412,7 @@ def toms748(f, a, b, args=(), k=1,
     As mentioned in the parameter documentation, the computed root ``x0`` will
     satisfy ``np.isclose(x, x0, atol=xtol, rtol=rtol)``, where ``x`` is the
     exact root. In equation form, this terminating condition is ``abs(x - x0)
-    <= xtol + rtol * abs(x)``.
+    <= xtol + rtol * abs(x0)``.
 
     The default value ``xtol=2e-12`` may lead to surprising behavior if one
     expects `toms748` to always compute roots with relative error near machine

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -580,6 +580,7 @@ def bisect(f, a, b, args=(),
     brentq, brenth, bisect, newton
     fixed_point : scalar fixed-point finder
     fsolve : n-dimensional root-finding
+    elementwise.find_root : Efficient elementwise 1-D root-finder.
 
     """
     if not isinstance(args, tuple):
@@ -645,6 +646,7 @@ def ridder(f, a, b, args=(),
     --------
     brentq, brenth, bisect, newton : 1-D root-finding
     fixed_point : scalar fixed-point finder
+    elementwise.find_root : Efficient elementwise 1-D root-finder.
 
     Notes
     -----
@@ -783,6 +785,7 @@ def brentq(f, a, b, args=(),
     fsolve : N-D root-finding
     brenth, ridder, bisect, newton : 1-D root-finding
     fixed_point : scalar fixed-point finder
+    elementwise.find_root : Efficient elementwise 1-D root-finder.
 
     Notes
     -----
@@ -914,6 +917,8 @@ def brenth(f, a, b, args=(),
     fsolve : N-D root-finding
     brentq, ridder, bisect, newton : 1-D root-finding
     fixed_point : scalar fixed-point finder
+    elementwise.find_root : Efficient elementwise 1-D root-finder.
+
     Notes
     -----
     As mentioned in the parameter documentation, the computed root ``x0`` will
@@ -1377,6 +1382,7 @@ def toms748(f, a, b, args=(), k=1,
     --------
     brentq, brenth, ridder, bisect, newton
     fsolve : find roots in N dimensions.
+    elementwise.find_root : Efficient elementwise 1-D root-finder.
 
     Notes
     -----

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -581,7 +581,7 @@ def bisect(f, a, b, args=(),
     brentq, brenth, bisect, newton
     fixed_point : scalar fixed-point finder
     fsolve : n-dimensional root-finding
-    elementwise.find_root : Efficient elementwise 1-D root-finder.
+    elementwise.find_root : efficient elementwise 1-D root-finder
 
     """
     if not isinstance(args, tuple):
@@ -647,7 +647,7 @@ def ridder(f, a, b, args=(),
     --------
     brentq, brenth, bisect, newton : 1-D root-finding
     fixed_point : scalar fixed-point finder
-    elementwise.find_root : Efficient elementwise 1-D root-finder.
+    elementwise.find_root : efficient elementwise 1-D root-finder
 
     Notes
     -----
@@ -787,7 +787,7 @@ def brentq(f, a, b, args=(),
     fsolve : N-D root-finding
     brenth, ridder, bisect, newton : 1-D root-finding
     fixed_point : scalar fixed-point finder
-    elementwise.find_root : Efficient elementwise 1-D root-finder.
+    elementwise.find_root : efficient elementwise 1-D root-finder
 
     Notes
     -----
@@ -920,7 +920,7 @@ def brenth(f, a, b, args=(),
     fsolve : N-D root-finding
     brentq, ridder, bisect, newton : 1-D root-finding
     fixed_point : scalar fixed-point finder
-    elementwise.find_root : Efficient elementwise 1-D root-finder.
+    elementwise.find_root : efficient elementwise 1-D root-finder
 
     Notes
     -----
@@ -1386,7 +1386,7 @@ def toms748(f, a, b, args=(), k=1,
     --------
     brentq, brenth, ridder, bisect, newton
     fsolve : find roots in N dimensions.
-    elementwise.find_root : Efficient elementwise 1-D root-finder.
+    elementwise.find_root : efficient elementwise 1-D root-finder
 
     Notes
     -----

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -551,13 +551,14 @@ def bisect(f, a, b, args=(),
     exact root. In equation form, this terminating condition is ``abs(x - x0)
     <= xtol + rtol * abs(x)``.
 
-    A nonzero value of `xtol` may be useful for saving function evaluations
-    when a root is near zero in applications where the tiny absolute
-    differences available between floating point numbers near zero are not
-    meaningful. The default value ``xtol=2e-12`` may lead to surprising
-    behavior if one expects `bisect` to always compute roots with relative
-    error near machine precision. Care should be taken to select `xtol` for the
-    use case at hand.
+    The default value ``xtol=2e-12`` may lead to surprising behavior if one
+    expects `bisect` to always compute roots with relative error near machine
+    precision. Care should be taken to select `xtol` for the use case at hand.
+    Setting ``xtol=5e-324``, the smallest subnormal number, will ensure the
+    highest level of accuracy. Larger values of `xtol` may be useful for saving
+    function evaluations when a root is at or near zero in applications where
+    the tiny absolute differences available between floating point numbers near
+    zero are not meaningful.
 
     Examples
     --------
@@ -664,13 +665,14 @@ def ridder(f, a, b, args=(),
     exact root. In equation form, this terminating condition is ``abs(x - x0)
     <= xtol + rtol * abs(x)``.
 
-    A nonzero value of `xtol` may be useful for saving function evaluations
-    when a root is near zero in applications where the tiny absolute
-    differences available between floating point numbers near zero are not
-    meaningful. The default value ``xtol=2e-12`` may lead to surprising
-    behavior if one expects `ridder` to always compute roots with relative
-    error near machine precision. Care should be taken to select `xtol` for the
-    use case at hand.
+    The default value ``xtol=2e-12`` may lead to surprising behavior if one
+    expects `ridder` to always compute roots with relative error near machine
+    precision. Care should be taken to select `xtol` for the use case at hand.
+    Setting ``xtol=5e-324``, the smallest subnormal number, will ensure the
+    highest level of accuracy. Larger values of `xtol` may be useful for saving
+    function evaluations when a root is at or near zero in applications where
+    the tiny absolute differences available between floating point numbers near
+    zero are not meaningful.
 
     References
     ----------
@@ -796,13 +798,14 @@ def brentq(f, a, b, args=(),
     exact root. In equation form, this terminating condition is ``abs(x - x0)
     <= xtol + rtol * abs(x)``.
 
-    A nonzero value of `xtol` may be useful for saving function evaluations
-    when a root is near zero in applications where the tiny absolute
-    differences available between floating point numbers near zero are not
-    meaningful. The default value ``xtol=2e-12`` may lead to surprising
-    behavior if one expects `brentq` to always compute roots with relative
-    error near machine precision. Care should be taken to select `xtol` for the
-    use case at hand.
+    The default value ``xtol=2e-12`` may lead to surprising behavior if one
+    expects `brentq` to always compute roots with relative error near machine
+    precision. Care should be taken to select `xtol` for the use case at hand.
+    Setting ``xtol=5e-324``, the smallest subnormal number, will ensure the
+    highest level of accuracy. Larger values of `xtol` may be useful for saving
+    function evaluations when a root is at or near zero in applications where
+    the tiny absolute differences available between floating point numbers near
+    zero are not meaningful.
 
     References
     ----------
@@ -926,13 +929,14 @@ def brenth(f, a, b, args=(),
     exact root. In equation form, this terminating condition is ``abs(x - x0)
     <= xtol + rtol * abs(x)``.
 
-    A nonzero value of `xtol` may be useful for saving function evaluations
-    when a root is near zero in applications where the tiny absolute
-    differences available between floating point numbers near zero are not
-    meaningful. The default value ``xtol=2e-12`` may lead to surprising
-    behavior if one expects `brenth` to always compute roots with relative
-    error near machine precision. Care should be taken to select `brenth` for the
-    use case at hand.
+    The default value ``xtol=2e-12`` may lead to surprising behavior if one
+    expects `brenth` to always compute roots with relative error near machine
+    precision. Care should be taken to select `xtol` for the use case at hand.
+    Setting ``xtol=5e-324``, the smallest subnormal number, will ensure the
+    highest level of accuracy. Larger values of `xtol` may be useful for saving
+    function evaluations when a root is at or near zero in applications where
+    the tiny absolute differences available between floating point numbers near
+    zero are not meaningful.
 
     References
     ----------
@@ -1410,13 +1414,14 @@ def toms748(f, a, b, args=(), k=1,
     exact root. In equation form, this terminating condition is ``abs(x - x0)
     <= xtol + rtol * abs(x)``.
 
-    A nonzero value of `xtol` may be useful for saving function evaluations
-    when a root is near zero in applications where the tiny absolute
-    differences available between floating point numbers near zero are not
-    meaningful. The default value ``xtol=2e-12`` may lead to surprising
-    behavior if one expects `toms748` to always compute roots with relative
-    error near machine precision. Care should be taken to select `xtol` for the
-    use case at hand.
+    The default value ``xtol=2e-12`` may lead to surprising behavior if one
+    expects `toms748` to always compute roots with relative error near machine
+    precision. Care should be taken to select `xtol` for the use case at hand.
+    Setting ``xtol=5e-324``, the smallest subnormal number, will ensure the
+    highest level of accuracy. Larger values of `xtol` may be useful for saving
+    function evaluations when a root is at or near zero in applications where
+    the tiny absolute differences available between floating point numbers near
+    zero are not meaningful.
 
     References
     ----------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-18740

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR makes a docs fix to the problem reported in gh-18740 for `bisect`. The problem was that a choice of the default absolute tolerance `xtol` for deciding convergence can lead to very large relative errors for roots near zero because the absolute error is deemed small enough. In that issue, @mdhaber and I both agreed that a smaller default would make more sense if starting from scratch but that it's better to be cautious about changing defaults in widely used, over 20-year-old code. Instead, this just clarifies documentation of the termination condition, makes users aware of potential surprises due to the default value of `xtol`, and suggests taking care to select `xtol` for the use case at hand.

I've also changed appearances of `np.allclose` in the documentation of the termination condition to `np.isclose`, which I think makes more sense in a scalar context, and added `scipy.optimize.elementwise.find_root` to the `See Also` sections of the other bracketing root finders.

#### Additional information
<!--Any additional information you think is important.-->
I didn't make any mention of setting `xtol` to the smallest subnormal to o