### PR TITLE
MAINT: bump musl image

### DIFF
--- a/.github/workflows/musllinux.yml
+++ b/.github/workflows/musllinux.yml
@@ -35,7 +35,7 @@ jobs:
     container:
       # Use container used for building musllinux wheels
       # it has git installed, all the pythons, etc
-      image: quay.io/pypa/musllinux_1_1_x86_64
+      image: quay.io/pypa/musllinux_1_2_x86_64
 
 
     steps:


### PR DESCRIPTION
Bumps the musl image used in CI. Corresponds to the default cibuildwheel image, and the image used for building numpy wheels.