### PR TITLE
DOC: ndimage.affine_transformation: add examples to docstring

### DIFF
--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -537,25 +537,31 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     --------
     Use the ``affine_transform`` to stretch an image::
 
-        from scipy.ndimage import affine_transform
-        from scipy.datasets import face
-        from matplotlib import pyplot as plt
+    >>> from scipy.ndimage import affine_transform
+    >>> from scipy.datasets import face
+    >>> from matplotlib import pyplot as plt
 
-        im = face(gray=True)
-        matrix = (0.5, 2)
-        im2 = affine_transform(im, matrix)
+    >>> im = face(gray=True)
+    >>> matrix = (0.5, 2)
+    >>> im2 = affine_transform(im, matrix)
 
-        plt.imshow(im2)
-        plt.savefig("tmp2.png")
+    >>> plt.imshow(im2)
 
-    Rotation an image by 90 degrees and project it onto an expanded canvas
+    Rotate an image by 90 degrees and project it onto an expanded canvas::
 
-        matrix = ((0, 1), (1, 0))
-        im2 = affine_transform(im, matrix, output_shape=(1024, 1024))
+    >>> matrix = ((0, 1), (1, 0))
+    >>> im2 = affine_transform(im, matrix, output_shape=(1024, 1024))
 
-        plt.imshow(im2)
-        plt.savefig("tmp.png")
+    >>> plt.imshow(im2)
 
+    Offset the rotation so that the image is centred::
+
+    >>> matrix = ((0, 1), (1, 0))
+    >>> output_shape = (1200, 1200)
+    >>> offset = (np.array(im.shape) - output_shape) / 2
+    >>> im2 = affine_transform(im, matrix, offset=offset, output_shape=output_shape)
+
+    >>> plt.imshow(im2)
 
     Notes
     -----

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -553,7 +553,6 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         im2 = affine_transform(im, matrix, output_shape=(1024, 1024))
 
         plt.imshow(im2)
-        plt.savefig("tmp.png")
 
 
     Notes

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -537,6 +537,10 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     --------
     Use the ``affine_transform`` to stretch an image::
 
+        from scipy.ndimage import affine_transform
+        from scipy.datasets import face
+        from matplotlib import pyplot as plt
+
         im = face(gray=True)
         matrix = (0.5, 2)
         im2 = affine_transform(im, matrix)

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -533,6 +533,26 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     affine_transform : ndarray
         The transformed input.
 
+    Examples
+    --------
+    Use the ``affine_transform`` to stretch an image::
+
+        im = face(gray=True)
+        matrix = (0.5, 2)
+        im2 = affine_transform(im, matrix)
+
+        plt.imshow(im2)
+        plt.savefig("tmp2.png")
+
+    Rotation an image by 90 degrees and project it onto an expanded canvas
+
+        matrix = ((0, 1), (1, 0))
+        im2 = affine_transform(im, matrix, output_shape=(1024, 1024))
+
+        plt.imshow(im2)
+        plt.savefig("tmp.png")
+
+
     Notes
     -----
     The given matrix and offset are used to find for each point in the

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -546,7 +546,6 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         im2 = affine_transform(im, matrix)
 
         plt.imshow(im2)
-        plt.savefig("tmp2.png")
 
     Rotation an image by 90 degrees and project it onto an expanded canvas
 

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -535,7 +535,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
 
     Examples
     --------
-    Use the ``affine_transform`` to stretch an image::
+    Use the `affine_transform` to stretch an image::
 
     >>> from scipy.ndimage import affine_transform
     >>> from scipy.datasets import face

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -535,7 +535,7 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
 
     Examples
     --------
-    Use the `affine_transform` to stretch an image::
+    Use `affine_transform` to stretch an image::
 
     >>> from scipy.ndimage import affine_transform
     >>> from scipy.datasets import face

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -544,8 +544,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     >>> im = face(gray=True)
     >>> matrix = (0.5, 2)
     >>> im2 = affine_transform(im, matrix)
-
     >>> plt.imshow(im2)
+    >>> plt.show()
 
     Rotate an image by 90 degrees and project it onto an expanded canvas::
 

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -551,8 +551,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
 
     >>> matrix = ((0, 1), (1, 0))
     >>> im3 = affine_transform(im, matrix, output_shape=(1024, 1024))
-
     >>> plt.imshow(im3)
+    >>> plt.show()
 
     Offset the rotation so that the image is centred::
 

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -560,8 +560,8 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     >>> output_shape = (1200, 1200)
     >>> offset = (np.array(im.shape) - output_shape) / 2
     >>> im4 = affine_transform(im, matrix, offset=offset, output_shape=output_shape)
-
     >>> plt.imshow(im4)
+    >>> plt.show()
 
     Notes
     -----

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -541,7 +541,6 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
     >>> from scipy.datasets import face
     >>> from matplotlib import pyplot as plt
     >>> import numpy as np
-
     >>> im = face(gray=True)
     >>> matrix = (0.5, 2)
     >>> im2 = affine_transform(im, matrix)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

[Issue 7168 - DOC: Add "Examples" to docstrings](https://github.com/scipy/scipy/issues/7168)

#### What does this implement/fix?
<!--Please explain your changes.-->

I have added some example code to the docstring for ``scipy.ndarray.interpolation.affine_transform``

#### Additional information
<!--Any additional information you think is important.-->

I'm happy to delete the matplotlib figures if they are inappropriate
