### PR TITLE
MAINT: integrate: break dependency on optimize

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1189,6 +1189,53 @@ class _RichResult(dict):
         return list(self.keys())
 
 
+# moved from scipy.optimize._optimize.py so that scipy.integrate does not need to have
+# a dependancy on scipy.optimize
+class OptimizeResult(_RichResult):
+    """
+    Represents the optimization result.
+
+    Attributes
+    ----------
+    x : ndarray
+        The solution of the optimization.
+    success : bool
+        Whether or not the optimizer exited successfully.
+    status : int
+        Termination status of the optimizer. Its value depends on the
+        underlying solver. Refer to `message` for details.
+    message : str
+        Description of the cause of the termination.
+    fun : float
+        Value of objective function at `x`.
+    jac, hess : ndarray
+        Values of objective function's Jacobian and its Hessian at `x` (if
+        available). The Hessian may be an approximation, see the documentation
+        of the function in question.
+    hess_inv : object
+        Inverse of the objective function's Hessian; may be an approximation.
+        Not available for all solvers. The type of this attribute may be
+        either np.ndarray or scipy.sparse.linalg.LinearOperator.
+    nfev, njev, nhev : int
+        Number of evaluations of the objective functions and of its
+        Jacobian and Hessian.
+    nit : int
+        Number of iterations performed by the optimizer.
+    maxcv : float
+        The maximum constraint violation.
+
+    Notes
+    -----
+    Depending on the specific solver being used, `OptimizeResult` may
+    not have all attributes listed here, and they may have additional
+    attributes not listed here. Since this class is essentially a
+    subclass of dict with attribute accessors, one can see which
+    attributes are available using the `OptimizeResult.keys` method.
+
+    """
+    pass
+
+
 def _indenter(s, n=0):
     """
     Ensures that lines after the first are indented by the specified amount

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -4,6 +4,7 @@ import pytest
 import numpy as np
 
 import scipy._lib._elementwise_iterative_method as eim
+from scipy._lib._util import OptimizeResult
 import scipy._lib.array_api_extra as xpx
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal, xp_assert_less
 from scipy._lib._array_api import is_numpy, is_torch
@@ -593,14 +594,14 @@ class TestJacobian(JacobianHessianTest):
         res01 = jacobian(lambda y: df1_0xy(z[0], y), z[1:2], initial_step=10)
         res10 = jacobian(lambda x: df1_1xy(x, z[1]), z[0:1], initial_step=10)
         res11 = jacobian(lambda y: df1_1xy(z[0], y), z[1:2], initial_step=10)
-        ref = optimize.OptimizeResult()
+        ref = OptimizeResult()
         for attr in ['success', 'status', 'df', 'nit', 'nfev']:
             ref_attr = xp.asarray([[getattr(res00, attr), getattr(res01, attr)],
                                    [getattr(res10, attr), getattr(res11, attr)]])
             ref[attr] = xp.squeeze(
                 ref_attr,
                 axis=tuple(ax for ax, size in enumerate(ref_attr.shape) if size == 1)
-            )            
+            )
             rtol = 1.5e-5 if res[attr].dtype == xp.float32 else 1.5e-14
             xp_assert_close(res[attr], ref[attr], rtol=rtol)
 

--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -6,7 +6,7 @@ from numpy.linalg import pinv
 
 from scipy.sparse import coo_matrix, csc_matrix
 from scipy.sparse.linalg import splu
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 
 
 EPS = np.finfo(float).eps

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -4,7 +4,7 @@ from .bdf import BDF
 from .radau import Radau
 from .rk import RK23, RK45, DOP853
 from .lsoda import LSODA
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 from .common import EPS, OdeSolution
 from .base import OdeSolver
 

--- a/scipy/optimize/_cobyla_py.py
+++ b/scipy/optimize/_cobyla_py.py
@@ -14,9 +14,9 @@ import functools
 from threading import RLock
 
 import numpy as np
+from scipy._lib._util import OptimizeResult
 from scipy.optimize import _cobyla as cobyla
-from ._optimize import (OptimizeResult, _check_unknown_options,
-    _prepare_scalar_function)
+from ._optimize import _check_unknown_options, _prepare_scalar_function
 try:
     from itertools import izip
 except ImportError:

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -6,12 +6,12 @@ import warnings
 
 import numpy as np
 
-from scipy.optimize import OptimizeResult, minimize
+from scipy.optimize import minimize
 from scipy.optimize._constraints import (Bounds, new_bounds_to_old,
                                          NonlinearConstraint, LinearConstraint)
 from scipy.optimize._optimize import _status_message, _wrap_callback
-from scipy._lib._util import (check_random_state, MapWrapper, _FunctionWrapper,
-                              rng_integers, _transition_to_rng)
+from scipy._lib._util import (OptimizeResult, check_random_state, MapWrapper,
+                              _FunctionWrapper, rng_integers, _transition_to_rng)
 from scipy._lib._sparse import issparse
 
 

--- a/scipy/optimize/_direct_py.py
+++ b/scipy/optimize/_direct_py.py
@@ -3,7 +3,7 @@ from typing import (  # noqa: UP035
 )
 
 import numpy as np
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 from ._constraints import old_bound_to_new, Bounds
 from ._direct import direct as _direct  # type: ignore
 

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -8,7 +8,7 @@ A Dual Annealing global optimization algorithm
 """
 
 import numpy as np
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 from scipy.optimize import minimize, Bounds
 from scipy.special import gammaln
 from scipy._lib._util import check_random_state, _transition_to_rng

--- a/scipy/optimize/_isotonic.py
+++ b/scipy/optimize/_isotonic.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from ._optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 from ._pava_pybind import pava
 
 if TYPE_CHECKING:

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -35,8 +35,10 @@ Functions
 
 import numpy as np
 from numpy import array, asarray, float64, zeros
+
+from scipy._lib._util import OptimizeResult
 from . import _lbfgsb
-from ._optimize import (MemoizeJac, OptimizeResult, _call_callback_maybe_halt,
+from ._optimize import (MemoizeJac, _call_callback_maybe_halt,
                         _wrap_callback, _check_unknown_options,
                         _prepare_scalar_function)
 from ._constraints import old_bound_to_new

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -16,7 +16,8 @@ Functions
 
 import numpy as np
 
-from ._optimize import OptimizeResult, OptimizeWarning
+from scipy._lib._util import OptimizeResult
+from ._optimize import OptimizeWarning
 from warnings import warn
 from ._linprog_highs import _linprog_highs
 from ._linprog_ip import _linprog_ip

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -15,7 +15,9 @@ References
 
 import inspect
 import numpy as np
-from ._optimize import OptimizeWarning, OptimizeResult
+
+from scipy._lib._util import OptimizeResult
+from ._optimize import OptimizeWarning
 from warnings import warn
 from ._highspy._highs_wrapper import _highs_wrapper
 from ._highspy._core import(

--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -20,10 +20,11 @@ References
 
 import numpy as np
 import scipy as sp
+from scipy._lib._util import OptimizeResult
 import scipy.sparse as sps
 from warnings import warn
 from scipy.linalg import LinAlgError
-from ._optimize import OptimizeWarning, OptimizeResult, _check_unknown_options
+from ._optimize import OptimizeWarning, _check_unknown_options
 from ._linprog_util import _postsolve
 has_umfpack = True
 has_cholmod = True

--- a/scipy/optimize/_linprog_rs.py
+++ b/scipy/optimize/_linprog_rs.py
@@ -25,7 +25,7 @@ from ._optimize import _check_unknown_options
 from ._bglu_dense import LU
 from ._bglu_dense import BGLU as BGLU
 from ._linprog_util import _postsolve
-from ._optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 
 
 def _phase_one(A, b, x0, callback, postsolve_args, maxiter, tol, disp,

--- a/scipy/optimize/_linprog_simplex.py
+++ b/scipy/optimize/_linprog_simplex.py
@@ -30,7 +30,9 @@ References
 
 import numpy as np
 from warnings import warn
-from ._optimize import OptimizeResult, OptimizeWarning, _check_unknown_options
+
+from scipy._lib._util import OptimizeResult
+from ._optimize import OptimizeWarning, _check_unknown_options
 from ._linprog_util import _postsolve
 
 

--- a/scipy/optimize/_lsq/bvls.py
+++ b/scipy/optimize/_lsq/bvls.py
@@ -1,7 +1,7 @@
 """Bounded-variable least-squares algorithm."""
 import numpy as np
 from numpy.linalg import norm, lstsq
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 
 from .common import print_header_linear, print_iteration_linear
 

--- a/scipy/optimize/_lsq/dogbox.py
+++ b/scipy/optimize/_lsq/dogbox.py
@@ -44,7 +44,7 @@ import numpy as np
 from numpy.linalg import lstsq, norm
 
 from scipy.sparse.linalg import LinearOperator, aslinearoperator, lsmr
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 from scipy._lib._util import _call_callback_maybe_halt
 
 

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -5,11 +5,11 @@ import numpy as np
 from numpy.linalg import norm
 
 from scipy.sparse.linalg import LinearOperator
-from scipy.optimize import _minpack, OptimizeResult
+from scipy.optimize import _minpack
 from scipy.optimize._numdiff import approx_derivative, group_columns
 from scipy.optimize._minimize import Bounds
 from scipy._lib._sparse import issparse
-from scipy._lib._util import _workers_wrapper
+from scipy._lib._util import OptimizeResult, _workers_wrapper
 
 from .trf import trf
 from .dogbox import dogbox

--- a/scipy/optimize/_lsq/lsq_linear.py
+++ b/scipy/optimize/_lsq/lsq_linear.py
@@ -3,7 +3,7 @@ import numpy as np
 from numpy.linalg import norm
 from scipy.sparse import issparse, csr_array
 from scipy.sparse.linalg import LinearOperator, lsmr
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 from scipy.optimize._minimize import Bounds
 
 from .common import in_bounds, compute_grad

--- a/scipy/optimize/_lsq/trf.py
+++ b/scipy/optimize/_lsq/trf.py
@@ -97,7 +97,7 @@ import numpy as np
 from numpy.linalg import norm
 from scipy.linalg import svd, qr
 from scipy.sparse.linalg import lsmr
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 
 from .common import (
     step_size_to_bound, find_active_constraints, in_bounds,

--- a/scipy/optimize/_lsq/trf_linear.py
+++ b/scipy/optimize/_lsq/trf_linear.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.linalg import norm
 from scipy.linalg import qr, solve_triangular
 from scipy.sparse.linalg import lsmr
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 
 from .givens_elimination import givens_elimination
 from .common import (

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -6,7 +6,7 @@ from numpy.exceptions import VisibleDeprecationWarning
 from scipy.sparse import csc_array, vstack, issparse
 from ._highspy._highs_wrapper import _highs_wrapper  # type: ignore[import-not-found,import-untyped]
 from ._constraints import LinearConstraint, Bounds
-from ._optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 from ._linprog_highs import _highs_to_scipy_status_message
 
 

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -15,12 +15,13 @@ from warnings import warn
 
 import numpy as np
 
+from scipy._lib._util import OptimizeResult
 # unconstrained minimization
 from ._optimize import (_minimize_neldermead, _minimize_powell, _minimize_cg,
                         _minimize_bfgs, _minimize_newtoncg,
                         _minimize_scalar_brent, _minimize_scalar_bounded,
-                        _minimize_scalar_golden, MemoizeJac, OptimizeResult,
-                        _wrap_callback, _recover_from_bracket_error)
+                        _minimize_scalar_golden, MemoizeJac, _wrap_callback,
+                        _recover_from_bracket_error)
 from ._trustregion_dogleg import _minimize_dogleg
 from ._trustregion_ncg import _minimize_trust_ncg
 from ._trustregion_krylov import _minimize_trust_krylov

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -7,9 +7,9 @@ from numpy import (atleast_1d, triu, shape, transpose, zeros, prod, greater,
                    finfo, inexact, issubdtype, dtype)
 from scipy import linalg
 from scipy.linalg import svd, cholesky, solve_triangular, LinAlgError
-from scipy._lib._util import _asarray_validated, _lazywhere, _contains_nan
-from scipy._lib._util import getfullargspec_no_self as _getfullargspec
-from ._optimize import OptimizeResult, _check_unknown_options, OptimizeWarning
+from scipy._lib._util import (OptimizeResult, _asarray_validated, _lazywhere,
+                              _contains_nan, getfullargspec_no_self as _getfullargspec)
+from ._optimize import _check_unknown_options, OptimizeWarning
 from ._lsq import least_squares
 # from ._lsq.common import make_strictly_feasible
 from ._lsq.least_squares import prepare_bounds

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -38,8 +38,8 @@ from ._linesearch import (line_search_wolfe1, line_search_wolfe2,
                           LineSearchWarning)
 from ._numdiff import approx_derivative
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
-from scipy._lib._util import (MapWrapper, check_random_state, _RichResult,
-                              _call_callback_maybe_halt, _transition_to_rng)
+from scipy._lib._util import (MapWrapper, check_random_state, _call_callback_maybe_halt,
+                              _transition_to_rng, OptimizeResult)
 from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
 from scipy._lib._array_api import array_namespace, xp_capabilities
 from scipy._lib import array_api_extra as xpx
@@ -107,51 +107,6 @@ def _wrap_callback(callback, method=None):
 
     wrapped_callback.stop_iteration = False
     return wrapped_callback
-
-
-class OptimizeResult(_RichResult):
-    """
-    Represents the optimization result.
-
-    Attributes
-    ----------
-    x : ndarray
-        The solution of the optimization.
-    success : bool
-        Whether or not the optimizer exited successfully.
-    status : int
-        Termination status of the optimizer. Its value depends on the
-        underlying solver. Refer to `message` for details.
-    message : str
-        Description of the cause of the termination.
-    fun : float
-        Value of objective function at `x`.
-    jac, hess : ndarray
-        Values of objective function's Jacobian and its Hessian at `x` (if
-        available). The Hessian may be an approximation, see the documentation
-        of the function in question.
-    hess_inv : object
-        Inverse of the objective function's Hessian; may be an approximation.
-        Not available for all solvers. The type of this attribute may be
-        either np.ndarray or scipy.sparse.linalg.LinearOperator.
-    nfev, njev, nhev : int
-        Number of evaluations of the objective functions and of its
-        Jacobian and Hessian.
-    nit : int
-        Number of iterations performed by the optimizer.
-    maxcv : float
-        The maximum constraint violation.
-
-    Notes
-    -----
-    Depending on the specific solver being used, `OptimizeResult` may
-    not have all attributes listed here, and they may have additional
-    attributes not listed here. Since this class is essentially a
-    subclass of dict with attribute accessors, one can see which
-    attributes are available using the `OptimizeResult.keys` method.
-
-    """
-    pass
 
 
 class OptimizeWarning(UserWarning):

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -2,10 +2,10 @@ import numpy as np
 import operator
 import warnings
 import numbers
-from . import (linear_sum_assignment, OptimizeResult)
+from . import (linear_sum_assignment)
 from ._optimize import _check_unknown_options
 
-from scipy._lib._util import check_random_state
+from scipy._lib._util import OptimizeResult, check_random_state
 import itertools
 
 QUADRATIC_ASSIGNMENT_METHODS = ['faq', '2opt']

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -11,7 +11,8 @@ import numpy as np
 
 from warnings import warn
 
-from ._optimize import MemoizeJac, OptimizeResult, _check_unknown_options
+from scipy._lib._util import OptimizeResult
+from ._optimize import MemoizeJac, _check_unknown_options
 from ._minpack_py import _root_hybr, leastsq
 from ._spectral import _root_df_sane
 from . import _nonlin as nonlin

--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -8,11 +8,11 @@ import sys
 import numpy as np
 
 from scipy import spatial
-from scipy.optimize import OptimizeResult, minimize, Bounds
+from scipy.optimize import minimize, Bounds
 from scipy.optimize._optimize import MemoizeJac
 from scipy.optimize._constraints import new_bounds_to_old
 from scipy.optimize._minimize import standardize_constraints
-from scipy._lib._util import _FunctionWrapper
+from scipy._lib._util import _FunctionWrapper, OptimizeResult
 
 from scipy.optimize._shgo_lib._complex import Complex
 

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -16,10 +16,11 @@ Functions
 __all__ = ['approx_jacobian', 'fmin_slsqp']
 
 import numpy as np
+from scipy._lib._util import OptimizeResult
 from scipy.optimize._slsqp import slsqp
 from numpy import (zeros, array, linalg, append, concatenate, finfo,
                    sqrt, vstack, isfinite, atleast_1d)
-from ._optimize import (OptimizeResult, _check_unknown_options,
+from ._optimize import (_check_unknown_options,
                         _prepare_scalar_function, _clip_x_for_func,
                         _check_clip_x)
 from ._numdiff import approx_derivative

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -4,7 +4,7 @@ Spectral Algorithm for Nonlinear Equations
 import collections
 
 import numpy as np
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 from scipy.optimize._optimize import _check_unknown_options
 from ._linesearch import _nonmonotone_line_search_cruz, _nonmonotone_line_search_cheng
 

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -32,8 +32,9 @@ value of the function, and whose second argument is the gradient of the function
 (as a list of values); or None, to abort the minimization.
 """
 
+from scipy._lib._util import OptimizeResult
 from scipy.optimize import _moduleTNC as moduleTNC
-from ._optimize import (MemoizeJac, OptimizeResult, _check_unknown_options,
+from ._optimize import (MemoizeJac, _check_unknown_options,
                        _prepare_scalar_function)
 from ._constraints import old_bound_to_new
 from scipy._lib._array_api import array_namespace

--- a/scipy/optimize/_trustregion.py
+++ b/scipy/optimize/_trustregion.py
@@ -3,9 +3,10 @@ import math
 import warnings
 
 import numpy as np
+from scipy._lib._util import OptimizeResult
 import scipy.linalg
 from ._optimize import (_check_unknown_options, _status_message,
-                        OptimizeResult, _prepare_scalar_function,
+                        _prepare_scalar_function,
                         _call_callback_maybe_halt)
 from scipy.optimize._hessian_update_strategy import HessianUpdateStrategy
 from scipy.optimize._differentiable_functions import FD_METHODS

--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -5,7 +5,7 @@ from .._differentiable_functions import VectorFunction
 from .._constraints import (
     NonlinearConstraint, LinearConstraint, PreparedConstraint, Bounds, strict_bounds)
 from .._hessian_update_strategy import BFGS
-from .._optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 from .._differentiable_functions import ScalarFunction
 from .equality_constrained_sqp import equality_constrained_sqp
 from .canonical_constraint import (CanonicalConstraint,

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -2,7 +2,7 @@ import warnings
 from collections import namedtuple
 import operator
 from . import _zeros
-from ._optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 import numpy as np
 
 

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -10,7 +10,8 @@ from pytest import raises as assert_raises
 import numpy as np
 from numpy import cos, sin
 
-from scipy.optimize import basinhopping, OptimizeResult
+from scipy._lib._util import OptimizeResult
+from scipy.optimize import basinhopping
 from scipy.optimize._basinhopping import (
     Storage, RandomDisplacement, Metropolis, AdaptiveStepsize)
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -5,9 +5,10 @@ import multiprocessing
 from multiprocessing.dummy import Pool as ThreadPool
 import platform
 
+from scipy._lib._util import OptimizeResult
 from scipy.optimize._differentialevolution import (DifferentialEvolutionSolver,
                                                    _ConstraintWrapper)
-from scipy.optimize import differential_evolution, OptimizeResult
+from scipy.optimize import differential_evolution
 from scipy.optimize._constraints import (Bounds, NonlinearConstraint,
                                          LinearConstraint)
 from scipy.optimize import rosen, minimize

--- a/scipy/optimize/tests/test_cobyqa.py
+++ b/scipy/optimize/tests/test_cobyqa.py
@@ -3,11 +3,11 @@ import pytest
 import threading
 from numpy.testing import assert_allclose, assert_equal
 
+from scipy._lib._util import OptimizeResult
 from scipy.optimize import (
     Bounds,
     LinearConstraint,
     NonlinearConstraint,
-    OptimizeResult,
     minimize,
 )
 

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -14,7 +14,7 @@ from scipy.optimize import least_squares, Bounds
 from scipy.optimize._lsq.least_squares import IMPLEMENTED_LOSSES
 from scipy.optimize._lsq.common import EPS, make_strictly_feasible, CL_scaling_vector
 
-from scipy.optimize import OptimizeResult
+from scipy._lib._util import OptimizeResult
 
 def fun_trivial(x, a=0):
     return (x - a)**2 + 5.0

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -29,14 +29,14 @@ from scipy.optimize._root import ROOT_METHODS
 from scipy.optimize._root_scalar import ROOT_SCALAR_METHODS
 from scipy.optimize._qap import QUADRATIC_ASSIGNMENT_METHODS
 from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
-from scipy.optimize._optimize import MemoizeJac, show_options, OptimizeResult
+from scipy.optimize._optimize import MemoizeJac, show_options
 from scipy.optimize import rosen, rosen_der, rosen_hess
 
 from scipy.sparse import (coo_matrix, csc_matrix, csr_matrix, coo_array,
                           csr_array, csc_array)
 from scipy._lib._array_api_no_0d import xp_assert_equal
 from scipy._lib._array_api import make_skip_xp_backends
-from scipy._lib._util import MapWrapper
+from scipy._lib._util import MapWrapper, OptimizeResult
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
@@ -1232,8 +1232,8 @@ class TestOptimizeSimple(CheckOptimize):
                         stop = True
                         break
 
-            return optimize.OptimizeResult(fun=besty, x=bestx, nit=niter,
-                                           nfev=funcalls, success=(niter > 1))
+            return OptimizeResult(fun=besty, x=bestx, nit=niter,
+                                  nfev=funcalls, success=(niter > 1))
 
         x0 = [1.35, 0.9, 0.8, 1.1, 1.2]
         res = optimize.minimize(optimize.rosen, x0, method=custmin,
@@ -1249,7 +1249,7 @@ class TestOptimizeSimple(CheckOptimize):
         def custmin(fun, x0, **options):
             assert options['bounds'] is bounds
             assert options['constraints'] is constraints
-            return optimize.OptimizeResult()
+            return OptimizeResult()
 
         x0 = [1, 1]
         optimize.minimize(optimize.rosen, x0, method=custmin,
@@ -1336,7 +1336,7 @@ class TestOptimizeSimple(CheckOptimize):
         results = []
 
         def callback(x, *args, **kwargs):
-            assert not isinstance(x, optimize.OptimizeResult)
+            assert not isinstance(x, OptimizeResult)
             results.append((x, np.copy(x)))
 
         routine(func, x0, callback=callback, **kwargs)
@@ -1982,8 +1982,8 @@ class TestOptimizeScalar:
                     stop = True
                     break
 
-            return optimize.OptimizeResult(fun=besty, x=bestx, nit=niter,
-                                           nfev=funcalls, success=(niter > 1))
+            return OptimizeResult(fun=besty, x=bestx, nit=niter,
+                                  nfev=funcalls, success=(niter > 1))
 
         res = optimize.minimize_scalar(self.fun, bracket=(0, 4),
                                        method=custmin,
@@ -3203,7 +3203,7 @@ class TestGlobalOptimization:
                    ]
 
         for result in results:
-            assert isinstance(result, optimize.OptimizeResult)
+            assert isinstance(result, OptimizeResult)
             assert hasattr(result, "x")
             assert hasattr(result, "success")
             assert hasattr(result, "message")

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -11,10 +11,9 @@ import numpy as np
 from numpy import finfo, power, nan, isclose, sqrt, exp, sin, cos
 
 from scipy import optimize
-from scipy.optimize import (_zeros_py as zeros, newton, root_scalar,
-                            OptimizeResult)
+from scipy.optimize import (_zeros_py as zeros, newton, root_scalar)
 
-from scipy._lib._util import getfullargspec_no_self as _getfullargspec
+from scipy._lib._util import OptimizeResult, getfullargspec_no_self as _getfullargspec
 
 # Import testing parameters
 from scipy.optimize._tstutils import get_tests, functions as tstutils_functions

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -2,7 +2,7 @@ import warnings
 from collections import namedtuple
 import numpy as np
 from scipy import optimize, stats
-from scipy._lib._util import check_random_state, _transition_to_rng
+from scipy._lib._util import check_random_state, _transition_to_rng, OptimizeResult
 
 
 def _combine_bounds(name, user_bounds, shape_domain, integral):
@@ -1145,7 +1145,7 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
     res = stats.monte_carlo_test(data, rvs, statistic_fun, vectorized=True,
                                  n_resamples=n_mc_samples, axis=-1,
                                  alternative=alternative)
-    opt_res = optimize.OptimizeResult()
+    opt_res = OptimizeResult()
     opt_res.success = True
     opt_res.message = "The fit was performed successfully."
     opt_res.x = nhd_vals

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -10,14 +10,13 @@ from numpy import (isscalar, r_, log, around, unique, asarray, zeros,
 
 from scipy import optimize, special, interpolate, stats
 from scipy._lib._bunch import _make_tuple_bunch
-from scipy._lib._util import _rename_parameter, _contains_nan, _get_nan
+from scipy._lib._util import _rename_parameter, _contains_nan, _get_nan, OptimizeResult
 
 from scipy._lib._array_api import (
     array_namespace,
     xp_size,
     xp_vector_norm,
 )
-
 from ._ansari_swilk_statistics import gscale, swilk
 from . import _stats_py, _wilcoxon
 from ._fit import FitResult
@@ -2282,7 +2281,7 @@ def anderson(x, dist='norm'):
 
     # FitResult initializer expects an optimize result, so let's work with it
     message = '`anderson` successfully fit the distribution to the data.'
-    res = optimize.OptimizeResult(success=True, message=message)
+    res = OptimizeResult(success=True, message=message)
     res.x = np.array(fit_params)
     fit_result = FitResult(getattr(distributions, dist), y,
                            discrete=False, res=res)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -31,6 +31,7 @@ from scipy._lib._array_api_no_0d import (
     xp_assert_equal,
     xp_assert_less,
 )
+from scipy._lib._util import OptimizeResult
 
 
 skip_xp_backends = pytest.mark.skip_xp_backends
@@ -2582,7 +2583,7 @@ class TestYeojohnson:
 
         def optimizer(fun, lam_yeo):
             out = optimize.fminbound(fun, -lam_yeo, lam_yeo, xtol=1.48e-08)
-            result = optimize.OptimizeResult()
+            result = OptimizeResult()
             result.x = out
             return result
 

--- a/tach.toml
+++ b/tach.toml
@@ -68,7 +68,7 @@ depends_on = ["scipy._lib", "scipy.fft"]
 
 [[modules]]
 path = "scipy.integrate"
-depends_on = ["scipy._lib", "scipy.interpolate", "scipy.sparse", "scipy.stats", "scipy.sparse.linalg", "scipy.special", "scipy.linalg", "scipy.optimize"]
+depends_on = ["scipy._lib", "scipy.interpolate", "scipy.sparse", "scipy.stats", "scipy.sparse.linalg", "scipy.special", "scipy.linalg"]
 
 [[modules]]
 path = "scipy.interpolate"


### PR DESCRIPTION
Follow up https://github.com/scipy/scipy/pull/22671

Currently, `scipy.integrate` depends on `scipy.optimize` as some functions return instances of `OptimizeResult`. This seems a little unnecessary to import an entire module just for a result object! Instead, we can move `OptimizeResult` right next to `_RichResult` (which it is a subclass of) in `_lib` which both modules already import.