### PR TITLE
MAINT: compensate for dot exceptions

### DIFF
--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -1407,9 +1407,10 @@ def _postsolve(x, postsolve_args, complete=False):
         x = rev(x)
 
     fun = x.dot(c)
-    slack = b_ub - A_ub.dot(x)  # report slack for ORIGINAL UB constraints
-    # report residuals of ORIGINAL EQ constraints
-    con = b_eq - A_eq.dot(x)
+    with np.errstate(invalid="ignore"):
+        slack = b_ub - A_ub.dot(x)  # report slack for ORIGINAL UB constraints
+        # report residuals of ORIGINAL EQ constraints
+        con = b_eq - A_eq.dot(x)
 
     return x, fun, slack, con
 

--- a/scipy/sparse/linalg/_isolve/_gcrotmk.py
+++ b/scipy/sparse/linalg/_isolve/_gcrotmk.py
@@ -433,7 +433,8 @@ def gcrotmk(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=1000, M=None, callback
             ux = axpy(u, ux, ux.shape[0], -byc)  # ux -= u*byc
 
         # cx := V H y
-        hy = Q.dot(R.dot(y))
+        with np.errstate(invalid="ignore"):
+            hy = Q.dot(R.dot(y))
         cx = vs[0] * hy[0]
         for v, hyc in zip(vs[1:], hy[1:]):
             cx = axpy(v, cx, cx.shape[0], hyc)  # cx += v*hyc


### PR DESCRIPTION
* Fixes gh-22720.

* This patch adds a few floating point exception handling shims to compensate for the upstream
change for `np.dot` at https://github.com/numpy/numpy/pull/28442, merged five days ago. This allows the SciPy testsuite to pass again locally on x86_64 Linux against NumPy `main`.