### PR TITLE
ENH/BUG: optimize: use `_differentiable_functions.VectorFunction` in `least_squares`

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -684,11 +684,17 @@ class VectorFunction:
     def fun(self, x):
         self._update_x(x)
         self._update_fun()
-        return self.f
+        # returns a copy so that downstream can't overwrite the
+        # internal attribute
+        return self.f.copy()
 
     def jac(self, x):
         self._update_x(x)
         self._update_jac()
+        if hasattr(self.J, "copy"):
+            # returns a copy so that downstream can't overwrite the
+            # internal attribute. But one can't copy a LinearOperator
+            return self.J.copy()
         return self.J
 
     def hess(self, x, v):
@@ -696,6 +702,10 @@ class VectorFunction:
         self._update_v(v)
         self._update_x(x)
         self._update_hess()
+        if hasattr(self.H, "copy"):
+            # returns a copy so that downstream can't overwrite the
+            # internal attribute. But one can't copy non-arrays
+            return self.H.copy()
         return self.H
 
 

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -429,7 +429,8 @@ class VectorFunction:
     """
     def __init__(self, fun, x0, jac, hess,
                  finite_diff_rel_step=None, finite_diff_jac_sparsity=None,
-                 finite_diff_bounds=(-np.inf, np.inf), sparse_jacobian=None, workers=None):
+                 finite_diff_bounds=(-np.inf, np.inf), sparse_jacobian=None,
+                 workers=None):
         if not callable(jac) and jac not in FD_METHODS:
             raise ValueError(f"`jac` must be either callable or one of {FD_METHODS}.")
 

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -545,9 +545,9 @@ class VectorFunction:
                     sparse_jacobian is None and sps.issparse(self.J)):
                 def update_jac():
                     self._update_fun()
-                    self.J, dct = sps.csr_array(
-                        approx_derivative(fun_wrapped, self.x, f0=self.f,
-                                          **finite_diff_options))
+                    _J, dct = approx_derivative(fun_wrapped, self.x, f0=self.f,
+                                                **finite_diff_options)
+                    self.J = sps.csr_array(_J)
                     self.nfev += dct['nfev']
                 self.J = sps.csr_array(self.J)
                 self.sparse_jacobian = True
@@ -555,8 +555,9 @@ class VectorFunction:
             elif sps.issparse(self.J):
                 def update_jac():
                     self._update_fun()
-                    self.J, dct = approx_derivative(fun_wrapped, self.x, f0=self.f,
-                                                    **finite_diff_options).toarray()
+                    _J, dct = approx_derivative(fun_wrapped, self.x, f0=self.f,
+                                                    **finite_diff_options)
+                    self.J = _J.toarray()
                     self.nfev += dct['nfev']
                 self.J = self.J.toarray()
                 self.sparse_jacobian = False

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -429,7 +429,7 @@ class VectorFunction:
     """
     def __init__(self, fun, x0, jac, hess,
                  finite_diff_rel_step=None, finite_diff_jac_sparsity=None,
-                 finite_diff_bounds=None, sparse_jacobian=None, workers=None):
+                 finite_diff_bounds=(-np.inf, np.inf), sparse_jacobian=None, workers=None):
         if not callable(jac) and jac not in FD_METHODS:
             raise ValueError(f"`jac` must be either callable or one of {FD_METHODS}.")
 

--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -524,7 +524,12 @@ class VectorFunction:
                     return jac(x).toarray()
                 self.J = self.J.toarray()
                 self.sparse_jacobian = False
-
+            elif isinstance(self.J, LinearOperator):
+                # no atleast_2D for LinearOperators
+                def jac_wrapped(x):
+                    self.njev += 1
+                    return jac(x)
+                self.sparse_jacobian = False
             else:
                 def jac_wrapped(x):
                     self.njev += 1

--- a/scipy/optimize/_lsq/dogbox.py
+++ b/scipy/optimize/_lsq/dogbox.py
@@ -308,7 +308,7 @@ def dogbox(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev, x_scale,
 
             cost = cost_new
 
-            J = jac(x, f)
+            J = jac(x)
             njev += 1
 
             if loss_function is not None:

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -885,7 +885,10 @@ def least_squares(
     if callable(jac):
         jac_wrapped = _WrapArgsKwargs(jac, args=args, kwargs=kwargs)
 
-    _dummy_hess = lambda x, v: x
+    def _dummy_hess(x, *args):
+        # we don't care about Hessian evaluations
+        return x
+
     vector_fun = VectorFunction(
         fun_wrapped,
         x0,

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -870,16 +870,14 @@ def least_squares(
     if tr_options is None:
         tr_options = {}
 
-    #########################
+    ###########################################################################
     # assemble VectorFunction
-    #########################
+    ###########################################################################
     # first wrap the args/kwargs
     fun_wrapped = _WrapArgsKwargs(fun, args=args, kwargs=kwargs)
     jac_wrapped = jac
     if callable(jac):
         jac_wrapped = _WrapArgsKwargs(jac, args=args, kwargs=kwargs)
-
-    # sparse_jacobian = None,
 
     _dummy_hess = lambda x, v: x
     vector_fun = VectorFunction(
@@ -892,6 +890,7 @@ def least_squares(
         finite_diff_bounds=bounds,
         workers=workers
     )
+    ###########################################################################
 
     f0 = vector_fun.fun(x0)
     J0 = vector_fun.jac(x0)
@@ -929,6 +928,9 @@ def least_squares(
                 raise ValueError("method='lm' does not support "
                                  "`jac_sparsity`.")
         else:
+            # this will raise a ValueError if the jac_sparsity isn't correct
+            _ = check_jac_sparsity(jac_sparsity, m, n)
+
             if jac_sparsity is not None and tr_solver == 'exact':
                 raise ValueError("tr_solver='exact' is incompatible "
                                  "with `jac_sparsity`.")

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -553,8 +553,8 @@ def least_squares(
 
     Notes
     -----
-    Method 'lm' (Levenberg-Marquardt) calls a wrapper over least-squares
-    algorithms implemented in MINPACK (lmder, lmdif). It runs the
+    Method 'lm' (Levenberg-Marquardt) calls a wrapper over a least-squares
+    algorithm implemented in MINPACK (lmder). It runs the
     Levenberg-Marquardt algorithm formulated as a trust-region type algorithm.
     The implementation is based on paper [JJMore]_, it is very robust and
     efficient with a lot of smart tricks. It should be your first choice

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -410,7 +410,10 @@ def least_squares(
         If None (default), the value is chosen automatically as 100 * n.
 
         .. versionchanged:: 1.16.0
-            The default for the 'lm' method is changed to 100 * n.
+            The default for the 'lm' method is changed to 100 * n, for both a callable and
+            a numerically estimated jacobian. Previously the default when using an estimated
+            jacobian was 100 * n * (n + 1), because the method included evaluations used in
+            the estimation. 
 
     diff_step : None or array_like, optional
         Determines the relative step size for the finite difference

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -10,6 +10,7 @@ from scipy.optimize._differentiable_functions import VectorFunction
 from scipy.optimize._numdiff import group_columns
 from scipy.optimize._minimize import Bounds
 from scipy._lib._sparse import issparse
+from scipy._lib._array_api import array_namespace
 from scipy._lib._util import _workers_wrapper
 
 from .trf import trf
@@ -64,8 +65,12 @@ def call_minpack(fun, x0, jac, ftol, xtol, gtol, max_nfev, x_scale, jac_method=N
     # jacobian). Otherwise they're very similar internally.
     # We now do all the finite differencing in VectorFunction, which means we can drop
     # lmdif and just use lmder.
+
+    # for sending a copy of x0 into _lmder
+    xp = array_namespace(x0)
+
     x, info, status = _minpack._lmder(
-        fun, jac, x0, (), full_output, col_deriv,
+        fun, jac, xp.astype(x0, x0.dtype), (), full_output, col_deriv,
         ftol, xtol, gtol, max_nfev, factor, diag)
 
     f = info['fvec']

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -59,6 +59,11 @@ def call_minpack(fun, x0, jac, ftol, xtol, gtol, max_nfev, x_scale, jac_method=N
     if max_nfev is None:
         max_nfev = 100 * n
 
+    # lmder is typically used for systems with analytic jacobians, with lmdif being
+    # used if there is only an objective fun (lmdif uses finite differences to estimate
+    # jacobian). Otherwise they're very similar internally.
+    # We now do all the finite differencing in VectorFunction, which means we can drop
+    # lmdif and just use lmder.
     x, info, status = _minpack._lmder(
         fun, jac, x0, (), full_output, col_deriv,
         ftol, xtol, gtol, max_nfev, factor, diag)
@@ -294,8 +299,7 @@ def least_squares(
         twice as many operations as '2-point' (default). The scheme 'cs'
         uses complex steps, and while potentially the most accurate, it is
         applicable only when `fun` correctly handles complex inputs and
-        can be analytically continued to the complex plane. Method 'lm'
-        always uses the '2-point' scheme. If callable, it is used as
+        can be analytically continued to the complex plane If callable, it is used as
         ``jac(x, *args, **kwargs)`` and should return a good approximation
         (or the exact value) for the Jacobian as an array_like (np.atleast_2d
         is applied), a sparse array (csr_array preferred for performance) or

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -299,7 +299,7 @@ def least_squares(
         twice as many operations as '2-point' (default). The scheme 'cs'
         uses complex steps, and while potentially the most accurate, it is
         applicable only when `fun` correctly handles complex inputs and
-        can be analytically continued to the complex plane If callable, it is used as
+        can be analytically continued to the complex plane. If callable, it is used as
         ``jac(x, *args, **kwargs)`` and should return a good approximation
         (or the exact value) for the Jacobian as an array_like (np.atleast_2d
         is applied), a sparse array (csr_array preferred for performance) or

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -410,10 +410,10 @@ def least_squares(
         If None (default), the value is chosen automatically as 100 * n.
 
         .. versionchanged:: 1.16.0
-            The default for the 'lm' method is changed to 100 * n, for both a callable and
-            a numerically estimated jacobian. Previously the default when using an estimated
-            jacobian was 100 * n * (n + 1), because the method included evaluations used in
-            the estimation. 
+            The default for the 'lm' method is changed to 100 * n, for both a callable
+            and a numerically estimated jacobian. Previously the default when using an
+            estimated jacobian was 100 * n * (n + 1), because the method included
+            evaluations used in the estimation.
 
     diff_step : None or array_like, optional
         Determines the relative step size for the finite difference

--- a/scipy/optimize/_lsq/trf.py
+++ b/scipy/optimize/_lsq/trf.py
@@ -373,7 +373,7 @@ def trf_bounds(fun, jac, x0, f0, J0, lb, ub, ftol, xtol, gtol, max_nfev,
 
             cost = cost_new
 
-            J = jac(x, f)
+            J = jac(x)
             njev += 1
 
             if loss_function is not None:
@@ -548,7 +548,7 @@ def trf_no_bounds(fun, jac, x0, f0, J0, ftol, xtol, gtol, max_nfev,
 
             cost = cost_new
 
-            J = jac(x, f)
+            J = jac(x)
             njev += 1
 
             if loss_function is not None:

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -762,6 +762,29 @@ class TestVectorialFunction(TestCase):
         assert_array_equal(ex.nhev, nhev)
         assert_array_equal(analit.nhev+approx.nhev, nhev)
 
+    def test_fgh_overlap(self):
+        # VectorFunction.fun/jac should return copies to internal attributes
+        ex = ExVectorialFunction()
+        x0 = np.array([1.0, 0.0])
+
+        vf = VectorFunction(ex.fun, x0, '3-point', ex.hess, None, None,
+                            (-np.inf, np.inf), None)
+        f = vf.fun(np.array([1.1, 0.1]))
+        J = vf.jac([1.1, 0.1])
+        assert vf.f is not f
+        assert vf.J is not J
+        assert_equal(f, vf.f)
+        assert_equal(J, vf.J)
+
+        vf = VectorFunction(ex.fun, x0, ex.jac, ex.hess, None, None,
+                            (-np.inf, np.inf), None)
+        f = vf.fun(np.array([1.1, 0.1]))
+        J = vf.jac([1.1, 0.1])
+        assert vf.f is not f
+        assert vf.J is not J
+        assert_equal(f, vf.f)
+        assert_equal(J, vf.J)
+
     @pytest.mark.thread_unsafe
     def test_x_storage_overlap(self):
         # VectorFunction should not store references to arrays, it should

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -481,8 +481,9 @@ class TestVectorialFunction(TestCase):
         assert_array_equal(analit.nfev, nfev)
         assert_array_equal(ex.njev, njev)
         assert_array_equal(analit.njev, njev)
-        approx = VectorFunction(ex.fun, x0, '2-point', ex.hess, None, None,
-                                (-np.inf, np.inf), None)
+        # create with defaults for the keyword arguments, to
+        # ensure that the defaults work
+        approx = VectorFunction(ex.fun, x0, '2-point', ex.hess)
         nfev += 3
         assert_array_equal(ex.nfev, nfev)
         assert_array_equal(analit.nfev+approx.nfev, nfev)

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -805,14 +805,6 @@ class TestLM(BaseMixin):
         assert_raises(ValueError, least_squares, fun_trivial, 2.0,
                       method='lm', loss='huber')
 
-    def test_nfev_correct(self):
-        # check total number of function evaluations must be exact
-        x0 = np.ones(5)
-        f = Fun_Trivial_Nfev()
-        serial = least_squares(f, x0, method='lm')
-        assert f.nfev == serial.nfev
-        assert serial.njev is None
-
 
 def test_basic():
     # test that 'method' arg is really optional

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -20,15 +20,6 @@ def fun_trivial(x, a=0):
     return (x - a)**2 + 5.0
 
 
-class Fun_Trivial_Nfev:
-    def __init__(self):
-        self.nfev = 0
-
-    def __call__(self, x, a=0):
-        self.nfev += 1
-        return fun_trivial(x, a)
-
-
 def jac_trivial(x, a=0.0):
     return 2 * (x - a)
 


### PR DESCRIPTION
Updates the internals of `optimize.least_squares` to use `optimize._differentiable_functions.VectorFunction`.

The `lm` method now uses `VectorFunction` to calculate numeric derivatives instead of relying on `_minpack._lmder`. Consequently the `lm` method is now able to take advantage of various features of `approx_derivative` (used by `VectorFunction`). These include the `workers` keyword (parallelise the numerical differentiation), any of the `2-point`/`3-point`/`cs` steps. Down the line this may offer the potential to use LinearOperator, jac_sparsity. `approx_derivative` is also more accurate than the FD done in `_minpack._lmdif`.

The other two methods (`trf`/`dogbox`) also use `VectorFunction`. The `VectorFunction` class offers memoisation of function and jacobian, which can reduce the total number of their evaluations, although `trf` and `dogbox` were careful about their design in that regard.

Finally some bug fixes (introduced in #22549) are made to `VectorFunction`.

