### PR TITLE
MAINT: migrate `gdtria` from cdflib to cephes and scipy's own rootfinder

### DIFF
--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -1116,6 +1116,7 @@ cdef extern from r"xsf_wrappers.h":
     double special_ber(double) nogil
     double special_berp(double) nogil
     double xsf_gdtrib(double, double, double) nogil
+    double xsf_gdtria(double, double, double) nogil
     npy_double special_kei(npy_double) nogil
     npy_double special_keip(npy_double) nogil
     void special_ckelvin(npy_double, npy_cdouble *, npy_cdouble *, npy_cdouble *, npy_cdouble *) nogil
@@ -1631,10 +1632,6 @@ cdef _proto_fdtridfd_t *_proto_fdtridfd_t_var = &_func_fdtridfd
 
 cdef extern from r"_ufuncs_defs.h":
     cdef npy_int _func_cephes_fresnl_wrap "cephes_fresnl_wrap"(npy_double, npy_double *, npy_double *)nogil
-
-from ._cdflib_wrappers cimport gdtria as _func_gdtria
-ctypedef double _proto_gdtria_t(double, double, double) noexcept nogil
-cdef _proto_gdtria_t *_proto_gdtria_t_var = &_func_gdtria
 
 from ._cdflib_wrappers cimport gdtrix as _func_gdtrix
 ctypedef double _proto_gdtrix_t(double, double, double) noexcept nogil
@@ -2596,7 +2593,7 @@ cpdef double gdtrc(double x0, double x1, double x2) noexcept nogil:
 
 cpdef double gdtria(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.gdtria"""
-    return _func_gdtria(x0, x1, x2)
+    return xsf_gdtria(x0, x1, x2)
 
 cpdef double gdtrib(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.gdtrib"""

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -359,8 +359,8 @@
         }
     },
     "gdtria": {
-        "_cdflib_wrappers.pxd": {
-            "gdtria": "ddd->d"
+        "xsf_wrappers.h": {
+            "xsf_gdtria": "ddd->d"
         }
     },
     "gdtrib": {

--- a/scipy/special/tests/test_xsf_cuda.py
+++ b/scipy/special/tests/test_xsf_cuda.py
@@ -26,6 +26,7 @@ def get_test_cases():
         (sc.ellipkinc, "cephes/ellik.h", "out0 = xsf::cephes::ellik(in0, in1)"),
         (sc.ellipeinc, "cephes/ellie.h", "out0 = xsf::cephes::ellie(in0, in1)"),
         (sc.gdtrib, "cdflib.h", "out0 = xsf::gdtrib(in0, in1, in2)"),
+        (sc.gdtria, "cdflib.h", "out0 = xsf::gdtria(in0, in1, in2)"),
         (sc.sici, "sici.h", "xsf::sici(in0, &out0, &out1)"),
         (sc.shichi, "sici.h", "xsf::shichi(in0, &out0, &out1)"),
     ]

--- a/scipy/special/xsf/cdflib.h
+++ b/scipy/special/xsf/cdflib.h
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include "cephes/igam.h"
@@ -43,10 +42,10 @@ XSF_HOST_DEVICE inline double gdtrib(double a, double p, double x) {
     }
     double q = 1.0 - p;
     auto func = [a, p, q, x](double b) {
-	if (p <= q) {
-	    return cephes::igam(b, a * x) - p;
-	}
-	return q - cephes::igamc(b, a * x);
+        if (p <= q) {
+            return cephes::igam(b, a * x) - p;
+        }
+        return q - cephes::igamc(b, a * x);
     };
     double lower_bound = std::numeric_limits<double>::min();
     double upper_bound = std::numeric_limits<double>::max();
@@ -72,7 +71,7 @@ XSF_HOST_DEVICE inline double gdtrib(double a, double p, double x) {
      * floating point values.
      */
     auto [xl, xr, f_xl, f_xr, bracket_status] = detail::bracket_root_for_cdf_inversion(
-        func, 1.0, lower_bound, upper_bound, -0.875, 7.0, 0.125, 8, false, 342
+        func, 1.0, lower_bound, upper_bound, -0.875, 7.0, 0.125, 8.0, false, 342
     );
     if (bracket_status == 1) {
         set_error("gdtrib", SF_ERROR_UNDERFLOW, NULL);
@@ -92,6 +91,93 @@ XSF_HOST_DEVICE inline double gdtrib(double a, double p, double x) {
     if (root_status) {
         /* The root finding return should only fail if there's a bug in our code. */
         set_error("gdtrib", SF_ERROR_OTHER, "Computational Error, (%.17g, %.17g, %.17g)", a, p, x);
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return result;
+}
+
+XSF_HOST_DEVICE inline double gdtria(double p, double b, double x) {
+    if (std::isnan(p) || std::isnan(b) || std::isnan(x)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (!((0 <= p) && (p <= 1))) {
+        set_error("gdtria", SF_ERROR_DOMAIN, "Input parameter p is out of range");
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (!(b > 0) || std::isinf(b)) {
+        set_error("gdtria", SF_ERROR_DOMAIN, "Input parameter b is out of range");
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (!(x >= 0) || std::isinf(x)) {
+        set_error("gdtria", SF_ERROR_DOMAIN, "Input parameter x is out of range");
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (x == 0.0) {
+        if (p == 0.0) {
+            set_error("gdtria", SF_ERROR_DOMAIN, "Indeterminate result for (x, p) == (0, 0).");
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+        /* gdtria(p, b, x) tends to 0 as x -> 0 when p > 0 */
+        return 0.0;
+    }
+    if (p == 0.0) {
+        return 0.0;
+    }
+    if (p == 1.0) {
+        /* gdtria(p, b, x) tends to 0 as p -> 1.0 from the left when x > 0. */
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    double q = 1.0 - p;
+    auto func = [b, p, q, x](double a) {
+        if (p <= q) {
+            return cephes::igam(b, a * x) - p;
+        }
+        return q - cephes::igamc(b, a * x);
+    };
+    double lower_bound = std::numeric_limits<double>::min();
+    double upper_bound = std::numeric_limits<double>::max();
+    /* To explain the magic constants used below:
+        * 1.0 is the initial guess for the root. -0.875 is the initial step size
+        * for the leading bracket endpoint if the bracket search will proceed to the
+        * left, likewise 7.0 is the initial step size when the bracket search will
+        * proceed to the right. 0.125 is the scale factor for a left moving bracket
+        * search and 8.0 the scale factor for a right moving bracket search. These
+        * constants are chosen so that:
+        *
+        * 1. The scale factor and bracket endpoints remain powers of 2, allowing for
+        *    exact arithmetic, preventing roundoff error from causing numerical catastrophe
+        *    which could lead to unexpected results.
+        * 2. The bracket sizes remain constant in a relative sense. Each candidate bracket
+        *    will contain roughly the same number of floating point values. This means that
+        *    the number of necessary function evaluations in the worst case scenario for
+        *    Chandrupatla's algorithm will remain constant.
+        *
+        * false specifies that the function is not decreasing. 342 is equal to
+        * max(ceil(log_8(DBL_MAX)), ceil(log_(1/8)(DBL_MIN))). An upper bound for the
+        * number of iterations needed in this bracket search to check all normalized
+        * floating point values.
+        */
+    auto [xl, xr, f_xl, f_xr, bracket_status] = detail::bracket_root_for_cdf_inversion(
+        func, 1.0, lower_bound, upper_bound, -0.875, 7.0, 0.125, 8.0, false, 342
+    );
+    if (bracket_status == 1) {
+        set_error("gdtria", SF_ERROR_UNDERFLOW, NULL);
+        return 0.0;
+    }
+    if (bracket_status == 2) {
+        set_error("gdtria", SF_ERROR_OVERFLOW, NULL);
+        return std::numeric_limits<double>::infinity();
+    }
+    if (bracket_status >= 3) {
+        set_error("gdtria", SF_ERROR_OTHER, "Computational Error");
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    auto [result, root_status] = detail::find_root_chandrupatla(
+        func, xl, xr, f_xl, f_xr, std::numeric_limits<double>::epsilon(), 1e-100, 100
+    );
+    if (root_status) {
+        /* The root finding return should only fail if there's a bug in our code. */
+        set_error("gdtria", SF_ERROR_OTHER, "Computational Error, (%.17g, %.17g, %.17g)", p, b, x);
         return std::numeric_limits<double>::quiet_NaN();
     }
     return result;

--- a/scipy/special/xsf/cdflib.h
+++ b/scipy/special/xsf/cdflib.h
@@ -71,7 +71,7 @@ XSF_HOST_DEVICE inline double gdtrib(double a, double p, double x) {
      * floating point values.
      */
     auto [xl, xr, f_xl, f_xr, bracket_status] = detail::bracket_root_for_cdf_inversion(
-        func, 1.0, lower_bound, upper_bound, -0.875, 7.0, 0.125, 8.0, false, 342
+        func, 1.0, lower_bound, upper_bound, -0.875, 7.0, 0.125, 8, false, 342
     );
     if (bracket_status == 1) {
         set_error("gdtrib", SF_ERROR_UNDERFLOW, NULL);
@@ -117,14 +117,12 @@ XSF_HOST_DEVICE inline double gdtria(double p, double b, double x) {
             set_error("gdtria", SF_ERROR_DOMAIN, "Indeterminate result for (x, p) == (0, 0).");
             return std::numeric_limits<double>::quiet_NaN();
         }
-        /* gdtria(p, b, x) tends to 0 as x -> 0 when p > 0 */
         return 0.0;
     }
     if (p == 0.0) {
         return 0.0;
     }
     if (p == 1.0) {
-        /* gdtria(p, b, x) tends to 0 as p -> 1.0 from the left when x > 0. */
         return std::numeric_limits<double>::quiet_NaN();
     }
     double q = 1.0 - p;
@@ -136,27 +134,7 @@ XSF_HOST_DEVICE inline double gdtria(double p, double b, double x) {
     };
     double lower_bound = std::numeric_limits<double>::min();
     double upper_bound = std::numeric_limits<double>::max();
-    /* To explain the magic constants used below:
-        * 1.0 is the initial guess for the root. -0.875 is the initial step size
-        * for the leading bracket endpoint if the bracket search will proceed to the
-        * left, likewise 7.0 is the initial step size when the bracket search will
-        * proceed to the right. 0.125 is the scale factor for a left moving bracket
-        * search and 8.0 the scale factor for a right moving bracket search. These
-        * constants are chosen so that:
-        *
-        * 1. The scale factor and bracket endpoints remain powers of 2, allowing for
-        *    exact arithmetic, preventing roundoff error from causing numerical catastrophe
-        *    which could lead to unexpected results.
-        * 2. The bracket sizes remain constant in a relative sense. Each candidate bracket
-        *    will contain roughly the same number of floating point values. This means that
-        *    the number of necessary function evaluations in the worst case scenario for
-        *    Chandrupatla's algorithm will remain constant.
-        *
-        * false specifies that the function is not decreasing. 342 is equal to
-        * max(ceil(log_8(DBL_MAX)), ceil(log_(1/8)(DBL_MIN))). An upper bound for the
-        * number of iterations needed in this bracket search to check all normalized
-        * floating point values.
-        */
+
     auto [xl, xr, f_xl, f_xr, bracket_status] = detail::bracket_root_for_cdf_inversion(
         func, 1.0, lower_bound, upper_bound, -0.875, 7.0, 0.125, 8.0, false, 342
     );

--- a/scipy/special/xsf_wrappers.cpp
+++ b/scipy/special/xsf_wrappers.cpp
@@ -608,6 +608,8 @@ double xsf_gdtrc(double a, double b, double x) { return xsf::gdtrc(a, b, x); }
 
 double xsf_gdtrib(double a, double p, double x) { return xsf::gdtrib(a, p, x); }
 
+double xsf_gdtria(double p, double b, double x) { return xsf::gdtria(p, b, x); }
+
 double xsf_kolmogorov(double x) { return xsf::kolmogorov(x); }
 
 double xsf_kolmogc(double x) { return xsf::kolmogc(x); }

--- a/scipy/special/xsf_wrappers.h
+++ b/scipy/special/xsf_wrappers.h
@@ -343,6 +343,7 @@ double xsf_fdtri(double a, double b, double y);
 double xsf_gdtr(double a, double b, double x);
 double xsf_gdtrc(double a, double b, double x);
 double xsf_gdtrib(double a, double p, double x);
+double xsf_gdtria(double p, double b, double x);
 double xsf_kolmogorov(double x);
 double xsf_kolmogc(double x);
 double xsf_kolmogi(double x);


### PR DESCRIPTION
#### Reference issue
Towards #21966

#### What does this implement/fix?
Refactors `gdtria` in the same way as `gdtrib` was reimplemented in #21454

#### Additional information
Edge cases are not really handled yet, opening for initial feedback and to get familiarized with the new root finding machinery.