### PR TITLE
TST: special: remove test skips due to array-api-strict#131

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ test = [
     "scikit-umfpack",
     "pooch",
     "hypothesis>=6.30",
-    "array-api-strict>=2.3",
+    "array-api-strict>=2.3.1",
     "Cython",
     "meson",
     'ninja; sys_platform != "emscripten"',

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch
 hypothesis>=6.30
-array-api-strict>=2.0,<2.1.1
+array-api-strict>=2.3
 Cython
 meson
 ninja; sys_platform != "emscripten"

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch
 hypothesis>=6.30
-array-api-strict>=2.3
+array-api-strict>=2.3.1
 Cython
 meson
 ninja; sys_platform != "emscripten"

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -10,11 +10,8 @@ from scipy._lib._array_api_no_0d import (xp_assert_equal, xp_assert_close,
 
 from scipy.special import log_softmax, logsumexp, softmax
 from scipy.special._logsumexp import _wrap_radians
-from scipy.stats.tests.test_stats import skip_xp_backends
 
 from scipy._lib.array_api_extra.testing import lazy_xp_function
-
-
 
 
 dtypes = ['float32', 'float64', 'int32', 'int64', 'complex64', 'complex128']

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -184,7 +184,6 @@ class TestLogSumExp:
         desired = np.asarray(1000.0 + math.log(2.0))
         xp_assert_close(logsumexp(a), desired)
 
-    @skip_xp_backends('array_api_strict', reason='data-apis/array-api-strict#131')
     @pytest.mark.parametrize('dtype', dtypes)
     def test_dtypes_a(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -194,7 +193,6 @@ class TestLogSumExp:
         desired = xp.asarray(1000.0 + math.log(2.0), dtype=desired_dtype)
         xp_assert_close(logsumexp(a), desired)
 
-    @skip_xp_backends('array_api_strict', reason='data-apis/array-api-strict#131')
     @pytest.mark.parametrize('dtype_a', dtypes)
     @pytest.mark.parametrize('dtype_b', dtypes)
     def test_dtypes_ab(self, dtype_a, dtype_b, xp):
@@ -225,7 +223,6 @@ class TestLogSumExp:
         ref = xp.logaddexp(a[0], a[1])
         xp_assert_close(res, ref)
 
-    @skip_xp_backends('array_api_strict', reason='data-apis/array-api-strict#131')
     @pytest.mark.filterwarnings(
         "ignore:The `numpy.copyto` function is not implemented:FutureWarning:dask"
     )

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -4,8 +4,7 @@ from scipy.special._support_alternative_backends import (get_array_special_func,
                                                          array_special_func_map)
 from scipy import special
 from scipy._lib._array_api_no_0d import xp_assert_close
-from scipy._lib._array_api import (is_cupy, is_dask, is_jax, is_torch,
-                                   is_array_api_strict, SCIPY_DEVICE)
+from scipy._lib._array_api import is_cupy, is_dask, is_jax, is_torch, SCIPY_DEVICE
 from scipy._lib.array_api_compat import numpy as np
 
 

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -58,8 +58,6 @@ def test_support_alternative_backends(xp, f_name, n_args, dtype, shapes):
         pytest.skip("boolean index assignment")
     if is_jax(xp) and f_name == "stdtrit":
         pytest.skip(f"`{f_name}` requires scipy.optimize support for immutable arrays")
-    if is_array_api_strict(xp) and f_name == "xlogy":
-        pytest.skip(f"`{f_name}` needs data-apis/array-api-strict#131 to be resolved")
 
     shapes = shapes[:n_args]
     f = getattr(special, f_name)


### PR DESCRIPTION
#### Reference issue
gh-22683
data-apis/array-api-strict#131

#### What does this implement/fix?
Now that array-api-strict#131 is closed and 2.3.1 is released, we should be able to remove these test skips.