### PR TITLE
ENH: stats: add support for multiple parameterizations for custom distributions in new distribution infra

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3689,8 +3689,8 @@ def make_distribution(dist):
     ...             nu = a + b
     ...             mu = a / nu
     ...         elif mu is not None and nu is not None and a is None and b is None:
-    ...             b = mu * nu
-    ...             a = nu - b
+    ...             a = mu * nu
+    ...             b = nu - a
     ...         else:
     ...             raise ValueError("Invalid parameterization of MyBeta.")
     ...         return {"a": a, "b": b, "mu": mu, "nu": nu}
@@ -3700,19 +3700,10 @@ def make_distribution(dist):
     ...         return {'endpoints': (0, 1)}
     ...
     ...     def pdf(self, x, a, b, mu, nu):
-    ...         return x**(a - 1) * (1 - x)**(b - 1) / special.beta(a, b)
-    ...
-    ...     def logpdf(self, x, a, b, mu, nu):
-    ...         return (a - 1) * np.log(x) + (b - 1)*np.log1p(-x) - special.betaln(a, b)
+    ...         return special._ufuncs._beta_pdf(x, a, b)
     ...
     ...     def cdf(self, x, a, b, mu, nu):
     ...         return special.betainc(a, b, x)
-    ...
-    ...     def moment(self, order, kind='raw', *, a, b, mu, nu):
-    ...         if order == 1 and kind == "raw":
-    ...             return mu
-    ...         if order == 2 and kind == "central":
-    ...             return mu * (1 - mu) / (1 + nu)
     >>>
     >>> MyBeta = stats.make_distribution(MyBeta())
     >>> X = MyBeta(a=2.0, b=2.0)

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3511,14 +3511,6 @@ def make_distribution(dist):
             in which case support for an old interface version may be deprecated
             and eventually removed.
         parameters : dict or tuple
-            If a ``tuple`` it should be a ``tuple`` of ``dict``s with the structure
-            described below. Each ``dict`` in the ``tuple`` will correspond to a
-            separate parametrization of the distribution. If multiple parameterizations
-            are specified, ``dist``'s class must also define a method
-            ``_process_parameters`` to allow mapping between the different
-            parameterizations. The requirements for this method are described further
-            below.
-
             If a ``dict``, each key is the name of a parameter,
             and the corresponding value is either a dictionary or tuple.
             If the value is a dictionary, it may have the following items, with default
@@ -3541,7 +3533,17 @@ def make_distribution(dist):
                 ``endpoints`` tuple above, and should define a subinterval of the
                 domain given by ``endpoints``.
 
-            A ``tuple`` value ``(a, b)`` is equivalent to ``{endpoints: (a, b)}``.
+            A ``tuple`` value ``(a, b)`` associated to a key in the ``parameters``
+            ``dict`` is equivalent to ``{endpoints: (a, b)}``.
+
+            Custom distributions with multiple parameterizations can be defined by
+            having the ``parameters`` attribute be a ``tuple`` of ``dict``s with
+            the structure described above. In this case, ``dist``'s class must also
+            define a method ``process_parameters` to map between the different
+            parameterizations. It must take all parameters from all parameterizations
+            as optional keyword arguments and return a ``dict`` mapping parameters to
+            values, filling in values from other parameterizations using values from
+            the supplied parameterization.
 
         support : dict or tuple
             A dictionary describing the support of the distribution or a tuple
@@ -3556,24 +3558,16 @@ def make_distribution(dist):
         ``moment``, and ``sample``.
         If defined, these methods must accept the parameters of the distribution as
         keyword arguments and also accept any positional-only arguments accepted by
-        the corresponding method of `ContinuousDistribution`. The ``moment`` method
-        must accept the ``order`` and ``kind`` arguments by position or keyword, but
-        may return ``None`` if a formula is not available for the arguments; in this
-        case, the infrastructure will fall back to a default implementation. The
-        ``sample`` method must accept ``shape`` by position or keyword, but contrary
-        to the public method of the same name, the argument it receives will be the
-        *full* shape of the output array - that is, the shape passed to the public
-        method prepended to the broadcasted shape of random variable parameters. If
-        multiple parameterizations are defined, these methods must accept all
-        parameters from all parameterizations.
-
-        If the class's ``parameters`` attribute contains a ``tuple`` defining multiple
-        parameterizations, then the class must also define a ``__process_parameters``
-        method for mapping between the parameterizations. It must take all parameters
-        from all parameterizations as optional keyword arguments and return a dictionary
-        mapping parameters to values, filling in values from other parameterizations
-        using values from the supplied parameterization.
-
+        the corresponding method of `ContinuousDistribution`. When multiple
+        parameterizations are defined, these methods must accept all parameters from
+        all parameterizations. The ``moment`` method must accept the ``order`` and
+        ``kind`` arguments by position or keyword, but may return ``None`` if a
+        formula is not available for the arguments; in this case, the infrastructure
+        will fall back to a default implementation. The ``sample`` method must accept
+        ``shape`` by position or keyword, but contrary to the public method of the
+        same name, the argument it receives will be the *full* shape of the output
+        array - that is, the shape passed to the public method prepended to the
+        broadcasted shape of random variable parameters.
 
     Returns
     -------
@@ -3671,7 +3665,7 @@ def make_distribution(dist):
     np.True_
 
     Create a custom distribution with multiple parameterizations. Here we create a
-    custom version of the Beta distribution that has an alternative parameterization
+    custom version of the beta distribution that has an alternative parameterization
     in terms of the mean ``mu`` and a dispersion parameter ``nu``.
 
     >>> class MyBeta:
@@ -3686,7 +3680,7 @@ def make_distribution(dist):
     ...             {"mu": (0, 1), "nu": (0, np.inf)},
     ...         )
     ...
-    ...     def _process_parameters(self, a=None, b=None, mu=None, nu=None):
+    ...     def process_parameters(self, a=None, b=None, mu=None, nu=None):
     ...         if a is not None and b is not None and mu is None and nu is None:
     ...             nu = a + b
     ...             mu = a / nu
@@ -3912,11 +3906,11 @@ def _make_distribution_custom(dist):
         CustomDistribution._moment_central_formula = _moment_central_formula
         CustomDistribution._moment_standardized_formula = _moment_standardized_formula
 
-    if hasattr(dist, '_process_parameters'):
+    if hasattr(dist, 'process_parameters'):
         setattr(
             CustomDistribution,
             "_process_parameters",
-            getattr(dist, "_process_parameters")
+            getattr(dist, "process_parameters")
         )
 
     support_etc = _combine_docs(CustomDistribution, include_examples=False).lstrip()

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3515,8 +3515,9 @@ def make_distribution(dist):
             described below. Each ``dict`` in the ``tuple`` will correspond to a
             separate parametrization of the distribution. If multiple parameterizations
             are specified, ``dist``'s class must also define a method
-           ``_process_parameters`` to allow mapping between the different parameterizations.
-           The requirements for this method are described further below.
+            ``_process_parameters`` to allow mapping between the different
+            parameterizations. The requirements for this method are described further
+            below.
 
             If a ``dict``, each key is the name of a parameter,
             and the corresponding value is either a dictionary or tuple.
@@ -3682,18 +3683,16 @@ def make_distribution(dist):
     ...     def parameters(self):
     ...         return (
     ...             {"a": (0, np.inf), "b": (0, np.inf)},
-    ...             {"mu": (0, np.inf), "nu": (0, np.inf)},
+    ...             {"mu": (0, 1), "nu": (0, np.inf)},
     ...         )
     ...
     ...     def _process_parameters(self, a=None, b=None, mu=None, nu=None):
     ...         if a is not None and b is not None and mu is None and nu is None:
     ...             nu = a + b
     ...             mu = a / nu
-    ...         elif mu is not None and nu is not None and a is None and b is None:
+    ...         else:
     ...             a = mu * nu
     ...             b = nu - a
-    ...         else:
-    ...             raise ValueError("Invalid parameterization of MyBeta.")
     ...         return {"a": a, "b": b, "mu": mu, "nu": nu}
     ...
     ...     @property
@@ -3914,7 +3913,11 @@ def _make_distribution_custom(dist):
         CustomDistribution._moment_standardized_formula = _moment_standardized_formula
 
     if hasattr(dist, '_process_parameters'):
-        setattr(CustomDistribution, "_process_parameters", getattr(dist, "_process_parameters"))
+        setattr(
+            CustomDistribution,
+            "_process_parameters",
+            getattr(dist, "_process_parameters")
+        )
 
     support_etc = _combine_docs(CustomDistribution, include_examples=False).lstrip()
     docs = [

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3852,6 +3852,11 @@ def _make_distribution_custom(dist):
     )
     parameterizations = []
     for parameterization in dist_parameters:
+        # The attribute name ``parameters`` appears reasonable from a user facing
+        # perspective, but there is a little tension here with the internal. It's
+        # important to keep in mind that the ``parameters`` attribute in a
+        # user-created custom distribution specifies ``_parameterizations`` within
+        # the infrastructure.
         parameters = []
 
         for name, info in parameterization.items():

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3511,7 +3511,7 @@ def make_distribution(dist):
             in which case support for an old interface version may be deprecated
             and eventually removed.
         parameters : dict or tuple
-            If a ``dict``, each key is the name of a parameter,
+            If a dictionary, each key is the name of a parameter,
             and the corresponding value is either a dictionary or tuple.
             If the value is a dictionary, it may have the following items, with default
             values used for entries which aren't present.
@@ -3533,17 +3533,17 @@ def make_distribution(dist):
                 ``endpoints`` tuple above, and should define a subinterval of the
                 domain given by ``endpoints``.
 
-            A ``tuple`` value ``(a, b)`` associated to a key in the ``parameters``
-            ``dict`` is equivalent to ``{endpoints: (a, b)}``.
+            A tuple value ``(a, b)`` associated to a key in the ``parameters``
+            dictionary is equivalent to ``{endpoints: (a, b)}``.
 
             Custom distributions with multiple parameterizations can be defined by
-            having the ``parameters`` attribute be a ``tuple`` of ``dict``s with
-            the structure described above. In this case, ``dist``'s class must also
-            define a method ``process_parameters` to map between the different
+            having the ``parameters`` attribute be a tuple of dictionaries with
+            the structure described above. In this case, ``dist``\'s class must also
+            define a method ``process_parameters`` to map between the different
             parameterizations. It must take all parameters from all parameterizations
-            as optional keyword arguments and return a ``dict`` mapping parameters to
+            as optional keyword arguments and return a dictionary mapping parameters to
             values, filling in values from other parameterizations using values from
-            the supplied parameterization.
+            the supplied parameterization. See example.
 
         support : dict or tuple
             A dictionary describing the support of the distribution or a tuple
@@ -3558,16 +3558,16 @@ def make_distribution(dist):
         ``moment``, and ``sample``.
         If defined, these methods must accept the parameters of the distribution as
         keyword arguments and also accept any positional-only arguments accepted by
-        the corresponding method of `ContinuousDistribution`. When multiple
-        parameterizations are defined, these methods must accept all parameters from
-        all parameterizations. The ``moment`` method must accept the ``order`` and
-        ``kind`` arguments by position or keyword, but may return ``None`` if a
-        formula is not available for the arguments; in this case, the infrastructure
-        will fall back to a default implementation. The ``sample`` method must accept
-        ``shape`` by position or keyword, but contrary to the public method of the
-        same name, the argument it receives will be the *full* shape of the output
-        array - that is, the shape passed to the public method prepended to the
-        broadcasted shape of random variable parameters.
+        the corresponding method of `ContinuousDistribution`. 
+        When multiple parameterizations are defined, these methods must accept
+        all parameters from all parameterizations. The ``moment`` method
+        must accept the ``order`` and ``kind`` arguments by position or keyword, but
+        may return ``None`` if a formula is not available for the arguments; in this
+        case, the infrastructure will fall back to a default implementation. The
+        ``sample`` method must accept ``shape`` by position or keyword, but contrary
+        to the public method of the same name, the argument it receives will be the
+        *full* shape of the output array - that is, the shape passed to the public
+        method prepended to the broadcasted shape of random variable parameters.
 
     Returns
     -------
@@ -3675,19 +3675,17 @@ def make_distribution(dist):
     ...
     ...     @property
     ...     def parameters(self):
-    ...         return (
-    ...             {"a": (0, np.inf), "b": (0, np.inf)},
-    ...             {"mu": (0, 1), "nu": (0, np.inf)},
-    ...         )
+    ...         return ({"a": (0, np.inf), "b": (0, np.inf)},
+    ...                 {"mu": (0, 1), "nu": (0, np.inf)})
     ...
     ...     def process_parameters(self, a=None, b=None, mu=None, nu=None):
-    ...         if a is not None and b is not None and mu is None and nu is None:
+    ...         if a is not None and b is not None:
     ...             nu = a + b
     ...             mu = a / nu
     ...         else:
     ...             a = mu * nu
     ...             b = nu - a
-    ...         return {"a": a, "b": b, "mu": mu, "nu": nu}
+    ...         return dict(a=a, b=b, mu=mu, nu=nu)
     ...
     ...     @property
     ...     def support(self):

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3594,6 +3594,7 @@ def make_distribution(dist):
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
     >>> from scipy import stats
+    >>> from scipy import special
 
     Create a `ContinuousDistribution` from `scipy.stats.loguniform`.
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1273,8 +1273,8 @@ class TestMakeDistribution:
         assert_allclose(X1.icdf(p), X2.icdf(p))
         assert_allclose(X1.iccdf(p), X2.iccdf(p))
 
-    @pytest.mark.parametrize("a", [0.5, 1.0, 2.0, 4.0, 8.0])
-    @pytest.mark.parametrize("b", [0.5, 1.0, 2.0, 4.0, 8.0])
+    @pytest.mark.parametrize("a", [0.5, np.asarray([0.5, 1.0, 2.0, 4.0, 8.0])])
+    @pytest.mark.parametrize("b", [0.5, np.asarray([0.5, 1.0, 2.0, 4.0, 8.0])])
     def test_custom_multiple_parameterizations(self, a, b):
         rng = np.random.default_rng(7548723590230982)
         class MyBeta:

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_allclose, assert_equal
 from hypothesis import strategies, given, reproduce_failure, settings  # noqa: F401
 import hypothesis.extra.numpy as npst
 
+from scipy import special
 from scipy import stats
 from scipy.stats._fit import _kolmogorov_smirnov
 from scipy.stats._ksstats import kolmogn
@@ -1271,6 +1272,67 @@ class TestMakeDistribution:
         assert_allclose(X1.ccdf(x), X2.ccdf(x))
         assert_allclose(X1.icdf(p), X2.icdf(p))
         assert_allclose(X1.iccdf(p), X2.iccdf(p))
+
+    @pytest.mark.parametrize("a", [0.5, 1.0, 2.0, 4.0, 8.0])
+    @pytest.mark.parametrize("b", [0.5, 1.0, 2.0, 4.0, 8.0])
+    def test_custom_multiple_parameterizations(self, a, b):
+        rng = np.random.default_rng(7548723590230982)
+        class MyBeta:
+            @property
+            def __make_distribution_version__(self):
+                return "1.16.0"
+
+            @property
+            def parameters(self):
+                return (
+                    {"a": (0, np.inf), "b": (0, np.inf)},
+                    {"mu": (0, np.inf), "nu": (0, np.inf)},
+                )
+
+            def _process_parameters(self, a=None, b=None, mu=None, nu=None):
+                if a is not None and b is not None and mu is None and nu is None:
+                    nu = a + b
+                    mu = a / nu
+                elif mu is not None and nu is not None and a is None and b is None:
+                    a = mu * nu
+                    b = nu - a
+                else:
+                    raise ValueError("Invalid parameterization of MyBeta.")
+                return {"a": a, "b": b, "mu": mu, "nu": nu}
+
+            @property
+            def support(self):
+                return {'endpoints': (0, 1)}
+
+            def pdf(self, x, a, b, mu, nu):
+                return special._ufuncs._beta_pdf(x, a, b)
+
+            def cdf(self, x, a, b, mu, nu):
+                return special.betainc(a, b, x)
+
+        Beta = stats.make_distribution(stats.beta)
+        MyBeta = stats.make_distribution(MyBeta())
+
+        mu = a / (a + b)
+        nu = a + b
+
+        X = MyBeta(a=a, b=b)
+        Y = MyBeta(mu=mu, nu=nu)
+        Z = Beta(a=a, b=b)
+        print(X, Y, Z)
+
+        x = Z.sample(shape=10, rng=rng)
+        p = Z.cdf(x)
+
+        assert_allclose(Z.support(), X.support())
+        assert_allclose(Z.median(), X.median())
+        assert_allclose(Z.pdf(x), X.pdf(x))
+        assert_allclose(Z.cdf(x), X.cdf(x))
+
+        assert_allclose(Z.support(), Y.support())
+        assert_allclose(Z.median(), Y.median())
+        assert_allclose(Z.pdf(x), Y.pdf(x))
+        assert_allclose(Z.cdf(x), Y.cdf(x))
 
     def test_input_validation(self):
         message = '`levy_stable` is not supported.'

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1319,10 +1319,8 @@ class TestMakeDistribution:
         X = MyBeta(a=a, b=b)
         Y = MyBeta(mu=mu, nu=nu)
         Z = Beta(a=a, b=b)
-        print(X, Y, Z)
 
         x = Z.sample(shape=10, rng=rng)
-        p = Z.cdf(x)
 
         assert_allclose(Z.support(), X.support())
         assert_allclose(Z.median(), X.median())

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1289,7 +1289,7 @@ class TestMakeDistribution:
                     {"mu": (0, 1), "nu": (0, np.inf)},
                 )
 
-            def _process_parameters(self, a=None, b=None, mu=None, nu=None):
+            def process_parameters(self, a=None, b=None, mu=None, nu=None):
                 if a is not None and b is not None and mu is None and nu is None:
                     nu = a + b
                     mu = a / nu

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1286,18 +1286,16 @@ class TestMakeDistribution:
             def parameters(self):
                 return (
                     {"a": (0, np.inf), "b": (0, np.inf)},
-                    {"mu": (0, np.inf), "nu": (0, np.inf)},
+                    {"mu": (0, 1), "nu": (0, np.inf)},
                 )
 
             def _process_parameters(self, a=None, b=None, mu=None, nu=None):
                 if a is not None and b is not None and mu is None and nu is None:
                     nu = a + b
                     mu = a / nu
-                elif mu is not None and nu is not None and a is None and b is None:
+                else:
                     a = mu * nu
                     b = nu - a
-                else:
-                    raise ValueError("Invalid parameterization of MyBeta.")
                 return {"a": a, "b": b, "mu": mu, "nu": nu}
 
             @property
@@ -1321,16 +1319,23 @@ class TestMakeDistribution:
         Z = Beta(a=a, b=b)
 
         x = Z.sample(shape=10, rng=rng)
+        p = Z.cdf(x)
 
-        assert_allclose(Z.support(), X.support())
-        assert_allclose(Z.median(), X.median())
-        assert_allclose(Z.pdf(x), X.pdf(x))
-        assert_allclose(Z.cdf(x), X.cdf(x))
+        assert_allclose(X.support(), Z.support())
+        assert_allclose(X.median(), Z.median())
+        assert_allclose(X.pdf(x), Z.pdf(x))
+        assert_allclose(X.cdf(x), Z.cdf(x))
+        assert_allclose(X.ccdf(x), Z.ccdf(x))
+        assert_allclose(X.icdf(p), Z.icdf(p))
+        assert_allclose(X.iccdf(p), Z.iccdf(p))
 
-        assert_allclose(Z.support(), Y.support())
-        assert_allclose(Z.median(), Y.median())
-        assert_allclose(Z.pdf(x), Y.pdf(x))
-        assert_allclose(Z.cdf(x), Y.cdf(x))
+        assert_allclose(Y.support(), Z.support())
+        assert_allclose(Y.median(), Z.median())
+        assert_allclose(Y.pdf(x), Z.pdf(x))
+        assert_allclose(Y.cdf(x), Z.cdf(x))
+        assert_allclose(Y.ccdf(x), Z.ccdf(x))
+        assert_allclose(Y.icdf(p), Z.icdf(p))
+        assert_allclose(Y.iccdf(p), Z.iccdf(p))
 
     def test_input_validation(self):
         message = '`levy_stable` is not supported.'


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
There is no issue, but this was discussed in https://github.com/scipy/scipy/pull/22560#issuecomment-2676153771.

#### What does this implement/fix?
<!--Please explain your changes.-->
This updates `make_distribution` to allow for specifying custom distributions with multiple parameterizations following @mdhaber's suggestion here https://github.com/scipy/scipy/pull/22560#issuecomment-2676153771. Previously the `parameterization` attribute of user defined custom distribution classes could only be a dictionary defining a single parameterization. Now it can also be a tuple of such dictionaries. If a user defined custom distribution class has multiple parameterizations defined through such a tuple, the class also must define the method `_process_parameters` that allows mapping between parameterizations.

I added an example and test that defines a custom Beta distribution with two parameterizations, the regular one, and an alternative parameterization in terms of the mean $\mu = \frac{a}{a + b}$ and a dispersion parameter $\nu = a + b$. The alternative parameterization is used in [beta-binomial regression](https://www.researchgate.net/publication/7184584_A_better_lemon_squeezer_Maximum-likelihood_regression_with_beta-distributed_dependent_variables).

#### Additional information
<!--Any additional information you think is important.-->
@mdhaber, is this what you had in mind? Is it fine that methods like `pdf` should take all parameters from all parameterizations even if they aren't used? Is it fine that users have to define `_process_parameters` like this?

Also, this isn't really related to the content of this PR, but I noticed while writing tests that `CustomDistribution`'s raise when calling methods for which they don't define an implementation instead of using a default implementation. So for example, for the distribution from the test

```python
    class MyBeta:
            @property
            def __make_distribution_version__(self):
                return "1.16.0"

            @property
            def parameters(self):
                return (
                    {"a": (0, np.inf), "b": (0, np.inf)},
                    {"mu": (0, np.inf), "nu": (0, np.inf)},
                )

            def _process_parameters(self, a=None, b=None, mu=None, nu=None):
                if a is not None and b is not None and mu is None and nu is None:
                    nu = a + b
                    mu = a / nu
                elif mu is not None and nu is not None and a is None and b is None:
                    a = mu * nu
                    b = nu - a
                else:
                    raise ValueError("Invalid parameterization of MyBeta.")
                return {"a": a, "b": b, "mu": mu, "nu": nu}

            @property
            def support(self):
                return {'endpoints': (0, 1)}

            def pdf(self, x, a, b, mu, nu):
                return special._ufuncs._beta_pdf(x, a, b)

            def cdf(self, x, a, b, mu, nu):
                return special.betainc(a, b, x)

    MyBeta = stats.make_distribution(MyBeta())
    X = MyBeta(a=2.0, b=2.0)
```

`X.entropy()` will raise with

```
NotImplementedError: `CustomDistribution` does not provide an accurate implementation of the required method. Consider leaving `method` and `tol` unspecified to use another implementation.
```

Is that expected? Should we change it so that the default implementation is used instead? I haven't untangled exactly why this is happening yet.
