### PR TITLE
DOC: fft.hfft2: added example

### DIFF
--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -1484,6 +1484,15 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
     This is really just `hfftn` with different default behavior.
     For more details see `hfftn`.
 
+    Examples
+    --------
+    >>> import scipy.fft
+    >>> import numpy as np
+    >>> x = np.array([[1+0j, 2+0j], [2+0j, 1+0j]])  # Hermitian-symmetric input
+    >>> scipy.fft.hfft2(x, s=(2, 2))
+    array([[ 6.,  0.],
+          [ 0., -2.]])
+
     """
     return (Dispatchable(x, np.ndarray),)
 

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -1491,7 +1491,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
     >>> x = np.array([[1+0j, 2+0j], [2+0j, 1+0j]])  # Hermitian-symmetric input
     >>> scipy.fft.hfft2(x, s=(2, 2))
     array([[ 6.,  0.],
-          [ 0., -2.]])
+           [ 0., -2.]])
 
     """
     return (Dispatchable(x, np.ndarray),)


### PR DESCRIPTION
Reference issue
Issue (https://github.com/scipy/scipy/issues/7168) DOC: Add "Examples" to docstrings #7168

What does this implement?
I added an example code to the docstrings of  `scipy.fft.hfft2`

Additional information
This is my first contribution to this repository, so if I made any mistake on convention for the docstring or made another mistake, feel free to point it out.