### PR TITLE
MAINT: special: refine `logsumexp` writeback behaviour

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -514,7 +514,7 @@ def xp_ravel(x: Array, /, *, xp: ModuleType | None = None) -> Array:
 
 
 # utility to broadcast arrays and promote to common dtype
-def xp_broadcast_promote(*args, ensure_writeable=False, force_floating=False, xp=None):
+def xp_broadcast_promote(*args, force_floating=False, xp=None):
     xp = array_namespace(*args) if xp is None else xp
 
     args = [(_asarray(arg, subok=True) if arg is not None else arg) for arg in args]
@@ -561,9 +561,10 @@ def xp_broadcast_promote(*args, ensure_writeable=False, force_floating=False, xp
             kwargs = {'subok': True} if is_numpy(xp) else {}
             arg = xp.broadcast_to(arg, shape, **kwargs)
 
-        # convert dtype/copy only if needed
-        if (arg.dtype != dtype) or ensure_writeable:
-            arg = xp.astype(arg, dtype, copy=True)
+        # This is much faster than xp.astype(arg, dtype, copy=False)
+        if arg.dtype != dtype:
+            arg = xp.astype(arg, dtype)
+
         out.append(arg)
 
     return out

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -104,7 +104,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
 
     """
     xp = array_namespace(a, b)
-    a, b = xp_broadcast_promote(a, b, ensure_writeable=True, force_floating=True, xp=xp)
+    a, b = xp_broadcast_promote(a, b, force_floating=True, xp=xp)
     a = xpx.atleast_nd(a, ndim=1, xp=xp)
     b = xpx.atleast_nd(b, ndim=1, xp=xp) if b is not None else b
     axis = tuple(range(a.ndim)) if axis is None else axis
@@ -115,10 +115,10 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
             # delegate edge case handling to the behavior of `xp.log` and `xp.exp`,
             # which should follow the C99 standard for complex values.
             b_exp_a = xp.exp(a) if b is None else b * xp.exp(a)
-            sum = xp.sum(b_exp_a, axis=axis, keepdims=True)
-            sgn_inf = _sign(sum, xp) if return_sign else None
-            sum = xp.abs(sum) if return_sign else sum
-            out_inf = xp.log(sum)
+            sum_ = xp.sum(b_exp_a, axis=axis, keepdims=True)
+            sgn_inf = _sign(sum_, xp=xp) if return_sign else None
+            sum_ = xp.abs(sum_) if return_sign else sum_
+            out_inf = xp.log(sum_)
 
         with np.errstate(divide='ignore', invalid='ignore'):  # log of zero is OK
             out, sgn = _logsumexp(a, b, axis=axis, return_sign=return_sign, xp=xp)
@@ -138,11 +138,11 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     if xp.isdtype(out.dtype, 'complex floating'):
         if return_sign:
             real = xp.real(sgn)
-            imag = xp_float_to_complex(_wrap_radians(xp.imag(sgn), xp))
+            imag = xp_float_to_complex(_wrap_radians(xp.imag(sgn), xp=xp), xp=xp)
             sgn = real + imag*1j
         else:
             real = xp.real(out)
-            imag = xp_float_to_complex(_wrap_radians(xp.imag(out), xp))
+            imag = xp_float_to_complex(_wrap_radians(xp.imag(out), xp=xp), xp=xp)
             out = real + imag*1j
 
     # Deal with shape details - reducing dimensions and convert 0-D to scalar for NumPy
@@ -154,8 +154,7 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     return (out, sgn) if return_sign else out
 
 
-def _wrap_radians(x, xp=None):
-    xp = array_namespace(x) if xp is None else xp
+def _wrap_radians(x, *, xp):
     # Wrap radians to (-pi, pi] interval
     wrapped = -((-x + xp.pi) % (2 * xp.pi) - xp.pi)
     # preserve relative precision
@@ -163,7 +162,7 @@ def _wrap_radians(x, xp=None):
     return xp.where(no_wrap, x, wrapped)
 
 
-def _elements_and_indices_with_max_real(a, axis=-1, xp=None):
+def _elements_and_indices_with_max_real(a, *, axis=-1, xp):
     # This is an array-API compatible `max` function that works something
     # like `np.max` for complex input. The important part is that it finds
     # the element with maximum real part. When there are multiple complex values
@@ -172,13 +171,12 @@ def _elements_and_indices_with_max_real(a, axis=-1, xp=None):
     # `take_along_axis`, and even if it did, we would have problems with axis tuples.
     # Feel free to rewrite! It's ugly, but it's not the purpose of the PR, and
     # it gets the job done.
-    xp = array_namespace(a) if xp is None else xp
 
     if xp.isdtype(a.dtype, "complex floating"):
         # select all elements with max real part.
         real_a = xp.real(a)
-        max = xp.max(real_a, axis=axis, keepdims=True)
-        mask = real_a == max
+        max_ = xp.max(real_a, axis=axis, keepdims=True)
+        mask = real_a == max_
 
         # Of those, choose one arbitrarily. This is a reasonably
         # simple, array-API compatible way of doing so that doesn't
@@ -188,37 +186,36 @@ def _elements_and_indices_with_max_real(a, axis=-1, xp=None):
         max_i = xp.max(i, axis=axis, keepdims=True)
         mask = i == max_i
         a = xp.where(mask, a, 0.)
-        max = xp.sum(a, axis=axis, dtype=a.dtype, keepdims=True)
+        max_ = xp.sum(a, axis=axis, dtype=a.dtype, keepdims=True)
     else:
-        max = xp.max(a, axis=axis, keepdims=True)
-        mask = a == max
+        max_ = xp.max(a, axis=axis, keepdims=True)
+        mask = a == max_
 
-    return xp.asarray(max), xp.asarray(mask)
+    return max_, mask
 
 
-def _sign(x, xp):
+def _sign(x, *, xp):
     return x / xp.where(x == 0, 1., xp.abs(x))
 
 
-def _logsumexp(a, b, axis, return_sign, xp):
-
+def _logsumexp(a, b, *, axis, return_sign, xp):
     # This has been around for about a decade, so let's consider it a feature:
     # Even if element of `a` is infinite or NaN, it adds nothing to the sum if
     # the corresponding weight is zero.
     if b is not None:
-        a = xpx.at(a, b == 0).set(-xp.inf)
+        a = xpx.at(a, b == 0).set(-xp.inf, copy=True)
 
     # Find element with maximum real part, since this is what affects the magnitude
     # of the exponential. Possible enhancement: include log of `b` magnitude in `a`.
     a_max, i_max = _elements_and_indices_with_max_real(a, axis=axis, xp=xp)
 
     # for precision, these terms are separated out of the main sum.
-    a = xpx.at(a, i_max).set(-xp.inf)
+    a = xpx.at(a, i_max).set(-xp.inf, copy=True if b is None else None)
     i_max_dt = xp.astype(i_max, a.dtype)
     # This is an inefficient way of getting `m` because it is the sum of a sparse
     # array; however, this is the simplest way I can think of to get the right shape.
-    m = (xp.sum(i_max_dt, axis=axis, keepdims=True, dtype=a.dtype) if b is None
-         else xp.sum(b * i_max_dt, axis=axis, keepdims=True, dtype=a.dtype))
+    b_i_max = i_max_dt if b is None else b * i_max_dt
+    m = xp.sum(b_i_max, axis=axis, keepdims=True, dtype=a.dtype)
 
     # Shift, exponentiate, scale, and sum
     exp = b * xp.exp(a - a_max) if b is not None else xp.exp(a - a_max)

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -28,7 +28,7 @@ def test_wrap_radians(xp):
                     0, 1e-300, 1, math.pi, math.pi+1])
     ref = xp.asarray([math.pi-1, math.pi, -1, -1e-300,
                     0, 1e-300, 1, math.pi, -math.pi+1])
-    res = _wrap_radians(x, xp)
+    res = _wrap_radians(x, xp=xp)
     xp_assert_close(res, ref, atol=0)
 
 
@@ -291,6 +291,15 @@ class TestLogSumExp:
         res = logsumexp(xp.asarray([x, y]))
         ref = xp.log(xp.sum(xp.exp(xp.asarray([x, y]))))
         xp_assert_equal(res, ref)
+
+    def test_no_writeback(self, xp):
+        """Test that logsumexp doesn't accidentally write back to its parameters."""
+        a = xp.asarray([5., 4.])
+        b = xp.asarray([3., 2.])
+        logsumexp(a)
+        logsumexp(a, b=b)
+        xp_assert_equal(a, xp.asarray([5., 4.]))
+        xp_assert_equal(b, xp.asarray([3., 2.]))
 
 
 class TestSoftmax:


### PR DESCRIPTION
- Revisit how `logsumexp` avoids writing back to its arguments.
- Remove unnecessary deep copy of `b`
- On JAX and (in the future) PyData Sparse, remove an unnecessary copy of `a`.
- Add test that the arguments are effectively preserved.
- Minor style cleanup.
