### PR TITLE
TST: weightedtau rng thread safety

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2111,15 +2111,15 @@ def test_weightedtau_vs_quadratic():
     def weigher(x):
         return 1. / (x + 1)
 
-    np.random.seed(42)
+    rng = np.random.default_rng(42)
     for s in range(3,10):
         a = []
         # Generate rankings with ties
         for i in range(s):
             a += [i]*i
         b = list(a)
-        np.random.shuffle(a)
-        np.random.shuffle(b)
+        rng.shuffle(a)
+        rng.shuffle(b)
         # First pass: use element indices as ranks
         rank = np.arange(len(a), dtype=np.intp)
         for _ in range(2):
@@ -2128,7 +2128,7 @@ def test_weightedtau_vs_quadratic():
                 actual = stats.weightedtau(a, b, rank, weigher, add).statistic
                 assert_approx_equal(expected, actual)
             # Second pass: use a random rank
-            np.random.shuffle(rank)
+            rng.shuffle(rank)
 
 
 class TestFindRepeats:


### PR DESCRIPTION
* This deals with one of the items in gh-22758.

* `test_weightedtau_vs_quadratic()` has been adjusted to use a local "scoped"/modern NumPy random `Generator` rather than a global random seed, which allows the following parallel stress test incantation to pass 3 times in a row locally on x86_64 Linux after failing 3 times in a row on latest `main`:

`python dev.py test -t scipy/stats/tests/test_stats.py::test_weightedtau_vs_quadratic -- -- --parallel-threads=40 --iterations=40`

* For a bit more detail, the shuffled arrays (`a` and `b`) were not shuffled deterministically in the repeat incantations on SciPy `main`, and possibly other data structures were also not deterministic as a result. I believe I've seen swaps away from global NumPy random state in a few thread safety patches now so I believe this is not unexpected. I could also perhaps use i.e., 17 digits instead of 2 for `default_rng` but ...
