### PR TITLE
BUG: optimize: `VectorFunction.f_updated` wasn't being set on initialisation

### DIFF
--- a/scipy/optimize/_differentiable_functions.py
+++ b/scipy/optimize/_differentiable_functions.py
@@ -500,7 +500,7 @@ class VectorFunction:
             self.f = fun_wrapped(xp_copy(self.x))
 
         self._update_fun_impl = update_fun
-        update_fun()
+        self._update_fun()
 
         self.v = np.zeros_like(self.f)
         self.m = self.v.size

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -406,7 +406,8 @@ def least_squares(
         of crucial importance.
     max_nfev : None or int, optional
         For all methods this parameter controls the maximum number of function
-        evaluations separate to those used in numerical approximation of the jacobian.
+        evaluations used by each method, separate to those used in numerical
+        approximation of the jacobian.
         If None (default), the value is chosen automatically as 100 * n.
 
         .. versionchanged:: 1.16.0

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -564,6 +564,24 @@ class TestVectorialFunction(TestCase):
         assert_array_almost_equal(f_analit, f_approx)
         assert_array_almost_equal(J_analit, J_approx)
 
+    def test_updating_on_initial_setup(self):
+        # Check that memoisation works with the freshly created VectorFunction
+        # On initialization vf.f_updated attribute wasn't being set correctly.
+        x0 = np.array([2.5, 3.0])
+        ex = ExVectorialFunction()
+        vf = VectorFunction(ex.fun, x0, ex.jac, ex.hess)
+        assert vf.f_updated
+        assert vf.nfev == 1
+        assert vf.njev == 1
+        assert ex.nfev == 1
+        assert ex.njev == 1
+        vf.fun(x0)
+        vf.jac(x0)
+        assert vf.nfev == 1
+        assert vf.njev == 1
+        assert ex.nfev == 1
+        assert ex.njev == 1
+
     @pytest.mark.fail_slow(5.0)
     def test_workers(self):
         x0 = np.array([2.5, 3.0])

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -36,6 +36,15 @@ def fun_rosenbrock(x):
     return np.array([10 * (x[1] - x[0]**2), (1 - x[0])])
 
 
+class Fun_Rosenbrock:
+    def __init__(self):
+        self.nfev = 0
+
+    def __call__(self, x, a=0):
+        self.nfev += 1
+        return fun_rosenbrock(x)
+
+
 def jac_rosenbrock(x):
     return np.array([
         [-20 * x[0], 10],
@@ -287,6 +296,17 @@ class BaseMixin:
         assert_equal(res.njev, 1)
         assert_equal(res.status, 0)
         assert_equal(res.success, 0)
+
+    def test_nfev(self):
+        # checks that the true number of nfev are being consumed
+        for i in range(1, 3):
+            rng = np.random.default_rng(128908)
+            x0 = rng.uniform(size=2) * 10
+            ftrivial = Fun_Rosenbrock()
+            res = least_squares(
+               ftrivial, x0, jac=jac_rosenbrock, method=self.method, max_nfev=i
+            )
+            assert res.nfev == ftrivial.nfev
 
     def test_rosenbrock(self):
         x0 = [-2, 1]


### PR DESCRIPTION
Found a bug that `optimize._differentiable_functions.VectorFunction` didn't have its `f_updated` attribute set correctly upon initialisation. This PR fixes that, and adds a check that the attribute is set correctly. 

Other tests are added to check that `least_squares` have the correct number of `nfev`, which is how I discovered the bug.