### PR TITLE
ENH: io.loadmat: extract data from MATLAB objects/classes

### DIFF
--- a/scipy/io/matlab/_mio5_params.py
+++ b/scipy/io/matlab/_mio5_params.py
@@ -277,5 +277,11 @@ class MatlabOpaque(np.ndarray):
         return obj
 
 
-OPAQUE_DTYPE = np.dtype(
-    [('s0', 'O'), ('s1', 'O'), ('s2', 'O'), ('arr', 'O')])
+OPAQUE_DTYPE = np.dtype([
+    ('object_reference', np.uint32),
+    ('n_dims', np.uint32),
+    ('dims', object),
+    ('object_id', np.uint32),
+    ('class_id', np.uint32)
+]) 
+#! legacy for now, remove later


### PR DESCRIPTION
This pull request is part of an enhancement to `io.loadmat` to incorporate reading and writing of MATLAB objects/classes in MAT-files.

This has been detailed in #22736, and references other issues opened in the past #11818 #12408 #13636 #15984 

The purpose of this PR is to contribute to the development process iteratively, allowing for feedback along the way. The initial commit includes:
- Updated `MatFile5Reader.read_file_header()` to return the subsystem offset. This will be used as a flag later on to detect and process subsystem data

- Updated `VarReader5.read_header()` to return the variable name for `mxOPAQUE_CLASS`
    - Additional headers i.e., Type System Name and Class Name, are read but not included as part of the header. As per my knowledge, they are not required for processing `mxOPAQUE_CLASS` arrays
    
- Updated `VarReader5.read_opaque()` to return the object ID of the variable.
    - Object ID will be used to link field contents from the subsystem to the variable name
    - Other metadata like class ID and object reference is not required
    - TODO: Extract `ndims` and `dims` from this data element and update the var header
    
- Updated `OPAQUE_DTYPE` to represent `object_id`. This is simply to check if the variable is an object when finally linking it with the subsystem