### PR TITLE
BUG: sparse: Remove reference cycle to improve memory use

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -824,19 +824,19 @@ class MatrixLinearOperator(LinearOperator):
             self.__adj = _AdjointMatrixOperator(self.A)
         return self.__adj
 
+
 class _AdjointMatrixOperator(MatrixLinearOperator):
     def __init__(self, adjoint_array):
-        self.__adjoint = adjoint_array
         self.A = adjoint_array.T.conj()
         self.args = (adjoint_array,)
         self.shape = adjoint_array.shape[1], adjoint_array.shape[0]
 
     @property
     def dtype(self):
-        return self.__adjoint.dtype
+        return self.args[0].dtype
 
     def _adjoint(self):
-        return MatrixLinearOperator(self.__adjoint)
+        return MatrixLinearOperator(self.args[0])
 
 
 class IdentityOperator(LinearOperator):

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -821,22 +821,22 @@ class MatrixLinearOperator(LinearOperator):
 
     def _adjoint(self):
         if self.__adj is None:
-            self.__adj = _AdjointMatrixOperator(self)
+            self.__adj = _AdjointMatrixOperator(self.A)
         return self.__adj
 
 class _AdjointMatrixOperator(MatrixLinearOperator):
-    def __init__(self, adjoint):
-        self.A = adjoint.A.T.conj()
-        self.__adjoint = adjoint
-        self.args = (adjoint,)
-        self.shape = adjoint.shape[1], adjoint.shape[0]
+    def __init__(self, adjoint_array):
+        self.__adjoint = adjoint_array
+        self.A = adjoint_array.T.conj()
+        self.args = (adjoint_array,)
+        self.shape = adjoint_array.shape[1], adjoint_array.shape[0]
 
     @property
     def dtype(self):
         return self.__adjoint.dtype
 
     def _adjoint(self):
-        return self.__adjoint
+        return MatrixLinearOperator(self.__adjoint)
 
 
 class IdentityOperator(LinearOperator):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -13,6 +13,7 @@ import scipy.sparse as sparse
 
 import scipy.sparse.linalg._interface as interface
 from scipy.sparse._sputils import matrix
+from scipy._lib._gcutils import assert_deallocated, IS_PYPY
 
 
 class TestLinearOperator:
@@ -524,3 +525,13 @@ def test_sparse_matmat_exception():
         A @ np.identity(4)
     with assert_raises(ValueError):
         np.identity(4) @ A
+
+
+@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
+def test_MatrixLinearOperator_refcycle():
+    # gh-10634
+    # Test that MatrixLinearOperator can be automatically garbage collected
+    A = np.eye(2)
+    with assert_deallocated(interface.MatrixLinearOperator, A) as op:
+        op.adjoint()
+        del op


### PR DESCRIPTION
#### Reference issue
Fixes #10634

#### What does this implement/fix?

When users run `least_squares()` with `method='trf'`, or `method='dogbox`, with `tr_solver='lsmr'`, this creates a MatrixLinearOperator. It also takes the adjoint of this operator. The MatrixLinearOperator caches its adjoint to avoid re-creating it, and the adjoint caches the original matrix, so that `operator.adjoint().adjoint()` returns the original MatrixLinearOperator. Since this creates a reference cycle, this has the potential to increase memory use.

This can be fixed by changing _AdjointLinearOperator to cache the array backing the MatrixLinearOperator rather than cache the MatrixLinearOperator itself. In other words, the MatrixLinearOperator can keep the _AdjointLinearOperator object alive, but not vice-versa. The MatrixLinearOperator is re-created when required.

There are two test programs that demonstrate the practical impact of this reference cycle.

The first is a example based on the issue report's original example, which can be found here: https://github.com/nickodell/paleochrono_hacks_donotuse/ You can use `python paleochrono.py AICC2012-Hulu-VLR` to run the test script that I ran. The change I am making here reduced memory usage from a peak of 4GB to a peak of 1GB.

I made another example, which is as simple as possible to demonstrate the bug.

```
from scipy.optimize import least_squares
import psutil
import numpy as np


def fun(x):
    return x + 1

def jac(x):
    return np.diag(np.ones_like(x))

def run_problem():
    x0 = np.random.rand(1000)
    res = least_squares(fun, x0, jac=jac, method='trf', tr_solver='lsmr')
    #print(res)


for i in range(1000):
    run_problem()
    if i % 100 == 0:
        print(psutil.Process().memory_info().rss / 1e6, "MB")
```

In this example, memory usage is reduced from a peak of 2243 MB to 862 MB.

~~This example also shows that there is unfortunately still a reference cycle inside `scipy.optimize`, specifically VectorFunction. This PR does not fix that. See #20768 for discussion of the reference cycle in VectorFunction, and [this test](https://github.com/scipy/scipy/blob/2c16b8bfab4d98a824d4723aebd133a402b53c83/scipy/optimize/tests/test_differentiable_functions.py#L995).~~

#### Additional information

While I tried to avoid any performance regressions, converting a matrix into adjoint and back again is unfortunately 5000 ns slower with this patch.

See this benchmark: https://gist.github.com/nickodell/07244788e2433bf4b9b74f0164124712

On main:

```
Took 4792 -/+ 82 ns for <function convert_to_mlo at 0x7f96489b4360>
Took 6373 -/+ 319 ns for <function take_adjoint_twice at 0x7f9610a85580>
Took 6233 -/+ 50 ns for <function get_original_from_adjoint at 0x7f9610a85620>
```

With patch:

```
Took 4885 -/+ 108 ns for <function convert_to_mlo at 0x7f9973904360>
Took 6734 -/+ 86 ns for <function take_adjoint_twice at 0x7f993b9d9580>
Took 11670 -/+ 65 ns for <function get_original_from_adjoint at 0x7f993b9d9620>
```