### PR TITLE
TST: stats: add marray tests for _length_nonmasked directly

### DIFF
--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -275,22 +275,6 @@ def test_ttest_ind_from_stats(xp):
     assert res.statistic.shape == shape
     assert res.pvalue.shape == shape
 
-@pytest.mark.parametrize("keepdims", [False, True])
-def test_length_nonmasked_marray_axis0(keepdims):
-    xp = marray._get_namespace(np)
-
-    data = [[1.0, 2.0, 3.0],
-            [4.0, 5.0, 6.0]]
-    mask = [[False, True, False],
-            [False, False, True]]
-
-    marr = xp.asarray(data, mask=mask)
-
-    result = _length_nonmasked(marr, axis=0, keepdims=keepdims, xp=xp)
-    expected = np.array([[2, 1, 1]]) if keepdims else np.array([2, 1, 1])
-    np.testing.assert_array_equal(result.data, expected)
-
-
 def test_length_nonmasked_marray_iterable_axis_raises():
     xp = marray._get_namespace(np)
 

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -282,7 +282,8 @@ def test_length_nonmasked_marray_iterable_axis_raises():
     mask = [[False, False], [True, False]]
     marr = xp.asarray(data, mask=mask)
 
-    # This should raise because axis is a tuple, and that's not supported for MArray
+    # Axis tuples are not currently supported for MArray input.
+    # This test can be removed after support is added.
     with pytest.raises(NotImplementedError,
         match="`axis` must be an integer or None for use with `MArray`"):
         _length_nonmasked(marr, axis=(0, 1), xp=xp)

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -3,7 +3,7 @@ import numpy as np
 from scipy import stats
 
 from scipy._lib._array_api import xp_assert_close, xp_assert_equal
-from scipy.stats._stats_py import _xp_mean, _xp_var
+from scipy.stats._stats_py import _xp_mean, _xp_var, _length_nonmasked
 from scipy.stats._axis_nan_policy import _axis_nan_policy_factory
 
 
@@ -274,3 +274,31 @@ def test_ttest_ind_from_stats(xp):
     xp_assert_close(res.pvalue.mask, mask)
     assert res.statistic.shape == shape
     assert res.pvalue.shape == shape
+
+@pytest.mark.parametrize("keepdims", [False, True])
+def test_length_nonmasked_marray_axis0(keepdims):
+    xp = marray._get_namespace(np)
+
+    data = [[1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0]]
+    mask = [[False, True, False],
+            [False, False, True]]
+
+    marr = xp.asarray(data, mask=mask)
+
+    result = _length_nonmasked(marr, axis=0, keepdims=keepdims, xp=xp)
+    expected = np.array([[2, 1, 1]]) if keepdims else np.array([2, 1, 1])
+    np.testing.assert_array_equal(result.data, expected)
+
+
+def test_length_nonmasked_marray_iterable_axis_raises():
+    xp = marray._get_namespace(np)
+
+    data = [[1.0, 2.0], [3.0, 4.0]]
+    mask = [[False, False], [True, False]]
+    marr = xp.asarray(data, mask=mask)
+
+    # This should raise because axis is a tuple, and that's not supported for MArray
+    with pytest.raises(NotImplementedError,
+        match="`axis` must be an integer or None for use with `MArray`"):
+        _length_nonmasked(marr, axis=(0, 1), xp=xp)


### PR DESCRIPTION
This PR adds two tests that add coverage for `_length_nonmasked` in `scipy/stats/_stats_py.py` directly, handling the case when the input is a masked array `marray`. This was introduced in https://github.com/scipy/scipy/pull/22393