### PR TITLE
TST/MAINT: signal.symiirorder2: r, omega, precision are floats; use default dtypes

### DIFF
--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -5,7 +5,7 @@ from numpy import (zeros_like, array, tan, arange, floor,
                    moveaxis, abs, complex64, float32)
 import numpy as np
 
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, xp_promote
 
 from scipy._lib._util import normalize_axis_index
 
@@ -797,10 +797,9 @@ def symiirorder2(input, r, omega, precision=-1.0):
         The filtered signal.
     """
     xp = array_namespace(input)
-
-    # internals are numpy-only
-    input = np.asarray(input)
-    omega = np.asarray(omega)
+    input = xp_promote(input, force_floating=True, xp=xp)
+    # This function uses C internals
+    input = np.ascontiguousarray(input)
 
     if r >= 1.0:
         raise ValueError('r must be less than 1.0')
@@ -808,22 +807,16 @@ def symiirorder2(input, r, omega, precision=-1.0):
     if input.ndim > 2:
         raise ValueError('Input must be 1D or 2D')
 
-    if not input.flags.c_contiguous:
-        input = input.copy()
-
     squeeze_dim = False
     if input.ndim == 1:
         input = input[None, :]
         squeeze_dim = True
 
-    if np.issubdtype(input.dtype, np.integer):
-        input = input.astype(np.promote_types(input.dtype, np.float32))
-
     rsq = r * r
-    a2 = 2 * r * np.cos(omega)
+    a2 = 2 * r * math.cos(omega)
     a3 = -rsq
-    cs = np.atleast_1d(1 - 2 * r * np.cos(omega) + rsq)
-    sos = np.atleast_2d(np.r_[cs, 0, 0, 1, -a2, -a3]).astype(input.dtype)
+    cs = 1 - 2 * r * math.cos(omega) + rsq
+    sos = np.asarray([cs, 0, 0, 1, -a2, -a3], dtype=input.dtype)
 
     # Find the starting (forward) conditions.
     ic_fwd = symiirorder2_ic_fwd(input, r, omega, precision)
@@ -831,7 +824,7 @@ def symiirorder2(input, r, omega, precision=-1.0):
     # Apply first the system cs / (1 - a2 * z^-1 - a3 * z^-2)
     # Compute the initial conditions in the form expected by sosfilt
     # coef = np.asarray([[a3, a2], [0, a3]], dtype=input.dtype)
-    coef = np.r_[a3, a2, 0, a3].reshape(2, 2).astype(input.dtype)
+    coef = np.asarray([[a3, a2], [0, a3]], dtype=input.dtype)
     zi = np.matmul(coef, ic_fwd[:, :, None])[:, :, 0]
 
     y_fwd, _ = sosfilt(sos, axis_slice(input, 2), zi=zi[None])

--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -714,6 +714,7 @@ def symiirorder1(signal, c0, z1, precision=-1.0):
         The filtered signal.
     """
     xp = array_namespace(signal)
+    signal = xp_promote(signal, force_floating=True, xp=xp)
 
     # internals of symiirorder1 are numpy-only
     signal = np.asarray(signal)
@@ -728,9 +729,6 @@ def symiirorder1(signal, c0, z1, precision=-1.0):
     if signal.ndim == 1:
         signal = signal[None, :]
         squeeze_dim = True
-
-    if np.issubdtype(signal.dtype, np.integer):
-        signal = signal.astype(np.promote_types(signal.dtype, np.float32))
 
     y0 = symiirorder1_ic(signal, z1, precision)
 

--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -715,8 +715,7 @@ def symiirorder1(signal, c0, z1, precision=-1.0):
     """
     xp = array_namespace(signal)
     signal = xp_promote(signal, force_floating=True, xp=xp)
-
-    # internals of symiirorder1 are numpy-only
+    # This function uses C internals
     signal = np.asarray(signal)
 
     if abs(z1) >= 1:

--- a/scipy/signal/tests/test_splines.py
+++ b/scipy/signal/tests/test_splines.py
@@ -332,10 +332,10 @@ class TestSymIIR:
     def test_symiir2(self, dtype, precision, xp):
         dtype = getattr(xp, dtype)
 
-        r = xp.asarray(0.5, dtype=dtype)
-        omega = xp.asarray(xp.pi / 3.0, dtype=dtype)
-        cs = 1 - 2 * r * xp.cos(omega) + r * r
-        a2 = 2 * r * xp.cos(omega)
+        r = 0.5
+        omega = math.pi / 3.0
+        cs = 1 - 2 * r * math.cos(omega) + r * r
+        a2 = 2 * r * math.cos(omega)
         a3 = -r * r
 
         n = 100

--- a/scipy/signal/tests/test_splines.py
+++ b/scipy/signal/tests/test_splines.py
@@ -373,11 +373,8 @@ class TestSymIIR:
         s = rng.uniform(size=16).astype(dtyp)
         s = xp.asarray(s)
 
-        if is_cupy(xp):
-            # cupy returns f64 for f32 inputs
-            dtype = xp.float64
-        else:
-            dtype = getattr(xp, dtyp)
+        # cupy returns f64 for f32 inputs
+        dtype = xp.float64 if is_cupy(xp) else getattr(xp, dtyp)
 
         res = symiirorder2(s, 0.1, 0.1, precision=1e-10)
 

--- a/scipy/signal/tests/test_splines.py
+++ b/scipy/signal/tests/test_splines.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 import pytest
 import scipy._lib.array_api_extra as xpx
-from scipy._lib._array_api import xp_assert_close, is_cupy
+from scipy._lib._array_api import is_cupy, xp_assert_close, xp_default_dtype
 
 from scipy.signal._spline import (
     symiirorder1_ic, symiirorder2_ic_fwd, symiirorder2_ic_bwd)
@@ -190,7 +190,6 @@ class TestSymIIR:
             0.19982875, 0.20355805, 0.47378628, 0.57232247, 0.51597393,
             0.25935107, 0.31438554, 0.41096728, 0.4190693 , 0.25812255,
             0.33671467], dtype=res.dtype)
-        assert res.dtype == dtype
         atol = {xp.float64: 1e-15, xp.float32: 1e-7}[dtype]
         xp_assert_close(res, exp_res, atol=atol)
 
@@ -367,13 +366,18 @@ class TestSymIIR:
         out = symiirorder2(signal, r, omega, precision)
         xp_assert_close(out, exp, atol=4e-6, rtol=6e-7)
 
-    @skip_xp_backends(cpu_only=True)
+    @skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="C internals")
     @pytest.mark.parametrize('dtyp', ['float32', 'float64'])
     def test_symiir2_values(self, dtyp, xp):
         rng = np.random.RandomState(1234)
         s = rng.uniform(size=16).astype(dtyp)
         s = xp.asarray(s)
-        dtyp = getattr(xp, dtyp)
+
+        if is_cupy(xp):
+            # cupy returns f64 for f32 inputs
+            dtype = xp.float64
+        else:
+            dtype = getattr(xp, dtyp)
 
         res = symiirorder2(s, 0.1, 0.1, precision=1e-10)
 
@@ -382,12 +386,8 @@ class TestSymIIR:
             [0.26572609, 0.53408018, 0.51032696, 0.72115829, 0.69486885,
              0.3649055 , 0.37349478, 0.74165032, 0.89718521, 0.80582483,
              0.46758053, 0.51898709, 0.65025605, 0.65394321, 0.45273595,
-             0.53539183], dtype=dtyp
+             0.53539183], dtype=dtype
         )
-
-        if not is_cupy(xp):
-            # cupy returns f64 for f32 inputs
-            assert res.dtype == dtyp
 
         # The values in SciPy 1.14 agree with those in SciPy 1.9.1 to this
         # accuracy only. Implementation differences are twofold:
@@ -397,7 +397,7 @@ class TestSymIIR:
         # test_symiir2_initial_{fwd,bwd} above, so the difference is likely
         # due to a different way roundoff errors accumulate in the filter.
         # In that respect, sosfilt is likely doing a better job.
-        xp_assert_close(res, exp_res, atol=2e-6, check_dtype=False)
+        xp_assert_close(res, exp_res, atol=2e-6)
 
         I1 = xp.asarray(1 + 1j, dtype=xp.result_type(s, xp.complex64))
         s = s * I1
@@ -405,7 +405,7 @@ class TestSymIIR:
         with pytest.raises((TypeError, ValueError)):
             res = symiirorder2(s, 0.5, 0.1)
 
-    @skip_xp_backends(cpu_only=True)
+    @skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="C internals")
     @xfail_xp_backends("cupy", reason="cupy does not accept integer arrays")
     def test_symiir1_integer_input(self, xp):
         s = xp.where(
@@ -413,11 +413,11 @@ class TestSymIIR:
             xp.asarray(-1),
             xp.asarray(1),
         )
-        expected = symiirorder1(xp.astype(s, xp.float64), 0.5, 0.5)
+        expected = symiirorder1(xp.astype(s, xp_default_dtype(xp)), 0.5, 0.5)
         out = symiirorder1(s, 0.5, 0.5)
         xp_assert_close(out, expected)
 
-    @skip_xp_backends(cpu_only=True)
+    @skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="C internals")
     @xfail_xp_backends("cupy", reason="cupy does not accept integer arrays")
     def test_symiir2_integer_input(self, xp):
         s = xp.where(
@@ -425,6 +425,6 @@ class TestSymIIR:
             xp.asarray(-1),
             xp.asarray(1),
         )
-        expected = symiirorder2(xp.astype(s, xp.float64), 0.5, xp.pi / 3.0)
+        expected = symiirorder2(xp.astype(s, xp_default_dtype(xp)), 0.5, xp.pi / 3.0)
         out = symiirorder2(s, 0.5, xp.pi / 3.0)
         xp_assert_close(out, expected)


### PR DESCRIPTION
- The parameters r, omega, and precision of `scipy.signal.symiirorder2` are floats, as per the documentation.
This PR undoes an improper wrapping in `xp.asarray` in the test.
This fixes a regression vs. array-api-strict git tip, which has started crashing on `__mul__` and other ops vs. np.float64 types, on the line `a2 = 2 * r * np.cos(omega)` because r was an `array_api_strict.Array`.
- When the torch default dtype is float32, `symiirorder1` and `symiirorder2` now return float32 when fed with int inputs, accordingly to the general `xp_promote` policy.
- Re-enabled several tests on CuPy
- Cosmetic enhancement of the code.