### PR TITLE
BUG: signal._short_time_fft: incorrect index computation in `upper_border_begin`

### DIFF
--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -1814,7 +1814,7 @@ class ShortTimeFFT:
         # move window left until does not stick out to the right:
         for q_ in range(q2, q1, -1):
             k_ = q_ * self.hop + (self.m_num - self.m_num_mid)
-            if k_ < n or all(w2[n-k_:] == 0):
+            if k_ <= n or all(w2[n-k_:] == 0):
                 return (q_ + 1) * self.hop - self.m_num_mid, q_ + 1
         return 0, 0  # border starts at first slice
 

--- a/scipy/signal/tests/_scipy_spectral_test_shim.py
+++ b/scipy/signal/tests/_scipy_spectral_test_shim.py
@@ -124,11 +124,8 @@ def _stft_wrapper(x, fs=1.0, window='hann', nperseg=256, noverlap=None,
     k_off = nperseg // 2
     p0 = 0  # ST.lower_border_end[1] + 1
     nn = x.shape[axis] if padded else n+k_off+1
-    p1 = ST.upper_border_begin(nn)[1]  # ST.p_max(n) + 1
-
-    # This is bad hack to pass the test test_roundtrip_boundary_extension():
-    if padded is True and nperseg - noverlap == 1:
-        p1 -= nperseg // 2 - 1  # the reasoning behind this is not clear to me
+    # number of frames akin to legacy stft computation
+    p1 = (x.shape[axis] - len(win)) // nstep + 1 # ST.upper_border_begin(nn)[1]  # ST.p_max(n) + 1
 
     detr = None if detrend is False else detrend
     Sxx = ST.stft_detrend(x, detr, p0, p1, k_offset=k_off, axis=axis)

--- a/scipy/signal/tests/_scipy_spectral_test_shim.py
+++ b/scipy/signal/tests/_scipy_spectral_test_shim.py
@@ -103,7 +103,7 @@ def _stft_wrapper(x, fs=1.0, window='hann', nperseg=256, noverlap=None,
         # This is an edge case where shortTimeFFT returns one more time slice
         # than the Scipy stft() shorten to remove last time slice:
         if n % 2 == 1 and nperseg % 2 == 1 and noverlap % 2 == 1:
-            x = x[..., :axis - 1]
+            x = x[..., : -1]
 
         nadd = (-(x.shape[-1]-nperseg) % nstep) % nperseg
         zeros_shape = list(x.shape[:-1]) + [nadd]
@@ -125,18 +125,13 @@ def _stft_wrapper(x, fs=1.0, window='hann', nperseg=256, noverlap=None,
     p0 = 0  # ST.lower_border_end[1] + 1
     nn = x.shape[axis] if padded else n+k_off+1
     # number of frames akin to legacy stft computation
-    p1 = (x.shape[axis] - len(win)) // nstep + 1 # ST.upper_border_begin(nn)[1]  # ST.p_max(n) + 1
+    p1 = (x.shape[axis] - nperseg) // nstep + 1 
 
     detr = None if detrend is False else detrend
     Sxx = ST.stft_detrend(x, detr, p0, p1, k_offset=k_off, axis=axis)
     t = ST.t(nn, 0, p1 - p0, k_offset=0 if boundary is not None else k_off)
     if x.dtype in (np.float32, np.complex64):
         Sxx = Sxx.astype(np.complex64)
-
-    # workaround for test_average_all_segments() - seems to be buggy behavior:
-    if boundary is None and padded is False:
-        t, Sxx = t[1:-1], Sxx[..., :-2]
-        t -= k_off / fs
 
     return ST.f, t, Sxx
 

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -542,8 +542,10 @@ def test_border_values_exotic():
 
     SFT = ShortTimeFFT(np.flip(w), hop=20, fs=1)
     assert SFT.upper_border_begin(4) == (16, 1)
-    assert SFT.upper_border_begin(3) == (16, 1)
-    assert SFT.upper_border_begin(2) == (16, 1)
+    assert SFT.upper_border_begin(5) == (16, 1)
+    assert SFT.upper_border_begin(23) == (36, 2)
+    assert SFT.upper_border_begin(24) == (36, 2)
+    assert SFT.upper_border_begin(25) == (36, 2)
 
     SFT._hop = -1  # provoke unreachable line
     with pytest.raises(RuntimeError):

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -541,7 +541,9 @@ def test_border_values_exotic():
     assert SFT.lower_border_end == (0, 0)
 
     SFT = ShortTimeFFT(np.flip(w), hop=20, fs=1)
-    assert SFT.upper_border_begin(4) == (0, 0)
+    assert SFT.upper_border_begin(4) == (16, 1)
+    assert SFT.upper_border_begin(3) == (16, 1)
+    assert SFT.upper_border_begin(2) == (16, 1)
 
     SFT._hop = -1  # provoke unreachable line
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Hi!

There seems to be a small bug in `upper_border_begin` of the ShortTimeFFT class in `signal._short_time_fft`.

#### bug and fix

in the loop to find the [highest window unaffected by any padding](https://github.com/scipy/scipy/blob/2636204c5da7f8786adf111eecddc251299139f5/scipy/signal/_short_time_fft.py#L1817) we have
`k_ = q_ * self.hop + (self.m_num - self.m_num_mid)`
k_ is the first index outside window q_ and the clause right after 
`if k_ < n or all(w2[n-k_:] == 0):`
should be an inlcusive clause
`if k_ <= n or all(w2[n-k_:] == 0)` so if it evaluates to true either:
- the last window index falls within the signal of length n, or 
- the part of the window after signal is attenuated to zero


#### related bugs in the tests


The fix brings changes in the tests. A first one [here](https://github.com/scipy/scipy/blob/2636204c5da7f8786adf111eecddc251299139f5/scipy/signal/tests/test_short_time_fft.py#L544):

```
w = np.array([0, 0, 0, 0, 0, 0, 0, 1.])
SFT = ShortTimeFFT(np.flip(w), hop=20, fs=1)
assert SFT.upper_border_begin(4) == (0, 0)
```
This should be `assert SFT.upper_border_begin(4) == (16, 1)`. This line is a good example of what goes wrong, testing different seq lengths
```
w = np.array([0, 0, 0, 0, 0, 0, 0, 1.])
SFT = sig.ShortTimeFFT(np.flip(w), hop=20, fs=1)
for k in range(1,7):
    print("window length:", k, "upper border:", SFT.upper_border_begin(k) )
```
results in 
```
window length: 1 upper border: (16, 1)
window length: 2 upper border: (16, 1)
window length: 3 upper border: (16, 1)
window length: 4 upper border: (0, 0)
window length: 5 upper border: (16, 1)
window length: 6 upper border: (16, 1)
```
where the window ending at index 3 (k_ = 4) is wrongly returned as being affected by post padding for a sequence length of 4, when the window ends exactly at the sequence end. 
The values before and after window length 4 are okay again because of the zeroes in the window.

To also test for the correct handling of zero elements in the windows, I propose a several tests as a replacement:
```
assert SFT.upper_border_begin(4) == (16, 1)
assert SFT.upper_border_begin(3) == (16, 1)
assert SFT.upper_border_begin(2) == (16, 1)
```

and a [second failed test](https://github.com/scipy/scipy/blob/2636204c5da7f8786adf111eecddc251299139f5/scipy/signal/tests/_scipy_spectral_test_shim.py#L127) which is related to an existing hack to make test_roundtrip_boundary_extension() pass. The code is currently:
```
 p1 = ST.upper_border_begin(nn)[1]  # ST.p_max(n) + 1

 # This is bad hack to pass the test test_roundtrip_boundary_extension():
 if padded is True and nperseg - noverlap == 1:
    p1 -= nperseg // 2 - 1  # the reasoning behind this is not clear to me
```

to make this work I'd replace the upper bound computation 
(which is there to get the number frames of the spectrogram that is produced by the [legacy stft](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.stft.html))
with an approximation of stft which holds exactly if the ratio is evenly divisible:
```
p1 = (x.shape[axis] - len(win)) // nstep + 1 # ST.upper_border_begin(nn)[1]  # ST.p_max(n) + 1
```

This should be correct for the tests in question, fingers crossed for no new tests failing.





