### PR TITLE
DOC/DEV: remove references to CirrusCI in skipping CI doc

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,7 +57,6 @@ benchmarks/asv.conf.json  @larsoner
 # CI config
 .circleci/  @larsoner
 .github/workflows/  @larsoner @andyfaff
-.cirrus.star  @larsoner @andyfaff
 
 # Doc
 requirements/doc.txt  @tupui

--- a/.github/label-globs.yml
+++ b/.github/label-globs.yml
@@ -156,7 +156,6 @@ CI:
     - .circleci/**
     - .github/workflows/**
     - ci/**
-    - .cirrus.star
 
 DX:
 - changed-files:

--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -56,6 +56,8 @@ CircleCI
 * ``run_benchmarks``: verify how the changes impact performance
 * ``refguide_check``: doctests from examples and benchmarks
 
+.. _skip-ci:
+
 Skipping
 ========
 

--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -56,14 +56,6 @@ CircleCI
 * ``run_benchmarks``: verify how the changes impact performance
 * ``refguide_check``: doctests from examples and benchmarks
 
-CirrusCI
---------
-* ``Tests``: test suite for specific architecture like
-  ``musllinux, arm, aarch``
-* ``Wheels``: build and upload some wheels
-
-.. _skip-ci:
-
 Skipping
 ========
 
@@ -79,7 +71,6 @@ Skipping CI can be achieved by adding a special text in the commit message:
 
 * ``[skip actions]``: will skip GitHub Actions
 * ``[skip circle]``: will skip CircleCI
-* ``[skip cirrus]``: will skip CirrusCI
 * ``[docs only]``: will skip *all but* the CircleCI checks and the linter
 * ``[lint only]``: will skip *all but* the linter
 * ``[skip ci]``: will skip *all* CI
@@ -88,7 +79,7 @@ Of course, you can combine these to skip multiple workflows.
 
 This skip information should be placed on a new line. In this example, we
 just updated a ``.rst`` file in the documentation and ask to skip all but the
-relevant docs checks (skip Cirrus and GitHub Actions' workflows)::
+relevant docs checks (skip GitHub Actions' workflows)::
 
     DOC: improve QMCEngine examples.
 

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -38,7 +38,7 @@ reported by users.)
 
    As a general guideline, try to accumulate small documentation changes (such
    as typos) instead of sending them one by one. Whenever possible, also make
-   sure to use the correct commands to :ref:`skip CI checks <skip-ci>` on
+   sure to use the correct commands to skip CI checks on
    documentation changes.
 
 Some functions/objects defined in C or Fortran extension modules have their

--- a/doc/source/dev/contributor/rendering_documentation.rst
+++ b/doc/source/dev/contributor/rendering_documentation.rst
@@ -38,7 +38,7 @@ reported by users.)
 
    As a general guideline, try to accumulate small documentation changes (such
    as typos) instead of sending them one by one. Whenever possible, also make
-   sure to use the correct commands to skip CI checks on
+   sure to use the correct commands to :ref:`skip CI checks <skip-ci>` on
    documentation changes.
 
 Some functions/objects defined in C or Fortran extension modules have their


### PR DESCRIPTION
#### Reference issue
#22768

#### What does this implement/fix?
This PR removes references to CirrusCI in the "Skipping CI" documentation and elsewhere, since CirrusCI is no longer used in SciPy.

#### Additional information
Docs only.
