### PR TITLE
DOC: optimize: Add the multiplier details to SLSQP funcs

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -554,7 +554,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     Karush-Kuhn-Tucker (KKT) multipliers, which are a generalization
     of Lagrange multipliers to inequality-constrained optimization problems.
 
-    Notice that at solution, the first constraint is active, let's evaluate the
+    Notice that at the solution, the first constraint is active. Let's evaluate the
     function at solution:
 
     >>> cons[0]['fun'](res.x)

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -529,7 +529,6 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
         [ 0.09495377,  0.18996269,  0.38165151,  0.7664427,   1.53713523]
     ])
 
-
     Next, consider a minimization problem with several constraints (namely
     Example 16.4 from [5]_). The objective function is:
 
@@ -547,10 +546,42 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
     The optimization problem is solved using the SLSQP method as:
 
-    >>> res = minimize(fun, (2, 0), method='SLSQP', bounds=bnds,
-    ...                constraints=cons)
+    >>> res = minimize(fun, (2, 0), method='SLSQP', bounds=bnds, constraints=cons)
 
-    It should converge to the theoretical solution (1.4 ,1.7).
+    It should converge to the theoretical solution [1.4 ,1.7]. *SLSQP* also
+    returns the multipliers that are used in the solution of the problem. These
+    multipliers, when the problem constraints are linear can be thought as the
+    Karush-Kuhn-Tucker (KKT) multipliers, which are a generalization
+    of Lagrange multipliers to inequality-constrained optimization problems.
+
+    Notice that at solution, the first constraint is active, let's evaluate the
+    function at solution:
+
+    >>> cons[0]['fun'](res.x)
+    np.float64(1.4901224698604665e-09)
+
+    Also notice that at optimality there is a non-zero multiplier:
+
+    >>> res.multipliers
+    array([0.8, 0. , 0. ])
+
+    This can be understood as the local sensitivity of the optimal value of the
+    objective function with respect to changes in the first constraint. If we
+    tighten the constraint by a small amount ``eps``:
+
+    >>> eps = 0.01
+    ... cons[0]['fun'] = lambda x: x[0] - 2 * x[1] + 2 - eps
+
+    we expect the optimal value of the objective function to increase by
+    approximately ``eps * res.multipliers[0]``:
+
+    >>> eps * res.multipliers[0]  # Expected change in f0
+    np.float64(0.008000000027153205)
+    >>> f0 = res.fun  # Keep track of the previous optimal value
+    ... res = minimize(fun, (2, 0), method='SLSQP', bounds=bnds, constraints=cons)
+    ... f1 = res.fun  # New optimal value
+    ... f1 - f0
+    np.float64(0.008019998807885509)
 
     """
     x0 = np.atleast_1d(np.asarray(x0))

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -570,7 +570,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     tighten the constraint by a small amount ``eps``:
 
     >>> eps = 0.01
-    ... cons[0]['fun'] = lambda x: x[0] - 2 * x[1] + 2 - eps
+    >>> cons[0]['fun'] = lambda x: x[0] - 2 * x[1] + 2 - eps
 
     we expect the optimal value of the objective function to increase by
     approximately ``eps * res.multipliers[0]``:
@@ -578,9 +578,9 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     >>> eps * res.multipliers[0]  # Expected change in f0
     np.float64(0.008000000027153205)
     >>> f0 = res.fun  # Keep track of the previous optimal value
-    ... res = minimize(fun, (2, 0), method='SLSQP', bounds=bnds, constraints=cons)
-    ... f1 = res.fun  # New optimal value
-    ... f1 - f0
+    >>> res = minimize(fun, (2, 0), method='SLSQP', bounds=bnds, constraints=cons)
+    >>> f1 = res.fun  # New optimal value
+    >>> f1 - f0
     np.float64(0.008019998807885509)
 
     """

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -548,9 +548,9 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
     >>> res = minimize(fun, (2, 0), method='SLSQP', bounds=bnds, constraints=cons)
 
-    It should converge to the theoretical solution [1.4 ,1.7]. *SLSQP* also
+    It should converge to the theoretical solution ``[1.4 ,1.7]``. *SLSQP* also
     returns the multipliers that are used in the solution of the problem. These
-    multipliers, when the problem constraints are linear can be thought as the
+    multipliers, when the problem constraints are linear, can be thought of as the
     Karush-Kuhn-Tucker (KKT) multipliers, which are a generalization
     of Lagrange multipliers to inequality-constrained optimization problems.
 
@@ -560,7 +560,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     >>> cons[0]['fun'](res.x)
     np.float64(1.4901224698604665e-09)
 
-    Also notice that at optimality there is a non-zero multiplier:
+    Also, notice that at optimality there is a non-zero multiplier:
 
     >>> res.multipliers
     array([0.8, 0. , 0. ])

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -490,6 +490,8 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     .. [19] Zhang, Z. "PRIMA: Reference Implementation for Powell's Methods with
         Modernization and Amelioration", https://www.libprima.net,
         :doi:`10.5281/zenodo.8052654`
+    .. [20] Karush-Kuhn-Tucker conditions,
+        https://en.wikipedia.org/wiki/Karush%E2%80%93Kuhn%E2%80%93Tucker_conditions
 
     Examples
     --------
@@ -552,7 +554,7 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
     returns the multipliers that are used in the solution of the problem. These
     multipliers, when the problem constraints are linear, can be thought of as the
     Karush-Kuhn-Tucker (KKT) multipliers, which are a generalization
-    of Lagrange multipliers to inequality-constrained optimization problems.
+    of Lagrange multipliers to inequality-constrained optimization problems ([20]_).
 
     Notice that at the solution, the first constraint is active. Let's evaluate the
     function at solution:

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -268,10 +268,11 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
     attribute as a NumPy array. Denoting the dimension of the equality constraints
     with ``meq``, and of inequality constraints with ``mineq``, then the returned
     array slice ``m[:meq]`` contains the multipliers for the equality constraints,
-    ``m[meq:]`` contains the multipliers for the inequality constraints. The
-    multipliers corresponding to bound inequalities are not returned. See [1]_
-    pp. 321 or [2]_ for an explanation of how to interpret these multipliers. The
-    internal QP problem is solved using the methods given in [3]_ Chapter 25.
+    and the remaining ``m[meq:meq + mineq]`` contains the multipliers for the 
+    inequality constraints. The multipliers corresponding to bound inequalities 
+    are not returned. See [1]_ pp. 321 or [2]_ for an explanation of how to interpret
+    these multipliers. The internal QP problem is solved using the methods given
+    in [3]_ Chapter 25.
 
     Note that if new-style `NonlinearConstraint` or `LinearConstraint` were
     used, then ``minimize`` converts them first to old-style constraint dicts.

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -227,8 +227,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         Precision target for the value of f in the stopping criterion. This value
         controls the final accuracy for checking various optimality conditions;
         gradient of the lagrangian and absolute sum of the constraint violations
-        should be lower than ``ftol``. Similarly, if computed step size and the
-        objective function chage are checked against this value. Default is 1e-6.
+        should be lower than ``ftol``. Similarly, computed step size and the
+        objective function changes are checked against this value. Default is 1e-6.
     eps : float
         Step size used for numerical approximation of the Jacobian.
     disp : bool
@@ -249,6 +249,45 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         This evaluation is carried out as ``workers(fun, iterable)``.
 
         .. versionadded:: 1.16.0
+
+    Returns
+    -------
+    res : OptimizeResult
+        The optimization result represented as an ``OptimizeResult`` object.
+        In this dict-like object the following fields are of particular importance:
+        ``x`` the solution array, ``success`` a Boolean flag indicating if the
+        optimizer exited successfully, ``message`` which describes the reason for
+        termination, and ``multipliers`` which contains the Karush-Kuhn-Tucker
+        (KKT) multipliers for the QP approximation used in solving the original
+        nonlinear problem. See ``Notes`` below. See also `OptimizeResult` for a
+        description of other attributes.
+
+    Notes
+    -----
+    The KKT multipliers are returned in the ``OptimizeResult.multipliers``
+    attribute as a NumPy array. Denoting the dimension of the equality constraints
+    with ``meq``, and of inequality constraints with ``mineq``, then the returned
+    array slice ``m[:meq]`` contains the multipliers for the equality constraints,
+    ``m[meq:]`` contains the multipliers for the inequality constraints. The
+    multipliers corresponding to bound inequalities are not returned. See [1]_
+    pp. 321 or [2]_ for an explanation of how to interpret these multipliers. The
+    internal QP problem is solved using the methods given in [3]_ Chapter 25.
+
+    Note that if new-style `NonlinearConstraint` or `LinearConstraint` were
+    used, then ``minimize`` converts them first to old-style constraint dicts.
+    It is possible for a single new-style constraint to simultaneously contain
+    both inequality and equality constraints. This means that if there is mixing
+    within a single constraint, then the returned list of multipliers will have
+    a different length than the original new-style constraints.
+
+    References
+    ----------
+    .. [1] Nocedal, J., and S J Wright, 2006, "Numerical Optimization", Springer,
+       New York.
+    .. [2] Kraft, D., "A software package for sequential quadratic programming",
+       1988, Tech. Rep. DFVLR-FB 88-28, DLR German Aerospace Center, Germany.
+    .. [3] Lawson, C. L., and R. J. Hanson, 1995, "Solving Least Squares Problems",
+       SIAM, Philadelphia, PA.
 
     """
     _check_unknown_options(unknown_options)

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -253,7 +253,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
     Returns
     -------
     res : OptimizeResult
-        The optimization result represented as an ``OptimizeResult`` object.
+        The optimization result represented as an `OptimizeResult` object.
         In this dict-like object the following fields are of particular importance:
         ``x`` the solution array, ``success`` a Boolean flag indicating if the
         optimizer exited successfully, ``message`` which describes the reason for

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -221,8 +221,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
     Minimize a scalar function of one or more variables using Sequential
     Least Squares Programming (SLSQP).
 
-    Options
-    -------
+    Parameters
+    ----------
     ftol : float
         Precision target for the value of f in the stopping criterion. This value
         controls the final accuracy for checking various optimality conditions;


### PR DESCRIPTION

#### Reference issue
Closes #22769 
Closes #14394 
Closes #15641 

#### What does this implement/fix?

Adds more information about what is returned under the `OptimizeResult` regarding the new `multipliers` key. Also brought the text from #15641 here to the `minimize` tutorial. 
