### PR TITLE
TST: stats.quantile: add edge test case for axis=None && keepdims=True

### DIFF
--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -162,7 +162,9 @@ class TestQuantile:
          ([[], []], 0.5, np.full(2, np.nan), {'axis': -1}),
          ([[], []], 0.5, np.zeros((0,)), {'axis': 0, 'keepdims': False}),
          ([[], []], 0.5, np.zeros((1, 0)), {'axis': 0, 'keepdims': True}),
-         ([], [0.5, 0.6], np.full(2, np.nan), {}),])
+         ([], [0.5, 0.6], np.full(2, np.nan), {}),
+         ([[1, 2], [3, 4]], [0.25, 0.5, 0.75], [[1.75, 2.5, 3.25]], 
+          {'axis': None, 'keepdims': True}),])
     def test_edge_cases(self, x, p, ref, kwargs, xp):
         default_dtype = xp_default_dtype(xp)
         x, p, ref = xp.asarray(x), xp.asarray(p), xp.asarray(ref, dtype=default_dtype)

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -163,6 +163,8 @@ class TestQuantile:
          ([[], []], 0.5, np.zeros((0,)), {'axis': 0, 'keepdims': False}),
          ([[], []], 0.5, np.zeros((1, 0)), {'axis': 0, 'keepdims': True}),
          ([], [0.5, 0.6], np.full(2, np.nan), {}),
+         (np.arange(1, 28).reshape((3, 3, 3)), 0.5, [[[14.]]],
+          {'axis': None, 'keepdims': True}),
          ([[1, 2], [3, 4]], [0.25, 0.5, 0.75], [[1.75, 2.5, 3.25]], 
           {'axis': None, 'keepdims': True}),])
     def test_edge_cases(self, x, p, ref, kwargs, xp):


### PR DESCRIPTION
Adds a test edge case for `stats.quantile` introduced in https://github.com/scipy/scipy/pull/22352, with arguments `axis=None, keepdims=True`