### PR TITLE
MAINT: optimize.least_squares: change `x_scale` default

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -50,7 +50,6 @@ def call_minpack(fun, x0, jac, ftol, xtol, gtol, max_nfev, x_scale, jac_method=N
     # ``x_scale='jac'`` corresponds to ``diag=None``.
 
     # 1.16.0 - default x_scale changed to 'jac', with diag=None
-    print(x_scale)
     if x_scale is None or (isinstance(x_scale, str) and x_scale == 'jac'):
         diag = None
     else:

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -48,9 +48,13 @@ def call_minpack(fun, x0, jac, ftol, xtol, gtol, max_nfev, x_scale, jac_method=N
 
     # Compute MINPACK's `diag`, which is inverse of our `x_scale` and
     # ``x_scale='jac'`` corresponds to ``diag=None``.
-    if isinstance(x_scale, str) and x_scale == 'jac':
+
+    # 1.16.0 - default x_scale changed to 'jac', with diag=None
+    print(x_scale)
+    if x_scale is None or (isinstance(x_scale, str) and x_scale == 'jac'):
         diag = None
     else:
+        # x_scale specified, so use that
         diag = 1 / x_scale
 
     full_output = True
@@ -131,7 +135,14 @@ def check_tolerance(ftol, xtol, gtol, method):
     return ftol, xtol, gtol
 
 
-def check_x_scale(x_scale, x0):
+def check_x_scale(x_scale, x0, method):
+    # normalise the default scaling
+    if x_scale is None:
+        if method == 'lm':
+            return 'jac'
+        else:   # dogbox, trf
+            x_scale = 1.0
+
     if isinstance(x_scale, str) and x_scale == 'jac':
         return x_scale
 
@@ -256,7 +267,7 @@ class _WrapArgsKwargs:
 @_workers_wrapper
 def least_squares(
         fun, x0, jac='2-point', bounds=(-np.inf, np.inf), method='trf',
-        ftol=1e-8, xtol=1e-8, gtol=1e-8, x_scale=1.0, loss='linear',
+        ftol=1e-8, xtol=1e-8, gtol=1e-8, x_scale=None, loss='linear',
         f_scale=1.0, diff_step=None, tr_solver=None, tr_options=None,
         jac_sparsity=None, max_nfev=None, verbose=0, args=(), kwargs=None,
         callback=None, workers=None
@@ -368,7 +379,7 @@ def least_squares(
         If None and 'method' is not 'lm', the termination by this condition is
         disabled. If 'method' is 'lm', this tolerance must be higher than
         machine epsilon.
-    x_scale : array_like or 'jac', optional
+    x_scale : {None, array_like, 'jac'}, optional
         Characteristic scale of each variable. Setting `x_scale` is equivalent
         to reformulating the problem in scaled variables ``xs = x / x_scale``.
         An alternative view is that the size of a trust region along jth
@@ -377,7 +388,18 @@ def least_squares(
         along any of the scaled variables has a similar effect on the cost
         function. If set to 'jac', the scale is iteratively updated using the
         inverse norms of the columns of the Jacobian matrix (as described in
-        [JJMore]_).
+        [JJMore]_). The default scaling for each method is as follows:
+
+        * For 'trf' : ``x_scale == 1``
+        * For 'trf' : ``x_scale == 1``
+        * For 'jac' : ``x_scale == 'jac'``
+
+        .. versionchanged:: 1.16.0
+            The default value is changed from 1 to None to indicate the default
+            approach to scaling.
+            For the 'lm' method the default scaling is changed from 1 to 'jac'.
+            This has been found to give better performance.
+
     loss : str or callable, optional
         Determines the loss function. The following keyword values are allowed:
 
@@ -877,7 +899,7 @@ def least_squares(
     if not in_bounds(x0, lb, ub):
         raise ValueError("Initial guess is outside of provided bounds")
 
-    x_scale = check_x_scale(x_scale, x0)
+    x_scale = check_x_scale(x_scale, x0, method)
 
     ftol, xtol, gtol = check_tolerance(ftol, xtol, gtol, method)
 

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -398,7 +398,8 @@ def least_squares(
             The default value is changed from 1 to None to indicate the default
             approach to scaling.
             For the 'lm' method the default scaling is changed from 1 to 'jac'.
-            This has been found to give better performance.
+            This has been found to give better performance, and is the same
+            scaling performed by ``leastsq``.
 
     loss : str or callable, optional
         Determines the loss function. The following keyword values are allowed:

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -399,7 +399,7 @@ def least_squares(
             a default approach to scaling is used.
             For the 'lm' method the default scaling is changed from 1 to 'jac'.
             This has been found to give better performance, and is the same
-            scaling performed by ``leastsq``.
+            scaling as performed by ``leastsq``.
 
     loss : str or callable, optional
         Determines the loss function. The following keyword values are allowed:

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -395,8 +395,8 @@ def least_squares(
         * For 'jac'    : ``x_scale == 'jac'``
 
         .. versionchanged:: 1.16.0
-            The default value is changed from 1 to None to indicate that a
-            default approach to scaling is used.
+            The default keyword value is changed from 1 to None to indicate that
+            a default approach to scaling is used.
             For the 'lm' method the default scaling is changed from 1 to 'jac'.
             This has been found to give better performance, and is the same
             scaling performed by ``leastsq``.

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -387,15 +387,16 @@ def least_squares(
         along any of the scaled variables has a similar effect on the cost
         function. If set to 'jac', the scale is iteratively updated using the
         inverse norms of the columns of the Jacobian matrix (as described in
-        [JJMore]_). The default scaling for each method is as follows:
+        [JJMore]_). The default scaling for each method (i.e.
+        if ``x_scale is None``) is as follows:
 
-        * For 'trf' : ``x_scale == 1``
-        * For 'trf' : ``x_scale == 1``
-        * For 'jac' : ``x_scale == 'jac'``
+        * For 'trf'    : ``x_scale == 1``
+        * For 'dogbox' : ``x_scale == 1``
+        * For 'jac'    : ``x_scale == 'jac'``
 
         .. versionchanged:: 1.16.0
-            The default value is changed from 1 to None to indicate the default
-            approach to scaling.
+            The default value is changed from 1 to None to indicate that a
+            default approach to scaling is used.
             For the 'lm' method the default scaling is changed from 1 to 'jac'.
             This has been found to give better performance, and is the same
             scaling performed by ``leastsq``.

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -239,8 +239,6 @@ class BaseMixin:
         assert_raises(ValueError, least_squares, fun_trivial,
                       2.0, x_scale=-1.0, method=self.method)
         assert_raises(ValueError, least_squares, fun_trivial,
-                      2.0, x_scale=None, method=self.method)
-        assert_raises(ValueError, least_squares, fun_trivial,
                       2.0, x_scale=1.0+2.0j, method=self.method)
 
     def test_diff_step(self):


### PR DESCRIPTION
The default x-scaling for `leastsq` is set by the `diag` keyword, which defaults to `None`. In `_minpack._lmder/_lmdif` if the `diag` keyword is `None` the diagonal scaling array is set to 1, `mode` is set to 1, which means the variables will be scaled internally.

The default x-scaling for `least_squares` with the `'lm'` method is set by the `x_scale` keyword, which currently defaults to 1.  This is normalised to an array of ones that is then passed to `call_minpack`, which sets `diag` to `1 / x_scale`. When this is passed to `_minpack._lmder/_lmdif` because an array is passed the `mode` is set to 2, which means the variables will be scaled by the `diag` array.

`leastsq` and `least_squares` therefore have different behaviour w.r.t the x-scaling. This PR proposes to change the behaviour of the `lm` method of `least_squares` to match `leastsq`.

I believe it should close https://github.com/scipy/scipy/issues/19459, and possibly #15178. The PR #19700 becomes redundant.

This is a change in behaviour. I am not sure if this necessarily needs a deprecation cycle (not clear how that would be done).
