### PR TITLE
TST: stats: mark some tests as slow

### DIFF
--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1062,8 +1062,9 @@ class TestMakeDistribution:
         distname = distdata[0]
 
         slow = {'argus', 'exponpow', 'exponweib', 'genexpon', 'gompertz', 'halfgennorm',
-                'johnsonsb', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'powerlognorm',
-                'powernorm', 'recipinvgauss', 'studentized_range', 'vonmises_line'}
+                'johnsonsb', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'norminvgauss',
+                'powerlognorm', 'powernorm', 'recipinvgauss', 'studentized_range',
+                'vonmises_line'}
         if not int(os.environ.get('SCIPY_XSLOW', '0')) and distname in slow:
             pytest.skip('Skipping as XSLOW')
 
@@ -1195,6 +1196,7 @@ class TestMakeDistribution:
 
     # pdf and cdf formulas below can warn on boundary of support in some cases.
     # See https://github.com/scipy/scipy/pull/22560#discussion_r1962763840.
+    @pytest.mark.slow
     @pytest.mark.filterwarnings("ignore::RuntimeWarning")
     @pytest.mark.parametrize("c", [-1, 0, 1, np.asarray([-2.1, -1., 0., 1., 2.1])])
     def test_custom_variable_support(self, c):


### PR DESCRIPTION
I've seen these tests (`TestMakeDistribution::test_custom_variable_support[1]` and `TestMakeDistribution::test_rv_generic` with `norminvgauss`) and failing as slightly too slow recently. 

I think it's safe to mark them as slow to run them on fewer platforms and give them a little more time to finish.