### PR TITLE
BUG: `signal.windows._windows.kaiser_bessel_derived`: use `asarray` instead of `array`

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -502,7 +502,7 @@ class TestKaiser:
 class TestKaiserBesselDerived:
 
     def test_basic(self, xp):
-        # cover case `M < 1`
+        # cover case `M < 1`
         w = windows.kaiser_bessel_derived(0.5, beta=4.0, xp=xp)
         xp_assert_equal(w, xp.asarray([]))
 

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -502,6 +502,9 @@ class TestKaiser:
 class TestKaiserBesselDerived:
 
     def test_basic(self, xp):
+        w = windows.kaiser_bessel_derived(0.5, beta=4.0, xp=xp)
+        xp_assert_equal(w, xp.asarray([]))
+
         M = 100
         w = windows.kaiser_bessel_derived(M, beta=4.0, xp=xp)
         w2 = windows.get_window(('kaiser bessel derived', 4.0),

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -502,6 +502,7 @@ class TestKaiser:
 class TestKaiserBesselDerived:
 
     def test_basic(self, xp):
+        # cover case `M < 1`
         w = windows.kaiser_bessel_derived(0.5, beta=4.0, xp=xp)
         xp_assert_equal(w, xp.asarray([]))
 

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1379,7 +1379,7 @@ def kaiser_bessel_derived(M, beta, *, sym=True, xp=None, device=None):
             "shapes"
         )
     elif M < 1:
-        return xp.array([])
+        return xp.asarray([])
     elif M % 2:
         raise ValueError(
             "Kaiser-Bessel Derived windows are only defined for even number "


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-22800.

#### What does this implement/fix?
- adds a test for `M<1` for robustness
- the function now uses `asarray` instead of `array` for `M<1` (array API standard)

