### PR TITLE
MAINT: use `xp.asarray` instead of `xp.array`

### DIFF
--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2319,8 +2319,8 @@ def _fftautocorr(x):
     x_fft = sp_fft.rfft(x, use_N, axis=-1)
     cxy = sp_fft.irfft(x_fft * x_fft.conj(), n=use_N)[:, :N]
     # Or equivalently (but in most cases slower):
-    # cxy = xp.array([xp.convolve(xx, yy[::-1], mode='full')
-    #                 for xx, yy in zip(x, x)])[:, N-1:2*N-1]
+    # cxy = xp.asarray([xp.convolve(xx, yy[::-1], mode='full')
+    #                   for xx, yy in zip(x, x)])[:, N-1:2*N-1]
     return cxy
 
 

--- a/scipy/stats/tests/test_variation.py
+++ b/scipy/stats/tests/test_variation.py
@@ -172,9 +172,9 @@ class TestVariation:
                       reason='`nan_policy` only supports NumPy backend')
     @pytest.mark.parametrize("nan_policy", ['propagate', 'omit'])
     def test_combined_edge_cases(self, nan_policy, xp):
-        x = xp.array([[0, 10, xp.nan, 1],
-                      [0, -5, xp.nan, 2],
-                      [0, -5, xp.nan, 3]])
+        x = xp.asarray([[0, 10, xp.nan, 1],
+                        [0, -5, xp.nan, 2],
+                        [0, -5, xp.nan, 3]])
         if nan_policy == 'omit':
             with pytest.warns(SmallSampleWarning, match=too_small_nd_omit):
                 y = variation(x, axis=0, nan_policy=nan_policy)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
A quick PR to get rid of a couple of final/leftover instances on `xp.array`. (No more `xp.array` in the codebase now!)

#### Additional information
<!--Any additional information you think is important.-->
