### PR TITLE
CI: start using the `CIBW_ENABLE` env var

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -216,8 +216,7 @@ jobs:
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}
-          CIBW_PRERELEASE_PYTHONS: True
-          CIBW_FREE_THREADED_SUPPORT: True
+          CIBW_ENABLE: cpython-freethreading cpython-prerelease
 
       - name: Rename macOS wheels
         if: startsWith( matrix.buildplat[0], 'macos-' )


### PR DESCRIPTION
The `CIBW_FREE_THREADED_SUPPORT` and `CIBW_PRERELEASE_PYTHONS` are deprecated (see https://cibuildwheel.pypa.io/en/stable/options/#enable).

There is no functional change, this is just a cleanup.

I skipped CI since there are no changes affecting regular CI, and I ran wheel builds on my fork ([in this job](https://github.com/rgommers/scipy/actions/runs/14294661858)) for completeness.