### PR TITLE
WIP, BUG: zero gain at DC for firwin

### DIFF
--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -451,6 +451,8 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
     from .windows import get_window
     win = get_window(window, numtaps, fftbins=False)
     h *= win
+    if not pass_zero:
+        h -= np.mean(h)
 
     # Now handle scaling if desired.
     if scale:


### PR DESCRIPTION
* Fixes gh-19291

* In the cognate issue, the author indicates that for `firwin()` with `pass_zero=False`, the DC gain must be zero, which is equivalent to the filter coefficients summing to zero. At the moment, this appears to not be the case, especially at low `numtaps`, likely because of insufficient flexibility to shape the frequency response.

* One workaround is to subtract the mean from the filter coefficients, enforcing the DC gain of zero (zero sum). Note that this is simply a mathematical adjustment that appears to work with the current testsuite--I'm not a domain expert.

* I've added an additional check that is stricter than the one described in the issue above to be cautious--that additional check fails, but I'm not actually sure it needs to pass. I'll ping the original ticket author to check on that.

[ci skip] [skip ci]


