### PR TITLE
TST: fix issue with `cython_special` test which was missing `-DCYTHON_CCOMPLEX=0`

### DIFF
--- a/scipy/special/tests/_cython_examples/meson.build
+++ b/scipy/special/tests/_cython_examples/meson.build
@@ -20,6 +20,7 @@ py3.extension_module(
   'extending.pyx',
   install: false,
   cython_args: cython_args,
+  c_args: ['-DCYTHON_CCOMPLEX=0'] # see gh-18975 for why we need this
 )
 
 extending_cpp = fs.copyfile('extending.pyx', 'extending_cpp.pyx')
@@ -29,4 +30,5 @@ py3.extension_module(
   install: false,
   override_options : ['cython_language=cpp'],
   cython_args: cython_args,
+  cpp_args: ['-DCYTHON_CCOMPLEX=0']
 )


### PR DESCRIPTION
Closes gh-22767

@pratham-mcw could you please confirm that this fixes the issue?