### PR TITLE
BUG: special.hyp2f1: fix for extreme inputs

### DIFF
--- a/scipy/special/tests/test_hyp2f1.py
+++ b/scipy/special/tests/test_hyp2f1.py
@@ -2544,6 +2544,8 @@ class TestHyp2f1:
             for case in mark.args[1]
         ]
 
+class TestHyp2f1ExtremeInputs:
+
     @pytest.mark.parametrize("a", [1.0, 2.0, 3.0, -np.inf, np.inf])
     @pytest.mark.parametrize("b", [3.0, 4.0, 5.0, -np.inf, np.inf])
     @pytest.mark.parametrize("c", [3.0, 5.0, 6.0, 7.0])

--- a/scipy/special/tests/test_hyp2f1.py
+++ b/scipy/special/tests/test_hyp2f1.py
@@ -2558,3 +2558,7 @@ class TestHyp2f1:
 
         assert(np.isnan(hyp2f1(1.0, 10**7, 3.0, 4.0 + 1.0j)))
         assert(np.isnan(hyp2f1(1.0, -10**7, 3.0, 4.0 + 1.0j)))
+
+        # Already correct in main but testing for surety
+        assert(np.isnan(hyp2f1(np.inf, 1.0, 3.0, 4.0)))
+        assert(np.isnan(hyp2f1(1.0, np.inf, 3.0, 4.0)))

--- a/scipy/special/tests/test_hyp2f1.py
+++ b/scipy/special/tests/test_hyp2f1.py
@@ -2543,3 +2543,18 @@ class TestHyp2f1:
             if mark.name == 'parametrize'
             for case in mark.args[1]
         ]
+
+    @pytest.mark.parametrize("a", [1.0, 2.0, 3.0, -np.inf, np.inf])
+    @pytest.mark.parametrize("b", [3.0, 4.0, 5.0, -np.inf, np.inf])
+    @pytest.mark.parametrize("c", [3.0, 5.0, 6.0, 7.0])
+    @pytest.mark.parametrize("z", [4.0 + 1.0j])
+    def test_inf_a_b(self, a, b, c, z):
+        if np.any(np.isinf(np.asarray([a, b]))):
+            assert(np.isnan(hyp2f1(a, b, c, z)))
+
+    def test_large_a_b(self):
+        assert(np.isnan(hyp2f1(10**7, 1.0, 3.0, 4.0 + 1.0j)))
+        assert(np.isnan(hyp2f1(-10**7, 1.0, 3.0, 4.0 + 1.0j)))
+
+        assert(np.isnan(hyp2f1(1.0, 10**7, 3.0, 4.0 + 1.0j)))
+        assert(np.isnan(hyp2f1(1.0, -10**7, 3.0, 4.0 + 1.0j)))

--- a/scipy/special/xsf/hyp2f1.h
+++ b/scipy/special/xsf/hyp2f1.h
@@ -553,7 +553,7 @@ XSF_HOST_DEVICE inline std::complex<double> hyp2f1(double a, double b, double c,
      * the series at a or b of smaller magnitude. This is to ensure proper
      * handling of situations like a < c < b <= 0, a, b, c all non-positive
      * integers, where terminating at a would lead to a term of the form 0 / 0. */
-    std::uint64_t max_degree;
+    double max_degree;
     if (a_neg_int || b_neg_int) {
         if (a_neg_int && b_neg_int) {
             max_degree = a > b ? std::abs(a) : std::abs(b);
@@ -562,7 +562,7 @@ XSF_HOST_DEVICE inline std::complex<double> hyp2f1(double a, double b, double c,
         } else {
             max_degree = std::abs(b);
         }
-        if (max_degree <= UINT64_MAX - 1) {
+        if (max_degree <= (double) UINT64_MAX) {
             auto series_generator = detail::HypergeometricSeriesGenerator(a, b, c, z);
             return detail::series_eval_fixed_length(series_generator, std::complex<double>{0.0, 0.0}, max_degree + 1);
         } else {
@@ -583,7 +583,7 @@ XSF_HOST_DEVICE inline std::complex<double> hyp2f1(double a, double b, double c,
      * (DLMF 15.8.1) */
     if (c_minus_a_neg_int || c_minus_b_neg_int) {
         max_degree = c_minus_b_neg_int ? std::abs(c - b) : std::abs(c - a);
-        if (max_degree <= UINT64_MAX - 2) {
+        if (max_degree <= (double) UINT64_MAX) {
             result = std::pow(1.0 - z, c - a - b);
             auto series_generator = detail::HypergeometricSeriesGenerator(c - a, c - b, c, z);
             result *=

--- a/scipy/special/xsf/hyp2f1.h
+++ b/scipy/special/xsf/hyp2f1.h
@@ -562,7 +562,7 @@ XSF_HOST_DEVICE inline std::complex<double> hyp2f1(double a, double b, double c,
         } else {
             max_degree = std::abs(b);
         }
-        if (max_degree <= UINT64_MAX) {
+        if (max_degree <= UINT64_MAX - 1) {
             auto series_generator = detail::HypergeometricSeriesGenerator(a, b, c, z);
             return detail::series_eval_fixed_length(series_generator, std::complex<double>{0.0, 0.0}, max_degree + 1);
         } else {
@@ -583,7 +583,7 @@ XSF_HOST_DEVICE inline std::complex<double> hyp2f1(double a, double b, double c,
      * (DLMF 15.8.1) */
     if (c_minus_a_neg_int || c_minus_b_neg_int) {
         max_degree = c_minus_b_neg_int ? std::abs(c - b) : std::abs(c - a);
-        if (max_degree <= UINT64_MAX) {
+        if (max_degree <= UINT64_MAX - 2) {
             result = std::pow(1.0 - z, c - a - b);
             auto series_generator = detail::HypergeometricSeriesGenerator(c - a, c - b, c, z);
             result *=


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/20988

#### What does this implement/fix?
<!--Please explain your changes.-->

The fix is simple. There are two instances where we check, `max_degree <= UINT64_MAX`. However, just after these checks we do, `max_degree + 1` and `max_degree + 2`. So consider the edge case when `max_degree = UINT64_MAX` in case when `a` or `b` is `np.inf`. Then `max_degree + 1` and `max_degree + 2` will circle to `0`. And therefore the number of terms in the series expansion is `0`. So we get `0` as the output which the issue highlights.

To fix the problem I changed `max_degree <= UINT64_MAX - 1` and `max_degree <= UINT64 - 2`. So we get a `nan` now.

Tests added for the same.

#### Additional information
<!--Any additional information you think is important.-->

cc: @michaelpradel @steppi
