### PR TITLE
MAINT: sparse: add lazy loading for csgraph and linalg

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -299,6 +299,7 @@ sorted indices are required (e.g., when passing data to other libraries).
 # Nathan Bell, and Jake Vanderplas.
 
 import warnings as _warnings
+import importlib as _importlib
 
 from ._base import *
 from ._csr import *
@@ -314,8 +315,6 @@ from ._matrix import spmatrix
 from ._matrix_io import *
 from ._sputils import get_index_dtype, safely_cast_index_arrays
 
-# For backward compatibility with v0.19.
-from . import csgraph
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (
@@ -323,11 +322,28 @@ from . import (
     lil, sparsetools, sputils
 )
 
-__all__ = [s for s in dir() if not s.startswith('_')]
+_submodules = ["csgraph", "linalg"]
+
+__all__ = [s for s in dir() if not s.startswith('_')] + _submodules
 
 # Filter PendingDeprecationWarning for np.matrix introduced with numpy 1.15
 msg = 'the matrix subclass is not the recommended way'
 _warnings.filterwarnings('ignore', message=msg)
+
+def __dir__():
+   return __all__
+
+
+def __getattr__(name):
+    if name in _submodules:
+        return _importlib.import_module(f'scipy.sparse.{name}')
+    else:
+        try:
+            return globals()[name]
+        except KeyError:
+            raise AttributeError(
+                f"Module 'scipy.sparse' has no attribute '{name}'"
+            )
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -49,8 +49,9 @@ class spmatrix:
 
     # Restore matrix power
     def __pow__(self, power):
-        import scipy
-        return scipy.sparse.linalg.matrix_power(self, power)
+        from .linalg import matrix_power
+
+        return matrix_power(self, power)
 
     ## Backward compatibility
 

--- a/scipy/sparse/_matrix.py
+++ b/scipy/sparse/_matrix.py
@@ -49,9 +49,8 @@ class spmatrix:
 
     # Restore matrix power
     def __pow__(self, power):
-        from .linalg import matrix_power
-
-        return matrix_power(self, power)
+        import scipy
+        return scipy.sparse.linalg.matrix_power(self, power)
 
     ## Backward compatibility
 

--- a/tach.toml
+++ b/tach.toml
@@ -136,7 +136,7 @@ depends_on = ["scipy.linalg", "scipy.special", "scipy._lib", "scipy.fft"]
 
 [[modules]]
 path = "scipy.sparse"
-depends_on = ["scipy", "scipy._lib", "scipy.sparse.csgraph", "scipy.sparse.linalg"]
+depends_on = ["scipy", "scipy._lib", "scipy.sparse.linalg"]
 
 [[modules]]
 path = "scipy.sparse.csgraph"

--- a/tach.toml
+++ b/tach.toml
@@ -136,7 +136,7 @@ depends_on = ["scipy.linalg", "scipy.special", "scipy._lib", "scipy.fft"]
 
 [[modules]]
 path = "scipy.sparse"
-depends_on = ["scipy", "scipy._lib", "scipy.sparse.linalg"]
+depends_on = ["scipy", "scipy._lib"]
 
 [[modules]]
 path = "scipy.sparse.csgraph"

--- a/tach.toml
+++ b/tach.toml
@@ -136,7 +136,7 @@ depends_on = ["scipy.linalg", "scipy.special", "scipy._lib", "scipy.fft"]
 
 [[modules]]
 path = "scipy.sparse"
-depends_on = ["scipy", "scipy._lib"]
+depends_on = ["scipy", "scipy._lib", "scipy.sparse.linalg"]
 
 [[modules]]
 path = "scipy.sparse.csgraph"


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #22382
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds lazy loading for the two submodules in order to speed up import times.
#### Additional information
<!--Any additional information you think is important.-->
