### PR TITLE
MAINT: signal: consolidate `order_filter` tests

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -12,6 +12,7 @@ from pytest import raises as assert_raises
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal,
     assert_array_almost_equal,
+    xp_default_dtype,
 )
 
 from numpy import array, spacing, sin, pi, sort, sqrt
@@ -27,6 +28,10 @@ from scipy.signal import (argrelextrema, BadCoefficients, bessel, besselap, bili
                           lp2bs_zpk)
 from scipy.signal._filter_design import (_cplxreal, _cplxpair, _norm_factor,
                                         _bessel_poly, _bessel_zeros)
+
+skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
+
 
 try:
     import mpmath
@@ -4495,49 +4500,52 @@ class TestGammatone:
             gammatone(440, 'iir', fs=np.array([10, 20]))
 
 
+@skip_xp_backends(cpu_only=True, exceptions=['cupy'])
 class TestOrderFilter:
-    def test_doc_example(self):
-        x = np.arange(25).reshape(5, 5)
-        domain = np.identity(3)
+    def test_doc_example(self, xp):
+        x = xp.reshape(xp.arange(25, dtype=xp_default_dtype(xp)), (5, 5))
+        domain = xp.eye(3, dtype=xp_default_dtype(xp))
 
         # minimum of elements 1,3,9 (zero-padded) on phone pad
         # 7,5,3 on numpad
-        expected = np.array(
+        expected = xp.asarray(
             [[0., 0., 0., 0., 0.],
              [0., 0., 1., 2., 0.],
              [0., 5., 6., 7., 0.],
              [0., 10., 11., 12., 0.],
              [0., 0., 0., 0., 0.]],
+            dtype=xp_default_dtype(xp)
         )
-        xp_assert_close(order_filter(x, domain, 0), expected, check_dtype=False)
+        xp_assert_close(order_filter(x, domain, 0), expected)
 
         # maximum of elements 1,3,9 (zero-padded) on phone pad
         # 7,5,3 on numpad
-        expected = np.array(
+        expected = xp.asarray(
             [[6., 7., 8., 9., 4.],
              [11., 12., 13., 14., 9.],
              [16., 17., 18., 19., 14.],
              [21., 22., 23., 24., 19.],
              [20., 21., 22., 23., 24.]],
         )
-        xp_assert_close(order_filter(x, domain, 2), expected, check_dtype=False)
+        xp_assert_close(order_filter(x, domain, 2), expected)
 
         # and, just to complete the set, median of zero-padded elements
-        expected = np.array(
+        expected = xp.asarray(
             [[0, 1, 2, 3, 0],
              [5, 6, 7, 8, 3],
              [10, 11, 12, 13, 8],
              [15, 16, 17, 18, 13],
              [0, 15, 16, 17, 18]],
+            dtype=xp_default_dtype(xp)
         )
         xp_assert_close(order_filter(x, domain, 1), expected)
 
-    def test_medfilt_order_filter(self):
-        x = np.arange(25).reshape(5, 5)
+    def test_medfilt_order_filter(self, xp):
+        x = xp.reshape(xp.arange(25), (5, 5))
 
         # median of zero-padded elements 1,5,9 on phone pad
         # 7,5,3 on numpad
-        expected = np.array(
+        expected = xp.asarray(
             [[0, 1, 2, 3, 0],
              [1, 6, 7, 8, 4],
              [6, 11, 12, 13, 9],
@@ -4547,19 +4555,19 @@ class TestOrderFilter:
         xp_assert_close(medfilt(x, 3), expected)
 
         xp_assert_close(
-            order_filter(x, np.ones((3, 3)), 4),
+            order_filter(x, xp.ones((3, 3)), 4),
             expected
         )
 
-    def test_order_filter_asymmetric(self):
-        x = np.arange(25).reshape(5, 5)
-        domain = np.array(
+    def test_order_filter_asymmetric(self, xp):
+        x = xp.reshape(xp.arange(25), (5, 5))
+        domain = xp.asarray(
             [[1, 1, 0],
              [0, 1, 0],
              [0, 0, 0]],
         )
 
-        expected = np.array(
+        expected = xp.asarray(
             [[0, 0, 0, 0, 0],
              [0, 0, 1, 2, 3],
              [0, 5, 6, 7, 8],
@@ -4568,7 +4576,7 @@ class TestOrderFilter:
         )
         xp_assert_close(order_filter(x, domain, 0), expected)
 
-        expected = np.array(
+        expected = xp.asarray(
             [[0, 0, 0, 0, 0],
              [0, 1, 2, 3, 4],
              [5, 6, 7, 8, 9],

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -12,7 +12,6 @@ from pytest import raises as assert_raises
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal,
     assert_array_almost_equal,
-    xp_default_dtype,
 )
 
 from numpy import array, spacing, sin, pi, sort, sqrt
@@ -22,15 +21,11 @@ from scipy.signal import (argrelextrema, BadCoefficients, bessel, besselap, bili
                           firwin, freqs_zpk, freqs, freqz, freqz_zpk,
                           gammatone, group_delay, iircomb, iirdesign, iirfilter,
                           iirnotch, iirpeak, lp2bp, lp2bs, lp2hp, lp2lp, normalize,
-                          medfilt, order_filter,
                           sos2tf, sos2zpk, sosfreqz, freqz_sos, tf2sos, tf2zpk, zpk2sos,
                           zpk2tf, bilinear_zpk, lp2lp_zpk, lp2hp_zpk, lp2bp_zpk,
                           lp2bs_zpk)
 from scipy.signal._filter_design import (_cplxreal, _cplxpair, _norm_factor,
                                         _bessel_poly, _bessel_zeros)
-
-skip_xp_backends = pytest.mark.skip_xp_backends
-xfail_xp_backends = pytest.mark.xfail_xp_backends
 
 
 try:
@@ -4498,89 +4493,3 @@ class TestGammatone:
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
             gammatone(440, 'iir', fs=np.array([10, 20]))
-
-
-@skip_xp_backends(cpu_only=True, exceptions=['cupy'])
-class TestOrderFilter:
-    def test_doc_example(self, xp):
-        x = xp.reshape(xp.arange(25, dtype=xp_default_dtype(xp)), (5, 5))
-        domain = xp.eye(3, dtype=xp_default_dtype(xp))
-
-        # minimum of elements 1,3,9 (zero-padded) on phone pad
-        # 7,5,3 on numpad
-        expected = xp.asarray(
-            [[0., 0., 0., 0., 0.],
-             [0., 0., 1., 2., 0.],
-             [0., 5., 6., 7., 0.],
-             [0., 10., 11., 12., 0.],
-             [0., 0., 0., 0., 0.]],
-            dtype=xp_default_dtype(xp)
-        )
-        xp_assert_close(order_filter(x, domain, 0), expected)
-
-        # maximum of elements 1,3,9 (zero-padded) on phone pad
-        # 7,5,3 on numpad
-        expected = xp.asarray(
-            [[6., 7., 8., 9., 4.],
-             [11., 12., 13., 14., 9.],
-             [16., 17., 18., 19., 14.],
-             [21., 22., 23., 24., 19.],
-             [20., 21., 22., 23., 24.]],
-        )
-        xp_assert_close(order_filter(x, domain, 2), expected)
-
-        # and, just to complete the set, median of zero-padded elements
-        expected = xp.asarray(
-            [[0, 1, 2, 3, 0],
-             [5, 6, 7, 8, 3],
-             [10, 11, 12, 13, 8],
-             [15, 16, 17, 18, 13],
-             [0, 15, 16, 17, 18]],
-            dtype=xp_default_dtype(xp)
-        )
-        xp_assert_close(order_filter(x, domain, 1), expected)
-
-    def test_medfilt_order_filter(self, xp):
-        x = xp.reshape(xp.arange(25), (5, 5))
-
-        # median of zero-padded elements 1,5,9 on phone pad
-        # 7,5,3 on numpad
-        expected = xp.asarray(
-            [[0, 1, 2, 3, 0],
-             [1, 6, 7, 8, 4],
-             [6, 11, 12, 13, 9],
-             [11, 16, 17, 18, 14],
-             [0, 16, 17, 18, 0]],
-        )
-        xp_assert_close(medfilt(x, 3), expected)
-
-        xp_assert_close(
-            order_filter(x, xp.ones((3, 3)), 4),
-            expected
-        )
-
-    def test_order_filter_asymmetric(self, xp):
-        x = xp.reshape(xp.arange(25), (5, 5))
-        domain = xp.asarray(
-            [[1, 1, 0],
-             [0, 1, 0],
-             [0, 0, 0]],
-        )
-
-        expected = xp.asarray(
-            [[0, 0, 0, 0, 0],
-             [0, 0, 1, 2, 3],
-             [0, 5, 6, 7, 8],
-             [0, 10, 11, 12, 13],
-             [0, 15, 16, 17, 18]]
-        )
-        xp_assert_close(order_filter(x, domain, 0), expected)
-
-        expected = xp.asarray(
-            [[0, 0, 0, 0, 0],
-             [0, 1, 2, 3, 4],
-             [5, 6, 7, 8, 9],
-             [10, 11, 12, 13, 14],
-             [15, 16, 17, 18, 19]]
-        )
-        xp_assert_close(order_filter(x, domain, 1), expected)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1638,6 +1638,89 @@ class TestOrderFilt:
         expect = xp.asarray([2, 3, 2])
         xp_assert_equal(actual, expect)
 
+    def test_doc_example(self, xp):
+        x = xp.reshape(xp.arange(25, dtype=xp_default_dtype(xp)), (5, 5))
+        domain = xp.eye(3, dtype=xp_default_dtype(xp))
+
+        # minimum of elements 1,3,9 (zero-padded) on phone pad
+        # 7,5,3 on numpad
+        expected = xp.asarray(
+            [[0., 0., 0., 0., 0.],
+             [0., 0., 1., 2., 0.],
+             [0., 5., 6., 7., 0.],
+             [0., 10., 11., 12., 0.],
+             [0., 0., 0., 0., 0.]],
+            dtype=xp_default_dtype(xp)
+        )
+        xp_assert_close(signal.order_filter(x, domain, 0), expected)
+
+        # maximum of elements 1,3,9 (zero-padded) on phone pad
+        # 7,5,3 on numpad
+        expected = xp.asarray(
+            [[6., 7., 8., 9., 4.],
+             [11., 12., 13., 14., 9.],
+             [16., 17., 18., 19., 14.],
+             [21., 22., 23., 24., 19.],
+             [20., 21., 22., 23., 24.]],
+        )
+        xp_assert_close(signal.order_filter(x, domain, 2), expected)
+
+        # and, just to complete the set, median of zero-padded elements
+        expected = xp.asarray(
+            [[0, 1, 2, 3, 0],
+             [5, 6, 7, 8, 3],
+             [10, 11, 12, 13, 8],
+             [15, 16, 17, 18, 13],
+             [0, 15, 16, 17, 18]],
+            dtype=xp_default_dtype(xp)
+        )
+        xp_assert_close(signal.order_filter(x, domain, 1), expected)
+
+    def test_medfilt_order_filter(self, xp):
+        x = xp.reshape(xp.arange(25), (5, 5))
+
+        # median of zero-padded elements 1,5,9 on phone pad
+        # 7,5,3 on numpad
+        expected = xp.asarray(
+            [[0, 1, 2, 3, 0],
+             [1, 6, 7, 8, 4],
+             [6, 11, 12, 13, 9],
+             [11, 16, 17, 18, 14],
+             [0, 16, 17, 18, 0]],
+        )
+        xp_assert_close(signal.medfilt(x, 3), expected)
+
+        xp_assert_close(
+            signal.order_filter(x, xp.ones((3, 3)), 4),
+            expected
+        )
+
+    def test_order_filter_asymmetric(self, xp):
+        x = xp.reshape(xp.arange(25), (5, 5))
+        domain = xp.asarray(
+            [[1, 1, 0],
+             [0, 1, 0],
+             [0, 0, 0]],
+        )
+
+        expected = xp.asarray(
+            [[0, 0, 0, 0, 0],
+             [0, 0, 1, 2, 3],
+             [0, 5, 6, 7, 8],
+             [0, 10, 11, 12, 13],
+             [0, 15, 16, 17, 18]]
+        )
+        xp_assert_close(signal.order_filter(x, domain, 0), expected)
+
+        expected = xp.asarray(
+            [[0, 0, 0, 0, 0],
+             [0, 1, 2, 3, 4],
+             [5, 6, 7, 8, 9],
+             [10, 11, 12, 13, 14],
+             [15, 16, 17, 18, 19]]
+        )
+        xp_assert_close(signal.order_filter(x, domain, 1), expected)
+
 
 @skip_xp_backends(cpu_only=True, exceptions=['cupy'])
 class _TestLinearFilter:

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1676,6 +1676,8 @@ class TestOrderFilt:
         )
         xp_assert_close(signal.order_filter(x, domain, 1), expected)
 
+    @xfail_xp_backends('dask.array', reason='repeat requires an axis')
+    @xfail_xp_backends('torch', reason='array-api-compat#292')
     def test_medfilt_order_filter(self, xp):
         x = xp.reshape(xp.arange(25), (5, 5))
 


### PR DESCRIPTION
For some historic reasons, `order_filter` tests were split between two test modules, with some tests hiding in `test_filter_design.py`.

Thus, parametrize these previously hidden tests across the Array API backends, and move them to `test_signaltools.py`.

Two commits are on purpose: one commit adds backend testing, the other one moves tests.
