### PR TITLE
ENH: signal.lp2{lp,hp,bp,bs}: add array API standard support

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2864,8 +2864,11 @@ def bilinear_zpk(z, p, k, fs):
     >>> plt.ylabel('Amplitude [dB]')
     >>> plt.grid(True)
     """
-    z = atleast_1d(z)
-    p = atleast_1d(p)
+    xp = array_namespace(z, p)
+
+    z, p = map(xp.asarray, (z, p))
+    z = xpx.atleast_nd(z, ndim=1, xp=xp)
+    p = xpx.atleast_nd(p, ndim=1, xp=xp)
 
     fs = _validate_fs(fs, allow_none=False)
 
@@ -2878,10 +2881,10 @@ def bilinear_zpk(z, p, k, fs):
     p_z = (fs2 + p) / (fs2 - p)
 
     # Any zeros that were at infinity get moved to the Nyquist frequency
-    z_z = append(z_z, -ones(degree))
+    z_z = xp.concat((z_z, -xp.ones(degree)))
 
     # Compensate for gain change
-    k_z = k * real(prod(fs2 - z) / prod(fs2 - p))
+    k_z = k * xp.real(xp.prod(fs2 - z) / xp.prod(fs2 - p))
 
     return z_z, p_z, k_z
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -19,6 +19,7 @@ from scipy.signal._arraytools import _validate_fs
 
 import scipy._lib.array_api_extra as xpx
 from scipy._lib._array_api import array_namespace, xp_promote, xp_size
+from scipy._lib.array_api_compat import numpy as np_compat
 
 
 __all__ = ['findfreqs', 'freqs', 'freqz', 'tf2zpk', 'zpk2tf', 'normalize',
@@ -1716,7 +1717,7 @@ def _align_nums(nums, xp):
         max_width = max(xp_size(num) for num in nums)
 
         # pre-allocate
-        aligned_nums = xp.zeros((nums.shape[0], max_width))
+        aligned_nums = xp.zeros((len(nums), max_width))
 
         # Create numerators with padded zeros
         for index, num in enumerate(nums):
@@ -1801,7 +1802,11 @@ def normalize(b, a):
     Badly conditioned filter coefficients (numerator): the results may be meaningless
 
     """
-    xp = array_namespace(b, a)
+    try:
+        xp = array_namespace(b, a)
+    except TypeError:
+        # object arrays, test_ltisys.py::TestSS2TF::test_simo_round_trip
+        xp = np_compat
 
     den = xp.asarray(a)
     den = xpx.atleast_nd(den, ndim=1, xp=xp)

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4,11 +4,10 @@ import operator
 import warnings
 
 import numpy as np
-from numpy import (atleast_1d, poly, polyval, roots, real, asarray,
+from numpy import (atleast_1d, poly, polyval, roots, asarray,
                    pi, absolute, sqrt, tan, log10,
                    arcsinh, sin, exp, cosh, arccosh, ceil, conjugate,
-                   zeros, sinh, append, concatenate, prod, ones, full, array,
-                   mintypecode)
+                   sinh, concatenate, prod, array)
 from numpy.polynomial.polynomial import polyval as npp_polyval
 from numpy.polynomial.polynomial import polyvalfromroots
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2024,7 +2024,7 @@ def lp2hp(b, a, wo=1.0):
     d = a.shape[0]
     n = b.shape[0]
     if wo != 1:
-        pwo = wo ** xp.arange(max((d, n)), dtype=xp.float64)
+        pwo = wo ** xp.arange(max((d, n)), dtype=b.dtype)
     else:
         pwo = xp.ones(max((d, n)), dtype=b.dtype)
     if d >= n:
@@ -3031,6 +3031,7 @@ def lp2hp_zpk(z, p, k, wo=1.0):
     xp = array_namespace(z, p)
 
     z, p = map(xp.asarray, (z, p))
+    # XXX: no xp_promote here since that breaks TestButter
     z = xpx.atleast_nd(z, ndim=1, xp=xp)
     p = xpx.atleast_nd(p, ndim=1, xp=xp)
 
@@ -3121,6 +3122,7 @@ def lp2bp_zpk(z, p, k, wo=1.0, bw=1.0):
     xp = array_namespace(z, p)
 
     z, p = map(xp.asarray, (z, p))
+    z, p = xp_promote(z, p, force_floating=True, xp=xp)
     z = xpx.atleast_nd(z, ndim=1, xp=xp)
     p = xpx.atleast_nd(p, ndim=1, xp=xp)
 
@@ -3220,6 +3222,7 @@ def lp2bs_zpk(z, p, k, wo=1.0, bw=1.0):
     xp = array_namespace(z, p)
 
     z, p = map(xp.asarray, (z, p))
+    z, p = xp_promote(z, p, force_floating=True, xp=xp)
     z = xpx.atleast_nd(z, ndim=1, xp=xp)
     p = xpx.atleast_nd(p, ndim=1, xp=xp)
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2030,7 +2030,6 @@ def lp2hp(b, a, wo=1.0):
         pwo = xp.ones(max((d, n)), dtype=b.dtype)
     if d >= n:
         outa = xp.flip(a) * pwo
-        outb = xp.concat((xp.zeros(n, dtype=b.dtype), ))
         outb = _resize(b, (d,), xp=xp)
         outb[n:] = 0.0
         outb[:n] = xp.flip(b) * pwo[:n]

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1554,9 +1554,9 @@ class TestLp2hp_zpk:
         k = 1
 
         z_hp, p_hp, k_hp = lp2hp_zpk(z, p, k, 5)
-        xp_assert_equal(z_hp, xp.asarray([0.0, 0.0]))
+        xp_assert_equal(z_hp, xp.asarray([0.0, 0.0], dtype=z_hp.dtype))
         xp_assert_close(_sort_cmplx(p_hp, xp=xp), _sort_cmplx(p, xp=xp) * 5)
-        assert math.isclose(k_hp, 1.0)
+        assert math.isclose(k_hp, 1.0, rel_tol=4e-7)
 
         z = xp.asarray([-2j, +2j])
         p = xp.asarray([-0.75, -0.5-0.5j, -0.5+0.5j])
@@ -1581,7 +1581,7 @@ class TestLp2bp_zpk:
         z_bp, p_bp, k_bp = lp2bp_zpk(z, p, k, 15, 8)
         xp_assert_close(
             _sort_cmplx(z_bp, xp=xp),
-            _sort_cmplx([-25j, -9j, 0, +9j, +25j], xp=xp)
+            _sort_cmplx([-25j, -9j, 0, +9j, +25j], xp=xp), check_dtype=False
         )
         xp_assert_close(
             _sort_cmplx(p_bp, xp=xp),
@@ -1590,7 +1590,7 @@ class TestLp2bp_zpk:
                  +2j + cmath.sqrt(-8j - 225) - 2, -2j + cmath.sqrt(+8j - 225) - 2,
                  +2j - cmath.sqrt(-8j - 225) - 2, -2j - cmath.sqrt(+8j - 225) - 2
                 ], xp=xp
-            )
+            ), check_dtype=False
         )
         assert math.isclose(k_bp, 24.0)
 
@@ -1611,7 +1611,7 @@ class TestLp2bs_zpk:
                          +3j + math.sqrt(1234)*1j,
                          -3j + math.sqrt(1234)*1j,
                          +3j - math.sqrt(1234)*1j,
-                         -3j - math.sqrt(1234)*1j], xp=xp)
+                         -3j - math.sqrt(1234)*1j], xp=xp), check_dtype=False
         )
         xp_assert_close(
             _sort_cmplx(p_bs, xp=xp),
@@ -1620,7 +1620,8 @@ class TestLp2bs_zpk:
                          (-6 + 6j) - cmath.sqrt(-1225 - 72j),
                          (-6 - 6j) - cmath.sqrt(-1225 + 72j),
                          (-6 + 6j) + cmath.sqrt(-1225 - 72j),
-                         (-6 - 6j) + cmath.sqrt(-1225 + 72j), ], xp=xp)
+                         (-6 - 6j) + cmath.sqrt(-1225 + 72j), ], xp=xp),
+            check_dtype=False
         )
         assert math.isclose(k_bs, 32.0)
 
@@ -1646,7 +1647,7 @@ class TestBilinear_zpk:
                 xp=xp
             )
         )
-        assert math.isclose(k_d, 9696/69803)
+        assert math.isclose(k_d, 9696/69803, rel_tol=4e-7)
 
 
 class TestPrototypeType:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1366,6 +1366,7 @@ class TestLp2lp:
 
 class TestLp2hp:
 
+    @skip_xp_backends(eager_only=True, reason="in-place item assignment")
     def test_basic(self, xp):
         b = xp.asarray([0.25059432325190018])
         a = xp.asarray(
@@ -1380,6 +1381,7 @@ class TestLp2hp:
 
 class TestLp2bp:
 
+    @skip_xp_backends(eager_only=True, reason="in-place item assignment")
     def test_basic(self, xp):
         b = xp.asarray([1])
         a = xp.asarray([1, 2, 2, 1])
@@ -1394,6 +1396,7 @@ class TestLp2bp:
 
 class TestLp2bs:
 
+    @skip_xp_backends(eager_only=True, reason="in-place item assignment")
     def test_basic(self, xp):
         b = xp.asarray([1])
         a = xp.asarray([1, 1])

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 
 from itertools import product
@@ -26,6 +27,9 @@ from scipy.signal import (argrelextrema, BadCoefficients, bessel, besselap, bili
                           lp2bs_zpk)
 from scipy.signal._filter_design import (_cplxreal, _cplxpair, _norm_factor,
                                         _bessel_poly, _bessel_zeros)
+
+skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
 
 
 try:
@@ -1351,43 +1355,50 @@ class TestNormalize:
 
 class TestLp2lp:
 
-    def test_basic(self):
-        b = [1]
-        a = [1, np.sqrt(2), 1]
+    def test_basic(self, xp):
+        b = xp.asarray([1])
+        a = xp.asarray([1, math.sqrt(2), 1])
         b_lp, a_lp = lp2lp(b, a, 0.38574256627112119)
-        assert_array_almost_equal(b_lp, [0.1488], decimal=4)
-        assert_array_almost_equal(a_lp, [1, 0.5455, 0.1488], decimal=4)
+        assert_array_almost_equal(b_lp, xp.asarray([0.1488]), decimal=4)
+        assert_array_almost_equal(a_lp, xp.asarray([1, 0.5455, 0.1488]), decimal=4)
 
 
 class TestLp2hp:
 
-    def test_basic(self):
-        b = [0.25059432325190018]
-        a = [1, 0.59724041654134863, 0.92834805757524175, 0.25059432325190018]
-        b_hp, a_hp = lp2hp(b, a, 2*np.pi*5000)
-        xp_assert_close(b_hp, [1.0, 0, 0, 0])
-        xp_assert_close(a_hp, [1, 1.1638e5, 2.3522e9, 1.2373e14], rtol=1e-4)
+    def test_basic(self, xp):
+        b = xp.asarray([0.25059432325190018])
+        a = xp.asarray(
+            [1, 0.59724041654134863, 0.92834805757524175, 0.25059432325190018]
+        )
+        b_hp, a_hp = lp2hp(b, a, 2*math.pi*5000)
+        xp_assert_close(b_hp, xp.asarray([1.0, 0, 0, 0]))
+        xp_assert_close(
+            a_hp, xp.asarray([1, 1.1638e5, 2.3522e9, 1.2373e14]), rtol=1e-4
+        )
 
 
 class TestLp2bp:
 
-    def test_basic(self):
-        b = [1]
-        a = [1, 2, 2, 1]
-        b_bp, a_bp = lp2bp(b, a, 2*np.pi*4000, 2*np.pi*2000)
-        xp_assert_close(b_bp, [1.9844e12, 0, 0, 0], rtol=1e-6)
-        xp_assert_close(a_bp, [1, 2.5133e4, 2.2108e9, 3.3735e13,
-                               1.3965e18, 1.0028e22, 2.5202e26], rtol=1e-4)
+    def test_basic(self, xp):
+        b = xp.asarray([1])
+        a = xp.asarray([1, 2, 2, 1])
+        b_bp, a_bp = lp2bp(b, a, 2*math.pi*4000, 2*math.pi*2000)
+        xp_assert_close(b_bp, xp.asarray([1.9844e12, 0, 0, 0]), rtol=1e-6)
+        xp_assert_close(
+            a_bp,
+            xp.asarray([1, 2.5133e4, 2.2108e9, 3.3735e13,
+                        1.3965e18, 1.0028e22, 2.5202e26]), rtol=1e-4
+        )
 
 
 class TestLp2bs:
 
-    def test_basic(self):
-        b = [1]
-        a = [1, 1]
+    def test_basic(self, xp):
+        b = xp.asarray([1])
+        a = xp.asarray([1, 1])
         b_bs, a_bs = lp2bs(b, a, 0.41722257286366754, 0.18460575326152251)
-        assert_array_almost_equal(b_bs, [1, 0, 0.17407], decimal=5)
-        assert_array_almost_equal(a_bs, [1, 0.18461, 0.17407], decimal=5)
+        assert_array_almost_equal(b_bs, xp.asarray([1, 0, 0.17407]), decimal=5)
+        assert_array_almost_equal(a_bs, xp.asarray([1, 0.18461, 0.17407]), decimal=5)
 
 
 class TestBilinear:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1510,6 +1510,7 @@ def _sort_cmplx(arr, xp):
 
 class TestLp2lp_zpk:
 
+    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
     def test_basic(self, xp):
         z = xp.asarray([])
         p = xp.asarray([(-1+1j) / math.sqrt(2), (-1-1j) / math.sqrt(2)])
@@ -1546,6 +1547,7 @@ class TestLp2lp_zpk:
 
 class TestLp2hp_zpk:
 
+    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
     def test_basic(self, xp):
         z = xp.asarray([])
         p = xp.asarray([(-1+1j) / math.sqrt(2), (-1-1j) / math.sqrt(2)])
@@ -1571,23 +1573,31 @@ class TestLp2hp_zpk:
 
 class TestLp2bp_zpk:
 
-    def test_basic(self):
-        z = [-2j, +2j]
-        p = [-0.75, -0.5-0.5j, -0.5+0.5j]
+    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
+    def test_basic(self, xp):
+        z = xp.asarray([-2j, +2j])
+        p = xp.asarray([-0.75, -0.5-0.5j, -0.5+0.5j])
         k = 3
         z_bp, p_bp, k_bp = lp2bp_zpk(z, p, k, 15, 8)
-        xp_assert_close(sort(z_bp), sort([-25j, -9j, 0, +9j, +25j]))
-        xp_assert_close(sort(p_bp), sort([-3 + 6j*sqrt(6),
-                                          -3 - 6j*sqrt(6),
-                                          +2j+sqrt(-8j-225)-2,
-                                          -2j+sqrt(+8j-225)-2,
-                                          +2j-sqrt(-8j-225)-2,
-                                          -2j-sqrt(+8j-225)-2, ]))
-        xp_assert_close(k_bp, 24.0)
+        xp_assert_close(
+            _sort_cmplx(z_bp, xp=xp),
+            _sort_cmplx([-25j, -9j, 0, +9j, +25j], xp=xp)
+        )
+        xp_assert_close(
+            _sort_cmplx(p_bp, xp=xp),
+            _sort_cmplx(
+                [-3 + 6j*math.sqrt(6), -3 - 6j*math.sqrt(6),
+                 +2j + cmath.sqrt(-8j - 225) - 2, -2j + cmath.sqrt(+8j - 225) - 2,
+                 +2j - cmath.sqrt(-8j - 225) - 2, -2j - cmath.sqrt(+8j - 225) - 2
+                ], xp=xp
+            )
+        )
+        assert math.isclose(k_bp, 24.0)
 
 
 class TestLp2bs_zpk:
 
+    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
     def test_basic(self, xp):
         z = xp.asarray([-2j, +2j])
         p = xp.asarray([-0.75, -0.5-0.5j, -0.5+0.5j])
@@ -1617,6 +1627,7 @@ class TestLp2bs_zpk:
 
 class TestBilinear_zpk:
 
+    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
     def test_basic(self, xp):
         z = xp.asarray([-2j, +2j])
         p = xp.asarray([-0.75, -0.5-0.5j, -0.5+0.5j])

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1614,19 +1614,25 @@ class TestLp2bs_zpk:
 
 class TestBilinear_zpk:
 
-    def test_basic(self):
-        z = [-2j, +2j]
-        p = [-0.75, -0.5-0.5j, -0.5+0.5j]
+    def test_basic(self, xp):
+        z = xp.asarray([-2j, +2j])
+        p = xp.asarray([-0.75, -0.5-0.5j, -0.5+0.5j])
         k = 3
 
         z_d, p_d, k_d = bilinear_zpk(z, p, k, 10)
 
-        xp_assert_close(sort(z_d), sort([(20-2j)/(20+2j), (20+2j)/(20-2j),
-                                         -1]))
-        xp_assert_close(sort(p_d), sort([77/83,
-                                         (1j/2 + 39/2) / (41/2 - 1j/2),
-                                         (39/2 - 1j/2) / (1j/2 + 41/2), ]))
-        xp_assert_close(k_d, 9696/69803)
+        xp_assert_close(
+            _sort_cmplx(z_d, xp=xp),
+            _sort_cmplx([(20-2j) / (20+2j), (20+2j) / (20-2j), -1], xp=xp)
+        )
+        xp_assert_close(
+            _sort_cmplx(p_d, xp=xp),
+            _sort_cmplx(
+                [77/83, (1j/2 + 39/2) / (41/2 - 1j/2), (39/2 - 1j/2) / (1j/2 + 41/2)],
+                xp=xp
+            )
+        )
+        assert math.isclose(k_d, 9696/69803)
 
 
 class TestPrototypeType:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1510,7 +1510,9 @@ def _sort_cmplx(arr, xp):
 
 class TestLp2lp_zpk:
 
-    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
+    @xfail_xp_backends(
+        'dask.array', reason='https://github.com/dask/dask/issues/11883'
+    )
     def test_basic(self, xp):
         z = xp.asarray([])
         p = xp.asarray([(-1+1j) / math.sqrt(2), (-1-1j) / math.sqrt(2)])
@@ -1547,7 +1549,9 @@ class TestLp2lp_zpk:
 
 class TestLp2hp_zpk:
 
-    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
+    @xfail_xp_backends(
+        'dask.array', reason='https://github.com/dask/dask/issues/11883'
+    )
     def test_basic(self, xp):
         z = xp.asarray([])
         p = xp.asarray([(-1+1j) / math.sqrt(2), (-1-1j) / math.sqrt(2)])
@@ -1573,7 +1577,9 @@ class TestLp2hp_zpk:
 
 class TestLp2bp_zpk:
 
-    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
+    @xfail_xp_backends(
+        'dask.array', reason='https://github.com/dask/dask/issues/11883'
+    )
     def test_basic(self, xp):
         z = xp.asarray([-2j, +2j])
         p = xp.asarray([-0.75, -0.5-0.5j, -0.5+0.5j])
@@ -1597,7 +1603,9 @@ class TestLp2bp_zpk:
 
 class TestLp2bs_zpk:
 
-    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
+    @xfail_xp_backends(
+        'dask.array', reason='https://github.com/dask/dask/issues/11883'
+    )
     def test_basic(self, xp):
         z = xp.asarray([-2j, +2j])
         p = xp.asarray([-0.75, -0.5-0.5j, -0.5+0.5j])
@@ -1628,7 +1636,9 @@ class TestLp2bs_zpk:
 
 class TestBilinear_zpk:
 
-    @xfail_xp_backends('dask.array', reason='internal dask error in _sort_cmplx')
+    @xfail_xp_backends(
+        'dask.array', reason='https://github.com/dask/dask/issues/11883'
+    )
     def test_basic(self, xp):
         z = xp.asarray([-2j, +2j])
         p = xp.asarray([-0.75, -0.5-0.5j, -0.5+0.5j])

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -16,7 +16,7 @@ from scipy._lib._array_api import (
     assert_array_almost_equal,
 )
 
-from numpy import array, spacing, sin, pi, sort, sqrt
+from numpy import array, spacing, sin, pi, sort
 from scipy.signal import (argrelextrema, BadCoefficients, bessel, besselap, bilinear,
                           buttap, butter, buttord, cheb1ap, cheb1ord, cheb2ap,
                           cheb2ord, cheby1, cheby2, ellip, ellipap, ellipord,

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -4154,7 +4154,8 @@ class TestSOSFilt:
 
         # Test simple IIR
         y_r = xp.asarray([0, 2, 4, 6, 8, 10.], dtype=dt)
-        sos = tf2sos(b, a)
+        bb, aa = map(np.asarray, (b, a))
+        sos = tf2sos(bb, aa)
         sos = xp.asarray(sos)   # XXX while tf2sos is numpy only
         assert_array_almost_equal(sosfilt(sos, x), y_r)
 
@@ -4163,7 +4164,8 @@ class TestSOSFilt:
         # NOTE: This was changed (rel. to TestLinear...) to add a pole @zero:
         a = xp.asarray([1, 0], dtype=dt)
         y_r = xp.asarray([0, 1, 3, 5, 7, 9.], dtype=dt)
-        sos = tf2sos(b, a)
+        bb, aa = map(np.asarray, (b, a))
+        sos = tf2sos(bb, aa)
         sos = xp.asarray(sos)   # XXX while tf2sos is numpy only
         assert_array_almost_equal(sosfilt(sos, x), y_r)
 
@@ -4193,12 +4195,13 @@ class TestSOSFilt:
         y_r2_a1 = xp.asarray([[0, 2, 0], [6, -4, 6], [12, -10, 12],
                             [18, -16, 18]], dtype=dt)
 
-        sos = tf2sos(b, a)
+        bb, aa = map(np.asarray, (b, a))
+        sos = tf2sos(bb, aa)
         sos = xp.asarray(sos)   # XXX
         y = sosfilt(sos, x, axis=0)
         assert_array_almost_equal(y_r2_a0, y)
 
-        sos = tf2sos(b, a)
+        sos = tf2sos(bb, aa)
         sos = xp.asarray(sos)   # XXX
         y = sosfilt(sos, x, axis=1)
         assert_array_almost_equal(y_r2_a1, y)
@@ -4215,7 +4218,8 @@ class TestSOSFilt:
         a = xp.asarray([0.5, 0.5], dtype=dt)
 
         # Test last axis
-        sos = tf2sos(b, a)
+        bb, aa = map(np.asarray, (b, a))  # XXX until tf2sos is array api compatible
+        sos = tf2sos(bb, aa)
         sos = xp.asarray(sos)   # XXX
         y = sosfilt(sos, x)
         for i in range(x.shape[0]):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -485,7 +485,7 @@ class TestConvolve2d:
             )
             xp_assert_close(
                 xp.squeeze(
-                    signal.convolve2d(xp.asarray([a]), xp.asarray([b]), mode=mode),
+                    signal.convolve2d(a[None, :], b[None, :], mode=mode),
                     axis=0
                 ),
                 signal.convolve(a, b, mode=mode)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/20678

#### What does this implement/fix?
<!--Please explain your changes.-->

Make `lp2{lp,hp,bp,bs}` and their `_zpk` cousins array API compatible.

#### Additional information
<!--Any additional information you think is important.-->

Got to have a bit of fun with probably least used parts of numpy: `np.trim_zeros`, anyone? Also `np.append` and my personal favorite, `np.resize`.

That said, changes are mostly mechanical.