### PR TITLE
DOC: Fix incorrect versionadded tag for axis param in stats.pearsonr

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -867,7 +867,7 @@ def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
         # Possible loss of precision for int types
         res = xp_promote(res, force_floating=True, xp=xp)
         res = xp.where(invalid, xp.nan, res)
-    
+
     return res[()] if res.ndim == 0 else res
 
 
@@ -4415,7 +4415,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
         Axis along which to perform the calculation. Default is 0.
         If None, ravel both arrays before performing the calculation.
 
-        .. versionadded:: 1.14.0
+        .. versionadded:: 1.9.0
     alternative : {'two-sided', 'greater', 'less'}, optional
         Defines the alternative hypothesis. Default is 'two-sided'.
         The following options are available:


### PR DESCRIPTION
#### Reference issue
Closes gh-22004

#### What does this implement/fix?
This pull request corrects the `versionadded` directive for the `axis` parameter in the `scipy.stats.pearsonr` function. The docstring previously stated that the parameter was added in version `1.14.0`, but it was actually introduced in version `1.9.0`.

#### Additional information
This update aligns the documentation with the actual implementation history and helps ensure accurate API versioning for users.