### PR TITLE
BUG: add workaround for pytest assertion rewriting overreach

### DIFF
--- a/scipy/ndimage/_ndimage_api.py
+++ b/scipy/ndimage/_ndimage_api.py
@@ -12,4 +12,5 @@ from ._interpolation import *   # noqa: F403
 from ._measurements import *   # noqa: F403
 from ._morphology import *   # noqa: F403
 
-__all__ = [s for s in dir() if not s.startswith('_')]
+# '@' due to pytest bug, scipy/scipy#22236
+__all__ = [s for s in dir() if not s.startswith(('_', '@'))]


### PR DESCRIPTION
Closes gh-22236

See discussion of upstream bug from https://github.com/pytest-dev/pytest/issues/10845#issuecomment-2575032929.

To reproduce the bug:
- clone https://github.com/lucascolley/scipy-22236-repro, `cd scipy-22236-repro`
- [install Pixi](https://pixi.sh/latest/#installation) if you don't have it
- `pixi run broken`

To see that this fix works:
- `pixi run fixed`