### PR TITLE
DOC: stats.qmc.discrepancy: clarify definitions

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -20,7 +20,7 @@ from scipy._lib._util import DecimalNumber, GeneratorType, IntNumber, SeedType
 
 if TYPE_CHECKING:
     import numpy.typing as npt
-    
+
 import scipy.stats as stats
 from scipy._lib._util import rng_integers, _rng_spawn, _transition_to_rng
 from scipy.sparse.csgraph import minimum_spanning_tree
@@ -266,7 +266,10 @@ def discrepancy(
     * ``MD``: Mixture Discrepancy - mix between CD/WD covering more criteria
     * ``L2-star``: L2-star discrepancy - like CD BUT variant to rotation
 
-    See [2]_ for precise definitions of each method.
+    Methods ``CD``, ``WD``, and ``MD`` implement the right hand side of equations
+    9, 10, and 18 of [2]_, respectively; the square root is not taken. On the
+    other hand, ``L2-star`` computes the quantity given by equation 10 of
+    [3]_ as implemented by subsequent equations; the square root is taken.
 
     Lastly, using ``iterative=True``, it is possible to compute the
     discrepancy as if we had :math:`n+1` samples. This is useful if we want
@@ -1586,7 +1589,7 @@ class LatinHypercube(QMCEngine):
         for j in range(n_col):
             perms = self.rng.permutation(p)
             oa_sample_[:, j] = perms[oa_sample[:, j]]
-        
+
         oa_sample = oa_sample_
         # following is making a scrambled OA into an OA-LHS
         oa_lhs_sample = np.zeros(shape=(n_row, n_col))
@@ -2123,7 +2126,7 @@ class PoissonDisk(QMCEngine):
 
         # sample to generate per iteration in the hypersphere around center
         self.ncandidates = ncandidates
-        
+
         if u_bounds is None:
             u_bounds = np.ones(d)
         if l_bounds is None:


### PR DESCRIPTION
#### Reference issue
Closes gh-21293

#### What does this implement/fix?
Clarifies the definitions of the various discrepancy methods.

#### Additional information
Relevant equations from [2] (Zhou)
<img width="1006" alt="image" src="https://github.com/user-attachments/assets/be4ff5c1-b7e7-4ac7-9460-f88c904db4e8" />
<img width="986" alt="image" src="https://github.com/user-attachments/assets/cd74935b-2b36-4798-a1a1-22ae4986a75f" />

To confirm that `discrepancy` reports these quantities rather than the square root, compare:
```python3
import numpy as np
from scipy import stats
x = [[1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3],
     [1, 1, 2, 2, 2, 3, 3, 3, 1, 1, 1, 2, 2, 2, 3, 3, 1, 1, 1, 2, 2, 3, 3, 3],
     [1, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 1, 2, 3, 2, 3, 1, 2, 3]]
x = np.asarray(x).T
for method in ['CD', 'WD', 'MD']:
    # see "by the mapping..." from section 2.2
    print(stats.qmc.discrepancy((2*x-1)/(2*x.max()), method=method))
# 0.0327789208962088
# 0.10085162322816635
# 0.1094993587819948
```
against the left results of
<img width="1014" alt="image" src="https://github.com/user-attachments/assets/c83c7313-d876-4ed8-9196-eace8a70853e" />
<img width="990" alt="image" src="https://github.com/user-attachments/assets/79906807-1334-40cd-85a3-293846468546" />

---

The code that implements the L2-star discrepancy:
https://github.com/scipy/scipy/blob/604656229ab58c9b1aaa715d7ec740b3b11c6b94/scipy/stats/_qmc_cy.pyx#L216-L218

takes looks like like:
<img width="786" alt="image" src="https://github.com/user-attachments/assets/659bc70f-3dbe-443b-bbfb-66de92e5133e" />
which is the square root of a quantity $T^2$ defined by:
<img width="779" alt="image" src="https://github.com/user-attachments/assets/1fd1ecfd-6ce9-4ff2-a2e3-159febc2a86e" />
<img width="718" alt="image" src="https://github.com/user-attachments/assets/845b2256-437b-485f-91a3-cae9b83c74b2" />


