### PR TITLE
DOC: interpolate: remove outdated deprecation notices

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -331,12 +331,6 @@ def pchip_interpolate(xi, yi, x, der=0, axis=0):
         A 1-D array of real values. `yi`'s length along the interpolation
         axis must be equal to the length of `xi`. If N-D array, use axis
         parameter to select correct axis.
-
-        .. deprecated:: 1.13.0
-            Complex data is deprecated and will raise an error in
-            SciPy 1.15.0. If you are trying to use the real components of
-            the passed array, use ``np.real`` on `yi`.
-
     x : scalar or array_like
         Of length M.
     der : int or list, optional

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -620,13 +620,6 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     values : array_like, shape (m1, ..., mn, ...)
         The data on the regular grid in n dimensions. Complex data is
         accepted.
-
-        .. deprecated:: 1.13.0
-            Complex data is deprecated with ``method="pchip"`` and will raise an
-            error in SciPy 1.15.0. This is because ``PchipInterpolator`` only
-            works with real values. If you are trying to use the real components of
-            the passed array, use ``np.real`` on ``values``.
-
     xi : ndarray of shape (..., ndim)
         The coordinates to sample the gridded data at
 


### PR DESCRIPTION
The actual deprecation happened as scheduled but this notices snuck through 