### PR TITLE
POC/RFC: linalg: low-level nD support

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1237,23 +1237,13 @@ def inv(a, overwrite_a=False, check_finite=True):
     # Also check if dtype is LAPACK compatible
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
 
-    # XXX move flags/strides check to C
     if not (a1.flags['ALIGNED'] or a1.dtype.byteorder == '='):
         overwrite_a = True
         a1 = a1.copy()
 
-    # batched arrays always copy
-    overwrite_a = overwrite_a and a1.flags["F_CONTIGUOUS"] and a1.ndim == 2
-
-    extradim = False
-    if a1.ndim == 2:
-        a1 = a1[None, ...]
-        extradim = True
-
-    # by now, we have at least a 3D well behaved array of a BLAS-compatible dtype
+    # a1 is well behaved, invert it.
     inv_a = _batched_linalg.inv(a1, overwrite_a)
-
-    return inv_a[0, ...] if extradim else inv_a
+    return inv_a
 
 
 # Determinant

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1242,7 +1242,12 @@ def inv(a, overwrite_a=False, check_finite=True):
         a1 = a1.copy()
 
     # a1 is well behaved, invert it.
-    inv_a = _batched_linalg.inv(a1, overwrite_a)
+    try:
+        inv_a = _batched_linalg.inv(a1, overwrite_a)
+    except ValueError as e:
+        # reraise a LinAlgError. It'd be best to raise it in a first place, from C
+        raise LinAlgError(*e.args)
+
     return inv_a
 
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1237,17 +1237,18 @@ def inv(a, overwrite_a=False, check_finite=True):
     # Also check if dtype is LAPACK compatible
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
 
+    # XXX move flags/strides check to C
     if not (a1.flags['ALIGNED'] or a1.dtype.byteorder == '='):
-        overwrite_a = False
+        overwrite_a = True
         a1 = a1.copy()
 
+    # batched arrays always copy
+    overwrite_a = overwrite_a and a1.flags["F_CONTIGUOUS"] and a1.ndim == 2
+
+    extradim = False
     if a1.ndim == 2:
         a1 = a1[None, ...]
         extradim = True
-    else:
-        # batched arrays always copy
-        overwrite_a = overwrite_a and a1.flags["F_CONTIGUOUS"] and (a1.ndim < 3) 
-        extradim = False
 
     # by now, we have at least a 3D well behaved array of a BLAS-compatible dtype
     inv_a = _batched_linalg.inv(a1, overwrite_a)

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -1079,3 +1079,28 @@ def _check_work_float(value, dtype, int_dtype):
                              " cannot be performed with standard 64-bit"
                              " LAPACK.")
     return value
+
+
+# The numpy facilities for type-casting checks are too slow for small sized
+# arrays and eat away the time budget for the checkups. Here we set a
+# precomputed dict container of the numpy.can_cast() table.
+
+# It can be used to determine quickly what a dtype can be cast to LAPACK
+# compatible types, i.e., 'float32, float64, complex64, complex128'.
+# Then it can be checked via "casting_dict[arr.dtype.char]"
+
+_lapack_cast_dict = {x: ''.join([y for y in 'fdFD' if np.can_cast(x, y)])
+                    for x in np.typecodes['All']}
+
+def _normalize_lapack_dtype(a, overwrite_a):
+    """Make sure an input array has a LAPACK-compatible dtype, cast and copy otherwise.
+    """
+    if a.dtype.char not in 'fdFD':
+        dtype_char = _lapack_cast_dict[a.dtype.char]
+        if not dtype_char:  # No casting possible
+            raise TypeError(f'The dtype {a.dtype} cannot be cast '
+                            'to float(32, 64) or complex(64, 128).')
+
+        a = a.astype(dtype_char[0])  # makes a copy, free to scratch
+        overwrite_a = True
+    return a, overwrite_a

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -113,6 +113,21 @@ py3.extension_module('_decomp_interpolative',
   subdir: 'scipy/linalg'
 )
 
+
+py3.extension_module('_batched_linalg',
+  [
+    'src/_batched_linalg_module.cc',
+    'src/_batched_linalg.h',
+    'src/_lapack_trampolines.h'
+  ],
+  dependencies: [np_dep, lapack_dep, blas_dep],
+  include_directories: ['../_build_utils/src'],
+  install: true,
+  subdir: 'scipy/linalg'
+)
+
+
+
 # _solve_toeplitz
 py3.extension_module('_solve_toeplitz',
   linalg_init_cython_gen.process('_solve_toeplitz.pyx'),

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -118,7 +118,8 @@ py3.extension_module('_batched_linalg',
   [
     'src/_batched_linalg_module.cc',
     'src/_batched_linalg.h',
-    'src/_lapack_trampolines.h'
+    'src/_lapack_trampolines.h',
+    'src/_npymath.h'
   ],
   dependencies: [np_dep, lapack_dep, blas_dep],
   include_directories: ['../_build_utils/src'],

--- a/scipy/linalg/src/_batched_linalg.h
+++ b/scipy/linalg/src/_batched_linalg.h
@@ -1,0 +1,266 @@
+#pragma once
+
+#include "Python.h"
+#include <limits>
+#include <cassert>
+#include "numpy/arrayobject.h"
+#include "npy_cblas.h"
+#include "_lapack_trampolines.h"
+
+
+template<typename T> struct numeric_limits {};
+
+template<>
+struct numeric_limits<float>{
+    static constexpr double one = 1.0f;
+    static constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+};
+
+template<>
+struct numeric_limits<double>{
+    static constexpr double one = 1.0;
+    static constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+};
+
+
+template<>
+struct numeric_limits<npy_cfloat>{
+    static constexpr npy_cfloat one = {1.0f, 0.0f};
+    static constexpr npy_cfloat nan = {std::numeric_limits<float>::quiet_NaN(),
+                                       std::numeric_limits<float>::quiet_NaN()};
+};
+
+template<>
+struct numeric_limits<npy_cdouble>{
+    static constexpr npy_cdouble one = {1.0, 0.0};
+    static constexpr npy_cdouble nan = {std::numeric_limits<double>::quiet_NaN(),
+                                        std::numeric_limits<double>::quiet_NaN()};
+};
+
+
+/* 
+ * Helpers for filling/rearranging matrices
+ */
+
+
+/* identity square matrix generation */
+template<typename typ>
+static inline void
+identity_matrix(typ *matrix, Py_ssize_t n)
+{
+    Py_ssize_t i;
+    /* in IEEE floating point, zeroes are represented as bitwise 0 */
+    memset((void *)matrix, 0, n*n*sizeof(typ));
+
+    for (i = 0; i < n; ++i)
+    {
+        *matrix = numeric_limits<typ>::one;
+        matrix += n+1;
+    }
+}
+
+
+/* m-by-n matrix full of nans */
+template<typename typ>
+static inline void
+nan_matrix(typ *matrix, Py_ssize_t m, Py_ssize_t n)
+{
+    for (Py_ssize_t i=0; i < m*n; i++) {
+        *(matrix + i) = numeric_limits<typ>::nan;
+    }
+}
+
+
+// parroted from sqrtm
+template<typename T>
+inline void
+swap_cf(T* src, T* dst, const Py_ssize_t r, const Py_ssize_t c, const Py_ssize_t n)
+{
+    Py_ssize_t i, j, ith_row, r2, c2;
+    T *bb = dst;
+    T *aa = src;
+    if (r < 16) {
+        for (j = 0; j < c; j++)
+        {
+            ith_row = 0;
+            for (i = 0; i < r; i++) {
+                bb[ith_row] = aa[i];
+                ith_row += n;
+            }
+            aa += n;
+            bb += 1;
+        }
+    } else {
+        // If tall
+        if (r > c)
+        {
+            r2 = r/2;
+            swap_cf(src, dst, r2, c, n);
+            swap_cf(src + r2, dst+(r2)*n, r-r2, c, n);
+        } else {  // Nope
+            c2 = c/2;
+            swap_cf(src, dst, r, c2, n);
+            swap_cf(src+(c2)*n, dst+c2, r, c-c2, n);
+        }
+    }
+}
+
+
+/*
+ * Visit (m, n)-shaped slices of a ndim>=3 array in C order.
+ * Copy each slice into a buffer, make the buffer F-ordered
+ * for LAPACK.
+ */
+struct iter_data_t
+{
+    // grab useful data from the array to iterate
+    npy_intp ndim;
+    npy_intp *shape;
+    npy_intp *strides;
+    void *data_ptr;
+
+    npy_intp outer_size;  // math.prod(a.shape[:-2])
+    npy_intp m, n;        // core dimensions
+
+    iter_data_t(PyArrayObject *arr) {
+        ndim = PyArray_NDIM(arr);
+        shape = PyArray_SHAPE(arr);
+        strides = PyArray_STRIDES(arr);
+        data_ptr = PyArray_DATA(arr);
+
+        m = shape[ndim - 2];
+        n = shape[ndim - 1];
+
+        /* outer_size: the number of slices in the batch, math.prod(a.shape[:-2] */
+        outer_size = 1;
+        if(ndim > 2) {
+            for(int i=0; i < ndim - 2; i++) {
+                outer_size *= shape[i];
+            }
+        }
+    }
+
+    template<typename T>
+    void get_slice(const npy_intp idx, T *buffer) {
+
+        assert((0 <= idx) && (idx < outer_size));
+
+        /* parroted from sqrtm*/
+        npy_intp offset = 0;
+        npy_intp temp_idx = idx;
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset += (temp_idx % shape[i]) * strides[i];
+            temp_idx /= shape[i];
+        }
+
+        T *slice_ptr = (T *)(data_ptr) + offset/sizeof(T);
+
+        // copy the current n-x-n slice into the temp storage *in the Fortran order*
+        for(npy_intp i=0; i < m; i++) {
+            for(npy_intp j=0; j < n; j++) {
+                buffer[i + j*m] = *(slice_ptr + (i*strides[ndim - 2]/sizeof(T)) + (j*strides[ndim - 1]/sizeof(T)));
+            }
+        }
+    }
+};
+
+
+
+template<typename T>
+inline void inv_loop2(PyArrayObject *a, PyArrayObject *a_inv)
+{
+    /*
+     * Prepate the data for looping over the batch dimensions.
+     */
+    iter_data_t iter_data(a);
+    npy_intp n = iter_data.n;    // core dimensions are (n, n)
+
+    gesv_data_t<T> gesv_data((fortran_int)n);
+    T *ret_data = (T *)PyArray_DATA(a_inv);
+
+    /*
+     * Main NxN slice loop
+     */
+    for(npy_intp idx=0; idx < iter_data.outer_size; idx++) {
+        T *buffer = gesv_data.a;
+        iter_data.get_slice(idx, buffer);   // fill the buffer with the current slice
+
+        /* Call LAPACK  */
+        identity_matrix(gesv_data.b, n);
+        call_gesv(gesv_data);
+
+        if (gesv_data.info != 0) {
+            // XXX raise or quietly fill with nans
+            for(npy_intp i=0; i < n*n; i++) {
+                gesv_data.b[i] = std::numeric_limits<T>::quiet_NaN();
+            }
+        }
+
+        // copy to the output buffer, swap CF; XXX: can use dcopy from BLAS?
+        swap_cf(gesv_data.b, ret_data + idx*n*n, n, n, n);
+    }
+};
+
+
+
+template<typename T>
+inline int inv_loop(PyArrayObject *a, PyArrayObject *a_inv)
+{
+    /*
+     * Prepate the data for looping over the batch dimensions.
+     */
+    iter_data_t iter_data(a);
+    npy_intp n = iter_data.n;    // core dimensions are (n, n)
+
+    getrf_data_t<T> getrf_data((fortran_int)n, (fortran_int)n);
+    if(getrf_data.info != 0) {
+        return getrf_data.info;
+    }
+
+    getri_data_t<T> getri_data(getrf_data);
+    if(getri_data.info != 0) {
+        return getri_data.info;
+    }
+
+    T *ret_data = (T *)PyArray_DATA(a_inv);
+
+    /*
+     * Main NxN slice loop
+     */
+    for(npy_intp idx=0; idx < iter_data.outer_size; idx++) {
+        T *buffer = getrf_data.a;
+        iter_data.get_slice(idx, buffer);   // fill the buffer with the current slice
+
+        // factorize the current slice 
+        call_getrf(getrf_data);
+
+        if (getrf_data.info != 0) {
+            // LAPACK error.
+            // XXX raise or quietly fill with nans
+            std::cout << "problem at idx=" << idx << "\n";
+
+            nan_matrix(ret_data + idx*n*n, getri_data.n, getri_data.n);
+            continue; 
+        }
+
+        // prepare the data for the GETRI call
+        // (other getri_data members do not change between iterations
+        getri_data.a = getrf_data.a;
+        getri_data.ipiv = getrf_data.ipiv;
+        call_getri(getri_data);
+
+        if (getri_data.info != 0) {
+            // LAPACK error.
+            // XXX raise or quietly fill with nans
+            std::cout << "GETRI info = " << getri_data.info << "\n";
+
+            nan_matrix(ret_data + idx*n*n, getri_data.n, getri_data.n);
+            continue;
+        }
+
+        // copy to the output buffer, swap CF; XXX: can use dcopy from BLAS?
+        swap_cf(getri_data.a, ret_data + idx*n*n, n, n, n);
+    }
+    return 0;
+};
+

--- a/scipy/linalg/src/_batched_linalg.h
+++ b/scipy/linalg/src/_batched_linalg.h
@@ -14,7 +14,6 @@ using namespace _numpymath;
 
 
 // parroted from sqrtm
-// XXX can probably be replaced by ?copy from BLAS
 template<typename T>
 inline void
 swap_cf(T* src, T* dst, const Py_ssize_t r, const Py_ssize_t c, const Py_ssize_t n)
@@ -157,8 +156,6 @@ invert_slice(getrf_data_t<T>& getrf_data, getri_data_t<T>& getri_data) {
  * For the input array `arr`:
  *
  * - The caller must check that the dtype is LAPACK-compatible before calling this routine.
- * - The array is at least 3D (for a single 2D matrix, the caller must
-     insert an axis, e.g. `arr[None, ...]`).
  * - There are no restriction on the input array strides, this routine will handle
  *   them correctly.
  *

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -9,20 +9,26 @@
 static PyObject*
 py_inv(PyObject *self, PyObject *args)
 {
-
     PyObject *py_a;
     int overwrite_a = 0;
 
     if(!PyArg_ParseTuple(args, "O|p", &py_a, &overwrite_a)) {
         return NULL;
     }
+    if (!PyArray_CheckExact(py_a)){
+        return NULL;
+    }
+    // XXX: check NDIM, dtypes
+
 
     PyArrayObject *a = (PyArrayObject *)py_a;
+    PyArrayObject *a_inv;
 
     /*
         8. check LAPACK info, bail out : raise or warn or quiet (currently, the latter)
-       10. overwrite_a
-       11. checks/asserts: m, n > 0, lda >= n etc
+        9. checks/asserts: m, n > 0, lda >= n etc
+       10. overwrite_a related checks: flags etc, move from Python to here.
+       11. Error handling. Make it talk to np.errstate?
 
      */
 
@@ -30,13 +36,25 @@ py_inv(PyObject *self, PyObject *args)
     npy_intp *shape = PyArray_SHAPE(a);
     int typenum = PyArray_TYPE(a);
 
-    assert(ndim >= 3);  // XXX needs to make sure of this on the python side
-
-    /* Allocate the result */
-    PyArrayObject *a_inv = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, typenum);
-    if (!a_inv) {
-        PyErr_NoMemory();
+    bool dtype_ok = ((typenum == NPY_FLOAT)
+                      || (typenum == NPY_DOUBLE)
+                      || (typenum == NPY_CFLOAT)
+                      || (typenum == NPY_CDOUBLE));
+    if(!dtype_ok){
+        PyErr_SetString(PyExc_TypeError, "Incompatible dtype.");
         return NULL;
+    }
+
+    if(!overwrite_a) {
+        /* Allocate the result */
+        a_inv = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, typenum);
+        if (!a_inv) {
+            PyErr_NoMemory();
+            return NULL;
+        };
+    } else {
+        // XXX: check flags/strides
+        a_inv = a;
     }
 
     int status = -1;
@@ -46,18 +64,27 @@ py_inv(PyObject *self, PyObject *args)
     case(NPY_CFLOAT) : status = inv_loop<npy_cfloat>(a, a_inv); break;
     case(NPY_CDOUBLE) : status = inv_loop<npy_cdouble>(a, a_inv); break;
     default:
-        PyErr_SetString(PyExc_TypeError, "unknown typenum");
+        PyErr_SetString(PyExc_TypeError, "unreachable.");
         return NULL;
     }
 
-    if (status != 0){
-        PyErr_SetString(PyExc_RuntimeError, "Something went wrong.");
+    if (status == -101){
+        // memory error
+        if(!overwrite_a) {
+            // hey garbage collector
+            Py_DECREF(a_inv);
+        }
+        else {
+            // XXX: LinalgError
+            PyErr_Format(PyExc_ValueError, "A singular matrix. LAPACK error code is %d", status);
+        }
         return NULL;
     }
 
     return (PyObject *)a_inv;
 
 }
+
 
 
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -1,0 +1,102 @@
+#define PY_SSIZE_T_CLEAN
+#include "Python.h"
+#include <iostream>
+#include <limits>
+#include <cassert>
+#include "_batched_linalg.h"
+
+
+static PyObject*
+py_inv(PyObject *self, PyObject *args)
+{
+
+    PyObject *py_a;
+    int overwrite_a = 0;
+
+    if(!PyArg_ParseTuple(args, "O|p", &py_a, &overwrite_a)) {
+        return NULL;
+    }
+
+    PyArrayObject *a = (PyArrayObject *)py_a;
+
+    /*
+        8. check LAPACK info, bail out : raise or warn or quiet (currently, the latter)
+       10. overwrite_a
+       11. checks/asserts: m, n > 0, lda >= n etc
+
+     */
+
+    npy_intp ndim = PyArray_NDIM(a);
+    npy_intp *shape = PyArray_SHAPE(a);
+    int typenum = PyArray_TYPE(a);
+
+    assert(ndim >= 3);  // XXX needs to make sure of this on the python side
+
+    /* Allocate the result */
+    PyArrayObject *a_inv = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, typenum);
+    if (!a_inv) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    int status = -1;
+    switch(typenum) {
+    case(NPY_FLOAT) : status=inv_loop<float>(a, a_inv); break;
+    case(NPY_DOUBLE) : status=inv_loop<double>(a, a_inv); break;
+    case(NPY_CFLOAT) : status = inv_loop<npy_cfloat>(a, a_inv); break;
+    case(NPY_CDOUBLE) : status = inv_loop<npy_cdouble>(a, a_inv); break;
+    default:
+        PyErr_SetString(PyExc_TypeError, "unknown typenum");
+        return NULL;
+    }
+
+    if (status != 0){
+        PyErr_SetString(PyExc_RuntimeError, "Something went wrong.");
+        return NULL;
+    }
+
+    return (PyObject *)a_inv;
+
+}
+
+
+
+/////////////////////////////////////
+
+static PyMethodDef BatchedLinalgMethods[] = {
+    /* Batched linalg functions */
+    {"inv", py_inv, METH_VARARGS, 
+     "Invert a possibly batched matrix"},
+    {NULL, NULL, 0, NULL}        /* Sentinel */
+};
+
+
+
+static struct PyModuleDef batched_linalg_module = {
+    PyModuleDef_HEAD_INIT,
+    "_batched_linalg",   /* name of module */
+    NULL, //spam_doc, /* module documentation, may be NULL */
+    -1,       /* size of per-interpreter state of the module,
+                 or -1 if the module keeps state in global variables. */
+    BatchedLinalgMethods
+};
+
+
+PyMODINIT_FUNC
+PyInit__batched_linalg(void)
+{
+    PyObject *module;
+
+    import_array();
+
+    module = PyModule_Create(&batched_linalg_module);
+    if (module == NULL) {
+        return NULL;
+    }
+
+#if Py_GIL_DISABLED
+    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
+#endif
+
+    return module;
+}

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -98,7 +98,7 @@ py_inv(PyObject *self, PyObject *args)
     else {
         // XXX: LinalgError
         PyErr_Format(PyExc_ValueError,
-                     "A singular matrix. LAPACK error code is %ll", status);
+                     "A singular matrix. getri/getrf error code is %lld", status);
      }
 
      return NULL;

--- a/scipy/linalg/src/_lapack_trampolines.h
+++ b/scipy/linalg/src/_lapack_trampolines.h
@@ -1,20 +1,10 @@
 /*
- * LAPACK declarations and call trampolines.
- *
- * For each LAPACK function, `?FUNC`,
- *     1. declare the LAPACK prototypes
- *     2. declare the struct to hold the arguments. In a constructor, give arguments
- *        "default" values. E.g. set LDA to N; pointer to arrays, set to NULL.
- *        For a LAPACK function ?FUNC, the struct is `func_data_t`.
- *     3. declare/define the `call_func` overloads to map from C array types
- *        (float, double, npy_cfloat, npy_cdouble) to LAPACK prefixes, "sdcz".
+ * LAPACK declarations.
  */
 #pragma once
 #include "Python.h"
 #include "numpy/npy_math.h"
 #include "npy_cblas.h"
-
-typedef CBLAS_INT fortran_int;
 
 /*
  * declare LAPACK prototypes
@@ -23,58 +13,58 @@ typedef CBLAS_INT fortran_int;
 
 /* ?GESV */
 extern "C" {
-fortran_int
-BLAS_FUNC(sgesv)(fortran_int *n, fortran_int *nrhs, float a[], fortran_int *lda,
-                 fortran_int ipiv[], float b[], fortran_int *ldb, fortran_int *info
+CBLAS_INT
+BLAS_FUNC(sgesv)(CBLAS_INT *n, CBLAS_INT *nrhs, float a[], CBLAS_INT *lda,
+                 CBLAS_INT ipiv[], float b[], CBLAS_INT *ldb, CBLAS_INT *info
 );
-fortran_int
-BLAS_FUNC(dgesv)(fortran_int *n, fortran_int *nrhs, double a[], fortran_int *lda,
-                 fortran_int ipiv[], double b[], fortran_int *ldb, fortran_int *info
+CBLAS_INT
+BLAS_FUNC(dgesv)(CBLAS_INT *n, CBLAS_INT *nrhs, double a[], CBLAS_INT *lda,
+                 CBLAS_INT ipiv[], double b[], CBLAS_INT *ldb, CBLAS_INT *info
 );
-fortran_int
-BLAS_FUNC(cgesv)(fortran_int *n, fortran_int *nrhs, npy_cfloat a[], fortran_int *lda,
-                 fortran_int ipiv[], npy_cfloat b[], fortran_int *ldb, fortran_int *info
+CBLAS_INT
+BLAS_FUNC(cgesv)(CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat a[], CBLAS_INT *lda,
+                 CBLAS_INT ipiv[], npy_cfloat b[], CBLAS_INT *ldb, CBLAS_INT *info
 );
-fortran_int
-BLAS_FUNC(zgesv)(fortran_int *n, fortran_int *nrhs, npy_cdouble a[], fortran_int *lda,
-                 fortran_int ipiv[], npy_cdouble b[], fortran_int *ldb, fortran_int *info
+CBLAS_INT
+BLAS_FUNC(zgesv)(CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble a[], CBLAS_INT *lda,
+                 CBLAS_INT ipiv[], npy_cdouble b[], CBLAS_INT *ldb, CBLAS_INT *info
 );
 
 /* ?GETRF */
-fortran_int
-BLAS_FUNC(sgetrf)(fortran_int *m, fortran_int *n, float a[], fortran_int *lda,
-                  fortran_int ipiv[], fortran_int *info
+CBLAS_INT
+BLAS_FUNC(sgetrf)(CBLAS_INT *m, CBLAS_INT *n, float a[], CBLAS_INT *lda,
+                  CBLAS_INT ipiv[], CBLAS_INT *info
 );
-fortran_int
-BLAS_FUNC(dgetrf)(fortran_int *m, fortran_int *n, double a[], fortran_int *lda,
-                  fortran_int ipiv[], fortran_int *info
+CBLAS_INT
+BLAS_FUNC(dgetrf)(CBLAS_INT *m, CBLAS_INT *n, double a[], CBLAS_INT *lda,
+                  CBLAS_INT ipiv[], CBLAS_INT *info
 );
-fortran_int
-BLAS_FUNC(cgetrf)(fortran_int *m, fortran_int *n, npy_cfloat a[], fortran_int *lda,
-                  fortran_int ipiv[], fortran_int *info
+CBLAS_INT
+BLAS_FUNC(cgetrf)(CBLAS_INT *m, CBLAS_INT *n, npy_cfloat a[], CBLAS_INT *lda,
+                  CBLAS_INT ipiv[], CBLAS_INT *info
 );
-fortran_int
-BLAS_FUNC(zgetrf)(fortran_int *m, fortran_int *n, npy_cdouble a[], fortran_int *lda,
-                  fortran_int ipiv[], fortran_int *info
+CBLAS_INT
+BLAS_FUNC(zgetrf)(CBLAS_INT *m, CBLAS_INT *n, npy_cdouble a[], CBLAS_INT *lda,
+                  CBLAS_INT ipiv[], CBLAS_INT *info
 );
 
 
 /* ?GETRI */
-fortran_int
-BLAS_FUNC(sgetri)(fortran_int *n, float a[], fortran_int *lda, fortran_int ipiv[],
-                  float work[], fortran_int *lwork, fortran_int *info
+CBLAS_INT
+BLAS_FUNC(sgetri)(CBLAS_INT *n, float a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
+                  float work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
-fortran_int
-BLAS_FUNC(dgetri)(fortran_int *n, double a[], fortran_int *lda, fortran_int ipiv[],
-                  double work[], fortran_int *lwork, fortran_int *info
+CBLAS_INT
+BLAS_FUNC(dgetri)(CBLAS_INT *n, double a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
+                  double work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
-fortran_int
-BLAS_FUNC(cgetri)(fortran_int *n, npy_cfloat a[], fortran_int *lda, fortran_int ipiv[],
-                  npy_cfloat work[], fortran_int *lwork, fortran_int *info
+CBLAS_INT
+BLAS_FUNC(cgetri)(CBLAS_INT *n, npy_cfloat a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
+                  npy_cfloat work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
-fortran_int
-BLAS_FUNC(zgetri)(fortran_int *n, npy_cdouble a[], fortran_int *lda, fortran_int ipiv[],
-                  npy_cdouble work[], fortran_int *lwork, fortran_int *info
+CBLAS_INT
+BLAS_FUNC(zgetri)(CBLAS_INT *n, npy_cdouble a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
+                  npy_cdouble work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
 
 
@@ -82,140 +72,32 @@ BLAS_FUNC(zgetri)(fortran_int *n, npy_cdouble a[], fortran_int *lda, fortran_int
 
 
 /*
- * Hold the GESV related variables, handle allocation/deallocation.
+ * Generate type overloads, to map from C array types (float, double, npy_cfloat, npy_cdouble)
+ * to LAPACK prefixes, "sdcz".
  */
-template<typename T>
-struct gesv_data_t {
-    fortran_int n;
-    fortran_int nrhs;
-    T *a;
-    fortran_int lda;
-    fortran_int *ipiv;
-    fortran_int ldb;
-    T *b;
-    fortran_int info;
-
-    gesv_data_t(fortran_int n_) :
-        n(n_), nrhs(n_), lda(n_), ldb(n_), info(0)
-    {
-        a = (T *)malloc(n*n*sizeof(T));
-        b = (T *)malloc(n*n*sizeof(T));
-        ipiv = (fortran_int *)malloc(n*sizeof(fortran_int));
-        if ((a==NULL) || (b == NULL) || (ipiv == NULL)) {
-            PyErr_NoMemory();
-            info = -1;
-        }
-    };
-
-    ~gesv_data_t() {
-        free(a);
-        free(b);
-        free(ipiv);
-    };
+#define GEN_GETRF(PREFIX, TYPE) \
+inline void \
+GETRF(CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## getrf)(m, n, a, lda, ipiv, info); \
 };
 
 
-/*
- * Trampoline from a C type to the BLAS prefix (sdcz)
- */
-inline void call_gesv(gesv_data_t<float>& gesv_data) {
-    BLAS_FUNC(sgesv)(&gesv_data.n, &gesv_data.nrhs, gesv_data.a, &gesv_data.lda,
-                     gesv_data.ipiv, gesv_data.b, &gesv_data.ldb, &gesv_data.info
-    );
-}
-
-inline void call_gesv(gesv_data_t<double>& gesv_data) {
-    BLAS_FUNC(dgesv)(&gesv_data.n, &gesv_data.nrhs, gesv_data.a, &gesv_data.lda,
-                     gesv_data.ipiv, gesv_data.b, &gesv_data.ldb, &gesv_data.info
-    );
-}
-
-inline void call_gesv(gesv_data_t<npy_cfloat>& gesv_data) {
-    BLAS_FUNC(cgesv)(&gesv_data.n, &gesv_data.nrhs, gesv_data.a, &gesv_data.lda,
-                     gesv_data.ipiv, gesv_data.b, &gesv_data.ldb, &gesv_data.info
-    );
-}
-
-inline void call_gesv(gesv_data_t<npy_cdouble>& gesv_data) {
-    BLAS_FUNC(zgesv)(&gesv_data.n, &gesv_data.nrhs, gesv_data.a, &gesv_data.lda,
-                     gesv_data.ipiv, gesv_data.b, &gesv_data.ldb, &gesv_data.info
-    );
-}
-
-
-/*
- * Hold the GETRF related variables.
- *
- * No allocations/deallocations, initialize all array pointers to NULL and all other
- * out variables to sentinels (-101 etc).
- */
-template<typename T>
-struct getrf_data_t {
-    fortran_int m;
-    fortran_int n;
-    T *a;
-    fortran_int lda;
-    fortran_int *ipiv;
-    fortran_int info;
-
-    getrf_data_t(fortran_int m_, fortran_int n_) :
-        m(m_), n(n_), a(NULL), lda(n_), ipiv(NULL), info(-101)
-    {};
-};
-inline void
-call_getrf(getrf_data_t<float>& data) {
-    BLAS_FUNC(sgetrf)(&data.m, &data.n, data.a, &data.lda, data.ipiv, &data.info);
-}
-inline void
-call_getrf(getrf_data_t<double>& data) {
-    BLAS_FUNC(dgetrf)(&data.m, &data.n, data.a, &data.lda, data.ipiv, &data.info);
-}
-inline void
-call_getrf(getrf_data_t<npy_cfloat>& data) {
-    BLAS_FUNC(cgetrf)(&data.m, &data.n, data.a, &data.lda, data.ipiv, &data.info);
-}
-inline void
-call_getrf(getrf_data_t<npy_cdouble>& data) {
-    BLAS_FUNC(zgetrf)(&data.m, &data.n, data.a, &data.lda, data.ipiv, &data.info);
-}
-
-
-
-
-/*
- * Hold the GETRI related variables.
- * Perform the workspace query, allocate the work array.
- * Is only usable after a call to ?getrf.
- */
-template<typename T>
-struct getri_data_t {
-    fortran_int n;
-    T *a;
-    fortran_int lda;
-    fortran_int *ipiv;
-    T *work;
-    fortran_int lwork;
-    fortran_int info;
-
-    getri_data_t(getrf_data_t<T>& data) :
-        n(data.n), a(data.a), lda(data.lda), ipiv(data.ipiv), work(NULL), lwork(-1), info(-101)
-    {};
+#define GEN_GETRI(PREFIX, TYPE) \
+inline void \
+GETRI(CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_INT *lwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## getri)(n, a, lda, ipiv, work, lwork, info); \
 };
 
 
-inline void
-call_getri(getri_data_t<float>& data) {
-    BLAS_FUNC(sgetri)(&data.n, data.a, &data.lda, data.ipiv, data.work, &data.lwork, &data.info);
-}
-inline void
-call_getri(getri_data_t<double>& data) {
-    BLAS_FUNC(dgetri)(&data.n, data.a, &data.lda, data.ipiv, data.work, &data.lwork, &data.info);
-}
-inline void
-call_getri(getri_data_t<npy_cfloat>& data) {
-    BLAS_FUNC(cgetri)(&data.n, data.a, &data.lda, data.ipiv, data.work, &data.lwork, &data.info);
-}
-inline void
-call_getri(getri_data_t<npy_cdouble>& data) {
-    BLAS_FUNC(zgetri)(&data.n, data.a, &data.lda, data.ipiv, data.work, &data.lwork, &data.info);
-}
+GEN_GETRF(s,float)
+GEN_GETRF(d,double)
+GEN_GETRF(c,npy_cfloat)
+GEN_GETRF(z,npy_cdouble)
+
+GEN_GETRI(s,float)
+GEN_GETRI(d,double)
+GEN_GETRI(c,npy_cfloat)
+GEN_GETRI(z,npy_cdouble)
+

--- a/scipy/linalg/src/_lapack_trampolines.h
+++ b/scipy/linalg/src/_lapack_trampolines.h
@@ -1,82 +1,84 @@
 /*
  * LAPACK declarations and call trampolines.
+ *
+ * For each LAPACK function, `?FUNC`,
+ *     1. declare the LAPACK prototypes
+ *     2. declare the struct to hold the arguments. In a constructor, give arguments
+ *        "default" values. E.g. set LDA to N; pointer to arrays, set to NULL.
+ *        For a LAPACK function ?FUNC, the struct is `func_data_t`.
+ *     3. declare/define the `call_func` overloads to map from C array types
+ *        (float, double, npy_cfloat, npy_cdouble) to LAPACK prefixes, "sdcz".
  */
 #pragma once
 #include "Python.h"
-#include <complex>
 #include "numpy/npy_math.h"
 #include "npy_cblas.h"
 
 typedef CBLAS_INT fortran_int;
 
+/*
+ * declare LAPACK prototypes
+ */
+
 
 /* ?GESV */
-extern "C" fortran_int
-BLAS_FUNC(sgesv)(fortran_int *n, fortran_int *nrhs,
-                 float a[], fortran_int *lda,
-                 fortran_int ipiv[],
-                 float b[], fortran_int *ldb,
-                 fortran_int *info
+extern "C" {
+fortran_int
+BLAS_FUNC(sgesv)(fortran_int *n, fortran_int *nrhs, float a[], fortran_int *lda,
+                 fortran_int ipiv[], float b[], fortran_int *ldb, fortran_int *info
 );
-extern "C" fortran_int
-BLAS_FUNC(dgesv)(fortran_int *n, fortran_int *nrhs,
-                 double a[], fortran_int *lda,
-                 fortran_int ipiv[],
-                 double b[], fortran_int *ldb,
-                 fortran_int *info
+fortran_int
+BLAS_FUNC(dgesv)(fortran_int *n, fortran_int *nrhs, double a[], fortran_int *lda,
+                 fortran_int ipiv[], double b[], fortran_int *ldb, fortran_int *info
 );
-extern "C" fortran_int
-BLAS_FUNC(cgesv)(fortran_int *n, fortran_int *nrhs,
-                 npy_cfloat a[], fortran_int *lda,
-                 fortran_int ipiv[],
-                 npy_cfloat b[], fortran_int *ldb,
-                 fortran_int *info
+fortran_int
+BLAS_FUNC(cgesv)(fortran_int *n, fortran_int *nrhs, npy_cfloat a[], fortran_int *lda,
+                 fortran_int ipiv[], npy_cfloat b[], fortran_int *ldb, fortran_int *info
 );
-extern "C" fortran_int
-BLAS_FUNC(zgesv)(fortran_int *n, fortran_int *nrhs,
-                 npy_cdouble a[], fortran_int *lda,
-                 fortran_int ipiv[],
-                 npy_cdouble b[], fortran_int *ldb,
-                 fortran_int *info
+fortran_int
+BLAS_FUNC(zgesv)(fortran_int *n, fortran_int *nrhs, npy_cdouble a[], fortran_int *lda,
+                 fortran_int ipiv[], npy_cdouble b[], fortran_int *ldb, fortran_int *info
 );
 
 /* ?GETRF */
-extern "C" fortran_int
+fortran_int
 BLAS_FUNC(sgetrf)(fortran_int *m, fortran_int *n, float a[], fortran_int *lda,
                   fortran_int ipiv[], fortran_int *info
 );
-extern "C" fortran_int
+fortran_int
 BLAS_FUNC(dgetrf)(fortran_int *m, fortran_int *n, double a[], fortran_int *lda,
                   fortran_int ipiv[], fortran_int *info
 );
-extern "C" fortran_int
+fortran_int
 BLAS_FUNC(cgetrf)(fortran_int *m, fortran_int *n, npy_cfloat a[], fortran_int *lda,
                   fortran_int ipiv[], fortran_int *info
 );
-extern "C" fortran_int
+fortran_int
 BLAS_FUNC(zgetrf)(fortran_int *m, fortran_int *n, npy_cdouble a[], fortran_int *lda,
                   fortran_int ipiv[], fortran_int *info
 );
 
 
 /* ?GETRI */
-extern "C" fortran_int
-BLAS_FUNC(sgetri)(fortran_int *n, float a[], fortran_int *lda,
-                  fortran_int ipiv[], float work[], fortran_int *lwork, fortran_int *info
+fortran_int
+BLAS_FUNC(sgetri)(fortran_int *n, float a[], fortran_int *lda, fortran_int ipiv[],
+                  float work[], fortran_int *lwork, fortran_int *info
 );
-extern "C" fortran_int
-BLAS_FUNC(dgetri)(fortran_int *n, double a[], fortran_int *lda,
-                  fortran_int ipiv[], double work[], fortran_int *lwork, fortran_int *info
+fortran_int
+BLAS_FUNC(dgetri)(fortran_int *n, double a[], fortran_int *lda, fortran_int ipiv[],
+                  double work[], fortran_int *lwork, fortran_int *info
 );
-extern "C" fortran_int
-BLAS_FUNC(cgetri)(fortran_int *n, npy_cfloat a[], fortran_int *lda,
-                  fortran_int ipiv[], npy_cfloat work[], fortran_int *lwork, fortran_int *info
+fortran_int
+BLAS_FUNC(cgetri)(fortran_int *n, npy_cfloat a[], fortran_int *lda, fortran_int ipiv[],
+                  npy_cfloat work[], fortran_int *lwork, fortran_int *info
 );
-extern "C" fortran_int
-BLAS_FUNC(zgetri)(fortran_int *n, npy_cdouble a[], fortran_int *lda,
-                  fortran_int ipiv[], npy_cdouble work[], fortran_int *lwork, fortran_int *info
+fortran_int
+BLAS_FUNC(zgetri)(fortran_int *n, npy_cdouble a[], fortran_int *lda, fortran_int ipiv[],
+                  npy_cdouble work[], fortran_int *lwork, fortran_int *info
 );
 
+
+} // extern "C"
 
 
 /*
@@ -117,60 +119,35 @@ struct gesv_data_t {
  * Trampoline from a C type to the BLAS prefix (sdcz)
  */
 inline void call_gesv(gesv_data_t<float>& gesv_data) {
-    BLAS_FUNC(sgesv)(
-        &gesv_data.n,
-        &gesv_data.nrhs,
-        gesv_data.a,
-        &gesv_data.lda,
-        gesv_data.ipiv,
-        gesv_data.b,
-        &gesv_data.ldb,
-        &gesv_data.info
+    BLAS_FUNC(sgesv)(&gesv_data.n, &gesv_data.nrhs, gesv_data.a, &gesv_data.lda,
+                     gesv_data.ipiv, gesv_data.b, &gesv_data.ldb, &gesv_data.info
     );
 }
 
 inline void call_gesv(gesv_data_t<double>& gesv_data) {
-    BLAS_FUNC(dgesv)(
-        &gesv_data.n,
-        &gesv_data.nrhs,
-        gesv_data.a,
-        &gesv_data.lda,
-        gesv_data.ipiv,
-        gesv_data.b,
-        &gesv_data.ldb,
-        &gesv_data.info
+    BLAS_FUNC(dgesv)(&gesv_data.n, &gesv_data.nrhs, gesv_data.a, &gesv_data.lda,
+                     gesv_data.ipiv, gesv_data.b, &gesv_data.ldb, &gesv_data.info
     );
 }
 
 inline void call_gesv(gesv_data_t<npy_cfloat>& gesv_data) {
-    BLAS_FUNC(cgesv)(
-        &gesv_data.n,
-        &gesv_data.nrhs,
-        gesv_data.a,
-        &gesv_data.lda,
-        gesv_data.ipiv,
-        gesv_data.b,
-        &gesv_data.ldb,
-        &gesv_data.info
+    BLAS_FUNC(cgesv)(&gesv_data.n, &gesv_data.nrhs, gesv_data.a, &gesv_data.lda,
+                     gesv_data.ipiv, gesv_data.b, &gesv_data.ldb, &gesv_data.info
     );
 }
 
 inline void call_gesv(gesv_data_t<npy_cdouble>& gesv_data) {
-    BLAS_FUNC(zgesv)(
-        &gesv_data.n,
-        &gesv_data.nrhs,
-        gesv_data.a,
-        &gesv_data.lda,
-        gesv_data.ipiv,
-        gesv_data.b,
-        &gesv_data.ldb,
-        &gesv_data.info
+    BLAS_FUNC(zgesv)(&gesv_data.n, &gesv_data.nrhs, gesv_data.a, &gesv_data.lda,
+                     gesv_data.ipiv, gesv_data.b, &gesv_data.ldb, &gesv_data.info
     );
 }
 
 
 /*
- * Hold the GETRF related variables, handle allocation/deallocation.
+ * Hold the GETRF related variables.
+ *
+ * No allocations/deallocations, initialize all array pointers to NULL and all other
+ * out variables to sentinels (-101 etc).
  */
 template<typename T>
 struct getrf_data_t {
@@ -182,23 +159,9 @@ struct getrf_data_t {
     fortran_int info;
 
     getrf_data_t(fortran_int m_, fortran_int n_) :
-        m(m_), n(n_), lda(n_), info(-101)
-    {
-        a = (T *)malloc(m*n*sizeof(T));
-        ipiv = (fortran_int *)malloc(n*sizeof(fortran_int));
-        if ((a == NULL) || (ipiv == NULL)) {
-            PyErr_NoMemory();
-            info = -1;
-        }
-        info = 0;
-    };
-
-    ~getrf_data_t() {
-        free(a);
-        free(ipiv);
-    };
+        m(m_), n(n_), a(NULL), lda(n_), ipiv(NULL), info(-101)
+    {};
 };
-
 inline void
 call_getrf(getrf_data_t<float>& data) {
     BLAS_FUNC(sgetrf)(&data.m, &data.n, data.a, &data.lda, data.ipiv, &data.info);
@@ -217,16 +180,6 @@ call_getrf(getrf_data_t<npy_cdouble>& data) {
 }
 
 
-/* 
- * Grab a real part of a possibly complex array.
- * This is for the work queries.
- * There must be a better way, I'm sure.
- * XXX: move together with numeric_limits etc
- */
-inline float real_part(float value){ return value; }
-inline double real_part(double value){ return value; }
-inline float real_part(npy_cfloat value){ return npy_crealf(value); }
-inline double real_part(npy_cdouble value){return npy_creal(value); }
 
 
 /*
@@ -244,43 +197,9 @@ struct getri_data_t {
     fortran_int lwork;
     fortran_int info;
 
-    getri_data_t(getrf_data_t<T>& data) {
-        assert(data.m == data.n);
-        n = data.n;
-        a = data.a;
-        lda = data.lda;
-        ipiv = data.ipiv;
-
-        /*
-         * Workspace query.
-         */
-        lwork = -1;
-        work = (T *)malloc(10*sizeof(T));
-        if (work == NULL) {
-            PyErr_NoMemory();
-        }
-
-        call_getri(*this);
-        if (info != 0) {
-            PyErr_SetString(PyExc_ValueError, "?getri: lwork allocation failed.");
-        }
-
-        // Grab the value of `lwork`. The factor of 1.01 is from
-        // https://github.com/scipy/scipy/blob/v1.15.2/scipy/linalg/_basic.py#L1154
-        lwork = (fortran_int)(1.01 * real_part(work[0]));
-        free(work);
-
-        // Finally, allocate
-        work = (T *)malloc(lwork*sizeof(T));
-        if (work == NULL) {
-            PyErr_NoMemory();
-            info = -101;
-        }
-    }
-
-    ~getri_data_t() {
-        free(work);
-    };
+    getri_data_t(getrf_data_t<T>& data) :
+        n(data.n), a(data.a), lda(data.lda), ipiv(data.ipiv), work(NULL), lwork(-1), info(-101)
+    {};
 };
 
 

--- a/scipy/linalg/src/_lapack_trampolines.h
+++ b/scipy/linalg/src/_lapack_trampolines.h
@@ -1,0 +1,302 @@
+/*
+ * LAPACK declarations and call trampolines.
+ */
+#pragma once
+#include "Python.h"
+#include <complex>
+#include "numpy/npy_math.h"
+#include "npy_cblas.h"
+
+typedef CBLAS_INT fortran_int;
+
+
+/* ?GESV */
+extern "C" fortran_int
+BLAS_FUNC(sgesv)(fortran_int *n, fortran_int *nrhs,
+                 float a[], fortran_int *lda,
+                 fortran_int ipiv[],
+                 float b[], fortran_int *ldb,
+                 fortran_int *info
+);
+extern "C" fortran_int
+BLAS_FUNC(dgesv)(fortran_int *n, fortran_int *nrhs,
+                 double a[], fortran_int *lda,
+                 fortran_int ipiv[],
+                 double b[], fortran_int *ldb,
+                 fortran_int *info
+);
+extern "C" fortran_int
+BLAS_FUNC(cgesv)(fortran_int *n, fortran_int *nrhs,
+                 npy_cfloat a[], fortran_int *lda,
+                 fortran_int ipiv[],
+                 npy_cfloat b[], fortran_int *ldb,
+                 fortran_int *info
+);
+extern "C" fortran_int
+BLAS_FUNC(zgesv)(fortran_int *n, fortran_int *nrhs,
+                 npy_cdouble a[], fortran_int *lda,
+                 fortran_int ipiv[],
+                 npy_cdouble b[], fortran_int *ldb,
+                 fortran_int *info
+);
+
+/* ?GETRF */
+extern "C" fortran_int
+BLAS_FUNC(sgetrf)(fortran_int *m, fortran_int *n, float a[], fortran_int *lda,
+                  fortran_int ipiv[], fortran_int *info
+);
+extern "C" fortran_int
+BLAS_FUNC(dgetrf)(fortran_int *m, fortran_int *n, double a[], fortran_int *lda,
+                  fortran_int ipiv[], fortran_int *info
+);
+extern "C" fortran_int
+BLAS_FUNC(cgetrf)(fortran_int *m, fortran_int *n, npy_cfloat a[], fortran_int *lda,
+                  fortran_int ipiv[], fortran_int *info
+);
+extern "C" fortran_int
+BLAS_FUNC(zgetrf)(fortran_int *m, fortran_int *n, npy_cdouble a[], fortran_int *lda,
+                  fortran_int ipiv[], fortran_int *info
+);
+
+
+/* ?GETRI */
+extern "C" fortran_int
+BLAS_FUNC(sgetri)(fortran_int *n, float a[], fortran_int *lda,
+                  fortran_int ipiv[], float work[], fortran_int *lwork, fortran_int *info
+);
+extern "C" fortran_int
+BLAS_FUNC(dgetri)(fortran_int *n, double a[], fortran_int *lda,
+                  fortran_int ipiv[], double work[], fortran_int *lwork, fortran_int *info
+);
+extern "C" fortran_int
+BLAS_FUNC(cgetri)(fortran_int *n, npy_cfloat a[], fortran_int *lda,
+                  fortran_int ipiv[], npy_cfloat work[], fortran_int *lwork, fortran_int *info
+);
+extern "C" fortran_int
+BLAS_FUNC(zgetri)(fortran_int *n, npy_cdouble a[], fortran_int *lda,
+                  fortran_int ipiv[], npy_cdouble work[], fortran_int *lwork, fortran_int *info
+);
+
+
+
+/*
+ * Hold the GESV related variables, handle allocation/deallocation.
+ */
+template<typename T>
+struct gesv_data_t {
+    fortran_int n;
+    fortran_int nrhs;
+    T *a;
+    fortran_int lda;
+    fortran_int *ipiv;
+    fortran_int ldb;
+    T *b;
+    fortran_int info;
+
+    gesv_data_t(fortran_int n_) :
+        n(n_), nrhs(n_), lda(n_), ldb(n_), info(0)
+    {
+        a = (T *)malloc(n*n*sizeof(T));
+        b = (T *)malloc(n*n*sizeof(T));
+        ipiv = (fortran_int *)malloc(n*sizeof(fortran_int));
+        if ((a==NULL) || (b == NULL) || (ipiv == NULL)) {
+            PyErr_NoMemory();
+            info = -1;
+        }
+    };
+
+    ~gesv_data_t() {
+        free(a);
+        free(b);
+        free(ipiv);
+    };
+};
+
+
+/*
+ * Trampoline from a C type to the BLAS prefix (sdcz)
+ */
+inline void call_gesv(gesv_data_t<float>& gesv_data) {
+    BLAS_FUNC(sgesv)(
+        &gesv_data.n,
+        &gesv_data.nrhs,
+        gesv_data.a,
+        &gesv_data.lda,
+        gesv_data.ipiv,
+        gesv_data.b,
+        &gesv_data.ldb,
+        &gesv_data.info
+    );
+}
+
+inline void call_gesv(gesv_data_t<double>& gesv_data) {
+    BLAS_FUNC(dgesv)(
+        &gesv_data.n,
+        &gesv_data.nrhs,
+        gesv_data.a,
+        &gesv_data.lda,
+        gesv_data.ipiv,
+        gesv_data.b,
+        &gesv_data.ldb,
+        &gesv_data.info
+    );
+}
+
+inline void call_gesv(gesv_data_t<npy_cfloat>& gesv_data) {
+    BLAS_FUNC(cgesv)(
+        &gesv_data.n,
+        &gesv_data.nrhs,
+        gesv_data.a,
+        &gesv_data.lda,
+        gesv_data.ipiv,
+        gesv_data.b,
+        &gesv_data.ldb,
+        &gesv_data.info
+    );
+}
+
+inline void call_gesv(gesv_data_t<npy_cdouble>& gesv_data) {
+    BLAS_FUNC(zgesv)(
+        &gesv_data.n,
+        &gesv_data.nrhs,
+        gesv_data.a,
+        &gesv_data.lda,
+        gesv_data.ipiv,
+        gesv_data.b,
+        &gesv_data.ldb,
+        &gesv_data.info
+    );
+}
+
+
+/*
+ * Hold the GETRF related variables, handle allocation/deallocation.
+ */
+template<typename T>
+struct getrf_data_t {
+    fortran_int m;
+    fortran_int n;
+    T *a;
+    fortran_int lda;
+    fortran_int *ipiv;
+    fortran_int info;
+
+    getrf_data_t(fortran_int m_, fortran_int n_) :
+        m(m_), n(n_), lda(n_), info(-101)
+    {
+        a = (T *)malloc(m*n*sizeof(T));
+        ipiv = (fortran_int *)malloc(n*sizeof(fortran_int));
+        if ((a == NULL) || (ipiv == NULL)) {
+            PyErr_NoMemory();
+            info = -1;
+        }
+        info = 0;
+    };
+
+    ~getrf_data_t() {
+        free(a);
+        free(ipiv);
+    };
+};
+
+inline void
+call_getrf(getrf_data_t<float>& data) {
+    BLAS_FUNC(sgetrf)(&data.m, &data.n, data.a, &data.lda, data.ipiv, &data.info);
+}
+inline void
+call_getrf(getrf_data_t<double>& data) {
+    BLAS_FUNC(dgetrf)(&data.m, &data.n, data.a, &data.lda, data.ipiv, &data.info);
+}
+inline void
+call_getrf(getrf_data_t<npy_cfloat>& data) {
+    BLAS_FUNC(cgetrf)(&data.m, &data.n, data.a, &data.lda, data.ipiv, &data.info);
+}
+inline void
+call_getrf(getrf_data_t<npy_cdouble>& data) {
+    BLAS_FUNC(zgetrf)(&data.m, &data.n, data.a, &data.lda, data.ipiv, &data.info);
+}
+
+
+/* 
+ * Grab a real part of a possibly complex array.
+ * This is for the work queries.
+ * There must be a better way, I'm sure.
+ * XXX: move together with numeric_limits etc
+ */
+inline float real_part(float value){ return value; }
+inline double real_part(double value){ return value; }
+inline float real_part(npy_cfloat value){ return npy_crealf(value); }
+inline double real_part(npy_cdouble value){return npy_creal(value); }
+
+
+/*
+ * Hold the GETRI related variables.
+ * Perform the workspace query, allocate the work array.
+ * Is only usable after a call to ?getrf.
+ */
+template<typename T>
+struct getri_data_t {
+    fortran_int n;
+    T *a;
+    fortran_int lda;
+    fortran_int *ipiv;
+    T *work;
+    fortran_int lwork;
+    fortran_int info;
+
+    getri_data_t(getrf_data_t<T>& data) {
+        assert(data.m == data.n);
+        n = data.n;
+        a = data.a;
+        lda = data.lda;
+        ipiv = data.ipiv;
+
+        /*
+         * Workspace query.
+         */
+        lwork = -1;
+        work = (T *)malloc(10*sizeof(T));
+        if (work == NULL) {
+            PyErr_NoMemory();
+        }
+
+        call_getri(*this);
+        if (info != 0) {
+            PyErr_SetString(PyExc_ValueError, "?getri: lwork allocation failed.");
+        }
+
+        // Grab the value of `lwork`. The factor of 1.01 is from
+        // https://github.com/scipy/scipy/blob/v1.15.2/scipy/linalg/_basic.py#L1154
+        lwork = (fortran_int)(1.01 * real_part(work[0]));
+        free(work);
+
+        // Finally, allocate
+        work = (T *)malloc(lwork*sizeof(T));
+        if (work == NULL) {
+            PyErr_NoMemory();
+            info = -101;
+        }
+    }
+
+    ~getri_data_t() {
+        free(work);
+    };
+};
+
+
+inline void
+call_getri(getri_data_t<float>& data) {
+    BLAS_FUNC(sgetri)(&data.n, data.a, &data.lda, data.ipiv, data.work, &data.lwork, &data.info);
+}
+inline void
+call_getri(getri_data_t<double>& data) {
+    BLAS_FUNC(dgetri)(&data.n, data.a, &data.lda, data.ipiv, data.work, &data.lwork, &data.info);
+}
+inline void
+call_getri(getri_data_t<npy_cfloat>& data) {
+    BLAS_FUNC(cgetri)(&data.n, data.a, &data.lda, data.ipiv, data.work, &data.lwork, &data.info);
+}
+inline void
+call_getri(getri_data_t<npy_cdouble>& data) {
+    BLAS_FUNC(zgetri)(&data.n, data.a, &data.lda, data.ipiv, data.work, &data.lwork, &data.info);
+}

--- a/scipy/linalg/src/_npymath.h
+++ b/scipy/linalg/src/_npymath.h
@@ -1,0 +1,89 @@
+/*
+ * Helpers for dealing with npy_cdouble/npy_cfloat types.
+ */
+#pragma once
+#include "numpy/npy_math.h"
+
+namespace _numpymath{
+
+/*
+ * std::numeric_limits and useful constants.
+ */
+
+template<typename T> struct numeric_limits {};
+
+template<>
+struct numeric_limits<float>{
+    static constexpr double one = 1.0f;
+    static constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+};
+
+template<>
+struct numeric_limits<double>{
+    static constexpr double one = 1.0;
+    static constexpr double nan = std::numeric_limits<double>::quiet_NaN();
+};
+
+
+template<>
+struct numeric_limits<npy_cfloat>{
+    static constexpr npy_cfloat one = {1.0f, 0.0f};
+    static constexpr npy_cfloat nan = {std::numeric_limits<float>::quiet_NaN(),
+                                       std::numeric_limits<float>::quiet_NaN()};
+};
+
+template<>
+struct numeric_limits<npy_cdouble>{
+    static constexpr npy_cdouble one = {1.0, 0.0};
+    static constexpr npy_cdouble nan = {std::numeric_limits<double>::quiet_NaN(),
+                                        std::numeric_limits<double>::quiet_NaN()};
+};
+
+
+
+/* 
+ * Grab a real part of a possibly complex array.
+ * This is for the work queries.
+ * There must be a better way, I'm sure.
+ */
+inline float real_part(float value){ return value; }
+inline double real_part(double value){ return value; }
+inline float real_part(npy_cfloat value){ return npy_crealf(value); }
+inline double real_part(npy_cdouble value){return npy_creal(value); }
+
+
+
+/* 
+ * Helpers for filling/rearranging matrices
+ */
+
+
+/* identity square matrix generation */
+template<typename typ>
+static inline void
+identity_matrix(typ *matrix, ptrdiff_t n)
+{
+    ptrdiff_t i;
+    /* in IEEE floating point, zeroes are represented as bitwise 0 */
+    memset((void *)matrix, 0, n*n*sizeof(typ));
+
+    for (i = 0; i < n; ++i)
+    {
+        *matrix = numeric_limits<typ>::one;
+        matrix += n+1;
+    }
+}
+
+
+/* m-by-n matrix full of nans */
+template<typename typ>
+static inline void
+nan_matrix(typ *matrix, ptrdiff_t m, ptrdiff_t n)
+{
+    for (ptrdiff_t i=0; i < m*n; i++) {
+        *(matrix + i) = numeric_limits<typ>::nan;
+    }
+}
+
+
+}  // namespace _numpymath

--- a/scipy/linalg/src/_npymath.h
+++ b/scipy/linalg/src/_npymath.h
@@ -15,12 +15,14 @@ template<typename T> struct numeric_limits {};
 
 template<>
 struct numeric_limits<float>{
+    static constexpr double zero = 0.0f;
     static constexpr double one = 1.0f;
     static constexpr float nan = std::numeric_limits<float>::quiet_NaN();
 };
 
 template<>
 struct numeric_limits<double>{
+    static constexpr double zero = 0.0;
     static constexpr double one = 1.0;
     static constexpr double nan = std::numeric_limits<double>::quiet_NaN();
 };
@@ -28,6 +30,7 @@ struct numeric_limits<double>{
 
 template<>
 struct numeric_limits<npy_cfloat>{
+    static constexpr npy_cfloat zero = {0.0f, 0.0f};
     static constexpr npy_cfloat one = {1.0f, 0.0f};
     static constexpr npy_cfloat nan = {std::numeric_limits<float>::quiet_NaN(),
                                        std::numeric_limits<float>::quiet_NaN()};
@@ -35,6 +38,7 @@ struct numeric_limits<npy_cfloat>{
 
 template<>
 struct numeric_limits<npy_cdouble>{
+    static constexpr npy_cdouble zero = {0.0, 0.0};
     static constexpr npy_cdouble one = {1.0, 0.0};
     static constexpr npy_cdouble nan = {std::numeric_limits<double>::quiet_NaN(),
                                         std::numeric_limits<double>::quiet_NaN()};
@@ -77,11 +81,12 @@ static inline void
 identity_matrix(typ *matrix, ptrdiff_t n)
 {
     ptrdiff_t i;
-    /* in IEEE floating point, zeroes are represented as bitwise 0 */
-    memset((void *)matrix, 0, n*n*sizeof(typ));
 
-    for (i = 0; i < n; ++i)
-    {
+    for(i=0; i < n*n; ++i) {
+        *(matrix + i) = numeric_limits<typ>::zero;
+    }
+
+    for (i = 0; i < n; ++i) {
         *matrix = numeric_limits<typ>::one;
         matrix += n+1;
     }

--- a/scipy/linalg/src/_npymath.h
+++ b/scipy/linalg/src/_npymath.h
@@ -2,6 +2,7 @@
  * Helpers for dealing with npy_cdouble/npy_cfloat types.
  */
 #pragma once
+#include <iostream>
 #include "numpy/npy_math.h"
 
 namespace _numpymath{
@@ -51,6 +52,18 @@ inline double real_part(double value){ return value; }
 inline float real_part(npy_cfloat value){ return npy_crealf(value); }
 inline double real_part(npy_cdouble value){return npy_creal(value); }
 
+
+/*
+ * Debug helper: print out an npy_{cfloat,cdouble} value
+ */
+std::ostream& operator<<(std::ostream& os, npy_cfloat x) {
+    os << "(" << npy_crealf(x) << ", " << npy_cimagf(x) << ")";
+    return os;
+}
+std::ostream& operator<<(std::ostream& os, npy_cdouble x) {
+    os << "(" << npy_creal(x) << ", " << npy_cimag(x) << ")";
+    return os;
+}
 
 
 /* 

--- a/scipy/linalg/src/_npymath.h
+++ b/scipy/linalg/src/_npymath.h
@@ -2,6 +2,7 @@
  * Helpers for dealing with npy_cdouble/npy_cfloat types.
  */
 #pragma once
+#include "Python.h"
 #include <iostream>
 #include "numpy/npy_math.h"
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/21466
supersedes and closes https://github.com/scipy/scipy/pull/21935

#### What does this implement/fix?
<!--Please explain your changes.-->

Add infrastructure for low-level batching in scipy.linalg. 

This is an alternative to gh-21935, which copy-pasted the gufunc infrastructure from numpy. This PR, instead, does manual looping over the batch dimensions, with the iterator from `sqrtm`, cc https://github.com/scipy/scipy/pull/22406#issuecomment-2796989303

Similar to gh-21935, here I convert `inv`. Which by itself is not a very interesting function; it's just simple enough to be useful as a guinea pig for the infrastructure. The PR looks large, but PRs for additional functions will be much smaller.

Remaining TBDs and action items:

- <s>`overwrite_a` not done yet; probably worth tackling in a follow-up;</s>
- "weird" dtypes, float16 and longdouble; also backwards compatible handling of integer array-likes
- what strategy we we use for when operation fails for some subarrays and succeeds for others: do we silently fill the failing parts with nans, or raise or fill with nans and emit a warning, cf https://github.com/scipy/scipy/issues/22476.  Currently this PR does quiet fill-with-nans.


#### Additional information
<!--Any additional information you think is important.-->

Quick-and-dirty performance measurements: basically, we are on par with numpy.linalg, which is to say 5-10x faster than the current scipy main for deep stacks of matrices of small core dimension.

```
In [1]: from scipy.linalg import inv

In [2]: from scipy.linalg._basic import inv0

In [3]: import numpy as np

In [4]: n = 10

In [5]: a = np.ones((n//2, n//5, n//10, n, n), dtype=float) + 8*np.eye(n)

In [6]: %timeit np.linalg.inv(a)
26.4 μs ± 409 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [7]: %timeit inv(a)
23.4 μs ± 187 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [8]: %timeit inv0(a)
211 μs ± 834 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```