### PR TITLE
MAINT: _lib/differentiate: update EIM with `at.set`

### DIFF
--- a/scipy/_lib/_elementwise_iterative_method.py
+++ b/scipy/_lib/_elementwise_iterative_method.py
@@ -314,7 +314,7 @@ def _update_active(work, res, res_work_pairs, active, mask, preserve_shape, xp):
     if mask is not None:
         if preserve_shape:
             active_mask = xp.zeros_like(mask)
-            active_mask = xpx.at(active_mask)[active].set(1)
+            active_mask = xpx.at(active_mask)[active].set(True)
             active_mask = active_mask & mask
             for key, val in update_dict.items():
                 try:

--- a/scipy/_lib/_elementwise_iterative_method.py
+++ b/scipy/_lib/_elementwise_iterative_method.py
@@ -16,6 +16,7 @@ import math
 import numpy as np
 from ._util import _RichResult, _call_callback_maybe_halt
 from ._array_api import array_namespace, xp_size, xp_result_type
+import scipy._lib.array_api_extra as xpx
 
 _ESIGNERR = -1
 _ECONVERR = -2
@@ -263,7 +264,7 @@ def _loop(work, callback, shape, maxiter, func, args, dtype, pre_func_eval,
 
         post_termination_check(work)
 
-    work.status[:] = _ECALLBACK if cb_terminate else _ECONVERR
+    work.status = xpx.at(work.status)[:].set(_ECALLBACK if cb_terminate else _ECONVERR)
     return _prepare_result(work, res, res_work_pairs, active, shape,
                            customize_result, preserve_shape, xp)
 
@@ -313,20 +314,20 @@ def _update_active(work, res, res_work_pairs, active, mask, preserve_shape, xp):
     if mask is not None:
         if preserve_shape:
             active_mask = xp.zeros_like(mask)
-            active_mask[active] = 1
+            active_mask = xpx.at(active_mask)[active].set(1)
             active_mask = active_mask & mask
             for key, val in update_dict.items():
                 try:
-                    res[key][active_mask] = val[active_mask]
+                    res[key] = xpx.at(res[key])[active_mask].set(val[active_mask])
                 except (IndexError, TypeError, KeyError):
-                    res[key][active_mask] = val
+                    res[key] = xpx.at(res[key])[active_mask].set(val)
         else:
             active_mask = active[mask]
             for key, val in update_dict.items():
                 try:
-                    res[key][active_mask] = val[mask]
+                    res[key] = xpx.at(res[key])[active_mask].set(val[mask])
                 except (IndexError, TypeError, KeyError):
-                    res[key][active_mask] = val
+                    res[key] = xpx.at(res[key])[active_mask].set(val)
     else:
         for key, val in update_dict.items():
             if preserve_shape:
@@ -334,7 +335,7 @@ def _update_active(work, res, res_work_pairs, active, mask, preserve_shape, xp):
                     val = val[active]
                 except (IndexError, TypeError, KeyError):
                     pass
-            res[key][active] = val
+            res[key] = xpx.at(res[key])[active].set(val)
 
 
 def _prepare_result(work, res, res_work_pairs, active, shape, customize_result,

--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -4,6 +4,7 @@ import numpy as np
 import scipy._lib._elementwise_iterative_method as eim
 from scipy._lib._util import _RichResult
 from scipy._lib._array_api import array_namespace, xp_copy, xp_promote
+import scipy._lib.array_api_extra as xpx
 
 _EERRORINCREASE = -1  # used in derivative
 
@@ -404,7 +405,7 @@ def derivative(f, x, *, args=(), tolerances=None, maxiter=10,
     h0 = xp.broadcast_to(h0, shape)
     h0 = xp.reshape(h0, (-1,))
     h0 = xp.astype(h0, dtype)
-    h0[h0 <= 0] = xp.asarray(xp.nan, dtype=dtype)
+    h0 = xpx.at(h0)[h0 <= 0].set(xp.nan)
 
     status = xp.full_like(x, eim._EINPROGRESS, dtype=xp.int32)  # in progress
     nit, nfev = 0, 1  # one function evaluations performed above
@@ -477,9 +478,9 @@ def derivative(f, x, *, args=(), tolerances=None, maxiter=10,
         n_new = 2*n if work.nit == 0 else 2  # number of new abscissae
         x_eval = xp.zeros((work.hdir.shape[0], n_new), dtype=work.dtype)
         il, ic, ir = work.il, work.ic, work.ir
-        x_eval[ir] = work.x[ir][:, xp.newaxis] + hr[ir]
-        x_eval[ic] = work.x[ic][:, xp.newaxis] + hc[ic]
-        x_eval[il] = work.x[il][:, xp.newaxis] - hr[il]
+        x_eval = xpx.at(x_eval)[ir].set(work.x[ir][:, xp.newaxis] + hr[ir])
+        x_eval = xpx.at(x_eval)[ic].set(work.x[ic][:, xp.newaxis] + hc[ic])
+        x_eval = xpx.at(x_eval)[il].set( work.x[il][:, xp.newaxis] - hr[il])
         return x_eval
 
     def post_func_eval(x, f, work):
@@ -529,14 +530,14 @@ def derivative(f, x, *, args=(), tolerances=None, maxiter=10,
             fo = xp.concat((work_fo[:, 0:1], work_fo[:, -2*n:]), axis=-1)
 
         work.fs = xp.zeros((ic.shape[0], work.fs.shape[-1] + 2*n_new), dtype=work.dtype)
-        work.fs[ic] = work_fc
-        work.fs[io] = work_fo
+        work.fs = xpx.at(work.fs)[ic].set(work_fc)
+        work.fs = xpx.at(work.fs)[io].set(work_fo)
 
         wc, wo = _derivative_weights(work, n, xp)
         work.df_last = xp.asarray(work.df, copy=True)
-        work.df[ic] = fc @ wc / work.h[ic]
-        work.df[io] = fo @ wo / work.h[io]
-        work.df[il] *= -1
+        work.df = xpx.at(work.df)[ic].set(fc @ wc / work.h[ic])
+        work.df = xpx.at(work.df)[io].set(fo @ wo / work.h[io])
+        work.df = xpx.at(work.df)[il].multiply(-1)
 
         work.h /= work.fac
         work.error_last = work.error
@@ -554,13 +555,14 @@ def derivative(f, x, *, args=(), tolerances=None, maxiter=10,
         stop = xp.astype(xp.zeros_like(work.df), xp.bool)
 
         i = work.error < work.atol + work.rtol*abs(work.df)
-        work.status[i] = eim._ECONVERGED
-        stop[i] = True
+        work.status = xpx.at(work.status)[i].set(eim._ECONVERGED)
+        stop = xpx.at(stop)[i].set(True)
 
         if work.nit > 0:
             i = ~((xp.isfinite(work.x) & xp.isfinite(work.df)) | stop)
-            work.df[i], work.status[i] = xp.nan, eim._EVALUEERR
-            stop[i] = True
+            work.df = xpx.at(work.df)[i].set(xp.nan)
+            work.status = xpx.at(work.status)[i].set(eim._EVALUEERR)
+            stop = xpx.at(stop)[i].set(True)
 
         # With infinite precision, there is a step size below which
         # all smaller step sizes will reduce the error. But in floating point
@@ -570,8 +572,8 @@ def derivative(f, x, *, args=(), tolerances=None, maxiter=10,
         # detecting a step size that minimizes the total error, but this
         # heuristic seems simple and effective.
         i = (work.error > work.error_last*10) & ~stop
-        work.status[i] = _EERRORINCREASE
-        stop[i] = True
+        work.status = xpx.at(work.status)[i].set(_EERRORINCREASE)
+        stop = xpx.at(stop)[i].set(True)
 
         return stop
 
@@ -923,7 +925,7 @@ def jacobian(f, x, *, tolerances=None, maxiter=10, order=8, initial_step=0.5,
         if x.ndim != x0.ndim:
             xph = xp.expand_dims(xph, axis=-1)
         xph = xp_copy(xp.broadcast_to(xph, new_shape), xp=xp)
-        xph[i, i] = x
+        xph = xpx.at(xph)[i, i].set(x)
         return f(xph)
 
     res = derivative(wrapped, x, tolerances=tolerances,

--- a/scipy/differentiate/_differentiate.py
+++ b/scipy/differentiate/_differentiate.py
@@ -480,7 +480,7 @@ def derivative(f, x, *, args=(), tolerances=None, maxiter=10,
         il, ic, ir = work.il, work.ic, work.ir
         x_eval = xpx.at(x_eval)[ir].set(work.x[ir][:, xp.newaxis] + hr[ir])
         x_eval = xpx.at(x_eval)[ic].set(work.x[ic][:, xp.newaxis] + hc[ic])
-        x_eval = xpx.at(x_eval)[il].set( work.x[il][:, xp.newaxis] - hr[il])
+        x_eval = xpx.at(x_eval)[il].set(work.x[il][:, xp.newaxis] - hr[il])
         return x_eval
 
     def post_func_eval(x, f, work):

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -13,11 +13,9 @@ from scipy.differentiate import derivative, jacobian, hessian
 from scipy.differentiate._differentiate import _EERRORINCREASE
 
 array_api_strict_skip_reason = 'Array API does not support fancy indexing assignment.'
-jax_skip_reason = 'JAX arrays do not support item assignment.'
 
 
 @pytest.mark.skip_xp_backends('array_api_strict', reason=array_api_strict_skip_reason)
-@pytest.mark.skip_xp_backends('jax.numpy',reason=jax_skip_reason)
 @pytest.mark.skip_xp_backends('dask.array', reason='boolean indexing assignment')
 class TestDerivative:
 
@@ -213,12 +211,13 @@ class TestDerivative:
         # test that `step_direction` works as expected
         def f(x):
             y = xp.exp(x)
-            y[(x < 0) + (x > 2)] = xp.nan
+            y = xpx.at(y)[(x < 0) + (x > 2)].set(xp.nan)
             return y
 
         x = xp.linspace(0, 2, 10)
         step_direction = xp.zeros_like(x)
-        step_direction[x < 0.6], step_direction[x > 1.4] = 1, -1
+        step_direction = xpx.at(step_direction)[x < 0.6].set(1)
+        step_direction = xpx.at(step_direction)[x > 1.4].set(-1)
         res = derivative(f, x, step_direction=step_direction)
         xp_assert_close(res.df, xp.exp(x))
         assert xp.all(res.success)
@@ -473,7 +472,6 @@ class JacobianHessianTest:
 
 
 @pytest.mark.skip_xp_backends('array_api_strict', reason=array_api_strict_skip_reason)
-@pytest.mark.skip_xp_backends('jax.numpy',reason=jax_skip_reason)
 @pytest.mark.skip_xp_backends('dask.array', reason='boolean indexing assignment')
 class TestJacobian(JacobianHessianTest):
     jh_func = jacobian
@@ -612,10 +610,10 @@ class TestJacobian(JacobianHessianTest):
         eps = 1e-7  # torch needs wiggle room?
 
         def f(x):
-            x[0, x[0] < b[0]] = xp.nan
-            x[0, x[0] > b[0] + 0.25] = xp.nan
-            x[1, x[1] > b[1]] = xp.nan
-            x[1, x[1] < b[1] - 0.1-eps] = xp.nan
+            x = xpx.at(x)[0, x[0] < b[0]].set(xp.nan)
+            x = xpx.at(x)[0, x[0] > b[0] + 0.25].set(xp.nan)
+            x = xpx.at(x)[1, x[1] > b[1]].set(xp.nan)
+            x = xpx.at(x)[1, x[1] < b[1] - 0.1-eps].set(xp.nan)
             return TestJacobian.f5(x, xp)
 
         dir = [1, -1, 0]
@@ -629,7 +627,6 @@ class TestJacobian(JacobianHessianTest):
 
 
 @pytest.mark.skip_xp_backends('array_api_strict', reason=array_api_strict_skip_reason)
-@pytest.mark.skip_xp_backends('jax.numpy',reason=jax_skip_reason)
 @pytest.mark.skip_xp_backends('dask.array', reason='boolean indexing assignment')
 class TestHessian(JacobianHessianTest):
     jh_func = hessian

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -600,7 +600,7 @@ class TestJacobian(JacobianHessianTest):
             ref[attr] = xp.squeeze(
                 ref_attr,
                 axis=tuple(ax for ax, size in enumerate(ref_attr.shape) if size == 1)
-            )            
+            )
             rtol = 1.5e-5 if res[attr].dtype == xp.float32 else 1.5e-14
             xp_assert_close(res[attr], ref[attr], rtol=rtol)
 

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -463,12 +463,12 @@ def rosen_hess(x):
     xp = array_namespace(x)
     x = xp_promote(x, force_floating=True, xp=xp)
 
-    H = (xpx.create_diagonal(-400 * x[:-1], offset=1, xp=xp) 
+    H = (xpx.create_diagonal(-400 * x[:-1], offset=1, xp=xp)
          - xpx.create_diagonal(400 * x[:-1], offset=-1, xp=xp))
     diagonal = xp.zeros(x.shape[0], dtype=x.dtype)
-    diagonal[0] = 1200 * x[0]**2 - 400 * x[1] + 2
-    diagonal[-1] = 200
-    diagonal[1:-1] = 202 + 1200 * x[1:-1]**2 - 400 * x[2:]
+    diagonal = xpx.at(diagonal)[0].set(1200 * x[0]**2 - 400 * x[1] + 2)
+    diagonal = xpx.at(diagonal)[-1].set(200)
+    diagonal = xpx.at(diagonal)[1:-1].set(202 + 1200 * x[1:-1]**2 - 400 * x[2:])
     return H + xpx.create_diagonal(diagonal, xp=xp)
 
 


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
Updates `_elementwise_iterative_method.py` and `_differentiate.py` to use `xpx.at.set` instead of `__setitem__`. This allows `scipy.differentiate` to be used with JAX arrays. Functions in other modules can be updated separately.

#### Additional information
Execution is quite slow with JAX, though.