### PR TITLE
MAINT: _lib: eliminate try/excepts in EIM

### DIFF
--- a/scipy/stats/_continued_fraction.py
+++ b/scipy/stats/_continued_fraction.py
@@ -8,6 +8,7 @@ from scipy._lib._util import _RichResult
 from scipy import special
 
 # Todo:
+# Avoid special-casing key 'n' in _lib._elementwise_iterative_method::_check_termination
 # Rearrange termination condition to allow absolute and relative tolerances?
 # Interpret/return |f_n - f_{n-1}| as an error estimate?
 # Return gracefully for size=0 arrays


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/22846#discussion_r2047372716

#### What does this implement/fix?
As noted in https://github.com/scipy/scipy/pull/22846#discussion_r2047372716, there were some undesirable (ugly, slow, non-specific) `try`/`except`s in `_lib._elementwise_iterative_method.py`. I thought it was going to be more complicated to remove them, hence the deferred maintenance, but it turned out to be pretty easy.
