### PR TITLE
TST: optimize `VectorFunction` add test for J0=None branch in _VectorHessWrapper._fd_hess

### DIFF
--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -349,6 +349,15 @@ class TestScalarFunction(TestCase):
         assert_array_equal(ex.nhev, nhev)
         assert_array_equal(analit.nhev+approx.nhev, nhev)
 
+        # Test VectorFunction.hess_wrapped with J0=None
+        x = np.array([1.5, 0.5])  # Ensure x is a numpy array
+        v = np.array([1.0, 2.0])
+        njev_before = approx.hess_wrapped.njev
+        H = approx.hess_wrapped(x, v, J0=None)
+        assert isinstance(H, LinearOperator)
+        # The njev counter should be incremented by exactly 1
+        assert approx.hess_wrapped.njev == njev_before + 1
+
     @pytest.mark.thread_unsafe
     def test_x_storage_overlap(self):
         # Scalar_Function should not store references to arrays, it should
@@ -779,6 +788,15 @@ class TestVectorialFunction(TestCase):
         assert_array_equal(analit.njev+approx.njev, njev)
         assert_array_equal(ex.nhev, nhev)
         assert_array_equal(analit.nhev+approx.nhev, nhev)
+
+        # Test VectorFunction.hess_wrapped with J0=None
+        x = np.array([1.5, 0.5])
+        v = np.array([1.0, 2.0])
+        njev_before = approx.hess_wrapped.njev
+        H = approx.hess_wrapped(x, v, J0=None)
+        assert isinstance(H, LinearOperator)
+        # The njev counter should be incremented by exactly 1
+        assert approx.hess_wrapped.njev == njev_before + 1
 
     def test_fgh_overlap(self):
         # VectorFunction.fun/jac should return copies to internal attributes


### PR DESCRIPTION
Add test to cover the J0=None branch in _VectorHessWrapper._fd_hess via VectorFunction finite-difference Hessian. This was introduced in https://github.com/scipy/scipy/pull/22764

https://github.com/andyfaff/scipy/blob/535d348c31d378b136f98ac114ba44e1e2c7a731/scipy/optimize/_differentiable_functions.py#L490-L492



