### PR TITLE
TST: Mark test as slow for custom distributions in the new infra with multiple parametrizations

### DIFF
--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1275,6 +1275,7 @@ class TestMakeDistribution:
         assert_allclose(X1.icdf(p), X2.icdf(p))
         assert_allclose(X1.iccdf(p), X2.iccdf(p))
 
+    @pytest.mark.slow
     @pytest.mark.parametrize("a", [0.5, np.asarray([0.5, 1.0, 2.0, 4.0, 8.0])])
     @pytest.mark.parametrize("b", [0.5, np.asarray([0.5, 1.0, 2.0, 4.0, 8.0])])
     def test_custom_multiple_parameterizations(self, a, b):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
I noticed this test I'd written failing due to taking too long when reviewing the unrelated PR #22823 and @mdhaber reported that he'd seen it failing elsewhere. Marking as slow.

#### Additional information
<!--Any additional information you think is important.-->
I think this is fine for now, but further on it would would probably be good to write a faster test for this feature.
