### PR TITLE
TST: fix `boxcox_llf` test failure on main

### DIFF
--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2044,7 +2044,8 @@ class TestBoxcox_llf:
         llf = stats.boxcox_llf(1e-8, data)
         # The expected value was computed with mpsci, set mpmath.mp.dps=100
         # expect float64 output for integer input
-        xp_assert_close(llf, xp.asarray(-15.32401272869016598, dtype=xp.float64))
+        xp_assert_close(llf, xp.asarray(-15.32401272869016598, dtype=xp.float64),
+                        rtol=1e-7)
 
     def test_axis(self, xp):
         data = xp.asarray([[100, 200], [300, 400]])


### PR DESCRIPTION
This was caused by a recent change to add array API support, the used `xp_assert_close` has an rtol that's more tight than `np.testing.assert_allclose` (5.96e-8 vs. 1e-7), so just reset the precision to the original value to make the test pass again.

Failure on Arch Linux x86-64 in a conda-forge environment:

```
_________________________ TestBoxcox_llf.test_instability_gh20021[numpy] _________________________
scipy/stats/tests/test_morestats.py:2047: in test_instability_gh20021
    xp_assert_close(llf, xp.asarray(-15.32401272869016598, dtype=xp.float64))
E   AssertionError:
E   Not equal to tolerance rtol=5.96046e-08, atol=0
E
E   Mismatched elements: 1 / 1 (100%)
E   Max absolute difference among violations: 1.41313445e-06
E   Max relative difference among violations: 9.22169979e-08
E    ACTUAL: array(-15.324014)
E    DESIRED: array(-15.324013)
```