### PR TITLE
MAINT: spatial.pdist: make dimensionality error more descriptive

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2294,7 +2294,7 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
 
     X = _asarray(X)
     if X.ndim != 2:
-        raise ValueError(f'A 2-dimensional array must be passed. (Shape was {X.ndim}).')
+        raise ValueError(f'A 2-dimensional array must be passed. (Shape was {X.shape}).')
 
     n = X.shape[0]
     return xpx.lazy_apply(_np_pdist, X, out,

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -2294,7 +2294,7 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
 
     X = _asarray(X)
     if X.ndim != 2:
-        raise ValueError('A 2-dimensional array must be passed.')
+        raise ValueError(f'A 2-dimensional array must be passed. (Shape was {X.ndim}).')
 
     n = X.shape[0]
     return xpx.lazy_apply(_np_pdist, X, out,


### PR DESCRIPTION
Previously, this error message did not describe what the dimensionality of the object was passed was. Including the actual value helps smooth debugging.
