### PR TITLE
TST: integrate/spatial: make fail_slow allowances

### DIFF
--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -631,6 +631,7 @@ class TestCumulativeSimpson:
         # `simpson` uses the trapezoidal rule
         return theoretical_difference
 
+    @pytest.mark.fail_slow(10)
     @pytest.mark.thread_unsafe
     @pytest.mark.slow
     @given(
@@ -662,6 +663,7 @@ class TestCumulativeSimpson:
             res[..., 1:], ref[..., 1:] + theoretical_difference[..., 1:], atol=1e-16
         )
 
+    @pytest.mark.fail_slow(10)
     @pytest.mark.thread_unsafe
     @pytest.mark.slow
     @given(

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -426,6 +426,7 @@ def test_random_ball_vectorized(kdtree_type):
     assert_(isinstance(r[0, 0], list))
 
 
+@pytest.mark.fail_slow(5)
 def test_query_ball_point_multithreading(kdtree_type):
     np.random.seed(0)
     n = 5000


### PR DESCRIPTION
I've seen these failing in the `fail_slow` jobs, so I'm giving them extra time.
```
test_cumulative_simpson_against_simpson_with_default_dx
test_cumulative_simpson_against_simpson
test_query_ball_point_multithreading
```
I'll go ahead and merge to reduce the number of unhelpful test failures we're getting right now, but if you can help speed these up or think they can be marked slow, please do!
