### PR TITLE
TST: reintroduce `eager_warns` and fix free-threading test failures

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -6,9 +6,10 @@ https://data-apis.org/array-api/latest/purpose_and_scope.html
 The SciPy use case of the Array API is described on the following page:
 https://data-apis.org/array-api/latest/use_cases.html#use-case-scipy
 """
-import os
+import contextlib
 import dataclasses
 import functools
+import os
 import textwrap
 
 from collections.abc import Generator, Iterable, Iterator
@@ -39,8 +40,8 @@ from scipy._lib._docscrape import FunctionDoc
 
 __all__ = [
     '_asarray', 'array_namespace', 'assert_almost_equal', 'assert_array_almost_equal',
-    'default_xp', 'is_lazy_array', 'is_marray',
-    'is_array_api_strict', 'is_complex', 'is_cupy', 'is_jax', 'is_numpy', 'is_torch', 
+    'default_xp', 'eager_warns', 'is_lazy_array', 'is_marray',
+    'is_array_api_strict', 'is_complex', 'is_cupy', 'is_jax', 'is_numpy', 'is_torch',
     'SCIPY_ARRAY_API', 'SCIPY_DEVICE', 'scipy_namespace_for',
     'xp_assert_close', 'xp_assert_equal', 'xp_assert_less',
     'xp_copy', 'xp_device', 'xp_ravel', 'xp_size',
@@ -246,7 +247,7 @@ _default_xp_ctxvar: ContextVar[ModuleType] = ContextVar("_default_xp")
 @contextmanager
 def default_xp(xp: ModuleType) -> Generator[None, None, None]:
     """In all ``xp_assert_*`` and ``assert_*`` function calls executed within this
-    context manager, test by default that the array namespace is 
+    context manager, test by default that the array namespace is
     the provided across all arrays, unless one explicitly passes the ``xp=``
     parameter or ``check_namespace=False``.
 
@@ -260,6 +261,17 @@ def default_xp(xp: ModuleType) -> Generator[None, None, None]:
         _default_xp_ctxvar.reset(token)
 
 
+def eager_warns(x, warning_type, match=None):
+    """pytest.warns context manager, but only if x is not a lazy array."""
+    import pytest
+    # This attribute is interpreted by pytest-run-parallel, ensuring that tests that use
+    # `eager_warns` aren't run in parallel (since pytest.warns isn't thread-safe).
+    __thread_safe__ = False  # noqa: F841
+    if is_lazy_array(x):
+        return contextlib.nullcontext()
+    return pytest.warns(warning_type, match=match)
+
+
 def _strict_check(actual, desired, xp, *,
                   check_namespace=True, check_dtype=True, check_shape=True,
                   check_0d=True):
@@ -270,7 +282,7 @@ def _strict_check(actual, desired, xp, *,
             xp = _default_xp_ctxvar.get()
         except LookupError:
             xp = array_namespace(desired)
- 
+
     if check_namespace:
         _assert_matching_namespace(actual, desired, xp)
 
@@ -486,7 +498,7 @@ def xp_result_type(*args, force_floating=False, xp):
     standard `result_type` in a few ways:
 
     - There is a `force_floating` argument that ensures that the result type
-      is floating point, even when all args are integer.     
+      is floating point, even when all args are integer.
     - When a TypeError is raised (e.g. due to an unsupported promotion)
       and `force_floating=True`, we define a custom rule: use the result type
       of the default float and any other floats passed. See
@@ -542,7 +554,7 @@ def xp_promote(*args, broadcast=False, force_floating=False, xp):
     This function accepts array-like iterables, which are immediately converted
     to the namespace's arrays before result type calculation. Consequently, the
     result dtype may be different when an argument is `1.` vs `[1.]`.
-    
+
     See Also
     --------
     xp_result_type

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2,10 +2,11 @@
 #
 # Further enhancements and tests added by numerous SciPy developers.
 #
-import math
-import warnings
-import sys
 import contextlib
+import math
+import re
+import sys
+import warnings
 from functools import partial
 
 import numpy as np
@@ -16,7 +17,7 @@ from numpy.testing import (assert_array_equal, assert_almost_equal,
                            suppress_warnings)
 import pytest
 from pytest import raises as assert_raises
-import re
+
 from scipy import optimize, stats, special
 from scipy.stats._morestats import _abw_state, _get_As_weibull, _Avals_weibull
 from .common_tests import check_named_results
@@ -365,6 +366,7 @@ class TestAnderson:
         with pytest.raises(ValueError, match=message):
             stats.anderson(x, 'weibull_min')
 
+    @pytest.mark.thread_unsafe
     def test_weibull_warning_error(self):
         # Check for warning message when there are too few observations
         # This is also an example in which an error occurs during fitting
@@ -2024,6 +2026,7 @@ class TestBoxcox_llf:
         llf2 = stats.boxcox_llf(lmbda, np.vstack([x, x]).T)
         xp_assert_close(xp.asarray([llf, llf]), xp.asarray(llf2), rtol=1e-12)
 
+    @pytest.mark.thread_unsafe
     def test_empty(self, xp):
         message = "One or more sample arguments is too small..."
         context = (pytest.warns(SmallSampleWarning, match=message) if is_numpy(xp)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -83,6 +83,13 @@ lazy_xp_function(stats.tmin, static_argnames=("inclusive", "axis"))
 lazy_xp_function(stats.tmax, static_argnames=("inclusive", "axis"))
 
 
+def eager_warns(x, warning_type, match=None):
+    """pytest.warns context manager, but only if x is not a lazy array."""
+    if is_lazy_array(x):
+        return contextlib.nullcontext()
+    return pytest.warns(warning_type, match=match)
+
+
 class TestTrimmedStats:
     # TODO: write these tests to handle missing values properly
     dprec = np.finfo(np.float64).precision
@@ -3062,11 +3069,7 @@ class TestZscore:
 
     def test_zscore_constant_input_1d(self, xp):
         x = xp.asarray([-0.087] * 3)
-        warn_ctx = (
-            contextlib.nullcontext() if is_lazy_array(x)
-            else pytest.warns(RuntimeWarning, match="Precision loss occurred..."))
-
-        with warn_ctx:
+        with eager_warns(x, RuntimeWarning, match="Precision loss occurred..."):
             z = stats.zscore(x)
         xp_assert_equal(z, xp.full(x.shape, xp.nan))
 
@@ -3077,16 +3080,12 @@ class TestZscore:
     def test_zscore_constant_input_2d(self, xp):
         x = xp.asarray([[10.0, 10.0, 10.0, 10.0],
                         [10.0, 11.0, 12.0, 13.0]])
-        warn_ctx = (
-            contextlib.nullcontext() if is_lazy_array(x)
-            else pytest.warns(RuntimeWarning, match="Precision loss occurred..."))
-
-        with warn_ctx:        
+        with eager_warns(x, RuntimeWarning, match="Precision loss occurred..."):
             z0 = stats.zscore(x, axis=0)
         xp_assert_close(z0, xp.asarray([[xp.nan, -1.0, -1.0, -1.0],
                                         [xp.nan, 1.0, 1.0, 1.0]]))
 
-        with warn_ctx:
+        with eager_warns(x, RuntimeWarning, match="Precision loss occurred..."):
             z1 = stats.zscore(x, axis=1)
         xp_assert_equal(z1, xp.stack([xp.asarray([xp.nan, xp.nan, xp.nan, xp.nan]),
                                       stats.zscore(x[1, :])]))
@@ -3095,7 +3094,7 @@ class TestZscore:
         xp_assert_equal(z, xp.reshape(stats.zscore(xp.reshape(x, (-1,))), x.shape))
 
         y = xp.ones((3, 6))
-        with warn_ctx:
+        with eager_warns(y, RuntimeWarning, match="Precision loss occurred..."):
             z = stats.zscore(y, axis=None)
         xp_assert_equal(z, xp.full(y.shape, xp.asarray(xp.nan)))
 
@@ -3106,17 +3105,14 @@ class TestZscore:
                         [10.0, 12.0, xp.nan, 10.0]])
         s = (3/2)**0.5
         s2 = 2**0.5
-        warn_ctx = (
-            contextlib.nullcontext() if is_lazy_array(x)
-            else pytest.warns(RuntimeWarning, match="Precision loss occurred..."))
 
-        with warn_ctx:
+        with eager_warns(x, RuntimeWarning, match="Precision loss occurred..."):
             z0 = stats.zscore(x, nan_policy='omit', axis=0)
         xp_assert_close(z0, xp.asarray([[xp.nan, -s, -1.0, xp.nan],
                                         [xp.nan, 0, 1.0, xp.nan],
                                         [xp.nan, s, xp.nan, xp.nan]]))
 
-        with warn_ctx:
+        with eager_warns(x, RuntimeWarning, match="Precision loss occurred..."):
             z1 = stats.zscore(x, nan_policy='omit', axis=1)
         xp_assert_close(z1, xp.asarray([[xp.nan, xp.nan, xp.nan, xp.nan],
                                         [-s, 0, s, xp.nan],
@@ -3734,25 +3730,17 @@ class TestSkew(SkewKurtosisTest):
     def test_skew_constant_value(self, xp):
         # Skewness of a constant input should be NaN (gh-16061)
         a = xp.asarray([-0.27829495]*10)  # xp.repeat not currently available
-        warn_ctx = (
-            contextlib.nullcontext() if is_lazy_array(a)
-            else pytest.warns(RuntimeWarning, match="Precision loss occurred..."))
 
-        with warn_ctx:
+        with eager_warns(a, RuntimeWarning, match="Precision loss occurred"):
             xp_assert_equal(stats.skew(a), xp.asarray(xp.nan))
-        with warn_ctx:
             xp_assert_equal(stats.skew(a*2.**50), xp.asarray(xp.nan))
-        with warn_ctx:
             xp_assert_equal(stats.skew(a/2.**50), xp.asarray(xp.nan))
-        with warn_ctx:
             xp_assert_equal(stats.skew(a, bias=False), xp.asarray(xp.nan))
 
-        # # similarly, from gh-11086:
-        a = xp.asarray([14.3]*7)
-        with warn_ctx:
+            # # similarly, from gh-11086:
+            a = xp.asarray([14.3]*7)
             xp_assert_equal(stats.skew(a), xp.asarray(xp.nan))
-        a = 1. + xp.arange(-3., 4)*1e-16
-        with warn_ctx:
+            a = 1. + xp.arange(-3., 4)*1e-16
             xp_assert_equal(stats.skew(a), xp.asarray(xp.nan))
 
     @skip_xp_backends(eager_only=True)
@@ -3854,17 +3842,10 @@ class TestKurtosis(SkewKurtosisTest):
     def test_kurtosis_constant_value(self, xp):
         # Kurtosis of a constant input should be NaN (gh-16061)
         a = xp.asarray([-0.27829495]*10)
-        warn_ctx = (
-            contextlib.nullcontext() if is_lazy_array(a)
-            else pytest.warns(RuntimeWarning, match="Precision loss occurred..."))
-
-        with warn_ctx:
+        with eager_warns(a, RuntimeWarning, match="Precision loss occurred"):
             assert xp.isnan(stats.kurtosis(a, fisher=False))
-        with warn_ctx:
             assert xp.isnan(stats.kurtosis(a * float(2**50), fisher=False))
-        with warn_ctx:
             assert xp.isnan(stats.kurtosis(a / float(2**50), fisher=False))
-        with warn_ctx:
             assert xp.isnan(stats.kurtosis(a, fisher=False, bias=False))
 
     @pytest.mark.parametrize('axis', [-1, 0, 2, None])
@@ -6110,11 +6091,8 @@ class TestTTestInd:
         # test zero division problem
         x = xp.zeros(3)
         y = xp.ones(3)
-        warn_ctx = (
-            contextlib.nullcontext() if is_lazy_array(x)
-            else pytest.warns(RuntimeWarning, match="Precision loss occurred..."))
 
-        with warn_ctx:
+        with eager_warns(x, RuntimeWarning, match="Precision loss occurred"):
             t, p = stats.ttest_ind(x, y, equal_var=False)
 
         xp_assert_equal(t, xp.asarray(-xp.inf))


### PR DESCRIPTION
The first commit reverts gh-22771, which is possible now that `pytest-run-parallel` 0.4.0 is available. The second moves to to `_lib._array_api` where I think it belongs, and uses it to address a few more test failures that occurred a few times in the last few days in the free-threading CI job (see https://github.com/scipy/scipy/issues/22758#issuecomment-2816855461).

