### PR TITLE
MAINT: linalg.svd: raise correct error message for GESDD when info=-4

### DIFF
--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -169,6 +169,9 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     if info > 0:
         raise LinAlgError("SVD did not converge")
     if info < 0:
+        if lapack_driver == "gesdd" and info == -4:
+            msg = "A has a NaN entry"
+            raise ValueError(msg)
         raise ValueError(f'illegal value in {-info}th argument of internal gesdd')
     if compute_uv:
         return u, s, v

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1224,6 +1224,13 @@ def test_svd_gesdd_nofegfault():
         svd(df)
 
 
+def test_gesdd_nan_error_message():
+    A = np.eye(2)
+    A[0, 0] = np.nan
+    with pytest.raises(ValueError, match="NaN"):
+        svd(A, check_finite=False)
+
+
 class TestSVDVals:
 
     @pytest.mark.parametrize('dt', [int, float, np.float32, complex, np.complex64])


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4e954dde-3887-4a96-be13-5378e8e32843)
Makes the error message closer to the infomation shown above when `gesdd` returns `info=-4` 