### PR TITLE
BUG: optimize._highspy: don't import from inside a C module

### DIFF
--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -23,10 +23,13 @@ from ._highspy._core import(
     HighsDebugLevel,
     ObjSense,
     HighsModelStatus,
-    simplex_constants as s_c,
+    simplex_constants as s_c,  # [1]
 )
 from scipy.sparse import csc_array, vstack, issparse
 
+# [1]: Directly importing from "._highspy._core.simplex_constants"
+# causes problems when reloading.
+# See https://github.com/scipy/scipy/pull/22869 for details.
 
 def _highs_to_scipy_status_message(highs_status, highs_message):
     """Converts HiGHS status number/message to SciPy status number/message"""

--- a/scipy/optimize/_linprog_highs.py
+++ b/scipy/optimize/_linprog_highs.py
@@ -23,10 +23,7 @@ from ._highspy._core import(
     HighsDebugLevel,
     ObjSense,
     HighsModelStatus,
-)
-from ._highspy._core.simplex_constants import (
-    SimplexStrategy,
-    SimplexEdgeWeightStrategy,
+    simplex_constants as s_c,
 )
 from scipy.sparse import csc_array, vstack, issparse
 
@@ -293,13 +290,13 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
         simplex_dual_edge_weight_strategy,
         'simplex_dual_edge_weight_strategy',
         choices={'dantzig': \
-                 SimplexEdgeWeightStrategy.kSimplexEdgeWeightStrategyDantzig,
+                 s_c.SimplexEdgeWeightStrategy.kSimplexEdgeWeightStrategyDantzig,
                  'devex': \
-                 SimplexEdgeWeightStrategy.kSimplexEdgeWeightStrategyDevex,
+                 s_c.SimplexEdgeWeightStrategy.kSimplexEdgeWeightStrategyDevex,
                  'steepest-devex': \
-                 SimplexEdgeWeightStrategy.kSimplexEdgeWeightStrategyChoose,
+                 s_c.SimplexEdgeWeightStrategy.kSimplexEdgeWeightStrategyChoose,
                  'steepest': \
-                 SimplexEdgeWeightStrategy.kSimplexEdgeWeightStrategySteepestEdge,
+                 s_c.SimplexEdgeWeightStrategy.kSimplexEdgeWeightStrategySteepestEdge,
                  None: None})
 
     c, A_ub, b_ub, A_eq, b_eq, bounds, x0, integrality = lp
@@ -334,7 +331,7 @@ def _linprog_highs(lp, solver, time_limit=None, presolve=True,
         'primal_feasibility_tolerance': primal_feasibility_tolerance,
         'simplex_dual_edge_weight_strategy':
             simplex_dual_edge_weight_strategy_enum,
-        'simplex_strategy': SimplexStrategy.kSimplexStrategyDual,
+        'simplex_strategy': s_c.SimplexStrategy.kSimplexStrategyDual,
         'ipm_iteration_limit': maxiter,
         'simplex_iteration_limit': maxiter,
         'mip_rel_gap': mip_rel_gap,


### PR DESCRIPTION
`scipy.optimize._highspy._core` is a C module. While it contains C modules, most notably `simplex_constants`, it may or may not be a package by the strict definition of Python 3.12's `importlib`. Thus directly importing from it may fail.

#### Reference issue
#22868 

#### What does this implement/fix?
Reloading scipy didn't work reliably.
