### PR TITLE
CI: limit pytest-fail-slow usage to a single CI job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -233,7 +233,7 @@ jobs:
   #################################################################################
   gcc9:
     # Purpose is to examine builds with oldest-supported gcc and test with pydata/sparse.
-    name: Oldest GCC & pydata/sparse, fast, py3.11/npMin, pip+pytest
+    name: Oldest GCC & pydata/sparse, full, py3.11/npMin, pip+pytest
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
@@ -574,7 +574,7 @@ jobs:
 
   #################################################################################
   test_aarch64:
-    name: aarch64, fast, py3.12/npAny, pip+pytest
+    name: aarch64, fast, fail slow, py3.12/npAny, pip+pytest
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
@@ -598,6 +598,10 @@ jobs:
     - name: Install Python packages
       run: |
         python -m pip install -r requirements/build.txt -r requirements/test.txt
+        # We want to check for test timing only in a single job, on Linux, running the
+        # fast test suite. This is that job. See gh-20806 for previous issues
+        # after running this job on Windows and in multiple jobs.
+        python -m pip install pytest-fail-slow
 
     - name: Install SciPy
       run: |
@@ -607,4 +611,4 @@ jobs:
       run: |
         export OMP_NUM_THREADS=2
         cd ..
-        pytest --pyargs scipy -m 'not slow'
+        pytest --pyargs scipy -m 'not slow' --durations=0 --durations-min=0.5 --fail-slow=1.0

--- a/.github/workflows/linux_intel_oneAPI.yml
+++ b/.github/workflows/linux_intel_oneAPI.yml
@@ -87,7 +87,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate scipy-dev
-          conda install -c conda-forge pkg-config meson meson-python ninja numpy cython pybind11 pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich-click click doit pydevtool hypothesis
+          conda install -c conda-forge pkg-config meson meson-python ninja numpy cython pybind11 pytest pytest-xdist pytest-timeout pooch rich-click click doit pydevtool hypothesis
 
       - name: Initialise Intel oneAPI and Build SciPy
         shell: bash -l {0}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,8 +21,8 @@ jobs:
     name: Get commit message
     uses: ./.github/workflows/commit_message.yml
 
-  fast_dev_py_fail_slow:
-    name: fail slow, fast, py3.12/npAny, dev.py
+  fast_dev_py:
+    name: fast, py3.12/npAny, dev.py
     needs: get_commit_message
     # Ensure (a) this doesn't run on forks by default, and
     #        (b) it does run with Act locally (`github` doesn't exist there)
@@ -49,7 +49,7 @@ jobs:
 
       - name: pip-packages
         run: |
-          pip install numpy cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich_click click doit pydevtool hypothesis
+          pip install numpy cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis
           python -m pip install -r requirements/openblas.txt
 
       - name: Build
@@ -60,12 +60,12 @@ jobs:
         run: |
           # test runner parallel clashes with OpenBLAS multithreading
           $env:OPENBLAS_NUM_THREADS=1
-          python dev.py test -j2 -- --durations=0 --durations-min=0.25 --fail-slow=1.0
+          python dev.py test -j2 -- --durations=25
 
 
   #############################################################################
-  full_dev_py_min_numpy_fail_slow:
-    name: fail slow, full, py3.11/npMin, dev.py
+  full_dev_py_min_numpy:
+    name: full, py3.11/npMin, dev.py
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
@@ -91,7 +91,7 @@ jobs:
       - name: pip-packages
         run: |
           # 1.25.2 is currently our oldest supported NumPy version
-          python -m pip install numpy==1.25.2 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich_click click doit pydevtool hypothesis
+          python -m pip install numpy==1.25.2 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch rich_click click doit pydevtool hypothesis
           python -m pip install -r requirements/openblas.txt
 
       - name: Build
@@ -102,7 +102,7 @@ jobs:
         run: |
           # test runner parallel clashes with OpenBLAS multithreading
           $env:OPENBLAS_NUM_THREADS=1
-          python dev.py test -j2 --mode full -- --durations=0 --durations-min=1.0 --timeout=60 --fail-slow=5.0
+          python dev.py test -j2 --mode full -- --durations=25 --timeout=60
 
 
   #############################################################################

--- a/.github/workflows/windows_intel_oneAPI.yml
+++ b/.github/workflows/windows_intel_oneAPI.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install packages from conda
         shell: cmd /C call {0}
         run: |
-          conda install -c conda-forge pkg-config meson meson-python ninja openblas libblas=*=*openblas numpy==2.0 cython pybind11 pytest pytest-xdist pytest-timeout pytest-fail-slow pooch rich-click click doit pydevtool hypothesis
+          conda install -c conda-forge pkg-config meson meson-python ninja openblas libblas=*=*openblas numpy==2.0 cython pybind11 pytest pytest-xdist pytest-timeout pooch rich-click click doit pydevtool hypothesis
 
       # MSVC is unable to compile Pythran code, therefore we need to use
       # -C-Duse-pythran=false while building SciPy.

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -120,6 +120,7 @@ class TestInt32Overflow:
     def teardown_method(self):
         gc.collect()
 
+    @pytest.mark.fail_slow(2)  # keep in fast set, only non-slow test
     def test_coo_todense(self):
         # Check *_todense routines (cf. gh-2179)
         #

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -321,6 +321,7 @@ def test_lpmv():
 # beta
 # ------------------------------------------------------------------------------
 
+@pytest.mark.slow
 @check_version(mpmath, '0.15')
 def test_beta():
     np.random.seed(1234)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -651,6 +651,7 @@ class TestPearsonr:
             assert_equal(res2.statistic, res.statistic)
             assert_equal(res2.pvalue, res.pvalue)
 
+    @pytest.mark.slow
     @pytest.mark.parametrize('alternative', ('less', 'greater', 'two-sided'))
     def test_bootstrap_ci(self, alternative):
         rng = np.random.default_rng(2462935790378923)


### PR DESCRIPTION
Addresses the flakiness of the Windows CI jobs. Implements what I proposed in https://github.com/scipy/scipy/issues/20806#issuecomment-2585776891. I picked the Linux aarch64 job as the only one where it was easy to cleanly add these flags.

Also marks a couple of tests that take a second or more as slow. I ran the job with a limit of 0.7 seconds, and that flagged two of these tests, the rest were fine. That gives 30% room for jitter, with the unchanged 1.0 second limit. In case this turns out to still result in spurious failures, we should remove support completely.

Closes gh-20806

