### PR TITLE
ENH: stats.quantile: add `weights` parameter

### DIFF
--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -197,3 +197,15 @@ class TestQuantile:
         res = stats.quantile(xp.asarray(x), xp.asarray(p), method=method)
         ref = np.quantile(x, p, method=method)
         xp_assert_equal(res, xp.asarray(ref, dtype=xp.float64))
+
+    def test_quantile_weighted_basic():
+        x = np.array([1, 2, 3, 4, 5])
+        w = np.array([1, 2, 1, 1, 5])
+        q = stats.quantile(x, 0.5, method='inverted_cdf', weights=w)
+        np.testing.assert_allclose(q, 4.5)
+
+    def test_quantile_weighted_wrong_method():
+        x = np.array([1, 2, 3, 4, 5])
+        w = np.array([1, 2, 1, 1, 5])
+        with pytest.raises(NotImplementedError):
+            stats.quantile(x, 0.5, method='linear', weights=w)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #22794

#### What does this implement/fix?
Added support for weights parameter for inverted_cdf method

#### Additional information
<!--Any additional information you think is important.-->
