### PR TITLE
MAINT: signal: correct the `get_window` delegator

### DIFF
--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -172,8 +172,8 @@ def kaiser_beta_signature(a):
 def kaiserord_signature(ripple, width):
     return np
 
-def get_window_signature(window, Nx, fftbins=True):
-    return np
+def get_window_signature(window, Nx, fftbins=True, *, xp=None, device=None):
+    return np if xp is None else xp
 #################################
 
 

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -20,7 +20,7 @@ JAX_SIGNAL_FUNCS = [
 ]
 
 # some cupyx.scipy.signal functions are incompatible with their scipy counterparts
-CUPY_BLACKLIST = ['lfilter_zi', 'sosfilt_zi']
+CUPY_BLACKLIST = ['lfilter_zi', 'sosfilt_zi', 'get_window']
 
 def delegate_xp(delegator, module_name):
     def inner(func):

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -10,7 +10,7 @@ from scipy.fft import fft
 from scipy.signal import windows, get_window, resample
 from scipy._lib._array_api import (
      xp_assert_close, xp_assert_equal, array_namespace, is_torch, is_jax, is_cupy,
-     assert_array_almost_equal, SCIPY_DEVICE,
+     assert_array_almost_equal, SCIPY_DEVICE, is_numpy
 )
 
 skip_xp_backends = pytest.mark.skip_xp_backends
@@ -853,6 +853,15 @@ class TestGetWindow:
                                     0.504551152, 0.], dtype=xp.float64), atol=1e-9)
         xp_assert_close(get_window('lanczos', 6, xp=xp),
                         get_window('sinc', 6, xp=xp))
+
+    def test_xp_default(self, xp):
+        # no explicit xp= argument, default to numpy
+        win = get_window('lanczos', 6)
+        assert isinstance(win, np.ndarray)
+
+        win = get_window('lanczos', 6, xp=xp)
+        if not is_numpy(xp):
+            assert not isinstance(win, np.ndarray)
 
 
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/2620")


### PR DESCRIPTION
`scipy.signal.get_window` has an `xp=` argument, but its delegator `get_window_signature` was always returning `np` for the namespace, so correct that.