### PR TITLE
DEV: add editable install support for `spin`

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -504,7 +504,7 @@ def smoke_docs(*, parent_callback, pytest_args, **kwargs):
 @meson.build_dir_option
 @click.pass_context
 def refguide_check(ctx, build_dir=None, *args, **kwargs):
-    """:wrench: Run refguide check."""
+    """🔧 Run refguide check."""
     click.secho(
             "Invoking `build` prior to running refguide-check:",
             bold=True, fg="bright_green"
@@ -604,7 +604,7 @@ def smoke_tutorials(ctx, pytest_args, tests, verbose, build_dir, *args, **kwargs
     help="Do not run cython-lint.")
 @click.pass_context
 def lint(ctx, fix, diff_against, files, all, no_cython):
-    """:dash: Run linter on modified files and check for
+    """🔦 Run linter on modified files and check for
     disallowed Unicode characters and possibly-invalid test names."""
     root = Path(__file__).parent.parent
 
@@ -725,7 +725,7 @@ def _dirty_git_working_dir():
 @click.pass_context
 def bench(ctx, tests, submodule, compare, verbose, quick,
           commits, build_dir=None, *args, **kwargs):
-    """:wrench: Run benchmarks.
+    """🔧 Run benchmarks.
 
     \b
     ```python

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -205,32 +205,41 @@ def test(*, parent_callback, pytest_args, tests, coverage,
     build_dir = os.path.abspath(kwargs['build_dir'])
     site_package_dir = get_site_packages(build_dir)
 
-    if site_package_dir is None and coverage:
-        raise FileNotFoundError(
-            "SciPy build not found, please execute "
-            "``spin build`` before calling ``spin test --coverage``. "
-            "We need it to figure out whether ``lcov`` can be called or not.")
-
-    if site_package_dir is not None:
-        with working_dir(site_package_dir):
-            sys.path.insert(0, site_package_dir)
-            os.environ['PYTHONPATH'] = \
-                os.pathsep.join((site_package_dir, os.environ.get('PYTHONPATH', '')))
-            was_built_with_gcov_flag = len(list(Path(build_dir).rglob("*.gcno"))) > 0
-            if was_built_with_gcov_flag:
-                config = importlib.import_module("scipy.__config__").show(mode='dicts')
-                compilers_config = config['Compilers']
-                cpp = compilers_config['c++']['name']
-                c = compilers_config['c']['name']
-                fortran = compilers_config['fortran']['name']
-                if not (c == 'gcc' and cpp == 'gcc' and fortran == 'gcc'):
-                    print("SciPy was built with --gcov flag which requires "
-                        "LCOV while running tests.\nFurther, LCOV usage "
-                        "requires GCC for C, C++ and Fortran codes in SciPy.\n"
-                        "Compilers used currently are:\n"
-                        f"  C: {c}\n  C++: {cpp}\n  Fortran: {fortran}\n"
-                        "Therefore, exiting without running tests.")
-                    exit(1) # Exit because tests will give missing symbol error
+    if coverage:
+        if is_editable_install():
+            click.secho(
+                "Error: cannot generate coverage report for editable installs",
+                fg="bright_red",
+            )
+            raise SystemExit(1)
+        elif site_package_dir is None:
+            raise FileNotFoundError(
+                "SciPy build not found, please execute "
+                "``spin build`` before calling ``spin test --coverage``. "
+                "We need it to figure out whether ``lcov`` can be called or not.")
+        else:
+            # Check needed to ensure gcov functions correctly.
+            with working_dir(site_package_dir):
+                sys.path.insert(0, site_package_dir)
+                os.environ['PYTHONPATH'] = os.pathsep.join(
+                        (site_package_dir, os.environ.get('PYTHONPATH', '')))
+                was_built_with_gcov_flag = len(list(
+                    Path(build_dir).rglob("*.gcno"))) > 0
+                if was_built_with_gcov_flag:
+                    config = importlib.import_module(
+                            "scipy.__config__").show(mode='dicts')
+                    compilers_config = config['Compilers']
+                    cpp = compilers_config['c++']['name']
+                    c = compilers_config['c']['name']
+                    fortran = compilers_config['fortran']['name']
+                    if not (c == 'gcc' and cpp == 'gcc' and fortran == 'gcc'):
+                        print("SciPy was built with --gcov flag which requires "
+                            "LCOV while running tests.\nFurther, LCOV usage "
+                            "requires GCC for C, C++ and Fortran codes in SciPy.\n"
+                            "Compilers used currently are:\n"
+                            f"  C: {c}\n  C++: {cpp}\n  Fortran: {fortran}\n"
+                            "Therefore, exiting without running tests.")
+                        exit(1) # Exit because tests will give missing symbol error
 
     if submodule:
         tests = PROJECT_MODULE + "." + submodule
@@ -389,11 +398,18 @@ def working_dir(new_dir):
 def mypy(ctx, build_dir=None):
     """🦆 Run Mypy tests for SciPy
     """
-    click.secho(
-            "Invoking `build` prior to running mypy tests:",
-            bold=True, fg="bright_green"
+    if is_editable_install():
+        click.secho(
+            "Error: Mypy does not work (well) for editable installs",
+            fg="bright_red",
         )
-    ctx.invoke(build)
+        raise SystemExit(1)
+    else:
+        click.secho(
+                "Invoking `build` prior to running mypy tests:",
+                bold=True, fg="bright_green"
+            )
+        ctx.invoke(build)
 
     try:
         import mypy.api
@@ -405,9 +421,9 @@ def mypy(ctx, build_dir=None):
 
     build_dir = os.path.abspath(build_dir)
     root = Path(build_dir).parent
-    install_dir = meson._get_site_packages(build_dir)
     config = os.path.join(root, "mypy.ini")
     check_path = PROJECT_MODULE
+    install_dir = meson._get_site_packages(build_dir)
 
     with working_dir(install_dir):
         os.environ['MYPY_FORCE_COLOR'] = '1'
@@ -1029,7 +1045,16 @@ def cpu_count(only_physical_cores=False):
     return aggregate_cpu_count
 
 def get_site_packages(build_dir):
+    """site-packages directory is path to installed in-tree build.
+
+    Returns None if `scipy` wasn't build at all.
+    Returns an empty string (from spin.meson call) for an editable install.
+    """
     try:
         return meson._get_site_packages(build_dir)
     except FileNotFoundError:
         return None
+
+
+def is_editable_install():
+    return meson._is_editable_install_of_same_source('scipy')

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -54,7 +54,7 @@ UPLOAD_DIR=/srv/docs_scipy_org/doc/scipy-$(RELEASE)
 
 # `set -o pipefail` is specific to bash
 SHELL = /bin/bash
-SCIPYVER:=$(shell $(PYTHON) -c "import scipy; print(scipy.version.git_revision[:10])" 2>/dev/null)
+SCIPYVER:=$(shell $(PYTHON) -c "import scipy; print(scipy.version.git_revision[:10])" | tail -c11 2>/dev/null)
 GITVER ?= $(shell (cd ..; set -o pipefail && git rev-parse HEAD 2>/dev/null | cut -c1-10) || echo Unknown)
 
 version-check:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,8 @@ PKG_CONFIG_PATH = "{project}"
   ".spin/cmds.py:build",
   ".spin/cmds.py:test",
   ".spin/cmds.py:mypy",
-  ".spin/cmds.py:lint"
+  ".spin/cmds.py:lint",
+  "spin.cmds.pip.install"
 ]
 "Environments" = [
   "spin.cmds.meson.run",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,14 @@
 [pytest]
 addopts = -l
-norecursedirs = doc tools scipy/_lib/array_api_compat scipy/_lib/cobyqa scipy/_lib/highs
 junit_family=xunit2
+norecursedirs =
+    doc
+    tools
+    scipy/_lib/array_api_compat
+    scipy/_lib/array_api_extra
+    scipy/_lib/cobyqa
+    scipy/_lib/highs
+    scipy/_lib/pyprima
 
 filterwarnings =
     error

--- a/scipy/_lib/_unuran_utils.py
+++ b/scipy/_lib/_unuran_utils.py
@@ -1,9 +1,0 @@
-"""Helper functions to get location of UNU.RAN source files."""
-
-import pathlib
-
-
-def _unuran_dir(ret_path: bool = False) -> pathlib.Path | str:
-    """Directory where root unuran/ directory lives."""
-    p = pathlib.Path(__file__).parent / "unuran"
-    return p if ret_path else str(p)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -216,7 +216,7 @@ if SCIPY_ARRAY_API:
 
     # by default, use all available backends
     if (
-        isinstance(SCIPY_ARRAY_API, str) 
+        isinstance(SCIPY_ARRAY_API, str)
         and SCIPY_ARRAY_API.lower() not in ("1", "true", "all")
     ):
         SCIPY_ARRAY_API_ = json.loads(SCIPY_ARRAY_API)
@@ -285,7 +285,7 @@ skip_xp_invalid_arg = pytest.mark.skipif(SCIPY_ARRAY_API,
 
 def _backends_kwargs_from_request(request, skip_or_xfail):
     """A helper for {skip,xfail}_xp_backends.
-    
+
     Return dict of {backend to skip/xfail: top reason to skip/xfail it}
     """
     markers = list(request.node.iter_markers(f'{skip_or_xfail}_xp_backends'))
@@ -343,7 +343,7 @@ def _backends_kwargs_from_request(request, skip_or_xfail):
                 f"Please specify only one backend per marker: {marker.args}"
             )
 
-    return {backend: backend_reasons[0] 
+    return {backend: backend_reasons[0]
             for backend, backend_reasons in reasons.items()
             if backend_reasons}
 
@@ -611,12 +611,25 @@ if HAVE_SCPDT:
         # equivalent to "pytest --ignore=path/to/file"
         "scipy/special/_precompute",
         "scipy/interpolate/_interpnd_info.py",
+        "scipy/interpolate/_rbfinterp_pythran.py",
+        "scipy/_build_utils/tempita.py",
         "scipy/_lib/array_api_compat",
         "scipy/_lib/highs",
         "scipy/_lib/unuran",
         "scipy/_lib/_gcutils.py",
         "scipy/_lib/doccer.py",
         "scipy/_lib/_uarray",
+        "scipy/linalg/_cython_signature_generator.py",
+        "scipy/linalg/_generate_pyx.py",
+        "scipy/linalg/_linalg_pythran.py",
+        "scipy/linalg/_matfuncs_sqrtm_triu.py",
+        "scipy/ndimage/utils/generate_label_testvectors.py",
+        "scipy/optimize/_group_columns.py",
+        "scipy/optimize/_max_len_seq_inner.py",
+        "scipy/signal/_max_len_seq_inner.py",
+        "scipy/sparse/_generate_sparsetools.py",
+        "scipy/special/_generate_pyx.py",
+        "scipy/stats/_stats_pythran.py",
     ]
 
     dt_config.pytest_extra_xfail = {


### PR DESCRIPTION
Addresses a part of gh-22887.

Running `spin install` will perform an editable install in the active environment. After that, `spin test` and other commands will pick up the editable install as expected.

Two things that are not supported are measuring coverage and running Mypy. Those seem to require a regular install with all files on disk, they cannot use the import hook for editable installs. Hence that will remain unsupported. It's a pretty minor limitation, everything else should work as advertised.