### PR TITLE
MAINT: fix `np.copyto` warnings on Dask

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -628,6 +628,20 @@ def xp_default_dtype(xp):
         return xp.float64
 
 
+def xp_result_device(*args):
+    """Return the device of an array in `args`, for the purpose of
+    input-output device propagation.
+    If there are multiple devices, return an arbitrary one.
+    If there are no arrays, return None (this typically happens only on NumPy).
+    """
+    for arg in args:
+        # Do not do a duck-type test for the .device attribute, as many backends today
+        # don't have it yet. See workarouunds in array_api_compat.device().
+        if is_array_api_obj(arg):
+            return xp_device(arg)
+    return None
+
+
 def is_marray(xp):
     """Returns True if `xp` is an MArray namespace; False otherwise."""
     return "marray" in xp.__name__

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -12,7 +12,8 @@ from typing import Literal, TypeAlias, TypeVar
 
 import numpy as np
 from scipy._lib._array_api import (Array, array_namespace, is_lazy_array,
-                                   is_numpy, is_marray, xp_size, xp_result_type)
+                                   is_numpy, is_marray, xp_result_device,
+                                   xp_size, xp_result_type)
 from scipy._lib._docscrape import FunctionDoc, Parameter
 from scipy._lib._sparse import issparse
 
@@ -1009,11 +1010,14 @@ def _rng_spawn(rng, n_children):
     return child_rngs
 
 
-def _get_nan(*data, xp=None):
+def _get_nan(*data, shape=(), xp=None):
     xp = array_namespace(*data) if xp is None else xp
     # Get NaN of appropriate dtype for data
     dtype = xp_result_type(*data, force_floating=True, xp=xp)
-    res = xp.asarray(xp.nan, dtype=dtype)[()]
+    device = xp_result_device(*data)
+    res = xp.full(shape, xp.nan, dtype=dtype, device=device)
+    if not shape:
+        res = res[()]
     # whenever mdhaber/marray#89 is resolved, could just return `res`
     return res.data if is_marray(xp) else res
 

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -222,9 +222,6 @@ class TestLogSumExp:
         ref = xp.logaddexp(a[0], a[1])
         xp_assert_close(res, ref)
 
-    @pytest.mark.filterwarnings(
-        "ignore:The `numpy.copyto` function is not implemented:FutureWarning:dask"
-    )
     @pytest.mark.parametrize('dtype', ['complex64', 'complex128'])
     def test_gh21610(self, xp, dtype):
         # gh-21610 noted that `logsumexp` could return imaginary components
@@ -240,7 +237,7 @@ class TestLogSumExp:
 
         res = logsumexp(x, axis=1)
         ref = xp.log(xp.sum(xp.exp(x), axis=1))
-        max = xp.full_like(xp.imag(res), xp.asarray(xp.pi))
+        max = xp.full_like(xp.imag(res), xp.pi)
         xp_assert_less(xp.abs(xp.imag(res)), max)
         xp_assert_close(res, ref)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6762,9 +6762,7 @@ def ttest_ind(a, b, *, axis=0, equal_var=True, nan_policy='propagate',
         raise NotImplementedError(message)
 
     result_shape = _broadcast_array_shapes_remove_axis((a, b), axis=axis)
-    NaN = _get_nan(a, b, xp=xp)
-    if result_shape != ():
-        NaN = xp.asarray(xp.broadcast_to(NaN, result_shape), copy=True)
+    NaN = _get_nan(a, b, shape=result_shape, xp=xp)
     if xp_size(a) == 0 or xp_size(b) == 0:
         return TtestResult(NaN, NaN, df=NaN, alternative=NaN,
                            standard_error=NaN, estimate=NaN)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -6762,8 +6762,9 @@ def ttest_ind(a, b, *, axis=0, equal_var=True, nan_policy='propagate',
         raise NotImplementedError(message)
 
     result_shape = _broadcast_array_shapes_remove_axis((a, b), axis=axis)
-    NaN = xp.full(result_shape, _get_nan(a, b, xp=xp))
-    NaN = NaN[()] if NaN.ndim == 0 else NaN
+    NaN = _get_nan(a, b, xp=xp)
+    if result_shape != ():
+        NaN = xp.asarray(xp.broadcast_to(NaN, result_shape), copy=True)
     if xp_size(a) == 0 or xp_size(b) == 0:
         return TtestResult(NaN, NaN, df=NaN, alternative=NaN,
                            standard_error=NaN, estimate=NaN)

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -103,23 +103,20 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
         axis = 0
 
     n = a.shape[axis]
-    NaN = _get_nan(a)
 
     if a.size == 0 or ddof > n:
         # Handle as a special case to avoid spurious warnings.
         # The return values, if any, are all nan.
-        shp = list(a.shape)
-        shp.pop(axis)
-        if shp:
-            return xp.asarray(xp.broadcast_to(NaN, tuple(shp)), copy=True)
-        return NaN
+        shape = list(a.shape)
+        shape.pop(axis)
+        return _get_nan(a, shape=tuple(shape), xp=xp)
 
     mean_a = xp.mean(a, axis=axis)
 
     if ddof == n:
         # Another special case.  Result is either inf or nan.
         std_a = xp.std(a, axis=axis, correction=0)
-        result = xp.where(std_a > 0, xp.copysign(xp.inf, mean_a), NaN)
+        result = xp.where(std_a > 0, xp.copysign(xp.inf, mean_a), xp.nan)
         return result[()] if result.ndim == 0 else result
 
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -110,8 +110,9 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
         # The return values, if any, are all nan.
         shp = list(a.shape)
         shp.pop(axis)
-        result = xp.full(shp, fill_value=NaN)
-        return result[()] if result.ndim == 0 else result
+        if shp:
+            return xp.asarray(xp.broadcast_to(NaN, tuple(shp)), copy=True)
+        return NaN
 
     mean_a = xp.mean(a, axis=axis)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6138,7 +6138,7 @@ class TestTTestInd:
         # The results should be arrays containing nan with shape
         # given by the broadcast nonaxis dimensions.
         a = xp.empty((3, 1, 0))
-        b = xp.asarray(b)
+        b = xp.asarray(b, dtype=a.dtype)
         with np.testing.suppress_warnings() as sup:
             # first case should warn, second shouldn't?
             sup.filter(SmallSampleWarning, too_small_nd_not_omit)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3063,9 +3063,6 @@ class TestZscore:
             z = stats.zscore(x)
         xp_assert_equal(z, xp.full(x.shape, xp.nan))
 
-    @pytest.mark.filterwarnings(
-        "ignore:The `numpy.copyto` function is not implemented:FutureWarning:dask"
-    )
     @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning:dask")
     def test_zscore_constant_input_2d(self, xp):
         x = xp.asarray([[10.0, 10.0, 10.0, 10.0],
@@ -3086,7 +3083,7 @@ class TestZscore:
         y = xp.ones((3, 6))
         with eager_warns(y, RuntimeWarning, match="Precision loss occurred..."):
             z = stats.zscore(y, axis=None)
-        xp_assert_equal(z, xp.full(y.shape, xp.asarray(xp.nan)))
+        xp_assert_equal(z, xp.full(y.shape, xp.nan))
 
     @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning:dask")
     def test_zscore_constant_input_2d_nan_policy_omit(self, xp):
@@ -6120,10 +6117,6 @@ class TestTTestInd:
         assert_allclose(r2, (-2.5354627641855498, 0.052181400457057901),
                         atol=1e-15)
 
-    # internal dask warning we can't do anything about
-    @pytest.mark.filterwarnings(
-        "ignore:The `numpy.copyto` function is not implemented:FutureWarning:dask"
-    )
     def test_ttest_ind_empty_1d_returns_nan(self, xp):
         # Two empty inputs should return a TtestResult containing nan
         # for both values.
@@ -6137,10 +6130,6 @@ class TestTTestInd:
         xp_assert_equal(res.statistic, NaN)
         xp_assert_equal(res.pvalue, NaN)
 
-    # internal dask warning we can't do anything about
-    @pytest.mark.filterwarnings(
-        "ignore:The `numpy.copyto` function is not implemented:FutureWarning:dask"
-    )
     @pytest.mark.parametrize('b, expected_shape',
                             [(np.empty((1, 5, 0)), (3, 5)),
                             (np.empty((1, 0, 0)), (3, 0))])

--- a/scipy/stats/tests/test_variation.py
+++ b/scipy/stats/tests/test_variation.py
@@ -133,10 +133,6 @@ class TestVariation:
         y = variation(x)
         xp_assert_equal(y, xp.asarray(xp.nan, dtype=x.dtype))
 
-    # internal dask warning we can't do anything about
-    @pytest.mark.filterwarnings(
-        "ignore:The `numpy.copyto` function is not implemented:FutureWarning:dask"
-    )
     @pytest.mark.parametrize('axis, expected',
                              [(0, []), (1, [np.nan]*3), (None, np.nan)])
     def test_2d_size_zero_with_axis(self, axis, expected, xp):


### PR DESCRIPTION
As per the Array API Standard, `fill_value` can't be an Array.
Discussion [here](https://github.com/data-apis/array-api/issues/909) to allow it in the next draft.
This triggers a warning in Dask.

This PR also fixes a bug in `stats.ttest_ind` where the returned dtype was the default float, regardless of inputs.
Finally, this PR returns a flaw in device propagation from input to output when returning NaN, with the device reverting to the default one instead of the device of the inputs.