### PR TITLE
ENH:io.loadmat: Returning variable name for `mxOPAQUE_CLASS` variables

### DIFF
--- a/scipy/io/matlab/_mio5_params.py
+++ b/scipy/io/matlab/_mio5_params.py
@@ -278,4 +278,4 @@ class MatlabOpaque(np.ndarray):
 
 
 OPAQUE_DTYPE = np.dtype(
-    [('s0', 'O'), ('s1', 'O'), ('s2', 'O'), ('arr', 'O')])
+    [('_TypeSystem', 'O'), ('_Class', 'O'), ('_ObjectMetadata', 'O')])

--- a/scipy/io/matlab/_mio5_utils.pyx
+++ b/scipy/io/matlab/_mio5_utils.pyx
@@ -596,7 +596,7 @@ cdef class VarReader5:
         # all miMATRIX types except the mxOPAQUE_CLASS have dims and a
         # name.
         if mc == mxOPAQUE_CLASS:
-            header.name = None
+            header.name = self.read_int8_string()
             header.dims = None
             return header
         header.n_dims = self.read_into_int32s(header.dims_ptr, sizeof(header.dims_ptr))
@@ -986,8 +986,7 @@ cdef class VarReader5:
         # Cython (0.23.4).
         res = np.empty((1,), dtype=OPAQUE_DTYPE)
         res0 = res[0]
-        res0['s0'] = self.read_int8_string()
-        res0['s1'] = self.read_int8_string()
-        res0['s2'] = self.read_int8_string()
-        res0['arr'] = self.read_mi_matrix()
+        res0['_TypeSystem'] = PyUnicode_FromString(self.read_int8_string())
+        res0['_Class'] = PyUnicode_FromString(self.read_int8_string())
+        res0['_ObjectMetadata'] = self.read_mi_matrix()
         return res


### PR DESCRIPTION
Hi! 
This is a small change related to earlier PR #22847 on handling `mxOPAQUE_CLASS` object in `.mat` files. 

Currently, `scipy.io.loadmat` return `"None"` as the variable name for `mxOPAQUE_CLASS` types. This results in overwriting of the final dictionary when multiple opaque objects are present in a MAT-file.

Since the other PR on this topic is understandably very complex, and will have a longer developmental cycle, this PR instead focuses on a simple, functional fix: 
1. Return variable name for `mxOPAQUE_CLASS` objects
2. Update `OPAQUE_DTYPE` in `_mio5_params.py` to more appropriately reflect field headers for these object types

These fixes would enable custom wrappers (like [mine](https://github.com/foreverallama/matio)) to read opaque objects, while the development of the other PR continues.

## Additional Context

`mxOPAQUE_CLASS` data element format is as follows:
1. Array Flags (indicating `mxOPAQUE_CLASS`
2. Array Name (`int8` string)
3. Type System Name (`int8` string)
4. Class Name (`int8` string)
5. Object Metadata - Any of the other array types