### PR TITLE
MAINT: special.logsumexp: improvement when weight of largest magnitude element is negative

### DIFF
--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -227,24 +227,29 @@ def _logsumexp(a, b, *, axis, return_sign, xp):
     s = xp.where(s == 0, s, s/m)
 
     # Separate sign/magnitude information
-    sgn = None
-    if return_sign:
-        # Use the numpy>=2.0 convention for sign.
-        # When all array libraries agree, this can become sng = xp.sign(s).
-        sgn = _sign(s + 1, xp=xp) * _sign(m, xp=xp)
+    # Originally, this was only performed if `return_sign=True`.
+    # However, this is also needed if any elements of `m < 0` or `s < -1`.
+    # An improvement would be to perform the calculations only on these entries.
 
-        if xp.isdtype(s.dtype, "real floating"):
-            # The log functions need positive arguments
-            s = xp.where(s < -1, -s - 2, s)
-            m = xp.abs(m)
-        else:
-            # `a_max` can have a sign component for complex input
-            sgn = sgn * xp.exp(xp.imag(a_max) * 1.0j)
+    # Use the numpy>=2.0 convention for sign.
+    # When all array libraries agree, this can become sng = xp.sign(s).
+    sgn = _sign(s + 1, xp=xp) * _sign(m, xp=xp)
+
+    if xp.isdtype(s.dtype, "real floating"):
+        # The log functions need positive arguments
+        s = xp.where(s < -1, -s - 2, s)
+        m = xp.abs(m)
+    else:
+        # `a_max` can have a sign component for complex input
+        sgn = sgn * xp.exp(xp.imag(a_max) * 1.0j)
 
     # Take log and undo shift
     out = xp.log1p(s) + xp.log(m) + a_max
 
-    out = xp.real(out) if return_sign else out
+    if return_sign:
+        out = xp.real(out)
+    elif xp.isdtype(out.dtype, 'real floating'):
+        out = xpx.at(out)[sgn < 0].set(xp.nan)
 
     return out, sgn
 

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -311,6 +311,20 @@ class TestLogSumExp:
             assert xp_device(logsumexp(x)) == xp_device(x)
             assert xp_device(logsumexp(x, b=x)) == xp_device(x)
 
+    def test_gh22903(self, xp):
+        # gh-22903 reported that `logsumexp` produced NaN where the weight associated
+        # with the max magnitude element was negative and `return_sign=False`, even if
+        # the net result should be the log of a positive number.
+
+        # result is log of positive number
+        a = xp.asarray([3.06409428, 0.37251854, 3.87471931])
+        b = xp.asarray([1.88190708, 2.84174795, -0.85016884])
+        xp_assert_close(logsumexp(a, b=b), logsumexp(a, b=b, return_sign=True)[0])
+
+        # result is log of negative number
+        b = xp.asarray([1.88190708, 2.84174795, -3.85016884])
+        xp_assert_close(logsumexp(a, b=b), xp.asarray(xp.nan))
+
 
 @make_skip_xp_backends(softmax)
 class TestSoftmax:


### PR DESCRIPTION
#### Reference issue
Closes gh-22903

#### What does this implement/fix?
gh-22903 reported that `logsumexp` produced NaN where the weight associated with the max magnitude element was negative and `return_sign=False`, even if the net result should be the log of a positive number. This happened to be avoided in `main`, but not in the best way. This fixes the root of the problem.

#### Additional information
Easier to review hiding whitespace changes.
@tylerjereddy I can help resolve any merge conflict in the backport. If this doesn't backport cleanly enough, there's no rush on this PR