### PR TITLE
TST: `linalg` add test coverage to exception handling for invalid shapes in `linalg._decomp_cossin._cossin`

### DIFF
--- a/scipy/linalg/tests/test_decomp_cossin.py
+++ b/scipy/linalg/tests/test_decomp_cossin.py
@@ -112,6 +112,20 @@ def test_cossin_error_non_iterable():
     with pytest.raises(ValueError, match="containing the subblocks of X"):
         cossin(12j)
 
+def test_cossin_error_invalid_shape():
+    # Invalid x12 dimensions
+    p, q = 3, 4
+    invalid_x12 = np.ones((p, q + 2))
+    valid_ones = np.ones((p, q))
+    with pytest.raises(ValueError, 
+            match=r"Invalid x12 dimensions: desired \(3, 4\), got \(3, 6\)"):
+        cossin((valid_ones, invalid_x12, valid_ones, valid_ones))
+
+    # Invalid x21 dimensions
+    invalid_x21 = np.ones(p + 2)
+    with pytest.raises(ValueError, 
+            match=r"Invalid x21 dimensions: desired \(3, 4\), got \(1, 5\)"):
+        cossin((valid_ones, valid_ones, invalid_x21, valid_ones))
 
 def test_cossin_error_non_square():
     with pytest.raises(ValueError, match="only supports square"):


### PR DESCRIPTION
This PR adds a test case to ensure exceptions are properly raised when `linalg._decomp_cossin._cossin` has arguments with non-decomposable shapes.

