### PR TITLE
TST: `optimize` add test coverage to callback warning in `optimize.least_squares`

### DIFF
--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -813,6 +813,17 @@ class TestLM(BaseMixin):
 
         assert_raises(ValueError, least_squares, fun_trivial, 2.0,
                       method='lm', loss='huber')
+    
+    def test_callback_with_lm_method(self):
+        def callback(x):
+            assert(False)  # Dummy callback function
+        
+        with suppress_warnings() as sup:
+            sup.filter(
+                UserWarning,
+                "Callback function specified, but not supported with `lm` method."
+            )
+            least_squares(fun_trivial, x0=[0], method='lm', callback=callback)
 
 
 def test_basic():


### PR DESCRIPTION
Adds a test to ensure warning is emitted when `optimize.least_squares` is called with `method='lm'` and `callback` function, and that the `callback` function is not used.