### PR TITLE
MAINT: spatial.cKDTree: remove software prefetching and software branch-prediction

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -31,10 +31,6 @@ cdef extern from "<limits.h>":
 
 __all__ = ['cKDTree']
 
-cdef extern from *:
-    int NPY_LIKELY(int)
-    int NPY_UNLIKELY(int)
-
 
 # C++ implementations
 # ===================
@@ -188,7 +184,7 @@ cdef class coo_entries:
         _dtype = [('i',np.intp),('j',np.intp),('v',np.float64)]
         res_dtype = np.dtype(_dtype, align = True)
         n = <np.intp_t> self.buf.size()
-        if NPY_LIKELY(n > 0):
+        if (n > 0):
             pr = self.buf.data()
             uintptr = <np.uintp_t> (<void*> pr)
             dtype = np.dtype(np.uint8)
@@ -211,7 +207,7 @@ cdef class coo_entries:
             coo_entry *pr
             dict res_dict
         n = <np.intp_t> self.buf.size()
-        if NPY_LIKELY(n > 0):
+        if (n > 0):
             pr = self.buf.data()
             res_dict = dict()
             for k in range(n):
@@ -261,7 +257,7 @@ cdef class ordered_pairs:
             np.uintp_t uintptr
             np.intp_t n
         n = <np.intp_t> self.buf.size()
-        if NPY_LIKELY(n > 0):
+        if (n > 0):
             pr = self.buf.data()
             uintptr = <np.uintp_t> (<void*> pr)
             dtype = np.dtype(np.intp)
@@ -1076,7 +1072,7 @@ cdef class cKDTree:
         results = n * [None]
         for i in range(n):
             m = <np.intp_t> (vvres[i].size())
-            if NPY_LIKELY(m > 0):
+            if (m > 0):
                 tmp = m * [None]
                 cur = vvres[i].data()
                 for j in range(m):

--- a/scipy/spatial/ckdtree/src/build.cxx
+++ b/scipy/spatial/ckdtree/src/build.cxx
@@ -52,7 +52,7 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
     }
     else {
 
-        if (CKDTREE_LIKELY(_compact)) {
+        if (_compact) {
             /* Recompute hyperrectangle bounds. This should lead to a more
              * compact kd-tree but comes at the expense of larger construction
              * time. However, construction time is usually dwarfed by the
@@ -107,7 +107,7 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
             return partition_ptr - indices;
         };
 
-        if (CKDTREE_LIKELY(_median)) {
+        if (_median) {
             /* split on median to create a balanced tree
              * adopted from scikit-learn
              */
@@ -143,7 +143,7 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
             p = partition_pivot(indices + start_idx, indices + end_idx, split);
         }
 
-        if (CKDTREE_UNLIKELY(p == start_idx || p == end_idx)) {
+        if (p == start_idx || p == end_idx) {
             // All children are equal in this dimension, try again with new bounds
             assert(!_compact);
             self->tree_buffer->pop_back();
@@ -160,7 +160,7 @@ build(ckdtree *self, ckdtree_intp_t start_idx, intptr_t end_idx,
             return build(self, start_idx, end_idx, tmp_maxes, tmp_mins, _median, _compact);
         }
 
-        if (CKDTREE_LIKELY(_compact)) {
+        if (_compact) {
             _less = build(self, start_idx, p, maxes, mins, _median, _compact);
             _greater = build(self, p, end_idx, maxes, mins, _median, _compact);
         }

--- a/scipy/spatial/ckdtree/src/ckdtree_decl.h
+++ b/scipy/spatial/ckdtree/src/ckdtree_decl.h
@@ -7,9 +7,6 @@
  * */
 #include <numpy/npy_common.h>
 #include <cmath>
-#define CKDTREE_LIKELY(x) NPY_LIKELY(x)
-#define CKDTREE_UNLIKELY(x)  NPY_UNLIKELY(x)
-#define CKDTREE_PREFETCH(x, rw, loc)  NPY_PREFETCH(x, rw, loc)
 
 #define ckdtree_intp_t npy_intp
 #define ckdtree_fmin(x, y)   fmin(x, y)

--- a/scipy/spatial/ckdtree/src/count_neighbors.cxx
+++ b/scipy/spatial/ckdtree/src/count_neighbors.cxx
@@ -100,26 +100,11 @@ traverse(
             const ckdtree_intp_t end1 = node1->end_idx;
             const ckdtree_intp_t end2 = node2->end_idx;
 
-            CKDTREE_PREFETCH(sdata + sindices[start1] * m, 0, m);
-
-            if (start1 < end1 - 1)
-                CKDTREE_PREFETCH(sdata + sindices[start1+1] * m, 0, m);
 
             /* brute-force */
             for (i = start1; i < end1; ++i) {
 
-                if (i < end1 - 2)
-                    CKDTREE_PREFETCH(sdata + sindices[i+2] * m, 0, m);
-
-                CKDTREE_PREFETCH(odata + oindices[start2] * m, 0, m);
-
-                if (start2 < end2 - 1)
-                    CKDTREE_PREFETCH(odata + oindices[start2+1] * m, 0, m);
-
                 for (j = start2; j < end2; ++j) {
-
-                    if (j < end2 - 2)
-                        CKDTREE_PREFETCH(odata + oindices[j+2] * m, 0, m);
 
                     double d = MinMaxDist::point_point_p(params->self.tree,
                             sdata + sindices[i] * m,
@@ -210,14 +195,14 @@ count_neighbors(struct CNBParams *params,
     Rectangle r1(self->m, self->raw_mins, self->raw_maxes);
     Rectangle r2(other->m, other->raw_mins, other->raw_maxes);
 
-    if (CKDTREE_LIKELY(self->raw_boxsize_data == NULL)) {
-        HANDLE(CKDTREE_LIKELY(p == 2), MinkowskiDistP2)
+    if (self->raw_boxsize_data == NULL) {
+        HANDLE(p == 2, MinkowskiDistP2)
         HANDLE(p == 1, MinkowskiDistP1)
         HANDLE(std::isinf(p), MinkowskiDistPinf)
         HANDLE(1, MinkowskiDistPp)
         {}
     } else {
-        HANDLE(CKDTREE_LIKELY(p == 2), BoxMinkowskiDistP2)
+        HANDLE(p == 2, BoxMinkowskiDistP2)
         HANDLE(p == 1, BoxMinkowskiDistP1)
         HANDLE(std::isinf(p), BoxMinkowskiDistPinf)
         HANDLE(1, BoxMinkowskiDistPp)

--- a/scipy/spatial/ckdtree/src/distance.h
+++ b/scipy/spatial/ckdtree/src/distance.h
@@ -117,10 +117,10 @@ struct BoxDist1D {
          *
          * We will fix the convention later.
          * */
-        if (CKDTREE_UNLIKELY(full <= 0)) {
+        if (full <= 0) {
             /* A non-periodic dimension */
             /* \/     */
-            if(max <= 0 || min >= 0) {
+            if (max <= 0 || min >= 0) {
                 /* do not pass though 0 */
                 min = ckdtree_fabs(min);
                 max = ckdtree_fabs(max);
@@ -230,7 +230,7 @@ struct BoxDist1D {
         tmax = x - max;
         tmin = x - min;
         /* is the test point in this range */
-        if(CKDTREE_LIKELY(tmax < 0 && tmin > 0)) {
+        if(tmax < 0 && tmin > 0) {
             /* yes. min distance is 0 */
             return 0;
         }
@@ -262,8 +262,8 @@ struct BoxDist1D {
     wrap_distance(const double x, const double hb, const double fb)
     {
         double x1;
-        if (CKDTREE_UNLIKELY(x < -hb)) x1 = fb + x;
-        else if (CKDTREE_UNLIKELY(x > hb)) x1 = x - fb;
+        if (x < -hb) x1 = fb + x;
+        else if (x > hb) x1 = x - fb;
         else x1 = x;
     #if 0
         printf("ckdtree_fabs_b x : %g x1 %g\n", x, x1);

--- a/scipy/spatial/ckdtree/src/query.cxx
+++ b/scipy/spatial/ckdtree/src/query.cxx
@@ -133,7 +133,7 @@ struct nodeinfo {
     }
 
     inline void update_side_distance(const int d, const double new_side_distance, const double p) {
-        if (CKDTREE_UNLIKELY(std::isinf(p))) {
+        if (std::isinf(p)) {
             min_distance = ckdtree_fmax(min_distance, new_side_distance);
         } else {
             min_distance += new_side_distance - side_distances()[d];
@@ -261,7 +261,7 @@ query_single_point(const ckdtree *self,
     }
 
     /* fiddle approximation factor */
-    if (CKDTREE_LIKELY(p == 2.0)) {
+    if (p == 2.0) {
         double tmp = 1. + eps;
         epsfac = 1. / (tmp*tmp);
     }
@@ -273,7 +273,7 @@ query_single_point(const ckdtree *self,
         epsfac = 1. / std::pow((1. + eps), p);
 
     /* internally we represent all distances as distance**p */
-    if (CKDTREE_LIKELY(p == 2.0)) {
+    if (p == 2.0) {
         double tmp = distance_upper_bound;
         distance_upper_bound = tmp*tmp;
     }
@@ -292,14 +292,7 @@ query_single_point(const ckdtree *self,
                 const double *data = self->raw_data;
                 const ckdtree_intp_t *indices = self->raw_indices;
 
-                CKDTREE_PREFETCH(data+indices[start_idx]*m, 0, m);
-                if (start_idx < end_idx - 1)
-                    CKDTREE_PREFETCH(data+indices[start_idx+1]*m, 0, m);
-
                 for (i=start_idx; i<end_idx; ++i) {
-
-                    if (i < end_idx - 2)
-                        CKDTREE_PREFETCH(data+indices[i+2]*m, 0, m);
 
                     d = MinMaxDist::point_point_p(self, data+indices[i]*m, x, p, m, distance_upper_bound);
                     if (d < distance_upper_bound) {
@@ -346,7 +339,7 @@ query_single_point(const ckdtree *self,
 
             ni2 = nipool.allocate();
 
-            if (CKDTREE_LIKELY(self->raw_boxsize_data == NULL)) {
+            if (self->raw_boxsize_data == NULL) {
                 /*
                  * non periodic : the 'near' node is know from the
                  * relative distance to the split, and
@@ -449,13 +442,13 @@ query_single_point(const ckdtree *self,
 
     /* fill output arrays with sorted neighbors */
     for (i = 0; i < nk; ++i) {
-        if(CKDTREE_UNLIKELY(k[i] - 1 >= nnb)) {
+        if (k[i] - 1 >= nnb) {
             result_indices[i] = self->n;
             result_distances[i] = inf;
         } else {
             neighbor = sorted_neighbors[k[i] - 1];
             result_indices[i] = neighbor.contents.intdata;
-            if (CKDTREE_LIKELY(p == 2.0))
+            if (p == 2.0)
                 result_distances[i] = std::sqrt(-neighbor.priority);
             else if ((p == 1.) || (std::isinf(p)))
                 result_distances[i] = -neighbor.priority;
@@ -488,12 +481,12 @@ query_knn(const ckdtree      *self,
     ckdtree_intp_t m = self->m;
     ckdtree_intp_t i;
 
-    if(CKDTREE_LIKELY(!self->raw_boxsize_data)) {
+    if (!self->raw_boxsize_data) {
         for (i=0; i<n; ++i) {
             double *dd_row = dd + (i*nk);
             ckdtree_intp_t *ii_row = ii + (i*nk);
             const double *xx_row = xx + (i*m);
-            HANDLE(CKDTREE_LIKELY(p == 2), MinkowskiDistP2)
+            HANDLE(p == 2, MinkowskiDistP2)
             HANDLE(p == 1, MinkowskiDistP1)
             HANDLE(std::isinf(p), MinkowskiDistPinf)
             HANDLE(1, MinkowskiDistPp)
@@ -510,7 +503,7 @@ query_knn(const ckdtree      *self,
             for(j=0; j<m; ++j) {
                 xx_row[j] = BoxDist1D::wrap_position(old_xx_row[j], self->raw_boxsize_data[j]);
             }
-            HANDLE(CKDTREE_LIKELY(p == 2), BoxMinkowskiDistP2)
+            HANDLE(p == 2, BoxMinkowskiDistP2)
             HANDLE(p == 1, BoxMinkowskiDistP1)
             HANDLE(std::isinf(p), BoxMinkowskiDistPinf)
             HANDLE(1, BoxMinkowskiDistPp) {}

--- a/scipy/spatial/ckdtree/src/query_ball_point.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_point.cxx
@@ -75,14 +75,7 @@ traverse_checking(const ckdtree *self,
         const ckdtree_intp_t start = lnode->start_idx;
         const ckdtree_intp_t end = lnode->end_idx;
 
-        CKDTREE_PREFETCH(data + indices[start] * m, 0, m);
-        if (start < end - 1)
-            CKDTREE_PREFETCH(data + indices[start+1] * m, 0, m);
-
         for (i = start; i < end; ++i) {
-
-            if (i < end -2 )
-                CKDTREE_PREFETCH(data + indices[i+2] * m, 0, m);
 
             d = MinMaxDist::point_point_p(self, data + indices[i] * m, tpt, p, m, tub);
 
@@ -124,9 +117,9 @@ query_ball_point(const ckdtree *self, const double *x,
     for (ckdtree_intp_t i=0; i < n_queries; ++i) {
         const ckdtree_intp_t m = self->m;
         Rectangle rect(m, self->raw_mins, self->raw_maxes);
-        if (CKDTREE_LIKELY(self->raw_boxsize_data == NULL)) {
+        if (self->raw_boxsize_data == NULL) {
             Rectangle point(m, x + i * m, x + i * m);
-            HANDLE(CKDTREE_LIKELY(p == 2), MinkowskiDistP2)
+            HANDLE(p == 2, MinkowskiDistP2)
             HANDLE(p == 1, MinkowskiDistP1)
             HANDLE(std::isinf(p), MinkowskiDistPinf)
             HANDLE(1, MinkowskiDistPp)
@@ -137,7 +130,7 @@ query_ball_point(const ckdtree *self, const double *x,
             for(j=0; j<m; ++j) {
                 point.maxes()[j] = point.mins()[j] = BoxDist1D::wrap_position(point.mins()[j], self->raw_boxsize_data[j]);
             }
-            HANDLE(CKDTREE_LIKELY(p == 2), BoxMinkowskiDistP2)
+            HANDLE(p == 2, BoxMinkowskiDistP2)
             HANDLE(p == 1, BoxMinkowskiDistP1)
             HANDLE(std::isinf(p), BoxMinkowskiDistPinf)
             HANDLE(1, BoxMinkowskiDistPp)

--- a/scipy/spatial/ckdtree/src/query_ball_tree.cxx
+++ b/scipy/spatial/ckdtree/src/query_ball_tree.cxx
@@ -90,27 +90,11 @@ traverse_checking(const ckdtree *self, const ckdtree *other,
             const ckdtree_intp_t end1 = lnode1->end_idx;
             const ckdtree_intp_t end2 = lnode2->end_idx;
 
-            CKDTREE_PREFETCH(sdata + sindices[start1] * m, 0, m);
-
-            if (start1 < end1 - 1)
-                CKDTREE_PREFETCH(sdata + sindices[start1+1] * m, 0, m);
-
             for (i = start1; i < end1; ++i) {
-
-                if (i < end1 - 2)
-                    CKDTREE_PREFETCH(sdata + sindices[i+2] * m, 0, m);
-
-                CKDTREE_PREFETCH(odata + oindices[start2] * m, 0, m);
-
-                if (start2 < end2 - 1)
-                    CKDTREE_PREFETCH(odata + oindices[start2+1] * m, 0, m);
 
                 auto &results_i = results[sindices[i]];
 
                 for (j = start2; j < end2; ++j) {
-
-                    if (j < end2 - 2)
-                        CKDTREE_PREFETCH(odata + oindices[j+2] * m, 0, m);
 
                     d = MinMaxDist::point_point_p(
                             self,
@@ -195,14 +179,14 @@ query_ball_tree(const ckdtree *self, const ckdtree *other,
     Rectangle r1(self->m, self->raw_mins, self->raw_maxes);
     Rectangle r2(other->m, other->raw_mins, other->raw_maxes);
 
-    if(CKDTREE_LIKELY(self->raw_boxsize_data == NULL)) {
-        HANDLE(CKDTREE_LIKELY(p == 2), MinkowskiDistP2)
+    if (self->raw_boxsize_data == NULL) {
+        HANDLE(p == 2, MinkowskiDistP2)
         HANDLE(p == 1, MinkowskiDistP1)
         HANDLE(std::isinf(p), MinkowskiDistPinf)
         HANDLE(1, MinkowskiDistPp)
         {}
     } else {
-        HANDLE(CKDTREE_LIKELY(p == 2), BoxMinkowskiDistP2)
+        HANDLE(p == 2, BoxMinkowskiDistP2)
         HANDLE(p == 1, BoxMinkowskiDistP1)
         HANDLE(std::isinf(p), BoxMinkowskiDistPinf)
         HANDLE(1, BoxMinkowskiDistPp)

--- a/scipy/spatial/ckdtree/src/query_pairs.cxx
+++ b/scipy/spatial/ckdtree/src/query_pairs.cxx
@@ -106,14 +106,8 @@ traverse_checking(const ckdtree *self,
             const ckdtree_intp_t end1 = lnode1->end_idx;
             const ckdtree_intp_t end2 = lnode2->end_idx;
 
-            CKDTREE_PREFETCH(data+indices[start1]*m, 0, m);
-            if (start1 < end1 - 1)
-               CKDTREE_PREFETCH(data+indices[start1+1]*m, 0, m);
 
             for(i = start1; i < end1; ++i) {
-
-                if (i < end1 - 2)
-                     CKDTREE_PREFETCH(data+indices[i+2]*m, 0, m);
 
                 /* Special care here to avoid duplicate pairs */
                 if (node1 == node2)
@@ -121,15 +115,7 @@ traverse_checking(const ckdtree *self,
                 else
                     min_j = start2;
 
-                if (min_j < end2)
-                    CKDTREE_PREFETCH(data+indices[min_j]*m, 0, m);
-                if (min_j < end2 - 1)
-                    CKDTREE_PREFETCH(data+indices[min_j+1]*m, 0, m);
-
                 for (j = min_j; j < end2; ++j) {
-
-                    if (j < end2 - 2)
-                        CKDTREE_PREFETCH(data+indices[j+2]*m, 0, m);
 
                     d = MinMaxDist::point_point_p(
                             self,
@@ -215,14 +201,14 @@ query_pairs(const ckdtree *self,
     Rectangle r1(self->m, self->raw_mins, self->raw_maxes);
     Rectangle r2(self->m, self->raw_mins, self->raw_maxes);
 
-    if(CKDTREE_LIKELY(self->raw_boxsize_data == NULL)) {
-        HANDLE(CKDTREE_LIKELY(p == 2), MinkowskiDistP2)
+    if (self->raw_boxsize_data == NULL) {
+        HANDLE(p == 2, MinkowskiDistP2)
         HANDLE(p == 1, MinkowskiDistP1)
         HANDLE(std::isinf(p), MinkowskiDistPinf)
         HANDLE(1, MinkowskiDistPp)
         {}
     } else {
-        HANDLE(CKDTREE_LIKELY(p == 2), BoxMinkowskiDistP2)
+        HANDLE(p == 2, BoxMinkowskiDistP2)
         HANDLE(p == 1, BoxMinkowskiDistP1)
         HANDLE(std::isinf(p), BoxMinkowskiDistPinf)
         HANDLE(1, BoxMinkowskiDistPp)

--- a/scipy/spatial/ckdtree/src/rectangle.h
+++ b/scipy/spatial/ckdtree/src/rectangle.h
@@ -128,7 +128,7 @@ template<typename MinMaxDist>
         p = _p;
 
         /* internally we represent all distances as distance ** p */
-        if (CKDTREE_LIKELY(p == 2.0))
+        if (p == 2.0)
             upper_bound = _upper_bound * _upper_bound;
         else if ((!std::isinf(p)) && (!std::isinf(_upper_bound)))
             upper_bound = std::pow(_upper_bound,p);
@@ -136,7 +136,7 @@ template<typename MinMaxDist>
             upper_bound = _upper_bound;
 
         /* fiddle approximation factor */
-        if (CKDTREE_LIKELY(p == 2.0)) {
+        if (p == 2.0) {
             double tmp = 1. + eps;
             epsfac = 1. / (tmp*tmp);
         }
@@ -212,7 +212,7 @@ template<typename MinMaxDist>
         subnomial = subnomial || ((min2 != 0 && min2 < inaccurate_distance_limit) || max2 < inaccurate_distance_limit);
         subnomial = subnomial || (min_distance < inaccurate_distance_limit || max_distance < inaccurate_distance_limit);
 
-        if (CKDTREE_UNLIKELY(subnomial)) {
+        if (subnomial) {
             MinMaxDist::rect_rect_p(tree, rect1, rect2, p, &min_distance, &max_distance);
         } else {
             min_distance += (min2 - min1);
@@ -235,7 +235,7 @@ template<typename MinMaxDist>
         --stack_size;
 
         /* assert stack_size >= 0 */
-        if (CKDTREE_UNLIKELY(stack_size < 0)) {
+        if (stack_size < 0) {
             const char *msg = "Bad stack size. This error should never occur.";
             throw std::logic_error(msg);
         }


### PR DESCRIPTION
#### Reference issue
Closes gh-22904

See also gh-22922

#### What does this implement/fix?
Removes prefetching and likely/unlikely statements in the code. It was useful in 2015 but not in 2025. Also it has been broken and defunct since a coding error in SciPy 1.3 (due to https://github.com/scipy/scipy/commit/6975656966bd526570af5616096487e10921f163). It complicates the code so it is time to remove it.


