### PR TITLE
BUG: interpolate: do not call PyArray macros on non-arrays

### DIFF
--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -23,8 +23,7 @@ check_array(PyObject *obj, npy_intp ndim, int typenum) {
 
     if(!cond) {
         std::string msg = ("Expected a " + std::to_string(ndim) + "-dim C contiguous array " +
-                           " of dtype = " + std::to_string(typenum) + "( got " +
-                           std::to_string(PyArray_TYPE((PyArrayObject*)obj)) +" )\n");
+                           " of dtype = " + std::to_string(typenum) + "\n");
         // XXX: name the dtype from typenum? Also type of arg if not array
         PyErr_SetString(PyExc_ValueError, msg.c_str());
         return 0;


### PR DESCRIPTION
closes gh-22931

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
