### PR TITLE
MAINT: optimize.zeros: fix error message

### DIFF
--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -225,6 +225,10 @@ class TestBracketMethods(TestScalarRootFinders):
         assert r.converged
         assert_allclose(root, 0)
 
+    def test_gh_22934(self):
+        with pytest.raises(ValueError, match="maxiter must be >= 0"):
+            zeros.brentq(lambda x: x**2 - 1, -2, 0, maxiter=-1)
+
 
 class TestNewton(TestScalarRootFinders):
     def test_newton_collections(self):

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -96,7 +96,7 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
         return NULL;
     }
     if (iter < 0) {
-        PyErr_SetString(PyExc_ValueError, "iter must be >= 0");
+        PyErr_SetString(PyExc_ValueError, "maxiter must be >= 0");
         return NULL;
     }
 

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -96,7 +96,7 @@ call_solver(solver_type solver, PyObject *self, PyObject *args)
         return NULL;
     }
     if (iter < 0) {
-        PyErr_SetString(PyExc_ValueError, "maxiter should be > 0");
+        PyErr_SetString(PyExc_ValueError, "iter must be >= 0");
         return NULL;
     }
 


### PR DESCRIPTION
#### Reference issue
No issue involved.

#### What does this implement/fix?
This tiny PR fixes the error message in `scipy/optimize/zeros.c` at
```
if (iter < 0) {
	PyErr_SetString(PyExc_ValueError, "maxiter should be > 0");
	return NULL;
}
```
Only negative `iter` are disallowed which means that `iter == 0` is allowed which leads to something like `iter must be >= 0`.

#### Additional information
