### PR TITLE
ENH: Handle missing attrs `.dtype` or `.dtype.kind` in sparse indexer

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -231,7 +231,7 @@ class IndexMixin:
             elif isinstance(idx, slice) or isintlike(idx):
                 index_1st.append(idx)
                 prelim_ndim += 1
-            elif (ix := _compatible_boolean_index(idx, self.ndim)) is not None:
+            elif (ix := _get_compatible_boolean_index(idx, self.ndim)) is not None:
                 index_1st.append(ix)
                 prelim_ndim += ix.ndim
             elif issparse(idx):
@@ -420,8 +420,8 @@ class IndexMixin:
         self._set_arrayXarray(row, col, x)
 
 
-def _compatible_boolean_index(idx, desired_ndim):
-    """Check for boolean array or array-like. peek before asarray for array-like"""
+def _get_compatible_boolean_index(idx, desired_ndim):
+    """Check for compatible boolean array-like value, converting to one if necessary."""
     # use attribute ndim to indicate a compatible array and check dtype
     # if not, look at 1st element as quick rejection of bool, else slower asanyarray
     if not hasattr(idx, 'ndim'):
@@ -439,6 +439,7 @@ def _compatible_boolean_index(idx, desired_ndim):
         # since first is boolean, construct array and check all elements
         idx = np.asanyarray(idx)
 
-    if idx.dtype.kind == 'b':
-        return idx
+    if hasattr(idx, 'dtype'):
+        if hasattr(idx.dtype, 'kind') and idx.dtype.kind == 'b':
+            return idx
     return None


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

None found

#### What does this implement/fix?

Here, we enable the passing of certain array-like objects such as a `torch.Tensor` for indexing sparse matrices. Currently, an object that has `ndim` such as `torch.Tensor` does not get converted by an `np.asanyarray` call. As a result, an exception occurs when the code attempts to access its non-existent `.dtype.kind` (it has `.dtype` but this lacks a `.kind` attribute unlike for a numpy array).

Notably, I did not include handling to detect a boolean `torch.Tensor`, but I can take a stab at that if desired (without importing `torch` of course). Pending feedback I'm also open to making other changes or improvements.

#### Additional information

Reproduction of error:
1. Use a CUDA environment with NVIDIA drivers installed
2. `pip install scanpy torch` 
3. Run the below code

```python
import anndata
import numpy as np
import scanpy as sc
import torch


# Initialize CUDA
print("Emptying CUDA cache...")
torch.cuda.empty_cache()
print("Initializing CUDA...")
torch.cuda.init()
# Set float32 matmul precision for better performance on NVIDIA GPUs
print("Setting float32 matmul precision to medium...")
torch.set_float32_matmul_precision("medium")

# Test CUDA initialization
print("Testing CUDA via matrix multiplication of random tensors...")
a = torch.rand((100, 100), device="cuda")
b = torch.rand((100, 100), device="cuda")
_ = torch.matmul(a, b)
print("Finished testing CUDA initialization.")

print("Loading small AnnData dataset...")
adata = sc.datasets.pbmc3k()
x = adata.X

# Subsample the data
indices = torch.arange(x.shape[0])
subsampled_indices = indices.split(512)
for batch in subsampled_indices:
    x_batch = x[batch, :]
    # ...

```
Yields exception:
```
Traceback (most recent call last):
  File "/home/ubuntu/Projects/cyrapids/scarches_tensor_index.py", line 31, in <module>
    x_batch = x[batch, :]
              ~^^^^^^^^^^
  File "/opt/pytorch/lib/python3.12/site-packages/scipy/sparse/_index.py", line 30, in __getitem__
    index, new_shape = self._validate_indices(key)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lib/python3.12/site-packages/scipy/sparse/_index.py", line 234, in _validate_indices
    elif (ix := _compatible_boolean_index(idx, self.ndim)) is not None:
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lib/python3.12/site-packages/scipy/sparse/_index.py", line 442, in _compatible_boolean_index
    if idx.dtype.kind == 'b':
       ^^^^^^^^^^^^^^
AttributeError: 'torch.dtype' object has no attribute 'kind'
```
