### PR TITLE
MAINT: stats.qmc.Sobol: fix stacklevel of warning

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -1863,7 +1863,7 @@ class Sobol(QMCEngine):
             # verify n is 2**n
             if not (n & (n - 1) == 0):
                 warnings.warn("The balance properties of Sobol' points require"
-                              " n to be a power of 2.", stacklevel=2)
+                              " n to be a power of 2.", stacklevel=3)
 
             if n == 1:
                 sample = self._first_point


### PR DESCRIPTION
A pretty trivial change but it cropped up while using this in my own research so thought I'd quickly fix. The stacklevel is currently set to 2 however the call stack is `.random() ->._random() -> warnings.warn()` so it should be set to 3.