### PR TITLE
MAINT: fix regressions in array-api-strict after disabling np.float64

### DIFF
--- a/scipy/fft/_fftlog_backend.py
+++ b/scipy/fft/_fftlog_backend.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 from warnings import warn
 from ._basic import rfft, irfft
@@ -8,7 +10,7 @@ from scipy._lib._array_api import array_namespace
 __all__ = ['fht', 'ifht', 'fhtoffset']
 
 # constants
-LN_2 = np.log(2)
+LN_2 = math.log(2)
 
 
 def fht(a, dln, mu, offset=0.0, bias=0.0):
@@ -168,11 +170,11 @@ def fhtoffset(dln, mu, initial=0.0, bias=0.0):
 
     xp = (mu+1+q)/2
     xm = (mu+1-q)/2
-    y = np.pi/(2*dln)
-    zp = loggamma(xp + 1j*y)
-    zm = loggamma(xm + 1j*y)
-    arg = (LN_2 - lnkr)/dln + (zp.imag + zm.imag)/np.pi
-    return lnkr + (arg - np.round(arg))*dln
+    y = math.pi/(2*dln)
+    zp = complex(loggamma(xp + 1j*y))
+    zm = complex(loggamma(xm + 1j*y))
+    arg = (LN_2 - lnkr)/dln + (zp.imag + zm.imag)/math.pi
+    return lnkr + (arg - round(arg))*dln
 
 
 def _fhtq(a, u, inverse=False, *, xp=None):

--- a/scipy/fft/_fftlog_backend.py
+++ b/scipy/fft/_fftlog_backend.py
@@ -1,5 +1,3 @@
-import math
-
 import numpy as np
 from warnings import warn
 from ._basic import rfft, irfft
@@ -10,7 +8,7 @@ from scipy._lib._array_api import array_namespace
 __all__ = ['fht', 'ifht', 'fhtoffset']
 
 # constants
-LN_2 = math.log(2)
+LN_2 = np.log(2)
 
 
 def fht(a, dln, mu, offset=0.0, bias=0.0):
@@ -170,11 +168,11 @@ def fhtoffset(dln, mu, initial=0.0, bias=0.0):
 
     xp = (mu+1+q)/2
     xm = (mu+1-q)/2
-    y = math.pi/(2*dln)
-    zp = complex(loggamma(xp + 1j*y))
-    zm = complex(loggamma(xm + 1j*y))
-    arg = (LN_2 - lnkr)/dln + (zp.imag + zm.imag)/math.pi
-    return lnkr + (arg - round(arg))*dln
+    y = np.pi/(2*dln)
+    zp = loggamma(xp + 1j*y)
+    zm = loggamma(xm + 1j*y)
+    arg = (LN_2 - lnkr)/dln + (zp.imag + zm.imag)/np.pi
+    return lnkr + (arg - np.round(arg))*dln
 
 
 def _fhtq(a, u, inverse=False, *, xp=None):

--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -23,7 +23,7 @@ def test_fht_agrees_with_fftlog(xp):
 
     r = np.logspace(-4, 4, 16)
 
-    dln = np.log(r[1]/r[0])
+    dln = math.log(r[1]/r[0])
     mu = 0.3
     offset = 0.0
     bias = 0.0
@@ -161,7 +161,7 @@ def test_fht_exact(n, xp):
     r = np.logspace(-2, 2, n)
     a = xp.asarray(r**gamma)
 
-    dln = np.log(r[1]/r[0])
+    dln = math.log(r[1]/r[0])
 
     offset = fhtoffset(dln, mu, initial=0.0, bias=gamma)
 

--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -60,6 +60,10 @@ def test_fht_agrees_with_fftlog(xp):
     # test 3: positive bias
     bias = 0.8
     offset = fhtoffset(dln, mu, bias=bias)
+    # offset is a np.float64, which array-api-strict disallows
+    # even if it's technically a subclass of float
+    offset = float(offset)
+
     ours = fht(a, dln, mu, offset=offset, bias=bias)
     theirs = [-7.3436673558316850E+00, +0.1710271207817100E+00,
               +0.1065374386206564E+00, -0.5121739602708132E-01,
@@ -75,6 +79,8 @@ def test_fht_agrees_with_fftlog(xp):
     # test 4: negative bias
     bias = -0.8
     offset = fhtoffset(dln, mu, bias=bias)
+    offset = float(offset)
+
     ours = fht(a, dln, mu, offset=offset, bias=bias)
     theirs = [+0.8985777068568745E-05, +0.4074898209936099E-04,
               +0.2123969254700955E-03, +0.1009558244834628E-02,
@@ -101,6 +107,9 @@ def test_fht_identity(n, bias, offset, optimal, xp):
 
     if optimal:
         offset = fhtoffset(dln, mu, initial=offset, bias=bias)
+        # offset is a np.float64, which array-api-strict disallows
+        # even if it's technically a subclass of float
+        offset = float(offset)
 
     A = fht(a, dln, mu, offset=offset, bias=bias)
     a_ = ifht(A, dln, mu, offset=offset, bias=bias)
@@ -164,6 +173,9 @@ def test_fht_exact(n, xp):
     dln = math.log(r[1]/r[0])
 
     offset = fhtoffset(dln, mu, initial=0.0, bias=gamma)
+    # offset is a np.float64, which array-api-strict disallows
+    # even if it's technically a subclass of float
+    offset = float(offset)
 
     A = fht(a, dln, mu, offset=offset, bias=gamma)
 

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1299,7 +1299,7 @@ def kaiser(M, beta, sym=True, *, xp=None, device=None):
     n = xp.arange(0, M, dtype=xp.float64, device=device)
     alpha = (M - 1) / 2.0
     w = (special.i0(beta * xp.sqrt(1 - ((n - alpha) / alpha) ** 2.0)) /
-         special.i0(xp.asarray(beta)))
+         special.i0(xp.asarray(beta, dtype=xp.float64)))
 
     return _truncate(w, needs_trunc)
 

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1299,7 +1299,7 @@ def kaiser(M, beta, sym=True, *, xp=None, device=None):
     n = xp.arange(0, M, dtype=xp.float64, device=device)
     alpha = (M - 1) / 2.0
     w = (special.i0(beta * xp.sqrt(1 - ((n - alpha) / alpha) ** 2.0)) /
-         special.i0(beta))
+         special.i0(xp.asarray(beta)))
 
     return _truncate(w, needs_trunc)
 


### PR DESCRIPTION
Fix regressions after
- data-apis/array-api-strict#145
- data-apis/array-api-strict#148