### PR TITLE
REL, MAINT: prep for 1.15.4

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release/1.15.4-notes
    release/1.15.3-notes
    release/1.15.2-notes
    release/1.15.1-notes

--- a/doc/source/release/1.15.4-notes.rst
+++ b/doc/source/release/1.15.4-notes.rst
@@ -1,0 +1,23 @@
+==========================
+SciPy 1.15.4 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.15.4 is a bug-fix release with no new features
+compared to 1.15.3.
+
+
+
+Authors
+=======
+* Name (commits)
+
+
+Issues closed for 1.15.4
+------------------------
+
+
+
+Pull requests for 1.15.4
+------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.15.3"
+version = "1.15.4.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Prepare for SciPy `1.15.4`, just in case.

This is very unlikely to happen unless there is an emergency, since branching for `1.16.x` is approaching, some of us are at the summit next week, etc.
