### PR TITLE
MAINT: wheel downloader

### DIFF
--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -16,7 +16,8 @@ from bs4 import BeautifulSoup
 __version__ = '0.1'
 
 # Edit these for other projects.
-STAGING_URL = "https://pypi.anaconda.org/multibuild-wheels-staging/simple/scipy/"
+STAGING_FILE_URL = "https://pypi.anaconda.org/multibuild-wheels-staging/simple/scipy/"
+STAGING_URL = 'https://anaconda.org/multibuild-wheels-staging/scipy'
 PREFIX = 'scipy'
 
 def http_manager():
@@ -47,7 +48,7 @@ def get_wheel_names(version):
     """
     http = http_manager()
     tmpl = re.compile(rf"^.*{PREFIX}-{version}-.*\.whl$")
-    index_url = f"{STAGING_URL}"
+    index_url = f"{STAGING_FILE_URL}"
     index_html = http.request('GET', index_url)
     soup = BeautifulSoup(index_html.data, 'html.parser')
     return soup.findAll(string=tmpl)

--- a/tools/download-wheels.py
+++ b/tools/download-wheels.py
@@ -16,7 +16,7 @@ from bs4 import BeautifulSoup
 __version__ = '0.1'
 
 # Edit these for other projects.
-STAGING_URL = 'https://anaconda.org/multibuild-wheels-staging/scipy'
+STAGING_URL = "https://pypi.anaconda.org/multibuild-wheels-staging/simple/scipy/"
 PREFIX = 'scipy'
 
 def http_manager():
@@ -47,7 +47,7 @@ def get_wheel_names(version):
     """
     http = http_manager()
     tmpl = re.compile(rf"^.*{PREFIX}-{version}-.*\.whl$")
-    index_url = f"{STAGING_URL}/files"
+    index_url = f"{STAGING_URL}"
     index_html = http.request('GET', index_url)
     soup = BeautifulSoup(index_html.data, 'html.parser')
     return soup.findAll(string=tmpl)


### PR DESCRIPTION
This fixes the downloading of all the wheels as part of the release process. This is to fix the issue mentioned in the comment at https://github.com/scipy/scipy/issues/21424#issuecomment-2863526109. The problem in that comment arises because https://anaconda.org/multibuild-wheels-staging/scipy/files is a "fancy" webpage, which only has so much space for listing files before one has to manually press next to see more files. The page isn't able to list all files for a given scipy version at once, which means that not all the wheel names for that version are scrapable.

This PR changes the staging URL to https://pypi.anaconda.org/multibuild-wheels-staging/simple/scipy/, which I think gives all the files. When I use this different URL all 45 of the wheels are downloaded.

@tylerjereddy