### PR TITLE
ENH: optimize.differential_evolution: enable passing parameters to polishing step

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1252,6 +1252,12 @@ class DifferentialEvolutionSolver:
                 self.minimizer_kwargs['bounds'] = self.limits.T
             if 'constraints' not in self.minimizer_kwargs:
                 self.minimizer_kwargs['constraints'] = self.constraints
+            if 'fun' in self.minimizer_kwargs or 'x0' in self.minimizer_kwargs:
+                warnings.warn("user-provided arguments fun or x0 in minimizer_kwargs"
+                              " will be overridden", UserWarning, stacklevel=2)
+            self.minimizer_kwargs['fun'] =\
+                lambda x: list(self._mapwrapper(self.func,np.atleast_2d(x)))[0]
+            self.minimizer_kwargs['x0'] = np.copy(DE_result.x)
 
             if self._wrapped_constraints:
                 constr_violation = self._constraint_violation_fn(DE_result.x)
@@ -1263,10 +1269,7 @@ class DifferentialEvolutionSolver:
                                   UserWarning, stacklevel=2)
             if self.disp:
                 print(f"Polishing solution with '{self.minimizer_kwargs['method']}'")
-            result = minimize(lambda x:
-                                list(self._mapwrapper(self.func, np.atleast_2d(x)))[0],
-                              np.copy(DE_result.x),
-                              **self.minimizer_kwargs)
+            result = minimize(**self.minimizer_kwargs)
 
             self._nfev += result.nfev
             DE_result.nfev = self._nfev

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -1701,3 +1701,25 @@ class TestDifferentialEvolutionSolver:
                 bounds,
                 strategy=custom_strategy_fn
             )
+
+    def test_minimizer_kwargs(self):
+        # test that minimizer_kwargs can be used to pass a jacobian, which is then
+        # used by differential_evolution, and result contains the number of jacobian
+        # evaluations
+        bounds = [(-10, 10)]
+        jac_calls = [0]
+
+        def quadratic(x):
+            return 1. + 2. * x + 3. * x**2.
+
+        def quadratic_jac(x):
+            jac_calls[0] += 1
+            return 2. + 6. * x
+
+        result = differential_evolution(quadratic,
+                                        bounds,
+                                        polish=True,
+                                        minimizer_kwargs={"jac": quadratic_jac})
+        assert_almost_equal(result.fun, 2 / 3.)
+        assert jac_calls[0] > 0
+        assert jac_calls[0] == result.njev


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
As a final step, differential evolution calls the `minimize` function to "polish" the results. It would be useful to be able to pass additional parameters to the `minimize function` (e.g. a jacobian or the name of a minimization method). The dual annealing method already offers this option. This commit adds this possibility for differential evolution via the `minimizer_kwargs` parameter. The default behavior is unchanged.
