### PR TITLE
MAINT: stats.make_distribution: fix most remaining discrete distribution specific issues

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1371,12 +1371,13 @@ def _gen_harmonic_leq1(n, a):
     """Generalized harmonic number, a <= 1"""
     if not np.size(n):
         return n
-    n_max = np.max(n)  # loop starts at maximum of all n
+    n_max = np.nanmax(n)  # loop starts at maximum of all n
     out = np.zeros_like(a, dtype=float)
     # add terms of harmonic series; starting from smallest to avoid roundoff
     for i in np.arange(n_max, 0, -1, dtype=float):
         mask = i <= n  # don't add terms after nth
         out[mask] += 1/i**a[mask]
+    out[np.isnan(n)] = np.nan
     return out
 
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1872,9 +1872,9 @@ class _nchypergeom_gen(rv_discrete):
     def _argcheck(self, M, n, N, odds):
         M, n = np.asarray(M), np.asarray(n),
         N, odds = np.asarray(N), np.asarray(odds)
-        cond1 = (M.astype(int) == M) & (M >= 0)
-        cond2 = (n.astype(int) == n) & (n >= 0)
-        cond3 = (N.astype(int) == N) & (N >= 0)
+        cond1 = (~np.isnan(M)) & (M.astype(int) == M) & (M >= 0)
+        cond2 = (~np.isnan(n)) & (n.astype(int) == n) & (n >= 0)
+        cond3 = (~np.isnan(N)) & (N.astype(int) == N) & (N >= 0)
         cond4 = odds > 0
         cond5 = N <= M
         cond6 = n <= M
@@ -1884,6 +1884,8 @@ class _nchypergeom_gen(rv_discrete):
 
         @_vectorize_rvs_over_shapes
         def _rvs1(M, n, N, odds, size, random_state):
+            if np.isnan(M) | np.isnan(n) | np.isnan(N):
+                return np.full(size, np.nan)
             length = np.prod(size)
             urn = _PyStochasticLib3()
             rv_gen = getattr(urn, self.rvs_name)
@@ -1901,15 +1903,19 @@ class _nchypergeom_gen(rv_discrete):
 
         @np.vectorize
         def _pmf1(x, M, n, N, odds):
+            if np.isnan(x) | np.isnan(M) | np.isnan(n) | np.isnan(N):
+                return np.nan
             urn = self.dist(N, n, M, odds, 1e-12)
             return urn.probability(x)
 
         return _pmf1(x, M, n, N, odds)
 
-    def _stats(self, M, n, N, odds, moments):
+    def _stats(self, M, n, N, odds, moments='mv'):
 
         @np.vectorize
         def _moments1(M, n, N, odds):
+            if np.isnan(M) | np.isnan(n) | np.isnan(N):
+                return np.nan, np.nan
             urn = self.dist(N, n, M, odds, 1e-12)
             return urn.moments()
 

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3857,7 +3857,7 @@ def make_distribution(dist):
         `make_distribution` does not work perfectly with all instances of
         `rv_continuous`. Known failures include `levy_stable`, `vonmises`,
         `hypergeom`, `nchypergeom_fisher`, `nchypergeom_wallenius`,
-        `poisson_binom`; and some methods of some distributions
+        `poisson_binom`, and 'skellam'. Some methods of some distributions
         will not support array shape parameters.
 
     Parameters
@@ -4067,7 +4067,7 @@ def make_distribution(dist):
     """
     if dist in {stats.levy_stable, stats.vonmises, stats.hypergeom,
                 stats.nchypergeom_fisher, stats.nchypergeom_wallenius,
-                stats.poisson_binom}:
+                stats.poisson_binom, stats.skellam}:
         raise NotImplementedError(f"`{dist.name}` is not supported.")
 
     if isinstance(dist, stats.rv_continuous | stats.rv_discrete):

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3856,8 +3856,7 @@ def make_distribution(dist):
 
         `make_distribution` does not work perfectly with all instances of
         `rv_continuous`. Known failures include `levy_stable`, `vonmises`,
-        `hypergeom`, `nchypergeom_fisher`, `nchypergeom_wallenius`,
-        `poisson_binom`, and 'skellam'. Some methods of some distributions
+        `hypergeom`, `poisson_binom`, and 'skellam'. Some methods of some distributions
         will not support array shape parameters.
 
     Parameters
@@ -4066,7 +4065,6 @@ def make_distribution(dist):
 
     """
     if dist in {stats.levy_stable, stats.vonmises, stats.hypergeom,
-                stats.nchypergeom_fisher, stats.nchypergeom_wallenius,
                 stats.poisson_binom, stats.skellam}:
         raise NotImplementedError(f"`{dist.name}` is not supported.")
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1122,8 +1122,6 @@ class TestMakeDistribution:
             'vonmises',               # circular distribution; shouldn't work
             'poisson_binom',          # vector shape parameter
             'hypergeom',              # distribution functions need interpolation
-            'nchypergeom_fisher',     # distribution functions don't accept NaN
-            'nchypergeom_wallenius',  # distribution functions don't accept NaN
             'skellam',                # gh-22956 (_ncx2_pdf crashes with extreme input)
         }:
             return
@@ -1131,14 +1129,15 @@ class TestMakeDistribution:
         # skip single test, mostly due to slight disagreement
         custom_tolerances = {'ksone': 1e-5, 'kstwo': 1e-5}  # discontinuous PDF
         skip_entropy = {'kstwobign', 'pearson3'}  # tolerance issue
-        skip_skewness = {'exponpow', 'ksone'}  # tolerance issue
-        skip_kurtosis = {'chi', 'exponpow', 'invgamma',  # tolerance issue
-                         'johnsonsb', 'ksone', 'kstwo'}  # tolerance issue
+        skip_skewness = {'exponpow', 'ksone', 'nchypergeom_wallenius'}  # tolerance
+        skip_kurtosis = {'chi', 'exponpow', 'invgamma',  # tolerance
+                         'johnsonsb', 'ksone', 'kstwo',  # tolerance
+                         'nchypergeom_wallenius'}  # tolerance
         skip_logccdf = {'arcsine', 'skewcauchy', 'trapezoid', 'triang'}  # tolerance
         skip_raw = {2: {'alpha', 'foldcauchy', 'halfcauchy', 'levy', 'levy_l'},
                     3: {'pareto'},  # stats.pareto is just wrong
                     4: {'invgamma'}}  # tolerance issue
-        skip_standardized = {'exponpow', 'ksone'}  # tolerances
+        skip_standardized = {'exponpow', 'ksone', 'nchypergeom_wallenius'}  # tolerances
         skip_median = {'nhypergeom', 'yulesimon',  # nan mismatch
                        'betanbinom', 'zipf', 'logser'}  # median 0th element
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1124,7 +1124,7 @@ class TestMakeDistribution:
             'hypergeom',              # distribution functions need interpolation
             'nchypergeom_fisher',     # distribution functions don't accept NaN
             'nchypergeom_wallenius',  # distribution functions don't accept NaN
-            'skellam',                # during `entropy`, Fatal Python error: Aborted!
+            'skellam',                # gh-22956 (_ncx2_pdf crashes with extreme input)
         }:
             return
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1113,7 +1113,7 @@ class TestMakeDistribution:
                 'johnsonsb', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'norminvgauss',
                 'powerlognorm', 'powernorm', 'recipinvgauss', 'studentized_range',
                 'vonmises_line', # continuous
-                'betanbinom', 'zipf', 'logser', 'skellam'}  # discrete
+                'skellam'}  # discrete
         if not int(os.environ.get('SCIPY_XSLOW', '0')) and distname in slow:
             pytest.skip('Skipping as XSLOW')
 
@@ -1139,7 +1139,8 @@ class TestMakeDistribution:
                     3: {'pareto'},  # stats.pareto is just wrong
                     4: {'invgamma'}}  # tolerance issue
         skip_standardized = {'exponpow', 'ksone'}  # tolerances
-        skip_median = {'nhypergeom', 'yulesimon'}  # nan mismatch
+        skip_median = {'nhypergeom', 'yulesimon',  # nan mismatch
+                       'betanbinom', 'zipf', 'logser'}  # median 0th element
 
         dist = getattr(stats, distname)
         params = dict(zip(dist.shapes.split(', '), distdata[1])) if dist.shapes else {}

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1125,7 +1125,6 @@ class TestMakeDistribution:
             'nchypergeom_fisher',     # distribution functions don't accept NaN
             'nchypergeom_wallenius',  # distribution functions don't accept NaN
             'skellam',                # during `entropy`, Fatal Python error: Aborted!
-            'zipfian',                # during init, value error due to unexpected nans
         }:
             return
 
@@ -1195,10 +1194,14 @@ class TestMakeDistribution:
                 if distname not in skip_standardized:
                     assert_allclose(X.moment(order, kind='standardized'),
                                     Y.stats('mvsk'[order-1]), rtol=rtol, atol=atol)
-            seed = 845298245687345
-            assert_allclose(X.sample(shape=10, rng=seed),
-                            Y.rvs(size=10, random_state=np.random.default_rng(seed)),
-                            rtol=rtol)
+            if isinstance(dist, stats.rv_continuous):
+                # For discrete distributions, these won't agree at the far left end
+                # of the support, and the new infrastructure is slow there (for now).
+                seed = 845298245687345
+                assert_allclose(X.sample(shape=10, rng=seed),
+                                Y.rvs(size=10,
+                                      random_state=np.random.default_rng(seed)),
+                                rtol=rtol)
 
     def test_custom(self):
         rng = np.random.default_rng(7548723590230982)


### PR DESCRIPTION
#### Reference issue
gh-22312

#### What does this implement/fix?
gh-22312 added a new discrete distribution infrastructure and a way to use the infrastructure with existing discrete distributions, but there were distribution-specific issues that precluded use with some distributions. This resolves those issues for `nchypergeom_fisher`, `nchypergeom_fisher`, and `zipfian`. It also runs tests properly on `betanbinom`, `zipf`, and `logser`.
