### PR TITLE
BUG: interpolate.make_splrep: raise error when `residuals.sum()` becomes `NaN`

### DIFF
--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -60,7 +60,7 @@ def _get_residuals(x, y, t, k, w):
     residuals = _compute_residuals(w2, spl(x), y)
     fp = residuals.sum()
     if np.isnan(fp):
-        raise RuntimeError(_iermesg[1])
+        raise ValueError(_iermesg[1])
     return residuals, fp
 
 

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -666,7 +666,7 @@ def _make_splrep_impl(x, y, *, w=None, xb=None, xe=None, k=3, s=0, t=None, nest=
         nest = max(m + k + 1, 2*k + 3)
     else:
         if nest < 2*(k + 1):
-            raise ValueError(f"`nest` too small: {nest = } < 2*(k+1) = {2*(k+1)}.")    
+            raise ValueError(f"`nest` too small: {nest = } < 2*(k+1) = {2*(k+1)}.")
         if t is not None:
             raise ValueError("Either supply `t` or `nest`.")
 

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -57,7 +57,11 @@ def _get_residuals(x, y, t, k, w):
     _, _, c = _lsq_solve_qr(x, y, t, k, w)
     c = np.ascontiguousarray(c)
     spl = BSpline(t, c, k)
-    return _compute_residuals(w2, spl(x), y)
+    residuals = _compute_residuals(w2, spl(x), y)
+    fp = residuals.sum()
+    if np.isnan(fp):
+        raise RuntimeError(_iermesg[1])
+    return residuals, fp
 
 
 def _compute_residuals(w2, splx, y):
@@ -258,8 +262,7 @@ def _generate_knots_impl(x, y, *, w=None, xb=None, xe=None, k=3, s=0, nest=None)
 
         # construct the LSQ spline with this set of knots
         fpold = fp
-        residuals = _get_residuals(x, y, t, k, w=w)
-        fp = residuals.sum()
+        residuals, fp = _get_residuals(x, y, t, k, w=w)
         fpms = fp - s
 
         # c  test whether the approximation sinf(x) is an acceptable solution.
@@ -300,7 +303,7 @@ def _generate_knots_impl(x, y, *, w=None, xb=None, xe=None, k=3, s=0, nest=None)
 
             # recompute if needed
             if j < nplus - 1:
-                residuals = _get_residuals(x, y, t, k, w=w)
+                residuals, _ = _get_residuals(x, y, t, k, w=w)
 
     # this should never be reached
     return
@@ -536,11 +539,15 @@ class Bunch:
         self.__dict__.update(**kwargs)
 
 
-_iermesg = {
-2: """error. a theoretically impossible result was found during
+_iermesg1 = """error. a theoretically impossible result was found during
 the iteration process for finding a smoothing spline with
 fp = s. probably causes : s too small.
-there is an approximation returned but the corresponding
+"""
+
+_iermesg = {
+1: _iermesg1 + """the weighted sum of squared residuals is becoming NaN
+""",
+2: _iermesg1 + """there is an approximation returned but the corresponding
 weighted sum of squared residuals does not satisfy the
 condition abs(fp-s)/s < tol.
 """,
@@ -685,13 +692,11 @@ def _make_splrep_impl(x, y, *, w=None, xb=None, xe=None, k=3, s=0, t=None, nest=
     # ### bespoke solver ####
     # initial conditions
     # f(p=inf) : LSQ spline with knots t   (XXX: reuse R, c)
-    residuals = _get_residuals(x, y, t, k, w=w)
-    fp = residuals.sum()
+    _, fp = _get_residuals(x, y, t, k, w=w)
     fpinf = fp - s
 
     # f(p=0): LSQ spline without internal knots
-    residuals = _get_residuals(x, y, np.array([xb]*(k+1) + [xe]*(k+1)), k, w)
-    fp0 = residuals.sum()
+    _, fp0 = _get_residuals(x, y, np.array([xb]*(k+1) + [xe]*(k+1)), k, w)
     fp0 = fp0 - s
 
     # solve
@@ -989,4 +994,3 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=
     spl1 = BSpline(spl.t, cc, spl.k, axis=1)
 
     return spl1, u
-

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3533,6 +3533,8 @@ class TestMakeSplrep:
             xp_assert_close(np.r_[spl.c, [0]*(spl.k+1)],
                             tck[1], atol=5e-13)
 
+    def test_issue_22704(self):
+        # Reference - https://github.com/scipy/scipy/issues/22704
         x = np.asarray([20.00, 153.81, 175.57, 202.47, 237.11,
              253.61, 258.56, 273.40, 284.54, 293.61,
              298.56, 301.86, 305.57, 307.22, 308.45,
@@ -3542,7 +3544,7 @@ class TestMakeSplrep:
              25.20, 21.60, 18.00, 14.40, 10.80,
              7.20, 3.60, 0.0], dtype=np.float64)
         w = np.asarray([1.38723] * y.shape[0], dtype=np.float64)
-        with assert_raises(RuntimeError):
+        with assert_raises(ValueError):
             make_splrep(x, y, w=w, k=2, s=12)
 
     def test_shape(self):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3533,6 +3533,18 @@ class TestMakeSplrep:
             xp_assert_close(np.r_[spl.c, [0]*(spl.k+1)],
                             tck[1], atol=5e-13)
 
+        x = np.asarray([20.00, 153.81, 175.57, 202.47, 237.11,
+             253.61, 258.56, 273.40, 284.54, 293.61,
+             298.56, 301.86, 305.57, 307.22, 308.45,
+             310.10, 310.10, 310.50], dtype=np.float64)
+        y = np.asarray([53.00, 49.50, 48.60, 46.80, 43.20,
+             40.32, 39.60, 36.00, 32.40, 28.80,
+             25.20, 21.60, 18.00, 14.40, 10.80,
+             7.20, 3.60, 0.0], dtype=np.float64)
+        w = np.asarray([1.38723] * y.shape[0], dtype=np.float64)
+        with assert_raises(RuntimeError):
+            make_splrep(x, y, w=w, k=2, s=12)
+
     def test_shape(self):
         # make sure coefficients have the right shape (not extra dims)
         n, k = 10, 3

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2167,7 +2167,7 @@ class TestSmoothingSpline:
         # using an iterative algorithm for minimizing the GCV criteria. These
         # algorithms may vary, so the tolerance should be rather low.
         # Not checking dtypes as gcvspl.npz stores little endian arrays, which
-        # result in conflicting dtypes on big endian systems. 
+        # result in conflicting dtypes on big endian systems.
         xp_assert_close(y_compr, y_GCVSPL, atol=1e-4, rtol=1e-4, check_dtype=False)
 
     def test_non_regularized_case(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/22704

#### What does this implement/fix?
<!--Please explain your changes.-->

In this PR I raise a generic `RuntimeError` when we encounter `residuals.sum() == NaN`.  Added a test as well.

Another way to raise en error is to specifically check whether the first element of any row of `A[:nc]` is `0.0` at the following place (which I think would be too specific and we won't be able to cover the problem generally which is `residuals.sum()` becoming `NaN`).

https://github.com/scipy/scipy/blob/da7717ec686eceeb054168ccb31b58a50ec81f74/scipy/interpolate/_bsplines.py#L1870-L1871

There is one more way which is to check for any of `c` is `NaN`. This is also reasonable and it would be happen earlier than `residuals.sum()` becoming `NaN`. Let me know if you want to go with this approach.

@ev-br 

#### Additional information
<!--Any additional information you think is important.-->
