### PR TITLE
BUG: signal: fix incorrect vendoring of `npp_polyval`

### DIFF
--- a/scipy/signal/_polyutils.py
+++ b/scipy/signal/_polyutils.py
@@ -6,6 +6,7 @@ namespace, and "new-style", np.polynomial.polynomial, routines.
 To distinguish the two sets, the "new-style" routine names start with `npp_`
 """
 import scipy._lib.array_api_extra as xpx
+from scipy._lib._array_api import xp_promote, xp_default_dtype
 
 
 def _sort_cmplx(arr, xp):
@@ -138,15 +139,18 @@ def polymul(a1, a2, *, xp):
 # ### New-style routines ###
 
 
-# https://github.com/numpy/numpy/blob/v2.2.0/numpy/polynomial/polynomial.py#L845-L894
+# https://github.com/numpy/numpy/blob/v2.2.0/numpy/polynomial/polynomial.py#L663
 def npp_polyval(x, c, *, xp, tensor=True):
+    if xp.isdtype(c.dtype, 'integral'):
+        c = xp.astype(c, xp_default_dtype(xp))
+
     c = xpx.atleast_nd(c, ndim=1, xp=xp)
     if isinstance(x, tuple | list):
         x = xp.asarray(x)
     if tensor:
         c = xp.reshape(c, (c.shape + (1,)*x.ndim))
 
-    c0 = c[-1, ...]
+    c0, _ = xp_promote(c[-1, ...], x, broadcast=True, xp=xp)
     for i in range(2, c.shape[0] + 1):
         c0 = c[-i, ...] + c0*x
     return c0

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -749,6 +749,11 @@ class TestFreqz:
         w, h = freqz(xp.asarray([1.0]), worN=N)
         assert w.shape == (N,)
 
+    def test_gh_22886(self, xp):
+        w, h = freqz(xp.asarray([1.]), worN=xp.asarray([0., 0.1]))
+        xp_assert_equal(w, xp.asarray([0. , 0.1]))
+        xp_assert_equal(h, xp.asarray([1.+0.j, 1.+0.j]))
+
     def test_basic(self, xp):
         w, h = freqz(xp.asarray([1.0]), worN=8)
         assert_array_almost_equal(w, xp.pi * xp.arange(8, dtype=w.dtype) / 8.)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

fixes gh-22981

#### What does this implement/fix?
<!--Please explain your changes.-->

Add a missing broadcast-promote operation to our array-api compatible clone of `numpy.polynomial`: the clone was missing `c0 = c[-1] + x*0` (https://github.com/numpy/numpy/blob/v2.2.0/numpy/polynomial/polynomial.py#L752), and this PR adds a slightly more verbose variant --- which is a harder to dismiss as a no-op (which I initially did). 

#### Additional information
<!--Any additional information you think is important.-->
