### PR TITLE
ENH: fix typo in differential_evolution docstring for atol parameter

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -204,7 +204,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
         convergence.
     atol : float, optional
         Absolute tolerance for convergence, the solving stops when
-        ``np.std(pop) <= atol + tol * np.abs(np.mean(population_energies))``,
+        ``np.std(population_energies) <= atol + tol * np.abs(np.mean(population_energies))``,
         where and `atol` and `tol` are the absolute and relative tolerance
         respectively.
     updating : {'immediate', 'deferred'}, optional


### PR DESCRIPTION
#### Reference issue
ENH: fix typo in differential_evolution docstring for atol parameter

#### What does this implement/fix?
In scipy.optimize._differentialevolution.py there is a typo in the description of `atol` parameter in differential_evolution function. In line 207, it should be np.std(population_energies) instead of np.std(pop). This can be checked from the description of `tol` parameter, line 110.


