### PR TITLE
ENH: `signal.cspline1d_eval,qspline1d_eval` throw exception for empty cj array

### DIFF
--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -579,6 +579,9 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
     newx = (np.asarray(newx) - x0) / float(dx)
     cj = np.asarray(cj)
 
+    if cj.size == 0:
+        raise ValueError("Spline coefficients 'cj' must not be empty.")
+
     res = zeros_like(newx, dtype=cj.dtype)
     if res.size == 0:
         return xp.asarray(res)
@@ -662,6 +665,9 @@ def qspline1d_eval(cj, newx, dx=1.0, x0=0):
         return xp.asarray(res)
 
     cj = np.asarray(cj)
+    if cj.size == 0:
+        raise ValueError("Spline coefficients 'cj' must not be empty.")
+    
     N = len(cj)
     cond1 = newx < 0
     cond2 = newx > (N - 1)

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -182,6 +182,11 @@ class TestBSplines:
             signal.cspline1d_eval(cj, xp.asarray(newx), dx=dx, x0=x[0]), newy
         )
 
+        with pytest.raises(ValueError,
+                            match="Spline coefficients 'cj' must not be empty."):
+            signal.cspline1d_eval(xp.asarray([], dtype=xp.float64), 
+                                  xp.asarray([0.0], dtype=xp.float64))
+
     @skip_xp_backends(cpu_only=True)
     def test_qspline1d_eval(self, xp):
         xp_assert_close(signal.qspline1d_eval(xp.asarray([0., 0]), xp.asarray([0.])),
@@ -210,6 +215,11 @@ class TestBSplines:
             cj, xp.asarray(newx, dtype=xp.float64), dx=dx, x0=x[0]
         )
         xp_assert_close(r, newy)
+
+        with pytest.raises(ValueError, 
+                           match="Spline coefficients 'cj' must not be empty."):
+            signal.qspline1d_eval(xp.asarray([], dtype=xp.float64), 
+                                  xp.asarray([0.0], dtype=xp.float64))
 
 
 # i/o dtypes with scipy 1.9.1, likely fixed by backwards compat


### PR DESCRIPTION
Empty cj array should be invalid argument to spline evaluation. Without the guard the mirror symmetry implementation would lead to infinite recursion. 

 ![image](https://github.com/user-attachments/assets/fdcf42ab-6d00-45c4-82cc-769dc9662d25)