### PR TITLE
CI: pin marray version

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Install MArray
       run: |
-        python -m pip install marray
+        python -m pip install marray==0.0.8
 
     - name:  Prepare compiler cache
       id:    prep-ccache


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
To avoid potential CI failures associated with a new release of `marray`, this pins the `marray` version.
