### PR TITLE
CI: temporarily disable free-threaded job with parallel-threads

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -456,7 +456,7 @@ jobs:
     needs: get_commit_message
     strategy:
       matrix:
-        parallel: ['0', '1']
+        parallel: ['0']  # '1' temporarily disabled, `stats` segfault (see gh-22758)
 
     runs-on: ubuntu-latest
     if: >


### PR DESCRIPTION
Reasons:
1. A segfault in `stats/_distribution_infrastructure.py` since ~1 week, see https://github.com/scipy/scipy/issues/22758#issuecomment-2883968653
2. Preferred not to have this not-so-stable job running on the 1.16.x branch

Re-enable on `main` after 1.16.x has branched and (1) is investigated.