### PR TITLE
BUG: Fix duplicate `--pyargs` due to double addition in SciPy and `spin`

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -131,7 +131,7 @@ def build(*, parent_callback, meson_args, jobs, verbose, werror, asan, debug,
                 os.getcwd(),
                 os.environ.get('PKG_CONFIG_PATH', '')
                 ])
-        
+
     if use_system_libraries:
         meson_args = meson_args + ("-Duse-system-libraries=auto",)
 
@@ -266,9 +266,6 @@ def test(*, parent_callback, pytest_args, tests, coverage,
     n_jobs = parallel
     if (n_jobs != 1) and ('-n' not in pytest_args):
         pytest_args = ('-n', str(n_jobs)) + pytest_args
-
-    if tests and '--pyargs' not in pytest_args:
-        pytest_args += ('--pyargs', tests)
 
     if durations:
         pytest_args += ('--durations', durations)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/22980

#### What does this implement/fix?
<!--Please explain your changes.-->

Taken from comment, https://github.com/scipy/scipy/issues/22980#issuecomment-2886507645

The `tests` are passed twice, first in the below line, 

https://github.com/scipy/scipy/blob/4bf6e4b32e4b0be404a88001b4f0dd6d7e9d9333/.spin/cmds.py#L270-L271

Then `"tests": tests` is passed in the below line,

https://github.com/scipy/scipy/blob/4bf6e4b32e4b0be404a88001b4f0dd6d7e9d9333/.spin/cmds.py#L279-L280

and then `spin` also adds them via `--pyargs` in the below line,

https://github.com/scientific-python/spin/blob/fee6abe42cea118c2e4577cce5e0ca034c55748e/spin/cmds/meson.py#L566

So there are two ways to do it,

1. Either not pass `"tests": tests` so that `spin` doesn't add it (update, https://github.com/scipy/scipy/blob/4bf6e4b32e4b0be404a88001b4f0dd6d7e9d9333/.spin/cmds.py#L279-L280)
2. Don't update `--pyargs` (i.e., remove, https://github.com/scipy/scipy/blob/4bf6e4b32e4b0be404a88001b4f0dd6d7e9d9333/.spin/cmds.py#L270-L271) and let `spin` do it

I would go with second option because it will help in reducing code in SciPy's `.spin/cmds.py`. :-).

#### Additional information
<!--Any additional information you think is important.-->

cc: @rgommers @ev-br 
