### PR TITLE
CI: give redirect action status write permission

### DIFF
--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -3,7 +3,8 @@ name: Redirect circleci artifacts
 on: [status]
 
 permissions:
-   contents: read  # to fetch code (actions/checkout)
+  contents: read  # to fetch code (actions/checkout)
+  statuses: write  # to report circleci status (scientific-python/circleci-artifacts-redirector-action)
 
 jobs:
   circleci_artifacts_redirector_job:


### PR DESCRIPTION
Give the redirect action permission to write statuses

#### Reference issue

#23007

#### What does this implement/fix?

The `scientific-python/circleci-artifacts-redirector-action` action uses the `client.rest.repos.createCommitStatus()` function, which I believe requires `statuses: write` permission.

#### Additional information
<!--Any additional information you think is important.-->

Note: I think this ought to fix it, but I am opening this PR to run CI.