### PR TITLE
MAINT: version pins/prep for 1.16.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,19 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.15.0",
-    "Cython>=3.0.8",        # when updating version, also update check in meson.build
-    "pybind11>=2.13.2",     # when updating version, also update check in scipy/meson.build
-    "pythran>=0.14.0",
+    # The upper bound on meson-python is pre-emptive only; 0.18.0
+    # is working at the time of writing, and chance of breakage
+    # in 0.19/0.20 is low
+    "meson-python>=0.15.0,<0.21.0",
+    # We need at least Cython 3.1.0 for free-threaded CPython;
+    # for other CPython versions, the regular pre-emptive
+    # Cython version bounds policy applies
+    "Cython>=3.0.8,<3.2.0",
+    # The upper bound on pybind11 is pre-emptive only
+    "pybind11>=2.13.2,<2.14.0",
+    # The upper bound on pythran is pre-emptive only; 0.17.0
+    # is released/working at the time of writing
+    "pythran>=0.14.0,<0.18.0",
 
     # numpy requirement for wheel builds for distribution on PyPI - building
     # against 2.x yields wheels that are also compatible with numpy 1.x at
@@ -28,7 +37,8 @@ requires = [
     # Note that building against numpy 1.x works fine too - users and
     # redistributors can do this by installing the numpy version they like and
     # disabling build isolation.
-    "numpy>=2.0.0rc1",
+    # NOTE: need numpy>=2.1.3 for free-threaded CPython support
+    "numpy>=2.0.0,<2.6",
 ]
 
 [project]
@@ -46,7 +56,9 @@ maintainers = [
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
 requires-python = ">=3.11"
 dependencies = [
-    "numpy>=1.25.2",
+    # free-threaded CPython support requires more
+    # recent NumPy release at runtime (>= 2.1.3)
+    "numpy>=1.25.2,<2.6",
 ] # keep in sync with `min_numpy_version` in meson.build
 readme = "README.rst"
 classifiers = [

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -64,7 +64,7 @@ del _distributor_init
 from scipy._lib import _pep440
 # In maintenance branch, change to np_maxversion N+3 if numpy is at N
 np_minversion = '1.25.2'
-np_maxversion = '9.9.99'
+np_maxversion = '2.6.0'
 if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
         _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):
     import warnings


### PR DESCRIPTION
* Adjust the build and runtime dependency version upper bounds (on maintenance branch) as we prepare for the release of SciPy `1.16.0rc1`. Many of the details are based on the code changes and discussion at gh-22024. In particular, see that PR for some discussion on free-threading support. This assumes that we will offer a release that is free of NumPy `2.3.0` deprecation warnings, which seems reasonable based on current release cycles.

Getting this just right can be tricky, thanks for any review suggestions. I'll prepare the `.mailmap` updates under separate cover today, and currently intend to try to keep to schedule for RC1 on May 21.
