### PR TITLE
DOC: .mailmap updates for 1.16.0rc1

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -182,8 +182,10 @@ Eric Larson <larson.eric.d@gmail.com> Eric89GXL <larson.eric.d@gmail.com>
 Eric Quintero <eric.antonio.quintero@gmail.com> e-q <eric.antonio.quintero@gmail.com>
 Eric Quintero <eric.antonio.quintero@gmail.com> Eric Quintero <e-q@users.noreply.github.com>
 Eric Soroos <eric-github@soroos.net> wiredfool <eric-github@soroos.net>
+Eric Zitong Zhou <zitongzhou1999@gmail.com> zitongzhoueric <zitongzhou1999@gmail.com>
 Étienne Tremblay <45673646+30blay@users.noreply.github.com> 30blay <45673646+30blay@users.noreply.github.com>
-Evandro <15084103+evbernardes@users.noreply.github.com> evbernardes <evbernardes@gmail.com>
+Evandro Bernardes <15084103+evbernardes@users.noreply.github.com> evbernardes <evbernardes@gmail.com>
+Evandro Bernardes <15084103+evbernardes@users.noreply.github.com> Evandro <15084103+evbernardes@users.noreply.github.com>
 Evgeni Burovski <evgeny.burovskiy@gmail.com> Zhenya <evgeni@burovski.me>
 Evgeni Burovski <evgeny.burovskiy@gmail.com> Evgeni Burovski <evgeni@burovski.me>
 Evan W Jones <60061381+E-W-Jones@users.noreply.github.com> Evan <60061381+E-W-Jones@users.noreply.github.com>
@@ -214,6 +216,8 @@ Garrett Reynolds <garrettreynolds5@gmail.com> Garrett-R <garrettreynolds5@gmail.
 Gaël Varoquaux <gael.varoquaux@normalesup.org> Gael varoquaux <gael.varoquaux@normalesup.org>
 Gavin Zhang <zhanggan@cn.ibm.com> GavinZhang <zhanggan@cn.ibm.com>
 Gavin Zhang <zhanggan@cn.ibm.com> Gavin Zhang <zheddie@163.com>
+Gauthier Berthomieu <72027971+Gautzilla@users.noreply.github.com> Gautzilla <72027971+Gautzilla@users.noreply.github.com>
+Gayatri Chakkithara <113033661+redpinecube@users.noreply.github.com> redpinecube <113033661+redpinecube@users.noreply.github.com>
 Geordie McBain <gdmcbain@protonmail.com> G. D. McBain <gdmcbain@protonmail.com>
 Gang Zhao <zhaog6@lsec.cc.ac.cn> zhaog6 <31978442+zhaog6@users.noreply.github.com>
 Gian Marco Messa <gianmarco.messa@gmail.com> messagian <gianmarco.messa@gmail.com>
@@ -224,6 +228,7 @@ Giorgio Patrini <giorgio.patrini@anu.edu.au> giorgiop <giorgio.patrini@nicta.com
 Gregory R. Lee <grlee77@gmail.com> Gregory R. Lee <gregory.lee@cchmc.org>
 Gregory R. Lee <grlee77@gmail.com> Gregory Lee <grlee77@gmail.com>
 Golnaz Irannejad <golnazirannejad@gmail.com> golnazir <golnazirannejad@gmail.com>
+Guido Imperiale <crusaderky@gmail.com> crusaderky <crusaderky@gmail.com>
 Guillaume Horel <thrasibule@users.noreply.github.com> Thrasibule <thrasibule@users.noreply.github.com>
 Guo Fei <<guofei9987@foxmail.com> Guofei <<guofei9987@foxmail.com>
 Guus Kamphuis <guuskamphuis@gmail.com> ZoutigeWolf <guuskamphuis@gmail.com>
@@ -282,6 +287,7 @@ Jeff Armstrong <jeff@approximatrix.com> ArmstrongJ <approximatrix@gmail.com>
 Jeff Armstrong <jeff@approximatrix.com> Jeff Armstrong <jeff@approximatrix.com>
 Jesse Engel <jesse.engel@gmail.com> jesseengel <jesse.engel@gmail.com>
 Jesse Livezey <jesse.livezey@gmail.com> Jesse Livezey <jlivezey@lbl.gov>
+Jigyasu Krishnan <jigyasu@outlook.in> Jigyasu <jigyasu@outlook.in>
 Jin-Guo Liu <cacate0129@gmail.com> GiggleLiu <cacate0129@gmail.com>
 J.L. Lanfranchi <jll1062@phys.psu.edu> J. L. Lanfranchi <jllanfranchi@users.noreply.github.com>
 J.L. Lanfranchi <jll1062@phys.psu.edu> J.L. Lanfranchi <jllanfranchi@users.noreply.github.com>
@@ -325,10 +331,12 @@ Kai Striega <kaistriega@gmail.com> Kai <kaistriega@gmail.com>
 Kai Striega <kaistriega@gmail.com> kai <kaistriega@gmail.com>
 Kai Striega <kaistriega@gmail.com> kai-striega <kaistriega+github@gmail.com>
 Kai Striega <kaistriega@gmail.com> Kai Striega <kaistriega+github@gmail.com>
+Karthik Viswanath Ganti <kganti2@illinois.edu> karthik-ganti-2025 <kganti2@illinois.edu>
 Kat Huang <kat@aya.yale.edu> kat <kat@aya.yale.edu>
 Kenji S Emerson <psmd.iberutaru@gmail.com> Sparrow <psmd.iberutaru@gmail.com>
 Kentaro Yamamoto <38549987+yamaken1343@users.noreply.github.com> yamaken <38549987+yamaken1343@users.noreply.github.com>
 Kevin Richard Green <kevin.richard.green@gmail.com> kevinrichardgreen <kevin.richard.green@gmail.com>
+Kirill R. <dartvader316-dev@pm.me> dartvader316 <dartvader316-dev@pm.me>
 Klaus Sembritzki <klausem@gmail.com> klaus <klausem@gmail.com>
 Klesk Chonkin <kleskjr@gmail.com> kleskjr <kleskjr@gmail.com>
 Krzysztof Pióro <38890793+krzysztofpioro@users.noreply.github.com> krzysztofpioro <38890793+krzysztofpioro@users.noreply.github.com>
@@ -366,6 +374,7 @@ Marc Honnorat <marc.honnorat@gmail.com> honnorat <marc.honnorat@gmail.com>
 Marcello Seri <mseri@users.noreply.github.com> mseri <mseri@users.noreply.github.com>
 Marco Maggi <124086916+m-maggi@users.noreply.github.com> m-maggi <124086916+m-maggi@users.noreply.github.com>
 Mark E Fuller <mark.e.fuller@gmx.de> Mark E. Fuller <mark.e.fuller@gmx.de>
+Mark van Rossum <mark.vanrossum@nottingham.ac.uk> vrossum <mark.vanrossum@nottingham.ac.uk>
 Mark Wiebe <> Mark <>
 Martin Manns <mmanns@gmx.net> manns <mmanns@gmx.net>
 Martin Reinecke <martin.reinecke1@gmx.de> mreineck <martin.reinecke1@gmx.de>
@@ -397,6 +406,7 @@ Michael James Bedford <SunsetOrange@users.noreply.github.com> Michael <SunsetOra
 Michael Marien <marien.mich@gmail.com> michaelmarien <marien.mich@gmail.com>
 Miguel A. Batalla <miguelangel@batalla.pro> mabatalla <miguelangel@batalla.pro>
 Mikhail Pak <mikhail.pak@tum.de> mp4096 <mikhail.pak@tum.de>
+Mikhail Ryazanov <mikhail.ryazanov@gmail.com> MikhailRyazanov <mikhail.ryazanov@gmail.com>
 Milad Sadeghi DM <EverLookNeverSee@Protonmail.ch> ELNS <57490926+EverLookNeverSee@users.noreply.github.com>
 Muhammad Firmansyah Kasim <firman.kasim@gmail.com> mfkasim91 <firman.kasim@gmail.com>
 Nathan Bell <wnbell@localhost> wnbell <wnbell@localhost>
@@ -422,6 +432,7 @@ Pablo Winant <pablo.winant@gmail.com> pablo.winant@gmail.com <Pablo Winant>
 Pamphile Roy <roy.pamphile@gmail.com> Pamphile ROY <proy@bongfish.com>
 Pamphile Roy <roy.pamphile@gmail.com> Pamphile ROY <roy.pamphile@gmail.com>
 Pamphile Roy <roy.pamphile@gmail.com> Tupui <23188539+tupui@users.noreply.github.com>
+Param Singh <techhero724@gmail.com> PARAM SINGH <techhero724@gmail.com>
 Patrick Snape <patricksnape@gmail.com> patricksnape <patricksnape@gmail.com>
 Paul Kienzle <pkienzle@gmail.com> Paul Kienzle <pkienzle@nist.gov>
 Paul van Mulbregt <pvanmulbregt@users.noreply.github.com> pvanmulbregt <pvanmulbregt@users.noreply.github.com>
@@ -448,6 +459,7 @@ Pierre de Buyl <pdebuyl@pdebuyl.be> Pierre de Buyl <pdebuyl@ulb.ac.be>
 Pierre GM <pierregm@localhost> pierregm <pierregm@localhost>
 Poom Chiarawongse <eight1911@gmail.com> Poom Chiarawongse <tchiarawongs@gmail.com>
 Poom Chiarawongse <eight1911@gmail.com> poom <eight1911@gmail.com>
+Pratham Kumar <pratham.kumar@multicorewareinc.com> pratham-mcw <pratham.kumar@multicorewareinc.com>
 Quentin Barthélemy <q.barthelemy@gmail.com> qbarthelemy <q.barthelemy@gmail.com>
 Radoslaw Guzinski <radoslaw.guzinski@esa.int> radosuav <rmgu@dhi-gras.com>
 Radoslaw Guzinski <radoslaw.guzinski@esa.int> radosuav <radoslaw.guzinski@esa.int>
@@ -471,6 +483,7 @@ Ruikang Sun <srk888666@qq.com> SunRuikang <srk888666@qq.com>
 Rupak Das <dr10ru@yahoo.co.in> Rupak <dr10ru@yahoo.co.in>
 Ruslan Yevdokymov <evruslan17@gmail.com> Ruslan Yevdokymov <38809160+ruslanye@users.noreply.github.com>
 Ryan Gibson <ryan.alexander.gibson@gmail.com> ragibson <ryan.alexander.gibson@gmail.com>
+Sagi Ezri <sagi.ezri@gmail.com> sagi-ezri <sagi.ezri@gmail.com>
 Sam Lewis <sam.vr.lewis@gmail.com> Sam Lewis <samvrlewis@users.noreply.github.com>
 Sam McCormack <sampmccormack@gmail.com> Sam McCormack <TheGreatCabbage@users.noreply.github.com>
 Sam Mason <sam@samason.uk> Sam Mason <sam.mason@warwick.ac.uk>
@@ -537,6 +550,7 @@ Travis Oliphant <teoliphant@gmail.com> Travis E. Oliphant <teoliphant@gmail.com>
 Travis Oliphant <teoliphant@gmail.com> Travis Oliphant <oliphant@enthought.com>
 Uwe Schmitt <uwe.schmitt@localhost> uwe.schmitt <uwe.schmitt@localhost>
 Vicky Close <vicky.r.close@gmail.com> vickyclose <vicky.r.close@gmail.com>
+Victor PM <vpecanins@gmail.com> vpecanins <vpecanins@gmail.com>
 Vladyslav Rachek <wsw.raczek@gmail.com> Vladyslav Rachek <36896640+erheron@users.noreply.github.com>
 Warren Weckesser <warren.weckesser@gmail.com> warren.weckesser <warren.weckesser@localhost>
 Warren Weckesser <warren.weckesser@gmail.com> Warren Weckesser <warren.weckesser@enthought.com>
@@ -548,8 +562,11 @@ Will Tirone <will.tirone1@gmail.com> willtirone <will.tirone1@gmail.com>
 Xiao Yuan <yuanx749@gmail.com> yuanx749 <yuanx749@gmail.com>
 Xingyu Liu <38244988+charlotte12l@users.noreply.github.com> 刘星雨 <liuxingyu.12@bytedance.com>
 Yagiz Olmez <57116432+yagizolmez@users.noreply.github.com> yagizolmez <yagizolmez@pop-os.localdomain>
+Yongcai Huang <97007177+YongcaiHuang@users.noreply.github.com> YongcaiHuang <97007177+YongcaiHuang@users.noreply.github.com>
 Yu Feng <rainwoodman@gmail.com> Yu Feng <yfeng1@waterfall.dyn.berkeley.edu>
+Yuji Ikeda <yuji.ikeda.ac.jp@gmail.com> yuzie007 <yuji.ikeda.ac.jp@gmail.com>
 Yves-Rémi Van Eycke <yves-remi@hotmail.com> vanpact <yves-remi@hotmail.com>
+Zaikun Zhang <zaikunzhang@gmail.com> zaikunzhang <zaikunzhang@gmail.com>
 Zé Vinícius <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>
 Zhida Shang <57895730+futuer-szd@users.noreply.github.com> Futuer <57895730+futuer-szd@users.noreply.github.com>
 Zoufiné Lauer-Bare <raszoufine@gmail.com> zolabar <raszoufine@gmail.com>

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -334,6 +334,8 @@ Authors
 * Nickolai Belakovski (5)
 * Peter Bell (1)
 * Benoît W. (1) +
+* Evandro Bernardes (1)
+* Gauthier Berthomieu (1) +
 * Maxwell Bileschi (1) +
 * Sam Birch (1) +
 * Florian Bourgey (3) +
@@ -344,21 +346,19 @@ Authors
 * Dietrich Brunn (52)
 * Evgeni Burovski (252)
 * Christine P. Chai (12) +
+* Gayatri Chakkithara (1) +
 * Saransh Chopra (2) +
 * Omer Cohen (1) +
 * Lucas Colley (91)
-* crusaderky (56) +
 * Yahya Darman (3) +
-* dartvader316 (2) +
 * Benjamin Eisele (1) +
 * Donnie Erb (1)
-* Evandro (1)
-* Sagi Ezri (57) +
+* Sagi Ezri (58) +
 * Alexander Fabisch (2) +
 * Matthew H Flamm (1)
-* Gautzilla (1) +
+* Karthik Viswanath Ganti (1) +
 * Neil Girdhar (1)
-* Ralf Gommers (149)
+* Ralf Gommers (153)
 * Rohit Goswami (4)
 * Saarthak Gupta (4) +
 * Matt Haberland (320)
@@ -367,14 +367,17 @@ Authors
 * Chengyu Han (1) +
 * Charles Harris (1)
 * Kim Hsieh (4) +
+* Yongcai Huang (2) +
 * Lukas Huber (1) +
-* Guido Imperiale (47) +
-* Jigyasu (1) +
-* karthik-ganti-2025 (1) +
+* Yuji Ikeda (2) +
+* Guido Imperiale (103) +
 * Robert Kern (2)
 * Harin Khakhi (2) +
 * Agriya Khetarpal (4)
+* Kirill R. (2) +
 * Tetsuo Koyama (1)
+* Jigyasu Krishnan (1) +
+* Pratham Kumar (3) +
 * David Kun (1) +
 * Eric Larson (3)
 * lciti (1)
@@ -387,7 +390,6 @@ Authors
 * Nikolay Mayorov (2)
 * Melissa Weber Mendonça (10)
 * Miguel Cárdenas (2) +
-* MikhailRyazanov (6) +
 * Swastik Mishra (1) +
 * Sturla Molden (2)
 * Andreas Nazlidis (1) +
@@ -395,14 +397,13 @@ Authors
 * Parth Nobel (1) +
 * Nick ODell (9)
 * Giacomo Petrillo (1)
+* Victor PM (10) +
 * pmav99 (1) +
-* Ilhan Polat (72)
-* pratham-mcw (3) +
-* Tyler Reddy (73)
-* redpinecube (1) +
+* Ilhan Polat (73)
+* Tyler Reddy (66)
 * Érico Nogueira Rolim (1) +
 * Pamphile Roy (10)
-* sagi-ezri (1) +
+* Mikhail Ryazanov (6)
 * Atsushi Sakai (9)
 * Marco Salathe (1) +
 * sanvi (1) +
@@ -415,7 +416,7 @@ Authors
 * Scott Shambaugh (4)
 * ShannonS00 (1) +
 * sildater (3) +
-* PARAM SINGH (1) +
+* Param Singh (1) +
 * G Sreeja (7) +
 * Albert Steppi (133)
 * Kai Striega (3)
@@ -426,31 +427,27 @@ Authors
 * Jamie Townsend (2) +
 * Edgar Andrés Margffoy Tuay (4)
 * Matthias Urlichs (1) +
+* Mark van Rossum (1) +
 * Jacob Vanderplas (2)
 * David Varela (2) +
 * Christian Veenhuis (3)
 * vfdev (1)
-* vpecanins (10) +
-* vrossum (1) +
 * Stefan van der Walt (2)
 * Warren Weckesser (5)
 * Jason N. White (1) +
 * windows-server-2003 (5)
 * Zhiqing Xiao (1)
 * Pavadol Yamsiri (1)
-* YongcaiHuang (2) +
 * Rory Yorke (3)
-* yuzie007 (2) +
 * Irwin Zaid (4)
-* zaikunzhang (1) +
 * Austin Zhang (1) +
 * William Zijie Zhang (1) +
-* Eric Zitong Zhou (5) +
-* zitongzhoueric (6) +
+* Zaikun Zhang (1) +
+* Eric Zitong Zhou (11) +
 * Case Zumbrum (2) +
 * ਗਗਨਦੀਪ ਸਿੰਘ (Gagandeep Singh) (45)
 
-    A total of 124 people contributed to this release.
+    A total of 121 people contributed to this release.
     People with a "+" by their names contributed a patch for the first time.
     This list of names is automatically generated, and may not be fully complete.
 


### PR DESCRIPTION
* Update the `.mailmap` for SciPy `1.16.0rc1` release. This is generally done by checking GitHub user profiles for names/academic web pages (when the currently-listed name looks like a handle rather than proper name), and occasionally by searching online for names associated with a commit-provided email address.

[docs only]

In general, I've assumed that folks would prefer their proper given and surname(s) for acknowledgement. This is just a convention we've been following, and there are sometimes folks who prefer to remain a bit more anonymous (let me know if you want your name reverted). I took note of a few GitHub usernames where I was less confident about my ability to assign a proper name given the available information--these folks are free to let me know their preferred acknowledgement name and I'll update accordingly (otherwise, I'll leave them as is):

- [ ] @aiudirog
- [ ] @Backfisch263
- [ ] @lciti
- [ ] @pmav99
- [ ] @ciaokitty
- [ ] @ShannonS00
- [ ] @sildater
- [ ] @gsreeja11
- [ ] @Tearyt
- [ ] @vfdev
- [ ] @vpecanins
- [ ] @windows-server-2003

Doc build was still passing locally; update release note author list still looks "ok," and makes sense that it has a few less entries after catching duplicates with updates here.