### PR TITLE
MAINT: fix inaccuracy in factorial2 docstring

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3231,7 +3231,7 @@ def factorial2(n, exact=False, extend="zero"):
     --------
     >>> from scipy.special import factorial2
     >>> factorial2(7, exact=False)
-    array(105.00000000000001)
+    np.float64(105.00000000000001)
     >>> factorial2(7, exact=True)
     105
 


### PR DESCRIPTION
Noticed a small inaccuracy in the docs, not sure why this isn't caught by the doctests