### PR TITLE
DEV: spin: remove duplicate argument `-j` from parent commands

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -179,7 +179,7 @@ def build(*, parent_callback, meson_args, verbose, werror, asan, debug,
         "'jax.numpy', 'dask.array')."
     )
 )
-@spin.util.extend_command(spin.cmds.meson.test)
+@spin.util.extend_command(spin.cmds.meson.test, remove_args=("n_jobs",))
 def test(*, parent_callback, pytest_args, tests, coverage,
          durations, submodule, mode, parallel,
          array_api_backend, **kwargs):
@@ -263,10 +263,6 @@ def test(*, parent_callback, pytest_args, tests, coverage,
         if markexpr != "full":
             pytest_args = ('-m', markexpr) + pytest_args
 
-    n_jobs = parallel
-    if (n_jobs != 1) and ('-n' not in pytest_args):
-        pytest_args = ('-n', str(n_jobs)) + pytest_args
-
     if durations:
         pytest_args += ('--durations', durations)
 
@@ -274,7 +270,7 @@ def test(*, parent_callback, pytest_args, tests, coverage,
         os.environ['SCIPY_ARRAY_API'] = json.dumps(list(array_api_backend))
 
     parent_callback(**{"pytest_args": pytest_args, "tests": tests,
-                    "coverage": coverage, **kwargs})
+                    "coverage": coverage, "n_jobs": parallel, **kwargs})
 
 @click.option(
         '--list-targets', '-t', default=False, is_flag=True,

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -61,8 +61,8 @@ PROJECT_MODULE = "scipy"
     '--tags', default="runtime,python-runtime,tests,devel",
     show_default=True, help="Install tags to be used by meson."
 )
-@spin.util.extend_command(spin.cmds.meson.build)
-def build(*, parent_callback, meson_args, jobs, verbose, werror, asan, debug,
+@spin.util.extend_command(spin.cmds.meson.build, remove_args=("jobs",))
+def build(*, parent_callback, meson_args, verbose, werror, asan, debug,
           release, parallel, setup_args, show_build_log,
           with_scipy_openblas, with_accelerate, use_system_libraries,
           tags, **kwargs):

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -286,8 +286,8 @@ def test(*, parent_callback, pytest_args, tests, coverage,
             "needed in order to make docstring changes in C/Cython files " + \
             "show up."
 )
-@spin.util.extend_command(spin.cmds.meson.docs)
-def docs(*, parent_callback, sphinx_target, clean, jobs,
+@spin.util.extend_command(spin.cmds.meson.docs, remove_args=("jobs", ))
+def docs(*, parent_callback, sphinx_target, clean,
          list_targets, parallel, no_cache, **kwargs):
     """📖 Build Sphinx documentation
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/22980

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR only deals with duplication of `-j` in parent command and in the extended command in `.cmds/spin.py`. This went unnoticed in the initial addition of `spin` because only after recent update of `click`, it has started raising `UserWarning` on duplication of arguments.

This `UserWarning` was being raised in `build`, `test`, and `docs` on my macOS and Linux machines. The problem is OS independent.

For fixing this problem, I have used `remove_args` functionality of `@spin.util.extend_command`. I have removed those arguments from parent command to keep SciPy's build interface backwards compatible (SciPy uses `--parallel` everywhere, `spin` use `--jobs`). However, `spin` still handles the job argument, we in SciPy just take the value from `parallel` and pass it on to `spin` via `parent_callback`. This fix helps in keeping APIs backwards compatible with minimal change.

#### Additional information
<!--Any additional information you think is important.-->

I still see warnings related to duplication of `-C` when I run `spin build`. The reason is we use `-C` for short hand of `--setup-args` and `spin` uses `-C` for short hand of `--build-dir`.  Check the links below. Removing this duplication would be tricky, a separate topic of discussion though.

```zsh
(scipy-dev) 14:34:19:~/Quansight/scipy % spin build
/Users/czgdp1807/mambaforge/envs/scipy-dev/lib/python3.13/site-packages/click/core.py:1193: UserWarning: The parameter -C is used more than once. Remove its duplicate as parameters should be unique.
  parser = self.make_parser(ctx)
/Users/czgdp1807/mambaforge/envs/scipy-dev/lib/python3.13/site-packages/click/core.py:1186: UserWarning: The parameter -C is used more than once. Remove its duplicate as parameters should be unique.
  self.parse_args(ctx, args)
$ meson compile -j 10 -C build
.
.
.
```

https://github.com/scipy/scipy/blob/2ebb23877c780f69db32ae856fa50172e5caff15/.spin/cmds.py#L40-L43

https://github.com/scientific-python/spin/blob/fee6abe42cea118c2e4577cce5e0ca034c55748e/spin/cmds/meson.py#L275-L283

https://github.com/scientific-python/spin/blob/fee6abe42cea118c2e4577cce5e0ca034c55748e/spin/cmds/meson.py#L311-L312

cc: @rgommers @ev-br @tylerjereddy 

