### PR TITLE
DEV: Remove `--parallel` and rely on `spin`'s `--jobs` argument

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -34,10 +34,6 @@ PROJECT_MODULE = "scipy"
 @click.option(
     '--release', '-r', default=False, is_flag=True, help="Release build")
 @click.option(
-    '--parallel', '-j', default=None, metavar='N_JOBS',
-    help=("Number of parallel jobs for building. "
-            "This defaults to the number of available physical CPU cores"))
-@click.option(
     '--setup-args', '-C', default=[], multiple=True,
     help=("Pass along one or more arguments to `meson setup` "
             "Repeat the `-C` in case of multiple arguments."))
@@ -63,7 +59,7 @@ PROJECT_MODULE = "scipy"
 )
 @spin.util.extend_command(spin.cmds.meson.build)
 def build(*, parent_callback, meson_args, jobs, verbose, werror, asan, debug,
-          release, parallel, setup_args, show_build_log,
+          release, setup_args, show_build_log,
           with_scipy_openblas, with_accelerate, use_system_libraries,
           tags, **kwargs):
     """🔧 Build package with Meson/ninja and install
@@ -135,13 +131,11 @@ def build(*, parent_callback, meson_args, jobs, verbose, werror, asan, debug,
     if use_system_libraries:
         meson_args = meson_args + ("-Duse-system-libraries=auto",)
 
-    if parallel is None:
+    if jobs is None:
         # Use number of physical cores rather than ninja's default of 2N+2,
         # to avoid out of memory issues (see gh-17941 and gh-18443)
         n_cores = cpu_count(only_physical_cores=True)
         jobs = n_cores
-    else:
-        jobs = parallel
 
     meson_install_args = meson_install_args + ("--tags=" + tags, )
 
@@ -167,10 +161,6 @@ def build(*, parent_callback, meson_args, jobs, verbose, werror, asan, debug,
     help=("'fast', 'full', or something that could be passed to "
             "`pytest -m` as a marker expression"))
 @click.option(
-    '--parallel', '-j', default=1, metavar='N_JOBS',
-    help="Number of parallel jobs for testing"
-)
-@click.option(
     '--array-api-backend', '-b', default=None, metavar='ARRAY_BACKEND',
     multiple=True,
     help=(
@@ -181,8 +171,7 @@ def build(*, parent_callback, meson_args, jobs, verbose, werror, asan, debug,
 )
 @spin.util.extend_command(spin.cmds.meson.test)
 def test(*, parent_callback, pytest_args, tests, coverage,
-         durations, submodule, mode, parallel,
-         array_api_backend, **kwargs):
+         durations, submodule, mode, array_api_backend, **kwargs):
     """🔧 Run tests
 
     PYTEST_ARGS are passed through directly to pytest, e.g.:
@@ -263,10 +252,6 @@ def test(*, parent_callback, pytest_args, tests, coverage,
         if markexpr != "full":
             pytest_args = ('-m', markexpr) + pytest_args
 
-    n_jobs = parallel
-    if (n_jobs != 1) and ('-n' not in pytest_args):
-        pytest_args = ('-n', str(n_jobs)) + pytest_args
-
     if durations:
         pytest_args += ('--durations', durations)
 
@@ -281,10 +266,6 @@ def test(*, parent_callback, pytest_args, tests, coverage,
         help='List doc targets',
     )
 @click.option(
-        '--parallel', '-j', default="auto", metavar='N_JOBS',
-        help="Number of parallel jobs"
-    )
-@click.option(
     '--no-cache', default=False, is_flag=True,
     help="Forces a full rebuild of the docs. Note that this may be " + \
             "needed in order to make docstring changes in C/Cython files " + \
@@ -292,7 +273,7 @@ def test(*, parent_callback, pytest_args, tests, coverage,
 )
 @spin.util.extend_command(spin.cmds.meson.docs)
 def docs(*, parent_callback, sphinx_target, clean, jobs,
-         list_targets, parallel, no_cache, **kwargs):
+         list_targets, no_cache, **kwargs):
     """📖 Build Sphinx documentation
 
     By default, SPHINXOPTS="-W", raising errors on warnings.
@@ -326,7 +307,6 @@ def docs(*, parent_callback, sphinx_target, clean, jobs,
     if no_cache:
         SPHINXOPTS += " -E"
 
-    jobs = parallel
     SPHINXOPTS = os.environ.get("SPHINXOPTS", "") + SPHINXOPTS
     os.environ["SPHINXOPTS"] = SPHINXOPTS
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/22980
Closes https://github.com/scipy/scipy/pull/23025

Check the details in - https://github.com/scipy/scipy/pull/23025

#### What does this implement/fix?
<!--Please explain your changes.-->

This approaches the problem by removing `--parallel` and relying on `spin`'s `--jobs` argument for passing the number of jobs to be used for build/test purposes in SciPy.

Refer - https://github.com/scipy/scipy/pull/23025#issuecomment-2897476447

#### Additional information
<!--Any additional information you think is important.-->

cc: @rgommers @ev-br @tylerjereddy 

Locally everything works for me. Let me see what happens on CI. All tests should pass I believe.
