### PR TITLE
REL: set 1.16.0rc2 unreleased

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.16.0rc1"
+version = "1.16.0rc2.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Set the version to SciPy `1.16.0rc2` "unreleased."

[ci skip] [skip ci]

@rgommers @ev-br just for visibility because a release cycle is going -- I'm on PTO May 25-31 inclusive. This was already factored into the [release schedule](https://discuss.scientific-python.org/t/proposed-release-schedule-for-scipy-1-16-0/1883). If something goes "wrong," presumably a PyPI yank of the RC would suffice for a few days.
