### PR TITLE
DEP: linalg: remove kron

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -360,7 +360,6 @@ coverage_ignore_c_items = {}
 plot_pre_code = """
 import warnings
 for key in (
-        'interp2d` is deprecated',  # Deprecation of scipy.interpolate.interp2d
         '`kurtosistest` p-value may be',  # intentionally "bad" example in docstring
         ):
     warnings.filterwarnings(action='ignore', message='.*' + key + '.*')

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -493,14 +493,8 @@ if HAVE_SCPDT:
             known_warnings[name] = dict(category=RuntimeWarning,
                                         message='divide by zero')
 
-        # Deprecated stuff in scipy.signal and elsewhere
-        deprecated = [
-            'scipy.signal.cwt', 'scipy.signal.morlet', 'scipy.signal.morlet2',
-            'scipy.signal.ricker',
-            'scipy.integrate.simpson',
-            'scipy.interpolate.interp2d',
-            'scipy.linalg.kron',
-        ]
+        # Deprecated stuff
+        deprecated = []
         for name in deprecated:
             known_warnings[name] = dict(category=DeprecationWarning)
 

--- a/scipy/linalg/__init__.py
+++ b/scipy/linalg/__init__.py
@@ -46,7 +46,6 @@ Basics
    lstsq - Solve a linear least-squares problem
    pinv - Pseudo-inverse (Moore-Penrose) using lstsq
    pinvh - Pseudo-inverse of hermitian matrix
-   kron - Kronecker product of two arrays
    khatri_rao - Khatri-Rao product of two arrays
    orthogonal_procrustes - Solve an orthogonal Procrustes problem
    matrix_balance - Balance matrix entries with a similarity transformation

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -7,7 +7,7 @@ from scipy._lib._util import _apply_over_batch
 
 
 __all__ = ['toeplitz', 'circulant', 'hankel',
-           'hadamard', 'leslie', 'kron', 'block_diag', 'companion',
+           'hadamard', 'leslie', 'block_diag', 'companion',
            'helmert', 'hilbert', 'invhilbert', 'pascal', 'invpascal', 'dft',
            'fiedler', 'fiedler_companion', 'convolution_matrix']
 
@@ -337,60 +337,6 @@ def leslie(f, s):
     a[0] = f
     a[list(range(1, n)), list(range(0, n - 1))] = s
     return a
-
-
-def kron(a, b):
-    """
-    Kronecker product.
-
-    .. deprecated:: 1.15.0
-        `kron` has been deprecated in favour of `numpy.kron` and will be
-        removed in SciPy 1.17.0.
-
-    The result is the block matrix::
-
-        a[0,0]*b    a[0,1]*b  ... a[0,-1]*b
-        a[1,0]*b    a[1,1]*b  ... a[1,-1]*b
-        ...
-        a[-1,0]*b   a[-1,1]*b ... a[-1,-1]*b
-
-    Parameters
-    ----------
-    a : (M, N) ndarray
-        Input array
-    b : (P, Q) ndarray
-        Input array
-
-    Returns
-    -------
-    A : (M*P, N*Q) ndarray
-        Kronecker product of `a` and `b`.
-
-    Examples
-    --------
-    >>> from numpy import array
-    >>> from scipy.linalg import kron
-    >>> kron(array([[1,2],[3,4]]), array([[1,1,1]]))
-    array([[1, 1, 1, 2, 2, 2],
-           [3, 3, 3, 4, 4, 4]])
-
-    """
-    msg = ("`kron` has been deprecated in favour of `numpy.kron` in SciPy"
-           " 1.15.0 and will be removed in SciPy 1.17.0.")
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
-    # accommodate empty arrays
-    if a.size == 0 or b.size == 0:
-        m = a.shape[0] * b.shape[0]
-        n = a.shape[1] * b.shape[1]
-        return np.empty_like(a, shape=(m, n))
-
-    if not a.flags['CONTIGUOUS']:
-        a = np.reshape(a, a.shape)
-    if not b.flags['CONTIGUOUS']:
-        b = np.reshape(b, b.shape)
-    o = np.outer(a, b)
-    o = o.reshape(a.shape + b.shape)
-    return np.concatenate(np.concatenate(o, axis=1), axis=1)
 
 
 def block_diag(*arrs):

--- a/scipy/linalg/special_matrices.py
+++ b/scipy/linalg/special_matrices.py
@@ -6,7 +6,7 @@ from scipy._lib.deprecation import _sub_module_deprecation
 
 __all__ = [  # noqa: F822
     'toeplitz', 'circulant', 'hankel',
-    'hadamard', 'leslie', 'kron', 'block_diag', 'companion',
+    'hadamard', 'leslie', 'block_diag', 'companion',
     'helmert', 'hilbert', 'invhilbert', 'pascal', 'invpascal', 'dft',
     'fiedler', 'fiedler_companion', 'convolution_matrix'
 ]

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -8,7 +8,7 @@ from pytest import raises as assert_raises
 from scipy.fft import fft
 from scipy.special import comb
 from scipy.linalg import (toeplitz, hankel, circulant, hadamard, leslie, dft,
-                          companion, kron, block_diag,
+                          companion, block_diag,
                           helmert, hilbert, invhilbert, pascal, invpascal,
                           fiedler, fiedler_companion, eigvals,
                           convolution_matrix)
@@ -205,36 +205,6 @@ class TestBlockDiag:
                                [0, 0, 2, 3, 0, 0],
                                [0, 0, 4, 5, 0, 0],
                                [0, 0, 6, 7, 0, 0]])
-
-
-class TestKron:
-    @pytest.mark.thread_unsafe
-    def test_dep(self):
-        with pytest.deprecated_call(match="`kron`"):
-            kron(np.array([[1, 2],[3, 4]]),np.array([[1, 1, 1]]))
-
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-    def test_basic(self):
-
-        a = kron(array([[1, 2], [3, 4]]), array([[1, 1, 1]]))
-        assert_array_equal(a, array([[1, 1, 1, 2, 2, 2],
-                                     [3, 3, 3, 4, 4, 4]]))
-
-        m1 = array([[1, 2], [3, 4]])
-        m2 = array([[10], [11]])
-        a = kron(m1, m2)
-        expected = array([[10, 20],
-                          [11, 22],
-                          [30, 40],
-                          [33, 44]])
-        assert_array_equal(a, expected)
-
-    @pytest.mark.filterwarnings('ignore::DeprecationWarning')
-    def test_empty(self):
-        m1 = np.empty((0, 2))
-        m2 = np.empty((1, 3))
-        a = kron(m1, m2)
-        assert_allclose(a, np.empty((0, 6)))
 
 
 class TestHelmert:


### PR DESCRIPTION
`kron` is due to be removed in this release.

Also in the second commit tidies up some outdated warning filters etc