### PR TITLE
DEP: interpolate.interpnd: remove incidental imports from private but present module

### DIFF
--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -360,6 +360,7 @@ def test_api_importable():
                           ('scipy.interpolate.dfitpack', None),
                           ('scipy.interpolate.fitpack', None),
                           ('scipy.interpolate.fitpack2', None),
+                          ('scipy.interpolate.interpnd', None),
                           ('scipy.interpolate.interpolate', None),
                           ('scipy.interpolate.ndgriddata', None),
                           ('scipy.interpolate.polyint', None),

--- a/scipy/interpolate/interpnd.py
+++ b/scipy/interpolate/interpnd.py
@@ -7,10 +7,7 @@ from scipy._lib.deprecation import _sub_module_deprecation
 
 __all__ = [  # noqa: F822
     'CloughTocher2DInterpolator',
-    'GradientEstimationWarning',
     'LinearNDInterpolator',
-    'NDInterpolatorBase',
-    'estimate_gradients_2d_global',
 ]
 
 


### PR DESCRIPTION
follow up to https://github.com/scipy/scipy/pull/21754, removing these accidentally exposed functions is due for this release