### PR TITLE
BUG: signal.csd: Zero-pad for different size inputs

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -900,11 +900,11 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     if x.shape[axis] < y.shape[axis]:  # zero-pad x to shape of y:
         z_shape = list(y.shape)
         z_shape[axis] = y.shape[axis] - x.shape[axis]
-        x = np.concat((x, np.zeros(z_shape)), axis=axis)
+        x = np.concatenate((x, np.zeros(z_shape)), axis=axis)
     elif y.shape[axis] < x.shape[axis]:  # zero-pad y to shape of x:
         z_shape = list(x.shape)
         z_shape[axis] = x.shape[axis] - y.shape[axis]
-        y = np.concat((y, np.zeros(z_shape)), axis=axis)
+        y = np.concatenate((y, np.zeros(z_shape)), axis=axis)
 
     # using cast() to make mypy happy:
     fft_mode = cast(FFT_MODE_TYPE, 'onesided' if return_onesided else 'twosided')

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -897,6 +897,15 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     if np.iscomplexobj(x) and return_onesided:
         return_onesided = False
 
+    if x.shape[axis] < y.shape[axis]:  # zero-pad x to shape of y:
+        z_shape = list(y.shape)
+        z_shape[axis] = y.shape[axis] - x.shape[axis]
+        x = np.concat((x, np.zeros(z_shape)), axis=axis)
+    elif y.shape[axis] < x.shape[axis]:  # zero-pad y to shape of x:
+        z_shape = list(x.shape)
+        z_shape[axis] = x.shape[axis] - y.shape[axis]
+        y = np.concat((y, np.zeros(z_shape)), axis=axis)
+
     # using cast() to make mypy happy:
     fft_mode = cast(FFT_MODE_TYPE, 'onesided' if return_onesided else 'twosided')
     if scaling not in (scales := {'spectrum': 'magnitude', 'density': 'psd'}):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -594,19 +594,22 @@ class TestCSD:
 
     def test_unequal_length_input_1D(self):
         """Test zero-padding for input `x.shape[axis] != y.shape[axis]` for 1d arrays.
-        """
-        n = 8
-        x = irfft([0, 0, 8], n=n)  # x = [2, 0, -2, 0, 2, 0, -2, 0]
 
-        kw = dict(fs=n, window='boxcar', nperseg=8)
+        This test ensures that issue 23036 is fixed.
+        """
+        x = np.tile([4, 0, -4, 0], 4)
+
+        kw = dict(fs=len(x), window='boxcar', nperseg=4)
         X0 = signal.csd(x, np.copy(x), **kw)[1]  # `x is x` must be False
-        X1 = signal.csd(x, x[:4], **kw)[1]
-        X2 = signal.csd(x[:4], x, **kw)[1]
+        X1 = signal.csd(x, x[:8], **kw)[1]
+        X2 = signal.csd(x[:8], x, **kw)[1]
         xp_assert_close(X1, X0 / 2)
         xp_assert_close(X2, X0 / 2)
 
     def test_unequal_length_input_3D(self):
         """Test zero-padding for input `x.shape[axis] != y.shape[axis]` for 3d arrays.
+
+        This test ensures that issue 23036 is fixed.
         """
         n = 8
         x = np.zeros(2 * 3 * n).reshape(2, n, 3)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -8,6 +8,7 @@ import pytest
 from pytest import raises as assert_raises
 
 from scipy import signal
+from scipy._lib._array_api import xp_assert_close
 from scipy.fft import fftfreq, rfftfreq, fft, irfft
 from scipy.integrate import trapezoid
 from scipy.signal import (periodogram, welch, lombscargle, coherence, csd,
@@ -590,6 +591,33 @@ class TestCSD:
 
         assert_allclose(f, f1)
         assert_allclose(c, c1)
+
+    def test_unequal_length_input_1D(self):
+        """Test zero-padding for input `x.shape[axis] != y.shape[axis]` for 1d arrays.
+        """
+        n = 8
+        x = irfft([0, 0, 8], n=n)  # x = [2, 0, -2, 0, 2, 0, -2, 0]
+
+        kw = dict(fs=n, window='boxcar', nperseg=8)
+        X0 = signal.csd(x, np.copy(x), **kw)[1]  # `x is x` must be False
+        X1 = signal.csd(x, x[:4], **kw)[1]
+        X2 = signal.csd(x[:4], x, **kw)[1]
+        xp_assert_close(X1, X0 / 2)
+        xp_assert_close(X2, X0 / 2)
+
+    def test_unequal_length_input_3D(self):
+        """Test zero-padding for input `x.shape[axis] != y.shape[axis]` for 3d arrays.
+        """
+        n = 8
+        x = np.zeros(2 * 3 * n).reshape(2, n, 3)
+        x[:, 0, :] = n
+
+        kw = dict(fs=n, window='boxcar', nperseg=n, detrend=None, axis=1)
+        X0 = signal.csd(x, x.copy(), **kw)[1]  # `x is x` must be False
+        X1 = signal.csd(x, x[:, :2, :], **kw)[1]
+        X2 = signal.csd(x[:, :2, :], x, **kw)[1]
+        xp_assert_close(X1, X0)
+        xp_assert_close(X2, X0)
 
     def test_real_onesided_even(self):
         x = np.zeros(16)


### PR DESCRIPTION
Fixes #23036

This bug was introduced in 1.16.0rc1 with PR #22460.

