### PR TITLE
DEV: add `spin notes` and `spin authors` commands

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -573,6 +573,43 @@ def smoke_tutorials(ctx, pytest_args, tests, verbose, build_dir, *args, **kwargs
     util.run(cmd)
 
 @click.command()
+@click.argument('version_args', nargs=2)
+@click.pass_context
+def notes(ctx_obj, version_args):
+    """Release notes and log generation.
+
+    Example:
+
+      spin notes v1.7.0 v1.8.0
+    """
+    if version_args:
+        sys.argv = version_args
+        log_start = sys.argv[0]
+        log_end = sys.argv[1]
+    cmd = ["python", "tools/write_release_and_log.py", f"{log_start}", f"{log_end}"]
+    click.secho(' '.join(cmd), bold=True, fg="bright_blue")
+    util.run(cmd)
+
+@click.command()
+@click.argument('revision_args', nargs=2)
+@click.pass_context
+def authors(ctx_obj, revision_args):
+    """Generate list of authors who contributed within revision
+    interval.
+
+    Example:
+
+      spin authors v1.7.0 v1.8.0
+    """
+    if revision_args:
+        sys.argv = revision_args
+        start_revision = sys.argv[0]
+        end_revision = sys.argv[1]
+    cmd = ["python", "tools/authors.py", f"{start_revision}..{end_revision}"]
+    click.secho(' '.join(cmd), bold=True, fg="bright_blue")
+    util.run(cmd)
+
+@click.command()
 @click.option(
     '--fix', default=False, is_flag=True,
     help='Attempt to auto-fix errors')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,4 +192,8 @@ PKG_CONFIG_PATH = "{project}"
   ".spin/cmds.py:refguide_check",
   ".spin/cmds.py:smoke_tutorials"
 ]
+"Release" = [
+  ".spin/cmds.py:notes",
+  ".spin/cmds.py:authors"
+]
 "Metrics" = [".spin/cmds.py:bench"]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Towards https://github.com/scipy/scipy/pull/23041#pullrequestreview-2863890044

#### What does this implement/fix?
<!--Please explain your changes.-->

Added two functions for `spin notes` and `spin authors`. See the output below,

<details>

<summary>

`spin notes v1.7.0 v1.8.0 `

</summary>

```zsh
(scipy-dev) 2:17:47:~/Quansight/scipy % spin notes v1.7.0 v1.8.0                
python tools/write_release_and_log.py v1.7.0 v1.8.0
$ python tools/write_release_and_log.py v1.7.0 v1.8.0
Release README generated successfully
Release logs generated successfully
```

See the contents of generated files below,

**release/Changelog**

```zsh
commit b5d8bab88af61d61de09641243848df63380a67f
Author: Tyler Reddy <tyler.je.reddy@gmail.com>
Date:   Fri Feb 4 07:42:21 2022 -0700

    REL: 1.8.0 release commit.

commit d84f731d4df03915ce3dd8013a86eab0db5ec60e
Merge: 920e27b282 315dd5340c
Author: Tyler Reddy <tyler.je.reddy@gmail.com>
Date:   Fri Feb 4 07:31:58 2022 -0700

    Merge pull request #15521 from tylerjereddy/treddy_prep_180_final
    
    MAINT: prepare for SciPy 1.8.0 final

commit 315dd5340cd2825682087f195663d2f63deb3f24
Author: Tyler Reddy <tyler.je.reddy@gmail.com>
Date:   Thu Feb 3 20:44:16 2022 -0700

    DOC: update 1.8.0 relnotes.

commit b54b7ae0240cad126a1a9baf2ed71c97c15ddc15
Author: Pamphile Roy <roy.pamphile@gmail.com>
Date:   Thu Feb 3 14:15:59 2022 +0100

    MAINT: fix broken link and remove CI badges
    
    [skip azp] [skip actions]

commit 920e27b282583531cbf5b5ad348845f0c4bddeed
Author: Tyler Reddy <tyler.je.reddy@gmail.com>
Date:   Thu Feb 3 20:31:57 2022 -0700

    REL: 1.8.0 unreleased.
.
.
.
```

**release/README.txt**

```zsh
==========================
SciPy 1.17.0 Release Notes
==========================

.. note:: SciPy 1.17.0 is not released yet!

.. contents::

SciPy 1.17.0 is the culmination of X months of hard work. It contains
many new features, numerous bug-fixes, improved test coverage and better
documentation. There have been a number of deprecations and API changes
in this release, which are documented below. All users are encouraged to
upgrade to this release, as there are a large number of bug-fixes and
optimizations. Before upgrading, we recommend that users check that
their own code does not use deprecated SciPy functionality (to do so,
run your code with ``python -Wd`` and check for ``DeprecationWarning`` s).
Our development attention will now shift to bug-fix releases on the
1.17.x branch, and on adding new features on the main branch.

This release requires Python 3.11-3.14 and NumPy 1.25.2 or greater.


**************************
Highlights of this release
**************************


************
New features
************

`scipy.cluster` improvements
============================


`scipy.interpolate` improvements
================================


`scipy.linalg` improvements
===========================


`scipy.ndimage` improvements
============================


`scipy.optimize` improvements
=============================


`scipy.signal` improvements
===========================


`scipy.sparse` improvements
===========================



`scipy.spatial` improvements
============================


`scipy.special` improvements
============================


`scipy.stats` improvements
==========================



*******************
Deprecated features
*******************

`scipy.linalg` deprecations
===========================


`scipy.spatial` deprecations
============================



******************************
Backwards incompatible changes
******************************

*************
Other changes
*************



*******
Authors
*******



************************
Issues closed for 1.17.0
************************


************************
Pull requests for 1.17.0
************************



Checksums
=========

MD5
~~~

8667384b5848557e48979ff183d97f54  Changelog
bb04a28b0a037732d7264e585b0bc6df  README.txt

SHA256
~~~~~~

b24ccac1eb0b6fcfa66f31b529a527ee721b941832a47a9aa5771db13f34f1c1  Changelog
02c4de4d5089fe135dbf1fa9b36923bd4c6992419c89eab23011e1e9f529d19c  README.txt
```

</details>

<details>

<summary>

`spin authors v1.7.0 v1.8.0`

</summary>

```zsh
(scipy-dev) 2:17:52:~/Quansight/scipy % spin authors v1.7.0 v1.8.0              
python tools/authors.py v1.7.0..v1.8.0
$ python tools/authors.py v1.7.0..v1.8.0

Authors
=======

* 99991 (1) +
* endolith (5)
* h-vetinari (26)
* adamadanandy (2) +
* akeemlh (1) +
* Anton Akhmerov (2)
* Marvin Albert (1) +
* alegresor (1) +
* Andrew Annex (1) +
* Pantelis Antonoudiou (2) +
* Ross Barnowski (41) +
* Christoph Baumgarten (7)
* Stephen Becker (1) +
* Nickolai Belakovski (1)
* Peter Bell (49)
* berberto (2) +
* Georgii Bocharov (1) +
* Evgeni Burovski (25)
* Matthias Bussonnier (3)
* CJ Carey (2)
* Justin Charlong (2) +
* Hood Chatham (2) +
* Dennis Collaris (1) +
* David Cottrell (2) +
* cruyffturn (1) +
* da-woods (1) +
* Anirudh Dagar (44)
* Tiger Du (1) +
* Thomas Duvernay (6)
* Dani El-Ayyass (2) +
* Castedo Ellerman (1) +
* Donnie Erb (2) +
* Andreas Esders-Kopecky (1) +
* Livio F (1) +
* Isuru Fernando (9)
* Evelyn Fitzgerald (1) +
* Sara Fridovich-Keil (2) +
* Mark E Fuller (2) +
* Ralf Gommers (217)
* Kevin Richard Green (1) +
* guiweber (1) +
* Nitish Gupta (1) +
* Matt Haberland (222)
* J. Hariharan (1) +
* Charles Harris (1)
* Jonathan Helgert (1) +
* Trever Hines (1)
* Ian Hunt-Isaak (1) +
* ich (2) +
* Kei Ishikawa (1)
* Itrimel (1) +
* Jan-Hendrik Müller (1) +
* jarneal (1) +
* Jebby993 (1) +
* Yikun Jiang (1) +
* Evan W Jones (1) +
* Nathaniel Jones (1) +
* Jeffrey Kelling (4) +
* Malik Idrees Hasan Khan (2) +
* Paul Kienzle (1)
* Sergey B Kirpichev (1)
* Kadatatlu Kishore (1) +
* Andrew Knyazev (2)
* Ravin Kumar (1) +
* Peter Mahler Larsen (6)
* Eric Larson (12)
* Antony Lee (3)
* Gregory R. Lee (1)
* Tim Leslie (2)
* lezcano (2) +
* Xingyu Liu (45)
* Christian Lorentzen (2)
* Lorenzo (2) +
* Smit Lunagariya (121) +
* Lv101Magikarp (1) +
* Yair M (1) +
* Cong Ma (2)
* Lorenzo Maffioli (2) +
* majiang (1) +
* Brian McFee (1) +
* Nicholas McKibben (9)
* John Speed Meyers (1) +
* millivolt9 (1) +
* Jarrod Millman (2)
* Harsh Mishra (2) +
* Boaz Mohar (1) +
* naelsondouglas (1) +
* Andrew Nelson (94)
* Nico Schlömer (43)
* Thomas Nowotny (1) +
* nullptr (1) +
* Teddy Ort (3) +
* Nick Papior (4)
* ParticularMiner (1) +
* Dima Pasechnik (5)
* Tirth Patel (42)
* Matti Picus (2)
* Ilhan Polat (51)
* Adrian Price-Whelan (2) +
* Quentin Barthélemy (4) +
* Sundar R (1) +
* Judah Rand (4) +
* Tyler Reddy (185)
* Renal-Of-Loon (1) +
* Frederic Renner (2) +
* Pamphile Roy (94)
* Bharath Saiguhan (1) +
* Atsushi Sakai (37)
* Eric Schanet (1) +
* Sebastian Wallkötter (3)
* serge-sans-paille (6)
* Reshama Shaikh (3) +
* Namami Shanker (2)
* siddhantwahal (1) +
* Walter Simson (1) +
* Leo C. Stein (4) +
* Albert Steppi (4)
* Kai Striega (19)
* Diana Sukhoverkhova (1)
* Søren Fuglede Jørgensen (2)
* Masayuki Takagi (1) +
* Mike Taves (3)
* Ben Thompson (2) +
* Bas van Beek (47)
* Jacob Vanderplas (2)
* Dhruv Vats (2) +
* Thomas Viehmann (1) +
* Pauli Virtanen (2)
* Vlad (1) +
* Arthur Volant (23)
* Samuel Wallan (2)
* Stefan van der Walt (36)
* Warren Weckesser (39)
* Michael Wende (1) +
* Josh Wilson (1)
* Haoyin Xu (4) +
* Rory Yorke (2)
* Egor Zemlyanoy (2)
* Gang Zhao (15) +
* ਗਗਨਦੀਪ ਸਿੰਘ (Gagandeep Singh) (38) +
* 赵丰 (Zhao Feng) (1) +

    A total of 141 people contributed to this release.
    People with a "+" by their names contributed a patch for the first time.
    This list of names is automatically generated, and may not be fully complete.
    
NOTE: Check this list manually! It is automatically generated and some names
      may be missing.
```

</details>

#### Additional information
<!--Any additional information you think is important.-->

The implementation of `notes` and `authors` is almost same. So it might be tempting to factor out it into something `def release_command(version_args, cmd_type=None)`, where `cmd_type` can be a string or Python enum. However, I didn't do it because I think it would be an overkill. But still sharing my thoughts in case reviewers recommend to go with it.
