### PR TITLE
ENH: interpolate: array API for BSpline-based `make_` functions

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1796,6 +1796,8 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True, *, method="
     does not matter as long as the corresponding weight is zero.)
 
     """
+    xp = array_namespace(x, y, t, w)
+
     x = _as_float_array(x, check_finite)
     y = _as_float_array(y, check_finite)
     t = _as_float_array(t, check_finite)
@@ -1890,6 +1892,7 @@ def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True, *, method="
     # restore the shape of `c` for both single and multiple r.h.s.
     c = c.reshape((n,) + y.shape[1:])
     c = np.ascontiguousarray(c)
+    t, c = xp.asarray(t), xp.asarray(c)
     return BSpline.construct_fast(t, c, k, axis=axis)
 
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -357,7 +357,7 @@ class BSpline:
         xp = array_namespace(t)
         t = np.asarray(t)
         k = t.shape[0] - 2
-        t = _as_float_array(t)
+        t = _as_float_array(t)  # TODO: use concat_1d instead of np.r_
         t = np.r_[(t[0]-1,) * k, t, (t[-1]+1,) * k]
         c = np.zeros_like(t)
         c[k] = 1.

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -2322,6 +2322,7 @@ def make_smoothing_spline(x, y, w=None, lam=None, *, axis=0):
     >>> plt.show()
 
     """  # noqa:E501
+    xp = array_namespace(x, y)
 
     x = np.ascontiguousarray(x, dtype=float)
     y = np.ascontiguousarray(y, dtype=float)
@@ -2421,6 +2422,7 @@ def make_smoothing_spline(x, y, w=None, lam=None, *, axis=0):
                cm0 * (t[-4] - t[-6]) + cm1,
                cm0 * (2 * t[-4] - t[-5] - t[-6]) + cm1]
 
+    t, c_ = xp.asarray(t), xp.asarray(c_)
     return BSpline.construct_fast(t, c_, 3, axis=axis)
 
 

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -983,14 +983,20 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=
     .. [2] P. Dierckx, "Curve and surface fitting with splines", Monographs on
         Numerical Analysis, Oxford University Press, 1993.
     """  # noqa:E501
-    xp = array_namespace(x, w, u, t)
+
+    # x can be either a 2D array or a list of 1D arrays
+    if isinstance(x, list):
+        xp = array_namespace(*x, w, u, t)
+    else:
+        xp = array_namespace(x, w, u, t)
+
     x = xp.stack(x, axis=1)
 
     # construct the default parametrization of the curve
     if u is None:
         dp = (x[1:, :] - x[:-1, :])**2
-        u = xp.cumulative_sum(xp.sum(xp.sqrt(dp, axis=1)))
-        u = concat_1d[0, u / u[-1]]
+        u = xp.cumulative_sum( xp.sqrt(xp.sum(dp, axis=1)) )
+        u = concat_1d(xp, 0., u / u[-1])
 
     if s == 0:
         if t is not None or w is not None or nest is not None:
@@ -1008,4 +1014,4 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=
     cc = spl.c.T
     spl1 = BSpline(spl.t, cc, spl.k, axis=1)
 
-    return spl1, u
+    return spl1, xp.asarray(u)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2301,7 +2301,7 @@ class TestSmoothingSpline:
         # them randomly
         for ind in rng.choice(range(100), size=10):
             w = xp.ones(n)
-            w[xp.asarray(ind)] = 30.
+            w[int(ind)] = 30.
             spl_w = make_smoothing_spline(x, y, w)
             # check that spline with weight in a certain point is closer to the
             # original point than the one without weights
@@ -3329,7 +3329,7 @@ index 1afb1900f1..d817e51ad8 100644
                   [0., 0., 0., 0., 2., 4., 6., 7., 7., 7., 7.],
                   [0., 0., 0., 0., 2., 3., 4., 5., 7, 7., 7., 7.]
         ]
-        wanted = [xp.asarray(want) for want in wanted]
+        wanted = [xp.asarray(want, dtype=xp.float64) for want in wanted]
 
         assert len(knots) == len(wanted)
         for t, tt in zip(knots, wanted):
@@ -3353,7 +3353,9 @@ index 1afb1900f1..d817e51ad8 100644
 
         knots = list(generate_knots(x, y, k=3, s=s, nest=10))
         xp_assert_close(
-            knots[-1], xp.asarray([0., 0., 0., 0., 2., 4., 7., 7., 7., 7.]), atol=1e-15
+            knots[-1],
+            xp.asarray([0., 0., 0., 0., 2., 4., 7., 7., 7., 7.], dtype=xp.float64),
+            atol=1e-15
         )
 
         with assert_raises(ValueError):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2175,6 +2175,7 @@ def data_file(basename):
                         'data', basename)
 
 
+@skip_xp_backends(cpu_only=True)
 class TestSmoothingSpline:
     #
     # test make_smoothing_spline
@@ -2266,7 +2267,7 @@ class TestSmoothingSpline:
         # result in conflicting dtypes on big endian systems.
         xp_assert_close(y_compr, y_GCVSPL, atol=1e-4, rtol=1e-4, check_dtype=False)
 
-    def test_non_regularized_case(self):
+    def test_non_regularized_case(self, xp):
         """
         In case the regularization parameter is 0, the resulting spline
         is an interpolation spline with natural boundary conditions.
@@ -2277,10 +2278,12 @@ class TestSmoothingSpline:
         x = np.sort(rng.random_sample(n) * 4 - 2)
         y = x**2 * np.sin(4 * x) + x**3 + rng.normal(0., 1.5, n)
 
+        x, y = xp.asarray(x), xp.asarray(y)
+
         spline_GCV = make_smoothing_spline(x, y, lam=0.)
         spline_interp = make_interp_spline(x, y, 3, bc_type='natural')
 
-        grid = np.linspace(x[0], x[-1], 2 * n)
+        grid = xp.linspace(x[0], x[-1], 2 * n)
         xp_assert_close(spline_GCV(grid),
                         spline_interp(grid),
                         atol=1e-15)
@@ -2301,7 +2304,7 @@ class TestSmoothingSpline:
         # them randomly
         for ind in rng.choice(range(100), size=10):
             w = xp.ones(n)
-            w[int(ind)] = 30.
+            xpx.at(w, int(ind)).set(30.)    # w[int(ind)] = 30.
             spl_w = make_smoothing_spline(x, y, w)
             # check that spline with weight in a certain point is closer to the
             # original point than the one without weights
@@ -3236,6 +3239,7 @@ def _add_knot(x, t, k, residuals):
     return t_new
 
 
+@skip_xp_backends(cpu_only=True)
 class TestGenerateKnots:
     def test_split_add_knot(self):
         # smoke test implementation details: insert a new knot given residuals
@@ -3477,6 +3481,7 @@ class F_dense:
         return fp - self.s
 
 
+@skip_xp_backends(cpu_only=True)
 class TestMakeSplrep:
     def test_input_errors(self):
         x = np.linspace(0, 10, 11)
@@ -3683,6 +3688,7 @@ class TestMakeSplrep:
         assert spl_1.t.shape[0] == 2 * (k + 1)
 
 
+@skip_xp_backends(cpu_only=True)
 class TestMakeSplprep:
     def _get_xyk(self, m=10, k=3, xp=np):
         x = xp.arange(m, dtype=xp.float64) * xp.pi / m

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2286,20 +2286,22 @@ class TestSmoothingSpline:
                         atol=1e-15)
 
     @pytest.mark.fail_slow(2)
-    def test_weighted_smoothing_spline(self):
+    def test_weighted_smoothing_spline(self, xp):
         # create data sample
         rng = np.random.RandomState(1234)
         n = 100
         x = np.sort(rng.random_sample(n) * 4 - 2)
         y = x**2 * np.sin(4 * x) + x**3 + rng.normal(0., 1.5, n)
 
+        x, y = map(xp.asarray, (x, y))
+
         spl = make_smoothing_spline(x, y)
 
         # in order not to iterate over all of the indices, we select 10 of
         # them randomly
         for ind in rng.choice(range(100), size=10):
-            w = np.ones(n)
-            w[ind] = 30.
+            w = xp.ones(n)
+            w[xp.asarray(ind)] = 30.
             spl_w = make_smoothing_spline(x, y, w)
             # check that spline with weight in a certain point is closer to the
             # original point than the one without weights

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3531,12 +3531,12 @@ class TestMakeSplrep:
             # len(x) != len(y)
             make_splrep(np.arange(8), np.arange(9), s=0.1)
 
-    def _get_xykt(self):
-        x = np.linspace(0, 5, 11)
-        y  = np.sin(x*3.14 / 5)**2
+    def _get_xykt(self, xp=np):
+        x = xp.linspace(0, 5, 11)
+        y  = xp.sin(x*3.14 / 5)**2
         k = 3
         s = 1.7e-4
-        tt = np.array([0]*(k+1) + [2.5, 4.0] + [5]*(k+1))
+        tt = xp.asarray([0]*(k+1) + [2.5, 4.0] + [5]*(k+1))
 
         return x, y, k, s, tt
 
@@ -3579,18 +3579,19 @@ class TestMakeSplrep:
         assert D.shape[0] == n - 2*k - 2   # number of internal knots
         xp_assert_close(D, D_dense, atol=1e-15)
 
-    def test_simple_vs_splrep(self):
-        x, y, k, s, tt = self._get_xykt()
-        tt = np.array([0]*(k+1) + [2.5, 4.0] + [5]*(k+1))
+    def test_simple_vs_splrep(self, xp):
+        x, y, k, s, tt = self._get_xykt(xp)
+        tt = xp.asarray([0]*(k+1) + [2.5, 4.0] + [5]*(k+1))
 
-        t,c,k = splrep(x, y, k=k, s=s)
+        t, c, k = splrep(x, y, k=k, s=s)
+        t, c = xp.asarray(t), xp.asarray(c)
         assert all(t == tt)
 
         spl = make_splrep(x, y, k=k, s=s)
-        xp_assert_close(c[:spl.c.size], spl.c, atol=1e-15)
+        xp_assert_close(c[:spl.c.shape[0]], spl.c, atol=1e-15)
 
-    def test_with_knots(self):
-        x, y, k, s, _ = self._get_xykt()
+    def test_with_knots(self, xp):
+        x, y, k, s, _ = self._get_xykt(xp)
 
         t = list(generate_knots(x, y, k=k, s=s))[-1]
 
@@ -3601,18 +3602,18 @@ class TestMakeSplrep:
         xp_assert_close(spl_auto.c, spl_t.c, atol=1e-15)
         assert spl_auto.k == spl_t.k
 
-    def test_no_internal_knots(self):
+    def test_no_internal_knots(self, xp):
         # should not fail if there are no internal knots
         n = 10
-        x = np.arange(n)
+        x = xp.arange(n, dtype=xp.float64)
         y = x**3
         k = 3
         spl = make_splrep(x, y, k=k, s=1)
         assert spl.t.shape[0] == 2*(k+1)
 
-    def test_default_s(self):
+    def test_default_s(self, xp):
         n = 10
-        x = np.arange(n)
+        x = xp.arange(n, dtype=xp.float64)
         y = x**3
         spl = make_splrep(x, y, k=3)
         spl_i = make_interp_spline(x, y, k=3)
@@ -3648,10 +3649,10 @@ class TestMakeSplrep:
         with assert_raises(ValueError):
             make_splrep(x, y, w=w, k=2, s=12)
 
-    def test_shape(self):
+    def test_shape(self, xp):
         # make sure coefficients have the right shape (not extra dims)
         n, k = 10, 3
-        x = np.arange(n)
+        x = xp.arange(n, dtype=xp.float64)
         y = x**3
 
         spl = make_splrep(x, y, k=k)
@@ -3664,10 +3665,10 @@ class TestMakeSplrep:
         spl_2 = make_splrep(x, y + 1/(1+y), k=k, s=1e-5)
         assert spl_2.c.ndim == 1
 
-    def test_s0_vs_not(self):
+    def test_s0_vs_not(self, xp):
         # check that the shapes are consistent
         n, k = 10, 3
-        x = np.arange(n)
+        x = xp.arange(n, dtype=xp.float64)
         y = x**3
 
         spl_0 = make_splrep(x, y, k=3, s=0)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3682,9 +3682,9 @@ class TestMakeSplrep:
 
 
 class TestMakeSplprep:
-    def _get_xyk(self, m=10, k=3):
-        x = np.arange(m) * np.pi / m
-        y = [np.sin(x), np.cos(x)]
+    def _get_xyk(self, m=10, k=3, xp=np):
+        x = xp.arange(m, dtype=xp.float64) * xp.pi / m
+        y = [xp.sin(x), xp.cos(x)]
         return x, y, k
 
     @pytest.mark.parametrize('s', [0, 0.1, 1e-3, 1e-5])
@@ -3752,22 +3752,22 @@ class TestMakeSplprep:
         with assert_raises(ValueError):
             make_splprep(np.asarray(y).T, s=s)
 
-    def test_default_s_is_zero(self):
-        x, y, k = self._get_xyk(m=10)
+    def test_default_s_is_zero(self, xp):
+        x, y, k = self._get_xyk(m=10, xp=xp)
 
         spl, u = make_splprep(y)
-        xp_assert_close(spl(u), y, atol=1e-15)
+        xp_assert_close(spl(u), xp.stack(y), atol=1e-15)
 
-    def test_s_zero_vs_near_zero(self):
+    def test_s_zero_vs_near_zero(self, xp):
         # s=0 and s \approx 0 are consistent
-        x, y, k = self._get_xyk(m=10)
+        x, y, k = self._get_xyk(m=10, xp=xp)
 
         spl_i, u_i = make_splprep(y, s=0)
         spl_n, u_n = make_splprep(y, s=1e-15)
 
         xp_assert_close(u_i, u_n, atol=1e-15)
-        xp_assert_close(spl_i(u_i), y, atol=1e-15)
-        xp_assert_close(spl_n(u_n), y, atol=1e-7)
+        xp_assert_close(spl_i(u_i), xp.stack(y), atol=1e-15)
+        xp_assert_close(spl_n(u_n), xp.stack(y), atol=1e-7)
         assert spl_i.axis == spl_n.axis
         assert spl_i.c.shape == spl_n.c.shape
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

on top of https://github.com/scipy/scipy/pull/23020

#### What does this implement/fix?
<!--Please explain your changes.-->

Convert 
- [x] `make_lsq_spline`
- [x] `make_smoothing_spline`
- [x] `make_splrep`
- [x] `make_splprep`
- [x] `generate_knots`

to be array API compatible.

#### Additional information
<!--Any additional information you think is important.-->

This uses the same pattern as gh-23020 : infer the namespace of inputs, convert inputs to numpy, do CPU-only computations, convert outputs to the target namespace.