### PR TITLE
BUG: sparse: correct nnz count for DIA format

### DIFF
--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -131,9 +131,9 @@ class _dia_base(_data_matrix):
         if axis is not None:
             raise NotImplementedError("_getnnz over an axis is not implemented "
                                       "for DIA format")
-        rows, cols = self.shape
-        row_len = min(cols, self.data.shape[1])
-        return int(np.maximum(np.minimum(rows + self.offsets, row_len) -
+        M, N = self.shape
+        L = min(self.data.shape[1], N)
+        return int(np.maximum(np.minimum(M + self.offsets, L) -
                               np.maximum(self.offsets, 0),
                               0).sum())
 

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -131,14 +131,11 @@ class _dia_base(_data_matrix):
         if axis is not None:
             raise NotImplementedError("_getnnz over an axis is not implemented "
                                       "for DIA format")
-        M,N = self.shape
-        nnz = 0
-        for k in self.offsets:
-            if k > 0:
-                nnz += min(M,N-k)
-            else:
-                nnz += min(M+k,N)
-        return int(nnz)
+        rows, cols = self.shape
+        row_len = min(cols, self.data.shape[1])
+        return int(np.maximum(np.minimum(rows + self.offsets, row_len) -
+                              np.maximum(self.offsets, 0),
+                              0).sum())
 
     _getnnz.__doc__ = _spbase._getnnz.__doc__
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -5018,6 +5018,45 @@ class TestDIA(sparse_test_class(getset=False, slicing=False, slicing_assign=Fals
         m.setdiag((3,), k=3)
         assert_equal(m.offsets.dtype, np.int64)
 
+    def ill_cases(self):
+        # Ill-formed inputs and reference 2 x 2 outputs for testing _getnnz()
+        # and tocsr(): list of tuples (data, offsets, nnz, dense array)
+
+        d1 = [[1]]        # diagonal shorter than width
+        d3 = [[1, 2, 3]]  # diagonal longer than width
+
+        return [(d1, [-1], 1, [[0, 0], [1, 0]]),  # within
+                (d1, [1],  0, [[0, 0], [0, 0]]),  # above (but within if full)
+                (d1, [3],  0, [[0, 0], [0, 0]]),  # all above
+                (d1, [-3], 0, [[0, 0], [0, 0]]),  # all below
+                (d3, [-1], 1, [[0, 0], [1, 0]]),  # within (only head)
+                (d3, [1],  1, [[0, 2], [0, 0]]),  # within (only tail)
+                (d3, [3],  0, [[0, 0], [0, 0]]),  # all above
+                (d3, [-3], 0, [[0, 0], [0, 0]]),  # all below
+                # empty
+                (None, None, 0, [[0, 0], [0, 0]]),
+                # explicit zeros
+                ([[0, 0]], [0], 2, [[0, 0], [0, 0]]),
+                # overfilled shorter-diagonal, out of order
+                (np.arange(1, 1 + 7).reshape((7, 1)),
+                 [0, 1, 2, 3, -1, -2, -3],
+                 2, [[1, 0], [5, 0]]),
+                # overfilled longer-diagonal, out of order
+                (np.arange(1, 1 + 7 * 3).reshape((7, 3)),
+                 [0, 1, 2, 3, -1, -2, -3],
+                 4, [[1, 5], [13, 2]])]
+
+    def test_getnnz(self):
+        for data, ofsets, nnz, ref in self.ill_cases():
+            for shape in [(2, 2), (0, 2), (2, 0)]:
+                if data is None:
+                    A = dia_array(shape)
+                else:
+                    A = dia_array((data, ofsets), shape=shape)
+                if 0 in shape:
+                    nnz = 0
+                assert A._getnnz() == nnz
+
     @pytest.mark.skip(reason='DIA stores extra zeros')
     def test_getnnz_axis(self):
         pass


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See [report](https://github.com/scipy/scipy/pull/23009#issuecomment-2902612542) (after “P.S.”, and following [request](https://github.com/scipy/scipy/pull/23009#issuecomment-2905019734) by @dschult) in gh-23009.

#### What does this implement/fix?
Current `_getnnz()` implementation for sparse DIA format produces incorrect (sometimes meaningless and potentially dangerous) results for ill-constructed arrays. For example:
```python
>>> from scipy.sparse import dia_array
>>> d = dia_array(([[1, 2, 3]], [5]), shape=(3, 3))
>>> d.toarray()
array([[0, 0, 0],
       [0, 0, 0],
       [0, 0, 0]])
>>> d.nnz
-2
```
This PR adds tests to detect such problems and reimplements the `_getnnz()` method to produce correct results for all internally consistent, even if not optimal, array states.

#### Additional information
<!--Any additional information you think is important.-->
The new implementation is also faster than the current one for arrays with >2 diagonals.
(But ~2 times slower for single-diagonal arrays; however, works correctly in all cases, so direct comparison is not completely fair. Plus, this is perhaps not a very common use case.)

Test cases are produced here by a separate function to be reused for `tocsr()` tests in gh-23009, which needs to be refactored after merging this PR.