### PR TITLE
DEV: help debug free-threading build of Fortran modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ benchmarks/html
 benchmarks/scipy-benchmarks
 .github/workflows/.pixi
 .openblas
+scipy-openblas.pc
 scipy/_distributor_init_local.py
 scipy/__config__.py
 scipy/_lib/_ccallback_c.c

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -36,10 +36,12 @@ thread_dep = dependency('threads', required: false)
 # version easily for >=2.0.
 _numpy_dep = dependency('numpy', required: false)
 f2py_freethreading_arg = []
-if _numpy_dep.found()
-  if _numpy_dep.version().version_compare('>=2.1.0')
-    f2py_freethreading_arg = ['--free-threading']
-  endif
+if _numpy_dep.found() and _numpy_dep.version().version_compare('>=2.1.0')
+  f2py_freethreading_arg = ['--free-threading']
+  message('f2py free-threading enabled')
+else
+  message('f2py free-threading disabled; need numpy >=2.1.0.')
+  message('See https://github.com/mesonbuild/meson/issues/14651')
 endif
 
 # NumPy include directory - needed in all submodules


### PR DESCRIPTION
This just cost me way too many hours to debug.
XREF https://github.com/mesonbuild/meson/issues/14651

Scipy warning (which is an error when running tests) below for the benefit of github searches:

> RuntimeWarning: The global interpreter lock (GIL) has been enabled to load module 'scipy.linalg._fblas', which has not declared that it can run safely without the GIL. To override this behavior and keep the GIL disabled (at your own risk), run with PYTHON_GIL=0 or -Xgil=0.

besides `linalg`, I can see fortran modules using this in `integrate`, `interpolate`, and `io`.