### PR TITLE
ENH: stats.tukey_hsd: improve array index iteration in ``TukeyHSDResult.__str__``

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1749,13 +1749,12 @@ class TukeyHSDResult:
         s = ("Pairwise Group Comparisons"
              f" ({self._ci_cl*100:.1f}% Confidence Interval)\n")
         s += "Comparison  Statistic  p-value  Lower CI  Upper CI\n"
-        for i in range(self.pvalue.shape[0]):
-            for j in range(self.pvalue.shape[0]):
-                if i != j:
-                    s += (f" ({i} - {j}) {self.statistic[i, j]:>10.3f}"
-                          f"{self.pvalue[i, j]:>10.3f}"
-                          f"{self._ci.low[i, j]:>10.3f}"
-                          f"{self._ci.high[i, j]:>10.3f}\n")
+        for i, j in np.ndindex(self.pvalue.shape):
+            if i != j:
+                s += (f" ({i} - {j}) {self.statistic[i, j]:>10.3f}"
+                      f"{self.pvalue[i, j]:>10.3f}"
+                      f"{self._ci.low[i, j]:>10.3f}"
+                      f"{self._ci.high[i, j]:>10.3f}\n")
         return s
 
     def confidence_interval(self, confidence_level=.95):


### PR DESCRIPTION
This fixes an issue where the wrong axis length was used during iteration in ``scipy.stats._hypotests.TukeyHSDResult.__str__``, by using the less error-prone ``np.ndindex`` as index iterator. Note that this wasn't causing any problems at runtime at the moment, because as far as I can tell, the relevant arrays are always square. Either way, this way the code is less confusing :shrug:.