### PR TITLE
ENH: stats.entropy: add normalize parameter to skip input normalization

### DIFF
--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -148,6 +148,7 @@ def entropy(pk: np.typing.ArrayLike,
     >>> entropy(pk, qk, base=2, normalize=False)
     0.08164398904051034
 
+    .. versionadded:: 1.15.4
     """
     if base is not None and base <= 0:
         raise ValueError("`base` must be a positive number or `None`.")

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -146,7 +146,7 @@ def entropy(pk: np.typing.ArrayLike,
     >>> pk = np.array([2.0, 8.0])
     >>> qk = np.array([1.0, 9.0])
     >>> entropy(pk, qk, base=2, normalize=False)
-    0.08164398904051034
+    0.6405999884615012
 
     .. versionadded:: 1.15.4
     """

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -121,7 +121,7 @@ class TestEntropy:
         qk = xp.asarray([1.0, 9.0, 2.0, 2.0, 5.0, 3.0, 6.0, 4.0, 5.0, 3.0])
         result = stats.entropy(pk, qk, base=2, normalize=False)
 
-        expected = xp.asarray(3.4388635654728785)
+        expected = xp.asarray(2.190590872098243)
         xp_assert_close(result, expected)
 
     def test_entropy_normalize_true_equals_false_when_inputs_normalized(self, xp):
@@ -131,7 +131,7 @@ class TestEntropy:
         res1 = stats.entropy(pk, qk, base=2)
         res2 = stats.entropy(pk, qk, base=2, normalize=False)
 
-        expected = xp.asarray(0.08560810937047036) 
+        expected = xp.asarray(0.0660149997115376) 
         xp_assert_close(res1, expected)
         xp_assert_close(res2, expected)
 

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -115,6 +115,26 @@ class TestEntropy:
         message = "`base` must be a positive number."
         with pytest.raises(ValueError, match=message):
             stats.entropy(x, base=-2)
+    
+    def test_entropy_normalize_false_expected_value(self, xp):
+        pk = xp.asarray([2.0, 8.0, 3.0, 1.0, 6.0, 2.0, 7.0, 4.0, 5.0, 2.0])
+        qk = xp.asarray([1.0, 9.0, 2.0, 2.0, 5.0, 3.0, 6.0, 4.0, 5.0, 3.0])
+        result = stats.entropy(pk, qk, base=2, normalize=False)
+
+        expected = xp.asarray(3.4388635654728785)
+        xp_assert_close(result, expected)
+
+    def test_entropy_normalize_true_equals_false_when_inputs_normalized(self, xp):
+        pk = xp.asarray([0.05, 0.2, 0.1, 0.05, 0.15, 0.05, 0.2, 0.1, 0.05, 0.05])
+        qk = xp.asarray([0.05, 0.15, 0.1, 0.1, 0.15, 0.1, 0.15, 0.1, 0.05, 0.05])
+
+        res1 = stats.entropy(pk, qk, base=2)
+        res2 = stats.entropy(pk, qk, base=2, normalize=False)
+
+        expected = xp.asarray(0.08560810937047036) 
+        xp_assert_close(res1, expected)
+        xp_assert_close(res2, expected)
+
 
 
 @pytest.mark.skip_xp_backends("dask.array", reason="boolean index assignment")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
#23064 

#### What does this implement/fix?
Added a keyword-only argument `normalize` to scipy.stats.entropy, defaulting to True.
	•	When `normalize=True` (default), input arrays pk and qk are normalized to sum to 1 along the specified axis.
	•	When `normalize=False`, inputs are treated as already normalized, and no internal normalization is performed.

This addition offers more flexibility and avoids redundant normalization when it’s unnecessary.

