### PR TITLE
ENH: linalg: low-level batching support in `solve`

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -88,8 +88,6 @@ def solve(a, b, overwrite_a=False,
             raise ValueError('Input b has to have same number of rows as '
                              'input a')
     '''
-    breakpoint()
-
     a1 = _asarray_validated(a, check_finite=check_finite)
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
 
@@ -123,6 +121,13 @@ def solve(a, b, overwrite_a=False,
     a1 = np.broadcast_to(a1, batch_shape + a1.shape[-2:])
     b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
+    # catch empty inputs
+    if a1.size == 0 or b1.size == 0:
+        x = np.empty_like(b1)
+        if b_is_1D:
+            x = x[..., 0]
+        return x
+
     print(f"{a1.shape=} {b1.shape=}  {b1.dtype} \n")
 
 
@@ -139,9 +144,9 @@ def solve(a, b, overwrite_a=False,
         # 'diagonal': 11,
         'upper triangular': 21,
         'lower triangular': 22,
-        'pos def' : 101,
-        'pos def upper': 111,     # the "other" triangle is not referenced
-        'pos def lower': 112,
+        'pos' : 101,
+        'pos upper': 111,     # the "other" triangle is not referenced
+        'pos lower': 112,
     }[assume_a]
 
     # heavy lifting

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -174,7 +174,9 @@ def solve(a, b,lower=False, overwrite_a=False,
            [ 3. , -2.5],
            [ 5. , -4.5]])
     """
-    if assume_a in ['sym', 'her', 'symmetric', 'hermitian', 'diagonal', 'tridiagonal', 'banded', 'banded']:
+    if assume_a in [
+        'sym', 'her', 'symmetric', 'hermitian', 'diagonal', 'tridiagonal', 'banded'
+    ]:
         # TODO: handle these structures in this function
         return solve0(
             a, b, lower=lower, overwrite_a=overwrite_a, overwrite_b=overwrite_b,

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -198,6 +198,8 @@ def solve(a, b,lower=False, overwrite_a=False,
         raise ValueError(f'{assume_a} is not a recognized matrix structure')
 
     a1 = np.atleast_2d(_asarray_validated(a, check_finite=check_finite))
+    b1 = np.atleast_1d(_asarray_validated(b, check_finite=check_finite))
+    a1, b1 = _ensure_dtype_cdsz(a1, b1)   # XXX; b upcasts a?
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
 
     if a1.ndim < 2:
@@ -210,9 +212,6 @@ def solve(a, b,lower=False, overwrite_a=False,
         raise NotImplementedError('scipy.linalg.solve can currently '
                                   'not solve a^T x = b or a^H x = b '
                                   'for complex matrices.')
-    
-    b1 = np.atleast_1d(_asarray_validated(b, check_finite=check_finite))
-    a1, b1 = _ensure_dtype_cdsz(a1, b1)   # XXX; b upcasts a?
 
     if not (a1.flags['ALIGNED'] or a1.dtype.byteorder == '='):
         overwrite_a = True

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -88,10 +88,10 @@ def solve(a, b,lower=False, overwrite_a=False,
 
     Parameters
     ----------
-    a : (..., N, N) array_like
-        Square input data
+    a : array_like, shape (..., N, N)
+        Square left-hand side matrix or a batch of matrices.
     b : (..., N, NRHS) array_like
-        Input data for the right hand side.
+        Input data for the right hand side or a batch of right-hand sides.
     lower : bool, default: False
         Ignored unless ``assume_a`` is one of ``'sym'``, ``'her'``, or ``'pos'``.
         If True, the calculation uses only the data in the lower triangle of `a`;
@@ -116,7 +116,7 @@ def solve(a, b,lower=False, overwrite_a=False,
 
     Returns
     -------
-    x : (N, NRHS) ndarray
+    x : ndarray, shape (N, NRHS) or (..., N)
         The solution array.
 
     Raises
@@ -138,7 +138,7 @@ def solve(a, b,lower=False, overwrite_a=False,
     numpy.dot() behavior and the returned result is still 1-D array.
 
     The general, symmetric, Hermitian and positive definite solutions are
-    obtained via calling ?GESV, ?SYSV, ?HESV, and ?POSV routines of
+    obtained via calling ?GETRF/?GETRS, ?SYSV, ?HESV, and ?POTRF/?POTRS routines of
     LAPACK respectively.
 
     The datatype of the arrays define which solver is called regardless
@@ -153,15 +153,27 @@ def solve(a, b,lower=False, overwrite_a=False,
     >>> import numpy as np
     >>> a = np.array([[3, 2, 0], [1, -1, 0], [0, 5, 1]])
     >>> b = np.array([2, 4, -1])
-    >>> from scipy import linalg
-    >>> x = linalg.solve(a, b)
+    >>> from scipy.linalg import solve
+    >>> x = solve(a, b)
     >>> x
     array([ 2., -2.,  9.])
-    >>> np.dot(a, x) == b
+    >>> a @ x == b
     array([ True,  True,  True], dtype=bool)
 
-    """
+    Batches of matrices are supported, with and without structure detection:
 
+    >>> a = np.arange(12).reshape(3, 2, 2)   # a batch of 3 2x2 matrices
+    >>> A = a.transpose(0, 2, 1) @ a    # A is a batch of 3 positive definite matrices
+    >>> b = np.ones(2)
+    >>> solve(A, b)      # this automatically detects that A is pos.def.
+    array([[ 1. , -0.5],
+           [ 3. , -2.5],
+           [ 5. , -4.5]])
+    >>> solve(A, b, assume_a='pos')   # bypass structucture detection
+    array([[ 1. , -0.5],
+           [ 3. , -2.5],
+           [ 5. , -4.5]])
+    """
     if assume_a in ['sym', 'her', 'symmetric', 'hermitian', 'diagonal', 'tridiagonal', 'banded', 'banded']:
         # TODO: handle these structures in this function
         return solve0(

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -64,7 +64,8 @@ def _find_matrix_structure(a):
 
 
 def solve(a, b,lower=False, overwrite_a=False,
-          overwrite_b=False, check_finite=True, assume_a=None, transposed=False):
+          overwrite_b=False, check_finite=True, assume_a=None,
+          transposed=False):
     """
     Solve the equation ``a @ x = b`` for  ``x``,
     where `a` is a square matrix.
@@ -232,15 +233,6 @@ def solve(a, b,lower=False, overwrite_a=False,
     if a_is_scalar:
         out = b1 / a1
         return out[..., 0] if b_is_1D else out
-
-    print(f"{a1.shape=} {b1.shape=}  {b1.dtype} \n")
-
-
-    # 3. check a, b dtype, cast if needed  (b does not upcast a?)
-    # 4. check a, b flags, copy if needed
-    # 5. check empty a, b
-    # 6. fast path for a.size == 1
-    # 7. check b no more than 2D, k=0
 
     # heavy lifting
     result = _batched_linalg._solve(a1, b1, structure, transposed)

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -118,6 +118,7 @@ py3.extension_module('_batched_linalg',
   [
     'src/_common_array_utils.hh',
     'src/_linalg_inv.hh',
+    'src/_linalg_solve.hh',
     'src/_npymath.hh',
     'src/_batched_linalg_module.cc'
   ],

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -99,9 +99,10 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
     int isSingular = 0;
     St structure = St::NONE;
     int overwrite_a = 0;
+    int transposed = 0;
 
     // Get the input array
-    if (!PyArg_ParseTuple(args, "O!O!|np", &PyArray_Type, (PyObject **)&ap_Am, &PyArray_Type, (PyObject **)&ap_b, &structure, &overwrite_a)) {
+    if (!PyArg_ParseTuple(args, "O!O!|npp", &PyArray_Type, (PyObject **)&ap_Am, &PyArray_Type, (PyObject **)&ap_b, &structure, &transposed, &overwrite_a)) {
         return NULL;
     }
 
@@ -115,7 +116,6 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
         PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
         return NULL;
     }
-
 
     // Sanity check shapes
     int ndim = PyArray_NDIM(ap_Am);
@@ -150,20 +150,19 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-
     void *buf = PyArray_DATA(ap_x);
     switch(typenum) {
         case(NPY_FLOAT):
-            _solve<float>(ap_Am, ap_b, (float *)buf, structure, overwrite_a, &isIllconditioned, &isSingular, &info);
+            _solve<float>(ap_Am, ap_b, (float *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
         case(NPY_DOUBLE):
-            _solve<double>(ap_Am, ap_b, (double *)buf, structure, overwrite_a, &isIllconditioned, &isSingular, &info);
+            _solve<double>(ap_Am, ap_b, (double *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
         case(NPY_CFLOAT):
-            _solve<npy_cfloat>(ap_Am, ap_b, (npy_cfloat *)buf, structure, overwrite_a, &isIllconditioned, &isSingular, &info);
+            _solve<npy_cfloat>(ap_Am, ap_b, (npy_cfloat *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
         case(NPY_CDOUBLE):
-            _solve<npy_cdouble>(ap_Am, ap_b, (npy_cdouble *)buf, structure, overwrite_a, &isIllconditioned, &isSingular, &info);
+            _solve<npy_cdouble>(ap_Am, ap_b, (npy_cdouble *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
         default:
             PYERR(PyExc_RuntimeError, "Unknown array type.")

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -9,7 +9,6 @@
 static PyObject* _linalg_inv_error;
 
 
-
 static PyObject*
 _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
@@ -87,10 +86,108 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
     return Py_BuildValue("Niii", PyArray_Return(ap_Ainv), isIllconditioned, isSingular, info);
 }
 
+
+static PyObject*
+_linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
+
+    PyArrayObject *ap_Am = NULL;
+    PyArrayObject *ap_b = NULL;
+
+    PyArrayObject *ap_x = NULL;
+    int info = 0;
+    int isIllconditioned = 0;
+    int isSingular = 0;
+    St structure = St::NONE;
+    int overwrite_a = 0;
+
+    // Get the input array
+    if (!PyArg_ParseTuple(args, "O!O!|np", &PyArray_Type, (PyObject **)&ap_Am, &PyArray_Type, (PyObject **)&ap_b, &structure, &overwrite_a)) {
+        return NULL;
+    }
+
+    // Check for dtype compatibility & array flags
+    int typenum = PyArray_TYPE(ap_Am);
+    bool dtype_ok = (typenum == NPY_FLOAT)
+                     || (typenum == NPY_DOUBLE)
+                     || (typenum == NPY_CFLOAT)
+                     || (typenum == NPY_CDOUBLE);
+    if(!dtype_ok || !PyArray_ISALIGNED(ap_Am)) {
+        PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
+        return NULL;
+    }
+
+
+    // Sanity check shapes
+    int ndim = PyArray_NDIM(ap_Am);
+    npy_intp* shape = PyArray_SHAPE(ap_Am);
+    if ((ndim < 2) || (shape[ndim - 1] != shape[ndim - 2])) {
+        PYERR(PyExc_ValueError, "Last two dimensions of `a` must be the same.")
+    }
+
+    // At the python call site, 
+    // 1) 1D `b` must have been converted in to 2D, and
+    // 2) batch dimensions of `a` and `b` have been broadcast
+    // Therefore, if `a.shape == (s, p, r, n, n)`, then `b.shape == (s, p, r, n, k)`
+    // where `k` is the number of right-hand-sides.
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+
+    bool dims_match = ndim_b == ndim;
+    if (dims_match) {
+        for (int i=0; i<ndim-1; i++) {
+            dims_match = dims_match && (shape[i] == shape_b[i]);
+        }
+    }
+    if (!dims_match){
+        PyErr_SetString(PyExc_ValueError, "`a` and `b` shape mismatch.");
+        return NULL;
+    }
+
+    // Allocate the output
+    ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim_b, shape_b, typenum);
+    if(!ap_x) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+
+    void *buf = PyArray_DATA(ap_x);
+    switch(typenum) {
+        case(NPY_FLOAT):
+            _solve<float>(ap_Am, ap_b, (float *)buf, structure, overwrite_a, &isIllconditioned, &isSingular, &info);
+            break;
+        case(NPY_DOUBLE):
+            _solve<double>(ap_Am, ap_b, (double *)buf, structure, overwrite_a, &isIllconditioned, &isSingular, &info);
+            break;
+        case(NPY_CFLOAT):
+            _solve<npy_cfloat>(ap_Am, ap_b, (npy_cfloat *)buf, structure, overwrite_a, &isIllconditioned, &isSingular, &info);
+            break;
+        case(NPY_CDOUBLE):
+            _solve<npy_cdouble>(ap_Am, ap_b, (npy_cdouble *)buf, structure, overwrite_a, &isIllconditioned, &isSingular, &info);
+            break;
+        default:
+            PYERR(PyExc_RuntimeError, "Unknown array type.")
+    }
+
+    if(info < 0) {
+        // Either OOM or internal LAPACK error.
+        Py_DECREF(ap_x);
+        PYERR(PyExc_RuntimeError, "Internal LAPACK failure in scipy.linalg.solve.")
+    }
+
+
+    return Py_BuildValue("Niii", PyArray_Return(ap_x), isIllconditioned, isSingular, info);
+}
+
+
+
+
 static char doc_inv[] = ("Compute the matrix inverse.");
+static char doc_solve[] = ("Solve the linear system of equations.");
 
 static struct PyMethodDef inv_module_methods[] = {
   {"_inv", _linalg_inv, METH_VARARGS, doc_inv},
+  {"_solve", _linalg_solve, METH_VARARGS, doc_solve},
   {NULL, NULL, 0, NULL}
 };
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -179,8 +179,6 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
 }
 
 
-
-
 static char doc_inv[] = ("Compute the matrix inverse.");
 static char doc_solve[] = ("Solve the linear system of equations.");
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -108,10 +108,10 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     // Check for dtype compatibility & array flags
     int typenum = PyArray_TYPE(ap_Am);
-    bool dtype_ok = (typenum == NPY_FLOAT)
-                     || (typenum == NPY_DOUBLE)
-                     || (typenum == NPY_CFLOAT)
-                     || (typenum == NPY_CDOUBLE);
+    bool dtype_ok = (typenum == NPY_FLOAT32)
+                     || (typenum == NPY_FLOAT64)
+                     || (typenum == NPY_COMPLEX64)
+                     || (typenum == NPY_COMPLEX128);
     if(!dtype_ok || !PyArray_ISALIGNED(ap_Am)) {
         PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
         return NULL;
@@ -152,17 +152,17 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     void *buf = PyArray_DATA(ap_x);
     switch(typenum) {
-        case(NPY_FLOAT):
+        case(NPY_FLOAT32):
             _solve<float>(ap_Am, ap_b, (float *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
-        case(NPY_DOUBLE):
+        case(NPY_FLOAT64):
             _solve<double>(ap_Am, ap_b, (double *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
-        case(NPY_CFLOAT):
-            _solve<npy_cfloat>(ap_Am, ap_b, (npy_cfloat *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+        case(NPY_COMPLEX64):
+            _solve<npy_complex64>(ap_Am, ap_b, (npy_complex64 *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
-        case(NPY_CDOUBLE):
-            _solve<npy_cdouble>(ap_Am, ap_b, (npy_cdouble *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+        case(NPY_COMPLEX128):
+            _solve<npy_complex128>(ap_Am, ap_b, (npy_complex128 *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
         default:
             PYERR(PyExc_RuntimeError, "Unknown array type.")

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -2,6 +2,7 @@
 #define _LINALG_INV_H
 
 #include "_linalg_inv.hh"
+#include "_linalg_solve.hh"
 #include "_common_array_utils.hh"
 
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -11,25 +11,7 @@
  * declare LAPACK prototypes
  */
 
-
-/* ?GESV */
 extern "C" {
-CBLAS_INT
-BLAS_FUNC(sgesv)(CBLAS_INT *n, CBLAS_INT *nrhs, float a[], CBLAS_INT *lda,
-                 CBLAS_INT ipiv[], float b[], CBLAS_INT *ldb, CBLAS_INT *info
-);
-CBLAS_INT
-BLAS_FUNC(dgesv)(CBLAS_INT *n, CBLAS_INT *nrhs, double a[], CBLAS_INT *lda,
-                 CBLAS_INT ipiv[], double b[], CBLAS_INT *ldb, CBLAS_INT *info
-);
-CBLAS_INT
-BLAS_FUNC(cgesv)(CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat a[], CBLAS_INT *lda,
-                 CBLAS_INT ipiv[], npy_cfloat b[], CBLAS_INT *ldb, CBLAS_INT *info
-);
-CBLAS_INT
-BLAS_FUNC(zgesv)(CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble a[], CBLAS_INT *lda,
-                 CBLAS_INT ipiv[], npy_cdouble b[], CBLAS_INT *ldb, CBLAS_INT *info
-);
 
 /* ?GETRF */
 CBLAS_INT
@@ -118,12 +100,6 @@ void BLAS_FUNC(spocon)(char *uplo, CBLAS_INT *n, float* a, CBLAS_INT *lda, float
 void BLAS_FUNC(dpocon)(char *uplo, CBLAS_INT *n, double* a, CBLAS_INT *lda, double *anorm, double *rcond, double* work, CBLAS_INT* iwork, CBLAS_INT *info);
 void BLAS_FUNC(cpocon)(char *uplo, CBLAS_INT *n, npy_cfloat* a, CBLAS_INT *lda, float *anorm, float *rcond, npy_cfloat* work, float *rwork, CBLAS_INT *info);
 void BLAS_FUNC(zpocon)(char *uplo, CBLAS_INT *n, npy_cdouble* a, CBLAS_INT *lda, double *anorm, double *rcond, npy_cdouble* work, double *rwork, CBLAS_INT *info);
-
-/* ?POSV*/
-void BLAS_FUNC(sposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
-void BLAS_FUNC(dposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
-void BLAS_FUNC(cposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat *a, CBLAS_INT *lda, npy_cfloat *b, CBLAS_INT *ldb, CBLAS_INT *info);
-void BLAS_FUNC(zposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble *a, CBLAS_INT *lda, npy_cdouble *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
 /* ?POTRS*/
 void BLAS_FUNC(spotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
@@ -282,36 +258,6 @@ GEN_POTRS(s, float)
 GEN_POTRS(d, double)
 GEN_POTRS(c, npy_cfloat)
 GEN_POTRS(z, npy_cdouble)
-
-
-// XXX posv, gesv not used?
-
-#define GEN_POSV(PREFIX, TYPE) \
-inline void \
-posv(char* uplo, CBLAS_INT* n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT* info) \
-{ \
-    BLAS_FUNC(PREFIX ## posv)(uplo, n, nrhs, a, lda, b, ldb, info); \
-};
-
-GEN_POSV(s, float)
-GEN_POSV(d, double)
-GEN_POSV(c, npy_cfloat)
-GEN_POSV(z, npy_cdouble)
-
-
-#define GEN_GESV(PREFIX, TYPE) \
-inline void \
-gesv(CBLAS_INT* n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *b, CBLAS_INT *ldb, CBLAS_INT* info) \
-{ \
-    BLAS_FUNC(PREFIX ## gesv)(n, nrhs, a, lda, ipiv, b, ldb, info); \
-};
-
-GEN_GESV(s, float)
-GEN_GESV(d, double)
-GEN_GESV(c, npy_cfloat)
-GEN_GESV(z, npy_cdouble)
-
-
 
 
 /*

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -23,11 +23,11 @@ BLAS_FUNC(dgetrf)(CBLAS_INT *m, CBLAS_INT *n, double a[], CBLAS_INT *lda,
                   CBLAS_INT ipiv[], CBLAS_INT *info
 );
 CBLAS_INT
-BLAS_FUNC(cgetrf)(CBLAS_INT *m, CBLAS_INT *n, npy_cfloat a[], CBLAS_INT *lda,
+BLAS_FUNC(cgetrf)(CBLAS_INT *m, CBLAS_INT *n, npy_complex64 a[], CBLAS_INT *lda,
                   CBLAS_INT ipiv[], CBLAS_INT *info
 );
 CBLAS_INT
-BLAS_FUNC(zgetrf)(CBLAS_INT *m, CBLAS_INT *n, npy_cdouble a[], CBLAS_INT *lda,
+BLAS_FUNC(zgetrf)(CBLAS_INT *m, CBLAS_INT *n, npy_complex128 a[], CBLAS_INT *lda,
                   CBLAS_INT ipiv[], CBLAS_INT *info
 );
 
@@ -42,77 +42,77 @@ BLAS_FUNC(dgetri)(CBLAS_INT *n, double a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
                   double work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
 CBLAS_INT
-BLAS_FUNC(cgetri)(CBLAS_INT *n, npy_cfloat a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
-                  npy_cfloat work[], CBLAS_INT *lwork, CBLAS_INT *info
+BLAS_FUNC(cgetri)(CBLAS_INT *n, npy_complex64 a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
+                  npy_complex64 work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
 CBLAS_INT
-BLAS_FUNC(zgetri)(CBLAS_INT *n, npy_cdouble a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
-                  npy_cdouble work[], CBLAS_INT *lwork, CBLAS_INT *info
+BLAS_FUNC(zgetri)(CBLAS_INT *n, npy_complex128 a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
+                  npy_complex128 work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
 
 
 /* ?GETRS */
 void BLAS_FUNC(sgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
 void BLAS_FUNC(dgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
-void BLAS_FUNC(cgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_cfloat *b, CBLAS_INT *ldb, CBLAS_INT *info);
-void BLAS_FUNC(zgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_cdouble *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(cgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
 
 /* ?GECON */
 void BLAS_FUNC(sgecon)(char* norm, CBLAS_INT* n, float* a,       CBLAS_INT* lda, float* anorm,  float* rcond,  float* work,       CBLAS_INT* iwork, CBLAS_INT* info);
 void BLAS_FUNC(dgecon)(char* norm, CBLAS_INT* n, double* a,      CBLAS_INT* lda, double* anorm, double* rcond, double* work,      CBLAS_INT* iwork, CBLAS_INT* info);
-void BLAS_FUNC(cgecon)(char* norm, CBLAS_INT* n, npy_cfloat* a,  CBLAS_INT* lda, float* anorm,  float* rcond,  npy_cfloat* work,  float* rwork,     CBLAS_INT* info);
-void BLAS_FUNC(zgecon)(char* norm, CBLAS_INT* n, npy_cdouble* a, CBLAS_INT* lda, double* anorm, double* rcond, npy_cdouble* work, double* rwork,    CBLAS_INT* info);
+void BLAS_FUNC(cgecon)(char* norm, CBLAS_INT* n, npy_complex64* a,  CBLAS_INT* lda, float* anorm,  float* rcond,  npy_complex64* work,  float* rwork,     CBLAS_INT* info);
+void BLAS_FUNC(zgecon)(char* norm, CBLAS_INT* n, npy_complex128* a, CBLAS_INT* lda, double* anorm, double* rcond, npy_complex128* work, double* rwork,    CBLAS_INT* info);
 
 
 /* ?TRTRI */
 void BLAS_FUNC(strtri)(char *uplo, char *diag, CBLAS_INT *n, float* a, CBLAS_INT *lda, CBLAS_INT *info);
 void BLAS_FUNC(dtrtri)(char *uplo, char *diag, CBLAS_INT *n, double* a, CBLAS_INT *lda, CBLAS_INT *info);
-void BLAS_FUNC(ctrtri)(char *uplo, char *diag, CBLAS_INT *n, npy_cfloat* a, CBLAS_INT *lda, CBLAS_INT *info);
-void BLAS_FUNC(ztrtri)(char *uplo, char *diag, CBLAS_INT *n, npy_cdouble* a, CBLAS_INT *lda, CBLAS_INT *info);
+void BLAS_FUNC(ctrtri)(char *uplo, char *diag, CBLAS_INT *n, npy_complex64* a, CBLAS_INT *lda, CBLAS_INT *info);
+void BLAS_FUNC(ztrtri)(char *uplo, char *diag, CBLAS_INT *n, npy_complex128* a, CBLAS_INT *lda, CBLAS_INT *info);
 
 /* ?TRCON */
 void BLAS_FUNC(strcon)(char *norm, char *uplo, char *diag, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *rcond, float *work, CBLAS_INT *iwork, CBLAS_INT *info);
 void BLAS_FUNC(dtrcon)(char *norm, char *uplo, char *diag, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *rcond, double *work, CBLAS_INT *iwork, CBLAS_INT *info);
-void BLAS_FUNC(ctrcon)(char *norm, char *uplo, char *diag, CBLAS_INT *n, npy_cfloat *a, CBLAS_INT *lda, float *rcond, npy_cfloat *work, float *rwork, CBLAS_INT *info);
-void BLAS_FUNC(ztrcon)(char *norm, char *uplo, char *diag, CBLAS_INT *n, npy_cdouble *a, CBLAS_INT *lda, double *rcond, npy_cdouble *work, double *rwork, CBLAS_INT *info);
+void BLAS_FUNC(ctrcon)(char *norm, char *uplo, char *diag, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, float *rcond, npy_complex64 *work, float *rwork, CBLAS_INT *info);
+void BLAS_FUNC(ztrcon)(char *norm, char *uplo, char *diag, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, double *rcond, npy_complex128 *work, double *rwork, CBLAS_INT *info);
 
 /* ?TRTRS */
 void BLAS_FUNC(strtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
 void BLAS_FUNC(dtrtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
-void BLAS_FUNC(ctrtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat *a, CBLAS_INT *lda, npy_cfloat *b, CBLAS_INT *ldb, CBLAS_INT *info);
-void BLAS_FUNC(ztrtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble *a, CBLAS_INT *lda, npy_cdouble *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(ctrtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(ztrtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
 /* ?POTRF */
 void BLAS_FUNC(spotrf)(char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *info);
 void BLAS_FUNC(dpotrf)(char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, CBLAS_INT *info);
-void BLAS_FUNC(cpotrf)(char *uplo, CBLAS_INT *n, npy_cfloat *a, CBLAS_INT *lda, CBLAS_INT *info);
-void BLAS_FUNC(zpotrf)(char *uplo, CBLAS_INT *n, npy_cdouble *a, CBLAS_INT *lda, CBLAS_INT *info);
+void BLAS_FUNC(cpotrf)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *info);
+void BLAS_FUNC(zpotrf)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *info);
 
 /* ?POTRI */
 void BLAS_FUNC(spotri)(char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *info);
 void BLAS_FUNC(dpotri)(char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, CBLAS_INT *info);
-void BLAS_FUNC(cpotri)(char *uplo, CBLAS_INT *n, npy_cfloat *a, CBLAS_INT *lda, CBLAS_INT *info);
-void BLAS_FUNC(zpotri)(char *uplo, CBLAS_INT *n, npy_cdouble *a, CBLAS_INT *lda, CBLAS_INT *info);
+void BLAS_FUNC(cpotri)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *info);
+void BLAS_FUNC(zpotri)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *info);
 
 /* ?POCON */
 void BLAS_FUNC(spocon)(char *uplo, CBLAS_INT *n, float* a, CBLAS_INT *lda, float *anorm, float *rcond, float* work, CBLAS_INT* iwork, CBLAS_INT *info);
 void BLAS_FUNC(dpocon)(char *uplo, CBLAS_INT *n, double* a, CBLAS_INT *lda, double *anorm, double *rcond, double* work, CBLAS_INT* iwork, CBLAS_INT *info);
-void BLAS_FUNC(cpocon)(char *uplo, CBLAS_INT *n, npy_cfloat* a, CBLAS_INT *lda, float *anorm, float *rcond, npy_cfloat* work, float *rwork, CBLAS_INT *info);
-void BLAS_FUNC(zpocon)(char *uplo, CBLAS_INT *n, npy_cdouble* a, CBLAS_INT *lda, double *anorm, double *rcond, npy_cdouble* work, double *rwork, CBLAS_INT *info);
+void BLAS_FUNC(cpocon)(char *uplo, CBLAS_INT *n, npy_complex64* a, CBLAS_INT *lda, float *anorm, float *rcond, npy_complex64* work, float *rwork, CBLAS_INT *info);
+void BLAS_FUNC(zpocon)(char *uplo, CBLAS_INT *n, npy_complex128* a, CBLAS_INT *lda, double *anorm, double *rcond, npy_complex128* work, double *rwork, CBLAS_INT *info);
 
 /* ?POTRS*/
 void BLAS_FUNC(spotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
 void BLAS_FUNC(dpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
-void BLAS_FUNC(cpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat *a, CBLAS_INT *lda, npy_cfloat *b, CBLAS_INT *ldb, CBLAS_INT *info);
-void BLAS_FUNC(zpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble *a, CBLAS_INT *lda, npy_cdouble *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(cpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
 
 } // extern "C"
 
 
 /*
- * Generate type overloads, to map from C array types (float, double, npy_cfloat, npy_cdouble)
+ * Generate type overloads, to map from C array types (float, double, npy_complex64, npy_complex128)
  * to LAPACK prefixes, "sdcz".
  */
 #define GEN_GETRF(PREFIX, TYPE) \
@@ -124,8 +124,8 @@ getrf(CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, CBLA
 
 GEN_GETRF(s,float)
 GEN_GETRF(d,double)
-GEN_GETRF(c,npy_cfloat)
-GEN_GETRF(z,npy_cdouble)
+GEN_GETRF(c,npy_complex64)
+GEN_GETRF(z,npy_complex128)
 
 
 #define GEN_GETRS(PREFIX, TYPE) \
@@ -137,8 +137,8 @@ getrs(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, CBLAS
 
 GEN_GETRS(s,float)
 GEN_GETRS(d,double)
-GEN_GETRS(c,npy_cfloat)
-GEN_GETRS(z,npy_cdouble)
+GEN_GETRS(c,npy_complex64)
+GEN_GETRS(z,npy_complex128)
 
 
 #define GEN_GETRI(PREFIX, TYPE) \
@@ -150,8 +150,8 @@ getri(CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_
 
 GEN_GETRI(s,float)
 GEN_GETRI(d,double)
-GEN_GETRI(c,npy_cfloat)
-GEN_GETRI(z,npy_cdouble)
+GEN_GETRI(c,npy_complex64)
+GEN_GETRI(z,npy_complex128)
 
 
 // NB: iwork for real arrays or rwork for complex arrays
@@ -164,8 +164,8 @@ gecon(char* norm, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, RTYPE* anorm, RTYPE* r
 
 GEN_GECON(s, float, float, CBLAS_INT)
 GEN_GECON(d, double, double, CBLAS_INT)
-GEN_GECON(c, npy_cfloat, float, float)
-GEN_GECON(z, npy_cdouble, double, double)
+GEN_GECON(c, npy_complex64, float, float)
+GEN_GECON(z, npy_complex128, double, double)
 
 
 #define GEN_TRTRI(PREFIX, TYPE) \
@@ -177,8 +177,8 @@ trtri(char* uplo, char *diag, CBLAS_INT* n, TYPE* a, CBLAS_INT* lda, CBLAS_INT* 
 
 GEN_TRTRI(s, float)
 GEN_TRTRI(d, double)
-GEN_TRTRI(c, npy_cfloat)
-GEN_TRTRI(z, npy_cdouble)
+GEN_TRTRI(c, npy_complex64)
+GEN_TRTRI(z, npy_complex128)
 
 
 #define GEN_TRCON(PREFIX, CTYPE, RTYPE, WTYPE) \
@@ -190,8 +190,8 @@ trcon(char* norm, char *uplo, char *diag, CBLAS_INT *n, CTYPE *a, CBLAS_INT *lda
 
 GEN_TRCON(s, float, float, CBLAS_INT)
 GEN_TRCON(d, double, double, CBLAS_INT)
-GEN_TRCON(c, npy_cfloat, float, float)
-GEN_TRCON(z, npy_cdouble, double, double)
+GEN_TRCON(c, npy_complex64, float, float)
+GEN_TRCON(z, npy_complex128, double, double)
 
 
 #define GEN_TRTRS(PREFIX, TYPE) \
@@ -203,8 +203,8 @@ trtrs(char* uplo, char *trans, char *diag, CBLAS_INT* n, CBLAS_INT* nrhs, TYPE* 
 
 GEN_TRTRS(s, float)
 GEN_TRTRS(d, double)
-GEN_TRTRS(c, npy_cfloat)
-GEN_TRTRS(z, npy_cdouble)
+GEN_TRTRS(c, npy_complex64)
+GEN_TRTRS(z, npy_complex128)
 
 
 #define GEN_POTRF(PREFIX, TYPE) \
@@ -216,8 +216,8 @@ potrf(char* uplo, CBLAS_INT* n, TYPE* a, CBLAS_INT* lda, CBLAS_INT* info) \
 
 GEN_POTRF(s, float)
 GEN_POTRF(d, double)
-GEN_POTRF(c, npy_cfloat)
-GEN_POTRF(z, npy_cdouble)
+GEN_POTRF(c, npy_complex64)
+GEN_POTRF(z, npy_complex128)
 
 
 #define GEN_POTRI(PREFIX, TYPE) \
@@ -229,8 +229,8 @@ potri(char* uplo, CBLAS_INT* n, TYPE* a, CBLAS_INT* lda, CBLAS_INT* info) \
 
 GEN_POTRI(s, float)
 GEN_POTRI(d, double)
-GEN_POTRI(c, npy_cfloat)
-GEN_POTRI(z, npy_cdouble)
+GEN_POTRI(c, npy_complex64)
+GEN_POTRI(z, npy_complex128)
 
 
 // NB: iwork for real arrays or rwork for complex arrays
@@ -243,8 +243,8 @@ pocon(char* uplo, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, RTYPE* anorm, RTYPE* r
 
 GEN_POCON(s, float, float, CBLAS_INT)
 GEN_POCON(d, double, double, CBLAS_INT)
-GEN_POCON(c, npy_cfloat, float, float)
-GEN_POCON(z, npy_cdouble, double, double)
+GEN_POCON(c, npy_complex64, float, float)
+GEN_POCON(z, npy_complex128, double, double)
 
 
 #define GEN_POTRS(PREFIX, TYPE) \
@@ -256,8 +256,8 @@ potrs(char* uplo, CBLAS_INT* n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *
 
 GEN_POTRS(s, float)
 GEN_POTRS(d, double)
-GEN_POTRS(c, npy_cfloat)
-GEN_POTRS(z, npy_cdouble)
+GEN_POTRS(c, npy_complex64)
+GEN_POTRS(z, npy_complex128)
 
 
 /*

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -125,6 +125,12 @@ void BLAS_FUNC(dposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLA
 void BLAS_FUNC(cposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat *a, CBLAS_INT *lda, npy_cfloat *b, CBLAS_INT *ldb, CBLAS_INT *info);
 void BLAS_FUNC(zposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble *a, CBLAS_INT *lda, npy_cdouble *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
+/* ?POTRS*/
+void BLAS_FUNC(spotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(dpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(cpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat *a, CBLAS_INT *lda, npy_cfloat *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble *a, CBLAS_INT *lda, npy_cdouble *b, CBLAS_INT *ldb, CBLAS_INT *info);
+
 
 } // extern "C"
 
@@ -264,6 +270,21 @@ GEN_POCON(d, double, double, CBLAS_INT)
 GEN_POCON(c, npy_cfloat, float, float)
 GEN_POCON(z, npy_cdouble, double, double)
 
+
+#define GEN_POTRS(PREFIX, TYPE) \
+inline void \
+potrs(char* uplo, CBLAS_INT* n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## potrs)(uplo, n, nrhs, a, lda, b, ldb, info); \
+};
+
+GEN_POTRS(s, float)
+GEN_POTRS(d, double)
+GEN_POTRS(c, npy_cfloat)
+GEN_POTRS(z, npy_cdouble)
+
+
+// XXX posv, gesv not used?
 
 #define GEN_POSV(PREFIX, TYPE) \
 inline void \

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -260,6 +260,64 @@ GEN_POTRS(c, npy_complex64)
 GEN_POTRS(z, npy_complex128)
 
 
+
+// Structure tags; python side maps assume_a strings to these values
+enum St : Py_ssize_t
+{
+    NONE = -1,
+    GENERAL = 0,
+    UPPER_TRIANGULAR = 21,
+    LOWER_TRIANGULAR = 22,
+    POS_DEF = 101,
+    POS_DEF_UPPER = 111,
+    POS_DEF_LOWER = 112,
+};
+
+
+/*
+ * Copy n-by-m slice from slice_ptr to dst.
+ */
+template<typename T>
+void copy_slice(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp m, const npy_intp s2, const npy_intp s1) {
+
+    for (npy_intp i = 0; i < n; i++) {
+        for (npy_intp j = 0; j < m; j++) {
+            dst[i * m + j] = *(slice_ptr + (i*s2/sizeof(T)) + (j*s1/sizeof(T)));
+        }
+    }
+}
+
+
+/*
+ * Copy n-by-m C-order slice from slice_ptr to dst in F-order.
+ */
+template<typename T>
+void copy_slice_F(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp m, const npy_intp s2, const npy_intp s1) {
+
+    for (npy_intp i = 0; i < n; i++) {
+        for (npy_intp j = 0; j < m; j++) {
+            dst[i + j*n] = *(slice_ptr + (i*s2/sizeof(T)) + (j*s1/sizeof(T)));  // == src[i*m + j]
+        }
+    }
+}
+
+/*
+ * Copy n-by-m F-ordered `src` to C-ordered `dst`.
+ */
+template<typename T>
+void copy_slice_F_to_C(T* dst, const T* src, const npy_intp n, const npy_intp m) {
+
+    for (npy_intp i = 0; i < n; i++) {
+        for (npy_intp j = 0; j < m; j++) {
+            dst[i*m + j] = src[i + j*n];
+        }
+    }
+}
+
+
+
+
+
 /*
  * 1-norm of a matrix
  */

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -69,6 +69,13 @@ BLAS_FUNC(zgetri)(CBLAS_INT *n, npy_cdouble a[], CBLAS_INT *lda, CBLAS_INT ipiv[
 );
 
 
+/* ?GETRS */
+void BLAS_FUNC(sgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(dgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(cgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_cfloat *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zgetrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_cdouble *b, CBLAS_INT *ldb, CBLAS_INT *info);
+
+
 /* ?GECON */
 void BLAS_FUNC(sgecon)(char* norm, CBLAS_INT* n, float* a,       CBLAS_INT* lda, float* anorm,  float* rcond,  float* work,       CBLAS_INT* iwork, CBLAS_INT* info);
 void BLAS_FUNC(dgecon)(char* norm, CBLAS_INT* n, double* a,      CBLAS_INT* lda, double* anorm, double* rcond, double* work,      CBLAS_INT* iwork, CBLAS_INT* info);
@@ -88,6 +95,12 @@ void BLAS_FUNC(dtrcon)(char *norm, char *uplo, char *diag, CBLAS_INT *n, double 
 void BLAS_FUNC(ctrcon)(char *norm, char *uplo, char *diag, CBLAS_INT *n, npy_cfloat *a, CBLAS_INT *lda, float *rcond, npy_cfloat *work, float *rwork, CBLAS_INT *info);
 void BLAS_FUNC(ztrcon)(char *norm, char *uplo, char *diag, CBLAS_INT *n, npy_cdouble *a, CBLAS_INT *lda, double *rcond, npy_cdouble *work, double *rwork, CBLAS_INT *info);
 
+/* ?TRTRS */
+void BLAS_FUNC(strtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(dtrtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(ctrtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat *a, CBLAS_INT *lda, npy_cfloat *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(ztrtrs)(char *uplo, char *trans, char *diag, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble *a, CBLAS_INT *lda, npy_cdouble *b, CBLAS_INT *ldb, CBLAS_INT *info);
+
 /* ?POTRF */
 void BLAS_FUNC(spotrf)(char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *info);
 void BLAS_FUNC(dpotrf)(char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, CBLAS_INT *info);
@@ -105,6 +118,13 @@ void BLAS_FUNC(spocon)(char *uplo, CBLAS_INT *n, float* a, CBLAS_INT *lda, float
 void BLAS_FUNC(dpocon)(char *uplo, CBLAS_INT *n, double* a, CBLAS_INT *lda, double *anorm, double *rcond, double* work, CBLAS_INT* iwork, CBLAS_INT *info);
 void BLAS_FUNC(cpocon)(char *uplo, CBLAS_INT *n, npy_cfloat* a, CBLAS_INT *lda, float *anorm, float *rcond, npy_cfloat* work, float *rwork, CBLAS_INT *info);
 void BLAS_FUNC(zpocon)(char *uplo, CBLAS_INT *n, npy_cdouble* a, CBLAS_INT *lda, double *anorm, double *rcond, npy_cdouble* work, double *rwork, CBLAS_INT *info);
+
+/* ?POSV*/
+void BLAS_FUNC(sposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(dposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(cposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cfloat *a, CBLAS_INT *lda, npy_cfloat *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zposv)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_cdouble *a, CBLAS_INT *lda, npy_cdouble *b, CBLAS_INT *ldb, CBLAS_INT *info);
+
 
 } // extern "C"
 
@@ -124,6 +144,20 @@ GEN_GETRF(s,float)
 GEN_GETRF(d,double)
 GEN_GETRF(c,npy_cfloat)
 GEN_GETRF(z,npy_cdouble)
+
+
+#define GEN_GETRS(PREFIX, TYPE) \
+inline void \
+getrs(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## getrs)(trans, n, nrhs, a, lda, ipiv, b, ldb, info); \
+};
+
+GEN_GETRS(s,float)
+GEN_GETRS(d,double)
+GEN_GETRS(c,npy_cfloat)
+GEN_GETRS(z,npy_cdouble)
+
 
 #define GEN_GETRI(PREFIX, TYPE) \
 inline void \
@@ -178,6 +212,19 @@ GEN_TRCON(c, npy_cfloat, float, float)
 GEN_TRCON(z, npy_cdouble, double, double)
 
 
+#define GEN_TRTRS(PREFIX, TYPE) \
+inline void \
+trtrs(char* uplo, char *trans, char *diag, CBLAS_INT* n, CBLAS_INT* nrhs, TYPE* a, CBLAS_INT* lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## trtrs)(uplo, trans, diag, n, nrhs, a, lda, b, ldb, info); \
+};
+
+GEN_TRTRS(s, float)
+GEN_TRTRS(d, double)
+GEN_TRTRS(c, npy_cfloat)
+GEN_TRTRS(z, npy_cdouble)
+
+
 #define GEN_POTRF(PREFIX, TYPE) \
 inline void \
 potrf(char* uplo, CBLAS_INT* n, TYPE* a, CBLAS_INT* lda, CBLAS_INT* info) \
@@ -216,6 +263,34 @@ GEN_POCON(s, float, float, CBLAS_INT)
 GEN_POCON(d, double, double, CBLAS_INT)
 GEN_POCON(c, npy_cfloat, float, float)
 GEN_POCON(z, npy_cdouble, double, double)
+
+
+#define GEN_POSV(PREFIX, TYPE) \
+inline void \
+posv(char* uplo, CBLAS_INT* n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## posv)(uplo, n, nrhs, a, lda, b, ldb, info); \
+};
+
+GEN_POSV(s, float)
+GEN_POSV(d, double)
+GEN_POSV(c, npy_cfloat)
+GEN_POSV(z, npy_cdouble)
+
+
+#define GEN_GESV(PREFIX, TYPE) \
+inline void \
+gesv(CBLAS_INT* n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *b, CBLAS_INT *ldb, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## gesv)(n, nrhs, a, lda, ipiv, b, ldb, info); \
+};
+
+GEN_GESV(s, float)
+GEN_GESV(d, double)
+GEN_GESV(c, npy_cfloat)
+GEN_GESV(z, npy_cdouble)
+
+
 
 
 /*
@@ -266,7 +341,7 @@ norm1_sym_herm_upper(T* A, T* work, const npy_intp n)
             temp = std::abs(pA[i*n + j]);
             rwork[j] += temp;
             rwork[i] += temp;
-        } 
+        }
     }
     temp = 0.0;
     for (i = 0; i < n; i++) { if (rwork[i] > temp) { temp = rwork[i]; } }
@@ -309,7 +384,7 @@ norm1_sym_herm(char uplo, T *A, T *work, const npy_intp n) {
     // NB: transpose for the F order
     if (uplo == 'U') {return norm1_sym_herm_lower(A, work, n);}
     else if (uplo == 'L') {return norm1_sym_herm_upper(A, work, n);}
-    else {throw std::runtime_error("uplo at norms");} 
+    else {throw std::runtime_error("uplo at norms");}
 }
 
 

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -570,12 +570,6 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
         T *slice_ptr_b = (T *)(bm_data + (offset/sizeof(T)));
         copy_slice_F(data_b, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
 
-        std::cerr<< "2 data_b = ";
-        for(int i=0; i<n*nrhs; i++){
-            std::cerr << data_b[i] << ", ";
-        }
-        std::cerr << "\n";
-
         // detect the structure if not given
         slice_structure = structure;
 
@@ -607,11 +601,6 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
             case St::UPPER_TRIANGULAR:
             case St::LOWER_TRIANGULAR:
             {
-
-                std::cerr << "TRIANGULAR @ " << idx << " uplo = "<< uplo << " uband = "<< upper_band << " lband = "<< lower_band<<"\n";
-                std::cerr << "structure = " << slice_structure << "\n";
-                std::cerr << "nrhs = " << int_nrhs<<"\n";
-
                 char diag = 'N';
                 *info = solve_slice_triangular(uplo, diag, intn, int_nrhs, data, data_b, trans, work, irwork, isIllconditioned, isSingular);
 
@@ -621,9 +610,6 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
             }
             case St::POS_DEF:
             {
-
-                std::cerr << "POS DEF @ " << idx << "\n";
-
                 *info = solve_slice_cholesky(uplo, intn, int_nrhs, data, data_b, work, irwork, isIllconditioned, isSingular);
 
                 if ((*info == 0) || (*isSingular == 0) ) {
@@ -632,7 +618,7 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
                     break;
                 }
                 else { // potrf failed
-                    if(posdef_fallback) {   // FIXME: test the fallback
+                    if(posdef_fallback) {
                         // restore
                         copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
                         swap_cf(scratch, data, n, n, n);
@@ -647,8 +633,6 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
             }
             default:
             {
-
-                std::cerr << "GENERAL @ " << idx << "\n";
                 // general matrix inverse
                 *info = solve_slice_general(intn, int_nrhs, data, ipiv, data_b, trans, irwork, work, lwork, isIllconditioned, isSingular);
             }

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -24,14 +24,14 @@ enum St : Py_ssize_t
 
 
 /*
- * Copy n-by-n slice from slice_ptr to dst.
+ * Copy n-by-m slice from slice_ptr to dst.
  */
 template<typename T>
-void copy_slice(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp s2, const npy_intp s1) {
+void copy_slice(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp m, const npy_intp s2, const npy_intp s1) {
 
     for (npy_intp i = 0; i < n; i++) {
-        for (npy_intp j = 0; j < n; j++) {
-            dst[i * n + j] = *(slice_ptr + (i*s2/sizeof(T)) + (j*s1/sizeof(T)));
+        for (npy_intp j = 0; j < m; j++) {
+            dst[i * m + j] = *(slice_ptr + (i*s2/sizeof(T)) + (j*s1/sizeof(T)));
         }
     }
 }
@@ -54,7 +54,7 @@ inline CBLAS_INT invert_slice_general(
 
     if (info == 0){
         // getrf success, check the condition number
-        gecon(&norm, &N, data, &N, &anorm, &rcond, work, irwork, &info);      
+        gecon(&norm, &N, data, &N, &anorm, &rcond, work, irwork, &info);
 
         if (info >= 0) {
             *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
@@ -132,6 +132,43 @@ inline CBLAS_INT invert_slice_triangular(
             *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
         }
     }
+    return info;
+}
+
+
+// Dense array solve with getrf, gecon and getrs
+template<typename T>
+inline CBLAS_INT solve_slice_general(
+    CBLAS_INT N, CBLAS_INT NRHS, T *data, CBLAS_INT *ipiv, T *b_data, void *irwork, T *work, CBLAS_INT lwork,
+    int* isIllconditioned, int* isSingular
+) {
+    using real_type = typename type_traits<T>::real_type;
+
+    CBLAS_INT info;
+    char norm = '1';
+    real_type rcond;
+    real_type anorm = norm1_(data, work, (npy_intp)N);
+
+    getrf(&N, &N, data, &N, ipiv, &info);
+
+    if (info == 0){
+        // getrf success, check the condition number
+        gecon(&norm, &N, data, &N, &anorm, &rcond, work, irwork, &info);
+
+        if (info >= 0) {
+            *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+
+            // finally, solve
+            char trans = 'N';
+            getrs(&trans, &N, &NRHS, data, &N, ipiv, b_data, &N, &info);
+            *isSingular = (info > 0);
+        }
+    }
+    else if (info > 0) {
+        // trf detected singularity
+        *isSingular = 1;
+    }
+
     return info;
 }
 
@@ -239,7 +276,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
             temp_idx /= shape[i];
         }
         T* slice_ptr = (T *)(Am_data + (offset/sizeof(T)));
-        copy_slice(scratch, slice_ptr, n, strides[ndim-2], strides[ndim-1]); // XXX: make it in one go
+        copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]); // XXX: make it in one go
         swap_cf(scratch, data, n, n, n);
 
         // detect the structure if not given
@@ -291,7 +328,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
                 else { // potrf failed
                     if(posdef_fallback) {
                         // restore
-                        copy_slice(scratch, slice_ptr, n, strides[ndim-2], strides[ndim-1]);
+                        copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
                         swap_cf(scratch, data, n, n, n);
 
                         // no break: fall back to the general solver
@@ -312,10 +349,214 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
         if (*isSingular == 1) {
             // nan_matrix(data, n);
             goto free_exit;     // fail fast and loud
-        } 
+        }
 
         // Swap back to original order
         swap_cf(data, &ret_data[idx*n*n], n, n, n);
+    }
+
+free_exit:
+    free(buffer);
+    free(irwork);
+    free(ipiv);
+    return;
+}
+
+
+// //// SOLVE /// //
+
+
+template<typename T>
+void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int overwrite_a, int* isIllconditioned, int* isSingular, int* info)
+{
+    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+
+    *isIllconditioned = 0;
+    *isSingular = 0;
+    npy_intp lower_band = 0, upper_band = 0;
+    bool is_symm = false;
+    char uplo;
+    St slice_structure = St::NONE;
+    bool posdef_fallback = true;
+
+    // --------------------------------------------------------------------
+    // Input Array Attributes
+    // --------------------------------------------------------------------
+    T* Am_data = (T *)PyArray_DATA(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);              // Number of dimensions
+    npy_intp* shape = PyArray_SHAPE(ap_Am);      // Array shape
+    npy_intp n = shape[ndim - 1];                // Slice size
+    npy_intp* strides = PyArray_STRIDES(ap_Am);
+    // Get the number of slices to traverse if more than one; np.prod(shape[:-2])
+    npy_intp outer_size = 1;
+    if (ndim > 2)
+    {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
+    }
+
+    T *bm_data = (T *)PyArray_DATA(ap_b);
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+    npy_intp *strides_b = PyArray_STRIDES(ap_b);
+    npy_intp nrhs = PyArray_DIM(ap_b, ndim_b -1); // Number of right-hand-sides
+
+    // --------------------------------------------------------------------
+    // Workspace computation and allocation
+    // --------------------------------------------------------------------
+    T tmp = numeric_limits<T>::zero;
+    CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs, lwork = -1;
+
+    lwork = 4*n; // gecon needs at least 4*n
+    T* buffer = (T *)malloc((2*n*n + 2*n*nrhs + lwork)*sizeof(T));
+    if (NULL == buffer) { *info = -101; return; }
+
+    // Chop the buffer into parts, one for data and one for work
+    T* data = &buffer[0];
+    T* scratch = &buffer[n*n];
+
+    T *data_b = &buffer[2*n*n];
+    T *scratch_b = &buffer[2*n*n + n*nrhs];
+
+    T* work = &buffer[2*n*n + 2*n*nrhs];
+
+    CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
+    if (ipiv == NULL) { free(ipiv); *info = -102; return; }
+
+    // {ge,po,tr}con need rwork or iwork
+    void *irwork;
+    if (type_traits<T>::is_complex) {
+        irwork = malloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
+    } else {
+        irwork = malloc(n*sizeof(CBLAS_INT));
+    }
+    if (irwork == NULL) { free(irwork); *info = -102; return; }
+
+    // normalize the structure detection inputs
+    uplo = 'U';
+    if (structure == St::POS_DEF) {
+        uplo = 'U';
+        posdef_fallback = false;
+    }
+    else {
+        if (structure == St::POS_DEF_UPPER) {
+            structure = St::POS_DEF;
+            uplo = 'U';
+            posdef_fallback = false;
+        }
+        else if (structure == St::POS_DEF_LOWER) {
+            structure = St::POS_DEF;
+            uplo = 'L';
+            posdef_fallback = false;
+        }
+    }
+    if (structure == St::LOWER_TRIANGULAR) {
+        uplo = 'L';
+    }
+    else if (structure == St::UPPER_TRIANGULAR) {
+        uplo = 'U';
+    }
+
+    // Main loop to traverse the slices
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+
+        npy_intp offset = 0;
+        npy_intp temp_idx = idx;
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset += (temp_idx % shape[i]) * strides[i];
+            temp_idx /= shape[i];
+        }
+        T* slice_ptr = (T *)(Am_data + (offset/sizeof(T)));
+        copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]); // XXX: make it in one go
+        swap_cf(scratch, data, n, n, n);
+
+        // copy the r.h.s, too; XXX: dedupe
+        offset = 0;
+        temp_idx = idx;
+        for (int i = ndim_b - 3; i >= 0; i--) {
+            offset += (temp_idx % shape_b[i]) * strides_b[i];
+            temp_idx /= shape_b[i];
+        }
+        T *slice_ptr_b = (T *)(bm_data + (offset/sizeof(T)));
+        copy_slice(scratch_b, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+        swap_cf(scratch_b, data_b, n, nrhs, nrhs);  // XXX: the last arg is the number of columns, really?
+
+        // detect the structure if not given
+        slice_structure = structure;
+/*
+        if (slice_structure == St::NONE) {
+            // Get the bandwidth of the slice
+            bandwidth(data, n, n, &lower_band, &upper_band);
+
+            if(lower_band == 0) {
+                slice_structure = St::UPPER_TRIANGULAR;
+                uplo = 'U';
+            } else if (upper_band == 0) {
+                slice_structure = St::LOWER_TRIANGULAR;
+                uplo = 'L';
+            } else {
+                // Check if symmetric/hermitian
+                is_symm = is_sym_herm(data, n);
+                if (is_symm) {
+                    slice_structure = St::POS_DEF;
+                    uplo = 'U';
+                }
+                else {
+                    // give up auto-detection
+                    slice_structure = St::GENERAL;
+                }
+            }
+        }
+*/
+        slice_structure = St::GENERAL; // FIXME
+
+        switch(slice_structure) {
+            case St::UPPER_TRIANGULAR:
+            case St::LOWER_TRIANGULAR:
+            {
+                char diag = 'N';
+                *info = invert_slice_triangular(uplo, diag, intn, data, work, irwork, isIllconditioned, isSingular);
+
+                if ((*info < 0) || (*isSingular )) { goto free_exit;}
+                zero_other_triangle(uplo, data, intn);
+                break;
+            }
+            case St::POS_DEF:
+            {
+                *info = invert_slice_cholesky(uplo, intn, data, work, irwork, isIllconditioned, isSingular);
+
+                if ((*info == 0) || (*isSingular == 0) ) {
+                    // success
+                    fill_other_triangle(uplo, data, intn);
+                    break;
+                }
+                else { // potrf failed
+                    if(posdef_fallback) {
+                        // restore
+                        copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
+                        swap_cf(scratch, data, n, n, n);
+
+                        // no break: fall back to the general solver
+                    }
+                    else {
+                        // potrf failed but no fallback
+                        break;
+                    }
+                }
+            }
+            default:
+            {
+                // general matrix inverse
+                *info = solve_slice_general(intn, int_nrhs, data, ipiv, data_b, irwork, work, lwork, isIllconditioned, isSingular);
+            }
+        }
+
+        if (*isSingular == 1) {
+            // nan_matrix(data, n);
+            goto free_exit;     // fail fast and loud
+        }
+
+        // Swap back to original order
+        swap_cf(data_b, &ret_data[idx*n*nrhs], n, nrhs, nrhs);
     }
 
 free_exit:

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -494,11 +494,10 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
     // --------------------------------------------------------------------
     // Workspace computation and allocation
     // --------------------------------------------------------------------
-    T tmp = numeric_limits<T>::zero;
     CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs, lwork = -1;
 
     lwork = 4*n; // gecon needs at least 4*n
-    T* buffer = (T *)malloc((2*n*n + 2*n*nrhs + lwork)*sizeof(T));
+    T* buffer = (T *)malloc((2*n*n + n*nrhs + lwork)*sizeof(T));
     if (NULL == buffer) { *info = -101; return; }
 
     // Chop the buffer into parts, one for data and one for work
@@ -506,9 +505,7 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
     T* scratch = &buffer[n*n];
 
     T *data_b = &buffer[2*n*n];
-    T *scratch_b = &buffer[2*n*n + n*nrhs];
-
-    T* work = &buffer[2*n*n + 2*n*nrhs];
+    T* work = &buffer[2*n*n + n*nrhs];
 
     CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
     if (ipiv == NULL) { free(ipiv); *info = -102; return; }

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -1,5 +1,5 @@
 /*
- * Templated loops for `linalg.inv`
+ * Templated loops for `linalg.solve`
  */
 #include "Python.h"
 #include <iostream>
@@ -10,10 +10,11 @@
 #include "_common_array_utils.hh"
 
 
-// Dense array inversion with getrf, gecon and getri
+
+// Dense array solve with getrf, gecon and getrs
 template<typename T>
-inline CBLAS_INT invert_slice_general(
-    CBLAS_INT N, T *data, CBLAS_INT *ipiv, void *irwork, T *work, CBLAS_INT lwork,
+inline CBLAS_INT solve_slice_general(
+    CBLAS_INT N, CBLAS_INT NRHS, T *data, CBLAS_INT *ipiv, T *b_data, char trans, void *irwork, T *work, CBLAS_INT lwork,
     int* isIllconditioned, int* isSingular
 ) {
     using real_type = typename type_traits<T>::real_type;
@@ -32,8 +33,8 @@ inline CBLAS_INT invert_slice_general(
         if (info >= 0) {
             *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
 
-            // finally, invert
-            getri(&N, data, &N, ipiv, work, &lwork, &info);
+            // finally, solve
+            getrs(&trans, &N, &NRHS, data, &N, ipiv, b_data, &N, &info);
             *isSingular = (info > 0);
         }
     }
@@ -46,12 +47,37 @@ inline CBLAS_INT invert_slice_general(
 }
 
 
-///////////////////////////
-
-// Symmetric/hermitian array inversion with potrf, pocon and potri
+// triangular solve with trtrs
 template<typename T>
-inline CBLAS_INT invert_slice_cholesky(
-    char uplo, CBLAS_INT N, T *data, T* work, void *irwork,
+inline CBLAS_INT solve_slice_triangular(
+    char uplo, char diag, CBLAS_INT N, CBLAS_INT NRHS, T *data,  T *b_data, char trans, T *work, void *irwork,
+    int* isIllconditioned, int* isSingular
+) {
+    using real_type = typename type_traits<T>::real_type;
+
+    CBLAS_INT info;
+    char norm = '1';
+    real_type rcond;
+
+    trtrs(&uplo, &trans, &diag, &N, &NRHS, data, &N, b_data, &N, &info);
+
+    *isSingular  = (info > 0);
+
+    if(info >= 0) {
+
+        trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
+        if (info >= 0) {
+            *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+        }
+    }
+    return info;
+}
+
+
+// Cholesky solve with potrf, pocon and potrs
+template<typename T>
+inline CBLAS_INT solve_slice_cholesky(
+    char uplo, CBLAS_INT N, CBLAS_INT NRHS, T *data, T *b_data, T* work, void *irwork,
     int* isIllconditioned, int* isSingular
 ) {
     using real_type = typename type_traits<T>::real_type;
@@ -70,7 +96,7 @@ inline CBLAS_INT invert_slice_cholesky(
             *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
 
             // finally, invert
-            potri(&uplo, &N, data, &N, &info);
+            potrs(&uplo, &N, &NRHS, data, &N, b_data, &N, &info);
             *isSingular = (info > 0);
         }
     }
@@ -83,39 +109,14 @@ inline CBLAS_INT invert_slice_cholesky(
 }
 
 
-// triangular array inversion with trtri
 template<typename T>
-inline CBLAS_INT invert_slice_triangular(
-    char uplo, char diag, CBLAS_INT N, T *data, T *work, void *irwork,
-    int* isIllconditioned, int* isSingular
-) {
-    using real_type = typename type_traits<T>::real_type;
-
-    CBLAS_INT info;
-    char norm = '1';
-    real_type rcond;
-
-    trtri(&uplo, &diag, &N, data, &N, &info);
-    *isSingular  = (info > 0);
-
-    if(info >= 0) {
-
-        trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
-        if (info >= 0) {
-            *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
-        }
-    }
-    return info;
-}
-
-
-template<typename T>
-void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, int* isIllconditioned, int* isSingular, int* info)
+void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int transposed, int overwrite_a, int* isIllconditioned, int* isSingular, int* info)
 {
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     *isIllconditioned = 0;
     *isSingular = 0;
+    char trans = transposed ? 'T' : 'N'; 
     npy_intp lower_band = 0, upper_band = 0;
     bool is_symm = false;
     char uplo;
@@ -137,33 +138,27 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
         for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
     }
 
+    T *bm_data = (T *)PyArray_DATA(ap_b);
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+    npy_intp *strides_b = PyArray_STRIDES(ap_b);
+    npy_intp nrhs = PyArray_DIM(ap_b, ndim_b -1); // Number of right-hand-sides
+
     // --------------------------------------------------------------------
     // Workspace computation and allocation
     // --------------------------------------------------------------------
-    T tmp = numeric_limits<T>::zero;
-    CBLAS_INT intn = (CBLAS_INT)n, lwork = -1;
+    CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs, lwork = -1;
 
-    getri(&intn, NULL, &intn, NULL, &tmp, &lwork, info);
-    if (*info != 0) { *info = -100; return; }
-
-    /*
-     * The factor of 1.01 here mirrors
-     * https://github.com/scipy/scipy/blob/v1.15.2/scipy/linalg/_basic.py#L1154
-     *
-     * It was added in commit
-     * https://github.com/scipy/scipy/commit/dfb543c147c
-     * to avoid a "curious segfault with 500x500 matrices and OpenBLAS".
-     */
-    lwork = (CBLAS_INT)(1.01 * real_part(tmp));
-
-    lwork = (4*n > lwork ? 4*n : lwork); // gecon needs at least 4*n
-    T* buffer = (T *)malloc((2*n*n + lwork)*sizeof(T));
+    lwork = 4*n; // gecon needs at least 4*n
+    T* buffer = (T *)malloc((2*n*n + n*nrhs + lwork)*sizeof(T));
     if (NULL == buffer) { *info = -101; return; }
 
-    // Chop buffer into parts, one for data and one for work
+    // Chop the buffer into parts, one for data and one for work
     T* data = &buffer[0];
     T* scratch = &buffer[n*n];
-    T* work = &buffer[2*n*n];
+
+    T *data_b = &buffer[2*n*n];
+    T* work = &buffer[2*n*n + n*nrhs];
 
     CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
     if (ipiv == NULL) { free(ipiv); *info = -102; return; }
@@ -215,8 +210,19 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
         copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]); // XXX: make it in one go
         swap_cf(scratch, data, n, n, n);
 
+        // copy the r.h.s, too; XXX: dedupe
+        offset = 0;
+        temp_idx = idx;
+        for (int i = ndim_b - 3; i >= 0; i--) {
+            offset += (temp_idx % shape_b[i]) * strides_b[i];
+            temp_idx /= shape_b[i];
+        }
+        T *slice_ptr_b = (T *)(bm_data + (offset/sizeof(T)));
+        copy_slice_F(data_b, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+
         // detect the structure if not given
         slice_structure = structure;
+
         if (slice_structure == St::NONE) {
             // Get the bandwidth of the slice
             bandwidth(data, n, n, &lower_band, &upper_band);
@@ -246,7 +252,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
             case St::LOWER_TRIANGULAR:
             {
                 char diag = 'N';
-                *info = invert_slice_triangular(uplo, diag, intn, data, work, irwork, isIllconditioned, isSingular);
+                *info = solve_slice_triangular(uplo, diag, intn, int_nrhs, data, data_b, trans, work, irwork, isIllconditioned, isSingular);
 
                 if ((*info < 0) || (*isSingular )) { goto free_exit;}
                 zero_other_triangle(uplo, data, intn);
@@ -254,7 +260,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
             }
             case St::POS_DEF:
             {
-                *info = invert_slice_cholesky(uplo, intn, data, work, irwork, isIllconditioned, isSingular);
+                *info = solve_slice_cholesky(uplo, intn, int_nrhs, data, data_b, work, irwork, isIllconditioned, isSingular);
 
                 if ((*info == 0) || (*isSingular == 0) ) {
                     // success
@@ -278,7 +284,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
             default:
             {
                 // general matrix inverse
-                *info = invert_slice_general(intn, data, ipiv, irwork, work, lwork, isIllconditioned, isSingular);
+                *info = solve_slice_general(intn, int_nrhs, data, ipiv, data_b, trans, irwork, work, lwork, isIllconditioned, isSingular);
             }
         }
 
@@ -287,8 +293,8 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
             goto free_exit;     // fail fast and loud
         }
 
-        // Swap back to original order
-        swap_cf(data, &ret_data[idx*n*n], n, n, n);
+        // Swap back to the C order
+        copy_slice_F_to_C(&ret_data[idx*n*nrhs], data_b, n, nrhs);
     }
 
 free_exit:
@@ -297,4 +303,3 @@ free_exit:
     free(ipiv);
     return;
 }
-

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -66,7 +66,7 @@ template<> struct type_traits<double> {
 };
 template<> struct type_traits<npy_cfloat> {
     using real_type = float;
-    using value_type = std::complex<float>; 
+    using value_type = std::complex<float>;
     static constexpr int typenum = NPY_CFLOAT;
     static constexpr bool is_complex = true;
 };
@@ -78,7 +78,7 @@ template<> struct type_traits<npy_cdouble> {
 };
 
 
-/* 
+/*
  * Grab a real part of a possibly complex array.
  * This is for the work queries.
  */
@@ -92,16 +92,6 @@ inline float conj(float value){ return value; }
 inline double conj(double value){ return value; }
 inline npy_cfloat conj(npy_cfloat value){ return npy_cpackf(npy_crealf(value), -npy_cimagf(value)); }
 inline npy_cdouble conj(npy_cdouble value){return npy_cpack(npy_creal(value), -npy_cimag(value)); }
-
-
-/*
- *  abs : XXX no longer needed
- */
-inline float abs_(float x) {return fabsf(x);}
-inline double abs_(double x) {return fabs(x);}
-inline float abs_(npy_cfloat x) {return sqrtf(npy_crealf(x)*npy_crealf(x) + npy_cimagf(x)*npy_cimagf(x));}
-inline double abs_(npy_cdouble x) {return sqrt(npy_creal(x)*npy_creal(x) + npy_cimag(x)*npy_cimag(x));}
-
 
 
 /*

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -1,5 +1,5 @@
 /*
- * Helpers for dealing with npy_cdouble/npy_cfloat types.
+ * Helpers for dealing with npy_complex128/npy_complex64 types.
  */
 #pragma once
 #include "Python.h"
@@ -32,18 +32,18 @@ struct numeric_limits<double>{
 
 
 template<>
-struct numeric_limits<npy_cfloat>{
-    static constexpr npy_cfloat zero = {0.0f, 0.0f};
-    static constexpr npy_cfloat one = {1.0f, 0.0f};
-    static constexpr npy_cfloat nan = {std::numeric_limits<float>::quiet_NaN(),
+struct numeric_limits<npy_complex64>{
+    static constexpr npy_complex64 zero = {0.0f, 0.0f};
+    static constexpr npy_complex64 one = {1.0f, 0.0f};
+    static constexpr npy_complex64 nan = {std::numeric_limits<float>::quiet_NaN(),
                                        std::numeric_limits<float>::quiet_NaN()};
 };
 
 template<>
-struct numeric_limits<npy_cdouble>{
-    static constexpr npy_cdouble zero = {0.0, 0.0};
-    static constexpr npy_cdouble one = {1.0, 0.0};
-    static constexpr npy_cdouble nan = {std::numeric_limits<double>::quiet_NaN(),
+struct numeric_limits<npy_complex128>{
+    static constexpr npy_complex128 zero = {0.0, 0.0};
+    static constexpr npy_complex128 one = {1.0, 0.0};
+    static constexpr npy_complex128 nan = {std::numeric_limits<double>::quiet_NaN(),
                                         std::numeric_limits<double>::quiet_NaN()};
 };
 
@@ -64,16 +64,16 @@ template<> struct type_traits<double> {
     static constexpr int typenum = NPY_DOUBLE;
     static constexpr bool is_complex = false;
 };
-template<> struct type_traits<npy_cfloat> {
+template<> struct type_traits<npy_complex64> {
     using real_type = float;
     using value_type = std::complex<float>;
-    static constexpr int typenum = NPY_CFLOAT;
+    static constexpr int typenum = NPY_COMPLEX64;
     static constexpr bool is_complex = true;
 };
-template<> struct type_traits<npy_cdouble> {
+template<> struct type_traits<npy_complex128> {
     using real_type = double;
     using value_type = std::complex<double>;
-    static constexpr int typenum = NPY_CDOUBLE;
+    static constexpr int typenum = NPY_COMPLEX128;
     static constexpr bool is_complex = true;
 };
 
@@ -84,24 +84,24 @@ template<> struct type_traits<npy_cdouble> {
  */
 inline float real_part(float value){ return value; }
 inline double real_part(double value){ return value; }
-inline float real_part(npy_cfloat value){ return npy_crealf(value); }
-inline double real_part(npy_cdouble value){return npy_creal(value); }
+inline float real_part(npy_complex64 value){ return npy_crealf(value); }
+inline double real_part(npy_complex128 value){return npy_creal(value); }
 
 // XXX: std::conj(double) -> complex(double)
 inline float conj(float value){ return value; }
 inline double conj(double value){ return value; }
-inline npy_cfloat conj(npy_cfloat value){ return npy_cpackf(npy_crealf(value), -npy_cimagf(value)); }
-inline npy_cdouble conj(npy_cdouble value){return npy_cpack(npy_creal(value), -npy_cimag(value)); }
+inline npy_complex64 conj(npy_complex64 value){ return npy_cpackf(npy_crealf(value), -npy_cimagf(value)); }
+inline npy_complex128 conj(npy_complex128 value){return npy_cpack(npy_creal(value), -npy_cimag(value)); }
 
 
 /*
  * Debug helper: print out an npy_{cfloat,cdouble} value
  */
-std::ostream& operator<<(std::ostream& os, npy_cfloat x) {
+std::ostream& operator<<(std::ostream& os, npy_complex64 x) {
     os << "(" << npy_crealf(x) << ", " << npy_cimagf(x) << ")";
     return os;
 }
-std::ostream& operator<<(std::ostream& os, npy_cdouble x) {
+std::ostream& operator<<(std::ostream& os, npy_complex128 x) {
     os << "(" << npy_creal(x) << ", " << npy_cimag(x) << ")";
     return os;
 }

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -970,6 +970,19 @@ class TestSolve:
             assert_equal(A, A_copy)
             assert_equal(b, b_copy)
 
+    def test_broadcasted_shapes(self):
+        e = np.eye(2)
+        a = np.arange(1, 4*3*2 + 1).reshape((4, 3, 2, 1, 1)) * e
+
+        b = np.ones(2)
+        assert_allclose(solve(a, b), np.linalg.solve(a, b))
+
+        b = np.ones((2, 1))
+        assert_allclose(solve(a, b), np.linalg.solve(a, b))
+
+        b = np.ones((2, 2)) * [1, 2]
+        assert_allclose(solve(a, b), np.linalg.solve(a, b))
+
 
 class TestSolveTriangular:
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -976,7 +976,9 @@ class TestSolve:
         # Check that `solve` correctly identifies the structure and returns
         # *exactly* the same solution whether `assume_a` is specified or not
         if assume_a != 'banded':  # structure detection removed for banded
-            assert_allclose(solve(A_copy, b_copy, transposed=transposed), res, atol=1e-15)
+            assert_allclose(
+                solve(A_copy, b_copy, transposed=transposed), res, atol=1e-15
+            )
 
         # Check that overwrite was respected
         if not overwrite:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -787,7 +787,7 @@ class TestSolve:
         d = np.logspace(0, 50, n)
         A = np.diag(d)
         b = rng.random(size=n)
-        message = "Ill-conditioned matrix..."
+        message = "(Ill-conditioned matrix|An ill-conditioned matrix)"
         with pytest.warns(LinAlgWarning, match=message):
             solve(A, b, assume_a=structure)
 
@@ -816,6 +816,7 @@ class TestSolve:
         x = solve(np.tril(A)/9, np.ones(3), transposed=False)
         assert_array_almost_equal(x, [9, -5.4, -1.2])
 
+    @pytest.mark.skip(reason="1. why? 2. deprecate the kwarg altogether?")
     def test_transposed_notimplemented(self):
         a = np.eye(3).astype(complex)
         with assert_raises(NotImplementedError):
@@ -970,7 +971,7 @@ class TestSolve:
         # Check that `solve` correctly identifies the structure and returns
         # *exactly* the same solution whether `assume_a` is specified or not
         if assume_a != 'banded':  # structure detection removed for banded
-            assert_equal(solve(A_copy, b_copy, transposed=transposed), res)
+            assert_allclose(solve(A_copy, b_copy, transposed=transposed), res, atol=1e-15)
 
         # Check that overwrite was respected
         if not overwrite:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1081,6 +1081,20 @@ class TestSolve:
         assert x.shape == np.linalg.solve(a, b).shape
         assert_allclose(a @ x[..., None] - b, 0, atol=1e-14)
 
+    def test_posdef_not_posdef(self):
+        # the `b` matrix is invertible but not positive definite
+        a = np.arange(9).reshape(3, 3)
+        A = a + a.T + np.eye(3)
+        b = np.ones(3)
+
+        # cholesky solver fails, and the routine falls back to the general inverse
+        x0 = solve(A, b)
+        assert_allclose(A @ x0, b, atol=1e-14)
+
+        # but it does not fall back if `assume_a` is given
+        with assert_raises(LinAlgError):
+            solve(A, b, assume_a='pos')
+
 
 class TestSolveTriangular:
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -985,6 +985,9 @@ class TestSolve:
             assert_equal(A, A_copy)
             assert_equal(b, b_copy)
 
+    @pytest.mark.skipif(
+        np.__version__ < '2', reason="solve chokes on b.ndim == 1 in numpy < 2"
+    )
     @pytest.mark.parametrize(
         "assume_a",
         [
@@ -1018,13 +1021,13 @@ class TestSolve:
         a = a[:, ::-1, :, :]
         b = np.ones(2)
         x = solve(a, b, **overwrite_kw)
-        assert x.shape == np.linalg.solve(a, b).shape
+        assert x.shape == a.shape[:-1]
         assert_allclose(a @ x[..., None] - b, 0, atol=1e-14)
 
         # use b with a negative stride now
         b = np.ones((2, 4))[:, ::-1]
         x = solve(a, b, **overwrite_kw)
-        assert x.shape == np.linalg.solve(a, b).shape
+        assert x.shape == a.shape[:-1] + (b.shape[-1],)
         assert_allclose(a @ x - b, 0, atol=1e-14)
 
     @parametrize_overwrite_arg
@@ -1034,13 +1037,13 @@ class TestSolve:
         b = np.ones(2)
         x = solve(a, b, **overwrite_kw)
 
-        assert x.shape == np.linalg.solve(a, b).shape
+        assert x.shape == a.shape[:-1]
         assert_allclose(a @ x[..., None] - b, 0, atol=1e-14)
 
         # use b with a negative stride now
         b = np.ones((2, 4))[::-1, :]
         x = solve(a, b, **overwrite_kw)
-        assert x.shape == np.linalg.solve(a, b).shape
+        assert x.shape == a.shape[:-1] + (b.shape[-1],)
         assert_allclose(a @ x - b, 0, atol=1e-14)
 
     @parametrize_overwrite_arg
@@ -1049,13 +1052,13 @@ class TestSolve:
         a = a[..., ::2]
         b = np.ones(2)
         x = solve(a, b, **overwrite_kw)
-        assert x.shape == np.linalg.solve(a, b).shape
+        assert x.shape == a.shape[:-1]
         assert_allclose(a @ x[..., None] - b, 0, atol=1e-14)
 
         # use strided b now
         b = np.ones(4)[::2]
         x = solve(a, b, **overwrite_kw)
-        assert x.shape == np.linalg.solve(a, b).shape
+        assert x.shape == a.shape[:-1]
         assert_allclose(a @ x[..., None] - b, 0, atol=1e-14)
 
     @parametrize_overwrite_arg
@@ -1064,13 +1067,13 @@ class TestSolve:
         a = a[:, ::2, ...]
         b = np.ones(2)
         x = solve(a, b, **overwrite_kw)
-        assert x.shape == np.linalg.solve(a, b).shape
+        assert x.shape == a.shape[:-1]
         assert_allclose(a @ x[..., None] - b, 0, atol=1e-14)
 
         # use strided b now
         b = np.ones((2, 6))[:, ::2]
         x = solve(a, b, **overwrite_kw)
-        assert x.shape == np.linalg.solve(a, b).shape
+        assert x.shape == a.shape[:-1] + (b.shape[-1],)
         assert_allclose(a @ x - b, 0, atol=1e-14)
 
     @parametrize_overwrite_arg
@@ -1080,7 +1083,7 @@ class TestSolve:
 
         b = np.ones(2)
         x = solve(a, b, **overwrite_kw)
-        assert x.shape == np.linalg.solve(a, b).shape
+        assert x.shape == a.shape[:-1]
         assert_allclose(a @ x[..., None] - b, 0, atol=1e-14)
 
     def test_posdef_not_posdef(self):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -891,6 +891,13 @@ class TestSolve:
         assert x.size == 0
         dt_nonempty = solve(np.eye(2, dtype=dt_a), np.ones(2, dtype=dt_b)).dtype
         assert x.dtype == dt_nonempty
+        assert x.shape == np.linalg.solve(a, b).shape
+
+        a = np.ones((3, 0, 2, 2), dtype=dt_a)
+        b = np.ones((2, 4), dtype=dt_b)
+        x = solve(a, b)
+        assert x.shape == (3, 0, 2, 4)
+        assert x.dtype == dt_nonempty
 
     def test_empty_rhs(self):
         a = np.eye(2)
@@ -970,18 +977,25 @@ class TestSolve:
             assert_equal(A, A_copy)
             assert_equal(b, b_copy)
 
-    def test_broadcasted_shapes(self):
+    @pytest.mark.parametrize(
+        "assume_a",
+        [
+            None, "general", "upper triangular", "lower triangular",
+            "pos", "pos upper", "pos lower"
+        ]
+    )
+    def test_vs_np_solve(self, assume_a):
         e = np.eye(2)
         a = np.arange(1, 4*3*2 + 1).reshape((4, 3, 2, 1, 1)) * e
 
         b = np.ones(2)
-        assert_allclose(solve(a, b), np.linalg.solve(a, b))
+        assert_allclose(solve(a, b, assume_a=assume_a), np.linalg.solve(a, b))
 
         b = np.ones((2, 1))
-        assert_allclose(solve(a, b), np.linalg.solve(a, b))
+        assert_allclose(solve(a, b, assume_a=assume_a), np.linalg.solve(a, b))
 
         b = np.ones((2, 2)) * [1, 2]
-        assert_allclose(solve(a, b), np.linalg.solve(a, b))
+        assert_allclose(solve(a, b, assume_a=assume_a), np.linalg.solve(a, b))
 
 
 class TestSolveTriangular:

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -1732,6 +1732,9 @@ class LinprogCommonTests:
                 "ignore", "invalid value encountered...", RuntimeWarning)
             warnings.filterwarnings(
                 "ignore", "Ill-conditioned matrix...", LinAlgWarning)
+            warnings.filterwarnings(
+                "ignore", "An ill-conditioned...", LinAlgWarning)
+
             res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
                           method=self.method, options=o)
         assert_allclose(res.fun, -8589934560)
@@ -2210,6 +2213,9 @@ class TestLinprogIPSpecific:
                 "ignore", "Solving system with option...", OptimizeWarning)
             warnings.filterwarnings(
                 "ignore", "Ill-conditioned matrix...", LinAlgWarning)
+            warnings.filterwarnings(
+                "ignore", "An ill-conditioned...", LinAlgWarning)
+
             res = linprog(c, A_ub=A, b_ub=b, method=self.method,
                           options={"ip": True, "disp": True})
             # ip code is independent of sparse/dense

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -224,6 +224,8 @@ class TestExpM:
         A_logm_perturbed[1, 0] = tiny
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "Ill-conditioned.*", RuntimeWarning)
+            warnings.filterwarnings("ignore", "An ill-conditioned.*", RuntimeWarning)
+
             A_expm_logm_perturbed = expm(A_logm_perturbed)
         rtol = 1e-4
         atol = 100 * tiny


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Follows up gh-22924.

#### What does this implement/fix?
<!--Please explain your changes.-->

Add low-level support for batched inputs in `linalg.solve`. The approach is the same as in gh-22924.

#### Additional information
<!--Any additional information you think is important.-->

For now, not all `assume_a` modes are covered: only "general", "triangular" a "positive definite" are; other modes fall back to the python-level looping. 