### PR TITLE
MAINT: smoke-docs: add a `--doctest-only-doctests` flag to spin/dev.py

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -3,6 +3,7 @@ import os
 import sys
 import importlib
 import importlib.util
+import importlib.metadata
 import json
 import traceback
 import warnings
@@ -456,8 +457,11 @@ def smoke_docs(*, parent_callback, pytest_args, **kwargs):
 
     """  # noqa: E501
     # prevent obscure error later; cf https://github.com/numpy/numpy/pull/26691/
-    if not importlib.util.find_spec("scipy_doctest"):
-        raise ModuleNotFoundError("Please install scipy-doctest")
+    if (
+        not importlib.util.find_spec("scipy_doctest")
+        or importlib.metadata.version("scipy_doctest") < "1.8.0"
+    ):
+        raise ModuleNotFoundError("Please install scipy-doctest>=1.8.0")
 
     tests = kwargs["tests"]
     if kwargs["submodule"]:
@@ -469,6 +473,7 @@ def smoke_docs(*, parent_callback, pytest_args, **kwargs):
     # turn doctesting on:
     doctest_args = (
         '--doctest-modules',
+        '--doctest-only-doctests=true',
         '--doctest-collect=api'
     )
 

--- a/dev.py
+++ b/dev.py
@@ -911,7 +911,9 @@ class SmokeDocs(Task):
 
         # Request doctesting; use strategy=api unless -t path/to/specific/file
         # also switch off assertion rewriting: not useful for doctests
-        extra_argv += ["--doctest-modules", "--assert=plain"]
+        extra_argv += [
+            "--doctest-modules", "--doctest-only-doctests=true", "--assert=plain"
+        ]
         if not args.tests:
             extra_argv += ['--doctest-collect=api']
 


### PR DESCRIPTION
This bumps the minimum scipy_doctest version to >=1.8.0

See https://discuss.scientific-python.org/t/scipy-doctest-select-only-doctests-or-both-doctests-and-unit-tests/1950 for the discussion.

TL;DR: this change is currently a no-op; this is the only change needed to be forward compatible with an upcoming breaking change in scipy-doctest, no further action is needed in scipy itself. Unfortunately, all users who do `$ spin smoke-docs` locally will need to `pip install --update scipy-doctest` --- once. 
