### PR TITLE
TST: signal: fix flaky TestZpk2Sos

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -399,7 +399,7 @@ class TestZpk2Sos:
     def test_dtypes(self, dt, pairing, analog, xp):
         dtype = getattr(xp, dt)
         # the poles have to be complex
-        cdtype = (xp.empty(1, dtype=dtype) + 1j*xp.empty(1, dtype=dtype)).dtype
+        cdtype = (xp.empty(0, dtype=dtype) + 1j*xp.empty(0, dtype=dtype)).dtype
 
         z = xp.asarray([-1, -1], dtype=dtype)
         p = xp.asarray([0.57149 + 0.29360j, 0.57149 - 0.29360j], dtype=cdtype)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -399,7 +399,7 @@ class TestZpk2Sos:
     def test_dtypes(self, dt, pairing, analog, xp):
         dtype = getattr(xp, dt)
         # the poles have to be complex
-        cdtype = (xp.empty(0, dtype=dtype) + 1j*xp.empty(0, dtype=dtype)).dtype
+        cdtype = (1j*xp.empty(0, dtype=dtype)).dtype
 
         z = xp.asarray([-1, -1], dtype=dtype)
         p = xp.asarray([0.57149 + 0.29360j, 0.57149 - 0.29360j], dtype=cdtype)


### PR DESCRIPTION
Fix random failure

> FAILED scipy/signal/tests/test_filter_design.py::TestZpk2Sos::test_dtypes[numpy-nearest-False-complex64] - RuntimeWarning: invalid value encountered in add

https://github.com/scipy/scipy/actions/runs/15346372789/job/43183426526?pr=23083