### PR TITLE
CI: move pre-release and free-threading jobs to CPython 3.14-dev

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -481,6 +481,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         # Needs nightly numpy build until the 2.3.x release for Python 3.14 support
+        # pip install -r requirements/build.txt
         pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
         pip install meson-python Cython pybind11 pythran ninja
         pip install -r requirements/openblas.txt

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/commit_message.yml
 
   test_meson:
-    name: mypy (py3.11) & dev deps (py3.13), fast, spin
+    name: mypy (py3.11) & dev deps (py3.14), fast, spin
     needs: get_commit_message
     # If using act to run CI locally the github object does not exist and
     # the usual skipping should not be enforced
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.11', '3.13-dev'] # this run will use python dev versions when available
+        python-version: ['3.11', '3.14-dev'] # this run will use python dev versions when available
         maintenance-branch:
           - ${{ contains(github.ref, 'maintenance/') || contains(github.base_ref, 'maintenance/') }}
         exclude:
@@ -68,7 +68,7 @@ jobs:
         python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson pooch hypothesis spin
 
     - name: Install Python packages from repositories
-      if: matrix.python-version == '3.13-dev' # this run will use python dev versions when available
+      if: matrix.python-version == '3.14-dev' # this run will use python dev versions when available
       run: |
         python -m pip install git+https://github.com/numpy/numpy.git
         python -m pip install ninja cython pytest pybind11 pytest-xdist pytest-timeout spin pooch hypothesis "setuptools<67.3" meson
@@ -471,7 +471,7 @@ jobs:
 
     - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
-        python-version: '3.13t'
+        python-version: '3.14t-dev'
 
     - name: Install Ubuntu dependencies
       run: |
@@ -480,7 +480,9 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        pip install -r requirements/build.txt
+        # Needs nightly numpy build until the 2.3.x release for Python 3.14 support
+        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
+        pip install meson-python Cython pybind11 pythran ninja
         pip install -r requirements/openblas.txt
         pip install spin pytest pytest-xdist threadpoolctl pooch hypothesis
 


### PR DESCRIPTION
NumPy now has `cp314` wheels up, built against Python 3.14.0b2, so it's a good time to start testing here. I'm moving the pre-release job that is meant for this purpose over to 3.14-dev, as well as the free-threading job because CPython 3.14-dev has an increasing amount of improvements and thread-safety fixes for free-threading that are not (and won't become) available in 3.13.x releases.

I am working on `cp314` wheels as well, but those are currently failing fairly spectacularly, so let's start with this.