### PR TITLE
BUG: sparse: correct eq and ne with different shapes. (and add test)

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -658,7 +658,7 @@ class _spbase(SparseABC):
                 # eq and ne return True or False instead of an array when the shapes
                 # don't match. Numpy doesn't do this. Is this what we want?
                 if op in (operator.eq, operator.ne):
-                    return op == operator.eq
+                    return op is operator.ne
                 raise ValueError("inconsistent shape")
 
             csr_self = (self if self.ndim < 3 else self.reshape(1, -1)).tocsr()

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -433,6 +433,13 @@ class _TestCommon:
         for dtype in self.checked_dtypes:
             check(dtype)
 
+    def test_eq_ne_different_shapes(self):
+        if self.datsp.format not in ['bsr', 'csc', 'csr']:
+            pytest.skip("Bool comparisons only implemented for BSR, CSC, and CSR.")
+        # Is this what we want? numpy raises when shape differs. we return False.
+        assert (self.datsp == self.datsp.T) is False
+        assert (self.datsp != self.datsp.T) is True
+
     def test_lt(self):
         sup = suppress_warnings()
         sup.filter(SparseEfficiencyWarning)


### PR DESCRIPTION
Fixes #23068 

Operators != and == return incorrect results for differently shaped sparse arrays/matrices. This was introduced in #22897 and has been released in 1.16rc.  The result of differently shaped boolean eq/ne was not tested and fell through the cracks.

This PR adds a test and fixes the bug.

There is also a bigger question here: 
Why doesn't sparse raise when the shapes don't match. 
Numpy raises a ValueError because the sizes do not broadcast to the same shape. 

We should at least change sparray treatment of this up-to-now untested case.  If/when we support broadcasting the results will differ.    But that's for a separate PR.  This is a bug-fix. 