### PR TITLE
DEV: Address issues in `spin docs` command

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -262,59 +262,26 @@ def test(*, parent_callback, pytest_args, tests, coverage,
     parent_callback(**{"pytest_args": pytest_args, "tests": tests,
                     "coverage": coverage, **kwargs})
 
-@click.option(
-        '--list-targets', '-t', default=False, is_flag=True,
-        help='List doc targets',
-    )
-@click.option(
-    '--no-cache', default=False, is_flag=True,
-    help="Forces a full rebuild of the docs. Note that this may be " + \
-            "needed in order to make docstring changes in C/Cython files " + \
-            "show up."
-)
-@spin.util.extend_command(spin.cmds.meson.docs)
-def docs(*, parent_callback, sphinx_target, clean, jobs,
-         list_targets, no_cache, **kwargs):
+@spin.util.extend_command(spin.cmds.meson.docs, remove_args=("sphinx_gallery_plot", ))
+def docs(*, parent_callback, sphinx_target, clean, jobs, **kwargs):
     """📖 Build Sphinx documentation
 
-    By default, SPHINXOPTS="-W", raising errors on warnings.
-    To build without raising on warnings:
+    Following Sphinx targets are supported:
 
-      SPHINXOPTS="" spin docs
+    html:
 
-    To list all Sphinx targets:
+      spin docs html
 
-      spin docs targets
-
-    To build another Sphinx target:
-
-      spin docs TARGET
-
-    E.g., to build a zipfile of the html docs for distribution:
+    dist: to build a zipfile of the html docs for distribution
 
       spin docs dist
 
     """
     meson.docs.ignore_unknown_options = True
 
-    if clean: # SciPy has its own mechanism to clear the previous docs build
-        cwd = os.getcwd()
-        os.chdir(os.path.join(cwd, "doc"))
-        subprocess.call(["make", "clean"], cwd=os.getcwd())
-        clean = False
-        os.chdir(cwd)
-
-    SPHINXOPTS = "-W"
-    if no_cache:
-        SPHINXOPTS += " -E"
-
-    SPHINXOPTS = os.environ.get("SPHINXOPTS", "") + SPHINXOPTS
-    os.environ["SPHINXOPTS"] = SPHINXOPTS
-
-    sphinx_target = "html"
-
     parent_callback(**{"sphinx_target": sphinx_target,
-                       "clean": clean, "jobs": jobs, **kwargs})
+                       "clean": clean, "jobs": jobs,
+                       "sphinx_gallery_plot": False, **kwargs})
 
 def _set_pythonpath(pythonpath):
     env = os.environ

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -262,7 +262,8 @@ def test(*, parent_callback, pytest_args, tests, coverage,
     parent_callback(**{"pytest_args": pytest_args, "tests": tests,
                     "coverage": coverage, **kwargs})
 
-@spin.util.extend_command(spin.cmds.meson.docs, remove_args=("sphinx_gallery_plot", ), doc="")
+@spin.util.extend_command(spin.cmds.meson.docs,
+                          remove_args=("sphinx_gallery_plot", ), doc="")
 def docs(*, parent_callback, sphinx_target, clean, jobs, **kwargs):
     """📖 Build Sphinx documentation
 

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -58,7 +58,7 @@ PROJECT_MODULE = "scipy"
     '--tags', default="runtime,python-runtime,tests,devel",
     show_default=True, help="Install tags to be used by meson."
 )
-@spin.util.extend_command(spin.cmds.meson.build)
+@spin.util.extend_command(spin.cmds.meson.build, doc="")
 def build(*, parent_callback, meson_args, jobs, verbose, werror, asan, debug,
           release, setup_args, show_build_log,
           with_scipy_openblas, with_accelerate, use_system_libraries,
@@ -170,7 +170,7 @@ def build(*, parent_callback, meson_args, jobs, verbose, werror, asan, debug,
         "'jax.numpy', 'dask.array')."
     )
 )
-@spin.util.extend_command(spin.cmds.meson.test)
+@spin.util.extend_command(spin.cmds.meson.test, doc="")
 def test(*, parent_callback, pytest_args, tests, coverage,
          durations, submodule, mode, array_api_backend, **kwargs):
     """🔧 Run tests
@@ -262,7 +262,7 @@ def test(*, parent_callback, pytest_args, tests, coverage,
     parent_callback(**{"pytest_args": pytest_args, "tests": tests,
                     "coverage": coverage, **kwargs})
 
-@spin.util.extend_command(spin.cmds.meson.docs, remove_args=("sphinx_gallery_plot", ))
+@spin.util.extend_command(spin.cmds.meson.docs, remove_args=("sphinx_gallery_plot", ), doc="")
 def docs(*, parent_callback, sphinx_target, clean, jobs, **kwargs):
     """📖 Build Sphinx documentation
 
@@ -294,7 +294,7 @@ def _set_pythonpath(pythonpath):
 @click.option(
     '--pythonpath', '-p', metavar='PYTHONPATH', default=None,
     help='Paths to prepend to PYTHONPATH')
-@spin.util.extend_command(spin.cmds.meson.python)
+@spin.util.extend_command(spin.cmds.meson.python, doc="")
 def python(*, parent_callback, pythonpath, **kwargs):
     """🐍 Launch Python shell with PYTHONPATH set
 
@@ -308,7 +308,7 @@ def python(*, parent_callback, pythonpath, **kwargs):
 @click.option(
     '--pythonpath', '-p', metavar='PYTHONPATH', default=None,
     help='Paths to prepend to PYTHONPATH')
-@spin.util.extend_command(spin.cmds.meson.ipython)
+@spin.util.extend_command(spin.cmds.meson.ipython, doc="")
 def ipython(*, parent_callback, pythonpath, **kwargs):
     """💻 Launch IPython shell with PYTHONPATH set
 
@@ -322,7 +322,7 @@ def ipython(*, parent_callback, pythonpath, **kwargs):
 @click.option(
     '--pythonpath', '-p', metavar='PYTHONPATH', default=None,
     help='Paths to prepend to PYTHONPATH')
-@spin.util.extend_command(spin.cmds.meson.shell)
+@spin.util.extend_command(spin.cmds.meson.shell, doc="")
 def shell(*, parent_callback, pythonpath, **kwargs):
     """💻 Launch shell with PYTHONPATH set
 
@@ -390,7 +390,7 @@ def mypy(ctx, build_dir=None):
     print(report, end='')
     print(errors, end='', file=sys.stderr)
 
-@spin.util.extend_command(test, doc='')
+@spin.util.extend_command(test, doc="")
 def smoke_docs(*, parent_callback, pytest_args, **kwargs):
     """🔧 Run doctests of objects in the public API.
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Addresses https://github.com/scipy/scipy/pull/23041#discussion_r2105773841

#### What does this implement/fix?
<!--Please explain your changes.-->

There are multiple issues with the `docs` command, in SciPy and also in NumPy:

- For both: docstring looks bad, needs improving:
    - [x] `SPHINXOPTS` should be removed since it's both too niche and incorrect,
    - [x] It should explain what targets are supported and how to build exactly those - `html`, `dist` only for SciPy, and in addition `latex` for NumPy (better renamed to `pdf` probably)
    - [x] `spin docs targets` should not be mentioned, that's just confusing for no good reason.
- [x] For both: `sphinx-gallery` is not used and hence should not be an option, that is confusing
- [x] For SciPy: docstring is displayed twice (see below)
- [x] For SciPy: `--clean` doesn't work indeed, deferring to `spin` should work
- [x] For SciPy: `--no-cache` doesn't seem useful, it says it forces a full rebuild, so seems duplicate with `--clean` at that point.
- [x] For SciPy: `--list-targets` can then also be removed

_Originally posted by @rgommers in https://github.com/scipy/scipy/pull/23041#discussion_r2105773841_
            

#### Additional information
<!--Any additional information you think is important.-->
