### PR TITLE
DEV: remove duplicate `--doctest-collect=api` in `spin smoke-docs`

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -474,7 +474,6 @@ def smoke_docs(*, parent_callback, pytest_args, **kwargs):
     doctest_args = (
         '--doctest-modules',
         '--doctest-only-doctests=true',
-        '--doctest-collect=api'
     )
 
     if not tests:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/23053

#### What does this implement/fix?
<!--Please explain your changes.-->

The `--doctest-collect=api` was present by default in `doctest_args` which shouldn't be the case. It should only be present `not tests` is `True`. Made the change and now the duplication is absent.

#### Additional information
<!--Any additional information you think is important.-->

cc: @rgommers @ev-br 
