### PR TITLE
DOC: linalg: fix overview for `cdf2rdf` and `khatri_rao`

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -1497,6 +1497,8 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
 
 def cdf2rdf(w, v):
     """
+    Complex diagonal form to real diagonal block form.
+
     Converts complex eigenvalues ``w`` and eigenvectors ``v`` to real
     eigenvalues in a block diagonal form ``wr`` and the associated real
     eigenvectors ``vr``, such that::

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -986,7 +986,7 @@ def signm(A, disp=_NoValue):
 @_apply_over_batch(('a', 2), ('b', 2))
 def khatri_rao(a, b):
     r"""
-    Khatri-rao product
+    Khatri-Rao product of two matrices.
 
     A column-wise Kronecker product of two matrices
 


### PR DESCRIPTION
In both cases took overview from `linalg.__init__.py`.

[docs only]

#### Reference issue
None; searching open issues for `khatri_rao` and `cdf2rdf` yields no hits.

#### What does this implement/fix?
Fixes minor errors in linalg overview for the two functions.
