### PR TITLE
CI: move to `cibuildwheel` 3.0b4 and to `manylinux_2_28`

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -212,7 +212,7 @@ jobs:
           echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@d04cacbc9866d432033b1d09142936e6a0e2121a # v2.23.2
+        uses: pypa/cibuildwheel@cf078b0954f3fd08b8445a7bf2c3fb83ab3bb971 # v3.0.0b4
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ package = 'scipy'
 install = ['--skip-subprojects']
 
 [tool.cibuildwheel]
-skip = "cp36-* cp37-* cp38-* pp* *_ppc64le *_i686 *_s390x"
+skip = "cp38-* *_ppc64le *_i686 *_s390x"
 # We're only testing with essential test dependencies, not optional ones.
 # Some of those require binary wheels (often missing for some platforms),
 # or they slow down the test suite runs too much or simply aren't necessary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ package = 'scipy'
 install = ['--skip-subprojects']
 
 [tool.cibuildwheel]
-skip = "cp38-* *_ppc64le *_i686 *_s390x"
+skip = ["*_i686", "*_ppc64le", "*_s390x", "*_universal2"]
 # We're only testing with essential test dependencies, not optional ones.
 # Some of those require binary wheels (often missing for some platforms),
 # or they slow down the test suite runs too much or simply aren't necessary.
@@ -146,8 +146,10 @@ before-test = "bash {project}/tools/wheels/cibw_before_test.sh {project}"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux2014"
-manylinux-aarch64-image = "manylinux2014"
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"
+musllinux-x86_64-image = "musllinux_1_2"
+musllinux-aarch64-image = "musllinux_1_2"
 before-build = "bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
 
 [tool.cibuildwheel.linux.environment]


### PR DESCRIPTION
These changes were made in NumPy already, the `manylinux_2_28` one a few months ago (will be in 2.3.0) and the `cibuildwheel` one more recently (reason: a release is imminent, and this is needed for Python 3.14 support).

We need to backport the `cibuildwheel` change to the 1.16.x branch within 2-3 months when we do a release to add `cp314` wheels, but I wouldn't do that now since it's not a final release yet (even though it should be stable).

The changes to `pyproject.toml` also match those in NumPy; the other changes are just for explicitness - `musllinux_1_2` was already the default, and we were already not building `universal2` wheels. The `cp36-* cp37-* pp*` are no longer built by default, so the skips can be removed (leaving them in would cause a warning actually).