### PR TITLE
MAINT: 1.16.0rc2 backports

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -77,7 +77,7 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
         # should also be able to do multi-archs on a single entry, e.g.
-        # [windows-2019, win*, "AMD64 x86"]. However, those two require a different compiler setup
+        # [windows-2022, win*, "AMD64 x86"]. However, those two require a different compiler setup
         # so easier to separate out here.
         - [ubuntu-22.04, manylinux, x86_64, "", ""]
         - [ubuntu-22.04, musllinux, x86_64, "", ""]
@@ -87,7 +87,7 @@ jobs:
         - [macos-13, macosx, x86_64, accelerate, "14.0"]
         - [macos-14, macosx, arm64, openblas, "12.3"]
         - [macos-14, macosx, arm64, accelerate, "14.0"]
-        - [windows-2019, win, AMD64, "", ""]
+        - [windows-2022, win, AMD64, "", ""]
         python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -71,7 +71,7 @@ jobs:
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -115,7 +115,7 @@ jobs:
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/doc/source/building/redistributable_binaries.rst
+++ b/doc/source/building/redistributable_binaries.rst
@@ -55,6 +55,40 @@ More detailed information on these build dependencies can be found in
 :ref:`toolchain-roadmap`.
 
 
+Using system dependencies instead of vendored sources
+-----------------------------------------------------
+
+SciPy contains a *lot* of code that has been vendored from libraries written in
+C, C++ and Fortran. This is done for a mix of historical and robustness
+reasons. Distro packagers sometimes have reasons to want to *unvendor* this
+code, ensuring that they only have a single version of a particular library in
+use. We offer a build option, ``-Duse-system-libraries``, to allow them to do
+so, e.g.:
+
+.. code::
+
+    $ python -m build -wnx -Duse-system-libraries=boost.math
+
+The build option takes the following values:
+
+- ``none``: Use the source code shipped as part of SciPy, do not look for
+  external dependencies (default).
+- ``all``: Use external libraries for all components controlled by
+  ``use-system-libraries``, and error out if they are not found. Detecting is
+  done by Meson, typically first through the ``pkg-config`` and then the
+  ``cmake`` method of the ``dependency()`` function.
+- ``auto``: Try detecting external libraries, and if they are not found then
+  fall back onto vendored sources.
+- A comma-separated list of dependency names (e.g., ``boost.math,qhull``). If
+  given, uses the ``all`` behavior for the named dependencies (and ``none`` for
+  the rest). See ``meson.options`` in the root of the SciPy repository or sdist
+  for all supported options.
+
+It's also valid to combine the generic and named-library options above, for
+example ``boost.math,auto`` will apply the ``auto`` behavior to all
+dependencies other than ``boost.math``.
+
+
 Stripping the test suite from a wheel or installed package
 ----------------------------------------------------------
 

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -369,7 +369,7 @@ Authors
 * Matthew H Flamm (1)
 * Karthik Viswanath Ganti (1) +
 * Neil Girdhar (1)
-* Ralf Gommers (157)
+* Ralf Gommers (158)
 * Rohit Goswami (4)
 * Saarthak Gupta (4) +
 * Matt Haberland (325)
@@ -413,7 +413,7 @@ Authors
 * Victor PM (10) +
 * pmav99 (1) +
 * Ilhan Polat (73)
-* Tyler Reddy (91)
+* Tyler Reddy (96)
 * Érico Nogueira Rolim (1) +
 * Pamphile Roy (10)
 * Mikhail Ryazanov (6)
@@ -640,7 +640,7 @@ Issues closed for 1.16.0
 * `#22965 <https://github.com/scipy/scipy/issues/22965>`__: BUG: The attribute "nit" is not found when using the callback...
 * `#22981 <https://github.com/scipy/scipy/issues/22981>`__: Bug with freqz when specifying worN after #22886
 * `#23035 <https://github.com/scipy/scipy/issues/23035>`__: TST: theilsope & siegelslope-related tests are failing on PyPy3.11...
-* `#23036 <https://github.com/scipy/scipy/issues/23036>`__: BUG: scipy.signal.csd doesn't zero-pad for different size inputs...
+* `#23036 <https://github.com/scipy/scipy/issues/23036>`__: BUG: signal.csd: doesn't zero-pad for different size inputs in...
 * `#23038 <https://github.com/scipy/scipy/issues/23038>`__: DOC: ``linalg.toeplitz`` does not support batching like the ``1.16.0rc1``...
 * `#23046 <https://github.com/scipy/scipy/issues/23046>`__: ENH: ``vectorized_filter``\ : special case of scalar ``size``...
 * `#23061 <https://github.com/scipy/scipy/issues/23061>`__: DOC: Wrong SPDX identifier for OpenBLAS and LAPACK
@@ -1111,3 +1111,4 @@ Pull requests for 1.16.0
 * `#23099 <https://github.com/scipy/scipy/pull/23099>`__: MAINT: fix SPDX license expressions for LAPACK, OpenBLAS, GCC
 * `#23106 <https://github.com/scipy/scipy/pull/23106>`__: TST: CI broken vs pytest 8.4.0
 * `#23110 <https://github.com/scipy/scipy/pull/23110>`__: BUG: spatial.distance: yule implementation in ``distance_metrics.h``
+* `#23113 <https://github.com/scipy/scipy/pull/23113>`__: DOC: improve docs for ``-Duse-system-libraries`` build option

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -260,12 +260,9 @@ Expired Deprecations
   must be specified separately as ``x`` and ``y``.
 - Support for NumPy masked arrays has been removed from
   `scipy.stats.power_divergence` and `scipy.stats.chisquare`.
-- The deprecated ``scipy.optimize.slsqp.zeros`` function has been removed.
-- Several deprecated unintentionally-public helper functions in `scipy.sparse`
-  have been removed as detailed at
-  `<https://github.com/scipy/scipy-stubs/pull/557>`__.
-- Most of the deprecated functions in ``scipy.interpolate.dfitpack``
-  have been removed.
+- A significant number of functions from non-public namespaces
+  (e.g., ``scipy.sparse.base``, ``scipy.interpolate.dfitpack``) were cleaned
+  up. They were previously already emitting deprecation warnings.
 
 
 ******************************

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -191,9 +191,14 @@ New features
   `~scipy.stats.power_divergence`, `~scipy.stats.chisquare`,
   `~scipy.stats.pointbiserialr`, `~scipy.stats.kendalltau`,
   `~scipy.stats.weightedtau`, `~scipy.stats.theilslopes`,
-  `~scipy.stats.siegelslopes`, and `~scipy.stats.boxcox_llf`.
+  `~scipy.stats.siegelslopes`, `~scipy.stats.boxcox_llf`, and
+  `~scipy.stats.linregress`.
+- Support for ``keepdims`` and ``nan_policy`` keywords was added to
+  `~scipy.stats.gstd`.
 - The performance of `scipy.stats.special_ortho_group` and `scipy.stats.pearsonr`
   was improved.
+- Support for an ``rng`` keyword argument was added to the ``logcdf`` and
+  ``cdf`` methods of ``multivariate_normal_gen`` and ``multivariate_normal_frozen``.
 
 
 **************************
@@ -255,6 +260,12 @@ Expired Deprecations
   must be specified separately as ``x`` and ``y``.
 - Support for NumPy masked arrays has been removed from
   `scipy.stats.power_divergence` and `scipy.stats.chisquare`.
+- The deprecated ``scipy.optimize.slsqp.zeros`` function has been removed.
+- Several deprecated unintentionally-public helper functions in `scipy.sparse`
+  have been removed as detailed at
+  `<https://github.com/scipy/scipy-stubs/pull/557>`__.
+- Most of the deprecated functions in ``scipy.interpolate.dfitpack``
+  have been removed.
 
 
 ******************************
@@ -267,6 +278,9 @@ Backwards incompatible changes
   to the rules specified in :ref:`linalg_batch`.
 - `scipy.stats.bootstrap` now explicitly broadcasts elements of ``data`` to the
   same shape (ignoring ``axis``) before performing the calculation.
+- Several submodule names are no longer available via ``from scipy.signal import *``,
+  but may still be imported directly, as detailed at
+  `<https://github.com/scipy/scipy-stubs/pull/549>`__.
 
 
 ***********************************
@@ -343,7 +357,7 @@ Authors
 * Richard Strong Bowen (2) +
 * Jake Bowhay (126)
 * Matthew Brett (1)
-* Dietrich Brunn (52)
+* Dietrich Brunn (53)
 * Evgeni Burovski (252)
 * Christine P. Chai (12) +
 * Gayatri Chakkithara (1) +
@@ -358,10 +372,10 @@ Authors
 * Matthew H Flamm (1)
 * Karthik Viswanath Ganti (1) +
 * Neil Girdhar (1)
-* Ralf Gommers (153)
+* Ralf Gommers (157)
 * Rohit Goswami (4)
 * Saarthak Gupta (4) +
-* Matt Haberland (320)
+* Matt Haberland (325)
 * Sasha Hafner (1) +
 * Joren Hammudoglu (9)
 * Chengyu Han (1) +
@@ -370,13 +384,14 @@ Authors
 * Yongcai Huang (2) +
 * Lukas Huber (1) +
 * Yuji Ikeda (2) +
-* Guido Imperiale (103) +
+* Guido Imperiale (104) +
 * Robert Kern (2)
 * Harin Khakhi (2) +
 * Agriya Khetarpal (4)
 * Kirill R. (2) +
 * Tetsuo Koyama (1)
 * Jigyasu Krishnan (1) +
+* Abhishek Kumar (2) +
 * Pratham Kumar (3) +
 * David Kun (1) +
 * Eric Larson (3)
@@ -389,6 +404,7 @@ Authors
 * Panos Mavrogiorgos (1) +
 * Nikolay Mayorov (2)
 * Melissa Weber Mendonça (10)
+* Michał Górny (1)
 * Miguel Cárdenas (2) +
 * Swastik Mishra (1) +
 * Sturla Molden (2)
@@ -400,7 +416,7 @@ Authors
 * Victor PM (10) +
 * pmav99 (1) +
 * Ilhan Polat (73)
-* Tyler Reddy (66)
+* Tyler Reddy (91)
 * Érico Nogueira Rolim (1) +
 * Pamphile Roy (10)
 * Mikhail Ryazanov (6)
@@ -410,7 +426,7 @@ Authors
 * Neil Schemenauer (2) +
 * Daniel Schmitz (20)
 * Martin Schuck (1) +
-* Dan Schult (32)
+* Dan Schult (33)
 * Tomer Sery (19)
 * Adrian Seyboldt (1) +
 * Scott Shambaugh (4)
@@ -443,11 +459,12 @@ Authors
 * Austin Zhang (1) +
 * William Zijie Zhang (1) +
 * Zaikun Zhang (1) +
+* Zhenyu Zhu (1) +
 * Eric Zitong Zhou (11) +
 * Case Zumbrum (2) +
 * ਗਗਨਦੀਪ ਸਿੰਘ (Gagandeep Singh) (45)
 
-    A total of 121 people contributed to this release.
+    A total of 124 people contributed to this release.
     People with a "+" by their names contributed a patch for the first time.
     This list of names is automatically generated, and may not be fully complete.
 
@@ -625,6 +642,13 @@ Issues closed for 1.16.0
 * `#22956 <https://github.com/scipy/scipy/issues/22956>`__: BUG: special._ufuncs._ncx2_pdf: interpreter crash with extreme...
 * `#22965 <https://github.com/scipy/scipy/issues/22965>`__: BUG: The attribute "nit" is not found when using the callback...
 * `#22981 <https://github.com/scipy/scipy/issues/22981>`__: Bug with freqz when specifying worN after #22886
+* `#23035 <https://github.com/scipy/scipy/issues/23035>`__: TST: theilsope & siegelslope-related tests are failing on PyPy3.11...
+* `#23036 <https://github.com/scipy/scipy/issues/23036>`__: BUG: scipy.signal.csd doesn't zero-pad for different size inputs...
+* `#23038 <https://github.com/scipy/scipy/issues/23038>`__: DOC: ``linalg.toeplitz`` does not support batching like the ``1.16.0rc1``...
+* `#23046 <https://github.com/scipy/scipy/issues/23046>`__: ENH: ``vectorized_filter``\ : special case of scalar ``size``...
+* `#23061 <https://github.com/scipy/scipy/issues/23061>`__: DOC: Wrong SPDX identifier for OpenBLAS and LAPACK
+* `#23068 <https://github.com/scipy/scipy/issues/23068>`__: BUG: sparse: ``!=`` operator with csr matrices
+* `#23109 <https://github.com/scipy/scipy/issues/23109>`__: BUG: spatial.distance.cdist: wrong result in Yule metric
 
 ************************
 Pull requests for 1.16.0
@@ -1066,6 +1090,7 @@ Pull requests for 1.16.0
 * `#22982 <https://github.com/scipy/scipy/pull/22982>`__: BUG: signal: fix incorrect vendoring of ``npp_polyval``
 * `#22984 <https://github.com/scipy/scipy/pull/22984>`__: MAINT: special: remove test_compiles_in_cupy
 * `#22987 <https://github.com/scipy/scipy/pull/22987>`__: DOC: sparse: sparray migration guide updates
+* `#22991 <https://github.com/scipy/scipy/pull/22991>`__: DOC: update SciPy 1.16.0 release notes
 * `#22992 <https://github.com/scipy/scipy/pull/22992>`__: ENH: ``signal.cspline1d_eval,qspline1d_eval`` throw exception...
 * `#22994 <https://github.com/scipy/scipy/pull/22994>`__: DOC: signal.csd: Small fixes to docstr
 * `#22997 <https://github.com/scipy/scipy/pull/22997>`__: CI: temporarily disable free-threaded job with parallel-threads
@@ -1074,3 +1099,18 @@ Pull requests for 1.16.0
 * `#23000 <https://github.com/scipy/scipy/pull/23000>`__: ENH/DOC/TST: ``cluster.vq``\ : use ``xp_capabilities``
 * `#23001 <https://github.com/scipy/scipy/pull/23001>`__: DOC: ``special``\ : update top-level docs to reflect ``xp_capabilities``
 * `#23005 <https://github.com/scipy/scipy/pull/23005>`__: BUG: sparse: fix mean/sum change in return of np.matrix for sparse...
+* `#23010 <https://github.com/scipy/scipy/pull/23010>`__: DOC: edit and extend the release notes for 1.16.0
+* `#23013 <https://github.com/scipy/scipy/pull/23013>`__: MAINT: version pins/prep for 1.16.0rc1
+* `#23014 <https://github.com/scipy/scipy/pull/23014>`__: DOC: .mailmap updates for 1.16.0rc1
+* `#23029 <https://github.com/scipy/scipy/pull/23029>`__: DOC: add documentation for the new ``use-system-libraries`` build...
+* `#23031 <https://github.com/scipy/scipy/pull/23031>`__: REL: set 1.16.0rc2 unreleased
+* `#23040 <https://github.com/scipy/scipy/pull/23040>`__: DOC: linalg: adjust release note wording
+* `#23044 <https://github.com/scipy/scipy/pull/23044>`__: TST: update all ``result_to_tuple=`` callables to accept two...
+* `#23047 <https://github.com/scipy/scipy/pull/23047>`__: BUG: signal.csd: Zero-pad for different size inputs
+* `#23048 <https://github.com/scipy/scipy/pull/23048>`__: MAINT: ndimage.vectorized_filter: fix behavior of axes when length...
+* `#23051 <https://github.com/scipy/scipy/pull/23051>`__: MAINT/ENH: ndimage.vectorized_filter: adjust scalar size to match...
+* `#23086 <https://github.com/scipy/scipy/pull/23086>`__: CI: update windows-2019 runner image to windows-2022
+* `#23091 <https://github.com/scipy/scipy/pull/23091>`__: BUG: sparse: correct eq and ne with different shapes. (and add...
+* `#23099 <https://github.com/scipy/scipy/pull/23099>`__: MAINT: fix SPDX license expressions for LAPACK, OpenBLAS, GCC
+* `#23106 <https://github.com/scipy/scipy/pull/23106>`__: TST: CI broken vs pytest 8.4.0
+* `#23110 <https://github.com/scipy/scipy/pull/23110>`__: BUG: spatial.distance: yule implementation in ``distance_metrics.h``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ requires = [
     "Cython>=3.0.8,<3.2.0",
     # The upper bound on pybind11 is pre-emptive only
     "pybind11>=2.13.2,<2.14.0",
-    # The upper bound on pythran is pre-emptive only; 0.17.0
+    # The upper bound on pythran is pre-emptive only; 0.18.0
     # is released/working at the time of writing
-    "pythran>=0.14.0,<0.18.0",
+    "pythran>=0.14.0,<0.19.0",
 
     # numpy requirement for wheel builds for distribution on PyPI - building
     # against 2.x yields wheels that are also compatible with numpy 1.x at

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -101,9 +101,10 @@ def _vectorized_filter_iv(input, function, size, footprint, output, mode, cval, 
                        "(`len(size)` or `footprint.ndim`) does not equal the number "
                        "of axes of `input` (`input.ndim`).")
             raise ValueError(message)
-        axes = (axes,) if np.isscalar(axes) else axes
     else:
-        axes = tuple(range(-n_axes, 0))
+        axes = tuple(range(-n_axes, 0)) if axes is None else axes
+
+    axes = (axes,) if np.isscalar(axes) else axes
 
     # If `origin` is provided, then it must be "broadcastable" to a tuple with length
     # equal to the core dimensionality.

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -219,7 +219,19 @@ def vectorized_filter(input, function, *, size=None, footprint=None, output=None
 
         where ``axis`` specifies the axis (or axes) of ``window`` along which
         the filter function is evaluated.
-    %(size_foot)s
+    size : scalar or tuple, optional
+        See `footprint` below. Ignored if `footprint` is given.
+    footprint : array, optional
+        Either `size` or `footprint` must be defined. `size` gives
+        the shape that is taken from the input array, at every element
+        position, to define the input to the filter function.
+        `footprint` is a boolean array that specifies (implicitly) a
+        shape, but also which of the elements within this shape will get
+        passed to the filter function. Thus ``size=(n, m)`` is equivalent
+        to ``footprint=np.ones((n, m))``.
+        We adjust `size` to the number of dimensions indicated by `axes`.
+        For instance, if `axes` is ``(0, 2, 1)`` and ``n`` is passed for ``size``,
+        then the effective `size` is ``(n, n, n)``.
     %(output)s
     mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
         The `mode` parameter determines how the input array is extended

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -68,12 +68,23 @@ def _vectorized_filter_iv(input, function, size, footprint, output, mode, cval, 
     if size is not None and footprint is not None:
         raise ValueError("Either `size` or `footprint` may be provided, not both.")
 
-    # Either footprint or size must be provided, and these determine the core
-    # dimensionality...
+    if axes is None:
+        axes = tuple(range(-input.ndim, 0))
+    elif np.isscalar(axes):
+        axes = (axes,)
+    n_axes = len(axes)
+    n_batch = input.ndim - n_axes
+
+    if n_axes > input.ndim:
+        message = ("The length of `axes` may not exceed the dimensionality of `input`"
+                   "(`input.ndim`).")
+        raise ValueError(message)
+
+    # Either footprint or size must be provided
     footprinted_function = function
     if size is not None:
         # If provided, size must be an integer or tuple of integers.
-        size = (size,)*input.ndim if np.isscalar(size) else tuple(size)
+        size = (size,)*n_axes if np.isscalar(size) else tuple(size)
         valid = [xp.isdtype(xp.asarray(i).dtype, 'integral') and i > 0 for i in size]
         if not all(valid):
             raise ValueError("All elements of `size` must be positive integers.")
@@ -84,13 +95,10 @@ def _vectorized_filter_iv(input, function, size, footprint, output, mode, cval, 
         def footprinted_function(input, *args, axis=-1, **kwargs):
             return function(input[..., footprint], *args, axis=-1, **kwargs)
 
-    n_axes = len(size)
-    n_batch = input.ndim - n_axes
-
-    # ...which can't exceed the dimensionality of `input`.
-    if n_axes > input.ndim:
-        message = ("The dimensionality of the window (`len(size)` or `footprint.ndim`) "
-                   "may not exceed the number of axes of `input` (`input.ndim`).")
+    # And by now, the dimensionality of the footprint must equal the number of axes
+    if n_axes != len(size):
+        message = ("`axes` must be compatible with the dimensionality "
+                   "of the window specified by `size` or `footprint`.")
         raise ValueError(message)
 
     # If this is not *equal* to the dimensionality of `input`, then `axes`
@@ -151,10 +159,9 @@ def _vectorized_filter_iv(input, function, size, footprint, output, mode, cval, 
 
     # For simplicity, work with `axes` at the end.
     working_axes = tuple(range(-n_axes, 0))
-    if axes is not None:
-        input = xp.moveaxis(input, axes, working_axes)
-        output = (xp.moveaxis(output, axes, working_axes)
-                  if output is not None else output)
+    input = xp.moveaxis(input, axes, working_axes)
+    output = (xp.moveaxis(output, axes, working_axes)
+              if output is not None else output)
 
     # Wrap the function to limit maximum memory usage, deal with `footprint`,
     # and populate `output`. The latter requires some verbosity because we
@@ -191,8 +198,8 @@ def _vectorized_filter_iv(input, function, size, footprint, output, mode, cval, 
                                                          **kwargs)
         return output
 
-    return (input, wrapped_function, size, mode, cval,
-            origin, working_axes, n_axes, n_batch, xp)
+    return (input, wrapped_function, size, mode, cval, origin,
+            working_axes, axes, n_axes, n_batch, xp)
 
 
 @_ni_docstrings.docfiller
@@ -410,7 +417,7 @@ def vectorized_filter(input, function, *, size=None, footprint=None, output=None
 
     """  # noqa: E501
 
-    (input, function, size, mode, cval, origin, working_axes, n_axes, n_batch, xp
+    (input, function, size, mode, cval, origin, working_axes, axes, n_axes, n_batch, xp
      ) = _vectorized_filter_iv(input, function, size, footprint, output, mode, cval,
         origin, axes, batch_memory)
 
@@ -456,7 +463,7 @@ def vectorized_filter(input, function, *, size=None, footprint=None, output=None
     res = function(view)
 
     # move working_axes back to original positions
-    return xp.moveaxis(res, working_axes, axes) if axes is not None else res
+    return xp.moveaxis(res, working_axes, axes)
 
 
 def _invalid_origin(origin, lenw):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2908,15 +2908,19 @@ class TestVectorizedFilter:
         with pytest.raises(ValueError, match=message):
             ndimage.vectorized_filter(input, function, size=0)
 
-        message = "The dimensionality of the window"
+        message = "The length of `axes` may not exceed "
+        axes = (0, 1, 2)
         with pytest.raises(ValueError, match=message):
-            ndimage.vectorized_filter(input, function, size=(1, 2, 3))
+            ndimage.vectorized_filter(input, function, size=(1, 2), axes=axes)
         with pytest.raises(ValueError, match=message):
-            ndimage.vectorized_filter(input, function, footprint=xp.ones((2, 2, 2)))
+            ndimage.vectorized_filter(input, function, footprint=xp.ones((2, 2)),
+                                      axes=axes)
 
-        message = "`axes` must be provided if the dimensionality..."
+        message = "`axes` must be compatible with the dimensionality..."
         with pytest.raises(ValueError, match=message):
             ndimage.vectorized_filter(input, function, size=(1,))
+        with pytest.raises(ValueError, match=message):
+            ndimage.vectorized_filter(input, function, size=(2,), axes=(0,1))
 
         message = "All elements of `origin` must be integers"
         with pytest.raises(ValueError, match=message):
@@ -2986,7 +2990,20 @@ class TestVectorizedFilter:
         ref = ndimage.vectorized_filter(input, function, size=21)
         xp_assert_close(res, ref)
 
-    def test_gh23046(self, xp):
+    def test_gh23046_feature(self, xp):
+        # The intent of gh-23046 was to always allow `size` to be a scalar.
+        rng = np.random.default_rng(45982734597824)
+        img = xp.asarray(rng.random((5, 5)))
+
+        ref = ndimage.vectorized_filter(img, xp.mean, size=2)
+        res = ndimage.vectorized_filter(img, xp.mean, size=2, axes=(0, 1))
+        xp_assert_close(res, ref)
+
+        ref = ndimage.vectorized_filter(img, xp.mean, size=(2,), axes=(0,))
+        res = ndimage.vectorized_filter(img, xp.mean, size=2, axes=0)
+        xp_assert_close(res, ref)
+
+    def test_gh23046_fix(self, xp):
         # While investigating the feasibility of gh-23046, I noticed a bug when the
         # length of an `axes` tuple equals the dimensionality of the image.
         rng = np.random.default_rng(45982734597824)
@@ -3000,6 +3017,7 @@ class TestVectorizedFilter:
         res = ndimage.vectorized_filter(img, xp.mean, size=size[::-1], axes=(1, 0),
                                         mode='constant')
         xp_assert_close(res, ref)
+
 
 
 @given(x=npst.arrays(dtype=np.float64,

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2571,7 +2571,7 @@ class TestThreading:
         for i in range(n):
             fun(*args, output=out[i, ...])
 
-    @xfail_xp_backends("cupy", 
+    @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
     def test_correlate1d(self, xp):
         d = np.random.randn(5000)
@@ -2585,7 +2585,7 @@ class TestThreading:
         self.check_func_thread(4, ndimage.correlate1d, (d, k), ot)
         xp_assert_equal(os, ot)
 
-    @xfail_xp_backends("cupy", 
+    @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
     def test_correlate(self, xp):
         d = xp.asarray(np.random.randn(500, 500))
@@ -2596,7 +2596,7 @@ class TestThreading:
         self.check_func_thread(4, ndimage.correlate, (d, k), ot)
         xp_assert_equal(os, ot)
 
-    @xfail_xp_backends("cupy", 
+    @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
     def test_median_filter(self, xp):
         d = xp.asarray(np.random.randn(500, 500))
@@ -2606,7 +2606,7 @@ class TestThreading:
         self.check_func_thread(4, ndimage.median_filter, (d, 3), ot)
         xp_assert_equal(os, ot)
 
-    @xfail_xp_backends("cupy", 
+    @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
     def test_uniform_filter1d(self, xp):
         d = np.random.randn(5000)
@@ -2619,7 +2619,7 @@ class TestThreading:
         self.check_func_thread(4, ndimage.uniform_filter1d, (d, 5), ot)
         xp_assert_equal(os, ot)
 
-    @xfail_xp_backends("cupy", 
+    @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
     def test_minmax_filter(self, xp):
         d = xp.asarray(np.random.randn(500, 500))
@@ -2984,6 +2984,21 @@ class TestVectorizedFilter:
         # window is bigger than input shouldn't be a problem
         res = ndimage.vectorized_filter(input, function, size=21)
         ref = ndimage.vectorized_filter(input, function, size=21)
+        xp_assert_close(res, ref)
+
+    def test_gh23046(self, xp):
+        # While investigating the feasibility of gh-23046, I noticed a bug when the
+        # length of an `axes` tuple equals the dimensionality of the image.
+        rng = np.random.default_rng(45982734597824)
+        img = xp.asarray(rng.random((5, 5)))
+        size = (2, 3)
+        ref = ndimage.vectorized_filter(img.T, xp.mean, size=size).T
+        res = ndimage.vectorized_filter(img, xp.mean, size=size, axes=(1, 0))
+        xp_assert_close(res, ref)
+
+        ref = ndimage.vectorized_filter(img, xp.mean, size=size, mode='constant')
+        res = ndimage.vectorized_filter(img, xp.mean, size=size[::-1], axes=(1, 0),
+                                        mode='constant')
         xp_assert_close(res, ref)
 
 

--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -239,7 +239,7 @@ class SparseMixin:
 
         # Default lsmr arguments should not fully converge the solution
         default_lsmr_sol = lsq_linear(A, b, lsq_solver='lsmr')
-        with pytest.raises(AssertionError, match=""):
+        with pytest.raises(AssertionError):
             assert_allclose(exact_sol.x, default_lsmr_sol.x)
 
         # By increasing the maximum lsmr iters, it will converge

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -897,6 +897,15 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     if np.iscomplexobj(x) and return_onesided:
         return_onesided = False
 
+    if x.shape[axis] < y.shape[axis]:  # zero-pad x to shape of y:
+        z_shape = list(y.shape)
+        z_shape[axis] = y.shape[axis] - x.shape[axis]
+        x = np.concatenate((x, np.zeros(z_shape)), axis=axis)
+    elif y.shape[axis] < x.shape[axis]:  # zero-pad y to shape of x:
+        z_shape = list(x.shape)
+        z_shape[axis] = x.shape[axis] - y.shape[axis]
+        y = np.concatenate((y, np.zeros(z_shape)), axis=axis)
+
     # using cast() to make mypy happy:
     fft_mode = cast(FFT_MODE_TYPE, 'onesided' if return_onesided else 'twosided')
     if scaling not in (scales := {'spectrum': 'magnitude', 'density': 'psd'}):

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -658,7 +658,7 @@ class _spbase(SparseABC):
                 # eq and ne return True or False instead of an array when the shapes
                 # don't match. Numpy doesn't do this. Is this what we want?
                 if op in (operator.eq, operator.ne):
-                    return op == operator.eq
+                    return op is operator.ne
                 raise ValueError("inconsistent shape")
 
             csr_self = (self if self.ndim < 3 else self.reshape(1, -1)).tocsr()

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -433,6 +433,13 @@ class _TestCommon:
         for dtype in self.checked_dtypes:
             check(dtype)
 
+    def test_eq_ne_different_shapes(self):
+        if self.datsp.format not in ['bsr', 'csc', 'csr']:
+            pytest.skip("Bool comparisons only implemented for BSR, CSC, and CSR.")
+        # Is this what we want? numpy raises when shape differs. we return False.
+        assert (self.datsp == self.datsp.T) is False
+        assert (self.datsp != self.datsp.T) is True
+
     def test_lt(self):
         sup = suppress_warnings()
         sup.filter(SparseEfficiencyWarning)

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -722,7 +722,7 @@ struct YuleDistance {
     template <typename T>
     struct Acc {
         Acc(): ntt(0), nft(0), nff(0), ntf(0) {}
-        intptr_t ntt, nft, nff, ntf;
+        T ntt, nft, nff, ntf;
     };
 
     template <typename T>
@@ -736,7 +736,7 @@ struct YuleDistance {
             return acc;
         },
         [](const Acc<T>& acc) INLINE_LAMBDA {
-            intptr_t half_R = acc.ntf * acc.nft;
+            T half_R = acc.ntf * acc.nft;
             return (2. * half_R) / (acc.ntt * acc.nff + half_R + (half_R == 0));
         },
         [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {
@@ -754,13 +754,13 @@ struct YuleDistance {
         transform_reduce_2d_<2>(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
             Acc<T> acc;
             acc.ntt = w * ((x != 0) & (y != 0));
-            acc.ntf = w * ((x != 0) & (!(y != 0)));
-            acc.nft = w * ((!(x != 0)) & (y != 0));
-            acc.nff = w * ((!(x != 0)) & (!(y != 0)));
+            acc.ntf = w * ((x != 0) & (y == 0));
+            acc.nft = w * ((x == 0) & (y != 0));
+            acc.nff = w * ((x == 0) & (y == 0));
             return acc;
         },
         [](const Acc<T>& acc) INLINE_LAMBDA {
-            intptr_t half_R = acc.ntf * acc.nft;
+            T half_R = acc.ntf * acc.nft;
             return (2. * half_R) / (acc.ntt * acc.nff + half_R + (half_R == 0));
         },
         [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2231,6 +2231,18 @@ def test_immutable_input(metric):
         getattr(scipy.spatial.distance, metric)(x, x, w=x)
 
 
+def test_gh_23109():
+    a = np.array([0, 0, 1, 1])
+    b = np.array([0, 1, 1, 0])
+    w = np.asarray([1.5, 1.2, 0.7, 1.3])
+    expected = yule(a, b, w=w)
+    assert_allclose(expected, 1.1954022988505748)
+    actual = cdist(np.atleast_2d(a),
+                   np.atleast_2d(b),
+                   metric='yule', w=w)
+    assert_allclose(actual, expected)
+
+
 class TestJaccard:
 
     def test_pdist_jaccard_random(self):

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -403,16 +403,8 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
     override.update(temp)
 
     if result_to_tuple is None:
-        def result_to_tuple(res):
+        def result_to_tuple(res, _):
             return res
-
-    # The only `result_to_tuple` that needs the second argument (number of
-    # outputs) is the one for `moment`, and this was realized very late.
-    # Rather than changing all `result_to_tuple` definitions, we wrap them
-    # here to accept a second argument if they don't already.
-    if len(inspect.signature(result_to_tuple).parameters) == 1:
-        def result_to_tuple(res, _, f=result_to_tuple):
-            return f(res)
 
     if not callable(too_small):
         def is_too_small(samples, *ts_args, axis=-1, **ts_kwargs):

--- a/scipy/stats/_correlation.py
+++ b/scipy/stats/_correlation.py
@@ -81,7 +81,7 @@ def _chatterjeexi_iv(y_continuous, method):
     return y_continuous, method
 
 
-def _unpack(res):
+def _unpack(res, _):
     return res.statistic, res.pvalue
 
 

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -20,7 +20,7 @@ __all__ = ['entropy', 'differential_entropy']
         2 if ("qk" in kwgs and kwgs["qk"] is not None)
         else 1
     ),
-    n_outputs=1, result_to_tuple=lambda x: (x,), paired=True,
+    n_outputs=1, result_to_tuple=lambda x, _: (x,), paired=True,
     too_small=-1  # entropy doesn't have too small inputs
 )
 def entropy(pk: np.typing.ArrayLike,
@@ -170,7 +170,7 @@ def _differential_entropy_is_too_small(samples, kwargs, axis=-1):
 
 
 @_axis_nan_policy_factory(
-    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,),
+    lambda x: x, n_outputs=1, result_to_tuple=lambda x, _: (x,),
     too_small=_differential_entropy_is_too_small
 )
 def differential_entropy(

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -482,7 +482,7 @@ def _cdf_cvm(x, n=None):
     return y
 
 
-def _cvm_result_to_tuple(res):
+def _cvm_result_to_tuple(res, _):
     return res.statistic, res.pvalue
 
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -222,7 +222,7 @@ def mvsdist(data):
 
 
 @_axis_nan_policy_factory(
-    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1, default_axis=None
+    lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1, default_axis=None
 )
 def kstat(data, n=2, *, axis=None):
     r"""
@@ -327,7 +327,7 @@ def kstat(data, n=2, *, axis=None):
 
 
 @_axis_nan_policy_factory(
-    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1, default_axis=None
+    lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1, default_axis=None
 )
 def kstatvar(data, n=2, *, axis=None):
     r"""Return an unbiased estimator of the variance of the k-statistic.
@@ -984,7 +984,7 @@ def boxcox_llf(lmb, data, *, axis=0, keepdims=False, nan_policy='propagate'):
 
 
 @_axis_nan_policy_factory(lambda x: x, n_outputs=1, default_axis=0,
-                          result_to_tuple=lambda x: (x,))
+                          result_to_tuple=lambda x, _: (x,))
 def _boxcox_llf(data, axis=0, *, lmb):
     xp = array_namespace(data)
     lmb, data = xp_promote(lmb, data, force_floating=True, xp=xp)
@@ -3496,7 +3496,7 @@ def mood(x, y, axis=0, alternative="two-sided"):
 WilcoxonResult = _make_tuple_bunch('WilcoxonResult', ['statistic', 'pvalue'])
 
 
-def wilcoxon_result_unpacker(res):
+def wilcoxon_result_unpacker(res, _):
     if hasattr(res, 'zstatistic'):
         return res.statistic, res.pvalue, res.zstatistic
     else:
@@ -3993,7 +3993,7 @@ def _circfuncs_common(samples, period, xp=None):
 
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, default_axis=None,
-    result_to_tuple=lambda x: (x,)
+    result_to_tuple=lambda x, _: (x,)
 )
 def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
     r"""Compute the circular mean of a sample of angle observations.
@@ -4086,7 +4086,7 @@ def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
 
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, default_axis=None,
-    result_to_tuple=lambda x: (x,)
+    result_to_tuple=lambda x, _: (x,)
 )
 def circvar(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
     r"""Compute the circular variance of a sample of angle observations.
@@ -4180,7 +4180,7 @@ def circvar(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
 
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, default_axis=None,
-    result_to_tuple=lambda x: (x,)
+    result_to_tuple=lambda x, _: (x,)
 )
 def circstd(samples, high=2*pi, low=0, axis=None, nan_policy='propagate', *,
             normalize=False):

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -21,7 +21,8 @@ def _n_samples_optional_x(kwargs):
 
 @_axis_nan_policy_factory(TheilslopesResult, default_axis=None, n_outputs=4,
                           n_samples=_n_samples_optional_x,
-                          result_to_tuple=tuple, paired=True, too_small=1)
+                          result_to_tuple=lambda x, _: tuple(x), paired=True,
+                          too_small=1)
 def theilslopes(y, x=None, alpha=0.95, method='separate'):
     r"""
     Computes the Theil-Sen estimator for a set of points (x, y).
@@ -204,7 +205,8 @@ def _find_repeats(arr):
 
 @_axis_nan_policy_factory(SiegelslopesResult, default_axis=None, n_outputs=2,
                           n_samples=_n_samples_optional_x,
-                          result_to_tuple=tuple, paired=True, too_small=1)
+                          result_to_tuple=lambda x, _: tuple(x), paired=True,
+                          too_small=1)
 def siegelslopes(y, x=None, method="hierarchical"):
     r"""
     Computes the Siegel estimator for a set of points (x, y).

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -160,7 +160,7 @@ def _pack_CorrelationResult(statistic, pvalue, correlation):
     return res
 
 
-def _unpack_CorrelationResult(res):
+def _unpack_CorrelationResult(res, _):
     return res.statistic, res.pvalue, res.correlation
 
 
@@ -168,7 +168,7 @@ def _unpack_CorrelationResult(res):
 @xp_capabilities()
 @_axis_nan_policy_factory(
         lambda x: x, n_samples=1, n_outputs=1, too_small=0, paired=True,
-        result_to_tuple=lambda x: (x,), kwd_samples=['weights'])
+        result_to_tuple=lambda x, _: (x,), kwd_samples=['weights'])
 def gmean(a, axis=0, dtype=None, weights=None):
     r"""Compute the weighted geometric mean along the specified axis.
 
@@ -252,7 +252,7 @@ def gmean(a, axis=0, dtype=None, weights=None):
 @xp_capabilities(jax_jit=False, allow_dask_compute=1)
 @_axis_nan_policy_factory(
         lambda x: x, n_samples=1, n_outputs=1, too_small=0, paired=True,
-        result_to_tuple=lambda x: (x,), kwd_samples=['weights'])
+        result_to_tuple=lambda x, _: (x,), kwd_samples=['weights'])
 def hmean(a, axis=0, dtype=None, *, weights=None):
     r"""Calculate the weighted harmonic mean along the specified axis.
 
@@ -353,7 +353,7 @@ def hmean(a, axis=0, dtype=None, *, weights=None):
 @xp_capabilities(jax_jit=False, allow_dask_compute=1)
 @_axis_nan_policy_factory(
         lambda x: x, n_samples=1, n_outputs=1, too_small=0, paired=True,
-        result_to_tuple=lambda x: (x,), kwd_samples=['weights'])
+        result_to_tuple=lambda x, _: (x,), kwd_samples=['weights'])
 def pmean(a, p, *, axis=0, dtype=None, weights=None):
     r"""Calculate the weighted power mean along the specified axis.
 
@@ -634,7 +634,7 @@ def _put_val_to_limits(a, limits, inclusive, val=np.nan, xp=None):
 @xp_capabilities()
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, default_axis=None,
-    result_to_tuple=lambda x: (x,)
+    result_to_tuple=lambda x, _: (x,)
 )
 def tmean(a, limits=None, inclusive=(True, True), axis=None):
     """Compute the trimmed mean.
@@ -689,7 +689,7 @@ def tmean(a, limits=None, inclusive=(True, True), axis=None):
 
 @xp_capabilities()
 @_axis_nan_policy_factory(
-    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
+    lambda x: x, n_outputs=1, result_to_tuple=lambda x, _: (x,)
 )
 def tvar(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     """Compute the trimmed variance.
@@ -749,7 +749,7 @@ def tvar(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
 
 @xp_capabilities()
 @_axis_nan_policy_factory(
-    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
+    lambda x: x, n_outputs=1, result_to_tuple=lambda x, _: (x,)
 )
 def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
     """Compute the trimmed minimum.
@@ -813,7 +813,7 @@ def tmin(a, lowerlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
 
 @xp_capabilities()
 @_axis_nan_policy_factory(
-    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
+    lambda x: x, n_outputs=1, result_to_tuple=lambda x, _: (x,)
 )
 def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
     """Compute the trimmed maximum.
@@ -876,7 +876,7 @@ def tmax(a, upperlimit=None, axis=0, inclusive=True, nan_policy='propagate'):
 
 @xp_capabilities()
 @_axis_nan_policy_factory(
-    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
+    lambda x: x, n_outputs=1, result_to_tuple=lambda x, _: (x,)
 )
 def tstd(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     """Compute the trimmed sample standard deviation.
@@ -929,7 +929,7 @@ def tstd(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
 
 @xp_capabilities()
 @_axis_nan_policy_factory(
-    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
+    lambda x: x, n_outputs=1, result_to_tuple=lambda x, _: (x,)
 )
 def tsem(a, limits=None, inclusive=(True, True), axis=0, ddof=1):
     """Compute the trimmed standard error of the mean.
@@ -1265,7 +1265,7 @@ def _share_masks(*args, xp):
 
 @xp_capabilities(jax_jit=False, allow_dask_compute=2)
 @_axis_nan_policy_factory(
-    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1
+    lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1
 )
 # nan_policy handled by `_axis_nan_policy`, but needs to be left
 # in signature to preserve use as a positional argument
@@ -1366,7 +1366,7 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
 
 @xp_capabilities(jax_jit=False, allow_dask_compute=2)
 @_axis_nan_policy_factory(
-    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1
+    lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1
 )
 # nan_policy handled by `_axis_nan_policy`, but needs to be left
 # in signature to preserve use as a positional argument
@@ -2602,7 +2602,7 @@ def obrientransform(*samples):
 
 @xp_capabilities()
 @_axis_nan_policy_factory(
-    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1, too_small=1
+    lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1, too_small=1
 )
 def sem(a, axis=0, ddof=1, nan_policy='propagate'):
     """Compute standard error of the mean.
@@ -3070,7 +3070,7 @@ _scale_conversions = {'normal': special.erfinv(0.5) * 2.0 * math.sqrt(2.0)}
 
 
 @_axis_nan_policy_factory(
-    lambda x: x, result_to_tuple=lambda x: (x,), n_outputs=1,
+    lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1,
     default_axis=None, override={'nan_propagation': False}
 )
 def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
@@ -4068,7 +4068,7 @@ class AlexanderGovernResult:
 
 @_axis_nan_policy_factory(
     AlexanderGovernResult, n_samples=None,
-    result_to_tuple=lambda x: (x.statistic, x.pvalue),
+    result_to_tuple=lambda x, _: (x.statistic, x.pvalue),
     too_small=1
 )
 def alexandergovern(*samples, nan_policy='propagate', axis=0):
@@ -6027,7 +6027,7 @@ def pack_TtestResult(statistic, pvalue, df, alternative, standard_error,
                        standard_error=standard_error, estimate=estimate)
 
 
-def unpack_TtestResult(res):
+def unpack_TtestResult(res, _):
     return (res.statistic, res.pvalue, res.df, res._alternative,
             res._standard_error, res._estimate)
 
@@ -7633,7 +7633,7 @@ def _tuple_to_KstestResult(statistic, pvalue,
                         statistic_sign=statistic_sign)
 
 
-def _KstestResult_to_tuple(res):
+def _KstestResult_to_tuple(res, _):
     return *res, res.statistic_location, res.statistic_sign
 
 
@@ -10651,7 +10651,7 @@ def _pack_LinregressResult(slope, intercept, rvalue, pvalue, stderr, intercept_s
                             intercept_stderr=intercept_stderr)
 
 
-def _unpack_LinregressResult(res):
+def _unpack_LinregressResult(res, _):
     return tuple(res) + (res.intercept_stderr,)
 
 

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -7,7 +7,7 @@ from ._axis_nan_policy import _axis_nan_policy_factory
 
 
 @_axis_nan_policy_factory(
-    lambda x: x, n_outputs=1, result_to_tuple=lambda x: (x,)
+    lambda x: x, n_outputs=1, result_to_tuple=lambda x, _: (x,)
 )
 def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
     """

--- a/tools/wheels/LICENSE_linux.txt
+++ b/tools/wheels/LICENSE_linux.txt
@@ -9,7 +9,7 @@ Name: OpenBLAS
 Files: scipy.libs/libscipy_openblas*.so
 Description: bundled as a dynamically linked library
 Availability: https://github.com/OpenMathLib/OpenBLAS/
-License: BSD-3-Clause-Attribution
+License: BSD-3-Clause
   Copyright (c) 2011-2014, The OpenBLAS Project
   All rights reserved.
   
@@ -45,7 +45,7 @@ Name: LAPACK
 Files: scipy.libs/libscipy_openblas*.so
 Description: bundled in OpenBLAS
 Availability: https://github.com/OpenMathLib/OpenBLAS/
-License: BSD-3-Clause-Attribution
+License: BSD-3-Clause-Open-MPI
   Copyright (c) 1992-2013 The University of Tennessee and The University
                           of Tennessee Research Foundation.  All rights
                           reserved.
@@ -100,7 +100,7 @@ Name: GCC runtime library
 Files: scipy.libs/libgfortran*.so
 Description: dynamically linked to files compiled with gcc
 Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
-License: GPL-3.0-with-GCC-exception
+License: GPL-3.0-or-later WITH GCC-exception-3.1
   Copyright (C) 2002-2017 Free Software Foundation, Inc.
   
   Libgfortran is free software; you can redistribute it and/or modify

--- a/tools/wheels/LICENSE_osx.txt
+++ b/tools/wheels/LICENSE_osx.txt
@@ -9,7 +9,7 @@ Name: OpenBLAS
 Files: scipy/.dylibs/libscipy_openblas*.so
 Description: bundled as a dynamically linked library
 Availability: https://github.com/OpenMathLib/OpenBLAS/
-License: BSD-3-Clause-Attribution
+License: BSD-3-Clause
   Copyright (c) 2011-2014, The OpenBLAS Project
   All rights reserved.
 
@@ -45,7 +45,7 @@ Name: LAPACK
 Files: scipy/.dylibs/libscipy_openblas*.so
 Description: bundled in OpenBLAS
 Availability: https://github.com/OpenMathLib/OpenBLAS/
-License: BSD-3-Clause-Attribution
+License: BSD-3-Clause-Open-MPI
   Copyright (c) 1992-2013 The University of Tennessee and The University
                           of Tennessee Research Foundation.  All rights
                           reserved.
@@ -100,7 +100,7 @@ Name: GCC runtime library
 Files: scipy/.dylibs/libgfortran*, scipy/.dylibs/libgcc*
 Description: dynamically linked to files compiled with gcc
 Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
-License: GPL-3.0-with-GCC-exception
+License: GPL-3.0-or-later WITH GCC-exception-3.1
   Copyright (C) 2002-2017 Free Software Foundation, Inc.
   
   Libgfortran is free software; you can redistribute it and/or modify

--- a/tools/wheels/LICENSE_win32.txt
+++ b/tools/wheels/LICENSE_win32.txt
@@ -9,7 +9,7 @@ Name: OpenBLAS
 Files: scipy.libs\libscipy_openblas*.dll
 Description: bundled as a dynamically linked library
 Availability: https://github.com/OpenMathLib/OpenBLAS/
-License: BSD-3-Clause-Attribution
+License: BSD-3-Clause
   Copyright (c) 2011-2014, The OpenBLAS Project
   All rights reserved.
   
@@ -45,7 +45,7 @@ Name: LAPACK
 Files: scipy.libs\libscipy_openblas*.dll
 Description: bundled in OpenBLAS
 Availability: https://github.com/OpenMathLib/OpenBLAS/
-License: BSD-3-Clause-Attribution
+License: BSD-3-Clause-Open-MPI
   Copyright (c) 1992-2013 The University of Tennessee and The University
                           of Tennessee Research Foundation.  All rights
                           reserved.
@@ -100,7 +100,7 @@ Name: GCC runtime library
 Files: scipy.libs\libscipy_openblas*.dll
 Description: statically linked to files compiled with gcc
 Availability: https://gcc.gnu.org/git/?p=gcc.git;a=tree;f=libgfortran
-License: GPL-3.0-with-GCC-exception
+License: GPL-3.0-or-later WITH GCC-exception-3.1
   Copyright (C) 2002-2017 Free Software Foundation, Inc.
   
   Libgfortran is free software; you can redistribute it and/or modify


### PR DESCRIPTION
Backports included so far:

1. gh-23086
2. gh-23044
3. gh-23029
4. gh-23047
5. gh-23048
6. gh-23051
7. gh-23091
8. gh-23099
9. gh-23106
10. gh-23110
11. gh-23113


-------

TODO:

- [x] reactivate CI, perhaps test wheel builds again depending on how many backports we finally end up with
- [x] consider merging some of the open backport-labeled PRs/dealing with other recent issues; i.e., https://github.com/scipy/scipy/pulls?q=is%3Apr+is%3Aopen+label%3Abackport-candidate
- [x] check that everything is "ok" with us relative to NumPy in release cycle
- [x] Potential release notes adjustment to deal with based on an analysis of type hints/stubs project: https://github.com/scipy/scipy/pull/23098#issuecomment-2942130558
- [x] recheck release notes after above shims
- [x] carefully reread the full diff