### PR TITLE
TST: CI broken vs pytest 8.4.0

### DIFF
--- a/scipy/optimize/tests/test_lsq_linear.py
+++ b/scipy/optimize/tests/test_lsq_linear.py
@@ -239,7 +239,7 @@ class SparseMixin:
 
         # Default lsmr arguments should not fully converge the solution
         default_lsmr_sol = lsq_linear(A, b, lsq_solver='lsmr')
-        with pytest.raises(AssertionError, match=""):
+        with pytest.raises(AssertionError):
             assert_allclose(exact_sol.x, default_lsmr_sol.x)
 
         # By increasing the maximum lsmr iters, it will converge


### PR DESCRIPTION
CI has become very very red this morning
e.g. https://github.com/scipy/scipy/actions/runs/15413696523/job/43371422477?pr=23104