### PR TITLE
BUG: spatial.distance: yule implementation in `distance_metrics.h`

### DIFF
--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -722,7 +722,7 @@ struct YuleDistance {
     template <typename T>
     struct Acc {
         Acc(): ntt(0), nft(0), nff(0), ntf(0) {}
-        intptr_t ntt, nft, nff, ntf;
+        T ntt, nft, nff, ntf;
     };
 
     template <typename T>
@@ -736,7 +736,7 @@ struct YuleDistance {
             return acc;
         },
         [](const Acc<T>& acc) INLINE_LAMBDA {
-            intptr_t half_R = acc.ntf * acc.nft;
+            T half_R = acc.ntf * acc.nft;
             return (2. * half_R) / (acc.ntt * acc.nff + half_R + (half_R == 0));
         },
         [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {
@@ -754,13 +754,13 @@ struct YuleDistance {
         transform_reduce_2d_<2>(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
             Acc<T> acc;
             acc.ntt = w * ((x != 0) & (y != 0));
-            acc.ntf = w * ((x != 0) & (!(y != 0)));
-            acc.nft = w * ((!(x != 0)) & (y != 0));
-            acc.nff = w * ((!(x != 0)) & (!(y != 0)));
+            acc.ntf = w * ((x != 0) & (y == 0));
+            acc.nft = w * ((x == 0) & (y != 0));
+            acc.nff = w * ((x == 0) & (y == 0));
             return acc;
         },
         [](const Acc<T>& acc) INLINE_LAMBDA {
-            intptr_t half_R = acc.ntf * acc.nft;
+            T half_R = acc.ntf * acc.nft;
             return (2. * half_R) / (acc.ntt * acc.nff + half_R + (half_R == 0));
         },
         [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2231,7 +2231,7 @@ def test_immutable_input(metric):
         getattr(scipy.spatial.distance, metric)(x, x, w=x)
 
 
-def test_ajz():
+def test_gh_23109():
     a = np.array([0, 0, 1, 1])
     b = np.array([0, 1, 1, 0])
     w = np.asarray([1.5, 1.2, 0.7, 1.3])

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2231,6 +2231,18 @@ def test_immutable_input(metric):
         getattr(scipy.spatial.distance, metric)(x, x, w=x)
 
 
+def test_ajz():
+    a = np.array([0, 0, 1, 1])
+    b = np.array([0, 1, 1, 0])
+    w = np.asarray([1.5, 1.2, 0.7, 1.3])
+    expected = yule(a, b, w=w)
+    assert_allclose(expected, 1.1954022988505748)
+    actual = cdist(np.atleast_2d(a),
+                   np.atleast_2d(b),
+                   metric='yule', w=w)
+    assert_allclose(actual, expected)
+
+
 class TestJaccard:
 
     def test_pdist_jaccard_random(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes gh-23109 

#### What does this implement/fix?
<!--Please explain your changes.-->

Fixes C++ header implementation of yule metric.

Previously, internal variable type is `intptr_t`. This changes to generic type `T`, in accordance to other boolean distance metric implementations, and also fixes bug that result of `cdist` function does not equal to python implementation of `yule`.
