### PR TITLE
MAINT: remove duplicated test in `stats.tests.test_stats.py`

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7136,8 +7136,6 @@ class TestPMean:
     def test_bad_exponent(self, xp):
         with pytest.raises(ValueError, match='Power mean only defined for'):
             stats.pmean(xp.asarray([1, 2, 3]), xp.asarray([0]))
-        with pytest.raises(ValueError, match='Power mean only defined for'):
-            stats.pmean(xp.asarray([1, 2, 3]), xp.asarray([0]))
 
     def test_1d(self, xp):
         a, p = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100], 3.5


### PR DESCRIPTION
#### Reference issue
No issue involved.

#### What does this implement/fix?
This tiny PR removes an unnecessary duplicated test in `stats.tests.test_stats.py`.

#### Additional information
