### PR TITLE
DOC: Add missing BLAS Level 2 functions

### DIFF
--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -45,15 +45,19 @@ BLAS Level 1 functions
 .. autosummary::
    :toctree: generated/
 
-   caxpy
-   ccopy
-   cdotc
-   cdotu
-   crotg
-   cscal
-   csrot
-   csscal
-   cswap
+   sasum
+   saxpy
+   scasum
+   scnrm2
+   scopy
+   sdot
+   snrm2
+   srot
+   srotg
+   srotm
+   srotmg
+   sscal
+   sswap
    dasum
    daxpy
    dcopy
@@ -71,19 +75,15 @@ BLAS Level 1 functions
    idamax
    isamax
    izamax
-   sasum
-   saxpy
-   scasum
-   scnrm2
-   scopy
-   sdot
-   snrm2
-   srot
-   srotg
-   srotm
-   srotmg
-   sscal
-   sswap
+   caxpy
+   ccopy
+   cdotc
+   cdotu
+   crotg
+   cscal
+   csrot
+   csscal
+   cswap
    zaxpy
    zcopy
    zdotc

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -104,12 +104,15 @@ BLAS Level 2 functions
    sgemv
    sger
    ssbmv
+   sspmv
    sspr
    sspr2
    ssymv
    ssyr
    ssyr2
    stbmv
+   stbsv
+   stpmv
    stpsv
    strmv
    strsv
@@ -117,12 +120,15 @@ BLAS Level 2 functions
    dgemv
    dger
    dsbmv
+   dspmv
    dspr
    dspr2
    dsymv
    dsyr
    dsyr2
    dtbmv
+   dtbsv
+   dtpmv
    dtpsv
    dtrmv
    dtrsv
@@ -137,13 +143,15 @@ BLAS Level 2 functions
    chpmv
    chpr
    chpr2
+   cspmv
+   cspr
+   csyr
    ctbmv
    ctbsv
    ctpmv
    ctpsv
    ctrmv
    ctrsv
-   csyr
    zgbmv
    zgemv
    zgerc
@@ -155,12 +163,15 @@ BLAS Level 2 functions
    zhpmv
    zhpr
    zhpr2
+   zspmv
+   zspr
+   zsyr
    ztbmv
    ztbsv
    ztpmv
+   ztpsv
    ztrmv
    ztrsv
-   zsyr
 
 BLAS Level 3 functions
 ----------------------


### PR DESCRIPTION
I noticed that not all of the available BLAS (level 2)  functions were listed in the docs in https://github.com/scipy/scipy-stubs/pull/594. This should take care of that