### PR TITLE
BUG: implicit string concatenation in ``linalg._decomp_interpolative.__all__``

### DIFF
--- a/scipy/linalg/_decomp_interpolative.pyx
+++ b/scipy/linalg/_decomp_interpolative.pyx
@@ -124,11 +124,11 @@ __all__ = ['idd_estrank', 'idd_ldiv', 'idd_poweroftwo', 'idd_reconid', 'iddp_aid
            'iddp_asvd', 'iddp_id', 'iddp_qrpiv', 'iddp_svd', 'iddr_aid', 'iddr_asvd',
            'iddr_id', 'iddr_qrpiv', 'iddr_svd', 'idz_estrank', 'idz_reconid',
            'idzp_aid', 'idzp_asvd', 'idzp_id', 'idzp_qrpiv', 'idzp_svd', 'idzr_aid',
-           'idzr_asvd', 'idzr_id', 'idzr_qrpiv', 'idzr_svd', 'idd_id2svd', 'idz_id2svd'
+           'idzr_asvd', 'idzr_id', 'idzr_qrpiv', 'idzr_svd', 'idd_id2svd', 'idz_id2svd',
            # LinearOperator funcs
            'idd_findrank', 'iddp_rid', 'iddp_rsvd', 'iddr_rid', 'iddr_rsvd',
            'idz_findrank', 'idzp_rid', 'idzp_rsvd', 'idzr_rid', 'idzr_rsvd',
-           'idd_snorm', 'idz_snorm', 'idd_diffsnorm', 'idz_diffsnorm'
+           'idd_snorm', 'idz_snorm', 'idd_diffsnorm', 'idz_diffsnorm',
            ]
 
 


### PR DESCRIPTION
I noticed the following Siamese export in scipy/scipy-stubs#536:

```pycon
>>> from scipy.linalg import _decomp_interpolative
>>> _decomp_interpolative.__all__[27]
'idz_id2svdidd_findrank'
```

So I threw a `,` at it 🤷🏻 