### PR TITLE
BUG: remove ``cdef`` exports in ``linalg._decomp_interpolative``

### DIFF
--- a/scipy/linalg/_decomp_interpolative.pyx
+++ b/scipy/linalg/_decomp_interpolative.pyx
@@ -120,7 +120,7 @@ from scipy.linalg.cython_lapack cimport dlarfgp, dorm2r, zunm2r, zlarfgp
 from scipy.linalg.cython_blas cimport dnrm2, dtrsm, dznrm2, ztrsm
 
 
-__all__ = ['idd_estrank', 'idd_ldiv', 'idd_poweroftwo', 'idd_reconid', 'iddp_aid',
+__all__ = ['idd_estrank', 'idd_reconid', 'iddp_aid',
            'iddp_asvd', 'iddp_id', 'iddp_qrpiv', 'iddp_svd', 'iddr_aid', 'iddr_asvd',
            'iddr_id', 'iddr_qrpiv', 'iddr_svd', 'idz_estrank', 'idz_reconid',
            'idzp_aid', 'idzp_asvd', 'idzp_id', 'idzp_qrpiv', 'idzp_svd', 'idzr_aid',


### PR DESCRIPTION
The  `idd_ldiv` and `idd_poweroftwo` cython-only `cdef` functions were exported in the `__all__` of `scipy.linalg._decomp_interpolative`.

```pycon
>>> from scipy.linalg._decomp_interpolative import *
Traceback (most recent call last):
  File "<python-input-10>", line 1, in <module>
    from scipy.linalg._decomp_interpolative import *
AttributeError: module 'scipy.linalg._decomp_interpolative' has no attribute 'idd_ldiv'
```

related to #23115
