### PR TITLE
TYP: generic ``signal.ShortTimeFFT`` type

### DIFF
--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -21,6 +21,7 @@
 # Linter does not allow to import ``Generator`` from ``typing`` module:
 from collections.abc import Generator, Callable
 from functools import cache, lru_cache, partial
+from types import GenericAlias
 from typing import get_args, Literal
 
 import numpy as np
@@ -419,6 +420,9 @@ class ShortTimeFFT:
     _fac_mag: float | None = None
     _fac_psd: float | None = None
     _lower_border_end: tuple[int, int] | None = None
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, win: np.ndarray, hop: int, fs: float, *,
                  fft_mode: FFT_MODE_TYPE = 'onesided',

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -19,6 +19,7 @@ Notes
 """
 import math
 from itertools import product
+from types import GenericAlias
 from typing import cast, get_args, Literal
 
 import numpy as np
@@ -1096,3 +1097,7 @@ def test_energy_conservation(N_x: int, w_size: int, t_step: int, f_c: float):
     X = SFT.stft(x)
     xp = SFT.istft(X, k1=N_x)
     assert xp.shape == x.shape
+
+
+def test_subscriptable_generic_type():
+    assert isinstance(ShortTimeFFT[np.float64], GenericAlias)


### PR DESCRIPTION
In scipy/scipy-stubs#547, `signal.ShortTimeFFT`  was made into an optional generic type. But it can currently only be used that way from a `.pyi`, a `if TYPE_CHECKING` block, or in certain situations with `from __future__ import annotations`. In practice, this can be rather confusing and annoying for users.

This change will allow `scipy-stubs` users (or anyone else for that matter) to subscript the `ShortTimeFFT` type in all situations, e.g.:

```py
# from __future__ import annotations 
#    ^-- not need anymore

import numpy as np
from typing import Never
from scipy.signal import ShortTimeFFT

def create_black_hole(stft: ShortTimeFFT[np.complex128]) -> Never:
    # --implementation left as an exercise to the reader--
```

Closes scipy/scipy-stubs#545
