### PR TITLE
TYP: Disable NumPy's deprecated mypy plugin

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -5,7 +5,6 @@ warn_redundant_casts = True
 # not consistent enough for this to be a reasonable default.
 warn_unused_ignores = False
 show_error_codes = True
-plugins = numpy.typing.mypy_plugin
 
 #
 # Typing tests is low priority, but enabling type checking on the


### PR DESCRIPTION
From the [NumPy 2.3.0 release notes](https://github.com/numpy/numpy/releases/tag/v2.3.0):

> The `numpy.typing.mypy_plugin` has been deprecated in favor of
> platform-agnostic static type inference. Please remove
> `numpy.typing.mypy_plugin` from the `plugins` section of your mypy
> configuration. If this change results in new errors being reported,
> kindly open an issue.
>
>([gh-28129](https://github.com/numpy/numpy/pull/28129))