### PR TITLE
MAINT: Update vendored ``_lib.decorators`` module to ``v5.2.1``

### DIFF
--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy._lib.decorator import decorator as _decorator
+from scipy._lib.decorator import decoratorx as _decorator
 
 __all__ = ['delaunay_plot_2d', 'convex_hull_plot_2d', 'voronoi_plot_2d']
 

--- a/tools/lint.toml
+++ b/tools/lint.toml
@@ -1,6 +1,7 @@
 exclude = [
   "scipy/_build_utils/tempita/*",
   "scipy/_lib/_docscrape.py",
+  "scipy/_lib/decorator.py",
   "scipy/_lib/pyprima",
   "scipy/datasets/_registry.py",
 ]


### PR DESCRIPTION
This updates ``decorator.py`` from `v4.2.1` to [`v5.2.1`](https://github.com/micheles/decorator/tree/5.2.1) (commit [``cdeab3c`` ](https://github.com/micheles/decorator/blob/cdeab3cc06f93a81395aa0cb39c086c14499917f/src/decorator.py)), superseding #23119.
