### PR TITLE
DOC: fix linkcode_resolve line-number anchors

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -502,7 +502,7 @@ def linkcode_resolve(domain, info):
         lineno = None
 
     if lineno:
-        linespec = f"#L{0}-L{1}".format(lineno, lineno + len(source) - 1)
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
     else:
         linespec = ""
 


### PR DESCRIPTION
#### Reference issue
Closes #22294

#### What does this implement/fix?
The current `linkcode_resolve` in `doc/source/conf.py` was emitting a literal `#L0-L1` because it used an f-string with `{0}`/`{1}` plus `.format()`.  
This patch replaces that block with a single f-string so that it really becomes `#L{start}-L{end}`.

```diff
-        linespec = f"#L{0}-L{1}".format(lineno, lineno + len(source) - 1)
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
```