### PR TITLE
DOC: fix linkcode_resolve linespec so anchors are #Lstart-Lend (backport to 1.15.x)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -482,7 +482,7 @@ def linkcode_resolve(domain, info):
         lineno = None
 
     if lineno:
-        linespec = f"#L{0}-L{1}".format(lineno, lineno + len(source) - 1)
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
     else:
         linespec = ""
 


### PR DESCRIPTION
#### Reference issue
Closes #22294

#### What does this implement/fix?
Backport of #23127 to maintenance/1.15.x.