### PR TITLE
DOC: special.roots_jacobi: add example to docstring

### DIFF
--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -247,6 +247,13 @@ def roots_jacobi(n, alpha, beta, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Example 
+    >>> from scipy.special import roots_jacobi
+
+    >>> x, w = roots_jacobi(3, 0.5, 0.5)
+    >>> print("Sample points:", x)
+    >>> print("Weights:", w)
+
     """
     m = int(n)
     if n < 1 or n != m:

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -249,10 +249,9 @@ def roots_jacobi(n, alpha, beta, mu=False):
 
     Example 
     >>> from scipy.special import roots_jacobi
+    >>> roots_jacobi(3, 0.5, 0.5)
+    (array([-0.70710678,  0.        ,  0.70710678]), array([0.39269908, 0.78539816, 0.39269908]))
 
-    >>> x, w = roots_jacobi(3, 0.5, 0.5)
-    >>> print("Sample points:", x)
-    >>> print("Weights:", w)
 
     """
     m = int(n)

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -220,22 +220,22 @@ def roots_jacobi(n, alpha, beta, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order
+        Quadrature order.
     alpha : float
         alpha must be > -1
     beta : float
         beta must be > -1
     mu : bool, optional
-        If True, return the sum of the weights, optional.
+        If True, return the sum of the weights in addition to sample points and weights.
 
     Returns
     -------
     x : ndarray
-        Sample points
+        Sample points.
     w : ndarray
-        Weights
-    mu : float
-        Sum of the weights
+        Weights.
+    mu : float, optional
+        Sum of the weights, only returned if `mu=True`.
 
     See Also
     --------
@@ -247,13 +247,20 @@ def roots_jacobi(n, alpha, beta, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
-    Example 
+    Examples
+    --------
     >>> from scipy.special import roots_jacobi
-    >>> roots_jacobi(3, 0.5, 0.5)
-    (array([-0.70710678,  0.        ,  0.70710678]), array([0.39269908, 0.78539816, 0.39269908]))
+    >>> x, w = roots_jacobi(3, 0.5, 0.5)
+    >>> x
+    array([-0.70710678,  0.        ,  0.70710678])
+    >>> w
+    array([0.39269908, 0.78539816, 0.39269908])
 
-
+    >>> x, w, mu = roots_jacobi(3, 0.5, 0.5, mu=True)
+    >>> mu
+    1.5707963267948966  # Sum of weights, equals pi/2 for alpha = beta = 0.5
     """
+
     m = int(n)
     if n < 1 or n != m:
         raise ValueError("n must be a positive integer.")


### PR DESCRIPTION
#### Reference issue  
Related to gh-7168.

#### What does this implement/fix?  
Added an example to the docstring of the `roots_jacobi` function in `scipy.special`. The example shows how to import the function, compute sample points and weights, and print them.

#### Additional information  
This improves the documentation by providing a clear usage example for `roots_jacobi`.
