### PR TITLE
DEV: spin: change shorthand of `--setup-args` to `-S` to avoid `UserWarning`

### DIFF
--- a/.github/workflows/pixi.toml
+++ b/.github/workflows/pixi.toml
@@ -33,7 +33,7 @@ gmpy2 = "*"
 ccache = ">=4.10.1,<5"
 
 [feature.build.tasks]
-build = { cmd = "spin build -C-Dblas=blas -C-Dlapack=lapack -C-Duse-g77-abi=true", cwd = "../..", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
+build = { cmd = "spin build -S-Dblas=blas -S-Dlapack=lapack -S-Duse-g77-abi=true", cwd = "../..", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
 wheel = { cmd = "python -m build -wnx -Cbuild-dir=build-whl && cp dist/*.whl ../../wheelhouse/", cwd = "../.." }
 
 [feature.test.tasks]

--- a/.github/workflows/windows_intel_oneAPI.yml
+++ b/.github/workflows/windows_intel_oneAPI.yml
@@ -96,7 +96,7 @@ jobs:
           call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
           set FC=ifx
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          spin build -C-Duse-pythran=false -C--vsenv
+          spin build -S-Duse-pythran=false -S--vsenv
 
       # "import scipy; scipy.test();" fails because
       # scipy/sparse/linalg/_eigen/arpack crashes.

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -35,9 +35,9 @@ PROJECT_MODULE = "scipy"
 @click.option(
     '--release', '-r', default=False, is_flag=True, help="Release build")
 @click.option(
-    '--setup-args', '-C', default=[], multiple=True,
+    '--setup-args', '-S', default=[], multiple=True,
     help=("Pass along one or more arguments to `meson setup` "
-            "Repeat the `-C` in case of multiple arguments."))
+            "Repeat the `-S` in case of multiple arguments."))
 @click.option(
     '--show-build-log', default=False, is_flag=True,
     help="Show build output rather than using a log file")

--- a/doc/source/building/blas_lapack.rst
+++ b/doc/source/building/blas_lapack.rst
@@ -16,7 +16,7 @@ BLAS/LAPACK on Linux distros, and can be dynamically switched between
 implementations on conda-forge), use::
 
     $ # for a development build
-    $ spin build -C-Dblas=blas -C-Dlapack=lapack
+    $ spin build -S-Dblas=blas -S-Dlapack=lapack
 
     $ # to build and install a wheel
     $ python -m build -Csetup-args=-Dblas=blas -Csetup-args=-Dlapack=lapack

--- a/doc/source/dev/contributor/debugging_linalg_issues.rst
+++ b/doc/source/dev/contributor/debugging_linalg_issues.rst
@@ -170,7 +170,7 @@ in the exact same way as in `SciPy's conda-forge build recipe
     $ mamba env create -f environment.yml
     $ mamba activate scipy-dev
     $ mamba install "libblas=*=*netlib"  # necessary, we need to build against blas/lapack
-    $ spin build -C-Dblas=blas -C-Dlapack=lapack -C-Duse-g77-abi=true
+    $ spin build -S-Dblas=blas -S-Dlapack=lapack -S-Duse-g77-abi=true
     $ spin test -s linalg  # run tests to verify
     $ mamba install "libblas=*=*mkl"
     $ spin test -s linalg
@@ -222,7 +222,7 @@ source.
 
 Once you have everything set up, the development experience is::
 
-    $ spin build -C-Dblas=flexiblas -C-Dlapack=flexiblas
+    $ spin build -S-Dblas=flexiblas -S-Dlapack=flexiblas
     $ FLEXIBLAS=NETLIB spin test -s linalg
     $ FLEXIBLAS=OpenBLAS spin test -s linalg
     # Or export the environment variable to make the selection stick:
@@ -277,7 +277,7 @@ We're now ready to build SciPy against FlexiBLAS::
 
     $ export PKG_CONFIG_PATH=$PWD/flexiblas-setup/built-libs/lib/pkgconfig/
     $ cd scipy
-    $ spin build -C-Dblas=flexiblas -C-Dlapack=flexiblas
+    $ spin build -S-Dblas=flexiblas -S-Dlapack=flexiblas
     ...
     Run-time dependency flexiblas found: YES 3.4.2
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/23116

#### What does this implement/fix?
<!--Please explain your changes.-->

Implements the solution in,

>  If there isn't, we can change to:
> 
> ```
> -C, --build-dir
> -S, --setup-args
> ```

#### Additional information
<!--Any additional information you think is important.-->

cc: @rgommers 
