### PR TITLE
REL: set 1.16.0rc3 unreleased

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.16.0rc2"
+version = "1.16.0rc3.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Set the version of SciPy to `1.16.0rc3.dev0` (unreleased).

[ci skip] [skip ci]

We're unlikely to do an RC3, and this is just a convention (did it last cycle too: https://github.com/scipy/scipy/pull/22181) with the CI turned off.

In all likelihood, if there are no major problems, we'll just do `1.16.0` "final" by adjusting the `version` string again, etc.

We're still on track for the originally-scheduled final release on June 18th--that's 1.5 weeks away still.