### PR TITLE
BUG: signal.sawtooth: handle small negative values

### DIFF
--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -409,6 +409,14 @@ class TestSawtoothWaveform:
         assert all(np.isfinite(waveform[:3]))
         assert all(np.isnan(waveform[3:]))
 
+    def test_nonfinite_t(self):
+        # where t is nan or inf, output is nan
+        waveform = waveforms.sawtooth([0, 1, 2, np.nan, np.inf])
+        assert all(np.isfinite(waveform[:3]))
+        assert all(np.isnan(waveform[3:]))
+
+        # check both t and width invalid => nan
+        assert np.isnan(waveforms.sawtooth(np.inf, 1.1))
 
 class TestSquareWaveform:
     def test_dtype(self):

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -390,6 +390,25 @@ class TestSawtoothWaveform:
         waveform = waveforms.sawtooth(1)
         assert waveform.dtype == np.float64
 
+    def test_small_negative(self):
+        # gh-22940 regression
+        assert waveforms.sawtooth(-np.finfo(float).smallest_normal) == 1
+
+    def test_broadcast(self):
+        t = np.array([[1,2,3],[4,5,6]])
+        w = np.array([[[0.1]],[[0.9]]])
+
+        wbroad = waveforms.sawtooth(t, w)
+        w1 = waveforms.sawtooth(t, w.flat[0])
+        w2 = waveforms.sawtooth(t, w.flat[1])
+
+        xp_assert_equal(wbroad, np.stack((w1, w2)))
+
+    def test_bad_width(self):
+        waveform = waveforms.sawtooth(0, [0, 0.9, 1, -0.1, 1.1, np.nan, np.inf])
+        assert all(np.isfinite(waveform[:3]))
+        assert all(np.isnan(waveform[3:]))
+
 
 class TestSquareWaveform:
     def test_dtype(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-22940.

#### What does this implement/fix?
The remainder operation performed in `sawtooth` mapped -1e-16 (and smaller magnitude values) to `2*pi`, resulting in the check `tmod < w * 2 * pi` omitting this value, and when `width=1` (the default), giving divide-by-zero in evaluating the `mask3` result for (actually empty) interval [`width*2*pi`, `2*pi`]. [edit: `*`s caused havoc in Markdown, back-ticked them.]

To fix this, I've used `np.fmod` instead instead of `np.mod`, so that the remainder has the sign of the dividend, and there are now four branches in the evaluation of the function to handle the negative values.

I've added a regression test for this case.

#### Additional information
I've also somewhat modernized the code, and documented two pre-existing behaviours:
  - t and width are broadcast
  - where width is out-of-range, output is NaN

I've added tests for both of these.  This could be further improved, e.g., raise a warning on out-of-range width.

Do I need a `.. versionadded` for this?  Seems like a fix, so I assume not.