### PR TITLE
CI: validate build on Win-ARM64 

### DIFF
--- a/.github/windows_arm64_steps/action.yml
+++ b/.github/windows_arm64_steps/action.yml
@@ -7,6 +7,12 @@ runs:
       shell: pwsh
       run: |
         Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.6/LLVM-20.1.6-woa64.exe -UseBasicParsing -OutFile LLVM-woa64.exe
+        $expectedHash = "92f69a1134e32e54b07d51c6e24d9594852f6476f32c3d70471ae00fffc2d462"
+        $fileHash = (Get-FileHash -Path "LLVM-woa64.exe" -Algorithm SHA256).Hash
+        if ($fileHash -ne $expectedHash) {
+            Write-Error "Checksum verification failed. The downloaded file may be corrupted or tampered with."
+            exit 1
+        }
         Start-Process -FilePath ".\LLVM-woa64.exe" -ArgumentList "/S" -Wait
         echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/.github/windows_arm64_steps/action.yml
+++ b/.github/windows_arm64_steps/action.yml
@@ -1,0 +1,22 @@
+name: Build Dependencies(Win-ARM64)
+description: "Common setup steps for Win-ARM64 CI"
+runs:
+  using: "composite"
+  steps:
+    - name: Install LLVM
+      shell: pwsh
+      run: |
+        Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.6/LLVM-20.1.6-woa64.exe -UseBasicParsing -OutFile LLVM-woa64.exe
+        Start-Process -FilePath ".\LLVM-woa64.exe" -ArgumentList "/S" -Wait
+        echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Install pkgconf via vcpkg
+      shell: pwsh
+      run: |
+        & "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" arm64
+        $env:VCPKG_ROOT = "C:\vcpkg"
+        Set-Location $env:VCPKG_ROOT
+        ./vcpkg install pkgconf:arm64-windows
+        $pkgconfPath = "$env:VCPKG_ROOT\installed\arm64-windows\tools\pkgconf"
+        Copy-Item "$pkgconfPath\pkgconf.exe" "$pkgconfPath\pkg-config.exe" -Force
+        echo "$pkgconfPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -168,3 +168,104 @@ jobs:
           # test runner parallel clashes with OpenBLAS multithreading
           $env:OPENBLAS_NUM_THREADS=1
           pytest --pyargs scipy
+          
+
+  #############################################################################
+  fast_spin_arm64:
+    name: fast, py3.12/npAny, spin (Win-ARM64)
+    runs-on: windows-11-arm
+    if: > 
+      needs.get_commit_message.outputs.message == 1 &&
+      (github.repository == 'scipy/scipy' || github.repository == '')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+        
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          architecture: 'arm64'
+          
+      - name: Set up Flang and pkgconf for ARM64
+        uses: ./.github/windows_arm64_steps
+
+      - name: pip-packages
+        run: |
+          pip install numpy cython pybind11 pythran meson ninja pytest pytest-xdist pytest-timeout pooch spin hypothesis
+          python -m pip install -r requirements/openblas.txt
+
+      - name: Build
+        run: |
+          $env:cc = "clang-cl"
+          $env:cxx = "clang-cl"
+          $env:fc = "flang-new"
+          spin build --with-scipy-openblas
+
+      - name: Test
+        run: |
+          $env:OPENBLAS_NUM_THREADS = 1
+          spin test -j2 -- --durations=25
+          
+
+  #############################################################################
+  full_build_sdist_wheel_arm64:
+    name: no pythran & sdist+wheel, full, py3.11/npPre, pip+pytest (Win-ARM64)
+    runs-on: windows-11-arm
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1 &&
+      (github.repository == 'scipy/scipy' || github.repository == '')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+  
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          architecture: 'arm64'
+          cache: 'pip'
+          cache-dependency-path: 'environment.yml'
+  
+      - name: Set up Flang and pkgconf for ARM64
+        uses: ./.github/windows_arm64_steps
+  
+      - name: Install OpenBLAS
+        shell: bash
+        run: |
+          set -xe
+          export PKG_CONFIG_PATH=$(cygpath -u "$PKG_CONFIG_PATH")
+          export PATH="$(cygpath -u 'C:\vcpkg\installed\arm64-windows\tools\pkgconf'):$PATH"
+          python -m pip install -r requirements/openblas.txt
+          bash tools/wheels/cibw_before_build_win.sh .
+          echo "PKG_CONFIG_PATH=$(cygpath -w "${{ github.workspace }}")" >> $GITHUB_ENV
+  
+      - name: pip-packages
+        run: |
+          python -m pip install build delvewheel cython pybind11 meson-python meson ninja pytest pytest-xdist pytest-timeout pooch hypothesis numpy
+  
+      - name: Build
+        shell: bash
+        run: |
+          set -xe
+          export CC=clang-cl
+          export CXX=clang-cl
+          export FC=flang-new
+          export PATH="$(cygpath -u 'C:\vcpkg\installed\arm64-windows\tools\pkgconf'):$PATH"
+          python -m build --no-isolation -x -Csetup-args="-Duse-pythran=false"
+          wheel_name=$(ls dist/*.whl)
+          openblas_dir=$(python -c"import scipy_openblas32 as sop; print(sop.get_lib_dir())")
+          delvewheel repair --add-path "$openblas_dir" -w wheelhouse "$wheel_name"
+          python -m pip install wheelhouse/*
+  
+      - name: Test
+        shell: pwsh
+        run: |
+          Set-Location $env:RUNNER_TEMP
+          $env:OPENBLAS_NUM_THREADS = 1
+          pytest --pyargs scipy -n2  

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -174,17 +174,18 @@ jobs:
   fast_spin_arm64:
     name: fast, py3.12/npAny, spin (Win-ARM64)
     runs-on: windows-11-arm
+    needs: get_commit_message
     if: > 
       needs.get_commit_message.outputs.message == 1 &&
       (github.repository == 'scipy/scipy' || github.repository == '')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: '3.12'
           architecture: 'arm64'
@@ -220,12 +221,12 @@ jobs:
       (github.repository == 'scipy/scipy' || github.repository == '')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
           python-version: '3.11'
           architecture: 'arm64'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-          
+
       - name: Setup Python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-          
+
       - name: Setup Python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
         with:
@@ -168,7 +168,7 @@ jobs:
           # test runner parallel clashes with OpenBLAS multithreading
           $env:OPENBLAS_NUM_THREADS=1
           pytest --pyargs scipy
-          
+
 
   #############################################################################
   fast_spin_arm64:
@@ -182,13 +182,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-        
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
           architecture: 'arm64'
-          
+
       - name: Set up Flang and pkgconf for ARM64
         uses: ./.github/windows_arm64_steps
 
@@ -208,7 +208,7 @@ jobs:
         run: |
           $env:OPENBLAS_NUM_THREADS = 1
           spin test -j2 -- --durations=25
-          
+
 
   #############################################################################
   full_build_sdist_wheel_arm64:
@@ -223,7 +223,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-  
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -231,10 +231,10 @@ jobs:
           architecture: 'arm64'
           cache: 'pip'
           cache-dependency-path: 'environment.yml'
-  
+
       - name: Set up Flang and pkgconf for ARM64
         uses: ./.github/windows_arm64_steps
-  
+
       - name: Install OpenBLAS
         shell: bash
         run: |
@@ -244,11 +244,11 @@ jobs:
           python -m pip install -r requirements/openblas.txt
           bash tools/wheels/cibw_before_build_win.sh .
           echo "PKG_CONFIG_PATH=$(cygpath -w "${{ github.workspace }}")" >> $GITHUB_ENV
-  
+
       - name: pip-packages
         run: |
           python -m pip install build delvewheel cython pybind11 meson-python meson ninja pytest pytest-xdist pytest-timeout pooch hypothesis numpy
-  
+
       - name: Build
         shell: bash
         run: |
@@ -262,10 +262,10 @@ jobs:
           openblas_dir=$(python -c"import scipy_openblas32 as sop; print(sop.get_lib_dir())")
           delvewheel repair --add-path "$openblas_dir" -w wheelhouse "$wheel_name"
           python -m pip install wheelhouse/*
-  
+
       - name: Test
         shell: pwsh
         run: |
           Set-Location $env:RUNNER_TEMP
           $env:OPENBLAS_NUM_THREADS = 1
-          pytest --pyargs scipy -n2  
+          pytest --pyargs scipy -n2

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -3,6 +3,7 @@
 #
 
 from functools import reduce
+import sysconfig
 
 from numpy.testing import (assert_equal, assert_array_almost_equal, assert_,
                            assert_allclose, assert_almost_equal,
@@ -500,7 +501,7 @@ class TestDlasd4:
             roots.append(res[1])
 
             assert_(
-                (res[3] <= 0), 
+                (res[3] <= 0),
                 f"LAPACK root finding dlasd4 failed to find the singular value {i}"
             )
         roots = np.array(roots)[::-1]
@@ -3489,6 +3490,9 @@ def test_sy_hetrs(mtype, dtype, lower):
 def test_sy_he_tri(dtype, lower, mtype):
     if mtype == 'he' and dtype in REAL_DTYPES:
         pytest.skip("hetri not for real dtypes.")
+    if sysconfig.get_platform() == 'win-arm64' and dtype in COMPLEX_DTYPES:
+        pytest.skip("Test segfaulting on win-arm64 in CI, see gh-23133")
+
     rng = np.random.default_rng(1723059677121834)
     n = 20
     A = rng.random((n, n)) + rng.random((n, n))*1j

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -32,14 +32,14 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import sys
-import os.path
-
 from functools import wraps, partial
+import os.path
+import sys
+import sysconfig
+import warnings
 import weakref
 
 import numpy as np
-import warnings
 from numpy.linalg import norm
 from numpy.testing import (verbose, assert_,
                            assert_array_equal, assert_equal,
@@ -608,6 +608,7 @@ class TestCdist:
                     y2 = cdist(new_type(X1), new_type(X2), metric=metric)
                     assert_allclose(y1, y2, rtol=eps, verbose=verbose > 2)
 
+    @pytest.mark.skipif(sysconfig.get_platform() == 'win-arm64', reason="numpy#29442")
     def test_cdist_out(self, metric):
         # Test that out parameter works properly
         eps = 1e-15


### PR DESCRIPTION

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes: https://github.com/scipy/scipy/issues/21562 https://github.com/scipy/scipy/issues/22825

#### What does this implement/fix?
<!--Please explain your changes.-->
Enables new CI environment for building & validating SciPy for Win-ARM64.

#### Additional information
<!--Any additional information you think is important.-->

- The PR introduces setting up a new CI environment for building and testing SciPy locally for Win-ARM64.
- This CI setup depends on the latest stable LLVM toolchain & vcpkg(for native pkg-config).