### PR TITLE
ENH: interpolate: Array API for PPoly and related objects

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -153,11 +153,12 @@ class CubicHermiteSpline(PPoly):
         slope = xp.diff(y, axis=0) / dxr
         t = (dydx[:-1, ...] + dydx[1:, ...] - 2 * slope) / dxr
 
-        c = xp.empty((4, x.shape[0] - 1) + y.shape[1:], dtype=t.dtype)
-        c[0, ...] = t / dxr
-        c[1, ...] = (slope - dydx[:-1, ...]) / dxr - t
-        c[2, ...] = dydx[:-1, ...]
-        c[3, ...] = y[:-1, ...]
+        c = xp.stack((
+           t / dxr,
+           (slope - dydx[:-1, ...]) / dxr - t,
+           dydx[:-1, ...],
+           y[:-1, ...]
+        ))
 
         super().__init__(c, x, extrapolate=extrapolate)
         self.axis = axis

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -71,7 +71,13 @@ def prepare_input(x, y, axis, dydx=None, xp=None):
     return x, dx, y, axis, dydx
 
 
-@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=1)
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[
+        ("dask.array",
+         "https://github.com/data-apis/array-api-extra/issues/488")
+    ]
+)
 class CubicHermiteSpline(PPoly):
     """Piecewise cubic interpolator to fit values and first derivatives (C1 smooth).
 
@@ -163,6 +169,13 @@ class CubicHermiteSpline(PPoly):
         self.axis = axis
 
 
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[
+        ("dask.array",
+         "https://github.com/data-apis/array-api-extra/issues/488")
+    ]
+)
 class PchipInterpolator(CubicHermiteSpline):
     r"""PCHIP shape-preserving interpolator (C1 smooth).
 
@@ -600,7 +613,13 @@ class Akima1DInterpolator(CubicHermiteSpline):
                                   "an Akima interpolator.")
 
 
-@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=1)
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[
+        ("dask.array",
+         "https://github.com/data-apis/array-api-extra/issues/488")
+    ]
+)
 class CubicSpline(CubicHermiteSpline):
     """Piecewise cubic interpolator to fit values (C2 smooth).
 

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -5,7 +5,7 @@ from typing import Literal
 import numpy as np
 
 from scipy.linalg import solve, solve_banded
-from scipy._lib._array_api import array_namespace, xp_size
+from scipy._lib._array_api import array_namespace, xp_size, xp_capabilities
 from scipy._lib.array_api_compat import numpy as np_compat
 
 from . import PPoly
@@ -71,6 +71,7 @@ def prepare_input(x, y, axis, dydx=None, xp=None):
     return x, dx, y, axis, dydx
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=1)
 class CubicHermiteSpline(PPoly):
     """Piecewise cubic interpolator to fit values and first derivatives (C1 smooth).
 
@@ -384,6 +385,11 @@ def pchip_interpolate(xi, yi, x, der=0, axis=0):
         return [P.derivative(nu)(x) for nu in der]
 
 
+@xp_capabilities(cpu_only=True, xfail_backends=[
+    ("dask.array", "lacks nd fancy indexing"),
+    ("jax.numpy", "immutable arrays"),
+    ("array_api_strict", "fancy indexing __setitem__"),
+])
 class Akima1DInterpolator(CubicHermiteSpline):
     r"""Akima "visually pleasing" interpolator (C1 smooth).
 
@@ -594,6 +600,7 @@ class Akima1DInterpolator(CubicHermiteSpline):
                                   "an Akima interpolator.")
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=1)
 class CubicSpline(CubicHermiteSpline):
     """Piecewise cubic interpolator to fit values (C2 smooth).
 

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -5,6 +5,8 @@ from typing import Literal
 import numpy as np
 
 from scipy.linalg import solve, solve_banded
+from scipy._lib._array_api import array_namespace
+from scipy._lib.array_api_compat import numpy as np_compat
 
 from . import PPoly
 from ._polyint import _isscalar
@@ -13,7 +15,7 @@ __all__ = ["CubicHermiteSpline", "PchipInterpolator", "pchip_interpolate",
            "Akima1DInterpolator", "CubicSpline"]
 
 
-def prepare_input(x, y, axis, dydx=None):
+def prepare_input(x, y, axis, dydx=None, xp=None):
     """Prepare input for cubic spline interpolators.
 
     All data are converted to numpy arrays and checked for correctness.
@@ -21,26 +23,28 @@ def prepare_input(x, y, axis, dydx=None):
     axis. The value of `axis` is converted to lie in
     [0, number of dimensions of `y`).
     """
+    if xp is None:
+        xp = array_namespace(x, y, dydx)
 
-    x, y = map(np.asarray, (x, y))
-    if np.issubdtype(x.dtype, np.complexfloating):
+    x, y = map(xp.asarray, (x, y))
+    if xp.isdtype(x.dtype, "complex floating"):
         raise ValueError("`x` must contain real values.")
-    x = x.astype(float)
+    x = xp.astype(x, xp.float64)
 
-    if np.issubdtype(y.dtype, np.complexfloating):
-        dtype = complex
+    if xp.isdtype(y.dtype, "complex floating"):
+        dtype = xp.complex128
     else:
-        dtype = float
+        dtype = xp.float64
 
     if dydx is not None:
-        dydx = np.asarray(dydx)
+        dydx = xp.asarray(dydx)
         if y.shape != dydx.shape:
             raise ValueError("The shapes of `y` and `dydx` must be identical.")
-        if np.issubdtype(dydx.dtype, np.complexfloating):
-            dtype = complex
-        dydx = dydx.astype(dtype, copy=False)
+        if xp.isdtype(dydx.dtype, "complex floating"):
+            dtype = xp.complex128
+        dydx = xp.astype(dydx, dtype, copy=False)
 
-    y = y.astype(dtype, copy=False)
+    y = xp.astype(y, dtype, copy=False)
     axis = axis % y.ndim
     if x.ndim != 1:
         raise ValueError("`x` must be 1-dimensional.")
@@ -50,21 +54,21 @@ def prepare_input(x, y, axis, dydx=None):
         raise ValueError(f"The length of `y` along `axis`={axis} doesn't "
                          "match the length of `x`")
 
-    if not np.all(np.isfinite(x)):
+    if not xp.all(xp.isfinite(x)):
         raise ValueError("`x` must contain only finite values.")
-    if not np.all(np.isfinite(y)):
+    if not xp.all(xp.isfinite(y)):
         raise ValueError("`y` must contain only finite values.")
 
-    if dydx is not None and not np.all(np.isfinite(dydx)):
+    if dydx is not None and not xp.all(xp.isfinite(dydx)):
         raise ValueError("`dydx` must contain only finite values.")
 
-    dx = np.diff(x)
-    if np.any(dx <= 0):
+    dx = xp.diff(x)
+    if xp.any(dx <= 0):
         raise ValueError("`x` must be strictly increasing sequence.")
 
-    y = np.moveaxis(y, axis, 0)
+    y = xp.moveaxis(y, axis, 0)
     if dydx is not None:
-        dydx = np.moveaxis(dydx, axis, 0)
+        dydx = xp.moveaxis(dydx, axis, 0)
 
     return x, dx, y, axis, dydx
 
@@ -138,20 +142,22 @@ class CubicHermiteSpline(PPoly):
     """
 
     def __init__(self, x, y, dydx, axis=0, extrapolate=None):
+        xp = array_namespace(x, y, dydx)
+
         if extrapolate is None:
             extrapolate = True
 
         x, dx, y, axis, dydx = prepare_input(x, y, axis, dydx)
 
-        dxr = dx.reshape([dx.shape[0]] + [1] * (y.ndim - 1))
-        slope = np.diff(y, axis=0) / dxr
-        t = (dydx[:-1] + dydx[1:] - 2 * slope) / dxr
+        dxr = xp.reshape(dx, (dx.shape[0], ) + (1, ) * (y.ndim - 1))
+        slope = xp.diff(y, axis=0) / dxr
+        t = (dydx[:-1, ...] + dydx[1:, ...] - 2 * slope) / dxr
 
-        c = np.empty((4, len(x) - 1) + y.shape[1:], dtype=t.dtype)
-        c[0] = t / dxr
-        c[1] = (slope - dydx[:-1]) / dxr - t
-        c[2] = dydx[:-1]
-        c[3] = y[:-1]
+        c = xp.empty((4, x.shape[0] - 1) + y.shape[1:], dtype=t.dtype)
+        c[0, ...] = t / dxr
+        c[1, ...] = (slope - dydx[:-1, ...]) / dxr - t
+        c[2, ...] = dydx[:-1, ...]
+        c[3, ...] = y[:-1, ...]
 
         super().__init__(c, x, extrapolate=extrapolate)
         self.axis = axis
@@ -240,25 +246,26 @@ class PchipInterpolator(CubicHermiteSpline):
     __class_getitem__ = None
 
     def __init__(self, x, y, axis=0, extrapolate=None):
-        x, _, y, axis, _ = prepare_input(x, y, axis)
-        if np.iscomplexobj(y):
+        xp = array_namespace(x, y)
+        x, _, y, axis, _ = prepare_input(x, y, axis, xp=xp)
+        if xp.isdtype(y.dtype, "complex floating"):
             msg = ("`PchipInterpolator` only works with real values for `y`. "
                    "If you are trying to use the real components of the passed array, "
                    "use `np.real` on the array before passing to `PchipInterpolator`.")
             raise ValueError(msg)
-        xp = x.reshape((x.shape[0],) + (1,)*(y.ndim-1))
-        dk = self._find_derivatives(xp, y)
+        xv = xp.reshape(x, (x.shape[0],) + (1,)*(y.ndim-1))
+        dk = self._find_derivatives(xv, y, xp=xp)
         super().__init__(x, y, dk, axis=0, extrapolate=extrapolate)
         self.axis = axis
 
     @staticmethod
-    def _edge_case(h0, h1, m0, m1):
+    def _edge_case(h0, h1, m0, m1, xp):
         # one-sided three-point estimate for the derivative
         d = ((2*h0 + h1)*m0 - h0*m1) / (h0 + h1)
 
         # try to preserve shape
-        mask = np.sign(d) != np.sign(m0)
-        mask2 = (np.sign(m0) != np.sign(m1)) & (np.abs(d) > 3.*np.abs(m0))
+        mask = xp.sign(d) != xp.sign(m0)
+        mask2 = (xp.sign(m0) != xp.sign(m1)) & (xp.abs(d) > 3.*xp.abs(m0))
         mmm = (~mask) & mask2
 
         d[mask] = 0.
@@ -267,7 +274,7 @@ class PchipInterpolator(CubicHermiteSpline):
         return d
 
     @staticmethod
-    def _find_derivatives(x, y):
+    def _find_derivatives(x, y, xp):
         # Determine the derivatives at the points y_k, d_k, by using
         #  PCHIP algorithm is:
         # We choose the derivatives at the point x_k by
@@ -288,12 +295,12 @@ class PchipInterpolator(CubicHermiteSpline):
 
         if y.shape[0] == 2:
             # edge case: only have two points, use linear interpolation
-            dk = np.zeros_like(y)
+            dk = xp.zeros_like(y)
             dk[0] = mk
             dk[1] = mk
-            return dk.reshape(y_shape)
+            return xp.reshape(dk, y_shape)
 
-        smk = np.sign(mk)
+        smk = xp.sign(mk)
         condition = (smk[1:] != smk[:-1]) | (mk[1:] == 0) | (mk[:-1] == 0)
 
         w1 = 2*hk[1:] + hk[:-1]
@@ -310,10 +317,10 @@ class PchipInterpolator(CubicHermiteSpline):
 
         # special case endpoints, as suggested in
         # Cleve Moler, Numerical Computing with MATLAB, Chap 3.6 (pchiptx.m)
-        dk[0] = PchipInterpolator._edge_case(hk[0], hk[1], mk[0], mk[1])
-        dk[-1] = PchipInterpolator._edge_case(hk[-1], hk[-2], mk[-1], mk[-2])
+        dk[0] = PchipInterpolator._edge_case(hk[0], hk[1], mk[0], mk[1], xp=xp)
+        dk[-1] = PchipInterpolator._edge_case(hk[-1], hk[-2], mk[-1], mk[-2], xp=xp)
 
-        return dk.reshape(y_shape)
+        return xp.reshape(dk, y_shape)
 
 
 def pchip_interpolate(xi, yi, x, der=0, axis=0):
@@ -500,9 +507,11 @@ class Akima1DInterpolator(CubicHermiteSpline):
             raise NotImplementedError(f"`method`={method} is unsupported.")
         # Original implementation in MATLAB by N. Shamsundar (BSD licensed), see
         # https://www.mathworks.com/matlabcentral/fileexchange/1814-akima-interpolation
-        x, dx, y, axis, _ = prepare_input(x, y, axis)
 
-        if np.iscomplexobj(y):
+        xp = array_namespace(x, y)
+        x, dx, y, axis, _ = prepare_input(x, y, axis, xp=xp)
+
+        if xp.isdtype(y.dtype, "complex floating"):
             msg = ("`Akima1DInterpolator` only works with real values for `y`. "
                    "If you are trying to use the real components of the passed array, "
                    "use `np.real` on the array before passing to "
@@ -514,36 +523,36 @@ class Akima1DInterpolator(CubicHermiteSpline):
 
         if y.shape[0] == 2:
             # edge case: only have two points, use linear interpolation
-            xp = x.reshape((x.shape[0],) + (1,)*(y.ndim-1))
-            hk = xp[1:] - xp[:-1]
-            mk = (y[1:] - y[:-1]) / hk
-            t = np.zeros_like(y)
+            xv = xp.reshape(x, (x.shape[0],) + (1,)*(y.ndim-1))
+            hk = xv[1:, ...] - xv[:-1, ...]
+            mk = (y[1:, ...] - y[:-1, ...]) / hk
+            t = xp.zeros_like(y)
             t[...] = mk
         else:
             # determine slopes between breakpoints
-            m = np.empty((x.size + 3, ) + y.shape[1:])
+            m = xp.empty((x.shape[0] + 3, ) + y.shape[1:])
             dx = dx[(slice(None), ) + (None, ) * (y.ndim - 1)]
-            m[2:-2] = np.diff(y, axis=0) / dx
+            m[2:-2, ...] = xp.diff(y, axis=0) / dx
 
             # add two additional points on the left ...
-            m[1] = 2. * m[2] - m[3]
-            m[0] = 2. * m[1] - m[2]
+            m[1, ...] = 2. * m[2, ...] - m[3, ...]
+            m[0, ...] = 2. * m[1, ...] - m[2, ...]
             # ... and on the right
-            m[-2] = 2. * m[-3] - m[-4]
-            m[-1] = 2. * m[-2] - m[-3]
+            m[-2, ...] = 2. * m[-3, ...] - m[-4, ...]
+            m[-1, ...] = 2. * m[-2, ...] - m[-3, ...]
 
             # if m1 == m2 != m3 == m4, the slope at the breakpoint is not
             # defined. This is the fill value:
-            t = .5 * (m[3:] + m[:-3])
+            t = .5 * (m[3:, ...] + m[:-3, ...])
             # get the denominator of the slope t
-            dm = np.abs(np.diff(m, axis=0))
+            dm = xp.abs(xp.diff(m, axis=0))
             if method == "makima":
-                pm = np.abs(m[1:] + m[:-1])
-                f1 = dm[2:] + 0.5 * pm[2:]
-                f2 = dm[:-2] + 0.5 * pm[:-2]
+                pm = xp.abs(m[1:, ...] + m[:-1, ...])
+                f1 = dm[2:, ...] + 0.5 * pm[2:, ...]
+                f2 = dm[:-2, ...] + 0.5 * pm[:-2, ...]
             else:
-                f1 = dm[2:]
-                f2 = dm[:-2]
+                f1 = dm[2:, ...]
+                f2 = dm[:-2, ...]
 
             # makima is more numerically stable for small f12,
             # so a finite cutoff should not improve any behavior
@@ -556,7 +565,9 @@ class Akima1DInterpolator(CubicHermiteSpline):
             f12 = f1 + f2
 
             # These are the mask of where the slope at breakpoint is defined:
-            ind = np.nonzero(f12 > break_mult * np.max(f12, initial=-np.inf))
+            mmax = xp.asarray(np.max(np.asarray(f12), initial=-np.inf))
+            ind = xp.nonzero(f12 > break_mult * mmax)
+
             x_ind, y_ind = ind[0], ind[1:]
             # Set the slope at breakpoint
             t[ind] = m[(x_ind + 1,) + y_ind] + (
@@ -752,7 +763,8 @@ class CubicSpline(CubicHermiteSpline):
     """
 
     def __init__(self, x, y, axis=0, bc_type='not-a-knot', extrapolate=None):
-        x, dx, y, axis, _ = prepare_input(x, y, axis)
+        xp = array_namespace(x, y)
+        x, dx, y, axis, _ = prepare_input(x, y, axis, xp=np_compat)
         n = len(x)
 
         bc, y = self._validate_bc(bc_type, y, y.shape[1:], axis)
@@ -917,6 +929,7 @@ class CubicSpline(CubicHermiteSpline):
                                      overwrite_b=True, check_finite=False)
                     s = s.reshape(b.shape)
 
+        x, y, s = map(xp.asarray, (x, y, s))
         super().__init__(x, y, s, axis=0, extrapolate=extrapolate)
         self.axis = axis
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -10,6 +10,8 @@ import scipy.special as spec
 from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
+from scipy._lib._array_api import array_namespace, concat_1d
+
 from . import _fitpack_py
 from ._polyint import _Interpolator1D
 from . import _ppoly
@@ -592,14 +594,16 @@ class interp1d(_Interpolator1D):
 
 class _PPolyBase:
     """Base class for piecewise polynomials."""
-    __slots__ = ('c', 'x', 'extrapolate', 'axis')
+    __slots__ = ('_c', '_x', 'extrapolate', 'axis', '_asarray')
 
     # generic type compatibility with scipy-stubs
     __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, c, x, extrapolate=None, axis=0):
-        self.c = np.asarray(c)
-        self.x = np.ascontiguousarray(x, dtype=np.float64)
+        self._asarray  = array_namespace(c, x).asarray
+
+        self._c = np.asarray(c)
+        self._x = np.ascontiguousarray(x, dtype=np.float64)
 
         if extrapolate is None:
             extrapolate = True
@@ -607,12 +611,12 @@ class _PPolyBase:
             extrapolate = bool(extrapolate)
         self.extrapolate = extrapolate
 
-        if self.c.ndim < 2:
+        if self._c.ndim < 2:
             raise ValueError("Coefficients array must be at least "
                              "2-dimensional.")
 
-        if not (0 <= axis < self.c.ndim - 1):
-            raise ValueError(f"axis={axis} must be between 0 and {self.c.ndim-1}")
+        if not (0 <= axis < self._c.ndim - 1):
+            raise ValueError(f"axis={axis} must be between 0 and {self._c.ndim-1}")
 
         self.axis = axis
         if axis != 0:
@@ -622,32 +626,48 @@ class _PPolyBase:
             #                                               ^
             #                                              axis
             # So we roll two of them.
-            self.c = np.moveaxis(self.c, axis+1, 0)
-            self.c = np.moveaxis(self.c, axis+1, 0)
+            self._c = np.moveaxis(self._c, axis+1, 0)
+            self._c = np.moveaxis(self._c, axis+1, 0)
 
-        if self.x.ndim != 1:
+        if self._x.ndim != 1:
             raise ValueError("x must be 1-dimensional")
-        if self.x.size < 2:
+        if self._x.size < 2:
             raise ValueError("at least 2 breakpoints are needed")
-        if self.c.ndim < 2:
+        if self._c.ndim < 2:
             raise ValueError("c must have at least 2 dimensions")
-        if self.c.shape[0] == 0:
+        if self._c.shape[0] == 0:
             raise ValueError("polynomial must be at least of order 0")
-        if self.c.shape[1] != self.x.size-1:
+        if self._c.shape[1] != self._x.size-1:
             raise ValueError("number of coefficients != len(x)-1")
-        dx = np.diff(self.x)
+        dx = np.diff(self._x)
         if not (np.all(dx >= 0) or np.all(dx <= 0)):
             raise ValueError("`x` must be strictly increasing or decreasing.")
 
-        dtype = self._get_dtype(self.c.dtype)
-        self.c = np.ascontiguousarray(self.c, dtype=dtype)
+        dtype = self._get_dtype(self._c.dtype)
+        self._c = np.ascontiguousarray(self._c, dtype=dtype)
 
     def _get_dtype(self, dtype):
         if np.issubdtype(dtype, np.complexfloating) \
-               or np.issubdtype(self.c.dtype, np.complexfloating):
+               or np.issubdtype(self._c.dtype, np.complexfloating):
             return np.complex128
         else:
             return np.float64
+
+    @property
+    def x(self):
+        return self._asarray(self._x)
+
+    @x.setter
+    def x(self, xval):
+        self._x = np.asarray(xval)
+
+    @property
+    def c(self):
+        return self._asarray(self._c)
+
+    @c.setter
+    def c(self, cval):
+        self._c = np.asarray(cval)
 
     @classmethod
     def construct_fast(cls, c, x, extrapolate=None, axis=0):
@@ -660,12 +680,13 @@ class _PPolyBase:
         array must have dtype float.
         """
         self = object.__new__(cls)
-        self.c = c
-        self.x = x
+        self._c = np.asarray(c)
+        self._x = np.asarray(x)
         self.axis = axis
         if extrapolate is None:
             extrapolate = True
         self.extrapolate = extrapolate
+        self._asarray = array_namespace(c, x).asarray
         return self
 
     def _ensure_c_contiguous(self):
@@ -673,10 +694,10 @@ class _PPolyBase:
         c and x may be modified by the user. The Cython code expects
         that they are C contiguous.
         """
-        if not self.x.flags.c_contiguous:
-            self.x = self.x.copy()
-        if not self.c.flags.c_contiguous:
-            self.c = self.c.copy()
+        if not self._x.flags.c_contiguous:
+            self._x = self._x.copy()
+        if not self._c.flags.c_contiguous:
+            self._c = self._c.copy()
 
     def extend(self, c, x):
         """
@@ -709,9 +730,9 @@ class _PPolyBase:
             raise ValueError("invalid dimensions for x")
         if x.shape[0] != c.shape[1]:
             raise ValueError(f"Shapes of x {x.shape} and c {c.shape} are incompatible")
-        if c.shape[2:] != self.c.shape[2:] or c.ndim != self.c.ndim:
+        if c.shape[2:] != self._c.shape[2:] or c.ndim != self._c.ndim:
             raise ValueError(
-                f"Shapes of c {c.shape} and self.c {self.c.shape} are incompatible"
+                f"Shapes of c {c.shape} and self._c {self._c.shape} are incompatible"
             )
 
         if c.size == 0:
@@ -721,14 +742,14 @@ class _PPolyBase:
         if not (np.all(dx >= 0) or np.all(dx <= 0)):
             raise ValueError("`x` is not sorted.")
 
-        if self.x[-1] >= self.x[0]:
+        if self._x[-1] >= self._x[0]:
             if not x[-1] >= x[0]:
                 raise ValueError("`x` is in the different order "
                                 "than `self.x`.")
 
-            if x[0] >= self.x[-1]:
+            if x[0] >= self._x[-1]:
                 action = 'append'
-            elif x[-1] <= self.x[0]:
+            elif x[-1] <= self._x[0]:
                 action = 'prepend'
             else:
                 raise ValueError("`x` is neither on the left or on the right "
@@ -738,9 +759,9 @@ class _PPolyBase:
                 raise ValueError("`x` is in the different order "
                                 "than `self.x`.")
 
-            if x[0] <= self.x[-1]:
+            if x[0] <= self._x[-1]:
                 action = 'append'
-            elif x[-1] >= self.x[0]:
+            elif x[-1] >= self._x[0]:
                 action = 'prepend'
             else:
                 raise ValueError("`x` is neither on the left or on the right "
@@ -748,20 +769,20 @@ class _PPolyBase:
 
         dtype = self._get_dtype(c.dtype)
 
-        k2 = max(c.shape[0], self.c.shape[0])
-        c2 = np.zeros((k2, self.c.shape[1] + c.shape[1]) + self.c.shape[2:],
+        k2 = max(c.shape[0], self._c.shape[0])
+        c2 = np.zeros((k2, self._c.shape[1] + c.shape[1]) + self._c.shape[2:],
                     dtype=dtype)
 
         if action == 'append':
-            c2[k2-self.c.shape[0]:, :self.c.shape[1]] = self.c
-            c2[k2-c.shape[0]:, self.c.shape[1]:] = c
-            self.x = np.r_[self.x, x]
+            c2[k2-self._c.shape[0]:, :self._c.shape[1]] = self._c
+            c2[k2-c.shape[0]:, self._c.shape[1]:] = c
+            self._x = np.r_[self._x, x]
         elif action == 'prepend':
-            c2[k2-self.c.shape[0]:, :c.shape[1]] = c
-            c2[k2-c.shape[0]:, c.shape[1]:] = self.c
-            self.x = np.r_[x, self.x]
+            c2[k2-self._c.shape[0]:, :c.shape[1]] = c
+            c2[k2-c.shape[0]:, c.shape[1]:] = self._c
+            self._x = np.r_[x, self._x]
 
-        self.c = c2
+        self._c = c2
 
     def __call__(self, x, nu=0, extrapolate=None):
         """
@@ -802,19 +823,19 @@ class _PPolyBase:
         # With periodic extrapolation we map x to the segment
         # [self.x[0], self.x[-1]].
         if extrapolate == 'periodic':
-            x = self.x[0] + (x - self.x[0]) % (self.x[-1] - self.x[0])
+            x = self._x[0] + (x - self._x[0]) % (self._x[-1] - self._x[0])
             extrapolate = False
 
-        out = np.empty((len(x), prod(self.c.shape[2:])), dtype=self.c.dtype)
+        out = np.empty((len(x), prod(self._c.shape[2:])), dtype=self._c.dtype)
         self._ensure_c_contiguous()
         self._evaluate(x, nu, extrapolate, out)
-        out = out.reshape(x_shape + self.c.shape[2:])
+        out = out.reshape(x_shape + self._c.shape[2:])
         if self.axis != 0:
             # transpose to move the calculated values to the interpolation axis
             l = list(range(out.ndim))
             l = l[x_ndim:x_ndim+self.axis] + l[:x_ndim] + l[x_ndim+self.axis:]
             out = out.transpose(l)
-        return out
+        return self._asarray(out)
 
 
 class PPoly(_PPolyBase):
@@ -877,8 +898,8 @@ class PPoly(_PPolyBase):
     """
 
     def _evaluate(self, x, nu, extrapolate, out):
-        _ppoly.evaluate(self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-                        self.x, x, nu, bool(extrapolate), out)
+        _ppoly.evaluate(self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
+                        self._x, x, nu, bool(extrapolate), out)
 
     def derivative(self, nu=1):
         """
@@ -909,9 +930,9 @@ class PPoly(_PPolyBase):
 
         # reduce order
         if nu == 0:
-            c2 = self.c.copy()
+            c2 = self._c.copy()
         else:
-            c2 = self.c[:-nu, :].copy()
+            c2 = self._c[:-nu, :].copy()
 
         if c2.shape[0] == 0:
             # derivative of order 0 is zero
@@ -922,6 +943,7 @@ class PPoly(_PPolyBase):
         c2 *= factor[(slice(None),) + (None,)*(c2.ndim-1)]
 
         # construct a compatible polynomial
+        c2 = self._asarray(c2)
         return self.construct_fast(c2, self.x, self.extrapolate, self.axis)
 
     def antiderivative(self, nu=1):
@@ -957,18 +979,18 @@ class PPoly(_PPolyBase):
         if nu <= 0:
             return self.derivative(-nu)
 
-        c = np.zeros((self.c.shape[0] + nu, self.c.shape[1]) + self.c.shape[2:],
-                     dtype=self.c.dtype)
-        c[:-nu] = self.c
+        c = np.zeros((self._c.shape[0] + nu, self._c.shape[1]) + self._c.shape[2:],
+                     dtype=self._c.dtype)
+        c[:-nu] = self._c
 
         # divide by the correct rising factorials
-        factor = spec.poch(np.arange(self.c.shape[0], 0, -1), nu)
+        factor = spec.poch(np.arange(self._c.shape[0], 0, -1), nu)
         c[:-nu] /= factor[(slice(None),) + (None,)*(c.ndim-1)]
 
         # fix continuity of added degrees of freedom
         self._ensure_c_contiguous()
         _ppoly.fix_continuity(c.reshape(c.shape[0], c.shape[1], -1),
-                              self.x, nu - 1)
+                              self._x, nu - 1)
 
         if self.extrapolate == 'periodic':
             extrapolate = False
@@ -976,6 +998,7 @@ class PPoly(_PPolyBase):
             extrapolate = self.extrapolate
 
         # construct a compatible polynomial
+        c = self._asarray(c)
         return self.construct_fast(c, self.x, extrapolate, self.axis)
 
     def integrate(self, a, b, extrapolate=None):
@@ -1008,7 +1031,7 @@ class PPoly(_PPolyBase):
             a, b = b, a
             sign = -1
 
-        range_int = np.empty((prod(self.c.shape[2:]),), dtype=self.c.dtype)
+        range_int = np.empty((prod(self._c.shape[2:]),), dtype=self._c.dtype)
         self._ensure_c_contiguous()
 
         # Compute the integral.
@@ -1016,15 +1039,15 @@ class PPoly(_PPolyBase):
             # Split the integral into the part over period (can be several
             # of them) and the remaining part.
 
-            xs, xe = self.x[0], self.x[-1]
+            xs, xe = self._x[0], self._x[-1]
             period = xe - xs
             interval = b - a
             n_periods, left = divmod(interval, period)
 
             if n_periods > 0:
                 _ppoly.integrate(
-                    self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-                    self.x, xs, xe, False, out=range_int)
+                    self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
+                    self._x, xs, xe, False, out=range_int)
                 range_int *= n_periods
             else:
                 range_int.fill(0)
@@ -1038,27 +1061,27 @@ class PPoly(_PPolyBase):
             remainder_int = np.empty_like(range_int)
             if b <= xe:
                 _ppoly.integrate(
-                    self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-                    self.x, a, b, False, out=remainder_int)
+                    self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
+                    self._x, a, b, False, out=remainder_int)
                 range_int += remainder_int
             else:
                 _ppoly.integrate(
-                    self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-                    self.x, a, xe, False, out=remainder_int)
+                    self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
+                    self._x, a, xe, False, out=remainder_int)
                 range_int += remainder_int
 
                 _ppoly.integrate(
-                    self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-                    self.x, xs, xs + left + a - xe, False, out=remainder_int)
+                    self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
+                    self._x, xs, xs + left + a - xe, False, out=remainder_int)
                 range_int += remainder_int
         else:
             _ppoly.integrate(
-                self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-                self.x, a, b, bool(extrapolate), out=range_int)
+                self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
+                self._x, a, b, bool(extrapolate), out=range_int)
 
         # Return
         range_int *= sign
-        return range_int.reshape(self.c.shape[2:])
+        return self._asarray(range_int.reshape(self._c.shape[2:]))
 
     def solve(self, y=0., discontinuity=True, extrapolate=None):
         """
@@ -1114,24 +1137,24 @@ class PPoly(_PPolyBase):
 
         self._ensure_c_contiguous()
 
-        if np.issubdtype(self.c.dtype, np.complexfloating):
+        if np.issubdtype(self._c.dtype, np.complexfloating):
             raise ValueError("Root finding is only for "
                              "real-valued polynomials")
 
         y = float(y)
-        r = _ppoly.real_roots(self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-                              self.x, y, bool(discontinuity),
+        r = _ppoly.real_roots(self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
+                              self._x, y, bool(discontinuity),
                               bool(extrapolate))
-        if self.c.ndim == 2:
+        if self._c.ndim == 2:
             return r[0]
         else:
-            r2 = np.empty(prod(self.c.shape[2:]), dtype=object)
+            r2 = np.empty(prod(self._c.shape[2:]), dtype=object)
             # this for-loop is equivalent to ``r2[...] = r``, but that's broken
             # in NumPy 1.6.0
             for ii, root in enumerate(r):
                 r2[ii] = root
 
-            return r2.reshape(self.c.shape[2:])
+            return r2.reshape(self._c.shape[2:])
 
     def roots(self, discontinuity=True, extrapolate=None):
         """
@@ -1230,18 +1253,20 @@ class PPoly(_PPolyBase):
 
         """
         if isinstance(tck, BSpline):
-            t, c, k = tck.tck
+            t, c, k = tck._t, tck._c, tck.k
+            _asarray = tck._asarray
             if extrapolate is None:
                 extrapolate = tck.extrapolate
         else:
             t, c, k = tck
+            _asarray = np.asarray
 
         cvals = np.empty((k + 1, len(t)-1), dtype=c.dtype)
         for m in range(k, -1, -1):
-            y = _fitpack_py.splev(t[:-1], tck, der=m)
-            cvals[k - m, :] = y/spec.gamma(m+1)
+            y = _fitpack_py.splev(t[:-1], (t, c, k), der=m)
+            cvals[k - m, :] = y / spec.gamma(m+1)
 
-        return cls.construct_fast(cvals, t, extrapolate)
+        return cls.construct_fast(_asarray(cvals), _asarray(t), extrapolate)
 
     @classmethod
     def from_bernstein_basis(cls, bp, extrapolate=None):
@@ -1267,9 +1292,9 @@ class PPoly(_PPolyBase):
 
         rest = (None,)*(bp.c.ndim-2)
 
-        c = np.zeros_like(bp.c)
+        c = np.zeros_like(bp._c)
         for a in range(k+1):
-            factor = (-1)**a * comb(k, a) * bp.c[a]
+            factor = (-1)**a * comb(k, a) * bp._c[a]
             for s in range(a, k+1):
                 val = comb(k-a, s-a) * (-1)**s
                 c[k-s] += factor * val / dx[(slice(None),)+rest]**s
@@ -1277,7 +1302,7 @@ class PPoly(_PPolyBase):
         if extrapolate is None:
             extrapolate = bp.extrapolate
 
-        return cls.construct_fast(c, bp.x, extrapolate, bp.axis)
+        return cls.construct_fast(bp._asarray(c), bp.x, extrapolate, bp.axis)
 
 
 class BPoly(_PPolyBase):
@@ -1369,8 +1394,8 @@ class BPoly(_PPolyBase):
 
     def _evaluate(self, x, nu, extrapolate, out):
         _ppoly.evaluate_bernstein(
-            self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
-            self.x, x, nu, bool(extrapolate), out)
+            self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
+            self._x, x, nu, bool(extrapolate), out)
 
     def derivative(self, nu=1):
         """
@@ -1400,7 +1425,7 @@ class BPoly(_PPolyBase):
 
         # reduce order
         if nu == 0:
-            c2 = self.c.copy()
+            c2 = self._c.copy()
         else:
             # For a polynomial
             #    B(x) = \sum_{a=0}^{k} c_a b_{a, k}(x),
@@ -1412,17 +1437,18 @@ class BPoly(_PPolyBase):
             # finally, for an interval [y, y + dy] with dy != 1,
             # we need to correct for an extra power of dy
 
-            rest = (None,)*(self.c.ndim-2)
+            rest = (None,)*(self._c.ndim-2)
 
-            k = self.c.shape[0] - 1
-            dx = np.diff(self.x)[(None, slice(None))+rest]
-            c2 = k * np.diff(self.c, axis=0) / dx
+            k = self._c.shape[0] - 1
+            dx = np.diff(self._x)[(None, slice(None))+rest]
+            c2 = k * np.diff(self._c, axis=0) / dx
 
         if c2.shape[0] == 0:
             # derivative of order 0 is zero
             c2 = np.zeros((1,) + c2.shape[1:], dtype=c2.dtype)
 
         # construct a compatible polynomial
+        c2 = self._asarray(c2)
         return self.construct_fast(c2, self.x, self.extrapolate, self.axis)
 
     def antiderivative(self, nu=1):
@@ -1458,7 +1484,7 @@ class BPoly(_PPolyBase):
             return bp
 
         # Construct the indefinite integrals on individual intervals
-        c, x = self.c, self.x
+        c, x = self._c, self._x
         k = c.shape[0]
         c2 = np.zeros((k+1,) + c.shape[1:], dtype=c.dtype)
 
@@ -1479,7 +1505,8 @@ class BPoly(_PPolyBase):
         else:
             extrapolate = self.extrapolate
 
-        return self.construct_fast(c2, x, extrapolate, axis=self.axis)
+        c2 = self._asarray(c2)
+        return self.construct_fast(c2, self.x, extrapolate, axis=self.axis)
 
     def integrate(self, a, b, extrapolate=None):
         """
@@ -1524,7 +1551,7 @@ class BPoly(_PPolyBase):
                 a, b = b, a
                 sign = -1
 
-            xs, xe = self.x[0], self.x[-1]
+            xs, xe = self._x[0], self._x[-1]
             period = xe - xs
             interval = b - a
             n_periods, left = divmod(interval, period)
@@ -1541,13 +1568,13 @@ class BPoly(_PPolyBase):
             else:
                 res += ib(xe) - ib(a) + ib(xs + left + a - xe) - ib(xs)
 
-            return sign * res
+            return self._asarray(sign * res)
         else:
             return ib(b) - ib(a)
 
     def extend(self, c, x):
-        k = max(self.c.shape[0], c.shape[0])
-        self.c = self._raise_degree(self.c, k - self.c.shape[0])
+        k = max(self._c.shape[0], c.shape[0])
+        self._c = self._raise_degree(self._c, k - self._c.shape[0])
         c = self._raise_degree(c, k - c.shape[0])
         return _PPolyBase.extend(self, c, x)
     extend.__doc__ = _PPolyBase.extend.__doc__
@@ -1576,16 +1603,16 @@ class BPoly(_PPolyBase):
 
         rest = (None,)*(pp.c.ndim-2)
 
-        c = np.zeros_like(pp.c)
+        c = np.zeros_like(pp._c)
         for a in range(k+1):
-            factor = pp.c[a] / comb(k, k-a) * dx[(slice(None),)+rest]**(k-a)
+            factor = pp._c[a] / comb(k, k-a) * dx[(slice(None),)+rest]**(k-a)
             for j in range(k-a, k+1):
                 c[j] += factor * comb(j, k-a)
 
         if extrapolate is None:
             extrapolate = pp.extrapolate
 
-        return cls.construct_fast(c, pp.x, extrapolate, pp.axis)
+        return cls.construct_fast(pp._asarray(c), pp.x, extrapolate, pp.axis)
 
     @classmethod
     def from_derivatives(cls, xi, yi, orders=None, extrapolate=None):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1287,8 +1287,8 @@ class PPoly(_PPolyBase):
             raise TypeError(f".from_bernstein_basis only accepts BPoly instances. "
                             f"Got {type(bp)} instead.")
 
-        dx = np.diff(bp.x)
-        k = bp.c.shape[0] - 1  # polynomial order
+        dx = np.diff(bp._x)
+        k = bp._c.shape[0] - 1  # polynomial order
 
         rest = (None,)*(bp.c.ndim-2)
 
@@ -1598,14 +1598,14 @@ class BPoly(_PPolyBase):
             raise TypeError(f".from_power_basis only accepts PPoly instances. "
                             f"Got {type(pp)} instead.")
 
-        dx = np.diff(pp.x)
-        k = pp.c.shape[0] - 1   # polynomial order
+        dx = np.diff(pp._x)
+        k = pp._c.shape[0] - 1   # polynomial order
 
-        rest = (None,)*(pp.c.ndim-2)
+        rest = (None,)*(pp._c.ndim-2)
 
         c = np.zeros_like(pp._c)
         for a in range(k+1):
-            factor = pp._c[a] / comb(k, k-a) * dx[(slice(None),)+rest]**(k-a)
+            factor = pp._c[a] / comb(k, k-a) * dx[(slice(None),) + rest]**(k-a)
             for j in range(k-a, k+1):
                 c[j] += factor * comb(j, k-a)
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -10,7 +10,7 @@ import scipy.special as spec
 from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, xp_capabilities
 
 from . import _fitpack_py
 from ._polyint import _Interpolator1D
@@ -838,6 +838,7 @@ class _PPolyBase:
         return self._asarray(out)
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=1)
 class PPoly(_PPolyBase):
     """Piecewise polynomial in the power basis.
 
@@ -1305,6 +1306,7 @@ class PPoly(_PPolyBase):
         return cls.construct_fast(bp._asarray(c), bp.x, extrapolate, bp.axis)
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False)
 class BPoly(_PPolyBase):
     """Piecewise polynomial in the Bernstein basis.
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -838,7 +838,13 @@ class _PPolyBase:
         return self._asarray(out)
 
 
-@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=1)
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[
+        ("dask.array",
+         "https://github.com/data-apis/array-api-extra/issues/488")
+    ]
+)
 class PPoly(_PPolyBase):
     """Piecewise polynomial in the power basis.
 
@@ -1306,7 +1312,13 @@ class PPoly(_PPolyBase):
         return cls.construct_fast(bp._asarray(c), bp.x, extrapolate, bp.axis)
 
 
-@xp_capabilities(cpu_only=True, jax_jit=False)
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[
+        ("dask.array",
+         "https://github.com/data-apis/array-api-extra/issues/488")
+    ]
+)
 class BPoly(_PPolyBase):
     """Piecewise polynomial in the Bernstein basis.
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -10,7 +10,7 @@ import scipy.special as spec
 from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
-from scipy._lib._array_api import array_namespace, concat_1d
+from scipy._lib._array_api import array_namespace
 
 from . import _fitpack_py
 from ._polyint import _Interpolator1D

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -836,6 +836,7 @@ class TestLagrange:
         assert_array_almost_equal(p.coeffs,pl.coeffs)
 
 
+@xfail_xp_backends("jax.numpy", reason="immutable arrays")
 @xfail_xp_backends("array_api_strict", reason="fancy indexing __setitem__")
 @skip_xp_backends(cpu_only=True)
 class TestAkima1DInterpolator:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -837,6 +837,7 @@ class TestLagrange:
 
 
 @xfail_xp_backends("array_api_strict", reason="fancy indexing __setitem__")
+@skip_xp_backends(cpu_only=True)
 class TestAkima1DInterpolator:
     def test_eval(self, xp):
         x = xp.arange(0., 11.)
@@ -1035,6 +1036,7 @@ def test_complex(method):
         _run_concurrent_barrier(10, worker_fn, ak, x_ext)
 
 
+@skip_xp_backends(cpu_only=True)
 class TestPPolyCommon:
     # test basic functionality for PPoly and BPoly
     def test_sort_check(self, xp):
@@ -1245,6 +1247,7 @@ class TestPolySubclassing:
         assert bp.__class__ == self.B
 
 
+@skip_xp_backends(cpu_only=True)
 class TestPPoly:
     def test_simple(self, xp):
         c = xp.asarray([[1, 4], [2, 5], [3, 6]])
@@ -1751,6 +1754,7 @@ class TestPPoly:
                 xp_assert_close(pp.roots(), np.asarray([1.0, -1.0]))
 
 
+@skip_xp_backends(cpu_only=True)
 class TestBPoly:
     def test_simple(self, xp):
         x = xp.asarray([0, 1])
@@ -1887,6 +1891,7 @@ class TestBPoly:
                 assert not np.isnan(bp_d([-0.1, 2.1])).any()
 
 
+@skip_xp_backends(cpu_only=True)
 class TestBPolyCalculus:
     def test_derivative(self, xp):
         x = xp.asarray([0, 1, 3])
@@ -2049,6 +2054,7 @@ class TestBPolyCalculus:
                         atol=1e-12, rtol=1e-12)
 
 
+@skip_xp_backends(cpu_only=True)
 class TestPolyConversions:
     def test_bp_from_pp(self, xp):
         x = xp.asarray([0, 1, 3])

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -836,52 +836,53 @@ class TestLagrange:
         assert_array_almost_equal(p.coeffs,pl.coeffs)
 
 
+@xfail_xp_backends("array_api_strict", reason="fancy indexing __setitem__")
 class TestAkima1DInterpolator:
-    def test_eval(self):
-        x = np.arange(0., 11.)
-        y = np.array([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
+    def test_eval(self, xp):
+        x = xp.arange(0., 11.)
+        y = xp.asarray([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
         ak = Akima1DInterpolator(x, y)
-        xi = np.array([0., 0.5, 1., 1.5, 2.5, 3.5, 4.5, 5.1, 6.5, 7.2,
+        xi = xp.asarray([0., 0.5, 1., 1.5, 2.5, 3.5, 4.5, 5.1, 6.5, 7.2,
             8.6, 9.9, 10.])
-        yi = np.array([0., 1.375, 2., 1.5, 1.953125, 2.484375,
+        yi = xp.asarray([0., 1.375, 2., 1.5, 1.953125, 2.484375,
             4.1363636363636366866103344, 5.9803623910336236590978842,
             5.5067291516462386624652936, 5.2031367459745245795943447,
             4.1796554159017080820603951, 3.4110386597938129327189927,
             3.])
         xp_assert_close(ak(xi), yi)
 
-    def test_eval_mod(self):
+    def test_eval_mod(self, xp):
         # Reference values generated with the following MATLAB code:
         # format longG
         # x = 0:10; y = [0. 2. 1. 3. 2. 6. 5.5 5.5 2.7 5.1 3.];
         # xi = [0. 0.5 1. 1.5 2.5 3.5 4.5 5.1 6.5 7.2 8.6 9.9 10.];
         # makima(x, y, xi)
-        x = np.arange(0., 11.)
-        y = np.array([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
+        x = xp.arange(0., 11.)
+        y = xp.asarray([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
         ak = Akima1DInterpolator(x, y, method="makima")
-        xi = np.array([0., 0.5, 1., 1.5, 2.5, 3.5, 4.5, 5.1, 6.5, 7.2,
+        xi = xp.asarray([0., 0.5, 1., 1.5, 2.5, 3.5, 4.5, 5.1, 6.5, 7.2,
                        8.6, 9.9, 10.])
-        yi = np.array([
+        yi = xp.asarray([
             0.0, 1.34471153846154, 2.0, 1.44375, 1.94375, 2.51939102564103,
             4.10366931918656, 5.98501550899192, 5.51756330960439, 5.1757231914014,
             4.12326636931311, 3.32931513157895, 3.0])
         xp_assert_close(ak(xi), yi)
 
-    def test_eval_2d(self):
-        x = np.arange(0., 11.)
-        y = np.array([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
-        y = np.column_stack((y, 2. * y))
+    def test_eval_2d(self, xp):
+        x = xp.arange(0., 11.)
+        y = xp.asarray([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
+        y = xp.stack((y, 2. * y), axis=1)
         ak = Akima1DInterpolator(x, y)
-        xi = np.array([0., 0.5, 1., 1.5, 2.5, 3.5, 4.5, 5.1, 6.5, 7.2,
+        xi = xp.asarray([0., 0.5, 1., 1.5, 2.5, 3.5, 4.5, 5.1, 6.5, 7.2,
                        8.6, 9.9, 10.])
-        yi = np.array([0., 1.375, 2., 1.5, 1.953125, 2.484375,
+        yi = xp.asarray([0., 1.375, 2., 1.5, 1.953125, 2.484375,
                        4.1363636363636366866103344,
                        5.9803623910336236590978842,
                        5.5067291516462386624652936,
                        5.2031367459745245795943447,
                        4.1796554159017080820603951,
                        3.4110386597938129327189927, 3.])
-        yi = np.column_stack((yi, 2. * yi))
+        yi = xp.stack((yi, 2. * yi), axis=1)
         xp_assert_close(ak(xi), yi)
 
     def test_eval_3d(self):
@@ -909,19 +910,19 @@ class TestAkima1DInterpolator:
         yi[:, 1, 1] = 4. * yi_
         xp_assert_close(ak(xi), yi)
 
-    def test_linear_interpolant_edge_case_1d(self):
-        x = np.array([0.0, 1.0], dtype=float)
-        y = np.array([0.5, 1.0])
+    def test_linear_interpolant_edge_case_1d(self, xp):
+        x = xp.asarray([0.0, 1.0], dtype=xp.float64)
+        y = xp.asarray([0.5, 1.0])
         akima = Akima1DInterpolator(x, y, axis=0, extrapolate=None)
-        xp_assert_close(akima(0.45), np.array(0.725))
+        xp_assert_close(akima(0.45), xp.asarray(0.725))
 
-    def test_linear_interpolant_edge_case_2d(self):
-        x = np.array([0., 1.])
-        y = np.column_stack((x, 2. * x, 3. * x, 4. * x))
+    def test_linear_interpolant_edge_case_2d(self, xp):
+        x = xp.asarray([0., 1.])
+        y = xp.stack((x, 2. * x, 3. * x, 4. * x), axis=1)
 
         ak = Akima1DInterpolator(x, y)
-        xi = np.array([0.5, 1.])
-        yi = np.array([[0.5, 1., 1.5, 2. ],
+        xi = xp.asarray([0.5, 1.])
+        yi = xp.asarray([[0.5, 1., 1.5, 2. ],
                        [1., 2., 3., 4.]])
         xp_assert_close(ak(xi), yi)
 
@@ -952,15 +953,14 @@ class TestAkima1DInterpolator:
         ak = Akima1DInterpolator(x, y.transpose(2, 1, 0), axis=2)
         xp_assert_close(ak(xi), yi.transpose(2, 1, 0))
 
-
-    def test_degenerate_case_multidimensional(self):
+    def test_degenerate_case_multidimensional(self, xp):
         # This test is for issue #5683.
-        x = np.array([0, 1, 2])
-        y = np.vstack((x, x**2)).T
+        x = xp.asarray([0, 1, 2])
+        y = xp.stack((x, x**2)).T
         ak = Akima1DInterpolator(x, y)
-        x_eval = np.array([0.5, 1.5])
+        x_eval = xp.asarray([0.5, 1.5])
         y_eval = ak(x_eval)
-        xp_assert_close(y_eval, np.vstack((x_eval, x_eval**2)).T)
+        xp_assert_close(y_eval, xp.stack((x_eval, x_eval**2)).T)
 
     def test_extend(self):
         x = np.arange(0., 11.)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -842,16 +842,18 @@ class TestLagrange:
 @skip_xp_backends(cpu_only=True)
 class TestAkima1DInterpolator:
     def test_eval(self, xp):
-        x = xp.arange(0., 11.)
-        y = xp.asarray([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
+        x = xp.arange(0., 11., dtype=xp.float64)
+        y = xp.asarray(
+            [0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.], dtype=xp.float64
+        )
         ak = Akima1DInterpolator(x, y)
         xi = xp.asarray([0., 0.5, 1., 1.5, 2.5, 3.5, 4.5, 5.1, 6.5, 7.2,
-            8.6, 9.9, 10.])
+            8.6, 9.9, 10.], dtype=xp.float64)
         yi = xp.asarray([0., 1.375, 2., 1.5, 1.953125, 2.484375,
             4.1363636363636366866103344, 5.9803623910336236590978842,
             5.5067291516462386624652936, 5.2031367459745245795943447,
             4.1796554159017080820603951, 3.4110386597938129327189927,
-            3.])
+            3.], dtype=xp.float64)
         xp_assert_close(ak(xi), yi)
 
     def test_eval_mod(self, xp):
@@ -860,31 +862,35 @@ class TestAkima1DInterpolator:
         # x = 0:10; y = [0. 2. 1. 3. 2. 6. 5.5 5.5 2.7 5.1 3.];
         # xi = [0. 0.5 1. 1.5 2.5 3.5 4.5 5.1 6.5 7.2 8.6 9.9 10.];
         # makima(x, y, xi)
-        x = xp.arange(0., 11.)
-        y = xp.asarray([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
+        x = xp.arange(0., 11., dtype=xp.float64)
+        y = xp.asarray(
+            [0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.], dtype=xp.float64
+        )
         ak = Akima1DInterpolator(x, y, method="makima")
         xi = xp.asarray([0., 0.5, 1., 1.5, 2.5, 3.5, 4.5, 5.1, 6.5, 7.2,
-                       8.6, 9.9, 10.])
+                       8.6, 9.9, 10.], dtype=xp.float64)
         yi = xp.asarray([
             0.0, 1.34471153846154, 2.0, 1.44375, 1.94375, 2.51939102564103,
             4.10366931918656, 5.98501550899192, 5.51756330960439, 5.1757231914014,
-            4.12326636931311, 3.32931513157895, 3.0])
+            4.12326636931311, 3.32931513157895, 3.0], dtype=xp.float64)
         xp_assert_close(ak(xi), yi)
 
     def test_eval_2d(self, xp):
-        x = xp.arange(0., 11.)
-        y = xp.asarray([0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.])
+        x = xp.arange(0., 11., dtype=xp.float64)
+        y = xp.asarray(
+            [0., 2., 1., 3., 2., 6., 5.5, 5.5, 2.7, 5.1, 3.], dtype=xp.float64
+        )
         y = xp.stack((y, 2. * y), axis=1)
         ak = Akima1DInterpolator(x, y)
         xi = xp.asarray([0., 0.5, 1., 1.5, 2.5, 3.5, 4.5, 5.1, 6.5, 7.2,
-                       8.6, 9.9, 10.])
+                       8.6, 9.9, 10.], dtype=xp.float64)
         yi = xp.asarray([0., 1.375, 2., 1.5, 1.953125, 2.484375,
                        4.1363636363636366866103344,
                        5.9803623910336236590978842,
                        5.5067291516462386624652936,
                        5.2031367459745245795943447,
                        4.1796554159017080820603951,
-                       3.4110386597938129327189927, 3.])
+                       3.4110386597938129327189927, 3.], dtype=xp.float64)
         yi = xp.stack((yi, 2. * yi), axis=1)
         xp_assert_close(ak(xi), yi)
 
@@ -917,7 +923,7 @@ class TestAkima1DInterpolator:
         x = xp.asarray([0.0, 1.0], dtype=xp.float64)
         y = xp.asarray([0.5, 1.0])
         akima = Akima1DInterpolator(x, y, axis=0, extrapolate=None)
-        xp_assert_close(akima(0.45), xp.asarray(0.725))
+        xp_assert_close(akima(0.45), xp.asarray(0.725, dtype=xp.float64))
 
     def test_linear_interpolant_edge_case_2d(self, xp):
         x = xp.asarray([0., 1.])
@@ -925,8 +931,9 @@ class TestAkima1DInterpolator:
 
         ak = Akima1DInterpolator(x, y)
         xi = xp.asarray([0.5, 1.])
-        yi = xp.asarray([[0.5, 1., 1.5, 2. ],
-                       [1., 2., 3., 4.]])
+        yi = xp.asarray([[0.5, 1., 1.5, 2.],
+                         [1., 2., 3., 4.]], dtype=xp.float64
+        )
         xp_assert_close(ak(xi), yi)
 
         ak = Akima1DInterpolator(x, y.T, axis=1)
@@ -958,10 +965,10 @@ class TestAkima1DInterpolator:
 
     def test_degenerate_case_multidimensional(self, xp):
         # This test is for issue #5683.
-        x = xp.asarray([0, 1, 2])
+        x = xp.asarray([0, 1, 2], dtype=xp.float64)
         y = xp.stack((x, x**2)).T
         ak = Akima1DInterpolator(x, y)
-        x_eval = xp.asarray([0.5, 1.5])
+        x_eval = xp.asarray([0.5, 1.5], dtype=xp.float64)
         y_eval = ak(x_eval)
         xp_assert_close(y_eval, xp.stack((x_eval, x_eval**2)).T)
 
@@ -1255,8 +1262,10 @@ class TestPPoly:
         c = xp.asarray([[1, 4], [2, 5], [3, 6]])
         x = xp.asarray([0, 0.5, 1])
         p = PPoly(c, x)
-        xp_assert_close(p(0.3), xp.asarray(1*0.3**2 + 2*0.3 + 3))
-        xp_assert_close(p(0.7), xp.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6))
+        xp_assert_close(p(0.3), xp.asarray(1*0.3**2 + 2*0.3 + 3, dtype=xp.float64))
+        xp_assert_close(
+            p(0.7), xp.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6, dtype=xp.float64)
+        )
 
     def test_periodic(self, xp):
         c = xp.asarray([[1, 4], [2, 5], [3, 6]])
@@ -1264,12 +1273,14 @@ class TestPPoly:
         p = PPoly(c, x, extrapolate='periodic')
 
         xp_assert_close(p(1.3),
-                        xp.asarray(1 * 0.3 ** 2 + 2 * 0.3 + 3))
-        xp_assert_close(p(-0.3),
-                        xp.asarray(4 * (0.7 - 0.5) ** 2 + 5 * (0.7 - 0.5) + 6))
+                        xp.asarray(1 * 0.3 ** 2 + 2 * 0.3 + 3, dtype=xp.float64))
+        xp_assert_close(
+            p(-0.3),
+            xp.asarray(4 * (0.7 - 0.5) ** 2 + 5 * (0.7 - 0.5) + 6, dtype=xp.float64)
+        )
 
-        xp_assert_close(p(1.3, 1), xp.asarray(2 * 0.3 + 2))
-        xp_assert_close(p(-0.3, 1), xp.asarray(8 * (0.7 - 0.5) + 5))
+        xp_assert_close(p(1.3, 1), xp.asarray(2 * 0.3 + 2, dtype=xp.float64))
+        xp_assert_close(p(-0.3, 1), xp.asarray(8 * (0.7 - 0.5) + 5, dtype=xp.float64))
 
     def test_read_only(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
@@ -1463,15 +1474,17 @@ class TestPPoly:
     def test_antiderivative_simple(self, xp):
         # [ p1(x) = 3*x**2 + 2*x + 1,
         #   p2(x) = 1.6875]
-        c = xp.asarray([[3, 2, 1], [0, 0, 1.6875]]).T
+        c = xp.asarray([[3, 2, 1], [0, 0, 1.6875]], dtype=xp.float64).T
         # [ pp1(x) = x**3 + x**2 + x,
         #   pp2(x) = 1.6875*(x - 0.25) + pp1(0.25)]
-        ic = xp.asarray([[1, 1, 1, 0], [0, 0, 1.6875, 0.328125]]).T
+        ic = xp.asarray([[1, 1, 1, 0], [0, 0, 1.6875, 0.328125]], dtype=xp.float64).T
         # [ ppp1(x) = (1/4)*x**4 + (1/3)*x**3 + (1/2)*x**2,
         #   ppp2(x) = (1.6875/2)*(x - 0.25)**2 + pp1(0.25)*x + ppp1(0.25)]
         iic = xp.asarray([[1/4, 1/3, 1/2, 0, 0],
-                          [0, 0, 1.6875/2, 0.328125, 0.037434895833333336]]).T
-        x = xp.asarray([0, 0.25, 1])
+                          [0, 0, 1.6875/2, 0.328125, 0.037434895833333336]],
+                         dtype=xp.float64
+        ).T
+        x = xp.asarray([0, 0.25, 1], dtype=xp.float64)
 
         pp = PPoly(c, x)
         ipp = pp.antiderivative()
@@ -1762,20 +1775,22 @@ class TestBPoly:
         x = xp.asarray([0, 1])
         c = xp.asarray([[3]])
         bp = BPoly(c, x)
-        xp_assert_close(bp(0.1), xp.asarray(3.))
+        xp_assert_close(bp(0.1), xp.asarray(3., dtype=xp.float64))
 
     def test_simple2(self, xp):
         x = xp.asarray([0, 1])
         c = xp.asarray([[3], [1]])
         bp = BPoly(c, x)   # 3*(1-x) + 1*x
-        xp_assert_close(bp(0.1), xp.asarray(3*0.9 + 1.*0.1))
+        xp_assert_close(bp(0.1), xp.asarray(3*0.9 + 1.*0.1, dtype=xp.float64))
 
     def test_simple3(self, xp):
         x = xp.asarray([0, 1])
         c = xp.asarray([[3], [1], [4]])
         bp = BPoly(c, x)   # 3 * (1-x)**2 + 2 * x (1-x) + 4 * x**2
-        xp_assert_close(bp(0.2),
-                        xp.asarray(3 * 0.8*0.8 + 1 * 2*0.2*0.8 + 4 * 0.2*0.2))
+        xp_assert_close(
+            bp(0.2),
+            xp.asarray(3 * 0.8*0.8 + 1 * 2*0.2*0.8 + 4 * 0.2*0.2, dtype=xp.float64)
+        )
 
     def test_simple4(self, xp):
         x = xp.asarray([0, 1])
@@ -1785,7 +1800,7 @@ class TestBPoly:
                         xp.asarray(    0.7**3 +
                                    3 * 0.7**2 * 0.3 +
                                    3 * 0.7 * 0.3**2 +
-                                   2 * 0.3**3)
+                                   2 * 0.3**3, dtype=xp.float64)
         )
 
     def test_simple5(self, xp):
@@ -1797,7 +1812,7 @@ class TestBPoly:
                                  4 * 0.7**3 * 0.3 +
                              8 * 6 * 0.7**2 * 0.3**2 +
                              2 * 4 * 0.7 * 0.3**3 +
-                                 0.3**4)
+                                 0.3**4, dtype=xp.float64)
         )
 
     def test_periodic(self, xp):
@@ -1806,11 +1821,11 @@ class TestBPoly:
         # [3*(1-x)**2, 2*((x-1)/2)**2]
         bp = BPoly(c, x, extrapolate='periodic')
 
-        xp_assert_close(bp(3.4), xp.asarray(3 * 0.6**2))
-        xp_assert_close(bp(-1.3), xp.asarray(2 * (0.7/2)**2))
+        xp_assert_close(bp(3.4), xp.asarray(3 * 0.6**2, dtype=xp.float64))
+        xp_assert_close(bp(-1.3), xp.asarray(2 * (0.7/2)**2, dtype=xp.float64))
 
-        xp_assert_close(bp(3.4, 1), xp.asarray(-6 * 0.6))
-        xp_assert_close(bp(-1.3, 1), xp.asarray(2 * (0.7/2)))
+        xp_assert_close(bp(3.4, 1), xp.asarray(-6 * 0.6, dtype=xp.float64))
+        xp_assert_close(bp(-1.3, 1), xp.asarray(2 * (0.7/2), dtype=xp.float64))
 
     def test_descending(self):
         rng = np.random.RandomState(0)
@@ -1865,8 +1880,9 @@ class TestBPoly:
         bp = BPoly(c, x)
         xval = 0.1
         s = xval / 2  # s = (x - xa) / (xb - xa)
-        xp_assert_close(bp(xval),
-                        xp.asarray(3 * (1-s)*(1-s) + 1 * 2*s*(1-s) + 4 * s*s)
+        xp_assert_close(
+            bp(xval),
+            xp.asarray(3 * (1-s)*(1-s) + 1 * 2*s*(1-s) + 4 * s*s, dtype=xp.float64)
         )
 
     def test_two_intervals(self, xp):
@@ -1874,8 +1890,8 @@ class TestBPoly:
         c = xp.asarray([[3, 0], [0, 0], [0, 2]])
         bp = BPoly(c, x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
 
-        xp_assert_close(bp(0.4), xp.asarray(3 * 0.6*0.6))
-        xp_assert_close(bp(1.7), xp.asarray(2 * (0.7/2)**2))
+        xp_assert_close(bp(0.4), xp.asarray(3 * 0.6*0.6, dtype=xp.float64))
+        xp_assert_close(bp(1.7), xp.asarray(2 * (0.7/2)**2, dtype=xp.float64))
 
     def test_extrapolate_attr(self):
         x = [0, 2]
@@ -1900,15 +1916,15 @@ class TestBPolyCalculus:
         c = xp.asarray([[3, 0], [0, 0], [0, 2]])
         bp = BPoly(c, x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
         bp_der = bp.derivative()
-        xp_assert_close(bp_der(0.4), xp.asarray(-6*(0.6)))
-        xp_assert_close(bp_der(1.7), xp.asarray(0.7))
+        xp_assert_close(bp_der(0.4), xp.asarray(-6*(0.6), dtype=xp.float64))
+        xp_assert_close(bp_der(1.7), xp.asarray(0.7, dtype=xp.float64))
 
         # derivatives in-place
         xp_assert_close(xp.stack([bp(0.4, nu) for nu in [1, 2, 3]]),
-                        xp.asarray([-6*(1-0.4), 6., 0.])
+                        xp.asarray([-6*(1-0.4), 6., 0.], dtype=xp.float64)
         )
         xp_assert_close(xp.stack([bp(1.7, nu) for nu in [1, 2, 3]]),
-                        xp.asarray([0.7, 1., 0])
+                        xp.asarray([0.7, 1., 0], dtype=xp.float64)
         )
 
     def test_derivative_ppoly(self, xp):
@@ -1955,7 +1971,7 @@ class TestBPolyCalculus:
         bp = BPoly(c, x)
         bi = bp.antiderivative()
 
-        xx = xp.linspace(0, 3, 11)
+        xx = xp.linspace(0, 3, 11, dtype=xp.float64)
         xp_assert_close(bi(xx),
                         xp.where(xx < 1, xx**2 / 2.,
                                          0.5 * xx * (xx/2. - 1) + 3./4),

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -22,6 +22,9 @@ from scipy.integrate import nquad
 
 from scipy.special import binom
 
+skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
+
 
 class TestInterp2D:
     def test_interp2d(self):
@@ -1034,9 +1037,9 @@ def test_complex(method):
 
 class TestPPolyCommon:
     # test basic functionality for PPoly and BPoly
-    def test_sort_check(self):
-        c = np.array([[1, 4], [2, 5], [3, 6]])
-        x = np.array([0, 1, 0.5])
+    def test_sort_check(self, xp):
+        c = xp.asarray([[1, 4], [2, 5], [3, 6]])
+        x = xp.asarray([0, 1, 0.5])
         assert_raises(ValueError, PPoly, c, x)
         assert_raises(ValueError, BPoly, c, x)
 
@@ -1045,7 +1048,7 @@ class TestPPolyCommon:
         with assert_raises(ValueError):
             PPoly([1, 2], [0, 1])
 
-    def test_extend(self):
+    def test_extend(self, xp):
         # Test adding new points to the piecewise polynomial
         np.random.seed(1234)
 
@@ -1053,12 +1056,14 @@ class TestPPolyCommon:
         x = np.unique(np.r_[0, 10 * np.random.rand(30), 10])
         c = 2*np.random.rand(order+1, len(x)-1, 2, 3) - 1
 
-        for cls in (PPoly, BPoly):
-            pp = cls(c[:,:9], x[:10])
-            pp.extend(c[:,9:], x[10:])
+        c, x = xp.asarray(c), xp.asarray(x)
 
-            pp2 = cls(c[:, 10:], x[10:])
-            pp2.extend(c[:, :10], x[:10])
+        for cls in (PPoly, BPoly):
+            pp = cls(c[:, :9, ...], x[:10])
+            pp.extend(c[:, 9:, ...], x[10:])
+
+            pp2 = cls(c[:, 10:, ...], x[10:])
+            pp2.extend(c[:, :10, ...], x[:10])
 
             pp3 = cls(c, x)
 
@@ -1067,15 +1072,15 @@ class TestPPolyCommon:
             xp_assert_equal(pp2.c, pp3.c)
             xp_assert_equal(pp2.x, pp3.x)
 
-    def test_extend_diff_orders(self):
+    def test_extend_diff_orders(self, xp):
         # Test extending polynomial with different order one
         np.random.seed(1234)
 
-        x = np.linspace(0, 1, 6)
-        c = np.random.rand(2, 5)
+        x = xp.linspace(0, 1, 6)
+        c = xp.asarray(np.random.rand(2, 5))
 
-        x2 = np.linspace(1, 2, 6)
-        c2 = np.random.rand(4, 5)
+        x2 = xp.linspace(1, 2, 6)
+        c2 = xp.asarray(np.random.rand(4, 5))
 
         for cls in (PPoly, BPoly):
             pp1 = cls(c, x)
@@ -1086,27 +1091,29 @@ class TestPPolyCommon:
 
             # NB. doesn't match to pp1 at the endpoint, because pp1 is not
             #     continuous with pp2 as we took random coefs.
-            xi1 = np.linspace(0, 1, 300, endpoint=False)
-            xi2 = np.linspace(1, 2, 300)
+            xi1 = xp.linspace(0, 1, 300, endpoint=False)
+            xi2 = xp.linspace(1, 2, 300)
 
             xp_assert_close(pp1(xi1), pp_comb(xi1))
             xp_assert_close(pp2(xi2), pp_comb(xi2))
 
-    def test_extend_descending(self):
+    def test_extend_descending(self, xp):
         np.random.seed(0)
 
         order = 3
         x = np.sort(np.random.uniform(0, 10, 20))
         c = np.random.rand(order + 1, x.shape[0] - 1, 2, 3)
 
+        c, x = xp.asarray(c), xp.asarray(x)
+
         for cls in (PPoly, BPoly):
             p = cls(c, x)
 
-            p1 = cls(c[:, :9], x[:10])
-            p1.extend(c[:, 9:], x[10:])
+            p1 = cls(c[:, :9, ...], x[:10])
+            p1.extend(c[:, 9:, ...], x[10:])
 
-            p2 = cls(c[:, 10:], x[10:])
-            p2.extend(c[:, :10], x[:10])
+            p2 = cls(c[:, 10:, ...], x[10:])
+            p2.extend(c[:, :10, ...], x[:10])
 
             xp_assert_equal(p1.c, p.c)
             xp_assert_equal(p1.x, p.x)
@@ -1131,20 +1138,21 @@ class TestPPolyCommon:
 
             assert_raises(ValueError, p, np.array([[0.1, 0.2], [0.4]], dtype=object))
 
-    def test_concurrency(self):
+    def test_concurrency(self, xp):
         # Check that no segfaults appear with concurrent access to BPoly, PPoly
         c = np.random.rand(8, 12, 5, 6, 7)
         x = np.sort(np.random.rand(13))
-        xp = np.random.rand(3, 4)
+        xpp = np.random.rand(3, 4)
+
+        c, x, xpp = map(xp.asarray, (c, x, xpp))
 
         for cls in (PPoly, BPoly):
             interp = cls(c, x)
 
-            def worker_fn(_, interp, xp):
-                interp(xp)
+            def worker_fn(_, interp, xpp):
+                interp(xpp)
 
-            _run_concurrent_barrier(10, worker_fn, interp, xp)
-
+            _run_concurrent_barrier(10, worker_fn, interp, xpp)
 
     def test_complex_coef(self):
         np.random.seed(12345)
@@ -1158,19 +1166,22 @@ class TestPPolyCommon:
                 xp_assert_close(p(xp, nu).real, p_re(xp, nu))
                 xp_assert_close(p(xp, nu).imag, p_im(xp, nu))
 
-    def test_axis(self):
+    def test_axis(self, xp):
         np.random.seed(12345)
         c = np.random.rand(3, 4, 5, 6, 7, 8)
         c_s = c.shape
-        xp = np.random.random((1, 2))
+        xpp = np.random.random((1, 2))
+
+        c, xpp = xp.asarray(c), xp.asarray(xpp)
+
         for axis in (0, 1, 2, 3):
             m = c.shape[axis+1]
-            x = np.sort(np.random.rand(m+1))
+            x = xp.asarray(np.sort(np.random.rand(m+1)))
             for cls in (PPoly, BPoly):
                 p = cls(c, x, axis=axis)
                 assert p.c.shape == c_s[axis:axis+2] + c_s[:axis] + c_s[axis+2:]
-                res = p(xp)
-                targ_shape = c_s[:axis] + xp.shape + c_s[2+axis:]
+                res = p(xpp)
+                targ_shape = c_s[:axis] + xpp.shape + c_s[2+axis:]
                 assert res.shape == targ_shape
 
                 # deriv/antideriv does not drop the axis
@@ -1235,25 +1246,25 @@ class TestPolySubclassing:
 
 
 class TestPPoly:
-    def test_simple(self):
-        c = np.array([[1, 4], [2, 5], [3, 6]])
-        x = np.array([0, 0.5, 1])
+    def test_simple(self, xp):
+        c = xp.asarray([[1, 4], [2, 5], [3, 6]])
+        x = xp.asarray([0, 0.5, 1])
         p = PPoly(c, x)
-        xp_assert_close(p(0.3), np.asarray(1*0.3**2 + 2*0.3 + 3))
-        xp_assert_close(p(0.7), np.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6))
+        xp_assert_close(p(0.3), xp.asarray(1*0.3**2 + 2*0.3 + 3))
+        xp_assert_close(p(0.7), xp.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6))
 
-    def test_periodic(self):
-        c = np.array([[1, 4], [2, 5], [3, 6]])
-        x = np.array([0, 0.5, 1])
+    def test_periodic(self, xp):
+        c = xp.asarray([[1, 4], [2, 5], [3, 6]])
+        x = xp.asarray([0, 0.5, 1])
         p = PPoly(c, x, extrapolate='periodic')
 
         xp_assert_close(p(1.3),
-                        np.asarray(1 * 0.3 ** 2 + 2 * 0.3 + 3))
+                        xp.asarray(1 * 0.3 ** 2 + 2 * 0.3 + 3))
         xp_assert_close(p(-0.3),
-                        np.asarray(4 * (0.7 - 0.5) ** 2 + 5 * (0.7 - 0.5) + 6))
+                        xp.asarray(4 * (0.7 - 0.5) ** 2 + 5 * (0.7 - 0.5) + 6))
 
-        xp_assert_close(p(1.3, 1), np.asarray(2 * 0.3 + 2))
-        xp_assert_close(p(-0.3, 1), np.asarray(8 * (0.7 - 0.5) + 5))
+        xp_assert_close(p(1.3, 1), xp.asarray(2 * 0.3 + 2))
+        xp_assert_close(p(-0.3, 1), xp.asarray(8 * (0.7 - 0.5) + 5))
 
     def test_read_only(self):
         c = np.array([[1, 4], [2, 5], [3, 6]])
@@ -1317,9 +1328,10 @@ class TestPPoly:
             roots_a = pa.roots()
             xp_assert_close(roots_a, np.sort(roots_d), rtol=1e-12)
 
-    def test_multi_shape(self):
+    def test_multi_shape(self, xp):
         c = np.random.rand(6, 2, 1, 2, 3)
         x = np.array([0, 0.5, 1])
+
         p = PPoly(c, x)
         assert p.x.shape == x.shape
         assert p.c.shape == c.shape
@@ -1377,12 +1389,24 @@ class TestPPoly:
             p = PPoly.from_spline(b)
             assert p.extrapolate == b.extrapolate
 
-    def test_derivative_simple(self):
+    def test_from_spline_2(self, xp):
+        # BSpline namespace propagates to PPoly
+        rng = np.random.RandomState(1234)
+        x = np.sort(np.r_[0, rng.rand(11), 1])
+        y = rng.rand(len(x))
+        t, c, k = splrep(x, y, s=0)     
+        spl = BSpline(xp.asarray(t), xp.asarray(c), k)
+        pp = PPoly.from_spline(spl)
+
+        xi = xp.linspace(0, 1, 11)
+        xp_assert_close(pp(xi), spl(xi))
+
+    def test_derivative_simple(self, xp):
         np.random.seed(1234)
-        c = np.array([[4, 3, 2, 1]]).T
-        dc = np.array([[3*4, 2*3, 2]]).T
-        ddc = np.array([[2*3*4, 1*2*3]]).T
-        x = np.array([0, 1])
+        c = xp.asarray([[4, 3, 2, 1]]).T
+        dc = xp.asarray([[3*4, 2*3, 2]]).T
+        ddc = xp.asarray([[2*3*4, 1*2*3]]).T
+        x = xp.asarray([0, 1])
 
         pp = PPoly(c, x)
         dpp = PPoly(dc, x)
@@ -1431,19 +1455,18 @@ class TestPPoly:
         xp_assert_close(np.asarray(q(2) - q(0)),
                         np.asarray(1.5))
 
-    def test_antiderivative_simple(self):
-        np.random.seed(1234)
+    def test_antiderivative_simple(self, xp):
         # [ p1(x) = 3*x**2 + 2*x + 1,
         #   p2(x) = 1.6875]
-        c = np.array([[3, 2, 1], [0, 0, 1.6875]]).T
+        c = xp.asarray([[3, 2, 1], [0, 0, 1.6875]]).T
         # [ pp1(x) = x**3 + x**2 + x,
         #   pp2(x) = 1.6875*(x - 0.25) + pp1(0.25)]
-        ic = np.array([[1, 1, 1, 0], [0, 0, 1.6875, 0.328125]]).T
+        ic = xp.asarray([[1, 1, 1, 0], [0, 0, 1.6875, 0.328125]]).T
         # [ ppp1(x) = (1/4)*x**4 + (1/3)*x**3 + (1/2)*x**2,
         #   ppp2(x) = (1.6875/2)*(x - 0.25)**2 + pp1(0.25)*x + ppp1(0.25)]
-        iic = np.array([[1/4, 1/3, 1/2, 0, 0],
-                        [0, 0, 1.6875/2, 0.328125, 0.037434895833333336]]).T
-        x = np.array([0, 0.25, 1])
+        iic = xp.asarray([[1/4, 1/3, 1/2, 0, 0],
+                          [0, 0, 1.6875/2, 0.328125, 0.037434895833333336]]).T
+        x = xp.asarray([0, 0.25, 1])
 
         pp = PPoly(c, x)
         ipp = pp.antiderivative()
@@ -1729,59 +1752,59 @@ class TestPPoly:
 
 
 class TestBPoly:
-    def test_simple(self):
-        x = [0, 1]
-        c = [[3]]
+    def test_simple(self, xp):
+        x = xp.asarray([0, 1])
+        c = xp.asarray([[3]])
         bp = BPoly(c, x)
-        xp_assert_close(bp(0.1), np.asarray(3.))
+        xp_assert_close(bp(0.1), xp.asarray(3.))
 
-    def test_simple2(self):
-        x = [0, 1]
-        c = [[3], [1]]
+    def test_simple2(self, xp):
+        x = xp.asarray([0, 1])
+        c = xp.asarray([[3], [1]])
         bp = BPoly(c, x)   # 3*(1-x) + 1*x
-        xp_assert_close(bp(0.1), np.asarray(3*0.9 + 1.*0.1))
+        xp_assert_close(bp(0.1), xp.asarray(3*0.9 + 1.*0.1))
 
-    def test_simple3(self):
-        x = [0, 1]
-        c = [[3], [1], [4]]
+    def test_simple3(self, xp):
+        x = xp.asarray([0, 1])
+        c = xp.asarray([[3], [1], [4]])
         bp = BPoly(c, x)   # 3 * (1-x)**2 + 2 * x (1-x) + 4 * x**2
         xp_assert_close(bp(0.2),
-                np.asarray(3 * 0.8*0.8 + 1 * 2*0.2*0.8 + 4 * 0.2*0.2))
+                        xp.asarray(3 * 0.8*0.8 + 1 * 2*0.2*0.8 + 4 * 0.2*0.2))
 
-    def test_simple4(self):
-        x = [0, 1]
-        c = [[1], [1], [1], [2]]
+    def test_simple4(self, xp):
+        x = xp.asarray([0, 1])
+        c = xp.asarray([[1], [1], [1], [2]])
         bp = BPoly(c, x)
         xp_assert_close(bp(0.3),
-                        np.asarray(    0.7**3 +
+                        xp.asarray(    0.7**3 +
                                    3 * 0.7**2 * 0.3 +
                                    3 * 0.7 * 0.3**2 +
                                    2 * 0.3**3)
         )
 
-    def test_simple5(self):
-        x = [0, 1]
-        c = [[1], [1], [8], [2], [1]]
+    def test_simple5(self, xp):
+        x = xp.asarray([0, 1])
+        c = xp.asarray([[1], [1], [8], [2], [1]])
         bp = BPoly(c, x)
         xp_assert_close(bp(0.3),
-                        np.asarray(  0.7**4 +
+                        xp.asarray(  0.7**4 +
                                  4 * 0.7**3 * 0.3 +
                              8 * 6 * 0.7**2 * 0.3**2 +
                              2 * 4 * 0.7 * 0.3**3 +
                                  0.3**4)
         )
 
-    def test_periodic(self):
-        x = [0, 1, 3]
-        c = [[3, 0], [0, 0], [0, 2]]
+    def test_periodic(self, xp):
+        x = xp.asarray([0, 1, 3])
+        c = xp.asarray([[3, 0], [0, 0], [0, 2]])
         # [3*(1-x)**2, 2*((x-1)/2)**2]
         bp = BPoly(c, x, extrapolate='periodic')
 
-        xp_assert_close(bp(3.4), np.asarray(3 * 0.6**2))
-        xp_assert_close(bp(-1.3), np.asarray(2 * (0.7/2)**2))
+        xp_assert_close(bp(3.4), xp.asarray(3 * 0.6**2))
+        xp_assert_close(bp(-1.3), xp.asarray(2 * (0.7/2)**2))
 
-        xp_assert_close(bp(3.4, 1), np.asarray(-6 * 0.6))
-        xp_assert_close(bp(-1.3, 1), np.asarray(2 * (0.7/2)))
+        xp_assert_close(bp(3.4, 1), xp.asarray(-6 * 0.6))
+        xp_assert_close(bp(-1.3, 1), xp.asarray(2 * (0.7/2)))
 
     def test_descending(self):
         rng = np.random.RandomState(0)
@@ -1830,23 +1853,23 @@ class TestBPoly:
         dp = p.derivative()
         assert dp.c.shape == (5, 2, 1, 2, 3)
 
-    def test_interval_length(self):
-        x = [0, 2]
-        c = [[3], [1], [4]]
+    def test_interval_length(self, xp):
+        x = xp.asarray([0, 2])
+        c = xp.asarray([[3], [1], [4]])
         bp = BPoly(c, x)
         xval = 0.1
         s = xval / 2  # s = (x - xa) / (xb - xa)
         xp_assert_close(bp(xval),
-                        np.asarray(3 * (1-s)*(1-s) + 1 * 2*s*(1-s) + 4 * s*s)
+                        xp.asarray(3 * (1-s)*(1-s) + 1 * 2*s*(1-s) + 4 * s*s)
         )
 
-    def test_two_intervals(self):
-        x = [0, 1, 3]
-        c = [[3, 0], [0, 0], [0, 2]]
+    def test_two_intervals(self, xp):
+        x = xp.asarray([0, 1, 3])
+        c = xp.asarray([[3, 0], [0, 0], [0, 2]])
         bp = BPoly(c, x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
 
-        xp_assert_close(bp(0.4), np.asarray(3 * 0.6*0.6))
-        xp_assert_close(bp(1.7), np.asarray(2 * (0.7/2)**2))
+        xp_assert_close(bp(0.4), xp.asarray(3 * 0.6*0.6))
+        xp_assert_close(bp(1.7), xp.asarray(2 * (0.7/2)**2))
 
     def test_extrapolate_attr(self):
         x = [0, 2]
@@ -1865,36 +1888,38 @@ class TestBPoly:
 
 
 class TestBPolyCalculus:
-    def test_derivative(self):
-        x = [0, 1, 3]
-        c = [[3, 0], [0, 0], [0, 2]]
+    def test_derivative(self, xp):
+        x = xp.asarray([0, 1, 3])
+        c = xp.asarray([[3, 0], [0, 0], [0, 2]])
         bp = BPoly(c, x)  # [3*(1-x)**2, 2*((x-1)/2)**2]
         bp_der = bp.derivative()
-        xp_assert_close(bp_der(0.4), np.asarray(-6*(0.6)))
-        xp_assert_close(bp_der(1.7), np.asarray(0.7))
+        xp_assert_close(bp_der(0.4), xp.asarray(-6*(0.6)))
+        xp_assert_close(bp_der(1.7), xp.asarray(0.7))
 
         # derivatives in-place
-        xp_assert_close(np.asarray([bp(0.4, nu) for nu in [1, 2, 3]]),
-                        np.asarray([-6*(1-0.4), 6., 0.])
+        xp_assert_close(xp.stack([bp(0.4, nu) for nu in [1, 2, 3]]),
+                        xp.asarray([-6*(1-0.4), 6., 0.])
         )
-        xp_assert_close(np.asarray([bp(1.7, nu) for nu in [1, 2, 3]]),
-                        np.asarray([0.7, 1., 0])
+        xp_assert_close(xp.stack([bp(1.7, nu) for nu in [1, 2, 3]]),
+                        xp.asarray([0.7, 1., 0])
         )
 
-    def test_derivative_ppoly(self):
+    def test_derivative_ppoly(self, xp):
         # make sure it's consistent w/ power basis
         rng = np.random.RandomState(1234)
         m, k = 5, 8   # number of intervals, order
         x = np.sort(rng.random(m))
         c = rng.random((k, m-1))
+
+        c, x = xp.asarray(c), xp.asarray(x)
         bp = BPoly(c, x)
         pp = PPoly.from_bernstein_basis(bp)
 
         for d in range(k):
             bp = bp.derivative()
             pp = pp.derivative()
-            xp = np.linspace(x[0], x[-1], 21)
-            xp_assert_close(bp(xp), pp(xp))
+            xpp = xp.linspace(x[0], x[-1], 21)
+            xp_assert_close(bp(xpp), pp(xpp))
 
     def test_deriv_inplace(self):
         rng = np.random.RandomState(1234)
@@ -1905,11 +1930,11 @@ class TestBPolyCalculus:
         # test both real and complex coefficients
         for cc in [c.copy(), c*(1. + 2.j)]:
             bp = BPoly(cc, x)
-            xp = np.linspace(x[0], x[-1], 21)
+            xpp = np.linspace(x[0], x[-1], 21)
             for i in range(k):
-                xp_assert_close(bp(xp, i), bp.derivative(i)(xp))
+                xp_assert_close(bp(xpp, i), bp.derivative(i)(xpp))
 
-    def test_antiderivative_simple(self):
+    def test_antiderivative_simple(self, xp):
         # f(x) = x        for x \in [0, 1),
         #        (x-1)/2  for x \in [1, 3]
         #
@@ -1917,15 +1942,15 @@ class TestBPolyCalculus:
         # F(x) = x**2 / 2            for x \in [0, 1),
         #        0.5*x*(x/2 - 1) + A  for x \in [1, 3]
         # where A = 3/4 for continuity at x = 1.
-        x = [0, 1, 3]
-        c = [[0, 0], [1, 1]]
+        x = xp.asarray([0, 1, 3])
+        c = xp.asarray([[0, 0], [1, 1]])
 
         bp = BPoly(c, x)
         bi = bp.antiderivative()
 
-        xx = np.linspace(0, 3, 11)
+        xx = xp.linspace(0, 3, 11)
         xp_assert_close(bi(xx),
-                        np.where(xx < 1, xx**2 / 2.,
+                        xp.where(xx < 1, xx**2 / 2.,
                                          0.5 * xx * (xx/2. - 1) + 3./4),
                         atol=1e-12, rtol=1e-12)
 
@@ -1961,10 +1986,11 @@ class TestBPolyCalculus:
         xp_assert_close(bp(xx - 1e-14),
                         bp(xx + 1e-14), atol=1e-12, rtol=1e-12)
 
-    def test_integrate(self):
+    def test_integrate(self, xp):
         rng = np.random.RandomState(1234)
         x = np.sort(rng.random(11))
         c = rng.random((4, 10))
+        x, c = xp.asarray(x), xp.asarray(c)
         bp = BPoly(c, x)
         pp = PPoly.from_bernstein_basis(bp)
         xp_assert_close(bp.integrate(0, 1),
@@ -1985,37 +2011,37 @@ class TestBPolyCalculus:
         xp_assert_close(b1.integrate(0, 2, extrapolate=True),
                         np.asarray(2.), atol=1e-14, check_0d=False)
 
-    def test_integrate_periodic(self):
-        x = np.array([1, 2, 4])
-        c = np.array([[0., 0.], [-1., -1.], [2., -0.], [1., 2.]])
+    def test_integrate_periodic(self, xp):
+        x = xp.asarray([1, 2, 4])
+        c = xp.asarray([[0., 0.], [-1., -1.], [2., -0.], [1., 2.]])
 
         P = BPoly.from_power_basis(PPoly(c, x), extrapolate='periodic')
         I = P.antiderivative()
 
-        period_int = I(4) - I(1)
+        period_int = xp.asarray(I(4) - I(1))
 
         xp_assert_close(P.integrate(1, 4), period_int) #, check_0d=False)
         xp_assert_close(P.integrate(-10, -7), period_int)
-        xp_assert_close(P.integrate(-10, -4), 2 * period_int)
+        xp_assert_close(P.integrate(-10, -4), xp.asarray(2 * period_int))
 
-        xp_assert_close(P.integrate(1.5, 2.5), I(2.5) - I(1.5))
-        xp_assert_close(P.integrate(3.5, 5), I(2) - I(1) + I(4) - I(3.5))
+        xp_assert_close(P.integrate(1.5, 2.5), xp.asarray(I(2.5) - I(1.5)))
+        xp_assert_close(P.integrate(3.5, 5), xp.asarray(I(2) - I(1) + I(4) - I(3.5)))
         xp_assert_close(P.integrate(3.5 + 12, 5 + 12),
-                        I(2) - I(1) + I(4) - I(3.5))
+                        xp.asarray(I(2) - I(1) + I(4) - I(3.5)))
         xp_assert_close(P.integrate(3.5, 5 + 12),
-                        I(2) - I(1) + I(4) - I(3.5) + 4 * period_int)
+                        xp.asarray(I(2) - I(1) + I(4) - I(3.5) + 4 * period_int))
 
-        xp_assert_close(P.integrate(0, -1), I(2) - I(3))
-        xp_assert_close(P.integrate(-9, -10), I(2) - I(3))
-        xp_assert_close(P.integrate(0, -10), I(2) - I(3) - 3 * period_int)
+        xp_assert_close(P.integrate(0, -1), xp.asarray(I(2) - I(3)))
+        xp_assert_close(P.integrate(-9, -10), xp.asarray(I(2) - I(3)))
+        xp_assert_close(P.integrate(0, -10), xp.asarray(I(2) - I(3) - 3 * period_int))
 
-    def test_antider_neg(self):
+    def test_antider_neg(self, xp):
         # .derivative(-nu) ==> .andiderivative(nu) and vice versa
-        c = [[1]]
-        x = [0, 1]
+        c = xp.asarray([[1]])
+        x = xp.asarray([0, 1])
         b = BPoly(c, x)
 
-        xx = np.linspace(0, 1, 21)
+        xx = xp.linspace(0, 1, 21)
 
         xp_assert_close(b.derivative(-1)(xx), b.antiderivative()(xx),
                         atol=1e-12, rtol=1e-12)
@@ -2024,16 +2050,16 @@ class TestBPolyCalculus:
 
 
 class TestPolyConversions:
-    def test_bp_from_pp(self):
-        x = [0, 1, 3]
-        c = [[3, 2], [1, 8], [4, 3]]
+    def test_bp_from_pp(self, xp):
+        x = xp.asarray([0, 1, 3])
+        c = xp.asarray([[3, 2], [1, 8], [4, 3]])
         pp = PPoly(c, x)
         bp = BPoly.from_power_basis(pp)
         pp1 = PPoly.from_bernstein_basis(bp)
 
-        xp = [0.1, 1.4]
-        xp_assert_close(pp(xp), bp(xp))
-        xp_assert_close(pp(xp), pp1(xp))
+        xv = xp.asarray([0.1, 1.4])
+        xp_assert_close(pp(xv), bp(xv))
+        xp_assert_close(pp(xv), pp1(xv))
 
     def test_bp_from_pp_random(self):
         rng = np.random.RandomState(1234)
@@ -2044,20 +2070,20 @@ class TestPolyConversions:
         bp = BPoly.from_power_basis(pp)
         pp1 = PPoly.from_bernstein_basis(bp)
 
-        xp = np.linspace(x[0], x[-1], 21)
-        xp_assert_close(pp(xp), bp(xp))
-        xp_assert_close(pp(xp), pp1(xp))
+        xv = np.linspace(x[0], x[-1], 21)
+        xp_assert_close(pp(xv), bp(xv))
+        xp_assert_close(pp(xv), pp1(xv))
 
-    def test_pp_from_bp(self):
-        x = [0, 1, 3]
-        c = [[3, 3], [1, 1], [4, 2]]
+    def test_pp_from_bp(self, xp):
+        x = xp.asarray([0, 1, 3])
+        c = xp.asarray([[3, 3], [1, 1], [4, 2]])
         bp = BPoly(c, x)
         pp = PPoly.from_bernstein_basis(bp)
         bp1 = BPoly.from_power_basis(pp)
 
-        xp = [0.1, 1.4]
-        xp_assert_close(bp(xp), pp(xp))
-        xp_assert_close(bp(xp), bp1(xp))
+        xv = xp.asarray([0.1, 1.4])
+        xp_assert_close(bp(xv), pp(xv))
+        xp_assert_close(bp(xv), bp1(xv))
 
     def test_broken_conversions(self):
         # regression test for gh-10597: from_power_basis only accepts PPoly etc.

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -836,6 +836,7 @@ class TestLagrange:
         assert_array_almost_equal(p.coeffs,pl.coeffs)
 
 
+@xfail_xp_backends("dask.array", reason="lacks nd fancy indexing")
 @xfail_xp_backends("jax.numpy", reason="immutable arrays")
 @xfail_xp_backends("array_api_strict", reason="fancy indexing __setitem__")
 @skip_xp_backends(cpu_only=True)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1,5 +1,6 @@
 from scipy._lib._array_api import (
-    xp_assert_equal, xp_assert_close, assert_almost_equal, assert_array_almost_equal
+    xp_assert_equal, xp_assert_close, assert_almost_equal, assert_array_almost_equal,
+    make_xp_test_case
 )
 from pytest import raises as assert_raises
 import pytest
@@ -836,10 +837,7 @@ class TestLagrange:
         assert_array_almost_equal(p.coeffs,pl.coeffs)
 
 
-@xfail_xp_backends("dask.array", reason="lacks nd fancy indexing")
-@xfail_xp_backends("jax.numpy", reason="immutable arrays")
-@xfail_xp_backends("array_api_strict", reason="fancy indexing __setitem__")
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(Akima1DInterpolator)
 class TestAkima1DInterpolator:
     def test_eval(self, xp):
         x = xp.arange(0., 11., dtype=xp.float64)
@@ -1045,7 +1043,7 @@ def test_complex(method):
         _run_concurrent_barrier(10, worker_fn, ak, x_ext)
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(PPoly, BPoly)
 class TestPPolyCommon:
     # test basic functionality for PPoly and BPoly
     def test_sort_check(self, xp):
@@ -1256,7 +1254,7 @@ class TestPolySubclassing:
         assert bp.__class__ == self.B
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(PPoly)
 class TestPPoly:
     def test_simple(self, xp):
         c = xp.asarray([[1, 4], [2, 5], [3, 6]])
@@ -1769,7 +1767,7 @@ class TestPPoly:
                 xp_assert_close(pp.roots(), np.asarray([1.0, -1.0]))
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(BPoly)
 class TestBPoly:
     def test_simple(self, xp):
         x = xp.asarray([0, 1])
@@ -1909,7 +1907,7 @@ class TestBPoly:
                 assert not np.isnan(bp_d([-0.1, 2.1])).any()
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(BPoly)
 class TestBPolyCalculus:
     def test_derivative(self, xp):
         x = xp.asarray([0, 1, 3])
@@ -2072,7 +2070,7 @@ class TestBPolyCalculus:
                         atol=1e-12, rtol=1e-12)
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(BPoly, PPoly)
 class TestPolyConversions:
     def test_bp_from_pp(self, xp):
         x = xp.asarray([0, 1, 3])

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -785,7 +785,7 @@ class TestCubicSpline:
             self.check_correctness(S, 'periodic', 'periodic')
 
     def test_periodic_eval(self, xp):
-        x = xp.linspace(0, 2 * xp.pi, 10)
+        x = xp.linspace(0, 2 * xp.pi, 10, dtype=xp.float64)
         y = xp.cos(x)
         S = CubicSpline(x, y, bc_type='periodic')
         assert_almost_equal(S(1), S(1 + 2 * xp.pi), decimal=15)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -3,7 +3,8 @@ import io
 import numpy as np
 
 from scipy._lib._array_api import (
-    xp_assert_equal, xp_assert_close, assert_array_almost_equal, assert_almost_equal
+    xp_assert_equal, xp_assert_close, assert_array_almost_equal, assert_almost_equal,
+    make_xp_test_case
 )
 from pytest import raises as assert_raises
 import pytest
@@ -665,7 +666,7 @@ class TestPCHIP:
         xp_assert_close(r, np.asarray([0.5]))
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(CubicSpline)
 class TestCubicSpline:
     @staticmethod
     def check_correctness(S, bc_start='not-a-knot', bc_end='not-a-knot',
@@ -892,7 +893,7 @@ class TestCubicSpline:
         assert_raises(ValueError, CubicSpline, x, y, 0, 'periodic', True)
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(CubicHermiteSpline)
 def test_CubicHermiteSpline_correctness(xp):
     x = xp.asarray([0, 2, 7])
     y = xp.asarray([-1, 2, 3])

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -780,11 +780,14 @@ class TestCubicSpline:
             S = CubicSpline(x, Y, axis=1, bc_type='periodic')
             self.check_correctness(S, 'periodic', 'periodic')
 
-    def test_periodic_eval(self):
-        x = np.linspace(0, 2 * np.pi, 10)
-        y = np.cos(x)
+    def test_periodic_eval(self, xp):
+        x = xp.linspace(0, 2 * xp.pi, 10)
+        y = xp.cos(x)
         S = CubicSpline(x, y, bc_type='periodic')
-        assert_almost_equal(S(1), S(1 + 2 * np.pi), decimal=15)
+        assert_almost_equal(S(1), S(1 + 2 * xp.pi), decimal=15)
+
+        S = CubicSpline(x, y)
+        assert_almost_equal(S(x), xp.cos(x), decimal=15)
 
     def test_second_derivative_continuity_gh_11758(self):
         # gh-11758: C2 continuity fail
@@ -885,10 +888,10 @@ class TestCubicSpline:
         assert_raises(ValueError, CubicSpline, x, y, 0, 'periodic', True)
 
 
-def test_CubicHermiteSpline_correctness():
-    x = [0, 2, 7]
-    y = [-1, 2, 3]
-    dydx = [0, 3, 7]
+def test_CubicHermiteSpline_correctness(xp):
+    x = xp.asarray([0, 2, 7])
+    y = xp.asarray([-1, 2, 3])
+    dydx = xp.asarray([0, 3, 7])
     s = CubicHermiteSpline(x, y, dydx)
     xp_assert_close(s(x), y, check_shape=False, check_dtype=False, rtol=1e-15)
     xp_assert_close(s(x, 1), dydx, check_shape=False, check_dtype=False, rtol=1e-15)

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -16,6 +16,9 @@ from scipy.interpolate import (
     make_interp_spline)
 from scipy._lib._testutils import _run_concurrent_barrier
 
+skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
+
 
 def check_shape(interpolator_cls, x_shape, y_shape, deriv_shape=None, axis=0,
                 extra_args=None):
@@ -662,6 +665,7 @@ class TestPCHIP:
         xp_assert_close(r, np.asarray([0.5]))
 
 
+@skip_xp_backends(cpu_only=True)
 class TestCubicSpline:
     @staticmethod
     def check_correctness(S, bc_start='not-a-knot', bc_end='not-a-knot',
@@ -888,6 +892,7 @@ class TestCubicSpline:
         assert_raises(ValueError, CubicSpline, x, y, 0, 'periodic', True)
 
 
+@skip_xp_backends(cpu_only=True)
 def test_CubicHermiteSpline_correctness(xp):
     x = xp.asarray([0, 2, 7])
     y = xp.asarray([-1, 2, 3])


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Continues gh-23052 ; cross-ref https://github.com/scipy/scipy/issues/23754 

#### What does this implement/fix?
<!--Please explain your changes.-->

Convert

- [x] PPoly
- [x] BPoly
- [x] CubicHermiteSpline
- [x] PchipInterpolator
- [x] Akima1DInterpolator
- [x] CubicSpline    
.
- [ ] PPoly.roots
- [ ] BPoly.from_derivatives


#### Additional information
<!--Any additional information you think is important.-->

Two not-entirely-trivial items, both related to (the lack of) ragged arrays:

- `PPoly.roots` returns either a numeric array or an object array, depending on the data. We discussed it a while ago, https://github.com/scipy/scipy/pull/3260#issuecomment-1166510296, and the conclusion was, basically, "yes it's ugly but not worth breaking backwards compat for". That was before array API though. The only Array API compatible way I can imagine is to make it return either an array or a list of arrays. While not great, it is similar in spirit to what it does now.
- `BPoly.from_derivatives` accepts either an array or a list of arrays. The latter we cannot avoid because otherwise we'd need ragged arrays. 

