### PR TITLE
TST: ndimage.vectorized_filter: add missing assertion to test

### DIFF
--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3001,6 +3001,7 @@ class TestVectorizedFilter:
 
         ref = ndimage.vectorized_filter(img, xp.mean, size=(2,), axes=(0,))
         res = ndimage.vectorized_filter(img, xp.mean, size=2, axes=0)
+        xp_assert_close(res, ref)
 
     def test_gh23046_fix(self, xp):
         # While investigating the feasibility of gh-23046, I noticed a bug when the


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/23051#pullrequestreview-2898267253

#### Additional information
@tylerjereddy Thought I'd mentioned that this function might be considered for the highlights of the 1.16 release. The original PR gh-23051 closed about a dozen issues, so the highlight might help to get the word out there.