### PR TITLE
TST: optimize: cap pytest-run-parallel memory usage

### DIFF
--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -400,6 +400,7 @@ class BaseMixin:
                                 method=self.method)
             assert_allclose(res.x, x_opt)
 
+    @pytest.mark.parallel_threads(4)  # 0.4 GiB per thread RAM usage
     @pytest.mark.fail_slow(5.0)
     def test_workers(self):
         serial = least_squares(fun_trivial, 2.0, method=self.method)


### PR DESCRIPTION
When running `pytest --parallel-threads=32` on my box, this single test causes a 13~14 GiB spike in memory usage. It's best to cap it.