### PR TITLE
CI: bump OpenBLAS and cibuildwheel versions

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -212,7 +212,7 @@ jobs:
           echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@cf078b0954f3fd08b8445a7bf2c3fb83ab3bb971 # v3.0.0b4
+        uses: pypa/cibuildwheel@3c5ff0988806752c5a6502c845f9edc2d98095d6 # v3.0.0rc3
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/requirements/openblas.txt
+++ b/requirements/openblas.txt
@@ -1,1 +1,1 @@
-scipy-openblas32==0.3.28.0.2
+scipy-openblas32==0.3.29.265.1


### PR DESCRIPTION
The latest OpenBLAS version is `0.3.29.265.1`, it has some changes that are needed for `win_arm64`; bumping across the board will be useful.

`cibuildwheel` is a regular bump, to `3.0.0rc3` (final release should be really close).

Full set of wheel builds done on my fork, all green: [CI log](https://github.com/rgommers/scipy/actions/runs/15581437034). 