### PR TITLE
ENH: Add support for 64 bit indices in `sparse.csgraph.minimum_spanning_tree`

### DIFF
--- a/scipy/sparse/csgraph/tests/test_spanning_tree.py
+++ b/scipy/sparse/csgraph/tests/test_spanning_tree.py
@@ -1,5 +1,6 @@
 """Test the minimum spanning tree function"""
 import numpy as np
+import pytest
 from numpy.testing import assert_
 import numpy.testing as npt
 from scipy.sparse import csr_array
@@ -64,3 +65,32 @@ def test_minimum_spanning_tree():
 
         npt.assert_array_equal(mintree.toarray(), expected,
             'Incorrect spanning tree found.')
+
+@pytest.mark.parametrize("dtype", [np.int32, np.int64])
+def test_mst_with_various_index_dtypes(dtype):
+    # Row indices
+    indptr = np.array([0, 2, 4, 5], dtype=dtype)
+    indices = np.array([1, 2, 0, 2, 1], dtype=dtype)
+    data = np.array([2, 0, 2, 3, 3], dtype=float)
+
+    graph = csr_array((data, indices, indptr), shape=(3, 3))
+
+    # Check whether the dtype of indices is as expected
+    assert graph.indices.dtype == dtype
+    assert graph.indptr.dtype == dtype
+
+    # Compute MST
+    mst = minimum_spanning_tree(graph)
+
+    # Check whether the dtype of indices is as expected
+    assert mst.indices.dtype == dtype
+    assert mst.indptr.dtype == dtype
+
+    # Expected MST has 2 edges: (0->1, weight 2)
+    expected = np.array([
+        [0, 2, 0],
+        [0, 0, 0],
+        [0, 0, 0]
+    ], dtype=float)
+
+    npt.assert_array_almost_equal(mst.toarray(), expected)

--- a/scipy/sparse/csgraph/tests/test_spanning_tree.py
+++ b/scipy/sparse/csgraph/tests/test_spanning_tree.py
@@ -6,6 +6,8 @@ import numpy.testing as npt
 from scipy.sparse import csr_array, coo_array
 from scipy.sparse.csgraph import minimum_spanning_tree
 
+from scipy._lib._array_api import xp_assert_close
+
 
 def test_minimum_spanning_tree():
 
@@ -94,7 +96,7 @@ def test_mst_with_various_index_dtypes(dtype):
         [0, 0, 0]
     ], dtype=float)
 
-    npt.assert_array_almost_equal(mst.toarray(), expected)
+    xp_assert_close(mst.toarray(), expected)
 
     # COO array
     data = np.array([1.0, 4.0, 3.0, 2.0, 5.0], dtype=float)
@@ -123,4 +125,4 @@ def test_mst_with_various_index_dtypes(dtype):
     expected[3, 4] = 2.0
     expected[4, 5] = 5.0
 
-    npt.assert_array_almost_equal(mst.toarray(), expected)
+    xp_assert_close(mst.toarray(), expected)

--- a/scipy/sparse/csgraph/tests/test_traversal.py
+++ b/scipy/sparse/csgraph/tests/test_traversal.py
@@ -145,4 +145,3 @@ def test_int64_indices(tree_func, directed):
     assert g.indices.dtype == np.int64
     tree = tree_func(g, 0, directed=directed)
     assert_array_almost_equal(csgraph_to_dense(tree), [[0, 1], [0, 0]])
-


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/20817

#### What does this implement/fix?
<!--Please explain your changes.-->

I have implemented overloading of `minimum_spanning_tree` for `np.int64`. It uses a similar approach as used in `_traversal.pyx`. 

Right now I had to use `_min_spanning_tree2` called from `_min_spanning_tree` because otherwise cython was giving me `ambigious overload error` (followed the pattern in `_traversal.pyx`) and it worked out.

Binary size comparison,

On `main`,

```zsh
(scipy-dev) 1:29:25:~/Quansight/scipy/build-install/usr/lib/python3.13/site-packages/scipy/sparse/csgraph % ls -l _min_spanning_tree.cpython-313-darwin.so
-rwxr-xr-x  1 czgdp1807  staff  115048 Jun 12 01:27 _min_spanning_tree.cpython-313-darwin.so
```

On this PR,

```zsh
(scipy-dev) 2:37:33:~/Quansight/scipy/build-install/usr/lib/python3.13/site-packages/scipy/sparse/csgraph % ls -l _min_spanning_tree.cpython-313-darwin.so
-rwxr-xr-x  1 czgdp1807  staff  153080 Jun 12 02:36 _min_spanning_tree.cpython-313-darwin.so
```

An increase of 33% for `_min_spanning_tree.cpython-313-darwin.so `.

Full wheels,

```zsh
(scipy-dev) 3:00:12:~/Quansight/scipy % ls -l *.whl
-rw-r--r--  1 czgdp1807  staff  20236016 Jun 12 02:59 scipy-1.17.0.dev0-cp313-cp313-macosx_15_0_arm64-mst_i32_i64.whl # this PR
-rw-r--r--  1 czgdp1807  staff  20219016 Jun 12 03:00 scipy-1.17.0.dev0-cp313-cp313-macosx_15_0_arm64.whl # main
```

**0.084 %** for overall SciPy wheel.

I think the increase is very small when we look from the perspective of full SciPy wheel size.

#### Additional information
<!--Any additional information you think is important.-->

I tried benchmarking but seems like there no benchmarks for `minimum_spanning_tree` in SciPy. Should we add one?

cc: @rgommers @perimosocordiae
