### PR TITLE
ENH: linalg: stop erroring out in `dnrm2(..., inc<0)`

### DIFF
--- a/scipy/linalg/fblas_l1.pyf.src
+++ b/scipy/linalg/fblas_l1.pyf.src
@@ -388,7 +388,7 @@ function <prefix3>nrm2(n,x,offx,incx) result(n2)
 
   <ftype3> dimension(*),intent(in) :: x
 
-  integer optional, intent(in),check(incx>0) :: incx = 1
+  integer optional, intent(in),check(incx>0||incx<0) :: incx = 1
 
   integer optional,intent(in),depend(x) :: offx=0
   check(offx>=0 && offx<len(x)) :: offx
@@ -410,7 +410,7 @@ function <prefix4>nrm2(n,x,offx,incx) result(n2)
 
   <ftype4> dimension(*),intent(in) :: x
 
-  integer optional, intent(in),check(incx>0) :: incx = 1
+  integer optional, intent(in),check(incx>0||incx<0) :: incx = 1
 
   integer optional,intent(in),depend(x) :: offx=0
   check(offx>=0 && offx<len(x)) :: offx

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -1023,9 +1023,9 @@ def test_trsm(dtype):
     assert_allclose(x1, x2.conj().T, atol=tol)
 
 
-@pytest.mark.xfail(run=False,
-                   reason="gh-16930")
 def test_gh_169309():
+    # regression test for https://github.com/scipy/scipy/issues/16930:
+    # older OpenBLAS were incorrectly handling `incx < 0`
     x = np.repeat(10, 9)
     actual = scipy.linalg.blas.dnrm2(x, 5, 3, -1)
     expected = math.sqrt(500)

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -1030,13 +1030,3 @@ def test_gh_169309():
     actual = scipy.linalg.blas.dnrm2(x, 5, 3, -1)
     expected = math.sqrt(500)
     assert_allclose(actual, expected)
-
-
-def test_dnrm2_neg_incx():
-    # check that dnrm2(..., incx < 0) raises
-    # XXX: remove the test after the lowest supported BLAS implements
-    # negative incx (new in LAPACK 3.10)
-    x = np.repeat(10, 9)
-    incx = -1
-    with assert_raises(fblas.__fblas_error):
-        scipy.linalg.blas.dnrm2(x, 5, 3, incx)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/16930

#### What does this implement/fix?
<!--Please explain your changes.-->

Revert the f2py-level check to block `incx<0` argument of `blas.dnrm2`, un-xfail the test which probes `incx<0`.

#### Additional information
<!--Any additional information you think is important.-->

- https://github.com/scipy/scipy/issues/16930 reported that negative `incx` is not handled by then-current OpenBLAS.
- https://github.com/scipy/scipy/pull/20341 added an f2py-level check for `incx>0`.
- https://github.com/scipy/scipy/pull/23154 bumped the minimum OpenBLAS version to hopefully past the version where the original error was fixed.
