### PR TITLE
MAINT: backports and prep for 1.16.0 "final"

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -60,7 +60,8 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click pooch hypothesis array-api-strict spin
+        # array-api-strict pinned because gh-23183
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click pooch hypothesis "array-api-strict<2.4" spin
 
     - name: Install PyTorch CPU
       run: |

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -503,7 +503,7 @@ def linkcode_resolve(domain, info):
         lineno = None
 
     if lineno:
-        linespec = f"#L{0}-L{1}".format(lineno, lineno + len(source) - 1)
+        linespec = f"#L{lineno}-L{lineno + len(source) - 1}"
     else:
         linespec = ""
 

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.16.0 Release Notes
 ==========================
 
-.. note:: SciPy 1.16.0 is not released yet!
-
 .. contents::
 
 SciPy 1.16.0 is the culmination of 6 months of hard work. It contains
@@ -352,7 +350,7 @@ Authors
 * Florian Bourgey (3) +
 * Charles Bousseau (2) +
 * Richard Strong Bowen (2) +
-* Jake Bowhay (126)
+* Jake Bowhay (127)
 * Matthew Brett (1)
 * Dietrich Brunn (53)
 * Evgeni Burovski (252)
@@ -372,9 +370,9 @@ Authors
 * Ralf Gommers (158)
 * Rohit Goswami (4)
 * Saarthak Gupta (4) +
-* Matt Haberland (325)
+* Matt Haberland (326)
 * Sasha Hafner (1) +
-* Joren Hammudoglu (9)
+* Joren Hammudoglu (11)
 * Chengyu Han (1) +
 * Charles Harris (1)
 * Kim Hsieh (4) +
@@ -385,6 +383,7 @@ Authors
 * Robert Kern (2)
 * Harin Khakhi (2) +
 * Agriya Khetarpal (4)
+* Daniil Kiktenko (1) +
 * Kirill R. (2) +
 * Tetsuo Koyama (1)
 * Jigyasu Krishnan (1) +
@@ -396,6 +395,7 @@ Authors
 * Antony Lee (1)
 * Kieran Leschinski (1) +
 * Thomas Li (2) +
+* Yuxi Long (2) +
 * Christian Lorentzen (2)
 * Loïc Estève (4)
 * Panos Mavrogiorgos (1) +
@@ -413,7 +413,7 @@ Authors
 * Victor PM (10) +
 * pmav99 (1) +
 * Ilhan Polat (73)
-* Tyler Reddy (96)
+* Tyler Reddy (109)
 * Érico Nogueira Rolim (1) +
 * Pamphile Roy (10)
 * Mikhail Ryazanov (6)
@@ -461,7 +461,7 @@ Authors
 * Case Zumbrum (2) +
 * ਗਗਨਦੀਪ ਸਿੰਘ (Gagandeep Singh) (45)
 
-    A total of 124 people contributed to this release.
+    A total of 126 people contributed to this release.
     People with a "+" by their names contributed a patch for the first time.
     This list of names is automatically generated, and may not be fully complete.
 
@@ -586,6 +586,7 @@ Issues closed for 1.16.0
 * `#22271 <https://github.com/scipy/scipy/issues/22271>`__: Query: empty ``Rotation`` is not allowed in scipy=1.15
 * `#22282 <https://github.com/scipy/scipy/issues/22282>`__: QUERY/DEV: test failure in IDE with ``SCIPY_ARRAY_API``
 * `#22288 <https://github.com/scipy/scipy/issues/22288>`__: QUERY: Pyright raises error/warning in IDE
+* `#22294 <https://github.com/scipy/scipy/issues/22294>`__: DOC: ``source`` now links to top of file, not location within...
 * `#22303 <https://github.com/scipy/scipy/issues/22303>`__: ENH: stats.special_ortho_group: improve and simplify
 * `#22309 <https://github.com/scipy/scipy/issues/22309>`__: DOC: optimize.elementwise.find_minimum: harmonize documented/implemented...
 * `#22328 <https://github.com/scipy/scipy/issues/22328>`__: QUERY: stats.beta.fit: ``FitError`` on reasonable data
@@ -1108,7 +1109,13 @@ Pull requests for 1.16.0
 * `#23051 <https://github.com/scipy/scipy/pull/23051>`__: MAINT/ENH: ndimage.vectorized_filter: adjust scalar size to match...
 * `#23086 <https://github.com/scipy/scipy/pull/23086>`__: CI: update windows-2019 runner image to windows-2022
 * `#23091 <https://github.com/scipy/scipy/pull/23091>`__: BUG: sparse: correct eq and ne with different shapes. (and add...
+* `#23098 <https://github.com/scipy/scipy/pull/23098>`__: MAINT: 1.16.0rc2 backports
 * `#23099 <https://github.com/scipy/scipy/pull/23099>`__: MAINT: fix SPDX license expressions for LAPACK, OpenBLAS, GCC
 * `#23106 <https://github.com/scipy/scipy/pull/23106>`__: TST: CI broken vs pytest 8.4.0
 * `#23110 <https://github.com/scipy/scipy/pull/23110>`__: BUG: spatial.distance: yule implementation in ``distance_metrics.h``
 * `#23113 <https://github.com/scipy/scipy/pull/23113>`__: DOC: improve docs for ``-Duse-system-libraries`` build option
+* `#23114 <https://github.com/scipy/scipy/pull/23114>`__: DOC: Add missing BLAS Level 2 functions
+* `#23127 <https://github.com/scipy/scipy/pull/23127>`__: DOC: fix linkcode_resolve line-number anchors
+* `#23131 <https://github.com/scipy/scipy/pull/23131>`__: REL: set 1.16.0rc3 unreleased
+* `#23134 <https://github.com/scipy/scipy/pull/23134>`__: BUG: linalg.lapack: fix incorrectly sized work array for {c,z}syrti
+* `#23146 <https://github.com/scipy/scipy/pull/23146>`__: DOC: stats.Mixture: add example

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -44,6 +44,8 @@ Highlights of this release
 - A new class, `scipy.spatial.transform.RigidTransform`, provides functionality
   to convert between different representations of rigid transforms in 3-D
   space.
+- A new function `scipy.ndimage.vectorized_filter` for generic filters that
+  take advantage of a vectorized Python callable was added.
 
 ************
 New features
@@ -300,6 +302,8 @@ Build and packaging related changes
 *************
 Other changes
 *************
+- A new accompanying release of ``scipy-stubs`` (``v1.16.0.0``) is
+  available.
 - The internal dependency of ``scipy._lib`` on ``scipy.sparse`` was removed,
   which reduces the import time of a number of other SciPy submodules.
 - Support for free-threaded CPython was improved: the last known thread-safety
@@ -367,7 +371,7 @@ Authors
 * Matthew H Flamm (1)
 * Karthik Viswanath Ganti (1) +
 * Neil Girdhar (1)
-* Ralf Gommers (158)
+* Ralf Gommers (159)
 * Rohit Goswami (4)
 * Saarthak Gupta (4) +
 * Matt Haberland (326)
@@ -413,7 +417,7 @@ Authors
 * Victor PM (10) +
 * pmav99 (1) +
 * Ilhan Polat (73)
-* Tyler Reddy (109)
+* Tyler Reddy (112)
 * Érico Nogueira Rolim (1) +
 * Pamphile Roy (10)
 * Mikhail Ryazanov (6)
@@ -485,7 +489,7 @@ Issues closed for 1.16.0
 * `#8367 <https://github.com/scipy/scipy/issues/8367>`__: ENH: stats.mvndst: make thread-safe
 * `#8411 <https://github.com/scipy/scipy/issues/8411>`__: nan with betainc for a=0, b=3 and x=0.5
 * `#8916 <https://github.com/scipy/scipy/issues/8916>`__: ENH: ndimage.generic_filter: slow on large images
-* `#9077 <https://github.com/scipy/scipy/issues/9077>`__: maximum_filter is not symetrical with nans
+* `#9077 <https://github.com/scipy/scipy/issues/9077>`__: maximum_filter is not symmetrical with nans
 * `#9841 <https://github.com/scipy/scipy/issues/9841>`__: ENH: linalg: 0-th dimension must be fixed to 1 but got 2 (real...
 * `#9873 <https://github.com/scipy/scipy/issues/9873>`__: ENH: ndimage: majority voting filter
 * `#10416 <https://github.com/scipy/scipy/issues/10416>`__: ENH: optimize.minimize: slsqp: give better error when work array...
@@ -503,7 +507,7 @@ Issues closed for 1.16.0
 * `#13914 <https://github.com/scipy/scipy/issues/13914>`__: DOC: sparse.csgraph.shortest_path: predecessors array contains...
 * `#13952 <https://github.com/scipy/scipy/issues/13952>`__: fmin_cobyla result violates constraint
 * `#13982 <https://github.com/scipy/scipy/issues/13982>`__: ENH: linalg.eigh_tridiagonal: divide and conquer option
-* `#14394 <https://github.com/scipy/scipy/issues/14394>`__: ENH: optmize.slsqp: return Lagrange multipliers
+* `#14394 <https://github.com/scipy/scipy/issues/14394>`__: ENH: optimize.slsqp: return Lagrange multipliers
 * `#14569 <https://github.com/scipy/scipy/issues/14569>`__: BUG: signal.resample: inconsistency across dtypes
 * `#14915 <https://github.com/scipy/scipy/issues/14915>`__: BUG: optimize.minimize: corruption/segfault with constraints
 * `#15153 <https://github.com/scipy/scipy/issues/15153>`__: BUG: signal.resample: incorrect with ``datetime[ns]`` for ``t``...
@@ -647,6 +651,7 @@ Issues closed for 1.16.0
 * `#23061 <https://github.com/scipy/scipy/issues/23061>`__: DOC: Wrong SPDX identifier for OpenBLAS and LAPACK
 * `#23068 <https://github.com/scipy/scipy/issues/23068>`__: BUG: sparse: ``!=`` operator with csr matrices
 * `#23109 <https://github.com/scipy/scipy/issues/23109>`__: BUG: spatial.distance.cdist: wrong result in Yule metric
+* `#23169 <https://github.com/scipy/scipy/issues/23169>`__: BUG: special.betainc: evaluates incorrectly to nan when ``b=0``
 
 ************************
 Pull requests for 1.16.0
@@ -1119,3 +1124,4 @@ Pull requests for 1.16.0
 * `#23131 <https://github.com/scipy/scipy/pull/23131>`__: REL: set 1.16.0rc3 unreleased
 * `#23134 <https://github.com/scipy/scipy/pull/23134>`__: BUG: linalg.lapack: fix incorrectly sized work array for {c,z}syrti
 * `#23146 <https://github.com/scipy/scipy/pull/23146>`__: DOC: stats.Mixture: add example
+* `#23170 <https://github.com/scipy/scipy/pull/23170>`__: TST: add all SciPy-specific pytest markers to ``scipy/conftest.py``

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,6 +29,7 @@ filterwarnings =
     ignore:Jitify is performing a one-time only warm-up::cupy
     ignore:.*scipy.misc.*:DeprecationWarning
 
+# When updating the markers here, also update them in scipy/conftest.py
 markers =
     slow: Tests that are very slow
     xslow: mark test as extremely slow (not run unless explicitly requested)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -34,6 +34,31 @@ except Exception:
 
 
 def pytest_configure(config):
+    """
+    Add pytest markers to avoid PytestUnknownMarkWarning
+
+    This needs to contain all markers that are SciPy-specific, as well as
+    dummy fallbacks for markers defined in optional test packages.
+
+    Note that we need both the registration here *and* in `pytest.ini`.
+    """
+    config.addinivalue_line("markers",
+        "slow: Tests that are very slow.")
+    config.addinivalue_line("markers",
+        "xslow: mark test as extremely slow (not run unless explicitly requested)")
+    config.addinivalue_line("markers",
+        "xfail_on_32bit: mark test as failing on 32-bit platforms")
+    config.addinivalue_line("markers",
+        "array_api_backends: test iterates on all array API backends")
+    config.addinivalue_line("markers",
+        ("skip_xp_backends(backends, reason=None, np_only=False, cpu_only=False, " +
+         "eager_only=False, exceptions=None): mark the desired skip configuration " +
+         "for the `skip_xp_backends` fixture"))
+    config.addinivalue_line("markers",
+        ("xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, " +
+         "eager_only=False, exceptions=None): mark the desired xfail configuration " +
+         "for the `xfail_xp_backends` fixture"))
+
     try:
         import pytest_timeout  # noqa:F401
     except Exception:

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -45,15 +45,19 @@ BLAS Level 1 functions
 .. autosummary::
    :toctree: generated/
 
-   caxpy
-   ccopy
-   cdotc
-   cdotu
-   crotg
-   cscal
-   csrot
-   csscal
-   cswap
+   sasum
+   saxpy
+   scasum
+   scnrm2
+   scopy
+   sdot
+   snrm2
+   srot
+   srotg
+   srotm
+   srotmg
+   sscal
+   sswap
    dasum
    daxpy
    dcopy
@@ -71,19 +75,15 @@ BLAS Level 1 functions
    idamax
    isamax
    izamax
-   sasum
-   saxpy
-   scasum
-   scnrm2
-   scopy
-   sdot
-   snrm2
-   srot
-   srotg
-   srotm
-   srotmg
-   sscal
-   sswap
+   caxpy
+   ccopy
+   cdotc
+   cdotu
+   crotg
+   cscal
+   csrot
+   csscal
+   cswap
    zaxpy
    zcopy
    zdotc

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -104,12 +104,15 @@ BLAS Level 2 functions
    sgemv
    sger
    ssbmv
+   sspmv
    sspr
    sspr2
    ssymv
    ssyr
    ssyr2
    stbmv
+   stbsv
+   stpmv
    stpsv
    strmv
    strsv
@@ -117,12 +120,15 @@ BLAS Level 2 functions
    dgemv
    dger
    dsbmv
+   dspmv
    dspr
    dspr2
    dsymv
    dsyr
    dsyr2
    dtbmv
+   dtbsv
+   dtpmv
    dtpsv
    dtrmv
    dtrsv
@@ -137,13 +143,15 @@ BLAS Level 2 functions
    chpmv
    chpr
    chpr2
+   cspmv
+   cspr
+   csyr
    ctbmv
    ctbsv
    ctpmv
    ctpsv
    ctrmv
    ctrsv
-   csyr
    zgbmv
    zgemv
    zgerc
@@ -155,12 +163,15 @@ BLAS Level 2 functions
    zhpmv
    zhpr
    zhpr2
+   zspmv
+   zspr
+   zsyr
    ztbmv
    ztbsv
    ztpmv
+   ztpsv
    ztrmv
    ztrsv
-   zsyr
 
 BLAS Level 3 functions
 ----------------------

--- a/scipy/linalg/flapack_sym_herm.pyf.src
+++ b/scipy/linalg/flapack_sym_herm.pyf.src
@@ -1411,24 +1411,39 @@ subroutine <prefix2c>heequb(lower,n,a,lda,s,scond,amax,work,info)
 
 end subroutine <prefix2c>heequb
 
-
-subroutine <prefix>sytri(lower,n,a,lda,ipiv,work,info)
+subroutine <prefix2>sytri(lower,n,a,lda,ipiv,work,info)
     ! ?SYTRI computes the inverse of a symmetric indefinite matrix
     ! A using the factorization A = U*D*U**T or A = L*D*L**T computed by
     ! ?SYTRF.
     threadsafe
     callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,work,&info)
-    callprotoargument char*, F_INT*, <ctype>*, F_INT*, F_INT*, <ctype>*, F_INT*
+    callprotoargument char*, F_INT*, <ctype2>*, F_INT*, F_INT*, <ctype2>*, F_INT*
 
     integer optional intent(in), check(lower==0||lower==1) :: lower = 0
     integer intent(hide), depend(a) :: n=shape(a,1)
-    <ftype> dimension(lda,n),intent(in,out,copy,out=inv_a) :: a
+    <ftype2> dimension(lda,n),intent(in,out,copy,out=inv_a) :: a
     integer depend(a),intent(hide) :: lda = max(shape(a,0),1)
     integer depend(n),dimension(n),intent(in) :: ipiv
-    <ftype> depend(n),dimension(n),intent(hide,cache) :: work
+    <ftype2> depend(n),dimension(n),intent(hide,cache) :: work
     integer intent(out):: info
-end subroutine <prefix>sytri
+end subroutine <prefix2>sytri
 
+subroutine <prefix2c>sytri(lower,n,a,lda,ipiv,work,info)
+    ! ?SYTRI computes the inverse of a symmetric indefinite matrix
+    ! A using the factorization A = U*D*U**T or A = L*D*L**T computed by
+    ! ?SYTRF.
+    threadsafe
+    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,ipiv,work,&info)
+    callprotoargument char*, F_INT*, <ctype2c>*, F_INT*, F_INT*, <ctype2c>*, F_INT*
+
+    integer optional intent(in), check(lower==0||lower==1) :: lower = 0
+    integer intent(hide), depend(a) :: n=shape(a,1)
+    <ftype2c> dimension(lda,n),intent(in,out,copy,out=inv_a) :: a
+    integer depend(a),intent(hide) :: lda = max(shape(a,0),1)
+    integer depend(n),dimension(n),intent(in) :: ipiv
+    <ftype2c> depend(n),dimension(2*n),intent(hide,cache) :: work
+    integer intent(out):: info
+end subroutine <prefix2>sytri
 
 subroutine <prefix2c>hetri(lower,n,a,lda,ipiv,work,info)
     ! ?HETRI computes the inverse of a complex Hermitian indefinite matrix

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -5100,6 +5100,30 @@ class Mixture(_ProbabilityDistribution):
     .. [1] Mixture distribution, *Wikipedia*,
            https://en.wikipedia.org/wiki/Mixture_distribution
 
+
+    Examples
+    --------
+    A mixture of normal distributions:
+
+    >>> mixture = stats.Mixture([stats.Normal(mu=1, sigma=5), stats.Normal(mu=2, sigma=1), stats.Normal(mu=-3, sigma=0.5)], weights=[0.2, 0.5, 0.3])
+    >>> pdf_xs = np.arange(-10, 10, 0.1)
+    >>> plt.plot(pdf_xs, mixture.pdf(pdf_xs))
+    >>> plt.title('PDF of normal distribution mixture')
+    >>> plt.show()
+    >>> print(f'Mean: {mixture.mean():.2f}, median: {mixture.median():.2f}, mode: {mixture.mode():.2f}')
+    Mean: 0.30, median: 1.14, mode: 2.00
+
+    A mixture of `ContinuousDistribution` objects generated from `stats.make_distribution`:
+
+    >>> mixture = stats.Mixture([stats.make_distribution(stats.loguniform)(a=1, b=3), stats.make_distribution(stats.laplace)()], weights=[0.2, 0.8])
+    >>> pdf_xs = np.arange(-10, 10, 0.1)
+    >>> plt.plot(pdf_xs, mixture.pdf(pdf_xs))
+    >>> plt.title('PDF of loguniform and laplace mixture')
+    >>> print(f'Mean: {mixture.mean():.2f}, median: {mixture.median():.2f}, mode: {mixture.mode():.2f}')
+    >>> plt.show()
+    Mean: 0.36, median: 0.29, mode: 1.00
+
+
     """
     # Todo:
     # Add support for array shapes, weights

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -5108,24 +5108,17 @@ class Mixture(_ProbabilityDistribution):
     >>> import numpy as np
     >>> from scipy import stats
     >>> import matplotlib.pyplot as plt
-    >>> mixture = stats.Mixture([stats.Normal(mu=1, sigma=5), stats.Normal(mu=2, sigma=1), stats.Normal(mu=-3, sigma=0.5)], weights=[0.2, 0.5, 0.3])
-    >>> pdf_xs = np.arange(-10, 10, 0.1)
-    >>> plt.plot(pdf_xs, mixture.pdf(pdf_xs))
+    >>> X1 = stats.Normal(mu=-2, sigma=1)
+    >>> X2 = stats.Normal(mu=2, sigma=1)
+    >>> mixture = stats.Mixture([X1, X2], weights=[0.4, 0.6])
+    >>> print(f'mean: {mixture.mean():.2f}, '
+    ...       f'median: {mixture.median():.2f}, '
+    ...       f'mode: {mixture.mode():.2f}')
+    mean: 0.40, median: 1.04, mode: 2.00
+    >>> x = np.linspace(-10, 10, 300)
+    >>> plt.plot(x, mixture.pdf(x))
     >>> plt.title('PDF of normal distribution mixture')
     >>> plt.show()
-    >>> print(f'Mean: {mixture.mean():.2f}, median: {mixture.median():.2f}, mode: {mixture.mode():.2f}')
-    Mean: 0.30, median: 1.14, mode: 2.00
-
-    A mixture of `ContinuousDistribution` objects generated from `stats.make_distribution`:
-
-    >>> mixture = stats.Mixture([stats.make_distribution(stats.loguniform)(a=1, b=3), stats.make_distribution(stats.laplace)()], weights=[0.2, 0.8])
-    >>> pdf_xs = np.arange(-10, 10, 0.1)
-    >>> plt.plot(pdf_xs, mixture.pdf(pdf_xs))
-    >>> plt.title('PDF of loguniform and laplace mixture')
-    >>> print(f'Mean: {mixture.mean():.2f}, median: {mixture.median():.2f}, mode: {mixture.mode():.2f}')
-    >>> plt.show()
-    Mean: 0.36, median: 0.29, mode: 1.00
-
 
     """
     # Todo:

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -5105,6 +5105,9 @@ class Mixture(_ProbabilityDistribution):
     --------
     A mixture of normal distributions:
 
+    >>> import numpy as np
+    >>> from scipy import stats
+    >>> import matplotlib.pyplot as plt
     >>> mixture = stats.Mixture([stats.Normal(mu=1, sigma=5), stats.Normal(mu=2, sigma=1), stats.Normal(mu=-3, sigma=0.5)], weights=[0.2, 0.5, 0.3])
     >>> pdf_xs = np.arange(-10, 10, 0.1)
     >>> plt.plot(pdf_xs, mixture.pdf(pdf_xs))


### PR DESCRIPTION
I think the current plan is still to release `1.16.0` "final" in the coming week, unless there are objections. June is pretty crazy for me so getting this backport work rolling now.

Backports included (so far):

1. gh-23146
2. gh-23134
3. gh-23127
4. gh-23114
5. gh-23170

TODO:

- [x] check test suite locally
- [x] check doc build/release notes locally
- [x] update the SciPy `1.16.0` release notes following additional backport activity
- [x] remove the "is not released yet" blurb from the release notes on the optimistic assumption we may be able to do the final release
- [ ] make sure the regular CI passes here
- [x] make sure the full wheel build passes here (just to avoid surprises at actual release time)
- [x] @mdhaber wanted `vectorized_filter` considered for the highlights section (we have a lot of highlights, could consider a bit of shuffling around maybe)
- [x] mention `scipy-stubs` `v1.16.0.0` in relnotes