### PR TITLE
TST: add all SciPy-specific pytest markers to `scipy/conftest.py`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -29,6 +29,7 @@ filterwarnings =
     ignore:Jitify is performing a one-time only warm-up::cupy
     ignore:.*scipy.misc.*:DeprecationWarning
 
+# When updating the markers here, also update them in scipy/conftest.py
 markers =
     slow: Tests that are very slow
     xslow: mark test as extremely slow (not run unless explicitly requested)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -34,6 +34,31 @@ except Exception:
 
 
 def pytest_configure(config):
+    """
+    Add pytest markers to avoid PytestUnknownMarkWarning
+
+    This needs to contain all markers that are SciPy-specific, as well as
+    dummy fallbacks for markers defined in optional test packages.
+
+    Note that we need both the registration here *and* in `pytest.ini`.
+    """
+    config.addinivalue_line("markers",
+        "slow: Tests that are very slow.")
+    config.addinivalue_line("markers",
+        "xslow: mark test as extremely slow (not run unless explicitly requested)")
+    config.addinivalue_line("markers",
+        "xfail_on_32bit: mark test as failing on 32-bit platforms")
+    config.addinivalue_line("markers",
+        "array_api_backends: test iterates on all array API backends")
+    config.addinivalue_line("markers",
+        ("skip_xp_backends(backends, reason=None, np_only=False, cpu_only=False, " +
+         "eager_only=False, exceptions=None): mark the desired skip configuration " +
+         "for the `skip_xp_backends` fixture"))
+    config.addinivalue_line("markers",
+        ("xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, " +
+         "eager_only=False, exceptions=None): mark the desired xfail configuration " +
+         "for the `xfail_xp_backends` fixture"))
+
     try:
         import pytest_timeout  # noqa:F401
     except Exception:


### PR DESCRIPTION
This is necessary in addition to putting them in `pytest.ini`, because the ini file doesn't get installed and hence running the test suite with `pytest --pyargs scipy` will otherwise generate a lot of warnings.

Here is a [recent CI log for a wheel build job](https://github.com/scipy/scipy/actions/runs/15651318642/job/44096437311) showing a large amount of log pollution, that is fixed with this PR (verified on my fork).