### PR TITLE
ENH/DOC: signal.hilbert:  Refactor to avoid extra scaling array and improve docstr 

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2473,7 +2473,7 @@ def deconvolve(signal, divisor):
     return quot, rem
 
 
-def hilbert(x, N=None, axis=-1):
+def hilbert(x, N=None, axis=-1, workers=None):
     r"""FFT-based computation of the analytic signal.
 
     The analytic signal is calculated by filtering out the negative frequencies and
@@ -2491,6 +2491,10 @@ def hilbert(x, N=None, axis=-1):
         Number of Fourier components.  Default: ``x.shape[axis]``
     axis : int, optional
         Axis along which to do the transformation.  Default: -1.
+    workers : int, optional
+        Maximum number of workers to use for parallel computation. If negative,
+        the value wraps around from ``os.cpu_count()``. See ``scipy.fft.fft()``
+        for more details.
 
     Returns
     -------
@@ -2577,7 +2581,7 @@ def hilbert(x, N=None, axis=-1):
     if N <= 0:
         raise ValueError("N must be positive.")
 
-    Xf = sp_fft.fft(x, N, axis=axis)
+    Xf = sp_fft.fft(x, N, axis=axis, workers=workers)
     h = xp.zeros(N, dtype=Xf.dtype)
     if N % 2 == 0:
         h[0] = h[N // 2] = 1
@@ -2590,7 +2594,7 @@ def hilbert(x, N=None, axis=-1):
         ind = [xp.newaxis] * x.ndim
         ind[axis] = slice(None)
         h = h[tuple(ind)]
-    x = sp_fft.ifft(Xf * h, axis=axis)
+    x = sp_fft.ifft(Xf * h, axis=axis, workers=workers)
     return x
 
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2491,8 +2491,8 @@ def hilbert(x, N=None, axis=-1):
     x : array_like
         Signal data.  Must be real.
     N : int, optional
-        Number of Fourier components. ``x`` is cropped or zero-padded to length
-        ``N`` along ``axis``.  Default: ``x.shape[axis]``
+        Number of output samples. `x` is initially cropped or zero-padded to length
+        `N` along `axis`.  Default: ``x.shape[axis]``
     axis : int, optional
         Axis along which to do the transformation.  Default: -1.
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2473,7 +2473,7 @@ def deconvolve(signal, divisor):
     return quot, rem
 
 
-def hilbert(x, N=None, axis=-1, workers=None):
+def hilbert(x, N=None, axis=-1):
     r"""FFT-based computation of the analytic signal.
 
     The analytic signal is calculated by zeroing out the negative frequencies and
@@ -2482,6 +2482,9 @@ def hilbert(x, N=None, axis=-1, workers=None):
     signal.
     
     The transformation is done along the last axis by default.
+
+    For numpy arrays, `scipy.fft.set_workers` can be used to change the number of
+    workers used for the FFTs.
 
     Parameters
     ----------
@@ -2492,10 +2495,6 @@ def hilbert(x, N=None, axis=-1, workers=None):
         ``N`` along ``axis``.  Default: ``x.shape[axis]``
     axis : int, optional
         Axis along which to do the transformation.  Default: -1.
-    workers : int, optional
-        Maximum number of workers to use for parallel computation. If negative,
-        the value wraps around from ``os.cpu_count()``. See ``scipy.fft.fft()``
-        for more details.
 
     Returns
     -------
@@ -2582,20 +2581,17 @@ def hilbert(x, N=None, axis=-1, workers=None):
     if N <= 0:
         raise ValueError("N must be positive.")
 
-    Xf = sp_fft.fft(x, N, axis=axis, workers=workers)
-    if x.ndim > 1:
-         axis = axis % x.ndim
-         ind = [slice(None)] * axis
-    else:
-        ind = []
+    Xf = sp_fft.fft(x, N, axis=axis)
+    Xf = xp.moveaxis(Xf, axis, -1)
     if N % 2 == 0:
-        Xf[tuple(ind + [slice(1, N // 2)])] *= 2.0
-        Xf[tuple(ind + [slice(N // 2 + 1, N)])] = 0.0
+        Xf[..., 1: N // 2] *= 2.0
+        Xf[..., N // 2 + 1:N] = 0.0
     else:
-        Xf[tuple(ind + [slice(1, (N + 1) // 2)])] *= 2.0
-        Xf[tuple(ind + [slice((N + 1) // 2, N)])] = 0.0
+        Xf[..., 1:(N + 1) // 2] *= 2.0
+        Xf[..., (N + 1) // 2:N] = 0.0
 
-    x = sp_fft.ifft(Xf, axis=axis, workers=workers)
+    Xf = xp.moveaxis(Xf, -1, axis)
+    x = sp_fft.ifft(Xf, axis=axis)
     return x
 
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3469,6 +3469,15 @@ class TestHilbert:
         a0hilb = xp.asarray(a0hilb)
         assert_almost_equal(aan[0, :], a0hilb, 14, err_msg='N regression')
 
+    def test_hilbert_axis_3d(self, xp):
+        a = xp.reshape(xp.arange(3 * 5 * 7, dtype=xp.float64), (3, 5, 7))
+        # test axis
+        aa = hilbert(a, axis=-1)
+        for axis in [0, 1]:
+            aap = hilbert(np.moveaxis(a, -1, axis), axis=axis)
+            aap = np.moveaxis(aap, axis, -1)
+            xp_assert_equal(aa, aap)
+
     @pytest.mark.parametrize('dtype', ['float32', 'float64'])
     def test_hilbert_types(self, dtype, xp):
         dtype = getattr(xp, dtype)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3474,8 +3474,8 @@ class TestHilbert:
         # test axis
         aa = hilbert(a, axis=-1)
         for axis in [0, 1]:
-            aap = hilbert(np.moveaxis(a, -1, axis), axis=axis)
-            aap = np.moveaxis(aap, axis, -1)
+            aap = hilbert(xp.moveaxis(a, -1, axis), axis=axis)
+            aap = xp.moveaxis(aap, axis, -1)
             xp_assert_equal(aa, aap)
 
     @pytest.mark.parametrize('dtype', ['float32', 'float64'])

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3388,8 +3388,7 @@ class TestHilbert:
         x = xp.arange(8.0)
         assert_raises(ValueError, hilbert, x, N=0)
 
-    @pytest.mark.parametrize('workers', [None, 2])
-    def test_hilbert_theoretical(self, xp, workers):
+    def test_hilbert_theoretical(self, xp):
         # test cases by Ariel Rokem
         decimal = 14
 
@@ -3401,7 +3400,7 @@ class TestHilbert:
         a3 = xp.cos(2 * t)
         a = xp.stack([a0, a1, a2, a3])
 
-        h = hilbert(a, workers=workers)
+        h = hilbert(a)
         h_abs = xp.abs(h)
 
         h_angle = xp.atan2(xp.imag(h), xp.real(h)) #  np.angle(h)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3388,7 +3388,8 @@ class TestHilbert:
         x = xp.arange(8.0)
         assert_raises(ValueError, hilbert, x, N=0)
 
-    def test_hilbert_theoretical(self, xp):
+    @pytest.mark.parametrize('workers', [None, 2])
+    def test_hilbert_theoretical(self, xp, workers):
         # test cases by Ariel Rokem
         decimal = 14
 
@@ -3400,7 +3401,7 @@ class TestHilbert:
         a3 = xp.cos(2 * t)
         a = xp.stack([a0, a1, a2, a3])
 
-        h = hilbert(a)
+        h = hilbert(a, workers=workers)
         h_abs = xp.abs(h)
 
         h_angle = xp.atan2(xp.imag(h), xp.real(h)) #  np.angle(h)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
Added a `workers` argument to `signal.hilbert()` that gets passed into the underlying `ifft/fft` calls.  I see reasonable speedups when using this in cases where I am doing many transforms in one call. I modified a test to run with the default and 2 workers. Is there a reason why `workers` couldn't be added as an argument to any function in `signal` that uses scipy's fft functions?

I also refactored the scaling so that it is done in-place on the fft coefficients rather than allocating an extra scaling array. I think this change should be reasonably well covered by existing tests, but added a 3d example. I see a small speedup on arrays that are fairly large on the transform axis. Would it be helpful to add an `asv` benchmark for `hilbert`?

I also tried to clarify a few parts of the docstring that I found unclear, but couldn't build them locally to check for formatting issues. I see
```
ERROR: [numpydoc] While processing docstring for 'scipy.interpolate.BSpline'
```