### PR TITLE
BUG: `spin bench` ignores `--quick` parameter

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -784,10 +784,7 @@ def bench(ctx, tests, submodule, compare, verbose, quick,
             f'Running benchmarks on SciPy {np_ver}',
             bold=True, fg="bright_green"
         )
-        cmd = [
-            'asv', 'run', '--dry-run',
-            '--show-stderr', '--python=same',
-            '--quick'] + bench_args
+        cmd = ['asv', 'run', '--dry-run', '--show-stderr', '--python=same'] + bench_args
         _run_asv(cmd)
     else:
         # Ensure that we don't have uncommited changes


### PR DESCRIPTION
Towards #23166.

Fix bug where `spin bench` and `spin bench --quick` would both call `asv --quick`.