### PR TITLE
CI: skip JAX 0.6.2

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -68,7 +68,8 @@ jobs:
 
     - name: Install JAX
       run: |
-        python -m pip install "jax[cpu]"
+        # Skip 0.6.2: https://github.com/jax-ml/jax/issues/29537
+        python -m pip install "jax[cpu]!=0.6.2"
 
     - name: Install Dask
       run: |

--- a/.github/workflows/pixi.toml
+++ b/.github/workflows/pixi.toml
@@ -96,8 +96,8 @@ test-cupy = { cmd = "spin test -b cupy", cwd = "../.." }
 platforms = ["linux-64"]
 
 [feature.jax-cpu.dependencies]
-jax = "*"
-jaxlib = { version = "*", build = "*cpu*" }
+jax = "!=0.6.2"  # https://github.com/jax-ml/jax/issues/29537
+jaxlib = { version = "!=0.6.2", build = "*cpu*" }
 
 [feature.jax-cuda]
 platforms = ["linux-64"]


### PR DESCRIPTION
https://github.com/scipy/scipy/issues/23177
Unblock CI