### PR TITLE
TST: ndimage: avoid implicit dtype conversions in vectorized_filter tests

### DIFF
--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2864,7 +2864,14 @@ class TestVectorizedFilter:
             assert res.dtype == sum_dtype
 
             output = xp.empty_like(input)
-            res = ndimage.vectorized_filter(input, xp.sum, output=output, **kwargs)
+            res = ndimage.vectorized_filter(
+                input,
+                lambda x, *args, **kw: xp.astype(
+                    xp.sum(x, *args, **kw), x.dtype, copy=False
+                ),
+                output=output,
+                **kwargs
+            )
             xp_assert_close(res, xp.astype(xp.stack(ref), dtype))
             assert res.dtype == dtype
 


### PR DESCRIPTION
Here's a test which does   `vectorized_filter(input, xp.sum, output)`, with output being `xp.empty_like(input)`. This is problematic for short integers because
- the output of xp.sum(int8_array) is int64 (the default int dtype), and
- internally, vectorized_filter does roughly, `output[some_indices] = xp.sum(input[some_indices])`

So what happens here is that the output of the `sum` in the r.h.s. gets silently downcast to the dtype of the l.h.s. by `__setitem__`.

This kind of sort of works in many array libraries, but is technically unspecified by the Array API standard. And indeed this starts failing with array-api-strict in https://github.com/data-apis/array-api-strict/pull/157

Thus, a test only change to make downcasting explicit.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
