### PR TITLE
CI: remove free-threading workarounds in wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -212,7 +212,7 @@ jobs:
           echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@3c5ff0988806752c5a6502c845f9edc2d98095d6 # v3.0.0rc3
+        uses: pypa/cibuildwheel@5f22145df44122af0f5a201f93cf0207171beca7 # v3.0.0
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -204,13 +204,6 @@ jobs:
 
       #     echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
 
-      - name: Disable build isolation for python free-threaded version
-        if: endsWith(matrix.python[0], 't')
-        shell: bash
-        run: |
-          CIBW="pip; args: --no-build-isolation"
-          echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
-
       - name: Build wheels
         uses: pypa/cibuildwheel@5f22145df44122af0f5a201f93cf0207171beca7 # v3.0.0
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires = [
     # Note that building against numpy 1.x works fine too - users and
     # redistributors can do this by installing the numpy version they like and
     # disabling build isolation.
-    "numpy>=2.0.0rc1",
+    "numpy>=2.0.0",
 ]
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,6 @@ test-requires = [
     "pooch",
     "hypothesis",
 ]
-before-test = "bash {project}/tools/wheels/cibw_before_test.sh {project}"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 
 [tool.cibuildwheel.linux]

--- a/tools/wheels/cibw_before_build_linux.sh
+++ b/tools/wheels/cibw_before_build_linux.sh
@@ -17,17 +17,13 @@ printenv
 # Update license
 cat $PROJECT_DIR/tools/wheels/LICENSE_linux.txt >> $PROJECT_DIR/LICENSE.txt
 
-# TODO: delete along with enabling build isolation by unsetting
-# CIBW_BUILD_FRONTEND when scipy is buildable under free-threaded
-# python with a released version of cython
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    python -m pip install -U --pre pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    python -m pip install git+https://github.com/serge-sans-paille/pythran
-    python -m pip install ninja meson-python pybind11
-fi
+# Not needed anymore, but leave commented out in case we need to start pulling
+# in a dev version of some dependency again.
+#FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+#if [[ $FREE_THREADED_BUILD == "True" ]]; then
+#    # Workarounds here
+#fi
 
-# Install Openblas
+# Install OpenBLAS
 python -m pip install -r requirements/openblas.txt
 python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > $PROJECT_DIR/scipy-openblas.pc

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -59,18 +59,7 @@ if [[ $PLATFORM == "arm64" ]]; then
   type -p gfortran
 fi
 
-# TODO: delete along with enabling build isolation by unsetting
-# CIBW_BUILD_FRONTEND when scipy is buildable under free-threaded
-# python with a released version of cython
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    python -m pip install -U --pre pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    python -m pip install git+https://github.com/serge-sans-paille/pythran
-    python -m pip install ninja meson-python pybind11
-fi
-
-# Install Openblas
+# Install OpenBLAS
 python -m pip install -r requirements/openblas.txt
 python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > $PROJECT_DIR/scipy-openblas.pc
 

--- a/tools/wheels/cibw_before_build_win.sh
+++ b/tools/wheels/cibw_before_build_win.sh
@@ -6,20 +6,9 @@ printenv
 # Update license
 cat $PROJECT_DIR/tools/wheels/LICENSE_win32.txt >> $PROJECT_DIR/LICENSE.txt
 
-# Install Openblas
+# Install OpenBLAS
 python -m pip install -r requirements/openblas.txt
 python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > $PROJECT_DIR/scipy-openblas.pc
-
-# TODO: delete along with enabling build isolation by unsetting
-# CIBW_BUILD_FRONTEND when scipy is buildable under free-threaded
-# python with a released version of cython
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    python -m pip install -U --pre pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    python -m pip install git+https://github.com/serge-sans-paille/pythran
-    python -m pip install ninja meson-python pybind11
-fi
 
 # delvewheel is the equivalent of delocate/auditwheel for windows.
 python -m pip install delvewheel wheel

--- a/tools/wheels/cibw_before_test.sh
+++ b/tools/wheels/cibw_before_test.sh
@@ -1,8 +1,0 @@
-set -ex
-
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    # TODO: delete when numpy is buildable under free-threaded python
-    python -m pip install -U --pre pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-fi


### PR DESCRIPTION
These are no longer needed since Cython, Pythran and NumPy all have public releases that support free-threading now.

Also include two small dependency bumps: 
- numpy: 2.0.0rc1 -> 2.0.0
- cibuildwheel 3.0.0rc3 -> 3.0.0 

I did a full set of wheel builds on my fork, all green: [CI log](https://github.com/rgommers/scipy/actions/runs/15734610009).