### PR TITLE
DOC: spatial: Rigid Transformation docs cleanup

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -404,17 +404,17 @@ class RigidTransform:
 
         Notes
         -----
-        4x4 rigid transformation matrices are of the form:
+        4x4 rigid transformation matrices are of the form::
 
-        ..
+            [       tx]
+            [   R   ty]
+            [       tz]
+            [ 0 0 0  1]
 
-            [R | t]
-            [0 | 1]
-
-        where ``R`` is a 3x3 rotation matrix and ``t`` is a 3x1 translation
-        vector ``[tx, ty, tz]``. As rotation matrices must be proper
-        orthogonal, the rotation component is orthonormalized using singular
-        value decomposition before initialization.
+        where ``R`` is a 3x3 rotation matrix and ``t = [tx, ty, tz]`` is a 3x1
+        translation vector. As rotation matrices must be proper orthogonal, the
+        rotation component is orthonormalized using singular value decomposition
+        before initialization.
 
         Examples
         --------
@@ -933,15 +933,15 @@ class RigidTransform:
     def as_matrix(self) -> Array:
         """Return a copy of the matrix representation of the transform.
 
-        4x4 rigid transformation matrices are of the form:
+        4x4 rigid transformation matrices are of the form::
 
-        ..
+            [       tx]
+            [   R   ty]
+            [       tz]
+            [ 0 0 0  1]
 
-            [R | t]
-            [0 | 1]
-
-        where ``R`` is a 3x3 orthonormal rotation matrix and ``t`` is a 3x1
-        translation vector ``[tx, ty, tz]``.
+        where ``R`` is a 3x3 orthonormal rotation matrix and
+        ``t = [tx, ty, tz]`` is a 3x1 translation vector.
 
         Returns
         -------
@@ -989,17 +989,17 @@ class RigidTransform:
         """Return the translation and rotation components of the transform,
         where the rotation is applied first, followed by the translation.
 
-        4x4 rigid transformation matrices are of the form:
+        4x4 rigid transformation matrices are of the form::
 
-        ..
+            [       tx]
+            [   R   ty]
+            [       tz]
+            [ 0 0 0  1]
 
-            [R | t]
-            [0 | 1]
-
-        Where ``R`` is a 3x3 orthonormal rotation matrix and ``t`` is a 3x1
-        translation vector ``[tx, ty, tz]``. This function returns the rotation
-        corresponding to this rotation matrix ``r = Rotation.from_matrix(R)``
-        and the translation vector ``t``.
+        Where ``R`` is a 3x3 orthonormal rotation matrix and
+        ``t = [tx, ty, tz]`` is a 3x1 translation vector. This function
+        returns the rotation corresponding to this rotation matrix
+        ``r = Rotation.from_matrix(R)`` and the translation vector ``t``.
 
         Take a transform ``tf`` and a vector ``v``. When applying the transform
         to the vector, the result is the same as if the transform was applied
@@ -1272,9 +1272,10 @@ class RigidTransform:
     def __mul__(self, other: RigidTransform) -> RigidTransform:
         """Compose this transform with the other.
 
-        If `p` and `q` are two transforms, then the composition of 'q followed
-        by p' is equivalent to `p * q`. In terms of transformation matrices,
-        the composition can be expressed as ``p.as_matrix() @ q.as_matrix()``.
+        If ``p`` and ``q`` are two transforms, then the composition of '``q``
+        followed by ``p``' is equivalent to ``p * q``. In terms of
+        transformation matrices, the composition can be expressed as
+        ``p.as_matrix() @ q.as_matrix()``.
 
         In terms of translations and rotations, the composition when applied to
         a vector ``v`` is equivalent to


### PR DESCRIPTION
#### Reference issue

#### What does this implement/fix?
Some of the rigid transformation docs weren't rendering as intended, this fixes that and IMO gives a more intuitive matrix representation.

**Before:** 
![image](https://github.com/user-attachments/assets/2c35851c-1611-4c63-8e87-9b31e3d32b7c)

**After:**
![image](https://github.com/user-attachments/assets/9a8f2d0e-caa8-48a6-a144-c6eb60d92687)
