### PR TITLE
DOC: fft: tutorial improvements

### DIFF
--- a/doc/source/tutorial/examples/fft_ParemetricClosedCurve.py
+++ b/doc/source/tutorial/examples/fft_ParemetricClosedCurve.py
@@ -1,0 +1,30 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.collections import LineCollection
+from scipy.fft import ifft, fftshift
+
+X = np.array([0, -3.699 - 3669j, -0.4812 - 2650j, 1.013 - 2008j, 1.98 + 1253j,
+              3.538 + 505.4j, -0.742 + 616.5j, 0, 2.91 + 236.9j, 1.498 + 187j,
+              -4.823 + 305j, 0, 0, 0, 0, 0, 0, 0, 0, 5.863 + 165.6j, 0, 0,
+              -3.965 + 146.9j, 0, 0.5565 + 290.3j, 0, -2.706 - 615.6j, 5.784 + 1870j,
+              -6.915 - 1080j, 8.614 - 864j, 4.133 + 2527j]) # DFT values
+N, N1 = len(X), len(X)*8  # number of samples and number of interpolation points
+
+x = ifft(X)  # determine sample values of closed curve
+
+t1 = np.arange(N1 + 1) / N1  # interpolate by utilizing Fourier series
+x1 = sum([c_k * np.exp(2j * np.pi * k_ * t1)
+          for k_, c_k in enumerate(fftshift(X / N), start=-(N//2))])
+
+fg0, ax0 = plt.subplots(1, 1, tight_layout=True)
+ax0.set(title=f"Parametric Closed Curve $x(t)$ generated from {len(x)} Samples",
+        xlabel=r"Re$\{x(t)\}$", ylabel=r"Im$\{x(t)\}$")
+
+ax0.scatter(x.real, x.imag, c=np.arange(N) / N, s=8, cmap='twilight')
+
+pts1 = np.stack((x1.real, x1.imag), axis=1)  # extract 2d points
+ln1 = ax0.add_collection(LineCollection(np.stack((pts1[:-1], pts1[1:]), axis=1),
+                                        array=t1[:-1], cmap='twilight'))
+fg0.colorbar(ln1, label="Parameter $t$")
+
+plt.show()

--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -795,9 +795,8 @@ as shown in the following example.
     >>> Ax = np.array([0.2, 0.8, 0.6])               # signal amplitudes
     >>> t = np.linspace(0.0, Tp, N, endpoint=False)  # time in s (one segment)
     >>> f = rfftfreq(M*N, Ts)                        # frequency in Hz
-    >>> x = np.zeros(M*N)
-    >>> x[:N] = np.sum(Ax[:,np.newaxis]*np.cos(2.0*np.pi*np.outer(Fx,t)), axis=0)
-    >>> yr = rfft(x)
+    >>> x = np.sum(Ax[:,np.newaxis]*np.cos(2.0*np.pi*np.outer(Fx,t)), axis=0)
+    >>> yr = rfft(x, M*N)
     >>> ya = 20.0*np.log10(2.0/N * np.abs(yr))
     >>>
     >>> # plot ya vs. f in the range [0, Fs/2]
@@ -858,7 +857,7 @@ two bin frequencies, and the amplitude in these two bins is scaled
 by :math:`2/\pi`, i.e., it appears 4 dB below the actual peak.
 The side peaks are close to integer-plus-half multiples of :math:`F_p`
 relative to :math:`F_x.`
-When the spectrum is plotted in dB, the envelop of the spectral leakage
+When the spectrum is plotted in dB, the envelope of the spectral leakage
 near the main peak takes the form of a negative logarithmic function,
 which falls by 6 dB (or 1 bit in log2) per doubling of the distance
 from the main peak.
@@ -899,8 +898,8 @@ the Blackman window and the Dolph–Chebyshev window with 100 dB attenuation.
     >>> import matplotlib.pyplot as plt
     >>> fig, ax = plt.subplots(figsize=(7,4))
     >>> fig.tight_layout()
-    >>> ax.plot(n, windows.blackman(N), 'g', label='blackman')
-    >>> ax.plot(n, windows.chebwin(N, at=100), 'r', label='cheb(100)')
+    >>> ax.plot(n, windows.blackman(N, sym=False), 'g', label='blackman')
+    >>> ax.plot(n, windows.chebwin(N, at=100, sym=False), 'r', label='cheb(100)')
     >>> ax.legend()
     >>>
     >>> # decorations
@@ -914,7 +913,7 @@ Their spectrum, which shows also their spectral leakage pattern,
 is calculated and plotted with the following code:
 
 .. plot::
-    :alt: "This code generates calculates and plots the spectrum of three windows: (1) the rectangular window, (2) the  Blackman window, and (3) the Dolph–Chebyshev window with 100 dB attenuation. The main axes shows the spectrum at integer-plus-half bin width, which is approximately equal to the envelop of the spectral leakage. An inset axes shows a detail of the spectrum for the first 6 bins."
+    :alt: "This code generates calculates and plots the spectrum of three windows: (1) the rectangular window, (2) the  Blackman window, and (3) the Dolph–Chebyshev window with 100 dB attenuation. The main axes shows the spectrum at integer-plus-half bin width, which is approximately equal to the envelope of the spectral leakage. An inset axes shows a detail of the spectrum for the first 6 bins."
 
     >>> from scipy.fft import rfft, rfftfreq
     >>> from scipy.signal import windows
@@ -922,14 +921,14 @@ is calculated and plotted with the following code:
     >>> M = 10   # number of segments
     >>> N = 400  # window length
     >>> f = rfftfreq(M*N, 1.0/N)  # normalized frequency
-    >>> x = np.zeros((3, M*N))    # space for 3 windows
-    >>> x[0,:N] = np.ones(N)
-    >>> x[1,:N] = windows.blackman(N)
-    >>> x[2,:N] = windows.chebwin(N, at=100)
-    >>> yr = rfft(x, axis=1)
+    >>> x = np.zeros((3, N))      # space for 3 windows
+    >>> x[0,:] = np.ones(N)
+    >>> x[1,:] = windows.blackman(N, sym=False)
+    >>> x[2,:] = windows.chebwin(N, at=100, sym=False)
+    >>> yr = rfft(x, M*N, axis=1)
     >>> eps = np.spacing(1.0)
     >>> ya = 20.0*np.log10(eps + np.abs(yr) / np.sum(x, axis=1, keepdims=True))
-    >>> # envelop of ya
+    >>> # envelope of ya
     >>> fm = f[:-1].reshape(-1,M)
     >>> yam = ya[:,:-1].reshape(3,-1,M)
     >>> ke = np.argmax(yam, axis=-1)
@@ -969,7 +968,7 @@ by the sum of the window sequence).
 The inset shows the amplitude for the first few bins.
 As it is seen, the amplitude has large variation over the continuous frequency,
 due to the zero values at or near every bin frequency.
-The main plot shows the envelop of the amplitude vs. frequency,
+The main plot shows the envelope of the amplitude vs. frequency,
 which is also the worst-case pattern for the spectral leakage.
 
 These three windows are applied to a signal as shown below.
@@ -990,9 +989,9 @@ These three windows are applied to a signal as shown below.
     >>> t = np.linspace(0.0, Tp, N, endpoint=False)  # time in s
     >>> f = rfftfreq(N, Ts)                          # frequency in Hz
     >>> w = np.empty((3, N))                         # space for 3 windows
-    >>> w[0,:N] = np.ones(N)
-    >>> w[1,:N] = windows.blackman(N)
-    >>> w[2,:N] = windows.chebwin(N, at=100)
+    >>> w[0,:] = np.ones(N)
+    >>> w[1,:] = windows.blackman(N, sym=False)
+    >>> w[2,:] = windows.chebwin(N, at=100, sym=False)
     >>> x = w * np.sum(Ax[:,np.newaxis]*np.cos(2.0*np.pi*np.outer(Fx,t)), axis=0)
     >>> yr = rfft(x, axis=1)
     >>> eps = np.spacing(1.0)

--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -8,15 +8,16 @@ Fourier Transforms (:mod:`scipy.fft`)
 .. contents::
 
 
-Fourier analysis is a method for expressing a function as a sum of periodic
-components, and for recovering the signal from those components. When both
-the function and its Fourier transform are replaced with discretized
-counterparts, it is called the discrete Fourier transform (DFT). The DFT has
-become a mainstay of numerical computing in part because of a very fast
-algorithm for computing it, called the Fast Fourier Transform (FFT), which was
-known to Gauss (1805) and was brought to light in its current form by Cooley
-and Tukey [CT65]_. Press et al. [NR07]_ provide an accessible introduction to
-Fourier analysis and its applications.
+Fourier analysis is a method which decomposes a function into periodic
+components, and reconstructs it from those components.
+When both the function and its Fourier transform are discretized,
+it is called the "Discrete Fourier Transform" (DFT).
+The DFT has become a mainstay of numerical computing in part because
+of a fast algorithm for computing it, with complexity
+:math:`O(n\,{\rm log}\,n),` called the "Fast Fourier Transform" (FFT).
+This algorithm was known to Gauss (1805) and was brought to light in its
+current form by Cooley and Tukey [CT65]_. Press et al. [NR07]_ provide an
+accessible introduction to Fourier analysis and its applications.
 
 
 .. _tutorial_FFT:
@@ -24,171 +25,219 @@ Fourier analysis and its applications.
 Fast Fourier transforms
 -----------------------
 
-1-D discrete Fourier transforms
-___________________________________________
+1-D DFT
+_______
 
-The FFT ``y[k]`` of length :math:`N` of the length-:math:`N` sequence ``x[n]`` is
+The DFT of a complex sequence :math:`x[n]` of length :math:`N,`
+is another complex sequence :math:`y[k]` of length :math:`N,`
 defined as
 
 .. math::
 
-    y[k] = \sum_{n=0}^{N-1} e^{-2 \pi j \frac{k n}{N} } x[n] \, ,
+    y[k] = \sum_{n=0}^{N-1} e^{-j 2 \pi k n / N} x[n] \, .
 
-and the inverse transform is defined as follows
+The inverse transform is
 
 .. math::
 
-    x[n] = \frac{1}{N} \sum_{k=0}^{N-1} e^{2 \pi j \frac{k n}{N} } y[k] \, .
+    x[n] = \frac{1}{N} \sum_{k=0}^{N-1} e^{j 2 \pi k n / N} y[k] \, .
 
-These transforms can be calculated by means of :func:`fft` and :func:`ifft`,
-respectively, as shown in the following example.
+DFT and its inverse are linear transforms in :math:`\mathcal{C}^N,`
+with a symmetric transformation matrix.
+The transformation matrix of the inverse DFT is the complex conjugate
+of the transformation matrix of DFT, divided by :math:`N.`
+
+It can be shown that
+
+.. math::
+
+    y[0] = \sum_{n=0}^{N-1} x[n] \, ,\quad
+    x[0] = \frac{1}{N} \sum_{k=0}^{N-1} y[k] \, ,\quad
+    \sum_{n=0}^{N-1} |x[n]|^2 = \frac{1}{N} \sum_{k=0}^{N-1} |y[k]|^2 \, .
+
+The DFT and its inverse can be calculated by means of :func:`fft`
+and :func:`ifft`, respectively, as shown in the following example.
 
 >>> from scipy.fft import fft, ifft
 >>> import numpy as np
->>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+>>> x = np.array([1.0, 2.0, -1.0, -1.5, 1.5, 0.5])
 >>> y = fft(x)
 >>> y
-array([ 4.5       +0.j        ,  2.08155948-1.65109876j,
-       -1.83155948+1.60822041j, -1.83155948-1.60822041j,
-        2.08155948+1.65109876j])
->>> yinv = ifft(y)
->>> yinv
-array([ 1.0+0.j,  2.0+0.j,  1.0+0.j, -1.0+0.j,  1.5+0.j])
+array([ 2.5-0.j        ,  3.5+0.8660254j , -2. -3.46410162j,
+        0.5-0.j        , -2. +3.46410162j,  3.5-0.8660254j ])
+>>> ifft(y)
+array([ 1. +0.j,  2. +0.j, -1. +0.j, -1.5+0.j,  1.5-0.j,  0.5+0.j])
+>>>
+>>> # the following are equal for any complex x
+>>> np.isclose(ifft(x), fft(x.conj()).conj()/len(x))
+array([ True,  True,  True,  True,  True,  True])
+>>> y[0], np.sum(x)
+(2.5-0j, 2.5)
+>>> x[0], np.mean(y)
+(1.0, 1+3.700743415417188e-17j)
+>>> np.sum(np.abs(x)**2), np.mean(np.abs(y)**2)
+(10.75, 10.75)
 
-
-From the definition of the FFT it can be seen that
-
-.. math::
-
-    y[0] = \sum_{n=0}^{N-1} x[n] \, .
-
-In the example
-
->>> np.sum(x)
-4.5
-
-which corresponds to :math:`y[0]`. For N even, the elements
-:math:`y[1]...y[N/2-1]` contain the positive-frequency terms, and the elements
-:math:`y[N/2]...y[N-1]` contain the negative-frequency terms, in order of
-decreasingly negative frequency. For N odd, the elements
-:math:`y[1]...y[(N-1)/2]` contain the positive-frequency terms, and the
-elements :math:`y[(N+1)/2]...y[N-1]` contain the negative-frequency terms, in
-order of decreasingly negative frequency.
-
-In case the sequence x is real-valued, the values of :math:`y[n]` for positive
-frequencies is the conjugate of the values :math:`y[n]` for negative
-frequencies (because the spectrum is symmetric). Typically, only the FFT
-corresponding to positive frequencies is plotted.
-
-The example plots the FFT of the sum of two sines.
+The sequences :math:`x[n]` and :math:`y[k]` in the previous example
+are shown graphically below.
 
 .. plot::
-    :alt: "This code generates an X-Y plot showing amplitude on the Y axis vs frequency on the X axis. A single blue trace has an amplitude of zero all the way across with the exception of two peaks. The taller first peak is at 50 Hz with a second peak at 80 Hz."
+    :alt: "This code generates a plot of the sequences x[n], Re y[[k], Im y[k]. The value at each point is shown with a marker and with a vertical bar from the horizontal axis."
 
-    >>> from scipy.fft import fft, fftfreq
+    >>> from scipy.fft import fft
     >>> import numpy as np
-    >>> # Number of sample points
-    >>> N = 600
-    >>> # sample spacing
-    >>> T = 1.0 / 800.0
-    >>> x = np.linspace(0.0, N*T, N, endpoint=False)
-    >>> y = np.sin(50.0 * 2.0*np.pi*x) + 0.5*np.sin(80.0 * 2.0*np.pi*x)
-    >>> yf = fft(y)
-    >>> xf = fftfreq(N, T)[:N//2]
+    >>> x = np.array([1.0, 2.0, -1.0, -1.5, 1.5, 0.5])
+    >>> y = fft(x)
+    >>> n = np.r_[:len(x)]
+    >>> k = np.r_[:len(y)]  # same as n
+    >>>
+    >>> # plot x, Re y, Im y
     >>> import matplotlib.pyplot as plt
-    >>> plt.plot(xf, 2.0/N * np.abs(yf[0:N//2]))
-    >>> plt.grid()
+    >>> fig, ax = plt.subplots(nrows=1, ncols=3, figsize=(7,3))
+    >>> fig.tight_layout()
+    >>> ax[0].scatter(n, x)
+    >>> ax[1].scatter(k, y.real)
+    >>> ax[2].scatter(k, y.imag)
+    >>>
+    >>> # decorations
+    >>> ax[0].plot(np.outer([1, 1], n), np.outer([0, 1], x), 'b')
+    >>> ax[1].plot(np.outer([1, 1], k), np.outer([0, 1], y.real), 'b')
+    >>> ax[2].plot(np.outer([1, 1], k), np.outer([0, 1], y.imag), 'b')
+    >>> ax[0].set_title('x[n]')
+    >>> ax[1].set_title('Re y[k]')
+    >>> ax[2].set_title('Im y[k]')
+    >>> for i in (0, 1, 2):
+    >>>     ax[i].set_xlim(-1, 6)
+    >>>     ax[i].set_ylim(-4, 4)
+    >>>     ax[i].grid()
     >>> plt.show()
 
 
-The FFT input signal is inherently truncated. This truncation can be modeled
-as multiplication of an infinite signal with a rectangular window function. In
-the spectral domain this multiplication becomes convolution of the signal
-spectrum with the window function spectrum, being of form :math:`\sin(x)/x`.
-This convolution is the cause of an effect called spectral leakage (see
-[WPW]_). Windowing the signal with a dedicated window function helps mitigate
-spectral leakage. The example below uses a Blackman window from scipy.signal
-and shows the effect of windowing (the zero component of the FFT has been
-truncated for illustrative purposes).
+In the usual case in which :math:`x[n]` is real, the subsequence
+:math:`y[1],\ldots,y[N-1]` is conjugate-symmetric, i.e.,
+:math:`y[N-k] = y^*[k],` for :math:`k=1,\ldots,N-1.`
+Therefore :math:`y[N/2]` is real for even :math:`N,`
+while :math:`y[0]` is real for either even or odd :math:`N.`
+The subsequence :math:`y[0],\ldots,y[N//2]` contains :math:`N`
+independent real values, and it is sufficient to reconstruct :math:`x[n].`
+Typically only this subsequence is plotted for real :math:`x[n].`
+
+In many applications, the sequence :math:`x[n]` represents samples taken
+from a real function of time :math:`x(t),` at a fixed time interval :math:`T_s,`
+i.e., :math:`x[n] = x(n\,T_s).` The parameter :math:`T_s` is called
+"sampling time", or "time resolution", while its inverse :math:`F_s=1/T_s`
+is called "sampling frequency", or "sampling rate".
+The time duration spanned by :math:`N` samples is :math:`T_p=N\,T_s`
+and is called "sampling period", while its inverse
+:math:`F_p=1/T_p=F_s/N` is called "bin width", or "frequency resolution".
+In analogy to :math:`x[n],` the sequence :math:`y[k]` is considered to be
+the samples of a complex function of frequency :math:`y(f),` at a fixed
+frequency interval :math:`F_p,` i.e., :math:`y[k] = y(k\,F_p).`
+The frequencies :math:`k\,F_p` are called "bin frequencies".
+
+The following example models the samples taken from a real signal
+containing two sinusoidal components and a bias (such that its
+spectrum can be easily predicted). It calculates the DFT of the signal
+using :func:`fft`, and then it plots its amplitude vs. frequency.
+The frequency points are caclulated using the convenience function
+:func:`rfftfreq`, which takes as arguments the parameters :math:`N`
+and :math:`T_s` and returns the multiples of the bin width :math:`F_p`
+in the range :math:`[0,F_s/2].` These are the frequency points of
+interest for the FFT of a real signal.
 
 .. plot::
-    :alt: "This code generates an X-Y log-linear plot with amplitude on the Y axis vs frequency on the X axis. The first trace is the FFT with two peaks at 50 and 80 Hz and a noise floor around an amplitude of 1e-2. The second trace is the windowed FFT and has the same two peaks but the noise floor is much lower around an amplitude of 1e-7 due to the window function."
+    :alt: "This code generates a plot of the amplitude of the transform vs. frequency, shown as a blue line. Its Y value is zero all the way across the X axis, with the exception of three peaks. The first peak is at zero frequency, with expected amplitude 0.4. The second peak is at 50 Hz with expected amplitude 0.8. The third peak is at 125 Hz with expected amplitude 0.6. The expected amplitudes at each frequency are shown with short horizontal lines. More details around the peaks at 50 Hz and 125 Hz are shown in inset axes."
 
-    >>> from scipy.fft import fft, fftfreq
+    >>> from scipy.fft import fft, rfftfreq
     >>> import numpy as np
-    >>> # Number of sample points
-    >>> N = 600
-    >>> # sample spacing
-    >>> T = 1.0 / 800.0
-    >>> x = np.linspace(0.0, N*T, N, endpoint=False)
-    >>> y = np.sin(50.0 * 2.0*np.pi*x) + 0.5*np.sin(80.0 * 2.0*np.pi*x)
-    >>> yf = fft(y)
-    >>> from scipy.signal.windows import blackman
-    >>> w = blackman(N)
-    >>> ywf = fft(y*w)
-    >>> xf = fftfreq(N, T)[:N//2]
+    >>> N = 400        # number of samples
+    >>> Fs = 800.0     # sampling frequency in Hz
+    >>> Ts = 1.0 / Fs  # sampling time (step) in s
+    >>> Tp = N / Fs    # sampling period (total) in s
+    >>> Fp = Fs / N    # bin width (frequency resolution) in Hz
+    >>> Fx = np.array([0.0, 50.0, 125.0])            # signal frequencies in Hz
+    >>> Ax = np.array([0.2, 0.8, 0.6])               # signal amplitudes
+    >>> t = np.linspace(0.0, Tp, N, endpoint=False)  # time in s
+    >>> f = rfftfreq(N, Ts)                          # frequency in Hz
+    >>> x = np.sum(Ax[:,np.newaxis]*np.cos(2.0*np.pi*np.outer(Fx,t)), axis=0)
+    >>> y = fft(x)
+    >>> ya = 2.0/N * np.abs(y[:len(f)])
+    >>>
+    >>> # plot ya vs. f in the range [0, Fs/2]
     >>> import matplotlib.pyplot as plt
-    >>> plt.semilogy(xf[1:N//2], 2.0/N * np.abs(yf[1:N//2]), '-b')
-    >>> plt.semilogy(xf[1:N//2], 2.0/N * np.abs(ywf[1:N//2]), '-r')
-    >>> plt.legend(['FFT', 'FFT w. window'])
-    >>> plt.grid()
+    >>> fig, ax = plt.subplots(figsize=(7,4))
+    >>> fig.tight_layout()
+    >>> ax.plot(f, ya)
+    >>>
+    >>> # decorations
+    >>> for i in range(len(Fx)):
+    >>>     # expected amplitude at frequency Fx[i]
+    >>>     a = Ax[i] if i > 0 else 2*Ax[i]
+    >>>     ax.plot(Fx[i]+np.array([[-6.0, 6.0], [-3.0, 3.0]]), a*np.r_[1.0, 1.0], 'g')
+    >>> ax.set_title(f'N={N}, Fp={Fp} Hz, Fs={Fs} Hz')
+    >>> ax.set_xlabel('f [Hz]')
+    >>> ax.set_ylabel('2/N |y|')
+    >>> ax.grid()
+    >>> for i in (1, 2):
+    >>>     axi = fig.add_axes([0.35+0.22*i, 0.4, 0.13, 0.4])
+    >>>     # frequency indices around Fx[i]
+    >>>     k = np.r_[int(Fx[i]/Fp+0.3)-4:int(Fx[i]/Fp+0.8)+5]
+    >>>     axi.scatter(f[k], ya[k], marker='o')
+    >>>     axi.plot(np.outer([1, 1], f[k]), np.outer([0, 1], ya[k]), 'b')
+    >>>     axi.set_xlim(f[k[0]]-Fp/2, f[k[-1]]+Fp/2)
+    >>>     axi.set_ylim(-0.1, 0.9)
+    >>>     axi.grid()
     >>> plt.show()
 
 
-In case the sequence x is complex-valued, the spectrum is no longer symmetric.
-To simplify working with the FFT functions, scipy provides the following two
-helper functions.
+The plotted spectrum is scaled such that the value at a peak gives
+the amplitude of the sinusoidal component at that frequency.
+With this scaling, the peak at zero frequency is equal to the mean value
+of the signal multiplied by 2.
+The first sinusoidal component has frequency equal to an exact multiple
+of :math:`F_p,` i.e., equal to one of the bin frequencies, therefore it
+appears as an impulse with the expected amplitude.
+The whole energy (the square of the Euclidean norm) of this component
+is concentated in a single bin. However, the second sinusoidal component
+has a frequency between two bin frequencies and its energy is spread in
+multiple bins (theoretically in all bins).
+This effect is called "spectral leakage" (see Appendix).
+Taking this effect into account, the expected amplitude at each of
+the two main peaks is :math:`2/\pi\cdot A_x[2],` i.e., 81% of the
+component energy is contained in the two main peaks and 19% is spread
+over the whole frequency range.
 
-The function :func:`fftfreq` returns the FFT sample frequency points.
+In the previous example we calculated the DFT of a sequence :math:`x`
+using :func:`fft`, and then we scaled its amplitude (absolute value)
+by :math:`2/N,` as in the following code:
 
->>> from scipy.fft import fftfreq
->>> freq = fftfreq(8, 0.125)
->>> freq
-array([ 0., 1., 2., 3., -4., -3., -2., -1.])
+>>> y = fft(x)
+>>> ya = 2.0/N * np.abs(y[:len(f)])
 
-In a similar spirit, the function :func:`fftshift` allows swapping the lower
-and upper halves of a vector, so that it becomes suitable for display.
+Since :math:`x` is real and the phase (angle) of :math:`y` is of no interest,
+we can obtain the same result by calculating the inverse DFT of :math:`x`
+using :func:`ifft`, and then scaling its amplitude by :math:`2.`
 
->>> from scipy.fft import fftshift
->>> x = np.arange(8)
->>> fftshift(x)
-array([4, 5, 6, 7, 0, 1, 2, 3])
+>>> yi = ifft(x)
+>>> ya = 2.0 * np.abs(yi[:len(f)])
 
-The example below plots the FFT of two complex exponentials; note the
-asymmetric spectrum.
+For a real sequence :math:`x` of length :math:`N,` only the first
+:math:`N//2+1` values of its DFT are used, since the remaining
+:math:`(N-1)//2` values are redundant.
+The function :func:`rfft` calculates the FFT of a real sequence
+and returns only the first :math:`N//2+1` values, which correspond to
+the :math:`N//2+1` frequency values returned by :func:`rfftfreq`.
 
-.. plot::
-    :alt: "This code generates an X-Y plot with amplitude on the Y axis vs frequency on the X axis. The trace is zero-valued across the plot except for two sharp peaks at -80 and 50 Hz. The 50 Hz peak on the right is twice as tall."
+>>> from scipy.fft import rfft
+>>> yr = rfft(x)
+>>> ya = 2.0/N * np.abs(yr)
 
-    >>> from scipy.fft import fft, fftfreq, fftshift
-    >>> import numpy as np
-    >>> # number of signal points
-    >>> N = 400
-    >>> # sample spacing
-    >>> T = 1.0 / 800.0
-    >>> x = np.linspace(0.0, N*T, N, endpoint=False)
-    >>> y = np.exp(50.0 * 1.j * 2.0*np.pi*x) + 0.5*np.exp(-80.0 * 1.j * 2.0*np.pi*x)
-    >>> yf = fft(y)
-    >>> xf = fftfreq(N, T)
-    >>> xf = fftshift(xf)
-    >>> yplot = fftshift(yf)
-    >>> import matplotlib.pyplot as plt
-    >>> plt.plot(xf, 1.0/N * np.abs(yplot))
-    >>> plt.grid()
-    >>> plt.show()
-
-
-The function :func:`rfft` calculates the FFT of a real sequence and outputs the
-complex FFT coefficients :math:`y[n]` for only half of the frequency range. The
-remaining negative frequency components are implied by the Hermitian symmetry of
-the FFT for a real input (``y[n] = conj(y[-n])``). In case of N being even:
-:math:`[Re(y[0]) + 0j, y[1], ..., Re(y[N/2]) + 0j]`; in case of N being odd
-:math:`[Re(y[0]) + 0j, y[1], ..., y[N/2]`. The terms shown explicitly as
-:math:`Re(y[k]) + 0j` are restricted to be purely real since, by the hermitian
-property, they are their own complex conjugate.
-
-The corresponding function :func:`irfft` calculates the IFFT of the FFT
-coefficients with this special ordering.
+The function :func:`irfft` is the inverse of :func:`rfft`, i.e.,
+it calculates the real sequence :math:`x[0],\ldots,x[N-1]` from
+a subsequence :math:`y[0],\ldots,y[N//2]` of its DFT.
+The parameter :math:`N` must be specified as an additional argument ``n``,
+because its parity cannot be determined from the length :math:`N//2+1`
+of the input argument (if ``n`` is not specified, an even :math:`N` is assumed).
 
 >>> from scipy.fft import fft, rfft, irfft
 >>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5, 1.0])
@@ -201,6 +250,7 @@ array([ 5.5 +0.j        ,  2.25-0.4330127j , -2.75-1.29903811j,
         1.5 +0.j        ])
 >>> irfft(yr)
 array([ 1. ,  2. ,  1. , -1. ,  1.5,  1. ])
+>>>
 >>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
 >>> fft(x)
 array([ 4.5       +0.j        ,  2.08155948-1.65109876j,
@@ -210,24 +260,112 @@ array([ 4.5       +0.j        ,  2.08155948-1.65109876j,
 >>> yr
 array([ 4.5       +0.j        ,  2.08155948-1.65109876j,
         -1.83155948+1.60822041j])
-
-Notice that the :func:`rfft` of odd and even length signals are of the same shape.
-By default, :func:`irfft` assumes the output signal should be of even length. And
-so, for odd signals, it will give the wrong result:
-
+>>> # n must be specified if it is odd
+>>> irfft(yr, n=len(x))
+array([ 1. ,  2. ,  1. , -1. ,  1.5])
+>>> # otherwise the result is not equal to the original signal
 >>> irfft(yr)
 array([ 1.70788987,  2.40843925, -0.37366961,  0.75734049])
 
-To recover the original odd-length signal, we **must** pass the output shape by
-the `n` parameter.
 
->>> irfft(yr, n=len(x))
-array([ 1. ,  2. ,  1. , -1. ,  1.5])
+The DFT of a sequence :math:`x` of length :math:`N,` can be extended to
+an infinite sequence :math:`y[k]` by using the DFT formula for any integer
+:math:`k.` With this extension, the infinite sequence :math:`y[k]` is a
+periodic function of :math:`k` with period :math:`N,` and the index :math:`k`
+is considered to be wrapped with period :math:`N,` i.e., the values
+:math:`k+mN` for different integers :math:`m` are indistinguishable.
+Similarly, the bin frequency in the DFT of a sampled signal is considered
+to be wrapped with period equal to the sampling frequency :math:`F_s.`
+
+If the sequence :math:`x` is not real, then the subsequence
+:math:`y[1],\ldots,y[N-1]` of its DFT is not conjugate-symmetric.
+The corresponding amplitudes may be symmetric (by chance or
+by construction), but usually they are not.
+In this case it is common to plot the spectrum of a signal with the
+zero frequency at the center of the horizontal axis, with the
+understanding that the bin frequency is wrapped with period :math:`F_s.`
+For an even :math:`N,` the bin frequency :math:`F_s/2` can be shown
+either as positive or negative (but usually not both).
+This kind of plot is called "two-sided", while the plot of the spectrum
+of a real signal in the range :math:`[0,F_s/2]` is called "one-sided".
+
+To simplify working with a two-sided spectrum, scipy provides two helper
+functions. The function :func:`fftfreq` takes as arguments the parameters
+:math:`N` and :math:`T_s,` and returns the sequence of bin frequencies
+of length :math:`N,` in which all bin frequencies :math:`f \ge F_s/2`
+are wrapped to :math:`f-F_s.` This makes negative the last :math:`N//2`
+bin frequencies in the sequence. The companion function :func:`fftshift`
+takes as argument a sequence of length :math:`N,` and returns the same
+sequence rotated to the right by :math:`N//2.` When it is applied to
+the output of :func:`fftfreq`, the result is in arithmetic order,
+as needed for the plot of a two-sided spectrum.
+
+>>> from scipy.fft import rfftfreq, fftfreq, fftshift
+>>> N = 8
+>>> rfftfreq(N, 1.0/N)
+array([0., 1., 2., 3., 4.])
+>>> f = fftfreq(N, 1.0/N)
+>>> f
+array([ 0., 1., 2., 3., -4., -3., -2., -1.])
+>>> fftshift(f)
+array([-4., -3., -2., -1.,  0.,  1.,  2.,  3.])
+>>> x = np.arange(N)
+>>> fftshift(x)
+array([4, 5, 6, 7, 0, 1, 2, 3])
+
+Notice that for an even :math:`N,` as in the example above,
+the bin frequency :math:`F_s/2` is shown as positive in a one-sided
+spectrum created with :func:`rfftfreq`, and as negative in a two-sided
+spectrum created with :func:`fftfreq` and :func:`fftshift`.
+
+The example below plots the spectrum of a complex signal containing
+two complex exponential components.
+
+.. plot::
+    :alt: "This code generates an X-Y plot with amplitude on the Y axis vs. frequency on the X axis. The trace is zero-valued across the plot except for two sharp peaks at -80 and 50 Hz. The 50 Hz peak on the right is twice as tall."
+
+    >>> from scipy.fft import fft, fftfreq, fftshift
+    >>> import numpy as np
+    >>> N = 400        # number of samples
+    >>> Fs = 800.0     # sampling frequency in Hz
+    >>> Ts = 1.0 / Fs  # sampling time (step) in s
+    >>> Tp = N / Fs    # sampling period (total) in s
+    >>> Fp = Fs / N    # bin width (frequency resolution) in Hz
+    >>> t = np.linspace(0.0, Tp, N, endpoint=False)  # time in s
+    >>> f = fftfreq(N, Ts)                           # frequency in Hz
+    >>> x = 0.8*np.exp(1.j * 2.0*np.pi*50.0*t) + 0.4*np.exp(-1.j * 2.0*np.pi*80.0*t)
+    >>> y = fft(x)
+    >>> ya = 1.0/N * np.abs(y)
+    >>> fc = fftshift(f)
+    >>> yc = fftshift(ya)
+    >>>
+    >>> # plot yc vs. fc in the range [-Fs/2, Fs/2)
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(figsize=(6,4))
+    >>> fig.tight_layout()
+    >>> ax.plot(fc, yc)
+    >>>
+    >>> # decorations
+    >>> ax.plot( 50.0+np.array([[-12.0, 12.0], [-8.0, 8.0]]), 0.8*np.r_[1.0, 1.0], 'g')
+    >>> ax.plot(-80.0+np.array([[-12.0, 12.0], [-8.0, 8.0]]), 0.4*np.r_[1.0, 1.0], 'g')
+    >>> ax.set_ylim(-0.1, 0.9)
+    >>> ax.set_title(f'N={N}, Fp={Fp} Hz, Fs={Fs} Hz')
+    >>> ax.set_xlabel('f [Hz]')
+    >>> ax.set_ylabel('|y|')
+    >>> ax.grid()
+    >>> plt.show()
+
+Notice that the spectrum is asymmetric with respect to zero frequency.
+If it had been plotted in the range :math:`[0,F_s),`
+the peak at -80 Hz would appear at 720 Hz.
+The amplitude is scaled such that the value at a peak gives
+the amplitude of the complex exponential component at that frequency.
+No spectral leakage is visible, since both signal frequencies are
+exact multiples of the bin width.
 
 
-
-2- and N-D discrete Fourier transforms
-_________________________________________________
+2-D and N-D DFT
+_______________
 
 The functions :func:`fft2` and :func:`ifft2` provide 2-D FFT and
 IFFT, respectively. Similarly, :func:`fftn` and :func:`ifftn` provide
@@ -399,7 +537,7 @@ giving a correctly normalized result.
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 
 Analogous results can be seen for the DCT-I, which is its own inverse up to a
-factor of :math:`2(N-1)`.
+factor of :math:`2(N-1).`
 
 >>> dct(dct(x, type=1, norm='ortho'), type=1, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
@@ -410,7 +548,7 @@ array([ 8. ,  16.,  8. , -8. ,  12.])
 >>> idct(dct(x, type=1), type=1)
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 
-And for the DCT-IV, which is also its own inverse up to a factor of :math:`2N`.
+And for the DCT-IV, which is also its own inverse up to a factor of :math:`2N.`
 
 >>> dct(dct(x, type=4, norm='ortho'), type=4, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
@@ -557,7 +695,7 @@ giving a correctly normalized result.
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 
 Analogous results can be seen for the DST-I, which is its own inverse up to a
-factor of :math:`2(N-1)`.
+factor of :math:`2(N-1).`
 
 >>> dst(dst(x, type=1, norm='ortho'), type=1, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
@@ -568,7 +706,7 @@ array([ 12.,  24.,  12., -12.,  18.])
 >>> idst(dst(x, type=1), type=1)
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
 
-And for the DST-IV, which is also its own inverse up to a factor of :math:`2N`.
+And for the DST-IV, which is also its own inverse up to a factor of :math:`2N.`
 
 >>> dst(dst(x, type=4, norm='ortho'), type=4, norm='ortho')
 array([ 1. ,  2. ,  1. , -1. ,  1.5])
@@ -612,6 +750,313 @@ the output array can be slightly shifted by an offset computed using the
 ``fhtoffset`` function.
 
 
+Appendix
+--------
+
+The applications of Fourier transforms are too many to be listed here.
+The aim of this appendix is to give some insight on how to interpret
+a spectrum, rather than to introduce domain specific applications.
+
+Spectral leakage
+________________
+
+Let :math:`x[n]` be a sequence of length :math:`N,` which represents samples
+from a continuous-time signal :math:`x(t),` taken at time :math:`t=n\,T_s.`
+Its DFT :math:`y[k]` represents the complex spectum of these samples at
+frequency :math:`f=k\,F_p,` where :math:`F_p = 1/(N\,T_s)` is the bin width.
+The sequence :math:`y[k]` can be extended to a continuous-frequency function
+:math:`y(f),` by substituting :math:`k=f/F_p` in the definition of DFT.
+This function is periodic with period equal to :math:`F_s=1/T_s.`
+We can consider that :math:`y(f)` reveals the complex spectrum at
+fractional values of :math:`k=f/F_p.` Notice that using the inverse DFT,
+the function :math:`y(f)` can be expressed in terms of the sequence
+:math:`y[k],` therefore both contain the same information about the
+sequence :math:`x[n].`
+
+An easy way to calculate the complex spectrum :math:`y(f),` is to append
+:math:`(M-1)\,N` zeros at the end of the sequence :math:`x[n].`
+The extended sequence has length :math:`M\,N` and its FFT gives the
+values of :math:`y(f)` with resolution :math:`F_p/M,`
+as shown in the following example.
+
+.. plot::
+    :alt: "This code calculates the spectrum of a signal at high resolution, using zero-extension. and plots its amplitude in dB, i.e., in 20*log10. The spectrum contains three peaks, at zero frequency, at 50 Hz and at 125 Hz. Two inset axes show more detail around the peaks at 50 Hz and 125 Hz."
+
+    >>> from scipy.fft import rfft, rfftfreq
+    >>> import numpy as np
+    >>> M = 10         # number of segments
+    >>> N = 400        # number of samples per segment
+    >>> Fs = 800.0     # sampling frequency in Hz
+    >>> Ts = 1.0 / Fs  # sampling time (step) in s
+    >>> Tp = N / Fs    # sampling period in s (one segment)
+    >>> Fp = Fs / N    # main bin width in Hz
+    >>> Fq = Fp / M    # sub-bin width in Hz
+    >>> Fx = np.array([0.0, 50.0, 125.0])            # signal frequencies in Hz
+    >>> Ax = np.array([0.2, 0.8, 0.6])               # signal amplitudes
+    >>> t = np.linspace(0.0, Tp, N, endpoint=False)  # time in s (one segment)
+    >>> f = rfftfreq(M*N, Ts)                        # frequency in Hz
+    >>> x = np.zeros(M*N)
+    >>> x[:N] = np.sum(Ax[:,np.newaxis]*np.cos(2.0*np.pi*np.outer(Fx,t)), axis=0)
+    >>> yr = rfft(x)
+    >>> ya = 20.0*np.log10(2.0/N * np.abs(yr))
+    >>>
+    >>> # plot ya vs. f in the range [0, Fs/2]
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(figsize=(7,4))
+    >>> fig.tight_layout()
+    >>> ax.plot(f, ya)
+    >>>
+    >>> # decorations
+    >>> for i in range(len(Fx)):
+    >>>     a = 20*np.log10(Ax[i] if i > 0 else 2*Ax[i])
+    >>>     ax.plot(Fx[i]+np.array([[-6.0, 6.0], [-3.0, 3.0]]), a*np.r_[1.0, 1.0], 'g')
+    >>> ax.set_ylim(-60.0, 0.0)
+    >>> ax.set_title(f'M={M}, N={N}, Fp/M={Fq}, Fp={Fp} Hz, Fs={Fs} Hz')
+    >>> ax.set_xlabel('f [Hz]')
+    >>> ax.set_ylabel('2/N |y| [dB]')
+    >>> ax.grid()
+    >>> for i in (1, 2):
+    >>>     axi = fig.add_axes([0.35+0.22*i, 0.45, 0.13, 0.4])
+    >>>     k = np.r_[int(Fx[i]/Fq+0.3)-4*M:int(Fx[i]/Fq+0.8)+4*M+1]
+    >>>     axi.plot(f[k], ya[k])
+    >>>     axi.set_xlim(f[k[0]], f[k[-1]])
+    >>>     axi.set_ylim(-60.0, 0.0)
+    >>>     axi.grid()
+    >>> plt.show()
+
+The amplitude of the spectrum is shown in dB, i.e., in 20*log10.
+As it is revealed by this example, each sinusoidal component in the signal,
+including the bias at zero frequency, appears with a common pattern around
+its frequency. This pattern is called "spectral leakage".
+
+For a complex exponential signal of the form
+
+.. math::
+
+    x[n] = e^{j 2 \pi F_x n T_s} \, ,
+
+where :math:`F_x` is the signal frequency, it can be shown that
+
+.. math::
+
+    \big|\frac{1}{N}\,y(f)\big| = |{\rm sinc}_N(\frac{f-F_x}{F_p})| \, ,
+
+where
+
+.. math::
+
+    {\rm sinc}_N(u) = \frac{\sin(\pi u)}{N\,\sin(\pi u/N)}
+
+is the "periodic sampling function" with period :math:`N.`
+
+This pattern has a main peak at the signal frequency :math:`F_x,`
+and zeros at all integer multiples of :math:`F_p` relative to :math:`F_x,`
+excluding integer multiples of :math:`F_s`
+(since the spectrum has period :math:`F_s`).
+In the worst case, the signal frequency is in the middle between
+two bin frequencies, and the amplitude in these two bins is scaled
+by :math:`2/\pi`, i.e., it appears 4 dB below the actual peak.
+The side peaks are close to integer-plus-half multiples of :math:`F_p`
+relative to :math:`F_x.`
+When the spectrum is plotted in dB, the envelop of the spectral leakage
+near the main peak takes the form of a negative logarithmic function,
+which falls by 6 dB (or 1 bit in log2) per doubling of the distance
+from the main peak.
+The second peak is 13 dB below the main peak, while the spectral leakage 
+at the far end (at distance :math:`F_s/2`) is :math:`1/N.`
+This spectral leakage is prohibitively high for most signal processing
+applications.
+
+For :math:`F_x=0,` the signal is :math:`x[n]=1,` therefore the
+spectral leakage pattern is the spectrum of the rectangular window
+(:math:`N` ones followed by zeros).
+
+
+Windows
+_______
+
+The standard way to reduce spectral leakage is to pre-mulitply the signal
+sequence :math:`x[n]` with a "window" sequence :math:`w[n]` of the same length,
+before the calculation of FFT.
+Typically the window sequence :math:`w[n]` is a smooth function of :math:`n,`
+with a peak at the center and zero or small values at the ends of the range
+of :math:`n,` such that the transition into and out of the sampling period
+is much smoother that with the (implied) rectangular window.
+There is a big number of useful windows, with different trade-offs between
+their performance parameters (see [WPW]_ and [Har78]_).
+
+Two of the windows available in scipy.signal.windows are shown below as an example:
+the Blackman window and the Dolph–Chebyshev window with 100 dB attenuation.
+
+.. plot::
+    :alt: "This code generates a plot of (1) the  Blackman window, and (2) the Dolph–Chebyshev window with 100 dB attenuation. Both window functions have a peak at the center of the horizontal axis. Their maximum value is normalized to 1."
+
+    >>> from scipy.signal import windows
+    >>> import numpy as np
+    >>> N = 400  # window length
+    >>> n = np.r_[:N]
+    >>> # plot w[n] vs. n
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(figsize=(7,4))
+    >>> fig.tight_layout()
+    >>> ax.plot(n, windows.blackman(N), 'g', label='blackman')
+    >>> ax.plot(n, windows.chebwin(N, at=100), 'r', label='cheb(100)')
+    >>> ax.legend()
+    >>>
+    >>> # decorations
+    >>> ax.set_title(f'N={N}')
+    >>> ax.set_xlabel('n')
+    >>> ax.set_ylabel('w[n]')
+    >>> ax.grid()
+    >>> plt.show()
+
+Their spectrum, which shows also their spectral leakage pattern,
+is calculated and plotted with the following code:
+
+.. plot::
+    :alt: "This code generates calculates and plots the spectrum of three windows: (1) the rectangular window, (2) the  Blackman window, and (3) the Dolph–Chebyshev window with 100 dB attenuation. The main axes shows the spectrum at integer-plus-half bin width, which is approximately equal to the envelop of the spectral leakage. An inset axes shows a detail of the spectrum for the first 6 bins."
+
+    >>> from scipy.fft import rfft, rfftfreq
+    >>> from scipy.signal import windows
+    >>> import numpy as np
+    >>> M = 10   # number of segments
+    >>> N = 400  # window length
+    >>> f = rfftfreq(M*N, 1.0/N)  # normalized frequency
+    >>> x = np.zeros((3, M*N))    # space for 3 windows
+    >>> x[0,:N] = np.ones(N)
+    >>> x[1,:N] = windows.blackman(N)
+    >>> x[2,:N] = windows.chebwin(N, at=100)
+    >>> yr = rfft(x, axis=1)
+    >>> eps = np.spacing(1.0)
+    >>> ya = 20.0*np.log10(eps + np.abs(yr) / np.sum(x, axis=1, keepdims=True))
+    >>> # envelop of ya
+    >>> fm = f[:-1].reshape(-1,M)
+    >>> yam = ya[:,:-1].reshape(3,-1,M)
+    >>> ke = np.argmax(yam, axis=-1)
+    >>> fe = np.take_along_axis(fm[np.newaxis], ke[:,:,np.newaxis], axis=-1).squeeze(axis=-1)
+    >>> yae = np.take_along_axis(yam, ke[:,:,np.newaxis], axis=-1).squeeze(axis=-1)
+    >>>
+    >>> # plot normalized spectrum vs. normalized frequency
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(figsize=(7,4))
+    >>> fig.tight_layout()
+    >>> ax.set_prop_cycle(color=['b', 'g', 'r'])
+    >>> ax.plot(fe.T, yae.T)
+    >>> ax.legend(['rectangle', 'blackman', 'cheb(100)'])
+    >>>
+    >>> # decorations
+    >>> ax.set_xlim(-1, N//2+1)
+    >>> ax.set_ylim(-150.0, 10.0)
+    >>> ax.set_title(f'N={N}, Fp=1, Fs={N}')
+    >>> ax.set_xlabel('normalized frequency (f/Fp)')
+    >>> ax.set_ylabel('normalized spectrum [dB]')
+    >>> ax.grid()
+    >>> axi = fig.add_axes([0.5, 0.2, 0.4, 0.5])
+    >>> axi.set_prop_cycle(color=['b', 'g', 'r'])
+    >>> ki = np.r_[0:M*6+1]
+    >>> axi.plot(f[ki], ya[:,ki].T)
+    >>> axi.set_xlim(0.0, 6.0)
+    >>> axi.set_ylim(-130.0, 10.0)
+    >>> axi.grid()
+    >>> plt.show()
+
+In the previous plot, the frequency is normalized such that the
+bin frequencies are the integer values in the horizontal axis
+(this is achieved by setting the sampling time equal to :math:`1/N`).
+The amplitude is normalized such that its value at zero frequency is 0 dB
+(this is achieved by dividing either the window function or its spectum
+by the sum of the window sequence).
+The inset shows the amplitude for the first few bins.
+As it is seen, the amplitude has large variation over the continuous frequency,
+due to the zero values at or near every bin frequency.
+The main plot shows the envelop of the amplitude vs. frequency,
+which is also the worst-case pattern for the spectral leakage.
+
+These three windows are applied to a signal as shown below.
+
+.. plot::
+    :alt: "This code calculates and plots the spectrum of a signal using three different windows: (1) rectangular, (2) Blackman, and (3) Dolph–Chebyshev window with 100 dB attenuation. The spectrum contains three peaks: at zero frequency, at 50 Hz and at 125 Hz. An inset axes shows the spectral leakage in more detail, around the peak at 125 Hz."
+
+    >>> from scipy.fft import rfft, rfftfreq
+    >>> from scipy.signal import windows
+    >>> import numpy as np
+    >>> N = 400        # number of samples
+    >>> Fs = 800.0     # sampling frequency in Hz
+    >>> Ts = 1.0 / Fs  # sampling time (step) in s
+    >>> Tp = N / Fs    # sampling period (total) in s
+    >>> Fp = Fs / N    # bin width (frequency resolution) in Hz
+    >>> Fx = np.array([0.0, 50.0, 125.0])            # signal frequencies in Hz
+    >>> Ax = np.array([0.2, 0.8, 0.6])               # signal amplitudes
+    >>> t = np.linspace(0.0, Tp, N, endpoint=False)  # time in s
+    >>> f = rfftfreq(N, Ts)                          # frequency in Hz
+    >>> w = np.empty((3, N))                         # space for 3 windows
+    >>> w[0,:N] = np.ones(N)
+    >>> w[1,:N] = windows.blackman(N)
+    >>> w[2,:N] = windows.chebwin(N, at=100)
+    >>> x = w * np.sum(Ax[:,np.newaxis]*np.cos(2.0*np.pi*np.outer(Fx,t)), axis=0)
+    >>> yr = rfft(x, axis=1)
+    >>> eps = np.spacing(1.0)
+    >>> ya = 20.0*np.log10(eps + 2.0 * np.abs(yr) / np.sum(w, axis=1, keepdims=True))
+    >>>
+    >>> # plot normalized spectrum vs. f for different windows
+    >>> import matplotlib.pyplot as plt
+    >>> fig, ax = plt.subplots(figsize=(7,4))
+    >>> fig.tight_layout()
+    >>> ax.set_prop_cycle(color=['b', 'g', 'r'])
+    >>> ax.plot(f, ya.T)
+    >>> ax.legend(['rectangle', 'blackman', 'cheb(100)'])
+    >>>
+    >>> # decorations
+    >>> for i in range(len(Fx)):
+    >>>     a = 20.0*np.log10(Ax[i] if i > 0 else 2*Ax[i])
+    >>>     ax.plot(Fx[i]+np.array([[-6.0, 6.0], [-3.0, 3.0]]), a*np.r_[1.0, 1.0], 'g')
+    >>> ax.set_ylim(-120.0, 0.0)
+    >>> ax.set_title(f'N={N}, Fp={Fp} Hz, Fs={Fs} Hz')
+    >>> ax.set_xlabel('f [Hz]')
+    >>> ax.set_ylabel('amplitude [dB]')
+    >>> ax.grid()
+    >>> axi = fig.add_axes([0.55, 0.22, 0.3, 0.5])
+    >>> axi.set_prop_cycle(color=['b', 'g', 'r'])
+    >>> ki = np.r_[int(Fx[2]/Fp+0.3)-10:int(Fx[2]/Fp+0.8)+11]
+    >>> axi.plot(f[ki], ya[:,ki].T)
+    >>> axi.set_xlim(f[ki[0]], f[ki[-1]])
+    >>> axi.set_ylim(-120.0, 0.0)
+    >>> axi.grid()
+    >>> plt.show()
+
+As it is seen in the last example, if the frequency of a sinusoidal
+component is an exact multiple of the bin width, then this component
+appears as an impulse when a rectangular window (no window) is used,
+which is the best possible pattern, while with other windows
+it appears to be broader than an impulse.
+However, except for the bias which is always at zero frequency,
+this condition is seldom true (usually also the assumption that the
+energy of a signal component is concentated at one frequency is not true).
+
+The main requirements in the design of a window function are the following:
+
+* It must be time-limited, i.e., its duration is equal to a parameter :math:`N.`
+
+* The gain within the first bin must be flat, otherwise the reading of the
+  amplitude at a peak does not give a good estimate of the actual (hidden) peak.
+
+* The passband bandwidth must be small, otherwise the width of a sinusoidal
+  or narrow-bandwidth component is too big.
+
+* The attenuation outside of the passband must increase rapidly with frequency,
+  otherwise the spectral leakage is too big.
+
+In addition, a window function must be easy to calculate for any length :math:`N.`
+As it is seen in previous examples, in order to fulfill these requirements,
+the window functions are smooth. However, a function which is smooth and
+has a bell-like shape, is not necessarily a good window function.
+For example, the product of two (same or different) window functions is
+also a smooth function, but its passband bandwidth is increased without
+much (or any) improvement in stopband attenuation.
+This means that it is not a good idea to apply a second window in order
+to reduce the spectral leakage.
+
+
 References
 ----------
 
@@ -623,12 +1068,15 @@ References
         2007, *Numerical Recipes: The Art of Scientific Computing*, ch.
         12-13.  Cambridge Univ. Press, Cambridge, UK.
 
-.. [Mak] J. Makhoul, 1980, 'A Fast Cosine Transform in One and Two Dimensions',
-       `IEEE Transactions on acoustics, speech and signal processing`
+.. [Mak] J. Makhoul, 1980, "A fast cosine transform in one and two dimensions",
+       `IEEE Trans. Acoustics, Speech, and Signal Processing`,
        vol. 28(1), pp. 27-34, :doi:`10.1109/TASSP.1980.1163351`
 
 .. [Ham00] A. J. S. Hamilton, 2000, "Uncorrelated modes of the non-linear power
        spectrum", *MNRAS*, 312, 257. :doi:`10.1046/j.1365-8711.2000.03071.x`
+
+.. [Har78] F. J. Harris, 1978, "On the use of windows for harmonic analysis
+       with the discrete Fourier transform", `Proc. IEEE`, vol. 66(1), pp. 51-83.
 
 .. [WPW] https://en.wikipedia.org/wiki/Window_function
 

--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -891,7 +891,7 @@ the Blackman window and the Dolph–Chebyshev window with 100 dB attenuation.
     >>> fig, ax = plt.subplots(figsize=(7,4))
     >>> fig.tight_layout()
     >>> ax.plot(n, windows.blackman(N, sym=False), 'g', label='blackman')
-    >>> ax.plot(n, windows.chebwin(N, at=100, sym=False), 'r', label='cheb(100)')
+    >>> ax.plot(n, windows.chebwin(N, at=100), 'r', label='cheb(100)')
     >>> ax.legend()
     >>>
     >>> # decorations
@@ -916,7 +916,7 @@ is calculated and plotted with the following code:
     >>> x = np.zeros((3, N))      # space for 3 windows
     >>> x[0,:] = np.ones(N)
     >>> x[1,:] = windows.blackman(N, sym=False)
-    >>> x[2,:] = windows.chebwin(N, at=100, sym=False)
+    >>> x[2,:] = windows.chebwin(N, at=100)
     >>> yr = rfft(x, M*N, axis=1)
     >>> eps = np.spacing(1.0)
     >>> ya = 20.0*np.log10(eps + np.abs(yr) / np.sum(x, axis=1, keepdims=True))
@@ -983,7 +983,7 @@ These three windows are applied to a signal as shown below.
     >>> w = np.empty((3, N))                         # space for 3 windows
     >>> w[0,:] = np.ones(N)
     >>> w[1,:] = windows.blackman(N, sym=False)
-    >>> w[2,:] = windows.chebwin(N, at=100, sym=False)
+    >>> w[2,:] = windows.chebwin(N, at=100)
     >>> x = w * np.sum(Ax[:,np.newaxis]*np.cos(2.0*np.pi*np.outer(Fx,t)), axis=0)
     >>> yr = rfft(x, axis=1)
     >>> eps = np.spacing(1.0)

--- a/doc/source/tutorial/fft.rst
+++ b/doc/source/tutorial/fft.rst
@@ -107,9 +107,9 @@ are shown graphically below.
     >>> ax[1].set_title('Re y[k]')
     >>> ax[2].set_title('Im y[k]')
     >>> for i in (0, 1, 2):
-    >>>     ax[i].set_xlim(-1, 6)
-    >>>     ax[i].set_ylim(-4, 4)
-    >>>     ax[i].grid()
+    ...     ax[i].set_xlim(-1, 6)
+    ...     ax[i].set_ylim(-4, 4)
+    ...     ax[i].grid()
     >>> plt.show()
 
 
@@ -171,22 +171,22 @@ interest for the FFT of a real signal.
     >>>
     >>> # decorations
     >>> for i in range(len(Fx)):
-    >>>     # expected amplitude at frequency Fx[i]
-    >>>     a = Ax[i] if i > 0 else 2*Ax[i]
-    >>>     ax.plot(Fx[i]+np.array([[-6.0, 6.0], [-3.0, 3.0]]), a*np.r_[1.0, 1.0], 'g')
+    ...     # expected amplitude at frequency Fx[i]
+    ...     a = Ax[i] if i > 0 else 2*Ax[i]
+    ...     ax.plot(Fx[i]+np.array([[-6.0, 6.0], [-3.0, 3.0]]), a*np.r_[1.0, 1.0], 'g')
     >>> ax.set_title(f'N={N}, Fp={Fp} Hz, Fs={Fs} Hz')
     >>> ax.set_xlabel('f [Hz]')
     >>> ax.set_ylabel('2/N |y|')
     >>> ax.grid()
     >>> for i in (1, 2):
-    >>>     axi = fig.add_axes([0.35+0.22*i, 0.4, 0.13, 0.4])
-    >>>     # frequency indices around Fx[i]
-    >>>     k = np.r_[int(Fx[i]/Fp+0.3)-4:int(Fx[i]/Fp+0.8)+5]
-    >>>     axi.scatter(f[k], ya[k], marker='o')
-    >>>     axi.plot(np.outer([1, 1], f[k]), np.outer([0, 1], ya[k]), 'b')
-    >>>     axi.set_xlim(f[k[0]]-Fp/2, f[k[-1]]+Fp/2)
-    >>>     axi.set_ylim(-0.1, 0.9)
-    >>>     axi.grid()
+    ...     axi = fig.add_axes([0.35+0.22*i, 0.4, 0.13, 0.4])
+    ...     # frequency indices around Fx[i]
+    ...     k = np.r_[int(Fx[i]/Fp+0.3)-4:int(Fx[i]/Fp+0.8)+5]
+    ...     axi.scatter(f[k], ya[k], marker='o')
+    ...     axi.plot(np.outer([1, 1], f[k]), np.outer([0, 1], ya[k]), 'b')
+    ...     axi.set_xlim(f[k[0]]-Fp/2, f[k[-1]]+Fp/2)
+    ...     axi.set_ylim(-0.1, 0.9)
+    ...     axi.grid()
     >>> plt.show()
 
 
@@ -808,20 +808,20 @@ as shown in the following example.
     >>>
     >>> # decorations
     >>> for i in range(len(Fx)):
-    >>>     a = 20*np.log10(Ax[i] if i > 0 else 2*Ax[i])
-    >>>     ax.plot(Fx[i]+np.array([[-6.0, 6.0], [-3.0, 3.0]]), a*np.r_[1.0, 1.0], 'g')
+    ...     a = 20*np.log10(Ax[i] if i > 0 else 2*Ax[i])
+    ...     ax.plot(Fx[i]+np.array([[-6.0, 6.0], [-3.0, 3.0]]), a*np.r_[1.0, 1.0], 'g')
     >>> ax.set_ylim(-60.0, 0.0)
     >>> ax.set_title(f'M={M}, N={N}, Fp/M={Fq}, Fp={Fp} Hz, Fs={Fs} Hz')
     >>> ax.set_xlabel('f [Hz]')
     >>> ax.set_ylabel('2/N |y| [dB]')
     >>> ax.grid()
     >>> for i in (1, 2):
-    >>>     axi = fig.add_axes([0.35+0.22*i, 0.45, 0.13, 0.4])
-    >>>     k = np.r_[int(Fx[i]/Fq+0.3)-4*M:int(Fx[i]/Fq+0.8)+4*M+1]
-    >>>     axi.plot(f[k], ya[k])
-    >>>     axi.set_xlim(f[k[0]], f[k[-1]])
-    >>>     axi.set_ylim(-60.0, 0.0)
-    >>>     axi.grid()
+    ...     axi = fig.add_axes([0.35+0.22*i, 0.45, 0.13, 0.4])
+    ...     k = np.r_[int(Fx[i]/Fq+0.3)-4*M:int(Fx[i]/Fq+0.8)+4*M+1]
+    ...     axi.plot(f[k], ya[k])
+    ...     axi.set_xlim(f[k[0]], f[k[-1]])
+    ...     axi.set_ylim(-60.0, 0.0)
+    ...     axi.grid()
     >>> plt.show()
 
 The amplitude of the spectrum is shown in dB, i.e., in 20*log10.
@@ -1008,8 +1008,8 @@ These three windows are applied to a signal as shown below.
     >>>
     >>> # decorations
     >>> for i in range(len(Fx)):
-    >>>     a = 20.0*np.log10(Ax[i] if i > 0 else 2*Ax[i])
-    >>>     ax.plot(Fx[i]+np.array([[-6.0, 6.0], [-3.0, 3.0]]), a*np.r_[1.0, 1.0], 'g')
+    ...     a = 20.0*np.log10(Ax[i] if i > 0 else 2*Ax[i])
+    ...     ax.plot(Fx[i]+np.array([[-6.0, 6.0], [-3.0, 3.0]]), a*np.r_[1.0, 1.0], 'g')
     >>> ax.set_ylim(-120.0, 0.0)
     >>> ax.set_title(f'N={N}, Fp={Fp} Hz, Fs={Fs} Hz')
     >>> ax.set_xlabel('f [Hz]')


### PR DESCRIPTION
#### Reference issue
Implements the improvements discussed in #23147.

#### What does this implement/fix?

The section "Fast Fourier transforms" -> "1-D DFT" is completely re-written. The main changes are:
* Corrected the use of `fftfreq`: changed to `rfftfreq` which is more suitable for one-sided spectrum.
* Extended the text with more clarifications.
* Extended the example plots with more details.
* Moved the description of spectral leakage and windows to a new section "Appendix" at the end.

#### Additional information

Appendix: More advanced topics which do not introduce the main fft functions, have been moved at the end, in order to have more space without disturbing the introduction of the main functions. The appendix could be extended with more topics in the future (I could contribute a new section about the power spectral density of random signals).

Decorations in plots: Several examples contain code which improves the appearance of the plot, or adds more details, but in general it is not useful for a real application. This code is labeled as "decorations" with a comment, it appears at the end of the example code, and it is separated from the main code with a blank line, in order to make easier the copy of the useful part in the example code.

Tight layout in plots: There seems to be a problem with the margins in plots, at least with my local renderer. I use tight layout because it makes the plot a little better, but the renderer cuts the labels at the edges (maybe a bug). Anyway the labels are not important, and the same code in jupyterlab produces correct plots, therefore users should not have problems when they copy code from the examples. I tried without the tight layout option, but it looks worse.

Punctuation after `:math:`: Punctuation (comma or full-stop) immediately after a closing backtick has been moved inside the backticks. Without this change, the rendered (or the browser) allows a line break between the math expression and the punctuation, i.e., the next line may start with a comma of full-stop, which is bad style. 

@lucascolley, @DietBru: FYI