### PR TITLE
CI: add cp314/cp314t nighly wheel builds

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,7 +88,7 @@ jobs:
         - [macos-14, macosx, arm64, openblas, "12.3"]
         - [macos-14, macosx, arm64, accelerate, "14.0"]
         - [windows-2022, win, AMD64, "", ""]
-        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"]]
+        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314-dev"], ["cp314t", "cp314-dev"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -183,26 +183,29 @@ jobs:
           fi
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
-      # - name: Inject environment variable for python dev version
-      #   if: ${{ matrix.python[1] == '3.14-dev'
-      #   shell: bash
-      #   run: |
-      #     # For dev versions of python need to use wheels from scientific-python-nightly-wheels
-      #     # When the python version is released please comment out this section, but do not remove
-      #     # (there will soon be another dev version to target).
-      #     DEPS0="pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-      #     DEPS1="pip install ninja meson-python pybind11 pythran cython"
+      - name: Inject environment variable for python dev versions
+        if: ${{ endswith(matrix.python[1], '-dev') }}
+        shell: bash
+        run: |
+          # For dev versions of python need to use wheels from scientific-python-nightly-wheels
+          # When the python version is released please comment out this section, but do not remove
+          # (there will soon be another dev version to target).
+          DEPS0="pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
+          DEPS1="pip install ninja meson-python pybind11 pythran cython"
 
-      #     CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
-      #     echo "CIBW_BEFORE_BUILD_LINUX=$CIBW" >> "$GITHUB_ENV"
+          CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+          echo "CIBW_BEFORE_BUILD_LINUX=$CIBW" >> "$GITHUB_ENV"
 
-      #     CIBW="$DEPS0 && $DEPS1 && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
-      #     echo "CIBW_BEFORE_BUILD_WINDOWS=$CIBW" >> "$GITHUB_ENV"
+          CIBW="$DEPS0 && $DEPS1 && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
+          echo "CIBW_BEFORE_BUILD_WINDOWS=$CIBW" >> "$GITHUB_ENV"
 
-      #     CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
-      #     echo "CIBW_BEFORE_BUILD_MACOS=$CIBW" >> "$GITHUB_ENV"
+          CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+          echo "CIBW_BEFORE_BUILD_MACOS=$CIBW" >> "$GITHUB_ENV"
 
-      #     echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
+          echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
+
+          CIBW="build; args: --no-isolation"
+          echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@5f22145df44122af0f5a201f93cf0207171beca7 # v3.0.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,6 +90,13 @@ jobs:
         - [windows-2022, win, AMD64, "", ""]
         python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314-dev"], ["cp314t", "cp314-dev"]]
         # python[0] is used to specify the python versions made by cibuildwheel
+        exclude:
+            # This combination was hanging consistently with CPython 3.14.0b2, retry later
+          - python: ["cp314t", "cp314-dev"]
+            buildplat: [ubuntu-24.04-arm, musllinux, aarch64, "", ""]
+            # This combination was failing repeatedly on pythran codegen, see gh-23187
+          - python: ["cp314t", "cp314-dev"]
+            buildplat: [ubuntu-22.04, musllinux, x86_64, "", ""]
 
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -2,8 +2,10 @@
 
 """
 
+import platform
 import os
 import random
+import sys
 import zlib
 
 from io import BytesIO
@@ -16,6 +18,7 @@ import numpy as np
 
 from numpy.testing import assert_, assert_equal
 from pytest import raises as assert_raises
+import pytest
 
 from scipy.io.matlab._streams import (make_stream,
     GenericStream, ZlibInputStream,
@@ -194,6 +197,9 @@ class TestZlibInputStream:
         stream.seek(1024)
         assert_(stream.all_data_read())
 
+    @pytest.mark.skipif(
+            (platform.system() == 'Windows' and sys.version_info >= (3, 14)),
+            reason='gh-23185')
     def test_all_data_read_overlap(self):
         COMPRESSION_LEVEL = 6
 
@@ -210,6 +216,9 @@ class TestZlibInputStream:
         stream.seek(len(data))
         assert_(stream.all_data_read())
 
+    @pytest.mark.skipif(
+            (platform.system() == 'Windows' and sys.version_info >= (3, 14)),
+            reason='gh-23185')
     def test_all_data_read_bad_checksum(self):
         COMPRESSION_LEVEL = 6
 

--- a/scipy/stats/tests/test_fast_gen_inversion.py
+++ b/scipy/stats/tests/test_fast_gen_inversion.py
@@ -6,6 +6,7 @@ from numpy.testing import (assert_array_equal, assert_allclose,
 from copy import deepcopy
 from scipy.stats.sampling import FastGeneratorInversion
 from scipy import stats
+from scipy._lib._testutils import IS_MUSL
 
 
 def test_bad_args():
@@ -142,6 +143,7 @@ def test_geninvgauss_uerror():
 
 
 # TODO: add more distributions
+@pytest.mark.skipif(IS_MUSL, reason="Hits RecursionError, see gh-23172")
 @pytest.mark.fail_slow(5)
 @pytest.mark.parametrize(("distname, args"), [("beta", (0.11, 0.11))])
 def test_error_extreme_params(distname, args):


### PR DESCRIPTION
We're about 5-6 weeks away from needing to do a release with Python 3.14 support (see the release schedule in [PEP 745](https://peps.python.org/pep-0745/)), so it'll be good to enable nightly wheels now and fix/report issues. 

There are a couple of tests that needed skipping - issues filed for those: gh-23172, gh-23185. Also, there is one wheel (`cp314t-musllinux_1_2_aarch64`) for which the test suite is hanging. The hang is the most serious problem and needs investigating next. That wheel is probably the least critical of all wheels though, so it's best to get the other ones deployed now.

We shouldn't backport this PR just yet; once 3.14.0rc1 is out and numpy has done a release that supports it, this will be significantly simpler to support on the `maintenance/1.16.x` branch. 