### PR TITLE
MAINT: a few more backports for 1.16.0

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -60,7 +60,8 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click pooch hypothesis array-api-strict spin
+        # array-api-strict pinned because gh-23183
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click pooch hypothesis "array-api-strict<2.4" spin
 
     - name: Install PyTorch CPU
       run: |

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -69,7 +69,8 @@ jobs:
 
     - name: Install JAX
       run: |
-        python -m pip install "jax[cpu]"
+        # Skip 0.6.2: https://github.com/jax-ml/jax/issues/29537
+        python -m pip install "jax[cpu]!=0.6.2"
 
     - name: Install Dask
       run: |

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -51,6 +51,7 @@ jobs:
       uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'  # not using a path to also cache pytorch
 
     - name: Install Ubuntu dependencies
       run: |

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -60,8 +60,7 @@ jobs:
 
     - name: Install Python packages
       run: |
-        # array-api-strict pinned because gh-23183
-        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click pooch hypothesis "array-api-strict<2.4" spin
+        python -m pip install numpy cython pytest pytest-xdist pytest-timeout pybind11 mpmath gmpy2 pythran ninja meson click pooch hypothesis array-api-strict spin
 
     - name: Install PyTorch CPU
       run: |

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -51,7 +51,6 @@ jobs:
       uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'pip'  # not using a path to also cache pytorch
 
     - name: Install Ubuntu dependencies
       run: |

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.12']
         maintenance-branch:
           - ${{ contains(github.ref, 'maintenance/') || contains(github.base_ref, 'maintenance/') }}
         exclude:

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -37,10 +37,6 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.12']
-        maintenance-branch:
-          - ${{ contains(github.ref, 'maintenance/') || contains(github.base_ref, 'maintenance/') }}
-        exclude:
-          - maintenance-branch: true
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pixi.toml
+++ b/.github/workflows/pixi.toml
@@ -97,8 +97,8 @@ test-cupy = { cmd = "python dev.py test -b cupy", cwd = "../.." }
 platforms = ["linux-64"]
 
 [feature.jax-cpu.dependencies]
-jax = "*"
-jaxlib = { version = "*", build = "*cpu*" }
+jax = "!=0.6.2"  # https://github.com/jax-ml/jax/issues/29537
+jaxlib = { version = "!=0.6.2", build = "*cpu*" }
 
 [feature.jax-cuda]
 platforms = ["linux-64"]

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -204,13 +204,6 @@ jobs:
 
       #     echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
 
-      - name: Disable build isolation for python free-threaded version
-        if: endsWith(matrix.python[0], 't')
-        shell: bash
-        run: |
-          CIBW="pip; args: --no-build-isolation"
-          echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
-
       - name: Build wheels
         uses: pypa/cibuildwheel@5f22145df44122af0f5a201f93cf0207171beca7 # v3.0.0
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -212,7 +212,7 @@ jobs:
           echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@d04cacbc9866d432033b1d09142936e6a0e2121a # v2.23.2
+        uses: pypa/cibuildwheel@5f22145df44122af0f5a201f93cf0207171beca7 # v3.0.0
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -245,6 +245,8 @@ Deprecated features
 - `scipy.stats.multinomial` now emits a ``FutureWarning`` if the rows of ``p``
   do not sum to ``1.0``. This condition will produce NaNs beginning in SciPy
   1.18.0.
+- The ``disp`` and ``iprint`` arguments of the ``l-bfgs-b`` solver of `scipy.optimize`
+  have been deprecated, and will be removed in SciPy 1.18.0.
 
 ********************
 Expired Deprecations
@@ -357,7 +359,7 @@ Authors
 * Jake Bowhay (127)
 * Matthew Brett (1)
 * Dietrich Brunn (53)
-* Evgeni Burovski (252)
+* Evgeni Burovski (254)
 * Christine P. Chai (12) +
 * Gayatri Chakkithara (1) +
 * Saransh Chopra (2) +
@@ -371,7 +373,7 @@ Authors
 * Matthew H Flamm (1)
 * Karthik Viswanath Ganti (1) +
 * Neil Girdhar (1)
-* Ralf Gommers (159)
+* Ralf Gommers (162)
 * Rohit Goswami (4)
 * Saarthak Gupta (4) +
 * Matt Haberland (326)
@@ -383,7 +385,7 @@ Authors
 * Yongcai Huang (2) +
 * Lukas Huber (1) +
 * Yuji Ikeda (2) +
-* Guido Imperiale (104) +
+* Guido Imperiale (105) +
 * Robert Kern (2)
 * Harin Khakhi (2) +
 * Agriya Khetarpal (4)
@@ -416,8 +418,8 @@ Authors
 * Giacomo Petrillo (1)
 * Victor PM (10) +
 * pmav99 (1) +
-* Ilhan Polat (73)
-* Tyler Reddy (112)
+* Ilhan Polat (74)
+* Tyler Reddy (128)
 * Érico Nogueira Rolim (1) +
 * Pamphile Roy (10)
 * Mikhail Ryazanov (6)
@@ -652,6 +654,8 @@ Issues closed for 1.16.0
 * `#23068 <https://github.com/scipy/scipy/issues/23068>`__: BUG: sparse: ``!=`` operator with csr matrices
 * `#23109 <https://github.com/scipy/scipy/issues/23109>`__: BUG: spatial.distance.cdist: wrong result in Yule metric
 * `#23169 <https://github.com/scipy/scipy/issues/23169>`__: BUG: special.betainc: evaluates incorrectly to nan when ``b=0``
+* `#23184 <https://github.com/scipy/scipy/issues/23184>`__: BUG: min Python version enforcement in 1.16.x series? (and main)
+* `#23186 <https://github.com/scipy/scipy/issues/23186>`__: BUG: scipy.optimize minimize routine does not show info logs...
 
 ************************
 Pull requests for 1.16.0
@@ -1123,5 +1127,11 @@ Pull requests for 1.16.0
 * `#23127 <https://github.com/scipy/scipy/pull/23127>`__: DOC: fix linkcode_resolve line-number anchors
 * `#23131 <https://github.com/scipy/scipy/pull/23131>`__: REL: set 1.16.0rc3 unreleased
 * `#23134 <https://github.com/scipy/scipy/pull/23134>`__: BUG: linalg.lapack: fix incorrectly sized work array for {c,z}syrti
+* `#23144 <https://github.com/scipy/scipy/pull/23144>`__: MAINT: array types: array-api-strict got stricter
 * `#23146 <https://github.com/scipy/scipy/pull/23146>`__: DOC: stats.Mixture: add example
+* `#23164 <https://github.com/scipy/scipy/pull/23164>`__: MAINT: backports and prep for 1.16.0 "final"
 * `#23170 <https://github.com/scipy/scipy/pull/23170>`__: TST: add all SciPy-specific pytest markers to ``scipy/conftest.py``
+* `#23178 <https://github.com/scipy/scipy/pull/23178>`__: CI: skip JAX 0.6.2
+* `#23180 <https://github.com/scipy/scipy/pull/23180>`__: CI: remove free-threading workarounds in wheel builds
+* `#23189 <https://github.com/scipy/scipy/pull/23189>`__: BLD: implement build-time version check for minimum Python version
+* `#23197 <https://github.com/scipy/scipy/pull/23197>`__: DEP: optimize: Add deprecation warnings to L-BFGS-B ``disp``\...

--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,12 @@ py3 = import('python').find_installation(pure: false)
 py3_dep = py3.dependency()
 
 min_numpy_version = '1.25.2'  # keep in sync with pyproject.toml
+min_python_version = '3.11'   # keep in sync with pyproject.toml
+
+python_version = py3.language_version()
+if python_version.version_compare(f'<@min_python_version@')
+  error(f'Minimum supported Python version is @min_python_version@, found @python_version@')
+endif
 
 # Emit a warning for 32-bit Python installs on Windows; users are getting
 # unexpected from-source builds there because we no longer provide wheels.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,6 @@ test-requires = [
     "pooch",
     "hypothesis",
 ]
-before-test = "bash {project}/tools/wheels/cibw_before_test.sh {project}"
 test-command = "bash {project}/tools/wheels/cibw_test_command.sh {project}"
 
 [tool.cibuildwheel.linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ maintainers = [
 # Note: Python and NumPy upper version bounds should be set correctly in
 # release branches, see:
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
-requires-python = ">=3.11"
+requires-python = ">=3.11"  # keep in sync with `min_python_version` in meson.build
 dependencies = [
     # free-threaded CPython support requires more
     # recent NumPy release at runtime (>= 2.1.3)

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -42,6 +42,8 @@ from ._optimize import (MemoizeJac, OptimizeResult, _call_callback_maybe_halt,
 from ._constraints import old_bound_to_new
 
 from scipy.sparse.linalg import LinearOperator
+from scipy._lib.deprecation import _NoValue
+import warnings
 
 __all__ = ['fmin_l_bfgs_b', 'LbfgsInvHessProduct']
 
@@ -93,7 +95,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
                   approx_grad=0,
                   bounds=None, m=10, factr=1e7, pgtol=1e-5,
                   epsilon=1e-8,
-                  iprint=-1, maxfun=15000, maxiter=15000, disp=None,
+                  iprint=_NoValue, maxfun=15000, maxiter=15000, disp=_NoValue,
                   callback=None, maxls=20):
     """
     Minimize a function func using the L-BFGS-B algorithm.
@@ -144,7 +146,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
         output and this keyword has no function.
 
         .. deprecated:: 1.15.0
-            This keyword is deprecated and will be removed from SciPy 1.17.0.
+            This keyword is deprecated and will be removed from SciPy 1.18.0.
 
     disp : int, optional
         Deprecated option that previously controlled the text printed on the
@@ -152,7 +154,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
         output and this keyword has no function.
 
         .. deprecated:: 1.15.0
-            This keyword is deprecated and will be removed from SciPy 1.17.0.
+            This keyword is deprecated and will be removed from SciPy 1.18.0.
 
     maxfun : int, optional
         Maximum number of function evaluations. Note that this function
@@ -265,7 +267,9 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
 
     # build options
     callback = _wrap_callback(callback)
-    opts = {'maxcor': m,
+    opts = {'disp': disp,
+            'iprint': iprint,
+            'maxcor': m,
             'ftol': factr * np.finfo(float).eps,
             'gtol': pgtol,
             'eps': epsilon,
@@ -288,9 +292,9 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
 
 
 def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
-                     disp=None, maxcor=10, ftol=2.2204460492503131e-09,
+                     disp=_NoValue, maxcor=10, ftol=2.2204460492503131e-09,
                      gtol=1e-5, eps=1e-8, maxfun=15000, maxiter=15000,
-                     iprint=-1, callback=None, maxls=20,
+                     iprint=_NoValue, callback=None, maxls=20,
                      finite_diff_rel_step=None, workers=None,
                      **unknown_options):
     """
@@ -305,7 +309,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         output and this keyword has no function.
 
         .. deprecated:: 1.15.0
-            This keyword is deprecated and will be removed from SciPy 1.17.0.
+            This keyword is deprecated and will be removed from SciPy 1.18.0.
 
     maxcor : int
         The maximum number of variable metric corrections used to
@@ -334,7 +338,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         output and this keyword has no function.
 
         .. deprecated:: 1.15.0
-            This keyword is deprecated and will be removed from SciPy 1.17.0.
+            This keyword is deprecated and will be removed from SciPy 1.18.0.
 
     maxls : int, optional
         Maximum number of line search steps (per iteration). Default is 20.
@@ -373,6 +377,17 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
 
     x0 = asarray(x0).ravel()
     n, = x0.shape
+    if disp is not _NoValue:
+        warnings.warn("scipy.optimize: The `disp` and `iprint` options of the "
+                      "L-BFGS-B solver are deprecated and will be removed in "
+                      "SciPy 1.18.0.",
+                      DeprecationWarning, stacklevel=3)
+
+    if iprint is not _NoValue:
+        warnings.warn("scipy.optimize: The `disp` and `iprint` options of the "
+                      "L-BFGS-B solver are deprecated and will be removed in "
+                      "SciPy 1.18.0.",
+                      DeprecationWarning, stacklevel=3)
 
     # historically old-style bounds were/are expected by lbfgsb.
     # That's still the case but we'll deal with new-style from here on,

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1126,7 +1126,7 @@ class TestOptimizeSimple(CheckOptimize):
 
     def test_minimize_l_bfgs_b(self):
         # Minimize with L-BFGS-B method
-        opts = {'disp': False, 'maxiter': self.maxiter}
+        opts = {'maxiter': self.maxiter}
         r = optimize.minimize(self.func, self.startparams,
                               method='L-BFGS-B', jac=self.grad,
                               options=opts)
@@ -1156,7 +1156,7 @@ class TestOptimizeSimple(CheckOptimize):
         # Check that the `ftol` parameter in l_bfgs_b works as expected
         v0 = None
         for tol in [1e-1, 1e-4, 1e-7, 1e-10]:
-            opts = {'disp': False, 'maxiter': self.maxiter, 'ftol': tol}
+            opts = {'maxiter': self.maxiter, 'ftol': tol}
             sol = optimize.minimize(self.func, self.startparams,
                                     method='L-BFGS-B', jac=self.grad,
                                     options=opts)
@@ -1173,7 +1173,7 @@ class TestOptimizeSimple(CheckOptimize):
         # check that the maxls is passed down to the Fortran routine
         sol = optimize.minimize(optimize.rosen, np.array([-1.2, 1.0]),
                                 method='L-BFGS-B', jac=optimize.rosen_der,
-                                options={'disp': False, 'maxls': 1})
+                                options={'maxls': 1})
         assert not sol.success
 
     def test_minimize_l_bfgs_b_maxfun_interruption(self):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1295,7 +1295,7 @@ class TestMedFilt:
         # us into wrong memory if used (but it does not need to be used)
         dummy = xp.arange(10, dtype=xp.float64)
         a = dummy[5:6]
-        a = xp.lib.stride_tricks.as_strided(a, strides=(16,))
+        a = np.lib.stride_tricks.as_strided(a, strides=(16,))
         xp_assert_close(signal.medfilt(a, 1),  xp.asarray([5.]))
 
     @skip_xp_backends(

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1295,7 +1295,7 @@ class TestMedFilt:
         # us into wrong memory if used (but it does not need to be used)
         dummy = xp.arange(10, dtype=xp.float64)
         a = dummy[5:6]
-        a.strides = 16
+        a = xp.lib.stride_tricks.as_strided(a, strides=(16,))
         xp_assert_close(signal.medfilt(a, 1),  xp.asarray([5.]))
 
     @skip_xp_backends(

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -942,7 +942,7 @@ def monte_carlo_test(data, rvs, statistic, *, vectorized=None,
                      for rvs_i, n_observations_i in zip(rvs, n_observations)]
         null_distribution.append(statistic(*resamples, axis=-1))
     null_distribution = xp.concat(null_distribution)
-    null_distribution = xp.reshape(null_distribution, [-1] + [1]*observed.ndim)
+    null_distribution = xp.reshape(null_distribution, (-1,) + (1,)*observed.ndim)
 
     # relative tolerance for detecting numerically distinct but
     # theoretically equal values in the null distribution

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10975,7 +10975,7 @@ def _xp_mean(x, /, *, axis=None, weights=None, keepdims=False, nan_policy='propa
             for i in axes:
                 final_shape[i] = 1
 
-        res = xp.reshape(res, final_shape)
+        res = xp.reshape(res, tuple(final_shape))
 
     return res[()] if res.ndim == 0 else res
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2053,13 +2053,13 @@ class TestBoxcox_llf:
     def test_axis(self, xp):
         data = xp.asarray([[100, 200], [300, 400]])
         llf_axis_0 = stats.boxcox_llf(1, data, axis=0)
-        llf_0 = xp.asarray([
+        llf_0 = xp.stack([
             stats.boxcox_llf(1, data[:, 0]),
             stats.boxcox_llf(1, data[:, 1]),
         ])
         xp_assert_close(llf_axis_0, llf_0)
         llf_axis_1 = stats.boxcox_llf(1, data, axis=1)
-        llf_1 = xp.asarray([
+        llf_1 = xp.stack([
             stats.boxcox_llf(1, data[0, :]),
             stats.boxcox_llf(1, data[1, :]),
         ])
@@ -2732,11 +2732,11 @@ class TestCircFuncs:
 
         res = circfunc(x, high=360, axis=1)
         ref = [circfunc(x[i, :], high=360) for i in range(x.shape[0])]
-        xp_assert_close(res, xp.asarray(ref))
+        xp_assert_close(res, xp.stack(ref))
 
         res = circfunc(x, high=360, axis=0)
         ref = [circfunc(x[:, i], high=360) for i in range(x.shape[1])]
-        xp_assert_close(res, xp.asarray(ref))
+        xp_assert_close(res, xp.stack(ref))
 
     @pytest.mark.parametrize("test_func,expected",
                              [(stats.circmean, 0.167690146),

--- a/tools/wheels/cibw_before_build_linux.sh
+++ b/tools/wheels/cibw_before_build_linux.sh
@@ -17,17 +17,13 @@ printenv
 # Update license
 cat $PROJECT_DIR/tools/wheels/LICENSE_linux.txt >> $PROJECT_DIR/LICENSE.txt
 
-# TODO: delete along with enabling build isolation by unsetting
-# CIBW_BUILD_FRONTEND when scipy is buildable under free-threaded
-# python with a released version of cython
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    python -m pip install -U --pre pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    python -m pip install git+https://github.com/serge-sans-paille/pythran
-    python -m pip install ninja meson-python pybind11
-fi
+# Not needed anymore, but leave commented out in case we need to start pulling
+# in a dev version of some dependency again.
+#FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
+#if [[ $FREE_THREADED_BUILD == "True" ]]; then
+#    # Workarounds here
+#fi
 
-# Install Openblas
+# Install OpenBLAS
 python -m pip install -r requirements/openblas.txt
 python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > $PROJECT_DIR/scipy-openblas.pc

--- a/tools/wheels/cibw_before_build_macos.sh
+++ b/tools/wheels/cibw_before_build_macos.sh
@@ -59,18 +59,7 @@ if [[ $PLATFORM == "arm64" ]]; then
   type -p gfortran
 fi
 
-# TODO: delete along with enabling build isolation by unsetting
-# CIBW_BUILD_FRONTEND when scipy is buildable under free-threaded
-# python with a released version of cython
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    python -m pip install -U --pre pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    python -m pip install git+https://github.com/serge-sans-paille/pythran
-    python -m pip install ninja meson-python pybind11
-fi
-
-# Install Openblas
+# Install OpenBLAS
 python -m pip install -r requirements/openblas.txt
 python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > $PROJECT_DIR/scipy-openblas.pc
 

--- a/tools/wheels/cibw_before_build_win.sh
+++ b/tools/wheels/cibw_before_build_win.sh
@@ -6,20 +6,9 @@ printenv
 # Update license
 cat $PROJECT_DIR/tools/wheels/LICENSE_win32.txt >> $PROJECT_DIR/LICENSE.txt
 
-# Install Openblas
+# Install OpenBLAS
 python -m pip install -r requirements/openblas.txt
 python -c "import scipy_openblas32; print(scipy_openblas32.get_pkg_config())" > $PROJECT_DIR/scipy-openblas.pc
-
-# TODO: delete along with enabling build isolation by unsetting
-# CIBW_BUILD_FRONTEND when scipy is buildable under free-threaded
-# python with a released version of cython
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    python -m pip install -U --pre pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-    python -m pip install git+https://github.com/serge-sans-paille/pythran
-    python -m pip install ninja meson-python pybind11
-fi
 
 # delvewheel is the equivalent of delocate/auditwheel for windows.
 python -m pip install delvewheel wheel

--- a/tools/wheels/cibw_before_test.sh
+++ b/tools/wheels/cibw_before_test.sh
@@ -1,8 +1,0 @@
-set -ex
-
-FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
-if [[ $FREE_THREADED_BUILD == "True" ]]; then
-    # TODO: delete when numpy is buildable under free-threaded python
-    python -m pip install -U --pre pip
-    python -m pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy cython
-fi


### PR DESCRIPTION
A few more things to tie up before the final `1.16.0` release. Skipping CI for now, until we're ready to go.

Backports included (so far):

1. gh-23178
2. gh-23180
3. gh-23189
4. gh-23144
5. gh-23197
6. gh-23199

TODO:
- [x] handle the Python version check at build time per gh-23184 (Ralf or I will do this in `meson`)
- [x] bump the version of Python used for the array API testing job (should error out with current `3.10` once first point above is handled) on this branch (unless this happens to not be bumped on `main` either, in which case we could backport, but anyway fix that here either way) -- EDIT: need to backport gh-23144
- [x] check the status of CI here again
- [ ] maybe update release notes one more time to get final changes (i.e., scrape in gh-23199); if I do that, probably `[docs only]`

