### PR TITLE
BUG/BENCH: remove unconditional `--quick` from `spin bench --compare`

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -798,7 +798,7 @@ def bench(ctx, tests, submodule, compare, verbose, quick,
             )
 
         cmd_compare = [
-            'asv', 'continuous', '--factor', '1.05', '--quick'
+            'asv', 'continuous', '--factor', '1.05'
         ] + bench_args + [commit_a, commit_b]
         _run_asv(cmd_compare)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Follow-up to gh-23176, see the discussion at gh-23166.

#### What does this implement/fix?
Allows `spin bench` to produce precise timings for comparison benchmarks. The `--quick` option now works as documented (previously it was always active and could not be disabled).

#### Additional information
Should not affect CI benchmark tests, as they call `asv` directly.
