### PR TITLE
 ENH: spatial: optimize performance of `RigidTransform`

### DIFF
--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1,3 +1,5 @@
+import pickle
+
 import pytest
 
 import numpy as np
@@ -1265,3 +1267,14 @@ def test_empty_transform_indexing(xp):
 
     with pytest.raises(IndexError):
         tf_zero[xp.asarray([False, True])]
+
+
+def test_pickling(xp):
+    # Note: Array API makes no provision for arrays to be pickleable, so
+    # it's OK to skip this test for the backends that don't support it
+    mat = xp.eye(4)
+    mat = xpx.at(mat)[0, 3].set(2.0)
+    tf = RigidTransform.from_matrix(mat)
+    pkl = pickle.dumps(tf)
+    unpickled = pickle.loads(pkl)
+    xp_assert_close(tf.as_matrix(), unpickled.as_matrix(), atol=1e-15)


### PR DESCRIPTION
This PR improves the performance of `RigidTransform` after the refactor into a pure `Python` class and a `Cython` backend. 

The bulk of performance losses stem from using `MemoryViews` in `Cython.` While the initial transfer into `Cython` is zero-copy and cheap, some `Cython` functions subsequently require these inputs to be `numpy` arrays instead of `MemoryViews,` which creates new `numpy` arrays. There are two solutions to this: 

- We can change the `Cython` types to `numpy` arrays. This is not recommended by `Cython` as the previous `numpy` typing interface is considered outdated.
- We can avoid calling `Cython` functions where possible

This PR opts for the second solution. In addition, it implements some smaller improvements like caching `xp`.

### Motivation
The refactor in #22972 has introduced some overhead that can be further reduced. See the benchmark below as a motivating example.

![image](https://github.com/user-attachments/assets/97cd42b4-28f4-4d90-b45c-046e60c6e0cd)

### Reference issue
This is a continuation of #22777 and a direct follow-up of #22972.

### Benchmarks
Below is a full benchmark. It compares the previous pure Cython implementation pre-#22972 ("scipy pure cython") with the performance of #22972 ("XP disabled / enabled") and this PR ("optimized XP enabled / disabled"). If Array API features are disabled, some functions have short paths and thus better performance. Hence, we benchmark #22972 and this PR twice, once with XP enabled and once with XP disabled.

[tf_benchmark.pdf](https://github.com/user-attachments/files/20833580/tf_benchmark.pdf)
