### PR TITLE
MAINT: Improve error type for RigidTransform.from_rotation

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -521,9 +521,8 @@ class RigidTransform:
         >>> len(tf)
         2
         """
-        # TODO: Should this not raise a TypeError?
         if not isinstance(rotation, Rotation):
-            raise ValueError(
+            raise TypeError(
                 "Expected `rotation` to be a `Rotation` instance, "
                 f"got {type(rotation)}."
             )

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1009,7 +1009,7 @@ def test_input_validation(xp):
             RigidTransform(matrix, normalize=True)
 
     # Test non-Rotation input
-    with pytest.raises(ValueError,
+    with pytest.raises(TypeError,
                        match="Expected `rotation` to be a `Rotation` instance"):
         RigidTransform.from_rotation(xp.eye(3))
 


### PR DESCRIPTION
A minor change that has come up during #22972. 

#### What does this implement/fix?
`RigidTransform` raises a `ValueError` when the type passed to `RigidTransform.from_rotation` is anything other than an instance of `Rotation,` which really should be a `TypeError.`