### PR TITLE
MAINT, TST: NumPy stride deprecation shim

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1295,7 +1295,7 @@ class TestMedFilt:
         # us into wrong memory if used (but it does not need to be used)
         dummy = xp.arange(10, dtype=xp.float64)
         a = dummy[5:6]
-        a = xp.lib.stride_tricks.as_strided(a, strides=(16,))
+        a = np.lib.stride_tricks.as_strided(a, strides=(16,))
         xp_assert_close(signal.medfilt(a, 1),  xp.asarray([5.]))
 
     @skip_xp_backends(

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1295,7 +1295,7 @@ class TestMedFilt:
         # us into wrong memory if used (but it does not need to be used)
         dummy = xp.arange(10, dtype=xp.float64)
         a = dummy[5:6]
-        a.strides = 16
+        a = xp.lib.stride_tricks.as_strided(a, strides=(16,))
         xp_assert_close(signal.medfilt(a, 1),  xp.asarray([5.]))
 
     @skip_xp_backends(


### PR DESCRIPTION
* This patch allows the SciPy testsuite to pass against NumPy `main` branch, after https://github.com/numpy/numpy/pull/28925 was merged in the last day or so.

We shouldn't really have to backport this, since it is slated for NumPy `2.4.x` series, but if it becomes annoying on the maintenance branch we could backport it since it is a test-only shim (though not running dev version tests on maintenance branches is also something we discussed in the past).