### PR TITLE
Fix miscalculation of norminvgauss CDF when x is very large

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -5526,6 +5526,10 @@ class norminvgauss_gen(rv_continuous):
         sq = np.hypot(1, x)  # reduce overflows
         return fac1 * sc.k1e(a * sq) * np.exp(b*x - a*sq + gamma) / sq
 
+    def _cdf(self, x, a, b):
+        # Use 1 - sf(x) for numerical stability instead of integrating from -inf to x
+        return 1.0 - self._sf(x, a, b)
+
     def _sf(self, x, a, b):
         if np.isscalar(x):
             # If x is a scalar, then so are a and b.


### PR DESCRIPTION
#### Reference issue
Closes #23196 

#### What does this implement/fix?
`norminvgauss` inappropriately used its inherited `_cdf_single` method to calculate the CDF, which worked fine for small values but not for large values. On the other hand, doing `1 - self_sf` in this case should always work. 

#### Additional information
I added a test that fails on the current implementation, but passes on this one. 
