### PR TITLE
DOC :  removes outdated notes from the `medfilt` function 

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1669,14 +1669,6 @@ def medfilt(volume, kernel_size=None):
     scipy.ndimage.median_filter
     scipy.signal.medfilt2d
 
-    Notes
-    -----
-    The more general function `scipy.ndimage.median_filter` has a more
-    efficient implementation of a median filter and therefore runs much faster.
-
-    For 2-dimensional images with ``uint8``, ``float32`` or ``float64`` dtypes,
-    the specialised function `scipy.signal.medfilt2d` may be faster.
-
     """
     xp = array_namespace(volume)
     volume = xp.asarray(volume)


### PR DESCRIPTION
This pull request removes outdated and redundant notes from the `medfilt` function in `scipy/signal/_signaltools.py`. The change simplifies the function's docstring by eliminating a comparison to other functions that may no longer be relevant.

-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->closes #23160


#### What does this implement/fix?
<!--Please explain your changes.-->
removes outdated note
#### Additional information
<!--Any additional information you think is important.-->
