### PR TITLE
DEP: spatial: raise error for complex input to cosine and correlation

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -650,7 +650,7 @@ def correlation(u, v, w=None, centered=True):
     v = _validate_vector(v)
     if np.iscomplexobj(u) or np.iscomplexobj(v):
         msg = "`u` and `v` must be real."
-        raise ValueError(msg)
+        raise TypeError(msg)
     if w is not None:
         w = _validate_weights(w)
         w = w / w.sum()

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -615,14 +615,8 @@ def correlation(u, v, w=None, centered=True):
     ----------
     u : (N,) array_like of floats
         Input array.
-
-        .. deprecated:: 1.15.0
-           Complex `u` is deprecated and will raise an error in SciPy 1.17.0
     v : (N,) array_like of floats
         Input array.
-
-        .. deprecated:: 1.15.0
-           Complex `v` is deprecated and will raise an error in SciPy 1.17.0
     w : (N,) array_like of floats, optional
         The weights for each value in `u` and `v`. Default is None,
         which gives each value a weight of 1.0
@@ -655,10 +649,8 @@ def correlation(u, v, w=None, centered=True):
     u = _validate_vector(u)
     v = _validate_vector(v)
     if np.iscomplexobj(u) or np.iscomplexobj(v):
-        message = (
-            "Complex `u` and `v` are deprecated and will raise an error in "
-            "SciPy 1.17.0.")
-        warnings.warn(message, DeprecationWarning, stacklevel=2)
+        msg = "`u` and `v` must be real."
+        raise ValueError(msg)
     if w is not None:
         w = _validate_weights(w)
         w = w / w.sum()
@@ -702,14 +694,8 @@ def cosine(u, v, w=None):
     ----------
     u : (N,) array_like of floats
         Input array.
-
-        .. deprecated:: 1.15.0
-           Complex `u` is deprecated and will raise an error in SciPy 1.17.0
     v : (N,) array_like of floats
         Input array.
-
-        .. deprecated:: 1.15.0
-           Complex `v` is deprecated and will raise an error in SciPy 1.17.0
     w : (N,) array_like of floats, optional
         The weights for each value in `u` and `v`. Default is None,
         which gives each value a weight of 1.0

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1594,7 +1594,7 @@ class TestSomeDistanceFunctions:
     def test_corr_dep_complex(self, func):
         x = [1+0j, 2+0j]
         y = [3+0j, 4+0j]
-        with pytest.raises(ValueError, match="real"):
+        with pytest.raises(TypeError, match="real"):
             func(x, y)
 
     def test_mahalanobis(self):

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1594,7 +1594,7 @@ class TestSomeDistanceFunctions:
     def test_corr_dep_complex(self, func):
         x = [1+0j, 2+0j]
         y = [3+0j, 4+0j]
-        with pytest.deprecated_call(match="Complex `u` and `v` are deprecated"):
+        with pytest.raises(ValueError, match="real"):
             func(x, y)
 
     def test_mahalanobis(self):


### PR DESCRIPTION
follow up to #21085

Complex inputs are deprecated and scheduled to be removed in this release.