### PR TITLE
TST: stats.ttest_ind: remove test of deprecated/removed `permutations`

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5419,7 +5419,6 @@ class Test_ttest_ind_permutations:
             stats.ttest_ind([1, 2, 3], [4, 5, 6], method='migratory')
 
 
-@pytest.mark.filterwarnings("ignore:Arguments...:DeprecationWarning")
 class Test_ttest_ind_common:
     # for tests that are performed on variations of the t-test (e.g. trimmed)
     @pytest.mark.xslow()

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5421,12 +5421,10 @@ class Test_ttest_ind_permutations:
 
 @pytest.mark.filterwarnings("ignore:Arguments...:DeprecationWarning")
 class Test_ttest_ind_common:
-    # for tests that are performed on variations of the t-test such as
-    # permutations and trimming
+    # for tests that are performed on variations of the t-test (e.g. trimmed)
     @pytest.mark.xslow()
-    @pytest.mark.parametrize("kwds", [{'permutations': 200, 'random_state': 0},
-                                      {'trim': .2}, {}],
-                             ids=["permutations", "trim", "basic"])
+    @pytest.mark.parametrize("kwds", [{'trim': .2}, {}],
+                             ids=["trim", "basic"])
     @pytest.mark.parametrize('equal_var', [True, False],
                              ids=['equal_var', 'unequal_var'])
     def test_ttest_many_dims(self, kwds, equal_var):


### PR DESCRIPTION
#### Reference issue
Closes gh-23204
gh-23188

#### What does this implement/fix?
Removes test of `permutations` argument removed in gh-23188.
