### PR TITLE
CI: always set Python in array API testing

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -37,10 +37,6 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.12']
-        maintenance-branch:
-          - ${{ contains(github.ref, 'maintenance/') || contains(github.base_ref, 'maintenance/') }}
-        exclude:
-          - maintenance-branch: true
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
* Forward port for the fix for: https://github.com/scipy/scipy/pull/23188#issuecomment-2993011648

* In short, I can't think of a good reason to disregard the setting of the matrix Python version in the array API CI job on maintenance branches at this point. This behavior also caused nontrivial loss of developer time for Lucas and I last night, since the `main` branch deviated from the maintenance branch behavior and I'd rather not have this repeated in the next release cycle since it would be easy to forget about and cause more head scratching.

[skip circle]