### PR TITLE
DEP: spatial.distance: remove kulczynski1 and sokalmichener metrics

### DIFF
--- a/benchmarks/benchmarks/spatial.py
+++ b/benchmarks/benchmarks/spatial.py
@@ -359,8 +359,8 @@ class Xdist(Benchmark):
               ['euclidean', 'minkowski', 'cityblock',
                'seuclidean', 'sqeuclidean', 'cosine', 'correlation',
                'hamming', 'jaccard', 'jensenshannon', 'chebyshev', 'canberra',
-               'braycurtis', 'mahalanobis', 'yule', 'dice', 'kulczynski1',
-               'rogerstanimoto', 'russellrao', 'sokalmichener', 'sokalsneath',
+               'braycurtis', 'mahalanobis', 'yule', 'dice',
+               'rogerstanimoto', 'russellrao', 'sokalsneath',
                'minkowski-P3'])
     param_names = ['num_points', 'metric']
 
@@ -392,8 +392,8 @@ class SingleDist(Benchmark):
     params = (['euclidean', 'minkowski', 'cityblock',
                'seuclidean', 'sqeuclidean', 'cosine', 'correlation',
                'hamming', 'jaccard', 'jensenshannon', 'chebyshev', 'canberra',
-               'braycurtis', 'mahalanobis', 'yule', 'dice', 'kulczynski1',
-               'rogerstanimoto', 'russellrao', 'sokalmichener', 'sokalsneath',
+               'braycurtis', 'mahalanobis', 'yule', 'dice',
+               'rogerstanimoto', 'russellrao', 'sokalsneath',
                'minkowski-P3'])
     param_names = ['metric']
 
@@ -425,8 +425,8 @@ class XdistWeighted(Benchmark):
         [10, 20, 100],
         ['euclidean', 'minkowski', 'cityblock', 'sqeuclidean', 'cosine',
          'correlation', 'hamming', 'jaccard', 'chebyshev', 'canberra',
-         'braycurtis', 'yule', 'dice', 'kulczynski1', 'rogerstanimoto',
-         'russellrao', 'sokalmichener', 'sokalsneath', 'minkowski-P3'])
+         'braycurtis', 'yule', 'dice', 'rogerstanimoto',
+         'russellrao', 'sokalsneath', 'minkowski-P3'])
     param_names = ['num_points', 'metric']
 
     def setup(self, num_points, metric):
@@ -454,8 +454,8 @@ class XdistWeighted(Benchmark):
 class SingleDistWeighted(Benchmark):
     params = (['euclidean', 'minkowski', 'cityblock', 'sqeuclidean', 'cosine',
                'correlation', 'hamming', 'jaccard', 'chebyshev', 'canberra',
-               'braycurtis', 'yule', 'dice', 'kulczynski1', 'rogerstanimoto',
-               'russellrao', 'sokalmichener', 'sokalsneath', 'minkowski-P3'])
+               'braycurtis', 'yule', 'dice', 'rogerstanimoto',
+               'russellrao', 'sokalsneath', 'minkowski-P3'])
     param_names = ['metric']
 
     def setup(self, metric):

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -60,10 +60,8 @@ computing the distances between all pairs.
    dice             -- the Dice dissimilarity.
    hamming          -- the Hamming distance.
    jaccard          -- the Jaccard distance.
-   kulczynski1      -- the Kulczynski 1 distance.
    rogerstanimoto   -- the Rogers-Tanimoto dissimilarity.
    russellrao       -- the Russell-Rao dissimilarity.
-   sokalmichener    -- the Sokal-Michener dissimilarity.
    sokalsneath      -- the Sokal-Sneath dissimilarity.
    yule             -- the Yule dissimilarity.
 
@@ -88,7 +86,6 @@ __all__ = [
     'is_valid_y',
     'jaccard',
     'jensenshannon',
-    'kulczynski1',
     'mahalanobis',
     'minkowski',
     'num_obs_dm',
@@ -97,7 +94,6 @@ __all__ = [
     'rogerstanimoto',
     'russellrao',
     'seuclidean',
-    'sokalmichener',
     'sokalsneath',
     'sqeuclidean',
     'squareform',
@@ -116,7 +112,6 @@ import numpy as np
 from scipy._lib._array_api import _asarray
 from scipy._lib._util import _asarray_validated, _transition_to_rng
 from scipy._lib import array_api_extra as xpx
-from scipy._lib.deprecation import _deprecated
 from scipy.linalg import norm
 from scipy.special import rel_entr
 from . import _hausdorff, _distance_pybind, _distance_wrap
@@ -901,86 +896,6 @@ def jaccard(u, v, w=None):
     return (a / b) if b != 0 else np.float64(0)
 
 
-_deprecated_kulczynski1 = _deprecated(
-    "The kulczynski1 metric is deprecated since SciPy 1.15.0 and will be "
-    "removed in SciPy 1.17.0.  Replace usage of 'kulczynski1(u, v)' with "
-    "'1/jaccard(u, v) - 1'."
-)
-
-
-@_deprecated_kulczynski1
-def kulczynski1(u, v, *, w=None):
-    """
-    Compute the Kulczynski 1 dissimilarity between two boolean 1-D arrays.
-
-    .. deprecated:: 1.15.0
-       This function is deprecated and will be removed in SciPy 1.17.0.
-       Replace usage of ``kulczynski1(u, v)`` with ``1/jaccard(u, v) - 1``.
-
-    The Kulczynski 1 dissimilarity between two boolean 1-D arrays `u` and `v`
-    of length ``n``, is defined as
-
-    .. math::
-
-         \\frac{c_{11}}
-              {c_{01} + c_{10}}
-
-    where :math:`c_{ij}` is the number of occurrences of
-    :math:`\\mathtt{u[k]} = i` and :math:`\\mathtt{v[k]} = j` for
-    :math:`k \\in {0, 1, ..., n-1}`.
-
-    Parameters
-    ----------
-    u : (N,) array_like, bool
-        Input array.
-    v : (N,) array_like, bool
-        Input array.
-    w : (N,) array_like, optional
-        The weights for each value in `u` and `v`. Default is None,
-        which gives each value a weight of 1.0
-
-    Returns
-    -------
-    kulczynski1 : float
-        The Kulczynski 1 distance between vectors `u` and `v`.
-
-    Notes
-    -----
-    This measure has a minimum value of 0 and no upper limit.
-    It is un-defined when there are no non-matches.
-
-    .. versionadded:: 1.8.0
-
-    References
-    ----------
-    .. [1] Kulczynski S. et al. Bulletin
-           International de l'Academie Polonaise des Sciences
-           et des Lettres, Classe des Sciences Mathematiques
-           et Naturelles, Serie B (Sciences Naturelles). 1927;
-           Supplement II: 57-203.
-
-    Examples
-    --------
-    >>> from scipy.spatial import distance
-    >>> distance.kulczynski1([1, 0, 0], [0, 1, 0])
-    0.0
-    >>> distance.kulczynski1([True, False, False], [True, True, False])
-    1.0
-    >>> distance.kulczynski1([True, False, False], [True])
-    0.5
-    >>> distance.kulczynski1([1, 0, 0], [3, 1, 0])
-    -3.0
-
-    """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
-    if w is not None:
-        w = _validate_weights(w)
-    (_, nft, ntf, ntt) = _nbool_correspond_all(u, v, w=w)
-
-    return ntt / (ntf + nft)
-
-
 def seuclidean(u, v, V):
     """
     Return the standardized Euclidean distance between two 1-D arrays.
@@ -1596,69 +1511,6 @@ def russellrao(u, v, w=None):
     return float(n - ntt) / n
 
 
-_deprecated_sokalmichener = _deprecated(
-    "The sokalmichener metric is deprecated since SciPy 1.15.0 and will be "
-    "removed in SciPy 1.17.0.  Replace usage of 'sokalmichener(u, v)' with "
-    "'rogerstanimoto(u, v)'."
-)
-
-
-@_deprecated_sokalmichener
-def sokalmichener(u, v, w=None):
-    """
-    Compute the Sokal-Michener dissimilarity between two boolean 1-D arrays.
-
-    .. deprecated:: 1.15.0
-       This function is deprecated and will be removed in SciPy 1.17.0.
-       Replace usage of ``sokalmichener(u, v)`` with ``rogerstanimoto(u, v)``.
-
-    The Sokal-Michener dissimilarity between boolean 1-D arrays `u` and `v`,
-    is defined as
-
-    .. math::
-
-       \\frac{R}
-            {S + R}
-
-    where :math:`c_{ij}` is the number of occurrences of
-    :math:`\\mathtt{u[k]} = i` and :math:`\\mathtt{v[k]} = j` for
-    :math:`k < n`, :math:`R = 2 * (c_{TF} + c_{FT})` and
-    :math:`S = c_{FF} + c_{TT}`.
-
-    Parameters
-    ----------
-    u : (N,) array_like, bool
-        Input array.
-    v : (N,) array_like, bool
-        Input array.
-    w : (N,) array_like, optional
-        The weights for each value in `u` and `v`. Default is None,
-        which gives each value a weight of 1.0
-
-    Returns
-    -------
-    sokalmichener : double
-        The Sokal-Michener dissimilarity between vectors `u` and `v`.
-
-    Examples
-    --------
-    >>> from scipy.spatial import distance
-    >>> distance.sokalmichener([1, 0, 0], [0, 1, 0])
-    0.8
-    >>> distance.sokalmichener([1, 0, 0], [1, 1, 0])
-    0.5
-    >>> distance.sokalmichener([1, 0, 0], [2, 0, 0])
-    -1.0
-
-    """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
-    if w is not None:
-        w = _validate_weights(w)
-    nff, nft, ntf, ntt = _nbool_correspond_all(u, v, w=w)
-    return float(2.0 * (ntf + nft)) / float(ntt + nff + 2.0 * (ntf + nft))
-
-
 def sokalsneath(u, v, w=None):
     """
     Compute the Sokal-Sneath dissimilarity between two boolean 1-D arrays.
@@ -1886,14 +1738,6 @@ _METRIC_INFOS = [
         pdist_func=PDistMetricWrapper('jensenshannon'),
     ),
     MetricInfo(
-        canonical_name='kulczynski1',
-        aka={'kulczynski1'},
-        types=['bool'],
-        dist_func=kulczynski1,
-        cdist_func=_deprecated_kulczynski1(_distance_pybind.cdist_kulczynski1),
-        pdist_func=_deprecated_kulczynski1(_distance_pybind.pdist_kulczynski1),
-    ),
-    MetricInfo(
         canonical_name='mahalanobis',
         aka={'mahalanobis', 'mahal', 'mah'},
         validator=_validate_mahalanobis_kwargs,
@@ -1932,14 +1776,6 @@ _METRIC_INFOS = [
         dist_func=seuclidean,
         cdist_func=CDistMetricWrapper('seuclidean'),
         pdist_func=PDistMetricWrapper('seuclidean'),
-    ),
-    MetricInfo(
-        canonical_name='sokalmichener',
-        aka={'sokalmichener'},
-        types=['bool'],
-        dist_func=sokalmichener,
-        cdist_func=_deprecated_sokalmichener(_distance_pybind.cdist_sokalmichener),
-        pdist_func=_deprecated_sokalmichener(_distance_pybind.pdist_sokalmichener),
     ),
     MetricInfo(
         canonical_name='sokalsneath',
@@ -1991,9 +1827,9 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
         The distance metric to use. The distance function can
         be 'braycurtis', 'canberra', 'chebyshev', 'cityblock',
         'correlation', 'cosine', 'dice', 'euclidean', 'hamming',
-        'jaccard', 'jensenshannon', 'kulczynski1',
+        'jaccard', 'jensenshannon',
         'mahalanobis', 'matching', 'minkowski', 'rogerstanimoto',
-        'russellrao', 'seuclidean', 'sokalmichener', 'sokalsneath',
+        'russellrao', 'seuclidean', 'sokalsneath',
         'sqeuclidean', 'yule'.
     out : ndarray, optional
         The output array.
@@ -2182,47 +2018,23 @@ def pdist(X, metric='euclidean', *, out=None, **kwargs):
         Computes the Dice distance between each pair of boolean
         vectors. (see dice function documentation)
 
-    18. ``Y = pdist(X, 'kulczynski1')``
 
-        Computes the kulczynski1 distance between each pair of
-        boolean vectors. (see kulczynski1 function documentation)
-
-        .. deprecated:: 1.15.0
-           This metric is deprecated and will be removed in SciPy 1.17.0.
-           Replace usage of ``pdist(X, 'kulczynski1')`` with
-           ``1 / pdist(X, 'jaccard') - 1``.
-
-    19. ``Y = pdist(X, 'rogerstanimoto')``
+    18. ``Y = pdist(X, 'rogerstanimoto')``
 
         Computes the Rogers-Tanimoto distance between each pair of
         boolean vectors. (see rogerstanimoto function documentation)
 
-    20. ``Y = pdist(X, 'russellrao')``
+    19. ``Y = pdist(X, 'russellrao')``
 
         Computes the Russell-Rao distance between each pair of
         boolean vectors. (see russellrao function documentation)
 
-    21. ``Y = pdist(X, 'sokalmichener')``
-
-        Computes the Sokal-Michener distance between each pair of
-        boolean vectors. (see sokalmichener function documentation)
-
-        .. deprecated:: 1.15.0
-           This metric is deprecated and will be removed in SciPy 1.17.0.
-           Replace usage of ``pdist(X, 'sokalmichener')`` with
-           ``pdist(X, 'rogerstanimoto')``.
-
-    22. ``Y = pdist(X, 'sokalsneath')``
+    20. ``Y = pdist(X, 'sokalsneath')``
 
         Computes the Sokal-Sneath distance between each pair of
         boolean vectors. (see sokalsneath function documentation)
 
-    23. ``Y = pdist(X, 'kulczynski1')``
-
-        Computes the Kulczynski 1 distance between each pair of
-        boolean vectors. (see kulczynski1 function documentation)
-
-    24. ``Y = pdist(X, f)``
+    21. ``Y = pdist(X, f)``
 
         Computes the distance between all pairs of vectors in X
         using the user supplied 2-arity function f. For example,
@@ -2797,9 +2609,8 @@ def cdist(XA, XB, metric='euclidean', *, out=None, **kwargs):
         The distance metric to use. If a string, the distance function can be
         'braycurtis', 'canberra', 'chebyshev', 'cityblock', 'correlation',
         'cosine', 'dice', 'euclidean', 'hamming', 'jaccard', 'jensenshannon',
-        'kulczynski1', 'mahalanobis', 'matching', 'minkowski',
-        'rogerstanimoto', 'russellrao', 'seuclidean', 'sokalmichener',
-        'sokalsneath', 'sqeuclidean', 'yule'.
+        'mahalanobis', 'matching', 'minkowski', 'rogerstanimoto', 'russellrao',
+        'seuclidean', 'sokalsneath', 'sqeuclidean', 'yule'.
     **kwargs : dict, optional
         Extra arguments to `metric`: refer to each metric documentation for a
         list of all possible arguments.
@@ -2983,44 +2794,24 @@ def cdist(XA, XB, metric='euclidean', *, out=None, **kwargs):
     17. ``Y = cdist(XA, XB, 'dice')``
 
         Computes the Dice distance between the boolean vectors. (see
-        `dice` function documentation)
+        `dice` function documentation).
 
-    18. ``Y = cdist(XA, XB, 'kulczynski1')``
-
-        Computes the kulczynski distance between the boolean
-        vectors. (see `kulczynski1` function documentation)
-
-        .. deprecated:: 1.15.0
-           This metric is deprecated and will be removed in SciPy 1.17.0.
-           Replace usage of ``cdist(XA, XB, 'kulczynski1')`` with
-           ``1 / cdist(XA, XB, 'jaccard') - 1``.
-
-    19. ``Y = cdist(XA, XB, 'rogerstanimoto')``
+    18. ``Y = cdist(XA, XB, 'rogerstanimoto')``
 
         Computes the Rogers-Tanimoto distance between the boolean
         vectors. (see `rogerstanimoto` function documentation)
 
-    20. ``Y = cdist(XA, XB, 'russellrao')``
+    19. ``Y = cdist(XA, XB, 'russellrao')``
 
         Computes the Russell-Rao distance between the boolean
         vectors. (see `russellrao` function documentation)
 
-    21. ``Y = cdist(XA, XB, 'sokalmichener')``
-
-        Computes the Sokal-Michener distance between the boolean
-        vectors. (see `sokalmichener` function documentation)
-
-        .. deprecated:: 1.15.0
-           This metric is deprecated and will be removed in SciPy 1.17.0.
-           Replace usage of ``cdist(XA, XB, 'sokalmichener')`` with
-           ``cdist(XA, XB, 'rogerstanimoto')``.
-
-    22. ``Y = cdist(XA, XB, 'sokalsneath')``
+    20. ``Y = cdist(XA, XB, 'sokalsneath')``
 
         Computes the Sokal-Sneath distance between the vectors. (see
         `sokalsneath` function documentation)
 
-    23. ``Y = cdist(XA, XB, f)``
+    21. ``Y = cdist(XA, XB, f)``
 
         Computes the distance between all pairs of vectors in X
         using the user supplied 2-arity function f. For example,

--- a/scipy/spatial/distance.pyi
+++ b/scipy/spatial/distance.pyi
@@ -34,12 +34,10 @@ _MetricKind = Literal[
     'minkowski', 'mi', 'm', 'pnorm',
     'jaccard', 'jacc', 'ja', 'j',
     'jensenshannon', 'js',
-    'kulczynski1',
     'mahalanobis', 'mahal', 'mah',
     'rogerstanimoto',
     'russellrao',
     'seuclidean', 'se', 's',
-    'sokalmichener',
     'sokalsneath',
     'sqeuclidean', 'sqe', 'sqeuclid',
     'yule',
@@ -138,10 +136,6 @@ def jensenshannon(
     p: ArrayLike, q: ArrayLike, base: float | None = ...
 ) -> np.float64: ...
 
-def kulczynski1(
-    u: ArrayLike, v: ArrayLike, w: ArrayLike | None = ...
-) -> np.float64: ...
-
 def mahalanobis(
     u: ArrayLike, v: ArrayLike, VI: ArrayLike
 ) -> np.float64: ...
@@ -177,10 +171,6 @@ def pdist(
 
 def seuclidean(
     u: ArrayLike, v: ArrayLike, V: ArrayLike
-) -> float: ...
-
-def sokalmichener(
-    u: ArrayLike, v: ArrayLike, w: ArrayLike | None = ...
 ) -> float: ...
 
 def sokalsneath(

--- a/scipy/spatial/src/distance_impl.h
+++ b/scipy/spatial/src/distance_impl.h
@@ -269,21 +269,6 @@ russellrao_distance_char(const char *u, const char *v, const npy_intp n)
     return (double)(n - ntt) / n;
 }
 
-
-static inline double
-kulczynski1_distance_char(const char *u, const char *v, const npy_intp n)
-{
-    npy_intp i;
-    npy_intp ntt = 0, ndiff = 0;
-
-    for (i = 0; i < n; ++i) {
-        const npy_bool x = (u[i] != 0), y = (v[i] != 0);
-        ntt += x & y;
-        ndiff += (x != y);
-    }
-    return ((double)ntt) / ((double)ndiff);
-}
-
 static inline double
 sokalsneath_distance_char(const char *u, const char *v, const npy_intp n)
 {
@@ -296,20 +281,6 @@ sokalsneath_distance_char(const char *u, const char *v, const npy_intp n)
         ndiff += (x != y);
     }
     return (2. * ndiff) / (2. * ndiff + ntt);
-}
-
-static inline double
-sokalmichener_distance_char(const char *u, const char *v, const npy_intp n)
-{
-    npy_intp i;
-    npy_intp ntt = 0, ndiff = 0;
-
-    for (i = 0; i < n; ++i) {
-        const npy_bool x = (u[i] != 0), y = (v[i] != 0);
-        ntt += x & y;
-        ndiff += (x != y);
-    }
-    return (2. * ndiff) / ((double)ndiff + n);
 }
 
 static inline double
@@ -476,10 +447,8 @@ DEFINE_CDIST(sqeuclidean, double)
 
 DEFINE_CDIST(dice, char)
 DEFINE_CDIST(jaccard, char)
-DEFINE_CDIST(kulczynski1, char)
 DEFINE_CDIST(rogerstanimoto, char)
 DEFINE_CDIST(russellrao, char)
-DEFINE_CDIST(sokalmichener, char)
 DEFINE_CDIST(sokalsneath, char)
 DEFINE_CDIST(yule, char)
 
@@ -512,10 +481,8 @@ DEFINE_PDIST(sqeuclidean, double)
 
 DEFINE_PDIST(dice, char)
 DEFINE_PDIST(jaccard, char)
-DEFINE_PDIST(kulczynski1, char)
 DEFINE_PDIST(rogerstanimoto, char)
 DEFINE_PDIST(russellrao, char)
-DEFINE_PDIST(sokalmichener, char)
 DEFINE_PDIST(sokalsneath, char)
 DEFINE_PDIST(yule, char)
 

--- a/scipy/spatial/src/distance_metrics.h
+++ b/scipy/spatial/src/distance_metrics.h
@@ -530,51 +530,6 @@ struct RogerstanimotoDistance {
     }
 };
 
-struct Kulczynski1Distance {
-    template <typename T>
-    struct Acc {
-        Acc(): ntt(0), ndiff(0) {}
-        T ntt, ndiff;
-    };
-
-    template <typename T>
-    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        transform_reduce_2d_<4>(out, x, y, [](T x, T y) INLINE_LAMBDA {
-            Acc<T> acc;
-            acc.ntt = (x != 0) & (y != 0);
-            acc.ndiff = (x != 0) != (y != 0);
-            return acc;
-        },
-        [](const Acc<T>& acc) INLINE_LAMBDA {
-            return acc.ntt / acc.ndiff;
-        },
-        [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {
-            Acc<T> acc;
-            acc.ntt = a.ntt + b.ntt;
-            acc.ndiff = a.ndiff + b.ndiff;
-            return acc;
-        });
-    }
-
-    template <typename T>
-    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
-            Acc<T> acc;
-            acc.ntt = w * ((x != 0) & (y != 0));
-            acc.ndiff = w * ((x != 0) != (y != 0));
-            return acc;
-        },
-        [](const Acc<T>& acc) INLINE_LAMBDA {
-            return acc.ntt / acc.ndiff;
-        },
-        [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {
-            Acc<T> acc;
-            acc.ntt = a.ntt + b.ntt;
-            acc.ndiff = a.ndiff + b.ndiff;
-            return acc;
-        });
-    }
-};
 
 struct RussellRaoDistance {
     template <typename T>
@@ -616,56 +571,6 @@ struct RussellRaoDistance {
         [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {
             Acc<T> acc;
             acc.ntt = a.ntt + b.ntt;
-            acc.n = a.n + b.n;
-            return acc;
-        });
-    }
-};
-
-struct SokalmichenerDistance {
-    template <typename T>
-    struct Acc {
-        Acc(): ntt(0), ndiff(0), n(0) {}
-        T ntt, ndiff, n;
-    };
-
-    template <typename T>
-    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y) const {
-        transform_reduce_2d_<4>(out, x, y, [](T x, T y) INLINE_LAMBDA {
-            Acc<T> acc;
-            acc.ntt = (x != 0) & (y != 0);
-            acc.ndiff = (x != 0) != (y != 0);
-            acc.n = 1;
-            return acc;
-        },
-        [](const Acc<T>& acc) INLINE_LAMBDA {
-            return (2 * acc.ndiff) / (acc.ndiff + acc.n);
-        },
-        [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {
-            Acc<T> acc;
-            acc.ntt = a.ntt + b.ntt;
-            acc.ndiff = a.ndiff + b.ndiff;
-            acc.n = a.n + b.n;
-            return acc;
-        });
-    }
-
-    template <typename T>
-    void operator()(StridedView2D<T> out, StridedView2D<const T> x, StridedView2D<const T> y, StridedView2D<const T> w) const {
-        transform_reduce_2d_(out, x, y, w, [](T x, T y, T w) INLINE_LAMBDA {
-            Acc<T> acc;
-            acc.ntt = w * ((x != 0) & (y != 0));
-            acc.ndiff = w * ((x != 0) != (y != 0));
-            acc.n = w;
-            return acc;
-        },
-        [](const Acc<T>& acc) INLINE_LAMBDA {
-            return (2 * acc.ndiff) / (acc.ndiff + acc.n);
-        },
-        [](const Acc<T>& a, const Acc<T>& b) INLINE_LAMBDA {
-            Acc<T> acc;
-            acc.ntt = a.ntt + b.ntt;
-            acc.ndiff = a.ndiff + b.ndiff;
             acc.n = a.n + b.n;
             return acc;
         });

--- a/scipy/spatial/src/distance_pybind.cpp
+++ b/scipy/spatial/src/distance_pybind.cpp
@@ -572,11 +572,6 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
               return pdist(out, x, w, JaccardDistance{});
           },
           "x"_a, "w"_a=py::none(), "out"_a=py::none());
-    m.def("pdist_kulczynski1",
-          [](py::object x, py::object w, py::object out) {
-              return pdist(out, x, w, Kulczynski1Distance{});
-          },
-          "x"_a, "w"_a=py::none(), "out"_a=py::none());
     m.def("pdist_rogerstanimoto",
           [](py::object x, py::object w, py::object out) {
               return pdist(out, x, w, RogerstanimotoDistance{});
@@ -587,11 +582,7 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
               return pdist(out, x, w, RussellRaoDistance{});
           },
           "x"_a, "w"_a=py::none(), "out"_a=py::none());
-    m.def("pdist_sokalmichener",
-          [](py::object x, py::object w, py::object out) {
-              return pdist(out, x, w, SokalmichenerDistance{});
-          },
-          "x"_a, "w"_a=py::none(), "out"_a=py::none());
+
     m.def("pdist_sokalsneath",
           [](py::object x, py::object w, py::object out) {
               return pdist(out, x, w, SokalsneathDistance{});
@@ -655,11 +646,6 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
               return cdist(out, x, y, w, JaccardDistance{});
           },
           "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
-    m.def("cdist_kulczynski1",
-          [](py::object x, py::object y, py::object w, py::object out) {
-              return cdist(out, x, y, w, Kulczynski1Distance{});
-          },
-          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
     m.def("cdist_hamming",
           [](py::object x, py::object y, py::object w, py::object out) {
               return cdist(out, x, y, w, HammingDistance{});
@@ -673,11 +659,6 @@ PYBIND11_MODULE(_distance_pybind, m, py::mod_gil_not_used()) {
     m.def("cdist_russellrao",
           [](py::object x, py::object y, py::object w, py::object out) {
               return cdist(out, x, y, w, RussellRaoDistance{});
-          },
-          "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
-    m.def("cdist_sokalmichener",
-          [](py::object x, py::object y, py::object w, py::object out) {
-              return cdist(out, x, y, w, SokalmichenerDistance{});
           },
           "x"_a, "y"_a, "w"_a=py::none(), "out"_a=py::none());
     m.def("cdist_sokalsneath",

--- a/scipy/spatial/src/distance_wrap.c
+++ b/scipy/spatial/src/distance_wrap.c
@@ -89,10 +89,8 @@ DEFINE_WRAP_CDIST(sqeuclidean, double)
 
 DEFINE_WRAP_CDIST(dice, char)
 DEFINE_WRAP_CDIST(jaccard, char)
-DEFINE_WRAP_CDIST(kulczynski1, char)
 DEFINE_WRAP_CDIST(rogerstanimoto, char)
 DEFINE_WRAP_CDIST(russellrao, char)
-DEFINE_WRAP_CDIST(sokalmichener, char)
 DEFINE_WRAP_CDIST(sokalsneath, char)
 DEFINE_WRAP_CDIST(yule, char)
 
@@ -381,11 +379,9 @@ DEFINE_WRAP_PDIST(jensenshannon, double)
 DEFINE_WRAP_PDIST(sqeuclidean, double)
 
 DEFINE_WRAP_PDIST(dice, char)
-DEFINE_WRAP_PDIST(kulczynski1, char)
 DEFINE_WRAP_PDIST(jaccard, char)
 DEFINE_WRAP_PDIST(rogerstanimoto, char)
 DEFINE_WRAP_PDIST(russellrao, char)
-DEFINE_WRAP_PDIST(sokalmichener, char)
 DEFINE_WRAP_PDIST(sokalsneath, char)
 DEFINE_WRAP_PDIST(yule, char)
 
@@ -715,9 +711,6 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"cdist_jensenshannon_double_wrap",
    cdist_jensenshannon_double_wrap,
    METH_VARARGS},
-   {"cdist_kulczynski1_bool_wrap",
-   cdist_kulczynski1_char_wrap,
-   METH_VARARGS},
   {"cdist_mahalanobis_double_wrap",
    (PyCFunction) cdist_mahalanobis_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
@@ -739,9 +732,6 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"cdist_seuclidean_double_wrap",
    (PyCFunction) cdist_seuclidean_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
-  {"cdist_sokalmichener_bool_wrap",
-   cdist_sokalmichener_char_wrap,
-   METH_VARARGS},
   {"cdist_sokalsneath_bool_wrap",
    cdist_sokalsneath_char_wrap,
    METH_VARARGS},
@@ -787,9 +777,6 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"pdist_jensenshannon_double_wrap",
    pdist_jensenshannon_double_wrap,
    METH_VARARGS},
-   {"pdist_kulczynski1_bool_wrap",
-   pdist_kulczynski1_char_wrap,
-   METH_VARARGS},
   {"pdist_mahalanobis_double_wrap",
    (PyCFunction) pdist_mahalanobis_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
@@ -811,9 +798,6 @@ static PyMethodDef _distanceWrapMethods[] = {
   {"pdist_seuclidean_double_wrap",
    (PyCFunction) pdist_seuclidean_double_wrap,
    METH_VARARGS | METH_KEYWORDS},
-  {"pdist_sokalmichener_bool_wrap",
-   pdist_sokalmichener_char_wrap,
-   METH_VARARGS},
   {"pdist_sokalsneath_bool_wrap",
    pdist_sokalsneath_char_wrap,
    METH_VARARGS},

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -57,10 +57,9 @@ from scipy.spatial.distance import (
 # jensenshannon  and seuclidean are referenced by string name.
 from scipy.spatial.distance import (braycurtis, canberra, chebyshev, cityblock,
                                     correlation, cosine, dice, euclidean,
-                                    hamming, jaccard, jensenshannon,
-                                    kulczynski1, mahalanobis,
+                                    hamming, jaccard, jensenshannon, mahalanobis,
                                     minkowski, rogerstanimoto,
-                                    russellrao, seuclidean, sokalmichener,  # noqa: F401
+                                    russellrao, seuclidean,  # noqa: F401
                                     sokalsneath, sqeuclidean, yule)
 from scipy._lib._util import np_long, np_ulong
 from scipy.conftest import skip_xp_invalid_arg
@@ -378,20 +377,6 @@ def _weight_checked(fn, n_args=2, default_axis=None, key=lambda x: x, weight_arg
     return wrapped
 
 
-class DummyContextManager:
-    def __enter__(self):
-        pass
-    def __exit__(self, *args):
-        pass
-
-
-def maybe_deprecated(metric: str):
-    if metric in ('kulczynski1', 'sokalmichener'):
-        return pytest.deprecated_call()
-    else:
-        return DummyContextManager()
-
-
 wcdist = _weight_checked(cdist, default_axis=1, squeeze=False)
 wcdist_no_const = _weight_checked(cdist, default_axis=1,
                                   squeeze=False, const_test=False)
@@ -406,14 +391,12 @@ wcityblock = _weight_checked(cityblock)
 wchebyshev = _weight_checked(chebyshev)
 wcosine = _weight_checked(cosine)
 wcorrelation = _weight_checked(correlation)
-wkulczynski1 = _weight_checked(kulczynski1)
 wjaccard = _weight_checked(jaccard)
 weuclidean = _weight_checked(euclidean, const_test=False)
 wsqeuclidean = _weight_checked(sqeuclidean, const_test=False)
 wbraycurtis = _weight_checked(braycurtis)
 wcanberra = _weight_checked(canberra, const_test=False)
 wsokalsneath = _weight_checked(sokalsneath)
-wsokalmichener = _weight_checked(sokalmichener)
 wrussellrao = _weight_checked(russellrao)
 
 
@@ -438,14 +421,11 @@ class TestCdist:
         args = [3.14] * 200
 
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric=metric, **kwargs)
+            cdist(X1, X2, metric=metric, **kwargs)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric=eval(metric), **kwargs)
+            cdist(X1, X2, metric=eval(metric), **kwargs)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric="test_" + metric, **kwargs)
+            cdist(X1, X2, metric="test_" + metric, **kwargs)
         with pytest.raises(TypeError):
             cdist(X1, X2, metric=metric, *args)
         with pytest.raises(TypeError):
@@ -584,11 +564,9 @@ class TestCdist:
             X2 = eo[eo_name][1::5, ::2]
             if verbose > 2:
                 print("testing: ", metric, " with: ", eo_name)
-            if metric in {'dice', 'yule',
-                          'rogerstanimoto',
-                          'russellrao', 'sokalmichener',
-                          'sokalsneath',
-                          'kulczynski1'} and 'bool' not in eo_name:
+            if (metric in {'dice', 'yule', 'rogerstanimoto', 'russellrao',
+                           'sokalsneath'}
+                and 'bool' not in eo_name):
                 # python version permits non-bools e.g. for fuzzy logic
                 continue
             self._check_calling_conventions(X1, X2, metric)
@@ -643,10 +621,8 @@ class TestCdist:
         if metric == 'minkowski':
             kwargs['p'] = 1.23
         out1 = np.empty((out_r, out_c), dtype=np.float64)
-        with maybe_deprecated(metric):
-            Y1 = cdist(X1, X2, metric, **kwargs)
-        with maybe_deprecated(metric):
-            Y2 = cdist(X1, X2, metric, out=out1, **kwargs)
+        Y1 = cdist(X1, X2, metric, **kwargs)
+        Y2 = cdist(X1, X2, metric, out=out1, **kwargs)
 
         # test that output is numerically equivalent
         assert_allclose(Y1, Y2, rtol=eps, verbose=verbose > 2)
@@ -657,25 +633,21 @@ class TestCdist:
         # test for incorrect shape
         out2 = np.empty((out_r-1, out_c+1), dtype=np.float64)
         with pytest.raises(ValueError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric, out=out2, **kwargs)
+            cdist(X1, X2, metric, out=out2, **kwargs)
 
         # test for C-contiguous order
         out3 = np.empty(
             (2 * out_r, 2 * out_c), dtype=np.float64)[::2, ::2]
         out4 = np.empty((out_r, out_c), dtype=np.float64, order='F')
         with pytest.raises(ValueError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric, out=out3, **kwargs)
+            cdist(X1, X2, metric, out=out3, **kwargs)
         with pytest.raises(ValueError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric, out=out4, **kwargs)
+            cdist(X1, X2, metric, out=out4, **kwargs)
 
         # test for incorrect dtype
         out5 = np.empty((out_r, out_c), dtype=np.int64)
         with pytest.raises(ValueError):
-            with maybe_deprecated(metric):
-                cdist(X1, X2, metric, out=out5, **kwargs)
+            cdist(X1, X2, metric, out=out5, **kwargs)
 
     @pytest.mark.thread_unsafe
     def test_striding(self, metric):
@@ -699,10 +671,8 @@ class TestCdist:
         kwargs = dict()
         if metric == 'minkowski':
             kwargs['p'] = 1.23
-        with maybe_deprecated(metric):
-            Y1 = cdist(X1, X2, metric, **kwargs)
-        with maybe_deprecated(metric):
-            Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
+        Y1 = cdist(X1, X2, metric, **kwargs)
+        Y2 = cdist(X1_copy, X2_copy, metric, **kwargs)
         # test that output is numerically equivalent
         assert_allclose(Y1, Y2, rtol=eps, verbose=verbose > 2)
 
@@ -715,8 +685,7 @@ class TestCdist:
         if metric == 'minkowski':
             kwargs['p'] = 1.23
 
-        with maybe_deprecated(metric):
-            out = cdist(x1, x2, metric=metric, **kwargs)
+        out = cdist(x1, x2, metric=metric, **kwargs)
 
         # Check reference counts aren't messed up. If we only hold weak
         # references, the arrays should be deallocated.
@@ -747,14 +716,11 @@ class TestPdist:
         args = [3.14] * 200
 
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                pdist(X1, metric=metric, **kwargs)
+            pdist(X1, metric=metric, **kwargs)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                pdist(X1, metric=eval(metric), **kwargs)
+            pdist(X1, metric=eval(metric), **kwargs)
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                pdist(X1, metric="test_" + metric, **kwargs)
+            pdist(X1, metric="test_" + metric, **kwargs)
         with pytest.raises(TypeError):
             pdist(X1, metric=metric, *args)
         with pytest.raises(TypeError):
@@ -1418,10 +1384,8 @@ class TestPdist:
             X = eo[eo_name][::5, ::2]
             if verbose > 2:
                 print("testing: ", metric, " with: ", eo_name)
-            if metric in {'dice', 'yule', 'matching',
-                          'rogerstanimoto', 'russellrao', 'sokalmichener',
-                          'sokalsneath',
-                          'kulczynski1'} and 'bool' not in eo_name:
+            if metric in {'dice', 'yule', 'matching', 'rogerstanimoto', 'russellrao',
+                          'sokalsneath'} and 'bool' not in eo_name:
                 # python version permits non-bools e.g. for fuzzy logic
                 continue
             self._check_calling_conventions(X, metric)
@@ -1471,10 +1435,8 @@ class TestPdist:
         if metric == 'minkowski':
             kwargs['p'] = 1.23
         out1 = np.empty(out_size, dtype=np.float64)
-        with maybe_deprecated(metric):
-            Y_right = pdist(X, metric, **kwargs)
-        with maybe_deprecated(metric):
-            Y_test1 = pdist(X, metric, out=out1, **kwargs)
+        Y_right = pdist(X, metric, **kwargs)
+        Y_test1 = pdist(X, metric, out=out1, **kwargs)
 
         # test that output is numerically equivalent
         assert_allclose(Y_test1, Y_right, rtol=eps)
@@ -1485,20 +1447,17 @@ class TestPdist:
         # test for incorrect shape
         out2 = np.empty(out_size + 3, dtype=np.float64)
         with pytest.raises(ValueError):
-            with maybe_deprecated(metric):
-                pdist(X, metric, out=out2, **kwargs)
+            pdist(X, metric, out=out2, **kwargs)
 
         # test for (C-)contiguous output
         out3 = np.empty(2 * out_size, dtype=np.float64)[::2]
         with pytest.raises(ValueError):
-            with maybe_deprecated(metric):
-                pdist(X, metric, out=out3, **kwargs)
+            pdist(X, metric, out=out3, **kwargs)
 
         # test for incorrect dtype
         out5 = np.empty(out_size, dtype=np.int64)
         with pytest.raises(ValueError):
-            with maybe_deprecated(metric):
-                pdist(X, metric, out=out5, **kwargs)
+            pdist(X, metric, out=out5, **kwargs)
 
     @pytest.mark.thread_unsafe
     def test_striding(self, metric):
@@ -1515,10 +1474,8 @@ class TestPdist:
         kwargs = dict()
         if metric == 'minkowski':
             kwargs['p'] = 1.23
-        with maybe_deprecated(metric):
-            Y1 = pdist(X, metric, **kwargs)
-        with maybe_deprecated(metric):
-            Y2 = pdist(X_copy, metric, **kwargs)
+        Y1 = pdist(X, metric, **kwargs)
+        Y2 = pdist(X_copy, metric, **kwargs)
         # test that output is numerically equivalent
         assert_allclose(Y1, Y2, rtol=eps, verbose=verbose > 2)
 
@@ -2039,46 +1996,6 @@ def test_sqeuclidean_dtypes():
 
 
 @pytest.mark.thread_unsafe
-def test_sokalmichener():
-    # Test that sokalmichener has the same result for bool and int inputs.
-    p = [True, True, False]
-    q = [True, False, True]
-    x = [int(b) for b in p]
-    y = [int(b) for b in q]
-    with pytest.deprecated_call():
-        dist1 = sokalmichener(p, q)
-    with pytest.deprecated_call():
-        dist2 = sokalmichener(x, y)
-    # These should be exactly the same.
-    assert_equal(dist1, dist2)
-
-
-@pytest.mark.thread_unsafe
-def test_sokalmichener_with_weight():
-    # from: | 1 |   | 0 |
-    # to:   | 1 |   | 1 |
-    # weight|   | 1 |   | 0.2
-    ntf = 0 * 1 + 0 * 0.2
-    nft = 0 * 1 + 1 * 0.2
-    ntt = 1 * 1 + 0 * 0.2
-    nff = 0 * 1 + 0 * 0.2
-    expected = 2 * (nft + ntf) / (ntt + nff + 2 * (nft + ntf))
-    assert_almost_equal(expected, 0.2857143)
-    with pytest.deprecated_call():
-        actual = sokalmichener([1, 0], [1, 1], w=[1, 0.2])
-    assert_almost_equal(expected, actual)
-
-    a1 = [False, False, True, True, True, False, False, True, True, True, True,
-          True, True, False, True, False, False, False, True, True]
-    a2 = [True, True, True, False, False, True, True, True, False, True,
-          True, True, True, True, False, False, False, True, True, True]
-
-    for w in [0.05, 0.1, 1.0, 20.0]:
-        with pytest.deprecated_call():
-            assert_almost_equal(sokalmichener(a2, a1, [w]), 0.6666666666666666)
-
-
-@pytest.mark.thread_unsafe
 def test_modifies_input(metric):
     # test whether cdist or pdist modifies input arrays
     X1 = np.asarray([[1., 2., 3.],
@@ -2086,10 +2003,8 @@ def test_modifies_input(metric):
                      [2.2, 2.3, 4.4],
                      [22.2, 23.3, 44.4]])
     X1_copy = X1.copy()
-    with maybe_deprecated(metric):
-        cdist(X1, X1, metric)
-    with maybe_deprecated(metric):
-        pdist(X1, metric)
+    cdist(X1, X1, metric)
+    pdist(X1, metric)
     assert_array_equal(X1, X1_copy)
 
 
@@ -2116,12 +2031,10 @@ def test_Xdist_deprecated_args(metric):
             continue
 
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                cdist(X1, X1, metric, **kwargs)
+            cdist(X1, X1, metric, **kwargs)
 
         with pytest.raises(TypeError):
-            with maybe_deprecated(metric):
-                pdist(X1, metric, **kwargs)
+            pdist(X1, metric, **kwargs)
 
 
 @pytest.mark.thread_unsafe
@@ -2135,11 +2048,9 @@ def test_Xdist_non_negative_weights(metric):
 
     for m in [metric, eval(metric), "test_" + metric]:
         with pytest.raises(ValueError):
-            with maybe_deprecated(metric):
-                pdist(X, m, w=w)
+            pdist(X, m, w=w)
         with pytest.raises(ValueError):
-            with maybe_deprecated(metric):
-                cdist(X, X, m, w=w)
+            cdist(X, X, m, w=w)
 
 
 def test__validate_vector():
@@ -2227,8 +2138,7 @@ def test_immutable_input(metric):
         pytest.skip("not applicable")
     x = np.arange(10, dtype=np.float64)
     x.setflags(write=False)
-    with maybe_deprecated(metric):
-        getattr(scipy.spatial.distance, metric)(x, x, w=x)
+    getattr(scipy.spatial.distance, metric)(x, x, w=x)
 
 
 def test_gh_23109():


### PR DESCRIPTION
Follow up to #21572

These metrics are scheduled to be removed in this release.