### PR TITLE
MAINT: forward port 1.16.0 relnotes

### DIFF
--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,9 +5,14 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.15.3 (stable)",
-        "version":"1.15.3",
+        "name": "1.16.0 (stable)",
+        "version":"1.16.0",
         "preferred": true,
+        "url": "https://docs.scipy.org/doc/scipy-1.16.0/"
+    },
+    {
+        "name": "1.15.3",
+        "version":"1.15.3",
         "url": "https://docs.scipy.org/doc/scipy-1.15.3/"
     },
     {

--- a/doc/source/release/1.16.0-notes.rst
+++ b/doc/source/release/1.16.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.16.0 Release Notes
 ==========================
 
-.. note:: SciPy 1.16.0 is not released yet!
-
 .. contents::
 
 SciPy 1.16.0 is the culmination of 6 months of hard work. It contains
@@ -28,68 +26,74 @@ Highlights of this release
   new support in `scipy.signal`, and additional support in `scipy.stats` and
   `scipy.special`. Improved support for JAX and Dask backends has been added,
   with notable support in `scipy.cluster.hierarchy`, many functions in
-  `scipy.special`, and many of the trimmed ``stats`` functions.
-- ``scipy.optimize`` now uses the new Python implementation from the
+  `scipy.special`, and many of the trimmed statistics functions.
+- `scipy.optimize` now uses the new Python implementation from the
   `PRIMA <https://www.libprima.net>`_ package for COBYLA.
   The PRIMA implementation `fixes many bugs <https://github.com/libprima/prima#bug-fixes>`_
   in the old Fortran 77 implementation with
   `a better performance on average <https://github.com/libprima/prima#improvements>`_.
-- ``scipy.sparse.coo_array`` now supports nD arrays with reshaping, arithmetic and
-  reduction operations like sum/mean/min/max. No nD indexing or ``random_array``
-  support yet.
+- `scipy.sparse.coo_array` now supports n-D arrays with reshaping, arithmetic and
+  reduction operations like sum/mean/min/max. No n-D indexing or
+  `~scipy.sparse.random_array` support yet.
 - Updated guide and tools for migration from sparse matrices to sparse arrays.
-- All functions in the `scipy.linalg` namespace that accept array arguments
-  now support N-dimensional arrays to be processed as a batch.
-- Two new `scipy.signal` functions, ``firwin_2d`` and
-  ``closest_STFT_dual_window``, for creation of a 2-D FIR filter and
-  ``ShortTimeFFT`` dual window calculation, respectivly.
-- A new class, ``RigidTransform``, is available in the ``transform`` submodule.
-  It provides functionality to convert between different representations of
-  rigid transforms in 3D space.
+- Nearly all functions in the `scipy.linalg` namespace that accept array
+  arguments now support N-dimensional arrays to be processed as a batch.
+- Two new `scipy.signal` functions, `~scipy.signal.firwin_2d` and
+  `~scipy.signal.closest_STFT_dual_window`, for creation of a 2-D FIR filter and
+  `~scipy.signal.ShortTimeFFT` dual window calculation, respectively.
+- A new class, `scipy.spatial.transform.RigidTransform`, provides functionality
+  to convert between different representations of rigid transforms in 3-D
+  space.
+- A new function `scipy.ndimage.vectorized_filter` for generic filters that
+  take advantage of a vectorized Python callable was added.
 
 ************
 New features
 ************
 
 ``scipy.io`` improvements
-==============================
-- ``savemat`` now provides informative warnings for invalid field names.
+=========================
+- `scipy.io.savemat` now provides informative warnings for invalid field names.
 - `scipy.io.mmread` now provides a clearer error message when provided with
   a source file path that does not exist.
 - `scipy.io.wavfile.read` can now read non-seekable files.
 
 
 ``scipy.integrate`` improvements
-==================================
-- Improved the error estimate of `scipy.integrate.tanhsinh`
+================================
+- The error estimate of `scipy.integrate.tanhsinh` was improved.
+
 
 ``scipy.interpolate`` improvements
 ==================================
-- Added batch support to `scipy.interpolate.make_smoothing_spline`
+- Batch support was added to `scipy.interpolate.make_smoothing_spline`.
+
 
 ``scipy.linalg`` improvements
 =============================
-- All functions in the `scipy.linalg` namespace that accept array arguments
-  now support N-dimensional arrays to be processed as a batch.
+- Nearly all functions in the `scipy.linalg` namespace that accept array
+  arguments now support N-dimensional arrays to be processed as a batch.
   See :ref:`linalg_batch` for details.
-- ``linalg.sqrtm`` is rewritten in C and its performance is improved. It also
-  tries harder to return real-valued results for real-valued inputs if
+- `scipy.linalg.sqrtm` is rewritten in C and its performance is improved. It
+  also tries harder to return real-valued results for real-valued inputs if
   possible. See the function docstring for more details. In this version the
   input argument ``disp`` and the optional output argument ``errest`` are
   deprecated and will be removed four versions later. Similarly, after
   changing the underlying algorithm to recursion, the ``blocksize`` keyword
   argument has no effect and will be removed two versions later.
-- Added wrappers for ``?stevd``, ``?langb``, ``?sytri``, ``?hetri`` and
-  ``?gbcon`` to `scipy.linalg.lapack`.
-- Improved default driver of `scipy.linalg.eigh_tridiagonal`.
+- Wrappers for ``?stevd``, ``?langb``, ``?sytri``, ``?hetri`` and
+  ``?gbcon`` were added to `scipy.linalg.lapack`.
+- The default driver of `scipy.linalg.eigh_tridiagonal` was improved.
 - `scipy.linalg.solve` can now estimate the reciprocal condition number and
   the matrix norm calculation is more efficient.
 
+
 ``scipy.ndimage`` improvements
 ==============================
-- Added `scipy.ndimage.vectorized_filter` for generic filters that take advantage
-  of a vectorized Python callable.
+- A new function `scipy.ndimage.vectorized_filter` for generic filters that
+  take advantage of a vectorized Python callable was added.
 - `scipy.ndimage.rotate` has improved performance, especially on ARM platforms.
+
 
 ``scipy.optimize`` improvements
 ===============================
@@ -106,92 +110,95 @@ New features
   ``rhobeg`` can help the algorithm take bigger steps initially, while a
   smaller ``tol`` can help it continue and find a better solution.
   For more information, see the `PRIMA documentation <https://www.libprima.net>`_.
-- Several of the ``minimize`` methods, and the ``least_squares`` function,
-  have been given a ``workers`` keyword. This allows parallelization of some
-  calculations via a map-like callable, such as ``multiprocessing.Pool``. These
-  parallelization opportunities typically occur during numerical
-  differentiation. This can greatly speed-up minimization when the objective
-  function is expensive to calculate.
-- The ``lm`` method of ``least_squares`` can now accept ``3-point`` and ``cs``
-  for the ``jac`` keyword.
-- SLSQP Fortran77 code ported to C. When this method is used now the constraint
-  multipliers are exposed to the user through the ``multiplier`` keyword of
-  the returned ``OptimizeResult`` object.
+- Several of the `scipy.optimize.minimize` methods, and the
+  `scipy.optimize.least_squares` function, have been given a ``workers``
+  keyword. This allows parallelization of some calculations via a map-like
+  callable, such as ``multiprocessing.Pool``. These parallelization
+  opportunities typically occur during numerical differentiation. This can
+  greatly speed up minimization when the objective function is expensive to
+  calculate.
+- The ``lm`` method of `scipy.optimize.least_squares` can now accept
+  ``3-point`` and ``cs`` for the ``jac`` keyword.
+- The SLSQP Fortran 77 code was ported to C. When this method is used now the
+  constraint multipliers are exposed to the user through the ``multiplier``
+  keyword of the returned `~scipy.optimize.OptimizeResult` object.
 - NNLS code has been corrected and rewritten in C to address the performance
   regression introduced in 1.15.x
-- ``optimize.root`` now warns for invalid inner parameters when using the
+- `scipy.optimize.root` now warns for invalid inner parameters when using the
   ``newton_krylov`` method
 - The return value of minimization with ``method='L-BFGS-B'`` now has
   a faster ``hess_inv.todense()`` implementation. Time complexity has improved
   from cubic to quadratic.
-- ``optimize.least_squares`` has a new ``callback`` argument that is applicable
-  to ``trf`` and ``dogbox`` methods. ``callback`` may be used to track
+- `scipy.optimize.least_squares` has a new ``callback`` argument that is applicable
+  to the ``trf`` and ``dogbox`` methods. ``callback`` may be used to track
   optimization results at each step or to provide custom conditions for
   stopping.
 
 
 ``scipy.signal`` improvements
 =============================
-- A new function ``firwin_2d`` for the creation of a 2-D FIR Filter using the
-  1-D window method was added.
-- ``signal.cspline1d_eval`` and ``signal.qspline1d_eval`` now provide an
-  informative error on empty input rather than hitting the recursion limit.
+- A new function `scipy.signal.firwin_2d` for the creation of a 2-D FIR Filter
+  using the 1-D window method was added.
+- `scipy.signal.cspline1d_eval` and `scipy.signal.qspline1d_eval` now provide
+  an informative error on empty input rather than hitting the recursion limit.
 - A new function `scipy.signal.closest_STFT_dual_window` to calculate the
-  ``ShortTimeFFT`` dual window of a given window closest to a desired dual
-  window.
+  `~scipy.signal.ShortTimeFFT` dual window of a given window closest to a
+  desired dual window.
 - A new classmethod `scipy.signal.ShortTimeFFT.from_win_equals_dual` to
-  create a ``ShortTimeFFT`` instance where the window and its dual are equal
-  up to a scaling factor. It allows to create short-time Fourier transforms
-  which are unitary mappings.
-- The performance of ``signal.convolve2d`` has improved.
+  create a `~scipy.signal.ShortTimeFFT` instance where the window and its dual
+  are equal up to a scaling factor. It allows to create short-time Fourier
+  transforms which are unitary mappings.
+- The performance of `scipy.signal.convolve2d` was improved.
 
 
 ``scipy.sparse`` improvements
 =============================
-- ``coo_array`` supports nD arrays using binary and reduction operations.
-- Math is faster between two DIA arrays/matrices: add, sub, multiply, matmul.
-- ``csgraph.dijkstra`` shortest_path is more efficient.
-- ``csgraph.yen`` has performance improvements.
-- Import of ``_lib.issparse`` allows checking for ``scipy.sparse`` object
-  without full import of ``scipy``.
-- add lazy loading of ``sparse.csgraph`` and ``sparse.linalg``.
+- `scipy.sparse.coo_array` now supports n-D arrays using binary and reduction
+  operations.
+- Faster operations between two DIA arrays/matrices for: add, sub, multiply,
+  matmul.
+- `scipy.sparse.csgraph.dijkstra` shortest_path is more efficient.
+- `scipy.sparse.csgraph.yen` has performance improvements.
+- Support for lazy loading of ``sparse.csgraph`` and ``sparse.linalg`` was
+  added.
 
 
 ``scipy.spatial`` improvements
 ==============================
-- A new class ``RigidTransform`` is available in the ``transform`` submodule. It
-  provides functionality to convert between different representations of rigid
-  transforms in 3D space, its application to vectors and transform composition.
+- A new class, `scipy.spatial.transform.RigidTransform`, provides functionality
+  to convert between different representations of rigid transforms in 3-D
+  space, its application to vectors and transform composition.
   It follows the same design approach as `scipy.spatial.transform.Rotation`.
-- `scipy.spatial.transform.Rotation` now has an appropriate ``__repr__`` method.
-- ``Rotation.apply`` has improved performance.
+- `~scipy.spatial.transform.Rotation` now has an appropriate ``__repr__`` method,
+  and improved performance for its `~scipy.spatial.transform.Rotation.apply`
+  method.
 
 
 ``scipy.stats`` improvements
 ============================
-- Added `scipy.stats.quantile`, an array API compatible function for quantile
-  estimation.
-- Extended `scipy.stats.make_distribution` to:
-
-  - work with existing discrete distributions and
-  - facilitate the creation of custom distributions
-
-  in the new random variable infrastructure.
-
-- Added `scipy.stats.Binomial`.
-- Added ``equal_var`` keyword to:
-
-  - `scipy.stats.tukey_hsd` (enables the Games-Howell test) and
-  - `scipy.stats.f_oneway` (enables Welch ANOVA).
-
-- Improved moment calculation for `scipy.stats.gennorm`.
-- Added native vectorization to `scipy.stats.mode` for faster batch calculation.
-- Added ``axis``, ``nan_policy``, and ``keepdims`` to `scipy.stats.power_divergence`,
-  `scipy.stats.chisquare`, `scipy.stats.pointbiserialr`, `scipy.stats.kendalltau`,
-  `scipy.stats.weightedtau`, `scipy.stats.theilslopes`, `scipy.stats.siegelslopes`,
-  and `scipy.stats.boxcox_llf`.
-- Improved speed of `scipy.stats.special_ortho_group`.
-- Improved speed of `scipy.stats.pearsonr`.
+- A new function `scipy.stats.quantile`, an array API compatible function for
+  quantile estimation, was added.
+- `scipy.stats.make_distribution` was extended to work with existing discrete
+  distributions and to facilitate the creation of custom distributions in the
+  new random variable infrastructure.
+- A new distribution, `scipy.stats.Binomial`, was added.
+- An ``equal_var`` keyword was added to `scipy.stats.tukey_hsd` (enables the
+  Games-Howell test) and `scipy.stats.f_oneway` (enables Welch ANOVA).
+- The moment calculation for `scipy.stats.gennorm` was improved.
+- The `scipy.stats.mode` implementation was vectorized, for faster batch
+  calculation.
+- Support for ``axis``, ``nan_policy``, and ``keepdims`` keywords was added to
+  `~scipy.stats.power_divergence`, `~scipy.stats.chisquare`,
+  `~scipy.stats.pointbiserialr`, `~scipy.stats.kendalltau`,
+  `~scipy.stats.weightedtau`, `~scipy.stats.theilslopes`,
+  `~scipy.stats.siegelslopes`, `~scipy.stats.boxcox_llf`, and
+  `~scipy.stats.linregress`.
+- Support for ``keepdims`` and ``nan_policy`` keywords was added to
+  `~scipy.stats.gstd`.
+- The performance of `scipy.stats.special_ortho_group` and `scipy.stats.pearsonr`
+  was improved.
+- Support for an ``rng`` keyword argument was added to the ``logcdf`` and
+  ``cdf`` methods of ``multivariate_normal_gen`` and ``multivariate_normal_frozen``.
 
 
 **************************
@@ -199,15 +206,16 @@ Array API Standard Support
 **************************
 
 Experimental support for array libraries other than NumPy has been added to
-existing sub-packages in recent versions of SciPy. Please consider testing
-these features by setting an environment variable ``SCIPY_ARRAY_API=1`` and
-providing PyTorch, JAX, or CuPy arrays as array arguments. Many functions
-in `scipy.stats`, `scipy.special`, `scipy.optimize`, and `scipy.constants`
-now provide tables documenting compatible array and device types as well as
-support for lazy arrays and JIT compilation. New features with support and
-old features with support added for SciPy 1.16.0 include:
+multiple submodules in recent versions of SciPy. Please consider testing
+these features by setting the environment variable ``SCIPY_ARRAY_API=1`` and
+providing PyTorch, JAX, CuPy or Dask arrays as array arguments.
 
-- Most features of `scipy.signal`
+Many functions in `scipy.stats`, `scipy.special`, `scipy.optimize`, and
+`scipy.constants` now provide tables documenting compatible array and device
+types as well as support for lazy arrays and JIT compilation. New features with
+support and old features with support added for SciPy 1.16.0 include:
+
+- Most of the `scipy.signal` functionality
 - `scipy.ndimage.vectorized_filter`
 - `scipy.special.stdtrit`
 - `scipy.special.softmax`
@@ -221,8 +229,10 @@ for JAX and Dask) in SciPy 1.16.0 include:
 
 - many of the `scipy.cluster.hierarchy` functions
 - many functions in `scipy.special`
-- many of the trimmed `stats` functions
+- many of the trimmed statistics functions in `scipy.stats`
 
+SciPy now has a CI job that exercises GPU (CUDA) support, and as a result
+using PyTorch, CuPy or JAX arrays on GPU with SciPy is now more reliable.
 
 
 *******************
@@ -235,13 +245,15 @@ Deprecated features
 - `scipy.stats.multinomial` now emits a ``FutureWarning`` if the rows of ``p``
   do not sum to ``1.0``. This condition will produce NaNs beginning in SciPy
   1.18.0.
+- The ``disp`` and ``iprint`` arguments of the ``l-bfgs-b`` solver of `scipy.optimize`
+  have been deprecated, and will be removed in SciPy 1.18.0.
 
 ********************
 Expired Deprecations
 ********************
 - ``scipy.sparse.conjtransp`` has been removed. Use ``.T.conj()`` instead.
 - The ``quadrature='trapz'`` option has been removed from
-  `scipy.integrate.quad_vec` and ``scipy.stats.trapz`` has been removed. Use
+  `scipy.integrate.quad_vec`, and ``scipy.stats.trapz`` has been removed. Use
   ``trapezoid`` in both instances instead.
 - `scipy.special.comb` and `scipy.special.perm` now raise when ``exact=True``
   and arguments are non-integral.
@@ -250,23 +262,68 @@ Expired Deprecations
   must be specified separately as ``x`` and ``y``.
 - Support for NumPy masked arrays has been removed from
   `scipy.stats.power_divergence` and `scipy.stats.chisquare`.
+- A significant number of functions from non-public namespaces
+  (e.g., ``scipy.sparse.base``, ``scipy.interpolate.dfitpack``) were cleaned
+  up. They were previously already emitting deprecation warnings.
 
 
 ******************************
 Backwards incompatible changes
 ******************************
 - Several of the `scipy.linalg` functions for solving a linear system (e.g.
-  `scipy.linalg.solve`) documented that the RHS argument must be either 1-D or
+  `~scipy.linalg.solve`) documented that the RHS argument must be either 1-D or
   2-D but did not always raise an error when the RHS argument had more the
   two dimensions. Now, many-dimensional right hand sides are treated according
   to the rules specified in :ref:`linalg_batch`.
 - `scipy.stats.bootstrap` now explicitly broadcasts elements of ``data`` to the
   same shape (ignoring ``axis``) before performing the calculation.
+- Several submodule names are no longer available via ``from scipy.signal import *``,
+  but may still be imported directly, as detailed at
+  `<https://github.com/scipy/scipy-stubs/pull/549>`__.
+
+
+***********************************
+Build and packaging related changes
+***********************************
+- The minimum supported version of Clang was bumped from 12.0 to 15.0.
+- The lowest supported macOS version for wheels on PyPI is now 10.14 instead of
+  10.13.
+- The sdist contents were optimized, resulting in a size reduction of about 50%,
+  from 60 MB to 30 MB.
+- For ``Cython>=3.1.0``, SciPy now uses the new ``cython --generate-shared``
+  functionality, which reduces the total size of SciPy's wheels and on-disk
+  installations significantly.
+- SciPy no longer contains an internal shared library that requires RPATH support,
+  after ``sf_error_state`` was removed from `scipy.special`.
+- A new build option ``-Duse-system-libraries`` has been added. It allows
+  opting in to using system libraries instead of using vendored sources.
+  Currently ``Boost.Math`` and ``Qhull`` are supported as system build
+  dependencies.
+
 
 *************
 Other changes
 *************
-- The ``lm`` method of ``least_squares`` function now has a different behavior
+- A new accompanying release of ``scipy-stubs`` (``v1.16.0.0``) is
+  available.
+- The internal dependency of ``scipy._lib`` on ``scipy.sparse`` was removed,
+  which reduces the import time of a number of other SciPy submodules.
+- Support for free-threaded CPython was improved: the last known thread-safety
+  issues in `scipy.special` were fixed, and ``pytest-run-parallel`` is now used
+  in a CI job to guard against regressions.
+- Support for `spin <https://github.com/scientific-python/spin>`__ as a developer
+  CLI was added, including support for editable installs. The SciPy-specific
+  ``python dev.py`` CLI will be removed in the next release cycle in favor of
+  ``spin``.
+- The vendored Qhull library was upgraded from version 2019.1 to 2020.2.
+- A large amount of the C++ code in ``scipy.special`` was moved to the new
+  header-only `xsf <https://github.com/scipy/xsf>`__ library. That library was
+  included back in the SciPy source tree as a git submodule.
+- The ``namedtuple``-like bunch objects returned by some SciPy functions
+  now have improved compatibility with the ``polars`` library.
+- The output of the ``rvs`` method of `scipy.stats.wrapcauchy` is now mapped to
+  the unit circle between 0 and ``2 * pi``.
+- The ``lm`` method of `scipy.optimize.least_squares` now has a different behavior
   for the maximum number of function evaluations, ``max_nfev``. The default for
   the ``lm`` method is changed to ``100 * n``, for both a callable and a
   numerically estimated jacobian. This limit on function evaluations excludes
@@ -276,20 +333,6 @@ Other changes
   ``lm`` method the number of function calls used in Jacobian approximation
   is no longer included in ``OptimizeResult.nfev``. This brings the behavior
   of ``lm``, ``trf``, and ``dogbox`` into line.
-- For ``Cython>=3.1.0b1``, SciPy now uses the new
-  ``cython --generate-shared`` functionality, which reduces the total size of
-  SciPy's wheels and on-disk installations significantly.
-- The output of `scipy.stats.wrapcauchy` ``rvs`` is now mapped to the unit circle
-  between 0 and ``2 * pi``.
-- The vendored Qhull library was upgraded from version 2019.1 to 2020.2.
-- A new build option ``-Duse-system-libraries`` has been added. It allows
-  opting in to using system libraries instead of using vendored sources.
-  Currently ``Boost.Math`` and ``Qhull`` are supported as system build
-  dependencies.
-- The ``namedtuple``-like bunch objects returned by some SciPy functions
-  now have improved compatibility with the ``polars`` library.
-- The testsuite thread safety with free-threaded CPython has improved.
-
 
 
 *******
@@ -306,60 +349,66 @@ Authors
 * Nickolai Belakovski (5)
 * Peter Bell (1)
 * Benoît W. (1) +
+* Evandro Bernardes (1)
+* Gauthier Berthomieu (1) +
 * Maxwell Bileschi (1) +
 * Sam Birch (1) +
 * Florian Bourgey (3) +
 * Charles Bousseau (2) +
 * Richard Strong Bowen (2) +
-* Jake Bowhay (126)
+* Jake Bowhay (127)
 * Matthew Brett (1)
-* Dietrich Brunn (52)
-* Evgeni Burovski (252)
+* Dietrich Brunn (53)
+* Evgeni Burovski (254)
 * Christine P. Chai (12) +
+* Gayatri Chakkithara (1) +
 * Saransh Chopra (2) +
 * Omer Cohen (1) +
 * Lucas Colley (91)
-* crusaderky (56) +
 * Yahya Darman (3) +
-* dartvader316 (2) +
 * Benjamin Eisele (1) +
 * Donnie Erb (1)
-* Evandro (1)
-* Sagi Ezri (57) +
+* Sagi Ezri (58) +
 * Alexander Fabisch (2) +
 * Matthew H Flamm (1)
-* Gautzilla (1) +
+* Karthik Viswanath Ganti (1) +
 * Neil Girdhar (1)
-* Ralf Gommers (149)
+* Ralf Gommers (162)
 * Rohit Goswami (4)
 * Saarthak Gupta (4) +
-* Matt Haberland (320)
+* Matt Haberland (326)
 * Sasha Hafner (1) +
-* Joren Hammudoglu (9)
+* Joren Hammudoglu (11)
 * Chengyu Han (1) +
 * Charles Harris (1)
 * Kim Hsieh (4) +
+* Yongcai Huang (2) +
 * Lukas Huber (1) +
-* Guido Imperiale (47) +
-* Jigyasu (1) +
-* karthik-ganti-2025 (1) +
+* Yuji Ikeda (2) +
+* Guido Imperiale (105) +
 * Robert Kern (2)
 * Harin Khakhi (2) +
 * Agriya Khetarpal (4)
+* Daniil Kiktenko (1) +
+* Kirill R. (2) +
 * Tetsuo Koyama (1)
+* Jigyasu Krishnan (1) +
+* Abhishek Kumar (2) +
+* Pratham Kumar (3) +
 * David Kun (1) +
 * Eric Larson (3)
 * lciti (1)
 * Antony Lee (1)
 * Kieran Leschinski (1) +
 * Thomas Li (2) +
+* Yuxi Long (2) +
 * Christian Lorentzen (2)
 * Loïc Estève (4)
 * Panos Mavrogiorgos (1) +
 * Nikolay Mayorov (2)
 * Melissa Weber Mendonça (10)
+* Michał Górny (1)
 * Miguel Cárdenas (2) +
-* MikhailRyazanov (6) +
 * Swastik Mishra (1) +
 * Sturla Molden (2)
 * Andreas Nazlidis (1) +
@@ -367,27 +416,26 @@ Authors
 * Parth Nobel (1) +
 * Nick ODell (9)
 * Giacomo Petrillo (1)
+* Victor PM (10) +
 * pmav99 (1) +
-* Ilhan Polat (72)
-* pratham-mcw (3) +
-* Tyler Reddy (73)
-* redpinecube (1) +
+* Ilhan Polat (74)
+* Tyler Reddy (128)
 * Érico Nogueira Rolim (1) +
 * Pamphile Roy (10)
-* sagi-ezri (1) +
+* Mikhail Ryazanov (6)
 * Atsushi Sakai (9)
 * Marco Salathe (1) +
 * sanvi (1) +
 * Neil Schemenauer (2) +
 * Daniel Schmitz (20)
 * Martin Schuck (1) +
-* Dan Schult (32)
+* Dan Schult (33)
 * Tomer Sery (19)
 * Adrian Seyboldt (1) +
 * Scott Shambaugh (4)
 * ShannonS00 (1) +
 * sildater (3) +
-* PARAM SINGH (1) +
+* Param Singh (1) +
 * G Sreeja (7) +
 * Albert Steppi (133)
 * Kai Striega (3)
@@ -398,31 +446,28 @@ Authors
 * Jamie Townsend (2) +
 * Edgar Andrés Margffoy Tuay (4)
 * Matthias Urlichs (1) +
+* Mark van Rossum (1) +
 * Jacob Vanderplas (2)
 * David Varela (2) +
 * Christian Veenhuis (3)
 * vfdev (1)
-* vpecanins (10) +
-* vrossum (1) +
 * Stefan van der Walt (2)
 * Warren Weckesser (5)
 * Jason N. White (1) +
 * windows-server-2003 (5)
 * Zhiqing Xiao (1)
 * Pavadol Yamsiri (1)
-* YongcaiHuang (2) +
 * Rory Yorke (3)
-* yuzie007 (2) +
 * Irwin Zaid (4)
-* zaikunzhang (1) +
 * Austin Zhang (1) +
 * William Zijie Zhang (1) +
-* Eric Zitong Zhou (5) +
-* zitongzhoueric (6) +
+* Zaikun Zhang (1) +
+* Zhenyu Zhu (1) +
+* Eric Zitong Zhou (11) +
 * Case Zumbrum (2) +
 * ਗਗਨਦੀਪ ਸਿੰਘ (Gagandeep Singh) (45)
 
-    A total of 124 people contributed to this release.
+    A total of 126 people contributed to this release.
     People with a "+" by their names contributed a patch for the first time.
     This list of names is automatically generated, and may not be fully complete.
 
@@ -446,7 +491,7 @@ Issues closed for 1.16.0
 * `#8367 <https://github.com/scipy/scipy/issues/8367>`__: ENH: stats.mvndst: make thread-safe
 * `#8411 <https://github.com/scipy/scipy/issues/8411>`__: nan with betainc for a=0, b=3 and x=0.5
 * `#8916 <https://github.com/scipy/scipy/issues/8916>`__: ENH: ndimage.generic_filter: slow on large images
-* `#9077 <https://github.com/scipy/scipy/issues/9077>`__: maximum_filter is not symetrical with nans
+* `#9077 <https://github.com/scipy/scipy/issues/9077>`__: maximum_filter is not symmetrical with nans
 * `#9841 <https://github.com/scipy/scipy/issues/9841>`__: ENH: linalg: 0-th dimension must be fixed to 1 but got 2 (real...
 * `#9873 <https://github.com/scipy/scipy/issues/9873>`__: ENH: ndimage: majority voting filter
 * `#10416 <https://github.com/scipy/scipy/issues/10416>`__: ENH: optimize.minimize: slsqp: give better error when work array...
@@ -464,7 +509,7 @@ Issues closed for 1.16.0
 * `#13914 <https://github.com/scipy/scipy/issues/13914>`__: DOC: sparse.csgraph.shortest_path: predecessors array contains...
 * `#13952 <https://github.com/scipy/scipy/issues/13952>`__: fmin_cobyla result violates constraint
 * `#13982 <https://github.com/scipy/scipy/issues/13982>`__: ENH: linalg.eigh_tridiagonal: divide and conquer option
-* `#14394 <https://github.com/scipy/scipy/issues/14394>`__: ENH: optmize.slsqp: return Lagrange multipliers
+* `#14394 <https://github.com/scipy/scipy/issues/14394>`__: ENH: optimize.slsqp: return Lagrange multipliers
 * `#14569 <https://github.com/scipy/scipy/issues/14569>`__: BUG: signal.resample: inconsistency across dtypes
 * `#14915 <https://github.com/scipy/scipy/issues/14915>`__: BUG: optimize.minimize: corruption/segfault with constraints
 * `#15153 <https://github.com/scipy/scipy/issues/15153>`__: BUG: signal.resample: incorrect with ``datetime[ns]`` for ``t``...
@@ -547,6 +592,7 @@ Issues closed for 1.16.0
 * `#22271 <https://github.com/scipy/scipy/issues/22271>`__: Query: empty ``Rotation`` is not allowed in scipy=1.15
 * `#22282 <https://github.com/scipy/scipy/issues/22282>`__: QUERY/DEV: test failure in IDE with ``SCIPY_ARRAY_API``
 * `#22288 <https://github.com/scipy/scipy/issues/22288>`__: QUERY: Pyright raises error/warning in IDE
+* `#22294 <https://github.com/scipy/scipy/issues/22294>`__: DOC: ``source`` now links to top of file, not location within...
 * `#22303 <https://github.com/scipy/scipy/issues/22303>`__: ENH: stats.special_ortho_group: improve and simplify
 * `#22309 <https://github.com/scipy/scipy/issues/22309>`__: DOC: optimize.elementwise.find_minimum: harmonize documented/implemented...
 * `#22328 <https://github.com/scipy/scipy/issues/22328>`__: QUERY: stats.beta.fit: ``FitError`` on reasonable data
@@ -600,6 +646,16 @@ Issues closed for 1.16.0
 * `#22956 <https://github.com/scipy/scipy/issues/22956>`__: BUG: special._ufuncs._ncx2_pdf: interpreter crash with extreme...
 * `#22965 <https://github.com/scipy/scipy/issues/22965>`__: BUG: The attribute "nit" is not found when using the callback...
 * `#22981 <https://github.com/scipy/scipy/issues/22981>`__: Bug with freqz when specifying worN after #22886
+* `#23035 <https://github.com/scipy/scipy/issues/23035>`__: TST: theilsope & siegelslope-related tests are failing on PyPy3.11...
+* `#23036 <https://github.com/scipy/scipy/issues/23036>`__: BUG: signal.csd: doesn't zero-pad for different size inputs in...
+* `#23038 <https://github.com/scipy/scipy/issues/23038>`__: DOC: ``linalg.toeplitz`` does not support batching like the ``1.16.0rc1``...
+* `#23046 <https://github.com/scipy/scipy/issues/23046>`__: ENH: ``vectorized_filter``\ : special case of scalar ``size``...
+* `#23061 <https://github.com/scipy/scipy/issues/23061>`__: DOC: Wrong SPDX identifier for OpenBLAS and LAPACK
+* `#23068 <https://github.com/scipy/scipy/issues/23068>`__: BUG: sparse: ``!=`` operator with csr matrices
+* `#23109 <https://github.com/scipy/scipy/issues/23109>`__: BUG: spatial.distance.cdist: wrong result in Yule metric
+* `#23169 <https://github.com/scipy/scipy/issues/23169>`__: BUG: special.betainc: evaluates incorrectly to nan when ``b=0``
+* `#23184 <https://github.com/scipy/scipy/issues/23184>`__: BUG: min Python version enforcement in 1.16.x series? (and main)
+* `#23186 <https://github.com/scipy/scipy/issues/23186>`__: BUG: scipy.optimize minimize routine does not show info logs...
 
 ************************
 Pull requests for 1.16.0
@@ -1041,6 +1097,7 @@ Pull requests for 1.16.0
 * `#22982 <https://github.com/scipy/scipy/pull/22982>`__: BUG: signal: fix incorrect vendoring of ``npp_polyval``
 * `#22984 <https://github.com/scipy/scipy/pull/22984>`__: MAINT: special: remove test_compiles_in_cupy
 * `#22987 <https://github.com/scipy/scipy/pull/22987>`__: DOC: sparse: sparray migration guide updates
+* `#22991 <https://github.com/scipy/scipy/pull/22991>`__: DOC: update SciPy 1.16.0 release notes
 * `#22992 <https://github.com/scipy/scipy/pull/22992>`__: ENH: ``signal.cspline1d_eval,qspline1d_eval`` throw exception...
 * `#22994 <https://github.com/scipy/scipy/pull/22994>`__: DOC: signal.csd: Small fixes to docstr
 * `#22997 <https://github.com/scipy/scipy/pull/22997>`__: CI: temporarily disable free-threaded job with parallel-threads
@@ -1049,3 +1106,32 @@ Pull requests for 1.16.0
 * `#23000 <https://github.com/scipy/scipy/pull/23000>`__: ENH/DOC/TST: ``cluster.vq``\ : use ``xp_capabilities``
 * `#23001 <https://github.com/scipy/scipy/pull/23001>`__: DOC: ``special``\ : update top-level docs to reflect ``xp_capabilities``
 * `#23005 <https://github.com/scipy/scipy/pull/23005>`__: BUG: sparse: fix mean/sum change in return of np.matrix for sparse...
+* `#23010 <https://github.com/scipy/scipy/pull/23010>`__: DOC: edit and extend the release notes for 1.16.0
+* `#23013 <https://github.com/scipy/scipy/pull/23013>`__: MAINT: version pins/prep for 1.16.0rc1
+* `#23014 <https://github.com/scipy/scipy/pull/23014>`__: DOC: .mailmap updates for 1.16.0rc1
+* `#23029 <https://github.com/scipy/scipy/pull/23029>`__: DOC: add documentation for the new ``use-system-libraries`` build...
+* `#23031 <https://github.com/scipy/scipy/pull/23031>`__: REL: set 1.16.0rc2 unreleased
+* `#23040 <https://github.com/scipy/scipy/pull/23040>`__: DOC: linalg: adjust release note wording
+* `#23044 <https://github.com/scipy/scipy/pull/23044>`__: TST: update all ``result_to_tuple=`` callables to accept two...
+* `#23047 <https://github.com/scipy/scipy/pull/23047>`__: BUG: signal.csd: Zero-pad for different size inputs
+* `#23048 <https://github.com/scipy/scipy/pull/23048>`__: MAINT: ndimage.vectorized_filter: fix behavior of axes when length...
+* `#23051 <https://github.com/scipy/scipy/pull/23051>`__: MAINT/ENH: ndimage.vectorized_filter: adjust scalar size to match...
+* `#23086 <https://github.com/scipy/scipy/pull/23086>`__: CI: update windows-2019 runner image to windows-2022
+* `#23091 <https://github.com/scipy/scipy/pull/23091>`__: BUG: sparse: correct eq and ne with different shapes. (and add...
+* `#23098 <https://github.com/scipy/scipy/pull/23098>`__: MAINT: 1.16.0rc2 backports
+* `#23099 <https://github.com/scipy/scipy/pull/23099>`__: MAINT: fix SPDX license expressions for LAPACK, OpenBLAS, GCC
+* `#23106 <https://github.com/scipy/scipy/pull/23106>`__: TST: CI broken vs pytest 8.4.0
+* `#23110 <https://github.com/scipy/scipy/pull/23110>`__: BUG: spatial.distance: yule implementation in ``distance_metrics.h``
+* `#23113 <https://github.com/scipy/scipy/pull/23113>`__: DOC: improve docs for ``-Duse-system-libraries`` build option
+* `#23114 <https://github.com/scipy/scipy/pull/23114>`__: DOC: Add missing BLAS Level 2 functions
+* `#23127 <https://github.com/scipy/scipy/pull/23127>`__: DOC: fix linkcode_resolve line-number anchors
+* `#23131 <https://github.com/scipy/scipy/pull/23131>`__: REL: set 1.16.0rc3 unreleased
+* `#23134 <https://github.com/scipy/scipy/pull/23134>`__: BUG: linalg.lapack: fix incorrectly sized work array for {c,z}syrti
+* `#23144 <https://github.com/scipy/scipy/pull/23144>`__: MAINT: array types: array-api-strict got stricter
+* `#23146 <https://github.com/scipy/scipy/pull/23146>`__: DOC: stats.Mixture: add example
+* `#23164 <https://github.com/scipy/scipy/pull/23164>`__: MAINT: backports and prep for 1.16.0 "final"
+* `#23170 <https://github.com/scipy/scipy/pull/23170>`__: TST: add all SciPy-specific pytest markers to ``scipy/conftest.py``
+* `#23178 <https://github.com/scipy/scipy/pull/23178>`__: CI: skip JAX 0.6.2
+* `#23180 <https://github.com/scipy/scipy/pull/23180>`__: CI: remove free-threading workarounds in wheel builds
+* `#23189 <https://github.com/scipy/scipy/pull/23189>`__: BLD: implement build-time version check for minimum Python version
+* `#23197 <https://github.com/scipy/scipy/pull/23197>`__: DEP: optimize: Add deprecation warnings to L-BFGS-B ``disp``\...


### PR DESCRIPTION
* Forward port the SciPy `1.16.0` release notes and do the usual version switcher update.

[docs only]
