### PR TITLE
BUG: signal.tf2sos: fix a new `ComplexWarning`

### DIFF
--- a/scipy/signal/_polyutils.py
+++ b/scipy/signal/_polyutils.py
@@ -117,9 +117,7 @@ def poly(seq_of_zeros, *, xp):
     if xp.isdtype(a.dtype, 'complex floating'):
         # if complex roots are all complex conjugates, the roots are real.
         roots = xp.asarray(seq_of_zeros, dtype=xp.complex128)
-        delta = xp.abs(_sort_cmplx(roots, xp) - _sort_cmplx(xp.conj(roots), xp=xp))
-        eps = xp.finfo(delta.dtype).eps * 10
-        if xp.all(delta < eps):
+        if xp.all(xp.sort(xp.imag(roots)) == xp.sort(xp.imag(xp.conj(roots)))):
             a = xp.asarray(xp.real(a), copy=True)
 
     return a

--- a/scipy/signal/_polyutils.py
+++ b/scipy/signal/_polyutils.py
@@ -117,7 +117,9 @@ def poly(seq_of_zeros, *, xp):
     if xp.isdtype(a.dtype, 'complex floating'):
         # if complex roots are all complex conjugates, the roots are real.
         roots = xp.asarray(seq_of_zeros, dtype=xp.complex128)
-        if xp.all(_sort_cmplx(roots, xp) == _sort_cmplx(xp.conj(roots), xp)):
+        delta = xp.abs(_sort_cmplx(roots, xp) - _sort_cmplx(xp.conj(roots), xp=xp))
+        eps = xp.finfo(delta.dtype).eps * 10
+        if xp.all(delta < eps):
             a = xp.asarray(xp.real(a), copy=True)
 
     return a

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -382,6 +382,19 @@ class TestTf2Sos:
         sos2 = tf2sos(b, a, analog=analog)
         assert_array_almost_equal(sos, sos2, decimal=4)
 
+    def test_gh_23221(self):
+        # Tests that this tf2sos call below does not produce ComplexWarnings
+        # This test is specific for scipy==1.6.0: later scipy versions do not produce
+        # the warning.
+        with suppress_warnings():
+            warnings.simplefilter("error")
+            tf2sos([0.21860986786301265, -0.4372197357260253, -0.2186098678630126,
+                    0.8744394714520509,  -0.21860986786301248, -0.4372197357260253,
+                    0.21860986786301265],
+                   [1., -4.18323041786553, 6.829924151626914, -5.407777865686045,
+                    2.0773105450802336,  -0.33482732571537893,  0.0186009178695853 ]
+            )
+
 
 @skip_xp_backends(
     cpu_only=True, reason="XXX zpk2sos is numpy-only", exceptions=['cupy']

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -767,6 +767,12 @@ class TestFreqz:
         xp_assert_equal(w, xp.asarray([0. , 0.1]))
         xp_assert_equal(h, xp.asarray([1.+0.j, 1.+0.j]))
 
+    def test_gh_23277(self):
+        # backwards compatibility: `w` array must be real, not complex
+        filt = [0.5 + 0.0j, 0.5 + 0.0j]
+        w, _ = freqz(filt, worN=8)
+        assert w.dtype == np.float64
+
     def test_basic(self, xp):
         w, h = freqz(xp.asarray([1.0]), worN=8)
         assert_array_almost_equal(w, xp.pi * xp.arange(8, dtype=w.dtype) / 8.)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -384,7 +384,7 @@ class TestTf2Sos:
 
     def test_gh_23221(self):
         # Tests that this tf2sos call below does not produce ComplexWarnings
-        # This test is specific for scipy==1.6.0: later scipy versions do not produce
+        # This test is specific for scipy==1.16.0: later scipy versions do not produce
         # the warning.
         with suppress_warnings():
             warnings.simplefilter("error")


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

reported in https://github.com/scipy/scipy/issues/23221#issuecomment-2997264496

fixes gh-23221, fixes gh-23277

#### What does this implement/fix?
<!--Please explain your changes.-->

Cherry-pick a part of gh-22911 to fix an issue reported for scipy==1.16.0 in gh-23221

https://github.com/scipy/scipy/issues/23221#issuecomment-2997264496

#### Additional information
<!--Any additional information you think is important.-->

The PR is against maintenance/1.16.x since the problem is already fixed in main.
