### PR TITLE
DOC: issue #23208 missing docstring issue resolved for some classes in scipy.io

### DIFF
--- a/scipy/io/arff/_arffread.py
+++ b/scipy/io/arff/_arffread.py
@@ -52,10 +52,22 @@ r_wcomattrval = re.compile(r"(\S+)\s+(..+$)")
 
 
 class ArffError(OSError):
+    """
+    I/O error raised when loading ARFF (Attribute-Relation File Format) data fails.
+
+    This error typically occurs when an ARFF file is malformed, has an unexpected
+    structure, or contains invalid attribute declarations.
+    """
     pass
 
 
 class ParseArffError(ArffError):
+    """
+    Error raised when parsing of an ARFF file fails.
+
+    This subclass of ArffError is specific to parsing-related issues, such as
+    syntax errors, improper quoting, or invalid attribute value types.
+    """
     pass
 
 

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -25,6 +25,12 @@ __all__ = [
 
 
 class WavFileWarning(UserWarning):
+    """
+    Warning issued when a problem is encountered while reading or writing WAV files.
+
+    This warning typically indicates unusual file formatting, such as an unexpected
+    chunk size, unsupported sample width, or nonstandard file headers.
+    """
     pass
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #23208 

#### What does this implement/fix?
<!--Please explain your changes.-->
Added the missing docstring to the following classes:
- WavFileWarning 
- ArffError 
- ParseArffError

#### Additional information
<!--Any additional information you think is important.-->
