### PR TITLE
DOC: Fix typo in 1.12.0-notes.rst

### DIFF
--- a/doc/source/release/1.12.0-notes.rst
+++ b/doc/source/release/1.12.0-notes.rst
@@ -285,7 +285,7 @@ Deprecated features
 - ``scipy.integrate.trapz``, ``scipy.integrate.cumtrapz``, and ``scipy.integrate.simps`` have
   been deprecated in favour of `scipy.integrate.trapezoid`, `scipy.integrate.cumulative_trapezoid`,
   and `scipy.integrate.simpson` respectively and will be removed in SciPy 1.14.
-- The ``tol`` argument of ``scipy.sparse.linalg.{bcg,bicstab,cg,cgs,gcrotmk,gmres,lgmres,minres,qmr,tfqmr}``
+- The ``tol`` argument of ``scipy.sparse.linalg.{bicg,bicgstab,cg,cgs,gcrotmk,gmres,lgmres,minres,qmr,tfqmr}``
   is now deprecated in favour of ``rtol`` and will be removed in SciPy 1.14.
   Furthermore, the default value of ``atol`` for these functions is due
   to change to ``0.0`` in SciPy 1.14.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#23231 

#### What does this implement/fix?
<!--Please explain your changes.-->

There is a typo in the release notes for scipy v1.12.0.
The last item of this [link](https://docs.scipy.org/doc/scipy/release/1.12.0-notes.html#deprecated-features):

> The `tol` argument of `scipy.sparse.linalg.{bcg,bicstab,...}` is now deprecated in favour of `rtol` ...

`scipy.sparse.linalg.{bcg,bicstab,...}` should be `scipy.sparse.linalg.{bicg,bicgstab,...}`. `scipy.sparse.linalg.bcg` and `scipy.sparse.linalg.bicstab` do not exsit.

#### Additional information
<!--Any additional information you think is important.-->
