### PR TITLE
ENH: Implement support for `bc_type="periodic"` in `make_splrep` and `make_splprep`

### DIFF
--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -24,7 +24,8 @@ import numpy as np
 from scipy._lib._array_api import array_namespace, concat_1d
 
 from ._bsplines import (
-    _not_a_knot, make_interp_spline, BSpline, fpcheck, _lsq_solve_qr
+    _not_a_knot, make_interp_spline, BSpline, fpcheck, _lsq_solve_qr,
+    _lsq_solve_qr_for_root_rati_periodic, _periodic_knots
 )
 from . import _dierckx      # type: ignore[attr-defined]
 
@@ -41,10 +42,7 @@ TOL = 0.001
 MAXIT = 20
 
 
-def _get_residuals(x, y, t, k, w):
-    # FITPACK has (w*(spl(x)-y))**2; make_lsq_spline has w*(spl(x)-y)**2
-    w2 = w**2
-
+def _get_residuals(x, y, t, k, w, periodic=False):
     # inline the relevant part of
     # >>> spl = make_lsq_spline(x, y, w=w2, t=t, k=k)
     # NB:
@@ -56,19 +54,21 @@ def _get_residuals(x, y, t, k, w):
     #         * For 2D (parametric=True), the summation is actually how the
     #           'residuals' are defined, see Eq. (42) in Dierckx1982
     #           (the reference is in the docstring of `class F`) below.
-    _, _, c = _lsq_solve_qr(x, y, t, k, w)
-    c = np.ascontiguousarray(c)
-    spl = BSpline(t, c, k)
-    residuals = _compute_residuals(w2, spl(x), y)
-    fp = residuals.sum()
-    if np.isnan(fp):
+    _, _, _, fp, residuals = _lsq_solve_qr(x, y, t, k, w, periodic=periodic)
+    if np.isnan(residuals.sum()):
         raise ValueError(_iermesg[1])
     return residuals, fp
 
+def _validate_bc_type(bc_type):
+    if bc_type is None:
+        return "not-a-knot"
 
-def _compute_residuals(w2, splx, y):
-    delta = ((splx - y)**2).sum(axis=1)
-    return w2 * delta
+    if bc_type not in ("not-a-knot", "periodic"):
+        raise ValueError("Only 'not-a-knot' and 'periodic' "
+                         "boundary conditions are recognised, "
+                         f"found {bc_type}")
+
+    return bc_type
 
 
 def add_knot(x, t, k, residuals):
@@ -95,7 +95,7 @@ def add_knot(x, t, k, residuals):
     return t_new
 
 
-def _validate_inputs(x, y, w, k, s, xb, xe, parametric):
+def _validate_inputs(x, y, w, k, s, xb, xe, parametric, periodic=False):
     """Common input validations for generate_knots and make_splrep.
     """
     x = np.asarray(x, dtype=float)
@@ -141,10 +141,15 @@ def _validate_inputs(x, y, w, k, s, xb, xe, parametric):
     if xe is None:
         xe = max(x)
 
+    if periodic and not np.allclose(y[0], y[-1], atol=1e-15):
+        raise ValueError("First and last points does not match which is required "
+                         "for `bc_type='periodic'`.")
+
     return x, y, w, k, s, xb, xe
 
 
-def generate_knots(x, y, *, w=None, xb=None, xe=None, k=3, s=0, nest=None):
+def generate_knots(x, y, *, w=None, xb=None, xe=None,
+                   k=3, s=0, nest=None, bc_type=None):
     """Generate knot vectors until the Least SQuares (LSQ) criterion is satified.
 
     Parameters
@@ -165,6 +170,16 @@ def generate_knots(x, y, *, w=None, xb=None, xe=None, k=3, s=0, nest=None):
         The smoothing factor. Default is ``s = 0``.
     nest : int, optional
         Stop when at least this many knots are placed.
+          ends are equivalent.
+    bc_type : str, optional
+        Boundary conditions.
+        Default is `"not-a-knot"`.
+        The following boundary conditions are recognized:
+
+        * ``"not-a-knot"`` (default): The first and second segments are the
+          same polynomial. This is equivalent to having ``bc_type=None``.
+        * ``"periodic"``: The values and the first ``k-1`` derivatives at the
+          ends are equivalent.
 
     Yields
     ------
@@ -222,50 +237,114 @@ def generate_knots(x, y, *, w=None, xb=None, xe=None, k=3, s=0, nest=None):
 
     """
     xp = array_namespace(x, y, w)
+    bc_type = _validate_bc_type(bc_type)
+    periodic = bc_type == 'periodic'
 
     if s == 0:
         if nest is not None or w is not None:
             raise ValueError("s == 0 is interpolation only")
-        t = _not_a_knot(x, k)
+        # For special-case k=1 (e.g., Lyche and Morken, Eq.(2.16)),
+        # _not_a_knot produces desired knot vector
+        if periodic and k > 1:
+            t = _periodic_knots(x, k)
+        else:
+            t = _not_a_knot(x, k)
         yield xp.asarray(t)
         return
 
     x, y, w, k, s, xb, xe = _validate_inputs(
-        x, y, w, k, s, xb, xe, parametric=np.ndim(y) == 2
+        x, y, w, k, s, xb, xe, parametric=np.ndim(y) == 2,
+        periodic=periodic
     )
 
-    yield from _generate_knots_impl(x, y, w, xb, xe, k, s, nest, xp=xp)
+    yield from _generate_knots_impl(x, y, w, xb, xe, k, s, nest, periodic, xp=xp)
 
 
-def _generate_knots_impl(x, y, w, xb, xe, k, s, nest, xp=np):
+def _generate_knots_impl(x, y, w, xb, xe, k, s, nest, periodic, xp=np):
+
     acc = s * TOL
     m = x.size    # the number of data points
 
     if nest is None:
         # the max number of knots. This is set in _fitpack_impl.py line 274
         # and fitpack.pyf line 198
-        nest = max(m + k + 1, 2*k + 3)
+        # Ref: https://github.com/scipy/scipy/blob/596b586e25e34bd842b575bac134b4d6924c6556/scipy/interpolate/_fitpack_impl.py#L260-L263
+        if periodic:
+            nest = max(m + 2*k, 2*k + 3)
+        else:
+            nest = max(m + k + 1, 2*k + 3)
     else:
         if nest < 2*(k + 1):
             raise ValueError(f"`nest` too small: {nest = } < 2*(k+1) = {2*(k+1)}.")
 
-    nmin = 2*(k + 1)    # the number of knots for an LSQ polynomial approximation
-    nmax = m + k + 1  # the number of knots for the spline interpolation
+    if not periodic:
+        nmin = 2*(k + 1)    # the number of knots for an LSQ polynomial approximation
+        nmax = m + k + 1  # the number of knots for the spline interpolation
+    else:
+        # Ref: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpperi.f#L54
+        nmin = 2*(k + 1)    # the number of knots for an LSQ polynomial approximation
+        # Ref: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpperi.f#L61
+        nmax = m + 2*k  # the number of knots for the spline interpolation
+
+    per = xe - xb
+    # Ref: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpperi.f#L107-L123
+    # Computes fp0 for constant function
+    if periodic:
+        t = np.zeros(nmin, dtype=float)
+        for i in range(0, k + 1):
+            t[i] = x[0] - (k - i) * per
+            t[i + k + 1] = x[m - 1] + i * per
+        _, fp = _get_residuals(x, y, t, k, w, periodic=periodic)
+        # For periodic splines, check whether constant function
+        # satisfies accuracy criterion
+        # Also if maximal number of nodes is equal to the minimal
+        # then constant function is the direct solution
+        # Ref: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpperi.f#L600-L610
+        if fp - s < acc or nmax == nmin:
+            yield t
+            return
+    else:
+        fp = 0.0
+        fpold = 0.0
 
     # start from no internal knots
-    t = np.asarray([xb]*(k+1) + [xe]*(k+1), dtype=float)
+    if not periodic:
+        t = np.asarray([xb]*(k+1) + [xe]*(k+1), dtype=float)
+    else:
+        # Ref: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpperi.f#L131
+        # Initialize knot vector `t` of size (2k + 3) with zeros.
+        # The central knot `t[k + 1]` is seeded with the midpoint value from `x`.
+        # Note that, in the `if periodic:` block (in the main loop below),
+        # the boundary knots `t[k]` and `t[n - k - 1]` are set to the endpoints `xb` and
+        # `xe`. Then, the surrounding knots on both ends are updated to ensure
+        # periodicity.
+        # Specifically:
+        # - Left-side knots are mirrored from the right end minus the period (`per`).
+        # - Right-side knots are mirrored from the left end plus the period.
+        # These updates ensure that the knot vector wraps around correctly for periodic
+        # B-spline fitting.
+        t = np.zeros(2*k + 3, dtype=float)
+        t[k + 1] = x[(m + 1)//2 - 1]
+        nplus = 1
     n = t.shape[0]
-    fp = 0.0
-    fpold = 0.0
 
     # c  main loop for the different sets of knots. m is a safe upper bound
     # c  for the number of trials.
-    for _ in range(m):
+    for iter in range(m):
+        # Ref: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpperi.f#L147-L158
+        if periodic:
+            n = t.shape[0]
+            t[k] = xb
+            t[n - k - 1] = xe
+            for j in range(1, k + 1):
+                t[k - j] = t[n - k - j - 1] - per
+                t[n - k + j - 1] = t[k + j] + per
         yield xp.asarray(t)
 
         # construct the LSQ spline with this set of knots
         fpold = fp
-        residuals, fp = _get_residuals(x, y, t, k, w=w)
+        residuals, fp = _get_residuals(x, y, t, k, w=w,
+                                        periodic=periodic)
         fpms = fp - s
 
         # c  test whether the approximation sinf(x) is an acceptable solution.
@@ -294,7 +373,10 @@ def _generate_knots_impl(x, y, w, xb, xe, k, s, nest, xp=np):
             # c  if n = nmax, sinf(x) is an interpolating spline.
             # c  if n=nmax we locate the knots as for interpolation.
             if n >= nmax:
-                t = _not_a_knot(x, k)
+                if not periodic:
+                    t = _not_a_knot(x, k)
+                else:
+                    t = _periodic_knots(x, k)
                 yield xp.asarray(t)
                 return
 
@@ -306,7 +388,7 @@ def _generate_knots_impl(x, y, w, xb, xe, k, s, nest, xp=np):
 
             # recompute if needed
             if j < nplus - 1:
-                residuals, _ = _get_residuals(x, y, t, k, w=w)
+                residuals, _ = _get_residuals(x, y, t, k, w=w, periodic=periodic)
 
     # this should never be reached
     return
@@ -465,7 +547,7 @@ class F:
         # the QR factorization of the data matrix, if not provided
         # NB: otherwise, must be consistent with x,y & s, but this is not checked
         if R is None and Y is None:
-            R, Y, _ = _lsq_solve_qr(x, y, t, k, w)
+            R, Y, _, _, _ = _lsq_solve_qr(x, y, t, k, w)
 
         # prepare to combine R and the discontinuity matrix (AB); also r.h.s. (YY)
         # https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L269
@@ -507,14 +589,179 @@ class F:
         _dierckx.qr_reduce(AB, offset, nc, QY, startrow=nc)
 
         # solve for the coefficients
-        c = _dierckx.fpback(AB, nc, QY)
+        c, _, fp = _dierckx.fpback(AB, nc, self.x, self.y, self.t, self.k, self.w, QY)
 
         spl = BSpline(self.t, c, self.k)
-        residuals = _compute_residuals(self.w**2, spl(self.x), self.y)
-        fp = residuals.sum()
-
         self.spl = spl   # store it
 
+        return fp - self.s
+
+class Fperiodic:
+    """
+    Fit a smooth periodic B-spline curve to given data points.
+
+    This class fits a periodic B-spline curve S(t) of degree k through data points
+    (x, y) with knots t. The spline is smooth and repeats itself at the start and
+    end, meaning the function and its derivatives up to order k-1 are equal
+    at the boundaries.
+
+    We want to find spline coefficients c that minimize the difference between
+    the spline and the data, while also keeping the spline smooth. This is done
+    by solving:
+
+        minimize || W^{1/2} (Y - B c) ||^2 + s * c^T @ R @ c
+        subject to periodic constraints on c.
+
+    where:
+      - Y is the data values,
+      - B is the matrix of B-spline basis functions at points x,
+      - W is a weighting matrix for the data points,
+      - s is the smoothing parameter (larger s means smoother curve),
+      - R is a matrix that penalizes wiggliness of the spline,
+      - c spline coefficients to be solved for
+      - periodic constraints ensure the spline repeats smoothly.
+
+    The solution is obtained by forming augmented matrices and performing
+    a QR factorization that incorporates these constraints, following the
+    approach in FITPACK's `fpperi.f`.
+
+    Parameters:
+    -----------
+    x : array_like, shape (n,)
+    y : array_like, shape (n, m)
+    t : array_like, shape (nt,)
+        Knot vector for the spline
+    k : int
+        Degree of the spline.
+    s : float
+        Controls smoothness: bigger s means smoother curve, smaller s fits data closer.
+    w : array_like, shape (n,), optional
+        Weights for data points. Defaults to all ones.
+    R, Y, A1, A2, Z : arrays, optional
+        Precomputed matrices from least squares and QR factorization steps to speed up
+        repeated fits with the same knots and data.
+
+    Attributes:
+    -----------
+    G1, G2 : arrays
+        Augmented matrices combining the original QR factors and constraints related to
+        the spline basis and data. G1 is roughly the "upper-triangular" part;
+        G2 contains additional constraint information for periodicity.
+
+    H1, H2 : arrays
+        Matrices associated with the discontinuity jump constraints of the k-th
+        derivative of B-splines at the knots. These encode the periodicity
+        conditions and are scaled by the smoothing parameter.
+
+    offset : array
+        Offset indices used for efficient indexing during QR reduction.
+
+    Methods:
+    --------
+    __call__(p):
+        Perform QR reduction of augmented matrices scaled by 1/p, solve for spline
+        coefficients, and return residual difference fp - s.
+
+    References:
+    -----------
+    - FITPACK's fpperi.f and fpcurf.f Fortran routines for periodic spline fitting.
+    """
+    def __init__(self, x, y, t, k, s, w=None, *,
+                 R=None, Y=None, A1=None, A2=None, Z=None):
+        # Initialize the class with input data points x, y,
+        # knot vector t, spline degree k, smoothing factor s,
+        # optional weights w, and optionally precomputed matrices.
+        self.x = x
+        self.y = y
+        self.t = t
+        self.k = k
+
+        # If weights not provided, default to uniform weights (all ones)
+        w = np.ones_like(x, dtype=float) if w is None else w
+
+        if w.ndim != 1:
+            raise ValueError(f"{w.ndim = } != 1.")
+        self.w = w
+
+        self.s = s
+
+        if y.ndim != 2:
+            raise ValueError(f"F: expected y.ndim == 2, got {y.ndim = } instead.")
+
+        # ### precompute matrices and factors needed for spline fitting ###
+
+        # Compute the discontinuity jump vector 'b' for the k-th derivative
+        # of B-splines at internal knots. This is needed for enforcing
+        # periodicity constraints. The jump discontinuities are stored in b.
+        # Refer: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpcurf.f#L252
+        b, b_offset, b_nc = disc(t, k)
+
+        # If QR factorization or auxiliary matrices (A1, A2, Z) are not provided,
+        # compute them via least squares on the data (x,y) with weights w.
+        # These matrices come from fitting B-spline basis to data.
+        if ((A1 is None or A2 is None or Z is None) or
+            (R is None and Y is None)):
+            # _lsq_solve_qr_for_root_rati_periodic computes QR factorization of
+            # data matrix and returns related matrices.
+            # Refer: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpperi.f#L171-L215
+            R, A1, A2, Z, _, _, _, _ = _lsq_solve_qr_for_root_rati_periodic(
+                x, y, t, k, w)
+
+        # Initialize augmented matrices G1, G2, H1, H2 and offset used
+        # for periodic B-spline fitting with constraints.
+        # This calls the C++ function `init_augmented_matrices` to set
+        # up these matrices based on A1, A2, and discontinuity vector b.
+        # Refer: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpperi.f#L441-L493
+        G1, G2, H1, H2, offset = _dierckx.init_augmented_matrices(A1, A2, b, len(t), k)
+
+        # Store these matrices as class attributes for use in evaluation
+        self.G1_ = G1
+        self.G2_ = G2
+        self.H1_ = H1
+        self.H2_ = H2
+        self.Z_ = Z
+        self.offset_ = offset
+
+    def __call__(self, p):
+        # Create copies of the augmented matrices to avoid overwriting originals
+        G1 = self.G1_.copy()
+        G2 = self.G2_.copy()
+        H1 = self.H1_.copy()
+        H2 = self.H2_.copy()
+        Z = self.Z_.copy()
+
+        # Scale H1 and H2 by the inverse of p (1/p), applying the pinv multiplier
+        # This scaling is required before QR reduction step to control smoothing.
+        pinv = 1/p
+        H1 = H1 * pinv
+        H2 = H2 * pinv
+
+        # Initialize vector c for coefficients with shape compatible with matrices.
+        # The first part of c is set from Z, which is related to least squares fit.
+        c = np.empty((len(self.t) - self.k - 1, Z.shape[1]), dtype=Z.dtype)
+        c[:len(self.t) - 2*self.k - 1, :] = Z[:len(self.t) - 2*self.k - 1, :]
+
+        # Perform QR factorization reduction on the augmented matrices
+        # This corresponds to the C++ function qr_reduce_augmented_matrices.
+        # It applies Givens rotations to eliminate entries and
+        # reduces the problem dimension by accounting for constraints.
+        # Refer: https://github.com/scipy/scipy/blob/maintenance/1.16.x/scipy/interpolate/fitpack/fpperi.f#L498-L534
+        _dierckx.qr_reduce_augmented_matrices(
+            G1, G2, H1, H2, c, self.offset_, len(self.t), self.k)
+
+        # Solve for the B-spline coefficients by backward substitution
+        # using the reduced matrices. This corresponds to the fpbacp routine in fitpack.
+        c, _, fp = _dierckx.fpbacp(
+            G1, G2, c,
+            self.k, self.k + 1, self.x[:-1], self.y[:-1, :],
+            self.t, self.w[:-1])
+
+        # Construct a BSpline object using knot vector t, coefficients c, and degree k
+        spl = BSpline(self.t, c, self.k)
+        self.spl = spl  # store it in the object
+
+        # Return the difference between the final residual fp and smoothing parameter s
+        # This quantity is used to assess fit quality in root-finding procedures.
         return fp - self.s
 
 
@@ -656,8 +903,7 @@ def root_rati(f, p0, bracket, acc):
 
     return Bunch(converged=converged, root=p, iterations=it, ier=ier)
 
-
-def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, xp=np):
+def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, periodic, xp=np):
     """Shared infra for make_splrep and make_splprep.
     """
     acc = s * TOL
@@ -666,7 +912,11 @@ def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, xp=np):
     if nest is None:
         # the max number of knots. This is set in _fitpack_impl.py line 274
         # and fitpack.pyf line 198
-        nest = max(m + k + 1, 2*k + 3)
+        # Ref: https://github.com/scipy/scipy/blob/596b586e25e34bd842b575bac134b4d6924c6556/scipy/interpolate/_fitpack_impl.py#L260-L263
+        if periodic:
+            nest = max(m + 2*k, 2*k + 3)
+        else:
+            nest = max(m + k + 1, 2*k + 3)
     else:
         if nest < 2*(k + 1):
             raise ValueError(f"`nest` too small: {nest = } < 2*(k+1) = {2*(k+1)}.")
@@ -674,14 +924,14 @@ def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, xp=np):
             raise ValueError("Either supply `t` or `nest`.")
 
     if t is None:
-        gen = _generate_knots_impl(x, y, w, xb, xe, k, s, nest)
+        gen = _generate_knots_impl(x, y, w, xb, xe, k, s, nest, periodic)
         t = list(gen)[-1]
     else:
-        fpcheck(x, t, k)
+        fpcheck(x, t, k, periodic=periodic)
 
     if t.shape[0] == 2 * (k + 1):
         # nothing to optimize
-        _, _, c = _lsq_solve_qr(x, y, t, k, w)
+        _, _, c, _, _ = _lsq_solve_qr(x, y, t, k, w, periodic=periodic)
         t, c = xp.asarray(t), xp.asarray(c)
         return BSpline(t, c, k)
 
@@ -689,23 +939,46 @@ def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, xp=np):
 
     # c  initial value for p.
     # https://github.com/scipy/scipy/blob/maintenance/1.11.x/scipy/interpolate/fitpack/fpcurf.f#L253
-    R, Y, _ = _lsq_solve_qr(x, y, t, k, w)
+    if periodic:
+        # N.B. - Check _lsq_solve_qr computation
+        # of p for periodic splines
+        R, A1, A2, Z, Y, _, p, _ = _lsq_solve_qr_for_root_rati_periodic(x, y, t, k, w)
+    else:
+        R, Y, _, _, _ = _lsq_solve_qr(x, y, t, k, w, periodic=periodic)
     nc = t.shape[0] -k -1
-    p = nc / R[:, 0].sum()
+    if not periodic:
+        p = nc / R[:, 0].sum()
 
     # ### bespoke solver ####
     # initial conditions
     # f(p=inf) : LSQ spline with knots t   (XXX: reuse R, c)
-    _, fp = _get_residuals(x, y, t, k, w=w)
+    # N.B. - Check _lsq_solve_qr which is called
+    # via _get_residuals for logic behind
+    # computation of fp for periodic splines
+    _, fp = _get_residuals(x, y, t, k, w, periodic=periodic)
     fpinf = fp - s
 
     # f(p=0): LSQ spline without internal knots
-    _, fp0 = _get_residuals(x, y, np.array([xb]*(k+1) + [xe]*(k+1)), k, w)
-    fp0 = fp0 - s
+    if not periodic:
+        _, fp0 = _get_residuals(x, y, np.array([xb]*(k+1) + [xe]*(k+1)), k, w)
+        fp0 = fp0 - s
+    else:
+        # f(p=0) is fp for constant function
+        # in case of periodic splines
+        per = xe - xb
+        tc = np.zeros(2*(k + 1), dtype=float)
+        for i in range(0, k + 1):
+            tc[i] = x[0] - (k - i) * per
+            tc[i + k + 1] = x[m - 1] + i * per
+        _, fp0 = _get_residuals(x, y, tc, k, w, periodic=periodic)
+        fp0 = fp0 - s
 
     # solve
     bracket = (0, fp0), (np.inf, fpinf)
-    f = F(x, y, t, k=k, s=s, w=w, R=R, Y=Y)
+    if not periodic:
+        f = F(x, y, t, k=k, s=s, w=w, R=R, Y=Y)
+    else:
+        f = Fperiodic(x, y, t, k=k, s=s, w=w, R=R, Y=Y, A1=A1, A2=A2, Z=Z)
     _ = root_rati(f, p, bracket, acc)
 
     # solve ALTERNATIVE: is roughly equivalent, gives slightly different results
@@ -724,7 +997,8 @@ def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, xp=np):
     return spl
 
 
-def make_splrep(x, y, *, w=None, xb=None, xe=None, k=3, s=0, t=None, nest=None):
+def make_splrep(x, y, *, w=None, xb=None, xe=None,
+                k=3, s=0, t=None, nest=None, bc_type=None):
     r"""Create a smoothing B-spline function with bounded error, minimizing derivative jumps.
 
     Given the set of data points ``(x[i], y[i])``, determine a smooth spline
@@ -773,6 +1047,20 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None, k=3, s=0, t=None, nest=None):
         The actual number of knots returned by this routine may be slightly
         larger than `nest`.
         Default is None (no limit, add up to ``m + k + 1`` knots).
+    periodic : bool, optional
+        If True, data points are considered periodic with period ``x[m-1]`` -
+        ``x[0]`` and a smooth periodic spline approximation is returned. Values of
+        ``y[m-1]`` and ``w[m-1]`` are not used.
+        The default is False, corresponding to boundary condition 'not-a-knot'.
+    bc_type : str, optional
+        Boundary conditions.
+        Default is `"not-a-knot"`.
+        The following boundary conditions are recognized:
+
+        * ``"not-a-knot"`` (default): The first and second segments are the
+          same polynomial. This is equivalent to having ``bc_type=None``.
+        * ``"periodic"``: The values and the first ``k-1`` derivatives at the
+          ends are equivalent.
 
     Returns
     -------
@@ -845,23 +1133,28 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None, k=3, s=0, t=None, nest=None):
     """  # noqa:E501
     xp = array_namespace(x, y, w, t)
     if t is not None:
-        t = np.asarray(t)
+        t = xp.asarray(t)
+    bc_type = _validate_bc_type(bc_type)
 
     if s == 0:
         if t is not None or w is not None or nest is not None:
             raise ValueError("s==0 is for interpolation only")
-        return make_interp_spline(x, y, k=k)
+        return make_interp_spline(x, y, k=k, bc_type=bc_type)
 
-    x, y, w, k, s, xb, xe = _validate_inputs(x, y, w, k, s, xb, xe, parametric=False)
+    periodic = (bc_type == 'periodic')
 
-    spl = _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, xp=xp)
+    x, y, w, k, s, xb, xe = _validate_inputs(x, y, w, k, s, xb, xe,
+                                             parametric=False, periodic=periodic)
+
+    spl = _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, periodic, xp=xp)
 
     # postprocess: squeeze out the last dimension: was added to simplify the internals.
     spl.c = spl.c[:, 0]
     return spl
 
 
-def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=None):
+def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
+                 k=3, s=0, t=None, nest=None, bc_type=None):
     r"""
     Create a smoothing parametric B-spline curve with bounded error, minimizing derivative jumps.
 
@@ -918,6 +1211,15 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=
         The actual number of knots returned by this routine may be slightly
         larger than `nest`.
         Default is None (no limit, add up to ``m + k + 1`` knots).
+    bc_type : str, optional
+        Boundary conditions.
+        Default is `"not-a-knot"`.
+        The following boundary conditions are recognized:
+
+        * ``"not-a-knot"`` (default): The first and second segments are the
+          same polynomial. This is equivalent to having ``bc_type=None``.
+        * ``"periodic"``: The values and the first ``k-1`` derivatives at the
+          ends are equivalent.
 
     Returns
     -------
@@ -984,6 +1286,10 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=
         Numerical Analysis, Oxford University Press, 1993.
     """  # noqa:E501
 
+    bc_type = _validate_bc_type(bc_type)
+
+    periodic = (bc_type == 'periodic')
+
     # x can be either a 2D array or a list of 1D arrays
     if isinstance(x, list):
         xp = array_namespace(*x, w, u, t)
@@ -1003,11 +1309,14 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=
             raise ValueError("s==0 is for interpolation only")
         return make_interp_spline(u, x.T, k=k, axis=1), u
 
-    u, x, w, k, s, ub, ue = _validate_inputs(u, x, w, k, s, ub, ue, parametric=True)
-    if t is not None:
-        t = np.asarray(t)
+    u, x, w, k, s, ub, ue = _validate_inputs(u, x, w, k, s, ub, ue,
+                                             parametric=True, periodic=periodic)
 
-    spl = _make_splrep_impl(u, x, w, ub, ue, k, s, t, nest, xp=xp)
+    if t is not None:
+        t = xp.asarray(t)
+
+    spl = _make_splrep_impl(u, x, w, ub, ue, k, s, t,
+                            nest, periodic=periodic, xp=xp)
 
     # posprocess: `axis=1` so that spl(u).shape == np.shape(x)
     # when `x` is a list of 1D arrays (cf original splPrep)

--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -171,10 +171,176 @@ data_matrix( /* inputs */
     *nc = len_t - k - 1;
 }
 
+/*
+ * Constructs the data matrix A for periodic B-spline basis functions.
+ *
+ * Inputs:
+ *  - xptr: array of x values, shape (m,)
+ *  - m: number of data points
+ *  - tptr: knot vector, shape (len_t,)
+ *  - len_t: length of knot vector
+ *  - k: spline degree
+ *  - wptr: weights for each x value, shape (m,)
+ *  - extrapolate: whether extrapolation outside knot range is allowed
+ *
+ * Outputs:
+ *  - Aptr: output matrix A, shape (m, k+1), holds basis function values
+ *  - H1ptr: periodic correction matrix H1, shape (m, k+1)
+ *  - H2ptr: periodic correction matrix H2, shape (m, k)
+ *  - offset_ptr: index array of shape (m,), each x lies in knot interval [offset(i) + k, offset(i) + k + 1)
+ *  - nc: number of spline coefficients (len_t - k - 1)
+ *
+ * Work array:
+ *  - wrk: temporary workspace of size (2k + 2), used by De Boor’s algorithm
+ */
+void
+data_matrix_periodic( /* inputs */
+            const double *xptr, int64_t m,
+            const double *tptr, int64_t len_t,
+            int k,
+            const double *wptr,
+            int extrapolate,
+            /* outputs */
+            double *Aptr,
+            double *H1ptr,
+            double *H2ptr,
+            int64_t *offset_ptr,
+            int64_t *nc,
+            /* work array*/
+            double *wrk)
+{
+    // Wrap raw input pointers into readable array types
+    auto x = ConstRealArray1D(xptr, m);
+    auto t = ConstRealArray1D(tptr, len_t);
+    auto w = ConstRealArray1D(wptr, m);
+    auto A = RealArray2D(Aptr, m, k + 1);
+    auto H1 = RealArray2D(H1ptr, m, k + 1);
+    auto H2 = RealArray2D(H2ptr, m, k);
+    auto offset = Array1D<int64_t, false>(offset_ptr, m);
+
+    // Initialize H1 and H2 to zeros
+    for( int64_t i = 0; i < m; i++ ) {
+        for( int64_t j = 0; j < k; j++ ) {
+            H1(i, j) = 0.0;
+            H2(i, j) = 0.0;
+        }
+        H1(i, k) = 0.0;
+    }
+
+    // Start search for x interval from index k (first possible non-zero region)
+    int64_t ind = k;
+
+    // Loop through each x value to construct rows of A, H1, H2
+    for (int i=0; i < m; ++i) {
+        double xval = x(i);
+
+        // Find index `ind` such that t[ind] <= xval < t[ind + 1]
+        ind = _find_interval(t.data, len_t, k, xval, ind, extrapolate);
+
+        // Handle invalid case: x out of knot range and extrapolation not allowed
+        if (!extrapolate && ind < 0) {
+            throw std::runtime_error("find_interval: out of bounds with x = " + std::to_string(xval));
+        }
+
+        // Set offset for this row; it indicates the starting index in the full coefficient array
+        // where the k+1 non-zero basis functions for x[i] should be applied
+        int64_t offseti = ind - k;
+        offset(i) = offseti;
+
+        // Compute the k+1 non-zero B-spline basis values at xval
+        _deBoor_D(t.data, xval, k, ind, 0, wrk);
+
+        // Fill A matrix with weighted basis values
+        for (int64_t j = 0; j < k + 1; ++j) {
+            A(i, j) = wrk[j] * w(i);
+        }
+
+        // ---- PERIODIC CORRECTION HANDLING ----
+        // ----------------------------------------------------------------------------
+        // In periodic B-splines, basis functions near the domain boundaries "wrap around"
+        // due to periodicity. This causes the data matrix to be conceptually banded
+        // but with values that go past the left or right ends.
+        //
+        // To handle this, we split the full dense data matrix D row-wise into:
+        //   - A(i, :)  → in-range basis values (no wrap)
+        //   - H1(i, :) → wrapped values from right end that wrap back into domain (positive wrap)
+        //   - H2(i, :) → wrapped values from left underflow (negative wrap)
+        //
+        // This preserves sparsity and enables efficient periodic QR reduction later.
+        //
+        // Example (assume degree k = 2):
+        //
+        // Full dense row D[i]: [ 0   0   b0   b1   b2   0   0   0   b3   b4 ]
+        // Index (j):           [ 0   1    2    3    4   5   6   7    8    9 ]
+        //                                      ↑    ↑    ↑
+        //                                      A    A    A
+        //                                                        ↑    ↑
+        //                                                       H2   H2
+        //
+        // Suppose offset[i] = 2, so:
+        //
+        //   A[i]  = [ b0, b1, b2 ]       → basis at indices 2, 3, 4
+        //   H1[i] = [  0,  0,  0 ]       → no positive wrap-around here
+        //   H2[i] = [ b4, b3 ]           → values that wrapped around left
+        //                                 and landed in indices -1, 0
+        //
+        // This decomposition allows us to keep the data matrix compact,
+        // and still capture all contributions due to periodicity.
+        // ----------------------------------------------------------------------------
+
+
+        // If x lies in the last 2k intervals of the knot vector, apply correction.
+        int64_t l = ind + 1;
+        if (l >= len_t - 2*k) {
+            int64_t j;
+            // First, reset H1 and H2 for the current row to zero
+            for (int64_t j = 0; j < k; ++j) {
+                H1(i, j) = 0;
+                H2(i, j) = 0;
+            }
+            H1(i, k) = 0;
+
+            // Initialize j to the index offset for periodic correction
+            j = l - len_t + 2*k;
+
+            // Loop over all (k+1) non-zero B-spline basis functions
+            for (int64_t i1 = 0; i1 < k+1; i1++) {
+                j += 1;
+
+                // l0: index after wrapping right end of the knot vector (used for periodic correction)
+                int64_t l0 = j;
+
+                // l1: corresponding "wrapped" index in original coefficient space
+                int64_t l1 = l0 - k;
+
+                // If l1 is still out of valid range, wrap it again until it fits
+                while (l1 > std::max(int64_t(0), len_t - 3*k - 1)) {
+                    // Apply modular arithmetic to wrap l1 to the start
+                    l0 = l1 - len_t + 3*k + 1;
+                    l1 = l0 - k;
+                }
+
+                // Now assign weighted basis value to H1 or H2 depending on index
+                if( l1 > 0 ) {
+                    // Normal wrap-around: put contribution into H1
+                    H1(i, l1 - 1) = wrk[i1] * w(i);
+                } else {
+                    // Negative wrap-around: accumulate contribution into H2
+                    // This ensures full periodic coverage even for overlapping parts
+                    H2(i, l0 - 1) += wrk[i1] * w(i);
+                }
+            }
+        }
+    }
+
+    // Set total number of coefficients = number of intervals = len(t) - k - 1
+    *nc = len_t - k - 1;
+}
+
 
 /*
  *   Solve the LSQ problem ||y - A@c||^2 via QR factorization.
- *  
+ *
     QR factorization follows FITPACK: we reduce A row-by-row by Givens rotations.
     To zero out the lower triangle, we use in the row `i` and column `j < i`,
     the diagonal element in that column. That way, the sequence is
@@ -262,6 +428,450 @@ qr_reduce(double *aptr, const int64_t m, const int64_t nz, // a(m, nz), packed
     } // for(i = ...
 }
 
+/**
+ * Performs QR reduction for periodic B-spline fitting.
+ *
+ * aptr: pointer to A (m, nz), holds basis function values
+ * h1ptr: periodic correction matrix H1, shape (m, k+1).
+ * h2ptr: periodic correction matrix H2, shape (m, k).
+ * m: number of data points.
+ * nz: number of non-zero B-spline basis functions.
+ * offset: index array of shape (m,), each x lies in knot interval [offset(i) + k, offset(i) + k + 1).
+ * nc: number of spline coefficients (len_t - k - 1).
+ * yptr: pointer to y (m + 1, ydim1): observed y-values (or RHS).
+ * ydim1: number of columns in y (typically 1).
+ * k: spline degree.
+ * len_t: length of knot vector.
+ * a1ptr: pointer to A1 ((len_t - k - 1) x (k + 1)): upper-triangular QR matrix.
+ * a2ptr: pointer to A2 ((len_t - 2k - 1) x k): for periodic boundary reduction.
+ * zptr: pointer to z (len_t - k - 1): transformed RHS vector.
+ * init_p: if true, compute smoothing term 'p'.
+ * p: Reference to smoothing term.
+ */
+void qr_reduce_periodic(
+    double *aptr, double *h1ptr, double *h2ptr,
+    const int64_t m, const int64_t nz,
+    int64_t *offset,
+    const int64_t nc,
+    double *yptr, const int64_t ydim1,
+    const int k, const int64_t len_t,
+    double *a1ptr,
+    double *a2ptr,
+    double *zptr,
+    double& fp,
+    bool init_p,
+    double& p
+) {
+    // Wrap raw pointers with helper matrix/array types
+    auto H  = RealArray2D(aptr, m, nz);
+    auto H1 = RealArray2D(h1ptr, m, nz);
+    auto H2 = RealArray2D(h2ptr, m, nz - 1);
+    auto A1 = RealArray2D(a1ptr, len_t - k - 1, k + 1);      // Main upper-triangular matrix
+    auto A2 = RealArray2D(a2ptr, len_t - 2*k - 1, k);        // For enforcing periodicity
+    auto z  = RealArray2D(zptr, len_t - k - 1, ydim1);              // Transformed RHS
+    auto y  = RealArray2D(yptr, m + 1, ydim1);               // Input/output Y vector
+    fp = 0.0;
+
+    std::vector<double> yi(ydim1, 0.0);
+
+    // Reset A1 and z to zero
+    for( int64_t i = 1; i <= len_t - k - 1; i++ ) {
+        for( int64_t ydimi = 0; ydimi < ydim1; ydimi++ ) {
+            z(i - 1, ydimi) = 0.0;
+        }
+        for( int64_t j = 1; j <= k + 1; j++ ) {
+            A1(i - 1, j - 1) = 0.0;
+        }
+    }
+
+    int64_t jper = 0;                    // Flag to initialize periodic block once
+    int64_t nk1 = len_t - k - 1;         // Total number of B-spline coefficients
+    int64_t n7 = nk1 - k;                // coefficients not used for periodicity
+    int64_t n10 = n7 - k;                // coefficients strictly away from periodic boundary
+
+    // Main loop over all data points
+    for( int64_t it = 1; it <= m; it++ ) {
+        for( int64_t ydimi = 0; ydimi < ydim1; ydimi++ ) {
+            yi[ydimi] = y(it - 1, ydimi);
+        }
+        int64_t ind = offset[it - 1] + k;
+        int64_t l = ind + 1;                          // l = leftmost non-zero + degree + 1
+        int64_t l5 = l - k - 1;
+
+        // Case 1: Point falls within the periodic boundary range
+        if (l5 >= n10) {
+
+            // Initialize A2 for the periodic case — run only once
+            if( jper == 0 ) {
+                for( int64_t i = 1; i <= n7; i++ ) {
+                    for( int64_t j = 1; j <= k; j++ ) {
+                        A2(i - 1, j - 1) = 0;
+                    }
+                }
+
+                // Copy tail of A1 into top of A2 for enforcing periodic constraints
+                int64_t jk = n10 + 1;
+                for( int64_t i = 1; i <= k; i++ ) {
+                    int64_t ik = jk;
+                    for( int64_t j = 1; j <= k + 1; j++ ) {
+                        if( ik <= 0 ) break;
+                        A2(ik - 1, i - 1) = A1(ik - 1, j - 1);
+                        ik--;
+                    }
+                    jk++;
+                }
+                jper = 1;
+            }
+
+            // Phase 1: Apply Givens rotations to reduce A1 and A2 to triangular form
+            if (n10 > 0) {
+                for( int64_t j = 1; j <= n10; j++ ) {
+                    double piv = H1(it - 1, 0);
+                    if( piv == 0.0 ) {
+                        // Shift H1 left
+                        for (int64_t h1i = 1; h1i <= k; h1i++) {
+                            H1(it - 1, h1i - 1) = H1(it - 1, h1i);
+                        }
+                        H1(it - 1, k) = 0.0;
+                    } else {
+                        // Apply Givens rotation
+                        double c, s, r;
+                        DLARTG(&A1(j - 1, 0), &piv, &c, &s, &r);
+                        A1(j - 1, 0) = r;
+
+                        for( int64_t ydimi = 0; ydimi < ydim1; ydimi++ ) {
+                            std::tie(z(j - 1, ydimi), yi[ydimi]) =
+                                fprota(c, s, z(j - 1, ydimi), yi[ydimi]);
+                        }
+                        for( int64_t h2i = 1; h2i <= k; h2i++ ) {
+                            std::tie(A2(j - 1, h2i - 1), H2(it - 1, h2i - 1)) = fprota(
+                                c, s, A2(j - 1, h2i - 1), H2(it - 1, h2i - 1));
+                        }
+
+                        if( j == n10 ) {
+                            break;
+                        }
+
+                        int64_t i2 = std::min(n10 - j, (int64_t)k) + 1;
+                        for( int64_t h1i = 1; h1i < i2; h1i++ ) {
+                            std::tie(A1(j - 1, h1i), H1(it - 1, h1i)) = fprota(c, s, A1(j - 1, h1i), H1(it - 1, h1i));
+                        }
+
+                        for( int64_t h1i = 1; h1i <= i2; h1i++ ) {
+                            H1(it - 1, h1i - 1) = H1(it - 1, h1i);
+                        }
+                        H1(it - 1, i2 - 1) = 0.0;
+                    }
+                }
+            }
+
+            // Phase 2: Givens rotations on A2 portion
+            for( int64_t j = 1; j <= k; j++ ) {
+                int64_t ij = n10 + j;
+                double piv = H2(it - 1, j - 1);
+                if (ij <= 0 || piv == 0.0) {
+                    continue;
+                }
+
+                double c, s, r;
+                DLARTG(&A2(ij - 1, j - 1), &piv, &c, &s, &r);
+                A2(ij - 1, j - 1) = r;
+                for( int64_t ydimi = 0; ydimi < ydim1; ydimi++ ) {
+                    std::tie(z(ij - 1, ydimi), yi[ydimi]) =
+                        fprota(c, s, z(ij - 1, ydimi), yi[ydimi]);
+                }
+
+                if( j == k ) {
+                    break;
+                }
+
+                for( int64_t h2i = j + 1; h2i <= k; h2i++ ) {
+                    std::tie(A2(ij - 1, h2i - 1), H2(it - 1, h2i - 1)) = fprota(
+                        c, s, A2(ij - 1, h2i - 1), H2(it - 1, h2i - 1));
+                }
+            }
+
+        } else {
+            // Case 2: Observation lies completely outside periodic range
+            int64_t j = l5;
+            for( int64_t i = 1; i <= k + 1; i++ ) {
+                j++;
+                double piv = H(it - 1, i - 1);
+                if( piv == 0.0 ) {
+                    continue;
+                }
+
+                double c, s, r;
+                DLARTG(&A1(j - 1, 0), &piv, &c, &s, &r);
+                A1(j - 1, 0) = r;
+                for( int64_t ydimi = 0; ydimi < ydim1; ydimi++ ) {
+                    std::tie(z(j - 1, ydimi), yi[ydimi]) = fprota(c, s, z(j - 1, ydimi), yi[ydimi]);
+                }
+
+                if( i == k + 1 ) {
+                    break;
+                }
+                int64_t i2 = 1;
+                for( int64_t i1 = i + 1; i1 <= k + 1; i1++ ) {
+                    i2++;
+                    std::tie(A1(j - 1, i2 - 1), H(it - 1, i1 - 1)) = fprota(
+                        c, s, A1(j - 1, i2 - 1), H(it - 1, i1 - 1));
+                }
+            }
+        }
+        for( int64_t ydimi = 0; ydimi < ydim1; ydimi++ ) {
+            fp += yi[ydimi] * yi[ydimi];
+        }
+    }
+
+    // Compute smoothing term 'p'
+    if( init_p ) {
+        p = 0.0;
+        int64_t l = n7;
+        for( int64_t i = 1; i <= k; i++ ) {
+            int64_t j = k + 1 - i;
+            p += A2(l - 1, j - 1);
+            l--;
+            if( l == 0 ) {
+                break;
+            }
+        }
+
+        if( l != 0 ) {
+            for( int64_t i = 0; i < n10; i++ ) {
+                p += A1(i, 0);
+            }
+        }
+        p = n7/p;
+    }
+}
+
+/**
+ * Applies QR reduction on augmented matrices using Givens rotations.
+ *
+ * Example for k=1, len_t=7 (small sizes):
+ *
+ * Dimensions:
+ *   g1: (4 x 3), g2: (4 x 2)
+ *   h1: (3 x 3), h2: (3 x 2)
+ *   c : (5 x 1), offset: (3)
+ *
+ * Initial matrices (example values):
+ * g1 = [ [3.0, 2.0, 1.0],
+ *        [4.0, 3.0, 2.0],
+ *        [5.0, 4.0, 3.0],
+ *        [6.0, 5.0, 4.0] ]
+ *
+ * g2 = [ [1.0, 2.0],
+ *        [2.0, 3.0],
+ *        [3.0, 4.0],
+ *        [4.0, 5.0] ]
+ *
+ * h1 = [ [2.0, 1.0, 0.0],
+ *        [1.0, 2.0, 1.0],
+ *        [0.0, 1.0, 2.0] ]
+ *
+ * h2 = [ [1.0, 0.0],
+ *        [0.0, 1.0],
+ *        [1.0, 1.0] ]
+ *
+ * c = [ [1.0],
+ *       [1.5],
+ *       [2.0],
+ *       [2.5],
+ *       [3.0] ]
+ *
+ * offset = [1, 1, 2]
+ *
+ * Iteration it=1:
+ * - offset(0) = 1
+ * - For j=1 to 2:
+ *    * piv = h1(0,0) = 2.0
+ *    * Apply Givens rotation on (g1(0,0)=3.0, piv=2.0) to zero out h1(0,0):
+ *       - Compute (cos, sin, r) so that:
+ *         [cos sin; -sin cos] * [3.0; 2.0] = [r; 0]
+ *       - Example result: r=3.6056, cos=0.8321, sin=0.5547
+ *    * Update g1(0,0) = r = 3.6056
+ *    * Rotate c(0,0) and yi=0 with (cos,sin), c(0,0) ≈ 0.8321, yi ≈ -0.5547
+ *    * For h2i in 0 to 1:
+ *      - Rotate pairs (g2(0,h2i), h2(0,h2i)) with same rotation
+ *    * For h1i in 1 to min(k+1, remaining cols):
+ *      - Rotate pairs (g1(0,h1i), h1(0,h1i))
+ *    * Shift h1 row left and zero last element
+ *
+ * Result:
+ *   h1(0,0) is zeroed,
+ *   corresponding elements in g1, g2, h2, c updated to maintain orthogonality.
+ *
+ * Subsequent iterations it=2, it=3 do similar Givens rotations to reduce
+ * matrices further towards upper-triangular form for stable solving.
+ *
+ * Purpose:
+ * - Systematically eliminate entries in h1, h2 (constraint matrices)
+ * - Update g1, g2 (main matrices) and c (solution vector)
+ * - Prepare system for efficient and stable spline coefficient computation
+ */
+void qr_reduce_augmented_matrices(
+    double* g1ptr, double* g2ptr,
+    double* h1ptr, double* h2ptr,
+    double* cptr, double* offsetptr,
+    int k, int64_t len_t, int64_t ydim2
+) {
+    auto g1 = RealArray2D(g1ptr, len_t - 2*k - 1, k + 2);  // Main block matrix part 1
+    auto g2 = RealArray2D(g2ptr, len_t - 2*k - 1, k + 1);  // Main block matrix part 2
+    auto h1 = RealArray2D(h1ptr, len_t - 2*k - 2, k + 2);  // Constraint matrix part 1 (to be zeroed out)
+    auto h2 = RealArray2D(h2ptr, len_t - 2*k - 2, k + 1);  // Constraint matrix part 2 (to be zeroed out)
+    auto c = RealArray2D(cptr, len_t - k - 1, ydim2);      // Right-hand side vector (updated during rotations)
+    auto offset = RealArray1D(offsetptr, len_t - 2*k - 2); // Offset array, starting row for rotations
+
+    std::vector<double> yi(ydim2, 0.0);
+
+    // Iterate over rows in the augmented matrix system (h1, h2 rows)
+    for( int64_t it = 1; it <= len_t - 2*k - 2; it++ ) {
+        for( int64_t ydimi = 0; ydimi < ydim2; ydimi++ ) {
+            yi[ydimi] = 0.0; // Auxiliary variable to hold rotated value of c
+        }
+
+        // Perform Givens rotations to zero out entries in h1 and update g1, g2, h2, c accordingly
+        for( int64_t j = offset(it - 1); j <= len_t - 3*k - 2; j++ ) {
+            // Pivot element from h1 that we want to zero out using rotation
+            double piv = h1(it - 1, 0);
+
+            double cos, sin, r;
+
+            // Compute Givens rotation parameters (cos, sin) to zero out piv when applied to g1(j-1,0)
+            // This solves: [cos sin; -sin cos] * [g1(j-1,0); piv] = [r; 0]
+            DLARTG(&g1(j - 1, 0), &piv, &cos, &sin, &r);
+
+            // Update g1 with the rotated value r (magnitude after rotation)
+            g1(j - 1, 0) = r;
+
+            // Apply the same rotation to c(j-1, 0) and yi (c vector updated to maintain system consistency)
+            for( int64_t ydimi = 0; ydimi < ydim2; ydimi++ ) {
+                std::tie(c(j - 1, ydimi), yi[ydimi]) =
+                    fprota(cos, sin, c(j - 1, ydimi), yi[ydimi]); // Auxiliary variable to hold rotated value of c
+            }
+
+
+            // Rotate pairs of elements in g2 and h2 with the same rotation to maintain orthogonality
+            for( int64_t h2i = 0; h2i < k + 1; h2i++ ) {
+                std::tie(g2(j - 1, h2i), h2(it - 1, h2i)) = fprota(cos, sin, g2(j - 1, h2i), h2(it - 1, h2i));
+            }
+
+            // If reached the last j in the loop, break since no more elements to rotate
+            if( j == (len_t - 3*k - 2) ) {
+                break ;
+            }
+
+            // Calculate number of elements to rotate between g1 and h1 for this step
+            int64_t i2 = std::min(len_t - 3*k - 2 - j, (int64_t) k + 1) + 1;
+
+            // Rotate pairs of elements in g1 and h1 with the same rotation for indices > 0
+            for( int64_t h1i = 1; h1i < i2; h1i++ ) {
+                std::tie(g1(j - 1, h1i), h1(it - 1, h1i)) = fprota(cos, sin, g1(j - 1, h1i), h1(it - 1, h1i));
+            }
+
+            // Shift h1 row left by one position to remove the zeroed element and set last to zero
+            for( int64_t h1i = 1; h1i <= (i2 - 1); h1i++ ) {
+                h1(it - 1, h1i - 1) = h1(it - 1, h1i);
+            }
+            h1(it - 1, i2 - 1) = 0.0; // Clear last shifted position (zeroed out)
+        }
+
+        // Now handle rotations on h2 part to zero out entries similarly
+        for( int64_t j = 1; j <= k + 1; j++ ) {
+            int64_t ij = len_t - 3*k - 2 + j; // Index in g2 to rotate with h2
+
+            if( ij <= 0 ) {
+                continue; // Skip if index out of bounds (safety check)
+            }
+
+            // Pivot element from h2 to be zeroed
+            double piv = h2(it - 1, j - 1);
+
+            double cos, sin, r;
+
+            // Compute Givens rotation parameters to zero out pivot against g2(ij-1, j-1)
+            DLARTG(&g2(ij - 1, j - 1), &piv, &cos, &sin, &r);
+
+            // Update g2 with rotated magnitude
+            g2(ij - 1, j - 1) = r;
+
+            // Rotate c(ij-1, 0) and yi with the same rotation to keep system consistent
+            for( int64_t ydimi = 0; ydimi < ydim2; ydimi++ ) {
+                std::tie(c(ij - 1, ydimi), yi[ydimi]) =
+                    fprota(cos, sin, c(ij - 1, ydimi), yi[ydimi]);
+            }
+
+            // If this is the last column in h2 for this row, break early
+            if( j == k + 1) {
+                break;
+            }
+
+            // Rotate remaining pairs in g2 and h2 in the same row with the rotation
+            for( int64_t h2i = j + 1; h2i <= k + 1; h2i++ ) {
+                std::tie(g2(ij - 1, h2i - 1), h2(it - 1, h2i - 1)) = fprota(
+                    cos, sin, g2(ij - 1, h2i - 1), h2(it - 1, h2i - 1));
+            }
+        }
+    }
+}
+
+void _compute_residuals(
+    /* inputs */
+    const double *xptr, int64_t m,      // x, shape (m,)
+    const double *yptr, int64_t ydim2,            // y(m, ydim2)
+    const double *tptr, int64_t len_t,  // t, shape (len_t,)
+    const double *wptr,                 // weights, shape (m,) // NB: len(w) == len(x), not checked
+    int k,
+    int extrapolate,
+    int64_t nc,
+    const double *cptr,                                 // c(nc, ydim2)
+    /* output */
+    double *fp,
+    double *residualsptr                            // residuals(m,)
+) {
+    auto x = ConstRealArray1D(xptr, m);
+    auto y = ConstRealArray2D(yptr, m, ydim2);
+    auto t = ConstRealArray1D(tptr, len_t);
+    auto w = ConstRealArray1D(wptr, m);
+    auto residuals = RealArray1D(residualsptr, m);
+    auto c = ConstRealArray2D(cptr, nc, ydim2);
+
+    *fp = 0.0;
+    double l = k + 2;
+    int64_t ind = k;
+    std::vector<double> wrk(2*k + 2);
+    for( int64_t it = 1; it <= m; it++ ) {
+        if( !(x(it - 1) < t(l - 1) || l > len_t - k - 1) ) {
+            l = l + 1;
+        }
+
+        double xval = x(it - 1);
+
+        // find the interval
+        ind = _find_interval(t.data, len_t, k, xval, ind, extrapolate);
+
+        // compute non-zero b-splines
+        _deBoor_D(t.data, xval, k, ind, 0, wrk.data());
+
+        residuals(it - 1) = 0.0;
+        for( int64_t yi = 0; yi < ydim2; yi++ ) {
+            double term = 0.0;
+            int64_t l0 = l - k - 2;
+
+            for( int64_t j = 1; j <= k + 1; j++ ) {
+                l0 = l0 + 1;
+                term = term + c(l0 - 1, yi) * wrk[j - 1];
+            }
+            double delta = w(it - 1) * (term - y(it - 1, yi));
+            term = delta * delta;
+            residuals(it - 1) += term;
+            *fp = *fp + term;
+        }
+    }
+}
+
 
 /*
  * Back substitution solve of `R @ c = y` with an upper triangular R.
@@ -285,17 +895,25 @@ void
 fpback( /* inputs*/
        const double *Rptr, int64_t m, int64_t nz,    // R(m, nz), packed
        int64_t nc,                                   // dense R would be (m, nc)
+       const double *xptr, int64_t m_,      // x, shape (m,)
+       const double *tptr, int64_t len_t,  // t, shape (len_t,)
+       int k,
+       const double *wptr,                 // weights, shape (m,) // NB: len(w) == len(x), not checked
+       int extrapolate,
+       const double* ywptr,
        const double *yptr, int64_t ydim2,            // y(m, ydim2)
         /* output */
-       double *cptr)                                 // c(nc, ydim2)
+       double *cptr,                                 // c(nc, ydim2)
+       double *fp,
+       double *residualsptr)                            // residuals(m,)
 {
     auto R = ConstRealArray2D(Rptr, m, nz);
-    auto y = ConstRealArray2D(yptr, m, ydim2);
+    auto yw = ConstRealArray2D(ywptr, m, ydim2);
     auto c = RealArray2D(cptr, nc, ydim2);
 
     // c[nc-1, ...] = y[nc-1] / R[nc-1, 0]
     for (int64_t l=0; l < ydim2; ++l) {
-        c(nc - 1, l) = y(nc - 1, l) / R(nc-1, 0);
+        c(nc - 1, l) = yw(nc - 1, l) / R(nc - 1, 0);
     }
 
     //for i in range(nc-2, -1, -1):
@@ -304,7 +922,7 @@ fpback( /* inputs*/
     for (int64_t i=nc-2; i >= 0; --i) {
         int64_t nel = std::min(nz, nc - i);
         for (int64_t l=0; l < ydim2; ++l){
-            double ssum = y(i, l);
+            double ssum = yw(i, l);
             for (int64_t j=1; j < nel; ++j) {
                 ssum -= R(i, j) * c(i + j, l);
             }
@@ -312,6 +930,129 @@ fpback( /* inputs*/
             c(i, l) = ssum;
         }
     }
+
+    _compute_residuals(
+        xptr, m_, yptr, ydim2, tptr, len_t,
+        wptr, k, extrapolate, nc, cptr, fp, residualsptr
+    );
+}
+
+void _fpbacp(
+        ConstRealArray2D& A1,
+        ConstRealArray2D& A2,
+        ConstRealArray2D& Z,
+        int k, int kp, int64_t len_t,
+        RealArray2D& c) {
+
+    int64_t nc = len_t - k - 1;
+    int64_t n = nc - k;
+    int64_t n2 = n - kp;
+    int64_t l = n;
+    std::vector<double> store(Z.ncols, 0.0);
+    for( int64_t i = 1; i <= kp; i++ ) {
+        for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+            store[ydimi] = Z(l - 1, ydimi);
+        }
+        int64_t j = kp + 2 - i;
+        if( i != 1 ) {
+            int64_t l0 = l;
+            for( int64_t l1 = j; l1 <= kp; l1++ ) {
+                l0 = l0 + 1;
+                for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+                    store[ydimi] = store[ydimi] - c(l0 - 1, ydimi) * A2(l - 1, l1 - 1);
+                }
+            }
+        }
+        for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+            c(l - 1, ydimi) = store[ydimi]/A2(l - 1, j - 2);
+        }
+        l = l - 1;
+        if( l == 0 ) {
+            return ;
+        }
+    }
+    for( int64_t i = 1; i <= n2; i++ ) {
+        for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+            store[ydimi] = Z(i - 1, ydimi);
+        }
+        l = n2;
+        for( int64_t j = 1; j <= kp; j++ ) {
+            l = l + 1;
+            for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+                store[ydimi] = store[ydimi] - c(l - 1, ydimi) * A2(i - 1, j - 1);
+            }
+        }
+        for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+            c(i - 1, ydimi) = store[ydimi];
+        }
+    }
+    int64_t i = n2;
+    for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+        c(i - 1, ydimi) = c(i - 1, ydimi)/A1(i - 1, 0);
+    }
+    if( i == 1 ) {
+        return ;
+    }
+    for( int64_t j = 2; j <= n2; j++ ) {
+        i = i - 1;
+        for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+            store[ydimi] = c(i - 1, ydimi);
+        }
+        int64_t i1 = kp;
+        if( j <= kp ) {
+            i1 = j - 1;
+        }
+        l = i;
+        for( int64_t l0 = 1; l0 <= i1; l0++ ) {
+            l = l + 1;
+            for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+                store[ydimi] = store[ydimi] - c(l - 1, ydimi) * A1(i - 1, l0);
+            }
+        }
+        for( int64_t ydimi = 0; ydimi < Z.ncols; ydimi++ ) {
+            c(i - 1, ydimi) = store[ydimi]/A1(i - 1, 0);
+        }
+    }
+}
+
+void
+fpbacp( /* inputs*/
+       const double *A1ptr,
+       int64_t a1_rows,
+       const double *A2ptr,
+       int64_t a2_rows,
+       const double *Zptr,
+       int k, int kp,
+       const double *xptr, int64_t m,      // x, shape (m,)
+       const double *yptr, int64_t ydim2,            // y(m, ydim2)
+       const double *tptr, int64_t len_t,  // t, shape (len_t,)
+       const double *wptr,                 // weights, shape (m,) // NB: len(w) == len(x), not checked
+       int extrapolate,
+       /* output */
+       double *cptr,
+       double *fp,
+       double *residualsptr) {
+
+    int64_t nc = len_t - k - 1;
+    auto A1 = ConstRealArray2D(A1ptr, a1_rows, kp + 1);
+    auto A2 = ConstRealArray2D(A2ptr, a2_rows, kp);
+    auto Z = ConstRealArray2D(Zptr, nc, ydim2);
+    auto c = RealArray2D(cptr, nc, ydim2);
+
+    _fpbacp(A1, A2, Z, k, kp, len_t, c);
+
+    int64_t offset = len_t - 2*k - 1;
+    for( int64_t i = 0; i < k; i++ ) {
+        for( int64_t ydimi = 0; ydimi < ydim2; ydimi++ ) {
+            c(i + offset, ydimi) = c(i, ydimi);
+        }
+    }
+
+    _compute_residuals(
+        xptr, m, yptr, ydim2, tptr, len_t,
+        wptr, k, extrapolate, nc, cptr, fp, residualsptr
+    );
+
 }
 
 
@@ -558,7 +1299,7 @@ norm_eq_lsq(const double *xptr, int64_t m,            // x, shape (m,)
             row = left - k + r;
             for (s=0; s < r+1; s++) {
                 clmn = left - k + s;
-                abT(clmn, r-s) += wrk[r] * wrk[s] * wval;   // NB: rows/cols swapped for F order                
+                abT(clmn, r-s) += wrk[r] * wrk[s] * wval;   // NB: rows/cols swapped for F order
             }
 
             // ... rhs = A.T @ y
@@ -574,7 +1315,7 @@ norm_eq_lsq(const double *xptr, int64_t m,            // x, shape (m,)
 
 /* Evaluate an N-dim tensor product spline or its derivative */
 void
-_evaluate_ndbspline(const double *xi_ptr, int64_t npts, int64_t ndim,  // xi, shape(npts, ndim) 
+_evaluate_ndbspline(const double *xi_ptr, int64_t npts, int64_t ndim,  // xi, shape(npts, ndim)
                     const double *t_ptr, int64_t max_len_t,            // t, shape (ndim, max_len_t)
                     const int64_t *len_t_ptr,                          // len_t, shape (ndim,)
                     const int64_t *k_ptr,                              // k, shape (ndim,)
@@ -598,7 +1339,7 @@ _evaluate_ndbspline(const double *xi_ptr, int64_t npts, int64_t ndim,  // xi, sh
     auto out = RealArray2D(out_ptr, npts, num_c_tr);
 
     // allocate work arrays (small, allocations unlikely to fail)
-    int64_t max_k = *std::max_element(k_ptr, k_ptr + ndim); 
+    int64_t max_k = *std::max_element(k_ptr, k_ptr + ndim);
     std::vector<double> wrk(2*max_k + 2);
     std::vector<int64_t> i(ndim);
 
@@ -724,7 +1465,7 @@ _coloc_nd(/* inputs */
     auto csr_data = RealArray1D(csr_data_ptr, npts*volume);
 
     // allocate work arrays (small, allocations unlikely to fail)
-    int64_t max_k = *std::max_element(k_ptr, k_ptr + ndim); 
+    int64_t max_k = *std::max_element(k_ptr, k_ptr + ndim);
     std::vector<double> wrk(2*max_k + 2);
     std::vector<int64_t> i(ndim);
 
@@ -782,7 +1523,7 @@ _coloc_nd(/* inputs */
                 idx_cflat += idx * strides_c1(d);
             }
 
-            /* 
+            /*
              *  Fill the row of the colocation matrix in the CSR format.
              * If it were dense, it would have been just
              * >>> matr[j, idx_cflat] = factor
@@ -796,6 +1537,317 @@ _coloc_nd(/* inputs */
     } // for( j=...
 
     return 0;
+}
+
+/**
+ * Initialize augmented matrices for periodic B-spline fitting system.
+ *
+ * This function prepares the augmented banded matrices used in FITPACK's
+ * periodic spline fitting algorithm. It expands and reorganizes the original
+ * banded matrices (a1, a2, b) into augmented forms (g1, g2, h1, h2) that
+ * incorporate periodic boundary conditions by linking the "head" and "tail"
+ * parts of the spline basis. The offset array stores index adjustments for
+ * wrap-around effects in the periodic system.
+ *
+ * Parameters:
+ * a1ptr: (len_t - k - 1) x (k + 1)
+ *        Original main banded matrix `a1` data.
+ *        Represents the core system matrix for spline fitting normal equations.
+ * a2ptr: (len_t - 2*k - 1) x k
+ *        Original secondary banded matrix `a2` data.
+ *        Contains coupling coefficients related to periodic boundary conditions.
+ * bptr: (len_t - 2*k - 2) x (k + 2)
+ *       Periodic constraints matrix `b`.
+ *       Encodes the periodic tail-head interactions in the spline basis.
+ * k: Spline degree.
+ * len_t: Length of the knot vector.
+ * g1ptr: (len_t - 2*k - 1) x (k + 2)
+ *        Output augmented matrix `g1`.
+ *        Augmented version of `a1` matrix, extended for periodicity.
+ * g2ptr: (len_t - 2*k - 1) x (k + 1)
+ *        Output augmented matrix `g2`.
+ *        Augmented version of `a2` with an extra zero column for periodic effects.
+ * h1ptr: (len_t - 2*k - 2) x (k + 2)
+ *        Output matrix `h1`.
+ *        Holds periodic contributions related to the "head" part of spline basis.
+ * h2ptr: (len_t - 2*k - 2) x (k + 1)
+ *        Output matrix `h2`.
+ *        Holds periodic contributions complementary to `h1`.
+ * offsetptr: (len_t - 2*k - 2)
+ *            Output offset array.
+ *            Contains index offsets used for wrap-around indexing in periodic system.
+ */
+void init_augmented_matrices(
+    double *a1ptr, double *a2ptr, double *bptr,
+    int k, int64_t len_t,
+    double *g1ptr, double *g2ptr,
+    double *h1ptr, double *h2ptr, double *offsetptr) {
+    // ----------------------------------------------------------------------------
+    // Augmented matrix construction for periodic B-spline fitting
+    //
+    // This function creates new matrices (g1, g2, h1, h2) from the original
+    // banded matrices (a1, a2, b). These new matrices help in handling
+    // periodic boundary conditions in B-spline fitting.
+    //
+    // In periodic splines, the start and end of the spline curve are connected.
+    // This means the basis functions near the end of the knot vector also affect
+    // the beginning of the curve — like wrapping around in a circle.
+    // To handle this properly in matrix form, we build special "augmented" matrices
+    // that include this wrapping information.
+    //
+    // Here's how each matrix is formed:
+    //
+    // - a1 → g1:
+    //     g1 is just a copy of a1, but with one extra column at the end (filled with zeros).
+    //     This extra column is used to hold wrapped values if needed later.
+    //
+    // - a2 → g2:
+    //     g2 is like a2, but with one extra column at the beginning (filled with zeros).
+    //     Also, some values from the end of a1 are copied into the bottom of g2 to handle
+    //     wrapping from the end back to the start.
+    //
+    // - b → h1 and h2:
+    //     b contains information about how the end of the spline interacts with the start.
+    //     This is split into:
+    //       → h1: stores the first part of each row of b (normally placed values)
+    //       → h2: stores the remaining values from b that would overflow (wrap around)
+    //
+    // - offset:
+    //     For each row, we store an offset value that tells us how the wrapping was done,
+    //     so that later steps in the algorithm can apply corrections at the right places.
+    //
+    // --------------------------
+    // Example (assume degree k = 2):
+    //
+    // Input shapes:
+    //   a1:  (len_t - k - 1)     x (k + 1)
+    //   a2:  (len_t - 2k - 1)    x (k)
+    //   b:   (len_t - 2k - 2)    x (k + 2)
+    //
+    // Output shapes:
+    //   g1:  (len_t - 2k - 1)    x (k + 2)
+    //   g2:  (len_t - 2k - 1)    x (k + 1)
+    //   h1:  (len_t - 2k - 2)    x (k + 2)
+    //   h2:  (len_t - 2k - 2)    x (k + 1)
+    //   offset: (len_t - 2k - 2)
+    //
+    // ASCII illustration of values:
+    //
+    //   a1 = [ a a a ]
+    //   a2 = [   a a ]
+    //   b  = [ b b b b ]   ← periodic influence terms (end → start)
+    //
+    //   g1 = [ a a a 0 ]   ← copy of a1 with extra column
+    //   g2 = [ 0 a a ]     ← copy of a2 with zero column added in front,
+    //                        and bottom rows filled from a1 for wrap-around
+    //
+    //   h1 = [ b b b b ]   ← first part of b copied here
+    //   h2 = [ b b b ]     ← overflow from b (after wrap-around) goes here
+    //
+    // ----------------------------------------------------------------------------
+    // Why is this necessary?
+    //
+    // If we don't do this augmentation, the spline system will miss connections
+    // between the end and the beginning of the curve. That means:
+    //
+    // - The periodic property will break: the curve won't join smoothly at the ends
+    // - The matrix will be incomplete or incorrect: wrapping basis functions
+    //   will be placed in the wrong location or lost
+    //
+    //   What does this mean?
+    //   Suppose we are fitting a periodic spline and x lies near the end of the domain.
+    //   Its non-zero basis functions are supposed to "wrap around" and influence
+    //   the start of the spline (because of periodicity).
+    //
+    //   Without the augmented matrices (h1, h2), these wrapped basis function values
+    //   will either:
+    //     (a) fall outside the bounds of the main system matrix (A, a1, a2), or
+    //     (b) overwrite unrelated entries, or
+    //     (c) be completely dropped during matrix assembly
+    //
+    //   As a result, the linear system we solve will be missing those terms —
+    //   meaning, we're not enforcing periodicity properly, and the spline
+    //   won't be continuous at the boundary.
+    //
+    //   h1 and h2 act like "extension slots" that safely store these out-of-bound
+    //   or wrapped values in the correct position, so the final matrix still
+    //   represents all required interactions correctly.
+    // - Solving the system will give wrong results or fitting errors near boundaries
+    //
+    // These augmented matrices ensure the periodic conditions are correctly applied
+    // and the final fitted spline is smooth and continuous across the domain.
+    //
+    // ----------------------------------------------------------------------------
+    // Why do we need g1 and g2?
+    //
+    // g1 and g2 are extended versions of a1 and a2.
+    // They include extra columns to handle the special case of periodic splines,
+    // where the end of the spline connects back to the beginning.
+    //
+    // - g1 is a copy of a1 with one extra column added at the end (filled with 0)
+    // - g2 has one extra column at the beginning (filled with 0),
+    //   and a few rows at the bottom are filled from the end of a1
+    //
+    // If we do not create g1 and g2 like this, here is what goes wrong:
+    //
+    // - Some values that are supposed to "wrap around" from the end to the start
+    //   will not fit in the original a1 or a2 matrix
+    //
+    // - These values may be:
+    //     - written in the wrong place,
+    //     - go outside the matrix and get ignored,
+    //     - or overwrite other important values
+    //
+    // - This breaks the structure of the system we are trying to solve
+    // - The result will be a spline that is not truly periodic —
+    //   it may have a sharp jump at the start or end
+    //
+    // In short, g1 and g2 give us extra space in the right place
+    // to safely store these wrap-around values, so the final matrix is correct.
+    // ----------------------------------------------------------------------------
+
+
+
+    // Wrap raw pointers as 2D arrays of appropriate sizes
+    // These matrices come from banded system representations in FITPACK
+    auto g1 = RealArray2D(g1ptr, len_t - 2*k - 1, k + 2);
+    auto g2 = RealArray2D(g2ptr, len_t - 2*k - 1, k + 1);
+    auto a1 = RealArray2D(a1ptr, len_t - k - 1, k + 1);
+    auto a2 = RealArray2D(a2ptr, len_t - 2*k - 1, k);
+    auto h1 = RealArray2D(h1ptr, len_t - 2*k - 2, k + 2);
+    auto h2 = RealArray2D(h2ptr, len_t - 2*k - 2, k + 1);
+    auto b = RealArray2D(bptr, len_t - 2*k - 2, k + 2);
+    auto offset = RealArray1D(offsetptr, len_t - 2*k - 2);
+
+    int64_t l0, l, l1;
+
+    // --------------------------------------------------------------------
+    // Copy matrix a1 into g1, extending the original banded system matrix.
+    //
+    // a1:
+    //  - Represents the main banded matrix from the spline normal equations
+    //  - Size corresponds to spline basis dimension minus degree adjustments
+    //
+    // g1:
+    //  - Augmented matrix version of a1, extended with an extra column (k+2 instead of k+1)
+    //  - Purpose: to incorporate periodic boundary conditions by increasing band size
+    // --------------------------------------------------------------------
+    for( int64_t i = 0; i < len_t - 2*k - 1; i++ ) {
+        for( int64_t j = 0; j < k + 1; j++ ) {
+            g1(i, j) = a1(i, j);
+        }
+    }
+    // Last column is zero-padded because g1 has one extra column compared to a1
+    for( int64_t i = 0; i < len_t - 2*k - 1; i++ ) {
+        g1(i, k + 1) = 0.0;
+    }
+
+    // --------------------------------------------------------------------
+    // Initialize first column of g2 to zero and fill remaining from a2
+    //
+    // a2:
+    //  - Represents off-diagonal banded matrix terms in the original system
+    //  - Corresponds to interactions related to the periodic part of the spline
+    //
+    // g2:
+    //  - Augmented version of a2 with an additional zero column at start
+    //  - First column zero to separate periodic contribution
+    // --------------------------------------------------------------------
+    for( int64_t i = 0; i < len_t - 2*k - 1; i++ ) {
+        g2(i, 0) = 0.0;
+    }
+    for( int64_t i = 0; i < len_t - 2*k - 1; i++ ) {
+        for( int64_t j = 1; j < k + 1; j++ ) {
+            g2(i, j) = a2(i, j - 1);
+        }
+    }
+
+    // --------------------------------------------------------------------
+    // Special case: Fill first column of g2 at the bottom with values from a1
+    // This enforces the periodic wrap-around conditions on the system matrix
+    // by linking last rows back to first columns.
+    //
+    // This is critical in periodic splines where basis functions "wrap around".
+    // --------------------------------------------------------------------
+    l = len_t - 3*k - 1;
+    for( int64_t j = 0; j < k + 1; j++ ) {
+        if( l <= 0 ) {
+            break;
+        }
+        g2(l - 1, 0) = a1(l - 1, j);
+        l = l - 1;
+    }
+
+    // --------------------------------------------------------------------
+    // Initialize h1, h2, and offset matrices which represent
+    // the "periodic" part of the augmented system.
+    //
+    // h1, h2:
+    //  - These matrices correspond to coefficients that arise from the
+    //    periodic boundary conditions and wrapping in the banded matrix system.
+    //  - They hold contributions from the "tail" of the spline basis interacting
+    //    with the "head" due to periodicity.
+    //
+    // b:
+    //  - Input matrix containing the periodic constraints and interactions.
+    //
+    // offset:
+    //  - Stores the integer shifts needed for correct indexing in
+    //    the augmented periodic system (wrap-around shifts).
+    // --------------------------------------------------------------------
+    for( int64_t it = 1; it <= len_t - 2*k - 2; it++ ) {
+        // Zero out current row for h1 and h2
+        for( int64_t i = 0; i < k + 1; i++ ) {
+            h1(it - 1, i) = 0;
+            h2(it - 1, i) = 0;
+        }
+        h1(it - 1, k + 1) = 0;
+
+        if( it <= len_t - 3*k - 2 ) {
+            // Fill h1 and h2 with rows from b matrix while handling wrap-around
+            l = it;
+            l0 = it;
+            for( int64_t j = 1; j <= k + 2; j++ ) {
+                if( l0 == len_t - 3*k - 1 ) {
+                    // If boundary reached, wrap and continue filling h2 from b
+                    l0 = 1;
+                    for( int64_t l1 = j; l1 <= k + 2; l1++ ) {
+                        h2(it - 1, l0 - 1) = b(it - 1, l1 - 1);
+                        l0 = l0 + 1;
+                    }
+                    break;
+                }
+                // Normal assignment to h1 from b
+                h1(it - 1, j - 1) = b(it - 1, j - 1);
+                l0 = l0 + 1;
+            }
+        } else {
+            // For rows beyond boundary, distribute elements from b to h1 and h2
+            // according to periodic wrap-around indexing logic
+            l = 1;
+            int64_t i = it - (len_t - 3*k - 1);
+            for( int64_t j = 1; j <= k + 2; j++ ) {
+                i = i + 1;
+                l0 = i;
+                l1 = l0 - (k + 1);
+
+                // Adjust indices for wrap-around within allowed bounds
+                while( l1 > std::max((int64_t) 0, len_t - 3*k - 2) ) {
+                    l0 = l1 - (len_t - 3*k - 2);
+                    l1 = l0 - (k + 1);
+                }
+
+                if( l1 > 0 ) {
+                    h1(it - 1, l1 - 1) = b(it - 1, j - 1);
+                } else {
+                    // Accumulate values in h2 for remaining wrapped positions
+                    h2(it - 1, l0 - 1) += b(it - 1, j - 1);
+                }
+            }
+        }
+        // Store the offset for this row for index calculations in periodic solver
+        offset(it - 1) = l;
+    }
 }
 
 

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -88,6 +88,16 @@ class TestSmokeTests:
                     xp_assert_close(spl.c, tck[1][:spl.c.size], atol=1e-13)
                 else:
                     assert k == 5   # knot length differ in some k=5 cases
+            else:
+                if np.allclose(v[0], v[-1], atol=1e-15):
+                    spl = make_splrep(x, v, k=k, s=s, xb=xb, xe=xe, bc_type='periodic')
+                    if k != 1: # knots for k == 1 in some cases
+                        xp_assert_close(spl.t, tck[0], atol=1e-15)
+                        xp_assert_close(spl.c, tck[1][:spl.c.size], atol=1e-13)
+                else:
+                    with assert_raises(ValueError):
+                        spl = make_splrep(x, v, k=k, s=s,
+                                          xb=xb, xe=xe, bc_type='periodic')
 
     def check_2(self, per=0, N=20, ia=0, ib=2*np.pi):
         a, b, dx = 0, 2*np.pi, 0.2*np.pi
@@ -117,7 +127,10 @@ class TestSmokeTests:
     def test_smoke_splrep_splev(self):
         self.check_1(s=1e-6)
         self.check_1(b=1.5*np.pi)
+
+    def test_smoke_splrep_splev_periodic(self):
         self.check_1(b=1.5*np.pi, xe=2*np.pi, per=1, s=1e-1)
+        self.check_1(b=2*np.pi, per=1, s=1e-1)
 
     @pytest.mark.parametrize('per', [0, 1])
     @pytest.mark.parametrize('at_nodes', [True, False])

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -32,7 +32,13 @@ class TestUnivariateSpline:
         assert abs(lut.get_residual()) < 1e-10
         assert_array_almost_equal(lut([1, 1.5, 2]), [3, 3, 3])
 
-        spl = make_splrep(x, y, k=1, s=len(x))
+    @pytest.mark.parametrize("bc_type", [None, 'periodic'])
+    def test_linear_constant_periodic(self, bc_type):
+        x = [1,2,3]
+        y = [3,3,3]
+        lut = UnivariateSpline(x,y,k=1)
+
+        spl = make_splrep(x, y, k=1, s=len(x), bc_type=bc_type)
         xp_assert_close(spl.t[1:-1], lut.get_knots(), atol=1e-15)
         xp_assert_close(spl.c, lut.get_coeffs(), atol=1e-15)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR moves the periodic B-spline fitting logic from FITPACK’s old Fortran code to a modern C++ + Python implementation. It helps reduce the dependency on legacy Fortran and brings the periodic case in line with the rest of the SciPy spline infrastructure.

The new code is exposed via `bc_type="periodic"` in both `make_splrep` and `make_splprep`. It follows the same logic as FITPACK, using extra matrix space to correctly handle basis functions that wrap around at the edges. Proper tests have been added, and the core algorithm is explained in the code with clear comments and ASCII diagrams to improve readability and maintainability.


#### Additional information
<!--Any additional information you think is important.-->

cc: @ev-br @rgommers 
