### PR TITLE
TYP: generic ``interpolate`` types

### DIFF
--- a/scipy/interpolate/_bary_rational.py
+++ b/scipy/interpolate/_bary_rational.py
@@ -25,6 +25,7 @@
 
 import warnings
 import operator
+from types import GenericAlias
 
 import numpy as np
 import scipy
@@ -35,6 +36,10 @@ __all__ = ["AAA", "FloaterHormannInterpolator"]
 
 class _BarycentricRational:
     """Base class for barycentric representation of a rational function."""
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     def __init__(self, x, y, **kwargs):
         # input validation
         z = np.asarray(x)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1,5 +1,6 @@
 import operator
 from math import prod
+from types import GenericAlias
 
 import numpy as np
 from scipy._lib._util import normalize_axis_index
@@ -205,6 +206,10 @@ class BSpline:
     .. [2] Carl de Boor, A practical guide to splines, Springer, 2001.
 
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
 
     def __init__(self, t, c, k, extrapolate=True, axis=0):
         super().__init__()
@@ -2124,7 +2129,7 @@ def _compute_optimal_gcv_parameter(X, wE, y, w):
             else:
                 raise ValueError(f"Unable to find minimum of the GCV "
                                  f"function: {gcv_est.message}")
-        return gcv_est 
+        return gcv_est
     else:
         # trailing dims must have been flattened already.
         raise RuntimeError("Internal error. Please report it to scipy developers.")

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -236,6 +236,9 @@ class PchipInterpolator(CubicHermiteSpline):
 
     """
 
+    # PchipInterpolator is not generic in scipy-stubs
+    __class_getitem__ = None
+
     def __init__(self, x, y, axis=0, extrapolate=None):
         x, _, y, axis, _ = prepare_input(x, y, axis)
         if np.iscomplexobj(y):
@@ -487,6 +490,9 @@ class Akima1DInterpolator(CubicHermiteSpline):
            https://blogs.mathworks.com/cleve/2019/04/29/makima-piecewise-cubic-interpolation/
 
     """
+
+    # PchipInterpolator is not generic in scipy-stubs
+    __class_getitem__ = None
 
     def __init__(self, x, y, axis=0, *, method: Literal["akima", "makima"]="akima",
                  extrapolate:bool | None = None):

--- a/scipy/interpolate/_interpnd.pyx
+++ b/scipy/interpolate/_interpnd.pyx
@@ -29,6 +29,7 @@ import scipy.spatial._qhull as qhull
 cimport scipy.spatial._qhull as qhull
 
 import warnings
+from types import GenericAlias
 
 #------------------------------------------------------------------------------
 # Numpy etc.
@@ -54,6 +55,9 @@ class NDInterpolatorBase:
     .. versionadded:: 0.9
 
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, points, values, fill_value=np.nan, ndim=None,
                  rescale=False, need_contiguous=True, need_values=True):
@@ -112,7 +116,7 @@ class NDInterpolatorBase:
         else:
             self.values = values.reshape(values.shape[0],
                                             np.prod(values.shape[1:]))
-        
+
         # Complex or real?
         self.is_complex = np.issubdtype(self.values.dtype, np.complexfloating)
         if self.is_complex:
@@ -146,7 +150,7 @@ class NDInterpolatorBase:
         xi = xi.reshape(-1, xi.shape[-1])
         xi = np.ascontiguousarray(xi, dtype=np.float64)
         return self._scale_x(xi), interpolation_points_shape
-    
+
     def __call__(self, *args):
         """
         interpolator(xi)
@@ -322,7 +326,7 @@ class LinearNDInterpolator(NDInterpolatorBase):
         cdef int i, j, k, m, ndim, isimplex, start, nvalues
         cdef qhull.DelaunayInfo_t info
         cdef double eps, eps_broad
-        
+
         ndim = xi.shape[1]
         fill_value = self.fill_value
 
@@ -932,7 +936,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
         NDInterpolatorBase.__init__(self, points, values, ndim=2,
                                     fill_value=fill_value, rescale=rescale,
                                     need_values=False)
-    
+
     def _set_values(self, values, fill_value=np.nan, need_contiguous=True, ndim=None):
         """
         Sets the values of the interpolation points.
@@ -946,7 +950,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
         if self.values is not None:
             self.grad = estimate_gradients_2d_global(self.tri, self.values,
                                                     tol=self._tol, maxiter=self._maxiter)
-    
+
     def _calculate_triangulation(self, points):
         self.tri = qhull.Delaunay(points)
 
@@ -992,7 +996,7 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
                 isimplex = qhull._find_simplex(&info, c,
                                                &xi[i,0],
                                                &start, eps, eps_broad)
-                
+
                 # 2) Clough-Tocher interpolation
 
                 if isimplex == -1:

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1,6 +1,7 @@
 __all__ = ['interp1d', 'interp2d', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
 
 from math import prod
+from types import GenericAlias
 
 import numpy as np
 from numpy import array, asarray, intp, poly1d, searchsorted
@@ -592,6 +593,9 @@ class interp1d(_Interpolator1D):
 class _PPolyBase:
     """Base class for piecewise polynomials."""
     __slots__ = ('c', 'x', 'extrapolate', 'axis')
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, c, x, extrapolate=None, axis=0):
         self.c = np.asarray(c)

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -4,6 +4,7 @@ import operator
 import numpy as np
 
 from math import prod
+from types import GenericAlias
 
 from . import _dierckx  # type: ignore[attr-defined]
 
@@ -74,6 +75,10 @@ class NdBSpline:
     NdPPoly : an N-dimensional piecewise tensor product polynomial
 
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     def __init__(self, t, c, k, *, extrapolate=None):
         self._k, self._indices_k1d, (self._t, self._len_t) = _preprocess_inputs(k, t)
 
@@ -350,7 +355,7 @@ def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):
     points : tuple of ndarrays of float, with shapes (m1,), ... (mN,)
         The points defining the regular grid in N dimensions. The points in
         each dimension (i.e. every element of the `points` tuple) must be
-        strictly ascending or descending.      
+        strictly ascending or descending.
     values : ndarray of float, shape (m1, ..., mN, ...)
         The data on the regular grid in n dimensions.
     k : int, optional
@@ -412,4 +417,3 @@ def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):
     coef = solver(matr, vals, **solver_args)
     coef = coef.reshape(xi_shape + v_shape[ndim:])
     return NdBSpline(t, coef, k)
-

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -1,4 +1,5 @@
 import warnings
+from types import GenericAlias
 
 import numpy as np
 from scipy.special import factorial
@@ -49,6 +50,9 @@ class _Interpolator1D:
     """
 
     __slots__ = ('_y_axis', '_y_extra_shape', 'dtype')
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, xi=None, yi=None, axis=None):
         self._y_axis = axis

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -1,6 +1,7 @@
 """Module for RBF interpolation."""
 import warnings
 from itertools import combinations_with_replacement
+from types import GenericAlias
 
 import numpy as np
 from numpy.linalg import LinAlgError
@@ -283,6 +284,9 @@ class RBFInterpolator:
     >>> plt.show()
 
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, y, d,
                  neighbors=None,

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -1,6 +1,7 @@
 __all__ = ['RegularGridInterpolator', 'interpn']
 
 import itertools
+from types import GenericAlias
 
 import numpy as np
 
@@ -271,6 +272,9 @@ class RegularGridInterpolator:
     _SPLINE_METHODS_ndbspl = {"slinear", "cubic", "quintic"}
     _SPLINE_METHODS = list(_SPLINE_DEGREE_MAP.keys())
     _ALL_METHODS = ["linear", "nearest"] + _SPLINE_METHODS
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, points, values, method="linear", bounds_error=True,
                  fill_value=np.nan, *, solver=None, solver_args=None):


### PR DESCRIPTION
This is the same story as with ##23118, but this time for these ``scipy.interpolate`` types:

- ``AAA``
- ``FloaterHormannInterpolator``
- ``BSpline``
- ``CubicHermiteSpline``
- ``CubicSpline``
- ``LinearNDInterpolator``
- ``PPoly``
- ``BPoly``
- ``NdPPoly``
- ``NdBSpline``
- ``NearestNDInterpolator``
- ``BarycentricInterpolator``
- ``KroghInterpolator``
- ``RBFInterpolator``
- ``RegularGridInterpolator``

---

Closes scipy/scipy-stubs#653
