### PR TITLE
BUG: stats.differential_entropy: check case when window_length is a param and is None

### DIFF
--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -167,8 +167,9 @@ def entropy(pk: np.typing.ArrayLike,
 def _differential_entropy_is_too_small(samples, kwargs, axis=-1):
     values = samples[0]
     n = values.shape[axis]
-    window_length = kwargs.get("window_length",
-                               math.floor(math.sqrt(n) + 0.5))
+    window_length = kwargs.get("window_length")
+    if window_length is None:
+        window_length = math.floor(math.sqrt(n) + 0.5)
     if not 2 <= 2 * window_length < n:
         return True
     return False

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -234,6 +234,14 @@ class TestDifferentialEntropy:
         with pytest.raises(ValueError, match=message):
             stats.differential_entropy(x, method='ekki-ekki')
 
+    def test_window_length_is_none(self, xp):
+        x = np.random.rand(10)
+        window_length = None
+
+        expected = stats.differential_entropy(x)
+        res = stats.differential_entropy(x, window_length=window_length)
+        xp_assert_close(res, expected, rtol=0.005)
+
     @methods
     def test_consistency(self, method, xp):
         # test that method is a consistent estimator

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -235,12 +235,11 @@ class TestDifferentialEntropy:
             stats.differential_entropy(x, method='ekki-ekki')
 
     def test_window_length_is_none(self, xp):
-        x = np.random.rand(10)
-        window_length = None
-
-        expected = stats.differential_entropy(x)
-        res = stats.differential_entropy(x, window_length=window_length)
-        xp_assert_close(res, expected, rtol=0.005)
+        rng = np.random.default_rng(358923459826738562)
+        x = xp.asarray(rng.random(size=10))
+        ref = stats.differential_entropy(x)
+        res = stats.differential_entropy(x, window_length=None)
+        xp_assert_close(res, ref, rtol=0.005)
 
     @methods
     def test_consistency(self, method, xp):


### PR DESCRIPTION
#### Reference issue
When the parameter `window_length` is passed to differential_entropy, but is None, `kwargs.get('window_length')` would not trigger the default value, keeps `window_length=None`, and raises a TypeError `2*window_length` --> int*NoneType

#### What does this implement/fix?
Now `kwargs.get('window_length')` would be None both in the case of empty/default parameter, and a `window_length=None` parameter. The check is performed later on the actual value of `window_length`.

#### Additional information
None to add
