### PR TITLE
Remove NumFOCUS as CoC contact

### DIFF
--- a/doc/source/dev/conduct/code_of_conduct.rst
+++ b/doc/source/dev/conduct/code_of_conduct.rst
@@ -118,14 +118,11 @@ scipy-conduct@googlegroups.com. Currently, the committee consists of:
 - Nathaniel J. Smith
 - Ralf Gommers
 
-If your report involves any members of the committee, or if they feel they have
-a conflict of interest in handling it, then they will recuse themselves from
-considering your report. Alternatively, if, for any reason, you feel
-uncomfortable making a report to the committee, then you can also contact:
-
-- Chair of the SciPy Steering Committee: Ralf Gommers, or
-- Senior `NumFOCUS staff <https://numfocus.org/code-of-conduct#persons-responsible>`__: conduct@numfocus.org
-
+If your report involves any members of the committee, or if they feel they
+have a conflict of interest in handling it, then they will recuse themselves
+from considering your report. Alternatively, if, for any reason, you feel
+uncomfortable making a report to the committee, then you can also contact the
+chair of the SciPy Steering Committee: Ralf Gommers.
 
 Incident reporting resolution & Code of Conduct enforcement
 -----------------------------------------------------------


### PR DESCRIPTION
As discussed on scipy-core-dev mailing list.

The problem with the current state is that the alternative contact (Ralf) is in fact on the CoC committee, so is not an alternative.

I'm perfectly happy to be that other person, but perhaps we should select someone else, outside Scipy, to be that person - with the understanding it will likely involve somewhere between no work and a very small amount of work.

[skip ci]