### PR TITLE
MAINT: ``spatial._plotutils``: remove matplotlib 1 code

### DIFF
--- a/scipy/spatial/_plotutils.py
+++ b/scipy/spatial/_plotutils.py
@@ -1,28 +1,12 @@
 import numpy as np
-from scipy._lib.decorator import decoratorx as _decorator
 
 __all__ = ['delaunay_plot_2d', 'convex_hull_plot_2d', 'voronoi_plot_2d']
 
 
-@_decorator
-def _held_figure(func, obj, ax=None, **kw):
+def _get_axes():
     import matplotlib.pyplot as plt
 
-    if ax is None:
-        fig = plt.figure()
-        ax = fig.gca()
-        return func(obj, ax=ax, **kw)
-
-    # As of matplotlib 2.0, the "hold" mechanism is deprecated.
-    # When matplotlib 1.x is no longer supported, this check can be removed.
-    was_held = getattr(ax, 'ishold', lambda: True)()
-    if was_held:
-        return func(obj, ax=ax, **kw)
-    try:
-        ax.hold(True)
-        return func(obj, ax=ax, **kw)
-    finally:
-        ax.hold(was_held)
+    return plt.figure().gca()
 
 
 def _adjust_bounds(ax, points):
@@ -33,7 +17,6 @@ def _adjust_bounds(ax, points):
     ax.set_ylim(xy_min[1], xy_max[1])
 
 
-@_held_figure
 def delaunay_plot_2d(tri, ax=None):
     """
     Plot the given Delaunay triangulation in 2-D
@@ -82,6 +65,8 @@ def delaunay_plot_2d(tri, ax=None):
         raise ValueError("Delaunay triangulation is not 2-D")
 
     x, y = tri.points.T
+
+    ax = ax or _get_axes()
     ax.plot(x, y, 'o')
     ax.triplot(x, y, tri.simplices.copy())
 
@@ -90,7 +75,6 @@ def delaunay_plot_2d(tri, ax=None):
     return ax.figure
 
 
-@_held_figure
 def convex_hull_plot_2d(hull, ax=None):
     """
     Plot the given convex hull diagram in 2-D
@@ -140,6 +124,7 @@ def convex_hull_plot_2d(hull, ax=None):
     if hull.points.shape[1] != 2:
         raise ValueError("Convex hull is not 2-D")
 
+    ax = ax or _get_axes()
     ax.plot(hull.points[:, 0], hull.points[:, 1], 'o')
     line_segments = [hull.points[simplex] for simplex in hull.simplices]
     ax.add_collection(LineCollection(line_segments,
@@ -150,7 +135,6 @@ def convex_hull_plot_2d(hull, ax=None):
     return ax.figure
 
 
-@_held_figure
 def voronoi_plot_2d(vor, ax=None, **kw):
     """
     Plot the given Voronoi diagram in 2-D
@@ -222,6 +206,8 @@ def voronoi_plot_2d(vor, ax=None, **kw):
 
     if vor.points.shape[1] != 2:
         raise ValueError("Voronoi diagram is not 2-D")
+
+    ax = ax or _get_axes()
 
     if kw.get('show_points', True):
         point_size = kw.get('point_size', None)


### PR DESCRIPTION
I believe that the lower bound for matplotlib is currentlly set to 3.5.

I also removed the ``_lib.decorator`` stuff for the sake of simplicity. Mypy should also be able to understand the code a bit better this way.