### PR TITLE
DOC: add orphaned modules to toctree

### DIFF
--- a/doc/source/reference/io.matlab.rst
+++ b/doc/source/reference/io.matlab.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. automodule:: scipy.io.matlab
    :no-members:
    :no-inherited-members:

--- a/doc/source/reference/signal.windows.rst
+++ b/doc/source/reference/signal.windows.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. automodule:: scipy.signal.windows
    :no-members:
    :no-inherited-members:

--- a/doc/source/reference/spatial.transform.rst
+++ b/doc/source/reference/spatial.transform.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. automodule:: scipy.spatial.transform
    :no-members:
    :no-inherited-members:

--- a/doc/source/reference/special.cython_special.rst
+++ b/doc/source/reference/special.cython_special.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 .. automodule:: scipy.special.cython_special
    :no-members:
    :no-inherited-members:

--- a/scipy/io/__init__.py
+++ b/scipy/io/__init__.py
@@ -5,6 +5,11 @@ Input and output (:mod:`scipy.io`)
 
 .. currentmodule:: scipy.io
 
+.. toctree::
+   :hidden:
+
+   io.matlab
+
 SciPy has many modules, classes, and functions available to read data
 from and write data to a variety of file formats.
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -3,6 +3,11 @@
 Signal processing (:mod:`scipy.signal`)
 =======================================
 
+.. toctree::
+   :hidden:
+
+   signal.windows
+
 Convolution
 ===========
 

--- a/scipy/spatial/__init__.py
+++ b/scipy/spatial/__init__.py
@@ -9,6 +9,7 @@ Spatial algorithms and data structures (:mod:`scipy.spatial`)
    :hidden:
 
    spatial.distance
+   spatial.transform
 
 Spatial transformations
 =======================

--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -5,6 +5,11 @@ Special functions (:mod:`scipy.special`)
 
 .. currentmodule:: scipy.special
 
+.. toctree::
+   :hidden:
+
+   special.cython_special
+
 Almost all of the functions below accept NumPy arrays as input
 arguments as well as single numbers. This means they follow
 broadcasting and automatic array-looping rules. Technically,


### PR DESCRIPTION
[docs only]

#### Reference issue
Closes https://github.com/scipy/scipy/issues/23237

#### What does this implement/fix?
There are four modules which are currently marked as orphaned and not part of the toctree, which hurts navigation in the docs: `io.matlab`, `signal.window`, `spatial.transform`, and `special.cython_special`. Screenshots and examples in the linked issue.

This PR includes these modules in the toctree. I don't know of a good reason why they would have been excluded in the first place, so please weigh in if there is rationale besides this being an oversight.

#### Additional information
<!--Any additional information you think is important.-->
