### PR TITLE
TST: sparse.linalg: improve coverage for `funm_multiply_krylov`

### DIFF
--- a/scipy/sparse/linalg/tests/test_funm_multiply_krylov.py
+++ b/scipy/sparse/linalg/tests/test_funm_multiply_krylov.py
@@ -132,6 +132,31 @@ class TestKrylovFunmv:
         observed = funm_multiply_krylov(expm, A, b, restart_every_m = 40)
         assert_allclose(observed, expected)
 
+    def test_funm_multiply_krylov_invalid_input(self):
+            A = np.array([[1, 2], [3, 4]])  # Non-hermitian matrix
+            b = np.array([1.0, 2.0])  # Ensure 'b' is a 1D array of floats
+
+            # Test for invalid 'b' (not 1D)
+            b_invalid = np.array([[1.0], [2.0]])  # 2D array
+            with pytest.raises(ValueError, 
+                    match="argument 'b' must be a 1D array."): 
+                funm_multiply_krylov(np.exp, A, b_invalid)
+
+            # Test for invalid restart parameter
+            with pytest.raises(ValueError, 
+                    match="argument 'restart_every_m' must be positive."): 
+                funm_multiply_krylov(np.exp, A, b, restart_every_m=0)
+
+            # Test for invalid max_restarts
+            with pytest.raises(ValueError, 
+                    match="argument 'max_restarts' must be positive."): 
+                funm_multiply_krylov(np.exp, A, b, max_restarts=0)
+
+            # Test for invalid 'assume_a' string
+            with pytest.raises(ValueError, 
+                    match="is not a recognized matrix structure"): 
+                funm_multiply_krylov(np.exp, A, b, assume_a='invalid')
+
 
 @pytest.mark.parametrize("dtype_a", DTYPES)
 @pytest.mark.parametrize("dtype_b", DTYPES)


### PR DESCRIPTION
This PR adds a test to ensure that `sparse.linalg._funm_multiply_krylov.funm_multiply_krylov` raises exceptions when given invalid inputs. This function was introduced in PR https://github.com/scipy/scipy/pull/22983 and missed some test coverage. This new test adds coverage to the following lines:
```py
--------------------------------------------------------------------------------
# scipy/sparse/linalg/_funm_multiply_krylov.py
--------------------------------------------------------------------------------
def funm_multiply_krylov(f, A, b, *, assume_a = "general", t = 1.0, atol = 0.0,
                         rtol = 1e-6, restart_every_m = None, max_restarts = 20):
    """
    A restarted Krylov method for evaluating ``y = f(tA) b`` from [1]_ [2]_.
    ... OMITTED
    """

    if assume_a not in {'hermitian', 'general', 'her', 'gen'}:
        raise ValueError(f'scipy.sparse.linalg.funm_multiply_krylov: {assume_a} ' #✅ NOW COVERED
                         'is not a recognized matrix structure') #✅ NOW COVERED
    is_hermitian = (assume_a == 'her') or (assume_a == 'hermitian')

    if len(b.shape) != 1:
        raise ValueError("scipy.sparse.linalg.funm_multiply_krylov: " #✅ NOW COVERED
                         "argument 'b' must be a 1D array.") #✅ NOW COVERED
    n = b.shape[0]

    if restart_every_m is None:
        restart_every_m = min(20, n)

    restart_every_m = int(restart_every_m)
    max_restarts = int(max_restarts)

    if restart_every_m <= 0:
        raise ValueError("scipy.sparse.linalg.funm_multiply_krylov: " #✅ NOW COVERED
                         "argument 'restart_every_m' must be positive.") #✅ NOW COVERED

    if max_restarts <= 0:
            raise ValueError("scipy.sparse.linalg.funm_multiply_krylov: " #✅ NOW COVERED
                             "argument 'max_restarts' must be positive.") #✅ NOW COVERED

    # ... OMITTED
--------------------------------------------------------------------------------
```


Note: Parts of this test have been automatically generated by a novel technique that we're currently developing as part of an academic research project aiming at improving test coverage. *To not waste developer time, two researchers manually checked the test before submitting it.* We appreciate the developers' time and any feedback is welcomed.