### PR TITLE
TST: `test_axis_nan_policy`: skip on unexpected exceptions

### DIFF
--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -511,8 +511,8 @@ def skip_nan_unexpected_exception():
         with np.errstate(all='raise'):
             x = np.asarray([1, 2, np.nan])
             np.mean(x)
-    except:
-        pytest.skip("nan raises unexpected exception in numpy")
+    except Exception as e:
+        pytest.skip(f"nan raises unexpected {e.__class__.__name__} in numpy")
 
 @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                           "paired", "unpacker"), axis_nan_policy_cases)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -537,6 +537,10 @@ def test_axis_nan_policy_axis_is_None(hypotest, args, kwds, n_samples,
                                  "xp_mean_1samp", "xp_mean_2samp", "xp_var",
                                  "weightedtau", "weightedtau_weighted"]:
             skip_nan_unexpected_exception()
+    # all_nans-propagate-ttest_ci is also affected, via scalar multiply
+    if (data_generator=="all_nans" and nan_policy=="propagate"
+        and hypotest.__name__=="ttest_ci"):
+        skip_nan_unexpected_exception()
     # mixed-omit-xp_var is also affected, via subtract
     if (data_generator=="mixed" and nan_policy=="omit"
         and hypotest.__name__=="xp_var"):

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -501,18 +501,18 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
 
     assert_allclose(res_nd, res_1d, rtol=1e-14)
 
-# nan should not raise a RuntimeWarning in np.mean()
-# but does on mips64el, triggering failure in some test cases
+# nan should not raise a exception in np.mean()
+# but does on some mips64el systems, triggering failure in some test cases
 # see https://github.com/scipy/scipy/issues/22360
 # and https://github.com/numpy/numpy/issues/23158
-def skip_unexpected_nan_RuntimeWarning():
+def skip_nan_unexpected_exception():
     try:
-        # should not raise RuntimeWarning
+        # should not raise an exception
         with np.errstate(all='raise'):
             x = np.asarray([1, 2, np.nan])
             np.mean(x)
-    except RuntimeWarning:
-        pytest.skip("nan raises unexpected RuntimeWarning in numpy")
+    except:
+        pytest.skip("nan raises unexpected exception in numpy")
 
 @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                           "paired", "unpacker"), axis_nan_policy_cases)
@@ -536,11 +536,11 @@ def test_axis_nan_policy_axis_is_None(hypotest, args, kwds, n_samples,
         if hypotest.__name__ in ["iqr", "ttest_ci",
                                  "xp_mean_1samp", "xp_mean_2samp", "xp_var",
                                  "weightedtau", "weightedtau_weighted"]:
-            skip_unexpected_nan_RuntimeWarning()
+            skip_nan_unexpected_exception()
     # mixed-omit-xp_var is also affected, via subtract
     if (data_generator=="mixed" and nan_policy=="omit"
         and hypotest.__name__=="xp_var"):
-        skip_unexpected_nan_RuntimeWarning()
+        skip_nan_unexpected_exception()
 
     rng = np.random.default_rng(0)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-22360.

#### What does this implement/fix?
Under some conditions, MIPS hardware (mips64le) causes numpy to raise an exception (FloatingPointError or RuntimeWarning) when processing nan in arrays.  This exception is unexpected, and causes `test_axis_nan_policy_axis_is_None` to fail in stats/tests/test_axis_nan_policy.py.

This PR screens for emission of an exception, and skips `test_axis_nan_policy_axis_is_None` if the problem is detected. The check is performed only for data_generator/nan_policy/hypotest combinations known to be affected, so as to not skip all testing unnecessarily.

#### Additional information
The problematic behaviour is discussed at https://github.com/numpy/numpy/issues/23158, and may be a combination of gcc compiler and MIPS hardware bugs. The problem is not reproducible in all mips64el environments, but is reproducible on debian build daemons, https://buildd.debian.org/status/logs.php?pkg=scipy&arch=mips64el
