### PR TITLE
TST: signal: add test for `zpk2tf` with multi-dimensional arrays

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -274,15 +274,15 @@ class TestZpk2Tf:
         xp_assert_close(b, bp)
         xp_assert_close(a, ap)
     
-    def test_zpk2tf_with_multi_dimensional_array(self):
-        z = np.array([[1, 2], [3, 4]])  # Multi-dimensional input
-        p = np.array([1, 2])
+    def test_zpk2tf_with_multi_dimensional_array(self, xp):
+        z = xp.asarray([[1, 2], [3, 4]])  # Multi-dimensional input
+        p = xp.asarray([1, 2])
         k = 1
         b, a = zpk2tf(z, p, k)
-        assert b.shape == (2, 3)
-        assert a.shape == (3,)
-        assert np.all(b[0] == np.poly(z[0]))  # Check first row of b
-        assert np.all(a == np.poly(p))
+        b_ref = xp.asarray([[1, -3, 2], [1, -7, 12]])
+        a_ref = xp.asarray([1, -3, 2])
+        xp_assert_equal(b, b_ref)
+        xp_assert_equal(a, a_ref)
 
 
 @skip_xp_backends("jax.numpy", reason='no eig in JAX on GPU.')

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -273,6 +273,16 @@ class TestZpk2Tf:
         bp, ap = zpk2tf(z, p, k)
         xp_assert_close(b, bp)
         xp_assert_close(a, ap)
+    
+    def test_zpk2tf_with_multi_dimensional_array(self):
+        z = np.array([[1, 2], [3, 4]])  # Multi-dimensional input
+        p = np.array([1, 2])
+        k = 1
+        b, a = zpk2tf(z, p, k)
+        assert b.shape == (2, 3)
+        assert a.shape == (3,)
+        assert np.all(b[0] == np.poly(z[0]))  # Check first row of b
+        assert np.all(a == np.poly(p))
 
 
 @skip_xp_backends("jax.numpy", reason='no eig in JAX on GPU.')
@@ -1689,16 +1699,6 @@ class TestBilinear:
 
         with pytest.raises(ValueError, match="Sampling.*be none"):
             bilinear(b, a, fs=None)
-
-    def test_zpk2tf_with_multi_dimensional_array(self):
-            z = np.array([[1, 2], [3, 4]])  # Multi-dimensional input
-            p = np.array([1, 2])
-            k = 1
-            b, a = zpk2tf(z, p, k)
-            assert b.shape == (2, 3)
-            assert a.shape == (3,)
-            assert np.all(b[0] == np.poly(z[0]))  # Check first row of b
-            assert np.all(a == np.poly(p))
 
 
 class TestLp2lp_zpk:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -274,6 +274,9 @@ class TestZpk2Tf:
         xp_assert_close(b, bp)
         xp_assert_close(a, ap)
     
+    @skip_xp_backends(cpu_only=True, reason="convolve on torch is cpu-only")
+    @skip_xp_backends("array_api_strict", 
+                      reason="Not supported yet, see pl-23265 for potential fix")
     def test_zpk2tf_with_multi_dimensional_array(self, xp):
         z = xp.asarray([[1, 2], [3, 4]])  # Multi-dimensional input
         p = xp.asarray([1, 2])

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -276,7 +276,7 @@ class TestZpk2Tf:
     
     @skip_xp_backends(cpu_only=True, reason="convolve on torch is cpu-only")
     @skip_xp_backends("array_api_strict", 
-                      reason="Not supported yet, see pl-23265 for potential fix")
+                      reason="Not supported yet, see scipy:gh-23265 for potential fix")
     @skip_xp_backends("jax.numpy", 
                       reason="zpk2tf not compatible with jax yet on multi-dim arrays")
     def test_zpk2tf_with_multi_dimensional_array(self, xp):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1690,6 +1690,16 @@ class TestBilinear:
         with pytest.raises(ValueError, match="Sampling.*be none"):
             bilinear(b, a, fs=None)
 
+    def test_zpk2tf_with_multi_dimensional_array(self):
+            z = np.array([[1, 2], [3, 4]])  # Multi-dimensional input
+            p = np.array([1, 2])
+            k = 1
+            b, a = zpk2tf(z, p, k)
+            assert b.shape == (2, 3)
+            assert a.shape == (3,)
+            assert np.all(b[0] == np.poly(z[0]))  # Check first row of b
+            assert np.all(a == np.poly(p))
+
 
 class TestLp2lp_zpk:
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -277,6 +277,8 @@ class TestZpk2Tf:
     @skip_xp_backends(cpu_only=True, reason="convolve on torch is cpu-only")
     @skip_xp_backends("array_api_strict", 
                       reason="Not supported yet, see pl-23265 for potential fix")
+    @skip_xp_backends("jax.numpy", 
+                      reason="zpk2tf not compatible with jax yet on multi-dim arrays")
     def test_zpk2tf_with_multi_dimensional_array(self, xp):
         z = xp.asarray([[1, 2], [3, 4]])  # Multi-dimensional input
         p = xp.asarray([1, 2])
@@ -284,8 +286,8 @@ class TestZpk2Tf:
         b, a = zpk2tf(z, p, k)
         b_ref = xp.asarray([[1, -3, 2], [1, -7, 12]])
         a_ref = xp.asarray([1, -3, 2])
-        xp_assert_equal(b, b_ref)
-        xp_assert_equal(a, a_ref)
+        xp_assert_close(b, b_ref, check_dtype=False)
+        xp_assert_close(a, a_ref, check_dtype=False)
 
 
 @skip_xp_backends("jax.numpy", reason='no eig in JAX on GPU.')


### PR DESCRIPTION
This PR adds a test to ensure that `signal.zpk2tf` is correct when given multi-dimensional inputs. PR https://github.com/scipy/scipy/pull/22896 updated `zpk2tf` to support array API but some test coverage were (still) missing. This new test adds coverage to the following lines (that were modified in the PR^^):
```py
--------------------------------------------------------------------------------
# scipy/signal/_filter_design.py
--------------------------------------------------------------------------------
def zpk2tf(z, p, k):
    r"""
    Return polynomial transfer function representation from zeros and poles

    # ... OMITTED
    """
    xp = array_namespace(z, p)
    z, p, k = map(xp.asarray, (z, p, k))

    z = xpx.atleast_nd(z, ndim=1, xp=xp)
    k = xpx.atleast_nd(k, ndim=1, xp=xp)
    if xp.isdtype(k.dtype, 'integral'):
        k = xp.astype(k, xp_default_dtype(xp))

    if z.ndim > 1:
        temp = _pu.poly(z[0], xp=xp) #✅ NOW COVERED
        b = xp.empty((z.shape[0], z.shape[1] + 1), dtype=temp.dtype) #✅ NOW COVERED
        if k.shape[0] == 1: #✅ NOW COVERED
            k = [k[0]] * z.shape[0]
        for i in range(z.shape[0]):
            b[i] = k[i] * _pu.poly(z[i], xp=xp) #✅ NOW COVERED
    else:
        b = k * _pu.poly(z, xp=xp)

    # ... OMITTED
```

Note: Parts of this test have been automatically generated by a novel technique that we're currently developing as part of an academic research project aiming at improving test coverage. *To not waste developer time, two researchers manually checked the test before submitting it.* We appreciate the developers' time and any feedback is welcomed.