### PR TITLE
BUG: signal.remez: fix handling of `weight` array

### DIFF
--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -834,7 +834,7 @@ def remez(numtaps, bands, desired, *, weight=None, type='bandpass',
     xp = array_namespace(bands, desired, weight)
     bands = np.asarray(bands)
     desired = np.asarray(desired)
-    if weight:
+    if weight is not None:
         weight = np.asarray(weight)
 
     fs = _validate_fs(fs, allow_none=True)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -546,9 +546,11 @@ class TestRemez:
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
             remez(11, .1, 1, fs=np.array([10, 20]))
 
-    def test_gh_23266(self):
-        weight = np.asarray([1.0, 2.0])
-        remez(21, [0.0, 0.2, 0.3, 0.5], [1.0, 0.0], weight=weight)
+    def test_gh_23266(self, xp):
+        bands = xp.asarray([0.0, 0.2, 0.3, 0.5])
+        desired = xp.asarray([1.0, 0.0])
+        weight = xp.asarray([1.0, 2.0])
+        remez(21, bands, desired, weight=weight)
 
 
 @skip_xp_backends(cpu_only=True, reason="lstsq")

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -546,6 +546,9 @@ class TestRemez:
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
             remez(11, .1, 1, fs=np.array([10, 20]))
 
+    def test_gh_23266(self):
+        weight = np.asarray([1.0, 2.0])
+        remez(21, [0.0, 0.2, 0.3, 0.5], [1.0, 0.0], weight=weight)
 
 
 @skip_xp_backends(cpu_only=True, reason="lstsq")


### PR DESCRIPTION
#### What does this implement/fix?

The `signal.remez` function can take an optional array of relative weights. In f45ba7bd311ee60c5c2f74c272cd3cd6c1dece86, logic was added that checks to see if weights were supplied and, if so, convert them to an array object.

https://github.com/scipy/scipy/blob/f45ba7bd311ee60c5c2f74c272cd3cd6c1dece86/scipy/signal/_fir_filter_design.py#L836-L837

However, the `if weight` check raises a `ValueError` if `weight` is a NumPy array with more than one element.

```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

It seems best to explicitly check `if weight is not None`.