### PR TITLE
MAINT: sparse: move `_validate_indices` and `_asindices` from methods to functions

### DIFF
--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -161,16 +161,6 @@ class _lil_base(_spbase, IndexMixin):
         # Everything else takes the normal path.
         return IndexMixin.__getitem__(self, key)
 
-    def _asindices(self, idx, N):
-        # LIL routines handle bounds-checking for us, so don't do it here.
-        try:
-            x = np.asarray(idx)
-        except (ValueError, TypeError, MemoryError) as e:
-            raise IndexError('invalid index') from e
-        if x.ndim not in (1, 2):
-            raise IndexError('Index dimension must be <= 2')
-        return x
-
     def _get_intXint(self, row, col):
         v = _csparsetools.lil_get1(self.shape[0], self.shape[1], self.rows,
                                    self.data, row, col)


### PR DESCRIPTION
This PR prepares `_indexing.py` for the nD indexing provided in #23218 
by refactoring two methods into functions.  Based on [#23218(comment)](https://github.com/scipy/scipy/pull/23218#discussion_r2162344895).

The idea is to avoid subclassing just to get those two methods. They only use `self.shape` and `self.format` so we pass those in as arguments.  `self.format` is used in two ways within `_asindices`:
- if format is LIL we don't need to check index bounds (they are checked in the updating methods).
- if the format is COO we don't need to force index arrays to be 1D or 2D.

This is not part of #23218 to make review easier. 

Note: To ease review, look at the changes in the second commit. The first commit only changes the indent and position within the file. Splitting these two makes the code changes easier to see. 