### PR TITLE
TYP: generic ``stats`` types

### DIFF
--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -1,4 +1,5 @@
 from functools import cached_property
+from types import GenericAlias
 
 import numpy as np
 from scipy import linalg
@@ -56,6 +57,10 @@ class Covariance:
     4.9595685102808205e-08
 
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     def __init__(self):
         message = ("The `Covariance` class cannot be instantiated directly. "
                    "Please use one of the factory methods "
@@ -462,6 +467,8 @@ class Covariance:
 
 class CovViaPrecision(Covariance):
 
+    __class_getitem__ = None
+
     def __init__(self, precision, covariance=None):
         precision = self._validate_matrix(precision, 'precision')
         if covariance is not None:
@@ -537,6 +544,8 @@ class CovViaDiagonal(Covariance):
 
 class CovViaCholesky(Covariance):
 
+    __class_getitem__ = None
+
     def __init__(self, cholesky):
         L = self._validate_matrix(cholesky, 'cholesky')
 
@@ -560,6 +569,8 @@ class CovViaCholesky(Covariance):
 
 
 class CovViaEigendecomposition(Covariance):
+
+    __class_getitem__ = None
 
     def __init__(self, eigendecomposition):
         eigenvalues, eigenvectors = eigendecomposition
@@ -619,6 +630,8 @@ class CovViaPSD(Covariance):
     """
     Representation of a covariance provided via an instance of _PSD
     """
+
+    __class_getitem__ = None
 
     def __init__(self, psd):
         self._LP = psd.U

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -505,6 +505,9 @@ def _sum_finite(x):
 # Frozen RV class
 class rv_frozen:
 
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(types.GenericAlias)
+
     def __init__(self, dist, *args, **kwds):
         self.args = args
         self.kwds = kwds

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -1,6 +1,7 @@
 import functools
 from abc import ABC, abstractmethod
 from functools import cached_property
+from types import GenericAlias
 import inspect
 import math
 
@@ -217,6 +218,9 @@ class _Domain(ABC):
 
     """
     symbols = {np.inf: r"\infty", -np.inf: r"-\infty", np.pi: r"\pi", -np.pi: r"-\pi"}
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     @abstractmethod
     def contains(self, x):
@@ -590,6 +594,10 @@ class _Parameter(ABC):
         of the parameter.
 
    """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     def __init__(self, name, *, domain, symbol=None, typical=None):
         self.name = name
         self.symbol = symbol or name
@@ -4140,6 +4148,8 @@ def _make_distribution_rv_generic(dist):
         _parameterizations = ([_Parameterization(*parameters)] if parameters
                               else [])
         _variable = _x_param
+
+        __class_getitem__ = None
 
         def __repr__(self):
             s = super().__repr__()

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -4,6 +4,7 @@
 import math
 import warnings
 import threading
+import types
 import numpy as np
 import scipy.linalg
 from scipy._lib import doccer
@@ -213,6 +214,7 @@ class multi_rv_generic:
     Class which encapsulates common functionality between all multivariate
     distributions.
     """
+
     def __init__(self, seed=None):
         super().__init__()
         self._random_state = check_random_state(seed)
@@ -247,6 +249,10 @@ class multi_rv_frozen:
     Class which encapsulates common functionality between all frozen
     multivariate distributions.
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(types.GenericAlias)
+
     @property
     def random_state(self):
         return self._dist._random_state
@@ -875,6 +881,8 @@ multivariate_normal = multivariate_normal_gen()
 
 
 class multivariate_normal_frozen(multi_rv_frozen):
+    __class_getitem__ = None
+
     def __init__(self, mean=None, cov=1, allow_singular=False, seed=None,
                  maxpts=None, abseps=1e-5, releps=1e-5):
         """Create a frozen multivariate normal distribution.
@@ -1412,6 +1420,7 @@ class matrix_normal_frozen(multi_rv_frozen):
     >>> distn.logpdf(X)
     -10.590229595124615
     """
+    __class_getitem__ = None
 
     def __init__(self, mean=None, rowcov=1, colcov=1, seed=None):
         self._dist = matrix_normal_gen(seed)
@@ -1830,6 +1839,8 @@ dirichlet = dirichlet_gen()
 
 
 class dirichlet_frozen(multi_rv_frozen):
+    __class_getitem__ = None
+
     def __init__(self, alpha, seed=None):
         self.alpha = _dirichlet_check_parameters(alpha)
         self._dist = dirichlet_gen(seed)
@@ -2527,6 +2538,8 @@ class wishart_frozen(multi_rv_frozen):
         that instance is used.
 
     """
+    __class_getitem__ = None
+
     def __init__(self, df, scale, seed=None):
         self._dist = wishart_gen(seed)
         self.dim, self.df, self.scale = self._dist._process_parameters(
@@ -3059,6 +3072,8 @@ invwishart = invwishart_gen()
 
 
 class invwishart_frozen(multi_rv_frozen):
+    __class_getitem__ = None
+
     def __init__(self, df, scale, seed=None):
         """Create a frozen inverse Wishart distribution.
 
@@ -3673,6 +3688,8 @@ special_ortho_group = special_ortho_group_gen()
 
 
 class special_ortho_group_frozen(multi_rv_frozen):
+    __class_getitem__ = None
+
     def __init__(self, dim=None, seed=None):
         """Create a frozen SO(N) distribution.
 
@@ -3826,6 +3843,8 @@ ortho_group = ortho_group_gen()
 
 
 class ortho_group_frozen(multi_rv_frozen):
+    __class_getitem__ = None
+
     def __init__(self, dim=None, seed=None):
         """Create a frozen O(N) distribution.
 
@@ -4081,6 +4100,8 @@ random_correlation = random_correlation_gen()
 
 
 class random_correlation_frozen(multi_rv_frozen):
+    __class_getitem__ = None
+
     def __init__(self, eigs, seed=None, tol=1e-13, diag_tol=1e-7):
         """Create a frozen random correlation matrix distribution.
 
@@ -4241,6 +4262,8 @@ unitary_group = unitary_group_gen()
 
 
 class unitary_group_frozen(multi_rv_frozen):
+    __class_getitem__ = None
+
     def __init__(self, dim=None, seed=None):
         """Create a frozen (U(N)) n-dimensional unitary matrix distribution.
 
@@ -4774,6 +4797,7 @@ class multivariate_t_gen(multi_rv_generic):
 
 
 class multivariate_t_frozen(multi_rv_frozen):
+    __class_getitem__ = None
 
     def __init__(self, loc=None, shape=1, df=1, allow_singular=False,
                  seed=None):
@@ -5687,6 +5711,8 @@ random_table = random_table_gen()
 
 
 class random_table_frozen(multi_rv_frozen):
+    __class_getitem__ = None
+
     def __init__(self, row, col, *, seed=None):
         self._dist = random_table_gen(seed)
         self._params = self._dist._process_parameters(row, col)

--- a/scipy/stats/_probability_distribution.py
+++ b/scipy/stats/_probability_distribution.py
@@ -1,8 +1,13 @@
 # Temporary file separated from _distribution_infrastructure.py
 # to simplify the diff during PR review.
 from abc import ABC, abstractmethod
+from types import GenericAlias
 
 class _ProbabilityDistribution(ABC):
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     @abstractmethod
     def support(self):
         r"""Support of the random variable
@@ -200,7 +205,7 @@ class _ProbabilityDistribution(ABC):
 
         The definitions for discrete random variables are analogous, with
         sums over the support replacing the integrals.
-        
+
         Parameters
         ----------
         order : int
@@ -1098,7 +1103,7 @@ class _ProbabilityDistribution(ABC):
 
         The CDF evaluates to its minimum value of :math:`0` for :math:`x < l`
         and its maximum value of :math:`1` for :math:`x ≥ r`.
-        
+
         The CDF is also known simply as the "distribution function".
 
         References
@@ -1303,7 +1308,7 @@ class _ProbabilityDistribution(ABC):
 
         The CCDF evaluates to its minimum value of :math:`0` for :math:`x ≥ r`
         and its maximum value of :math:`1` for :math:`x < l`.
-        
+
         The CCDF is also known as the "survival function".
 
         References


### PR DESCRIPTION
Same story as #23244, #23234, and #23118 but for the ``scipy.stats`` types, as  documented in the `scipy-stubs` readme: https://github.com/scipy/scipy-stubs#scipystats