### PR TITLE
TYP: generic ``sparse.linalg`` types

### DIFF
--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -109,6 +109,8 @@ static PyObject *SuperLU_solve(SuperLUObject * self, PyObject * args,
  */
 PyMethodDef SuperLU_methods[] = {
     {"solve", (PyCFunction) SuperLU_solve, METH_VARARGS | METH_KEYWORDS, NULL},
+    {"__class_getitem__", Py_GenericAlias, METH_CLASS | METH_O,
+        "For generic type compatibility with scipy-stubs"},
     {NULL, NULL}                /* sentinel */
 };
 

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -42,6 +42,7 @@ Several algorithms in the ``scipy.sparse`` library are able to operate on
 ``LinearOperator`` instances.
 """
 
+import types
 import warnings
 
 import numpy as np
@@ -150,6 +151,9 @@ class LinearOperator:
     ndim = 2
     # Necessary for right matmul with numpy arrays.
     __array_ufunc__ = None
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def __new__(cls, *args, **kwargs):
         if cls is LinearOperator:


### PR DESCRIPTION
Same story as #23268, #23244, #23234, and #23118 but for the ``scipy.sparse.linalg`` types (and some scary C stuff!), as documented in the `scipy-stubs` readme: https://github.com/scipy/scipy-stubs#scipysparselinalg