### PR TITLE
TYP: generic ``integrate`` types

### DIFF
--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -1,3 +1,5 @@
+from types import GenericAlias
+
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
 from scipy.sparse import issparse, csc_matrix, eye
@@ -194,6 +196,10 @@ class BDF(OdeSolver):
            sparse Jacobian matrices", Journal of the Institute of Mathematics
            and its Applications, 13, pp. 117-120, 1974.
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     def __init__(self, fun, t0, y0, t_bound, max_step=np.inf,
                  rtol=1e-3, atol=1e-6, jac=None, jac_sparsity=None,
                  vectorized=False, first_step=None, **extraneous):
@@ -204,7 +210,7 @@ class BDF(OdeSolver):
         self.rtol, self.atol = validate_tol(rtol, atol, self.n)
         f = self.fun(self.t, self.y)
         if first_step is None:
-            self.h_abs = select_initial_step(self.fun, self.t, self.y, 
+            self.h_abs = select_initial_step(self.fun, self.t, self.y,
                                              t_bound, max_step, f,
                                              self.direction, 1,
                                              self.rtol, self.atol)

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -1,3 +1,5 @@
+from types import GenericAlias
+
 import numpy as np
 from .base import OdeSolver, DenseOutput
 from .common import (validate_max_step, validate_tol, select_initial_step,
@@ -81,6 +83,9 @@ class RungeKutta(OdeSolver):
     order: int = NotImplemented
     error_estimator_order: int = NotImplemented
     n_stages: int = NotImplemented
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, fun, t0, y0, t_bound, max_step=np.inf,
                  rtol=1e-3, atol=1e-6, vectorized=False,

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -82,6 +82,7 @@ __all__ = ['ode', 'complex_ode']
 
 import re
 import threading
+import types
 import warnings
 
 from numpy import asarray, array, zeros, isscalar, real, imag, vstack
@@ -351,6 +352,9 @@ class ode:
         Springer-Verlag (1993)
 
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(types.GenericAlias)
 
     def __init__(self, f, jac=None):
         self.stiff = 0
@@ -788,6 +792,9 @@ class IntegratorBase:
     integrator_classes = []
     scalar = float
 
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(types.GenericAlias)
+
     def acquire_new_handle(self):
         # Some of the integrators have internal state (ancient
         # Fortran...), and so only one instance can use them at a time.
@@ -1054,6 +1061,8 @@ class zvode(vode):
     scalar = complex
     active_global_handle = 0
 
+    __class_getitem__ = None
+
     def reset(self, n, has_jac):
         mf = self._determine_mf_and_set_bands(has_jac)
 
@@ -1130,6 +1139,8 @@ class dopri5(IntegratorBase):
                 -3: 'step size becomes too small',
                 -4: 'problem is probably stiff (interrupted)',
                 }
+
+    __class_getitem__ = None
 
     def __init__(self,
                  rtol=1e-6, atol=1e-12,
@@ -1261,6 +1272,8 @@ class lsoda(IntegratorBase):
         -6: "Error weight became zero during problem.",
         -7: "Internal workspace insufficient to finish (internal error)."
     }
+
+    __class_getitem__ = None
 
     def __init__(self,
                  with_jacobian=False,


### PR DESCRIPTION
Same story as #23269, #23268, #23244, #23234, and #23118 but for the ``scipy.integrate`` types, as documented in the `scipy-stubs` readme: https://github.com/scipy/scipy-stubs#scipyintegrate

All of `scipy-stubs`' generic types should be covered now. But I might add some others in the future (e.g. scipy/scipy-stubs#671).