### PR TITLE
DOC: interpolate.make_interp_spline: fix minor formatting typos in docstring

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -146,7 +146,6 @@ class BSpline:
 
     Examples
     --------
-
     Translating the recursive definition of B-splines into Python code, we have:
 
     >>> def B(x, k, i, t):
@@ -304,7 +303,6 @@ class BSpline:
 
         Examples
         --------
-
         Construct a cubic B-spline:
 
         >>> import numpy as np
@@ -1400,7 +1398,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         Alternatively, the following string aliases are recognized:
 
         * ``"clamped"``: The first derivatives at the ends are zero. This is
-           equivalent to ``bc_type=([(1, 0.0)], [(1, 0.0)])``.
+          equivalent to ``bc_type=([(1, 0.0)], [(1, 0.0)])``.
         * ``"natural"``: The second derivatives at ends are zero. This is
           equivalent to ``bc_type=([(2, 0.0)], [(2, 0.0)])``.
         * ``"not-a-knot"`` (default): The first and second segments are the
@@ -1431,7 +1429,6 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
 
     Examples
     --------
-
     Use cubic interpolation on Chebyshev nodes:
 
     >>> import numpy as np


### PR DESCRIPTION
- The extra indentation before "clamped" caused that line to be rendered as bold.
- The blank line after "Examples" caused extra vertical space to be inserted.

(see https://scipy.github.io/devdocs/reference/generated/scipy.interpolate.make_interp_spline.html)

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
