### PR TITLE
DOC: interpolate.make_splprep: fix dimensions ordering

### DIFF
--- a/doc/source/tutorial/interpolate/smoothing_splines.rst
+++ b/doc/source/tutorial/interpolate/smoothing_splines.rst
@@ -343,8 +343,8 @@ problem it solves.
 The main user-visible difference of the parametric case is the user interface:
 
 - instead of two data arrays, ``x`` and ``y``, `make_splprep` receives a single
-  two-dimensional array, where the second dimension has size :math:`d` and each
-  data array is stored along the first dimension (alternatively, you can supply
+  two-dimensional array, where the first dimension has size :math:`d` and each
+  data array is stored along the second dimension (alternatively, you can supply
   a list of 1D arrays).
 
 - the return value is pair: a `BSpline` instance and the array of parameter

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -859,7 +859,7 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None, k=3, s=0, t=None, nest=
 
     Parameters
     ----------
-    x : array_like, shape (m, ndim)
+    x : array_like, shape (ndim, m)
         Sampled data points representing the curve in ``ndim`` dimensions.
         The typical use is a list of 1D arrays, each of length ``m``.
     w : array_like, shape(m,), optional


### PR DESCRIPTION
It is maybe a bit unfortunate that make_splprep takes input with (ndim, npoints) shape rather than the other way round, but changing that would be quite tedious wrt. deprecation and API changes; instead, just document the actual behavior.

To verify this, try e.g. running the make_splprep examples in smoothing_splintes.rst but transposing the arrays (replace `[xn, yn]` by `np.column_stack([xn, rn])`); this results in a ValueError.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
