### PR TITLE
BUG: fix signature of ``@_transition_to_rng`` functions (SPEC 7)

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -342,6 +342,13 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None,
 
             return fun(*args, **kwargs)
 
+        # Add the old parameter name to the function signature
+        wrapped_signature = inspect.signature(fun)
+        wrapper.__signature__ = wrapped_signature.replace(parameters=[
+            *wrapped_signature.parameters.values(),
+            inspect.Parameter(old_name, inspect.Parameter.KEYWORD_ONLY, default=None),
+        ])
+
         if replace_doc:
             doc = FunctionDoc(wrapper)
             parameter_names = [param.name for param in doc['Parameters']]


### PR DESCRIPTION
This adds the missing parameter to the signature of functions decorated with ``scipy._lib._util._transition_to_rng``, and closes #23216.

**Before:**

```pycon
>>> from scipy.linalg import clarkson_woodruff_transform
>>> import inspect
>>> inspect.signature(clarkson_woodruff_transform)
<Signature (input_matrix, sketch_size, rng=None)>
```

**After:**

```pycon
>>> from scipy.linalg import clarkson_woodruff_transform
>>> import inspect
>>> inspect.signature(clarkson_woodruff_transform)
<Signature (input_matrix, sketch_size, rng=None, *, seed=None)>
```

---

The reason I call this is bug, is because it's (still) perfectly valid to use the `seed` parameter for SPEC 7 functions:

```pycon
>>> import numpy as np
>>> clarkson_woodruff_transform(np.eye(2), 1, seed=1)
array([[-1., -1.]])
```

i.e. no (deprecation- or future-) warnings are shown.

See #23216 for the consequences of this missing signature parameter.

---

For reference: <https://scientific-python.org/specs/spec-0007/>
