### PR TITLE
BUG: linalg: Fix pointer casting order for sqrtm

### DIFF
--- a/scipy/linalg/_matfuncs_sqrtm.c
+++ b/scipy/linalg/_matfuncs_sqrtm.c
@@ -533,7 +533,7 @@ matrix_squareroot_c(const PyArrayObject* ap_Am, SCIPY_C* restrict ret_data, int*
     SCIPY_C* restrict data = &buffer[0];
     SCIPY_C* restrict vs = &buffer[n*n];
     SCIPY_C* restrict w = &buffer[2*n*n];
-    float* restrict rwork = &((float*)buffer)[2*n*n + n];
+    float* restrict rwork = (float*)(&buffer[2*n*n + n]);
     SCIPY_C* restrict work = &buffer[2*n*n + 2*n];
 
     for (npy_intp idx = 0; idx < outer_size; idx++) {
@@ -635,7 +635,7 @@ matrix_squareroot_z(const PyArrayObject* ap_Am, SCIPY_Z* restrict ret_data, int*
     SCIPY_Z* restrict data = &buffer[0];
     SCIPY_Z* restrict vs = &buffer[n*n];
     SCIPY_Z* restrict w = &buffer[2*n*n];
-    double* restrict rwork = &((double*)buffer)[2*n*n + n];
+    double* restrict rwork = (double*)(&buffer[2*n*n + n]);
     SCIPY_Z* restrict work = &buffer[2*n*n + 2*n];
 
     for (npy_intp idx = 0; idx < outer_size; idx++) {

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -454,6 +454,13 @@ class TestSqrtM:
         np.fill_diagonal(M, 1)
         assert np.isrealobj(sqrtm(M))
 
+    def test_gh23278(self):
+        M = np.array([[1., 0., 0.], [0, 1, -1j], [0, 1j, 2]])
+        sq = sqrtm(M)
+        assert_allclose(sq @ sq, M, atol=1e-14)
+        sq = sqrtm(M.astype(np.complex64))
+        assert_allclose(sq @ sq, M, atol=1e-6)
+
     def test_data_size_preservation_uint_in_float_out(self):
         M = np.eye(10, dtype=np.uint8)
         assert sqrtm(M).dtype == np.float64


### PR DESCRIPTION

#### Reference issue
Closes #23278 

#### Additional information

The pointer casting was done in the reverse order, causing to overwrite the original array.


