### PR TITLE
DOC: interpolate.LinearNDInterpolator: mention limitations

### DIFF
--- a/scipy/interpolate/_interpnd.pyx
+++ b/scipy/interpolate/_interpnd.pyx
@@ -258,6 +258,15 @@ class LinearNDInterpolator(NDInterpolatorBase):
     with Qhull [1]_, and on each triangle performing linear
     barycentric interpolation.
 
+    If you provide points only on the boundary of a shape rather
+    than the interior, the default tolerance will cause issues
+    assigning a simplex to certain points in the interior with
+    enough points on each side, resulting in missing values in the
+    output.  This is easiest to reproduce by providing 300
+    evenly-spaced points on the positive x and y axes and
+    requesting points to fill the grid: all points with `x+y<300`
+    should have values.
+
     .. note:: For data on a regular grid use `interpn` instead.
 
     Examples


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
This documents the issues uncovered in #21910.

#### What does this implement/fix?
<!--Please explain your changes.-->
This documents that linear interpolation is not intended to fill the interior of a very large array from the boundary.

#### Additional information
<!--Any additional information you think is important.-->
There's probably a dozen points with the given setup, starting around 150