### PR TITLE
TST: differentiate: use correct `xp_capabilities` for `jacobian`

### DIFF
--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -465,7 +465,7 @@ class JacobianHessianTest:
             jh_func(func, x, maxiter=-1)
 
 
-@make_xp_test_case(hessian)
+@make_xp_test_case(jacobian)
 class TestJacobian(JacobianHessianTest):
     jh_func = jacobian
 


### PR DESCRIPTION
Follow-up to #23287
@lucascolley 