### PR TITLE
BUG: ndimage.median_filter: single element array handling

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1989,7 +1989,8 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
                 "A sequence of modes is not supported by non-separable rank "
                 "filters")
         mode = _ni_support._extend_mode_to_code(mode, is_filter=True)
-        if input.ndim == 1:
+        lim2 = input.size - ((footprint.size - 1) / 2 - origin)
+        if input.ndim == 1 and ((lim2 >= 0) or (input.size == 1)):
             if input.dtype in (np.int64, np.float64, np.float32):
                 x = input
                 x_out = output

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1989,7 +1989,7 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
                 "A sequence of modes is not supported by non-separable rank "
                 "filters")
         mode = _ni_support._extend_mode_to_code(mode, is_filter=True)
-        lim2 = input.size - ((footprint.size - 1) / 2 - origin)
+        lim2 = input.size - ((footprint.size - 1) // 2 - origin)
         if input.ndim == 1 and ((lim2 >= 0) or (input.size == 1)):
             if input.dtype in (np.int64, np.float64, np.float32):
                 x = input

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1989,6 +1989,12 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
                 "A sequence of modes is not supported by non-separable rank "
                 "filters")
         mode = _ni_support._extend_mode_to_code(mode, is_filter=True)
+        # Some corner cases are currently not allowed to use the
+        # "new"/fast 1D rank filter code, including when the
+        # footprint is large compared to the array size.
+        # See discussion in gh-23293; longer-term it may be possible
+        # to allow the fast path for these corner cases as well,
+        # if algorithmic fixes are found.
         lim2 = input.size - ((footprint.size - 1) // 2 - origin)
         if input.ndim == 1 and ((lim2 >= 0) or (input.size == 1)):
             if input.dtype in (np.int64, np.float64, np.float32):

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -155,7 +155,24 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
                   int mode, T cval, int origin) {
   int i, arr_len_thresh, lim = (win_len - 1) / 2 - origin;
   int lim2 = arr_len - lim;
-  if (lim2 < 0) return;
+  if (arr_len == 1) {
+      switch (mode) {
+          case REFLECT:
+          case NEAREST:
+          case WRAP:
+          case MIRROR:
+              out_arr[0] = in_arr[0];
+              return;
+          case CONSTANT:
+              if (win_len == 1) {
+                  out_arr[0] = in_arr[0];
+              }
+              else {
+                  out_arr[0] = cval;
+              }
+              return;
+      }
+  }
   int offset;
   Mediator *m = MediatorNew(win_len, rank);
   T *data = new T[win_len]();

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -174,9 +174,6 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
                   return;
           }
       }
-      else {
-          return;
-      }
   }
   int offset;
   Mediator *m = MediatorNew(win_len, rank);

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -155,22 +155,27 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
                   int mode, T cval, int origin) {
   int i, arr_len_thresh, lim = (win_len - 1) / 2 - origin;
   int lim2 = arr_len - lim;
-  if (arr_len == 1) {
-      switch (mode) {
-          case REFLECT:
-          case NEAREST:
-          case WRAP:
-          case MIRROR:
-              out_arr[0] = in_arr[0];
-              return;
-          case CONSTANT:
-              if (win_len == 1) {
+  if (lim2 < 0) {
+      if (arr_len == 1) {
+          switch (mode) {
+              case REFLECT:
+              case NEAREST:
+              case WRAP:
+              case MIRROR:
                   out_arr[0] = in_arr[0];
-              }
-              else {
-                  out_arr[0] = cval;
-              }
-              return;
+                  return;
+              case CONSTANT:
+                  if (win_len == 1) {
+                      out_arr[0] = in_arr[0];
+                  }
+                  else {
+                      out_arr[0] = cval;
+                  }
+                  return;
+          }
+      }
+      else {
+          return;
       }
   }
   int offset;

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -155,7 +155,9 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
                   int mode, T cval, int origin) {
   int i, arr_len_thresh, lim = (win_len - 1) / 2 - origin;
   int lim2 = arr_len - lim;
-  if (lim2 < 0) {
+  /* Note: `arr_len == 1` is the only case implemented here for `lim2 < 0`; the calling code */
+  /* in _filters.py ensures that this function isn't called otherwise. xref gh-23293 for details. */
+  if (lim2 < 0 && arr_len == 1) {
       switch (mode) {
           case REFLECT:
           case NEAREST:

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -156,23 +156,21 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
   int i, arr_len_thresh, lim = (win_len - 1) / 2 - origin;
   int lim2 = arr_len - lim;
   if (lim2 < 0) {
-      if (arr_len == 1) {
-          switch (mode) {
-              case REFLECT:
-              case NEAREST:
-              case WRAP:
-              case MIRROR:
+      switch (mode) {
+          case REFLECT:
+          case NEAREST:
+          case WRAP:
+          case MIRROR:
+              out_arr[0] = in_arr[0];
+              return;
+          case CONSTANT:
+              if (win_len == 1) {
                   out_arr[0] = in_arr[0];
-                  return;
-              case CONSTANT:
-                  if (win_len == 1) {
-                      out_arr[0] = in_arr[0];
-                  }
-                  else {
-                      out_arr[0] = cval;
-                  }
-                  return;
-          }
+              }
+              else {
+                  out_arr[0] = cval;
+              }
+              return;
       }
   }
   int offset;

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3036,3 +3036,48 @@ class TestVectorizedFilter:
 def test_gh_22586_crash_property(x, size, mode):
     # property-based test for median_filter resilience to hard crashing
     ndimage.median_filter(x, size=size, mode=mode)
+
+
+@pytest.mark.parametrize('samples, mode, size, expected', [
+    ([1, 2], "reflect", 5, [2, 1]),
+    ([2], "reflect", 5, [2]), # original failure from gh-23075
+    ([2], "nearest", 5, [2]),
+    ([2], "wrap", 5, [2]),
+    ([2], "mirror", 5, [2]),
+    ([2], "constant", 5, [0]),
+    ([2], "reflect", 1, [2]),
+    ([2], "nearest", 1, [2]),
+    ([2], "wrap", 1, [2]),
+    ([2], "mirror", 1, [2]),
+    ([2], "constant", 1, [2]),
+    ([2], "reflect", 100, [2]),
+    ([2], "nearest", 100, [2]),
+    ([2], "wrap", 100, [2]),
+    ([2], "mirror", 100, [2]),
+    ([2], "constant", 100, [0]),
+])
+def test_gh_23075(samples, mode, size, expected):
+    # results verified against SciPy 1.14.1, before the median_filter
+    # overhaul
+    sample_array = np.asarray(samples, dtype=np.single)
+    expected = np.asarray(expected, dtype=np.single)
+    filtered_samples = ndimage.median_filter(sample_array, size=size, mode=mode)
+    assert_allclose(filtered_samples, expected, strict=True)
+
+
+@pytest.mark.parametrize('samples, size, cval, expected', [
+    ([2], 5, 17.7, [17.7]),
+    ([2], 1, 0, [2]),
+    ([2], 100, 1.4, [1.4]),
+    ([9], 137, -7807.7, [-7807.7]),
+])
+def test_gh_23075_constant(samples, size, cval, expected):
+    # results verified against SciPy 1.14.1, before the median_filter
+    # overhaul
+    sample_array = np.asarray(samples, dtype=np.single)
+    expected = np.asarray(expected, dtype=np.single)
+    filtered_samples = ndimage.median_filter(sample_array,
+                                             size=size,
+                                             mode="constant",
+                                             cval=cval)
+    assert_allclose(filtered_samples, expected, strict=True)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3059,8 +3059,8 @@ def test_gh_22586_crash_property(x, size, mode):
 def test_gh_23075(samples, mode, size, expected):
     # results verified against SciPy 1.14.1, before the median_filter
     # overhaul
-    sample_array = np.asarray(samples, dtype=np.single)
-    expected = np.asarray(expected, dtype=np.single)
+    sample_array = np.asarray(samples, dtype=np.float32)
+    expected = np.asarray(expected, dtype=np.float32)
     filtered_samples = ndimage.median_filter(sample_array, size=size, mode=mode)
     xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)
 

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3062,7 +3062,7 @@ def test_gh_23075(samples, mode, size, expected):
     sample_array = np.asarray(samples, dtype=np.single)
     expected = np.asarray(expected, dtype=np.single)
     filtered_samples = ndimage.median_filter(sample_array, size=size, mode=mode)
-    assert_allclose(filtered_samples, expected, strict=True)
+    xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)
 
 
 @pytest.mark.parametrize('samples, size, cval, expected', [
@@ -3080,4 +3080,4 @@ def test_gh_23075_constant(samples, size, cval, expected):
                                              size=size,
                                              mode="constant",
                                              cval=cval)
-    assert_allclose(filtered_samples, expected, strict=True)
+    xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3081,3 +3081,10 @@ def test_gh_23075_constant(samples, size, cval, expected):
                                              mode="constant",
                                              cval=cval)
     xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)
+
+
+def test_median_filter_lim2():
+    sample_array = np.ones(8)
+    expected = np.ones(8)
+    filtered_samples = ndimage.median_filter(sample_array, size=19, mode="reflect")
+    xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)


### PR DESCRIPTION
* Fixes gh-23075

* This patch adds special handling for the single-element array scenario in the above ticket, along with several regression test cases that get their expected values from running the same tests against SciPy `1.14.1`, before we overhauled the `median_filter` algorithm.

[skip circle]