### PR TITLE
TST: better thread-unsafe markers and re-enable pytest-run-parallel CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -517,6 +517,7 @@ jobs:
           scipy.integrate
           scipy.interpolate
           scipy.io
+          scipy._lib
           scipy.linalg
           scipy.misc
           scipy.ndimage
@@ -527,9 +528,11 @@ jobs:
           scipy.special
           scipy.stats
       run: |
-        # Note: only fast tests; full test suite is unlikely to uncover anything more,
-        #       and it'll be quite slow with pytest-run-parallel
-        spin test -t $TEST_SUBMODULES -- --parallel-threads=4
+        # Note: Only fast tests; full test suite is unlikely to uncover anything more,
+        #       and it'll be quite slow with pytest-run-parallel. Also skip
+        #       tests that won't run in parallel, those are covered by the
+        #       parallel == 0 run.
+        spin test -t $TEST_SUBMODULES -- --parallel-threads=4 --skip-thread-unsafe=true
 
   #################################################################################
   clang-17-build-only:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -457,7 +457,7 @@ jobs:
     needs: get_commit_message
     strategy:
       matrix:
-        parallel: ['0']  # '1' temporarily disabled, `stats` segfault (see gh-22758)
+        parallel: ['0', '1']
 
     runs-on: ubuntu-latest
     if: >

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -508,6 +508,7 @@ jobs:
         # Excluded modules:
         # - scipy.spatial has multiple issues  in kdtree/qhull, and gh-20655 is pending.
         TEST_SUBMODULES: >-
+          scipy._lib
           scipy.cluster
           scipy.constants
           scipy.datasets
@@ -517,7 +518,6 @@ jobs:
           scipy.integrate
           scipy.interpolate
           scipy.io
-          scipy._lib
           scipy.linalg
           scipy.misc
           scipy.ndimage

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -166,9 +166,6 @@ def eager_warns(warning_type, *, match=None, xp):
     """
     import pytest
     from scipy._lib._util import ignore_warns
-    # This attribute is interpreted by pytest-run-parallel, ensuring that tests that use
-    # `eager_warns` aren't run in parallel (since pytest.warns isn't thread-safe).
-    __thread_safe__ = False  # noqa: F841
     if is_numpy(xp) or is_array_api_strict(xp) or is_cupy(xp):
         return pytest.warns(warning_type, match=match)
     return ignore_warns(warning_type, match='' if match is None else match)

--- a/scipy/_lib/tests/test_config.py
+++ b/scipy/_lib/tests/test_config.py
@@ -18,7 +18,6 @@ class TestSciPyConfigs:
         "Python Information",
     ]
 
-    @pytest.mark.thread_unsafe
     @patch("scipy.__config__._check_pyyaml")
     def test_pyyaml_not_found(self, mock_yaml_importer):
         mock_yaml_importer.side_effect = ModuleNotFoundError()

--- a/scipy/_lib/tests/test_deprecation.py
+++ b/scipy/_lib/tests/test_deprecation.py
@@ -1,6 +1,6 @@
 import pytest
 
-@pytest.mark.thread_unsafe("deprecate_cython_api is not thread-safe")
+@pytest.mark.thread_unsafe(reason="deprecate_cython_api is not thread-safe")
 def test_cython_api_deprecation():
     match = ("`scipy._lib._test_deprecation_def.foo_deprecated` "
              "is deprecated, use `foo` instead!\n"

--- a/scipy/_lib/tests/test_deprecation.py
+++ b/scipy/_lib/tests/test_deprecation.py
@@ -1,6 +1,6 @@
 import pytest
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe("deprecate_cython_api is not thread-safe")
 def test_cython_api_deprecation():
     match = ("`scipy._lib._test_deprecation_def.foo_deprecated` "
              "is deprecated, use `foo` instead!\n"

--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -10,7 +10,6 @@ from .test_public_api import PUBLIC_MODULES
 
 @pytest.mark.fail_slow(40)
 @pytest.mark.slow
-@pytest.mark.thread_unsafe
 def test_public_modules_importable():
     pids = [subprocess.Popen([sys.executable, '-c', f'import {module}'])
             for module in PUBLIC_MODULES]

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -222,7 +222,7 @@ SKIP_LIST = [
 # while attempting to import each discovered package.
 # For now, `ignore_errors` only ignores what is necessary, but this could be expanded -
 # for example, to all errors from private modules or git subpackages - if desired.
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe("pkgutil.walk_packages is thread-unsafe?")
 def test_all_modules_are_expected():
     """
     Test that we don't add anything that looks like a new public module by
@@ -343,7 +343,6 @@ def test_api_importable():
                              f"{module_names}")
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.parametrize(("module_name", "correct_module"),
                          [('scipy.constants.codata', None),
                           ('scipy.constants.constants', None),

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -222,7 +222,9 @@ SKIP_LIST = [
 # while attempting to import each discovered package.
 # For now, `ignore_errors` only ignores what is necessary, but this could be expanded -
 # for example, to all errors from private modules or git subpackages - if desired.
-@pytest.mark.thread_unsafe("pkgutil.walk_packages is thread-unsafe?")
+@pytest.mark.thread_unsafe(
+    reason=("crashes in pkgutil.walk_packages, see "
+            "https://github.com/data-apis/array-api-compat/issues/343"))
 def test_all_modules_are_expected():
     """
     Test that we don't add anything that looks like a new public module by

--- a/scipy/_lib/tests/test_tmpdirs.py
+++ b/scipy/_lib/tests/test_tmpdirs.py
@@ -13,7 +13,7 @@ MY_PATH = abspath(__file__)
 MY_DIR = dirname(MY_PATH)
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="tempdir is not thread-safe")
 def test_tempdir():
     with tempdir() as tmpdir:
         fname = pjoin(tmpdir, 'example_file.txt')
@@ -22,7 +22,7 @@ def test_tempdir():
     assert_(not exists(tmpdir))
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="in_tempdir is not thread-safe")
 def test_in_tempdir():
     my_cwd = getcwd()
     with in_tempdir() as tmpdir:
@@ -34,7 +34,7 @@ def test_in_tempdir():
     assert_equal(getcwd(), my_cwd)
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="in_dir is not thread-safe")
 def test_given_directory():
     # Test InGivenDirectory
     cwd = getcwd()

--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -392,7 +392,6 @@ class TestKMeans:
         res, _ = kmeans2(xp.asarray(TESTDATA_2D), 2, minit='++', rng=rng)
         xp_assert_close(res, prev_res)
 
-    @pytest.mark.thread_unsafe
     def test_kmeans2_kpp_high_dim(self, xp):
         # Regression test for gh-11462
         rng = np.random.default_rng(23587923456834568)

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -677,7 +677,6 @@ class TestHessian(JacobianHessianTest):
         # assert np.unique(res.nfev).size == 3
 
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.skip_xp_backends(np_only=True,
                                   reason='Python list input uses NumPy backend')
     def test_small_rtol_warning(self, xp):

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -447,6 +447,7 @@ class TestFFTThreadSafe:
 
 
 @skip_xp_backends(np_only=True)
+@pytest.mark.thread_unsafe(reason="segfault + deadlock #23301")
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft])
 def test_multiprocess(func, xp):
     # Test that fft still works after fork (gh-10422)

--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -447,7 +447,6 @@ class TestFFTThreadSafe:
 
 
 @skip_xp_backends(np_only=True)
-@pytest.mark.thread_unsafe(reason="segfault + deadlock #23301")
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft])
 def test_multiprocess(func, xp):
     # Test that fft still works after fork (gh-10422)

--- a/scipy/fft/tests/test_fftlog.py
+++ b/scipy/fft/tests/test_fftlog.py
@@ -119,7 +119,6 @@ def test_fht_identity(n, bias, offset, optimal, xp):
 
 
 
-@pytest.mark.thread_unsafe
 def test_fht_special_cases(xp):
     rng = np.random.RandomState(3491349965)
 

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -174,7 +174,8 @@ def test_duplicate_timestamps():
     assert sol.success
     assert_equal(sol.status, 1)
 
-@pytest.mark.thread_unsafe
+
+@pytest.mark.thread_unsafe(reason="lsoda solver is not thread-safe")
 def test_integration():
     rtol = 1e-3
     atol = 1e-6
@@ -241,7 +242,6 @@ def test_integration():
         assert_allclose(res.sol(res.t), res.y, rtol=1e-15, atol=1e-15)
 
 
-@pytest.mark.thread_unsafe
 def test_integration_complex():
     rtol = 1e-3
     atol = 1e-6
@@ -771,7 +771,7 @@ def test_t_eval_dense_output():
     assert_(np.all(e < 5))
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="lsoda solver is not thread-safe")
 def test_t_eval_early_event():
     def early_event(t, y):
         return t - 7
@@ -1138,7 +1138,6 @@ def test_args():
     assert_allclose(zfinalevents[2], [zfinal])
 
 
-@pytest.mark.thread_unsafe
 def test_array_rtol():
     # solve_ivp had a bug with array_like `rtol`; see gh-15482
     # check that it's fixed

--- a/scipy/integrate/tests/test_banded_ode_solvers.py
+++ b/scipy/integrate/tests/test_banded_ode_solvers.py
@@ -125,7 +125,7 @@ def _analytical_solution(a, y0, t):
     return sol
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="vode integrator is not thread-safe")
 def test_banded_ode_solvers():
     # Test the "lsoda", "vode" and "zvode" solvers of the `ode` class
     # with a system that has a banded Jacobian matrix.
@@ -251,7 +251,7 @@ def banded_stiff_jac(t, y):
         [0,  0.04,           3e7*2*y[2],         0, 0]
     ])
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="lsoda integrator is not thread-safe")
 def test_banded_lsoda():
     # expected solution is given by problem with full jacobian
     tfull, yfull = _solve_robertson_lsoda(use_jac=True, banded=False)

--- a/scipy/integrate/tests/test_bvp.py
+++ b/scipy/integrate/tests/test_bvp.py
@@ -691,7 +691,7 @@ def test_nonlin_bc():
     assert_allclose(sol.sol(sol.x, 1), sol.yp, rtol=1e-10, atol=1e-10)
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="multithreaded sys.stdout parsing is not thread-safe")
 def test_verbose():
     # Smoke test that checks the printing does something and does not crash
     x = np.linspace(0, 1, 5)

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -142,7 +142,6 @@ class TestOde(TestODEClass):
                 continue
             self._do_problem(problem, 'dop853')
 
-    @pytest.mark.thread_unsafe
     def test_concurrent_fail(self):
         for sol in ('vode', 'zvode', 'lsoda'):
             def f(t, y):
@@ -635,7 +634,6 @@ class ODECheckParameterUse:
             solver.set_jac_params(omega)
         self._check_solver(solver)
 
-    @pytest.mark.thread_unsafe
     def test_warns_on_failure(self):
         # Set nsteps small to ensure failure
         solver = self._get_solver(f, jac)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -371,7 +371,6 @@ class TestTrapezoid:
 
 
 class TestQMCQuad:
-    @pytest.mark.thread_unsafe
     def test_input_validation(self):
         message = "`func` must be callable."
         with pytest.raises(TypeError, match=message):
@@ -448,7 +447,6 @@ class TestQMCQuad:
     def test_sign(self, signs):
         self.basic_test(signs=signs)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize("log", [False, True])
     def test_zero(self, log):
         message = "A lower limit was equal to an upper limit, so"
@@ -632,7 +630,6 @@ class TestCumulativeSimpson:
         return theoretical_difference
 
     @pytest.mark.fail_slow(10)
-    @pytest.mark.thread_unsafe
     @pytest.mark.slow
     @given(
         y=hyp_num.arrays(
@@ -664,7 +661,6 @@ class TestCumulativeSimpson:
         )
 
     @pytest.mark.fail_slow(10)
-    @pytest.mark.thread_unsafe
     @pytest.mark.slow
     @given(
         y=hyp_num.arrays(

--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -92,7 +92,6 @@ class TestAAA:
         with pytest.raises(ValueError, match="greater"):
             AAA([1], [1], max_terms=-1)
 
-    @pytest.mark.thread_unsafe
     def test_convergence_error(self):
         with pytest.warns(RuntimeWarning, match="AAA failed"):
             AAA(UNIT_INTERVAL, np.exp(UNIT_INTERVAL),  max_terms=1)
@@ -246,7 +245,6 @@ class TestAAA:
         r = AAA(z, np.tan(np.pi*z/2))
         assert_allclose(np.sort(np.abs(r.poles()))[:4], [1, 1, 3, 3], rtol=9e-7)
 
-    @pytest.mark.thread_unsafe
     def test_spiral_cleanup(self):
         z = np.exp(np.linspace(-0.5, 0.5 + 15j*np.pi, num=1000))
         # here we set `rtol=0` to force froissart doublets, without cleanup there

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -505,7 +505,6 @@ class TestBSpline:
         spl1 = BSpline(t, c[1, :], k)
         xp_assert_equal(spl(2.5), xp.stack([spl0(2.5), spl1(2.5)]))
 
-    @pytest.mark.thread_unsafe
     def test_design_matrix_bc_types(self):
         '''
         Splines with different boundary conditions are built on different
@@ -682,7 +681,6 @@ class TestBSpline:
         b = BSpline(t=t, c=c, k=0)
         xp_assert_close(b(xx), np.ones_like(xx) * 3.0)
 
-    @pytest.mark.thread_unsafe
     def test_concurrency(self, xp):
         # Check that no segfaults appear with concurrent access to BSpline
         b = _make_random_spline(xp=xp)
@@ -2845,7 +2843,6 @@ class TestNdBSpline:
         with assert_raises(ValueError, match="Data and knots*"):
             NdBSpline.design_matrix([[1, 2]], t3, [k]*3)
 
-    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         rng = np.random.default_rng(12345)
         k = 3
@@ -3376,7 +3373,6 @@ index 1afb1900f1..d817e51ad8 100644
 
         xp_assert_close(tt, t, atol=1e-15)
 
-    @pytest.mark.thread_unsafe
     def test_s_too_small(self):
         n = 14
         x = np.arange(n)
@@ -3606,7 +3602,6 @@ class TestMakeSplrep:
 
         xp_assert_close(spl.c, spl_i.c, atol=1e-15)
 
-    @pytest.mark.thread_unsafe
     def test_s_too_small(self):
         # both splrep and make_splrep warn that "s too small": ier=2
         n = 14

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -372,7 +372,6 @@ class TestUnivariateSpline:
         xp_assert_close(spl1([0.1, 0.5, 0.9, 0.99]),
                         spl2([0.1, 0.5, 0.9, 0.99]))
 
-    @pytest.mark.thread_unsafe
     def test_fpknot_oob_crash(self):
         # https://github.com/scipy/scipy/issues/3691
         x = range(109)
@@ -415,7 +414,6 @@ of squared residuals does not satisfy the condition abs(fp-s)/s < tol."""
 
 class TestLSQBivariateSpline:
     # NOTE: The systems in this test class are rank-deficient
-    @pytest.mark.thread_unsafe
     def test_linear_constant(self):
         x = [1,1,1,2,2,2,3,3,3]
         y = [1,2,3,1,2,3,1,2,3]
@@ -453,7 +451,6 @@ class TestLSQBivariateSpline:
                               + lut(xb, yb)*t*s)
                         assert_almost_equal(lut(xp,yp), zp)
 
-    @pytest.mark.thread_unsafe
     def test_integral(self):
         x = [1,1,1,2,2,2,8,8,8]
         y = [1,2,3,1,2,3,1,2,3]
@@ -473,7 +470,6 @@ class TestLSQBivariateSpline:
         assert_almost_equal(np.asarray(lut.integral(tx[0], tx[-1], ty[0], ty[-1])),
                             np.asarray(trpz))
 
-    @pytest.mark.thread_unsafe
     def test_empty_input(self):
         # Test whether empty inputs returns an empty output. Ticket 1014
         x = [1,1,1,2,2,2,3,3,3]
@@ -532,7 +528,6 @@ class TestLSQBivariateSpline:
             LSQBivariateSpline(x, y, z, tx, ty, eps=1.0)
         assert "eps should be between (0, 1)" in str(exc_info.value)
 
-    @pytest.mark.thread_unsafe
     def test_array_like_input(self):
         s = 0.1
         tx = np.array([1 + s, 3 - s])
@@ -553,7 +548,6 @@ class TestLSQBivariateSpline:
             xp_assert_close(spl1(2.0, 2.0), spl2(2.0, 2.0))
             assert len(r) == 2
 
-    @pytest.mark.thread_unsafe
     def test_unequal_length_of_knots(self):
         """Test for the case when the input knot-location arrays in x and y are
         of different lengths.
@@ -595,7 +589,6 @@ class TestSmoothBivariateSpline:
         assert abs(lut.get_residual()) < 1e-15
         assert_array_almost_equal(lut([1,1.5,2],[1,1.5]),[[0,0],[1,1],[2,2]])
 
-    @pytest.mark.thread_unsafe
     def test_integral(self):
         x = [1,1,1,2,2,2,4,4,4]
         y = [1,2,3,1,2,3,1,2,3]

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -387,15 +387,9 @@ class TestUnivariateSpline:
              0., 10.7, 0., 0., 10.6, 0., 0., 0., 10.4,
              0., 0., 10.6, 0., 0., 10.5, 0., 0., 0.,
              10.7, 0., 0., 0., 10.4, 0., 0., 0., 10.8, 0.]
-        with pytest.warns(UserWarning) as r:
+        msg = r"does not satisfy the condition abs\(fp-s\)/s < tol"
+        with pytest.warns(UserWarning, match=msg):
             UnivariateSpline(x, y, k=1)
-            assert len(r) == 1
-            assert str(r[0].message) == r"""
-The maximal number of iterations maxit (set to 20 by the program)
-allowed for finding a smoothing spline with fp=s has been reached: s
-too small.
-There is an approximation returned but the corresponding weighted sum
-of squared residuals does not satisfy the condition abs(fp-s)/s < tol."""
 
     def test_concurrency(self):
         # Check that no segfaults appear with concurrent access to

--- a/scipy/interpolate/tests/test_interpnd.py
+++ b/scipy/interpolate/tests/test_interpnd.py
@@ -174,7 +174,6 @@ class TestLinearNDInterpolation:
         assert_almost_equal(ip(0.5, 0.5), ip2(0.5, 0.5))
 
     @pytest.mark.slow
-    @pytest.mark.thread_unsafe
     @pytest.mark.skipif(_IS_32BIT, reason='it fails on 32-bit')
     def test_threading(self):
         # This test was taken from issue 8856

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2453,7 +2453,6 @@ class TestNdPPoly:
         paz = p.antiderivative((0, 0, 1))
         xp_assert_close(pz((u, v)), paz((u, v, b)) - paz((u, v, a)))
 
-    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         rng = np.random.default_rng(12345)
 

--- a/scipy/interpolate/tests/test_ndgriddata.py
+++ b/scipy/interpolate/tests/test_ndgriddata.py
@@ -246,7 +246,6 @@ class TestNearestNDInterpolator:
         with assert_raises(TypeError):
             NI([0.5, 0.5], query_options="not a dictionary")
 
-    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         npts, nd = 50, 3
         x = np.arange(npts * nd).reshape((npts, nd))

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -314,12 +314,10 @@ class TestKrogh:
                   1j*KroghInterpolator(x, y.imag).derivatives(0))
         xp_assert_close(cmplx, cmplx2, atol=1e-15)
 
-    @pytest.mark.thread_unsafe
     def test_high_degree_warning(self):
         with pytest.warns(UserWarning, match="40 degrees provided,"):
             KroghInterpolator(np.arange(40), np.ones(40))
 
-    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         P = KroghInterpolator(self.xs, self.ys)
 
@@ -519,7 +517,6 @@ class TestBarycentric:
         # at the nodes
         assert_almost_equal(yi, P.yi.ravel())
 
-    @pytest.mark.thread_unsafe
     def test_repeated_node(self):
         # check that a repeated node raises a ValueError
         # (computing the weights requires division by xi[i] - xi[j])
@@ -529,7 +526,6 @@ class TestBarycentric:
                            match="Interpolation points xi must be distinct."):
             BarycentricInterpolator(xis, ys)
 
-    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         P = BarycentricInterpolator(self.xs, self.ys)
 
@@ -625,7 +621,6 @@ class TestPCHIP:
             for t in (x[0], x[-1]):
                 assert pp(t, 1) != 0
 
-    @pytest.mark.thread_unsafe
     def test_all_zeros(self):
         x = np.arange(10)
         y = np.zeros_like(x)

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -3,7 +3,6 @@
 
 import numpy as np
 
-import pytest
 
 from scipy._lib._array_api import assert_array_almost_equal, assert_almost_equal
 
@@ -231,7 +230,6 @@ def test_rbf_epsilon_none_collinear():
     assert rbf.epsilon > 0
 
 
-@pytest.mark.thread_unsafe
 def test_rbf_concurrency():
     x = linspace(0, 10, 100)
     y0 = sin(x)

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -366,7 +366,6 @@ class _TestRBFInterpolator:
         with pytest.raises(ValueError, match=match):
             self.build(y, d, kernel='thin_plate_spline')
 
-    @pytest.mark.thread_unsafe
     def test_degree_warning(self):
         y = np.linspace(0, 1, 5)[:, None]
         d = np.zeros(5)

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -760,7 +760,6 @@ class TestRegularGridInterpolator:
                 (x, y), data, method='slinear',  solver_args={'woof': 42}
             )
 
-    @pytest.mark.thread_unsafe
     def test_concurrency(self):
         points, values = self._get_sample_4d()
         sample = np.array([[0.1 , 0.1 , 1.  , 0.9 ],
@@ -1031,7 +1030,6 @@ class TestInterpN:
 
         xp_assert_close(v1, v2)
 
-    @pytest.mark.thread_unsafe
     def test_complex_pchip(self):
         # Complex-valued data deprecated for pchip
         x, y, values = self._sample_2d_data()
@@ -1043,7 +1041,6 @@ class TestInterpN:
         with pytest.raises(ValueError, match='real'):
             interpn(points, values, sample, method='pchip')
 
-    @pytest.mark.thread_unsafe
     def test_complex_spline2fd(self):
         # Complex-valued data not supported by spline2fd
         x, y, values = self._sample_2d_data()

--- a/scipy/io/tests/test_idl.py
+++ b/scipy/io/tests/test_idl.py
@@ -278,7 +278,6 @@ class TestStructures:
         assert_identical(s.fc.r, np.array([0], dtype=np.int16))
         assert_identical(s.fc.c, np.array([4], dtype=np.int16))
 
-    @pytest.mark.thread_unsafe
     def test_arrays_corrupt_idl80(self):
         # test byte arrays with missing nbyte information from IDL 8.0 .sav file
         with warnings.catch_warnings():
@@ -456,7 +455,6 @@ def test_null_pointer():
     assert_identical(s.check, np.int16(5))
 
 
-@pytest.mark.thread_unsafe
 def test_invalid_pointer():
     # Regression test for invalid pointers (gh-4613).
 

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -54,13 +54,11 @@ class TestMMIOArray:
         b = mmread(self.fn, spmatrix=False)
         assert_equal(a, b)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('typeval, dtype', parametrize_args)
     def test_simple_integer(self, typeval, dtype):
         self.check_exact(array([[1, 2], [3, 4]], dtype=dtype),
                          (2, 2, 4, 'array', typeval, 'general'))
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('typeval, dtype', parametrize_args)
     def test_32bit_integer(self, typeval, dtype):
         a = array([[2**31-1, 2**31-2], [2**31-3, 2**31-4]], dtype=dtype)

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -407,7 +407,6 @@ def test_read_unknown_wave_format():
                 wavfile.read(fp, mmap=mmap)
 
 
-@pytest.mark.thread_unsafe
 def test_read_early_eof_with_data():
     # File ends inside 'data' chunk, but we keep incomplete data
     for mmap in [False, True]:

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -653,7 +653,6 @@ class TestNdimageFilters:
     @xfail_xp_backends('cupy', reason="cupy/cupy#8405")
     @pytest.mark.parametrize('dtype_kernel', complex_types)
     @pytest.mark.parametrize('dtype_input', types)
-    @pytest.mark.thread_unsafe
     def test_correlate_complex_kernel_invalid_cval(self, dtype_input,
                                                    dtype_kernel, xp):
         dtype_input = getattr(xp, dtype_input)
@@ -790,7 +789,6 @@ class TestNdimageFilters:
     @xfail_xp_backends("cupy", reason="unhashable type: 'ndarray'")
     @pytest.mark.parametrize('dtype', complex_types)
     @pytest.mark.parametrize('dtype_output', complex_types)
-    @pytest.mark.thread_unsafe
     def test_correlate1d_complex_input_and_kernel(self, dtype, dtype_output, xp,
                                                   num_parallel_threads):
         dtype = getattr(xp, dtype)

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -1301,7 +1301,6 @@ class TestZoom:
         )
 
     @pytest.mark.parametrize('mode', ['constant', 'wrap'])
-    @pytest.mark.thread_unsafe
     def test_zoom_grid_mode_warnings(self, mode, xp):
         # Warn on use of non-grid modes when grid_mode is True
         x = xp.reshape(xp.arange(9, dtype=xp.float64), (3, 3))

--- a/scipy/ndimage/tests/test_ni_support.py
+++ b/scipy/ndimage/tests/test_ni_support.py
@@ -39,7 +39,6 @@ def test_get_output_basic(dtype):
     assert result is output
 
 
-@pytest.mark.thread_unsafe
 def test_get_output_complex():
     shape = (2, 3)
 

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -28,7 +28,6 @@ class TestODR:
     def empty_data_func(self, B, x):
         return B[0]*x + B[1]
 
-    @pytest.mark.thread_unsafe
     def test_empty_data(self):
         beta0 = [0.02, 0.0]
         linear = Model(self.empty_data_func)

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -490,6 +490,7 @@ class Test_Metropolis:
         assert not res.success
 
 
+@pytest.mark.thread_unsafe(reason="shared state")
 class Test_AdaptiveStepsize:
     def setup_method(self):
         self.stepsize = 1.

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -344,7 +344,7 @@ class TestBasinHopping:
         assert_almost_equal(res.x, self.sol[i], self.tol)
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="unknown thread safety issue")
 class Test_Storage:
     def setup_method(self):
         self.x0 = np.array(1)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -717,6 +717,7 @@ class TestDifferentialEvolutionSolver:
                 solver.solve()
         assert s._updating == 'deferred'
 
+    @pytest.mark.thread_unsafe(reason="ThreadPool deadlocks")
     @pytest.mark.fail_slow(10)
     def test_parallel(self):
         # smoke test for parallelization with deferred updating

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -717,9 +717,7 @@ class TestDifferentialEvolutionSolver:
                 solver.solve()
         assert s._updating == 'deferred'
 
-    @pytest.mark.thread_unsafe(reason="ThreadPool deadlocks")
-    @pytest.mark.fail_slow(10)
-    def test_parallel(self):
+    def test_parallel_threads(self):
         # smoke test for parallelization with deferred updating
         bounds = [(0., 2.), (0., 2.)]
         # use threads instead of Process to speed things up for this simple example
@@ -730,6 +728,9 @@ class TestDifferentialEvolutionSolver:
             assert solver._updating == 'deferred'
             solver.solve()
 
+    @pytest.mark.fail_slow(10)
+    def test_parallel_processes(self):
+        bounds = [(0., 2.), (0., 2.)]
         with DifferentialEvolutionSolver(
             rosen, bounds, updating='deferred', workers=2, popsize=3, tol=0.1
         ) as solver:

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -843,7 +843,6 @@ class TestDifferentialEvolutionSolver:
             assert_almost_equal(cv, np.array([[0.0, 0.0, 0.], [2.1, 4.2, 0]]))
             assert cv.shape == (2, 3)
 
-    @pytest.mark.thread_unsafe
     def test_constraint_solve(self):
         def constr_f(x):
             return np.array([x[0] + x[1]])
@@ -861,7 +860,6 @@ class TestDifferentialEvolutionSolver:
         assert res.success
 
     @pytest.mark.fail_slow(10)
-    @pytest.mark.thread_unsafe
     def test_impossible_constraint(self):
         def constr_f(x):
             return np.array([x[0] + x[1]])
@@ -1538,7 +1536,6 @@ class TestDifferentialEvolutionSolver:
             DifferentialEvolutionSolver(f, bounds=bounds, polish=False,
                                         integrality=integrality)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.fail_slow(10)
     def test_vectorized(self):
         def quadratic(x):

--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -188,7 +188,6 @@ class TestDualAnnealing:
         assert_raises(ValueError, dual_annealing, self.func,
                       invalid_bounds)
 
-    @pytest.mark.thread_unsafe
     def test_deprecated_local_search_options_bounds(self):
         def func(x):
             return np.sum((x - 5) * (x - 1))
@@ -201,7 +200,6 @@ class TestDualAnnealing:
                 bounds=bounds,
                 minimizer_kwargs={"method": "CG", "bounds": bounds})
 
-    @pytest.mark.thread_unsafe
     def test_minimizer_kwargs_bounds(self):
         def func(x):
             return np.sum((x - 5) * (x - 1))

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -268,6 +268,7 @@ class TestApproxDerivativesDense:
         assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
         assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
+    @pytest.mark.thread_unsafe(reason="multiprocessing.Pool deadlocks")
     def test_scalar_vector(self):
         x0 = 0.5
         with MapWrapper(2) as mapper:
@@ -282,6 +283,7 @@ class TestApproxDerivativesDense:
         assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     @pytest.mark.fail_slow(5.0)
+    @pytest.mark.thread_unsafe(reason="multiprocessing.Pool deadlocks")
     def test_workers_evaluations_and_nfev(self):
         # check that nfev consumed by approx_derivative is tracked properly
         # and that parallel evaluation is same as series
@@ -342,7 +344,7 @@ class TestApproxDerivativesDense:
         assert_allclose(jac_diff_3, jac_true, rtol=3e-9)
         assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
-    @pytest.mark.thread_unsafe(reason="deadlocks for unknown reasons")
+    @pytest.mark.thread_unsafe(reason="multiprocessing.Pool deadlocks")
     def test_vector_vector(self):
         x0 = np.array([-100.0, 0.2])
         jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -342,6 +342,7 @@ class TestApproxDerivativesDense:
         assert_allclose(jac_diff_3, jac_true, rtol=3e-9)
         assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
+    @pytest.mark.thread_unsafe(reason="deadlocks for unknown reasons")
     def test_vector_vector(self):
         x0 = np.array([-100.0, 0.2])
         jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,

--- a/scipy/optimize/tests/test__numdiff.py
+++ b/scipy/optimize/tests/test__numdiff.py
@@ -268,7 +268,6 @@ class TestApproxDerivativesDense:
         assert_allclose(jac_diff_3, jac_true, rtol=1e-9)
         assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
-    @pytest.mark.thread_unsafe(reason="multiprocessing.Pool deadlocks")
     def test_scalar_vector(self):
         x0 = 0.5
         with MapWrapper(2) as mapper:
@@ -283,7 +282,6 @@ class TestApproxDerivativesDense:
         assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
     @pytest.mark.fail_slow(5.0)
-    @pytest.mark.thread_unsafe(reason="multiprocessing.Pool deadlocks")
     def test_workers_evaluations_and_nfev(self):
         # check that nfev consumed by approx_derivative is tracked properly
         # and that parallel evaluation is same as series
@@ -344,7 +342,6 @@ class TestApproxDerivativesDense:
         assert_allclose(jac_diff_3, jac_true, rtol=3e-9)
         assert_allclose(jac_diff_4, jac_true, rtol=1e-12)
 
-    @pytest.mark.thread_unsafe(reason="multiprocessing.Pool deadlocks")
     def test_vector_vector(self):
         x0 = np.array([-100.0, 0.2])
         jac_diff_2 = approx_derivative(self.fun_vector_vector, x0,

--- a/scipy/optimize/tests/test__root.py
+++ b/scipy/optimize/tests/test__root.py
@@ -85,7 +85,6 @@ class TestRoot:
         with assert_raises(ValueError):
             root(F, [0.1, 0.0], method='lm')
 
-    @pytest.mark.thread_unsafe
     def test_gh_10370(self):
         # gh-10370 reported that passing both `args` and `jac` to `root` with
         # `method='krylov'` caused a failure. Ensure that this is fixed whether

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1015,7 +1015,6 @@ class TestShgoFailures:
 
         np.testing.assert_equal(False, res.success)
 
-    @pytest.mark.thread_unsafe
     def test_6_1_lower_known_f_min(self):
         """Test Global mode limiting local evaluations with f* too high"""
         options = {  # Specify known function value

--- a/scipy/optimize/tests/test_constraint_conversion.py
+++ b/scipy/optimize/tests/test_constraint_conversion.py
@@ -207,7 +207,6 @@ class TestNewToOldSLSQP:
 
             assert_array_almost_equal(result.x, prob.x_opt, decimal=3)
 
-    @pytest.mark.thread_unsafe
     def test_warn_mixed_constraints(self):
         # warns about inefficiency of mixed equality/inequality constraints
         def fun(x):
@@ -221,7 +220,6 @@ class TestNewToOldSLSQP:
                  minimize(fun, (2, 0, 1),
                           method=self.method, bounds=bnds, constraints=cons)
 
-    @pytest.mark.thread_unsafe
     def test_warn_ignored_options(self):
         # warns about constraint options being ignored
         def fun(x):

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -349,7 +349,6 @@ class TestScalarFunction(TestCase):
         assert_array_equal(ex.nhev, nhev)
         assert_array_equal(analit.nhev+approx.nhev, nhev)
 
-    @pytest.mark.thread_unsafe
     def test_x_storage_overlap(self):
         # Scalar_Function should not store references to arrays, it should
         # store copies - this checks that updating an array in-place causes
@@ -812,7 +811,6 @@ class TestVectorialFunction(TestCase):
         assert_equal(f, vf.f)
         assert_equal(J, vf.J)
 
-    @pytest.mark.thread_unsafe
     def test_x_storage_overlap(self):
         # VectorFunction should not store references to arrays, it should
         # store copies - this checks that updating an array in-place causes

--- a/scipy/optimize/tests/test_linesearch.py
+++ b/scipy/optimize/tests/test_linesearch.py
@@ -256,7 +256,6 @@ class TestLineSearch:
                 assert_line_wolfe(x, p, s, f, fprime, err_msg=name)
         assert c > 3  # check that the iterator really works...
 
-    @pytest.mark.thread_unsafe
     def test_line_search_wolfe2_bounds(self):
         # See gh-7475
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -268,7 +268,6 @@ def generic_callback_test(self):
     assert_allclose(last_cb['slack'], res['slack'])
 
 
-@pytest.mark.thread_unsafe
 def test_unknown_solvers_and_options():
     c = np.array([-3, -2])
     A_ub = [[2, 1], [1, 1], [1, 0]]
@@ -294,7 +293,6 @@ def test_choose_solver():
     _assert_success(res, desired_fun=-18.0, desired_x=[2, 6])
 
 
-@pytest.mark.thread_unsafe
 def test_deprecation():
     with pytest.warns(DeprecationWarning):
         linprog(1, method='interior-point')
@@ -447,7 +445,6 @@ class LinprogCommonTests:
                       method=self.method, options=self.options)
         _assert_success(res, desired_fun=2, desired_x=[2])
 
-    @pytest.mark.thread_unsafe
     def test_unknown_options(self):
         c = np.array([-3, -2])
         A_ub = [[2, 1], [1, 1], [1, 0]]
@@ -464,7 +461,6 @@ class LinprogCommonTests:
         with pytest.warns(OptimizeWarning):
             f(c, A_ub=A_ub, b_ub=b_ub, options=o)
 
-    @pytest.mark.thread_unsafe
     def test_integrality_without_highs(self):
         # ensure that using `integrality` parameter without `method='highs'`
         # raises warning and produces correct solution to relaxed problem
@@ -615,7 +611,6 @@ class LinprogCommonTests:
         if do_presolve:
             assert_equal(res.nit, 0)
 
-    @pytest.mark.thread_unsafe
     def test_bounds_infeasible_2(self):
 
         # Test ill-valued bounds (lower inf, upper -inf)
@@ -1798,7 +1793,6 @@ class LinprogHiGHSTests(LinprogCommonTests):
         res = linprog(c, A_ub=A_ub, b_ub=b_ub, method=self.method)
         _assert_success(res, desired_fun=-18.0, desired_x=[2, 6])
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize("options",
                              [{"maxiter": -1},
                               {"disp": -1},
@@ -1986,7 +1980,6 @@ class TestLinprogSimplexDefault(LinprogSimplexTests):
         # even if the solution is wrong, the appropriate error is raised.
         pytest.skip("Simplex fails on this problem.")
 
-    @pytest.mark.thread_unsafe
     def test_bug_8174_low_tol(self):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate warning is issued.
@@ -2003,7 +1996,6 @@ class TestLinprogSimplexBland(LinprogSimplexTests):
     def test_bug_5400(self):
         pytest.skip("Simplex fails on this problem.")
 
-    @pytest.mark.thread_unsafe
     def test_bug_8174_low_tol(self):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate error is raised.
@@ -2039,7 +2031,6 @@ class TestLinprogSimplexNoPresolve(LinprogSimplexTests):
     def test_bug_7237_low_tol(self):
         pytest.skip("Simplex fails on this problem.")
 
-    @pytest.mark.thread_unsafe
     def test_bug_8174_low_tol(self):
         # Fails if the tolerance is too strict. Here, we test that
         # even if the solution is wrong, the appropriate warning is issued.

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -294,7 +294,6 @@ def test_infeasible_prob_16609():
 _msg_time = "Time limit reached. (HiGHS Status 13:"
 _msg_iter = "Iteration limit reached. (HiGHS Status 14:"
 
-@pytest.mark.thread_unsafe
 # See https://github.com/scipy/scipy/pull/19255#issuecomment-1778438888
 @pytest.mark.xfail(reason="Often buggy, revisit with callbacks, gh-19255")
 @pytest.mark.skipif(np.intp(0).itemsize < 8,

--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -466,7 +466,7 @@ class TestTrustRegionConstr:
                         Elec(n_electrons=2, constr_jac='3-point',
                              constr_hess=SR1())]
 
-    @pytest.mark.thread_unsafe
+    @pytest.mark.thread_unsafe(reason="sometimes fails in parallel")
     @pytest.mark.parametrize('prob', list_of_problems)
     @pytest.mark.parametrize('grad', ('prob.grad', '3-point', False))
     @pytest.mark.parametrize('hess', ("prob.hess", '3-point', SR1(),

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -564,7 +564,6 @@ class TestCurveFit:
         y = [3, 5, 7, 9]
         assert_allclose(curve_fit(f_linear, x, y)[0], [2, 1], atol=1e-10)
 
-    @pytest.mark.thread_unsafe
     def test_indeterminate_covariance(self):
         # Test that a warning is returned when pcov is indeterminate
         xdata = np.array([1, 2, 3, 4, 5, 6])

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -491,7 +491,6 @@ class TestJacobianDotSolve:
         self._check_dot(nonlin.ExcitingMixing, complex=False)
         self._check_dot(nonlin.ExcitingMixing, complex=True)
 
-    @pytest.mark.thread_unsafe
     def test_krylov(self):
         self._check_dot(nonlin.KrylovJacobian, complex=False, tol=1e-3)
         self._check_dot(nonlin.KrylovJacobian, complex=True, tol=1e-3)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -779,7 +779,6 @@ def test_neldermead_adaptive():
     assert_equal(res.success, True)
 
 
-@pytest.mark.thread_unsafe
 def test_bounded_powell_outsidebounds():
     # With the bounded Powell method if you start outside the bounds the final
     # should still be within the bounds (provided that the user doesn't make a
@@ -811,7 +810,6 @@ def test_bounded_powell_outsidebounds():
     assert_equal(res.status, 4)
 
 
-@pytest.mark.thread_unsafe
 def test_bounded_powell_vs_powell():
     # here we test an example where the bounded Powell method
     # will return a different result than the standard Powell
@@ -1432,7 +1430,6 @@ class TestOptimizeSimple(CheckOptimize):
         elif method == 'cobyqa':
             assert sol.status == 6  # Iteration limit reached
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('method', ['Nelder-Mead', 'Powell',
                                         'fmin', 'fmin_powell'])
     def test_runtime_warning(self, method):
@@ -1740,7 +1737,6 @@ class TestOptimizeSimple(CheckOptimize):
         with pytest.raises(ValueError, match=msg):
             optimize.minimize(f, x0=[1, 2, 3], method=method, bounds=bounds)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('method', ['bfgs', 'cg', 'newton-cg', 'powell'])
     def test_minimize_warnings_gh1953(self, method):
         # test that minimize methods produce warnings rather than just using
@@ -2116,7 +2112,6 @@ class TestOptimizeScalar:
         res = optimize.minimize_scalar(f, **kwargs)
         assert res.x.shape == res.fun.shape == f(res.x).shape == fshape
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('method', ['bounded', 'brent', 'golden'])
     def test_minimize_scalar_warnings_gh1953(self, method):
         # test that minimize_scalar methods produce warnings rather than just
@@ -2670,7 +2665,6 @@ class TestBrute:
         assert_allclose(resbrute1[-1], resbrute[-1])
         assert_allclose(resbrute1[0], resbrute[0])
 
-    @pytest.mark.thread_unsafe
     def test_runtime_warning(self, capsys):
         rng = np.random.default_rng(1234)
 
@@ -2690,7 +2684,7 @@ class TestBrute:
         assert_allclose(resbrute, 0)
 
 
-@pytest.mark.thread_unsafe
+
 @pytest.mark.fail_slow(20)
 def test_cobyla_threadsafe():
 

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -163,7 +163,6 @@ class QAPCommonTests:
         assert_equal(res.nit, 0)
         assert_equal(res.fun, 0)
 
-    @pytest.mark.thread_unsafe
     def test_unknown_options(self):
         A, B, opt_perm = chr12c()
 
@@ -171,7 +170,6 @@ class QAPCommonTests:
             quadratic_assignment(A, B, method=self.method,
                                  options={"ekki-ekki": True})
 
-    @pytest.mark.thread_unsafe
     def test_deprecation_future_warnings(self):
         # May be removed after SPEC-7 transition is complete in SciPy 1.17
         A = np.arange(16).reshape((4, 4))

--- a/scipy/optimize/tests/test_trustregion.py
+++ b/scipy/optimize/tests/test_trustregion.py
@@ -51,7 +51,6 @@ class TestTrustRegionSolvers:
         assert_allclose(r['x'], r['allvecs'][-1])
         assert_allclose(sum(r['allvecs'][1:]), accumulator.accum)
 
-    @pytest.mark.thread_unsafe
     def test_dogleg_user_warning(self):
         with pytest.warns(RuntimeWarning,
                           match=r'Maximum number of iterations'):

--- a/scipy/optimize/tests/test_trustregion_exact.py
+++ b/scipy/optimize/tests/test_trustregion_exact.py
@@ -272,6 +272,7 @@ class TestIterativeSubproblem:
                                       -0.84954934])
         assert_array_almost_equal(hits_boundary, True)
 
+    @pytest.mark.thread_unsafe(reason="fails in parallel")
     @pytest.mark.fail_slow(10)
     def test_for_random_entries(self):
         # Seed

--- a/scipy/optimize/tests/test_trustregion_krylov.py
+++ b/scipy/optimize/tests/test_trustregion_krylov.py
@@ -2,7 +2,6 @@
 Unit tests for Krylov space trust-region subproblem solver.
 
 """
-import pytest
 import numpy as np
 from scipy.optimize._trlib import (get_trlib_quadratic_subproblem)
 from numpy.testing import (assert_,
@@ -153,7 +152,6 @@ class TestKrylovQuadraticSubproblem:
                                       -0.84954934])
         assert_array_almost_equal(hits_boundary, True)
 
-    @pytest.mark.thread_unsafe
     def test_disp(self, capsys):
         H = -np.eye(5)
         g = np.array([0, 0, 0, 0, 1e-6])

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -367,7 +367,6 @@ class TestNewton(TestScalarRootFinders):
         x = zeros.newton(lambda y, z: z - y ** 2, [4] * 2, args=([15, 17],))
         assert_allclose(x, (3.872983346207417, 4.123105625617661))
 
-    @pytest.mark.thread_unsafe
     def test_array_newton_zero_der_failures(self):
         # test derivative zero warning
         with pytest.warns(RuntimeWarning):
@@ -437,7 +436,6 @@ class TestNewton(TestScalarRootFinders):
                 with pytest.raises(RuntimeError, match=msg):
                     x, r = zeros.newton(f1, x0, maxiter=iters, disp=True, **kwargs)
 
-    @pytest.mark.thread_unsafe
     def test_deriv_zero_warning(self):
         def func(x):
             return x ** 2 - 2.0
@@ -622,7 +620,6 @@ def test_complex_halley():
     assert_allclose(f(y, *coeffs), 0, atol=1e-6)
 
 
-@pytest.mark.thread_unsafe
 def test_zero_der_nz_dp(capsys):
     """Test secant method with a non-zero dp, but an infinite newton step"""
     # pick a symmetrical functions and choose a point on the side that with dx
@@ -655,7 +652,6 @@ def test_zero_der_nz_dp(capsys):
         x = zeros.newton(lambda y: (y + 1.0) ** 2, x0=p0, disp=True)
 
 
-@pytest.mark.thread_unsafe
 def test_array_newton_failures():
     """Test that array newton fails as expected"""
     # p = 0.68  # [MPa]
@@ -819,7 +815,6 @@ def test_gh9254_flag_if_maxiter_exceeded(maximum_iterations, flag_expected):
         assert result[1].iterations < maximum_iterations
 
 
-@pytest.mark.thread_unsafe
 def test_gh9551_raise_error_if_disp_true():
     """Test that if disp is true then zero derivative raises RuntimeError"""
 
@@ -893,7 +888,6 @@ def test_function_calls(solver_name, rs_interface):
         assert res[1].function_calls == f.calls
 
 
-@pytest.mark.thread_unsafe
 def test_gh_14486_converged_false():
     """Test that zero slope with secant method results in a converged=False"""
     def lhs(x):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -333,7 +333,6 @@ class TestSos2Zpk:
         xp_assert_close(_sort_cmplx(p2, xp=xp), _sort_cmplx(p, xp=xp))
         assert k2 == k
 
-    @pytest.mark.thread_unsafe
     @skip_xp_backends(
         cpu_only=True, reason="XXX zpk2sos is numpy-only",
     )
@@ -1265,6 +1264,9 @@ class TestFreqz_sos:
         # a check that dB[w <= 0.2] is less than or almost equal to -150.
         assert xp.max(dB[w <= 0.2]) < -150*(1 - 1e-12)
 
+    @pytest.mark.thread_unsafe(
+        reason=("mpmath gmpy2 backend is not thread-safe, "
+                "see https://github.com/mpmath/mpmath/issues/974"))
     @mpmath_check("0.10")
     def test_freqz_sos_against_mp(self, xp):
         # Compare the result of freqz_sos applied to a high order Butterworth
@@ -2026,7 +2028,6 @@ class TestButtord:
             buttord([20, 50], [14, 60], 1, -2)
         assert "gstop should be larger than 0.0" in str(exc_info.value)
 
-    @pytest.mark.thread_unsafe
     def test_runtime_warnings(self):
         msg = "Order is zero.*|divide by zero encountered"
         with pytest.warns(RuntimeWarning, match=msg):
@@ -4710,7 +4711,6 @@ class TestGroupDelay:
                                 0.229038045801298, 0.212185774208521])
         assert_array_almost_equal(gd, matlab_gd)
 
-    @pytest.mark.thread_unsafe
     @skip_xp_backends(np_only=True, reason="numpy.convolve")
     def test_singular(self, xp):
         # Let's create a filter with zeros and poles on the unit circle and

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -678,7 +678,6 @@ class TestFirls:
 
 class TestMinimumPhase:
 
-    @pytest.mark.thread_unsafe
     def test_bad_args(self):
         # not enough taps
         assert_raises(ValueError, minimum_phase, [1.])

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1,6 +1,5 @@
 import warnings
 
-import pytest
 
 import numpy as np
 from pytest import raises as assert_raises
@@ -187,7 +186,6 @@ class TestPlacePoles:
         assert fsf.rtol == 0
         assert fsf.nb_iter == 0
 
-    @pytest.mark.thread_unsafe
     def test_errors(self):
         # Test input mistakes from user
         A = np.array([0,7,0,0,0,0,0,7/3.,0,0,0,0,0,0,0,0]).reshape(4,4)

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -429,7 +429,6 @@ class TestPeakProminences:
         with raises(ValueError, match='wlen'):
             peak_prominences(np.arange(10), [3, 5], wlen=1)
 
-    @pytest.mark.thread_unsafe
     def test_warnings(self):
         """
         Verify that appropriate warnings are raised.
@@ -526,7 +525,6 @@ class TestPeakWidths:
             # prominence data contains None
             peak_widths([1, 2, 1], [1], prominence_data=(None, None, None))
 
-    @pytest.mark.thread_unsafe
     def test_warnings(self):
         """
         Verify that appropriate warnings are raised.

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -842,8 +842,8 @@ class TestFindPeaksCwt:
         test_data, act_locs = _gen_gaussians_even(sigmas, num_points)
         widths = np.arange(0.1, max(sigmas))
         noise_amp = 0.07
-        np.random.seed(18181911)
-        test_data += (np.random.rand(num_points) - 0.5)*(2*noise_amp)
+        rng = np.random.default_rng(18181911)
+        test_data += (rng.random(num_points) - 0.5)*(2*noise_amp)
         found_locs = find_peaks_cwt(test_data, widths, min_length=15,
                                          gap_thresh=1, min_snr=noise_amp / 5)
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -919,7 +919,6 @@ class TestFFTConvolve:
         out = fftconvolve(a, b, 'full', axes=[0])
         xp_assert_close(out, expected, atol=1e-10)
 
-    @pytest.mark.thread_unsafe
     @skip_xp_backends(np_only=True)
     def test_fft_nan(self, xp):
         n = 1000
@@ -2288,7 +2287,6 @@ class _TestLinearFilter:
         )
 
 
-
 class TestLinearFilterFloat32(_TestLinearFilter):
     dtype = 'float32'
 
@@ -2526,7 +2524,6 @@ class TestCorrelate:
         xp_assert_close(correlate(a, b, mode='same'), xp.asarray([17, 32, 23]))
         xp_assert_close(correlate(a, b, mode='full'), xp.asarray([6, 17, 32, 23, 12]))
         xp_assert_close(correlate(a, b, mode='valid'), xp.asarray([32]))
-
 
 
 @skip_xp_backends(np_only=True, reason="accepts ints, return numpy array")

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1511,7 +1511,6 @@ class TestLombscargle:
 
 
 class TestSTFT:
-    @pytest.mark.thread_unsafe
     def test_input_validation(self):
 
         def chk_VE(match):
@@ -1712,7 +1711,6 @@ class TestSTFT:
             assert_allclose(t, tr, err_msg=msg)
             assert_allclose(x, xr, err_msg=msg)
 
-    @pytest.mark.thread_unsafe
     def test_roundtrip_not_nola(self):
         rng = np.random.RandomState(1234)
 
@@ -1791,7 +1789,6 @@ class TestSTFT:
             assert_allclose(x, xr, err_msg=msg, rtol=1e-4, atol=1e-5)
             assert_(x.dtype == xr.dtype)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize('scaling', ['spectrum', 'psd'])
     def test_roundtrip_complex(self, scaling):
         rng = np.random.RandomState(1234)

--- a/scipy/sparse/csgraph/tests/test_matching.py
+++ b/scipy/sparse/csgraph/tests/test_matching.py
@@ -235,7 +235,6 @@ def test_min_weight_full_matching_large_infeasible():
         min_weight_full_bipartite_matching(coo_array(a))
 
 
-@pytest.mark.thread_unsafe
 def test_explicit_zero_causes_warning():
     biadjacency = csr_array(((2, 0, 3), (0, 1, 1), (0, 2, 3)))
     with pytest.warns(UserWarning):

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -1,4 +1,5 @@
 import sys
+import sysconfig
 import threading
 import warnings
 
@@ -302,6 +303,10 @@ class TestLinsolve:
 
             assert_array_almost_equal(X, sX.toarray())
 
+    @pytest.mark.skipif(
+        sysconfig.get_config_var('Py_GIL_DISABLED'),
+        reason=("scikits.umfpack doesn't support free-threaded Python. "
+                "See https://github.com/scikit-umfpack/scikit-umfpack/issues/113"))
     def test_shape_compatibility(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', SparseEfficiencyWarning)

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -270,7 +270,6 @@ class TestLinsolve:
         x2 = spsolve(As, Bs)
         assert_array_almost_equal(x, x2.toarray())
 
-    @pytest.mark.thread_unsafe
     def test_non_square(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', SparseEfficiencyWarning)
@@ -283,7 +282,6 @@ class TestLinsolve:
             b2 = array([1.0, 2.0])
             assert_raises(ValueError, spsolve, A2, b2)
 
-    @pytest.mark.thread_unsafe
     def test_example_comparison(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', SparseEfficiencyWarning)
@@ -304,8 +302,6 @@ class TestLinsolve:
 
             assert_array_almost_equal(X, sX.toarray())
 
-    @pytest.mark.thread_unsafe
-    @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_shape_compatibility(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', SparseEfficiencyWarning)
@@ -365,7 +361,6 @@ class TestLinsolve:
         b = csc_array((1, 3))
         assert_raises(ValueError, spsolve, A, b)
 
-    @pytest.mark.thread_unsafe
     def test_ndarray_support(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', SparseEfficiencyWarning)
@@ -497,7 +492,6 @@ class TestSplu:
             x = lu.solve(b, 'H')
             check(A.T.conj(), b, x, msg)
 
-    @pytest.mark.thread_unsafe
     def test_splu_smoketest(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", SparseEfficiencyWarning)
@@ -514,7 +508,6 @@ class TestSplu:
             for idx_dtype in [np.int32, np.int64]:
                 self._smoketest(splu, check, dtype, idx_dtype)
 
-    @pytest.mark.thread_unsafe
     def test_spilu_smoketest(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", SparseEfficiencyWarning)
@@ -536,7 +529,6 @@ class TestSplu:
 
         assert_(max(errors) > 1e-5)
 
-    @pytest.mark.thread_unsafe
     def test_spilu_drop_rule(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", SparseEfficiencyWarning)
@@ -668,7 +660,6 @@ class TestSplu:
             assert_raises(TypeError, lu.solve,
                           b.astype(np.complex128))
 
-    @pytest.mark.thread_unsafe
     def test_superlu_dlamch_i386_nan(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", SparseEfficiencyWarning)
@@ -687,7 +678,6 @@ class TestSplu:
             B = A.toarray()
             assert_(not np.isnan(B).any())
 
-    @pytest.mark.thread_unsafe
     def test_lu_attr(self):
         def check(dtype, complex_2=False):
             with warnings.catch_warnings():
@@ -724,7 +714,6 @@ class TestSplu:
         check(np.complex64, True)
         check(np.complex128, True)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.slow
     def test_threads_parallel(self):
         with warnings.catch_warnings():
@@ -749,7 +738,6 @@ class TestSplu:
 
             assert_equal(len(oks), 20)
 
-    @pytest.mark.thread_unsafe
     def test_singular_matrix(self):
         # Test that SuperLU does not print to stdout when a singular matrix is
         # passed. See gh-20993.
@@ -840,7 +828,6 @@ class TestSpsolveTriangular:
             assert_raises(scipy.linalg.LinAlgError,
                           spsolve_triangular, A, b, lower=lower)
 
-    @pytest.mark.thread_unsafe
     def test_bad_shape(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", SparseEfficiencyWarning)
@@ -853,7 +840,6 @@ class TestSpsolveTriangular:
             b2 = array([1.0, 2.0])
             assert_raises(ValueError, spsolve_triangular, A2, b2)
 
-    @pytest.mark.thread_unsafe
     def test_input_types(self):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", SparseEfficiencyWarning)
@@ -863,7 +849,6 @@ class TestSpsolveTriangular:
                 x = spsolve_triangular(matrix_type(A), b, lower=True)
                 assert_array_almost_equal(A.dot(x), b)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.slow
     @pytest.mark.parametrize("n", [10, 10**2, 10**3])
     @pytest.mark.parametrize("m", [1, 10])
@@ -915,7 +900,6 @@ class TestSpsolveTriangular:
             assert_allclose(A.dot(x), b, atol=1.5e-6)
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.parametrize("nnz", [10, 10**2, 10**3])
 @pytest.mark.parametrize("fmt", ["csr", "csc", "coo", "dia", "dok", "lil"])
 def test_is_sptriangular_and_spbandwidth(nnz, fmt):

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -1,5 +1,4 @@
 import sys
-import sysconfig
 import threading
 import warnings
 
@@ -303,10 +302,7 @@ class TestLinsolve:
 
             assert_array_almost_equal(X, sX.toarray())
 
-    @pytest.mark.skipif(
-        sysconfig.get_config_var('Py_GIL_DISABLED'),
-        reason=("scikits.umfpack doesn't support free-threaded Python. "
-                "See https://github.com/scikit-umfpack/scikit-umfpack/issues/113"))
+    @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_shape_compatibility(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', SparseEfficiencyWarning)

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -393,16 +393,14 @@ class NonSymmetricParams:
         self.complex_test_cases = [SNC, GNC]
 
 
-@pytest.mark.iterations(1)
 @pytest.mark.parametrize("sigma, mode", [(None, 'normal'), (0.5, 'normal'),
                                          (0.5, 'buckling'), (0.5, 'cayley')])
 @pytest.mark.parametrize("mattype", [csr_array, aslinearoperator, np.asarray])
 @pytest.mark.parametrize("which", ['LM', 'SM', 'LA', 'SA', 'BE'])
 @pytest.mark.parametrize("typ", ['f', 'd'])
 @pytest.mark.parametrize("D", SymmetricParams().real_test_cases)
-def test_symmetric_modes(num_parallel_threads, D, typ, which, mattype,
+def test_symmetric_modes(D, typ, which, mattype,
                          sigma, mode):
-    assert num_parallel_threads == 1
     rng = np.random.default_rng(1749531508689996)
     k = 2
     eval_evec(True, D, typ, k, which, None, sigma, mattype, None, mode, rng=rng)

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -399,8 +399,7 @@ class NonSymmetricParams:
 @pytest.mark.parametrize("which", ['LM', 'SM', 'LA', 'SA', 'BE'])
 @pytest.mark.parametrize("typ", ['f', 'd'])
 @pytest.mark.parametrize("D", SymmetricParams().real_test_cases)
-def test_symmetric_modes(D, typ, which, mattype,
-                         sigma, mode):
+def test_symmetric_modes(D, typ, which, mattype, sigma, mode):
     rng = np.random.default_rng(1749531508689996)
     k = 2
     eval_evec(True, D, typ, k, which, None, sigma, mattype, None, mode, rng=rng)

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -335,7 +335,6 @@ def test_failure_to_run_iterations():
     assert np.max(eigenvalues) > 0
 
 
-
 def test_failure_to_run_iterations_nonsymmetric():
     """Check that the code exists gracefully without breaking
     if the matrix in not symmetric.

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -146,7 +146,6 @@ def test_b_orthonormalize(n, m, Vdtype, Bdtype, BVdtype):
     assert_allclose(BXo, BXo1, atol=atol, rtol=atol)
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.filterwarnings("ignore:Exited at iteration 0")
 @pytest.mark.filterwarnings("ignore:Exited postprocessing")
 def test_nonhermitian_warning(capsys):
@@ -306,7 +305,6 @@ def _check_fiedler(n, p):
     assert_allclose(lobpcg_w, analytic_w[:2], atol=1e-14)
 
 
-@pytest.mark.thread_unsafe
 def test_fiedler_small_8():
     """Check the dense workaround path for small matrices.
     """
@@ -337,7 +335,7 @@ def test_failure_to_run_iterations():
     assert np.max(eigenvalues) > 0
 
 
-@pytest.mark.thread_unsafe
+
 def test_failure_to_run_iterations_nonsymmetric():
     """Check that the code exists gracefully without breaking
     if the matrix in not symmetric.
@@ -416,7 +414,6 @@ def test_eigsh_consistency(n, atol):
     assert_allclose(np.sort(vals), np.sort(lvals), atol=1e-14)
 
 
-@pytest.mark.thread_unsafe
 def test_verbosity():
     """Check that nonzero verbosity level code runs.
     """
@@ -469,7 +466,6 @@ def test_dtypes(vdtype, mdtype, arr_type):
     assert_allclose(np.sum(np.abs(eigvecs - eigvecs.conj())), 0, atol=1e-2)
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.filterwarnings("ignore:Exited at iteration")
 @pytest.mark.filterwarnings("ignore:Exited postprocessing")
 def test_inplace_warning():
@@ -487,7 +483,6 @@ def test_inplace_warning():
         eigvals, _ = lobpcg(A, X, maxiter=2, verbosityLevel=1)
 
 
-@pytest.mark.thread_unsafe
 def test_maxit():
     """Check lobpcg if maxit=maxiter runs maxiter iterations and
     if maxit=None runs 20 iterations (the default)

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -286,7 +286,6 @@ class SVDSCommonTests:
             svds(np.eye(10), return_singular_vectors=rsv, solver=self.solver, rng=0)
 
     # --- Test Parameters ---
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize("k", [3, 5])
     @pytest.mark.parametrize("which", ["LM", "SM"])
     def test_svds_parameter_k_which(self, k, which):
@@ -441,7 +440,6 @@ class SVDSCommonTests:
         with pytest.raises(AssertionError, match=message):
             assert_equal(res1a, res2a)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.filterwarnings("ignore:Exited postprocessing")
     def test_svd_maxiter(self):
         # check that maxiter works as expected: should not return accurate
@@ -473,7 +471,6 @@ class SVDSCommonTests:
         assert_allclose(np.abs(vhd), np.abs(vh), atol=1e-8)
         assert_allclose(np.abs(sd), np.abs(s), atol=1e-9)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize("rsv", (True, False, 'u', 'vh'))
     @pytest.mark.parametrize("shape", ((5, 7), (6, 6), (7, 5)))
     def test_svd_return_singular_vectors(self, rsv, shape):
@@ -546,7 +543,6 @@ class SVDSCommonTests:
     A1 = [[1, 2, 3], [3, 4, 3], [1 + 1j, 0, 2], [0, 0, 1]]
     A2 = [[1, 2, 3, 8 + 5j], [3 - 2j, 4, 3, 5], [1, 0, 2, 3], [0, 0, 1, 0]]
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.filterwarnings("ignore:k >= N - 1",
                                 reason="needed to demonstrate #16725")
     @pytest.mark.parametrize('A', (A1, A2))
@@ -583,7 +579,6 @@ class SVDSCommonTests:
             u, s, vh = svds(A2, k, solver=self.solver, rng=0)
         _check_svds(A, k, u, s, vh, atol=atol)
 
-    @pytest.mark.thread_unsafe
     def test_svd_linop(self):
         solver = self.solver
 
@@ -700,7 +695,6 @@ class SVDSCommonTests:
 
     # --- Test Edge Cases ---
     # Checks a few edge cases.
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize("shape", ((6, 5), (5, 5), (5, 6)))
     @pytest.mark.parametrize("dtype", (float, complex))
     def test_svd_LM_ones_matrix(self, shape, dtype):
@@ -724,7 +718,6 @@ class SVDSCommonTests:
         z = np.ones_like(s)
         assert_allclose(s, z)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.filterwarnings("ignore:k >= N - 1",
                                 reason="needed to demonstrate #16725")
     @pytest.mark.parametrize("shape", ((3, 4), (4, 4), (4, 3), (4, 2)))

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -219,7 +219,6 @@ def case(request):
     """
     return request.param
 
-@pytest.mark.thread_unsafe
 def test_maxiter(case):
     if not case.convergence:
         pytest.skip("Solver - Breakdown case, see gh-8829")
@@ -538,7 +537,6 @@ def test_x0_solves_problem_exactly(solver):
 
 
 # Specific tfqmr test
-@pytest.mark.thread_unsafe
 @pytest.mark.parametrize('case', IterativeParams().cases)
 def test_show(case, capsys):
     def cb(x):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -400,7 +400,6 @@ def test_pickle():
             assert_equal(getattr(A, k), getattr(B, k))
 
 
-@pytest.mark.thread_unsafe
 def test_inheritance():
     class Empty(interface.LinearOperator):
         pass

--- a/scipy/sparse/linalg/tests/test_norm.py
+++ b/scipy/sparse/linalg/tests/test_norm.py
@@ -42,7 +42,6 @@ class TestNorm:
         b = a.reshape((3, 3))
         self.b = scipy.sparse.csr_array(b)
 
-    @pytest.mark.thread_unsafe
     def test_matrix_norm(self):
 
         # Frobenius norm is the default

--- a/scipy/sparse/linalg/tests/test_onenormest.py
+++ b/scipy/sparse/linalg/tests/test_onenormest.py
@@ -232,7 +232,7 @@ class TestOnenormest:
 
 class TestAlgorithm_2_2:
 
-    @pytest.mark.thread_unsafe
+    @pytest.mark.thread_unsafe(reason="Fails in parallel for unknown reasons")
     def test_randn_inv(self):
         rng = np.random.RandomState(1234)
         n = 20

--- a/scipy/sparse/tests/test_64bit.py
+++ b/scipy/sparse/tests/test_64bit.py
@@ -84,7 +84,7 @@ def cases_64bit(sp_api):
                 yield pytest.param(cls, method_name, marks=marks)
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="scipy.sparse is not thread-safe")
 class RunAll64Bit:
     def _check_resiliency(self, cls, method_name, **kw):
         # Resiliency test, to check that sparse matrices deal reasonably
@@ -208,7 +208,7 @@ class Test64BitMatrixExtra(RunAll64Bit):
         self._check_resiliency(cls, method_name)
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="Fails in parallel for unknown reasons")
 class Test64BitTools:
     # classes that use get_index_dtype
     MAT_CLASSES = [

--- a/scipy/sparse/tests/test_64bit.py
+++ b/scipy/sparse/tests/test_64bit.py
@@ -84,7 +84,7 @@ def cases_64bit(sp_api):
                 yield pytest.param(cls, method_name, marks=marks)
 
 
-@pytest.mark.thread_unsafe(reason="scipy.sparse is not thread-safe")
+@pytest.mark.thread_unsafe(reason="fails in parallel")
 class RunAll64Bit:
     def _check_resiliency(self, cls, method_name, **kw):
         # Resiliency test, to check that sparse matrices deal reasonably

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -155,7 +155,6 @@ def test_sparse_divide(A):
     assert isinstance(A / A, np.ndarray)
 
 @parametrize_sparrays
-@pytest.mark.thread_unsafe
 def test_sparse_dense_divide(A):
     with pytest.warns(RuntimeWarning):
         assert isinstance((A / A.todense()), scipy.sparse.sparray)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2612,7 +2612,7 @@ class _TestGetSet:
         assert_array_equal(A.toarray(), B)
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="scipy.sparse is not thread-safe")
 class _TestSolve:
     def test_solve(self):
         # Test whether the lu_solve command segfaults, as reported by Nils

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2612,7 +2612,7 @@ class _TestGetSet:
         assert_array_equal(A.toarray(), B)
 
 
-@pytest.mark.thread_unsafe(reason="scipy.sparse is not thread-safe")
+@pytest.mark.thread_unsafe(reason="fails in parallel")
 class _TestSolve:
     def test_solve(self):
         # Test whether the lu_solve command segfaults, as reported by Nils

--- a/scipy/sparse/tests/test_common1d.py
+++ b/scipy/sparse/tests/test_common1d.py
@@ -232,7 +232,6 @@ class TestCommon1D:
         assert_allclose(dat_mean, datsp_mean)
         assert_equal(dat_mean.dtype, datsp_mean.dtype)
 
-    @pytest.mark.thread_unsafe
     def test_from_array(self, spcreator):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", ComplexWarning)
@@ -243,7 +242,6 @@ class TestCommon1D:
             assert_equal(spcreator(A).toarray(), A)
             assert_equal(spcreator(A, dtype='int16').toarray(), A.astype('int16'))
 
-    @pytest.mark.thread_unsafe
     def test_from_list(self, spcreator):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", ComplexWarning)
@@ -256,7 +254,6 @@ class TestCommon1D:
                 spcreator(A, dtype='int16').toarray(), np.array(A).astype('int16')
         )
 
-    @pytest.mark.thread_unsafe
     def test_from_sparse(self, spcreator):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", ComplexWarning)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -674,7 +674,6 @@ class TestConstructUtils:
         assert isinstance(bmat([[Gm, Gm]], format="csc"), spmatrix)
 
     @pytest.mark.xslow
-    @pytest.mark.thread_unsafe
     @pytest.mark.xfail_on_32bit("Can't create large array for test")
     def test_concatenate_int32_overflow(self):
         """ test for indptr overflow when concatenating matrices """

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -21,7 +21,6 @@ def int_to_int8(n):
     return (n + 128) % 256 - 128
 
 
-@pytest.mark.thread_unsafe  # Exception handling in CPython 3.13 has races
 def test_exception():
     assert_raises(MemoryError, _sparsetools.test_throw_error)
 
@@ -69,7 +68,6 @@ def test_regression_std_vector_dtypes():
 
 
 @pytest.mark.slow
-@pytest.mark.thread_unsafe
 @pytest.mark.xfail_on_32bit("Can't create large array for test")
 def test_nnz_overflow():
     # Regression test for gh-7230 / gh-7871, checking that coo_toarray
@@ -90,7 +88,6 @@ def test_nnz_overflow():
     assert_allclose(d, [[4]])
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.skipif(
     not (sys.platform.startswith('linux') and np.dtype(np.intp).itemsize >= 8),
     reason="test requires 64-bit Linux"
@@ -274,7 +271,6 @@ class TestInt32Overflow:
         m2.dot(m)  # shouldn't SIGSEGV
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.skip(reason="64-bit indices in sparse matrices not available")
 def test_csr_matmat_int64_overflow():
     n = 3037000500

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -411,7 +411,6 @@ class TestCdist:
                               'int': [np.float32, np.float64],
                               'float32': [np.float64]}
 
-    @pytest.mark.thread_unsafe
     def test_cdist_extra_args(self, metric):
         # Tests that args and kwargs are correctly handled
 
@@ -609,7 +608,6 @@ class TestCdist:
                     y2 = cdist(new_type(X1), new_type(X2), metric=metric)
                     assert_allclose(y1, y2, rtol=eps, verbose=verbose > 2)
 
-    @pytest.mark.thread_unsafe
     def test_cdist_out(self, metric):
         # Test that out parameter works properly
         eps = 1e-15
@@ -649,7 +647,6 @@ class TestCdist:
         with pytest.raises(ValueError):
             cdist(X1, X2, metric, out=out5, **kwargs)
 
-    @pytest.mark.thread_unsafe
     def test_striding(self, metric):
         # test that striding is handled correct with calls to
         # _copy_array_if_base_present
@@ -676,7 +673,6 @@ class TestCdist:
         # test that output is numerically equivalent
         assert_allclose(Y1, Y2, rtol=eps, verbose=verbose > 2)
 
-    @pytest.mark.thread_unsafe
     def test_cdist_refcount(self, metric):
         x1 = np.random.rand(10, 10)
         x2 = np.random.rand(10, 10)
@@ -708,7 +704,6 @@ class TestPdist:
                               'int': [np.float32, np.float64],
                               'float32': [np.float64]}
 
-    @pytest.mark.thread_unsafe
     def test_pdist_extra_args(self, metric):
         # Tests that args and kwargs are correctly handled
         X1 = [[1., 2.], [1.2, 2.3], [2.2, 2.3]]
@@ -1424,7 +1419,6 @@ class TestPdist:
                     y2 = pdist(new_type(X1), metric=metric)
                     assert_allclose(y1, y2, rtol=eps, verbose=verbose > 2)
 
-    @pytest.mark.thread_unsafe
     def test_pdist_out(self, metric):
         # Test that out parameter works properly
         eps = 1e-15
@@ -1459,7 +1453,6 @@ class TestPdist:
         with pytest.raises(ValueError):
             pdist(X, metric, out=out5, **kwargs)
 
-    @pytest.mark.thread_unsafe
     def test_striding(self, metric):
         # test that striding is handled correct with calls to
         # _copy_array_if_base_present
@@ -1545,7 +1538,6 @@ class TestSomeDistanceFunctions:
         dist = correlation(x, y)
         assert 0 <= dist <= 10 * np.finfo(np.float64).eps
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.filterwarnings('ignore:Casting complex')
     @pytest.mark.parametrize("func", [correlation, cosine])
     def test_corr_dep_complex(self, func):
@@ -1995,7 +1987,6 @@ def test_sqeuclidean_dtypes():
         assert_equal(d.dtype, dtype)
 
 
-@pytest.mark.thread_unsafe
 def test_modifies_input(metric):
     # test whether cdist or pdist modifies input arrays
     X1 = np.asarray([[1., 2., 3.],
@@ -2008,7 +1999,6 @@ def test_modifies_input(metric):
     assert_array_equal(X1, X1_copy)
 
 
-@pytest.mark.thread_unsafe
 def test_Xdist_deprecated_args(metric):
     # testing both cdist and pdist deprecated warnings
     X1 = np.asarray([[1., 2., 3.],
@@ -2037,7 +2027,6 @@ def test_Xdist_deprecated_args(metric):
             pdist(X1, metric, **kwargs)
 
 
-@pytest.mark.thread_unsafe
 def test_Xdist_non_negative_weights(metric):
     X = eo['random-float32-data'][::5, ::2]
     w = np.ones(X.shape[1])
@@ -2132,7 +2121,6 @@ def test_gh_17703():
     assert_allclose(actual, expected)
 
 
-@pytest.mark.thread_unsafe
 def test_immutable_input(metric):
     if metric in ("jensenshannon", "mahalanobis", "seuclidean"):
         pytest.skip("not applicable")

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -431,7 +431,6 @@ class TestDelaunay:
     # Shouldn't be inherently unsafe; retry with cpython 3.14 once traceback
     # thread safety issues are fixed (also goes for other test with same name
     # further down)
-    @pytest.mark.thread_unsafe
     def test_array_with_nans_fails(self):
         points_with_nan = np.array([(0,0), (0,1), (1,1), (1,np.nan)], dtype=np.float64)
         assert_raises(ValueError, qhull.Delaunay, points_with_nan)
@@ -611,7 +610,6 @@ class TestConvexHull:
         masked_array = np.ma.masked_all(1)
         assert_raises(ValueError, qhull.ConvexHull, masked_array)
 
-    @pytest.mark.thread_unsafe
     def test_array_with_nans_fails(self):
         points_with_nan = np.array([(0,0), (1,1), (2,np.nan)], dtype=np.float64)
         assert_raises(ValueError, qhull.ConvexHull, points_with_nan)

--- a/scipy/spatial/tests/test_slerp.py
+++ b/scipy/spatial/tests/test_slerp.py
@@ -102,7 +102,6 @@ class TestGeometricSlerp:
                             end=end,
                             t=np.linspace(0, 1, 10))
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.parametrize("start, end, expected", [
         # North and South Poles are definitely antipodes
         # but should be handled gracefully now

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -919,7 +919,6 @@ def test_as_euler_symmetric_axes(xp, seq_tuple, intrinsic):
     test_stats(angles_quat - angles, 1e-16, 1e-14)
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.parametrize("seq_tuple", permutations("xyz"))
 @pytest.mark.parametrize("intrinsic", (False, True))
 def test_as_euler_degenerate_asymmetric_axes(xp, seq_tuple, intrinsic):
@@ -949,7 +948,6 @@ def test_as_euler_degenerate_asymmetric_axes(xp, seq_tuple, intrinsic):
     xp_assert_close(mat_expected, mat_estimated, atol=atol)
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.parametrize("seq_tuple", permutations("xyz"))
 @pytest.mark.parametrize("intrinsic", (False, True))
 def test_as_euler_degenerate_symmetric_axes(xp, seq_tuple, intrinsic):
@@ -1106,7 +1104,6 @@ def test_approx_equal(xp):
     xp_assert_equal(p.approx_equal(q, atol), (r_mag < atol))
 
 
-@pytest.mark.thread_unsafe
 def test_approx_equal_single_rotation(xp):
     # also tests passing single argument to approx_equal
     p = Rotation.from_rotvec(xp.asarray([0, 0, 1e-9]))  # less than default atol of 1e-8
@@ -2233,7 +2230,6 @@ def test_as_davenport(xp):
             xp_assert_close(angles_dav, xp.asarray(angles))
 
 
-@pytest.mark.thread_unsafe
 def test_as_davenport_degenerate(xp):
     # Since we cannot check for angle equality, we check for rotation matrix
     # equality

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -1556,7 +1556,6 @@ class TestCombinatorics:
         assert_equal(special.comb(2, -1, exact=False), 0)
         assert_allclose(special.comb([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 120.])
 
-    @pytest.mark.thread_unsafe
     def test_comb_exact_non_int_error(self):
         msg = "`exact=True`"
         with pytest.raises(ValueError, match=msg):
@@ -1577,7 +1576,6 @@ class TestCombinatorics:
         assert_equal(special.perm(2, -1, exact=False), 0)
         assert_allclose(special.perm([2, -1, 2, 10], [3, 3, -1, 3]), [0., 0., 0., 720.])
 
-    @pytest.mark.thread_unsafe
     def test_perm_iv(self):
         # currently `exact=True` only support scalars
         with pytest.raises(ValueError, match="scalar integers"):
@@ -4582,7 +4580,6 @@ def test_pseudo_huber_small_r():
     assert_allclose(y, expected, rtol=1e-13)
 
 
-@pytest.mark.thread_unsafe
 def test_runtime_warning():
     with pytest.warns(RuntimeWarning,
                       match=r'Too many predicted coefficients'):

--- a/scipy/special/tests/test_cython_special.py
+++ b/scipy/special/tests/test_cython_special.py
@@ -318,7 +318,6 @@ def test_cython_api_completeness():
                 raise RuntimeError(f"{name} missing from tests!")
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.fail_slow(20)
 @pytest.mark.parametrize("param", PARAMS, ids=IDS)
 def test_cython_api(param):

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -621,7 +621,6 @@ BOOST_TESTS = [
 ]
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.parametrize('test', BOOST_TESTS, ids=repr)
 def test_boost(test):
      _test_factory(test)

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -27,6 +27,9 @@ try:
 except ImportError:
     mpmath = MissingModule('mpmath')
 
+pytestmark = pytest.mark.thread_unsafe(
+    reason=("mpmath gmpy2 backend is not thread-safe, "
+            "see https://github.com/mpmath/mpmath/issues/974"))
 
 # ------------------------------------------------------------------------------
 # expi

--- a/scipy/special/tests/test_nan_inputs.py
+++ b/scipy/special/tests/test_nan_inputs.py
@@ -37,7 +37,6 @@ def _get_ufuncs():
 UFUNCS, UFUNC_NAMES = _get_ufuncs()
 
 
-@pytest.mark.thread_unsafe
 @pytest.mark.parametrize("func", UFUNCS, ids=UFUNC_NAMES)
 def test_nan_inputs(func):
     args = (np.nan,)*func.nin

--- a/scipy/special/tests/test_precompute_gammainc.py
+++ b/scipy/special/tests/test_precompute_gammainc.py
@@ -18,6 +18,10 @@ except ImportError:
     mp = MissingModule('mpmath')
 
 
+pytestmark = pytest.mark.thread_unsafe(
+    reason=("mpmath gmpy2 backend is not thread-safe, "
+            "see https://github.com/mpmath/mpmath/issues/974"))
+
 @check_version(mp, '0.19')
 def test_g():
     # Test data for the g_k. See DLMF 5.11.4.

--- a/scipy/special/tests/test_sf_error.py
+++ b/scipy/special/tests/test_sf_error.py
@@ -54,7 +54,6 @@ def test_geterr():
         assert_(value in _sf_error_actions)
 
 
-@pytest.mark.thread_unsafe
 def test_seterr():
     entry_err = sc.geterr()
     try:
@@ -73,7 +72,7 @@ def test_seterr():
         sc.seterr(**entry_err)
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="module refcounts are not stable in multiple threads")
 @pytest.mark.skipif(not HAS_REFCOUNT, reason="Python lacks refcounts")
 def test_sf_error_special_refcount():
     # Regression test for gh-16233.
@@ -127,7 +126,6 @@ def test_errstate_cpp_alt_ufunc_machinery():
     assert_equal(olderr, sc.geterr())
 
 
-@pytest.mark.thread_unsafe
 def test_errstate():
     for category, error_code in _sf_error_code_map.items():
         for action in _sf_error_actions:

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -335,7 +335,6 @@ def nan_policy_1d(hypotest, data1d, unpacker, *args, n_outputs=2,
 @pytest.mark.parametrize(("nan_policy"), ("propagate", "omit", "raise"))
 @pytest.mark.parametrize(("axis"), (1,))
 @pytest.mark.parametrize(("data_generator"), ("mixed",))
-@pytest.mark.parallel_threads(1)
 def test_axis_nan_policy_fast(hypotest, args, kwds, n_samples, n_outputs,
                               paired, unpacker, nan_policy, axis,
                               data_generator):
@@ -519,7 +518,6 @@ def skip_nan_unexpected_exception():
 @pytest.mark.parametrize(("nan_policy"), ("propagate", "omit", "raise"))
 @pytest.mark.parametrize(("data_generator"),
                          ("all_nans", "all_finite", "mixed", "empty"))
-@pytest.mark.parallel_threads(1)
 def test_axis_nan_policy_axis_is_None(hypotest, args, kwds, n_samples,
                                       n_outputs, paired, unpacker, nan_policy,
                                       data_generator):
@@ -857,7 +855,6 @@ def _check_arrays_broadcastable(arrays, axis):
 @pytest.mark.slow
 @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                           "paired", "unpacker"), axis_nan_policy_cases)
-@pytest.mark.parallel_threads(1)
 def test_empty(hypotest, args, kwds, n_samples, n_outputs, paired, unpacker):
     # test for correct output shape when at least one input is empty
     if hypotest in {stats.kruskal, stats.friedmanchisquare} and not SCIPY_XSLOW:

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -48,7 +48,6 @@ class Test_RealInterval:
            inclusive_a=strategies.booleans(),
            inclusive_b=strategies.booleans(),
            data=strategies.data())
-    @pytest.mark.thread_unsafe
     def test_contains(self, shapes, inclusive_a, inclusive_b, data):
         # Test `contains` when endpoints are defined by parameters
         input_shapes, result_shape = shapes
@@ -128,7 +127,6 @@ class Test_RealInterval:
            inclusive_a=strategies.booleans(),
            inclusive_b=strategies.booleans(),
            )
-    @pytest.mark.thread_unsafe
     def test_str2(self, a, b, inclusive_a, inclusive_b):
         # I wrote this independently from the implementation of __str__, but
         # I imagine it looks pretty similar to __str__.
@@ -205,7 +203,6 @@ class TestDistributions:
     @settings(max_examples=20)
     @pytest.mark.parametrize('family', families)
     @given(data=strategies.data(), seed=strategies.integers(min_value=0))
-    @pytest.mark.thread_unsafe
     def test_support_moments_sample(self, family, data, seed):
         rng = np.random.default_rng(seed)
 
@@ -245,7 +242,6 @@ class TestDistributions:
                               ])
     @settings(max_examples=20)
     @given(data=strategies.data(), seed=strategies.integers(min_value=0))
-    @pytest.mark.thread_unsafe
     def test_funcs(self, family, data, seed, func, methods, arg):
         if family == Uniform and func == 'mode':
             pytest.skip("Mode is not unique; `method`s disagree.")
@@ -279,7 +275,6 @@ class TestDistributions:
                     check_ccdf2(dist, False, x, y, xy_result_shape, methods)
                     check_ccdf2(dist, True, x, y, xy_result_shape, methods)
 
-    @pytest.mark.thread_unsafe
     def test_plot(self):
         try:
             import matplotlib.pyplot as plt
@@ -1493,7 +1488,6 @@ class TestTransforms:
 
     @pytest.mark.fail_slow(10)
     @given(data=strategies.data(), seed=strategies.integers(min_value=0))
-    @pytest.mark.thread_unsafe
     def test_loc_scale(self, data, seed):
         # Need tests with negative scale
         rng = np.random.default_rng(seed)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -420,8 +420,7 @@ def test_integer_shapes(distname, shapename, shapes):
     assert not np.any(np.isnan(pmf[2, :]))
 
 
-@pytest.mark.parallel_threads(1)
-def test_frozen_attributes():
+def test_frozen_attributes(monkeypatch):
     # gh-14827 reported that all frozen distributions had both pmf and pdf
     # attributes; continuous should have pdf and discrete should have pmf.
     message = "'rv_discrete_frozen' object has no attribute"
@@ -429,10 +428,10 @@ def test_frozen_attributes():
         stats.binom(10, 0.5).pdf
     with pytest.raises(AttributeError, match=message):
         stats.binom(10, 0.5).logpdf
-    stats.binom.pdf = "herring"
+    monkeypatch.setattr(stats.binom, "pdf", "herring", raising=False)
     frozen_binom = stats.binom(10, 0.5)
     assert isinstance(frozen_binom, rv_discrete_frozen)
-    delattr(stats.binom, 'pdf')
+    assert not hasattr(frozen_binom, "pdf")
 
 
 @pytest.mark.parametrize('distname, shapes', distdiscrete)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5774,7 +5774,6 @@ class TestLevyStable:
             ),
         ]
     )
-    @pytest.mark.thread_unsafe
     def test_pdf_nolan_samples(
             self, nolan_pdf_sample_data, pct_range, alpha_range, beta_range
     ):
@@ -5988,7 +5987,6 @@ class TestLevyStable:
             ),
         ]
     )
-    @pytest.mark.thread_unsafe
     def test_cdf_nolan_samples(
             self, nolan_cdf_sample_data, pct_range, alpha_range, beta_range
     ):
@@ -7032,7 +7030,6 @@ class TestExpect:
         assert_allclose(res,
                         sum(_ for _ in range(lo, hi)) / (hi - lo), atol=1e-15)
 
-    @pytest.mark.thread_unsafe
     def test_zipf(self):
         # Test that there is no infinite loop even if the sum diverges
         with pytest.warns(RuntimeWarning):

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -1005,7 +1005,7 @@ class TestSomersD(_TestPythranFunc):
         assert res.statistic == expected_statistic
         assert res.pvalue == (0 if positive_correlation else 1)
 
-    @pytest.mark.thread_unsafe
+    @pytest.mark.thread_unsafe(reason="fails in parallel")
     def test_somersd_large_inputs_gh18132(self):
         # Test that large inputs where potential overflows could occur give
         # the expected output. This is tested in the case of binary inputs.

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -365,7 +365,6 @@ class TestAnderson:
         with pytest.raises(ValueError, match=message):
             stats.anderson(x, 'weibull_min')
 
-    @pytest.mark.thread_unsafe
     def test_weibull_warning_error(self):
         # Check for warning message when there are too few observations
         # This is also an example in which an error occurs during fitting
@@ -503,7 +502,6 @@ class TestAndersonKSamp:
                                   tm[0:5], 4)
         assert_allclose(p, 0.0041, atol=0.00025)
 
-    @pytest.mark.thread_unsafe
     def test_R_kSamples(self):
         # test values generates with R package kSamples
         # package version 1.2-6 (2017-06-14)
@@ -1424,7 +1422,6 @@ class TestProbplot:
         assert_allclose(osm1, osm2)
         assert_allclose(osr1, osr2)
 
-    @pytest.mark.thread_unsafe
     @pytest.mark.skipif(not have_matplotlib, reason="no matplotlib")
     def test_plot_kwarg(self):
         fig = plt.figure()
@@ -2031,7 +2028,6 @@ class TestBoxcox_llf:
         llf2 = stats.boxcox_llf(lmbda, np.vstack([x, x]).T)
         xp_assert_close(xp.asarray([llf, llf]), xp.asarray(llf2), rtol=1e-12)
 
-    @pytest.mark.thread_unsafe
     def test_empty(self, xp):
         message = "One or more sample arguments is too small..."
         context = (pytest.warns(SmallSampleWarning, match=message) if is_numpy(xp)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -3725,7 +3725,7 @@ def check_pickling(distfn, args):
     distfn.random_state = rndm
 
 
-@pytest.mark.thread_unsafe(reason="fails in parallel")
+@pytest.mark.thread_unsafe(reason="uses numpy global random state and monkey-patching")
 def test_random_state_property():
     scale = np.eye(3)
     scale[0, 1] = 0.5

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -2775,7 +2775,7 @@ class TestMultivariateT:
         _, p = normaltest(samples)
         assert ((p > P_VAL_MIN).all())
 
-    @pytest.mark.thread_unsafe
+    @pytest.mark.thread_unsafe(reason="uses mocking")
     @patch('scipy.stats.multivariate_normal._logpdf')
     def test_mvt_with_inf_df_calls_normal(self, mock):
         dist = multivariate_t(0, 1, df=np.inf, seed=7)
@@ -3725,8 +3725,8 @@ def check_pickling(distfn, args):
     distfn.random_state = rndm
 
 
-@pytest.mark.thread_unsafe
-def test_random_state_property(num_parallel_threads):
+@pytest.mark.thread_unsafe(reason="fails in parallel")
+def test_random_state_property():
     scale = np.eye(3)
     scale[0, 1] = 0.5
     scale[1, 0] = 0.5

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -597,8 +597,9 @@ class QMCEngineTests:
         "rng",
         (
             170382760648021597650530316304495310428,
-            np.random.default_rng(170382760648021597650530316304495310428),
-            None,
+            pytest.param(np.random.default_rng(170382760648021597650530316304495310428),
+                         marks=pytest.mark.thread_unsafe),
+            pytest.param(None, marks=pytest.mark.thread_unsafe),
         ),
     )
     def test_reset(self, scramble, rng):

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -144,7 +144,6 @@ class TestUtils:
         with pytest.raises(ValueError, match=r"'toto' is not a valid ..."):
             qmc.discrepancy(sample, method="toto")
 
-    @pytest.mark.thread_unsafe
     def test_discrepancy_parallel(self, monkeypatch):
         sample = np.array([[2, 1, 1, 2, 2, 2],
                            [1, 2, 2, 2, 2, 2],
@@ -602,7 +601,6 @@ class QMCEngineTests:
             None,
         ),
     )
-    @pytest.mark.thread_unsafe
     def test_reset(self, scramble, rng):
         engine = self.engine(d=2, scramble=scramble, rng=rng)
         ref_sample = engine.random(n=8)

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -597,12 +597,14 @@ class QMCEngineTests:
         "rng",
         (
             170382760648021597650530316304495310428,
-            pytest.param(np.random.default_rng(170382760648021597650530316304495310428),
-                         marks=pytest.mark.thread_unsafe),
+            lambda: np.random.default_rng(170382760648021597650530316304495310428),
             pytest.param(None, marks=pytest.mark.thread_unsafe),
         ),
     )
     def test_reset(self, scramble, rng):
+        if callable(rng):
+            # Initialize local RNG here to make it thread-local in pytest-run-parallel
+            rng = rng()
         engine = self.engine(d=2, scramble=scramble, rng=rng)
         ref_sample = engine.random(n=8)
 

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -505,7 +505,7 @@ class TestTransformedDensityRejection:
 
     @pytest.mark.parametrize("dist, mv_ex",
                              zip(dists, mvs))
-    @pytest.mark.thread_unsafe(reason="deadlocks in parallel")
+    @pytest.mark.thread_unsafe(reason="deadlocks for unknown reasons")
     def test_basic(self, dist, mv_ex):
         with warnings.catch_warnings():
             # filter the warnings thrown by UNU.RAN

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -377,7 +377,7 @@ class TestQRVS:
     @pytest.mark.parametrize('qrng', qrngs)
     @pytest.mark.parametrize('size_in, size_out', sizes)
     @pytest.mark.parametrize('d_in, d_out', ds)
-    @pytest.mark.thread_unsafe
+    @pytest.mark.thread_unsafe(reason="fails in parallel")
     def test_QRVS_shape_consistency(self, qrng, size_in, size_out,
                                     d_in, d_out, method):
         w32 = sys.platform == "win32" and platform.architecture()[0] == "32bit"
@@ -505,7 +505,7 @@ class TestTransformedDensityRejection:
 
     @pytest.mark.parametrize("dist, mv_ex",
                              zip(dists, mvs))
-    @pytest.mark.thread_unsafe
+    @pytest.mark.thread_unsafe(reason="deadlocks in parallel")
     def test_basic(self, dist, mv_ex):
         with warnings.catch_warnings():
             # filter the warnings thrown by UNU.RAN

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -812,6 +812,7 @@ class TestNumericalInversePolynomial:
     mv3 = [-0.45/np.pi, 0.2 * 250/3 * 0.5 - 0.45**2/np.pi**2]
     mvs = [mv0, mv1, mv2, mv3]
 
+    @pytest.mark.thread_unsafe(reason="deadlocks for unknown reasons")
     @pytest.mark.parametrize("dist, mv_ex",
                              zip(dists, mvs))
     def test_basic(self, dist, mv_ex):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1514,7 +1514,7 @@ class TestCorrSpearmanr2:
 
 # I need to figure out how to do this one.
 
-
+@pytest.mark.thread_unsafe(reason="fails in parallel")
 def test_kendalltau():
     # For the cases without ties, both variants should give the same
     # result.
@@ -1758,7 +1758,7 @@ def test_kendalltau_nan_2nd_arg():
     assert_allclose(r1.statistic, r2.statistic, atol=1e-15)
 
 
-@pytest.mark.thread_unsafe
+@pytest.mark.thread_unsafe(reason="fails in parallel")
 def test_kendalltau_gh18139_overflow():
     # gh-18139 reported an overflow in `kendalltau` that appeared after
     # SciPy 0.15.1. Check that this particular overflow does not occur.


### PR DESCRIPTION
The deleted `thread_unsafe` markers are no longer needed. Either because pytest-run-parallel can detect the thread-unsafe functionality or because the underlying thread-unsafety the mark was applied for has been fixed.

I also tried to add reasons for as many marks that are still needed as possible. Some of the reasons are still vague, unfortunately.

Hopefully now that the parallel tests are running on a 3.14t interpreter, they will fail randomly less often and this won't need to be disabled again (gh-22758).

I also reported upstream issues where it made sense to do so (e.g. for mpmath and scikit-umfpack) and link there.