### PR TITLE
BUG: spatial.transform.Rotation.from_quat: fix dtype inference for numpy backend

### DIFF
--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -2455,7 +2455,12 @@ class Rotation:
         to the correct type in frameworks that may not support double precision (e.g.
         jax by default).
         """
-        dtype = xp_result_type(quat, xp=xp, force_floating=True)
+        # Legacy behavior: NumPy rotations always use float64. The cython backend uses
+        # float64 views and will raise on Buffer dtype mismatches.
+        if is_numpy(xp):
+            dtype = np.float64
+        else:
+            dtype = xp_result_type(quat, xp=xp, force_floating=True)
         quat = xp.asarray(quat, dtype=dtype)
         # TODO: Remove this once we properly support broadcasting
         if quat.ndim not in (1, 2) or quat.shape[-1] != 4:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -43,6 +43,10 @@ def test_init_non_array():
     Rotation([0, 0, 0, 1])
 
 
+def test_numpy_float32_inputs():
+    Rotation.from_quat(np.array([1, 0, 0, 0], dtype=np.float32))
+
+
 def test_generic_quat_matrix(xp):
     x = xp.asarray([[3.0, 4, 0, 0], [5, 12, 0, 0]])
     r = Rotation.from_quat(x)


### PR DESCRIPTION
#### Reference issue
Closes #23297

#### What does this implement/fix?
Numpy requires `_quat` to be `float64` irrespective of the inputs because the cython backend uses `double` memory views. We now correctly enforce `float64` for numpy. Test coverage has also been added.