### PR TITLE
DOC: development_workflow: fix SciPy's commit guideline link

### DIFF
--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -290,7 +290,7 @@ Checklist before submitting a PR
 -  Does the documentation render correctly? See :ref:`rendering-documentation`.
 -  Is the code style correct? See :ref:`pep8-scipy`.
 -  Are there benchmarks? See :ref:`benchmarking-with-asv`.
--  Is the commit message :ref:`formatted correctly <numpy:writing-the-commit-message>`?
+-  Is the commit message formatted correctly? See :ref:`writing-the-commit-message`?
 -  Is the docstring of the new functionality tagged with
    ``.. versionadded:: X.Y.Z`` (where ``X.Y.Z`` is the version number of the
    next release? See the ``updating``, ``workers``, and ``constraints``

--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -290,7 +290,7 @@ Checklist before submitting a PR
 -  Does the documentation render correctly? See :ref:`rendering-documentation`.
 -  Is the code style correct? See :ref:`pep8-scipy`.
 -  Are there benchmarks? See :ref:`benchmarking-with-asv`.
--  Is the commit message formatted correctly? See :ref:`writing-the-commit-message`?
+-  Is the commit message formatted correctly? See :ref:`writing-the-commit-message`.
 -  Is the docstring of the new functionality tagged with
    ``.. versionadded:: X.Y.Z`` (where ``X.Y.Z`` is the version number of the
    next release? See the ``updating``, ``workers``, and ``constraints``


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Don't hop to NumPy if SciPy has its own guidelines :)

#### Additional information
<!--Any additional information you think is important.-->
