### PR TITLE
TST: free-threading performance tweaks

### DIFF
--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -126,7 +126,8 @@ def _func_with_args(x, a):
 
 @pytest.mark.fail_slow(10)
 @pytest.mark.parametrize('extra_args', [2, (2,)])
-@pytest.mark.parametrize('workers', [1, 10])
+@pytest.mark.parametrize('workers',
+                         [1, pytest.param(10, marks=pytest.mark.parallel_threads(4))])
 def test_quad_vec_pool_args(extra_args, workers):
     f = _func_with_args
     exact = np.array([0, 4/3, 8/3])

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -548,7 +548,7 @@ def test_linearoperator_deallocation():
         pass
 
 
-def test_parallel_threads():
+def test_parallel_threads(num_parallel_threads):
     results = []
     v0 = np.random.rand(50)
 
@@ -560,7 +560,8 @@ def test_parallel_threads():
         w, v = eigsh(x, k=3, v0=v0)
         results.append(w)
 
-    threads = [threading.Thread(target=worker) for k in range(10)]
+    nthreads = 9 // num_parallel_threads + 1
+    threads = [threading.Thread(target=worker) for _ in range(nthreads)]
     for t in threads:
         t.start()
     for t in threads:

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -674,6 +674,7 @@ class SVDSCommonTests:
 
     @pytest.mark.filterwarnings("ignore:Exited at iteration")
     @pytest.mark.filterwarnings("ignore:Exited postprocessing")
+    @pytest.mark.parallel_threads(4)  # Very slow
     @pytest.mark.parametrize("shape", SHAPES)
     # ARPACK supports only dtype float, complex, or np.float32
     @pytest.mark.parametrize("dtype", (float, complex, np.float32))

--- a/scipy/sparse/linalg/tests/test_funm_multiply_krylov.py
+++ b/scipy/sparse/linalg/tests/test_funm_multiply_krylov.py
@@ -49,11 +49,11 @@ class TestKrylovFunmv:
             assert_allclose(observed, expected, rtol = 1E-6, atol = 1E-8)
 
     @pytest.mark.parametrize("f", FUNCS)
-    def test_funm_multiply_krylov_nonhermitian_sparse(self, f):
+    def test_funm_multiply_krylov_nonhermitian_sparse(self, f, num_parallel_threads):
 
         rng = np.random.default_rng(1738151906092735)
         n = 100
-        nsamples = 10
+        nsamples = 1 + 9 // num_parallel_threads  # Very slow otherwise
 
         for i in range(nsamples):
             D = scipy.sparse.diags(rng.standard_normal(n))
@@ -88,11 +88,11 @@ class TestKrylovFunmv:
             assert_allclose(observed, expected, rtol = 1E-6, atol = 1E-8)
 
     @pytest.mark.parametrize("f", FUNCS)
-    def test_funm_multiply_krylov_hermitian_sparse(self, f):
+    def test_funm_multiply_krylov_hermitian_sparse(self, f, num_parallel_threads):
 
         rng = np.random.default_rng(1738151906092735)
         n = 100
-        nsamples = 10
+        nsamples = 1 + 9 // num_parallel_threads  # Very slow otherwise
 
         for i in range(nsamples):
             D = scipy.sparse.diags(rng.standard_normal(n))

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1113,6 +1113,7 @@ class TestNumericalInverseHermite:
 
     @pytest.mark.fail_slow(5)
     @pytest.mark.filterwarnings('ignore::RuntimeWarning')
+    @pytest.mark.parallel_threads(4)  # Very slow
     def test_basic_truncnorm_gh17155(self):
         self.basic_test_all_scipy_dists("truncnorm", (0.1, 2))
 


### PR DESCRIPTION
Speed up a bunch of tests that take tens or hundreds of seconds to complete with `--parallel-threads=32`.

CC @ngoldbaum 