### PR TITLE
TST: free-threading: More local RNGs

### DIFF
--- a/scipy/optimize/tests/test__dual_annealing.py
+++ b/scipy/optimize/tests/test__dual_annealing.py
@@ -37,7 +37,6 @@ class TestDualAnnealing:
         self.low_temperature = 0.1
         self.qv = 2.62
         self.seed = 1234
-        self.rng = check_random_state(self.seed)
         self.nb_fun_call = threading.local()
         self.ngev = threading.local()
 
@@ -70,11 +69,12 @@ class TestDualAnnealing:
     #        this needs investigating - see gh-12384
     @pytest.mark.parametrize('qv', [1.1, 1.41, 2, 2.62, 2.9])
     def test_visiting_stepping(self, qv):
+        rng = np.random.default_rng(1234)
         lu = list(zip(*self.ld_bounds))
         lower = np.array(lu[0])
         upper = np.array(lu[1])
         dim = lower.size
-        vd = VisitingDistribution(lower, upper, qv, self.rng)
+        vd = VisitingDistribution(lower, upper, qv, rng)
         values = np.zeros(dim)
         x_step_low = vd.visiting(values, 0, self.high_temperature)
         # Make sure that only the first component is changed
@@ -86,10 +86,11 @@ class TestDualAnnealing:
 
     @pytest.mark.parametrize('qv', [2.25, 2.62, 2.9])
     def test_visiting_dist_high_temperature(self, qv):
+        rng = np.random.default_rng(1234)
         lu = list(zip(*self.ld_bounds))
         lower = np.array(lu[0])
         upper = np.array(lu[1])
-        vd = VisitingDistribution(lower, upper, qv, self.rng)
+        vd = VisitingDistribution(lower, upper, qv, rng)
         # values = np.zeros(self.nbtestvalues)
         # for i in np.arange(self.nbtestvalues):
         #     values[i] = vd.visit_fn(self.high_temperature)

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -335,14 +335,14 @@ class TestLinear:
     some methods find the exact solution in a finite number of steps"""
 
     def _check(self, jac, N, maxiter, complex=False, **kw):
-        np.random.seed(123)
+        rng = np.random.default_rng(123)
 
-        A = np.random.randn(N, N)
+        A = rng.standard_normal((N, N))
         if complex:
-            A = A + 1j*np.random.randn(N, N)
-        b = np.random.randn(N)
+            A = A + 1j*rng.standard_normal((N, N))
+        b = rng.standard_normal(N)
         if complex:
-            b = b + 1j*np.random.randn(N)
+            b = b + 1j*rng.standard_normal(N)
 
         def func(x):
             return dot(A, x) - b

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -834,9 +834,9 @@ class TestFFTConvolve:
 
     @pytest.mark.parametrize('axes', ['', None, 0, [0], -1, [-1]])
     def test_random_data(self, axes, xp):
-        np.random.seed(1234)
-        a_np = np.random.rand(1233) + 1j * np.random.rand(1233)
-        b_np = np.random.rand(1321) + 1j * np.random.rand(1321)
+        rng = np.random.default_rng(1234)
+        a_np = np.random.rand(1233) + 1j * rng.random(1233)
+        b_np = np.random.rand(1321) + 1j * rng.random(1321)
         expected = xp.asarray(np.convolve(a_np, b_np, 'full'))
         a = xp.asarray(a_np)
         b = xp.asarray(b_np)
@@ -851,9 +851,9 @@ class TestFFTConvolve:
 
     @pytest.mark.parametrize('axes', [1, [1], -1, [-1]])
     def test_random_data_axes(self, axes, xp):
-        np.random.seed(1234)
-        a_np = np.random.rand(1233) + 1j * np.random.rand(1233)
-        b_np = np.random.rand(1321) + 1j * np.random.rand(1321)
+        rng = np.random.default_rng(1234)
+        a_np = np.random.rand(1233) + 1j * rng.random(1233)
+        b_np = np.random.rand(1321) + 1j * rng.random(1321)
         expected = np.convolve(a_np, b_np, 'full')
         a_np = np.tile(a_np, [2, 1])
         b_np = np.tile(b_np, [2, 1])
@@ -879,9 +879,9 @@ class TestFFTConvolve:
                                       [-1, -4]])
     def test_random_data_multidim_axes(self, axes, xp):
         a_shape, b_shape = (123, 22), (132, 11)
-        np.random.seed(1234)
-        a = xp.asarray(np.random.rand(*a_shape) + 1j * np.random.rand(*a_shape))
-        b = xp.asarray(np.random.rand(*b_shape) + 1j * np.random.rand(*b_shape))
+        rng = np.random.default_rng(1234)
+        a = xp.asarray(np.random.rand(*a_shape) + 1j * rng.random(a_shape))
+        b = xp.asarray(np.random.rand(*b_shape) + 1j * rng.random(b_shape))
         expected = convolve2d(a, b, 'full')
 
         a = a[:, :, None, None, None]
@@ -2586,11 +2586,11 @@ class TestCorrelateComplex:
         return int(2 * prec / 3)
 
     def _setup_rank1(self, dt, mode, xp):
-        np.random.seed(9)
+        rng = np.random.default_rng(9)
         a = np.random.randn(10).astype(dt)
-        a += 1j * np.random.randn(10).astype(dt)
+        a += 1j * rng.standard_normal(10).astype(dt)
         b = np.random.randn(8).astype(dt)
-        b += 1j * np.random.randn(8).astype(dt)
+        b += 1j * rng.standard_normal(8).astype(dt)
 
         y_r = (correlate(a.real, b.real, mode=mode) +
                correlate(a.imag, b.imag, mode=mode)).astype(dt)
@@ -2981,8 +2981,8 @@ def filtfilt_gust_opt(b, a, x):
 
 def check_filtfilt_gust(b, a, shape, axis, irlen=None):
     # Generate x, the data to be filtered.
-    np.random.seed(123)
-    x = np.random.randn(*shape)
+    rng = np.random.default_rng(123)
+    x = rng.standard_normal(shape)
 
     # Apply filtfilt to x. This is the main calculation to be checked.
     y = filtfilt(b, a, x, axis=axis, method="gust", irlen=irlen)
@@ -3061,8 +3061,6 @@ def test_filtfilt_gust(xp):
     eps = 1e-10
     r = np.max(np.abs(p))
     approx_impulse_len = int(np.ceil(np.log(eps) / np.log(r)))
-
-    np.random.seed(123)
 
     b, a = zpk2tf(z, p, k)
     for irlen in [None, approx_impulse_len]:

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -550,7 +550,8 @@ def test_linearoperator_deallocation():
 
 def test_parallel_threads():
     results = []
-    v0 = np.random.rand(50)
+    rng = np.random.default_rng(1234)
+    v0 = rng.random(50)
 
     def worker():
         x = diags_array([1, -2, 1], offsets=[-1, 0, 1], shape=(50, 50))

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -148,11 +148,11 @@ class TestRecurrence:
 
     def check_poly(self, func, param_ranges=(), x_range=(), nn=10,
                    nparam=10, nx=10, rtol=1e-8):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
 
         dataset = []
         for n in np.arange(nn):
-            params = [a + (b-a)*np.random.rand(nparam) for a,b in param_ranges]
+            params = [a + (b-a)*rng.random(nparam) for a,b in param_ranges]
             params = np.asarray(params).T
             if not param_ranges:
                 params = [0]
@@ -161,7 +161,7 @@ class TestRecurrence:
                     p = (n,) + tuple(p)
                 else:
                     p = (n,)
-                x = x_range[0] + (x_range[1] - x_range[0])*np.random.rand(nx)
+                x = x_range[0] + (x_range[1] - x_range[0])*rng.random(nx)
                 x[0] = x_range[0]  # always include domain start point
                 x[1] = x_range[1]  # always include domain end point
                 kw = dict(sig=(len(p)+1)*'d'+'->d')

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -529,7 +529,7 @@ class TestMultivariateNormal:
         assert_raises(ValueError, multivariate_normal.cdf, (0, 1, 2), mu, cov)
 
     def test_scalar_values(self):
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
 
         # When evaluated on scalar data, the pdf should return a scalar
         x, mean, cov = 1.5, 1.7, 2.5
@@ -537,9 +537,9 @@ class TestMultivariateNormal:
         assert_equal(pdf.ndim, 0)
 
         # When evaluated on a single vector, the pdf should return a scalar
-        x = np.random.randn(5)
-        mean = np.random.randn(5)
-        cov = np.abs(np.random.randn(5))  # Diagonal values for cov. matrix
+        x = rng.standard_normal(5)
+        mean = rng.standard_normal(5)
+        cov = np.abs(rng.standard_normal(5))  # Diagonal values for cov. matrix
         pdf = multivariate_normal.pdf(x, mean, cov)
         assert_equal(pdf.ndim, 0)
 
@@ -549,18 +549,18 @@ class TestMultivariateNormal:
         assert_equal(cdf.ndim, 0)
 
         # When evaluated on a single vector, the cdf should return a scalar
-        x = np.random.randn(5)
-        mean = np.random.randn(5)
-        cov = np.abs(np.random.randn(5))  # Diagonal values for cov. matrix
+        x = rng.standard_normal(5)
+        mean = rng.standard_normal(5)
+        cov = np.abs(rng.standard_normal(5))  # Diagonal values for cov. matrix
         cdf = multivariate_normal.cdf(x, mean, cov)
         assert_equal(cdf.ndim, 0)
 
     def test_logpdf(self):
         # Check that the log of the pdf is in fact the logpdf
-        np.random.seed(1234)
-        x = np.random.randn(5)
-        mean = np.random.randn(5)
-        cov = np.abs(np.random.randn(5))
+        rng = np.random.default_rng(1234)
+        x = rng.standard_normal(5)
+        mean = rng.standard_normal(5)
+        cov = np.abs(rng.standard_normal(5))
         d1 = multivariate_normal.logpdf(x, mean, cov)
         d2 = multivariate_normal.pdf(x, mean, cov)
         assert_allclose(d1, np.log(d2))
@@ -568,8 +568,8 @@ class TestMultivariateNormal:
     def test_logpdf_default_values(self):
         # Check that the log of the pdf is in fact the logpdf
         # with default parameters Mean=None and cov = 1
-        np.random.seed(1234)
-        x = np.random.randn(5)
+        rng = np.random.default_rng(1234)
+        x = rng.standard_normal(5)
         d1 = multivariate_normal.logpdf(x)
         d2 = multivariate_normal.pdf(x)
         # check whether default values are being used
@@ -580,10 +580,10 @@ class TestMultivariateNormal:
 
     def test_logcdf(self):
         # Check that the log of the cdf is in fact the logcdf
-        np.random.seed(1234)
-        x = np.random.randn(5)
-        mean = np.random.randn(5)
-        cov = np.abs(np.random.randn(5))
+        rng = np.random.default_rng(1234)
+        x = rng.standard_normal(5)
+        mean = rng.standard_normal(5)
+        cov = np.abs(rng.standard_normal(5))
         d1 = multivariate_normal.logcdf(x, mean, cov)
         d2 = multivariate_normal.cdf(x, mean, cov)
         assert_allclose(d1, np.log(d2))
@@ -591,8 +591,8 @@ class TestMultivariateNormal:
     def test_logcdf_default_values(self):
         # Check that the log of the cdf is in fact the logcdf
         # with default parameters Mean=None and cov = 1
-        np.random.seed(1234)
-        x = np.random.randn(5)
+        rng = np.random.default_rng(1234)
+        x = rng.standard_normal(5)
         d1 = multivariate_normal.logcdf(x)
         d2 = multivariate_normal.cdf(x)
         # check whether default values are being used
@@ -603,22 +603,22 @@ class TestMultivariateNormal:
 
     def test_rank(self):
         # Check that the rank is detected correctly.
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         n = 4
-        mean = np.random.randn(n)
+        mean = rng.standard_normal(n)
         for expected_rank in range(1, n + 1):
-            s = np.random.randn(n, expected_rank)
+            s = rng.standard_normal((n, expected_rank))
             cov = np.dot(s, s.T)
             distn = multivariate_normal(mean, cov, allow_singular=True)
             assert_equal(distn.cov_object.rank, expected_rank)
 
     def test_degenerate_distributions(self):
-
+        rng = np.random.default_rng(1234)
         for n in range(1, 5):
-            z = np.random.randn(n)
+            z = rng.standard_normal(n)
             for k in range(1, n):
                 # Sample a small covariance matrix.
-                s = np.random.randn(k, k)
+                s = rng.standard_normal((k, k))
                 cov_kk = np.dot(s, s.T)
 
                 # Embed the small covariance matrix into a larger singular one.
@@ -775,10 +775,10 @@ class TestMultivariateNormal:
 
     def test_frozen(self):
         # The frozen distribution should agree with the regular one
-        np.random.seed(1234)
-        x = np.random.randn(5)
-        mean = np.random.randn(5)
-        cov = np.abs(np.random.randn(5))
+        rng = np.random.default_rng(1234)
+        x = rng.standard_normal(5)
+        mean = rng.standard_normal(5)
+        cov = np.abs(rng.standard_normal(5))
         norm_frozen = multivariate_normal(mean, cov)
         assert_allclose(norm_frozen.pdf(x), multivariate_normal.pdf(x, mean, cov))
         assert_allclose(norm_frozen.logpdf(x),
@@ -805,9 +805,9 @@ class TestMultivariateNormal:
         # Make sure that pseudo-inverse and pseudo-det agree on cutoff
 
         # Assemble random covariance matrix with large and small eigenvalues
-        np.random.seed(1234)
+        rng = np.random.default_rng(1234)
         n = 7
-        x = np.random.randn(n, n)
+        x = rng.standard_normal((n, n))
         cov = np.dot(x, x.T)
         s, u = scipy.linalg.eigh(cov)
         s = np.full(n, 0.5)
@@ -842,9 +842,9 @@ class TestMultivariateNormal:
         assert_raises(ValueError, _PSD, cov)
 
     def test_exception_singular_cov(self):
-        np.random.seed(1234)
-        x = np.random.randn(5)
-        mean = np.random.randn(5)
+        rng = np.random.default_rng(1234)
+        x = rng.standard_normal(5)
+        mean = rng.standard_normal(5)
         cov = np.ones((5, 5))
         e = np.linalg.LinAlgError
         assert_raises(e, multivariate_normal, mean, cov)
@@ -1432,10 +1432,10 @@ class TestMatrixNormal:
 class TestDirichlet:
 
     def test_frozen_dirichlet(self):
-        np.random.seed(2846)
+        rng = np.random.default_rng(2846)
 
-        n = np.random.randint(1, 32)
-        alpha = np.random.uniform(10e-10, 100, n)
+        n = rng.integers(1, 32)
+        alpha = rng.uniform(10e-10, 100, n)
 
         d = dirichlet(alpha)
 
@@ -1444,15 +1444,15 @@ class TestDirichlet:
         assert_equal(d.entropy(), dirichlet.entropy(alpha))
         num_tests = 10
         for i in range(num_tests):
-            x = np.random.uniform(10e-10, 100, n)
+            x = rng.uniform(10e-10, 100, n)
             x /= np.sum(x)
             assert_equal(d.pdf(x[:-1]), dirichlet.pdf(x[:-1], alpha))
             assert_equal(d.logpdf(x[:-1]), dirichlet.logpdf(x[:-1], alpha))
 
     def test_numpy_rvs_shape_compatibility(self):
-        np.random.seed(2846)
+        rng = np.random.default_rng(2846)
         alpha = np.array([1.0, 2.0, 3.0])
-        x = np.random.dirichlet(alpha, size=7)
+        x = rng.dirichlet(alpha, size=7)
         assert_equal(x.shape, (7, 3))
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
@@ -1462,18 +1462,18 @@ class TestDirichlet:
         dirichlet.logpdf(x.T[:-1], alpha)
 
     def test_alpha_with_zeros(self):
-        np.random.seed(2846)
+        rng = np.random.default_rng(2846)
         alpha = [1.0, 0.0, 3.0]
         # don't pass invalid alpha to np.random.dirichlet
-        x = np.random.dirichlet(np.maximum(1e-9, alpha), size=7).T
+        x = rng.dirichlet(np.maximum(1e-9, alpha), size=7).T
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
     def test_alpha_with_negative_entries(self):
-        np.random.seed(2846)
+        rng = np.random.default_rng(2846)
         alpha = [1.0, -2.0, 3.0]
         # don't pass invalid alpha to np.random.dirichlet
-        x = np.random.dirichlet(np.maximum(1e-9, alpha), size=7).T
+        x = rng.dirichlet(np.maximum(1e-9, alpha), size=7).T
         assert_raises(ValueError, dirichlet.pdf, x, alpha)
         assert_raises(ValueError, dirichlet.logpdf, x, alpha)
 
@@ -1571,25 +1571,24 @@ class TestDirichlet:
 
     def test_K_and_K_minus_1_calls_equal(self):
         # Test that calls with K and K-1 entries yield the same results.
+        rng = np.random.default_rng(2846)
 
-        np.random.seed(2846)
-
-        n = np.random.randint(1, 32)
-        alpha = np.random.uniform(10e-10, 100, n)
+        n = rng.integers(1, 32)
+        alpha = rng.uniform(10e-10, 100, n)
 
         d = dirichlet(alpha)
         num_tests = 10
         for i in range(num_tests):
-            x = np.random.uniform(10e-10, 100, n)
+            x = rng.uniform(10e-10, 100, n)
             x /= np.sum(x)
             assert_almost_equal(d.pdf(x[:-1]), d.pdf(x))
 
     def test_multiple_entry_calls(self):
         # Test that calls with multiple x vectors as matrix work
-        np.random.seed(2846)
+        rng = np.random.default_rng(2846)
 
-        n = np.random.randint(1, 32)
-        alpha = np.random.uniform(10e-10, 100, n)
+        n = rng.integers(1, 32)
+        alpha = rng.uniform(10e-10, 100, n)
         d = dirichlet(alpha)
 
         num_tests = 10
@@ -1597,7 +1596,7 @@ class TestDirichlet:
         xm = None
         for i in range(num_tests):
             for m in range(num_multiple):
-                x = np.random.uniform(10e-10, 100, n)
+                x = rng.uniform(10e-10, 100, n)
                 x /= np.sum(x)
                 if xm is not None:
                     xm = np.vstack((xm, x))
@@ -1614,15 +1613,15 @@ class TestDirichlet:
             assert_array_almost_equal(rm, rs)
 
     def test_2D_dirichlet_is_beta(self):
-        np.random.seed(2846)
+        rng = np.random.default_rng(2846)
 
-        alpha = np.random.uniform(10e-10, 100, 2)
+        alpha = rng.uniform(10e-10, 100, 2)
         d = dirichlet(alpha)
         b = beta(alpha[0], alpha[1])
 
         num_tests = 10
         for i in range(num_tests):
-            x = np.random.uniform(10e-10, 100, 2)
+            x = rng.uniform(10e-10, 100, 2)
             x /= np.sum(x)
             assert_almost_equal(b.pdf(x), d.pdf([x]))
 
@@ -2039,7 +2038,6 @@ class TestMultinomial:
 
     def test_frozen(self):
         # The frozen distribution should agree with the regular one
-        np.random.seed(1234)
         n = 12
         pvals = (.1, .2, .3, .4)
         x = [[0,0,0,12],[0,0,1,11],[0,1,1,10],[1,1,1,9],[1,1,2,8]]
@@ -3383,7 +3381,6 @@ class TestMultivariateHypergeom:
 
     def test_frozen(self):
         # The frozen distribution should agree with the regular one
-        np.random.seed(1234)
         n = 12
         m = [7, 9, 11, 13]
         x = [[0, 0, 0, 12], [0, 0, 1, 11], [0, 1, 1, 10],

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1091,12 +1091,12 @@ class TestNumericalInverseHermite:
             # https://github.com/scipy/scipy/pull/13319#discussion_r626188955
             pytest.xfail("Fails - usually due to inaccurate CDF/PDF")
 
-        np.random.seed(0)
+        rng = np.random.default_rng(0)
 
         dist = getattr(stats, distname)(*shapes)
         fni = NumericalInverseHermite(dist)
 
-        x = np.random.rand(10)
+        x = rng.random(10)
         p_tol = np.max(np.abs(dist.ppf(x)-fni.ppf(x))/np.abs(dist.ppf(x)))
         u_tol = np.max(np.abs(dist.cdf(fni.ppf(x)) - x))
 


### PR DESCRIPTION
Replace a bunch of global RNGs with local ones. This fixes random failures when running 3.13t with `pytest-run-parallel`.

CC @ngoldbaum 