### PR TITLE
TST: stats: add test for CustomDistribution `__string__` & `__repr__`

### DIFF
--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1446,6 +1446,36 @@ class TestMakeDistribution:
             assert repr(dist(beta=2)) == "HalfGeneralizedNormal(beta=np.float64(2.0))"
         assert 'HalfGeneralizedNormal' in dist.__doc__
 
+    def test_custom_distribution_repr_str(self):
+            # Create a custom distribution class
+            class MyLogUniform:
+                @property
+                def __make_distribution_version__(self):
+                    return "1.16.0"
+
+                @property
+                def parameters(self):
+                    return {'a': {'endpoints': (0, np.inf), 
+                                  'inclusive': (False, False)},
+                            'b': {'endpoints': ('a', np.inf), 
+                                  'inclusive': (False, False)}}
+
+                @property
+                def support(self):
+                    return 'a', 'b'
+
+                def pdf(self, x, a, b):
+                    return 1 / (x * (np.log(b) - np.log(a)))
+
+            LogUniform = stats.make_distribution(MyLogUniform())
+            dist_instance = LogUniform(a=2.0, b=3.0)
+
+            # Test __str__ method
+            assert str(dist_instance) == 'MyLogUniform(a=2.0, b=3.0)'
+            # Test __repr__ method
+            assert repr(dist_instance) == \
+                'MyLogUniform(a=np.float64(2.0), b=np.float64(3.0))'
+
 
 class TestTransforms:
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1464,19 +1464,17 @@ class TestMakeDistribution:
                 def support(self):
                     return 'a', 'b'
 
-                def pdf(self, x, a, b):
-                    return 1 / (x * (np.log(b) - np.log(a)))
-
             LogUniform = stats.make_distribution(MyLogUniform())
             dist_instance = LogUniform(a=2.0, b=3.0)
 
             # Test __str__ method
             assert str(dist_instance) == 'MyLogUniform(a=2.0, b=3.0)'
             # Test __repr__ method
-            assert repr(dist_instance) in {
-                'MyLogUniform(a=np.float64(2.0), b=np.float64(3.0))',
-                'MyLogUniform(a=2.0, b=3.0)',
-            }
+            if np.__version__ >= "2":
+                assert repr(dist_instance) == \
+                    'MyLogUniform(a=np.float64(2.0), b=np.float64(3.0))'
+            else:
+                assert repr(dist_instance) == 'MyLogUniform(a=2.0, b=3.0)'
 
 
 class TestTransforms:

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1473,8 +1473,10 @@ class TestMakeDistribution:
             # Test __str__ method
             assert str(dist_instance) == 'MyLogUniform(a=2.0, b=3.0)'
             # Test __repr__ method
-            assert repr(dist_instance) == \
-                'MyLogUniform(a=np.float64(2.0), b=np.float64(3.0))'
+            assert repr(dist_instance) in {
+                'MyLogUniform(a=np.float64(2.0), b=np.float64(3.0))',
+                'MyLogUniform(a=2.0, b=3.0)',
+            }
 
 
 class TestTransforms:


### PR DESCRIPTION
This PR adds a test for the `__string__` & `__repr__` methods of `CustomDistribution` classes in the `stats.make_distribution` function. The test ensures that the string representations of the superclass `ContinuousDistribution` are correctly replaced with a custom string. PR https://github.com/scipy/scipy/pull/22371 added the methods without tests. This new test adds coverage to the following lines (that were modified in the PR^^):

```py
def _make_distribution_custom(dist):
    parameters = []
    support = getattr(dist, 'support')

    ...
    repr_str = dist.__class__.__name__

    class CustomDistribution(ContinuousDistribution):
        _parameterizations = ([_Parameterization(*parameters)] if parameters
                              else [])
        _variable = _x_param

        def __repr__(self):
            s = super().__repr__() #✅ NOW COVERED
            return s.replace('CustomDistribution', repr_str) #✅ NOW COVERED

        def __str__(self):
            s = super().__str__() #✅ NOW COVERED
            return s.replace('CustomDistribution', repr_str) #✅ NOW COVERED

    methods = {'sample', 'logentropy', 'entropy',
    ...
```

Note: Parts of this test have been automatically generated by a novel technique that we're currently developing as part of an academic research project aiming at improving test coverage. *To not waste developer time, two researchers manually checked the test before submitting it.* We appreciate the developers' time and any feedback is welcomed.