### PR TITLE
TST: io.wavfile: add test for `SeekEmulatingReader.seek`

### DIFF
--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -513,8 +513,5 @@ def test_seek_emulating_reader_invalid_seek():
         reader.seek(-1, 0)  # Negative position with SEEK_SET
     
     # Test SEEK_END with valid parameters (should not raise)
-    try:
-        pos = reader.seek(0, os.SEEK_END)  # Valid usage
-        assert pos == 2  # Check the position after seeking (corrected)
-    except Exception as e:
-        pytest.fail(f'Seek to SEEK_END raised an exception: {e}')
+    pos = reader.seek(0, os.SEEK_END)  # Valid usage
+    assert pos == 2, f"Failed to seek to end, got position {pos}"

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from io import BytesIO
+from io import (BytesIO, UnsupportedOperation)
 import threading
 
 import numpy as np
@@ -499,3 +499,22 @@ def test_wavfile_dtype_unsupported(tmpdir, dtype):
     rate = 8000
     with pytest.raises(ValueError, match="Unsupported"):
         wavfile.write(tmpfile, rate, data)
+
+def test_seek_emulating_reader_invalid_seek():
+    # Dummy data for the reader
+    reader = wavfile.SeekEmulatingReader(BytesIO(b'\x00\x00'))
+    
+    # Test SEEK_END with an invalid whence value
+    with pytest.raises(UnsupportedOperation):
+        reader.seek(0, 5)  # Invalid whence value
+    
+    # Test with negative seek value
+    with pytest.raises(UnsupportedOperation):
+        reader.seek(-1, 0)  # Negative position with SEEK_SET
+    
+    # Test SEEK_END with valid parameters (should not raise)
+    try:
+        pos = reader.seek(0, os.SEEK_END)  # Valid usage
+        assert pos == 2  # Check the position after seeking (corrected)
+    except Exception as e:
+        pytest.fail(f'Seek to SEEK_END raised an exception: {e}')


### PR DESCRIPTION
This PR adds a test for `io.wavfile::SeekEmulatingReader.seek`. It ensures seek works correctly when seeking exactly to the end (os.SEEK_END) or unsupoorted seek is used. PR https://github.com/scipy/scipy/pull/22208 introduced this emulator class but some test coverage were missing. 

```py
class SeekEmulatingReader:
    """
    Tracks stream position, provides tell(), and emulates only those
    seeks that can be supported by reading forward. Other seeks raise
    io.UnsupportedOperation. Note that this class implements only the
    minimum necessary to keep wavfile.read() happy.
    """
    def __init__(self, reader):
        self.reader = reader
        self.pos = 0

    def read(self, size=-1, /):
        data = self.reader.read(size)
        self.pos += len(data)
        return data
    
    def seek(self, offset, whence=os.SEEK_SET, /):
        match whence:
            case os.SEEK_SET if offset >= self.pos:
                self.read(offset - self.pos) # convert to relative
            case os.SEEK_CUR if offset >= 0:
                self.read(offset) # advance by offset
            case os.SEEK_END if offset == 0: #✅ NOW COVERED
                self.read() # advance to end of stream #✅ NOW COVERED
            case _: #✅ NOW COVERED
                raise io.UnsupportedOperation("SeekEmulatingReader was asked to emulate" #✅ NOW COVERED
                                              " a seek operation it does not support.") #✅ NOW COVERED
        return self.pos
```

Note: Parts of this test have been automatically generated by a novel technique that we're currently developing as part of an academic research project aiming at improving test coverage. *To not waste developer time, two researchers manually checked the test before submitting it.* We appreciate the developers' time and any feedback is welcomed.