### PR TITLE
BUG:DOC: sparse.linalg: Fix more arnaud bugs and add C code documentation

### DIFF
--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
@@ -1,52 +1,49 @@
 #ifndef ARNAUD_H
 #define ARNAUD_H
 
-#include <math.h>
-#include <complex.h>
-
-#if defined(_MSC_VER)
-    // MSVC definitions
-    typedef _Dcomplex ARNAUD_CPLX_TYPE;
-    typedef _Fcomplex ARNAUD_CPLXF_TYPE;
-
-#else
-    // C99 compliant compilers
-    typedef double complex ARNAUD_CPLX_TYPE;
-    typedef float complex ARNAUD_CPLXF_TYPE;
-
-#endif
-
+#include "types.h"
 
 enum ARNAUD_which {
-    which_LM = 0,    // want the NEV eigenvalues of largest magnitude.
-    which_SM = 1,    // want the NEV eigenvalues of smallest magnitude.
-    which_LR = 2,    // want the NEV eigenvalues of largest real part.
-    which_SR = 3,    // want the NEV eigenvalues of smallest real part.
-    which_LI = 4,    // want the NEV eigenvalues of largest imaginary part.
-    which_SI = 5,    // want the NEV eigenvalues of smallest imaginary part.
-    which_LA = 6,    // compute the NEV largest (algebraic) eigenvalues. (sym)
-    which_SA = 7,    // compute the NEV smallest (algebraic) eigenvalues. (sym)
-    which_BE = 8     // compute NEV eigenvalues, half from each end of the spectrum. (sym)
-};
-
-enum ARNAUD_ido {
-    ido_FIRST      = 0,  // First call
-    ido_OPX        = 1,  // OP*x needed
-    ido_BX         = 2,  // B*x needed
-    ido_USER_SHIFT = 3,  // User shifts are needed
-    ido_RANDOM     = 4,  // A random vector is needed to be written in resid
-    ido_RANDOM_OPX = 5,  // Force random vector to be in the range of OP
-    ido_DONE       = 99  // Done
+    which_LM = 0,    /**> want the NEV eigenvalues of largest magnitude. */
+    which_SM = 1,    /**> want the NEV eigenvalues of smallest magnitude. */
+    which_LR = 2,    /**> want the NEV eigenvalues of largest real part. */
+    which_SR = 3,    /**> want the NEV eigenvalues of smallest real part. */
+    which_LI = 4,    /**> want the NEV eigenvalues of largest imaginary part. */
+    which_SI = 5,    /**> want the NEV eigenvalues of smallest imaginary part. */
+    which_LA = 6,    /**> compute the NEV largest (algebraic) eigenvalues. (sym) */
+    which_SA = 7,    /**> compute the NEV smallest (algebraic) eigenvalues. (sym) */
+    which_BE = 8     /**> compute NEV eigenvalues, half from each end of the spectrum. (sym) */
 };
 
 /**
- * With the following structs, we collect all "SAVE"d Fortran variables to track
- * the problem and avoid reentry issues. It is not the cleanest and is laborious
- * but otherwise reentrancy is compromised. There are additional variables in the
- * original Fortran code that are also "SAVE"d however upon inspection, they
- * are assigned and then used in the same call and thus used without saving.
-**/
+ * @enum ARNAUD_ido
+ * @brief Iteration control for reverse communication interface.
+ *
+ * Used to indicate the action required by the calling program.
+ */
+enum ARNAUD_ido {
+    ido_FIRST      = 0,  /**< First call */
+    ido_OPX        = 1,  /**< OP*x needed */
+    ido_BX         = 2,  /**< B*x needed */
+    ido_USER_SHIFT = 3,  /**< User shifts are needed */
+    ido_RANDOM     = 4,  /**< A random vector is needed to be written in resid */
+    ido_RANDOM_OPX = 5,  /**< Force random vector to be in the range of OP */
+    ido_DONE       = 99  /**< Done */
+};
 
+
+/**
+ * @struct ARNAUD_state_s
+ * @brief State structure for single precision ARPACK-like solvers.
+ *
+ * This structure holds all persistent state and workspace variables
+ * required for the single precision (float) nonsymmetric and symmetric
+ * eigenvalue routines. It is designed to mimic the "SAVE" variables
+ * in the original Fortran ARPACK code, ensuring reentrancy and
+ * thread-safety.
+ *
+ * Members are grouped by their usage in different algorithmic phases.
+ */
 struct ARNAUD_state_s {
     float tol;               // problem parameter                input parameter
     float getv0_rnorm0;      // getv0 internal compute           internal
@@ -91,7 +88,18 @@ struct ARNAUD_state_s {
     int aup2_ushift;         // naupd2 flow control              internal
 };
 
-
+/**
+ * @struct ARNAUD_state_d
+ * @brief State structure for double precision ARPACK-like solvers.
+ *
+ * This structure holds all persistent state and workspace variables
+ * required for the double precision (double) nonsymmetric and symmetric
+ * eigenvalue routines. It is designed to mimic the "SAVE" variables
+ * in the original Fortran ARPACK code, ensuring reentrancy and
+ * thread-safety.
+ *
+ * Members are grouped by their usage in different algorithmic phases.
+ */
 struct ARNAUD_state_d {
     double tol;              // problem parameter                input parameter
     double getv0_rnorm0;     // getv0 internal compute           internal
@@ -137,7 +145,10 @@ struct ARNAUD_state_d {
 };
 
 
+
 void ARNAUD_snaupd(struct ARNAUD_state_s *V, float* resid, float* v, int ldv, int* ipntr, float* workd, float* workl);
+
+
 void ARNAUD_dnaupd(struct ARNAUD_state_d *V, double* resid, double* v, int ldv, int* ipntr, double* workd, double* workl);
 void ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork);
 void ARNAUD_znaupd(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPLX_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLX_TYPE* workd, ARNAUD_CPLX_TYPE* workl, double* rwork);

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
@@ -4,31 +4,31 @@
 #include "types.h"
 
 enum ARNAUD_which {
-    which_LM = 0,    /**> want the NEV eigenvalues of largest magnitude. */
-    which_SM = 1,    /**> want the NEV eigenvalues of smallest magnitude. */
-    which_LR = 2,    /**> want the NEV eigenvalues of largest real part. */
-    which_SR = 3,    /**> want the NEV eigenvalues of smallest real part. */
-    which_LI = 4,    /**> want the NEV eigenvalues of largest imaginary part. */
-    which_SI = 5,    /**> want the NEV eigenvalues of smallest imaginary part. */
-    which_LA = 6,    /**> compute the NEV largest (algebraic) eigenvalues. (sym) */
-    which_SA = 7,    /**> compute the NEV smallest (algebraic) eigenvalues. (sym) */
-    which_BE = 8     /**> compute NEV eigenvalues, half from each end of the spectrum. (sym) */
+    which_LM = 0,    /** want the NEV eigenvalues of largest magnitude.                      */
+    which_SM = 1,    /** want the NEV eigenvalues of smallest magnitude.                     */
+    which_LR = 2,    /** want the NEV eigenvalues of largest real part.                      */
+    which_SR = 3,    /** want the NEV eigenvalues of smallest real part.                     */
+    which_LI = 4,    /** want the NEV eigenvalues of largest imaginary part.                 */
+    which_SI = 5,    /** want the NEV eigenvalues of smallest imaginary part.                */
+    which_LA = 6,    /** compute the NEV largest (algebraic) eigenvalues. (sym)              */
+    which_SA = 7,    /** compute the NEV smallest (algebraic) eigenvalues. (sym)             */
+    which_BE = 8     /** compute NEV eigenvalues, half from each end of the spectrum. (sym)  */
 };
 
 /**
  * @enum ARNAUD_ido
- * @brief Iteration control for reverse communication interface.
+ * @brief Flow control for reverse communication interface.
  *
  * Used to indicate the action required by the calling program.
  */
 enum ARNAUD_ido {
-    ido_FIRST      = 0,  /**< First call */
-    ido_OPX        = 1,  /**< OP*x needed */
-    ido_BX         = 2,  /**< B*x needed */
-    ido_USER_SHIFT = 3,  /**< User shifts are needed */
-    ido_RANDOM     = 4,  /**< A random vector is needed to be written in resid */
-    ido_RANDOM_OPX = 5,  /**< Force random vector to be in the range of OP */
-    ido_DONE       = 99  /**< Done */
+    ido_FIRST      = 0,  /** First call                                        */
+    ido_OPX        = 1,  /** OP*x needed                                       */
+    ido_BX         = 2,  /** B*x needed                                        */
+    ido_USER_SHIFT = 3,  /** User shifts are needed                            */
+    ido_RANDOM     = 4,  /** A random vector is needed to be written in resid  */
+    ido_RANDOM_OPX = 5,  /** Force random vector to be in the range of OP      */
+    ido_DONE       = 99  /** Done                                              */
 };
 
 
@@ -42,50 +42,50 @@ enum ARNAUD_ido {
  * in the original Fortran ARPACK code, ensuring reentrancy and
  * thread-safety.
  *
- * Members are grouped by their usage in different algorithmic phases.
+ * Members are grouped by their usage in different parts of the program.
  */
 struct ARNAUD_state_s {
-    float tol;               // problem parameter                input parameter
-    float getv0_rnorm0;      // getv0 internal compute           internal
-    float aitr_betaj;        // naitr internal compute           internal
-    float aitr_rnorm1;       // naitr internal compute           internal
-    float aitr_wnorm;        // naitr internal compute           internal
-    float aup2_rnorm;        // naup2 internal compute           internal
-    enum ARNAUD_which which; // naupd flow control               input
-    enum ARNAUD_ido ido;     // naupd flow control               input/output
-    int info;                // problem outcome,                 input/output
-    int bmat;                // problem parameter, boolean       input
-    int mode;                // problem parameter,               input
-    int n;                   // problem parameter,               input
-    int ncv;                 // problem parameter,               input
-    int nev;                 // problem parameter,               input
-    int shift;               // problem parameter, boolean       input
-    int maxiter;             // problem parameter,               input
-    int nconv;               // problem outcome,                 output
-    int iter;                // problem intermediate,            internal
-    int np;                  // problem intermediate,            internal
-    int getv0_first;         // getv0 flow control               internal
-    int getv0_iter;          // getv0 flow control               internal
-    int getv0_itry;          // getv0 flow control               internal
-    int getv0_orth;          // getv0 flow control               internal
-    int aitr_iter;           // naitr flow control               internal
-    int aitr_j;              // naitr flow control               internal
-    int aitr_orth1;          // naitr flow control               internal
-    int aitr_orth2;          // naitr flow control               internal
-    int aitr_restart;        // naitr flow control               internal
-    int aitr_step3;          // naitr flow control               internal
-    int aitr_step4;          // naitr flow control               internal
-    int aitr_ierr;           // naitr flow control               internal
-    int aup2_initv;          // naupd2 flow control              internal
-    int aup2_iter;           // naupd2 flow control              internal
-    int aup2_getv0;          // naupd2 flow control              internal
-    int aup2_cnorm;          // naupd2 flow control              internal
-    int aup2_kplusp;         // naupd2 flow control              internal
-    int aup2_nev0;           // naupd2 internal compute          internal
-    int aup2_np0;            // naupd2 internal compute          internal
-    int aup2_numcnv;         // naupd2 internal compute          internal
-    int aup2_update;         // naupd2 flow control              internal
-    int aup2_ushift;         // naupd2 flow control              internal
+    float tol;               /** problem parameter                input parameter       */
+    float getv0_rnorm0;      /** getv0 internal compute           internal              */
+    float aitr_betaj;        /** naitr internal compute           internal              */
+    float aitr_rnorm1;       /** naitr internal compute           internal              */
+    float aitr_wnorm;        /** naitr internal compute           internal              */
+    float aup2_rnorm;        /** naup2 internal compute           internal              */
+    enum ARNAUD_which which; /** naupd flow control               input                 */
+    enum ARNAUD_ido ido;     /** naupd flow control               input/output          */
+    int info;                /** problem outcome,                 input/output          */
+    int bmat;                /** problem parameter, boolean       input                 */
+    int mode;                /** problem parameter,               input                 */
+    int n;                   /** problem parameter,               input                 */
+    int ncv;                 /** problem parameter,               input                 */
+    int nev;                 /** problem parameter,               input                 */
+    int shift;               /** problem parameter, boolean       input                 */
+    int maxiter;             /** problem parameter,               input                 */
+    int nconv;               /** problem outcome,                 output                */
+    int iter;                /** problem intermediate,            internal              */
+    int np;                  /** problem intermediate,            internal              */
+    int getv0_first;         /** getv0 flow control               internal              */
+    int getv0_iter;          /** getv0 flow control               internal              */
+    int getv0_itry;          /** getv0 flow control               internal              */
+    int getv0_orth;          /** getv0 flow control               internal              */
+    int aitr_iter;           /** naitr flow control               internal              */
+    int aitr_j;              /** naitr flow control               internal              */
+    int aitr_orth1;          /** naitr flow control               internal              */
+    int aitr_orth2;          /** naitr flow control               internal              */
+    int aitr_restart;        /** naitr flow control               internal              */
+    int aitr_step3;          /** naitr flow control               internal              */
+    int aitr_step4;          /** naitr flow control               internal              */
+    int aitr_ierr;           /** naitr flow control               internal              */
+    int aup2_initv;          /** naupd2 flow control              internal              */
+    int aup2_iter;           /** naupd2 flow control              internal              */
+    int aup2_getv0;          /** naupd2 flow control              internal              */
+    int aup2_cnorm;          /** naupd2 flow control              internal              */
+    int aup2_kplusp;         /** naupd2 flow control              internal              */
+    int aup2_nev0;           /** naupd2 internal compute          internal              */
+    int aup2_np0;            /** naupd2 internal compute          internal              */
+    int aup2_numcnv;         /** naupd2 internal compute          internal              */
+    int aup2_update;         /** naupd2 flow control              internal              */
+    int aup2_ushift;         /** naupd2 flow control              internal              */
 };
 
 /**
@@ -98,70 +98,274 @@ struct ARNAUD_state_s {
  * in the original Fortran ARPACK code, ensuring reentrancy and
  * thread-safety.
  *
- * Members are grouped by their usage in different algorithmic phases.
+ * Members are grouped by their usage in different parts of the program.
  */
 struct ARNAUD_state_d {
-    double tol;              // problem parameter                input parameter
-    double getv0_rnorm0;     // getv0 internal compute           internal
-    double aitr_betaj;       // naitr internal compute           internal
-    double aitr_rnorm1;      // naitr internal compute           internal
-    double aitr_wnorm;       // naitr internal compute           internal
-    double aup2_rnorm;       // naup2 internal compute           internal
-    enum ARNAUD_which which; // naupd flow control               input
-    enum ARNAUD_ido ido;     // naupd flow control               input/output
-    int info;                // problem outcome,                 input/output
-    int bmat;                // problem parameter, boolean       input
-    int mode;                // problem parameter,               input
-    int n;                   // problem parameter,               input
-    int ncv;                 // problem parameter,               input
-    int nev;                 // problem parameter,               input
-    int shift;               // problem parameter, boolean       input
-    int maxiter;             // problem parameter,               input
-    int nconv;               // problem outcome,                 output
-    int iter;                // problem intermediate,            internal
-    int np;                  // problem intermediate,            internal
-    int getv0_first;         // getv0 flow control               internal
-    int getv0_iter;          // getv0 flow control               internal
-    int getv0_itry;          // getv0 flow control               internal
-    int getv0_orth;          // getv0 flow control               internal
-    int aitr_iter;           // naitr flow control               internal
-    int aitr_j;              // naitr flow control               internal
-    int aitr_orth1;          // naitr flow control               internal
-    int aitr_orth2;          // naitr flow control               internal
-    int aitr_restart;        // naitr flow control               internal
-    int aitr_step3;          // naitr flow control               internal
-    int aitr_step4;          // naitr flow control               internal
-    int aitr_ierr;           // naitr flow control               internal
-    int aup2_initv;          // naupd2 flow control              internal
-    int aup2_iter;           // naupd2 flow control              internal
-    int aup2_getv0;          // naupd2 flow control              internal
-    int aup2_cnorm;          // naupd2 flow control              internal
-    int aup2_kplusp;         // naupd2 flow control              internal
-    int aup2_nev0;           // naupd2 internal compute          internal
-    int aup2_np0;            // naupd2 internal compute          internal
-    int aup2_numcnv;         // naupd2 internal compute          internal
-    int aup2_update;         // naupd2 flow control              internal
-    int aup2_ushift;         // naupd2 flow control              internal
+    double tol;              /** problem parameter                input parameter       */
+    double getv0_rnorm0;     /** getv0 internal compute           internal              */
+    double aitr_betaj;       /** naitr internal compute           internal              */
+    double aitr_rnorm1;      /** naitr internal compute           internal              */
+    double aitr_wnorm;       /** naitr internal compute           internal              */
+    double aup2_rnorm;       /** naup2 internal compute           internal              */
+    enum ARNAUD_which which; /** naupd flow control               input                 */
+    enum ARNAUD_ido ido;     /** naupd flow control               input/output          */
+    int info;                /** problem outcome,                 input/output          */
+    int bmat;                /** problem parameter, boolean       input                 */
+    int mode;                /** problem parameter,               input                 */
+    int n;                   /** problem parameter,               input                 */
+    int ncv;                 /** problem parameter,               input                 */
+    int nev;                 /** problem parameter,               input                 */
+    int shift;               /** problem parameter, boolean       input                 */
+    int maxiter;             /** problem parameter,               input                 */
+    int nconv;               /** problem outcome,                 output                */
+    int iter;                /** problem intermediate,            internal              */
+    int np;                  /** problem intermediate,            internal              */
+    int getv0_first;         /** getv0 flow control               internal              */
+    int getv0_iter;          /** getv0 flow control               internal              */
+    int getv0_itry;          /** getv0 flow control               internal              */
+    int getv0_orth;          /** getv0 flow control               internal              */
+    int aitr_iter;           /** naitr flow control               internal              */
+    int aitr_j;              /** naitr flow control               internal              */
+    int aitr_orth1;          /** naitr flow control               internal              */
+    int aitr_orth2;          /** naitr flow control               internal              */
+    int aitr_restart;        /** naitr flow control               internal              */
+    int aitr_step3;          /** naitr flow control               internal              */
+    int aitr_step4;          /** naitr flow control               internal              */
+    int aitr_ierr;           /** naitr flow control               internal              */
+    int aup2_initv;          /** naupd2 flow control              internal              */
+    int aup2_iter;           /** naupd2 flow control              internal              */
+    int aup2_getv0;          /** naupd2 flow control              internal              */
+    int aup2_cnorm;          /** naupd2 flow control              internal              */
+    int aup2_kplusp;         /** naupd2 flow control              internal              */
+    int aup2_nev0;           /** naupd2 internal compute          internal              */
+    int aup2_np0;            /** naupd2 internal compute          internal              */
+    int aup2_numcnv;         /** naupd2 internal compute          internal              */
+    int aup2_update;         /** naupd2 flow control              internal              */
+    int aup2_ushift;         /** naupd2 flow control              internal              */
 };
 
 
 
+/**
+ * @brief Main reverse communication loop for solving the standard or generalized
+ *        eigenvalue problem in single precision real arithmetic.
+ *
+ * @param V        Pointer to ARNAUD_state_s struct for the solver state (input/output).
+ * @param resid    Array, float, n; (input/output). If info = 1 in the first call,
+ *                 it should contain the initial starting vector. Otherwise holds the
+ *                 residual and also used in the matvec operations.
+ * @param v        Work array, float, (ldv, ncv), holds Arnoldi basis vectors (intput/output).
+ * @param ldv      Integer, leading dimension of v (typically n), (input).
+ * @param ipntr    Integer array, 14; For communicating pointer addresses etc (input/output).
+ * @param workd    Work array, float, >= 3*n; workspace for user-supplied operations (input/output).
+ * @param workl    Work array, float, >= 3*ncv*(ncv+2); internal solver workspace (input/output).
+ */
 void ARNAUD_snaupd(struct ARNAUD_state_s *V, float* resid, float* v, int ldv, int* ipntr, float* workd, float* workl);
 
-
+/**
+ * @brief Main reverse communication loop for solving the standard or generalized
+ *        eigenvalue problem in double precision real arithmetic.
+ *
+ * @param V        Pointer to ARNAUD_state_d struct for the solver state (input/output).
+ * @param resid    Array, double, n; (input/output). If info = 1 in the first call,
+ *                 it should contain the initial starting vector. Otherwise holds the
+ *                 residual and also used in the matvec operations.
+ * @param v        Work array, double, (ldv, ncv), holds Arnoldi basis vectors (intput/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; For communicating pointer addresses etc (input/output).
+ * @param workd    Work array, double, >= 3*n; workspace for user-supplied operations (input/output).
+ * @param workl    Work array, double, >= 3*ncv*(ncv+2); internal solver workspace (input/output).
+ */
 void ARNAUD_dnaupd(struct ARNAUD_state_d *V, double* resid, double* v, int ldv, int* ipntr, double* workd, double* workl);
+
+/**
+ * @brief Main reverse communication loop for solving the standard or generalized
+ *        eigenvalue problem in single precision complex arithmetic.
+ *
+ * @param V        Pointer to ARNAUD_state_s struct for the solver state (input/output).
+ * @param resid    Array, float complex, n; (input/output). If info = 1 in the first call,
+ *                 it should contain the initial starting vector. Otherwise holds the
+ *                 residual and also used in the matvec operations.
+ * @param v        Work array, float complex, (ldv, ncv), holds Arnoldi basis vectors (intput/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; For communicating pointer addresses etc (input/output).
+ * @param workd    Work array, float complex, >= 3*n; workspace for user-supplied operations (input/output).
+ * @param workl    Work array, float complex, >= 3*ncv*(ncv+2); internal solver workspace (input/output).
+ * @param rwork    Work array, float, >= 3*ncv; additional workspace for real valued computations (input/output).
+ */
 void ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork);
+
+/**
+ * @brief Main reverse communication loop for solving the standard or generalized
+ *        eigenvalue problem in double precision complex arithmetic.
+ *
+ * @param V        Pointer to ARNAUD_state_s struct for the solver state (input/output).
+ * @param resid    Array, double complex, n; (input/output). If info = 1 in the first call,
+ *                 it should contain the initial starting vector. Otherwise holds the
+ *                 residual and also used in the matvec operations.
+ * @param v        Work array, double complex, (ldv, ncv), holds Arnoldi basis vectors (intput/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; For communicating pointer addresses etc (input/output).
+ * @param workd    Work array, double complex, >= 3*n; workspace for user-supplied operations (input/output).
+ * @param workl    Work array, double complex, >= 3*ncv*(ncv+2); internal solver workspace (input/output).
+ * @param rwork    Work array, double, >= 3*ncv; additional workspace for real valued computations (input/output).
+ */
 void ARNAUD_znaupd(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPLX_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLX_TYPE* workd, ARNAUD_CPLX_TYPE* workl, double* rwork);
 
+/**
+ * @brief Computes the eigenvalues and eigenvectors of the matrix in single precision.
+ *
+ * @param V        Pointer to ARNAUD_state_s struct for the solver state (input/output).
+ * @param rvec     Integer, whether to compute eigenvectors (1) or not (0).
+ * @param howmny   Integer, which eigenvalues to compute, All (0), Select the ones with select array parameter (1) (input).
+ * @param select   Integer array, ncv; used as a boolean array for selecting which eigenvalues to compute (input).
+ * @param dr       Array, float, ncv; real parts of the computed eigenvalues (output).
+ * @param di       Array, float, ncv; imaginary parts of the computed eigenvalues (output).
+ * @param z        Work array, float, (ldz, ncv); holds the computed eigenvectors (output).
+ * @param ldz      Integer, leading dimension of z (must be at least n), (input).
+ * @param sigmar   Float, real part of the shift value (input).
+ * @param sigmai   Float, imaginary part of the shift value (input).
+ * @param workev   Work array, float, 3*ncv; used for storing intermediate results.
+ * @param resid    Array, float, n; residual vector obtained from snaupd (input).
+ * @param v        Work array, float, (ldv, ncv); holds Arnoldi basis vectors obtained from snaupd (input/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; must hold the result from snaupd (input/output).
+ * @param workd    Work array, float, >= 3*n; workspace (input).
+ * @param workl    Work array, float, >= 3*ncv*(ncv+2); holds the results of snaupd (input/output).
+ */
 void ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select, float* dr, float* di, float* z, int ldz, float sigmar, float sigmai, float* workev, float* resid, float* v, int ldv, int* ipntr, float* workd, float* workl);
+
+/**
+ * @brief Computes the eigenvalues and eigenvectors of the matrix in double precision.
+ *
+ * @param V        Pointer to ARNAUD_state_d struct for the solver state (input/output).
+ * @param rvec     Integer, whether to compute eigenvectors (1) or not (0).
+ * @param howmny   Integer, which eigenvalues to compute, All (0), Select the ones with select array parameter (1) (input).
+ * @param select   Integer array, ncv; used as a boolean array for selecting which eigenvalues to compute (input).
+ * @param dr       Array, double, ncv; real parts of the computed eigenvalues (output).
+ * @param di       Array, double, ncv; imaginary parts of the computed eigenvalues (output).
+ * @param z        Work array, double, (ldz, ncv); holds the computed eigenvectors (output).
+ * @param ldz      Integer, leading dimension of z (must be at least n), (input).
+ * @param sigmar   Float, real part of the shift value (input).
+ * @param sigmai   Float, imaginary part of the shift value (input).
+ * @param workev   Work array, double, 3*ncv; used for storing intermediate results.
+ * @param resid    Array, double, n; residual vector obtained from dnaupd (input).
+ * @param v        Work array, double, (ldv, ncv); holds Arnoldi basis vectors obtained from dnaupd (input/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; must hold the result from dnaupd (input/output).
+ * @param workd    Work array, double, >= 3*n; workspace (input).
+ * @param workl    Work array, double, >= 3*ncv*(ncv+2); holds the results of dnaupd (input/output).
+ */
 void ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select, double* dr, double* di, double* z, int ldz, double sigmar, double sigmai, double* workev, double* resid, double* v, int ldv, int* ipntr, double* workd, double* workl);
+
+/**
+ * @brief Computes the eigenvalues and eigenvectors of the matrix in single precision complex arithmetic.
+ *
+ * @param V        Pointer to ARNAUD_state_s struct for the solver state (input/output).
+ * @param rvec     Integer, whether to compute eigenvectors (1) or not (0).
+ * @param howmny   Integer, which eigenvalues to compute, All (0), Select the ones with select array parameter (1) (input).
+ * @param select   Integer array, ncv; used as a boolean array for selecting which eigenvalues to compute (input).
+ * @param d        Array, float complex, ncv; computed eigenvalues (output).
+ * @param z        Work array, float complex, (ldz, ncv); holds the computed eigenvectors (output).
+ * @param ldz      Integer, leading dimension of z (must be at least n), (input).
+ * @param sigma    Float complex, shift value (input).
+ * @param workev   Work array, float complex, 3*ncv; used for storing intermediate results (input/output).
+ * @param resid    Array, float complex, n; residual vector obtained from cnaupd (input).
+ * @param v        Work array, float complex, (ldv, ncv); holds Arnoldi basis vectors obtained from cnaupd (input/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; must hold the result from cnaupd (input/output).
+ * @param workd    Work array, float complex, >= 3*n; workspace (input).
+ * @param workl    Work array, float complex, >= 3*ncv*(ncv+2); holds the results of cnaupd (input/output).
+ * @param rwork    Work array, float, >= 3*ncv; additional workspace for real valued computations (input/output).
+ */
 void ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select, ARNAUD_CPLXF_TYPE* d, ARNAUD_CPLXF_TYPE* z, int ldz, ARNAUD_CPLXF_TYPE sigma, ARNAUD_CPLXF_TYPE* workev, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork);
+
+/**
+ * @brief Computes the eigenvalues and eigenvectors of the matrix in double precision complex arithmetic.
+ *
+ * @param V        Pointer to ARNAUD_state_d struct for the solver state (input/output).
+ * @param rvec     Integer, whether to compute eigenvectors (1) or not (0).
+ * @param howmny   Integer, which eigenvalues to compute, All (0), Select the ones with select array parameter (1) (input).
+ * @param select   Integer array, ncv; used as a boolean array for selecting which eigenvalues to compute (input).
+ * @param d        Array, double complex, ncv; computed eigenvalues (output).
+ * @param z        Work array, double complex, (ldz, ncv); holds the computed eigenvectors (output).
+ * @param ldz      Integer, leading dimension of z (must be at least n), (input).
+ * @param sigma    Double complex, shift value (input).
+ * @param workev   Work array, double complex, 3*ncv; used for storing intermediate results (input/output).
+ * @param resid    Array, double complex, n; residual vector obtained from znaupd (input).
+ * @param v        Work array, double complex, (ldv, ncv); holds Arnoldi basis vectors obtained from znaupd (input/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; must hold the result from znaupd (input/output).
+ * @param workd    Work array, double complex, >= 3*n; workspace (input).
+ * @param workl    Work array, double complex, >= 3*ncv*(ncv+2); holds the results of znaupd (input/output).
+ * @param rwork    Work array, float, >= 3*ncv; additional workspace for real valued computations (input/output).
+ */
 void ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select, ARNAUD_CPLX_TYPE* d, ARNAUD_CPLX_TYPE* z, int ldz, ARNAUD_CPLX_TYPE sigma, ARNAUD_CPLX_TYPE* workev, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPLX_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLX_TYPE* workd, ARNAUD_CPLX_TYPE* workl, double* rwork);
 
+/**
+ * @brief Computes the eigenvalues and eigenvectors of the symmetric matrix in single precision.
+ *
+ * @param V        Pointer to ARNAUD_state_s struct for the solver state (input/output).
+ * @param resid    Array, float, n; residual vector obtained from snaupd (input).
+ * @param v        Work array, float, (ldv, ncv); holds Arnoldi basis vectors obtained from snaupd (input/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; must hold the result from snaupd (input/output).
+ * @param workd    Work array, float, >= 3*n; workspace (input/output).
+ * @param workl    Work array, float, >= ncv*(ncv+8); holds the results of snaupd (input/output).
+ */
 void ARNAUD_ssaupd(struct ARNAUD_state_s *V, float* resid, float* v, int ldv, int* ipntr, float* workd, float* workl);
+
+/**
+ * @brief Computes the eigenvalues and eigenvectors of the symmetric matrix in double precision.
+ *
+ * @param V        Pointer to ARNAUD_state_d struct for the solver state (input/output).
+ * @param resid    Array, double, n; residual vector obtained from dnaupd (input).
+ * @param v        Work array, double, (ldv, ncv); holds Arnoldi basis vectors obtained from dnaupd (input/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; must hold the result from dnaupd (input/output).
+ * @param workd    Work array, double, >= 3*n; workspace (input/output).
+ * @param workl    Work array, double, >= ncv*(ncv+8); holds the results of dnaupd (input/output).
+ */
 void ARNAUD_dsaupd(struct ARNAUD_state_d *V, double* resid, double* v, int ldv, int* ipntr, double* workd, double* workl);
 
+/**
+ * @brief Computes the eigenvalues and eigenvectors of the symmetric matrix in single precision arithmetic.
+ *
+ * @param V        Pointer to ARNAUD_state_s struct for the solver state (input/output).
+ * @param rvec     Integer, whether to compute eigenvectors (1) or not (0).
+ * @param howmny   Integer, which eigenvalues to compute, All (0), Select the ones with select array parameter (1) (input).
+ * @param select   Integer array, ncv; used as a boolean array for selecting which eigenvalues to compute (input).
+ * @param d        Array, float complex, ncv; computed eigenvalues (output).
+ * @param z        Work array, float complex, (ldz, ncv); holds the computed eigenvectors (output).
+ * @param ldz      Integer, leading dimension of z (must be at least n), (input).
+ * @param sigma    Float complex, shift value (input).
+ * @param resid    Array, float complex, n; residual vector obtained from ssaupd (input).
+ * @param v        Work array, float complex, (ldv, ncv); holds Arnoldi basis vectors obtained from ssaupd (input/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; must hold the result from ssaupd (input/output).
+ * @param workd    Work array, float complex, >= 3*n; workspace (input).
+ * @param workl    Work array, float complex, >= 3*ncv*(ncv+2); holds the results of ssaupd (input/output).
+ */
 void ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select, float* d, float* z, int ldz, float sigma, float* resid, float* v, int ldv, int* ipntr, float* workd, float* workl);
+
+/**
+ * @brief Computes the eigenvalues and eigenvectors of the symmetric matrix in double precision arithmetic.
+ *
+ * @param V        Pointer to ARNAUD_state_d struct for the solver state (input/output).
+ * @param rvec     Integer, whether to compute eigenvectors (1) or not (0).
+ * @param howmny   Integer, which eigenvalues to compute, All (0), Select the ones with select array parameter (1) (input).
+ * @param select   Integer, ncv; used as a boolean array for selecting which eigenvalues to compute (input).
+ * @param d        Array, double complex, ncv; computed eigenvalues (output).
+ * @param z        Work array, double complex, (ldz, ncv); holds the computed eigenvectors (output).
+ * @param ldz      Integer, leading dimension of z (must be at least n), (input).
+ * @param sigma    Double complex, shift value (input).
+ * @param resid    Array, double complex, n; residual vector obtained from dsaupd (input).
+ * @param v        Work array, double complex, (ldv, ncv); holds Arnoldi basis vectors obtained from dsaupd (input/output).
+ * @param ldv      Integer, leading dimension of v (must be at least n), (input).
+ * @param ipntr    Integer array, 14; must hold the result from dsaupd (input/output).
+ * @param workd    Work array, double complex, >= 3*n; workspace (input).
+ * @param workl    Work array, double complex, >= 3*ncv*(ncv+2); holds the results of dsaupd (input/output).
+ */
 void ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select, double* d, double* z, int ldz, double sigma, double* resid, double* v, int ldv, int* ipntr, double* workd, double* workl);
 
-#endif /* ifndef */
+#endif

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/types.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/types.h
@@ -1,0 +1,23 @@
+#ifndef ARNAUD_TYPES_H
+#define ARNAUD_TYPES_H
+
+#include <stdint.h>
+#include <complex.h>
+
+
+#if defined(_MSC_VER)
+    // MSVC definition
+    typedef _Fcomplex ARNAUD_CPLXF_TYPE;
+    typedef _Dcomplex ARNAUD_CPLX_TYPE;
+    #define ARNAUD_cplxf(real, imag) ((_Fcomplex){real, imag})
+    #define ARNAUD_cplx(real, imag) ((_Dcomplex){real, imag})
+#else
+    // C99 compliant compilers
+    typedef float complex ARNAUD_CPLXF_TYPE;
+    typedef double complex ARNAUD_CPLX_TYPE;
+    #define ARNAUD_cplxf(real, imag) ((real) + (imag)*I)
+    #define ARNAUD_cplx(real, imag) ((real) + (imag)*I)
+#endif
+
+
+#endif

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double.c
@@ -477,17 +477,17 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         {
             if ((workl[iheigi+j] == 0.0) && (workl[iheigr+j] != 0.0))
             {
-                workev[j] = workl[invsub + j*ldq + V->ncv] / workl[iheigr+j];
+                workev[j] = workl[invsub + j*ldq + V->ncv - 1] / workl[iheigr+j];
             } else if (iconj == 0) {
 
                 temp = hypot(workl[iheigr+j], workl[iheigi+j]);
                 if (temp != 0.0)
                 {
-                    workev[j] = (workl[invsub + j*ldq + V->ncv]*workl[iheigr+j] +
-                                 workl[invsub + (j+1)*ldq + V->ncv]*workl[iheigi+j]
+                    workev[j] = (workl[invsub + j*ldq + V->ncv - 1]*workl[iheigr+j] +
+                                 workl[invsub + (j+1)*ldq + V->ncv - 1]*workl[iheigi+j]
                                 ) / temp / temp;
-                    workev[j+1] = (workl[invsub + (j+1)*ldq + V->ncv]*workl[iheigr+j] -
-                                 workl[invsub + j*ldq + V->ncv]*workl[iheigi+j]
+                    workev[j+1] = (workl[invsub + (j+1)*ldq + V->ncv - 1]*workl[iheigr+j] -
+                                 workl[invsub + j*ldq + V->ncv - 1]*workl[iheigi+j]
                                 ) / temp / temp;
                 }
                 iconj = 1;
@@ -1997,10 +1997,11 @@ LINE40:
     return;
 }
 
-void
+
+static void
 dsortc(const enum ARNAUD_which w, const int apply, const int n, double* xreal, double* ximag, double* y)
 {
-    int i, igap, j;
+    int i, gap, pos;
     double temp;
     ARNAUD_compare_cfunc *f;
 
@@ -2029,36 +2030,35 @@ dsortc(const enum ARNAUD_which w, const int apply, const int n, double* xreal, d
             break;
     }
 
-    igap = n / 2;
+    gap = n / 2;
 
-    while (igap != 0)
+    while (gap != 0)
     {
-        j = 0;
-        for (i = igap; i < n; i++)
+        for (i = gap; i < n; i++)
         {
-            while (f(xreal[j], ximag[j], xreal[j+igap], ximag[j+igap]))
+            pos = i - gap;
+            while ((pos >= 0) && (f(xreal[pos], ximag[pos], xreal[pos+gap], ximag[pos+gap])))
             {
-                if (j < 0) { break; }
-                temp = xreal[j];
-                xreal[j] = xreal[j+igap];
-                xreal[j+igap] = temp;
-                temp = ximag[j];
-                ximag[j] = ximag[j+igap];
-                ximag[j+igap] = temp;
+                temp = xreal[pos];
+                xreal[pos] = xreal[pos+gap];
+                xreal[pos+gap] = temp;
+                temp = ximag[pos];
+                ximag[pos] = ximag[pos+gap];
+                ximag[pos+gap] = temp;
 
                 if (apply)
                 {
-                    temp = y[j];
-                    y[j] = y[j+igap];
-                    y[j+igap] = temp;
+                    temp = y[pos];
+                    y[pos] = y[pos+gap];
+                    y[pos+gap] = temp;
                 }
-                j -= igap;
+                pos -= gap;
             }
-            j = i - igap + 1;
         }
-        igap = igap / 2;
+        gap = gap / 2;
     }
 }
+
 
 // The void casts are to avoid compiler warnings for unused parameters
 int

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double.h
@@ -1,6 +1,7 @@
 #ifndef ARNAUD_N_DOUBLE_H
 #define ARNAUD_N_DOUBLE_H
 
+#include <math.h>
 #include "arnaud/arnaud.h"
 #include "blaslapack_declarations.h"
 

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double_complex.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double_complex.h
@@ -1,20 +1,8 @@
 #ifndef ARNAUD_N_DOUBLE_COMPLEX_H
 #define ARNAUD_N_DOUBLE_COMPLEX_H
 
+#include <math.h>
 #include "arnaud/arnaud.h"
 #include "blaslapack_declarations.h"
-#include <complex.h>
-
-#if defined(_MSC_VER)
-    // MSVC definitions
-    typedef _Dcomplex ARNAUD_CPLX_TYPE;
-    #define ARNAUD_cplx(real, imag) ((_Dcomplex){real, imag})
-
-#else
-    // C99 compliant compilers
-    typedef double complex ARNAUD_CPLX_TYPE;
-    #define ARNAUD_cplx(real, imag) ((real) + (imag)*I)
-
-#endif
 
 #endif

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
@@ -477,17 +477,17 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         {
             if ((workl[iheigi+j] == 0.0) && (workl[iheigr+j] != 0.0))
             {
-                workev[j] = workl[invsub + j*ldq + V->ncv] / workl[iheigr+j];
+                workev[j] = workl[invsub + j*ldq + V->ncv - 1] / workl[iheigr+j];
             } else if (iconj == 0) {
 
                 temp = hypotf(workl[iheigr+j], workl[iheigi+j]);
                 if (temp != 0.0)
                 {
-                    workev[j] = (workl[invsub + j*ldq + V->ncv]*workl[iheigr+j] +
-                                 workl[invsub + (j+1)*ldq + V->ncv]*workl[iheigi+j]
+                    workev[j] = (workl[invsub + j*ldq + V->ncv - 1]*workl[iheigr+j] +
+                                 workl[invsub + (j+1)*ldq + V->ncv - 1]*workl[iheigi+j]
                                 ) / temp / temp;
-                    workev[j+1] = (workl[invsub + (j+1)*ldq + V->ncv]*workl[iheigr+j] -
-                                 workl[invsub + j*ldq + V->ncv]*workl[iheigi+j]
+                    workev[j+1] = (workl[invsub + (j+1)*ldq + V->ncv - 1]*workl[iheigr+j] -
+                                 workl[invsub + j*ldq + V->ncv - 1]*workl[iheigi+j]
                                 ) / temp / temp;
                 }
                 iconj = 1;
@@ -1997,10 +1997,11 @@ LINE40:
     return;
 }
 
-void
+
+static void
 ssortc(const enum ARNAUD_which w, const int apply, const int n, float* xreal, float* ximag, float* y)
 {
-    int i, igap, j;
+    int i, gap, pos;
     float temp;
     ARNAUD_compare_cfunc *f;
 
@@ -2029,36 +2030,35 @@ ssortc(const enum ARNAUD_which w, const int apply, const int n, float* xreal, fl
             break;
     }
 
-    igap = n / 2;
+    gap = n / 2;
 
-    while (igap != 0)
+    while (gap != 0)
     {
-        j = 0;
-        for (i = igap; i < n; i++)
+        for (i = gap; i < n; i++)
         {
-            while (f(xreal[j], ximag[j], xreal[j+igap], ximag[j+igap]))
+            pos = i - gap;
+            while ((pos >= 0) && (f(xreal[pos], ximag[pos], xreal[pos+gap], ximag[pos+gap])))
             {
-                if (j < 0) { break; }
-                temp = xreal[j];
-                xreal[j] = xreal[j+igap];
-                xreal[j+igap] = temp;
-                temp = ximag[j];
-                ximag[j] = ximag[j+igap];
-                ximag[j+igap] = temp;
+                temp = xreal[pos];
+                xreal[pos] = xreal[pos+gap];
+                xreal[pos+gap] = temp;
+                temp = ximag[pos];
+                ximag[pos] = ximag[pos+gap];
+                ximag[pos+gap] = temp;
 
                 if (apply)
                 {
-                    temp = y[j];
-                    y[j] = y[j+igap];
-                    y[j+igap] = temp;
+                    temp = y[pos];
+                    y[pos] = y[pos+gap];
+                    y[pos+gap] = temp;
                 }
-                j -= igap;
+                pos -= gap;
             }
-            j = i - igap + 1;
         }
-        igap = igap / 2;
+        gap = gap / 2;
     }
 }
+
 
 // The void casts are to avoid compiler warnings for unused parameters
 int

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
@@ -37,13 +37,13 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
        float* workev, float* resid, float* v, int ldv, int* ipntr, float* workd,
        float* workl)
 {
-    const float eps23 = powf(ulp, 2.0 / 3.0);
+    const float eps23 = powf(ulp, 2.0f / 3.0f);
     int ibd, iconj, ih, iheigr, iheigi, ihbds, iuptri, invsub, iri, irr, j, jj;
     int bounds, k, ldh, ldq, np, numcnv, reord, ritzr, ritzi;
     int iwork[1] = { 0 };
     int ierr = 0, int1 = 1, tmp_int = 0, nconv2 = 0, outncv;
-    float conds, rnorm, sep, temp, temp1, dbl0 = 0.0, dbl1 = 1.0, dblm1 = -1.0;
-    float vl[1] = { 0.0 };
+    float conds, rnorm, sep, temp, temp1, dbl0 = 0.0f, dbl1 = 1.0f, dblm1 = -1.0f;
+    float vl[1] = { 0.0f };
     enum ARNAUD_neupd_type TYP;
 
     if (V->nconv <= 0) {
@@ -66,7 +66,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
     if ((V->mode == 1) || (V->mode == 2)) {
         TYP = REGULAR;
-    } else if ((V->mode == 3) && (sigmai == 0.0)) {
+    } else if ((V->mode == 3) && (sigmai == 0.0f)) {
         TYP = SHIFTI;
     } else if (V->mode == 3) {
         TYP = REALPART;
@@ -132,7 +132,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
     //  RNORM is B-norm of the RESID(1:N).
     rnorm = workl[ih+2];
-    workl[ih+2] = 0.0;
+    workl[ih+2] = 0.0f;
 
     if (rvec) {
         reord = 0;
@@ -142,7 +142,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
         for (j = 0; j < V->ncv; j++)
         {
-            workl[bounds + j] = j;
+            workl[bounds + j] = j*1.0f;
             select[j] = 0;
         }
         // 10
@@ -265,7 +265,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
         for (j = 0; j < V->nconv; j++)
         {
-            if (workl[invsub + j*ldq + j] < 0.0)
+            if (workl[invsub + j*ldq + j] < 0.0f)
             {
                 sscal_(&V->nconv, &dblm1, &workl[iuptri + j], &ldq);
                 sscal_(&V->nconv, &dblm1, &workl[iuptri + j*ldq], &int1);
@@ -308,12 +308,12 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             iconj = 0;
             for (j = 0; j < V->nconv; j++)
             {
-                if (workl[iheigi + j] == 0.0)
+                if (workl[iheigi + j] == 0.0f)
                 {
 
                     //  real eigenvalue case
 
-                    temp = 1.0 / snrm2_(&V->ncv, &workl[invsub + j*ldq], &int1);
+                    temp = 1.0f / snrm2_(&V->ncv, &workl[invsub + j*ldq], &int1);
                     sscal_(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
 
                 } else {
@@ -326,7 +326,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
                     if (iconj == 0)
                     {
-                        temp = 1.0 / hypotf(snrm2_(&V->ncv, &workl[invsub + j*ldq], &int1),
+                        temp = 1.0f / hypotf(snrm2_(&V->ncv, &workl[invsub + j*ldq], &int1),
                                            snrm2_(&V->ncv, &workl[invsub + (j+1)*ldq], &int1));
                         sscal_(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
                         sscal_(&V->ncv, &temp, &workl[invsub + (j+1)*ldq], &int1);
@@ -343,7 +343,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             iconj = 0;
             for (j = 0; j < V->nconv; j++)
             {
-                if (workl[iheigi + j] != 0.0)
+                if (workl[iheigi + j] != 0.0f)
                 {
 
                     //  Complex conjugate pair case. Note that
@@ -475,13 +475,13 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         iconj = 0;
         for (j = 0; j < V->nconv; j++)
         {
-            if ((workl[iheigi+j] == 0.0) && (workl[iheigr+j] != 0.0))
+            if ((workl[iheigi+j] == 0.0f) && (workl[iheigr+j] != 0.0f))
             {
                 workev[j] = workl[invsub + j*ldq + V->ncv - 1] / workl[iheigr+j];
             } else if (iconj == 0) {
 
                 temp = hypotf(workl[iheigr+j], workl[iheigi+j]);
-                if (temp != 0.0)
+                if (temp != 0.0f)
                 {
                     workev[j] = (workl[invsub + j*ldq + V->ncv - 1]*workl[iheigr+j] +
                                  workl[invsub + (j+1)*ldq + V->ncv - 1]*workl[iheigi+j]
@@ -541,14 +541,14 @@ ARNAUD_snaupd(struct ARNAUD_state_s *V, float* resid, float* v,
             return;
         }
 
-        if (V->tol <= 0.0) {
+        if (V->tol <= 0.0f) {
             V->tol = ulp;
         }
         V->np = V->ncv - V->nev;
 
         for (j = 0; j < 3 * (V->ncv)*(V->ncv) + 6*(V->ncv); j++)
         {
-            workl[j] = 0.0;
+            workl[j] = 0.0f;
         }
     }
 
@@ -612,8 +612,8 @@ snaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
 {
     enum ARNAUD_which temp_which;
     int int1 = 1, j, tmp_int;
-    const float eps23 = powf(ulp, 2.0 / 3.0);
-    float temp = 0.0;
+    const float eps23 = powf(ulp, 2.0f / 3.0f);
+    float temp = 0.0f;
 
     if (V->ido == ido_FIRST)
     {
@@ -659,7 +659,7 @@ snaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
         V->getv0_itry = 1;
         sgetv0(V, V->aup2_initv, V->n, 0, v, ldv, resid, &V->aup2_rnorm, ipntr, workd);
         if (V->ido != ido_DONE) { return; }
-        if (V->aup2_rnorm == 0.0)
+        if (V->aup2_rnorm == 0.0f)
         {
             V->info = -9;
             V->ido = ido_DONE;
@@ -798,7 +798,7 @@ LINE20:
 
     for (j = 0; j < nptemp; j++)
     {
-        if (bounds[j] == 0.0)
+        if (bounds[j] == 0.0f)
         {
             V->np -= 1;
             V->nev += 1;
@@ -1016,7 +1016,7 @@ LINE100:
 void
 snconv(int n, float* ritzr, float* ritzi, float* bounds, const float tol, int* nconv)
 {
-    const float eps23 = powf(ulp, 2.0 / 3.0);
+    const float eps23 = powf(ulp, 2.0f / 3.0f);
     float temp;
 
     *nconv = 0;
@@ -1038,7 +1038,7 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
 {
     int select[1] = { 0 };
     int i, iconj, int1 = 1, j;
-    float dbl1 = 1.0, dbl0 = 0.0, temp, tmp_dbl, vl[1] = { 0.0 };
+    float dbl1 = 1.0f, dbl0 = 0.0f, temp, tmp_dbl, vl[1] = { 0.0f };
 
     //  1. Compute the eigenvalues, the last components of the
     //     corresponding Schur vectors and the full Schur form T
@@ -1049,9 +1049,9 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
     slacpy_("A", &n, &n, h, &ldh, workl, &n);
     for (j = 0; j < n-1; j++)
     {
-        bounds[j] = 0.0;
+        bounds[j] = 0.0f;
     }
-    bounds[n-1] = 1.0;
+    bounds[n-1] = 1.0f;
     slahqr_(&int1, &int1, &n, &int1, &n, workl, &n, ritzr, ritzi, &int1, &int1, bounds, &int1, ierr);
 
     if (*ierr != 0) { return; }
@@ -1077,13 +1077,13 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
     iconj = 0;
     for (i = 0; i < n; i++)
     {
-        if (fabsf(ritzi[i]) == 0.0)
+        if (fabsf(ritzi[i]) == 0.0f)
         {
 
             //  Real eigenvalue case
 
             temp = snrm2_(&n, &q[ldq*i], &int1);
-            tmp_dbl = 1.0 / temp;
+            tmp_dbl = 1.0f / temp;
             sscal_(&n, &tmp_dbl, &q[ldq*i], &int1);
 
         } else {
@@ -1098,7 +1098,7 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
             {
                 temp = hypotf(snrm2_(&n, &q[ldq*i], &int1),
                              snrm2_(&n, &q[ldq*(i+1)], &int1));
-                tmp_dbl = 1.0 / temp;
+                tmp_dbl = 1.0f / temp;
                 sscal_(&n, &tmp_dbl, &q[ldq*i], &int1);
                 sscal_(&n, &tmp_dbl, &q[ldq*(i+1)], &int1);
                 iconj = 1;
@@ -1116,7 +1116,7 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
     iconj = 0;
     for (i = 0; i < n; i++)
     {
-        if (fabsf(ritzi[i]) == 0.0)
+        if (fabsf(ritzi[i]) == 0.0f)
         {
 
             //  Real eigenvalue case
@@ -1155,7 +1155,7 @@ snaitr(struct ARNAUD_state_s *V, int k, int np, float* resid, float* rnorm,
     const float sq2o2 = sqrtf(2.0) / 2.0;
 
     int int1 = 1;
-    float dbl1 = 1.0, dbl0 = 0.0, dblm1 = -1.0, temp1, tst1;
+    float dbl1 = 1.0f, dbl0 = 0.0f, dblm1 = -1.0f, temp1, tst1;
 
     n = V->n;  // n is constant, this is just for typing convenience
     ipj = 0;
@@ -1206,13 +1206,13 @@ LINE1000:
 
     V->aitr_betaj = *rnorm;
 
-    if (*rnorm > 0.0) { goto LINE40; }
+    if (*rnorm > 0.0f) { goto LINE40; }
 
     //  Invariant subspace found, generate a new starting
     //  vector which is orthogonal to the current Arnoldi
     //  basis and continue the iteration.
 
-    V->aitr_betaj = 0.0;
+    V->aitr_betaj = 0.0f;
     V->getv0_itry = 1;
 
 LINE20:
@@ -1251,7 +1251,7 @@ LINE40:
     scopy_(&n, resid, &int1, &v[ldv*(V->aitr_j)], &int1);
     if (*rnorm >= unfl)
     {
-        temp1 = 1.0 / *rnorm;
+        temp1 = 1.0f / *rnorm;
         sscal_(&n, &temp1, &v[ldv*(V->aitr_j)], &int1);
         sscal_(&n, &temp1, &workd[ipj], &int1);
     } else {
@@ -1470,9 +1470,9 @@ LINE90:
 
         for (jj = 0; jj < n; jj++)
         {
-            resid[jj] = 0.0;
+            resid[jj] = 0.0f;
         }
-        *rnorm = 0.0;
+        *rnorm = 0.0f;
     }
 
     // Branch here directly if iterative refinement
@@ -1498,14 +1498,14 @@ LINE100:
             //  REFERENCE: LAPACK subroutine dlahqr
 
             tst1 = fabsf(h[i + ldh*i]) + fabsf(h[i+1 + ldh*(i+1)]);
-            if (tst1 == 0.0)
+            if (tst1 == 0.0f)
             {
                 tmp_int = k + np;
                 tst1 = slanhs_("1", &tmp_int, h, &ldh, &workd[n]);
             }
             if (fabsf(h[i+1 + ldh*i]) <= fmaxf(ulp*tst1, smlnum))
             {
-                h[i+1 + ldh*i] = 0.0;
+                h[i+1 + ldh*i] = 0.0f;
             }
         }
         // 110
@@ -1526,8 +1526,8 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
     int kplusp = *kev + np;
     float smlnum = unfl * ( n / ulp);
     float c, f, g, h11, h21, h12, h22, h32, s, sigmar, sigmai, r, t, tau, tst1;
-    float dbl1 = 1.0, dbl0 = 0.0, dblm1 = -1.0;
-    float u[3] = { 0.0 };
+    float dbl1 = 1.0f, dbl0 = 0.0f, dblm1 = -1.0f;
+    float u[3] = { 0.0f };
 
     //  Initialize Q to the identity to accumulate
     //  the rotations and reflections
@@ -1558,14 +1558,14 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
             cconj = 0;
             continue;
 
-        } else if ((jj < np - 1) && fabsf(sigmai) != 0.0) {
+        } else if ((jj < np - 1) && fabsf(sigmai) != 0.0f) {
 
             // This shift has nonzero imaginary part, so we will apply
             // together with the next one; turn on the skip flag.
 
             cconj = 1;
 
-        } else if ((jj == np - 1) && (fabsf(sigmai) != 0.0)) {
+        } else if ((jj == np - 1) && (fabsf(sigmai) != 0.0f)) {
 
             // We have one block left but the shift has nonzero imaginary part.
             // Don't apply it and reduce the number of shifts by incrementing
@@ -1589,7 +1589,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
             for (iend = istart; iend < kplusp - 1; iend++)
             {
                 tst1 = fabsf(h[iend + (iend * ldh)]) + fabsf(h[iend + 1 + (iend + 1) * ldh]);
-                if (tst1 == 0.0)
+                if (tst1 == 0.0f)
                 {
                     tmp_int = kplusp - jj;
                     tst1 = slanhs_("1", &tmp_int, h, &ldh, workl);
@@ -1603,18 +1603,18 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
             {
                 istart += 1;
                 continue;
-            } else if  ((istart + 1 == iend) && fabsf(sigmai) > 0.0) {
+            } else if  ((istart + 1 == iend) && fabsf(sigmai) > 0.0f) {
                 istart += 2;
                 continue;
             } else {
-                h[iend+1 + (iend * ldh)] = 0.0;
+                h[iend+1 + (iend * ldh)] = 0.0f;
             }
 
             // We have a block [istart, iend] inclusive.
             h11 = h[istart + istart * ldh];
             h21 = h[istart + 1 + istart * ldh];
 
-            if (fabsf(sigmai) == 0.0)
+            if (fabsf(sigmai) == 0.0f)
             {
 
                 f = h11 - sigmar;
@@ -1625,7 +1625,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
                     if (i > istart)
                     {
                         h[i + (i - 1) * ldh] = r;
-                        h[i + 1 + (i - 1) * ldh] = 0.0;
+                        h[i + 1 + (i - 1) * ldh] = 0.0f;
                     }
                     tmp_int = kplusp - i;
                     srot_(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
@@ -1660,10 +1660,10 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
                     if (i > istart)
                     {
                         h[i + (i - 1) * ldh] = u[0];
-                        h[i + 1 + (i - 1) * ldh] = 0.0;
-                        if (i < iend - 1) { h[i + 2 + (i - 1) * ldh] = 0.0; }
+                        h[i + 1 + (i - 1) * ldh] = 0.0f;
+                        if (i < iend - 1) { h[i + 2 + (i - 1) * ldh] = 0.0f; }
                     }
-                    u[0] = 1.0;
+                    u[0] = 1.0f;
 
                     tmp_int = kplusp - i;
                     slarf_("L", &nr, &tmp_int, u, &int1, &tau, &h[i + ldh*i], &ldh, workl);
@@ -1686,7 +1686,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
 
     for (j = 0; j < *kev; j++)
     {
-        if (h[j+1 + ldh*j] < 0.0)
+        if (h[j+1 + ldh*j] < 0.0f)
         {
             tmp_int = kplusp - j;
             sscal_(&tmp_int, &dblm1, &h[j+1 + ldh*j], &ldh);
@@ -1706,13 +1706,13 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
         //  REFERENCE: LAPACK subroutine dlahqr
 
         tst1 = fabsf(h[i + ldh*i]) + fabsf(h[i+1 + ldh*(i+1)]);
-        if (tst1 == 0.0)
+        if (tst1 == 0.0f)
         {
             tst1 = slanhs_("1", kev, h, &ldh, workl);
         }
         if (h[i+1 + ldh*i] <= fmaxf(ulp*tst1, smlnum))
         {
-            h[i+1 + ldh*i] = 0.0;
+            h[i+1 + ldh*i] = 0.0f;
         }
     }
     // 130
@@ -1723,7 +1723,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
     //  cannot GUARANTEE that the corresponding entry
     //  of H would be zero as in exact arithmetic.
 
-    if (h[*kev + ldh*(*kev-1)] > 0.0)
+    if (h[*kev + ldh*(*kev-1)] > 0.0f)
     {
         sgemv_("N", &n, &kplusp, &dbl1, v, &ldv, &q[(*kev)*ldq], &int1, &dbl0, &workd[n], &int1);
     }
@@ -1747,7 +1747,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
 
     //  Copy the (kev+1)-st column of (V*Q) in the appropriate place
 
-    if (h[*kev + ldh*(*kev-1)] > 0.0){
+    if (h[*kev + ldh*(*kev-1)] > 0.0f){
         scopy_(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
     }
 
@@ -1759,7 +1759,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
 
     sscal_(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
 
-    if (h[*kev + ldh*(*kev-1)] > 0.0)
+    if (h[*kev + ldh*(*kev-1)] > 0.0f)
     {
         saxpy_(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
     }
@@ -1813,7 +1813,7 @@ sngets(struct ARNAUD_state_s *V, int* kev, int* np,
     //  Accordingly decrease NP by one. In other words keep
     //  complex conjugate pairs together.
 
-    if ((ritzr[*np] - ritzr[*np-1] == 0.0) && (ritzi[*np] + ritzi[*np-1] == 0.0))
+    if ((ritzr[*np] - ritzr[*np-1] == 0.0f) && (ritzi[*np] + ritzi[*np-1] == 0.0f))
     {
         *np -= 1;
         *kev += 1;
@@ -1841,7 +1841,7 @@ sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
 {
     int jj, int1 = 1;
     const float sq2o2 = sqrtf(2.0) / 2.0;
-    float dbl1 = 1.0, dbl0 = 0.0, dblm1 = -1.0;;
+    float dbl1 = 1.0f, dbl0 = 0.0f, dblm1 = -1.0f;;
 
     if (V->ido == ido_FIRST)
     {
@@ -1987,8 +1987,8 @@ LINE40:
 
         //  Iterative refinement step "failed"
 
-        for (jj = 0; jj < n; jj++) { resid[jj] = 0.0; }
-        *rnorm = 0.0;
+        for (jj = 0; jj < n; jj++) { resid[jj] = 0.0f; }
+        *rnorm = 0.0f;
         V->info = -1;
     }
 

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.h
@@ -1,6 +1,7 @@
 #ifndef ARNAUD_N_SINGLE_H
 #define ARNAUD_N_SINGLE_H
 
+#include <math.h>
 #include "arnaud/arnaud.h"
 #include "blaslapack_declarations.h"
 

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single_complex.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single_complex.c
@@ -37,15 +37,15 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
        ARNAUD_CPLXF_TYPE* workev, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, int ldv,
        int* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork)
 {
-    const float eps23 = pow(ulp, 2.0 / 3.0);
+    const float eps23 = powf(ulp, 2.0f / 3.0f);
     int ibd, ih, iheig, ihbds, iuptri, invsub, irz, j, jj;
     int bounds, k, ldh, ldq, np, numcnv, outncv, reord, ritz;
     int ierr = 0, int1 = 1, tmp_int = 0, nconv2 = 0;
     float conds, sep, temp1, rtemp;
     ARNAUD_CPLXF_TYPE rnorm, temp;
-    ARNAUD_CPLXF_TYPE cdbl0 = ARNAUD_cplxf(0.0, 0.0);
-    ARNAUD_CPLXF_TYPE cdbl1 = ARNAUD_cplxf(1.0, 0.0);
-    ARNAUD_CPLXF_TYPE cdblm1 = ARNAUD_cplxf(-1.0, 0.0);
+    ARNAUD_CPLXF_TYPE cdbl0 = ARNAUD_cplxf(0.0f, 0.0f);
+    ARNAUD_CPLXF_TYPE cdbl1 = ARNAUD_cplxf(1.0f, 0.0f);
+    ARNAUD_CPLXF_TYPE cdblm1 = ARNAUD_cplxf(-1.0f, 0.0f);
     ARNAUD_CPLXF_TYPE vl[1] = { cdbl0 };
     enum ARNAUD_neupd_type TYP;
 
@@ -132,7 +132,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
     //  RNORM is B-norm of the RESID(1:N).
 
     rnorm = workl[ih+2];
-    workl[ih+2] = ARNAUD_cplxf(0.0, 0.0);
+    workl[ih+2] = ARNAUD_cplxf(0.0f, 0.0f);
 
     if (rvec) {
         reord = 0;
@@ -142,7 +142,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
         for (j = 0; j < V->ncv; j++)
         {
-            workl[bounds + j] = ARNAUD_cplxf(j, 0.0);
+            workl[bounds + j] = ARNAUD_cplxf(j*1.0f, 0.0f);
             select[j] = 0;
         }
         // 10
@@ -164,7 +164,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         numcnv = 0;
         for (j = 1; j <= V->ncv; j++)
         {
-            temp1 = fmax(eps23, cabsf(workl[irz + V->ncv - j]));
+            temp1 = fmaxf(eps23, cabsf(workl[irz + V->ncv - j]));
             jj = (int)crealf(workl[bounds + V->ncv - j]);
 
             if ((numcnv < V->nconv) && (cabsf(workl[ibd + jj]) <= V->tol*temp1))
@@ -264,7 +264,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             //  Note that since Q is orthogonal, R is a diagonal
             //  matrix consisting of plus or minus ones.
 
-            if (crealf(workl[invsub + j*ldq + j]) < 0.0)
+            if (crealf(workl[invsub + j*ldq + j]) < 0.0f)
             {
                 cscal_(&V->nconv, &cdblm1, &workl[iuptri + j], &ldq);
                 cscal_(&V->nconv, &cdblm1, &workl[iuptri + j*ldq], &int1);
@@ -305,7 +305,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
             for (j = 0; j < V->nconv; j++)
             {
-                rtemp = 1.0 / scnrm2_(&V->ncv, &workl[invsub + j*ldq], &int1);
+                rtemp = 1.0f / scnrm2_(&V->ncv, &workl[invsub + j*ldq], &int1);
                 csscal_(&V->ncv, &rtemp, &workl[invsub + j*ldq], &int1);
 
                 //  Ritz estimates can be obtained by taking
@@ -365,7 +365,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 #if defined(_MSC_VER)
             // Complex division is not supported in MSVC, multiply with reciprocal
             float mag_sq = powf(cabsf(workl[iheig + k]), 2.0);
-            temp = _FCmulcr(conjf(workl[iheig + k]), 1.0 / mag_sq);
+            temp = _FCmulcr(conjf(workl[iheig + k]), 1.0f / mag_sq);
             workl[ihbds + k] = _FCmulcc(_FCmulcc(workl[ihbds + k], temp), temp);
 #else
             temp = workl[iheig + k];
@@ -388,10 +388,10 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 #if defined(_MSC_VER)
             // Complex division is not supported in MSVC
             float mag_sq = powf(cabsf(workl[iheig + k]), 2.0);
-            temp = _FCmulcr(conjf(workl[iheig + k]), 1.0 / mag_sq);
+            temp = _FCmulcr(conjf(workl[iheig + k]), 1.0f / mag_sq);
             d[k] = ARNAUD_cplxf(crealf(temp) + crealf(sigma), cimagf(temp) + cimagf(sigma));
 #else
-            d[k] = 1.0 / workl[iheig + k] + sigma;
+            d[k] = 1.0f / workl[iheig + k] + sigma;
 #endif
         }
         // 60
@@ -413,12 +413,12 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
         for (j = 0; j < V->nconv; j++)
         {
-            if ((crealf(workl[iheig+j]) != 0.0) || (cimagf(workl[iheig+j]) != 0.0))
+            if ((crealf(workl[iheig+j]) != 0.0f) || (cimagf(workl[iheig+j]) != 0.0f))
             {
 #if defined(_MSC_VER)
                 // Complex division is not supported in MSVC
                 float mag_sq = powf(cabsf(workl[iheig + j]), 2.0);
-                temp = _FCmulcr(conjf(workl[iheig + j]), 1.0 / mag_sq);
+                temp = _FCmulcr(conjf(workl[iheig + j]), 1.0f / mag_sq);
                 workev[j] = _FCmulcc(workl[invsub + j*ldq + V->ncv - 1], temp);
 #else
                 workev[j] = workl[invsub + j*ldq + V->ncv - 1] / workl[iheig+j];
@@ -472,7 +472,7 @@ ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid,
             return;
         }
 
-        if (V->tol <= 0.0) {
+        if (V->tol <= 0.0f) {
             V-> tol = ulp;
         }
 
@@ -490,7 +490,7 @@ ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid,
 
         for (int j = 0; j < 3 * (V->ncv*V->ncv) + 6*V->ncv; j++)
         {
-            workl[j] = ARNAUD_cplxf(0.0, 0.0);
+            workl[j] = ARNAUD_cplxf(0.0f, 0.0f);
         }
     }
     //  Pointer into WORKL for address of H, RITZ, BOUNDS, Q
@@ -549,8 +549,8 @@ cnaup2(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid,
 {
     enum ARNAUD_which temp_which;
     int i, int1 = 1, j, tmp_int;
-    const float eps23 = pow(ulp, 2.0 / 3.0);
-    float temp = 0.0, rtemp;
+    const float eps23 = powf(ulp, 2.0f / 3.0f);
+    float temp = 0.0f, rtemp;
 
     if (V->ido == ido_FIRST)
     {
@@ -596,7 +596,7 @@ cnaup2(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid,
         V->getv0_itry = 1;
         cgetv0(V, V->aup2_initv, V->n, 0, v, ldv, resid, &V->aup2_rnorm, ipntr, workd);
         if (V->ido != ido_DONE) { return; }
-        if (V->aup2_rnorm == 0.0)
+        if (V->aup2_rnorm == 0.0f)
         {
             V->info = -9;
             V->ido = ido_DONE;
@@ -718,7 +718,7 @@ LINE20:
     V->nconv = 0;
     for (i = 0; i < V->nev; i++)
     {
-        rtemp = fmax(eps23, cabsf(ritz[V->np + i]));
+        rtemp = fmaxf(eps23, cabsf(ritz[V->np + i]));
         if (cabsf(bounds[V->np + i]) <= V->tol*rtemp)
         {
             V->nconv += 1;
@@ -739,7 +739,7 @@ LINE20:
 
     for (j = 0; j < nptemp; j++)
     {
-        if ((crealf(bounds[j]) == 0.0) && (cimagf(bounds[j]) == 0.0))
+        if ((crealf(bounds[j]) == 0.0f) && (cimagf(bounds[j]) == 0.0f))
         {
             V->np -= 1;
             V->nev += 1;
@@ -758,7 +758,7 @@ LINE20:
         //   Use h( 3,1 ) as storage to communicate
         //   rnorm to _neupd if needed
 
-         h[2] = ARNAUD_cplxf(V->aup2_rnorm, 0.0);
+         h[2] = ARNAUD_cplxf(V->aup2_rnorm, 0.0f);
 
         // Sort Ritz values so that converged Ritz
         // values appear within the first NEV locations
@@ -781,7 +781,7 @@ LINE20:
 
         for (j = 0; j < V->aup2_nev0; j++)
         {
-            temp = fmax(eps23, cabsf(ritz[j]));
+            temp = fmaxf(eps23, cabsf(ritz[j]));
             bounds[j] = ARNAUD_cplxf(crealf(bounds[j]) / temp, cimagf(bounds[j]) / temp);
         }
         // 35
@@ -799,7 +799,7 @@ LINE20:
 
         for (j = 0; j < V->aup2_nev0; j++)
         {
-            temp = fmax(eps23, cabsf(ritz[j]));
+            temp = fmaxf(eps23, cabsf(ritz[j]));
             bounds[j] = ARNAUD_cplxf(crealf(bounds[j]) * temp, cimagf(bounds[j]) * temp);
         }
         // 40
@@ -943,10 +943,10 @@ cnaitr(struct ARNAUD_state_s *V, int k, int np, ARNAUD_CPLXF_TYPE* resid,
     const float sq2o2 = sqrt(2.0) / 2.0;
 
     int int1 = 1;
-    float dbl1 = 1.0, temp1, tst1;
-    ARNAUD_CPLXF_TYPE cdbl1 = ARNAUD_cplxf(1.0, 0.0);
-    ARNAUD_CPLXF_TYPE cdblm1 = ARNAUD_cplxf(-1.0, 0.0);
-    ARNAUD_CPLXF_TYPE cdbl0 = ARNAUD_cplxf(0.0, 0.0);
+    float dbl1 = 1.0f, temp1, tst1;
+    ARNAUD_CPLXF_TYPE cdbl1 = ARNAUD_cplxf(1.0f, 0.0f);
+    ARNAUD_CPLXF_TYPE cdblm1 = ARNAUD_cplxf(-1.0f, 0.0f);
+    ARNAUD_CPLXF_TYPE cdbl0 = ARNAUD_cplxf(0.0f, 0.0f);
 
     n = V->n;  // n is constant, this is just for typing convenience
     ipj = 0;
@@ -997,13 +997,13 @@ LINE1000:
     //  an exact j-step Arnoldi factorization is present.
 
     V->aitr_betaj = *rnorm;
-    if (*rnorm > 0.0) { goto LINE40; }
+    if (*rnorm > 0.0f) { goto LINE40; }
 
     //  Invariant subspace found, generate a new starting
     //  vector which is orthogonal to the current Arnoldi
     //  basis and continue the iteration.
 
-    V->aitr_betaj = 0.0;
+    V->aitr_betaj = 0.0f;
     V->getv0_itry = 1;
 
 LINE20:
@@ -1043,7 +1043,7 @@ LINE40:
 
     if (*rnorm >= unfl)
     {
-        temp1 = 1.0 / *rnorm;
+        temp1 = 1.0f / *rnorm;
         csscal_(&n, &temp1, &v[ldv*V->aitr_j], &int1);
         csscal_(&n, &temp1, &workd[ipj], &int1);
     } else {
@@ -1128,7 +1128,7 @@ LINE60:
 
     cgemv_("N", &n, &tmp_int, &cdblm1, v, &ldv, &h[ldh*(V->aitr_j)], &int1, &cdbl1, resid, &int1);
 
-    if (V->aitr_j > 0) { h[V->aitr_j + ldh*(V->aitr_j-1)] = ARNAUD_cplxf(V->aitr_betaj, 0.0); }
+    if (V->aitr_j > 0) { h[V->aitr_j + ldh*(V->aitr_j-1)] = ARNAUD_cplxf(V->aitr_betaj, 0.0f); }
 
     V->aitr_orth1 = 1;
     if (V->bmat)
@@ -1258,9 +1258,9 @@ LINE90:
 
         for (jj = 0; jj < n; jj++)
         {
-            resid[jj] = ARNAUD_cplxf(0.0, 0.0);
+            resid[jj] = ARNAUD_cplxf(0.0f, 0.0f);
         }
-        *rnorm = 0.0;
+        *rnorm = 0.0f;
     }
 
 LINE100:
@@ -1283,16 +1283,16 @@ LINE100:
             //  REFERENCE: LAPACK subroutine dlahqr
 
             tst1 = cabsf(h[i + ldh*i]) + cabsf(h[i+1 + ldh*(i+1)]);
-            if (tst1 == 0.0)
+            if (tst1 == 0.0f)
             {
                 tmp_int = k + np;
                 // clanhs(norm, n, a, lda, work) with "work" being float type
                 // Recasting complex workspace to float for scratch space.
                 tst1 = clanhs_("1", &tmp_int, h, &ldh, (float*)&workd[n]);
             }
-            if (cabsf(h[i+1 + ldh*i]) <= fmax(ulp*tst1, smlnum))
+            if (cabsf(h[i+1 + ldh*i]) <= fmaxf(ulp*tst1, smlnum))
             {
-                h[i+1 + ldh*i] = ARNAUD_cplxf(0.0, 0.0);
+                h[i+1 + ldh*i] = ARNAUD_cplxf(0.0f, 0.0f);
             }
         }
         // 110
@@ -1315,8 +1315,8 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
     float tmp_dbl;
     ARNAUD_CPLXF_TYPE f, g, h11, h21, sigma, s, s2, r, t, tmp_cplx;
 
-    ARNAUD_CPLXF_TYPE cdbl1 = ARNAUD_cplxf(1.0, 0.0);
-    ARNAUD_CPLXF_TYPE cdbl0 = ARNAUD_cplxf(0.0, 0.0);
+    ARNAUD_CPLXF_TYPE cdbl1 = ARNAUD_cplxf(1.0f, 0.0f);
+    ARNAUD_CPLXF_TYPE cdbl0 = ARNAUD_cplxf(0.0f, 0.0f);
 
     int kplusp = *kev + np;
 
@@ -1341,14 +1341,14 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
         {
             for  (iend = istart; iend < kplusp - 1; iend++)
             {
-                tst1 = fabs(crealf(h[iend + ldh*iend])) + fabs(cimagf(h[iend + ldh*iend])) +
-                       fabs(crealf(h[iend+1 + ldh*(iend+1)])) + fabs(cimagf(h[iend+1 + ldh*(iend+1)]));
-                if (tst1 == 0.0)
+                tst1 = fabsf(crealf(h[iend + ldh*iend])) + fabsf(cimagf(h[iend + ldh*iend])) +
+                       fabsf(crealf(h[iend+1 + ldh*(iend+1)])) + fabsf(cimagf(h[iend+1 + ldh*(iend+1)]));
+                if (tst1 == 0.0f)
                 {
                    tmp_int = kplusp - jj;
                     clanhs_("1", &tmp_int, h, &ldh, (float*)workl);
                 }
-                if (fabs(crealf(h[iend+1 + ldh*iend])) <= fmax(ulp*tst1, smlnum))
+                if (fabsf(crealf(h[iend+1 + ldh*iend])) <= fmaxf(ulp*tst1, smlnum))
                 {
                     break;
                 }
@@ -1368,7 +1368,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
                 // Valid block found and it's not the entire remaining array
                 // Clean up the noise
 
-                h[iend+1 + ldh*iend] = ARNAUD_cplxf(0.0, 0.0);
+                h[iend+1 + ldh*iend] = ARNAUD_cplxf(0.0f, 0.0f);
             }
 
             h11 = h[istart + ldh*istart];
@@ -1386,7 +1386,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
                 if (i > istart)
                 {
                     h[i + ldh*(i-1)] = r;
-                    h[i + 1 + ldh*(i-1)] = ARNAUD_cplxf(0.0, 0.0);
+                    h[i + 1 + ldh*(i-1)] = ARNAUD_cplxf(0.0f, 0.0f);
                 }
                 tmp_int = kplusp - i;
                 crot_(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
@@ -1412,7 +1412,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
 
     for (j = 0; j < *kev; j++)
     {
-        if ((crealf(h[j+1 + ldh*j]) < 0.0) || (cimagf(h[j+1 + ldh*j]) != 0.0))
+        if ((crealf(h[j+1 + ldh*j]) < 0.0f) || (cimagf(h[j+1 + ldh*j]) != 0.0f))
         {
             tmp_dbl = cabsf(h[j+1 + ldh*j]);
             t = ARNAUD_cplxf(crealf(h[j+1 + ldh*j]) / tmp_dbl,
@@ -1428,7 +1428,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
             tmp_int = (j+np+2 > kplusp ? kplusp : j+np+2);
             cscal_(&tmp_int, &t, &q[ldq*(j+1)], &int1);
 
-            h[j+1 + ldh*j] = ARNAUD_cplxf(crealf(h[j+1 + ldh*j]), 0.0);
+            h[j+1 + ldh*j] = ARNAUD_cplxf(crealf(h[j+1 + ldh*j]), 0.0f);
         }
     }
     // 120
@@ -1443,15 +1443,15 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
         //  compressed H are nonnegative real numbers,
         //  we take advantage of this.
 
-        tst1 = fabs(crealf(h[i + ldh*i])) + fabs(crealf(h[i+1 + ldh*(i+1)])) +
-               fabs(cimagf(h[i + ldh*i])) + fabs(cimagf(h[i+1 + ldh*(i+1)]));
-        if (tst1 == 0.0)
+        tst1 = fabsf(crealf(h[i + ldh*i])) + fabsf(crealf(h[i+1 + ldh*(i+1)])) +
+               fabsf(cimagf(h[i + ldh*i])) + fabsf(cimagf(h[i+1 + ldh*(i+1)]));
+        if (tst1 == 0.0f)
         {
             tst1 = clanhs_("1", kev, h, &ldh, (float*)workl);
         }
-        if (crealf(h[i+1 + ldh*i]) <= fmax(ulp*tst1, smlnum))
+        if (crealf(h[i+1 + ldh*i]) <= fmaxf(ulp*tst1, smlnum))
         {
-            h[i+1 + ldh*i] = ARNAUD_cplxf(0.0, 0.0);
+            h[i+1 + ldh*i] = ARNAUD_cplxf(0.0f, 0.0f);
         }
     }
     // 130
@@ -1462,7 +1462,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
     //  cannot GUARANTEE that the corresponding entry
     //  of H would be zero as in exact arithmetic.
 
-    if (crealf(h[*kev + ldh*(*kev-1)]) > 0.0)
+    if (crealf(h[*kev + ldh*(*kev-1)]) > 0.0f)
     {
         cgemv_("N", &n, &kplusp, &cdbl1, v, &ldv, &q[(*kev)*ldq], &int1, &cdbl0, &workd[n], &int1);
     }
@@ -1483,7 +1483,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
 
     //  Copy the (kev+1)-st column of (V*Q) in the appropriate place
 
-    if (crealf(h[*kev + ldh*(*kev-1)]) > 0.0) {
+    if (crealf(h[*kev + ldh*(*kev-1)]) > 0.0f) {
         ccopy_(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
     }
 
@@ -1495,7 +1495,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
 
     cscal_(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
 
-    if (crealf(h[*kev + ldh*(*kev-1)]) > 0.0)
+    if (crealf(h[*kev + ldh*(*kev-1)]) > 0.0f)
     {
         caxpy_(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
     }
@@ -1513,8 +1513,8 @@ cneigh(float* rnorm, int n, ARNAUD_CPLXF_TYPE* h, int ldh, ARNAUD_CPLXF_TYPE* ri
     int int1 = 1, j;
     float temp;
     ARNAUD_CPLXF_TYPE vl[1];
-    vl[0] = ARNAUD_cplxf(0.0, 0.0);
-    ARNAUD_CPLXF_TYPE c1 = ARNAUD_cplxf(1.0, 0.0), c0 = ARNAUD_cplxf(0.0, 0.0);
+    vl[0] = ARNAUD_cplxf(0.0f, 0.0f);
+    ARNAUD_CPLXF_TYPE c1 = ARNAUD_cplxf(1.0f, 0.0f), c0 = ARNAUD_cplxf(0.0f, 0.0f);
 
     //  1. Compute the eigenvalues, the last components of the
     //     corresponding Schur vectors and the full Schur form T
@@ -1547,7 +1547,7 @@ cneigh(float* rnorm, int n, ARNAUD_CPLXF_TYPE* h, int ldh, ARNAUD_CPLXF_TYPE* ri
 
     for (j = 0; j < n; j++)
     {
-        temp = 1.0 / scnrm2_(&n, &q[j*ldq], &int1);
+        temp = 1.0f / scnrm2_(&n, &q[j*ldq], &int1);
         csscal_(&n, &temp, &q[j*ldq], &int1);
     }
 
@@ -1591,9 +1591,9 @@ cgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
 {
     int jj, int1 = 1;
     const float sq2o2 = sqrt(2.0) / 2.0;
-    ARNAUD_CPLXF_TYPE c0 = ARNAUD_cplxf(0.0, 0.0);
-    ARNAUD_CPLXF_TYPE c1 = ARNAUD_cplxf(1.0, 0.0);
-    ARNAUD_CPLXF_TYPE cm1 = ARNAUD_cplxf(-1.0, 0.0);
+    ARNAUD_CPLXF_TYPE c0 = ARNAUD_cplxf(0.0f, 0.0f);
+    ARNAUD_CPLXF_TYPE c1 = ARNAUD_cplxf(1.0f, 0.0f);
+    ARNAUD_CPLXF_TYPE cm1 = ARNAUD_cplxf(-1.0f, 0.0f);
 
     if (V->ido == ido_FIRST)
     {
@@ -1741,8 +1741,8 @@ LINE40:
 
         //  Iterative refinement step "failed"
 
-        for (jj = 0; jj < n; jj++) { resid[jj] = ARNAUD_cplxf(0.0, 0.0); }
-        *rnorm = 0.0;
+        for (jj = 0; jj < n; jj++) { resid[jj] = ARNAUD_cplxf(0.0f, 0.0f); }
+        *rnorm = 0.0f;
         V->info = -1;
     }
 
@@ -1824,9 +1824,9 @@ static int sortc_SI(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { retu
 static ARNAUD_CPLXF_TYPE
 cdotc_(const int* n, const ARNAUD_CPLXF_TYPE* restrict x, const int* incx, const ARNAUD_CPLXF_TYPE* restrict y, const int* incy)
 {
-    ARNAUD_CPLXF_TYPE result = ARNAUD_cplxf(0.0, 0.0);
+    ARNAUD_CPLXF_TYPE result = ARNAUD_cplxf(0.0f, 0.0f);
 #ifdef _MSC_VER
-    ARNAUD_CPLXF_TYPE temp = ARNAUD_cplxf(0.0, 0.0);
+    ARNAUD_CPLXF_TYPE temp = ARNAUD_cplxf(0.0f, 0.0f);
 #endif
     if (*n <= 0) { return result; }
 

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single_complex.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single_complex.h
@@ -1,20 +1,8 @@
 #ifndef ARNAUD_N_SINGLE_COMPLEX_H
 #define ARNAUD_N_SINGLE_COMPLEX_H
 
+#include <math.h>
 #include "arnaud/arnaud.h"
 #include "blaslapack_declarations.h"
-#include <complex.h>
-
-#if defined(_MSC_VER)
-    // MSVC definitions
-    typedef _Fcomplex ARNAUD_CPLXF_TYPE;
-    #define ARNAUD_cplxf(real, imag) ((_Fcomplex){real, imag})
-
-#else
-    // C99 compliant compilers
-    typedef float complex ARNAUD_CPLXF_TYPE;
-    #define ARNAUD_cplxf(real, imag) ((real) + (imag)*I)
-
-#endif
 
 #endif

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.c
@@ -1801,10 +1801,10 @@ LINE40:
 }
 
 
-void
+static void
 dsortr(const enum ARNAUD_which w, const int apply, const int n, double* x1, double* x2)
 {
-    int i, igap, j;
+    int i, gap, pos;
     double temp;
     ARNAUD_compare_rfunc *f;
 
@@ -1827,39 +1827,37 @@ dsortr(const enum ARNAUD_which w, const int apply, const int n, double* x1, doub
             break;
     }
 
-    igap = n / 2;
+    gap = n / 2;
 
-    while (igap != 0)
+    while (gap != 0)
     {
-        j = 0;
-        for (i = igap; i < n; i++)
+        for (i = gap; i < n; i++)
         {
-            while (f(x1[j], x1[j+igap]))
+            pos = i - gap;
+            while ((pos >= 0) && (f(x1[pos], x1[pos+gap])))
             {
-                if (j < 0) { break; }
-                temp = x1[j];
-                x1[j] = x1[j+igap];
-                x1[j+igap] = temp;
+                temp = x1[pos];
+                x1[pos] = x1[pos+gap];
+                x1[pos+gap] = temp;
 
                 if (apply)
                 {
-                    temp = x2[j];
-                    x2[j] = x2[j+igap];
-                    x2[j+igap] = temp;
+                    temp = x2[pos];
+                    x2[pos] = x2[pos+gap];
+                    x2[pos+gap] = temp;
                 }
-                j -= igap;
+                pos -= gap;
             }
-            j = i - igap + 1;
         }
-        igap = igap / 2;
+        gap = gap / 2;
     }
 }
 
 
-void
+static void
 dsesrt(const enum ARNAUD_which w, const int apply, const int n, double* x, int na, double* a, const int lda)
 {
-    int i, igap, j, int1 = 1;
+    int i, gap, pos, int1 = 1;
     double temp;
     ARNAUD_compare_rfunc *f;
 
@@ -1882,31 +1880,28 @@ dsesrt(const enum ARNAUD_which w, const int apply, const int n, double* x, int n
             break;
     }
 
-    igap = n / 2;
+    gap = n / 2;
 
-    while (igap != 0)
+    while (gap != 0)
     {
-        j = 0;
-        for (i = igap; i < n; i++)
+        for (i = gap; i < n; i++)
         {
-            while (f(x[j], x[j + igap]))
+            pos = i - gap;
+            while ((pos >= 0) && (f(x[pos], x[pos + gap])))
             {
-                if (j < 0) { break; }
-                temp = x[j];
-                x[j] = x[j+igap];
-                x[j+igap] = temp;
+                temp = x[pos];
+                x[pos] = x[pos+gap];
+                x[pos+gap] = temp;
 
                 if (apply)
                 {
-                    dswap_(&na, &a[lda*j], &int1, &a[lda*(j+igap)], &int1);
+                    dswap_(&na, &a[lda*pos], &int1, &a[lda*(pos+gap)], &int1);
                 }
-                j -= igap;
+                pos -= gap;
             }
-            j = i - igap + 1;
         }
-        igap = igap / 2;
+        gap = gap / 2;
     }
-    // 10, 40, 70, 120
 }
 
 

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.h
@@ -1,6 +1,7 @@
 #ifndef ARNAUD_S_DOUBLE_H
 #define ARNAUD_S_DOUBLE_H
 
+#include <math.h>
 #include "arnaud/arnaud.h"
 #include "blaslapack_declarations.h"
 

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_single.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_single.c
@@ -1804,7 +1804,7 @@ LINE40:
 void
 ssortr(const enum ARNAUD_which w, const int apply, const int n, float* x1, float* x2)
 {
-    int i, igap, j;
+    int i, gap, pos;
     float temp;
     ARNAUD_compare_rfunc *f;
 
@@ -1827,39 +1827,37 @@ ssortr(const enum ARNAUD_which w, const int apply, const int n, float* x1, float
             break;
     }
 
-    igap = n / 2;
+    gap = n / 2;
 
-    while (igap != 0)
+    while (gap != 0)
     {
-        j = 0;
-        for (i = igap; i < n; i++)
+        for (i = gap; i < n; i++)
         {
-            while (f(x1[j], x1[j+igap]))
+            pos = i - gap;
+            while ((pos >= 0) && (f(x1[pos], x1[pos+gap])))
             {
-                if (j < 0) { break; }
-                temp = x1[j];
-                x1[j] = x1[j+igap];
-                x1[j+igap] = temp;
+                temp = x1[pos];
+                x1[pos] = x1[pos+gap];
+                x1[pos+gap] = temp;
 
                 if (apply)
                 {
-                    temp = x2[j];
-                    x2[j] = x2[j+igap];
-                    x2[j+igap] = temp;
+                    temp = x2[pos];
+                    x2[pos] = x2[pos+gap];
+                    x2[pos+gap] = temp;
                 }
-                j -= igap;
+                pos -= gap;
             }
-            j = i - igap + 1;
         }
-        igap = igap / 2;
+        gap = gap / 2;
     }
 }
 
 
-void
+static void
 ssesrt(const enum ARNAUD_which w, const int apply, const int n, float* x, int na, float* a, const int lda)
 {
-    int i, igap, j, int1 = 1;
+    int i, gap, pos, int1 = 1;
     float temp;
     ARNAUD_compare_rfunc *f;
 
@@ -1882,31 +1880,28 @@ ssesrt(const enum ARNAUD_which w, const int apply, const int n, float* x, int na
             break;
     }
 
-    igap = n / 2;
+    gap = n / 2;
 
-    while (igap != 0)
+    while (gap != 0)
     {
-        j = 0;
-        for (i = igap; i < n; i++)
+        for (i = gap; i < n; i++)
         {
-            while (f(x[j], x[j + igap]))
+            pos = i - gap;
+            while ((pos >= 0) && (f(x[pos], x[pos + gap])))
             {
-                if (j < 0) { break; }
-                temp = x[j];
-                x[j] = x[j+igap];
-                x[j+igap] = temp;
+                temp = x[pos];
+                x[pos] = x[pos+gap];
+                x[pos+gap] = temp;
 
                 if (apply)
                 {
-                    sswap_(&na, &a[lda*j], &int1, &a[lda*(j+igap)], &int1);
+                    sswap_(&na, &a[lda*pos], &int1, &a[lda*(pos+gap)], &int1);
                 }
-                j -= igap;
+                pos -= gap;
             }
-            j = i - igap + 1;
         }
-        igap = igap / 2;
+        gap = gap / 2;
     }
-    // 10, 40, 70, 120
 }
 
 

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_single.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_single.c
@@ -172,7 +172,7 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
         for (j = 0; j < V->ncv; j++)
         {
-            workl[bounds + j] = j;
+            workl[bounds + j] = j*1.0f;
             select[j] = 0;
         }
         // 10

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_single.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_single.h
@@ -1,6 +1,7 @@
 #ifndef ARNAUD_S_SINGLE_H
 #define ARNAUD_S_SINGLE_H
 
+#include <math.h>
 #include "arnaud/arnaud.h"
 #include "blaslapack_declarations.h"
 

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/blaslapack_declarations.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/blaslapack_declarations.h
@@ -1,18 +1,7 @@
 #ifndef BLASLAPACK_DECLARATIONS_H
 #define BLASLAPACK_DECLARATIONS_H
 
-#include <complex.h>
-
-#if defined(_MSC_VER)
-    // MSVC definition
-    typedef _Fcomplex ARNAUD_CPLXF_TYPE;
-    typedef _Dcomplex ARNAUD_CPLX_TYPE;
-#else
-    // C99 compliant compilers
-    typedef float complex ARNAUD_CPLXF_TYPE;
-    typedef double complex ARNAUD_CPLX_TYPE;
-#endif
-
+#include "arnaud/types.h"
 
 // BLAS
 void saxpy_(int* n, float* alpha, float* x, int* incx, float* y, int* incy);


### PR DESCRIPTION
This PR adds more C documentation and also fixes a few more bugs; 

- Eigenvector purification off-by-one error in complex valued solvers
- Not handling negative increments properly in custom `zdotc` and `cdotc` (not that arnaud was using any but just in case)
- Shellsort algorithm did not initialize properly in none of the flavors. Now cleaned up and restructured.

Also minor project restructuring is added regarding the type declarations and includes. 