### PR TITLE
BUG: sparse: `multiply()` should produce CSC output for CSC input

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -493,6 +493,8 @@ class _spbase(SparseABC):
             return self._mul_scalar(other)
 
         if self.ndim < 3:
+            if self.format in ('bsr', 'csc', 'csr'):  # DIA has its own multiply
+                return self._multiply_2d_with_broadcasting(other)
             return self.tocsr()._multiply_2d_with_broadcasting(other)
 
         if not (issparse(other) or isdense(other)):

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1639,6 +1639,9 @@ class _TestCommon:
         B = array([[0,7,0],[0,-4,0]])
         Asp = self.spcreator(A)
         Bsp = self.spcreator(B)
+        # check output format
+        out_fmt = Asp.format if Asp.format in ('csc', 'dia', 'bsr') else 'csr'
+        assert (Asp.multiply(Bsp)).format == out_fmt
         assert_almost_equal(Asp.multiply(Bsp).toarray(), A*B)  # sparse/sparse
         assert_almost_equal(Asp.multiply(B).toarray(), A*B)  # sparse/dense
 


### PR DESCRIPTION
Fixes #23321

Adds a test of the format of the output of `multiply()` method.
Fixes handling of CSC and BSR to pass this test.

The Issue reports that CSC by CSC multiplication results in CSR starting for SciPy v16.0. 
This error was an unintentional change from PR #22897.
It turns out to affect CSC and BSR formats (multiplying any other formats).

We should backport this for any upcoming bugfix release.