### PR TITLE
DOC/BUG: Fix whitespace in docstrings of several functions.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: cimg/python:3.11
+    - image: cimg/python:3.13
   working_directory: ~/repo
 
 commands:
@@ -115,7 +115,7 @@ jobs:
           name: build docs
           no_output_timeout: 25m
           command: |
-            export PYTHONPATH=$PWD/build-install/usr/lib/python3.11/site-packages
+            export PYTHONPATH=$PWD/build-install/usr/lib/python3.13/site-packages
             spin docs -j2 2>&1 | tee sphinx_log.txt
 
       - run:
@@ -148,7 +148,7 @@ jobs:
           name: run asv
           no_output_timeout: 30m
           command: |
-            export PYTHONPATH=$PWD/build-install/usr/lib/python3.11/site-packages
+            export PYTHONPATH=$PWD/build-install/usr/lib/python3.13/site-packages
             cd benchmarks
             asv machine --machine CircleCI
             export SCIPY_GLOBAL_BENCH_NUMTRIALS=1
@@ -176,7 +176,7 @@ jobs:
           no_output_timeout: 25m
           command: |
             sudo apt-get install -y wamerican-small
-            export PYTHONPATH=$PWD/build-install/usr/lib/python3.11/site-packages
+            export PYTHONPATH=$PWD/build-install/usr/lib/python3.13/site-packages
             spin refguide-check
 
       - run:

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -67,51 +67,51 @@ def _safe_norm(v):
 
 _doc_parts = dict(
     params_basic="""
-    F : function(x) -> f
-        Function whose root to find; should take and return an array-like
-        object.
-    xin : array_like
-        Initial guess for the solution
+F : function(x) -> f
+    Function whose root to find; should take and return an array-like
+    object.
+xin : array_like
+    Initial guess for the solution
     """.strip(),
     params_extra="""
-    iter : int, optional
-        Number of iterations to make. If omitted (default), make as many
-        as required to meet tolerances.
-    verbose : bool, optional
-        Print status to stdout on every iteration.
-    maxiter : int, optional
-        Maximum number of iterations to make. If more are needed to
-        meet convergence, `NoConvergence` is raised.
-    f_tol : float, optional
-        Absolute tolerance (in max-norm) for the residual.
-        If omitted, default is 6e-6.
-    f_rtol : float, optional
-        Relative tolerance for the residual. If omitted, not used.
-    x_tol : float, optional
-        Absolute minimum step size, as determined from the Jacobian
-        approximation. If the step size is smaller than this, optimization
-        is terminated as successful. If omitted, not used.
-    x_rtol : float, optional
-        Relative minimum step size. If omitted, not used.
-    tol_norm : function(vector) -> scalar, optional
-        Norm to use in convergence check. Default is the maximum norm.
-    line_search : {None, 'armijo' (default), 'wolfe'}, optional
-        Which type of a line search to use to determine the step size in the
-        direction given by the Jacobian approximation. Defaults to 'armijo'.
-    callback : function, optional
-        Optional callback function. It is called on every iteration as
-        ``callback(x, f)`` where `x` is the current solution and `f`
-        the corresponding residual.
+iter : int, optional
+    Number of iterations to make. If omitted (default), make as many
+    as required to meet tolerances.
+verbose : bool, optional
+    Print status to stdout on every iteration.
+maxiter : int, optional
+    Maximum number of iterations to make. If more are needed to
+    meet convergence, `NoConvergence` is raised.
+f_tol : float, optional
+    Absolute tolerance (in max-norm) for the residual.
+    If omitted, default is 6e-6.
+f_rtol : float, optional
+    Relative tolerance for the residual. If omitted, not used.
+x_tol : float, optional
+    Absolute minimum step size, as determined from the Jacobian
+    approximation. If the step size is smaller than this, optimization
+    is terminated as successful. If omitted, not used.
+x_rtol : float, optional
+    Relative minimum step size. If omitted, not used.
+tol_norm : function(vector) -> scalar, optional
+    Norm to use in convergence check. Default is the maximum norm.
+line_search : {None, 'armijo' (default), 'wolfe'}, optional
+    Which type of a line search to use to determine the step size in the
+    direction given by the Jacobian approximation. Defaults to 'armijo'.
+callback : function, optional
+    Optional callback function. It is called on every iteration as
+    ``callback(x, f)`` where `x` is the current solution and `f`
+    the corresponding residual.
 
-    Returns
-    -------
-    sol : ndarray
-        An array (of similar array type as `x0`) containing the final solution.
+Returns
+-------
+sol : ndarray
+    An array (of similar array type as `x0`) containing the final solution.
 
-    Raises
-    ------
-    NoConvergence
-        When a solution was not found.
+Raises
+------
+NoConvergence
+    When a solution was not found.
 
     """.strip()
 )
@@ -831,27 +831,27 @@ class LowRankMatrix:
 
 
 _doc_parts['broyden_params'] = """
-    alpha : float, optional
-        Initial guess for the Jacobian is ``(-1/alpha)``.
-    reduction_method : str or tuple, optional
-        Method used in ensuring that the rank of the Broyden matrix
-        stays low. Can either be a string giving the name of the method,
-        or a tuple of the form ``(method, param1, param2, ...)``
-        that gives the name of the method and values for additional parameters.
+alpha : float, optional
+    Initial guess for the Jacobian is ``(-1/alpha)``.
+reduction_method : str or tuple, optional
+    Method used in ensuring that the rank of the Broyden matrix
+    stays low. Can either be a string giving the name of the method,
+    or a tuple of the form ``(method, param1, param2, ...)``
+    that gives the name of the method and values for additional parameters.
 
-        Methods available:
+    Methods available:
 
-        - ``restart``: drop all matrix columns. Has no extra parameters.
-        - ``simple``: drop oldest matrix column. Has no extra parameters.
-        - ``svd``: keep only the most significant SVD components.
-          Takes an extra parameter, ``to_retain``, which determines the
-          number of SVD components to retain when rank reduction is done.
-          Default is ``max_rank - 2``.
+    - ``restart``: drop all matrix columns. Has no extra parameters.
+    - ``simple``: drop oldest matrix column. Has no extra parameters.
+    - ``svd``: keep only the most significant SVD components.
+        Takes an extra parameter, ``to_retain``, which determines the
+        number of SVD components to retain when rank reduction is done.
+        Default is ``max_rank - 2``.
 
-    max_rank : int, optional
-        Maximum rank for the Broyden matrix.
-        Default is infinity (i.e., no rank reduction).
-    """.strip()
+max_rank : int, optional
+    Maximum rank for the Broyden matrix.
+    Default is infinity (i.e., no rank reduction).
+""".strip()
 
 
 class BroydenFirst(GenericBroyden):

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -2017,8 +2017,7 @@ trimdoc = """
         Whether to consider the limits as absolute values (False) or proportions
         to cut (True).
     axis : int, optional
-        Axis along which to trim.
-"""
+        Axis along which to trim."""
 
 
 def trim(a, limits=None, inclusive=(True,True), relative=False, axis=None):
@@ -2026,8 +2025,7 @@ def trim(a, limits=None, inclusive=(True,True), relative=False, axis=None):
     Trims an array by masking the data outside some given limits.
 
     Returns a masked version of the input array.
-
-    %s
+%s
 
     Examples
     --------
@@ -2126,8 +2124,7 @@ trim1 = trimtail
 def trimmed_mean(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
                  axis=None):
     """Returns the trimmed mean of the data along the given axis.
-
-    %s
+%s
 
     """
     if (not isinstance(limits,tuple)) and isinstance(limits,float):
@@ -2145,8 +2142,7 @@ if trimmed_mean.__doc__:
 def trimmed_var(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
                 axis=None, ddof=0):
     """Returns the trimmed variance of the data along the given axis.
-
-    %s
+%s
     ddof : {0,integer}, optional
         Means Delta Degrees of Freedom. The denominator used during computations
         is (n-ddof). DDOF=0 corresponds to a biased estimate, DDOF=1 to an un-
@@ -2170,8 +2166,7 @@ if trimmed_var.__doc__:
 def trimmed_std(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
                 axis=None, ddof=0):
     """Returns the trimmed standard deviation of the data along the given axis.
-
-    %s
+%s
     ddof : {0,integer}, optional
         Means Delta Degrees of Freedom. The denominator used during computations
         is (n-ddof). DDOF=0 corresponds to a biased estimate, DDOF=1 to an un-


### PR DESCRIPTION
Several docstrings are processed during import.  In some cases, the indentation of blocks of lines in the resulting docstrings was incorrect, and unnecessary extra lines were added.  The bad indentation caused Sphinx warnings when building the html documentation.

This fixes the following warnings generated by Sphinx when running `spin docs html`:

```
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.anderson:13: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.anderson:29: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden1:11: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden1:16: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden1:38: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden2:11: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden2:16: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden2:38: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.diagbroyden:17: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.diagbroyden:26: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.excitingmixing:16: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.excitingmixing:29: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.linearmixing:14: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.linearmixing:23: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.newton_krylov:11: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.newton_krylov:58: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/stats/_mstats_basic.py:docstring of scipy.stats._mstats_basic.trimmed_std:9: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/stats/_mstats_basic.py:docstring of scipy.stats._mstats_basic.trimmed_var:9: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
```