### PR TITLE
DOC: interpolate/RBF: tweak the docstring example, tweak dimensions

### DIFF
--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -272,8 +272,9 @@ class RBFInterpolator:
     >>> xobs = 2*Halton(2, seed=rng).random(100) - 1
     >>> yobs = np.sum(xobs, axis=1)*np.exp(-6*np.sum(xobs**2, axis=1))
 
-    >>> xgrid = np.mgrid[-1:1:50j, -1:1:50j]
-    >>> xflat = xgrid.reshape(2, -1).T
+    >>> x1 = np.linspace(-1, 1, 50)
+    >>> xgrid = np.asarray(np.meshgrid(x1, x1, indexing='ij'))
+    >>> xflat = xgrid.reshape(2, -1).T     # make it a 2-D array
     >>> yflat = RBFInterpolator(xobs, yobs)(xflat)
     >>> ygrid = yflat.reshape(50, 50)
 
@@ -469,12 +470,12 @@ class RBFInterpolator:
 
         Parameters
         ----------
-        x : (Q, N) array_like
+        x : (npts, ndim) array_like
             Evaluation point coordinates.
 
         Returns
         -------
-        (Q, ...) ndarray
+        ndarray, shape (npts, )
             Values of the interpolant at `x`.
 
         """


### PR DESCRIPTION
Use a slightly less esoteric numpy incantation for creating a grid (what is 3j in  `np.mgrid[-1:1:3j, -1:1:3j]` and how will the result change if the step is real not complex?). While at it, use slightly more self-documenting labels for the input and output dimensions in `RBFInterpolator.__call__`  (what is Q and what is N?)
