### PR TITLE
DOC/BUG: Fix a few dynamically modified docstrings.

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -9,6 +9,7 @@ import inspect
 import math
 import os
 import sys
+import textwrap
 from types import ModuleType
 from typing import Literal, TypeAlias, TypeVar
 
@@ -1209,3 +1210,8 @@ def np_vecdot(x1, x2, /, *, axis=-1):
         # of course there are other fancy ways of doing this (e.g. `einsum`)
         # but let's keep it simple since it's temporary
         return np.sum(x1 * x2, axis=axis)
+
+
+def _dedent_for_py313(s):
+    """Apply textwrap.dedent to s for Python versions 3.13 or later."""
+    return s if sys.version_info < (3, 13) else textwrap.dedent(s)

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -12,7 +12,7 @@ from scipy.linalg import norm, solve, inv, qr, svd, LinAlgError
 import scipy.sparse.linalg
 import scipy.sparse
 from scipy.linalg import get_blas_funcs
-from scipy._lib._util import copy_if_needed
+from scipy._lib._util import copy_if_needed, _dedent_for_py313
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from ._linesearch import scalar_search_wolfe1, scalar_search_armijo
 from inspect import signature
@@ -66,14 +66,14 @@ def _safe_norm(v):
 
 
 _doc_parts = dict(
-    params_basic="""
+    params_basic=_dedent_for_py313("""
     F : function(x) -> f
         Function whose root to find; should take and return an array-like
         object.
     xin : array_like
         Initial guess for the solution
-    """.strip(),
-    params_extra="""
+    """).strip(),
+    params_extra=_dedent_for_py313("""
     iter : int, optional
         Number of iterations to make. If omitted (default), make as many
         as required to meet tolerances.
@@ -113,7 +113,7 @@ _doc_parts = dict(
     NoConvergence
         When a solution was not found.
 
-    """.strip()
+    """).strip()
 )
 
 
@@ -830,7 +830,7 @@ class LowRankMatrix:
         del self.ds[q:]
 
 
-_doc_parts['broyden_params'] = """
+_doc_parts['broyden_params'] = _dedent_for_py313("""
     alpha : float, optional
         Initial guess for the Jacobian is ``(-1/alpha)``.
     reduction_method : str or tuple, optional
@@ -851,7 +851,7 @@ _doc_parts['broyden_params'] = """
     max_rank : int, optional
         Maximum rank for the Broyden matrix.
         Default is infinity (i.e., no rank reduction).
-    """.strip()
+    """).strip()
 
 
 class BroydenFirst(GenericBroyden):

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -41,7 +41,7 @@ import warnings
 from collections import namedtuple
 
 from . import distributions
-from scipy._lib._util import _rename_parameter, _contains_nan
+from scipy._lib._util import _rename_parameter, _contains_nan, _dedent_for_py313
 from scipy._lib._bunch import _make_tuple_bunch
 import scipy.special as special
 import scipy.stats._stats_py
@@ -1987,7 +1987,7 @@ def trimr(a, limits=None, inclusive=(True, True), axis=None):
         return ma.apply_along_axis(_trimr1D, axis, a, lolim,uplim,loinc,upinc)
 
 
-trimdoc = """
+trimdoc = _dedent_for_py313("""
     Parameters
     ----------
     a : sequence
@@ -2017,8 +2017,7 @@ trimdoc = """
         Whether to consider the limits as absolute values (False) or proportions
         to cut (True).
     axis : int, optional
-        Axis along which to trim.
-"""
+        Axis along which to trim.""")
 
 
 def trim(a, limits=None, inclusive=(True,True), relative=False, axis=None):


### PR DESCRIPTION
In Python 3.13, common indents are automatically removed from docstrings.  For the docstrings that we modify during import, we have to dedent the added text when running Python 3.13.

This fixes the following warnings generated by Sphinx when running `spin docs html`:

```
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.anderson:13: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.anderson:29: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden1:11: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden1:16: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden1:38: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden2:11: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden2:16: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.broyden2:38: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.diagbroyden:17: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.diagbroyden:26: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.excitingmixing:16: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.excitingmixing:29: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.linearmixing:14: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.linearmixing:23: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.newton_krylov:11: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/optimize/_nonlin.py:docstring of scipy.optimize._nonlin.newton_krylov:58: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/stats/_mstats_basic.py:docstring of scipy.stats._mstats_basic.trimmed_std:9: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.13/site-packages/scipy/stats/_mstats_basic.py:docstring of scipy.stats._mstats_basic.trimmed_var:9: WARNING: Block quote ends without a blank line; unexpected unindent. [docutils]
```
