### PR TITLE
BLD: Add bigobj flag for MSVC to fix object file section limit

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -111,6 +111,10 @@ if cc.get_id() == 'clang-cl'
   add_project_arguments('-Qunused-arguments', language: ['c', 'cpp'])
 endif
 
+if cpp.get_id() == 'msvc'
+  add_project_arguments('/bigobj', language: 'cpp')
+endif
+
 if host_machine.system() == 'darwin'
   if cc.has_link_argument('-Wl,-dead_strip')
     # Allow linker to strip unused symbols


### PR DESCRIPTION
Closes #23329

PR Description:

- MSVC fails to compile highs_bindings.cpp due to exceeding the default object file section limit.
- This patch adds the /bigobj flag when using MSVC to resolve the C1128 compiler error.

Reference:
<img width="1346" height="277" alt="image" src="https://github.com/user-attachments/assets/6319b895-d1c6-4fdc-b2ab-4a93cae8e042" />

CI Job failure : https://github.com/scipy/scipy/actions/runs/16298418130/job/46026301158