### PR TITLE
TST: `signal`: add tests for `_polyutils._trim_zeros` and `_polyutils._poly1d`

### DIFF
--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4935,4 +4935,4 @@ def test_poly1d_empty_trimmed(xp):
     # Testing trimming that results in an empty array
     z = xp.asarray([])  # Empty array input
     result = _pu._poly1d(z, xp=xp)
-    assert xp.array_equal(result, xp.asarray([0]))  # Should return zero array
+    xp_assert_equal(result, xp.asarray([0.]))

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1710,13 +1710,13 @@ class TestBilinear:
         b = [0, 0, 1, 2, 3, 0, 0]
         expected_b = [1, 2, 3]
         b_trimmed = _trim_zeros(np.array(b), 'fb')
-        assert_array_almost_equal(b_trimmed, expected_b)
+        np.testing.assert_array_equal(b_trimmed, expected_b)
 
         # Test for trailing zeros
         b = [1, 2, 3, 0, 0]
         expected_b = [1, 2, 3]
         b_trimmed = _trim_zeros(np.array(b), 'fb')
-        assert_array_almost_equal(b_trimmed, expected_b)
+        np.testing.assert_array_equal(b_trimmed, expected_b)
 
 
 class TestLp2lp_zpk:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4926,13 +4926,13 @@ class TestGammatone:
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
             gammatone(440, 'iir', fs=np.asarray([10, 20]))
 
-def test_poly1d_invalid_dimension():
+def test_poly1d_invalid_dimension(xp):
     with pytest.raises(ValueError, match="Polynomial must be 1d only."):
-        z = np.asarray([[1, 2], [3, 4]])  # 2D array
-        _ = _pu._poly1d(z, xp=np)  # This should raise an error
+        z = xp.asarray([[1, 2], [3, 4]])  # 2D array
+        _ = _pu._poly1d(z, xp=xp)  # This should raise an error
 
-def test_poly1d_empty_trimmed():
+def test_poly1d_empty_trimmed(xp):
     # Testing trimming that results in an empty array
-    z = np.asarray([])  # Empty array input
-    result = _pu._poly1d(z, xp=np)
-    assert np.array_equal(result, np.asarray([0]))  # Should return zero array
+    z = xp.asarray([])  # Empty array input
+    result = _pu._poly1d(z, xp=xp)
+    assert xp.array_equal(result, xp.asarray([0]))  # Should return zero array


### PR DESCRIPTION
This PR adds tests to utility functions used by signal filters `_polyutils._trim_zeros`  and `_polyutils._poly1d`. This functions were added by PR https://github.com/scipy/scipy/pull/22896 that converted filters to Array API. We are not sure if it offers better clarity to test these private utility functions directly, or you prefer testing through a filter function like `signal.tf2zpk`, feel free to let us know. These tests add coverage to the following lines that were modified by the PR:

```py
# scipy/signal/_polyutils.py
def _trim_zeros(filt, trim='fb'):
    first = 0
    trim = trim.upper()
    if 'F' in trim:
        for i in filt:
            if i != 0.:
                break
            else:
                first = first + 1 #✅ NOW COVERED
    last = filt.shape[0]
    if 'B' in trim:
        for i in filt[::-1]: #✅ NOW COVERED
            if i != 0.: #✅ NOW COVERED
                break #✅ NOW COVERED
            else:
                last = last - 1 #✅ NOW COVERED
    return filt[first:last]
...
def _poly1d(c_or_r, *, xp):
    """ Constructor of np.poly1d object from an array of coefficients (r=False)
    """
    c_or_r = xpx.atleast_nd(c_or_r, ndim=1, xp=xp)
    if c_or_r.ndim > 1:
        raise ValueError("Polynomial must be 1d only.") #✅ NOW COVERED
    c_or_r = _trim_zeros(c_or_r, trim='f')
    if c_or_r.shape[0] == 0:
        c_or_r = xp.asarray([0], dtype=c_or_r.dtype) #✅ NOW COVERED
    return c_or_r 
```

Note: Parts of this test have been automatically generated by a novel technique that we're currently developing as part of an academic research project aiming at improving test coverage. *To not waste developer time, two researchers manually checked the test before submitting it.* We appreciate the developers' time and any feedback is welcomed.