### PR TITLE
DOC: optimize.minimize: remove outdated limitation for equality constraints in COBYLA

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -188,7 +188,6 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
         Equality constraint means that the constraint function result is to
         be zero whereas inequality means that it is to be non-negative.
-        Note that COBYLA only supports inequality constraints.
 
     tol : float, optional
         Tolerance for termination. When `tol` is specified, the selected


### PR DESCRIPTION
#### Reference issue
Closes #23338
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Updates docstring for optimize.minimize to reflect the fact that COBYLA now supports equality constraints (as of 1.16.0).

#### Additional information
<!--Any additional information you think is important.-->
