### PR TITLE
BUG: signal: zpk2tf: support array-api-strict on multi-dim arrays

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1288,12 +1288,13 @@ def zpk2tf(z, p, k):
         k = xp.astype(k, xp_default_dtype(xp))
 
     if z.ndim > 1:
-        temp = _pu.poly(z[0], xp=xp)
+        temp = _pu.poly(z[0, ...], xp=xp)
         b = xp.empty((z.shape[0], z.shape[1] + 1), dtype=temp.dtype)
         if k.shape[0] == 1:
             k = [k[0]] * z.shape[0]
         for i in range(z.shape[0]):
-            b[i] = k[i] * _pu.poly(z[i], xp=xp)
+            k_i = xp.asarray(k[i], dtype=xp.int64)
+            b[i, ...] = k_i * _pu.poly(z[i, ...], xp=xp)
     else:
         b = k * _pu.poly(z, xp=xp)
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -273,8 +273,6 @@ class TestZpk2Tf:
         xp_assert_close(a, ap)
     
     @skip_xp_backends(cpu_only=True, reason="convolve on torch is cpu-only")
-    @skip_xp_backends("array_api_strict", 
-                      reason="Not supported yet, see scipy:gh-23265 for potential fix")
     @skip_xp_backends("jax.numpy", 
                       reason="zpk2tf not compatible with jax yet on multi-dim arrays")
     def test_zpk2tf_with_multi_dimensional_array(self, xp):


### PR DESCRIPTION
This PR adds array-api-strict support to `signal.zpk2tf` on multi-dimensional input arrays. This lack of support was discovered by PR https://github.com/scipy/scipy/pull/23265 that added a test to this branch. The patch was proposed by @tylerjereddy in https://github.com/scipy/scipy/pull/23265#discussion_r2186148265. Note this still doesn't work on JAX any feedback is appreciated.