### PR TITLE
DOC: correct dimensions of PPoly.c in docstring

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -830,7 +830,7 @@ class PPoly(_PPolyBase):
     Parameters
     ----------
     c : ndarray, shape (k+1, m, ...)
-        Polynomial coefficients, order `k` and `m` intervals.
+        Polynomial coefficients, degree `k` and `m` intervals.
     x : ndarray, shape (m+1,)
         Polynomial breakpoints. Must be sorted in either increasing or
         decreasing order.

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -829,7 +829,7 @@ class PPoly(_PPolyBase):
 
     Parameters
     ----------
-    c : ndarray, shape (k, m, ...)
+    c : ndarray, shape (k+1, m, ...)
         Polynomial coefficients, order `k` and `m` intervals.
     x : ndarray, shape (m+1,)
         Polynomial breakpoints. Must be sorted in either increasing or


### PR DESCRIPTION
#### Reference issue

Closes gh-23345

#### What does this implement/fix?

Fix incorrect array dimension in parameters block of the docstring

#### Additional information

See in the issue
