### PR TITLE
MAINT: sparse: `multiply()` uses attribute presence instead of format to decide to convert to CSR

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -493,9 +493,10 @@ class _spbase(SparseABC):
             return self._mul_scalar(other)
 
         if self.ndim < 3:
-            if self.format in ('bsr', 'csc', 'csr'):  # DIA has its own multiply
+            try:
                 return self._multiply_2d_with_broadcasting(other)
-            return self.tocsr()._multiply_2d_with_broadcasting(other)
+            except AttributeError:
+                return self.tocsr()._multiply_2d_with_broadcasting(other)
 
         if not (issparse(other) or isdense(other)):
             # If it's a list or whatever, treat it like an array


### PR DESCRIPTION
This small change to follow up on #23322 improves internal handling of the decision whether to convert to CSR when using `A.multiply(B)`. Based on a  @perimosocordiae [comment from 23322](https://github.com/scipy/scipy/pull/23322#discussion_r2204515416)

Instead of checking the format: `if A.format in ("csc", "csr", "bsr"):`
This PR uses a try/except to look for the right method, and if exception occurs, it converts and then runs the method.

Not sure whether this should be a backport alongside 23322, but I added that label -- can be removed if that is a pain.

No changes to output or behavior. Eases long term maintainability. 
