### PR TITLE
BUG: linalg: fix `solve(..., assume_a='pos', lower=False)`

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -63,7 +63,7 @@ def _find_matrix_structure(a):
     return kind, n_below, n_above
 
 
-def solve(a, b,lower=None, overwrite_a=False,
+def solve(a, b, lower=None, overwrite_a=False,
           overwrite_b=False, check_finite=True, assume_a=None,
           transposed=False):
     """

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -63,7 +63,7 @@ def _find_matrix_structure(a):
     return kind, n_below, n_above
 
 
-def solve(a, b,lower=False, overwrite_a=False,
+def solve(a, b,lower=None, overwrite_a=False,
           overwrite_b=False, check_finite=True, assume_a=None,
           transposed=False):
     """
@@ -178,6 +178,8 @@ def solve(a, b,lower=False, overwrite_a=False,
         'sym', 'her', 'symmetric', 'hermitian', 'diagonal', 'tridiagonal', 'banded'
     ]:
         # TODO: handle these structures in this function
+        if lower is None:
+            lower = False
         return solve0(
             a, b, lower=lower, overwrite_a=overwrite_a, overwrite_b=overwrite_b,
             check_finite=check_finite, assume_a=assume_a, transposed=transposed
@@ -196,6 +198,15 @@ def solve(a, b,lower=False, overwrite_a=False,
     }.get(assume_a, 'unknown')
     if structure == 'unknown':
         raise ValueError(f'{assume_a} is not a recognized matrix structure')
+
+    if (
+        (assume_a == 'pos upper' and lower is True) or
+        (assume_a == 'pos lower' and lower is False)
+    ):
+        raise ValueError(f"Conflicting {assume_a = } and {lower = }.")
+
+    if lower is None:
+        lower = False
 
     a1 = np.atleast_2d(_asarray_validated(a, check_finite=check_finite))
     b1 = np.atleast_1d(_asarray_validated(b, check_finite=check_finite))
@@ -248,7 +259,7 @@ def solve(a, b,lower=False, overwrite_a=False,
         return out[..., 0] if b_is_1D else out
 
     # heavy lifting
-    result = _batched_linalg._solve(a1, b1, structure, transposed)
+    result = _batched_linalg._solve(a1, b1, structure, lower, transposed)
     x, is_ill_cond, is_singular, info = result
 
     if info < 0:

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -101,9 +101,10 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
     St structure = St::NONE;
     int overwrite_a = 0;
     int transposed = 0;
+    int lower=0;
 
     // Get the input array
-    if (!PyArg_ParseTuple(args, "O!O!|npp", &PyArray_Type, (PyObject **)&ap_Am, &PyArray_Type, (PyObject **)&ap_b, &structure, &transposed, &overwrite_a)) {
+    if (!PyArg_ParseTuple(args, "O!O!|nppp", &PyArray_Type, (PyObject **)&ap_Am, &PyArray_Type, (PyObject **)&ap_b, &structure, &lower, &transposed, &overwrite_a)) {
         return NULL;
     }
 
@@ -154,16 +155,16 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
     void *buf = PyArray_DATA(ap_x);
     switch(typenum) {
         case(NPY_FLOAT32):
-            _solve<float>(ap_Am, ap_b, (float *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+            _solve<float>(ap_Am, ap_b, (float *)buf, structure, lower, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
         case(NPY_FLOAT64):
-            _solve<double>(ap_Am, ap_b, (double *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+            _solve<double>(ap_Am, ap_b, (double *)buf, structure, lower, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
         case(NPY_COMPLEX64):
-            _solve<npy_complex64>(ap_Am, ap_b, (npy_complex64 *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+            _solve<npy_complex64>(ap_Am, ap_b, (npy_complex64 *)buf, structure, lower, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
         case(NPY_COMPLEX128):
-            _solve<npy_complex128>(ap_Am, ap_b, (npy_complex128 *)buf, structure, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+            _solve<npy_complex128>(ap_Am, ap_b, (npy_complex128 *)buf, structure, lower, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
             break;
         default:
             PYERR(PyExc_RuntimeError, "Unknown array type.")

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -110,7 +110,7 @@ inline CBLAS_INT solve_slice_cholesky(
 
 
 template<typename T>
-void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int transposed, int overwrite_a, int* isIllconditioned, int* isSingular, int* info)
+void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int lower, int transposed, int overwrite_a, int* isIllconditioned, int* isSingular, int* info)
 {
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
@@ -119,7 +119,7 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
     char trans = transposed ? 'T' : 'N'; 
     npy_intp lower_band = 0, upper_band = 0;
     bool is_symm = false;
-    char uplo;
+    char uplo = 'X';    // sentinel
     St slice_structure = St::NONE;
     bool posdef_fallback = true;
 
@@ -173,10 +173,9 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
     if (irwork == NULL) { free(irwork); *info = -102; return; }
 
     // normalize the structure detection inputs
-    uplo = 'U';
     if (structure == St::POS_DEF) {
-        uplo = 'U';
         posdef_fallback = false;
+        uplo = lower ? 'L' : 'U';
     }
     else {
         if (structure == St::POS_DEF_UPPER) {


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Reported in https://github.com/scipy/scipy/pull/23071#issuecomment-3085826112

#### What does this implement/fix?
<!--Please explain your changes.-->

Actually plumb the 'lower' argument to the Cholesky routines in `scipy.linalg.solve`. This is a regression from gh-23071, is thus only relevant to the -dev version.

#### Additional information
<!--Any additional information you think is important.-->

While at it, improve validation for conflicting `assume_a` and `lower` arguments. At some point we should consider https://github.com/scipy/scipy/issues/23072 but for now we should error out for definitely wrong combinations.