### PR TITLE
ENH, MAINT: linalg: assume_a="diagonal" for solve and inv

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -105,7 +105,7 @@ class Bench(Benchmark):
 class BatchedSolveBench(Benchmark):
     params = [
         [(100, 10, 10), (100, 20, 20), (100, 100)],
-        ["gen", "pos", "sym"],
+        ["gen", "pos", "sym", "diagonal"],
         ["scipy", "numpy"]
     ]
     param_names = ["shape", "structure" ,"module"]
@@ -120,6 +120,10 @@ class BatchedSolveBench(Benchmark):
             self.a = a @ a.mT
         elif structure == "sym":
             self.a = a + a.mT
+        elif structure == "diagonal":
+            self.a = np.zeros_like(a)
+            for i in range(shape[-1]):
+                self.a[..., i, i] = a[..., i, i]
         else:
             self.a = a
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -79,7 +79,7 @@ def _format_emit_errors_warnings(err_lst):
 
     if singular:
         raise LinAlgError(
-            f"An ill-conditioned matrix detected: slice(s) {singular} are singular."
+            f"A singular matrix detected: slice(s) {singular} are singular."
         )
 
     if lapack_err:

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -208,9 +208,7 @@ def solve(a, b, lower=False, overwrite_a=False,
            [ 3. , -2.5],
            [ 5. , -4.5]])
     """
-    if assume_a in [
-        'diagonal', 'tridiagonal', 'banded'
-    ]:
+    if assume_a in ['tridiagonal', 'banded']:
         # TODO: handle these structures in this function
         return solve0(
             a, b, lower=lower, overwrite_a=overwrite_a, overwrite_b=overwrite_b,
@@ -221,7 +219,7 @@ def solve(a, b, lower=False, overwrite_a=False,
     structure = {
         None: -1,
         'general': 0, 'gen': 0,
-        # 'diagonal': 11,
+        'diagonal': 11,
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101, 'positive definite': 101,
@@ -1348,6 +1346,7 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
 
     =============================  ================================
      general                        'general' (or 'gen')
+     diagonal                       'diagonal'
      upper triangular               'upper triangular'
      lower triangular               'lower triangular'
      symmetric positive definite    'pos'
@@ -1355,8 +1354,10 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
      Hermitian                      'her'
     =============================  ================================
 
-    For the 'pos', 'sym' and 'her' options, only the specified triangle of the input
-    matrix is used, and the other triangle is not referenced.
+    For the 'pos' option, only the triangle of the input matrix specified in
+    the `lower` argument is used, and the other triangle is not referenced.
+    Likewise, an explicit `assume_a='diagonal'` means that off-diagonal elements
+    are not referenced.
 
     Array argument(s) of this function may have additional
     "batch" dimensions prepended to the core shape. In this case, the array is treated
@@ -1439,8 +1440,8 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
     # keep the numbers in sync with C at `linalg/src/_common_array_utils.hh`
     structure = {
         None: -1,
-        'general': 0,
-        # 'diagonal': 11,
+        'general': 0, 'gen': 0,
+        'diagonal': 11,
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101,

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -430,6 +430,7 @@ enum St : Py_ssize_t
 {
     NONE = -1,
     GENERAL = 0,
+    DIAGONAL = 11,
     UPPER_TRIANGULAR = 21,
     LOWER_TRIANGULAR = 22,
     POS_DEF = 101,

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -159,6 +159,45 @@ void invert_slice_triangular(
 }
 
 
+// Diagonal array inversion
+template<typename T>
+inline void invert_slice_diagonal(
+    CBLAS_INT N, T *data, SliceStatus& status
+) {
+    using real_type = typename type_traits<T>::real_type;
+    using value_type = typename type_traits<T>::value_type;
+    value_type *pdata = reinterpret_cast<value_type *>(data);
+
+    value_type zero(0.), one(1.);
+    real_type maxa(0.), maxinva(0.);
+
+    for (CBLAS_INT j=0; j<N; j++) {
+        value_type ajj = pdata[j*N + j];
+
+        status.is_singular = (ajj == zero);
+        if (status.is_singular) {
+            status.lapack_info  = j;
+            return;
+        }
+
+        value_type inv_ajj = one / ajj;
+        pdata[j*N + j] = inv_ajj;
+
+        // condition number
+        real_type absa = std::abs(ajj), absinva = std::abs(inv_ajj);
+
+        if(absa != absa) {
+            status.is_ill_conditioned = true;
+        } else {
+            if(absa > maxa) {maxa = absa;}
+            if(absinva > maxinva) {maxinva = absinva;}
+        }
+    }
+    status.is_ill_conditioned = status.is_ill_conditioned || (maxa * maxinva > 1./ numeric_limits<real_type>::eps);
+    status.rcond = maxa * maxinva;
+}
+
+
 template<typename T>
 int
 _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwrite_a, SliceStatusVec& vec_status)
@@ -288,7 +327,10 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
             // Get the bandwidth of the slice
             bandwidth(data, n, n, &lower_band, &upper_band);
 
-            if(lower_band == 0) {
+            if ((upper_band == 0) && (lower_band == 0)) {
+                slice_structure = St::DIAGONAL;
+            }
+            else if(lower_band == 0) {
                 slice_structure = St::UPPER_TRIANGULAR;
                 uplo = 'U';
             } else if (upper_band == 0) {
@@ -310,6 +352,19 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
         init_status(slice_status, idx, slice_structure);
 
         switch(slice_structure) {
+            case St::DIAGONAL:
+            {
+                invert_slice_diagonal(intn, data, slice_status);
+
+                if ((slice_status.lapack_info < 0) || (slice_status.is_singular )) {
+                    vec_status.push_back(slice_status);
+                    goto free_exit;
+                }
+                else if (slice_status.is_ill_conditioned) {
+                    vec_status.push_back(slice_status);
+                }
+                break;
+            }
             case St::UPPER_TRIANGULAR:
             case St::LOWER_TRIANGULAR:
             {

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -186,14 +186,10 @@ inline void invert_slice_diagonal(
         // condition number
         real_type absa = std::abs(ajj), absinva = std::abs(inv_ajj);
 
-        if(absa != absa) {
-            status.is_ill_conditioned = true;
-        } else {
-            if(absa > maxa) {maxa = absa;}
-            if(absinva > maxinva) {maxinva = absinva;}
-        }
+        if(absa > maxa) {maxa = absa;}
+        if(absinva > maxinva) {maxinva = absinva;}
     }
-    status.is_ill_conditioned = status.is_ill_conditioned || (maxa * maxinva > 1./ numeric_limits<real_type>::eps);
+    status.is_ill_conditioned = maxa * maxinva > 1./ numeric_limits<real_type>::eps;
     status.rcond = maxa * maxinva;
 }
 

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -187,14 +187,10 @@ inline void solve_slice_diagonal(
         // condition number
         real_type absa = std::abs(ajj), absinva = std::abs(inv_ajj);
 
-        if(absa != absa) {
-            status.is_ill_conditioned = true;
-        } else {
-            if(absa > maxa) {maxa = absa;}
-            if(absinva > maxinva) {maxinva = absinva;}
-        }
+        if(absa > maxa) {maxa = absa;}
+        if(absinva > maxinva) {maxinva = absinva;}
     }
-    status.is_ill_conditioned = status.is_ill_conditioned || (maxa * maxinva > 1./ numeric_limits<real_type>::eps);
+    status.is_ill_conditioned = maxa * maxinva > 1./ numeric_limits<real_type>::eps;
     status.rcond = maxa * maxinva;
 }
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -991,7 +991,7 @@ class TestSolve:
     @pytest.mark.parametrize(
         "assume_a",
         [
-            None, "general", "upper triangular", "lower triangular", "pos"
+            None, "diagonal", "general", "upper triangular", "lower triangular", "pos",
         ]
     )
     def test_vs_np_solve(self, assume_a):
@@ -1471,6 +1471,18 @@ class TestInv:
         mask = np.where(1 - np.tri(*y.shape, -1) == 0, np.nan, 1)
         y_inv_2_l = inv(y*mask.T, check_finite=False, assume_a='lower triangular')
         assert_allclose(y_inv_2_l @ np.tril(y), np.eye(5), atol=1e-15)
+
+    def test_diagonal(self):
+        a = np.stack([np.triu(np.ones((3, 3))), np.diag(np.arange(1, 4))])
+        inv_a = inv(a)
+
+        # basic diagonal invert
+        assert_allclose(inv_a[1], np.diag(1 / np.arange(1, 4)), atol=1e-14)
+
+        # ill-conditioned inputs warn
+        a = np.asarray([[1e30, 0], [0, 1]])
+        with pytest.warns(LinAlgWarning):
+            inv(a, assume_a="diagonal")
 
 
 class TestDet:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1116,6 +1116,26 @@ class TestSolve:
         with assert_raises(LinAlgError):
             solve(A, b, assume_a='pos')
 
+    def test_diagonal(self):
+        a = np.stack([np.triu(np.ones((3, 3))), np.diag(np.arange(1, 4))])
+        b = np.ones(3)
+        x = solve(a, b)
+
+        # basic diagonal solve
+        assert_allclose(x[1, ...], 1 / np.arange(1, 4), atol=1e-14)
+
+        # ill-conditioned inputs warn
+        a = np.asarray([[1e30, 0], [0, 1]])
+        b = np.ones(2)
+        with pytest.warns(LinAlgWarning):
+            solve(a, b, assume_a="diagonal")
+
+        # singular input raises
+        a = np.asarray([[0, 0], [0, 1]])
+        b = np.ones(2)
+        with pytest.raises(LinAlgError):
+            solve(a, b, assume_a="diagonal")
+
 
 class TestSolveTriangular:
 
@@ -1482,6 +1502,11 @@ class TestInv:
         # ill-conditioned inputs warn
         a = np.asarray([[1e30, 0], [0, 1]])
         with pytest.warns(LinAlgWarning):
+            inv(a, assume_a="diagonal")
+
+        # singular input raises
+        a = np.asarray([[0, 0], [0, 1]])
+        with pytest.raises(LinAlgError):
             inv(a, assume_a="diagonal")
 
 


### PR DESCRIPTION
Move `assume_a="diagonal"` mode of `scipy.linalg.solve` to C, add this mode to `inv`.

The patch is an enhancement for `inv` and MAINT for `solve`.
