### PR TITLE
DOC: Add example to `show_config()`

### DIFF
--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -138,13 +138,13 @@ def show(mode=DisplayModes.stdout.value):
 
     Examples
     --------
-    >>> import scipy as sp
-    >>> sp.show_config()
+    >>> import scipy
+    >>> scipy.show_config()
     ... # formatted output is printed to the console
 
-    >>> config_dict = sp.show_config(mode='dicts')
+    >>> config_dict = scipy.show_config(mode='dicts')
     >>> list(config_dict.keys())
-    ['pyyaml', 'lapack_info', 'openblas_info', 'blas_opt_info', 'lapack_opt_info', 'openblas_lapack_info']
+    ['Compilers', 'Machine Information', 'Build Dependencies', 'Python Information']
 
     Notes
     -----

--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -136,6 +136,16 @@ def show(mode=DisplayModes.stdout.value):
     out : {`dict`, `None`}
         If mode is `'dicts'`, a dict is returned, else None
 
+    Examples
+    --------
+    >>> import scipy as sp
+    >>> sp.show_config()
+    ... # formatted output is printed to the console
+
+    >>> config_dict = sp.show_config(mode='dicts')
+    >>> list(config_dict.keys())
+    ['pyyaml', 'lapack_info', 'openblas_info', 'blas_opt_info', 'lapack_opt_info', 'openblas_lapack_info']
+
     Notes
     -----
     1. The `'stdout'` mode will give more readable


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Issue (https://github.com/scipy/scipy/issues/7168) 
#### What does this implement/fix?
This pull request adds a usage example to the docstring for the `scipy.show_config` function. The example demonstrates both the default `stdout` mode and the `dicts` mode.

#### Additional information
<!--Any additional information you think is important.-->
As a first-time contributor, I welcome any feedback on improving this pull request.