### PR TITLE
DOC: io: add docstrings to warnings and errors

### DIFF
--- a/scipy/io/arff/_arffread.py
+++ b/scipy/io/arff/_arffread.py
@@ -52,10 +52,22 @@ r_wcomattrval = re.compile(r"(\S+)\s+(..+$)")
 
 
 class ArffError(OSError):
+    """
+    Base exception for errors when reading ARFF files.
+    
+    Raised when an ARFF file cannot be read due to file access issues,
+    corruption, or unsupported features.
+    """
     pass
 
 
 class ParseArffError(ArffError):
+    """
+    Exception for syntax and parsing errors in ARFF files.
+    
+    Raised when an ARFF file has invalid syntax, malformed attributes,
+    or data that doesn't match the expected format.
+    """
     pass
 
 

--- a/scipy/io/wavfile.py
+++ b/scipy/io/wavfile.py
@@ -25,6 +25,12 @@ __all__ = [
 
 
 class WavFileWarning(UserWarning):
+    """
+    Warning for WAV files with format issues that can still be read.
+    
+    Raised when a WAV file has problems like missing metadata or 
+    non-standard formatting, but can still be processed successfully.
+    """
     pass
 
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #23208

#### What does this implement/fix?
This PR adds the missing docstrings for `WavFileWarning`, `ArffError`, and `ParseArffError` in the `scipy.io` module. This ensures that the purpose of each warning and exception is clear in the generated documentation.

#### Additional information
<!--Any additional information you think is important.-->
