### PR TITLE
MAINT: linalg.{inv, solve}: better error reporting for batched arrays

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1324,7 +1324,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
 
 
 # matrix inversion
-def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
+def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
     r"""
     Compute the inverse of a matrix.
 
@@ -1336,11 +1336,11 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
      general                        'general' (or 'gen')
      upper triangular               'upper triangular'
      lower triangular               'lower triangular'
-     symmetric positive definite    'pos', 'pos upper', 'pos lower'
+     symmetric positive definite    'pos'
     =============================  ================================
 
-    For the 'pos upper' and 'pos lower' options, only the specified
-    triangle of the input matrix is used, and the other triangle is not referenced.
+    For the 'pos' option, only the specified triangle of the input matrix is used, and
+    the other triangle is not referenced.
 
     Array argument(s) of this function may have additional
     "batch" dimensions prepended to the core shape. In this case, the array is treated
@@ -1360,6 +1360,11 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
         Valid entries are described above.
         If omitted or ``None``, checks are performed to identify structure so the
         appropriate solver can be called.
+    lower : bool, optional
+        Ignored unless assume_a is one of 'sym', 'her', or 'pos'. If True, the
+        calculation uses only the data in the lower triangle of `a`; entries above the
+        diagonal are ignored. If False (default), the calculation uses only the data in
+        the upper triangle of `a`; entries below the diagonal are ignored.
 
     Returns
     -------
@@ -1423,12 +1428,10 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101,
-        'pos upper': 111,     # the "other" triangle is not referenced
-        'pos lower': 112,
     }[assume_a]
 
     # a1 is well behaved, invert it.
-    inv_a, err_lst = _batched_linalg._inv(a1, structure, overwrite_a)
+    inv_a, err_lst = _batched_linalg._inv(a1, structure, overwrite_a, lower)
 
     # emit helpful errors/warnings
     if err_lst:

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1351,8 +1351,8 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
      symmetric positive definite    'pos'
     =============================  ================================
 
-    For the 'pos' option, only the specified triangle of the input matrix is used, and
-    the other triangle is not referenced.
+    For the 'pos' option, only the triangle of the input matrix specified in
+    the `lower` argument is used, and the other triangle is not referenced.
 
     Array argument(s) of this function may have additional
     "batch" dimensions prepended to the core shape. In this case, the array is treated
@@ -1373,7 +1373,7 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
         If omitted or ``None``, checks are performed to identify structure so the
         appropriate solver can be called.
     lower : bool, optional
-        Ignored unless assume_a is one of 'sym', 'her', or 'pos'. If True, the
+        Ignored unless `assume_a` is one of 'sym', 'her', or 'pos'. If True, the
         calculation uses only the data in the lower triangle of `a`; entries above the
         diagonal are ignored. If False (default), the calculation uses only the data in
         the upper triangle of `a`; entries below the diagonal are ignored.

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -63,7 +63,7 @@ def _find_matrix_structure(a):
     return kind, n_below, n_above
 
 
-def solve(a, b, lower=None, overwrite_a=False,
+def solve(a, b, lower=False, overwrite_a=False,
           overwrite_b=False, check_finite=True, assume_a=None,
           transposed=False):
     """
@@ -182,8 +182,6 @@ def solve(a, b, lower=None, overwrite_a=False,
         'sym', 'her', 'symmetric', 'hermitian', 'diagonal', 'tridiagonal', 'banded'
     ]:
         # TODO: handle these structures in this function
-        if lower is None:
-            lower = False
         return solve0(
             a, b, lower=lower, overwrite_a=overwrite_a, overwrite_b=overwrite_b,
             check_finite=check_finite, assume_a=assume_a, transposed=transposed
@@ -197,20 +195,9 @@ def solve(a, b, lower=None, overwrite_a=False,
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101, 'positive definite': 101,
-        'pos upper': 111,     # the "other" triangle is not referenced
-        'pos lower': 112,
     }.get(assume_a, 'unknown')
     if structure == 'unknown':
         raise ValueError(f'{assume_a} is not a recognized matrix structure')
-
-    if (
-        (assume_a == 'pos upper' and lower is True) or
-        (assume_a == 'pos lower' and lower is False)
-    ):
-        raise ValueError(f"Conflicting {assume_a = } and {lower = }.")
-
-    if lower is None:
-        lower = False
 
     a1 = np.atleast_2d(_asarray_validated(a, check_finite=check_finite))
     b1 = np.atleast_1d(_asarray_validated(b, check_finite=check_finite))

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1428,15 +1428,33 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
     }[assume_a]
 
     # a1 is well behaved, invert it.
-    result = _batched_linalg._inv(a1, structure, overwrite_a)
-    inv_a, is_ill_cond, is_singular, info = result
+    inv_a, err_lst = _batched_linalg._inv(a1, structure, overwrite_a)
 
-    if info < 0:
-        raise ValueError("Internal LAPACK error.")
-    if is_singular:
-        raise LinAlgError("A singular matrix detected")
-    if is_ill_cond:
-        warnings.warn("An ill-conditioned matrix detected", LinAlgWarning, stacklevel=2)
+    # emit helpful errors/warnings
+    if err_lst:
+        singular, lapack_err, ill_cond = [], [], []
+        for i, dct in enumerate(err_lst):
+            if dct["is_singular"]:
+                singular.append(i)
+            if dct["lapack_info"] < 0:
+                lapack_err.append(f"slice {i} emits lapack info={dct['lapack_info']}")
+            if dct["is_ill_conditioned"]:
+                ill_cond.append(f"slice {i} has rcond = {dct['rcond']}")
+
+        if singular:
+            raise LinAlgError(
+                f"An ill-conditioned matrix detected: slice(s) {singular} are singular."
+            )
+
+        if lapack_err:
+            raise ValueError(f"Internal LAPACK errors: {','.join(lapack_err)}.")
+
+        if ill_cond:
+           warnings.warn(
+                f"An ill-conditioned matrix detected: {','.join(ill_cond)}.",
+                LinAlgWarning,
+                stacklevel=2
+            )
 
     return inv_a
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -63,7 +63,7 @@ def _find_matrix_structure(a):
     return kind, n_below, n_above
 
 
-def _format_errors(err_lst):
+def _format_emit_errors_warnings(err_lst):
     """Format/emit errors/warnings from a lowlevel batched routine.
 
     See inv, solve.
@@ -282,9 +282,8 @@ def solve(a, b, lower=False, overwrite_a=False,
     # heavy lifting
     x, err_lst = _batched_linalg._solve(a1, b1, structure, lower, transposed)
 
-    # emit helpful errors/warnings
     if err_lst:
-        _format_errors(err_lst)
+        _format_emit_errors_warnings(err_lst)
 
     if b_is_1D:
         x = x[..., 0]
@@ -1446,9 +1445,8 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
     # a1 is well behaved, invert it.
     inv_a, err_lst = _batched_linalg._inv(a1, structure, overwrite_a, lower)
 
-    # emit helpful errors/warnings
     if err_lst:
-        _format_errors(err_lst)
+        _format_emit_errors_warnings(err_lst)
 
     return inv_a
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -10,6 +10,10 @@
 static PyObject* _linalg_inv_error;
 
 
+PyObject* 
+convert_vec_status(SliceStatusVec& vec_status);
+
+
 static PyObject*
 _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
@@ -20,8 +24,6 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
     St structure = St::NONE;
     int overwrite_a;
     int lower;
-    PyObject *ret_dct = NULL;
-    PyObject *ret_lst = NULL;
 
     // Get the input array
     if (!PyArg_ParseTuple(args, ("O!|npp"), &PyArray_Type, (PyObject **)&ap_Am, &structure, &overwrite_a, &lower)) {
@@ -85,26 +87,7 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
         Py_DECREF(ap_Ainv);
         PYERR(PyExc_RuntimeError, "Memory error in scipy.linalg.inv.")
     }
-    if (vec_status.empty()) {
-        ret_lst = PyList_New(0);
-    } else {
-        // Problems detected in some slices, report.
-
-        ret_lst = PyList_New(0);
-        for (size_t i=0; i<vec_status.size(); i++) {
-            SliceStatus status = vec_status[i];
-            ret_dct = Py_BuildValue(
-                "{s:n,s:n,s:i,s:i,s:d,s:n}",
-                "num", status.slice_num,
-                "structure", status.structure,
-                "is_singular", status.is_singular,
-                "is_ill_conditioned", status.is_ill_conditioned,
-                "rcond", status.rcond,
-                "lapack_info", status.lapack_info
-            );
-            PyList_Append(ret_lst, ret_dct);
-        }
-    }
+    PyObject *ret_lst = convert_vec_status(vec_status);
 
     return Py_BuildValue("NN", PyArray_Return(ap_Ainv), ret_lst);
 }
@@ -118,8 +101,7 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     PyArrayObject *ap_x = NULL;
     int info = 0;
-    int isIllconditioned = 0;
-    int isSingular = 0;
+    SliceStatusVec vec_status;
     St structure = St::NONE;
     int overwrite_a = 0;
     int transposed = 0;
@@ -177,29 +159,62 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
     void *buf = PyArray_DATA(ap_x);
     switch(typenum) {
         case(NPY_FLOAT32):
-            _solve<float>(ap_Am, ap_b, (float *)buf, structure, lower, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+            info = _solve<float>(ap_Am, ap_b, (float *)buf, structure, lower, transposed, overwrite_a, vec_status);
             break;
         case(NPY_FLOAT64):
-            _solve<double>(ap_Am, ap_b, (double *)buf, structure, lower, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+            info = _solve<double>(ap_Am, ap_b, (double *)buf, structure, lower, transposed, overwrite_a, vec_status);
             break;
         case(NPY_COMPLEX64):
-            _solve<npy_complex64>(ap_Am, ap_b, (npy_complex64 *)buf, structure, lower, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+            info = _solve<npy_complex64>(ap_Am, ap_b, (npy_complex64 *)buf, structure, lower, transposed, overwrite_a, vec_status);
             break;
         case(NPY_COMPLEX128):
-            _solve<npy_complex128>(ap_Am, ap_b, (npy_complex128 *)buf, structure, lower, transposed, overwrite_a, &isIllconditioned, &isSingular, &info);
+            info = _solve<npy_complex128>(ap_Am, ap_b, (npy_complex128 *)buf, structure, lower, transposed, overwrite_a, vec_status);
             break;
         default:
             PYERR(PyExc_RuntimeError, "Unknown array type.")
     }
 
-    if(info < 0) {
+    if (info < 0) {
         // Either OOM or internal LAPACK error.
         Py_DECREF(ap_x);
-        PYERR(PyExc_RuntimeError, "Internal LAPACK failure in scipy.linalg.solve.")
+        PYERR(PyExc_RuntimeError, "Memory error in scipy.linalg.solve.")
     }
+    PyObject *ret_lst = convert_vec_status(vec_status);
+
+    return Py_BuildValue("NN", PyArray_Return(ap_x), ret_lst);
+}
 
 
-    return Py_BuildValue("Niii", PyArray_Return(ap_x), isIllconditioned, isSingular, info);
+
+/*
+ * Helper: convert a vector of slice error statuses to list of dicts
+ */
+PyObject* 
+convert_vec_status(SliceStatusVec& vec_status) {
+    PyObject *ret_dct = NULL;
+    PyObject *ret_lst = NULL;
+
+    if (vec_status.empty()) {
+        ret_lst = PyList_New(0);
+    } else {
+        // Problems detected in some slices, report.
+
+        ret_lst = PyList_New(0);
+        for (size_t i=0; i<vec_status.size(); i++) {
+            SliceStatus status = vec_status[i];
+            ret_dct = Py_BuildValue(
+                "{s:n,s:n,s:i,s:i,s:d,s:n}",
+                "num", status.slice_num,
+                "structure", status.structure,
+                "is_singular", status.is_singular,
+                "is_ill_conditioned", status.is_ill_conditioned,
+                "rcond", status.rcond,
+                "lapack_info", status.lapack_info
+            );
+            PyList_Append(ret_lst, ret_dct);
+        }
+    }
+    return ret_lst;
 }
 
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -19,11 +19,12 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
     SliceStatusVec vec_status;
     St structure = St::NONE;
     int overwrite_a;
+    int lower;
     PyObject *ret_dct = NULL;
     PyObject *ret_lst = NULL;
 
     // Get the input array
-    if (!PyArg_ParseTuple(args, ("O!|np"), &PyArray_Type, (PyObject **)&ap_Am, &structure, &overwrite_a)) {
+    if (!PyArg_ParseTuple(args, ("O!|npp"), &PyArray_Type, (PyObject **)&ap_Am, &structure, &overwrite_a, &lower)) {
         return NULL;
     }
 
@@ -64,16 +65,16 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
     void *buf = PyArray_DATA(ap_Ainv);
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _inverse<float>(ap_Am, (float *)buf, structure, overwrite_a, vec_status);
+            info = _inverse<float>(ap_Am, (float *)buf, structure, lower, overwrite_a, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _inverse<double>(ap_Am, (double *)buf, structure, overwrite_a, vec_status);
+            info = _inverse<double>(ap_Am, (double *)buf, structure, lower, overwrite_a, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _inverse<npy_complex64>(ap_Am, (npy_complex64 *)buf, structure, overwrite_a, vec_status);
+            info = _inverse<npy_complex64>(ap_Am, (npy_complex64 *)buf, structure, lower, overwrite_a, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _inverse<npy_complex128>(ap_Am, (npy_complex128 *)buf, structure, overwrite_a, vec_status);
+            info = _inverse<npy_complex128>(ap_Am, (npy_complex128 *)buf, structure, lower, overwrite_a, vec_status);
             break;
         default:
             PYERR(PyExc_RuntimeError, "Unknown array type.")

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -275,6 +275,21 @@ enum St : Py_ssize_t
 
 
 /*
+ * Rich return object
+ */
+struct SliceStatus {
+    Py_ssize_t slice_num;
+    Py_ssize_t structure;
+    int is_singular;
+    int is_ill_conditioned;
+    double rcond;
+    Py_ssize_t lapack_info;
+};
+
+typedef std::vector<SliceStatus> SliceStatusVec;
+
+
+/*
  * Copy n-by-m slice from slice_ptr to dst.
  */
 template<typename T>

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -286,6 +286,17 @@ struct SliceStatus {
     Py_ssize_t lapack_info;
 };
 
+
+void init_status(SliceStatus& slice_status, npy_intp idx, St slice_structure) {
+    slice_status.slice_num = idx;
+    slice_status.structure = (Py_ssize_t)slice_structure;
+    slice_status.is_singular = 0;
+    slice_status.is_ill_conditioned = 0;
+    slice_status.rcond = 0;
+    slice_status.lapack_info = 0;
+}
+
+
 typedef std::vector<SliceStatus> SliceStatusVec;
 
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -269,8 +269,8 @@ enum St : Py_ssize_t
     UPPER_TRIANGULAR = 21,
     LOWER_TRIANGULAR = 22,
     POS_DEF = 101,
-    POS_DEF_UPPER = 111,
-    POS_DEF_LOWER = 112,
+    SYM = 201,
+    HER = 211
 };
 
 

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -169,7 +169,11 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     T* work = &buffer[2*n*n];
 
     CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
-    if (ipiv == NULL) { free(ipiv); info = -102; return (int)info; }
+    if (ipiv == NULL) {
+        free(buffer);
+        info = -102;
+        return (int)info;
+    }
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
@@ -178,7 +182,12 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
     }
-    if (irwork == NULL) { free(irwork); info = -102; return (int)info; }
+    if (irwork == NULL) {
+        free(buffer);
+        free(ipiv);
+        info = -102;
+        return (int)info;
+    }
 
     // normalize the structure detection inputs
     uplo = lower? 'L' : 'U';

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -11,15 +11,6 @@
 #include "_common_array_utils.hh"
 
 
-void init_status(SliceStatus& slice_status, npy_intp idx, St slice_structure) {
-    slice_status.slice_num = idx;
-    slice_status.structure = (Py_ssize_t)slice_structure;
-    slice_status.is_singular = 0;
-    slice_status.is_ill_conditioned = 0;
-    slice_status.rcond = 0;
-    slice_status.lapack_info = 0;
-}
-
 // Dense array inversion with getrf, gecon and getri
 template<typename T>
 void invert_slice_general(

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -3,6 +3,7 @@
  */
 #include "Python.h"
 #include <iostream>
+#include <vector>
 #include "numpy/arrayobject.h"
 #include "numpy/npy_math.h"
 #include "npy_cblas.h"
@@ -10,11 +11,20 @@
 #include "_common_array_utils.hh"
 
 
+void init_status(SliceStatus& slice_status, npy_intp idx, St slice_structure) {
+    slice_status.slice_num = idx;
+    slice_status.structure = (Py_ssize_t)slice_structure;
+    slice_status.is_singular = 0;
+    slice_status.is_ill_conditioned = 0;
+    slice_status.rcond = 0;
+    slice_status.lapack_info = 0;
+}
+
 // Dense array inversion with getrf, gecon and getri
 template<typename T>
-inline CBLAS_INT invert_slice_general(
+void invert_slice_general(
     CBLAS_INT N, T *data, CBLAS_INT *ipiv, void *irwork, T *work, CBLAS_INT lwork,
-    int* isIllconditioned, int* isSingular
+    SliceStatus& status
 ) {
     using real_type = typename type_traits<T>::real_type;
 
@@ -25,24 +35,24 @@ inline CBLAS_INT invert_slice_general(
 
     getrf(&N, &N, data, &N, ipiv, &info);
 
+    status.lapack_info = (Py_ssize_t)info;
     if (info == 0){
         // getrf success, check the condition number
         gecon(&norm, &N, data, &N, &anorm, &rcond, work, irwork, &info);
 
+        status.rcond = (double)rcond;
         if (info >= 0) {
-            *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
 
             // finally, invert
             getri(&N, data, &N, ipiv, work, &lwork, &info);
-            *isSingular = (info > 0);
+            status.is_singular = (info > 0);
         }
     }
     else if (info > 0) {
         // trf detected singularity
-        *isSingular = 1;
+        status.is_singular = 1;
     }
-
-    return info;
 }
 
 
@@ -50,9 +60,9 @@ inline CBLAS_INT invert_slice_general(
 
 // Symmetric/hermitian array inversion with potrf, pocon and potri
 template<typename T>
-inline CBLAS_INT invert_slice_cholesky(
+void invert_slice_cholesky(
     char uplo, CBLAS_INT N, T *data, T* work, void *irwork,
-    int* isIllconditioned, int* isSingular
+    SliceStatus& status
 ) {
     using real_type = typename type_traits<T>::real_type;
 
@@ -62,32 +72,33 @@ inline CBLAS_INT invert_slice_cholesky(
     real_type rcond;
 
     potrf(&uplo, &N, data, &N, &info);
+
+    status.lapack_info = (Py_ssize_t)info;
     if (info == 0) {
         // potrf success
         pocon(&uplo, &N, data, &N, &anorm, &rcond, work, irwork, &info);
 
         if (info >= 0) {
-            *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.rcond = (double)rcond;
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
 
             // finally, invert
             potri(&uplo, &N, data, &N, &info);
-            *isSingular = (info > 0);
+            status.is_singular = (info > 0);
         }
     }
     else if (info > 0) {
         // trf detected singularity
-        *isSingular = 1;
+        status.is_singular = 1;
     }
-
-    return info;
 }
 
 
 // triangular array inversion with trtri
 template<typename T>
-inline CBLAS_INT invert_slice_triangular(
+void invert_slice_triangular(
     char uplo, char diag, CBLAS_INT N, T *data, T *work, void *irwork,
-    int* isIllconditioned, int* isSingular
+    SliceStatus& status
 ) {
     using real_type = typename type_traits<T>::real_type;
 
@@ -96,31 +107,32 @@ inline CBLAS_INT invert_slice_triangular(
     real_type rcond;
 
     trtri(&uplo, &diag, &N, data, &N, &info);
-    *isSingular  = (info > 0);
+    status.is_singular  = (info > 0);
 
+    status.lapack_info = (Py_ssize_t)info;
     if(info >= 0) {
 
         trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
         if (info >= 0) {
-            *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.rcond = (double)rcond;
         }
     }
-    return info;
 }
 
 
 template<typename T>
-void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, int* isIllconditioned, int* isSingular, CBLAS_INT* info)
+int
+_inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, SliceStatusVec& vec_status)
 {
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
-    *isIllconditioned = 0;
-    *isSingular = 0;
     npy_intp lower_band = 0, upper_band = 0;
     bool is_symm = false;
     char uplo;
     St slice_structure = St::NONE;
     bool posdef_fallback = true;
+    SliceStatus slice_status;
 
     // --------------------------------------------------------------------
     // Input Array Attributes
@@ -141,10 +153,10 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     T tmp = numeric_limits<T>::zero;
-    CBLAS_INT intn = (CBLAS_INT)n, lwork = -1;
+    CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
 
-    getri(&intn, NULL, &intn, NULL, &tmp, &lwork, info);
-    if (*info != 0) { *info = -100; return; }
+    getri(&intn, NULL, &intn, NULL, &tmp, &lwork, &info);
+    if (info != 0) { info = -100; return (int)info; }
 
     /*
      * The factor of 1.01 here mirrors
@@ -158,7 +170,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
 
     lwork = (4*n > lwork ? 4*n : lwork); // gecon needs at least 4*n
     T* buffer = (T *)malloc((2*n*n + lwork)*sizeof(T));
-    if (NULL == buffer) { *info = -101; return; }
+    if (NULL == buffer) { info = -101; return (int)info; }
 
     // Chop buffer into parts, one for data and one for work
     T* data = &buffer[0];
@@ -166,7 +178,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
     T* work = &buffer[2*n*n];
 
     CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
-    if (ipiv == NULL) { free(ipiv); *info = -102; return; }
+    if (ipiv == NULL) { free(ipiv); info = -102; return (int)info; }
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
@@ -175,7 +187,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
     }
-    if (irwork == NULL) { free(irwork); *info = -102; return; }
+    if (irwork == NULL) { free(irwork); info = -102; return (int)info; }
 
     // normalize the structure detection inputs
     uplo = 'U';
@@ -241,23 +253,34 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
             }
         }
 
+        init_status(slice_status, idx, slice_structure);
+
         switch(slice_structure) {
             case St::UPPER_TRIANGULAR:
             case St::LOWER_TRIANGULAR:
             {
                 char diag = 'N';
-                *info = invert_slice_triangular(uplo, diag, intn, data, work, irwork, isIllconditioned, isSingular);
+                invert_slice_triangular(uplo, diag, intn, data, work, irwork, slice_status);
 
-                if ((*info < 0) || (*isSingular )) { goto free_exit;}
+                if ((slice_status.lapack_info < 0) || (slice_status.is_singular )) {
+                    vec_status.push_back(slice_status);
+                    goto free_exit;
+                }
+                else if (slice_status.is_ill_conditioned) {
+                    vec_status.push_back(slice_status);
+                }
                 zero_other_triangle(uplo, data, intn);
                 break;
             }
             case St::POS_DEF:
             {
-                *info = invert_slice_cholesky(uplo, intn, data, work, irwork, isIllconditioned, isSingular);
+                invert_slice_cholesky(uplo, intn, data, work, irwork, slice_status);
 
-                if ((*info == 0) || (*isSingular == 0) ) {
-                    // success
+                if ((slice_status.lapack_info == 0) || (!slice_status.is_singular) ) {
+                    // success (maybe ill-conditioned)
+                    if(slice_status.is_ill_conditioned) {
+                        vec_status.push_back(slice_status);
+                    }
                     fill_other_triangle(uplo, data, intn);
                     break;
                 }
@@ -266,11 +289,13 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
                         // restore
                         copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
                         swap_cf(scratch, data, n, n, n);
+                        init_status(slice_status, idx, slice_structure);
 
                         // no break: fall back to the general solver
                     }
                     else {
                         // potrf failed but no fallback
+                        vec_status.push_back(slice_status);
                         break;
                     }
                 }
@@ -278,11 +303,16 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
             default:
             {
                 // general matrix inverse
-                *info = invert_slice_general(intn, data, ipiv, irwork, work, lwork, isIllconditioned, isSingular);
+                invert_slice_general(intn, data, ipiv, irwork, work, lwork, slice_status);
+
+                if ((slice_status.lapack_info != 0) || slice_status.is_singular || slice_status.is_ill_conditioned) {
+                    // some problem detected, store data to report
+                    vec_status.push_back(slice_status);
+                }
             }
         }
 
-        if (*isSingular == 1) {
+        if (slice_status.is_singular == 1) {
             // nan_matrix(data, n);
             goto free_exit;     // fail fast and loud
         }
@@ -295,6 +325,6 @@ free_exit:
     free(buffer);
     free(irwork);
     free(ipiv);
-    return;
+    return 1;
 }
 

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -123,7 +123,7 @@ void invert_slice_triangular(
 
 template<typename T>
 int
-_inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, SliceStatusVec& vec_status)
+_inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwrite_a, SliceStatusVec& vec_status)
 {
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
@@ -190,22 +190,9 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, Slice
     if (irwork == NULL) { free(irwork); info = -102; return (int)info; }
 
     // normalize the structure detection inputs
-    uplo = 'U';
+    uplo = lower? 'L' : 'U';
     if (structure == St::POS_DEF) {
-        uplo = 'U';
         posdef_fallback = false;
-    }
-    else {
-        if (structure == St::POS_DEF_UPPER) {
-            structure = St::POS_DEF;
-            uplo = 'U';
-            posdef_fallback = false;
-        }
-        else if (structure == St::POS_DEF_LOWER) {
-            structure = St::POS_DEF;
-            uplo = 'L';
-            posdef_fallback = false;
-        }
     }
     if (structure == St::LOWER_TRIANGULAR) {
         uplo = 'L';
@@ -244,7 +231,6 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, Slice
                 is_symm = is_sym_herm(data, n);
                 if (is_symm) {
                     slice_structure = St::POS_DEF;
-                    uplo = 'U';
                 }
                 else {
                     // give up auto-detection

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -161,7 +161,11 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     T* work = &buffer[2*n*n + n*nrhs];
 
     CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
-    if (ipiv == NULL) { free(ipiv); info = -102; return (int)info; }
+    if (ipiv == NULL) {
+        free(buffer);
+        info = -102;
+        return (int)info;
+    }
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
@@ -170,7 +174,12 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
     }
-    if (irwork == NULL) { free(irwork); info = -102; return (int)info; }
+    if (irwork == NULL) {
+        free(buffer);
+        free(ipiv);
+        info = -102;
+        return (int)info;
+    }
 
     // normalize the structure detection inputs
     uplo = lower ? 'L' : 'U';

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -173,21 +173,9 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
     if (irwork == NULL) { free(irwork); *info = -102; return; }
 
     // normalize the structure detection inputs
+    uplo = lower ? 'L' : 'U';
     if (structure == St::POS_DEF) {
         posdef_fallback = false;
-        uplo = lower ? 'L' : 'U';
-    }
-    else {
-        if (structure == St::POS_DEF_UPPER) {
-            structure = St::POS_DEF;
-            uplo = 'U';
-            posdef_fallback = false;
-        }
-        else if (structure == St::POS_DEF_LOWER) {
-            structure = St::POS_DEF;
-            uplo = 'L';
-            posdef_fallback = false;
-        }
     }
     if (structure == St::LOWER_TRIANGULAR) {
         uplo = 'L';
@@ -237,7 +225,6 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
                 is_symm = is_sym_herm(data, n);
                 if (is_symm) {
                     slice_structure = St::POS_DEF;
-                    uplo = 'U';
                 }
                 else {
                     // give up auto-detection

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1386,13 +1386,13 @@ class TestInv:
 
         assert_allclose(y_inv1, y_inv0, atol=1e-15)
 
-        # check that the lower triangle is not referenced for "pos upper"
+        # check that the lower triangle is not referenced for `lower=False`
         mask = np.where(1 - np.tri(*y.shape, -1) == 0, np.nan, 1)
-        y_inv2 = inv(y*mask, check_finite=False, assume_a="pos upper")
+        y_inv2 = inv(y*mask, check_finite=False, assume_a="pos", lower=False)
         assert_allclose(y_inv2, y_inv0, atol=1e-15)
 
-        # repeat with the upper triangle and "pos lower"
-        y_inv3 = inv(y*mask.T, check_finite=False, assume_a="pos lower")
+        # repeat with the upper triangle
+        y_inv3 = inv(y*mask.T, check_finite=False, assume_a="pos", lower=True)
         assert_allclose(y_inv3, y_inv0, atol=1e-15)
 
     def test_posdef_not_posdef(self):
@@ -1400,13 +1400,18 @@ class TestInv:
         a = np.arange(9).reshape(3, 3)
         b = a + a.T + np.eye(3)
 
-        # cholesky solver fails, and the routine falls back to the general inverse
+        # cholesky solver fails, and the routine falls back to the symmetric inverse
         b_inv0 = inv(b)
         assert_allclose(b_inv0 @ b, np.eye(3), atol=3e-15)
 
         # but it does not fall back if `assume_a` is given
         with assert_raises(LinAlgError):
             inv(b, assume_a='pos')
+
+        # TODO:
+        #   1. posdef fallback for complex symmetric, hermitian inputs
+        #   2. assume_a = "sym" for real and complex
+        #   3. assume_a = "her" for real and complex
 
     def test_triangular_1(self):
         x = np.arange(25, dtype=float).reshape(5, 5)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -992,8 +992,7 @@ class TestSolve:
     @pytest.mark.parametrize(
         "assume_a",
         [
-            None, "general", "upper triangular", "lower triangular",
-            "pos", "pos upper", "pos lower"
+            None, "general", "upper triangular", "lower triangular", "pos"
         ]
     )
     def test_vs_np_solve(self, assume_a):
@@ -1022,19 +1021,9 @@ class TestSolve:
         result_np = np.linalg.solve(aa, b)
         assert_allclose(out, result_np, atol=1e-15)
 
-        out = solve(a, b, assume_a='pos lower')
-        assert_allclose(out, result_np, atol=1e-15)
-
         # repeat with uplo='U'
         out = solve(a.T, b, assume_a='pos', lower=False)
         assert_allclose(out, result_np, atol=1e-15)
-
-        out = solve(a.T, b, assume_a='pos upper')
-        assert_allclose(out, result_np, atol=1e-15)
-
-        # conflicting assume_a & lower
-        with assert_raises(ValueError):
-            solve(a, b, assume_a='pos upper', lower=True)
 
     def test_readonly(self):
         a = np.eye(3)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1368,6 +1368,10 @@ class TestInv:
         with pytest.warns(LinAlgWarning):
             inv(a)
 
+        a2 = np.stack([np.diag([1., 1e-20]), np.diag([1, 1]), np.diag([1, 1e-20])])
+        with pytest.warns(LinAlgWarning):
+            inv(a2)
+
     def test_wrong_assume_a(self):
         with assert_raises(KeyError):
             inv(np.eye(2), assume_a="kaboom")


### PR DESCRIPTION
- Return a rich(-er) structure from the low-level inversion routine, account for e.g. multiple slices being ill-conditioned.

For each "problematic" slice of batched array, we fill in a struct of diagostic values (whether it is singular or ill-conditioned, whether a LAPACK routine detects an internal error etc), collect all such slices into vector, and convert it into a list of dicts, which can be easily manipulated on the python side. python-side handling is minimal ATM--- the main point of this PR is to lay the groundwork, and we'll be able to polish the reporting as we gain some usage.

cross-ref the "make error handling more flexible" and "improve error reporting" bullets of https://github.com/scipy/scipy/issues/23141

- remove `assume_a = "pos lower" from inv and solve. This mode was not released yet, therefore we should remove it before they are frozen by the 1.17 release.

- tighten the memory allocation strategy, plug a potential memory leak.
