### PR TITLE
TST: linalg: small tolerance bump for `test_orth_memory_efficiency`

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2916,7 +2916,7 @@ def _check_orth(n, dtype, skip_big=False):
 
     Y = orth(X)
     assert_equal(Y.shape, (n, 1))
-    assert_allclose(Y, Y.mean(), atol=tol)
+    assert_allclose(Y, Y.mean(), atol=tol, rtol=1.4e-7)
 
     Y = orth(X.T)
     assert_equal(Y.shape, (2, 1))


### PR DESCRIPTION
This was failing in a cross compilation CI job from x86-64 to aarch64 ([CI log](https://github.com/rgommers/scipy/actions/runs/16294476137/job/46013373138)):
```
>       assert_allclose(Y, Y.mean(), atol=tol)
E       AssertionError:
E       Not equal to tolerance rtol=1e-07, atol=2.22045e-13
E
E       Mismatched elements: 1 / 10000000 (1e-05%)
E       Max absolute difference among violations: 4.29873957e-11
E       Max relative difference among violations: 1.35938081e-07
E        ACTUAL: array([[-0.000316],
E              [-0.000316],
E              [-0.000316],...
E        DESIRED: array(-0.000316)
```

It's only a minor bump, the default rtol of 1e-7 was used before.