### PR TITLE
ENH: Add ``NdBSpline.derivative`` method

### DIFF
--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -282,26 +282,24 @@ class NdBSpline:
 
         Parameters
         ----------
-        nu : int or array_like of shape (ndim,)
+        nu : array_like of shape (ndim,)
             Order(s) of the derivative to compute along each dimension.
-            A single integer means the same order for all dimensions.
 
         Returns
         -------
         NdBSpline
             A new NdBSpline representing the derivative.
         """
-        nu_arr = np.atleast_1d(nu)
+        nu_arr = np.asarray(nu, dtype=np.int64)
         ndim = len(self.t)
 
-        if nu_arr.ndim > 1 or (nu_arr.shape[0] != 1 and nu_arr.shape[0] != ndim):
-            raise ValueError(f"Invalid derivative orders {nu = } for ndim = {ndim}")
-
-        if nu_arr.shape[0] == 1:
-            nu_arr = np.repeat(nu_arr, ndim)
+        if nu_arr.ndim != 1 or nu_arr.shape[0] != ndim:
+            raise ValueError(
+                f"invalid number of derivative orders {nu = } for "
+                f"ndim = {len(self.t)}.")
 
         if any(n < 0 for n in nu_arr):
-            raise ValueError("Derivative orders must be non-negative")
+            raise ValueError(f"derivatives must be positive, got {nu = }")
 
         t_new = list(self.t)
         k_new = list(self.k)

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -311,7 +311,10 @@ class NdBSpline:
             for _ in range(n):
                 k_current = k_new[axis]
                 if k_current < 1:
-                    raise ValueError(f"Derivative order too high along axis {axis}")
+                    # No degree left -> derivative is identically zero
+                    c_new[...] = 0.0
+                    k_new[axis] = 0
+                    break  # No need to continue differentiating this axis
 
                 c_new, t_new[axis] = self._bspline_derivative_along_axis(
                     c_new, t_new[axis], k_current, axis

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1068,8 +1068,7 @@ class TestRectBivariateSpline:
         with assert_raises(ValueError):
             lut.partial_derivative(4, 1)
 
-        with assert_raises(ValueError):
-            lut_ndbspline.derivative([4, 1])
+        assert (lut_ndbspline.derivative([4, 1]).c == 0.0).all()
 
     def test_broadcast(self):
         x = array([1,2,3,4,5])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Coming from second point of, https://github.com/czgdp1807/scipy/pull/21#issuecomment-3067047601,

> `RectBivariateSpline.partial_derivative` : we'd want to add a corresponding method to NdBSpline. Implementation wise AFAICS the low-level routine, `fitpack/pardtc.f`, is equivalent to applying `splder` in a loop over dimensions. This should be done in a separate PR though. The name of the method should probably follow that of NdPPoly, https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NdPPoly.derivative.html#scipy.interpolate.NdPPoly.derivative

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR adds a `.derivative()` method to the `NdBSpline` class, enabling evaluation of partial derivatives of B-splines along each axis.

## 🔧 What’s Added

- `NdBSpline.derivative(nu)` method, where `nu` is a list/array of derivative orders per axis.
- Internally uses 1D `BSpline.derivative()` applied along each axis.

## ✅ Tests

Added thorough unit tests to validate correctness of `NdBSpline.derivative()` by comparing results against `RectBivariateSpline.partial_derivative`:

- `test_partial_derivative_method_grid`: full grid-based derivative comparison
- `test_partial_derivative_method`: pointwise (grid=False) diagonal derivative check
- DRY principle applied across tests for clarity and maintainability
- Currently tests only the 2D case using `RectBivariateSpline` for validation
- ~More generic test coverage for **higher-dimensional splines** will follow in subsequent commits.~ I have added the tests for higher dimensions as well.

#### Additional information
<!--Any additional information you think is important.-->

cc: @rgommers @ev-br 
