### PR TITLE
MAINT: backports for SciPy 1.16.1

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,7 +88,7 @@ jobs:
         - [macos-14, macosx, arm64, openblas, "12.3"]
         - [macos-14, macosx, arm64, accelerate, "14.0"]
         - [windows-2022, win, AMD64, "", ""]
-        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"]]
+        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314-dev"], ["cp314t", "cp314-dev"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -183,26 +183,29 @@ jobs:
           fi
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
-      # - name: Inject environment variable for python dev version
-      #   if: ${{ matrix.python[1] == '3.14-dev'
-      #   shell: bash
-      #   run: |
-      #     # For dev versions of python need to use wheels from scientific-python-nightly-wheels
-      #     # When the python version is released please comment out this section, but do not remove
-      #     # (there will soon be another dev version to target).
-      #     DEPS0="pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-      #     DEPS1="pip install ninja meson-python pybind11 pythran cython"
+      - name: Inject environment variable for python dev versions
+        if: ${{ endswith(matrix.python[1], '-dev') }}
+        shell: bash
+        run: |
+          # For dev versions of python need to use wheels from scientific-python-nightly-wheels
+          # When the python version is released please comment out this section, but do not remove
+          # (there will soon be another dev version to target).
+          DEPS0="pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
+          DEPS1="pip install ninja meson-python pybind11 pythran cython"
 
-      #     CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
-      #     echo "CIBW_BEFORE_BUILD_LINUX=$CIBW" >> "$GITHUB_ENV"
+          CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+          echo "CIBW_BEFORE_BUILD_LINUX=$CIBW" >> "$GITHUB_ENV"
 
-      #     CIBW="$DEPS0 && $DEPS1 && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
-      #     echo "CIBW_BEFORE_BUILD_WINDOWS=$CIBW" >> "$GITHUB_ENV"
+          CIBW="$DEPS0 && $DEPS1 && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
+          echo "CIBW_BEFORE_BUILD_WINDOWS=$CIBW" >> "$GITHUB_ENV"
 
-      #     CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
-      #     echo "CIBW_BEFORE_BUILD_MACOS=$CIBW" >> "$GITHUB_ENV"
+          CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+          echo "CIBW_BEFORE_BUILD_MACOS=$CIBW" >> "$GITHUB_ENV"
 
-      #     echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
+          echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
+
+          CIBW="build; args: --no-isolation"
+          echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@5f22145df44122af0f5a201f93cf0207171beca7 # v3.0.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,6 +90,13 @@ jobs:
         - [windows-2022, win, AMD64, "", ""]
         python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314-dev"], ["cp314t", "cp314-dev"]]
         # python[0] is used to specify the python versions made by cibuildwheel
+        exclude:
+            # This combination was hanging consistently with CPython 3.14.0b2, retry later
+          - python: ["cp314t", "cp314-dev"]
+            buildplat: [ubuntu-24.04-arm, musllinux, aarch64, "", ""]
+            # This combination was failing repeatedly on pythran codegen, see gh-23187
+          - python: ["cp314t", "cp314-dev"]
+            buildplat: [ubuntu-22.04, musllinux, x86_64, "", ""]
 
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,7 +88,7 @@ jobs:
         - [macos-14, macosx, arm64, openblas, "12.3"]
         - [macos-14, macosx, arm64, accelerate, "14.0"]
         - [windows-2022, win, AMD64, "", ""]
-        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314-dev"], ["cp314t", "cp314-dev"]]
+        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314"], ["cp314t", "cp314"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -183,29 +183,30 @@ jobs:
           fi
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
-      - name: Inject environment variable for python dev versions
-        if: ${{ endswith(matrix.python[1], '-dev') }}
-        shell: bash
-        run: |
-          # For dev versions of python need to use wheels from scientific-python-nightly-wheels
-          # When the python version is released please comment out this section, but do not remove
-          # (there will soon be another dev version to target).
-          DEPS0="pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-          DEPS1="pip install ninja meson-python pybind11 pythran cython"
 
-          CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
-          echo "CIBW_BEFORE_BUILD_LINUX=$CIBW" >> "$GITHUB_ENV"
+      # - name: Inject environment variable for python dev version
+      #   if: ${{ matrix.python[1] == '3.14-dev'
+      #   shell: bash
+      #   run: |
+      #     # For dev versions of python need to use wheels from scientific-python-nightly-wheels
+      #     # When the python version is released please comment out this section, but do not remove
+      #     # (there will soon be another dev version to target).
+      #     DEPS0="pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
+      #     DEPS1="pip install ninja meson-python pybind11 pythran cython"
 
-          CIBW="$DEPS0 && $DEPS1 && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
-          echo "CIBW_BEFORE_BUILD_WINDOWS=$CIBW" >> "$GITHUB_ENV"
+      #     CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+      #     echo "CIBW_BEFORE_BUILD_LINUX=$CIBW" >> "$GITHUB_ENV"
 
-          CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
-          echo "CIBW_BEFORE_BUILD_MACOS=$CIBW" >> "$GITHUB_ENV"
+      #     CIBW="$DEPS0 && $DEPS1 && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
+      #     echo "CIBW_BEFORE_BUILD_WINDOWS=$CIBW" >> "$GITHUB_ENV"
 
-          echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
+      #     CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+      #     echo "CIBW_BEFORE_BUILD_MACOS=$CIBW" >> "$GITHUB_ENV"
 
-          CIBW="build; args: --no-isolation"
-          echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
+      #     echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
+
+      #     CIBW="build; args: --no-isolation"
+      #     echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@ffd835cef18fa11522f608fc0fa973b89f5ddc87 # v3.1.0

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -215,7 +215,7 @@ jobs:
           echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@5f22145df44122af0f5a201f93cf0207171beca7 # v3.0.0
+        uses: pypa/cibuildwheel@ffd835cef18fa11522f608fc0fa973b89f5ddc87 # v3.1.0
         env:
           CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}*
           CIBW_ARCHS: ${{ matrix.buildplat[2] }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,13 +90,6 @@ jobs:
         - [windows-2022, win, AMD64, "", ""]
         python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314-dev"], ["cp314t", "cp314-dev"]]
         # python[0] is used to specify the python versions made by cibuildwheel
-        exclude:
-            # This combination was hanging consistently with CPython 3.14.0b2, retry later
-          - python: ["cp314t", "cp314-dev"]
-            buildplat: [ubuntu-24.04-arm, musllinux, aarch64, "", ""]
-            # This combination was failing repeatedly on pythran codegen, see gh-23187
-          - python: ["cp314t", "cp314-dev"]
-            buildplat: [ubuntu-22.04, musllinux, x86_64, "", ""]
 
     env:
       IS_32_BIT: ${{ matrix.buildplat[2] == 'x86' }}

--- a/doc/source/release/1.16.1-notes.rst
+++ b/doc/source/release/1.16.1-notes.rst
@@ -4,8 +4,8 @@ SciPy 1.16.1 Release Notes
 
 .. contents::
 
-SciPy 1.16.1 is a bug-fix release with no new features
-compared to 1.16.0.
+SciPy 1.16.1 is a bug-fix release that adds support for
+Python 3.14.0rc1, including PyPI wheels.
 
 
 

--- a/doc/source/release/1.16.1-notes.rst
+++ b/doc/source/release/1.16.1-notes.rst
@@ -12,12 +12,57 @@ compared to 1.16.0.
 Authors
 =======
 * Name (commits)
+* Evgeni Burovski (1)
+* Rob Falck (1)
+* Ralf Gommers (7)
+* Geoffrey Gunter (1) +
+* Matt Haberland (2)
+* Joren Hammudoglu (1)
+* Andrew Nelson (2)
+* newyork_loki (1) +
+* Ilhan Polat (1)
+* Tyler Reddy (25)
+* Daniel Schmitz (1)
+* Dan Schult (2)
+
+    A total of 12 people contributed to this release.
+    People with a "+" by their names contributed a patch for the first time.
+    This list of names is automatically generated, and may not be fully complete.
 
 
 Issues closed for 1.16.1
 ------------------------
 
+* `#23075 <https://github.com/scipy/scipy/issues/23075>`__: BUG: ndimage.median_filter: always returns ``0`` on single element...
+* `#23158 <https://github.com/scipy/scipy/issues/23158>`__: BUG: optimize.shgo: unbounded cache in Complex.split_edge
+* `#23216 <https://github.com/scipy/scipy/issues/23216>`__: BUG: ``@_transition_to_rng`` leads to inconsistent function signatures
+* `#23217 <https://github.com/scipy/scipy/issues/23217>`__: BUG: stats.beta.entropy: doesn't work with array-valued a, b
+* `#23221 <https://github.com/scipy/scipy/issues/23221>`__: BUG: signal.tf2sos: ``ComplexWarning``
+* `#23277 <https://github.com/scipy/scipy/issues/23277>`__: BUG: signal.freqz: erroneously returns complex-valued frequencies
+* `#23278 <https://github.com/scipy/scipy/issues/23278>`__: BUG: linalg.sqrtm: incorrect results in 1.16.0 when at least...
+* `#23321 <https://github.com/scipy/scipy/issues/23321>`__: BUG: CSC matrix multiplication and indptrs
+* `#23329 <https://github.com/scipy/scipy/issues/23329>`__: BUG: Compilation failure in HiGHs with MSVC
+* `#23338 <https://github.com/scipy/scipy/issues/23338>`__: DOC: optimize.minimize: erroneously claims COBYLA doesn't support...
 
 
 Pull requests for 1.16.1
 ------------------------
+
+* `#23167 <https://github.com/scipy/scipy/pull/23167>`__: BUG: optimize.shgo: Complex cache ``split_edge`` differently
+* `#23187 <https://github.com/scipy/scipy/pull/23187>`__: CI: add cp314/cp314t nighly wheel builds
+* `#23206 <https://github.com/scipy/scipy/pull/23206>`__: DOC: ndimage.vectorized_filter: correct ``output`` description
+* `#23214 <https://github.com/scipy/scipy/pull/23214>`__: REL, MAINT: prep for 1.16.1
+* `#23222 <https://github.com/scipy/scipy/pull/23222>`__: BUG: signal.tf2sos: fix a new ``ComplexWarning``
+* `#23266 <https://github.com/scipy/scipy/pull/23266>`__: BUG: signal.remez: fix handling of ``weight`` array
+* `#23276 <https://github.com/scipy/scipy/pull/23276>`__: BUG: fix signature of ``@_transition_to_rng`` functions (SPEC...
+* `#23279 <https://github.com/scipy/scipy/pull/23279>`__: BUG: linalg: Fix pointer casting order for sqrtm
+* `#23280 <https://github.com/scipy/scipy/pull/23280>`__: BUG: fix broadcasting in ``beta.entropy()`` with new infrastructure
+* `#23284 <https://github.com/scipy/scipy/pull/23284>`__: DOC: optimize.least_squares: minor nit
+* `#23293 <https://github.com/scipy/scipy/pull/23293>`__: BUG: ndimage.median_filter: single element array handling
+* `#23322 <https://github.com/scipy/scipy/pull/23322>`__: BUG: sparse: ``multiply()`` should produce CSC output for CSC...
+* `#23332 <https://github.com/scipy/scipy/pull/23332>`__: BLD: Add bigobj flag for MSVC to fix object file section limit
+* `#23339 <https://github.com/scipy/scipy/pull/23339>`__: DOC: optimize.minimize: remove outdated limitation for equality...
+* `#23348 <https://github.com/scipy/scipy/pull/23348>`__: MAINT: sparse: ``multiply()`` uses attribute presence instead...
+* `#23380 <https://github.com/scipy/scipy/pull/23380>`__: CI: bump to cibuildwheel 3.1.0 for 3.14.0rc1, add cp314t musllinux...
+* `#23384 <https://github.com/scipy/scipy/pull/23384>`__: CI: disable special-casing of 3.14-dev now that Python 3.14rc1...
+* `#23387 <https://github.com/scipy/scipy/pull/23387>`__: MAINT: Python 3.14 to classifiers

--- a/meson.build
+++ b/meson.build
@@ -98,6 +98,10 @@ if ff.has_argument('-Wno-conversion')
   add_project_arguments('-Wno-conversion', language: 'fortran')
 endif
 
+if cpp.get_id() == 'msvc'
+  add_project_arguments('/bigobj', language: 'cpp')
+endif
+
 if host_machine.system() == 'darwin'
   if cc.has_link_argument('-Wl,-dead_strip')
     # Allow linker to strip unused symbols

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ requires = [
     # Cython version bounds policy applies
     "Cython>=3.0.8,<3.2.0",
     # The upper bound on pybind11 is pre-emptive only
-    "pybind11>=2.13.2,<2.14.0",
+    "pybind11>=2.13.2,<3.1.0",
     # The upper bound on pythran is pre-emptive only; 0.18.0
     # is released/working at the time of writing
     "pythran>=0.14.0,<0.19.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -351,6 +351,13 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None,
 
             return fun(*args, **kwargs)
 
+        # Add the old parameter name to the function signature
+        wrapped_signature = inspect.signature(fun)
+        wrapper.__signature__ = wrapped_signature.replace(parameters=[
+            *wrapped_signature.parameters.values(),
+            inspect.Parameter(old_name, inspect.Parameter.KEYWORD_ONLY, default=None),
+        ])
+
         if replace_doc:
             doc = FunctionDoc(wrapper)
             parameter_names = [param.name for param in doc['Parameters']]

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -2,7 +2,10 @@
 
 """
 
+import platform
 import os
+import random
+import sys
 import zlib
 
 from io import BytesIO
@@ -15,6 +18,7 @@ import numpy as np
 
 from numpy.testing import assert_, assert_equal
 from pytest import raises as assert_raises
+import pytest
 
 from scipy.io.matlab._streams import (make_stream,
     GenericStream, ZlibInputStream,
@@ -194,6 +198,9 @@ class TestZlibInputStream:
         stream.seek(1024)
         assert_(stream.all_data_read())
 
+    @pytest.mark.skipif(
+            (platform.system() == 'Windows' and sys.version_info >= (3, 14)),
+            reason='gh-23185')
     def test_all_data_read_overlap(self):
         COMPRESSION_LEVEL = 6
 
@@ -210,6 +217,9 @@ class TestZlibInputStream:
         stream.seek(len(data))
         assert_(stream.all_data_read())
 
+    @pytest.mark.skipif(
+            (platform.system() == 'Windows' and sys.version_info >= (3, 14)),
+            reason='gh-23185')
     def test_all_data_read_bad_checksum(self):
         COMPRESSION_LEVEL = 6
 

--- a/scipy/io/matlab/tests/test_streams.py
+++ b/scipy/io/matlab/tests/test_streams.py
@@ -4,7 +4,6 @@
 
 import platform
 import os
-import random
 import sys
 import zlib
 

--- a/scipy/linalg/_matfuncs_sqrtm.c
+++ b/scipy/linalg/_matfuncs_sqrtm.c
@@ -533,7 +533,7 @@ matrix_squareroot_c(const PyArrayObject* ap_Am, SCIPY_C* restrict ret_data, int*
     SCIPY_C* restrict data = &buffer[0];
     SCIPY_C* restrict vs = &buffer[n*n];
     SCIPY_C* restrict w = &buffer[2*n*n];
-    float* restrict rwork = &((float*)buffer)[2*n*n + n];
+    float* restrict rwork = (float*)(&buffer[2*n*n + n]);
     SCIPY_C* restrict work = &buffer[2*n*n + 2*n];
 
     for (npy_intp idx = 0; idx < outer_size; idx++) {
@@ -635,7 +635,7 @@ matrix_squareroot_z(const PyArrayObject* ap_Am, SCIPY_Z* restrict ret_data, int*
     SCIPY_Z* restrict data = &buffer[0];
     SCIPY_Z* restrict vs = &buffer[n*n];
     SCIPY_Z* restrict w = &buffer[2*n*n];
-    double* restrict rwork = &((double*)buffer)[2*n*n + n];
+    double* restrict rwork = (double*)(&buffer[2*n*n + n]);
     SCIPY_Z* restrict work = &buffer[2*n*n + 2*n];
 
     for (npy_intp idx = 0; idx < outer_size; idx++) {

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -460,6 +460,13 @@ class TestSqrtM:
         np.fill_diagonal(M, 1)
         assert np.isrealobj(sqrtm(M))
 
+    def test_gh23278(self):
+        M = np.array([[1., 0., 0.], [0, 1, -1j], [0, 1j, 2]])
+        sq = sqrtm(M)
+        assert_allclose(sq @ sq, M, atol=1e-14)
+        sq = sqrtm(M.astype(np.complex64))
+        assert_allclose(sq @ sq, M, atol=1e-6)
+
     def test_data_size_preservation_uint_in_float_out(self):
         M = np.eye(10, dtype=np.uint8)
         assert sqrtm(M).dtype == np.float64

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1989,7 +1989,14 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
                 "A sequence of modes is not supported by non-separable rank "
                 "filters")
         mode = _ni_support._extend_mode_to_code(mode, is_filter=True)
-        if input.ndim == 1:
+        # Some corner cases are currently not allowed to use the
+        # "new"/fast 1D rank filter code, including when the
+        # footprint is large compared to the array size.
+        # See discussion in gh-23293; longer-term it may be possible
+        # to allow the fast path for these corner cases as well,
+        # if algorithmic fixes are found.
+        lim2 = input.size - ((footprint.size - 1) // 2 - origin)
+        if input.ndim == 1 and ((lim2 >= 0) or (input.size == 1)):
             if input.dtype in (np.int64, np.float64, np.float32):
                 x = input
                 x_out = output

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -232,7 +232,9 @@ def vectorized_filter(input, function, *, size=None, footprint=None, output=None
         We adjust `size` to the number of dimensions indicated by `axes`.
         For instance, if `axes` is ``(0, 2, 1)`` and ``n`` is passed for ``size``,
         then the effective `size` is ``(n, n, n)``.
-    %(output)s
+    output : array, optional
+        The array in which to place the output. By default, an array of the dtype
+        returned by `function` will be created.
     mode : {'reflect', 'constant', 'nearest', 'mirror', 'wrap'}, optional
         The `mode` parameter determines how the input array is extended
         beyond its boundaries. Default is 'reflect'. Behavior for each valid

--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -155,7 +155,26 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
                   int mode, T cval, int origin) {
   int i, arr_len_thresh, lim = (win_len - 1) / 2 - origin;
   int lim2 = arr_len - lim;
-  if (lim2 < 0) return;
+  /* Note: `arr_len == 1` is the only case implemented here for `lim2 < 0`; the calling code */
+  /* in _filters.py ensures that this function isn't called otherwise. xref gh-23293 for details. */
+  if (lim2 < 0 && arr_len == 1) {
+      switch (mode) {
+          case REFLECT:
+          case NEAREST:
+          case WRAP:
+          case MIRROR:
+              out_arr[0] = in_arr[0];
+              return;
+          case CONSTANT:
+              if (win_len == 1) {
+                  out_arr[0] = in_arr[0];
+              }
+              else {
+                  out_arr[0] = cval;
+              }
+              return;
+      }
+  }
   int offset;
   Mediator *m = MediatorNew(win_len, rank);
   T *data = new T[win_len]();

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3029,3 +3029,55 @@ class TestVectorizedFilter:
 def test_gh_22586_crash_property(x, size, mode):
     # property-based test for median_filter resilience to hard crashing
     ndimage.median_filter(x, size=size, mode=mode)
+
+
+@pytest.mark.parametrize('samples, mode, size, expected', [
+    ([1, 2], "reflect", 5, [2, 1]),
+    ([2], "reflect", 5, [2]), # original failure from gh-23075
+    ([2], "nearest", 5, [2]),
+    ([2], "wrap", 5, [2]),
+    ([2], "mirror", 5, [2]),
+    ([2], "constant", 5, [0]),
+    ([2], "reflect", 1, [2]),
+    ([2], "nearest", 1, [2]),
+    ([2], "wrap", 1, [2]),
+    ([2], "mirror", 1, [2]),
+    ([2], "constant", 1, [2]),
+    ([2], "reflect", 100, [2]),
+    ([2], "nearest", 100, [2]),
+    ([2], "wrap", 100, [2]),
+    ([2], "mirror", 100, [2]),
+    ([2], "constant", 100, [0]),
+])
+def test_gh_23075(samples, mode, size, expected):
+    # results verified against SciPy 1.14.1, before the median_filter
+    # overhaul
+    sample_array = np.asarray(samples, dtype=np.float32)
+    expected = np.asarray(expected, dtype=np.float32)
+    filtered_samples = ndimage.median_filter(sample_array, size=size, mode=mode)
+    xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)
+
+
+@pytest.mark.parametrize('samples, size, cval, expected', [
+    ([2], 5, 17.7, [17.7]),
+    ([2], 1, 0, [2]),
+    ([2], 100, 1.4, [1.4]),
+    ([9], 137, -7807.7, [-7807.7]),
+])
+def test_gh_23075_constant(samples, size, cval, expected):
+    # results verified against SciPy 1.14.1, before the median_filter
+    # overhaul
+    sample_array = np.asarray(samples, dtype=np.single)
+    expected = np.asarray(expected, dtype=np.single)
+    filtered_samples = ndimage.median_filter(sample_array,
+                                             size=size,
+                                             mode="constant",
+                                             cval=cval)
+    xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)
+
+
+def test_median_filter_lim2():
+    sample_array = np.ones(8)
+    expected = np.ones(8)
+    filtered_samples = ndimage.median_filter(sample_array, size=19, mode="reflect")
+    xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)

--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -17,7 +17,7 @@ from .trf import trf
 from .dogbox import dogbox
 from .common import EPS, in_bounds, make_strictly_feasible
 
-    
+
 from scipy.optimize._optimize import _wrap_callback
 
 TERMINATION_MESSAGES = {
@@ -392,7 +392,7 @@ def least_squares(
 
         * For 'trf'    : ``x_scale == 1``
         * For 'dogbox' : ``x_scale == 1``
-        * For 'jac'    : ``x_scale == 'jac'``
+        * For 'lm'     : ``x_scale == 'jac'``
 
         .. versionchanged:: 1.16.0
             The default keyword value is changed from 1 to None to indicate that

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -188,7 +188,6 @@ def minimize(fun, x0, args=(), method=None, jac=None, hess=None,
 
         Equality constraint means that the constraint function result is to
         be zero whereas inequality means that it is to be non-negative.
-        Note that COBYLA only supports inequality constraints.
 
     tol : float, optional
         Tolerance for termination. When `tol` is specified, the selected

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -183,6 +183,7 @@ class Complex:
             self.V = VertexCacheIndex()
 
         self.V_non_symm = []  # List of non-symmetric vertices
+        self.split_edge = cache(self._split_edge)
 
     def __call__(self):
         return self.H
@@ -995,8 +996,7 @@ class Complex:
                 d_v0v1.connect(d_v1v2)
         return
 
-    @cache
-    def split_edge(self, v1, v2):
+    def _split_edge(self, v1, v2):
         v1 = self.V[v1]
         v2 = self.V[v2]
         # Destroy original edge, if it exists:

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -834,7 +834,7 @@ def remez(numtaps, bands, desired, *, weight=None, type='bandpass',
     xp = array_namespace(bands, desired, weight)
     bands = np.asarray(bands)
     desired = np.asarray(desired)
-    if weight:
+    if weight is not None:
         weight = np.asarray(weight)
 
     fs = _validate_fs(fs, allow_none=True)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -546,6 +546,11 @@ class TestRemez:
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
             remez(11, .1, 1, fs=np.array([10, 20]))
 
+    def test_gh_23266(self, xp):
+        bands = xp.asarray([0.0, 0.2, 0.3, 0.5])
+        desired = xp.asarray([1.0, 0.0])
+        weight = xp.asarray([1.0, 2.0])
+        remez(21, bands, desired, weight=weight)
 
 
 @skip_xp_backends(cpu_only=True, reason="lstsq")

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -494,6 +494,8 @@ class _spbase(SparseABC):
             return self._mul_scalar(other)
 
         if self.ndim < 3:
+            if self.format in ('bsr', 'csc', 'csr'):  # DIA has its own multiply
+                return self._multiply_2d_with_broadcasting(other)
             return self.tocsr()._multiply_2d_with_broadcasting(other)
 
         if not (issparse(other) or isdense(other)):

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -494,9 +494,10 @@ class _spbase(SparseABC):
             return self._mul_scalar(other)
 
         if self.ndim < 3:
-            if self.format in ('bsr', 'csc', 'csr'):  # DIA has its own multiply
+            try:
                 return self._multiply_2d_with_broadcasting(other)
-            return self.tocsr()._multiply_2d_with_broadcasting(other)
+            except AttributeError:
+                return self.tocsr()._multiply_2d_with_broadcasting(other)
 
         if not (issparse(other) or isdense(other)):
             # If it's a list or whatever, treat it like an array

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1624,6 +1624,9 @@ class _TestCommon:
         B = array([[0,7,0],[0,-4,0]])
         Asp = self.spcreator(A)
         Bsp = self.spcreator(B)
+        # check output format
+        out_fmt = Asp.format if Asp.format in ('csc', 'dia', 'bsr') else 'csr'
+        assert (Asp.multiply(Bsp)).format == out_fmt
         assert_almost_equal(Asp.multiply(Bsp).toarray(), A*B)  # sparse/sparse
         assert_almost_equal(Asp.multiply(B).toarray(), A*B)  # sparse/dense
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5003,6 +5003,19 @@ class TestBeta:
         #     return float(entropy)
         assert_allclose(stats.beta(a, b).entropy(), ref, rtol=tol)
 
+    def test_entropy_broadcasting(self):
+        # gh-23127 reported that the entropy method of the beta
+        # distribution did not broadcast correctly.
+        Beta = stats.make_distribution(stats.beta)
+        a = np.asarray([5e6, 100, 1e9, 10])
+        b = np.asarray([5e6, 1e9, 100, 20])
+        res = Beta(a=a, b=b).entropy()
+        ref = np.asarray([Beta(a=a[0], b=b[0]).entropy(),
+                          Beta(a=a[1], b=b[1]).entropy(),
+                          Beta(a=a[2], b=b[2]).entropy(),
+                          Beta(a=a[3], b=b[3]).entropy()])
+        assert_allclose(res, ref)
+
 
 class TestBetaPrime:
     # the test values are used in test_cdf_gh_17631 / test_ppf_gh_17631

--- a/scipy/stats/tests/test_fast_gen_inversion.py
+++ b/scipy/stats/tests/test_fast_gen_inversion.py
@@ -6,6 +6,7 @@ from numpy.testing import (assert_array_equal, assert_allclose,
 from copy import deepcopy
 from scipy.stats.sampling import FastGeneratorInversion
 from scipy import stats
+from scipy._lib._testutils import IS_MUSL
 
 
 def test_bad_args():
@@ -142,6 +143,7 @@ def test_geninvgauss_uerror():
 
 
 # TODO: add more distributions
+@pytest.mark.skipif(IS_MUSL, reason="Hits RecursionError, see gh-23172")
 @pytest.mark.fail_slow(5)
 @pytest.mark.parametrize(("distname, args"), [("beta", (0.11, 0.11))])
 def test_error_extreme_params(distname, args):


### PR DESCRIPTION
The time for SciPy `1.16.1` is probably drawing closer given the recent release of ABI-stable CPython `3.14.0rc1`, and also just the general accumulation of bugs. For the pre-requisite NumPy release that supports `3.14`, Chuck mentioned in the NumPy meeting this morning a few things about `cibuildwheel` (lack of stable release maybe?), and some Cirrus->GHA migration stuff happening there. Anyway, I'll keep an eye on the supporting NumPy release progress.

Backports included (so far, and with merge conflicts noted):

1. gh-23206
2. gh-23279
3. gh-23284
4. gh-23322
5. gh-23332 (**merge conflicts resolved manually**)
6. gh-23339
7. gh-23348
8. gh-23167
9. gh-23266
10. gh-23276
11. gh-23280
12. gh-23293
13. gh-23387
14. gh-23384
15. gh-23380
16. gh-23187

Backports already merged to the maintenance branch:
1. gh-23222

TODO:

- [x] backports needed for building wheels/supporting `3.14`? may still need a bit of action on `main` as well?
- [x] any other unmerged backports? I'd like to see gh-23293 backported, that fixes a pretty egregious bug, but it is my PR so would prefer not to self-merge
- [x] free-threading status/concerns? We ended up disabling the `3.13t` CI tests on the release branch here to just get things released--do we want to try to re-enable (it has been re-enabled on `main`, though I think just quite recently with Nathan's push) and also support `3.14t`? This may be quite a mess of backports?
- [x] update the release notes when the backporting work is done, and to add a short blurb about `3.14` support
- [x] get the CI passing, up to and including confirmation of `3.14`/`3.14t` wheel build/test success I suppose--that's going to be a decent number of wheels with `3.13`/ `3.13t` as well?