### PR TITLE
MAINT: stats: Apply xp_capabilities decorator to all public functions

### DIFF
--- a/doc/source/array_api_capabilities_table.py
+++ b/doc/source/array_api_capabilities_table.py
@@ -120,6 +120,7 @@ class ArrayAPISupportPerFunction(SphinxDirective):
 
         new_rows = []
         S = BackendSupportStatus
+        missing_xp_capabilities = False
         for row in relevant_rows:
             func = row["function"]
             new_row = [self._get_generated_doc_link_for_function(module, func)]
@@ -132,6 +133,8 @@ class ArrayAPISupportPerFunction(SphinxDirective):
                     cell_text = "✔️"
                 elif supported == S.NO:
                     cell_text = "✖"
+                else:
+                    missing_xp_capabilities = True
                 new_row.append(cell_text)
             new_rows.append(new_row)
         table_nodes = _make_reST_table(new_rows, headers, self.state)
@@ -141,7 +144,10 @@ class ArrayAPISupportPerFunction(SphinxDirective):
         legend += nodes.paragraph(text="✔️ = supported")
         legend += nodes.paragraph(text="✖ = unsupported")
         legend += nodes.paragraph(text="N/A = out-of-scope")
-        legend += nodes.paragraph(text="blank = not currently documented")
+        if missing_xp_capabilities:
+            # Only include blank in the legend if there are actually functions
+            # missing the xp_capabilities decorator.
+            legend += nodes.paragraph(text="blank = not currently documented")
         return [legend] + table_nodes
 
 def setup(app: Sphinx) -> ExtensionMetadata:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1644,7 +1644,7 @@ def test_align_vectors_noise(xp):
     xp_assert_close(error_vector[2], xp.asarray(0.0)[()], atol=tolerance)
 
     # Check error bounds using covariance matrix
-    cov *= sigma
+    cov *= xp.asarray(sigma)
     xp_assert_close(cov[0, 0], xp.asarray(0.0)[()], atol=tolerance)
     xp_assert_close(cov[1, 1], xp.asarray(0.0)[()], atol=tolerance)
     xp_assert_close(cov[2, 2], xp.asarray(0.0)[()], atol=tolerance)

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -4,6 +4,8 @@ import numpy as np
 from operator import index
 from collections import namedtuple
 
+from scipy._lib._array_api import xp_capabilities
+
 __all__ = ['binned_statistic',
            'binned_statistic_2d',
            'binned_statistic_dd']
@@ -13,6 +15,7 @@ BinnedStatisticResult = namedtuple('BinnedStatisticResult',
                                    ('statistic', 'bin_edges', 'binnumber'))
 
 
+@xp_capabilities(np_only=True)
 def binned_statistic(x, values, statistic='mean',
                      bins=10, range=None):
     """
@@ -192,6 +195,7 @@ BinnedStatistic2dResult = namedtuple('BinnedStatistic2dResult',
                                       'binnumber'))
 
 
+@xp_capabilities(np_only=True)
 def binned_statistic_2d(x, y, values, statistic='mean',
                         bins=10, range=None, expand_binnumbers=False):
     """
@@ -373,6 +377,7 @@ def _bincount(x, weights):
     return z
 
 
+@xp_capabilities(np_only=True)
 def binned_statistic_dd(sample, values, statistic='mean',
                         bins=10, range=None, expand_binnumbers=False,
                         binned_statistic_result=None):

--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -1,5 +1,6 @@
 from math import sqrt
 import numpy as np
+from scipy._lib._array_api import xp_capabilities
 from scipy._lib._util import _validate_int
 from scipy.optimize import brentq
 from scipy.special import ndtri
@@ -199,6 +200,7 @@ def _binom_wilson_conf_int(k, n, confidence_level, alternative, correction):
     return lo, hi
 
 
+@xp_capabilities(np_only=True)
 def binomtest(k, n, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.

--- a/scipy/stats/_bws_test.py
+++ b/scipy/stats/_bws_test.py
@@ -1,6 +1,7 @@
 import numpy as np
 from functools import partial
 from scipy import stats
+from scipy._lib._array_api import xp_capabilities
 
 
 def _bws_input_validation(x, y, alternative, method):
@@ -59,6 +60,7 @@ def _bws_statistic(x, y, alternative, axis):
     return B
 
 
+@xp_capabilities(np_only=True)
 def bws_test(x, y, *, alternative="two-sided", method=None):
     r'''Perform the Baumgartner-Weiss-Schindler test on two independent samples.
 

--- a/scipy/stats/_correlation.py
+++ b/scipy/stats/_correlation.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy import stats
+from scipy._lib._array_api import xp_capabilities
 from scipy.stats._stats_py import _SimpleNormal, SignificanceResult, _get_pvalue
 from scipy.stats._axis_nan_policy import _axis_nan_policy_factory
 
@@ -85,6 +86,7 @@ def _unpack(res, _):
     return res.statistic, res.pvalue
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(SignificanceResult, paired=True, n_samples=2,
                           result_to_tuple=_unpack, n_outputs=2, too_small=1)
 def chatterjeexi(x, y, *, axis=0, y_continuous=False, method='asymptotic'):

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -8,7 +8,7 @@ import math
 import numpy as np
 from numpy import inf
 
-from scipy._lib._array_api import xp_promote
+from scipy._lib._array_api import xp_capabilities, xp_promote
 from scipy._lib._util import _rng_spawn, _RichResult
 from scipy._lib._docscrape import ClassDoc, NumpyDocString
 from scipy import special, stats
@@ -3865,6 +3865,7 @@ _distribution_names = {
 
 
 # beta, genextreme, gengamma, t, tukeylambda need work for 1D arrays
+@xp_capabilities(np_only=True)
 def make_distribution(dist):
     """Generate a `UnivariateDistribution` class from a compatible object
 
@@ -4533,6 +4534,7 @@ class TruncatedDistribution(TransformedDistribution):
                     f"lb={str(self.lb)}, ub={str(self.ub)})")
 
 
+@xp_capabilities(np_only=True)
 def truncate(X, lb=-np.inf, ub=np.inf):
     """Truncate the support of a random variable.
 
@@ -4958,6 +4960,7 @@ class OrderStatisticDistribution(TransformedDistribution):
                     f"n={str(self.n)})")
 
 
+@xp_capabilities(np_only=True)
 def order_statistic(X, /, *, r, n):
     r"""Probability distribution of an order statistic
 
@@ -5621,6 +5624,7 @@ class FoldedDistribution(TransformedDistribution):
             return f"abs({str(self._dist)})"
 
 
+@xp_capabilities(np_only=True)
 def abs(X, /):
     r"""Absolute value of a random variable
 
@@ -5663,6 +5667,7 @@ def abs(X, /):
     return FoldedDistribution(X)
 
 
+@xp_capabilities(np_only=True)
 def exp(X, /):
     r"""Natural exponential of a random variable
 
@@ -5709,6 +5714,7 @@ def exp(X, /):
                                             logdh=lambda u: -np.log(u))
 
 
+@xp_capabilities(np_only=True)
 def log(X, /):
     r"""Natural logarithm of a non-negative random variable
 

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -9,11 +9,12 @@ import numpy as np
 from scipy import special
 from ._axis_nan_policy import _axis_nan_policy_factory
 from scipy._lib._array_api import (array_namespace, xp_promote, xp_device,
-                                   is_marray, _share_masks)
+                                   is_marray, _share_masks, xp_capabilities)
 
 __all__ = ['entropy', 'differential_entropy']
 
 
+@xp_capabilities()
 @_axis_nan_policy_factory(
     lambda x: x,
     n_samples=lambda kwgs: (
@@ -175,6 +176,7 @@ def _differential_entropy_is_too_small(samples, kwargs, axis=-1):
     return False
 
 
+@xp_capabilities()
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x, _: (x,),
     too_small=_differential_entropy_is_too_small

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -2,6 +2,7 @@ import warnings
 from collections import namedtuple
 import numpy as np
 from scipy import optimize, stats
+from scipy._lib._array_api import xp_capabilities
 from scipy._lib._util import check_random_state, _transition_to_rng
 
 
@@ -313,6 +314,7 @@ class FitResult:
         return ax
 
 
+@xp_capabilities(out_of_scope=True)
 def fit(dist, data, bounds=None, *, guess=None, method='mle',
         optimizer=optimize.differential_evolution):
     r"""Fit a discrete or continuous distribution to data
@@ -738,6 +740,7 @@ GoodnessOfFitResult = namedtuple('GoodnessOfFitResult',
                                   'null_distribution'))
 
 
+@xp_capabilities(out_of_scope=True)
 @_transition_to_rng('random_state')
 def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
                     guessed_params=None, statistic='ad', n_mc_samples=9999,

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -9,6 +9,7 @@ from scipy.optimize import shgo
 from . import distributions
 from ._common import ConfidenceInterval
 from ._continuous_distns import norm
+from scipy._lib._array_api import xp_capabilities
 from scipy.special import gamma, kv, gammaln
 from scipy.fft import ifft
 from ._stats_pythran import _a_ij_Aij_Dij2
@@ -26,6 +27,7 @@ Epps_Singleton_2sampResult = namedtuple('Epps_Singleton_2sampResult',
                                         ('statistic', 'pvalue'))
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(Epps_Singleton_2sampResult, n_samples=2, too_small=4)
 def epps_singleton_2samp(x, y, t=(0.4, 0.8)):
     """Compute the Epps-Singleton (ES) test statistic.
@@ -148,6 +150,7 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8)):
     return Epps_Singleton_2sampResult(w, p)
 
 
+@xp_capabilities(np_only=True)
 def poisson_means_test(k1, n1, k2, n2, *, diff=0, alternative='two-sided'):
     r"""
     Performs the Poisson means test, AKA the "E-test".
@@ -486,6 +489,7 @@ def _cvm_result_to_tuple(res, _):
     return res.statistic, res.pvalue
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(CramerVonMisesResult, n_samples=1, too_small=1,
                           result_to_tuple=_cvm_result_to_tuple)
 def cramervonmises(rvs, cdf, args=()):
@@ -709,6 +713,7 @@ class SomersDResult:
     table: np.ndarray
 
 
+@xp_capabilities(np_only=True)
 def somersd(x, y=None, alternative='two-sided'):
     r"""Calculates Somers' D, an asymmetric measure of ordinal association.
 
@@ -920,6 +925,7 @@ class BarnardExactResult:
     pvalue: float
 
 
+@xp_capabilities(np_only=True)
 def barnard_exact(table, alternative="two-sided", pooled=True, n=32):
     r"""Perform a Barnard exact test on a 2x2 contingency table.
 
@@ -1191,6 +1197,7 @@ class BoschlooExactResult:
     pvalue: float
 
 
+@xp_capabilities(np_only=True)
 def boschloo_exact(table, alternative="two-sided", n=32):
     r"""Perform Boschloo's exact test on a 2x2 contingency table.
 
@@ -1544,6 +1551,7 @@ def _pval_cvm_2samp_exact(s, m, n):
     return np.float64(np.sum(freq[value >= zeta]) / combinations)
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(CramerVonMisesResult, n_samples=2, too_small=1,
                           result_to_tuple=_cvm_result_to_tuple)
 def cramervonmises_2samp(x, y, method='auto'):
@@ -1846,6 +1854,7 @@ def _tukey_hsd_iv(args, equal_var):
     return args
 
 
+@xp_capabilities(np_only=True)
 def tukey_hsd(*args, equal_var=True):
     """Perform Tukey's HSD test for equality of means over multiple treatments.
 

--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -1,6 +1,7 @@
 import threading
 import numpy as np
 from collections import namedtuple
+from scipy._lib._array_api import xp_capabilities
 from scipy import special
 from scipy import stats
 from scipy.stats._stats_py import _rankdata
@@ -224,6 +225,7 @@ def _mwu_choose_method(n1, n2, ties):
 MannwhitneyuResult = namedtuple('MannwhitneyuResult', ('statistic', 'pvalue'))
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(MannwhitneyuResult, n_samples=2)
 def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
                  axis=0, method="auto"):

--- a/scipy/stats/_mgc.py
+++ b/scipy/stats/_mgc.py
@@ -1,6 +1,7 @@
 import warnings
 import numpy as np
 
+from scipy._lib._array_api import xp_capabilities
 from scipy._lib._util import check_random_state, MapWrapper, rng_integers, _contains_nan
 from scipy._lib._bunch import _make_tuple_bunch
 from scipy.spatial.distance import cdist
@@ -95,6 +96,7 @@ MGCResult = _make_tuple_bunch('MGCResult',
                               ['statistic', 'pvalue', 'mgc_dict'], [])
 
 
+@xp_capabilities(np_only=True)
 def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
                          workers=1, is_twosamp=False, random_state=None):
     r"""Computes the Multiscale Graph Correlation (MGC) test statistic.

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -16,6 +16,7 @@ import scipy._lib.array_api_extra as xpx
 from scipy._lib._array_api import (
     array_namespace,
     is_marray,
+    xp_capabilities,
     xp_size,
     xp_vector_norm,
     xp_promote,
@@ -53,6 +54,7 @@ Variance = namedtuple('Variance', ('statistic', 'minmax'))
 Std_dev = namedtuple('Std_dev', ('statistic', 'minmax'))
 
 
+@xp_capabilities(np_only=True)
 def bayes_mvs(data, alpha=0.90):
     r"""
     Bayesian confidence intervals for the mean, var, and std.
@@ -152,6 +154,7 @@ def bayes_mvs(data, alpha=0.90):
     return m_res, v_res, s_res
 
 
+@xp_capabilities(np_only=True)
 def mvsdist(data):
     """
     'Frozen' distributions for mean, variance, and standard deviation of data.
@@ -227,6 +230,7 @@ def mvsdist(data):
     return mdist, vdist, sdist
 
 
+@xp_capabilities()
 @_axis_nan_policy_factory(
     lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1, default_axis=None
 )
@@ -332,6 +336,7 @@ def kstat(data, n=2, *, axis=None):
         raise ValueError("Should not be here.")
 
 
+@xp_capabilities()
 @_axis_nan_policy_factory(
     lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1, default_axis=None
 )
@@ -506,6 +511,7 @@ def _add_axis_labels_title(plot, xlabel, ylabel, title):
         pass
 
 
+@xp_capabilities(np_only=True)
 def probplot(x, sparams=(), dist='norm', fit=True, plot=None, rvalue=False):
     """
     Calculate quantiles for a probability plot, and optionally show the plot.
@@ -669,6 +675,7 @@ def probplot(x, sparams=(), dist='norm', fit=True, plot=None, rvalue=False):
         return osm, osr
 
 
+@xp_capabilities(np_only=True)
 def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
     """Calculate the shape parameter that maximizes the PPCC.
 
@@ -757,6 +764,7 @@ def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
                           args=(osm_uniform, osr, dist.ppf))
 
 
+@xp_capabilities(np_only=True)
 def ppcc_plot(x, a, b, dist='tukeylambda', plot=None, N=80):
     """Calculate and optionally plot probability plot correlation coefficient.
 
@@ -877,6 +885,7 @@ def _log_var(logx, xp, axis):
     return special.logsumexp(2 * logxmu, axis=axis) - math.log(logx.shape[axis])
 
 
+@xp_capabilities()
 def boxcox_llf(lmb, data, *, axis=0, keepdims=False, nan_policy='propagate'):
     r"""The boxcox log-likelihood function.
 
@@ -1053,6 +1062,7 @@ def _boxcox_conf_interval(x, lmax, alpha):
     return lmminus, lmplus
 
 
+@xp_capabilities(np_only=True)
 def boxcox(x, lmbda=None, alpha=None, optimizer=None):
     r"""Return a dataset transformed by a Box-Cox power transformation.
 
@@ -1215,6 +1225,7 @@ class _BigFloat:
 _BigFloat_singleton = _BigFloat()
 
 
+@xp_capabilities(np_only=True)
 def boxcox_normmax(
     x, brack=None, method='pearsonr', optimizer=None, *, ymax=_BigFloat_singleton
 ):
@@ -1484,6 +1495,7 @@ def _normplot(method, x, la, lb, plot=None, N=80):
     return lmbdas, ppcc
 
 
+@xp_capabilities(np_only=True)
 def boxcox_normplot(x, la, lb, plot=None, N=80):
     """Compute parameters for a Box-Cox normality plot, optionally show it.
 
@@ -1552,6 +1564,7 @@ def boxcox_normplot(x, la, lb, plot=None, N=80):
     return _normplot('boxcox', x, la, lb, plot, N)
 
 
+@xp_capabilities(np_only=True)
 def yeojohnson(x, lmbda=None):
     r"""Return a dataset transformed by a Yeo-Johnson power transformation.
 
@@ -1679,6 +1692,7 @@ def _yeojohnson_transform(x, lmbda):
     return out
 
 
+@xp_capabilities(np_only=True)
 def yeojohnson_llf(lmb, data):
     r"""The yeojohnson log-likelihood function.
 
@@ -1785,6 +1799,7 @@ def yeojohnson_llf(lmb, data):
     return loglike
 
 
+@xp_capabilities(np_only=True)
 def yeojohnson_normmax(x, brack=None):
     """Compute optimal Yeo-Johnson transform parameter.
 
@@ -1874,6 +1889,7 @@ def yeojohnson_normmax(x, brack=None):
         return optimize.fminbound(_neg_llf, lb, ub, args=(x,), xtol=tol_brent)
 
 
+@xp_capabilities(np_only=True)
 def yeojohnson_normplot(x, la, lb, plot=None, N=80):
     """Compute parameters for a Yeo-Johnson normality plot, optionally show it.
 
@@ -1947,6 +1963,7 @@ def yeojohnson_normplot(x, la, lb, plot=None, N=80):
 ShapiroResult = namedtuple('ShapiroResult', ('statistic', 'pvalue'))
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(ShapiroResult, n_samples=1, too_small=2, default_axis=None)
 def shapiro(x):
     r"""Perform the Shapiro-Wilk test for normality.
@@ -2141,6 +2158,7 @@ AndersonResult = _make_tuple_bunch('AndersonResult',
                                     'significance_level'], ['fit_result'])
 
 
+@xp_capabilities(np_only=True)
 def anderson(x, dist='norm'):
     """Anderson-Darling test for data coming from a particular distribution.
 
@@ -2431,6 +2449,7 @@ Anderson_ksampResult = _make_tuple_bunch(
 )
 
 
+@xp_capabilities(np_only=True)
 def anderson_ksamp(samples, midrank=True, *, method=None):
     """The Anderson-Darling test for k-samples.
 
@@ -2689,6 +2708,7 @@ class _ABW:
 _abw_state = threading.local()
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(AnsariResult, n_samples=2)
 def ansari(x, y, alternative='two-sided'):
     """Perform the Ansari-Bradley test for equal scale parameters.
@@ -2856,7 +2876,7 @@ def ansari(x, y, alternative='two-sided'):
 
 BartlettResult = namedtuple('BartlettResult', ('statistic', 'pvalue'))
 
-
+@xp_capabilities()
 @_axis_nan_policy_factory(BartlettResult, n_samples=None)
 def bartlett(*samples, axis=0):
     r"""Perform Bartlett's test for equal variances.
@@ -2976,6 +2996,7 @@ def bartlett(*samples, axis=0):
 LeveneResult = namedtuple('LeveneResult', ('statistic', 'pvalue'))
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(LeveneResult, n_samples=None)
 def levene(*samples, center='median', proportiontocut=0.05):
     r"""Perform Levene test for equal variances.
@@ -3132,6 +3153,7 @@ def _apply_func(x, g, func):
 FlignerResult = namedtuple('FlignerResult', ('statistic', 'pvalue'))
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(FlignerResult, n_samples=None)
 def fligner(*samples, center='median', proportiontocut=0.05):
     r"""Perform Fligner-Killeen test for equality of variance.
@@ -3359,6 +3381,7 @@ def _mood_too_small(samples, kwargs, axis=-1):
     return N < 3
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(SignificanceResult, n_samples=2, too_small=_mood_too_small)
 def mood(x, y, axis=0, alternative="two-sided"):
     """Perform Mood's test for equal scale parameters.
@@ -3530,6 +3553,7 @@ def wilcoxon_outputs(kwds):
     return 2
 
 
+@xp_capabilities(np_only=True)
 @_rename_parameter("mode", "method")
 @_axis_nan_policy_factory(
     wilcoxon_result_object, paired=True,
@@ -3775,6 +3799,7 @@ MedianTestResult = _make_tuple_bunch(
 )
 
 
+@xp_capabilities(np_only=True)
 def median_test(*samples, ties='below', correction=True, lambda_=1,
                 nan_policy='propagate'):
     """Perform a Mood's median test.
@@ -4004,6 +4029,7 @@ def _circfuncs_common(samples, period, xp=None):
     return samples, sin_samp, cos_samp
 
 
+@xp_capabilities()
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, default_axis=None,
     result_to_tuple=lambda x, _: (x,)
@@ -4097,6 +4123,7 @@ def circmean(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
     return (res * (period / (2.0 * pi)) - low) % period + low
 
 
+@xp_capabilities()
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, default_axis=None,
     result_to_tuple=lambda x, _: (x,)
@@ -4191,6 +4218,7 @@ def circvar(samples, high=2*pi, low=0, axis=None, nan_policy='propagate'):
     return res
 
 
+@xp_capabilities()
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, default_axis=None,
     result_to_tuple=lambda x, _: (x,)
@@ -4307,6 +4335,7 @@ class DirectionalStats:
                 f" mean_resultant_length={self.mean_resultant_length})")
 
 
+@xp_capabilities()
 def directional_stats(samples, *, axis=0, normalize=True):
     """
     Computes sample statistics for directional data.
@@ -4446,6 +4475,7 @@ def directional_stats(samples, *, axis=0, normalize=True):
     return DirectionalStats(mean_direction, mean_resultant_length)
 
 
+@xp_capabilities(np_only=True)
 def false_discovery_control(ps, *, axis=0, method='bh'):
     """Adjust p-values to control the false discovery rate.
 

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -10,6 +10,7 @@ from scipy.optimize import minimize_scalar
 from scipy.stats._common import ConfidenceInterval
 from scipy.stats._qmc import check_random_state
 from scipy.stats._stats_py import _var
+from scipy._lib._array_api import xp_capabilities
 from scipy._lib._util import _transition_to_rng, DecimalNumber, SeedType
 
 
@@ -179,6 +180,7 @@ class DunnettResult:
         return self._ci
 
 
+@xp_capabilities(np_only=True)
 @_transition_to_rng('random_state', replace_doc=False)
 def dunnett(
     *samples: "npt.ArrayLike",  # noqa: D417

--- a/scipy/stats/_page_trend_test.py
+++ b/scipy/stats/_page_trend_test.py
@@ -6,6 +6,7 @@ import threading
 import numpy as np
 
 from ._continuous_distns import norm
+from scipy._lib._array_api import xp_capabilities
 import scipy.stats
 
 
@@ -16,6 +17,7 @@ class PageTrendTestResult:
     method: str
 
 
+@xp_capabilities(np_only=True)
 def page_trend_test(data, ranked=False, predicted_ranks=None, method='auto'):
     r"""
     Perform Page's Test, a measure of trend in observations between treatments.

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -1,7 +1,13 @@
 import numpy as np
 from scipy.special import betainc
-from scipy._lib._array_api import (xp_ravel, array_namespace, xp_promote,
-                                   xp_device, _length_nonmasked)
+from scipy._lib._array_api import (
+    xp_capabilities,
+    xp_ravel,
+    array_namespace,
+    xp_promote,
+    xp_device,
+    _length_nonmasked
+)
 import scipy._lib.array_api_extra as xpx
 from scipy.stats._axis_nan_policy import _broadcast_arrays, _contains_nan
 
@@ -98,6 +104,8 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims):
     return y, p, method, axis, nan_policy, keepdims, n, axis_none, ndim, p_mask, xp
 
 
+@xp_capabilities(skip_backends=(("dask.array", "No take_along_axis yet."),
+                                ("jax.numpy", "No mutation.")))
 def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=None):
     """
     Compute the p-th quantile of the data along the specified axis.

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -7,7 +7,12 @@ import inspect
 
 from scipy._lib._util import (check_random_state, _rename_parameter, rng_integers,
                               _transition_to_rng)
-from scipy._lib._array_api import array_namespace, is_numpy, xp_result_type
+from scipy._lib._array_api import (
+    array_namespace,
+    is_numpy,
+    xp_capabilities,
+    xp_result_type,
+)
 from scipy.special import ndtr, ndtri, comb, factorial
 
 from ._common import ConfidenceInterval
@@ -277,6 +282,7 @@ class BootstrapResult:
     standard_error: float | np.ndarray
 
 
+@xp_capabilities(np_only=True)
 @_transition_to_rng('random_state')
 def bootstrap(data, statistic, *, n_resamples=9999, batch=None,
               vectorized=None, paired=False, axis=0, confidence_level=0.95,
@@ -756,6 +762,7 @@ class MonteCarloTestResult:
     null_distribution: np.ndarray
 
 
+@xp_capabilities()
 @_rename_parameter('sample', 'data')
 def monte_carlo_test(data, rvs, statistic, *, vectorized=None,
                      n_resamples=9999, batch=None, alternative="two-sided",
@@ -1083,6 +1090,7 @@ def _power_iv(rvs, test, n_observations, significance, vectorized,
             n_resamples_int, batch_iv, vals, keys, shape[1:])
 
 
+@xp_capabilities(np_only=True)
 def power(test, rvs, n_observations, *, significance=0.01, vectorized=None,
           n_resamples=10000, batch=None, kwargs=None):
     r"""Simulate the power of a hypothesis test under an alternative hypothesis.
@@ -1605,6 +1613,7 @@ def _permutation_test_iv(data, statistic, permutation_type, vectorized,
             batch_iv, alternative, axis_int, rng)
 
 
+@xp_capabilities(np_only=True)
 @_transition_to_rng('random_state')
 def permutation_test(data, statistic, *, permutation_type='independent',
                      vectorized=None, n_resamples=9999, batch=None,

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -9,6 +9,7 @@ from scipy.stats._common import ConfidenceInterval
 from scipy.stats._qmc import check_random_state
 from scipy.stats._resampling import BootstrapResult
 from scipy.stats import qmc, bootstrap
+from scipy._lib._array_api import xp_capabilities
 from scipy._lib._util import _transition_to_rng
 
 
@@ -236,6 +237,8 @@ class SobolResult:
             first_order=first_order, total_order=total_order
         )
 
+
+@xp_capabilities(np_only=True)
 @_transition_to_rng('random_state', replace_doc=False)
 def sobol_indices(
     *,

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -1,6 +1,7 @@
 import warnings
 import numpy as np
 from . import distributions
+from .._lib._array_api import xp_capabilities
 from .._lib._bunch import _make_tuple_bunch
 from ._axis_nan_policy import _axis_nan_policy_factory
 from ._stats_pythran import siegelslopes as siegelslopes_pythran
@@ -19,6 +20,7 @@ def _n_samples_optional_x(kwargs):
     return 2 if kwargs.get('x', None) is not None else 1
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(TheilslopesResult, default_axis=None, n_outputs=4,
                           n_samples=_n_samples_optional_x,
                           result_to_tuple=lambda x, _: tuple(x), paired=True,
@@ -203,6 +205,7 @@ def _find_repeats(arr):
     return unique[atleast2], freq[atleast2]
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(SiegelslopesResult, default_axis=None, n_outputs=2,
                           n_samples=_n_samples_optional_x,
                           result_to_tuple=lambda x, _: tuple(x), paired=True,

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -473,6 +473,7 @@ def _mode_result(mode, count):
     return ModeResult(mode, count)
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(_mode_result, override={'nan_propagation': False})
 def mode(a, axis=0, nan_policy='propagate', keepdims=False):
     r"""Return an array of the modal (most common) value in the passed array.
@@ -1954,6 +1955,7 @@ def jarque_bera(x, *, axis=None):
 #####################################
 
 
+@xp_capabilities(np_only=True)
 def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
                       axis=None):
     """Calculate the score at a given percentile of the input sequence.
@@ -2078,6 +2080,7 @@ def _compute_qth_percentile(sorted_, per, interpolation_method, axis):
     return np.add.reduce(sorted_[tuple(indexer)] * weights, axis=axis) / sumval
 
 
+@xp_capabilities(np_only=True)
 def percentileofscore(a, score, kind='rank', nan_policy='propagate'):
     """Compute the percentile rank of a score relative to a list of scores.
 
@@ -2315,6 +2318,7 @@ CumfreqResult = namedtuple('CumfreqResult',
                             'extrapoints'))
 
 
+@xp_capabilities(np_only=True)
 def cumfreq(a, numbins=10, defaultreallimits=None, weights=None):
     """Return a cumulative frequency histogram, using the histogram function.
 
@@ -2397,6 +2401,7 @@ RelfreqResult = namedtuple('RelfreqResult',
                             'extrapoints'))
 
 
+@xp_capabilities(np_only=True)
 def relfreq(a, numbins=10, defaultreallimits=None, weights=None):
     """Return a relative frequency histogram, using the histogram function.
 
@@ -2477,6 +2482,7 @@ def relfreq(a, numbins=10, defaultreallimits=None, weights=None):
 #        VARIABILITY FUNCTIONS      #
 #####################################
 
+@xp_capabilities(np_only=True)
 def obrientransform(*samples):
     """Compute the O'Brien transform on input data (any number of arrays).
 
@@ -3035,6 +3041,7 @@ def gstd(a, axis=0, ddof=1, *, keepdims=False, nan_policy='propagate'):
 _scale_conversions = {'normal': special.erfinv(0.5) * 2.0 * math.sqrt(2.0)}
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(
     lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1,
     default_axis=None, override={'nan_propagation': False}
@@ -3208,6 +3215,7 @@ def _mad_1d(x, center, nan_policy):
     return mad
 
 
+@xp_capabilities(np_only=True)
 def median_abs_deviation(x, axis=0, center=np.median, scale=1.0,
                          nan_policy='propagate'):
     r"""
@@ -3370,6 +3378,7 @@ def median_abs_deviation(x, axis=0, center=np.median, scale=1.0,
 SigmaclipResult = namedtuple('SigmaclipResult', ('clipped', 'lower', 'upper'))
 
 
+@xp_capabilities(np_only=True)
 def sigmaclip(a, low=4., high=4.):
     """Perform iterative sigma-clipping of array elements.
 
@@ -3439,6 +3448,7 @@ def sigmaclip(a, low=4., high=4.):
     return SigmaclipResult(c, critlower, critupper)
 
 
+@xp_capabilities(np_only=True)
 def trimboth(a, proportiontocut, axis=0):
     """Slice off a proportion of items from both ends of an array.
 
@@ -3525,6 +3535,7 @@ def trimboth(a, proportiontocut, axis=0):
     return atmp[tuple(sl)]
 
 
+@xp_capabilities(np_only=True)
 def trim1(a, proportiontocut, tail='right', axis=0):
     """Slice off a proportion from ONE end of the passed array distribution.
 
@@ -3612,6 +3623,7 @@ def trim1(a, proportiontocut, tail='right', axis=0):
     return atmp[tuple(sl)]
 
 
+@xp_capabilities(np_only=True)
 def trim_mean(a, proportiontocut, axis=0):
     """Return mean of array after trimming a specified fraction of extreme values
 
@@ -3737,6 +3749,7 @@ def _f_oneway_is_too_small(samples, kwargs=None, axis=-1):
     return False
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(
     F_onewayResult, n_samples=None, too_small=_f_oneway_is_too_small)
 def f_oneway(*samples, axis=0, equal_var=True):
@@ -4032,6 +4045,7 @@ class AlexanderGovernResult:
     pvalue: float
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(
     AlexanderGovernResult, n_samples=None,
     result_to_tuple=lambda x, _: (x.statistic, x.pvalue),
@@ -4779,6 +4793,7 @@ def pearsonr(x, y, *, alternative='two-sided', method=None, axis=0):
                           alternative=alternative, x=x, y=y, axis=axis)
 
 
+@xp_capabilities(np_only=True)
 def fisher_exact(table, alternative=None, *, method=None):
     """Perform a Fisher exact test on a contingency table.
 
@@ -5158,6 +5173,7 @@ def _untabulate(table):
     return np.concatenate(x), np.concatenate(y)
 
 
+@xp_capabilities(np_only=True)
 def spearmanr(a, b=None, axis=0, nan_policy='propagate',
               alternative='two-sided'):
     r"""Calculate a Spearman correlation coefficient with associated p-value.
@@ -5420,6 +5436,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
         return res
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(_pack_CorrelationResult, n_samples=2,
                           result_to_tuple=_unpack_CorrelationResult, paired=True,
                           too_small=1, n_outputs=3)
@@ -5518,6 +5535,7 @@ def pointbiserialr(x, y):
     return res
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(_pack_CorrelationResult, default_axis=None, n_samples=2,
                           result_to_tuple=_unpack_CorrelationResult, paired=True,
                           too_small=1, n_outputs=3)
@@ -5732,6 +5750,7 @@ def _weightedtau_n_samples(kwargs):
     return 2 if (isinstance(rank, bool) or rank is None) else 3
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(_pack_CorrelationResult, default_axis=None,
                           n_samples=_weightedtau_n_samples,
                           result_to_tuple=_unpack_CorrelationResult, paired=True,
@@ -7415,6 +7434,7 @@ def _KstestResult_to_tuple(res, _):
     return *res, res.statistic_location, res.statistic_sign
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=1, n_outputs=4,
                           result_to_tuple=_KstestResult_to_tuple)
 @_rename_parameter("mode", "method")
@@ -7760,6 +7780,7 @@ def _attempt_exact_2kssamp(n1, n2, g, d, alternative):
     return True, d, prob
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=2, n_outputs=4,
                           result_to_tuple=_KstestResult_to_tuple)
 @_rename_parameter("mode", "method")
@@ -8043,6 +8064,7 @@ def _kstest_n_samples(kwargs):
     return 1 if (isinstance(cdf, str) or callable(cdf)) else 2
 
 
+@xp_capabilities(out_of_scope=True)
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=_kstest_n_samples,
                           n_outputs=4, result_to_tuple=_KstestResult_to_tuple)
 @_rename_parameter("mode", "method")
@@ -8239,6 +8261,7 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', method='auto'):
                     _no_deco=True)
 
 
+@xp_capabilities(np_only=True)
 def tiecorrect(rankvals):
     """Tie correction factor for Mann-Whitney U and Kruskal-Wallis H tests.
 
@@ -8287,6 +8310,7 @@ def tiecorrect(rankvals):
 RanksumsResult = namedtuple('RanksumsResult', ('statistic', 'pvalue'))
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(RanksumsResult, n_samples=2)
 def ranksums(x, y, alternative='two-sided'):
     """Compute the Wilcoxon rank-sum statistic for two samples.
@@ -8372,6 +8396,7 @@ def ranksums(x, y, alternative='two-sided'):
 KruskalResult = namedtuple('KruskalResult', ('statistic', 'pvalue'))
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(KruskalResult, n_samples=None)
 def kruskal(*samples, nan_policy='propagate'):
     """Compute the Kruskal-Wallis H-test for independent samples.
@@ -8473,6 +8498,7 @@ FriedmanchisquareResult = namedtuple('FriedmanchisquareResult',
                                      ('statistic', 'pvalue'))
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(FriedmanchisquareResult, n_samples=None, paired=True)
 def friedmanchisquare(*samples):
     """Compute the Friedman test for repeated samples.
@@ -8566,6 +8592,7 @@ BrunnerMunzelResult = namedtuple('BrunnerMunzelResult',
                                  ('statistic', 'pvalue'))
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(BrunnerMunzelResult, n_samples=2)
 def brunnermunzel(x, y, alternative="two-sided", distribution="t",
                   nan_policy='propagate'):
@@ -8997,6 +9024,7 @@ def quantile_test_iv(x, q, p, alternative):
     return x, q, p, alternative
 
 
+@xp_capabilities(np_only=True)
 def quantile_test(x, *, q=0, p=0.5, alternative='two-sided'):
     r"""
     Perform a quantile test and compute a confidence interval of the quantile.
@@ -9335,6 +9363,7 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided'):
 #####################################
 
 
+@xp_capabilities(np_only=True)
 def wasserstein_distance_nd(u_values, v_values, u_weights=None, v_weights=None):
     r"""
     Compute the Wasserstein-1 distance between two N-D discrete distributions.
@@ -9541,6 +9570,7 @@ def wasserstein_distance_nd(u_values, v_values, u_weights=None, v_weights=None):
     return -opt_res.fun
 
 
+@xp_capabilities(np_only=True)
 def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     r"""
     Compute the Wasserstein-1 distance between two 1D discrete distributions.
@@ -9633,6 +9663,7 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     return _cdf_distance(1, u_values, v_values, u_weights, v_weights)
 
 
+@xp_capabilities(np_only=True)
 def energy_distance(u_values, v_values, u_weights=None, v_weights=None):
     r"""Compute the energy distance between two 1D distributions.
 
@@ -10106,6 +10137,7 @@ def _rankdata(x, method, return_ties=False, xp=None):
     return ranks
 
 
+@xp_capabilities(np_only=True)
 def expectile(a, alpha=0.5, *, weights=None):
     r"""Compute the expectile at the specified level.
 
@@ -10286,6 +10318,7 @@ def _prk(r, k):
     return (-1)**(r-k)*special.binom(r, k)*special.binom(r+k, k)
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(  # noqa: E302
     _moment_result_object, n_samples=1, result_to_tuple=_moment_tuple,
     n_outputs=lambda kwds: _moment_outputs(kwds, [1, 2, 3, 4])
@@ -10388,6 +10421,7 @@ def _unpack_LinregressResult(res, _):
     return tuple(res) + (res.intercept_stderr,)
 
 
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(_pack_LinregressResult, n_samples=2,
                           result_to_tuple=_unpack_LinregressResult, paired=True,
                           too_small=1, n_outputs=6)

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -4,6 +4,7 @@ import warnings
 
 import numpy as np
 from scipy import special, interpolate, stats
+from scipy._lib._array_api import xp_capabilities
 from scipy.stats._censored_data import CensoredData
 from scipy.stats._common import ConfidenceInterval
 
@@ -249,6 +250,7 @@ def _iv_CensoredData(
     return sample
 
 
+@xp_capabilities(np_only=True)
 def ecdf(sample: "npt.ArrayLike | CensoredData") -> ECDFResult:
     """Empirical cumulative distribution function of a sample.
 
@@ -483,6 +485,7 @@ class LogRankResult:
     pvalue: np.ndarray
 
 
+@xp_capabilities(np_only=True)
 def logrank(
     x: "npt.ArrayLike | CensoredData",
     y: "npt.ArrayLike | CensoredData",

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -1,12 +1,18 @@
 import warnings
 import numpy as np
 
-from scipy._lib._array_api import array_namespace, xp_device, _length_nonmasked
+from scipy._lib._array_api import (
+    array_namespace,
+    xp_capabilities,
+    xp_device,
+    _length_nonmasked,
+)
 import scipy._lib.array_api_extra as xpx
 
 from ._axis_nan_policy import _axis_nan_policy_factory
 
 
+@xp_capabilities()
 @_axis_nan_policy_factory(
     lambda x: x, n_outputs=1, result_to_tuple=lambda x, _: (x,)
 )

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -28,6 +28,7 @@ from ._stats_py import power_divergence, _untabulate
 from ._relative_risk import relative_risk
 from ._crosstab import crosstab
 from ._odds_ratio import odds_ratio
+from scipy._lib._array_api import xp_capabilities
 from scipy._lib._bunch import _make_tuple_bunch
 from scipy import stats
 
@@ -36,6 +37,7 @@ __all__ = ['margins', 'expected_freq', 'chi2_contingency', 'crosstab',
            'association', 'relative_risk', 'odds_ratio']
 
 
+@xp_capabilities(np_only=True)
 def margins(a):
     """Return a list of the marginal sums of the array `a`.
 
@@ -88,6 +90,7 @@ def margins(a):
     return margsums
 
 
+@xp_capabilities(np_only=True)
 def expected_freq(observed):
     """
     Compute the expected frequencies from a contingency table.
@@ -142,6 +145,7 @@ Chi2ContingencyResult = _make_tuple_bunch(
 )
 
 
+@xp_capabilities(np_only=True)
 def chi2_contingency(observed, correction=True, lambda_=None, *, method=None):
     """Chi-square test of independence of variables in a contingency table.
 
@@ -418,6 +422,7 @@ def _chi2_monte_carlo_method(observed, expected, method):
                                   alternative='greater', **method)
 
 
+@xp_capabilities(np_only=True)
 def association(observed, method="cramer", correction=False, lambda_=None):
     """Calculates degree of association between two nominal variables.
 

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -6,12 +6,14 @@ import numpy as np
 
 from scipy import stats
 from scipy.stats import norm, expon  # type: ignore[attr-defined]
+from scipy._lib._array_api import make_xp_test_case
 from scipy._lib._array_api_no_0d import (xp_assert_close, xp_assert_equal,
                                          xp_assert_less)
 
+
 skip_xp_backends = pytest.mark.skip_xp_backends
 
-
+@make_xp_test_case(stats.entropy)
 class TestEntropy:
     def test_entropy_positive(self, xp):
         # See ticket #497
@@ -117,6 +119,7 @@ class TestEntropy:
             stats.entropy(x, base=-2)
 
 
+@make_xp_test_case(stats.differential_entropy)
 class TestDifferentialEntropy:
     """
     Vasicek results are compared with the R package vsgoftest.

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -26,7 +26,7 @@ from scipy.stats._distr_params import distcont
 from scipy.stats._axis_nan_policy import (SmallSampleWarning, too_small_nd_omit,
                                           too_small_1d_omit, too_small_1d_not_omit)
 
-from scipy._lib._array_api import is_numpy, is_torch
+from scipy._lib._array_api import is_numpy, is_torch, make_xp_test_case
 from scipy._lib._array_api_no_0d import (
     xp_assert_close,
     xp_assert_equal,
@@ -741,6 +741,7 @@ class TestAnsari:
         assert_allclose(pval_l, 1-pval/2, atol=1e-12)
 
 
+@make_xp_test_case(stats.bartlett)
 class TestBartlett:
     def test_data(self, xp):
         # https://www.itl.nist.gov/div898/handbook/eda/section3/eda357.htm
@@ -1802,6 +1803,7 @@ x_kstat = [16.34, 10.76, 11.84, 13.55, 15.85, 18.20, 7.51, 10.22, 12.52, 14.68,
            12.10, 15.02, 16.83, 16.98, 19.92, 9.47, 11.68, 13.41, 15.35, 19.11]
 
 
+@make_xp_test_case(stats.kstat)
 class TestKstat:
     def test_moments_normal_distribution(self, xp):
         rng = np.random.RandomState(32149)
@@ -1860,6 +1862,7 @@ class TestKstat:
         xp_assert_close(res, xp.asarray(ref))
 
 
+@make_xp_test_case(stats.kstatvar)
 class TestKstatVar:
     @pytest.mark.filterwarnings("ignore:invalid value encountered in scalar divide")
     def test_empty_input(self, xp):
@@ -1998,6 +2001,7 @@ class TestPpccMax:
                             -0.71215366521264145, decimal=7)
 
 
+@make_xp_test_case(stats.boxcox_llf)
 class TestBoxcox_llf:
 
     @pytest.mark.parametrize("dtype", ["float32", "float64"])
@@ -2674,6 +2678,7 @@ class TestYeojohnsonNormmax:
         assert np.allclose(lmbda, 1.305, atol=1e-3)
 
 
+@make_xp_test_case(stats.circmean, stats.circvar, stats.circstd)
 class TestCircFuncs:
     # In gh-5747, the R package `circular` was used to calculate reference
     # values for the circular variance, e.g.:
@@ -3062,6 +3067,8 @@ class TestMedianTest:
         res = stats.median_test(x, y, correction=correction)
         assert_equal((res.statistic, res.pvalue, res.median, res.table), res)
 
+
+@make_xp_test_case(stats.directional_stats)
 class TestDirectionalStats:
     # Reference implementations are not available
     def test_directional_stats_correctness(self, xp):

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -2,7 +2,13 @@ import pytest
 import numpy as np
 
 from scipy import stats
-from scipy._lib._array_api import xp_default_dtype, is_numpy, is_torch, SCIPY_ARRAY_API
+from scipy._lib._array_api import (
+    xp_default_dtype,
+    is_numpy,
+    is_torch,
+    make_xp_test_case,
+    SCIPY_ARRAY_API,
+)
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 from scipy._lib._util import _apply_over_batch
 
@@ -37,8 +43,7 @@ def quantile_reference(x, p, *, axis, nan_policy, keepdims, method):
     return res
 
 
-@skip_xp_backends('dask.array', reason="No take_along_axis yet.")
-@skip_xp_backends('jax.numpy', reason="No mutation.")
+@make_xp_test_case(stats.quantile)
 class TestQuantile:
 
     def test_input_validation(self, xp):

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from scipy._lib._util import rng_integers
-from scipy._lib._array_api import is_numpy
+from scipy._lib._array_api import is_numpy, make_xp_test_case
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 from scipy import stats, special
 from scipy.optimize import root
@@ -758,6 +758,7 @@ def test_gh_20850():
 
 # --- Test Monte Carlo Hypothesis Test --- #
 
+@make_xp_test_case(monte_carlo_test)
 class TestMonteCarloHypothesisTest:
     atol = 2.5e-2  # for comparing p-value
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -46,6 +46,7 @@ import scipy._lib.array_api_extra as xpx
 
 lazy_xp_modules = [stats]
 skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
 
 
 """ Numbers in docstrings beginning with 'W' refer to the section numbers
@@ -7050,6 +7051,7 @@ class TestGSTD:
         gstd_actual = stats.gstd(a, axis=1)
         xp_assert_close(gstd_actual, xp.asarray([4, np.nan]))
 
+    @xfail_xp_backends("jax.numpy", reason="returns subnormal instead of nan")
     def test_ddof_equal_to_number_of_observations(self, xp):
         x = xp.asarray(self.array_1d)
         res = stats.gstd(x, ddof=x.shape[0])

--- a/scipy/stats/tests/test_variation.py
+++ b/scipy/stats/tests/test_variation.py
@@ -6,7 +6,7 @@ import pytest
 
 from scipy.stats import variation
 from scipy._lib._util import AxisError
-from scipy._lib._array_api import is_numpy
+from scipy._lib._array_api import is_numpy, make_xp_test_case
 from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
 from scipy.stats._axis_nan_policy import (too_small_nd_omit, too_small_nd_not_omit,
                                           SmallSampleWarning)
@@ -14,6 +14,7 @@ from scipy.stats._axis_nan_policy import (too_small_nd_omit, too_small_nd_not_om
 skip_xp_backends = pytest.mark.skip_xp_backends
 
 
+@make_xp_test_case(variation)
 class TestVariation:
     """
     Test class for scipy.stats.variation


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR applies the `xp_capabilities` decorator to all public functions and function-likes (named non-type callables) in `scipy.stats`. I added a test to `scipy._lib.tests.test_array_api` to check for presence of the decorator which now passes for `scipy.stats`. To create this PR a followed a recipe given by @crusaderky:

1. Temporarily tamper with xp_capabilities to always skip array_api_strict; then run `python dev.py tests -b array_api_strict -m array_api_backends` to see what is still running. Proceed to apply `@xp_capabilities` and `@make_xp_test_case` and remove the explicit `@skip_xp_backends` and `@xfail_xp_backends` to everything that crops up.
2. Review the surviving explicit `skip_xp_backends` and `xfail_xp_backends` . They should only apply to edge cases and not to the general functionality of a public function.
3. Investigate `__all__` in the scipy submodules to see if you can extract an inventory of everything that isn't decorated without too much noise.

#### Additional information
<!--Any additional information you think is important.-->
I'm marked this at draft because it branches off from #23081, the PR adding tables summarizing alternative backend support, not main, so #23081 should go in first. GPU coverage for `stats` is now up to 33% for CuPy and Jax and 28% for PyTorch. The slightly lower percentage for PyTorch is due to PyTorch missing the `betainc` function.

I marked functions as out of scope if they take distributions from the old infrastructure as input. I didn't mark transform functions from the new infrastructure like `stats.exp`, `stats.log`, `stats.abs` as out-of-scope, because the intention is to make distributions from the new infrastructure work across backends, so even though these functions don't take arrays as inputs, I think it still makes sense to consider them in-scope. This current work is only for functions and function-like callables, and there still needs to be remaining work to handle classes (like distributions from the new infra) that we'd to consider in-scope.
