### PR TITLE
CI: disable special-casing of 3.14-dev now that Python 3.14rc1 is out

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -88,7 +88,7 @@ jobs:
         - [macos-14, macosx, arm64, openblas, "12.3"]
         - [macos-14, macosx, arm64, accelerate, "14.0"]
         - [windows-2022, win, AMD64, "", ""]
-        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314-dev"], ["cp314t", "cp314-dev"]]
+        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314"], ["cp314t", "cp314"]]
         # python[0] is used to specify the python versions made by cibuildwheel
 
     env:
@@ -183,29 +183,30 @@ jobs:
           fi
           echo "CIBW_REPAIR_WHEEL_COMMAND_MACOS=$CIBW" >> "$GITHUB_ENV"
 
-      - name: Inject environment variable for python dev versions
-        if: ${{ endswith(matrix.python[1], '-dev') }}
-        shell: bash
-        run: |
-          # For dev versions of python need to use wheels from scientific-python-nightly-wheels
-          # When the python version is released please comment out this section, but do not remove
-          # (there will soon be another dev version to target).
-          DEPS0="pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
-          DEPS1="pip install ninja meson-python pybind11 pythran cython"
 
-          CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
-          echo "CIBW_BEFORE_BUILD_LINUX=$CIBW" >> "$GITHUB_ENV"
+      # - name: Inject environment variable for python dev version
+      #   if: ${{ matrix.python[1] == '3.14-dev'
+      #   shell: bash
+      #   run: |
+      #     # For dev versions of python need to use wheels from scientific-python-nightly-wheels
+      #     # When the python version is released please comment out this section, but do not remove
+      #     # (there will soon be another dev version to target).
+      #     DEPS0="pip install --pre -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy"
+      #     DEPS1="pip install ninja meson-python pybind11 pythran cython"
 
-          CIBW="$DEPS0 && $DEPS1 && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
-          echo "CIBW_BEFORE_BUILD_WINDOWS=$CIBW" >> "$GITHUB_ENV"
+      #     CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_linux.sh {project}"
+      #     echo "CIBW_BEFORE_BUILD_LINUX=$CIBW" >> "$GITHUB_ENV"
 
-          CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
-          echo "CIBW_BEFORE_BUILD_MACOS=$CIBW" >> "$GITHUB_ENV"
+      #     CIBW="$DEPS0 && $DEPS1 && bash {project}/tools/wheels/cibw_before_build_win.sh {project}"
+      #     echo "CIBW_BEFORE_BUILD_WINDOWS=$CIBW" >> "$GITHUB_ENV"
 
-          echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
+      #     CIBW="$DEPS0;$DEPS1;bash {project}/tools/wheels/cibw_before_build_macos.sh {project}"
+      #     echo "CIBW_BEFORE_BUILD_MACOS=$CIBW" >> "$GITHUB_ENV"
 
-          CIBW="build; args: --no-isolation"
-          echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
+      #     echo "CIBW_BEFORE_TEST=$DEPS0" >> "$GITHUB_ENV"
+
+      #     CIBW="build; args: --no-isolation"
+      #     echo "CIBW_BUILD_FRONTEND=$CIBW" >> "$GITHUB_ENV"
 
       - name: Build wheels
         uses: pypa/cibuildwheel@ffd835cef18fa11522f608fc0fa973b89f5ddc87 # v3.1.0


### PR DESCRIPTION
This reverts changes made in scipy#23187, keeping the commented out code for once 3.15-dev arrives.

Tested on my fork [here](https://github.com/rgommers/scipy/actions/runs/16522174701).