### PR TITLE
MAINT: Python 3.14 to classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
     "Topic :: Scientific/Engineering",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
* With NumPy `2.3.2` now out with Python `3.14.0rc1` support, and Ralf's PRs that test SciPy wheels against that same version of Python now passing/merged, it is probably time to add this to the classifiers and backport it.

* See: https://github.com/numpy/numpy/pull/29444

[ci skip] [skip ci]
