### PR TITLE
DOC: stats.rv_continuous.ppf/isf: document convention

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3809,7 +3809,7 @@ class rv_discrete(rv_generic):
         For discrete distributions, the `sf` is not strictly invertible. By convention,
         this method returns the minimum value `k` for which the `sf` at `k` is
         no greater than `q`. There is one exception: the `isf` of ``1`` is ``a-1``,
-        where ``a`` is the right endpoint of the support.
+        where ``a`` is the left endpoint of the support.
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3761,8 +3761,8 @@ class rv_discrete(rv_generic):
         -----
         For discrete distributions, the `cdf` is not strictly invertible. By convention,
         this method returns the minimum value `k` for which the `cdf` at `k` is at
-        least `q`. There is one exception: if ``a`` is the left endpoint of the support,
-        then the `ppf` of ``0`` is ``a-1``.
+        least `q`. There is one exception:  the `ppf` of ``0`` is ``a-1``,
+        where ``a`` is the left endpoint of the support.
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)
@@ -3808,8 +3808,8 @@ class rv_discrete(rv_generic):
         -----
         For discrete distributions, the `sf` is not strictly invertible. By convention,
         this method returns the minimum value `k` for which the `sf` at `k` is
-        no greater than `q`. There is one exception: if ``a`` is the right endpoint of
-        the support, then the `isf` of ``1`` is ``a-1``.
+        no greater than `q`. There is one exception: the `isf` of ``1`` is ``a-1``,
+        where ``a`` is the right endpoint of the support.
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3757,6 +3757,13 @@ class rv_discrete(rv_generic):
         k : array_like
             Quantile corresponding to the lower tail probability, q.
 
+        Notes
+        -----
+        For discrete distributions, the `cdf` is not strictly invertible. By convention,
+        this method returns the minimum value `k` for which the `cdf` at `k` is at
+        least `q`. There is one exception: if ``a`` is the left endpoint of the support,
+        then the `ppf` of ``0`` is ``a-1``.
+
         """
         args, loc, _ = self._parse_args(*args, **kwds)
         q, loc = map(asarray, (q, loc))
@@ -3796,6 +3803,13 @@ class rv_discrete(rv_generic):
         -------
         k : ndarray or scalar
             Quantile corresponding to the upper tail probability, q.
+
+        Notes
+        -----
+        For discrete distributions, the `sf` is not strictly invertible. By convention,
+        this method returns the minimum value `k` for which the `sf` at `k` is
+        no greater than `q`. There is one exception: if ``a`` is the right endpoint of
+        the support, then the `isf` of ``1`` is ``a-1``.
 
         """
         args, loc, _ = self._parse_args(*args, **kwds)


### PR DESCRIPTION
#### Reference issue
Closes gh-23358

#### What does this implement/fix?
This documents the convention of `stats.rv_continuous.ppf`/`isf`.

#### Additional information
@scottshambaugh I know you already closed gh-23358, but hopefully this addresses the issue more completely. Please check me carefully - it's tricky! In case it helps, the documentation of the new infrastructure [`icdf`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Normal.icdf.html#scipy.stats.Normal.icdf) and [`iccdf`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.Normal.iccdf.html#scipy.stats.Normal.iccdf) should match[^1]. If it looks good, please indicate your approval; I think that will encourage a maintainer to merge.

*Oops, I forgot `[docs only]`. Next time.*

[^1]: I'm not just copy-pasting because we don't use LaTeX for the old infra. Note that use of single/double backticks is correct according to numpydoc conventions, which I wrote, so no need to worry about that.