### PR TITLE
TST: stats.make_distribution: test `CustomDistribution` str/repr

### DIFF
--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1237,6 +1237,12 @@ class TestMakeDistribution:
 
         X = LogUniform(a=np.exp(1), b=np.exp(3))
         Y = stats.exp(Uniform(a=1., b=3.))
+
+        # pre-2.0 support is not needed for much longer, so let's just test with 2.0+
+        if np.__version__ >= "2.0":
+            assert str(Y) == "exp(Uniform(a=1.0, b=3.0))"
+            assert repr(Y) == "exp(Uniform(a=np.float64(1.0), b=np.float64(3.0)))"
+
         x = X.sample(shape=10, rng=rng)
         p = X.cdf(x)
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1235,13 +1235,13 @@ class TestMakeDistribution:
 
         LogUniform = stats.make_distribution(MyLogUniform())
 
-        X = LogUniform(a=np.exp(1), b=np.exp(3))
-        Y = stats.exp(Uniform(a=1., b=3.))
+        X = LogUniform(a=1., b=np.e)
+        Y = stats.exp(Uniform(a=0., b=1.))
 
         # pre-2.0 support is not needed for much longer, so let's just test with 2.0+
         if np.__version__ >= "2.0":
-            assert str(Y) == "exp(Uniform(a=1.0, b=3.0))"
-            assert repr(Y) == "exp(Uniform(a=np.float64(1.0), b=np.float64(3.0)))"
+            assert str(X) == f"MyLogUniform(a=1.0, b={np.e})"
+            assert repr(X) == f"MyLogUniform(a=np.float64(1.0), b=np.float64({np.e}))"
 
         x = X.sample(shape=10, rng=rng)
         p = X.cdf(x)


### PR DESCRIPTION
#### Reference issue
Supersedes gh-23310

#### What does this implement/fix?
Tests `CustomDistribution` `str` and `repr`. 
The advantage compared to gh-23310 is that this adds the assertion to an existing test of a `CustomDistribution` rather than writing a new one. 

@tylerjereddy You had reviewed gh-23310 and suggested that I take a look, so I thought I'd ping you here.