### PR TITLE
ENH: add Accelerate ILP64 support and CI job

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,8 +28,6 @@ jobs:
   test_meson:
     name: Conda & umfpack/scikit-sparse, fast, py3.11/npAny, spin
     needs: get_commit_message
-    # If using act to run CI locally the github object does not exist and
-    # the usual skipping should not be enforced
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
@@ -143,8 +141,6 @@ jobs:
   test_scipy_openblas:
     name: M1 & OpenBLAS, fast, py3.11/npAny, spin
     needs: get_commit_message
-    # If using act to run CI locally the github object does not exist and
-    # the usual skipping should not be enforced
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
@@ -184,19 +180,17 @@ jobs:
         spin test
 
 
-  test_meson_accelerate:
-    name: Accelerate, fast, py3.11/npAny, spin
+  test_accelerate:
+    name: Accelerate, full, py3.13/npAny, spin
     needs: get_commit_message
-    # If using act to run CI locally the github object does not exist and
-    # the usual skipping should not be enforced
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: macos-15
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.11"]
-
+        blas-interface: ["LP64", "ILP64"]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
@@ -205,24 +199,34 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+        python-version: "3.13"
 
-    - name: Build and Install SciPy
+    - name: Make gfortran-13 on runner image usable
       run: |
-        sudo xcode-select -s /Applications/Xcode_16.app
+        # Ensure we use gfortran-13 and that its runtime is on the library search path
+        FC=$(which gfortran-13)
+        GFORTRAN_LIB=$(dirname `$FC --print-file-name libgfortran.dylib`)
+        echo DYLD_LIBRARY_PATH=$GFORTRAN_LIB >> "$GITHUB_ENV"
+        echo FC=$FC >> "$GITHUB_ENV"
 
-        git submodule update --init
-        GFORTRAN_LOC=$(which gfortran-13)
-        ln -s $GFORTRAN_LOC gfortran
-        export PATH=$PWD:$PATH
+    - name: Install dependencies from PyPI
+      run: |
+        pip install meson cython pythran pybind11 ninja numpy spin pooch pytest hypothesis
 
-        # Ensure we have gfortran dylib
-        GFORTRAN_LIB=$(dirname `gfortran --print-file-name libgfortran.dylib`)
-        export DYLD_LIBRARY_PATH=$GFORTRAN_LIB
+    - name: Build SciPy with Accelerate (LP64)
+      if: matrix.blas-interface == 'LP64'
+      run: |
+        # The b_ndebug flag is a workaround for `_LIBCPP_ENABLE_ASSERTIONS` warnings, can
+        # be removed once Meson 1.8.3 is out with the fix (see meson#14440).
+        spin build --with-accelerate -S-Db_ndebug=true
 
-        pip install meson cython pythran pybind11 ninja numpy spin
-        spin build --with-accelerate
+    - name: Build SciPy with Accelerate (ILP64)
+      if: matrix.blas-interface == 'ILP64'
+      run: |
+        # Once Meson has full BLAS support (xref meson#14773), the
+        # `blas-symbol-suffix` flag can be dropped.
+        spin build -S-Dblas=accelerate -S-Duse-ilp64=true -S-Dblas-symbol-suffix='$NEWLAPACK$ILP64' -S-Db_ndebug=true
 
-        pip install pooch pytest hypothesis
-        spin test
+    - name: Run the test suite
+      run: |
+        spin test -m full

--- a/scipy/_build_utils/src/npy_cblas.h
+++ b/scipy/_build_utils/src/npy_cblas.h
@@ -32,7 +32,7 @@ enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
             #error "Accelerate ILP64 support is only available with macOS 13.3 SDK or later"
         #endif
     #else
-       /* #define NO_APPEND_FORTRAN */
+        /* New Accelerate suffix is always $NEWLAPACK or $NEWLAPACK$ILP64 (no underscore appended) */
         #ifdef HAVE_BLAS_ILP64
             #define BLAS_SYMBOL_SUFFIX $NEWLAPACK$ILP64
         #else
@@ -47,11 +47,10 @@ enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
 #define BLAS_FORTRAN_SUFFIX _
 #endif
 
-// New Accelerate suffix is always $NEWLAPACK (no underscore)
+/* Accelerate doesn't use an underscore as suffix, so fix that up here */
 #ifdef ACCELERATE_NEW_LAPACK
 #undef BLAS_FORTRAN_SUFFIX
 #define BLAS_FORTRAN_SUFFIX
-#define BLAS_SYMBOL_SUFFIX $NEWLAPACK
 #endif
 
 #ifndef BLAS_SYMBOL_PREFIX

--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -448,6 +448,8 @@ def test_splprep_segfault():
     tck, u = splprep([x, y], task=-1, t=uknots)  # here is the crash
 
 
+@pytest.mark.skipif(dfitpack_int == np.int64,
+        reason='Will crash (see gh-23396), test only meant for 32-bit overflow')
 def test_bisplev_integer_overflow():
     np.random.seed(1)
 
@@ -502,7 +504,7 @@ def test_spalde_scalar_input():
 
 def test_spalde_nc():
     # regression test for https://github.com/scipy/scipy/issues/19002
-    # here len(t) = 29 and len(c) = 25 (== len(t) - k - 1) 
+    # here len(t) = 29 and len(c) = 25 (== len(t) - k - 1)
     x = np.asarray([-10., -9., -8., -7., -6., -5., -4., -3., -2.5, -2., -1.5,
                     -1., -0.5, 0., 0.5, 1., 1.5, 2., 2.5, 3., 4., 5., 6.],
                     dtype="float")

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -394,7 +394,10 @@ if use_ilp64
        '-DFIX_MKL_2025_ILP64_MISSING_SYMBOL'
      ]
      c_flags_ilp64 += ['-DBLAS_SYMBOL_SUFFIX=_64']
-
+elif uses_accelerate
+    blas_ilp64 = dependency('accelerate')
+    lapack_ilp64 = blas_ilp64
+    _args_blas_ilp64 += ['-DACCELERATE_NEW_LAPACK']
   elif blas_name == 'scipy-openblas'
       # scipy_openblas64, a separate library
       blas_ilp64 = dependency('scipy-openblas64')
@@ -433,7 +436,7 @@ if use_ilp64
     compile_args: _args_blas_ilp64,
     include_directories: _blas_incdir,
   )
-  lapack_dep = declare_dependency(dependencies: [lapack_ilp64, blas_ilp64])
+  lapack_dep = declare_dependency(dependencies: [lapack_ilp64, blas_dep])
 
   g77_abi_wrappers_ilp64 = static_library(
     'g77_abi_wrappers_ilp64',


### PR DESCRIPTION
This is a follow-up to gh-22743, fixing a few small issues with that PR. That makes Accelerate build and test fine on macOS >=13.3 with the latest Meson release, the only manual bit being that one has to  add the BLAS symbol suffix manually with `-Dblas-symbol-suffix=$NEWLAPACK$ILP64`.
    
The one hiccup is an interpolate test for integer overflow that starts crashing, see gh-23396.

For the CI job, cleans up the existing Accelerate job a bit and makes the CI logs easier to read by breaking  up the steps.  Adds a new ILP64 job, and switches the jobs to `-m full` because it only takes 2 minutes or so longer and any ILP64-specific tests are likely to be marked as slow. Also there are no other `-m full` jobs for macOS.