### PR TITLE
BUG: Skip installing gmpy2(test deps) for Win-ARM64

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ pytest-timeout
 pytest-xdist
 asv
 mpmath
-gmpy2
+gmpy2; sys_platform != "win32" or platform_machine != "ARM64"
 threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ pytest-timeout
 pytest-xdist
 asv
 mpmath
-gmpy2; sys_platform != "win32" and platform_machine != "ARM64"
+gmpy2;
 threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ pytest-timeout
 pytest-xdist
 asv
 mpmath
-gmpy2
+gmpy2; sys_platform != "win32" and platform_machine != "ARM64"
 threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ pytest-timeout
 pytest-xdist
 asv
 mpmath
-gmpy2;
+gmpy2
 threadpoolctl
 # scikit-umfpack  # circular dependency issues
 pooch

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -33,6 +33,13 @@ def generate_requirement_file(name, req_list, *, extra_list=None):
         req_list = [x for x in req_list if "numpy" not in x]
         req_list.append("ninja")
 
+    if name == "test":
+        req_list = [
+            f'{x}; sys_platform != "win32" or platform_machine != "ARM64"' 
+            if x == "gmpy2" else x 
+            for x in req_list
+        ]
+
     if extra_list:
         req_list += extra_list
 


### PR DESCRIPTION
Issue Description:
- SciPy started providing wheels for Windows ARM64 in nightly builds. 
- Upon installing python dependencies from requirements folder, I found that installation of test dependencies are failing due to unavailability of gmpy2 for Win-ARM64
- Due to this, the installation of complete test dependencies are failing.

Fix:
- Added conditional statement to avoid installing gmpy2 for Windows ARM64 which leads to successful installation of test dependencies for Win-ARM64.