### PR TITLE
MAINT: ndimage: add `xp_capabilities` to functions in public API

### DIFF
--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -103,7 +103,7 @@ capabilities_dict = {
         cpu_only=True, allow_dask_compute=True, jax_jit=False
     ),
     "generate_binary_structure": xp_capabilities(out_of_scope=True),
-    "map_coodinates": xp_capabilities(
+    "map_coordinates": xp_capabilities(
         cpu_only=True, exceptions=["cupy", "jax.numpy"],
         allow_dask_compute=True, jax_jit=True
     )

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -76,11 +76,23 @@ def delegate_xp(delegator, module_name, capabilities=None):
         return capabilities(wrapper)
     return inner
 
+default_capabilities = xp_capabilities(
+    cpu_only=True, exceptions=['cupy', 'jax.numpy']
+)
+
+capabilities_dict = {
+    "geometric_transform": xp_capabilities(
+        cpu_only=True, exceptions=['jax.numpy']
+    ),
+}
+
 # ### decorate ###
 for func_name in _ndimage_api.__all__:
     bare_func = getattr(_ndimage_api, func_name)
     delegator = getattr(_delegators, func_name + "_signature")
 
-    f = delegate_xp(delegator, MODULE_NAME)(bare_func)
+    capabilities = capabilities_dict.get(func_name, default_capabilities)
+
+    f = delegate_xp(delegator, MODULE_NAME, capabilities)(bare_func)
     # add the decorated function to the namespace, to be imported in __init__.py
     vars()[func_name] = f

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -84,6 +84,9 @@ capabilities_dict = {
     "geometric_transform": xp_capabilities(
         cpu_only=True, exceptions=['jax.numpy']
     ),
+    "find_objects": xp_capabilities(
+        cpu_only=True, exceptions=['jax.numpy']
+    ),
 }
 
 # ### decorate ###

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -87,6 +87,13 @@ capabilities_dict = {
     "find_objects": xp_capabilities(
         cpu_only=True, exceptions=['jax.numpy']
     ),
+    "distance_transform_bf": xp_capabilities(
+        cpu_only=True, exceptions=['jax.numpy']
+    ),
+    "distance_transform_cdt": xp_capabilities(
+        cpu_only=True, exceptions=['jax.numpy']
+    ),
+    "generate_binary_structure": xp_capabilities(out_of_scope=True),
 }
 
 # ### decorate ###

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -77,23 +77,30 @@ def delegate_xp(delegator, module_name, capabilities=None):
     return inner
 
 default_capabilities = xp_capabilities(
-    cpu_only=True, exceptions=['cupy', 'jax.numpy']
+    cpu_only=True, exceptions=["cupy"], allow_dask_compute=True, jax_jit=False
 )
 
 capabilities_dict = {
     "geometric_transform": xp_capabilities(
-        cpu_only=True, exceptions=['jax.numpy']
+        cpu_only=True, allow_dask_compute=True, jax_jit=False
     ),
     "find_objects": xp_capabilities(
-        cpu_only=True, exceptions=['jax.numpy']
+        cpu_only=True, allow_dask_compute=True, jax_jit=False
     ),
     "distance_transform_bf": xp_capabilities(
-        cpu_only=True, exceptions=['jax.numpy']
+        cpu_only=True, allow_dask_compute=True, jax_jit=False
     ),
     "distance_transform_cdt": xp_capabilities(
-        cpu_only=True, exceptions=['jax.numpy']
+        cpu_only=True, allow_dask_compute=True, jax_jit=False
+    ),
+    "vectorized_filter": xp_capabilities(
+        cpu_only=True, allow_dask_compute=True, jax_jit=False
     ),
     "generate_binary_structure": xp_capabilities(out_of_scope=True),
+    "map_coodinates": xp_capabilities(
+        cpu_only=True, exceptions=["cupy", "jax.numpy"],
+        allow_dask_compute=True, jax_jit=True
+    )
 }
 
 # ### decorate ###

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -66,7 +66,8 @@ def delegate_xp(delegator, module_name, capabilities=None):
                     elif isinstance(result, int):
                         return result
                     elif isinstance(result, dict):
-                        # value_indices: result is {np.int64(1): (array(0), array(1))} etc
+                        # value_indices:
+                        # result is {np.int64(1): (array(0), array(1))} etc
                         return {
                             k.item(): tuple(xp.asarray(vv) for vv in v)
                             for k,v in result.items()

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -25,7 +25,13 @@ def _maybe_convert_arg(arg, xp):
 
 # Some cupyx.scipy.ndimage functions don't exist or are incompatible with
 # their SciPy counterparts
-CUPY_BLOCKLIST = ['vectorized_filter']
+CUPY_BLOCKLIST = [
+    'distance_transform_bf',
+    'distance_transform_cdt',
+    'find_objects',
+    'geometric_transform',
+    'vectorized_filter',
+]
 
 
 def delegate_xp(delegator, module_name, capabilities=None):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -18,6 +18,8 @@ from scipy._lib._array_api import (
     assert_array_almost_equal,
     xp_assert_close,
     xp_assert_equal,
+    make_xp_test_case,
+    make_xp_pytest_param,
 )
 from scipy._lib._array_api import (is_cupy, is_torch, is_dask, is_jax, array_namespace,
                                    is_array_api_strict, xp_copy)
@@ -28,7 +30,6 @@ from . import types, float_types, complex_types
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
-pytestmark = [skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'])]
 
 uses_output_dtype = skip_xp_backends(
     np_only=True, exceptions=["cupy"],
@@ -125,8 +126,9 @@ def _cases_axes_tuple_length_mismatch():
             yield filter_func, kwargs, key, val
 
 
+@make_xp_test_case(ndimage.correlate, ndimage.correlate1d,
+                   ndimage.convolve, ndimage.convolve1d)
 class TestNdimageFilters:
-
     def _validate_complex(self, xp, array, kernel, type2, mode='reflect',
                           cval=0, check_warnings=True):
         # utility for validating complex-valued correlations
@@ -981,7 +983,7 @@ class TestNdimageFilters:
         xp_assert_close(output, expected)
 
     @skip_xp_backends("cupy",
-                      reason="https://github.com/cupy/cupy/pull/8339")
+                       reason="https://github.com/cupy/cupy/pull/8339")
     @pytest.mark.parametrize('func', [ndimage.correlate, ndimage.convolve])
     @pytest.mark.parametrize(
         'dtype', [np.float32, np.float64, np.complex64, np.complex128]
@@ -2185,6 +2187,7 @@ class TestNdimageFilters:
 
 
 @xfail_xp_backends("cupy", reason="TypeError")
+@make_xp_test_case(ndimage.generic_filter)
 def test_ticket_701(xp):
     # Test generic filter sizes
     arr = xp.asarray(np.arange(4).reshape(2, 2))
@@ -2244,6 +2247,7 @@ def test_gaussian_kernel1d(xp):
                     xp.asarray(_gaussian_kernel1d(sigma, 3, radius)))
 
 
+@make_xp_test_case(ndimage.gaussian_filter, ndimage.gaussian_filter1d)
 def test_orders_gauss(xp):
     # Check order inputs to Gaussians
     arr = xp.zeros((1,))
@@ -2258,8 +2262,14 @@ def test_orders_gauss(xp):
 
 
 @xfail_xp_backends("cupy", reason="TypeError")
-def test_valid_origins(xp):
+@make_xp_test_case(
+    ndimage.generic_filter,
+    ndimage.generic_filter1d,
+    ndimage.percentile_filter,
+)
+def test_valid_origins1(xp):
     """Regression test for #1311."""
+    
     def func(x):
         return xp.mean(x)
 
@@ -2271,18 +2281,38 @@ def test_valid_origins(xp):
     assert_raises(ValueError, ndimage.percentile_filter, data, 0.2, size=3,
                   origin=2)
 
-    for filter in [ndimage.uniform_filter, ndimage.minimum_filter,
-                   ndimage.maximum_filter, ndimage.maximum_filter1d,
-                   ndimage.median_filter, ndimage.minimum_filter1d]:
-        # This should work, since for size == 3, the valid range for origin is
-        # -1 to 1.
-        list(filter(data, 3, origin=-1))
-        list(filter(data, 3, origin=1))
-        # Just check this raises an error instead of silently accepting or
-        # segfaulting.
-        assert_raises(ValueError, filter, data, 3, origin=2)
+
+@xfail_xp_backends("cupy", reason="TypeError")
+@pytest.mark.parametrize(
+    "filter_func",
+    [
+        make_xp_pytest_param(ndimage.uniform_filter),
+        make_xp_pytest_param(ndimage.minimum_filter),
+        make_xp_pytest_param(ndimage.maximum_filter),
+        make_xp_pytest_param(ndimage.maximum_filter1d),
+        make_xp_pytest_param(ndimage.median_filter),
+        make_xp_pytest_param(ndimage.minimum_filter1d),
+    ],
+)    
+def test_valid_origins2(xp, filter_func):
+    """Regression test for #1311."""
+    data = xp.asarray([1, 2, 3, 4, 5], dtype=xp.float64)
+
+    # This should work, since for size == 3, the valid range for origin is
+    # -1 to 1.
+    list(filter_func(data, 3, origin=-1))
+    list(filter_func(data, 3, origin=1))
+    # Just check this raises an error instead of silently accepting or
+    # segfaulting.
+    assert_raises(ValueError, filter_func, data, 3, origin=2)
 
 
+@make_xp_test_case(
+    ndimage.correlate1d,
+    ndimage.correlate,
+    ndimage.convolve1d,
+    ndimage.convolve,
+)
 def test_bad_convolve_and_correlate_origins(xp):
     """Regression test for gh-822."""
     # Before gh-822 was fixed, these would generate seg. faults or
@@ -2301,8 +2331,22 @@ def test_bad_convolve_and_correlate_origins(xp):
     assert_raises(ValueError, ndimage.convolve,
                   xp.ones((3, 5)), xp.ones((2, 2)), origin=[0, -2])
 
-@skip_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8430")
-def test_multiple_modes(xp):
+
+@pytest.mark.parametrize(
+    "filter_func,args,kwargs",
+    [
+        make_xp_pytest_param(ndimage.gaussian_filter, [1], {}),
+        make_xp_pytest_param(ndimage.prewitt, [], {}),
+        make_xp_pytest_param(ndimage.sobel, [], {}),
+        make_xp_pytest_param(ndimage.laplace, [], {}),
+        make_xp_pytest_param(ndimage.gaussian_laplace, [1], {}),
+        make_xp_pytest_param(ndimage.maximum_filter, [], {"size": 5}),
+        make_xp_pytest_param(ndimage.minimum_filter, [], {"size": 5}),
+        make_xp_pytest_param(ndimage.gaussian_gradient_magnitude, [1], {}),
+        make_xp_pytest_param(ndimage.uniform_filter, [5], {}),
+    ],
+)
+def test_multiple_modes(xp, filter_func, args, kwargs):
     # Test that the filters with multiple mode capabilities for different
     # dimensions give the same result as applying a single mode.
     arr = xp.asarray([[1., 0., 0.],
@@ -2312,27 +2356,16 @@ def test_multiple_modes(xp):
     mode1 = 'reflect'
     mode2 = ['reflect', 'reflect']
 
-    xp_assert_equal(ndimage.gaussian_filter(arr, 1, mode=mode1),
-                 ndimage.gaussian_filter(arr, 1, mode=mode2))
-    xp_assert_equal(ndimage.prewitt(arr, mode=mode1),
-                 ndimage.prewitt(arr, mode=mode2))
-    xp_assert_equal(ndimage.sobel(arr, mode=mode1),
-                 ndimage.sobel(arr, mode=mode2))
-    xp_assert_equal(ndimage.laplace(arr, mode=mode1),
-                 ndimage.laplace(arr, mode=mode2))
-    xp_assert_equal(ndimage.gaussian_laplace(arr, 1, mode=mode1),
-                 ndimage.gaussian_laplace(arr, 1, mode=mode2))
-    xp_assert_equal(ndimage.maximum_filter(arr, size=5, mode=mode1),
-                 ndimage.maximum_filter(arr, size=5, mode=mode2))
-    xp_assert_equal(ndimage.minimum_filter(arr, size=5, mode=mode1),
-                 ndimage.minimum_filter(arr, size=5, mode=mode2))
-    xp_assert_equal(ndimage.gaussian_gradient_magnitude(arr, 1, mode=mode1),
-                 ndimage.gaussian_gradient_magnitude(arr, 1, mode=mode2))
-    xp_assert_equal(ndimage.uniform_filter(arr, 5, mode=mode1),
-                 ndimage.uniform_filter(arr, 5, mode=mode2))
+    xp_assert_equal(filter_func(arr, *args, mode=mode1, **kwargs),
+                    filter_func(arr, *args, mode=mode2, **kwargs))
 
 
-@skip_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8430")
+@make_xp_test_case(
+    ndimage.gaussian_filter1d, ndimage.gaussian_filter,
+    ndimage.uniform_filter1d, ndimage.uniform_filter,
+    ndimage.maximum_filter1d, ndimage.maximum_filter,
+    ndimage.minimum_filter1d, ndimage.minimum_filter,
+)
 def test_multiple_modes_sequentially(xp):
     # Test that the filters with multiple mode capabilities for different
     # dimensions give the same result as applying the filters with
@@ -2366,6 +2399,7 @@ def test_multiple_modes_sequentially(xp):
                  ndimage.minimum_filter(arr, size=5, mode=modes))
 
 
+@make_xp_test_case(ndimage.prewitt)
 def test_multiple_modes_prewitt(xp):
     # Test prewitt filter for multiple extrapolation modes
     arr = xp.asarray([[1., 0., 0.],
@@ -2382,6 +2416,7 @@ def test_multiple_modes_prewitt(xp):
                  ndimage.prewitt(arr, mode=modes))
 
 
+@make_xp_test_case(ndimage.sobel)
 def test_multiple_modes_sobel(xp):
     # Test sobel filter for multiple extrapolation modes
     arr = xp.asarray([[1., 0., 0.],
@@ -2398,6 +2433,7 @@ def test_multiple_modes_sobel(xp):
                  ndimage.sobel(arr, mode=modes))
 
 
+@make_xp_test_case(ndimage.laplace)
 def test_multiple_modes_laplace(xp):
     # Test laplace filter for multiple extrapolation modes
     arr = xp.asarray([[1., 0., 0.],
@@ -2414,6 +2450,7 @@ def test_multiple_modes_laplace(xp):
                  ndimage.laplace(arr, mode=modes))
 
 
+@make_xp_test_case(ndimage.gaussian_laplace)
 def test_multiple_modes_gaussian_laplace(xp):
     # Test gaussian_laplace filter for multiple extrapolation modes
     arr = xp.asarray([[1., 0., 0.],
@@ -2430,6 +2467,7 @@ def test_multiple_modes_gaussian_laplace(xp):
                         ndimage.gaussian_laplace(arr, 1, mode=modes))
 
 
+@make_xp_test_case(ndimage.gaussian_gradient_magnitude)
 def test_multiple_modes_gaussian_gradient_magnitude(xp):
     # Test gaussian_gradient_magnitude filter for multiple
     # extrapolation modes
@@ -2447,7 +2485,8 @@ def test_multiple_modes_gaussian_gradient_magnitude(xp):
 
     assert_almost_equal(expected, calculated)
 
-@skip_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8430")
+
+@make_xp_test_case(ndimage.uniform_filter)
 def test_multiple_modes_uniform(xp):
     # Test uniform filter for multiple extrapolation modes
     arr = xp.asarray([[1., 0., 0.],
@@ -2473,6 +2512,10 @@ def _count_nonzero(arr):
     return xp.sum(xp.astype(arr, xp.int8))
 
 
+@make_xp_test_case(
+    ndimage.gaussian_filter, ndimage.gaussian_filter1d,
+    ndimage.gaussian_laplace, ndimage.gaussian_gradient_magnitude,
+)
 def test_gaussian_truncate(xp):
     # Test that Gaussian filters can be truncated at different widths.
     # These tests only check that the result has the expected number
@@ -2519,6 +2562,7 @@ def test_gaussian_truncate(xp):
 
 
 @xfail_xp_backends("cupy", reason="cupy/cupy#8402")
+@make_xp_test_case(ndimage.gaussian_filter1d, ndimage.gaussian_filter)
 def test_gaussian_radius(xp):
     # Test that Gaussian filters with radius argument produce the same
     # results as the filters with corresponding truncate argument.
@@ -2549,6 +2593,7 @@ def test_gaussian_radius(xp):
 
 
 @xfail_xp_backends("cupy", reason="cupy/cupy#8402")
+@make_xp_test_case(ndimage.gaussian_filter1d)
 def test_gaussian_radius_invalid(xp):
     # radius must be a nonnegative integer
     with assert_raises(ValueError):
@@ -2572,6 +2617,7 @@ class TestThreading:
 
     @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
+    @make_xp_test_case(ndimage.correlate1d)
     def test_correlate1d(self, xp):
         d = np.random.randn(5000)
         os = np.empty((4, d.size))
@@ -2586,6 +2632,7 @@ class TestThreading:
 
     @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
+    @make_xp_test_case(ndimage.correlate)
     def test_correlate(self, xp):
         d = xp.asarray(np.random.randn(500, 500))
         k = xp.asarray(np.random.randn(10, 10))
@@ -2597,6 +2644,7 @@ class TestThreading:
 
     @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
+    @make_xp_test_case(ndimage.median_filter)
     def test_median_filter(self, xp):
         d = xp.asarray(np.random.randn(500, 500))
         os = xp.empty([4] + list(d.shape))
@@ -2607,6 +2655,7 @@ class TestThreading:
 
     @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
+    @make_xp_test_case(ndimage.uniform_filter1d)
     def test_uniform_filter1d(self, xp):
         d = np.random.randn(5000)
         os = np.empty((4, d.size))
@@ -2620,6 +2669,7 @@ class TestThreading:
 
     @xfail_xp_backends("cupy",
                        reason="XXX thread exception; cannot repro outside of pytest")
+    @make_xp_test_case(ndimage.maximum_filter, ndimage.minimum_filter)
     def test_minmax_filter(self, xp):
         d = xp.asarray(np.random.randn(500, 500))
         os = xp.empty([4] + list(d.shape))
@@ -2631,7 +2681,7 @@ class TestThreading:
         self.check_func_thread(4, ndimage.minimum_filter, (d, 3), ot)
         xp_assert_equal(os, ot)
 
-
+@make_xp_test_case(ndimage.maximum_filter1d, ndimage.minimum_filter1d)
 def test_minmaximum_filter1d(xp):
     # Regression gh-3898
     in_ = xp.arange(10)
@@ -2662,6 +2712,7 @@ def test_minmaximum_filter1d(xp):
 
 
 @xfail_xp_backends("cupy", reason="cupy/cupy#8401")
+@make_xp_test_case(ndimage.uniform_filter1d)
 def test_uniform_filter1d_roundoff_errors(xp):
     # gh-6930
     in_ = np.repeat([0, 1, 0], [9, 9, 9])
@@ -2672,6 +2723,7 @@ def test_uniform_filter1d_roundoff_errors(xp):
         xp_assert_equal(xp.sum(out), xp.asarray(10 - filter_size), check_0d=False)
 
 
+@make_xp_test_case(ndimage.maximum_filter)
 def test_footprint_all_zeros(xp):
     # regression test for gh-6876: footprint of all zeros segfaults
     arr = xp.asarray(np.random.randint(0, 100, (100, 100)))
@@ -2683,6 +2735,7 @@ def test_footprint_all_zeros(xp):
 @xfail_xp_backends("cupy", reason="does not raise")
 @skip_xp_backends("array_api_strict", reason="no float16")
 @skip_xp_backends("dask.array", reason="no float16")
+@make_xp_test_case(ndimage.gaussian_filter)
 def test_gaussian_filter_float16(xp):
     # gh-8207
     data = xp.asarray([1], dtype=xp.float16)
@@ -2692,6 +2745,7 @@ def test_gaussian_filter_float16(xp):
 
 
 @xfail_xp_backends("cupy", reason="does not raise")
+@make_xp_test_case(ndimage.rank_filter)
 def test_rank_filter_noninteger_rank(xp):
     # regression test for issue 9388: ValueError for
     # non integer rank when performing rank_filter
@@ -2701,6 +2755,7 @@ def test_rank_filter_noninteger_rank(xp):
                   footprint=footprint)
 
 
+@make_xp_test_case(ndimage.rank_filter)
 def test_size_footprint_both_set(xp):
     # test for input validation, expect user warning when
     # size and footprint is set
@@ -2770,7 +2825,7 @@ def test_gh_22333():
 
 
 @pytest.mark.filterwarnings("ignore:The given NumPy array is not writable:UserWarning")
-@pytest.mark.skip_xp_backends(cpu_only=True, exceptions=['cupy'])
+@make_xp_test_case(ndimage.vectorized_filter)
 class TestVectorizedFilter:
     @pytest.mark.parametrize("axes, size",
                              [(None, (3, 4, 5)), ((0, 2), (3, 4)), ((-1,), (5,))])

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -6,6 +6,8 @@ from scipy._lib._array_api import (
     assert_array_almost_equal,
     assert_almost_equal,
     is_cupy,
+    make_xp_test_case,
+    make_xp_pytest_param,
 )
 
 import pytest
@@ -13,14 +15,14 @@ import pytest
 from scipy import ndimage
 
 skip_xp_backends = pytest.mark.skip_xp_backends
-pytestmark = [skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'])]
 
 
-@skip_xp_backends('jax.numpy', reason="jax-ml/jax#23827")
+#@skip_xp_backends('jax.numpy', reason="jax-ml/jax#23827")
 class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15), (1, 10)])
     @pytest.mark.parametrize('dtype, dec', [("float32", 6), ("float64", 14)])
+    @make_xp_test_case(ndimage.fourier_gaussian)
     def test_fourier_gaussian_real01(self, shape, dtype, dec, xp):
         fft = getattr(xp, 'fft')
 
@@ -38,6 +40,7 @@ class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec', [("complex64", 6), ("complex128", 14)])
+    @make_xp_test_case(ndimage.fourier_gaussian)
     def test_fourier_gaussian_complex01(self, shape, dtype, dec, xp):
         fft = getattr(xp, 'fft')
 
@@ -55,6 +58,7 @@ class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15), (1, 10)])
     @pytest.mark.parametrize('dtype, dec', [("float32", 6), ("float64", 14)])
+    @make_xp_test_case(ndimage.fourier_uniform)
     def test_fourier_uniform_real01(self, shape, dtype, dec, xp):
         fft = getattr(xp, 'fft')
 
@@ -72,6 +76,7 @@ class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec', [("complex64", 6), ("complex128", 14)])
+    @make_xp_test_case(ndimage.fourier_uniform)
     def test_fourier_uniform_complex01(self, shape, dtype, dec, xp):
         fft = getattr(xp, 'fft')
 
@@ -89,6 +94,7 @@ class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec', [("float32", 4), ("float64", 11)])
+    @make_xp_test_case(ndimage.fourier_shift)
     def test_fourier_shift_real01(self, shape, dtype, dec, xp):
         fft = getattr(xp, 'fft')
 
@@ -104,6 +110,7 @@ class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec', [("complex64", 4), ("complex128", 11)])
+    @make_xp_test_case(ndimage.fourier_shift)
     def test_fourier_shift_complex01(self, shape, dtype, dec, xp):
         fft = getattr(xp, 'fft')
 
@@ -120,6 +127,7 @@ class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15), (1, 10)])
     @pytest.mark.parametrize('dtype, dec', [("float32", 5), ("float64", 14)])
+    @make_xp_test_case(ndimage.fourier_ellipsoid)
     def test_fourier_ellipsoid_real01(self, shape, dtype, dec, xp):
         fft = getattr(xp, 'fft')
 
@@ -137,6 +145,7 @@ class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15)])
     @pytest.mark.parametrize('dtype, dec', [("complex64", 5), ("complex128", 14)])
+    @make_xp_test_case(ndimage.fourier_ellipsoid)
     def test_fourier_ellipsoid_complex01(self, shape, dtype, dec, xp):
         fft = getattr(xp, 'fft')
 
@@ -152,12 +161,14 @@ class TestNdimageFourier:
         assert_almost_equal(ndimage.sum(xp.real(a)), xp.asarray(1.0), decimal=dec,
                             check_0d=False)
 
+    @make_xp_test_case(ndimage.fourier_ellipsoid)
     def test_fourier_ellipsoid_unimplemented_ndim(self, xp):
         # arrays with ndim > 3 raise NotImplementedError
         x = xp.ones((4, 6, 8, 10), dtype=xp.complex128)
         with pytest.raises(NotImplementedError):
             ndimage.fourier_ellipsoid(x, 3)
 
+    @make_xp_test_case(ndimage.fourier_ellipsoid)
     def test_fourier_ellipsoid_1d_complex(self, xp):
         # expected result of 1d ellipsoid is the same as for fourier_uniform
         for shape in [(32, ), (31, )]:
@@ -171,9 +182,9 @@ class TestNdimageFourier:
     @pytest.mark.parametrize('dtype', ["float32", "float64",
                                        "complex64", "complex128"])
     @pytest.mark.parametrize('test_func',
-                             [ndimage.fourier_ellipsoid,
-                              ndimage.fourier_gaussian,
-                              ndimage.fourier_uniform])
+                             [make_xp_pytest_param(ndimage.fourier_ellipsoid),
+                              make_xp_pytest_param(ndimage.fourier_gaussian),
+                              make_xp_pytest_param(ndimage.fourier_uniform)])
     def test_fourier_zero_length_dims(self, shape, dtype, test_func, xp):
         if (
             is_cupy(xp)

--- a/scipy/ndimage/tests/test_fourier.py
+++ b/scipy/ndimage/tests/test_fourier.py
@@ -17,7 +17,6 @@ from scipy import ndimage
 skip_xp_backends = pytest.mark.skip_xp_backends
 
 
-#@skip_xp_backends('jax.numpy', reason="jax-ml/jax#23827")
 class TestNdimageFourier:
 
     @pytest.mark.parametrize('shape', [(32, 16), (31, 15), (1, 10)])

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -6,6 +6,7 @@ from scipy._lib._array_api import (
     _asarray, assert_array_almost_equal,
     is_jax, np_compat,
     xp_assert_equal, xp_assert_close,
+    make_xp_test_case,
 )
 
 import pytest
@@ -16,7 +17,6 @@ from . import types
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
-pytestmark = [skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'])]
 
 
 eps = 1e-12
@@ -33,7 +33,7 @@ ndimage_to_numpy_mode = {
 
 class TestBoundaries:
 
-    @skip_xp_backends("cupy", reason="CuPy does not have geometric_transform")
+    @make_xp_test_case(ndimage.geometric_transform)
     @pytest.mark.parametrize(
         'mode, expected_value',
         [('nearest', [1.5, 2.5, 3.5, 4, 4, 4, 4]),
@@ -54,7 +54,7 @@ class TestBoundaries:
                                         output_shape=(7,), order=1),
             xp.asarray(expected_value))
 
-    @skip_xp_backends("cupy", reason="CuPy does not have geometric_transform")
+    @make_xp_test_case(ndimage.geometric_transform)
     @pytest.mark.parametrize(
         'mode, expected_value',
         [('nearest', [1, 1, 2, 3]),
@@ -75,6 +75,7 @@ class TestBoundaries:
                                         output_shape=(4,)),
             xp.asarray(expected_value))
 
+    @make_xp_test_case(ndimage.map_coordinates)
     @pytest.mark.parametrize('mode', ['mirror', 'reflect', 'grid-mirror',
                                       'grid-wrap', 'grid-constant',
                                       'nearest'])
@@ -103,6 +104,7 @@ class TestBoundaries:
         xp_assert_close(y, expected, rtol=1e-7, atol=atol)
 
 
+@make_xp_test_case(ndimage.spline_filter)
 @pytest.mark.parametrize('order', range(2, 6))
 @pytest.mark.parametrize('dtype', types)
 class TestSpline:
@@ -144,7 +146,7 @@ class TestSpline:
         assert_array_almost_equal(out, expected)
 
 
-@skip_xp_backends("cupy", reason="CuPy does not have geometric_transform")
+@make_xp_test_case(ndimage.geometric_transform)
 @pytest.mark.parametrize('order', range(0, 6))
 class TestGeometricTransform:
 
@@ -423,7 +425,7 @@ class TestGeometricTransform:
         assert_array_almost_equal(out, xp.asarray([5, 7]))
 
 
-@skip_xp_backends("cupy", reason="CuPy does not have geometric_transform")
+@make_xp_test_case(ndimage.geometric_transform)
 class TestGeometricTransformExtra:
 
     def test_geometric_transform_grid_constant_order1(self, xp):
@@ -501,6 +503,7 @@ class TestGeometricTransformExtra:
         assert_array_almost_equal(out, [1])
 
 
+@make_xp_test_case(ndimage.map_coordinates)
 class TestMapCoordinates:
 
     @pytest.mark.parametrize('order', range(0, 6))
@@ -620,6 +623,7 @@ class TestMapCoordinates:
             raise pytest.skip('Not enough memory available') from e
 
 
+@make_xp_test_case(ndimage.affine_transform)
 class TestAffineTransform:
 
     @pytest.mark.parametrize('order', range(0, 6))
@@ -1000,6 +1004,7 @@ class TestAffineTransform:
         )
 
 
+@make_xp_test_case(ndimage.shift)
 class TestShift:
 
     @pytest.mark.parametrize('order', range(0, 6))
@@ -1199,6 +1204,7 @@ class TestShift:
         )
 
 
+@make_xp_test_case(ndimage.zoom)
 class TestZoom:
 
     @pytest.mark.parametrize('order', range(0, 6))
@@ -1341,6 +1347,7 @@ class TestZoom:
         xp_assert_equal(output, x)
 
 
+@make_xp_test_case(ndimage.rotate)
 class TestRotate:
 
     @pytest.mark.parametrize('order', range(0, 6))

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -17,6 +17,7 @@ from . import types
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
+# lazy_xp_modules = [ndimage]
 
 
 eps = 1e-12

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -10,6 +10,7 @@ from scipy._lib._array_api import (
     xp_assert_close,
     assert_array_almost_equal,
     assert_almost_equal,
+    make_xp_test_case,
 )
 
 import pytest
@@ -20,7 +21,6 @@ import scipy.ndimage as ndimage
 from . import types
 
 skip_xp_backends = pytest.mark.skip_xp_backends
-pytestmark = [skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'])]
 
 IS_WINDOWS_AND_NP1 = os.name == 'nt' and np.__version__ < '2'
 
@@ -147,6 +147,7 @@ class Test_measurements_select:
             assert result[1].dtype.kind == 'i'
 
 
+@make_xp_test_case(ndimage.label)
 def test_label01(xp):
     data = xp.ones(())
     out, n = ndimage.label(data)
@@ -154,6 +155,7 @@ def test_label01(xp):
     assert n == 1
 
 
+@make_xp_test_case(ndimage.label)
 def test_label02(xp):
     data = xp.zeros(())
     out, n = ndimage.label(data)
@@ -161,6 +163,7 @@ def test_label02(xp):
     assert n == 0
 
 
+@make_xp_test_case(ndimage.label)
 def test_label03(xp):
     data = xp.ones([1])
     out, n = ndimage.label(data)
@@ -168,6 +171,7 @@ def test_label03(xp):
     assert n == 1
 
 
+@make_xp_test_case(ndimage.label)
 def test_label04(xp):
     data = xp.zeros([1])
     out, n = ndimage.label(data)
@@ -175,6 +179,7 @@ def test_label04(xp):
     assert n == 0
 
 
+@make_xp_test_case(ndimage.label)
 def test_label05(xp):
     data = xp.ones([5])
     out, n = ndimage.label(data)
@@ -182,6 +187,7 @@ def test_label05(xp):
     assert n == 1
 
 
+@make_xp_test_case(ndimage.label)
 def test_label06(xp):
     data = xp.asarray([1, 0, 1, 1, 0, 1])
     out, n = ndimage.label(data)
@@ -189,6 +195,7 @@ def test_label06(xp):
     assert n == 3
 
 
+@make_xp_test_case(ndimage.label)
 def test_label07(xp):
     data = xp.asarray([[0, 0, 0, 0, 0, 0],
                        [0, 0, 0, 0, 0, 0],
@@ -207,6 +214,7 @@ def test_label07(xp):
     assert n == 0
 
 
+@make_xp_test_case(ndimage.label)
 def test_label08(xp):
     data = xp.asarray([[1, 0, 0, 0, 0, 0],
                        [0, 0, 1, 1, 0, 0],
@@ -224,6 +232,7 @@ def test_label08(xp):
     assert n == 4
 
 
+@make_xp_test_case(ndimage.label)
 def test_label09(xp):
     data = xp.asarray([[1, 0, 0, 0, 0, 0],
                        [0, 0, 1, 1, 0, 0],
@@ -243,6 +252,7 @@ def test_label09(xp):
     assert n == 3
 
 
+@make_xp_test_case(ndimage.label)
 def test_label10(xp):
     data = xp.asarray([[0, 0, 0, 0, 0, 0],
                        [0, 1, 1, 0, 1, 0],
@@ -258,6 +268,7 @@ def test_label10(xp):
     assert n == 1
 
 
+@make_xp_test_case(ndimage.label)
 def test_label11(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -280,6 +291,7 @@ def test_label11(xp):
 
 
 @skip_xp_backends(np_only=True, reason='inplace output is numpy-specific')
+@make_xp_test_case(ndimage.label)
 def test_label11_inplace(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -301,6 +313,7 @@ def test_label11_inplace(xp):
         assert n == 4
 
 
+@make_xp_test_case(ndimage.label)
 def test_label12(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -320,6 +333,7 @@ def test_label12(xp):
         assert n == 1
 
 
+@make_xp_test_case(ndimage.label)
 def test_label13(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -340,6 +354,7 @@ def test_label13(xp):
 
 @skip_xp_backends(np_only=True, exceptions=["cupy"],
                   reason='output=dtype is numpy-specific')
+@make_xp_test_case(ndimage.label)
 def test_label_output_typed(xp):
     data = xp.ones([5])
     for t in types:
@@ -353,6 +368,7 @@ def test_label_output_typed(xp):
 
 @skip_xp_backends(np_only=True, exceptions=["cupy"],
                   reason='output=dtype is numpy-specific')
+@make_xp_test_case(ndimage.label)
 def test_label_output_dtype(xp):
     data = xp.ones([5])
     for t in types:
@@ -364,6 +380,7 @@ def test_label_output_dtype(xp):
 
 
 @skip_xp_backends(np_only=True, reason="in-place output is numpy-specific")
+@make_xp_test_case(ndimage.label)
 def test_label_output_wrong_size(xp):
     data = xp.ones([5])
     for t in types:
@@ -372,6 +389,7 @@ def test_label_output_wrong_size(xp):
         assert_raises(ValueError, ndimage.label, data, output=output)
 
 
+@make_xp_test_case(ndimage.label)
 def test_label_structuring_elements(xp):
     data = np.loadtxt(os.path.join(os.path.dirname(
         __file__), "data", "label_inputs.txt"))
@@ -394,7 +412,8 @@ def test_label_structuring_elements(xp):
             xp_assert_equal(ndimage.label(d, s)[0], results[r, :, :], check_dtype=False)
             r += 1
 
-@skip_xp_backends("cupy", reason="`cupyx.scipy.ndimage` does not have `find_objects`")
+
+@make_xp_test_case(ndimage.label, ndimage.find_objects)
 def test_ticket_742(xp):
     def SE(img, thresh=.7, size=4):
         mask = img > thresh
@@ -413,6 +432,7 @@ def test_ticket_742(xp):
         SE(a)
 
 
+@make_xp_test_case(ndimage.label)
 def test_gh_issue_3025(xp):
     """Github issue #3025 - improper merging of labels"""
     d = np.zeros((60, 320))
@@ -425,7 +445,7 @@ def test_gh_issue_3025(xp):
     assert ndimage.label(d, xp.ones((3, 3)))[1] == 1
 
 
-@skip_xp_backends("cupy", reason="cupyx.scipy.ndimage does not have find_object")
+@make_xp_test_case(ndimage.label, ndimage.find_objects)
 class TestFindObjects:
     def test_label_default_dtype(self, xp):
         test_array = np.random.rand(10, 10)
@@ -513,6 +533,7 @@ class TestFindObjects:
                            (slice(5, 6, None), slice(3, 5, None))]
 
 
+@make_xp_test_case(ndimage.value_indices)
 def test_value_indices01(xp):
     "Test dictionary keys and entries"
     data = xp.asarray([[1, 0, 0, 0, 0, 0],
@@ -535,6 +556,7 @@ def test_value_indices01(xp):
             xp_assert_equal(v, true_v)
 
 
+@make_xp_test_case(ndimage.value_indices)
 def test_value_indices02(xp):
     "Test input checking"
     data = xp.zeros((5, 4), dtype=xp.float32)
@@ -543,6 +565,7 @@ def test_value_indices02(xp):
         ndimage.value_indices(data)
 
 
+@make_xp_test_case(ndimage.value_indices)
 def test_value_indices03(xp):
     "Test different input array shapes, from 1-D to 4-D"
     for shape in [(36,), (18, 2), (3, 3, 4), (3, 3, 2, 2)]:
@@ -560,6 +583,7 @@ def test_value_indices03(xp):
                 xp_assert_equal(vik, true_vik)
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum01(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -568,6 +592,7 @@ def test_sum01(xp):
         assert output == 0
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum02(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -576,6 +601,7 @@ def test_sum02(xp):
         assert output == 0
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum03(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -584,6 +610,7 @@ def test_sum03(xp):
         assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum04(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -592,6 +619,7 @@ def test_sum04(xp):
         assert_almost_equal(output, xp.asarray(3.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum05(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -600,6 +628,7 @@ def test_sum05(xp):
         assert_almost_equal(output, xp.asarray(10.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum06(xp):
     labels = np.asarray([], dtype=bool)
     labels = xp.asarray(labels)
@@ -610,6 +639,7 @@ def test_sum06(xp):
         assert output == 0
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum07(xp):
     labels = np.ones([0, 4], dtype=bool)
     labels = xp.asarray(labels)
@@ -620,6 +650,7 @@ def test_sum07(xp):
         assert output == 0
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum08(xp):
     labels = np.asarray([1, 0], dtype=bool)
     labels = xp.asarray(labels)
@@ -630,6 +661,7 @@ def test_sum08(xp):
         assert output == 1
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum09(xp):
     labels = np.asarray([1, 0], dtype=bool)
     labels = xp.asarray(labels)
@@ -640,6 +672,7 @@ def test_sum09(xp):
         assert_almost_equal(output, xp.asarray(4.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum10(xp):
     labels = np.asarray([1, 0], dtype=bool)
     input = np.asarray([[1, 2], [3, 4]], dtype=bool)
@@ -650,6 +683,7 @@ def test_sum10(xp):
     assert_almost_equal(output, xp.asarray(2.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum11(xp):
     labels = xp.asarray([1, 2], dtype=xp.int8)
     for type in types:
@@ -660,6 +694,7 @@ def test_sum11(xp):
         assert_almost_equal(output, xp.asarray(6.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum12(xp):
     labels = xp.asarray([[1, 2], [2, 4]], dtype=xp.int8)
     for type in types:
@@ -669,6 +704,7 @@ def test_sum12(xp):
         assert_array_almost_equal(output, xp.asarray([4.0, 0.0, 5.0]))
 
 
+@make_xp_test_case(ndimage.sum)
 def test_sum_labels(xp):
     labels = xp.asarray([[1, 2], [2, 4]], dtype=xp.int8)
     for type in types:
@@ -682,6 +718,7 @@ def test_sum_labels(xp):
         assert_array_almost_equal(output_labels, xp.asarray([4.0, 0.0, 5.0]))
 
 
+@make_xp_test_case(ndimage.mean)
 def test_mean01(xp):
     labels = np.asarray([1, 0], dtype=bool)
     labels = xp.asarray(labels)
@@ -692,6 +729,7 @@ def test_mean01(xp):
         assert_almost_equal(output, xp.asarray(2.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.mean)
 def test_mean02(xp):
     labels = np.asarray([1, 0], dtype=bool)
     input = np.asarray([[1, 2], [3, 4]], dtype=bool)
@@ -702,6 +740,7 @@ def test_mean02(xp):
     assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.mean)
 def test_mean03(xp):
     labels = xp.asarray([1, 2])
     for type in types:
@@ -712,6 +751,7 @@ def test_mean03(xp):
         assert_almost_equal(output, xp.asarray(3.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.mean)
 def test_mean04(xp):
     labels = xp.asarray([[1, 2], [2, 4]], dtype=xp.int8)
     with np.errstate(all='ignore'):
@@ -727,6 +767,7 @@ def test_mean04(xp):
             assert xp.isnan(output[1])
 
 
+@make_xp_test_case(ndimage.minimum)
 def test_minimum01(xp):
     labels = np.asarray([1, 0], dtype=bool)
     labels = xp.asarray(labels)
@@ -737,6 +778,7 @@ def test_minimum01(xp):
         assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.minimum)
 def test_minimum02(xp):
     labels = np.asarray([1, 0], dtype=bool)
     input = np.asarray([[2, 2], [2, 4]], dtype=bool)
@@ -747,6 +789,7 @@ def test_minimum02(xp):
     assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.minimum)
 def test_minimum03(xp):
     labels = xp.asarray([1, 2])
     for type in types:
@@ -758,6 +801,7 @@ def test_minimum03(xp):
         assert_almost_equal(output, xp.asarray(2.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.minimum)
 def test_minimum04(xp):
     labels = xp.asarray([[1, 2], [2, 3]])
     for type in types:
@@ -768,6 +812,7 @@ def test_minimum04(xp):
         assert_array_almost_equal(output, xp.asarray([2.0, 4.0, 0.0]))
 
 
+@make_xp_test_case(ndimage.maximum)
 def test_maximum01(xp):
     labels = np.asarray([1, 0], dtype=bool)
     labels = xp.asarray(labels)
@@ -778,6 +823,7 @@ def test_maximum01(xp):
         assert_almost_equal(output, xp.asarray(3.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.maximum)
 def test_maximum02(xp):
     labels = np.asarray([1, 0], dtype=bool)
     input = np.asarray([[2, 2], [2, 4]], dtype=bool)
@@ -787,6 +833,7 @@ def test_maximum02(xp):
     assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.maximum)
 def test_maximum03(xp):
     labels = xp.asarray([1, 2])
     for type in types:
@@ -797,6 +844,7 @@ def test_maximum03(xp):
         assert_almost_equal(output, xp.asarray(4.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.maximum)
 def test_maximum04(xp):
     labels = xp.asarray([[1, 2], [2, 3]])
     for type in types:
@@ -807,12 +855,14 @@ def test_maximum04(xp):
         assert_array_almost_equal(output, xp.asarray([3.0, 4.0, 0.0]))
 
 
+@make_xp_test_case(ndimage.maximum)
 def test_maximum05(xp):
     # Regression test for ticket #501 (Trac)
     x = xp.asarray([-3, -2, -1])
     assert ndimage.maximum(x) == -1
 
 
+@make_xp_test_case(ndimage.median)
 def test_median01(xp):
     a = xp.asarray([[1, 2, 0, 1],
                     [5, 3, 0, 4],
@@ -826,6 +876,7 @@ def test_median01(xp):
     assert_array_almost_equal(output, xp.asarray([2.5, 4.0, 6.0]))
 
 
+@make_xp_test_case(ndimage.median)
 def test_median02(xp):
     a = xp.asarray([[1, 2, 0, 1],
                     [5, 3, 0, 4],
@@ -835,6 +886,7 @@ def test_median02(xp):
     assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.median)
 def test_median03(xp):
     a = xp.asarray([[1, 2, 0, 1],
                     [5, 3, 0, 4],
@@ -848,6 +900,7 @@ def test_median03(xp):
     assert_almost_equal(output, xp.asarray(3.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.median)
 def test_median_gh12836_bool(xp):
     # test boolean addition fix on example from gh-12836
     a = np.asarray([1, 1], dtype=bool)
@@ -856,6 +909,7 @@ def test_median_gh12836_bool(xp):
     assert_array_almost_equal(output, xp.asarray([1.0]))
 
 
+@make_xp_test_case(ndimage.median)
 def test_median_no_int_overflow(xp):
     # test integer overflow fix on example from gh-12836
     a = xp.asarray([65, 70], dtype=xp.int8)
@@ -863,6 +917,7 @@ def test_median_no_int_overflow(xp):
     assert_array_almost_equal(output, xp.asarray([67.5]))
 
 
+@make_xp_test_case(ndimage.variance)
 def test_variance01(xp):
     with np.errstate(all='ignore'):
         for type in types:
@@ -874,6 +929,7 @@ def test_variance01(xp):
             assert xp.isnan(output)
 
 
+@make_xp_test_case(ndimage.variance)
 def test_variance02(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -882,6 +938,7 @@ def test_variance02(xp):
         assert_almost_equal(output, xp.asarray(0.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.variance)
 def test_variance03(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -890,6 +947,7 @@ def test_variance03(xp):
         assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.variance)
 def test_variance04(xp):
     input = np.asarray([1, 0], dtype=bool)
     input = xp.asarray(input)
@@ -897,6 +955,7 @@ def test_variance04(xp):
     assert_almost_equal(output, xp.asarray(0.25), check_0d=False)
 
 
+@make_xp_test_case(ndimage.variance)
 def test_variance05(xp):
     labels = xp.asarray([2, 2, 3])
     for type in types:
@@ -907,6 +966,7 @@ def test_variance05(xp):
         assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.variance)
 def test_variance06(xp):
     labels = xp.asarray([2, 2, 3, 3, 4])
     with np.errstate(all='ignore'):
@@ -917,6 +977,7 @@ def test_variance06(xp):
             assert_array_almost_equal(output, xp.asarray([1.0, 1.0, 0.0]))
 
 
+@make_xp_test_case(ndimage.standard_deviation)
 def test_standard_deviation01(xp):
     with np.errstate(all='ignore'):
         for type in types:
@@ -928,6 +989,7 @@ def test_standard_deviation01(xp):
             assert xp.isnan(output)
 
 
+@make_xp_test_case(ndimage.standard_deviation)
 def test_standard_deviation02(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -936,6 +998,7 @@ def test_standard_deviation02(xp):
         assert_almost_equal(output, xp.asarray(0.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.standard_deviation)
 def test_standard_deviation03(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -944,6 +1007,7 @@ def test_standard_deviation03(xp):
         assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.standard_deviation)
 def test_standard_deviation04(xp):
     input = np.asarray([1, 0], dtype=bool)
     input = xp.asarray(input)
@@ -951,6 +1015,7 @@ def test_standard_deviation04(xp):
     assert_almost_equal(output, xp.asarray(0.5), check_0d=False)
 
 
+@make_xp_test_case(ndimage.standard_deviation)
 def test_standard_deviation05(xp):
     labels = xp.asarray([2, 2, 3])
     for type in types:
@@ -960,6 +1025,7 @@ def test_standard_deviation05(xp):
         assert_almost_equal(output, xp.asarray(1.0), check_0d=False)
 
 
+@make_xp_test_case(ndimage.standard_deviation)
 def test_standard_deviation06(xp):
     labels = xp.asarray([2, 2, 3, 3, 4])
     with np.errstate(all='ignore'):
@@ -972,6 +1038,7 @@ def test_standard_deviation06(xp):
             assert_array_almost_equal(output, xp.asarray([1.0, 1.0, 0.0]))
 
 
+@make_xp_test_case(ndimage.standard_deviation)
 def test_standard_deviation07(xp):
     labels = xp.asarray([1])
     with np.errstate(all='ignore'):
@@ -985,6 +1052,7 @@ def test_standard_deviation07(xp):
             assert_array_almost_equal(output, xp.asarray([0]))
 
 
+@make_xp_test_case(ndimage.minimum_position)
 def test_minimum_position01(xp):
     labels = np.asarray([1, 0], dtype=bool)
     labels = xp.asarray(labels)
@@ -995,6 +1063,7 @@ def test_minimum_position01(xp):
         assert output == (0, 0)
 
 
+@make_xp_test_case(ndimage.minimum_position)
 def test_minimum_position02(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -1005,6 +1074,7 @@ def test_minimum_position02(xp):
         assert output == (1, 2)
 
 
+@make_xp_test_case(ndimage.minimum_position)
 def test_minimum_position03(xp):
     input = np.asarray([[5, 4, 2, 5],
                         [3, 7, 0, 2],
@@ -1014,6 +1084,7 @@ def test_minimum_position03(xp):
     assert output == (1, 2)
 
 
+@make_xp_test_case(ndimage.minimum_position)
 def test_minimum_position04(xp):
     input = np.asarray([[5, 4, 2, 5],
                         [3, 7, 1, 2],
@@ -1023,6 +1094,7 @@ def test_minimum_position04(xp):
     assert output == (0, 0)
 
 
+@make_xp_test_case(ndimage.minimum_position)
 def test_minimum_position05(xp):
     labels = xp.asarray([1, 2, 0, 4])
     for type in types:
@@ -1034,6 +1106,7 @@ def test_minimum_position05(xp):
         assert output == (2, 0)
 
 
+@make_xp_test_case(ndimage.minimum_position)
 def test_minimum_position06(xp):
     labels = xp.asarray([1, 2, 3, 4])
     for type in types:
@@ -1045,6 +1118,7 @@ def test_minimum_position06(xp):
         assert output == (0, 1)
 
 
+@make_xp_test_case(ndimage.minimum_position)
 def test_minimum_position07(xp):
     labels = xp.asarray([1, 2, 3, 4])
     for type in types:
@@ -1058,6 +1132,7 @@ def test_minimum_position07(xp):
         assert output[1] == (1, 2)
 
 
+@make_xp_test_case(ndimage.maximum_position)
 def test_maximum_position01(xp):
     labels = np.asarray([1, 0], dtype=bool)
     labels = xp.asarray(labels)
@@ -1069,6 +1144,7 @@ def test_maximum_position01(xp):
         assert output == (1, 0)
 
 
+@make_xp_test_case(ndimage.maximum_position)
 def test_maximum_position02(xp):
     for type in types:
         dtype = getattr(xp, type)
@@ -1079,6 +1155,7 @@ def test_maximum_position02(xp):
         assert output == (1, 2)
 
 
+@make_xp_test_case(ndimage.maximum_position)
 def test_maximum_position03(xp):
     input = np.asarray([[5, 4, 2, 5],
                         [3, 7, 8, 2],
@@ -1088,6 +1165,7 @@ def test_maximum_position03(xp):
     assert output == (0, 0)
 
 
+@make_xp_test_case(ndimage.maximum_position)
 def test_maximum_position04(xp):
     labels = xp.asarray([1, 2, 0, 4])
     for type in types:
@@ -1099,6 +1177,7 @@ def test_maximum_position04(xp):
         assert output == (1, 1)
 
 
+@make_xp_test_case(ndimage.maximum_position)
 def test_maximum_position05(xp):
     labels = xp.asarray([1, 2, 0, 4])
     for type in types:
@@ -1110,6 +1189,7 @@ def test_maximum_position05(xp):
         assert output == (0, 0)
 
 
+@make_xp_test_case(ndimage.maximum_position)
 def test_maximum_position06(xp):
     labels = xp.asarray([1, 2, 0, 4])
     for type in types:
@@ -1123,6 +1203,7 @@ def test_maximum_position06(xp):
         assert output[1] == (1, 1)
 
 
+@make_xp_test_case(ndimage.maximum_position)
 def test_maximum_position07(xp):
     # Test float labels
     labels = xp.asarray([1.0, 2.5, 0.0, 4.5])
@@ -1137,6 +1218,8 @@ def test_maximum_position07(xp):
         assert output[1] == (0, 3)
 
 
+@make_xp_test_case(ndimage.extrema, ndimage.minimum, ndimage.maximum,
+                   ndimage.minimum_position, ndimage.maximum_position)
 def test_extrema01(xp):
     labels = np.asarray([1, 0], dtype=bool)
     labels = xp.asarray(labels)
@@ -1153,6 +1236,8 @@ def test_extrema01(xp):
         assert output1 == (output2, output3, output4, output5)
 
 
+@make_xp_test_case(ndimage.extrema, ndimage.minimum, ndimage.maximum,
+                   ndimage.minimum_position, ndimage.maximum_position)
 def test_extrema02(xp):
     labels = xp.asarray([1, 2])
     for type in types:
@@ -1171,6 +1256,8 @@ def test_extrema02(xp):
         assert output1 == (output2, output3, output4, output5)
 
 
+@make_xp_test_case(ndimage.extrema, ndimage.minimum, ndimage.maximum,
+                   ndimage.minimum_position, ndimage.maximum_position)
 def test_extrema03(xp):
     labels = xp.asarray([[1, 2], [2, 3]])
     for type in types:
@@ -1199,6 +1286,8 @@ def test_extrema03(xp):
         assert output1[3] == output5
 
 
+@make_xp_test_case(ndimage.extrema, ndimage.minimum, ndimage.maximum,
+                   ndimage.minimum_position, ndimage.maximum_position)
 def test_extrema04(xp):
     labels = xp.asarray([1, 2, 0, 4])
     for type in types:
@@ -1222,6 +1311,7 @@ def test_extrema04(xp):
         assert output1[3] == output5
 
 
+@make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass01(xp):
     expected = (0.0, 0.0)
     for type in types:
@@ -1231,6 +1321,7 @@ def test_center_of_mass01(xp):
         assert output == expected
 
 
+@make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass02(xp):
     expected = (1, 0)
     for type in types:
@@ -1240,6 +1331,7 @@ def test_center_of_mass02(xp):
         assert output == expected
 
 
+@make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass03(xp):
     expected = (0, 1)
     for type in types:
@@ -1249,6 +1341,7 @@ def test_center_of_mass03(xp):
         assert output == expected
 
 
+@make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass04(xp):
     expected = (1, 1)
     for type in types:
@@ -1258,6 +1351,7 @@ def test_center_of_mass04(xp):
         assert output == expected
 
 
+@make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass05(xp):
     expected = (0.5, 0.5)
     for type in types:
@@ -1267,6 +1361,7 @@ def test_center_of_mass05(xp):
         assert output == expected
 
 
+@make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass06(xp):
     expected = (0.5, 0.5)
     input = np.asarray([[1, 2], [3, 1]], dtype=bool)
@@ -1275,6 +1370,7 @@ def test_center_of_mass06(xp):
     assert output == expected
 
 
+@make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass07(xp):
     labels = xp.asarray([1, 0])
     expected = (0.5, 0.0)
@@ -1284,6 +1380,7 @@ def test_center_of_mass07(xp):
     assert output == expected
 
 
+@make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass08(xp):
     labels = xp.asarray([1, 2])
     expected = (0.5, 1.0)
@@ -1293,6 +1390,7 @@ def test_center_of_mass08(xp):
     assert output == expected
 
 
+@make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass09(xp):
     labels = xp.asarray((1, 2))
     expected = xp.asarray([(0.5, 0.0), (0.5, 1.0)], dtype=xp.float64)
@@ -1302,6 +1400,7 @@ def test_center_of_mass09(xp):
     xp_assert_equal(xp.asarray(output), xp.asarray(expected))
 
 
+@make_xp_test_case(ndimage.histogram)
 def test_histogram01(xp):
     expected = xp.ones(10)
     input = xp.arange(10)
@@ -1309,6 +1408,7 @@ def test_histogram01(xp):
     assert_array_almost_equal(output, expected)
 
 
+@make_xp_test_case(ndimage.histogram)
 def test_histogram02(xp):
     labels = xp.asarray([1, 1, 1, 1, 2, 2, 2, 2])
     expected = xp.asarray([0, 2, 0, 1, 1])
@@ -1318,6 +1418,7 @@ def test_histogram02(xp):
 
 
 @skip_xp_backends(np_only=True, reason='object arrays')
+@make_xp_test_case(ndimage.histogram)
 def test_histogram03(xp):
     labels = xp.asarray([1, 0, 1, 1, 2, 2, 2, 2])
     expected1 = xp.asarray([0, 1, 0, 1, 1])
@@ -1329,7 +1430,8 @@ def test_histogram03(xp):
     assert_array_almost_equal(output[0], expected1)
     assert_array_almost_equal(output[1], expected2)
 
-
+@make_xp_test_case(ndimage.mean, ndimage.variance, ndimage.standard_deviation,
+                   ndimage.median, ndimage.minimum, ndimage.maximum)
 def test_stat_funcs_2d(xp):
     a = xp.asarray([[5, 6, 0, 0, 0], [8, 9, 0, 0, 0], [0, 0, 0, 3, 5]])
     lbl = xp.asarray([[1, 1, 0, 0, 0], [1, 1, 0, 0, 0], [0, 0, 0, 2, 2]])
@@ -1354,6 +1456,7 @@ def test_stat_funcs_2d(xp):
 
 
 @skip_xp_backends("cupy", reason="no watershed_ift on CuPy")
+@make_xp_test_case(ndimage.watershed_ift)
 class TestWatershedIft:
 
     def test_watershed_ift01(self, xp):
@@ -1584,6 +1687,7 @@ class TestWatershedIft:
 
 @skip_xp_backends(np_only=True)
 @pytest.mark.parametrize("dt", [np.intc, np.uintc])
+@make_xp_test_case(ndimage.value_indices)
 def test_gh_19423(dt, xp):
     rng = np.random.default_rng(123)
     max_val = 8

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -2820,7 +2820,6 @@ class TestNdimageMorphology:
     )
     def test_grey_axes(self, xp, func, expand_axis, origin, footprint_mode,
                        mode):
-        func_name = func.__name__
         data = xp.asarray([[0, 0, 0, 1, 0, 0, 0],
                            [0, 0, 0, 4, 0, 0, 0],
                            [0, 0, 2, 1, 0, 2, 0],

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -1,7 +1,9 @@
 import numpy as np
 from scipy._lib._array_api import (
     is_cupy, is_numpy,
-    xp_assert_close, xp_assert_equal, assert_array_almost_equal
+    xp_assert_close, xp_assert_equal, assert_array_almost_equal,
+    make_xp_test_case,
+    make_xp_pytest_param,
 )
 import pytest
 from pytest import raises as assert_raises
@@ -12,12 +14,11 @@ from . import types
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
-pytestmark = [skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'])]
 
 
 class TestNdimageMorphology:
 
-    @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf.')
+    @make_xp_test_case(ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_bf01(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -67,7 +68,7 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(ft, expected)
 
-    @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf.')
+    @make_xp_test_case(ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_bf02(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -117,7 +118,7 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(ft, expected)
 
-    @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf.')
+    @make_xp_test_case(ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_bf03(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -167,9 +168,11 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(ft, expected)
 
+
     @skip_xp_backends(
         np_only=True, reason='inplace distances= arrays are numpy-specific'
     )
+    @make_xp_test_case(ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_bf04(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -222,6 +225,7 @@ class TestNdimageMorphology:
             assert_array_almost_equal(tft, ft)
 
     @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf')
+    @make_xp_test_case(ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_bf05(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -270,7 +274,7 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(ft, expected)
 
-    @xfail_xp_backends('cupy', reason='CuPy does not have distance_transform_bf')
+    @make_xp_test_case(ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_bf06(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -319,7 +323,7 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(ft, expected)
 
-    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_bf")
+    @make_xp_test_case(ndimage.distance_transform_bf)
     def test_distance_transform_bf07(self, xp):
         # test input validation per discussion on PR #13302
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -336,7 +340,8 @@ class TestNdimageMorphology:
                 data, return_distances=False, return_indices=False
             )
 
-    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_cdt")
+    @make_xp_test_case(ndimage.distance_transform_bf,
+                       ndimage.distance_transform_cdt)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_cdt01(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -377,7 +382,8 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(ft, expected)
 
-    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_cdt")
+    @make_xp_test_case(ndimage.distance_transform_bf,
+                       ndimage.distance_transform_cdt)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_cdt02(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -419,6 +425,7 @@ class TestNdimageMorphology:
     @skip_xp_backends(
         np_only=True, reason='inplace indices= arrays are numpy-specific'
     )
+    @make_xp_test_case(ndimage.distance_transform_cdt)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_cdt03(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -472,6 +479,7 @@ class TestNdimageMorphology:
     @skip_xp_backends(
         np_only=True, reason='XXX: does not raise unless indices is a numpy array'
     )
+    @make_xp_test_case(ndimage.distance_transform_cdt)
     def test_distance_transform_cdt04(self, xp):
         # test input validation per discussion on PR #13302
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -492,8 +500,8 @@ class TestNdimageMorphology:
                 indices=indices_out
             )
 
-    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_cdt")
     @xfail_xp_backends("torch", reason="int overflow")
+    @make_xp_test_case(ndimage.distance_transform_cdt)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_cdt05(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -512,7 +520,9 @@ class TestNdimageMorphology:
         actual = ndimage.distance_transform_cdt(data, metric=metric_arg)
         assert xp.sum(actual) == -21
 
-    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_bf")
+    @skip_xp_backends("cupy", reason="CuPy does not have distance_transform_bf")
+    @make_xp_test_case(ndimage.distance_transform_edt,
+                       ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_edt01(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -545,6 +555,8 @@ class TestNdimageMorphology:
     @skip_xp_backends(
         np_only=True, reason='inplace distances= are numpy-specific'
     )
+    @make_xp_test_case(ndimage.distance_transform_edt,
+                       ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_edt02(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -606,7 +618,8 @@ class TestNdimageMorphology:
         for ft in fts:
             assert_array_almost_equal(tft, ft)
 
-    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_bf")
+    @make_xp_test_case(ndimage.distance_transform_edt,
+                       ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_edt03(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -624,7 +637,8 @@ class TestNdimageMorphology:
         out = ndimage.distance_transform_edt(data, sampling=[2, 2])
         assert_array_almost_equal(out, ref)
 
-    @xfail_xp_backends("cupy", reason="CuPy does not have distance_transform_bf")
+    @make_xp_test_case(ndimage.distance_transform_edt,
+                       ndimage.distance_transform_bf)
     @pytest.mark.parametrize('dtype', types)
     def test_distance_transform_edt4(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -645,6 +659,7 @@ class TestNdimageMorphology:
     @xfail_xp_backends(
         "cupy", reason="Only 2D and 3D distance transforms are supported in CuPy"
     )
+    @make_xp_test_case(ndimage.distance_transform_edt)
     def test_distance_transform_edt5(self, xp):
         # Ticket #954 regression test
         out = ndimage.distance_transform_edt(xp.asarray(False))
@@ -653,6 +668,7 @@ class TestNdimageMorphology:
     @xfail_xp_backends(
         np_only=True, reason='XXX: does not raise unless indices is a numpy array'
     )
+    @make_xp_test_case(ndimage.distance_transform_edt)
     def test_distance_transform_edt6(self, xp):
         # test input validation per discussion on PR #13302
         data = xp.asarray([[0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -673,34 +689,31 @@ class TestNdimageMorphology:
                 distances=distances_out
             )
 
-    @skip_xp_backends(np_only=True,
-                      reason="generate_binary_structure always generates numpy objects")
+    @make_xp_test_case(ndimage.generate_binary_structure)
     def test_generate_structure01(self, xp):
         struct = ndimage.generate_binary_structure(0, 1)
         assert struct == 1
 
-    @skip_xp_backends(np_only=True,
-                      reason="generate_binary_structure always generates numpy objects")
+    @make_xp_test_case(ndimage.generate_binary_structure)
     def test_generate_structure02(self, xp):
         struct = ndimage.generate_binary_structure(1, 1)
         assert_array_almost_equal(struct, [1, 1, 1])
 
-    @skip_xp_backends(np_only=True,
-                      reason="generate_binary_structure always generates numpy objects")
+    @make_xp_test_case(ndimage.generate_binary_structure)
     def test_generate_structure03(self, xp):
         struct = ndimage.generate_binary_structure(2, 1)
         assert_array_almost_equal(struct, [[0, 1, 0],
                                            [1, 1, 1],
                                            [0, 1, 0]])
 
-    @skip_xp_backends(np_only=True,
-                      reason="generate_binary_structure always generates numpy objects")
+    @make_xp_test_case(ndimage.generate_binary_structure)
     def test_generate_structure04(self, xp):
         struct = ndimage.generate_binary_structure(2, 2)
         assert_array_almost_equal(struct, [[1, 1, 1],
                                            [1, 1, 1],
                                            [1, 1, 1]])
 
+    @make_xp_test_case(ndimage.iterate_structure)
     def test_iterate_structure01(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -715,6 +728,7 @@ class TestNdimageMorphology:
         expected = xp.asarray(expected)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.iterate_structure)
     def test_iterate_structure02(self, xp):
         struct = [[0, 1],
                   [1, 1],
@@ -730,6 +744,7 @@ class TestNdimageMorphology:
 
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.iterate_structure)
     def test_iterate_structure03(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -746,6 +761,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out[0], expected)
         assert out[1] == [2, 2]
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion01(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -753,6 +769,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data)
         assert out == xp.asarray(1, dtype=out.dtype)
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion02(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -760,6 +777,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, border_value=1)
         assert out == xp.asarray(1, dtype=out.dtype)
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion03(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -767,6 +785,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data)
         assert_array_almost_equal(out, xp.asarray([0]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion04(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -774,6 +793,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, border_value=1)
         assert_array_almost_equal(out, xp.asarray([1]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion05(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -781,8 +801,10 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data)
         assert_array_almost_equal(out, xp.asarray([0, 1, 0]))
 
-    @pytest.mark.parametrize('dtype', types)
+
     @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/8912")
+    @make_xp_test_case(ndimage.binary_erosion)
+    @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion05_broadcasted(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones((1, ), dtype=dtype)
@@ -790,6 +812,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data)
         assert_array_almost_equal(out, xp.asarray([0, 1, 0]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion06(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -797,6 +820,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, border_value=1)
         assert_array_almost_equal(out, xp.asarray([1, 1, 1]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion07(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -804,6 +828,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data)
         assert_array_almost_equal(out, xp.asarray([0, 1, 1, 1, 0]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion08(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -811,6 +836,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, border_value=1)
         assert_array_almost_equal(out, xp.asarray([1, 1, 1, 1, 1]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion09(self, dtype, xp):
         data = np.ones([5], dtype=dtype)
@@ -819,6 +845,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data)
         assert_array_almost_equal(out, xp.asarray([0, 0, 0, 0, 0]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion10(self, dtype, xp):
         data = np.ones([5], dtype=dtype)
@@ -827,6 +854,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, border_value=1)
         assert_array_almost_equal(out, xp.asarray([1, 0, 0, 0, 1]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion11(self, dtype, xp):
         data = np.ones([5], dtype=dtype)
@@ -836,6 +864,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, struct, border_value=1)
         assert_array_almost_equal(out, xp.asarray([1, 0, 1, 0, 1]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion12(self, dtype, xp):
         data = np.ones([5], dtype=dtype)
@@ -845,6 +874,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, struct, border_value=1, origin=-1)
         assert_array_almost_equal(out, xp.asarray([0, 1, 0, 1, 1]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion13(self, dtype, xp):
         data = np.ones([5], dtype=dtype)
@@ -854,6 +884,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, struct, border_value=1, origin=1)
         assert_array_almost_equal(out, xp.asarray([1, 1, 0, 1, 0]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion14(self, dtype, xp):
         data = np.ones([5], dtype=dtype)
@@ -863,6 +894,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, struct, border_value=1)
         assert_array_almost_equal(out, xp.asarray([1, 1, 0, 0, 1]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion15(self, dtype, xp):
         data = np.ones([5], dtype=dtype)
@@ -872,6 +904,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, struct, border_value=1, origin=-1)
         assert_array_almost_equal(out, xp.asarray([1, 0, 0, 1, 1]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion16(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -879,6 +912,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, border_value=1)
         assert_array_almost_equal(out, xp.asarray([[1]]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion17(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -886,6 +920,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data)
         assert_array_almost_equal(out, xp.asarray([[0]]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion18(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -893,6 +928,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data)
         assert_array_almost_equal(out, xp.asarray([[0, 0, 0]]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion19(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -900,6 +936,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, border_value=1)
         assert_array_almost_equal(out, xp.asarray([[1, 1, 1]]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion20(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -909,6 +946,7 @@ class TestNdimageMorphology:
                                                    [0, 1, 0],
                                                    [0, 0, 0]]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion21(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -918,6 +956,7 @@ class TestNdimageMorphology:
                                                    [1, 1, 1],
                                                    [1, 1, 1]]))
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion22(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -941,6 +980,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, border_value=1)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion23(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -966,6 +1006,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, struct, border_value=1)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion24(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -991,6 +1032,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, struct, border_value=1)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion25(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -1018,6 +1060,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_erosion(data, struct, border_value=1)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_erosion)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_erosion26(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -1049,6 +1092,7 @@ class TestNdimageMorphology:
     @xfail_xp_backends(
         "cupy", reason="CuPy: NotImplementedError: only brute_force iteration"
     )
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion27(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1078,6 +1122,7 @@ class TestNdimageMorphology:
                       reason='inplace out= arguments are numpy-specific')
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion28(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1109,6 +1154,7 @@ class TestNdimageMorphology:
     @xfail_xp_backends(
         "cupy", reason="CuPy: NotImplementedError: only brute_force iteration"
     )
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion29(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1138,6 +1184,7 @@ class TestNdimageMorphology:
                       reason='inplace out= arguments are numpy-specific')
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion30(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1173,6 +1220,7 @@ class TestNdimageMorphology:
 
     @skip_xp_backends(np_only=True, exceptions=["cupy"],
                       reason='inplace out= arguments are numpy-specific')
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion31(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1203,6 +1251,7 @@ class TestNdimageMorphology:
 
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion32(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1230,6 +1279,7 @@ class TestNdimageMorphology:
 
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion33(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1263,6 +1313,7 @@ class TestNdimageMorphology:
                                      border_value=1, mask=mask, iterations=-1)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion34(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1296,8 +1347,9 @@ class TestNdimageMorphology:
                                      border_value=1, mask=mask)
         assert_array_almost_equal(out, expected)
 
-    @skip_xp_backends(np_only=True, exceptions=["cupy"], 
+    @skip_xp_backends(np_only=True, exceptions=["cupy"],
                       reason='inplace out= arguments are numpy-specific')
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion35(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1341,6 +1393,7 @@ class TestNdimageMorphology:
 
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion36(self, xp):
         struct = [[0, 1, 0],
                   [1, 0, 1],
@@ -1386,6 +1439,7 @@ class TestNdimageMorphology:
                       reason='inplace out= arguments are numpy-specific')
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion37(self, xp):
         a = np.asarray([[1, 0, 1],
                         [0, 1, 0],
@@ -1400,6 +1454,7 @@ class TestNdimageMorphology:
                                    border_value=True),
             b)
 
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion38(self, xp):
         data = np.asarray([[1, 0, 1],
                            [0, 1, 0],
@@ -1413,6 +1468,7 @@ class TestNdimageMorphology:
                       reason='inplace out= arguments are numpy-specific')
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion39(self, xp):
         iterations = np.int32(3)
         struct = [[0, 1, 0],
@@ -1446,6 +1502,7 @@ class TestNdimageMorphology:
                       reason='inplace out= arguments are numpy-specific')
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_erosion)
     def test_binary_erosion40(self, xp):
         iterations = np.int64(3)
         struct = [[0, 1, 0],
@@ -1476,6 +1533,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation01(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones([], dtype=dtype)
@@ -1483,6 +1541,7 @@ class TestNdimageMorphology:
         assert out == xp.asarray(1, dtype=out.dtype)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation02(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.zeros([], dtype=dtype)
@@ -1490,6 +1549,7 @@ class TestNdimageMorphology:
         assert out == xp.asarray(False)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation03(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones([1], dtype=dtype)
@@ -1497,6 +1557,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1], dtype=out.dtype))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation04(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.zeros([1], dtype=dtype)
@@ -1504,6 +1565,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([0]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation05(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones([3], dtype=dtype)
@@ -1511,6 +1573,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1, 1, 1]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation05_broadcasted(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones((1, ), dtype=dtype)
@@ -1519,6 +1582,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1, 1, 1]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation06(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.zeros([3], dtype=dtype)
@@ -1526,6 +1590,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([0, 0, 0]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation07(self, dtype, xp):
         data = np.zeros([3], dtype=dtype)
         data[1] = 1
@@ -1534,6 +1599,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1, 1, 1]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation08(self, dtype, xp):
         data = np.zeros([5], dtype=dtype)
         data[1] = 1
@@ -1543,6 +1609,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1, 1, 1, 1, 1]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation09(self, dtype, xp):
         data = np.zeros([5], dtype=dtype)
         data[1] = 1
@@ -1551,6 +1618,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1, 1, 1, 0, 0]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation10(self, dtype, xp):
         data = np.zeros([5], dtype=dtype)
         data[1] = 1
@@ -1559,6 +1627,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([0, 1, 1, 1, 0]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation11(self, dtype, xp):
         data = np.zeros([5], dtype=dtype)
         data[1] = 1
@@ -1567,6 +1636,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1, 1, 0, 0, 0]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation12(self, dtype, xp):
         data = np.zeros([5], dtype=dtype)
         data[1] = 1
@@ -1576,6 +1646,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1, 0, 1, 0, 0]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation13(self, dtype, xp):
         data = np.zeros([5], dtype=dtype)
         data[1] = 1
@@ -1585,6 +1656,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1, 0, 1, 0, 1]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation14(self, dtype, xp):
         data = np.zeros([5], dtype=dtype)
         data[1] = 1
@@ -1594,6 +1666,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([0, 1, 0, 1, 0]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation15(self, dtype, xp):
         data = np.zeros([5], dtype=dtype)
         data[1] = 1
@@ -1604,6 +1677,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([1, 1, 0, 1, 0]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation16(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones([1, 1], dtype=dtype)
@@ -1611,6 +1685,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([[1]]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation17(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.zeros([1, 1], dtype=dtype)
@@ -1618,6 +1693,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([[0]]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation18(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones([1, 3], dtype=dtype)
@@ -1625,6 +1701,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, xp.asarray([[1, 1, 1]]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation19(self, dtype, xp):
         dtype = getattr(xp, dtype)
         data = xp.ones([3, 3], dtype=dtype)
@@ -1634,6 +1711,7 @@ class TestNdimageMorphology:
                                                    [1, 1, 1]]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation20(self, dtype, xp):
         data = np.zeros([3, 3], dtype=dtype)
         data[1, 1] = 1
@@ -1644,6 +1722,7 @@ class TestNdimageMorphology:
                                                    [0, 1, 0]]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation21(self, dtype, xp):
         struct = ndimage.generate_binary_structure(2, 2)
         struct = xp.asarray(struct)
@@ -1656,6 +1735,7 @@ class TestNdimageMorphology:
                                                    [1, 1, 1]]))
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation22(self, dtype, xp):
         dtype = getattr(xp, dtype)
         expected = [[0, 1, 0, 0, 0, 0, 0, 0],
@@ -1679,6 +1759,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation23(self, dtype, xp):
         dtype = getattr(xp, dtype)
         expected = [[1, 1, 1, 1, 1, 1, 1, 1],
@@ -1702,6 +1783,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation24(self, dtype, xp):
         dtype = getattr(xp, dtype)
         expected = [[1, 1, 0, 0, 0, 0, 0, 0],
@@ -1725,6 +1807,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation25(self, dtype, xp):
         dtype = getattr(xp, dtype)
         expected = [[1, 1, 0, 0, 0, 0, 1, 1],
@@ -1748,6 +1831,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation26(self, dtype, xp):
         dtype = getattr(xp, dtype)
         struct = ndimage.generate_binary_structure(2, 2)
@@ -1773,6 +1857,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation27(self, dtype, xp):
         dtype = getattr(xp, dtype)
         struct = [[0, 1],
@@ -1799,6 +1884,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation28(self, dtype, xp):
         dtype = getattr(xp, dtype)
         expected = [[1, 1, 1, 1],
@@ -1815,6 +1901,7 @@ class TestNdimageMorphology:
 
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation29(self, xp):
         struct = [[0, 1],
                   [1, 1]]
@@ -1838,6 +1925,7 @@ class TestNdimageMorphology:
                       reason='output= arrays are numpy-specific')
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation30(self, xp):
         struct = [[0, 1],
                   [1, 1]]
@@ -1861,6 +1949,7 @@ class TestNdimageMorphology:
 
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation31(self, xp):
         struct = [[0, 1],
                   [1, 1]]
@@ -1884,6 +1973,7 @@ class TestNdimageMorphology:
                       reason='output= arrays are numpy-specific')
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation32(self, xp):
         struct = [[0, 1],
                   [1, 1]]
@@ -1907,6 +1997,7 @@ class TestNdimageMorphology:
 
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation33(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1948,6 +2039,7 @@ class TestNdimageMorphology:
                       reason='inplace output= arrays are numpy-specific')
     @xfail_xp_backends("cupy",
                        reason="NotImplementedError: only brute_force iteration")
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation34(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -1977,6 +2069,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation35(self, dtype, xp):
         dtype = getattr(xp, dtype)
         tmp = [[1, 1, 0, 0, 0, 0, 1, 1],
@@ -2025,6 +2118,7 @@ class TestNdimageMorphology:
                                       origin=(1, 1), border_value=1)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_dilation)
     def test_binary_dilation36(self, xp):
         # gh-21009
         data = np.zeros([], dtype=bool)
@@ -2032,6 +2126,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_dilation(data, iterations=-1)
         assert out == xp.asarray(False)
 
+    @make_xp_test_case(ndimage.binary_propagation)
     def test_binary_propagation01(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -2068,6 +2163,7 @@ class TestNdimageMorphology:
                                          mask=mask, border_value=0)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_propagation)
     def test_binary_propagation02(self, xp):
         struct = [[0, 1, 0],
                   [1, 1, 1],
@@ -2097,6 +2193,7 @@ class TestNdimageMorphology:
                                          mask=mask, border_value=1)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_propagation)
     def test_binary_propagation03(self, xp):
         # gh-21009
         data = xp.asarray(np.zeros([], dtype=bool))
@@ -2104,6 +2201,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_propagation(data)
         assert out == expected
 
+    @make_xp_test_case(ndimage.binary_opening)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_opening01(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -2127,6 +2225,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_opening(data)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_opening)
     @pytest.mark.parametrize('dtype', types)
     def test_binary_opening02(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -2153,6 +2252,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_closing)
     def test_binary_closing01(self, dtype, xp):
         dtype = getattr(xp, dtype)
         expected = [[0, 0, 0, 0, 0, 0, 0, 0],
@@ -2176,6 +2276,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
     @pytest.mark.parametrize('dtype', types)
+    @make_xp_test_case(ndimage.binary_closing)
     def test_binary_closing02(self, dtype, xp):
         dtype = getattr(xp, dtype)
         struct = ndimage.generate_binary_structure(2, 2)
@@ -2200,6 +2301,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_closing(data, struct)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_fill_holes)
     def test_binary_fill_holes01(self, xp):
         expected = np.asarray([[0, 0, 0, 0, 0, 0, 0, 0],
                                [0, 0, 1, 1, 1, 1, 0, 0],
@@ -2222,6 +2324,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_fill_holes(data)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_fill_holes)
     def test_binary_fill_holes02(self, xp):
         expected = np.asarray([[0, 0, 0, 0, 0, 0, 0, 0],
                                [0, 0, 0, 1, 1, 0, 0, 0],
@@ -2242,6 +2345,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_fill_holes(data)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_fill_holes)
     def test_binary_fill_holes03(self, xp):
         expected = np.asarray([[0, 0, 0, 0, 0, 0, 0, 0],
                                [0, 0, 1, 0, 0, 0, 0, 0],
@@ -2270,14 +2374,19 @@ class TestNdimageMorphology:
     @pytest.mark.parametrize('border_value',[0, 1])
     @pytest.mark.parametrize('origin', [(0, 0), (-1, 0)])
     @pytest.mark.parametrize('expand_axis', [0, 1, 2])
-    @pytest.mark.parametrize('func_name', ["binary_erosion",
-                                           "binary_dilation",
-                                           "binary_opening",
-                                           "binary_closing",
-                                           "binary_hit_or_miss",
-                                           "binary_propagation",
-                                           "binary_fill_holes"])
-    def test_binary_axes(self, xp, func_name, expand_axis, origin, border_value):
+    @pytest.mark.parametrize(
+        'func', [
+            make_xp_pytest_param(ndimage.binary_erosion),
+            make_xp_pytest_param(ndimage.binary_dilation),
+            make_xp_pytest_param(ndimage.binary_opening),
+            make_xp_pytest_param(ndimage.binary_closing),
+            make_xp_pytest_param(ndimage.binary_hit_or_miss),
+            make_xp_pytest_param(ndimage.binary_propagation),
+            make_xp_pytest_param(ndimage.binary_fill_holes),
+        ]
+    )
+    def test_binary_axes(self, xp, func, expand_axis, origin, border_value):
+        func_name = func.__name__
         struct = np.asarray([[0, 1, 0],
                              [1, 1, 1],
                              [0, 1, 0]], bool)
@@ -2301,7 +2410,7 @@ class TestNdimageMorphology:
             kwargs['border_value'] = border_value
         elif border_value != 0:
             pytest.skip('border_value !=0 unsupported by this function')
-        func = getattr(ndimage, func_name)
+
         expected = func(data, struct, **kwargs)
 
         # replicate data and expected result along a new axis
@@ -2320,6 +2429,7 @@ class TestNdimageMorphology:
             out = func(data, struct, axes=axes, **kwargs)
         xp_assert_close(out, expected)
 
+    @make_xp_test_case(ndimage.grey_erosion)
     def test_grey_erosion01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2334,6 +2444,7 @@ class TestNdimageMorphology:
     @skip_xp_backends("jax.numpy", reason="output=array requires buffer view")
     @skip_xp_backends("dask.array", reason="output=array requires buffer view")
     @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/8398")
+    @make_xp_test_case(ndimage.grey_erosion)
     def test_grey_erosion01_overlap(self, xp):
 
         array = xp.asarray([[3, 2, 5, 1, 4],
@@ -2347,6 +2458,7 @@ class TestNdimageMorphology:
                                               [5, 5, 3, 3, 1]])
         )
 
+    @make_xp_test_case(ndimage.grey_erosion)
     def test_grey_erosion02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2361,6 +2473,7 @@ class TestNdimageMorphology:
                                               [5, 5, 3, 3, 1]])
         )
 
+    @make_xp_test_case(ndimage.grey_erosion)
     def test_grey_erosion03(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2375,6 +2488,7 @@ class TestNdimageMorphology:
                                               [4, 4, 2, 2, 0]])
         )
 
+    @make_xp_test_case(ndimage.grey_dilation)
     def test_grey_dilation01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2387,6 +2501,7 @@ class TestNdimageMorphology:
                                               [8, 8, 8, 7, 7]]),
         )
 
+    @make_xp_test_case(ndimage.grey_dilation)
     def test_grey_dilation02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2401,6 +2516,7 @@ class TestNdimageMorphology:
                                               [8, 8, 8, 7, 7]]),
         )
 
+    @make_xp_test_case(ndimage.grey_dilation)
     def test_grey_dilation03(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2415,6 +2531,7 @@ class TestNdimageMorphology:
                                               [9, 9, 9, 8, 8]]),
         )
 
+    @make_xp_test_case(ndimage.grey_opening)
     def test_grey_opening01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2425,6 +2542,7 @@ class TestNdimageMorphology:
         output = ndimage.grey_opening(array, footprint=footprint)
         assert_array_almost_equal(output, expected)
 
+    @make_xp_test_case(ndimage.grey_opening)
     def test_grey_opening02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2439,6 +2557,7 @@ class TestNdimageMorphology:
                                       structure=structure)
         assert_array_almost_equal(output, expected)
 
+    @make_xp_test_case(ndimage.grey_closing)
     def test_grey_closing01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2449,6 +2568,7 @@ class TestNdimageMorphology:
         output = ndimage.grey_closing(array, footprint=footprint)
         assert_array_almost_equal(output, expected)
 
+    @make_xp_test_case(ndimage.grey_closing)
     def test_grey_closing02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2464,6 +2584,8 @@ class TestNdimageMorphology:
         assert_array_almost_equal(output, expected)
 
     @skip_xp_backends(np_only=True, reason='output= arrays are numpy-specific')
+    @make_xp_test_case(ndimage.grey_dilation, ndimage.grey_erosion,
+                       ndimage.morphological_gradient)
     def test_morphological_gradient01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2480,6 +2602,8 @@ class TestNdimageMorphology:
                                        structure=structure, output=output)
         assert_array_almost_equal(output, expected)
 
+    @make_xp_test_case(ndimage.grey_dilation, ndimage.grey_erosion,
+                       ndimage.morphological_gradient)
     def test_morphological_gradient02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2496,6 +2620,8 @@ class TestNdimageMorphology:
         assert_array_almost_equal(output, expected)
 
     @skip_xp_backends(np_only=True, reason='output= arrays are numpy-specific')
+    @make_xp_test_case(ndimage.grey_dilation, ndimage.grey_erosion,
+                       ndimage.morphological_laplace)
     def test_morphological_laplace01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2512,6 +2638,8 @@ class TestNdimageMorphology:
                                       structure=structure, output=output)
         assert_array_almost_equal(output, expected)
 
+    @make_xp_test_case(ndimage.grey_dilation, ndimage.grey_erosion,
+                       ndimage.morphological_laplace)
     def test_morphological_laplace02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2529,6 +2657,7 @@ class TestNdimageMorphology:
 
     @skip_xp_backends("jax.numpy", reason="output=array requires buffer view")
     @skip_xp_backends("dask.array", reason="output=array requires buffer view")
+    @make_xp_test_case(ndimage.grey_opening, ndimage.white_tophat)
     def test_white_tophat01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2543,6 +2672,7 @@ class TestNdimageMorphology:
                              structure=structure, output=output)
         assert_array_almost_equal(output, expected)
 
+    @make_xp_test_case(ndimage.grey_opening, ndimage.white_tophat)
     def test_white_tophat02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2557,6 +2687,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(output, expected)
 
     @xfail_xp_backends('cupy', reason="cupy#8399")
+    @make_xp_test_case(ndimage.white_tophat)
     def test_white_tophat03(self, xp):
 
         array = np.asarray([[1, 0, 0, 0, 0, 0, 0],
@@ -2583,6 +2714,7 @@ class TestNdimageMorphology:
 
     @skip_xp_backends("jax.numpy", reason="output=array requires buffer view")
     @skip_xp_backends("dask.array", reason="output=array requires buffer view")
+    @make_xp_test_case(ndimage.white_tophat)
     def test_white_tophat04(self, xp):
         array = np.eye(5, dtype=bool)
         structure = np.ones((3, 3), dtype=bool)
@@ -2596,6 +2728,7 @@ class TestNdimageMorphology:
 
     @skip_xp_backends("jax.numpy", reason="output=array requires buffer view")
     @skip_xp_backends("dask.array", reason="output=array requires buffer view")
+    @make_xp_test_case(ndimage.grey_closing, ndimage.black_tophat)
     def test_black_tophat01(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2610,6 +2743,7 @@ class TestNdimageMorphology:
                              structure=structure, output=output)
         assert_array_almost_equal(output, expected)
 
+    @make_xp_test_case(ndimage.grey_closing, ndimage.black_tophat)
     def test_black_tophat02(self, xp):
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2624,6 +2758,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(output, expected)
 
     @xfail_xp_backends('cupy', reason="cupy/cupy#8399")
+    @make_xp_test_case(ndimage.black_tophat)
     def test_black_tophat03(self, xp):
 
         array = np.asarray([[1, 0, 0, 0, 0, 0, 0],
@@ -2650,6 +2785,7 @@ class TestNdimageMorphology:
 
     @skip_xp_backends("jax.numpy", reason="output=array requires buffer view")
     @skip_xp_backends("dask.array", reason="output=array requires buffer view")
+    @make_xp_test_case(ndimage.black_tophat)
     def test_black_tophat04(self, xp):
         array = xp.asarray(np.eye(5, dtype=bool))
         structure = xp.asarray(np.ones((3, 3), dtype=bool))
@@ -2669,17 +2805,22 @@ class TestNdimageMorphology:
                                       'mirror', 'wrap'])
     @pytest.mark.parametrize('footprint_mode', ['size', 'footprint',
                                                 'structure'])
-    @pytest.mark.parametrize('func_name', ["grey_erosion",
-                                           "grey_dilation",
-                                           "grey_opening",
-                                           "grey_closing",
-                                           "morphological_laplace",
-                                           "morphological_gradient",
-                                           "white_tophat",
-                                           "black_tophat"])
-    def test_grey_axes(self, xp, func_name, expand_axis, origin, footprint_mode,
+    @pytest.mark.parametrize(
+        'func',
+        [
+            make_xp_pytest_param(ndimage.grey_erosion),
+            make_xp_pytest_param(ndimage.grey_dilation),
+            make_xp_pytest_param(ndimage.grey_opening),
+            make_xp_pytest_param(ndimage.grey_closing),
+            make_xp_pytest_param(ndimage.morphological_laplace),
+            make_xp_pytest_param(ndimage.morphological_gradient),
+            make_xp_pytest_param(ndimage.white_tophat),
+            make_xp_pytest_param(ndimage.black_tophat),
+        ]
+    )
+    def test_grey_axes(self, xp, func, expand_axis, origin, footprint_mode,
                        mode):
-
+        func_name = func.__name__
         data = xp.asarray([[0, 0, 0, 1, 0, 0, 0],
                            [0, 0, 0, 4, 0, 0, 0],
                            [0, 0, 2, 1, 0, 2, 0],
@@ -2694,7 +2835,7 @@ class TestNdimageMorphology:
             kwargs['footprint'] = xp.asarray([[1, 0, 1], [1, 1, 0]])
         if footprint_mode == 'structure':
             kwargs['structure'] = xp.ones_like(kwargs['footprint'])
-        func = getattr(ndimage, func_name)
+
         expected = func(data, **kwargs)
 
         # replicate data and expected result along a new axis
@@ -2716,6 +2857,7 @@ class TestNdimageMorphology:
 
     @skip_xp_backends(np_only=True, exceptions=["cupy"],
                       reason="inplace output= is numpy-specific")
+    @make_xp_test_case(ndimage.binary_hit_or_miss)
     @pytest.mark.parametrize('dtype', types)
     def test_hit_or_miss01(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -2744,6 +2886,7 @@ class TestNdimageMorphology:
         ndimage.binary_hit_or_miss(data, struct, output=out)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_hit_or_miss)
     @pytest.mark.parametrize('dtype', types)
     def test_hit_or_miss02(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -2763,6 +2906,7 @@ class TestNdimageMorphology:
         out = ndimage.binary_hit_or_miss(data, struct)
         assert_array_almost_equal(out, expected)
 
+    @make_xp_test_case(ndimage.binary_hit_or_miss)
     @pytest.mark.parametrize('dtype', types)
     def test_hit_or_miss03(self, dtype, xp):
         dtype = getattr(xp, dtype)
@@ -2795,6 +2939,7 @@ class TestNdimageMorphology:
         assert_array_almost_equal(out, expected)
 
 
+@make_xp_test_case(ndimage.binary_dilation, ndimage.grey_dilation)
 class TestDilateFix:
 
     # pytest's setup_method seems to clash with the autouse `xp` fixture
@@ -2815,6 +2960,7 @@ class TestDilateFix:
         else:
             self.dilated3x3 = xp.astype(dilated3x3, xp.uint8)
 
+
     def test_dilation_square_structure(self, xp):
         self._setup(xp)
         result = ndimage.grey_dilation(self.array, structure=self.sq3x3)
@@ -2827,6 +2973,7 @@ class TestDilateFix:
         assert_array_almost_equal(result, self.dilated3x3)
 
 
+@make_xp_test_case(ndimage.binary_opening, ndimage.binary_closing)
 class TestBinaryOpeningClosing:
 
     def _setup(self, xp):
@@ -2853,6 +3000,7 @@ class TestBinaryOpeningClosing:
         xp_assert_equal(closed_new, self.closed_old)
 
 
+@make_xp_test_case(ndimage.binary_erosion)
 def test_binary_erosion_noninteger_iterations(xp):
     # regression test for gh-9905, gh-9909: ValueError for
     # non integer iterations
@@ -2861,6 +3009,7 @@ def test_binary_erosion_noninteger_iterations(xp):
     assert_raises(TypeError, ndimage.binary_erosion, data, iterations=1.5)
 
 
+@make_xp_test_case(ndimage.binary_dilation)
 def test_binary_dilation_noninteger_iterations(xp):
     # regression test for gh-9905, gh-9909: ValueError for
     # non integer iterations
@@ -2869,6 +3018,7 @@ def test_binary_dilation_noninteger_iterations(xp):
     assert_raises(TypeError, ndimage.binary_dilation, data, iterations=1.5)
 
 
+@make_xp_test_case(ndimage.binary_opening)
 def test_binary_opening_noninteger_iterations(xp):
     # regression test for gh-9905, gh-9909: ValueError for
     # non integer iterations
@@ -2877,6 +3027,7 @@ def test_binary_opening_noninteger_iterations(xp):
     assert_raises(TypeError, ndimage.binary_opening, data, iterations=1.5)
 
 
+@make_xp_test_case(ndimage.binary_closing)
 def test_binary_closing_noninteger_iterations(xp):
     # regression test for gh-9905, gh-9909: ValueError for
     # non integer iterations
@@ -2888,6 +3039,7 @@ def test_binary_closing_noninteger_iterations(xp):
 @xfail_xp_backends(
     "cupy", reason="CuPy: NotImplementedError: only brute_force iteration"
 )
+@make_xp_test_case(ndimage.binary_erosion)
 def test_binary_closing_noninteger_brute_force_passes_when_true(xp):
     # regression test for gh-9905, gh-9909: ValueError for non integer iterations
     data = xp.ones([1])
@@ -2903,29 +3055,34 @@ def test_binary_closing_noninteger_brute_force_passes_when_true(xp):
                   reason="inplace output= is numpy-specific")
 @xfail_xp_backends("cupy", reason="NotImplementedError: only brute_force iteration")
 @pytest.mark.parametrize(
-    'function',
-    ['binary_erosion', 'binary_dilation', 'binary_opening', 'binary_closing'],
+    'func',
+    [
+        make_xp_pytest_param(ndimage.binary_erosion),
+        make_xp_pytest_param(ndimage.binary_dilation),
+        make_xp_pytest_param(ndimage.binary_opening),
+        make_xp_pytest_param(ndimage.binary_closing),
+    ],
 )
 @pytest.mark.parametrize('iterations', [1, 5])
 @pytest.mark.parametrize('brute_force', [False, True])
-def test_binary_input_as_output(function, iterations, brute_force, xp):
+def test_binary_input_as_output(func, iterations, brute_force, xp):
     rstate = np.random.RandomState(123)
     data = rstate.randint(low=0, high=2, size=100).astype(bool)
     data = xp.asarray(data)
-    ndi_func = getattr(ndimage, function)
 
     # input data is not modified
     data_orig = data.copy()
-    expected = ndi_func(data, brute_force=brute_force, iterations=iterations)
+    expected = func(data, brute_force=brute_force, iterations=iterations)
     xp_assert_equal(data, data_orig)
 
     # data should now contain the expected result
-    ndi_func(data, brute_force=brute_force, iterations=iterations, output=data)
+    func(data, brute_force=brute_force, iterations=iterations, output=data)
     xp_assert_equal(data, expected)
 
 
 @skip_xp_backends(np_only=True, exceptions=["cupy"],
                   reason="inplace output= is numpy-specific")
+@make_xp_test_case(ndimage.binary_hit_or_miss)
 def test_binary_hit_or_miss_input_as_output(xp):
     rstate = np.random.RandomState(123)
     data = rstate.randint(low=0, high=2, size=100).astype(bool)
@@ -2941,8 +3098,7 @@ def test_binary_hit_or_miss_input_as_output(xp):
     xp_assert_equal(data, expected)
 
 
-@xfail_xp_backends("cupy",
-                   reason="CuPy does not have distance_transform_cdt")
+@make_xp_test_case(ndimage.distance_transform_cdt)
 def test_distance_transform_cdt_invalid_metric(xp):
     msg = 'invalid metric provided'
     with pytest.raises(ValueError, match=msg):

--- a/scipy/ndimage/tests/test_splines.py
+++ b/scipy/ndimage/tests/test_splines.py
@@ -2,12 +2,9 @@
 import pytest
 
 import numpy as np
-from scipy._lib._array_api import assert_almost_equal
+from scipy._lib._array_api import assert_almost_equal, make_xp_test_case
 
 from scipy import ndimage
-
-skip_xp_backends = pytest.mark.skip_xp_backends
-pytestmark = [skip_xp_backends(cpu_only=True, exceptions=['cupy', 'jax.numpy'])]
 
 
 def get_spline_knot_values(order):
@@ -56,6 +53,7 @@ def make_spline_knot_matrix(xp, n, order, mode='mirror'):
     return xp.asarray(matrix / knot_values_sum)
 
 
+@make_xp_test_case(ndimage.spline_filter1d)
 @pytest.mark.parametrize('order', [0, 1, 2, 3, 4, 5])
 @pytest.mark.parametrize('mode', ['mirror', 'grid-wrap', 'reflect'])
 def test_spline_filter_vs_matrix_solution(order, mode, xp):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Following up on #23410 and #23381, this adds the `xp_capabilities` decorator to all public functions in `scipy.ndimage`. `ndimage` uses a `support_alternative_backends` dispatching infrastructure similar to what `special` does, so the decorators are added in `scipy/ndimage/_support_alternative_backends.py` after creating dispatching wrappers.

#### Additional information
<!--Any additional information you think is important.-->
