### PR TITLE
DOC: Add complexity remark to scipy.stats.kendalltau

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5552,6 +5552,9 @@ def kendalltau(x, y, *, nan_policy='propagate',
     tau-a is not implemented separately because both tau-b and tau-c reduce
     to tau-a in the absence of ties.
 
+    Although a naive implementation has O(n^2) complexity, this implementation
+    uses a Fenwick tree to do the computation in O(n log(n)) complexity.
+
     Parameters
     ----------
     x, y : array_like


### PR DESCRIPTION
[docs only]

#### Reference issue

Follow-up of #23408 

#### What does this implement/fix?

Naive computation of kendalltau has O(n^2) complexity, it is important to note that this implementation is way faster with O(n log(n)) complexity, to avoid misunderstandings.

#### Additional information

None.