### PR TITLE
MAINT: break import dependencies between special-linalg and linalg-sparse

### DIFF
--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -44,6 +44,7 @@ def cwt_matrix(n_rows, n_columns, rng=None):
     .. math:: \|SA\| = (1 \pm \epsilon)\|A\|
     Where the error epsilon is related to the size of S.
     """
+    # lazy import to prevent to prevent sparse dependency for whole module (gh-23420)
     from scipy.sparse import csc_matrix
     rng = check_random_state(rng)
     rows = rng_integers(rng, 0, n_rows, n_columns)
@@ -174,6 +175,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, rng=None):
     166.58473879945151
 
     """
+    # lazy import to prevent to prevent sparse dependency for whole module (gh-23420)
     from scipy.sparse import issparse
     if issparse(input_matrix) and input_matrix.ndim > 2:
         message = "Batch support for sparse arrays is not available."

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from scipy._lib._util import (check_random_state, rng_integers,
                               _transition_to_rng, _apply_over_batch)
-from scipy.sparse import csc_matrix, issparse
 
 __all__ = ['clarkson_woodruff_transform']
 
@@ -45,6 +44,7 @@ def cwt_matrix(n_rows, n_columns, rng=None):
     .. math:: \|SA\| = (1 \pm \epsilon)\|A\|
     Where the error epsilon is related to the size of S.
     """
+    from scipy.sparse import csc_matrix
     rng = check_random_state(rng)
     rows = rng_integers(rng, 0, n_rows, n_columns)
     cols = np.arange(n_columns+1)
@@ -174,6 +174,7 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, rng=None):
     166.58473879945151
 
     """
+    from scipy.sparse import issparse
     if issparse(input_matrix) and input_matrix.ndim > 2:
         message = "Batch support for sparse arrays is not available."
         raise NotImplementedError(message)

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -171,6 +171,7 @@ def _gen_roots_and_weights(n, mu0, an_func, bn_func, f, df, symmetrize, mu):
     mu ( = h_0 )        is the integral of the weight over the orthogonal
                         interval
     """
+    # lazy import to prevent to prevent linalg dependency for whole module (gh-23420)
     from scipy import linalg
     k = np.arange(n, dtype='d')
     c = np.zeros((2, n))

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -78,7 +78,6 @@ References
 import numpy as np
 from numpy import (exp, inf, pi, sqrt, floor, sin, cos, around,
                    hstack, arccos, arange)
-from scipy import linalg
 from scipy.special import airy
 
 # Local imports.
@@ -172,6 +171,7 @@ def _gen_roots_and_weights(n, mu0, an_func, bn_func, f, df, symmetrize, mu):
     mu ( = h_0 )        is the integral of the weight over the orthogonal
                         interval
     """
+    from scipy import linalg
     k = np.arange(n, dtype='d')
     c = np.zeros((2, n))
     c[0,1:] = bn_func(k[1:])


### PR DESCRIPTION
closes #22412

Removes some of the spaghetti by making the imports lazy