### PR TITLE
DX: don't lint cython build output

### DIFF
--- a/scipy/linalg/_decomp_lu_cython.pyi
+++ b/scipy/linalg/_decomp_lu_cython.pyi
@@ -5,4 +5,5 @@ from typing import TypeVar
 # this mimicks the `ctypedef fused lapack_t`
 _LapackT = TypeVar("_LapackT", np.float32, np.float64, np.complex64, np.complex128)
 
-def lu_dispatcher(a: NDArray[_LapackT], u: NDArray[_LapackT], piv: NDArray[np.integer], permute_l: bool) -> None: ...
+def lu_dispatcher(a: NDArray[_LapackT], u: NDArray[_LapackT], piv: NDArray[np.integer],
+                  permute_l: bool) -> None: ...

--- a/scipy/spatial/_qhull.pyi
+++ b/scipy/spatial/_qhull.pyi
@@ -5,11 +5,11 @@ Static type checking stub file for scipy/spatial/qhull.pyx
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
-from typing_extensions import final
+from typing import final
 
 class QhullError(RuntimeError):
     ...
-    
+
 @final
 class _Qhull:
     # Read-only cython attribute that behaves, more or less, like a property

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -105,9 +105,9 @@ def run_cython_lint(files):
 
 
 def run_cython_lint_all():
-    pyx_files = glob.glob("**/*.pyx", recursive=True)
-    pxd_files = glob.glob("**/*.pxd", recursive=True)
-    pxi_files = glob.glob("**/*.pxi", recursive=True)
+    pyx_files = glob.glob("scipy/**/*.pyx", recursive=True)
+    pxd_files = glob.glob("scipy/**/*.pxd", recursive=True)
+    pxi_files = glob.glob("scipy/**/*.pxi", recursive=True)
     files = pyx_files + pxd_files + pxi_files
 
     res = subprocess.run(
@@ -168,7 +168,7 @@ def main():
         if rc == 0 and rc_cy != 0:
             rc = rc_cy
         sys.exit(rc)
-    
+
     if not ((args.files is None) ^ (args.branch is None)):
         print('Specify either `--diff-against` or `--files`. Aborting.')
         sys.exit(1)


### PR DESCRIPTION
closes #22053

Configures linter to not check build output. Also fixes up some random complaints.