### PR TITLE
DOC: special: add example to ellipeinc and correct docstring of ellipj

### DIFF
--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -978,7 +978,7 @@ const char *ellipeinc_doc = R"(
     --------
     The elliptic integral of the second kind can be used to find the circumference of an
     ellipse with semi-major axis ``a`` and semi-minor axis ``b``.
-    ```
+
     >>> import numpy as np
     >>> from scipy.special import ellipeinc
     >>> a, b = 3.5, 2.1

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -990,9 +990,9 @@ const char *ellipeinc_doc = R"(
 const char *ellipj_doc = R"(
     ellipj(u, m, out=None)
 
-    Jacobian elliptic functions
+    Jacobi elliptic functions
 
-    Calculates the Jacobian elliptic functions of parameter `m` between
+    Calculates the Jacobi elliptic functions of parameter `m` between
     0 and 1, and real argument `u`.
 
     Parameters

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -983,8 +983,8 @@ const char *ellipeinc_doc = R"(
     >>> from scipy.special import ellipeinc
     >>> a, b = 3.5, 2.1
     >>> e = np.sqrt(1.0 - b**2/a**2)  # eccentricity
-    >>> ellipeinc(np.pi/2, e**2)
-    np.float64(1.2763499431699064)
+    >>> 4*a*ellipeinc(np.pi/2, e**2)
+    np.float64(17.86889920437869)
     )";
 
 const char *ellipj_doc = R"(

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -973,6 +973,18 @@ const char *ellipeinc_doc = R"(
     .. [3] NIST Digital Library of Mathematical
            Functions. http://dlmf.nist.gov/, Release 1.0.28 of
            2020-09-15. See Sec. 19.25(i) https://dlmf.nist.gov/19.25#i
+
+    Examples
+    --------
+    The elliptic integral of the second kind can be used to find the circumference of an
+    ellipse with semi-major axis ``a`` and semi-minor axis ``b``.
+    ```
+    >>> import numpy as np
+    >>> from scipy.special import ellipeinc
+    >>> a, b = 3.5, 2.1
+    >>> e = np.sqrt(1.0 - b**2/a**2)  # eccentricity
+    >>> ellipeinc(np.pi/2, e**2)
+    np.float64(1.2763499431699064)
     )";
 
 const char *ellipj_doc = R"(


### PR DESCRIPTION
towards #7168

The first commit adds an example to `ellipeinc`

The second corrects the description of `ellipj` from "Jacobian elliptic functions" to  "Jacobi elliptic functions" which I believe is correct, see https://www.mathworks.com/help/matlab/ref/ellipj.html for example
