### PR TITLE
ENH: spatial: optimize performance of Rotation

### DIFF
--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -2183,8 +2183,8 @@ class Rotation:
 
         self._quat = self._backend.setitem(self._quat, value.as_quat(), indexer)
 
-    @classmethod
-    def identity(cls, num: int | None = None) -> Rotation:
+    @staticmethod
+    def identity(num: int | None = None) -> Rotation:
         """Get identity rotation(s).
 
         Composition with the identity rotation has no effect.
@@ -2200,7 +2200,8 @@ class Rotation:
         identity : Rotation object
             The identity rotation.
         """
-        return cls(cython_backend.identity(num), normalize=True)
+        quat = cython_backend.identity(num)
+        return Rotation._from_raw_quat(quat, xp=array_namespace(quat))
 
     @classmethod
     @_transition_to_rng("random_state", position_num=2)

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -2143,6 +2143,10 @@ class Rotation:
         if is_array and indexer.dtype == self._xp.bool:
             return Rotation(self._quat[indexer], normalize=False)
         if is_array and self._xp.isdtype(indexer.dtype, "integral"):
+            # xp.take is implementation-defined for zero-dim arrays, hence we raise
+            # pre-emptively to have consistent behavior across frameworks.
+            if self._quat.shape[0] == 0:
+                raise IndexError("cannot do a non-empty take from an empty axes.")
             return Rotation(self._xp.take(self._quat, indexer, axis=0), normalize=False)
         return Rotation(self._quat[indexer, ...], normalize=False)
 
@@ -2579,7 +2583,7 @@ class Rotation:
         rot._quat = quat
         rot._xp = xp
         if backend is None:
-            backend = backend_registry[xp]
+            backend = backend_registry.get(xp, xp_backend)
         rot._backend = backend
         return rot
 

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -19,16 +19,9 @@ from scipy._lib._array_api import (
 )
 from scipy._lib.array_api_compat import device as xp_device
 import scipy._lib.array_api_extra as xpx
-from scipy._lib._util import _transition_to_rng
+from scipy._lib._util import _transition_to_rng, broadcastable
 
 backend_registry = {array_namespace(np.empty(0)): cython_backend}
-
-
-def broadcastable(shape_a: tuple[int, ...], shape_b: tuple[int, ...]) -> bool:
-    """Check if two shapes are broadcastable."""
-    return all(
-        (m == n) or (m == 1) or (n == 1) for m, n in zip(shape_a[::-1], shape_b[::-1])
-    )
 
 
 class Rotation:
@@ -320,6 +313,7 @@ class Rotation:
         scalar_first: bool = False,
     ):
         xp = array_namespace(quat)
+        self._xp = xp
         quat = self._to_array(quat, xp)
         # Legacy behavior for cython backend: Differentiate between single quat and
         # batched quats. We only use this for the cython backend. The Array API backend
@@ -542,9 +536,10 @@ class Rotation:
 
         .. versionadded:: 1.4.0
         """
-        backend = backend_registry.get(array_namespace(matrix), xp_backend)
+        xp = array_namespace(matrix)
+        backend = backend_registry.get(xp, xp_backend)
         quat = backend.from_matrix(matrix)
-        return Rotation(quat, normalize=False, copy=False)
+        return Rotation._from_raw_quat(quat, xp=xp, backend=backend)
 
     @staticmethod
     @xp_capabilities(
@@ -614,9 +609,10 @@ class Rotation:
         (1, 3)
 
         """
-        backend = backend_registry.get(array_namespace(rotvec), xp_backend)
+        xp = array_namespace(rotvec)
+        backend = backend_registry.get(xp, xp_backend)
         quat = backend.from_rotvec(rotvec, degrees=degrees)
-        return Rotation(quat, normalize=False, copy=False)
+        return Rotation._from_raw_quat(quat, xp=xp, backend=backend)
 
     @staticmethod
     @xp_capabilities(
@@ -715,9 +711,10 @@ class Rotation:
         (2, 4)
 
         """
-        backend = backend_registry.get(array_namespace(angles), xp_backend)
+        xp = array_namespace(angles)
+        backend = backend_registry.get(xp, xp_backend)
         quat = backend.from_euler(seq, angles, degrees=degrees)
-        return Rotation(quat, normalize=False, copy=False)
+        return Rotation._from_raw_quat(quat, xp=xp, backend=backend)
 
     @staticmethod
     @xp_capabilities(
@@ -842,9 +839,10 @@ class Rotation:
         >>> r.as_quat()
         [ 0.701057,  0.430459, -0.092296,  0.560986]
         """  # noqa: E501
-        backend = backend_registry.get(array_namespace(axes), xp_backend)
+        xp = array_namespace(axes)
+        backend = backend_registry.get(xp, xp_backend)
         quat = backend.from_davenport(axes, order, angles, degrees)
-        return Rotation(quat, normalize=False, copy=False)
+        return Rotation._from_raw_quat(quat, xp=xp, backend=backend)
 
     @staticmethod
     @xp_capabilities(
@@ -914,9 +912,10 @@ class Rotation:
         (1, 3)
 
         """
-        backend = backend_registry.get(array_namespace(mrp), xp_backend)
+        xp = array_namespace(mrp)
+        backend = backend_registry.get(xp, xp_backend)
         quat = backend.from_mrp(mrp)
-        return Rotation(quat, normalize=False, copy=False)
+        return Rotation._from_raw_quat(quat, xp=xp, backend=backend)
 
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]
@@ -1352,8 +1351,9 @@ class Rotation:
         >>> r.as_davenport([ez, ex, ey], 'extrinsic', degrees=True).shape
         (2, 3)
         """
-        xp = array_namespace(self._quat)
-        axes = xp.asarray(axes, dtype=self._quat.dtype, device=xp_device(self._quat))
+        axes = self._xp.asarray(
+            axes, dtype=self._quat.dtype, device=xp_device(self._quat)
+        )
         davenport = self._backend.as_davenport(self._quat, axes, order, degrees)
         if self._single:
             return davenport[0, ...]
@@ -1486,7 +1486,7 @@ class Rotation:
         quats = xp.concat(
             [xpx.atleast_nd(x.as_quat(), ndim=2, xp=xp) for x in rotations]
         )
-        return Rotation(quats, normalize=False)
+        return Rotation._from_raw_quat(quats, xp=xp)
 
     @xp_capabilities(
         skip_backends=[
@@ -1612,8 +1612,7 @@ class Rotation:
                [ 1.09533535, -0.8365163 ,  0.3169873 ]])
 
         """
-        xp = array_namespace(self._quat)
-        vectors = xp.asarray(
+        vectors = self._xp.asarray(
             vectors, device=xp_device(self._quat), dtype=self._quat.dtype
         )
         single_vector = vectors.ndim == 1
@@ -1623,8 +1622,8 @@ class Rotation:
             raise ValueError(
                 f"Expected input of shape (3,) or (P, 3), got {vectors.shape}."
             )
-        if is_numpy(xp):
-            vectors = xpx.atleast_nd(vectors, ndim=2, xp=xp)
+        if is_numpy(self._xp):
+            vectors = xpx.atleast_nd(vectors, ndim=2, xp=self._xp)
         result = self._backend.apply(self._quat, vectors, inverse=inverse)
         if self._single and single_vector:
             return result[0, ...]
@@ -1791,7 +1790,7 @@ class Rotation:
         quat = self._backend.pow(self._quat, n)
         if self._single:
             quat = quat[0]
-        return Rotation(quat, normalize=False, copy=False)
+        return Rotation._from_raw_quat(quat, xp=self._xp, backend=self._backend)
 
     @xp_capabilities(
         skip_backends=[("dask.array", "cannot handle zero-length rotations")]
@@ -1831,7 +1830,7 @@ class Rotation:
         q_inv = self._backend.inv(self._quat)
         if self._single:
             q_inv = q_inv[0, ...]
-        return Rotation(q_inv, normalize=False, copy=False)
+        return Rotation._from_raw_quat(q_inv, xp=self._xp, backend=self._backend)
 
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]
@@ -1971,7 +1970,7 @@ class Rotation:
         array([0.24945696, 0.25054542, 0.24945696])
         """
         mean = self._backend.mean(self._quat, weights=weights)
-        return Rotation(mean, normalize=False)
+        return Rotation._from_raw_quat(mean, xp=self._xp, backend=self._backend)
 
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]
@@ -2019,7 +2018,7 @@ class Rotation:
         )
         if self._single:
             reduced = reduced[0, ...]
-        rot = Rotation(reduced, normalize=False, copy=False)
+        rot = Rotation._from_raw_quat(reduced, xp=self._xp, backend=self._backend)
         if return_indices:
             left_idx = left_idx if left is not None else None
             right_idx = right_idx if right is not None else None
@@ -2138,20 +2137,13 @@ class Rotation:
             raise TypeError("Single rotation is not subscriptable.")
         is_array = isinstance(indexer, type(self._quat))
         # Masking is only specified in the Array API when the array is the sole index
-        # TODO: Getting xp on every call may be expensive. Check if we can make access
-        # to xp more efficient. Should we store a self._xp attribute?
         # TODO: This special case handling is mainly a result of Array API limitations.
         # Ideally we would get rid of them altogether and converge to [indexer, ...]
         # indexing.
-        xp = array_namespace(self._quat)
-        if is_array and indexer.dtype == xp.bool:
+        if is_array and indexer.dtype == self._xp.bool:
             return Rotation(self._quat[indexer], normalize=False)
-        if is_array and (indexer.dtype == xp.int64 or indexer.dtype == xp.int32):
-            # Array API limitation: Integer index arrays are only allowed with integer
-            # indices
-            all_ind = xp.arange(4)
-            indexer = xp.reshape(indexer, (indexer.shape[0], 1))
-            return Rotation(self._quat[indexer, all_ind], normalize=False)
+        if is_array and self._xp.isdtype(indexer.dtype, "integral"):
+            return Rotation(self._xp.take(self._quat, indexer, axis=0), normalize=False)
         return Rotation(self._quat[indexer, ...], normalize=False)
 
     @xp_capabilities(
@@ -2204,7 +2196,7 @@ class Rotation:
         identity : Rotation object
             The identity rotation.
         """
-        return cls(cython_backend.identity(num), normalize=False, copy=False)
+        return cls(cython_backend.identity(num), normalize=True)
 
     @classmethod
     @_transition_to_rng("random_state", position_num=2)
@@ -2259,7 +2251,6 @@ class Rotation:
         scipy.stats.special_ortho_group
 
         """
-        # DECISION: How do we handle random numbers in other frameworks?
         # TODO: The array API does not have a unified random interface. This method only
         # creates numpy arrays. If we do want to support other frameworks, we need a way
         # to handle other rng implementations.
@@ -2476,11 +2467,12 @@ class Rotation:
         array([[0., 1., 0.],
                [0., 1., 2.]])
         """
-        backend = backend_registry.get(array_namespace(a), xp_backend)
+        xp = array_namespace(a)
+        backend = backend_registry.get(xp, xp_backend)
         q, rssd, sensitivity = backend.align_vectors(a, b, weights, return_sensitivity)
         if return_sensitivity:
-            return Rotation(q, normalize=False, copy=False), rssd, sensitivity
-        return Rotation(q, normalize=False, copy=False), rssd
+            return Rotation._from_raw_quat(q, xp=xp, backend=backend), rssd, sensitivity
+        return Rotation._from_raw_quat(q, xp=xp, backend=backend), rssd
 
     def __getstate__(self) -> tuple[Array, bool]:
         return (self._quat, self._single)
@@ -2488,6 +2480,7 @@ class Rotation:
     def __setstate__(self, state: tuple[Array, bool]):
         quat, single = state
         xp = array_namespace(quat)
+        self._xp = xp
         self._backend = backend_registry.get(xp, xp_backend)
         self._quat = xp.asarray(quat, copy=True)
         self._single = single
@@ -2569,6 +2562,26 @@ class Rotation:
         # indices.
         for i in range(self._quat.shape[0]):
             yield Rotation(self._quat[i, ...], normalize=False, copy=False)
+
+    @staticmethod
+    def _from_raw_quat(
+        quat: Array, xp: ModuleType, backend: ModuleType | None = None
+    ) -> Rotation:
+        """Create a Rotation skipping all sanitization steps.
+
+        This method is intended for internal, performant creation of Rotations with
+        quaternions that are guaranteed to be valid.
+        """
+        rot = Rotation.__new__(Rotation)
+        rot._single = quat.ndim == 1 and is_numpy(xp)
+        if rot._single:
+            quat = xpx.atleast_nd(quat, ndim=2, xp=xp)
+        rot._quat = quat
+        rot._xp = xp
+        if backend is None:
+            backend = backend_registry[xp]
+        rot._backend = backend
+        return rot
 
 
 class Slerp:

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -890,8 +890,8 @@ def random(num=None, rng=None):
 @cython.embedsignature(True)
 def identity(num: int | None = None) -> double[:, :]:
     if num is None:
-        return np.array([0, 0, 0, 1])
-    q = np.zeros((num, 4))
+        return np.array([0, 0, 0, 1], dtype=np.float64)
+    q = np.zeros((num, 4), dtype=np.float64)
     q[:, 3] = 1
     return q
 

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -461,8 +461,8 @@ def from_euler(seq, angles, bint degrees=False):
     quat = _elementary_quat_compose(seq.encode(), angles, intrinsic)
 
     if is_single:
-        return quat[0]
-    return quat
+        return np.asarray(quat, dtype=float)[0]
+    return np.asarray(quat, dtype=float)
 
 
 @cython.embedsignature(True)
@@ -549,8 +549,8 @@ def from_matrix(matrix):
         _normalize4(quat[ind])
 
     if is_single:
-        return quat[0]
-    return quat
+        return np.asarray(quat, dtype=float)[0]
+    return np.asarray(quat, dtype=float)
 
 
 @cython.embedsignature(True)
@@ -595,8 +595,8 @@ def from_rotvec(rotvec, bint degrees=False):
         quat[ind, 3] = cos(angle / 2)
 
     if is_single:
-        return quat[0]
-    return quat
+        return np.asarray(quat, dtype=float)[0]
+    return np.asarray(quat, dtype=float)
 
 
 @cython.embedsignature(True)
@@ -1243,7 +1243,7 @@ def pow(double[:, :] quat, n) -> double[:, :]:
 @cython.embedsignature(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def from_davenport(axes, order: str, angles, bint degrees=False) -> double[:, :]:
+def from_davenport(axes, order: str, angles, bint degrees=False):
     if order in ['e', 'extrinsic']:
         extrinsic = True
     elif order in ['i', 'intrinsic']:
@@ -1283,4 +1283,6 @@ def from_davenport(axes, order: str, angles, bint degrees=False) -> double[:, :]
         else:
             q = compose_quat(q, qi)
 
-    return q[0] if is_single else q
+    if is_single:
+        return np.asarray(q, dtype=float)[0]
+    return np.asarray(q, dtype=float)


### PR DESCRIPTION
This PR improves the performance of Rotation after the refactor into a pure Python class and a Cython backend.

Optimizations are pretty much the same as in #23193. It also removes `broadcastable` from `_rotation.py` which has moved to `scipy._lib._util`.

### Motivation
Calling into the backends always costs some performance. We now skip validations for backend functions that are guaranteed and tested to return valid quaternions. An example of performance gains can be seen below

<img width="2572" height="2059" alt="image" src="https://github.com/user-attachments/assets/f2c00e12-08f0-4aed-976f-9f4c2b8a59b6" />

### Reference issue(s)
This is a continuation of #22777 working towards #22500 and a direct follow-up of #23198 and #23249. For more information on the progress towards #22500, see #23391.

### Changes to the Cython backend
The changes to the Cython backends make sure we always return numpy arrays instead of memory views. I think this is justified and should have already been done in the original PR as it is natural to assume that all backends return "their" `Array` type.

### Benchmarks
Full benchmarks are given below. We compare the current implementation with the optimized (this PR) version. Current performance is plotted in dashed lines, the optimized performance in solid lines. jax has a native implementation for some of the functions. These are plotted in dotted lines. Since the plots are getting a bit crowded, each framework is plotted in a dedicated subplot. Axes are consistent across individual functions (e.g. the axes for `Rotation.from_matrix` have the same ticks across all frameworks). The array API feature flag is always enabled.

[rotation_benchmark.pdf](https://github.com/user-attachments/files/21566714/rotation_benchmark.pdf)
