### PR TITLE
ENH: spatial.geometric_slerp: allow for extrapolation

### DIFF
--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -175,6 +175,26 @@ def geometric_slerp(
     ...         result[...,2],
     ...         c='k')
     >>> plt.show()
+
+    It is also possible to perform extrapolations outside
+    the interpolation interval by using interpolation parameter
+    values below 0 or above 1. For example, the above example
+    may be adjusted to extrapolate to an antipodal position:
+
+    >>> fig = plt.figure()
+    >>> ax = fig.add_subplot(111, projection='3d')
+    >>> ax.plot_surface(x, y, z, color='y', alpha=0.1)
+    >>> start = np.array([1, 0, 0])
+    >>> end = np.array([0, 0, 1])
+    >>> t_vals = np.linspace(0, 2, 400)
+    >>> result = geometric_slerp(start,
+    ...                          end,
+    ...                          t_vals)
+    >>> ax.plot(result[...,0],
+    ...         result[...,1],
+    ...         result[...,2],
+    ...         c='k')
+    >>> plt.show()
     """
 
     start = np.asarray(start, dtype=np.float64)

--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -190,10 +190,7 @@ def geometric_slerp(
     >>> result = geometric_slerp(start,
     ...                          end,
     ...                          t_vals)
-    >>> ax.plot(result[...,0],
-    ...         result[...,1],
-    ...         result[...,2],
-    ...         c='k')
+    >>> ax.plot(result[...,0], result[...,1], result[...,2], c='k')
     >>> plt.show()
     """
 

--- a/scipy/spatial/_geometric_slerp.py
+++ b/scipy/spatial/_geometric_slerp.py
@@ -52,10 +52,13 @@ def geometric_slerp(
         object. `n` must be greater than 1.
     t : float or (n_points,) 1D array-like
         A float or 1D array-like of doubles representing interpolation
-        parameters, with values required in the inclusive interval
-        between 0 and 1. A common approach is to generate the array
+        parameters. A common approach is to generate the array
         with ``np.linspace(0, 1, n_pts)`` for linearly spaced points.
         Ascending, descending, and scrambled orders are permitted.
+
+        .. versionchanged:: 1.17.0
+            Extrapolation is permitted, allowing values below `0`
+            and above `1`.
     tol : float
         The absolute tolerance for determining if the start and end
         coordinates are antipodes.
@@ -73,7 +76,7 @@ def geometric_slerp(
     Raises
     ------
     ValueError
-        If ``start`` and ``end`` are antipodes, not on the
+        If ``start`` or ``end`` are not on the
         unit n-sphere, or for a variety of degenerate conditions.
 
     See Also
@@ -225,9 +228,6 @@ def geometric_slerp(
 
     if t.size == 0:
         return np.empty((0, start.size))
-
-    if t.min() < 0 or t.max() > 1:
-        raise ValueError("interpolation parameter must be in [0, 1]")
 
     if t.ndim == 0:
         return _geometric_slerp(start,

--- a/scipy/spatial/tests/test_slerp.py
+++ b/scipy/spatial/tests/test_slerp.py
@@ -1,3 +1,4 @@
+import math
 import warnings
 
 import numpy as np
@@ -181,20 +182,6 @@ class TestGeometricSlerp:
                                  end=end,
                                  t=np.linspace(0, 1, 4))
         assert_allclose(actual, expected, atol=1e-16)
-
-    @pytest.mark.parametrize("t", [
-        # both interval ends clearly violate limits
-        np.linspace(-20, 20, 300),
-        # only one interval end violating limit slightly
-        np.linspace(-0.0001, 0.0001, 17),
-        ])
-    def test_t_values_limits(self, t):
-        # geometric_slerp() should appropriately handle
-        # interpolation parameters < 0 and > 1
-        with pytest.raises(ValueError, match='interpolation parameter'):
-            _ = geometric_slerp(start=np.array([1, 0]),
-                                end=np.array([0, 1]),
-                                t=t)
 
     @pytest.mark.parametrize("start, end", [
         (np.array([1]),
@@ -416,3 +403,64 @@ class TestGeometricSlerp:
             geometric_slerp(start=arr1,
                             end=arr1,
                             t=t)
+
+
+    @pytest.mark.parametrize("start, end, t, expected", [
+    # verify intuitive cases for t > 1 or < 0 (extrapolation)
+
+    # quarter way around the unit circle, doubling to
+    # half way around (allowed antipode since non-ambiguous
+    # geodesic):
+    ([0, 1], [1, 0], 2, [0, -1]),
+    # 1/8 way around the unit circle, quadrupling to half way
+    # (another allowed non-ambiguous antipode)
+    ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], 4, [0, -1]),
+    # 1/8 way around the unit circle, 6x to 3/4 way around (270 deg)
+    ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], 6, [-1, 0]),
+    # 1/8 way around the unit circle, 7x to 315 deg
+    ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], 7, [-math.sqrt(2)/2, math.sqrt(2)/2]),
+    # the above three extrapolations in reverse order should be returned
+    # in that same order:
+    ([0, 1],
+     [math.sqrt(2)/2, math.sqrt(2)/2],
+     [7, 6, 4],
+     [[-math.sqrt(2)/2, math.sqrt(2)/2],
+      [-1, 0],
+      [0, -1]]),
+    # same case in 3d (sphere), in the xy plane:
+    ([0, 1, 0],
+     [math.sqrt(2)/2, math.sqrt(2)/2, 0],
+     [7, 6, 4],
+     [[-math.sqrt(2)/2, math.sqrt(2)/2, 0],
+      [-1, 0, 0],
+      [0, -1, 0]]),
+    # 1/8 way around the unit circle, moving 300 deg backwards
+    # should end up at pi/6 (since there is no forward travel with
+    # negative extrapolation)
+    ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], (-300/45), [math.sqrt(3)/2, 0.5]),
+    ])
+    def test_extrapolation_basic(self, start, end, t, expected):
+        actual_path = geometric_slerp(start=start,
+                                      end=end,
+                                      t=t)
+        assert_allclose(actual_path, expected, atol=2e-16)
+
+    @pytest.mark.parametrize("start, end, t, expected", [
+    # cases where start and end proper are antipodes
+    # and t > 1 or < 0; these cases should issue a warning due to
+    # geodesic ambiguity
+
+    # North to South on unit sphere, then back to North again;
+    # there are an infinite number of possible routes, but they all
+    # return back to North
+    ([0, 0, 1], [0, 0, -1], -2, [0, 0, 1]),
+    # move "backwards" to South pole via an infinite number
+    # of possible routes
+    ([0, 0, 1], [0, 0, -1], -1, [0, 0, -1]),
+    ])
+    def test_extrapolation_antipodes(self, start, end, t, expected):
+        with pytest.warns(UserWarning, match='antipodes'):
+            actual_path = geometric_slerp(start=start,
+                                          end=end,
+                                          t=t)
+        assert_allclose(actual_path, expected, atol=2.8e-16)

--- a/scipy/spatial/tests/test_slerp.py
+++ b/scipy/spatial/tests/test_slerp.py
@@ -406,38 +406,39 @@ class TestGeometricSlerp:
 
 
     @pytest.mark.parametrize("start, end, t, expected", [
-    # verify intuitive cases for t > 1 or < 0 (extrapolation)
+        # verify intuitive cases for t > 1 or < 0 (extrapolation)
 
-    # quarter way around the unit circle, doubling to
-    # half way around (allowed antipode since non-ambiguous
-    # geodesic):
-    ([0, 1], [1, 0], 2, [0, -1]),
-    # 1/8 way around the unit circle, quadrupling to half way
-    # (another allowed non-ambiguous antipode)
-    ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], 4, [0, -1]),
-    # 1/8 way around the unit circle, 6x to 3/4 way around (270 deg)
-    ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], 6, [-1, 0]),
-    # 1/8 way around the unit circle, 7x to 315 deg
-    ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], 7, [-math.sqrt(2)/2, math.sqrt(2)/2]),
-    # the above three extrapolations in reverse order should be returned
-    # in that same order:
-    ([0, 1],
-     [math.sqrt(2)/2, math.sqrt(2)/2],
-     [7, 6, 4],
-     [[-math.sqrt(2)/2, math.sqrt(2)/2],
-      [-1, 0],
-      [0, -1]]),
-    # same case in 3d (sphere), in the xy plane:
-    ([0, 1, 0],
-     [math.sqrt(2)/2, math.sqrt(2)/2, 0],
-     [7, 6, 4],
-     [[-math.sqrt(2)/2, math.sqrt(2)/2, 0],
-      [-1, 0, 0],
-      [0, -1, 0]]),
-    # 1/8 way around the unit circle, moving 300 deg backwards
-    # should end up at pi/6 (since there is no forward travel with
-    # negative extrapolation)
-    ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], (-300/45), [math.sqrt(3)/2, 0.5]),
+        # quarter way around the unit circle, doubling to
+        # half way around (allowed antipode since non-ambiguous
+        # geodesic):
+        ([0, 1], [1, 0], 2, [0, -1]),
+        # 1/8 way around the unit circle, quadrupling to half way
+        # (another allowed non-ambiguous antipode)
+        ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], 4, [0, -1]),
+        # 1/8 way around the unit circle, 6x to 3/4 way around (270 deg)
+        ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], 6, [-1, 0]),
+        # 1/8 way around the unit circle, 7x to 315 deg
+        ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], 7,
+         [-math.sqrt(2)/2, math.sqrt(2)/2]),
+        # the above three extrapolations in reverse order should be returned
+        # in that same order:
+        ([0, 1],
+         [math.sqrt(2)/2, math.sqrt(2)/2],
+         [7, 6, 4],
+         [[-math.sqrt(2)/2, math.sqrt(2)/2],
+          [-1, 0],
+          [0, -1]]),
+        # same case in 3d (sphere), in the xy plane:
+        ([0, 1, 0],
+         [math.sqrt(2)/2, math.sqrt(2)/2, 0],
+         [7, 6, 4],
+         [[-math.sqrt(2)/2, math.sqrt(2)/2, 0],
+          [-1, 0, 0],
+          [0, -1, 0]]),
+        # 1/8 way around the unit circle, moving 300 deg backwards
+        # should end up at pi/6 (since there is no forward travel with
+        # negative extrapolation)
+        ([0, 1], [math.sqrt(2)/2, math.sqrt(2)/2], (-300/45), [math.sqrt(3)/2, 0.5]),
     ])
     def test_extrapolation_basic(self, start, end, t, expected):
         actual_path = geometric_slerp(start=start,
@@ -460,7 +461,5 @@ class TestGeometricSlerp:
     ])
     def test_extrapolation_antipodes(self, start, end, t, expected):
         with pytest.warns(UserWarning, match='antipodes'):
-            actual_path = geometric_slerp(start=start,
-                                          end=end,
-                                          t=t)
+            actual_path = geometric_slerp(start=start, end=end, t=t)
         assert_allclose(actual_path, expected, atol=2.8e-16)


### PR DESCRIPTION
* Fixes gh-23400.

* Add support and regression tests for extrapolation behavior in `geometric_slerp()`, and update the documentation for the interpolation parameter accordingly.

* The `Raises` section of the `geometric_slerp()` docstring was also updated to remove a spurious claim about antipodes--we now actually allow i.e., North and South pole points despite the infinite number of paths between them on the sphere, and enforce this behavior in our regression tests (a warning, but not error, is issued). That is not directly related to the changes here, but the documented innacurracy of behavior would otherwise make this harder to reason about.

[ci skip] [skip ci]

TODO:

- [x] reactivate the CI and make sure it is passing (it passes locally, for now)
- [x] think of some more useful extrapolation test cases to add?
- [x] expand the `geometric_slerp()` docstring to include an example (+ plot) of extrapolation on the circle or sphere

@Ockenfuss since you were enthusiastic about adding this capability, would you like to suggest a few more interesting test cases and possibly make a suggestion for a docstring example of extrapolation you'd like to see?
