### PR TITLE
DOC: interpolate.RBFInterpolator: fix typo

### DIFF
--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -204,7 +204,7 @@ class RBFInterpolator:
     linear equations
 
     .. math::
-        (K(y, y) + \\lambda I) a + P(y) b = d
+        (K(x, y) + \\lambda I) a + P(y) b = d
 
     and
 


### PR DESCRIPTION
[docs only]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #23431 

#### What does this implement/fix?

In the equation used to describe the K matrix, we describe it as K(y, y). This ought to be K(x, y).

#### Additional information
<!--Any additional information you think is important.-->
