### PR TITLE
MAINT: ensure Qhull license file gets included in wheels

### DIFF
--- a/scipy/spatial/COPYING_QHULL.txt
+++ b/scipy/spatial/COPYING_QHULL.txt
@@ -1,0 +1,39 @@
+                    Qhull, Copyright (c) 1993-2020
+                    
+                            C.B. Barber
+                           Arlington, MA 
+                          
+                               and
+
+       The National Science and Technology Research Center for
+        Computation and Visualization of Geometric Structures
+                        (The Geometry Center)
+                       University of Minnesota
+
+                       email: qhull@qhull.org
+
+This software includes Qhull from C.B. Barber and The Geometry Center.  
+Files derived from Qhull 1.0 are copyrighted by the Geometry Center.  The
+remaining files are copyrighted by C.B. Barber.  Qhull is free software 
+and may be obtained via http from www.qhull.org.  It may be freely copied, 
+modified, and redistributed under the following conditions:
+
+1. All copyright notices must remain intact in all files.
+
+2. A copy of this text file must be distributed along with any copies 
+   of Qhull that you redistribute; this includes copies that you have 
+   modified, or copies of programs or other software products that 
+   include Qhull.
+
+3. If you modify Qhull, you must include a notice giving the
+   name of the person performing the modification, the date of
+   modification, and the reason for such modification.
+
+4. When distributing modified versions of Qhull, or other software 
+   products that include Qhull, you must provide notice that the original 
+   source code may be obtained as noted above.
+
+5. There is no warranty or other guarantee of fitness for Qhull, it is 
+   provided solely "as is".  Bug reports or fixes may be sent to 
+   qhull_bug@qhull.org; the authors may or may not act on them as 
+   they desire.

--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -85,6 +85,12 @@ py3.extension_module('_hausdorff',
 )
 
 py3.install_sources([
+    'COPYING_QHULL.txt',  # copied from subprojects/qhull_r (see gh-23428)
+  ],
+  subdir: 'scipy/spatial/qhull_src'
+)
+
+py3.install_sources([
     '_qhull.pyi',
     '_voronoi.pyi',
     'distance.pyi'


### PR DESCRIPTION
Copying the license file from `subprojects/qhull_r` is a short-term hacky fix, because due to using a subproject we can't grab the license file from its new location.

Closes gh-23428