### PR TITLE
DOC: fix documentation bug in `Rotation.as_davenport`

### DIFF
--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1299,7 +1299,7 @@ class Rotation:
             - Second angle belongs to a set of size 180 degrees,
               given by: ``[-lambda, 180 - lambda]``, if ``lambda ≥ 0`` or
               ``[-180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
-              is the angle in [-180, 180] that rotates axis 3 unto axis 1 
+              is the angle in [-180, 180] that rotates axis 3 onto axis 1 
               using axis 2 as the rotation vector.
 
         References

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1297,7 +1297,8 @@ class Rotation:
             - First angle belongs to [-180, 180] degrees (both inclusive)
             - Third angle belongs to [-180, 180] degrees (both inclusive)
             - Second angle belongs to a set of size 180 degrees,
-              given by: ``[-abs(lambda), 180 - abs(lambda)]``, where ``lambda``
+              given by: ``[-lambda, 180 - lambda]``, if ``lambda ≥ 0`` or
+              ``[180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
               is the angle between the first and third axes.
 
         References

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1299,7 +1299,8 @@ class Rotation:
             - Second angle belongs to a set of size 180 degrees,
               given by: ``[-lambda, 180 - lambda]``, if ``lambda ≥ 0`` or
               ``[-180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
-              is the angle between the first and third axes.
+              is the angle in [-180, 180] that rotates axis 3 unto axis 1 
+              using axis 2 as the rotation vector.
 
         References
         ----------

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1252,9 +1252,9 @@ class Rotation:
         rotations.
 
         For both Euler angles and Davenport angles, consecutive axes must
-        be are orthogonal (``axis2`` is orthogonal to both ``axis1`` and
-        ``axis3``). For Euler angles, there is an additional relationship
-        between ``axis1`` or ``axis3``, with two possibilities:
+        be orthogonal (``axis2`` is orthogonal to both ``axis1`` and ``axis3``). 
+        For Euler angles, there is an additional relationship between ``axis1`` 
+        or ``axis3``, with two possibilities:
 
             - ``axis1`` and ``axis3`` are also orthogonal (asymmetric sequence)
             - ``axis1 == axis3`` (symmetric sequence)

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1298,7 +1298,7 @@ class Rotation:
             - Third angle belongs to [-180, 180] degrees (both inclusive)
             - Second angle belongs to a set of size 180 degrees,
               given by: ``[-lambda, 180 - lambda]``, if ``lambda ≥ 0`` or
-              ``[180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
+              ``[-180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
               is the angle between the first and third axes.
 
         References

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1383,7 +1383,7 @@ class Rotation:
             - Second angle belongs to a set of size 180 degrees,
               given by: ``[-lambda, 180 - lambda]``, if ``lambda ≥ 0`` or
               ``[-180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
-              is the angle in [-180, 180] that rotates axis 3 unto axis 1 
+              is the angle in [-180, 180] that rotates axis 3 onto axis 1 
               using axis 2 as the rotation vector.
 
         References

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1382,7 +1382,7 @@ class Rotation:
             - Third angle belongs to [-180, 180] degrees (both inclusive)
             - Second angle belongs to a set of size 180 degrees,
               given by: ``[-lambda, 180 - lambda]``, if ``lambda ≥ 0`` or
-              ``[180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
+              ``[-180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
               is the angle between the first and third axes.
 
         References

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1333,9 +1333,9 @@ class Rotation:
         rotations.
 
         For both Euler angles and Davenport angles, consecutive axes must
-        be are orthogonal (``axis2`` is orthogonal to both ``axis1`` and
-        ``axis3``). For Euler angles, there is an additional relationship
-        between ``axis1`` or ``axis3``, with two possibilities:
+        be orthogonal (``axis2`` is orthogonal to both ``axis1`` and ``axis3``). 
+        For Euler angles, there is an additional relationship between ``axis1`` 
+        or ``axis3``, with two possibilities:
 
         - ``axis1`` and ``axis3`` are also orthogonal (asymmetric sequence)
         - ``axis1 == axis3`` (symmetric sequence)

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1378,13 +1378,17 @@ class Rotation:
             Shape depends on shape of inputs used to initialize object.
             The returned angles are in the range:
 
-            - First angle belongs to [-180, 180] degrees (both inclusive)
-            - Third angle belongs to [-180, 180] degrees (both inclusive)
-            - Second angle belongs to a set of size 180 degrees,
-              given by: ``[-lambda, 180 - lambda]``, if ``lambda ≥ 0`` or
-              ``[-180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
-              is the angle in [-180, 180] that rotates axis 3 onto axis 1 
-              using axis 2 as the rotation vector.
+            - First angle belongs to :math:`[-180°,\ 180°]` (both inclusive)
+            - Third angle belongs to :math:`[-180°,\ 180°]` (both inclusive)
+            - Second angle belongs to a set of size 180°,
+              given by: 
+              
+                - :math:`[-\lambda,\ 180° {-\lambda}]`, if :math:`\lambda ≥ 0`
+                - :math:`[-180° - \lambda,\ {-\lambda}]`, if :math:`\lambda < 0`
+                
+              Here :math:`\lambda` is the angle in :math:`[-180°,\ 180°]` that rotates 
+              axis 3 onto axis 1 using axis 2 as the rotation vector. (all intervals 
+              inclusive on both sides)
 
         References
         ----------

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1387,8 +1387,8 @@ class Rotation:
                 - :math:`[-180° - \lambda,\ {-\lambda}]`, if :math:`\lambda < 0`
                 
               Here :math:`\lambda` is the angle in :math:`[-180°,\ 180°]` that rotates 
-              axis 3 onto axis 1 using axis 2 as the rotation vector. (all intervals 
-              inclusive on both sides)
+              axis 3 onto axis 1 using axis 2 as the rotation vector
+              (all intervals inclusive on both sides).
 
         References
         ----------

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1383,7 +1383,8 @@ class Rotation:
             - Second angle belongs to a set of size 180 degrees,
               given by: ``[-lambda, 180 - lambda]``, if ``lambda ≥ 0`` or
               ``[-180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
-              is the angle between the first and third axes.
+              is the angle in [-180, 180] that rotates axis 3 unto axis 1 
+              using axis 2 as the rotation vector.
 
         References
         ----------

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1381,7 +1381,8 @@ class Rotation:
             - First angle belongs to [-180, 180] degrees (both inclusive)
             - Third angle belongs to [-180, 180] degrees (both inclusive)
             - Second angle belongs to a set of size 180 degrees,
-              given by: ``[-abs(lambda), 180 - abs(lambda)]``, where ``lambda``
+              given by: ``[-lambda, 180 - lambda]``, if ``lambda ≥ 0`` or
+              ``[180 - lambda, -lambda]``, if ``lambda < 0``. Here ``lambda``
               is the angle between the first and third axes.
 
         References


### PR DESCRIPTION
[docs only]

Fix the documentation giving the wrong range of possible values for the second axis when lambda is negative.

If lambda is negative, the code will flip the second axis, calculate it with the now positive value of lambda and flip the sign of the second calculated angle. Therefore the range of possible values for negative lambda is the range of possible values for positive lambda, but mirrored at zero.

The following code demonstrates this behaviour:

```py
from scipy.spatial.transform import Rotation
import numpy as np

# positive lambda:
axes = [
     [1,0,0],
     [0,1,0],
     [1,0,1],
]

# negative lambda:
axes_flipped = [
      [1,0,0],
      [0,-1,0],
      [1,0,1],
]

n1, n2, n3 = (axis.direction for axis in axes)
print(f"λ = {np.rad2deg(np.arctan2(np.cross(n1, n2).dot(n3), n1.dot(n3)))}")
# λ = 45.0

rot = Rotation.from_rotvec(np.deg2rad([0,90,0]))

np.rad2deg(Rotation.identity().as_davenport(axes, "extrinsic"))
# array([0.00000000e+00, 6.36110936e-15, 0.00000000e+00])
np.rad2deg(rot.as_davenport(axes, "extrinsic"))
# array([ 0., 90.,  0.])
np.rad2deg(rot.inv().as_davenport(axes, "extrinsic"))
# array([-1.80000000e+02, -6.36110936e-15,  1.80000000e+02])

np.rad2deg(Rotation.identity().as_davenport(axes_flipped, "extrinsic"))
# array([ 0.00000000e+00, -6.36110936e-15,  0.00000000e+00])
np.rad2deg(rot.as_davenport(axes_flipped, "extrinsic")
# array([  0., -90.,   0.])
np.rad2deg(rot.inv().as_davenport(axes_flipped, "extrinsic"))
# array([-1.80000000e+02,  6.36110936e-15,  1.80000000e+02])
```

