### PR TITLE
BUG: fix regression for non-integer `maxiter` in SLSQP

### DIFF
--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -235,7 +235,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         Set to True to print convergence messages. If False,
         `verbosity` is ignored and set to 0.
     maxiter : int
-        Maximum number of iterations.
+        Maximum number of iterations. All inputs are passed through ``int()``.
+        Default value is 100.
     finite_diff_rel_step : None or array_like, optional
         If ``jac in ['2-point', '3-point', 'cs']`` the relative step size to
         use for numerical approximation of `jac`. The absolute step
@@ -268,8 +269,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
     attribute as a NumPy array. Denoting the dimension of the equality constraints
     with ``meq``, and of inequality constraints with ``mineq``, then the returned
     array slice ``m[:meq]`` contains the multipliers for the equality constraints,
-    and the remaining ``m[meq:meq + mineq]`` contains the multipliers for the 
-    inequality constraints. The multipliers corresponding to bound inequalities 
+    and the remaining ``m[meq:meq + mineq]`` contains the multipliers for the
+    inequality constraints. The multipliers corresponding to bound inequalities
     are not returned. See [1]_ pp. 321 or [2]_ for an explanation of how to interpret
     these multipliers. The internal QP problem is solved using the methods given
     in [3]_ Chapter 25.
@@ -461,7 +462,7 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
         "inconsistent": 0,
         "reset": 0,
         "iter": 0,
-        "itermax": maxiter,
+        "itermax": int(maxiter),
         "line": 0,
         "m": m,
         "meq": meq,

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -234,9 +234,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
     disp : bool
         Set to True to print convergence messages. If False,
         `verbosity` is ignored and set to 0.
-    maxiter : int
-        Maximum number of iterations. All inputs are passed through ``int()``.
-        Default value is 100.
+    maxiter : int, optional
+        Maximum number of iterations. Default value is 100.
     finite_diff_rel_step : None or array_like, optional
         If ``jac in ['2-point', '3-point', 'cs']`` the relative step size to
         use for numerical approximation of `jac`. The absolute step

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3167,6 +3167,15 @@ def test_bounds_with_list():
     )
 
 
+@pytest.mark.parametrize('method', (
+    'slsqp', 'cg', 'cobyqa', 'powell','nelder-mead', 'bfgs', 'l-bfgs-b',
+    'trust-constr'))
+def test_minimize_maxiter_noninteger(method):
+    # Regression test for gh-23430
+    x0 = np.array([1.3, 0.7, 0.8, 1.9, 1.2])
+    optimize.minimize(rosen, x0, method=method, options={'maxiter': 100.1})
+
+
 def test_x_overwritten_user_function():
     # if the user overwrites the x-array in the user function it's likely
     # that the minimizer stops working properly.


### PR DESCRIPTION
Closes gh-23430. Fix by @ilayn, split off from gh-23433. I added a regression test and a doc tweak.