### PR TITLE
MAINT: Support ruff 0.12

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -58,5 +58,5 @@ dependencies:
   # For CLI
   - spin
   # For linting
-  - ruff>=0.0.292
+  - ruff>=0.12.0
   - cython-lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ dev = [
     "typing_extensions",
     "types-psutil",
     "pycodestyle",
-    "ruff>=0.0.292",
+    "ruff>=0.12.0",
     "cython-lint>=0.12.2",
 ]
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,5 +5,5 @@ mypy==1.10.0
 typing_extensions
 types-psutil
 pycodestyle
-ruff>=0.0.292
+ruff>=0.12.0
 cython-lint>=0.12.2

--- a/scipy/special/_orthogonal.pyi
+++ b/scipy/special/_orthogonal.pyi
@@ -276,7 +276,7 @@ class orthopoly1d(np.poly1d):
             weights: np.typing.ArrayLike | None,
             hn: float = ...,
             kn: float = ...,
-            wfunc = Optional[Callable[[float], float]],  # noqa: UP007
+            wfunc = Optional[Callable[[float], float]],  # noqa: UP045
             limits = tuple[float, float] | None,
             monic: bool = ...,
             eval_func: np.ufunc = ...,

--- a/tools/lint.py
+++ b/tools/lint.py
@@ -119,7 +119,7 @@ def run_cython_lint_all():
 
 
 def check_ruff_version():
-    min_version = packaging.version.parse('0.0.292')
+    min_version = packaging.version.parse('0.12.0')
     res = subprocess.run(
         ['ruff', '--version'],
         stdout=subprocess.PIPE,
@@ -127,7 +127,7 @@ def check_ruff_version():
     )
     version = res.stdout.replace('ruff ', '')
     if packaging.version.parse(version) < min_version:
-        raise RuntimeError("Linting requires `ruff>=0.0.292`. Please upgrade `ruff`.")
+        raise RuntimeError("Linting requires `ruff>=0.12.0`. Please upgrade `ruff`.")
 
 
 def main():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->


#### What does this implement/fix?

In ruff [0.12.0](https://github.com/astral-sh/ruff/releases/tag/0.12.0):
> * [non-pep604-annotation-union](https://docs.astral.sh/ruff/rules/non-pep604-annotation-union) (`UP007`) has now been split into two rules. `UP007` now applies only to `typing.Union`, while [non-pep604-annotation-optional](https://docs.astral.sh/ruff/rules/non-pep604-annotation-optional) (`UP045`) checks for use of `typing.Optional`. `UP045` has also been stabilized in this release, but you may need to update existing `include`, `ignore`, or `noqa` settings to accommodate this change.

#### Additional information

While we could ignore both rules, I prefer requiring a decently recent version of ruff.