### PR TITLE
ENH, MAINT: simpler calculate_areas()

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -311,9 +311,8 @@ class SphericalVoronoi:
         areas = self.radius * theta
 
         # Correct arcs which go the wrong way (single-hemisphere inputs)
-        signs = np.sign(np.einsum('ij,ij->i', arcs[:, 0],
-                                              self.vertices - self.center))
-        indices = np.where(signs < 0)
+        indices = np.einsum('ij,ij->i', arcs[:, 0],
+                            self.vertices - self.center) < 0
         areas[indices] = 2 * np.pi * self.radius - areas[indices]
         return areas
 


### PR DESCRIPTION
* Simplify the 2D area calculation for `SphericalVoronoi`. We can remove two full
NumPy operations with no change in test suite outcome.

* The change in performance via `asv` (measured on ARM Mac) via the following incantation is only a fairly small improvement, but the gradual simplification may inspire algorithmic improvements longer term:
`asv continuous --factor=1.04 -E virtualenv -e -b "time_spherical_polygon_area_calculation" main treddy_simplify_areas_2d`

```
| Change   | Before [5616c90f] <main>   | After [74818633] <treddy_simplify_areas_2d>   |   Ratio | Benchmark (Parameter)                                                     |
|----------|----------------------------|-----------------------------------------------|---------|---------------------------------------------------------------------------|
| -        | 12.1±0.03μs                | 11.6±0.01μs                                   |    0.96 | spatial.SphericalVorAreas.time_spherical_polygon_area_calculation(100, 2) |
| -        | 8.19±0.04μs                | 7.57±0.05μs                                   |    0.92 | spatial.SphericalVorAreas.time_spherical_polygon_area_calculation(10, 2)  |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

[skip circle]

There are no short term plans for array API support here, so I don't think we need to worry about boolean indexing support for now (the algorithm more broadly handles jagged data structures because of arbitrary-shaped polygons anyway).