### PR TITLE
BUG: sparse: nD sparse save_npz and load_npz

### DIFF
--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -61,6 +61,7 @@ def save_npz(file, matrix, compressed=True):
         arrays_dict.update(offsets=matrix.offsets)
     elif matrix.format == 'coo':
         arrays_dict.update(row=matrix.row, col=matrix.col)
+        arrays_dict.update(coords=matrix.coords)
     else:
         msg = f'Save is not implemented for sparse matrix of format {matrix.format}.'
         raise NotImplementedError(msg)
@@ -157,9 +158,10 @@ def load_npz(file):
             return cls((loaded['data'], loaded['indices'], loaded['indptr']),
                        shape=loaded['shape'])
         elif sparse_format == 'dia':
-            return cls((loaded['data'], loaded['offsets']),
-                       shape=loaded['shape'])
+            return cls((loaded['data'], loaded['offsets']), shape=loaded['shape'])
         elif sparse_format == 'coo':
+            if 'coords' in loaded:
+                return cls((loaded['data'], loaded['coords']), shape=loaded['shape'])
             return cls((loaded['data'], (loaded['row'], loaded['col'])),
                        shape=loaded['shape'])
         else:

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -60,8 +60,11 @@ def save_npz(file, matrix, compressed=True):
     elif matrix.format == 'dia':
         arrays_dict.update(offsets=matrix.offsets)
     elif matrix.format == 'coo':
-        arrays_dict.update(row=matrix.row, col=matrix.col)
-        arrays_dict.update(coords=matrix.coords)
+        if matrix.ndim == 2:
+            # TODO: After a few releases, switch 2D case to save with coords only.
+            arrays_dict.update(row=matrix.row, col=matrix.col)
+        else:
+            arrays_dict.update(coords=matrix.coords)
     else:
         msg = f'Save is not implemented for sparse matrix of format {matrix.format}.'
         raise NotImplementedError(msg)

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import tempfile
 
+import pytest
 from pytest import raises as assert_raises
 from numpy.testing import assert_equal, assert_
 
@@ -72,8 +73,10 @@ def test_sparray_vs_spmatrix():
     assert_(loaded_matrix.dtype == loaded_array.dtype)
     assert_equal(loaded_matrix.toarray(), loaded_array.toarray())
 
-def test_nd_coo_format(tmpdir):
-    A = coo_array([[[0]]])
+@pytest.mark.parametrize("value", [0, 1.2])
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_nd_coo_format(ndim, value, tmpdir):
+    A = coo_array([value]).reshape((1,) * ndim)
 
     #save/load array
     with tmpdir.as_cwd():

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -72,17 +72,15 @@ def test_sparray_vs_spmatrix():
     assert_(loaded_matrix.dtype == loaded_array.dtype)
     assert_equal(loaded_matrix.toarray(), loaded_array.toarray())
 
-def test_nd_coo_format():
+def test_nd_coo_format(tmpdir):
     A = coo_array([[[0]]])
 
     #save/load array
-    fd, tmpfile = tempfile.mkstemp(suffix='.npz')
-    os.close(fd)
-    try:
+    with tmpdir.as_cwd():
+        tmpfile = "f.npz"
+
         save_npz(tmpfile, A)
         loaded_A = load_npz(tmpfile)
-    finally:
-        os.remove(tmpfile)
 
     assert isinstance(loaded_A, coo_array)
     assert_(loaded_A.shape == A.shape)

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -5,8 +5,9 @@ import tempfile
 from pytest import raises as assert_raises
 from numpy.testing import assert_equal, assert_
 
-from scipy.sparse import (sparray, csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
-                          coo_matrix, dok_matrix, csr_array, save_npz, load_npz)
+from scipy.sparse import (sparray, csr_array, coo_array, save_npz, load_npz,
+                          csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
+                          coo_matrix, dok_matrix)
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -70,6 +71,22 @@ def test_sparray_vs_spmatrix():
     assert isinstance(loaded_array, sparray)
     assert_(loaded_matrix.dtype == loaded_array.dtype)
     assert_equal(loaded_matrix.toarray(), loaded_array.toarray())
+
+def test_nd_coo_format():
+    A = coo_array([[[0]]])
+
+    #save/load array
+    fd, tmpfile = tempfile.mkstemp(suffix='.npz')
+    os.close(fd)
+    try:
+        save_npz(tmpfile, A)
+        loaded_A = load_npz(tmpfile)
+    finally:
+        os.remove(tmpfile)
+
+    assert isinstance(loaded_A, coo_array)
+    assert_(loaded_A.shape == A.shape)
+    assert_equal(A.toarray(), loaded_A.toarray())
 
 def test_malicious_load():
     class Executor:


### PR DESCRIPTION
Fixes #23462 

`save_npz` writes a `coo_array` as if it has ndim == 2 (whether 1D or nD for n>2).
`load_npz` for coo_array always creates 2D array.

This PR allows COO sparse format to be saved and loaded as nD.

I'm not sure what the backward compatibility tradition is for `save_npz` and `load_npz`.
For `save_npz` this PR saves `A.coords` as well as `A.row` and `A.col`, though all that is needed is to save `coords`.  This makes all stored files bigger than needed, but they can be read by older SciPy versions of load_npz.
For `load_npz` this PR checks the loaded arrays for the name `coords`, and use that if it is present. Otherwise it loads the older version arrays `row` and `col`. This allows us to load files that were saved using older SciPy versions.

I can change it to have `save_npz` store smaller files (with only `coords`) so new versions of SciPy can read older versions of npz files but older versions of SciPy cannot read newer saved npz files.  Or maybe its better to still use row/col for 2D, and coords for 1D and nD.