### PR TITLE
DOC: optimize.shgo: correct `minimize_every_iter ` description

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -182,7 +182,7 @@ def shgo(
 
         minimize_every_iter : bool
             If True then promising global sampling points will be passed to a
-            local minimization routine every iteration. If True then only the
+            local minimization routine every iteration. If False then only the
             final minimizer pool will be run. Defaults to True.
 
         local_iter : int


### PR DESCRIPTION
Currently, The description for the argument ```minimize_every_iter``` has the following description. The second if true, should be a false. 

```
        minimize_every_iter : bool
            If True then promising global sampling points will be passed to a
            local minimization routine every iteration. If True then only the
            final minimizer pool will be run. Defaults to True.
```

[docs only]


