### PR TITLE
BUG: optimize: fix the incompatible dtypes in L-BFGS-B

### DIFF
--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -440,8 +440,8 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         raise ValueError('maxls must be positive.')
 
     x = array(x0, dtype=np.float64)
-    f = array(0.0, dtype=np.int32)
-    g = zeros((n,), dtype=np.int32)
+    f = array(0.0, dtype=np.float64)
+    g = zeros((n,), dtype=np.float64)
     wa = zeros(2*m*n + 5*n + 11*m*m + 8*m, float64)
     iwa = zeros(3*n, dtype=np.int32)
     task = zeros(2, dtype=np.int32)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR fixes dtype incompatibility between the C L-BFGS-B implementation and the Python module which calls the C implementation.

#### Additional information
<!--Any additional information you think is important.-->