### PR TITLE
BUG: signal.lombscargle: replace in-place input adjustments

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -243,11 +243,11 @@ def lombscargle(
         )
 
     # weight vector must sum to 1
-    weights *= 1.0 / weights.sum()
+    weights = weights * (1.0 / weights.sum())
 
     # if requested, perform precenter
     if precenter:
-        y -= y.mean()
+        y = y - y.mean()
 
     # transform arrays
     # row vector

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1507,7 +1507,7 @@ class TestLombscargle:
         freqs = [np.pi/2.0] * 2  # must have 2+ elements
 
         lombscargle(t, y, freqs)
-    
+
     def test_input_mutation(self):
         # this tests for mutation of the input arrays
         # https://github.com/scipy/scipy/issues/23474
@@ -1521,8 +1521,8 @@ class TestLombscargle:
         p = 0.7  # Fraction of points to select
 
         # Randomly select a fraction of an array with timesteps
-        rng = np.random.RandomState(2353425)
-        r = rng.rand(nin)
+        rng = np.random.default_rng()
+        r = rng.random(nin)
         t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
 
         # Plot a sine wave for the selected times
@@ -1542,10 +1542,10 @@ class TestLombscargle:
         lombscargle(t, y, f, precenter=True, weights=weights)
 
         # check all 4 array inputs
-        assert_array_equal(t_org, t)
-        assert_array_equal(y_org, y)
-        assert_array_equal(f_org, f)
-        assert_array_equal(weights_org, weights)
+        assert_array_equal(t, t_org)
+        assert_array_equal(y, y_org)
+        assert_array_equal(f, f_org)
+        assert_array_equal(weights, weights_org)
 
 
 class TestSTFT:

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1539,7 +1539,7 @@ class TestLombscargle:
         f_org = f.copy()
         weights_org = weights.copy()
 
-        pgram = lombscargle(t, y, f, precenter=True, weights=weights)
+        lombscargle(t, y, f, precenter=True, weights=weights)
 
         # check all 4 array inputs
         assert_array_equal(t_org, t)

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1061,7 +1061,6 @@ class TestLombscargle:
         delta = f[1] - f[0]
         assert(w - f[np.argmax(P)] < (delta/2.))
 
-
     def test_amplitude(self):
         # Test if height of peak in unnormalized Lomb-Scargle periodogram
         # corresponds to amplitude of the generated input signal.
@@ -1508,6 +1507,45 @@ class TestLombscargle:
         freqs = [np.pi/2.0] * 2  # must have 2+ elements
 
         lombscargle(t, y, freqs)
+    
+    def test_input_mutation(self):
+        # this tests for mutation of the input arrays
+        # https://github.com/scipy/scipy/issues/23474
+
+        # Input parameters
+        ampl = 2.
+        w = 1.
+        phi = 0.5 * np.pi
+        nin = 100
+        nout = 1000
+        p = 0.7  # Fraction of points to select
+
+        # Randomly select a fraction of an array with timesteps
+        rng = np.random.RandomState(2353425)
+        r = rng.rand(nin)
+        t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
+
+        # Plot a sine wave for the selected times
+        y = ampl * np.sin(w*t + phi)
+
+        # Define the array of frequencies for which to compute the periodogram
+        f = np.linspace(0.01, 10., nout)
+
+        weights = np.ones_like(y)
+
+        # create original copies before passing
+        t_org = t.copy()
+        y_org = y.copy()
+        f_org = f.copy()
+        weights_org = weights.copy()
+
+        pgram = lombscargle(t, y, f, precenter=True, weights=weights)
+
+        # check all 4 array inputs
+        assert_array_equal(t_org, t)
+        assert_array_equal(y_org, y)
+        assert_array_equal(f_org, f)
+        assert_array_equal(weights_org, weights)
 
 
 class TestSTFT:


### PR DESCRIPTION
See gh-23474


#### Reference issue
Closes gh-23474.

#### What does this implement/fix?
Replaces the two in-place operations that are performed on the inputs (in certain situations).

#### Additional information
None
