### PR TITLE
DOC: Clarify parameter selection process in differential_evolution documentation

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1728,16 +1728,19 @@ class DifferentialEvolutionSolver:
         crossovers = rng.uniform(size=(S, self.parameter_count))
         crossovers = crossovers < self.cross_over_probability
         if self.strategy in self._binomial:
-            # A randomly selected parameter is always from the bprime vector for binomial
-            # If you fill in modulo with a loop you have to set the last one to
-            # true. If you don't use a loop then you can have any random entry
-            # be True.
+            # A randomly selected parameter is always from the bprime vector for binomial crossover.
+            # The fill_point ensures at least one parameter comes from bprime, preventing
+            # the possibility of no mutation influence in the trial vector.
             i = np.arange(S)
             crossovers[i, fill_point[i]] = True
             trial = np.where(crossovers, bprime, trial)
             return trial
 
         elif self.strategy in self._exponential:
+            # For exponential crossover, fill_point determines the starting index
+            # for a consecutive sequence of parameters from bprime. The sequence
+            # continues until a crossover probability check fails. The starting index is always from the bprime vector ensuring at
+            # least one parameter comes from bprime.
             crossovers[..., 0] = True
             for j in range(S):
                 i = 0
@@ -1769,15 +1772,18 @@ class DifferentialEvolutionSolver:
         crossovers = rng.uniform(size=self.parameter_count)
         crossovers = crossovers < self.cross_over_probability
         if self.strategy in self._binomial:
-            # the last one is always from the bprime vector for binomial
-            # If you fill in modulo with a loop you have to set the last one to
-            # true. If you don't use a loop then you can have any random entry
-            # be True.
+            # A randomly selected parameter is always from the bprime vector for binomial crossover.
+            # The fill_point ensures at least one parameter comes from bprime, preventing
+            # the possibility of no mutation influence in the trial vector.
             crossovers[fill_point] = True
             trial = np.where(crossovers, bprime, trial)
             return trial
 
         elif self.strategy in self._exponential:
+            # For exponential crossover, fill_point determines the starting index
+            # for a consecutive sequence of parameters from bprime. The sequence
+            # continues until a crossover probability check fails. The starting index is always from the bprime vector ensuring at
+            # least one parameter comes from bprime.
             i = 0
             crossovers[0] = True
             while i < self.parameter_count and crossovers[i]:

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -318,10 +318,13 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     or the original candidate is made with a binomial distribution (the 'bin'
     in 'best1bin') - a random number in [0, 1) is generated. If this number is
     less than the `recombination` constant then the parameter is loaded from
-    ``b'``, otherwise it is loaded from the original candidate. A randomly selected parameter is always loaded from ``b'``. For binomial crossover, this is a single random parameter. For exponential crossover, this is the starting point of a consecutive sequence of parameters from ``b'``. Once the trial candidate is built
-    its fitness is assessed. If the trial is better than the original candidate
-    then it takes its place. If it is also better than the best overall
-    candidate it also replaces that.
+    ``b'``, otherwise it is loaded from the original candidate. A randomly 
+    selected parameter is always loaded from ``b'``. For binomial crossover, 
+    this is a single random parameter. For exponential crossover, this is the 
+    starting point of a consecutive sequence of parameters from ``b'``. Once 
+    the trial candidate is built its fitness is assessed. If the trial is
+    better than the original candidate then it takes its place. If it is
+    also better than the best overall candidate it also replaces that.
 
     The other strategies available are outlined in Qiang and
     Mitchell (2014) [3]_.

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -318,8 +318,7 @@ def differential_evolution(func, bounds, args=(), strategy='best1bin',
     or the original candidate is made with a binomial distribution (the 'bin'
     in 'best1bin') - a random number in [0, 1) is generated. If this number is
     less than the `recombination` constant then the parameter is loaded from
-    ``b'``, otherwise it is loaded from the original candidate. The final
-    parameter is always loaded from ``b'``. Once the trial candidate is built
+    ``b'``, otherwise it is loaded from the original candidate. A randomly selected parameter is always loaded from ``b'``. For binomial crossover, this is a single random parameter. For exponential crossover, this is the starting point of a consecutive sequence of parameters from ``b'``. Once the trial candidate is built
     its fitness is assessed. If the trial is better than the original candidate
     then it takes its place. If it is also better than the best overall
     candidate it also replaces that.
@@ -1729,7 +1728,7 @@ class DifferentialEvolutionSolver:
         crossovers = rng.uniform(size=(S, self.parameter_count))
         crossovers = crossovers < self.cross_over_probability
         if self.strategy in self._binomial:
-            # the last one is always from the bprime vector for binomial
+            # A randomly selected parameter is always from the bprime vector for binomial
             # If you fill in modulo with a loop you have to set the last one to
             # true. If you don't use a loop then you can have any random entry
             # be True.

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -1728,9 +1728,10 @@ class DifferentialEvolutionSolver:
         crossovers = rng.uniform(size=(S, self.parameter_count))
         crossovers = crossovers < self.cross_over_probability
         if self.strategy in self._binomial:
-            # A randomly selected parameter is always from the bprime vector for binomial crossover.
-            # The fill_point ensures at least one parameter comes from bprime, preventing
-            # the possibility of no mutation influence in the trial vector.
+            # A randomly selected parameter is always from the bprime vector for
+            # binomial crossover. The fill_point ensures at least one parameter
+            # comes from bprime, preventing the possibility of no mutation 
+            # influence in the trial vector.
             i = np.arange(S)
             crossovers[i, fill_point[i]] = True
             trial = np.where(crossovers, bprime, trial)
@@ -1739,8 +1740,9 @@ class DifferentialEvolutionSolver:
         elif self.strategy in self._exponential:
             # For exponential crossover, fill_point determines the starting index
             # for a consecutive sequence of parameters from bprime. The sequence
-            # continues until a crossover probability check fails. The starting index is always from the bprime vector ensuring at
-            # least one parameter comes from bprime.
+            # continues until a crossover probability check fails. The starting
+            # index is always from the bprime vector ensuring at least one 
+            # parameter comes from bprime.
             crossovers[..., 0] = True
             for j in range(S):
                 i = 0
@@ -1772,9 +1774,10 @@ class DifferentialEvolutionSolver:
         crossovers = rng.uniform(size=self.parameter_count)
         crossovers = crossovers < self.cross_over_probability
         if self.strategy in self._binomial:
-            # A randomly selected parameter is always from the bprime vector for binomial crossover.
-            # The fill_point ensures at least one parameter comes from bprime, preventing
-            # the possibility of no mutation influence in the trial vector.
+            # A randomly selected parameter is always from the bprime vector for
+            # binomial crossover. The fill_point ensures at least one parameter
+            # comes from bprime, preventing the possibility of no mutation
+            # influence in the trial vector.
             crossovers[fill_point] = True
             trial = np.where(crossovers, bprime, trial)
             return trial
@@ -1782,8 +1785,9 @@ class DifferentialEvolutionSolver:
         elif self.strategy in self._exponential:
             # For exponential crossover, fill_point determines the starting index
             # for a consecutive sequence of parameters from bprime. The sequence
-            # continues until a crossover probability check fails. The starting index is always from the bprime vector ensuring at
-            # least one parameter comes from bprime.
+            # continues until a crossover probability check fails. The starting
+            # index is always from the bprime vector ensuring at least one 
+            # parameter comes from bprime.
             i = 0
             crossovers[0] = True
             while i < self.parameter_count and crossovers[i]:


### PR DESCRIPTION
#### Reference issue
The documentation for differential evolution mentioned 
`The final parameter is always loaded from ``b'```
which is different from how it is implemented in the code. 

In case of a single worker, `scipy.optimize._differentialevolution.DifferentialEvolutionSolver._mutate` 
defines the strategy of parameter selection. In the case of multiple workers, this is defined at 
`scipy.optimize._differentialevolution.DifferentialEvolutionSolver._mutate_many
`

Both of the functions show that the parameter to be mandatorily loaded from b' is controlled by `fill_point = rng_integers(rng, self.parameter_count)`.
For binomial crossover, it is a randomly selected parameter; for exponential crossover, fill_point is the starting point which is mandatorily loaded from b'

#### What does this implement/fix?
This fixes the comment and the documentation surrounding the mandatory selection of one parameter from b'.
