### PR TITLE
DOC: Update outdated `lazy_xp_function` references

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -332,7 +332,7 @@ To properly test scipy with JAX, you need to wrap the tested scipy functions
 with `@jax.jit` before they are called by the unit tests.
 To achieve this, you should tag them as follows in your test module::
 
-  from scipy._lib._lazy_testing import lazy_xp_function
+  from scipy._lib.array_api_extra.testing import lazy_xp_function
   from scipy.mymodule import toto
 
   lazy_xp_function(toto)
@@ -343,7 +343,7 @@ To achieve this, you should tag them as follows in your test module::
       # When xp==jax.numpy, toto is wrapped with @jax.jit
       xp_assert_close(toto(a, b), a)
 
-See full documentation in `scipy/_lib/_lazy_testing.py`.
+See full documentation `here <https://data-apis.org/array-api-extra/generated/array_api_extra.testing.lazy_xp_function.html>`_.
 
 
 Additional information


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
[docs only]

#### Reference issue
Closes #23477.

#### What does this implement/fix?
Updates the `import` statement and links to the correct documentation page.

#### Additional information
<!--Any additional information you think is important.-->
Based on @lucascolley's suggestions.