### PR TITLE
ENH: signal.abcd_normalize: Refactor, improve docstr, and make ARRAY API compatible

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -735,6 +735,8 @@ Although the sets of roots are stored as ordered NumPy arrays, their ordering
 does not matter: ``([-1, -2], [-3, -4], 1)`` is the same filter as
 ``([-2, -1], [-4, -3], 1)``.
 
+.. _tutorial_signal_state_space_representation:
+
 State-space system representation
 *********************************
 

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -92,7 +92,7 @@ Filter design
                     -- defined as pass and stop bands.
    firwin2       -- Windowed FIR filter design, with arbitrary frequency
                     -- response.
-   firwin_2d        -- Windowed FIR filter design, with frequency response for 
+   firwin_2d        -- Windowed FIR filter design, with frequency response for
                     -- 2D using 1D design.
    freqs         -- Analog filter frequency response from TF coefficients.
    freqs_zpk     -- Analog filter frequency response from ZPK coefficients.
@@ -128,7 +128,7 @@ Lower-level filter design functions:
 .. autosummary::
    :toctree: generated/
 
-   abcd_normalize -- Check state-space matrices and ensure they are rank-2.
+   abcd_normalize -- Check state-space matrices compatibility and ensure they are 2d.
    band_stop_obj  -- Band Stop Objective Function for order minimization.
    besselap       -- Return (z,p,k) for analog prototype of Bessel filter.
    buttap         -- Return (z,p,k) for analog prototype of Butterworth filter.

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -203,13 +203,13 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     D = xp.zeros((q, p)) if xp_size(D) == 0 else D
 
     if A.shape != (n, n):
-        raise ValueError(f"Parameter A was converted to shape {A.shape} != ({n}, {n})!")
+        raise ValueError(f"Parameter A has shape {A.shape} but should be ({n}, {n})!")
     if B.shape != (n, p):
-        raise ValueError(f"Parameter B was converted to shape {B.shape} != ({n}, {p})!")
+        raise ValueError(f"Parameter B has shape {B.shape} but should be ({n}, {p})!")
     if C.shape != (q, n):
-        raise ValueError(f"Parameter C was converted to shape {C.shape} != ({q}, {n})!")
+        raise ValueError(f"Parameter C has shape {C.shape} but should be ({q}, {n})!")
     if D.shape != (q, p):
-        raise ValueError(f"Parameter D was converted to shape {D.shape} != ({q}, {p})!")
+        raise ValueError(f"Parameter D has shape {D.shape} but should be ({q}, {p})!")
 
     return A, B, C, D
 

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -119,7 +119,7 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
 
     Converts input matrices into two-dimensional arrays as needed. Then the dimensions
     n, q, p are determined by investigating the non-zero entries of the array shapes.
-    If a parameter is ``None``, or has shape (0, 0), it is tried to set it to a
+    If a parameter is ``None``, or has shape (0, 0), it is set to a
     zero-array of compatible shape. Finally, it is verified that all parameter shapes
     are compatible to each other. If that fails, a ``ValueError`` is raised. Note that
     the dimensions n, q, p are allowed to be zero.

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -127,13 +127,13 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     Parameters
     ----------
     A: array_like, optional
-        Must be convertible to a two-dimensional array of shape (n, n).
+        Two-dimensional array of shape (n, n).
     B: array_like, optional
-        Must be convertible to a two-dimensional array of shape (n, p).
+        Two-dimensional array of shape (n, p).
     C: array_like, optional
-        Must be convertible to a two-dimensional array of shape (q, n).
+        Two-dimensional array of shape (q, n).
     D: array_like, optional
-        Must be convertible to a two-dimensional array of shape (q, p).
+        Two-dimensional array of shape (q, p).
 
     Returns
     -------

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -190,8 +190,8 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
         raise ValueError("Dimension q is undefined for parameters C = D = None!")
 
     xp = array_namespace(A, B, C, D)
-    A, B, C, D = (xpx.atleast_nd(M_, ndim=2) if M_ is not None else xp.zeros((0, 0))
-                  for M_ in (A, B, C, D))
+    A, B, C, D = (xpx.atleast_nd(xp.asarray(M_), ndim=2) if M_ is not None else
+                  xp.zeros((0, 0)) for M_ in (A, B, C, D))
 
     n = A.shape[0] or B.shape[0] or C.shape[1] or 0  # try finding non-zero dimensions
     p = B.shape[1] or D.shape[1] or 0

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -8,7 +8,7 @@ from numpy import (r_, eye, atleast_2d, poly, dot,
                    asarray, zeros, array, outer)
 from scipy import linalg
 
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, xp_size
 import scipy._lib.array_api_extra as xpx
 from ._filter_design import tf2zpk, zpk2tf, normalize
 
@@ -197,10 +197,10 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     p = B.shape[1] or D.shape[1] or 0
     q = C.shape[0] or D.shape[0] or 0
 
-    A = xp.zeros((n, n)) if A.size == 0 else A  # Create zero-matrices if needed
-    B = xp.zeros((n, p)) if B.size == 0 else B
-    C = xp.zeros((q, n)) if C.size == 0 else C
-    D = xp.zeros((q, p)) if D.size == 0 else D
+    A = xp.zeros((n, n)) if xp_size(A) == 0 else A  # Create zero-matrices if needed
+    B = xp.zeros((n, p)) if xp_size(B) == 0 else B
+    C = xp.zeros((q, n)) if xp_size(C) == 0 else C
+    D = xp.zeros((q, p)) if xp_size(D) == 0 else D
 
     if A.shape != (n, n):
         raise ValueError(f"Parameter A was converted to shape {A.shape} != ({n}, {n})!")

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -8,6 +8,7 @@ from numpy import (r_, eye, atleast_2d, poly, dot,
                    asarray, zeros, array, outer)
 from scipy import linalg
 
+from scipy._lib._array_api import array_namespace
 from ._filter_design import tf2zpk, zpk2tf, normalize
 
 
@@ -112,83 +113,102 @@ def tf2ss(num, den):
     return A, B, C, D
 
 
-def _none_to_empty_2d(arg):
-    if arg is None:
-        return zeros((0, 0))
-    else:
-        return arg
-
-
-def _atleast_2d_or_none(arg):
-    if arg is not None:
-        return atleast_2d(arg)
-
-
-def _shape_or_none(M):
-    if M is not None:
-        return M.shape
-    else:
-        return (None,) * 2
-
-
-def _choice_not_none(*args):
-    for arg in args:
-        if arg is not None:
-            return arg
-
-
-def _restore(M, shape):
-    if M.shape == (0, 0):
-        return zeros(shape)
-    else:
-        if M.shape != shape:
-            raise ValueError("The input arrays have incompatible shapes.")
-        return M
-
-
 def abcd_normalize(A=None, B=None, C=None, D=None):
-    """Check state-space matrices and ensure they are 2-D.
+    """Check state-space matrices compatibility and ensure they are 2d arrays.
 
-    If enough information on the system is provided, that is, enough
-    properly-shaped arrays are passed to the function, the missing ones
-    are built from this information, ensuring the correct number of
-    rows and columns. Otherwise a ValueError is raised.
+    Converts input matrices into two-dimensional arrays as needed. Then the dimensions
+    n, q, p are determined by investigating the non-zero entries of the array shapes.
+    If a parameter is ``None``, or has shape (0, 0), it is tried to set it to a
+    zero-array of compatible shape. Finally, it is verified that all parameter shapes
+    are compatible to each other. If that fails, a ``ValueError`` is raised. Note that
+    the dimensions n, q, p are allowed to be zero.
 
     Parameters
     ----------
-    A, B, C, D : array_like, optional
-        State-space matrices. All of them are None (missing) by default.
-        See `ss2tf` for format.
+    A: array_like, optional
+        Must be convertible to a two-dimensional array of shape (n, n).
+    B: array_like, optional
+        Must be convertible to a two-dimensional array of shape (n, p).
+    C: array_like, optional
+        Must be convertible to a two-dimensional array of shape (q, n).
+    D: array_like, optional
+        Must be convertible to a two-dimensional array of shape (q, p).
 
     Returns
     -------
     A, B, C, D : array
-        Properly shaped state-space matrices.
+        State-space matrices as two-dimensional arrays.
+
+    Notes
+    -----
+    The :ref:`tutorial_signal_state_space_representation` section of the
+    :ref:`user_guide` presents the corresponding definitions of continuous-time and
+    disrcete time state space systems.
 
     Raises
     ------
     ValueError
-        If not enough information on the system was provided.
+        If the dimensions n, q, or p could not be determined or if the shapes are
+        incompatible with each other.
 
+    See Also
+    --------
+    StateSpace: Linear Time Invariant system in state-space form.
+    dlti: Discrete-time linear time invariant system base class.
+    tf2ss: Transfer function to state-space representation.
+    ss2tf: State-space to transfer function.
+    ss2zpk: State-space representation to zero-pole-gain representation.
+    cont2discrete: Transform a continuous to a discrete state-space system.
+
+    Examples
+    --------
+    The following example demonstrates that the passed lists are converted into
+    two-dimensional arrays:
+
+    >>> from scipy.signal import abcd_normalize
+    >>> AA, BB, CC, DD = abcd_normalize(A=[[1, 2], [3, 4]], B=[[-1], [5]],
+    ...                                 C=[[4, 5]], D=2.5)
+    >>> AA.shape, BB.shape, CC.shape, DD.shape
+    ((2, 2), (2, 1), (1, 2), (1, 1))
+
+    In the following, the missing parameter C is assumed to be an array of zeros
+    with shape (1, 2):
+
+    >>> from scipy.signal import abcd_normalize
+    >>> AA, BB, CC, DD = abcd_normalize(A=[[1, 2], [3, 4]], B=[[-1], [5]], D=2.5)
+    >>> AA.shape, BB.shape, CC.shape, DD.shape
+    ((2, 2), (2, 1), (1, 2), (1, 1))
+    >>> CC
+    array([[0., 0.]])
     """
-    A, B, C, D = map(_atleast_2d_or_none, (A, B, C, D))
+    if A is None and B is None and C is None:
+        raise ValueError("Dimension n is undefined for parameters A = B = C = None!")
+    if B is None and D is None:
+        raise ValueError("Dimension p is undefined for parameters B = D = None!")
+    if C is None and D is None:
+        raise ValueError("Dimension q is undefined for parameters C = D = None!")
 
-    MA, NA = _shape_or_none(A)
-    MB, NB = _shape_or_none(B)
-    MC, NC = _shape_or_none(C)
-    MD, ND = _shape_or_none(D)
+    xp = array_namespace(A, B, C, D)
+    A, B, C, D = (xp.atleast_2d(M_) if M_ is not None else np.zeros((0, 0))
+                  for M_ in (A, B, C, D))
 
-    p = _choice_not_none(MA, MB, NC)
-    q = _choice_not_none(NB, ND)
-    r = _choice_not_none(MC, MD)
-    if p is None or q is None or r is None:
-        raise ValueError("Not enough information on the system.")
+    n = A.shape[0] or B.shape[0] or C.shape[1] or 0  # try finding non-zero dimensions
+    p = B.shape[1] or D.shape[1] or 0
+    q = C.shape[0] or D.shape[0] or 0
 
-    A, B, C, D = map(_none_to_empty_2d, (A, B, C, D))
-    A = _restore(A, (p, p))
-    B = _restore(B, (p, q))
-    C = _restore(C, (r, p))
-    D = _restore(D, (r, q))
+    A = xp.zeros((n, n)) if A.size == 0 else A  # Create zero-matrices if needed
+    B = xp.zeros((n, p)) if B.size == 0 else B
+    C = xp.zeros((q, n)) if C.size == 0 else C
+    D = xp.zeros((q, p)) if D.size == 0 else D
+
+    if A.shape != (n, n):
+        raise ValueError(f"Parameter A was converted to shape {A.shape} != ({n}, {n})!")
+    if B.shape != (n, p):
+        raise ValueError(f"Parameter B was converted to shape {B.shape} != ({n}, {p})!")
+    if C.shape != (q, n):
+        raise ValueError(f"Parameter C was converted to shape {C.shape} != ({q}, {n})!")
+    if D.shape != (q, p):
+        raise ValueError(f"Parameter D was converted to shape {D.shape} != ({q}, {p})!")
 
     return A, B, C, D
 

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -9,6 +9,7 @@ from numpy import (r_, eye, atleast_2d, poly, dot,
 from scipy import linalg
 
 from scipy._lib._array_api import array_namespace
+import scipy._lib.array_api_extra as xpx
 from ._filter_design import tf2zpk, zpk2tf, normalize
 
 
@@ -189,7 +190,7 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
         raise ValueError("Dimension q is undefined for parameters C = D = None!")
 
     xp = array_namespace(A, B, C, D)
-    A, B, C, D = (xp.atleast_2d(M_) if M_ is not None else np.zeros((0, 0))
+    A, B, C, D = (xpx.atleast_nd(M_, ndim=2) if M_ is not None else xp.zeros((0, 0))
                   for M_ in (A, B, C, D))
 
     n = A.shape[0] or B.shape[0] or C.shape[1] or 0  # try finding non-zero dimensions

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -30,7 +30,7 @@ from scipy.interpolate import make_interp_spline
 from ._filter_design import (tf2zpk, zpk2tf, normalize, freqs, freqz, freqs_zpk,
                             freqz_zpk)
 from ._lti_conversion import (tf2ss, abcd_normalize, ss2tf, zpk2ss, ss2zpk,
-                             cont2discrete, _atleast_2d_or_none)
+                              cont2discrete)
 
 import numpy as np
 from numpy import (real, atleast_1d, squeeze, asarray, zeros,
@@ -1527,7 +1527,7 @@ class StateSpace(LinearTimeInvariant):
 
     @A.setter
     def A(self, A):
-        self._A = _atleast_2d_or_none(A)
+        self._A = np.atleast_2d(A) if A is not None else None
 
     @property
     def B(self):
@@ -1536,7 +1536,7 @@ class StateSpace(LinearTimeInvariant):
 
     @B.setter
     def B(self, B):
-        self._B = _atleast_2d_or_none(B)
+        self._B = np.atleast_2d(B) if B is not None else None
         self.inputs = self.B.shape[-1]
 
     @property
@@ -1546,7 +1546,7 @@ class StateSpace(LinearTimeInvariant):
 
     @C.setter
     def C(self, C):
-        self._C = _atleast_2d_or_none(C)
+        self._C = np.atleast_2d(C) if C is not None else None
         self.outputs = self.C.shape[0]
 
     @property
@@ -1556,7 +1556,7 @@ class StateSpace(LinearTimeInvariant):
 
     @D.setter
     def D(self, D):
-        self._D = _atleast_2d_or_none(D)
+        self._D = np.atleast_2d(D) if D is not None else None
 
     def _copy(self, system):
         """

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 from pytest import raises as assert_raises
 from scipy._lib._array_api import(
-    assert_almost_equal, xp_assert_equal, xp_assert_close
+    assert_almost_equal, array_namespace, xp_assert_equal, xp_assert_close
 )
 
 from scipy.signal import (ss2tf, tf2ss, lti,
@@ -915,10 +915,12 @@ class TestZerosPolesGain:
 
 class Test_abcd_normalize:
     def setup_method(self):
-        self.A = np.array([[1.0, 2.0], [3.0, 4.0]])
-        self.B = np.array([[-1.0], [5.0]])
-        self.C = np.array([[4.0, 5.0]])
-        self.D = np.array([[2.5]])
+        xp = array_namespace()
+        self.A = xp.array([[1.0, 2.0], [3.0, 4.0]])
+        self.B = xp.array([[-1.0], [5.0]])
+        self.C = xp.array([[4.0, 5.0]])
+        self.D = xp.array([[2.5]])
+        self.xp = xp
 
     def test_no_matrix_fails(self):
         assert_raises(ValueError, abcd_normalize)
@@ -959,8 +961,9 @@ class Test_abcd_normalize:
         xp_assert_equal(B.shape[1], D.shape[1])
 
     def test_zero_dimension_is_not_none1(self):
-        B_ = np.zeros((2, 0))
-        D_ = np.zeros((0, 0))
+        xp = self.xp  # shorthand
+        B_ = xp.zeros((2, 0))
+        D_ = xp.zeros((0, 0))
         A, B, C, D = abcd_normalize(A=self.A, B=B_, D=D_)
         xp_assert_equal(A, self.A)
         xp_assert_equal(B, B_)
@@ -969,8 +972,9 @@ class Test_abcd_normalize:
         assert C.shape[1] == self.A.shape[0]
 
     def test_zero_dimension_is_not_none2(self):
-        B_ = np.zeros((2, 0))
-        C_ = np.zeros((0, 2))
+        xp = self.xp  # shorthand
+        B_ = xp.zeros((2, 0))
+        C_ = xp.zeros((0, 2))
         A, B, C, D = abcd_normalize(A=self.A, B=B_, C=C_)
         xp_assert_equal(A, self.A)
         xp_assert_equal(B, B_)

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1050,13 +1050,15 @@ class Test_abcd_normalize:
         assert C.shape == (D_.shape[0], A_.shape[0])
 
     def test_missing_ABC_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, D=self.D)
+        assert_raises(ValueError, abcd_normalize, D=xp.asarray(self.D))
 
     def test_missing_BD_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, A=self.A, C=self.C)
+        assert_raises(ValueError, abcd_normalize, A=xp.asarray(self.A),
+                      C=xp.asarray(self.C))
 
     def test_missing_CD_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, A=self.A, B=self.B)
+        assert_raises(ValueError, abcd_normalize, A=xp.asarray(self.A),
+                      B=xp.asarray(self.B))
 
 
 class Test_bode:

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -944,12 +944,12 @@ class Test_abcd_normalize:
                       xp.asarray([-1, 5]), xp.asarray(self.C), xp.asarray(self.D))
 
     def test_normalized_matrices_unchanged(self, xp):
-        A, B, C, D = abcd_normalize(xp.asarray(self.A), xp.asarray(self.B),
-                                    xp.asarray(self.C), xp.asarray(self.D))
-        xp_assert_equal(A, self.A)
-        xp_assert_equal(B, self.B)
-        xp_assert_equal(C, self.C)
-        xp_assert_equal(D, self.D)
+        A_, B_, C_, D_ = map(xp.asarray, (self.A, self.B, self.C, self.D))
+        A, B, C, D = abcd_normalize(A=A_, B=B_, C=C_, D=D_)
+        xp_assert_equal(A, A_)
+        xp_assert_equal(B, B_)
+        xp_assert_equal(C, C_)
+        xp_assert_equal(D, D_)
 
     def test_shapes(self, xp):
         A, B, C, D = abcd_normalize(xp.asarray(self.A), xp.asarray(self.B),
@@ -965,7 +965,7 @@ class Test_abcd_normalize:
         B_ = xp.zeros((2, 0))
         D_ = xp.zeros((0, 0))
         A, B, C, D = abcd_normalize(A=A_, B=B_, D=D_)
-        xp_assert_equal(A, self.A)
+        xp_assert_equal(A, A_)
         xp_assert_equal(B, B_)
         xp_assert_equal(D, D_)
         assert C.shape[0] == D_.shape[0]


### PR DESCRIPTION
The function `signal.abcd_normalize` including its docstr were refactored to make it more visible what the function exactly does. This allowed to remove the internal helpers `_none_to_empty_2d`, `_atleast_2d_or_none`, `_shape_or_none`, `_choice_not_none` and `_restore`. Besides the wording of the error messages of the raised `ValueError` exceptions, there are no changes in functionality.
