### PR TITLE
DOC: signal.detrend: clarify `overwrite_data` behaviour

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4052,7 +4052,7 @@ def vectorstrength(events, period):
 
 def detrend(data: np.ndarray, axis: int = -1,
             type: Literal['linear', 'constant'] = 'linear',
-            bp: ArrayLike | int = 0, overwrite_data = False) -> np.ndarray:
+            bp: ArrayLike | int = 0, overwrite_data:bool = False) -> np.ndarray:
     r"""Remove linear or constant trend along axis from data.
 
     Parameters

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4052,7 +4052,7 @@ def vectorstrength(events, period):
 
 def detrend(data: np.ndarray, axis: int = -1,
             type: Literal['linear', 'constant'] = 'linear',
-            bp: ArrayLike | int = 0, overwrite_data:bool = False) -> np.ndarray:
+            bp: ArrayLike | int = 0, overwrite_data: bool = False) -> np.ndarray:
     r"""Remove linear or constant trend along axis from data.
 
     Parameters

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4075,7 +4075,7 @@ def detrend(data: np.ndarray, axis: int = -1,
     overwrite_data: bool, optional
         If True, allow in place detrending and avoid a copy. Default is
         False. In place modification applies only if ``type == 'linear'``
-        and also depends in the data type and memory layout of `data`.
+        and also depends on the data type and memory layout of `data`.
 
     Returns
     -------

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -32,6 +32,7 @@ from scipy._lib._array_api import (
 )
 from scipy._lib.array_api_compat import is_array_api_obj
 import scipy._lib.array_api_extra as xpx
+from scipy._lib.deprecation import _NoValue
 
 
 __all__ = ['correlate', 'correlation_lags', 'correlate2d',
@@ -4052,7 +4053,7 @@ def vectorstrength(events, period):
 
 def detrend(data: np.ndarray, axis: int = -1,
             type: Literal['linear', 'constant'] = 'linear',
-            bp: ArrayLike | int = 0, allow_overwrite: bool = False) -> np.ndarray:
+            bp: ArrayLike | int = 0, overwrite_data = False) -> np.ndarray:
     r"""Remove linear or constant trend along axis from data.
 
     Parameters
@@ -4072,7 +4073,7 @@ def detrend(data: np.ndarray, axis: int = -1,
         performed for each part of `data` between two break points.
         Break points are specified as indices into `data`. This parameter
         only has an effect when ``type == 'linear'``.
-    allow_overwrite: bool, optional
+    overwrite_data: bool, optional
         If True, allow in place detrending and avoid a copy. Default is
         False. In place modification applies only if ``type == 'linear'``
         and also depends in the data type and memory layout of `data`.

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -32,7 +32,6 @@ from scipy._lib._array_api import (
 )
 from scipy._lib.array_api_compat import is_array_api_obj
 import scipy._lib.array_api_extra as xpx
-from scipy._lib.deprecation import _NoValue
 
 
 __all__ = ['correlate', 'correlation_lags', 'correlate2d',

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4052,7 +4052,7 @@ def vectorstrength(events, period):
 
 def detrend(data: np.ndarray, axis: int = -1,
             type: Literal['linear', 'constant'] = 'linear',
-            bp: ArrayLike | int = 0, overwrite_data: bool = False) -> np.ndarray:
+            bp: ArrayLike | int = 0, allow_overwrite: bool = False) -> np.ndarray:
     r"""Remove linear or constant trend along axis from data.
 
     Parameters
@@ -4072,8 +4072,10 @@ def detrend(data: np.ndarray, axis: int = -1,
         performed for each part of `data` between two break points.
         Break points are specified as indices into `data`. This parameter
         only has an effect when ``type == 'linear'``.
-    overwrite_data : bool, optional
-        If True, perform in place detrending and avoid a copy. Default is False
+    allow_overwrite: bool, optional
+        If True, allow in place detrending and avoid a copy. Default is
+        False. In place modification applies only if ``type == 'linear'``
+        and also depends in the data type and memory layout of `data`.
 
     Returns
     -------

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4075,7 +4075,8 @@ def detrend(data: np.ndarray, axis: int = -1,
     overwrite_data: bool, optional
         If True, allow in place detrending and avoid a copy. Default is
         False. In place modification applies only if ``type == 'linear'``
-        and also depends on the data type and memory layout of `data`.
+        and `data` is of the floating point dtype ``float32``, ``float64``,
+        ``complex64`` or ``complex128``.
 
     Returns
     -------


### PR DESCRIPTION
The argument `overwrite_data=True` made it appear as if overwriting was guaranteed. However, overwriting only happens when ``type == linear`` and ``dtype is in "dtDF"`` and array reshaping returns a view. I changed the argument name to `allow_overwrite` and updated the docstring to indicate overwriting only happens under specific conditions.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-14498

#### What does this implement/fix?
<!--Please explain your changes.-->
This makes the behavior for in place modifications more explicit

#### Additional information
<!--Any additional information you think is important.-->
