### PR TITLE
ENH: integrate.quad: shortcut if upper/lower bounds are equal

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -432,6 +432,18 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
     if not isinstance(args, tuple):
         args = (args,)
 
+    # Shortcut for empty interval, also works for improper integrals.
+    if a == b:
+        if full_output == 0:
+            return (0., 0.)
+        else:
+            return (0., 0., {"neval": 0, "last": 0,
+                             "alist": np.full(limit, np.nan, dtype=np.float64),
+                             "blist": np.full(limit, np.nan, dtype=np.float64),
+                             "rlist": np.zeros(limit, dtype=np.float64),
+                             "elist": np.zeros(limit, dtype=np.float64),
+                             "iord" : np.zeros(limit, dtype=np.int32)})
+
     # check the limits of integration: \int_a^b, expect a < b
     flip, a, b = b < a, min(a, b), max(a, b)
 

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -3,7 +3,7 @@ import math
 import numpy as np
 from numpy import sqrt, cos, sin, arctan, exp, log, pi
 from numpy.testing import (assert_,
-        assert_allclose, assert_array_less, assert_almost_equal)
+        assert_allclose, assert_array_less, assert_almost_equal, assert_equal)
 import pytest
 
 from scipy.integrate import quad, dblquad, tplquad, nquad
@@ -242,6 +242,21 @@ class TestQuad:
         res_2 = quad(f, 1, 0, weight='alg', wvar=(0, 0), full_output=True)
         err = max(res_1[1], res_2[1])
         assert_allclose(res_1[0], -res_2[0], atol=err)
+
+    def test_b_equals_a(self):
+        def f(x):
+            return 1/x
+
+        upper = lower = 0.
+        zero, err, infodict = quad(f, lower, upper, full_output=1)
+        limit = 50
+        assert (zero, err) == (0., 0.)
+        assert_equal(infodict, {"neval": 0, "last": 0,
+                                "alist": np.full(limit, np.nan, dtype=np.float64),
+                                "blist": np.full(limit, np.nan, dtype=np.float64),
+                                "rlist": np.zeros(limit, dtype=np.float64),
+                                "elist": np.zeros(limit, dtype=np.float64),
+                                "iord" : np.zeros(limit, dtype=np.int32)})
 
     def test_complex(self):
         def tfunc(x):


### PR DESCRIPTION
#### Reference issue
Closes gh-18142.

#### What does this implement/fix?
Shortcut integration if upper and lower integration bounds are equal. See original issue for details.

#### Additional information
This is based on an earlier PR (gh-18147), which was deleted without merging. Compared to that, this PR eliminates a `RuntimeWarning` when running with `full_output=1` (`np.full(limit, np.nan, dtype=np.int32)` tried to cast `np.nan` to an integer) and adds `full_output` to the test.