### PR TITLE
ENH: integrate.romb: array-API support

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -857,6 +857,9 @@ def romb(y, dx=1.0, axis=-1, show=False):
     ======================================================
     -0.742561336672229  # may vary
 
+    >>> integrate.romb([[1, 2, 3], [4, 5, 6]], show=True)
+    *** Printing table only supported for integrals of a single data set.
+    array([ 4., 10.])
     """
     y = np.asarray(y)
     nd = len(y.shape)

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -800,7 +800,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
     return res
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities()
 def romb(y, dx=1.0, axis=-1, show=False):
     """
     Romberg integration using samples of a function.
@@ -861,7 +861,8 @@ def romb(y, dx=1.0, axis=-1, show=False):
     *** Printing table only supported for integrals of a single data set.
     array([ 4., 10.])
     """
-    y = np.asarray(y)
+    xp = array_namespace(y)
+    y = xp.asarray(y)
     nd = len(y.shape)
     Nsamps = y.shape[axis]
     Ninterv = Nsamps-1
@@ -878,7 +879,7 @@ def romb(y, dx=1.0, axis=-1, show=False):
     slice_all = (slice(None),) * nd
     slice0 = tupleset(slice_all, axis, 0)
     slicem1 = tupleset(slice_all, axis, -1)
-    h = Ninterv * np.asarray(dx, dtype=float)
+    h = Ninterv * xp.asarray(dx, dtype=xp.float64)
     R[(0, 0)] = (y[slice0] + y[slicem1])/2.0*h
     slice_R = slice_all
     start = stop = step = Ninterv
@@ -886,7 +887,7 @@ def romb(y, dx=1.0, axis=-1, show=False):
         start >>= 1
         slice_R = tupleset(slice_R, axis, slice(start, stop, step))
         step >>= 1
-        R[(i, 0)] = 0.5*(R[(i-1, 0)] + h*y[slice_R].sum(axis=axis))
+        R[(i, 0)] = 0.5*(R[(i-1, 0)] + h*xp.sum(y[slice_R], axis=axis))
         for j in range(1, i+1):
             prev = R[(i, j-1)]
             R[(i, j)] = prev + (prev-R[(i-1, j-1)]) / ((1 << (2*j))-1)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -40,11 +40,11 @@ class TestFixedQuad:
 @make_xp_test_case(romb)
 class TestRomb:
     def test_romb(self, xp):
-        xp_assert_equal(romb(xp.arange(17)), 128.0)
+        xp_assert_equal(romb(xp.arange(17, dtype=xp.float64)), 128.0)
 
     def test_romb_gh_3731(self, xp):
         # Check that romb makes maximal use of data points
-        x = xp.arange(2**4+1)
+        x = xp.arange(2**4+1, dtype=xp.float64)
         y = xp.cos(0.2*x)
         val = romb(y)
         val2, err = quad(lambda x: xp.cos(0.2*x), x.min(), x.max())

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -15,7 +15,7 @@ from scipy.integrate._quadrature import _cumulative_simpson_unequal_intervals
 from scipy import stats, special, integrate
 from scipy.conftest import skip_xp_invalid_arg
 from scipy._lib._array_api import make_xp_test_case
-from scipy._lib._array_api_no_0d import xp_assert_close
+from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
@@ -39,16 +39,16 @@ class TestFixedQuad:
 
 @make_xp_test_case(romb)
 class TestRomb:
-    def test_romb(self):
-        assert_equal(romb(np.arange(17)), 128)
+    def test_romb(self, xp):
+        xp_assert_equal(romb(xp.arange(17)), 128.0)
 
-    def test_romb_gh_3731(self):
+    def test_romb_gh_3731(self, xp):
         # Check that romb makes maximal use of data points
-        x = np.arange(2**4+1)
-        y = np.cos(0.2*x)
+        x = xp.arange(2**4+1)
+        y = xp.cos(0.2*x)
         val = romb(y)
-        val2, err = quad(lambda x: np.cos(0.2*x), x.min(), x.max())
-        assert_allclose(val, val2, rtol=1e-8, atol=0)
+        val2, err = quad(lambda x: xp.cos(0.2*x), x.min(), x.max())
+        xp_assert_close(val, val2, rtol=1e-8, atol=0)
 
 
 @make_xp_test_case(newton_cotes)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -44,10 +44,10 @@ class TestRomb:
 
     def test_romb_gh_3731(self, xp):
         # Check that romb makes maximal use of data points
-        x = xp.arange(2**4+1, dtype=xp.float64)
-        y = xp.cos(0.2*x)
-        val = romb(y)
-        expected, err = quad(lambda x: np.cos(np.array(0.2*x)), xp.min(x), xp.max(x))
+        x = np.arange(2**4+1, dtype=np.float64)
+        y = np.cos(0.2*x)
+        val = romb(xp.asarray(y, dtype=xp.float64))
+        expected, err = quad(lambda x: np.cos(np.array(0.2*x)), np.min(x), np.max(x))
         xp_assert_close(val, xp.asarray(expected), rtol=1e-8, atol=0)
 
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -40,7 +40,7 @@ class TestFixedQuad:
 @make_xp_test_case(romb)
 class TestRomb:
     def test_romb(self, xp):
-        xp_assert_equal(romb(xp.arange(17, dtype=xp.float64)), xp.asarray(128.0))
+        xp_assert_equal(romb(xp.arange(17.0)), xp.asarray(128.0))
 
     def test_romb_gh_3731(self, xp):
         # Check that romb makes maximal use of data points

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -42,14 +42,13 @@ class TestRomb:
     def test_romb(self, xp):
         xp_assert_equal(romb(xp.arange(17, dtype=xp.float64)), xp.asarray(128.0))
 
-    @pytest.mark.skip_xp_backends(np_only=True, reason="`quad` not yet implemented using array API")
     def test_romb_gh_3731(self, xp):
         # Check that romb makes maximal use of data points
         x = xp.arange(2**4+1, dtype=xp.float64)
         y = xp.cos(0.2*x)
         val = romb(y)
-        val2, err = quad(lambda x: xp.cos(0.2*x), x.min(), x.max())
-        xp_assert_close(val, val2, rtol=1e-8, atol=0)
+        expected, err = quad(lambda x: np.cos(np.array(0.2*x)), xp.min(x), xp.max(x))
+        xp_assert_close(val, xp.asarray(expected), rtol=1e-8, atol=0)
 
 
 @make_xp_test_case(newton_cotes)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -40,8 +40,9 @@ class TestFixedQuad:
 @make_xp_test_case(romb)
 class TestRomb:
     def test_romb(self, xp):
-        xp_assert_equal(romb(xp.arange(17, dtype=xp.float64)), 128.0)
+        xp_assert_equal(romb(xp.arange(17, dtype=xp.float64)), xp.asarray(128.0))
 
+    @pytest.mark.skip_xp_backends(np_only=True, reason="`quad` not yet implemented using array API")
     def test_romb_gh_3731(self, xp):
         # Check that romb makes maximal use of data points
         x = xp.arange(2**4+1, dtype=xp.float64)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -40,15 +40,15 @@ class TestFixedQuad:
 @make_xp_test_case(romb)
 class TestRomb:
     def test_romb(self, xp):
-        xp_assert_equal(romb(xp.arange(17.0)), xp.asarray(128.0))
+        xp_assert_equal(romb(xp.arange(17.0)), xp.asarray(128.0, dtype=xp.float64))
 
     def test_romb_gh_3731(self, xp):
         # Check that romb makes maximal use of data points
-        x = np.arange(2**4+1, dtype=np.float64)
+        x = np.arange(2**4+1)
         y = np.cos(0.2*x)
-        val = romb(xp.asarray(y, dtype=xp.float64))
-        expected, err = quad(lambda x: np.cos(np.array(0.2*x)), np.min(x), np.max(x))
-        xp_assert_close(val, xp.asarray(expected), rtol=1e-8, atol=0)
+        val = romb(xp.asarray(y))
+        expected, _ = quad(lambda x: np.cos(np.array(0.2*x)), np.min(x), np.max(x))
+        xp_assert_close(val, xp.asarray(expected, dtype=xp.float64), rtol=1e-8, atol=0)
 
 
 @make_xp_test_case(newton_cotes)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Contributes to #20930

#### What does this implement/fix?
<!--Please explain your changes.-->
- Fixes `romb` test cases to use `xp` fixture (tests were silently skipping before)
- Adds array API standard support to `romb`
- Adds docstring example where table can't be printed

#### Additional information
Not sure exactly what the prior return type of the romb function was (a scalar array, or just a scalar value). Ran out of time today to investigate - happy to followup on this, just uploading now so maintainers can review.

---

*First time contribution as part of sprinting with EuroScipy2025. Feel free to call out teachable moments.*
