### PR TITLE
TST: additional tests if `integrate.quad` upper/lower bounds are equal

### DIFF
--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -437,12 +437,16 @@ def quad(func, a, b, args=(), full_output=0, epsabs=1.49e-8, epsrel=1.49e-8,
         if full_output == 0:
             return (0., 0.)
         else:
-            return (0., 0., {"neval": 0, "last": 0,
-                             "alist": np.full(limit, np.nan, dtype=np.float64),
-                             "blist": np.full(limit, np.nan, dtype=np.float64),
-                             "rlist": np.zeros(limit, dtype=np.float64),
-                             "elist": np.zeros(limit, dtype=np.float64),
-                             "iord" : np.zeros(limit, dtype=np.int32)})
+            infodict = {"neval": 0, "last": 0,
+                        "alist": np.full(limit, np.nan, dtype=np.float64),
+                        "blist": np.full(limit, np.nan, dtype=np.float64),
+                        "rlist": np.zeros(limit, dtype=np.float64),
+                        "elist": np.zeros(limit, dtype=np.float64),
+                        "iord" : np.zeros(limit, dtype=np.int32)}
+            if complex_func:
+                return (0.+0.j, 0.+0.j, {"real": infodict, "imag": infodict})
+            else:
+                return (0., 0., infodict)
 
     # check the limits of integration: \int_a^b, expect a < b
     flip, a, b = b < a, min(a, b), max(a, b)

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -243,20 +243,28 @@ class TestQuad:
         err = max(res_1[1], res_2[1])
         assert_allclose(res_1[0], -res_2[0], atol=err)
 
-    def test_b_equals_a(self):
+    @pytest.mark.parametrize("complex_func", [True, False])
+    def test_b_equals_a(self, complex_func):
         def f(x):
             return 1/x
 
         upper = lower = 0.
-        zero, err, infodict = quad(f, lower, upper, full_output=1)
         limit = 50
+        expected_infodict = {"neval": 0, "last": 0,
+                             "alist": np.full(limit, np.nan, dtype=np.float64),
+                             "blist": np.full(limit, np.nan, dtype=np.float64),
+                             "rlist": np.zeros(limit, dtype=np.float64),
+                             "elist": np.zeros(limit, dtype=np.float64),
+                             "iord" : np.zeros(limit, dtype=np.int32)}
+
+        zero, err, infodict = quad(f, lower, upper, full_output=1,
+                                   complex_func=complex_func)
         assert (zero, err) == (0., 0.)
-        assert_equal(infodict, {"neval": 0, "last": 0,
-                                "alist": np.full(limit, np.nan, dtype=np.float64),
-                                "blist": np.full(limit, np.nan, dtype=np.float64),
-                                "rlist": np.zeros(limit, dtype=np.float64),
-                                "elist": np.zeros(limit, dtype=np.float64),
-                                "iord" : np.zeros(limit, dtype=np.int32)})
+        if complex_func:
+            assert_equal(infodict, {"real": expected_infodict,
+                                    "imag": expected_infodict})
+        else:
+            assert_equal(infodict, expected_infodict)
 
     def test_complex(self):
         def tfunc(x):

--- a/scipy/integrate/tests/test_quadpack.py
+++ b/scipy/integrate/tests/test_quadpack.py
@@ -377,7 +377,11 @@ class TestDblquad:
             (1, np.inf, -1, np.inf, np.pi / 4 * ((erf(1) + 1) * erfc(1))),
             # Multiple integration of a function in n = 2 variables: f(x, y, z)
             # over domain D = [-inf, inf] for all n.
-            (-np.inf, np.inf, -np.inf, np.inf, np.pi)
+            (-np.inf, np.inf, -np.inf, np.inf, np.pi),
+            # Multiple integration of a function in n = 2 variables: f(x, y, z)
+            # over domain D = [0, 0] for each n (one at a time).
+            (0, 0, 0, np.inf, 0.),
+            (0, np.inf, 0, 0, 0.),
         ]
     )
     def test_double_integral_improper(
@@ -550,6 +554,11 @@ class TestTplquad:
             # over domain D = [-inf, inf] for all n.
             (-np.inf, np.inf, -np.inf, np.inf, -np.inf, np.inf,
              np.pi ** (3 / 2)),
+            # Multiple integration of a function in n = 3 variables: f(x, y, z)
+            # over domain D = [0, 0] for each n (one at a time).
+            (0, 0, 0, np.inf, 0, np.inf, 0),
+            (0, np.inf, 0, 0, 0, np.inf, 0),
+            (0, np.inf, 0, np.inf, 0, 0, 0),
         ],
     )
     def test_triple_integral_improper(


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-23494.

#### What does this implement/fix?
Adds tests for `complex_func=True` as well as for `dblquad` and `tplquad`. Since the latter two already call `nquad` under the hood, I don’t think an additional test for `nquad` is useful. @j-bowhay, let me know if you disagree!