### PR TITLE
DOC: add header to array api support in docstring

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -682,6 +682,8 @@ def _make_capabilities_note(fun_name, capabilities):
         # that explains what is and isn't in-scope, but such a section
         # doesn't exist yet. Using :ref:`dev-arrayapi` as a placeholder.
         note = f"""
+        **Array API Support**
+
         `{fun_name}` is not in-scope for support of Python Array API Standard compatible
         backends other than NumPy.
 
@@ -691,6 +693,8 @@ def _make_capabilities_note(fun_name, capabilities):
 
     # Note: deliberately not documenting array-api-strict
     note = f"""
+    **Array API Support**
+
     `{fun_name}` has experimental support for Python Array API Standard compatible
     backends in addition to NumPy. Please consider testing these features
     by setting an environment variable ``SCIPY_ARRAY_API=1`` and providing

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -682,7 +682,7 @@ def _make_capabilities_note(fun_name, capabilities):
         # that explains what is and isn't in-scope, but such a section
         # doesn't exist yet. Using :ref:`dev-arrayapi` as a placeholder.
         note = f"""
-        **Array API Support**
+        **Array API Standard Support**
 
         `{fun_name}` is not in-scope for support of Python Array API Standard compatible
         backends other than NumPy.

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -693,7 +693,7 @@ def _make_capabilities_note(fun_name, capabilities):
 
     # Note: deliberately not documenting array-api-strict
     note = f"""
-    **Array API Support**
+    **Array API Standard Support**
 
     `{fun_name}` has experimental support for Python Array API Standard compatible
     backends in addition to NumPy. Please consider testing these features


### PR DESCRIPTION
towards #23398

Currently array api support is appended to the notes section of the docstring which isn't great for visibility. This PR adds a subheader to separate it from the rest of the notes section