### PR TITLE
ENH: add array api support for `linalg.orthogonal_procrustes` and `_apply_over_batch`

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1143,11 +1143,13 @@ def _apply_over_batch(*argdefs):
                     else:
                         arrays.append(kwargs.pop(name))
 
+            xp = array_namespace(*arrays)
+
             # Determine core and batch shapes
             batch_shapes = []
             core_shapes = []
             for i, (array, ndim) in enumerate(zip(arrays, ndims)):
-                array = None if array is None else np.asarray(array)
+                array = None if array is None else xp.asarray(array)
                 shape = () if array is None else array.shape
 
                 if ndim == "1|2":  # special case for `solve`, etc.
@@ -1168,7 +1170,7 @@ def _apply_over_batch(*argdefs):
             for i, (array, core_shape) in enumerate(zip(arrays, core_shapes)):
                 if array is None:
                     continue
-                arrays[i] = np.broadcast_to(array, batch_shape + core_shape)
+                arrays[i] = xp.broadcast_to(array, batch_shape + core_shape)
 
             # Main loop
             results = []
@@ -1183,9 +1185,9 @@ def _apply_over_batch(*argdefs):
 
             # Reshape results
             for i, result in enumerate(results):
-                result = np.stack(result)
+                result = xp.stack(result)
                 core_shape = result.shape[1:]
-                results[i] = np.reshape(result, batch_shape + core_shape)
+                results[i] = xp.reshape(result, batch_shape + core_shape)
 
             # Assume `result` should be a single array if there is only one element or
             # a `tuple` otherwise. This is easily generalized by allowing the

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -11,7 +11,7 @@ from scipy._lib._array_api import array_namespace, xp_capabilities, _asarray, is
 __all__ = ['orthogonal_procrustes']
 
 
-@xp_capabilities(jax_jit=False, allow_dask_compute=1)
+@xp_capabilities(jax_jit=False, allow_dask_compute=2)
 @_apply_over_batch(('A', 2), ('B', 2))
 def orthogonal_procrustes(A, B, check_finite=True):
     """

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -11,7 +11,7 @@ from scipy._lib._array_api import array_namespace, xp_capabilities, _asarray, is
 __all__ = ['orthogonal_procrustes']
 
 
-@xp_capabilities(jax_jit=False)
+@xp_capabilities(jax_jit=False, allow_dask_compute=1)
 @_apply_over_batch(('A', 2), ('B', 2))
 def orthogonal_procrustes(A, B, check_finite=True):
     """

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -4,12 +4,13 @@ Solve the orthogonal Procrustes problem.
 """
 import numpy as np
 from scipy._lib._util import _apply_over_batch
-from ._decomp_svd import svd
+from scipy._lib._array_api import array_namespace, xp_capabilities, _asarray
 
 
 __all__ = ['orthogonal_procrustes']
 
 
+@xp_capabilities()
 @_apply_over_batch(('A', 2), ('B', 2))
 def orthogonal_procrustes(A, B, check_finite=True):
     """
@@ -94,20 +95,20 @@ def orthogonal_procrustes(A, B, check_finite=True):
     True
 
     """
-    if check_finite:
-        A = np.asarray_chkfinite(A)
-        B = np.asarray_chkfinite(B)
-    else:
-        A = np.asanyarray(A)
-        B = np.asanyarray(B)
+    xp = array_namespace(A, B)
+
+    A = _asarray(A, xp=xp, check_finite=check_finite, subok=True)
+    B = _asarray(B, xp=xp, check_finite=check_finite, subok=True)
+
     if A.ndim != 2:
         raise ValueError(f'expected ndim to be 2, but observed {A.ndim}')
     if A.shape != B.shape:
         raise ValueError(f'the shapes of A and B differ ({A.shape} vs {B.shape})')
+    breakpoint()
     # Be clever with transposes, with the intention to save memory.
     # The conjugate has no effect for real inputs, but gives the correct solution
     # for complex inputs.
-    u, w, vt = svd((B.T @ np.conjugate(A)).T)
+    u, w, vt = xp.linalg.svd((B.T @ xp.conj(A)).T)
     R = u @ vt
     scale = w.sum()
     return R, scale

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -11,8 +11,10 @@ from scipy._lib._array_api import array_namespace, xp_capabilities, _asarray, is
 __all__ = ['orthogonal_procrustes']
 
 
-@xp_capabilities(jax_jit=False,
-                 skip_backends=[("dask", "full_matrics=True is not supported by dask")])
+@xp_capabilities(
+    jax_jit=False,
+    skip_backends=[("dask.array", "full_matrics=True is not supported by dask")],
+)
 @_apply_over_batch(('A', 2), ('B', 2))
 def orthogonal_procrustes(A, B, check_finite=True):
     """

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -11,7 +11,7 @@ from scipy._lib._array_api import array_namespace, xp_capabilities, _asarray, is
 __all__ = ['orthogonal_procrustes']
 
 
-@xp_capabilities()
+@xp_capabilities(jax_jit=False)
 @_apply_over_batch(('A', 2), ('B', 2))
 def orthogonal_procrustes(A, B, check_finite=True):
     """

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -13,7 +13,7 @@ __all__ = ['orthogonal_procrustes']
 
 @xp_capabilities(
     jax_jit=False,
-    skip_backends=[("dask.array", "full_matrics=True is not supported by dask")],
+    skip_backends=[("dask.array", "full_matrices=True is not supported by dask")],
 )
 @_apply_over_batch(('A', 2), ('B', 2))
 def orthogonal_procrustes(A, B, check_finite=True):

--- a/scipy/linalg/_procrustes.py
+++ b/scipy/linalg/_procrustes.py
@@ -11,7 +11,8 @@ from scipy._lib._array_api import array_namespace, xp_capabilities, _asarray, is
 __all__ = ['orthogonal_procrustes']
 
 
-@xp_capabilities(jax_jit=False, allow_dask_compute=2)
+@xp_capabilities(jax_jit=False,
+                 skip_backends=[("dask", "full_matrics=True is not supported by dask")])
 @_apply_over_batch(('A', 2), ('B', 2))
 def orthogonal_procrustes(A, B, check_finite=True):
     """

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -19,6 +19,7 @@ from scipy.linalg import (solve, inv, det, lstsq, pinv, pinvh, norm,
 from scipy.linalg._testutils import assert_no_overwrite
 from scipy._lib._testutils import check_free_memory, IS_MUSL
 from scipy.linalg.blas import HAS_ILP64
+from scipy.conftest import skip_xp_invalid_arg
 
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
@@ -2326,7 +2327,7 @@ class TestSolveCirculant:
 
 
 class TestMatrix_Balance:
-
+    @skip_xp_invalid_arg
     def test_string_arg(self):
         assert_raises(ValueError, matrix_balance, 'Some string for fail')
 

--- a/scipy/linalg/tests/test_cythonized_array_utils.py
+++ b/scipy/linalg/tests/test_cythonized_array_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.linalg import bandwidth, issymmetric, ishermitian
+from scipy.conftest import skip_xp_invalid_arg
 import pytest
 from pytest import raises
 
@@ -22,7 +23,7 @@ def test_bandwidth_non2d_input():
 
 
 @pytest.mark.parametrize('T', [x for x in np.typecodes['All']
-                               if x not in 'eGUVOMm'])
+                               if x not in 'eGUVOMmS'])
 def test_bandwidth_square_inputs(T):
     n = 20
     k = 4
@@ -46,6 +47,7 @@ def test_bandwidth_square_inputs(T):
     assert bandwidth(A) == (2, 2)
 
 
+@skip_xp_invalid_arg
 @pytest.mark.parametrize('T', [x for x in np.typecodes['All']
                                if x not in 'eGUVOMm'])
 def test_bandwidth_rect_inputs(T):
@@ -60,6 +62,7 @@ def test_bandwidth_rect_inputs(T):
     assert bandwidth(R) == (k, k)
 
 
+@skip_xp_invalid_arg
 def test_issymetric_ishermitian_dtypes():
     n = 5
     for t in np.typecodes['All']:

--- a/scipy/linalg/tests/test_cythonized_array_utils.py
+++ b/scipy/linalg/tests/test_cythonized_array_utils.py
@@ -5,6 +5,7 @@ import pytest
 from pytest import raises
 
 
+@skip_xp_invalid_arg
 def test_bandwidth_dtypes():
     n = 5
     for t in np.typecodes['All']:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -34,6 +34,7 @@ from scipy.sparse._sputils import matrix
 
 from scipy._lib._testutils import check_free_memory
 from scipy.linalg.blas import HAS_ILP64
+from scipy.conftest import skip_xp_invalid_arg
 try:
     from scipy.__config__ import CONFIG
 except ImportError:
@@ -926,6 +927,7 @@ class TestEigh:
         w, z = eigh(a)
         w, z = eigh(a, b)
 
+    @skip_xp_invalid_arg
     def test_eigh_of_sparse(self):
         # This tests the rejection of inputs that eigh cannot currently handle.
         import scipy.sparse

--- a/scipy/linalg/tests/test_procrustes.py
+++ b/scipy/linalg/tests/test_procrustes.py
@@ -7,8 +7,7 @@ from pytest import raises as assert_raises
 
 from scipy.linalg import orthogonal_procrustes
 from scipy.sparse._sputils import matrix
-from scipy._lib._array_api import make_xp_test_case
-from scipy._lib._array_api_no_0d import xp_assert_close
+from scipy._lib._array_api import make_xp_test_case, xp_assert_close
 from scipy.conftest import skip_xp_invalid_arg
 
 def _centered(A, xp):
@@ -140,7 +139,7 @@ class TestOrthogonalProcrustes:
         expected = xp.asarray([[3, 21], [-18, 0], [3, -21], [24, 0]], dtype=xp.float64)
         xp_assert_close(B_approx, expected, atol=1e-8)
         # Check disparity symmetry.
-        expected_disparity = xp.asarray(0.4501246882793018, dtype=xp.float64)
+        expected_disparity = xp.asarray(0.4501246882793018, dtype=xp.float64)[()]
         AB_disparity = (xp.linalg.matrix_norm(B_approx - B_orig)
                         / xp.linalg.matrix_norm(B))**2
         xp_assert_close(AB_disparity, expected_disparity)

--- a/scipy/linalg/tests/test_procrustes.py
+++ b/scipy/linalg/tests/test_procrustes.py
@@ -2,14 +2,18 @@ from itertools import product, permutations
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_less, assert_allclose
+from numpy.testing import assert_allclose
 from pytest import raises as assert_raises
 
-from scipy.linalg import inv, eigh, norm, svd
 from scipy.linalg import orthogonal_procrustes
 from scipy.sparse._sputils import matrix
-from scipy._lib._array_api import make_xp_test_case, xp_assert_close
+from scipy._lib._array_api import make_xp_test_case
+from scipy._lib._array_api_no_0d import xp_assert_close
+from scipy.conftest import skip_xp_invalid_arg
 
+def _centered(A, xp):
+    mu = xp.mean(A, axis=0)
+    return A - mu, mu
 
 @make_xp_test_case(orthogonal_procrustes)
 class TestOrthogonalProcrustes:
@@ -54,163 +58,153 @@ class TestOrthogonalProcrustes:
                                                  B_orig * xp.asarray(B_scale))
                     xp_assert_close(R, R_orig)
 
+    @skip_xp_invalid_arg()
+    def test_orthogonal_procrustes_array_conversion(self):
+        rng = np.random.RandomState(1234)
+        for m, n in ((6, 4), (4, 4), (4, 6)):
+            A_arr = rng.randn(m, n)
+            B_arr = rng.randn(m, n)
+            As = (A_arr, A_arr.tolist(), matrix(A_arr))
+            Bs = (B_arr, B_arr.tolist(), matrix(B_arr))
+            R_arr, s = orthogonal_procrustes(A_arr, B_arr)
+            AR_arr = A_arr.dot(R_arr)
+            for A, B in product(As, Bs):
+                R, s = orthogonal_procrustes(A, B)
+                AR = A_arr.dot(R)
+                assert_allclose(AR, AR_arr)
 
-def test_orthogonal_procrustes_array_conversion():
-    rng = np.random.RandomState(1234)
-    for m, n in ((6, 4), (4, 4), (4, 6)):
-        A_arr = rng.randn(m, n)
-        B_arr = rng.randn(m, n)
-        As = (A_arr, A_arr.tolist(), matrix(A_arr))
-        Bs = (B_arr, B_arr.tolist(), matrix(B_arr))
-        R_arr, s = orthogonal_procrustes(A_arr, B_arr)
-        AR_arr = A_arr.dot(R_arr)
-        for A, B in product(As, Bs):
+    def test_orthogonal_procrustes(self, xp):
+        rng = np.random.RandomState(1234)
+        for m, n in ((6, 4), (4, 4), (4, 6)):
+            # Sample a random target matrix.
+            B = xp.asarray(rng.randn(m, n))
+            # Sample a random orthogonal matrix
+            # by computing eigh of a sampled symmetric matrix.
+            X = xp.asarray(rng.randn(n, n))
+            w, V = xp.linalg.eigh(X.T + X)
+            xp_assert_close(xp.linalg.inv(V), V.T)
+            # Compute a matrix with a known orthogonal transformation that gives B.
+            A = B @ V.T
+            # Check that an orthogonal transformation from A to B can be recovered.
             R, s = orthogonal_procrustes(A, B)
-            AR = A_arr.dot(R)
-            assert_allclose(AR, AR_arr)
+            xp_assert_close(xp.linalg.inv(R), R.T)
+            xp_assert_close(A @ R, B)
+            # Create a perturbed input matrix.
+            A_perturbed = A + 1e-2 * xp.asarray(rng.randn(m, n))
+            # Check that the orthogonal procrustes function can find an orthogonal
+            # transformation that is better than the orthogonal transformation
+            # computed from the original input matrix.
+            R_prime, s = orthogonal_procrustes(A_perturbed, B)
+            xp_assert_close(xp.linalg.inv(R_prime), R_prime.T)
+            # Compute the naive and optimal transformations of the perturbed input.
+            naive_approx = A_perturbed @ R
+            optim_approx = A_perturbed @ R_prime
+            # Compute the Frobenius norm errors of the matrix approximations.
+            naive_approx_error = xp.linalg.matrix_norm(naive_approx - B, ord='fro')
+            optim_approx_error = xp.linalg.matrix_norm(optim_approx - B, ord='fro')
+            # Check that the orthogonal Procrustes approximation is better.
+            assert xp.all(optim_approx_error < naive_approx_error)
 
-
-def test_orthogonal_procrustes():
-    rng = np.random.RandomState(1234)
-    for m, n in ((6, 4), (4, 4), (4, 6)):
-        # Sample a random target matrix.
-        B = rng.randn(m, n)
-        # Sample a random orthogonal matrix
-        # by computing eigh of a sampled symmetric matrix.
-        X = rng.randn(n, n)
-        w, V = eigh(X.T + X)
-        assert_allclose(inv(V), V.T)
-        # Compute a matrix with a known orthogonal transformation that gives B.
-        A = np.dot(B, V.T)
-        # Check that an orthogonal transformation from A to B can be recovered.
+    def test_orthogonal_procrustes_exact_example(self, xp):
+        # Check a small application.
+        # It uses translation, scaling, reflection, and rotation.
+        #
+        #         |
+        #   a  b  |
+        #         |
+        #   d  c  |        w
+        #         |
+        # --------+--- x ----- z ---
+        #         |
+        #         |        y
+        #         |
+        #
+        A_orig = xp.asarray([[-3, 3], [-2, 3], [-2, 2], [-3, 2]], dtype=xp.float64)
+        B_orig = xp.asarray([[3, 2], [1, 0], [3, -2], [5, 0]], dtype=xp.float64)
+        A, A_mu = _centered(A_orig, xp)
+        B, B_mu = _centered(B_orig, xp)
         R, s = orthogonal_procrustes(A, B)
-        assert_allclose(inv(R), R.T)
-        assert_allclose(A.dot(R), B)
-        # Create a perturbed input matrix.
-        A_perturbed = A + 1e-2 * rng.randn(m, n)
-        # Check that the orthogonal procrustes function can find an orthogonal
-        # transformation that is better than the orthogonal transformation
-        # computed from the original input matrix.
-        R_prime, s = orthogonal_procrustes(A_perturbed, B)
-        assert_allclose(inv(R_prime), R_prime.T)
-        # Compute the naive and optimal transformations of the perturbed input.
-        naive_approx = A_perturbed.dot(R)
-        optim_approx = A_perturbed.dot(R_prime)
-        # Compute the Frobenius norm errors of the matrix approximations.
-        naive_approx_error = norm(naive_approx - B, ord='fro')
-        optim_approx_error = norm(optim_approx - B, ord='fro')
-        # Check that the orthogonal Procrustes approximation is better.
-        assert_array_less(optim_approx_error, naive_approx_error)
+        scale = s / xp.linalg.matrix_norm(A)**2
+        B_approx = scale * A @ R + B_mu
+        xp_assert_close(B_approx, B_orig, atol=1e-8)
 
+    def test_orthogonal_procrustes_stretched_example(self, xp):
+        # Try again with a target with a stretched y axis.
+        A_orig = xp.asarray([[-3, 3], [-2, 3], [-2, 2], [-3, 2]], dtype=xp.float64)
+        B_orig = xp.asarray([[3, 40], [1, 0], [3, -40], [5, 0]], dtype=xp.float64)
+        A, A_mu = _centered(A_orig, xp)
+        B, B_mu = _centered(B_orig, xp)
+        R, s = orthogonal_procrustes(A, B)
+        scale = s / xp.linalg.matrix_norm(A)**2
+        B_approx = scale * A @ R + B_mu
+        expected = xp.asarray([[3, 21], [-18, 0], [3, -21], [24, 0]], dtype=xp.float64)
+        xp_assert_close(B_approx, expected, atol=1e-8)
+        # Check disparity symmetry.
+        expected_disparity = xp.asarray(0.4501246882793018)
+        AB_disparity = (xp.linalg.matrix_norm(B_approx - B_orig)
+                        / xp.linalg.matrix_norm(B))**2
+        xp_assert_close(AB_disparity, expected_disparity)
+        R, s = orthogonal_procrustes(B, A)
+        scale = s / xp.linalg.matrix_norm(B)**2
+        A_approx = scale * B @ R + A_mu
+        BA_disparity = (xp.linalg.matrix_norm(A_approx - A_orig)
+                        / xp.linalg.matrix_norm(A))**2
+        xp_assert_close(BA_disparity, expected_disparity)
 
-def _centered(A):
-    mu = A.mean(axis=0)
-    return A - mu, mu
+    def test_orthogonal_procrustes_skbio_example(self, xp):
+        # This transformation is also exact.
+        # It uses translation, scaling, and reflection.
+        #
+        #   |
+        #   | a
+        #   | b
+        #   | c d
+        # --+---------
+        #   |
+        #   |       w
+        #   |
+        #   |       x
+        #   |
+        #   |   z   y
+        #   |
+        #
+        A_orig = xp.asarray([[4, -2], [4, -4], [4, -6], [2, -6]], dtype=xp.float64)
+        B_orig = xp.asarray([[1, 3], [1, 2], [1, 1], [2, 1]], dtype=xp.float64)
+        B_standardized = xp.asarray([[-0.13363062, 0.6681531],
+                                     [-0.13363062, 0.13363062],
+                                     [-0.13363062, -0.40089186],
+                                     [0.40089186, -0.40089186]])
+        A, A_mu = _centered(A_orig, xp)
+        B, B_mu = _centered(B_orig, xp)
+        R, s = orthogonal_procrustes(A, B)
+        scale = s / xp.linalg.matrix_norm(A)**2
+        B_approx = scale * A @ R + B_mu
+        xp_assert_close(B_approx, B_orig)
+        xp_assert_close(B / xp.linalg.matrix_norm(B), B_standardized)
 
+    def test_empty(self, xp):
+        a = xp.empty((0, 0))
+        r, s = orthogonal_procrustes(a, a)
+        xp_assert_close(r, xp.empty((0, 0)))
 
-def test_orthogonal_procrustes_exact_example():
-    # Check a small application.
-    # It uses translation, scaling, reflection, and rotation.
-    #
-    #         |
-    #   a  b  |
-    #         |
-    #   d  c  |        w
-    #         |
-    # --------+--- x ----- z ---
-    #         |
-    #         |        y
-    #         |
-    #
-    A_orig = np.array([[-3, 3], [-2, 3], [-2, 2], [-3, 2]], dtype=float)
-    B_orig = np.array([[3, 2], [1, 0], [3, -2], [5, 0]], dtype=float)
-    A, A_mu = _centered(A_orig)
-    B, B_mu = _centered(B_orig)
-    R, s = orthogonal_procrustes(A, B)
-    scale = s / np.square(norm(A))
-    B_approx = scale * np.dot(A, R) + B_mu
-    assert_allclose(B_approx, B_orig, atol=1e-8)
+        a = xp.empty((0, 3))
+        r, s = orthogonal_procrustes(a, a)
+        xp_assert_close(r, xp.eye(3))
 
-
-def test_orthogonal_procrustes_stretched_example():
-    # Try again with a target with a stretched y axis.
-    A_orig = np.array([[-3, 3], [-2, 3], [-2, 2], [-3, 2]], dtype=float)
-    B_orig = np.array([[3, 40], [1, 0], [3, -40], [5, 0]], dtype=float)
-    A, A_mu = _centered(A_orig)
-    B, B_mu = _centered(B_orig)
-    R, s = orthogonal_procrustes(A, B)
-    scale = s / np.square(norm(A))
-    B_approx = scale * np.dot(A, R) + B_mu
-    expected = np.array([[3, 21], [-18, 0], [3, -21], [24, 0]], dtype=float)
-    assert_allclose(B_approx, expected, atol=1e-8)
-    # Check disparity symmetry.
-    expected_disparity = 0.4501246882793018
-    AB_disparity = np.square(norm(B_approx - B_orig) / norm(B))
-    assert_allclose(AB_disparity, expected_disparity)
-    R, s = orthogonal_procrustes(B, A)
-    scale = s / np.square(norm(B))
-    A_approx = scale * np.dot(B, R) + A_mu
-    BA_disparity = np.square(norm(A_approx - A_orig) / norm(A))
-    assert_allclose(BA_disparity, expected_disparity)
-
-
-def test_orthogonal_procrustes_skbio_example():
-    # This transformation is also exact.
-    # It uses translation, scaling, and reflection.
-    #
-    #   |
-    #   | a
-    #   | b
-    #   | c d
-    # --+---------
-    #   |
-    #   |       w
-    #   |
-    #   |       x
-    #   |
-    #   |   z   y
-    #   |
-    #
-    A_orig = np.array([[4, -2], [4, -4], [4, -6], [2, -6]], dtype=float)
-    B_orig = np.array([[1, 3], [1, 2], [1, 1], [2, 1]], dtype=float)
-    B_standardized = np.array([
-        [-0.13363062, 0.6681531],
-        [-0.13363062, 0.13363062],
-        [-0.13363062, -0.40089186],
-        [0.40089186, -0.40089186]])
-    A, A_mu = _centered(A_orig)
-    B, B_mu = _centered(B_orig)
-    R, s = orthogonal_procrustes(A, B)
-    scale = s / np.square(norm(A))
-    B_approx = scale * np.dot(A, R) + B_mu
-    assert_allclose(B_approx, B_orig)
-    assert_allclose(B / norm(B), B_standardized)
-
-
-def test_empty():
-    a = np.empty((0, 0))
-    r, s = orthogonal_procrustes(a, a)
-    assert_allclose(r, np.empty((0, 0)))
-
-    a = np.empty((0, 3))
-    r, s = orthogonal_procrustes(a, a)
-    assert_allclose(r, np.identity(3))
-
-
-@pytest.mark.parametrize('shape', [(4, 5), (5, 5), (5, 4)])
-def test_unitary(shape):
-    # gh-12071 added support for unitary matrices; check that it
-    # works as intended.
-    m, n = shape
-    rng = np.random.default_rng(589234981235)
-    A = rng.random(shape) + rng.random(shape) * 1j
-    Q = rng.random((n, n)) + rng.random((n, n)) * 1j
-    Q, _ = np.linalg.qr(Q)
-    B = A @ Q
-    R, scale = orthogonal_procrustes(A, B)
-    assert_allclose(R @ R.conj().T, np.eye(n), atol=1e-14)
-    assert_allclose(A @ Q, B)
-    if shape != (4, 5):  # solution is unique
-        assert_allclose(R, Q)
-    _, s, _ = svd(A.conj().T @ B)
-    assert_allclose(scale, np.sum(s))
+    @pytest.mark.parametrize('shape', [(4, 5), (5, 5), (5, 4)])
+    def test_unitary(self, shape, xp):
+        # gh-12071 added support for unitary matrices; check that it
+        # works as intended.
+        m, n = shape
+        rng = np.random.default_rng(589234981235)
+        A = xp.asarray(rng.random(shape) + rng.random(shape) * 1j)
+        Q = xp.asarray(rng.random((n, n)) + rng.random((n, n)) * 1j)
+        Q, _ = xp.linalg.qr(Q)
+        B = A @ Q
+        R, scale = orthogonal_procrustes(A, B)
+        xp_assert_close(R @ xp.conj(R).T, xp.eye(n, dtype=xp.complex128), atol=1e-14)
+        xp_assert_close(A @ Q, B)
+        if shape != (4, 5):  # solution is unique
+            xp_assert_close(R, Q)
+        _, s, _ = xp.linalg.svd(xp.conj(A).T @ B)
+        xp_assert_close(scale, xp.sum(s))

--- a/scipy/linalg/tests/test_procrustes.py
+++ b/scipy/linalg/tests/test_procrustes.py
@@ -140,7 +140,7 @@ class TestOrthogonalProcrustes:
         expected = xp.asarray([[3, 21], [-18, 0], [3, -21], [24, 0]], dtype=xp.float64)
         xp_assert_close(B_approx, expected, atol=1e-8)
         # Check disparity symmetry.
-        expected_disparity = xp.asarray(0.4501246882793018)
+        expected_disparity = xp.asarray(0.4501246882793018, dtype=xp.float64)
         AB_disparity = (xp.linalg.matrix_norm(B_approx - B_orig)
                         / xp.linalg.matrix_norm(B))**2
         xp_assert_close(AB_disparity, expected_disparity)
@@ -173,7 +173,7 @@ class TestOrthogonalProcrustes:
         B_standardized = xp.asarray([[-0.13363062, 0.6681531],
                                      [-0.13363062, 0.13363062],
                                      [-0.13363062, -0.40089186],
-                                     [0.40089186, -0.40089186]])
+                                     [0.40089186, -0.40089186]], dtype=xp.float64)
         A, A_mu = _centered(A_orig, xp)
         B, B_mu = _centered(B_orig, xp)
         R, s = orthogonal_procrustes(A, B)

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -10,6 +10,7 @@ from scipy.linalg import solve_continuous_lyapunov, solve_discrete_lyapunov
 from scipy.linalg import solve_continuous_are, solve_discrete_are
 from scipy.linalg import block_diag, solve, LinAlgError
 from scipy.sparse._sputils import matrix
+from scipy.conftest import skip_xp_invalid_arg
 
 
 # dtypes for testing size-0 case following precedent set in gh-20295
@@ -109,6 +110,7 @@ class TestSolveLyapunov:
         assert_array_almost_equal(
                       np.dot(np.dot(a, x), a.conj().transpose()) - x, -1.0*q)
 
+    @skip_xp_invalid_arg
     def test_cases(self):
         for case in self.cases:
             self.check_continuous_case(case[0], case[1])


### PR DESCRIPTION
Adds array api support to `linalg.orthogonal_procrustes` since this is a pretty straightforward function. Also converts the utility function `_apply_over_batch`