### PR TITLE
DOC: interpolate: Ndbspline derivative methods list

### DIFF
--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -277,19 +277,20 @@ class NdBSpline:
 
         return new_c, new_t
 
-    def derivative(self, nu=1):
+    def derivative(self, nu):
         """
-        Construct a new NdBSpline representing the derivative.
+        Construct a new NdBSpline representing the partial derivative.
 
         Parameters
         ----------
         nu : array_like of shape (ndim,)
-            Order(s) of the derivative to compute along each dimension.
+            Orders of the partial derivatives to compute along each dimension.
 
         Returns
         -------
         NdBSpline
-            A new NdBSpline representing the derivative.
+            A new NdBSpline representing the partial derivative of the original spline.
+
         """
         nu_arr = np.asarray(nu, dtype=np.int64)
         ndim = len(self.t)
@@ -300,7 +301,7 @@ class NdBSpline:
                 f"ndim = {len(self.t)}.")
 
         if any(n < 0 for n in nu_arr):
-            raise ValueError(f"derivatives must be positive, got {nu = }")
+            raise ValueError(f"derivative orders must be positive, got {nu = }")
 
         t_new = list(self.t)
         k_new = list(self.k)

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -67,6 +67,7 @@ class NdBSpline:
     Methods
     -------
     __call__
+    derivative
     design_matrix
 
     See Also

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -300,7 +300,7 @@ class NdBSpline:
                 f"invalid number of derivative orders {nu = } for "
                 f"ndim = {len(self.t)}.")
 
-        if any(n < 0 for n in nu_arr):
+        if any(nu_arr < 0):
             raise ValueError(f"derivative orders must be positive, got {nu = }")
 
         t_new = list(self.t)


### PR DESCRIPTION
A follow-up to https://github.com/scipy/scipy/pull/23375 :

- add `.derivative` to the `Methods` listing
- remove the default `nu=1` since we now require that `nu` is an array-like of the correct length
- minor tweaks of  wording in the docstring and error messages.