### PR TITLE
ENH/BUG: signal.get_window: Refactor and allow '_periodic' and `_symmetric` suffix on window names.

### DIFF
--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -92,7 +92,7 @@ Filter design
                     -- defined as pass and stop bands.
    firwin2       -- Windowed FIR filter design, with arbitrary frequency
                     -- response.
-   firwin_2d        -- Windowed FIR filter design, with frequency response for 
+   firwin_2d        -- Windowed FIR filter design, with frequency response for
                     -- 2D using 1D design.
    freqs         -- Analog filter frequency response from TF coefficients.
    freqs_zpk     -- Analog filter frequency response from ZPK coefficients.
@@ -242,7 +242,7 @@ obtain these windows by name:
 .. autosummary::
    :toctree: generated/
 
-   get_window -- Return a window of a given length and type.
+   get_window -- Convenience function for creating various windows.
 
 Peak finding
 ============

--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -238,11 +238,11 @@ convolve2d_signature = convolve_signature
 correlate2d_signature = convolve_signature
 
 
-def coherence_signature(x, y, fs=1.0, window='hann', *args, **kwds):
+def coherence_signature(x, y, fs=1.0, window='hann_periodic', *args, **kwds):
     return array_namespace(x, y, _skip_if_str_or_tuple(window))
 
 
-def csd_signature(x, y, fs=1.0, window='hann', *args, **kwds):
+def csd_signature(x, y, fs=1.0, window='hann_periodic', *args, **kwds):
     return array_namespace(x, y, _skip_if_str_or_tuple(window))
 
 
@@ -250,19 +250,19 @@ def periodogram_signature(x, fs=1.0, window='boxcar'):
     return array_namespace(x, _skip_if_str_or_tuple(window))
 
 
-def welch_signature(x, fs=1.0, window='hann', *args, **kwds):
+def welch_signature(x, fs=1.0, window='hann_periodic', *args, **kwds):
     return array_namespace(x, _skip_if_str_or_tuple(window))
 
 
-def spectrogram_signature(x, fs=1.0, window=('tukey', 0.25), *args, **kwds):
+def spectrogram_signature(x, fs=1.0, window=('tukey_periodic', 0.25), *args, **kwds):
     return array_namespace(x, _skip_if_str_or_tuple(window))
 
 
-def stft_signature(x, fs=1.0, window='hann', *args, **kwds):
+def stft_signature(x, fs=1.0, window='hann_periodic', *args, **kwds):
     return array_namespace(x, _skip_if_str_or_tuple(window))
 
 
-def istft_signature(Zxx, fs=1.0, window='hann', *args, **kwds):
+def istft_signature(Zxx, fs=1.0, window='hann_periodic', *args, **kwds):
     return array_namespace(Zxx, _skip_if_str_or_tuple(window))
 
 
@@ -423,7 +423,7 @@ tf2zpk_signature = lp2bp_signature
 tf2sos_signature = lp2bp_signature
 
 normalize_signature = lp2bp_signature
-residue_signature = lp2bp_signature 
+residue_signature = lp2bp_signature
 residuez_signature = residue_signature
 
 
@@ -562,4 +562,3 @@ def wiener_signature(im, mysize=None, noise=None):
 
 def zoom_fft_signature(x, fn, m=None, *, fs=2, endpoint=False, axis=-1):
     return array_namespace(x, fn)
-

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -9,7 +9,7 @@ from scipy.fft import irfft, fft, ifft
 from scipy.linalg import (toeplitz, hankel, solve, LinAlgError, LinAlgWarning,
                           lstsq)
 from scipy.signal._arraytools import _validate_fs
-
+from .windows import get_window
 from . import _sigtools
 
 from scipy._lib._array_api import array_namespace, xp_size, xp_default_dtype
@@ -271,13 +271,13 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
         Nyquist frequency.
     cutoff : float or 1-D array_like
         Cutoff frequency of filter (expressed in the same units as `fs`)
-        OR an array of cutoff frequencies (that is, band edges). In the 
-        former case, as a float, the cutoff frequency should correspond 
-        with the half-amplitude point, where the attenuation will be -6dB. 
-        In the latter case, the frequencies in `cutoff` should be positive 
-        and monotonically increasing between 0 and `fs/2`. The values 0 
-        and `fs/2` must not be included in `cutoff`. It should be noted 
-        that this is different than the behavior of `scipy.signal.iirdesign`, 
+        OR an array of cutoff frequencies (that is, band edges). In the
+        former case, as a float, the cutoff frequency should correspond
+        with the half-amplitude point, where the attenuation will be -6dB.
+        In the latter case, the frequencies in `cutoff` should be positive
+        and monotonically increasing between 0 and `fs/2`. The values 0
+        and `fs/2` must not be included in `cutoff`. It should be noted
+        that this is different from the behavior of `scipy.signal.iirdesign`,
         where the cutoff is the half-power point (-3dB).
     width : float or None, optional
         If `width` is not None, then assume it is the approximate width
@@ -285,8 +285,10 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
         for use in Kaiser FIR filter design. In this case, the `window`
         argument is ignored.
     window : string or tuple of string and parameter values, optional
-        Desired window to use. See `scipy.signal.get_window` for a list
-        of windows and required parameters.
+        Desired window to use. Default is ``'hamming'``. The window will be symmetric,
+        unless a suffix ``'_periodic'`` is appended to the window name (e.g.,
+        ``'hamming_perodic'``) Consult `~scipy.signal.get_window` for a list of windows
+        and required parameters.
     pass_zero : {True, False, 'bandpass', 'lowpass', 'highpass', 'bandstop'}, optional
         If True, the gain at the frequency 0 (i.e., the "DC gain") is 1.
         If False, the DC gain is 0. Can also be a string argument for the
@@ -452,7 +454,6 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
         h -= left * xpx.sinc(left * m, xp=xp)
 
     # Get and apply the window function.
-    from .windows import get_window
     win = get_window(window, numtaps, fftbins=False, xp=xp)
     h *= win
 
@@ -508,9 +509,10 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
         power of 2 that is not less than `numtaps`. `nfreqs` must be greater
         than `numtaps`.
     window : string or (string, float) or float, or None, optional
-        Window function to use. Default is "hamming". See
-        `scipy.signal.get_window` for the complete list of possible values.
-        If None, no window function is applied.
+        Desired window to use. Default is ``'hamming'``. The window will be symmetric,
+        unless a suffix ``'_periodic'`` is appended to the window name (e.g.,
+        ``'hamming_perodic'``) Consult `~scipy.signal.get_window` for a list of windows
+        and required parameters. If ``None``, no window function is applied.
     antisymmetric : bool, optional
         Whether resulting impulse response is symmetric/antisymmetric.
         See Notes for more details.
@@ -664,7 +666,6 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
 
     if window is not None:
         # Create the window to apply to the filter coefficients.
-        from .windows import get_window
         wind = get_window(window, numtaps, fftbins=False, xp=xp)
     else:
         wind = 1
@@ -1322,7 +1323,7 @@ def firwin_2d(hsize, window, *, fc=None, fs=2, circular=False,
     filter. The filter is separable with linear phase; it will be designed
     as a product of two 1D filters with dimensions defined by `hsize`.
     Additionally, it can create approximately circularly symmetric 2-D windows.
-    
+
     Parameters
     ----------
     hsize : tuple or list of length 2
@@ -1330,17 +1331,18 @@ def firwin_2d(hsize, window, *, fc=None, fs=2, circular=False,
         number of coefficients in the row direction and `hsize[1]` specifies
         the number of coefficients in the column direction.
     window : tuple or list of length 2 or string
-        Desired window to use for each 1D filter or a single window type 
-        for creating circularly symmetric 2-D windows. Each element should be
-        a string or tuple of string and parameter values. See
-        `~scipy.signal.get_window` for a list of windows and required
-        parameters.
+        Desired window to use for each 1D filter or a single window type for creating
+        circularly symmetric 2-D windows. Each element should be a string or tuple of
+        string and parameter values. The generated windows will be symmetric, unless a
+        suffix ``'_periodic'`` is appended to the window name (e.g.,
+        ``'hamming_perodic'``). Consult `~scipy.signal.get_window` for a list of windows
+        and required parameters.
     fc : float or 1-D array_like, optional
         Cutoff frequency of the filter in the same units as `fs`. This defines
         the frequency at which the filter's gain drops to approximately -6 dB
         (half power) in a low-pass or high-pass filter. For multi-band filters,
-        `fc` can be an array of cutoff frequencies (i.e., band edges) in the 
-        range [0, fs/2], with each band specified in pairs. Required if 
+        `fc` can be an array of cutoff frequencies (i.e., band edges) in the
+        range [0, fs/2], with each band specified in pairs. Required if
         `circular` is False.
     fs : float, optional
         The sampling frequency of the signal. Default is 2.
@@ -1349,17 +1351,17 @@ def firwin_2d(hsize, window, *, fc=None, fs=2, circular=False,
     pass_zero : {True, False, 'bandpass', 'lowpass', 'highpass', 'bandstop'}, optional
         This parameter is directly passed to `firwin` for each scalar frequency axis.
         Hence, if ``True``, the DC gain, i.e., the gain at frequency (0, 0), is 1.
-        If ``False``, the DC gain is 0 at frequency (0, 0) if `circular` is ``True``. 
+        If ``False``, the DC gain is 0 at frequency (0, 0) if `circular` is ``True``.
         If `circular` is ``False`` the frequencies (0, f1) and (f0, 0) will
         have gain 0.
-        It can also be a string argument for the desired filter type 
+        It can also be a string argument for the desired filter type
         (equivalent to ``btype`` in IIR design functions).
     scale : bool, optional
         This parameter is directly passed to `firwin` for each scalar frequency axis.
         Set to ``True`` to scale the coefficients so that the frequency
         response is exactly unity at a certain frequency on one frequency axis.
         That frequency is either:
-        
+
         - 0 (DC) if the first passband starts at 0 (i.e. pass_zero is ``True``)
         - `fs`/2 (the Nyquist frequency) if the first passband ends at `fs`/2
           (i.e., the filter is a single band highpass filter);
@@ -1438,9 +1440,9 @@ def firwin_2d(hsize, window, *, fc=None, fs=2, circular=False,
         if fc is None:
             raise ValueError("Cutoff frequency `fc` must be "
                              "provided when `circular` is True")
-        
+
         n_r = max(hsize[0], hsize[1]) * 8  # oversample 1d window by factor 8
-        
+
         win_r = firwin(n_r, cutoff=fc, window=window, fs=fs)
 
         f1, f2 = np.meshgrid(np.linspace(-1, 1, hsize[0]), np.linspace(-1, 1, hsize[1]))

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -571,10 +571,12 @@ class ShortTimeFFT:
             Window overlap in samples. It relates to the `hop` increment by
             ``hop = npsereg - noverlap``.
         symmetric_win: bool
-            If ``True`` then a symmetric window is generated, else a periodic
-            window is generated (default). Though symmetric windows seem for
-            most applications to be more sensible, the default of a periodic
-            windows was chosen to correspond to the default of `get_window`.
+            If ``True`` then a symmetric window is generated, else a periodic window is
+            generated (default). Though symmetric windows seem for most applications to
+            be more sensible, the default of a periodic windows was chosen to
+            correspond to the default of `get_window`. This parameter is ignored, if
+            the window name in the `window` parameter has a suffix ``'_periodic'`` or
+            ``'_symmetric'`` appended to it (e.g., ``'hann_symmetric'``).
         fft_mode : 'twosided', 'centered', 'onesided', 'onesided2X'
             Mode of FFT to be used (default 'onesided').
             See property `fft_mode` for details.
@@ -598,7 +600,7 @@ class ShortTimeFFT:
 
         >>> from scipy.signal import ShortTimeFFT, get_window
         >>> nperseg = 9  # window length
-        >>> w = get_window(('gaussian', 2.), nperseg)
+        >>> w = get_window(('gaussian_periodic', 2.), nperseg)
         >>> fs = 128  # sampling frequency
         >>> hop = 3  # increment of STFT time slice
         >>> SFT0 = ShortTimeFFT(w, hop, fs=fs)

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1626,7 +1626,7 @@ def istft(Zxx, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length must be nperseg. Defaults
-        to a perodic Hann window. Must match the window used to generate the
+        to a periodic Hann window. Must match the window used to generate the
         STFT for faithful inversion.
     nperseg : int, optional
         Number of data points corresponding to each STFT segment. This

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -494,7 +494,7 @@ def periodogram(x, fs=1.0, window='boxcar', nfft=None, detrend='constant',
                  scaling=scaling, axis=axis)
 
 
-def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
+def welch(x, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=None,
           detrend='constant', return_onesided=True, scaling='density',
           axis=-1, average='mean'):
     r"""
@@ -517,7 +517,7 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length must be nperseg. Defaults
-        to a Hann window.
+        to a periodic Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
@@ -669,7 +669,7 @@ def welch(x, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     return freqs, Pxx.real
 
 
-def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
+def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=None,
         detrend='constant', return_onesided=True, scaling='density',
         axis=-1, average='mean'):
     r"""
@@ -690,7 +690,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length must be nperseg. Defaults
-        to a Hann window.
+        to a periodic Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
@@ -954,7 +954,7 @@ def csd(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     return SFT.f, Pxy
 
 
-def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
+def spectrogram(x, fs=1.0, window=('tukey_periodic', .25), nperseg=None, noverlap=None,
                 nfft=None, detrend='constant', return_onesided=True,
                 scaling='density', axis=-1, mode='psd'):
     """Compute a spectrogram with consecutive Fourier transforms (legacy function).
@@ -982,7 +982,7 @@ def spectrogram(x, fs=1.0, window=('tukey', .25), nperseg=None, noverlap=None,
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length must be nperseg.
-        Defaults to a Tukey window with shape parameter of 0.25.
+        Defaults to a periodic Tukey window with shape parameter of 0.25.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the
@@ -1410,7 +1410,7 @@ def check_NOLA(window, nperseg, noverlap, tol=1e-10):
     return np.min(binsums) > tol
 
 
-def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
+def stft(x, fs=1.0, window='hann_periodic', nperseg=256, noverlap=None, nfft=None,
          detrend=False, return_onesided=True, boundary='zeros', padded=True,
          axis=-1, scaling='spectrum'):
     r"""Compute the Short Time Fourier Transform (legacy function).
@@ -1437,7 +1437,7 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length must be nperseg. Defaults
-        to a Hann window.
+        to a periodic Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to 256.
     noverlap : int, optional
@@ -1601,7 +1601,7 @@ def stft(x, fs=1.0, window='hann', nperseg=256, noverlap=None, nfft=None,
     return freqs, time, Zxx
 
 
-def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
+def istft(Zxx, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=None,
           input_onesided=True, boundary=True, time_axis=-1, freq_axis=-2,
           scaling='spectrum'):
     r"""Perform the inverse Short Time Fourier transform (legacy function).
@@ -1626,7 +1626,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length must be nperseg. Defaults
-        to a Hann window. Must match the window used to generate the
+        to a perodic Hann window. Must match the window used to generate the
         STFT for faithful inversion.
     nperseg : int, optional
         Number of data points corresponding to each STFT segment. This
@@ -1903,7 +1903,7 @@ def istft(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None, nfft=None,
     return time, x
 
 
-def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
+def coherence(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None,
               nfft=None, detrend='constant', axis=-1):
     r"""
     Estimate the magnitude squared coherence estimate, Cxy, of
@@ -1928,7 +1928,7 @@ def coherence(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
         DFT-even by default. See `get_window` for a list of windows and
         required parameters. If `window` is array_like it will be used
         directly as the window and its length must be nperseg. Defaults
-        to a Hann window.
+        to a periodic Hann window.
     nperseg : int, optional
         Length of each segment. Defaults to None, but if window is str or
         tuple, is set to 256, and if window is array_like, is set to the

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -788,9 +788,11 @@ class TestGetWindow:
           entry characterizing the existence of window parameters as ``True``,
           ``False`` or ``'OPTIONAL'``.
 
-          It is checked that the key tuple contains the windo names contain the name of
-          the window function, and it is verified that the second entry in the value
-          tuple is either ``True``, ``False`` or ``'OPTIONAL'``.
+
+          It is verified that the correct window name (i.e., corresponding to the
+          function in the value tuple) is included in the key tuple. It is also checked
+          that the second entry in the value tuple is either ``True``, ``False`` or
+          ``'OPTIONAL'``.
           """
         for nn_, v_ in _WIN_FUNC_DATA.items():
             func_name = v_[0].__name__

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -8,6 +8,7 @@ from pytest import raises as assert_raises
 
 from scipy.fft import fft
 from scipy.signal import windows, get_window, resample
+from scipy.signal.windows._windows import _WIN_FUNC_DATA
 from scipy._lib._array_api import (
      xp_assert_close, xp_assert_equal, array_namespace, is_torch, is_jax, is_cupy,
      assert_array_almost_equal, SCIPY_DEVICE, is_numpy
@@ -777,6 +778,25 @@ class TestLanczos:
 
 
 class TestGetWindow:
+    """Unit test for `scipy.signal.get_windows`. """
+
+    def test_WIN_FUNC_DATA_integrity(self):
+        """Verify that the `_windows._WIN_FUNC_DATA` dict is consistent.
+
+          The keys of _WIN_FUNC_DATA are made of tuples of strings of allowed window
+          names. Its values are 2-tuples made up of the window function and a
+          entry characterizing the existence of window parameters as ``True``,
+          ``False`` or ``'OPTIONAL'``.
+
+          It is checked that the key tuple contains the windo names contain the name of
+          the window function, and it is verified that the second entry in the value
+          tuple is either ``True``, ``False`` or ``'OPTIONAL'``.
+          """
+        for nn_, v_ in _WIN_FUNC_DATA.items():
+            func_name = v_[0].__name__
+            msg = f"Function name in {nn_} does not contain name of actual function!"
+            assert func_name in nn_, msg
+            assert v_[1] in (True, False, 'OPTIONAL')
 
     def test_boxcar(self, xp):
         w = windows.get_window('boxcar', 12, xp=xp)
@@ -810,19 +830,54 @@ class TestGetWindow:
     def test_dpss(self, xp):
         win1 = windows.get_window(('dpss', 3), 64, fftbins=False, xp=xp)
         win2 = windows.dpss(64, 3, xp=xp)
-        assert_array_almost_equal(win1, win2, decimal=4)
+        xp_assert_equal(win1, win2)
 
     def test_kaiser_float(self, xp):
         win1 = windows.get_window(7.2, 64, xp=xp)
         win2 = windows.kaiser(64, 7.2, False, xp=xp)
-        xp_assert_close(win1, win2)
+        xp_assert_equal(win1, win2)
 
+    @pytest.mark.parametrize('Nx', [-1, 3.0, np.float64(3)])
+    def test_invalid_parameter_NX(self, Nx, xp):
+        with pytest.raises(ValueError, match="^Parameter Nx=.*"):
+            windows.get_window('hann', Nx, xp=xp)
+
+    # noinspection PyTypeChecker
     def test_invalid_inputs(self, xp):
-        # Window is not a float, tuple, or string
-        assert_raises(ValueError, windows.get_window, set('hann'), 8, xp=xp)
+        """Raise all exceptions (except those concerning parameter `Nx`). """
+        with pytest.raises(ValueError, match="^Parameter fftbins=.*"):
+            windows.get_window('hann', 5, fftbins=1, xp=xp)
+        with pytest.raises(ValueError, match="^Parameter window=.*"):
+            windows.get_window(['hann',], 5, xp=xp)
+        with pytest.raises(ValueError, match="^First tuple entry of parameter win.*"):
+            windows.get_window((42,), 5, xp=xp)
+        with pytest.raises(ValueError, match="^Invalid window name 'INVALID'.*"):
+            windows.get_window('INVALID', 5, xp=xp)
+        with pytest.raises(ValueError, match="^'hann' does not allow parameters.*"):
+            windows.get_window(('hann', 1), 5, xp=xp)
+        with pytest.raises(ValueError, match="^'kaiser' must have parameters.*"):
+            windows.get_window('kaiser', 5, xp=xp)
+        with pytest.raises(ValueError, match="^Window dpss must have one.*"):
+            windows.get_window(('dpss', 1, 2), 5, xp=xp)
+        with pytest.raises(ValueError, match="^'general_cosine' does not accept.*"):
+            xp_ = xp or np  # ensure parameter xp_ is not None
+            windows.get_window(('general cosine', [1, 2]), 5, xp=xp_)
 
-        # Unknown window type error
-        assert_raises(ValueError, windows.get_window, 'broken', 4, xp=xp)
+    def test_symmetric_periodic(self, xp):
+        """Ensure that suffixes `_periodic` and `_symmetric` work for window names. """
+        w_sym = windows.bartlett(5, sym=True, xp=xp)
+        xp_assert_close(get_window('bartlett', 5, fftbins=False, xp=xp), w_sym)
+        xp_assert_close(get_window('bartlett_symmetric', 5, xp=xp), w_sym)
+        # overwrite parameter `fftbins`:
+        xp_assert_close(get_window('bartlett_symmetric', 5, fftbins=True, xp=xp), w_sym)
+
+        w_per = windows.bartlett(5, sym=False, xp=xp)
+        xp_assert_close(get_window('bartlett', 5, xp=xp), w_per)
+        xp_assert_close(get_window('bartlett', 5, fftbins=True, xp=xp), w_per)
+        xp_assert_close(get_window('bartlett_periodic', 5, xp=xp), w_per)
+        # overwrite parameter `fftbins`:
+        xp_assert_close(get_window('bartlett_periodic', 5, fftbins=False, xp=xp),
+                        w_per)
 
     @xfail_xp_backends(np_only=True, reason='TODO: make resample array API ready')
     def test_array_as_window(self, xp):

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -9,7 +9,7 @@ The suite of window functions for filtering and spectral estimation.
 .. autosummary::
    :toctree: generated/
 
-   get_window              -- Return a window of a given length and type.
+   get_window              -- Convenience function for creating various windows.
 
    barthann                -- Bartlett-Hann window
    bartlett                -- Bartlett window

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -2360,8 +2360,8 @@ for nn_, v_ in _WIN_FUNC_DATA.items():
 def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
     r"""Convenience function for creating various windows.
 
-    This function is wrapper for the window functions provided in the
-    `scipy.signal.windows` name.space.
+    This function is a wrapper for the window functions provided in the
+    `scipy.signal.windows` namespace.
 
     Parameters
     ----------
@@ -2389,7 +2389,7 @@ def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
     Raises
     ------
     ValueError
-        If the provided parameters do not allow to choose a vali window function
+        If the provided parameters do not allow to choose a valid window function
         with valid parameters.
 
     Notes
@@ -2411,7 +2411,7 @@ def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
         Bartlett window (aliases: ``'bart', 'brt'``)
     `blackman`/ ``'blackman'``:
         Blackman window (aliases: ``'black', 'blk'``)
-    `blackman` / ``'blackmanharris'``:
+    `blackmanharris` / ``'blackmanharris'``:
         4-term Blackman-Harris window (aliases: ``'blackharr', 'bkh'``)
     `bohman` / ``'bohman'``:
         Bohman window (aliases: ``'bman', 'bmn'``)
@@ -2452,7 +2452,7 @@ def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
     `lanczos` / ``'lanczos'``:
         Lanczos / sinc window (aliases: ``'sinc'``)
     `nuttall`/ ``'nuttall'``:
-        Minimum 4-term Blackman-Harris window according to Nuttal
+        Minimum 4-term Blackman-Harris window according to Nuttall
         (aliases: ``'nutl', 'nut'``)
     `parzen` / ``'parzen'``:
         Parzen window (aliases: ``'parz', 'par'``)
@@ -2469,7 +2469,7 @@ def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
 
     Examples
     --------
-    This example shows a different usages of the `window` parameter:
+    This example shows different usages of the `window` parameter:
 
     >>> from scipy.signal import get_window
     >>> get_window('triang', 7)

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -1,6 +1,7 @@
 """The suite of window functions."""
 
 import math
+import numbers
 import operator
 import warnings
 from scipy._lib import doccer
@@ -2323,173 +2324,240 @@ def _fftautocorr(x):
     #                   for xx, yy in zip(x, x)])[:, N-1:2*N-1]
     return cxy
 
-
-_win_equiv_raw = {
+_WIN_FUNC_DATA = { # Format: {(name0, name1, ...): (function, needs parameters)
     ('barthann', 'brthan', 'bth'): (barthann, False),
     ('bartlett', 'bart', 'brt'): (bartlett, False),
     ('blackman', 'black', 'blk'): (blackman, False),
     ('blackmanharris', 'blackharr', 'bkh'): (blackmanharris, False),
     ('bohman', 'bman', 'bmn'): (bohman, False),
-    ('boxcar', 'box', 'ones',
-        'rect', 'rectangular'): (boxcar, False),
+    ('boxcar', 'box', 'ones', 'rect', 'rectangular'): (boxcar, False),
     ('chebwin', 'cheb'): (chebwin, True),
     ('cosine', 'halfcosine'): (cosine, False),
     ('dpss',): (dpss, True),
-    ('exponential', 'poisson'): (exponential, False),
+    ('exponential', 'poisson'): (exponential, 'OPTIONAL'),
     ('flattop', 'flat', 'flt'): (flattop, False),
     ('gaussian', 'gauss', 'gss'): (gaussian, True),
     ('general cosine', 'general_cosine'): (general_cosine, True),
-    ('general gaussian', 'general_gaussian',
-        'general gauss', 'general_gauss', 'ggs'): (general_gaussian, True),
+    ('general gaussian', 'general_gaussian', 'general gauss',
+     'general_gauss', 'ggs'): (general_gaussian, True),
     ('general hamming', 'general_hamming'): (general_hamming, True),
     ('hamming', 'hamm', 'ham'): (hamming, False),
     ('hann', 'han'): (hann, False),
     ('kaiser', 'ksr'): (kaiser, True),
-    ('kaiser bessel derived', 'kbd'): (kaiser_bessel_derived, True),
+    ('kaiser bessel derived', 'kaiser_bessel_derived',
+     'kbd'): (kaiser_bessel_derived, True),
     ('lanczos', 'sinc'): (lanczos, False),
     ('nuttall', 'nutl', 'nut'): (nuttall, False),
     ('parzen', 'parz', 'par'): (parzen, False),
-    ('taylor', 'taylorwin'): (taylor, False),
+    ('taylor', 'taylorwin'): (taylor, 'OPTIONAL'),
     ('triangle', 'triang', 'tri'): (triang, False),
-    ('tukey', 'tuk'): (tukey, False),
-}
-
-# Fill dict with all valid window name strings
-_win_equiv = {}
-for k, v in _win_equiv_raw.items():
-    for key in k:
-        _win_equiv[key] = v[0]
-
-# Keep track of which windows need additional parameters
-_needs_param = set()
-for k, v in _win_equiv_raw.items():
-    if v[1]:
-        _needs_param.update(k)
+    ('tukey', 'tuk'): (tukey, 'OPTIONAL'), }
+_WIN_FUNCS = dict()
+for nn_, v_ in _WIN_FUNC_DATA.items():
+    _WIN_FUNCS.update({n_: v_ for n_ in nn_})
 
 
 def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
-    """
-    Return a window of a given length and type.
+    r"""Convenience function for creating various windows.
+
+    This function is wrapper for the window functions provided in the
+    `scipy.signal.windows` name.space.
 
     Parameters
     ----------
-    window : string, float, or tuple
-        The type of window to create. See below for more details.
+    window : str | tuple | float
+        Either a string with the window name or a tuple consisting of window name and
+        window parameters. If it is a float, a `~scipy.singal.kaiser` window is
+        created with `window` being the shape parameter. Consult the Notes below for
+        more details.
     Nx : int
         The number of samples in the window.
     fftbins : bool, optional
-        If True (default), create a "periodic" window, ready to use with
-        `ifftshift` and be multiplied by the result of an FFT (see also
-        :func:`~scipy.fft.fftfreq`).
-        If False, create a "symmetric" window, for use in filter design.
+        If ``True`` (default), create a periodic window, ready to use with `ifftshift`
+        and be multiplied by the result of an FFT (see also
+        :func:`~scipy.fft.fftfreq`). If ``False``, create a symmetric window, for use
+        in filter design. This parameter is ignored, if the window name in the
+        `window` parameter has a suffix ``'_periodic'`` or ``'_symmetric'`` appended to
+        it (e.g., ``'hann_symmetric'``).
     %(xp_device_snippet)s
 
     Returns
     -------
     get_window : ndarray
-        Returns a window of length `Nx` and type `window`
+        Returns the created window as a one-dimensional array made of `Nx` samples.
+
+    Raises
+    ------
+    ValueError
+        If the provided parameters do not allow to choose a vali window function
+        with valid parameters.
 
     Notes
     -----
-    Window types:
+    Note that by default this function returns a periodic window, whereas the wrapped
+    window functions return a symmetric window by default. This is caused by the
+    `fftbins` parameter having the inverse meaning of the `sym` parameter of the
+    wrapped function, which are both ``True`` by default.
 
-    - `~scipy.signal.windows.boxcar`
-    - `~scipy.signal.windows.triang`
-    - `~scipy.signal.windows.blackman`
-    - `~scipy.signal.windows.hamming`
-    - `~scipy.signal.windows.hann`
-    - `~scipy.signal.windows.bartlett`
-    - `~scipy.signal.windows.flattop`
-    - `~scipy.signal.windows.parzen`
-    - `~scipy.signal.windows.bohman`
-    - `~scipy.signal.windows.blackmanharris`
-    - `~scipy.signal.windows.nuttall`
-    - `~scipy.signal.windows.barthann`
-    - `~scipy.signal.windows.cosine`
-    - `~scipy.signal.windows.exponential`
-    - `~scipy.signal.windows.tukey`
-    - `~scipy.signal.windows.taylor`
-    - `~scipy.signal.windows.lanczos`
-    - `~scipy.signal.windows.kaiser` (needs beta)
-    - `~scipy.signal.windows.kaiser_bessel_derived` (needs beta)
-    - `~scipy.signal.windows.gaussian` (needs standard deviation)
-    - `~scipy.signal.windows.general_cosine` (needs weighting coefficients)
-    - `~scipy.signal.windows.general_gaussian` (needs power, width)
-    - `~scipy.signal.windows.general_hamming` (needs window coefficient)
-    - `~scipy.signal.windows.dpss` (needs normalized half-bandwidth)
-    - `~scipy.signal.windows.chebwin` (needs attenuation)
+    .. currentmodule:: scipy.signal.windows
 
+    The following list shows the wrapped window functions with the respective settings
+    of the `window` parameter followed by a short description. Aliases for alternative
+    window names are given in parenthesis.
 
-    If the window requires no parameters, then `window` can be a string.
+    `barthann` / ``'barthann'``:
+        Modified Bartlett-Hann window (aliases: ``'brthan', 'bth'``)
+    `bartlett` / ``'bartlett'``:
+        Bartlett window (aliases: ``'bart', 'brt'``)
+    `blackman`/ ``'blackman'``:
+        Blackman window (aliases: ``'black', 'blk'``)
+    `blackman` / ``'blackmanharris'``:
+        4-term Blackman-Harris window (aliases: ``'blackharr', 'bkh'``)
+    `bohman` / ``'bohman'``:
+        Bohman window (aliases: ``'bman', 'bmn'``)
+    `boxcar` / ``'boxcar'``:
+        Rectangular window (aliases: ``'box', 'ones', 'rect', 'rectangular'``)
+    `chebwin` / ``('chebwin', at)``:
+        Dolph-Chebyshev window with `at` dB attenuation (aliases: ``'cheb'``)
+    `cosine` / ``'cosine'``:
+        Cosine window (aliases: ``'halfcosine'``)
+    `dpss` / ``('dpss', NW)``:
+        First window of discrete prolate spheroidal sequence with standardized half
+        bandwidth ``NW`` and "approximate" norm.
+    `exponential` / ``'exponential'`` / ``('exponential', center, tau)``:
+        Exponential / Poisson window centered at ``center`` (default: ``None``) with
+        deacy ``tau`` (default: ``1``) (aliases: ``'poisson'``)
+    `flattop`/ ``'flattop'``:
+        Flat top window (aliases: ``'flat', 'flt'``)
+    `gaussian` / ``('gaussian', std)``:
+        Gaussian with standard deviation `std` (aliases: ``'gauss', 'gss'``)
+    `general_cosine` / ``('general cosine', a)``:
+        Generic weighted sum of cosine terms with weighting coefficients ``a``
+        (aliases: ``'general_cosine'``)
+    `general_gaussian` / ``('general gaussian', p, sig)``:
+        Generalized Gaussian with shape parameter ``p`` and standard deviation ``sig``
+        (aliases: ``'general_gaussian', 'general gauss', 'general_gauss', 'ggs'``)
+    `general_hamming` / ``('general hamming', alpha)``:
+        Generalized Hamming window with coefficent ``alpha``
+        (aliases: ``'general_hamming'``)
+    `hamming` / ``'hamming'``:
+        Hamming window (aliases: ``'hamm', 'ham'``)
+    `hann` / ``'hann'``:
+        Hann window (aliases: ``'han'``)
+    `kaiser` / ``('kaiser', beta)``:
+        Kaiser window with shape parameter ``beta`` (aliases: ``'ksr'``)
+    `kaiser_bessel_derived` / ``('kaiser bessel derived', beta)``:
+        Kaiser-Bessel derived window with shape parameter ``beta``
+        (aliases: ``'kaiser_bessel_derived', 'kbd'``)
+    `lanczos` / ``'lanczos'``:
+        Lanczos / sinc window (aliases: ``'sinc'``)
+    `nuttall`/ ``'nuttall'``:
+        Minimum 4-term Blackman-Harris window according to Nuttal
+        (aliases: ``'nutl', 'nut'``)
+    `parzen` / ``'parzen'``:
+        Parzen window (aliases: ``'parz', 'par'``)
+    `taylor` / ``'taylor'`` / (``'taylor', nbar, sll, norm)``:
+        Taylor window with ``nbar`` adjascent sidelobes (default: ``4``)), ``sll`` dB
+        suppression level (default: ``30``) and boolean value ``norm``
+        (default: ``True``) (aliases: ``taylorwin``)
+    `triang`/ ``'triangle'``:
+        Triangle window (aliases: ``'triang', 'tri'``)
+    `tukey` / ``'tukey'`` / ``('tukey', alpha)``:
+        Tukey window with shape parameter ``alpha`` (default: ``0.5``)
+        (aliases: ``'tuk'``)
 
-    If the window requires parameters, then `window` must be a tuple
-    with the first argument the string name of the window, and the next
-    arguments the needed parameters.
-
-    If `window` is a floating point number, it is interpreted as the beta
-    parameter of the `~scipy.signal.windows.kaiser` window.
-
-    Each of the window types listed above is also the name of
-    a function that can be called directly to create a window of
-    that type.
 
     Examples
     --------
-    >>> from scipy import signal
-    >>> signal.get_window('triang', 7)
+    This example shows a different usages of the `window` parameter:
+
+    >>> from scipy.signal import get_window
+    >>> get_window('triang', 7)
     array([ 0.125,  0.375,  0.625,  0.875,  0.875,  0.625,  0.375])
-    >>> signal.get_window(('kaiser', 4.0), 9)
-    array([ 0.08848053,  0.29425961,  0.56437221,  0.82160913,  0.97885093,
-            0.97885093,  0.82160913,  0.56437221,  0.29425961])
-    >>> signal.get_window(('exponential', None, 1.), 9)
+    >>> get_window(('exponential', None, 1.), 9)
     array([ 0.011109  ,  0.03019738,  0.082085  ,  0.22313016,  0.60653066,
             0.60653066,  0.22313016,  0.082085  ,  0.03019738])
-    >>> signal.get_window(4.0, 9)
+    >>> get_window(('kaiser', 4.0), 9)
+    array([ 0.08848053,  0.29425961,  0.56437221,  0.82160913,  0.97885093,
+            0.97885093,  0.82160913,  0.56437221,  0.29425961])
+    >>> get_window(4.0, 9)  # same as previous call
     array([ 0.08848053,  0.29425961,  0.56437221,  0.82160913,  0.97885093,
             0.97885093,  0.82160913,  0.56437221,  0.29425961])
 
+    The following snippet shows different ways to create identical symmetric and
+    periodic Bartlett windows:
+
+    >>> from scipy.signal import get_window, windows
+    >>> # Symmetric window:
+    >>> windows.bartlett(5)  # Parameter `sym` defaults to True
+    array([0. , 0.5, 1. , 0.5, 0. ])
+    >>> get_window('bartlett', 5, fftbins=False)
+    array([0. , 0.5, 1. , 0.5, 0. ])
+    >>> get_window('bartlett_symmetric', 5)
+    array([0. , 0.5, 1. , 0.5, 0. ])
+    >>> # Periodic window:
+    >>> windows.bartlett(4, sym=False)
+    array([0. , 0.5, 1. , 0.5])
+    >>> get_window('bartlett', 4)  # Parameter `fftbins` defaults to True
+    array([0. , 0.5, 1. , 0.5])
+    >>> get_window('bartlett_periodic', 4)
+    array([0. , 0.5, 1. , 0.5])
+    >>> # `_periodic' suffix overrides `fftbins` parameter:
+    >>> get_window('bartlett_periodic', 4, fftbins=False)
+    array([0. , 0.5, 1. , 0.5])
+
+    Note that a periodic window can be created out of a symmetric window by discarding
+    the last sample.
     """
+    if not (Nx > 0 and isinstance(Nx, numbers.Integral)):
+        raise ValueError(f"Parameter {Nx=} is not a positive integer")
+    if not isinstance(fftbins, bool):
+        raise ValueError(f"Parameter {fftbins=} is not of type bool!")
+
+    if not isinstance(window, str | tuple):
+        try: # if parameter window can be converted to a float, return kaiser window:
+            beta = float(window)
+        except Exception as float_exception:
+            err_msg = f"Parameter {window=} must be a tuple, a string or a float!"
+            raise ValueError(err_msg) from float_exception
+        return kaiser(Nx, beta, not fftbins, xp=xp, device=device)
+
+    if isinstance(window, tuple) and not isinstance(window[0], str):
+        raise ValueError(f"First tuple entry of parameter {window=} is not a str!")
+
     sym = not fftbins
-    try:
-        beta = float(window)
-    except (TypeError, ValueError) as e:
-        args = ()
-        if isinstance(window, tuple):
-            winstr = window[0]
-            if len(window) > 1:
-                args = window[1:]
-        elif isinstance(window, str):
-            if window in _needs_param:
-                raise ValueError("The '" + window + "' window needs one or "
-                                 "more parameters -- pass a tuple.") from e
-            else:
-                winstr = window
-        else:
-            raise ValueError(
-                f"{str(type(window))} as window type is not supported.") from e
+    win_name = window if isinstance(window, str) else window[0]
+    if win_name.endswith('_symmetric'):  # overwrite `fftbins` / `sym` if needed
+        sym, win_name = True, win_name[:-10]  # remove '_symmetric' from `win_name`
+    elif win_name.endswith('_periodic'):
+        sym, win_name = False, win_name[:-9]  # remove '_periodic' from `win_name`
 
-        if winstr == 'general_cosine' and (xp is not None or device is not None):
-            raise ValueError(
-                'general_cosine window does not accept xp and device kwargs '
-            )
+    if win_name not in _WIN_FUNCS:
+        raise ValueError(f"Invalid window name '{win_name}' in parameter {window=}!")
 
-        try:
-            winfunc = _win_equiv[winstr]
-        except KeyError as e:
-            raise ValueError("Unknown window type.") from e
+    func, has_args = _WIN_FUNCS[win_name]
+    args = window[1:] if isinstance(window, tuple) else tuple()
+    if len(args) > 0 and has_args is False:
+        raise ValueError(f"'{win_name}' does not allow parameters, but {window=}!")
+    if len(args) == 0 and has_args is True:
+        raise ValueError(f"'{win_name}' must have parameters, but {window=}!")
+    # has_args == 'OPTIONAL' allows len(args) == 0 as well as len(args) > 0
 
-        if winfunc is dpss:
-            params = (Nx,) + args + (None,)
-        else:
-            params = (Nx,) + args
-    else:
-        winfunc = kaiser
-        params = (Nx, beta)
+    if not has_args:
+        return func(Nx, sym=sym, xp=xp, device=device)
 
-    if winfunc == general_cosine:
-        return winfunc(*params, sym=sym)
-    else:
-        return winfunc(*params, sym=sym, xp=xp, device=device)
+    # special cases taken from original implementation:
+    if func is dpss:
+        if len(args) != 1:
+            raise ValueError(f"Window {win_name} must have one parameter but {window=}")
+        return dpss(Nx, args[0], Kmax=None, sym=sym, xp=xp, device=device)
+    if func is general_cosine:
+        if not (xp is None and device is None):
+            raise ValueError("'general_cosine' does not accept the parameters xp " +
+                             "and device not being None!")
+        return general_cosine(Nx, *args, sym=sym)
+
+    return func(Nx, *args, sym=sym, xp=xp, device=device)
 
 
 ########## complete the docstrings, on import
@@ -2510,4 +2578,3 @@ _names = [x for x in __all__ if x != 'general_cosine']
 for name in _names:
     window = vars()[name]
     window.__doc__ = doccer.docformat(window.__doc__, _xp_device_snippet)
-


### PR DESCRIPTION
To make symmetric and periodic windows more distinguishable, the `window` parameter of `get_window` allows now the window name instead of only being `hann` also to be `hann_periodic` and `hann_symmetric`, which overrides the `fftbin` parameter.

This benefits the functions `coherence`, `csd`, `periodogram`, `welch`, `spectrogram`, `stft`, `istft`, `resample`,  `resample_poly`, `firwin`, `firwin2`, `firwin_2d`, `check_COLA` and `check_NOLA` which utilize `get_window` but do not expose the `fftbin` parameter. Where applicable the suffixes have been added to the default values and the docstr have been updated, like `welch(window='hann_periodic', ...)`.

Furthermore:
* Expanded and improved docstr of `get_window` with focus on clarifying the difference between using symmetric and periodic windows.
* Refactored `get_window` to provide more thorough error handling and more informative error messages.
* Miscellaneous small improvements

Closes #13671, Closes #23449.

