### PR TITLE
BUG: shgo mutating user supplied dictionaries

### DIFF
--- a/scipy/optimize/_shgo.py
+++ b/scipy/optimize/_shgo.py
@@ -496,6 +496,12 @@ class SHGO:
             raise ValueError(("Unknown sampling_method specified."
                               " Valid methods: {}").format(', '.join(methods)))
 
+        # copy the options dictionaries so that the user input is not mutated
+        if minimizer_kwargs is not None and isinstance(minimizer_kwargs, dict):
+            minimizer_kwargs = minimizer_kwargs.copy()
+        if options is not None and isinstance(options, dict):
+            options = options.copy()
+
         if options is not None and options.get('jac', None) is True:
             if minimizer_kwargs is None:
                 minimizer_kwargs = {}

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -834,13 +834,18 @@ class TestShgoArguments:
         def func(x):
             return np.sum(np.power(x, 2)), 2 * x
 
+        min_kwds = {"method": "SLSQP", "jac": True}
+        opt_kwds = {"jac": True}
         shgo(
             func,
             bounds=[[-1, 1], [1, 2]],
             n=100, iters=5,
             sampling_method="sobol",
-            minimizer_kwargs={'method': 'SLSQP', 'jac': True}
+            minimizer_kwargs=min_kwds,
+            options=opt_kwds
         )
+        assert min_kwds['jac'] is True
+        assert "jac" in opt_kwds
 
         # new
         def func(x):


### PR DESCRIPTION
Whilst investigating #23517 it became apparent that `shgo` is mutating user supplied dictionaries, which is a no-no. This PR adds a fix and test.