### PR TITLE
MAINT: Use reshape instead of setting the shape attribute for numpy arrays

### DIFF
--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -187,7 +187,7 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
     fp = o['fp']
     n = len(t)
     u = o['u']
-    c.shape = idim, n - k - 1
+    c = c.reshape((idim, n - k - 1))
     tcku = [t, list(c), k], u
     if ier <= 0 and not quiet:
         warnings.warn(
@@ -693,7 +693,7 @@ def bisplev(x, y, tck, dx=0, dy=0):
         raise ValueError("Invalid input data")
     if ier:
         raise TypeError("An error occurred")
-    z.shape = len(x), len(y)
+    z = z.reshape((len(x), len(y)))
     if len(z) > 1:
         return z
     if len(z[0]) > 1:

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2507,7 +2507,7 @@ def _ppoly_eval_2(coeffs, breaks, xnew, fill=np.nan):
     V = np.vander(diff, N=K)
     values = np.array([np.dot(V[k, :], pp[:, indxs[k]]) for k in range(len(xx))])
     res[mask] = values
-    res.shape = saveshape
+    res = res.reshape(saveshape)
     return res
 
 

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -38,7 +38,7 @@ pytestmark = pytest.mark.thread_unsafe
 def mlarr(*args, **kwargs):
     """Convenience function to return matlab-compatible 2-D array."""
     arr = np.array(*args, **kwargs)
-    arr.shape = matdims(arr)
+    arr = arr.reshape(matdims(arr))
     return arr
 
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1274,7 +1274,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
         # This is the same tolerance as used in np.linalg.matrix_rank.
         tol = abs_fc.max(axis=-1) * nc * np.finfo(np.float64).eps
         if tol.shape != ():
-            tol.shape = tol.shape + (1,)
+            tol = tol.reshape(tol.shape + (1,))
         else:
             tol = np.atleast_1d(tol)
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2765,7 +2765,7 @@ def test_aligned_mem_float():
 
     # Create an array with boundary offset 4
     z = np.frombuffer(a.data, offset=2, count=100, dtype=float32)
-    z.shape = 10, 10
+    z = z.reshape((10, 10))
 
     eig(z, overwrite_a=True)
     eig(z.T, overwrite_a=True)
@@ -2780,7 +2780,7 @@ def test_aligned_mem():
 
     # Create an array with boundary offset 4
     z = np.frombuffer(a.data, offset=4, count=100, dtype=float)
-    z.shape = 10, 10
+    z = z.reshape((10, 10))
 
     eig(z, overwrite_a=True)
     eig(z.T, overwrite_a=True)
@@ -2793,7 +2793,7 @@ def test_aligned_mem_complex():
 
     # Create an array with boundary offset 8
     z = np.frombuffer(a.data, offset=8, count=100, dtype=complex)
-    z.shape = 10, 10
+    z = z.reshape((10, 10))
 
     eig(z, overwrite_a=True)
     # This does not need special handling
@@ -2809,7 +2809,7 @@ def check_lapack_misaligned(func, args, kwargs):
             aa = np.zeros(a[i].size*a[i].dtype.itemsize+8, dtype=np.uint8)
             aa = np.frombuffer(aa.data, offset=4, count=a[i].size,
                                dtype=a[i].dtype)
-            aa.shape = a[i].shape
+            aa = aa.reshape(a[i].shape)
             aa[...] = a[i]
             a[i] = aa
             func(*a, **kwargs)
@@ -2822,11 +2822,10 @@ def check_lapack_misaligned(func, args, kwargs):
                    reason="Ticket #1152, triggers a segfault in rare cases.")
 def test_lapack_misaligned():
     M = np.eye(10, dtype=float)
-    R = np.arange(100)
-    R.shape = 10, 10
+    R = np.arange(100).reshape((10, 10))
     S = np.arange(20000, dtype=np.uint8)
     S = np.frombuffer(S.data, offset=4, count=100, dtype=float)
-    S.shape = 10, 10
+    S = S.reshape((10, 10))
     b = np.ones(10)
     LU, piv = lu_factor(S)
     for (func, args, kwargs) in [

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1409,7 +1409,7 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
 
     x0 = asarray(x0).flatten()
     if x0.ndim == 0:
-        x0.shape = (1,)
+        x0 = x0.reshape((1,))
     if maxiter is None:
         maxiter = len(x0) * 200
 

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -989,7 +989,7 @@ def firls(numtaps, bands, desired, *, weight=None, fs=None):
         raise ValueError("bands must contain frequency pairs.")
     if (bands < 0).any() or (bands > 1).any():
         raise ValueError("bands must be between 0 and 1 relative to Nyquist")
-    bands.shape = (-1, 2)
+    bands = bands.reshape((-1, 2))
 
     # check remaining params
     desired = np.asarray(desired).flatten()
@@ -998,7 +998,7 @@ def firls(numtaps, bands, desired, *, weight=None, fs=None):
             f"desired must have one entry per frequency, got {desired.size} "
             f"gains for {bands.size} frequencies."
         )
-    desired.shape = (-1, 2)
+    desired = desired.reshape((-1, 2))
     if (np.diff(bands) <= 0).any() or (np.diff(bands[:, 0]) < 0).any():
         raise ValueError("bands must be monotonically nondecreasing and have "
                          "width > 0.")

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4940,10 +4940,10 @@ def sosfilt(sos, x, axis=-1, zi=None):
     zi = np.ascontiguousarray(np.reshape(zi, (-1, n_sections, 2)))
     sos = sos.astype(dtype, copy=False)
     _sosfilt(sos, x, zi)
-    x.shape = x_shape
+    x = x.reshape(x_shape)
     x = np.moveaxis(x, -1, axis)
     if return_zi:
-        zi.shape = zi_shape
+        zi = zi.reshape(zi_shape)
         zi = np.moveaxis(zi, (-2, -1), (0, axis + 1))
         out = (xp.asarray(x), xp.asarray(zi))
     else:
@@ -5055,7 +5055,7 @@ def sosfiltfilt(sos, x, axis=-1, padtype='odd', padlen=None):
     zi = sosfilt_zi(sos)  # shape (n_sections, 2) --> (n_sections, ..., 2, ...)
     zi_shape = [1] * x.ndim
     zi_shape[axis] = 2
-    zi.shape = [n_sections] + zi_shape
+    zi = zi.reshape([n_sections] + zi_shape)
     x_0 = axis_slice(ext, stop=1, axis=axis)
     (y, zf) = sosfilt(sos, ext, axis=axis, zi=zi * x_0)
     y_0 = axis_slice(y, start=-1, axis=axis)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3524,8 +3524,8 @@ def mood(x, y, axis=0, alternative="two-sided"):
         z = z[0]
         pval = pval[0]
     else:
-        z.shape = res_shape
-        pval.shape = res_shape
+        z = z.reshape(res_shape)
+        pval = pval.reshape(res_shape)
     return SignificanceResult(z[()], pval[()])
 
 

--- a/scipy/stats/_tukeylambda_stats.py
+++ b/scipy/stats/_tukeylambda_stats.py
@@ -96,7 +96,7 @@ def tukeylambda_variance(lam):
     if reg.size > 0:
         v[reg_mask] = (2.0 / reg**2) * (1.0 / (1.0 + 2 * reg) -
                                         beta(reg + 1, reg + 1))
-    v.shape = shp
+    v = v.reshape(shp)
     return v
 
 
@@ -195,5 +195,5 @@ def tukeylambda_kurtosis(lam):
 
     # The return value will be a numpy array; resetting the shape ensures that
     # if `lam` was a scalar, the return value is a 0-d array.
-    k.shape = shp
+    k = k.reshape(shp)
     return k

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1279,10 +1279,8 @@ class TestMood:
               0.00493777682814261, -2.45170638784613, 0.477237302613617,
               -0.596558168631403, 0.792203270299649, 0.289636710177348]
 
-        x1 = np.array(x1)
-        x2 = np.array(x2)
-        x1.shape = (10, 2)
-        x2.shape = (15, 2)
+        x1 = np.array(x1).reshape((10,2))
+        x2 = np.array(x2).reshape((15,2))
         assert_array_almost_equal(stats.mood(x1, x2, axis=None),
                                   [-1.31716607555, 0.18778296257])
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -541,7 +541,7 @@ class TestTrimming:
         assert_equal(trimx.count(), 48)
         assert_equal(trimx._mask, [1]*16 + [0]*34 + [1]*20 + [0]*14 + [1]*16)
         x._mask = nomask
-        x.shape = (10,10)
+        x = x.reshape((10,10))
         assert_equal(mstats.trimboth(x).count(), 60)
         assert_equal(mstats.trimtail(x).count(), 80)
 


### PR DESCRIPTION
We replace setting of the `shape` attribute with calls to `reshape(...)`. In this PR we only handle a part of the cases to keep the PR small for reviewers. In followup PRs we can handle the remaining cases.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Addresses part of #23522

#### What does this implement/fix?

Addresses (upcoming) deprecations from numpy. See https://github.com/numpy/numpy/issues/28800

<!--- #### Additional information --->
<!--Any additional information you think is important.-->
