### PR TITLE
MAINT: Use reshape instead of setting the shape attribute for numpy

### DIFF
--- a/scipy/interpolate/tests/test_fitpack.py
+++ b/scipy/interpolate/tests/test_fitpack.py
@@ -204,7 +204,7 @@ class TestSmokeTests:
         t2 = makepairs(tt[0], tt[1])
         v1 = bisplev(tt[0], tt[1], tck)
         v2 = f2(t2[0], t2[1])
-        v2.shape = len(tt[0]), len(tt[1])
+        v2 = v2.reshape(len(tt[0]), len(tt[1]))
 
         assert norm2(np.ravel(v1 - v2)) < 1e-2
 

--- a/scipy/interpolate/tests/test_rbf.py
+++ b/scipy/interpolate/tests/test_rbf.py
@@ -33,7 +33,7 @@ def check_rbf2d_interpolation(function):
     z = x*exp(-x**2-1j*y**2)
     rbf = Rbf(x, y, z, epsilon=2, function=function)
     zi = rbf(x, y)
-    zi.shape = x.shape
+    zi = zi.reshape(x.shape)
     assert_array_almost_equal(z, zi)
 
 
@@ -46,7 +46,7 @@ def check_rbf3d_interpolation(function):
     d = x*exp(-x**2 - y**2)
     rbf = Rbf(x, y, z, d, epsilon=2, function=function)
     di = rbf(x, y, z)
-    di.shape = x.shape
+    di = di.reshape(x.shape)
     assert_array_almost_equal(di, d)
 
 
@@ -79,7 +79,7 @@ def check_2drbf2d_interpolation(function):
     z = np.vstack([z0, z1]).T
     rbf = Rbf(x, y, z, epsilon=2, function=function, mode='N-D')
     zi = rbf(x, y)
-    zi.shape = z.shape
+    zi = zi.reshape(z.shape)
     assert_array_almost_equal(z, zi)
 
 
@@ -94,7 +94,7 @@ def check_2drbf3d_interpolation(function):
     d = np.vstack([d0, d1]).T
     rbf = Rbf(x, y, z, d, epsilon=2, function=function, mode='N-D')
     di = rbf(x, y, z)
-    di.shape = d.shape
+    di = di.reshape(d.shape)
     assert_array_almost_equal(di, d)
 
 

--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -2201,7 +2201,7 @@ def distance_transform_bf(input, metric="euclidean", sampling=None,
         ft = np.ravel(ft)
         for ii in range(tmp2.shape[0]):
             rtmp = np.ravel(tmp2[ii, ...])[ft]
-            rtmp.shape = tmp1.shape
+            rtmp = rtmp.reshape(tmp1.shape)
             tmp2[ii, ...] = rtmp
         ft = tmp2
 
@@ -2390,8 +2390,7 @@ def distance_transform_cdt(input, metric='chessboard', return_distances=True,
 
     rank = dt.ndim
     if return_indices:
-        ft = np.arange(dt.size, dtype=np.int32)
-        ft.shape = dt.shape
+        ft = np.arange(dt.size, dtype=np.int32).reshape(dt.shape)
     else:
         ft = None
 
@@ -2414,7 +2413,7 @@ def distance_transform_cdt(input, metric='chessboard', return_distances=True,
             tmp = np.indices(dt.shape, dtype=np.int32)
         for ii in range(tmp.shape[0]):
             rtmp = np.ravel(tmp[ii, ...])[ft]
-            rtmp.shape = dt.shape
+            rtmp = rtmp.reshape(dt.shape)
             tmp[ii, ...] = rtmp
         ft = tmp
 

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -52,8 +52,7 @@ def _as2d(ar):
     if ar.ndim == 2:
         return ar
     else:  # Assume 1!
-        aux = np.asarray(ar)
-        aux.shape = (ar.shape[0], 1)
+        aux = np.asarray(ar).reshape((ar.shape[0], 1))
         return aux
 
 


### PR DESCRIPTION


#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Addresses part of https://github.com/scipy/scipy/issues/23522

#### What does this implement/fix?
<!--Please explain your changes.-->

We replace setting of the shape attribute with calls to reshape(...). In this PR we only handle a part of the cases to keep the PR small for reviewers. In followup PRs we can handle the remaining cases.


