### PR TITLE
DOC: stats.log: correct return description

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -5726,7 +5726,7 @@ def log(X, /):
     Returns
     -------
     Y : `ContinuousDistribution`
-        A random variable :math:`Y = \exp(X)`.
+        A random variable :math:`Y = \log(X)`.
 
     Examples
     --------


### PR DESCRIPTION
#### What does this implement/fix?
Fixes a mistake in the return description of `stats.log`.
