### PR TITLE
MAINT: Use reshape instead of setting the shape attribute for numpy

### DIFF
--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -222,8 +222,7 @@ def face(gray=False):
     with open(fname, 'rb') as f:
         rawdata = f.read()
     face_data = bz2.decompress(rawdata)
-    face = frombuffer(face_data, dtype='uint8')
-    face.shape = (768, 1024, 3)
+    face = frombuffer(face_data, dtype='uint8').reshape((768, 1024, 3))
     if gray is True:
         face = (0.21 * face[:, :, 0] + 0.71 * face[:, :, 1] +
                 0.07 * face[:, :, 2]).astype('uint8')

--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -696,13 +696,13 @@ class netcdf_file:
                 a_size = reduce(mul, shape, 1) * size
                 if self.use_mmap:
                     data = self._mm_buf[begin_:begin_+a_size].view(dtype=dtype_)
-                    data.shape = shape
+                    data = data.reshape(shape)
                 else:
                     pos = self.fp.tell()
                     self.fp.seek(begin_)
                     data = frombuffer(self.fp.read(a_size), dtype=dtype_
                                       ).copy()
-                    data.shape = shape
+                    data = data.reshape(shape)
                     self.fp.seek(pos)
 
             # Add variable.

--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -720,13 +720,13 @@ class netcdf_file:
             if self.use_mmap:
                 buf = self._mm_buf[begin:begin+self._recs*self._recsize]
                 rec_array = buf.view(dtype=dtypes)
-                rec_array.shape = (self._recs,)
+                rec_array = rec_array.reshape((self._recs,))
             else:
                 pos = self.fp.tell()
                 self.fp.seek(begin)
                 rec_array = frombuffer(self.fp.read(self._recs*self._recsize),
                                        dtype=dtypes).copy()
-                rec_array.shape = (self._recs,)
+                rec_array = rec_array.reshape((self._recs,))
                 self.fp.seek(pos)
 
             for var in rec_vars:

--- a/scipy/odr/_models.py
+++ b/scipy/odr/_models.py
@@ -9,7 +9,7 @@ __all__ = ['Model', 'exponential', 'multilinear', 'unilinear', 'quadratic',
 
 def _lin_fcn(B, x):
     a, b = B[0], B[1:]
-    b.shape = (b.shape[0], 1)
+    b = b.reshape((b.shape[0], 1))
 
     return a + (x*b).sum(axis=0)
 
@@ -17,15 +17,13 @@ def _lin_fcn(B, x):
 def _lin_fjb(B, x):
     a = np.ones(x.shape[-1], float)
     res = np.concatenate((a, x.ravel()))
-    res.shape = (B.shape[-1], x.shape[-1])
-    return res
+    return res.reshape((B.shape[-1], x.shape[-1]))
 
 
 def _lin_fjd(B, x):
     b = B[1:]
     b = np.repeat(b, (x.shape[-1],)*b.shape[-1], axis=0)
-    b.shape = x.shape
-    return b
+    return b.reshape(x.shape)
 
 
 def _lin_est(data):
@@ -43,7 +41,7 @@ def _lin_est(data):
 
 def _poly_fcn(B, x, powers):
     a, b = B[0], B[1:]
-    b.shape = (b.shape[0], 1)
+    b = b.reshape((b.shape[0], 1))
 
     return a + np.sum(b * np.power(x, powers), axis=0)
 
@@ -51,13 +49,12 @@ def _poly_fcn(B, x, powers):
 def _poly_fjacb(B, x, powers):
     res = np.concatenate((np.ones(x.shape[-1], float),
                           np.power(x, powers).flat))
-    res.shape = (B.shape[-1], x.shape[-1])
-    return res
+    return res.reshape((B.shape[-1], x.shape[-1]))
 
 
 def _poly_fjacd(B, x, powers):
     b = B[1:]
-    b.shape = (b.shape[0], 1)
+    b = b.reshape((b.shape[0], 1))
 
     b = b * powers
 
@@ -74,8 +71,7 @@ def _exp_fjd(B, x):
 
 def _exp_fjb(B, x):
     res = np.concatenate((np.ones(x.shape[-1], float), x * np.exp(B[1] * x)))
-    res.shape = (2, x.shape[-1])
-    return res
+    return res.reshape((2, x.shape[-1]))
 
 
 def _exp_est(data):
@@ -163,7 +159,7 @@ def polynomial(order):
         # Scalar.
         powers = np.arange(1, powers + 1)
 
-    powers.shape = (len(powers), 1)
+    powers = powers.reshape((len(powers), 1))
     len_beta = len(powers) + 1
 
     def _poly_est(data, len_beta=len_beta):
@@ -221,9 +217,7 @@ def _unilin_fjd(B, x):
 
 def _unilin_fjb(B, x):
     _ret = np.concatenate((x, np.ones(x.shape, float)))
-    _ret.shape = (2,) + x.shape
-
-    return _ret
+    return _ret.reshape((2,) + x.shape)
 
 
 def _unilin_est(data):
@@ -240,9 +234,7 @@ def _quad_fjd(B, x):
 
 def _quad_fjb(B, x):
     _ret = np.concatenate((x*x, x, np.ones(x.shape, float)))
-    _ret.shape = (3,) + x.shape
-
-    return _ret
+    return _ret.reshape((3,) + x.shape)
 
 
 def _quad_est(data):

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -3483,7 +3483,8 @@ class multinomial_gen(multi_rv_generic):
 
         n = n[..., np.newaxis]
         new_axes_needed = max(p.ndim, n.ndim) - x.ndim + 1
-        x.shape += (1,)*new_axes_needed
+        new_shape = x.shape + (1,)*new_axes_needed
+        x = x.reshape(new_shape)
 
         term2 = np.sum(binom.pmf(x, n, p)*gammaln(x+1),
                        axis=(-1, -1-new_axes_needed))

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -2073,7 +2073,7 @@ def _compute_qth_percentile(sorted_, per, interpolation_method, axis):
         weights = array([(j - idx), (idx - i)], float)
         wshape = [1] * sorted_.ndim
         wshape[axis] = 2
-        weights.shape = wshape
+        weights = weights.reshape(wshape)
         sumval = weights.sum()
 
     # Use np.add.reduce (== np.sum but a little faster) to coerce data type


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Addresses part of https://github.com/scipy/scipy/issues/23522

#### What does this implement/fix?

With this third PR all deprecated setting of the `shape` attribute on numpy arrays has been replaced with `reshape` operations.

