### PR TITLE
CI: swap to windows-2025 [wheel build]

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -77,7 +77,7 @@ jobs:
         # https://github.com/github/feedback/discussions/7835#discussioncomment-1769026
         buildplat:
         # should also be able to do multi-archs on a single entry, e.g.
-        # [windows-2022, win*, "AMD64 x86"]. However, those two require a different compiler setup
+        # [windows-2025, win*, "AMD64 x86"]. However, those two require a different compiler setup
         # so easier to separate out here.
         - [ubuntu-22.04, manylinux, x86_64, "", ""]
         - [ubuntu-22.04, musllinux, x86_64, "", ""]
@@ -87,7 +87,7 @@ jobs:
         - [macos-13, macosx, x86_64, accelerate, "14.0"]
         - [macos-14, macosx, arm64, openblas, "12.3"]
         - [macos-14, macosx, arm64, accelerate, "14.0"]
-        - [windows-2022, win, AMD64, "", ""]
+        - [windows-2025, win, AMD64, "", ""]
         - [windows-11-arm, win, ARM64, "", ""]
         python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp313t", "3.13"], ["cp314", "cp314"], ["cp314t", "cp314"]]
         # python[0] is used to specify the python versions made by cibuildwheel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,7 @@ jobs:
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -71,7 +71,7 @@ jobs:
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -115,7 +115,7 @@ jobs:
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
-    runs-on: windows-2022
+    runs-on: windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
> The "windows-latest" label in GitHub Actions will be migrated to the Windows Server 2025 runner image.
This change will be rolled out over a period of several weeks beginning September 2, 2025 and will complete by September 30, 2025.
During this period your workflows will gradually switch over to the new image, once they are migrated they will not run on Windows Server 2022 in any future runs.
[IMPORTANT] The Windows Server 2025 image may have different tools installed than Windows Server 2022. You can check the [tool list for Windows 2025](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md?elqTrackId=086c2bda1209481a8e3e7b1fb946df0e&elq=4357f7f350c3481285ae202096bdf591&elqaid=4573&elqat=1&elqCampaignId=4763&elqak=8AF5E363CAA3D05433FD8CF75B89A0C1E242EFDD3F9A2F165D2575C9725FA8B84EBD) to proactively identify any tooling differences and make updates to your workflows accordingly.
What you need to do:
You do not need to do anything at this time if you want your workflows to migrate to the latest windows version. If you want to remain on Windows 2022 you can follow the below instructions.
Switch your workflows to use the windows-2022 label by changing workflow YAML to use runs-on: windows-2022. We support the two latest stable windows versions plus latest beta, so windows 2022 will be maintained for the next 3 years.

2022 will still be around for a while, but this is speculative just to see if we can migrate at this time.