### PR TITLE
ENH:optimize: Implement backstep behavior in SLSQP on raise of Analysis Error

### DIFF
--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -335,6 +335,14 @@ Benchmark problems
    rosen_hess - The Hessian matrix of the Rosenbrock function.
    rosen_hess_prod - Product of the Rosenbrock Hessian with a vector.
 
+User Errors
+-----------
+
+.. autosummary::
+   :toctree: generated/
+
+   AnalysisError - Error that can be raised in SLSQP to trigger backstepping.
+
 Legacy functions
 ================
 
@@ -429,7 +437,7 @@ from ._lbfgsb_py import fmin_l_bfgs_b, LbfgsInvHessProduct
 from ._tnc import fmin_tnc
 from ._cobyla_py import fmin_cobyla
 from ._nonlin import *
-from ._slsqp_py import fmin_slsqp
+from ._slsqp_py import fmin_slsqp, AnalysisError
 from ._nnls import nnls
 from ._basinhopping import basinhopping
 from ._linprog import linprog, linprog_verbose_callback
@@ -446,6 +454,7 @@ from ._dual_annealing import dual_annealing
 from ._qap import quadratic_assignment
 from ._direct_py import direct
 from ._milp import milp
+
 
 # Deprecated namespaces, to be removed in v2.0.0
 from . import (

--- a/scipy/optimize/__slsqp.h
+++ b/scipy/optimize/__slsqp.h
@@ -76,7 +76,7 @@ void dtrsv_(char* uplo, char* trans, char* diag, int* n, double* a, int* lda, do
 // and back such that it is thread-safe.
 struct SLSQP_vars {
     double acc, alpha, f0, gs, h1, h2, h3, h4, t, t0, tol;
-    int exact, inconsistent, reset, iter, itermax, line, m, meq, mode, n;
+    int exact, inconsistent, reset, iter, itermax, line, m, meq, mode, n, fnc_failure;
 };
 
 
@@ -266,7 +266,7 @@ slsqp(PyObject* Py_UNUSED(dummy), PyObject* args)
     // the Python dictionary.
 
     #define STRUCT_DOUBLE_FIELD_NAMES X(acc) X(alpha) X(f0) X(gs) X(h1) X(h2) X(h3) X(h4) X(t) X(t0) X(tol)
-    #define STRUCT_INT_FIELD_NAMES X(exact) X(inconsistent) X(reset) X(iter) X(itermax) X(line) X(m) X(meq) X(mode) X(n)
+    #define STRUCT_INT_FIELD_NAMES X(exact) X(inconsistent) X(reset) X(iter) X(itermax) X(line) X(m) X(meq) X(mode) X(n) X(fnc_failure)
     #define STRUCT_FIELD_NAMES STRUCT_INT_FIELD_NAMES STRUCT_DOUBLE_FIELD_NAMES
 
     // Parse the dictionary, if the field is not found, raise an error.


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
This feature implements the ability for a user to trigger backstopping in the SLSQP algorithm, via raising the newly added AnalysisError. 

In large scale optimization problems, it can be common to have numerical iterative processes as part of the objective or constraint functions. In cases where these processes fail to converge, the optimization may fail to recover. Furthermore, many problem have invalid regions where either constraints or the objective cannot be evaluated. In cases where a user can detect this occurrence during function evaluation, they can now force SLSQP to backstep by raising an AnalysisError.

It should be noted that this is not a substitute for constraints. In the convergence failure cases, regions that cause this can be hard to predict making the user of constraints to avoid them challenging. In the invalid region cases, the SLSQP algorithm will often iterate through infeasible space, meaning that constraints cannot fully prevent the optimization from stepping through the region. 

This functionality is current provided by a number of modern optimization (IPOPT, SNOPT) and is build upon by MDO frameworks such as [OpenMDAO](https://openmdao.org/newdocs/versions/latest/advanced_user_guide/analysis_errors/analysis_error.html).

#### Simple Example
Here is an example using a function similar to the Rosenbrock function, where a number of infeasible regions have been place throughout the design space. The attached screenshots show the behavior from a starting point of (2, 2) and (2, 4).

```python
def fun(x):
    if np.cos(2.0*x[0]) + np.cos(2.0*x[1]) > 0.5:
        raise AnalysisError("Invalid Region")
    return (1-x[0])**2 + (1-x[1])**2 + 0.5*(2.0*x[1]-x[0]**2)**2

res = minimize(fun, starting_point, method="SLSQP")
```
In the case of the starting point of (2, 2), the function hits the invalid region, and is able to step out with a single backstep (note that after iter 2, the optimizer take additional minor iterations unrelated to the user triggered backstep)
<img width="800" height="600" alt="opt_progress_start_2 00_2 00" src="https://github.com/user-attachments/assets/710f0041-09cd-4857-b376-13856d4642dd" />
```
     message: Optimization terminated successfully
     success: True
      status: 0
         fun: 0.09194417645660757
           x: [ 1.213e+00  8.241e-01]
         nit: 6
         jac: [-2.326e-03  1.569e-03]
        nfev: 19
        njev: 6
```

In the case of the starting point of (2,4), the function hits numerous invalid regions during the first iteration, and is still able to recover and complete the optimization
<img width="800" height="600" alt="opt_progress_start_2 00_4 00" src="https://github.com/user-attachments/assets/ad7d9a5d-aeac-4a10-9072-030431175f1a" />
```
     message: Optimization terminated successfully
     success: True
      status: 0
         fun: 0.09194382638399702
           x: [ 1.213e+00  8.242e-01]
         nit: 7
         jac: [-8.721e-05  2.895e-04]
        nfev: 22
        njev: 7
```






