### PR TITLE
ENH: Add two private ufuncs related to generalized harmonic numbers.

### DIFF
--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -13,7 +13,7 @@ from scipy._lib._array_api import (array_namespace, xp_size, xp_ravel, xp_copy,
 from scipy import special, stats
 from scipy.integrate import quad_vec, nsum, tanhsinh as _tanhsinh
 from scipy.integrate._tanhsinh import _pair_cache
-from scipy.stats._discrete_distns import _gen_harmonic_gt1
+from scipy.special._ufuncs import _gen_harmonic
 
 
 def norm_pdf(x, xp=None):
@@ -785,7 +785,7 @@ class TestNSum:
 
     f3.a = 1
     f3.b = rng.integers(5, 15, size=(3, 1))
-    f3.ref = _gen_harmonic_gt1(f3.b, p)
+    f3.ref = _gen_harmonic(f3.b, p)
     f3.args = (p,)
 
     def test_input_validation(self, xp):
@@ -1116,7 +1116,7 @@ class TestNSum:
         assert res.error.dtype == dtype
 
         rtol = 1e-12 if dtype == xp.float64 else 1e-6
-        ref = _gen_harmonic_gt1(np.asarray([10, xp.inf]), 2)
+        ref = [_gen_harmonic(10, 2), special.zeta(2, 1)]
         xp_assert_close(res.sum, xp.asarray(ref, dtype=dtype), rtol=rtol)
 
     @pytest.mark.parametrize('case', [(10, 100), (100, 10)])

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -78,10 +78,12 @@ import re
 import textwrap
 
 special_ufuncs = [
-    '_cospi', '_lambertw', '_scaled_exp1', '_sinpi', '_spherical_jn', '_spherical_jn_d',
-    '_spherical_yn', '_spherical_yn_d', '_spherical_in', '_spherical_in_d',
-    '_spherical_kn', '_spherical_kn_d', 'airy', 'airye', 'bei', 'beip', 'ber', 'berp',
-    'binom', 'exp1', 'expi', 'expit', 'exprel', 'gamma', 'gammaln', 'hankel1',
+    '_cospi', '_gen_harmonic', '_lambertw', '_normalized_gen_harmonic',
+    '_scaled_exp1', '_sinpi',
+    '_spherical_jn', '_spherical_jn_d', '_spherical_yn', '_spherical_yn_d',
+    '_spherical_in', '_spherical_in_d', '_spherical_kn', '_spherical_kn_d',
+    'airy', 'airye', 'bei', 'beip', 'ber', 'berp', 'binom',
+    'exp1', 'expi', 'expit', 'exprel', 'gamma', 'gammaln', 'hankel1',
     'hankel1e', 'hankel2', 'hankel2e', 'hyp2f1', 'it2i0k0', 'it2j0y0', 'it2struve0',
     'itairy', 'iti0k0', 'itj0y0', 'itmodstruve0', 'itstruve0',
     'iv', '_iv_ratio', '_iv_ratio_c', 'ive', 'jv',

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -35,6 +35,7 @@
 #include <xsf/trig.h>
 #include <xsf/wright_bessel.h>
 #include <xsf/zeta.h>
+#include "gen_harmonic.h"
 
 // This is the extension module for the NumPy ufuncs in SciPy's special module. To create such a ufunc, call
 // "xsf::numpy::ufunc" with a braced list of kernel functions that will become the ufunc overloads. There are
@@ -46,8 +47,10 @@
 
 extern const char *_cospi_doc;
 extern const char *_sinpi_doc;
+extern const char *_gen_harmonic_doc;
 extern const char *_log1mexp_doc;
 extern const char *_log1pmx_doc;
+extern const char *_normalized_gen_harmonic_doc;
 extern const char *airy_doc;
 extern const char *airye_doc;
 extern const char *bei_doc;
@@ -232,6 +235,14 @@ PyMODINIT_FUNC PyInit__special_ufuncs() {
                            static_cast<xsf::numpy::F_F>(xsf::cospi), static_cast<xsf::numpy::D_D>(xsf::cospi)},
                           "_cospi", _cospi_doc);
     PyModule_AddObjectRef(_special_ufuncs, "_cospi", _cospi);
+
+    PyObject *_gen_harmonic =
+        xsf::numpy::ufunc({gen_harmonic}, "_gen_harmonic", _gen_harmonic_doc);
+    PyModule_AddObjectRef(_special_ufuncs, "_gen_harmonic", _gen_harmonic);
+
+    PyObject *_normalized_gen_harmonic =
+        xsf::numpy::ufunc({normalized_gen_harmonic}, "_normalized_gen_harmonic", _normalized_gen_harmonic_doc);
+    PyModule_AddObjectRef(_special_ufuncs, "_normalized_gen_harmonic", _normalized_gen_harmonic);
 
     PyObject *_lambertw = xsf::numpy::ufunc(
         {static_cast<xsf::numpy::Dld_D>(xsf::lambertw), static_cast<xsf::numpy::Flf_F>(xsf::lambertw)}, "_lambertw",

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -2,6 +2,30 @@ const char *_cospi_doc = R"(
     Internal function, do not use.
     )";
 
+const char *_gen_harmonic_doc = R"(
+    _gen_harmonic(n, a)
+
+    Internal private function.
+
+    Compute sum_{i=1}^{n} i**-a for 1 <= m <= n.
+
+    This is the generalized harmonic number.
+
+    nan is returned if n < 1.
+
+    This function is used in scipy.stats.zipfian.
+    )";
+
+const char *_normalized_gen_harmonic_doc = R"(
+    _normalized_gen_harmonic(j, k, n, a)
+
+    Internal private function.
+
+    Compute (sum_{i=j}^{k} i**-a)/(sum_{i=1}^{n} i**-a) for 1 <= j <= k <= n.
+
+    This function is used in scipy.stats.zipfian.
+    )";
+
 const char *besselpoly_doc = R"(
     besselpoly(a, lmb, nu, out=None)
 

--- a/scipy/special/_ufuncs.pyi
+++ b/scipy/special/_ufuncs.pyi
@@ -257,6 +257,7 @@ _cosine_invcdf: np.ufunc
 _cospi: np.ufunc
 _ellip_harm: np.ufunc
 _factorial: np.ufunc
+_gen_harmonic: np.ufunc
 _igam_fac: np.ufunc
 _kolmogc: np.ufunc
 _kolmogci: np.ufunc
@@ -266,6 +267,7 @@ _lanczos_sum_expg_scaled: np.ufunc
 _lgam1p: np.ufunc
 _log1mexp: np.ufunc
 _log1pmx: np.ufunc
+_normalized_gen_harmonic: np.ufunc
 _riemann_zeta: np.ufunc
 _scaled_exp1: np.ufunc
 _sf_error_test_function: np.ufunc

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -9,16 +9,6 @@
             "cosine_invcdf": "d->d"
         }
     },
-    "_gen_harmonic": {
-        "gen_harmonic.h++": {
-            "gen_harmonic": "qd->d"
-        }
-    },
-    "_normalized_gen_harmonic": {
-        "gen_harmonic.h++": {
-            "normalized_gen_harmonic": "qqqd->d"
-        }
-    },
     "_ellip_harm": {
         "_ellip_harm.pxd": {
             "ellip_harmonic": "ddiiddd->d"

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -9,6 +9,16 @@
             "cosine_invcdf": "d->d"
         }
     },
+    "_gen_harmonic": {
+        "gen_harmonic.h++": {
+            "gen_harmonic": "qd->d"
+        }
+    },
+    "_normalized_gen_harmonic": {
+        "gen_harmonic.h++": {
+            "normalized_gen_harmonic": "qqqd->d"
+        }
+    },
     "_ellip_harm": {
         "_ellip_harm.pxd": {
             "ellip_harmonic": "ddiiddd->d"

--- a/scipy/special/gen_harmonic.h
+++ b/scipy/special/gen_harmonic.h
@@ -150,12 +150,12 @@ normalized_gen_harmonic(int64_t j, int64_t k, int64_t n, double a)
     //
     // Now we know 1 <= j <= k <= n
     //
+    if (n == 1) {
+        // IEEE: pow(1.0, _) is 1.0.
+        // n == 1 implies j == k == 1.
+        return 1.0;
+    }
     if (std::isnan(a)) {
-        if (n == 1) {
-            // n == 1 implies j == k == 1.
-            // IEEE: pow(1.0, nan) is 1.0.
-            return 1.0;
-        }
         return NAN;
     }
     if (std::isinf(a)) {
@@ -172,11 +172,7 @@ normalized_gen_harmonic(int64_t j, int64_t k, int64_t n, double a)
         }
         else {
             // a = -inf
-            if (n == 1) {
-                // Numerator and denominator are both 1.
-                return 1.0;
-            }
-            else if (k == 1) {
+            if (k == 1) {
                 // Numerator is 1, denominator is +inf.
                 return 0.0;
             }
@@ -193,7 +189,7 @@ normalized_gen_harmonic(int64_t j, int64_t k, int64_t n, double a)
         return normalized_sum_powers(j, k, n, a);
     }
     else {
-        // If here, we know a is finite and a > 1, and 1 <= j <= k <= n.
+        // If here, we know a is finite and a > 1, n > 1, and 1 <= j <= k <= n.
         // See the comments in _gen_harmonic() for an explanation of why
         // we check the ratios of the zeta functions before using them
         // to compute the result.

--- a/scipy/special/gen_harmonic.h
+++ b/scipy/special/gen_harmonic.h
@@ -48,11 +48,11 @@ gen_harmonic(int64_t n, double a)
                  "n >= 1 is required, but got n = %" PRId64, n);
         return NAN;
     }
+    if (n == 1) {
+        // IEEE: pow(1.0, _) is 1.0.
+        return 1.0;
+    }
     if (std::isnan(a)) {
-        if (n == 1) {
-            // IEEE: pow(1.0, nan) is 1.0.
-            return 1.0;
-        }
         return NAN;
     }
     if (std::isinf(a)) {
@@ -62,13 +62,7 @@ gen_harmonic(int64_t n, double a)
         }
         else {
             // a = -inf
-            if (n == 1) {
-                // IEEE: pow(1.0, inf) = 1
-                return 1.0;
-            }
-            else {
-                return INFINITY;
-            }
+            return INFINITY;
         }
     }
     if (a == 0) {
@@ -78,7 +72,7 @@ gen_harmonic(int64_t n, double a)
         return sum_powers(1, n, a);
     }
     else {
-        // If here, we know a is finite and a > 1, and n >= 1.
+        // If here, we know a is finite and a > 1, and n > 1.
         //
         // For a > 1, we can use the formula zeta(a, 1) - zeta(a, n + 1),
         // where zeta(a, k) is the Hurwitiz zeta function.

--- a/scipy/special/gen_harmonic.h
+++ b/scipy/special/gen_harmonic.h
@@ -1,0 +1,231 @@
+#include <cmath>
+#include <cstdint>
+#include <xsf/zeta.h>  // for xsf::cephes::zeta(a, n)
+#include "sf_error.h"
+
+
+//
+// Compute sum_{i=m}^{n} i**-a.
+//
+// This function assumes 1 <= m <= n and `a` is finite.
+//
+static inline double
+sum_powers(int64_t m, int64_t n, double a)
+{
+    double sum = 0.0;
+    if (a >= 0) {
+        for (int64_t i = n; i >= m; --i) {
+            sum += std::pow(i, -a);
+        }
+    }
+    else {
+        for (int64_t i = m; i <= n; ++i) {
+            sum += std::pow(i, -a);
+        }
+    }
+    return sum;
+}
+
+//
+// Compute
+//
+//   sum_{i=1}^{n} i**-a
+//
+// This is the generalized harmonic number H_{n, a} [1].
+//
+// * If n < 1, NAN is returned with SF_ERROR_DOMAIN set.
+// * If a > 1 and not too close to 1, the sum is computed using
+//   the Hurwitz zeta function.  Otherwise it is computed as a simple
+//   sum of the powers.
+//
+// [1] https://en.wikipedia.org/wiki/Harmonic_number#Generalized_harmonic_numbers
+//
+static inline double
+gen_harmonic(int64_t n, double a)
+{
+    if (n < 1) {
+        sf_error("_gen_harmonic", SF_ERROR_DOMAIN,
+                 "n >= 1 is required, but got n = %" PRId64, n);
+        return NAN;
+    }
+    if (std::isnan(a)) {
+        if (n == 1) {
+            // IEEE: pow(1.0, nan) is 1.0.
+            return 1.0;
+        }
+        return NAN;
+    }
+    if (std::isinf(a)) {
+        if (a > 0) {
+            // a = +inf
+            return 1.0;
+        }
+        else {
+            // a = -inf
+            if (n == 1) {
+                // IEEE: pow(1.0, inf) = 1
+                return 1.0;
+            }
+            else {
+                return INFINITY;
+            }
+        }
+    }
+    if (a == 0) {
+        return static_cast<double>(n);
+    }
+    if (a <= 1) {
+        return sum_powers(1, n, a);
+    }
+    else {
+        // If here, we know a is finite and a > 1, and n >= 1.
+        //
+        // For a > 1, we can use the formula zeta(a, 1) - zeta(a, n + 1),
+        // where zeta(a, k) is the Hurwitiz zeta function.
+        // But if zeta(a, 1) and zeta(a, n + 1) are close, precision is lost
+        // in the subtraction, so we use the explicit sum instead. We consider
+        // the values "close" if zeta(a, n + 1)/zeta(a, 1) > 0.5.
+        //
+        double z1 = xsf::cephes::zeta(a, static_cast<double>(1));
+        double znp1 =  xsf::cephes::zeta(a, static_cast<double>(n + 1));
+        if (znp1 / z1 <= 0.5) {
+            return z1 - znp1;
+        }
+        else {
+            return sum_powers(1, n, a);
+        }
+    }
+}
+
+
+//
+// Computes
+//
+//      sum_{i=j}^{k} i**-a
+//      -------------------
+//      sum_{i=1}^{n} i**-a
+//
+// Requires 1 <= j <= k <= n and finite a.
+//
+//
+
+static inline double
+normalized_sum_powers(int64_t j, int64_t k, int64_t n, double a)
+{
+    double numer = 0.0;
+    double denom = 0.0;
+    if (a >= 0) {
+        for (int64_t i = n; i >= 1; --i) {
+            double term = std::pow(i, -a);
+            denom += term;
+            if (i >= j && i <= k) {
+                numer += term;
+            }
+        }
+    }
+    else {
+        for (int64_t i = 1; i <= n; ++i) {
+            double term = std::pow(i, -a);
+            denom += term;
+            if (i >= j && i <= k) {
+                numer += term;
+            }
+        }
+    }
+    return numer / denom;
+}
+
+//
+// Computes
+//
+//      sum_{i=j}^{k} i**-a
+//      -------------------
+//      sum_{i=1}^{n} i**-a
+//
+// Requires 1 <= j <= k <= n; returns NAN if that is not true.
+//
+static inline double
+normalized_gen_harmonic(int64_t j, int64_t k, int64_t n, double a)
+{
+    if (j < 1 || k < j || n < k) {
+        sf_error("_normalized_gen_harmonic", SF_ERROR_DOMAIN,
+                 "1 <= j <= k <= n is required, but got j = %" PRId64 ", "
+                 "k = %" PRId64 ", and n = %" PRId64, j, k, n);
+        return NAN;
+    }
+    //
+    // Now we know 1 <= j <= k <= n
+    //
+    if (std::isnan(a)) {
+        if (n == 1) {
+            // n == 1 implies j == k == 1.
+            // IEEE: pow(1.0, nan) is 1.0.
+            return 1.0;
+        }
+        return NAN;
+    }
+    if (std::isinf(a)) {
+        if (a > 0) {
+            // a = +inf
+            if (j == 1) {
+                // Numerator and denominator are both 1.
+                return 1.0;
+            }
+            else {
+                // Numerator is 0, denominator is 1.
+                return 0.0;
+            }
+        }
+        else {
+            // a = -inf
+            if (n == 1) {
+                // Numerator and denominator are both 1.
+                return 1.0;
+            }
+            else if (k == 1) {
+                // Numerator is 1, denominator is +inf.
+                return 0.0;
+            }
+            else {
+                // Numerator and denominator are both +inf.
+                return NAN;
+            }
+        }
+    }
+    if (a == 0) {
+        return static_cast<double>(k - j + 1) / static_cast<double>(n);
+    }
+    if (a <= 1) {
+        return normalized_sum_powers(j, k, n, a);
+    }
+    else {
+        // If here, we know a is finite and a > 1, and 1 <= j <= k <= n.
+        // See the comments in _gen_harmonic() for an explanation of why
+        // we check the ratios of the zeta functions before using them
+        // to compute the result.
+        double zj = xsf::cephes::zeta(a, static_cast<double>(j));
+        double zkp1 =  xsf::cephes::zeta(a, static_cast<double>(k + 1));
+        double z1  = xsf::cephes::zeta(a, static_cast<double>(1));
+        double znp1 = xsf::cephes::zeta(a, static_cast<double>(n + 1));
+        bool zeta_numer_ok = zkp1 / zj < 0.5;
+        bool zeta_denom_ok = znp1 / z1 < 0.5;
+        if (zeta_numer_ok) {
+            if (zeta_denom_ok) {
+                // OK to use the zeta formula for the numerator
+                // and denominator.
+                return (zj - zkp1) / (z1 - znp1);
+            }
+            else {
+                return (zj - zkp1) / sum_powers(1, n, a);
+            }
+        }
+        else {
+            if (zeta_denom_ok) {
+                return sum_powers(j, k, a) / (z1 - znp1);
+            }
+            else {
+                return normalized_sum_powers(j, k, n, a);
+            }
+        }
+    }
+}

--- a/scipy/special/gen_harmonic.h
+++ b/scipy/special/gen_harmonic.h
@@ -7,7 +7,7 @@
 
 //
 // If zeta(a, n + 1) / zeta(a, 1) exceeds zeta_ratio_threshold, the two
-// values are close enough that the loss of precision in the subraction
+// values are close enough that the loss of precision in the subtraction
 // zeta(a, 1) - zeta(a, n + 1) should be avoided by using the direct
 // sum of powers instead.  The most conservative value would 0.5, but
 // experimentation shows that 0.9 maintains a relative error of less

--- a/scipy/special/gen_harmonic.h
+++ b/scipy/special/gen_harmonic.h
@@ -6,6 +6,16 @@
 
 
 //
+// If zeta(a, n + 1) / zeta(a, 1) exceeds zeta_ratio_threshold, the two
+// values are close enough that the loss of precision in the subraction
+// zeta(a, 1) - zeta(a, n + 1) should be avoided by using the direct
+// sum of powers instead.  The most conservative value would 0.5, but
+// experimentation shows that 0.9 maintains a relative error of less
+// than 5e-15.
+//
+static const double zeta_ratio_threshold = 0.9;
+
+//
 // Compute sum_{i=m}^{n} i**-a.
 //
 // This function assumes 1 <= m <= n and `a` is finite.
@@ -79,11 +89,11 @@ gen_harmonic(int64_t n, double a)
         // where zeta(a, k) is the Hurwitiz zeta function.
         // But if zeta(a, 1) and zeta(a, n + 1) are close, precision is lost
         // in the subtraction, so we use the explicit sum instead. We consider
-        // the values "close" if zeta(a, n + 1)/zeta(a, 1) > 0.5.
+        // the values "close" if zeta(a, n + 1)/zeta(a, 1) > zeta_ratio_threshold.
         //
         double z1 = xsf::cephes::zeta(a, static_cast<double>(1));
         double znp1 =  xsf::cephes::zeta(a, static_cast<double>(n + 1));
-        if (znp1 / z1 <= 0.5) {
+        if (znp1 / z1 <= zeta_ratio_threshold) {
             return z1 - znp1;
         }
         else {
@@ -198,8 +208,8 @@ normalized_gen_harmonic(int64_t j, int64_t k, int64_t n, double a)
         double zkp1 =  xsf::cephes::zeta(a, static_cast<double>(k + 1));
         double z1  = xsf::cephes::zeta(a, static_cast<double>(1));
         double znp1 = xsf::cephes::zeta(a, static_cast<double>(n + 1));
-        bool zeta_numer_ok = zkp1 / zj < 0.5;
-        bool zeta_denom_ok = znp1 / z1 < 0.5;
+        bool zeta_numer_ok = zkp1 / zj < zeta_ratio_threshold;
+        bool zeta_denom_ok = znp1 / z1 < zeta_ratio_threshold;
         if (zeta_numer_ok) {
             if (zeta_denom_ok) {
                 // OK to use the zeta formula for the numerator

--- a/scipy/special/gen_harmonic.h
+++ b/scipy/special/gen_harmonic.h
@@ -1,5 +1,6 @@
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <xsf/zeta.h>  // for xsf::cephes::zeta(a, n)
 #include "sf_error.h"
 
@@ -46,14 +47,14 @@ gen_harmonic(int64_t n, double a)
     if (n < 1) {
         sf_error("_gen_harmonic", SF_ERROR_DOMAIN,
                  "n >= 1 is required, but got n = %" PRId64, n);
-        return NAN;
+        return std::numeric_limits<double>::quiet_NaN();
     }
     if (n == 1) {
         // IEEE: pow(1.0, _) is 1.0.
         return 1.0;
     }
     if (std::isnan(a)) {
-        return NAN;
+        return std::numeric_limits<double>::quiet_NaN();
     }
     if (std::isinf(a)) {
         if (a > 0) {
@@ -62,7 +63,7 @@ gen_harmonic(int64_t n, double a)
         }
         else {
             // a = -inf
-            return INFINITY;
+            return std::numeric_limits<double>::infinity();
         }
     }
     if (a == 0) {
@@ -145,7 +146,7 @@ normalized_gen_harmonic(int64_t j, int64_t k, int64_t n, double a)
         sf_error("_normalized_gen_harmonic", SF_ERROR_DOMAIN,
                  "1 <= j <= k <= n is required, but got j = %" PRId64 ", "
                  "k = %" PRId64 ", and n = %" PRId64, j, k, n);
-        return NAN;
+        return std::numeric_limits<double>::quiet_NaN();
     }
     //
     // Now we know 1 <= j <= k <= n
@@ -156,7 +157,7 @@ normalized_gen_harmonic(int64_t j, int64_t k, int64_t n, double a)
         return 1.0;
     }
     if (std::isnan(a)) {
-        return NAN;
+        return std::numeric_limits<double>::quiet_NaN();
     }
     if (std::isinf(a)) {
         if (a > 0) {
@@ -178,7 +179,7 @@ normalized_gen_harmonic(int64_t j, int64_t k, int64_t n, double a)
             }
             else {
                 // Numerator and denominator are both +inf.
-                return NAN;
+                return std::numeric_limits<double>::quiet_NaN();
             }
         }
     }

--- a/scipy/special/tests/meson.build
+++ b/scipy/special/tests/meson.build
@@ -18,6 +18,7 @@ python_sources = [
   'test_faddeeva.py',
   'test_gamma.py',
   'test_gammainc.py',
+  'test_gen_harmonic.py',
   'test_hyp2f1.py',
   'test_hypergeometric.py',
   'test_iv_ratio.py',

--- a/scipy/special/tests/test_gen_harmonic.py
+++ b/scipy/special/tests/test_gen_harmonic.py
@@ -1,0 +1,85 @@
+import numpy as np
+from numpy.testing import assert_allclose, assert_equal
+import pytest
+from scipy.special._ufuncs import _gen_harmonic, _normalized_gen_harmonic
+
+
+#
+# In the following tests, reference values were computed with mpmath.
+#
+
+@pytest.mark.parametrize(
+    'n, a, ref',
+    [(8, 9.0, 1.0020083884212339),
+     (1000, 2.5, 1.3414661912046497),
+     (10, 1.5, 1.9953364933456017),
+     (10000, 1.25, 4.1951168257387765),
+     (10000,1.00001, 9.787182620770265),
+     (80, 1.000002, 4.965460167788836),
+     (75, 1 + 1e-12, 4.901355630543771),
+     (100, 1 + 1e-14, 5.187377517639515),
+     (100, 1 + 8e-16, 5.187377517639611),
+     (100, 1.0, 5.187377517639621),
+     (7, 1.0, 2.592857142857143),
+     (8000, 1.0, 9.564474984261423),
+     (5, 1 - 1e-12, 2.2833333333347143),
+     (25000, 1 - 1e-12, 10.703866768669737),
+     (1000, 0.995, 7.6058022857089975),
+     (1000, 0.75, 19.055178975831392),
+     (10000, 0.25, 1332.5700547197382),
+     (5, 1e-8, 4.999999952125083),
+     (15, 1e-16, 14.999999999999996),
+     (100, 0.0, 100.0),
+     (4, -1.0, 10.0),
+     (75, -1.5, 19811.38815892374)]
+)
+def test_gen_harmonic(n, a, ref):
+    h = _gen_harmonic(n, a)
+    assert_allclose(h, ref, rtol=5e-15)
+
+
+@pytest.mark.parametrize(
+    'n, a, ref',
+    [(10, np.inf, 1.0),
+     (1, np.nan, 1.0),
+     (1, -np.inf, 1.0),
+     (3, np.nan, np.nan),
+     (-3, 1.0, np.nan)]
+)
+def test_gen_harmonic_exact_cases(n, a, ref):
+    h = _gen_harmonic(n, a)
+    assert_equal(h, ref)
+
+
+@pytest.mark.parametrize(
+    'j, k, n, a, ref',
+    [(400, 5000, 5000, 10.0, 4.2821759663214485e-25),
+     (400, 5000, 5000, 3.5, 1.11086549102426e-07),
+     (1, 2, 3, 1.5, 0.8755176866163012),
+     (300, 500, 500, 1 + 1e-14, 0.07559343891632035),
+     (1500, 2500, 3000, 1 - 1e-12, 0.05957291246371843),
+     (10, 12, 16, 0.5, 0.13601665344521513),
+     (16, 16, 20, 0.125, 0.04583107002260924),
+     (10, 12, 16, -0.5, 0.22359306724308234),
+     (1, 8000, 10000, -1.5, 0.5724512895513029)]
+)
+def test_normalized_gen_harmonic(j, k, n, a, ref):
+    h = _normalized_gen_harmonic(j, k, n, a)
+    assert_allclose(h, ref, 5e-15)
+
+
+@pytest.mark.parametrize(
+    'j, k, n, a, ref',
+    [(1, 1, 1, 0.5, 1.0),
+     (1, 1, 1, np.nan, 1.0),
+     (1, 2, 5, np.nan, np.nan),
+     (1, 2, 1, 1.25, np.nan),
+     (1, 2, 3, np.inf, 1.0),
+     (2, 3, 4, np.inf, 0.0),
+     (1, 1, 10, -np.inf, 0.0),
+     (2, 3, 4, -np.inf, np.nan),
+     (3, 6, 8, 0.0, 0.5)]
+)
+def test_normalized_gen_harmonic_exact_cases(j, k, n, a, ref):
+    h = _normalized_gen_harmonic(j, k, n, a)
+    assert_equal(h, ref)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -22,7 +22,7 @@ vals = ([1, 2, 3, 4], [0.1, 0.2, 0.3, 0.4])
 distdiscrete += [[stats.rv_discrete(values=vals), ()]]
 
 # For these distributions, test_discrete_basic only runs with test mode full
-distslow = {'zipfian', 'nhypergeom'}
+distslow = {'nhypergeom'}
 
 # Override number of ULPs adjustment for `check_cdf_ppf`
 roundtrip_cdf_ppf_exceptions = {'nbinom': 30}

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -361,6 +361,40 @@ class TestZipfian:
         pmf_k_int32 = dist.pmf(k_int32)
         assert_equal(pmf, pmf_k_int32)
 
+    # Reference values were computed with mpmath.
+    @pytest.mark.parametrize(
+        'k, a, n, ref',
+        [(3, 1 + 1e-12, 10, 0.11380571738244807),
+         (995, 1 + 1e-9, 1000, 0.0001342634472310051)]
+    )
+    def test_pmf_against_mpmath(self, k, a, n, ref):
+        p = zipfian.pmf(k, a, n)
+        assert_allclose(p, ref, 5e-16)
+
+    # Reference values were computed with mpmath.
+    @pytest.mark.parametrize(
+        'k, a, n, ref',
+        [(4990, 1.25, 5000, 5.780138225335147e-05),
+         (9998, 3.5, 10000, 1.775352757966365e-14),
+         (50000, 3.5, 100000, 5.227803621367486e-13),
+         (10, 6.0, 100, 1.523108153557902e-06),
+         (95, 6.0, 100, 5.572438078308601e-12)]
+    )
+    def test_sf_against_mpmath(self, k, a, n, ref):
+        sf = zipfian.sf(k, a, n)
+        assert_allclose(sf, ref, rtol=8e-15)
+
+    # Reference values were computed with mpmath.
+    @pytest.mark.parametrize(
+        'a, n, ref',
+        [(1 + 1e-9, 100, 19.27756356649707),
+         (1 + 1e-7, 100000, 8271.194454731552),
+         (1.001, 3, 1.6360225521183804)]
+    )
+    def test_mean_against_mpmath(self, a, n, ref):
+        m = zipfian.mean(a, n)
+        assert_allclose(m, ref, rtol=8e-15)
+
 
 class TestNCH:
     np.random.seed(2)  # seeds 0 and 1 had some xl = xu; randint failed

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -249,7 +249,8 @@ def cases_test_fit_mle():
                       'nbinom', 'norminvgauss',
                       'pareto', 'pearson3', 'powerlaw', 'powernorm',
                       'randint', 'rdist', 'recipinvgauss', 'rice', 'skewnorm',
-                      't', 'uniform', 'weibull_max', 'weibull_min', 'wrapcauchy'}
+                      't', 'uniform', 'weibull_max', 'weibull_min', 'wrapcauchy',
+                      'zipfian'}
 
     # Please keep this list in alphabetical order...
     xslow_basic_fit = {'betabinom', 'betanbinom', 'burr', 'dpareto_lognorm',
@@ -260,7 +261,7 @@ def cases_test_fit_mle():
                        'nct', 'ncx2', 'nhypergeom',
                        'powerlognorm', 'reciprocal', 'rel_breitwigner',
                        'skellam', 'trapezoid', 'triang',
-                       'tukeylambda', 'vonmises', 'zipfian'}
+                       'tukeylambda', 'vonmises'}
 
     for dist in dict(distdiscrete + distcont):
         if dist in skip_basic_fit or not isinstance(dist, str):
@@ -306,7 +307,8 @@ def cases_test_fit_mse():
                       'semicircular',
                       't', 'triang', 'truncexpon', 'truncpareto',
                       'uniform',
-                      'wald', 'weibull_max', 'weibull_min', 'wrapcauchy'}
+                      'wald', 'weibull_max', 'weibull_min', 'wrapcauchy',
+                      'zipfian'}
 
     # Please keep this list in alphabetical order...
     xslow_basic_fit = {'argus', 'beta', 'betaprime', 'burr', 'burr12',
@@ -318,7 +320,7 @@ def cases_test_fit_mse():
                        'pearson3', 'powerlognorm',
                        'reciprocal', 'rel_breitwigner', 'rice',
                        'trapezoid', 'truncnorm', 'truncweibull_min',
-                       'vonmises_line', 'zipfian'}
+                       'vonmises_line'}
 
     warns_basic_fit = {'skellam'}  # can remove mark after gh-14901 is resolved
 


### PR DESCRIPTION
Two private ufuncs are added to `scipy.special._ufuncs`:

* `_gen_harmonic(n, a)` computes the generalized harmonic number

$$\sum_{i=1}^n i^{-a}$$

* `_normalized_gen_harmonic(j, k, n, a)` computes
  
$$\frac{\displaystyle\sum_{i=j}^k i^{-a}}{\displaystyle\sum_{i=1}^n i^{-a}}$$

These functions are used in `scipy.stats.zipfian` to improve performance and to improve precision when a is greater than but close to 1.

These aren't made part of the public API, so I don't think they need to become part of `xsf`.  That could be done in the future if there is downstream interest in such functions.

#### Reference issue

This change was inspired by https://github.com/scipy/scipy/issues/23487, but it doesn't close that issue.  The change makes the generation of random variates in `zipfian.rvs()` significantly faster, but there is another change (to be submitted in a follow-up PR) that should definitively resolve the slowness issue.

#### What does this implement/fix?

Before this change, the calculation of the harmonic numbers used in `stats.zipfian` when a <= 1 was implemented with a Python for-loop, so it was very slow.  This was especially evident in the generation of random variates, as noted in gh-23487.

This PR also improves the precision of the calculations in `zipfian` when `a` is greater than but close to 1.  When `a` > 1, the sum of the powers can be written $\zeta(a, m) - \zeta(a, n + 1)$, where $\zeta(a, m)$ is the Hurwitz zeta function.  Because of the subtraction, this formula loses numerical precision when $\zeta(a, m) \approx \zeta(a, n + 1)$.  In that case, the new function falls back to the simple sum of the powers. (See the comments in the code for more precise details.)

