### PR TITLE
MAINT, BLD: ignore meson wraplock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ pip-wheel-metadata
 .mesonpy-native-file.ini
 installdir/
 .mesonpy/
+.wraplock
 
 # doit
 ######


### PR DESCRIPTION
* The `1.9.0` release of `meson` from a few days ago includes some locking improvements that consistently lead to at least one `.wraplock` file artifact in the SciPy directory when using `spin build ...` commands. I think we might as well ignore these files just like they do upstream at https://github.com/mesonbuild/meson/pull/13854.

[ci skip] [skip ci]