### PR TITLE
ENH: linalg: add symmetric/hermitian modes to `linalg.inv`; add `lower={True, False}` argument

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1323,10 +1323,12 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
      upper triangular               'upper triangular'
      lower triangular               'lower triangular'
      symmetric positive definite    'pos'
+     symmetric                      'sym'
+     Hermitian                      'her'
     =============================  ================================
 
-    For the 'pos' option, only the specified triangle of the input matrix is used, and
-    the other triangle is not referenced.
+    For the 'pos', 'sym' and 'her' options, only the specified triangle of the input
+    matrix is used, and the other triangle is not referenced.
 
     Parameters
     ----------
@@ -1402,7 +1404,7 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
         overwrite_a = True
         a1 = a1.copy()
 
-    # keep the numbers in sync with C
+    # keep the numbers in sync with C at `linalg/src/_common_array_utils.hh`
     structure = {
         None: -1,
         'general': 0,
@@ -1410,6 +1412,8 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101,
+        'sym' : 201,
+        'her' : 211,
     }[assume_a]
 
     # a1 is well behaved, invert it.

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1310,7 +1310,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
 
 
 # matrix inversion
-def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
+def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
     r"""
     Compute the inverse of a matrix.
 
@@ -1322,11 +1322,11 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
      general                        'general' (or 'gen')
      upper triangular               'upper triangular'
      lower triangular               'lower triangular'
-     symmetric positive definite    'pos', 'pos upper', 'pos lower'
+     symmetric positive definite    'pos'
     =============================  ================================
 
-    For the 'pos upper' and 'pos lower' options, only the specified
-    triangle of the input matrix is used, and the other triangle is not referenced.
+    For the 'pos' option, only the specified triangle of the input matrix is used, and
+    the other triangle is not referenced.
 
     Parameters
     ----------
@@ -1342,6 +1342,11 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
         Valid entries are described above.
         If omitted or ``None``, checks are performed to identify structure so the
         appropriate solver can be called.
+    lower : bool, optional
+        Ignored unless assume_a is one of 'sym', 'her', or 'pos'. If True, the
+        calculation uses only the data in the lower triangle of `a`; entries above the
+        diagonal are ignored. If False (default), the calculation uses only the data in
+        the upper triangle of `a`; entries below the diagonal are ignored.
 
     Returns
     -------
@@ -1405,12 +1410,10 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101,
-        'pos upper': 111,     # the "other" triangle is not referenced
-        'pos lower': 112,
     }[assume_a]
 
     # a1 is well behaved, invert it.
-    inv_a, err_lst = _batched_linalg._inv(a1, structure, overwrite_a)
+    inv_a, err_lst = _batched_linalg._inv(a1, structure, overwrite_a, lower)
 
     # emit helpful errors/warnings
     if err_lst:

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -19,11 +19,12 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
     SliceStatusVec vec_status;
     St structure = St::NONE;
     int overwrite_a;
+    int lower;
     PyObject *ret_dct = NULL;
     PyObject *ret_lst = NULL;
 
     // Get the input array
-    if (!PyArg_ParseTuple(args, ("O!|np"), &PyArray_Type, (PyObject **)&ap_Am, &structure, &overwrite_a)) {
+    if (!PyArg_ParseTuple(args, ("O!|npp"), &PyArray_Type, (PyObject **)&ap_Am, &structure, &overwrite_a, &lower)) {
         return NULL;
     }
 
@@ -64,16 +65,16 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
     void *buf = PyArray_DATA(ap_Ainv);
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _inverse<float>(ap_Am, (float *)buf, structure, overwrite_a, vec_status);
+            info = _inverse<float>(ap_Am, (float *)buf, structure, lower, overwrite_a, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _inverse<double>(ap_Am, (double *)buf, structure, overwrite_a, vec_status);
+            info = _inverse<double>(ap_Am, (double *)buf, structure, lower, overwrite_a, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _inverse<npy_complex64>(ap_Am, (npy_complex64 *)buf, structure, overwrite_a, vec_status);
+            info = _inverse<npy_complex64>(ap_Am, (npy_complex64 *)buf, structure, lower, overwrite_a, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _inverse<npy_complex128>(ap_Am, (npy_complex128 *)buf, structure, overwrite_a, vec_status);
+            info = _inverse<npy_complex128>(ap_Am, (npy_complex128 *)buf, structure, lower, overwrite_a, vec_status);
             break;
         default:
             PYERR(PyExc_RuntimeError, "Unknown array type.")

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -275,6 +275,21 @@ enum St : Py_ssize_t
 
 
 /*
+ * Rich return object
+ */
+struct SliceStatus {
+    Py_ssize_t slice_num;
+    Py_ssize_t structure;
+    int is_singular;
+    int is_ill_conditioned;
+    double rcond;
+    Py_ssize_t lapack_info;
+};
+
+typedef std::vector<SliceStatus> SliceStatusVec;
+
+
+/*
  * Copy n-by-m slice from slice_ptr to dst.
  */
 template<typename T>

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -4,6 +4,7 @@
 #ifndef _SCIPY_COMMON_ARRAY_UTILS_H
 #define _SCIPY_COMMON_ARRAY_UTILS_H
 #include "Python.h"
+#include <tuple>
 #include "numpy/npy_math.h"
 #include "npy_cblas.h"
 
@@ -107,6 +108,45 @@ void BLAS_FUNC(dpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBL
 void BLAS_FUNC(cpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 void BLAS_FUNC(zpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
+/* ?SYTRF*/
+void BLAS_FUNC(ssytrf)(char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dsytrf)(char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(csytrf)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(zsytrf)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+
+/* ?SYTRI */
+void BLAS_FUNC(ssytri)(char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *work, CBLAS_INT *info);
+void BLAS_FUNC(dsytri)(char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *work, CBLAS_INT *info);
+void BLAS_FUNC(csytri)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *work, CBLAS_INT *info);
+void BLAS_FUNC(zsytri)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *work, CBLAS_INT *info);
+
+/* ?SYCON*/
+void BLAS_FUNC(ssycon)(char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *anorm, float *rcond,  float *work, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(dsycon)(char *uplo, CBLAS_INT *n, double *a,CBLAS_INT *lda, CBLAS_INT *ipiv, double *anorm, double *rcond, double *work, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(csycon)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *anorm, float *rcond, npy_complex64 *work, CBLAS_INT *info);
+void BLAS_FUNC(zsycon)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *anorm, double *rcond, npy_complex128 *work, CBLAS_INT *info);
+
+/* ?HETRF */
+void BLAS_FUNC(chetrf)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(zhetrf)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+
+/* ?HETRI */
+void BLAS_FUNC(chetri)(char *uplo, CBLAS_INT *n, npy_complex64 *a,  CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *work, CBLAS_INT *info);
+void BLAS_FUNC(zhetri)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *work, CBLAS_INT *info);
+
+/* ?SYTRS*/
+void BLAS_FUNC(ssytrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(dsytrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(csytrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zsytrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+
+/* ?HECON*/
+void BLAS_FUNC(checon)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *anorm, float *rcond, npy_complex64 *work, CBLAS_INT *info);
+void BLAS_FUNC(zhecon)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *anorm, double *rcond, npy_complex128 *work, CBLAS_INT *info);
+
+/* ?HETRS*/
+void BLAS_FUNC(chetrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zhetrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
 } // extern "C"
 
@@ -260,6 +300,103 @@ GEN_POTRS(c, npy_complex64)
 GEN_POTRS(z, npy_complex128)
 
 
+#define GEN_SYTRF(PREFIX, TYPE) \
+inline void \
+sytrf(char* uplo, CBLAS_INT* n, TYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_INT *lwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## sytrf)(uplo, n, a, lda, ipiv, work, lwork, info); \
+};
+
+GEN_SYTRF(s, float)
+GEN_SYTRF(d, double)
+GEN_SYTRF(c, npy_complex64)
+GEN_SYTRF(z, npy_complex128)
+
+
+// dispatch to sSYtrf for "float hermitian"
+#define GEN_HETRF(PREFIX, L_PREFIX, TYPE) \
+inline void \
+hetrf(char* uplo, CBLAS_INT* n, TYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_INT *lwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## L_PREFIX ## trf)(uplo, n, a, lda, ipiv, work, lwork, info); \
+};
+
+GEN_HETRF(s, sy, float)
+GEN_HETRF(d, sy, double)
+GEN_HETRF(c, he, npy_complex64)
+GEN_HETRF(z, he, npy_complex128)
+
+
+#define GEN_SYTRI(PREFIX, TYPE) \
+inline void \
+sytri(char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## sytri)(uplo, n, a, lda, ipiv, work, info); \
+};
+
+GEN_SYTRI(s, float)
+GEN_SYTRI(d, double)
+GEN_SYTRI(c, npy_complex64)
+GEN_SYTRI(z, npy_complex128)
+
+
+// dispatch to sSYtri for "float hermitian"
+#define GEN_HETRI(PREFIX, L_PREFIX, TYPE) \
+inline void \
+hetri(char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## L_PREFIX ## tri)(uplo, n, a, lda, ipiv, work, info); \
+};
+
+GEN_HETRI(s, sy, float)
+GEN_HETRI(d, sy, double)
+GEN_HETRI(c, he, npy_complex64)
+GEN_HETRI(z, he, npy_complex128)
+
+
+// NB: iwork for real arrays only, no rwork for complex routines (10 arguments for s- d- variants; 9 arguments for c- and z- variants)
+#define GEN_SYCON(PREFIX, CTYPE, RTYPE, WTYPE) \
+inline void \
+sycon(char* uplo, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, RTYPE* anorm, RTYPE* rcond, CTYPE* work, void *irwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## sycon)(uplo, n, a, lda, ipiv, anorm, rcond, work, (WTYPE *)irwork, info); \
+};
+
+GEN_SYCON(s, float, float, CBLAS_INT)
+GEN_SYCON(d, double, double, CBLAS_INT)
+
+#define GEN_SYCON_CZ(PREFIX, CTYPE, RTYPE, WTYPE) \
+inline void \
+sycon(char* uplo, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, RTYPE* anorm, RTYPE* rcond, CTYPE* work, void *irwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## sycon)(uplo, n, a, lda, ipiv, anorm, rcond, work, info); \
+};
+
+GEN_SYCON_CZ(c, npy_complex64, float, float)
+GEN_SYCON_CZ(z, npy_complex128, double, double)
+
+
+// dispatch to sSYcon for "float hermitian"
+#define GEN_HECON(PREFIX, CTYPE, RTYPE, WTYPE) \
+inline void \
+hecon(char* uplo, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, RTYPE* anorm, RTYPE* rcond, CTYPE* work, void *irwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## sycon)(uplo, n, a, lda, ipiv, anorm, rcond, work, (WTYPE *)irwork, info); \
+};
+
+GEN_HECON(s, float, float, CBLAS_INT)
+GEN_HECON(d, double, double, CBLAS_INT)
+
+#define GEN_HECON_CZ(PREFIX, CTYPE, RTYPE, WTYPE) \
+inline void \
+hecon(char* uplo, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, RTYPE* anorm, RTYPE* rcond, CTYPE* work, void *irwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## hecon)(uplo, n, a, lda, ipiv, anorm, rcond, work, info); \
+};
+
+GEN_HECON_CZ(c, npy_complex64, float, float)
+GEN_HECON_CZ(z, npy_complex128, double, double)
+
 
 // Structure tags; python side maps assume_a strings to these values
 enum St : Py_ssize_t
@@ -271,6 +408,8 @@ enum St : Py_ssize_t
     POS_DEF = 101,
     POS_DEF_UPPER = 111,
     POS_DEF_LOWER = 112,
+    SYM = 201,
+    HER = 211
 };
 
 
@@ -466,17 +605,26 @@ bandwidth(T* data, npy_intp n, npy_intp m, npy_intp* lower_band, npy_intp* upper
 
 
 template<typename T>
-bool
+std::tuple<bool, bool>
 is_sym_herm(const T *data, npy_intp n) {
+    // Return a pair of (is_symmetric_or_hermitian, is_symmetric_not_hermitian)
     using value_type = typename type_traits<T>::value_type;
     const value_type *p_data = reinterpret_cast<const value_type *>(data);
+    bool all_sym = true, all_herm = true;
 
     for (npy_intp i=0; i < n; i++) {
         for (npy_intp j=0; j < n; j++) {
-            if(p_data[i*n + j] != std::conj(p_data[i + j*n])) { return false; }
+            value_type elem1 = p_data[i*n + j];
+            value_type elem2 = p_data[i + j*n];
+            all_sym = all_sym && (elem1 == elem2);
+            all_herm = all_herm && (elem1 == std::conj(elem2));
+            if(!(all_sym || all_herm)) {
+                // short-circuit : it's neither symmetric not hermitian
+                return std::make_tuple(false, false);
+            }
         }
     }
-    return true;
+    return std::make_tuple(true, all_sym ? true : false);
 }
 
 
@@ -533,6 +681,25 @@ fill_other_triangle(char uplo, T *data, npy_intp n) {
         for (npy_intp i=0; i<n; i++) {
             for (npy_intp j=0; j<i+1; j++){
                 data[j + i*n] = conj(data[i + j*n]);
+            }
+        }
+    }
+}
+
+// XXX deduplicate (conj or noconj)
+template<typename T>
+inline void
+fill_other_triangle_noconj(char uplo, T *data, npy_intp n) {
+    if (uplo == 'U') {
+        for (npy_intp i=0; i<n; i++) {
+            for (npy_intp j=i+1; j<n; j++){
+                data[j + i*n] = data[i + j*n];
+            }
+        }
+    } else {
+        for (npy_intp i=0; i<n; i++) {
+            for (npy_intp j=0; j<i+1; j++){
+                data[j + i*n] = data[i + j*n];
             }
         }
     }

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -93,6 +93,53 @@ void invert_slice_cholesky(
     }
 }
 
+// Symmetric/hermitian array inversion with sytrf/hetrf and sytri/hetri
+template<typename T>
+void invert_slice_sym_herm(
+    char uplo, CBLAS_INT N, T *data, CBLAS_INT *ipiv, T *work, void *irwork, CBLAS_INT lwork,
+    bool is_symm_not_herm, 
+    SliceStatus& status
+) {
+    using real_type = typename type_traits<T>::real_type;
+
+    CBLAS_INT info;
+    real_type rcond;
+    real_type anorm = norm1_sym_herm(uplo, data, work, (npy_intp)N);
+
+    if(is_symm_not_herm) {
+        sytrf(&uplo, &N, data, &N, ipiv, work, &lwork, &info);
+    } else {
+        hetrf(&uplo, &N, data, &N, ipiv, work, &lwork, &info);
+    }
+
+    status.lapack_info = (Py_ssize_t)info;
+    if (info == 0) {
+        // {sy,he}trf success
+        if (is_symm_not_herm) {
+            sycon(&uplo, &N, data, &N, ipiv, &anorm, &rcond, work, irwork, &info);
+        } else {
+            hecon(&uplo, &N, data, &N, ipiv, &anorm, &rcond, work, irwork, &info);
+        }
+
+        if (info >= 0) {
+            status.rcond = (double)rcond;
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+
+            // finally, invert
+            if (is_symm_not_herm) {
+                sytri(&uplo, &N, data, &N, ipiv, work, &info);
+            } else {
+                hetri(&uplo, &N, data, &N, ipiv, work, &info);
+            }
+            status.is_singular = (info > 0);
+        }
+    }
+    else if (info > 0) {
+        // trf detected singularity
+        status.is_singular = 1;
+    }
+}
+
 
 // triangular array inversion with trtri
 template<typename T>
@@ -128,7 +175,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     npy_intp lower_band = 0, upper_band = 0;
-    bool is_symm = false;
+    bool is_symm_or_herm = false, is_symm_not_herm = false;
     char uplo;
     St slice_structure = St::NONE;
     bool posdef_fallback = true;
@@ -194,6 +241,12 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     if (structure == St::POS_DEF) {
         posdef_fallback = false;
     }
+    else if (structure == St::SYM) {
+        is_symm_not_herm = true;
+    }
+    else if (structure == St::HER) {
+        is_symm_not_herm = false;
+    }
     if (structure == St::LOWER_TRIANGULAR) {
         uplo = 'L';
     }
@@ -228,8 +281,8 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                 uplo = 'L';
             } else {
                 // Check if symmetric/hermitian
-                is_symm = is_sym_herm(data, n);
-                if (is_symm) {
+                std::tie(is_symm_or_herm, is_symm_not_herm) = is_sym_herm(data, n);
+                if (is_symm_or_herm) {
                     slice_structure = St::POS_DEF;
                 }
                 else {
@@ -277,7 +330,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                         swap_cf(scratch, data, n, n, n);
                         init_status(slice_status, idx, slice_structure);
 
-                        // no break: fall back to the general solver
+                        // no break: fall back to the symmetric solver
                     }
                     else {
                         // potrf failed but no fallback
@@ -285,6 +338,28 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                         break;
                     }
                 }
+            }
+            case St::SYM:     // NB: if POS_DEF failed, fall-through to here
+            case St::HER:
+            {
+                invert_slice_sym_herm(uplo, intn, data, ipiv, work, irwork, lwork, is_symm_not_herm, slice_status);
+
+                if ((slice_status.lapack_info < 0) || (slice_status.is_singular )) {
+                    vec_status.push_back(slice_status);
+                    goto free_exit;
+                }
+                else if (slice_status.is_ill_conditioned) {
+                    vec_status.push_back(slice_status);
+                }
+
+                if (is_symm_not_herm) {
+                    fill_other_triangle_noconj(uplo, data, intn);
+                }
+                else {
+                    fill_other_triangle(uplo, data, intn);
+                }
+                break;
+
             }
             default:
             {

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -3,6 +3,7 @@
  */
 #include "Python.h"
 #include <iostream>
+#include <vector>
 #include "numpy/arrayobject.h"
 #include "numpy/npy_math.h"
 #include "npy_cblas.h"
@@ -10,11 +11,20 @@
 #include "_common_array_utils.hh"
 
 
+void init_status(SliceStatus& slice_status, npy_intp idx, St slice_structure) {
+    slice_status.slice_num = idx;
+    slice_status.structure = (Py_ssize_t)slice_structure;
+    slice_status.is_singular = 0;
+    slice_status.is_ill_conditioned = 0;
+    slice_status.rcond = 0;
+    slice_status.lapack_info = 0;
+}
+
 // Dense array inversion with getrf, gecon and getri
 template<typename T>
-inline CBLAS_INT invert_slice_general(
+void invert_slice_general(
     CBLAS_INT N, T *data, CBLAS_INT *ipiv, void *irwork, T *work, CBLAS_INT lwork,
-    int* isIllconditioned, int* isSingular
+    SliceStatus& status
 ) {
     using real_type = typename type_traits<T>::real_type;
 
@@ -25,24 +35,24 @@ inline CBLAS_INT invert_slice_general(
 
     getrf(&N, &N, data, &N, ipiv, &info);
 
+    status.lapack_info = (Py_ssize_t)info;
     if (info == 0){
         // getrf success, check the condition number
         gecon(&norm, &N, data, &N, &anorm, &rcond, work, irwork, &info);
 
+        status.rcond = (double)rcond;
         if (info >= 0) {
-            *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
 
             // finally, invert
             getri(&N, data, &N, ipiv, work, &lwork, &info);
-            *isSingular = (info > 0);
+            status.is_singular = (info > 0);
         }
     }
     else if (info > 0) {
         // trf detected singularity
-        *isSingular = 1;
+        status.is_singular = 1;
     }
-
-    return info;
 }
 
 
@@ -50,9 +60,9 @@ inline CBLAS_INT invert_slice_general(
 
 // Symmetric/hermitian array inversion with potrf, pocon and potri
 template<typename T>
-inline CBLAS_INT invert_slice_cholesky(
+void invert_slice_cholesky(
     char uplo, CBLAS_INT N, T *data, T* work, void *irwork,
-    int* isIllconditioned, int* isSingular
+    SliceStatus& status
 ) {
     using real_type = typename type_traits<T>::real_type;
 
@@ -62,32 +72,33 @@ inline CBLAS_INT invert_slice_cholesky(
     real_type rcond;
 
     potrf(&uplo, &N, data, &N, &info);
+
+    status.lapack_info = (Py_ssize_t)info;
     if (info == 0) {
         // potrf success
         pocon(&uplo, &N, data, &N, &anorm, &rcond, work, irwork, &info);
 
         if (info >= 0) {
-            *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.rcond = (double)rcond;
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
 
             // finally, invert
             potri(&uplo, &N, data, &N, &info);
-            *isSingular = (info > 0);
+            status.is_singular = (info > 0);
         }
     }
     else if (info > 0) {
         // trf detected singularity
-        *isSingular = 1;
+        status.is_singular = 1;
     }
-
-    return info;
 }
 
 
 // triangular array inversion with trtri
 template<typename T>
-inline CBLAS_INT invert_slice_triangular(
+void invert_slice_triangular(
     char uplo, char diag, CBLAS_INT N, T *data, T *work, void *irwork,
-    int* isIllconditioned, int* isSingular
+    SliceStatus& status
 ) {
     using real_type = typename type_traits<T>::real_type;
 
@@ -96,31 +107,32 @@ inline CBLAS_INT invert_slice_triangular(
     real_type rcond;
 
     trtri(&uplo, &diag, &N, data, &N, &info);
-    *isSingular  = (info > 0);
+    status.is_singular  = (info > 0);
 
+    status.lapack_info = (Py_ssize_t)info;
     if(info >= 0) {
 
         trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
         if (info >= 0) {
-            *isIllconditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.rcond = (double)rcond;
         }
     }
-    return info;
 }
 
 
 template<typename T>
-void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, int* isIllconditioned, int* isSingular, CBLAS_INT* info)
+int
+_inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, SliceStatusVec& vec_status)
 {
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
-    *isIllconditioned = 0;
-    *isSingular = 0;
     npy_intp lower_band = 0, upper_band = 0;
     bool is_symm = false;
     char uplo;
     St slice_structure = St::NONE;
     bool posdef_fallback = true;
+    SliceStatus slice_status;
 
     // --------------------------------------------------------------------
     // Input Array Attributes
@@ -141,10 +153,10 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     T tmp = numeric_limits<T>::zero;
-    CBLAS_INT intn = (CBLAS_INT)n, lwork = -1;
+    CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
 
-    getri(&intn, NULL, &intn, NULL, &tmp, &lwork, info);
-    if (*info != 0) { *info = -100; return; }
+    getri(&intn, NULL, &intn, NULL, &tmp, &lwork, &info);
+    if (info != 0) { info = -100; return (int)info; }
 
     /*
      * The factor of 1.01 here mirrors
@@ -158,7 +170,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
 
     lwork = (4*n > lwork ? 4*n : lwork); // gecon needs at least 4*n
     T* buffer = (T *)malloc((2*n*n + lwork)*sizeof(T));
-    if (NULL == buffer) { *info = -101; return; }
+    if (NULL == buffer) { info = -101; return (int)info; }
 
     // Chop buffer into parts, one for data and one for work
     T* data = &buffer[0];
@@ -166,7 +178,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
     T* work = &buffer[2*n*n];
 
     CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
-    if (ipiv == NULL) { free(ipiv); *info = -102; return; }
+    if (ipiv == NULL) { free(ipiv); info = -102; return (int)info; }
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
@@ -175,7 +187,7 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
     }
-    if (irwork == NULL) { free(irwork); *info = -102; return; }
+    if (irwork == NULL) { free(irwork); info = -102; return (int)info; }
 
     // normalize the structure detection inputs
     uplo = 'U';
@@ -241,23 +253,34 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
             }
         }
 
+        init_status(slice_status, idx, slice_structure);
+
         switch(slice_structure) {
             case St::UPPER_TRIANGULAR:
             case St::LOWER_TRIANGULAR:
             {
                 char diag = 'N';
-                *info = invert_slice_triangular(uplo, diag, intn, data, work, irwork, isIllconditioned, isSingular);
+                invert_slice_triangular(uplo, diag, intn, data, work, irwork, slice_status);
 
-                if ((*info < 0) || (*isSingular )) { goto free_exit;}
+                if ((slice_status.lapack_info < 0) || (slice_status.is_singular )) {
+                    vec_status.push_back(slice_status);
+                    goto free_exit;
+                }
+                else if (slice_status.is_ill_conditioned) {
+                    vec_status.push_back(slice_status);
+                }
                 zero_other_triangle(uplo, data, intn);
                 break;
             }
             case St::POS_DEF:
             {
-                *info = invert_slice_cholesky(uplo, intn, data, work, irwork, isIllconditioned, isSingular);
+                invert_slice_cholesky(uplo, intn, data, work, irwork, slice_status);
 
-                if ((*info == 0) || (*isSingular == 0) ) {
-                    // success
+                if ((slice_status.lapack_info == 0) || (!slice_status.is_singular) ) {
+                    // success (maybe ill-conditioned)
+                    if(slice_status.is_ill_conditioned) {
+                        vec_status.push_back(slice_status);
+                    }
                     fill_other_triangle(uplo, data, intn);
                     break;
                 }
@@ -266,11 +289,13 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
                         // restore
                         copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
                         swap_cf(scratch, data, n, n, n);
+                        init_status(slice_status, idx, slice_structure);
 
                         // no break: fall back to the general solver
                     }
                     else {
                         // potrf failed but no fallback
+                        vec_status.push_back(slice_status);
                         break;
                     }
                 }
@@ -278,11 +303,16 @@ void _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, 
             default:
             {
                 // general matrix inverse
-                *info = invert_slice_general(intn, data, ipiv, irwork, work, lwork, isIllconditioned, isSingular);
+                invert_slice_general(intn, data, ipiv, irwork, work, lwork, slice_status);
+
+                if ((slice_status.lapack_info != 0) || slice_status.is_singular || slice_status.is_ill_conditioned) {
+                    // some problem detected, store data to report
+                    vec_status.push_back(slice_status);
+                }
             }
         }
 
-        if (*isSingular == 1) {
+        if (slice_status.is_singular == 1) {
             // nan_matrix(data, n);
             goto free_exit;     // fail fast and loud
         }
@@ -295,6 +325,6 @@ free_exit:
     free(buffer);
     free(irwork);
     free(ipiv);
-    return;
+    return 1;
 }
 

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -123,7 +123,7 @@ void invert_slice_triangular(
 
 template<typename T>
 int
-_inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, SliceStatusVec& vec_status)
+_inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwrite_a, SliceStatusVec& vec_status)
 {
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
@@ -190,22 +190,9 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, Slice
     if (irwork == NULL) { free(irwork); info = -102; return (int)info; }
 
     // normalize the structure detection inputs
-    uplo = 'U';
+    uplo = lower? 'L' : 'U';
     if (structure == St::POS_DEF) {
-        uplo = 'U';
         posdef_fallback = false;
-    }
-    else {
-        if (structure == St::POS_DEF_UPPER) {
-            structure = St::POS_DEF;
-            uplo = 'U';
-            posdef_fallback = false;
-        }
-        else if (structure == St::POS_DEF_LOWER) {
-            structure = St::POS_DEF;
-            uplo = 'L';
-            posdef_fallback = false;
-        }
     }
     if (structure == St::LOWER_TRIANGULAR) {
         uplo = 'L';
@@ -244,7 +231,6 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int overwrite_a, Slice
                 is_symm = is_sym_herm(data, n);
                 if (is_symm) {
                     slice_structure = St::POS_DEF;
-                    uplo = 'U';
                 }
                 else {
                     // give up auto-detection

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -118,7 +118,7 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
     *isSingular = 0;
     char trans = transposed ? 'T' : 'N'; 
     npy_intp lower_band = 0, upper_band = 0;
-    bool is_symm = false;
+    bool is_symm_or_herm = false, is_symm_not_herm = false;
     char uplo = 'X';    // sentinel
     St slice_structure = St::NONE;
     bool posdef_fallback = true;
@@ -234,8 +234,8 @@ void _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure
                 uplo = 'L';
             } else {
                 // Check if symmetric/hermitian
-                is_symm = is_sym_herm(data, n);
-                if (is_symm) {
+                std::tie(is_symm_or_herm, is_symm_not_herm) = is_sym_herm(data, n);
+                if (is_symm_or_herm) {
                     slice_structure = St::POS_DEF;
                     uplo = 'U';
                 }

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1385,13 +1385,13 @@ class TestInv:
 
         assert_allclose(y_inv1, y_inv0, atol=1e-15)
 
-        # check that the lower triangle is not referenced for "pos upper"
+        # check that the lower triangle is not referenced for `lower=False`
         mask = np.where(1 - np.tri(*y.shape, -1) == 0, np.nan, 1)
-        y_inv2 = inv(y*mask, check_finite=False, assume_a="pos upper")
+        y_inv2 = inv(y*mask, check_finite=False, assume_a="pos", lower=False)
         assert_allclose(y_inv2, y_inv0, atol=1e-15)
 
-        # repeat with the upper triangle and "pos lower"
-        y_inv3 = inv(y*mask.T, check_finite=False, assume_a="pos lower")
+        # repeat with the upper triangle
+        y_inv3 = inv(y*mask.T, check_finite=False, assume_a="pos", lower=True)
         assert_allclose(y_inv3, y_inv0, atol=1e-15)
 
     def test_posdef_not_posdef(self):
@@ -1399,13 +1399,18 @@ class TestInv:
         a = np.arange(9).reshape(3, 3)
         b = a + a.T + np.eye(3)
 
-        # cholesky solver fails, and the routine falls back to the general inverse
+        # cholesky solver fails, and the routine falls back to the symmetric inverse
         b_inv0 = inv(b)
         assert_allclose(b_inv0 @ b, np.eye(3), atol=3e-15)
 
         # but it does not fall back if `assume_a` is given
         with assert_raises(LinAlgError):
             inv(b, assume_a='pos')
+
+        # TODO:
+        #   1. posdef fallback for complex symmetric, hermitian inputs
+        #   2. assume_a = "sym" for real and complex
+        #   3. assume_a = "her" for real and complex
 
     def test_triangular_1(self):
         x = np.arange(25, dtype=float).reshape(5, 5)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1367,6 +1367,10 @@ class TestInv:
         with pytest.warns(LinAlgWarning):
             inv(a)
 
+        a2 = np.stack([np.diag([1., 1e-20]), np.diag([1, 1]), np.diag([1, 1e-20])])
+        with pytest.warns(LinAlgWarning):
+            inv(a2)
+
     def test_wrong_assume_a(self):
         with assert_raises(KeyError):
             inv(np.eye(2), assume_a="kaboom")


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

a part of https://github.com/scipy/scipy/issues/23141

#### What does this implement/fix?
<!--Please explain your changes.-->

Add specialized inversion routines for symmetric and hermitian matrices to `linalg.inv`.

When an argument of `inv` is auto-detected as symmetric or hermitian, we first try the Cholesky based inversion. If that fails, it means that the matrix is symmetric but not positive definite. On main, we fall back to the generic solver; 
In this PR, we fall back to the new "sym" or "her" routines ,backed by LAPACK's   `?sytrf/?sycon/?sytri` and `?hetrf/?hecon/?hetri`.

Using explicit `assume_a="sym"` or `"her"` bypasses the autodetection, similar to other modes.

#### Additional information
<!--Any additional information you think is important.-->

For "pos", "sym" and "her" modes, we need to be able to select the upper or lower triangle. Given the long discussion in https://github.com/scipy/scipy/pull/23350, this PR adds a new `lower={True/False}` argument to `inv`  and _removes the "pos lower" mode_. Removing the mode has no backwards compatible concerns because it was only added in scipy 1.17 which has not been released yet (in https://github.com/scipy/scipy/pull/22924).

Also this PR is based off https://github.com/scipy/scipy/pull/23362, if only to minimize code churn. If that PR lands before this one, I'll rebase.

There are three separate commits: one MAINT for gh-23362, one ENH for the new `lower` argument, and the third one adds the new "sym/her" modes. 