### PR TITLE
`linalg.solve`: move "sym"/"her" solvers to C

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -102,6 +102,36 @@ class Bench(Benchmark):
     )
 
 
+class BatchedSolveBench(Benchmark):
+    params = [
+        [(100, 10, 10), (100, 20, 20), (100, 100)],
+        ["gen", "pos", "sym"],
+        ["scipy", "numpy"]
+    ]
+    param_names = ["shape", "structure" ,"module"]
+
+    def setup(self, shape, structure, module):
+        a = random(shape)
+        # larger diagonal ensures non-singularity:
+        for i in range(shape[-1]):
+            a[..., i, i] = 10*(.1+a[..., i, i])
+
+        if structure == "pos":
+            self.a = a @ a.mT
+        elif structure == "sym":
+            self.a = a + a.mT
+        else:
+            self.a = a
+
+        self.b = random([a.shape[-1]])
+
+    def time_solve(self, shape, structure, module):
+        if module == 'numpy':
+            nl.solve(self.a, self.b)
+        else:
+            sl.solve(self.a, self.b, assume_a=structure)
+
+
 class Norm(Benchmark):
     params = [
         [(20, 20), (100, 100), (1000, 1000), (20, 1000), (1000, 20)],

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -209,7 +209,7 @@ def solve(a, b, lower=False, overwrite_a=False,
            [ 5. , -4.5]])
     """
     if assume_a in [
-        'sym', 'her', 'symmetric', 'hermitian', 'diagonal', 'tridiagonal', 'banded'
+        'diagonal', 'tridiagonal', 'banded'
     ]:
         # TODO: handle these structures in this function
         return solve0(
@@ -225,6 +225,8 @@ def solve(a, b, lower=False, overwrite_a=False,
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101, 'positive definite': 101,
+        'sym' : 201, 'symmetric': 201,
+        'her' : 211, 'hermitian': 211,
     }.get(assume_a, 'unknown')
     if structure == 'unknown':
         raise ValueError(f'{assume_a} is not a recognized matrix structure')

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1349,10 +1349,12 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
      upper triangular               'upper triangular'
      lower triangular               'lower triangular'
      symmetric positive definite    'pos'
+     symmetric                      'sym'
+     Hermitian                      'her'
     =============================  ================================
 
-    For the 'pos' option, only the triangle of the input matrix specified in
-    the `lower` argument is used, and the other triangle is not referenced.
+    For the 'pos', 'sym' and 'her' options, only the specified triangle of the input
+    matrix is used, and the other triangle is not referenced.
 
     Array argument(s) of this function may have additional
     "batch" dimensions prepended to the core shape. In this case, the array is treated
@@ -1432,7 +1434,7 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
         overwrite_a = True
         a1 = a1.copy()
 
-    # keep the numbers in sync with C
+    # keep the numbers in sync with C at `linalg/src/_common_array_utils.hh`
     structure = {
         None: -1,
         'general': 0,
@@ -1440,6 +1442,8 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101,
+        'sym' : 201,
+        'her' : 211,
     }[assume_a]
 
     # a1 is well behaved, invert it.

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -398,6 +398,33 @@ GEN_HECON_CZ(c, npy_complex64, float, float)
 GEN_HECON_CZ(z, npy_complex128, double, double)
 
 
+#define GEN_SYTRS(PREFIX, TYPE) \
+inline void \
+sytrs(char* uplo, CBLAS_INT* n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *b, CBLAS_INT *ldb, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## sytrs)(uplo, n, nrhs, a, lda, ipiv, b, ldb, info); \
+};
+
+GEN_SYTRS(s, float)
+GEN_SYTRS(d, double)
+GEN_SYTRS(c, npy_complex64)
+GEN_SYTRS(z, npy_complex128)
+
+
+// dispatch to sSYtrs for "float hermitian"
+#define GEN_HETRS(PREFIX, L_PREFIX, TYPE) \
+inline void \
+hetrs(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *b, CBLAS_INT *ldb, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## L_PREFIX ## trs)(uplo, n, nrhs, a, lda, ipiv, b, ldb, info); \
+};
+
+GEN_HETRS(s, sy, float)
+GEN_HETRS(d, sy, double)
+GEN_HETRS(c, he, npy_complex64)
+GEN_HETRS(z, he, npy_complex128)
+
+
 // Structure tags; python side maps assume_a strings to these values
 enum St : Py_ssize_t
 {

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -488,7 +488,9 @@ CBLAS_INT _calc_lwork(T _lwrk, double fudge_factor=1.0) {
     using real_type = typename type_traits<T>::real_type;
 
     real_type value = real_part(_lwrk) * fudge_factor;
-    if(type_traits<T>::is_single_precision) {
+    if((std::is_same<real_type, float>::value) ||
+       (std::is_same<real_type, npy_complex64>::value)
+    ) {
         // Single-precision routine -- take next fp value to work
         // around possible truncation in LAPACK code
         value = std::nextafter(value, std::numeric_limits<real_type>::infinity());

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -4,6 +4,7 @@
 #ifndef _SCIPY_COMMON_ARRAY_UTILS_H
 #define _SCIPY_COMMON_ARRAY_UTILS_H
 #include "Python.h"
+#include <tuple>
 #include "numpy/npy_math.h"
 #include "npy_cblas.h"
 
@@ -107,6 +108,45 @@ void BLAS_FUNC(dpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBL
 void BLAS_FUNC(cpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 void BLAS_FUNC(zpotrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
+/* ?SYTRF*/
+void BLAS_FUNC(ssytrf)(char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dsytrf)(char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(csytrf)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(zsytrf)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+
+/* ?SYTRI */
+void BLAS_FUNC(ssytri)(char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *work, CBLAS_INT *info);
+void BLAS_FUNC(dsytri)(char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *work, CBLAS_INT *info);
+void BLAS_FUNC(csytri)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *work, CBLAS_INT *info);
+void BLAS_FUNC(zsytri)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *work, CBLAS_INT *info);
+
+/* ?SYCON*/
+void BLAS_FUNC(ssycon)(char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *anorm, float *rcond,  float *work, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(dsycon)(char *uplo, CBLAS_INT *n, double *a,CBLAS_INT *lda, CBLAS_INT *ipiv, double *anorm, double *rcond, double *work, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(csycon)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *anorm, float *rcond, npy_complex64 *work, CBLAS_INT *info);
+void BLAS_FUNC(zsycon)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *anorm, double *rcond, npy_complex128 *work, CBLAS_INT *info);
+
+/* ?HETRF */
+void BLAS_FUNC(chetrf)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(zhetrf)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+
+/* ?HETRI */
+void BLAS_FUNC(chetri)(char *uplo, CBLAS_INT *n, npy_complex64 *a,  CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *work, CBLAS_INT *info);
+void BLAS_FUNC(zhetri)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *work, CBLAS_INT *info);
+
+/* ?SYTRS*/
+void BLAS_FUNC(ssytrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(dsytrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(csytrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zsytrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+
+/* ?HECON*/
+void BLAS_FUNC(checon)(char *uplo, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, float *anorm, float *rcond, npy_complex64 *work, CBLAS_INT *info);
+void BLAS_FUNC(zhecon)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, double *anorm, double *rcond, npy_complex128 *work, CBLAS_INT *info);
+
+/* ?HETRS*/
+void BLAS_FUNC(chetrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zhetrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
 } // extern "C"
 
@@ -259,6 +299,103 @@ GEN_POTRS(d, double)
 GEN_POTRS(c, npy_complex64)
 GEN_POTRS(z, npy_complex128)
 
+
+#define GEN_SYTRF(PREFIX, TYPE) \
+inline void \
+sytrf(char* uplo, CBLAS_INT* n, TYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_INT *lwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## sytrf)(uplo, n, a, lda, ipiv, work, lwork, info); \
+};
+
+GEN_SYTRF(s, float)
+GEN_SYTRF(d, double)
+GEN_SYTRF(c, npy_complex64)
+GEN_SYTRF(z, npy_complex128)
+
+
+// dispatch to sSYtrf for "float hermitian"
+#define GEN_HETRF(PREFIX, L_PREFIX, TYPE) \
+inline void \
+hetrf(char* uplo, CBLAS_INT* n, TYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_INT *lwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## L_PREFIX ## trf)(uplo, n, a, lda, ipiv, work, lwork, info); \
+};
+
+GEN_HETRF(s, sy, float)
+GEN_HETRF(d, sy, double)
+GEN_HETRF(c, he, npy_complex64)
+GEN_HETRF(z, he, npy_complex128)
+
+
+#define GEN_SYTRI(PREFIX, TYPE) \
+inline void \
+sytri(char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## sytri)(uplo, n, a, lda, ipiv, work, info); \
+};
+
+GEN_SYTRI(s, float)
+GEN_SYTRI(d, double)
+GEN_SYTRI(c, npy_complex64)
+GEN_SYTRI(z, npy_complex128)
+
+
+// dispatch to sSYtri for "float hermitian"
+#define GEN_HETRI(PREFIX, L_PREFIX, TYPE) \
+inline void \
+hetri(char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *ipiv, TYPE *work, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## L_PREFIX ## tri)(uplo, n, a, lda, ipiv, work, info); \
+};
+
+GEN_HETRI(s, sy, float)
+GEN_HETRI(d, sy, double)
+GEN_HETRI(c, he, npy_complex64)
+GEN_HETRI(z, he, npy_complex128)
+
+
+// NB: iwork for real arrays only, no rwork for complex routines (10 arguments for s- d- variants; 9 arguments for c- and z- variants)
+#define GEN_SYCON(PREFIX, CTYPE, RTYPE, WTYPE) \
+inline void \
+sycon(char* uplo, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, RTYPE* anorm, RTYPE* rcond, CTYPE* work, void *irwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## sycon)(uplo, n, a, lda, ipiv, anorm, rcond, work, (WTYPE *)irwork, info); \
+};
+
+GEN_SYCON(s, float, float, CBLAS_INT)
+GEN_SYCON(d, double, double, CBLAS_INT)
+
+#define GEN_SYCON_CZ(PREFIX, CTYPE, RTYPE, WTYPE) \
+inline void \
+sycon(char* uplo, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, RTYPE* anorm, RTYPE* rcond, CTYPE* work, void *irwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## sycon)(uplo, n, a, lda, ipiv, anorm, rcond, work, info); \
+};
+
+GEN_SYCON_CZ(c, npy_complex64, float, float)
+GEN_SYCON_CZ(z, npy_complex128, double, double)
+
+
+// dispatch to sSYcon for "float hermitian"
+#define GEN_HECON(PREFIX, CTYPE, RTYPE, WTYPE) \
+inline void \
+hecon(char* uplo, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, RTYPE* anorm, RTYPE* rcond, CTYPE* work, void *irwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## sycon)(uplo, n, a, lda, ipiv, anorm, rcond, work, (WTYPE *)irwork, info); \
+};
+
+GEN_HECON(s, float, float, CBLAS_INT)
+GEN_HECON(d, double, double, CBLAS_INT)
+
+#define GEN_HECON_CZ(PREFIX, CTYPE, RTYPE, WTYPE) \
+inline void \
+hecon(char* uplo, CBLAS_INT* n, CTYPE* a, CBLAS_INT* lda, CBLAS_INT *ipiv, RTYPE* anorm, RTYPE* rcond, CTYPE* work, void *irwork, CBLAS_INT* info) \
+{ \
+    BLAS_FUNC(PREFIX ## hecon)(uplo, n, a, lda, ipiv, anorm, rcond, work, info); \
+};
+
+GEN_HECON_CZ(c, npy_complex64, float, float)
+GEN_HECON_CZ(z, npy_complex128, double, double)
 
 
 // Structure tags; python side maps assume_a strings to these values
@@ -477,17 +614,26 @@ bandwidth(T* data, npy_intp n, npy_intp m, npy_intp* lower_band, npy_intp* upper
 
 
 template<typename T>
-bool
+std::tuple<bool, bool>
 is_sym_herm(const T *data, npy_intp n) {
+    // Return a pair of (is_symmetric_or_hermitian, is_symmetric_not_hermitian)
     using value_type = typename type_traits<T>::value_type;
     const value_type *p_data = reinterpret_cast<const value_type *>(data);
+    bool all_sym = true, all_herm = true;
 
     for (npy_intp i=0; i < n; i++) {
         for (npy_intp j=0; j < n; j++) {
-            if(p_data[i*n + j] != std::conj(p_data[i + j*n])) { return false; }
+            value_type elem1 = p_data[i*n + j];
+            value_type elem2 = p_data[i + j*n];
+            all_sym = all_sym && (elem1 == elem2);
+            all_herm = all_herm && (elem1 == std::conj(elem2));
+            if(!(all_sym || all_herm)) {
+                // short-circuit : it's neither symmetric not hermitian
+                return std::make_tuple(false, false);
+            }
         }
     }
-    return true;
+    return std::make_tuple(true, all_sym ? true : false);
 }
 
 
@@ -544,6 +690,25 @@ fill_other_triangle(char uplo, T *data, npy_intp n) {
         for (npy_intp i=0; i<n; i++) {
             for (npy_intp j=0; j<i+1; j++){
                 data[j + i*n] = conj(data[i + j*n]);
+            }
+        }
+    }
+}
+
+// XXX deduplicate (conj or noconj)
+template<typename T>
+inline void
+fill_other_triangle_noconj(char uplo, T *data, npy_intp n) {
+    if (uplo == 'U') {
+        for (npy_intp i=0; i<n; i++) {
+            for (npy_intp j=i+1; j<n; j++){
+                data[j + i*n] = data[i + j*n];
+            }
+        }
+    } else {
+        for (npy_intp i=0; i<n; i++) {
+            for (npy_intp j=0; j<i+1; j++){
+                data[j + i*n] = data[i + j*n];
             }
         }
     }

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -84,6 +84,53 @@ void invert_slice_cholesky(
     }
 }
 
+// Symmetric/hermitian array inversion with sytrf/hetrf and sytri/hetri
+template<typename T>
+void invert_slice_sym_herm(
+    char uplo, CBLAS_INT N, T *data, CBLAS_INT *ipiv, T *work, void *irwork, CBLAS_INT lwork,
+    bool is_symm_not_herm, 
+    SliceStatus& status
+) {
+    using real_type = typename type_traits<T>::real_type;
+
+    CBLAS_INT info;
+    real_type rcond;
+    real_type anorm = norm1_sym_herm(uplo, data, work, (npy_intp)N);
+
+    if(is_symm_not_herm) {
+        sytrf(&uplo, &N, data, &N, ipiv, work, &lwork, &info);
+    } else {
+        hetrf(&uplo, &N, data, &N, ipiv, work, &lwork, &info);
+    }
+
+    status.lapack_info = (Py_ssize_t)info;
+    if (info == 0) {
+        // {sy,he}trf success
+        if (is_symm_not_herm) {
+            sycon(&uplo, &N, data, &N, ipiv, &anorm, &rcond, work, irwork, &info);
+        } else {
+            hecon(&uplo, &N, data, &N, ipiv, &anorm, &rcond, work, irwork, &info);
+        }
+
+        if (info >= 0) {
+            status.rcond = (double)rcond;
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+
+            // finally, invert
+            if (is_symm_not_herm) {
+                sytri(&uplo, &N, data, &N, ipiv, work, &info);
+            } else {
+                hetri(&uplo, &N, data, &N, ipiv, work, &info);
+            }
+            status.is_singular = (info > 0);
+        }
+    }
+    else if (info > 0) {
+        // trf detected singularity
+        status.is_singular = 1;
+    }
+}
+
 
 // triangular array inversion with trtri
 template<typename T>
@@ -119,7 +166,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     npy_intp lower_band = 0, upper_band = 0;
-    bool is_symm = false;
+    bool is_symm_or_herm = false, is_symm_not_herm = false;
     char uplo;
     St slice_structure = St::NONE;
     bool posdef_fallback = true;
@@ -194,6 +241,12 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     if (structure == St::POS_DEF) {
         posdef_fallback = false;
     }
+    else if (structure == St::SYM) {
+        is_symm_not_herm = true;
+    }
+    else if (structure == St::HER) {
+        is_symm_not_herm = false;
+    }
     if (structure == St::LOWER_TRIANGULAR) {
         uplo = 'L';
     }
@@ -228,8 +281,8 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                 uplo = 'L';
             } else {
                 // Check if symmetric/hermitian
-                is_symm = is_sym_herm(data, n);
-                if (is_symm) {
+                std::tie(is_symm_or_herm, is_symm_not_herm) = is_sym_herm(data, n);
+                if (is_symm_or_herm) {
                     slice_structure = St::POS_DEF;
                 }
                 else {
@@ -277,7 +330,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                         swap_cf(scratch, data, n, n, n);
                         init_status(slice_status, idx, slice_structure);
 
-                        // no break: fall back to the general solver
+                        // no break: fall back to the symmetric solver
                     }
                     else {
                         // potrf failed but no fallback
@@ -285,6 +338,28 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                         break;
                     }
                 }
+            }
+            case St::SYM:     // NB: if POS_DEF failed, fall-through to here
+            case St::HER:
+            {
+                invert_slice_sym_herm(uplo, intn, data, ipiv, work, irwork, lwork, is_symm_not_herm, slice_status);
+
+                if ((slice_status.lapack_info < 0) || (slice_status.is_singular )) {
+                    vec_status.push_back(slice_status);
+                    goto free_exit;
+                }
+                else if (slice_status.is_ill_conditioned) {
+                    vec_status.push_back(slice_status);
+                }
+
+                if (is_symm_not_herm) {
+                    fill_other_triangle_noconj(uplo, data, intn);
+                }
+                else {
+                    fill_other_triangle(uplo, data, intn);
+                }
+                break;
+
             }
             default:
             {

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -359,7 +359,6 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                     fill_other_triangle(uplo, data, intn);
                 }
                 break;
-
             }
             default:
             {

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -14,7 +14,7 @@
 // Dense array solve with getrf, gecon and getrs
 template<typename T>
 inline void solve_slice_general(
-    CBLAS_INT N, CBLAS_INT NRHS, T *data, CBLAS_INT *ipiv, T *b_data, char trans, void *irwork, T *work, CBLAS_INT lwork,
+    CBLAS_INT N, CBLAS_INT NRHS, T *data, CBLAS_INT *ipiv, T *b_data, char trans, void *irwork, T *work,
     SliceStatus& status
 ) {
     using real_type = typename type_traits<T>::real_type;
@@ -146,7 +146,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     // --------------------------------------------------------------------
     // Workspace computation and allocation
     // --------------------------------------------------------------------
-    CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs, lwork = -1, info;
+    CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs, lwork, info;
 
     // XXX: workspace query
     lwork = 4*n; // gecon needs at least 4*n
@@ -293,7 +293,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
             default:
             {
                 // general matrix inverse
-                solve_slice_general(intn, int_nrhs, data, ipiv, data_b, trans, irwork, work, lwork, slice_status);
+                solve_slice_general(intn, int_nrhs, data, ipiv, data_b, trans, irwork, work, slice_status);
 
                 if ((slice_status.lapack_info != 0) || slice_status.is_singular || slice_status.is_ill_conditioned) {
                     // some problem detected, store data to report

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -116,7 +116,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
 
     char trans = transposed ? 'T' : 'N'; 
     npy_intp lower_band = 0, upper_band = 0;
-    bool is_symm = false;
+    bool is_symm_or_herm = false, is_symm_not_herm = false;
     char uplo = 'X';    // sentinel
     St slice_structure = St::NONE;
     bool posdef_fallback = true;
@@ -231,8 +231,8 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
                 uplo = 'L';
             } else {
                 // Check if symmetric/hermitian
-                is_symm = is_sym_herm(data, n);
-                if (is_symm) {
+                std::tie(is_symm_or_herm, is_symm_not_herm) = is_sym_herm(data, n);
+                if (is_symm_or_herm) {
                     slice_structure = St::POS_DEF;
                 }
                 else {

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -56,6 +56,7 @@ template<> struct type_traits<float> {
     using value_type = float;
     static constexpr int typenum = NPY_FLOAT;
     static constexpr bool is_complex = false;
+    static constexpr bool is_single_precision = true;
 
 };
 template<> struct type_traits<double> {
@@ -63,18 +64,21 @@ template<> struct type_traits<double> {
     using value_type = double;
     static constexpr int typenum = NPY_DOUBLE;
     static constexpr bool is_complex = false;
+    static constexpr bool is_single_precision = false;
 };
 template<> struct type_traits<npy_complex64> {
     using real_type = float;
     using value_type = std::complex<float>;
     static constexpr int typenum = NPY_COMPLEX64;
     static constexpr bool is_complex = true;
+    static constexpr bool is_single_precision = true;
 };
 template<> struct type_traits<npy_complex128> {
     using real_type = double;
     using value_type = std::complex<double>;
     static constexpr int typenum = NPY_COMPLEX128;
     static constexpr bool is_complex = true;
+    static constexpr bool is_single_precision = false;
 };
 
 

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -56,7 +56,6 @@ template<> struct type_traits<float> {
     using value_type = float;
     static constexpr int typenum = NPY_FLOAT;
     static constexpr bool is_complex = false;
-    static constexpr bool is_single_precision = true;
 
 };
 template<> struct type_traits<double> {
@@ -64,21 +63,18 @@ template<> struct type_traits<double> {
     using value_type = double;
     static constexpr int typenum = NPY_DOUBLE;
     static constexpr bool is_complex = false;
-    static constexpr bool is_single_precision = false;
 };
 template<> struct type_traits<npy_complex64> {
     using real_type = float;
     using value_type = std::complex<float>;
     static constexpr int typenum = NPY_COMPLEX64;
     static constexpr bool is_complex = true;
-    static constexpr bool is_single_precision = true;
 };
 template<> struct type_traits<npy_complex128> {
     using real_type = double;
     using value_type = std::complex<double>;
     static constexpr int typenum = NPY_COMPLEX128;
     static constexpr bool is_complex = true;
-    static constexpr bool is_single_precision = false;
 };
 
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1384,10 +1384,13 @@ class TestInv:
         y_inv3 = inv(y*mask.T, check_finite=False, assume_a="pos", lower=True)
         assert_allclose(y_inv3, y_inv0, atol=1e-15)
 
-    def test_posdef_not_posdef(self):
-        # the `b` matrix is invertible but not positive definite
+    @pytest.mark.parametrize('complex_', [False, True])
+    def test_posdef_not_posdef(self, complex_):
+        # the `b` matrix is invertible but not pos definite: test the "sym" fallback
         a = np.arange(9).reshape(3, 3)
         b = a + a.T + np.eye(3)
+        if complex_:
+            b = b + 1j*b
 
         # cholesky solver fails, and the routine falls back to the symmetric inverse
         b_inv0 = inv(b)
@@ -1397,10 +1400,58 @@ class TestInv:
         with assert_raises(LinAlgError):
             inv(b, assume_a='pos')
 
-        # TODO:
-        #   1. posdef fallback for complex symmetric, hermitian inputs
-        #   2. assume_a = "sym" for real and complex
-        #   3. assume_a = "her" for real and complex
+        # test posdef fallback to the hermitian solver, too
+        if complex_:
+            a = np.arange(9).reshape(3, 3)
+            a = a + 1j*a
+            b = a + a.T.conj() + np.eye(3)
+            assert_allclose(inv(b) @ b, np.eye(3), atol=3e-15)
+
+    @pytest.mark.parametrize('complex_', [False, True])
+    def test_sym(self, complex_):
+        # test the "sym" mode
+        a = np.arange(9).reshape(3, 3)
+        b = a + a.T + np.eye(3)
+        if complex_:
+            b = b + 1j*b
+
+        b_inv0 = inv(b)
+        assert_allclose(b_inv0 @ b, np.eye(3), atol=1e-14)
+
+        b_inv1 = inv(b, assume_a="sym")
+        assert_allclose(b_inv0, b_inv1, atol=1e-15)
+
+        # check that the "other" triangle is not referenced
+        mask = np.where(1 - np.tri(*a.shape, -1) == 0, np.nan, 1)
+        b_inv2 = inv(b*mask, check_finite=False, assume_a="sym", lower=False)
+        assert_allclose(b_inv2, b_inv0, atol=1e-15)
+
+        # repeat with the upper triangle
+        b_inv3 = inv(b*mask.T, check_finite=False, assume_a="sym", lower=True)
+        assert_allclose(b_inv3, b_inv0, atol=1e-15)
+
+    @pytest.mark.parametrize('complex_', [False, True])
+    def test_her(self, complex_):
+        # test the "her" mode
+        a = np.arange(9).reshape(3, 3)
+        if complex_:
+            a = a + 1j*a
+        b = a + a.T.conj() + np.eye(3)
+
+        b_inv0 = inv(b)
+        assert_allclose(b_inv0 @ b, np.eye(3), atol=1e-14)
+
+        b_inv1 = inv(b, assume_a="her")
+        assert_allclose(b_inv0, b_inv1, atol=1e-15)
+
+        # check that the "other" triangle is not referenced
+        mask = np.where(1 - np.tri(*a.shape, -1) == 0, np.nan, 1)
+        b_inv2 = inv(b*mask, check_finite=False, assume_a="her", lower=False)
+        assert_allclose(b_inv2, b_inv0, atol=1e-15)
+
+        # repeat with the upper triangle
+        b_inv3 = inv(b*mask.T, check_finite=False, assume_a="her", lower=True)
+        assert_allclose(b_inv3, b_inv0, atol=1e-15)
 
     def test_triangular_1(self):
         x = np.arange(25, dtype=float).reshape(5, 5)
@@ -1437,13 +1488,6 @@ class TestInv:
         mask = np.where(1 - np.tri(*y.shape, -1) == 0, np.nan, 1)
         y_inv_2_l = inv(y*mask.T, check_finite=False, assume_a='lower triangular')
         assert_allclose(y_inv_2_l @ np.tril(y), np.eye(5), atol=1e-15)
-
-        # TODO
-        # 1. general, ill-conditioned: warns
-        # 2. posdef, ill-conditioned: warns
-        # 4. triangular, upper, lower, ill-conditioned: warns
-        # 5. assume_a="posdef" but Cholesky fails: fall back to general or raise?
-        # 6. error control (fast-fail, fill with nans, fill and raise)
 
 
 class TestDet:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1408,49 +1408,33 @@ class TestInv:
             assert_allclose(inv(b) @ b, np.eye(3), atol=3e-15)
 
     @pytest.mark.parametrize('complex_', [False, True])
-    def test_sym(self, complex_):
-        # test the "sym" mode
-        a = np.arange(9).reshape(3, 3)
-        b = a + a.T + np.eye(3)
-        if complex_:
-            b = b + 1j*b
-
-        b_inv0 = inv(b)
-        assert_allclose(b_inv0 @ b, np.eye(3), atol=1e-14)
-
-        b_inv1 = inv(b, assume_a="sym")
-        assert_allclose(b_inv0, b_inv1, atol=1e-15)
-
-        # check that the "other" triangle is not referenced
-        mask = np.where(1 - np.tri(*a.shape, -1) == 0, np.nan, 1)
-        b_inv2 = inv(b*mask, check_finite=False, assume_a="sym", lower=False)
-        assert_allclose(b_inv2, b_inv0, atol=1e-15)
-
-        # repeat with the upper triangle
-        b_inv3 = inv(b*mask.T, check_finite=False, assume_a="sym", lower=True)
-        assert_allclose(b_inv3, b_inv0, atol=1e-15)
-
-    @pytest.mark.parametrize('complex_', [False, True])
-    def test_her(self, complex_):
-        # test the "her" mode
+    @pytest.mark.parametrize('sym_herm', ['sym', 'her'])
+    def test_sym_her(self, complex_, sym_herm):
+        # test "sym" and "her" modes
         a = np.arange(9).reshape(3, 3)
         if complex_:
             a = a + 1j*a
-        b = a + a.T.conj() + np.eye(3)
 
-        b_inv0 = inv(b)
+        if sym_herm == "sym":
+            b = a + a.T
+        else:   # sym_herm == "herm":
+            b = a + a.T.conj()
+
+        b = b + np.eye(3)
+
+        b_inv0 = np.linalg.inv(b)
         assert_allclose(b_inv0 @ b, np.eye(3), atol=1e-14)
 
-        b_inv1 = inv(b, assume_a="her")
+        b_inv1 = inv(b, assume_a=sym_herm)
         assert_allclose(b_inv0, b_inv1, atol=1e-15)
 
         # check that the "other" triangle is not referenced
         mask = np.where(1 - np.tri(*a.shape, -1) == 0, np.nan, 1)
-        b_inv2 = inv(b*mask, check_finite=False, assume_a="her", lower=False)
+        b_inv2 = inv(b*mask, check_finite=False, assume_a=sym_herm, lower=False)
         assert_allclose(b_inv2, b_inv0, atol=1e-15)
 
         # repeat with the upper triangle
-        b_inv3 = inv(b*mask.T, check_finite=False, assume_a="her", lower=True)
+        b_inv3 = inv(b*mask.T, check_finite=False, assume_a=sym_herm, lower=True)
         assert_allclose(b_inv3, b_inv0, atol=1e-15)
 
     def test_triangular_1(self):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Is based off and includes https://github.com/scipy/scipy/pull/23541 <s>and https://github.com/scipy/scipy/pull/23362</s>

#### What does this implement/fix?
<!--Please explain your changes.-->

Move `"sym"` and `"her"` modes of `linalg.solve` to C. The method is similar to that of `inv`, gh-23541, --- we first try Cholesky solve, and if it fails, fall back to sym/her instead of a general solve. 

#### Additional information
<!--Any additional information you think is important.-->

This PR is the third PR is the "stack", with two previous items being
- refactor of error reporting from C to user, gh-23362
- implementation of "sym"/"her" modes for `linalg.inv`, gh-23541

If either of these lands, I'll rebase this one. Or can land this one in one go instead of going PR-by-PR. Reviewer's preferernce :-).
