### PR TITLE
BUG: signal: Control output dtypes in `abcd_normalize` by adding new …

### DIFF
--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -58,8 +58,7 @@ def _skip_if_poly1d(arg):
 
 ###################
 
-def abcd_normalize_signature(A=None, B=None, C=None, D=None, *, dtype=None,
-                             device=None):
+def abcd_normalize_signature(A=None, B=None, C=None, D=None, *, dtype=None):
     return array_namespace(A, B, C, D)
 
 def argrelextrema_signature(data, *args, **kwds):

--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -58,8 +58,8 @@ def _skip_if_poly1d(arg):
 
 ###################
 
-def abcd_normalize_signature(A=None, B=None, C=None, D=None, *, dtype=None, xp=None,
-                   device=None):
+def abcd_normalize_signature(A=None, B=None, C=None, D=None, *, dtype=None,
+                             device=None):
     return array_namespace(A, B, C, D)
 
 def argrelextrema_signature(data, *args, **kwds):

--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -58,6 +58,10 @@ def _skip_if_poly1d(arg):
 
 ###################
 
+def abcd_normalize_signature(A=None, B=None, C=None, D=None, *, dtype=None, xp=None,
+                   device=None):
+    return array_namespace(A, B, C, D)
+
 def argrelextrema_signature(data, *args, **kwds):
     return array_namespace(data)
 

--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -58,10 +58,6 @@ def _skip_if_poly1d(arg):
 
 ###################
 
-def abcd_normalize_signature(A=None, B=None, C=None, D=None):
-    return array_namespace(A, B, C, D)
-
-
 def argrelextrema_signature(data, *args, **kwds):
     return array_namespace(data)
 

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1893,7 +1893,7 @@ def normalize(b, a):
     `b` is 0.  In the following example, the result is as expected:
 
     >>> import warnings
-    >>> with warnings.catch_warnings(record=True) as w:
+    >>> with warnings.catch_warnings(record=True, action='always') as w:
     ...     num, den = normalize([0, 3, 6], [2, -5, 4])
 
     >>> num
@@ -5105,12 +5105,14 @@ def _bessel_poly(n, reverse=False):
     Sequence is http://oeis.org/A001498, and output can be confirmed to
     match http://oeis.org/A001498/b001498.txt :
 
-    >>> from scipy.signal._filter_design import _bessel_poly
-    >>> i = 0
-    >>> for n in range(51):
-    ...     for x in _bessel_poly(n, reverse=True):
-    ...         print(i, x)
-    ...         i += 1
+    .. code_block:: python
+
+        from scipy.signal._filter_design import _bessel_poly
+        i = 0
+        for n in range(51):
+            for x in _bessel_poly(n, reverse=True):
+                print(i, x)
+                i += 1
 
     """
     if abs(int(n)) != n:

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -8,7 +8,7 @@ from numpy import (r_, eye, atleast_2d, poly, dot,
                    asarray, zeros, array, outer)
 from scipy import linalg
 
-from scipy._lib._array_api import array_namespace, xp_capabilities, xp_size
+from scipy._lib._array_api import array_namespace, xp_size
 import scipy._lib.array_api_extra as xpx
 from ._filter_design import tf2zpk, zpk2tf, normalize
 
@@ -114,7 +114,6 @@ def tf2ss(num, den):
     return A, B, C, D
 
 
-@xp_capabilities()
 def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None):
     r"""Check state-space matrices compatibility and ensure they are 2d arrays.
 

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -214,10 +214,10 @@ def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, xp=None,
     >>> print(f" AA: {AA.dtype}, BB: {BB.dtype}\n CC: {CC.dtype}, DD: {DD.dtype}")
      AA: float64, BB: float64
      CC: float64, DD: float64
-    >>> AA, BB, CC, DD = abcd_normalize(A=A, D=D, dtype=np.int32)  # Explicit dtype
+    >>> AA, BB, CC, DD = abcd_normalize(A=A, D=D, dtype=np.float32)  # Explicit dtype
     >>> print(f" AA: {AA.dtype}, BB: {BB.dtype}\n CC: {CC.dtype}, DD: {DD.dtype}")
-     AA: int32, BB: int32
-     CC: int32, DD: int32
+     AA: float32, BB: float32
+     CC: float32, DD: float32
     """
     if A is None and B is None and C is None:
         raise ValueError("Dimension n is undefined for parameters A = B = C = None!")

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -115,8 +115,7 @@ def tf2ss(num, den):
 
 
 @xp_capabilities()
-def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, xp=None,
-                   device=None):
+def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, device=None):
     r"""Check state-space matrices compatibility and ensure they are 2d arrays.
 
     First, the input matrices are converted into two-dimensional arrays with
@@ -146,14 +145,9 @@ def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, xp=None,
             With this new parameter, all return values have identical dtypes.
             In previous versions the dtype of the input was preserved.
 
-    xp : array_namespace, optional
-        The namespace for the return array. When ``None`` (default), then it is derived
-        from the parameters `A`, `B`, `C`, `D`. It should be compatible with the array
-        API standard or supported by array-api-compat. ``numpy`` is used by if
-        ``None`` and the parameters are not arrays.
-    device : any
-        Optional device specification for created matrices. Should match one of the
-        supported device specifications in ``xp``.
+    device : device, optional
+        Optional device specification for returened matrices.
+        Only applicabe when using an alterantive backend.
 
     Returns
     -------
@@ -226,7 +220,7 @@ def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, xp=None,
     if C is None and D is None:
         raise ValueError("Dimension q is undefined for parameters C = D = None!")
 
-    xp = xp or array_namespace(A, B, C, D)
+    xp = array_namespace(A, B, C, D)
 
     # convert inputs into 2d arrays (zero-size 2d array if None):
     A, B, C, D = (xpx.atleast_nd(xp.asarray(M_, device=device), ndim=2, xp=xp)

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -8,7 +8,7 @@ from numpy import (r_, eye, atleast_2d, poly, dot,
                    asarray, zeros, array, outer)
 from scipy import linalg
 
-from scipy._lib._array_api import array_namespace, xp_size
+from scipy._lib._array_api import array_namespace, xp_capabilities, xp_size
 import scipy._lib.array_api_extra as xpx
 from ._filter_design import tf2zpk, zpk2tf, normalize
 
@@ -114,43 +114,65 @@ def tf2ss(num, den):
     return A, B, C, D
 
 
-def abcd_normalize(A=None, B=None, C=None, D=None):
-    """Check state-space matrices compatibility and ensure they are 2d arrays.
+@xp_capabilities()
+def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, xp=None,
+                   device=None):
+    r"""Check state-space matrices compatibility and ensure they are 2d arrays.
 
-    Converts input matrices into two-dimensional arrays as needed. Then the dimensions
-    n, q, p are determined by investigating the non-zero entries of the array shapes.
-    If a parameter is ``None``, or has shape (0, 0), it is set to a
-    zero-array of compatible shape. Finally, it is verified that all parameter shapes
-    are compatible to each other. If that fails, a ``ValueError`` is raised. Note that
-    the dimensions n, q, p are allowed to be zero.
+    First, the input matrices are converted into two-dimensional arrays with
+    appropriate dtype as needed. Then the dimensions n, q, p are determined by
+    investigating the array shapes. If an input is ``None``, or has size zero, it is
+    set to an array of zeros of compatible shape. Finally, it is verified that all
+    parameter shapes are compatible with each other. If that fails, a ``ValueError`` is
+    raised. Note that the dimensions n, q, p are allowed to be zero.
 
     Parameters
     ----------
-    A: array_like, optional
+    A : array_like, optional
         Two-dimensional array of shape (n, n).
-    B: array_like, optional
+    B : array_like, optional
         Two-dimensional array of shape (n, p).
-    C: array_like, optional
+    C : array_like, optional
         Two-dimensional array of shape (q, n).
-    D: array_like, optional
+    D : array_like, optional
         Two-dimensional array of shape (q, p).
+    dtype : dtype | None, optional
+        Cast all matrices to the specified dtype. If set to ``None`` (default), their
+        dtypes will be "complex128" if any of the matrices are complex-valued.
+        Otherwise, they will be of the type "float64".
+
+        .. versionadded:: 1.18.0
+
+            With this new parameter, all return values have identical dtypes.
+            In previous versions the dtype of the input was preserved.
+
+    xp : array_namespace, optional
+        The namespace for the return array. When ``None`` (default), then it is derived
+        from the parameters `A`, `B`, `C`, `D`. It should be compatible with the array
+        API standard or supported by array-api-compat. ``numpy`` is used by if
+        ``None`` and the parameters are not arrays.
+    device : any
+        Optional device specification for created matrices. Should match one of the
+        supported device specifications in ``xp``.
 
     Returns
     -------
     A, B, C, D : array
-        State-space matrices as two-dimensional arrays.
-
-    Notes
-    -----
-    The :ref:`tutorial_signal_state_space_representation` section of the
-    :ref:`user_guide` presents the corresponding definitions of continuous-time and
-    disrcete time state space systems.
+        State-space matrices as two-dimensional arrays with identical dtype.
 
     Raises
     ------
     ValueError
         If the dimensions n, q, or p could not be determined or if the shapes are
         incompatible with each other.
+
+    Notes
+    -----
+    If a matrix is not modified, the original matrix (not a copy) is returned.
+
+    The :ref:`tutorial_signal_state_space_representation` section of the
+    :ref:`user_guide` presents the corresponding definitions of continuous-time and
+    disrcete time state space systems.
 
     See Also
     --------
@@ -181,6 +203,21 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     ((2, 2), (2, 1), (1, 2), (1, 1))
     >>> CC
     array([[0., 0.]])
+
+    The following snippet shows the effect of the `dtype` parameter:
+
+    >>> import numpy as np
+    >>> from scipy.signal import abcd_normalize
+    >>> A, D = [[1, 2], [3, 4]], 2.5
+    ...
+    >>> AA, BB, CC, DD = abcd_normalize(A=A, D=D)  # default type casting
+    >>> print(f" AA: {AA.dtype}, BB: {BB.dtype}\n CC: {CC.dtype}, DD: {DD.dtype}")
+     AA: float64, BB: float64
+     CC: float64, DD: float64
+    >>> AA, BB, CC, DD = abcd_normalize(A=A, D=D, dtype=np.int32)  # Explicit dtype
+    >>> print(f" AA: {AA.dtype}, BB: {BB.dtype}\n CC: {CC.dtype}, DD: {DD.dtype}")
+     AA: int32, BB: int32
+     CC: int32, DD: int32
     """
     if A is None and B is None and C is None:
         raise ValueError("Dimension n is undefined for parameters A = B = C = None!")
@@ -189,18 +226,37 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     if C is None and D is None:
         raise ValueError("Dimension q is undefined for parameters C = D = None!")
 
-    xp = array_namespace(A, B, C, D)
-    A, B, C, D = (xpx.atleast_nd(xp.asarray(M_), ndim=2) if M_ is not None else
-                  xp.zeros((0, 0)) for M_ in (A, B, C, D))
+    xp = xp or array_namespace(A, B, C, D)
 
-    n = A.shape[0] or B.shape[0] or C.shape[1] or 0  # try finding non-zero dimensions
-    p = B.shape[1] or D.shape[1] or 0
-    q = C.shape[0] or D.shape[0] or 0
+    # convert inputs into 2d arrays (zero-size 2d array if None):
+    A, B, C, D = (xpx.atleast_nd(xp.asarray(M_, device=device), ndim=2, xp=xp)
+                  if M_ is not None else xp.zeros((0, 0), device=device)
+                  for M_ in (A, B, C, D))
 
-    A = xp.zeros((n, n)) if xp_size(A) == 0 else A  # Create zero-matrices if needed
-    B = xp.zeros((n, p)) if xp_size(B) == 0 else B
-    C = xp.zeros((q, n)) if xp_size(C) == 0 else C
-    D = xp.zeros((q, p)) if xp_size(D) == 0 else D
+    if dtype is None:
+        to_comp = any(xp.isdtype(M_.dtype, 'complex floating') for M_ in (A, B, C, D))
+        dtype = xp.complex128 if to_comp else xp.float64
+    else:
+        try:
+            is_numeric = xp.isdtype(dtype, 'numeric')
+        except Exception as dtype_error:
+            err_msg = f"Parameter {dtype=} must be None or a numeric dtype!"
+            raise ValueError(err_msg) from dtype_error
+        if not is_numeric:
+            raise ValueError(f"Parameter {dtype=} is not a numeric dtype!")
+
+    n = A.shape[0] or B.shape[0] or C.shape[1] # try finding non-zero dimensions
+    p = B.shape[1] or D.shape[1]
+    q = C.shape[0] or D.shape[0]
+
+    # Create zero matrices as needed:
+    A = xp.zeros((n, n), device=device) if xp_size(A) == 0 else A
+    B = xp.zeros((n, p), device=device) if xp_size(B) == 0 else B
+    C = xp.zeros((q, n), device=device) if xp_size(C) == 0 else C
+    D = xp.zeros((q, p), device=device) if xp_size(D) == 0 else D
+
+    A, B, C, D = (xp.astype(M_, dtype, copy=False, device=device)
+                  for M_ in (A, B, C, D))
 
     if A.shape != (n, n):
         raise ValueError(f"Parameter A has shape {A.shape} but should be ({n}, {n})!")
@@ -243,6 +299,17 @@ def ss2tf(A, B, C, D, input=0):
         Denominator of the resulting transfer function(s). `den` is a sequence
         representation of the denominator polynomial.
 
+    Notes
+    -----
+    Before calculating `num` and `den`, the function `abcd_normalize` is called to
+    convert the parameters `A`, `B`, `C`, `D` into two-dimesional arrays. Their dtypes
+    will be "complex128" if any of the matrices are complex-valued. Otherwise, they
+    will be of type "float64".
+
+    The :ref:`tutorial_signal_state_space_representation` section of the
+    :ref:`user_guide` presents the corresponding definitions of continuous-time and
+    disrcete time state space systems.
+
     Examples
     --------
     Convert the state-space representation:
@@ -271,7 +338,7 @@ def ss2tf(A, B, C, D, input=0):
     """
     # transfer function is C (sI - A)**(-1) B + D
 
-    # Check consistency and make them all rank-2 arrays
+    # Check consistency and make them all floating point 2d arrays:
     A, B, C, D = abcd_normalize(A, B, C, D)
 
     nout, nin = D.shape

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -115,7 +115,7 @@ def tf2ss(num, den):
 
 
 @xp_capabilities()
-def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, device=None):
+def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None):
     r"""Check state-space matrices compatibility and ensure they are 2d arrays.
 
     First, the input matrices are converted into two-dimensional arrays with
@@ -144,10 +144,6 @@ def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, device=None):
 
             With this new parameter, all return values have identical dtypes.
             In previous versions the dtype of the input was preserved.
-
-    device : device, optional
-        Optional device specification for returened matrices.
-        Only applicabe when using an alterantive backend.
 
     Returns
     -------
@@ -223,9 +219,8 @@ def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, device=None):
     xp = array_namespace(A, B, C, D)
 
     # convert inputs into 2d arrays (zero-size 2d array if None):
-    A, B, C, D = (xpx.atleast_nd(xp.asarray(M_, device=device), ndim=2, xp=xp)
-                  if M_ is not None else xp.zeros((0, 0), device=device)
-                  for M_ in (A, B, C, D))
+    A, B, C, D = (xpx.atleast_nd(xp.asarray(M_), ndim=2, xp=xp)
+                  if M_ is not None else xp.zeros((0, 0)) for M_ in (A, B, C, D))
 
     if dtype is None:
         to_comp = any(xp.isdtype(M_.dtype, 'complex floating') for M_ in (A, B, C, D))
@@ -244,13 +239,12 @@ def abcd_normalize(A=None, B=None, C=None, D=None, *, dtype=None, device=None):
     q = C.shape[0] or D.shape[0]
 
     # Create zero matrices as needed:
-    A = xp.zeros((n, n), device=device) if xp_size(A) == 0 else A
-    B = xp.zeros((n, p), device=device) if xp_size(B) == 0 else B
-    C = xp.zeros((q, n), device=device) if xp_size(C) == 0 else C
-    D = xp.zeros((q, p), device=device) if xp_size(D) == 0 else D
+    A = xp.zeros((n, n)) if xp_size(A) == 0 else A
+    B = xp.zeros((n, p)) if xp_size(B) == 0 else B
+    C = xp.zeros((q, n)) if xp_size(C) == 0 else C
+    D = xp.zeros((q, p)) if xp_size(D) == 0 else D
 
-    A, B, C, D = (xp.astype(M_, dtype, copy=False, device=device)
-                  for M_ in (A, B, C, D))
+    A, B, C, D = (xp.astype(M_, dtype, copy=False) for M_ in (A, B, C, D))
 
     if A.shape != (n, n):
         raise ValueError(f"Parameter A has shape {A.shape} but should be ({n}, {n})!")

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -177,10 +177,10 @@ class lti(LinearTimeInvariant):
 
     >>> signal.lti(1, 2, 3, 4)
     StateSpaceContinuous(
-    array([[1]]),
-    array([[2]]),
-    array([[3]]),
-    array([[4]]),
+    array([[1.]]),
+    array([[2.]]),
+    array([[3.]]),
+    array([[4.]]),
     dt: None
     )
 
@@ -350,19 +350,19 @@ class dlti(LinearTimeInvariant):
 
     >>> signal.dlti(1, 2, 3, 4)
     StateSpaceDiscrete(
-    array([[1]]),
-    array([[2]]),
-    array([[3]]),
-    array([[4]]),
+    array([[1.]]),
+    array([[2.]]),
+    array([[3.]]),
+    array([[4.]]),
     dt: True
     )
 
     >>> signal.dlti(1, 2, 3, 4, dt=0.1)
     StateSpaceDiscrete(
-    array([[1]]),
-    array([[2]]),
-    array([[3]]),
-    array([[4]]),
+    array([[1.]]),
+    array([[2.]]),
+    array([[3.]]),
+    array([[4.]]),
     dt: 0.1
     )
 
@@ -1254,11 +1254,20 @@ class StateSpace(LinearTimeInvariant):
 
     Notes
     -----
+    If the parameter `system` is a tuple (A, B, C, D) with four state space matrices,
+    then those matrices are converted into two-dimensional arrays by calling
+    `abcd_normalize`. Their dtypes will be "complex128" if any of the matrices are
+    complex-valued. Otherwise, they will be of type "float64".
+
     Changing the value of properties that are not part of the
     `StateSpace` system representation (such as `zeros` or `poles`) is very
     inefficient and may lead to numerical inaccuracies.  It is better to
     convert to the specific system representation first. For example, call
     ``sys = sys.to_zpk()`` before accessing/changing the zeros, poles or gain.
+
+    The :ref:`tutorial_signal_state_space_representation` section of the
+    :ref:`user_guide` presents the corresponding definitions of continuous-time and
+    disrcete time state space systems.
 
     Examples
     --------
@@ -1272,12 +1281,12 @@ class StateSpace(LinearTimeInvariant):
     >>> sys = signal.StateSpace(a, b, c, d)
     >>> print(sys)
     StateSpaceContinuous(
-    array([[0, 1],
-           [0, 0]]),
-    array([[0],
-           [1]]),
-    array([[1, 0]]),
-    array([[0]]),
+    array([[0., 1.],
+           [0., 0.]]),
+    array([[0.],
+           [1.]]),
+    array([[1., 0.]]),
+    array([[0.]]),
     dt: None
     )
 
@@ -1287,8 +1296,8 @@ class StateSpace(LinearTimeInvariant):
            [0. , 1. ]]),
     array([[0.005],
            [0.1  ]]),
-    array([[1, 0]]),
-    array([[0]]),
+    array([[1., 0.]]),
+    array([[0.]]),
     dt: 0.1
     )
 
@@ -1301,8 +1310,8 @@ class StateSpace(LinearTimeInvariant):
            [0. , 1. ]]),
     array([[0.005],
            [0.1  ]]),
-    array([[1, 0]]),
-    array([[0]]),
+    array([[1., 0.]]),
+    array([[0.]]),
     dt: 0.1
     )
 
@@ -1344,6 +1353,7 @@ class StateSpace(LinearTimeInvariant):
         self._C = None
         self._D = None
 
+        # Convert A, B, C, D into 2d arrays of dtype float64 or complex128:
         self.A, self.B, self.C, self.D = abcd_normalize(*system)
 
     def __repr__(self):

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -791,8 +791,8 @@ class TransferFunctionContinuous(TransferFunction, lti):
 
     >>> signal.TransferFunction(num, den)
     TransferFunctionContinuous(
-    array([ 1.,  3.,  3.]),
-    array([ 1.,  2.,  1.]),
+    array([1., 3., 3.]),
+    array([1., 2., 1.]),
     dt: None
     )
 
@@ -871,8 +871,8 @@ class TransferFunctionDiscrete(TransferFunction, dlti):
 
     >>> signal.TransferFunction(num, den, dt=0.5)
     TransferFunctionDiscrete(
-    array([ 1.,  3.,  3.]),
-    array([ 1.,  2.,  1.]),
+    array([1., 3., 3.]),
+    array([1., 2., 1.]),
     dt: 0.5
     )
 
@@ -1682,12 +1682,12 @@ class StateSpaceContinuous(StateSpace, lti):
     >>> sys = signal.StateSpace(a, b, c, d)
     >>> print(sys)
     StateSpaceContinuous(
-    array([[0, 1],
-           [0, 0]]),
-    array([[0],
-           [1]]),
-    array([[1, 0]]),
-    array([[0]]),
+    array([[0., 1.],
+           [0., 0.]]),
+    array([[0.],
+           [1.]]),
+    array([[1., 0.]]),
+    array([[0.]]),
     dt: None
     )
 
@@ -1759,12 +1759,12 @@ class StateSpaceDiscrete(StateSpace, dlti):
 
     >>> signal.StateSpace(a, b, c, d, dt=0.1)
     StateSpaceDiscrete(
-    array([[ 1. ,  0.1],
-           [ 0. ,  1. ]]),
-    array([[ 0.005],
-           [ 0.1  ]]),
-    array([[1, 0]]),
-    array([[0]]),
+    array([[1. ,  0.1],
+           [0. ,  1. ]]),
+    array([[0.005],
+           [0.1  ]]),
+    array([[1., 0.]]),
+    array([[0.]]),
     dt: 0.1
     )
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3013,9 +3013,9 @@ def _cmplx_sort(p):
 
     Examples
     --------
-    >>> from scipy import signal
+    >>> from scipy.signal._signaltools import _cmplx_sort
     >>> vals = [1, 4, 1+1.j, 3]
-    >>> p_sorted, indx = signal.cmplx_sort(vals)
+    >>> p_sorted, indx = _cmplx_sort(vals)
     >>> p_sorted
     array([1.+0.j, 1.+1.j, 3.+0.j, 4.+0.j])
     >>> indx

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -22,7 +22,8 @@ JAX_SIGNAL_FUNCS = [
 
 # some cupyx.scipy.signal functions are incompatible with their scipy counterparts
 CUPY_BLACKLIST = [
-    'lfilter_zi', 'sosfilt_zi', 'get_window', 'besselap', 'envelope', 'remez', 'bessel'
+    'abcd_normalize', 'bessel', 'besselap', 'envelope', 'get_window', 'lfilter_zi',
+    'sosfilt_zi', 'remez',
 ]
 
 # freqz_sos is a sosfreqz rename, and cupy does not have the new name yet (in v13.x)

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -359,29 +359,31 @@ class TestC2dLti:
     def test_c2d_ss(self, xp):
         # StateSpace
         A = np.array([[-0.3, 0.1], [0.2, -0.7]])
-        B = np.array([[0.], [1.]])
-        C = np.array([[1., 0.]])
+        B = np.array([[0], [1]])
+        C = np.array([[1, 0]])
         D = 0
         dt = 0.05
 
         A_res = np.array([[0.985136404135682, 0.004876671474795],
                           [0.009753342949590, 0.965629718236502]])
         B_res = np.array([[0.000122937599964], [0.049135527547844]])
+        # Resulting A, B, C, D are arrays of the same dtype due to abcd_normalize() use:
+        C_res = np.astype(C, A_res.dtype)
 
         sys_ssc = lti(A, B, C, D)
         sys_ssd = sys_ssc.to_discrete(dt=dt)
 
         xp_assert_close(sys_ssd.A, A_res)
         xp_assert_close(sys_ssd.B, B_res)
-        xp_assert_close(sys_ssd.C, C)
+        xp_assert_close(sys_ssd.C, C_res)
         xp_assert_close(sys_ssd.D, np.zeros_like(sys_ssd.D))
 
         sys_ssd2 = c2d(sys_ssc, dt=dt)
 
         xp_assert_close(sys_ssd2.A, A_res)
         xp_assert_close(sys_ssd2.B, B_res)
-        xp_assert_close(sys_ssd2.C, C)
-        xp_assert_close(sys_ssd2.D, np.zeros_like(sys_ssd2.D))
+        xp_assert_close(sys_ssd2.C, C_res)
+        xp_assert_close(sys_ssd2.D, np.zeros_like(sys_ssd.D))
 
     def test_c2d_tf(self, xp):
 

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -359,8 +359,8 @@ class TestC2dLti:
     def test_c2d_ss(self, xp):
         # StateSpace
         A = np.array([[-0.3, 0.1], [0.2, -0.7]])
-        B = np.array([[0], [1]])
-        C = np.array([[1, 0]])
+        B = np.array([[0.], [1.]])
+        C = np.array([[1., 0.]])
         D = 0
         dt = 0.05
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -931,25 +931,25 @@ class Test_abcd_normalize:
     def test_no_matrix_fails(self):
         assert_raises(ValueError, abcd_normalize)
 
-    def test_A_nosquare_fails(self, xp):
+    def test_A_nosquare_fails(self):
         assert_raises(ValueError, abcd_normalize,
-                      [1, -1], self.B, self.C, self.D, xp=xp)
+                      [1, -1], self.B, self.C, self.D)
 
-    def test_AB_mismatch_fails(self, xp):
+    def test_AB_mismatch_fails(self):
         assert_raises(ValueError, abcd_normalize,
-                      self.A, [-1, 5], self.C, self.D, xp=xp)
+                      self.A, [-1, 5], self.C, self.D)
 
-    def test_AC_mismatch_fails(self, xp):
+    def test_AC_mismatch_fails(self):
         assert_raises(ValueError, abcd_normalize,
-                      self.A, self.B, [[4.0], [5.0]], self.D, xp=xp)
+                      self.A, self.B, [[4.0], [5.0]], self.D)
 
-    def test_CD_mismatch_fails(self, xp):
+    def test_CD_mismatch_fails(self):
         assert_raises(ValueError, abcd_normalize,
-                      self.A, self.B, self.C, [2.5, 0], xp=xp)
+                      self.A, self.B, self.C, [2.5, 0])
 
     def test_BD_mismatch_fails(self, xp):
         assert_raises(ValueError, abcd_normalize,
-                      self.A, [-1, 5], self.C, self.D, xp=xp)
+                      self.A, [-1, 5], self.C, self.D)
 
     def test_normalized_matrices_unchanged(self, xp):
         A_, B_, C_, D_ = map(xp.asarray, (self.A, self.B, self.C, self.D))
@@ -960,8 +960,8 @@ class Test_abcd_normalize:
         xp_assert_equal(C, C_)
         xp_assert_equal(D, D_)
 
-    def test_shapes(self, xp):
-        A, B, C, D = abcd_normalize(self.A, self.B, [1, 0], 0, xp=xp)
+    def test_shapes(self):
+        A, B, C, D = abcd_normalize(self.A, self.B, [1, 0], 0)
         assert A.shape[0] == A.shape[1]
         assert A.shape[0] == B.shape[0]
         assert A.shape[0] == C.shape[1]
@@ -1076,17 +1076,18 @@ class Test_abcd_normalize:
         with pytest.raises(ValueError, match="^Parameter dtype=<class 'str'>"):
             abcd_normalize(self.A, self.B, self.C, self.D, dtype=str)
         with pytest.raises(ValueError, match="^Parameter dtype="):
-            abcd_normalize(self.A, self.B, self.C, self.D, dtype=np.datetime64, xp=np)
+            abcd_normalize(self.A, self.B, self.C, self.D, dtype=np.datetime64)
 
     def test_param_dtype(self, xp):
-        AA, BB, CC, DD = abcd_normalize(A=self.A, D=self.D, xp=xp)
+        A, D = xp.asarray(self.A), xp.asarray(self.D)
+        AA, BB, CC, DD = abcd_normalize(A=A, D=D)
         assert AA.dtype == BB.dtype == CC.dtype == DD.dtype == xp.float64
 
-        AA, BB, CC, DD = abcd_normalize(A=self.A, D=self.D, dtype=xp.int64, xp=xp)
+        AA, BB, CC, DD = abcd_normalize(A=A, D=D, dtype=xp.int64)
         assert AA.dtype == BB.dtype == CC.dtype == DD.dtype == xp.int64
 
         DD_ = 1 + 2j  # converts to complex128
-        AA, BB, CC, DD = abcd_normalize(A=self.A, D=DD_, xp=xp)
+        AA, BB, CC, DD = abcd_normalize(A=A, D=DD_)
         assert AA.dtype == BB.dtype == CC.dtype == DD.dtype == xp.complex128
 
 

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -718,6 +718,13 @@ class TestStateSpace:
         StateSpace(np.array([[1, 2], [3, 4]]), np.array([[1], [2]]),
                    np.array([[1, 0]]), np.array([[0]]))
 
+        # Verify that parameter are casted correctly:
+        AA = np.array([1], dtype=np.int64)
+        ss0 = StateSpace(AA, 1, 1, 1)
+        assert ss0.A.dtype == ss0.B.dtype == ss0.C.dtype == ss0.D.dtype == np.float64
+        ss1 = StateSpace(AA, 1, 1, 1+1j)
+        assert ss1.A.dtype == ss1.B.dtype == ss1.C.dtype == ss1.D.dtype == np.complex128
+
     def test_conversion(self):
         # Check the conversion functions
         s = StateSpace(1, 2, 3, 4)
@@ -925,37 +932,36 @@ class Test_abcd_normalize:
         assert_raises(ValueError, abcd_normalize)
 
     def test_A_nosquare_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, xp.asarray([1, -1]),
-                      xp.asarray(self.B), xp.asarray(self.C), xp.asarray(self.D))
+        assert_raises(ValueError, abcd_normalize,
+                      [1, -1], self.B, self.C, self.D, xp=xp)
 
     def test_AB_mismatch_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, xp.asarray(self.A),
-                      xp.asarray([-1, 5]), xp.asarray(self.C), xp.asarray(self.D))
+        assert_raises(ValueError, abcd_normalize,
+                      self.A, [-1, 5], self.C, self.D, xp=xp)
 
     def test_AC_mismatch_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, xp.asarray(self.A),
-                      xp.asarray(self.B), xp.asarray([[4.0], [5.0]]),
-                      xp.asarray(self.D))
+        assert_raises(ValueError, abcd_normalize,
+                      self.A, self.B, [[4.0], [5.0]], self.D, xp=xp)
 
     def test_CD_mismatch_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, xp.asarray(self.A),
-                      xp.asarray(self.B), xp.asarray(self.C), xp.asarray([2.5, 0]))
+        assert_raises(ValueError, abcd_normalize,
+                      self.A, self.B, self.C, [2.5, 0], xp=xp)
 
     def test_BD_mismatch_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, xp.asarray(self.A),
-                      xp.asarray([-1, 5]), xp.asarray(self.C), xp.asarray(self.D))
+        assert_raises(ValueError, abcd_normalize,
+                      self.A, [-1, 5], self.C, self.D, xp=xp)
 
     def test_normalized_matrices_unchanged(self, xp):
         A_, B_, C_, D_ = map(xp.asarray, (self.A, self.B, self.C, self.D))
-        A, B, C, D = abcd_normalize(A=A_, B=B_, C=C_, D=D_)
+        # On torch/float32: A_, B_, C_, D_ are of dtype float32 => set dtype:
+        A, B, C, D = abcd_normalize(A=A_, B=B_, C=C_, D=D_, dtype=A_.dtype)
         xp_assert_equal(A, A_)
         xp_assert_equal(B, B_)
         xp_assert_equal(C, C_)
         xp_assert_equal(D, D_)
 
     def test_shapes(self, xp):
-        A, B, C, D = abcd_normalize(xp.asarray(self.A), xp.asarray(self.B),
-                                    xp.asarray([1, 0]), xp.asarray(0))
+        A, B, C, D = abcd_normalize(self.A, self.B, [1, 0], 0, xp=xp)
         assert A.shape[0] == A.shape[1]
         assert A.shape[0] == B.shape[0]
         assert A.shape[0] == C.shape[1]
@@ -966,7 +972,8 @@ class Test_abcd_normalize:
         A_ = xp.asarray(self.A)
         B_ = xp.zeros((2, 0))
         D_ = xp.zeros((0, 0))
-        A, B, C, D = abcd_normalize(A=A_, B=B_, D=D_)
+        # On torch/float32: A_, B_, C_, D_ are of dtype float32 => set dtype:
+        A, B, C, D = abcd_normalize(A=A_, B=B_, D=D_, dtype=A_.dtype)
         xp_assert_equal(A, A_)
         xp_assert_equal(B, B_)
         xp_assert_equal(D, D_)
@@ -977,7 +984,8 @@ class Test_abcd_normalize:
         A_ = xp.asarray(self.A)
         B_ = xp.zeros((2, 0))
         C_ = xp.zeros((0, 2))
-        A, B, C, D = abcd_normalize(A=A_, B=B_, C=C_)
+        # On torch/float32: A_, B_, C_, D_ are of dtype float32 => set dtype:
+        A, B, C, D = abcd_normalize(A=A_, B=B_, C=C_, dtype=A_.dtype)
         xp_assert_equal(A, A_)
         xp_assert_equal(B, B_)
         xp_assert_equal(C, C_)
@@ -1055,12 +1063,31 @@ class Test_abcd_normalize:
         assert_raises(ValueError, abcd_normalize, D=xp.asarray(self.D))
 
     def test_missing_BD_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, A=xp.asarray(self.A),
-                      C=xp.asarray(self.C))
+        A, C = xp.asarray(self.A),xp.asarray(self.C)
+        assert_raises(ValueError, abcd_normalize, A=A, C=C)
 
     def test_missing_CD_fails(self, xp):
-        assert_raises(ValueError, abcd_normalize, A=xp.asarray(self.A),
-                      B=xp.asarray(self.B))
+        A, B = xp.asarray(self.A), xp.asarray(self.B)
+        assert_raises(ValueError, abcd_normalize, A=A, B=B)
+
+    def test_param_dtype_exceptions(self):
+        with pytest.raises(ValueError, match="^Parameter dtype='INVALID' must be"):
+            abcd_normalize(self.A, self.B, self.C, self.D, dtype='INVALID')
+        with pytest.raises(ValueError, match="^Parameter dtype=<class 'str'>"):
+            abcd_normalize(self.A, self.B, self.C, self.D, dtype=str)
+        with pytest.raises(ValueError, match="^Parameter dtype="):
+            abcd_normalize(self.A, self.B, self.C, self.D, dtype=np.datetime64, xp=np)
+
+    def test_param_dtype(self, xp):
+        AA, BB, CC, DD = abcd_normalize(A=self.A, D=self.D, xp=xp)
+        assert AA.dtype == BB.dtype == CC.dtype == DD.dtype == xp.float64
+
+        AA, BB, CC, DD = abcd_normalize(A=self.A, D=self.D, dtype=xp.int64, xp=xp)
+        assert AA.dtype == BB.dtype == CC.dtype == DD.dtype == xp.int64
+
+        DD_ = 1 + 2j  # converts to complex128
+        AA, BB, CC, DD = abcd_normalize(A=self.A, D=DD_, xp=xp)
+        assert AA.dtype == BB.dtype == CC.dtype == DD.dtype == xp.complex128
 
 
 class Test_bode:


### PR DESCRIPTION
With this PR `signal.abcd_normalize` gains the capability of controlling the dtype of the returned arrays through the new keyword parameter ~~`cast_to`~~ `dtype`. The new default behavior is to make the output dtype float64 / complex128 (depending on input dtypes). Alternatively, either a specific dtype can be provided or type conversion can be turned off.

The idea behind adding a new keyword parameter was to make it clearly visible what `abcd_normalize` is actually doing.

Additionally:
* `signal.ss2tf`, `signal.StateSpace` now convert parameters to float64 / complex128 due to relying on `abcd_normalize`.
* ~~The initializer of class `signal.StateSpace` gained the keyword `cast_to`, which is passed to `abcd_normalize` for normalizing matrix parameters. Hence, those are converted to floating by default.~~
* Unit tests were added to ensure 100% coverage.
* Marginal docstr improvements.
* Supersedes PR #13235 from 2020: The `abcd_normalize` code diverged too much for making sensible adaptions in that PR.
* Closes #13125.
* Closes #18982.
* Closes #19629.

