### PR TITLE
BUG: fix levene and fligner test incorrect results with trimmed mean

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3012,7 +3012,7 @@ def levene(*samples, center='median', proportiontocut=0.05):
         The sample data, possibly with different lengths. Only one-dimensional
         samples are accepted.
     center : {'mean', 'median', 'trimmed'}, optional
-        Which function of the data to use in the test.  The default
+        Which statistics to use to center data points within each sample.  Default
         is 'median'.
     proportiontocut : float, optional
         When `center` is 'trimmed', this gives the proportion of data points
@@ -3102,11 +3102,10 @@ def levene(*samples, center='median', proportiontocut=0.05):
             return np.mean(x, axis=0)
 
     else:  # center == 'trimmed'
-        samples = tuple(_stats_py.trimboth(np.sort(sample), proportiontocut)
-                        for sample in samples)
 
         def func(x):
-            return np.mean(x, axis=0)
+            return _stats_py.trim_mean(x, proportiontocut, axis=0)
+
 
     for j in range(k):
         Ni[j] = len(samples[j])

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3166,8 +3166,8 @@ def fligner(*samples, center='median', proportiontocut=0.05):
     sample1, sample2, ... : array_like
         Arrays of sample data.  Need not be the same length.
     center : {'mean', 'median', 'trimmed'}, optional
-        Keyword argument controlling which function of the data is used in
-        computing the test statistic.  The default is 'median'.
+        Which statistics to use to center data points within each sample. Default
+        is 'median'.
     proportiontocut : float, optional
         When `center` is 'trimmed', this gives the proportion of data points
         to cut from each end. (See `scipy.stats.trim_mean`.)
@@ -3268,11 +3268,9 @@ def fligner(*samples, center='median', proportiontocut=0.05):
             return np.mean(x, axis=0)
 
     else:  # center == 'trimmed'
-        samples = tuple(_stats_py.trimboth(sample, proportiontocut)
-                        for sample in samples)
 
         def func(x):
-            return np.mean(x, axis=0)
+            return _stats_py.trim_mean(x, proportiontocut, axis=0)
 
     Ni = asarray([len(samples[j]) for j in range(k)])
     Yci = asarray([func(samples[j]) for j in range(k)])

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1123,18 +1123,6 @@ class TestFligner:
         assert_almost_equal(Xsq1, Xsq2)
         assert_almost_equal(pval1, pval2)
 
-    def test_trimmed2(self):
-        x = [1.2, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 100.0]
-        y = [0.0, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 200.0]
-        # Use center='trimmed'
-        Xsq1, pval1 = stats.fligner(x, y, center='trimmed',
-                                    proportiontocut=0.125)
-        # Trim the data here, and use center='mean'
-        Xsq2, pval2 = stats.fligner(x[1:-1], y[1:-1], center='mean')
-        # Result should be the same.
-        assert_almost_equal(Xsq1, Xsq2)
-        assert_almost_equal(pval1, pval2)
-
     # The following test looks reasonable at first, but fligner() uses the
     # function stats.rankdata(), and in one of the cases in this test,
     # there are ties, while in the other (because of normal rounding

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -801,6 +801,13 @@ class TestLevene:
         assert_almost_equal(W, 1.7059176930008939, 7)
         assert_almost_equal(pval, 0.0990829755522, 7)
 
+    def test_mean(self):
+        # numbers from R: leveneTest in package car
+        args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
+        W, pval = stats.levene(*args, center="mean")
+        assert_almost_equal(W, 2.15945985647285, 7)
+        assert_almost_equal(pval, 0.032236826559783, 7)
+
     def test_trimmed1(self):
         # Test that center='trimmed' gives the same result as center='mean'
         # when proportiontocut=0.

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -811,22 +811,11 @@ class TestLevene:
         assert_almost_equal(pval1, pval2)
 
     def test_trimmed2(self):
-        x = [1.2, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 100.0]
-        y = [0.0, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 200.0]
-        np.random.seed(1234)
-        x2 = np.random.permutation(x)
-
-        # Use center='trimmed'
-        W0, pval0 = stats.levene(x, y, center='trimmed',
-                                 proportiontocut=0.125)
-        W1, pval1 = stats.levene(x2, y, center='trimmed',
-                                 proportiontocut=0.125)
-        # Trim the data here, and use center='mean'
-        W2, pval2 = stats.levene(x[1:-1], y[1:-1], center='mean')
-        # Result should be the same.
-        assert_almost_equal(W0, W2)
-        assert_almost_equal(W1, W2)
-        assert_almost_equal(pval1, pval2)
+        # numbers from R: leveneTest in package car
+        args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
+        W, pval = stats.levene(*args, center="trimmed", proportiontocut=0.25)
+        assert_almost_equal(W, 2.07712845686874, 7)
+        assert_almost_equal(pval, 0.0397269688035377, 7)
 
     def test_equal_mean_median(self):
         x = np.linspace(-1, 1, 21)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1123,6 +1123,16 @@ class TestFligner:
         assert_almost_equal(Xsq1, Xsq2)
         assert_almost_equal(pval1, pval2)
 
+    def test_trimmed_nonregression(self):
+        # This is a non-regression test
+        # Expected results are *not* from an external gold standard,
+        # we're just making sure the results remain consistent
+        # in the future in case of changes
+        args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
+        W, pval = stats.fligner(*args, center="trimmed", proportiontocut=0.25)
+        assert_almost_equal(W, 15.953569890010614, 7)
+        assert_almost_equal(pval, 0.06785752327432863, 7)
+
     # The following test looks reasonable at first, but fligner() uses the
     # function stats.rankdata(), and in one of the cases in this test,
     # there are ties, while in the other (because of normal rounding

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -805,8 +805,8 @@ class TestLevene:
         # numbers from R: leveneTest in package car
         args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
         W, pval = stats.levene(*args, center="mean")
-        assert_almost_equal(W, 2.15945985647285, 7)
-        assert_almost_equal(pval, 0.032236826559783, 7)
+        assert_allclose(W, 2.15945985647285, rtol=5e-14)
+        assert_allclose(pval, 0.032236826559783, rtol=5e-14)
 
     def test_trimmed1(self):
         # Test that center='trimmed' gives the same result as center='mean'
@@ -821,8 +821,8 @@ class TestLevene:
         # numbers from R: leveneTest in package car
         args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
         W, pval = stats.levene(*args, center="trimmed", proportiontocut=0.25)
-        assert_almost_equal(W, 2.07712845686874, 7)
-        assert_almost_equal(pval, 0.0397269688035377, 7)
+        assert_allclose(W, 2.07712845686874, rtol=5e-14)
+        assert_allclose(pval, 0.0397269688035377, rtol=5e-14)
 
     def test_equal_mean_median(self):
         x = np.linspace(-1, 1, 21)
@@ -1130,8 +1130,8 @@ class TestFligner:
         # in the future in case of changes
         args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
         W, pval = stats.fligner(*args, center="trimmed", proportiontocut=0.25)
-        assert_almost_equal(W, 15.953569890010614, 7)
-        assert_almost_equal(pval, 0.06785752327432863, 7)
+        assert_allclose(W, 15.953569890010614, rtol=5e-14)
+        assert_allclose(pval, 0.06785752327432863, rtol=5e-14)
 
     # The following test looks reasonable at first, but fligner() uses the
     # function stats.rankdata(), and in one of the cases in this test,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes gh-23551

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR changes the implementation of the Levene test in the case where the selected center is the trimmed mean, in order to trim the data within each sample only when computing the center, instead of the whole test as was the case before.

The corresponding unit test is changed accordingly, and the results are tested against values obtained with R's `leveneTest` method from the `car` package. An additional test is added for the case where the selected center is the mean, also tested against the same R function.

A similar change is made in the implementation of the Fligner test, because I believe the same error was made there, but no unit tests are added because I couldn't find any R library that implements the same test to compute values to compare to. I removed the corresponding unit test instead, because otherwise it would have been broken.

#### Additional information
<!--Any additional information you think is important.-->
