### PR TITLE
DOC: ``special.modfresnelm`` docstring equation fix

### DIFF
--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -5647,7 +5647,7 @@ const char *modfresnelm_doc = R"(
     fm : scalar or ndarray
         Integral ``F_-(x)``: ``integral(exp(-1j*t*t), t=x..inf)``
     km : scalar or ndarray
-        Integral ``K_-(x)``: ``1/sqrt(pi)*exp(1j*(x*x+pi/4))*fp``
+        Integral ``K_-(x)``: ``1/sqrt(pi)*exp(1j*(x*x+pi/4))*fm``
 
     See Also
     --------


### PR DESCRIPTION
The `modfresnelm` equation for $K_-$ uses $F_+$ as factor, which looked kinda suspicious.
So I looked up to definitions in the literature, and for some reason, that was surprisingly difficult. Anyway, these integrals are apparently very esoteric, but I eventually was able to find some:

<img width="470" height="260" alt="image" src="https://github.com/user-attachments/assets/e25cebc2-f37d-4395-8eef-7bd6e9b25a4f" />

https://ieeexplore.ieee.org/abstract/document/29391

(I can't share the pdf *here*, since it smells like rum and comes with a parrot).