### PR TITLE
MAINT: Use np.view instead of setting dtype

### DIFF
--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -27,7 +27,7 @@ class _data_matrix(_spbase):
 
     @dtype.setter
     def dtype(self, newtype):
-        self.data.dtype = newtype
+        self.data = self.data.view(newtype)
 
     def _deduped_data(self):
         if hasattr(self, 'sum_duplicates'):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Addresses part of #23522 

#### What does this implement/fix?
Replaces .dtype assignments with `.view()`.
