### PR TITLE
ENH: linalg.fiedler: add native batch support and array api support

### DIFF
--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -3,6 +3,8 @@ import math
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
 from scipy._lib._util import _apply_over_batch
+from scipy._lib._array_api import array_namespace, xp_capabilities, xp_size
+import scipy._lib.array_api_extra as xpx
 
 
 __all__ = ['toeplitz', 'circulant', 'hankel',
@@ -905,6 +907,7 @@ def dft(n, scale=None):
     return m
 
 
+@xp_capabilities()
 def fiedler(a):
     """Returns a symmetric Fiedler matrix
 
@@ -973,14 +976,15 @@ def fiedler(a):
     15409152
 
     """
-    a = np.atleast_1d(a)
+    xp = array_namespace(a)
+    a = xpx.atleast_nd(xp.asarray(a), ndim=1)
 
-    if a.size == 0:
-        return np.array([], dtype=float)
-    elif a.size == 1:
-        return np.array([[0.]])
+    if xp_size(a) == 0:
+        return xp.asarray([], dtype=xp.float64)
+    elif xp_size(a) == 1:
+        return xp.asarray([[0.]])
     else:
-        return np.abs(a[..., :, None] - a[..., None, :])
+        return xp.abs(a[..., :, xp.newaxis] - a[..., xp.newaxis, :])
 
 
 def fiedler_companion(a):

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -975,15 +975,12 @@ def fiedler(a):
     """
     a = np.atleast_1d(a)
 
-    if a.ndim > 1:
-        return np.apply_along_axis(fiedler, -1, a)
-
     if a.size == 0:
         return np.array([], dtype=float)
     elif a.size == 1:
         return np.array([[0.]])
     else:
-        return np.abs(a[:, None] - a)
+        return np.abs(a[..., :, None] - a[..., None, :])
 
 
 def fiedler_companion(a):

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -13,6 +13,7 @@ from scipy.linalg import (toeplitz, hankel, circulant, hadamard, leslie, dft,
                           fiedler, fiedler_companion, eigvals,
                           convolution_matrix)
 from numpy.linalg import cond
+from scipy._lib._array_api import make_xp_test_case, xp_assert_equal, xp_size
 
 
 class TestToeplitz:
@@ -503,19 +504,22 @@ def test_dft():
     assert_array_almost_equal(mx, fx)
 
 
-def test_fiedler():
-    f = fiedler([])
-    assert_equal(f.size, 0)
-    f = fiedler([123.])
-    assert_array_equal(f, np.array([[0.]]))
-    f = fiedler(np.arange(1, 7))
-    des = np.array([[0, 1, 2, 3, 4, 5],
-                    [1, 0, 1, 2, 3, 4],
-                    [2, 1, 0, 1, 2, 3],
-                    [3, 2, 1, 0, 1, 2],
-                    [4, 3, 2, 1, 0, 1],
-                    [5, 4, 3, 2, 1, 0]])
-    assert_array_equal(f, des)
+@make_xp_test_case(fiedler)
+def test_fiedler(xp):
+    f = fiedler(xp.asarray([]))
+    assert xp_size(f) == 0
+
+    f = fiedler(xp.asarray([123.]))
+    xp_assert_equal(f, xp.asarray([[0.]]))
+
+    f = fiedler(xp.arange(1, 7))
+    des = xp.asarray([[0, 1, 2, 3, 4, 5],
+                      [1, 0, 1, 2, 3, 4],
+                      [2, 1, 0, 1, 2, 3],
+                      [3, 2, 1, 0, 1, 2],
+                      [4, 3, 2, 1, 0, 1],
+                      [5, 4, 3, 2, 1, 0]])
+    xp_assert_equal(f, des)
 
 
 def test_fiedler_companion():


### PR DESCRIPTION
Firstly, changes batch support to be native rather than using `apply_along_axis`. Secondly, adds array api support.