### PR TITLE
CI: pin scikit-umfpack to 0.3.3 to avoid failures, 0.4.2 is broken.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -111,7 +111,8 @@ jobs:
         mamba install python=${{ matrix.python-version}}
 
         # optional test dependencies
-        mamba install scikit-umfpack scikit-sparse
+        # scikit-umfpack is pinned because 0.4.2 packages seem broken, see gh-23564
+        mamba install "scikit-umfpack=0.3.3" scikit-sparse
 
         # configure system boost
         mamba install libboost-headers=1.89.0


### PR DESCRIPTION
Workaround while the actual issue can be investigated, probably needs an upstream fix. See gh-23564 for more details on failures.

Closes gh-23564