### PR TITLE
ENH: interpolate.AAA: add diagonal scaling to improve conditioning

### DIFF
--- a/scipy/interpolate/_bary_rational.py
+++ b/scipy/interpolate/_bary_rational.py
@@ -457,6 +457,7 @@ class AAA(_BarycentricRational):
         errors = np.empty(max_terms, dtype=A.real.dtype)
         R = np.repeat(np.mean(f), M)
         ill_conditioned = False
+        ill_conditioned_tol = 1/(3*np.finfo(dtype).eps)
 
         # AAA iteration
         for m in range(max_terms):
@@ -486,8 +487,8 @@ class AAA(_BarycentricRational):
                     _, s, V = scipy.linalg.svd(
                         A[mask, : m + 1], full_matrices=False, check_finite=False,
                     )
-                    with np.errstate(invalid="ignore"):
-                        if s[0]/s[-1] > 1/(3*np.finfo(dtype).eps):
+                    with np.errstate(invalid="ignore", divide="ignore"):
+                        if s[0]/s[-1] > ill_conditioned_tol:
                             ill_conditioned = True
                 if ill_conditioned:
                     col_norm = np.linalg.norm(A[mask, : m + 1], axis=0)

--- a/scipy/interpolate/_bary_rational.py
+++ b/scipy/interpolate/_bary_rational.py
@@ -456,6 +456,7 @@ class AAA(_BarycentricRational):
         A = np.empty((M, max_terms), dtype=dtype)
         errors = np.empty(max_terms, dtype=A.real.dtype)
         R = np.repeat(np.mean(f), M)
+        ill_conditioned = False
 
         # AAA iteration
         for m in range(max_terms):
@@ -481,13 +482,25 @@ class AAA(_BarycentricRational):
             rows = mask.sum()
             if rows >= m + 1:
                 # The usual tall-skinny case
-                _, s, V = scipy.linalg.svd(
-                    A[mask, : m + 1], full_matrices=False, check_finite=False,
-                )
+                if not ill_conditioned:
+                    _, s, V = scipy.linalg.svd(
+                        A[mask, : m + 1], full_matrices=False, check_finite=False,
+                    )
+                    with np.errstate(invalid="ignore"):
+                        if s[0]/s[-1] > 1/(3*np.finfo(dtype).eps):
+                            ill_conditioned = True
+                if ill_conditioned:
+                    col_norm = np.linalg.norm(A[mask, : m + 1], axis=0)
+                    _, s, V = scipy.linalg.svd(
+                        A[mask, : m + 1]/col_norm, full_matrices=False,
+                        check_finite=False,
+                    )
                 # Treat case of multiple min singular values
                 mm = s == np.min(s)
                 # Aim for non-sparse weight vector
                 wj = (V.conj()[mm, :].sum(axis=0) / np.sqrt(mm.sum())).astype(dtype)
+                if ill_conditioned:
+                    wj /= col_norm
             else:
                 # Fewer rows than columns
                 V = scipy.linalg.null_space(A[mask, : m + 1], check_finite=False)

--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -266,7 +266,7 @@ class TestAAA:
         r = AAA(z, f)
 
         zz = np.logspace(-15, 0, 500)
-        assert_allclose(r(zz), np.sqrt(zz))
+        assert_allclose(r(zz), np.sqrt(zz), rtol=9e-6)
 
 
 class TestFloaterHormann:

--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -259,6 +259,15 @@ class TestAAA:
         # check accuracy
         assert_allclose(r(z), np.tan(np.pi*z/2), atol=6e-12, rtol=3e-12)
 
+    def test_diag_scaling(self):
+        # fails without diag scaling
+        z = np.logspace(-15, 0, 300)
+        f = np.sqrt(z)
+        r = AAA(z, f)
+
+        zz = np.logspace(-15, 0, 500)
+        assert_allclose(r(zz), np.sqrt(zz))
+
 
 class TestFloaterHormann:
     def runge(self, z):


### PR DESCRIPTION
For tricky example, e.g. the added test, the Loewner matrix becomes ill-conditioned. This pr adds a check for this which then triggers diagonal scaling.