### PR TITLE
MAINT: remove empty lines added to docstring by various decorators

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -777,7 +777,7 @@ def xp_capabilities(
         note = _make_capabilities_note(f.__name__, sphinx_capabilities)
         doc = FunctionDoc(f)
         doc['Notes'].append(note)
-        doc = str(doc).split("\n", 1)[1]  # remove signature
+        doc = str(doc).split("\n", 1)[1].lstrip(" \n")  # remove signature
         try:
             f.__doc__ = doc
         except AttributeError:

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -363,7 +363,7 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None,
                 new_doc = [_desc] + old_doc_keep
                 _rng_parameter_doc = Parameter('rng', _type, new_doc)
                 doc['Parameters'][parameter_names.index('rng')] = _rng_parameter_doc
-                doc = str(doc).split("\n", 1)[1]  # remove signature
+                doc = str(doc).split("\n", 1)[1].lstrip(" \n")  # remove signature
                 wrapper.__doc__ = str(doc)
         return wrapper
 
@@ -1196,7 +1196,7 @@ def _apply_over_batch(*argdefs):
 
         doc = FunctionDoc(wrapper)
         doc['Extended Summary'].append(_batch_note.rstrip())
-        wrapper.__doc__ = str(doc).split("\n", 1)[1]  # remove signature
+        wrapper.__doc__ = str(doc).split("\n", 1)[1].lstrip(" \n")  # remove signature
 
         return wrapper
     return decorator

--- a/scipy/_lib/deprecation.py
+++ b/scipy/_lib/deprecation.py
@@ -263,7 +263,7 @@ def _deprecate_positional_args(func=None, *, version=None,
         admonition += custom_message
         doc['Extended Summary'] += [admonition]
 
-        doc = str(doc).split("\n", 1)[1]  # remove signature
+        doc = str(doc).split("\n", 1)[1].lstrip(" \n")  # remove signature
         inner_f.__doc__ = str(doc)
 
         return inner_f

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -673,7 +673,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
         else:
             doc['Parameters'].append(_keepdims_parameter_doc)
         doc['Notes'] += _standard_note_addition
-        doc = str(doc).split("\n", 1)[1]  # remove signature
+        doc = str(doc).split("\n", 1)[1].lstrip(" \n")  # remove signature
         axis_nan_policy_wrapper.__doc__ = str(doc)
 
         sig = inspect.signature(axis_nan_policy_wrapper)


### PR DESCRIPTION
closes #23581 

Strips the extra `\n` added by `FunctionDoc`.