### PR TITLE
MAINT: Test spatial.transform.Rotation.__iter__ with jit

### DIFF
--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -2611,7 +2611,7 @@ class Rotation:
         m[1:] = [" " * 21 + m[i] for i in range(1, len(m))]
         return "Rotation.from_matrix(" + "\n".join(m) + ")"
 
-    @xp_capabilities(jax_jit=False)
+    @xp_capabilities()
     def __iter__(self) -> Iterator[Rotation]:
         """Iterate over rotations."""
         if self._single or self._quat.ndim == 1:


### PR DESCRIPTION
Now that https://github.com/data-apis/array-api-extra/pull/418 has been merged and updated in #23586 we can remove the restriction on `jax_jit` in `xp_capabilities` for `Rotation.__iter__`. Tests leveraging this are already in place.

See also https://github.com/scipy/scipy/pull/23425#discussion_r2330002252.

CC @lucascolley 