### PR TITLE
MAINT: fix more memory management and error handling issues in C code

### DIFF
--- a/scipy/optimize/__slsqp.h
+++ b/scipy/optimize/__slsqp.h
@@ -214,11 +214,15 @@ nnls(PyObject* Py_UNUSED(dummy), PyObject* args) {
         PYERR(slsqp_error, "scipy.optimize._slsqplib: Failed to create capsule.");
     }
 
-    PyArray_SetBaseObject((PyArrayObject *)ap_ret, capsule);
+    // For ref counting of the memory
+    if (PyArray_SetBaseObject(ap_ret, capsule) == -1) {
+        Py_DECREF(ap_ret);
+        free(mem_ret);
+        PYERR(slsqp_error, "scipy.optimize._slsqplib: Failed to set array's base.");
+    }
 
     // Return the result
     return Py_BuildValue("Ndi", PyArray_Return(ap_ret), rnorm, info);
-
 }
 
 

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -158,8 +158,11 @@ static PyObject *SuperLU_getter(PyObject *selfp, void *data)
         }
 
         /* For ref counting of the memory */
-        PyArray_SetBaseObject((PyArrayObject*)perm_r, (PyObject*)self);
         Py_INCREF(self);
+        if (PyArray_SetBaseObject((PyArrayObject*)perm_r, (PyObject*)self) == -1) {
+            Py_DECREF(self);
+            return NULL;
+        }
         return perm_r;
     }
     else if (strcmp(name, "perm_c") == 0) {
@@ -173,8 +176,11 @@ static PyObject *SuperLU_getter(PyObject *selfp, void *data)
         }
 
         /* For ref counting of the memory */
-        PyArray_SetBaseObject((PyArrayObject*)perm_c, (PyObject*)self);
         Py_INCREF(self);
+        if (PyArray_SetBaseObject((PyArrayObject*)perm_c, (PyObject*)self) == -1) {
+            Py_DECREF(self);
+            return NULL;
+        }
         return perm_c;
     }
     else if (strcmp(name, "U") == 0 || strcmp(name, "L") == 0) {


### PR DESCRIPTION
This is a follow-up to gh-23563. Main changes:
- `PyArray_SimpleNewFromData` on plain C arrays requires taking care of memory management of the data being passed in. There are two strategies:
    - In general, creating a capsule to hold the data and making setting the `.base` attribute of the created ndarray to that capsule will do the right thing. This pattern is documented at https://numpy.org/devdocs/reference/c-api/data_memory.html#what-happens-when-deallocating-if-there-is-no-policy-set
    - If one is sure that the data won't go out of scope, it can be done much more concisely by telling the ndarray that it doesn't own the data. This is fairly rare probably, but callback functions do fit this pattern.
- Proper error handling for `PyCapsule_New` and `PyArray_SetBaseObject`.
- A somewhat larger refactor in `__minpack.h`, because that code was particularly hard to read.
- Clean up casting back and forth between `PyArrayObject` and `PyObject` to be more minimal.
- Fix some very unergonomic tuple constructing that was leaking a bit of memory as well. `PyTuple_Pack` is usually the better constructor to use.