### PR TITLE
DOC: forward port 1.16.2 relnotes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -182,8 +182,10 @@ Eric Larson <larson.eric.d@gmail.com> Eric89GXL <larson.eric.d@gmail.com>
 Eric Quintero <eric.antonio.quintero@gmail.com> e-q <eric.antonio.quintero@gmail.com>
 Eric Quintero <eric.antonio.quintero@gmail.com> Eric Quintero <e-q@users.noreply.github.com>
 Eric Soroos <eric-github@soroos.net> wiredfool <eric-github@soroos.net>
+Eric Zitong Zhou <zitongzhou1999@gmail.com> zitongzhoueric <zitongzhou1999@gmail.com>
 Étienne Tremblay <45673646+30blay@users.noreply.github.com> 30blay <45673646+30blay@users.noreply.github.com>
-Evandro <15084103+evbernardes@users.noreply.github.com> evbernardes <evbernardes@gmail.com>
+Evandro Bernardes <15084103+evbernardes@users.noreply.github.com> evbernardes <evbernardes@gmail.com>
+Evandro Bernardes <15084103+evbernardes@users.noreply.github.com> Evandro <15084103+evbernardes@users.noreply.github.com>
 Evgeni Burovski <evgeny.burovskiy@gmail.com> Zhenya <evgeni@burovski.me>
 Evgeni Burovski <evgeny.burovskiy@gmail.com> Evgeni Burovski <evgeni@burovski.me>
 Evan W Jones <60061381+E-W-Jones@users.noreply.github.com> Evan <60061381+E-W-Jones@users.noreply.github.com>
@@ -214,6 +216,8 @@ Garrett Reynolds <garrettreynolds5@gmail.com> Garrett-R <garrettreynolds5@gmail.
 Gaël Varoquaux <gael.varoquaux@normalesup.org> Gael varoquaux <gael.varoquaux@normalesup.org>
 Gavin Zhang <zhanggan@cn.ibm.com> GavinZhang <zhanggan@cn.ibm.com>
 Gavin Zhang <zhanggan@cn.ibm.com> Gavin Zhang <zheddie@163.com>
+Gauthier Berthomieu <72027971+Gautzilla@users.noreply.github.com> Gautzilla <72027971+Gautzilla@users.noreply.github.com>
+Gayatri Chakkithara <113033661+redpinecube@users.noreply.github.com> redpinecube <113033661+redpinecube@users.noreply.github.com>
 Geordie McBain <gdmcbain@protonmail.com> G. D. McBain <gdmcbain@protonmail.com>
 Gang Zhao <zhaog6@lsec.cc.ac.cn> zhaog6 <31978442+zhaog6@users.noreply.github.com>
 Gian Marco Messa <gianmarco.messa@gmail.com> messagian <gianmarco.messa@gmail.com>
@@ -224,6 +228,7 @@ Giorgio Patrini <giorgio.patrini@anu.edu.au> giorgiop <giorgio.patrini@nicta.com
 Gregory R. Lee <grlee77@gmail.com> Gregory R. Lee <gregory.lee@cchmc.org>
 Gregory R. Lee <grlee77@gmail.com> Gregory Lee <grlee77@gmail.com>
 Golnaz Irannejad <golnazirannejad@gmail.com> golnazir <golnazirannejad@gmail.com>
+Guido Imperiale <crusaderky@gmail.com> crusaderky <crusaderky@gmail.com>
 Guillaume Horel <thrasibule@users.noreply.github.com> Thrasibule <thrasibule@users.noreply.github.com>
 Guo Fei <<guofei9987@foxmail.com> Guofei <<guofei9987@foxmail.com>
 Guus Kamphuis <guuskamphuis@gmail.com> ZoutigeWolf <guuskamphuis@gmail.com>
@@ -282,6 +287,7 @@ Jeff Armstrong <jeff@approximatrix.com> ArmstrongJ <approximatrix@gmail.com>
 Jeff Armstrong <jeff@approximatrix.com> Jeff Armstrong <jeff@approximatrix.com>
 Jesse Engel <jesse.engel@gmail.com> jesseengel <jesse.engel@gmail.com>
 Jesse Livezey <jesse.livezey@gmail.com> Jesse Livezey <jlivezey@lbl.gov>
+Jigyasu Krishnan <jigyasu@outlook.in> Jigyasu <jigyasu@outlook.in>
 Jin-Guo Liu <cacate0129@gmail.com> GiggleLiu <cacate0129@gmail.com>
 J.L. Lanfranchi <jll1062@phys.psu.edu> J. L. Lanfranchi <jllanfranchi@users.noreply.github.com>
 J.L. Lanfranchi <jll1062@phys.psu.edu> J.L. Lanfranchi <jllanfranchi@users.noreply.github.com>
@@ -325,10 +331,12 @@ Kai Striega <kaistriega@gmail.com> Kai <kaistriega@gmail.com>
 Kai Striega <kaistriega@gmail.com> kai <kaistriega@gmail.com>
 Kai Striega <kaistriega@gmail.com> kai-striega <kaistriega+github@gmail.com>
 Kai Striega <kaistriega@gmail.com> Kai Striega <kaistriega+github@gmail.com>
+Karthik Viswanath Ganti <kganti2@illinois.edu> karthik-ganti-2025 <kganti2@illinois.edu>
 Kat Huang <kat@aya.yale.edu> kat <kat@aya.yale.edu>
 Kenji S Emerson <psmd.iberutaru@gmail.com> Sparrow <psmd.iberutaru@gmail.com>
 Kentaro Yamamoto <38549987+yamaken1343@users.noreply.github.com> yamaken <38549987+yamaken1343@users.noreply.github.com>
 Kevin Richard Green <kevin.richard.green@gmail.com> kevinrichardgreen <kevin.richard.green@gmail.com>
+Kirill R. <dartvader316-dev@pm.me> dartvader316 <dartvader316-dev@pm.me>
 Klaus Sembritzki <klausem@gmail.com> klaus <klausem@gmail.com>
 Klesk Chonkin <kleskjr@gmail.com> kleskjr <kleskjr@gmail.com>
 Krzysztof Pióro <38890793+krzysztofpioro@users.noreply.github.com> krzysztofpioro <38890793+krzysztofpioro@users.noreply.github.com>
@@ -366,6 +374,7 @@ Marc Honnorat <marc.honnorat@gmail.com> honnorat <marc.honnorat@gmail.com>
 Marcello Seri <mseri@users.noreply.github.com> mseri <mseri@users.noreply.github.com>
 Marco Maggi <124086916+m-maggi@users.noreply.github.com> m-maggi <124086916+m-maggi@users.noreply.github.com>
 Mark E Fuller <mark.e.fuller@gmx.de> Mark E. Fuller <mark.e.fuller@gmx.de>
+Mark van Rossum <mark.vanrossum@nottingham.ac.uk> vrossum <mark.vanrossum@nottingham.ac.uk>
 Mark Wiebe <> Mark <>
 Martin Manns <mmanns@gmx.net> manns <mmanns@gmx.net>
 Martin Reinecke <martin.reinecke1@gmx.de> mreineck <martin.reinecke1@gmx.de>
@@ -397,7 +406,9 @@ Michael James Bedford <SunsetOrange@users.noreply.github.com> Michael <SunsetOra
 Michael Marien <marien.mich@gmail.com> michaelmarien <marien.mich@gmail.com>
 Miguel A. Batalla <miguelangel@batalla.pro> mabatalla <miguelangel@batalla.pro>
 Mikhail Pak <mikhail.pak@tum.de> mp4096 <mikhail.pak@tum.de>
+Mikhail Ryazanov <mikhail.ryazanov@gmail.com> MikhailRyazanov <mikhail.ryazanov@gmail.com>
 Milad Sadeghi DM <EverLookNeverSee@Protonmail.ch> ELNS <57490926+EverLookNeverSee@users.noreply.github.com>
+Mugunthan Selvanayagam <mugunthan.selvanayagam@multicorewareinc.com> Mugu~~ <mugunthan.selvanayagam@multicorewareinc.com>
 Muhammad Firmansyah Kasim <firman.kasim@gmail.com> mfkasim91 <firman.kasim@gmail.com>
 Nathan Bell <wnbell@localhost> wnbell <wnbell@localhost>
 Nathan Woods <woodscn@lanl.gov> Charles Nathan Woods <woodscn@pn1504346.lanl.gov>
@@ -422,6 +433,7 @@ Pablo Winant <pablo.winant@gmail.com> pablo.winant@gmail.com <Pablo Winant>
 Pamphile Roy <roy.pamphile@gmail.com> Pamphile ROY <proy@bongfish.com>
 Pamphile Roy <roy.pamphile@gmail.com> Pamphile ROY <roy.pamphile@gmail.com>
 Pamphile Roy <roy.pamphile@gmail.com> Tupui <23188539+tupui@users.noreply.github.com>
+Param Singh <techhero724@gmail.com> PARAM SINGH <techhero724@gmail.com>
 Patrick Snape <patricksnape@gmail.com> patricksnape <patricksnape@gmail.com>
 Paul Kienzle <pkienzle@gmail.com> Paul Kienzle <pkienzle@nist.gov>
 Paul van Mulbregt <pvanmulbregt@users.noreply.github.com> pvanmulbregt <pvanmulbregt@users.noreply.github.com>
@@ -448,6 +460,7 @@ Pierre de Buyl <pdebuyl@pdebuyl.be> Pierre de Buyl <pdebuyl@ulb.ac.be>
 Pierre GM <pierregm@localhost> pierregm <pierregm@localhost>
 Poom Chiarawongse <eight1911@gmail.com> Poom Chiarawongse <tchiarawongs@gmail.com>
 Poom Chiarawongse <eight1911@gmail.com> poom <eight1911@gmail.com>
+Pratham Kumar <pratham.kumar@multicorewareinc.com> pratham-mcw <pratham.kumar@multicorewareinc.com>
 Quentin Barthélemy <q.barthelemy@gmail.com> qbarthelemy <q.barthelemy@gmail.com>
 Radoslaw Guzinski <radoslaw.guzinski@esa.int> radosuav <rmgu@dhi-gras.com>
 Radoslaw Guzinski <radoslaw.guzinski@esa.int> radosuav <radoslaw.guzinski@esa.int>
@@ -471,6 +484,7 @@ Ruikang Sun <srk888666@qq.com> SunRuikang <srk888666@qq.com>
 Rupak Das <dr10ru@yahoo.co.in> Rupak <dr10ru@yahoo.co.in>
 Ruslan Yevdokymov <evruslan17@gmail.com> Ruslan Yevdokymov <38809160+ruslanye@users.noreply.github.com>
 Ryan Gibson <ryan.alexander.gibson@gmail.com> ragibson <ryan.alexander.gibson@gmail.com>
+Sagi Ezri <sagi.ezri@gmail.com> sagi-ezri <sagi.ezri@gmail.com>
 Sam Lewis <sam.vr.lewis@gmail.com> Sam Lewis <samvrlewis@users.noreply.github.com>
 Sam McCormack <sampmccormack@gmail.com> Sam McCormack <TheGreatCabbage@users.noreply.github.com>
 Sam Mason <sam@samason.uk> Sam Mason <sam.mason@warwick.ac.uk>
@@ -537,6 +551,7 @@ Travis Oliphant <teoliphant@gmail.com> Travis E. Oliphant <teoliphant@gmail.com>
 Travis Oliphant <teoliphant@gmail.com> Travis Oliphant <oliphant@enthought.com>
 Uwe Schmitt <uwe.schmitt@localhost> uwe.schmitt <uwe.schmitt@localhost>
 Vicky Close <vicky.r.close@gmail.com> vickyclose <vicky.r.close@gmail.com>
+Victor PM <vpecanins@gmail.com> vpecanins <vpecanins@gmail.com>
 Vladyslav Rachek <wsw.raczek@gmail.com> Vladyslav Rachek <36896640+erheron@users.noreply.github.com>
 Warren Weckesser <warren.weckesser@gmail.com> warren.weckesser <warren.weckesser@localhost>
 Warren Weckesser <warren.weckesser@gmail.com> Warren Weckesser <warren.weckesser@enthought.com>
@@ -548,8 +563,11 @@ Will Tirone <will.tirone1@gmail.com> willtirone <will.tirone1@gmail.com>
 Xiao Yuan <yuanx749@gmail.com> yuanx749 <yuanx749@gmail.com>
 Xingyu Liu <38244988+charlotte12l@users.noreply.github.com> 刘星雨 <liuxingyu.12@bytedance.com>
 Yagiz Olmez <57116432+yagizolmez@users.noreply.github.com> yagizolmez <yagizolmez@pop-os.localdomain>
+Yongcai Huang <97007177+YongcaiHuang@users.noreply.github.com> YongcaiHuang <97007177+YongcaiHuang@users.noreply.github.com>
 Yu Feng <rainwoodman@gmail.com> Yu Feng <yfeng1@waterfall.dyn.berkeley.edu>
+Yuji Ikeda <yuji.ikeda.ac.jp@gmail.com> yuzie007 <yuji.ikeda.ac.jp@gmail.com>
 Yves-Rémi Van Eycke <yves-remi@hotmail.com> vanpact <yves-remi@hotmail.com>
+Zaikun Zhang <zaikunzhang@gmail.com> zaikunzhang <zaikunzhang@gmail.com>
 Zé Vinícius <jvmirca@gmail.com> Ze Vinicius <jvmirca@gmail.com>
 Zhida Shang <57895730+futuer-szd@users.noreply.github.com> Futuer <57895730+futuer-szd@users.noreply.github.com>
 Zoufiné Lauer-Bare <raszoufine@gmail.com> zolabar <raszoufine@gmail.com>

--- a/doc/source/_static/version_switcher.json
+++ b/doc/source/_static/version_switcher.json
@@ -5,9 +5,14 @@
         "url": "https://scipy.github.io/devdocs/"
     },
     {
-        "name": "1.16.1 (stable)",
-        "version":"1.16.1",
+        "name": "1.16.2 (stable)",
+        "version":"1.16.2",
         "preferred": true,
+        "url": "https://docs.scipy.org/doc/scipy-1.16.2/"
+    },
+    {
+        "name": "1.16.1",
+        "version":"1.16.1",
         "url": "https://docs.scipy.org/doc/scipy-1.16.1/"
     },
     {

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -9,6 +9,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
    :maxdepth: 1
 
    release/1.17.0-notes
+   release/1.16.2-notes
    release/1.16.1-notes
    release/1.16.0-notes
    release/1.15.3-notes

--- a/doc/source/release/1.16.2-notes.rst
+++ b/doc/source/release/1.16.2-notes.rst
@@ -1,0 +1,68 @@
+==========================
+SciPy 1.16.2 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.16.2 is a bug-fix release with no new features
+compared to 1.16.1. This is the first stable release of
+SciPy to provide Windows on ARM wheels on PyPI.
+
+
+
+Authors
+=======
+* Name (commits)
+* Dietrich Brunn (1)
+* Ralf Gommers (6)
+* Adam Jones (1)
+* Gleb Khmyznikov (1) +
+* Jost Migenda (1) +
+* newyork_loki (1)
+* Nick ODell (3)
+* Dimitri Papadopoulos Orfanos (1)
+* Ilhan Polat (2)
+* Tyler Reddy (26)
+* Mugunthan Selvanayagam (1) +
+* Shuhei Watanabe (1) +
+
+    A total of 12 people contributed to this release.
+    People with a "+" by their names contributed a patch for the first time.
+    This list of names is automatically generated, and may not be fully complete.
+
+
+Issues closed for 1.16.2
+------------------------
+
+* `#21562 <https://github.com/scipy/scipy/issues/21562>`__: BLD: Windows Arm builds
+* `#22244 <https://github.com/scipy/scipy/issues/22244>`__: MAINT: specify lower bound for ``pytest`` in ``pyproject.toml``
+* `#22825 <https://github.com/scipy/scipy/issues/22825>`__: CI: new GH runners available for macOS 15 and Windows 2025
+* `#23411 <https://github.com/scipy/scipy/issues/23411>`__: BUG: signal.periodogram: memory leak
+* `#23428 <https://github.com/scipy/scipy/issues/23428>`__: Incomplete license terms for sub components since version 1.16.0...
+* `#23429 <https://github.com/scipy/scipy/issues/23429>`__: BUG: optimize.nnls: memory leak
+* `#23430 <https://github.com/scipy/scipy/issues/23430>`__: BUG: optimize: missing error checking for slsqp inputs
+* `#23458 <https://github.com/scipy/scipy/issues/23458>`__: CI: CUDA compilation failures for all cupy tests
+* `#23474 <https://github.com/scipy/scipy/issues/23474>`__: BUG: signal.lombscargle(precenter=True) modifies input array...
+* `#23564 <https://github.com/scipy/scipy/issues/23564>`__: CI: macOS conda-forge job failing because of scikit-umfpack upgrade
+
+
+Pull requests for 1.16.2
+------------------------
+
+* `#23122 <https://github.com/scipy/scipy/pull/23122>`__: BLD: Windows Arm64 wheel support
+* `#23133 <https://github.com/scipy/scipy/pull/23133>`__: CI: validate build on Win-ARM64
+* `#23154 <https://github.com/scipy/scipy/pull/23154>`__: CI: bump OpenBLAS and cibuildwheel versions
+* `#23402 <https://github.com/scipy/scipy/pull/23402>`__: REL, MAINT: prepare for SciPy 1.16.2
+* `#23403 <https://github.com/scipy/scipy/pull/23403>`__: BUG: Skip installing gmpy2(test deps) for Win-ARM64
+* `#23414 <https://github.com/scipy/scipy/pull/23414>`__: BUG: signal: Avoid unbounded cache for ShortTimeFFT
+* `#23435 <https://github.com/scipy/scipy/pull/23435>`__: MAINT: ensure Qhull license file gets included in wheels
+* `#23442 <https://github.com/scipy/scipy/pull/23442>`__: BUG: fix regression for non-integer ``maxiter`` in SLSQP
+* `#23452 <https://github.com/scipy/scipy/pull/23452>`__: MAINT: Update licensing of bundled software
+* `#23457 <https://github.com/scipy/scipy/pull/23457>`__: BUG: signal.ShortTimeFFT: Remove ``@lru_cache`` decorators
+* `#23471 <https://github.com/scipy/scipy/pull/23471>`__: BUG: optimize: fix the incompatible dtypes in L-BFGS-B
+* `#23475 <https://github.com/scipy/scipy/pull/23475>`__: BUG: signal.lombscargle: replace in-place input adjustments
+* `#23488 <https://github.com/scipy/scipy/pull/23488>`__: MAINT: Bump CuPy to 13.6.0 to fix GPU CI
+* `#23495 <https://github.com/scipy/scipy/pull/23495>`__: MAINT: add lower bound for pytest
+* `#23540 <https://github.com/scipy/scipy/pull/23540>`__: MAINT, BLD: ignore meson wraplock
+* `#23563 <https://github.com/scipy/scipy/pull/23563>`__: BUG: fix memory leaks in ``optimize.nnls`` and ``linalg.sqrtm``
+* `#23576 <https://github.com/scipy/scipy/pull/23576>`__: CI: pin scikit-umfpack to 0.3.3 to avoid failures, 0.4.2 is broken.


### PR DESCRIPTION
* Forward port the SciPy `1.16.2` release notes, `.mailmap` changes from the release branch (which I often forget to do), and the version switcher update.

[docs only]
