### PR TITLE
REL, MAINT: prepare for SciPy 1.16.3

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -8,6 +8,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 .. toctree::
    :maxdepth: 1
 
+   release/1.16.3-notes
    release/1.16.2-notes
    release/1.16.1-notes
    release/1.16.0-notes

--- a/doc/source/release/1.16.3-notes.rst
+++ b/doc/source/release/1.16.3-notes.rst
@@ -1,0 +1,23 @@
+==========================
+SciPy 1.16.3 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.16.3 is a bug-fix release with no new features
+compared to 1.16.2.
+
+
+
+Authors
+=======
+* Name (commits)
+
+
+Issues closed for 1.16.3
+------------------------
+
+
+
+Pull requests for 1.16.3
+------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.16.2"
+version = "1.16.3.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Prepare for SciPy `1.16.3`, just in case.

[ci skip] [skip ci]
