### PR TITLE
BUG: signal.lfilter: More meaningful error messages for invalid parameters.

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2178,14 +2178,17 @@ def lfilter(b, a, x, axis=-1, zi=None):
     if zi is not None:
        zi = np.asarray(zi)
 
+    if not (b.ndim == 1 and xp_size(b) > 0):
+        raise ValueError(f"Parameter b is not a non-empty 1d array, since {b.shape=}!")
+    if not (a.ndim == 1 and xp_size(a) > 0):
+        raise ValueError(f"Parameter a is not a non-empty 1d array, since {a.shape=}!")
+
     if len(a) == 1:
         # This path only supports types fdgFDGO to mirror _linear_filter below.
         # Any of b, a, x, or zi can set the dtype, but there is no default
         # casting of other types; instead a NotImplementedError is raised.
         b = np.asarray(b)
         a = np.asarray(a)
-        if b.ndim != 1 and a.ndim != 1:
-            raise ValueError('object of too small depth for desired array')
         x = _validate_x(x)
         inputs = [b, a, x]
         if zi is not None:
@@ -2193,7 +2196,8 @@ def lfilter(b, a, x, axis=-1, zi=None):
             # singleton dims.
             zi = np.asarray(zi)
             if zi.ndim != x.ndim:
-                raise ValueError('object of too small depth for desired array')
+                raise ValueError("Dimensions of parameters x and zi must match, but " +
+                                 f"{x.ndim=}, {zi.ndim=}!")
             expected_shape = list(x.shape)
             expected_shape[axis] = b.shape[0] - 1
             expected_shape = tuple(expected_shape)
@@ -2210,7 +2214,7 @@ def lfilter(b, a, x, axis=-1, zi=None):
                     elif k != axis and zi.shape[k] == 1:
                         strides[k] = 0
                     else:
-                        raise ValueError('Unexpected shape for zi: expected '
+                        raise ValueError('Unexpected shape for parameter zi: expected '
                                          f'{expected_shape}, found {zi.shape}.')
                 zi = np.lib.stride_tricks.as_strided(zi, expected_shape,
                                                      strides)
@@ -2218,7 +2222,9 @@ def lfilter(b, a, x, axis=-1, zi=None):
         dtype = np.result_type(*inputs)
 
         if dtype.char not in 'fdgFDGO':
-            raise NotImplementedError(f"input type '{dtype}' not supported")
+            p_types = tuple(p_.dtype.char for p_ in inputs)
+            raise NotImplementedError("Parameter dtypes must be convertible to one of "
+                                      f"'fdgFDGO'! Given input dtypes are {p_types}.")
 
         b = np.array(b, dtype=dtype)
         a = np.asarray(a, dtype=dtype)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2222,9 +2222,8 @@ def lfilter(b, a, x, axis=-1, zi=None):
         dtype = np.result_type(*inputs)
 
         if dtype.char not in 'fdgFDGO':
-            p_types = tuple(p_.dtype.char for p_ in inputs)
-            raise NotImplementedError("Parameter dtypes must be convertible to one of "
-                                      f"'fdgFDGO'! Given input dtypes are {p_types}.")
+            raise NotImplementedError("Parameter's dtypes produced result type " +
+                                      f"'{dtype}', which is not supported!")
 
         b = np.array(b, dtype=dtype)
         a = np.asarray(a, dtype=dtype)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1838,6 +1838,7 @@ class _TestLinearFilter:
                      else self.dtype)
             return xp.asarray(arr, dtype=dtype)
 
+    @skip_xp_backends('cupy', reason='XXX https://github.com/scipy/scipy/issues/23539')
     def test_invalid_params(self, xp):
         """Verify all exceptions are raised. """
         b, a, x = xp.asarray([1]), xp.asarray([2]), xp.asarray([3, 4])

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1850,7 +1850,7 @@ class _TestLinearFilter:
             lfilter(b, xp.eye(2), x)  # a not one-dimensional
         with pytest.raises(ValueError, match="^Parameter a is not"):
             lfilter(b, xp.asarray([]), x)  # a empty
-        with pytest.raises(NotImplementedError, match="^Parameter dtypes must be "):
+        with pytest.raises(NotImplementedError, match="^Parameter's dtypes produced "):
             b, a, x = (xp.astype(v_, xp.uint64, copy=False) for v_ in (b, a, x))
             lfilter(b, a, x)  # fails with uint64 dtype
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1838,6 +1838,21 @@ class _TestLinearFilter:
                      else self.dtype)
             return xp.asarray(arr, dtype=dtype)
 
+    def test_invalid_params(self, xp):
+        """Verify all exceptions are raised. """
+        b, a, x = xp.asarray([1]), xp.asarray([2]), xp.asarray([3, 4])
+        with pytest.raises(ValueError, match="^Parameter b is not"):
+            lfilter(xp.eye(2), a, x)  # b not one-dimensional
+        with pytest.raises(ValueError, match="^Parameter b is not"):
+            lfilter(xp.asarray([]), a, x)  # b empty
+        with pytest.raises(ValueError, match="^Parameter a is not"):
+            lfilter(b, xp.eye(2), x)  # a not one-dimensional
+        with pytest.raises(ValueError, match="^Parameter a is not"):
+            lfilter(b, xp.asarray([]), x)  # a empty
+        with pytest.raises(NotImplementedError, match="^Parameter dtypes must be "):
+            b, a, x = (xp.astype(v_, xp.uint64, copy=False) for v_ in (b, a, x))
+            lfilter(b, a, x)  # fails with uint64 dtype
+
     def test_rank_1_IIR(self, xp):
         x = self.generate((6,), xp)
         b = self.convert_dtype([1, -1], xp)


### PR DESCRIPTION

The raising of exceptions in `lfliter` is refactored. Also, a unit test is added to ensure 100% code coverage.

Closes #23555.
