### PR TITLE
TYP: more generic `integrate` types

### DIFF
--- a/scipy/integrate/_ivp/base.py
+++ b/scipy/integrate/_ivp/base.py
@@ -1,3 +1,4 @@
+from types import GenericAlias
 import numpy as np
 
 
@@ -128,6 +129,9 @@ class OdeSolver:
     """
     TOO_SMALL_STEP = "Required step size is less than spacing between numbers."
 
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     def __init__(self, fun, t0, y0, t_bound, vectorized,
                  support_complex=False):
         self.t_old = None
@@ -242,6 +246,10 @@ class DenseOutput:
     t_min, t_max : float
         Time range of the interpolation.
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     def __init__(self, t_old, t):
         self.t_old = t_old
         self.t = t

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -1,5 +1,3 @@
-from types import GenericAlias
-
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
 from scipy.sparse import issparse, csc_matrix, eye
@@ -196,9 +194,6 @@ class BDF(OdeSolver):
            sparse Jacobian matrices", Journal of the Institute of Mathematics
            and its Applications, 13, pp. 117-120, 1974.
     """
-
-    # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, fun, t0, y0, t_bound, max_step=np.inf,
                  rtol=1e-3, atol=1e-6, jac=None, jac_sparsity=None,

--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -1,5 +1,3 @@
-from types import GenericAlias
-
 import numpy as np
 from .base import OdeSolver, DenseOutput
 from .common import (validate_max_step, validate_tol, select_initial_step,
@@ -83,9 +81,6 @@ class RungeKutta(OdeSolver):
     order: int = NotImplemented
     error_estimator_order: int = NotImplemented
     n_stages: int = NotImplemented
-
-    # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, fun, t0, y0, t_bound, max_step=np.inf,
                  rtol=1e-3, atol=1e-6, vectorized=False,


### PR DESCRIPTION
Since #23270, `integrate.OdeSolver` and `integrate.DenseOutput` have also been made into generic types (scipy/scipy-stubs#880). This ensures that they can be used as such at runtime.

Note that since `BDF` subclasses `OdeSolver`, it no longer needs the classmethod, so I cancelled it.