### PR TITLE
TST: shim for NumPy warning changes

### DIFF
--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3024,7 +3024,7 @@ class TestVectorizedFilter:
         res = ndimage.vectorized_filter(input, xp.mean, size=1)
         xp_assert_equal(res, input)
 
-    @pytest.mark.filterwarnings("ignore:Mean of empty slice.:RuntimeWarning")
+    @pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
     def test_edge_cases(self, xp):
         rng = np.random.default_rng(4835982345234982)
         function = xp.mean

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -812,7 +812,7 @@ def test_check_empty_inputs():
                 if output is not None:
                     with warnings.catch_warnings():
                         warnings.filterwarnings(
-                            "ignore", "Mean of empty slice.", RuntimeWarning)
+                            "ignore", "Mean of empty slice", RuntimeWarning)
                         warnings.filterwarnings(
                             "ignore", "invalid value encountered", RuntimeWarning)
                         reference = samples[0].mean(axis=axis)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -983,7 +983,7 @@ class TestTheilslopes:
 
     def test_theilslopes_warnings(self):
         # Test `theilslopes` with degenerate input; see gh-15943
-        msg = "All `x` coordinates.*|Mean of empty slice.|invalid value encountered.*"
+        msg = "All `x` coordinates.*|Mean of empty slice|invalid value encountered.*"
         with pytest.warns(RuntimeWarning, match=msg):
             res = mstats.theilslopes([0, 1], [0, 0])
             assert np.all(np.isnan(res))


### PR DESCRIPTION
* Fixes gh-23603 by suppressing the match on the final punctuation. Locally, this restores full testsuite passing against latest NumPy `main`.

[skip circle]

Normally I'd leave this as suitable for a new contributor to get involved, but I'm working to revert a hack on the release branch and having the tests all green against NumPy `main` there is nice too, so just doing it..