### PR TITLE
TST, MAINT: backports, restore lfilter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,8 @@ jobs:
           command: |
             pip install numpy cython pybind11 pythran ninja meson
             pip install -r requirements/doc.txt
-            pip install mpmath gmpy2 "asv>=0.6.0" pooch threadpoolctl spin
+            # asv upper bound due to issue in gh-23611, remove when that is resolved
+            pip install mpmath gmpy2 "asv<0.6.5" pooch threadpoolctl spin
             # extra benchmark deps
             pip install pyfftw cffi pytest
 

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2963,7 +2963,7 @@ class TestVectorizedFilter:
         res = ndimage.vectorized_filter(input, xp.mean, size=1)
         xp_assert_equal(res, input)
 
-    @pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
+    @pytest.mark.filterwarnings(r"ignore:Mean of empty slice\.?:RuntimeWarning")
     def test_edge_cases(self, xp):
         rng = np.random.default_rng(4835982345234982)
         function = xp.mean

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2963,7 +2963,7 @@ class TestVectorizedFilter:
         res = ndimage.vectorized_filter(input, xp.mean, size=1)
         xp_assert_equal(res, input)
 
-    @pytest.mark.filterwarnings("ignore:Mean of empty slice.:RuntimeWarning")
+    @pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
     def test_edge_cases(self, xp):
         rng = np.random.default_rng(4835982345234982)
         function = xp.mean

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2084,9 +2084,7 @@ class _TestLinearFilter:
         a = self.convert_dtype(a, xp)
         x = self.convert_dtype(x, xp)
         zi = self.convert_dtype(zi, xp)
-        # NOTE: MemoryError is currently allowed below because of:
-        # https://github.com/numpy/numpy/issues/29721
-        assert_raises((ValueError, MemoryError), lfilter, b, a, x, axis, zi)
+        assert_raises(ValueError, lfilter, b, a, x, axis, zi)
 
     @skip_xp_backends('cupy', reason='cupy does not raise')
     def test_bad_size_zi(self, xp):
@@ -2136,11 +2134,7 @@ class _TestLinearFilter:
         self.base_bad_size_zi([1, 1, 1], [1], x2, 0, [[0, 1, 2, 3], [4, 5, 6, 7]], xp)
 
         self.base_bad_size_zi([1], [1, 1], x2, 0, [0, 1, 2], xp)
-        # this case is disabled on the release branch
-        # because of:
-        # https://github.com/scipy/scipy/pull/23543#issuecomment-3276286172
-        # https://github.com/numpy/numpy/issues/29721
-        #self.base_bad_size_zi([1], [1, 1], x2, 0, [[[0, 1, 2]]], xp)
+        self.base_bad_size_zi([1], [1, 1], x2, 0, [[[0, 1, 2]]], xp)
         self.base_bad_size_zi([1], [1, 1], x2, 0, [[0], [1], [2]], xp)
         self.base_bad_size_zi([1], [1, 1], x2, 0, [[0, 1]], xp)
         self.base_bad_size_zi([1], [1, 1], x2, 0, [[0, 1, 2, 3]], xp)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -783,7 +783,7 @@ def test_check_empty_inputs():
                                                                     axis)
                 if output is not None:
                     with np.testing.suppress_warnings() as sup:
-                        sup.filter(RuntimeWarning, "Mean of empty slice.")
+                        sup.filter(RuntimeWarning, "Mean of empty slice")
                         sup.filter(RuntimeWarning, "invalid value encountered")
                         reference = samples[0].mean(axis=axis)
                     np.testing.assert_equal(output, reference)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -870,7 +870,7 @@ def test_empty(hypotest, args, kwds, n_samples, n_outputs, paired, unpacker):
                 concat = stats._stats_py._broadcast_concatenate(samples, axis,
                                                                 paired=paired)
                 with np.testing.suppress_warnings() as sup:
-                    sup.filter(RuntimeWarning, "Mean of empty slice.")
+                    sup.filter(RuntimeWarning, r"Mean of empty slice\.?")
                     sup.filter(RuntimeWarning, "invalid value encountered")
                     expected = np.mean(concat, axis=axis) * np.nan
                     mask = np.isnan(expected)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -783,7 +783,7 @@ def test_check_empty_inputs():
                                                                     axis)
                 if output is not None:
                     with np.testing.suppress_warnings() as sup:
-                        sup.filter(RuntimeWarning, "Mean of empty slice")
+                        sup.filter(RuntimeWarning, r"Mean of empty slice\.?")
                         sup.filter(RuntimeWarning, "invalid value encountered")
                         reference = samples[0].mean(axis=axis)
                     np.testing.assert_equal(output, reference)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -984,7 +984,7 @@ class TestTheilslopes:
 
     def test_theilslopes_warnings(self):
         # Test `theilslopes` with degenerate input; see gh-15943
-        msg = "All `x` coordinates.*|Mean of empty slice|invalid value encountered.*"
+        msg = r"All `x` coordinates.*|Mean of empty slice\.?|invalid value encountered.*"  # noqa: E501
         with pytest.warns(RuntimeWarning, match=msg):
             res = mstats.theilslopes([0, 1], [0, 0])
             assert np.all(np.isnan(res))

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -984,7 +984,7 @@ class TestTheilslopes:
 
     def test_theilslopes_warnings(self):
         # Test `theilslopes` with degenerate input; see gh-15943
-        msg = "All `x` coordinates.*|Mean of empty slice.|invalid value encountered.*"
+        msg = "All `x` coordinates.*|Mean of empty slice|invalid value encountered.*"
         with pytest.warns(RuntimeWarning, match=msg):
             res = mstats.theilslopes([0, 1], [0, 0])
             assert np.all(np.isnan(res))


### PR DESCRIPTION
This PR against the release branch backports gh-23614 and removes the hacks introduced in gh-23543 now that NumPy has fixed the issue I reported upstream with the patch from https://github.com/numpy/numpy/pull/29745.

Locally, this allows the full testsuite to pass against latest NumPy `main` without having to suppress any of our tests.

This isn't particularly high priority, and `1.16.3` isn't planned, but let's just clean this all up just in case.