### PR TITLE
BUG: ndimage: fix handling of memory allocation failures.

### DIFF
--- a/scipy/ndimage/src/_rank_filter_1d.cpp
+++ b/scipy/ndimage/src/_rank_filter_1d.cpp
@@ -5,17 +5,47 @@
 #include "Python.h"
 #include "numpy/arrayobject.h"
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <memory>
+#include <new>
 
-struct Mediator // this is used for rank keeping
+//
+// This is used for rank keeping.
+//
+class Mediator
 {
+public:
+  int *mem;  // Single array of ints to hold the memory for `pos` and `heap`.
   int *pos;  // index into `heap` for each value
   int *heap; // max/rank/min heap holding indexes into `data`.
   int N;     // allocated size.
   int idx;   // position in circular queue
   int minCt; // count of items in min heap
   int maxCt; // count of items in max heap
+
+  //
+  // This constructor will throw an exception if memory allocation
+  // fails.  The caller *must* handle this exception so that it
+  // does not propagate out to Python-land.
+  //
+  Mediator(int nItems, int rank) {
+    mem = new int[2 * nItems];  // Might throw std::bad_alloc
+    pos = mem;                  // `pos` uses the first `nItems` elements of `mem`.
+    heap = mem + nItems + rank; // `heap` uses the second `nItems`; it actually
+                                // points to `rank` elements into the second
+                                // block of `nItems` elements.
+    N = nItems;
+    idx = 0;
+    minCt = nItems - rank - 1;
+    maxCt = rank;
+    while (nItems--) {
+      pos[nItems] = nItems - rank;
+      heap[pos[nItems]] = nItems;
+    }
+  }
+
+  ~Mediator() {
+    delete [] mem;
+  }
 };
 
 typedef enum {
@@ -90,27 +120,6 @@ template <typename T> inline int maxSortUp(T *data, Mediator *m, int i) {
 
 /*--- Public Interface ---*/
 
-// creates new Mediator: to calculate `nItems` running rank.
-Mediator *MediatorNew(int nItems, int rank) {
-  Mediator *m = new Mediator;
-  m->pos = new int[nItems];
-  m->heap = new int[nItems];
-  if ((m == nullptr) || (m->pos == nullptr) || (m->heap == nullptr)) {
-    printf("out of memory\n");
-    exit(1);
-  }
-  m->heap += rank; // points to rank
-  m->N = nItems;
-  m->idx = 0;
-  m->minCt = nItems - rank - 1;
-  m->maxCt = rank;
-  while (nItems--) {
-    m->pos[nItems] = nItems - rank;
-    m->heap[m->pos[nItems]] = nItems;
-  }
-  return m;
-}
-
 // Inserts item, maintains rank in O(lg nItems)
 template <typename T> void MediatorInsert(T *data, Mediator *m, T v) {
   int p = m->pos[m->idx];
@@ -150,8 +159,12 @@ template <typename T> void MediatorInsert(T *data, Mediator *m, T v) {
   }
 }
 
+//
+// _rank_filter() requires the allocation of memory.  If the allocation fails,
+// the function returns -1.  Otherwise it returns 0.
+//
 template <typename T>
-void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
+int _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
                   int mode, T cval, int origin) {
   int i, arr_len_thresh, lim = (win_len - 1) / 2 - origin;
   int lim2 = arr_len - lim;
@@ -164,7 +177,7 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
           case WRAP:
           case MIRROR:
               out_arr[0] = in_arr[0];
-              return;
+              return 0;
           case CONSTANT:
               if (win_len == 1) {
                   out_arr[0] = in_arr[0];
@@ -172,32 +185,38 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
               else {
                   out_arr[0] = cval;
               }
-              return;
+              return 0;
       }
   }
   int offset;
-  Mediator *m = MediatorNew(win_len, rank);
-  T *data = new T[win_len]();
+  std::unique_ptr<Mediator> m;
+  std::unique_ptr<T[]> data;
+  try {
+    m = std::make_unique<Mediator>(win_len, rank);
+    data = std::unique_ptr<T[]>(new T[win_len]());
+  } catch (std::bad_alloc&) {
+    return -1;
+  }
 
   switch (mode) {
   case REFLECT:
     for (i = win_len - lim - 1; i > -1; i--) {
-      MediatorInsert(data, m, in_arr[i]);
+      MediatorInsert(data.get(), m.get(), in_arr[i]);
     }
     break;
   case CONSTANT:
     for (i = win_len - lim; i > 0; i--) {
-      MediatorInsert(data, m, cval);
+      MediatorInsert(data.get(), m.get(), cval);
     }
     break;
   case NEAREST:
     for (i = win_len - lim; i > 0; i--) {
-      MediatorInsert(data, m, in_arr[0]);
+      MediatorInsert(data.get(), m.get(), in_arr[0]);
     }
     break;
   case MIRROR:
     for (i = win_len - lim; i > 0; i--) {
-      MediatorInsert(data, m, in_arr[i]);
+      MediatorInsert(data.get(), m.get(), in_arr[i]);
     }
     break;
   case WRAP:
@@ -208,81 +227,80 @@ void _rank_filter(T *in_arr, int rank, int arr_len, int win_len, T *out_arr,
         offset = 0;
     }
     for (i = arr_len - lim - offset - 2 * origin; i < arr_len; i++) {
-      MediatorInsert(data, m, in_arr[i]);
+      MediatorInsert(data.get(), m.get(), in_arr[i]);
     }
     break;
   }
 
   for (i = 0; i < lim; i++) {
-    MediatorInsert(data, m, in_arr[i]);
+    MediatorInsert(data.get(), m.get(), in_arr[i]);
   }
   for (i = lim; i < arr_len; i++) {
-    MediatorInsert(data, m, in_arr[i]);
+    MediatorInsert(data.get(), m.get(), in_arr[i]);
     out_arr[i - lim] = data[m->heap[0]];
   }
   switch (mode) {
   case REFLECT:
     arr_len_thresh = arr_len - 1;
     for (i = 0; i < lim; i++) {
-      MediatorInsert(data, m, in_arr[arr_len_thresh - i]);
+      MediatorInsert(data.get(), m.get(), in_arr[arr_len_thresh - i]);
       out_arr[lim2 + i] = data[m->heap[0]];
     }
     break;
   case CONSTANT:
     for (i = 0; i < lim; i++) {
-      MediatorInsert(data, m, cval);
+      MediatorInsert(data.get(), m.get(), cval);
       out_arr[lim2 + i] = data[m->heap[0]];
     }
     break;
   case NEAREST:
     arr_len_thresh = arr_len - 1;
     for (i = 0; i < lim; i++) {
-      MediatorInsert(data, m, in_arr[arr_len_thresh]);
+      MediatorInsert(data.get(), m.get(), in_arr[arr_len_thresh]);
       out_arr[lim2 + i] = data[m->heap[0]];
     }
     break;
   case MIRROR:
     arr_len_thresh = arr_len - 2;
     for (i = 0; i < lim; i++) {
-      MediatorInsert(data, m, in_arr[arr_len_thresh - i]);
+      MediatorInsert(data.get(), m.get(), in_arr[arr_len_thresh - i]);
       out_arr[lim2 + i] = data[m->heap[0]];
     }
     break;
   case WRAP:
     for (i = 0; i < lim; i++) {
-      MediatorInsert(data, m, in_arr[i]);
+      MediatorInsert(data.get(), m.get(), in_arr[i]);
       out_arr[lim2 + i] = data[m->heap[0]];
     }
     break;
   }
-
-  m->heap -= rank;
-  delete[] m->heap;
-  m->heap = nullptr;
-  delete[] m->pos;
-  m->pos = nullptr;
-  delete m;
-  m = nullptr;
-  delete[] data;
-  data = nullptr;
+  return 0;
 }
+
 
 // Python wrapper for rank_filter
 static PyObject *rank_filter(PyObject *self, PyObject *args) {
   PyObject *in_arr_obj, *out_arr_obj, *cval_obj;
   int rank, arr_len, win_len, mode, origin, type;
+  int rank_filter_status = 0;
+
   if (!PyArg_ParseTuple(args, "OiiOiOi", &in_arr_obj, &rank, &win_len,
                         &out_arr_obj, &mode, &cval_obj, &origin)) {
     return NULL;
   }
+
   PyArrayObject *in_arr = (PyArrayObject *)PyArray_FROM_OTF(
       in_arr_obj, NPY_NOTYPE, NPY_ARRAY_IN_ARRAY);
-  PyArrayObject *out_arr = (PyArrayObject *)PyArray_FROM_OTF(
-      out_arr_obj, NPY_NOTYPE, NPY_ARRAY_INOUT_ARRAY2);
-
-  if (in_arr == NULL || out_arr == NULL) {
+  if (in_arr == NULL) {
     return NULL;
   }
+  PyArrayObject *out_arr = (PyArrayObject *)PyArray_FROM_OTF(
+      out_arr_obj, NPY_NOTYPE, NPY_ARRAY_INOUT_ARRAY2);
+  if (out_arr == NULL) {
+    Py_DECREF(in_arr);
+    return NULL;
+  }
+
   arr_len = PyArray_SIZE(in_arr);
   type = PyArray_TYPE(in_arr);
 
@@ -291,32 +309,38 @@ static PyObject *rank_filter(PyObject *self, PyObject *args) {
     float *c_in_arr = (float *)PyArray_DATA(in_arr);
     float *c_out_arr = (float *)PyArray_DATA(out_arr);
     float cval = (float)PyFloat_AsDouble(cval_obj);
-    _rank_filter(c_in_arr, rank, arr_len, win_len, c_out_arr, mode, cval,
-                 origin);
+    rank_filter_status = _rank_filter(c_in_arr, rank, arr_len, win_len, c_out_arr,
+                                      mode, cval, origin);
     break;
   }
   case NPY_DOUBLE: {
     double *c_in_arr = (double *)PyArray_DATA(in_arr);
     double *c_out_arr = (double *)PyArray_DATA(out_arr);
     double cval = PyFloat_AsDouble(cval_obj);
-    _rank_filter(c_in_arr, rank, arr_len, win_len, c_out_arr, mode, cval,
-                 origin);
+    rank_filter_status = _rank_filter(c_in_arr, rank, arr_len, win_len, c_out_arr,
+                                      mode, cval, origin);
     break;
   }
   case NPY_INT64: {
     int64_t *c_in_arr = (int64_t *)PyArray_DATA(in_arr);
     int64_t *c_out_arr = (int64_t *)PyArray_DATA(out_arr);
     int64_t cval = PyLong_AsLongLong(cval_obj);
-    _rank_filter(c_in_arr, rank, arr_len, win_len, c_out_arr, mode, cval,
-                 origin);
+    rank_filter_status = _rank_filter(c_in_arr, rank, arr_len, win_len, c_out_arr,
+                                      mode, cval, origin);
     break;
   }
   default:
     PyErr_SetString(PyExc_TypeError, "Unsupported array type");
     break;
   }
+  if (rank_filter_status == -1) {
+    PyErr_SetString(PyExc_MemoryError, "failed to allocate memory for rank filter");
+  }
   Py_DECREF(in_arr);
   Py_DECREF(out_arr);
+  if (PyErr_Occurred()) {
+    return NULL;
+  }
   Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
* Allocate the memory used by Mediator in a constructor, and
  free it in the corresponding destructor.  Since a constructor
  can't return an error status, it throws an exception if the
  memory allocation fails.
* In _rank_filter(), the dynamically allocated Mediator instance
  and the work array 'data' are managed with 'unique_ptr'.  The
  exception that might be thrown when either of these is allocated
  is caught and converted to a return value of -1; _rank_filter()
  now returns 0 when it succeeds.
* In rank_filter(), a return value of -1 from _rank_filter() will
  result in a MemoryError exception being set.
* The potential failures of PyArray_FROM_OTF are now handled so
  that a failure of one does not cause the memory  allocated for
  the other to be leaked.

Closes gh-22365.