### PR TITLE
MAINT: optimize.differential_evolution: fix mistake in `partial` import

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -2,6 +2,7 @@
 differential_evolution: The differential evolution global optimization algorithm
 Added by Andrew Nelson 2014
 """
+from functools import partial
 import warnings
 
 import numpy as np

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -4,7 +4,6 @@ Unit tests for the differential global minimization algorithm.
 from multiprocessing.dummy import Pool as ThreadPool
 import platform
 import warnings
-from functools import partial
 
 from scipy.optimize._differentialevolution import (DifferentialEvolutionSolver,
                                                    _ConstraintWrapper)


### PR DESCRIPTION
In gh-23538, I used `[skip ci]` when removing import of `partial` to fix a lint error, but I accidentally removed it from the wrong file; see https://github.com/scipy/scipy/pull/23538#pullrequestreview-3222078763. (I forgot about `lint only` at the time, which would have caught the issue.) This fixes the problem.