### PR TITLE
BUG: sparse.csgraph.yen: Validate source and sink to avoid seg. faults.

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -1507,6 +1507,10 @@ def yen(
     csgraph = validate_graph(csgraph, directed, DTYPE, dense_output=False)
 
     cdef int N = csgraph.shape[0]
+    if source < 0 or source >= N or sink < 0 or sink >= N:
+        msg = ("For csgraph with shape (N, N), must have 0 <= source < N and "
+               f"0 <= sink < N. Got {N=}, {source=}, {sink=}.")
+        raise ValueError(msg)
     cdef int has_negative_weights = False
     dist_array = np.full(K, INFINITY, dtype=DTYPE)
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -516,6 +516,13 @@ def test_yen_negative_weights():
     assert_allclose(distances, [-2.])
 
 
+@pytest.mark.parametrize('source, sink', [(0, -1), (10000, 1), (2, 6)])
+def test_yen_source_sink_validation(source, sink):
+    # directed_G has shape (6, 6)
+    with pytest.raises(ValueError, match="must have 0 <="):
+        yen(directed_G, source, sink, 2)
+
+
 @pytest.mark.parametrize("min_only", (True, False))
 @pytest.mark.parametrize("directed", (True, False))
 @pytest.mark.parametrize("return_predecessors", (True, False))


### PR DESCRIPTION
Closes gh-23553.
