### PR TITLE
MAINT: stats: remove '.' in 'mean of empty slice' warning catcher

### DIFF
--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -900,7 +900,7 @@ def test_empty(hypotest, args, kwds, n_samples, n_outputs, paired, unpacker):
                                                                        paired=paired)
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
-                        "ignore", "Mean of empty slice.", RuntimeWarning)
+                        "ignore", "Mean of empty slice", RuntimeWarning)
                     warnings.filterwarnings(
                         "ignore", "invalid value encountered", RuntimeWarning)
                     expected = np.mean(concat, axis=axis) * np.nan

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3552,7 +3552,7 @@ class TestMoments:
         else:
             with warnings.catch_warnings():  # needed by array_api_strict
                 warnings.filterwarnings(
-                    "ignore", "Mean of empty slice.", RuntimeWarning)
+                    "ignore", "Mean of empty slice", RuntimeWarning)
                 warnings.filterwarnings("ignore", "invalid value", RuntimeWarning)
                 test_cases()
 


### PR DESCRIPTION
#### Reference issue
gh-23614
gh-23617

#### What does this implement/fix?
gh-23614 removed a period from some "Mean of empty slice" warning suppression patterns, apparently due to a change in NumPy's warning message. I still saw failures in gh-23617; this should fix those.