### PR TITLE
MAINT: io: Improve `spmatrix` arg handling and description in `io`

### DIFF
--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -305,7 +305,7 @@ def mmread(source, *, spmatrix=True):
         Matrix Market filename (extensions .mtx, .mtz.gz)
         or open file-like object.
     spmatrix : bool, optional (default: True)
-        If ``True``, return sparse ``coo_matrix``. Otherwise return ``coo_array``.
+        If ``True``, return sparse matrix. Otherwise return sparse array.
 
     Returns
     -------

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -467,7 +467,7 @@ def hb_read(path_or_open_file, *, spmatrix=True):
         If a file-like object, it is used as-is. Otherwise, it is opened
         before reading.
     spmatrix : bool, optional (default: True)
-        If ``True``, return sparse ``coo_matrix``. Otherwise return ``coo_array``.
+        If ``True``, return sparse matrix. Otherwise return sparse array.
 
     Returns
     -------

--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -91,7 +91,7 @@ def mmread(source, *, spmatrix=True):
         Matrix Market filename (extensions .mtx, .mtz.gz)
         or open file-like object.
     spmatrix : bool, optional (default: True)
-        If ``True``, return sparse ``coo_matrix``. Otherwise return ``coo_array``.
+        If ``True``, return sparse matrix. Otherwise return sparse array.
 
     Returns
     -------
@@ -571,7 +571,7 @@ class MMFile:
             Matrix Market filename (extensions .mtx, .mtz.gz)
             or open file object.
         spmatrix : bool, optional (default: True)
-            If ``True``, return sparse ``coo_matrix``. Otherwise return ``coo_array``.
+            If ``True``, return sparse matrix. Otherwise return sparse array.
 
         Returns
         -------

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -99,7 +99,8 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=True, **kwargs):
        True to append the .mat extension to the end of the given
        filename, if not already present. Default is True.
     spmatrix : bool, optional (default: True)
-        If ``True``, return sparse ``coo_matrix``. Otherwise return ``coo_array``.
+        If ``True``, return sparse matrix. Otherwise return sparse array.
+        Format is `COO` for MatFile 4 and `CSC` for MatFile 5.
         Only relevant for sparse variables.
     byte_order : str or None, optional
        None by default, implying byte order guessed from mat
@@ -234,10 +235,11 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=True, **kwargs):
         MR, _ = mat_reader_factory(f, **kwargs)
         matfile_dict = MR.get_variables(variable_names)
     if spmatrix:
-        from scipy.sparse import issparse, coo_matrix
+        from scipy.sparse import issparse, coo_matrix, csc_matrix
         for name, var in list(matfile_dict.items()):
             if issparse(var):
-                matfile_dict[name] = coo_matrix(var)
+                fmt_matrix = coo_matrix if var.format == "coo" else csc_matrix
+                matfile_dict[name] = fmt_matrix(var)
 
     if mdict is not None:
         mdict.update(matfile_dict)


### PR DESCRIPTION
Fixes #23594 
Thanks @jornbr

This PR does the following:
- Allow matfile/mio input to convert based on `spmatrix` arg  w/o changing sparse format. Used to convert to COO even when CSC format in the file (MatFile v5).
- Update docs for `spmatrix` arg in for _mio, _mmio, hd, and fast_market_matrix to focus on `spmatrix` vs `sparray` rather than even bringing up the sparse format.
