### PR TITLE
DOC/BUG: signal.firwin: Improve documentation

### DIFF
--- a/doc/source/tutorial/examples/signal_Filtering_firwin2_example.py
+++ b/doc/source/tutorial/examples/signal_Filtering_firwin2_example.py
@@ -1,0 +1,20 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.signal as signal
+
+fs, numtaps = 2, 41  # sampling frequency and number of taps
+freqs = [0.0, 0.3, 0.6, 1.0]  # corner frequencies
+gains = [1.0, 2.0, 0.5, 0.8]  # desired gains at corner frequencies
+
+b = signal.firwin2(numtaps, freqs, gains, fs=fs)  # design filter
+f, H = signal.freqz(b, fs=fs)  # calculate frequency response
+
+fg, ax = plt.subplots(1, 1, tight_layout=True)  # do the plotting
+ax.set(title=f"Frequency Response of {numtaps}-tap Band-pass FIR-Filter",
+       ylabel="Gain", xlim=(0, fs/2),
+       xlabel=rf"Frequency $f\,$ in hertz (sampling frequency $f_S={fs}\,$Hz)")
+ax.plot(freqs,gains, 'ko--', alpha=.5, label="Desired Gains")
+ax.plot(f, np.abs(H), label="Response $|H(f)|$")
+ax.grid()
+ax.legend()
+plt.show()

--- a/doc/source/tutorial/examples/signal_Filtering_firwin2_example.py
+++ b/doc/source/tutorial/examples/signal_Filtering_firwin2_example.py
@@ -9,11 +9,11 @@ gains = [1.0, 2.0, 0.5, 0.8]  # desired gains at corner frequencies
 b = signal.firwin2(numtaps, freqs, gains, fs=fs)  # design filter
 f, H = signal.freqz(b, fs=fs)  # calculate frequency response
 
-fg, ax = plt.subplots(1, 1, tight_layout=True)  # do the plotting
+fg, ax = plt.subplots(1, 1, layout="constrained")  # do the plotting
 ax.set(title=f"Frequency Response of {numtaps}-tap Band-pass FIR-Filter",
        ylabel="Gain", xlim=(0, fs/2),
        xlabel=rf"Frequency $f\,$ in hertz (sampling frequency $f_S={fs}\,$Hz)")
-ax.plot(freqs,gains, 'ko--', alpha=.5, label="Desired Gains")
+ax.plot(freqs, gains, 'ko--', alpha=.5, label="Desired Gains")
 ax.plot(f, np.abs(H), label="Response $|H(f)|$")
 ax.grid()
 ax.legend()

--- a/doc/source/tutorial/examples/signal_Filtering_firwin_example.py
+++ b/doc/source/tutorial/examples/signal_Filtering_firwin_example.py
@@ -1,0 +1,32 @@
+import numpy as np
+import scipy.signal as signal
+import matplotlib.pyplot as plt
+
+fs = 2  # sampling frequency
+n0, f0_c = 40, 0.5  # number of taps and cut-off frequency for H_0(f)
+n1, ff1_c = 41, [0.3, 0.8]  # number of taps and cut-off frequencies for H_1(f)
+
+b0 = signal.firwin(n0, f0_c, fs=fs)  # design FIR filters
+b1 = signal.firwin(n1, ff1_c, fs=fs)
+
+f0, H0 = signal.freqz(b0, fs=fs)  # calculate frequency responses
+f1, H1 = signal.freqz(b1, fs=fs)
+H0_dB, H1_dB = (20 * np.log10(np.abs(H_)) for H_ in (H0, H1))  # convert to dB
+
+# do the plotting:
+fg0, (ax0, ax1) = plt.subplots(2, 1, sharex='all', tight_layout=True, figsize=(6, 4))
+ax0.set(title=f"Frequency Response of {n0}-tap Low-pass FIR-Filter", xlim=(0, fs/2))
+ax0.plot(f0, H0_dB, 'C0', label="Response $|H_0(f)|$")
+ax0.axvline(f0_c, color='C2', linestyle='--', label=rf"$f_0={f0_c}\,$Hz")
+
+ax1.set_title(f"Frequency Response of {n1}-tap Band-stop FIR-Filter")
+ax1.set_xlabel(rf"Frequency $f\,$ in hertz (sampling frequency $f_S={fs}\,$Hz)")
+ax1.plot(f1, H1_dB, 'C0', label="Response $|H_1(f)|$")
+ax1.axvline(ff1_c[0], color='C2', linestyle='--', label=rf"$f_0={ff1_c[0]}\,$Hz")
+ax1.axvline(ff1_c[1], color='C3', linestyle='--', label=rf"$f_1={ff1_c[1]}\,$Hz")
+
+for ax_ in (ax0, ax1):
+    ax_.set_ylabel("Gain in dB")
+    ax_.legend()
+    ax_.grid()
+plt.show()

--- a/doc/source/tutorial/examples/signal_Filtering_firwin_example.py
+++ b/doc/source/tutorial/examples/signal_Filtering_firwin_example.py
@@ -14,7 +14,8 @@ f1, H1 = signal.freqz(b1, fs=fs)
 H0_dB, H1_dB = (20 * np.log10(np.abs(H_)) for H_ in (H0, H1))  # convert to dB
 
 # do the plotting:
-fg0, (ax0, ax1) = plt.subplots(2, 1, sharex='all', tight_layout=True, figsize=(6, 4))
+fg0, (ax0, ax1) = plt.subplots(2, 1, sharex='all', layout="constrained",
+                               figsize=(6, 4))
 ax0.set(title=f"Frequency Response of {n0}-tap Low-pass FIR-Filter", xlim=(0, fs/2))
 ax0.plot(f0, H0_dB, 'C0', label="Response $|H_0(f)|$")
 ax0.axvline(f0_c, color='C2', linestyle='--', label=rf"$f_0={f0_c}\,$Hz")

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -519,64 +519,32 @@ for designing both types of filters.
 FIR Filter
 """"""""""
 
-The function :func:`firwin` designs filters according to the window method.
-Depending on the provided arguments, the function returns different filter
-types (e.g., low-pass, band-pass...).
+The function :func:`firwin` designs filters according to the window method. Depending
+on the provided arguments, the function returns different filter types (e.g., low-pass,
+band-pass...). The following example designs a low-pass and a band-stop filter and
+plots their frequency responses. The low-pass corner frequency of 0.5 Hz and the stop
+band interval of 0.3 Hz to 0.8 Hz are denoted by vertical dashed lines. Since the
+sampling frequency is set to 2 Hz, only the frequency range between 0 Hz and the
+Nyquist frequency of 1 Hz is plotted.
 
-The example below designs a low-pass and a band-stop filter, respectively.
+.. plot:: tutorial/examples/signal_Filtering_firwin_example.py
+    :alt: Example of utilizing `firwin` to design a low-pass and a band-stop filter.
 
-.. plot::
-   :alt: "This code displays an X-Y plot with the amplitude response on the Y axis vs frequency on the X axis. The first (low-pass) trace in blue starts with a pass-band at 0 dB and curves down around halfway through with some ripple in the stop-band about 80 dB down. The second (band-stop) trace in red starts and ends at 0 dB, but the middle third is down about 60 dB from the peak with some ripple where the filter would suppress a signal."
+The function :func:`firwin2` allows design of almost arbitrary frequency responses by
+specifying an array of corner frequencies and corresponding gains, respectively. The
+example below designs a filter with such an arbitrary amplitude response and plots the
+its frequency response on a linear magnitude scale. The four specified gains corner are
+denoted by gray dots connected by a dashed line, whereas the response of the filter is
+depicted by a continuous blue line.
 
-   >>> import numpy as np
-   >>> import scipy.signal as signal
-   >>> import matplotlib.pyplot as plt
+.. plot:: tutorial/examples/signal_Filtering_firwin2_example.py
+    :alt: Example of utilizing `firwin2` to design an arbitrary response filter.
 
-   >>> b1 = signal.firwin(40, 0.5)
-   >>> b2 = signal.firwin(41, [0.3, 0.8])
-   >>> w1, h1 = signal.freqz(b1)
-   >>> w2, h2 = signal.freqz(b2)
+The deviations between the desired gains and the calculated response can be reduced
+by increasing the number of taps.
 
-   >>> plt.title('Digital filter frequency response')
-   >>> plt.plot(w1, 20*np.log10(np.abs(h1)), 'b')
-   >>> plt.plot(w2, 20*np.log10(np.abs(h2)), 'r')
-   >>> plt.ylabel('Amplitude Response (dB)')
-   >>> plt.xlabel('Frequency (rad/sample)')
-   >>> plt.grid()
-   >>> plt.show()
-
-Note that :func:`firwin` uses, per default, a normalized frequency defined such
-that the value :math:`1` corresponds to the Nyquist frequency, whereas the
-function :func:`freqz` is defined such that the value :math:`\pi` corresponds
-to the Nyquist frequency.
-
-
-The function :func:`firwin2` allows design of almost arbitrary frequency
-responses by specifying an array of corner frequencies and corresponding
-gains, respectively.
-
-The example below designs a filter with such an arbitrary amplitude response.
-
-.. plot::
-   :alt: "This code displays an X-Y plot with amplitude response on the Y axis vs frequency on the X axis. A single trace forms a shape similar to a heartbeat signal."
-
-   >>> import numpy as np
-   >>> import scipy.signal as signal
-   >>> import matplotlib.pyplot as plt
-
-   >>> b = signal.firwin2(150, [0.0, 0.3, 0.6, 1.0], [1.0, 2.0, 0.5, 0.0])
-   >>> w, h = signal.freqz(b)
-
-   >>> plt.title('Digital filter frequency response')
-   >>> plt.plot(w, np.abs(h))
-   >>> plt.title('Digital filter frequency response')
-   >>> plt.ylabel('Amplitude Response')
-   >>> plt.xlabel('Frequency (rad/sample)')
-   >>> plt.grid()
-   >>> plt.show()
-
-Note the linear scaling of the y-axis and the different definition of the
-Nyquist frequency in :func:`firwin2` and :func:`freqz` (as explained above).
+Note that the functions :func:`firwin`, :func:`firwin2` and :func:`freqz` use different
+default sampling frequencies.
 
 
 IIR Filter

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -327,7 +327,7 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
 
     See Also
     --------
-    firwin2:  Window method FIR filter design specifying gain-freque.ncy pairs
+    firwin2:  Window method FIR filter design specifying gain-frequency pairs.
     firwin_2d: 2D FIR filter design using the window method.
     firls: FIR filter design using least-squares error minimization.
     minimum_phase: Convert a FIR filter to minimum phase
@@ -348,7 +348,7 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
     >>> f_c, width = 30, 20  # corner frequency (-6 dB gain)
     >>> taps = [20, 40, 60]  # number of taps
     ...
-    >>> fg, (ax0, ax1) = plt.subplots(2, 1, sharex='all', tight_layout=True,
+    >>> fg, (ax0, ax1) = plt.subplots(2, 1, sharex='all', layout="constrained",
     ...                               figsize=(5, 4))
     >>> ax0.set_title(rf"Response of ${f_c}\,$Hz low-pass Filter with " +
     ...               rf"${width}\,$Hz transition region")
@@ -388,7 +388,7 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
     >>> n, f_c = 40, 30  # number of taps and corner frequency (-6 dB gain)
     >>> widths = (2, 10, 25)  # width of transition region
     ...
-    >>> fg, ax = plt.subplots(1, 1, tight_layout=True)
+    >>> fg, ax = plt.subplots(1, 1, layout="constrained",)
     >>> ax.set(title=rf"Response of {n}-tap ${f_c}\,$Hz low-pass Filter",
     ...        xlabel=rf"Frequency $f\,$ in hertz (sampling frequency $f_S={fs}\,$Hz)",
     ...        ylabel="Gain in dB", xlim=(0, fs/2))
@@ -421,7 +421,7 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
     >>> cutoff = [40, 60]  # corner frequencies (-6 dB gain)
     >>> windows = ('boxcar', 'hamming', 'hann', 'blackman')
     ...
-    >>> fg, ax = plt.subplots(1, 1, tight_layout=True)  # set up plotting
+    >>> fg, ax = plt.subplots(1, 1, layout="constrained")  # set up plotting
     >>> ax.set(title=rf"Response of {n}-tap Filter with ${cutoff}\,$Hz passband",
     ...        xlabel=rf"Frequency $f\,$ in hertz (sampling frequency $f_S={fs}\,$Hz)",
     ...        ylabel="Gain in dB", xlim=(0, fs/2))
@@ -453,7 +453,7 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
     >>> import scipy.signal as signal
     ...
     >>> cutoffs = [0.5, (.25, .75)]  # cutoff parameters
-    >>> fg, axx = plt.subplots(4, 1, sharex='all', tight_layout=True,
+    >>> fg, axx = plt.subplots(4, 1, sharex='all', layout="constrained",
     ...                        figsize=(5, 4))
     >>> for ax, (cutoff, pass_zero) in zip(axx, product(cutoffs, (True, False))):
     ...     ax.set(title=f"firwin(41, {cutoff=}, {pass_zero=}, fs=2)", ylabel="Gain")

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -252,8 +252,7 @@ def kaiserord(ripple, width):
 
 def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
            scale=True, fs=None):
-    """
-    FIR filter design using the window method.
+    r"""FIR filter design using the window method.
 
     This function computes the coefficients of a finite impulse response
     filter. The filter will have linear phase; it will be Type I if
@@ -266,21 +265,21 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
     Parameters
     ----------
     numtaps : int
-        Length of the filter (number of coefficients, i.e. the filter
+        Length of the filter (number of coefficients, i.e., the filter
         order + 1).  `numtaps` must be odd if a passband includes the
         Nyquist frequency.
     cutoff : float or 1-D array_like
         Cutoff frequency of filter (expressed in the same units as `fs`)
-        OR an array of cutoff frequencies (that is, band edges). In the
+        or an array of cutoff frequencies (that is, band edges). In the
         former case, as a float, the cutoff frequency should correspond
-        with the half-amplitude point, where the attenuation will be -6dB.
+        with the half-amplitude point, where the attenuation will be -6 dB.
         In the latter case, the frequencies in `cutoff` should be positive
         and monotonically increasing between 0 and `fs/2`. The values 0
         and `fs/2` must not be included in `cutoff`. It should be noted
-        that this is different from the behavior of `scipy.signal.iirdesign`,
-        where the cutoff is the half-power point (-3dB).
+        that this is different from the behavior of `~scipy.signal.iirdesign`,
+        where the cutoff is the half-power point (-3 dB).
     width : float or None, optional
-        If `width` is not None, then assume it is the approximate width
+        If `width` is not ``None``, then assume it is the approximate width
         of the transition region (expressed in the same units as `fs`)
         for use in Kaiser FIR filter design. In this case, the `window`
         argument is ignored.
@@ -290,22 +289,22 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
         ``'hamming_perodic'``) Consult `~scipy.signal.get_window` for a list of windows
         and required parameters.
     pass_zero : {True, False, 'bandpass', 'lowpass', 'highpass', 'bandstop'}, optional
-        If True, the gain at the frequency 0 (i.e., the "DC gain") is 1.
-        If False, the DC gain is 0. Can also be a string argument for the
-        desired filter type (equivalent to ``btype`` in IIR design functions).
+        Toggles the zero frequency bin (or DC gain) to be in the passband (``True``) or
+        in the stopband (``False``).  ``'bandstop'``, ``'lowpass'`` are synonyms for
+        ``True`` and ``'bandpass'``, ``'highpass'`` are synonyms for ``False``.
+        ``'lowpass'``, ``'highpass'`` additionally require `cutoff` to be a scalar
+        value or a length-one array. Default: ``True``.
 
         .. versionadded:: 1.3.0
            Support for string arguments.
     scale : bool, optional
-        Set to True to scale the coefficients so that the frequency
-        response is exactly unity at a certain frequency.
-        That frequency is either:
+        Set to ``True`` to scale the coefficients so that the frequency response is
+        exactly unity at a certain frequency. That frequency is either:
 
-        - 0 (DC) if the first passband starts at 0 (i.e. pass_zero
-          is True)
-        - `fs/2` (the Nyquist frequency) if the first passband ends at
-          `fs/2` (i.e the filter is a single band highpass filter);
-          center of first passband otherwise
+        - 0 (DC) if the first passband starts at 0 (i.e., `pass_zero` is ``True``)
+        - `fs/2` (the Nyquist frequency) if the first passband ends at `fs/2`
+          (i.e., the filter is a single band highpass filter); center of first
+          passband otherwise
 
     fs : float, optional
         The sampling frequency of the signal. Each frequency in `cutoff`
@@ -313,8 +312,8 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
 
     Returns
     -------
-    h : (numtaps,) ndarray
-        Coefficients of length `numtaps` FIR filter.
+    h : ndarray
+        FIR filter coefficients as 1d array with `numtaps` entries.
 
     Raises
     ------
@@ -334,46 +333,138 @@ def firwin(numtaps, cutoff, *, width=None, window='hamming', pass_zero=True,
 
     Examples
     --------
-    Low-pass from 0 to f:
+    The following example calculates frequency responses of a 30 Hz low-pass filter
+    with various numbers of taps. The transition region width is 20 Hz. The upper plot
+    shows the gain and the lower plot the phase. The vertical dashed line marks the
+    corner frequency and the gray background the transition region.
 
-    >>> from scipy import signal
-    >>> numtaps = 3
-    >>> f = 0.1
-    >>> signal.firwin(numtaps, f)
-    array([ 0.06799017,  0.86401967,  0.06799017])
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> import scipy.signal as signal
+    ...
+    >>> fs = 200  # sampling frequency and number of taps
+    >>> f_c, width = 30, 20  # corner frequency (-6 dB gain)
+    >>> taps = [20, 40, 60]  # number of taps
+    ...
+    >>> fg, (ax0, ax1) = plt.subplots(2, 1, sharex='all', tight_layout=True,
+    ...                               figsize=(5, 4))
+    >>> ax0.set_title(rf"Response of ${f_c}\,$Hz low-pass Filter")
+    >>> ax0.set(ylabel="Gain in dB", xlim=(0, fs/2))
+    >>> ax1.set(xlabel=rf"Frequency $f\,$ in hertz (sampling frequency $f_S={fs}\,$Hz)",
+    ...         ylabel="Phase in Degrees")
+    ...
+    >>> for n in taps:  # calculate filter and plot response:
+    ...     bb = signal.firwin(n, f_c, width=width, fs=fs)
+    ...     f, H = signal.freqz(bb, fs=fs)  # calculate frequency response
+    ...     H_dB, H_ph = 20 * np.log10(abs(H)), np.rad2deg(np.unwrap(np.angle(H)))
+    ...     H_ph[H_dB<-150] = np.nan
+    ...     ax0.plot(f, H_dB, alpha=.5, label=rf"{n} taps")
+    ...     ax1.plot(f, H_ph, alpha=.5, label=rf"{n} taps")
+    >>> for ax_ in (ax0, ax1):
+    ...     ax_.axvspan(f_c-width/2, f_c+width/2,color='gray', alpha=.25)
+    ...     ax_.axvline(f_c, color='gray', linestyle='--', alpha=.5)
+    ...     ax_.grid()
+    ...     ax_.legend()
+    >>> plt.show()
 
-    Use a specific window function:
+    The plots show that with increasing number of taps, the suppression in the stopband
+    increases and the (negative) slope of the phase steepens, which signifies a longer
+    signal delay in the filter. Note that the plots contain numeric artifacts caused by
+    the limited frequency resolution: The phase jumps are not real---in reality the
+    phase is a straight line with a constant negative slope. Furthermore, the gains
+    contain zero values (i.e., :math:`-\infty` dB), which are also not depicted.
 
-    >>> signal.firwin(numtaps, f, window='nuttall')
-    array([  3.56607041e-04,   9.99286786e-01,   3.56607041e-04])
+    The second example determines the frequency responses of a 30 Hz low-pass filter
+    with 40 taps. This time the width of the transition region varies:
 
-    High-pass ('stop' from 0 to f):
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> import scipy.signal as signal
+    ...
+    >>> fs = 200  # sampling frequency and number of taps
+    >>> n, f_c = 40, 30  # number of taps and corner frequency (-6 dB gain)
+    >>> widths = (2, 10, 25)  # width of transition region
+    ...
+    >>> fg, ax = plt.subplots(1, 1, tight_layout=True)
+    >>> ax.set(title=rf"Response of {n}-tap ${f_c}\,$Hz low-pass Filter",
+    ...        xlabel=rf"Frequency $f\,$ in hertz (sampling frequency $f_S={fs}\,$Hz)",
+    ...        ylabel="Gain in dB", xlim=(0, fs/2))
+    >>> ax.axvline(f_c, color='gray', linestyle='--', alpha=.7)  # mark corner frequency
+    ...
+    >>> for width in widths:  # calculate filter and plot response:
+    ...     bb = signal.firwin(n, f_c, width=width, fs=fs)
+    ...     f, H = signal.freqz(bb, fs=fs)  # calculate frequency response
+    ...     H_dB= 20 * np.log10(abs(H))  # convert todB
+    ...     ax.plot(f, H_dB, alpha=.5, label=rf"width$={width}\,$Hz")
+    ...
+    >>> ax.grid()
+    >>> ax.legend()
+    >>> plt.show()
 
-    >>> signal.firwin(numtaps, f, pass_zero=False)
-    array([-0.00859313,  0.98281375, -0.00859313])
+    It can be seen in the plot above that with increasing width of the transition
+    region the suppression in the stopband increases. Since the phase does not vary, it
+    is not depicted.
 
-    Band-pass:
+    Instead of defining a transition region width, a window function can also be
+    specified. The plot below depicts the response of an 80 tap band-pass filter having
+    a passband ranging form 40 Hz to 60 Hz (denoted by a gray background) with
+    different windows:
 
-    >>> f1, f2 = 0.1, 0.2
-    >>> signal.firwin(numtaps, [f1, f2], pass_zero=False)
-    array([ 0.06301614,  0.88770441,  0.06301614])
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> import scipy.signal as signal
+    ...
+    >>> fs, n = 200, 80  # sampling frequency and number of taps
+    >>> cutoff = [40, 60]  # corner frequencies (-6 dB gain)
+    >>> windows = ('boxcar', 'hamming', 'hann', 'blackman')
+    ...
+    >>> fg, ax = plt.subplots(1, 1, tight_layout=True)  # set up plotting
+    >>> ax.set(title=rf"Response of {n}-tap Filter with ${cutoff}\,$Hz passband",
+    ...        xlabel=rf"Frequency $f\,$ in hertz (sampling frequency $f_S={fs}\,$Hz)",
+    ...        ylabel="Gain in dB", xlim=(0, fs/2))
+    >>> ax.axvspan(*cutoff, color='gray', alpha=.25)  # mark passband
+    ...
+    >>> for win in windows:  # calculate filter and plot response:
+    ...     bb = signal.firwin(n, cutoff, window=win, pass_zero=False, fs=fs)
+    ...     f, H = signal.freqz(bb, fs=fs)  # calculate frequency response
+    ...     H_dB = 20 * np.log10(abs(H))  # convert to dB
+    ...     ax.plot(f, H_dB, alpha=.5, label=win)
+    ...
+    >>> ax.grid()
+    >>> ax.legend()
+    >>> plt.show()
 
-    Band-stop:
+    The plot shows that the choice of window mainly influences the balance of the
+    suppression in the stopband against the width of the transition region. Note that
+    utilizing the `~scipy.signal.windows.boxcar` window corresponds to just truncating
+    the ideal infinite impulse response to the length of `numtaps` samples.
 
-    >>> signal.firwin(numtaps, [f1, f2])
-    array([-0.00801395,  1.0160279 , -0.00801395])
+    The last example illustrates  how to use the `cutoff` and `pass_zero` parameters to
+    create a low-pass, a high-pass, a band-stop and a band-pass filter. The desired
+    ideal frequency gain is drawn as a gray dashed line whereas the response of the FIR
+    filter is depicted as a blue continuous line:
 
-    Multi-band (passbands are [0, f1], [f2, f3] and [f4, 1]):
-
-    >>> f3, f4 = 0.3, 0.4
-    >>> signal.firwin(numtaps, [f1, f2, f3, f4])
-    array([-0.01376344,  1.02752689, -0.01376344])
-
-    Multi-band (passbands are [f1, f2] and [f3,f4]):
-
-    >>> signal.firwin(numtaps, [f1, f2, f3, f4], pass_zero=False)
-    array([ 0.04890915,  0.91284326,  0.04890915])
-
+    >>> from itertools import product
+    >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> import scipy.signal as signal
+    ...
+    >>> cutoffs = [0.5, (.25, .75)]  # cutoff parameters
+    >>> fg, axx = plt.subplots(4, 1, sharex='all', tight_layout=True,
+    ...                        figsize=(5, 4))
+    >>> for ax, (cutoff, pass_zero) in zip(axx, product(cutoffs, (True, False))):
+    ...     ax.set(title=f"firwin(41, {cutoff=}, {pass_zero=}, fs=2)", ylabel="Gain")
+    ...
+    ...     bb = signal.firwin(41, cutoff, pass_zero=pass_zero, fs=2)
+    ...     ff, HH = signal.freqz(bb, fs=2)
+    ...     ax.plot(ff, abs(HH), 'C0-', label="FIR Response")
+    ...
+    ...     f_d = np.hstack(([0], np.atleast_1d(cutoff), [1]))
+    ...     H_d = np.tile([1, 0] if pass_zero else [0, 1], 3)[:len(f_d)]
+    ...     ax.step(f_d, H_d, 'k--', where='post', alpha=.3, label="Desired Response")
+    >>> axx[-1].set(xlabel=r"Frequency $f\,$ in hertz (sampling frequency $f_S=2\,$Hz)",
+    ...             xlim=(0, 1))
+    >>> plt.show()
     """
     # NB: scipy's version of array_namespace returns `np_compat` for int or floats
     xp = array_namespace(cutoff)


### PR DESCRIPTION
* Clarify behavior of `pass_zero` parameter. Closes #19291.
* Make example section more useful by adding examples with plots which illustrate the behavior of the significant parameters.
* Improve `firwin` and `firwin2` plots in `signal.rst`.

[docs only]
