### PR TITLE
BUG: stats.levy_stable.logpdf: fix incorrect values for `beta == +-1`

### DIFF
--- a/scipy/stats/_levy_stable/__init__.py
+++ b/scipy/stats/_levy_stable/__init__.py
@@ -214,10 +214,40 @@ def _pdf_single_value_piecewise_Z0(x0, alpha, beta, **kwds):
     elif alpha == 1.0 and beta == 0.0:
         # cauchy
         return 1 / (1 + x0 ** 2) / np.pi
+    elif 1 < alpha < 2:
+        in_tail_region = (beta == 1.0 and x0 < 0.0) or (beta == -1.0 and x0 > 0.0)
+        if in_tail_region:
+            result = _levy_stable_tail_asymptotic(x0, alpha, beta)
+            if result is not None:
+                return result
 
     return _pdf_single_value_piecewise_post_rounding_Z0(
         x0, alpha, beta, quad_eps, x_tol_near_zeta
     )
+
+def _levy_stable_tail_asymptotic(x0, alpha, beta, cutoff_exponent=8.0):
+    """
+    Handle tail asymptotic for beta=-1 (right-tail) or beta=1 (left-tail), 1<alpha<=2.
+    Returns None if not in asymptotic region.
+    Nolan (Proposition 3.1).
+    """
+    if not (1.0 < alpha < 2.0) or beta not in (-1.0, 1.0):
+        return None
+    x0 += beta * np.tan(np.pi * alpha / 2)
+    if beta == 1:
+        x0 = -x0
+    # Constants (same for both tails)
+    p = alpha / (alpha - 1)
+    a = (2.0 - alpha) / (2.0 * alpha - 2.0)
+    cosa = np.cos(np.pi * alpha / 2)
+    c2 = np.abs(1 - alpha) * (alpha**alpha / np.abs(cosa)) ** (1 / (1 - alpha))
+    c1 = (alpha / abs(cosa)) ** (1 / (2 - 2 * alpha))
+    c1 /= (2 * np.pi * np.abs(1 - alpha)) ** 0.5
+
+    if c2 * x0**p >= cutoff_exponent:
+        # far enough in the tail
+        return c1 * x0**a * np.exp(-c2 * (x0**p))
+    return None
 
 
 def _pdf_single_value_piecewise_post_rounding_Z0(x0, alpha, beta, quad_eps,

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6127,6 +6127,23 @@ class TestLevyStable:
                     verbose=False
                 )
 
+    @pytest.mark.parametrize(
+        "param, alpha, beta, xs, expected",
+        [
+            (0, 1.6, 1.0, [-15.0, -14.0, -13.0], [-187.14442, -157.14116, -130.35267]),
+            (1, 1.6, 1.0, [-15.0, -14.0, -13.0], [-165.02031, -137.36717, -112.82235]),
+            (0, 1.4, -1.0, [13.0, 14.0, 15.0], [-367.19433, -464.70496, -579.43993]),
+            (1, 1.4, -1.0, [13.0, 14.0, 15.0], [-258.12165, -334.61399, -426.07241]),
+        ],
+    )
+    def test_logpdf_tail(self, param, alpha, beta, xs, expected):
+        # gh-20636
+        # Test levy_stable.logpdf accuracy in the tails when beta=1 or beta=-1
+        # for both S0/S1 parameterizations.
+        stats.levy_stable.parameterization = f"S{param}"
+        logpdfs = stats.levy_stable(alpha=alpha, beta=beta).logpdf(xs)
+        assert_allclose(logpdfs, expected, rtol=1e-5)
+
     @pytest.mark.parametrize("param", [0, 1])
     @pytest.mark.parametrize("case", ["pdf", "cdf"])
     def test_location_scale(

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6130,16 +6130,42 @@ class TestLevyStable:
     @pytest.mark.parametrize(
         "param, alpha, beta, xs, expected",
         [
-            (0, 1.6, 1.0, [-15.0, -14.0, -13.0], [-187.14442, -157.14116, -130.35267]),
-            (1, 1.6, 1.0, [-15.0, -14.0, -13.0], [-165.02031, -137.36717, -112.82235]),
-            (0, 1.4, -1.0, [13.0, 14.0, 15.0], [-367.19433, -464.70496, -579.43993]),
-            (1, 1.4, -1.0, [13.0, 14.0, 15.0], [-258.12165, -334.61399, -426.07241]),
+            (
+                0,
+                1.6,
+                1.0,
+                [-15.0, -14.0, -13.0],
+                [-187.1444263, -157.1411663, -130.3526688],
+            ),
+            (
+                1,
+                1.6,
+                1.0,
+                [-15.0, -14.0, -13.0],
+                [-165.0203129, -137.3671717, -112.8223545],
+            ),
+            (
+                0,
+                1.4,
+                -1.0,
+                [13.0, 14.0, 15.0],
+                [-367.1943293, -464.7049565, -579.4399286],
+            ),
+            (
+                1,
+                1.4,
+                -1.0,
+                [13.0, 14.0, 15.0],
+                [-258.1216497, -334.6139857, -426.0724094],
+            ),
         ],
     )
     def test_logpdf_tail(self, param, alpha, beta, xs, expected):
         # gh-20636
+        # Expected values computed from Mathematica.
         # Test levy_stable.logpdf accuracy in the tails when beta=1 or beta=-1
         # for both S0/S1 parameterizations.
+        # Testing logpdf instead of pdf as more compact.
         stats.levy_stable.parameterization = f"S{param}"
         logpdfs = stats.levy_stable(alpha=alpha, beta=beta).logpdf(xs)
         assert_allclose(logpdfs, expected, rtol=1e-5)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #20636

#### What does this implement/fix?
Fix tail asymptotics of logpdf for beta=-1 and beta=1

#### Comments
Expected values in the test were computed via Mathematica.

#### Reproducible example

```python
from scipy.stats import levy_stable
import numpy as np
from matplotlib import pyplot as plt

loc = 0.0
scale = 1.0
(alpha, beta) = (1.6, 1.0)

xs = np.linspace(-15, 0.0, 30)
if beta==-1.0:
    xs *= -1.0

levy_stable.parameterization = "S1"
log_pdf_S1_scipy = levy_stable(alpha, beta, loc=loc, scale=scale).logpdf(xs)

levy_stable.parameterization = "S0"
log_pdf_S0_scipy = levy_stable(alpha, beta, loc=loc, scale=scale).logpdf(xs)

if beta==1.0:
    log_pdf_S1_scipy_old = np.array([
        -68.43963144, -65.49096863, -62.71821277, -60.11736153, -57.68437972,
        -55.41519974, -53.30572237, -51.35181816, -49.54932953, -47.89407275,
        -46.38124626, -44.83221836, -40.12078201, -34.24971308, -28.93942999,
        -24.19115239, -19.98008686, -16.28066725, -13.06671442, -10.31138392,
        -7.98710404,  -6.06550641,  -4.51734947,  -3.31243690,  -2.41953621,
        -1.80630926,  -1.43927776,  -1.28386664,  -1.30459730,  -1.46553721
    ])
    log_pdf_S0_scipy_old = np.array([
        -72.88614827, -69.68370175, -66.66272843, -63.81927226, -61.14934422,
        -58.64892238, -56.31395218, -54.14034706, -52.12398962, -50.26073333,
        -48.54640519, -46.97675954, -45.52808222, -42.51307119, -36.56274208,
        -31.01919155, -26.04640635, -21.62100479, -17.71766602, -14.31046429,
        -11.37283140,  -8.87749786,  -6.79642653,  -5.10073879,  -3.76063464,
        -2.74531030,  -2.02288185,  -1.56033279,  -1.32351906,  -1.27729076
    ])
elif beta==-1.0:
    log_pdf_S1_scipy_old = np.array([
    -1.46553721,  -1.30459730,  -1.28386664,  -1.43927776,  -1.80630926,
    -2.41953621,  -3.31243690,  -4.51734947,  -6.06550641,  -7.98710404,
    -10.31365396, -13.06849249, -16.28208745, -19.98124042, -24.19210317,
    -28.94022648, -34.25060526, -40.14771929, -46.65557006, -53.79771366,
    -61.59729036, -70.07705122, -79.25938194, -89.16632454, -99.81959686,
    -111.24061039,-123.45048640,-136.47007079,-150.31994763,-165.02045163
    ])

    log_pdf_S0_scipy_old = np.array([
    -1.27729076,  -1.32351906,  -1.56033279,  -2.02288185,  -2.74531030,
    -3.76063464,  -5.10073879,  -6.79642653,  -8.88015138, -11.37488254,
    -14.31208425, -17.71896915, -21.62206978, -26.04728904, -31.01994759,
    -36.56482720, -42.70620992, -49.46791323, -56.87332158, -64.94541470,
    -73.70679307, -83.17970083, -93.38604658,-104.34742215,-116.08511970,
    -128.62014739,-141.97324360,-156.16489004,-171.21532384,-187.14454860
    ])
else:
    raise ValueError("beta must be -1.0 or 1.0 to compare with old results")

fig, ax = plt.subplots()
ax.plot(xs, log_pdf_S1_scipy, label="scipy corrected S1")
ax.plot(xs, log_pdf_S0_scipy, label="scipy corrected S0")
ax.plot(xs, log_pdf_S1_scipy_old, "r--", label="scipy S1")
ax.plot(xs, log_pdf_S0_scipy_old, "g--", label="scipy S0")
ax.legend()
ax.set_title(f"alpha={alpha}, beta={beta}")
plt.show()
```
<img width="640" height="480" alt="Figure_1" src="https://github.com/user-attachments/assets/d5e9c5c8-06c0-4888-84f5-3e5b2c161f1c" />
<img width="640" height="480" alt="beta_1_levy_log_pdf" src="https://github.com/user-attachments/assets/976df000-85d8-49d2-888f-b81acf35339e" />

