### PR TITLE
maint: :sparse: name loadnpz test tmpdir in a way to avoid unsafe thread

### DIFF
--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -80,7 +80,8 @@ def test_nd_coo_format(ndim, value, tmpdir):
 
     #save/load array
     with tmpdir.as_cwd():
-        tmpfile = "f.npz"
+        # make name depend on parameters to keep threadsafe
+        tmpfile = f"value{value}{ndim}f.npz"
 
         save_npz(tmpfile, A)
         loaded_A = load_npz(tmpfile)


### PR DESCRIPTION
This is a small followup to #23465 which changes a test to avoid failures in freethreading (1) tests.

The test uses the `tmpdir` fixture with a fixed `tmpfile` name. But the function is parametrized so multiple copies of that tmpfile are being used at the same time. It doesn't always raise, but it occasionally leads to failure in the freethreading CI.

This PR makes the name of the file include the parameter values so `tmpfile` differs between tests hopefully eliminating the threading issue.  I'm open to other solutions.