### PR TITLE
DEV: drop `shallow` from submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,11 +4,9 @@
 [submodule "scipy/sparse/linalg/_propack/PROPACK"]
 	path = scipy/sparse/linalg/_propack/PROPACK
 	url = https://github.com/scipy/PROPACK.git
-	shallow = true
 [submodule "scipy/_lib/unuran"]
 	path = scipy/_lib/unuran
 	url = https://github.com/scipy/unuran.git
-	shallow = true
 [submodule "scipy/_lib/array_api_compat"]
 	path = scipy/_lib/array_api_compat
 	url = https://github.com/data-apis/array-api-compat.git
@@ -27,12 +25,10 @@
 [submodule "subprojects/highs"]
 	path = subprojects/highs
 	url = https://github.com/scipy/HiGHs
-	shallow = true
 
 [submodule "subprojects/boost_math/math"]
 	path = subprojects/boost_math/math
 	url = https://github.com/boostorg/math.git
-	shallow = true
 
 [submodule "subprojects/xsf"]
 	path = subprojects/xsf


### PR DESCRIPTION
@rgommers I know we might not want to merge this, but I'm persistently hitting errors like

```
fatal: transport 'file' not allowed
fatal: Fetched in submodule path 'math', but it did not contain 5e088ffe2ed0e237b9069e3a7352865283d8f196. Direct fetching of that commit failed.
```

Is there a better way around it than this?
