### PR TITLE
DOC: ndimage: fix example of 'wrap' mode for interpolation functions

### DIFF
--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -109,7 +109,7 @@ _mode_interp_constant_doc = (
     'grid-wrap' (`a b c d | a b c d | a b c d`)
         The input is extended by wrapping around to the opposite edge.
 
-    'wrap' (`d b c d | a b c d | b c a b`)
+    'wrap' (`c d b c | a b c d | b c a b`)
         The input is extended by wrapping around to the opposite edge, but in a
         way such that the last point and initial point exactly overlap. In this
         case it is not well defined which sample will be chosen at the point of

--- a/scipy/ndimage/_ni_docstrings.py
+++ b/scipy/ndimage/_ni_docstrings.py
@@ -109,11 +109,17 @@ _mode_interp_constant_doc = (
     'grid-wrap' (`a b c d | a b c d | a b c d`)
         The input is extended by wrapping around to the opposite edge.
 
-    'wrap' (`c d b c | a b c d | b c a b`)
+    'wrap' (`b c d b c | a b c d | b c a b c`)
         The input is extended by wrapping around to the opposite edge, but in a
         way such that the last point and initial point exactly overlap. In this
         case it is not well defined which sample will be chosen at the point of
-        overlap.""")
+        overlap.
+
+
+        For the example illustrated above, the edge values ``a`` and ``d`` overlap,
+        while the inner pattern ``b c`` repeats. The example demonstrates one
+        possible output, while ``b c a b c | a b c d | b c d b c`` is another,
+        since either ``a`` or ``d`` may occur at each point of overlap.""")
 _mode_interp_mirror_doc = (
     _mode_interp_constant_doc.replace("Default is 'constant'",
                                       "Default is 'mirror'")


### PR DESCRIPTION
[docs only]

The current docstring description of `mode='wrap'` for the functions in `scipy/ndimage/_interpolation.py` is wrong, as illustrated by the following snippet:

```py3
>>> import numpy as np, scipy.ndimage
>>> scipy.ndimage.affine_transform(
...     np.array([0, 1, 2, 3]),  # length 4, same as the original example
...     np.eye(1),  # no rotation or scaling
...     offset=-4,  # show 4 entries to the left
...     output_shape=(12,),  # also show 4 entries to the right
...     mode='wrap')
array([2, 3, 1, 2, 0, 1, 2, 3, 1, 2, 0, 1])
```

The text itself is fine; the problem is just with the little example on the array `a b c d`. It might be clearer to show more repetitions:

```
d b c d b c d b c | a b c d | b c a b c a b c a
```

Or a single repetition of length 3, like with `mode='mirror'`:

```
d b c | a b c d | b c a
```

But I chose to just correct the typo with the smallest possible change.

(It would also be simpler to see what's going on if the _left_ repetitions used `a` instead of `d` and the _right_ repetitions used `d` instead of `a`, but that would require a code change, or leaning hard on the warning that "it is not well defined which sample will be chosen at the point of overlap":
```
a b c a b c a b c | a b c d | b c d b c d b c d
```
)