### PR TITLE
TST: stats: test against `marray` backend again

### DIFF
--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -19,10 +19,6 @@ pytestmark = [
             " is hidden behind SCIPY_ARRAY_API flag."
         ),
     ),
-    pytest.mark.skip_xp_backends(
-        "array_api_strict",
-        reason="scipy/#23412",
-    ),
 ]
 
 skip_backend = pytest.mark.skip_xp_backends

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -108,8 +108,7 @@ class TestQuantile:
     @skip_xp_backends(cpu_only=True, reason="PyTorch doesn't have `betainc`.")
     @pytest.mark.parametrize('axis', [0, 1])
     @pytest.mark.parametrize('keepdims', [False, True])
-    # Test with `marray` again when `asarray` supports `device`
-    @pytest.mark.parametrize('nan_policy', ['omit', 'propagate'])  # 'marray'
+    @pytest.mark.parametrize('nan_policy', ['omit', 'propagate', 'marray'])
     @pytest.mark.parametrize('dtype', ['float32', 'float64'])
     @pytest.mark.parametrize('method', ['linear', 'harrell-davis'])
     def test_against_reference(self, axis, keepdims, nan_policy, dtype, method, xp):


### PR DESCRIPTION
#### Reference issue
Closes gh-23412

#### What does this implement/fix?
Re-activates tests with `marray` backend.