### PR TITLE
CI: fix issue with spin broken due to new click release (follow-up)

### DIFF
--- a/.github/workflows/linux_intel_oneAPI.yml
+++ b/.github/workflows/linux_intel_oneAPI.yml
@@ -87,7 +87,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate scipy-dev
-          conda install -c conda-forge pkg-config meson meson-python ninja numpy cython pybind11 pytest pytest-xdist pytest-timeout pooch hypothesis spin
+          conda install -c conda-forge pkg-config meson meson-python ninja numpy cython pybind11 pytest pytest-xdist pytest-timeout pooch hypothesis spin "click<8.3.0"
 
       - name: Initialise Intel oneAPI and Build SciPy
         shell: bash -l {0}

--- a/.github/workflows/windows_intel_oneAPI.yml
+++ b/.github/workflows/windows_intel_oneAPI.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install packages from conda
         shell: cmd /C call {0}
         run: |
-          conda install -c conda-forge pkg-config meson meson-python ninja openblas libblas=*=*openblas numpy==2.0 cython pybind11 pytest pytest-xdist pytest-timeout pooch spin hypothesis
+          conda install -c conda-forge pkg-config meson meson-python ninja openblas libblas=*=*openblas numpy==2.0 cython pybind11 pytest pytest-xdist pytest-timeout pooch spin hypothesis "click<8.3.0"
 
       # MSVC is unable to compile Pythran code, therefore we need to use
       # -C-Duse-pythran=false while building SciPy.

--- a/environment.yml
+++ b/environment.yml
@@ -57,6 +57,7 @@ dependencies:
   - threadpoolctl
   # For CLI
   - spin
+  - click<8.3.0  # transitive dependency of `spin`, 8.3.0 is breaking (see gh-23642)
   # For linting
   - ruff>=0.12.0
   - cython-lint


### PR DESCRIPTION
This fixes the conda-based CI jobs, which were not yet failing when the initial fix went in.

Closes gh-23642