### PR TITLE
ENH: signal: Convert Savitzky-Golay filter to Array API

### DIFF
--- a/scipy/signal/_polyutils.py
+++ b/scipy/signal/_polyutils.py
@@ -178,7 +178,7 @@ def polyfit(x, y, deg, *, xp, rcond=None):
     s = xpx.apply_where(sing_val_mask, (s,), lambda x: 1. / x, fill_value=0.)
 
     sigma = xp.eye(s.shape[0]) * s    # == np.diag(s)
-    c = vt.mT @ sigma @ u.mT @ y
+    c = vt.T @ sigma @ u.T @ y
     c = (c.T / scale).T  # broadcast scale coefficients
 
     # warn on rank reduction, which indicates an ill conditioned matrix

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -147,7 +147,7 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     y = xpx.at(y, deriv).set(float_factorial(deriv) / (delta ** deriv))
 
     # Find the least-squares solution of A*c = y
-    coeffs = xp.linalg.pinv(A) @ y
+    coeffs, _, _, _ = _pu._lstsq(A, y, xp=xp)
 
     return coeffs
 

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -1,12 +1,15 @@
-import numpy as np
-from scipy.linalg import lstsq
 from scipy._lib._util import float_factorial
+from scipy._lib.array_api_compat import numpy as np_compat
+from scipy._lib._array_api import array_namespace, xp_swapaxes, xp_device
+import scipy._lib.array_api_extra as xpx
+
 from scipy.ndimage import convolve1d  # type: ignore[attr-defined]
+from scipy.signal import _polyutils as _pu
 from ._arraytools import axis_slice
 
 
 def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
-                  use="conv"):
+                  use="conv", xp=None, device=None):
     """Compute the coefficients for a 1-D Savitzky-Golay FIR filter.
 
     Parameters
@@ -115,36 +118,41 @@ def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
     if use not in ['conv', 'dot']:
         raise ValueError("`use` must be 'conv' or 'dot'")
 
+    # cf windows/_windows.py
+    xp = np_compat if xp is None else array_namespace(xp.empty(0))
+
     if deriv > polyorder:
-        coeffs = np.zeros(window_length)
+        coeffs = xp.zeros(window_length, dtype=xp.float64, device=device)
         return coeffs
 
     # Form the design matrix A. The columns of A are powers of the integers
     # from -pos to window_length - pos - 1. The powers (i.e., rows) range
     # from 0 to polyorder. (That is, A is a vandermonde matrix, but not
     # necessarily square.)
-    x = np.arange(-pos, window_length - pos, dtype=float)
+    x = xp.arange(-pos, window_length - pos, dtype=xp.float64, device=device)
 
     if use == "conv":
         # Reverse so that result can be used in a convolution.
-        x = x[::-1]
+        x = xp.flip(x)
 
-    order = np.arange(polyorder + 1).reshape(-1, 1)
+    order = xp.reshape(
+        xp.arange(polyorder + 1, dtype=xp.float64, device=device), (-1, 1)
+    )
     A = x ** order
 
     # y determines which order derivative is returned.
-    y = np.zeros(polyorder + 1)
+    y = xp.zeros(polyorder + 1, dtype=xp.float64, device=device)
     # The coefficient assigned to y[deriv] scales the result to take into
     # account the order of the derivative and the sample spacing.
-    y[deriv] = float_factorial(deriv) / (delta ** deriv)
+    y = xpx.at(y, deriv).set(float_factorial(deriv) / (delta ** deriv))
 
     # Find the least-squares solution of A*c = y
-    coeffs, _, _, _ = lstsq(A, y)
+    coeffs = xp.linalg.pinv(A) @ y
 
     return coeffs
 
 
-def _polyder(p, m):
+def _polyder(p, m, *, xp):
     """Differentiate polynomials represented with coefficients.
 
     p must be a 1-D or 2-D array.  In the 2-D case, each column gives
@@ -156,14 +164,16 @@ def _polyder(p, m):
     if m == 0:
         result = p
     else:
-        n = len(p)
+        n = p.shape[0]
         if n <= m:
-            result = np.zeros_like(p[:1, ...])
+            result = xp.zeros_like(p[:1, ...])
         else:
-            dp = p[:-m].copy()
+            dp = xp.asarray(p[:-m, ...], copy=True)
             for k in range(m):
-                rng = np.arange(n - k - 1, m - k - 1, -1)
-                dp *= rng.reshape((n - m,) + (1,) * (p.ndim - 1))
+                rng = xp.arange(
+                    n - k - 1, m - k - 1, -1, dtype=p.dtype, device=xp_device(p)
+                )
+                dp *= xp.reshape(rng, (n - m,) + (1,) * (p.ndim - 1))
             result = dp
     return result
 
@@ -177,6 +187,7 @@ def _fit_edge(x, window_start, window_stop, interp_start, interp_stop,
     from `interp_start` to `interp_stop`. Put the result into the
     corresponding slice of `y`.
     """
+    xp = array_namespace(x)
 
     # Get the edge into a (window_length, -1) array.
     x_edge = axis_slice(x, start=window_start, stop=window_stop, axis=axis)
@@ -184,32 +195,42 @@ def _fit_edge(x, window_start, window_stop, interp_start, interp_stop,
         xx_edge = x_edge
         swapped = False
     else:
-        xx_edge = x_edge.swapaxes(axis, 0)
+        xx_edge = xp_swapaxes(x_edge, axis, 0, xp)
         swapped = True
-    xx_edge = xx_edge.reshape(xx_edge.shape[0], -1)
+    xx_edge = xp.reshape(xx_edge, (xx_edge.shape[0], -1))
 
     # Fit the edges.  poly_coeffs has shape (polyorder + 1, -1),
     # where '-1' is the same as in xx_edge.
-    poly_coeffs = np.polyfit(np.arange(0, window_stop - window_start),
-                             xx_edge, polyorder)
+    poly_coeffs = _pu.polyfit(
+        xp.arange(
+            0, window_stop - window_start, dtype=x.dtype, device=xp_device(x)
+        ), xx_edge, polyorder, xp=xp
+    )
 
     if deriv > 0:
-        poly_coeffs = _polyder(poly_coeffs, deriv)
+        poly_coeffs = _polyder(poly_coeffs, deriv, xp=xp)
 
     # Compute the interpolated values for the edge.
-    i = np.arange(interp_start - window_start, interp_stop - window_start)
-    values = np.polyval(poly_coeffs, i.reshape(-1, 1)) / (delta ** deriv)
+    i = xp.arange(
+        interp_start - window_start, interp_stop - window_start,
+        dtype=poly_coeffs.dtype, device=xp_device(poly_coeffs)
+    )
+    values = _pu.polyval(poly_coeffs, xp.reshape(i, (-1, 1)), xp=xp) / (delta ** deriv)
 
     # Now put the values into the appropriate slice of y.
     # First reshape values to match y.
     shp = list(y.shape)
     shp[0], shp[axis] = shp[axis], shp[0]
-    values = values.reshape(interp_stop - interp_start, *shp[1:])
+    values = xp.reshape(values, (interp_stop - interp_start, *shp[1:]))
     if swapped:
-        values = values.swapaxes(0, axis)
+        values = xp_swapaxes(values, 0, axis, xp)
     # Get a view of the data to be replaced by values.
-    y_edge = axis_slice(y, start=interp_start, stop=interp_stop, axis=axis)
-    y_edge[...] = values
+    y_slice = [slice(None)] * y.ndim
+    y_slice[axis] = slice(interp_start, interp_stop)
+    y = xpx.at(y, tuple(y_slice)).set(values)
+
+    return y
+
 
 
 def _fit_edges_polyfit(x, window_length, polyorder, deriv, delta, axis, y):
@@ -220,11 +241,13 @@ def _fit_edges_polyfit(x, window_length, polyorder, deriv, delta, axis, y):
     This function just calls _fit_edge twice, once for each end of the axis.
     """
     halflen = window_length // 2
-    _fit_edge(x, 0, window_length, 0, halflen, axis,
+    y = _fit_edge(x, 0, window_length, 0, halflen, axis,
               polyorder, deriv, delta, y)
     n = x.shape[axis]
-    _fit_edge(x, n - window_length, n, n - halflen, n, axis,
+    y = _fit_edge(x, n - window_length, n, n - halflen, n, axis,
               polyorder, deriv, delta, y)
+
+    return y
 
 
 def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
@@ -333,12 +356,15 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         raise ValueError("mode must be 'mirror', 'constant', 'nearest' "
                          "'wrap' or 'interp'.")
 
-    x = np.asarray(x)
+    xp = array_namespace(x)
+    x = xp.asarray(x)
     # Ensure that x is either single or double precision floating point.
-    if x.dtype != np.float64 and x.dtype != np.float32:
-        x = x.astype(np.float64)
+    if x.dtype != xp.float64 and x.dtype != xp.float32:
+        x = xp.astype(x, xp.float64)
 
-    coeffs = savgol_coeffs(window_length, polyorder, deriv=deriv, delta=delta)
+    coeffs = savgol_coeffs(
+        window_length, polyorder, deriv=deriv, delta=delta, xp=xp, device=xp_device(x)
+    )
 
     if mode == "interp":
         if window_length > x.shape[axis]:
@@ -349,7 +375,7 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
         # of the ends of the sequence, use the polynomial that is fitted to
         # the last `window_length` elements.
         y = convolve1d(x, coeffs, axis=axis, mode="constant")
-        _fit_edges_polyfit(x, window_length, polyorder, deriv, delta, axis, y)
+        y = _fit_edges_polyfit(x, window_length, polyorder, deriv, delta, axis, y)
     else:
         # Any mode other than 'interp' is passed on to ndimage.convolve1d.
         y = convolve1d(x, coeffs, axis=axis, mode=mode, cval=cval)

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -1,11 +1,9 @@
 import pytest
 import numpy as np
-from numpy.testing import (assert_equal, 
-                           assert_array_equal,
-)
 
 from scipy._lib._array_api import (
-    assert_almost_equal, assert_array_almost_equal, xp_assert_close
+    assert_almost_equal, assert_array_almost_equal, xp_assert_close, xp_assert_equal,
+    xp_swapaxes
 )
 
 from scipy.ndimage import convolve1d   # type: ignore[attr-defined]
@@ -13,13 +11,14 @@ from scipy.ndimage import convolve1d   # type: ignore[attr-defined]
 from scipy.signal import savgol_coeffs, savgol_filter
 from scipy.signal._savitzky_golay import _polyder
 
+skip_xp_backends = pytest.mark.skip_xp_backends
 
-def check_polyder(p, m, expected):
-    dp = _polyder(p, m)
-    assert_array_equal(dp, expected)
+def check_polyder(p, m, expected, xp):
+    dp = _polyder(p, m, xp=xp)
+    xp_assert_equal(dp, expected)
 
 
-def test_polyder():
+def test_polyder(xp):
     cases = [
         ([5], 0, [5]),
         ([5], 1, [0]),
@@ -33,14 +32,21 @@ def test_polyder():
         ([[3, 2, 1], [5, 6, 7]], 3, [[0], [0]]),
     ]
     for p, m, expected in cases:
-        check_polyder(np.array(p).T, m, np.array(expected).T)
+        pp = xp.asarray(p)
+        ee = xp.asarray(expected)
+        check_polyder(
+            pp.T if pp.ndim == 2 else pp,
+            m,
+            ee.T if ee.ndim ==2 else ee,
+            xp
+        )
 
 
 #--------------------------------------------------------------------
 # savgol_coeffs tests
 #--------------------------------------------------------------------
 
-def alt_sg_coeffs(window_length, polyorder, pos):
+def alt_sg_coeffs(window_length, polyorder, pos, xp):
     """This is an alternative implementation of the SG coefficients.
 
     It uses numpy.polyfit and numpy.polyval. The results should be
@@ -55,125 +61,132 @@ def alt_sg_coeffs(window_length, polyorder, pos):
     t = np.arange(window_length)
     unit = (t == pos).astype(int)
     h = np.polyval(np.polyfit(t, unit, polyorder), t)
-    return h
+    return xp.asarray(h)
 
 
-def test_sg_coeffs_trivial():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_coeffs_trivial(xp):
     # Test a trivial case of savgol_coeffs: polyorder = window_length - 1
-    h = savgol_coeffs(1, 0)
-    xp_assert_close(h, [1.0])
+    h = savgol_coeffs(1, 0, xp=xp)
+    xp_assert_close(h, xp.asarray([1.0], dtype=xp.float64))
 
-    h = savgol_coeffs(3, 2)
-    xp_assert_close(h, [0.0, 1, 0], atol=1e-10)
+    h = savgol_coeffs(3, 2, xp=xp)
+    xp_assert_close(h, xp.asarray([0.0, 1, 0], dtype=xp.float64), atol=1e-10)
 
-    h = savgol_coeffs(5, 4)
-    xp_assert_close(h, [0.0, 0, 1, 0, 0], atol=1e-10)
+    h = savgol_coeffs(5, 4, xp=xp)
+    xp_assert_close(h, xp.asarray([0.0, 0, 1, 0, 0], dtype=xp.float64), atol=1e-10)
 
-    h = savgol_coeffs(5, 4, pos=1)
-    xp_assert_close(h, [0.0, 0, 0, 1, 0], atol=1e-10)
+    h = savgol_coeffs(5, 4, pos=1, xp=xp)
+    xp_assert_close(h, xp.asarray([0.0, 0, 0, 1, 0], dtype=xp.float64), atol=1e-10)
 
-    h = savgol_coeffs(5, 4, pos=1, use='dot')
-    xp_assert_close(h, [0.0, 1, 0, 0, 0], atol=1e-10)
+    h = savgol_coeffs(5, 4, pos=1, use='dot', xp=xp)
+    xp_assert_close(h, xp.asarray([0.0, 1, 0, 0, 0], dtype=xp.float64), atol=1e-10)
 
 
-def compare_coeffs_to_alt(window_length, order):
+def compare_coeffs_to_alt(window_length, order, xp):
     # For the given window_length and order, compare the results
     # of savgol_coeffs and alt_sg_coeffs for pos from 0 to window_length - 1.
     # Also include pos=None.
     for pos in [None] + list(range(window_length)):
-        h1 = savgol_coeffs(window_length, order, pos=pos, use='dot')
-        h2 = alt_sg_coeffs(window_length, order, pos=pos)
+        h1 = savgol_coeffs(window_length, order, pos=pos, use='dot', xp=xp)
+        h2 = alt_sg_coeffs(window_length, order, pos=pos, xp=xp)
         xp_assert_close(
             h1, h2, atol=1e-10,
             err_msg=f"window_length = {window_length}, order = {order}, pos = {pos}"
         )
 
 
-def test_sg_coeffs_compare():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_coeffs_compare(xp):
     # Compare savgol_coeffs() to alt_sg_coeffs().
     for window_length in range(1, 8, 2):
         for order in range(window_length):
-            compare_coeffs_to_alt(window_length, order)
+            compare_coeffs_to_alt(window_length, order, xp=xp)
 
 
-def test_sg_coeffs_exact():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_coeffs_exact(xp):
     polyorder = 4
     window_length = 9
     halflen = window_length // 2
 
-    x = np.linspace(0, 21, 43)
+    x = xp.linspace(0, 21, 43)
     delta = x[1] - x[0]
 
     # The data is a cubic polynomial.  We'll use an order 4
     # SG filter, so the filtered values should equal the input data
     # (except within half window_length of the edges).
     y = 0.5 * x ** 3 - x
-    h = savgol_coeffs(window_length, polyorder)
+    h = savgol_coeffs(window_length, polyorder, xp=xp)
     y0 = convolve1d(y, h)
     xp_assert_close(y0[halflen:-halflen], y[halflen:-halflen])
 
     # Check the same input, but use deriv=1.  dy is the exact result.
     dy = 1.5 * x ** 2 - 1
-    h = savgol_coeffs(window_length, polyorder, deriv=1, delta=delta)
+    h = savgol_coeffs(window_length, polyorder, deriv=1, delta=delta, xp=xp)
     y1 = convolve1d(y, h)
     xp_assert_close(y1[halflen:-halflen], dy[halflen:-halflen])
 
     # Check the same input, but use deriv=2. d2y is the exact result.
     d2y = 3.0 * x
-    h = savgol_coeffs(window_length, polyorder, deriv=2, delta=delta)
+    h = savgol_coeffs(window_length, polyorder, deriv=2, delta=delta, xp=xp)
     y2 = convolve1d(y, h)
     xp_assert_close(y2[halflen:-halflen], d2y[halflen:-halflen])
 
 
-def test_sg_coeffs_deriv():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_coeffs_deriv(xp):
     # The data in `x` is a sampled parabola, so using savgol_coeffs with an
     # order 2 or higher polynomial should give exact results.
-    i = np.array([-2.0, 0.0, 2.0, 4.0, 6.0])
+    i = xp.asarray([-2.0, 0.0, 2.0, 4.0, 6.0], dtype=xp.float64)
     x = i ** 2 / 4
     dx = i / 2
-    d2x = np.full_like(i, 0.5)
-    for pos in range(x.size):
-        coeffs0 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot')
-        xp_assert_close(coeffs0.dot(x), x[pos], atol=1e-10)
-        coeffs1 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot', deriv=1)
-        xp_assert_close(coeffs1.dot(x), dx[pos], atol=1e-10)
-        coeffs2 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot', deriv=2)
-        xp_assert_close(coeffs2.dot(x), d2x[pos], atol=1e-10)
+    d2x = xp.full_like(i, 0.5)
+    for pos in range(x.shape[0]):
+        coeffs0 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot', xp=xp)
+        xp_assert_close(coeffs0 @ x, x[pos], atol=1e-10)
+        coeffs1 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot', deriv=1, xp=xp)
+        xp_assert_close(coeffs1 @ x, dx[pos], atol=1e-10)
+        coeffs2 = savgol_coeffs(5, 3, pos=pos, delta=2.0, use='dot', deriv=2, xp=xp)
+        xp_assert_close(coeffs2 @ x , d2x[pos], atol=1e-10)
 
 
-def test_sg_coeffs_deriv_gt_polyorder():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_coeffs_deriv_gt_polyorder(xp):
     """
     If deriv > polyorder, the coefficients should be all 0.
     This is a regression test for a bug where, e.g.,
         savgol_coeffs(5, polyorder=1, deriv=2)
     raised an error.
     """
-    coeffs = savgol_coeffs(5, polyorder=1, deriv=2)
-    assert_array_equal(coeffs, np.zeros(5))
-    coeffs = savgol_coeffs(7, polyorder=4, deriv=6)
-    assert_array_equal(coeffs, np.zeros(7))
+    coeffs = savgol_coeffs(5, polyorder=1, deriv=2, xp=xp)
+    xp_assert_equal(coeffs, xp.zeros(5, dtype=xp.float64))
+    coeffs = savgol_coeffs(7, polyorder=4, deriv=6, xp=xp)
+    xp_assert_equal(coeffs, xp.zeros(7, dtype=xp.float64))
 
 
-def test_sg_coeffs_large():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_coeffs_large(xp):
     # Test that for large values of window_length and polyorder the array of
     # coefficients returned is symmetric. The aim is to ensure that
     # no potential numeric overflow occurs.
-    coeffs0 = savgol_coeffs(31, 9)
-    assert_array_almost_equal(coeffs0, coeffs0[::-1])
-    coeffs1 = savgol_coeffs(31, 9, deriv=1)
-    assert_array_almost_equal(coeffs1, -coeffs1[::-1])
+    coeffs0 = savgol_coeffs(31, 9, xp=xp)
+    assert_array_almost_equal(coeffs0, xp.flip(coeffs0))
+    coeffs1 = savgol_coeffs(31, 9, deriv=1, xp=xp)
+    assert_array_almost_equal(coeffs1, -xp.flip(coeffs1))
 
 # --------------------------------------------------------------------
 # savgol_coeffs tests for even window length
 # --------------------------------------------------------------------
 
 
-def test_sg_coeffs_even_window_length():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_coeffs_even_window_length(xp):
     # Simple case - deriv=0, polyorder=0, 1
     window_lengths = [4, 6, 8, 10, 12, 14, 16]
     for length in window_lengths:
-        h_p_d = savgol_coeffs(length, 0, 0)
-        xp_assert_close(h_p_d, np.ones_like(h_p_d) / length)
+        h_p_d = savgol_coeffs(length, 0, 0, xp=xp)
+        xp_assert_close(h_p_d, xp.ones_like(h_p_d) / length)
 
     # Verify with closed forms
     # deriv=1, polyorder=1, 2
@@ -190,63 +203,67 @@ def test_sg_coeffs_even_window_length():
         m = length//2
         expected_output = [h_p_d_closed_form_1(k, m)
                            for k in range(-m + 1, m + 1)][::-1]
-        actual_output = savgol_coeffs(length, 1, 1)
-        xp_assert_close(expected_output, actual_output)
-        actual_output = savgol_coeffs(length, 2, 1)
-        xp_assert_close(expected_output, actual_output)
+        expected_output = xp.asarray(expected_output, dtype=xp.float64)
+        actual_output = savgol_coeffs(length, 1, 1, xp=xp)
+        xp_assert_close(actual_output, expected_output)
+        actual_output = savgol_coeffs(length, 2, 1, xp=xp)
+        xp_assert_close(actual_output, expected_output)
 
         expected_output = [h_p_d_closed_form_2(k, m)
                            for k in range(-m + 1, m + 1)][::-1]
-        actual_output = savgol_coeffs(length, 2, 2)
-        xp_assert_close(expected_output, actual_output)
-        actual_output = savgol_coeffs(length, 3, 2)
-        xp_assert_close(expected_output, actual_output)
+        expected_output = xp.asarray(expected_output, dtype=xp.float64)
+        actual_output = savgol_coeffs(length, 2, 2, xp=xp)
+        xp_assert_close(actual_output, expected_output)
+        actual_output = savgol_coeffs(length, 3, 2, xp=xp)
+        xp_assert_close(actual_output, expected_output)
 
 #--------------------------------------------------------------------
 # savgol_filter tests
 #--------------------------------------------------------------------
 
-
-def test_sg_filter_trivial():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_filter_trivial(xp):
     """ Test some trivial edge cases for savgol_filter()."""
-    x = np.array([1.0])
+    x = xp.asarray([1.0])
     y = savgol_filter(x, 1, 0)
-    assert_equal(y, [1.0])
+    xp_assert_equal(y, xp.asarray([1.0]))
 
     # Input is a single value. With a window length of 3 and polyorder 1,
     # the value in y is from the straight-line fit of (-1,0), (0,3) and
     # (1, 0) at 0. This is just the average of the three values, hence 1.0.
-    x = np.array([3.0])
+    x = xp.asarray([3.0])
     y = savgol_filter(x, 3, 1, mode='constant')
-    assert_almost_equal(y, [1.0], decimal=15)
+    assert_almost_equal(y, xp.asarray([1.0]), decimal=15)
 
-    x = np.array([3.0])
+    x = xp.asarray([3.0])
     y = savgol_filter(x, 3, 1, mode='nearest')
-    assert_almost_equal(y, [3.0], decimal=15)
+    assert_almost_equal(y, xp.asarray([3.0]), decimal=15)
 
-    x = np.array([1.0] * 3)
+    x = xp.asarray([1.0] * 3)
     y = savgol_filter(x, 3, 1, mode='wrap')
-    assert_almost_equal(y, [1.0, 1.0, 1.0], decimal=15)
+    assert_almost_equal(y, xp.asarray([1.0, 1.0, 1.0]), decimal=15)
 
 
-def test_sg_filter_basic():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_filter_basic(xp):
     # Some basic test cases for savgol_filter().
-    x = np.array([1.0, 2.0, 1.0])
+    x = xp.asarray([1.0, 2.0, 1.0])
     y = savgol_filter(x, 3, 1, mode='constant')
-    xp_assert_close(y, [1.0, 4.0 / 3, 1.0])
+    xp_assert_close(y, xp.asarray([1.0, 4.0 / 3, 1.0]))
 
     y = savgol_filter(x, 3, 1, mode='mirror')
-    xp_assert_close(y, [5.0 / 3, 4.0 / 3, 5.0 / 3])
+    xp_assert_close(y, xp.asarray([5.0 / 3, 4.0 / 3, 5.0 / 3]))
 
     y = savgol_filter(x, 3, 1, mode='wrap')
-    xp_assert_close(y, [4.0 / 3, 4.0 / 3, 4.0 / 3])
+    xp_assert_close(y, xp.asarray([4.0 / 3, 4.0 / 3, 4.0 / 3]))
 
 
-def test_sg_filter_2d():
-    x = np.array([[1.0, 2.0, 1.0],
-                  [2.0, 4.0, 2.0]])
-    expected = np.array([[1.0, 4.0 / 3, 1.0],
-                         [2.0, 8.0 / 3, 2.0]])
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_filter_2d(xp):
+    x = xp.asarray([[1.0, 2.0, 1.0],
+                    [2.0, 4.0, 2.0]])
+    expected = xp.asarray([[1.0, 4.0 / 3, 1.0],
+                           [2.0, 8.0 / 3, 2.0]])
     y = savgol_filter(x, 3, 1, mode='constant')
     xp_assert_close(y, expected)
 
@@ -254,22 +271,23 @@ def test_sg_filter_2d():
     xp_assert_close(y, expected.T)
 
 
-def test_sg_filter_interp_edges():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_filter_interp_edges(xp):
     # Another test with low degree polynomial data, for which we can easily
     # give the exact results. In this test, we use mode='interp', so
     # savgol_filter should match the exact solution for the entire data set,
     # including the edges.
-    t = np.linspace(-5, 5, 21)
+    t = xp.linspace(-5, 5, 21, dtype=xp.float64)
     delta = t[1] - t[0]
     # Polynomial test data.
-    x = np.array([t,
+    x = xp.stack([t,
                   3 * t ** 2,
                   t ** 3 - t])
-    dx = np.array([np.ones_like(t),
+    dx = xp.stack([xp.ones_like(t),
                    6 * t,
                    3 * t ** 2 - 1.0])
-    d2x = np.array([np.zeros_like(t),
-                    np.full_like(t, 6),
+    d2x = xp.stack([xp.zeros_like(t),
+                    xp.full_like(t, 6),
                     6 * t])
 
     window_length = 7
@@ -303,20 +321,21 @@ def test_sg_filter_interp_edges():
     xp_assert_close(y2, d2x, atol=1e-12)
 
 
-def test_sg_filter_interp_edges_3d():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_filter_interp_edges_3d(xp):
     # Test mode='interp' with a 3-D array.
-    t = np.linspace(-5, 5, 21)
+    t = xp.linspace(-5, 5, 21)
     delta = t[1] - t[0]
-    x1 = np.array([t, -t])
-    x2 = np.array([t ** 2, 3 * t ** 2 + 5])
-    x3 = np.array([t ** 3, 2 * t ** 3 + t ** 2 - 0.5 * t])
-    dx1 = np.array([np.ones_like(t), -np.ones_like(t)])
-    dx2 = np.array([2 * t, 6 * t])
-    dx3 = np.array([3 * t ** 2, 6 * t ** 2 + 2 * t - 0.5])
+    x1 = xp.stack([t, -t])
+    x2 = xp.stack([t ** 2, 3 * t ** 2 + 5])
+    x3 = xp.stack([t ** 3, 2 * t ** 3 + t ** 2 - 0.5 * t])
+    dx1 = xp.stack([xp.ones_like(t), -xp.ones_like(t)])
+    dx2 = xp.stack([2 * t, 6 * t])
+    dx3 = xp.stack([3 * t ** 2, 6 * t ** 2 + 2 * t - 0.5])
 
     # z has shape (3, 2, 21)
-    z = np.array([x1, x2, x3])
-    dz = np.array([dx1, dx2, dx3])
+    z = xp.stack([x1, x2, x3])
+    dz = xp.stack([dx1, dx2, dx3])
 
     y = savgol_filter(z, 7, 3, axis=-1, mode='interp', delta=delta)
     xp_assert_close(y, z, atol=1e-10)
@@ -325,8 +344,8 @@ def test_sg_filter_interp_edges_3d():
     xp_assert_close(dy, dz, atol=1e-10)
 
     # z has shape (3, 21, 2)
-    z = np.array([x1.T, x2.T, x3.T])
-    dz = np.array([dx1.T, dx2.T, dx3.T])
+    z = xp.stack([x1.T, x2.T, x3.T])
+    dz = xp.stack([dx1.T, dx2.T, dx3.T])
 
     y = savgol_filter(z, 7, 3, axis=1, mode='interp', delta=delta)
     xp_assert_close(y, z, atol=1e-10)
@@ -335,8 +354,8 @@ def test_sg_filter_interp_edges_3d():
     xp_assert_close(dy, dz, atol=1e-10)
 
     # z has shape (21, 3, 2)
-    z = z.swapaxes(0, 1).copy()
-    dz = dz.swapaxes(0, 1).copy()
+    z = xp.asarray(xp_swapaxes(z, 0, 1, xp=xp), copy=True)
+    dz = xp.asarray(xp_swapaxes(dz, 0, 1, xp=xp), copy=True)
 
     y = savgol_filter(z, 7, 3, axis=0, mode='interp', delta=delta)
     xp_assert_close(y, z, atol=1e-10)
@@ -345,10 +364,11 @@ def test_sg_filter_interp_edges_3d():
     xp_assert_close(dy, dz, atol=1e-10)
 
 
-def test_sg_filter_valid_window_length_3d():
+@skip_xp_backends("dask.array", reason="linalg.pinv is missing")
+def test_sg_filter_valid_window_length_3d(xp):
     """Tests that the window_length check is using the correct axis."""
 
-    x = np.ones((10, 20, 30))
+    x = xp.ones((10, 20, 30))
 
     savgol_filter(x, window_length=29, polyorder=3, mode='interp')
 

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -104,6 +104,7 @@ def test_sg_coeffs_compare(xp):
             compare_coeffs_to_alt(window_length, order, xp=xp)
 
 
+@skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="convolve1d is cpu-only")
 @skip_xp_backends("dask.array", reason="linalg.pinv is missing")
 def test_sg_coeffs_exact(xp):
     polyorder = 4
@@ -221,6 +222,7 @@ def test_sg_coeffs_even_window_length(xp):
 # savgol_filter tests
 #--------------------------------------------------------------------
 
+@skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="convolve1d is cpu-only")
 @skip_xp_backends("dask.array", reason="linalg.pinv is missing")
 def test_sg_filter_trivial(xp):
     """ Test some trivial edge cases for savgol_filter()."""
@@ -244,6 +246,7 @@ def test_sg_filter_trivial(xp):
     assert_almost_equal(y, xp.asarray([1.0, 1.0, 1.0]), decimal=15)
 
 
+@skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="convolve1d is cpu-only")
 @skip_xp_backends("dask.array", reason="linalg.pinv is missing")
 def test_sg_filter_basic(xp):
     # Some basic test cases for savgol_filter().
@@ -258,6 +261,7 @@ def test_sg_filter_basic(xp):
     xp_assert_close(y, xp.asarray([4.0 / 3, 4.0 / 3, 4.0 / 3]))
 
 
+@skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="convolve1d is cpu-only")
 @skip_xp_backends("dask.array", reason="linalg.pinv is missing")
 def test_sg_filter_2d(xp):
     x = xp.asarray([[1.0, 2.0, 1.0],
@@ -271,6 +275,7 @@ def test_sg_filter_2d(xp):
     xp_assert_close(y, expected.T)
 
 
+@skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="convolve1d is cpu-only")
 @skip_xp_backends("dask.array", reason="linalg.pinv is missing")
 def test_sg_filter_interp_edges(xp):
     # Another test with low degree polynomial data, for which we can easily
@@ -321,6 +326,7 @@ def test_sg_filter_interp_edges(xp):
     xp_assert_close(y2, d2x, atol=1e-12)
 
 
+@skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="convolve1d is cpu-only")
 @skip_xp_backends("dask.array", reason="linalg.pinv is missing")
 def test_sg_filter_interp_edges_3d(xp):
     # Test mode='interp' with a 3-D array.
@@ -364,6 +370,7 @@ def test_sg_filter_interp_edges_3d(xp):
     xp_assert_close(dy, dz, atol=1e-10)
 
 
+@skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="convolve1d is cpu-only")
 @skip_xp_backends("dask.array", reason="linalg.pinv is missing")
 def test_sg_filter_valid_window_length_3d(xp):
     """Tests that the window_length check is using the correct axis."""

--- a/scipy/signal/tests/test_savitzky_golay.py
+++ b/scipy/signal/tests/test_savitzky_golay.py
@@ -91,7 +91,7 @@ def compare_coeffs_to_alt(window_length, order, xp):
         h1 = savgol_coeffs(window_length, order, pos=pos, use='dot', xp=xp)
         h2 = alt_sg_coeffs(window_length, order, pos=pos, xp=xp)
         xp_assert_close(
-            h1, h2, atol=1e-10,
+            h1, h2, atol=2e-10,
             err_msg=f"window_length = {window_length}, order = {order}, pos = {pos}"
         )
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/20678

#### What does this implement/fix?
<!--Please explain your changes.-->

Convert `signal.savgol_filter` and `signal.savgol_coeffs` to be Array API compatible

#### Additional information
<!--Any additional information you think is important.-->

- `savgol_coeffs` receives scalars and return arrays, hence gets new arguments, `xp=None, device=None`, similar to `signal.windows` and `fft`
-<s> both functions used to rely on `lstsq`, which is not a part of Array API linalg extension; Replace it with `pinv` and a manual call to SVD (where we emit a warning for rank-deficient problems)</s> EDIT: Use `scipy.linalg.lstsq` for numpy arrays, backend-specific `xp.linalg.lstsq` if available, and fall back to a manual svd computation otherwise.
- `dask` backend is limited in several ways, needs to be skipped all around
