### PR TITLE
DOC/DEV: Document `scipy.signal`'s Array API caveats.

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -226,6 +226,7 @@ conversion will raise an exception. The reason for that is that silent data
 transfer between devices is considered bad practice, as it is likely to be a
 large and hard-to-detect performance bottleneck.
 
+.. _dev-arrayapi_adding_tests:
 
 Adding tests
 ------------
@@ -521,4 +522,3 @@ Support with JIT
    :stats: array_api_support_stats_jit
    :stats.contingency: array_api_support_stats_contingency_jit
    :stats.qmc: array_api_support_stats_qmc_jit
-

--- a/doc/source/dev/api-dev/array_api_modules_tables/signal.rst
+++ b/doc/source/dev/api-dev/array_api_modules_tables/signal.rst
@@ -13,16 +13,15 @@ incomplete) tables about the
 
 Caveats
 -------
-The functions in the `~scipy.signal` module are decorated to call their counterparts in
 `JAX <https://docs.jax.dev/en/latest/jax.scipy.html>`__ and `CuPy
-<https://docs.cupy.dev/en/stable/reference/scipy_signal.html>`__ when the environment
-variable ``SCIPY_ARRAY_API`` is set. This works around incompatibilities in those
-backends.
+<https://docs.cupy.dev/en/stable/reference/scipy_signal.html>`__ provide alternative
+implementations for some `~scipy.signal` functions. When such a function is called, a
+decorator decides which implementation to use by inspecting the `xp` parameter.
 
 Hence, there can be, especially during CI testing, discrepancies in behavior between
-SciPy and the JAX and CuPy backends. Skipping the incompatible backends in unit tests,
-as described in the :ref:`dev-arrayapi_adding_tests` section, is the currently
-recommended workaround.
+the default NumPy-based implementation and the JAX and CuPy backends. Skipping the
+incompatible backends in unit tests, as described in the
+:ref:`dev-arrayapi_adding_tests` section, is the currently recommended workaround.
 
 The functions are decorated by the code in file
 ``scipy/signal/_support_alternative_backends.py``:
@@ -30,7 +29,8 @@ The functions are decorated by the code in file
 .. literalinclude:: ../../../../../scipy/signal/_support_alternative_backends.py
     :lineno-match:
 
-Note that the function will only be decorated if its signature is listed in the file
+Note that a function will only be decorated if the environment variable
+``SCIPY_ARRAY_API`` is set and its signature is listed in the file
 ``scipy/signal/_delegators.py``. E.g., for `~scipy.signal.firwin`, the signature
 function looks like this:
 

--- a/doc/source/dev/api-dev/array_api_modules_tables/signal.rst
+++ b/doc/source/dev/api-dev/array_api_modules_tables/signal.rst
@@ -1,5 +1,44 @@
+.. _array_api_support_signal:
+
 Array API Standard Support: ``signal``
 ======================================
+This page explains some caveats of the `~scipy.signal` module and provides (currently
+incomplete) tables about the
+:ref:`CPU <array_api_support_signal_cpu>`,
+:ref:`GPU <array_api_support_signal_gpu>` and
+:ref:`JIT <array_api_support_signal_jit>` support.
+
+
+.. _array_api_support_signal_caveats:
+
+Caveats
+-------
+The functions in the `~scipy.signal` module are decorated to call their counterparts in
+`JAX <https://docs.jax.dev/en/latest/jax.scipy.html>`__ and `CuPy
+<https://docs.cupy.dev/en/stable/reference/scipy_signal.html>`__ when the environment
+variable ``SCIPY_ARRAY_API`` is set. This works around incompatibilities in those
+backends.
+
+Hence, there can be, especially during CI testing, discrepancies in behavior between
+SciPy and the JAX and CuPy backends. Skipping the incompatible backends in unit tests,
+as described in the :ref:`dev-arrayapi_adding_tests` section, is the currently
+recommended workaround.
+
+The functions are decorated by the code in file
+``scipy/signal/_support_alternative_backends.py``:
+
+.. literalinclude:: ../../../../../scipy/signal/_support_alternative_backends.py
+    :lineno-match:
+
+Note that the function will only be decorated if its signature is listed in the file
+``scipy/signal/_delegators.py``. E.g., for `~scipy.signal.firwin`, the signature
+function looks like this:
+
+.. literalinclude:: ../../../../../scipy/signal/_delegators.py
+    :pyobject: firwin_signature
+    :lineno-match:
+
+
 
 .. _array_api_support_signal_cpu:
 


### PR DESCRIPTION
This is a contribution towards resolving issue #23539 by pointing to the code decorating `scipy.signal` calls. 

I am not sure if I caught all relevant information. The  `Caveats` section should be the explanation to point to when needing to skip unit tests due to CuPy or JAX issues.

What is not included are guidelines on how to consistently mark skipped unit tests, i.e., how to word the `reason` parameter to make it easier to unmark, once the backends caught up.

