### PR TITLE
MAINT: signal: tighten the workaround for object arrays

### DIFF
--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -137,9 +137,11 @@ iirpeak_signature = iirnotch_signature
 
 
 def savgol_coeffs_signature(
-    window_length, polyorder, deriv=0, delta=1.0, pos=None, use='conv'
+    window_length, polyorder, deriv=0, delta=1.0, pos=None, use='conv',
+    *, xp=None, device=None
 ):
-    return np
+    return np if xp is None else xp
+
 
 
 def unit_impulse_signature(shape, idx=None, dtype=float):
@@ -246,7 +248,7 @@ def csd_signature(x, y, fs=1.0, window='hann_periodic', *args, **kwds):
     return array_namespace(x, y, _skip_if_str_or_tuple(window))
 
 
-def periodogram_signature(x, fs=1.0, window='boxcar'):
+def periodogram_signature(x, fs=1.0, window='boxcar', *args, **kwds):
     return array_namespace(x, _skip_if_str_or_tuple(window))
 
 
@@ -342,7 +344,7 @@ def firwin2_signature(numtaps, freq, gain, *args, **kwds):
     return array_namespace(freq, gain)
 
 
-def freqs_zpk_signature(z, p, k, worN, *args, **kwds):
+def freqs_zpk_signature(z, p, k, worN=200, *args, **kwds):
     return array_namespace(z, p, worN)
 
 freqz_zpk_signature = freqs_zpk_signature
@@ -351,7 +353,10 @@ freqz_zpk_signature = freqs_zpk_signature
 def freqs_signature(b, a, worN=200, *args, **kwds):
     return array_namespace(b, a, worN)
 
-freqz_signature = freqs_signature
+
+def freqz_signature(b, a=1, worN=512, *args, **kwds):
+    # differs from freqs: `a` has a default value
+    return array_namespace(b, a, worN)
 
 
 def freqz_sos_signature(sos, worN=512, *args, **kwds):
@@ -369,7 +374,7 @@ def group_delay_signature(system, w=512, whole=False, fs=6.283185307179586):
     return array_namespace(*system, w)
 
 
-def hilbert_signature(x, N=None, axis=-1):
+def hilbert_signature(x, *args, **kwds):
     return array_namespace(x)
 
 hilbert2_signature = hilbert_signature

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -36,8 +36,11 @@ def delegate_xp(delegator, module_name):
                 xp = delegator(*args, **kwds)
             except TypeError:
                 # object arrays
-                import numpy as np
-                xp = np
+                if func.__name__ == "tf2ss":
+                    import numpy as np
+                    xp = np
+                else:
+                    raise
 
             # try delegating to a cupyx/jax namesake
             if is_cupy(xp) and func.__name__ not in CUPY_BLACKLIST:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1081,6 +1081,7 @@ class TestFreqz:
                               (False, True, 257),
                               (True, False, 257),
                               (True, True, 257)])
+    
     @xfail_xp_backends("cupy", reason="XXX: CuPy's version suspect")
     def test_17289(self, whole, nyquist, worN, xp):
         d = xp.asarray([0.0, 1.0])

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1081,6 +1081,7 @@ class TestFreqz:
                               (False, True, 257),
                               (True, False, 257),
                               (True, True, 257)])
+    @xfail_xp_backends("cupy", reason="XXX: CuPy's version suspect")
     def test_17289(self, whole, nyquist, worN, xp):
         d = xp.asarray([0.0, 1.0])
         w, Drfft = freqz(d, worN=32, whole=whole, include_nyquist=nyquist)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -797,10 +797,11 @@ class TestFreqz:
             assert_array_almost_equal(w, expected_w)
             assert_array_almost_equal(h, h_whole)
 
-            # simultaneously check int-like support
-            w, h = freqz(b, a, worN=np.int32(4), whole=True)
-            assert_array_almost_equal(w, expected_w)
-            assert_array_almost_equal(h, h_whole)
+            if is_numpy(xp):
+                # simultaneously check int-like support
+                w, h = freqz(b, a, worN=np.int32(4), whole=True)
+                assert_array_almost_equal(w, expected_w)
+                assert_array_almost_equal(h, h_whole)
 
             w, h = freqz(b, a, worN=w, whole=True)
             assert_array_almost_equal(w, expected_w)
@@ -1018,13 +1019,14 @@ class TestFreqz:
         xp_assert_close(h1, h2)
         xp_assert_close(w1, xp.linspace(0, fs, 5, endpoint=False))
 
-        # w is an array_like
-        for w in ([123], (123,), xp.asarray([123]), (50, 123, 230),
-                  xp.asarray([50, 123, 230])):
-            w1, h1 = freqz(b, a, w, fs=fs)
-            w2, h2 = freqz(b, a, 2*pi*xp.asarray(w, dtype=xp.float64)/ fs)
-            xp_assert_close(h1, h2)
-            xp_assert_close(w1, xp.asarray(w), check_dtype=False)
+        if is_numpy(xp):
+            # w is an array_like
+            for w in ([123], (123,), xp.asarray([123]), (50, 123, 230),
+                      xp.asarray([50, 123, 230])):
+                w1, h1 = freqz(b, a, w, fs=fs)
+                w2, h2 = freqz(b, a, 2*pi*xp.asarray(w, dtype=xp.float64)/ fs)
+                xp_assert_close(h1, h2)
+                xp_assert_close(w1, xp.asarray(w), check_dtype=False)
 
     def test_w_or_N_types(self):
         # Measure at 7 (polyval) or 8 (fft) equally-spaced points
@@ -4604,7 +4606,7 @@ class TestIIRComb:
         b, a = iircomb(50/int(44100/2), 50.0, ftype='notch', xp=xp)
 
         # Compute the frequency response at an upper harmonic of 50
-        freqs, response = freqz(b, a, [22000], fs=44100)
+        freqs, response = freqz(b, a, xp.asarray([22000]), fs=44100)
 
         # Before bug fix, this would produce N = 881, so that 22 kHz was ~0 dB.
         # Now N = 882 correctly and 22 kHz should be a notch <-220 dB

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3398,16 +3398,20 @@ class TestHilbert2:
         x = xp.reshape(xp.arange(16), (4, 4))
         with pytest.raises(ValueError, match="^x must be real."):
             hilbert2(xp.asarray([[1.0 + 0.0j]]))
-        with pytest.raises(ValueError, match="^axes must be a tuple of length 2"):
-            hilbert2(x, axes=(0, 1, 2))
-        with pytest.raises(ValueError, match="^axes must contain 2 distinct axes"):
-            hilbert2(x, axes=(0, 0))
         with pytest.raises(ValueError, match="^N must be positive."):
             hilbert2(x, N=-1)
         with pytest.raises(ValueError, match="^When given as a tuple, N must hold"):
             hilbert2(x, N=(1, 1, 1))
         with pytest.raises(ValueError, match="^When given as a tuple, N must hold"):
             hilbert2(x, N=(0, 1))
+
+    @skip_xp_backends("cupy", reason="CuPy's hilbert2 does not have axes= argument")
+    def test_bad_args2(self, xp):
+        x = xp.reshape(xp.arange(16), (4, 4))
+        with pytest.raises(ValueError, match="^axes must be a tuple of length 2"):
+            hilbert2(x, axes=(0, 1, 2))
+        with pytest.raises(ValueError, match="^axes must contain 2 distinct axes"):
+            hilbert2(x, axes=(0, 0))
 
     @pytest.mark.parametrize('dtype', ['float32', 'float64'])
     def test_hilbert2_types(self, dtype, xp):

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1378,7 +1378,7 @@ class TestResample:
         # window.shape must equal to sig.shape[0]
         sig = xp.arange(128, dtype=xp.float64)
         num = 256
-        win = signal.get_window(('kaiser', 8.0), 160)
+        win = signal.get_window(('kaiser', 8.0), 160, xp=xp)
         assert_raises(ValueError, signal.resample, sig, num, window=win)
         assert_raises(ValueError, signal.resample, sig, num, domain='INVALID')
 
@@ -1390,7 +1390,7 @@ class TestResample:
         assert_raises(ValueError, signal.resample_poly, sig, 2, 1, padtype='')
         assert_raises(ValueError, signal.resample_poly, sig, 2, 1,
                       padtype='mean', cval=10)
-        assert_raises(ValueError, signal.resample_poly, sig, 2, 1, window=np.eye(2))
+        assert_raises(ValueError, signal.resample_poly, sig, 2, 1, window=xp.eye(2))
 
         # test for issue #6505 - should not modify window.shape when axis ≠ 0
         sig2 = xp.tile(xp.arange(160, dtype=xp.float64), (2, 1))
@@ -1525,6 +1525,7 @@ class TestResample:
                     half_len = 10 * max_rate
                     window = signal.firwin(2 * half_len + 1, f_c,
                                            window=('kaiser', 5.0))
+                    window = xp.asarray(window)
                     polyargs = {'window': window, 'padtype': padtype}
                 else:
                     polyargs = {'padtype': padtype}


### PR DESCRIPTION
Now that the deprecation of object arrays in lfilter et al has expired, tighten the try-except stanza in `_support_alternative_backends`. Turns out it was masking several small errors elsewhere, so fix them.

The only remaining instance of object array is in `tf2ss`, and it is explicitly tested for. We might want to deprecate these, separately.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
