### PR TITLE
DOC: linalg: document batch support

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1451,6 +1451,10 @@ def det(a, overwrite_a=False, check_finite=True):
     The determinant is a scalar that is a function of the associated square
     matrix coefficients. The determinant value is zero for singular matrices.
 
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     a : (..., M, M) array_like

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -2225,6 +2225,11 @@ def matmul_toeplitz(c_or_cr, x, check_finite=False, workers=None):
     and r as its first row. If r is not given, ``r == conjugate(c)`` is
     assumed.
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     c_or_cr : array_like or tuple of (array_like, array_like)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -869,7 +869,7 @@ def _solve_banded(nlower, nupper, ab, b, overwrite_ab, overwrite_b, check_finite
 def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
                   check_finite=True):
     """
-    Solve the equation ``a @ x = b`` for ``x``,  where ``a`` is the 
+    Solve the equation ``a @ x = b`` for ``x``,  where ``a`` is the
     Hermitian positive-definite banded matrix defined by `ab`.
 
     Uses Thomas' Algorithm, which is more efficient than standard LU
@@ -1135,11 +1135,6 @@ def solve_circulant(c, b, singular='raise', tol=None,
     respectively. For a large vector `c`, this is *much* faster than
     solving the system with the full circulant matrix.
 
-    The documentation is written assuming array arguments are of specified
-    "core" shapes. However, array argument(s) of this function may have additional
-    "batch" dimensions prepended to the core shape. In this case, the array is treated
-    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
-    
     Parameters
     ----------
     c : array_like
@@ -1350,7 +1345,7 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
     Array argument(s) of this function may have additional
     "batch" dimensions prepended to the core shape. In this case, the array is treated
     as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
-    
+
     Parameters
     ----------
     a : array_like, shape (..., M, M)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1347,6 +1347,10 @@ def inv(a, overwrite_a=False, check_finite=True, assume_a=None):
     For the 'pos upper' and 'pos lower' options, only the specified
     triangle of the input matrix is used, and the other triangle is not referenced.
 
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+    
     Parameters
     ----------
     a : array_like, shape (..., M, M)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -86,6 +86,10 @@ def solve(a, b, lower=None, overwrite_a=False,
      general                        'general' (or 'gen')
     =============================  ================================
 
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     a : array_like, shape (..., N, N)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -747,6 +747,11 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
         a10  a21  a32  a43  a54   *
         a20  a31  a42  a53   *    *
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     (l, u) : (integer, integer)
@@ -1005,6 +1010,11 @@ def solve_toeplitz(c_or_cr, b, check_finite=True):
     and ``r`` as its first row. If ``r`` is not given, ``r == conjugate(c)`` is
     assumed.
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     c_or_cr : array_like or tuple of (array_like, array_like)
@@ -1121,6 +1131,11 @@ def solve_circulant(c, b, singular='raise', tol=None,
     respectively. For a large vector `c`, this is *much* faster than
     solving the system with the full circulant matrix.
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+    
     Parameters
     ----------
     c : array_like

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -1510,6 +1510,10 @@ def cdf2rdf(w, v):
 
     .. versionadded:: 1.1.0
 
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+    
     Parameters
     ----------
     w : (..., M) array_like

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -188,6 +188,11 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
 def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
     """Solve the linear equations A x = b, given the Cholesky factorization of A.
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     (c, lower) : tuple, (array, bool)
@@ -338,6 +343,11 @@ def cho_solve_banded(cb_and_lower, b, overwrite_b=False, check_finite=True):
     """
     Solve the linear equations ``A x = b``, given the Cholesky factorization of
     the banded Hermitian ``A``.
+
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
     Parameters
     ----------

--- a/scipy/linalg/_decomp_cossin.py
+++ b/scipy/linalg/_decomp_cossin.py
@@ -39,6 +39,11 @@ def cossin(X, p=None, q=None, separate=False,
     subblocks in an iterable from which the shapes would be derived. See the
     examples below.
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     X : array_like, iterable
@@ -79,13 +84,6 @@ def cossin(X, p=None, q=None, separate=False,
         matrix consisting of the blocks ``V1H`` (``q`` x ``q``) and ``V2H``
         (``m-q`` x ``m-q``) orthogonal/unitary matrices. If ``separate=True``,
         this contains the tuple of ``(V1H, V2H)``.
-
-    Notes
-    -----
-    The documentation is written assuming array arguments are of specified
-    "core" shapes. However, array argument(s) of this function may have additional
-    "batch" dimensions prepended to the core shape. In this case, the array is treated
-    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
     References
     ----------

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -134,6 +134,11 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
 def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
     """Solve an equation system, a x = b, given the LU factorization of a
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     (lu, piv)

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -227,9 +227,13 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True,
     ``True`` then ``L`` is returned already permuted and hence satisfying
     ``A = L @ U``.
 
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
-    a : (M, N) array_like
+    a : (..., M, N) array_like
         Array to decompose
     permute_l : bool, optional
         Perform the multiplication P*L (Default: do not permute)

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -233,8 +233,7 @@ def logm(A, disp=_NoValue):
 def expm(A):
     """Compute the matrix exponential of an array.
 
-    The documentation is written assuming array arguments are of specified
-    "core" shapes. However, array argument(s) of this function may have additional
+    Array argument(s) of this function may have additional
     "batch" dimensions prepended to the core shape. In this case, the array is treated
     as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
@@ -424,8 +423,7 @@ def sqrtm(A, disp=_NoValue, blocksize=_NoValue):
     real-valued matrices the return type can be complex if, numerically, there
     is an eigenvalue on the negative real axis.
 
-    The documentation is written assuming array arguments are of specified
-    "core" shapes. However, array argument(s) of this function may have additional
+    Array argument(s) of this function may have additional
     "batch" dimensions prepended to the core shape. In this case, the array is treated
     as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -233,6 +233,11 @@ def logm(A, disp=_NoValue):
 def expm(A):
     """Compute the matrix exponential of an array.
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     A : ndarray
@@ -418,6 +423,11 @@ def sqrtm(A, disp=_NoValue, blocksize=_NoValue):
     Moreover, not every real matrix has a real square root. Hence, for
     real-valued matrices the return type can be complex if, numerically, there
     is an eigenvalue on the negative real axis.
+
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
     Parameters
     ----------

--- a/scipy/linalg/_sketches.py
+++ b/scipy/linalg/_sketches.py
@@ -67,6 +67,11 @@ def clarkson_woodruff_transform(input_matrix, sketch_size, rng=None):
     with high probability via the Clarkson-Woodruff Transform, otherwise
     known as the CountSketch matrix.
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     input_matrix : array_like, shape (..., n, d)

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -93,6 +93,10 @@ def circulant(c):
     """
     Construct a circulant matrix.
 
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     c : (..., N,)  array_like
@@ -276,6 +280,11 @@ def leslie(f, s):
     n-1 array of survival coefficients `s`, return the associated Leslie
     matrix.
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     f : (N,) array_like
@@ -356,8 +365,7 @@ def block_diag(*arrs):
     ----------
     A, B, C, ... : array_like
         Input arrays.  A 1-D array or array_like sequence of length ``n`` is
-        treated as a 2-D array with shape ``(1, n)``. Any dimensions before
-        the last two are treated as batch dimensions; see :ref:`linalg_batch`.
+        treated as a 2-D array with shape ``(1, n)``.
 
     Returns
     -------
@@ -431,6 +439,10 @@ def companion(a):
 
     Create the companion matrix [1]_ associated with the polynomial whose
     coefficients are given in `a`.
+
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
     Parameters
     ----------
@@ -927,6 +939,10 @@ def fiedler(a):
     eigenvalues are negative. Although not valid generally, for certain inputs,
     the inverse and the determinant can be derived explicitly as given in [1]_.
 
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     a : (..., n,) array_like
@@ -1003,6 +1019,10 @@ def fiedler_companion(a):
     Given a polynomial coefficient array ``a``, this function forms a
     pentadiagonal matrix with a special structure whose eigenvalues coincides
     with the roots of ``a``.
+
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
     Parameters
     ----------
@@ -1086,6 +1106,10 @@ def convolution_matrix(a, n, mode='full'):
 
     Constructs the Toeplitz matrix representing one-dimensional
     convolution [1]_.  See the notes below for details.
+
+    Array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
     Parameters
     ----------

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -26,6 +26,11 @@ def toeplitz(c, r=None):
     and r as its first row. If r is not given, ``r == conjugate(c)`` is
     assumed.
 
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     c : array_like
@@ -341,6 +346,11 @@ def block_diag(*arrs):
         [[A, 0, 0],
          [0, B, 0],
          [0, 0, C]]
+
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
     Parameters
     ----------


### PR DESCRIPTION
#### Reference issue
Toward gh-21466

#### What does this implement/fix?
Adds documentation about batch support where it is missing. Sometimes there is already some reference to batching, but I think there should always be a link to the batch tutorial.