### PR TITLE
BUG: Fixes #23644: sparse: csc_array.setdiag() makes indices unsorted

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -821,6 +821,10 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             coo._setdiag(values, k)
             arrays = coo._coo_to_compressed(self._swap)
             self.indptr, self.indices, self.data, _ = arrays
+            # Sort the indices (like in _insert_many)
+            if self.has_sorted_indices:
+                self.has_sorted_indices = False  # force a sort
+                self.sort_indices()
 
     def _prepare_indices(self, i, j):
         M, N = self._swap(self._shape_as_2d)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -817,12 +817,13 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             self._insert_many(i[is_new], j[is_new], x[is_new])
         else:
             # convert to coo for _set_diag
+            do_sort = self.has_sorted_indices
             coo = self.tocoo()
             coo._setdiag(values, k)
             arrays = coo._coo_to_compressed(self._swap)
             self.indptr, self.indices, self.data, _ = arrays
             # Sort the indices (like in _insert_many)
-            if self.has_sorted_indices:
+            if do_sort:
                 self.has_sorted_indices = False  # force a sort
                 self.sort_indices()
 

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -813,7 +813,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # replace existing entries
             self.data[offsets[is_existing]] = x[is_existing]
             # create new entries
-            is_new = ~is_existing
+            is_new = np.logical_not(is_existing, out=is_existing)
+            del is_existing
             self._insert_many(i[is_new], j[is_new], x[is_new])
         else:
             # convert to coo for _set_diag

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -804,17 +804,17 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             self.data[offsets] = x
             return
 
-        mask = (offsets >= 0)
+        is_existing = (offsets >= 0)
+        is_new = ~is_existing
+        N_new = is_new.sum()
+
         # Boundary between csc and convert to coo
         # The value 0.001 is justified in gh-19962#issuecomment-1920499678
-        if self.nnz - mask.sum() < self.nnz * 0.001:
+        if N_new < self.nnz * 0.001:
             # replace existing entries
-            self.data[offsets[mask]] = x[mask]
+            self.data[offsets[is_existing]] = x[is_existing]
             # create new entries
-            mask = ~mask
-            i = i[mask]
-            j = j[mask]
-            self._insert_many(i, j, x[mask])
+            self._insert_many(i[is_new], j[is_new], x[is_new])
         else:
             # convert to coo for _set_diag
             coo = self.tocoo()

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -805,8 +805,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             return
 
         is_existing = (offsets >= 0)
-        is_new = ~is_existing
-        N_new = is_new.sum()
+        N_new = len(is_existing) - np.count_nonzero(is_existing)
 
         # Boundary between csc and convert to coo
         # The value 0.001 is justified in gh-19962#issuecomment-1920499678
@@ -814,6 +813,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
             # replace existing entries
             self.data[offsets[is_existing]] = x[is_existing]
             # create new entries
+            is_new = ~is_existing
             self._insert_many(i[is_new], j[is_new], x[is_new])
         else:
             # convert to coo for _set_diag

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4218,7 +4218,6 @@ class _CompressedMixin:
         D = self.dia_container((diags, offsets), shape=(N, N))
         return self._test_setdiag_sorted(D)
 
-    @pytest.mark.xfail(reason="bug in _cs_matrix._setdiag")
     def test_setdiag_cooconvert(self):
         # Test large ratio of new elements
         # see gh-23644

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -4519,13 +4519,6 @@ class TestCSR(_CompressedMixin, sparse_test_class()):
         for x in [a, b, c, d, e, f]:
             x + x
 
-    def test_setdiag_csr(self):
-        # see gh-21791 setting mixture of existing and not when new_values < 0.001*nnz
-        D = self.dia_container(([np.arange(1002)], [0]), shape=(1002, 1002))
-        A = self.spcreator(D)
-        A.setdiag(5 * np.ones(A.shape[0]))
-        assert A[-1, -1] == 5
-
     def test_binop_explicit_zeros(self):
         # Check that binary ops don't introduce spurious explicit zeros.
         # See gh-9619 for context.
@@ -4700,13 +4693,6 @@ class TestCSC(_CompressedMixin, sparse_test_class()):
         # These shouldn't fail
         for x in [a, b, c, d, e, f]:
             x + x
-
-    def test_setdiag_csc(self):
-        # see gh-21791 setting mixture of existing and not when new_values < 0.001*nnz
-        D = self.dia_container(([np.arange(1002)], [0]), shape=(1002, 1002))
-        A = self.spcreator(D)
-        A.setdiag(5 * np.ones(A.shape[0]))
-        assert A[-1, -1] == 5
 
 
 TestCSC.init_class()


### PR DESCRIPTION
#### Reference issue
Fixes #23644,

#### What does this implement/fix?
This PR:

* fixes #23644 by sorting COO indices in `_cs_matrix._setdiag`.
* refactors `mask` -> `is_existing` and `is_new` in `_setdiag`.
* fixes the condition for converting to COO format in `_setdiag`.
* adds tests for the logic branches in `_setdiag`.

This PR checks whether `has_sorted_indices` is set in the COO branch, and sorts the
newly-created diagonal indices accordingly.

It also updates the condition for converting to COO format in `_setdiag`.
The previous condition was:

```python
self.nnz - mask.sum() < self.nnz * 0.001
```

where `mask` was the logical array that was True for existing elements
on the `k`-th diagonal. This condition did not have the intended effect
when there were non-zeros *not* on the diagonal being set. The new
condition is:

```python
N_new < self.nnz * 0.001
```

where `N_new` is the number of non-existing elements on the `k`-th
diagonal.

This PR also refactors the `mask` array to be named explicitly
`is_existing` because it represents the logical indexing of existing
elements. Similarly, `is_new = ~is_existing`.

This PR creates a new mixin class for testing the
`_cs_matrix._setdiag` function branches from gh-19962. 

The existing `test_setdiag_cs[cr]` methods are now encompassed by the
`_CompressedMixin.test_setdiag_noconvert` method. Remove them to avoid
repeating logic and redundant tests.

#### Additional information
Just to note, the `_cs_matrix._setdiag` function, and similarly the `_coo_base._setdiag` function, cannot create duplicate
entries, so we don't actually need to check `has_canonical_format` or run
`sum_duplicates()`. Both `_setdiag` functions allow explicit zeros,
but that is not part of the SciPy definition of "canonical" format. Thus, we can just check `has_sorted_indices` and run
`sort_indices()` if necessary.

