### PR TITLE
MAINT: linalg.hankel: warn against changing behavior for multidimensional arrays

### DIFF
--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import numpy as np
 from numpy.lib.stride_tricks import as_strided
@@ -146,7 +147,7 @@ def circulant(c):
 
 
 def hankel(c, r=None):
-    """
+    r"""
     Construct a Hankel matrix.
 
     The Hankel matrix has constant anti-diagonals, with `c` as its
@@ -159,13 +160,17 @@ def hankel(c, r=None):
     Parameters
     ----------
     c : array_like
-        First column of the matrix. Whatever the actual shape of `c`, it
-        will be converted to a 1-D array.
+        First column of the matrix.
     r : array_like, optional
         Last row of the matrix. If None, ``r = zeros_like(c)`` is assumed.
         r[0] is ignored; the last row of the returned matrix is
-        ``[c[-1], r[1:]]``. Whatever the actual shape of `r`, it will be
-        converted to a 1-D array.
+        ``[c[-1], r[1:]]``.
+
+        .. warning::
+
+            Beginning in SciPy 1.19, multidimensional input will be treated as a batch,
+            not ``ravel``\ ed. To preserve the existing behavior, ``ravel`` arguments
+            before passing them to `toeplitz`.
 
     Returns
     -------
@@ -191,11 +196,19 @@ def hankel(c, r=None):
            [4, 7, 7, 8, 9]])
 
     """
-    c = np.asarray(c).ravel()
+    c = np.asarray(c)
     if r is None:
         r = np.zeros_like(c)
     else:
-        r = np.asarray(r).ravel()
+        r = np.asarray(r)
+
+    if c.ndim > 1 or r.ndim > 1:
+        msg = ("Beginning in SciPy 1.19, multidimensional input will be treated as a "
+               "batch, not `ravel`ed. To preserve the existing behavior and silence "
+               "this warning, `ravel` arguments before passing them to `hankel`.")
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+        c, r = c.ravel(), r.ravel()
+
     # Form a 1-D array of values to be used in the matrix, containing `c`
     # followed by r[1:].
     vals = np.concatenate((c, r[1:]))

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -588,6 +588,7 @@ class TestConvolutionMatrix:
                                      (convolution_matrix, (5, 'same')),
                                      (fiedler, ()),
                                      (fiedler_companion, ()),
+                                     (hankel, (np.arange(9),)),
                                      (leslie, (np.arange(9),)),
                                      (toeplitz, (np.arange(9),)),
                                      ])
@@ -596,6 +597,12 @@ def test_batch(f, args):
     batch_shape = (2, 3)
     m = 10
     A = rng.random(batch_shape + (m,))
+
+    if f in {hankel}:
+        message = "Beginning in SciPy 1.19, multidimensional input will be..."
+        with pytest.warns(FutureWarning, match=message):
+            f(A, *args)
+        return
 
     res = f(A, *args)
     ref = np.asarray([f(a, *args) for a in A.reshape(-1, m)])


### PR DESCRIPTION
#### Reference issue
Toward gh-21466
Addendum to gh-22193

#### What does this implement/fix?
Like `linalg.toeplitz`, `linalg.solve_toeplitz`, and `linalg.matmul_toeplitz` did, `linalg.hankel` currently documents that `c` and `r` with dimensionality greater than 1 will be `ravel`ed.

gh-21446 and gh-22193 added warnings that the `toeplitz` functions would no longer `ravel` in 1.17; rather, multidimensional arrays would be treated as batches of 1-D arrays.

This adds a similar warning to `linalg.hankel`. It also removes the documentation that n-D arrays will be raveled; it is still implicit in the admonition, and we don't really want to advertise it for new uses.

#### Additional information
Discussion post in https://discuss.scientific-python.org/t/maint-linalg-hankel-warn-against-changing-behavior-for-multidimensional-arrays/2129