### PR TITLE
BUG: linalg:solve...are: fix bug when optional array is skipped

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1175,7 +1175,8 @@ def _apply_over_batch(*argdefs):
             # Main loop
             results = []
             for index in np.ndindex(batch_shape):
-                result = f(*(array[index] for array in arrays), *other_args, **kwargs)
+                result = f(*((array[index] if array is not None else None)
+                             for array in arrays), *other_args, **kwargs)
                 # Assume `result` is either a tuple or single array. This is easily
                 # generalized by allowing the contributor to pass an `unpack_result`
                 # callable to the decorator factory.

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -339,7 +339,6 @@ def solve_discrete_lyapunov(a, q, method=None):
     return x
 
 
-@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2))
 def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
     r"""
     Solves the continuous-time algebraic Riccati equation (CARE).
@@ -368,6 +367,11 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
     is solved. When omitted, ``e`` is assumed to be the identity and ``s``
     is assumed to be the zero matrix with sizes compatible with ``a`` and
     ``b``, respectively.
+
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
     Parameters
     ----------
@@ -458,7 +462,12 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
     True
 
     """
+    # ensure that all arguments are present when using `_apply_over_batch` (gh-23336)
+    return _solve_continuous_are(a, b, q, r, e, s, balanced)
 
+
+@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2))
+def _solve_continuous_are(a, b, q, r, e, s, balanced):
     # Validate input arguments
     a, b, q, r, e, s, m, n, r_or_c, gen_are = _are_validate_args(
                                                      a, b, q, r, e, s, 'care')
@@ -545,7 +554,6 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
     return (x + x.conj().T)/2
 
 
-@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2))
 def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
     r"""
     Solves the discrete-time algebraic Riccati equation (DARE).
@@ -573,6 +581,11 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
 
     is solved. When omitted, ``e`` is assumed to be the identity and ``s``
     is assumed to be the zero matrix.
+
+    The documentation is written assuming array arguments are of specified
+    "core" shapes. However, array argument(s) of this function may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 
     Parameters
     ----------
@@ -666,7 +679,12 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
     True
 
     """
+    # ensure that all arguments are present when using `_apply_over_batch` (gh-23336)
+    return _solve_discrete_are(a, b, q, r, e, s, balanced)
 
+
+@_apply_over_batch(('a', 2), ('b', 2), ('q', 2), ('r', 2), ('e', 2), ('s', 2))
+def _solve_discrete_are(a, b, q, r, e, s, balanced):
     # Validate input arguments
     a, b, q, r, e, s, m, n, r_or_c, gen_are = _are_validate_args(
                                                      a, b, q, r, e, s, 'dare')

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -388,8 +388,15 @@ class TestBatch:
         b = b + 5*np.eye(5)
         q = q + 5*np.eye(5)
         r = r + 5*np.eye(5)
-        # can't easily generate valid random e, s
+        e = np.eye(5)
+        s = np.zeros((5, 5))
         self.batch_test(fun, (a, b, q, r))
+        self.batch_test(fun, (a, b, q, r, e))
+        self.batch_test(fun, (a, b, q, r, e, s))
+
+        res = fun(a, b, q, r)
+        ref = fun(a, b, q, r, s=s)
+        np.testing.assert_allclose(res, ref)
 
     @pytest.mark.parametrize('dtype', floating)
     def test_rsf2cs(self, dtype):

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -577,6 +577,22 @@ class TestSolveDiscreteAre:
         assert_raises(LinAlgError, solve_continuous_are, A, B, Q, R)
 
 
+class TestSolveCommonAre:
+    @pytest.mark.parametrize("solver", [solve_continuous_are, solve_discrete_are])
+    def test_with_skipped_array_argument_gh23336(self, solver):
+        # gh-23336 reported a failure when optional argument `e` was skipped
+        A = np.array([[-0.9, 0.25], [0, -1.1]])
+        B = np.array([[0.23], [0.45]])
+        Q = np.eye(2)
+        R = np.atleast_2d(0.45)
+        E = np.eye(2)
+        S = np.array([[0.1], [0.2]])
+
+        res = solver(A, B, Q, R, s=S)
+        ref = solver(A, B, Q, R, E, S)
+        np.testing.assert_allclose(res, ref)
+
+
 def test_solve_generalized_continuous_are():
     cases = [
         # Two random examples differ by s term


### PR DESCRIPTION
#### Reference issue
Closes gh-23336

#### What does this implement/fix?
gh-23336 reported that `linalg.solve_continuous_are` failed when the optional array argument `e` was skipped. This fixes the bug in `solve_continuous_are` and `solve_discrete_are` removing the decorator from the public function. Then, when all array arguments are available (possibly with default value), a private function with the decorator is used to produce the result.

#### Additional information
I think these are the only batched `linalg` functions that allow an array argument to be skipped. Please check me on that.
