### PR TITLE
MAINT: sparse: avoid recent free-threading `test_matrix_io.py` failures

### DIFF
--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -75,18 +75,17 @@ def test_sparray_vs_spmatrix():
 
 @pytest.mark.parametrize("value", [0, 1.2])
 @pytest.mark.parametrize("ndim", [1, 2, 3])
-def test_nd_coo_format(ndim, value, tmpdir):
+def test_nd_coo_format(ndim, value):
     A = coo_array([value]).reshape((1,) * ndim)
 
     #save/load array
-    with tmpdir.as_cwd():
-        tmpfile = "f.npz"
-
-        try:
-            save_npz(tmpfile, A)
-            loaded_A = load_npz(tmpfile)
-        finally:
-            os.remove(tmpfile)
+    fd, tmpfile = tempfile.mkstemp(suffix='.npz')
+    os.close(fd)
+    try:
+        save_npz(tmpfile, A)
+        loaded_A = load_npz(tmpfile)
+    finally:
+        os.remove(tmpfile)
 
     assert isinstance(loaded_A, coo_array)
     assert_(loaded_A.shape == A.shape)

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -82,8 +82,11 @@ def test_nd_coo_format(ndim, value, tmpdir):
     with tmpdir.as_cwd():
         tmpfile = "f.npz"
 
-        save_npz(tmpfile, A)
-        loaded_A = load_npz(tmpfile)
+        try:
+            save_npz(tmpfile, A)
+            loaded_A = load_npz(tmpfile)
+        finally:
+            os.remove(tmpfile)
 
     assert isinstance(loaded_A, coo_array)
     assert_(loaded_A.shape == A.shape)


### PR DESCRIPTION
I've been seeing quite a few `freethread (1)` CI failures with origins in `sparse/tests/test_matrix_io.py` since my PR #23465 was merged. I think the `tmpdir` idiom in the test is not closing the tmpfile used so an exception is raised.

For example: https://github.com/scipy/scipy/actions/runs/18046087738/job/51357077699
shows errors occurring in two tests -- the test changed here, as well as an unrelated test that I think is getting caught in trouble due to parallel garbage collection. The test I've changed in this PR is always involved and the other one changes from failure to failure.  Unfortunately the failures do not even always happen.

I thought about skipping this test for the threadsafe tests, but realized we are no longer closing the file. So I'm just adding back code to close the file.