### PR TITLE
MAINT: optimize: fix usage of `nextafter(..., where=)` without `out=`.

### DIFF
--- a/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
+++ b/scipy/optimize/_trustregion_constr/minimize_trustregion_constr.py
@@ -338,8 +338,10 @@ def _minimize_trustregion_constr(fun, x0, args, grad,
         verbose = 1
 
     if bounds is not None:
-        modified_lb = np.nextafter(bounds.lb, -np.inf, where=bounds.lb > -np.inf)
-        modified_ub = np.nextafter(bounds.ub, np.inf, where=bounds.ub < np.inf)
+        modified_lb = np.nextafter(bounds.lb, -np.inf, where=bounds.lb > -np.inf,
+                                   out=None)
+        modified_ub = np.nextafter(bounds.ub, np.inf, where=bounds.ub < np.inf,
+                                   out=None)
         modified_lb = np.where(np.isfinite(bounds.lb), modified_lb, bounds.lb)
         modified_ub = np.where(np.isfinite(bounds.ub), modified_ub, bounds.ub)
         bounds = Bounds(modified_lb, modified_ub, keep_feasible=bounds.keep_feasible)


### PR DESCRIPTION
This raises a warning now (after https://github.com/numpy/numpy/pull/29813) because it returns uninitialized memory. The usage seems correct, so I left the code as is, although the performance difference of using `where=` over `np.where` is probably negligible.

Fixes CI failures in jobs using numpy nightlies that look like:
```
 FAILED scipy/optimize/tests/test_minimize_constrained.py::test_gh11649 - UserWarning: 'where' used without 'out', expect unitialized memory in output. If this is intentional, use out=None.
```