### PR TITLE
DOC: Add missing toctree captions for having subheaders in the left sidebar.

### DIFF
--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -423,6 +423,7 @@ Customizing builds
 ------------------
 
 .. toctree::
+   :caption: Customizing builds
    :maxdepth: 1
 
    compilers_and_options
@@ -435,6 +436,7 @@ Background information
 ----------------------
 
 .. toctree::
+   :caption: Background information
    :maxdepth: 1
 
    understanding_meson

--- a/doc/source/dev/api-dev/api-dev-toc.rst
+++ b/doc/source/dev/api-dev/api-dev-toc.rst
@@ -6,6 +6,7 @@ SciPy API Development Guide
 
 .. toctree::
    :maxdepth: 1
+   :caption: API Development Guide
 
    nan_policy
    special_ufuncs

--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -407,6 +407,7 @@ feasability are demonstrated.
 
 .. toctree::
    :hidden:
+   :caption: API Coverage
 
    array_api_modules_tables/cluster_vq
    array_api_modules_tables/cluster_hierarchy

--- a/doc/source/dev/contributor/contributor_toc.rst
+++ b/doc/source/dev/contributor/contributor_toc.rst
@@ -91,6 +91,7 @@ Compiled code
 
 .. toctree::
     :hidden:
+    :caption: Contributor Guide
 
     development_workflow
     pep8

--- a/doc/source/dev/gitwash/gitwash.rst
+++ b/doc/source/dev/gitwash/gitwash.rst
@@ -20,6 +20,8 @@ Contents:
 
 .. toctree::
    :maxdepth: 2
+   :caption: Git for development
+
 
    development_setup
    configure_git

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -37,6 +37,8 @@ the organization section.
 .. This toctree defines previous/next for contributor guide documents
 .. toctree::
    :hidden:
+   :caption: Contributor Guide
+
 
    contributor/development_workflow
    contributor/pep8

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -160,6 +160,7 @@ change is made.
   - `scipy.stats.sampling`
 
 .. toctree::
+   :caption: SciPy Modules
    :maxdepth: 1
    :hidden:
    :titlesonly:

--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -6,7 +6,9 @@ This is the list of changes to SciPy between each release. For full details,-not
 see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
 
 .. toctree::
+   :caption: Releases
    :maxdepth: 1
+
 
    release/1.17.0-notes
    release/1.16.2-notes


### PR DESCRIPTION
Not every "section" in the documentation displays a sub-header in the left sidebar, like the "User Guide" section does:

<img width="296" height="173" alt="image" src="https://github.com/user-attachments/assets/d7ebb954-aeb0-4e53-941e-2468a34c0395" />

This sub-header is defined by the `:caption:` option in the `toctree`, i.e., by:
```rst
.. toctree::
   :caption: User guide
   :maxdepth: 1
   :hidden:
```
This PR adds missing `:caption:` entries to make the left sidebar more useful.