### PR TITLE
MAINT: Remove 'o' (Greek omicron) from allowed symbols.

### DIFF
--- a/tools/check_unicode.py
+++ b/tools/check_unicode.py
@@ -16,7 +16,7 @@ from get_submodule_paths import get_submodule_paths
 #
 # BEGIN_INCLUDE_RST (do not change this line!)
 latin1_letters = set(chr(cp) for cp in range(192, 256))
-greek_letters = set('αβγδεζηθικλμνξoπρστυϕχψω' + 'ΓΔΘΛΞΠΣϒΦΨΩ')
+greek_letters = set('αβγδεζηθικλμνξπρστυϕχψω' + 'ΓΔΘΛΞΠΣϒΦΨΩ')
 box_drawing_chars = set(chr(cp) for cp in range(0x2500, 0x2580))
 extra_symbols = set('®ő∫≠≥≤±∞²³·→√✅⛔⚠️')
 allowed = latin1_letters | greek_letters | box_drawing_chars | extra_symbols


### PR DESCRIPTION
This small PR removes the small latin letter 'o' from the constant `greek_letters` in `tools/unicode.py`, which is used by the command `spin lint`. Note that it should have been the Unicode symbol "\N{GREEK SMALL LETTER OMICRON}", which is very hard to distinguish from the latin letter.

Verifying the the entries of  `greek_letters`  can be achieved by executing the following
commands in an interpreter running in the `tool` sub-directory:
 ```python
>>> import unicodedata
... from check_unicode import greek_letters
... 
... for s in sorted(greek_letters):
...     print(f"'{s}': {unicodedata.name(s)}")     
'o': LATIN SMALL LETTER O
'Γ': GREEK CAPITAL LETTER GAMMA
'Δ': GREEK CAPITAL LETTER DELTA
'Θ': GREEK CAPITAL LETTER THETA
...
```
The "o" is removed, since it cannot be distinguished from an omicron:
```python
>>> "\N{GREEK SMALL LETTER OMICRON}\N{LATIN SMALL LETTER O}"
'οo'
```

PS: The `extra_symbols` constant, i.e.,
```python
extra_symbols = set('®ő∫≠≥≤±∞²³·→√✅⛔⚠️')
```
contains the length 2 symbol  '⚠️'. I.e.:
```python
>>> import unicodedata
... 
>>> w_sign = '⚠️'
>>> len(w_sign)
2
>>> for s in sorted(w_sign):
...     print(f"'{s}': {unicodedata.name(s)}")
'⚠': WARNING SIGN
'️': VARIATION SELECTOR-16
```
Changing  '⚠️' into a single symbol results in  '⚠️' results in '⚠'. I didn't have any good idea on how to treat  '⚠️' as a single symbol, in [check_unicode]. So I made no changes in this regard.

[check_unicode]: https://github.com/scipy/scipy/blob/5f07547bff1fad8b89d376a5f7fa5c0b3dba30d7/tools/check_unicode.py#L26
