### PR TITLE
MAINT: stats.pmean: enforce finite `p` requirement

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -457,6 +457,10 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
         return gmean(a, axis=axis, dtype=dtype, weights=weights)
     elif math.isinf(p):
         fun = xp.max if p > 0 else xp.min
+        if weights is not None:
+            zero_weight_fun = xp.min if p > 0 else xp.max
+            a_zero_weight = zero_weight_fun(a, axis=None)
+            a = xpx.at(a, weights==0).set(a_zero_weight)
         return fun(a, axis=axis)
 
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -350,8 +350,7 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
 
         \left( \frac{ 1 }{ n } \sum_{i=1}^n a_i^p \right)^{ 1 / p }  \, .
 
-    When ``p=0``, it returns the geometric mean; when ``p=math.inf``, it returns
-    the maximum; and when ``p=-math.inf``, it returns the minimum.
+    When ``p=0``, it returns the geometric mean.
 
     This mean is also called generalized mean or Hölder mean, and must not be
     confused with the Kolmogorov generalized mean, also called
@@ -362,7 +361,7 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
     a : array_like
         Input array, masked array or object that can be converted to an array.
     p : int or float
-        Exponent.
+        Exponent. Must be finite.
     axis : int or None, optional
         Axis along which the power mean is computed. Default is 0.
         If None, compute over the whole array `a`.
@@ -436,6 +435,11 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
     if not isinstance(p, int | float):
         raise ValueError("Power mean only defined for exponent of type int or "
                          "float.")
+    if p == 0:
+        return gmean(a, axis=axis, dtype=dtype, weights=weights)
+    elif math.isinf(p):
+        message = "Power mean only implemented for finite `p`"
+        raise NotImplementedError(message)
 
     xp = array_namespace(a, weights)
     a = xp.asarray(a, dtype=dtype)
@@ -452,16 +456,6 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
         message = ("The power mean is only defined if all elements are "
                    "non-negative; otherwise, the result is NaN.")
         warnings.warn(message, RuntimeWarning, stacklevel=2)
-
-    if p == 0:
-        return gmean(a, axis=axis, dtype=dtype, weights=weights)
-    elif math.isinf(p):
-        fun = xp.max if p > 0 else xp.min
-        if weights is not None:
-            zero_weight_fun = xp.min if p > 0 else xp.max
-            a_zero_weight = zero_weight_fun(a, axis=None)
-            a = xpx.at(a, weights==0).set(a_zero_weight)
-        return fun(a, axis=axis)
 
     with np.errstate(divide='ignore', invalid='ignore'):
         return _xp_mean(a**float(p), axis=axis, weights=weights)**(1/p)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6,7 +6,6 @@
 
     Additional tests by a host of SciPy developers.
 """
-import math
 import os
 import re
 import warnings
@@ -7013,20 +7012,10 @@ class TestPMean:
 
     def test_infinite_p_gh23111(self):
         # gh-23111 reported that `pmean` didn't work properly with infinite `p`;
-        # check that the example from the issue is resolved
-        assert stats.pmean([2], np.inf) == 2.0
-
-    @pytest.mark.parametrize("dtype", [np.int32, np.float64, None])
-    @pytest.mark.parametrize("axis", [0, 1, None])
-    @pytest.mark.parametrize("weighted", [False, True])
-    def test_infinite_p_gh23111b(self, xp, dtype, axis, weighted):
-        rng = np.random.default_rng(2359823495872948752)
-        size = (5, 6)
-        a = xp.asarray(rng.integers(100, size=size).astype(dtype))
-        w = xp.asarray(rng.integers(100, size=size).astype(dtype)) if weighted else None
-        kwargs = dict(weights=w, axis=axis, xp=xp)
-        check_equal_pmean(a, math.inf, xp.max(a, axis=axis), **kwargs)
-        check_equal_pmean(a, -math.inf, xp.min(a, axis=axis), **kwargs)
+        # check that this raises an appropriate error message
+        message = "Power mean only implemented for finite `p`"
+        with pytest.raises(NotImplementedError, match=message):
+            stats.pmean([2], np.inf)
 
 
 @make_xp_test_case(stats.gstd)


### PR DESCRIPTION
#### Reference issue
Closes gh-23111

#### What does this implement/fix?
I started to correct `scipy.stats.pmean` when `p` is infinite by adding special cases, but there are a lot of degenerate cases to consider/test that don't just fall out of the obvious implementation. Beyond zero weights (mentioned in the issue), one would need to consider _all_ zero weights, infinite weights, weight and value arrays with incompatible shapes, etc. So I decided to just document the limitation that `p` must be finite and raise an error for infinite `p`.