### PR TITLE
TST: special: avoid extremely slow edge cases in `mpmath` tests

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1573,7 +1573,7 @@ class TestSystematic:
             lambda n, a, b, x: sc.eval_jacobi(int(n), a, b, x),
             lambda n, a, b, x: exception_to_nan(jacobi)(n, a, b, x, **HYPERKW),
             [IntArg(), Arg(), Arg(), Arg()],
-            n=20000,
+            n=4095,
             dps=50,
         )
 


### PR DESCRIPTION
This PR reduces `spin test --no-build -t scipy.special.tests.test_mpmath::TestSystematic::test_jacobi_int -m full` from >5 mins (I didn't wait the whole time out, but a CI run in gh-23654 showed about half an hour!), to <1 second on my machine.

See prior investigation at
https://github.com/scipy/scipy/pull/23654#issuecomment-3342109949. Quoting from there:

> Explanation for the power of 2 cutoff: `n=4096` translates to a jump to `n==6` from `n==5` at
> 
> https://github.com/scipy/scipy/blob/f466f35b7d0ed33e6fd697cceccef175e256f074/scipy/special/_mptestutils.py#L39
> 
> For negative inf `a` and positive inf `b` (the defaults for `Arg`), and `n==5`, the "logspace between 10 and b"
> 
> https://github.com/scipy/scipy/blob/f466f35b7d0ed33e6fd697cceccef175e256f074/scipy/special/_mptestutils.py#L75-L77
> 
> is just
> 
> ```
> (Pdb) logpts2
> array([10.])
> ```
> 
> but for `n==6`, it is
> 
> ```
> (Pdb) logpts2
> array([1.00000000e+001, 8.98846567e+307])
> ```

The slowness appears to come not from edge cases in `mpmath`, but in `xsf`. It seems that calls to `xsf::cephes::detail::hyt2f1` are very slow with `b=-8.9884656743110496E+307`, or in fact any suitably large `b`. This can be observed in Python, with 

```python
In [3]: %time scipy.special.hyp2f1(10, -1e20, -5.5, 5)
CPU times: user 9.49 s, sys: 36.3 ms, total: 9.53 s
Wall time: 9.54 s
Out[3]: np.float64(nan)
```

Not sure if we are expecting `xsf` to more quickly spit out a `nan` here @steppi @WarrenWeckesser ? If we expect it to be this slow, then maybe the `test_mpmath` infra should be reworked to not pass such large values. It makes a very large amount of such calls when `n>=4096` in this test, hence why this PR fixes the problem.

Either way, it seems fine to merge this for now, as @rgommers suggested in gh-23654.