### PR TITLE
MAINT: stats.rv_discrete.ppf/isf: fix behavior with array args, `q=0`/`q=1`

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3771,12 +3771,14 @@ class rv_discrete(rv_generic):
         _a, _b = self._get_support(*args)
         cond0 = self._argcheck(*args) & (loc == loc)
         cond1 = (q > 0) & (q < 1)
-        cond2 = (q == 1) & cond0
+        cond2 = (q == 0) & cond0
+        cond3 = (q == 1) & cond0
         cond = cond0 & cond1
         output = np.full(shape(cond), fill_value=self.badvalue, dtype='d')
         # output type 'd' to handle nin and inf
-        place(output, (q == 0)*(cond == cond), _a-1 + loc)
-        place(output, cond2, _b + loc)
+
+        place(output, cond2, argsreduce(cond2, _a-1 + loc)[0])
+        place(output, cond3, argsreduce(cond3, _b + loc)[0])
         if np.any(cond):
             goodargs = argsreduce(cond, *((q,)+args+(loc,)))
             loc, goodargs = goodargs[-1], goodargs[:-1]
@@ -3827,8 +3829,8 @@ class rv_discrete(rv_generic):
         # output type 'd' to handle nin and inf
         lower_bound = _a - 1 + loc
         upper_bound = _b + loc
-        place(output, cond2*(cond == cond), lower_bound)
-        place(output, cond3*(cond == cond), upper_bound)
+        place(output, cond2, argsreduce(cond2, lower_bound)[0])
+        place(output, cond3, argsreduce(cond3, upper_bound)[0])
 
         # call place only if at least 1 valid argument
         if np.any(cond):

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -600,7 +600,8 @@ def test_gh18919_ppf_array_args():
     res = stats.binom.ppf(q, n, p)
     np.testing.assert_allclose(res, ref)
 
-def test_gh18919_ppf_isf_array_args2():
+@pytest.mark.parametrize("dist", [stats.binom, stats.boltzmann])
+def test_gh18919_ppf_isf_array_args2(dist):
     # a more general version of the test above. Requires that arguments are broadcasted
     # by the infrastructure.
     rng = np.random.default_rng(34873457824358729823)
@@ -612,12 +613,12 @@ def test_gh18919_ppf_isf_array_args2():
     q[rng.random(size=30) > 0.7] = 0
     q[rng.random(size=30) > 0.7] = 1
 
-    res = stats.binom.ppf(q, n, p, loc=loc)
-    ref = _ufuncs._binom_ppf(q, n, p) + loc
-    ref[np.broadcast_to(q, ref.shape) == 0] -= 1
+    args = (q, n, p) if dist == stats.binom else (q, p, n)
+
+    res = dist.ppf(*args, loc=loc)
+    ref = np.vectorize(dist.ppf)(*args) + loc
     np.testing.assert_allclose(res, ref)
 
-    res = stats.binom.isf(q, n, p, loc=loc)
-    ref = _ufuncs._binom_isf(q, n, p) + loc
-    ref[np.broadcast_to(q, ref.shape) == 1] -= 1
+    res = dist.isf(*args, loc=loc)
+    ref = np.vectorize(dist.isf)(*args) + loc
     np.testing.assert_allclose(res, ref)

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from scipy import stats
+from scipy.special import _ufuncs
 from .common_tests import (check_normalization, check_moment,
                            check_mean_expect,
                            check_var_expect, check_skew_expect,
@@ -579,3 +580,44 @@ def test__pmf_float_input():
     rv = rv_exponential(a=0.0, b=float('inf'))
     rvs = rv.rvs(random_state=42)  # should not crash due to integer input to `_pmf`
     assert_allclose(rvs, 0)
+
+
+def test_gh18919_ppf_array_args():
+    # gh-18919 reported incorrect results for ppf and isf of discrete distributions when
+    # arguments were arrays and first argument (`q`) had elements at the boundaries of
+    # the support.
+    q = [[0.5, 1.0, 0.5],
+         [1.0, 0.5, 1.0],
+         [0.5, 1.0, 0.5]]
+
+    n = [[45, 46, 47],
+         [48, 49, 50],
+         [51, 52, 53]]
+
+    p = 0.5
+
+    ref = _ufuncs._binom_ppf(q, n, p)
+    res = stats.binom.ppf(q, n, p)
+    np.testing.assert_allclose(res, ref)
+
+def test_gh18919_ppf_isf_array_args2():
+    # a more general version of the test above. Requires that arguments are broadcasted
+    # by the infrastructure.
+    rng = np.random.default_rng(34873457824358729823)
+    q = rng.random(size=(30, 1, 1, 1))
+    n = rng.integers(10, 30, size=(10, 1, 1))
+    p = rng.random(size=(4, 1))
+    loc = rng.integers(5, size=(3,))
+
+    q[rng.random(size=30) > 0.7] = 0
+    q[rng.random(size=30) > 0.7] = 1
+
+    res = stats.binom.ppf(q, n, p, loc=loc)
+    ref = _ufuncs._binom_ppf(q, n, p) + loc
+    ref[np.broadcast_to(q, ref.shape) == 0] -= 1
+    np.testing.assert_allclose(res, ref)
+
+    res = stats.binom.isf(q, n, p, loc=loc)
+    ref = _ufuncs._binom_isf(q, n, p) + loc
+    ref[np.broadcast_to(q, ref.shape) == 1] -= 1
+    np.testing.assert_allclose(res, ref)


### PR DESCRIPTION
#### Reference issue
Closes gh-18919

### What does this implement/fix?
gh-18919 reported strange behavior in discrete distribution ppf/isf when arguments are arrays and `q=0`/`q=1`.
In essence it's this gotcha:
```python3
import numpy as np
x = np.asarray([1, 2, 3, 4])
np.place(x, x > 2, 2*x)
x  
# expected:  array([1, 2, 6, 8])
# got:       array([1, 2, 2, 4])
```
From [`np.place` ](https://numpy.org/doc/2.1/reference/generated/numpy.place.html) documentation of the third argument, `vals`:
> Only the first N elements are used, where N is the number of True values in `mask`.

So when `vals` has too many elements, no error is raised; it just starts taking elements from the left.

Looks like this bug has been around since the beginning, or at least since uses of `insert` were replaced with `place`. The same bug was fixed for continuous distributions in https://github.com/scipy/scipy/commit/126d5bf9b96e137f1199c1767962adb3497e1041 but the discrete distributions were not done at the same time.