### PR TITLE
MAINT: stats.multivariate_t.logpdf/pdf: fix infinite DOF special case

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -5128,10 +5128,12 @@ class multivariate_t_gen(multi_rv_generic):
         dim, loc, shape, df = self._process_parameters(loc, shape, df)
         x = self._process_quantiles(x, dim)
         shape_info = _PSD(shape)
-        return self._logpdf(x, loc, shape_info.U, shape_info.log_pdet, df, dim,
-                            shape_info.rank)
+        cov_object = _covariance.CovViaPSD(shape_info)
 
-    def _logpdf(self, x, loc, prec_U, log_pdet, df, dim, rank):
+        return self._logpdf(x, loc, shape_info.U, shape_info.log_pdet, df, dim,
+                            shape_info.rank, cov_object)
+
+    def _logpdf(self, x, loc, prec_U, log_pdet, df, dim, rank, cov_object=None):
         """Utility method `pdf`, `logpdf` for parameters.
 
         Parameters
@@ -5160,7 +5162,7 @@ class multivariate_t_gen(multi_rv_generic):
 
         """
         if df == np.inf:
-            return multivariate_normal._logpdf(x, loc, prec_U, log_pdet, rank)
+            return multivariate_normal._logpdf(x, loc, cov_object)
 
         dev = x - loc
         maha = np.square(np.dot(dev, prec_U)).sum(axis=-1)

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -3708,6 +3708,29 @@ class TestMultivariateT:
         _entropy2 = stats.multivariate_t.entropy(shape=cov, df=df2)
         assert_allclose(_entropy1, _entropy2, rtol=1e-5)
 
+    def test_logpdf_df_inf_gh19930(self):
+        # `multivariate_t._logpdf` (and `logpdf`/`pdf`) was not working with infinite
+        # `df` after an update to `multivariate_normal._logpdf`.
+
+        # Reproducible example from the issue
+        res = multivariate_t.logpdf(1, 1, 1, df=np.inf)
+        ref = multivariate_normal.logpdf(1, 1, 1)
+        assert_allclose(res, ref)
+
+        # More extensive test
+        # Generate a valid multivariate normal distribution and corresponding MVT
+        rng = np.random.default_rng(324893259825)
+        mean = rng.random(3)
+        cov = rng.random((3, 3)) + np.eye(3)*3
+        cov = cov.T + cov
+        X = multivariate_normal(mean=mean, cov=cov)
+        Y = multivariate_t(loc=mean, shape=cov, df=np.inf)
+
+        # compare the pdf and logpdf at 10 random points
+        x = X.rvs(10)
+        assert_allclose(Y.logpdf(x), X.logpdf(x))
+        assert_allclose(Y.pdf(x), X.pdf(x))
+
 
 class TestMultivariateHypergeom:
     @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference issue
Closes gh-19930

#### What does this implement/fix?
`multivariate_t._logpdf` resorts to `multivariate_normal._logpdf` when `df` is infinite. When `multivariate_normal._logpdf` was updated, this feature broke, but it wasn't caught by tests. This fixes the failure and adds a test.
