### PR TITLE
DOC: correct typo in `factorialk` parameters doc

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3052,7 +3052,7 @@ def factorialk(n, k, exact=False, extend="zero"):
     n : int or float or complex (or array_like thereof)
         Input values for multifactorial. Non-integer values require
         ``extend='complex'``. By default, the return value for ``n < 0`` is 0.
-    n : int or float or complex (or array_like thereof)
+    k : int or float or complex (or array_like thereof)
         Order of multifactorial. Non-integer values require ``extend='complex'``.
     exact : bool, optional
         If ``exact`` is set to True, calculate the answer exactly using


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes https://github.com/scipy/scipy/issues/23703

#### What does this implement/fix?
Corrects a minor typo in the parameters documentation of `scipy.special.factorialk`

<!--#### Additional information-->
<!--Any additional information you think is important.-->
