### PR TITLE
TST: stats.Binomial.logcdf: improves precision in tails

### DIFF
--- a/scipy/stats/_new_distributions.py
+++ b/scipy/stats/_new_distributions.py
@@ -479,22 +479,22 @@ class Binomial(DiscreteDistribution):
         return scu._binom_cdf(x, n, p)
 
     def _logcdf_formula(self, x, *, n, p, **kwargs):
-        # todo: add this strategy to infrastructure more generally while avoiding
-        # expensive calculations to figure out which tail we're in
-        mode = self._mode_formula(n=n, p=p)
-        return xpx.apply_where(x < mode, (x, n, p),
+        # todo: add this strategy to infrastructure more generally, but allow dist
+        #   author to specify threshold other than median in case median is expensive
+        median = self._icdf_formula(0.5, n=n, p=p)
+        return xpx.apply_where(x < median, (x, n, p),
             lambda *args: np.log(scu._binom_cdf(*args)),
-            lambda *args: scu._log1mexp(np.log(scu._binom_sf(*args)))
+            lambda *args: np.log1p(-scu._binom_sf(*args))
         )
 
     def _ccdf_formula(self, x, *, n, p, **kwargs):
         return scu._binom_sf(x, n, p)
 
     def _logccdf_formula(self, x, *, n, p, **kwargs):
-        mode = self._mode_formula(n=n, p=p)
-        return xpx.apply_where(x > mode, (x, n, p),
-            lambda *args: np.log(scu._binom_sf(*args)),
-            lambda *args: scu._log1mexp(np.log(scu._binom_cdf(*args)))
+        median = self._icdf_formula(0.5, n=n, p=p)
+        return xpx.apply_where(x < median, (x, n, p),
+            lambda *args: np.log1p(-scu._binom_cdf(*args)),
+            lambda *args: np.log(scu._binom_sf(*args))
         )
 
     def _icdf_formula(self, x, *, n, p, **kwargs):

--- a/scipy/stats/_new_distributions.py
+++ b/scipy/stats/_new_distributions.py
@@ -3,7 +3,9 @@ import sys
 import numpy as np
 from numpy import inf
 
+from scipy._lib import array_api_extra as xpx
 from scipy import special
+from scipy.special import _ufuncs as scu
 from scipy.stats._distribution_infrastructure import (
     ContinuousDistribution, DiscreteDistribution, _RealInterval, _IntegerInterval,
     _RealParameter, _Parameterization, _combine_docs)
@@ -462,7 +464,7 @@ class Binomial(DiscreteDistribution):
         super().__init__(n=n, p=p, **kwargs)
 
     def _pmf_formula(self, x, *, n, p, **kwargs):
-        return special._ufuncs._binom_pmf(x, n, p)
+        return scu._binom_pmf(x, n, p)
 
     def _logpmf_formula(self, x, *, n, p, **kwargs):
         # This implementation is from the ``scipy.stats.binom`` and could be improved
@@ -474,16 +476,32 @@ class Binomial(DiscreteDistribution):
         return combiln + special.xlogy(x, p) + special.xlog1py(n-x, -p)
 
     def _cdf_formula(self, x, *, n, p, **kwargs):
-        return special._ufuncs._binom_cdf(x, n, p)
+        return scu._binom_cdf(x, n, p)
+
+    def _logcdf_formula(self, x, *, n, p, **kwargs):
+        # todo: add this strategy to infrastructure more generally while avoiding
+        # expensive calculations to figure out which tail we're in
+        mode = self._mode_formula(n=n, p=p)
+        return xpx.apply_where(x < mode, (x, n, p),
+            lambda *args: np.log(scu._binom_cdf(*args)),
+            lambda *args: scu._log1mexp(np.log(scu._binom_sf(*args)))
+        )
 
     def _ccdf_formula(self, x, *, n, p, **kwargs):
-        return special._ufuncs._binom_sf(x, n, p)
+        return scu._binom_sf(x, n, p)
+
+    def _logccdf_formula(self, x, *, n, p, **kwargs):
+        mode = self._mode_formula(n=n, p=p)
+        return xpx.apply_where(x > mode, (x, n, p),
+            lambda *args: np.log(scu._binom_sf(*args)),
+            lambda *args: scu._log1mexp(np.log(scu._binom_cdf(*args)))
+        )
 
     def _icdf_formula(self, x, *, n, p, **kwargs):
-        return special._ufuncs._binom_ppf(x, n, p)
+        return scu._binom_ppf(x, n, p)
 
     def _iccdf_formula(self, x, *, n, p, **kwargs):
-        return special._ufuncs._binom_isf(x, n, p)
+        return scu._binom_isf(x, n, p)
 
     def _mode_formula(self, *, n, p, **kwargs):
         # https://en.wikipedia.org/wiki/Binomial_distribution#Mode

--- a/scipy/stats/tests/meson.build
+++ b/scipy/stats/tests/meson.build
@@ -27,6 +27,7 @@ py3.install_sources([
     'test_mstats_extras.py',
     'test_multicomp.py',
     'test_multivariate.py',
+    'test_new_distributions.py',
     'test_odds_ratio.py',
     'test_qmc.py',
     'test_quantile.py',

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -622,7 +622,7 @@ def test_axis_nan_policy_axis_is_None(hypotest, args, kwds, n_samples,
     # Make sure any results returned by reference/public function are identical
     # and all attributes are *NumPy* scalars
     res1db, res1dc = unpacker(res1db), unpacker(res1dc)
-    assert_equal(res1dc, res1db)
+    assert_allclose(res1dc, res1db, rtol=1e-15)
     all_results = list(res1db) + list(res1dc)
 
     if res1da is not None:

--- a/scipy/stats/tests/test_new_distributions.py
+++ b/scipy/stats/tests/test_new_distributions.py
@@ -1,0 +1,17 @@
+# file for distribution-specific tests with new infrastructure (UnivariateDistribution)
+import numpy as np
+from numpy.testing import assert_allclose
+from scipy import stats
+
+class TestBinomial:
+    def test_gh23708_binomial_logcdf_method_complement(self):
+        # gh-23708 found that `logcdf` method='complement' was inaccurate in the tails
+        x = np.asarray([0., 18.])
+        X = stats.Binomial(n=np.asarray([18.]), p=np.asarray(0.71022842))
+        assert_allclose(X.logcdf(x, method='complement'), X.logcdf(x), rtol=1e-15)
+        assert_allclose(X.logccdf(x, method='complement'), X.logccdf(x), rtol=1e-15)
+
+        # going even deeper into the tails
+        X = stats.Binomial(n=100, p=0.5)
+        assert_allclose(X.logcdf(0, method='complement'), X.logpmf(0), rtol=1e-15)
+        assert_allclose(X.logccdf(99, method='complement'), X.logpmf(100), rtol=1e-15)


### PR DESCRIPTION
#### Reference issue
Closes gh-23708
Closes gh-23711

#### What does this implement/fix?
gh-23708 reported a hypothesis-generated test failure of `scipy.stats.Binomial.logccdf` when using the "complement" method in a tail of the distribution. This fixes that by increasing the precision of `logcdf`/`logccdf` in the "other" tail.
 
Separately, since it's a one-line fix reported at the same time (...and I accidentally committed to the wrong branch), it also fixes a test failure observed in gh-23711. It's a floating point equality test that was being performed with `assert_equal`, but it needs a small tolerance, so use `assert_allclose` with `rtol=1e-15`.