### PR TITLE
ENH: spatial: Implement `RigidTransform.mean()`

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -1049,10 +1049,9 @@ class RigidTransform:
                [ 0.51801458,  0.13833531, -0.84411151,  0.52429339],
                [0., 0., 0., 1.]])
         """
-        backend = select_backend(self._xp, cython_compatible=False)
-        mean = backend.mean(self._matrix, weights=weights)
+        mean = self._backend.mean(self._matrix, weights=weights)
         return RigidTransform._from_raw_matrix(mean, xp=self._xp,
-                                               backend=backend)
+                                               backend=self._backend)
 
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]

--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -1016,8 +1016,8 @@ class RigidTransform:
         Returns
         -------
         mean : `RigidTransform` instance
-            Object containing the mean of the transforms in the current
-            instance.
+            Single transform containing the mean of the transforms in the
+            current instance.
 
         References
         ----------
@@ -1049,18 +1049,10 @@ class RigidTransform:
                [ 0.51801458,  0.13833531, -0.84411151,  0.52429339],
                [0., 0., 0., 1.]])
         """
-        t, r = self.as_components()
-        r_mean = r.mean(weights=weights)
-        xp = array_namespace(t)
-        if weights is None:
-            t_mean = xp.mean(t, axis=tuple(range(t.ndim - 1)))
-        else:
-            axis = tuple(range(t.ndim - 1))
-            norm = xp.sum(weights[..., None], axis=axis)
-            wsum = xp.sum(t * weights[..., None], axis=axis)
-            t_mean = wsum / norm
-        mean = RigidTransform.from_components(t_mean, r_mean)
-        return mean
+        backend = select_backend(self._xp, cython_compatible=False)
+        mean = backend.mean(self._matrix, weights=weights)
+        return RigidTransform._from_raw_matrix(mean, xp=self._xp,
+                                               backend=backend)
 
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]

--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -114,6 +114,7 @@ class RigidTransform:
     as_exp_coords
     as_dual_quat
     concatenate
+    mean
     apply
     inv
     identity
@@ -982,6 +983,84 @@ class RigidTransform:
             [xpx.atleast_nd(x.as_matrix(), ndim=3, xp=xp) for x in transforms]
         )
         return RigidTransform._from_raw_matrix(matrix, xp, None)
+
+    @xp_capabilities(
+        skip_backends=[("dask.array", "missing linalg.cross/det functions")]
+    )
+    def mean(self, weights: ArrayLike | None = None) -> RigidTransform:
+        """Get the mean of the transforms.
+
+        The mean of a set of transforms is the same as the mean of its
+        rotation and translation components.
+
+        The mean used for the rotation component is the chordal L2 mean (also
+        called the projected or induced arithmetic mean) [1]_. If ``A`` is a
+        set of rotation matrices, then the mean ``M`` is the rotation matrix
+        that minimizes the following loss function:
+
+        .. math::
+
+            L(M) = \\sum_{i = 1}^{n} w_i \\lVert \\mathbf{A}_i -
+            \\mathbf{M} \\rVert^2 ,
+
+        where :math:`w_i`'s are the `weights` corresponding to each matrix.
+
+        Parameters
+        ----------
+        weights : array_like shape (..., N), optional
+            Weights describing the relative importance of the transforms. If
+            None (default), then all values in `weights` are assumed to be
+            equal. If given, the shape of `weights` must be broadcastable to
+            the transform shape. Weights must be non-negative.
+
+        Returns
+        -------
+        mean : `RigidTransform` instance
+            Object containing the mean of the transforms in the current
+            instance.
+
+        References
+        ----------
+        .. [1] Hartley, Richard, et al.,
+                "Rotation Averaging", International Journal of Computer Vision
+                103, 2013, pp. 267-305.
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> from scipy.spatial.transform import RigidTransform as Tf
+        >>> from scipy.spatial.transform import Rotation as R
+        >>> rng = np.random.default_rng(seed=123)
+
+        The mean of a set of transforms is the same as the mean of the
+        translation and rotation components:
+
+        >>> t = rng.random((4, 3))
+        >>> r = R.random(4, rng=rng)
+        >>> tf = Tf.from_components(t, r)
+        >>> tf.mean().as_matrix()
+        array([[ 0.61593485, -0.74508342,  0.25588075,  0.66999034],
+               [-0.59353615, -0.65246765, -0.47116962,  0.25481794],
+               [ 0.51801458,  0.13833531, -0.84411151,  0.52429339],
+               [0., 0., 0., 1.]])
+        >>> Tf.from_components(t.mean(axis=0), r.mean()).as_matrix()
+        array([[ 0.61593485, -0.74508342,  0.25588075,  0.66999034],
+               [-0.59353615, -0.65246765, -0.47116962,  0.25481794],
+               [ 0.51801458,  0.13833531, -0.84411151,  0.52429339],
+               [0., 0., 0., 1.]])
+        """
+        t, r = self.as_components()
+        r_mean = r.mean(weights=weights)
+        xp = array_namespace(t)
+        if weights is None:
+            t_mean = xp.mean(t, axis=tuple(range(t.ndim - 1)))
+        else:
+            axis = tuple(range(t.ndim - 1))
+            norm = xp.sum(weights[..., None], axis=axis)
+            wsum = xp.sum(t * weights[..., None], axis=axis)
+            t_mean = wsum / norm
+        mean = RigidTransform.from_components(t_mean, r_mean)
+        return mean
 
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]

--- a/scipy/spatial/transform/_rigid_transform_cy.pyx
+++ b/scipy/spatial/transform/_rigid_transform_cy.pyx
@@ -5,6 +5,7 @@ from ._rotation_cy import from_matrix as from_rot_matrix
 from ._rotation_cy import inv as rot_inv
 from ._rotation_cy import from_quat, from_rotvec
 from ._rotation_cy import as_matrix, as_quat, as_rotvec, compose_quat
+from ._rotation_cy import mean as rot_mean
 
 cimport numpy as np
 cimport cython
@@ -241,6 +242,36 @@ def pow(double[:, :, :] matrix, float n):
     elif n == 1:
         return matrix
     return from_exp_coords(as_exp_coords(matrix) * n)
+
+
+@cython.embedsignature(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def mean(double[:, :, :] matrix, weights=None):
+    if matrix.shape[0] == 0:
+        raise ValueError("Mean of an empty transform set is undefined.")
+    
+    quat = as_quat(from_rot_matrix(matrix[:, :3, :3]))
+    t = np.asarray(matrix[:, :3, 3])
+
+    if weights is None:
+        weights = np.ones(quat.shape[0])
+    else:
+        weights = np.asarray(weights)
+        if np.any(weights < 0):
+            raise ValueError("`weights` must be non-negative.")
+        if weights.ndim != 1:
+            raise ValueError(f"Expected `weights` to be 1 dimensional, got "
+                             f"{weights.shape}.")
+        if weights.shape[0] != matrix.shape[0]:
+            raise ValueError("Expected `weights` to have number of values equal to "
+                             f"number of transforms, got {weights.shape[0]} values and "
+                             f"{matrix.shape[0]} transforms.")
+
+    quat_mean = rot_mean(quat, weights=weights)
+    t_mean = np.average(t, axis=0, weights=weights)
+    r_mean = as_matrix(np.asarray([quat_mean]))
+    return _create_transformation_matrix(t_mean, r_mean, single=True)
 
 
 @cython.embedsignature(True)

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -953,16 +953,15 @@ def mean(double[:, :] quat, weights=None):
         weights = np.ones(quat.shape[0])
     else:
         weights = np.asarray(weights)
-        if weights.ndim != 1:
-            raise ValueError("Expected `weights` to be 1 dimensional, got "
-                                "shape {}.".format(weights.shape))
-        if weights.shape[0] != quat.shape[0]:
-            raise ValueError("Expected `weights` to have number of values "
-                                "equal to number of rotations, got "
-                                "{} values and {} rotations.".format(
-                                weights.shape[0], quat.shape[0]))
         if np.any(weights < 0):
             raise ValueError("`weights` must be non-negative.")
+        if weights.ndim != 1:
+            raise ValueError(f"Expected `weights` to be 1 dimensional, got "
+                             f"{weights.shape}.")
+        if weights.shape[0] != quat.shape[0]:
+            raise ValueError("Expected `weights` to have number of values equal to "
+                             f"number of rotations, got {weights.shape[0]} values and "
+                             f"{quat.shape[0]} rotations.")
 
     quat = np.asarray(quat)
     K = np.dot(weights * quat.T, quat)

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1020,7 +1020,7 @@ def test_mean(xp, ndim: int):
     dtype = xpx.default_dtype(xp)
     t = xp.asarray(rng.normal(size=(ndim,) * (ndim - 1) + (3,)), dtype=dtype)
     q = xp.asarray(rng.normal(size=(ndim,) * (ndim - 1) + (4,)), dtype=dtype)
-    r = rotation_to_xp(Rotation.from_quat(q), xp=xp)
+    r = Rotation.from_quat(q)
     tf = RigidTransform.from_components(t, r)
 
     # Unweighted mean
@@ -1055,8 +1055,7 @@ def test_mean_invalid_weights(xp):
     tf = RigidTransform.from_matrix(xp.tile(xp.eye(4), (4, 1, 1)))
     if is_lazy_array(tf.as_matrix()):
         m = tf.mean(weights=-xp.ones(4))
-        # Only the rotation submatrix will be nan
-        assert xp.all(xp.isnan(m.as_matrix()[:3, :3]))
+        assert xp.all(xp.isnan(m.as_matrix()))
     else:
         with pytest.raises(ValueError, match="non-negative"):
             tf.mean(weights=-xp.ones(4))

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1022,21 +1022,27 @@ def test_mean(xp, ndim: int):
     r = rotation_to_xp(Rotation.from_quat(q), xp=xp)
     tf = RigidTransform.from_components(t, r)
 
+    # Unweighted mean
+    axis = tuple(range(t.ndim - 1))
+    t_mean = xp.mean(t, axis=axis)
+    r_mean = r.mean()
+    xp_assert_close(tf.mean().as_matrix(),
+                    RigidTransform.from_components(t_mean, r_mean).as_matrix(),
+                    atol=atol)
+
+    # Weighted mean
     if ndim == 1:
         weights = None
         t_mean = t
     else:
         weights = xp.asarray(rng.random(size=(ndim,) * (ndim - 1)))
-        axis = tuple(range(t.ndim - 1))
         norm = xp.sum(weights[..., None], axis=axis)
         wsum = xp.sum(t * weights[..., None], axis=axis)
         t_mean = wsum/norm
     r_mean = r.mean(weights=weights)
-    tf_mean = tf.mean(weights=weights)
-
-    tf_from_components = RigidTransform.from_components(t_mean, r_mean)
-    xp_assert_close(tf_mean.as_matrix(),
-                    tf_from_components.as_matrix(), atol=atol)
+    xp_assert_close(tf.mean(weights=weights).as_matrix(),
+                    RigidTransform.from_components(t_mean, r_mean).as_matrix(),
+                    atol=atol)
 
 
 @make_xp_test_case(RigidTransform.from_translation)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1298,8 +1298,9 @@ def test_mean(xp, ndim: int):
     desired = xp.asarray(0.0)[()]
     atol = 1e-6 if xp_default_dtype(xp) is xp.float32 else 1e-10
     for t in thetas:
-        r = Rotation.from_rotvec(t * axes)
-        xp_assert_close(r.mean().magnitude(), desired, atol=atol)
+        r_mean = Rotation.from_rotvec(t * axes).mean()
+        assert r_mean.shape == ()
+        xp_assert_close(r_mean.magnitude(), desired, atol=atol)
 
 
 @make_xp_test_case(Rotation.from_rotvec, Rotation.mean, Rotation.inv,
@@ -1323,6 +1324,7 @@ def test_weighted_mean(xp, ndim: int):
 
         r = Rotation.from_rotvec(t * axes)
         m = r.mean()
+        assert m.shape == ()
         xp_assert_close((m * mw.inv()).magnitude(), expected, atol=1e-6)
 
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1333,7 +1333,7 @@ def test_mean_invalid_weights(xp):
     r = Rotation.from_quat(xp.eye(4))
     if is_lazy_array(r.as_quat()):
         m = r.mean(weights=-xp.ones(4))
-        assert all(xp.isnan(m._quat))
+        assert xp.all(xp.isnan(m._quat))
     else:
         with pytest.raises(ValueError, match="non-negative"):
             r.mean(weights=-xp.ones(4))


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?

Implements `RigidTransform.mean()`, to mirror the existing `Rotation.mean()`. Part of the spatial transformation roadmap: https://github.com/scipy/scipy/issues/22370

#### Additional information
<!--Any additional information you think is important.-->
