### PR TITLE
TST: test_as_euler_symmetric_axes tol bump

### DIFF
--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -971,7 +971,7 @@ def test_as_euler_symmetric_axes(xp, seq_tuple, intrinsic):
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles)
     angles_quat = rotation.as_euler(seq)
-    xp_assert_close(angles, angles_quat, atol=0, rtol=1e-13)
+    xp_assert_close(angles, angles_quat, atol=0, rtol=1.1e-13)
     test_stats(angles_quat - angles, 1e-16, 1e-14)
 
 


### PR DESCRIPTION
* Fixes gh-23720. A minor tolerance bump to a test that fails with `torch` on ARM Mac. Probably slipped through because I think we mostly test array API on Linux in CI (which is probably enough in general).

[skip circle]
