### PR TITLE
DOC: Fixing scipy.linalg.polar `u` docstring.

### DIFF
--- a/scipy/linalg/_decomp_polar.py
+++ b/scipy/linalg/_decomp_polar.py
@@ -31,7 +31,7 @@ def polar(a, side="right"):
     -------
     u : (m, n) ndarray
         If `a` is square, then `u` is unitary. If m > n, then the columns
-        of `a` are orthonormal, and if m < n, then the rows of `u` are
+        of `u` are orthonormal, and if m < n, then the rows of `u` are
         orthonormal.
     p : ndarray
         `p` is Hermitian positive semidefinite. If `a` is nonsingular, `p`


### PR DESCRIPTION
#### What does this implement/fix?
The documentation wrongly stated that the columns `a` are orthonormal but this is meant to be `u`, as this referencing the u matrix.
