### PR TITLE
DRAFT: Analyze macos-15-intel problems of issue 23710

### DIFF
--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -70,8 +70,7 @@ def _calc_dual_canonical_window(win: np.ndarray, hop: int) -> np.ndarray:
 
 def _closest_STFT_dual_window2(win: np.ndarray, hop: int,
                              desired_dual: np.ndarray | None = None, *,
-                             scaled: bool = True) \
-        -> tuple[np.ndarray, float | complex]:
+                             scaled: bool = True):
     """Analyze macos15-intel problems (issue 23710) """
     if desired_dual is None:  # default is rectangular window
         desired_dual = np.ones_like(win)
@@ -95,7 +94,7 @@ def _closest_STFT_dual_window2(win: np.ndarray, hop: int,
     q_d = w_d * q_d
 
     if not scaled:
-        return w_d + desired_dual - q_d, 1.
+        return w_d + desired_dual - q_d, 1., None, None
 
     numerator = q_d.conjugate().T @ w_d
     denominator = q_d.T.real @ q_d.real + q_d.T.imag @ q_d.imag  # always >= 0
@@ -104,7 +103,7 @@ def _closest_STFT_dual_window2(win: np.ndarray, hop: int,
             "Unable to calculate scaled closest dual window due to numerically " +
             "unstable scaling factor! Try setting parameter `scaled` to False.")
     alpha = numerator / denominator
-    return w_d + alpha * (desired_dual - q_d), alpha
+    return w_d + alpha * (desired_dual - q_d), alpha, q_d, w_d
 
 
 def closest_STFT_dual_window(win: np.ndarray, hop: int,

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -85,6 +85,30 @@ def test_closest_STFT_dual_window_exceptions():
 def test_macos15_intel_repeatability():
     """This test fails to replicate the problem of issue 23710 in a test with
     only NumPy dependencies. """
+    # win_name, m, hop, sym_win = 'hann', 17, 8, True
+    # win = get_window(win_name, m, not sym_win)
+    # d_win = np.ones_like(win)
+    # d0, s0, qd0, wd0 = _closest_STFT_dual_window2(win, hop, d_win, scaled=True)
+    qd1 = np.array([0.0, 0.041067318521830716, 0.19526214587563503, 0.5384608080042774,
+                    1.0, 1.2060600302011566, 1.1380711874576983, 1.0379412550374412,
+                    1.0, 1.0379412550374412, 1.1380711874576983, 1.2060600302011564,
+                    1.0, 0.5384608080042773, 0.19526214587563503, 0.04106731852183083,
+                    0.0])
+    # xp_assert_equal(qd0, qd1)
+
+    qd2 = qd1.copy()
+    xp_assert_equal(qd2, qd1)
+
+    denominator1 = qd1 @ qd1
+    denominator2 = qd2 @ qd2
+    xp_assert_equal(denominator2, denominator1)  # fails on macos15-intel (!?)
+
+def test_macos15_intel_repeatability1():
+    """Replicate the problem of issue 23710 in a test with only NumPy dependencies.
+
+    This version still calls `_closest_STFT_dual_window2` but does not use their return
+    values,
+    """
     win_name, m, hop, sym_win = 'hann', 17, 8, True
     win = get_window(win_name, m, not sym_win)
     d_win = np.ones_like(win)

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -107,12 +107,16 @@ def test_issue2370(win_name, m, hop, sym_win, scaled=True):
     d2, s2, qd2, wd2 = _closest_STFT_dual_window2(win, hop, d_win, scaled=scaled)
 
     # Identical function calls should produce identical results:
-    xp_assert_equal(wd2, wd1)
     xp_assert_equal(qd2, qd1)
     assert qd1 is not qd2  # ensure mutating qd1 is not the problem
 
     # Taken from closest_STFT_dual_window (qd1 == qd2):
+    assert np.all(qd1.imag == 0)
     denominator1 = qd1.T.real @ qd1.real + qd1.T.imag @ qd1.imag  # always >= 0
+
+    assert np.all(qd2.imag == 0)
+    xp_assert_equal(qd2, qd1)
+
     denominator2 = qd2.T.real @ qd2.real + qd2.T.imag @ qd2.imag  # always >= 0
     xp_assert_equal(denominator2, denominator1)  # fails on macos15-intel
 

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -82,6 +82,19 @@ def test_closest_STFT_dual_window_exceptions():
         closest_STFT_dual_window(np.ones(4), 2, np.zeros(4), scaled=True)
 
 
+def test_macos15_intel_repeatability():
+    """Try to replicate problem of issue 23710 in a test only NumPy dependencies. """
+    qd1 = np.array([
+        0.0, 0.041067318521830716, 0.19526214587563503, 0.5384608080042774, 1.0,
+        1.2060600302011566, 1.1380711874576983, 1.0379412550374412, 1.0,
+        1.0379412550374412, 1.1380711874576983, 1.2060600302011564, 1.0,
+        0.5384608080042773, 0.19526214587563503, 0.04106731852183083])
+    qd2 = qd1.copy()
+    denominator1 = qd1.T.real @ qd1.real + qd1.T.imag @ qd1.imag
+    denominator2 = qd2.T.real @ qd2.real + qd2.T.imag @ qd2.imag
+    xp_assert_equal(denominator2, denominator1)  # fails on macos15-intel
+
+
 @pytest.mark.parametrize('sym_win', (False, True))
 @pytest.mark.parametrize('hop', (8, 9))
 @pytest.mark.parametrize('m', (16, 17))

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -82,26 +82,37 @@ def test_closest_STFT_dual_window_exceptions():
         closest_STFT_dual_window(np.ones(4), 2, np.zeros(4), scaled=True)
 
 
-@pytest.mark.parametrize("scaled", (True, False))
 @pytest.mark.parametrize('sym_win', (False, True))
 @pytest.mark.parametrize('hop', (8, 9))
 @pytest.mark.parametrize('m', (16, 17))
 @pytest.mark.parametrize('win_name', ('hann', 'hamming'))
-def test_issue2370(win_name, m, hop, sym_win, scaled):
+def test_issue2370(win_name, m, hop, sym_win, scaled=True):
     """Analyze macos15-intel problems (issue 23710) """
     win = get_window(win_name, m, not sym_win)
-    win1 = win.copy()
-    d1, s1, qd1, wd1 = _closest_STFT_dual_window2(win, hop, np.ones_like(win),
-                                                  scaled=scaled)
-    xp_assert_equal(win, win1, err_msg="win is mutated (1)")
-    d2, s2, qd2, wd2 = _closest_STFT_dual_window2(win, hop, np.ones_like(win),
-                                        scaled=scaled)
-    xp_assert_equal(win, win1, err_msg="win is mutated (2)")
-
+    d_win = np.ones_like(win)
+    win1 = get_window(win_name, m, not sym_win)
+    d_win1 = np.ones_like(win1)
+    d1, s1, qd1, wd1 = _closest_STFT_dual_window2(win, hop, d_win, scaled=scaled)
+    xp_assert_equal(win, win1, err_msg="parameter win mutated (1)")
+    xp_assert_equal(d_win, d_win1, err_msg="parameter d_win mutated (1)")
+    d2, s2, qd2, wd2 = _closest_STFT_dual_window2(win, hop, d_win, scaled=scaled)
+    xp_assert_equal(win, win1, err_msg="parameter win mutated (2)")
+    xp_assert_equal(d_win, d_win1, err_msg="parameter d_win mutated (2)")
 
     # Identical function calls should produce identical results:
     xp_assert_equal(qd2, qd1)
     xp_assert_equal(wd2, wd1)
+
+    # Taken from closest_STFT_dual_window:
+    numerator1 = qd1.conjugate().T @ wd1
+    denominator1 = qd1.T.real @ qd1.real + qd1.T.imag @ qd1.imag  # always >= 0
+    alpha1 = numerator1 / denominator1
+
+    numerator2 = qd2.conjugate().T @ wd2
+    denominator2 = qd2.T.real @ qd2.real + qd2.T.imag @ qd2.imag  # always >= 0
+    alpha2 = numerator2 / denominator2
+    assert alpha2 == alpha1
+
     xp_assert_equal(d2, d1, err_msg=f"{s2-s1=}")
     assert s2 == s1, "Default for parameter `desired_dual` is not ok!"
 

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -90,10 +90,18 @@ def test_closest_STFT_dual_window_exceptions():
 def test_issue2370(win_name, m, hop, sym_win, scaled):
     """Analyze macos15-intel problems (issue 23710) """
     win = get_window(win_name, m, not sym_win)
-    d1, s1 = _closest_STFT_dual_window2(win, hop, np.ones_like(win), scaled=scaled)
-    d2, s2 = _closest_STFT_dual_window2(win, hop, np.ones_like(win), scaled=scaled)
+    win1 = win.copy()
+    d1, s1, qd1, wd1 = _closest_STFT_dual_window2(win, hop, np.ones_like(win),
+                                                  scaled=scaled)
+    xp_assert_equal(win, win1, err_msg="win is mutated (1)")
+    d2, s2, qd2, wd2 = _closest_STFT_dual_window2(win, hop, np.ones_like(win),
+                                        scaled=scaled)
+    xp_assert_equal(win, win1, err_msg="win is mutated (2)")
 
-    # Identical function calls should produce identical results
+
+    # Identical function calls should produce identical results:
+    xp_assert_equal(qd2, qd1)
+    xp_assert_equal(wd2, wd1)
     xp_assert_equal(d2, d1, err_msg=f"{s2-s1=}")
     assert s2 == s1, "Default for parameter `desired_dual` is not ok!"
 

--- a/scipy/signal/tests/test_short_time_fft.py
+++ b/scipy/signal/tests/test_short_time_fft.py
@@ -85,15 +85,23 @@ def test_closest_STFT_dual_window_exceptions():
 def test_macos15_intel_repeatability():
     """This test fails to replicate the problem of issue 23710 in a test with
     only NumPy dependencies. """
-    qd1 = np.array([
-        0.0, 0.041067318521830716, 0.19526214587563503, 0.5384608080042774, 1.0,
-        1.2060600302011566, 1.1380711874576983, 1.0379412550374412, 1.0,
-        1.0379412550374412, 1.1380711874576983, 1.2060600302011564, 1.0,
-        0.5384608080042773, 0.19526214587563503, 0.04106731852183083])
+    win_name, m, hop, sym_win = 'hann', 17, 8, True
+    win = get_window(win_name, m, not sym_win)
+    d_win = np.ones_like(win)
+    d0, s0, qd0, wd0 = _closest_STFT_dual_window2(win, hop, d_win, scaled=True)
+    qd1 = np.array([0.0, 0.041067318521830716, 0.19526214587563503, 0.5384608080042774,
+                    1.0, 1.2060600302011566, 1.1380711874576983, 1.0379412550374412,
+                    1.0, 1.0379412550374412, 1.1380711874576983, 1.2060600302011564,
+                    1.0, 0.5384608080042773, 0.19526214587563503, 0.04106731852183083,
+                    0.0])
+    xp_assert_equal(qd0, qd1)
+
     qd2 = qd1.copy()
-    denominator1 = qd1.T.real @ qd1.real + qd1.T.imag @ qd1.imag
-    denominator2 = qd2.T.real @ qd2.real + qd2.T.imag @ qd2.imag
-    xp_assert_equal(denominator2, denominator1)  # fails on macos15-intel
+    xp_assert_equal(qd2, qd1)
+
+    denominator1 = qd1 @ qd1
+    denominator2 = qd2 @ qd2
+    xp_assert_equal(denominator2, denominator1)  # fails on macos15-intel (!?)
 
 
 @pytest.mark.parametrize('sym_win', (False, True))


### PR DESCRIPTION
DO NOT MERGE!

Issue #23713 shows that only on "macos-15-intel" hardware, `signal.closest_STFT_dual_window` does not produce identical results though, it should. Here, additional tests are added to investigate that behavior.

This PR is needed due to lack of having local macos-15-intel hardware. Consult also PR #23713.
