### PR TITLE
BUG: spatial: Fix shape of Rotation mean when ndim > 1

### DIFF
--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -82,8 +82,8 @@ class Rotation:
 
     A `Rotation` instance can contain a single rotation transform or rotations of
     multiple leading dimensions. E.g., it is possible to have an N-dimensional array of
-    (N, M, K) rotations. When applied to other rotations or vectors, standard broadcasting
-    rules apply.
+    (N, M, K) rotations. When applied to other rotations or vectors, standard
+    broadcasting rules apply.
 
     Indexing within a rotation is supported to access a subset of the rotations stored
     in a `Rotation` instance.
@@ -2011,13 +2011,13 @@ class Rotation:
             Weights describing the relative importance of the rotations. If
             None (default), then all values in `weights` are assumed to be
             equal. If given, the shape of `weights` must be broadcastable to
-            the rotation shape.
+            the rotation shape. Weights must be non-negative.
 
         Returns
         -------
         mean : `Rotation` instance
-            Object containing the mean of the rotations in the current
-            instance.
+            Single rotation containing the mean of the rotations in the
+            current instance.
 
         References
         ----------

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -481,6 +481,7 @@ def mean(quat: Array, weights: ArrayLike | None = None) -> Array:
     # Branching code is okay for checks that include meta info such as shapes and types
     if weights is None:
         quat = xpx.atleast_nd(quat, ndim=2, xp=xp)
+        quat = xp.reshape(quat, (-1, 4))
         K = xp.matrix_transpose(quat) @ quat  # TODO: Replace with .mT
     else:
         weights = xp.asarray(weights, dtype=dtype, device=device)
@@ -500,7 +501,9 @@ def mean(quat: Array, weights: ArrayLike | None = None) -> Array:
 
         # Make sure we can transpose quat
         quat = xpx.atleast_nd(quat, ndim=2, xp=xp)
-        K = xp.matrix_transpose(weights[..., None] * quat) @ quat
+        quat = xp.reshape(quat, (-1, 4))
+        weights_flat = xp.reshape(weights, (-1,))
+        K = xp.matrix_transpose(weights_flat[..., None] * quat) @ quat
 
     _, v = xp.linalg.eigh(K)
     return v[..., -1]

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1295,9 +1295,7 @@ def test_mean(xp, ndim: int):
     axes = xp.concat((-xp.eye(3), xp.eye(3)))
     axes = xp.reshape(axes, (1,) * (ndim - 1) + (6, 3))
     thetas = xp.linspace(0, xp.pi / 2, 100)
-    desired = xp.zeros((1,) * (ndim - 1))
-    if desired.ndim == 0:
-        desired = desired[()]
+    desired = xp.asarray(0.0)[()]
     atol = 1e-6 if xp_default_dtype(xp) is xp.float32 else 1e-10
     for t in thetas:
         r = Rotation.from_rotvec(t * axes)
@@ -1318,16 +1316,14 @@ def test_weighted_mean(xp, ndim: int):
     axes = xp.tile(axes, batch_shape + (1, 1))
     weights = xp.tile(weights, batch_shape + (1,))
 
-    expected = xp.zeros(batch_shape)
-    if expected.ndim == 0:
-        expected = expected[()]
+    expected = xp.asarray(0.0)[()]
     for t in thetas:
         rw = Rotation.from_rotvec(t * axes[..., :2, :])
         mw = rw.mean(weights=weights)
 
         r = Rotation.from_rotvec(t * axes)
         m = r.mean()
-        xp_assert_close((m * mw.inv()).magnitude(), expected, atol=1e-10)
+        xp_assert_close((m * mw.inv()).magnitude(), expected, atol=1e-6)
 
 
 @make_xp_test_case(Rotation.mean)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
N/A

#### What does this implement/fix?
When https://github.com/scipy/scipy/pull/23467 was merged, Rotations gained the ability to have shapes with ndim > 1. However the current implementation of `Rotation.mean()` only reduces along the last axis. This does not match the expected behavior of arrays without an `axis` parameter specified (not yet implemented for Rotations).

```python
import numpy as np
from scipy.spatial.transform import Rotation, RigidTransform

rng = np.random.default_rng(123)
q = rng.normal(size=(1, 2, 4))
r = Rotation.from_quat(q)
print(r.shape)
print(r.mean().shape)
# (1, 2)
# (1,)

a = q[..., 0]  # numpy array
print(a.shape)
print(a.mean().shape)
# (1, 2)
# ()
```

This PR updates it so that a single rotation is always returned.
```python
print(r.mean().shape)
# ()
```

#### Additional information
The bug is not yet present in a public release, and can be fixed prior to 1.17.0 going out.

@amacati could you take a look?