### PR TITLE
MAINT: migrate `nrdtrimn` to boost

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -5875,6 +5875,15 @@ add_newdoc("nrdtrimn",
     nrdtrisd : Inverse of normal distribution CDF with respect to
                standard deviation
 
+    Notes
+    -----
+    This function is a wrapper for the `find_scale` routine from the
+    Boost.Math C++ library [1]_.
+
+    References
+    ----------
+    .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
+
     Examples
     --------
     `nrdtrimn` can be used to recover the mean of a normal distribution
@@ -5894,7 +5903,7 @@ add_newdoc("nrdtrimn",
 
     >>> from scipy.special import nrdtrimn
     >>> nrdtrimn(p, std, x)
-    3.0000000000000004
+    3.0
 
     """)
 

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -337,27 +337,6 @@ cdef inline double nctdtrinc(double df, double p, double t) noexcept nogil:
     return get_result("nctdtrinc", argnames, result, status, bound, 1)
 
 
-cdef inline double nrdtrimn(double p, double std, double x) noexcept nogil:
-    cdef:
-        double q = 1.0 - p
-        double result, bound
-        int status = 10
-        char *argnames[4]
-        TupleDID ret
-
-    if isnan(p) or isnan(std) or isnan(x):
-      return NAN
-
-    argnames[0] = "p"
-    argnames[1] = "q"
-    argnames[2] = "x"
-    argnames[3] = "std"
-
-    ret = cdfnor_which3(p, q, x, std)
-    result, status, bound = ret.d1, ret.i1, ret.d2
-    return get_result("nrdtrimn", argnames, result, status, bound, 1)
-
-
 cdef inline double nrdtrisd(double mn, double p, double x) noexcept nogil:
     cdef:
         double q = 1.0 - p

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -2295,4 +2295,58 @@ chdtriv_double(double p, double x)
     return chdtriv_wrap(p, x);
 }
 
+template<typename Real>
+Real
+norm_cdf_inv_mean_wrap(const Real p, const Real std, const Real x)
+{
+    if (std::isnan(p) || std::isnan(std) || std::isnan(x)) {
+        return NAN;
+    }
+    // p must be in (0, 1)
+    if (p <= 0 || p >= 1) {
+        sf_error("nrdtrimn", SF_ERROR_DOMAIN, NULL);
+        return NAN;
+    }
+    if (std <= 0) {
+        sf_error("nrdtrimn", SF_ERROR_DOMAIN, NULL);
+        return NAN;
+    }
+    if (std::isinf(std)) {
+        return - INFINITY;
+    }
+    if (std::isinf(x)) {
+        return (x > 0) ? INFINITY : -INFINITY;
+    }
+    Real y;
+    try {
+        y = boost::math::find_location<
+            boost::math::normal_distribution<Real, SpecialPolicy>>(x, p, std);
+    } catch (const std::domain_error&) {
+        sf_error("nrdtrimn", SF_ERROR_DOMAIN, NULL);
+        y = NAN;
+    } catch (const std::overflow_error&) {
+        sf_error("nrdtrimn", SF_ERROR_OVERFLOW, NULL);
+        y = INFINITY;
+    } catch (const std::underflow_error&) {
+        sf_error("nrdtrimn", SF_ERROR_UNDERFLOW, NULL);
+        y = 0;
+    } catch (...) {
+        sf_error("nrdtrimn", SF_ERROR_NO_RESULT, NULL);
+        y = NAN;
+    }
+    return y;
+}
+
+float
+norm_cdf_inv_mean_float(float p, float std, float x)
+{
+    return norm_cdf_inv_mean_wrap(p, std, x);
+}
+
+double
+norm_cdf_inv_mean_double(double p, double std, double x)
+{
+    return norm_cdf_inv_mean_wrap(p, std, x);
+}
+
 #endif

--- a/scipy/special/cdflib.c
+++ b/scipy/special/cdflib.c
@@ -2401,16 +2401,6 @@ struct TupleDID cdfnbn_which3(double p, double q, double s, double pr, double om
     //**********************************************************************
 
 
-struct TupleDID cdfnor_which3(double p, double q, double x, double sd)
-{
-    if (!(sd > 0.0)) {
-        return (struct TupleDID){.d1 = 0.0, .i1 = -4, .d2 = 0.0};
-    }
-    double z = dinvnr(p, q);
-    return (struct TupleDID){.d1 = x - sd*z, .i1 = 0, .d2 = 0.0};
-}
-
-
 struct TupleDID cdfnor_which4(double p, double q, double x, double mean)
 {
     double z = dinvnr(p, q);

--- a/scipy/special/cdflib.h
+++ b/scipy/special/cdflib.h
@@ -115,7 +115,6 @@ struct TupleDID cdfgam_which2(double, double, double, double);
 struct TupleDID cdfgam_which4(double, double, double, double);
 struct TupleDID cdfnbn_which2(double, double, double, double, double);
 struct TupleDID cdfnbn_which3(double, double, double, double, double);
-struct TupleDID cdfnor_which3(double, double, double, double);
 struct TupleDID cdfnor_which4(double, double, double, double);
 struct TupleDID cdfpoi_which2(double, double, double);
 struct TupleDID cdft_which3(double, double, double);

--- a/scipy/special/cython_special.pxd
+++ b/scipy/special/cython_special.pxd
@@ -199,7 +199,7 @@ cpdef double nctdtrinc(double x0, double x1, double x2) noexcept nogil
 cpdef df_number_t nctdtrit(df_number_t x0, df_number_t x1, df_number_t x2) noexcept nogil
 cpdef Dd_number_t ndtr(Dd_number_t x0) noexcept nogil
 cpdef double ndtri(double x0) noexcept nogil
-cpdef double nrdtrimn(double x0, double x1, double x2) noexcept nogil
+cpdef df_number_t nrdtrimn(df_number_t x0, df_number_t x1, df_number_t x2) noexcept nogil
 cpdef double nrdtrisd(double x0, double x1, double x2) noexcept nogil
 cdef void obl_ang1(double x0, double x1, double x2, double x3, double *y0, double *y1) noexcept nogil
 cdef void obl_ang1_cv(double x0, double x1, double x2, double x3, double x4, double *y0, double *y1) noexcept nogil

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -802,6 +802,7 @@ Available functions
 - :py:func:`~scipy.special.nrdtrimn`::
 
         double nrdtrimn(double, double, double)
+        float nrdtrimn(float, float, float)
 
 - :py:func:`~scipy.special.nrdtrisd`::
 
@@ -1733,10 +1734,6 @@ cdef _proto_nctdtridf_t *_proto_nctdtridf_t_var = &_func_nctdtridf
 from ._cdflib_wrappers cimport nctdtrinc as _func_nctdtrinc
 ctypedef double _proto_nctdtrinc_t(double, double, double) noexcept nogil
 cdef _proto_nctdtrinc_t *_proto_nctdtrinc_t_var = &_func_nctdtrinc
-
-from ._cdflib_wrappers cimport nrdtrimn as _func_nrdtrimn
-ctypedef double _proto_nrdtrimn_t(double, double, double) noexcept nogil
-cdef _proto_nrdtrimn_t *_proto_nrdtrimn_t_var = &_func_nrdtrimn
 
 from ._cdflib_wrappers cimport nrdtrisd as _func_nrdtrisd
 ctypedef double _proto_nrdtrisd_t(double, double, double) noexcept nogil
@@ -3146,6 +3143,15 @@ cpdef df_number_t ncfdtri(df_number_t x0, df_number_t x1, df_number_t x2, df_num
         else:
             return NAN
 
+cpdef df_number_t nrdtrimn(df_number_t x0, df_number_t x1, df_number_t x2) noexcept nogil:
+    """See the documentation for scipy.special.nrdtrimn"""
+    if df_number_t is float:
+        return (<float(*)(float, float, float) noexcept nogil>scipy.special._ufuncs_cxx._export_norm_cdf_inv_mean_float)(x0, x1, x2)
+    elif df_number_t is double:
+        return (<double(*)(double, double, double) noexcept nogil>scipy.special._ufuncs_cxx._export_norm_cdf_inv_mean_double)(x0, x1, x2)
+    else:
+        return NAN
+
 cpdef double ncfdtridfd(double x0, double x1, double x2, double x3) noexcept nogil:
     """See the documentation for scipy.special.ncfdtridfd"""
     return _func_ncfdtridfd(x0, x1, x2, x3)
@@ -3199,10 +3205,6 @@ cpdef Dd_number_t ndtr(Dd_number_t x0) noexcept nogil:
 cpdef double ndtri(double x0) noexcept nogil:
     """See the documentation for scipy.special.ndtri"""
     return xsf_ndtri(x0)
-
-cpdef double nrdtrimn(double x0, double x1, double x2) noexcept nogil:
-    """See the documentation for scipy.special.nrdtrimn"""
-    return _func_nrdtrimn(x0, x1, x2)
 
 cpdef double nrdtrisd(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.nrdtrisd"""

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -576,8 +576,10 @@
         }
     },
     "nrdtrimn": {
-        "_cdflib_wrappers.pxd": {
-            "nrdtrimn": "ddd->d"        }
+        "boost_special_functions.h++": {
+            "norm_cdf_inv_mean_float": "fff->f",
+            "norm_cdf_inv_mean_double": "ddd->d"
+        }
     },
     "nrdtrisd": {
         "_cdflib_wrappers.pxd": {

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -844,3 +844,16 @@ class TestNoncentralChiSquaredFunctions:
 @pytest.mark.parametrize("x", [0.1, 100])
 def test_chdtriv_p_equals_1_returns_0(x):
     assert sp.chdtriv(1, x) == 0
+
+
+class TestNrdtrimn:
+    @pytest.mark.parametrize("x", [-np.inf, np.inf])
+    def test_nrdtrimn_infinite_x(self, x):
+        result = sp.nrdtrimn(0.5, 1, x)
+        assert np.isinf(result)
+        assert np.sign(result) == np.sign(x)
+
+    def test_infinite_sd(self):
+        result = sp.nrdtrimn(0.5, np.inf, 1)
+        assert np.isinf(result)
+        assert result < 0

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -847,13 +847,14 @@ def test_chdtriv_p_equals_1_returns_0(x):
 
 
 class TestNrdtrimn:
-    @pytest.mark.parametrize("x", [-np.inf, np.inf])
-    def test_nrdtrimn_infinite_x(self, x):
-        result = sp.nrdtrimn(0.5, 1, x)
-        assert np.isinf(result)
-        assert np.sign(result) == np.sign(x)
+    def test_nrdtrimn_positive_infinite_x(self):
+        result = sp.nrdtrimn(0.5, 1, np.inf)
+        assert np.isposinf(result)
+
+    def test_nrdtrimn_negative_infinite_x(self):
+        result = sp.nrdtrimn(0.5, 1, -np.inf)
+        assert np.isneginf(result)
 
     def test_infinite_sd(self):
         result = sp.nrdtrimn(0.5, np.inf, 1)
-        assert np.isinf(result)
-        assert result < 0
+        assert np.isneginf(result)


### PR DESCRIPTION
#### Reference issue
Towards #21966 

#### Additional information
I tried to preserve cdflib's edge case handling with infinite input and added explicit tests.

##### Alternative
`nrdtrimn` is actually a simple reparametrization of `ndtri` using `nrdtrimn=x-std * ndtri(p)`. See the code below:

```python
from scipy import special as sc
from scipy.stats import norm

mean, std, x = 3, 2, 6
p = norm.cdf(x, loc=mean, scale=std)

nrdtrimn_result = x - std * sc.ndtri(p)
``` 

Since we do not want to add these to xsf though, I went with boost anyway.