### PR TITLE
ENH: stats.logser: implement sf

### DIFF
--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -937,6 +937,14 @@ class logser_gen(rv_discrete):
         # logser.pmf(k) = - p**k / (k*log(1-p))
         return -np.power(p, k) * 1.0 / k / special.log1p(-p)
 
+    def _sf(self, k, p):
+        tiny = 1e-100
+        # Ideally, this is the unregularized beta function with `b=0`. We don't have
+        # an unregularized beta function (yet, although we could get it from Boost),
+        # and neither technically support `b=0` - despite the function being accurate
+        # for `b` super close to zero. See https://github.com/scipy/scipy/issues/3890.
+        return -special.betainc(k+1, tiny, p) * special.beta(k+1, tiny) / np.log1p(-p)
+
     def _stats(self, p):
         r = special.log1p(-p)
         mu = p / (p - 1.0) / r

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -2496,6 +2496,20 @@ class TestLogser:
         #   1.000000005
         assert_allclose(m, 1.000000005)
 
+    def test_sf(self):
+        p = [[0.5], [1e-5], [1 - 1e-5]]
+        k = [1, 10, 100, 1000]
+        # Reference values from Wolfram Alpha, e.g.
+        # SurvivalFunction[LogSeriesDistribution[99999/100000], 1000]
+        # 0.35068668662799737584735036958139157462633608106500173019897861351038286634
+        ref = [[0.2786524795555183, 0.00011876901682721189,
+                1.1159788564768581e-32, 1.3437300083506688e-304],
+               [5.000008333375e-06, 9.090946969973778e-52, 0, 0],
+               [0.9131419722083134, 0.745601735620566,
+                0.5495169511115096, 0.3506866866279974]]
+        res = stats.logser.sf(k, p)
+        np.testing.assert_allclose(res, ref, atol=1e-300)
+
 
 class TestGumbel_r_l:
     @pytest.fixture(scope='function')


### PR DESCRIPTION
#### Reference issue
Closes gh-3890

#### What does this implement/fix?
Implements `sf` for `logser`.

#### Additional information
See https://github.com/scipy/scipy/issues/3890#issuecomment-2322808889 for rationale.
@ev-br you requested, so I thought I'd ping you.