### PR TITLE
MAINT: stats.percentileofscore: raise with multidimensional input

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -2102,33 +2102,34 @@ def percentileofscore(a, score, kind='rank', nan_policy='propagate'):
     ----------
     a : array_like
         A 1-D array to which `score` is compared.
-    score : array_like
-        Scores to compute percentiles for.
+    score : float or array_like
+        A float score or array of scores for which to compute the percentile(s).
     kind : {'rank', 'weak', 'strict', 'mean'}, optional
         Specifies the interpretation of the resulting score.
         The following options are available (default is 'rank'):
 
-          * 'rank': Average percentage ranking of score.  In case of multiple
-            matches, average the percentage rankings of all matching scores.
-          * 'weak': This kind corresponds to the definition of a cumulative
-            distribution function.  A percentileofscore of 80% means that 80%
-            of values are less than or equal to the provided score.
-          * 'strict': Similar to "weak", except that only values that are
-            strictly less than the given score are counted.
-          * 'mean': The average of the "weak" and "strict" scores, often used
-            in testing.  See https://en.wikipedia.org/wiki/Percentile_rank
+        * 'rank': Average percentage ranking of score.  In case of multiple
+          matches, average the percentage rankings of all matching scores.
+        * 'weak': This kind corresponds to the definition of a cumulative
+          distribution function.  A percentileofscore of 80% means that 80%
+          of values are less than or equal to the provided score.
+        * 'strict': Similar to "weak", except that only values that are
+          strictly less than the given score are counted.
+        * 'mean': The average of the "weak" and "strict" scores, often used
+          in testing.  See https://en.wikipedia.org/wiki/Percentile_rank
+
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Specifies how to treat `nan` values in `a`.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan (for each value in `score`).
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan (for each value in `score`).
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
 
     Returns
     -------
-    pcos : float
-        Percentile-position of score (0-100) relative to `a`.
+    pcos : float or array-like
+        Percentile-position(s) of `score` (0-100) relative to `a`.
 
     See Also
     --------
@@ -2182,8 +2183,12 @@ def percentileofscore(a, score, kind='rank', nan_policy='propagate'):
     """
 
     a = np.asarray(a)
-    n = len(a)
     score = np.asarray(score)
+
+    if a.ndim != 1:
+        raise ValueError("`a` must be 1-dimensional.")
+
+    n = len(a)
 
     # Nan treatment
     cna = _contains_nan(a, nan_policy)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4160,6 +4160,13 @@ class TestPercentileOfScore:
         a = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         assert_equal(self.f(a, scores, kind="rank"), results)
 
+    def test_multidimensional_error(self):
+        # gh-21563 reported that `percentileofscore` accepted multidimensional
+        # arrays but did not produce meaningful results.
+        message = "`a` must be 1-dimensional."
+        with pytest.raises(ValueError, match=message):
+            stats.percentileofscore(np.ones((3, 3)), 1)
+
 
 PowerDivCase = namedtuple('Case',  # type: ignore[name-match]
                           ['f_obs', 'f_exp', 'ddof', 'axis',


### PR DESCRIPTION
#### Reference issue
Closes gh-21563

#### What does this implement/fix?
gh-21563 reported that `percentileofscore` produced nonsense results with multidimensional input.
This PR makes `percentileofscore` raise with multidimensional input.

#### Additional information
gh-21563 suggested that `percentileofscore` could be extended to accept multidimensional arrays. Indeed, it could, but there haven't been any moves toward that since the issue was reported, so let's fix the bug.

Also, perhaps the names made it difficult to see, but `stats.percentileofscore` does essentially the same thing as  `mstats.plotting_positions`, `mstats.meppf`, and `stats.ecdf` - which is essentially the inverse of `stats.scoreatpercentile`, `mstats.scoreatpercentile`, `mstats.mquantile`, and `stats.quantile`. I mention it because it seems these were developed in isolation, leading to a lot of redundancy.

It would be better to consider the whole picture at once. gh-22194 tracks the need for a function like this that supports multidimensional input (superseding `mstats.plotting_positions` as `stats.quantile` supersedes `mstats.mquantile`) and native support for `marray` and other array API arrays.