### PR TITLE
CI: silence pyparsing 3.3.0a1 deprecation warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,7 +28,7 @@ filterwarnings =
     ignore:Using the slower implementation::cupy
     ignore:Jitify is performing a one-time only warm-up::cupy
     ignore:.*scipy.misc.*:DeprecationWarning
-    ignore:.*deprecated - use.*:DeprecationWarning  # remove when gh-23701 is resolved
+    ignore:.*deprecated - use.*:DeprecationWarning
 
 # When updating the markers here, also update them in scipy/conftest.py
 markers =

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,7 @@ filterwarnings =
     ignore:Using the slower implementation::cupy
     ignore:Jitify is performing a one-time only warm-up::cupy
     ignore:.*scipy.misc.*:DeprecationWarning
+    ignore:.*deprecated - use.*:DeprecationWarning  # remove when gh-23701 is resolved
 
 # When updating the markers here, also update them in scipy/conftest.py
 markers =


### PR DESCRIPTION
#### Reference issue
gh-23701

#### What does this implement/fix?
gh-23701 has been causing CI failures for several days now. This PR stops that.

#### Additional information
To be reverted when gh-23701 is resolved.