### PR TITLE
MAINT: stats: remove use of `np.random.seed`

### DIFF
--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -197,12 +197,8 @@ def check_named_args(distfn, x, shape_args, defaults, meths):
 def check_random_state_property(distfn, args):
     # check the random_state attribute of a distribution *instance*
 
-    # This test fiddles with distfn.random_state. This breaks other tests,
-    # hence need to save it and then restore.
-    rndm = distfn.random_state
-
     # baseline: this relies on the global state
-    np.random.seed(1234)
+    np.random.seed(1234)  # valid use of np.random.seed
     distfn.random_state = None
     r0 = distfn.rvs(*args, size=8)
 
@@ -230,9 +226,6 @@ def check_random_state_property(distfn, args):
 
     # ... and that does not alter the instance-level random_state!
     npt.assert_equal(distfn.random_state.get_state(), orig_state)
-
-    # finally, restore the random_state
-    distfn.random_state = rndm
 
 
 def check_meth_dtype(distfn, arg, meths):

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -986,9 +986,9 @@ def test_non_broadcastable(hypotest, args, kwds, n_samples, n_outputs, paired,
 
 def test_masked_array_2_sentinel_array():
     # prepare arrays
-    np.random.seed(0)
-    A = np.random.rand(10, 11, 12)
-    B = np.random.rand(12)
+    rng = np.random.default_rng(805715284)
+    A = rng.random((10, 11, 12))
+    B = rng.random(12)
     mask = A < 0.5
     A = np.ma.masked_array(A, mask)
 
@@ -1119,10 +1119,10 @@ def test_masked_stat_1d():
 @pytest.mark.parametrize(("axis"), range(-3, 3))
 def test_masked_stat_3d(axis):
     # basic test of _axis_nan_policy_factory with 3D masked sample
-    np.random.seed(0)
-    a = np.random.rand(3, 4, 5)
-    b = np.random.rand(4, 5)
-    c = np.random.rand(4, 1)
+    rng = np.random.default_rng(3679428403)
+    a = rng.random((3, 4, 5))
+    b = rng.random((4, 5))
+    c = rng.random((4, 1))
 
     mask_a = a < 0.1
     mask_c = [False, False, False, True]

--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -159,9 +159,9 @@ class TestBinnedStatistic:
 
     def test_1d_range_keyword(self):
         # Regression test for gh-3063, range can be (min, max) or [(min, max)]
-        np.random.seed(9865)
+        rng = np.random.default_rng(6823616729)
         x = np.arange(30)
-        data = np.random.random(30)
+        data = rng.random(30)
 
         mean, bins, _ = binned_statistic(x[:15], data[:15])
         mean_range, bins_range, _ = binned_statistic(x, data, range=[(0, 14)])
@@ -479,8 +479,9 @@ class TestBinnedStatistic:
 
     def test_dd_binned_statistic_result(self):
         # NOTE: tests the reuse of bin_edges from previous call
-        x = np.random.random((10000, 3))
-        v = np.random.random(10000)
+        rng = np.random.default_rng(8111360615)
+        x = rng.random((10000, 3))
+        v = rng.random(10000)
         bins = np.linspace(0, 1, 10)
         bins = (bins, bins, bins)
 
@@ -494,8 +495,9 @@ class TestBinnedStatistic:
         assert_allclose(stat, stat2)
 
     def test_dd_zero_dedges(self):
-        x = np.random.random((10000, 3))
-        v = np.random.random(10000)
+        rng = np.random.default_rng(1132724173)
+        x = rng.random((10000, 3))
+        v = rng.random(10000)
         bins = np.linspace(0, 1, 10)
         bins = np.append(bins, 1)
         bins = (bins, bins, bins)

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -587,7 +587,6 @@ def test_gh1320_regression():
 
 def test_method_of_moments():
     # example from https://en.wikipedia.org/wiki/Method_of_moments_(statistics)
-    np.random.seed(1234)
     x = [0, 0, 0, 0, 1]
     a = 1/5 - 2*np.sqrt(3)/5
     b = 1/5 + 2*np.sqrt(3)/5

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -168,8 +168,9 @@ def test_ppf_with_loc(dist, args):
     except TypeError:
         distfn = dist
     #check with a negative, no and positive relocation.
-    np.random.seed(1942349)
-    re_locs = [np.random.randint(-10, -1), 0, np.random.randint(1, 10)]
+    rng = np.random.default_rng(5108587887)
+
+    re_locs = [rng.integers(-10, -1), 0, rng.integers(1, 10)]
     _a, _b = distfn.support(*args)
     for loc in re_locs:
         npt.assert_array_equal(
@@ -185,17 +186,17 @@ def test_isf_with_loc(dist, args):
     except TypeError:
         distfn = dist
     # check with a negative, no and positive relocation.
-    np.random.seed(1942349)
-    re_locs = [np.random.randint(-10, -1), 0, np.random.randint(1, 10)]
+    rng = np.random.default_rng(4030503535)
+    re_locs = [rng.integers(-10, -1), 0, rng.integers(1, 10)]
     _a, _b = distfn.support(*args)
     for loc in re_locs:
         expected = _b + loc, _a - 1 + loc
         res = distfn.isf(0., *args, loc=loc), distfn.isf(1., *args, loc=loc)
         npt.assert_array_equal(expected, res)
     # test broadcasting behaviour
-    re_locs = [np.random.randint(-10, -1, size=(5, 3)),
+    re_locs = [rng.integers(-10, -1, size=(5, 3)),
                np.zeros((5, 3)),
-               np.random.randint(1, 10, size=(5, 3))]
+               rng.integers(1, 10, size=(5, 3))]
     _a, _b = distfn.support(*args)
     for loc in re_locs:
         expected = _b + loc, _a - 1 + loc

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -177,8 +177,8 @@ def test_issue_11134():
 
 
 def test_issue_7406():
-    np.random.seed(0)
-    assert_equal(binom.ppf(np.random.rand(10), 0, 0.5), 0)
+    rng = np.random.default_rng(4763112764)
+    assert_equal(binom.ppf(rng.random(10), 0, 0.5), 0)
 
     # Also check that endpoints (q=0, q=1) are correct
     assert_equal(binom.ppf(0, 0, 0.5), -1)
@@ -186,8 +186,9 @@ def test_issue_7406():
 
 
 def test_issue_5122():
+    rng = np.random.default_rng(8312492117)
     p = 0
-    n = np.random.randint(100, size=10)
+    n = rng.integers(100, size=10)
 
     x = 0
     ppf = binom.ppf(x, n, p)
@@ -397,17 +398,19 @@ class TestZipfian:
 
 
 class TestNCH:
-    np.random.seed(2)  # seeds 0 and 1 had some xl = xu; randint failed
-    shape = (2, 4, 3)
-    max_m = 100
-    m1 = np.random.randint(1, max_m, size=shape)    # red balls
-    m2 = np.random.randint(1, max_m, size=shape)    # white balls
-    N = m1 + m2                                     # total balls
-    n = randint.rvs(0, N, size=N.shape)             # number of draws
-    xl = np.maximum(0, n-m2)                        # lower bound of support
-    xu = np.minimum(n, m1)                          # upper bound of support
-    x = randint.rvs(xl, xu, size=xl.shape)
-    odds = np.random.rand(*x.shape)*2
+    def setup_method(self):
+        rng = np.random.default_rng(7162434334)
+        shape = (2, 4, 3)
+        max_m = 100
+        m1 = rng.integers(1, max_m, size=shape)  # red balls
+        m2 = rng.integers(1, max_m, size=shape)  # white balls
+        N = m1 + m2  # total balls
+        n = randint.rvs(0, N, size=N.shape, random_state=rng)  # number of draws
+        xl = np.maximum(0, n-m2)  # lower bound of support
+        xu = np.minimum(n, m1)  # upper bound of support
+        x = randint.rvs(xl, xu, size=xl.shape, random_state=rng)
+        odds = rng.random(x.shape)*2
+        self.x, self.N, self.m1, self.n, self.odds = x, N, m1, n, odds
 
     # test output is more readable when function names (strings) are passed
     @pytest.mark.parametrize('dist_name',

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -77,6 +77,9 @@ def test_distributions_submodule():
 
 
 class TestVonMises:
+    def setup_method(self):
+        self.rng = np.random.default_rng(6320571663)
+
     @pytest.mark.parametrize('k', [0.1, 1, 101])
     @pytest.mark.parametrize('x', [0, 1, np.pi, 10, 100])
     def test_vonmises_periodic(self, k, x):
@@ -257,7 +260,7 @@ class TestVonMises:
         assert_allclose(dist.ppf(0.9), np.pi*0.8, rtol=1e-15)
         assert_allclose(dist.mean(), 0, atol=1e-15)
         assert_allclose(dist.expect(), 0, atol=1e-15)
-        assert np.all(np.abs(dist.rvs(size=10, random_state=1234)) <= np.pi)
+        assert np.all(np.abs(dist.rvs(size=10, random_state=self.rng)) <= np.pi)
 
     def test_vonmises_fit_equal_data(self):
         # When all data are equal, expect kappa = 1e16.
@@ -355,19 +358,19 @@ def test_support(dist):
 
 class TestRandInt:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(8826485737)
 
     def test_rvs(self):
-        vals = stats.randint.rvs(5, 30, size=100)
+        vals = stats.randint.rvs(5, 30, size=100, random_state=self.rng)
         assert_(np.all(vals < 30) & np.all(vals >= 5))
         assert_(len(vals) == 100)
-        vals = stats.randint.rvs(5, 30, size=(2, 50))
+        vals = stats.randint.rvs(5, 30, size=(2, 50), random_state=self.rng)
         assert_(np.shape(vals) == (2, 50))
         assert_(vals.dtype.char in typecodes['AllInteger'])
-        val = stats.randint.rvs(15, 46)
+        val = stats.randint.rvs(15, 46, random_state=self.rng)
         assert_((val >= 15) & (val < 46))
         assert_(isinstance(val, np.ScalarType), msg=repr(type(val)))
-        val = stats.randint(15, 46).rvs(3)
+        val = stats.randint(15, 46).rvs(3, random_state=self.rng)
         assert_(val.dtype.char in typecodes['AllInteger'])
 
     def test_pdf(self):
@@ -386,16 +389,16 @@ class TestRandInt:
 
 class TestBinom:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(1778595878)
 
     def test_rvs(self):
-        vals = stats.binom.rvs(10, 0.75, size=(2, 50))
+        vals = stats.binom.rvs(10, 0.75, size=(2, 50), random_state=self.rng)
         assert_(np.all(vals >= 0) & np.all(vals <= 10))
         assert_(np.shape(vals) == (2, 50))
         assert_(vals.dtype.char in typecodes['AllInteger'])
-        val = stats.binom.rvs(10, 0.75)
+        val = stats.binom.rvs(10, 0.75, random_state=self.rng)
         assert_(isinstance(val, int))
-        val = stats.binom(10, 0.75).rvs(3)
+        val = stats.binom(10, 0.75).rvs(3, random_state=self.rng)
         assert_(isinstance(val, np.ndarray))
         assert_(val.dtype.char in typecodes['AllInteger'])
 
@@ -469,16 +472,16 @@ class TestArcsine:
 
 class TestBernoulli:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(7836792223)
 
     def test_rvs(self):
-        vals = stats.bernoulli.rvs(0.75, size=(2, 50))
+        vals = stats.bernoulli.rvs(0.75, size=(2, 50), random_state=self.rng)
         assert_(np.all(vals >= 0) & np.all(vals <= 1))
         assert_(np.shape(vals) == (2, 50))
         assert_(vals.dtype.char in typecodes['AllInteger'])
-        val = stats.bernoulli.rvs(0.75)
+        val = stats.bernoulli.rvs(0.75, random_state=self.rng)
         assert_(isinstance(val, int))
-        val = stats.bernoulli(0.75).rvs(3)
+        val = stats.bernoulli(0.75).rvs(3, random_state=self.rng)
         assert_(isinstance(val, np.ndarray))
         assert_(val.dtype.char in typecodes['AllInteger'])
 
@@ -854,16 +857,16 @@ class TestCrystalBall:
 
 class TestNBinom:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(5861367021)
 
     def test_rvs(self):
-        vals = stats.nbinom.rvs(10, 0.75, size=(2, 50))
+        vals = stats.nbinom.rvs(10, 0.75, size=(2, 50), random_state=self.rng)
         assert_(np.all(vals >= 0))
         assert_(np.shape(vals) == (2, 50))
         assert_(vals.dtype.char in typecodes['AllInteger'])
-        val = stats.nbinom.rvs(10, 0.75)
+        val = stats.nbinom.rvs(10, 0.75, random_state=self.rng)
         assert_(isinstance(val, int))
-        val = stats.nbinom(10, 0.75).rvs(3)
+        val = stats.nbinom(10, 0.75).rvs(3, random_state=self.rng)
         assert_(isinstance(val, np.ndarray))
         assert_(val.dtype.char in typecodes['AllInteger'])
 
@@ -884,34 +887,34 @@ class TestNBinom:
 
 class TestGenInvGauss:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(6473281180)
 
     @pytest.mark.slow
     def test_rvs_with_mode_shift(self):
         # ratio_unif w/ mode shift
         gig = stats.geninvgauss(2.3, 1.5)
-        _, p = stats.kstest(gig.rvs(size=1500, random_state=1234), gig.cdf)
+        _, p = stats.kstest(gig.rvs(size=1500, random_state=self.rng), gig.cdf)
         assert_equal(p > 0.05, True)
 
     @pytest.mark.slow
     def test_rvs_without_mode_shift(self):
         # ratio_unif w/o mode shift
         gig = stats.geninvgauss(0.9, 0.75)
-        _, p = stats.kstest(gig.rvs(size=1500, random_state=1234), gig.cdf)
+        _, p = stats.kstest(gig.rvs(size=1500, random_state=self.rng), gig.cdf)
         assert_equal(p > 0.05, True)
 
     @pytest.mark.slow
     def test_rvs_new_method(self):
         # new algorithm of Hoermann / Leydold
         gig = stats.geninvgauss(0.1, 0.2)
-        _, p = stats.kstest(gig.rvs(size=1500, random_state=1234), gig.cdf)
+        _, p = stats.kstest(gig.rvs(size=1500, random_state=self.rng), gig.cdf)
         assert_equal(p > 0.05, True)
 
     @pytest.mark.slow
     def test_rvs_p_zero(self):
         def my_ks_check(p, b):
             gig = stats.geninvgauss(p, b)
-            rvs = gig.rvs(size=1500, random_state=1234)
+            rvs = gig.rvs(size=1500, random_state=self.rng)
             return stats.kstest(rvs, gig.cdf)[1] > 0.05
         # boundary cases when p = 0
         assert_equal(my_ks_check(0, 0.2), True)  # new algo
@@ -926,7 +929,7 @@ class TestGenInvGauss:
 
     def test_invgauss(self):
         # test that invgauss is special case
-        ig = stats.geninvgauss.rvs(size=1500, p=-0.5, b=1, random_state=1234)
+        ig = stats.geninvgauss.rvs(size=1500, p=-0.5, b=1, random_state=1464878613)
         assert_equal(stats.kstest(ig, 'invgauss', args=[1])[1] > 0.15, True)
         # test pdf and cdf
         mu, x = 100, np.linspace(0.01, 1, 10)
@@ -955,8 +958,6 @@ class TestGenInvGauss:
 
 
 class TestGenHyperbolic:
-    def setup_method(self):
-        np.random.seed(1234)
 
     def test_pdf_r(self):
         # test against R package GeneralizedHyperbolic
@@ -1189,9 +1190,6 @@ class TestHypSecant:
 
 
 class TestNormInvGauss:
-    def setup_method(self):
-        np.random.seed(1234)
-
     def test_cdf_R(self):
         # test pdf and cdf vals against R
         # require("GeneralizedHyperbolic")
@@ -1260,16 +1258,16 @@ class TestNormInvGauss:
 
 class TestGeom:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(7672986002)
 
     def test_rvs(self):
-        vals = stats.geom.rvs(0.75, size=(2, 50))
+        vals = stats.geom.rvs(0.75, size=(2, 50), random_state=self.rng)
         assert_(np.all(vals >= 0))
         assert_(np.shape(vals) == (2, 50))
         assert_(vals.dtype.char in typecodes['AllInteger'])
-        val = stats.geom.rvs(0.75)
+        val = stats.geom.rvs(0.75, random_state=self.rng)
         assert_(isinstance(val, int))
-        val = stats.geom(0.75).rvs(3)
+        val = stats.geom(0.75).rvs(3, random_state=self.rng)
         assert_(isinstance(val, np.ndarray))
         assert_(val.dtype.char in typecodes['AllInteger'])
 
@@ -1277,8 +1275,7 @@ class TestGeom:
         # previously, RVS were converted to `np.int32` on some platforms,
         # causing overflow for moderately large integer output (gh-9313).
         # Check that this is resolved to the extent possible w/ `np.int64`.
-        rng = np.random.default_rng(649496242618848)
-        rvs = stats.geom.rvs(np.exp(-35), size=5, random_state=rng)
+        rvs = stats.geom.rvs(np.exp(-35), size=5, random_state=self.rng)
         assert rvs.dtype == np.int64
         assert np.all(rvs > np.iinfo(np.int32).max)
 
@@ -1332,9 +1329,8 @@ class TestGeom:
         random_state = np.random.RandomState(294582935)
         assert (stats.geom.rvs(1e-30, size=10, random_state=random_state) > 0).all()
 
+
 class TestPlanck:
-    def setup_method(self):
-        np.random.seed(1234)
 
     def test_sf(self):
         vals = stats.planck.sf([1, 2, 3], 5.)
@@ -1350,6 +1346,9 @@ class TestPlanck:
 
 
 class TestGennorm:
+    def setup_method(self):
+        self.rng = np.random.default_rng(2204049394)
+
     def test_laplace(self):
         # test against Laplace (special case for beta=1)
         points = [1, 2, 3]
@@ -1365,28 +1364,25 @@ class TestGennorm:
         assert_almost_equal(pdf1, pdf2)
 
     def test_rvs(self):
-        rng = np.random.RandomState(0)
         # 0 < beta < 1
         dist = stats.gennorm(0.5)
-        rvs = dist.rvs(size=1000, random_state=rng)
+        rvs = dist.rvs(size=1000, random_state=self.rng)
         assert stats.kstest(rvs, dist.cdf).pvalue > 0.1
         # beta = 1
         dist = stats.gennorm(1)
-        rvs = dist.rvs(size=1000, random_state=rng)
-        rvs_laplace = stats.laplace.rvs(size=1000, random_state=rng)
+        rvs = dist.rvs(size=1000, random_state=self.rng)
+        rvs_laplace = stats.laplace.rvs(size=1000, random_state=self.rng)
         assert stats.ks_2samp(rvs, rvs_laplace).pvalue > 0.1
         # beta = 2
         dist = stats.gennorm(2)
-        dist.random_state = rng
-        rvs = dist.rvs(size=1000, random_state=rng)
-        rvs_norm = stats.norm.rvs(scale=1/2**0.5, size=1000, random_state=rng)
+        dist.random_state = self.rng
+        rvs = dist.rvs(size=1000, random_state=self.rng)
+        rvs_norm = stats.norm.rvs(scale=1/2**0.5, size=1000, random_state=self.rng)
         assert stats.ks_2samp(rvs, rvs_norm).pvalue > 0.1
 
     def test_rvs_broadcasting(self):
-        rng = np.random.default_rng(0)
         dist = stats.gennorm([[0.5, 1.], [2., 5.]])
-        dist.random_state = rng
-        rvs = dist.rvs(size=[1000, 2, 2])
+        rvs = dist.rvs(size=[1000, 2, 2], random_state=self.rng)
         assert stats.kstest(rvs[:, 0, 0], stats.gennorm(0.5).cdf)[1] > 0.1
         assert stats.kstest(rvs[:, 0, 1], stats.gennorm(1.0).cdf)[1] > 0.1
         assert stats.kstest(rvs[:, 1, 0], stats.gennorm(2.0).cdf)[1] > 0.1
@@ -1723,7 +1719,7 @@ class TestLaplaceasymmetric:
 
 class TestTruncnorm:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(3255963201)
 
     @pytest.mark.parametrize("a, b, ref",
                              [(0, 100, 0.7257913526447274),
@@ -1778,30 +1774,30 @@ class TestTruncnorm:
     def test_gh_2477_small_values(self):
         # Check a case that worked in the original issue.
         low, high = -11, -10
-        x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
+        x = stats.truncnorm.rvs(low, high, 0, 1, size=10, random_state=self.rng)
         assert_(low < x.min() < x.max() < high)
         # Check a case that failed in the original issue.
         low, high = 10, 11
-        x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
+        x = stats.truncnorm.rvs(low, high, 0, 1, size=10, random_state=self.rng)
         assert_(low < x.min() < x.max() < high)
 
     def test_gh_2477_large_values(self):
         # Check a case that used to fail because of extreme tailness.
         low, high = 100, 101
-        x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
+        x = stats.truncnorm.rvs(low, high, 0, 1, size=10, random_state=self.rng)
         assert_(low <= x.min() <= x.max() <= high), str([low, high, x])
 
         # Check some additional extreme tails
         low, high = 1000, 1001
-        x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
+        x = stats.truncnorm.rvs(low, high, 0, 1, size=10, random_state=self.rng)
         assert_(low < x.min() < x.max() < high)
 
         low, high = 10000, 10001
-        x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
+        x = stats.truncnorm.rvs(low, high, 0, 1, size=10, random_state=self.rng)
         assert_(low < x.min() < x.max() < high)
 
         low, high = -10001, -10000
-        x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
+        x = stats.truncnorm.rvs(low, high, 0, 1, size=10, random_state=self.rng)
         assert_(low < x.min() < x.max() < high)
 
     def test_gh_9403_nontail_values(self):
@@ -1951,7 +1947,7 @@ class TestTruncnorm:
     def test_gh_1489_trac_962_rvs(self):
         # Check the original example.
         low, high = 10, 15
-        x = stats.truncnorm.rvs(low, high, 0, 1, size=10)
+        x = stats.truncnorm.rvs(low, high, 0, 1, size=10, random_state=self.rng)
         assert_(low < x.min() < x.max() < high)
 
     def test_gh_11299_rvs(self):
@@ -1959,7 +1955,7 @@ class TestTruncnorm:
         # Test multiple shape parameters simultaneously.
         low = [-10, 10, -np.inf, -5, -np.inf, -np.inf, -45, -45, 40, -10, 40]
         high = [-5, 11, 5, np.inf, 40, -40, 40, -40, 45, np.inf, np.inf]
-        x = stats.truncnorm.rvs(low, high, size=(5, len(low)))
+        x = stats.truncnorm.rvs(low, high, size=(5, len(low)), random_state=self.rng)
         assert np.shape(x) == (5, len(low))
         assert_(np.all(low <= x.min(axis=0)))
         assert_(np.all(x.max(axis=0) <= high))
@@ -1967,8 +1963,7 @@ class TestTruncnorm:
     def test_rvs_Generator(self):
         # check that rvs can use a Generator
         if hasattr(np.random, "default_rng"):
-            stats.truncnorm.rvs(-10, -5, size=5,
-                                random_state=np.random.default_rng())
+            stats.truncnorm.rvs(-10, -5, size=5, random_state=self.rng)
 
     def test_logcdf_gh17064(self):
         # regression test for gh-17064 - avoid roundoff error for logcdfs ~0
@@ -2057,16 +2052,16 @@ class TestGenLogistic:
 
 class TestHypergeom:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(1765545342)
 
     def test_rvs(self):
-        vals = stats.hypergeom.rvs(20, 10, 3, size=(2, 50))
+        vals = stats.hypergeom.rvs(20, 10, 3, size=(2, 50), random_state=self.rng)
         assert np.all(vals >= 0) & np.all(vals <= 3)
         assert np.shape(vals) == (2, 50)
         assert vals.dtype.char in typecodes['AllInteger']
-        val = stats.hypergeom.rvs(20, 3, 10)
+        val = stats.hypergeom.rvs(20, 3, 10, random_state=self.rng)
         assert isinstance(val, int)
-        val = stats.hypergeom(20, 3, 10).rvs(3)
+        val = stats.hypergeom(20, 3, 10).rvs(3, random_state=self.rng)
         assert isinstance(val, np.ndarray)
         assert val.dtype.char in typecodes['AllInteger']
 
@@ -2219,6 +2214,8 @@ class TestHypergeom:
 
 
 class TestLoggamma:
+    def setup_method(self):
+        self.rng = np.random.default_rng(8638464332)
 
     # Expected cdf values were computed with mpmath. For given x and c,
     #     x = mpmath.mpf(x)
@@ -2296,7 +2293,7 @@ class TestLoggamma:
     @pytest.mark.parametrize('c', [0.1, 0.001])
     def test_rvs(self, c):
         # Regression test for gh-11094.
-        x = stats.loggamma.rvs(c, size=100000)
+        x = stats.loggamma.rvs(c, size=100000, random_state=self.rng)
         # Before gh-11094 was fixed, the case with c=0.001 would
         # generate many -inf values.
         assert np.isfinite(x).all()
@@ -2370,6 +2367,9 @@ class TestJohnsonb:
 
 
 class TestLogistic:
+    def setup_method(self):
+        self.rng = np.random.default_rng(2807014525)
+
     # gh-6226
     def test_cdf_ppf(self):
         x = np.linspace(-20, 20)
@@ -2407,7 +2407,8 @@ class TestLogistic:
     @pytest.mark.parametrize("loc_rvs,scale_rvs", [(0.4484955, 0.10216821),
                                                    (0.62918191, 0.74367064)])
     def test_fit(self, loc_rvs, scale_rvs):
-        data = stats.logistic.rvs(size=100, loc=loc_rvs, scale=scale_rvs)
+        data = stats.logistic.rvs(size=100, loc=loc_rvs, scale=scale_rvs,
+                                  random_state=self.rng)
 
         # test that result of fit method is the same as optimization
         def func(input, data):
@@ -2429,7 +2430,7 @@ class TestLogistic:
         assert_allclose(fit_method, expected_solution, atol=1e-30)
 
     def test_fit_comp_optimizer(self):
-        data = stats.logistic.rvs(size=100, loc=0.5, scale=2)
+        data = stats.logistic.rvs(size=100, loc=0.5, scale=2, random_state=self.rng)
         _assert_less_or_close_loglike(stats.logistic, data)
         _assert_less_or_close_loglike(stats.logistic, data, floc=1)
         _assert_less_or_close_loglike(stats.logistic, data, fscale=1)
@@ -2459,16 +2460,16 @@ class TestLogistic:
 
 class TestLogser:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(187505461)
 
     def test_rvs(self):
-        vals = stats.logser.rvs(0.75, size=(2, 50))
+        vals = stats.logser.rvs(0.75, size=(2, 50), random_state=self.rng)
         assert np.all(vals >= 1)
         assert np.shape(vals) == (2, 50)
         assert vals.dtype.char in typecodes['AllInteger']
-        val = stats.logser.rvs(0.75)
+        val = stats.logser.rvs(0.75, random_state=self.rng)
         assert isinstance(val, int)
-        val = stats.logser(0.75).rvs(3)
+        val = stats.logser(0.75).rvs(3, random_state=self.rng)
         assert isinstance(val, np.ndarray)
         assert val.dtype.char in typecodes['AllInteger']
 
@@ -2805,15 +2806,15 @@ class TestGenpareto:
 
 class TestPearson3:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(2775995570)
 
     def test_rvs(self):
-        vals = stats.pearson3.rvs(0.1, size=(2, 50))
+        vals = stats.pearson3.rvs(0.1, size=(2, 50), random_state=self.rng)
         assert np.shape(vals) == (2, 50)
         assert vals.dtype.char in typecodes['AllFloat']
-        val = stats.pearson3.rvs(0.5)
+        val = stats.pearson3.rvs(0.5, random_state=self.rng)
         assert isinstance(val, float)
-        val = stats.pearson3(0.5).rvs(3)
+        val = stats.pearson3(0.5).rvs(3, random_state=self.rng)
         assert isinstance(val, np.ndarray)
         assert val.dtype.char in typecodes['AllFloat']
         assert len(val) == 3
@@ -2956,7 +2957,7 @@ class TestKappa4:
 
 class TestPoisson:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(9799340796)
 
     def test_pmf_basic(self):
         # Basic case
@@ -2975,13 +2976,13 @@ class TestPoisson:
         assert_equal(interval, (0, 0))
 
     def test_rvs(self):
-        vals = stats.poisson.rvs(0.5, size=(2, 50))
+        vals = stats.poisson.rvs(0.5, size=(2, 50), random_state=self.rng)
         assert np.all(vals >= 0)
         assert np.shape(vals) == (2, 50)
         assert vals.dtype.char in typecodes['AllInteger']
-        val = stats.poisson.rvs(0.5)
+        val = stats.poisson.rvs(0.5, random_state=self.rng)
         assert isinstance(val, int)
-        val = stats.poisson(0.5).rvs(3)
+        val = stats.poisson(0.5).rvs(3, random_state=self.rng)
         assert isinstance(val, np.ndarray)
         assert val.dtype.char in typecodes['AllInteger']
 
@@ -2997,8 +2998,6 @@ class TestPoisson:
 
 
 class TestKSTwo:
-    def setup_method(self):
-        np.random.seed(1234)
 
     def test_cdf(self):
         for n in [1, 2, 3, 10, 100, 1000]:
@@ -3144,16 +3143,16 @@ class TestKSTwo:
 
 class TestZipf:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(2444103536)
 
     def test_rvs(self):
-        vals = stats.zipf.rvs(1.5, size=(2, 50))
+        vals = stats.zipf.rvs(1.5, size=(2, 50), random_state=self.rng)
         assert np.all(vals >= 1)
         assert np.shape(vals) == (2, 50)
         assert vals.dtype.char in typecodes['AllInteger']
-        val = stats.zipf.rvs(1.5)
+        val = stats.zipf.rvs(1.5, random_state=self.rng)
         assert isinstance(val, int)
-        val = stats.zipf(1.5).rvs(3)
+        val = stats.zipf(1.5).rvs(3, random_state=self.rng)
         assert isinstance(val, np.ndarray)
         assert val.dtype.char in typecodes['AllInteger']
 
@@ -3169,18 +3168,18 @@ class TestZipf:
 
 class TestDLaplace:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(460403075)
 
     def test_rvs(self):
-        vals = stats.dlaplace.rvs(1.5, size=(2, 50))
+        vals = stats.dlaplace.rvs(1.5, size=(2, 50), random_state=self.rng)
         assert np.shape(vals) == (2, 50)
         assert vals.dtype.char in typecodes['AllInteger']
-        val = stats.dlaplace.rvs(1.5)
+        val = stats.dlaplace.rvs(1.5, random_state=self.rng)
         assert isinstance(val, int)
-        val = stats.dlaplace(1.5).rvs(3)
+        val = stats.dlaplace(1.5).rvs(3, random_state=self.rng)
         assert isinstance(val, np.ndarray)
         assert val.dtype.char in typecodes['AllInteger']
-        assert stats.dlaplace.rvs(0.8) is not None
+        assert stats.dlaplace.rvs(0.8, random_state=self.rng) is not None
 
     def test_stats(self):
         # compare the explicit formulas w/ direct summation using pmf
@@ -3205,13 +3204,13 @@ class TestDLaplace:
 
 class TestInvgauss:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(5422839947)
 
     @pytest.mark.parametrize("rvs_mu,rvs_loc,rvs_scale",
                              [(2, 0, 1), (4.635, 4.362, 6.303)])
     def test_fit(self, rvs_mu, rvs_loc, rvs_scale):
         data = stats.invgauss.rvs(size=100, mu=rvs_mu,
-                                  loc=rvs_loc, scale=rvs_scale)
+                                  loc=rvs_loc, scale=rvs_scale, random_state=self.rng)
         # Analytical MLEs are calculated with formula when `floc` is fixed
         mu, loc, scale = stats.invgauss.fit(data, floc=rvs_loc)
 
@@ -3225,7 +3224,7 @@ class TestInvgauss:
         assert_allclose(scale_mle, scale, atol=1e-15, rtol=1e-15)
         assert_equal(loc, rvs_loc)
         data = stats.invgauss.rvs(size=100, mu=rvs_mu,
-                                  loc=rvs_loc, scale=rvs_scale)
+                                  loc=rvs_loc, scale=rvs_scale, random_state=self.rng)
         # fixed parameters are returned
         mu, loc, scale = stats.invgauss.fit(data, floc=rvs_loc - 1,
                                             fscale=rvs_scale + 1)
@@ -3272,7 +3271,7 @@ class TestInvgauss:
         # fixed `fscale` to an arbitrary number still provides a better fit
         # than the super method
         _assert_less_or_close_loglike(stats.invgauss, data, floc=rvs_loc,
-                                      fscale=np.random.rand(1)[0])
+                                      fscale=self.rng.random(1)[0])
 
     def test_fit_raise_errors(self):
         assert_fit_warnings(stats.invgauss)
@@ -3878,6 +3877,9 @@ class TestF:
 
 
 class TestStudentT:
+    def setup_method(self):
+        self.rng = np.random.default_rng(5442451539)
+
     def test_rvgeneric_std(self):
         # Regression test for #1191
         assert_array_almost_equal(stats.t.std([5, 6]), [1.29099445, 1.22474487])
@@ -3928,10 +3930,9 @@ class TestStudentT:
                                             [[1, 0], [0, 1]],
                                             [[0], [1]]])
     def test_t_inf_df(self, methname, df_infmask):
-        np.random.seed(0)
         df_infmask = np.asarray(df_infmask, dtype=bool)
-        df = np.random.uniform(0, 10, size=df_infmask.shape)
-        x = np.random.randn(*df_infmask.shape)
+        df = self.rng.uniform(0, 10, size=df_infmask.shape)
+        x = self.rng.standard_normal(df_infmask.shape)
         df[df_infmask] = np.inf
         t_dist = stats.t(df=df, loc=3, scale=1)
         t_dist_ref = stats.t(df=df[~df_infmask], loc=3, scale=1)
@@ -3948,9 +3949,8 @@ class TestStudentT:
                                             [[1, 0], [0, 1]],
                                             [[0], [1]]])
     def test_t_inf_df_stats_entropy(self, df_infmask):
-        np.random.seed(0)
         df_infmask = np.asarray(df_infmask, dtype=bool)
-        df = np.random.uniform(0, 10, size=df_infmask.shape)
+        df = self.rng.uniform(0, 10, size=df_infmask.shape)
         df[df_infmask] = np.inf
         res = stats.t.stats(df=df, loc=3, scale=1, moments='mvsk')
         res_ex_inf = stats.norm.stats(loc=3, scale=1, moments='mvsk')
@@ -3994,20 +3994,20 @@ class TestStudentT:
 
 class TestRvDiscrete:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(333348228)
 
     def test_rvs(self):
         states = [-1, 0, 1, 2, 3, 4]
         probability = [0.0, 0.3, 0.4, 0.0, 0.3, 0.0]
         samples = 1000
         r = stats.rv_discrete(name='sample', values=(states, probability))
-        x = r.rvs(size=samples)
+        x = r.rvs(size=samples, random_state=self.rng)
         assert isinstance(x, np.ndarray)
 
         for s, p in zip(states, probability):
             assert abs(sum(x == s)/float(samples) - p) < 0.05
 
-        x = r.rvs()
+        x = r.rvs(random_state=self.rng)
         assert np.issubdtype(type(x), np.integer)
 
     def test_entropy(self):
@@ -5470,6 +5470,9 @@ class TestChi2:
 
 
 class TestGumbelL:
+    def setup_method(self):
+        self.rng = np.random.default_rng(3922444007)
+
     # gh-6228
     def test_cdf_ppf(self):
         x = np.linspace(-100, -4)
@@ -5495,7 +5498,7 @@ class TestGumbelL:
     def test_fit_fixed_param(self, loc):
         # ensure fixed location is correctly reflected from `gumbel_r.fit`
         # See comments at end of gh-12737.
-        data = stats.gumbel_l.rvs(size=100, loc=loc)
+        data = stats.gumbel_l.rvs(size=100, loc=loc, random_state=self.rng)
         fitted_loc, _ = stats.gumbel_l.fit(data, floc=loc)
         assert_equal(fitted_loc, loc)
 
@@ -5522,6 +5525,9 @@ class TestGumbelR:
 
 
 class TestLevyStable:
+    def setup_method(self):
+        self.rng = np.random.default_rng(7195199371)
+
     @pytest.fixture(autouse=True)
     def reset_levy_stable_params(self):
         """Setup default parameters for levy_stable generator"""
@@ -5648,7 +5654,7 @@ class TestLevyStable:
             alpha=alpha, beta=beta, scale=gamma, loc=delta
         )
         _, p = stats.kstest(
-            ls.rvs(size=sample_size, random_state=1234), ls.cdf
+            ls.rvs(size=sample_size, random_state=self.rng), ls.cdf
         )
         assert p > 0.05
 
@@ -5656,12 +5662,11 @@ class TestLevyStable:
     @pytest.mark.parametrize('beta', [0.5, 1])
     def test_rvs_alpha1(self, beta):
         """Additional test cases for rvs for alpha equal to 1."""
-        np.random.seed(987654321)
         alpha = 1.0
         loc = 0.5
         scale = 1.5
         x = stats.levy_stable.rvs(alpha, beta, loc=loc, scale=scale,
-                                  size=5000)
+                                  size=5000, random_state=self.rng)
         stat, p = stats.kstest(x, 'levy_stable',
                                args=(alpha, beta, loc, scale))
         assert p > 0.01
@@ -5705,7 +5710,7 @@ class TestLevyStable:
         """Test that fit agrees with rvs for each parametrization."""
         stats.levy_stable.parametrization = parametrization
         data = stats.levy_stable.rvs(
-            alpha, beta, loc=delta, scale=gamma, size=10000, random_state=1234
+            alpha, beta, loc=delta, scale=gamma, size=10000, random_state=self.rng
         )
         fit = stats.levy_stable._fitstart(data)
         alpha_obs, beta_obs, delta_obs, gamma_obs = fit
@@ -6385,11 +6390,11 @@ class TestLevyStable:
 
 class TestArrayArgument:  # test for ticket:992
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(7556981556)
 
     def test_noexception(self):
         rvs = stats.norm.rvs(loc=(np.arange(5)), scale=np.ones(5),
-                             size=(10, 5))
+                             size=(10, 5), random_state=self.rng)
         assert_equal(rvs.shape, (10, 5))
 
 
@@ -6424,11 +6429,14 @@ def test_args_reduce():
 
 
 class TestFitMethod:
+    def setup_method(self):
+        self.rng = np.random.default_rng(7310515167)
+
     # fitting assumes continuous parameters
     skip = ['ncf', 'ksone', 'kstwo', 'irwinhall']
 
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(4522425749)
 
     # skip these b/c deprecated, or only loc and scale arguments
     fitSkipNonFinite = ['expon', 'norm', 'uniform', 'irwinhall']
@@ -6446,9 +6454,8 @@ class TestFitMethod:
 
     def test_fix_fit_2args_lognorm(self):
         # Regression test for #1551.
-        np.random.seed(12345)
         with np.errstate(all='ignore'):
-            x = stats.lognorm.rvs(0.25, 0., 20.0, size=20)
+            x = stats.lognorm.rvs(0.25, 0., 20.0, size=20, random_state=self.rng)
             expected_shape = np.sqrt(((np.log(x) - np.log(20))**2).mean())
             assert_allclose(np.array(stats.lognorm.fit(x, floc=0, fscale=20)),
                             [expected_shape, 0, 20], atol=1e-8)
@@ -6620,7 +6627,7 @@ class TestFitMethod:
         # take a beta distribution, with shapes='a, b', and make sure that
         # fa is equivalent to f0, and fb is equivalent to f1
         a, b = 3., 4.
-        x = stats.beta.rvs(a, b, size=100, random_state=1234)
+        x = stats.beta.rvs(a, b, size=100, random_state=self.rng)
         res_1 = stats.beta.fit(x, f0=3., method=method)
         res_2 = stats.beta.fit(x, fa=3., method=method)
         assert_allclose(res_1, res_2, atol=1e-12, rtol=1e-12)
@@ -6650,7 +6657,7 @@ class TestFitMethod:
 
         # gamma distribution
         a = 3.
-        data = stats.gamma.rvs(a, size=100)
+        data = stats.gamma.rvs(a, size=100, random_state=self.rng)
         aa, ll, ss = stats.gamma.fit(data, fa=a, method=method)
         assert_equal(aa, a)
 
@@ -6658,15 +6665,12 @@ class TestFitMethod:
     def test_extra_params(self, method):
         # unknown parameters should raise rather than be silently ignored
         dist = stats.exponnorm
-        data = dist.rvs(K=2, size=100)
+        data = dist.rvs(K=2, size=100, random_state=self.rng)
         dct = dict(enikibeniki=-101)
         assert_raises(TypeError, dist.fit, data, **dct, method=method)
 
 
 class TestFrozen:
-    def setup_method(self):
-        np.random.seed(1234)
-
     # Test that a frozen distribution gives the same results as the original
     # object.
     #
@@ -7215,6 +7219,9 @@ class TestRecipInvGauss:
 
 
 class TestRice:
+    def setup_method(self):
+        self.rng = np.random.default_rng(666822542)
+
     def test_rice_zero_b(self):
         # rice distribution should work with b=0, cf gh-2164
         x = [0.2, 1., 5.]
@@ -7238,8 +7245,8 @@ class TestRice:
 
     def test_rice_rvs(self):
         rvs = stats.rice.rvs
-        assert_equal(rvs(b=3.).size, 1)
-        assert_equal(rvs(b=3., size=(3, 5)).shape, (3, 5))
+        assert_equal(rvs(b=3., random_state=self.rng).size, 1)
+        assert_equal(rvs(b=3., size=(3, 5), random_state=self.rng).shape, (3, 5))
 
     def test_rice_gh9836(self):
         # test that gh-9836 is resolved; previously jumped to 1 at the end
@@ -7285,7 +7292,7 @@ class TestRice:
 
 class TestErlang:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(2792245532)
 
     def test_erlang_runtimewarning(self):
         # erlang should generate a RuntimeWarning if a non-integer
@@ -7295,8 +7302,8 @@ class TestErlang:
 
             # The non-integer shape parameter 1.3 should trigger a
             # RuntimeWarning
-            assert_raises(RuntimeWarning,
-                          stats.erlang.rvs, 1.3, loc=0, scale=1, size=4)
+            assert_raises(RuntimeWarning, stats.erlang.rvs, 1.3, loc=0,
+                          scale=1, size=4, random_state=self.rng)
 
             # Calling the fit method with `f0` set to an integer should
             # *not* trigger a RuntimeWarning.  It should return the same
@@ -7313,7 +7320,7 @@ class TestErlang:
 
 class TestRayleigh:
     def setup_method(self):
-        np.random.seed(987654321)
+        self.rng = np.random.default_rng(7186715712)
 
     # gh-6227
     def test_logpdf(self):
@@ -7327,7 +7334,8 @@ class TestRayleigh:
     @pytest.mark.parametrize("rvs_loc,rvs_scale", [(0.85373171, 0.86932204),
                                                    (0.20558821, 0.61621008)])
     def test_fit(self, rvs_loc, rvs_scale):
-        data = stats.rayleigh.rvs(size=250, loc=rvs_loc, scale=rvs_scale)
+        data = stats.rayleigh.rvs(size=250, loc=rvs_loc,
+                                  scale=rvs_scale, random_state=self.rng)
 
         def scale_mle(data, floc):
             return (np.sum((data - floc) ** 2) / (2 * len(data))) ** .5
@@ -7354,7 +7362,8 @@ class TestRayleigh:
     def test_fit_comparison_super_method(self, rvs_loc, rvs_scale):
         # test that the objective function result of the analytical MLEs is
         # less than or equal to that of the numerically optimized estimate
-        data = stats.rayleigh.rvs(size=250, loc=rvs_loc, scale=rvs_scale)
+        data = stats.rayleigh.rvs(size=250, loc=rvs_loc,
+                                  scale=rvs_scale, random_state=self.rng)
         _assert_less_or_close_loglike(stats.rayleigh, data)
 
     def test_fit_warnings(self):
@@ -8798,8 +8807,7 @@ def test_hypergeom_interval_1802():
 
 
 def test_distribution_too_many_args():
-    np.random.seed(1234)
-
+    rng = np.random.default_rng(5976604568)
     # Check that a TypeError is raised when too many args are given to a method
     # Regression test for ticket 1815.
     x = np.linspace(0.1, 0.7, num=5)
@@ -8807,7 +8815,8 @@ def test_distribution_too_many_args():
     assert_raises(TypeError, stats.gamma.pdf, x, 2, 3, 4, loc=1.0)
     assert_raises(TypeError, stats.gamma.pdf, x, 2, 3, 4, 5)
     assert_raises(TypeError, stats.gamma.pdf, x, 2, 3, loc=1.0, scale=0.5)
-    assert_raises(TypeError, stats.gamma.rvs, 2., 3, loc=1.0, scale=0.5)
+    assert_raises(TypeError, stats.gamma.rvs, 2., 3, loc=1.0, scale=0.5,
+                  random_state=rng)
     assert_raises(TypeError, stats.gamma.cdf, x, 2., 3, loc=1.0, scale=0.5)
     assert_raises(TypeError, stats.gamma.ppf, x, 2., 3, loc=1.0, scale=0.5)
     assert_raises(TypeError, stats.gamma.stats, 2., 3, loc=1.0, scale=0.5)
@@ -8820,8 +8829,8 @@ def test_distribution_too_many_args():
     stats.gamma.stats(2., 3)
     stats.gamma.stats(2., 3, 4)
     stats.gamma.stats(2., 3, 4, 'mv')
-    stats.gamma.rvs(2., 3, 4, 5)
-    stats.gamma.fit(stats.gamma.rvs(2., size=7), 2.)
+    stats.gamma.rvs(2., 3, 4, 5, random_state=rng)
+    stats.gamma.fit(stats.gamma.rvs(2., size=7, random_state=rng), 2.)
 
     # Also for a discrete distribution
     stats.geom.pmf(x, 2, loc=3)  # no error, loc=3
@@ -9507,7 +9516,7 @@ def test_ncf_ppf_issue_17026():
 
 class TestHistogram:
     def setup_method(self):
-        np.random.seed(1234)
+        self.rng = np.random.default_rng(6561174822)
 
         # We have 8 bins
         # [1,2), [2,3), [3,4), [4,5), [5,6), [6,7), [7,8), [8,9)
@@ -9518,7 +9527,7 @@ class TestHistogram:
                                   6, 6, 6, 6, 7, 7, 7, 8, 8, 9], bins=8)
         self.template = stats.rv_histogram(histogram)
 
-        data = stats.norm.rvs(loc=1.0, scale=2.5, size=10000, random_state=123)
+        data = stats.norm.rvs(loc=1.0, scale=2.5, size=10000, random_state=self.rng)
         norm_histogram = np.histogram(data, bins=50)
         self.norm_template = stats.rv_histogram(norm_histogram)
 
@@ -9572,7 +9581,7 @@ class TestHistogram:
 
     def test_rvs(self):
         N = 10000
-        sample = self.template.rvs(size=N, random_state=123)
+        sample = self.template.rvs(size=N, random_state=self.rng)
         assert_equal(np.sum(sample < 1.0), 0.0)
         assert_allclose(np.sum(sample <= 2.0), 1.0/25.0 * N, rtol=0.2)
         assert_allclose(np.sum(sample <= 2.5), 2.0/25.0 * N, rtol=0.2)
@@ -9666,7 +9675,7 @@ class TestLogUniform:
         # test roundtrip error
         cdf = rng.uniform(0, 1, size=1000)
         assert_allclose(dist.cdf(dist.ppf(cdf)), cdf)
-        rvs = dist.rvs(size=1000)
+        rvs = dist.rvs(size=1000, random_state=rng)
         assert_allclose(dist.ppf(dist.cdf(rvs)), rvs)
 
         # test a property of the pdf (and that there is no overflow)
@@ -9680,9 +9689,12 @@ class TestLogUniform:
 
 
 class TestArgus:
+    def setup_method(self):
+        self.rng = np.random.default_rng(3395603429)
+
     def test_argus_rvs_large_chi(self):
         # test that the algorithm can handle large values of chi
-        x = stats.argus.rvs(50, size=500, random_state=325)
+        x = stats.argus.rvs(50, size=500, random_state=self.rng)
         assert_almost_equal(stats.argus(50).mean(), x.mean(), decimal=4)
 
     @pytest.mark.parametrize('chi, random_state', [
@@ -9691,7 +9703,7 @@ class TestArgus:
             [3.5, 135]    # chi > 1.8: transform conditional Gamma distribution
         ])
     def test_rvs(self, chi, random_state):
-        x = stats.argus.rvs(chi, size=500, random_state=random_state)
+        x = stats.argus.rvs(chi, size=500, random_state=self.rng)
         _, p = stats.kstest(x, "argus", (chi, ))
         assert_(p > 0.05)
 
@@ -9700,7 +9712,7 @@ class TestArgus:
         # test for gh-11699 => rejection method case 1 can even handle chi=0
         # the CDF of the distribution for chi=0 is 1 - (1 - x**2)**(3/2)
         # test rvs against distribution of limit chi=0
-        r = stats.argus.rvs(chi, size=500, random_state=890981)
+        r = stats.argus.rvs(chi, size=500, random_state=self.rng)
         _, p = stats.kstest(r, lambda x: 1 - (1 - x**2)**(3/2))
         assert_(p > 0.05)
 
@@ -9812,6 +9824,8 @@ class TestArgus:
 
 
 class TestNakagami:
+    def setup_method(self):
+        self.rng = np.random.default_rng(9626839526)
 
     def test_logpdf(self):
         # Test nakagami logpdf for an input where the PDF is smaller
@@ -9915,7 +9929,7 @@ class TestNakagami:
         # The first tuple of the parameters' values is discussed in gh-10908
         N = 100
         samples = stats.nakagami.rvs(size=N, nu=nu, loc=loc,
-                                     scale=scale, random_state=1337)
+                                     scale=scale, random_state=self.rng)
         nu_est, loc_est, scale_est = stats.nakagami.fit(samples)
         assert_allclose(nu_est, nu, rtol=0.2)
         assert_allclose(loc_est, loc, rtol=0.2)
@@ -9946,7 +9960,7 @@ class TestNakagami:
         nu = 0.5
         n = 100
         samples = stats.nakagami.rvs(size=n, nu=nu, loc=loc,
-                                     scale=scale, random_state=1337)
+                                     scale=scale, random_state=self.rng)
         nu_est, loc_est, scale_est = stats.nakagami.fit(samples, f0=nu)
 
         # Analytical values
@@ -9959,6 +9973,8 @@ class TestNakagami:
 
 
 class TestWrapCauchy:
+    def setup_method(self):
+        self.rng = np.random.default_rng(2439107123)
 
     def test_cdf_shape_broadcasting(self):
         # Regression test for gh-13791.
@@ -9990,7 +10006,8 @@ class TestWrapCauchy:
     @pytest.mark.parametrize('scale', [1e-10, 1, 1e10])
     def test_rvs_lie_on_circle(self, c, loc, scale):
         # Check that the random variates lie in range [0, 2*pi]
-        x = stats.wrapcauchy.rvs(c=c, loc=loc, scale=scale, size=1000)
+        x = stats.wrapcauchy.rvs(c=c, loc=loc, scale=scale,
+                                 size=1000, random_state=self.rng)
         assert np.all(x >= 0)
         assert np.all(x <= 2 * np.pi)
 
@@ -10002,9 +10019,9 @@ def test_rvs_no_size_error():
             return 1
 
     rvs_no_size = rvs_no_size_gen(name='rvs_no_size')
-
+    rng = np.random.default_rng(1334886239)
     with assert_raises(TypeError, match=r"_rvs\(\) got (an|\d) unexpected"):
-        rvs_no_size.rvs()
+        rvs_no_size.rvs(random_state=rng)
 
 
 @pytest.mark.parametrize('distname, args', invdistdiscrete + invdistcont)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9686,12 +9686,9 @@ class TestLogUniform:
 
 
 class TestArgus:
-    def setup_method(self):
-        self.rng = np.random.default_rng(3395603429)
-
     def test_argus_rvs_large_chi(self):
         # test that the algorithm can handle large values of chi
-        x = stats.argus.rvs(50, size=500, random_state=self.rng)
+        x = stats.argus.rvs(50, size=500, random_state=325)
         assert_almost_equal(stats.argus(50).mean(), x.mean(), decimal=4)
 
     @pytest.mark.parametrize('chi, random_state', [
@@ -9700,7 +9697,7 @@ class TestArgus:
             [3.5, 135]    # chi > 1.8: transform conditional Gamma distribution
         ])
     def test_rvs(self, chi, random_state):
-        x = stats.argus.rvs(chi, size=500, random_state=self.rng)
+        x = stats.argus.rvs(chi, size=500, random_state=random_state)
         _, p = stats.kstest(x, "argus", (chi, ))
         assert_(p > 0.05)
 
@@ -9709,7 +9706,7 @@ class TestArgus:
         # test for gh-11699 => rejection method case 1 can even handle chi=0
         # the CDF of the distribution for chi=0 is 1 - (1 - x**2)**(3/2)
         # test rvs against distribution of limit chi=0
-        r = stats.argus.rvs(chi, size=500, random_state=self.rng)
+        r = stats.argus.rvs(chi, size=500, random_state=890981)
         _, p = stats.kstest(r, lambda x: 1 - (1 - x**2)**(3/2))
         assert_(p > 0.05)
 

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6429,9 +6429,6 @@ def test_args_reduce():
 
 
 class TestFitMethod:
-    def setup_method(self):
-        self.rng = np.random.default_rng(7310515167)
-
     # fitting assumes continuous parameters
     skip = ['ncf', 'ksone', 'kstwo', 'irwinhall']
 

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -226,7 +226,8 @@ class TestDifferentialEntropy:
         )
 
     def test_input_validation(self, xp):
-        x = np.random.rand(10)
+        rng = np.random.default_rng(4315387321)
+        x = rng.random(10)
         x = xp.asarray(x.tolist())
 
         message = "`base` must be a positive number or `None`."

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -226,8 +226,7 @@ class TestDifferentialEntropy:
         )
 
     def test_input_validation(self, xp):
-        rng = np.random.default_rng(4315387321)
-        x = rng.random(10)
+        x = np.ones(10)
         x = xp.asarray(x.tolist())
 
         message = "`base` must be a positive number or `None`."

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -1011,7 +1011,7 @@ class TestSomersD(_TestPythranFunc):
         # generate lists of random classes 1-2 (binary)
         classes = [1, 2]
         n_samples = 10 ** 6
-        rng = np.random.default_rng(6889320191)  #
+        rng = np.random.default_rng(6889320191)
         x = rng.choice(classes, n_samples)
         y = rng.choice(classes, n_samples)
 

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -1,7 +1,6 @@
 from itertools import product
 
 import numpy as np
-import random
 import functools
 import pytest
 from numpy.testing import (assert_, assert_equal, assert_allclose,
@@ -45,7 +44,6 @@ class TestEppsSingleton:
         assert_almost_equal(p, 0.06364, decimal=3)
 
     def test_epps_singleton_array_like(self):
-        np.random.seed(1234)
         x, y = np.arange(30), np.arange(28)
 
         w1, p1 = epps_singleton_2samp(list(x), list(y))
@@ -469,13 +467,13 @@ class TestMannWhitneyU:
         # is performed on one pair of samples at a time.
         # Tests that gh-12837 and gh-11113 (requests for n-d input)
         # are resolved
-        np.random.seed(0)
+        rng = np.random.default_rng(6083743794)
 
         # arrays are broadcastable except for axis = -3
         axis = -3
         m, n = 7, 10  # sample sizes
-        x = np.random.rand(m, 3, 8)
-        y = np.random.rand(6, n, 1, 8) + 0.1
+        x = rng.random((m, 3, 8))
+        y = rng.random((6, n, 1, 8)) + 0.1
         res = mannwhitneyu(x, y, method=method, axis=axis)
 
         shape = (6, 3, 8)  # appropriate shape of outputs, given inputs
@@ -1005,7 +1003,6 @@ class TestSomersD(_TestPythranFunc):
         assert res.statistic == expected_statistic
         assert res.pvalue == (0 if positive_correlation else 1)
 
-    @pytest.mark.thread_unsafe(reason="fails in parallel")
     def test_somersd_large_inputs_gh18132(self):
         # Test that large inputs where potential overflows could occur give
         # the expected output. This is tested in the case of binary inputs.
@@ -1014,16 +1011,16 @@ class TestSomersD(_TestPythranFunc):
         # generate lists of random classes 1-2 (binary)
         classes = [1, 2]
         n_samples = 10 ** 6
-        random.seed(6272161)
-        x = random.choices(classes, k=n_samples)
-        y = random.choices(classes, k=n_samples)
+        rng = np.random.default_rng(6889320191)  #
+        x = rng.choice(classes, n_samples)
+        y = rng.choice(classes, n_samples)
 
         # get value to compare with: sklearn output
         # from sklearn import metrics
         # val_auc_sklearn = metrics.roc_auc_score(x, y)
         # # convert to the Gini coefficient (Gini = (AUC*2)-1)
         # val_sklearn = 2 * val_auc_sklearn - 1
-        val_sklearn = -0.001528138777036947
+        val_sklearn = 0.000624401938730923
 
         # calculate the Somers' D statistic, which should be equal to the
         # result of val_sklearn until approximately machine precision
@@ -1614,8 +1611,8 @@ class TestTukeyHSD:
 
     def test_rand_symm(self):
         # test some expected identities of the results
-        np.random.seed(1234)
-        data = np.random.rand(3, 100)
+        rng = np.random.default_rng(2699550179)
+        data = rng.random((3, 100))
         res = stats.tukey_hsd(*data)
         conf = res.confidence_interval()
         # the confidence intervals should be negated symmetric of each other

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -458,7 +458,8 @@ def test_pdf_logpdf_weighted():
     assert_almost_equal(logpdf, logpdf2, decimal=12)
 
     # There are more points than data
-    gkde = stats.gaussian_kde(xs, weights=np.random.rand(len(xs)))
+    rng = np.random.default_rng(4531935345)
+    gkde = stats.gaussian_kde(xs, weights=rng.random(len(xs)))
     pdf = np.log(gkde.evaluate(xn))
     pdf2 = gkde.logpdf(xn)
     assert_almost_equal(pdf, pdf2, decimal=12)

--- a/scipy/stats/tests/test_mgc.py
+++ b/scipy/stats/tests/test_mgc.py
@@ -74,7 +74,7 @@ class TestMGCStat:
         self.rng = np.random.default_rng(1266219746)
 
     def _simulations(self, samps=100, dims=1, sim_type="", rng=None):
-        rng = rng if rng is not None else self.rng
+        rng = rng or self.rng
         # linear simulation
         if sim_type == "linear":
             x = rng.uniform(-1, 1, size=(samps, 1))
@@ -89,8 +89,8 @@ class TestMGCStat:
 
         # independence (tests type I simulation)
         elif sim_type == "independence":
-            u = self.rng.normal(0, 1, size=(samps, 1))
-            v = self.rng.normal(0, 1, size=(samps, 1))
+            u = self.rng.standard_normal(size=(samps, 1))
+            v = self.rng.standard_normal(size=(samps, 1))
             u_2 = self.rng.binomial(1, p=0.5, size=(samps, 1))
             v_2 = self.rng.binomial(1, p=0.5, size=(samps, 1))
             x = u/3 + 2*u_2 - 1
@@ -103,7 +103,7 @@ class TestMGCStat:
 
         # add dimensions of noise for higher dimensions
         if dims > 1:
-            dims_noise = self.rng.normal(0, 1, size=(samps, dims-1))
+            dims_noise = self.rng.standard_normal(size=(samps, dims-1))
             x = np.concatenate((x, dims_noise), axis=1)
 
         return x, y
@@ -147,7 +147,7 @@ class TestMGCStat:
     def test_twosamp(self):
         # generate x and y
         x = self.rng.binomial(100, 0.5, size=(100, 5))
-        y = self.rng.normal(0, 1, size=(80, 5))
+        y = self.rng.standard_normal(size=(80, 5))
 
         # test stat and pvalue
         stat, pvalue, _ = stats.multiscale_graphcorr(x, y, random_state=self.rng)
@@ -155,7 +155,7 @@ class TestMGCStat:
         assert_approx_equal(pvalue, 0.001, significant=1)
 
         # generate x and y
-        y = self.rng.normal(0, 1, size=(100, 5))
+        y = self.rng.standard_normal(size=(100, 5))
 
         # test stat and pvalue
         stat, pvalue, _ = stats.multiscale_graphcorr(x, y, is_twosamp=True,

--- a/scipy/stats/tests/test_mgc.py
+++ b/scipy/stats/tests/test_mgc.py
@@ -70,25 +70,29 @@ class TestMGCErrorWarnings:
 class TestMGCStat:
     """ Test validity of MGC test statistic
     """
-    def _simulations(self, samps=100, dims=1, sim_type=""):
+    def setup_method(self):
+        self.rng = np.random.default_rng(1266219746)
+
+    def _simulations(self, samps=100, dims=1, sim_type="", rng=None):
+        rng = rng if rng is not None else self.rng
         # linear simulation
         if sim_type == "linear":
-            x = np.random.uniform(-1, 1, size=(samps, 1))
-            y = x + 0.3 * np.random.random_sample(size=(x.size, 1))
+            x = rng.uniform(-1, 1, size=(samps, 1))
+            y = x + 0.3 * rng.random(size=(x.size, 1))
 
         # spiral simulation
         elif sim_type == "nonlinear":
-            unif = np.array(np.random.uniform(0, 5, size=(samps, 1)))
+            unif = np.array(self.rng.uniform(0, 5, size=(samps, 1)))
             x = unif * np.cos(np.pi * unif)
             y = (unif * np.sin(np.pi * unif) +
-                 0.4*np.random.random_sample(size=(x.size, 1)))
+                 0.4*self.rng.random(size=(x.size, 1)))
 
         # independence (tests type I simulation)
         elif sim_type == "independence":
-            u = np.random.normal(0, 1, size=(samps, 1))
-            v = np.random.normal(0, 1, size=(samps, 1))
-            u_2 = np.random.binomial(1, p=0.5, size=(samps, 1))
-            v_2 = np.random.binomial(1, p=0.5, size=(samps, 1))
+            u = self.rng.normal(0, 1, size=(samps, 1))
+            v = self.rng.normal(0, 1, size=(samps, 1))
+            u_2 = self.rng.binomial(1, p=0.5, size=(samps, 1))
+            v_2 = self.rng.binomial(1, p=0.5, size=(samps, 1))
             x = u/3 + 2*u_2 - 1
             y = v/3 + 2*v_2 - 1
 
@@ -99,74 +103,74 @@ class TestMGCStat:
 
         # add dimensions of noise for higher dimensions
         if dims > 1:
-            dims_noise = np.random.normal(0, 1, size=(samps, dims-1))
+            dims_noise = self.rng.normal(0, 1, size=(samps, dims-1))
             x = np.concatenate((x, dims_noise), axis=1)
 
         return x, y
 
     @pytest.mark.xslow
     @pytest.mark.parametrize("sim_type, obs_stat, obs_pvalue", [
+        # Reference values produced by `multiscale_graphcorr` ->
+        # this only guards against unintended changes
         ("linear", 0.97, 1/1000),           # test linear simulation
         ("nonlinear", 0.163, 1/1000),       # test spiral simulation
-        ("independence", -0.0094, 0.78)     # test independence simulation
+        ("independence", -0.0012, 0.3646)   # test independence simulation
     ])
     def test_oned(self, sim_type, obs_stat, obs_pvalue):
-        np.random.seed(12345678)
-
         # generate x and y
-        x, y = self._simulations(samps=100, dims=1, sim_type=sim_type)
+        rng = np.random.default_rng(8157117705)
+        x, y = self._simulations(samps=100, dims=1, sim_type=sim_type, rng=rng)
 
         # test stat and pvalue
-        stat, pvalue, _ = stats.multiscale_graphcorr(x, y)
+        stat, pvalue, _ = stats.multiscale_graphcorr(x, y, random_state=rng)
         assert_approx_equal(stat, obs_stat, significant=1)
         assert_approx_equal(pvalue, obs_pvalue, significant=1)
 
     @pytest.mark.xslow
     @pytest.mark.parametrize("sim_type, obs_stat, obs_pvalue", [
+        # Reference values produced by `multiscale_graphcorr` ->
+        # this only guards against unintended changes
         ("linear", 0.184, 1/1000),           # test linear simulation
-        ("nonlinear", 0.0190, 0.117),        # test spiral simulation
+        ("nonlinear", 0.113, 0.001),         # test spiral simulation
     ])
     def test_fived(self, sim_type, obs_stat, obs_pvalue):
-        np.random.seed(12345678)
-
         # generate x and y
-        x, y = self._simulations(samps=100, dims=5, sim_type=sim_type)
+        rng = np.random.default_rng(8157117705)
+        x, y = self._simulations(samps=100, dims=5, sim_type=sim_type, rng=rng)
 
         # test stat and pvalue
-        stat, pvalue, _ = stats.multiscale_graphcorr(x, y)
+        stat, pvalue, _ = stats.multiscale_graphcorr(x, y, random_state=rng)
         assert_approx_equal(stat, obs_stat, significant=1)
         assert_approx_equal(pvalue, obs_pvalue, significant=1)
 
     @pytest.mark.xslow
     def test_twosamp(self):
-        np.random.seed(12345678)
-
         # generate x and y
-        x = np.random.binomial(100, 0.5, size=(100, 5))
-        y = np.random.normal(0, 1, size=(80, 5))
+        x = self.rng.binomial(100, 0.5, size=(100, 5))
+        y = self.rng.normal(0, 1, size=(80, 5))
 
         # test stat and pvalue
-        stat, pvalue, _ = stats.multiscale_graphcorr(x, y)
+        stat, pvalue, _ = stats.multiscale_graphcorr(x, y, random_state=self.rng)
         assert_approx_equal(stat, 1.0, significant=1)
         assert_approx_equal(pvalue, 0.001, significant=1)
 
         # generate x and y
-        y = np.random.normal(0, 1, size=(100, 5))
+        y = self.rng.normal(0, 1, size=(100, 5))
 
         # test stat and pvalue
-        stat, pvalue, _ = stats.multiscale_graphcorr(x, y, is_twosamp=True)
+        stat, pvalue, _ = stats.multiscale_graphcorr(x, y, is_twosamp=True,
+                                                     random_state=self.rng)
         assert_approx_equal(stat, 1.0, significant=1)
         assert_approx_equal(pvalue, 0.001, significant=1)
 
     @pytest.mark.xslow
     def test_workers(self):
-        np.random.seed(12345678)
-
         # generate x and y
         x, y = self._simulations(samps=100, dims=1, sim_type="linear")
 
         # test stat and pvalue
-        stat, pvalue, _ = stats.multiscale_graphcorr(x, y, workers=2)
+        stat, pvalue, _ = stats.multiscale_graphcorr(x, y, workers=2,
+                                                     random_state=self.rng)
         assert_approx_equal(stat, 0.97, significant=1)
         assert_approx_equal(pvalue, 0.001, significant=1)
 
@@ -182,7 +186,6 @@ class TestMGCStat:
 
     @pytest.mark.xslow
     def test_dist_perm(self):
-        np.random.seed(12345678)
         # generate x and y
         x, y = self._simulations(samps=100, dims=1, sim_type="nonlinear")
         distx = cdist(x, x, metric="euclidean")
@@ -197,8 +200,6 @@ class TestMGCStat:
     @pytest.mark.fail_slow(20)  # all other tests are XSLOW; we need at least one to run
     @pytest.mark.slow
     def test_pvalue_literature(self):
-        np.random.seed(12345678)
-
         # generate x and y
         x, y = self._simulations(samps=100, dims=1, sim_type="linear")
 
@@ -208,8 +209,6 @@ class TestMGCStat:
 
     @pytest.mark.xslow
     def test_alias(self):
-        np.random.seed(12345678)
-
         # generate x and y
         x, y = self._simulations(samps=100, dims=1, sim_type="linear")
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -816,8 +816,8 @@ class TestLevene:
 
     def test_equal_mean_median(self):
         x = np.linspace(-1, 1, 21)
-        np.random.seed(1234)
-        x2 = np.random.permutation(x)
+        rng = np.random.default_rng(4058827756)
+        x2 = rng.permutation(x)
         y = x**3
         W1, pval1 = stats.levene(x, y, center='mean')
         W2, pval2 = stats.levene(x2, y, center='median')
@@ -1235,9 +1235,9 @@ class TestMood:
     def test_mood_order_of_args(self):
         # z should change sign when the order of arguments changes, pvalue
         # should not change
-        np.random.seed(1234)
-        x1 = np.random.randn(10, 1)
-        x2 = np.random.randn(15, 1)
+        rng = np.random.default_rng(4058827756)
+        x1 = rng.standard_normal((10, 1))
+        x2 = rng.standard_normal((15, 1))
         z1, p1 = stats.mood(x1, x2)
         z2, p2 = stats.mood(x2, x1)
         assert_array_almost_equal([z1, p1], [-z2, p2])
@@ -1272,9 +1272,9 @@ class TestMood:
         # Test if the results of mood test in 2-D case are consistent with the
         # R result for the same inputs.  Numbers from R mood.test().
         ny = 5
-        np.random.seed(1234)
-        x1 = np.random.randn(10, ny)
-        x2 = np.random.randn(15, ny)
+        rng = np.random.default_rng()
+        x1 = rng.standard_normal((10, ny))
+        x2 = rng.standard_normal((15, ny))
         z_vectest, pval_vectest = stats.mood(x1, x2)
 
         for j in range(ny):
@@ -1293,9 +1293,9 @@ class TestMood:
 
     def test_mood_3d(self):
         shape = (10, 5, 6)
-        np.random.seed(1234)
-        x1 = np.random.randn(*shape)
-        x2 = np.random.randn(*shape)
+        rng = np.random.default_rng(3602349075)
+        x1 = rng.standard_normal(shape)
+        x2 = rng.standard_normal(shape)
 
         for axis in range(3):
             z_vectest, pval_vectest = stats.mood(x1, x2, axis=axis)

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -284,9 +284,10 @@ class TestCorr:
         assert_allclose(p, 0.9977404035446)
 
         # intuitive test (with obvious positive correlation)
+        rng = np.random.default_rng(9607138567)
         n = 100
         x = np.linspace(0, 5, n)
-        y = 0.1*x + np.random.rand(n)  # y is positively correlated w/ x
+        y = 0.1*x + rng.random(n)  # y is positively correlated w/ x
 
         stat1, p1 = mstats.spearmanr(x, y)
 
@@ -420,11 +421,11 @@ class TestCorr:
         # nan_policy='omit' matches behavior of stats.kendalltau
         # Accuracy of the alternatives is tested in stats/tests/test_stats.py
 
-        np.random.seed(0)
+        rng = np.random.default_rng(8755235945)
         n = 50
-        x = np.random.rand(n)
-        y = np.random.rand(n)
-        mask = np.random.rand(n) > 0.5
+        x = rng.random(n)
+        y = rng.random(n)
+        mask = rng.random(n) > 0.5
 
         x_masked = ma.array(x, mask=mask)
         y_masked = ma.array(y, mask=mask)
@@ -934,8 +935,9 @@ def test_regress_simple():
 
 
 def test_linregress_identical_x():
+    rng = np.random.default_rng(74578245698)
     x = np.zeros(10)
-    y = np.random.random(10)
+    y = rng.random(10)
     msg = "Cannot calculate a linear regression if all x values are identical"
     with assert_raises(ValueError, match=msg):
         mstats.linregress(x, y)
@@ -1259,9 +1261,11 @@ class TestKruskal:
 
 # TODO: for all ttest functions, add tests with masked array inputs
 class TestTtest_rel:
+    def setup_method(self):
+        self.rng = np.random.default_rng(9373599542)
+
     def test_vs_nonmasked(self):
-        np.random.seed(1234567)
-        outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
+        outcome = self.rng.standard_normal((20, 4)) + [0, 0, 1, 2]
 
         # 1-D inputs
         res1 = stats.ttest_rel(outcome[:, 0], outcome[:, 1])
@@ -1281,8 +1285,7 @@ class TestTtest_rel:
         assert_allclose(res2, res3)
 
     def test_fully_masked(self):
-        np.random.seed(1234567)
-        outcome = ma.masked_array(np.random.randn(3, 2),
+        outcome = ma.masked_array(self.rng.standard_normal((3, 2)),
                                   mask=[[1, 1, 1], [0, 0, 0]])
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -1294,8 +1297,7 @@ class TestTtest_rel:
                 assert_array_equal(p, (np.nan, np.nan))
 
     def test_result_attributes(self):
-        np.random.seed(1234567)
-        outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
+        outcome = self.rng.standard_normal((20, 4)) + [0, 0, 1, 2]
 
         res = mstats.ttest_rel(outcome[:, 0], outcome[:, 1])
         attributes = ('statistic', 'pvalue')
@@ -1353,9 +1355,11 @@ class TestTtest_rel:
 
 
 class TestTtest_ind:
+    def setup_method(self):
+        self.rng = np.random.default_rng(4776115069)
+
     def test_vs_nonmasked(self):
-        np.random.seed(1234567)
-        outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
+        outcome = self.rng.standard_normal((20, 4)) + [0, 0, 1, 2]
 
         # 1-D inputs
         res1 = stats.ttest_ind(outcome[:, 0], outcome[:, 1])
@@ -1383,8 +1387,8 @@ class TestTtest_ind:
         assert_allclose(res4, res5)
 
     def test_fully_masked(self):
-        np.random.seed(1234567)
-        outcome = ma.masked_array(np.random.randn(3, 2), mask=[[1, 1, 1], [0, 0, 0]])
+        outcome = ma.masked_array(self.rng.standard_normal((3, 2)),
+                                  mask=[[1, 1, 1], [0, 0, 0]])
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", "invalid value encountered in absolute", RuntimeWarning)
@@ -1395,8 +1399,7 @@ class TestTtest_ind:
                 assert_array_equal(p, (np.nan, np.nan))
 
     def test_result_attributes(self):
-        np.random.seed(1234567)
-        outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
+        outcome = self.rng.standard_normal((20, 4)) + [0, 0, 1, 2]
 
         res = mstats.ttest_ind(outcome[:, 0], outcome[:, 1])
         attributes = ('statistic', 'pvalue')
@@ -1450,9 +1453,11 @@ class TestTtest_ind:
 
 
 class TestTtest_1samp:
+    def setup_method(self):
+        self.rng = np.random.default_rng(6043813830)
+
     def test_vs_nonmasked(self):
-        np.random.seed(1234567)
-        outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
+        outcome = self.rng.standard_normal((20, 4)) + [0, 0, 1, 2]
 
         # 1-D inputs
         res1 = stats.ttest_1samp(outcome[:, 0], 1)
@@ -1460,8 +1465,7 @@ class TestTtest_1samp:
         assert_allclose(res1, res2)
 
     def test_fully_masked(self):
-        np.random.seed(1234567)
-        outcome = ma.masked_array(np.random.randn(3), mask=[1, 1, 1])
+        outcome = ma.masked_array(self.rng.standard_normal(3), mask=[1, 1, 1])
         expected = (np.nan, np.nan)
         with warnings.catch_warnings():
             warnings.filterwarnings(
@@ -1472,8 +1476,7 @@ class TestTtest_1samp:
                 assert_array_equal(t, expected)
 
     def test_result_attributes(self):
-        np.random.seed(1234567)
-        outcome = np.random.randn(20, 4) + [0, 0, 1, 2]
+        outcome = self.rng.standard_normal((20, 4)) + [0, 0, 1, 2]
 
         res = mstats.ttest_1samp(outcome[:, 0], 1)
         attributes = ('statistic', 'pvalue')
@@ -1837,7 +1840,8 @@ class TestCompareWithStats:
 
     def test_skewtest_2D_notmasked(self):
         # a normal ndarray is passed to the masked function
-        x = np.random.random((20, 2)) * 20.
+        rng = np.random.default_rng(2790153686)
+        x = rng.random((20, 2)) * 20.
         r = stats.skewtest(x)
         rm = stats.mstats.skewtest(x)
         assert_allclose(np.asarray(r), np.asarray(rm))

--- a/scipy/stats/tests/test_mstats_extras.py
+++ b/scipy/stats/tests/test_mstats_extras.py
@@ -36,8 +36,8 @@ def test_hdmedian():
 
 
 def test_rsh():
-    np.random.seed(132345)
-    x = np.random.randn(100)
+    rng = np.random.default_rng(806795795)
+    x = rng.standard_normal(100)
     res = ms.rsh(x)
     # Just a sanity check that the code runs and output shape is correct.
     # TODO: check that implementation is correct.

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -289,7 +289,8 @@ def _random_covariance(dim, evals, rng, singular=False):
 
 
 def _sample_orthonormal_matrix(n):
-    M = np.random.randn(n, n)
+    rng = np.random.default_rng(9086764251)
+    M = rng.standard_normal((n, n))
     u, s, v = scipy.linalg.svd(M)
     return u
 
@@ -3331,7 +3332,8 @@ class TestMultivariateT:
         # pdf() and logpdf() should return probabilities of shape
         # (n_samples,) when x has n_samples.
         n_samples = 7
-        x = np.random.random((n_samples, dim))
+        rng = np.random.default_rng(2767231913)
+        x = rng.random((n_samples, dim))
         res = multivariate_t(loc, shape, df).pdf(x)
         assert (res.shape == (n_samples,))
         res = multivariate_t(loc, shape, df).logpdf(x)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -564,7 +564,7 @@ def test_bootstrap_alternative(method):
 def test_jackknife_resample():
     shape = 3, 4, 5, 6
     rng = np.random.default_rng(5274950392)
-    x = rng.standard_normal(shape)
+    x = rng.random(size=shape)
     y = next(_resampling._jackknife_resample(x))
 
     for i in range(shape[-1]):
@@ -583,8 +583,8 @@ def test_jackknife_resample():
 @pytest.mark.parametrize("rng_name", ["RandomState", "default_rng"])
 def test_bootstrap_resample(rng_name):
     rng = getattr(np.random, rng_name)
-    rng1 = rng(0)
-    rng2 = rng(0)
+    rng1 = rng(3949441460)
+    rng2 = rng(3949441460)
 
     n_resamples = 10
     shape = 3, 4, 5, 6

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -563,8 +563,8 @@ def test_bootstrap_alternative(method):
 
 def test_jackknife_resample():
     shape = 3, 4, 5, 6
-    np.random.seed(0)
-    x = np.random.rand(*shape)
+    rng = np.random.default_rng(5274950392)
+    x = rng.standard_normal(shape)
     y = next(_resampling._jackknife_resample(x))
 
     for i in range(shape[-1]):
@@ -582,17 +582,15 @@ def test_jackknife_resample():
 
 @pytest.mark.parametrize("rng_name", ["RandomState", "default_rng"])
 def test_bootstrap_resample(rng_name):
-    rng = getattr(np.random, rng_name, None)
-    if rng is None:
-        pytest.skip(f"{rng_name} not available.")
+    rng = getattr(np.random, rng_name)
     rng1 = rng(0)
     rng2 = rng(0)
 
     n_resamples = 10
     shape = 3, 4, 5, 6
 
-    np.random.seed(0)
-    x = np.random.rand(*shape)
+    rng = np.random.default_rng(5274950392)
+    x = rng.random(shape)
     y = _resampling._bootstrap_resample(x, n_resamples, rng=rng1)
 
     for i in range(n_resamples):
@@ -610,8 +608,8 @@ def test_bootstrap_resample(rng_name):
 @pytest.mark.parametrize("axis", [0, 1, 2])
 def test_percentile_of_score(score, axis):
     shape = 10, 20, 30
-    np.random.seed(0)
-    x = np.random.rand(*shape)
+    rng = np.random.default_rng(5903363153)
+    x = rng.random(shape)
     p = _resampling._percentile_of_score(x, score, axis=-1)
 
     def vectorized_pos(a, score, axis):

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -568,8 +568,8 @@ class TestBootstrap:
 
     def test_jackknife_resample(self, xp):
         shape = 3, 4, 5, 6
-        np.random.seed(0)
-        x = np.random.rand(*shape)
+        rng = np.random.default_rng(5274950392)
+        x = rng.random(size=shape)
         y = next(_resampling._jackknife_resample(xp.asarray(x), xp=xp))
 
         for i in range(shape[-1]):
@@ -587,15 +587,14 @@ class TestBootstrap:
                                   reason="Test uses ... + fancy indexing")
     @pytest.mark.parametrize("rng_name", ["RandomState", "default_rng"])
     def test_bootstrap_resample(self, rng_name, xp):
-        rng = getattr(np.random, rng_name)
-
-        rng1 = rng(0)
-        rng2 = rng(0)
+        rng_gen = getattr(np.random, rng_name)
+        rng1 = rng_gen(3949441460)
+        rng2 = rng_gen(3949441460)
 
         n_resamples = 10
         shape = 3, 4, 5, 6
 
-        rng = np.random.default_rng(5894822712842015040)
+        rng = np.random.default_rng(5274950392)
         x = xp.asarray(rng.random(shape))
         y = _resampling._bootstrap_resample(x, n_resamples, rng=rng1, xp=xp)
 
@@ -613,8 +612,8 @@ class TestBootstrap:
     @pytest.mark.parametrize("axis", [0, 1, 2])
     def test_percentile_of_score(self, score, axis, xp):
         shape = 10, 20, 30
-        np.random.seed(0)
-        x = np.random.rand(*shape)
+        rng = np.random.default_rng(5903363153)
+        x = rng.random(shape)
         dtype = xp_default_dtype(xp)
         p = _resampling._percentile_of_score(xp.asarray(x, dtype=dtype),
                                              xp.asarray(score, dtype=dtype),

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -176,7 +176,7 @@ def test_random_state(method, kwargs):
     rng = np.random.RandomState(123)
     rng1 = Method(**kwargs)
     rvs1 = rng1.rvs(100, random_state=rng)
-    np.random.seed(None)
+    np.random.seed(None)  # valid use of np.random.seed
     rng2 = Method(**kwargs, random_state=123)
     rvs2 = rng2.rvs(100)
     assert_equal(rvs1, rvs2)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1068,6 +1068,9 @@ class TestCorrSpearmanr:
         your program has them.
     """
 
+    def setup_method(self):
+        self.rng = np.random.default_rng(228584263)
+
     def test_scalar(self):
         y = stats.spearmanr(4., 2.)
         assert_(np.isnan(y).all())
@@ -1078,9 +1081,8 @@ class TestCorrSpearmanr:
 
     def test_uneven_2d_shapes(self):
         # Different number of columns should work - those just get concatenated.
-        np.random.seed(232324)
-        x = np.random.randn(4, 3)
-        y = np.random.randn(4, 2)
+        x = self.rng.standard_normal((4, 3))
+        y = self.rng.standard_normal((4, 2))
         assert stats.spearmanr(x, y).statistic.shape == (5, 5)
         assert stats.spearmanr(x.T, y.T, axis=1).pvalue.shape == (5, 5)
 
@@ -1088,8 +1090,7 @@ class TestCorrSpearmanr:
         assert_raises(ValueError, stats.spearmanr, x.T, y.T)
 
     def test_ndim_too_high(self):
-        np.random.seed(232324)
-        x = np.random.randn(4, 3, 2)
+        x = self.rng.standard_normal((4, 3, 2))
         assert_raises(ValueError, stats.spearmanr, x)
         assert_raises(ValueError, stats.spearmanr, x, x)
         assert_raises(ValueError, stats.spearmanr, x, None, None)
@@ -1107,8 +1108,8 @@ class TestCorrSpearmanr:
         assert_raises(ValueError, stats.spearmanr, x, x, nan_policy='foobar')
 
     def test_nan_policy_bug_12458(self):
-        np.random.seed(5)
-        x = np.random.rand(5, 10)
+        rng = np.random.default_rng(8119864466)
+        x = rng.random((5, 10))
         k = 6
         x[:, k] = np.nan
         y = np.delete(x, k, axis=1)
@@ -1120,10 +1121,9 @@ class TestCorrSpearmanr:
         assert_allclose(px, py, atol=1e-14)
 
     def test_nan_policy_bug_12411(self):
-        np.random.seed(5)
         m = 5
         n = 10
-        x = np.random.randn(m, n)
+        x = self.rng.standard_normal((m, n))
         x[1, 0] = np.nan
         x[3, -1] = np.nan
         corr, pvalue = stats.spearmanr(x, axis=1, nan_policy="propagate")
@@ -2382,8 +2382,9 @@ class TestRegression:
         assert_equal(result.intercept_stderr, np.nan)
 
     def test_identical_x(self):
+        rng = np.random.default_rng(7872425088)
         x = np.zeros(10)
-        y = np.random.random(10)
+        y = rng.random(10)
         msg = "Cannot calculate a linear regression"
         with assert_raises(ValueError, match=msg):
             stats.linregress(x, y)
@@ -2633,8 +2634,8 @@ class TestMode:
 
     @pytest.mark.parametrize('axis', range(-4, 0))
     def test_negative_axes_gh_15375(self, axis, xp):
-        np.random.seed(984213899)
-        a = xp.asarray(np.random.rand(10, 11, 12, 13))
+        rng = np.random.default_rng(7090348401)
+        a = xp.asarray(rng.random((10, 11, 12, 13)))
         res0 = stats.mode(a, axis=a.ndim+axis)
         res1 = stats.mode(a, axis=axis)
         xp_assert_equal(res0.mode, res1.mode)
@@ -3190,7 +3191,7 @@ class TestGZscore:
 
 
 class TestMedianAbsDeviation:
-    def setup_class(self):
+    def setup_method(self):
         self.dat_nan = np.array([2.20, 2.20, 2.4, 2.4, 2.5, 2.7, 2.8, 2.9,
                                  3.03, 3.03, 3.10, 3.37, 3.4, 3.4, 3.4, 3.5,
                                  3.6, 3.7, 3.7, 3.7, 3.7, 3.77, 5.28, np.nan])
@@ -3509,8 +3510,8 @@ class TestMoments:
     """
     testcase = [1., 2., 3., 4.]
     scalar_testcase = 4.
-    np.random.seed(1234)
-    testcase_moment_accuracy = np.random.rand(42)
+    rng = np.random.default_rng(2285049930)
+    testcase_moment_accuracy = rng.random(42)
 
     @pytest.mark.parametrize('size', [10, (10, 2)])
     @pytest.mark.parametrize('m, c', product((0, 1, 2, 3), (None, 0, 1)))
@@ -3595,7 +3596,8 @@ class TestMoments:
         if dtype=='complex128' and is_torch(xp):
             pytest.skip()
         dtype = getattr(xp, dtype)
-        x = xp.asarray(np.random.rand(5), dtype=dtype)
+        rng = np.random.default_rng(3824693518)
+        x = xp.asarray(rng.random(5), dtype=dtype)
         y = stats.moment(x, order=order)
         xp_assert_equal(y, xp.asarray(expect, dtype=dtype))
 
@@ -4926,9 +4928,9 @@ class TestKSTwoSamples:
         """Ensure gh-12218 is fixed."""
         # gh-1228 triggered a TypeError calculating sqrt(n1*n2*(n1+n2)).
         # n1, n2 both large integers, the product exceeded 2^64
-        np.random.seed(12345678)
+        rng = np.random.default_rng(8751495592)
         n1 = 2097152  # 2*^21
-        rvs1 = stats.uniform.rvs(size=n1, loc=0., scale=1)
+        rvs1 = stats.uniform.rvs(size=n1, loc=0., scale=1, random_state=rng)
         rvs2 = rvs1 + 1  # Exact value of rvs2 doesn't matter.
         stats.ks_2samp(rvs1, rvs2, alternative='greater', mode='asymp')
         stats.ks_2samp(rvs1, rvs2, alternative='less', mode='asymp')
@@ -5350,9 +5352,9 @@ class Test_ttest_ind_permutations:
     N = 20
 
     # data for most tests
-    np.random.seed(0)
-    a = np.vstack((np.arange(3*N//4), np.random.random(3*N//4)))
-    b = np.vstack((np.arange(N//4) + 100, np.random.random(N//4)))
+    rng = np.random.default_rng(169708062)
+    a = np.vstack((np.arange(3*N//4), rng.random(3*N//4)))
+    b = np.vstack((np.arange(N//4) + 100, rng.random(N//4)))
 
     # data for equal variance tests
     a2 = np.arange(10)
@@ -5363,10 +5365,9 @@ class Test_ttest_ind_permutations:
     b3 = [3, 4]
 
     # data for bigger test
-    np.random.seed(0)
     rvs1 = stats.norm.rvs(loc=5, scale=10,  # type: ignore
-                          size=500).reshape(100, 5).T
-    rvs2 = stats.norm.rvs(loc=8, scale=20, size=100)  # type: ignore
+                          size=500, random_state=rng).reshape(100, 5).T
+    rvs2 = stats.norm.rvs(loc=8, scale=20, size=100, random_state=rng)  # type: ignore
 
     p_d = [1/1001, (676+1)/1001]  # desired pvalues
     p_d_gen = [1/1001, (672 + 1)/1001]  # desired pvalues for Generator seed
@@ -5465,9 +5466,9 @@ class Test_ttest_ind_common:
                              ids=['equal_var', 'unequal_var'])
     def test_ttest_many_dims(self, kwds, equal_var):
         # Test that test works on many-dimensional arrays
-        np.random.seed(0)
-        a = np.random.rand(5, 4, 4, 7, 1, 6)
-        b = np.random.rand(4, 1, 8, 2, 6)
+        rng = np.random.default_rng(3815288136)
+        a = rng.random((5, 4, 4, 7, 1, 6))
+        b = rng.random((4, 1, 8, 2, 6))
         res = stats.ttest_ind(a, b, axis=-3, **kwds)
 
         # compare fully-vectorized t-test against t-test on smaller slice
@@ -5741,9 +5742,9 @@ class Test_ttest_CI:
 def test__broadcast_concatenate():
     # test that _broadcast_concatenate properly broadcasts arrays along all
     # axes except `axis`, then concatenates along axis
-    np.random.seed(0)
-    a = np.random.rand(5, 4, 4, 3, 1, 6)
-    b = np.random.rand(4, 1, 8, 2, 6)
+    rng = np.random.default_rng(7544340069)
+    a = rng.random((5, 4, 4, 3, 1, 6))
+    b = rng.random((4, 1, 8, 2, 6))
     c = _broadcast_concatenate((a, b), axis=-3)
     # broadcast manually as an independent check
     a = np.tile(a, (1, 1, 1, 1, 2, 1))
@@ -6009,8 +6010,9 @@ def _convert_pvalue_alternative(t, p, alt, xp):
 @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning:dask")
 @make_xp_test_case(stats.ttest_1samp)
 def test_ttest_1samp_new(xp):
+    rng = np.random.default_rng(88123290)
     n1, n2, n3 = (10, 15, 20)
-    rvn1 = stats.norm.rvs(loc=5, scale=10, size=(n1, n2, n3))
+    rvn1 = stats.norm.rvs(loc=5, scale=10, size=(n1, n2, n3), random_state=rng)
     rvn1 = xp.asarray(rvn1)
 
     # check multidimensional array and correct axis handling
@@ -6070,8 +6072,9 @@ def test_ttest_1samp_new(xp):
 
 @skip_xp_backends(np_only=True, reason="Only NumPy has nan_policy='omit' for now")
 def test_ttest_1samp_new_omit(xp):
+    rng = np.random.default_rng(4008400329)
     n1, n2, n3 = (5, 10, 15)
-    rvn1 = stats.norm.rvs(loc=5, scale=10, size=(n1, n2, n3))
+    rvn1 = stats.norm.rvs(loc=5, scale=10, size=(n1, n2, n3), random_state=rng)
     rvn1 = xp.asarray(rvn1)
 
     rvn1[0:2, 1:3, 4:8] = xp.nan
@@ -6387,8 +6390,8 @@ class TestNormalTest(NormalityTests):
 
 class TestRankSums:
 
-    np.random.seed(0)
-    x, y = np.random.rand(2, 10)
+    rng = np.random.default_rng(3417115752)
+    x, y = rng.random((2, 10))
 
     @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
     def test_ranksums_result_attributes(self, alternative):
@@ -6426,8 +6429,8 @@ class TestJarqueBera:
     @skip_xp_backends(np_only=True)
     def test_jarque_bera_array_like(self, xp):
         # array-like only relevant for NumPy
-        np.random.seed(987654321)
-        x = np.random.normal(0, 1, 100000)
+        rng = np.random.default_rng(9294968266)
+        x = rng.normal(0, 1, size=100000)
 
         jb_test1 = JB1, p1 = stats.jarque_bera(list(x))
         jb_test2 = JB2, p2 = stats.jarque_bera(tuple(x))
@@ -7326,8 +7329,8 @@ class TestTrim:
         assert_equal(stats.trim_mean([5,4,3,1,2,0], 2/6.), 2.5)
 
         # check axis argument
-        np.random.seed(1234)
-        a = np.random.randint(20, size=(5, 6, 4, 7))
+        rng = np.random.default_rng(3417115752)
+        a = rng.integers(20, size=(5, 6, 4, 7))
         for axis in [0, 1, 2, 3, -1]:
             res1 = stats.trim_mean(a, 2/6., axis=axis)
             res2 = stats.trim_mean(np.moveaxis(a, axis, 0), 2/6.)
@@ -7878,6 +7881,9 @@ class TestFOneWay:
 
 
 class TestKruskal:
+    def setup_method(self):
+        self.rng = np.random.default_rng(1808365978)
+
     def test_simple(self):
         x = [1]
         y = [2]
@@ -7956,8 +7962,8 @@ class TestKruskal:
     def test_large_no_samples(self):
         # Test to see if large samples are handled correctly.
         n = 50000
-        x = np.random.randn(n)
-        y = np.random.randn(n) + 50
+        x = self.rng.standard_normal(n)
+        y = self.rng.standard_normal(n) + 50
         h, p = stats.kruskal(x, y)
         expected = 0
         assert_approx_equal(p, expected)
@@ -8752,6 +8758,9 @@ class TestQuantileTest:
 
 
 class TestPageTrendTest:
+    def setup_method(self):
+        self.rng = np.random.default_rng(1808365978)
+
     # expected statistic and p-values generated using R at
     # https://rdrr.io/cran/cultevo/, e.g.
     # library(cultevo)
@@ -8766,13 +8775,14 @@ class TestPageTrendTest:
     # results could be checked (to limited precision) against tables in
     # scipy.stats.page_trend_test reference [1]
 
-    np.random.seed(0)
-    data_3_25 = np.random.rand(3, 25)
-    data_10_26 = np.random.rand(10, 26)
+    rng = np.random.default_rng(3113562111)
+    data_3_25 = rng.random((3, 25))
+    rng = np.random.default_rng(3113562111)
+    data_10_26 = rng.random((10, 26))
 
     ts = [
-          (12805, 0.3886487053947608, False, 'asymptotic', data_3_25),
-          (49140, 0.02888978556179862, False, 'asymptotic', data_10_26),
+          (12949, 0.275539045444, False, 'asymptotic', data_3_25),
+          (47221, 0.5703651063709, False, 'asymptotic', data_10_26),
           (12332, 0.7722477197436702, False, 'asymptotic',
            [[72, 47, 73, 35, 47, 96, 30, 59, 41, 36, 56, 49, 81,
              43, 70, 47, 28, 28, 62, 20, 61, 20, 80, 24, 50],
@@ -8813,10 +8823,8 @@ class TestPageTrendTest:
            [[3, 2, 1], [3, 2, 1], [3, 2, 1], [3, 2, 1], [3, 2, 1], [3, 2, 1],
             [3, 2, 1], [3, 2, 1], [3, 2, 1], [2, 1, 3], [1, 2, 3]]),
          ]
-
     @pytest.mark.parametrize("L, p, ranked, method, data", ts)
     def test_accuracy(self, L, p, ranked, method, data):
-        np.random.seed(42)
         res = stats.page_trend_test(data, ranked=ranked, method=method)
         assert_equal(L, res.statistic)
         assert_allclose(p, res.pvalue)
@@ -8840,24 +8848,22 @@ class TestPageTrendTest:
              [1, 2, 3, 4, 5, 6, 7, 8], [1, 2, 3, 4, 5, 6, 7, 8],
              [1, 2, 3, 4, 5, 6, 7, 8]]),
           ]
-
     # only the first of these appears slow because intermediate data are
     # cached and used on the rest
-    @pytest.mark.parametrize("L, p, ranked, method, data", ts)
+    @pytest.mark.parametrize("L, p, ranked, method, data", ts2)
     @pytest.mark.slow()
     def test_accuracy2(self, L, p, ranked, method, data):
-        np.random.seed(42)
         res = stats.page_trend_test(data, ranked=ranked, method=method)
         assert_equal(L, res.statistic)
         assert_allclose(p, res.pvalue)
         assert_equal(method, res.method)
 
     def test_options(self):
-        np.random.seed(42)
+        rng = np.random.default_rng(183973867)
         m, n = 10, 20
         predicted_ranks = np.arange(1, n+1)
-        perm = np.random.permutation(np.arange(n))
-        data = np.random.rand(m, n)
+        perm = rng.permutation(np.arange(n))
+        data = rng.random((m, n))
         ranks = stats.rankdata(data, axis=1)
         res1 = stats.page_trend_test(ranks)
         res2 = stats.page_trend_test(ranks, ranked=True)
@@ -8872,8 +8878,6 @@ class TestPageTrendTest:
 
     def test_Ames_assay(self):
         # test from _page_trend_test.py [2] page 151; data on page 144
-        np.random.seed(42)
-
         data = [[101, 117, 111], [91, 90, 107], [103, 133, 121],
                 [136, 140, 144], [190, 161, 201], [146, 120, 116]]
         data = np.array(data).T
@@ -8903,10 +8907,11 @@ class TestPageTrendTest:
             stats.page_trend_test([[[1]]])
 
         # test invalid dimensions
+        rng = np.random.default_rng(2482566048)
         with assert_raises(ValueError, match="Page's L is only appropriate"):
-            stats.page_trend_test(np.random.rand(1, 3))
+            stats.page_trend_test(rng.random((1, 3)))
         with assert_raises(ValueError, match="Page's L is only appropriate"):
-            stats.page_trend_test(np.random.rand(2, 2))
+            stats.page_trend_test(rng.random((2, 2)))
 
         # predicted ranks must include each integer [1, 2, 3] exactly once
         message = "`predicted_ranks` must include each integer"

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6430,7 +6430,7 @@ class TestJarqueBera:
     def test_jarque_bera_array_like(self, xp):
         # array-like only relevant for NumPy
         rng = np.random.default_rng(9294968266)
-        x = rng.normal(0, 1, size=100000)
+        x = rng.standard_normal(size=100000)
 
         jb_test1 = JB1, p1 = stats.jarque_bera(list(x))
         jb_test2 = JB2, p2 = stats.jarque_bera(tuple(x))
@@ -8823,6 +8823,7 @@ class TestPageTrendTest:
            [[3, 2, 1], [3, 2, 1], [3, 2, 1], [3, 2, 1], [3, 2, 1], [3, 2, 1],
             [3, 2, 1], [3, 2, 1], [3, 2, 1], [2, 1, 3], [1, 2, 3]]),
          ]
+
     @pytest.mark.parametrize("L, p, ranked, method, data", ts)
     def test_accuracy(self, L, p, ranked, method, data):
         res = stats.page_trend_test(data, ranked=ranked, method=method)


### PR DESCRIPTION
#### Reference issue
Toward gh-14322

#### What does this implement/fix?
Removes uses of `np.random.seed` from `scipy.stats`. 

#### Additional information
There are two exceptions involving tests designed to check behavior with the `RandomState` singleton. These are marked with a comment "valid use of np.random.seed".