### PR TITLE
Cygwin interpolate test xfail

### DIFF
--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -1,3 +1,5 @@
+#include <Python.h>
+/* __fitpack.h includes Python.h */
 #include <string>
 #include <cstdint>
 #include <vector>

--- a/scipy/interpolate/src/__fitpack.h
+++ b/scipy/interpolate/src/__fitpack.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <Python.h>
+/* npy_cblas.h includes python.h */
 #include <iostream>
 #include <cinttypes>
 #include <tuple>

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -6,6 +6,7 @@ import cmath
 import threading
 import copy
 import warnings
+import sys
 
 import numpy as np
 from scipy._lib._array_api import (
@@ -695,6 +696,11 @@ class TestBSpline:
         _run_concurrent_barrier(10, worker_fn, b)
 
 
+    @pytest.mark.xfail(
+        sys.platform == "cygwin",
+        reason="threading.get_native_id not implemented",
+        raises=AttributeError
+    )
     def test_memmap(self, tmpdir):
         # Make sure that memmaps can be used as t and c atrributes after the
         # spline has been constructed. This is similar to what happens in a


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Separated from #23737

#### What does this implement/fix?
<!--Please explain your changes.-->
This gets SciPy compiling again on Cygwin, and all tests in interpolate passing.

In particular, it includes `Python.h` at the top of a few files, and marks a bspline mmap test xfail because Cygwin's threading module doesn't have `get_native_id`

#### Additional information
<!--Any additional information you think is important.-->
