### PR TITLE
DOC: stats.beta: document issues with 3- and 4- parameter MLE

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -728,6 +728,15 @@ class beta_gen(rv_continuous):
     the computation of the ``pdf``, ``cdf``, ``ppf``, ``sf`` and ``isf``
     methods. [1]_
 
+    Maximum likelihood estimates of parameters are only available when the location and
+    scale are fixed. When either of these parameters is free, ``beta.fit`` resorts to
+    numerical optimization, but this problem is unbounded: the location and scale may be
+    chosen to make the minimum and maximum elements of the data coincide with the
+    endpoints of the support, and the shape parameters may be chosen to make the PDF at
+    these points infinite. For best results, pass ``floc`` and ``fscale`` keyword
+    arguments to fix the location and scale, or use `scipy.stats.fit` with
+    ``method='mse'``.
+
     %(after_notes)s
 
     References


### PR DESCRIPTION
#### Reference issue
Closes gh-23742

#### What does this implement/fix?
Documents issue with 3- and 4-parameter `beta` maximum likelihood estimation and the better alternatives.
