### PR TITLE
MAINT: interpolate: use xp-capabilities for make_* functions

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -14,7 +14,7 @@ from scipy.sparse import csr_array
 from scipy.special import poch
 from itertools import combinations
 
-from scipy._lib._array_api import array_namespace, concat_1d
+from scipy._lib._array_api import array_namespace, concat_1d, xp_capabilities
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
            "make_smoothing_spline"]
@@ -1407,6 +1407,7 @@ def _make_periodic_spline(x, y, t, k, axis, *, xp):
     return BSpline.construct_fast(t, c, k, extrapolate='periodic', axis=axis)
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True)
 def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
                        check_finite=True):
     """Create an interpolating B-spline with specified degree and boundary conditions.
@@ -1684,6 +1685,7 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     return BSpline.construct_fast(t, c, k, axis=axis)
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True)
 def make_lsq_spline(x, y, t, k=3, w=None, axis=0, check_finite=True, *, method="qr"):
     r"""Create a smoothing B-spline satisfying the Least SQuares (LSQ) criterion.
 
@@ -2237,6 +2239,7 @@ def _coeff_of_divided_diff(x):
     return res
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True)
 def make_smoothing_spline(x, y, w=None, lam=None, *, axis=0):
     r"""
     Create a smoothing B-spline satisfying the Generalized Cross Validation (GCV) criterion.

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -21,7 +21,7 @@ import warnings
 import operator
 import numpy as np
 
-from scipy._lib._array_api import array_namespace, concat_1d
+from scipy._lib._array_api import array_namespace, concat_1d, xp_capabilities
 
 from ._bsplines import (
     _not_a_knot, make_interp_spline, BSpline, fpcheck, _lsq_solve_qr,
@@ -148,6 +148,7 @@ def _validate_inputs(x, y, w, k, s, xb, xe, parametric, periodic=False):
     return x, y, w, k, s, xb, xe
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True)
 def generate_knots(x, y, *, w=None, xb=None, xe=None,
                    k=3, s=0, nest=None, bc_type=None):
     """Generate knot vectors until the Least SQuares (LSQ) criterion is satified.
@@ -997,6 +998,7 @@ def _make_splrep_impl(x, y, w, xb, xe, k, s, t, nest, periodic, xp=np):
     return spl
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True)
 def make_splrep(x, y, *, w=None, xb=None, xe=None,
                 k=3, s=0, t=None, nest=None, bc_type=None):
     r"""Create a smoothing B-spline function with bounded error, minimizing derivative jumps.
@@ -1153,6 +1155,7 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
     return spl
 
 
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True)
 def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
                  k=3, s=0, t=None, nest=None, bc_type=None):
     r"""

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -9,7 +9,7 @@ import warnings
 
 import numpy as np
 from scipy._lib._array_api import (
-    xp_assert_equal, xp_assert_close, xp_default_dtype, concat_1d
+    xp_assert_equal, xp_assert_close, xp_default_dtype, concat_1d, make_xp_test_case
 )
 import scipy._lib.array_api_extra as xpx
 from pytest import raises as assert_raises
@@ -1224,7 +1224,7 @@ class TestInterop:
         assert isinstance(tck_n2, tuple)   # back-compat: tck in, tck out
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(make_interp_spline)
 class TestInterp:
     #
     # Test basic ways of constructing interpolating splines.
@@ -1767,7 +1767,7 @@ def make_lsq_full_matrix(x, y, t, k=3):
 parametrize_lsq_methods = pytest.mark.parametrize("method", ["norm-eq", "qr"])
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(make_lsq_spline)
 class TestLSQ:
     #
     # Test make_lsq_spline
@@ -2176,7 +2176,7 @@ def data_file(basename):
                         'data', basename)
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(make_smoothing_spline)
 class TestSmoothingSpline:
     #
     # test make_smoothing_spline
@@ -3246,7 +3246,7 @@ def _add_knot(x, t, k, residuals):
     return t_new
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(generate_knots)
 class TestGenerateKnots:
     def test_split_add_knot(self):
         # smoke test implementation details: insert a new knot given residuals
@@ -3716,6 +3716,7 @@ class _TestMakeSplrepBase:
         xp_assert_close(spl.c, c[:-k - 1], atol=1e-15)
 
 
+@make_xp_test_case(make_splrep)
 class TestMakeSplrep(_TestMakeSplrepBase):
 
     @pytest.mark.parametrize("k", [1, 2, 3, 4, 5, 6])
@@ -3865,6 +3866,7 @@ class TestMakeSplrep(_TestMakeSplrepBase):
         assert spl_1.t.shape[0] == 2 * (k + 1)
 
 
+@make_xp_test_case(make_splrep)
 class TestMakeSplrepPeriodic(_TestMakeSplrepBase):
 
     bc_type = 'periodic'
@@ -3960,7 +3962,7 @@ class TestMakeSplrepPeriodic(_TestMakeSplrepBase):
         xp_assert_close(y_check[0], y_check[1])
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(make_splprep)
 class TestMakeSplprep:
     def _get_xyk(self, m=10, k=3, xp=np):
         x = xp.arange(m, dtype=xp.float64) * xp.pi / m
@@ -4068,6 +4070,7 @@ class TestMakeSplprep:
         xp_assert_close(spl(u), [x], atol=1e-15)
 
 
+@make_xp_test_case(make_splprep)
 class TestMakeSplprepPeriodic:
 
     def _get_xyk(self, n=10, k=3, xp=np):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -42,7 +42,6 @@ from scipy.interpolate import _bsplines as _b
 from scipy.interpolate import _dierckx
 
 skip_xp_backends = pytest.mark.skip_xp_backends
-xfail_xp_backends = pytest.mark.xfail_xp_backends
 
 
 @skip_xp_backends(cpu_only=True)
@@ -147,7 +146,8 @@ class TestBSpline:
                         bspl(xx), atol=1e-14)
 
     @skip_xp_backends("dask.array", reason="_naive_eval is not dask-compatible")
-    @skip_xp_backends("torch", reason="_naive_eval breaks down on torch. Why?")
+    @skip_xp_backends("jax.numpy", reason="too slow; XXX a slow-if marker?")
+    @skip_xp_backends("torch", reason="OOB on CI")
     def test_rndm_naive_eval(self, xp):
         # test random coefficient spline *on the base interval*,
         # t[k] <= x < t[-k-1]
@@ -3896,7 +3896,7 @@ class TestMakeSplrepPeriodic(_TestMakeSplrepBase):
     def test_periodic_with_periodic_data(self, xp):
         N = 10
         a, b = 0, 2*xp.pi
-        x = xp.linspace(a, b, N + 1)    # nodes
+        x = xp.linspace(a, b, N + 1, dtype=xp.float64)    # nodes
 
         y = xp.cos(x)
         spl = make_splrep(x, y, s=1e-8, bc_type=self.bc_type)
@@ -4071,7 +4071,7 @@ class TestMakeSplprep:
 class TestMakeSplprepPeriodic:
 
     def _get_xyk(self, n=10, k=3, xp=np):
-        x = xp.linspace(0, 2*xp.pi, n)
+        x = xp.linspace(0, 2*xp.pi, n, dtype=xp.float64)
         y = [xp.sin(x), xp.cos(x)]
         return x, y, k
 


### PR DESCRIPTION
While at it, add array API tests for the recently added periodic spline fitting (`make_sprep(...., bc_type="periodic"`).

Am not adding `xp_capabilities` to `BSpline` because it runs into the same problem as https://github.com/scipy/scipy/pull/23135#issuecomment-3265704061 : `make_xp_test_case` turns a class into a function under `dask`, and this messes up classmethods.