### PR TITLE
BUG: interpolate: fail gracefully if all weights are zero

### DIFF
--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -109,6 +109,9 @@ def _validate_inputs(x, y, w, k, s, xb, xe, parametric, periodic=False):
             raise ValueError(f"{w.ndim = } not implemented yet.")
         if (w < 0).any():
             raise ValueError("Weights must be non-negative")
+        if w.sum() == 0:
+            raise ValueError("All weights are zero.")
+
 
     if y.ndim == 0 or y.ndim > 2:
         raise ValueError(f"{y.ndim = } not supported (must be 1 or 2.)")

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3418,7 +3418,7 @@ index 1afb1900f1..d817e51ad8 100644
         # regression test for https://github.com/scipy/scipy/issues/23542
         gen = generate_knots([0.,1.,2.,3.], [4.,5.,6.,7.], w=[0.,0.,0.,0.], s=1)
         with pytest.raises(ValueError, match="weights are zero"):
-            knots = list(gen)
+            list(gen)
 
 
 def disc_naive(t, k):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3414,6 +3414,12 @@ index 1afb1900f1..d817e51ad8 100644
         assert len(r) == 1
         xp_assert_equal(knots[-1], tck[0])
 
+    def test_zero_weights(self):
+        # regression test for https://github.com/scipy/scipy/issues/23542
+        gen = generate_knots([0.,1.,2.,3.], [4.,5.,6.,7.], w=[0.,0.,0.,0.], s=1)
+        with pytest.raises(ValueError, match="weights are zero"):
+            knots = list(gen)
+
 
 def disc_naive(t, k):
     """Straitforward way to compute the discontinuity matrix. For testing ONLY.


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/23542

#### What does this implement/fix?
<!--Please explain your changes.-->

While the meaning of `np.count_nonzero(weights) < k+1` is not immediately obvious, having all weights to be zero is clearly an error.

Thus, emit a clear error for definitely erroneous inputs, and leave the rest to some other day.



#### Additional information
<!--Any additional information you think is important.-->
