### PR TITLE
ENH: interpolate: make NdBSpline and RGI Array API compatible

### DIFF
--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -10,6 +10,7 @@ from . import _dierckx  # type: ignore[attr-defined]
 
 import scipy.sparse.linalg as ssl
 from scipy.sparse import csr_array
+from scipy._lib._array_api import array_namespace
 
 from ._bsplines import _not_a_knot, BSpline
 
@@ -83,14 +84,16 @@ class NdBSpline:
     def __init__(self, t, c, k, *, extrapolate=None):
         self._k, self._indices_k1d, (self._t, self._len_t) = _preprocess_inputs(k, t)
 
+        self._asarray = array_namespace(c, *t).asarray
+
         if extrapolate is None:
             extrapolate = True
         self.extrapolate = bool(extrapolate)
 
-        self.c = np.asarray(c)
+        self._c = np.asarray(c)
 
         ndim = self._t.shape[0]   # == len(self.t)
-        if self.c.ndim < ndim:
+        if self._c.ndim < ndim:
             raise ValueError(f"Coefficients must be at least {ndim}-dimensional.")
 
         for d in range(ndim):
@@ -98,15 +101,15 @@ class NdBSpline:
             kd = self.k[d]
             n = td.shape[0] - kd - 1
 
-            if self.c.shape[d] != n:
+            if self._c.shape[d] != n:
                 raise ValueError(f"Knots, coefficients and degree in dimension"
                                  f" {d} are inconsistent:"
-                                 f" got {self.c.shape[d]} coefficients for"
+                                 f" got {self._c.shape[d]} coefficients for"
                                  f" {len(td)} knots, need at least {n} for"
                                  f" k={k}.")
 
-        dt = _get_dtype(self.c.dtype)
-        self.c = np.ascontiguousarray(self.c, dtype=dt)
+        dt = _get_dtype(self._c.dtype)
+        self._c = np.ascontiguousarray(self._c, dtype=dt)
 
     @property
     def k(self):
@@ -115,7 +118,13 @@ class NdBSpline:
     @property
     def t(self):
         # repack the knots into a tuple
-        return tuple(self._t[d, :self._len_t[d]] for d in range(self._t.shape[0]))
+        return tuple(
+            self._asarray(self._t[d, :self._len_t[d]]) for d in range(self._t.shape[0])
+        )
+
+    @property
+    def c(self):
+        return self._asarray(self._c)
 
     def __call__(self, xi, *, nu=None, extrapolate=None):
         """Evaluate the tensor product b-spline at ``xi``.
@@ -126,7 +135,7 @@ class NdBSpline:
             The coordinates to evaluate the interpolator at.
             This can be a list or tuple of ndim-dimensional points
             or an array with the shape (num_points, ndim).
-        nu : array_like, optional, shape (ndim,)
+        nu : sequence of length ``ndim``, optional
             Orders of derivatives to evaluate. Each must be non-negative.
             Defaults to the zeroth derivivative.
         extrapolate : bool, optional
@@ -165,12 +174,12 @@ class NdBSpline:
             raise ValueError(f"Shapes: xi.shape={xi_shape} and ndim={ndim}")
 
         # complex -> double
-        was_complex = self.c.dtype.kind == 'c'
-        cc = self.c
-        if was_complex and self.c.ndim == ndim:
+        was_complex = self._c.dtype.kind == 'c'
+        cc = self._c
+        if was_complex and self._c.ndim == ndim:
             # make sure that core dimensions are intact, and complex->float
             # size doubling only adds a trailing dimension
-            cc = self.c[..., None]
+            cc = self._c[..., None]
         cc = cc.view(float)
 
         # prepare the coefficients: flatten the trailing dimensions
@@ -193,8 +202,9 @@ class NdBSpline:
                                  _strides_c1,
                                  self._indices_k1d,
         )
-        out = out.view(self.c.dtype)
-        return out.reshape(xi_shape[:-1] + self.c.shape[ndim:])
+        out = out.view(self._c.dtype)
+        out = out.reshape(xi_shape[:-1] + self._c.shape[ndim:])
+        return self._asarray(out)
 
     @classmethod
     def design_matrix(cls, xvals, t, k, extrapolate=True):
@@ -303,9 +313,10 @@ class NdBSpline:
         if any(nu_arr < 0):
             raise ValueError(f"derivative orders must be positive, got {nu = }")
 
-        t_new = list(self.t)
+        # extract t and c as numpy arrays
+        t_new = [self._t[d, :self._len_t[d]] for d in range(self._t.shape[0])]
         k_new = list(self.k)
-        c_new = self.c.copy()
+        c_new = self._c.copy()
 
         for axis, n in enumerate(nu_arr):
             if n == 0:
@@ -316,8 +327,11 @@ class NdBSpline:
             )
             k_new[axis] = max(k_new[axis] - n, 0)
 
-        return NdBSpline(tuple(t_new), c_new,
-                         tuple(k_new), extrapolate=self.extrapolate)
+        return NdBSpline(tuple(self._asarray(t) for t in t_new),
+                         self._asarray(c_new),
+                         tuple(k_new),
+                         extrapolate=self.extrapolate
+        )
 
 def _preprocess_inputs(k, t_tpl):
     """Helpers: validate and preprocess NdBSpline inputs.
@@ -384,6 +398,7 @@ def _preprocess_inputs(k, t_tpl):
     #    array([[1, 2, 3, 4],
     #           [5, 6, nan, nan],
     #           [7, 8, 9, nan]])
+    t_tpl = [np.asarray(t) for t in t_tpl]
     ndim = len(t_tpl)
     len_t = [len(ti) for ti in t_tpl]
     _t = np.empty((ndim, max(len_t)), dtype=float)

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -10,7 +10,7 @@ from . import _dierckx  # type: ignore[attr-defined]
 
 import scipy.sparse.linalg as ssl
 from scipy.sparse import csr_array
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, xp_capabilities
 
 from ._bsplines import _not_a_knot, BSpline
 
@@ -25,6 +25,13 @@ def _get_dtype(dtype):
         return np.float64
 
 
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[
+        ("dask.array",
+         "https://github.com/data-apis/array-api-extra/issues/488")
+    ]
+)
 class NdBSpline:
     """Tensor product spline object.
 

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -294,9 +294,18 @@ class RegularGridInterpolator:
 
         try:
             xp = array_namespace(*points, values)
-        except Exception:
-            # "duck-type" values
-            xp = np_compat
+        except Exception as e:
+            # either "duck-type" values or a user error?
+            xp = array_namespace(*points)
+            try:
+                xp_v = array_namespace(values)
+            except Exception:
+                # "duck-type" values indeed, continue with `xp` as the namespace
+                pass
+            else:
+                # both `points` and `values` are array API objects, check consistency
+                if xp_v != xp:
+                    raise e
 
         self._asarray = xp.asarray
         self.method = method

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -6,6 +6,8 @@ from types import GenericAlias
 import numpy as np
 
 import scipy.sparse.linalg as ssl
+from scipy._lib._array_api import array_namespace
+from scipy._lib.array_api_compat import numpy as np_compat, is_array_api_obj
 
 from ._interpnd import _ndim_coords_from_arrays
 from ._cubic import PchipInterpolator
@@ -281,17 +283,25 @@ class RegularGridInterpolator:
         if method not in self._ALL_METHODS:
             raise ValueError(f"Method '{method}' is not defined")
         elif method in self._SPLINE_METHODS:
-            self._validate_grid_dimensions(points, method)
+            self._validate_grid_dimensions(points, method)   # NB: uses np.atleast_1d
+
+        try:
+            xp = array_namespace(*points, values)
+        except Exception:
+            # "duck-type" values
+            xp = np_compat
+
+        self._asarray = xp.asarray
         self.method = method
         self._spline = None
         self.bounds_error = bounds_error
-        self.grid, self._descending_dimensions = _check_points(points)
-        self.values = self._check_values(values)
-        self._check_dimensionality(self.grid, self.values)
-        self.fill_value = self._check_fill_value(self.values, fill_value)
+        self._grid, self._descending_dimensions = _check_points(points)
+        self._values = self._check_values(values)
+        self._check_dimensionality(self._grid, self._values)
+        self.fill_value = self._check_fill_value(self._values, fill_value)
         if self._descending_dimensions:
-            self.values = np.flip(values, axis=self._descending_dimensions)
-        if self.method == "pchip" and np.iscomplexobj(self.values):
+            self._values = np.flip(values, axis=self._descending_dimensions)
+        if self.method == "pchip" and np.iscomplexobj(self._values):
             msg = ("`PchipInterpolator` only works with real values. If you are trying "
                    "to use the real components of the passed array, use `np.real` on "
                    "the array before passing to `RegularGridInterpolator`.")
@@ -311,7 +321,7 @@ class RegularGridInterpolator:
         if solver is None:
             solver = ssl.gcrotmk
         spl = make_ndbspl(
-                self.grid, self.values, self._SPLINE_DEGREE_MAP[method],
+                self._grid, self._values, self._SPLINE_DEGREE_MAP[method],
                 solver=solver, **solver_args
               )
         return spl
@@ -323,6 +333,9 @@ class RegularGridInterpolator:
         return _check_points(points)
 
     def _check_values(self, values):
+        if is_array_api_obj(values):
+            values = np.asarray(values)
+
         if not hasattr(values, 'ndim'):
             # allow reasonable duck-typed values
             values = np.asarray(values)
@@ -418,18 +431,18 @@ class RegularGridInterpolator:
 
         if method == "linear":
             indices, norm_distances = self._find_indices(xi.T)
-            if (ndim == 2 and hasattr(self.values, 'dtype') and
-                    self.values.ndim == 2 and self.values.flags.writeable and
-                    self.values.dtype in (np.float64, np.complex128) and
-                    self.values.dtype.byteorder == '='):
+            if (ndim == 2 and hasattr(self._values, 'dtype') and
+                    self._values.ndim == 2 and self._values.flags.writeable and
+                    self._values.dtype in (np.float64, np.complex128) and
+                    self._values.dtype.byteorder == '='):
                 # until cython supports const fused types, the fast path
                 # cannot support non-writeable values
                 # a fast path
-                out = np.empty(indices.shape[1], dtype=self.values.dtype)
-                result = evaluate_linear_2d(self.values,
+                out = np.empty(indices.shape[1], dtype=self._values.dtype)
+                result = evaluate_linear_2d(self._values,
                                             indices,
                                             norm_distances,
-                                            self.grid,
+                                            self._grid,
                                             out)
             else:
                 result = self._evaluate_linear(indices, norm_distances)
@@ -438,7 +451,7 @@ class RegularGridInterpolator:
             result = self._evaluate_nearest(indices, norm_distances)
         elif method in self._SPLINE_METHODS:
             if is_method_changed:
-                self._validate_grid_dimensions(self.grid, method)
+                self._validate_grid_dimensions(self._grid, method)
             if method in self._SPLINE_METHODS_recursive:
                 result = self._evaluate_spline(xi, method)
             else:
@@ -450,12 +463,20 @@ class RegularGridInterpolator:
         # f(nan) = nan, if any
         if np.any(nans):
             result[nans] = np.nan
-        return result.reshape(xi_shape[:-1] + self.values.shape[ndim:])
+        return self._asarray(result.reshape(xi_shape[:-1] + self._values.shape[ndim:]))
+
+    @property
+    def grid(self):
+        return tuple(self._asarray(p) for p in self._grid)
+
+    @property
+    def values(self):
+        return self._asarray(self._values)
 
     def _prepare_xi(self, xi):
-        ndim = len(self.grid)
+        ndim = len(self._grid)
         xi = _ndim_coords_from_arrays(xi, ndim=ndim)
-        if xi.shape[-1] != len(self.grid):
+        if xi.shape[-1] != ndim:
             raise ValueError("The requested sample points xi have dimension "
                              f"{xi.shape[-1]} but this "
                              f"RegularGridInterpolator has dimension {ndim}")
@@ -469,8 +490,8 @@ class RegularGridInterpolator:
 
         if self.bounds_error:
             for i, p in enumerate(xi.T):
-                if not np.logical_and(np.all(self.grid[i][0] <= p),
-                                      np.all(p <= self.grid[i][-1])):
+                if not np.logical_and(np.all(self._grid[i][0] <= p),
+                                      np.all(p <= self._grid[i][-1])):
                     raise ValueError(
                         f"One of the requested xi is out of bounds in dimension {i}"
                     )
@@ -481,18 +502,18 @@ class RegularGridInterpolator:
         return xi, xi_shape, ndim, nans, out_of_bounds
 
     def _evaluate_linear(self, indices, norm_distances):
-        # slice for broadcasting over trailing dimensions in self.values
-        vslice = (slice(None),) + (None,)*(self.values.ndim - len(indices))
+        # slice for broadcasting over trailing dimensions in self._values
+        vslice = (slice(None),) + (None,)*(self._values.ndim - len(indices))
 
         # Compute shifting up front before zipping everything together
         shift_norm_distances = [1 - yi for yi in norm_distances]
         shift_indices = [i + 1 for i in indices]
 
         # The formula for linear interpolation in 2d takes the form:
-        # values = self.values[(i0, i1)] * (1 - y0) * (1 - y1) + \
-        #          self.values[(i0, i1 + 1)] * (1 - y0) * y1 + \
-        #          self.values[(i0 + 1, i1)] * y0 * (1 - y1) + \
-        #          self.values[(i0 + 1, i1 + 1)] * y0 * y1
+        # values = self._values[(i0, i1)] * (1 - y0) * (1 - y1) + \
+        #          self._values[(i0, i1 + 1)] * (1 - y0) * y1 + \
+        #          self._values[(i0 + 1, i1)] * y0 * (1 - y1) + \
+        #          self._values[(i0 + 1, i1 + 1)] * y0 * y1
         # We pair i with 1 - yi (zipped1) and i + 1 with yi (zipped2)
         zipped1 = zip(indices, shift_norm_distances)
         zipped2 = zip(shift_indices, norm_distances)
@@ -507,14 +528,14 @@ class RegularGridInterpolator:
             weight = np.array([1.])
             for w in weights:
                 weight = weight * w
-            term = np.asarray(self.values[edge_indices]) * weight[vslice]
+            term = np.asarray(self._values[edge_indices]) * weight[vslice]
             value = value + term   # cannot use += because broadcasting
         return value
 
     def _evaluate_nearest(self, indices, norm_distances):
         idx_res = [np.where(yi <= .5, i, i + 1)
                    for i, yi in zip(indices, norm_distances)]
-        return self.values[tuple(idx_res)]
+        return self._values[tuple(idx_res)]
 
     def _validate_grid_dimensions(self, points, method):
         k = self._SPLINE_DEGREE_MAP[method]
@@ -528,7 +549,7 @@ class RegularGridInterpolator:
     def _evaluate_spline(self, xi, method):
         # ensure xi is 2D list of points to evaluate (`m` is the number of
         # points and `n` is the number of interpolation dimensions,
-        # ``n == len(self.grid)``.)
+        # ``n == len(self._grid)``.)
         if xi.ndim == 1:
             xi = xi.reshape((1, xi.size))
         m, n = xi.shape
@@ -539,9 +560,9 @@ class RegularGridInterpolator:
         # the 0th axis of its argument array (for 1D routine it's its ``y``
         # array). Thus permute the interpolation axes of `values` *and keep
         # trailing dimensions trailing*.
-        axes = tuple(range(self.values.ndim))
+        axes = tuple(range(self._values.ndim))
         axx = axes[:n][::-1] + axes[n:]
-        values = self.values.transpose(axx)
+        values = self._values.transpose(axx)
 
         if method == 'pchip':
             _eval_func = self._do_pchip
@@ -556,14 +577,14 @@ class RegularGridInterpolator:
         # can at least vectorize the first pass across all points in the
         # last variable of xi.
         last_dim = n - 1
-        first_values = _eval_func(self.grid[last_dim],
+        first_values = _eval_func(self._grid[last_dim],
                                   values,
                                   xi[:, last_dim],
                                   k)
 
         # the rest of the dimensions have to be on a per point-in-xi basis
-        shape = (m, *self.values.shape[n:])
-        result = np.empty(shape, dtype=self.values.dtype)
+        shape = (m, *self._values.shape[n:])
+        result = np.empty(shape, dtype=self._values.dtype)
         for j in range(m):
             # Main process: Apply 1D interpolate in each dimension
             # sequentially, starting with the last dimension.
@@ -572,7 +593,7 @@ class RegularGridInterpolator:
             for i in range(last_dim-1, -1, -1):
                 # Interpolate for each 1D from the last dimensions.
                 # This collapses each 1D sequence into a scalar.
-                folded_values = _eval_func(self.grid[i],
+                folded_values = _eval_func(self._grid[i],
                                            folded_values,
                                            xi[j, i],
                                            k)
@@ -593,13 +614,13 @@ class RegularGridInterpolator:
         return values
 
     def _find_indices(self, xi):
-        return find_indices(self.grid, xi)
+        return find_indices(self._grid, xi)
 
     def _find_out_of_bounds(self, xi):
         # check for out of bounds xi
         out_of_bounds = np.zeros((xi.shape[1]), dtype=bool)
         # iterate through dimensions
-        for x, grid in zip(xi, self.grid):
+        for x, grid in zip(xi, self._grid):
             out_of_bounds += x < grid[0]
             out_of_bounds += x > grid[-1]
         return out_of_bounds

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import scipy.sparse.linalg as ssl
 from scipy._lib._array_api import array_namespace, xp_capabilities
-from scipy._lib.array_api_compat import numpy as np_compat, is_array_api_obj
+from scipy._lib.array_api_compat import is_array_api_obj
 
 from ._interpnd import _ndim_coords_from_arrays
 from ._cubic import PchipInterpolator
@@ -296,7 +296,7 @@ class RegularGridInterpolator:
             xp = array_namespace(*points, values)
         except Exception as e:
             # either "duck-type" values or a user error?
-            xp = array_namespace(*points)
+            xp = array_namespace(*points) # still forbid mixed namespaces in `points`
             try:
                 xp_v = array_namespace(values)
             except Exception:

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -6,7 +6,7 @@ from types import GenericAlias
 import numpy as np
 
 import scipy.sparse.linalg as ssl
-from scipy._lib._array_api import array_namespace
+from scipy._lib._array_api import array_namespace, xp_capabilities
 from scipy._lib.array_api_compat import numpy as np_compat, is_array_api_obj
 
 from ._interpnd import _ndim_coords_from_arrays
@@ -56,6 +56,13 @@ def _check_dimensionality(points, values):
             )
 
 
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[
+        ("dask.array",
+         "https://github.com/data-apis/array-api-extra/issues/488")
+    ]
+)
 class RegularGridInterpolator:
     """Interpolator of specified order on a rectilinear grid in N ≥ 1 dimensions.
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2421,7 +2421,7 @@ class NdBSpline0:
         return np.asarray(result)
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(NdBSpline)
 class TestNdBSpline:
 
     def test_1D(self, xp):

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -19,16 +19,19 @@ from scipy.interpolate import (RegularGridInterpolator, interpn,
 from scipy.sparse._sputils import matrix
 from scipy._lib._testutils import _run_concurrent_barrier
 
+skip_xp_backends = pytest.mark.skip_xp_backends
+
 
 parametrize_rgi_interp_methods = pytest.mark.parametrize(
     "method", RegularGridInterpolator._ALL_METHODS
 )
 
+@skip_xp_backends(cpu_only=True, reason="compliled code")
 class TestRegularGridInterpolator:
-    def _get_sample_4d(self):
+    def _get_sample_4d(self, xp):
         # create a 4-D grid of 3 points in each dimension
         points = [(0., .5, 1.)] * 4
-        values = np.asarray([0., .5, 1.])
+        values = xp.asarray([0., .5, 1.])
         values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
         values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
@@ -36,10 +39,10 @@ class TestRegularGridInterpolator:
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
         return points, values
 
-    def _get_sample_4d_2(self):
+    def _get_sample_4d_2(self, xp):
         # create another 4-D grid of 3 points in each dimension
         points = [(0., .5, 1.)] * 2 + [(0., 5., 10.)] * 2
-        values = np.asarray([0., .5, 1.])
+        values = xp.asarray([0., .5, 1.])
         values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
         values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
@@ -47,10 +50,10 @@ class TestRegularGridInterpolator:
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
         return points, values
 
-    def _get_sample_4d_3(self):
+    def _get_sample_4d_3(self, xp):
         # create another 4-D grid of 7 points in each dimension
         points = [(0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0)] * 4
-        values = np.asarray([0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0])
+        values = xp.asarray([0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0])
         values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
         values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
@@ -58,10 +61,10 @@ class TestRegularGridInterpolator:
         values = (values0 + values1 * 10 + values2 * 100 + values3 * 1000)
         return points, values
 
-    def _get_sample_4d_4(self):
+    def _get_sample_4d_4(self, xp):
         # create another 4-D grid of 2 points in each dimension
         points = [(0.0, 1.0)] * 4
-        values = np.asarray([0.0, 1.0])
+        values = xp.asarray([0.0, 1.0])
         values0 = values[:, np.newaxis, np.newaxis, np.newaxis]
         values1 = values[np.newaxis, :, np.newaxis, np.newaxis]
         values2 = values[np.newaxis, np.newaxis, :, np.newaxis]
@@ -71,7 +74,7 @@ class TestRegularGridInterpolator:
 
     @parametrize_rgi_interp_methods
     def test_list_input(self, method):
-        points, values = self._get_sample_4d_3()
+        points, values = self._get_sample_4d_3(xp=np)
 
         sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
@@ -87,8 +90,9 @@ class TestRegularGridInterpolator:
         xp_assert_close(v1, v2)
 
     @pytest.mark.parametrize('method', ['cubic', 'quintic', 'pchip'])
-    def test_spline_dim_error(self, method):
-        points, values = self._get_sample_4d_4()
+    def test_spline_dim_error(self, method, xp):
+        points, values = self._get_sample_4d_4(xp)
+        points = list(xp.asarray(p) for p in points)
         match = "points in dimension"
 
         # Check error raise when creating interpolator
@@ -97,7 +101,7 @@ class TestRegularGridInterpolator:
 
         # Check error raise when creating interpolator
         interp = RegularGridInterpolator(points, values)
-        sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
+        sample = xp.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
         with pytest.raises(ValueError, match=match):
             interp(sample, method=method)
@@ -108,25 +112,27 @@ class TestRegularGridInterpolator:
             (
                 _get_sample_4d,
                 np.asarray(
-                    [[0.1, 0.1, 1.0, 0.9],
-                     [0.2, 0.1, 0.45, 0.8],
-                     [0.5, 0.5, 0.5, 0.5]]
+                [[0.1, 0.1, 1.0, 0.9],
+                 [0.2, 0.1, 0.45, 0.8],
+                 [0.5, 0.5, 0.5, 0.5]]
                 ),
             ),
             (_get_sample_4d_2, np.asarray([0.1, 0.1, 10.0, 9.0])),
         ],
     )
-    def test_linear_and_slinear_close(self, points_values, sample):
-        points, values = points_values(self)
+    def test_linear_and_slinear_close(self, points_values, sample, xp):
+        points, values = points_values(self, xp)
+        points, sample = list(xp.asarray(p) for p in points), xp.asarray(sample)
         interp = RegularGridInterpolator(points, values, method="linear")
         v1 = interp(sample)
         interp = RegularGridInterpolator(points, values, method="slinear")
         v2 = interp(sample)
         xp_assert_close(v1, v2)
 
-    def test_derivatives(self):
-        points, values = self._get_sample_4d()
-        sample = np.array([[0.1 , 0.1 , 1.  , 0.9 ],
+    def test_derivatives(self, xp):
+        points, values = self._get_sample_4d(xp)
+        points = list(xp.asarray(p) for p in points)
+        sample = xp.asarray([[0.1 , 0.1 , 1.  , 0.9 ],
                            [0.2 , 0.1 , 0.45, 0.8 ],
                            [0.5 , 0.5 , 0.5 , 0.5 ]])
         interp = RegularGridInterpolator(points, values, method="slinear")
@@ -136,34 +142,35 @@ class TestRegularGridInterpolator:
             interp(sample, nu=1)
 
         xp_assert_close(interp(sample, nu=(1, 0, 0, 0)),
-                        np.asarray([1.0, 1, 1]), atol=1e-15)
+                        xp.asarray([1.0, 1, 1], dtype=xp.float64), atol=1e-15)
         xp_assert_close(interp(sample, nu=(0, 1, 0, 0)),
-                        np.asarray([10.0, 10, 10]), atol=1e-15)
+                        xp.asarray([10.0, 10, 10], dtype=xp.float64), atol=1e-15)
 
         # 2nd derivatives of a linear function are zero
         xp_assert_close(interp(sample, nu=(0, 1, 1, 0)),
-                        np.asarray([0.0, 0, 0]), atol=2e-12)
+                        xp.asarray([0.0, 0, 0], dtype=xp.float64), atol=2e-12)
 
     @parametrize_rgi_interp_methods
-    def test_complex(self, method):
+    def test_complex(self, method, xp):
         if method == "pchip":
             pytest.skip("pchip does not make sense for complex data")
-        points, values = self._get_sample_4d_3()
+        points, values = self._get_sample_4d_3(xp)
+        points = list(xp.asarray(p) for p in points)
         values = values - 2j*values
-        sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
+        sample = xp.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
 
         interp = RegularGridInterpolator(points, values, method=method)
-        rinterp = RegularGridInterpolator(points, values.real, method=method)
-        iinterp = RegularGridInterpolator(points, values.imag, method=method)
+        rinterp = RegularGridInterpolator(points, xp.real(values), method=method)
+        iinterp = RegularGridInterpolator(points, xp.imag(values), method=method)
 
         v1 = interp(sample)
         v2 = rinterp(sample) + 1j*iinterp(sample)
         xp_assert_close(v1, v2)
 
-    def test_cubic_vs_pchip(self):
-        x, y = [1, 2, 3, 4], [1, 2, 3, 4]
-        xg, yg = np.meshgrid(x, y, indexing='ij')
+    def test_cubic_vs_pchip(self, xp):
+        x, y = xp.asarray([1, 2, 3, 4]), xp.asarray([1, 2, 3, 4])
+        xg, yg = xp.meshgrid(x, y, indexing='ij')
 
         values = (lambda x, y: x**4 * y**4)(xg, yg)
         cubic = RegularGridInterpolator((x, y), values, method='cubic')
@@ -171,44 +178,49 @@ class TestRegularGridInterpolator:
 
         vals_cubic = cubic([1.5, 2])
         vals_pchip = pchip([1.5, 2])
-        assert not np.allclose(vals_cubic, vals_pchip, atol=1e-14, rtol=0)
+        #assert not np.allclose(vals_cubic, vals_pchip, atol=1e-14, rtol=0)
+        assert not xp.all(xp.abs(vals_cubic - vals_pchip) < 1e-14)
 
-    def test_linear_xi1d(self):
-        points, values = self._get_sample_4d_2()
+    def test_linear_xi1d(self, xp):
+        points, values = self._get_sample_4d_2(xp)
+        points = list(xp.asarray(p) for p in points)
         interp = RegularGridInterpolator(points, values)
-        sample = np.asarray([0.1, 0.1, 10., 9.])
-        wanted = np.asarray([1001.1])
+        sample = xp.asarray([0.1, 0.1, 10., 9.])
+        wanted = xp.asarray([1001.1], dtype=xp.float64)
         assert_array_almost_equal(interp(sample), wanted)
 
-    def test_linear_xi3d(self):
-        points, values = self._get_sample_4d()
+    def test_linear_xi3d(self, xp):
+        points, values = self._get_sample_4d(xp)
+        points = list(xp.asarray(p) for p in points)
         interp = RegularGridInterpolator(points, values)
-        sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
+        sample = xp.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
-        wanted = np.asarray([1001.1, 846.2, 555.5])
+        wanted = xp.asarray([1001.1, 846.2, 555.5])
         assert_array_almost_equal(interp(sample), wanted)
 
     @pytest.mark.parametrize(
         "sample, wanted",
         [
-            (np.asarray([0.1, 0.1, 0.9, 0.9]), 1100.0),
-            (np.asarray([0.1, 0.1, 0.1, 0.1]), 0.0),
-            (np.asarray([0.0, 0.0, 0.0, 0.0]), 0.0),
-            (np.asarray([1.0, 1.0, 1.0, 1.0]), 1111.0),
-            (np.asarray([0.1, 0.4, 0.6, 0.9]), 1055.0),
+            ([0.1, 0.1, 0.9, 0.9], 1100.0),
+            ([0.1, 0.1, 0.1, 0.1], 0.0),
+            ([0.0, 0.0, 0.0, 0.0], 0.0),
+            ([1.0, 1.0, 1.0, 1.0], 1111.0),
+            ([0.1, 0.4, 0.6, 0.9], 1055.0),
         ],
     )
-    def test_nearest(self, sample, wanted):
-        points, values = self._get_sample_4d()
+    def test_nearest(self, sample, wanted, xp):
+        points, values = self._get_sample_4d(xp)
+        points, sample = tuple(xp.asarray(p) for p in points), xp.asarray(sample)
         interp = RegularGridInterpolator(points, values, method="nearest")
-        wanted = np.asarray([wanted])
+        wanted = xp.asarray([wanted], dtype=xp.float64)
         assert_array_almost_equal(interp(sample), wanted)
 
-    def test_linear_edges(self):
-        points, values = self._get_sample_4d()
+    def test_linear_edges(self, xp):
+        points, values = self._get_sample_4d(xp)
+        points = list(xp.asarray(p) for p in points)
         interp = RegularGridInterpolator(points, values)
-        sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.]])
-        wanted = np.asarray([0., 1111.])
+        sample = xp.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.]])
+        wanted = xp.asarray([0., 1111.])
         assert_array_almost_equal(interp(sample), wanted)
 
     def test_valid_create(self):
@@ -229,54 +241,65 @@ class TestRegularGridInterpolator:
         assert_raises(ValueError, RegularGridInterpolator, points, values,
                       method="undefmethod")
 
-    def test_valid_call(self):
-        points, values = self._get_sample_4d()
+    def test_valid_call(self, xp):
+        points, values = self._get_sample_4d(xp)
+        points = list(xp.asarray(p) for p in points)
         interp = RegularGridInterpolator(points, values)
-        sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.]])
-        assert_raises(ValueError, interp, sample, "undefmethod")
-        sample = np.asarray([[0., 0., 0.], [1., 1., 1.]])
-        assert_raises(ValueError, interp, sample)
-        sample = np.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.1]])
-        assert_raises(ValueError, interp, sample)
+        sample = xp.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.]])
+        with assert_raises(ValueError):
+            interp(sample, "undefmethod")
 
-    def test_out_of_bounds_extrap(self):
-        points, values = self._get_sample_4d()
+        sample = xp.asarray([[0., 0., 0.], [1., 1., 1.]])
+        with assert_raises(ValueError):
+            interp(sample)
+
+        sample = xp.asarray([[0., 0., 0., 0.], [1., 1., 1., 1.1]])
+        with assert_raises(ValueError):
+            interp(sample)
+
+    def test_out_of_bounds_extrap(self, xp):
+        points, values = self._get_sample_4d(xp)
+        points = list(xp.asarray(p) for p in points)
         interp = RegularGridInterpolator(points, values, bounds_error=False,
                                          fill_value=None)
-        sample = np.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
-                             [21, 2.1, -1.1, -11], [2.1, 2.1, -1.1, -1.1]])
-        wanted = np.asarray([0., 1111., 11., 11.])
+        sample = xp.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
+                             [21, 2.1, -1.1, -11], [2.1, 2.1, -1.1, -1.1]],
+                            dtype=xp.float64)
+        wanted = xp.asarray([0., 1111., 11., 11.], dtype=xp.float64)
         assert_array_almost_equal(interp(sample, method="nearest"), wanted)
-        wanted = np.asarray([-111.1, 1222.1, -11068., -1186.9])
+        wanted = xp.asarray([-111.1, 1222.1, -11068., -1186.9], dtype=xp.float64)
         assert_array_almost_equal(interp(sample, method="linear"), wanted)
 
-    def test_out_of_bounds_extrap2(self):
-        points, values = self._get_sample_4d_2()
+    def test_out_of_bounds_extrap2(self, xp):
+        points, values = self._get_sample_4d_2(xp)
+        points = list(xp.asarray(p) for p in points)
         interp = RegularGridInterpolator(points, values, bounds_error=False,
                                          fill_value=None)
-        sample = np.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
-                             [21, 2.1, -1.1, -11], [2.1, 2.1, -1.1, -1.1]])
-        wanted = np.asarray([0., 11., 11., 11.])
+        sample = xp.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
+                             [21, 2.1, -1.1, -11], [2.1, 2.1, -1.1, -1.1]],
+                            dtype=xp.float64)
+        wanted = xp.asarray([0., 11., 11., 11.], dtype=xp.float64)
         assert_array_almost_equal(interp(sample, method="nearest"), wanted)
-        wanted = np.asarray([-12.1, 133.1, -1069., -97.9])
+        wanted = xp.asarray([-12.1, 133.1, -1069., -97.9], dtype=xp.float64)
         assert_array_almost_equal(interp(sample, method="linear"), wanted)
 
-    def test_out_of_bounds_fill(self):
-        points, values = self._get_sample_4d()
+    def test_out_of_bounds_fill(self, xp):
+        points, values = self._get_sample_4d(xp)
+        points = list(xp.asarray(p) for p in points)
         interp = RegularGridInterpolator(points, values, bounds_error=False,
-                                         fill_value=np.nan)
-        sample = np.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
+                                         fill_value=xp.nan)
+        sample = xp.asarray([[-.1, -.1, -.1, -.1], [1.1, 1.1, 1.1, 1.1],
                              [2.1, 2.1, -1.1, -1.1]])
-        wanted = np.asarray([np.nan, np.nan, np.nan])
+        wanted = xp.asarray([xp.nan, xp.nan, xp.nan])
         assert_array_almost_equal(interp(sample, method="nearest"), wanted)
         assert_array_almost_equal(interp(sample, method="linear"), wanted)
-        sample = np.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
+        sample = xp.asarray([[0.1, 0.1, 1., .9], [0.2, 0.1, .45, .8],
                              [0.5, 0.5, .5, .5]])
-        wanted = np.asarray([1001.1, 846.2, 555.5])
+        wanted = xp.asarray([1001.1, 846.2, 555.5])
         assert_array_almost_equal(interp(sample), wanted)
 
     def test_nearest_compare_qhull(self):
-        points, values = self._get_sample_4d()
+        points, values = self._get_sample_4d(np)
         interp = RegularGridInterpolator(points, values, method="nearest")
         points_qhull = itertools.product(*points)
         points_qhull = [p for p in points_qhull]
@@ -288,7 +311,7 @@ class TestRegularGridInterpolator:
         assert_array_almost_equal(interp(sample), interp_qhull(sample))
 
     def test_linear_compare_qhull(self):
-        points, values = self._get_sample_4d()
+        points, values = self._get_sample_4d(np)
         interp = RegularGridInterpolator(points, values)
         points_qhull = itertools.product(*points)
         points_qhull = [p for p in points_qhull]
@@ -761,7 +784,7 @@ class TestRegularGridInterpolator:
             )
 
     def test_concurrency(self):
-        points, values = self._get_sample_4d()
+        points, values = self._get_sample_4d(np)
         sample = np.array([[0.1 , 0.1 , 1.  , 0.9 ],
                            [0.2 , 0.1 , 0.45, 0.8 ],
                            [0.5 , 0.5 , 0.5 , 0.5 ],

--- a/scipy/interpolate/tests/test_rgi.py
+++ b/scipy/interpolate/tests/test_rgi.py
@@ -6,7 +6,8 @@ import numpy as np
 from numpy.exceptions import ComplexWarning
 
 from scipy._lib._array_api import (
-    xp_assert_equal, xp_assert_close, assert_array_almost_equal
+    xp_assert_equal, xp_assert_close, assert_array_almost_equal,
+    make_xp_test_case
 )
 from scipy.conftest import skip_xp_invalid_arg
 
@@ -19,14 +20,12 @@ from scipy.interpolate import (RegularGridInterpolator, interpn,
 from scipy.sparse._sputils import matrix
 from scipy._lib._testutils import _run_concurrent_barrier
 
-skip_xp_backends = pytest.mark.skip_xp_backends
-
 
 parametrize_rgi_interp_methods = pytest.mark.parametrize(
     "method", RegularGridInterpolator._ALL_METHODS
 )
 
-@skip_xp_backends(cpu_only=True, reason="compliled code")
+@make_xp_test_case(RegularGridInterpolator)
 class TestRegularGridInterpolator:
     def _get_sample_4d(self, xp):
         # create a 4-D grid of 3 points in each dimension


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards gh-23754

#### What does this implement/fix?
<!--Please explain your changes.-->

Make `NdBSpline` array API compatible. The pattern is the same as `BSpline`: convert inputs to numpy, call the compiled implementation, convert back.

One exception is `design_matrix` which returns a `csr_array`, which is numpy-only, so there's nothing we can do until there's array api compatibility in `scipy.sparse`.

#### Additional information
<!--Any additional information you think is important.-->
