### PR TITLE
DOC: special: consistent modified Bessel order and fix Hankel function refs

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -91,15 +91,15 @@ Bessel functions
                         complex argument.
    yve               -- Exponentially scaled Bessel function of the second kind \
                         of real order.
+   iv                -- Modified Bessel function of the first kind of real order.
+   ive               -- Exponentially scaled modified Bessel function of the \
+                        first kind.
    kn                -- Modified Bessel function of the second kind of integer \
                         order `n`
    kv                -- Modified Bessel function of the second kind of real order \
                         `v`
    kve               -- Exponentially scaled modified Bessel function of the \
                         second kind.
-   iv                -- Modified Bessel function of the first kind of real order.
-   ive               -- Exponentially scaled modified Bessel function of the \
-                        first kind.
    hankel1           -- Hankel function of the first kind.
    hankel1e          -- Exponentially scaled Hankel function of the first kind.
    hankel2           -- Hankel function of the second kind.
@@ -173,8 +173,8 @@ Derivatives of Bessel functions
 
    jvp  -- Compute nth derivative of Bessel function Jv(z) with respect to `z`.
    yvp  -- Compute nth derivative of Bessel function Yv(z) with respect to `z`.
-   kvp  -- Compute nth derivative of real-order modified Bessel function Kv(z)
    ivp  -- Compute nth derivative of modified Bessel function Iv(z) with respect to `z`.
+   kvp  -- Compute nth derivative of real-order modified Bessel function Kv(z)
    h1vp -- Compute nth derivative of Hankel function H1v(z) with respect to `z`.
    h2vp -- Compute nth derivative of Hankel function H2v(z) with respect to `z`.
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1147,7 +1147,7 @@ def h1vp(v, z, n=1):
         Argument at which to evaluate the derivative. Can be real or
         complex.
     n : int, default 1
-        Order of derivative. For 0 returns the Hankel function `h1v` itself.
+        Order of derivative. For 0 returns the Hankel function `hankel1` itself.
 
     Returns
     -------
@@ -1216,7 +1216,7 @@ def h2vp(v, z, n=1):
         Argument at which to evaluate the derivative. Can be real or
         complex.
     n : int, default 1
-        Order of derivative. For 0 returns the Hankel function `h2v` itself.
+        Order of derivative. For 0 returns the Hankel function `hankel2` itself.
 
     Returns
     -------


### PR DESCRIPTION
This moves modified Bessel functions of the first kind (`iv`) before those of the second kind (`kv`), and corrects references to the `hankel1` and `hankel2` functions.