### PR TITLE
TST: signal: isolate use of alternative backend only to function being tested in signal tests

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -331,7 +331,7 @@ ensure that any failures that occur on a backend actually relate to the function
 of interest, and avoids the need to skip backends due to lack of support for
 functions other than ``f``.
 
-To help facillitate such backend isolation, there is a function ``_xp_copy_to_numpy``
+To help facilitate such backend isolation, there is a function ``_xp_copy_to_numpy``
 in ``scipy._lib._array_api`` which can copy an arbitrary ``xp`` array to a NumPy
 array, bypassing any device transfer guards, while preserving dtypes. It is essential
 that this function is only used in tests for functions other than the one being

--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -362,7 +362,8 @@ but would not produce the correct dtype behavior::
   z, p, b, a = map(xp.asarray, (z, p, b, a))
 
   # With float64 inputs, the outputs bp and ap will be of dtype
-  # float64.
+  # float64. Note that the parameter k is a Python scalar which does
+  # not impact output dtype for NumPy >= 2.0.
   bp, ap = zpk2tf(z, p, k)
   # xp_assert_close checks for matching dtype. Due to the way the
   # code was written above, zpk2tf is not tested with float32 inputs

--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -329,15 +329,14 @@ functions evaluated within a test, for the purpose of producing reference values
 inputs, round-trip calculations, etc. should instead use the NumPy backend. This helps
 ensure that any failures that occur on a backend actually relate to the function
 of interest, and avoids the need to skip backends due to lack of support for
-functions other than ``f`` when ``f`` is supported.
+functions other than ``f``.
 
 To help facillitate such backend isolation, there is a function ``_xp_copy_to_numpy``
 in ``scipy._lib._array_api`` which can copy an arbitrary ``xp`` array to a NumPy
 array, bypassing any device transfer guards, while preserving dtypes. It is essential
-that this function is only used in tests and in tests only for the purpose of isolating
-use of alternative backends to only the function being tested. Attempts to copy a
-device array to NumPy outside of tests should fail, because otherwise it can become
-opaque whether a function is working on GPU or not.
+that this function is only used in tests for functions other than the one being
+tested. Attempts to copy a device array to NumPy outside of tests should fail,
+because otherwise it can become opaque whether a function is working on GPU or not.
 
 When attempting to isolate use of alternative backends to a particular function, one
 must be mindful that PyTorch allows for setting a default dtype, and SciPy is tested

--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -371,7 +371,7 @@ but would not produce the correct dtype behavior::
   xp_assert_close(b, bp)
   xp_assert_close(a, ap)
 
-One should instead construct all inputs as ``xp`` arrays and then copy to
+One could instead construct all inputs as ``xp`` arrays and then copy to
 NumPy arrays in order to ensure the default dtype is respected::
 
   # calls to xp.asarray will respect the default dtype.

--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -391,6 +391,13 @@ NumPy arrays in order to ensure the default dtype is respected::
   xp_assert_close(b, bp)
   xp_assert_close(a, ap)
 
+The above suggestions mainly concern the bulk conversion of existing tests to
+work with alternative backends. There may be specific cases where such isolation
+is neither necessary nor desirable. Maintainers have discretion to write and
+accept tests as they see fit, so long as they take care to investigate that use
+of the alternative backend across multiple functions in the same test is sound,
+and will not require unnecessary skips or xfails to be added.
+
 
 Testing the JAX JIT compiler
 ----------------------------

--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -323,13 +323,19 @@ PyTorch, and JAX on CPU.
 Testing Practice
 ````````````````
 
-It's best if individual tests using the ``xp`` fixture restrict
-use of alternative backends to only a single function ``f`` being tested. Other
-functions evaluated within a test, for the purpose of producing reference values,
-inputs, round-trip calculations, etc. should instead use the NumPy backend. This helps
-ensure that any failures that occur on a backend actually relate to the function
-of interest, and avoids the need to skip backends due to lack of support for
-functions other than ``f``.
+It's important that for any supported function ``f``, there exist tests using
+the ``xp`` fixture that restrict use of alternative backends to only the function
+``f`` being tested. Other functions evaluated within a test, for the purpose of
+producing reference values, inputs, round-trip calculations, etc. should instead
+use the NumPy backend. This helps ensure that any failures that occur on a backend
+actually relate to the function of interest, and avoids the need to skip backends
+due to lack of support for functions other than ``f``. Property based integration
+tests which check that some invariant holds using the same alternative backend
+across different functions can also have value, giving a window into the general
+health of backend support for a module, but in order to ensure the test suite
+actually reflects the state of backend support for each function, it's vital to
+have tests which isolate use of the alternative backend only to the function being
+tested.
 
 To help facilitate such backend isolation, there is a function ``_xp_copy_to_numpy``
 in ``scipy._lib._array_api`` which can copy an arbitrary ``xp`` array to a NumPy
@@ -390,13 +396,6 @@ NumPy arrays in order to ensure the default dtype is respected::
   bp, ap = zpk2tf(z, p, k)
   xp_assert_close(b, bp)
   xp_assert_close(a, ap)
-
-The above suggestions mainly concern the bulk conversion of existing tests to
-work with alternative backends. There may be specific cases where such isolation
-is neither necessary nor desirable. Maintainers have discretion to write and
-accept tests as they see fit, so long as they take care to investigate that use
-of the alternative backend across multiple functions in the same test is sound,
-and will not require unnecessary skips or xfails to be added.
 
 
 Testing the JAX JIT compiler

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -166,7 +166,7 @@ def _xp_copy_to_numpy(x: Array) -> np.ndarray:
     -------
     ndarray
     """
-    xp  = array_namespace(x)
+    xp = array_namespace(x)
     if is_numpy(xp):
         return x.copy()
     if is_cupy(xp):

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -55,7 +55,7 @@ __all__ = [
     'np_compat', 'get_native_namespace_name',
     'SCIPY_ARRAY_API', 'SCIPY_DEVICE', 'scipy_namespace_for',
     'xp_assert_close', 'xp_assert_equal', 'xp_assert_less',
-    'xp_copy', 'xp_copy_to_numpy', 'xp_device', 'xp_ravel', 'xp_size',
+    'xp_copy', 'xp_device', 'xp_ravel', 'xp_size',
     'xp_unsupported_param_msg', 'xp_vector_norm', 'xp_capabilities',
     'xp_result_type', 'xp_promote',
     'make_xp_test_case', 'make_xp_pytest_marks', 'make_xp_pytest_param',

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -147,13 +147,16 @@ def xp_copy(x: Array, *, xp: ModuleType | None = None) -> Array:
     return _asarray(x, copy=True, xp=xp)
 
 
-def xp_copy_to_numpy(x: Array) -> np.ndarray:
+def _xp_copy_to_numpy(x: Array) -> np.ndarray:
     """Copies a possibly on device array to a NumPy array.
 
-    This function is primarily intended for converting alternative backend
-    arrays to numpy arrays within test code, to allow use of the alternative
-    to be isolated to only the function being tested, not function used to
-    compute reference values etc.
+    This function is intended only for converting alternative backend
+    arrays to numpy arrays within test code, to make it easier for use
+    of the alternative backend to be isolated only to the function being
+    tested. `_xp_copy_to_numpy` should NEVER be used except in test code
+    for the specific purpose mentioned above. In production code, attempts
+    to copy device arrays to NumPy arrays should fail, or else functions
+    may appear to be working on the GPU when they actually aren't.
     
     Parameters
     ----------
@@ -172,7 +175,7 @@ def xp_copy_to_numpy(x: Array) -> np.ndarray:
         return x.cpu().numpy()
     # Fall back to np.asarray. This will work for jax.numpy and
     # dask.array. If new backends are added, they may require
-    # explicit handling..
+    # explicit handling.
     return np.asarray(x, copy=True)
 
 
@@ -330,7 +333,7 @@ def xp_assert_close_nulp(actual, desired, *, nulp=1, check_namespace=True,
         check_shape=check_shape, check_0d=check_0d
     )
 
-    actual, desired = map(xp_copy_to_numpy, (actual, desired))
+    actual, desired = map(_xp_copy_to_numpy, (actual, desired))
     return np.testing.assert_array_almost_equal_nulp(actual, desired, nulp=nulp)
 
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -319,6 +319,21 @@ def xp_assert_close(actual, desired, *, rtol=None, atol=0, check_namespace=True,
                                       atol=atol, err_msg=err_msg)
 
 
+def xp_assert_close_nulp(actual, desired, *, nulp=1, check_namespace=True,
+                         check_dtype=True, check_shape=True, check_0d=True,
+                         err_msg='', xp=None):
+    __tracebackhide__ = True  # Hide traceback for py.test
+
+    actual, desired, xp = _strict_check(
+        actual, desired, xp,
+        check_namespace=check_namespace, check_dtype=check_dtype,
+        check_shape=check_shape, check_0d=check_0d
+    )
+
+    actual, desired = map(xp_copy_to_numpy, (actual, desired))
+    return np.testing.assert_array_almost_equal_nulp(actual, desired, nulp=nulp)
+
+
 def xp_assert_less(actual, desired, *, check_namespace=True, check_dtype=True,
                    check_shape=True, check_0d=True, err_msg='', verbose=True, xp=None):
     __tracebackhide__ = True  # Hide traceback for py.test

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -8,7 +8,7 @@ from importlib import import_module
 from scipy._lib._array_api import (
     SCIPY_ARRAY_API, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy,
     np_compat, xp_default_dtype, xp_result_type, is_torch,
-    xp_capabilities_table
+    xp_capabilities_table, xp_copy_to_numpy
 )
 from scipy._lib._array_api_docs_tables import is_named_function_like_object
 from scipy._lib import array_api_extra as xpx
@@ -143,6 +143,27 @@ class TestArrayAPI:
                 pass
             else:
                 assert x[0] != y[0]
+
+    @pytest.mark.parametrize(
+        "dtype",
+        ["float32", "float64", "complex64", "complex128", "int32", "int64"],
+    )
+    @pytest.mark.parametrize(
+        "data", [[], 1, [1, 2, 3], [[1, 2], [2, 3]]],
+    )
+    def test_copy_to_numpy(self, xp, data, dtype):
+        xp_dtype = getattr(xp, dtype)
+        np_dtype = getattr(np, dtype)
+        x = xp.asarray(data, dtype=xp_dtype)
+        y = xp_copy_to_numpy(x)
+        assert isinstance(y, np.ndarray)
+        assert y.dtype == np_dtype
+        assert x.shape == y.shape
+        np.testing.assert_equal(y, np.asarray(data, dtype=np_dtype))
+        if is_numpy(xp):
+            # Ensure y is a copy when xp is numpy.
+            assert id(x) != id(y)
+
     
     @pytest.mark.parametrize('dtype', ['int32', 'int64', 'float32', 'float64'])
     @pytest.mark.parametrize('shape', [(), (3,)])

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -8,7 +8,7 @@ from importlib import import_module
 from scipy._lib._array_api import (
     SCIPY_ARRAY_API, array_namespace, _asarray, xp_copy, xp_assert_equal, is_numpy,
     np_compat, xp_default_dtype, xp_result_type, is_torch,
-    xp_capabilities_table, xp_copy_to_numpy
+    xp_capabilities_table, _xp_copy_to_numpy
 )
 from scipy._lib._array_api_docs_tables import is_named_function_like_object
 from scipy._lib import array_api_extra as xpx
@@ -155,7 +155,7 @@ class TestArrayAPI:
         xp_dtype = getattr(xp, dtype)
         np_dtype = getattr(np, dtype)
         x = xp.asarray(data, dtype=xp_dtype)
-        y = xp_copy_to_numpy(x)
+        y = _xp_copy_to_numpy(x)
         assert isinstance(y, np.ndarray)
         assert y.dtype == np_dtype
         assert x.shape == y.shape

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -238,17 +238,17 @@ class TestZpk2Tf:
             assert isinstance(a, np.ndarray)
 
     @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
-    @skip_xp_backends(cpu_only=True, reason="XXX zpk2sos is numpy-only")
     def test_conj_pair(self, xp):
         # conjugate pairs give real-coeff num & den
         z = xp.asarray([1j, -1j, 2j, -2j])
+        z_np = xp_copy_to_numpy(z)
         # shouldn't need elements of pairs to be adjacent
         p = xp.asarray([1+1j, 3-100j, 3+100j, 1-1j])
+        p_np = xp_copy_to_numpy(p_np)
         k = 23
 
         # np.poly should do the right thing, but be explicit about
         # taking real part
-        z_np, p_np = map(np.asarray, (z, p))
         b_np = k * np.poly(z_np).real
         a_np = np.poly(p_np).real
         b, a = map(xp.asarray, (b_np, a_np))
@@ -262,13 +262,12 @@ class TestZpk2Tf:
         assert xp.isdtype(ap.dtype, 'real floating')
 
     @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
-    @skip_xp_backends(
-        cpu_only=True, reason="XXX zpk2sos is numpy-only", exceptions=['cupy']
-    )
     def test_complexk(self, xp):
         # regression: z, p real, k complex k gave real b, a
         b, a = xp.asarray([1j, 1j]), xp.asarray([1.0, 2])
-        z, p, k = tf2zpk(b, a)
+        b_np, a_np = map(xp_copy_to_numpy, (b, a))
+        z_np, p_np, k_np = tf2zpk(b_np, a_np)
+        z, p, k = map(xp_copy_to_numpy, (z, p, k))
         xp_assert_close(k, xp.asarray(1j), check_0d=False)
         bp, ap = zpk2tf(z, p, k)
         xp_assert_close(b, bp)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4684,7 +4684,7 @@ class TestIIRFilter:
             iirfilter(2, [0.6, 0.5])
 
 
-@skip_xp_backends(cpu_only=True, reason="np.convolve")
+@skip_xp_backends(cpu_only=True, exceptions=["cupy"], reason="np.convolve")
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
 class TestGroupDelay:
     def test_identity_filter(self, xp):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4696,7 +4696,7 @@ class TestGroupDelay:
         b = firwin(N + 1, 0.1)
         b = xp.asarray(b)
         w, gd = group_delay((b, 1))
-        xp_assert_close(gd, xp.ones_like(gd)*(0.5 * N))
+        xp_assert_close(gd, xp.ones_like(gd)*(0.5 * N), rtol=5e-7)
 
     @pytest.mark.xfail(DEFAULT_F32, reason="wrong answer with torch/float32")
     def test_iir(self, xp):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2593,8 +2593,9 @@ class TestBessel:
 
         for N in range(1, 11):
             p1 = np.sort(bond_poles[N])
-            ap = besselap(N, 'delay')
-            p2 = np.sort(np.concatenate(_cplxreal(ap[1])))
+            z, p, k = besselap(N, 'delay', xp=xp)
+            assert array_namespace(z) == array_namespace(p) == xp
+            p2 = np.sort(np.concatenate(_cplxreal(xp_copy_to_numpy(p))))
             assert_array_almost_equal(xp.asarray(p1), xp.asarray(p2), decimal=10)
 
         # "Frequency Normalized Bessel Pole Locations"
@@ -2621,8 +2622,9 @@ class TestBessel:
 
         for N in range(1, 11):
             p1 = np.sort(bond_poles[N])
-            ap = besselap(N, 'mag')
-            p2 = np.sort(np.concatenate(_cplxreal(ap[1])))
+            z, p, k = besselap(N, 'mag', xp=xp)
+            assert array_namespace(z) == array_namespace(p) == xp
+            p2 = np.sort(np.concatenate(_cplxreal(xp_copy_to_numpy(p))))
             assert_array_almost_equal(xp.asarray(p1), xp.asarray(p2), decimal=10)
 
         # Compare to https://www.ranecommercial.com/legacy/note147.html
@@ -2843,9 +2845,8 @@ class TestBessel:
                  -.2373280669322028974199184 + 1.211476658382565356579418j],
             }
         for N in originals:
-            p1 = np.union1d(originals[N], np.conj(originals[N]))
-            p2 = besselap(N)[1]
-            p1, p2 = xp.asarray(p1), xp.asarray(p2)
+            p1 = xp.asarray(np.union1d(originals[N], np.conj(originals[N])))
+            p2 = besselap(N, xp=xp)[1]
             xp_assert_close(_sort_cmplx(p1, xp=xp),
                             _sort_cmplx(p2, xp=xp), rtol=1e-14, check_dtype=False)
 
@@ -2855,9 +2856,10 @@ class TestBessel:
         for N in (1, 2, 3, 4, 5, 51, 72):
             for w0 in (1, 100):
                 b, a = bessel(N, xp.asarray(w0), analog=True, norm='phase')
-                w = xp.linspace(0, w0, 100)
-                w, h = freqs(b, a, w)
-                phase = np.unwrap(np.angle(xp.asarray(h)))
+                assert array_namespace(b) == array_namespace(a) == xp
+                w = np.linspace(0, w0, 100)
+                w, h = freqs(xp_copy_to_numpy(b), xp_copy_to_numpy(a), w)
+                phase = np.unwrap(np.angle(h))
                 xp_assert_close(
                     xp.asarray(phase[[0, -1]]), xp.asarray([0, -N*xp.pi/4]), rtol=1e-1
                 )
@@ -2868,10 +2870,11 @@ class TestBessel:
         for N in (1, 2, 3, 4, 5, 51, 72):
             for w0 in (1, 100):
                 b, a = bessel(N, xp.asarray(w0), analog=True, norm='mag')
-                w = xp.asarray([0.0, w0])
-                w, h = freqs(b, a, w)
-                mag = xp.abs(h)
-                xp_assert_close(mag, xp.asarray([1, 1/math.sqrt(2)]))
+                assert array_namespace(b) == array_namespace(a) == xp
+                w = [0.0, w0]
+                w, h = freqs(xp_copy_to_numpy(b), xp_copy_to_numpy(a), w)
+                mag = np.abs(h)
+                xp_assert_close(xp.asarray(mag), xp.asarray([1, 1/math.sqrt(2)]))
 
     def test_norm_delay(self, xp):
         # Test some orders and frequencies and see that they have the right
@@ -2879,10 +2882,10 @@ class TestBessel:
         for N in (1, 2, 3, 4, 5, 51, 72):
             for w0 in (1, 100):
                 b, a = bessel(N, xp.asarray(w0), analog=True, norm='delay')
-                w = xp.linspace(0, 10*w0, 1000)
-                w, h = freqs(b, a, w)
-                unwr_h = xp.asarray(np.unwrap(np.angle(np.asarray(h))))
-                delay = -xp.diff(unwr_h) / xp.diff(w)
+                w = np.linspace(0, 10*w0, 1000)
+                w, h = freqs(xp_copy_to_numpy(b), xp_copy_to_numpy(a), w)
+                unwr_h = np.asarray(np.unwrap(np.angle(np.asarray(h))))
+                delay = -np.diff(unwr_h) / np.diff(w)
                 assert math.isclose(delay[0], 1/w0, rel_tol=1e-4)
 
     def test_norm_factor(self):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2237,7 +2237,7 @@ class TestCheb2ord:
         rp = 3
         rs = 90
         N, Wn = cheb2ord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
-        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'bs', False)
+        b, a = cheby2(N, rs, _xp_copy_to_numpy(Wn), 'bs', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -244,7 +244,7 @@ class TestZpk2Tf:
         z_np = xp_copy_to_numpy(z)
         # shouldn't need elements of pairs to be adjacent
         p = xp.asarray([1+1j, 3-100j, 3+100j, 1-1j])
-        p_np = xp_copy_to_numpy(p_np)
+        p_np = xp_copy_to_numpy(p)
         k = 23
 
         # np.poly should do the right thing, but be explicit about
@@ -267,7 +267,7 @@ class TestZpk2Tf:
         b, a = xp.asarray([1j, 1j]), xp.asarray([1.0, 2])
         b_np, a_np = map(xp_copy_to_numpy, (b, a))
         z_np, p_np, k_np = tf2zpk(b_np, a_np)
-        z, p, k = map(xp_copy_to_numpy, (z, p, k))
+        z, p, k = map(xp.asarray, (z_np, p_np, k_np))
         xp_assert_close(k, xp.asarray(1j), check_0d=False)
         bp, ap = zpk2tf(z, p, k)
         xp_assert_close(b, bp)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1599,7 +1599,7 @@ class TestLp2bs:
 
 
 @skip_xp_backends(
-    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
+    cpu_only=True, exceptions=["cupy"], reason="uses np.polynomial.Polynomial"
 )
 class TestBilinear:
     """Tests for function `signal.bilinear`. """
@@ -1892,9 +1892,6 @@ def dB(x):
 
 
 @pytest.mark.skipif(DEFAULT_F32, reason="XXX needs figuring out")
-@skip_xp_backends(
-    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
-)
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
 class TestButtord:
 
@@ -1950,6 +1947,9 @@ class TestButtord:
             rtol=1e-15
         )
 
+    @skip_xp_backends(
+        cpu_only=True, exceptions=["cupy"], reason="optimize.fminbound"
+    )
     def test_bandstop(self, xp):
         wp = [0.1, 0.6]
         ws = [0.2, 0.5]
@@ -2046,9 +2046,6 @@ class TestButtord:
 
 
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
-@skip_xp_backends(
-    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
-)
 class TestCheb1ord:
 
     @xfail_xp_backends("torch", reason="accuracy is bad")
@@ -2098,6 +2095,9 @@ class TestCheb1ord:
         assert N == 9
         xp_assert_close(Wn, xp.asarray([0.2, 0.5]), rtol=1e-15)
 
+    @skip_xp_backends(
+        cpu_only=True, exceptions=["cupy"], reason="optimize.fminbound"
+    )
     def test_bandstop(self, xp):
         wp = [0.1, 0.6]
         ws = [0.2, 0.5]
@@ -2180,9 +2180,6 @@ class TestCheb1ord:
 
 @pytest.mark.skipif(DEFAULT_F32, reason="XXX needs figuring out")
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
-@skip_xp_backends(
-    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
-)
 class TestCheb2ord:
 
     def test_lowpass(self, xp):
@@ -2231,6 +2228,9 @@ class TestCheb2ord:
         xp_assert_close(Wn, xp.asarray([0.14876937565923479, 0.59748447842351482]),
                         rtol=1e-15)
 
+    @skip_xp_backends(
+        cpu_only=True, exceptions=["cupy"], reason="optimize.fminbound"
+    )
     def test_bandstop(self, xp):
         wp = [0.1, 0.6]
         ws = [0.2, 0.5]
@@ -2312,9 +2312,7 @@ class TestCheb2ord:
 
 @pytest.mark.skipif(DEFAULT_F32, reason="XXX needs figuring out")
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
-@skip_xp_backends(
-    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
-)
+@skip_xp_backends(cpu_only=True,  reason="special.ellipk")
 class TestEllipord:
 
     def test_lowpass(self, xp):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -218,6 +218,9 @@ class TestTf2zpk:
             assert_raises(BadCoefficients, tf2zpk, [1e-15], [1.0, 1.0])
 
 
+@skip_xp_backends(
+    cpu_only=True, exceptions=["cupy"], reason="zpk2sos is numpy only"
+)
 class TestZpk2Tf:
 
     def test_identity(self, xp):
@@ -1602,6 +1605,9 @@ class TestLp2bs:
         assert_array_almost_equal(a_bs, xp.asarray([1, 0.18461, 0.17407]), decimal=5)
 
 
+@skip_xp_backends(
+    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
+)
 class TestBilinear:
     """Tests for function `signal.bilinear`. """
 
@@ -1893,6 +1899,9 @@ def dB(x):
 
 
 @pytest.mark.skipif(DEFAULT_F32, reason="XXX needs figuring out")
+@skip_xp_backends(
+    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
+)
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
 class TestButtord:
 
@@ -2044,6 +2053,9 @@ class TestButtord:
 
 
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
+@skip_xp_backends(
+    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
+)
 class TestCheb1ord:
 
     @xfail_xp_backends("torch", reason="accuracy is bad")
@@ -2175,6 +2187,9 @@ class TestCheb1ord:
 
 @pytest.mark.skipif(DEFAULT_F32, reason="XXX needs figuring out")
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
+@skip_xp_backends(
+    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
+)
 class TestCheb2ord:
 
     def test_lowpass(self, xp):
@@ -2304,6 +2319,9 @@ class TestCheb2ord:
 
 @pytest.mark.skipif(DEFAULT_F32, reason="XXX needs figuring out")
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
+@skip_xp_backends(
+    cpu_only=True, exceptions=["cupy"], reason="not array api agnostic"
+)
 class TestEllipord:
 
     def test_lowpass(self, xp):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -13,7 +13,7 @@ from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, array_namespace,
     assert_array_almost_equal, xp_size, xp_default_dtype, is_numpy,
     is_cupy, scipy_namespace_for, xp_assert_close_nulp,
-    xp_copy_to_numpy
+    _xp_copy_to_numpy
 )
 import scipy._lib.array_api_extra as xpx
 
@@ -244,10 +244,10 @@ class TestZpk2Tf:
     def test_conj_pair(self, xp):
         # conjugate pairs give real-coeff num & den
         z = xp.asarray([1j, -1j, 2j, -2j])
-        z_np = xp_copy_to_numpy(z)
+        z_np = _xp_copy_to_numpy(z)
         # shouldn't need elements of pairs to be adjacent
         p = xp.asarray([1+1j, 3-100j, 3+100j, 1-1j])
-        p_np = xp_copy_to_numpy(p)
+        p_np = _xp_copy_to_numpy(p)
         k = 23
 
         # np.poly should do the right thing, but be explicit about
@@ -268,7 +268,7 @@ class TestZpk2Tf:
     def test_complexk(self, xp):
         # regression: z, p real, k complex k gave real b, a
         b, a = xp.asarray([1j, 1j]), xp.asarray([1.0, 2])
-        b_np, a_np = map(xp_copy_to_numpy, (b, a))
+        b_np, a_np = map(_xp_copy_to_numpy, (b, a))
         z_np, p_np, k_np = tf2zpk(b_np, a_np)
         z, p, k = map(xp.asarray, (z_np, p_np, k_np))
         xp_assert_close(k, xp.asarray(1j), check_0d=False)
@@ -1904,7 +1904,7 @@ class TestButtord:
         rp = 3
         rs = 60
         N, Wn = buttord(xp.asarray(wp), ws, rp, rs, False)
-        b, a = butter(N, xp_copy_to_numpy(Wn), 'lowpass', False)
+        b, a = butter(N, _xp_copy_to_numpy(Wn), 'lowpass', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp < dB(h[w <= wp]))
@@ -1920,7 +1920,7 @@ class TestButtord:
         rp = 3
         rs = 70
         N, Wn = buttord(xp.asarray(wp), ws, rp, rs, False)
-        b, a = butter(N, xp_copy_to_numpy(Wn), 'highpass', False)
+        b, a = butter(N, _xp_copy_to_numpy(Wn), 'highpass', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp < dB(h[wp <= w]))
@@ -1936,7 +1936,7 @@ class TestButtord:
         rp = 3
         rs = 80
         N, Wn = buttord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
-        b, a = butter(N, xp_copy_to_numpy(Wn), 'bandpass', False)
+        b, a = butter(N, _xp_copy_to_numpy(Wn), 'bandpass', False)
         w, h = freqz(b, a)
         w /= np.pi
 
@@ -1956,7 +1956,7 @@ class TestButtord:
         rp = 3
         rs = 90
         N, Wn = buttord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
-        b, a = butter(N, xp_copy_to_numpy(Wn), 'bandstop', False)
+        b, a = butter(N, _xp_copy_to_numpy(Wn), 'bandstop', False)
         w, h = freqz(b, a)
         w /= np.pi
 
@@ -1975,7 +1975,7 @@ class TestButtord:
         rp = 3
         rs = 60
         N, Wn = buttord(xp.asarray(wp), ws, rp, rs, True)
-        b, a = butter(N, xp_copy_to_numpy(Wn), 'lowpass', True)
+        b, a = butter(N, _xp_copy_to_numpy(Wn), 'lowpass', True)
         w, h = freqs(b, a)
         assert np.all(-rp < dB(h[w <= wp]))
         assert np.all(dB(h[ws <= w]) < -rs)
@@ -2000,7 +2000,7 @@ class TestButtord:
         rs = 80
         fs = 44100
         N, Wn = buttord(xp.asarray(wp), xp.asarray(ws), rp, rs, False, fs=fs)
-        b, a = butter(N, xp_copy_to_numpy(Wn), 'bandpass', False, fs=fs)
+        b, a = butter(N, _xp_copy_to_numpy(Wn), 'bandpass', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
 
         assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
@@ -2058,7 +2058,7 @@ class TestCheb1ord:
         rp = 3
         rs = 60
         N, Wn = cheb1ord(xp.asarray(wp), ws, rp, rs, False)
-        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'low', False)
+        b, a = cheby1(N, rp, _xp_copy_to_numpy(Wn), 'low', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[w <= wp]))
@@ -2074,7 +2074,7 @@ class TestCheb1ord:
         rp = 3
         rs = 70
         N, Wn = cheb1ord(xp.asarray(wp), ws, rp, rs, False)
-        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'high', False)
+        b, a = cheby1(N, rp, _xp_copy_to_numpy(Wn), 'high', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[wp <= w]))
@@ -2089,7 +2089,7 @@ class TestCheb1ord:
         rp = 3
         rs = 80
         N, Wn = cheb1ord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
-        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'band', False)
+        b, a = cheby1(N, rp, _xp_copy_to_numpy(Wn), 'band', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
@@ -2104,7 +2104,7 @@ class TestCheb1ord:
         rp = 3
         rs = 90
         N, Wn = cheb1ord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
-        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'stop', False)
+        b, a = cheby1(N, rp, _xp_copy_to_numpy(Wn), 'stop', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
@@ -2119,7 +2119,7 @@ class TestCheb1ord:
         rp = 3
         rs = 70
         N, Wn = cheb1ord(wp, xp.asarray(ws), rp, rs, True)
-        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'high', True)
+        b, a = cheby1(N, rp, _xp_copy_to_numpy(Wn), 'high', True)
         w, h = freqs(b, a)
         assert np.all(-rp - 0.1 < dB(h[wp <= w]))
         assert np.all(dB(h[w <= ws]) < -rs + 0.1)
@@ -2137,7 +2137,7 @@ class TestCheb1ord:
         rs = 60
         fs = 48000
         N, Wn = cheb1ord(wp, xp.asarray(ws), rp, rs, False, fs=fs)
-        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'low', False, fs=fs)
+        b, a = cheby1(N, rp, _xp_copy_to_numpy(Wn), 'low', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
         assert np.all(-rp - 0.1 < dB(h[w <= wp]))
         assert np.all(dB(h[ws <= w]) < -rs + 0.1)
@@ -2191,7 +2191,7 @@ class TestCheb2ord:
         rp = 3
         rs = 60
         N, Wn = cheb2ord(wp, xp.asarray(ws), rp, rs, False)
-        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'lp', False)
+        b, a = cheby2(N, rs, _xp_copy_to_numpy(Wn), 'lp', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[w <= wp]))
@@ -2206,7 +2206,7 @@ class TestCheb2ord:
         rp = 3
         rs = 70
         N, Wn = cheb2ord(wp, xp.asarray(ws), rp, rs, False)
-        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'hp', False)
+        b, a = cheby2(N, rs, _xp_copy_to_numpy(Wn), 'hp', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[wp <= w]))
@@ -2221,7 +2221,7 @@ class TestCheb2ord:
         rp = 3
         rs = 80
         N, Wn = cheb2ord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
-        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'bp', False)
+        b, a = cheby2(N, rs, _xp_copy_to_numpy(Wn), 'bp', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
@@ -2253,7 +2253,7 @@ class TestCheb2ord:
         rp = 3
         rs = 80
         N, Wn = cheb2ord(xp.asarray(wp), xp.asarray(ws), rp, rs, True)
-        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'bp', True)
+        b, a = cheby2(N, rs, _xp_copy_to_numpy(Wn), 'bp', True)
         w, h = freqs(b, a)
         assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
         assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
@@ -2269,7 +2269,7 @@ class TestCheb2ord:
         rs = 70
         fs = 1000
         N, Wn = cheb2ord(wp, xp.asarray(ws), rp, rs, False, fs=fs)
-        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'hp', False, fs=fs)
+        b, a = cheby2(N, rs, _xp_copy_to_numpy(Wn), 'hp', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
         assert np.all(-rp - 0.1 < dB(h[wp <= w]))
         assert np.all(dB(h[w <= ws]) < -rs + 0.1)
@@ -2323,7 +2323,7 @@ class TestEllipord:
         rp = 3
         rs = 60
         N, Wn = ellipord(wp, xp.asarray(ws), rp, rs, False)
-        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'lp', False)
+        b, a = ellip(N, rp, rs, _xp_copy_to_numpy(Wn), 'lp', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[w <= wp]))
@@ -2339,7 +2339,7 @@ class TestEllipord:
         rp = 3
         rs = 1000
         N, Wn = ellipord(wp, xp.asarray(ws), rp, rs, False)
-        sos = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'lp', False, output='sos')
+        sos = ellip(N, rp, rs, _xp_copy_to_numpy(Wn), 'lp', False, output='sos')
         w, h = freqz_sos(sos)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[w <= wp]))
@@ -2351,7 +2351,7 @@ class TestEllipord:
         rp = 3
         rs = 70
         N, Wn = ellipord(wp, xp.asarray(ws), rp, rs, False)
-        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'hp', False)
+        b, a = ellip(N, rp, rs, _xp_copy_to_numpy(Wn), 'hp', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[wp <= w]))
@@ -2366,7 +2366,7 @@ class TestEllipord:
         rp = 3
         rs = 80
         N, Wn = ellipord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
-        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'bp', False)
+        b, a = ellip(N, rp, rs, _xp_copy_to_numpy(Wn), 'bp', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
@@ -2381,7 +2381,7 @@ class TestEllipord:
         rp = 3
         rs = 90
         N, Wn = ellipord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
-        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'bs', False)
+        b, a = ellip(N, rp, rs, _xp_copy_to_numpy(Wn), 'bs', False)
         w, h = freqz(b, a)
         w /= np.pi
         assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
@@ -2396,7 +2396,7 @@ class TestEllipord:
         rp = 3
         rs = 90
         N, Wn = ellipord(xp.asarray(wp), xp.asarray(ws), rp, rs, True)
-        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'bs', True)
+        b, a = ellip(N, rp, rs, _xp_copy_to_numpy(Wn), 'bs', True)
         w, h = freqs(b, a)
         assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
         assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
@@ -2413,7 +2413,7 @@ class TestEllipord:
         rs = 90
         fs = 8000
         N, Wn = ellipord(xp.asarray(wp), xp.asarray(ws), rp, rs, False, fs=fs)
-        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'bs', False, fs=fs)
+        b, a = ellip(N, rp, rs, _xp_copy_to_numpy(Wn), 'bs', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
         assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
         assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
@@ -2606,7 +2606,7 @@ class TestBessel:
             p1 = np.sort(bond_poles[N])
             z, p, k = besselap(N, 'delay', xp=xp)
             assert array_namespace(z) == array_namespace(p) == xp
-            p2 = np.sort(np.concatenate(_cplxreal(xp_copy_to_numpy(p))))
+            p2 = np.sort(np.concatenate(_cplxreal(_xp_copy_to_numpy(p))))
             assert_array_almost_equal(xp.asarray(p1), xp.asarray(p2), decimal=10)
 
         # "Frequency Normalized Bessel Pole Locations"
@@ -2635,7 +2635,7 @@ class TestBessel:
             p1 = np.sort(bond_poles[N])
             z, p, k = besselap(N, 'mag', xp=xp)
             assert array_namespace(z) == array_namespace(p) == xp
-            p2 = np.sort(np.concatenate(_cplxreal(xp_copy_to_numpy(p))))
+            p2 = np.sort(np.concatenate(_cplxreal(_xp_copy_to_numpy(p))))
             assert_array_almost_equal(xp.asarray(p1), xp.asarray(p2), decimal=10)
 
         # Compare to https://www.ranecommercial.com/legacy/note147.html
@@ -2869,7 +2869,7 @@ class TestBessel:
                 b, a = bessel(N, xp.asarray(w0), analog=True, norm='phase')
                 assert array_namespace(b) == array_namespace(a) == xp
                 w = np.linspace(0, w0, 100)
-                w, h = freqs(xp_copy_to_numpy(b), xp_copy_to_numpy(a), w)
+                w, h = freqs(_xp_copy_to_numpy(b), _xp_copy_to_numpy(a), w)
                 phase = np.unwrap(np.angle(h))
                 xp_assert_close(
                     xp.asarray(phase[[0, -1]]), xp.asarray([0, -N*xp.pi/4]), rtol=1e-1
@@ -2883,7 +2883,7 @@ class TestBessel:
                 b, a = bessel(N, xp.asarray(w0), analog=True, norm='mag')
                 assert array_namespace(b) == array_namespace(a) == xp
                 w = [0.0, w0]
-                w, h = freqs(xp_copy_to_numpy(b), xp_copy_to_numpy(a), w)
+                w, h = freqs(_xp_copy_to_numpy(b), _xp_copy_to_numpy(a), w)
                 mag = np.abs(h)
                 xp_assert_close(xp.asarray(mag), xp.asarray([1, 1/math.sqrt(2)]))
 
@@ -2894,7 +2894,7 @@ class TestBessel:
             for w0 in (1, 100):
                 b, a = bessel(N, xp.asarray(w0), analog=True, norm='delay')
                 w = np.linspace(0, 10*w0, 1000)
-                w, h = freqs(xp_copy_to_numpy(b), xp_copy_to_numpy(a), w)
+                w, h = freqs(_xp_copy_to_numpy(b), _xp_copy_to_numpy(a), w)
                 unwr_h = np.asarray(np.unwrap(np.angle(np.asarray(h))))
                 delay = -np.diff(unwr_h) / np.diff(w)
                 assert math.isclose(delay[0], 1/w0, rel_tol=1e-4)
@@ -4386,7 +4386,7 @@ class TestIIRComb:
         freqs, response = freqz(b, a, 1000, fs=10000)
 
         # Find the notch using argrelextrema
-        comb_points = argrelextrema(abs(xp_copy_to_numpy(response)), np.less)[0]
+        comb_points = argrelextrema(abs(_xp_copy_to_numpy(response)), np.less)[0]
         comb_points = xp.asarray(comb_points)
 
         # Verify that the first notch sits at 1000 Hz
@@ -4853,7 +4853,7 @@ class TestGammatone:
             b, a = gammatone(1000, ftype, fs=fs, xp=xp)
 
             # Calculate the frequency response.
-            freqs, response = freqz(xp_copy_to_numpy(b), xp_copy_to_numpy(a))
+            freqs, response = freqz(_xp_copy_to_numpy(b), _xp_copy_to_numpy(a))
 
             # Determine peak magnitude of the response
             # and corresponding frequency.
@@ -4874,7 +4874,7 @@ class TestGammatone:
     @xfail_xp_backends("jax.numpy", reason="no eig(..) on JAX CUDA")
     def test_iir_symmetry(self, xp):
         b, a = gammatone(440, 'iir', fs=24000, xp=xp)
-        z, p, k = tf2zpk(xp_copy_to_numpy(b), xp_copy_to_numpy(a))
+        z, p, k = tf2zpk(_xp_copy_to_numpy(b), _xp_copy_to_numpy(a))
         z, p, k = map(xp.asarray, (z, p, k))
         xp_assert_equal(_sort_cmplx(z, xp=xp), _sort_cmplx(xp.conj(z), xp=xp))
         xp_assert_equal(_sort_cmplx(p, xp=xp), _sort_cmplx(xp.conj(p), xp=xp))

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1614,26 +1614,28 @@ class TestBilinear:
     @pytest.mark.xfail(DEFAULT_F32, reason="wrong answer with torch/float32")
     def test_basic(self, xp):
         # reference output values computed with sympy
-        b = [0.14879732743343033]
-        a = [1, 0.54552236880522209, 0.14879732743343033]
-        b, a = map(xp.asarray, (b, a))
+        b = xp.asarray([0.14879732743343033])
+        a = xp.asarray([1, 0.54552236880522209, 0.14879732743343033])
 
-        b_zref = [0.08782128175913713, 0.17564256351827426, 0.08782128175913713]
-        a_zref = [1.0, -1.0047722097030667, 0.3560573367396151]
-        b_zref, a_zref = map(np.asarray, (b_zref, a_zref))
+        b_zref = xp.asarray(
+            [0.08782128175913713, 0.17564256351827426, 0.08782128175913713]
+        )
+        a_zref = xp.asarray(
+            [1.0, -1.0047722097030667, 0.3560573367396151]
+        )
 
         b_z, a_z = bilinear(b, a, 0.5)
 
-        xp_assert_close_nulp(b_z, xp.asarray(b_zref))
-        xp_assert_close_nulp(a_z, xp.asarray(a_zref))
+        xp_assert_close_nulp(b_z, b_zref)
+        xp_assert_close_nulp(a_z, z_zref)
 
-        b = [1, 0, 0.17407467530697837]
-        a = [1, 0.18460575326152251, 0.17407467530697837]
-        b, a = map(xp.asarray, (b, a))
+        b = xp.asarray([1, 0, 0.17407467530697837])
+        a = xp.asarray([1, 0.18460575326152251, 0.17407467530697837])
 
-        b_zref = [0.8641286432189045, -1.2157757001964216, 0.8641286432189045]
-        a_zref = [1.0, -1.2157757001964216, 0.7282572864378091]
-        b_zref, a_zref = map(np.asarray, (b_zref, a_zref))
+        b_zref = xp.asarray(
+            [0.8641286432189045, -1.2157757001964216, 0.8641286432189045]
+        )
+        a_zref = xp.asarray([1.0, -1.2157757001964216, 0.7282572864378091])
 
         b_z, a_z = bilinear(b, a, 0.5)
 
@@ -1646,20 +1648,20 @@ class TestBilinear:
         # regression for gh-6606
         # results shouldn't change when leading zeros are added to
         # input numerator or denominator
-        b = [0.14879732743343033]
-        a = [1, 0.54552236880522209, 0.14879732743343033]
-        b, a = map(xp.asarray, (b, a))
+        b = xp.asarray([0.14879732743343033])
+        a = xp.asarray([1, 0.54552236880522209, 0.14879732743343033])
 
-        b_zref = [0.08782128175913713, 0.17564256351827426, 0.08782128175913713]
-        a_zref = [1.0, -1.0047722097030667, 0.3560573367396151]
-        b_zref, a_zref = map(np.asarray, (b_zref, a_zref))
+        b_zref = xp.asarray(
+            [0.08782128175913713, 0.17564256351827426, 0.08782128175913713]
+        )
+        a_zref = xp.asarray([1.0, -1.0047722097030667, 0.3560573367396151])
 
         for lzn, lzd in product(range(4), range(4)):
             b_z, a_z = bilinear(xpx.pad(b, (lzn, 0), xp=xp),
                                 xpx.pad(a, (lzd, 0), xp=xp),
                                 0.5)
-            xp_assert_close_nulp(b_z, xp.asarray(b_zref))
-            xp_assert_close_nulp(a_z, xp.asarray(a_zref))
+            xp_assert_close_nulp(b_z, b_zref)
+            xp_assert_close_nulp(a_z, a_zref)
 
     @pytest.mark.xfail(DEFAULT_F32, reason="wrong answer with torch/float32")
     @xfail_xp_backends("cupy", reason="complex inputs not supported")
@@ -1686,13 +1688,13 @@ class TestBilinear:
         a_zref = [(1+0j),
                   (-1.8839476369292854-0.606808151331815j),
                   (0.7954687330018285+0.5717459398142481j)]
-        b_zref, a_zref = map(np.asarray, (b_zref, a_zref))
+        b_zref, a_zref = map(xp.asarray, (b_zref, a_zref))
 
         b_z, a_z = bilinear(b, a, fs)
 
         # the 3 ulp difference determined from testing
-        xp_assert_close_nulp(b_z, xp.asarray(b_zref), nulp=3)
-        xp_assert_close_nulp(a_z, xp.asarray(a_zref), nulp=3)
+        xp_assert_close_nulp(b_z, b_zref, nulp=3)
+        xp_assert_close_nulp(a_z, a_zref, nulp=3)
 
     def test_fs_validation(self):
         b = [0.14879732743343033]
@@ -2893,7 +2895,7 @@ class TestBessel:
                 b, a = bessel(N, xp.asarray(w0), analog=True, norm='delay')
                 w = np.linspace(0, 10*w0, 1000)
                 w, h = freqs(_xp_copy_to_numpy(b), _xp_copy_to_numpy(a), w)
-                unwr_h = np.asarray(np.unwrap(np.angle(np.asarray(h))))
+                unwr_h = np.unwrap(np.angle(h))
                 delay = -np.diff(unwr_h) / np.diff(w)
                 assert math.isclose(delay[0], 1/w0, rel_tol=1e-4)
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2043,22 +2043,21 @@ class TestButtord:
             buttord(wp, ws, rp, rs, False, fs=np.array([10, 20]))
 
 
-@skip_xp_backends(cpu_only=True, reason="convolve on torch is cpu-only")
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
 class TestCheb1ord:
 
     @xfail_xp_backends("torch", reason="accuracy is bad")
     def test_lowpass(self, xp):
         wp = 0.2
-        ws = xp.asarray(0.3)
+        ws = 0.3
         rp = 3
         rs = 60
-        N, Wn = cheb1ord(wp, ws, rp, rs, False)
-        b, a = cheby1(N, rp, Wn, 'low', False)
+        N, Wn = cheb1ord(xp.asarray(wp), ws, rp, rs, False)
+        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'low', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[w <= wp]))
-        assert xp.all(dB(h[ws <= w]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
         assert N == 8
         xp_assert_close(Wn, xp.asarray(0.2), rtol=1e-15, check_0d=False)
@@ -2066,59 +2065,59 @@ class TestCheb1ord:
     @xfail_xp_backends("torch", reason="accuracy is bad")
     def test_highpass(self, xp):
         wp = 0.3
-        ws = xp.asarray(0.2)
+        ws = 0.2
         rp = 3
         rs = 70
-        N, Wn = cheb1ord(wp, ws, rp, rs, False)
-        b, a = cheby1(N, rp, Wn, 'high', False)
+        N, Wn = cheb1ord(xp.asarray(wp), ws, rp, rs, False)
+        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'high', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[wp <= w]))
-        assert xp.all(dB(h[w <= ws]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
         assert N == 9
         xp_assert_close(Wn, xp.asarray(0.3), rtol=1e-15, check_0d=False)
 
     def test_bandpass(self, xp):
-        wp = xp.asarray([0.2, 0.5])
-        ws = xp.asarray([0.1, 0.6])
+        wp = [0.2, 0.5]
+        ws = [0.1, 0.6]
         rp = 3
         rs = 80
-        N, Wn = cheb1ord(wp, ws, rp, rs, False)
-        b, a = cheby1(N, rp, Wn, 'band', False)
+        N, Wn = cheb1ord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
+        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'band', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[xp.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert xp.all(dB(h[xp.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
 
         assert N == 9
         xp_assert_close(Wn, xp.asarray([0.2, 0.5]), rtol=1e-15)
 
     def test_bandstop(self, xp):
-        wp = xp.asarray([0.1, 0.6])
-        ws = xp.asarray([0.2, 0.5])
+        wp = [0.1, 0.6]
+        ws = [0.2, 0.5]
         rp = 3
         rs = 90
-        N, Wn = cheb1ord(wp, ws, rp, rs, False)
-        b, a = cheby1(N, rp, Wn, 'stop', False)
+        N, Wn = cheb1ord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
+        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'stop', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[xp.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert xp.all(dB(h[xp.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
         assert N == 10
         xp_assert_close(Wn, xp.asarray([0.14758232569947785, 0.6]), rtol=1e-5)
 
     def test_analog(self, xp):
         wp = 700
-        ws = xp.asarray(100.)
+        ws = 100.
         rp = 3
         rs = 70
-        N, Wn = cheb1ord(wp, ws, rp, rs, True)
-        b, a = cheby1(N, rp, Wn, 'high', True)
+        N, Wn = cheb1ord(wp, xp.asarray(ws), rp, rs, True)
+        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'high', True)
         w, h = freqs(b, a)
-        assert xp.all(-rp - 0.1 < dB(h[wp <= w]))
-        assert xp.all(dB(h[w <= ws]) < -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
         assert N == 4
         assert math.isclose(Wn, 700.0, rel_tol=1e-15)
@@ -2128,15 +2127,15 @@ class TestCheb1ord:
     @xfail_xp_backends("torch", reason="accuracy issues")
     def test_fs_param(self, xp):
         wp = 4800
-        ws = xp.asarray(7200.)
+        ws = 7200.
         rp = 3
         rs = 60
         fs = 48000
-        N, Wn = cheb1ord(wp, ws, rp, rs, False, fs=fs)
-        b, a = cheby1(N, rp, Wn, 'low', False, fs=fs)
+        N, Wn = cheb1ord(wp, xp.asarray(ws), rp, rs, False, fs=fs)
+        b, a = cheby1(N, rp, xp_copy_to_numpy(Wn), 'low', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
-        assert xp.all(-rp - 0.1 < dB(h[w <= wp]))
-        assert xp.all(dB(h[ws <= w]) < -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
         assert N == 8
         assert math.isclose(Wn, 4800.0, rel_tol=1e-15)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2304,20 +2304,19 @@ class TestCheb2ord:
 
 @pytest.mark.skipif(DEFAULT_F32, reason="XXX needs figuring out")
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
-@skip_xp_backends(cpu_only=True, reason="convolve on torch is cpu-only")
 class TestEllipord:
 
     def test_lowpass(self, xp):
         wp = 0.2
-        ws = xp.asarray(0.3)
+        ws = 0.3
         rp = 3
         rs = 60
-        N, Wn = ellipord(wp, ws, rp, rs, False)
-        b, a = ellip(N, rp, rs, Wn, 'lp', False)
+        N, Wn = ellipord(wp, xp.asarray(ws), rp, rs, False)
+        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'lp', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[w <= wp]))
-        assert xp.all(dB(h[ws <= w]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
         assert N == 5
         assert math.isclose(Wn, 0.2, rel_tol=1e-15)
@@ -2325,71 +2324,71 @@ class TestEllipord:
     def test_lowpass_1000dB(self, xp):
         # failed when ellipkm1 wasn't used in ellipord and ellipap
         wp = 0.2
-        ws = xp.asarray(0.3)
+        ws = 0.3
         rp = 3
         rs = 1000
-        N, Wn = ellipord(wp, ws, rp, rs, False)
-        sos = ellip(N, rp, rs, Wn, 'lp', False, output='sos')
+        N, Wn = ellipord(wp, xp.asarray(ws), rp, rs, False)
+        sos = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'lp', False, output='sos')
         w, h = freqz_sos(sos)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[w <= wp]))
-        assert xp.all(dB(h[ws <= w]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
     def test_highpass(self, xp):
         wp = 0.3
-        ws = xp.asarray(0.2)
+        ws = 0.2
         rp = 3
         rs = 70
-        N, Wn = ellipord(wp, ws, rp, rs, False)
-        b, a = ellip(N, rp, rs, Wn, 'hp', False)
+        N, Wn = ellipord(wp, xp.asarray(ws), rp, rs, False)
+        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'hp', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[wp <= w]))
-        assert xp.all(dB(h[w <= ws]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
         assert N == 6
         assert math.isclose(Wn, 0.3, rel_tol=1e-15)
 
     def test_bandpass(self, xp):
-        wp = xp.asarray([0.2, 0.5])
-        ws = xp.asarray([0.1, 0.6])
+        wp = [0.2, 0.5]
+        ws = [0.1, 0.6]
         rp = 3
         rs = 80
-        N, Wn = ellipord(wp, ws, rp, rs, False)
-        b, a = ellip(N, rp, rs, Wn, 'bp', False)
+        N, Wn = ellipord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
+        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'bp', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[xp.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert xp.all(dB(h[xp.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
 
         assert N == 6
         xp_assert_close(Wn, xp.asarray([0.2, 0.5]), rtol=1e-15)
 
     def test_bandstop(self, xp):
-        wp = xp.asarray([0.1, 0.6])
-        ws = xp.asarray([0.2, 0.5])
+        wp = [0.1, 0.6]
+        ws = [0.2, 0.5]
         rp = 3
         rs = 90
-        N, Wn = ellipord(wp, ws, rp, rs, False)
-        b, a = ellip(N, rp, rs, Wn, 'bs', False)
+        N, Wn = ellipord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
+        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'bs', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[xp.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert xp.all(dB(h[xp.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
         assert N == 7
         xp_assert_close(Wn, xp.asarray([0.14758232794342988, 0.6]), rtol=1e-5)
 
     def test_analog(self, xp):
-        wp = xp.asarray([1000.0, 6000])
-        ws = xp.asarray([2000.0, 5000])
+        wp = [1000.0, 6000]
+        ws = [2000.0, 5000]
         rp = 3
         rs = 90
-        N, Wn = ellipord(wp, ws, rp, rs, True)
-        b, a = ellip(N, rp, rs, Wn, 'bs', True)
+        N, Wn = ellipord(xp.asarray(wp), xp.asarray(ws), rp, rs, True)
+        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'bs', True)
         w, h = freqs(b, a)
-        assert xp.all(-rp - 0.1 < dB(h[xp.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert xp.all(dB(h[xp.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
         assert N == 8
         xp_assert_close(Wn, xp.asarray([1666.6666, 6000]))
@@ -2397,16 +2396,16 @@ class TestEllipord:
         assert ellipord(1, 1.2, 1, 80, analog=True)[0] == 9
 
     def test_fs_param(self, xp):
-        wp = xp.asarray([400.0, 2400])
-        ws = xp.asarray([800.0, 2000])
+        wp = [400.0, 2400]
+        ws = [800.0, 2000]
         rp = 3
         rs = 90
         fs = 8000
-        N, Wn = ellipord(wp, ws, rp, rs, False, fs=fs)
-        b, a = ellip(N, rp, rs, Wn, 'bs', False, fs=fs)
+        N, Wn = ellipord(xp.asarray(wp), xp.asarray(ws), rp, rs, False, fs=fs)
+        b, a = ellip(N, rp, rs, xp_copy_to_numpy(Wn), 'bs', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
-        assert xp.all(-rp - 0.1 < dB(h[xp.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert xp.all(dB(h[xp.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
         assert N == 7
         xp_assert_close(Wn, xp.asarray([590.3293117737195, 2400]), rtol=1e-5)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -12,7 +12,7 @@ from pytest import raises as assert_raises
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, array_namespace,
     assert_array_almost_equal, xp_size, xp_default_dtype, is_numpy,
-    is_cupy, is_torch, scipy_namespace_for, xp_assert_close_nulp,
+    is_cupy, scipy_namespace_for, xp_assert_close_nulp,
     xp_copy_to_numpy
 )
 import scipy._lib.array_api_extra as xpx
@@ -1108,10 +1108,7 @@ class TestFreqz_sos:
 
         w, h, sos = map(xp.asarray, (w, h, sos))
         w2, h2 = freqz_sos(sos, worN=N)
-        if not (is_cupy(xp) or is_torch(xp)):
-            xp_assert_equal(w2, w)
-        else:
-            xp_assert_close(w2, w, rtol=1e-15)
+        xp_assert_close(w2, w, rtol=1e-15)
         xp_assert_close(h2, h, rtol=1e-10, atol=1e-14)
 
         b, a = ellip(3, 1, 30, (0.2, 0.3), btype='bandpass')
@@ -1120,10 +1117,7 @@ class TestFreqz_sos:
 
         w, h, sos = map(xp.asarray, (w, h, sos))
         w2, h2 = freqz_sos(sos, worN=N)
-        if not (is_cupy(xp) or is_torch(xp)):
-            xp_assert_equal(w2, w)
-        else:
-            xp_assert_close(w2, w, rtol=1e-15)
+        xp_assert_close(w2, w, rtol=1e-15)
         xp_assert_close(h2, h, rtol=1e-10, atol=1e-14)
 
         # must have at least one section

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4695,8 +4695,8 @@ class TestGroupDelay:
         # Let's design linear phase FIR and check that the group delay
         # is constant.
         N = 100
-        b = firwin(N + 1, xp.asarray(0.1))
-        b = xp.asarray(b)    # XXX until firwin PR has landed
+        b = firwin(N + 1, 0.1)
+        b = xp.asarray(b)
         w, gd = group_delay((b, 1))
         xp_assert_close(gd, xp.ones_like(gd)*(0.5 * N))
 
@@ -4704,7 +4704,8 @@ class TestGroupDelay:
     def test_iir(self, xp):
         # Let's design Butterworth filter and test the group delay at
         # some points against MATLAB answer.
-        b, a = butter(4, xp.asarray(0.1))
+        b, a = butter(4, 0.1)
+        b, a = map(xp.asarray, (b, a))
         w = xp.linspace(0, xp.pi, num=10, endpoint=False)
         w, gd = group_delay((b, a), w=w)
         matlab_gd = xp.asarray([8.249313898506037, 11.958947880907104,
@@ -4744,7 +4745,8 @@ class TestGroupDelay:
     def test_fs_param(self, xp):
         # Let's design Butterworth filter and test the group delay at
         # some points against the normalized frequency answer.
-        b, a = butter(4, xp.asarray(4800), fs=96000)
+        b, a = butter(4, 4800, fs=96000)
+        b, a = map(xp.asarray, (b, a))
         w = xp.linspace(0, 96000/2, num=10, endpoint=False)
         w, gd = group_delay((b, a), w=w, fs=96000)
         norm_gd = xp.asarray([8.249313898506037, 11.958947880907104,

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4366,7 +4366,6 @@ class TestIIRComb:
 
     # Verify that the filter's frequency response contains a
     # notch at the cutoff frequency
-    @skip_xp_backends(cpu_only=True, reason='XXX convert argrelextrema')
     @pytest.mark.parametrize('ftype', ('notch', 'peak'))
     def test_frequency_response(self, ftype, xp):
         # Create a notching or peaking comb filter at 1000 Hz
@@ -4376,7 +4375,7 @@ class TestIIRComb:
         freqs, response = freqz(b, a, 1000, fs=10000)
 
         # Find the notch using argrelextrema
-        comb_points = argrelextrema(abs(np.asarray(response)), np.less)[0]
+        comb_points = argrelextrema(abs(xp_copy_to_numpy(response)), np.less)[0]
         comb_points = xp.asarray(comb_points)
 
         # Verify that the first notch sits at 1000 Hz

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2175,81 +2175,80 @@ class TestCheb1ord:
 
 @pytest.mark.skipif(DEFAULT_F32, reason="XXX needs figuring out")
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
-@skip_xp_backends(cpu_only=True, reason="convolve on torch is cpu-only")
 class TestCheb2ord:
 
     def test_lowpass(self, xp):
         wp = 0.2
-        ws = xp.asarray(0.3)
+        ws = 0.3
         rp = 3
         rs = 60
-        N, Wn = cheb2ord(wp, ws, rp, rs, False)
-        b, a = cheby2(N, rs, Wn, 'lp', False)
+        N, Wn = cheb2ord(wp, xp.asarray(ws), rp, rs, False)
+        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'lp', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[w <= wp]))
-        assert xp.all(dB(h[ws <= w]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[w <= wp]))
+        assert np.all(dB(h[ws <= w]) < -rs + 0.1)
 
         assert N == 8
         xp_assert_close(Wn, xp.asarray(0.28647639976553163), rtol=1e-15, check_0d=False)
 
     def test_highpass(self, xp):
         wp = 0.3
-        ws = xp.asarray(0.2)
+        ws = 0.2
         rp = 3
         rs = 70
-        N, Wn = cheb2ord(wp, ws, rp, rs, False)
-        b, a = cheby2(N, rs, Wn, 'hp', False)
+        N, Wn = cheb2ord(wp, xp.asarray(ws), rp, rs, False)
+        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'hp', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[wp <= w]))
-        assert xp.all(dB(h[w <= ws]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
         assert N == 9
         xp_assert_close(Wn, xp.asarray(0.20697492182903282), rtol=1e-15, check_0d=False)
 
     def test_bandpass(self, xp):
-        wp = xp.asarray([0.2, 0.5])
-        ws = xp.asarray([0.1, 0.6])
+        wp = [0.2, 0.5]
+        ws = [0.1, 0.6]
         rp = 3
         rs = 80
-        N, Wn = cheb2ord(wp, ws, rp, rs, False)
-        b, a = cheby2(N, rs, Wn, 'bp', False)
+        N, Wn = cheb2ord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
+        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'bp', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[xp.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert xp.all(dB(h[xp.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
 
         assert N == 9
         xp_assert_close(Wn, xp.asarray([0.14876937565923479, 0.59748447842351482]),
                         rtol=1e-15)
 
     def test_bandstop(self, xp):
-        wp = xp.asarray([0.1, 0.6])
-        ws = xp.asarray([0.2, 0.5])
+        wp = [0.1, 0.6]
+        ws = [0.2, 0.5]
         rp = 3
         rs = 90
-        N, Wn = cheb2ord(wp, ws, rp, rs, False)
-        b, a = cheby2(N, rs, Wn, 'bs', False)
+        N, Wn = cheb2ord(xp.asarray(wp), xp.asarray(ws), rp, rs, False)
+        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'bs', False)
         w, h = freqz(b, a)
-        w /= xp.pi
-        assert xp.all(-rp - 0.1 < dB(h[xp.logical_or(w <= wp[0], wp[1] <= w)]))
-        assert xp.all(dB(h[xp.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
+        w /= np.pi
+        assert np.all(-rp - 0.1 < dB(h[np.logical_or(w <= wp[0], wp[1] <= w)]))
+        assert np.all(dB(h[np.logical_and(ws[0] <= w, w <= ws[1])]) < -rs + 0.1)
 
         assert N == 10
         xp_assert_close(Wn, xp.asarray([0.19926249974781743, 0.50125246585567362]),
                         rtol=1e-6)
 
     def test_analog(self, xp):
-        wp = xp.asarray([20., 50])
-        ws = xp.asarray([10., 60])
+        wp = [20., 50]
+        ws = [10., 60]
         rp = 3
         rs = 80
-        N, Wn = cheb2ord(wp, ws, rp, rs, True)
-        b, a = cheby2(N, rs, Wn, 'bp', True)
+        N, Wn = cheb2ord(xp.asarray(wp), xp.asarray(ws), rp, rs, True)
+        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'bp', True)
         w, h = freqs(b, a)
-        assert xp.all(-rp - 0.1 < dB(h[xp.logical_and(wp[0] <= w, w <= wp[1])]))
-        assert xp.all(dB(h[xp.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[np.logical_and(wp[0] <= w, w <= wp[1])]))
+        assert np.all(dB(h[np.logical_or(w <= ws[0], ws[1] <= w)]) < -rs + 0.1)
 
         assert N == 11
         xp_assert_close(Wn, xp.asarray([1.673740595370124e+01, 5.974641487254268e+01]),
@@ -2257,15 +2256,15 @@ class TestCheb2ord:
 
     def test_fs_param(self, xp):
         wp = 150
-        ws = xp.asarray(100.)
+        ws = 100.
         rp = 3
         rs = 70
         fs = 1000
-        N, Wn = cheb2ord(wp, ws, rp, rs, False, fs=fs)
-        b, a = cheby2(N, rs, Wn, 'hp', False, fs=fs)
+        N, Wn = cheb2ord(wp, xp.asarray(ws), rp, rs, False, fs=fs)
+        b, a = cheby2(N, rs, xp_copy_to_numpy(Wn), 'hp', False, fs=fs)
         w, h = freqz(b, a, fs=fs)
-        assert xp.all(-rp - 0.1 < dB(h[wp <= w]))
-        assert xp.all(dB(h[w <= ws]) < -rs + 0.1)
+        assert np.all(-rp - 0.1 < dB(h[wp <= w]))
+        assert np.all(dB(h[w <= ws]) < -rs + 0.1)
 
         assert N == 9
         assert math.isclose(Wn, 103.4874609145164, rel_tol=1e-15)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -238,6 +238,7 @@ class TestZpk2Tf:
             assert isinstance(a, np.ndarray)
 
     @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
+    @xfail_xp_backends("cupy", reason="inaccurate")
     def test_conj_pair(self, xp):
         # conjugate pairs give real-coeff num & den
         z = xp.asarray([1j, -1j, 2j, -2j])

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1627,7 +1627,7 @@ class TestBilinear:
         b_z, a_z = bilinear(b, a, 0.5)
 
         xp_assert_close_nulp(b_z, b_zref)
-        xp_assert_close_nulp(a_z, z_zref)
+        xp_assert_close_nulp(a_z, a_zref)
 
         b = xp.asarray([1, 0, 0.17407467530697837])
         a = xp.asarray([1, 0.18460575326152251, 0.17407467530697837])

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4721,6 +4721,7 @@ class TestGroupDelay:
         assert_array_almost_equal(gd, matlab_gd)
 
     @xfail_xp_backends("cupy", reason="does not warn")
+    @xfail_xp_backends("torch", reason="does not warn")
     def test_singular(self, xp):
         # Let's create a filter with zeros and poles on the unit circle and
         # check if warnings are raised at those frequencies.

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1614,8 +1614,9 @@ class TestBilinear:
     @pytest.mark.xfail(DEFAULT_F32, reason="wrong answer with torch/float32")
     def test_basic(self, xp):
         # reference output values computed with sympy
-        b = xp.asarray([0.14879732743343033])
-        a = xp.asarray([1, 0.54552236880522209, 0.14879732743343033])
+        b = [0.14879732743343033]
+        a = [1, 0.54552236880522209, 0.14879732743343033]
+        b, a = map(xp.asarray, (b, a))
 
         b_zref = xp.asarray(
             [0.08782128175913713, 0.17564256351827426, 0.08782128175913713]
@@ -1648,8 +1649,9 @@ class TestBilinear:
         # regression for gh-6606
         # results shouldn't change when leading zeros are added to
         # input numerator or denominator
-        b = xp.asarray([0.14879732743343033])
-        a = xp.asarray([1, 0.54552236880522209, 0.14879732743343033])
+        b = [0.14879732743343033]
+        a = [1, 0.54552236880522209, 0.14879732743343033]
+        b, a = map(xp.asarray, (b, a))
 
         b_zref = xp.asarray(
             [0.08782128175913713, 0.17564256351827426, 0.08782128175913713]

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -7,7 +7,6 @@ from itertools import product
 
 from scipy._lib import _pep440
 import numpy as np
-from numpy.testing import assert_array_almost_equal_nulp
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._array_api import (

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -7,7 +7,7 @@ import pytest
 import scipy._lib.array_api_extra as xpx
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, assert_almost_equal, assert_array_almost_equal,
-    array_namespace, xp_default_dtype
+    array_namespace, xp_default_dtype, xp_copy_to_numpy
 )
 from scipy.fft import fft, fft2
 from scipy.signal import (kaiser_beta, kaiser_atten, kaiserord,
@@ -151,11 +151,11 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = xp.asarray([0.0, 0.25, 0.5-width/2, 0.5+width/2, 0.75, 1.0])
-        freqs, response = freqz(taps, worN=xp.pi*freq_samples)
+        freq_samples = np.asarray([0.0, 0.25, 0.5-width/2, 0.5+width/2, 0.75, 1.0])
+        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(
-            xp.abs(response),
+            xp.abs(xp.asarray(response)),
             xp.asarray([1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5
         )
 
@@ -178,10 +178,10 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = xp.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2, 0.75, 1.0])
-        freqs, response = freqz(taps, worN=np.pi*freq_samples)
+        freq_samples = np.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2, 0.75, 1.0])
+        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
-        assert_array_almost_equal(xp.abs(response),
+        assert_array_almost_equal(xp.abs(xp.asarray(response)),
                                   xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5)
 
         taps_str = firwin(ntaps, pass_zero='highpass', **kwargs)
@@ -200,11 +200,11 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = xp.asarray([0.0, 0.2, 0.3 - width/2, 0.3 + width/2, 0.5,
+        freq_samples = np.asarray([0.0, 0.2, 0.3 - width/2, 0.3 + width/2, 0.5,
                                    0.7 - width/2, 0.7 + width/2, 0.8, 1.0])
-        freqs, response = freqz(taps, worN=np.pi*freq_samples)
+        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
-        assert_array_almost_equal(xp.abs(response),
+        assert_array_almost_equal(xp.abs(xp.asarray(response)),
                 xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5)
 
         taps_str = firwin(ntaps, pass_zero='bandpass', **kwargs)
@@ -222,13 +222,13 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = xp.asarray([0.0, 0.1, 0.2 - width/2, 0.2 + width/2, 0.35,
+        freq_samples = np.asarray([0.0, 0.1, 0.2 - width/2, 0.2 + width/2, 0.35,
                                    0.5 - width/2, 0.5 + width/2, 0.65,
                                    0.8 - width/2, 0.8 + width/2, 0.9, 1.0])
-        freqs, response = freqz(taps, worN=np.pi*freq_samples)
+        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(
-            xp.abs(response),
+            xp.abs(xp.asarray(response)),
             xp.asarray([1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]),
             decimal=5
         )
@@ -250,11 +250,11 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = xp.asarray([0.0, 200, 300 - width/2, 300 + width/2, 500,
+        freq_samples = np.asarray([0.0, 200, 300 - width/2, 300 + width/2, 500,
                                    700 - width/2, 700 + width/2, 800, 1000])
-        freqs, response = freqz(taps, worN=np.pi*freq_samples/nyquist)
+        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples/nyquist)
 
-        assert_array_almost_equal(xp.abs(response),
+        assert_array_almost_equal(xp.abs(xp.asarray(response)),
                 xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5)
 
     def test_array_cutoff(self, xp):
@@ -307,7 +307,7 @@ class TestFirWinMore:
             firwin2(51, .5, 1, fs=np.array([10, 20]))
 
 
-@skip_xp_backends(cpu_only=True, reason="firwin2 uses np.interp")
+@skip_xp_backends(cpu_only=True, reason="firwin2 uses np.interp", exceptions=["cupy"])
 class TestFirwin2:
 
     def test_invalid_args(self):
@@ -366,12 +366,11 @@ class TestFirwin2:
         freq = xp.asarray([0.0, 0.5, 1.0])
         gain = xp.asarray([1.0, 1.0, 0.0])
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
-        freq_samples = xp.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2,
+        freq_samples = np.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2,
                                                         0.75, 1.0 - width/2])
-        freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        freqs, response = xp.asarray(freqs), xp.asarray(response)
+        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
         assert_array_almost_equal(
-            xp.abs(response),
+            xp.abs(xp.asarray(response)),
             xp.asarray([1.0, 1.0, 1.0, 1.0 - width, 0.5, width]), decimal=5
         )
 
@@ -386,10 +385,9 @@ class TestFirwin2:
         gain = xp.asarray([0.0, 0.0, 1.0, 1.0])
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
         freq_samples = np.array([0.0, 0.25, 0.5 - width, 0.5 + width, 0.75, 1.0])
-        freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        freqs, response = xp.asarray(freqs), xp.asarray(response)
+        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
         assert_array_almost_equal(
-            xp.abs(response),
+            xp.abs(xp.asarray(response)),
             xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5
         )
 
@@ -404,10 +402,9 @@ class TestFirwin2:
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
         freq_samples = np.array([0.0, 0.4 - width, 0.4 + width, 0.45,
                                     0.5 - width, 0.5 + width, 0.75, 1.0])
-        freqs, response = freqz(taps, worN=np.pi*freq_samples)
-        freqs, response = xp.asarray(freqs), xp.asarray(response)
+        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
         assert_array_almost_equal(
-            xp.abs(response),
+            xp.abs(xp.asarray(response)),
             xp.asarray([1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5
         )
 
@@ -437,7 +434,8 @@ class TestFirwin2:
         dec = {'decimal': 4.5} if xp_default_dtype(xp) == xp.float32 else {}
         assert_array_almost_equal(taps[: ntaps // 2], flip(-taps[ntaps // 2:]), **dec)
 
-        freqs, response = freqz(taps, worN=2048)
+        freqs, response = freqz(xp_copy_to_numpy(taps), worN=2048)
+        freqs, response = map(xp.asarray, (freqs, response))
         assert_array_almost_equal(xp.abs(response), freqs / xp.pi, decimal=4)
 
     @skip_xp_backends("jax.numpy", reason="immutable arrays")
@@ -456,11 +454,11 @@ class TestFirwin2:
                                   flip(-taps[ntaps // 2 + 1:]), **dec
         )
 
-        freqs, response1 = freqz(taps, worN=2048)
+        freqs, response1 = freqz(xp_copy_to_numpy(taps), worN=2048)
         response2 = xp.asarray(
-            np.interp(np.asarray(freqs) / np.pi, np.asarray(freq), np.asarray(gain))
+            np.interp(freqs / np.pi, xp_copy_to_numpy(freq), xp_copy_to_numpy(gain))
         )
-        assert_array_almost_equal(xp.abs(response1), response2, decimal=3)
+        assert_array_almost_equal(xp.abs(xp.asarray(response1)), response2, decimal=3)
 
     def test_fs_nyq(self, xp):
         taps1 = firwin2(80, xp.asarray([0.0, 0.5, 1.0]), xp.asarray([1.0, 1.0, 0.0]))

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -252,7 +252,9 @@ class TestFirWinMore:
         # we know it should be approximately 0 or 1.
         freq_samples = np.asarray([0.0, 200, 300 - width/2, 300 + width/2, 500,
                                    700 - width/2, 700 + width/2, 800, 1000])
-        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples/nyquist)
+        freqs, response = freqz(
+            _xp_copy_to_numpy(taps), worN=np.pi*freq_samples/nyquist
+        )
 
         assert_array_almost_equal(xp.abs(xp.asarray(response)),
                 xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -548,7 +548,7 @@ class TestRemez:
         remez(21, bands, desired, weight=weight)
 
 
-@skip_xp_backends(cpu_only=True, reason="lstsq")
+@skip_xp_backends(cpu_only=True, reason="lstsq", exceptions=["cupy"])
 class TestFirls:
 
     def test_bad_args(self):
@@ -596,7 +596,7 @@ class TestFirls:
         assert_array_almost_equal(hodd, xp.zeros_like(hodd))
 
         # now check the frequency response
-        w, H = freqz(np.asarray(h), 1)
+        w, H = freqz(xp_copy_to_numpy(h), 1)
         w, H = xp.asarray(w), xp.asarray(H)
         f = w/2/xp.pi
         Hmag = xp.abs(H)
@@ -650,7 +650,8 @@ class TestFirls:
     def test_rank_deficient(self, xp):
         # solve() runs but warns (only sometimes, so here we don't use match)
         x = firls(21, xp.asarray([0, 0.1, 0.9, 1]), xp.asarray([1, 1, 0, 0]))
-        w, h = freqz(x, fs=2.)
+        w, h = freqz(xp_copy_to_numpy(x), fs=2.)
+        w, h = map(xp.asarray, (w, h))
         absh2 = xp.abs(h[:2])
         xp_assert_close(absh2, xp.ones_like(absh2), atol=1e-5)
         absh2 = xp.abs(h[-2:])
@@ -659,7 +660,8 @@ class TestFirls:
         # filters, but using shorter ones is faster computationally and
         # the idea is the same)
         x = firls(101, xp.asarray([0, 0.01, 0.99, 1]), xp.asarray([1, 1, 0, 0]))
-        w, h = freqz(x, fs=2.)
+        w, h = freqz(xp_copy_to_numpy(x), fs=2.)
+        w, h = map(xp.asarray, (w, h))
         mask = xp.asarray(w < 0.01)
         h = xp.asarray(h)
         assert xp.sum(xp.astype(mask, xp.int64)) > 3

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -7,7 +7,7 @@ import pytest
 import scipy._lib.array_api_extra as xpx
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, assert_almost_equal, assert_array_almost_equal,
-    array_namespace, xp_default_dtype, xp_copy_to_numpy
+    array_namespace, xp_default_dtype, _xp_copy_to_numpy
 )
 from scipy.fft import fft, fft2
 from scipy.signal import (kaiser_beta, kaiser_atten, kaiserord,
@@ -152,7 +152,7 @@ class TestFirWinMore:
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
         freq_samples = np.asarray([0.0, 0.25, 0.5-width/2, 0.5+width/2, 0.75, 1.0])
-        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
+        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(
             xp.abs(xp.asarray(response)),
@@ -179,7 +179,7 @@ class TestFirWinMore:
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
         freq_samples = np.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2, 0.75, 1.0])
-        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
+        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(xp.abs(xp.asarray(response)),
                                   xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5)
@@ -202,7 +202,7 @@ class TestFirWinMore:
         # we know it should be approximately 0 or 1.
         freq_samples = np.asarray([0.0, 0.2, 0.3 - width/2, 0.3 + width/2, 0.5,
                                    0.7 - width/2, 0.7 + width/2, 0.8, 1.0])
-        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
+        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(xp.abs(xp.asarray(response)),
                 xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5)
@@ -225,7 +225,7 @@ class TestFirWinMore:
         freq_samples = np.asarray([0.0, 0.1, 0.2 - width/2, 0.2 + width/2, 0.35,
                                    0.5 - width/2, 0.5 + width/2, 0.65,
                                    0.8 - width/2, 0.8 + width/2, 0.9, 1.0])
-        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
+        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(
             xp.abs(xp.asarray(response)),
@@ -252,7 +252,7 @@ class TestFirWinMore:
         # we know it should be approximately 0 or 1.
         freq_samples = np.asarray([0.0, 200, 300 - width/2, 300 + width/2, 500,
                                    700 - width/2, 700 + width/2, 800, 1000])
-        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples/nyquist)
+        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples/nyquist)
 
         assert_array_almost_equal(xp.abs(xp.asarray(response)),
                 xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0]), decimal=5)
@@ -368,7 +368,7 @@ class TestFirwin2:
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
         freq_samples = np.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2,
                                                         0.75, 1.0 - width/2])
-        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
+        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
         assert_array_almost_equal(
             xp.abs(xp.asarray(response)),
             xp.asarray([1.0, 1.0, 1.0, 1.0 - width, 0.5, width]), decimal=5
@@ -385,7 +385,7 @@ class TestFirwin2:
         gain = xp.asarray([0.0, 0.0, 1.0, 1.0])
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
         freq_samples = np.array([0.0, 0.25, 0.5 - width, 0.5 + width, 0.75, 1.0])
-        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
+        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
         assert_array_almost_equal(
             xp.abs(xp.asarray(response)),
             xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5
@@ -402,7 +402,7 @@ class TestFirwin2:
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
         freq_samples = np.array([0.0, 0.4 - width, 0.4 + width, 0.45,
                                     0.5 - width, 0.5 + width, 0.75, 1.0])
-        freqs, response = freqz(xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
+        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
         assert_array_almost_equal(
             xp.abs(xp.asarray(response)),
             xp.asarray([1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5
@@ -434,7 +434,7 @@ class TestFirwin2:
         dec = {'decimal': 4.5} if xp_default_dtype(xp) == xp.float32 else {}
         assert_array_almost_equal(taps[: ntaps // 2], flip(-taps[ntaps // 2:]), **dec)
 
-        freqs, response = freqz(xp_copy_to_numpy(taps), worN=2048)
+        freqs, response = freqz(_xp_copy_to_numpy(taps), worN=2048)
         freqs, response = map(xp.asarray, (freqs, response))
         assert_array_almost_equal(xp.abs(response), freqs / xp.pi, decimal=4)
 
@@ -454,9 +454,9 @@ class TestFirwin2:
                                   flip(-taps[ntaps // 2 + 1:]), **dec
         )
 
-        freqs, response1 = freqz(xp_copy_to_numpy(taps), worN=2048)
+        freqs, response1 = freqz(_xp_copy_to_numpy(taps), worN=2048)
         response2 = xp.asarray(
-            np.interp(freqs / np.pi, xp_copy_to_numpy(freq), xp_copy_to_numpy(gain))
+            np.interp(freqs / np.pi, _xp_copy_to_numpy(freq), _xp_copy_to_numpy(gain))
         )
         assert_array_almost_equal(xp.abs(xp.asarray(response1)), response2, decimal=3)
 
@@ -596,7 +596,7 @@ class TestFirls:
         assert_array_almost_equal(hodd, xp.zeros_like(hodd))
 
         # now check the frequency response
-        w, H = freqz(xp_copy_to_numpy(h), 1)
+        w, H = freqz(_xp_copy_to_numpy(h), 1)
         w, H = xp.asarray(w), xp.asarray(H)
         f = w/2/xp.pi
         Hmag = xp.abs(H)
@@ -650,7 +650,7 @@ class TestFirls:
     def test_rank_deficient(self, xp):
         # solve() runs but warns (only sometimes, so here we don't use match)
         x = firls(21, xp.asarray([0, 0.1, 0.9, 1]), xp.asarray([1, 1, 0, 0]))
-        w, h = freqz(xp_copy_to_numpy(x), fs=2.)
+        w, h = freqz(_xp_copy_to_numpy(x), fs=2.)
         w, h = map(xp.asarray, (w, h))
         absh2 = xp.abs(h[:2])
         xp_assert_close(absh2, xp.ones_like(absh2), atol=1e-5)
@@ -660,7 +660,7 @@ class TestFirls:
         # filters, but using shorter ones is faster computationally and
         # the idea is the same)
         x = firls(101, xp.asarray([0, 0.01, 0.99, 1]), xp.asarray([1, 1, 0, 0]))
-        w, h = freqz(xp_copy_to_numpy(x), fs=2.)
+        w, h = freqz(_xp_copy_to_numpy(x), fs=2.)
         w, h = map(xp.asarray, (w, h))
         mask = xp.asarray(w < 0.01)
         h = xp.asarray(h)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -151,7 +151,8 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.asarray([0.0, 0.25, 0.5-width/2, 0.5+width/2, 0.75, 1.0])
+        freq_samples = xp.asarray([0.0, 0.25, 0.5-width/2, 0.5+width/2, 0.75, 1.0])
+        freq_samples = _xp_copy_to_numpy(freq_samples)
         freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(
@@ -178,7 +179,8 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2, 0.75, 1.0])
+        freq_samples = xp.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2, 0.75, 1.0])
+        freq_samples = _xp_copy_to_numpy(freq_samples)
         freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(xp.abs(xp.asarray(response)),
@@ -200,8 +202,9 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.asarray([0.0, 0.2, 0.3 - width/2, 0.3 + width/2, 0.5,
+        freq_samples = xp.asarray([0.0, 0.2, 0.3 - width/2, 0.3 + width/2, 0.5,
                                    0.7 - width/2, 0.7 + width/2, 0.8, 1.0])
+        freq_samples = _xp_copy_to_numpy(freq_samples)
         freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(xp.abs(xp.asarray(response)),
@@ -222,9 +225,10 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.asarray([0.0, 0.1, 0.2 - width/2, 0.2 + width/2, 0.35,
+        freq_samples = xp.asarray([0.0, 0.1, 0.2 - width/2, 0.2 + width/2, 0.35,
                                    0.5 - width/2, 0.5 + width/2, 0.65,
                                    0.8 - width/2, 0.8 + width/2, 0.9, 1.0])
+        freq_samples = _xp_copy_to_numpy(freq_samples)
         freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
 
         assert_array_almost_equal(
@@ -250,8 +254,9 @@ class TestFirWinMore:
 
         # Check the gain at a few samples where
         # we know it should be approximately 0 or 1.
-        freq_samples = np.asarray([0.0, 200, 300 - width/2, 300 + width/2, 500,
+        freq_samples = xp.asarray([0.0, 200, 300 - width/2, 300 + width/2, 500,
                                    700 - width/2, 700 + width/2, 800, 1000])
+        freq_samples = _xp_copy_to_numpy(freq_samples)
         freqs, response = freqz(
             _xp_copy_to_numpy(taps), worN=np.pi*freq_samples/nyquist
         )
@@ -368,8 +373,9 @@ class TestFirwin2:
         freq = xp.asarray([0.0, 0.5, 1.0])
         gain = xp.asarray([1.0, 1.0, 0.0])
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
-        freq_samples = np.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2,
-                                                        0.75, 1.0 - width/2])
+        freq_samples = xp.asarray([0.0, 0.25, 0.5 - width/2, 0.5 + width/2,
+                                   0.75, 1.0 - width/2])
+        freq_samples = _xp_copy_to_numpy(freq_samples)
         freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
         assert_array_almost_equal(
             xp.abs(xp.asarray(response)),
@@ -386,7 +392,8 @@ class TestFirwin2:
         freq = xp.asarray([0.0, 0.5, 0.5, 1.0])
         gain = xp.asarray([0.0, 0.0, 1.0, 1.0])
         taps = firwin2(ntaps, freq, gain, window=('kaiser', beta))
-        freq_samples = np.array([0.0, 0.25, 0.5 - width, 0.5 + width, 0.75, 1.0])
+        freq_samples = xp.asarray([0.0, 0.25, 0.5 - width, 0.5 + width, 0.75, 1.0])
+        freq_samples = _xp_copy_to_numpy(freq_samples)
         freqs, response = freqz(_xp_copy_to_numpy(taps), worN=np.pi*freq_samples)
         assert_array_almost_equal(
             xp.abs(xp.asarray(response)),

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -30,7 +30,7 @@ from scipy._lib import _testutils
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, is_numpy, is_torch, is_jax, is_cupy,
     assert_array_almost_equal, assert_almost_equal,
-    xp_copy, xp_size, xp_default_dtype, array_namespace, xp_copy_to_numpy
+    xp_copy, xp_size, xp_default_dtype, xp_copy_to_numpy
 )
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -30,7 +30,7 @@ from scipy._lib import _testutils
 from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, is_numpy, is_torch, is_jax, is_cupy,
     assert_array_almost_equal, assert_almost_equal,
-    xp_copy, xp_size, xp_default_dtype, xp_copy_to_numpy
+    xp_copy, xp_size, xp_default_dtype, _xp_copy_to_numpy
 )
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
@@ -1941,7 +1941,7 @@ class _TestLinearFilter:
         b = self.convert_dtype([1, -1], xp)
         a = self.convert_dtype([0.5, 0.5], xp)
 
-        a_np, b_np, x_np = map(xp_copy_to_numpy, (a, b, x))
+        a_np, b_np, x_np = map(_xp_copy_to_numpy, (a, b, x))
         for axis in range(x.ndim):
             y = lfilter(b, a, x, axis)
             y_r = np.apply_along_axis(lambda w: lfilter(b_np, a_np, w), axis, x_np)
@@ -1959,13 +1959,13 @@ class _TestLinearFilter:
             zi = self.convert_dtype(xp.ones(zi_shape), xp)
             zi1 = self.convert_dtype([1], xp)
             y, zf = lfilter(b, a, x, axis, zi)
-            b_np, a_np, zi1_np = map(xp_copy_to_numpy, (b, a, zi1))
+            b_np, a_np, zi1_np = map(_xp_copy_to_numpy, (b, a, zi1))
             def lf0(w):
                 return np.asarray(lfilter(b_np, a_np, w, zi=zi1_np)[0])
             def lf1(w):
                 return np.asarray(lfilter(b_np, a_np, w, zi=zi1_np)[1])
-            y_r = np.apply_along_axis(lf0, axis, xp_copy_to_numpy(x))
-            zf_r = np.apply_along_axis(lf1, axis, xp_copy_to_numpy(x))
+            y_r = np.apply_along_axis(lf0, axis, _xp_copy_to_numpy(x))
+            zf_r = np.apply_along_axis(lf1, axis, _xp_copy_to_numpy(x))
             assert_array_almost_equal(y, xp.asarray(y_r))
             assert_array_almost_equal(zf, xp.asarray(zf_r))
 
@@ -1974,7 +1974,7 @@ class _TestLinearFilter:
         b = self.convert_dtype([1, 0, -1], xp)
         a = self.convert_dtype([1], xp)
 
-        a_np, b_np, x_np = map(xp_copy_to_numpy, (a, b, x))
+        a_np, b_np, x_np = map(_xp_copy_to_numpy, (a, b, x))
         for axis in range(x.ndim):
             y = lfilter(b, a, x, axis)
             y_r = np.apply_along_axis(lambda w: lfilter(b_np, a_np, w), axis, x_np)
@@ -1986,13 +1986,13 @@ class _TestLinearFilter:
         b = self.convert_dtype([1, 0, -1], xp)
         a = self.convert_dtype([1], xp)
 
-        x_np, b_np, a_np = map(xp_copy_to_numpy, (x, b, a))
+        x_np, b_np, a_np = map(_xp_copy_to_numpy, (x, b, a))
         for axis in range(x.ndim):
             zi_shape = list(x.shape)
             zi_shape[axis] = 2
             zi = self.convert_dtype(xp.ones(zi_shape), xp)
             zi1 = self.convert_dtype([1, 1], xp)
-            zi1_np = xp_copy_to_numpy(zi1)
+            zi1_np = _xp_copy_to_numpy(zi1)
             y, zf = lfilter(b, a, x, axis, zi)
             def lf0(w):
                 return np.asarray(lfilter(b_np, a_np, w, zi=zi1_np)[0])

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -460,10 +460,10 @@ class TestConvolve2d:
     )
     def test_consistency_convolve_funcs(self, xp):
         # Compare np.convolve, signal.convolve, signal.convolve2d
-        a_np = np.arange(5)
-        b_np = np.asarray([3.2, 1.4, 3])
-        a = xp.asarray(a_np)
-        b = xp.asarray(b_np)
+        a = xp.arange(5)
+        b = xp.asarray([3.2, 1.4, 3])
+        a_np = _xp_copy_to_numpy(a)
+        b_np = _xp_copy_to_numpy(b)
 
         for mode in ['full', 'valid', 'same']:
             xp_assert_close(
@@ -1562,7 +1562,7 @@ class TestResample:
                 y_resamp = signal.resample_poly(x, rate_to, rate,
                                                 padtype=padtype)
             assert y_to.shape == y_resamp.shape
-            corr = xp.asarray(np.corrcoef(y_to, np.asarray(y_resamp))[0, 1])
+            corr = xp.asarray(np.corrcoef(y_to, y_resamp)[0, 1])
             assert corr > 0.99, corr
 
         # More tests of fft method (Master 0.18.1 fails these)
@@ -1961,9 +1961,9 @@ class _TestLinearFilter:
             y, zf = lfilter(b, a, x, axis, zi)
             b_np, a_np, zi1_np = map(_xp_copy_to_numpy, (b, a, zi1))
             def lf0(w):
-                return np.asarray(lfilter(b_np, a_np, w, zi=zi1_np)[0])
+                return lfilter(b_np, a_np, w, zi=zi1_np)[0]
             def lf1(w):
-                return np.asarray(lfilter(b_np, a_np, w, zi=zi1_np)[1])
+                return lfilter(b_np, a_np, w, zi=zi1_np)[1]
             y_r = np.apply_along_axis(lf0, axis, _xp_copy_to_numpy(x))
             zf_r = np.apply_along_axis(lf1, axis, _xp_copy_to_numpy(x))
             assert_array_almost_equal(y, xp.asarray(y_r))
@@ -1995,9 +1995,9 @@ class _TestLinearFilter:
             zi1_np = _xp_copy_to_numpy(zi1)
             y, zf = lfilter(b, a, x, axis, zi)
             def lf0(w):
-                return np.asarray(lfilter(b_np, a_np, w, zi=zi1_np)[0])
+                return lfilter(b_np, a_np, w, zi=zi1_np)[0]
             def lf1(w):
-                return np.asarray(lfilter(b_np, a_np, w, zi=zi1_np)[1])
+                return lfilter(b_np, a_np, w, zi=zi1_np)[1]
             y_r = np.apply_along_axis(lf0, axis, x_np)
             zf_r = np.apply_along_axis(lf1, axis, x_np)
             assert_array_almost_equal(y, xp.asarray(y_r))

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -40,7 +40,7 @@ import pytest
 
 from scipy._lib import array_api_extra as xpx
 from scipy._lib._array_api import (
-    xp_assert_close, array_namespace, xp_copy_to_numpy, is_cupy
+    xp_assert_close, array_namespace, _xp_copy_to_numpy, is_cupy
 )
 from scipy._lib.array_api_compat import numpy as np_compat
 from scipy.signal import upfirdn, firwin
@@ -201,7 +201,7 @@ class TestUpfirdn:
 
         h = xp.asarray(firwin(31, 1. / down, window='hamming'))
         yl = xp.asarray(
-            upfirdn_naive(xp_copy_to_numpy(x), xp_copy_to_numpy(h), 1, down)
+            upfirdn_naive(_xp_copy_to_numpy(x), _xp_copy_to_numpy(h), 1, down)
         )
         y = upfirdn(h, x, up=1, down=down)
         assert y.shape == (want_len,)
@@ -272,7 +272,7 @@ class TestUpfirdn:
             concat = array_namespace(left).concat
             y_expected = concat((left, x, right))
         else:
-            y_expected = np.pad(xp_copy_to_numpy(x), (npre, npost), mode=mode)
+            y_expected = np.pad(_xp_copy_to_numpy(x), (npre, npost), mode=mode)
             y_expected = xp.asarray(y_expected)
 
         y_expected = xp.asarray(y_expected, dtype=xp.float64)
@@ -307,9 +307,9 @@ class TestUpfirdn:
         npad = h_len - 1
         if mode in ['antisymmetric', 'antireflect', 'smooth', 'line']:
             # use _pad_test test function for modes not supported by np.pad.
-            xpad = _pad_test(xp_copy_to_numpy(x), npre=npad, npost=npad, mode=mode)
+            xpad = _pad_test(_xp_copy_to_numpy(x), npre=npad, npost=npad, mode=mode)
         else:
-            xpad = np.pad(xp_copy_to_numpy(x), npad, mode=mode)
+            xpad = np.pad(_xp_copy_to_numpy(x), npad, mode=mode)
 
         xpad = xp.asarray(xpad)
         ypad = upfirdn(h, xpad, up=1, down=1, mode='constant')

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -40,8 +40,9 @@ import pytest
 
 from scipy._lib import array_api_extra as xpx
 from scipy._lib._array_api import (
-    xp_assert_close, array_namespace
+    xp_assert_close, array_namespace, xp_copy_to_numpy, is_cupy
 )
+from scipy._lib.array_api_compat import numpy as np_compat
 from scipy.signal import upfirdn, firwin
 from scipy.signal._upfirdn import _output_len, _upfirdn_modes
 from scipy.signal._upfirdn_apply import _pad_test
@@ -65,12 +66,15 @@ def upfirdn_naive(x, h, up=1, down=1):
 
 class UpFIRDnCase:
     """Test _UpFIRDn object"""
-    def __init__(self, up, down, h, x_dtype):
+    def __init__(self, up, down, h, x_dtype, *, xp=None):
+        if xp is None:
+            xp = np_compat
         self.up = up
         self.down = down
         self.h = np.atleast_1d(h)
         self.x_dtype = x_dtype
         self.rng = np.random.RandomState(17)
+        self.xp = xp
 
     def __call__(self):
         # tiny signal
@@ -85,6 +89,9 @@ class UpFIRDnCase:
         # ramp
         self.scrub(np.arange(10).astype(self.x_dtype))
         # 3D, random
+        if is_cupy(self.xp):
+            # ndim > 2 is unsupported in CuPy.
+            return
         size = (2, 3, 5)
         x = self.rng.randn(*size).astype(self.x_dtype)
         if self.x_dtype in (np.complex64, np.complex128):
@@ -96,31 +103,34 @@ class UpFIRDnCase:
             self.scrub(x, axis=axis)
 
     def scrub(self, x, axis=-1):
+        xp = self.xp
         yr = np.apply_along_axis(upfirdn_naive, axis, x,
                                  self.h, self.up, self.down)
         want_len = _output_len(len(self.h), x.shape[axis], self.up, self.down)
         assert yr.shape[axis] == want_len
-        y = upfirdn(self.h, x, self.up, self.down, axis=axis)
+        y = upfirdn(xp.asarray(self.h), xp.asarray(x), self.up, self.down,
+                    axis=axis)
         assert y.shape[axis] == want_len
         assert y.shape == yr.shape
         dtypes = (self.h.dtype, x.dtype)
         if all(d == np.complex64 for d in dtypes):
-            assert y.dtype == np.complex64
+            assert y.dtype == xp.complex64
         elif np.complex64 in dtypes and np.float32 in dtypes:
-            assert y.dtype == np.complex64
+            assert y.dtype == xp.complex64
         elif all(d == np.float32 for d in dtypes):
-            assert y.dtype == np.float32
+            assert y.dtype == xp.float32
         elif np.complex128 in dtypes or np.complex64 in dtypes:
-            assert y.dtype == np.complex128
+            assert y.dtype == xp.complex128
         else:
-            assert y.dtype == np.float64
-        xp_assert_close(yr.astype(y.dtype), y)
+            assert y.dtype == xp.float64
+        yr = xp.asarray(yr, dtype=y.dtype)
+        xp_assert_close(yr, y)
 
 
 _UPFIRDN_TYPES = ("int64", "float32", "complex64", "float64", "complex128")
 
 
-@skip_xp_backends(cpu_only=True, reason='Cython implementation')
+@skip_xp_backends(cpu_only=True, reason='Cython implementation', exceptions=["cupy"])
 class TestUpfirdn:
 
     @skip_xp_backends(np_only=True, reason="enough to only test on numpy")
@@ -190,30 +200,30 @@ class TestUpfirdn:
         x = xp.asarray(x, dtype=dtype)
 
         h = xp.asarray(firwin(31, 1. / down, window='hamming'))
-        yl = xp.asarray(upfirdn_naive(x, h, 1, down))
+        yl = xp.asarray(
+            upfirdn_naive(xp_copy_to_numpy(x), xp_copy_to_numpy(h), 1, down)
+        )
         y = upfirdn(h, x, up=1, down=down)
         assert y.shape == (want_len,)
         assert yl.shape[0] == y.shape[0]
         xp_assert_close(yl, y, atol=1e-7, rtol=1e-7)
 
-    @skip_xp_backends(np_only=True, reason="apply_along_axis")
     @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('h', (1., 1j))
     @pytest.mark.parametrize('up, down', [(1, 1), (2, 2), (3, 2), (2, 3)])
     def test_vs_naive_delta(self, x_dtype, h, up, down, xp):
-        UpFIRDnCase(up, down, h, x_dtype)()
+        UpFIRDnCase(up, down, h, x_dtype, xp=xp)()
 
-    @skip_xp_backends(np_only=True, reason="apply_along_axis")
     @pytest.mark.parametrize('x_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('h_dtype', _UPFIRDN_TYPES)
     @pytest.mark.parametrize('p_max, q_max',
                              list(product((10, 100), (10, 100))))
     def test_vs_naive(self, x_dtype, h_dtype, p_max, q_max, xp):
-        tests = self._random_factors(p_max, q_max, h_dtype, x_dtype)
+        tests = self._random_factors(p_max, q_max, h_dtype, x_dtype, xp=xp)
         for test in tests:
             test()
 
-    def _random_factors(self, p_max, q_max, h_dtype, x_dtype):
+    def _random_factors(self, p_max, q_max, h_dtype, x_dtype, *, xp):
         n_rep = 3
         longest_h = 25
         random_state = np.random.RandomState(17)
@@ -233,7 +243,7 @@ class TestUpfirdn:
             if h_dtype is complex:
                 h += 1j * random_state.randint(len_h)
 
-            tests.append(UpFIRDnCase(p, q, h, x_dtype))
+            tests.append(UpFIRDnCase(p, q, h, x_dtype, xp=xp))
 
         return tests
 
@@ -262,7 +272,7 @@ class TestUpfirdn:
             concat = array_namespace(left).concat
             y_expected = concat((left, x, right))
         else:
-            y_expected = np.pad(np.asarray(x), (npre, npost), mode=mode)
+            y_expected = np.pad(xp_copy_to_numpy(x), (npre, npost), mode=mode)
             y_expected = xp.asarray(y_expected)
 
         y_expected = xp.asarray(y_expected, dtype=xp.float64)
@@ -278,6 +288,8 @@ class TestUpfirdn:
         )
     )
     def test_modes(self, size, h_len, mode, dtype, xp):
+        if is_cupy(xp) and mode != "constant":
+            pytest.skip(reason="only mode='constant' supported by CuPy")
         dtype_np = getattr(np, dtype)
         dtype_xp = getattr(xp, dtype)
 
@@ -295,9 +307,9 @@ class TestUpfirdn:
         npad = h_len - 1
         if mode in ['antisymmetric', 'antireflect', 'smooth', 'line']:
             # use _pad_test test function for modes not supported by np.pad.
-            xpad = _pad_test(np.asarray(x), npre=npad, npost=npad, mode=mode)
+            xpad = _pad_test(xp_copy_to_numpy(x), npre=npad, npost=npad, mode=mode)
         else:
-            xpad = np.pad(np.asarray(x), npad, mode=mode)
+            xpad = np.pad(xp_copy_to_numpy(x), npad, mode=mode)
 
         xpad = xp.asarray(xpad)
         ypad = upfirdn(h, xpad, up=1, down=1, mode='constant')


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #23750

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR updates tests in `signal` which use the `xp` fixture to always isolate use of the alternative backend to only the function being tested. Many of the tests already did this, but some computed reference values or other values use to validate results with the `xp` backend, with some tests even skipped on some backends due to functions other than the function being tested not being supported. I originally did this work while adding `xp_capabilities` decorators for `signal` functions and using them in the `signal` tests, and realized that this would best be split into a separate PR.

To help implement such isolation, I added a function `xp_copy_to_numpy` which copies `xp` arrays to `np` arrays, to make it more straightforward to allow non-tested functions within a test to use the NumPy backend. There were some `signal` tests which used [`numpy.testing.assert_array_almost_equal_nulp`](https://numpy.org/doc/2.3/reference/generated/numpy.testing.assert_array_almost_equal_nulp.html), and were skipped on alternative backends for this reason. I created `scipy._lib._array_api.xp_assert_close_nulp` which does the strict checks, and then converts to numpy and uses `numpy.testing.assert_array_almost_equal_nulp` internally. These tests probably could have been rewritten to just use `xp_assert_close`, but for now it seems reasonable to preserve the existing behavior as much as possible. 
#### Additional information
<!--Any additional information you think is important.-->
