### PR TITLE
MAINT: clean up some outdated CPython C API idioms

### DIFF
--- a/scipy/_lib/src/ccallback.h
+++ b/scipy/_lib/src/ccallback.h
@@ -209,14 +209,14 @@ static int ccallback_prepare(ccallback_t *callback, ccallback_signature_t *signa
     }
     else if (capsule != NULL ||
              (PyObject_TypeCheck(callback_obj, lowlevelcallable_type) &&
-              PyCapsule_CheckExact(PyTuple_GET_ITEM(callback_obj, 0)))) {
+              PyCapsule_CheckExact(PyTuple_GetItem(callback_obj, 0)))) {
         /* PyCapsule in LowLevelCallable (or parse result from above) */
         void *ptr, *user_data;
         ccallback_signature_t *sig;
         const char *name;
 
         if (capsule == NULL) {
-            capsule = PyTuple_GET_ITEM(callback_obj, 0);
+            capsule = PyTuple_GetItem(callback_obj, 0);
         }
 
         name = PyCapsule_GetName(capsule);

--- a/scipy/io/matlab/_pyalloc.pxd
+++ b/scipy/io/matlab/_pyalloc.pxd
@@ -1,13 +1,13 @@
 # -*- python -*- or rather like
 
 from cpython cimport PyBytes_FromStringAndSize, \
-    PyBytes_AS_STRING, PyBytes_Size
+    PyBytes_AsString, PyBytes_Size
 
 
 # Function to allocate, wrap memory via Python string creation
 cdef inline object pyalloc_v(Py_ssize_t n, void **pp):
     cdef object ob = PyBytes_FromStringAndSize(NULL, n)
-    pp[0] = <void*> PyBytes_AS_STRING(ob)
+    pp[0] = <void*> PyBytes_AsString(ob)
     return ob
 
 

--- a/scipy/io/matlab/_streams.pyx
+++ b/scipy/io/matlab/_streams.pyx
@@ -2,7 +2,7 @@
 
 import zlib
 
-from cpython cimport PyBytes_AS_STRING, PyBytes_Size
+from cpython cimport PyBytes_AsString, PyBytes_Size
 
 from ._pyalloc cimport pyalloc_v
 
@@ -68,7 +68,7 @@ cdef class GenericStream:
             data = self.fobj.read(n)
             if PyBytes_Size(data) != n:
                 raise OSError('could not read bytes')
-            pp[0] = <void*>PyBytes_AS_STRING(data)
+            pp[0] = <void*>PyBytes_AsString(data)
             return data
 
         cdef object d_copy = pyalloc_v(n, pp)

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -824,13 +824,13 @@ PyObject *newSuperLUObject(SuperMatrix * A, PyObject * option_dict,
     char *s = "";                               \
     PyObject *tmpobj = NULL;                    \
     if (input == Py_None) return 1;             \
-    if (PyBytes_Check(input)) {                \
-        s = PyBytes_AS_STRING(input);          \
+    if (PyBytes_Check(input)) {                 \
+        s = PyBytes_AsString(input);            \
     }                                           \
     else if (PyUnicode_Check(input)) {          \
         tmpobj = PyUnicode_AsASCIIString(input);\
         if (tmpobj == NULL) return 0;           \
-        s = PyBytes_AS_STRING(tmpobj);         \
+        s = PyBytes_AsString(tmpobj);           \
     }                                           \
     else if (PyLong_Check(input)) {              \
         i = PyLong_AsLong(input);                \

--- a/scipy/stats/_unuran/unuran_callback.h
+++ b/scipy/stats/_unuran/unuran_callback.h
@@ -24,15 +24,11 @@
         goto done;                                                                          \
     }                                                                                       \
                                                                                             \
-    arg1 = PyTuple_New(2);                                                                  \
+    arg1 = PyTuple_Pack(2, argobj, funcname);                                               \
     if (arg1 == NULL) {                                                                     \
         error = 1;                                                                          \
         goto done;                                                                          \
     }                                                                                       \
-                                                                                            \
-    PyTuple_SET_ITEM(arg1, 0, argobj);                                                      \
-    PyTuple_SET_ITEM(arg1, 1, funcname);                                                    \
-    argobj = NULL; funcname = NULL;                                                         \
                                                                                             \
     res = PyObject_CallObject(callback->py_function, arg1);                                 \
     if (res == NULL) {                                                                      \


### PR DESCRIPTION
Motivated by the discussion in scipy#19878. With these changes, all Cython code can be built against the Limited API. That just requires adding `-DPy_LIMITED_API=0x030C0000` as a flag to `cython_c_args` in scipy/meson.build

Note that using the Limited API isn't all that useful yet, since it's blocked by lack of support in dependencies other than Cython. But it's a start, and makes it easier to do benchmarking of the functionality implemented in Cython.
