### PR TITLE
BUG: odr: prevent segfault with explicit model and job=1 (#23763)

### DIFF
--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -799,6 +799,10 @@ class ODR:
             y_s = list(self.data.y.shape)
             if self.model.implicit:
                 raise OdrError("an implicit model cannot use response data")
+            if self.job is not None and (self.job % 10) == 1:
+                raise OdrError("the self.job parameter was set to 1 mod 10;"
+                               " this configures an implicit model, and"
+                               " an implicit model cannot use response data")
         else:
             # implicit model with q == self.data.y
             y_s = [self.data.y, x_s[-1]]

--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -800,9 +800,8 @@ class ODR:
             if self.model.implicit:
                 raise OdrError("an implicit model cannot use response data")
             if self.job is not None and (self.job % 10) == 1:
-                raise OdrError("the self.job parameter was set to 1 mod 10;"
-                               " this configures an implicit model, and"
-                               " an implicit model cannot use response data")
+                raise OdrError("job parameter requests an implicit model,"
+                               " but an explicit model was passed")
         else:
             # implicit model with q == self.data.y
             y_s = [self.data.y, x_s[-1]]

--- a/scipy/odr/tests/test_odr.py
+++ b/scipy/odr/tests/test_odr.py
@@ -12,8 +12,8 @@ import pytest
 from pytest import raises as assert_raises
 
 from scipy.odr import (Data, Model, ODR, RealData, OdrStop, OdrWarning,
-                       multilinear, exponential, unilinear, quadratic,
-                       polynomial)
+                       OdrError, multilinear, exponential, unilinear,
+                       quadratic, polynomial)
 
 
 class TestODR:
@@ -604,3 +604,18 @@ class TestODR:
         obj_pickle = pickle.dumps(output)
         del output
         pickle.loads(obj_pickle)
+
+    def test_explicit_model_with_implicit_job(self):
+        """
+        Verify fix for gh-23763 that ODR doesn't segfault
+        """
+        x = np.linspace(0, 10, 10)
+        y = 2.0 + 3.0 * x
+
+        data = Data(x, y)
+        model = unilinear  # this is an explicit model
+
+        # job=1 is implicit, should raise on explicit model
+        with assert_raises(OdrError):
+            odr = ODR(data, model, job=1)
+            odr.run()


### PR DESCRIPTION
#### Reference issue
Closes #23763

#### What does this implement/fix?
ODR now raises an OdrError if job is 1 mod 10 which configures implicit mode, even if model.implicit isn't set to be true. Also adds a corresponding test case.

#### Additional information
