### PR TITLE
DOC/DX: Document use of `--` in spin ipython and spin python

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -319,7 +319,7 @@ def ipython(*, parent_callback, pythonpath, **kwargs):
 
     OPTIONS are passed through directly to IPython, e.g.:
 
-    spin ipython -i myscript.py
+    spin ipython -- -i myscript.py
     """
     _set_pythonpath(pythonpath)
     parent_callback(**kwargs)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
First contribution to opensource.

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes issue #23760

#### What does this implement/fix?
<!--Please explain your changes.-->
It is a documentation change that ensures that the 
spin ipython --help
spin python --help
displays the correct information regarding the passing OPTIONS in ipython/python directly 
spin ipython -- -i myscript.py

#### Additional information
<!--Any additional information you think is important.-->
None
