### PR TITLE
CI: pin Python 3.11.13 in CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ _defaults: &defaults
   docker:
     # CircleCI maintains a library of pre-built images
     # documented at https://circleci.com/docs/2.0/circleci-images/
-    - image: cimg/python:3.11
+    - image: cimg/python:3.11.13
   working_directory: ~/repo
 
 commands:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #23642

#### What does this implement/fix?

On 2025-10-15, at 01:24 UTC, CircleCI updated their Python 3.11 image to 3.11.14. Shortly after, our docs job started failing.

The `cimg/python:3.11` image contains a copy of click 8.3.0 located at `/home/circleci/.local/lib/python3.11/site-packages`.

```
(scipy-dev) nodell@scipy-dev:~/scipy$ docker run -it cimg/python:3.11
circleci@43d62fd81758:~/project$ pip show click
Name: click
Version: 8.3.0
Summary: Composable command line interface toolkit
Home-page: 
Author: 
Author-email: 
License-Expression: BSD-3-Clause
Location: /home/circleci/.local/lib/python3.11/site-packages
Requires: 
Required-by: userpath
```

This copy of click is installed by CircleCI when they create the image, as part of installing `pipx`.

For some reason (probably `PYTHONPATH` manipulation) this copy is not uninstalled when we install spin. Spin is not compatible with this version of click, so it breaks the refguide_check and build_docs steps.

Revert this change to make docs builds work again.

#### Additional information
<!--Any additional information you think is important.-->

By downgrading to 3.11.13, we would be missing [these security fixes](https://www.python.org/downloads/release/python-31114/).