### PR TITLE
ENH: interpolate.RegularGridInterpolator: remove zeroes from design matrix

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -357,6 +357,46 @@ class RGI_Cubic(Benchmark):
         self.interp(self.xi)
 
 
+class RGI_Quintic(Benchmark):
+    """
+    Benchmark RegularGridInterpolator with method="quintic".
+    """
+    param_names = ['ndim', 'n_samples', 'method']
+    params = [
+        [2],
+        [10, 40],
+    ]
+
+    def setup(self, ndim, n_samples):
+        rng = np.random.default_rng(314159)
+
+        self.points = [np.sort(rng.random(size=n_samples))
+                       for _ in range(ndim)]
+        self.values = rng.random(size=[n_samples]*ndim)
+
+        # choose in-bounds sample points xi
+        bounds = [(p.min(), p.max()) for p in self.points]
+        xi = [rng.uniform(low, high, size=n_samples)
+              for low, high in bounds]
+        self.xi = np.array(xi).T
+
+        self.interp = interpolate.RegularGridInterpolator(
+            self.points,
+            self.values,
+            method='quintic'
+        )
+
+    def time_rgi_setup_interpolator(self, ndim, n_samples):
+        self.interp = interpolate.RegularGridInterpolator(
+            self.points,
+            self.values,
+            method='quintic'
+        )
+
+    def time_rgi(self, ndim, n_samples):
+        self.interp(self.xi)
+
+
 class RegularGridInterpolatorValues(interpolate.RegularGridInterpolator):
     def __init__(self, points, xi, **kwargs):
         # create fake values for initialization

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -473,6 +473,11 @@ def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):
     # construct the colocation matrix
     matr = NdBSpline.design_matrix(xvals, t, k)
 
+    # Remove zeros from the sparse matrix
+    # If k=1, then solve() doesn't take long enough for this to help
+    if k[0] >= 3:
+        matr.eliminate_zeros()
+
     # Solve for the coefficients given `values`.
     # Trailing dimensions: first ndim dimensions are data, the rest are batch
     # dimensions, so stack `values` into a 2D array for `spsolve` to undestand.


### PR DESCRIPTION


#### Reference issue
Closes #23762

#### What does this implement/fix?

Removes zeroes from the design matrix of RegularGridInterpolator where those zeros slow down the fit.

Benchmark result for cubic:

```
$ (cd benchmarks/; asv continuous  --interleave-rounds -a rounds=10 --factor 1.05 --bench interpolate.RGI_Cubic 7d63c6e085610d830d0ea371dc564c8649369a8e 0e5115073a46d2ca3e8ae544d90c1730c02d0005;)

[90.00%] · For scipy commit 0e511507 <njo-rgi-elim-zeros-2> (round 10/10):
[90.00%] ·· Benchmarking virtualenv-py3.13-Cython-meson-python-numpy-pybind11-pytest-pythran
[92.50%] ··· interpolate.RGI_Cubic.time_rgi                                                                                                                                                                        ok
[92.50%] ··· ====== =========== ========== ==============
             --                           method
             ------------------ -------------------------
              ndim   n_samples    cubic     cubic_legacy 
             ====== =========== ========== ==============
               2         10      68.2±1μs   1.97±0.04ms  
               2         40      80.6±1μs   7.66±0.09ms  
               2        100      108±2μs     20.4±0.4ms  
               2        200      166±3μs     46.8±0.8ms  
               2        400      327±4μs      121±2ms    
             ====== =========== ========== ==============

[95.00%] ··· interpolate.RGI_Cubic.time_rgi_setup_interpolator                                                                                                                                                     ok
[95.00%] ··· ====== =========== ============= ==============
             --                            method           
             ------------------ ----------------------------
              ndim   n_samples      cubic      cubic_legacy 
             ====== =========== ============= ==============
               2         10      3.45±0.04ms    23.5±0.7μs  
               2         40       26.4±0.3ms    23.2±0.6μs  
               2        100        468±9ms      23.2±0.6μs  
               2        200       4.03±0.03s    23.3±0.7μs  
               2        400       5.24±0.08s    24.5±0.4μs  
             ====== =========== ============= ==============

[95.00%] · For scipy commit 7d63c6e0 <main> (round 10/10):
[95.00%] ·· Building for virtualenv-py3.13-Cython-meson-python-numpy-pybind11-pytest-pythran...
[95.00%] ·· Benchmarking virtualenv-py3.13-Cython-meson-python-numpy-pybind11-pytest-pythran
[97.50%] ··· interpolate.RGI_Cubic.time_rgi                                                                                                                                                                        ok
[97.50%] ··· ====== =========== ========== ==============
             --                           method
             ------------------ -------------------------
              ndim   n_samples    cubic     cubic_legacy
             ====== =========== ========== ==============
               2         10      67.1±1μs   1.97±0.03ms
               2         40      78.8±1μs    7.63±0.1ms
               2        100      106±1μs     20.7±0.5ms
               2        200      165±2μs     47.1±0.8ms
               2        400      328±2μs      121±1ms
             ====== =========== ========== ==============

[100.00%] ··· interpolate.RGI_Cubic.time_rgi_setup_interpolator                                                                                                                                                     ok
[100.00%] ··· ====== =========== ============= ==============
              --                            method
              ------------------ ----------------------------
               ndim   n_samples      cubic      cubic_legacy
              ====== =========== ============= ==============
                2         10      3.48±0.04ms    22.8±0.4μs
                2         40       28.9±0.3ms    23.0±0.3μs
                2        100        558±10ms     23.1±0.4μs
                2        200       5.23±0.01s    23.7±0.4μs
                2        400       6.39±0.1s     24.1±0.3μs
              ====== =========== ============= ==============

| Change   | Before [7d63c6e0] <main>   | After [0e511507] <njo-rgi-elim-zeros-2>   |   Ratio | Benchmark (Parameter)                                              |
|----------|----------------------------|-------------------------------------------|---------|--------------------------------------------------------------------|
| -        | 28.9±0.3ms                 | 26.4±0.3ms                                |    0.91 | interpolate.RGI_Cubic.time_rgi_setup_interpolator(2, 40, 'cubic')  |
| -        | 558±10ms                   | 468±9ms                                   |    0.84 | interpolate.RGI_Cubic.time_rgi_setup_interpolator(2, 100, 'cubic') |
| -        | 6.39±0.1s                  | 5.24±0.08s                                |    0.82 | interpolate.RGI_Cubic.time_rgi_setup_interpolator(2, 400, 'cubic') |
| -        | 5.23±0.01s                 | 4.03±0.03s                                |    0.77 | interpolate.RGI_Cubic.time_rgi_setup_interpolator(2, 200, 'cubic') |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

#### Additional information
<!--Any additional information you think is important.-->
