### PR TITLE
BUG:optimize:SLSQP: Use double negative in an if condition for NaN handling

### DIFF
--- a/scipy/optimize/__slsqp.c
+++ b/scipy/optimize/__slsqp.c
@@ -240,7 +240,7 @@ MODE1:
     }
     S->h1 = S->t - S->t0;
 
-    if ((S->h1 > (S->h3 / 10.0)) && (S->line <= 10))
+    if (!((S->h1 <= (S->h3 / 10.0)) || (S->line > 10)))
     {
         S->alpha = fmax(S->h3/(2.0*(S->h3 - S->h1)), alfmin);
         goto LINE_SEARCH;


### PR DESCRIPTION
#### Reference issue
https://github.com/scikit-hep/pyhf/issues/2593
https://discuss.scientific-python.org/t/minimization-result-success-change-after-slsqp-fortran-to-c-rewrite/2136


#### What does this implement/fix?
As reported in the pyhf issue, the contrapositive condition does not handle NaN the way old Fortran code handles. Hence reverted to the original condition and used the negated value. Since the report was not bare SciPy call, I did not find a good example to add a test for this branch.


@tylerjereddy if we do not have any plans for 1.16.3, no problem, please remove the backport candidate label.  
