### PR TITLE
TST: some more test tol bumps

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -119,7 +119,7 @@ jobs:
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
-      && (github.repository == 'andyfaff/scipy' || github.repository == '')
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -119,7 +119,7 @@ jobs:
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
-      && (github.repository == 'scipy/scipy' || github.repository == '')
+      && (github.repository == 'andyfaff/scipy' || github.repository == '')
     runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -292,6 +292,11 @@ class TestDerivative:
             if key == 'status':
                 assert res[key] == eim._ECONVERR
                 assert res2[key] == eim._ECALLBACK
+            elif key == 'error':
+                # switched from equality check to accommodate
+                # macosx-x86_64/Accelerate
+                xp_assert_close(res2[key], res[key], rtol=1e-14)
+                xp_assert_close(callback.res[key], res[key], rtol=1e-14)
             else:
                 assert res2[key] == callback.res[key] == res[key]
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -471,7 +471,8 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
             res = hypotest(*data1d, *args, nan_policy=nan_policy, **kwds)
         res_1db = unpacker(res)
 
-        assert_allclose(res_1db, res_1da, rtol=1e-15)
+        # changed from 1e-15 solely to appease macosx-x86_64+Accelerate
+        assert_allclose(res_1db, res_1da, rtol=4e-15)
         res_1d[i] = res_1db
 
     res_1d = np.moveaxis(res_1d, -1, 0)


### PR DESCRIPTION
@mdhaber looks like there's another temperamental test fail on macosx-x86_64/Accelerate. Doesn't happen all the time.

There's also another test flake:

```
_________________ TestDerivative.test_maxiter_callback[numpy] __________________

self = <scipy.differentiate.tests.test_differentiate.TestDerivative object at 0x10d033890>
xp = <module 'scipy._lib.array_api_compat.numpy' from '/Users/runner/work/scipy/scipy/build-install/usr/lib/python3.13/site-packages/scipy/_lib/array_api_compat/numpy/__init__.py'>

    def test_maxiter_callback(self, xp):
        # Test behavior of `maxiter` parameter and `callback` interface
        x = xp.asarray(0.612814, dtype=xp.float64)
        maxiter = 3
    
        def f(x):
            res = special.ndtr(x)
            return res
    
        default_order = 8
        res = derivative(f, x, maxiter=maxiter, tolerances=dict(rtol=1e-15))
        assert not xp.any(res.success)
        assert xp.all(res.nfev == default_order + 1 + (maxiter - 1)*2)
        assert xp.all(res.nit == maxiter)
    
        def callback(res):
            callback.iter += 1
            callback.res = res
            assert hasattr(res, 'x')
            assert float(res.df) not in callback.dfs
            callback.dfs.add(float(res.df))
            assert res.status == eim._EINPROGRESS
            if callback.iter == maxiter:
                raise StopIteration
        callback.iter = -1  # callback called once before first iteration
        callback.res = None
        callback.dfs = set()
    
        res2 = derivative(f, x, callback=callback, tolerances=dict(rtol=1e-15))
        # terminating with callback is identical to terminating due to maxiter
        # (except for `status`)
        for key in res.keys():
            if key == 'status':
                assert res[key] == eim._ECONVERR
                assert res2[key] == eim._ECALLBACK
            else:
>               assert res2[key] == callback.res[key] == res[key]
E               assert np.float64(8.526512829121202e-14) == np.float64(8.171241461241152e-14)

callback   = <function TestDerivative.test_maxiter_callback.<locals>.callback at 0x120e54b80>
default_order = 8
f          = <function TestDerivative.test_maxiter_callback.<locals>.f at 0x120e54a40>
key        = 'error'
maxiter    = 3
res        =      success: False
      status: -2
          df: 0.3306453155026219
       error: 8.171241461241152e-14
         nit: 3
        nfev: 13
           x: 0.612814
res2       =      success: False
      status: -4
          df: 0.3306453155026219
       error: 8.526512829121202e-14
         nit: 3
        nfev: 13
           x: 0.612814
self       = <scipy.differentiate.tests.test_differentiate.TestDerivative object at 0x10d033890>
x          = array(0.612814)
xp         = <module 'scipy._lib.array_api_compat.numpy' from '/Users/runner/work/scipy/scipy/build-install/usr/lib/python3.13/site-packages/scipy/_lib/array_api_compat/numpy/__init__.py'>

scipy/differentiate/tests/test_differentiate.py:296: AssertionError
```

What would you like to do with the differentiate fail?
