### PR TITLE
ENH: sparse.linalg: add fast path for matvec of a CSR array

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -824,6 +824,9 @@ class MatrixLinearOperator(LinearOperator):
         self.__adj = None
         self.args = (A,)
 
+        if hasattr(A, '_matmul_vector'):
+            self._matvec = A._matmul_vector
+
     def _matmat(self, X):
         return self.A.dot(X)
 
@@ -838,6 +841,9 @@ class _AdjointMatrixOperator(MatrixLinearOperator):
         self.A = adjoint_array.T.conj()
         self.args = (adjoint_array,)
         self.shape = adjoint_array.shape[1], adjoint_array.shape[0]
+
+        if hasattr(self.A, '_matmul_vector'):
+            self._matvec = self.A._matmul_vector
 
     @property
     def dtype(self):

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -838,16 +838,10 @@ class MatrixLinearOperator(LinearOperator):
 
 class _AdjointMatrixOperator(MatrixLinearOperator):
     def __init__(self, adjoint_array):
-        self.A = adjoint_array.T.conj()
+        A = adjoint_array.T.conj()
+        super().__init__(A)
         self.args = (adjoint_array,)
         self.shape = adjoint_array.shape[1], adjoint_array.shape[0]
-
-        if hasattr(self.A, '_matmul_vector'):
-            self._matvec = self.A._matmul_vector
-
-    @property
-    def dtype(self):
-        return self.args[0].dtype
 
     def _adjoint(self):
         return MatrixLinearOperator(self.args[0])


### PR DESCRIPTION
#### Reference issue

N/A

#### What does this implement/fix?

While investigating the performance of RegularGridInterpolator, I noticed that when gcrotmk is calling matvec, only about 50% of the time in `matvec()` is spent actually computing the matrix-vector product. The rest is spent in various wrapper functions.

Therefore, I tried writing a `MatrixLinearOperator._matvec()` which calls `_matmul_vector` directly. By doing this, it avoids calling the `matmat`, `_matmat`, `dot`, `__matmul__` and `_matmul_dispatch` functions. This improves the speed of constructing a RegularGridInterpolator.

This improves the performance for CSR arrays, and likely also for COO, as that also defines a `_matmul_vector()`.

#### Additional information

Preliminary benchmark:

```
[50.00%] · For scipy commit fde4b9c4 <njo-rgi-improve1> (round 2/2):
[50.00%] ·· Benchmarking virtualenv-py3.13-Cython-meson-python-numpy-pybind11-pytest-pythran
[62.50%] ··· sparse_linalg_solve.Bench.time_solve                                                                                                                                  ok
[62.50%] ··· ======= ============= ============= ============= ============= ============= ============= ============= =============
             --                                                           solver                                                    
             ------- ---------------------------------------------------------------------------------------------------------------
              (n,n)      dense        spsolve          cg          minres        gmres         lgmres       gcrotmk        tfqmr    
             ======= ============= ============= ============= ============= ============= ============= ============= =============
                4      73.0±0.6μs     62.1±2μs      120±1μs      210±0.5μs      361±2μs       517±7μs       522±6μs       222±2μs   
                6       107±2μs      91.8±0.8μs     192±7μs       376±2μs       768±30μs      779±30μs      725±4μs       426±4μs   
                10      273±10μs      267±1μs       392±2μs       705±7μs      2.54±0.2ms   1.41±0.09ms   1.35±0.01ms     864±5μs   
                16    1.52±0.01ms     724±2μs       616±4μs     1.06±0.01ms   4.92±0.06ms   2.29±0.03ms    2.28±0.1ms   1.65±0.02ms 
                25        n/a       2.21±0.01ms   1.12±0.01ms   1.70±0.01ms    14.4±0.3ms   4.43±0.04ms    4.20±0.2ms   3.21±0.03ms 
                40        n/a       5.94±0.05ms   2.51±0.07ms   2.85±0.07ms     58.7±2ms    13.5±0.07ms   10.2±0.04ms   6.61±0.03ms 
                64        n/a        17.3±0.3ms   6.19±0.09ms    5.83±0.2ms     173±3ms      31.0±0.2ms     28.1±1ms     17.1±0.1ms 
               100        n/a        47.3±0.6ms   18.8±0.03ms   12.4±0.08ms     561±20ms      72.2±1ms      66.0±2ms     53.1±0.1ms 
             ======= ============= ============= ============= ============= ============= ============= ============= =============

[75.00%] ··· sparse_linalg_solve.Lgmres.time_inner                                                                                                                                 ok
[75.00%] ··· ======= ============= ============= ============= ============= =============
             --                                        m                                  
             ------- ---------------------------------------------------------------------
                n          10            30            60            90           180     
             ======= ============= ============= ============= ============= =============
                10      426±3μs       424±8μs       424±1μs       431±10μs      426±6μs   
                50      573±10μs      569±6μs       569±10μs      570±8μs       586±20μs  
               100    1.08±0.01ms   1.17±0.01ms   1.16±0.01ms   1.19±0.01ms   1.19±0.01ms 
               1000   1.35±0.02ms    4.07±0.2ms    9.53±0.1ms   16.7±0.09ms    55.6±0.4ms 
              10000    22.2±0.1ms    64.5±0.3ms    137±0.9ms      219±2ms       542±4ms   
             ======= ============= ============= ============= ============= =============

[75.00%] · For scipy commit 9d3be495 <main> (round 2/2):
[75.00%] ·· Building for virtualenv-py3.13-Cython-meson-python-numpy-pybind11-pytest-pythran...
[75.00%] ·· Benchmarking virtualenv-py3.13-Cython-meson-python-numpy-pybind11-pytest-pythran
[87.50%] ··· sparse_linalg_solve.Bench.time_solve                                                                                                                                  ok
[87.50%] ··· ======= ============= ============= ============= ============= ============= ============= ============= =============
             --                                                           solver                                                    
             ------- ---------------------------------------------------------------------------------------------------------------
              (n,n)      dense        spsolve          cg          minres        gmres         lgmres       gcrotmk        tfqmr    
             ======= ============= ============= ============= ============= ============= ============= ============= =============
                4      73.4±0.5μs    61.5±0.4μs     150±1μs       248±5μs      410±0.8μs      573±3μs       562±10μs      278±20μs  
                6       102±1μs       95.0±2μs      242±5μs       445±2μs       839±8μs       850±6μs       820±7μs       547±7μs   
                10      263±1μs       267±1μs       490±7μs       851±3μs     2.61±0.03ms   1.60±0.03ms   1.57±0.01ms   1.12±0.02ms 
                16    1.51±0.01ms     725±4μs       818±4μs     1.27±0.01ms   5.22±0.05ms   2.58±0.02ms   2.60±0.01ms   2.04±0.02ms 
                25        n/a         2.21±0ms    1.44±0.04ms   1.99±0.02ms    15.3±0.1ms   5.20±0.03ms   4.65±0.06ms   4.02±0.05ms 
                40        n/a       5.99±0.08ms   2.89±0.01ms    3.63±0.4ms    59.7±0.8ms    14.8±0.1ms    11.4±0.1ms    7.89±0.1ms 
                64        n/a       16.9±0.09ms   7.09±0.05ms   6.20±0.04ms     176±5ms       31.9±1ms     30.7±0.6ms    19.6±0.2ms 
               100        n/a        48.3±0.7ms   19.6±0.07ms    12.8±0.2ms     584±7ms      74.6±0.3ms     71.7±2ms     55.4±0.3ms 
             ======= ============= ============= ============= ============= ============= ============= ============= =============

[100.00%] ··· sparse_linalg_solve.Lgmres.time_inner                                                                                                                                 ok
[100.00%] ··· ======= ============= ============= ============= ============ =============
              --                                       m                                  
              ------- --------------------------------------------------------------------
                 n          10            30            60           90           180     
              ======= ============= ============= ============= ============ =============
                 10      472±3μs       472±5μs       497±20μs     467±4μs       471±3μs   
                 50      630±6μs       634±9μs       630±2μs      639±4μs       628±4μs   
                100    1.22±0.05ms   1.41±0.06ms     1.35±0ms     1.35±0ms    1.43±0.06ms 
                1000   1.61±0.02ms    4.58±0.1ms   10.5±0.03ms   18.5±0.1ms    60.3±0.4ms 
               10000    22.6±0.2ms    65.3±0.7ms     138±1ms      221±2ms       541±5ms   
              ======= ============= ============= ============= ============ =============

| Change   | Before [9d3be495] <main>   | After [fde4b9c4] <njo-rgi-improve1>   |   Ratio | Benchmark (Parameter)                                |
|----------|----------------------------|---------------------------------------|---------|------------------------------------------------------|
| -        | 5.22±0.05ms                | 4.92±0.06ms                           |    0.94 | sparse_linalg_solve.Bench.time_solve(16, 'gmres')    |
| -        | 15.3±0.1ms                 | 14.4±0.3ms                            |    0.94 | sparse_linalg_solve.Bench.time_solve(25, 'gmres')    |
| -        | 6.20±0.04ms                | 5.83±0.2ms                            |    0.94 | sparse_linalg_solve.Bench.time_solve(64, 'minres')   |
| -        | 562±10μs                   | 522±6μs                               |    0.93 | sparse_linalg_solve.Bench.time_solve(4, 'gcrotmk')   |
| -        | 628±4μs                    | 586±20μs                              |    0.93 | sparse_linalg_solve.Lgmres.time_inner(50, 180)       |
| -        | 71.7±2ms                   | 66.0±2ms                              |    0.92 | sparse_linalg_solve.Bench.time_solve(100, 'gcrotmk') |
| -        | 14.8±0.1ms                 | 13.5±0.07ms                           |    0.92 | sparse_linalg_solve.Bench.time_solve(40, 'lgmres')   |
| -        | 839±8μs                    | 768±30μs                              |    0.92 | sparse_linalg_solve.Bench.time_solve(6, 'gmres')     |
| -        | 850±6μs                    | 779±30μs                              |    0.92 | sparse_linalg_solve.Bench.time_solve(6, 'lgmres')    |
| -        | 30.7±0.6ms                 | 28.1±1ms                              |    0.92 | sparse_linalg_solve.Bench.time_solve(64, 'gcrotmk')  |
| -        | 467±4μs                    | 431±10μs                              |    0.92 | sparse_linalg_solve.Lgmres.time_inner(10, 90)        |
| -        | 60.3±0.4ms                 | 55.6±0.4ms                            |    0.92 | sparse_linalg_solve.Lgmres.time_inner(1000, 180)     |
| -        | 630±6μs                    | 573±10μs                              |    0.91 | sparse_linalg_solve.Lgmres.time_inner(50, 10)        |
| -        | 4.65±0.06ms                | 4.20±0.2ms                            |    0.9  | sparse_linalg_solve.Bench.time_solve(25, 'gcrotmk')  |
| -        | 573±3μs                    | 517±7μs                               |    0.9  | sparse_linalg_solve.Bench.time_solve(4, 'lgmres')    |
| -        | 472±3μs                    | 426±3μs                               |    0.9  | sparse_linalg_solve.Lgmres.time_inner(10, 10)        |
| -        | 471±3μs                    | 426±6μs                               |    0.9  | sparse_linalg_solve.Lgmres.time_inner(10, 180)       |
| -        | 472±5μs                    | 424±8μs                               |    0.9  | sparse_linalg_solve.Lgmres.time_inner(10, 30)        |
| -        | 10.5±0.03ms                | 9.53±0.1ms                            |    0.9  | sparse_linalg_solve.Lgmres.time_inner(1000, 60)      |
| -        | 18.5±0.1ms                 | 16.7±0.09ms                           |    0.9  | sparse_linalg_solve.Lgmres.time_inner(1000, 90)      |
| -        | 634±9μs                    | 569±6μs                               |    0.9  | sparse_linalg_solve.Lgmres.time_inner(50, 30)        |
| -        | 630±2μs                    | 569±10μs                              |    0.9  | sparse_linalg_solve.Lgmres.time_inner(50, 60)        |
| -        | 2.58±0.02ms                | 2.29±0.03ms                           |    0.89 | sparse_linalg_solve.Bench.time_solve(16, 'lgmres')   |
| -        | 11.4±0.1ms                 | 10.2±0.04ms                           |    0.89 | sparse_linalg_solve.Bench.time_solve(40, 'gcrotmk')  |
| -        | 1.22±0.05ms                | 1.08±0.01ms                           |    0.89 | sparse_linalg_solve.Lgmres.time_inner(100, 10)       |
| -        | 4.58±0.1ms                 | 4.07±0.2ms                            |    0.89 | sparse_linalg_solve.Lgmres.time_inner(1000, 30)      |
| -        | 639±4μs                    | 570±8μs                               |    0.89 | sparse_linalg_solve.Lgmres.time_inner(50, 90)        |
| -        | 1.60±0.03ms                | 1.41±0.09ms                           |    0.88 | sparse_linalg_solve.Bench.time_solve(10, 'lgmres')   |
| -        | 410±0.8μs                  | 361±2μs                               |    0.88 | sparse_linalg_solve.Bench.time_solve(4, 'gmres')     |
| -        | 820±7μs                    | 725±4μs                               |    0.88 | sparse_linalg_solve.Bench.time_solve(6, 'gcrotmk')   |
| -        | 1.35±0ms                   | 1.19±0.01ms                           |    0.88 | sparse_linalg_solve.Lgmres.time_inner(100, 90)       |
| -        | 2.89±0.01ms                | 2.51±0.07ms                           |    0.87 | sparse_linalg_solve.Bench.time_solve(40, 'cg')       |
| -        | 7.09±0.05ms                | 6.19±0.09ms                           |    0.87 | sparse_linalg_solve.Bench.time_solve(64, 'cg')       |
| -        | 19.6±0.2ms                 | 17.1±0.1ms                            |    0.87 | sparse_linalg_solve.Bench.time_solve(64, 'tfqmr')    |
| -        | 1.57±0.01ms                | 1.35±0.01ms                           |    0.86 | sparse_linalg_solve.Bench.time_solve(10, 'gcrotmk')  |
| -        | 1.35±0ms                   | 1.16±0.01ms                           |    0.86 | sparse_linalg_solve.Lgmres.time_inner(100, 60)       |
| -        | 5.20±0.03ms                | 4.43±0.04ms                           |    0.85 | sparse_linalg_solve.Bench.time_solve(25, 'lgmres')   |
| -        | 1.99±0.02ms                | 1.70±0.01ms                           |    0.85 | sparse_linalg_solve.Bench.time_solve(25, 'minres')   |
| -        | 497±20μs                   | 424±1μs                               |    0.85 | sparse_linalg_solve.Lgmres.time_inner(10, 60)        |
| -        | 1.27±0.01ms                | 1.06±0.01ms                           |    0.84 | sparse_linalg_solve.Bench.time_solve(16, 'minres')   |
| -        | 248±5μs                    | 210±0.5μs                             |    0.84 | sparse_linalg_solve.Bench.time_solve(4, 'minres')    |
| -        | 7.89±0.1ms                 | 6.61±0.03ms                           |    0.84 | sparse_linalg_solve.Bench.time_solve(40, 'tfqmr')    |
| -        | 445±2μs                    | 376±2μs                               |    0.84 | sparse_linalg_solve.Bench.time_solve(6, 'minres')    |
| -        | 1.61±0.02ms                | 1.35±0.02ms                           |    0.84 | sparse_linalg_solve.Lgmres.time_inner(1000, 10)      |
| -        | 851±3μs                    | 705±7μs                               |    0.83 | sparse_linalg_solve.Bench.time_solve(10, 'minres')   |
| -        | 1.43±0.06ms                | 1.19±0.01ms                           |    0.83 | sparse_linalg_solve.Lgmres.time_inner(100, 180)      |
| -        | 1.41±0.06ms                | 1.17±0.01ms                           |    0.83 | sparse_linalg_solve.Lgmres.time_inner(100, 30)       |
| -        | 2.04±0.02ms                | 1.65±0.02ms                           |    0.81 | sparse_linalg_solve.Bench.time_solve(16, 'tfqmr')    |
| -        | 490±7μs                    | 392±2μs                               |    0.8  | sparse_linalg_solve.Bench.time_solve(10, 'cg')       |
| -        | 4.02±0.05ms                | 3.21±0.03ms                           |    0.8  | sparse_linalg_solve.Bench.time_solve(25, 'tfqmr')    |
| -        | 150±1μs                    | 120±1μs                               |    0.8  | sparse_linalg_solve.Bench.time_solve(4, 'cg')        |
| -        | 278±20μs                   | 222±2μs                               |    0.8  | sparse_linalg_solve.Bench.time_solve(4, 'tfqmr')     |
| -        | 3.63±0.4ms                 | 2.85±0.07ms                           |    0.79 | sparse_linalg_solve.Bench.time_solve(40, 'minres')   |
| -        | 242±5μs                    | 192±7μs                               |    0.79 | sparse_linalg_solve.Bench.time_solve(6, 'cg')        |
| -        | 547±7μs                    | 426±4μs                               |    0.78 | sparse_linalg_solve.Bench.time_solve(6, 'tfqmr')     |
| -        | 1.12±0.02ms                | 864±5μs                               |    0.77 | sparse_linalg_solve.Bench.time_solve(10, 'tfqmr')    |
| -        | 1.44±0.04ms                | 1.12±0.01ms                           |    0.77 | sparse_linalg_solve.Bench.time_solve(25, 'cg')       |
| -        | 818±4μs                    | 616±4μs                               |    0.75 | sparse_linalg_solve.Bench.time_solve(16, 'cg')       |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```