### PR TITLE
MAINT: stats.iqr: prepare for array API translation

### DIFF
--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -349,7 +349,7 @@ def _quantile_hd(y, p, n, xp):
 def _quantile_bc(y, p, n, method, xp):
     # Methods retained for backward compatibility. NumPy documentation is not
     # quite right about what these methods do: if `p * (n - 1)` is integral,
-    # that is used as the index.
+    # that is used as the index. See numpy/numpy#28910.
     ij = p * (n - 1)
     if method == '_midpoint':
         return (xp.take_along_axis(y, xp.astype(xp.floor(ij), xp.int64), axis=-1)

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -42,7 +42,7 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims):
     methods = {'inverted_cdf', 'averaged_inverted_cdf', 'closest_observation',
                'hazen', 'interpolated_inverted_cdf', 'linear',
                'median_unbiased', 'normal_unbiased', 'weibull',
-               'harrell-davis'}
+               'harrell-davis', '_lower', '_midpoint', '_higher', '_nearest'}
     if method not in methods:
         message = f"`method` must be one of {methods}"
         raise ValueError(message)
@@ -284,6 +284,8 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
         res = _quantile_hf(y, p, n, method, xp)
     elif method in {'harrell-davis'}:
         res = _quantile_hd(y, p, n, xp)
+    elif method in {'_lower', '_midpoint', '_higher', '_nearest'}:
+        res = _quantile_bc(y, p, n, method, xp)
 
     res = xpx.at(res, p_mask).set(xp.nan)
 
@@ -342,3 +344,20 @@ def _quantile_hd(y, p, n, xp):
     w = xpx.at(w, xp.isnan(w)).set(0)
     res = xp.vecdot(w, y, axis=-1)
     return xp.moveaxis(res, 0, -1)
+
+
+def _quantile_bc(y, p, n, method, xp):
+    # Methods retained for backward compatibility. NumPy documentation is not
+    # quite right about what these methods do: if `p * (n - 1)` is integral,
+    # that is used as the index.
+    ij = p * (n - 1)
+    if method == '_midpoint':
+        return (xp.take_along_axis(y, xp.astype(xp.floor(ij), xp.int64), axis=-1)
+                + xp.take_along_axis(y, xp.astype(xp.ceil(ij), xp.int64), axis=-1)) / 2
+    elif method == '_lower':
+        k = xp.floor(ij)
+    elif method == '_higher':
+        k = xp.ceil(ij)
+    elif method == '_nearest':
+        k = np.round(ij)
+    return xp.take_along_axis(y, xp.astype(k, xp.int64), axis=-1)

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -359,5 +359,5 @@ def _quantile_bc(y, p, n, method, xp):
     elif method == '_higher':
         k = xp.ceil(ij)
     elif method == '_nearest':
-        k = np.round(ij)
+        k = xp.round(ij)
     return xp.take_along_axis(y, xp.astype(k, xp.int64), axis=-1)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3372,9 +3372,17 @@ class TestIQR:
         assert_equal(stats.iqr(x, rng=(12.5, 75)), 2.5)
         assert_almost_equal(stats.iqr(x, rng=(10, 50)), 1.6)  # 3-1.4
 
-        assert_raises(ValueError, stats.iqr, x, rng=(0, 101))
-        assert_raises(ValueError, stats.iqr, x, rng=(np.nan, 25))
-        assert_raises(TypeError, stats.iqr, x, rng=(0, 50, 60))
+        message = r"Elements of `rng` must be in the range \[0, 100\]."
+        with pytest.raises(ValueError, match=message):
+            stats.iqr(x, rng=(0, 101))
+
+        message = "`rng` must not contain NaNs."
+        with pytest.raises(ValueError, match=message):
+            stats.iqr(x, rng=(np.nan, 25))
+
+        message = "`rng` must be a two element sequence."
+        with pytest.raises(TypeError, match=message):
+            stats.iqr(x, rng=(0, 50, 60))
 
     def test_interpolation(self):
         x = np.arange(5)
@@ -3495,6 +3503,13 @@ class TestIQR:
 
         # Bad scale
         assert_raises(ValueError, stats.iqr, x, scale='foobar')
+
+    def test_rng_order(self):
+        # test that order of `rng` doesn't matter (as documented)
+        x = np.arange(8) * 0.5
+        res = stats.iqr(x, rng=(75, 25))
+        ref = stats.iqr(x)
+        assert_equal(res, ref)
 
 
 @make_xp_test_case(stats.moment)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
This refactors `stats.iqr` to prepare for array API translation:
- removes cruft (no longer needed due to use of `_axis_nan_policy` decorator
- uses `stats.quantile` instead of `np.percentile`
- strengthens some aspects of tests that seemed missing

#### Additional information
I had to implement the legacy `percentile` methods "lower", "higher", "midpoint", and "nearest" to replace `percentile` with `quantile`. The NumPy documentation about them is not exactly right, so I wrote them differently than described to match the actual behavior.
