### PR TITLE
ENH: stats.yeojohnson_llf: add array API support

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1806,9 +1806,9 @@ def yeojohnson_llf(lmb, data, *, axis=0, nan_policy='propagate', keepdims=False)
     # unless necessary.
     kwargs = {}
     if keepdims is not False:
-        kwargs[keepdims] = keepdims
+        kwargs['keepdims'] = keepdims
     if nan_policy != 'propagate':
-        kwargs[nan_policy] = nan_policy
+        kwargs['nan_policy'] = nan_policy
     res = _yeojohnson_llf(data, lmb=lmb, axis=axis, **kwargs)
     return res[()] if res.ndim == 0 else res
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -173,7 +173,10 @@ axis_nan_policy_cases = [
     (gstd, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.power_divergence, tuple(), dict(), 1, 2, False, None),
     (stats.chisquare, tuple(), dict(), 1, 2, False, None),
-    (stats._morestats._boxcox_llf, tuple(), dict(lmb=1.5), 1, 1, False, lambda x: (x,)),
+    (stats._morestats._boxcox_llf, tuple(),
+     dict(lmb=1.5), 1, 1, False, lambda x: (x,)),
+    (stats._morestats._yeojohnson_llf, tuple(),
+     dict(lmb=1.5), 1, 1, False, lambda x: (x,)),
 ]
 
 # If the message is one of those expected, put nans in

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2430,7 +2430,9 @@ class TestYeojohnson_llf:
         assert_allclose([llf, llf], llf2, rtol=1e-12)
 
     def test_empty(self):
-        assert_(np.isnan(stats.yeojohnson_llf(1, [])))
+        message = "One or more sample arguments is too small..."
+        with pytest.warns(SmallSampleWarning, match=message):
+            assert_(np.isnan(stats.yeojohnson_llf(1, [])))
 
 
 class TestYeojohnson:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2430,7 +2430,7 @@ class TestYeojohnson_llf:
         lmbda = 1
         ref = stats.yeojohnson_llf(lmbda, x)
         res = stats.yeojohnson_llf(lmbda, xp.stack([x, x]).T)
-        assert_allclose(res, ref, rtol=1e-12)
+        xp_assert_close(res, xp.stack((ref, ref)), rtol=1e-12)
 
     def test_empty(self, xp):
         message = "One or more sample arguments is too small..."

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2413,26 +2413,29 @@ class TestBoxcoxNormplot:
         assert_(stats.boxcox_normplot([], 0, 1).size == 0)
 
 
+@make_xp_test_case(stats.yeojohnson_llf)
 class TestYeojohnson_llf:
 
     def test_array_like(self):
+        # array_like not applicable with SCIPY_ARRAY_API=1
         x = stats.norm.rvs(size=100, loc=0, random_state=54321)
         lmbda = 1
         llf = stats.yeojohnson_llf(lmbda, x)
         llf2 = stats.yeojohnson_llf(lmbda, list(x))
         assert_allclose(llf, llf2, rtol=1e-12)
 
-    def test_2d_input(self):
+    def test_2d_input(self, xp):
         x = stats.norm.rvs(size=100, loc=10, random_state=54321)
+        x = xp.asarray(x)
         lmbda = 1
-        llf = stats.yeojohnson_llf(lmbda, x)
-        llf2 = stats.yeojohnson_llf(lmbda, np.vstack([x, x]).T)
-        assert_allclose([llf, llf], llf2, rtol=1e-12)
+        ref = stats.yeojohnson_llf(lmbda, x)
+        res = stats.yeojohnson_llf(lmbda, xp.stack([x, x]).T)
+        assert_allclose(res, ref, rtol=1e-12)
 
-    def test_empty(self):
+    def test_empty(self, xp):
         message = "One or more sample arguments is too small..."
-        with pytest.warns(SmallSampleWarning, match=message):
-            assert_(np.isnan(stats.yeojohnson_llf(1, [])))
+        with eager_warns(SmallSampleWarning, match=message, xp=xp):
+            assert xp.isnan(stats.yeojohnson_llf(1, xp.asarray([])))
 
 
 class TestYeojohnson:


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `stats.yeojohnson_llf`.

#### Additional information
Also adds `axis`, `nan_policy`, and `keepdims`. It may be easist to review commits separately.