### PR TITLE
DOC: Remove two references to files that do nothing

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -80,8 +80,6 @@ dist:
 	$(CURDIR)/build/env/bin/python -mpip install ..
 	make PYTHON="$(CURDIR)/build/env/bin/python" doc-dist
 
-doc-dist: VERSIONWARNING=-t versionwarning
-
 doc-dist: html
 	-test -d build/htmlhelp || make htmlhelp-build
 	-rm -rf build/dist
@@ -112,7 +110,7 @@ upload:
 html: version-check html-build
 html-build:
 	mkdir -p build/html build/doctrees
-	$(SPHINXBUILD) -WT --keep-going $(VERSIONWARNING) -b html $(ALLSPHINXOPTS) build/html $(FILES)
+	$(SPHINXBUILD) -WT --keep-going -b html $(ALLSPHINXOPTS) build/html $(FILES)
 
 coverage: build version-check
 	mkdir -p build/coverage build/doctrees

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -251,18 +251,6 @@ if 'dev' in version:
     html_theme_options["switcher"]["version_match"] = "development"
     html_theme_options["show_version_warning_banner"] = False
 
-if 'versionwarning' in tags:  # noqa: F821
-    # Specific to docs.scipy.org deployment.
-    # See https://github.com/scipy/docs.scipy.org/blob/main/_static/versionwarning.js_t
-    src = ('var script = document.createElement("script");\n'
-           'script.type = "text/javascript";\n'
-           'script.src = "/doc/_static/versionwarning.js";\n'
-           'document.head.appendChild(script);')
-    html_context = {
-        'VERSIONCHECK_JS': src
-    }
-    html_js_files += ['versioncheck.js', ]
-
 html_title = f"{project} v{version} Manual"
 html_static_path = ['_static']
 html_last_updated_fmt = '%b %d, %Y'

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -269,7 +269,6 @@ html_last_updated_fmt = '%b %d, %Y'
 
 html_css_files = [
     "scipy.css",
-    "try_examples.css",
 ]
 
 # html_additional_pages = {


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

N/A

#### What does this implement/fix?

In the deployed version of our docs, there are two errors in the console. This PR fixes them.

<img width="627" height="194" alt="Screenshot 2025-10-17 at 10 30 21 PM" src="https://github.com/user-attachments/assets/6a96accb-1085-4135-a2ad-543e2971e720" />

##### try_examples.css

Commit 35cddae4e11c011cbd5e3c1000d1e366857eedca introduced a new CSS file, to support a new interactive examples feature. It also modified `doc/source/conf.py` to include a `<style>` directive referencing the new CSS file. Then, commit a32bb6cb1bcaac27b8276cb46228486a1fa31e5b moved the file to `scipy.css`, but did not delete the file from where it was referenced in conf.py.

For this reason you get a 404 error whenever you load a page in the docs.

##### versionswitcher.js

versionswitcher.js used to provide a switching banner for non-stable versions. However, it depends on jQuery, and our Pydata Sphinx Theme no longer includes jQuery. Instead, the version switcher functionality is now [natively provided by our theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html).

Right now, it results in the following error:

```
Uncaught ReferenceError: $ is not defined
    <anonymous> https://docs.scipy.org/doc/_static/versionwarning.js:13
```

This error occurs on the very first non-comment line of this file, so I don't think it's doing anything useful. Sure enough, if I block it in my browser dev tools, the version switcher still works.

#### Additional information

Testing notes:

1. Changes to the config file seem to require running `spin build --clean`. Regular `spin build` doesn't seem to pick up on the change.
2. I tested the version switcher change by editing `docs/build/html/index.html`, finding the line `DOCUMENTATION_OPTIONS.show_version_warning_banner = false` and setting it to true. This causes it to show up.
3. I also tested `make doc-dist` to make sure it still builds.
