### PR TITLE
DOC: ``special.diric``: "Dirichlet function" -> "Dirichlet kernel"

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -735,7 +735,7 @@ Other special functions
    agm         -- Arithmetic, Geometric Mean.
    bernoulli   -- Bernoulli numbers B0..Bn (inclusive).
    binom       -- Binomial coefficient
-   diric       -- Periodic sinc function, also called the Dirichlet function.
+   diric       -- Periodic sinc function, also called the Dirichlet kernel.
    euler       -- Euler numbers E0..En (inclusive).
    expn        -- Exponential integral E_n.
    exp1        -- Exponential integral E_1 of complex argument z.

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -91,9 +91,9 @@ _FACTORIALK_LIMITS_32BITS = {1: 12, 2: 19, 3: 25, 4: 31, 5: 37,
 
 
 def diric(x, n):
-    """Periodic sinc function, also called the Dirichlet function.
+    """Periodic sinc function, also called the Dirichlet kernel.
 
-    The Dirichlet function is defined as::
+    The Dirichlet kernel is defined as::
 
         diric(x, n) = sin(x * n/2) / (n * sin(x / 2)),
 


### PR DESCRIPTION
`scipy.special.diric` implements the Dirichlet *kernel* ([wiki](https://wikipedia.org/wiki/Dirichlet_kernel), [wolfram](https://mathworld.wolfram.com/DirichletIntegrals.html)); not the Dirichlet *function* ([wiki](https://wikipedia.org/wiki/Dirichlet_function), [wolfram](https://mathworld.wolfram.com/DirichletFunction.html)).