### PR TITLE
BUG/TST: Bump xsf to v0.1.3 add tests for expi limits

### DIFF
--- a/scipy/special/tests/test_exponential_integrals.py
+++ b/scipy/special/tests/test_exponential_integrals.py
@@ -111,6 +111,12 @@ class TestExpi:
             rtol=1e-15
         )
 
+    def test_limits(self):
+        limit_zero = sc.expi(0)
+        assert limit_zero == -np.inf
+        limit_inf = sc.expi(np.inf)
+        assert limit_inf == np.inf
+
 
 class TestExpn:
 

--- a/scipy/special/tests/test_exponential_integrals.py
+++ b/scipy/special/tests/test_exponential_integrals.py
@@ -110,12 +110,11 @@ class TestExpi:
             atol=0,
             rtol=1e-15
         )
-
-    def test_limits(self):
-        limit_zero = sc.expi(0)
-        assert limit_zero == -np.inf
-        limit_inf = sc.expi(np.inf)
-        assert limit_inf == np.inf
+    
+    @pytest.mark.parametrize('x, expected', [(0, -np.inf), (np.inf, np.inf)]) 
+    def test_limits(self, x, expected):
+        y = sc.expi(x)
+        assert y == expected
 
 
 class TestExpn:


### PR DESCRIPTION
Closes #23738 

Bumps xsf to v0.1.3 and add tests for expi returning properly on 0 or inf.