### PR TITLE
DOC: slsqp parameters-->options [docs only]

### DIFF
--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -225,8 +225,8 @@ def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
     Minimize a scalar function of one or more variables using Sequential
     Least Squares Programming (SLSQP).
 
-    Parameters
-    ----------
+    Options
+    -------
     ftol : float
         Precision target for the value of f in the stopping criterion. This value
         controls the final accuracy for checking various optimality conditions;


### PR DESCRIPTION
SLSQP minimize documentation doesn't look like other methods. Most of the methods have a "see also" box, then options. SLSQP jumps straight to a parameters section. This PR is trying to make SLSQP look like the rest.