### PR TITLE
CI: optimize: allow new Pytorch message

### DIFF
--- a/scipy/optimize/tests/test_chandrupatla.py
+++ b/scipy/optimize/tests/test_chandrupatla.py
@@ -850,7 +850,8 @@ class TestFindRoot:
             find_root(func, bracket)
 
         # raised by `np.broadcast, but the traceback is readable IMO
-        message = "...not be broadcast..."  # all messages include this part
+        # all messages include this part
+        message = "(not be broadcast|Attempting to broadcast a dimension of length)"
         with pytest.raises((ValueError, RuntimeError), match=message):
             bracket = xp.asarray([-2, -3]), xp.asarray([3, 4, 5])
             find_root(func, bracket)


### PR DESCRIPTION
Pytorch 2.9.0 changes the error message on failed broadcasts. Allow the new style to pass tests.

#### Reference issue

Closes #23820


#### What does this implement/fix?

In pytorch/pytorch#160251, broadcast_shapes() was changed to call broadcasting logic in another part of the package. As a consequence, when we upgrade from Pytorch 2.9.0 to Pytorch 2.8.0, the error message changes here from

```
RuntimeError: Shape mismatch: objects cannot be broadcast to a single shape
```

to

```
RuntimeError: Attempting to broadcast a dimension of length 3 at -1! Mismatching argument at index 1 had torch.Size([3]); but expected shape should be broadcastable to [2]
```

Therefore, add a regex that allows either message.

#### Additional information

N/A