### PR TITLE
ENH: stats.kruskal: vectorize implementation

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8432,7 +8432,7 @@ KruskalResult = namedtuple('KruskalResult', ('statistic', 'pvalue'))
 
 @xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(KruskalResult, n_samples=None)
-def kruskal(*samples, nan_policy='propagate'):
+def kruskal(*samples, nan_policy='propagate', axis=0):
     """Compute the Kruskal-Wallis H-test for independent samples.
 
     The Kruskal-Wallis H-test tests the null hypothesis that the population
@@ -8454,6 +8454,11 @@ def kruskal(*samples, nan_policy='propagate'):
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
+    axis : int or tuple of ints, default: None
+        If an int or tuple of ints, the axis or axes of the input along which
+        to compute the statistic. The statistic of each axis-slice (e.g. row)
+        of the input will appear in a corresponding element of the output.
+        If ``None``, the input will be raveled before computing the statistic.
 
     Returns
     -------
@@ -8498,27 +8503,28 @@ def kruskal(*samples, nan_policy='propagate'):
     KruskalResult(statistic=7.0, pvalue=0.0301973834223185)
 
     """
-    samples = list(map(np.asarray, samples))
-
     num_groups = len(samples)
     if num_groups < 2:
         raise ValueError("Need at least two groups in stats.kruskal()")
 
-    n = np.asarray(list(map(len, samples)))
+    n = np.asarray([sample.shape[-1] for sample in samples])
+    totaln = np.sum(n)
 
-    alldata = np.concatenate(samples)
-    ranked = rankdata(alldata)
-    ties = tiecorrect(ranked)
-    if ties == 0:
-        raise ValueError('All numbers are identical in kruskal')
+    if np.any(n) < 1:  # Only needed for `test_axis_nan_policy`
+        raise ValueError("Inputs must not be empty.")
+
+    alldata = np.concatenate(samples, axis=-1)
+    ranked, t = _rankdata(alldata, method='average', return_ties=True)
+
+    # ties = tiecorrect(ranked)
+    ties = 1 - (t**3 - t).sum(axis=-1) / (totaln**3 - totaln)
 
     # Compute sum^2/n for each group and sum
-    j = np.insert(np.cumsum(n), 0, 0)
-    ssbn = 0
-    for i in range(num_groups):
-        ssbn += _square_of_sums(ranked[j[i]:j[i+1]]) / n[i]
+    j = np.cumsum(n, axis=-1)
+    ssbn = np.sum(ranked[..., :j[0]], axis=-1)**2 / n[0]
+    for i in range(1, num_groups):
+        ssbn += np.sum(ranked[..., j[i-1]:j[i]], axis=-1)**2 / n[i]
 
-    totaln = np.sum(n, dtype=float)
     h = 12.0 / (totaln * (totaln + 1)) * ssbn - 3 * (totaln + 1)
     df = num_groups - 1
     h /= ties


### PR DESCRIPTION
#### Reference issue
Toward gh-14651
Toward gh-20544

#### What does this implement/fix?
This vectorizes the `scipy.stats.kruskal` implementation in preparation for translation to the array API.