### PR TITLE
MAINT: interpolate: mark legacy functions out of scope for Array API

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -27,6 +27,7 @@ import numpy as np
 
 from . import _fitpack_impl
 from . import _dfitpack as dfitpack
+from scipy._lib._array_api import xp_capabilities
 
 
 dfitpack_int = dfitpack.types.intvar.dtype
@@ -70,6 +71,7 @@ _extrap_modes = {0: 0, 'extrapolate': 0,
                  3: 3, 'const': 3}
 
 
+@xp_capabilities(out_of_scope=True)
 class UnivariateSpline:
     """
     1-D smoothing spline fit to a given set of data points.
@@ -655,6 +657,7 @@ class UnivariateSpline:
         return UnivariateSpline._from_tck(tck, self.ext)
 
 
+@xp_capabilities(out_of_scope=True)
 class InterpolatedUnivariateSpline(UnivariateSpline):
     """
     1-D interpolating spline for a given set of data points.
@@ -777,6 +780,7 @@ This means that at least one of the following conditions is violated:
 """
 
 
+@xp_capabilities(out_of_scope=True)
 class LSQUnivariateSpline(UnivariateSpline):
     """
     1-D spline with explicit internal knots.
@@ -1186,6 +1190,7 @@ inaccurate. Deficiency may strongly depend on the value of eps."""
                     }
 
 
+@xp_capabilities(out_of_scope=True)
 class BivariateSpline(_BivariateSplineBase):
     """
     Base class for bivariate splines.
@@ -1352,6 +1357,7 @@ class _DerivedBivariateSpline(_BivariateSplineBase):
         raise AttributeError(f"method \"get_residual\" {self._invalid_why}")
 
 
+@xp_capabilities(out_of_scope=True)
 class SmoothBivariateSpline(BivariateSpline):
     """
     Smooth bivariate spline approximation.
@@ -1450,6 +1456,7 @@ class SmoothBivariateSpline(BivariateSpline):
         self.degrees = kx, ky
 
 
+@xp_capabilities(out_of_scope=True)
 class LSQBivariateSpline(BivariateSpline):
     """
     Weighted least-squares bivariate spline approximation.
@@ -1550,6 +1557,7 @@ class LSQBivariateSpline(BivariateSpline):
         self.degrees = kx, ky
 
 
+@xp_capabilities(out_of_scope=True)
 class RectBivariateSpline(BivariateSpline):
     """
     Bivariate spline approximation over a rectangular mesh.
@@ -1666,6 +1674,7 @@ WARNING. The coefficients of the spline returned have been computed as the
          the value of eps."""
 
 
+@xp_capabilities(out_of_scope=True)
 class SphereBivariateSpline(_BivariateSplineBase):
     """
     Bivariate spline s(x,y) of degrees 3 on a sphere, calculated from a
@@ -1833,6 +1842,7 @@ class SphereBivariateSpline(_BivariateSplineBase):
         return self.__call__(theta, phi, dtheta=dtheta, dphi=dphi, grid=False)
 
 
+@xp_capabilities(out_of_scope=True)
 class SmoothSphereBivariateSpline(SphereBivariateSpline):
     """
     Smooth bivariate spline approximation in spherical coordinates.
@@ -1975,6 +1985,7 @@ class SmoothSphereBivariateSpline(SphereBivariateSpline):
                                               dphi=dphi, grid=grid)
 
 
+@xp_capabilities(out_of_scope=True)
 class LSQSphereBivariateSpline(SphereBivariateSpline):
     """
     Weighted least-squares bivariate spline approximation in spherical
@@ -2159,6 +2170,7 @@ ERROR: on entry, the input data are controlled on validity
        approximation returned."""
 
 
+@xp_capabilities(out_of_scope=True)
 class RectSphereBivariateSpline(SphereBivariateSpline):
     """
     Bivariate spline approximation over a rectangular mesh on a sphere.

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -34,7 +34,7 @@ from numpy import (atleast_1d, array, ones, zeros, sqrt, ravel, transpose,
 #  f2py-generated version
 from . import _dfitpack as dfitpack
 
-from scipy._lib._array_api import array_namespace, concat_1d
+from scipy._lib._array_api import array_namespace, concat_1d, xp_capabilities
 
 
 dfitpack_int = dfitpack.types.intvar.dtype
@@ -417,6 +417,7 @@ _surfit_cache = {'tx': array([], float), 'ty': array([], float),
                  'wrk': array([], float), 'iwrk': array([], dfitpack_int)}
 
 
+@xp_capabilities(out_of_scope=True)
 def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
              kx=3, ky=3, task=0, s=None, eps=1e-16, tx=None, ty=None,
              full_output=0, nxest=None, nyest=None, quiet=1):
@@ -617,6 +618,7 @@ def bisplrep(x, y, z, w=None, xb=None, xe=None, yb=None, ye=None,
         return tck
 
 
+@xp_capabilities(out_of_scope=True)
 def bisplev(x, y, tck, dx=0, dy=0):
     """
     Evaluate a bivariate B-spline and its derivatives.
@@ -651,7 +653,7 @@ def bisplev(x, y, tck, dx=0, dy=0):
 
     Notes
     -----
-        See `bisplrep` to generate the `tck` representation.
+    See `bisplrep` to generate the `tck` representation.
 
     References
     ----------

--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -8,8 +8,10 @@ import numpy as np
 from ._fitpack_impl import bisplrep, bisplev, dblint  # noqa: F401
 from . import _fitpack_impl as _impl
 from ._bsplines import BSpline
+from scipy._lib._array_api import xp_capabilities
 
 
+@xp_capabilities(out_of_scope=True)
 def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
             full_output=0, nest=None, per=0, quiet=1):
     """
@@ -161,6 +163,7 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
     return res
 
 
+@xp_capabilities(out_of_scope=True)
 def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
            full_output=0, per=0, quiet=1):
     """
@@ -305,6 +308,7 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
     return res
 
 
+@xp_capabilities(out_of_scope=True)
 def splev(x, tck, der=0, ext=0):
     """
     Evaluate a B-spline or its derivatives.
@@ -395,6 +399,7 @@ def splev(x, tck, der=0, ext=0):
         return _impl.splev(x, tck, der, ext)
 
 
+@xp_capabilities(out_of_scope=True)
 def splint(a, b, tck, full_output=0):
     """
     Evaluate the definite integral of a B-spline between two given points.
@@ -465,6 +470,7 @@ def splint(a, b, tck, full_output=0):
         return _impl.splint(a, b, tck, full_output)
 
 
+@xp_capabilities(out_of_scope=True)
 def sproot(tck, mest=10):
     """
     Find the roots of a cubic B-spline.
@@ -560,6 +566,7 @@ def sproot(tck, mest=10):
         return _impl.sproot(tck, mest)
 
 
+@xp_capabilities(out_of_scope=True)
 def spalde(x, tck):
     """
     Evaluate a B-spline and all its derivatives at one point (or set of points) up
@@ -658,6 +665,7 @@ def spalde(x, tck):
         return _impl.spalde(x, tck)
 
 
+@xp_capabilities(out_of_scope=True)
 def insert(x, tck, m=1, per=0):
     """
     Insert knots into a B-spline.
@@ -759,6 +767,7 @@ def insert(x, tck, m=1, per=0):
         return _impl.insert(x, tck, m, per)
 
 
+@xp_capabilities(out_of_scope=True)
 def splder(tck, n=1):
     """
     Compute the spline representation of the derivative of a given spline
@@ -826,6 +835,7 @@ def splder(tck, n=1):
         return _impl.splder(tck, n)
 
 
+@xp_capabilities(out_of_scope=True)
 def splantider(tck, n=1):
     """
     Compute the spline for the antiderivative (integral) of a given spline.

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -173,6 +173,7 @@ def _do_extrapolate(fill_value):
             fill_value == 'extrapolate')
 
 
+@xp_capabilities(out_of_scope=True)
 class interp1d(_Interpolator1D):
     """
     Interpolate a 1-D function (legacy).

--- a/scipy/interpolate/_rbf.py
+++ b/scipy/interpolate/_rbf.py
@@ -48,10 +48,12 @@ import numpy as np
 from scipy import linalg
 from scipy.special import xlogy
 from scipy.spatial.distance import cdist, pdist, squareform
+from scipy._lib._array_api import xp_capabilities
 
 __all__ = ['Rbf']
 
 
+@xp_capabilities(out_of_scope=True)
 class Rbf:
     """
     Rbf(*args, **kwargs)


### PR DESCRIPTION
Mark legacy functions as out-of-scope for the Array API, so that the [% listings](https://scipy.github.io/devdocs/dev/api-dev/array_api.html) are less misleading---the tables are filled from `@xp_capabilities` decorated functions themselves. 

Why? Marking a function as _legacy_ basically signals that we no longer want to spend effort improving it. Array API is one way of improving it we are not interested in. 