### PR TITLE
ENH: stats.friedmanchisquare: simplify and vectorize implementation

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -49,7 +49,7 @@ from scipy import linalg  # noqa: F401
 from . import distributions
 from . import _mstats_basic as mstats_basic
 
-from ._stats_mstats_common import _find_repeats, theilslopes, siegelslopes
+from ._stats_mstats_common import theilslopes, siegelslopes
 from ._stats import _kendall_dis, _toint64, _weightedrankedtau
 
 from dataclasses import dataclass, field

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8596,22 +8596,14 @@ def friedmanchisquare(*samples):
                          f'for Friedman test, got {k}.')
 
     n = len(samples[0])
-    for i in range(1, k):
-        if len(samples[i]) != n:
-            raise ValueError('Unequal N in friedmanchisquare.  Aborting.')
 
     # Rank data
-    data = np.vstack(samples).T
+    data = np.stack(samples).T
     data = data.astype(float)
-    for i in range(len(data)):
-        data[i] = rankdata(data[i])
+    data, t = _rankdata(data, method='average', return_ties=True)
 
-    # Handle ties
-    ties = 0
-    for d in data:
-        _, repnum = _find_repeats(np.array(d, dtype=np.float64))
-        for t in repnum:
-            ties += t * (t*t - 1)
+    # # Handle ties
+    ties = np.sum(t * (t*t - 1))
     c = 1 - ties / (k*(k*k - 1)*n)
 
     ssbn = np.sum(data.sum(axis=0)**2)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8549,7 +8549,7 @@ def friedmanchisquare(*samples, axis=0):
     sample1, sample2, sample3... : array_like
         Arrays of observations.  All of the arrays must have the same number
         of elements.  At least three samples must be given.
-    axis : int or tuple of ints, default: None
+    axis : int or tuple of ints, default: 0
         If an int or tuple of ints, the axis or axes of the input along which
         to compute the statistic. The statistic of each axis-slice (e.g. row)
         of the input will appear in a corresponding element of the output.
@@ -8613,7 +8613,7 @@ def friedmanchisquare(*samples, axis=0):
     data = data.astype(float)
     data, t = _rankdata(data, method='average', return_ties=True)
 
-    # # Handle ties
+    # Handle ties
     ties = np.sum(t * (t*t - 1), axis=(0, -1))
     c = 1 - ties / (k*(k*k - 1)*n)
 


### PR DESCRIPTION
#### Reference issue
Toward gh-14651
Toward gh-20544

#### What does this implement/fix?
This vectorizes the `scipy.stats.friedmanchisquare` implementation in preparation for translation to the array API.