### PR TITLE
DOC: stats.quantile: clarify broadcasting behavior

### DIFF
--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -117,7 +117,11 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
     p : array_like of float
         Probability or sequence of probabilities of the quantiles to compute.
         Values must be between 0 and 1 (inclusive).
-        Must have length 1 along `axis` unless ``keepdims=True``.
+        While `numpy.quantile` can only compute quantiles according to the Cartesian
+        product of the first two arguments, this function enables calculation of
+        quantiles at different probabilities for each axis slice by following
+        broadcasting rules like those of `scipy.stats` reducing functions.
+        See `axis`, `keepdims`, and the examples.
     method : str, default: 'linear'
         The method to use for estimating the quantile.
         The available options, numbered as they appear in [1]_, are:
@@ -139,6 +143,10 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
         Axis along which the quantiles are computed.
         ``None`` ravels both `x` and `p` before performing the calculation,
         without checking whether the original shapes were compatible.
+        As in other `scipy.stats` functions, a positive integer `axis` is resolved
+        after prepending 1s to the shape of `x` or `p` as needed until the two arrays
+        have the same dimensionality. When providing `x` and `p` with different
+        dimensionality, consider using negative `axis` integers for clarity.
     nan_policy : str, default: 'propagate'
         Defines how to handle NaNs in the input data `x`.
 
@@ -164,7 +172,8 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
         axis to contain the number of quantiles given by ``p.size``. Therefore:
 
         - By default, the axis will be reduced away if possible (i.e. if there is
-          exactly one element of `q` per axis-slice of `x`).
+          exactly one element of `q` per axis-slice of `x`) and not reduced away
+          otherwise.
         - If `keepdims` is set to True, the axis will not be reduced away.
         - If `keepdims` is set to False, the axis will be reduced away
           if possible, and an error will be raised otherwise.
@@ -246,22 +255,36 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
     >>> x = np.asarray([[10, 8, 7, 5, 4],
     ...                 [0, 1, 2, 3, 5]])
 
-    Take the median along the last axis.
+    Take the median of each row.
 
     >>> stats.quantile(x, 0.5, axis=-1)
     array([7.,  2.])
 
-    Take a different quantile along each axis.
+    Take a different quantile for each row.
 
     >>> stats.quantile(x, [[0.25], [0.75]], axis=-1, keepdims=True)
     array([[5.],
            [3.]])
 
-    Take multiple quantiles along each axis.
+    Take multiple quantiles for each row.
 
     >>> stats.quantile(x, [0.25, 0.75], axis=-1)
     array([[5., 8.],
            [1., 3.]])
+
+    Take different quantiles for each row.
+
+    >>> p = np.asarray([[0.25, 0.75],
+    ...                 [0.5, 1.0]])
+    >>> stats.quantile(x, p, axis=-1)
+    array([[5., 8.],
+           [2., 5.]])
+
+    Take different quantiles for each column.
+
+    >>> stats.quantile(x.T, p.T, axis=0)
+    array([[5., 2.],
+           [8., 5.]])
 
     References
     ----------

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -172,8 +172,7 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
         axis to contain the number of quantiles given by ``p.size``. Therefore:
 
         - By default, the axis will be reduced away if possible (i.e. if there is
-          exactly one element of `q` per axis-slice of `x`) and not reduced away
-          otherwise.
+          exactly one element of `q` per axis-slice of `x`).
         - If `keepdims` is set to True, the axis will not be reduced away.
         - If `keepdims` is set to False, the axis will be reduced away
           if possible, and an error will be raised otherwise.


### PR DESCRIPTION
#### Reference issue
Closes gh-23832

#### What does this implement/fix?
Clarifies the broadcasting behavior of `stats.quantile`, which follows that of other `scipy.stats` functions and differs from the Cartesian-product behavior of `np.quantile`.

#### Additional information
@lucyleeow does this help?

In the documentation of *this* function, I'd rather not include the full rules followed by _all_ stats functions with an `axis` argument. Really, that belongs in a to-be-written tutorial[^1]. But for integer `axis` (assuming input core dimensionality of 1), they are something like:
- Determine the "effective dimensionality" of the input arrays as `max(array.ndim for array in arrays)`. Prepend 1s to the shapes of input arrays with lower dimensionality.
- `axis` now identifies the "core dimension" of the input, the rest are "batch dimensions" (AKA "loop dimensions"). Remove the core dimension from the array shapes and broadcast the shapes of the batch dimensions to get the effective "batch shape".  Broadcast each array to its effective shape, which is the batch shape with the length of the core dimension re-inserted at position `axis`.
- Perform the calculation. The result shape will be the batch shape with the output core shape (e.g. `(),` for reducing functions, possibly `(m,)` for `quantile` when the length of `p` along `axis` is `m`) inserted at position `axis`.

[^1]: I wrote the [Batched Linear Algebra Operations](https://scipy.github.io/devdocs/tutorial/linalg_batch.html) tutorial for `linalg`, and I think that turned out pretty clear. It would be nice to have something like that for `stats`.