### PR TITLE
ENH/DEP: sparse.linalg.LinearOperator: n-D batch support

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -38,3 +38,5 @@ ecef3490da68a0c53ba543c618bab0c8e15dccee
 ceafa8e730887b81cf10d483ce375559ebd1de09
 # Clean-up for UP031, UP032 lint rules (gh-21029)
 d1b5af016e907e037136b7a38e485437165490f2
+# Style cleanup in `sparse.linalg._interface` (gh-23836)
+726243cb85d4368d58fb1f95dc1749fb3f3dbce8

--- a/doc/source/_templates/autosummary/class.rst
+++ b/doc/source/_templates/autosummary/class.rst
@@ -18,12 +18,12 @@
       .. autosummary::
          :toctree:
       {% for item in all_methods %}
-         {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__', '__pow__'] %}
+         {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__', '__pow__', '__matmul__', '__truediv__', '__add__', '__rmul__', '__rmatmul__'] %}
          {{ name }}.{{ item }}
          {%- endif -%}
       {%- endfor %}
       {% for item in inherited_members %}
-         {%- if item in ['__call__', '__mul__', '__getitem__', '__len__', '__pow__'] %}
+         {%- if item in ['__call__', '__mul__', '__getitem__', '__len__', '__pow__', '__matmul__', '__truediv__', '__add__', '__rmul__', '__rmatmul__'] %}
          {{ name }}.{{ item }}
          {%- endif -%}
       {%- endfor %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -296,7 +296,8 @@ phantom_import_file = 'dump.xml'
 # Generate plots for example sections
 numpydoc_use_plots = True
 np_docscrape.ClassDoc.extra_public_methods = [  # should match class.rst
-    '__call__', '__mul__', '__getitem__', '__len__',
+    '__call__', '__mul__', '__getitem__', '__len__', '__pow__', '__matmul__',
+    '__truediv__', '__add__', '__rmul__', '__rmatmul__'
 ]
 
 # -----------------------------------------------------------------------------

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -369,14 +369,14 @@ def isintlike(x) -> bool:
     return True
 
 
-def isshape(x, nonneg=False, *, allow_nd=(2,)) -> bool:
+def isshape(x, nonneg=False, *, allow_nd=(2,), check_nd=True) -> bool:
     """Is x a valid tuple of dimensions?
 
     If nonneg, also checks that the dimensions are non-negative.
     Shapes of length in the tuple allow_nd are allowed.
     """
     ndim = len(x)
-    if ndim not in allow_nd:
+    if check_nd and ndim not in allow_nd:
         return False
 
     for d in x:

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -34,6 +34,8 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
     if math.prod(A.shape) == 0:
         message = "`A` must not be empty."
         raise ValueError(message)
+    if A.ndim != 2:
+        raise ValueError("Only 2-D input is supported for `A` (a single matrix)")
 
     # input validation/standardization for `k`
     kmax = min(A.shape) if solver == 'propack' else min(A.shape) - 1

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1320,6 +1320,8 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
     """
     A = convert_pydata_sparse_to_scipy(A)
+    if (A_ndim := len(A.shape)) > 2:
+        raise ValueError(f"{A_ndim}-dimensional `A` is unsupported, expected 2-D.")
     M = convert_pydata_sparse_to_scipy(M)
     if A.shape[0] != A.shape[1]:
         raise ValueError(f'expected square matrix (shape={A.shape})')
@@ -1652,6 +1654,8 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         else:
             return ret.real
 
+    if (A_ndim := len(A.shape)) > 2:
+        raise ValueError(f"{A_ndim}-dimensional `A` is unsupported, expected 2-D.")
     if A.shape[0] != A.shape[1]:
         raise ValueError(f'expected square matrix (shape={A.shape})')
     if M is not None:

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -706,3 +706,13 @@ def test_gh24358(dtype):
     # ARPACK can sometimes pick up the conjugate
     assert_allclose(np.abs(w.imag), 0.5173365219668336, atol=atol, rtol=0.0)
     assert_allclose(A @ z, w * z, atol=atol, rtol=0.0)
+
+
+@pytest.mark.parametrize("func", [eigs, eigsh])
+def test_nD(func):
+    """Check that >2-D operators are rejected cleanly."""
+    def id(x):
+        return x
+    A = LinearOperator(shape=(2, 2, 2), matvec=id, dtype=np.float64)
+    with pytest.raises(ValueError, match="expected 2-D"):
+        func(A)

--- a/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/lobpcg.py
@@ -547,6 +547,7 @@ def lobpcg(
                     raise ValueError(
                         f"The shape {A.shape} of the primary matrix\n"
                         f"defined by a callable object is wrong.\n"
+                        f"Expected {(n, n)}."
                     )
             elif issparse(A):
                 A = A.toarray()

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -108,8 +108,7 @@ def _check_svds_n(A, k, u, s, vh, which="LM", check_res=True,
 class CheckingLinearOperator(LinearOperator):
     def __init__(self, A):
         self.A = A
-        self.dtype = A.dtype
-        self.shape = A.shape
+        super().__init__(dtype=A.dtype, shape=A.shape)
 
     def _matvec(self, x):
         assert_equal(max(x.shape), np.size(x))
@@ -133,7 +132,7 @@ class SVDSCommonTests:
     _A_empty_msg = "`A` must not be empty."
     _A_dtype_msg = "`A` must be of numeric data type"
     _A_type_msg = "type not understood"
-    _A_ndim_msg = "array must have ndim <= 2"
+    _A_ndim_msg = "Only 2-D input"
     _A_validation_inputs = [
         (np.asarray([[]]), ValueError, _A_empty_msg),
         (np.array([['a', 'b'], ['c', 'd']], dtype='object'), ValueError, _A_dtype_msg),

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -42,11 +42,13 @@ Several algorithms in the ``scipy.sparse`` library are able to operate on
 ``LinearOperator`` instances.
 """
 
+import os
 import types
 import warnings
 
 import numpy as np
 
+from scipy import sparse
 from scipy.sparse import issparse
 from scipy.sparse._sputils import isshape, isintlike, asmatrix, is_pydata_spmatrix
 
@@ -59,7 +61,7 @@ class LinearOperator:
     Many iterative methods (e.g. `cg`, `gmres`) do not need to know the
     individual entries of a matrix to solve a linear system ``A@x = b``.
     Such solvers only require the computation of matrix vector
-    products, ``A@v`` where ``v`` is a dense vector.  This class serves as
+    products, ``A@v``, where ``v`` is a dense vector.  This class serves as
     an abstract interface between iterative solvers and matrix-like
     objects.
 
@@ -68,7 +70,8 @@ class LinearOperator:
 
     A subclass must implement either one of the methods ``_matvec``
     and ``_matmat``, and the attributes/properties ``shape`` (pair of
-    integers) and ``dtype`` (may be None). It may call the ``__init__``
+    integers, optionally with additional batch dimensions at the front)
+    and ``dtype`` (may be None). It may call the ``__init__``
     on this class to have these attributes validated. Implementing
     ``_matvec`` automatically implements ``_matmat`` (using a naive
     algorithm) and vice-versa.
@@ -80,20 +83,29 @@ class LinearOperator:
     ``_adjoint`` is preferable; ``_rmatvec`` is mostly there for
     backwards compatibility.
 
+    The defined operator may have additional "batch" dimensions
+    prepended to the core shape, to represent a batch of 2-D operators;
+    see :ref:`linalg_batch` for details.
+
     Parameters
     ----------
     shape : tuple
-        Matrix dimensions ``(M, N)``.
+        Matrix dimensions ``(..., M, N)``,
+        where ``...`` represents any additional batch dimensions.
     matvec : callable f(v)
-        Returns returns ``A @ v``.
+        Applies ``A`` to ``v``, where ``v`` is a dense vector
+        with shape ``(..., N)``.
     rmatvec : callable f(v)
-        Returns ``A^H @ v``, where ``A^H`` is the conjugate transpose of ``A``.
+        Applies ``A^H`` to ``v``, where ``A^H`` is the conjugate transpose of ``A``,
+        and ``v`` is a dense vector of shape ``(..., M)``.
     matmat : callable f(V)
-        Returns ``A @ V``, where ``V`` is a dense matrix with dimensions ``(N, K)``.
-    dtype : dtype
-        Data type of the matrix.
+        Returns ``A @ V``, where ``V`` is a dense matrix
+        with dimensions ``(..., N, K)``.
     rmatmat : callable f(V)
-        Returns ``A^H @ V``, where ``V`` is a dense matrix with dimensions ``(M, K)``.
+        Returns ``A^H @ V``, where ``A^H`` is the conjugate transpose of ``A``,
+        and where ``V`` is a dense matrix with dimensions ``(..., M, K)``.
+    dtype : dtype
+        Data type of the matrix or matrices.
 
     Attributes
     ----------
@@ -101,35 +113,54 @@ class LinearOperator:
         For linear operators describing products etc. of other linear
         operators, the operands of the binary operation.
     ndim : int
-        Number of dimensions (this is always 2)
+        Number of dimensions (greater than 2 in the case of batch dimensions).
+    T : LinearOperator
+        Transpose.
+    H : LinearOperator
+        Hermitian adjoint.
+    
+    Methods
+    -------
+    matvec
+    matmat
+    adjoint
+    transpose
+    rmatvec
+    rmatmat
+    dot
+    rdot
+    __mul__
+    __matmul__
+    __call__
+    __add__
+    __truediv__
+    __rmul__
+    __rmatmul__
 
     See Also
     --------
-    aslinearoperator : Construct LinearOperators
+    aslinearoperator : Construct a `LinearOperator`.
 
     Notes
     -----
     The user-defined `matvec` function must properly handle the case
-    where ``v`` has shape ``(N,)`` as well as the ``(N,1)`` case.  The shape of
-    the return type is handled internally by `LinearOperator`.
+    where ``v`` has shape ``(..., N)``.
 
     It is highly recommended to explicitly specify the `dtype`, otherwise
     it is determined automatically at the cost of a single matvec application
     on ``int8`` zero vector using the promoted `dtype` of the output.
-    Python ``int`` could be difficult to automatically cast to numpy integers
-    in the definition of the `matvec` so the determination may be inaccurate.
     It is assumed that `matmat`, `rmatvec`, and `rmatmat` would result in
     the same dtype of the output given an ``int8`` input as `matvec`.
 
-    LinearOperator instances can also be multiplied, added with each
-    other and exponentiated, all lazily: the result of these operations
-    is always a new, composite LinearOperator, that defers linear
+    `LinearOperator` instances can also be multiplied, added with each
+    other, and raised to integral powers, all lazily: the result of these
+    operations
+    is always a new, composite `LinearOperator`, that defers linear
     operations to the original operators and combines the results.
 
-    More details regarding how to subclass a LinearOperator and several
-    examples of concrete LinearOperator instances can be found in the
+    More details regarding how to subclass a `LinearOperator` and several
+    examples of concrete `LinearOperator` instances can be found in the
     external project `PyLops <https://pylops.readthedocs.io>`_.
-
 
     Examples
     --------
@@ -148,12 +179,13 @@ class LinearOperator:
 
     """
 
-    ndim = 2
     # Necessary for right matmul with numpy arrays.
     __array_ufunc__ = None
 
     # generic type compatibility with scipy-stubs
     __class_getitem__ = classmethod(types.GenericAlias)
+
+    ndim: int
 
     def __new__(cls, *args, **kwargs):
         if cls is LinearOperator:
@@ -174,17 +206,18 @@ class LinearOperator:
         """Initialize this LinearOperator.
 
         To be called by subclasses. ``dtype`` may be None; ``shape`` should
-        be convertible to a length-2 tuple.
+        be convertible to a length >=2 tuple.
         """
         if dtype is not None:
             dtype = np.dtype(dtype)
 
         shape = tuple(shape)
-        if not isshape(shape):
-            raise ValueError(f"invalid shape {shape!r} (must be 2-d)")
+        if not isshape(shape, check_nd=False) or len(shape) < 2:
+            raise ValueError(f"invalid shape {shape!r} (must be at least 2-d)")
 
         self.dtype = dtype
         self.shape = shape
+        self.ndim = len(shape)
 
     def _init_dtype(self):
         """Determine the dtype by executing `matvec` on an `int8` test vector.
@@ -209,170 +242,177 @@ class LinearOperator:
 
     def _matmat(self, X):
         """Default matrix-matrix multiplication handler.
+        
+        If ``self`` is a linear operator of shape ``(..., M, N)``,
+        then this method will be called on a shape ``(..., N, K)`` array,
+        and should return a shape ``(..., M, K)`` array.
 
-        Falls back on the user-defined _matvec method, so defining that will
-        define matrix multiplication (though in a very suboptimal way).
+        Falls back to `_matvec`, so defining that will
+        define matrix multiplication too (though in a very suboptimal way).
         """
-
-        return np.hstack([self.matvec(col.reshape(-1,1)) for col in X.T])
+        # NOTE: we can't use `_matvec` directly (for the unbatched case)
+        # as we can't assume that user-defined `matvec` functions support batching.
+        # TODO: determine whether user-defined `_matvec` supports batching,
+        # and use it directly.
+        return np.stack(
+            [self._matvec(X[..., :, i]) for i in range(X.shape[-1])],
+            axis=-1
+        )
 
     def _matvec(self, x):
         """Default matrix-vector multiplication handler.
 
-        If self is a linear operator of shape (M, N), then this method will
-        be called on a shape (N,) or (N, 1) ndarray, and should return a
-        shape (M,) or (M, 1) ndarray.
+        If ``self`` is a linear operator of shape ``(..., M, N)``,
+        then this method will be called on a shape
+        ``(..., N)`` array,
+        and should return a shape ``(..., M)`` array.
 
-        This default implementation falls back on _matmat, so defining that
+        Falls back to `_matmat`, so defining that
         will define matrix-vector multiplication as well.
         """
-        return self.matmat(x.reshape(-1, 1))
+        return self._matmat(x[..., np.newaxis])[..., 0]
+
+    def _shared_matvec(self, x, adjoint: bool = False):
+        x = np.asanyarray(x)
+
+        *self_broadcast_dims, M, N = self.shape
+        inner_dim, outer_dim = (M, N) if adjoint else (N, M)
+
+        # TODO: deprecate `np.matrix` support
+        if isinstance(x, np.matrix):
+            y = self._rmatvec(x) if adjoint else self._matvec(x)
+            if x.shape == (inner_dim, 1):
+                y = y.reshape(outer_dim, 1)
+            return asmatrix(y)
+
+        x_broadcast_dims: tuple[int, ...] = ()
+        row_vector: bool = False
+        if column_vector := x.shape == (inner_dim, 1):
+            func_name = "`rmatvec`" if adjoint else "`matvec`"
+            matmat_func_name = "`rmatmat`" if adjoint else "`matmat`"
+            msg = (
+                f"Calling {func_name} on 'column vectors' of shape "
+                f"`({inner_dim}, 1)` was deprecated in SciPy 1.18.0 and will no "
+                f"longer be possible in SciPy 1.20.0. "
+                f"Please call {matmat_func_name} instead for identical behaviour."
+            )
+            warnings.warn(
+                msg, FutureWarning,
+                skip_file_prefixes=(os.path.dirname(__file__),)
+            )
+            x = np.reshape(x, (inner_dim,))
+        elif x.ndim >= 1 and (row_vector := x.shape[-1] == inner_dim):
+            x_broadcast_dims = x.shape[:-1]
+
+        if not (row_vector or column_vector):
+            msg = (
+                f"Dimension mismatch: `x` must have a shape ending in "
+                f"`({inner_dim},)`, or shape `({inner_dim}, 1)`. "
+                f"Given shape: {x.shape}"
+            )
+            raise ValueError(msg)
+
+        y = self._rmatvec(x) if adjoint else self._matvec(x)
+
+        broadcasted_dims = np.broadcast_shapes(self_broadcast_dims, x_broadcast_dims)
+        if row_vector:
+            y = y.reshape(*broadcasted_dims, outer_dim)
+        elif column_vector:
+            y = y.reshape(*broadcasted_dims, outer_dim, 1)
+
+        return y
 
     def matvec(self, x):
         """Matrix-vector multiplication.
 
-        Performs the operation y=A@x where A is an MxN linear
-        operator and x is a column vector or 1-d array.
+        Applies ``A`` to `x`, where ``A`` is an ``M`` x ``N``
+        linear operator (or batch of linear operators)
+        and `x` is a row vector (or batch of such vectors).
 
         Parameters
         ----------
         x : {matrix, ndarray}
-            An array with shape (N,) or (N,1).
+            An array with shape ``(..., N)`` representing a row vector
+            (or batch of row vectors).
+
+            .. versionadded:: 1.18.0
+                A ``FutureWarning`` is emitted for column vector input of shape
+                ``(N, 1)``, for which an array with shape ``(M, 1)`` is returned.
+                `matmat` can be called instead for identical behaviour on such input.
 
         Returns
         -------
         y : {matrix, ndarray}
-            A matrix or ndarray with shape (M,) or (M,1) depending
-            on the type and shape of the x argument.
+            An array with shape ``(..., M)``.
 
         Notes
         -----
-        This matvec wraps the user-specified matvec routine or overridden
-        _matvec method to ensure that y has the correct shape and type.
-
+        This method wraps the user-specified ``matvec`` routine or overridden
+        ``_matvec`` method to ensure that `y` has the correct shape and type.
         """
-
-        x = np.asanyarray(x)
-
-        M,N = self.shape
-
-        if x.shape != (N,) and x.shape != (N,1):
-            raise ValueError('dimension mismatch')
-
-        y = self._matvec(x)
-
-        if isinstance(x, np.matrix):
-            y = asmatrix(y)
-        else:
-            y = np.asarray(y)
-
-        if x.ndim == 1:
-            y = y.reshape(M)
-        elif x.ndim == 2:
-            y = y.reshape(M,1)
-        else:
-            raise ValueError('invalid shape returned by user-defined matvec()')
-
-        return y
+        return self._shared_matvec(x)
 
     def rmatvec(self, x):
         """Adjoint matrix-vector multiplication.
 
-        Performs the operation y = A^H @ x where A is an MxN linear
-        operator and x is a column vector or 1-d array.
+        Applies ``A^H`` to `x`, where ``A`` is an
+        ``M`` x ``N`` linear operator (or batch of linear operators)
+        and `x` is a row vector (or batch of such vectors).
 
         Parameters
         ----------
         x : {matrix, ndarray}
-            An array with shape (M,) or (M,1).
+            An array with shape ``(..., M)`` representing a row vector
+            (or batch of row vectors),
+            or an array with shape ``(M, 1)`` representing a column vector.
+
+            .. versionadded:: 1.18.0
+                A ``FutureWarning`` is now emitted for column vector input of shape
+                ``(M, 1)``, for which an array with shape ``(N, 1)`` is returned.
+                `rmatmat` can be called instead for identical behaviour on such input.
 
         Returns
         -------
         y : {matrix, ndarray}
-            A matrix or ndarray with shape (N,) or (N,1) depending
-            on the type and shape of the x argument.
+            An array with shape ``(..., N)``.
 
         Notes
         -----
-        This rmatvec wraps the user-specified rmatvec routine or overridden
-        _rmatvec method to ensure that y has the correct shape and type.
-
+        This method wraps the user-specified ``rmatvec`` routine or overridden
+        ``_rmatvec`` method to ensure that `y` has the correct shape and type.
         """
-
-        x = np.asanyarray(x)
-
-        M,N = self.shape
-
-        if x.shape != (M,) and x.shape != (M,1):
-            raise ValueError('dimension mismatch')
-
-        y = self._rmatvec(x)
-
-        if isinstance(x, np.matrix):
-            y = asmatrix(y)
-        else:
-            y = np.asarray(y)
-
-        if x.ndim == 1:
-            y = y.reshape(N)
-        elif x.ndim == 2:
-            y = y.reshape(N,1)
-        else:
-            raise ValueError('invalid shape returned by user-defined rmatvec()')
-
-        return y
+        return self._shared_matvec(x, adjoint=True)
 
     def _rmatvec(self, x):
-        """Default implementation of _rmatvec; defers to adjoint."""
+        """Default implementation of `_rmatvec`.
+        Defers to `_rmatmat` or `adjoint`."""
         if type(self)._adjoint == LinearOperator._adjoint:
             # _adjoint not overridden, prevent infinite recursion
             if (hasattr(self, "_rmatmat")
                     and type(self)._rmatmat != LinearOperator._rmatmat):
                 # Try to use _rmatmat as a fallback
-                return self._rmatmat(x.reshape(-1, 1)).reshape(-1)
+                return self._rmatmat(x[..., np.newaxis])[..., 0]
             raise NotImplementedError
         else:
-            return self.H.matvec(x)
+            return self.H._matvec(x)
 
-    def matmat(self, X):
-        """Matrix-matrix multiplication.
-
-        Performs the operation y=A@X where A is an MxN linear
-        operator and X dense N*K matrix or ndarray.
-
-        Parameters
-        ----------
-        X : {matrix, ndarray}
-            An array with shape (N,K).
-
-        Returns
-        -------
-        Y : {matrix, ndarray}
-            A matrix or ndarray with shape (M,K) depending on
-            the type of the X argument.
-
-        Notes
-        -----
-        This matmat wraps any user-specified matmat routine or overridden
-        _matmat method to ensure that y has the correct type.
-
-        """
+    def _shared_matmat(self, X, adjoint: bool = False):
         if not (issparse(X) or is_pydata_spmatrix(X)):
             X = np.asanyarray(X)
 
-        if X.ndim != 2:
-            raise ValueError(f'expected 2-d ndarray or matrix, not {X.ndim}-d')
+        if X.ndim < 2:
+            raise ValueError(f'Expected at least 2-d ndarray or matrix, not {X.ndim}-d')
 
-        if X.shape[0] != self.shape[1]:
-            raise ValueError(f'dimension mismatch: {self.shape}, {X.shape}')
+        if X.shape[-2] != (self.shape[-2] if adjoint else self.shape[-1]):
+            raise ValueError(f'Dimension mismatch: {self.shape}, {X.shape}')
 
         try:
-            Y = self._matmat(X)
+            Y = self._rmatmat(X) if adjoint else self._matmat(X)
         except Exception as e:
             if issparse(X) or is_pydata_spmatrix(X):
                 raise TypeError(
                     "Unable to multiply a LinearOperator with a sparse matrix."
-                    " Wrap the matrix in aslinearoperator first."
+                    " Wrap the matrix with `aslinearoperator` first."
                 ) from e
             raise
 
@@ -381,83 +421,141 @@ class LinearOperator:
 
         return Y
 
+    def matmat(self, X):
+        """Matrix-matrix multiplication.
+
+        Performs the operation ``A @ X`` where ``A`` is an ``M`` x ``N``
+        linear operator (or batch of linear operators)
+        and `X` is a dense ``N`` x ``K`` matrix
+        (or batch of dense matrices).
+
+        Parameters
+        ----------
+        X : {matrix, ndarray}
+            An array with shape ``(..., N, K)`` representing the dense matrix
+            (or batch of dense matrices).
+
+        Returns
+        -------
+        Y : {matrix, ndarray}
+            An array with shape ``(..., M, K)``.
+
+        Notes
+        -----
+        This method wraps any user-specified ``matmat`` routine or overridden
+        ``_matmat`` method to ensure that `Y` has the correct type.
+        """
+        return self._shared_matmat(X)
+
     def rmatmat(self, X):
         """Adjoint matrix-matrix multiplication.
 
-        Performs the operation y = A^H @ x where A is an MxN linear
-        operator and x is a column vector or 1-d array, or 2-d array.
+        Performs the operation ``A^H @ X`` where ``A`` is an ``M`` x ``N``
+        linear operator (or batch of linear operators)
+        and `X` is a dense ``M`` x ``K`` matrix
+        (or batch of dense matrices).
         The default implementation defers to the adjoint.
 
         Parameters
         ----------
         X : {matrix, ndarray}
-            A matrix or 2D array.
+            An array with shape ``(..., M, K)`` representing the dense matrix
+            (or batch of dense matrices).
 
         Returns
         -------
         Y : {matrix, ndarray}
-            A matrix or 2D array depending on the type of the input.
+            An array with shape ``(..., N, K)``.
 
         Notes
         -----
-        This rmatmat wraps the user-specified rmatmat routine.
+        This method wraps any user-specified ``rmatmat`` routine or overridden
+        ``_rmatmat`` method to ensure that `Y` has the correct type.
 
         """
-        if not (issparse(X) or is_pydata_spmatrix(X)):
-            X = np.asanyarray(X)
-
-        if X.ndim != 2:
-            raise ValueError(f'expected 2-d ndarray or matrix, not {X.ndim}-d')
-
-        if X.shape[0] != self.shape[0]:
-            raise ValueError(f'dimension mismatch: {self.shape}, {X.shape}')
-
-        try:
-            Y = self._rmatmat(X)
-        except Exception as e:
-            if issparse(X) or is_pydata_spmatrix(X):
-                raise TypeError(
-                    "Unable to multiply a LinearOperator with a sparse matrix."
-                    " Wrap the matrix in aslinearoperator() first."
-                ) from e
-            raise
-
-        if isinstance(Y, np.matrix):
-            Y = asmatrix(Y)
-        return Y
+        return self._shared_matmat(X, adjoint=True)
 
     def _rmatmat(self, X):
-        """Default implementation of _rmatmat defers to rmatvec or adjoint."""
+        """Default implementation of `_rmatmat`; defers to `rmatvec` or `adjoint`."""
         if type(self)._adjoint == LinearOperator._adjoint:
-            return np.hstack([self.rmatvec(col.reshape(-1, 1)) for col in X.T])
+            # NOTE: we can't use `_rmatvec` directly as we can't assume that
+            # user-defined `rmatvec` functions support batching.
+            return np.stack(
+                [self._rmatvec(X[..., :, i]) for i in range(X.shape[-1])],
+                axis=-1
+            )
         else:
-            return self.H.matmat(X)
+            return self.H._matmat(X)
 
     def __call__(self, x):
+        """Apply this linear operator.
+        
+        Equivalent to `__matmul__`.
+        """
         return self@x
 
     def __mul__(self, x):
+        """Multiplication.
+        
+        Used by the ``*`` operator. Equivalent to `dot`.
+        """
         return self.dot(x)
 
     def __truediv__(self, other):
+        """Scalar Division.
+        
+        Returns a lazily scaled linear operator.
+        """
         if not np.isscalar(other):
             raise ValueError("Can only divide a linear operator by a scalar.")
 
         return _ScaledLinearOperator(self, 1.0/other)
 
     def dot(self, x):
-        """Matrix-matrix or matrix-vector multiplication.
+        """Multi-purpose multiplication method.
 
         Parameters
         ----------
-        x : array_like
-            1-d or 2-d array, representing a vector or matrix.
+        x : array_like or `LinearOperator` or scalar
+            Array-like input will be interpreted as a 1-D row vector or
+            2-D matrix (or batch of matrices)
+            depending on its shape. See the Returns section for details.
 
         Returns
         -------
-        Ax : array
-            1-d or 2-d array (depending on the shape of x) that represents
-            the result of applying this linear operator on x.
+        Ax : array or `LinearOperator`
+            - For `LinearOperator` input, operator composition is performed.
+
+            - For scalar input, a lazily scaled operator is returned.
+
+            - Otherwise, the input is expected to take the form of a dense
+              1-D vector or 2-D matrix (or batch of matrices),
+              interpreted as follows
+              (where ``self`` is an ``M`` by ``N`` linear operator):
+                
+              - If `x` has shape ``(N,)``
+                it is interpreted as a row vector
+                and `matvec` is called.
+              - If `x` has shape ``(..., N, K)`` for some
+                integer ``K``, it is interpreted as a matrix
+                (or batch of matrices if there are batch dimensions)
+                and `matmat` is called.
+
+        See Also
+        --------
+        __mul__ : Equivalent method used by the ``*`` operator.
+        __matmul__ :
+            Method used by the ``@`` operator which rejects scalar
+            input before calling this method.
+
+        Notes
+        -----
+        To perform matrix-vector multiplication on batches of vectors,
+        use `matvec`.
+
+        For clarity, it is recommended to use the `matvec` or
+        `matmat` methods directly instead of this method
+        when interacting with dense vectors and matrices.
 
         """
         if isinstance(x, LinearOperator):
@@ -468,49 +566,100 @@ class LinearOperator:
             if not issparse(x) and not is_pydata_spmatrix(x):
                 # Sparse matrices shouldn't be converted to numpy arrays.
                 x = np.asarray(x)
+                
+            N = self.shape[-1]
+    
+            # treat 1-D input as a vector and >1-D input as a matrix, if the shape fits
+            vector = x.shape == (N,)
+            matrix = x.ndim >=2 and x.shape[-2] == N
 
-            if x.ndim == 1 or x.ndim == 2 and x.shape[1] == 1:
+            if not (vector or matrix):
+                msg = (
+                    f"Dimension mismatch: array input `x` must have shape `({N},)` "
+                    f"or a shape ending in `({N}, K)` for some integer `K`. "
+                    f"Given shape: {x.shape}"
+                )
+                raise ValueError(msg)
+            
+            if vector:
                 return self.matvec(x)
-            elif x.ndim == 2:
+            elif matrix:
                 return self.matmat(x)
-            else:
-                raise ValueError(f'expected 1-d or 2-d array or matrix, got {x!r}')
 
     def __matmul__(self, other):
+        """Matrix Multiplication.
+        
+        Used by the ``@`` operator.
+        Rejects scalar input.
+        Otherwise, equivalent to `dot`.
+        """
         if np.isscalar(other):
             raise ValueError("Scalar operands are not allowed, "
                              "use '*' instead")
         return self.__mul__(other)
 
     def __rmatmul__(self, other):
+        """Matrix Multiplication from the right.
+        
+        Used by the ``@`` operator from the right.
+        Rejects scalar input.
+        Otherwise, equivalent to `rdot`.
+        """
         if np.isscalar(other):
             raise ValueError("Scalar operands are not allowed, "
                              "use '*' instead")
         return self.__rmul__(other)
 
     def __rmul__(self, x):
-        if np.isscalar(x):
-            return _ScaledLinearOperator(self, x)
-        else:
-            return self._rdot(x)
+        """Multiplication from the right.
+        
+        Used by the ``*`` operator from the right. Equivalent to `rdot`.
+        """
+        return self.rdot(x)
 
-    def _rdot(self, x):
-        """Matrix-matrix or matrix-vector multiplication from the right.
+    def rdot(self, x):
+        """Multi-purpose multiplication method from the right.
+
+        .. note ::
+
+            This method returns ``x A``.
+            To perform adjoint multiplication instead, use one of
+            `rmatvec` or `rmatmat`, or take the adjoint first,
+            like ``self.H.rdot(x)`` or ``x * self.H``.
 
         Parameters
         ----------
-        x : array_like
-            1-d or 2-d array, representing a vector or matrix.
+        x : array_like or `LinearOperator` or scalar
+            Array-like input will be interpreted as a 1-D row vector or
+            2-D matrix (or batch of matrices)
+            depending on its shape. See the Returns section for details.
 
         Returns
         -------
-        xA : array
-            1-d or 2-d array (depending on the shape of x) that represents
-            the result of applying this linear operator on x from the right.
+        xA : array or `LinearOperator`
+            - For `LinearOperator` input, operator composition is performed.
 
-        Notes
-        -----
-        This is copied from dot to implement right multiplication.
+            - For scalar input, a lazily scaled operator is returned.
+
+            - Otherwise, the input is expected to take the form of a dense
+              1-D vector or 2-D matrix (or batch of matrices),
+              interpreted as follows
+              (where ``self`` is an ``M`` by ``N`` linear operator):
+
+              - If `x` has shape ``(M,)``
+                it is interpreted as a row vector.
+              - If `x` has shape ``(..., K, M)`` for some
+                integer ``K``, it is interpreted as a matrix
+                (or batch of matrices if there are batch dimensions).
+
+        See Also
+        --------
+        dot : Multi-purpose multiplication method from the left.
+        __rmul__ :
+            Equivalent method, used by the ``*`` operator from the right.
+        __rmatmul__ :
+            Method used by the ``@`` operator from the right
+            which rejects scalar input before calling this method.
         """
         if isinstance(x, LinearOperator):
             return _ProductLinearOperator(x, self)
@@ -521,14 +670,35 @@ class LinearOperator:
                 # Sparse matrices shouldn't be converted to numpy arrays.
                 x = np.asarray(x)
 
+            M = self.shape[-2]
+
+            # treat 1-D input as a vector and >1-D input as a matrix, if the shape fits
+            vector = x.shape == (M,)
+            matrix = x.ndim >= 2 and x.shape[-1] == M
+
+            if not (vector or matrix):
+                msg = (
+                    f"Dimension mismatch: `x` must have shape `({M},)` "
+                    f"or a shape ending in `(K, {M})` for some integer `K`. "
+                    f"Given shape: {x.shape}."
+                )
+                raise ValueError(msg)
+
             # We use transpose instead of rmatvec/rmatmat to avoid
             # unnecessary complex conjugation if possible.
-            if x.ndim == 1 or x.ndim == 2 and x.shape[0] == 1:
-                return self.T.matvec(x.T).T
-            elif x.ndim == 2:
-                return self.T.matmat(x.T).T
-            else:
-                raise ValueError(f'expected 1-d or 2-d array or matrix, got {x!r}')
+            if vector:
+                return self.T.matvec(x.T)
+            elif matrix:
+                # scipy/scipy#24157
+                def mT(x):
+                    match x.ndim:
+                        case 0 | 1:
+                            return x
+                        case 2:
+                            return x.T
+                        case _:
+                            return np.moveaxis(x, -2, -1)
+                return mT(self.T.matmat(mT(x)))
 
     def __pow__(self, p):
         if np.isscalar(p):
@@ -537,6 +707,11 @@ class LinearOperator:
             return NotImplemented
 
     def __add__(self, x):
+        """Linear operator addition.
+        
+        The input must be a `LinearOperator`.
+        A lazily summed linear operator is returned.
+        """
         if isinstance(x, LinearOperator):
             return _SumLinearOperator(self, x)
         else:
@@ -549,52 +724,75 @@ class LinearOperator:
         return self.__add__(-x)
 
     def __repr__(self):
-        M,N = self.shape
         if self.dtype is None:
             dt = 'unspecified dtype'
         else:
             dt = 'dtype=' + str(self.dtype)
 
-        return f'<{M}x{N} {self.__class__.__name__} with {dt}>'
+        shape = 'x'.join(str(dim) for dim in self.shape)
+        return f'<{shape} {self.__class__.__name__} with {dt}>'
 
     def adjoint(self):
         """Hermitian adjoint.
 
-        Returns the Hermitian adjoint of self, aka the Hermitian
+        Returns the Hermitian adjoint of this linear operator,
+        also known as the Hermitian
         conjugate or Hermitian transpose. For a complex matrix, the
         Hermitian adjoint is equal to the conjugate transpose.
 
-        Can be abbreviated self.H instead of self.adjoint().
-
         Returns
         -------
-        A_H : LinearOperator
+        `LinearOperator`
             Hermitian adjoint of self.
+        
+        See Also
+        --------
+        :attr:`~scipy.sparse.linalg.LinearOperator.H` : Equivalent attribute.
         """
         return self._adjoint()
 
-    H = property(adjoint)
+    @property
+    def H(self):
+        """Hermitian adjoint.
+
+        See Also
+        --------
+        scipy.sparse.linalg.LinearOperator.adjoint : Equivalent method.
+        """
+        return self.adjoint()
 
     def transpose(self):
-        """Transpose this linear operator.
-
-        Can be abbreviated self.T instead of self.transpose().
+        """Transpose.
 
         Returns
         -------
-        A_T : LinearOperator
+        `LinearOperator`
             Transpose of the linear operator.
+        
+        See Also
+        --------
+        :attr:`~scipy.sparse.linalg.LinearOperator.T` : Equivalent attribute.
         """
         return self._transpose()
 
-    T = property(transpose)
+    @property
+    def T(self):
+        """Transpose.
+
+        See Also
+        --------
+        scipy.sparse.linalg.LinearOperator.transpose : Equivalent method.
+        """
+        return self.transpose()
 
     def _adjoint(self):
-        """Default implementation of _adjoint; defers to rmatvec."""
+        """Default implementation of `_adjoint`.
+        Defers to adjoint functions, e.g. `_rmatvec` for `_matvec`."""
         return _AdjointLinearOperator(self)
 
     def _transpose(self):
-        """ Default implementation of _transpose; defers to rmatvec + conj"""
+        """Default implementation of `_transpose`.
+        For `_matvec`, defers to `_rmatvec` + `np.conj`."""
         return _TransposedLinearOperator(self)
 
 
@@ -636,19 +834,21 @@ class _CustomLinearOperator(LinearOperator):
             return super()._rmatmat(X)
 
     def _adjoint(self):
-        return _CustomLinearOperator(shape=(self.shape[1], self.shape[0]),
-                                     matvec=self.__rmatvec_impl,
-                                     rmatvec=self.__matvec_impl,
-                                     matmat=self.__rmatmat_impl,
-                                     rmatmat=self.__matmat_impl,
-                                     dtype=self.dtype)
+        return _CustomLinearOperator(
+            shape=(*self.shape[:-2], self.shape[-1], self.shape[-2]),
+            matvec=self.__rmatvec_impl,
+            rmatvec=self.__matvec_impl,
+            matmat=self.__rmatmat_impl,
+            rmatmat=self.__matmat_impl,
+            dtype=self.dtype
+        )
 
 
 class _AdjointLinearOperator(LinearOperator):
     """Adjoint of arbitrary Linear Operator"""
 
     def __init__(self, A):
-        shape = (A.shape[1], A.shape[0])
+        shape = (*A.shape[:-2], A.shape[-1], A.shape[-2])
         super().__init__(dtype=A.dtype, shape=shape)
         self.A = A
         self.args = (A,)
@@ -669,7 +869,7 @@ class _TransposedLinearOperator(LinearOperator):
     """Transposition of arbitrary Linear Operator"""
 
     def __init__(self, A):
-        shape = (A.shape[1], A.shape[0])
+        shape = (*A.shape[:-2], A.shape[-1], A.shape[-2])
         super().__init__(dtype=A.dtype, shape=shape)
         self.A = A
         self.args = (A,)
@@ -689,6 +889,7 @@ class _TransposedLinearOperator(LinearOperator):
         return np.conj(self.A._matmat(np.conj(x)))
 
 def _get_dtype(operators, dtypes=None):
+    """Returns the promoted dtype from input dtypes and operators."""
     if dtypes is None:
         dtypes = []
     for obj in operators:
@@ -698,14 +899,17 @@ def _get_dtype(operators, dtypes=None):
 
 
 class _SumLinearOperator(LinearOperator):
+    """Representing ``A + B``"""
     def __init__(self, A, B):
-        if not isinstance(A, LinearOperator) or \
-                not isinstance(B, LinearOperator):
+        if not isinstance(A, LinearOperator) or not isinstance(B, LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
-        if A.shape != B.shape:
+        *A_broadcast_dims, A_M, A_N = A.shape
+        *B_broadcast_dims, B_M, B_N = B.shape
+        if (A_M, A_N) != (B_M, B_N):
             raise ValueError(f'cannot add {A} and {B}: shape mismatch')
+        broadcasted_dims = np.broadcast_shapes(A_broadcast_dims, B_broadcast_dims)
         self.args = (A, B)
-        super().__init__(_get_dtype([A, B]), A.shape)
+        super().__init__(_get_dtype([A, B]), (*broadcasted_dims, A_M, A_N))
 
     def _matvec(self, x):
         return self.args[0].matvec(x) + self.args[1].matvec(x)
@@ -725,14 +929,16 @@ class _SumLinearOperator(LinearOperator):
 
 
 class _ProductLinearOperator(LinearOperator):
+    """Representing ``A @ B``"""
     def __init__(self, A, B):
-        if not isinstance(A, LinearOperator) or \
-                not isinstance(B, LinearOperator):
+        if not isinstance(A, LinearOperator) or not isinstance(B, LinearOperator):
             raise ValueError('both operands have to be a LinearOperator')
-        if A.shape[1] != B.shape[0]:
+        *A_broadcast_dims, A_M, A_N = A.shape
+        *B_broadcast_dims, B_M, B_N = B.shape
+        if A_N != B_M:
             raise ValueError(f'cannot multiply {A} and {B}: shape mismatch')
-        super().__init__(_get_dtype([A, B]),
-                                                     (A.shape[0], B.shape[1]))
+        broadcasted_dims = np.broadcast_shapes(A_broadcast_dims, B_broadcast_dims)
+        super().__init__(_get_dtype([A, B]), (*broadcasted_dims, A_M, B_N))
         self.args = (A, B)
 
     def _matvec(self, x):
@@ -753,6 +959,7 @@ class _ProductLinearOperator(LinearOperator):
 
 
 class _ScaledLinearOperator(LinearOperator):
+    """Representing ``alpha * A``"""
     def __init__(self, A, alpha):
         if not isinstance(A, LinearOperator):
             raise ValueError('LinearOperator expected as A')
@@ -787,11 +994,13 @@ class _ScaledLinearOperator(LinearOperator):
 
 
 class _PowerLinearOperator(LinearOperator):
+    """Representing ``A ** p``"""
     def __init__(self, A, p):
         if not isinstance(A, LinearOperator):
             raise ValueError('LinearOperator expected as A')
-        if A.shape[0] != A.shape[1]:
-            raise ValueError(f'square LinearOperator expected, got {A!r}')
+        if A.shape[-2] != A.shape[-1]:
+            msg = f'square core-dimensions of LinearOperator expected, got {A!r}'
+            raise ValueError(msg)
         if not isintlike(p) or p < 0:
             raise ValueError('non-negative integer expected as p')
 
@@ -822,6 +1031,7 @@ class _PowerLinearOperator(LinearOperator):
 
 
 class MatrixLinearOperator(LinearOperator):
+    """Operator defined by a matrix `A` which implements ``@``."""
     def __init__(self, A):
         super().__init__(A.dtype, A.shape)
         self.A = A
@@ -829,7 +1039,7 @@ class MatrixLinearOperator(LinearOperator):
         self.args = (A,)
 
     def _matmat(self, X):
-        return self.A.dot(X)
+        return self.A @ X
 
     def _adjoint(self):
         if self.__adj is None:
@@ -838,10 +1048,21 @@ class MatrixLinearOperator(LinearOperator):
 
 
 class _AdjointMatrixOperator(MatrixLinearOperator):
-    def __init__(self, adjoint_array):
-        self.A = adjoint_array.T.conj()
-        self.args = (adjoint_array,)
-        self.shape = adjoint_array.shape[1], adjoint_array.shape[0]
+    """Representing ``A.H``, for `MatrixLinearOperator` `A`."""
+    def __init__(self, A):
+        if A.ndim > 2:
+            if issparse(A):
+                A_T = sparse.swapaxes(A, -1, -2)
+            else:
+                A_T = A.mT
+        else:
+            A_T = A.T
+        self.A = A_T.conj()
+        self.args = (A,)
+        self.shape = (
+            *A.shape[:-2], A.shape[-1], A.shape[-2]
+        )
+        self.ndim = A.ndim
 
     @property
     def dtype(self):
@@ -872,19 +1093,21 @@ class IdentityOperator(LinearOperator):
 
 
 def aslinearoperator(A):
-    """Return A as a LinearOperator.
+    """Return `A` as a `LinearOperator`.
 
-    See the LinearOperator documentation for additional information.
+    See the `LinearOperator` documentation for additional information.
 
     Parameters
     ----------
     A : object
         Object to convert to a `LinearOperator`. May be any one of the following types:
-        - ndarray
-        - matrix
-        - sparse array (e.g. csr_array, lil_array, etc.)
+
+        - `numpy.ndarray`
+        - `numpy.matrix`
+        - `scipy.sparse` array
+          (e.g. `~scipy.sparse.csr_array`, `~scipy.sparse.lil_array`, etc.)
         - `LinearOperator`
-        - An object with .shape and .matvec attributes
+        - An object with ``.shape`` and ``.matvec`` attributes
 
     Returns
     -------
@@ -893,8 +1116,8 @@ def aslinearoperator(A):
 
     Notes
     -----
-    If 'A' has no .dtype attribute, the data type is determined by calling
-    :func:`LinearOperator.matvec()` - set the .dtype attribute to prevent this
+    If `A` has no ``.dtype`` attribute, the data type is determined by calling
+    :func:`LinearOperator.matvec()` - set the ``.dtype`` attribute to prevent this
     call upon the linear operator creation.
 
     Examples
@@ -909,8 +1132,6 @@ def aslinearoperator(A):
         return A
 
     elif isinstance(A, np.ndarray) or isinstance(A, np.matrix):
-        if A.ndim > 2:
-            raise ValueError('array must have ndim <= 2')
         A = np.atleast_2d(np.asarray(A))
         return MatrixLinearOperator(A)
 

--- a/scipy/sparse/linalg/_isolve/lsmr.py
+++ b/scipy/sparse/linalg/_isolve/lsmr.py
@@ -195,6 +195,8 @@ def lsmr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     """
 
     A = aslinearoperator(A)
+    if A.ndim > 2:
+        raise ValueError(f"{A.ndim}-dimensional `A` is unsupported, expected 2-D.")
     b = atleast_1d(b)
     if b.ndim > 1:
         b = b.squeeze()

--- a/scipy/sparse/linalg/_isolve/lsqr.py
+++ b/scipy/sparse/linalg/_isolve/lsqr.py
@@ -322,6 +322,8 @@ def lsqr(A, b, damp=0.0, atol=1e-6, btol=1e-6, conlim=1e8,
     """
     A = convert_pydata_sparse_to_scipy(A)
     A = aslinearoperator(A)
+    if A.ndim > 2:
+        raise ValueError(f"{A.ndim}-dimensional `A` is unsupported, expected 2-D.")
     b = np.atleast_1d(b)
     if b.ndim > 1:
         b = b.squeeze()

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -809,3 +809,13 @@ class TestGMRES:
                         restart=10, callback_type='x')
         assert info == 20
         assert count[0] == 20
+
+
+def test_nD(solver):
+    """Check that >2-D operators are rejected cleanly."""
+    def id(x):
+        return x
+    A = LinearOperator(shape=(2, 2, 2), matvec=id, dtype=np.float64)
+    b = np.ones((2, 2))
+    with pytest.raises(ValueError, match="expected 2-D"):
+        solver(A, b)

--- a/scipy/sparse/linalg/_isolve/tests/test_lsmr.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lsmr.py
@@ -16,13 +16,13 @@ Dept of MS&E, Stanford University.
 
 """
 
+import numpy as np
 from numpy import array, arange, eye, zeros, ones, transpose, hstack
 from numpy.linalg import norm
 from numpy.testing import assert_allclose
 import pytest
 from scipy.sparse import coo_array
-from scipy.sparse.linalg._interface import aslinearoperator
-from scipy.sparse.linalg import lsmr
+from scipy.sparse.linalg import lsmr, LinearOperator, aslinearoperator
 from .test_lsqr import G, b
 
 
@@ -39,12 +39,12 @@ class TestLSMR:
 
     def testIdentityACase1(self):
         A = eye(self.n)
-        xtrue = zeros((self.n, 1))
+        xtrue = zeros((self.n,))
         self.assertCompatibleSystem(A, xtrue)
 
     def testIdentityACase2(self):
         A = eye(self.n)
-        xtrue = ones((self.n,1))
+        xtrue = ones((self.n,))
         self.assertCompatibleSystem(A, xtrue)
 
     def testIdentityACase3(self):
@@ -194,3 +194,12 @@ def test_lsmr_maxiter_zero_with_show():
     assert result[0] is not None  # x should exist
     assert result[1] == 0  # istop should be 0
     assert result[2] == 0  # itn should be 0
+
+def test_nD():
+    """Check that >2-D operators are rejected cleanly."""
+    def id(x):
+        return x
+    A = LinearOperator(shape=(2, 2, 2), matvec=id, dtype=np.float64)
+    b = np.ones((2, 2))
+    with pytest.raises(ValueError, match="expected 2-D"):
+        lsmr(A, b)

--- a/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lsqr.py
@@ -2,8 +2,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 import pytest
 import scipy.sparse
-import scipy.sparse.linalg
-from scipy.sparse.linalg import lsqr
+from scipy.sparse.linalg import lsqr, LinearOperator
 
 # Set up a test problem
 n = 35
@@ -118,3 +117,12 @@ def test_initialization():
     x = lsqr(G, b, show=show, atol=tol, btol=tol, iter_lim=maxit, x0=x0)
     assert_allclose(x_ref[0], x[0])
     assert_array_equal(b_copy, b)
+
+def test_nD():
+    """Check that >2-D operators are rejected cleanly."""
+    def id(x):
+        return x
+    A = LinearOperator(shape=(2, 2, 2), matvec=id, dtype=np.float64)
+    b = np.ones((2, 2))
+    with pytest.raises(ValueError, match="expected 2-D"):
+        lsqr(A, b)

--- a/scipy/sparse/linalg/_isolve/utils.py
+++ b/scipy/sparse/linalg/_isolve/utils.py
@@ -60,6 +60,8 @@ def make_system(A, M, x0, b):
     """
     A_ = A
     A = aslinearoperator(A)
+    if A.ndim > 2:
+        raise ValueError(f"{A.ndim}-dimensional `A` is unsupported, expected 2-D.")
 
     if A.shape[0] != A.shape[1]:
         raise ValueError(f'expected square matrix, but got shape={(A.shape,)}')

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -1,10 +1,12 @@
 """Test functions for the sparse.linalg._interface module
 """
 
+import contextlib
 from functools import partial
 from itertools import product
 import operator
-from typing import NamedTuple
+from typing import NamedTuple, Literal
+
 import pytest
 from pytest import raises as assert_raises, warns
 from numpy.testing import assert_, assert_equal, assert_allclose
@@ -15,6 +17,30 @@ import scipy.sparse as sparse
 import scipy.sparse.linalg._interface as interface
 from scipy.sparse._sputils import matrix
 from scipy._lib._gcutils import assert_deallocated, IS_PYPY
+
+
+def generate_broadcastable_shapes(nshapes, *, ndim=2, min=0, max=10, rng=None):
+    rng = np.random.default_rng(rng)
+    min = np.broadcast_to(min, ndim)  # so min and max can be scalars or array-like 
+    max = np.broadcast_to(max, ndim)
+    batch_shape = tuple(rng.integers(min_, max_+1) for min_, max_ in zip(min, max))
+    shapes = np.repeat([batch_shape], nshapes, axis=0)
+
+    # make some elements of some shapes 1 (while preserving overall batch shape)
+    for column in shapes.T:
+        column[rng.integers(1, nshapes):] = 1
+    # permute elements between shapes (while preserving overall batch shape)
+    shapes = list(rng.permuted(shapes, axis=0))
+    # potentially trim preceeding 1s from a shape
+    for i in range(len(shapes)):
+        shape = shapes[i]
+        j = np.where(shape != 1)[0][0] if np.any(shape != 1) else ndim
+        if rng.random() < 0.25:
+            shapes[i] = shape[rng.integers(j+1):]
+            break
+
+    assert np.broadcast_shapes(*shapes) == batch_shape
+    return [tuple(int(el) for el in shape) for shape in shapes]
 
 
 class TestLinearOperator:
@@ -49,7 +75,8 @@ class TestLinearOperator:
             assert_(A.args == ())
 
             assert_equal(A.matvec(np.array([1,2,3])), [14,32])
-            assert_equal(A.matvec(np.array([[1],[2],[3]])), [[14],[32]])
+            with pytest.warns(FutureWarning, match="column vectors"):
+                assert_equal(A.matvec(np.array([[1],[2],[3]])), [[14],[32]])
             assert_equal(A @ np.array([1,2,3]), [14,32])
             assert_equal(A @ np.array([[1],[2],[3]]), [[14],[32]])
             assert_equal(A.dot(np.array([1,2,3])), [14,32])
@@ -103,7 +130,8 @@ class TestLinearOperator:
             assert_(len(z.args) == 2 and z.args[0] is A and z.args[1] == 2)
 
             assert_(isinstance(A.matvec([1, 2, 3]), np.ndarray))
-            assert_(isinstance(A.matvec(np.array([[1],[2],[3]])), np.ndarray))
+            with pytest.warns(FutureWarning, match="column vectors"):
+                assert_(isinstance(A.matvec(np.array([[1],[2],[3]])), np.ndarray))
             assert_(isinstance(A @ np.array([1,2,3]), np.ndarray))
             assert_(isinstance(A @ np.array([[1],[2],[3]]), np.ndarray))
             assert_(isinstance(A.dot(np.array([1,2,3])), np.ndarray))
@@ -214,6 +242,34 @@ class TestLinearOperator:
         assert_raises(ValueError, operator.matmul, A, 2)
         assert_raises(ValueError, operator.matmul, 2, A)
 
+    def test_dimension_mismatch(self):
+        msg = "(D|d)imension mismatch"
+        A = interface.aslinearoperator(np.ones((3, 4)))
+        # matvec
+        A.matvec(np.ones(4))
+        with pytest.raises(ValueError, match=msg):
+            A.matvec(np.ones(3))
+        # rmatvec
+        A.rmatvec(np.ones(3))
+        with pytest.raises(ValueError, match=msg):
+            A.rmatvec(np.ones(4))
+        # matmat
+        A.matmat(np.ones((4, 3)))
+        with pytest.raises(ValueError, match=msg):
+            A.matmat(np.ones((3, 3)))
+        # rmatmat
+        A.rmatmat(np.ones((3, 3)))
+        with pytest.raises(ValueError, match=msg):
+            A.rmatmat(np.ones((4, 4)))
+        # dot
+        A.dot(np.ones((4, 3)))
+        with pytest.raises(ValueError, match=msg):
+            A.dot(np.ones((3, 3)))
+        # rdot
+        A.rdot(np.ones((3, 3)))
+        with pytest.raises(ValueError, match=msg):
+            A.rdot(np.ones((4, 4)))
+        
 
 class TestDotTests:
     """
@@ -223,7 +279,7 @@ class TestDotTests:
     """
     class OperatorArgs(NamedTuple):
         """
-        shape: shape of the operator
+        shape: (core) shape of the operator
         op_dtype: dtype of the operator
         data_dtype: real dtype corresponding to op_dtype for data generation
         complex: the operator has a complex dtype
@@ -261,7 +317,6 @@ class TestDotTests:
 
     def check_matvec(
         self, op: interface.LinearOperator, data_dtype: str, complex_data: bool = False,
-        check_operators: bool = False, check_dot: bool = False
     ):
         """
         This check verifies the equivalence of the forward and adjoint computation,
@@ -284,30 +339,35 @@ class TestDotTests:
         """
         rng = np.random.default_rng(42)
 
-        u = rng.standard_normal(op.shape[-1], dtype=data_dtype)
-        v = rng.standard_normal(op.shape[-2], dtype=data_dtype)
-        if complex_data:
-            u = u + (1j * rng.standard_normal(op.shape[-1], dtype=data_dtype))
-            v = v + (1j * rng.standard_normal(op.shape[-2], dtype=data_dtype))
+        dtype = np.dtype(data_dtype)
+        *batch_shape, M, N = op.shape
+        
+        # TODO: handle empty batches
+        u_broadcast, v_broadcast = generate_broadcastable_shapes(
+            2, ndim=3, min=0, max=5
+        )
 
-        op_u = op.matvec(u)
-        opH_v = op.rmatvec(v)
-
-        if check_operators:
-            assert_allclose(op_u, op * u)
-            assert_allclose(op_u, op @ u)
-            assert_allclose(opH_v, op.H * v)
-            assert_allclose(opH_v, op.H @ v)
-
-        if check_dot:
-            assert_allclose(op_u, op.dot(u))
-            assert_allclose(opH_v, op.H.dot(v))
-
-        op_u_H_v = np.vecdot(op_u, v, axis=-1)
-        uH_opH_v = np.vecdot(u, opH_v, axis=-1)
-
-        rtol = 1e-12 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
-        assert_allclose(op_u_H_v, uH_opH_v, rtol=rtol)
+        for u_shape, v_shape in (
+            # test broadcasting for unbatched RHS
+            ((N,), (M,)),
+            # as well as with the batch shape of `op` + 3-D broadcast dims
+            ((*u_broadcast, *batch_shape, N), (*v_broadcast, *batch_shape, M))
+        ):
+            u = rng.standard_normal(u_shape, dtype=dtype)
+            v = rng.standard_normal(v_shape, dtype=dtype)
+            if complex_data:
+                u = u + (1j * rng.standard_normal(u_shape, dtype=dtype))
+                v = v + (1j * rng.standard_normal(v_shape, dtype=dtype))
+    
+            op_u = op.matvec(u)
+            opH_v = op.rmatvec(v)
+    
+            op_u_H_v = np.vecdot(op_u, v, axis=-1)
+            uH_opH_v = np.vecdot(u, opH_v, axis=-1)
+    
+            rtol = 1e-12 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
+            atol = 2e-15 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
+            assert_allclose(op_u_H_v, uH_opH_v, rtol=rtol, atol=atol)
 
     def check_matmat(
         self, op: interface.LinearOperator, data_dtype: str, complex_data: bool = False,
@@ -335,11 +395,16 @@ class TestDotTests:
         rng = np.random.default_rng(42)
         k = rng.integers(2, 100)
 
-        U = rng.standard_normal(size=(op.shape[-1], k), dtype=data_dtype)
-        V = rng.standard_normal(size=(op.shape[-2], k), dtype=data_dtype)
+        dtype = np.dtype(data_dtype)
+        *batch_shape, M, N = op.shape
+        
+        # TODO: handle empty batches
+        # Test `U` and `V` with the same batch shape as `op`
+        U = rng.standard_normal(size=(*batch_shape, N, k), dtype=dtype)
+        V = rng.standard_normal(size=(*batch_shape, M, k), dtype=dtype)
         if complex_data:
-            U = U + (1j * rng.standard_normal(size=(op.shape[-1], k), dtype=data_dtype))
-            V = V + (1j * rng.standard_normal(size=(op.shape[-2], k), dtype=data_dtype))
+            U = U + (1j * rng.standard_normal(size=(*batch_shape, N, k), dtype=dtype))
+            V = V + (1j * rng.standard_normal(size=(*batch_shape, M, k), dtype=dtype))
 
         op_U = op.matmat(U)
         opH_V = op.rmatmat(V)
@@ -354,139 +419,159 @@ class TestDotTests:
             assert_allclose(op_U, op.dot(U))
             assert_allclose(opH_V, op.H.dot(V))
 
-        op_U_H = np.conj(op_U).T
-        UH = np.conj(U).T
+        op_U_H = np.conj(op_U).mT
+        UH = np.conj(U).mT
 
         op_U_H_V = np.matmul(op_U_H, V)
         UH_opH_V = np.matmul(UH, opH_V)
 
-        rtol = 3e-12 if np.finfo(data_dtype).eps < 1e-8 else 6e-4
-        assert_allclose(op_U_H_V, UH_opH_V, rtol=rtol)
+        rtol = 1e-12 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
+        atol = 2e-15 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
+        assert_allclose(op_U_H_V, UH_opH_V, rtol=rtol, atol=atol)
 
+    # TODO: batch shape (0,)
+    @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,)])
     @pytest.mark.parametrize("args", square_args_list)
-    def test_identity_square(self, args):
-        """Simple identity operator on square matrices"""
+    def test_identity_square(self, args: OperatorArgs, batch_shape: tuple[int, ...]):
+        """
+        Simple identity operator on square matrices.
+        Tests batches of RHS via `args.batch_shape`.
+        """
         def identity(x):
-            return x
+            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return np.full(shape, x)
 
+        shape = batch_shape + args.shape
         op = interface.LinearOperator(
-            shape=args.shape, dtype=args.op_dtype,
-            matvec=identity, rmatvec=identity
+            shape=shape, dtype=args.op_dtype,
+            matvec=identity, rmatvec=identity,
         )
 
         self.check_matvec(op, data_dtype=args.data_dtype, complex_data=args.complex)
         self.check_matmat(op, data_dtype=args.data_dtype, complex_data=args.complex)
     
+    # TODO: batch shape (0,)
+    @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,)])
     @pytest.mark.parametrize("args", all_args_list)
-    def test_identity_nonsquare(self, args):
-        """Identity operator with zero-padding on non-square matrices"""
+    def test_identity_nonsquare(self, args: OperatorArgs, batch_shape: tuple[int, ...]):
+        """
+        Identity operator with zero-padding on non-square matrices.
+        Tests batches of RHS via `args.batch_shape`.
+        """
+        M, N = args.shape
+        
+        def pad_core_dim(x, target_size):
+            pad_widths = [(0, 0)] * x.ndim # no padding for batch dims
+            pad_widths[-1] = (0, target_size - x.shape[-1]) # padding for core dim
+            return np.pad(x, pad_widths, mode="constant")
+        
         def mv(x):
-            # handle column vectors too
-            # (`LinearOperator` handles reshape in post-processing)
-            x = x.flatten()
-
-            match np.sign(x.shape[0] - args.shape[-2]):
+            match np.sign(x.shape[-1] - M):
                 case 0:  # square
-                    return x
+                    pass
                 case 1:  # crop x to size
-                    return x[:args.shape[-2]]
+                    x = x[..., :M]
                 case -1:  # pad with zeros
-                    pad_width = (0, args.shape[-2] - x.shape[0])
-                    return np.pad(x, pad_width, mode='constant', constant_values=0)
+                    x = pad_core_dim(x, target_size=M)
 
-        def rmv(x):
-            # handle column vectors too
-            # (`LinearOperator` handles reshape in post-processing)
-            x = x.flatten()
-            
-            match np.sign(args.shape[-1] - x.shape[0]):
+            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return np.full(shape, x)
+
+        def rmv(x):            
+            match np.sign(N - x.shape[-1]):
                 case 0:  # square
-                    return x
+                    pass
                 case 1:  # pad with zeros
-                    pad_width = (0, args.shape[-1] - x.shape[0])
-                    return np.pad(x, pad_width, mode='constant', constant_values=0)
+                    x = pad_core_dim(x, target_size=N)
                 case -1:  # crop x to size
-                    return x[:args.shape[-1]]
+                    x = x[..., :N]
 
+            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return np.full(shape, x)
+
+        shape = batch_shape + args.shape
         op = interface.LinearOperator(
-            shape=args.shape, dtype=args.op_dtype, matvec=mv, rmatvec=rmv
+            shape=shape, dtype=args.op_dtype, matvec=mv, rmatvec=rmv
         )
         
         self.check_matvec(op, data_dtype=args.data_dtype, complex_data=args.complex)
         self.check_matmat(op, data_dtype=args.data_dtype, complex_data=args.complex)
         
+    # TODO: batch shape (0,)
+    @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,)])
     @pytest.mark.parametrize("args", square_args_list)
-    def test_scaling_square(self, args):
-        """Simple (complex) scaling operator on square matrices"""
+    def test_scaling_square(self, args: OperatorArgs, batch_shape: tuple[int, ...]):
+        """
+        Simple (complex) scaling operator on square matrices.
+        Tests batches of RHS via `args.batch_shape`.
+        """
         def scale(x):
-            return (3 + 2j) * x
+            b = (3 + 2j) * x
+            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return np.full(shape, b)
 
         def r_scale(x):
-            return (3 - 2j) * x
+            b = (3 - 2j) * x
+            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return np.full(shape, b)
 
+        shape = batch_shape + args.shape
         op = interface.LinearOperator(
-            shape=args.shape, dtype=args.op_dtype, matvec=scale, rmatvec=r_scale
+            shape=shape, dtype=args.op_dtype, matvec=scale, rmatvec=r_scale
         )
-        self.check_matvec(
-            op, data_dtype=args.data_dtype, complex_data=args.complex,
-            check_operators=True, check_dot=True
-        )
-        self.check_matmat(
-            op, data_dtype=args.data_dtype, complex_data=args.complex,
-            check_operators=True, check_dot=True
-        )
+        self.check_matvec(op, data_dtype=args.data_dtype, complex_data=args.complex)
+        self.check_matmat(op, data_dtype=args.data_dtype, complex_data=args.complex)
 
-    def test_subclass_matmat(self):
+    # TODO: batch shape (0,)
+    @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,)])
+    def test_subclass_matmat(self, batch_shape: tuple[int, ...]):
         """
         Simple rotation operator defined by `matmat` and `adjoint`,
         subclassing `LinearOperator`.
+        Tests batches of RHS via `batch_shape`.
         """
-        def rmatmat(X):
-            theta = np.pi / 2
-            R_inv = np.array([
-                [np.cos(theta),  np.sin(theta)],
-                [-np.sin(theta), np.cos(theta)]
-            ])
-            return R_inv @ X
-
         class RotOp(interface.LinearOperator):
-            
+
             def __init__(self, dtype, shape, theta):
                 self._theta = theta
                 super().__init__(dtype, shape)
-            
+
             def _matmat(self, X):
                 theta = self._theta
                 R = np.array([
                     [np.cos(theta), -np.sin(theta)],
                     [np.sin(theta),  np.cos(theta)]
                 ])
-                return R @ X
+                B = R @ X
+                shape = np.broadcast_shapes(batch_shape, X.shape[:-2]) + X.shape[-2:]
+                return np.full(shape, B)
 
             def _adjoint(self):
                 negative_theta = -self._theta
                 return RotOp(self.dtype, self.shape, negative_theta)
-            
+
         theta = np.pi / 2
         dtype = "float64"
-        op = RotOp(shape=(2, 2), dtype=dtype, theta=theta)
+        op = RotOp(shape=(*batch_shape, 2, 2), dtype=dtype, theta=theta)
 
-        self.check_matvec(
-            op, data_dtype=dtype, complex_data=False,
-            check_operators=True, check_dot=True
-        )
-        self.check_matmat(
-            op, data_dtype=dtype, complex_data=False,
-            check_operators=True, check_dot=True
-        )
-    
+        self.check_matvec(op, data_dtype=dtype, complex_data=False)
+        self.check_matmat(op, data_dtype=dtype, complex_data=False)
+
+    # TODO: batch shape (0,)
+    @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,)])
     @pytest.mark.parametrize(
-        "matrix", [
-            np.asarray([[1, 2j, 3j], [4j, 5j, 6]]),
-            sparse.random_array((5, 5))
-        ]
+        "format", ["dense", "sparse"]
     )
-    def test_aslinearop(self, matrix):
+    def test_aslinearop(
+        self, format: Literal["dense", "sparse"], batch_shape: tuple[int, ...]
+    ):
+        """
+        Test operators coming from `aslinearoperator`,
+        *including batched LHS*.
+        """
+        rng = np.random.default_rng(42)
+        constructor = sparse.random_array if format == "sparse" else rng.standard_normal
+        matrix = constructor((*batch_shape, 4, 4))
         op = interface.aslinearoperator(matrix)
         data_dtype = "float64"
         self.check_matvec(op, data_dtype=data_dtype, complex_data=True)
@@ -593,17 +678,30 @@ class TestAsLinearOperator:
             x2 = np.array([[1, 4], [2, 5], [3, 6]])
 
             for x in xs:
-                assert_equal(A.matvec(x), A_array.dot(x))
+                ctx = (
+                    pytest.warns(FutureWarning, match="column vectors")
+                    if x.shape[-1] == 1
+                    else contextlib.nullcontext()
+                )
+                with ctx:
+                    assert_equal(A.matvec(x), A_array.dot(x))
+
                 assert_equal(A @ x, A_array.dot(x))
 
             assert_equal(A.matmat(x2), A_array.dot(x2))
             assert_equal(A @ x2, A_array.dot(x2))
 
             for y in ys:
-                assert_equal(A.rmatvec(y), A_array.T.conj().dot(y))
-                assert_equal(A.T.matvec(y), A_array.T.dot(y))
-                assert_equal(A.H.matvec(y), A_array.T.conj().dot(y))
-                assert_equal(A.adjoint().matvec(y), A_array.T.conj().dot(y))
+                ctx = (
+                    pytest.warns(FutureWarning, match="column vectors")
+                    if y.shape[-1] == 1
+                    else contextlib.nullcontext()
+                )
+                with ctx:
+                    assert_equal(A.rmatvec(y), A_array.T.conj().dot(y))
+                    assert_equal(A.T.matvec(y), A_array.T.dot(y))
+                    assert_equal(A.H.matvec(y), A_array.T.conj().dot(y))
+                    assert_equal(A.adjoint().matvec(y), A_array.T.conj().dot(y))
 
             for y in ys:
                 if y.ndim < 2:
@@ -634,7 +732,7 @@ class TestAsLinearOperator:
 
 
 def test_repr():
-    A = interface.LinearOperator(shape=(1, 1), matvec=lambda x: 1)
+    A = interface.LinearOperator(shape=(1, 1), matvec=lambda x: np.asarray([1]))
     repr_A = repr(A)
     assert_('unspecified dtype' not in repr_A, repr_A)
 
@@ -843,8 +941,8 @@ def test_MatrixLinearOperator_refcycle():
 @pytest.mark.parametrize("operator_definition", ["subclass_matvec", "subclass_matmat",
                                                  "__init__matvec", "__init__matmat",
                                                  "aslinearoperator"])
-@pytest.mark.parametrize("batch_A", [()])
-@pytest.mark.parametrize("batch_x", [()])
+@pytest.mark.parametrize("batch_A", [(), (5,)])
+@pytest.mark.parametrize("batch_x", [(), (6, 1)])
 @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
 def test_batch(left, operator_definition, batch_A, batch_x, dtype):
     # TODO ideas:
@@ -867,8 +965,7 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
 
     def matvec(A, x):
         if not batch_x:
-            # currently matvec is passed a column vector
-            assert x.ndim == 1 or ((x.ndim == 2) and (x.shape[-1] == 1))
+            assert x.ndim == 1
             return A @ x
         else:
             # It might make it easier on the author of LinearOperators to
@@ -927,16 +1024,16 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
     else:
         message = ("Calling `matvec` on 'column vectors'..." if left
                    else "Calling `rmatvec` on 'column vectors'...")
-        # with pytest.warns(FutureWarning, match=message):
-        np.testing.assert_allclose(A.matvec(x_col) if left else A.rmatvec(x_col),
-                                   A_ @ x_col if left else A_.mT.conj() @ x_col)
+        with pytest.warns(FutureWarning, match=message):
+            np.testing.assert_allclose(A.matvec(x_col) if left else A.rmatvec(x_col),
+                                       A_ @ x_col if left else A_.mT.conj() @ x_col)
     # c. with matrix (or batch of matrices)
-    with pytest.raises(ValueError, match="dimension mismatch"):
+    with pytest.raises(ValueError, match="Dimension mismatch:..."):
         A.matvec(x_mat) if left else A.rmatvec(x_mat)
 
     # Test matmat
     # a. with row vector (or batch of row vectors)
-    message = "dimension mismatch..." if batch_x else "expected 2-d..."
+    message = "Dimension mismatch:..." if batch_x else "Expected at least 2-d..."
     with pytest.raises(ValueError, match=message):
         A.matmat(x_row) if left else A.rmatmat(x_row)
     # b. with column vector (or batch of column vectors)
@@ -972,10 +1069,10 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
                 x_row @ A
         else:
             np.testing.assert_allclose(x_row @ A, x_row @ A_)
-            # np.testing.assert_allclose(A.rdot(x_row), x_row @ A_)
+            np.testing.assert_allclose(A.rdot(x_row), x_row @ A_)
         # b. with column vector (or batch of column vectors)
-        with pytest.raises(ValueError, match="dimension mismatch:..."):
+        with pytest.raises(ValueError, match="Dimension mismatch:..."):
             x_col @ A
         # c. with matrix (or batch of matrices)
         np.testing.assert_allclose(x_mat.mT.conj() @ A, x_mat.mT.conj() @ A_)
-        # np.testing.assert_allclose(A.rdot(x_mat.mT.conj()), x_mat.mT.conj() @ A_)
+        np.testing.assert_allclose(A.rdot(x_mat.mT.conj()), x_mat.mT.conj() @ A_)


### PR DESCRIPTION
#### Reference issue
Towards gh-23315.
Closes gh-8444.

https://discuss.scientific-python.org/t/batching-linearoperator-status-and-benchmarks/2199/1

#### What does this implement/fix?

Support for n-dimensional batches of linear operators in `sparse.linalg.LinearOperator`.

#### Deprecation

This PR introduces a `FutureWarning` for calling `{r}matvec` on column vectors. That API does not extend cleanly to batch dimensions, but identical behaviour can be achieved (and extended to batch dimensions) via `{r}matmat`.

#### Future work

Immediate follow-up (me): gh-24562

What I plan to work on:
- array API standard support (including take another look at pydata/sparse)
- supporting these batched operators in the iterative solvers of this submodule

Potential follow-ups that might be nice (but I don't have plans to work on) based on comments here and TODOs in the code:
- taking a look at `_CustomLinearOperator` and the `__init__`/`__new__` dance from the perspective of idiomatic OOP and typing practices in the present day
- performance optimisation when the user's `matvec` supports batching: https://github.com/lucascolley/scipy/blob/53eb4644c3dd8280f7c6dd8294e1c122a1e908b6/scipy/sparse/linalg/_interface.py#L255-L260
- purging `np.matrix` references from the docs and deprecating `np.matrix` support (probably SciPy 2.0 effort)
- some sort of diagram for the User Guide explaining how the various methods interact depending on how classes are instantiated: https://github.com/scipy/scipy/pull/23836#discussion_r2764807854
- API overhaul
	- renaming `matmat` to `matmul`
	- {`.T`, `.mT`, `.H`, `.mH`}, removing {`transpose`,` adjoint`}
	- getting rid of `dot` and `rdot`
	- restricting `*` to scalar-input-only rather than it being a superset of `@`?
- https://github.com/scipy/scipy/pull/24157 would enable some minor simplifications