### PR TITLE
ENH: stats.levene: vectorize implementation

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3652,6 +3652,7 @@ def trim1(a, proportiontocut, tail='right', axis=0):
 
 
 @xp_capabilities(np_only=True)
+@_axis_nan_policy_factory(lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1)
 def trim_mean(a, proportiontocut, axis=0):
     """Return mean of array after trimming a specified fraction of extreme values
 
@@ -3717,7 +3718,7 @@ def trim_mean(a, proportiontocut, axis=0):
     a = np.asarray(a)
 
     if a.size == 0:
-        return np.nan
+        return _get_nan(a)
 
     if axis is None:
         a = a.ravel()
@@ -10897,3 +10898,17 @@ class _SimpleStudentT:
 
     def sf(self, t):
         return special.stdtr(self.df, -t)
+
+
+class _SimpleF:
+    # A very simple, array-API compatible F distribution for use in
+    # hypothesis tests.
+    def __init__(self, dfn, dfd):
+        self.dfn = dfn
+        self.dfd = dfd
+
+    def cdf(self, x):
+        return special.fdtr(self.dfn, self.dfd, x)
+
+    def sf(self, x):
+        return special.fdtrc(self.dfn, self.dfd, x)

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -89,6 +89,7 @@ axis_nan_policy_cases = [
     (stats.gmean, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.hmean, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.pmean, (1.42,), dict(), 1, 1, False, lambda x: (x,)),
+    (stats.trim_mean, (0.05,), dict(), 1, 1, False, lambda x: (x,)),
     (stats.sem, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.iqr, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.kurtosis, tuple(), dict(), 1, 1, False, lambda x: (x,)),

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7350,8 +7350,10 @@ class TestTrim:
         assert_raises(ValueError, stats.trim_mean, a, 0.6)
 
         # empty input
-        assert_equal(stats.trim_mean([], 0.0), np.nan)
-        assert_equal(stats.trim_mean([], 0.6), np.nan)
+        with pytest.warns(SmallSampleWarning, match='too small'):
+            assert_equal(stats.trim_mean([], 0.0), np.nan)
+        with pytest.warns(SmallSampleWarning, match='too small'):
+            assert_equal(stats.trim_mean([], 0.6), np.nan)
 
 
 @make_xp_test_case(stats.sigmaclip)


### PR DESCRIPTION
#### Reference issue
Toward gh-14651
Toward gh-20544

#### What does this implement/fix?
This vectorizes the implementation of `scipy.stats.levene` and prepares for array API translation.

#### Additional information 
Also adds `_axis_nan_policy` decorator to `trim_mean` so `keepdims` can be used in `levene`.