### PR TITLE
DOC: fix denominator in scipy.stats.kstatvar for var(k2)

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -376,7 +376,7 @@ def kstatvar(data, n=2, *, axis=None):
     .. math::
 
         \mathrm{var}(k_1) &= \frac{k_2}{n}, \\
-        \mathrm{var}(k_2) &= \frac{2k_2^2n + (n-1)k_4}{n(n - 1)}.
+        \mathrm{var}(k_2) &= \frac{2k_2^2n + (n-1)k_4}{n(n + 1)}.
 
     References
     ----------


### PR DESCRIPTION
Correct the documentation formula for the unbiased variance of the second k-statistic. The denominator is updated from n(n - 1) to n(n + 1) to match the implementation and MathWorld reference.

#### Reference issue
Fixes gh-23842

#### What does this implement/fix?
This PR updates the docstring of `scipy.stats.kstatvar` to correct the denominator in the formula for the unbiased variance of the second k-statistic. The existing documentation erroneously used `n(n - 1)`, while both the implementation and MathWorld specify the denominator as `n(n + 1)`. Updating the docstring ensures consistency between the documentation, code, and external references.

#### Additional information
No functional changes are introduced; only documentation is updated.