### PR TITLE
ENH: stats.chatterjeexi: add array API support

### DIFF
--- a/scipy/stats/_correlation.py
+++ b/scipy/stats/_correlation.py
@@ -1,6 +1,6 @@
-import numpy as np
+import math
 from scipy import stats
-from scipy._lib._array_api import xp_capabilities
+from scipy._lib._array_api import xp_capabilities, array_namespace, xp_promote
 from scipy.stats._stats_py import _SimpleNormal, SignificanceResult, _get_pvalue
 from scipy.stats._axis_nan_policy import _axis_nan_policy_factory
 
@@ -8,11 +8,7 @@ from scipy.stats._axis_nan_policy import _axis_nan_policy_factory
 __all__ = ['chatterjeexi']
 
 
-# TODO:
-# - Adjust to respect dtype
-
-
-def _xi_statistic(x, y, y_continuous):
+def _xi_statistic(x, y, y_continuous, xp):
     # Compute xi correlation statistic
 
     # `axis=-1` is guaranteed by _axis_nan_policy decorator
@@ -20,50 +16,51 @@ def _xi_statistic(x, y, y_continuous):
 
     # "Rearrange the data as (X(1), Y(1)), . . . ,(X(n), Y(n))
     # such that X(1) ≤ ··· ≤ X(n)"
-    j = np.argsort(x, axis=-1)
-    j, y = np.broadcast_arrays(j, y)
-    y = np.take_along_axis(y, j, axis=-1)
+    j = xp.argsort(x, axis=-1)
+    j, y = xp.broadcast_arrays(j, y)
+    y = xp.take_along_axis(y, j, axis=-1)
 
     # "Let ri be the rank of Y(i), that is, the number of j such that Y(j) ≤ Y(i)"
     r = stats.rankdata(y, method='max', axis=-1)
     # " additionally define li to be the number of j such that Y(j) ≥ Y(i)"
     # Could probably compute this from r, but that can be an enhancement
     l = stats.rankdata(-y, method='max', axis=-1)
+    r, l = xp.astype(r, x.dtype), xp.astype(l, x.dtype)
 
-    num = np.sum(np.abs(np.diff(r, axis=-1)), axis=-1)
+    num = xp.sum(xp.abs(xp.diff(r, axis=-1)), axis=-1)
     if y_continuous:  # [1] Eq. 1.1
         statistic = 1 - 3 * num / (n ** 2 - 1)
     else:  # [1] Eq. 1.2
-        den = 2 * np.sum((n - l) * l, axis=-1)
+        den = 2 * xp.sum((n - l) * l, axis=-1)
         statistic = 1 - n * num / den
 
     return statistic, r, l
 
 
-def _xi_std(r, l, y_continuous):
+def _xi_std(r, l, y_continuous, xp):
     # Compute asymptotic standard deviation of xi under null hypothesis of independence
 
     # `axis=-1` is guaranteed by _axis_nan_policy decorator
-    n = np.float64(r.shape[-1])
+    n = r.shape[-1]
 
     # "Suppose that X and Y are independent and Y is continuous. Then
     # √n·ξn(X, Y) → N(0, 2/5) in distribution as n → ∞"
     if y_continuous:  # [1] Theorem 2.1
-        return np.sqrt(2 / 5) / np.sqrt(n)
+        return xp.asarray(math.sqrt(2 / 5) / math.sqrt(n), dtype=r.dtype)
 
     # "Suppose that X and Y are independent. Then √n·ξn(X, Y)
     # converges to N(0, τ²) in distribution as n → ∞
     # [1] Eq. 2.2 and surrounding math
-    i = np.arange(1, n + 1)
-    u = np.sort(r, axis=-1)
-    v = np.cumsum(u, axis=-1)
-    an = 1 / n**4 * np.sum((2*n - 2*i + 1) * u**2, axis=-1)
-    bn = 1 / n**5 * np.sum((v + (n - i)*u)**2, axis=-1)
-    cn = 1 / n**3 * np.sum((2*n - 2*i + 1) * u, axis=-1)
-    dn = 1 / n**3 * np.sum((l * (n - l)), axis=-1)
+    i = xp.arange(1, n + 1, dtype=r.dtype)
+    u = xp.sort(r, axis=-1)
+    v = xp.cumulative_sum(u, axis=-1)
+    an = 1 / n**4 * xp.sum((2*n - 2*i + 1) * u**2, axis=-1)
+    bn = 1 / n**5 * xp.sum((v + (n - i)*u)**2, axis=-1)
+    cn = 1 / n**3 * xp.sum((2*n - 2*i + 1) * u, axis=-1)
+    dn = 1 / n**3 * xp.sum((l * (n - l)), axis=-1)
     tau2 = (an - 2*bn + cn**2) / dn**2
 
-    return np.sqrt(tau2) / np.sqrt(n)
+    return xp.sqrt(tau2) / math.sqrt(n)
 
 
 def _chatterjeexi_iv(y_continuous, method):
@@ -86,7 +83,8 @@ def _unpack(res, _):
     return res.statistic, res.pvalue
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(skip_backends=[('dask.array', 'no take_along_axis'),
+                                ('cupy', 'no rankdata (xp.repeats limitation)')])
 @_axis_nan_policy_factory(SignificanceResult, paired=True, n_samples=2,
                           result_to_tuple=_unpack, n_outputs=2, too_small=1)
 def chatterjeexi(x, y, *, axis=0, y_continuous=False, method='asymptotic'):
@@ -212,9 +210,12 @@ def chatterjeexi(x, y, *, axis=0, y_continuous=False, method='asymptotic'):
     0.001186895213756626
 
     """
+    xp = array_namespace(x, y)
+
     # x, y, `axis` input validation taken care of by decorator
     # In fact, `axis` is guaranteed to be -1
     y_continuous, method = _chatterjeexi_iv(y_continuous, method)
+    x, y = xp_promote(x, y, force_floating=True, xp=xp)
 
     # A highly negative statistic is possible, e.g.
     # x = np.arange(100.), y = (x % 2 == 0)
@@ -222,17 +223,20 @@ def chatterjeexi(x, y, *, axis=0, y_continuous=False, method='asymptotic'):
     alternative = 'greater'
 
     if method == 'asymptotic':
-        xi, r, l = _xi_statistic(x, y, y_continuous)
-        std = _xi_std(r, l, y_continuous)
+        xi, r, l = _xi_statistic(x, y, y_continuous, xp=xp)
+        std = _xi_std(r, l, y_continuous, xp=xp)
         norm = _SimpleNormal()
-        pvalue = _get_pvalue(xi / std, norm, alternative=alternative)
+        pvalue = _get_pvalue(xi / std, norm, alternative=alternative, xp=xp)
     elif isinstance(method, stats.PermutationMethod):
         res = stats.permutation_test(
             # Could be faster if we just permuted the ranks; for now, keep it simple.
-            data=(y,), statistic=lambda y, axis: _xi_statistic(x, y, y_continuous)[0],
+            data=(y,),
+            statistic=lambda y, axis: _xi_statistic(x, y, y_continuous, xp=xp)[0],
             alternative=alternative, permutation_type='pairings', **method._asdict(),
             axis=-1)  # `axis=-1` is guaranteed by _axis_nan_policy decorator
 
         xi, pvalue = res.statistic, res.pvalue
 
+    xi = xi[()] if xi.ndim == 0 else xi
+    pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
     return SignificanceResult(xi, pvalue)

--- a/scipy/stats/tests/test_correlation.py
+++ b/scipy/stats/tests/test_correlation.py
@@ -1,16 +1,19 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_allclose
 
+from scipy._lib._array_api import make_xp_test_case, xp_default_dtype, is_jax
+from scipy._lib._array_api_no_0d import xp_assert_close
 from scipy import stats
 from scipy.stats._axis_nan_policy import SmallSampleWarning
 
 
+@make_xp_test_case(stats.chatterjeexi)
 class TestChatterjeeXi:
     @pytest.mark.parametrize('case', [
         dict(y_cont=True, statistic=-0.303030303030303, pvalue=0.9351329808526656),
         dict(y_cont=False, statistic=0.07407407407407396, pvalue=0.3709859367123997)])
-    def test_against_R_XICOR(self, case):
+    @pytest.mark.parametrize('dtype', ['float32', 'float64', None])
+    def test_against_R_XICOR(self, case, dtype, xp):
         # Test against R package XICOR, e.g.
         # library(XICOR)
         # options(digits=16)
@@ -23,16 +26,19 @@ class TestChatterjeeXi:
         #       0.7620801065573549, 0.31410063302647495, 0.7935620302236199,
         #       0.5423085761365468)
         # xicor(x, y, ties=FALSE, pvalue=TRUE)
-
+        if dtype == 'float32' and np.__version__ < "2":
+            pytest.skip("Scalar dtypes only respected after NEP 50.")
+        dtype = xp_default_dtype(xp) if dtype is None else getattr(xp, dtype)
         rng = np.random.default_rng(25982435982346983)
         x = rng.random(size=10)
-
         y = (rng.random(size=10) if case['y_cont']
              else rng.integers(0, 5, size=10))
+
+        x, y = xp.asarray(x, dtype=dtype), xp.asarray(y, dtype=dtype)
         res = stats.chatterjeexi(x, y, y_continuous=case['y_cont'])
 
-        assert_allclose(res.statistic, case['statistic'])
-        assert_allclose(res.pvalue, case['pvalue'])
+        xp_assert_close(res.statistic, xp.asarray(case['statistic'], dtype=dtype))
+        xp_assert_close(res.pvalue, xp.asarray(case['pvalue'], dtype=dtype))
 
     @pytest.mark.parametrize('y_continuous', (False, True))
     def test_permutation_asymptotic(self, y_continuous):
@@ -51,17 +57,20 @@ class TestChatterjeeXi:
         np.testing.assert_allclose(res.statistic, ref.statistic, rtol=1e-15)
         np.testing.assert_allclose(res.pvalue, ref.pvalue, rtol=2e-2)
 
-    def test_input_validation(self):
+    def test_input_validation(self, xp):
         rng = np.random.default_rng(25932435798274926)
         x, y = rng.random(size=(2, 10))
+        x, y = xp.asarray(x), xp.asarray(y)
 
-        message = 'Array shapes are incompatible for broadcasting.'
-        with pytest.raises(ValueError, match=message):
+        message = 'Array shapes are incompatible for broadcasting.|Incompatible shapes'
+        with pytest.raises((ValueError, TypeError), match=message):
             stats.chatterjeexi(x, y[:-1])
 
-        message = '...axis 10 is out of bounds for array...'
-        with pytest.raises(ValueError, match=message):
-            stats.chatterjeexi(x, y, axis=10)
+        if not is_jax(xp):
+            # jax misses out on some input validation from _axis_nan_policy decorator
+            message = '...axis 10 is out of bounds for array...|out of range'
+            with pytest.raises((ValueError, IndexError), match=message):
+                stats.chatterjeexi(x, y, axis=10)
 
         message = '`y_continuous` must be boolean.'
         with pytest.raises(ValueError, match=message):
@@ -71,10 +80,11 @@ class TestChatterjeeXi:
         with pytest.raises(ValueError, match=message):
             stats.chatterjeexi(x, y, method='ekki ekii')
 
-    def test_special_cases(self):
+    @pytest.mark.skip_xp_backends('jax.numpy', reason='no SmallSampleWarning (lazy)')
+    def test_special_cases(self, xp):
         message = 'One or more sample arguments is too small...'
         with pytest.warns(SmallSampleWarning, match=message):
-            res = stats.chatterjeexi([1], [2])
+            res = stats.chatterjeexi(xp.asarray([1]), xp.asarray([2]))
 
-        assert np.isnan(res.statistic)
-        assert np.isnan(res.pvalue)
+        assert xp.isnan(res.statistic)
+        assert xp.isnan(res.pvalue)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `scipy.stats.chatterjeexi`.

#### Additional information
Dask doesn't have `take_along_axis`, and JAX misses some of the input validation niceties from the `_axis_nan_policy` decorator. Otherwise, everything went pretty smoothly.