### PR TITLE
DOC: spin: Copy-edit help text for python and ipython commands.

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -303,9 +303,13 @@ def _set_pythonpath(pythonpath):
 def python(*, parent_callback, pythonpath, **kwargs):
     """🐍 Launch Python shell with PYTHONPATH set
 
-    OPTIONS are passed through directly to Python, e.g.:
+    OPTIONS refers to the spin command options (see below).
 
-    spin python -c 'import sys; print(sys.path)'
+    The optional PYTHON_ARGS, which must be separated from the
+    spin command options with `--`, are passed directly through to
+    the Python command.  For example,
+
+    spin python -- -c 'import sys; print(sys.path)'
     """
     _set_pythonpath(pythonpath)
     parent_callback(**kwargs)
@@ -317,7 +321,11 @@ def python(*, parent_callback, pythonpath, **kwargs):
 def ipython(*, parent_callback, pythonpath, **kwargs):
     """💻 Launch IPython shell with PYTHONPATH set
 
-    OPTIONS are passed through directly to IPython, e.g.:
+    OPTIONS refers to the spin command options (see below).
+
+    The optional IPYTHON_ARGS, which must be separated from the
+    spin command options with `--`, are passed directly through to
+    the IPython command.  For example,
 
     spin ipython -- -i myscript.py
     """


### PR DESCRIPTION
Closes gh-23760.

After this change, the help output looks like this:

```
$ spin python --help
Usage: spin python [OPTIONS]
                   [PYTHON_ARGS]...

  🐍 Launch Python shell with PYTHONPATH set

  OPTIONS refers to the spin command options (see below).

  The optional PYTHON_ARGS, which must be separated from the spin command options
  with `--`, are passed directly through to the Python command.  For example,

  spin python -- -c 'import sys; print(sys.path)'

Options:
  --no-build                   Disable building before executing command
  -C, --build-dir BUILD_DIR    Meson build directory; package is installed into
                               './{build-dir}-install'.  [env var:
                               SPIN_BUILD_DIR; default: build]
  -p, --pythonpath PYTHONPATH  Paths to prepend to PYTHONPATH
  --help                       Show this message and exit.
```
and
```
$ spin ipython --help
Usage: spin ipython [OPTIONS]
                    [IPYTHON_ARGS]...

  💻 Launch IPython shell with PYTHONPATH set

  OPTIONS refers to the spin command options (see below).

  The optional IPYTHON_ARGS, which must be separated from the spin command options
  with `--`, are passed directly through to the IPython command.  For example,

  spin ipython -- -i myscript.py

Options:
  --no-build                   Disable building before executing command
  -C, --build-dir BUILD_DIR    Meson build directory; package is installed into
                               './{build-dir}-install'.  [env var:
                               SPIN_BUILD_DIR; default: build]
  -p, --pythonpath PYTHONPATH  Paths to prepend to PYTHONPATH
  --help                       Show this message and exit.
```