### PR TITLE
TST: sparse.linalg.tfqmr: avoid failure due to platform-dependent, intermittent divide by zero

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -1,6 +1,7 @@
 """ Test functions for the sparse.linalg._isolve module
 """
 
+from contextlib import nullcontext
 import itertools
 import platform
 import pytest
@@ -542,7 +543,10 @@ def test_show(case, capsys):
     def cb(x):
         pass
 
-    x, info = tfqmr(case.A, case.b, callback=cb, show=True)
+    ctx = np.errstate(divide='ignore') if case.name == "nonsymposdef" else nullcontext()
+    with ctx:
+        x, info = tfqmr(case.A, case.b, callback=cb, show=True)
+
     out, err = capsys.readouterr()
 
     if case.name == "sym-nonpd":

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -543,7 +543,7 @@ def test_show(case, capsys):
     def cb(x):
         pass
 
-    ctx = np.errstate(divide='ignore') if case.name == "nonsymposdef" else nullcontext()
+    ctx = np.errstate(all='ignore') if case.name == "nonsymposdef" else nullcontext()
     with ctx:
         x, info = tfqmr(case.A, case.b, callback=cb, show=True)
 


### PR DESCRIPTION
#### What does this implement/fix?
This attempts to resolve the failure in a test of `tfqmr` in the Accelerate workflow (e.g. [here](https://github.com/scipy/scipy/actions/runs/18784648906)). It seems that `tfqmr` is known to fail in the test case due to algorithmic limitations, so the test is checking for a particular error message. The test fails because there is a divide by zero warning before the desired error occurs. The proposed solution is to avoid failure due to the divide by zero warning; hopefully then the error is emitted as intended. It seems appropriate to silence the warning in just this test case because the problem is only beginning to occur now, and only with Accelerate, and only intermittently. Those with knowledge of `tfqmr` are welcome to investigate further, but we need to keep this from generating false positives in CI.

Note that lack of failure in this CI run does not mean that the problem is resolved since it is intermittent, but if we merge this and it does fail again, at least we'll have more information to go on.