### PR TITLE
TST: stats.boxcox_llf: bump test tolerance

### DIFF
--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2025,7 +2025,7 @@ class TestBoxcox_llf:
         # The expected value was computed with mpsci, set mpmath.mp.dps=100
         # expect float64 output for integer input
         xp_assert_close(llf, xp.asarray(-15.32401272869016598, dtype=xp.float64),
-                        rtol=1e-7)
+                        rtol=5e-7)  # bumped tolerance from 1e-7 for Accelerate
 
     def test_axis(self, xp):
         data = xp.asarray([[100, 200], [300, 400]])


### PR DESCRIPTION
#### Reference issue
Closes gh-23859

#### What does this implement/fix?
Resolves test failure observed in CI by bumping the test tolerance.

#### Additional information
~~Accelerate seems to treat the rules of arithmetic as suggestions. Can we detect the platform in `xp_assert_close` and use that to bump tolerances for Accelerate across the board?~~ Oops, _this_ one isn't Accelerate.
