### PR TITLE
MAINT/TST: stats.yeojohnson_llf/boxcox_llf: fix/test nan_policy/keepdims of public functions

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -996,9 +996,9 @@ def boxcox_llf(lmb, data, *, axis=0, keepdims=False, nan_policy='propagate'):
     # unless necessary.
     kwargs = {}
     if keepdims is not False:
-        kwargs[keepdims] = keepdims
+        kwargs['keepdims'] = keepdims
     if nan_policy != 'propagate':
-        kwargs[nan_policy] = nan_policy
+        kwargs['nan_policy'] = nan_policy
     return _boxcox_llf(data, lmb=lmb, axis=axis, **kwargs)
 
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -73,6 +73,18 @@ def weightedtau_weighted(x, y, rank, **kwargs):
     return stats.weightedtau(x, y, rank, **kwargs)
 
 
+def boxcox_llf(data, lmb, axis=0, _no_deco=False, **kwargs):
+    if _no_deco:
+        return stats._morestats._boxcox_llf(data, lmb=lmb, axis=axis)
+    return stats.boxcox_llf(lmb, data, axis=axis, **kwargs)
+
+
+def yeojohnson_llf(data, lmb, axis=0, _no_deco=False, **kwargs):
+    if _no_deco:
+        return stats._morestats._yeojohnson_llf(data, lmb=lmb, axis=axis)
+    return stats.yeojohnson_llf(lmb, data, axis=axis, **kwargs)
+
+
 axis_nan_policy_cases = [
     # function, args, kwds, number of samples, number of outputs,
     # ... paired, unpacker function
@@ -173,10 +185,8 @@ axis_nan_policy_cases = [
     (gstd, tuple(), dict(), 1, 1, False, lambda x: (x,)),
     (stats.power_divergence, tuple(), dict(), 1, 2, False, None),
     (stats.chisquare, tuple(), dict(), 1, 2, False, None),
-    (stats._morestats._boxcox_llf, tuple(),
-     dict(lmb=1.5), 1, 1, False, lambda x: (x,)),
-    (stats._morestats._yeojohnson_llf, tuple(),
-     dict(lmb=1.5), 1, 1, False, lambda x: (x,)),
+    (boxcox_llf, tuple(), dict(lmb=1.5), 1, 1, False, lambda x: (x,)),
+    (yeojohnson_llf, tuple(), dict(lmb=1.5), 1, 1, False, lambda x: (x,)),
 ]
 
 # If the message is one of those expected, put nans in


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/23807#discussion_r2461320633

#### What does this implement/fix?
https://github.com/scipy/scipy/pull/23807#discussion_r2461320633 caught missing quotes that are needed to make `boxcox_llf` and `yeojohnson_llf` respect their `nan_policy` and `keepdims` arguments. The tests didn't catch the problem because they were run against the private functions (called almost immediately by the public function for technical reasons).
This fixes the bug in `boxcox_llf` (already fixed in `yeojohnson_llf` and adjusts the tests so they would have caught the issue.

#### Additional information
`boxcox_llf` bug (ignoring the new `nan_policy` and `keepdims` arguments) present in SciPy 1.16.2. We could backport the fix, but it wasn't a regression because the features were new, and nobody has reported the issue, so I'm not sure if it's critical.