### PR TITLE
ENH: spatial.transform.Rotation: Add shape to `random` and `identity`

### DIFF
--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -885,24 +885,36 @@ def inv(double[:, :] quat) -> double[:, :]:
 
 
 @cython.embedsignature(True)
+@cython.boundscheck(False)
+@cython.wraparound(False)
 @_transition_to_rng('random_state', position_num=1)
-def random(num=None, rng=None):
+def random(num: int | None = None, rng=None, shape: int | tuple[int, ...] | None = None):
     rng = check_random_state(rng)
-
-    if num is None:
-        sample = rng.normal(size=4)
-    else:
-        sample = rng.normal(size=(num, 4))
-
-    return sample
+    if num is None and shape is None:
+        shape = ()
+    elif num is not None:
+        shape = (num,)
+    elif isinstance(shape, int):
+        shape = (shape,)
+    elif not isinstance(shape, tuple):
+        raise ValueError("`shape` must be an int or a tuple of ints or None.")
+    return rng.normal(size=shape + (4,))
 
 
 @cython.embedsignature(True)
-def identity(num: int | None = None) -> double[:, :]:
-    if num is None:
-        return np.array([0, 0, 0, 1], dtype=np.float64)
-    q = np.zeros((num, 4), dtype=np.float64)
-    q[:, 3] = 1
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def identity(num: int | None, shape: int | tuple[int, ...] | None = None):
+    if num is None and shape is None:
+        shape = ()
+    elif num is not None:
+        shape = (num,)
+    elif isinstance(shape, int):
+        shape = (shape,)
+    elif not isinstance(shape, tuple):
+        raise ValueError("`shape` must be an int or a tuple of ints or None.")
+    q = np.zeros(shape + (4,), dtype=np.float64)
+    q[..., 3] = 1
     return q
 
 

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1689,7 +1689,7 @@ def test_random_rotation():
     assert_equal(Rotation.random(1, rng=rng).as_quat().shape, (1, 4))
     assert_equal(Rotation.random(5, rng=rng).as_quat().shape, (5, 4))
     # Shape argument
-    assert_equal(Rotation.random(rng=rng,shape=()).as_quat().shape, (4,))
+    assert_equal(Rotation.random(rng=rng, shape=()).as_quat().shape, (4,))
     assert_equal(Rotation.random(rng=rng, shape=(3,)).as_quat().shape, (3, 4))
     assert_equal(Rotation.random(rng=rng, shape=(2, 3)).as_quat().shape, (2, 3, 4))
     # Values should be the same for num=prod(shape)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1186,6 +1186,22 @@ def test_single_identity_invariance(xp):
     xp_assert_close(result.magnitude(), xp.zeros(n), atol=atol)
 
 
+def test_identity_shape():  # Not an xp test, identity is using numpy only for now
+    r = Rotation.identity(shape=())
+    assert r.as_quat().shape == (4,)
+    r = Rotation.identity(shape=5)  # Shape can be int
+    assert r.as_quat().shape == (5, 4)
+    r = Rotation.identity(shape=(2, 3))
+    assert r.as_quat().shape == (2, 3, 4)
+    # Errors
+    with pytest.raises(ValueError, match="`shape` must be an int or a tuple of ints"):
+        Rotation.identity(shape=2.5)
+    with pytest.raises(ValueError, match="Only one of `num` or `shape` can be"):
+        Rotation.identity(num=3, shape=(2, 2))
+    with pytest.raises(TypeError, match="takes from 0 to 1 positional arguments"):
+        Rotation.identity(3, 3)
+
+
 @make_xp_test_case(Rotation.magnitude)
 @pytest.mark.parametrize("ndim", range(1, 4))
 def test_magnitude(xp, ndim: int):
@@ -1664,12 +1680,22 @@ def test_n_rotations(xp):
 
 def test_random_rotation_shape():
     # No xp testing since random rotations are always using NumPy
-    rng = np.random.default_rng(146972845698875399755764481408308808739)
+    rng = np.random.default_rng(0)
     assert_equal(Rotation.random(rng=rng).as_quat().shape, (4,))
     assert_equal(Rotation.random(None, rng=rng).as_quat().shape, (4,))
-
     assert_equal(Rotation.random(1, rng=rng).as_quat().shape, (1, 4))
     assert_equal(Rotation.random(5, rng=rng).as_quat().shape, (5, 4))
+    # Shape argument
+    assert_equal(Rotation.random(rng=rng,shape=()).as_quat().shape, (4,))
+    assert_equal(Rotation.random(rng=rng, shape=(3,)).as_quat().shape, (3, 4))
+    assert_equal(Rotation.random(rng=rng, shape=(2, 3)).as_quat().shape, (2, 3, 4))
+    # Errors
+    with pytest.raises(ValueError, match="Only one of `num` or `shape` can be"):
+        Rotation.random(num=3,rng=rng, shape=(2, 2))
+    with pytest.raises(ValueError, match="`shape` must be an int or a tuple of ints"):
+        Rotation.random(rng=rng, shape=2.5)
+    with pytest.raises(TypeError, match="takes from 0 to 2 positional arguments"):
+        Rotation.random(1, rng, None)  # Shape should be kwarg only
 
 
 @make_xp_test_case(Rotation.align_vectors, Rotation.as_matrix)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1193,6 +1193,9 @@ def test_identity_shape():  # Not an xp test, identity is using numpy only for n
     assert r.as_quat().shape == (5, 4)
     r = Rotation.identity(shape=(2, 3))
     assert r.as_quat().shape == (2, 3, 4)
+    # Test values
+    r = Rotation.identity(shape=(2, 2, 3))
+    xp_assert_equal(r.as_quat().reshape(-1, 4), np.tile(np.eye(4)[-1], (2 * 2 * 3, 1)))
     # Errors
     with pytest.raises(ValueError, match="`shape` must be an int or a tuple of ints"):
         Rotation.identity(shape=2.5)
@@ -1678,7 +1681,7 @@ def test_n_rotations(xp):
     assert_equal(len(r[:-1]), 1)
 
 
-def test_random_rotation_shape():
+def test_random_rotation():
     # No xp testing since random rotations are always using NumPy
     rng = np.random.default_rng(0)
     assert_equal(Rotation.random(rng=rng).as_quat().shape, (4,))
@@ -1689,6 +1692,11 @@ def test_random_rotation_shape():
     assert_equal(Rotation.random(rng=rng,shape=()).as_quat().shape, (4,))
     assert_equal(Rotation.random(rng=rng, shape=(3,)).as_quat().shape, (3, 4))
     assert_equal(Rotation.random(rng=rng, shape=(2, 3)).as_quat().shape, (2, 3, 4))
+    # Values should be the same for num=prod(shape)
+    rng1, rng2 = np.random.default_rng(42), np.random.default_rng(42)
+    r_num = Rotation.random(6, rng=rng1)
+    r_shape = Rotation.random(rng=rng2, shape=(2, 3))
+    xp_assert_equal(r_num.as_quat(), r_shape.as_quat().reshape(6, 4))
     # Errors
     with pytest.raises(ValueError, match="Only one of `num` or `shape` can be"):
         Rotation.random(num=3,rng=rng, shape=(2, 2))


### PR DESCRIPTION
Implements the `shape` kwarg-only argument for `Rotation.random` and `Rotation.identity`.

#### Reference issue
Contributes towards #23391

#### What does this implement/fix?
Adds the shape argument to `Rotation.random` and `Rotation.identity`.

#### Additional information
We should decide what to do about deprecations. In its current form, shape could replace num easily since it can be both a `tuple[int, ...]` as well as an `int`.
