### PR TITLE
ENH: spatial.transform.RigidTransform: implement `shape` for `identity`

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -863,7 +863,9 @@ class RigidTransform:
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]
     )
-    def identity(num: int | None = None) -> RigidTransform:
+    def identity(
+        num: int | None = None, *, shape: int | tuple[int, ...] | None = None
+    ) -> RigidTransform:
         """Initialize an identity transform.
 
         Composition with the identity transform has no effect, and
@@ -874,6 +876,9 @@ class RigidTransform:
         num : int, optional
             Number of identity transforms to generate. If None (default),
             then a single transform is generated.
+        shape : int or tuple of ints, optional
+            Shape of the identity transforms. If specified, `num` must
+            be None.
 
         Returns
         -------
@@ -930,10 +935,17 @@ class RigidTransform:
         >>> len(tf)
         2
         """
-        if num is None:
-            matrix = np.eye(4)
-        else:
-            matrix = np.tile(np.eye(4), (num, 1, 1))
+        if num is not None and shape is not None:
+            raise ValueError("Only one of `num` and `shape` can be specified.")
+        if num is None and shape is None:
+            shape = ()
+        elif num is not None:
+            shape = (num,)
+        elif isinstance(shape, int):
+            shape = (shape,)
+        elif not isinstance(shape, tuple):
+            raise ValueError("`shape` must be an int or a tuple of ints or None.")
+        matrix = np.tile(np.eye(4), shape + (1, 1))
         # No need for a backend call here since identity is easy to construct and we are
         # currently not offering a backend-specific identity matrix
         return RigidTransform._from_raw_matrix(matrix, array_namespace(matrix))

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -684,7 +684,7 @@ def test_identity():
     expected = np.tile(np.eye(4), (2, 3, 1, 1))
     xp_assert_close(tf.as_matrix(), expected, atol=atol)
     # Test errors
-    with pytest.raises(ValueError, match="Only one of `num` and `shape` can be specified."):
+    with pytest.raises(ValueError, match="Only one of `num` and `shape` can be."):
         RigidTransform.identity(10, shape=(2, 3))
     with pytest.raises(TypeError, match="takes from 0 to 1 positional arguments"):
         RigidTransform.identity(None, (-1, 3))  # Shape is kwarg only

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -670,14 +670,26 @@ def test_from_as_internal_consistency(xp, ndim: int):
 def test_identity():
     # We do not use xp here because identity always returns numpy arrays
     atol = 1e-12
-
     # Test single identity
     tf = RigidTransform.identity()
     xp_assert_close(tf.as_matrix(), np.eye(4), atol=atol)
-
     # Test multiple identities
     tf = RigidTransform.identity(5)
     xp_assert_close(tf.as_matrix(), np.array([np.eye(4)] * 5), atol=atol)
+    # Test shape
+    tf = RigidTransform.identity(shape=3)
+    expected = np.tile(np.eye(4), (3, 1, 1))
+    xp_assert_close(tf.as_matrix(), expected, atol=atol)
+    tf = RigidTransform.identity(shape=(2, 3))
+    expected = np.tile(np.eye(4), (2, 3, 1, 1))
+    xp_assert_close(tf.as_matrix(), expected, atol=atol)
+    # Test errors
+    with pytest.raises(ValueError, match="Only one of `num` and `shape` can be specified."):
+        RigidTransform.identity(10, shape=(2, 3))
+    with pytest.raises(TypeError, match="takes from 0 to 1 positional arguments"):
+        RigidTransform.identity(None, (-1, 3))  # Shape is kwarg only
+    with pytest.raises(ValueError, match="`shape` must be an int or a tuple of ints"):
+        RigidTransform.identity(shape="invalid")
 
 
 @make_xp_test_case(RigidTransform.apply)


### PR DESCRIPTION
Implements the shape kwarg-only argument for `RigidTransform.identity`. This PR mirrors #23869, but does not include a `random` method since there is no `random` method for `RigidTransform`.

#### Reference issue
Contributes towards #23391

#### What does this implement/fix?
Adds the shape argument to `RigidTransform.identity`.

#### Additional information
Same as in #23869, we should talk about deprecating `num` at some point. In its current form, `shape` could replace `num` easily since it can be both a `tuple[int, ...]` as well as an `int`.