### PR TITLE
TST: interpolate.AAA: bump test tolerance

### DIFF
--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -199,7 +199,7 @@ class TestAAA:
     @pytest.mark.parametrize("func,atol,rtol",
                              [(lambda x: np.abs(x + 0.5 + 0.01j), 5e-13, 1e-7),
                               (lambda x: np.sin(1/(1.05 - x)), 2e-13, 1e-7),
-                              (lambda x: np.exp(-1/(x**2)), 3.5e-12, 0),
+                              (lambda x: np.exp(-1/(x**2)), 3.5e-11, 0),
                               (lambda x: np.exp(-100*x**2), 2e-12, 0),
                               (lambda x: np.exp(-10/(1.2 - x)), 1e-14, 0),
                               (lambda x: 1/(1+np.exp(100*(x + 0.5))), 2e-13, 1e-7),


### PR DESCRIPTION
#### What does this implement/fix?
A test of `interpolate.AAA` is failing in one workflow in main; e.g. https://github.com/scipy/scipy/actions/runs/18882816360/job/53890350662?pr=23878. This bumps the tolerance.

#### Additional information
@j-bowhay does this look safe?