### PR TITLE
DOC: forward port 1.16.3 relnotes

### DIFF
--- a/doc/source/release.rst
+++ b/doc/source/release.rst
@@ -9,6 +9,7 @@ see the `commit logs <https://github.com/scipy/scipy/commits/>`_.
    :maxdepth: 1
 
    release/1.17.0-notes
+   release/1.16.3-notes
    release/1.16.2-notes
    release/1.16.1-notes
    release/1.16.0-notes

--- a/doc/source/release/1.16.3-notes.rst
+++ b/doc/source/release/1.16.3-notes.rst
@@ -1,0 +1,54 @@
+==========================
+SciPy 1.16.3 Release Notes
+==========================
+
+.. contents::
+
+SciPy 1.16.3 is a bug-fix release with no new features
+compared to 1.16.2.
+
+
+
+Authors
+=======
+* Name (commits)
+* ChrisAB (1) +
+* Lucas Colley (1)
+* Ralf Gommers (3)
+* Matt Haberland (8)
+* Nick ODell (2)
+* Ilhan Polat (1)
+* Tyler Reddy (28)
+* Lucas Roberts (2)
+
+    A total of 8 people contributed to this release.
+    People with a "+" by their names contributed a patch for the first time.
+    This list of names is automatically generated, and may not be fully complete.
+
+
+Issues closed for 1.16.3
+------------------------
+
+* `#23336 <https://github.com/scipy/scipy/issues/23336>`__: BUG: linalg: wrong handling of args/kwargs in ``_apply_over_batch``
+* `#23469 <https://github.com/scipy/scipy/issues/23469>`__: BUG: huge speed and quality regression for stats.multivariate_normal.cdf
+* `#23589 <https://github.com/scipy/scipy/issues/23589>`__: BUG: ``lqmn(1,1,0)`` and ``lqmn(1,1,0j)`` return incompatible...
+* `#23642 <https://github.com/scipy/scipy/issues/23642>`__: CI: meson setup fails with "invalid int value: 'Sentinel.UNSET'"
+* `#23738 <https://github.com/scipy/scipy/issues/23738>`__: BUG: ``special.expi(inf)`` is ``nan``\ , should be ``inf``
+* `#23820 <https://github.com/scipy/scipy/issues/23820>`__: MAINT, TST: optimize test_input_validation torch failure
+* `#23859 <https://github.com/scipy/scipy/issues/23859>`__: TST, MAINT: boxcox_llf failing again
+
+
+Pull requests for 1.16.3
+------------------------
+
+* `#23602 <https://github.com/scipy/scipy/pull/23602>`__: REL, MAINT: prepare for SciPy 1.16.3
+* `#23615 <https://github.com/scipy/scipy/pull/23615>`__: TST, MAINT: backports, restore lfilter
+* `#23681 <https://github.com/scipy/scipy/pull/23681>`__: BUG: linalg:solve...are: fix bug when optional array is skipped
+* `#23685 <https://github.com/scipy/scipy/pull/23685>`__: MAINT: optimize: fix usage of ``nextafter(..., where=)`` without...
+* `#23777 <https://github.com/scipy/scipy/pull/23777>`__: CI: pin Python 3.11.13 in CircleCI job
+* `#23787 <https://github.com/scipy/scipy/pull/23787>`__: BUG:optimize:SLSQP: Use double negative in an if condition for...
+* `#23815 <https://github.com/scipy/scipy/pull/23815>`__: ENH: scipy.stats: speed up bivariate normal cdf
+* `#23817 <https://github.com/scipy/scipy/pull/23817>`__: BUG/TST: Bump xsf to v0.1.3 add tests for expi limits
+* `#23821 <https://github.com/scipy/scipy/pull/23821>`__: CI: optimize: allow new Pytorch message
+* `#23829 <https://github.com/scipy/scipy/pull/23829>`__: MAINT: patch vendored qhull source for security fix
+* `#23864 <https://github.com/scipy/scipy/pull/23864>`__: TST: stats.boxcox_llf: bump test tolerance


### PR DESCRIPTION
* Forward port the SciPy `1.16.3` release notes following the release this morning.

* Note that this patch does not include a version switcher update because we're trying to avoid some infrastructure taxing issues with patch release doc uploads that have effectively no changes as noted at:
https://github.com/scipy/docs.scipy.org/issues/102#issuecomment-3418039816

[docs only]
