### PR TITLE
DOC: cluster: move linkage matrix explanation to linkage docstring

### DIFF
--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -968,54 +968,54 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
 
         .. versionadded:: 1.0.0
 
-Returns
--------
-Z : ndarray
-    The hierarchical clustering encoded as a linkage matrix.
+    Returns
+    -------
+    Z : ndarray
+        The hierarchical clustering encoded as a linkage matrix.
 
-Notes
------
-The linkage matrix ``Z`` represents the hierarchical clustering as a
-dendrogram. It has shape ``(n - 1, 4)``, where each row
-``[idx1, idx2, dist, sample_count]`` corresponds to a single merge
-operation performed during clustering.
+    Notes
+    -----
+        The linkage matrix ``Z`` represents the hierarchical clustering as a
+        dendrogram. It has shape ``(n - 1, 4)``, where each row
+        ``[idx1, idx2, dist, sample_count]`` corresponds to a single merge
+        operation performed during clustering.
 
-- ``idx1`` and ``idx2`` are the cluster indices merged at this step.
-  Clusters with indices less than ``n`` correspond to original observations.
-- ``dist`` is the distance between these clusters at the time of merging.
-- ``sample_count`` is the number of original observations contained in the
-  newly formed cluster.
+        - ``idx1`` and ``idx2`` are the cluster indices merged at this step.
+          Clusters with indices less than ``n`` correspond to original observations.
+        - ``dist`` is the distance between these clusters at the time of merging.
+        - ``sample_count`` is the number of original observations contained in the
+          newly formed cluster.
 
-Algorithmically:
-1. Each observation is initially assigned to its own single-element cluster,
-   where the cluster index equals the observation index (0 to n-1).
-2. At each merge step, two clusters are combined into a new cluster.
-   The newly formed cluster is assigned an index starting from ``n``,
-   increasing by one at each step.
-   Thus, the cluster created at merge step ``i`` receives index ``n + i``.
+        Algorithmically:
+        1. Each observation is initially assigned to its own single-element cluster,
+           where the cluster index equals the observation index (0 to n-1).
+        2. At each merge step, two clusters are combined into a new cluster.
+           The newly formed cluster is assigned an index starting from ``n``,
+           increasing by one at each step.
+           Thus, the cluster created at merge step ``i`` receives index ``n + i``.
 
-This convention ensures that clusters with indices less than ``n``
-represent original observations, while clusters with indices greater than
-or equal to ``n`` correspond to clusters formed during the hierarchy
-construction.
+        This convention ensures that clusters with indices less than ``n``
+        represent original observations, while clusters with indices greater than
+        or equal to ``n`` correspond to clusters formed during the hierarchy
+        construction.
 
-This matrix can be visualized as a dendrogram; see
-:func:`scipy.cluster.hierarchy.dendrogram` for examples.
+        This matrix can be visualized as a dendrogram; see
+        :func:`scipy.cluster.hierarchy.dendrogram` for examples.
 
-1. For method 'single', an optimized algorithm based on minimum spanning
-   tree is implemented. It has time complexity :math:`O(n^2)`.
-   For methods 'complete', 'average', 'weighted', and 'ward', an algorithm
-   called nearest-neighbors chain is implemented. It also has time
-   complexity :math:`O(n^2)`.
-   For other methods, a naive algorithm is implemented with
-   :math:`O(n^3)` time complexity.
-   All algorithms use :math:`O(n^2)` memory.
-   Refer to [1]_ for details about the algorithms.
+        1. For method 'single', an optimized algorithm based on minimum spanning
+           tree is implemented. It has time complexity :math:`O(n^2)`.
+           For methods 'complete', 'average', 'weighted', and 'ward', an algorithm
+           called nearest-neighbors chain is implemented. It also has time
+           complexity :math:`O(n^2)`.
+           For other methods, a naive algorithm is implemented with
+           :math:`O(n^3)` time complexity.
+           All algorithms use :math:`O(n^2)` memory.
+           Refer to [1]_ for details about the algorithms.
 
-2. Methods 'centroid', 'median', and 'ward' are correctly defined only if
-   the Euclidean pairwise metric is used. If `y` is passed as precomputed
-   pairwise distances, then it is the user's responsibility to ensure that
-   these distances are Euclidean; otherwise, the result will be incorrect.
+        2. Methods 'centroid', 'median', and 'ward' are correctly defined only if
+           the Euclidean pairwise metric is used. If `y` is passed as precomputed
+           pairwise distances, then it is the user's responsibility to ensure that
+           these distances are Euclidean; otherwise, the result will be incorrect.
 
 See Also
 --------

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -973,37 +973,49 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     Z : ndarray
     The hierarchical clustering encoded as a linkage matrix.
 
-    The linkage matrix ``Z`` has shape ``(n-1, 4)``, where each row
-    ``[idx1, idx2, dist, sample_count]`` represents a merge in the
-    hierarchical clustering:
-    
-    * ``idx1`` and ``idx2`` — indices of the clusters that were merged.
-      Clusters numbered less than ``n`` correspond to original observations.
-    * ``dist`` — the distance between those clusters at the time of merging.
-    * ``sample_count`` — the total number of original observations
-      contained in the newly formed cluster.
+       Notes
+    -----
+    The linkage matrix ``Z`` represents the hierarchical clustering as a
+    dendrogram. It has shape ``(n - 1, 4)``, where each row
+    ``[idx1, idx2, dist, sample_count]`` corresponds to a single merge
+    operation performed during clustering.
+
+    - ``idx1`` and ``idx2`` are the cluster indices merged at this step.
+      Clusters with indices less than ``n`` correspond to original observations.
+    - ``dist`` is the distance between these clusters at the time of merging.
+    - ``sample_count`` is the number of original observations contained in the
+      newly formed cluster.
+
+    Algorithmically:
+    1. Each observation is initially assigned to its own single-element cluster,
+       where the cluster index equals the observation index (0 to n-1).
+    2. At each merge step, two clusters are combined into a new cluster.
+       The newly formed cluster is assigned an index starting from ``n``,
+       increasing by one at each step.  
+       Thus, the cluster created at merge step ``i`` receives index ``n + i``.
+
+    This convention ensures that clusters with indices less than ``n``
+    represent original observations, while clusters with indices greater than
+    or equal to ``n`` correspond to clusters formed during the hierarchy
+    construction.
 
     This matrix can be visualized as a dendrogram; see
-    :func:`scipy.cluster.hierarchy.dendrogram`.
+    :func:`scipy.cluster.hierarchy.dendrogram` for examples.
 
-
-
-    Notes
-    -----
+>>>>>>> Stashed changes
     1. For method 'single', an optimized algorithm based on minimum spanning
        tree is implemented. It has time complexity :math:`O(n^2)`.
-       For methods 'complete', 'average', 'weighted' and 'ward', an algorithm
+       For methods 'complete', 'average', 'weighted', and 'ward', an algorithm
        called nearest-neighbors chain is implemented. It also has time
        complexity :math:`O(n^2)`.
-       For other methods, a naive algorithm is implemented with :math:`O(n^3)`
-       time complexity.
+       For other methods, a naive algorithm is implemented with
+       :math:`O(n^3)` time complexity.
        All algorithms use :math:`O(n^2)` memory.
        Refer to [1]_ for details about the algorithms.
     2. Methods 'centroid', 'median', and 'ward' are correctly defined only if
-       Euclidean pairwise metric is used. If `y` is passed as precomputed
-       pairwise distances, then it is the user's responsibility to assure that
-       these distances are in fact Euclidean, otherwise the produced result
-       will be incorrect.
+       the Euclidean pairwise metric is used. If `y` is passed as precomputed
+       pairwise distances, then it is the user's responsibility to ensure that
+       these distances are Euclidean; otherwise, the result will be incorrect.
 
     See Also
     --------

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -971,7 +971,22 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     Returns
     -------
     Z : ndarray
-        The hierarchical clustering encoded as a linkage matrix.
+    The hierarchical clustering encoded as a linkage matrix.
+
+    The linkage matrix ``Z`` has shape ``(n-1, 4)``, where each row
+    ``[idx1, idx2, dist, sample_count]`` represents a merge in the
+    hierarchical clustering:
+    
+    * ``idx1`` and ``idx2`` — indices of the clusters that were merged.
+      Clusters numbered less than ``n`` correspond to original observations.
+    * ``dist`` — the distance between those clusters at the time of merging.
+    * ``sample_count`` — the total number of original observations
+      contained in the newly formed cluster.
+
+    This matrix can be visualized as a dendrogram; see
+    :func:`scipy.cluster.hierarchy.dendrogram`.
+
+
 
     Notes
     -----
@@ -2626,10 +2641,8 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
            [18.        , 19.        ,  5.77350269,  6.        ],
            [20.        , 21.        ,  8.16496581, 12.        ]])
 
-    This matrix represents a dendrogram, where the first and second elements
-    are the two clusters merged at each step, the third element is the
-    distance between these clusters, and the fourth element is the size of
-    the new cluster - the number of original data points included.
+    For more details about the structure and interpretation of the linkage
+    matrix, see :func:`scipy.cluster.hierarchy.linkage`.
 
     `scipy.cluster.hierarchy.fcluster` can be used to flatten the
     dendrogram, obtaining as a result an assignation of the original data

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -968,81 +968,81 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
 
         .. versionadded:: 1.0.0
 
-    Returns
-    -------
-    Z : ndarray
+Returns
+-------
+Z : ndarray
     The hierarchical clustering encoded as a linkage matrix.
 
-       Notes
-    -----
-    The linkage matrix ``Z`` represents the hierarchical clustering as a
-    dendrogram. It has shape ``(n - 1, 4)``, where each row
-    ``[idx1, idx2, dist, sample_count]`` corresponds to a single merge
-    operation performed during clustering.
+Notes
+-----
+The linkage matrix ``Z`` represents the hierarchical clustering as a
+dendrogram. It has shape ``(n - 1, 4)``, where each row
+``[idx1, idx2, dist, sample_count]`` corresponds to a single merge
+operation performed during clustering.
 
-    - ``idx1`` and ``idx2`` are the cluster indices merged at this step.
-      Clusters with indices less than ``n`` correspond to original observations.
-    - ``dist`` is the distance between these clusters at the time of merging.
-    - ``sample_count`` is the number of original observations contained in the
-      newly formed cluster.
+- ``idx1`` and ``idx2`` are the cluster indices merged at this step.
+  Clusters with indices less than ``n`` correspond to original observations.
+- ``dist`` is the distance between these clusters at the time of merging.
+- ``sample_count`` is the number of original observations contained in the
+  newly formed cluster.
 
-    Algorithmically:
-    1. Each observation is initially assigned to its own single-element cluster,
-       where the cluster index equals the observation index (0 to n-1).
-    2. At each merge step, two clusters are combined into a new cluster.
-       The newly formed cluster is assigned an index starting from ``n``,
-       increasing by one at each step.  
-       Thus, the cluster created at merge step ``i`` receives index ``n + i``.
+Algorithmically:
+1. Each observation is initially assigned to its own single-element cluster,
+   where the cluster index equals the observation index (0 to n-1).
+2. At each merge step, two clusters are combined into a new cluster.
+   The newly formed cluster is assigned an index starting from ``n``,
+   increasing by one at each step.
+   Thus, the cluster created at merge step ``i`` receives index ``n + i``.
 
-    This convention ensures that clusters with indices less than ``n``
-    represent original observations, while clusters with indices greater than
-    or equal to ``n`` correspond to clusters formed during the hierarchy
-    construction.
+This convention ensures that clusters with indices less than ``n``
+represent original observations, while clusters with indices greater than
+or equal to ``n`` correspond to clusters formed during the hierarchy
+construction.
 
-    This matrix can be visualized as a dendrogram; see
-    :func:`scipy.cluster.hierarchy.dendrogram` for examples.
+This matrix can be visualized as a dendrogram; see
+:func:`scipy.cluster.hierarchy.dendrogram` for examples.
 
->>>>>>> Stashed changes
-    1. For method 'single', an optimized algorithm based on minimum spanning
-       tree is implemented. It has time complexity :math:`O(n^2)`.
-       For methods 'complete', 'average', 'weighted', and 'ward', an algorithm
-       called nearest-neighbors chain is implemented. It also has time
-       complexity :math:`O(n^2)`.
-       For other methods, a naive algorithm is implemented with
-       :math:`O(n^3)` time complexity.
-       All algorithms use :math:`O(n^2)` memory.
-       Refer to [1]_ for details about the algorithms.
-    2. Methods 'centroid', 'median', and 'ward' are correctly defined only if
-       the Euclidean pairwise metric is used. If `y` is passed as precomputed
-       pairwise distances, then it is the user's responsibility to ensure that
-       these distances are Euclidean; otherwise, the result will be incorrect.
+1. For method 'single', an optimized algorithm based on minimum spanning
+   tree is implemented. It has time complexity :math:`O(n^2)`.
+   For methods 'complete', 'average', 'weighted', and 'ward', an algorithm
+   called nearest-neighbors chain is implemented. It also has time
+   complexity :math:`O(n^2)`.
+   For other methods, a naive algorithm is implemented with
+   :math:`O(n^3)` time complexity.
+   All algorithms use :math:`O(n^2)` memory.
+   Refer to [1]_ for details about the algorithms.
 
-    See Also
-    --------
-    scipy.spatial.distance.pdist : pairwise distance metrics
+2. Methods 'centroid', 'median', and 'ward' are correctly defined only if
+   the Euclidean pairwise metric is used. If `y` is passed as precomputed
+   pairwise distances, then it is the user's responsibility to ensure that
+   these distances are Euclidean; otherwise, the result will be incorrect.
 
-    References
-    ----------
-    .. [1] Daniel Mullner, "Modern hierarchical, agglomerative clustering
-           algorithms", :arXiv:`1109.2378v1`.
-    .. [2] Ziv Bar-Joseph, David K. Gifford, Tommi S. Jaakkola, "Fast optimal
-           leaf ordering for hierarchical clustering", 2001. Bioinformatics
-           :doi:`10.1093/bioinformatics/17.suppl_1.S22`
+See Also
+--------
+scipy.spatial.distance.pdist : pairwise distance metrics
 
-    Examples
-    --------
-    >>> from scipy.cluster.hierarchy import dendrogram, linkage
-    >>> from matplotlib import pyplot as plt
-    >>> X = [[i] for i in [2, 8, 0, 4, 1, 9, 9, 0]]
+References
+----------
+.. [1] Daniel Mullner, "Modern hierarchical, agglomerative clustering
+       algorithms", :arXiv:`1109.2378v1`.
+.. [2] Ziv Bar-Joseph, David K. Gifford, Tommi S. Jaakkola, "Fast optimal
+       leaf ordering for hierarchical clustering", 2001. Bioinformatics
+       :doi:`10.1093/bioinformatics/17.suppl_1.S22`
 
-    >>> Z = linkage(X, 'ward')
-    >>> fig = plt.figure(figsize=(25, 10))
-    >>> dn = dendrogram(Z)
+Examples
+--------
+>>> from scipy.cluster.hierarchy import dendrogram, linkage
+>>> from matplotlib import pyplot as plt
+>>> X = [[i] for i in [2, 8, 0, 4, 1, 9, 9, 0]]
 
-    >>> Z = linkage(X, 'single')
-    >>> fig = plt.figure(figsize=(25, 10))
-    >>> dn = dendrogram(Z)
-    >>> plt.show()
+>>> Z = linkage(X, 'ward')
+>>> fig = plt.figure(figsize=(25, 10))
+>>> dn = dendrogram(Z)
+
+>>> Z = linkage(X, 'single')
+>>> fig = plt.figure(figsize=(25, 10))
+>>> dn = dendrogram(Z)
+>>> plt.show()
     """
     xp = array_namespace(y)
     y = _asarray(y, order='C', dtype=xp.float64, xp=xp)

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -27,7 +27,18 @@ class _data_matrix(_spbase):
 
     @dtype.setter
     def dtype(self, newtype):
-        self.data = self.data.view(newtype)
+    """
+    Set the dtype by creating a view with the requested dtype rather
+    than assigning to the .dtype attribute directly (deprecated).
+    """
+    # Ensure newtype is accepted by numpy (allows strings, dtype objects, etc.)
+    import numpy as _np
+    newdtype = _np.dtype(newtype)
+
+    # Create a view with the requested dtype instead of setting .dtype
+    # This usually returns a view (no copy). If a copy is unavoidable,
+    # that's expected given numpy deprecation guidance.
+    self.data = self.data.view(newdtype)
 
     def _deduped_data(self):
         if hasattr(self, 'sum_duplicates'):

--- a/scipy/sparse/_data.py
+++ b/scipy/sparse/_data.py
@@ -27,18 +27,7 @@ class _data_matrix(_spbase):
 
     @dtype.setter
     def dtype(self, newtype):
-    """
-    Set the dtype by creating a view with the requested dtype rather
-    than assigning to the .dtype attribute directly (deprecated).
-    """
-    # Ensure newtype is accepted by numpy (allows strings, dtype objects, etc.)
-    import numpy as _np
-    newdtype = _np.dtype(newtype)
-
-    # Create a view with the requested dtype instead of setting .dtype
-    # This usually returns a view (no copy). If a copy is unavoidable,
-    # that's expected given numpy deprecation guidance.
-    self.data = self.data.view(newdtype)
+        self.data = self.data.view(newtype)
 
     def _deduped_data(self):
         if hasattr(self, 'sum_duplicates'):


### PR DESCRIPTION
docs: move linkage matrix explanation to linkage docstring and add cross-reference in fcluster

This PR moves the linkage matrix explanation from `fcluster` to the `linkage` docstring for better clarity,
and adds a cross-reference to the linkage documentation.

closes gh-23886