### PR TITLE
MAINT: stats.epps_singleton_2samp: NaNs/Infs in input -> NaNs in output

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8433,7 +8433,7 @@ def kruskal(*samples, nan_policy='propagate', axis=0):
           * 'propagate': returns nan
           * 'raise': throws an error
           * 'omit': performs the calculations ignoring nan values
-    axis : int or tuple of ints, default: None
+    axis : int or tuple of ints, default: 0
         If an int or tuple of ints, the axis or axes of the input along which
         to compute the statistic. The statistic of each axis-slice (e.g. row)
         of the input will appear in a corresponding element of the output.

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -79,8 +79,8 @@ class TestEppsSingleton:
         y[i[2], 2] = -np.inf
         w_res, p_res = epps_singleton_2samp(x, y, axis=-1)
 
-        assert_equal(w_ref, w_res)
-        assert_equal(p_ref, p_res)
+        assert_allclose(w_res, w_ref)
+        assert_allclose(p_res, p_ref)
 
     def test_names(self):
         x, y = np.arange(20), np.arange(30)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -65,9 +65,22 @@ class TestEppsSingleton:
             assert_equal(res.pvalue, np.nan)
 
     def test_epps_singleton_nonfinite(self):
-        # raise error if there are non-finite values
-        x, y = (1, 2, 3, 4, 5, np.inf), np.arange(10)
-        assert_raises(ValueError, epps_singleton_2samp, x, y)
+        rng = np.random.default_rng(83249872384543)
+        x = rng.random(size=(10, 11))
+        y = rng.random(size=(10, 12))
+        i = np.asarray([1, 4, 9])  # arbitrary rows
+
+        w_ref, p_ref = epps_singleton_2samp(x, y, axis=-1)
+        w_ref[i] = np.nan
+        p_ref[i] = np.nan
+
+        x[i[0], 0] = np.nan
+        x[i[1], 1] = np.inf
+        y[i[2], 2] = -np.inf
+        w_res, p_res = epps_singleton_2samp(x, y, axis=-1)
+
+        assert_equal(w_ref, w_res)
+        assert_equal(p_ref, p_res)
 
     def test_names(self):
         x, y = np.arange(20), np.arange(30)


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-23881

#### What does this implement/fix?
Currently, NaNs in the input of `epps_singleton_2samp` produce NaNs in the output, whereas Infs result in an error. Either the way, the calculation can't produce a valid number (e.g. in the Inf case, we have sines and cosines of infinity), so let's keep the result consistent. Now that the function is vectorized, it is preferable to return normally with NaNs in the output that correspond with affected slices. This PR makes that change.

#### Additional information
@j-bowhay also replaced `axis : None` with `axis : 0` as appropriate in the documentation of `epps_singleton_2samp` and `kruskal`.