### PR TITLE
BUG: linalg: fix MKL ILP64 symbol misnamings

### DIFF
--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -87,6 +87,7 @@ CONFIG = _cleanup(
                 "lib directory": r"@BLAS_LIBDIR@",
                 "openblas configuration": r"@BLAS_OPENBLAS_CONFIG@",
                 "pc file directory": r"@BLAS_PCFILEDIR@",
+                "has ilp64": bool(r"@BLAS_HAS_ILP64@".lower().replace('false', '')),
             },
             "lapack": {
                 "name": "@LAPACK_NAME@",
@@ -97,6 +98,7 @@ CONFIG = _cleanup(
                 "lib directory": r"@LAPACK_LIBDIR@",
                 "openblas configuration": r"@LAPACK_OPENBLAS_CONFIG@",
                 "pc file directory": r"@LAPACK_PCFILEDIR@",
+                "has ilp64": bool(r"@LAPACK_HAS_ILP64@".lower().replace('false', '')),
             },
             "pybind11": {
                 "name": "@PYBIND11_NAME@",

--- a/scipy/_build_utils/src/_blas64_defines.h
+++ b/scipy/_build_utils/src/_blas64_defines.h
@@ -50,6 +50,12 @@
 // https://community.intel.com/t5/Intel-oneAPI-Math-Kernel-Library/Missing-cspr-64-symbol-in-ILP64-MKL/td-p/1703471
 #ifdef FIX_MKL_2025_ILP64_MISSING_SYMBOL
 #define cspr_64_ cspr_64
+#define sgetc2_64_ sgetc2_64
+#define dgetc2_64_ dgetc2_64
+#define cgetc2_64_ cgetc2_64
+#define zgetc2_64_ zgetc2_64
+#define slasd4_64_ slasd4_64
+#define dlasd4_64_ dlasd4_64
 #endif
 
 #define F_INT npy_int64

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -227,12 +227,12 @@ try:
 except ImportError:
     _cblas = None
 
-try:
+from scipy.__config__ import CONFIG
+HAS_ILP64 = CONFIG['Build Dependencies']['blas']['has ilp64']
+del CONFIG
+_fblas_64 = None
+if HAS_ILP64:
     from scipy.linalg import _fblas_64
-    HAS_ILP64 = True
-except ImportError:
-    HAS_ILP64 = False
-    _fblas_64 = None
 
 # Expose all functions (only fblas --- cblas is an implementation detail)
 empty_module = None

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -875,12 +875,12 @@ try:
 except ImportError:
     _clapack = None
 
-try:
+from scipy.__config__ import CONFIG
+HAS_ILP64 = CONFIG['Build Dependencies']['lapack']['has ilp64']
+del CONFIG
+_flapack_64 = None
+if HAS_ILP64:
     from scipy.linalg import _flapack_64
-    HAS_ILP64 = True
-except ImportError:
-    HAS_ILP64 = False
-    _flapack_64 = None
 
 
 # Expose all functions (only flapack --- clapack is an implementation detail)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -35,10 +35,7 @@ from scipy.sparse._sputils import matrix
 from scipy._lib._testutils import check_free_memory
 from scipy.linalg.blas import HAS_ILP64
 from scipy.conftest import skip_xp_invalid_arg
-try:
-    from scipy.__config__ import CONFIG
-except ImportError:
-    CONFIG = None
+from scipy.__config__ import CONFIG
 
 IS_WASM = (sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"])
 
@@ -2317,9 +2314,8 @@ class TestHessenberg:
 
 
 blas_provider = blas_version = None
-if CONFIG is not None:
-    blas_provider = CONFIG['Build Dependencies']['blas']['name']
-    blas_version = CONFIG['Build Dependencies']['blas']['version']
+blas_provider = CONFIG['Build Dependencies']['blas']['name']
+blas_version = CONFIG['Build Dependencies']['blas']['version']
 
 
 class TestQZ:

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -22,10 +22,6 @@ from scipy.linalg.lapack import _compute_lwork
 from scipy.stats import ortho_group, unitary_group
 
 import scipy.sparse as sps
-try:
-    from scipy.__config__ import CONFIG
-except ImportError:
-    CONFIG = None
 
 try:
     from scipy.linalg import _clapack as clapack
@@ -34,14 +30,14 @@ except ImportError:
 from scipy.linalg.lapack import get_lapack_funcs
 from scipy.linalg.blas import get_blas_funcs
 
+from scipy.__config__ import CONFIG
+blas_provider = blas_version = None
+blas_provider = CONFIG['Build Dependencies']['blas']['name']
+blas_version = CONFIG['Build Dependencies']['blas']['version']
+
 REAL_DTYPES = [np.float32, np.float64]
 COMPLEX_DTYPES = [np.complex64, np.complex128]
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES
-
-blas_provider = blas_version = None
-if CONFIG is not None:
-    blas_provider = CONFIG['Build Dependencies']['blas']['name']
-    blas_version = CONFIG['Build Dependencies']['blas']['version']
 
 
 def generate_random_dtype_array(shape, dtype, rng):
@@ -73,6 +69,12 @@ def test_lapack_documented():
                 name not in names):
             missing.append(name)
     assert missing == [], 'Name(s) missing from lapack.__doc__ or ignore_list'
+
+
+def test_ilp64_blas_lapack_both_or_none():
+    from scipy.linalg.blas import HAS_ILP64 as blas_has_ilp64
+    from scipy.linalg.lapack import HAS_ILP64 as lapack_has_ilp64
+    assert blas_has_ilp64 == lapack_has_ilp64
 
 
 class TestFlapackSimple:

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -773,8 +773,10 @@ foreach name, dep : dependency_map
     conf_data.set(name + '_LIBDIR', dep.get_variable('libdir', default_value: 'unknown'))
     conf_data.set(name + '_OPENBLAS_CONFIG', dep.get_variable('openblas_config', default_value: 'unknown'))
     conf_data.set(name + '_PCFILEDIR', dep.get_variable('pcfiledir', default_value: 'unknown'))
+    conf_data.set(name + '_HAS_ILP64', use_ilp64)
   endif
 endforeach
+
 
 configure_file(
   input: '__config__.py.in',


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

In the ILP64 build,  in addition to 32-bit `_fblas.so` and `_flapack.so`, we build two more extensions, `_fblas_64.so` and `_flapack_64.so`. The latter fails to import due to missing symbols in the underlying MKL libraries: all ILP64 routines should have the `_64_`  suffix, but several names miss the trailing underscore. 

We already work around a missing symbol for the `_fblas_64` extension. Now that I tried to actually import `_flapack_64`, too [1], it's clear that we need to work around several others.

[1] Why importing them? While working on an SVD enhancement, I noticed that `scipy.linalg.lapack.HAS_ILP64` is False while `scipy.linalg.blas.HAS_ILP64` is True, while they should be either both False (in an LP64 build) or both True (for an ILP64 build). 

#### Additional information
<!--Any additional information you think is important.-->

The problem has been reported to Intel, so hopefully it'll get fixed in some future MKL version. Meanwhile, the workaround was needed with

```
$ mamba list |grep mkl
# packages in environment at /home/ev-br/.conda/envs/scipy-dev-mkl:
libblas                   3.9.0           31_hfdb39a5_mkl    conda-forge
libcblas                  3.9.0           31_h372d94f_mkl    conda-forge
liblapack                 3.9.0           31_hc41d3b0_mkl    conda-forge
mkl                       2024.2.2            ha957f24_16    conda-forge
mkl-devel                 2024.2.2            ha770c72_16    conda-forge
mkl-include               2024.2.2            ha957f24_16    conda-forge
```
