### PR TITLE
DOC: sparse: Add examples sections to three new function doc_strings

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -55,6 +55,14 @@ def expand_dims(A, /, *, axis=0):
     ValueError
         If provided a non-integer or out of range ``[-N-1, N]`` axis,
         where ``N`` is ``A.ndim``.
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_array, permute_dims
+    >>> A = csr_array([[1, 2], [2, 0]])
+    >>> expand_dims(A, axis=1).shape
+    (2, 1, 2)
+
     """
     if not isintlike(axis):
         raise ValueError(f"Invalid axis {axis}. Must be an integer.")
@@ -93,6 +101,14 @@ def swapaxes(A, axis1, axis2):
     ValueError
         If provided a non-integer or out of range ``[-N, N-1]`` axis,
         where ``N`` is ``A.ndim``.
+
+    Examples
+    --------
+    >>> from scipy.sparse import coo_array, permute_dims
+    >>> A = coo_array([[[1, 2, 3], [2, 0, 0]]])
+    >>> swapaxes(A, 1, 2).shape
+    (1, 3, 2)
+
     """
     axes = np.arange(A.ndim)
     try:
@@ -134,6 +150,14 @@ def permute_dims(A, axes=None, copy=False):
     ValueError
         If provided a non-integer or out of range ``[-N, N-1]`` axis,
         where ``N`` is ``A.ndim``.
+
+    Examples
+    --------
+    >>> from scipy.sparse import coo_array, permute_dims
+    >>> A = coo_array([[[1, 2, 3], [2, 0, 0]]])
+    >>> permute_dims(A, axes=(1, 2, 0)).shape
+    (2, 3, 1)
+
     """
     ndim = A.ndim
     if axes is None:

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -58,8 +58,10 @@ def expand_dims(A, /, *, axis=0):
 
     Examples
     --------
-    >>> from scipy.sparse import csr_array, permute_dims
+    >>> from scipy.sparse import csr_array, expand_dims
     >>> A = csr_array([[1, 2], [2, 0]])
+    >>> A.shape
+    (2, 2)
     >>> expand_dims(A, axis=1).shape
     (2, 1, 2)
 
@@ -104,8 +106,10 @@ def swapaxes(A, axis1, axis2):
 
     Examples
     --------
-    >>> from scipy.sparse import coo_array, permute_dims
+    >>> from scipy.sparse import coo_array, swapaxes
     >>> A = coo_array([[[1, 2, 3], [2, 0, 0]]])
+    >>> A.shape
+    (1, 2, 3)
     >>> swapaxes(A, 1, 2).shape
     (1, 3, 2)
 
@@ -155,6 +159,8 @@ def permute_dims(A, axes=None, copy=False):
     --------
     >>> from scipy.sparse import coo_array, permute_dims
     >>> A = coo_array([[[1, 2, 3], [2, 0, 0]]])
+    >>> A.shape
+    (1, 2, 3)
     >>> permute_dims(A, axes=(1, 2, 0)).shape
     (2, 3, 1)
 


### PR DESCRIPTION
As discussed in #23534 the doc_strings do not have examples section for 3 new functions: `expand_dims`, `swap_axes`, `permute_dims`. 

    We want the total in #7168 to be monotonically decreasing over time.

This PR adds the examples sections.