### PR TITLE
ENH: stats.wilcoxon: add array API support

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3573,7 +3573,9 @@ def wilcoxon_outputs(kwds):
     return 2
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(skip_backends=[("dask.array", "no rankdata"),
+                                ("cupy", "no rankdata")],
+                jax_jit=False, cpu_only=True)  # null distribution is CPU only
 @_rename_parameter("mode", "method")
 @_axis_nan_policy_factory(
     wilcoxon_result_object, paired=True,

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -6,7 +6,7 @@ from . import _morestats
 from ._axis_nan_policy import _broadcast_arrays
 from ._hypotests import _get_wilcoxon_distr
 from scipy._lib._util import _get_nan
-from scipy._lib._array_api import array_namespace, xp_promote, xp_size, xp_copy
+from scipy._lib._array_api import array_namespace, xp_promote, xp_size
 import scipy._lib.array_api_extra as xpx
 
 

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -6,7 +6,7 @@ from . import _morestats
 from ._axis_nan_policy import _broadcast_arrays
 from ._hypotests import _get_wilcoxon_distr
 from scipy._lib._util import _get_nan
-from scipy._lib._array_api import array_namespace, xp_promote, xp_size
+from scipy._lib._array_api import array_namespace, xp_promote, xp_size, xp_copy
 import scipy._lib.array_api_extra as xpx
 
 
@@ -128,6 +128,7 @@ def _wilcoxon_statistic(d, method, zero_method='wilcox', *, xp):
         # Wilcoxon's method for treating zeros was to remove them from
         # the calculation. We do this by replacing 0s with NaNs, which
         # are ignored anyway.
+        d = xp_copy(d)  # this was required for array-api-strict, but it shouldn't be
         d = xpx.at(d)[i_zeros].set(xp.nan)
 
     i_nan = xp.isnan(d)
@@ -252,7 +253,7 @@ def _wilcoxon_nd(x, y=None, zero_method='wilcox', correction=True,
             p = 2 * np.minimum(dist.sf(np.floor(r_plus_np)),
                                dist.cdf(np.ceil(r_plus_np)))
             p = np.clip(p, 0, 1)
-        p = xp.asarray(p)
+        p = xp.asarray(p, dtype=d.dtype)
     else:  # `PermutationMethod` instance (already validated)
         p = stats.permutation_test(
             (d,), lambda d: _wilcoxon_statistic(d, method, zero_method, xp=xp)[0],

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -6,6 +6,7 @@ from . import _morestats
 from ._axis_nan_policy import _broadcast_arrays
 from ._hypotests import _get_wilcoxon_distr
 from scipy._lib._util import _get_nan
+from scipy._lib._array_api import array_namespace, xp_promote, xp_size
 import scipy._lib.array_api_extra as xpx
 
 
@@ -55,22 +56,24 @@ class WilcoxonDistribution:
 
 
 def _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis):
+    xp = array_namespace(x, y)
+    x, y = xp_promote(x, y, force_floating=True, xp=xp)
 
-    axis = np.asarray(axis)[()]
+    axis = np.asarray(axis)[()]  # OK to use NumPy for input validation
     message = "`axis` must be an integer."
     if not np.issubdtype(axis.dtype, np.integer) or axis.ndim != 0:
         raise ValueError(message)
+    axis = int(axis)
 
     message = '`axis` must be compatible with the shape(s) of `x` (and `y`)'
     AxisError = getattr(np, 'AxisError', None) or np.exceptions.AxisError
     try:
         if y is None:
-            x = np.asarray(x)
             d = x
         else:
-            x, y = _broadcast_arrays((x, y), axis=axis)
+            x, y = _broadcast_arrays((x, y), axis=axis, xp=xp)
             d = x - y
-        d = np.moveaxis(d, axis, -1)
+        d = xp.moveaxis(d, axis, -1)
     except AxisError as e:
         raise AxisError(message) from e
 
@@ -79,9 +82,7 @@ def _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis):
         raise ValueError(message)
 
     message = "`x` (and `y`, if provided) must be an array of real numbers."
-    if np.issubdtype(d.dtype, np.integer):
-        d = d.astype(np.float64)
-    if not np.issubdtype(d.dtype, np.floating):
+    if not xp.isdtype(d.dtype, "real floating"):
         raise ValueError(message)
 
     zero_method = str(zero_method).lower()
@@ -112,43 +113,42 @@ def _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis):
     # For small samples, we decide later whether to perform an exact test or a
     # permutation test. The reason is that the presence of ties is not
     # known at the input validation stage.
-    n_zero = np.sum(d == 0)
+    n_zero = xp.count_nonzero(d == 0, axis=None)
     if method == "auto" and d.shape[-1] > 50:
         method = "asymptotic"
 
-    return d, zero_method, correction, alternative, method, axis, output_z, n_zero
+    return d, zero_method, correction, alternative, method, axis, output_z, n_zero, xp
 
 
-def _wilcoxon_statistic(d, method, zero_method='wilcox'):
-
+def _wilcoxon_statistic(d, method, zero_method='wilcox', *, xp):
+    dtype = d.dtype
     i_zeros = (d == 0)
 
     if zero_method == 'wilcox':
         # Wilcoxon's method for treating zeros was to remove them from
         # the calculation. We do this by replacing 0s with NaNs, which
         # are ignored anyway.
-        if not d.flags['WRITEABLE']:
-            d = d.copy()
-        d[i_zeros] = np.nan
+        d = xpx.at(d)[i_zeros].set(xp.nan)
 
-    i_nan = np.isnan(d)
-    n_nan = np.sum(i_nan, axis=-1)
-    count = d.shape[-1] - n_nan
+    i_nan = xp.isnan(d)
+    n_nan = xp.count_nonzero(i_nan, axis=-1)
+    count = xp.astype(d.shape[-1] - n_nan, dtype)
 
-    r, t = _rankdata(abs(d), 'average', return_ties=True)
+    r, t = _rankdata(xp.abs(d), 'average', return_ties=True, xp=xp)
+    r, t = xp.astype(r, dtype, copy=False), xp.astype(t, dtype, copy=False)
 
-    r_plus = np.sum((d > 0) * r, axis=-1)
-    r_minus = np.sum((d < 0) * r, axis=-1)
+    r_plus = xp.sum(xp.astype(d > 0, dtype) * r, axis=-1)
+    r_minus = xp.sum(xp.astype(d < 0, dtype) * r, axis=-1)
 
-    has_ties = (t == 0).any()
+    has_ties = xp.any(t == 0)
 
     if zero_method == "zsplit":
         # The "zero-split" method for treating zeros is to add half their contribution
         # to r_plus and half to r_minus.
         # See gh-2263 for the origin of this method.
-        r_zero_2 = np.sum(i_zeros * r, axis=-1) / 2
-        r_plus += r_zero_2
-        r_minus += r_zero_2
+        r_zero_2 = xp.sum(xp.astype(i_zeros, dtype) * r, axis=-1) / 2
+        r_plus = xpx.at(r_plus)[...].add(r_zero_2)
+        r_minus = xpx.at(r_minus)[...].add(r_zero_2)
 
     mn = count * (count + 1.) * 0.25
     se = count * (count + 1.) * (2. * count + 1.)
@@ -157,17 +157,19 @@ def _wilcoxon_statistic(d, method, zero_method='wilcox'):
         # Pratt's method for treating zeros was just to modify the z-statistic.
 
         # normal approximation needs to be adjusted, see Cureton (1967)
-        n_zero = i_zeros.sum(axis=-1)
-        mn -= n_zero * (n_zero + 1.) * 0.25
-        se -= n_zero * (n_zero + 1.) * (2. * n_zero + 1.)
+        n_zero = xp.astype(xp.count_nonzero(i_zeros, axis=-1), dtype)
+        mn = xpx.at(mn)[...].subtract(n_zero * (n_zero + 1.) * 0.25)
+        se = xpx.at(se)[...].subtract(n_zero * (n_zero + 1.) * (2. * n_zero + 1.))
 
         # zeros are not to be included in tie-correction.
         # any tie counts corresponding with zeros are in the 0th column
-        t[i_zeros.any(axis=-1), 0] = 0
+        # t[xp.any(i_zeros, axis=-1), 0] = 0
+        t_i_zeros = xp.zeros_like(i_zeros)
+        t_i_zeros = xpx.at(t_i_zeros)[..., 0].set(xp.any(i_zeros, axis=-1))
+        t = xpx.at(t)[t_i_zeros].set(0.)
 
-    tie_correct = (t**3 - t).sum(axis=-1)
-    se -= tie_correct/2
-    se = np.sqrt(se / 24)
+    tie_correct = xp.sum(t**3 - t, axis=-1)
+    se = xp.sqrt((se - tie_correct/2) / 24)
 
     # se = 0 means that no non-zero values are left in d. we only need z
     # if method is asymptotic. however, if method="auto", the switch to
@@ -177,35 +179,35 @@ def _wilcoxon_statistic(d, method, zero_method='wilcox'):
     if method in ["asymptotic", "auto"]:
         z = (r_plus - mn) / se
     else:
-        z = np.nan
+        z = xp.nan
 
     return r_plus, r_minus, se, z, count, has_ties
 
 
-def _correction_sign(z, alternative):
+def _correction_sign(z, alternative, xp):
     if alternative == 'greater':
         return 1
     elif alternative == 'less':
         return -1
     else:
-        return np.sign(z)
+        return xp.sign(z)
 
 
 def _wilcoxon_nd(x, y=None, zero_method='wilcox', correction=True,
                  alternative='two-sided', method='auto', axis=0):
 
     temp = _wilcoxon_iv(x, y, zero_method, correction, alternative, method, axis)
-    d, zero_method, correction, alternative, method, axis, output_z, n_zero = temp
+    d, zero_method, correction, alternative, method, axis, output_z, n_zero, xp = temp
 
-    if d.size == 0:
-        NaN = _get_nan(d)
+    if xp_size(d) == 0:
+        NaN = _get_nan(d, xp=xp)
         res = _morestats.WilcoxonResult(statistic=NaN, pvalue=NaN)
         if method == 'asymptotic':
             res.zstatistic = NaN
         return res
 
     r_plus, r_minus, se, z, count, has_ties = _wilcoxon_statistic(
-        d, method, zero_method
+        d, method, zero_method, xp=xp
     )
 
     # we only know if there are ties after computing the statistic and not
@@ -229,9 +231,9 @@ def _wilcoxon_nd(x, y=None, zero_method='wilcox', correction=True,
 
     if method == 'asymptotic':
         if correction:
-            sign = _correction_sign(z, alternative)
-            z -= sign * 0.5 / se
-        p = _get_pvalue(z, _SimpleNormal(), alternative, xp=np)
+            sign = _correction_sign(z, alternative, xp=xp)
+            z = xpx.at(z)[...].subtract(sign * 0.5 / se)
+        p = _get_pvalue(z, _SimpleNormal(), alternative, xp=xp)
     elif method == 'exact':
         dist = WilcoxonDistribution(count)
         # The null distribution in `dist` is exact only if there are no ties
@@ -241,25 +243,29 @@ def _wilcoxon_nd(x, y=None, zero_method='wilcox', correction=True,
         # non-integral statistic up before computing CDF and down before
         # computing SF. This preserves symmetry w.r.t. alternatives and
         # order of the input arguments. See gh-19872.
+        r_plus_np = np.asarray(r_plus)
         if alternative == 'less':
-            p = dist.cdf(np.ceil(r_plus))
+            p = dist.cdf(np.ceil(r_plus_np))
         elif alternative == 'greater':
-            p = dist.sf(np.floor(r_plus))
+            p = dist.sf(np.floor(r_plus_np))
         else:
-            p = 2 * np.minimum(dist.sf(np.floor(r_plus)),
-                               dist.cdf(np.ceil(r_plus)))
+            p = 2 * np.minimum(dist.sf(np.floor(r_plus_np)),
+                               dist.cdf(np.ceil(r_plus_np)))
             p = np.clip(p, 0, 1)
+        p = xp.asarray(p)
     else:  # `PermutationMethod` instance (already validated)
         p = stats.permutation_test(
-            (d,), lambda d: _wilcoxon_statistic(d, method, zero_method)[0],
+            (d,), lambda d: _wilcoxon_statistic(d, method, zero_method, xp=xp)[0],
             permutation_type='samples', **method._asdict(),
             alternative=alternative, axis=-1).pvalue
 
     # for backward compatibility...
-    statistic = np.minimum(r_plus, r_minus) if alternative=='two-sided' else r_plus
-    z = -np.abs(z) if (alternative == 'two-sided' and method == 'asymptotic') else z
+    statistic = xp.minimum(r_plus, r_minus) if alternative=='two-sided' else r_plus
+    z = -xp.abs(z) if (alternative == 'two-sided' and method == 'asymptotic') else z
 
-    res = _morestats.WilcoxonResult(statistic=statistic, pvalue=p[()])
+    statistic = statistic[()] if statistic.ndim == 0 else statistic
+    p = p[()] if p.ndim == 0 else p
+    res = _morestats.WilcoxonResult(statistic=statistic, pvalue=p)
     if output_z:
-        res.zstatistic = z[()]
+        res.zstatistic = z[()] if z.ndim == 0 else z
     return res

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -128,8 +128,8 @@ def _wilcoxon_statistic(d, method, zero_method='wilcox', *, xp):
         # Wilcoxon's method for treating zeros was to remove them from
         # the calculation. We do this by replacing 0s with NaNs, which
         # are ignored anyway.
-        d = xp_copy(d)  # this was required for array-api-strict, but it shouldn't be
-        d = xpx.at(d)[i_zeros].set(xp.nan)
+        # Copy required for array-api-strict. See data-apis/array-api-extra#506.
+        d = xpx.at(d)[i_zeros].set(xp.nan, copy=True)
 
     i_nan = xp.isnan(d)
     n_nan = xp.count_nonzero(i_nan, axis=-1)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -25,6 +25,7 @@ from scipy.stats._distr_params import distcont
 from scipy.stats._axis_nan_policy import (SmallSampleWarning, too_small_nd_omit,
                                           too_small_1d_omit, too_small_1d_not_omit)
 
+import scipy._lib.array_api_extra as xpx
 from scipy._lib._array_api import (is_torch, make_xp_test_case, eager_warns, xp_ravel,
                                    is_numpy)
 from scipy._lib._array_api_no_0d import (
@@ -1450,36 +1451,48 @@ class TestProbplot:
                           (np.nan, np.nan, np.nan)))
 
 
+@make_xp_test_case(stats.wilcoxon)
 class TestWilcoxon:
-    def test_wilcoxon_bad_arg(self):
+    def test_wilcoxon_bad_arg(self, xp):
         # Raise ValueError when two args of different lengths are given or
         # zero_method is unknown.
-        assert_raises(ValueError, stats.wilcoxon, [1, 2], [1, 2], "dummy")
-        assert_raises(ValueError, stats.wilcoxon, [1, 2], [1, 2],
-                      alternative="dummy")
-        assert_raises(ValueError, stats.wilcoxon, [1]*10, method="xyz")
+        x = xp.asarray([1, 2])
+        d = xp.asarray([1]*10)
+        message = "`zero_method` must be one of..."
+        with pytest.raises(ValueError, match=message):
+            stats.wilcoxon(x, x, "dummy...")
+        message = "`alternative` must be one of"
+        with pytest.raises(ValueError, match=message):
+            stats.wilcoxon(x, x, alternative="dummy")
+        message = "`method` must be one of..."
+        with pytest.raises(ValueError, match=message):
+            stats.wilcoxon(d, method="xyz")
 
-    def test_zero_diff(self):
-        x = np.arange(20)
+    def test_zero_diff(self, xp):
+        x = xp.arange(20)
         # pratt and wilcox do not work if x - y == 0 and method == "asymptotic"
         # => warning may be emitted and p-value is nan
         with np.errstate(invalid="ignore"):
             w, p = stats.wilcoxon(x, x, "wilcox", method="asymptotic")
-            assert_equal((w, p), (0.0, np.nan))
+            xp_assert_equal(w, xp.asarray(0.0))
+            xp_assert_equal(p, xp.asarray(xp.nan))
             w, p = stats.wilcoxon(x, x, "pratt", method="asymptotic")
-            assert_equal((w, p), (0.0, np.nan))
+            xp_assert_equal(w, xp.asarray(0.0))
+            xp_assert_equal(p, xp.asarray(xp.nan))
         # ranksum is n*(n+1)/2, split in half if zero_method == "zsplit"
-        assert_equal(stats.wilcoxon(x, x, "zsplit", method="asymptotic"),
-                     (20*21/4, 1.0))
+        w, p = stats.wilcoxon(x, x, "zsplit", method="asymptotic")
+        xp_assert_equal(w, xp.asarray(20*21/4))
+        xp_assert_equal(p, xp.asarray(1.0))
 
-    def test_pratt(self):
+    def test_pratt(self, xp):
         # regression test for gh-6805: p-value matches value from R package
         # coin (wilcoxsign_test) reported in the issue
-        x = [1, 2, 3, 4]
-        y = [1, 2, 3, 5]
+        x = xp.asarray([1, 2, 3, 4])
+        y = xp.asarray([1, 2, 3, 5])
         res = stats.wilcoxon(x, y, zero_method="pratt", method="asymptotic",
                              correction=False)
-        assert_allclose(res, (0.0, 0.31731050786291415))
+        xp_assert_close(res.statistic, xp.asarray(0.0))
+        xp_assert_close(res.pvalue, xp.asarray(0.31731050786291415))
 
     def test_wilcoxon_arg_type(self):
         # Should be able to accept list as arguments.
@@ -1490,63 +1503,66 @@ class TestWilcoxon:
         _ = stats.wilcoxon(arr, zero_method="zsplit", method="asymptotic")
         _ = stats.wilcoxon(arr, zero_method="wilcox", method="asymptotic")
 
-    def test_accuracy_wilcoxon(self):
+    def test_accuracy_wilcoxon(self, xp):
         freq = [1, 4, 16, 15, 8, 4, 5, 1, 2]
         nums = range(-4, 5)
-        x = np.concatenate([[u] * v for u, v in zip(nums, freq)])
-        y = np.zeros(x.size)
+        x = xp.asarray(np.concatenate([[u] * v for u, v in zip(nums, freq)]))
+        y = xp.zeros_like(x)
 
         T, p = stats.wilcoxon(x, y, "pratt", method="asymptotic",
                               correction=False)
-        assert_allclose(T, 423)
-        assert_allclose(p, 0.0031724568006762576)
+        xp_assert_close(T, xp.asarray(423.))
+        xp_assert_close(p, xp.asarray(0.0031724568006762576))
 
         T, p = stats.wilcoxon(x, y, "zsplit", method="asymptotic",
                               correction=False)
-        assert_allclose(T, 441)
-        assert_allclose(p, 0.0032145343172473055)
+        xp_assert_equal(T, xp.asarray(441.))
+        xp_assert_close(p, xp.asarray(0.0032145343172473055))
 
         T, p = stats.wilcoxon(x, y, "wilcox", method="asymptotic",
                               correction=False)
-        assert_allclose(T, 327)
-        assert_allclose(p, 0.00641346115861)
+        xp_assert_equal(T, xp.asarray(327.))
+        xp_assert_close(p, xp.asarray(0.00641346115861))
 
         # Test the 'correction' option, using values computed in R with:
+        # > options(digits=16)
         # > wilcox.test(x, y, paired=TRUE, exact=FALSE, correct={FALSE,TRUE})
-        x = np.array([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
-        y = np.array([133, 143, 119, 189, 112, 199, 198, 113, 115, 121, 142, 187])
+        x = xp.asarray([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
+        y = xp.asarray([133, 143, 119, 189, 112, 199, 198, 113, 115, 121, 142, 187])
         T, p = stats.wilcoxon(x, y, correction=False, method="asymptotic")
-        assert_equal(T, 34)
-        assert_allclose(p, 0.6948866, rtol=1e-6)
+        xp_assert_equal(T, xp.asarray(34.))
+        xp_assert_close(p, xp.asarray(0.6948866023724735))
         T, p = stats.wilcoxon(x, y, correction=True, method="asymptotic")
-        assert_equal(T, 34)
-        assert_allclose(p, 0.7240817, rtol=1e-6)
+        xp_assert_equal(T, xp.asarray(34.))
+        xp_assert_close(p, xp.asarray(0.7240816609153895))
 
-    def test_approx_mode(self):
+    @pytest.mark.parametrize("kwarg",
+        [{"method": "approx"}, {"mode": "approx"}, {"mode": "asymptotic"}])
+    def test_approx_mode(self, kwarg, xp):
         # Check that `mode` is still an alias of keyword `method`,
         # and `"approx"` is still an alias of argument `"asymptotic"`
-        x = np.array([3, 5, 23, 7, 243, 58, 98, 2, 8, -3, 9, 11])
-        y = np.array([2, -2, 1, 23, 0, 5, 12, 18, 99, 12, 17, 27])
-        res1 = stats.wilcoxon(x, y, "wilcox", method="approx")
-        res2 = stats.wilcoxon(x, y, "wilcox", method="asymptotic")
-        res3 = stats.wilcoxon(x, y, "wilcox", mode="approx")
-        res4 = stats.wilcoxon(x, y, "wilcox", mode="asymptotic")
-        assert res1 == res2 == res3 == res4
+        x = xp.asarray([3, 5, 23, 7, 243, 58, 98, 2, 8, -3, 9, 11])
+        y = xp.asarray([2, -2, 1, 23, 0, 5, 12, 18, 99, 12, 17, 27])
+        res = stats.wilcoxon(x, y, "wilcox", **kwarg)
+        ref = stats.wilcoxon(x, y, "wilcox", method="asymptotic")
+        xp_assert_equal(res.statistic, ref.statistic)
+        xp_assert_equal(res.pvalue, ref.pvalue)
 
-    def test_wilcoxon_result_attributes(self):
-        x = np.array([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
-        y = np.array([133, 143, 119, 189, 112, 199, 198, 113, 115, 121, 142, 187])
+    def test_wilcoxon_result_attributes(self, xp):
+        x = xp.asarray([120, 114, 181, 188, 180, 146, 121, 191, 132, 113, 127, 112])
+        y = xp.asarray([133, 143, 119, 189, 112, 199, 198, 113, 115, 121, 142, 187])
         res = stats.wilcoxon(x, y, correction=False, method="asymptotic")
         attributes = ('statistic', 'pvalue')
-        check_named_results(res, attributes)
+        check_named_results(res, attributes, xp=xp)
 
-    def test_wilcoxon_has_zstatistic(self):
+    def test_wilcoxon_has_zstatistic(self, xp):
         rng = np.random.default_rng(89426135444)
         x, y = rng.random(15), rng.random(15)
+        x, y = xp.asarray(x), xp.asarray(y)
 
         res = stats.wilcoxon(x, y, method="asymptotic")
-        ref = stats.norm.ppf(res.pvalue/2)
-        assert_allclose(res.zstatistic, ref)
+        ref = special.ndtri(res.pvalue/2)
+        xp_assert_close(res.zstatistic, ref)
 
         res = stats.wilcoxon(x, y, method="exact")
         assert not hasattr(res, 'zstatistic')
@@ -1554,29 +1570,32 @@ class TestWilcoxon:
         res = stats.wilcoxon(x, y)
         assert not hasattr(res, 'zstatistic')
 
-    def test_wilcoxon_tie(self):
+    def test_wilcoxon_tie(self, xp):
         # Regression test for gh-2391.
         # Corresponding R code is:
         #   > result = wilcox.test(rep(0.1, 10), exact=FALSE, correct=FALSE)
         #   > result$p.value
-        #   [1] 0.001565402
+        #   [1] 0.001565402258002551
         #   > result = wilcox.test(rep(0.1, 10), exact=FALSE, correct=TRUE)
         #   > result$p.value
-        #   [1] 0.001904195
-        stat, p = stats.wilcoxon([0.1] * 10, method="asymptotic",
-                                 correction=False)
-        expected_p = 0.001565402
-        assert_equal(stat, 0)
-        assert_allclose(p, expected_p, rtol=1e-6)
+        #   [1] 0.00190419504300439
+        d = xp.asarray([0.1] * 10)
+        expected_stat = xp.asarray(0.0)
 
-        stat, p = stats.wilcoxon([0.1] * 10, correction=True,
-                                 method="asymptotic")
-        expected_p = 0.001904195
-        assert_equal(stat, 0)
-        assert_allclose(p, expected_p, rtol=1e-6)
+        stat, p = stats.wilcoxon(d, method="asymptotic", correction=False, )
+        expected_p = xp.asarray(0.001565402258002551)
+        xp_assert_equal(stat, expected_stat)
+        xp_assert_close(p, expected_p)
 
-    def test_onesided(self):
-        # tested against "R version 3.4.1 (2017-06-30)"
+        stat, p = stats.wilcoxon(d, method="asymptotic", correction=True)
+        expected_p = xp.asarray(0.00190419504300439)
+        xp_assert_equal(stat, expected_stat)
+        xp_assert_close(p, expected_p)
+
+    @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
+    def test_onesided(self, dtype, xp):
+        # tested against "R version 4.0.3 (2020-10-10)"
+        #
         # x <- c(125, 115, 130, 140, 140, 115, 140, 125, 140, 135)
         # y <- c(110, 122, 125, 120, 140, 124, 123, 137, 135, 145)
         # cfg <- list(x = x, y = y, paired = TRUE, exact = FALSE)
@@ -1584,30 +1603,35 @@ class TestWilcoxon:
         # do.call(wilcox.test, c(cfg, list(alternative = "less", correct = TRUE)))
         # do.call(wilcox.test, c(cfg, list(alternative = "greater", correct = FALSE)))
         # do.call(wilcox.test, c(cfg, list(alternative = "greater", correct = TRUE)))
-        x = [125, 115, 130, 140, 140, 115, 140, 125, 140, 135]
-        y = [110, 122, 125, 120, 140, 124, 123, 137, 135, 145]
+        if is_numpy(xp) and xp.__version__ < "2.0" and dtype == 'float32':
+            pytest.skip("dtypes not preserved with pre-NEP 50 rules")
 
+        dtype = dtype if dtype is None else getattr(xp, dtype)
+        x = xp.asarray([125, 115, 130, 140, 140, 115, 140, 125, 140, 135], dtype=dtype)
+        y = xp.asarray([110, 122, 125, 120, 140, 124, 123, 137, 135, 145], dtype=dtype)
+
+        w_ref = xp.asarray(27.0, dtype=dtype)
         w, p = stats.wilcoxon(x, y, alternative="less", method="asymptotic",
                               correction=False)
-        assert_equal(w, 27)
-        assert_almost_equal(p, 0.7031847, decimal=6)
+        xp_assert_equal(w, w_ref)
+        xp_assert_close(p, xp.asarray(0.7031847042787, dtype=dtype))
 
         w, p = stats.wilcoxon(x, y, alternative="less", correction=True,
                               method="asymptotic")
-        assert_equal(w, 27)
-        assert_almost_equal(p, 0.7233656, decimal=6)
+        xp_assert_equal(w, w_ref)
+        xp_assert_close(p, xp.asarray(0.72336564289, dtype=dtype))
 
         w, p = stats.wilcoxon(x, y, alternative="greater",
                               method="asymptotic", correction=False)
-        assert_equal(w, 27)
-        assert_almost_equal(p, 0.2968153, decimal=6)
+        xp_assert_equal(w, w_ref)
+        xp_assert_close(p, xp.asarray(0.2968152957213, dtype=dtype))
 
         w, p = stats.wilcoxon(x, y, alternative="greater",
                               correction=True, method="asymptotic")
-        assert_equal(w, 27)
-        assert_almost_equal(p, 0.3176447, decimal=6)
+        xp_assert_equal(w, w_ref)
+        xp_assert_close(p, xp.asarray(0.3176446594176, dtype=dtype))
 
-    def test_exact_basic(self):
+    def test_exact_basic(self):  # exact distribution is NumPy-only
         for n in range(1, 51):
             pmf1 = _get_wilcoxon_distr(n)
             pmf2 = _get_wilcoxon_distr2(n)
@@ -1615,27 +1639,34 @@ class TestWilcoxon:
             assert_equal(sum(pmf1), 1)
             assert_array_almost_equal(pmf1, pmf2)
 
-    def test_exact_pval(self):
-        # expected values computed with "R version 3.4.1 (2017-06-30)"
-        x = np.array([1.81, 0.82, 1.56, -0.48, 0.81, 1.28, -1.04, 0.23,
-                      -0.75, 0.14])
-        y = np.array([0.71, 0.65, -0.2, 0.85, -1.1, -0.45, -0.84, -0.24,
-                      -0.68, -0.76])
+    @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
+    def test_exact_pval(self, dtype, xp):
+        # expected values computed with "R version 4.0.3 (2020-10-10)"
+        # options(digits=16)
+        # x < - c(1.81, 0.82, 1.56, -0.48, 0.81, 1.28, -1.04, 0.23, -0.75, 0.14)
+        # y < - c(0.71, 0.65, -0.2, 0.85, -1.1, -0.45, -0.84, -0.24, -0.68, -0.76)
+        # result = wilcox.test(x - y, exact=TRUE, alternative='l', correct=TRUE)
+        # result$p.value
+        dtype = dtype if dtype is None else getattr(xp, dtype)
+        x = xp.asarray([1.81, 0.82, 1.56, -0.48, 0.81, 1.28, -1.04, 0.23,
+                        -0.75, 0.14], dtype=dtype)
+        y = xp.asarray([0.71, 0.65, -0.2, 0.85, -1.1, -0.45, -0.84, -0.24,
+                        -0.68, -0.76], dtype=dtype)
         _, p = stats.wilcoxon(x, y, alternative="two-sided", method="exact")
-        assert_almost_equal(p, 0.1054688, decimal=6)
+        xp_assert_close(p, xp.asarray(0.10546875, dtype=dtype))
         _, p = stats.wilcoxon(x, y, alternative="less", method="exact")
-        assert_almost_equal(p, 0.9580078, decimal=6)
+        xp_assert_close(p, xp.asarray(0.95800781256, dtype=dtype))
         _, p = stats.wilcoxon(x, y, alternative="greater", method="exact")
-        assert_almost_equal(p, 0.05273438, decimal=6)
+        xp_assert_close(p, xp.asarray(0.052734375, dtype=dtype))
 
-        x = np.arange(0, 20) + 0.5
-        y = np.arange(20, 0, -1)
+        x = xp.arange(0., 20., dtype=dtype) + 0.5
+        y = xp.arange(20., 0., -1., dtype=dtype)
         _, p = stats.wilcoxon(x, y, alternative="two-sided", method="exact")
-        assert_almost_equal(p, 0.8694878, decimal=6)
+        xp_assert_close(p, xp.asarray(0.8694877624511719, dtype=dtype))
         _, p = stats.wilcoxon(x, y, alternative="less", method="exact")
-        assert_almost_equal(p, 0.4347439, decimal=6)
+        xp_assert_close(p, xp.asarray(0.4347438812255859, dtype=dtype))
         _, p = stats.wilcoxon(x, y, alternative="greater", method="exact")
-        assert_almost_equal(p, 0.5795889, decimal=6)
+        xp_assert_close(p, xp.asarray(0.5795888900756836, dtype=dtype))
 
     # These inputs were chosen to give a W statistic that is either the
     # center of the distribution (when the length of the support is odd), or
@@ -1646,67 +1677,76 @@ class TestWilcoxon:
     @pytest.mark.parametrize('x', [[-1, -2, 3],
                                    [-1, 2, -3, -4, 5],
                                    [-1, -2, 3, -4, -5, -6, 7, 8]])
-    def test_exact_p_1(self, x):
-        w, p = stats.wilcoxon(x)
+    def test_exact_p_1(self, x, xp):
+        w, p = stats.wilcoxon(xp.asarray(x))
         x = np.array(x)
         wtrue = x[x > 0].sum()
-        assert_equal(w, wtrue)
-        assert_equal(p, 1)
+        xp_assert_equal(w, xp.asarray(float(wtrue)))
+        xp_assert_equal(p, xp.asarray(1.0))
 
-    def test_auto(self):
+    def test_auto(self, xp):
         # auto default to exact if there are no ties and n <= 50
-        x = np.arange(0, 50) + 0.5
-        y = np.arange(50, 0, -1)
-        assert_equal(stats.wilcoxon(x, y),
-                     stats.wilcoxon(x, y, method="exact"))
+        x = xp.arange(0., 50.) + 0.5
+        y = xp.arange(50., 0., -1.)
+        xp_assert_equal(stats.wilcoxon(x, y).pvalue,
+                        stats.wilcoxon(x, y, method="exact").pvalue)
 
-        # n <= 50: if there are zeros in d = x-y, use PermutationMethod
-        pm = stats.PermutationMethod()
-        d = np.arange(-2, 5)
-        w, p = stats.wilcoxon(d)
-        # rerunning the test gives the same results since n_resamples
-        # is large enough to get deterministic results if n <= 13
-        # so we do not need to use a seed. to avoid longer runtimes of the
-        # test, use n=7 only. For n=13, see test_auto_permutation_edge_case
-        assert_equal((w, p), stats.wilcoxon(d, method=pm))
+        if is_numpy(xp):  # PermutationMethod is NumPy-only until gh-23772 merges
+            # n <= 50: if there are zeros in d = x-y, use PermutationMethod
+            pm = stats.PermutationMethod()
+            d = np.arange(-2, 5)
+            w, p = stats.wilcoxon(d)
+            # rerunning the test gives the same results since n_resamples
+            # is large enough to get deterministic results if n <= 13
+            # so we do not need to use a seed. to avoid longer runtimes of the
+            # test, use n=7 only. For n=13, see test_auto_permutation_edge_case
+            assert_equal((w, p), stats.wilcoxon(d, method=pm))
 
         # for larger vectors (n > 13) with ties/zeros, use asymptotic test
-        d = np.arange(-5, 9)  # zero
-        w, p = stats.wilcoxon(d)
-        assert_equal((w, p), stats.wilcoxon(d, method="asymptotic"))
+        d = xp.arange(-5, 9)  # zero
+        _, p = stats.wilcoxon(d)
+        xp_assert_equal(stats.wilcoxon(d, method="asymptotic").pvalue, xp.asarray(p))
 
-        d[d == 0] = 1  # tie
-        w, p = stats.wilcoxon(d)
-        assert_equal((w, p), stats.wilcoxon(d, method="asymptotic"))
+        d = xpx.at(d)[d == 0].set(1)  # tie
+        _, p = stats.wilcoxon(d)
+        xp_assert_equal(stats.wilcoxon(d, method="asymptotic").pvalue, xp.asarray(p))
 
         # use approximation for samples > 50
-        d = np.arange(1, 52)
-        assert_equal(stats.wilcoxon(d), stats.wilcoxon(d, method="asymptotic"))
+        d = xp.arange(1, 52)
+        _, p = stats.wilcoxon(d)
+        xp_assert_equal(stats.wilcoxon(d, method="asymptotic").pvalue, xp.asarray(p))
 
     @pytest.mark.xslow
-    def test_auto_permutation_edge_case(self):
+    @pytest.mark.skip_xp_backends(np_only=True)
+    def test_auto_permutation_edge_case(self, xp):
         # Check that `PermutationMethod()` is used and results are deterministic when
         # `method='auto'`, there are zeros or ties in `d = x-y`, and `len(d) <= 13`.
         d = np.arange(-5, 8)  # zero
-        res = stats.wilcoxon(d)
-        ref = (27.5, 0.3955078125)  # stats.wilcoxon(d, method=PermutationMethod())
-        assert_equal(res, ref)
+        res = stats.wilcoxon(xp.asarray(d))
+        # generated with stats.wilcoxon(d, method=PermutationMethod())
+        w, p = xp.asarray([27.5, 0.3955078125])
+        xp_assert_equal(res.statistic, w)
+        xp_assert_equal(res.pvalue, p)
 
         d[d == 0] = 1  # tie
-        res = stats.wilcoxon(d)
-        ref = (32, 0.3779296875)  # stats.wilcoxon(d, method=PermutationMethod())
-        assert_equal(res, ref)
+        res = stats.wilcoxon(xp.asarray(d))
+        # generated with stats.wilcoxon(d, method=PermutationMethod())
+        w, p = xp.asarray([32, 0.3779296875])
+        xp_assert_equal(res.statistic, w)
+        xp_assert_equal(res.pvalue, p)
+
 
     @pytest.mark.parametrize('size', [3, 5, 10])
-    def test_permutation_method(self, size):
+    @pytest.mark.skip_xp_backends(np_only=True)
+    def test_permutation_method(self, size, xp):
         rng = np.random.default_rng(92348034828501345)
-        x = rng.random(size=size)
+        x = xp.asarray(rng.random(size=size))
         res = stats.wilcoxon(x, method=stats.PermutationMethod())
         ref = stats.wilcoxon(x, method='exact')
-        assert_equal(res.statistic, ref.statistic)
-        assert_equal(res.pvalue, ref.pvalue)
+        xp_assert_equal(res.statistic, ref.statistic)
+        xp_assert_equal(res.pvalue, ref.pvalue)
 
-        x = rng.random(size=size*10)
+        x = xp.asarray(rng.random(size=size*10))
         rng = np.random.default_rng(59234803482850134)
         pm = stats.PermutationMethod(n_resamples=99, rng=rng)
         ref = stats.wilcoxon(x, method=pm)
@@ -1715,10 +1755,10 @@ class TestWilcoxon:
         pm = stats.PermutationMethod(n_resamples=99, random_state=rng)
         res = stats.wilcoxon(x, method=pm)
 
-        assert_equal(np.round(res.pvalue, 2), res.pvalue)  # n_resamples used
-        assert_equal(res.pvalue, ref.pvalue)  # rng/random_state used
+        xp_assert_equal(xp.round(res.pvalue, 2), res.pvalue)  # n_resamples used
+        xp_assert_equal(res.pvalue, ref.pvalue)  # rng/random_state used
 
-    def test_method_auto_nan_propagate_ND_length_gt_50_gh20591(self):
+    def test_method_auto_nan_propagate_ND_length_gt_50_gh20591(self, xp):
         # When method!='asymptotic', nan_policy='propagate', and a slice of
         # a >1 dimensional array input contained NaN, the result object of
         # `wilcoxon` could (under yet other conditions) return `zstatistic`
@@ -1728,53 +1768,65 @@ class TestWilcoxon:
         rng = np.random.default_rng(235889269872456)
         A = rng.normal(size=(51, 2))  # length along slice > exact threshold
         A[5, 1] = np.nan
+        A = xp.asarray(A)
         res = stats.wilcoxon(A)
         ref = stats.wilcoxon(A, method='asymptotic')
-        assert_allclose(res, ref)
+        xp_assert_close(res.statistic, ref.statistic)
+        xp_assert_close(res.pvalue, ref.pvalue)
         assert hasattr(ref, 'zstatistic')
         assert not hasattr(res, 'zstatistic')
 
     @pytest.mark.parametrize('method', ['exact', 'asymptotic'])
-    def test_symmetry_gh19872_gh20752(self, method):
+    def test_symmetry_gh19872_gh20752(self, method, xp):
         # Check that one-sided exact tests obey required symmetry. Bug reported
         # in gh-19872 and again in gh-20752; example from gh-19872 is more concise:
-        var1 = [62, 66, 61, 68, 74, 62, 68, 62, 55, 59]
-        var2 = [71, 71, 69, 61, 75, 71, 77, 72, 62, 65]
+        var1 = xp.asarray([62, 66, 61, 68, 74, 62, 68, 62, 55, 59])
+        var2 = xp.asarray([71, 71, 69, 61, 75, 71, 77, 72, 62, 65])
         ref = stats.wilcoxon(var1, var2, alternative='less', method=method)
         res = stats.wilcoxon(var2, var1, alternative='greater', method=method)
-        max_statistic = len(var1) * (len(var1) + 1) / 2
+        max_statistic = var1.shape[0] * (var1.shape[0] + 1) / 2
         assert int(res.statistic) != res.statistic
-        assert_allclose(max_statistic - res.statistic, ref.statistic, rtol=1e-15)
-        assert_allclose(res.pvalue, ref.pvalue, rtol=1e-15)
+        xp_assert_close(max_statistic - res.statistic, ref.statistic)
+        xp_assert_close(res.pvalue, ref.pvalue)
 
     @pytest.mark.parametrize("method", ('exact', stats.PermutationMethod()))
-    def test_all_zeros_exact(self, method):
+    def test_all_zeros_exact(self, method, xp):
         # previously, this raised a RuntimeWarning when calculating Z, even
         # when the Z value was not needed. Confirm that this no longer
         # occurs when `method` is 'exact' or a `PermutationMethod`.
-        res = stats.wilcoxon(np.zeros(5), method=method)
-        assert_allclose(res, [0, 1])
+        if method != "exact":
+            pytest.skip("PermutationMethod is NumPy-only until gh-23772 merges")
+        res = stats.wilcoxon(xp.zeros(5), method=method)
+        xp_assert_close(res.statistic, xp.asarray(0.))
+        xp_assert_close(res.pvalue, xp.asarray(1.))
 
-    def test_wilcoxon_axis_broadcasting_errors_gh22051(self):
+    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy->limited input validation')
+    def test_wilcoxon_axis_broadcasting_errors_gh22051(self, xp):
         # In previous versions of SciPy, `wilcoxon` gave an incorrect error
         # message when `AxisError` was not found in the base NumPy namespace.
         # Check that this is resolved with and without the ANP decorator.
+        x = xp.asarray([1, 2, 3])
+        y = xp.asarray([4, 5, 6])
+
         message = "Array shapes are incompatible for broadcasting."
         with pytest.raises(ValueError, match=message):
-            stats.wilcoxon([1, 2, 3], [4, 5])
+            stats.wilcoxon(x, y[:-1])
+
+        if not is_numpy(xp):
+            return  # hard to generalize the rest
 
         message = "operands could not be broadcast together with..."
         with pytest.raises(ValueError, match=message):
-            stats.wilcoxon([1, 2, 3], [4, 5], _no_deco=True)
+            stats.wilcoxon(x, y[:-1], _no_deco=True)
 
         AxisError = getattr(np, 'AxisError', None) or np.exceptions.AxisError
         message = "source: axis 3 is out of bounds for array of dimension 1"
         with pytest.raises(AxisError, match=message):
-            stats.wilcoxon([1, 2, 3], [4, 5, 6], axis=3)
+            stats.wilcoxon(x, y, axis=3)
 
         message = "`axis` must be compatible with the shape..."
         with pytest.raises(AxisError, match=message):
-            stats.wilcoxon([1, 2, 3], [4, 5, 6], axis=3, _no_deco=True)
+            stats.wilcoxon(x, y, axis=3, _no_deco=True)
 
 
 # data for k-statistics tests from

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1582,7 +1582,7 @@ class TestWilcoxon:
         d = xp.asarray([0.1] * 10)
         expected_stat = xp.asarray(0.0)
 
-        stat, p = stats.wilcoxon(d, method="asymptotic", correction=False, )
+        stat, p = stats.wilcoxon(d, method="asymptotic", correction=False)
         expected_p = xp.asarray(0.001565402258002551)
         xp_assert_equal(stat, expected_stat)
         xp_assert_close(p, expected_p)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `scipy.stats.wilcoxon`.