### PR TITLE
ENH: stats.friedmanchisquare: add array API support

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8519,7 +8519,8 @@ FriedmanchisquareResult = namedtuple('FriedmanchisquareResult',
                                      ('statistic', 'pvalue'))
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(skip_backends=[("cupy", "no rankdata"), ("dask.array", "no rankdata")],
+                 jax_jit=False)
 @_axis_nan_policy_factory(FriedmanchisquareResult, n_samples=None, paired=True)
 def friedmanchisquare(*samples, axis=0):
     """Compute the Friedman test for repeated samples.
@@ -8584,8 +8585,12 @@ def friedmanchisquare(*samples, axis=0):
     """
     k = len(samples)
     if k < 3:
-        raise ValueError('At least 3 sets of samples must be given '
+        raise ValueError('At least 3 samples must be given '
                          f'for Friedman test, got {k}.')
+
+    xp = array_namespace(*samples)
+    samples = xp_promote(*samples, force_floating=True, xp=xp)
+    dtype = samples[0].dtype
 
     n = samples[0].shape[-1]
     if n == 0:  # only for `test_axis_nan_policy`; user doesn't see this
@@ -8594,22 +8599,20 @@ def friedmanchisquare(*samples, axis=0):
     # Rank data
     # axis-slices are aligned with axis -1 by decorator; stack puts samples along axis 0
     # The transpose flips this so we can work with axis-slices along -1. This is a
-    # reducing statistic, so both axes 0 and -1 are consumed, but what's left has to be
-    # transposed back at the end.
-    data = np.stack(samples).T
-    data = data.astype(float)
+    # reducing statistic, so both axes 0 and -1 are consumed.
+    data = xp_swapaxes(xp.stack(samples), 0, -1)
     data, t = _rankdata(data, method='average', return_ties=True)
+    data, t = xp.asarray(data, dtype=dtype), xp.asarray(t, dtype=dtype)
 
     # Handle ties
-    ties = np.sum(t * (t*t - 1), axis=(0, -1))
+    ties = xp.sum(t * (t*t - 1), axis=(0, -1))
     c = 1 - ties / (k*(k*k - 1)*n)
 
-    ssbn = np.sum(data.sum(axis=0)**2, axis=-1)
+    ssbn = xp.sum(xp.sum(data, axis=0)**2, axis=-1)
     statistic = (12.0 / (k*n*(k+1)) * ssbn - 3*n*(k+1)) / c
 
-    statistic = statistic.T
-    chi2 = _SimpleChi2(k - 1)
-    pvalue = _get_pvalue(statistic, chi2, alternative='greater', symmetric=False, xp=np)
+    chi2 = _SimpleChi2(xp.asarray(k - 1, dtype=dtype))
+    pvalue = _get_pvalue(statistic, chi2, alternative='greater', symmetric=False, xp=xp)
     return FriedmanchisquareResult(statistic, pvalue)
 
 

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -911,6 +911,45 @@ class TestMisc:
         attributes = ('statistic', 'pvalue')
         check_named_results(result, attributes, ma=True)
 
+        # copied from `test_stats.py`
+        array = np.asarray
+        x1 = [array([0.763, 0.599, 0.954, 0.628, 0.882, 0.936, 0.661, 0.583,
+                     0.775, 1.0, 0.94, 0.619, 0.972, 0.957]),
+              array([0.768, 0.591, 0.971, 0.661, 0.888, 0.931, 0.668, 0.583,
+                     0.838, 1.0, 0.962, 0.666, 0.981, 0.978]),
+              array([0.771, 0.590, 0.968, 0.654, 0.886, 0.916, 0.609, 0.563,
+                     0.866, 1.0, 0.965, 0.614, 0.9751, 0.946]),
+              array([0.798, 0.569, 0.967, 0.657, 0.898, 0.931, 0.685, 0.625,
+                     0.875, 1.0, 0.962, 0.669, 0.975, 0.970])]
+
+        # From "Bioestadistica para las ciencias de la salud" Xf=18.95 p<0.001:
+        x2 = [array([4, 3, 5, 3, 5, 3, 2, 5, 4, 4, 4, 3]),
+              array([2, 2, 1, 2, 3, 1, 2, 3, 2, 1, 1, 3]),
+              array([2, 4, 3, 3, 4, 3, 3, 4, 4, 1, 2, 1]),
+              array([3, 5, 4, 3, 4, 4, 3, 3, 3, 4, 4, 4])]
+
+        # From Jerrorl H. Zar, "Biostatistical Analysis"(example 12.6),
+        # Xf=10.68, 0.005 < p < 0.01:
+        # Probability from this example is inexact
+        # using Chisquare approximation of Friedman Chisquare.
+        x3 = [array([7.0, 9.9, 8.5, 5.1, 10.3]),
+              array([5.3, 5.7, 4.7, 3.5, 7.7]),
+              array([4.9, 7.6, 5.5, 2.8, 8.4]),
+              array([8.8, 8.9, 8.1, 3.3, 9.1])]
+
+        # test using mstats
+        assert_array_almost_equal(mstats.friedmanchisquare(x1[0], x1[1],
+                                                           x1[2], x1[3]),
+                                  (10.2283464566929, 0.0167215803284414))
+        # the following fails
+        # assert_array_almost_equal(mstats.friedmanchisquare(x2[0],x2[1],x2[2],x2[3]),
+        #                           (18.9428571428571, 0.000280938375189499))
+
+        assert_array_almost_equal(mstats.friedmanchisquare(x3[0], x3[1],
+                                                           x3[2], x3[3]),
+                                  (10.68, 0.0135882729582176))
+        assert_raises(ValueError, mstats.friedmanchisquare,x3[0],x3[1])
+
 
 def test_regress_simple():
     # Regress a line with sinusoidal noise. Test for #1273.

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -912,21 +912,21 @@ class TestMisc:
         check_named_results(result, attributes, ma=True)
 
         # copied from `test_stats.py`
-        array = np.asarray
-        x1 = [array([0.763, 0.599, 0.954, 0.628, 0.882, 0.936, 0.661, 0.583,
-                     0.775, 1.0, 0.94, 0.619, 0.972, 0.957]),
-              array([0.768, 0.591, 0.971, 0.661, 0.888, 0.931, 0.668, 0.583,
-                     0.838, 1.0, 0.962, 0.666, 0.981, 0.978]),
-              array([0.771, 0.590, 0.968, 0.654, 0.886, 0.916, 0.609, 0.563,
-                     0.866, 1.0, 0.965, 0.614, 0.9751, 0.946]),
-              array([0.798, 0.569, 0.967, 0.657, 0.898, 0.931, 0.685, 0.625,
-                     0.875, 1.0, 0.962, 0.669, 0.975, 0.970])]
+        array = np.ma.asarray
+        x1 = [array([0.763, 0.599, 0.954, 0.628, 0.882, 0.936, 0.661,
+                     0.583, 0.775, 1.0, 0.94, 0.619, 0.972, 0.957]),
+              array([0.768, 0.591, 0.971, 0.661, 0.888, 0.931, 0.668,
+                     0.583, 0.838, 1.0, 0.962, 0.666, 0.981, 0.978]),
+              array([0.771, 0.590, 0.968, 0.654, 0.886, 0.916, 0.609,
+                     0.563, 0.866, 1.0, 0.965, 0.614, 0.9751, 0.946]),
+              array([0.798, 0.569, 0.967, 0.657, 0.898, 0.931, 0.685,
+                     0.625, 0.875, 1.0, 0.962, 0.669, 0.975, 0.970])]
 
         # From "Bioestadistica para las ciencias de la salud" Xf=18.95 p<0.001:
-        x2 = [array([4, 3, 5, 3, 5, 3, 2, 5, 4, 4, 4, 3]),
-              array([2, 2, 1, 2, 3, 1, 2, 3, 2, 1, 1, 3]),
-              array([2, 4, 3, 3, 4, 3, 3, 4, 4, 1, 2, 1]),
-              array([3, 5, 4, 3, 4, 4, 3, 3, 3, 4, 4, 4])]
+        # x2 = [array([4, 3, 5, 3, 5, 3, 2, 5, 4, 4, 4, 3]),
+        #       array([2, 2, 1, 2, 3, 1, 2, 3, 2, 1, 1, 3]),
+        #       array([2, 4, 3, 3, 4, 3, 3, 4, 4, 1, 2, 1]),
+        #       array([3, 5, 4, 3, 4, 4, 3, 3, 3, 4, 4, 4])]
 
         # From Jerrorl H. Zar, "Biostatistical Analysis"(example 12.6),
         # Xf=10.68, 0.005 < p < 0.01:
@@ -938,17 +938,16 @@ class TestMisc:
               array([8.8, 8.9, 8.1, 3.3, 9.1])]
 
         # test using mstats
-        assert_array_almost_equal(mstats.friedmanchisquare(x1[0], x1[1],
-                                                           x1[2], x1[3]),
+        assert_array_almost_equal(mstats.friedmanchisquare(*x1),
                                   (10.2283464566929, 0.0167215803284414))
+
         # the following fails
-        # assert_array_almost_equal(mstats.friedmanchisquare(x2[0],x2[1],x2[2],x2[3]),
+        # assert_array_almost_equal(mstats.friedmanchisquare(*x2),
         #                           (18.9428571428571, 0.000280938375189499))
 
-        assert_array_almost_equal(mstats.friedmanchisquare(x3[0], x3[1],
-                                                           x3[2], x3[3]),
+        assert_array_almost_equal(mstats.friedmanchisquare(*x3),
                                   (10.68, 0.0135882729582176))
-        assert_raises(ValueError, mstats.friedmanchisquare,x3[0],x3[1])
+        assert_raises(ValueError, mstats.friedmanchisquare, x3[0], x3[1])
 
 
 def test_regress_simple():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4506,31 +4506,31 @@ class TestFriedmanChiSquare:
     # verified with matlab and R
     # From Demsar "Statistical Comparisons of Classifiers over Multiple Data Sets"
     # 2006, Xf=9.28 (no tie handling, tie corrected Xf >=9.28)
-    x1 = [array([0.763, 0.599, 0.954, 0.628, 0.882, 0.936, 0.661, 0.583,
-                 0.775, 1.0, 0.94, 0.619, 0.972, 0.957]),
-          array([0.768, 0.591, 0.971, 0.661, 0.888, 0.931, 0.668, 0.583,
-                 0.838, 1.0, 0.962, 0.666, 0.981, 0.978]),
-          array([0.771, 0.590, 0.968, 0.654, 0.886, 0.916, 0.609, 0.563,
-                 0.866, 1.0, 0.965, 0.614, 0.9751, 0.946]),
-          array([0.798, 0.569, 0.967, 0.657, 0.898, 0.931, 0.685, 0.625,
-                 0.875, 1.0, 0.962, 0.669, 0.975, 0.970])]
+    x1 = [[0.763, 0.599, 0.954, 0.628, 0.882, 0.936, 0.661,
+           0.583, 0.775, 1.0, 0.94, 0.619, 0.972, 0.957],
+          [0.768, 0.591, 0.971, 0.661, 0.888, 0.931, 0.668,
+           0.583, 0.838, 1.0, 0.962, 0.666, 0.981, 0.978],
+          [0.771, 0.590, 0.968, 0.654, 0.886, 0.916, 0.609,
+           0.563, 0.866, 1.0, 0.965, 0.614, 0.9751, 0.946],
+          [0.798, 0.569, 0.967, 0.657, 0.898, 0.931, 0.685,
+           0.625, 0.875, 1.0, 0.962, 0.669, 0.975, 0.970]]
     ref1 = (10.2283464566929, 0.0167215803284414)
 
     # From "Bioestadistica para las ciencias de la salud" Xf=18.95 p<0.001:
-    x2 = [array([4, 3, 5, 3, 5, 3, 2, 5, 4, 4, 4, 3]),
-          array([2, 2, 1, 2, 3, 1, 2, 3, 2, 1, 1, 3]),
-          array([2, 4, 3, 3, 4, 3, 3, 4, 4, 1, 2, 1]),
-          array([3, 5, 4, 3, 4, 4, 3, 3, 3, 4, 4, 4])]
+    x2 = [[4, 3, 5, 3, 5, 3, 2, 5, 4, 4, 4, 3],
+          [2, 2, 1, 2, 3, 1, 2, 3, 2, 1, 1, 3],
+          [2, 4, 3, 3, 4, 3, 3, 4, 4, 1, 2, 1],
+          [3, 5, 4, 3, 4, 4, 3, 3, 3, 4, 4, 4]]
     ref2 = (18.9428571428571, 0.000280938375189499)
 
     # From Jerrorl H. Zar, "Biostatistical Analysis"(example 12.6),
     # Xf=10.68, 0.005 < p < 0.01:
     # Probability from this example is inexact
     # using Chisquare approximation of Friedman Chisquare.
-    x3 = [array([7.0, 9.9, 8.5, 5.1, 10.3]),
-          array([5.3, 5.7, 4.7, 3.5, 7.7]),
-          array([4.9, 7.6, 5.5, 2.8, 8.4]),
-          array([8.8, 8.9, 8.1, 3.3, 9.1])]
+    x3 = [[7.0, 9.9, 8.5, 5.1, 10.3],
+          [5.3, 5.7, 4.7, 3.5, 7.7],
+          [4.9, 7.6, 5.5, 2.8, 8.4],
+          [8.8, 8.9, 8.1, 3.3, 9.1]]
     ref3 = (10.68, 0.0135882729582176)
 
     @pytest.mark.parametrize("dtype", [None, "float32", "float64"])
@@ -4539,7 +4539,7 @@ class TestFriedmanChiSquare:
         if is_numpy(xp) and xp.__version__ < "2.0" and dtype=='float32':
             pytest.skip("NumPy doesn't preserve dtype pre-NEP 50.")
         dtype = dtype if dtype is None else getattr(xp, dtype)
-        data = [xp.asarray(array.tolist(), dtype=dtype) for array in data]
+        data = [xp.asarray(array, dtype=dtype) for array in data]
         res = stats.friedmanchisquare(*data)
         xp_assert_close(res.statistic, xp.asarray(ref[0], dtype=dtype))
         xp_assert_close(res.pvalue, xp.asarray(ref[1], dtype=dtype))
@@ -4547,7 +4547,7 @@ class TestFriedmanChiSquare:
     def test_too_few_samples(self, xp):
         message = "At least 3 samples must be given"
         with pytest.raises(ValueError, match=message):
-            stats.friedmanchisquare(*self.x3[:2])
+            stats.friedmanchisquare(xp.asarray(self.x3[0]), xp.asarray(self.x3[1]))
 
 
 class TestKSTest:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -26,7 +26,6 @@ from numpy import array, arange, float32, power
 import numpy as np
 
 import scipy.stats as stats
-import scipy.stats.mstats as mstats
 import scipy.stats._mstats_basic as mstats_basic
 from scipy.stats._ksstats import kolmogn
 from scipy.special._testutils import FuncData
@@ -4502,8 +4501,8 @@ class TestChisquare:
         xp_assert_equal(res.pvalue, p)
 
 
-def test_friedmanchisquare():
-    # see ticket:113
+@make_xp_test_case(stats.friedmanchisquare)
+class TestFriedmanChiSquare:
     # verified with matlab and R
     # From Demsar "Statistical Comparisons of Classifiers over Multiple Data Sets"
     # 2006, Xf=9.28 (no tie handling, tie corrected Xf >=9.28)
@@ -4515,46 +4514,40 @@ def test_friedmanchisquare():
                  0.866, 1.0, 0.965, 0.614, 0.9751, 0.946]),
           array([0.798, 0.569, 0.967, 0.657, 0.898, 0.931, 0.685, 0.625,
                  0.875, 1.0, 0.962, 0.669, 0.975, 0.970])]
+    ref1 = (10.2283464566929, 0.0167215803284414)
 
     # From "Bioestadistica para las ciencias de la salud" Xf=18.95 p<0.001:
-    x2 = [array([4,3,5,3,5,3,2,5,4,4,4,3]),
-          array([2,2,1,2,3,1,2,3,2,1,1,3]),
-          array([2,4,3,3,4,3,3,4,4,1,2,1]),
-          array([3,5,4,3,4,4,3,3,3,4,4,4])]
+    x2 = [array([4, 3, 5, 3, 5, 3, 2, 5, 4, 4, 4, 3]),
+          array([2, 2, 1, 2, 3, 1, 2, 3, 2, 1, 1, 3]),
+          array([2, 4, 3, 3, 4, 3, 3, 4, 4, 1, 2, 1]),
+          array([3, 5, 4, 3, 4, 4, 3, 3, 3, 4, 4, 4])]
+    ref2 = (18.9428571428571, 0.000280938375189499)
 
     # From Jerrorl H. Zar, "Biostatistical Analysis"(example 12.6),
     # Xf=10.68, 0.005 < p < 0.01:
     # Probability from this example is inexact
     # using Chisquare approximation of Friedman Chisquare.
-    x3 = [array([7.0,9.9,8.5,5.1,10.3]),
-          array([5.3,5.7,4.7,3.5,7.7]),
-          array([4.9,7.6,5.5,2.8,8.4]),
-          array([8.8,8.9,8.1,3.3,9.1])]
+    x3 = [array([7.0, 9.9, 8.5, 5.1, 10.3]),
+          array([5.3, 5.7, 4.7, 3.5, 7.7]),
+          array([4.9, 7.6, 5.5, 2.8, 8.4]),
+          array([8.8, 8.9, 8.1, 3.3, 9.1])]
+    ref3 = (10.68, 0.0135882729582176)
 
-    assert_array_almost_equal(stats.friedmanchisquare(x1[0],x1[1],x1[2],x1[3]),
-                              (10.2283464566929, 0.0167215803284414))
-    assert_array_almost_equal(stats.friedmanchisquare(x2[0],x2[1],x2[2],x2[3]),
-                              (18.9428571428571, 0.000280938375189499))
-    assert_array_almost_equal(stats.friedmanchisquare(x3[0],x3[1],x3[2],x3[3]),
-                              (10.68, 0.0135882729582176))
-    assert_raises(ValueError, stats.friedmanchisquare,x3[0],x3[1])
+    @pytest.mark.parametrize("dtype", [None, "float32", "float64"])
+    @pytest.mark.parametrize("data, ref", [(x1, ref1), (x2, ref2), (x3, ref3)])
+    def test_against_references(self, dtype, data, ref, xp):
+        if is_numpy(xp) and xp.__version__ < "2.0" and dtype=='float32':
+            pytest.skip("NumPy doesn't preserve dtype pre-NEP 50.")
+        dtype = dtype if dtype is None else getattr(xp, dtype)
+        data = [xp.asarray(array.tolist(), dtype=dtype) for array in data]
+        res = stats.friedmanchisquare(*data)
+        xp_assert_close(res.statistic, xp.asarray(ref[0], dtype=dtype))
+        xp_assert_close(res.pvalue, xp.asarray(ref[1], dtype=dtype))
 
-    # test for namedtuple attribute results
-    attributes = ('statistic', 'pvalue')
-    res = stats.friedmanchisquare(*x1)
-    check_named_results(res, attributes)
-
-    # test using mstats
-    assert_array_almost_equal(mstats.friedmanchisquare(x1[0], x1[1],
-                                                       x1[2], x1[3]),
-                              (10.2283464566929, 0.0167215803284414))
-    # the following fails
-    # assert_array_almost_equal(mstats.friedmanchisquare(x2[0],x2[1],x2[2],x2[3]),
-    #                           (18.9428571428571, 0.000280938375189499))
-    assert_array_almost_equal(mstats.friedmanchisquare(x3[0], x3[1],
-                                                       x3[2], x3[3]),
-                              (10.68, 0.0135882729582176))
-    assert_raises(ValueError, mstats.friedmanchisquare,x3[0],x3[1])
+    def test_too_few_samples(self, xp):
+        message = "At least 3 samples must be given"
+        with pytest.raises(ValueError, match=message):
+            stats.friedmanchisquare(*self.x3[:2])
 
 
 class TestKSTest:


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `scipy.stats.friedmanchisquare`.

#### Additional information
Diff looks a little smaller with whitespace changes ignored. The tests were not in a class, so I needed some indentation. Also, some mstats tests were in `test_stats`, so those needed to be moved over.