### PR TITLE
TST: stats: avoid modifying shared self.u

### DIFF
--- a/scipy/stats/tests/test_binned_statistic.py
+++ b/scipy/stats/tests/test_binned_statistic.py
@@ -64,8 +64,7 @@ class TestBinnedStatistic:
         # if either `values` or `sample` contain np.inf or np.nan throw
         # see issue gh-9010 for more
         x = self.x
-        u = self.u
-        orig = u[0]
+        u = self.u.copy()  # take copy before modification
         u[0] = np.inf
         assert_raises(ValueError, binned_statistic, u, x, 'std', bins=10)
         # need to test for non-python specific ints, e.g. np.int8, np.int64
@@ -73,8 +72,6 @@ class TestBinnedStatistic:
                       bins=np.int64(10))
         u[0] = np.nan
         assert_raises(ValueError, binned_statistic, u, x, 'count', bins=10)
-        # replace original value, u belongs the class
-        u[0] = orig
 
     def test_1d_result_attributes(self):
         x = self.x


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #23910

#### What does this implement/fix?

A test in scipy.stats.tests.test_binned_statistic.TestBinnedStatistic.test_non_finite_inputs_and_int_bins can make concurrent use of a class variable when run with pytest-run-parallel.
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

See issue for information about how to trigger the error locally.