### PR TITLE
ENH: stats.fligner: add array API support

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1,3 +1,4 @@
+import itertools
 import math
 import warnings
 import threading
@@ -3176,7 +3177,7 @@ def levene(*samples, center='median', proportiontocut=0.05, axis=0):
 FlignerResult = namedtuple('FlignerResult', ('statistic', 'pvalue'))
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(skip_backends=[('dask.array', 'no rankdata')], jax_jit=False)
 @_axis_nan_policy_factory(FlignerResult, n_samples=None)
 def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
     r"""Perform Fligner-Killeen test for equality of variance.
@@ -3268,54 +3269,63 @@ def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
 
     For a more detailed example, see :ref:`hypothesis_fligner`.
     """
+    xp = array_namespace(*samples)
+
     if center not in ['mean', 'median', 'trimmed']:
         raise ValueError("center must be 'mean', 'median' or 'trimmed'.")
 
     k = len(samples)
     if k < 2:
-        raise ValueError("Must enter at least two input sample vectors.")
+        raise ValueError("Must provide at least two samples.")
+
+    samples = xp_promote(*samples, force_floating=True, xp=xp)
+    dtype = samples[0].dtype
 
     # Handle empty input
     for sample in samples:
         if sample.size == 0:
-            NaN = _get_nan(*samples)
+            NaN = _get_nan(*samples, xp=xp)
             return FlignerResult(NaN, NaN)
 
     if center == 'median':
 
         def func(x):
-            return np.median(x, axis=-1, keepdims=True)
+            return (xp.median(x, axis=-1, keepdims=True)
+                    if (is_numpy(xp) or is_dask(xp))
+                    else stats.quantile(x, 0.5, axis=-1, keepdims=True))
 
     elif center == 'mean':
 
         def func(x):
-            return np.mean(x, axis=-1, keepdims=True)
+            return xp.mean(x, axis=-1, keepdims=True)
 
     else:  # center == 'trimmed'
 
         def func(x):
-            return _stats_py.trim_mean(x, proportiontocut, axis=-1, keepdims=True)
+            # keepdims=True doesn't currently work for lazy arrays
+            return _stats_py.trim_mean(x, proportiontocut, axis=-1)[..., xp.newaxis]
 
     ni = [sample.shape[-1] for sample in samples]
     N = sum(ni)
 
     # Implementation follows [3] pg 355 F-K.
     Xibar = [func(sample) for sample in samples]
-    Xij_Xibar = [np.abs(sample - Xibar_) for sample, Xibar_ in zip(samples, Xibar)]
-    Xij_Xibar = np.concatenate(Xij_Xibar, axis=-1)
-    ranks = _stats_py._rankdata(Xij_Xibar, method='average')
+    Xij_Xibar = [xp.abs(sample - Xibar_) for sample, Xibar_ in zip(samples, Xibar)]
+    Xij_Xibar = xp.concat(Xij_Xibar, axis=-1)
+    ranks = _stats_py._rankdata(Xij_Xibar, method='average', xp=xp)
+    ranks = xp.astype(ranks, dtype)
     a_Ni = special.ndtri(ranks / (2*(N + 1.0)) + 0.5)
 
     # [3] Equation 2.1
-    splits = np.cumsum(ni[:-1])
-    Ai = np.split(a_Ni,  splits, axis=-1)
-    Aibar = [np.mean(Ai_, axis=-1) for Ai_ in Ai]
-    abar = np.mean(a_Ni, axis=-1)
-    V2 = np.var(a_Ni, axis=-1, ddof=1)
+    splits = list(itertools.accumulate(ni, initial=0))
+    Ai = [a_Ni[..., i:j] for i, j in zip(splits[:-1], splits[1:])]
+    Aibar = [xp.mean(Ai_, axis=-1) for Ai_ in Ai]
+    abar = xp.mean(a_Ni, axis=-1)
+    V2 = xp.var(a_Ni, axis=-1, correction=1)
     statistic = sum(ni_ * (Aibar_ - abar)**2 for ni_, Aibar_ in zip(ni, Aibar)) / V2
 
-    chi2 = _SimpleChi2(k-1)
-    pval = _get_pvalue(statistic, chi2, alternative='greater', symmetric=False, xp=np)
+    chi2 = _SimpleChi2(xp.asarray(k-1, dtype=dtype))
+    pval = _get_pvalue(statistic, chi2, alternative='greater', symmetric=False, xp=xp)
     return FlignerResult(statistic, pval)
 
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3177,7 +3177,8 @@ def levene(*samples, center='median', proportiontocut=0.05, axis=0):
 FlignerResult = namedtuple('FlignerResult', ('statistic', 'pvalue'))
 
 
-@xp_capabilities(skip_backends=[('dask.array', 'no rankdata')], jax_jit=False)
+@xp_capabilities(skip_backends=[('dask.array', 'no rankdata'),
+                                ('cupy', 'no rankdata')], jax_jit=False)
 @_axis_nan_policy_factory(FlignerResult, n_samples=None)
 def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
     r"""Perform Fligner-Killeen test for equality of variance.

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1096,6 +1096,8 @@ class TestFligner:
 
     @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
     def test_data(self, dtype, xp):
+        if is_numpy(xp) and dtype == 'float32' and xp.__version__ < "2":
+            pytest.skip("Scalar dtypes only respected after NEP 50.")
         # numbers from R: fligner.test in package stats
         dtype = xp_default_dtype(xp) if dtype is None else getattr(xp, dtype)
         x1 = xp.arange(5, dtype=dtype)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -26,7 +26,7 @@ from scipy.stats._axis_nan_policy import (SmallSampleWarning, too_small_nd_omit,
                                           too_small_1d_omit, too_small_1d_not_omit)
 
 from scipy._lib._array_api import (is_torch, make_xp_test_case, eager_warns, xp_ravel,
-                                   is_numpy)
+                                   is_numpy, xp_default_dtype)
 from scipy._lib._array_api_no_0d import (
     xp_assert_close,
     xp_assert_equal,
@@ -1086,76 +1086,83 @@ class TestBinomTest:
             stats.binomtest(5, 6, p=sys.float_info.min)
 
 
+@make_xp_test_case(stats.fligner)
 class TestFligner:
 
-    def test_data(self):
-        # numbers from R: fligner.test in package stats
-        x1 = np.arange(5)
-        assert_array_almost_equal(stats.fligner(x1, x1**2),
-                                  (3.2282229927203536, 0.072379187848207877),
-                                  11)
+    def _perturb(self, g, rng=124987234782812):
+        # g arrays have ties to which statistic is very sensitive; break them
+        rng = np.random.default_rng(rng)
+        return (np.asarray(g) + 1e-10 * rng.standard_normal(len(g))).tolist()
 
-    def test_trimmed1(self):
+    @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
+    def test_data(self, dtype, xp):
+        # numbers from R: fligner.test in package stats
+        dtype = xp_default_dtype(xp) if dtype is None else getattr(xp, dtype)
+        x1 = xp.arange(5, dtype=dtype)
+        res = stats.fligner(x1, x1**2)
+        ref = (xp.asarray(3.2282229927203536, dtype=dtype),
+               xp.asarray(0.072379187848207877, dtype=dtype))
+        xp_assert_close(res[0], ref[0])
+        xp_assert_close(res[1], ref[1])
+
+    def test_trimmed1(self, xp):
         # Perturb input to break ties in the transformed data
         # See https://github.com/scipy/scipy/pull/8042 for more details
-        rs = np.random.RandomState(123)
-
-        def _perturb(g):
-            return (np.asarray(g) + 1e-10 * rs.randn(len(g))).tolist()
-
-        g1_ = _perturb(g1)
-        g2_ = _perturb(g2)
-        g3_ = _perturb(g3)
+        rng = np.random.default_rng(9952379681)
+        g1_ = xp.asarray(self._perturb(g1, rng=rng))
+        g2_ = xp.asarray(self._perturb(g2, rng=rng))
+        g3_ = xp.asarray(self._perturb(g3, rng=rng))
         # Test that center='trimmed' gives the same result as center='mean'
         # when proportiontocut=0.
         Xsq1, pval1 = stats.fligner(g1_, g2_, g3_, center='mean')
         Xsq2, pval2 = stats.fligner(g1_, g2_, g3_, center='trimmed',
                                     proportiontocut=0.0)
-        assert_almost_equal(Xsq1, Xsq2)
-        assert_almost_equal(pval1, pval2)
+        xp_assert_close(Xsq1, Xsq2)
+        xp_assert_close(pval1, pval2)
 
-    def test_trimmed_nonregression(self):
+    @pytest.mark.skip_xp_backends(np_only=True,
+                                  reason="inconsistent tie-breaking across backends")
+    def test_trimmed_nonregression(self, xp):
         # This is a non-regression test
         # Expected results are *not* from an external gold standard,
         # we're just making sure the results remain consistent
         # in the future in case of changes
         args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
+        args = [xp.asarray(arg, dtype=xp.float64) for arg in args]
         W, pval = stats.fligner(*args, center="trimmed", proportiontocut=0.25)
-        assert_allclose(W, 15.953569890010614, rtol=5e-14)
-        assert_allclose(pval, 0.06785752327432863, rtol=5e-14)
+        xp_assert_close(W, xp.asarray(15.953569890010614), rtol=5e-14)
+        xp_assert_close(pval, xp.asarray(0.06785752327432863), rtol=5e-14)
 
-    # The following test looks reasonable at first, but fligner() uses the
-    # function stats.rankdata(), and in one of the cases in this test,
-    # there are ties, while in the other (because of normal rounding
-    # errors) there are not.  This difference leads to differences in the
-    # third significant digit of W.
-    #
-    #def test_equal_mean_median(self):
-    #    x = np.linspace(-1,1,21)
-    #    y = x**3
-    #    W1, pval1 = stats.fligner(x, y, center='mean')
-    #    W2, pval2 = stats.fligner(x, y, center='median')
-    #    assert_almost_equal(W1, W2)
-    #    assert_almost_equal(pval1, pval2)
+    def test_trimmed_consistency(self, xp):
+        # Tests for consistency across multiple backends when ties are broken
+        rng = np.random.default_rng(4839206199)
+        args = [g1, g2, g3, g4, g5, g6, g7, g8, g9, g10]
+        args = [self._perturb(arg, rng=rng) for arg in args]
+        ref = stats.fligner(*args, center="trimmed", proportiontocut=0.25)
+        args = [xp.asarray(arg, dtype=xp.float64) for arg in args]
+        res = stats.fligner(*args, center="trimmed", proportiontocut=0.25)
+        xp_assert_close(res.statistic, xp.asarray(ref.statistic), rtol=5e-14)
+        xp_assert_close(res.pvalue, xp.asarray(ref.pvalue), rtol=5e-14)
 
-    def test_bad_keyword(self):
-        x = np.linspace(-1, 1, 21)
-        assert_raises(TypeError, stats.fligner, x, x, portiontocut=0.1)
+    def test_bad_center_value(self, xp):
+        x = xp.linspace(-1, 1, 21)
+        message = "center must be 'mean', 'median' or 'trimmed'."
+        with pytest.raises(ValueError, match=message):
+            stats.fligner(x, x, center='trim')
 
-    def test_bad_center_value(self):
-        x = np.linspace(-1, 1, 21)
-        assert_raises(ValueError, stats.fligner, x, x, center='trim')
-
-    def test_bad_num_args(self):
+    def test_bad_num_args(self, xp):
         # Too few args raises ValueError.
-        assert_raises(ValueError, stats.fligner, [1])
+        message = "Must provide at least two samples."
+        with pytest.raises(ValueError, match=message):
+            stats.fligner(xp.asarray([1, 2]))
 
-    def test_empty_arg(self):
-        x = np.arange(5)
+    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no _axis_nan_policy')
+    def test_empty_arg(self, xp):
+        x = xp.arange(5.)
         with pytest.warns(SmallSampleWarning, match=too_small_1d_not_omit):
-            res = stats.fligner(x, x**2, [])
-            assert_equal(res.statistic, np.nan)
-            assert_equal(res.pvalue, np.nan)
+            res = stats.fligner(x, x**2, xp.asarray([]))
+        xp_assert_equal(res.statistic, xp.asarray(xp.nan))
+        xp_assert_equal(res.pvalue, xp.asarray(xp.nan))
 
 
 def mood_cases_with_ties():


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `scipy.stats.fligner`.
