### PR TITLE
BUG: `special`: Fix convergence criterion in `eval_{legendre, gegenbauer}_l`

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -165,7 +165,7 @@ cdef inline double eval_gegenbauer_l(Py_ssize_t n, double alpha, double x) noexc
             p += d
             d *= -4*x**2 * (a - kk) * (-a + alpha + kk + n) / (
                 (n + 1 - 2*a + 2*kk) * (n + 2 - 2*a + 2*kk))
-            if fabs(d) == 1e-20*fabs(p):
+            if fabs(d) < 1e-20*fabs(p):
                 # converged
                 break
         return p
@@ -341,7 +341,7 @@ cdef inline double eval_legendre_l(Py_ssize_t n, double x) noexcept nogil:
             p += d
             d *= -2 * x**2 * (a - kk) * (2*n + 1 - 2*a + 2*kk) / (
                 (n + 1 - 2*a + 2*kk) * (n + 2 - 2*a + 2*kk))
-            if fabs(d) == 1e-20*fabs(p):
+            if fabs(d) < 1e-20*fabs(p):
                 # converged
                 break
         return p


### PR DESCRIPTION
Calling it a bug might be a overstating this a bit, but these convergence criteria would (almost) never be reached. It shouldn't make (much) difference in the outcomes, but this could help a little bit with performance for large $n$.

An alternative solution would be to just remove these checks.