### PR TITLE
ENH:optimize: implement Chandrupatla's method for classic root scalar interfaces

### DIFF
--- a/scipy/optimize/Zeros/chandrupatla.c
+++ b/scipy/optimize/Zeros/chandrupatla.c
@@ -1,0 +1,86 @@
+/*
+ * copied from ridder.c and adapted for Chandrupatla method
+ * doi:10.1016/S0965-9978(96)00051-8
+ */
+
+#include "zeros.h"
+#include <math.h>
+
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#define SIGN(a) ((a) > 0. ? 1. : -1.)
+
+/* Sets solver_stats->error_num
+    SIGNERR for sign_error;
+    CONVERR for convergence_error;
+*/
+
+double chandrupatla(callback_type f, double xa, double xb, double xtol,
+                    double rtol, int iter, void *func_data_param,
+                    scipy_zeros_info *solver_stats) {
+  int i;
+  double dm, xm, xc, fm, fa, fb, fc, tol, t, phi, xi;
+  solver_stats->error_num = INPROGRESS;
+
+  tol = xtol + rtol * MIN(fabs(xa), fabs(xb));
+  fa = (*f)(xa, func_data_param);
+  fb = (*f)(xb, func_data_param);
+  solver_stats->funcalls = 2;
+  if (fa == 0) {
+    solver_stats->error_num = CONVERGED;
+    return xa;
+  }
+  if (fb == 0) {
+    solver_stats->error_num = CONVERGED;
+    return xb;
+  }
+  if (signbit(fa) == signbit(fb)) {
+    solver_stats->error_num = SIGNERR;
+    return 0.;
+  }
+
+  t = 0.5;
+  xm = xa + t * (xb - xa); // to avoid maybe uninitialized warning
+  solver_stats->iterations = 0;
+  for (i = 0; i < iter; i++) {
+    solver_stats->iterations++;
+    dm = t * (xb - xa);
+    xm = xa + dm;
+    fm = (*f)(xm, func_data_param);
+    solver_stats->funcalls += 1;
+
+    if (signbit(fa) != signbit(fm)) { // warning: is noted wrongly in the flow
+                                      // chart of original paper
+      xc = xb;
+      xb = xa;
+      xa = xm;
+      fc = fb;
+      fb = fa;
+      fa = fm;
+    } else {
+      xc = xa;
+      xa = xm;
+      fc = fa;
+      fa = fm;
+    }
+
+    tol = xtol + rtol * xm;
+    if (fm == 0.0 || fabs(xb - xa) < tol) {
+      solver_stats->error_num = CONVERGED;
+      return xm;
+    }
+
+    // test if inverse quadratic interpolation is applicable
+    phi = (fa - fb) / (fc - fb);
+    xi = (xa - xb) / (xc - xb);
+    if (1 - sqrt(1 - xi) < phi && phi < sqrt(xi)) {
+      // do inverse quadratic interpolation
+      t = (fa / (fa - fb)) * (fc / (fc - fb)) -
+          ((xc - xa) / (xb - xa)) * (fa / (fc - fa)) * (fb / (fb - fc));
+    } else {
+      // do bisection
+      t = 0.5;
+    }
+  }
+  solver_stats->error_num = CONVERR;
+  return xm;
+}

--- a/scipy/optimize/Zeros/zeros.h
+++ b/scipy/optimize/Zeros/zeros.h
@@ -12,7 +12,6 @@ typedef struct {
     int error_num;
 } scipy_zeros_info;
 
-
 /* Must agree with _ECONVERGED, _ESIGNERR, _ECONVERR  in zeros.py */
 #define CONVERGED 0
 #define SIGNERR -1
@@ -28,6 +27,9 @@ extern double bisect(callback_type f, double xa, double xb, double xtol,
                      double rtol, int iter, void *func_data_param,
                      scipy_zeros_info *solver_stats);
 extern double ridder(callback_type f, double xa, double xb, double xtol,
+                     double rtol, int iter, void *func_data_param,
+                     scipy_zeros_info *solver_stats);
+extern double chandrupatla(callback_type f, double xa, double xb, double xtol,
                      double rtol, int iter, void *func_data_param,
                      scipy_zeros_info *solver_stats);
 extern double brenth(callback_type f, double xa, double xb, double xtol,

--- a/scipy/optimize/__init__.py
+++ b/scipy/optimize/__init__.py
@@ -158,6 +158,7 @@ Scalar functions
    brentq - quadratic interpolation Brent method.
    brenth - Brent method, modified by Harris with hyperbolic extrapolation.
    ridder - Ridder's method.
+   chandrupatla - Chandrupatla's method.
    bisect - Bisection method.
    newton - Newton's method (also Secant and Halley's methods).
    toms748 - Alefeld, Potra & Shi Algorithm 748.
@@ -171,6 +172,7 @@ The `root_scalar` function supports the following methods:
    optimize.root_scalar-brenth
    optimize.root_scalar-bisect
    optimize.root_scalar-ridder
+   optimize.root_scalar-chandrupatla
    optimize.root_scalar-newton
    optimize.root_scalar-toms748
    optimize.root_scalar-secant

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1,4 +1,4 @@
-#__docformat__ = "restructuredtext en"
+# __docformat__ = "restructuredtext en"
 # ******NOTICE***************
 # optimize.py module by Travis E. Oliphant
 #
@@ -17,11 +17,28 @@
 
 # Minimization routines
 
-__all__ = ['fmin', 'fmin_powell', 'fmin_bfgs', 'fmin_ncg', 'fmin_cg',
-           'fminbound', 'brent', 'golden', 'bracket', 'rosen', 'rosen_der',
-           'rosen_hess', 'rosen_hess_prod', 'brute', 'approx_fprime',
-           'line_search', 'check_grad', 'OptimizeResult', 'show_options',
-           'OptimizeWarning']
+__all__ = [
+    "fmin",
+    "fmin_powell",
+    "fmin_bfgs",
+    "fmin_ncg",
+    "fmin_cg",
+    "fminbound",
+    "brent",
+    "golden",
+    "bracket",
+    "rosen",
+    "rosen_der",
+    "rosen_hess",
+    "rosen_hess_prod",
+    "brute",
+    "approx_fprime",
+    "line_search",
+    "check_grad",
+    "OptimizeResult",
+    "show_options",
+    "OptimizeWarning",
+]
 
 __docformat__ = "restructuredtext en"
 
@@ -33,29 +50,35 @@ from numpy import eye, argmin, zeros, shape, asarray, sqrt
 import numpy as np
 from scipy.linalg import cholesky, issymmetric, LinAlgError
 from scipy.sparse.linalg import LinearOperator
-from ._linesearch import (line_search_wolfe1, line_search_wolfe2,
-                          line_search_wolfe2 as line_search,
-                          LineSearchWarning)
+from ._linesearch import (
+    line_search_wolfe1,
+    line_search_wolfe2,
+    line_search_wolfe2 as line_search,
+    LineSearchWarning,
+)
 from ._numdiff import approx_derivative
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
-from scipy._lib._util import (MapWrapper, check_random_state, _RichResult,
-                              _call_callback_maybe_halt, _transition_to_rng)
+from scipy._lib._util import (
+    MapWrapper,
+    check_random_state,
+    _RichResult,
+    _call_callback_maybe_halt,
+    _transition_to_rng,
+)
 from scipy.optimize._differentiable_functions import ScalarFunction, FD_METHODS
 from scipy._lib._array_api import array_namespace, xp_capabilities, xp_promote
 from scipy._lib import array_api_extra as xpx
 
 
 # standard status messages of optimizers
-_status_message = {'success': 'Optimization terminated successfully.',
-                   'maxfev': 'Maximum number of function evaluations has '
-                              'been exceeded.',
-                   'maxiter': 'Maximum number of iterations has been '
-                              'exceeded.',
-                   'pr_loss': 'Desired error not necessarily achieved due '
-                              'to precision loss.',
-                   'nan': 'NaN result encountered.',
-                   'out_of_bounds': 'The result is outside of the provided '
-                                    'bounds.'}
+_status_message = {
+    "success": "Optimization terminated successfully.",
+    "maxfev": "Maximum number of function evaluations has been exceeded.",
+    "maxiter": "Maximum number of iterations has been exceeded.",
+    "pr_loss": "Desired error not necessarily achieved due to precision loss.",
+    "nan": "NaN result encountered.",
+    "out_of_bounds": "The result is outside of the provided bounds.",
+}
 
 
 class MemoizeJac:
@@ -76,7 +99,7 @@ class MemoizeJac:
             self._value = fg[0]
 
     def __call__(self, x, *args):
-        """ returns the function value """
+        """returns the function value"""
         self._compute_if_needed(x, *args)
         return self._value
 
@@ -87,21 +110,25 @@ class MemoizeJac:
 
 def _wrap_callback(callback, method=None):
     """Wrap a user-provided callback so that attributes can be attached."""
-    if callback is None or method in {'tnc', 'cobyla', 'cobyqa'}:
+    if callback is None or method in {"tnc", "cobyla", "cobyqa"}:
         return callback  # don't wrap
 
     sig = inspect.signature(callback)
 
-    if set(sig.parameters) == {'intermediate_result'}:
+    if set(sig.parameters) == {"intermediate_result"}:
+
         def wrapped_callback(res):
             return callback(intermediate_result=res)
-    elif method == 'trust-constr':
+    elif method == "trust-constr":
+
         def wrapped_callback(res):
             return callback(np.copy(res.x), res)
-    elif method == 'differential_evolution':
+    elif method == "differential_evolution":
+
         def wrapped_callback(res):
             return callback(np.copy(res.x), res.convergence)
     else:
+
         def wrapped_callback(res):
             return callback(np.copy(res.x))
 
@@ -151,12 +178,15 @@ class OptimizeResult(_RichResult):
     attributes are available using the `OptimizeResult.keys` method.
 
     """
+
     pass
 
 
 class OptimizeWarning(UserWarning):
     """General warning for :mod:`scipy.optimize`."""
+
     pass
+
 
 def _check_positive_definite(Hk):
     def is_pos_def(A):
@@ -168,6 +198,7 @@ def _check_positive_definite(Hk):
                 return False
         else:
             return False
+
     if Hk is not None:
         if not is_pos_def(Hk):
             raise ValueError("'hess_inv0' matrix isn't positive definite.")
@@ -183,9 +214,7 @@ def _check_unknown_options(unknown_options):
 
 
 def is_finite_scalar(x):
-    """Test whether `x` is either a finite scalar or a finite array scalar.
-
-    """
+    """Test whether `x` is either a finite scalar or a finite array scalar."""
     return np.size(x) == 1 and np.isfinite(x)
 
 
@@ -198,12 +227,20 @@ def vecnorm(x, ord=2):
     elif ord == -np.inf:
         return np.amin(np.abs(x))
     else:
-        return np.sum(np.abs(x)**ord, axis=0)**(1.0 / ord)
+        return np.sum(np.abs(x) ** ord, axis=0) ** (1.0 / ord)
 
 
-def _prepare_scalar_function(fun, x0, jac=None, args=(), bounds=None,
-                             epsilon=None, finite_diff_rel_step=None,
-                             hess=None, workers=None):
+def _prepare_scalar_function(
+    fun,
+    x0,
+    jac=None,
+    args=(),
+    bounds=None,
+    epsilon=None,
+    finite_diff_rel_step=None,
+    hess=None,
+    workers=None,
+):
     """
     Creates a ScalarFunction object for use with scalar minimizers
     (BFGS/LBFGSB/SLSQP/TNC/CG/etc).
@@ -288,7 +325,7 @@ def _prepare_scalar_function(fun, x0, jac=None, args=(), bounds=None,
         # absolute step size. ScalarFunction has to be provided an
         # epsilon value that is not None to use absolute steps. This is
         # normally the case from most _minimize* methods.
-        grad = '2-point'
+        grad = "2-point"
         epsilon = epsilon
 
     if hess is None:
@@ -307,9 +344,17 @@ def _prepare_scalar_function(fun, x0, jac=None, args=(), bounds=None,
 
     # ScalarFunction caches. Reuse of fun(x) during grad
     # calculation reduces overall function evaluations.
-    sf = ScalarFunction(fun, x0, args, grad, hess,
-                        finite_diff_rel_step, bounds, epsilon=epsilon,
-                        workers=workers)
+    sf = ScalarFunction(
+        fun,
+        x0,
+        args,
+        grad,
+        hess,
+        finite_diff_rel_step,
+        bounds,
+        epsilon=epsilon,
+        workers=workers,
+    )
 
     return sf
 
@@ -329,9 +374,12 @@ def _clip_x_for_func(func, bounds):
 
 def _check_clip_x(x, bounds):
     if (x < bounds[0]).any() or (x > bounds[1]).any():
-        warnings.warn("Values in x were outside bounds during a "
-                      "minimize step, clipping to bounds",
-                      RuntimeWarning, stacklevel=3)
+        warnings.warn(
+            "Values in x were outside bounds during a "
+            "minimize step, clipping to bounds",
+            RuntimeWarning,
+            stacklevel=3,
+        )
         x = np.clip(x, bounds[0], bounds[1])
         return x
 
@@ -383,12 +431,15 @@ def rosen(x):
     """
     xp = array_namespace(x)
     x = xp_promote(x, force_floating=True, xp=xp)
-    r = xp.sum(100.0 * (x[1:] - x[:-1]**2.0)**2.0 + (1 - x[:-1])**2.0,
-               axis=0, dtype=x.dtype)
+    r = xp.sum(
+        100.0 * (x[1:] - x[:-1] ** 2.0) ** 2.0 + (1 - x[:-1]) ** 2.0,
+        axis=0,
+        dtype=x.dtype,
+    )
     return r
 
 
-@xp_capabilities(skip_backends=[('jax.numpy', "JAX doesn't allow item assignment.")])
+@xp_capabilities(skip_backends=[("jax.numpy", "JAX doesn't allow item assignment.")])
 def rosen_der(x):
     """
     The derivative (i.e. gradient) of the Rosenbrock function.
@@ -422,10 +473,9 @@ def rosen_der(x):
     xm_m1 = x[:-2]
     xm_p1 = x[2:]
     der = xp.zeros_like(x)
-    der[1:-1] = (200 * (xm - xm_m1**2) -
-                 400 * (xm_p1 - xm**2) * xm - 2 * (1 - xm))
-    der[0] = -400 * x[0] * (x[1] - x[0]**2) - 2 * (1 - x[0])
-    der[-1] = 200 * (x[-1] - x[-2]**2)
+    der[1:-1] = 200 * (xm - xm_m1**2) - 400 * (xm_p1 - xm**2) * xm - 2 * (1 - xm)
+    der[0] = -400 * x[0] * (x[1] - x[0] ** 2) - 2 * (1 - x[0])
+    der[-1] = 200 * (x[-1] - x[-2] ** 2)
     return der
 
 
@@ -463,16 +513,17 @@ def rosen_hess(x):
     xp = array_namespace(x)
     x = xp_promote(x, force_floating=True, xp=xp)
 
-    H = (xpx.create_diagonal(-400 * x[:-1], offset=1, xp=xp)
-         - xpx.create_diagonal(400 * x[:-1], offset=-1, xp=xp))
+    H = xpx.create_diagonal(-400 * x[:-1], offset=1, xp=xp) - xpx.create_diagonal(
+        400 * x[:-1], offset=-1, xp=xp
+    )
     diagonal = xp.zeros(x.shape[0], dtype=x.dtype)
-    diagonal = xpx.at(diagonal)[0].set(1200 * x[0]**2 - 400 * x[1] + 2)
+    diagonal = xpx.at(diagonal)[0].set(1200 * x[0] ** 2 - 400 * x[1] + 2)
     diagonal = xpx.at(diagonal)[-1].set(200)
-    diagonal = xpx.at(diagonal)[1:-1].set(202 + 1200 * x[1:-1]**2 - 400 * x[2:])
+    diagonal = xpx.at(diagonal)[1:-1].set(202 + 1200 * x[1:-1] ** 2 - 400 * x[2:])
     return H + xpx.create_diagonal(diagonal, xp=xp)
 
 
-@xp_capabilities(skip_backends=[('jax.numpy', "JAX doesn't allow item assignment.")])
+@xp_capabilities(skip_backends=[("jax.numpy", "JAX doesn't allow item assignment.")])
 def rosen_hess_prod(x, p):
     """
     Product of the Hessian matrix of the Rosenbrock function with a vector.
@@ -509,11 +560,13 @@ def rosen_hess_prod(x, p):
     x = xpx.atleast_nd(x, ndim=1, xp=xp)
     p = xp.asarray(p, dtype=x.dtype)
     Hp = xp.zeros(x.shape[0], dtype=x.dtype)
-    Hp[0] = (1200 * x[0]**2 - 400 * x[1] + 2) * p[0] - 400 * x[0] * p[1]
-    Hp[1:-1] = (-400 * x[:-2] * p[:-2] +
-                (202 + 1200 * x[1:-1]**2 - 400 * x[2:]) * p[1:-1] -
-                400 * x[1:-1] * p[2:])
-    Hp[-1] = -400 * x[-2] * p[-2] + 200*p[-1]
+    Hp[0] = (1200 * x[0] ** 2 - 400 * x[1] + 2) * p[0] - 400 * x[0] * p[1]
+    Hp[1:-1] = (
+        -400 * x[:-2] * p[:-2]
+        + (202 + 1200 * x[1:-1] ** 2 - 400 * x[2:]) * p[1:-1]
+        - 400 * x[1:-1] * p[2:]
+    )
+    Hp[-1] = -400 * x[-2] * p[-2] + 200 * p[-1]
     return Hp
 
 
@@ -534,8 +587,9 @@ def _wrap_scalar_function(function, args):
             try:
                 fx = np.asarray(fx).item()
             except (TypeError, ValueError) as e:
-                raise ValueError("The user-provided objective function "
-                                 "must return a scalar value.") from e
+                raise ValueError(
+                    "The user-provided objective function must return a scalar value."
+                ) from e
         return fx
 
     return ncalls, function_wrapper
@@ -565,15 +619,28 @@ def _wrap_scalar_function_maxfun_validation(function, args, maxfun):
             try:
                 fx = np.asarray(fx).item()
             except (TypeError, ValueError) as e:
-                raise ValueError("The user-provided objective function "
-                                 "must return a scalar value.") from e
+                raise ValueError(
+                    "The user-provided objective function must return a scalar value."
+                ) from e
         return fx
 
     return ncalls, function_wrapper
 
 
-def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
-         full_output=0, disp=1, retall=0, callback=None, initial_simplex=None):
+def fmin(
+    func,
+    x0,
+    args=(),
+    xtol=1e-4,
+    ftol=1e-4,
+    maxiter=None,
+    maxfun=None,
+    full_output=0,
+    disp=1,
+    retall=0,
+    callback=None,
+    initial_simplex=None,
+):
     """
     Minimize a function using the downhill simplex algorithm.
 
@@ -675,33 +742,46 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
            Harlow, UK, pp. 191-208.
 
     """
-    opts = {'xatol': xtol,
-            'fatol': ftol,
-            'maxiter': maxiter,
-            'maxfev': maxfun,
-            'disp': disp,
-            'return_all': retall,
-            'initial_simplex': initial_simplex}
+    opts = {
+        "xatol": xtol,
+        "fatol": ftol,
+        "maxiter": maxiter,
+        "maxfev": maxfun,
+        "disp": disp,
+        "return_all": retall,
+        "initial_simplex": initial_simplex,
+    }
 
     callback = _wrap_callback(callback)
     res = _minimize_neldermead(func, x0, args, callback=callback, **opts)
     if full_output:
-        retlist = res['x'], res['fun'], res['nit'], res['nfev'], res['status']
+        retlist = res["x"], res["fun"], res["nit"], res["nfev"], res["status"]
         if retall:
-            retlist += (res['allvecs'], )
+            retlist += (res["allvecs"],)
         return retlist
     else:
         if retall:
-            return res['x'], res['allvecs']
+            return res["x"], res["allvecs"]
         else:
-            return res['x']
+            return res["x"]
 
 
-def _minimize_neldermead(func, x0, args=(), callback=None,
-                         maxiter=None, maxfev=None, disp=False,
-                         return_all=False, initial_simplex=None,
-                         xatol=1e-4, fatol=1e-4, adaptive=False, bounds=None,
-                         **unknown_options):
+def _minimize_neldermead(
+    func,
+    x0,
+    args=(),
+    callback=None,
+    maxiter=None,
+    maxfev=None,
+    disp=False,
+    return_all=False,
+    initial_simplex=None,
+    xatol=1e-4,
+    fatol=1e-4,
+    adaptive=False,
+    bounds=None,
+    **unknown_options,
+):
     """
     Minimization of scalar function of one or more variables using the
     Nelder-Mead algorithm.
@@ -762,9 +842,9 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
     if adaptive:
         dim = float(len(x0))
         rho = 1
-        chi = 1 + 2/dim
-        psi = 0.75 - 1/(2*dim)
-        sigma = 1 - 1/dim
+        chi = 1 + 2 / dim
+        psi = 0.75 - 1 / (2 * dim)
+        sigma = 1 - 1 / dim
     else:
         rho = 1
         chi = 2
@@ -778,11 +858,15 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         lower_bound, upper_bound = bounds.lb, bounds.ub
         # check bounds
         if (lower_bound > upper_bound).any():
-            raise ValueError("Nelder Mead - one of the lower bounds "
-                             "is greater than an upper bound.")
+            raise ValueError(
+                "Nelder Mead - one of the lower bounds is greater than an upper bound."
+            )
         if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
-            warnings.warn("Initial guess is not within the specified bounds",
-                          OptimizeWarning, stacklevel=3)
+            warnings.warn(
+                "Initial guess is not within the specified bounds",
+                OptimizeWarning,
+                stacklevel=3,
+            )
 
     if bounds is not None:
         x0 = np.clip(x0, lower_bound, upper_bound)
@@ -795,7 +879,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         for k in range(N):
             y = np.array(x0, copy=True)
             if y[k] != 0:
-                y[k] = (1 + nonzdelt)*y[k]
+                y[k] = (1 + nonzdelt) * y[k]
             else:
                 y[k] = zdelt
             sim[k + 1] = y
@@ -837,7 +921,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
         # interior.
         msk = sim > upper_bound
         # reflect into the interior
-        sim = np.where(msk, 2*upper_bound - sim, sim)
+        sim = np.where(msk, 2 * upper_bound - sim, sim)
         # but make sure the reflection is no less than the lower_bound
         sim = np.clip(sim, lower_bound, upper_bound)
 
@@ -863,10 +947,12 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
 
     iterations = 1
 
-    while (fcalls[0] < maxfun and iterations < maxiter):
+    while fcalls[0] < maxfun and iterations < maxiter:
         try:
-            if (np.max(np.ravel(np.abs(sim[1:] - sim[0]))) <= xatol and
-                    np.max(np.abs(fsim[0] - fsim[1:])) <= fatol):
+            if (
+                np.max(np.ravel(np.abs(sim[1:] - sim[0]))) <= xatol
+                and np.max(np.abs(fsim[0] - fsim[1:])) <= fatol
+            ):
                 break
 
             xbar = np.add.reduce(sim[:-1], 0) / N
@@ -922,8 +1008,7 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
                         for j in one2np1:
                             sim[j] = sim[0] + sigma * (sim[j] - sim[0])
                             if bounds is not None:
-                                sim[j] = np.clip(
-                                    sim[j], lower_bound, upper_bound)
+                                sim[j] = np.clip(sim[j], lower_bound, upper_bound)
                             fsim[j] = func(sim[j])
             iterations += 1
         except _MaxFuncCallError:
@@ -943,27 +1028,34 @@ def _minimize_neldermead(func, x0, args=(), callback=None,
 
     if fcalls[0] >= maxfun:
         warnflag = 1
-        msg = _status_message['maxfev']
+        msg = _status_message["maxfev"]
         if disp:
             warnings.warn(msg, RuntimeWarning, stacklevel=3)
     elif iterations >= maxiter:
         warnflag = 2
-        msg = _status_message['maxiter']
+        msg = _status_message["maxiter"]
         if disp:
             warnings.warn(msg, RuntimeWarning, stacklevel=3)
     else:
-        msg = _status_message['success']
+        msg = _status_message["success"]
         if disp:
             print(msg)
             print(f"         Current function value: {fval:f}")
             print(f"         Iterations: {iterations:d}")
             print(f"         Function evaluations: {fcalls[0]:d}")
 
-    result = OptimizeResult(fun=fval, nit=iterations, nfev=fcalls[0],
-                            status=warnflag, success=(warnflag == 0),
-                            message=msg, x=x, final_simplex=(sim, fsim))
+    result = OptimizeResult(
+        fun=fval,
+        nit=iterations,
+        nfev=fcalls[0],
+        status=warnflag,
+        success=(warnflag == 0),
+        message=msg,
+        x=x,
+        final_simplex=(sim, fsim),
+    )
     if retall:
-        result['allvecs'] = allvecs
+        result["allvecs"] = allvecs
     return result
 
 
@@ -1044,13 +1136,13 @@ def approx_fprime(xk, f, epsilon=_epsilon, *args):
     xk = np.asarray(xk, float)
     f0 = f(xk, *args)
 
-    return approx_derivative(f, xk, method='2-point', abs_step=epsilon,
-                             args=args, f0=f0)
+    return approx_derivative(
+        f, xk, method="2-point", abs_step=epsilon, args=args, f0=f0
+    )
 
 
 @_transition_to_rng("seed", position_num=6)
-def check_grad(func, grad, x0, *args, epsilon=_epsilon,
-                direction='all', rng=None):
+def check_grad(func, grad, x0, *args, epsilon=_epsilon, direction="all", rng=None):
     r"""Check the correctness of a gradient function by comparing it against a
     (forward) finite-difference approximation of the gradient.
 
@@ -1115,37 +1207,39 @@ def check_grad(func, grad, x0, *args, epsilon=_epsilon,
     x0 = np.asarray(x0)
 
     def g(w, func, x0, v, *args):
-        return func(x0 + w*v, *args)
+        return func(x0 + w * v, *args)
 
-    if direction == 'random':
+    if direction == "random":
         _grad = np.asanyarray(grad(x0, *args))
         if _grad.ndim > 1:
-            raise ValueError("'random' can only be used with scalar valued"
-                             " func")
+            raise ValueError("'random' can only be used with scalar valued func")
         rng_gen = check_random_state(rng)
         v = rng_gen.standard_normal(size=(x0.shape))
         _args = (func, x0, v) + args
         _func = g
         vars = np.zeros((1,))
         analytical_grad = np.dot(_grad, v)
-    elif direction == 'all':
+    elif direction == "all":
         _args = args
         _func = func
         vars = x0
         analytical_grad = grad(x0, *args)
     else:
-        raise ValueError(f"{direction} is not a valid string for "
-                         "``direction`` argument")
+        raise ValueError(
+            f"{direction} is not a valid string for ``direction`` argument"
+        )
 
-    return np.sqrt(np.sum(np.abs(
-        (analytical_grad - approx_fprime(vars, _func, step, *_args))**2
-    )))
+    return np.sqrt(
+        np.sum(
+            np.abs((analytical_grad - approx_fprime(vars, _func, step, *_args)) ** 2)
+        )
+    )
 
 
 def approx_fhess_p(x0, p, fprime, epsilon, *args):
     # calculate fprime(x0) first, as this may be cached by ScalarFunction
     f1 = fprime(*((x0,) + args))
-    f2 = fprime(*((x0 + epsilon*p,) + args))
+    f2 = fprime(*((x0 + epsilon * p,) + args))
     return (f2 - f1) / epsilon
 
 
@@ -1153,8 +1247,7 @@ class _LineSearchError(RuntimeError):
     pass
 
 
-def _line_search_wolfe12(f, fprime, xk, pk, gfk, old_fval, old_old_fval,
-                         **kwargs):
+def _line_search_wolfe12(f, fprime, xk, pk, gfk, old_fval, old_old_fval, **kwargs):
     """
     Same as line_search_wolfe1, but fall back to line_search_wolfe2 if
     suitable step length is not found, and raise an exception if a
@@ -1167,11 +1260,9 @@ def _line_search_wolfe12(f, fprime, xk, pk, gfk, old_fval, old_old_fval,
 
     """
 
-    extra_condition = kwargs.pop('extra_condition', None)
+    extra_condition = kwargs.pop("extra_condition", None)
 
-    ret = line_search_wolfe1(f, fprime, xk, pk, gfk,
-                             old_fval, old_old_fval,
-                             **kwargs)
+    ret = line_search_wolfe1(f, fprime, xk, pk, gfk, old_fval, old_old_fval, **kwargs)
 
     if ret[0] is not None and extra_condition is not None:
         xp1 = xk + ret[0] * pk
@@ -1182,15 +1273,22 @@ def _line_search_wolfe12(f, fprime, xk, pk, gfk, old_fval, old_old_fval,
     if ret[0] is None:
         # line search failed: try different one.
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', LineSearchWarning)
+            warnings.simplefilter("ignore", LineSearchWarning)
             kwargs2 = {}
-            for key in ('c1', 'c2', 'amax'):
+            for key in ("c1", "c2", "amax"):
                 if key in kwargs:
                     kwargs2[key] = kwargs[key]
-            ret = line_search_wolfe2(f, fprime, xk, pk, gfk,
-                                     old_fval, old_old_fval,
-                                     extra_condition=extra_condition,
-                                     **kwargs2)
+            ret = line_search_wolfe2(
+                f,
+                fprime,
+                xk,
+                pk,
+                gfk,
+                old_fval,
+                old_old_fval,
+                extra_condition=extra_condition,
+                **kwargs2,
+            )
 
     if ret[0] is None:
         raise _LineSearchError()
@@ -1198,10 +1296,24 @@ def _line_search_wolfe12(f, fprime, xk, pk, gfk, old_fval, old_old_fval,
     return ret
 
 
-def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
-              epsilon=_epsilon, maxiter=None, full_output=0, disp=1,
-              retall=0, callback=None, xrtol=0, c1=1e-4, c2=0.9,
-              hess_inv0=None):
+def fmin_bfgs(
+    f,
+    x0,
+    fprime=None,
+    args=(),
+    gtol=1e-5,
+    norm=np.inf,
+    epsilon=_epsilon,
+    maxiter=None,
+    full_output=0,
+    disp=1,
+    retall=0,
+    callback=None,
+    xrtol=0,
+    c1=1e-4,
+    c2=0.9,
+    hess_inv0=None,
+):
     """
     Minimize a function using the BFGS algorithm.
 
@@ -1315,38 +1427,62 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
     array([ 2.85916637e-06, -4.54371951e-07])
 
     """
-    opts = {'gtol': gtol,
-            'norm': norm,
-            'eps': epsilon,
-            'disp': disp,
-            'maxiter': maxiter,
-            'return_all': retall,
-            'xrtol': xrtol,
-            'c1': c1,
-            'c2': c2,
-            'hess_inv0': hess_inv0}
+    opts = {
+        "gtol": gtol,
+        "norm": norm,
+        "eps": epsilon,
+        "disp": disp,
+        "maxiter": maxiter,
+        "return_all": retall,
+        "xrtol": xrtol,
+        "c1": c1,
+        "c2": c2,
+        "hess_inv0": hess_inv0,
+    }
 
     callback = _wrap_callback(callback)
     res = _minimize_bfgs(f, x0, args, fprime, callback=callback, **opts)
 
     if full_output:
-        retlist = (res['x'], res['fun'], res['jac'], res['hess_inv'],
-                   res['nfev'], res['njev'], res['status'])
+        retlist = (
+            res["x"],
+            res["fun"],
+            res["jac"],
+            res["hess_inv"],
+            res["nfev"],
+            res["njev"],
+            res["status"],
+        )
         if retall:
-            retlist += (res['allvecs'], )
+            retlist += (res["allvecs"],)
         return retlist
     else:
         if retall:
-            return res['x'], res['allvecs']
+            return res["x"], res["allvecs"]
         else:
-            return res['x']
+            return res["x"]
 
 
-def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
-                   gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
-                   disp=False, return_all=False, finite_diff_rel_step=None,
-                   xrtol=0, c1=1e-4, c2=0.9,
-                   hess_inv0=None, workers=None, **unknown_options):
+def _minimize_bfgs(
+    fun,
+    x0,
+    args=(),
+    jac=None,
+    callback=None,
+    gtol=1e-5,
+    norm=np.inf,
+    eps=_epsilon,
+    maxiter=None,
+    disp=False,
+    return_all=False,
+    finite_diff_rel_step=None,
+    xrtol=0,
+    c1=1e-4,
+    c2=0.9,
+    hess_inv0=None,
+    workers=None,
+    **unknown_options,
+):
     """
     Minimization of scalar function of one or more variables using the
     BFGS algorithm.
@@ -1413,9 +1549,15 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     if maxiter is None:
         maxiter = len(x0) * 200
 
-    sf = _prepare_scalar_function(fun, x0, jac, args=args, epsilon=eps,
-                                  finite_diff_rel_step=finite_diff_rel_step,
-                                  workers=workers)
+    sf = _prepare_scalar_function(
+        fun,
+        x0,
+        jac,
+        args=args,
+        epsilon=eps,
+        finite_diff_rel_step=finite_diff_rel_step,
+        workers=workers,
+    )
 
     f = sf.fun
     myfprime = sf.grad
@@ -1439,10 +1581,19 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
     while (gnorm > gtol) and (k < maxiter):
         pk = -np.dot(Hk, gfk)
         try:
-            alpha_k, fc, gc, old_fval, old_old_fval, gfkp1 = \
-                     _line_search_wolfe12(f, myfprime, xk, pk, gfk,
-                                          old_fval, old_old_fval, amin=1e-100,
-                                          amax=1e100, c1=c1, c2=c2)
+            alpha_k, fc, gc, old_fval, old_old_fval, gfkp1 = _line_search_wolfe12(
+                f,
+                myfprime,
+                xk,
+                pk,
+                gfk,
+                old_fval,
+                old_old_fval,
+                amin=1e-100,
+                amax=1e100,
+                c1=c1,
+                c2=c2,
+            )
         except _LineSearchError:
             # Line search failed to find a better solution.
             warnflag = 2
@@ -1464,14 +1615,14 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         if _call_callback_maybe_halt(callback, intermediate_result):
             break
         gnorm = vecnorm(gfk, ord=norm)
-        if (gnorm <= gtol):
+        if gnorm <= gtol:
             break
 
         #  See Chapter 5 in  P.E. Frandsen, K. Jonasson, H.B. Nielsen,
         #  O. Tingleff: "Unconstrained Optimization", IMM, DTU.  1999.
         #  These notes are available here:
         #  http://www2.imm.dtu.dk/documents/ftp/publlec.html
-        if (alpha_k*vecnorm(pk) <= xrtol*(xrtol + vecnorm(xk))):
+        if alpha_k * vecnorm(pk) <= xrtol * (xrtol + vecnorm(xk)):
             break
 
         if not np.isfinite(old_fval):
@@ -1484,31 +1635,30 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         # this was handled in numeric, let it remains for more safety
         # Cryptic comment above is preserved for posterity. Future reader:
         # consider change to condition below proposed in gh-1261/gh-17345.
-        if rhok_inv == 0.:
+        if rhok_inv == 0.0:
             rhok = 1000.0
             if disp:
                 msg = "Divide-by-zero encountered: rhok assumed large"
                 _print_success_message_or_warn(True, msg)
         else:
-            rhok = 1. / rhok_inv
+            rhok = 1.0 / rhok_inv
 
         A1 = I - sk[:, np.newaxis] * yk[np.newaxis, :] * rhok
         A2 = I - yk[:, np.newaxis] * sk[np.newaxis, :] * rhok
-        Hk = np.dot(A1, np.dot(Hk, A2)) + (rhok * sk[:, np.newaxis] *
-                                                 sk[np.newaxis, :])
+        Hk = np.dot(A1, np.dot(Hk, A2)) + (rhok * sk[:, np.newaxis] * sk[np.newaxis, :])
 
     fval = old_fval
 
     if warnflag == 2:
-        msg = _status_message['pr_loss']
+        msg = _status_message["pr_loss"]
     elif k >= maxiter:
         warnflag = 1
-        msg = _status_message['maxiter']
+        msg = _status_message["maxiter"]
     elif np.isnan(gnorm) or np.isnan(fval) or np.isnan(xk).any():
         warnflag = 3
-        msg = _status_message['nan']
+        msg = _status_message["nan"]
     else:
-        msg = _status_message['success']
+        msg = _status_message["success"]
 
     if disp:
         _print_success_message_or_warn(warnflag, msg)
@@ -1517,12 +1667,20 @@ def _minimize_bfgs(fun, x0, args=(), jac=None, callback=None,
         print(f"         Function evaluations: {sf.nfev:d}")
         print(f"         Gradient evaluations: {sf.ngev:d}")
 
-    result = OptimizeResult(fun=fval, jac=gfk, hess_inv=Hk, nfev=sf.nfev,
-                            njev=sf.ngev, status=warnflag,
-                            success=(warnflag == 0), message=msg, x=xk,
-                            nit=k)
+    result = OptimizeResult(
+        fun=fval,
+        jac=gfk,
+        hess_inv=Hk,
+        nfev=sf.nfev,
+        njev=sf.ngev,
+        status=warnflag,
+        success=(warnflag == 0),
+        message=msg,
+        x=xk,
+        nit=k,
+    )
     if retall:
-        result['allvecs'] = allvecs
+        result["allvecs"] = allvecs
     return result
 
 
@@ -1533,9 +1691,22 @@ def _print_success_message_or_warn(warnflag, message, warntype=None):
         warnings.warn(message, warntype or OptimizeWarning, stacklevel=3)
 
 
-def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
-            epsilon=_epsilon, maxiter=None, full_output=0, disp=1, retall=0,
-            callback=None, c1=1e-4, c2=0.4):
+def fmin_cg(
+    f,
+    x0,
+    fprime=None,
+    args=(),
+    gtol=1e-5,
+    norm=np.inf,
+    epsilon=_epsilon,
+    maxiter=None,
+    full_output=0,
+    disp=1,
+    retall=0,
+    callback=None,
+    c1=1e-4,
+    c2=0.4,
+):
     """
     Minimize a function using a nonlinear conjugate gradient algorithm.
 
@@ -1693,34 +1864,48 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
     array([-1.80851064, -0.25531915])
 
     """
-    opts = {'gtol': gtol,
-            'norm': norm,
-            'eps': epsilon,
-            'disp': disp,
-            'maxiter': maxiter,
-            'return_all': retall}
+    opts = {
+        "gtol": gtol,
+        "norm": norm,
+        "eps": epsilon,
+        "disp": disp,
+        "maxiter": maxiter,
+        "return_all": retall,
+    }
 
     callback = _wrap_callback(callback)
-    res = _minimize_cg(f, x0, args, fprime, callback=callback, c1=c1, c2=c2,
-                       **opts)
+    res = _minimize_cg(f, x0, args, fprime, callback=callback, c1=c1, c2=c2, **opts)
 
     if full_output:
-        retlist = res['x'], res['fun'], res['nfev'], res['njev'], res['status']
+        retlist = res["x"], res["fun"], res["nfev"], res["njev"], res["status"]
         if retall:
-            retlist += (res['allvecs'], )
+            retlist += (res["allvecs"],)
         return retlist
     else:
         if retall:
-            return res['x'], res['allvecs']
+            return res["x"], res["allvecs"]
         else:
-            return res['x']
+            return res["x"]
 
 
-def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
-                 gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
-                 disp=False, return_all=False, finite_diff_rel_step=None,
-                 c1=1e-4, c2=0.4, workers=None,
-                 **unknown_options):
+def _minimize_cg(
+    fun,
+    x0,
+    args=(),
+    jac=None,
+    callback=None,
+    gtol=1e-5,
+    norm=np.inf,
+    eps=_epsilon,
+    maxiter=None,
+    disp=False,
+    return_all=False,
+    finite_diff_rel_step=None,
+    c1=1e-4,
+    c2=0.4,
+    workers=None,
+    **unknown_options,
+):
     """
     Minimization of scalar function of one or more variables using the
     conjugate gradient algorithm.
@@ -1772,9 +1957,15 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
     if maxiter is None:
         maxiter = len(x0) * 200
 
-    sf = _prepare_scalar_function(fun, x0, jac=jac, args=args, epsilon=eps,
-                                  finite_diff_rel_step=finite_diff_rel_step,
-                                  workers=workers)
+    sf = _prepare_scalar_function(
+        fun,
+        x0,
+        jac=jac,
+        args=args,
+        epsilon=eps,
+        finite_diff_rel_step=finite_diff_rel_step,
+        workers=workers,
+    )
 
     f = sf.fun
     myfprime = sf.grad
@@ -1828,10 +2019,20 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
             return np.dot(pk, gfk) <= -sigma_3 * np.dot(gfk, gfk)
 
         try:
-            alpha_k, fc, gc, old_fval, old_old_fval, gfkp1 = \
-                     _line_search_wolfe12(f, myfprime, xk, pk, gfk, old_fval,
-                                          old_old_fval, c1=c1, c2=c2, amin=1e-100,
-                                          amax=1e100, extra_condition=descent_condition)
+            alpha_k, fc, gc, old_fval, old_old_fval, gfkp1 = _line_search_wolfe12(
+                f,
+                myfprime,
+                xk,
+                pk,
+                gfk,
+                old_fval,
+                old_old_fval,
+                c1=c1,
+                c2=c2,
+                amin=1e-100,
+                amax=1e100,
+                extra_condition=descent_condition,
+            )
         except _LineSearchError:
             # Line search failed to find a better solution.
             warnflag = 2
@@ -1852,15 +2053,15 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
 
     fval = old_fval
     if warnflag == 2:
-        msg = _status_message['pr_loss']
+        msg = _status_message["pr_loss"]
     elif k >= maxiter:
         warnflag = 1
-        msg = _status_message['maxiter']
+        msg = _status_message["maxiter"]
     elif np.isnan(gnorm) or np.isnan(fval) or np.isnan(xk).any():
         warnflag = 3
-        msg = _status_message['nan']
+        msg = _status_message["nan"]
     else:
-        msg = _status_message['success']
+        msg = _status_message["success"]
 
     if disp:
         _print_success_message_or_warn(warnflag, msg)
@@ -1869,18 +2070,39 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         print(f"         Function evaluations: {sf.nfev:d}")
         print(f"         Gradient evaluations: {sf.ngev:d}")
 
-    result = OptimizeResult(fun=fval, jac=gfk, nfev=sf.nfev,
-                            njev=sf.ngev, status=warnflag,
-                            success=(warnflag == 0), message=msg, x=xk,
-                            nit=k)
+    result = OptimizeResult(
+        fun=fval,
+        jac=gfk,
+        nfev=sf.nfev,
+        njev=sf.ngev,
+        status=warnflag,
+        success=(warnflag == 0),
+        message=msg,
+        x=xk,
+        nit=k,
+    )
     if retall:
-        result['allvecs'] = allvecs
+        result["allvecs"] = allvecs
     return result
 
 
-def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
-             epsilon=_epsilon, maxiter=None, full_output=0, disp=1, retall=0,
-             callback=None, c1=1e-4, c2=0.9):
+def fmin_ncg(
+    f,
+    x0,
+    fprime,
+    fhess_p=None,
+    fhess=None,
+    args=(),
+    avextol=1e-5,
+    epsilon=_epsilon,
+    maxiter=None,
+    full_output=0,
+    disp=1,
+    retall=0,
+    callback=None,
+    c1=1e-4,
+    c2=0.9,
+):
     """
     Unconstrained minimization of a function using the Newton-CG method.
 
@@ -1975,33 +2197,56 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
     Wright & Nocedal, 'Numerical Optimization', 1999, p. 140.
 
     """
-    opts = {'xtol': avextol,
-            'eps': epsilon,
-            'maxiter': maxiter,
-            'disp': disp,
-            'return_all': retall}
+    opts = {
+        "xtol": avextol,
+        "eps": epsilon,
+        "maxiter": maxiter,
+        "disp": disp,
+        "return_all": retall,
+    }
 
     callback = _wrap_callback(callback)
-    res = _minimize_newtoncg(f, x0, args, fprime, fhess, fhess_p,
-                             callback=callback, c1=c1, c2=c2, **opts)
+    res = _minimize_newtoncg(
+        f, x0, args, fprime, fhess, fhess_p, callback=callback, c1=c1, c2=c2, **opts
+    )
 
     if full_output:
-        retlist = (res['x'], res['fun'], res['nfev'], res['njev'],
-                   res['nhev'], res['status'])
+        retlist = (
+            res["x"],
+            res["fun"],
+            res["nfev"],
+            res["njev"],
+            res["nhev"],
+            res["status"],
+        )
         if retall:
-            retlist += (res['allvecs'], )
+            retlist += (res["allvecs"],)
         return retlist
     else:
         if retall:
-            return res['x'], res['allvecs']
+            return res["x"], res["allvecs"]
         else:
-            return res['x']
+            return res["x"]
 
 
-def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
-                       callback=None, xtol=1e-5, eps=_epsilon, maxiter=None,
-                       disp=False, return_all=False, c1=1e-4, c2=0.9, workers=None,
-                       **unknown_options):
+def _minimize_newtoncg(
+    fun,
+    x0,
+    args=(),
+    jac=None,
+    hess=None,
+    hessp=None,
+    callback=None,
+    xtol=1e-5,
+    eps=_epsilon,
+    maxiter=None,
+    disp=False,
+    return_all=False,
+    c1=1e-4,
+    c2=0.9,
+    workers=None,
+    **unknown_options,
+):
     """
     Minimization of scalar function of one or more variables using the
     Newton-CG algorithm.
@@ -2039,7 +2284,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     """
     _check_unknown_options(unknown_options)
     if jac is None:
-        raise ValueError('Jacobian is required for Newton-CG method')
+        raise ValueError("Jacobian is required for Newton-CG method")
     fhess_p = hessp
     fhess = hess
     avextol = xtol
@@ -2062,7 +2307,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     # - If hess is None but you have callable(hessp) then use the hessp.
     # - If hess and hessp are None then approximate hessp using the grad/jac.
 
-    if (hess in FD_METHODS or isinstance(_h, LinearOperator)):
+    if hess in FD_METHODS or isinstance(_h, LinearOperator):
         fhess = None
 
         def _hessp(x, p, *args):
@@ -2079,18 +2324,26 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
             print(f"         Gradient evaluations: {sf.ngev:d}")
             print(f"         Hessian evaluations: {hcalls:d}")
         fval = old_fval
-        result = OptimizeResult(fun=fval, jac=gfk, nfev=sf.nfev,
-                                njev=sf.ngev, nhev=hcalls, status=warnflag,
-                                success=(warnflag == 0), message=msg, x=xk,
-                                nit=k)
+        result = OptimizeResult(
+            fun=fval,
+            jac=gfk,
+            nfev=sf.nfev,
+            njev=sf.ngev,
+            nhev=hcalls,
+            status=warnflag,
+            success=(warnflag == 0),
+            message=msg,
+            x=xk,
+            nit=k,
+        )
         if retall:
-            result['allvecs'] = allvecs
+            result["allvecs"] = allvecs
         return result
 
     hcalls = 0
     if maxiter is None:
-        maxiter = len(x0)*200
-    cg_maxiter = 20*len(x0)
+        maxiter = len(x0) * 200
+    cg_maxiter = 20 * len(x0)
 
     xtol = len(x0) * avextol
     # Make sure we enter the while loop.
@@ -2105,7 +2358,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
     float64eps = np.finfo(np.float64).eps
     while update_l1norm > xtol:
         if k >= maxiter:
-            msg = "Warning: " + _status_message['maxiter']
+            msg = "Warning: " + _status_message["maxiter"]
             return terminate(1, msg)
         # Compute a search direction pk by applying the CG method to
         #  del2 f(xk) p = - grad f(xk) starting from 0.
@@ -2119,7 +2372,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
         i = 0
         dri0 = np.dot(ri, ri)
 
-        if fhess is not None:             # you want to compute hessian once.
+        if fhess is not None:  # you want to compute hessian once.
             A = sf.hess(xk)
             hcalls += 1
 
@@ -2142,7 +2395,7 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
             if 0 <= curv <= 3 * float64eps:
                 break
             elif curv < 0:
-                if (i > 0):
+                if i > 0:
                     break
                 else:
                     # fall back to steepest descent direction
@@ -2155,27 +2408,29 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
             betai = dri1 / dri0
             psupi = -ri + betai * psupi
             i += 1
-            dri0 = dri1          # update np.dot(ri,ri) for next time.
+            dri0 = dri1  # update np.dot(ri,ri) for next time.
         else:
             # curvature keeps increasing, bail out
-            msg = ("Warning: CG iterations didn't converge. The Hessian is not "
-                   "positive definite.")
+            msg = (
+                "Warning: CG iterations didn't converge. The Hessian is not "
+                "positive definite."
+            )
             return terminate(3, msg)
 
         pk = xsupi  # search direction is solution to system.
-        gfk = -b    # gradient at xk
+        gfk = -b  # gradient at xk
 
         try:
-            alphak, fc, gc, old_fval, old_old_fval, gfkp1 = \
-                     _line_search_wolfe12(f, fprime, xk, pk, gfk,
-                                          old_fval, old_old_fval, c1=c1, c2=c2)
+            alphak, fc, gc, old_fval, old_old_fval, gfkp1 = _line_search_wolfe12(
+                f, fprime, xk, pk, gfk, old_fval, old_old_fval, c1=c1, c2=c2
+            )
         except _LineSearchError:
             # Line search failed to find a better solution.
-            msg = "Warning: " + _status_message['pr_loss']
+            msg = "Warning: " + _status_message["pr_loss"]
             return terminate(2, msg)
 
         update = alphak * pk
-        xk += update        # upcast if necessary
+        xk += update  # upcast if necessary
         if retall:
             allvecs.append(xk)
         k += 1
@@ -2186,14 +2441,13 @@ def _minimize_newtoncg(fun, x0, args=(), jac=None, hess=None, hessp=None,
 
     else:
         if np.isnan(old_fval) or np.isnan(update_l1norm):
-            return terminate(3, _status_message['nan'])
+            return terminate(3, _status_message["nan"])
 
-        msg = _status_message['success']
+        msg = _status_message["success"]
         return terminate(0, msg)
 
 
-def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
-              full_output=0, disp=1):
+def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500, full_output=0, disp=1):
     """Bounded minimization for scalar functions.
 
     Parameters
@@ -2275,20 +2529,18 @@ def fminbound(func, x1, x2, args=(), xtol=1e-5, maxfun=500,
     >>> minimum, fval
     (4.000023843479476, 4.000023843479476)
     """
-    options = {'xatol': xtol,
-               'maxiter': maxfun,
-               'disp': disp}
+    options = {"xatol": xtol, "maxiter": maxfun, "disp": disp}
 
     res = _minimize_scalar_bounded(func, (x1, x2), args, **options)
     if full_output:
-        return res['x'], res['fun'], res['status'], res['nfev']
+        return res["x"], res["fun"], res["status"], res["nfev"]
     else:
-        return res['x']
+        return res["x"]
 
 
-def _minimize_scalar_bounded(func, bounds, args=(),
-                             xatol=1e-5, maxiter=500, disp=0,
-                             **unknown_options):
+def _minimize_scalar_bounded(
+    func, bounds, args=(), xatol=1e-5, maxiter=500, disp=0, **unknown_options
+):
     """
     Options
     -------
@@ -2313,7 +2565,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
     maxfun = maxiter
     # Test bounds are of correct form
     if len(bounds) != 2:
-        raise ValueError('bounds must have two elements.')
+        raise ValueError("bounds must have two elements.")
     x1, x2 = bounds
 
     if not (is_finite_scalar(x1) and is_finite_scalar(x2)):
@@ -2323,8 +2575,8 @@ def _minimize_scalar_bounded(func, bounds, args=(),
         raise ValueError("The lower bound exceeds the upper bound.")
 
     flag = 0
-    header = ' Func-count     x          f(x)          Procedure'
-    step = '       initial'
+    header = " Func-count     x          f(x)          Procedure"
+    step = "       initial"
 
     sqrt_eps = sqrt(2.2e-16)
     golden_mean = 0.5 * (3.0 - sqrt(5.0))
@@ -2348,7 +2600,7 @@ def _minimize_scalar_bounded(func, bounds, args=(),
         print(header)
         print("%5.0f   %12.6g %12.6g %s" % (fmin_data + (step,)))
 
-    while (np.abs(xf - xm) > (tol2 - 0.5 * (b - a))):
+    while np.abs(xf - xm) > (tol2 - 0.5 * (b - a)):
         golden = 1
         # Check for parabolic fit
         if np.abs(e) > tol1:
@@ -2364,16 +2616,19 @@ def _minimize_scalar_bounded(func, bounds, args=(),
             e = rat
 
             # Check for acceptability of parabola
-            if ((np.abs(p) < np.abs(0.5*q*r)) and (p > q*(a - xf)) and
-                    (p < q * (b - xf))):
+            if (
+                (np.abs(p) < np.abs(0.5 * q * r))
+                and (p > q * (a - xf))
+                and (p < q * (b - xf))
+            ):
                 rat = (p + 0.0) / q
                 x = xf + rat
-                step = '       parabolic'
+                step = "       parabolic"
 
                 if ((x - a) < tol2) or ((b - x) < tol2):
                     si = np.sign(xm - xf) + ((xm - xf) == 0)
                     rat = tol1 * si
-            else:      # do a golden-section step
+            else:  # do a golden-section step
                 golden = 1
 
         if golden:  # do a golden-section step
@@ -2381,8 +2636,8 @@ def _minimize_scalar_bounded(func, bounds, args=(),
                 e = a - xf
             else:
                 e = b - xf
-            rat = golden_mean*e
-            step = '       golden'
+            rat = golden_mean * e
+            step = "       golden"
 
         si = np.sign(rat) + (rat == 0)
         x = xf + si * np.maximum(np.abs(rat), tol1)
@@ -2426,20 +2681,26 @@ def _minimize_scalar_bounded(func, bounds, args=(),
     if disp > 0:
         _endprint(x, flag, fval, maxfun, xatol, disp)
 
-    result = OptimizeResult(fun=fval, status=flag, success=(flag == 0),
-                            message={0: 'Solution found.',
-                                     1: 'Maximum number of function calls '
-                                        'reached.',
-                                     2: _status_message['nan']}.get(flag, ''),
-                            x=xf, nfev=num, nit=num)
+    result = OptimizeResult(
+        fun=fval,
+        status=flag,
+        success=(flag == 0),
+        message={
+            0: "Solution found.",
+            1: "Maximum number of function calls reached.",
+            2: _status_message["nan"],
+        }.get(flag, ""),
+        x=xf,
+        nfev=num,
+        nit=num,
+    )
 
     return result
 
 
 class Brent:
-    #need to rethink design of __init__
-    def __init__(self, func, args=(), tol=1.48e-8, maxiter=500,
-                 full_output=0, disp=0):
+    # need to rethink design of __init__
+    def __init__(self, func, args=(), tol=1.48e-8, maxiter=500, full_output=0, disp=0):
         self.func = func
         self.args = args
         self.tol = tol
@@ -2457,7 +2718,7 @@ class Brent:
         self.brack = brack
 
     def get_bracket_info(self):
-        #set up
+        # set up
         func = self.func
         args = self.args
         brack = self.brack
@@ -2466,11 +2727,12 @@ class Brent:
         if brack is None:
             xa, xb, xc, fa, fb, fc, funcalls = bracket(func, args=args)
         elif len(brack) == 2:
-            xa, xb, xc, fa, fb, fc, funcalls = bracket(func, xa=brack[0],
-                                                       xb=brack[1], args=args)
+            xa, xb, xc, fa, fb, fc, funcalls = bracket(
+                func, xa=brack[0], xb=brack[1], args=args
+            )
         elif len(brack) == 3:
             xa, xb, xc = brack
-            if (xa > xc):  # swap so xa < xc can be assumed
+            if xa > xc:  # swap so xa < xc can be assumed
                 xc, xa = xa, xc
             if not ((xa < xb) and (xb < xc)):
                 raise ValueError(
@@ -2488,8 +2750,7 @@ class Brent:
 
             funcalls = 3
         else:
-            raise ValueError("Bracketing interval must be "
-                             "length 2 or 3 sequence.")
+            raise ValueError("Bracketing interval must be length 2 or 3 sequence.")
         ### END core bracket_info code ###
 
         return xa, xb, xc, fa, fb, fc, funcalls
@@ -2501,11 +2762,11 @@ class Brent:
         _mintol = self._mintol
         _cg = self._cg
         #################################
-        #BEGIN CORE ALGORITHM
+        # BEGIN CORE ALGORITHM
         #################################
         x = w = v = xb
         fw = fv = fx = fb
-        if (xa < xc):
+        if xa < xc:
             a = xa
             b = xc
         else:
@@ -2519,7 +2780,7 @@ class Brent:
             print(f"{'Func-count':^12} {'x':^12} {'f(x)': ^12}")
             print(f"{funcalls:^12g} {x:^12.6g} {fx:^12.6g}")
 
-        while (iter < self.maxiter):
+        while iter < self.maxiter:
             tol1 = self.tol * np.abs(x) + _mintol
             tol2 = 2.0 * tol1
             xmid = 0.5 * (a + b)
@@ -2529,51 +2790,54 @@ class Brent:
             # XXX In the first iteration, rat is only bound in the true case
             # of this conditional. This used to cause an UnboundLocalError
             # (gh-4140). It should be set before the if (but to what?).
-            if (np.abs(deltax) <= tol1):
-                if (x >= xmid):
-                    deltax = a - x       # do a golden section step
+            if np.abs(deltax) <= tol1:
+                if x >= xmid:
+                    deltax = a - x  # do a golden section step
                 else:
                     deltax = b - x
                 rat = _cg * deltax
-            else:                              # do a parabolic step
+            else:  # do a parabolic step
                 tmp1 = (x - w) * (fx - fv)
                 tmp2 = (x - v) * (fx - fw)
                 p = (x - v) * tmp2 - (x - w) * tmp1
                 tmp2 = 2.0 * (tmp2 - tmp1)
-                if (tmp2 > 0.0):
+                if tmp2 > 0.0:
                     p = -p
                 tmp2 = np.abs(tmp2)
                 dx_temp = deltax
                 deltax = rat
                 # check parabolic fit
-                if ((p > tmp2 * (a - x)) and (p < tmp2 * (b - x)) and
-                        (np.abs(p) < np.abs(0.5 * tmp2 * dx_temp))):
-                    rat = p * 1.0 / tmp2        # if parabolic step is useful.
+                if (
+                    (p > tmp2 * (a - x))
+                    and (p < tmp2 * (b - x))
+                    and (np.abs(p) < np.abs(0.5 * tmp2 * dx_temp))
+                ):
+                    rat = p * 1.0 / tmp2  # if parabolic step is useful.
                     u = x + rat
-                    if ((u - a) < tol2 or (b - u) < tol2):
+                    if (u - a) < tol2 or (b - u) < tol2:
                         if xmid - x >= 0:
                             rat = tol1
                         else:
                             rat = -tol1
                 else:
-                    if (x >= xmid):
+                    if x >= xmid:
                         deltax = a - x  # if it's not do a golden section step
                     else:
                         deltax = b - x
                     rat = _cg * deltax
 
-            if (np.abs(rat) < tol1):            # update by at least tol1
+            if np.abs(rat) < tol1:  # update by at least tol1
                 if rat >= 0:
                     u = x + tol1
                 else:
                     u = x - tol1
             else:
                 u = x + rat
-            fu = func(*((u,) + self.args))      # calculate new output value
+            fu = func(*((u,) + self.args))  # calculate new output value
             funcalls += 1
 
-            if (fu > fx):                 # if it's bigger than current
-                if (u < x):
+            if fu > fx:  # if it's bigger than current
+                if u < x:
                     a = u
                 else:
                     b = u
@@ -2586,7 +2850,7 @@ class Brent:
                     v = u
                     fv = fu
             else:
-                if (u >= x):
+                if u >= x:
                     a = x
                 else:
                     b = x
@@ -2602,7 +2866,7 @@ class Brent:
 
             iter += 1
         #################################
-        #END CORE ALGORITHM
+        # END CORE ALGORITHM
         #################################
 
         self.xmin = x
@@ -2688,18 +2952,17 @@ def brent(func, args=(), brack=None, tol=1.48e-8, full_output=0, maxiter=500):
     (0.0, 0.0)
 
     """
-    options = {'xtol': tol,
-               'maxiter': maxiter}
+    options = {"xtol": tol, "maxiter": maxiter}
     res = _minimize_scalar_brent(func, brack, args, **options)
     if full_output:
-        return res['x'], res['fun'], res['nit'], res['nfev']
+        return res["x"], res["fun"], res["nit"], res["nfev"]
     else:
-        return res['x']
+        return res["x"]
 
 
-def _minimize_scalar_brent(func, brack=None, args=(), xtol=1.48e-8,
-                           maxiter=500, disp=0,
-                           **unknown_options):
+def _minimize_scalar_brent(
+    func, brack=None, args=(), xtol=1.48e-8, maxiter=500, disp=0, **unknown_options
+):
     """
     Options
     -------
@@ -2727,10 +2990,11 @@ def _minimize_scalar_brent(func, brack=None, args=(), xtol=1.48e-8,
     _check_unknown_options(unknown_options)
     tol = xtol
     if tol < 0:
-        raise ValueError(f'tolerance should be >= 0, got {tol!r}')
+        raise ValueError(f"tolerance should be >= 0, got {tol!r}")
 
-    brent = Brent(func=func, args=args, tol=tol,
-                  full_output=True, maxiter=maxiter, disp=disp)
+    brent = Brent(
+        func=func, args=args, tol=tol, full_output=True, maxiter=maxiter, disp=disp
+    )
     brent.set_bracket(brack)
     brent.optimize()
     x, fval, nit, nfev = brent.get_result(full_output=True)
@@ -2738,9 +3002,11 @@ def _minimize_scalar_brent(func, brack=None, args=(), xtol=1.48e-8,
     success = nit < maxiter and not (np.isnan(x) or np.isnan(fval))
 
     if success:
-        message = ("\nOptimization terminated successfully;\n"
-                   "The returned value satisfies the termination criteria\n"
-                   f"(using xtol = {xtol} )")
+        message = (
+            "\nOptimization terminated successfully;\n"
+            "The returned value satisfies the termination criteria\n"
+            f"(using xtol = {xtol} )"
+        )
     else:
         if nit >= maxiter:
             message = "\nMaximum number of iterations exceeded"
@@ -2750,12 +3016,12 @@ def _minimize_scalar_brent(func, brack=None, args=(), xtol=1.48e-8,
     if disp:
         _print_success_message_or_warn(not success, message)
 
-    return OptimizeResult(fun=fval, x=x, nit=nit, nfev=nfev,
-                          success=success, message=message)
+    return OptimizeResult(
+        fun=fval, x=x, nit=nit, nfev=nfev, success=success, message=message
+    )
 
 
-def golden(func, args=(), brack=None, tol=_epsilon,
-           full_output=0, maxiter=5000):
+def golden(func, args=(), brack=None, tol=_epsilon, full_output=0, maxiter=5000):
     """
     Return the minimizer of a function of one variable using the golden section
     method.
@@ -2823,17 +3089,17 @@ def golden(func, args=(), brack=None, tol=_epsilon,
     (9.925165290385052e-18, 9.925165290385052e-18)
 
     """
-    options = {'xtol': tol, 'maxiter': maxiter}
+    options = {"xtol": tol, "maxiter": maxiter}
     res = _minimize_scalar_golden(func, brack, args, **options)
     if full_output:
-        return res['x'], res['fun'], res['nfev']
+        return res["x"], res["fun"], res["nfev"]
     else:
-        return res['x']
+        return res["x"]
 
 
-def _minimize_scalar_golden(func, brack=None, args=(),
-                            xtol=_epsilon, maxiter=5000, disp=0,
-                            **unknown_options):
+def _minimize_scalar_golden(
+    func, brack=None, args=(), xtol=_epsilon, maxiter=5000, disp=0, **unknown_options
+):
     """
     Options
     -------
@@ -2857,11 +3123,12 @@ def _minimize_scalar_golden(func, brack=None, args=(),
     if brack is None:
         xa, xb, xc, fa, fb, fc, funcalls = bracket(func, args=args)
     elif len(brack) == 2:
-        xa, xb, xc, fa, fb, fc, funcalls = bracket(func, xa=brack[0],
-                                                   xb=brack[1], args=args)
+        xa, xb, xc, fa, fb, fc, funcalls = bracket(
+            func, xa=brack[0], xb=brack[1], args=args
+        )
     elif len(brack) == 3:
         xa, xb, xc = brack
-        if (xa > xc):  # swap so xa < xc can be assumed
+        if xa > xc:  # swap so xa < xc can be assumed
             xc, xa = xa, xc
         if not ((xa < xb) and (xb < xc)):
             raise ValueError(
@@ -2884,7 +3151,7 @@ def _minimize_scalar_golden(func, brack=None, args=(),
     _gC = 1.0 - _gR
     x3 = xc
     x0 = xa
-    if (np.abs(xc - xb) > np.abs(xb - xa)):
+    if np.abs(xc - xb) > np.abs(xb - xa):
         x1 = xb
         x2 = xb + _gC * (xc - xb)
     else:
@@ -2902,7 +3169,7 @@ def _minimize_scalar_golden(func, brack=None, args=(),
     for i in range(maxiter):
         if np.abs(x3 - x0) <= tol * (np.abs(x1) + np.abs(x2)):
             break
-        if (f2 < f1):
+        if f2 < f1:
             x0 = x1
             x1 = x2
             x2 = _gR * x1 + _gC * x3
@@ -2916,7 +3183,7 @@ def _minimize_scalar_golden(func, brack=None, args=(),
             f1 = func(*((x1,) + args))
         funcalls += 1
         if disp > 2:
-            if (f1 < f2):
+            if f1 < f2:
                 xmin, fval = x1, f1
             else:
                 xmin, fval = x2, f2
@@ -2925,7 +3192,7 @@ def _minimize_scalar_golden(func, brack=None, args=(),
         nit += 1
     # end of iteration loop
 
-    if (f1 < f2):
+    if f1 < f2:
         xmin = x1
         fval = f1
     else:
@@ -2935,9 +3202,11 @@ def _minimize_scalar_golden(func, brack=None, args=(),
     success = nit < maxiter and not (np.isnan(fval) or np.isnan(xmin))
 
     if success:
-        message = ("\nOptimization terminated successfully;\n"
-                   "The returned value satisfies the termination criteria\n"
-                   f"(using xtol = {xtol} )")
+        message = (
+            "\nOptimization terminated successfully;\n"
+            "The returned value satisfies the termination criteria\n"
+            f"(using xtol = {xtol} )"
+        )
     else:
         if nit >= maxiter:
             message = "\nMaximum number of iterations exceeded"
@@ -2947,8 +3216,9 @@ def _minimize_scalar_golden(func, brack=None, args=(),
     if disp:
         _print_success_message_or_warn(not success, message)
 
-    return OptimizeResult(fun=fval, nfev=funcalls, x=xmin, nit=nit,
-                          success=success, message=message)
+    return OptimizeResult(
+        fun=fval, nfev=funcalls, x=xmin, nit=nit, success=success, message=message
+    )
 
 
 def bracket(func, xa=0.0, xb=1.0, args=(), grow_limit=110.0, maxiter=1000):
@@ -3031,14 +3301,14 @@ def bracket(func, xa=0.0, xb=1.0, args=(), grow_limit=110.0, maxiter=1000):
     xa, xb = np.asarray([xa, xb])
     fa = func(*(xa,) + args)
     fb = func(*(xb,) + args)
-    if (fa < fb):                      # Switch so fa > fb
+    if fa < fb:  # Switch so fa > fb
         xa, xb = xb, xa
         fa, fb = fb, fa
     xc = xb + _gold * (xb - xa)
     fc = func(*((xc,) + args))
     funcalls = 3
     iter = 0
-    while (fc < fb):
+    while fc < fb:
         tmp1 = (xb - xa) * (fb - fc)
         tmp2 = (xb - xc) * (fb - fa)
         val = tmp2 - tmp1
@@ -3048,36 +3318,38 @@ def bracket(func, xa=0.0, xb=1.0, args=(), grow_limit=110.0, maxiter=1000):
             denom = 2.0 * val
         w = xb - ((xb - xc) * tmp2 - (xb - xa) * tmp1) / denom
         wlim = xb + grow_limit * (xc - xb)
-        msg = ("No valid bracket was found before the iteration limit was "
-               "reached. Consider trying different initial points or "
-               "increasing `maxiter`.")
+        msg = (
+            "No valid bracket was found before the iteration limit was "
+            "reached. Consider trying different initial points or "
+            "increasing `maxiter`."
+        )
         if iter > maxiter:
             raise RuntimeError(msg)
         iter += 1
         if (w - xc) * (xb - w) > 0.0:
             fw = func(*((w,) + args))
             funcalls += 1
-            if (fw < fc):
+            if fw < fc:
                 xa = xb
                 xb = w
                 fa = fb
                 fb = fw
                 break
-            elif (fw > fb):
+            elif fw > fb:
                 xc = w
                 fc = fw
                 break
             w = xc + _gold * (xc - xb)
             fw = func(*((w,) + args))
             funcalls += 1
-        elif (w - wlim)*(wlim - xc) >= 0.0:
+        elif (w - wlim) * (wlim - xc) >= 0.0:
             w = wlim
             fw = func(*((w,) + args))
             funcalls += 1
-        elif (w - wlim)*(xc - w) > 0.0:
+        elif (w - wlim) * (xc - w) > 0.0:
             fw = func(*((w,) + args))
             funcalls += 1
-            if (fw < fc):
+            if fw < fc:
                 xb = xc
                 xc = w
                 w = xc + _gold * (xc - xb)
@@ -3098,10 +3370,12 @@ def bracket(func, xa=0.0, xb=1.0, args=(), grow_limit=110.0, maxiter=1000):
 
     # three conditions for a valid bracket
     cond1 = (fb < fc and fb <= fa) or (fb < fa and fb <= fc)
-    cond2 = (xa < xb < xc or xc < xb < xa)
+    cond2 = xa < xb < xc or xc < xb < xa
     cond3 = np.isfinite(xa) and np.isfinite(xb) and np.isfinite(xc)
-    msg = ("The algorithm terminated without finding a valid bracket. "
-           "Consider trying different initial points.")
+    msg = (
+        "The algorithm terminated without finding a valid bracket. "
+        "Consider trying different initial points."
+    )
     if not (cond1 and cond2 and cond3):
         e = BracketError(msg)
         e.data = (xa, xb, xc, fa, fb, fc, funcalls)
@@ -3143,8 +3417,9 @@ def _recover_from_bracket_error(solver, fun, bracket, args, **options):
         else:
             imin = np.argmin(fs)
             x, fun = xs[imin], fs[imin]
-        return OptimizeResult(fun=fun, nfev=funcalls, x=x,
-                              nit=0, success=False, message=msg)
+        return OptimizeResult(
+            fun=fun, nfev=funcalls, x=x, nit=0, success=False, message=msg
+        )
     return res
 
 
@@ -3186,7 +3461,7 @@ def _line_for_search(x0, alpha, lower_bound, upper_bound):
     # get nonzero indices of alpha so we don't get any zero division errors.
     # alpha will not be all zero, since it is called from _linesearch_powell
     # where we have a check for this.
-    nonzero, = alpha.nonzero()
+    (nonzero,) = alpha.nonzero()
     lower_bound, upper_bound = lower_bound[nonzero], upper_bound[nonzero]
     x0, alpha = x0[nonzero], alpha[nonzero]
     low = (lower_bound - x0) / alpha
@@ -3211,8 +3486,9 @@ def _line_for_search(x0, alpha, lower_bound, upper_bound):
     return (lmin, lmax) if lmax >= lmin else (0, 0)
 
 
-def _linesearch_powell(func, p, xi, tol=1e-3,
-                       lower_bound=None, upper_bound=None, fval=None):
+def _linesearch_powell(
+    func, p, xi, tol=1e-3, lower_bound=None, upper_bound=None, fval=None
+):
     """Line-search algorithm using fminbound.
 
     Find the minimum of the function ``func(x0 + alpha*direc)``.
@@ -3232,16 +3508,18 @@ def _linesearch_powell(func, p, xi, tol=1e-3,
         recomputing it so we can limit the ``fevals``.
 
     """
+
     def myfunc(alpha):
-        return func(p + alpha*xi)
+        return func(p + alpha * xi)
 
     # if xi is zero, then don't optimize
     if not np.any(xi):
-        return ((fval, p, xi) if fval is not None else (func(p), p, xi))
+        return (fval, p, xi) if fval is not None else (func(p), p, xi)
     elif lower_bound is None and upper_bound is None:
         # non-bounded minimization
-        res = _recover_from_bracket_error(_minimize_scalar_brent,
-                                          myfunc, None, tuple(), xtol=tol)
+        res = _recover_from_bracket_error(
+            _minimize_scalar_brent, myfunc, None, tuple(), xtol=tol
+        )
         alpha_min, fret = res.x, res.fun
         xi = alpha_min * xi
         return fret, p + xi, xi
@@ -3261,16 +3539,26 @@ def _linesearch_powell(func, p, xi, tol=1e-3,
             # is a subregion of the region bounded by -np.pi/2 and np.pi/2.
             bound = np.arctan(bound[0]), np.arctan(bound[1])
             res = _minimize_scalar_bounded(
-                lambda x: myfunc(np.tan(x)),
-                bound,
-                xatol=tol / 100)
+                lambda x: myfunc(np.tan(x)), bound, xatol=tol / 100
+            )
             xi = np.tan(res.x) * xi
             return res.fun, p + xi, xi
 
 
-def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
-                maxfun=None, full_output=0, disp=1, retall=0, callback=None,
-                direc=None):
+def fmin_powell(
+    func,
+    x0,
+    args=(),
+    xtol=1e-4,
+    ftol=1e-4,
+    maxiter=None,
+    maxfun=None,
+    full_output=0,
+    disp=1,
+    retall=0,
+    callback=None,
+    direc=None,
+):
     """
     Minimize a function using modified Powell's method.
 
@@ -3386,34 +3674,53 @@ def fmin_powell(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None,
     array(0.0)
 
     """
-    opts = {'xtol': xtol,
-            'ftol': ftol,
-            'maxiter': maxiter,
-            'maxfev': maxfun,
-            'disp': disp,
-            'direc': direc,
-            'return_all': retall}
+    opts = {
+        "xtol": xtol,
+        "ftol": ftol,
+        "maxiter": maxiter,
+        "maxfev": maxfun,
+        "disp": disp,
+        "direc": direc,
+        "return_all": retall,
+    }
 
     callback = _wrap_callback(callback)
     res = _minimize_powell(func, x0, args, callback=callback, **opts)
 
     if full_output:
-        retlist = (res['x'], res['fun'], res['direc'], res['nit'],
-                   res['nfev'], res['status'])
+        retlist = (
+            res["x"],
+            res["fun"],
+            res["direc"],
+            res["nit"],
+            res["nfev"],
+            res["status"],
+        )
         if retall:
-            retlist += (res['allvecs'], )
+            retlist += (res["allvecs"],)
         return retlist
     else:
         if retall:
-            return res['x'], res['allvecs']
+            return res["x"], res["allvecs"]
         else:
-            return res['x']
+            return res["x"]
 
 
-def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
-                     xtol=1e-4, ftol=1e-4, maxiter=None, maxfev=None,
-                     disp=False, direc=None, return_all=False,
-                     **unknown_options):
+def _minimize_powell(
+    func,
+    x0,
+    args=(),
+    callback=None,
+    bounds=None,
+    xtol=1e-4,
+    ftol=1e-4,
+    maxiter=None,
+    maxfev=None,
+    disp=False,
+    direc=None,
+    return_all=False,
+    **unknown_options,
+):
     """
     Minimization of scalar function of one or more variables using the
     modified Powell algorithm.
@@ -3536,9 +3843,11 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
     else:
         direc = asarray(direc, dtype=float)
         if np.linalg.matrix_rank(direc) != direc.shape[0]:
-            warnings.warn("direc input is not full rank, some parameters may "
-                          "not be optimized",
-                          OptimizeWarning, stacklevel=3)
+            warnings.warn(
+                "direc input is not full rank, some parameters may not be optimized",
+                OptimizeWarning,
+                stacklevel=3,
+            )
 
     if bounds is None:
         # don't make these arrays of all +/- inf. because
@@ -3550,8 +3859,11 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
         # bounds is standardized in _minimize.py.
         lower_bound, upper_bound = bounds.lb, bounds.ub
         if np.any(lower_bound > x0) or np.any(x0 > upper_bound):
-            warnings.warn("Initial guess is not within the specified bounds",
-                          OptimizeWarning, stacklevel=3)
+            warnings.warn(
+                "Initial guess is not within the specified bounds",
+                OptimizeWarning,
+                stacklevel=3,
+            )
 
     fval = func(x)
     x1 = x.copy()
@@ -3564,11 +3876,15 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
             for i in range(N):
                 direc1 = direc[i]
                 fx2 = fval
-                fval, x, direc1 = _linesearch_powell(func, x, direc1,
-                                                     tol=xtol * 100,
-                                                     lower_bound=lower_bound,
-                                                     upper_bound=upper_bound,
-                                                     fval=fval)
+                fval, x, direc1 = _linesearch_powell(
+                    func,
+                    x,
+                    direc1,
+                    tol=xtol * 100,
+                    lower_bound=lower_bound,
+                    upper_bound=upper_bound,
+                    fval=fval,
+                )
                 if (fx2 - fval) > delta:
                     delta = fx2 - fval
                     bigind = i
@@ -3600,19 +3916,21 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
             x2 = x + min(lmax, 1) * direc1
             fx2 = func(x2)
 
-            if (fx > fx2):
-                t = 2.0*(fx + fx2 - 2.0*fval)
-                temp = (fx - fval - delta)
-                t *= temp*temp
+            if fx > fx2:
+                t = 2.0 * (fx + fx2 - 2.0 * fval)
+                temp = fx - fval - delta
+                t *= temp * temp
                 temp = fx - fx2
-                t -= delta*temp*temp
+                t -= delta * temp * temp
                 if t < 0.0:
                     fval, x, direc1 = _linesearch_powell(
-                        func, x, direc1,
+                        func,
+                        x,
+                        direc1,
                         tol=xtol * 100,
                         lower_bound=lower_bound,
                         upper_bound=upper_bound,
-                        fval=fval
+                        fval=fval,
                     )
                     if np.any(direc1):
                         direc[bigind] = direc[-1]
@@ -3621,48 +3939,61 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
             break
 
     warnflag = 0
-    msg = _status_message['success']
+    msg = _status_message["success"]
     # out of bounds is more urgent than exceeding function evals or iters,
     # but I don't want to cause inconsistencies by changing the
     # established warning flags for maxfev and maxiter, so the out of bounds
     # warning flag becomes 3, but is checked for first.
     if bounds and (np.any(lower_bound > x) or np.any(x > upper_bound)):
         warnflag = 4
-        msg = _status_message['out_of_bounds']
+        msg = _status_message["out_of_bounds"]
     elif fcalls[0] >= maxfun:
         warnflag = 1
-        msg = _status_message['maxfev']
+        msg = _status_message["maxfev"]
     elif iter >= maxiter:
         warnflag = 2
-        msg = _status_message['maxiter']
+        msg = _status_message["maxiter"]
     elif np.isnan(fval) or np.isnan(x).any():
         warnflag = 3
-        msg = _status_message['nan']
+        msg = _status_message["nan"]
 
     if disp:
         _print_success_message_or_warn(warnflag, msg, RuntimeWarning)
         print(f"         Current function value: {fval:f}")
         print(f"         Iterations: {iter:d}")
         print(f"         Function evaluations: {fcalls[0]:d}")
-    result = OptimizeResult(fun=fval, direc=direc, nit=iter, nfev=fcalls[0],
-                            status=warnflag, success=(warnflag == 0),
-                            message=msg, x=x)
+    result = OptimizeResult(
+        fun=fval,
+        direc=direc,
+        nit=iter,
+        nfev=fcalls[0],
+        status=warnflag,
+        success=(warnflag == 0),
+        message=msg,
+        x=x,
+    )
     if retall:
-        result['allvecs'] = allvecs
+        result["allvecs"] = allvecs
     return result
 
 
 def _endprint(x, flag, fval, maxfun, xtol, disp):
     if flag == 0:
         if disp > 1:
-            print("\nOptimization terminated successfully;\n"
-                  "The returned value satisfies the termination criteria\n"
-                  "(using xtol = ", xtol, ")")
+            print(
+                "\nOptimization terminated successfully;\n"
+                "The returned value satisfies the termination criteria\n"
+                "(using xtol = ",
+                xtol,
+                ")",
+            )
         return
 
     if flag == 1:
-        msg = ("\nMaximum number of function evaluations exceeded --- "
-               "increase maxfun argument.\n")
+        msg = (
+            "\nMaximum number of function evaluations exceeded --- "
+            "increase maxfun argument.\n"
+        )
     elif flag == 2:
         msg = f"\n{_status_message['nan']}"
 
@@ -3670,8 +4001,9 @@ def _endprint(x, flag, fval, maxfun, xtol, disp):
     return
 
 
-def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
-          disp=False, workers=1):
+def brute(
+    func, ranges, args=(), Ns=20, full_output=0, finish=fmin, disp=False, workers=1
+):
     """Minimize a function over a given range by brute force.
 
     Uses the "brute force" method, i.e., computes the function's value
@@ -3845,22 +4177,21 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
     """
     N = len(ranges)
     if N > 40:
-        raise ValueError("Brute Force not possible with more "
-                         "than 40 variables.")
+        raise ValueError("Brute Force not possible with more than 40 variables.")
     lrange = list(ranges)
     for k in range(N):
         if not isinstance(lrange[k], slice):
             if len(lrange[k]) < 3:
                 lrange[k] = tuple(lrange[k]) + (complex(Ns),)
             lrange[k] = slice(*lrange[k])
-    if (N == 1):
+    if N == 1:
         lrange = lrange[0]
 
     grid = np.mgrid[lrange]
 
     # obtain an array of parameters that is iterable by a map-like callable
     inpt_shape = grid.shape
-    if (N > 1):
+    if N > 1:
         grid = np.reshape(grid, (inpt_shape[0], np.prod(inpt_shape[1:]))).T
 
     if not np.iterable(args):
@@ -3871,10 +4202,10 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
     # iterate over input arrays, possibly in parallel
     with MapWrapper(pool=workers) as mapper:
         Jout = np.array(list(mapper(wrapped_func, grid)))
-        if (N == 1):
+        if N == 1:
             grid = (grid,)
             Jout = np.squeeze(Jout)
-        elif (N > 1):
+        elif N > 1:
             Jout = np.reshape(Jout, inpt_shape[1:])
             grid = np.reshape(grid.T, inpt_shape)
 
@@ -3891,7 +4222,7 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
         xmin[k] = grid[k][tuple(Nindx)]
 
     Jmin = Jout[tuple(Nindx)]
-    if (N == 1):
+    if N == 1:
         grid = grid[0]
         xmin = xmin[0]
 
@@ -3899,14 +4230,14 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
         # set up kwargs for `finish` function
         finish_args = _getfullargspec(finish).args
         finish_kwargs = dict()
-        if 'full_output' in finish_args:
-            finish_kwargs['full_output'] = 1
-        if 'disp' in finish_args:
-            finish_kwargs['disp'] = disp
-        elif 'options' in finish_args:
+        if "full_output" in finish_args:
+            finish_kwargs["full_output"] = 1
+        if "disp" in finish_args:
+            finish_kwargs["disp"] = disp
+        elif "options" in finish_args:
             # pass 'disp' as `options`
             # (e.g., if `finish` is `minimize`)
-            finish_kwargs['options'] = {'disp': disp}
+            finish_kwargs["options"] = {"disp": disp}
 
         # run minimizer
         res = finish(func, xmin, args=args, **finish_kwargs)
@@ -3921,9 +4252,12 @@ def brute(func, ranges, args=(), Ns=20, full_output=0, finish=fmin,
             success = res[-1] == 0
         if not success:
             if disp:
-                warnings.warn("Either final optimization did not succeed or `finish` "
-                              "does not return `statuscode` as its last argument.",
-                              RuntimeWarning, stacklevel=2)
+                warnings.warn(
+                    "Either final optimization did not succeed or `finish` "
+                    "does not return `statuscode` as its last argument.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
     if full_output:
         return xmin, Jmin, grid, Jout
@@ -4055,91 +4389,96 @@ def show_options(solver=None, method=None, disp=True):
     import textwrap
 
     doc_routines = {
-        'minimize': (
-            ('bfgs', 'scipy.optimize._optimize._minimize_bfgs'),
-            ('cg', 'scipy.optimize._optimize._minimize_cg'),
-            ('cobyla', 'scipy.optimize._cobyla_py._minimize_cobyla'),
-            ('cobyqa', 'scipy.optimize._cobyqa_py._minimize_cobyqa'),
-            ('dogleg', 'scipy.optimize._trustregion_dogleg._minimize_dogleg'),
-            ('l-bfgs-b', 'scipy.optimize._lbfgsb_py._minimize_lbfgsb'),
-            ('nelder-mead', 'scipy.optimize._optimize._minimize_neldermead'),
-            ('newton-cg', 'scipy.optimize._optimize._minimize_newtoncg'),
-            ('powell', 'scipy.optimize._optimize._minimize_powell'),
-            ('slsqp', 'scipy.optimize._slsqp_py._minimize_slsqp'),
-            ('tnc', 'scipy.optimize._tnc._minimize_tnc'),
-            ('trust-ncg',
-             'scipy.optimize._trustregion_ncg._minimize_trust_ncg'),
-            ('trust-constr',
-             'scipy.optimize._trustregion_constr.'
-             '_minimize_trustregion_constr'),
-            ('trust-exact',
-             'scipy.optimize._trustregion_exact._minimize_trustregion_exact'),
-            ('trust-krylov',
-             'scipy.optimize._trustregion_krylov._minimize_trust_krylov'),
+        "minimize": (
+            ("bfgs", "scipy.optimize._optimize._minimize_bfgs"),
+            ("cg", "scipy.optimize._optimize._minimize_cg"),
+            ("cobyla", "scipy.optimize._cobyla_py._minimize_cobyla"),
+            ("cobyqa", "scipy.optimize._cobyqa_py._minimize_cobyqa"),
+            ("dogleg", "scipy.optimize._trustregion_dogleg._minimize_dogleg"),
+            ("l-bfgs-b", "scipy.optimize._lbfgsb_py._minimize_lbfgsb"),
+            ("nelder-mead", "scipy.optimize._optimize._minimize_neldermead"),
+            ("newton-cg", "scipy.optimize._optimize._minimize_newtoncg"),
+            ("powell", "scipy.optimize._optimize._minimize_powell"),
+            ("slsqp", "scipy.optimize._slsqp_py._minimize_slsqp"),
+            ("tnc", "scipy.optimize._tnc._minimize_tnc"),
+            ("trust-ncg", "scipy.optimize._trustregion_ncg._minimize_trust_ncg"),
+            (
+                "trust-constr",
+                "scipy.optimize._trustregion_constr._minimize_trustregion_constr",
+            ),
+            (
+                "trust-exact",
+                "scipy.optimize._trustregion_exact._minimize_trustregion_exact",
+            ),
+            (
+                "trust-krylov",
+                "scipy.optimize._trustregion_krylov._minimize_trust_krylov",
+            ),
         ),
-        'root': (
-            ('hybr', 'scipy.optimize._minpack_py._root_hybr'),
-            ('lm', 'scipy.optimize._root._root_leastsq'),
-            ('broyden1', 'scipy.optimize._root._root_broyden1_doc'),
-            ('broyden2', 'scipy.optimize._root._root_broyden2_doc'),
-            ('anderson', 'scipy.optimize._root._root_anderson_doc'),
-            ('diagbroyden', 'scipy.optimize._root._root_diagbroyden_doc'),
-            ('excitingmixing', 'scipy.optimize._root._root_excitingmixing_doc'),
-            ('linearmixing', 'scipy.optimize._root._root_linearmixing_doc'),
-            ('krylov', 'scipy.optimize._root._root_krylov_doc'),
-            ('df-sane', 'scipy.optimize._spectral._root_df_sane'),
+        "root": (
+            ("hybr", "scipy.optimize._minpack_py._root_hybr"),
+            ("lm", "scipy.optimize._root._root_leastsq"),
+            ("broyden1", "scipy.optimize._root._root_broyden1_doc"),
+            ("broyden2", "scipy.optimize._root._root_broyden2_doc"),
+            ("anderson", "scipy.optimize._root._root_anderson_doc"),
+            ("diagbroyden", "scipy.optimize._root._root_diagbroyden_doc"),
+            ("excitingmixing", "scipy.optimize._root._root_excitingmixing_doc"),
+            ("linearmixing", "scipy.optimize._root._root_linearmixing_doc"),
+            ("krylov", "scipy.optimize._root._root_krylov_doc"),
+            ("df-sane", "scipy.optimize._spectral._root_df_sane"),
         ),
-        'root_scalar': (
-            ('bisect', 'scipy.optimize._root_scalar._root_scalar_bisect_doc'),
-            ('brentq', 'scipy.optimize._root_scalar._root_scalar_brentq_doc'),
-            ('brenth', 'scipy.optimize._root_scalar._root_scalar_brenth_doc'),
-            ('ridder', 'scipy.optimize._root_scalar._root_scalar_ridder_doc'),
-            ('toms748', 'scipy.optimize._root_scalar._root_scalar_toms748_doc'),
-            ('secant', 'scipy.optimize._root_scalar._root_scalar_secant_doc'),
-            ('newton', 'scipy.optimize._root_scalar._root_scalar_newton_doc'),
-            ('halley', 'scipy.optimize._root_scalar._root_scalar_halley_doc'),
+        "root_scalar": (
+            ("bisect", "scipy.optimize._root_scalar._root_scalar_bisect_doc"),
+            ("brentq", "scipy.optimize._root_scalar._root_scalar_brentq_doc"),
+            ("brenth", "scipy.optimize._root_scalar._root_scalar_brenth_doc"),
+            ("ridder", "scipy.optimize._root_scalar._root_scalar_ridder_doc"),
+            (
+                "chandrupatla",
+                "scipy.optimize._root_scalar._root_scalar_chandrupatla_doc",
+            ),
+            ("toms748", "scipy.optimize._root_scalar._root_scalar_toms748_doc"),
+            ("secant", "scipy.optimize._root_scalar._root_scalar_secant_doc"),
+            ("newton", "scipy.optimize._root_scalar._root_scalar_newton_doc"),
+            ("halley", "scipy.optimize._root_scalar._root_scalar_halley_doc"),
         ),
-        'linprog': (
-            ('simplex', 'scipy.optimize._linprog._linprog_simplex_doc'),
-            ('interior-point', 'scipy.optimize._linprog._linprog_ip_doc'),
-            ('revised simplex', 'scipy.optimize._linprog._linprog_rs_doc'),
-            ('highs-ipm', 'scipy.optimize._linprog._linprog_highs_ipm_doc'),
-            ('highs-ds', 'scipy.optimize._linprog._linprog_highs_ds_doc'),
-            ('highs', 'scipy.optimize._linprog._linprog_highs_doc'),
+        "linprog": (
+            ("simplex", "scipy.optimize._linprog._linprog_simplex_doc"),
+            ("interior-point", "scipy.optimize._linprog._linprog_ip_doc"),
+            ("revised simplex", "scipy.optimize._linprog._linprog_rs_doc"),
+            ("highs-ipm", "scipy.optimize._linprog._linprog_highs_ipm_doc"),
+            ("highs-ds", "scipy.optimize._linprog._linprog_highs_ds_doc"),
+            ("highs", "scipy.optimize._linprog._linprog_highs_doc"),
         ),
-        'quadratic_assignment': (
-            ('faq', 'scipy.optimize._qap._quadratic_assignment_faq'),
-            ('2opt', 'scipy.optimize._qap._quadratic_assignment_2opt'),
+        "quadratic_assignment": (
+            ("faq", "scipy.optimize._qap._quadratic_assignment_faq"),
+            ("2opt", "scipy.optimize._qap._quadratic_assignment_2opt"),
         ),
-        'minimize_scalar': (
-            ('brent', 'scipy.optimize._optimize._minimize_scalar_brent'),
-            ('bounded', 'scipy.optimize._optimize._minimize_scalar_bounded'),
-            ('golden', 'scipy.optimize._optimize._minimize_scalar_golden'),
+        "minimize_scalar": (
+            ("brent", "scipy.optimize._optimize._minimize_scalar_brent"),
+            ("bounded", "scipy.optimize._optimize._minimize_scalar_bounded"),
+            ("golden", "scipy.optimize._optimize._minimize_scalar_golden"),
         ),
     }
 
     if solver is None:
         text = ["\n\n\n========\n", "minimize\n", "========\n"]
-        text.append(show_options('minimize', disp=False))
-        text.extend(["\n\n===============\n", "minimize_scalar\n",
-                     "===============\n"])
-        text.append(show_options('minimize_scalar', disp=False))
-        text.extend(["\n\n\n====\n", "root\n",
-                     "====\n"])
-        text.append(show_options('root', disp=False))
-        text.extend(['\n\n\n=======\n', 'linprog\n',
-                     '=======\n'])
-        text.append(show_options('linprog', disp=False))
+        text.append(show_options("minimize", disp=False))
+        text.extend(["\n\n===============\n", "minimize_scalar\n", "===============\n"])
+        text.append(show_options("minimize_scalar", disp=False))
+        text.extend(["\n\n\n====\n", "root\n", "====\n"])
+        text.append(show_options("root", disp=False))
+        text.extend(["\n\n\n=======\n", "linprog\n", "=======\n"])
+        text.append(show_options("linprog", disp=False))
         text = "".join(text)
     else:
         solver = solver.lower()
         if solver not in doc_routines:
-            raise ValueError(f'Unknown solver {solver!r}')
+            raise ValueError(f"Unknown solver {solver!r}")
 
         if method is None:
             text = []
             for name, _ in doc_routines[solver]:
-                text.extend(["\n\n" + name, "\n" + "="*len(name) + "\n\n"])
+                text.extend(["\n\n" + name, "\n" + "=" * len(name) + "\n\n"])
                 text.append(show_options(solver, name, disp=False))
             text = "".join(text)
         else:
@@ -4150,7 +4489,7 @@ def show_options(solver=None, method=None, disp=True):
             name = methods[method]
 
             # Import function object
-            parts = name.split('.')
+            parts = name.split(".")
             mod_name = ".".join(parts[:-1])
             __import__(mod_name)
             obj = getattr(sys.modules[mod_name], parts[-1])

--- a/scipy/optimize/_root_scalar.py
+++ b/scipy/optimize/_root_scalar.py
@@ -6,15 +6,25 @@ Functions
 ---------
 - root : find a root of a scalar function.
 """
+
 import numpy as np
 
 from . import _zeros_py as optzeros
 from ._numdiff import approx_derivative
 
-__all__ = ['root_scalar']
+__all__ = ["root_scalar"]
 
-ROOT_SCALAR_METHODS = ['bisect', 'brentq', 'brenth', 'ridder', 'toms748',
-                       'newton', 'secant', 'halley']
+ROOT_SCALAR_METHODS = [
+    "bisect",
+    "brentq",
+    "brenth",
+    "ridder",
+    "chandrupatla",
+    "toms748",
+    "newton",
+    "secant",
+    "halley",
+]
 
 
 class MemoizeDer:
@@ -27,6 +37,7 @@ class MemoizeDer:
     It supports the use case of a root-finder where `args` is fixed,
     `x` changes, and only rarely, if at all, does x assume the same value
     more than once."""
+
     def __init__(self, fun):
         self.fun = fun
         self.vals = None
@@ -59,11 +70,20 @@ class MemoizeDer:
         return self.n_calls
 
 
-def root_scalar(f, args=(), method=None, bracket=None,
-                fprime=None, fprime2=None,
-                x0=None, x1=None,
-                xtol=None, rtol=None, maxiter=None,
-                options=None):
+def root_scalar(
+    f,
+    args=(),
+    method=None,
+    bracket=None,
+    fprime=None,
+    fprime2=None,
+    x0=None,
+    x1=None,
+    xtol=None,
+    rtol=None,
+    maxiter=None,
+    options=None,
+):
     """
     Find a root of a scalar function.
 
@@ -83,14 +103,15 @@ def root_scalar(f, args=(), method=None, bracket=None,
     method : str, optional
         Type of solver.  Should be one of
 
-        - 'bisect'    :ref:`(see here) <optimize.root_scalar-bisect>`
-        - 'brentq'    :ref:`(see here) <optimize.root_scalar-brentq>`
-        - 'brenth'    :ref:`(see here) <optimize.root_scalar-brenth>`
-        - 'ridder'    :ref:`(see here) <optimize.root_scalar-ridder>`
-        - 'toms748'    :ref:`(see here) <optimize.root_scalar-toms748>`
-        - 'newton'    :ref:`(see here) <optimize.root_scalar-newton>`
-        - 'secant'    :ref:`(see here) <optimize.root_scalar-secant>`
-        - 'halley'    :ref:`(see here) <optimize.root_scalar-halley>`
+        - 'bisect'          :ref:`(see here) <optimize.root_scalar-bisect>`
+        - 'brentq'          :ref:`(see here) <optimize.root_scalar-brentq>`
+        - 'brenth'          :ref:`(see here) <optimize.root_scalar-brenth>`
+        - 'ridder'          :ref:`(see here) <optimize.root_scalar-ridder>`
+        - 'chandrupatla'    :ref:`(see here) <optimize.root_scalar-chandrupatla>`
+        - 'toms748'         :ref:`(see here) <optimize.root_scalar-toms748>`
+        - 'newton'          :ref:`(see here) <optimize.root_scalar-newton>`
+        - 'secant'          :ref:`(see here) <optimize.root_scalar-secant>`
+        - 'halley'          :ref:`(see here) <optimize.root_scalar-halley>`
 
     bracket: A sequence of 2 floats, optional
         An interval bracketing a root.  ``f(x, *args)`` must have different
@@ -148,25 +169,27 @@ def root_scalar(f, args=(), method=None, bracket=None,
 
     Arguments for each method are as follows (x=required, o=optional).
 
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    |                    method                     | f | args | bracket | x0 | x1 | fprime | fprime2 | xtol | rtol | maxiter | options |
-    +===============================================+===+======+=========+====+====+========+=========+======+======+=========+=========+
-    | :ref:`bisect <optimize.root_scalar-bisect>`   | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`brentq <optimize.root_scalar-brentq>`   | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`brenth <optimize.root_scalar-brenth>`   | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`ridder <optimize.root_scalar-ridder>`   | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`toms748 <optimize.root_scalar-toms748>` | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`secant <optimize.root_scalar-secant>`   | x |  o   |         | x  | o  |        |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`newton <optimize.root_scalar-newton>`   | x |  o   |         | x  |    |   o    |         |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
-    | :ref:`halley <optimize.root_scalar-halley>`   | x |  o   |         | x  |    |   x    |    x    |  o   |  o   |    o    |   o     |
-    +-----------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    |                    method                               | f | args | bracket | x0 | x1 | fprime | fprime2 | xtol | rtol | maxiter | options |
+    +=========================================================+===+======+=========+====+====+========+=========+======+======+=========+=========+
+    | :ref:`bisect <optimize.root_scalar-bisect>`             | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`brentq <optimize.root_scalar-brentq>`             | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`brenth <optimize.root_scalar-brenth>`             | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`ridder <optimize.root_scalar-ridder>`             | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`chandrupatla <optimize.root_scalar-chandrupatla>` | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`toms748 <optimize.root_scalar-toms748>`           | x |  o   |    x    |    |    |        |         |  o   |  o   |    o    |   o     |
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`secant <optimize.root_scalar-secant>`             | x |  o   |         | x  | o  |        |         |  o   |  o   |    o    |   o     |
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`newton <optimize.root_scalar-newton>`             | x |  o   |         | x  |    |   o    |         |  o   |  o   |    o    |   o     |
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
+    | :ref:`halley <optimize.root_scalar-halley>`             | x |  o   |         | x  |    |   x    |    x    |  o   |  o   |    o    |   o     |
+    +---------------------------------------------------------+---+------+---------+----+----+--------+---------+------+------+---------+---------+
 
     Examples
     --------
@@ -238,7 +261,7 @@ def root_scalar(f, args=(), method=None, bracket=None,
 
     # respect solver-specific default tolerances - only pass in if actually set
     kwargs = {}
-    for k in ['xtol', 'rtol', 'maxiter']:
+    for k in ["xtol", "rtol", "maxiter"]:
         v = locals().get(k)
         if v is not None:
             kwargs[k] = v
@@ -254,32 +277,33 @@ def root_scalar(f, args=(), method=None, bracket=None,
     # Use the "best" method available for the situation.
     if not method:
         if bracket is not None:
-            method = 'brentq'
+            method = "brentq"
         elif x0 is not None:
             if fprime:
                 if fprime2:
-                    method = 'halley'
+                    method = "halley"
                 else:
-                    method = 'newton'
+                    method = "newton"
             elif x1 is not None:
-                method = 'secant'
+                method = "secant"
             else:
-                method = 'newton'
+                method = "newton"
     if not method:
-        raise ValueError('Unable to select a solver as neither bracket '
-                         'nor starting point provided.')
+        raise ValueError(
+            "Unable to select a solver as neither bracket nor starting point provided."
+        )
 
     meth = method.lower()
-    map2underlying = {'halley': 'newton', 'secant': 'newton'}
+    map2underlying = {"halley": "newton", "secant": "newton"}
 
     try:
         methodc = getattr(optzeros, map2underlying.get(meth, meth))
     except AttributeError as e:
-        raise ValueError(f'Unknown solver {meth}') from e
+        raise ValueError(f"Unknown solver {meth}") from e
 
-    if meth in ['bisect', 'ridder', 'brentq', 'brenth', 'toms748']:
+    if meth in ["bisect", "ridder", "chandrupatla", "brentq", "brenth", "toms748"]:
         if not isinstance(bracket, list | tuple | np.ndarray):
-            raise ValueError(f'Bracket needed for {method}')
+            raise ValueError(f"Bracket needed for {method}")
 
         a, b = bracket[:2]
         try:
@@ -290,23 +314,25 @@ def root_scalar(f, args=(), method=None, bracket=None,
             # returns a NaN. It did so by wrapping the callable rather than
             # modifying compiled code, so the iteration count is not available.
             if hasattr(e, "_x"):
-                sol = optzeros.RootResults(root=e._x,
-                                           iterations=np.nan,
-                                           function_calls=e._function_calls,
-                                           flag=str(e), method=method)
+                sol = optzeros.RootResults(
+                    root=e._x,
+                    iterations=np.nan,
+                    function_calls=e._function_calls,
+                    flag=str(e),
+                    method=method,
+                )
             else:
                 raise
 
-    elif meth in ['secant']:
+    elif meth in ["secant"]:
         if x0 is None:
-            raise ValueError(f'x0 must not be None for {method}')
-        if 'xtol' in kwargs:
-            kwargs['tol'] = kwargs.pop('xtol')
-        r, sol = methodc(f, x0, args=args, fprime=None, fprime2=None,
-                         x1=x1, **kwargs)
-    elif meth in ['newton']:
+            raise ValueError(f"x0 must not be None for {method}")
+        if "xtol" in kwargs:
+            kwargs["tol"] = kwargs.pop("xtol")
+        r, sol = methodc(f, x0, args=args, fprime=None, fprime2=None, x1=x1, **kwargs)
+    elif meth in ["newton"]:
         if x0 is None:
-            raise ValueError(f'x0 must not be None for {method}')
+            raise ValueError(f"x0 must not be None for {method}")
         if not fprime:
             # approximate fprime with finite differences
 
@@ -320,24 +346,24 @@ def root_scalar(f, args=(), method=None, bracket=None,
                 # scalar input.
                 def f_wrapped(x, *args):
                     return f(x[0], *args)
-                return approx_derivative(f_wrapped, x, method='2-point', args=args)[0]
 
-        if 'xtol' in kwargs:
-            kwargs['tol'] = kwargs.pop('xtol')
-        r, sol = methodc(f, x0, args=args, fprime=fprime, fprime2=None,
-                         **kwargs)
-    elif meth in ['halley']:
+                return approx_derivative(f_wrapped, x, method="2-point", args=args)[0]
+
+        if "xtol" in kwargs:
+            kwargs["tol"] = kwargs.pop("xtol")
+        r, sol = methodc(f, x0, args=args, fprime=fprime, fprime2=None, **kwargs)
+    elif meth in ["halley"]:
         if x0 is None:
-            raise ValueError(f'x0 must not be None for {method}')
+            raise ValueError(f"x0 must not be None for {method}")
         if not fprime:
-            raise ValueError(f'fprime must be specified for {method}')
+            raise ValueError(f"fprime must be specified for {method}")
         if not fprime2:
-            raise ValueError(f'fprime2 must be specified for {method}')
-        if 'xtol' in kwargs:
-            kwargs['tol'] = kwargs.pop('xtol')
+            raise ValueError(f"fprime2 must be specified for {method}")
+        if "xtol" in kwargs:
+            kwargs["tol"] = kwargs.pop("xtol")
         r, sol = methodc(f, x0, args=args, fprime=fprime, fprime2=fprime2, **kwargs)
     else:
-        raise ValueError(f'Unknown solver {method}')
+        raise ValueError(f"Unknown solver {method}")
 
     if is_memoized:
         # Replace the function_calls count with the memoized count.
@@ -390,6 +416,7 @@ def _root_scalar_brenth_doc():
 
     """
     pass
+
 
 def _root_scalar_toms748_doc():
     r"""
@@ -512,6 +539,29 @@ def _root_scalar_ridder_doc():
     options: dict, optional
         Specifies any method-specific options not covered above.
 
+    """
+    pass
+
+
+def _root_scalar_chandrupatla_doc():
+    r"""
+    Options
+    -------
+    args : tuple, optional
+        Extra arguments passed to the objective function.
+    bracket: A sequence of 2 floats, optional
+        An interval bracketing a root.  ``f(x, *args)`` must have different
+        signs at the two endpoints.
+    xtol : float, optional
+        Tolerance (absolute) for termination.
+    rtol : float, optional
+        Tolerance (relative) for termination.
+    maxiter : int, optional
+        Maximum number of iterations.
+    options: dict, optional
+        Specifies any method-specific options not covered above.
+
+    .. versionadded:: 1.17.0
     """
     pass
 

--- a/scipy/optimize/cython_optimize/__init__.py
+++ b/scipy/optimize/cython_optimize/__init__.py
@@ -6,6 +6,7 @@ directly using Cython:
 
 - `~scipy.optimize.bisect`
 - `~scipy.optimize.ridder`
+- `~scipy.optimize.chandrupatla`
 - `~scipy.optimize.brenth`
 - `~scipy.optimize.brentq`
 
@@ -13,7 +14,7 @@ The Cython API for the root finding functions is similar except there is no
 ``disp`` argument. Import the root finding functions using ``cimport`` from
 `scipy.optimize.cython_optimize`. ::
 
-    from scipy.optimize.cython_optimize cimport bisect, ridder, brentq, brenth
+    from scipy.optimize.cython_optimize cimport bisect, ridder, chandrupatla, brentq, brenth
 
 
 Callback signature
@@ -64,7 +65,7 @@ These are the basic steps:
        cdef double brentq_wrapper_example(dict args, double xa, double xb,
                                           double xtol, double rtol, int mitr):
            # Cython automatically casts dictionary to struct
-           cdef test_params myargs = args
+           cdef test_params myargs = argsRidder
            return brentq(
                f, xa, xb, <test_params *> &myargs, xtol, rtol, mitr, NULL)
 

--- a/scipy/optimize/cython_optimize/_zeros.pyx.in
+++ b/scipy/optimize/cython_optimize/_zeros.pyx.in
@@ -1,6 +1,6 @@
 """Cython wrappers for root finders in c_zeros"""
 
-{{default root_finders = ['bisect', 'ridder', 'brenth', 'brentq']}}
+{{default root_finders = ['bisect', 'ridder', 'chandrupatla', 'brenth', 'brentq']}}
 
 from . cimport c_zeros
 
@@ -151,7 +151,7 @@ def full_output_example(args, xa, xb, xtol, rtol, mitr):
     -------
     full_output : dict
         the root, number of function calls, number of iterations, and the zero
-        function error number 
+        function error number
 
     This example finds the roots of a 3rd order polynomial with coefficients
     given as `args`.

--- a/scipy/optimize/cython_optimize/c_zeros.pxd
+++ b/scipy/optimize/cython_optimize/c_zeros.pxd
@@ -15,6 +15,11 @@ cdef extern from "../Zeros/ridder.c" nogil:
                   double rtol, int iter, void *func_data_param,
                   scipy_zeros_info *solver_stats)
 
+cdef extern from "../Zeros/chandrupatla.c" nogil:
+    double chandrupatla(callback_type f, double xa, double xb, double xtol,
+                  double rtol, int iter, void *func_data_param,
+                  scipy_zeros_info *solver_stats)
+
 cdef extern from "../Zeros/brenth.c" nogil:
     double brenth(callback_type f, double xa, double xb, double xtol,
                   double rtol, int iter, void *func_data_param,

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -48,6 +48,7 @@ rootfind_lib = static_library('rootfind',
     'Zeros/brenth.c',
     'Zeros/brentq.c',
     'Zeros/ridder.c',
+    'Zeros/chandrupatla.c',
     'Zeros/zeros.h'
   ],
   gnu_symbol_visibility: 'hidden',

--- a/scipy/optimize/tests/test_cython_optimize.py
+++ b/scipy/optimize/tests/test_cython_optimize.py
@@ -1,5 +1,5 @@
 """
-Test Cython optimize zeros API functions: ``bisect``, ``ridder``, ``brenth``,
+Test Cython optimize zeros API functions: ``bisect``, ``ridder``, ``chandrupatla``, ``brenth``,
 and ``brentq`` in `scipy.optimize.cython_optimize`, by finding the roots of a
 3rd order polynomial given a sequence of constant terms, ``a0``, and fixed 1st,
 2nd, and 3rd order terms in ``args``.
@@ -55,6 +55,17 @@ def test_ridder():
         EXPECTED,
         list(
             _zeros.loop_example('ridder', A0, ARGS, XLO, XHI, XTOL, RTOL, MITR)
+        ),
+        rtol=RTOL, atol=XTOL
+    )
+
+
+# test chandrupatla
+def test_chandrupatla():
+    npt.assert_allclose(
+        EXPECTED,
+        list(
+            _zeros.loop_example('chandrupatla', A0, ARGS, XLO, XHI, XTOL, RTOL, MITR)
         ),
         rtol=RTOL, atol=XTOL
     )

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -4,35 +4,38 @@ from functools import lru_cache
 
 import pytest
 
-from numpy.testing import (assert_,
-                           assert_allclose,
-                           assert_equal,
-                           assert_array_equal)
+from numpy.testing import assert_, assert_allclose, assert_equal, assert_array_equal
 import numpy as np
 from numpy import finfo, power, nan, isclose, sqrt, exp, sin, cos
 
 from scipy import optimize
-from scipy.optimize import (_zeros_py as zeros, newton, root_scalar,
-                            OptimizeResult)
+from scipy.optimize import _zeros_py as zeros, newton, root_scalar, OptimizeResult
 
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 
 # Import testing parameters
 from scipy.optimize._tstutils import get_tests, functions as tstutils_functions
 
-TOL = 4*np.finfo(float).eps  # tolerance
+TOL = 4 * np.finfo(float).eps  # tolerance
 
 _FLOAT_EPS = finfo(float).eps
 
-bracket_methods = [zeros.bisect, zeros.ridder, zeros.brentq, zeros.brenth,
-                   zeros.toms748]
+bracket_methods = [
+    zeros.bisect,
+    zeros.ridder,
+    zeros.brentq,
+    zeros.brenth,
+    zeros.toms748,
+    zeros.chandrupatla,
+]
 gradient_methods = [zeros.newton]
 all_methods = bracket_methods + gradient_methods
+
 
 # A few test functions used frequently:
 # # A simple quadratic, (x-1)^2 - 1
 def f1(x):
-    return x ** 2 - 2 * x - 1
+    return x**2 - 2 * x - 1
 
 
 def f1_1(x):
@@ -72,22 +75,23 @@ class TestScalarRootFinders:
     xtol = 4 * np.finfo(float).eps
     rtol = 4 * np.finfo(float).eps
 
-    def _run_one_test(self, tc, method, sig_args_keys=None,
-                      sig_kwargs_keys=None, **kwargs):
+    def _run_one_test(
+        self, tc, method, sig_args_keys=None, sig_kwargs_keys=None, **kwargs
+    ):
         method_args = []
         for k in sig_args_keys or []:
             if k not in tc:
                 # If a,b not present use x0, x1. Similarly for f and func
-                k = {'a': 'x0', 'b': 'x1', 'func': 'f'}.get(k, k)
+                k = {"a": "x0", "b": "x1", "func": "f"}.get(k, k)
             method_args.append(tc[k])
 
         method_kwargs = dict(**kwargs)
-        method_kwargs.update({'full_output': True, 'disp': False})
+        method_kwargs.update({"full_output": True, "disp": False})
         for k in sig_kwargs_keys or []:
             method_kwargs[k] = tc[k]
 
-        root = tc.get('root')
-        func_args = tc.get('args', ())
+        root = tc.get("root")
+        func_args = tc.get("args", ())
 
         try:
             r, rr = method(*method_args, args=func_args, **method_kwargs)
@@ -111,51 +115,66 @@ class TestScalarRootFinders:
         nRequired = len(sig.args) - nDefaults
         sig_args_keys = sig.args[:nRequired]
         sig_kwargs_keys = []
-        if name in ['secant', 'newton', 'halley']:
-            if name in ['newton', 'halley']:
-                sig_kwargs_keys.append('fprime')
-                if name in ['halley']:
-                    sig_kwargs_keys.append('fprime2')
-            kwargs['tol'] = self.xtol
+        if name in ["secant", "newton", "halley"]:
+            if name in ["newton", "halley"]:
+                sig_kwargs_keys.append("fprime")
+                if name in ["halley"]:
+                    sig_kwargs_keys.append("fprime2")
+            kwargs["tol"] = self.xtol
         else:
-            kwargs['xtol'] = self.xtol
-            kwargs['rtol'] = self.rtol
+            kwargs["xtol"] = self.xtol
+            kwargs["rtol"] = self.rtol
 
-        results = [list(self._run_one_test(
-            tc, method, sig_args_keys=sig_args_keys,
-            sig_kwargs_keys=sig_kwargs_keys, **kwargs)) for tc in tests]
+        results = [
+            list(
+                self._run_one_test(
+                    tc,
+                    method,
+                    sig_args_keys=sig_args_keys,
+                    sig_kwargs_keys=sig_kwargs_keys,
+                    **kwargs,
+                )
+            )
+            for tc in tests
+        ]
         # results= [[true root, full output, tc], ...]
 
         known_fail = known_fail or []
         notcvgd = [elt for elt in results if not elt[1].converged]
-        notcvgd = [elt for elt in notcvgd if elt[-1]['ID'] not in known_fail]
-        notcvged_IDS = [elt[-1]['ID'] for elt in notcvgd]
+        notcvgd = [elt for elt in notcvgd if elt[-1]["ID"] not in known_fail]
+        notcvged_IDS = [elt[-1]["ID"] for elt in notcvgd]
         assert_equal([len(notcvged_IDS), notcvged_IDS], [0, []])
 
         # The usable xtol and rtol depend on the test
-        tols = {'xtol': self.xtol, 'rtol': self.rtol}
+        tols = {"xtol": self.xtol, "rtol": self.rtol}
         tols.update(**kwargs)
-        rtol = tols['rtol']
-        atol = tols.get('tol', tols['xtol'])
+        rtol = tols["rtol"]
+        atol = tols.get("tol", tols["xtol"])
 
         cvgd = [elt for elt in results if elt[1].converged]
         approx = [elt[1].root for elt in cvgd]
         correct = [elt[0] for elt in cvgd]
         # See if the root matches the reference value
-        notclose = [[a] + elt for a, c, elt in zip(approx, correct, cvgd) if
-                    not isclose(a, c, rtol=rtol, atol=atol)
-                    and elt[-1]['ID'] not in known_fail]
+        notclose = [
+            [a] + elt
+            for a, c, elt in zip(approx, correct, cvgd)
+            if not isclose(a, c, rtol=rtol, atol=atol)
+            and elt[-1]["ID"] not in known_fail
+        ]
         # If not, evaluate the function and see if is 0 at the purported root
-        fvs = [tc['f'](aroot, *tc.get('args', tuple()))
-               for aroot, c, fullout, tc in notclose]
+        fvs = [
+            tc["f"](aroot, *tc.get("args", tuple()))
+            for aroot, c, fullout, tc in notclose
+        ]
         notclose = [[fv] + elt for fv, elt in zip(fvs, notclose) if fv != 0]
         assert_equal([notclose, len(notclose)], [[], 0])
         method_from_result = [result[1].method for result in results]
         expected_method = [name for _ in results]
         assert_equal(method_from_result, expected_method)
 
-    def run_collection(self, collection, method, name, smoothness=None,
-                       known_fail=None, **kwargs):
+    def run_collection(
+        self, collection, method, name, smoothness=None, known_fail=None, **kwargs
+    ):
         r"""Run a collection of tests using the specified method.
 
         The name is used to determine some optional arguments."""
@@ -164,60 +183,74 @@ class TestScalarRootFinders:
 
 
 class TestBracketMethods(TestScalarRootFinders):
-    @pytest.mark.parametrize('method', bracket_methods)
-    @pytest.mark.parametrize('function', tstutils_functions)
+    @pytest.mark.parametrize("method", bracket_methods)
+    @pytest.mark.parametrize("function", tstutils_functions)
     def test_basic_root_scalar(self, method, function):
         # Tests bracketing root finders called via `root_scalar` on a small
         # set of simple problems, each of which has a root at `x=1`. Checks for
         # converged status and that the root was found.
-        a, b = .5, sqrt(3)
+        a, b = 0.5, sqrt(3)
 
-        r = root_scalar(function, method=method.__name__, bracket=[a, b], x0=a,
-                        xtol=self.xtol, rtol=self.rtol)
+        r = root_scalar(
+            function,
+            method=method.__name__,
+            bracket=[a, b],
+            x0=a,
+            xtol=self.xtol,
+            rtol=self.rtol,
+        )
         assert r.converged
         assert_allclose(r.root, 1.0, atol=self.xtol, rtol=self.rtol)
         assert r.method == method.__name__
 
-    @pytest.mark.parametrize('method', bracket_methods)
-    @pytest.mark.parametrize('function', tstutils_functions)
+    @pytest.mark.parametrize("method", bracket_methods)
+    @pytest.mark.parametrize("function", tstutils_functions)
     def test_basic_individual(self, method, function):
         # Tests individual bracketing root finders on a small set of simple
         # problems, each of which has a root at `x=1`. Checks for converged
         # status and that the root was found.
-        a, b = .5, sqrt(3)
-        root, r = method(function, a, b, xtol=self.xtol, rtol=self.rtol,
-                         full_output=True)
+        a, b = 0.5, sqrt(3)
+        root, r = method(
+            function, a, b, xtol=self.xtol, rtol=self.rtol, full_output=True
+        )
 
         assert r.converged
         assert_allclose(root, 1.0, atol=self.xtol, rtol=self.rtol)
 
-    @pytest.mark.parametrize('method', bracket_methods)
-    @pytest.mark.parametrize('function', tstutils_functions)
+    @pytest.mark.parametrize("method", bracket_methods)
+    @pytest.mark.parametrize("function", tstutils_functions)
     def test_bracket_is_array(self, method, function):
         # Test bracketing root finders called via `root_scalar` on a small set
         # of simple problems, each of which has a root at `x=1`. Check that
         # passing `bracket` as a `ndarray` is accepted and leads to finding the
         # correct root.
-        a, b = .5, sqrt(3)
-        r = root_scalar(function, method=method.__name__,
-                        bracket=np.array([a, b]), x0=a, xtol=self.xtol,
-                        rtol=self.rtol)
+        a, b = 0.5, sqrt(3)
+        r = root_scalar(
+            function,
+            method=method.__name__,
+            bracket=np.array([a, b]),
+            x0=a,
+            xtol=self.xtol,
+            rtol=self.rtol,
+        )
         assert r.converged
         assert_allclose(r.root, 1.0, atol=self.xtol, rtol=self.rtol)
         assert r.method == method.__name__
 
-    @pytest.mark.parametrize('method', bracket_methods)
+    @pytest.mark.parametrize("method", bracket_methods)
     def test_aps_collection(self, method):
-        self.run_collection('aps', method, method.__name__, smoothness=1)
+        self.run_collection("aps", method, method.__name__, smoothness=1)
 
-    @pytest.mark.parametrize('method', [zeros.bisect, zeros.ridder,
-                                        zeros.toms748])
+    @pytest.mark.parametrize(
+        "method", [zeros.bisect, zeros.ridder, zeros.toms748, zeros.chandrupatla]
+    )
     def test_chandrupatla_collection(self, method):
-        known_fail = {'fun7.4'} if method == zeros.ridder else {}
-        self.run_collection('chandrupatla', method, method.__name__,
-                            known_fail=known_fail)
+        known_fail = {"fun7.4"} if method == zeros.ridder else {}
+        self.run_collection(
+            "chandrupatla", method, method.__name__, known_fail=known_fail
+        )
 
-    @pytest.mark.parametrize('method', bracket_methods)
+    @pytest.mark.parametrize("method", bracket_methods)
     def test_lru_cached_individual(self, method):
         # check that https://github.com/scipy/scipy/issues/10846 is fixed
         # (`root_scalar` failed when passed a function that was `@lru_cache`d)
@@ -233,20 +266,34 @@ class TestBracketMethods(TestScalarRootFinders):
 
 class TestNewton(TestScalarRootFinders):
     def test_newton_collections(self):
-        known_fail = ['aps.13.00']
-        known_fail += ['aps.12.05', 'aps.12.17']  # fails under Windows Py27
-        for collection in ['aps', 'complex']:
-            self.run_collection(collection, zeros.newton, 'newton',
-                                smoothness=2, known_fail=known_fail)
+        known_fail = ["aps.13.00"]
+        known_fail += ["aps.12.05", "aps.12.17"]  # fails under Windows Py27
+        for collection in ["aps", "complex"]:
+            self.run_collection(
+                collection, zeros.newton, "newton", smoothness=2, known_fail=known_fail
+            )
 
     def test_halley_collections(self):
-        known_fail = ['aps.12.06', 'aps.12.07', 'aps.12.08', 'aps.12.09',
-                      'aps.12.10', 'aps.12.11', 'aps.12.12', 'aps.12.13',
-                      'aps.12.14', 'aps.12.15', 'aps.12.16', 'aps.12.17',
-                      'aps.12.18', 'aps.13.00']
-        for collection in ['aps', 'complex']:
-            self.run_collection(collection, zeros.newton, 'halley',
-                                smoothness=2, known_fail=known_fail)
+        known_fail = [
+            "aps.12.06",
+            "aps.12.07",
+            "aps.12.08",
+            "aps.12.09",
+            "aps.12.10",
+            "aps.12.11",
+            "aps.12.12",
+            "aps.12.13",
+            "aps.12.14",
+            "aps.12.15",
+            "aps.12.16",
+            "aps.12.17",
+            "aps.12.18",
+            "aps.13.00",
+        ]
+        for collection in ["aps", "complex"]:
+            self.run_collection(
+                collection, zeros.newton, "halley", smoothness=2, known_fail=known_fail
+            )
 
     def test_newton(self):
         for f, f_1, f_2 in [(f1, f1_1, f1_2), (f2, f2_1, f2_2)]:
@@ -254,7 +301,7 @@ class TestNewton(TestScalarRootFinders):
             assert_allclose(f(x), 0, atol=1e-6)
             x = zeros.newton(f, 3, x1=5, tol=1e-6)  # secant, x0 and x1
             assert_allclose(f(x), 0, atol=1e-6)
-            x = zeros.newton(f, 3, fprime=f_1, tol=1e-6)   # newton
+            x = zeros.newton(f, 3, fprime=f_1, tol=1e-6)  # newton
             assert_allclose(f(x), 0, atol=1e-6)
             x = zeros.newton(f, 3, fprime=f_1, fprime2=f_2, tol=1e-6)  # halley
             assert_allclose(f(x), 0, atol=1e-6)
@@ -262,37 +309,38 @@ class TestNewton(TestScalarRootFinders):
     def test_newton_by_name(self):
         r"""Invoke newton through root_scalar()"""
         for f, f_1, f_2 in [(f1, f1_1, f1_2), (f2, f2_1, f2_2)]:
-            r = root_scalar(f, method='newton', x0=3, fprime=f_1, xtol=1e-6)
+            r = root_scalar(f, method="newton", x0=3, fprime=f_1, xtol=1e-6)
             assert_allclose(f(r.root), 0, atol=1e-6)
         for f, f_1, f_2 in [(f1, f1_1, f1_2), (f2, f2_1, f2_2)]:
-            r = root_scalar(f, method='newton', x0=3, xtol=1e-6)  # without f'
+            r = root_scalar(f, method="newton", x0=3, xtol=1e-6)  # without f'
             assert_allclose(f(r.root), 0, atol=1e-6)
 
     def test_secant_by_name(self):
         r"""Invoke secant through root_scalar()"""
         for f, f_1, f_2 in [(f1, f1_1, f1_2), (f2, f2_1, f2_2)]:
-            r = root_scalar(f, method='secant', x0=3, x1=2, xtol=1e-6)
+            r = root_scalar(f, method="secant", x0=3, x1=2, xtol=1e-6)
             assert_allclose(f(r.root), 0, atol=1e-6)
-            r = root_scalar(f, method='secant', x0=3, x1=5, xtol=1e-6)
+            r = root_scalar(f, method="secant", x0=3, x1=5, xtol=1e-6)
             assert_allclose(f(r.root), 0, atol=1e-6)
         for f, f_1, f_2 in [(f1, f1_1, f1_2), (f2, f2_1, f2_2)]:
-            r = root_scalar(f, method='secant', x0=3, xtol=1e-6)  # without x1
+            r = root_scalar(f, method="secant", x0=3, xtol=1e-6)  # without x1
             assert_allclose(f(r.root), 0, atol=1e-6)
 
     def test_halley_by_name(self):
         r"""Invoke halley through root_scalar()"""
         for f, f_1, f_2 in [(f1, f1_1, f1_2), (f2, f2_1, f2_2)]:
-            r = root_scalar(f, method='halley', x0=3,
-                            fprime=f_1, fprime2=f_2, xtol=1e-6)
+            r = root_scalar(
+                f, method="halley", x0=3, fprime=f_1, fprime2=f_2, xtol=1e-6
+            )
             assert_allclose(f(r.root), 0, atol=1e-6)
 
     def test_root_scalar_fail(self):
-        message = 'fprime2 must be specified for halley'
+        message = "fprime2 must be specified for halley"
         with pytest.raises(ValueError, match=message):
-            root_scalar(f1, method='halley', fprime=f1_1, x0=3, xtol=1e-6)  # no fprime2
-        message = 'fprime must be specified for halley'
+            root_scalar(f1, method="halley", fprime=f1_1, x0=3, xtol=1e-6)  # no fprime2
+        message = "fprime must be specified for halley"
         with pytest.raises(ValueError, match=message):
-            root_scalar(f1, method='halley', fprime2=f1_2, x0=3, xtol=1e-6)  # no fprime
+            root_scalar(f1, method="halley", fprime2=f1_2, x0=3, xtol=1e-6)  # no fprime
 
     def test_array_newton(self):
         """test newton with array"""
@@ -309,21 +357,35 @@ class TestNewton(TestScalarRootFinders):
             b = a[3] / a[5]
             return -a[2] * np.exp(a[0] / a[5] + x * b) * b**2
 
-        a0 = np.array([
-            5.32725221, 5.48673747, 5.49539973,
-            5.36387202, 4.80237316, 1.43764452,
-            5.23063958, 5.46094772, 5.50512718,
-            5.42046290
-        ])
+        a0 = np.array(
+            [
+                5.32725221,
+                5.48673747,
+                5.49539973,
+                5.36387202,
+                4.80237316,
+                1.43764452,
+                5.23063958,
+                5.46094772,
+                5.50512718,
+                5.42046290,
+            ]
+        )
         a1 = (np.sin(range(10)) + 1.0) * 7.0
         args = (a0, a1, 1e-09, 0.004, 10, 0.27456)
         x0 = [7.0] * 10
         x = zeros.newton(f1, x0, f1_1, args)
         x_expected = (
-            6.17264965, 11.7702805, 12.2219954,
-            7.11017681, 1.18151293, 0.143707955,
-            4.31928228, 10.5419107, 12.7552490,
-            8.91225749
+            6.17264965,
+            11.7702805,
+            12.2219954,
+            7.11017681,
+            1.18151293,
+            0.143707955,
+            4.31928228,
+            10.5419107,
+            12.7552490,
+            8.91225749,
         )
         assert_allclose(x, x_expected)
         # test halley's
@@ -335,70 +397,73 @@ class TestNewton(TestScalarRootFinders):
 
     def test_array_newton_complex(self):
         def f(x):
-            return x + 1+1j
+            return x + 1 + 1j
 
         def fprime(x):
             return 1.0
 
         t = np.full(4, 1j)
         x = zeros.newton(f, t, fprime=fprime)
-        assert_allclose(f(x), 0.)
+        assert_allclose(f(x), 0.0)
 
         # should work even if x0 is not complex
         t = np.ones(4)
         x = zeros.newton(f, t, fprime=fprime)
-        assert_allclose(f(x), 0.)
+        assert_allclose(f(x), 0.0)
 
         x = zeros.newton(f, t)
-        assert_allclose(f(x), 0.)
+        assert_allclose(f(x), 0.0)
 
     def test_array_secant_active_zero_der(self):
         """test secant doesn't continue to iterate zero derivatives"""
-        x = zeros.newton(lambda x, *a: x*x - a[0], x0=[4.123, 5],
-                         args=[np.array([17, 25])])
+        x = zeros.newton(
+            lambda x, *a: x * x - a[0], x0=[4.123, 5], args=[np.array([17, 25])]
+        )
         assert_allclose(x, (4.123105625617661, 5.0))
 
     def test_array_newton_integers(self):
         # test secant with float
-        x = zeros.newton(lambda y, z: z - y ** 2, [4.0] * 2,
-                         args=([15.0, 17.0],))
+        x = zeros.newton(lambda y, z: z - y**2, [4.0] * 2, args=([15.0, 17.0],))
         assert_allclose(x, (3.872983346207417, 4.123105625617661))
         # test integer becomes float
-        x = zeros.newton(lambda y, z: z - y ** 2, [4] * 2, args=([15, 17],))
+        x = zeros.newton(lambda y, z: z - y**2, [4] * 2, args=([15, 17],))
         assert_allclose(x, (3.872983346207417, 4.123105625617661))
 
     def test_array_newton_zero_der_failures(self):
         # test derivative zero warning
         with pytest.warns(RuntimeWarning):
-            zeros.newton(lambda y: y**2 - 2, [0., 0.], lambda y: 2 * y)
+            zeros.newton(lambda y: y**2 - 2, [0.0, 0.0], lambda y: 2 * y)
         # test failures and zero_der
         with pytest.warns(RuntimeWarning):
-            results = zeros.newton(lambda y: y**2 - 2, [0., 0.],
-                                   lambda y: 2*y, full_output=True)
+            results = zeros.newton(
+                lambda y: y**2 - 2, [0.0, 0.0], lambda y: 2 * y, full_output=True
+            )
             assert_allclose(results.root, 0)
             assert results.zero_der.all()
             assert not results.converged.any()
 
     def test_newton_combined(self):
         def f1(x):
-            return x ** 2 - 2 * x - 1
+            return x**2 - 2 * x - 1
+
         def f1_1(x):
             return 2 * x - 2
+
         def f1_2(x):
             return 2.0 + 0 * x
 
         def f1_and_p_and_pp(x):
-            return x**2 - 2*x-1, 2*x-2, 2.0
+            return x**2 - 2 * x - 1, 2 * x - 2, 2.0
 
-        sol0 = root_scalar(f1, method='newton', x0=3, fprime=f1_1)
-        sol = root_scalar(f1_and_p_and_pp, method='newton', x0=3, fprime=True)
+        sol0 = root_scalar(f1, method="newton", x0=3, fprime=f1_1)
+        sol = root_scalar(f1_and_p_and_pp, method="newton", x0=3, fprime=True)
         assert_allclose(sol0.root, sol.root, atol=1e-8)
-        assert_equal(2*sol.function_calls, sol0.function_calls)
+        assert_equal(2 * sol.function_calls, sol0.function_calls)
 
-        sol0 = root_scalar(f1, method='halley', x0=3, fprime=f1_1, fprime2=f1_2)
-        sol = root_scalar(f1_and_p_and_pp, method='halley', x0=3, fprime2=True)
+        sol0 = root_scalar(f1, method="halley", x0=3, fprime=f1_1, fprime2=f1_2)
+        sol = root_scalar(f1_and_p_and_pp, method="halley", x0=3, fprime2=True)
         assert_allclose(sol0.root, sol.root, atol=1e-8)
-        assert_equal(3*sol.function_calls, sol0.function_calls)
+        assert_equal(3 * sol.function_calls, sol0.function_calls)
 
     def test_newton_full_output(self, capsys):
         # Test the full_output capability, both when converging and not.
@@ -409,8 +474,11 @@ class TestNewton(TestScalarRootFinders):
         expected_counts = [(6, 7), (5, 10), (3, 9)]
 
         for derivs in range(3):
-            kwargs = {'tol': 1e-6, 'full_output': True, }
-            for k, v in [['fprime', f1_1], ['fprime2', f1_2]][:derivs]:
+            kwargs = {
+                "tol": 1e-6,
+                "full_output": True,
+            }
+            for k, v in [["fprime", f1_1], ["fprime2", f1_2]][:derivs]:
                 kwargs[k] = v
 
             x, r = zeros.newton(f1, x0, disp=False, **kwargs)
@@ -432,18 +500,20 @@ class TestNewton(TestScalarRootFinders):
             if derivs == 1:
                 # Check that the correct Exception is raised and
                 # validate the start of the message.
-                msg = f'Failed to converge after {iters} iterations, value is .*'
+                msg = f"Failed to converge after {iters} iterations, value is .*"
                 with pytest.raises(RuntimeError, match=msg):
                     x, r = zeros.newton(f1, x0, maxiter=iters, disp=True, **kwargs)
 
     def test_deriv_zero_warning(self):
         def func(x):
-            return x ** 2 - 2.0
+            return x**2 - 2.0
+
         def dfunc(x):
             return 2 * x
+
         with pytest.warns(RuntimeWarning):
             zeros.newton(func, 0.0, dfunc, disp=False)
-        with pytest.raises(RuntimeError, match='Derivative was zero'):
+        with pytest.raises(RuntimeError, match="Derivative was zero"):
             zeros.newton(func, 0.0, dfunc)
 
     def test_newton_does_not_modify_x0(self):
@@ -463,9 +533,8 @@ class TestNewton(TestScalarRootFinders):
             assert np.isscalar(x)
             return f1(x)
 
-        res_newton_default = root_scalar(f, method='newton', x0=3, xtol=1e-6)
-        res_secant_default = root_scalar(f, method='secant', x0=3, x1=2,
-                                         xtol=1e-6)
+        res_newton_default = root_scalar(f, method="newton", x0=3, xtol=1e-6)
+        res_secant_default = root_scalar(f, method="secant", x0=3, x1=2, xtol=1e-6)
         # `newton` uses the secant method when `x1` and `x2` are specified
         res_secant = newton(f, x0=3, x1=2, tol=1e-6, full_output=True)[1]
 
@@ -478,27 +547,29 @@ class TestNewton(TestScalarRootFinders):
         assert res_secant.root.shape == tuple()
 
         # Defaults are correct
-        assert (res_secant_default.root
-                == res_secant.root
-                != res_newton_default.iterations)
-        assert (res_secant_default.iterations
-                == res_secant_default.function_calls - 1  # true for secant
-                == res_secant.iterations
-                != res_newton_default.iterations
-                == res_newton_default.function_calls/2)  # newton 2-point diff
+        assert (
+            res_secant_default.root == res_secant.root != res_newton_default.iterations
+        )
+        assert (
+            res_secant_default.iterations
+            == res_secant_default.function_calls - 1  # true for secant
+            == res_secant.iterations
+            != res_newton_default.iterations
+            == res_newton_default.function_calls / 2
+        )  # newton 2-point diff
 
-    @pytest.mark.parametrize('kwargs', [dict(), {'method': 'newton'}])
+    @pytest.mark.parametrize("kwargs", [dict(), {"method": "newton"}])
     def test_args_gh19090(self, kwargs):
         def f(x, a, b):
             assert a == 3
             assert b == 1
-            return (x ** a - b)
+            return x**a - b
 
         res = optimize.root_scalar(f, x0=3, args=(3, 1), **kwargs)
         assert res.converged
         assert_allclose(res.root, 1)
 
-    @pytest.mark.parametrize('method', ['secant', 'newton'])
+    @pytest.mark.parametrize("method", ["secant", "newton"])
     def test_int_x0_gh19280(self, method):
         # Originally, `newton` ensured that only floats were passed to the
         # callable. This was inadvertently changed by gh-17669. Check that
@@ -521,7 +592,7 @@ class TestNewton(TestScalarRootFinders):
         with pytest.raises(ValueError, match="maxiter must be greater than 0"):
             zeros.newton(f1, 3, tol=1e-6, maxiter=-50)
 
-        with pytest.raises(ValueError, match="x1 and x0 must be different" ):
+        with pytest.raises(ValueError, match="x1 and x0 must be different"):
             zeros.newton(f1, 3, x1=3)
 
 
@@ -531,12 +602,13 @@ def test_gh_5555():
     def f(x):
         return x - root
 
-    methods = [zeros.bisect, zeros.ridder]
+    methods = [zeros.bisect, zeros.ridder, zeros.chandrupatla]
     xtol = rtol = TOL
     for method in methods:
         res = method(f, -1e8, 1e7, xtol=xtol, rtol=rtol)
-        assert_allclose(root, res, atol=xtol, rtol=rtol,
-                        err_msg=f'method {method.__name__}')
+        assert_allclose(
+            root, res, atol=xtol, rtol=rtol, err_msg=f"method {method.__name__}"
+        )
 
 
 def test_gh_5557():
@@ -574,18 +646,21 @@ def test_brent_underflow_in_root_bracketing():
     for a, b, root in [underflow_scenario, overflow_scenario]:
         c = np.exp(root)
         for method in [zeros.brenth, zeros.brentq]:
-            res = method(lambda x: np.exp(x)-c, a, b)
+            res = method(lambda x: np.exp(x) - c, a, b)
             assert_allclose(root, res)
 
 
 class TestRootResults:
-    r = zeros.RootResults(root=1.0, iterations=44, function_calls=46, flag=0,
-                          method="newton")
+    r = zeros.RootResults(
+        root=1.0, iterations=44, function_calls=46, flag=0, method="newton"
+    )
 
     def test_repr(self):
-        expected_repr = ("      converged: True\n           flag: converged"
-                         "\n function_calls: 46\n     iterations: 44\n"
-                         "           root: 1.0\n         method: newton")
+        expected_repr = (
+            "      converged: True\n           flag: converged"
+            "\n function_calls: 46\n     iterations: 44\n"
+            "           root: 1.0\n         method: newton"
+        )
         assert_equal(repr(self.r), expected_repr)
 
     def test_type(self):
@@ -594,6 +669,7 @@ class TestRootResults:
 
 def test_complex_halley():
     """Test Halley's works with complex roots"""
+
     def f(x, *a):
         return a[0] * x**2 + a[1] * x + a[2]
 
@@ -633,7 +709,7 @@ def test_zero_der_nz_dp(capsys):
     p0 = (200.0 - dx) / (2.0 + dx)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "RMS of", RuntimeWarning)
-        x = zeros.newton(lambda y: (y - 100.0)**2, x0=[p0] * 10)
+        x = zeros.newton(lambda y: (y - 100.0) ** 2, x0=[p0] * 10)
     assert_allclose(x, [100] * 10)
     # test scalar cases too
     p0 = (2.0 - 1e-4) / (2.0 + 1e-4)
@@ -641,14 +717,14 @@ def test_zero_der_nz_dp(capsys):
         warnings.filterwarnings("ignore", "Tolerance of", RuntimeWarning)
         x = zeros.newton(lambda y: (y - 1.0) ** 2, x0=p0, disp=False)
     assert_allclose(x, 1)
-    with pytest.raises(RuntimeError, match='Tolerance of'):
+    with pytest.raises(RuntimeError, match="Tolerance of"):
         x = zeros.newton(lambda y: (y - 1.0) ** 2, x0=p0, disp=True)
     p0 = (-2.0 + 1e-4) / (2.0 + 1e-4)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", "Tolerance of", RuntimeWarning)
         x = zeros.newton(lambda y: (y + 1.0) ** 2, x0=p0, disp=False)
     assert_allclose(x, -1)
-    with pytest.raises(RuntimeError, match='Tolerance of'):
+    with pytest.raises(RuntimeError, match="Tolerance of"):
         x = zeros.newton(lambda y: (y + 1.0) ** 2, x0=p0, disp=True)
 
 
@@ -666,22 +742,28 @@ def test_array_newton_failures():
     reynolds_number = rho * u * diameter / mu  # Reynolds number
 
     def colebrook_eqn(darcy_friction, re, dia):
-        return (1 / np.sqrt(darcy_friction) +
-                2 * np.log10(roughness / 3.7 / dia +
-                             2.51 / re / np.sqrt(darcy_friction)))
+        return 1 / np.sqrt(darcy_friction) + 2 * np.log10(
+            roughness / 3.7 / dia + 2.51 / re / np.sqrt(darcy_friction)
+        )
 
     # only some failures
     with pytest.warns(RuntimeWarning):
         result = zeros.newton(
-            colebrook_eqn, x0=[0.01, 0.2, 0.02223, 0.3], maxiter=2,
-            args=[reynolds_number, diameter], full_output=True
+            colebrook_eqn,
+            x0=[0.01, 0.2, 0.02223, 0.3],
+            maxiter=2,
+            args=[reynolds_number, diameter],
+            full_output=True,
         )
         assert not result.converged.all()
     # they all fail
     with pytest.raises(RuntimeError):
         result = zeros.newton(
-            colebrook_eqn, x0=[0.01] * 2, maxiter=2,
-            args=[reynolds_number, diameter], full_output=True
+            colebrook_eqn,
+            x0=[0.01] * 2,
+            maxiter=2,
+            args=[reynolds_number, diameter],
+            full_output=True,
         )
 
 
@@ -697,7 +779,7 @@ def test_gh8904_zeroder_at_root_fails():
     r = zeros.newton(f_zeroder_root, x0=0)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
     # test again with array
-    r = zeros.newton(f_zeroder_root, x0=[0]*10)
+    r = zeros.newton(f_zeroder_root, x0=[0] * 10)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
 
     # 1st derivative
@@ -706,19 +788,17 @@ def test_gh8904_zeroder_at_root_fails():
 
     # 2nd derivative
     def fder2(x):
-        return 6*x - 2
+        return 6 * x - 2
 
     # should work with newton and halley
     r = zeros.newton(f_zeroder_root, x0=0, fprime=fder)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
-    r = zeros.newton(f_zeroder_root, x0=0, fprime=fder,
-                     fprime2=fder2)
+    r = zeros.newton(f_zeroder_root, x0=0, fprime=fder, fprime2=fder2)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
     # test again with array
-    r = zeros.newton(f_zeroder_root, x0=[0]*10, fprime=fder)
+    r = zeros.newton(f_zeroder_root, x0=[0] * 10, fprime=fder)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
-    r = zeros.newton(f_zeroder_root, x0=[0]*10, fprime=fder,
-                     fprime2=fder2)
+    r = zeros.newton(f_zeroder_root, x0=[0] * 10, fprime=fder, fprime2=fder2)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
 
     # also test that if a root is found we do not raise RuntimeWarning even if
@@ -729,7 +809,7 @@ def test_gh8904_zeroder_at_root_fails():
     r = zeros.newton(f_zeroder_root, x0=0.5, fprime=fder)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
     # test again with array
-    r = zeros.newton(f_zeroder_root, x0=[0.5]*10, fprime=fder)
+    r = zeros.newton(f_zeroder_root, x0=[0.5] * 10, fprime=fder)
     assert_allclose(r, 0, atol=zeros._xtol, rtol=zeros._rtol)
     # doesn't apply to halley
 
@@ -740,13 +820,13 @@ def test_gh_8881():
     n = 9
 
     def f(x):
-        return power(x, 1.0/n) - power(n, 1.0/n)
+        return power(x, 1.0 / n) - power(n, 1.0 / n)
 
     def fp(x):
-        return power(x, (1.0-n)/n)/n
+        return power(x, (1.0 - n) / n) / n
 
     def fpp(x):
-        return power(x, (1.0-2*n)/n) * (1.0/n) * (1.0-n)/n
+        return power(x, (1.0 - 2 * n) / n) * (1.0 / n) * (1.0 - n) / n
 
     x0 = 0.1
     # The root is at x=9.
@@ -765,6 +845,7 @@ def test_gh_9608_preserve_array_shape():
     Test that shape is preserved for array inputs even if fprime or fprime2 is
     scalar
     """
+
     def f(x):
         return x**2
 
@@ -781,31 +862,34 @@ def test_gh_9608_preserve_array_shape():
     x0_array = np.array([-2, -3], dtype=np.float32)
     # This next invocation should fail
     with pytest.raises(IndexError):
-        result = zeros.newton(
-            f, x0_array, fprime=fp, fprime2=fpp, full_output=True
-        )
+        result = zeros.newton(f, x0_array, fprime=fp, fprime2=fpp, full_output=True)
 
     def fpp_array(x):
         return np.full(np.shape(x), 2, dtype=np.float32)
 
-    result = zeros.newton(
-        f, x0_array, fprime=fp, fprime2=fpp_array, full_output=True
-    )
+    result = zeros.newton(f, x0_array, fprime=fp, fprime2=fpp_array, full_output=True)
     assert result.converged.all()
 
 
 @pytest.mark.parametrize(
-    "maximum_iterations,flag_expected",
-    [(10, zeros.CONVERR), (100, zeros.CONVERGED)])
+    "maximum_iterations,flag_expected", [(10, zeros.CONVERR), (100, zeros.CONVERGED)]
+)
 def test_gh9254_flag_if_maxiter_exceeded(maximum_iterations, flag_expected):
     """
     Test that if the maximum iterations is exceeded that the flag is not
     converged.
     """
     result = zeros.brentq(
-        lambda x: ((1.2*x - 2.3)*x + 3.4)*x - 4.5,
-        -30, 30, (), 1e-6, 1e-6, maximum_iterations,
-        full_output=True, disp=False)
+        lambda x: ((1.2 * x - 2.3) * x + 3.4) * x - 4.5,
+        -30,
+        30,
+        (),
+        1e-6,
+        1e-6,
+        maximum_iterations,
+        full_output=True,
+        disp=False,
+    )
     assert result[1].flag == flag_expected
     if flag_expected == zeros.CONVERR:
         # didn't converge because exceeded maximum iterations
@@ -819,24 +903,26 @@ def test_gh9551_raise_error_if_disp_true():
     """Test that if disp is true then zero derivative raises RuntimeError"""
 
     def f(x):
-        return x*x + 1
+        return x * x + 1
 
     def f_p(x):
-        return 2*x
+        return 2 * x
 
     with pytest.warns(RuntimeWarning):
         zeros.newton(f, 1.0, f_p, disp=False)
     with pytest.raises(
-            RuntimeError,
-            match=r'^Derivative was zero\. Failed to converge after \d+ iterations, '
-                  r'value is [+-]?\d*\.\d+\.$'):
+        RuntimeError,
+        match=r"^Derivative was zero\. Failed to converge after \d+ iterations, "
+        r"value is [+-]?\d*\.\d+\.$",
+    ):
         zeros.newton(f, 1.0, f_p)
     root = zeros.newton(f, complex(10.0, 10.0), f_p)
     assert_allclose(root, complex(0.0, 1.0))
 
 
-@pytest.mark.parametrize('solver_name',
-                         ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
+@pytest.mark.parametrize(
+    "solver_name", ["brentq", "brenth", "bisect", "ridder", "toms748", "chandrupatla"]
+)
 def test_gh3089_8394(solver_name):
     # gh-3089 and gh-8394 reported that bracketing solvers returned incorrect
     # results when they encountered NaNs. Check that this is resolved.
@@ -848,8 +934,9 @@ def test_gh3089_8394(solver_name):
         solver(f, 0, 1)
 
 
-@pytest.mark.parametrize('method',
-                         ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
+@pytest.mark.parametrize(
+    "method", ["brentq", "brenth", "bisect", "ridder", "toms748", "chandrupatla"]
+)
 def test_gh18171(method):
     # gh-3089 and gh-8394 reported that bracketing solvers returned incorrect
     # results when they encountered NaNs. Check that `root_scalar` returns
@@ -857,6 +944,7 @@ def test_gh18171(method):
     def f(x):
         f._count += 1
         return np.nan
+
     f._count = 0
 
     res = root_scalar(f, bracket=(0, 1), method=method)
@@ -866,18 +954,23 @@ def test_gh18171(method):
     assert str(res.root) in res.flag
 
 
-@pytest.mark.parametrize('solver_name',
-                         ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
-@pytest.mark.parametrize('rs_interface', [True, False])
+@pytest.mark.parametrize(
+    "solver_name", ["brentq", "brenth", "bisect", "ridder", "toms748", "chandrupatla"]
+)
+@pytest.mark.parametrize("rs_interface", [True, False])
 def test_function_calls(solver_name, rs_interface):
     # There do not appear to be checks that the bracketing solvers report the
     # correct number of function evaluations. Check that this is the case.
-    solver = ((lambda f, a, b, **kwargs: root_scalar(f, bracket=(a, b)))
-              if rs_interface else getattr(zeros, solver_name))
+    solver = (
+        (lambda f, a, b, **kwargs: root_scalar(f, bracket=(a, b)))
+        if rs_interface
+        else getattr(zeros, solver_name)
+    )
 
     def f(x):
         f.calls += 1
         return x**2 - 1
+
     f.calls = 0
 
     res = solver(f, 0, 10, full_output=True)
@@ -890,34 +983,39 @@ def test_function_calls(solver_name, rs_interface):
 
 def test_gh_14486_converged_false():
     """Test that zero slope with secant method results in a converged=False"""
+
     def lhs(x):
-        return x * np.exp(-x*x) - 0.07
+        return x * np.exp(-x * x) - 0.07
 
-    with pytest.warns(RuntimeWarning, match='Tolerance of'):
-        res = root_scalar(lhs, method='secant', x0=-0.15, x1=1.0)
+    with pytest.warns(RuntimeWarning, match="Tolerance of"):
+        res = root_scalar(lhs, method="secant", x0=-0.15, x1=1.0)
     assert not res.converged
-    assert res.flag == 'convergence error'
+    assert res.flag == "convergence error"
 
-    with pytest.warns(RuntimeWarning, match='Tolerance of'):
+    with pytest.warns(RuntimeWarning, match="Tolerance of"):
         res = newton(lhs, x0=-0.15, x1=1.0, disp=False, full_output=True)[1]
     assert not res.converged
-    assert res.flag == 'convergence error'
+    assert res.flag == "convergence error"
 
 
-@pytest.mark.parametrize('solver_name',
-                         ['brentq', 'brenth', 'bisect', 'ridder', 'toms748'])
-@pytest.mark.parametrize('rs_interface', [True, False])
+@pytest.mark.parametrize(
+    "solver_name", ["brentq", "brenth", "bisect", "ridder", "toms748", "chandrupatla"]
+)
+@pytest.mark.parametrize("rs_interface", [True, False])
 def test_gh5584(solver_name, rs_interface):
     # gh-5584 reported that an underflow can cause sign checks in the algorithm
     # to fail. Check that this is resolved.
-    solver = ((lambda f, a, b, **kwargs: root_scalar(f, bracket=(a, b)))
-              if rs_interface else getattr(zeros, solver_name))
+    solver = (
+        (lambda f, a, b, **kwargs: root_scalar(f, bracket=(a, b)))
+        if rs_interface
+        else getattr(zeros, solver_name)
+    )
 
     def f(x):
-        return 1e-200*x
+        return 1e-200 * x
 
     # Report failure when signs are the same
-    with pytest.raises(ValueError, match='...must have different signs'):
+    with pytest.raises(ValueError, match="...must have different signs"):
         solver(f, -0.5, -0.4, full_output=True)
 
     # Solve successfully when signs are different
@@ -927,7 +1025,7 @@ def test_gh5584(solver_name, rs_interface):
     assert_allclose(res.root, 0, atol=1e-8)
 
     # Solve successfully when one side is negative zero
-    res = solver(f, -0.5, float('-0.0'), full_output=True)
+    res = solver(f, -0.5, float("-0.0"), full_output=True)
     res = res if rs_interface else res[1]
     assert res.converged
     assert_allclose(res.root, 0, atol=1e-8)
@@ -940,20 +1038,20 @@ def test_gh13407():
     # that the error message has been corrected and that `rtol=eps` can produce
     # a lower function value than `rtol=4*eps`.
     def f(x):
-        return x**3 - 2*x - 5
+        return x**3 - 2 * x - 5
 
     xtol = 1e-300
     eps = np.finfo(float).eps
-    x1 = zeros.toms748(f, 1e-10, 1e10, xtol=xtol, rtol=1*eps)
+    x1 = zeros.toms748(f, 1e-10, 1e10, xtol=xtol, rtol=1 * eps)
     f1 = f(x1)
-    x4 = zeros.toms748(f, 1e-10, 1e10, xtol=xtol, rtol=4*eps)
+    x4 = zeros.toms748(f, 1e-10, 1e10, xtol=xtol, rtol=4 * eps)
     f4 = f(x4)
     assert f1 < f4
 
     # using old-style syntax to get exactly the same message
-    message = fr"rtol too small \({eps/2:g} < {eps:g}\)"
+    message = rf"rtol too small \({eps / 2:g} < {eps:g}\)"
     with pytest.raises(ValueError, match=message):
-        zeros.toms748(f, 1e-10, 1e10, xtol=xtol, rtol=eps/2)
+        zeros.toms748(f, 1e-10, 1e10, xtol=xtol, rtol=eps / 2)
 
 
 def test_newton_complex_gh10103():
@@ -962,14 +1060,15 @@ def test_newton_complex_gh10103():
     # Check that this is resolved.
     def f(z):
         return z - 1
-    res = newton(f, 1+1j)
+
+    res = newton(f, 1 + 1j)
     assert_allclose(res, 1, atol=1e-12)
 
-    res = root_scalar(f, x0=1+1j, x1=2+1.5j, method='secant')
+    res = root_scalar(f, x0=1 + 1j, x1=2 + 1.5j, method="secant")
     assert_allclose(res.root, 1, atol=1e-12)
 
 
-@pytest.mark.parametrize('method', all_methods)
+@pytest.mark.parametrize("method", all_methods)
 def test_maxiter_int_check_gh10236(method):
     # gh-10236 reported that the error message when `maxiter` is not an integer
     # was difficult to interpret. Check that this was resolved (by gh-10907).
@@ -977,8 +1076,11 @@ def test_maxiter_int_check_gh10236(method):
     with pytest.raises(TypeError, match=message):
         method(f1, 0.0, 1.0, maxiter=72.45)
 
-@pytest.mark.parametrize("method", [zeros.bisect, zeros.ridder,
-                                    zeros.brentq, zeros.brenth])
+
+@pytest.mark.parametrize(
+    "method",
+    [zeros.bisect, zeros.ridder, zeros.brentq, zeros.brenth, zeros.chandrupatla],
+)
 def test_bisect_special_parameter(method):
     # give some zeros method strange parameters
     # and check whether an exception appears
@@ -990,6 +1092,6 @@ def test_bisect_special_parameter(method):
         return x - root
 
     with pytest.raises(ValueError, match="xtol too small"):
-       method(f, -1e8, 1e7, args=args, xtol=-1e-6, rtol=TOL)
+        method(f, -1e8, 1e7, args=args, xtol=-1e-6, rtol=TOL)
     with pytest.raises(ValueError, match="rtol too small"):
-       method(f, -1e8, 1e7, args=args, xtol=1e-6, rtol=rtolbad)
+        method(f, -1e8, 1e7, args=args, xtol=1e-6, rtol=rtolbad)

--- a/scipy/optimize/zeros.c
+++ b/scipy/optimize/zeros.c
@@ -160,6 +160,12 @@ _ridder(PyObject *self, PyObject *args)
 }
 
 static PyObject *
+_chandrupatla(PyObject *self, PyObject *args)
+{
+        return call_solver(chandrupatla,self,args);
+}
+
+static PyObject *
 _brenth(PyObject *self, PyObject *args)
 {
         return call_solver(brenth,self,args);
@@ -179,6 +185,7 @@ static PyMethodDef
 Zerosmethods[] = {
 	{"_bisect", _bisect, METH_VARARGS, "a"},
 	{"_ridder", _ridder, METH_VARARGS, "a"},
+	{"_chandrupatla", _chandrupatla, METH_VARARGS, "a"},
 	{"_brenth", _brenth, METH_VARARGS, "a"},
 	{"_brentq", _brentq, METH_VARARGS, "a"},
 	{NULL, NULL}

--- a/scipy/optimize/zeros.py
+++ b/scipy/optimize/zeros.py
@@ -6,13 +6,14 @@ from scipy._lib.deprecation import _sub_module_deprecation
 
 
 __all__ = [  # noqa: F822
-    'RootResults',
-    'bisect',
-    'brenth',
-    'brentq',
-    'newton',
-    'ridder',
-    'toms748',
+    "RootResults",
+    "bisect",
+    "brenth",
+    "brentq",
+    "newton",
+    "ridder",
+    "chandrupatla",
+    "toms748",
 ]
 
 
@@ -21,6 +22,10 @@ def __dir__():
 
 
 def __getattr__(name):
-    return _sub_module_deprecation(sub_package="optimize", module="zeros",
-                                   private_modules=["_zeros_py"], all=__all__,
-                                   attribute=name)
+    return _sub_module_deprecation(
+        sub_package="optimize",
+        module="zeros",
+        private_modules=["_zeros_py"],
+        all=__all__,
+        attribute=name,
+    )


### PR DESCRIPTION
#### Reference issue
none

#### What does this implement/fix?
I implemented Chandrupatla's root finding method for the classic interfaces, as it was only available for the `elementwise` interface.
I copied the existing code of Ridders' method and adapted it accordingly.

As this is my first PR here, I hope that I have not missed anything. Tried to catch up all references in docs and add the method to all tests were Ridders' was already present.