### PR TITLE
ENH: linalg/SVD: move the batching loop to C

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -148,6 +148,23 @@ class BatchedSolveBench(Benchmark):
             sl.solve(self.a, self.b, check_finite=False, **self.kwd)
 
 
+class BatchedSVDBench(Benchmark):
+    params = [
+        [(10, 10, 10, 2), (100, 10, 10), (100, 20, 20), (100, 100, 100)],
+        ["scipy", "numpy"]
+    ]
+    param_names = ['shape',  'module']
+
+    def setup(self, shape, module):
+        self.a = random(shape)
+
+    def time_svd(self, shape, module):
+        if module == 'numpy':
+            nl.svd(self.a)
+        else:
+            sl.svd(self.a)
+
+
 class Norm(Benchmark):
     params = [
         [(20, 20), (100, 100), (1000, 1000), (20, 1000), (1000, 20)],

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -8,6 +8,7 @@ from . import _batched_linalg
 # Local imports.
 from ._misc import LinAlgError, _datacopied
 from .lapack import _normalize_lapack_dtype, HAS_ILP64
+from scipy.linalg.lapack import get_lapack_funcs   # noqa: F401  (backwards compat)
 from ._decomp import _asarray_validated
 
 

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -153,15 +153,16 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     if a1.size == 0:
         u0, s0, v0 = svd(np.eye(2, dtype=a1.dtype))
 
-        s = np.empty_like(a1, shape=(0,), dtype=s0.dtype)
+        batch_shape = a1.shape[:-2]
+        s = np.empty_like(a1, shape=batch_shape + (0,), dtype=s0.dtype)
         if full_matrices:
-            u = np.empty_like(a1, shape=(m, m), dtype=u0.dtype)
+            u = np.empty_like(a1, shape=batch_shape + (m, m), dtype=u0.dtype)
             u[...] = np.identity(m)
-            v = np.empty_like(a1, shape=(n, n), dtype=v0.dtype)
+            v = np.empty_like(a1, shape=batch_shape + (n, n), dtype=v0.dtype)
             v[...] = np.identity(n)
         else:
-            u = np.empty_like(a1, shape=(m, 0), dtype=u0.dtype)
-            v = np.empty_like(a1, shape=(0, n), dtype=v0.dtype)
+            u = np.empty_like(a1, shape=batch_shape + (m, 0), dtype=u0.dtype)
+            v = np.empty_like(a1, shape=batch_shape + (0, n), dtype=v0.dtype)
         if compute_uv:
             return u, s, v
         else:

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -279,16 +279,16 @@ _linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _svd<float>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+            info = _svd<float>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _svd<double>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+            info = _svd<double>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _svd<npy_complex64>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+            info = _svd<npy_complex64>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _svd<npy_complex128>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+            info = _svd<npy_complex128>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, vec_status);
             break;
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -1,8 +1,11 @@
 #ifndef _LINALG_INV_H
 #define _LINALG_INV_H
 
+#include <cstring>
+
 #include "_linalg_inv.hh"
 #include "_linalg_solve.hh"
+#include "_linalg_svd.hh"
 #include "_common_array_utils.hh"
 
 
@@ -190,6 +193,126 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
 }
 
 
+static PyObject*
+_linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
+    PyArrayObject *ap_Am = NULL;
+    const char *lapack_driver = NULL;
+    int compute_uv = 1;
+    int full_matrices = 1;
+    PyArrayObject *ap_S = NULL, *ap_U = NULL, *ap_Vh = NULL;
+
+    int info = 0;
+    SliceStatusVec vec_status;
+
+    // Get the input array
+    if (!PyArg_ParseTuple(args, "O!s|pp", &PyArray_Type, (PyObject **)&ap_Am,  &lapack_driver, &compute_uv, &full_matrices)) {
+        return NULL;
+    }
+
+    // Check for dtype compatibility & array flags
+    int typenum = PyArray_TYPE(ap_Am);
+    bool dtype_ok = (typenum == NPY_FLOAT32)
+                     || (typenum == NPY_FLOAT64)
+                     || (typenum == NPY_COMPLEX64)
+                     || (typenum == NPY_COMPLEX128);
+    if(!dtype_ok || !PyArray_ISALIGNED(ap_Am)) {
+        PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
+        return NULL;
+    }
+
+    // Basic checks of array dimensions
+    int ndim = PyArray_NDIM(ap_Am);
+    npy_intp *shape = PyArray_SHAPE(ap_Am);
+    if (ndim < 2) {
+        PyErr_SetString(PyExc_ValueError, "Expected at least a 2D array.");
+    }
+
+    npy_intp m = shape[ndim - 2];
+    npy_intp n = shape[ndim - 1];
+    npy_intp k = m < n ? m : n; 
+
+    // Allocate the output(s)
+
+    // S.dtype is real if A.dtype is complex
+    npy_intp typenum_S = typenum;
+    if (typenum_S == NPY_COMPLEX64) { typenum_S = NPY_FLOAT32; }
+    else if (typenum_S == NPY_COMPLEX128) { typenum_S = NPY_FLOAT64; }
+
+    // S.shape = (..., k)
+    npy_intp shape_1[NPY_MAXDIMS];
+    for(int i=0; i<PyArray_NDIM(ap_Am); i++) {
+        shape_1[i] = PyArray_DIM(ap_Am, i);
+    }
+    shape_1[ndim - 2] = k;
+    ap_S = (PyArrayObject *)PyArray_SimpleNew(ndim-1, shape_1, typenum_S);
+    if(!ap_S) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    char jobz = compute_uv ? (full_matrices ? 'A' : 'S') : 'N';
+
+    // U.shape = (..., m, m) or (..., m, k) or not referenced (for jobz='N')
+    // Vh.shape = (..., n, n) or (..., k, n) or not referenced (for jobz='N')
+    if (jobz != 'N') {
+        npy_intp u_shape0, u_shape1, vh_shape0, vh_shape1;
+        u_vh_shapes(m, n, jobz, &u_shape0, &u_shape1, &vh_shape0, &vh_shape1);
+
+        shape_1[ndim-2] = u_shape0;
+        shape_1[ndim-1] = u_shape1;
+
+        ap_U = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
+        if (!ap_U) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+
+        shape_1[ndim-2] = vh_shape0;
+        shape_1[ndim-1] = vh_shape1;
+
+        ap_Vh = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
+        if (!ap_Vh) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+    }
+
+    switch(typenum) {
+        case(NPY_FLOAT32):
+            info = _svd<float>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+            break;
+        case(NPY_FLOAT64):
+            info = _svd<double>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+            break;
+        case(NPY_COMPLEX64):
+            info = _svd<npy_complex64>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+            break;
+        case(NPY_COMPLEX128):
+            info = _svd<npy_complex128>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+            break;
+        default:
+            PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");
+    }
+
+    if (info < 0) {
+        // Either OOM or internal LAPACK error.
+        Py_DECREF(ap_S);
+        Py_DECREF(ap_U);
+        Py_DECREF(ap_Vh);
+        PyErr_SetString(PyExc_RuntimeError, "Memory error in scipy.linalg.svd.");
+        return NULL;
+    }
+
+    PyObject *ret_lst = convert_vec_status(vec_status);
+
+    if (compute_uv){
+        return Py_BuildValue("NNNN", PyArray_Return(ap_U), PyArray_Return(ap_S), PyArray_Return(ap_Vh), ret_lst);
+    } else {
+        return Py_BuildValue("NN", PyArray_Return(ap_S), ret_lst);
+    }
+
+}
+
 
 /*
  * Helper: convert a vector of slice error statuses to list of dicts
@@ -225,10 +348,12 @@ convert_vec_status(SliceStatusVec& vec_status) {
 
 static char doc_inv[] = ("Compute the matrix inverse.");
 static char doc_solve[] = ("Solve the linear system of equations.");
+static char doc_svd[] = ("SVD factorization.");
 
 static struct PyMethodDef inv_module_methods[] = {
   {"_inv", _linalg_inv, METH_VARARGS, doc_inv},
   {"_solve", _linalg_solve, METH_VARARGS, doc_solve},
+  {"_svd", _linalg_svd, METH_VARARGS, doc_svd},
   {NULL, NULL, 0, NULL}
 };
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -263,6 +263,7 @@ _linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
         ap_U = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
         if (!ap_U) {
+            Py_DECREF(ap_S);
             PyErr_NoMemory();
             return NULL;
         }
@@ -272,6 +273,8 @@ _linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
         ap_Vh = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
         if (!ap_Vh) {
+            Py_DECREF(ap_S);
+            Py_DECREF(ap_U);
             PyErr_NoMemory();
             return NULL;
         }

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -322,28 +322,28 @@ fail:
 PyObject* 
 convert_vec_status(SliceStatusVec& vec_status) {
     PyObject *ret_dct = NULL;
-    PyObject *ret_lst = NULL;
+    PyObject *ret_lst = PyList_New(0);
 
     if (vec_status.empty()) {
-        ret_lst = PyList_New(0);
-    } else {
-        // Problems detected in some slices, report.
-
-        ret_lst = PyList_New(0);
-        for (size_t i=0; i<vec_status.size(); i++) {
-            SliceStatus status = vec_status[i];
-            ret_dct = Py_BuildValue(
-                "{s:n,s:n,s:i,s:i,s:d,s:n}",
-                "num", status.slice_num,
-                "structure", status.structure,
-                "is_singular", status.is_singular,
-                "is_ill_conditioned", status.is_ill_conditioned,
-                "rcond", status.rcond,
-                "lapack_info", status.lapack_info
-            );
-            PyList_Append(ret_lst, ret_dct);
-        }
+        return ret_lst;
     }
+
+    // Problems detected in some slices, report.
+    for (size_t i=0; i<vec_status.size(); i++) {
+        SliceStatus status = vec_status[i];
+        ret_dct = Py_BuildValue(
+            "{s:n,s:n,s:i,s:i,s:d,s:n}",
+            "num", status.slice_num,
+            "structure", status.structure,
+            "is_singular", status.is_singular,
+            "is_ill_conditioned", status.is_ill_conditioned,
+            "rcond", status.rcond,
+            "lapack_info", status.lapack_info
+        );
+        PyList_Append(ret_lst, ret_dct);
+        Py_DECREF(ret_dct);
+    }
+
     return ret_lst;
 }
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -168,6 +168,19 @@ void BLAS_FUNC(dgtcon)(char *norm, CBLAS_INT *n, double *dl, double *d, double *
 void BLAS_FUNC(cgtcon)(char *norm, CBLAS_INT *n, npy_complex64 *dl, npy_complex64 *d, npy_complex64 *du, npy_complex64 *du2, CBLAS_INT *ipiv, float *anorm, float *rcond, npy_complex64 *work, CBLAS_INT *info);
 void BLAS_FUNC(zgtcon)(char *norm, CBLAS_INT *n, npy_complex128 *dl, npy_complex128 *d, npy_complex128 *du, npy_complex128 *du2, CBLAS_INT *ipiv, double *anorm, double *rcond, npy_complex128 *work, CBLAS_INT *info);
 
+
+/* ?GESVD*/
+void BLAS_FUNC(sgesvd)(char *jobu, char *jobvt, CBLAS_INT *m, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *s, float *u, CBLAS_INT *ldu, float *vt, CBLAS_INT *ldvt, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dgesvd)(char *jobu, char *jobvt, CBLAS_INT *m, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *s, double *u, CBLAS_INT *ldu, double *vt, CBLAS_INT *ldvt, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(cgesvd)(char *jobu, char *jobvt, CBLAS_INT *m, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, float *s, npy_complex64 *u, CBLAS_INT *ldu, npy_complex64 *vt, CBLAS_INT *ldvt, npy_complex64 *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *info);
+void BLAS_FUNC(zgesvd)(char *jobu, char *jobvt, CBLAS_INT *m, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, double *s, npy_complex128 *u, CBLAS_INT *ldu, npy_complex128 *vt, CBLAS_INT *ldvt, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
+
+/* ?GESDD*/
+void BLAS_FUNC(sgesdd)(char *jobz, CBLAS_INT *m, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *s, float *u, CBLAS_INT *ldu, float *vt, CBLAS_INT *ldvt, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(dgesdd)(char *jobz, CBLAS_INT *m, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *s, double *u, CBLAS_INT *ldu, double *vt, CBLAS_INT *ldvt, double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(cgesdd)(char *jobz, CBLAS_INT *m, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, float *s, npy_complex64 *u, CBLAS_INT *ldu, npy_complex64 *vt, CBLAS_INT *ldvt, npy_complex64 *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(zgesdd)(char *jobz, CBLAS_INT *m, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, double *s, npy_complex128 *u, CBLAS_INT *ldu, npy_complex128 *vt, CBLAS_INT *ldvt, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *iwork, CBLAS_INT *info);
+
 } // extern "C"
 
 
@@ -494,6 +507,54 @@ GEN_GTCON_CZ(c, npy_complex64, float)
 GEN_GTCON_CZ(z, npy_complex128, double)
 
 
+/* ?GESDD*/
+// NB: ?GESVD : c- and z- variants have the rwork argument, s- and d- variants do not
+#define GEN_GESVD_SD(PREFIX, TYPE, RTYPE) \
+inline void \
+gesvd(char *jobu, char *jobvt, CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *s, TYPE *u, CBLAS_INT *ldu, TYPE *vt, CBLAS_INT *ldvt, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, info); \
+};
+
+GEN_GESVD_SD(s, float, float)
+GEN_GESVD_SD(d, double, double)
+
+
+#define GEN_GESVD_CZ(PREFIX, TYPE, RTYPE) \
+inline void \
+gesvd(char *jobu, char *jobvt, CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *s, TYPE *u, CBLAS_INT *ldu, TYPE *vt, CBLAS_INT *ldvt, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gesvd)(jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, info); \
+};
+
+GEN_GESVD_CZ(c, npy_complex64, float)
+GEN_GESVD_CZ(z, npy_complex128, double)
+
+
+
+/* ?GESDD*/
+// NB: ?GESDD : c- and z- variants have the rwork argument, s- and d- variants do not
+
+#define GEN_GESDD_SD(PREFIX, TYPE, RTYPE) \
+inline void \
+gesdd(char *jobz, CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *s, TYPE *u, CBLAS_INT *ldu, TYPE *vt, CBLAS_INT *ldvt, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, iwork, info); \
+};
+
+GEN_GESDD_SD(s, float, float)
+GEN_GESDD_SD(d, double, double)
+
+
+#define GEN_GESDD_CZ(PREFIX, TYPE, RTYPE) \
+inline void \
+gesdd(char *jobz, CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *s, TYPE *u, CBLAS_INT *ldu, TYPE *vt, CBLAS_INT *ldvt, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info); \
+};
+
+GEN_GESDD_CZ(c, npy_complex64, float)
+GEN_GESDD_CZ(z, npy_complex128, double)
 
 
 // Structure tags; python side maps assume_a strings to these values

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -642,6 +642,21 @@ CBLAS_INT _calc_lwork(T _lwrk, double fudge_factor=1.0) {
 }
 
 
+/*
+ * Given an array of ndim >= 2, compute a pointer to the start of the 2D "slice" idx
+ */
+template<typename T>
+T* compute_slice_ptr(npy_intp idx, T *Am_data, npy_intp ndim, npy_intp *shape, npy_intp *strides) {
+    npy_intp offset = 0;
+    npy_intp temp_idx = idx;
+    for (int i = ndim - 3; i >= 0; i--) {
+        offset += (temp_idx % shape[i]) * strides[i];
+        temp_idx /= shape[i];
+    }
+    T* slice_ptr = (T *)(Am_data + (offset/sizeof(T)));
+    return slice_ptr;
+}
+
 
 /*
  * Copy n-by-m slice from slice_ptr to dst.

--- a/scipy/linalg/src/_linalg_svd.hh
+++ b/scipy/linalg/src/_linalg_svd.hh
@@ -39,16 +39,10 @@ u_vh_shapes(npy_intp m, npy_intp n, char jobz,
     return 1;
 }
 
-/*
- * TODO:
- * 3. gesvd : work array sizes
- * 4. gesvd : call
- */
-
 
 template<typename T>
 int
-_svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, SliceStatusVec& vec_status)
+_svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, SliceStatusVec& vec_status)
 {
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -70,8 +64,8 @@ _svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObje
     }
 
     // output array attributes
-    npy_intp min_mn = m < n ? m : n; 
-    npy_intp max_mn = m < n ? n : m; 
+    npy_intp min_mn = m < n ? m : n;
+    npy_intp max_mn = m < n ? n : m;
 
     // U, Vh shapes ( =0 if compute_uv=False)
     npy_intp u_shape0, u_shape1, vh_shape0, vh_shape1;
@@ -119,8 +113,10 @@ _svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObje
         buf_Vh = &buf[m*n + lwork + u_shape0*u_shape1];
     }
 
+    CBLAS_INT *iwork = NULL;
+    real_type *rwork = NULL;
     // iwork
-    CBLAS_INT *iwork = (CBLAS_INT *)malloc(8*min_mn*sizeof(CBLAS_INT));
+    iwork = (CBLAS_INT *)malloc(8*min_mn*sizeof(CBLAS_INT));
     if (iwork == NULL) {
         free(buf);
         info = -102;
@@ -128,7 +124,6 @@ _svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObje
     }
 
     // rwork
-    real_type *rwork = NULL;
     if (type_traits<T>::is_complex) {
         // assume LAPACK > 3.6 (cf LAPACK docs on netlib.org)
         npy_intp lrwork = std::max(
@@ -151,13 +146,7 @@ _svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObje
         init_status(slice_status, idx, St::GENERAL);
 
         // copy the slice to `data` in F order
-        npy_intp offset = 0;
-        npy_intp temp_idx = idx;
-        for (int i = ndim - 3; i >= 0; i--) {
-            offset += (temp_idx % shape[i]) * strides[i];
-            temp_idx /= shape[i];
-        }
-        T* slice_ptr = (T *)(Am_data + (offset/sizeof(T)));
+        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
         copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
 
         // SVD the slice
@@ -171,7 +160,7 @@ _svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObje
             goto done;
         }
 
-        // copy-and-tranpose U and Vh slics from temp buffers to the output;
+        // copy-and-tranpose U and Vh slices from temp buffers to the output;
         // S slice is filled in in-place already; 
         copy_slice_F_to_C(ptr_U, buf_U, u_shape0, u_shape1);
         copy_slice_F_to_C(ptr_Vh, buf_Vh, vh_shape0, vh_shape1);
@@ -187,4 +176,144 @@ _svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObje
     free(iwork);
     free(rwork);
     return 0;
+}
+
+
+template<typename T>
+int
+_svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, SliceStatusVec& vec_status)
+{
+    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    SliceStatus slice_status;
+
+    // --------------------------------------------------------------------
+    // Input Array Attributes
+    // --------------------------------------------------------------------
+    T* Am_data = (T *)PyArray_DATA(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);              // Number of dimensions
+    npy_intp* shape = PyArray_SHAPE(ap_Am);      // Array shape
+    npy_intp m = shape[ndim - 2];                // Slice size
+    npy_intp n = shape[ndim - 1];
+    npy_intp* strides = PyArray_STRIDES(ap_Am);
+
+    // Get the number of slices to traverse if more than one; np.prod(shape[:-2])
+    npy_intp outer_size = 1;
+    if (ndim > 2) {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
+    }
+
+    // output array attributes
+    npy_intp min_mn = m < n ? m : n;
+
+    // U, Vh shapes ( =0 if compute_uv=False)
+    npy_intp u_shape0, u_shape1, vh_shape0, vh_shape1;
+    if(!u_vh_shapes(m, n, jobz, &u_shape0, &u_shape1, &vh_shape0, &vh_shape1)) {
+        return -101; // unknown value for jobz, bail out
+    }
+
+    CBLAS_INT ldu = (CBLAS_INT)(u_shape0 == 0 ? 1 : u_shape0);
+    CBLAS_INT ldvh = (CBLAS_INT)(vh_shape0 == 0 ? 1 : vh_shape0);
+
+    T *ptr_U = u_shape0 > 0 ? (T *)PyArray_DATA(ap_U) : NULL;
+    T *ptr_Vh = vh_shape0 > 0 ? (T *)PyArray_DATA(ap_Vh) : NULL;
+    real_type *ptr_S = (real_type *)PyArray_DATA(ap_S);
+
+    // --------------------------------------------------------------------
+    // Workspace computation and allocation
+    // --------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, lwork = -1, info;
+    T tmp = numeric_limits<T>::zero;
+
+    // query LWORK
+    gesvd(&jobz, &jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, &info);
+    if (info != 0) { info = -100; return (int)info; }
+
+    lwork = (CBLAS_INT)(real_part(tmp));
+    if(lwork == 0) { lwork = 1; }
+
+    // allocate
+    npy_intp bufsize = m*n + lwork;
+    if (jobz != 'N') {
+        bufsize += u_shape0 * u_shape1 + vh_shape0 * vh_shape1;    // U and Vh, if referenced
+    }
+
+    T *buf = (T *)malloc(bufsize*sizeof(T));
+    if (buf == NULL) { info = -101; return (int)info; }
+
+    // partition the workspace
+    T *data = &buf[0];
+    T *work = &buf[m*n];
+
+    T *buf_U = NULL;
+    T *buf_Vh = NULL;
+    if (jobz != 'N') {
+        buf_U = &buf[m*n + lwork];
+        buf_Vh = &buf[m*n + lwork + u_shape0*u_shape1];
+    }
+
+    CBLAS_INT *iwork = NULL;
+    real_type *rwork = NULL;
+    rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
+    if (rwork == NULL) {
+        free(buf);
+        info = -103;
+        return (int)info;
+    }
+
+    // --------------------------------------------------------------------
+    // Main loop to traverse the slices
+    // --------------------------------------------------------------------
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+        init_status(slice_status, idx, St::GENERAL);
+
+        // copy the slice to `data` in F order
+        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+
+        // SVD the slice
+        gesvd(&jobz, &jobz, &intm, &intn, data, &intm, ptr_S, buf_U, &ldu, buf_Vh, &ldvh, work, &lwork, rwork, &info);
+
+        if(info != 0) {
+            slice_status.lapack_info = (Py_ssize_t)info;
+            vec_status.push_back(slice_status);
+
+            // cut it short on error in any slice
+            goto done;
+        }
+
+        // copy-and-tranpose U and Vh slices from temp buffers to the output;
+        // S slice is filled in in-place already; 
+        copy_slice_F_to_C(ptr_U, buf_U, u_shape0, u_shape1);
+        copy_slice_F_to_C(ptr_Vh, buf_Vh, vh_shape0, vh_shape1);
+
+        // advance the output pointers: U, S, Vh are C-contiguous by construction
+        ptr_U += u_shape0 * u_shape1;
+        ptr_Vh += vh_shape0 * vh_shape1;
+        ptr_S += min_mn;
+    }
+
+ done:
+    free(buf);
+    free(iwork);
+    free(rwork);
+    return 0;
+}
+
+
+template<typename T>
+int
+_svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, const char * lapack_driver, SliceStatusVec& vec_status)
+{
+    int info;
+    if (strcmp(lapack_driver, "gesdd") == 0) {
+        info = _svd_gesdd<T>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+    }
+    else if (strcmp(lapack_driver, "gesvd") == 0) {
+        info = _svd_gesvd<T>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+    }
+    else {
+        // should have been validated at call site, really
+        info = -110;
+    }
+    return info;
 }

--- a/scipy/linalg/src/_linalg_svd.hh
+++ b/scipy/linalg/src/_linalg_svd.hh
@@ -1,0 +1,190 @@
+#include "npy_cblas.h"
+#include "_npymath.hh"
+#include "_common_array_utils.hh"
+
+
+/*
+ * SVD size helper: if A.shape == (m, n),
+ * U is either (m, m) or (m, k) and Vh is either (n, n) or (k, n)
+ */ 
+int
+u_vh_shapes(npy_intp m, npy_intp n, char jobz,
+            npy_intp *u_shape0, npy_intp *u_shape1,
+            npy_intp *vh_shape0, npy_intp *vh_shape1
+){
+    npy_intp k = m < n ? m : n; 
+
+    switch(jobz) {
+        case('N') :
+            *u_shape0 = 0;
+            *u_shape1 = 0;
+            *vh_shape0 = 0;
+            *vh_shape1 = 0;
+            break;
+        case('A'):
+            *u_shape0 = m;
+            *u_shape1 = m;
+            *vh_shape0 = n;
+            *vh_shape1 = n;
+            break;
+        case('S'):
+            *u_shape0 = m;
+            *u_shape1 = k;
+            *vh_shape0 = k;
+            *vh_shape1 = n;
+            break;
+        default:
+            return 0;  // error
+    }
+    return 1;
+}
+
+/*
+ * TODO:
+ * 3. gesvd : work array sizes
+ * 4. gesvd : call
+ */
+
+
+template<typename T>
+int
+_svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, SliceStatusVec& vec_status)
+{
+    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    SliceStatus slice_status;
+
+    // --------------------------------------------------------------------
+    // Input Array Attributes
+    // --------------------------------------------------------------------
+    T* Am_data = (T *)PyArray_DATA(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);              // Number of dimensions
+    npy_intp* shape = PyArray_SHAPE(ap_Am);      // Array shape
+    npy_intp m = shape[ndim - 2];                // Slice size
+    npy_intp n = shape[ndim - 1];
+    npy_intp* strides = PyArray_STRIDES(ap_Am);
+
+    // Get the number of slices to traverse if more than one; np.prod(shape[:-2])
+    npy_intp outer_size = 1;
+    if (ndim > 2) {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
+    }
+
+    // output array attributes
+    npy_intp min_mn = m < n ? m : n; 
+    npy_intp max_mn = m < n ? n : m; 
+
+    // U, Vh shapes ( =0 if compute_uv=False)
+    npy_intp u_shape0, u_shape1, vh_shape0, vh_shape1;
+    if(!u_vh_shapes(m, n, jobz, &u_shape0, &u_shape1, &vh_shape0, &vh_shape1)) {
+        return -101; // unknown value for jobz, bail out
+    }
+
+    CBLAS_INT ldu = (CBLAS_INT)(u_shape0 == 0 ? 1 : u_shape0);
+    CBLAS_INT ldvh = (CBLAS_INT)(vh_shape0 == 0 ? 1 : vh_shape0);
+
+    T *ptr_U = u_shape0 > 0 ? (T *)PyArray_DATA(ap_U) : NULL;
+    T *ptr_Vh = vh_shape0 > 0 ? (T *)PyArray_DATA(ap_Vh) : NULL;
+    real_type *ptr_S = (real_type *)PyArray_DATA(ap_S);
+
+    // --------------------------------------------------------------------
+    // Workspace computation and allocation
+    // --------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, lwork = -1, info;
+    T tmp = numeric_limits<T>::zero;
+
+    // query LWORK
+    gesdd(&jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, NULL, &info);
+    if (info != 0) { info = -100; return (int)info; }
+
+    lwork = (CBLAS_INT)(real_part(tmp));
+    if(lwork == 0) { lwork = 1; }
+
+    // allocate
+    npy_intp bufsize = m*n + lwork;
+    if (jobz != 'N') {
+        bufsize += u_shape0 * u_shape1 + vh_shape0 * vh_shape1;    // U and Vh, if referenced
+    }
+
+    T *buf = (T *)malloc(bufsize*sizeof(T));
+    if (buf == NULL) { info = -101; return (int)info; }
+
+    // partition the workspace
+    T *data = &buf[0];
+    T *work = &buf[m*n];
+
+    T *buf_U = NULL;
+    T *buf_Vh = NULL;
+    if (jobz != 'N') {
+        buf_U = &buf[m*n + lwork];
+        buf_Vh = &buf[m*n + lwork + u_shape0*u_shape1];
+    }
+
+    // iwork
+    CBLAS_INT *iwork = (CBLAS_INT *)malloc(8*min_mn*sizeof(CBLAS_INT));
+    if (iwork == NULL) {
+        free(buf);
+        info = -102;
+        return (int)info;
+    }
+
+    // rwork
+    real_type *rwork = NULL;
+    if (type_traits<T>::is_complex) {
+        // assume LAPACK > 3.6 (cf LAPACK docs on netlib.org)
+        npy_intp lrwork = std::max(
+            5*min_mn*min_mn + 5*min_mn,
+            2*max_mn*min_mn + 2*min_mn*min_mn + min_mn
+        );
+        rwork = (real_type *)malloc(lrwork * sizeof(real_type));
+        if (rwork == NULL) {
+            free(buf);
+            free(iwork);
+            info = -103;
+            return (int)info;
+        }
+    }
+
+    // --------------------------------------------------------------------
+    // Main loop to traverse the slices
+    // --------------------------------------------------------------------
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+        init_status(slice_status, idx, St::GENERAL);
+
+        // copy the slice to `data` in F order
+        npy_intp offset = 0;
+        npy_intp temp_idx = idx;
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset += (temp_idx % shape[i]) * strides[i];
+            temp_idx /= shape[i];
+        }
+        T* slice_ptr = (T *)(Am_data + (offset/sizeof(T)));
+        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+
+        // SVD the slice
+        gesdd(&jobz, &intm, &intn, data, &intm, ptr_S, buf_U, &ldu, buf_Vh, &ldvh, work, &lwork, rwork, iwork, &info);
+
+        if(info != 0) {
+            slice_status.lapack_info = (Py_ssize_t)info;
+            vec_status.push_back(slice_status);
+
+            // cut it short on error in any slice
+            goto done;
+        }
+
+        // copy-and-tranpose U and Vh slics from temp buffers to the output;
+        // S slice is filled in in-place already; 
+        copy_slice_F_to_C(ptr_U, buf_U, u_shape0, u_shape1);
+        copy_slice_F_to_C(ptr_Vh, buf_Vh, vh_shape0, vh_shape1);
+
+        // advance the output pointers: U, S, Vh are C-contiguous by construction
+        ptr_U += u_shape0 * u_shape1;
+        ptr_Vh += vh_shape0 * vh_shape1;
+        ptr_S += min_mn;
+    }
+
+ done:
+    free(buf);
+    free(iwork);
+    free(rwork);
+    return 0;
+}

--- a/scipy/linalg/src/_linalg_svd.hh
+++ b/scipy/linalg/src/_linalg_svd.hh
@@ -87,7 +87,7 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     T tmp = numeric_limits<T>::zero;
 
     // query LWORK
-    gesdd(&jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, NULL, &info);
+    call_gesdd(&jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, NULL, &info);
     if (info != 0) { info = -100; return (int)info; }
 
     lwork = (CBLAS_INT)(real_part(tmp));
@@ -150,7 +150,7 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
         copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
 
         // SVD the slice
-        gesdd(&jobz, &intm, &intn, data, &intm, ptr_S, buf_U, &ldu, buf_Vh, &ldvh, work, &lwork, rwork, iwork, &info);
+        call_gesdd(&jobz, &intm, &intn, data, &intm, ptr_S, buf_U, &ldu, buf_Vh, &ldvh, work, &lwork, rwork, iwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;
@@ -225,7 +225,7 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     T tmp = numeric_limits<T>::zero;
 
     // query LWORK
-    gesvd(&jobz, &jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, &info);
+    call_gesvd(&jobz, &jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, &info);
     if (info != 0) { info = -100; return (int)info; }
 
     lwork = (CBLAS_INT)(real_part(tmp));
@@ -271,7 +271,7 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
         copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
 
         // SVD the slice
-        gesvd(&jobz, &jobz, &intm, &intn, data, &intm, ptr_S, buf_U, &ldu, buf_Vh, &ldvh, work, &lwork, rwork, &info);
+        call_gesvd(&jobz, &jobz, &intm, &intn, data, &intm, ptr_S, buf_U, &ldu, buf_Vh, &ldvh, work, &lwork, rwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -185,12 +185,22 @@ class TestBatch:
         self.batch_test(fun, A, n_out=n_out)
 
     @pytest.mark.parametrize('compute_uv', [False, True])
+    @pytest.mark.parametrize('full_matrices', [False, True])
     @pytest.mark.parametrize('dtype', floating)
-    def test_svd(self, compute_uv, dtype):
+    def test_svd(self, compute_uv, full_matrices, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
         n_out = 3 if compute_uv else 1
-        self.batch_test(linalg.svd, A, n_out=n_out, kwargs=dict(compute_uv=compute_uv))
+        self.batch_test(
+            linalg.svd, A, n_out=n_out,
+            kwargs=dict(compute_uv=compute_uv, full_matrices=full_matrices)
+        )
+
+        A = get_random((5, 3, 2, 0), dtype=dtype, rng=rng)
+        self.batch_test(
+            linalg.svd, A, n_out=n_out,
+            kwargs=dict(compute_uv=compute_uv, full_matrices=full_matrices)
+        )
 
     @pytest.mark.parametrize('fun', [linalg.polar, linalg.qr, linalg.rq])
     @pytest.mark.parametrize('dtype', floating)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1217,9 +1217,11 @@ class TestSVD_GESVD(TestSVD_GESDD):
 @pytest.mark.xfail_on_32bit("out of memory in 32-bit CI workflow")
 @pytest.mark.parallel_threads_limit(2)  # 1.9 GiB per thread RAM usage
 @pytest.mark.fail_slow(10)
-def test_svd_gesdd_nofegfault():
+@pytest.mark.skipif(HAS_ILP64, reason="does not fail; is too slow")
+def test_svd_gesdd_nosegfault():
     # svd(a) with {U,VT}.size > INT_MAX does not segfault
     # cf https://github.com/scipy/scipy/issues/14001
+    check_free_memory(free_mb=19_000)
     df=np.ones((4799, 53130), dtype=np.float64)
     with assert_raises(ValueError):
         svd(df)

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -391,7 +391,7 @@ if use_ilp64
        '-DFIX_MKL_2025_ILP64_MISSING_SYMBOL'
      ]
      c_flags_ilp64 += ['-DBLAS_SYMBOL_SUFFIX=_64']
-elif uses_accelerate
+  elif uses_accelerate
     blas_ilp64 = dependency('accelerate')
     lapack_ilp64 = blas_ilp64
     _args_blas_ilp64 += ['-DACCELERATE_NEW_LAPACK']
@@ -445,8 +445,8 @@ elif uses_accelerate
 else
   # we're not using ILP64; user code will link to the always-available LP64 blas/lapack
   # (all users must use preprocessor macros BLAS_NAME to handle the two options)
-  blas_dep = blas
-  lapack_dep = lapack
+  blas_dep = blas_lp64_dep
+  lapack_dep = lapack_lp64_dep
   c_flags_ilp64 = []
 endif
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

For `linalg.svd` and `linalg.svdvals`, wrap LAPACK functions directly, instead of a python loop over the f2py wrapped routines. 
The C side uses the same machinery as `inv` and `solve` --- <s>in fact the PR is on top of gh-23362, and will need a rebase once that one lands</s>rebased. 

The end result is that the performance is basically on par with `np.linalg.svd`, _and_ we can choose the lapack driver (`?gesdd` or `?gesvd`). 

The added benchmark shows a reasonable performance gain for deep batches of small arrays. For larger arrays the linear algebra dominates, of course.

```
$ spin bench --compare main -t BatchedBench.time_svd

<snip>

[50.00%] · For scipy commit 89c1b34d <lowlevel_svd> (round 2/2):
[50.00%] ·· Benchmarking virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran
[75.00%] ··· linalg.BatchedBench.time_svd                                                                                                                      ok
[75.00%] ··· ================= ============= =============
             --                           module          
             ----------------- ---------------------------
                   shape           scipy         numpy    
             ================= ============= =============
              (10, 10, 10, 2)     255±5μs       247±9μs   
               (100, 10, 10)    1.77±0.01ms   1.74±0.01ms 
               (100, 20, 20)     6.50±0.1ms   6.47±0.02ms 
              (100, 100, 100)     206±4ms      149±0.1ms  
             ================= ============= =============

[75.00%] · For scipy commit 9da62d5e <main> (round 2/2):
[75.00%] ·· Building for virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran...
[75.00%] ·· Benchmarking virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran
[100.00%] ··· linalg.BatchedBench.time_svd                                                                                                                      ok
[100.00%] ··· ================= ============= =============
              --                           module          
              ----------------- ---------------------------
                    shape           scipy         numpy    
              ================= ============= =============
               (10, 10, 10, 2)   2.60±0.02ms     255±10μs  
                (100, 10, 10)    4.27±0.07ms   1.76±0.02ms 
                (100, 20, 20)     9.04±0.1ms   6.68±0.08ms 
               (100, 100, 100)     216±10ms      154±3ms   
              ================= ============= =============

| Change   | Before [9da62d5e] <main>   | After [89c1b34d] <lowlevel_svd>   |   Ratio | Benchmark (Parameter)                                  |
|----------|----------------------------|-----------------------------------|---------|--------------------------------------------------------|
| -        | 9.04±0.1ms                 | 6.50±0.1ms                        |    0.72 | linalg.BatchedBench.time_svd((100, 20, 20), 'scipy')   |
| -        | 4.27±0.07ms                | 1.77±0.01ms                       |    0.41 | linalg.BatchedBench.time_svd((100, 10, 10), 'scipy')   |
| -        | 2.60±0.02ms                | 255±5μs                           |    0.1  | linalg.BatchedBench.time_svd((10, 10, 10, 2), 'scipy') |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```


#### Additional information
<!--Any additional information you think is important.-->

A potential follow-up is to add `gejsv`: we have a low-level f2py wrapper, but it is not exposed as a driver for the high-level `linalg.svd`. Drivers for structured matrices can be added with an `assume_a` type keyword (given a structure, convert to a bidiagonal form, then use `?bdsqr` or `?bsdqc`, but all these are potential enhancements. The current PR as is should be backwards compatible.

