### PR TITLE
DEV: update `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@ pyproject.toml  @rgommers
 tools/generate_requirements.py  @rgommers
 requirements/  @rgommers
 environment.yml  @rgommers
-scipy/_build_utils/  @rgommers @thalassemia
+scipy/_build_utils/  @rgommers
 
 # Dev CLI
 .spin  @rgommers
@@ -44,7 +44,7 @@ scipy/interpolate/  @ev-br
 scipy/odr/  @rkern
 scipy/optimize/  @andyfaff
 scipy/signal/  @larsoner @ilayn @DietBru
-scipy/sparse/  @perimosocordiae @dschult
+scipy/sparse/  @perimosocordiae
 scipy/sparse/csgraph/
 scipy/sparse/linalg/
 scipy/spatial/  @tylerjereddy @peterbell10

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,29 +10,45 @@
 
 # Each line is a file pattern followed by one or more owners.
 
-.github/CODEOWNERS  @rgommers @larsoner
+.github/CODEOWNERS  @rgommers @larsoner @lucascolley
 
 # Build related files
 pyproject.toml  @rgommers
 tools/generate_requirements.py  @rgommers
 requirements/  @rgommers
 environment.yml  @rgommers
-meson*  @rgommers
+scipy/_build_utils/  @rgommers @thalassemia
 
 # Dev CLI
-spin  @rgommers
+.spin  @rgommers
+
+# CI config
+.circleci/  @larsoner
+.github/workflows/  @larsoner @andyfaff
+
+# Developer workspace
+*pixi*  @lucascolley
+
+# Linting
+lint*  @lucascolley
+
+# Array API
+*array_api*  @lucascolley
 
 # SciPy submodules (please keep in alphabetical order)
 scipy/fft/  @peterbell10
 scipy/fftpack/  @peterbell10
 scipy/linalg/  @larsoner @ilayn
-scipy/integrate/ @steppi
+scipy/integrate/  @steppi
 scipy/interpolate/  @ev-br
+scipy/odr/  @rkern
 scipy/optimize/  @andyfaff
-scipy/signal/  @larsoner @ilayn
-scipy/sparse/  @perimosocordiae
+scipy/signal/  @larsoner @ilayn @DietBru
+scipy/sparse/  @perimosocordiae @dschult
+scipy/sparse/csgraph/
+scipy/sparse/linalg/
 scipy/spatial/  @tylerjereddy @peterbell10
-scipy/special/  @person142 @steppi
+scipy/special/  @steppi
 scipy/stats/_distn_infrastructure/  @andyfaff @ev-br
 scipy/stats/*distr*.py  @ev-br
 scipy/stats/_continuous_distns/  @andyfaff
@@ -47,18 +63,16 @@ scipy/stats/_survival.py  @tupui @mdhaber
 scipy/stats/.unuran/  @tirthasheshpatel
 
 # Testing infrastructure
-ci/  @larsoner @andyfaff
 tools/refguide_check.py  @ev-br
 tools/  @larsoner @rgommers
 pytest.ini  @larsoner
 .coveragerc  @larsoner
 benchmarks/asv.conf.json  @larsoner
 
-# CI config
-.circleci/  @larsoner
-.github/workflows/  @larsoner @andyfaff
-
 # Doc
 requirements/doc.txt  @tupui
 doc/source/conf.py  @tupui
 doc/source/_static/  @tupui
+
+# Meson
+meson*  @rgommers


### PR DESCRIPTION
- add myself for `CODEOWNERS`, `*pixi*`, `lint*`, `*array_api*`
- add @rgommers @thalassemia for `scipy/_build_utils/`
- add @rkern for `scipy/odr/`
- add @DietBru for `scipy/signal/`
- add @dschult for `scipy/sparse/`
- remove code owners from `scipy/sparse/csgraph/` and `scipy/sparse/linalg/`
- remove @person142 following move to emeritus
- adjust for deleted/renamed directories
- reorder for a candidate sensible precedence:
	- `.github/workflows` does not dwarf `*pixi*` or `lint*`
	- `*array_api*` does not dwarf submodules
	- submodules do not dwarf `meson*`

feedback welcome :)