### PR TITLE
BUG:signal: Ensure consistent dtypes for filter functions across alternative backends

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1282,6 +1282,8 @@ def zpk2tf(z, p, k):
     xp = array_namespace(z, p)
     z, p = map(xp.asarray, (z, p))
     k = xp.asarray(k, dtype=xp.result_type(xp.real(z), xp.real(p), k))
+    if xp.isdtype(k.dtype, "integral"):
+        k = xp.astype(k, xp.float64)
 
     z = xpx.atleast_nd(z, ndim=1, xp=xp)
     k = xpx.atleast_nd(k, ndim=1, xp=xp)

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4665,9 +4665,9 @@ def buttap(N, *, xp=None, device=None):
 
     Returns
     -------
-    z : ndarray[floating]
+    z : ndarray[float64]
         Zeros of the transfer function. Is always an empty array.
-    p : ndarray[complexfloating]
+    p : ndarray[complex128]
         Poles of the transfer function.
     k : float
         Gain of the transfer function.
@@ -4708,9 +4708,9 @@ def cheb1ap(N, rp, *, xp=None, device=None):
 
     Returns
     -------
-    z : ndarray[floating]
+    z : ndarray[float64]
         Zeros of the transfer function. Is always an empty array.
-    p : ndarray[complexfloating]
+    p : ndarray[complex128]
         Poles of the transfer function.
     k : float
         Gain of the transfer function.
@@ -4766,17 +4766,12 @@ def cheb2ap(N, rs, *, xp=None, device=None):
     rs : float
         The attenuation in the stopband
     %(xp_device_snippet)s
-    dtype : Optional[DType]
-        Base real dtype for returned outputs (complex outputs will have the
-        corresponding complex dtype). ``dtype`` should be for the backend
-        ``xp``. ``None`` is equivalent to the default dtype for``xp``.
-        Default: None.
 
     Returns
     -------
-    z : ndarray[complexfloating]
+    z : ndarray[complex128]
         Zeros of the transfer function.
-    p : ndarray[complexfloating]
+    p : ndarray[complex128]
         Poles of the transfer function.
     k : float
         Gain of the transfer function.
@@ -4971,9 +4966,9 @@ def ellipap(N, rp, rs, *, xp=None, device=None):
 
     Returns
     -------
-    z : ndarray[complexfloating]
+    z : ndarray[complex128]
         Zeros of the transfer function.
-    p : ndarray[complexfloating]
+    p : ndarray[complex128]
         Poles of the transfer function.
     k : float
         Gain of the transfer function.
@@ -5302,9 +5297,9 @@ def besselap(N, norm='phase', *, xp=None, device=None):
 
     Returns
     -------
-    z : ndarray[floating]
+    z : ndarray[float64]
         Zeros of the transfer function. Is always an empty array.
-    p : ndarray[complexfloating]
+    p : ndarray[complex128]
         Poles of the transfer function.
     k : float
         Gain of the transfer function. For phase-normalized, this is always 1.

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2754,6 +2754,10 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     -----
     The ``'sos'`` output parameter was added in 0.16.0.
 
+    The current behavior is for ``ndarray`` outputs to have 64 bit precision
+    (``float64`` or ``complex128``) regardless of the dtype of `Wn` but
+    outputs may respect the dtype of `Wn` in a future version.
+
     Examples
     --------
     Generate a 17th-order Chebyshev II analog bandpass filter from 50 Hz to
@@ -3417,6 +3421,7 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
     z, p, k : ndarray, ndarray, float
         Zeros, poles, and system gain of the IIR filter transfer
         function.  Only returned if ``output='zpk'``.
+
     sos : ndarray
         Second-order sections representation of the IIR filter.
         Only returned if ``output='sos'``.
@@ -3444,6 +3449,10 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
         numerical precision issues. Consider inspecting output filter
         characteristics `freqz` or designing the filters with second-order
         sections via ``output='sos'``.
+
+    The current behavior is for ``ndarray`` outputs to have 64 bit precision
+    (``float64`` or ``complex128``) regardless of the dtype of `Wn` but
+    outputs may respect the dtype of `Wn` in a future version.
 
     Examples
     --------
@@ -3562,6 +3571,10 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
 
     The ``'sos'`` output parameter was added in 0.16.0.
 
+    The current behavior is for ``ndarray`` outputs to have 64 bit precision
+    (``float64`` or ``complex128``) regardless of the dtype of `Wn` but
+    outputs may respect the dtype of `Wn` in a future version.
+
     Examples
     --------
     Design an analog filter and plot its frequency response, showing the
@@ -3674,6 +3687,10 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     Type II filters do not roll off as fast as Type I (`cheby1`).
 
     The ``'sos'`` output parameter was added in 0.16.0.
+
+    The current behavior is for ``ndarray`` outputs to have 64 bit precision
+    (``float64`` or ``complex128``) regardless of the dtype of `Wn` but
+    outputs may respect the dtype of `Wn` in a future version.
 
     Examples
     --------
@@ -3797,6 +3814,10 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
     unity for odd-order filters, or -rp dB for even-order filters.
 
     The ``'sos'`` output parameter was added in 0.16.0.
+
+    The current behavior is for ``ndarray`` outputs to have 64 bit precision
+    (``float64`` or ``complex128``) regardless of the dtype of `Wn` but
+    outputs may respect the dtype of `Wn` in a future version.
 
     Examples
     --------
@@ -3933,6 +3954,10 @@ def bessel(N, Wn, btype='low', analog=False, output='ba', norm='phase',
     See `besselap` for implementation details and references.
 
     The ``'sos'`` output parameter was added in 0.16.0.
+
+    The current behavior is for ``ndarray`` outputs to have 64 bit precision
+    (``float64`` or ``complex128``) regardless of the dtype of `Wn` but
+    outputs may respect the dtype of `Wn` in a future version.
 
     References
     ----------

--- a/scipy/signal/_polyutils.py
+++ b/scipy/signal/_polyutils.py
@@ -101,7 +101,7 @@ def poly(seq_of_zeros, *, xp):
     seq_of_zeros = xpx.atleast_nd(seq_of_zeros, ndim=1, xp=xp)
 
     if seq_of_zeros.shape[0] == 0:
-        return 1.0
+        return xp.asarray(1.0, dtype=xp.real(seq_of_zeros).dtype)
 
     # prefer np.convolve etc, if available
     convolve_func = getattr(xp, 'convolve', None)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2619,7 +2619,7 @@ class TestBessel:
 
         for N in range(1, 11):
             p1 = np.sort(bond_poles[N])
-            z, p, k = besselap(N, 'delay', xp=xp, dtype=xp.float64)
+            z, p, k = besselap(N, 'delay', xp=xp)
             assert array_namespace(z) == array_namespace(p) == xp
             p2 = np.sort(np.concatenate(_cplxreal(_xp_copy_to_numpy(p))))
             assert_array_almost_equal(xp.asarray(p2), xp.asarray(p1), decimal=10)
@@ -2648,7 +2648,7 @@ class TestBessel:
 
         for N in range(1, 11):
             p1 = np.sort(bond_poles[N])
-            z, p, k = besselap(N, 'mag', xp=xp, dtype=xp.float64)
+            z, p, k = besselap(N, 'mag', xp=xp)
             assert array_namespace(z) == array_namespace(p) == xp
             p2 = np.sort(np.concatenate(_cplxreal(_xp_copy_to_numpy(p))))
             assert_array_almost_equal(xp.asarray(p2), xp.asarray(p1), decimal=10)
@@ -2876,7 +2876,7 @@ class TestBessel:
                 np.union1d(originals[N], np.conj(originals[N])),
                 dtype=xp.complex128
             )
-            p2 = besselap(N, xp=xp, dtype=xp.float64)[1]
+            p2 = besselap(N, xp=xp)[1]
             xp_assert_close(_sort_cmplx(p2, xp=xp),
                             _sort_cmplx(p1, xp=xp), rtol=1e-14)
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -3821,8 +3821,8 @@ class TestEllip:
         assert_array_almost_equal(a, xp.asarray([1., 1]))
 
         z, p, k = ellip(1, 1, 55, xp.asarray(0.3), output='zpk')
-        xp_assert_close(z, xp.asarray([-9.999999999999998e-01]), rtol=1e-14)
-        xp_assert_close(p, xp.asarray([-6.660721153525525e-04]), rtol=1e-10)
+        xp_assert_close(z, xp.asarray([-9.999999999999998e-01 + 0j]), rtol=1e-14)
+        xp_assert_close(p, xp.asarray([-6.660721153525525e-04 + 0j]), rtol=1e-10)
         assert math.isclose(k, 5.003330360576763e-01, rel_tol=1e-14)
 
     def test_basic(self, xp):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2958,10 +2958,11 @@ class TestBessel:
                                     xp_assert_close(ba1_, ba2_)
 
 
-# Currently the filter functions below all return float64 (or complex128) output
-# regardless of input dtype. Therefore reference arrays below are all given an
-# explicit 64 bit dtype, because the output will not match the xp_default_dtype
-# when the default dtype is float32. Although the output arrays and all internal
+# Currently the filter functions tested below (butter, cheby1, cheby2, ellip,
+# and bessel) all return float64 (or complex128) output regardless of input
+# dtype. Therefore reference arrays in these tests are all given an explicit 64
+# bit dtype, because the output will not match the xp_default_dtype when the
+# default dtype is float32. Although the output arrays and all internal
 # calculations are in 64 bit precision, tolerances are still loosened for the
 # float32 case when results are impacted by reduced precision in the inputs.
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2622,7 +2622,7 @@ class TestBessel:
             z, p, k = besselap(N, 'delay', xp=xp, dtype=xp.float64)
             assert array_namespace(z) == array_namespace(p) == xp
             p2 = np.sort(np.concatenate(_cplxreal(_xp_copy_to_numpy(p))))
-            assert_array_almost_equal(xp.asarray(p1), xp.asarray(p2), decimal=10)
+            assert_array_almost_equal(xp.asarray(p2), xp.asarray(p1), decimal=10)
 
         # "Frequency Normalized Bessel Pole Locations"
         bond_poles = {
@@ -2651,35 +2651,35 @@ class TestBessel:
             z, p, k = besselap(N, 'mag', xp=xp, dtype=xp.float64)
             assert array_namespace(z) == array_namespace(p) == xp
             p2 = np.sort(np.concatenate(_cplxreal(_xp_copy_to_numpy(p))))
-            assert_array_almost_equal(xp.asarray(p1), xp.asarray(p2), decimal=10)
+            assert_array_almost_equal(xp.asarray(p2), xp.asarray(p1), decimal=10)
 
         # Compare to https://www.ranecommercial.com/legacy/note147.html
         # "Table 1 - Bessel Crossovers of Second, Third, and Fourth-Order"
         a = xp.asarray([1, 1, 1/3], dtype=xp.float64)
         b2, a2 = bessel(2, xp.asarray(1.), norm='delay', analog=True)
-        xp_assert_close(xp.flip(a), a2/b2)
+        xp_assert_close(a2/b2, xp.flip(a))
 
         a = xp.asarray([1, 1, 2/5, 1/15], dtype=xp.float64)
         b2, a2 = bessel(3, xp.asarray(1.), norm='delay', analog=True)
-        xp_assert_close(xp.flip(a), a2/b2)
+        xp_assert_close(a2/b2, xp.flip(a))
 
         a = xp.asarray([1, 1, 9/21, 2/21, 1/105], dtype=xp.float64)
         b2, a2 = bessel(4, xp.asarray(1.), norm='delay', analog=True)
-        xp_assert_close(xp.flip(a), a2/b2)
+        xp_assert_close(a2/b2, xp.flip(a))
 
         a = xp.asarray([1, math.sqrt(3), 1], dtype=xp.float64)
         b2, a2 = bessel(2, xp.asarray(1.), norm='phase', analog=True)
-        xp_assert_close(xp.flip(a), a2/b2)
+        xp_assert_close(a2/b2, xp.flip(a))
 
         # TODO: Why so inaccurate?  Is reference flawed?
         a = xp.asarray([1, 2.481, 2.463, 1.018], dtype=xp.float64)
         b2, a2 = bessel(3, xp.asarray(1.), norm='phase', analog=True)
-        assert_array_almost_equal(xp.flip(a), a2/b2, decimal=1)
+        assert_array_almost_equal(a2/b2, xp.flip(a), decimal=1)
 
         # TODO: Why so inaccurate?  Is reference flawed?
         a = xp.asarray([1, 3.240, 4.5, 3.240, 1.050], dtype=xp.float64)
         b2, a2 = bessel(4, xp.asarray(1.), norm='phase', analog=True)
-        assert_array_almost_equal(xp.flip(a), a2/b2, decimal=1)
+        assert_array_almost_equal(a2/b2, xp.flip(a), decimal=1)
 
         # Table of -3 dB factors:
         N, scale = 2, xp.asarray([1.272, 1.272], dtype=xp.complex128)
@@ -2694,7 +2694,7 @@ class TestBessel:
         # TODO: Why so inaccurate?  Is reference flawed?
         N, scale = 4, xp.asarray([1.533]*4, dtype=xp.complex128)
         scale2 = besselap(N, 'mag', xp=xp)[1] / besselap(N, 'phase', xp=xp)[1]
-        assert_array_almost_equal(scale, scale2, decimal=1)
+        assert_array_almost_equal(scale2, scale, decimal=1)
 
     @pytest.mark.xfail(reason="Failing in mypy workflow - see gh-23902")
     def test_hardcoded(self, xp):
@@ -2877,8 +2877,8 @@ class TestBessel:
                 dtype=xp.complex128
             )
             p2 = besselap(N, xp=xp, dtype=xp.float64)[1]
-            xp_assert_close(_sort_cmplx(p1, xp=xp),
-                            _sort_cmplx(p2, xp=xp), rtol=1e-14)
+            xp_assert_close(_sort_cmplx(p2, xp=xp),
+                            _sort_cmplx(p1, xp=xp), rtol=1e-14)
 
     def test_norm_phase(self, xp):
         # Test some orders and frequencies and see that they have the right
@@ -2939,7 +2939,7 @@ class TestBessel:
             }
         for N in mpmath_values:
             z, p, k = besselap(N, 'delay')
-            xp_assert_close(mpmath_values[N], _norm_factor(p, k), rtol=1e-13)
+            xp_assert_close(_norm_factor(p, k), mpmath_values[N], rtol=1e-13)
 
     def test_bessel_poly(self):
         xp_assert_equal(_bessel_poly(5), [945, 945, 420, 105, 15, 1])

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -2958,6 +2958,13 @@ class TestBessel:
                                     xp_assert_close(ba1_, ba2_)
 
 
+# Currently the filter functions below all return float64 (or complex128) output
+# regardless of input dtype. Therefore reference arrays below are all given an
+# explicit 64 bit dtype, because the output will not match the xp_default_dtype
+# when the default dtype is float32. Although the output arrays and all internal
+# calculations are in 64 bit precision, tolerances are still loosened for the
+# float32 case when results are impacted by reduced precision in the inputs.
+
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
 @skip_xp_backends(cpu_only=True, reason="convolve on torch is cpu-only")
 class TestButter:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #23747 
#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes some inconsistencies in output dtype for filter functions when using PyTorch with default dtype `float32`. Currently on `main`, `default_dtype=float32` tests are skipped for filter functions, but such tests are enabled in this PR. This PR enforces the current behavior when using the NumPy backend of having outputs always have 64 bit base precision regardless of input `dtype` across backends. The principled thing to do would be to have the output `dtype` respect the input `dtype`, but I have been convinced by @ev-br that it is reasonable to do this incrementally, and start with a pragmatic fix. I have left a note in each relevant docstring informing users that a change in behavior may come in the future:

```python
#    The current behavior is for ``ndarray`` outputs to have 64 bit precision
#    (``float64`` or ``complex128``) regardless of the dtype of `Wn` but
#    outputs may respect the dtype of `Wn` in a future version.
```

In order to more ergonomically control output dtype, I have added a `dtype` keyword to the filter prototype functions (`besselap`, `buttap`, `cheb1ap`, `cheb2ap`, `ellipap`) which controls the base `dtype` for outputs. I am aware the name `dtype` may not be the best name for this kwarg because it does not control the output `dtype`, but rather the base real `dtype` for outputs, which in some cases are real and in some cases are complex. I would be happy to change the name of this kwarg to something which makes this more clear, perhaps `base_dtype`. Technically, I guess the addition of a new kwarg to the filter prototype functions is an enhancement that may require a post on the discourse.

There is another backwards incompatible change. For the filter prototype functions `buttap` etc., I have made the realness or complexness of outputs consistent across filter order. Previously, one could get either real or complex outputs depending on the order `N`. Now, if it is possible to get complex values for any `N`, the output `dtype` will be complex. I think this change is unobtrusive and in line with the general preference to avoid value-dependent output dtype. For cases like `buttap` where the array of zeros `z` is always empty, I have left the output as a real array because an empty set surely has no complex values in it. I suppose this change will also need to go through the discourse. I would be willing to revert it if there are reasonable objections. For filter functions themselves, the `dtype` can still depend on the value of the `btype` `kwarg` since the `"bandstop"` can have complex zeros (one for each zero at infinity of the associated lowpass filter). Of course, we could just have the `dtype` for `z` always complex to avoid this value dependency, but it seems more obtrusive than the existing change, which only impacts the dtypes of empty arrays. Also, I saw a good argument here, https://github.com/numpy/numpy/issues/29000#issuecomment-3414315562, from Sebastian Berg, that return dtype depending on a kwarg with a finite number of string literal options is not so bad, which has me convinced for the moment.

Beyond specifying a `dtype` in the filter prototype functions, making dtypes behave properly also required 

* A change in `zpk2tf` to avoid unnecessary overflow when `k` is a python scalar and the default dtype is `float32`.
* Another change in `zpk2tf` changing `*` to `xp.multiply` to work around PyTorch's difference in promotion rules for `0d` arrays` vs higher dimensional arrays (0d arrays are basically treated like NEP50 Python scalars, and don't impact the result dtype.
* A change in `scipy.signal._polyutils.poly` to avoid returning just a plain Python scalar in some branches, consistently returning an array (or numpy scalar) of appropriate dtype in all branches. There were some places where `xp.asarray` was getting called on the output of `scipy.signal._polyutils.poly`, casting it to the default dtype. Rather than the caller having to worry about this possibility, it seems easier for the function to always consistently return as array.

As mentioned above, `SCIPY_DEFAULT_DTYPE=float32` tests have been enabled for all filter functions. Although the output of the filter functions has `float64` base precision, tolerances still had to be loosened for the `float32` case due to round-off in the inputs. I added explicit float64 base precision dtypes to the reference output arrays.


#### Additional information
<!--Any additional information you think is important.-->
If we want to eventually update these filter functions to have output dtype respect the input dtype, it should hopefully be fairly straightforward. Setting the `dtype` in the filter prototype functions to be based on the input dtype, and getting rid of some explicit casts should do it. I think the primary bottleneck is just testing things out to make sure that we actually get useful results when all internal calculations are in float32 precision, and possibly needing to adapt things to lower precision. Then again, I thought this PR would be straightforward, but I found it fairly challenging to get all of the tests passing, even with the simpler behavior of always having `float64` output.
