### PR TITLE
ENH: stats._xp_searchsorted: private vectorized searchsorted

### DIFF
--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -415,4 +415,4 @@ def _xp_searchsorted(x, y, *, side='left', xp=None):
         a = xp.where(j, a, c)
 
     b = xp.where(y <= xp.min(x, axis=-1, keepdims=True), 0, b)
-    return b if side == 'left' else  x.shape[-1] - b
+    return b if side == 'left' else x.shape[-1] - b

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -395,7 +395,7 @@ def _xp_searchsorted(x, y, *, side='left', xp=None):
     xp = array_namespace(x, y) if xp is None else xp
     x, y = _broadcast_arrays((x, y), axis=-1, xp=xp)
 
-    a = xp.full(y.shape, 0)
+    a = xp.full(y.shape, 0, device=xp_device(x))
     n = xp.count_nonzero(~xp.isnan(x), axis=-1, keepdims=True)
     b = xp.broadcast_to(n, y.shape)
 

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -243,7 +243,7 @@ class Test_XPSearchsorted:
             mask = rng.random(shape) < 0.1
             x[mask] = np.nan
         x = np.sort(x, axis=-1)
-        x, y = np.astype(x, np.float64), np.astype(y, np.float64)
+        x, y = np.asarray(x, dtype=np.float64), np.asarray(y, dtype=np.float64)
         ref = xp.asarray(np_searchsorted(x, y, side=side))
         x, y = xp.asarray(x), xp.asarray(y)
         res = _xp_searchsorted(x, y, side=side)


### PR DESCRIPTION
#### Reference issue
Toward gh-14651
Toward gh-20544

#### What does this implement/fix?
Several stats functions use `searchsorted`, making them difficult to vectorize because `np.searchsorted` only accepts 1D arrays for the first argument (gh-4224). We can often get by reimplementing these functions in terms of `rankdata` and such (e.g. gh-23793, gh-23878), but it would likely be better (easier to write/review in the short term, more performant in the long term) to continue using `searchsorted`. To enable this, this PR implements a (private,) array-API compatible, vectorized version of `searchsorted`. 

#### Additional information
Despite using a plain-python `for` loop to perform bisection,  it's actually faster than `np.searchsorted` for sufficiently large second arguments.
```python3
rng = np.random.default_rng(2348345982435888453)
x = np.sort(rng.random(size=1000000), axis=-1)
y = rng.random(size=100000)
ref = np.searchsorted(x, y)
# 29.8 ms ± 1.06 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
res = _xp_searchsorted(x, y)
# 14.4 ms ± 150 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
np.testing.assert_equal(res, ref)
```

Surprisingly, it may not be faster for batches than looping over slices of the first argument, at least for NumPy. ~~I'll play around with the other backends to see if it might be better to just loop for now.~~ (Can be quite a bit faster - like 150x - than looping for `cupy`. For torch, we could delegate to their version of searchsorted, which is vectorized.) Ultimately, though, I would like to get `np.searchsorted` vectorized and work toward getting the array API standard updated to require vectorization; this is just a way to move forward until that happens.