### PR TITLE
ENH: spatial.transform: add `axis` argument to `RigidTransform.mean`

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -999,7 +999,10 @@ class RigidTransform:
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]
     )
-    def mean(self, weights: ArrayLike | None = None) -> RigidTransform:
+    def mean(self,
+        weights: ArrayLike | None = None,
+        axis: None | int | tuple[int, ...] = None
+    ) -> RigidTransform:
         """Get the mean of the transforms.
 
         The mean of a set of transforms is the same as the mean of its
@@ -1024,6 +1027,9 @@ class RigidTransform:
             None (default), then all values in `weights` are assumed to be
             equal. If given, the shape of `weights` must be broadcastable to
             the transform shape. Weights must be non-negative.
+        axis : None, int, or tuple of ints, optional
+            Axis or axes along which the means are computed. The default is to
+            compute the mean of all transforms.
 
         Returns
         -------
@@ -1061,7 +1067,7 @@ class RigidTransform:
                [ 0.51801458,  0.13833531, -0.84411151,  0.52429339],
                [0., 0., 0., 1.]])
         """
-        mean = self._backend.mean(self._matrix, weights=weights)
+        mean = self._backend.mean(self._matrix, weights=weights, axis=axis)
         return RigidTransform._from_raw_matrix(mean, xp=self._xp,
                                                backend=self._backend)
 

--- a/scipy/spatial/transform/_rigid_transform_cy.pyx
+++ b/scipy/spatial/transform/_rigid_transform_cy.pyx
@@ -269,7 +269,7 @@ def mean(double[:, :, :] matrix, weights=None, axis=None):
         )
     # Axis must be 0 for the cython backend. Everything else should have raised an
     # error during validation.
-    axis = (0,)
+    axis = 0
 
     quat = as_quat(from_rot_matrix(matrix[:, :3, :3]))
     t = np.asarray(matrix[:, :3, 3])

--- a/scipy/spatial/transform/_rigid_transform_xp.py
+++ b/scipy/spatial/transform/_rigid_transform_xp.py
@@ -247,15 +247,36 @@ def pow(matrix: Array, n: float | Array) -> Array:
     return from_exp_coords(as_exp_coords(matrix) * n)
 
 
-def mean(matrix: Array, weights: ArrayLike | None = None) -> Array:
+def mean(
+    matrix: Array,
+    weights: ArrayLike | None = None,
+    axis: None | int | tuple[int, ...] = None
+) -> Array:
     xp = array_namespace(matrix)
     if matrix.shape[0] == 0:
         raise ValueError("Mean of an empty rotation set is undefined.")
+    # Axis logic: For None, we reduce over all axes. For int, we only reduce over that
+    # axis. For tuple, we reduce over all specified axes.
+    all_axes = tuple(range(matrix.ndim - 2))
+    if axis is None:
+        axis = all_axes
+    elif isinstance(axis, int):
+        axis = (axis,)
+    if not isinstance(axis, tuple):
+        raise ValueError("`axis` must be None, int, or tuple of ints.")
+    # Ensure all axes are within bounds
+    if axis != () and ( min(axis) < -(matrix.ndim - 2) or max(axis) > (matrix.ndim - 3)):
+        raise ValueError(
+            f"axis {axis} is out of bounds for transform with shape "
+            f"{matrix.shape[:-2]}."
+        )
+    # Ensure all axes are positive and unique
+    axis = tuple(sorted(set(x % (matrix.ndim - 2) for x in axis)))
 
     lazy = is_lazy_array(matrix)
     quats = quat_from_matrix(matrix[..., :3, :3])
     if weights is None:
-        quats_mean = quat_mean(quats)
+        quats_mean = quat_mean(quats, axis=axis)
     else:
         neg_weights = weights < 0
         any_neg_weights = xp.any(neg_weights)
@@ -266,11 +287,10 @@ def mean(matrix: Array, weights: ArrayLike | None = None) -> Array:
                 f"Expected `weights` to match transform shape, got shape "
                 f"{weights.shape} for {matrix.shape[:-2]} transformations."
             )
-        quats_mean = quat_mean(quats, weights=weights)
+        quats_mean = quat_mean(quats, weights=weights, axis=axis)
     r_mean = quat_as_matrix(quats_mean)
 
     t = matrix[..., :3, 3]
-    axis = tuple(range(t.ndim - 1))
     if weights is None:
         t_mean = xp.mean(t, axis=axis)
     else:

--- a/scipy/spatial/transform/_rigid_transform_xp.py
+++ b/scipy/spatial/transform/_rigid_transform_xp.py
@@ -265,7 +265,9 @@ def mean(
     if not isinstance(axis, tuple):
         raise ValueError("`axis` must be None, int, or tuple of ints.")
     # Ensure all axes are within bounds
-    if axis != () and ( min(axis) < -(matrix.ndim - 2) or max(axis) > (matrix.ndim - 3)):
+    if (axis != () and
+       (min(axis) < -(matrix.ndim - 2) or max(axis) > (matrix.ndim - 3))
+    ):
         raise ValueError(
             f"axis {axis} is out of bounds for transform with shape "
             f"{matrix.shape[:-2]}."

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -1328,16 +1328,20 @@ def test_mean_axis(xp, ndim: int):
     axes = xp.tile(xp.concat((-xp.eye(3), xp.eye(3))), (3,) * (ndim - 1) + (1, 1))
     theta = xp.pi / 4
     r = Rotation.from_rotvec(theta * axes)
+
+    # Test mean over last axis
     desired = xp.full(axes.shape[:-2], 0.0)
     if ndim == 1:
         desired = desired[()]
     atol = 1e-6 if xp_default_dtype(xp) is xp.float32 else 1e-10
     xp_assert_close(r.mean(axis=-1).magnitude(), desired, atol=atol)
+
     # Test tuple axes
     desired = xp.full(axes.shape[1:-2], 0.0)
     if ndim < 3:
         desired = desired[()]
     xp_assert_close(r.mean(axis=(0, -1)).magnitude(), desired, atol=atol)
+
     # Empty axis tuple should return Rotation unchanged
     r_mean = r.mean(axis=())
     xp_assert_close(r_mean.as_quat(canonical=True), r.as_quat(canonical=True),
@@ -1352,6 +1356,7 @@ def test_mean_compare_axis(xp):
     rng = np.random.default_rng(0)
     q = xp.asarray(rng.normal(size=(4, 5, 6, 4)), dtype=xpx.default_dtype(xp))
     r = Rotation.from_quat(q)
+
     mean_0 = r.mean(axis=0)
     for i in range(q.shape[1]):
         for j in range(q.shape[2]):


### PR DESCRIPTION

#### Reference issue
Builds off of https://github.com/scipy/scipy/pull/23828 and closes out the last item in https://github.com/scipy/scipy/issues/23391.

#### What does this implement/fix?
Adds the `axis` argument to RigidTransform.mean, to match the Rotation implementation.

#### Additional information
@amacati FYI
