### PR TITLE
DOC: special.sh_legendre: add Examples section

### DIFF
--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2588,6 +2588,7 @@ def sh_legendre(n, monic=False):
 
     >>> import numpy as np
     >>> from scipy.special import sh_legendre, legendre
+    >>> from scipy.integrate import trapezoid
     >>> x = np.arange(0.0, 1.0, 0.01)
     >>> n = 3
     >>> np.allclose(sh_legendre(n)(x), legendre(n)(2*x - 1))
@@ -2600,7 +2601,7 @@ def sh_legendre(n, monic=False):
         (n+1) P_{n+1}^*(x) = (2n+1)(2x-1)\,P_n^*(x) - n\,P_{n-1}^*(x).
 
     This can be easily checked on :math:`[0, 1]` for :math:`n = 3`:
-    >>> x = np.arange(0.0, 1.0, 0.01)
+    >>> x = np.linspace(0.0, 1.0, 101)
     >>> lhs = (3 + 1) * sh_legendre(4)(x)
     >>> rhs = (2*3 + 1) * (2*x - 1) * sh_legendre(3)(x) - 3 * sh_legendre(2)(x)
     >>> np.allclose(lhs, rhs)
@@ -2610,13 +2611,14 @@ def sh_legendre(n, monic=False):
 
     >>> x = np.linspace(0.0, 1.0, 400)
     >>> y = sh_legendre(2)(x) * sh_legendre(3)(x)
-    >>> np.isclose(np.trapz(y, x), 0.0, atol=1e-4)
+    >>> bool(np.isclose(trapezoid(y, x), 0.0, atol=1e-4))
     True
 
     See Also
     --------
     scipy.special._orthogonal.legendre
     scipy.special._orthogonal.roots_sh_legendre
+    scipy.integrate.trapezoid
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2616,8 +2616,8 @@ def sh_legendre(n, monic=False):
 
     See Also
     --------
-    scipy.special._orthogonal.legendre
-    scipy.special._orthogonal.roots_sh_legendre
+    scipy.special.legendre
+    scipy.special.roots_sh_legendre
     scipy.integrate.trapezoid
     """
     if n < 0:

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2608,11 +2608,12 @@ def sh_legendre(n, monic=False):
     This can be easily checked on :math:`[0, 1]`
     for :math:`n = 3`:
 
+    >>> n = 3
     >>> x = np.linspace(0.0, 1.0, 101)
-    >>> lhs = (3 + 1) * sh_legendre(4)(x)
+    >>> lhs = (n + 1) * sh_legendre(n + 1)(x)
     >>> rhs = (
-    ...     (2*3 + 1) * (2*x - 1) * sh_legendre(3)(x)
-    ...     - 3 * sh_legendre(2)(x)
+    ...     (2*n + 1) * (2*x - 1) * sh_legendre(n)(x)
+    ...     - n * sh_legendre(n - 1)(x)
     ... )
     >>> np.allclose(lhs, rhs)
     True

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -1042,7 +1042,7 @@ def _initial_nodes(n):
 
     See Also
     --------
-    roots_hermite_as
+    roots_hermite_asy
     """
     # Turnover point
     # linear polynomial fit to error of 10, 25, 40, ..., 1000 point rules

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -1042,7 +1042,7 @@ def _initial_nodes(n):
 
     See Also
     --------
-    roots_hermite_asy
+    roots_hermite_as
     """
     # Turnover point
     # linear polynomial fit to error of 10, 25, 40, ..., 1000 point rules
@@ -2582,6 +2582,41 @@ def sh_legendre(n, monic=False):
     The polynomials :math:`P^*_n` are orthogonal over :math:`[0, 1]`
     with weight function 1.
 
+    Examples
+    --------
+    The shifted Legendre polynomials :math:`P_n^*` are related to the non-shifted polynomials :math:`P_n` by :math:`P_n^*(x) = P_n(2x - 1)`. We can verify this on the interval :math:`[0, 1]`:
+
+    >>> import numpy as np
+    >>> from scipy.special import sh_legendre, legendre
+    >>> x = np.arange(0.0, 1.0, 0.01)
+    >>> n = 3
+    >>> np.allclose(sh_legendre(n)(x), legendre(n)(2*x - 1))
+    True
+
+    The polynomials :math:`P_n^*` satisfy a recurrence relation obtained by the change of variables :math:`t = 2x - 1` in the standard Legendre recurrence:
+    
+    .. math::
+    
+        (n+1) P_{n+1}^*(x) = (2n+1)(2x-1)\,P_n^*(x) - n\,P_{n-1}^*(x).
+
+    This can be easily checked on :math:`[0, 1]` for :math:`n = 3`:
+    >>> x = np.arange(0.0, 1.0, 0.01)
+    >>> lhs = (3 + 1) * sh_legendre(4)(x)
+    >>> rhs = (2*3 + 1) * (2*x - 1) * sh_legendre(3)(x) - 3 * sh_legendre(2)(x)
+    >>> np.allclose(lhs, rhs)
+    True
+
+    Orthogonality over :math:`[0,1]` with weight 1 can be checked numerically; for example, :math:`P_2^*` is orthogonal to :math:`P_3^*`:
+
+    >>> x = np.linspace(0.0, 1.0, 400)
+    >>> y = sh_legendre(2)(x) * sh_legendre(3)(x)
+    >>> np.isclose(np.trapz(y, x), 0.0, atol=1e-4)
+    True
+
+    See Also
+    --------
+    scipy.special._orthogonal.legendre
+    scipy.special._orthogonal.roots_sh_legendre
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2631,7 +2631,6 @@ def sh_legendre(n, monic=False):
     --------
     scipy.special.legendre
     scipy.special.roots_sh_legendre
-    scipy.integrate.trapezoid
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2584,7 +2584,10 @@ def sh_legendre(n, monic=False):
 
     Examples
     --------
-    The shifted Legendre polynomials :math:`P_n^*` are related to the non-shifted polynomials :math:`P_n` by :math:`P_n^*(x) = P_n(2x - 1)`. We can verify this on the interval :math:`[0, 1]`:
+    The shifted Legendre polynomials :math:`P_n^*` are related
+    to the non-shifted polynomials :math:`P_n` by
+    :math:`P_n^*(x) = P_n(2x - 1)`. We can verify this on the
+    interval :math:`[0, 1]`:
 
     >>> import numpy as np
     >>> from scipy.special import sh_legendre, legendre
@@ -2594,20 +2597,28 @@ def sh_legendre(n, monic=False):
     >>> np.allclose(sh_legendre(n)(x), legendre(n)(2*x - 1))
     True
 
-    The polynomials :math:`P_n^*` satisfy a recurrence relation obtained by the change of variables :math:`t = 2x - 1` in the standard Legendre recurrence:
+    The polynomials :math:`P_n^*` satisfy a recurrence
+    relation obtained by the change of variables
+    :math:`t = 2x - 1` in the standard Legendre recurrence:
     
     .. math::
     
         (n+1) P_{n+1}^*(x) = (2n+1)(2x-1)\,P_n^*(x) - n\,P_{n-1}^*(x).
 
-    This can be easily checked on :math:`[0, 1]` for :math:`n = 3`:
+    This can be easily checked on :math:`[0, 1]`
+    for :math:`n = 3`:
     >>> x = np.linspace(0.0, 1.0, 101)
     >>> lhs = (3 + 1) * sh_legendre(4)(x)
-    >>> rhs = (2*3 + 1) * (2*x - 1) * sh_legendre(3)(x) - 3 * sh_legendre(2)(x)
+    >>> rhs = (
+    ...     (2*3 + 1) * (2*x - 1) * sh_legendre(3)(x)
+    ...     - 3 * sh_legendre(2)(x)
+    ... )
     >>> np.allclose(lhs, rhs)
     True
 
-    Orthogonality over :math:`[0,1]` with weight 1 can be checked numerically; for example, :math:`P_2^*` is orthogonal to :math:`P_3^*`:
+    Orthogonality over :math:`[0,1]` with weight 1 can be
+    checked numerically; for example, :math:`P_2^*`
+    is orthogonal to :math:`P_3^*`:
 
     >>> x = np.linspace(0.0, 1.0, 400)
     >>> y = sh_legendre(2)(x) * sh_legendre(3)(x)

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2607,6 +2607,7 @@ def sh_legendre(n, monic=False):
 
     This can be easily checked on :math:`[0, 1]`
     for :math:`n = 3`:
+
     >>> x = np.linspace(0.0, 1.0, 101)
     >>> lhs = (3 + 1) * sh_legendre(4)(x)
     >>> rhs = (
@@ -2622,7 +2623,7 @@ def sh_legendre(n, monic=False):
 
     >>> x = np.linspace(0.0, 1.0, 400)
     >>> y = sh_legendre(2)(x) * sh_legendre(3)(x)
-    >>> bool(np.isclose(trapezoid(y, x), 0.0, atol=1e-4))
+    >>> np.isclose(trapezoid(y, x), 0.0, atol=1e-12)
     True
 
     See Also


### PR DESCRIPTION


<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
#7168 

#### What does this implement/fix?
This PR adds an `Examples` section to `scipy.special.sh_legendre`. The examples show the relation between the shifted and standard Legendre polynomials, the recurrence relation, and the orthogonality over the interval [0, 1].

#### Additional information
This is my first PR to SciPy, so any feedback is really welcome!
