### PR TITLE
DOC: Add Examples section to idst function

### DIFF
--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -702,5 +702,24 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     type. DST type 1 and 4 are their own inverse and DSTs 2 and 3 are each
     other's inverses.
 
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.fft import idst, dst
+    >>> x = np.array([1.0, 2.0, 3.0, 4.0])
+    >>> idst(dst(x, type=2), type=2)
+    array([1., 2., 3., 4.])
+
+    The inverse DST-II is the normalized DST-III:
+
+    >>> # idst(X, type=2) is equivalent to dst(X, type=3) / (2*N)
+    >>> from scipy.fft import dst
+    >>> X = dst(x, type=2)
+    >>> idst(X, type=2)
+    array([1., 2., 3., 4.])
+    >>> dst(X, type=3) / (2 * len(x))
+    array([1., 2., 3., 4.])
+
     """
     return (Dispatchable(x, np.ndarray),)


### PR DESCRIPTION
## Description
This PR adds an Examples section to the `idst` function docstring in `scipy.fft`, addressing part of issue #7168.

## What does this implement/fix?
- Adds comprehensive examples demonstrating basic usage of `idst` as the inverse of `dst`
- Shows the mathematical relationship between IDST-II and DST-III

## Additional information
The examples follow NumPy docstring conventions and demonstrate:
1. Basic inverse transform usage
2. The equivalence between `idst(X, type=2)` and `dst(X, type=3) / (2*N)`

Contributes to resolving #7168 (167 functions still need examples)

## Checklist
- [x] I have read the [contributing guidelines](https://scipy.github.io/devdocs/dev/contributor/contributor_toc.html)
- [x] This is a documentation-only change
- [x] Added `[docs only]` to commit message to save CI credits