### PR TITLE
BUG: sparse.csgraph: remove rel import to fix Cython 3.2

### DIFF
--- a/scipy/sparse/csgraph/_reordering.pyx
+++ b/scipy/sparse/csgraph/_reordering.pyx
@@ -7,7 +7,7 @@ cimport numpy as np
 from warnings import warn
 from scipy.sparse import csr_array, issparse, SparseEfficiencyWarning
 from scipy.sparse._sputils import convert_pydata_sparse_to_scipy
-from . import maximum_bipartite_matching
+from scipy.sparse.csgraph import maximum_bipartite_matching
 
 np.import_array()
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Fixes #23932
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

For some unexplained reason, Cython fails to import another file in the same module when using a relative import. However, using an absolute import avoids the error.
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
