### PR TITLE
DOC correct "shape" type for "scipy.sparse.random_array"

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1405,7 +1405,7 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
     Parameters
     ----------
     shape : tuple of int
-        shape of the array as an n-tuple of integers `(m, ..., n)`.
+        shape of the array.
     density : real, optional (default: 0.01)
         density of the generated matrix: density equal to one means a full
         matrix, density of 0 means a matrix with no non-zero items.

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1404,8 +1404,8 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
 
     Parameters
     ----------
-    shape : tuple of two ints
-        shape of the array as a 2-tuple `(m, n)`.
+    shape : tuple of int
+        shape of the array as an n-tuple of integers `(m, ..., n)`.
     density : real, optional (default: 0.01)
         density of the generated matrix: density equal to one means a full
         matrix, density of 0 means a matrix with no non-zero items.

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -1404,8 +1404,8 @@ def random_array(shape, *, density=0.01, format='coo', dtype=None,
 
     Parameters
     ----------
-    shape : int or tuple of ints
-        shape of the array
+    shape : tuple of two ints
+        shape of the array as a 2-tuple `(m, n)`.
     density : real, optional (default: 0.01)
         density of the generated matrix: density equal to one means a full
         matrix, density of 0 means a matrix with no non-zero items.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #23925
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
This PR changes documentation for the `shape` parameter of `scipy.sparse.random_array`. The previous docstring stated that it could be an `int` or a tuple of ints, when in reality the implementation requires a 2-tuple `(m, n)` and does not really accept a single integer. The docstring now specifies that `shape`must be a tuple of two integers.
<!--Please explain your changes.-->

#### Additional information

