### PR TITLE
DOC clarify batching behavior in linalg.orth and linalg.null_space [d…

### DIFF
--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -329,6 +329,15 @@ def orth(A, rcond=None):
         Orthonormal basis for the range of A.
         K = effective rank of A, as determined by rcond
 
+    Notes
+    -----
+    When `A` is batched (i.e., `A.ndim` > 2) each slice over the batch
+    dimensions is processed independently. For a slice with shape
+    `(M, N)`, `orth` will return an array of shape `(M, K)`, where
+    `K` is the effective rank of that slice. Due to this, all slices
+    must produce the same effective rank, and if not, stacking fails with
+    `ValueError: all input arrays must have the same shape`.
+
     See Also
     --------
     svd : Singular value decomposition of a matrix
@@ -390,6 +399,16 @@ def null_space(A, rcond=None, *, overwrite_a=False, check_finite=True,
     Z : (N, K) ndarray
         Orthonormal basis for the null space of A.
         K = dimension of effective null space, as determined by rcond
+
+    Notes
+    -----
+    When `A` is a batched input array (i.e., `A.ndim > 2`) each slice
+    over the batch dimensions is processed independently. For a slice
+    with shape `(M, N)`, `null_space` will return an array of shape
+    `(N, K)`, where `K = N - r`, and `r` is the slice's effective rank.
+    Due to this, all slices must produce the same effective rank, and if
+    not, stacking will fail with `ValueError: all input arrays must have
+    the same shape`.
 
     See Also
     --------


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
#23896

#### What does this implement/fix?
This PR adds a `Notes` section to both `scipy.linalg.orth` and `scipy.linalg.null_space`, explaining the behavior of batched inputs when the slices have different ranks.

#### Additional information
<!--Any additional information you think is important.-->
