### PR TITLE
DOC: stats.cumfreq: correct bin edges of plot

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -2395,7 +2395,7 @@ def cumfreq(a, numbins=10, defaultreallimits=None, weights=None):
     Calculate space of values for x
 
     >>> x = res.lowerlimit + np.linspace(0, res.binsize*res.cumcount.size,
-    ...                                  res.cumcount.size)
+    ...                                  res.cumcount.size + 1)
 
     Plot histogram and cumulative histogram
 
@@ -2404,7 +2404,7 @@ def cumfreq(a, numbins=10, defaultreallimits=None, weights=None):
     >>> ax2 = fig.add_subplot(1, 2, 2)
     >>> ax1.hist(samples, bins=25)
     >>> ax1.set_title('Histogram')
-    >>> ax2.bar(x, res.cumcount, width=res.binsize)
+    >>> ax2.bar(x[:-1], res.cumcount, width=res.binsize, align='edge')
     >>> ax2.set_title('Cumulative histogram')
     >>> ax2.set_xlim([x.min(), x.max()])
 


### PR DESCRIPTION
In the example for `cumfreq`, the x-coordinates for the plot are calculated as
```python3
x = res.lowerlimit + np.linspace(0, res.binsize*res.frequency.size, res.frequency.size)
```
But `res.frequency.size` is the number of bins, one fewer than the number of bin edges, so `res.frequency.size` should be `res.frequency.size + 1`.

With that correction:
```python3
ref = np.count_nonzero(samples <= x[1:, np.newaxis], axis=-1)
np.testing.assert_equal(res.cumcount, ref)
```
is satisfied.

The plot currently looks like:

<img width="262" height="235" alt="Image" src="https://github.com/user-attachments/assets/87b2f21b-c7e4-46f9-ab00-a0c3c50ae4e9" />

The white lines between the bars is related. When we align the left edges of the bars to corrected left edges of the bins, the lines disappear.

<img width="252" height="237" alt="image" src="https://github.com/user-attachments/assets/448b7746-f92b-4364-be92-328964ef8adc" />