### PR TITLE
ENH: stats.estimated_cdf: array API function for `plotting_positions`/`percentileofscore`/`ecdf`/`cumfreq`

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -279,11 +279,12 @@ Frequency statistics
 .. autosummary::
    :toctree: generated/
 
-   cumfreq
    quantile
+   estimated_cdf
+   cumfreq
+   relfreq
    percentileofscore
    scoreatpercentile
-   relfreq
 
 .. autosummary::
    :toctree: generated/
@@ -627,7 +628,7 @@ from ._distribution_infrastructure import (
 from ._new_distributions import Normal, Logistic, Uniform, Binomial
 from ._mgc import multiscale_graphcorr
 from ._correlation import chatterjeexi, spearmanrho, theilslopes, siegelslopes
-from ._quantile import quantile
+from ._quantile import quantile, estimated_cdf
 
 
 # Deprecated namespaces, to be removed in v2.0.0

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -552,14 +552,14 @@ def _xp_searchsorted(x, y, *, side='left', xp=None):
 def estimated_cdf(x, y, *, method='linear',
                   axis=0, nan_policy='propagate', keepdims=None):
     """
-    Estimate the cumulative distribution function of the data along the specified axis.
+    Estimate the CDF for the distribution underlying a sample.
 
     Parameters
     ----------
     x : array_like of real numbers
         Data array.
     y : array_like of real numbers
-        Datum or data for which to estimate the cumulative probabilities.
+        Points at which to evaluate the estimated cdf.
         See `axis`, `keepdims`, and the examples for broadcasting behavior.
     method : str, default: 'linear'
         The method to use for estimating the cumulative distribution function.
@@ -577,7 +577,7 @@ def estimated_cdf(x, y, *, method='linear',
 
         See Notes for details.
     axis : int or None, default: 0
-        Axis along which the calculation is performed.
+        Axis along which samples in `x` are given in ND case.
         ``None`` ravels both `x` and `y` before performing the calculation,
         without checking whether the original shapes were compatible.
         As in other `scipy.stats` functions, a positive integer `axis` is resolved

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -7,6 +7,7 @@ from scipy._lib._array_api import (
     array_namespace,
     xp_promote,
     xp_device,
+    xp_size,
     _count_nonmasked,
     is_torch,
     is_lazy_array,
@@ -15,14 +16,31 @@ import scipy._external.array_api_extra as xpx
 from scipy.stats._axis_nan_policy import _broadcast_arrays, _contains_nan
 
 
-def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
+def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights, fun='quantile'):
     xp = array_namespace(x, p, weights)
+
+    if fun == "quantile":
+        methods = {'inverted_cdf', 'averaged_inverted_cdf', 'closest_observation',
+                   'hazen', 'interpolated_inverted_cdf', 'linear',
+                   'median_unbiased', 'normal_unbiased', 'weibull',
+                   'harrell-davis', '_lower', '_midpoint', '_higher', '_nearest',
+                   'round_outward', 'round_inward', 'round_nearest'}
+        allowed_types = 'real floating'
+        def mask_fun(p): return (p > 1) | (p < 0) | xp.isnan(p)
+        var2_name = 'p'
+        var2_type_msg = '`p` must have real floating dtype.'
+    else:
+        methods = set(_estimated_cdf_methods)
+        allowed_types = ('integral', 'real floating')
+        mask_fun = xp.isnan
+        var2_name = 'y'
+        var2_type_msg = '`y` must have real dtype.'
 
     if not xp.isdtype(xp.asarray(x).dtype, ('integral', 'real floating')):
         raise ValueError("`x` must have real dtype.")
 
-    if not xp.isdtype(xp.asarray(p).dtype, 'real floating'):
-        raise ValueError("`p` must have real floating dtype.")
+    if not xp.isdtype(xp.asarray(p).dtype, allowed_types):
+        raise ValueError(var2_type_msg)
 
     if not (weights is None
             or xp.isdtype(xp.asarray(weights).dtype, ('integral', 'real floating'))):
@@ -46,11 +64,6 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
         raise ValueError(message)
     axis = int(axis)
 
-    methods = {'inverted_cdf', 'averaged_inverted_cdf', 'closest_observation',
-               'hazen', 'interpolated_inverted_cdf', 'linear',
-               'median_unbiased', 'normal_unbiased', 'weibull',
-               'harrell-davis', '_lower', '_midpoint', '_higher', '_nearest',
-               'round_outward', 'round_inward', 'round_nearest'}
     if method not in methods:
         message = f"`method` must be one of {methods}"
         raise ValueError(message)
@@ -70,7 +83,7 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
     # If data has length zero along `axis`, the result will be an array of NaNs just
     # as if the data had length 1 along axis and were filled with NaNs. This is treated
     # naturally below whether `nan_policy` is `'propagate'` or `'omit'`.
-    if x.shape[axis] == 0:
+    if x.shape[axis] == 0 and fun == 'quantile':
         shape = list(x.shape)
         shape[axis] = 1
         x = xp.full(shape, xp.nan, dtype=dtype, device=xp_device(x))
@@ -91,7 +104,8 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
             (y, p, weights, i_y, n_zero_weight), axis=axis)
 
     if (keepdims is False) and (p.shape[axis] != 1):
-        message = "`keepdims` may be False only if the length of `p` along `axis` is 1."
+        message = ("`keepdims` may be False only if the length of "
+                   f"`{var2_name}` along `axis` is 1.")
         raise ValueError(message)
     keepdims = (p.shape[axis] != 1) if keepdims is None else keepdims
 
@@ -104,6 +118,7 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
     n = _count_nonmasked(y, -1, xp=xp, keepdims=True)
     n = n if n_zero_weight is None else n - n_zero_weight
 
+    nan_out = None
     if is_lazy_array(y) or contains_nans:
         nans = xp.isnan(y)
 
@@ -127,14 +142,20 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
 
     n = xp.asarray(n, dtype=dtype, device=xp_device(y))
 
-    p_mask = (p > 1) | (p < 0) | xp.isnan(p)
-    p = xp.where(p_mask, 0.5, p)
+    # apparently xpx.at is accepting nan_out as a mask even though it doesn't have the
+    # same number of dimensions as `y`, yet it still appears to work correctly?
+    # should refactor for clarity, and p_mask that gets returned here should probably
+    # get a different name - `nan_out` would be more appropriate!
+    p_mask = mask_fun(p) if nan_out is None else mask_fun(p) | nan_out
+    if is_lazy_array(p_mask) or xp.any(p_mask):
+        p = xp.where(p_mask, 0.5, p)  # these get NaN-ed out at the end
 
     return (y, p, method, axis, nan_policy, keepdims,
             n, axis_none, ndim, p_mask, weights, xp)
 
 
-@xp_capabilities(skip_backends=[("dask.array", "No take_along_axis yet.")])
+@xp_capabilities(skip_backends=[("dask.array", "No take_along_axis yet.")],
+                 marray=True)
 def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=None,
              weights=None):
     """
@@ -227,6 +248,7 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
     See Also
     --------
     numpy.quantile
+    estimated_cdf
     :ref:`outliers`
 
     Notes
@@ -381,6 +403,10 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
     else:  # method.startswith('round'):
         res = _quantile_winsor(y, p, n, method, xp)
 
+    return _post_quantile(res, p_mask, axis, axis_none, ndim, keepdims, xp)
+
+
+def _post_quantile(res, p_mask, axis, axis_none, ndim, keepdims, xp):
     res = xpx.at(res, p_mask).set(xp.nan)
 
     # Reshape per axis/keepdims
@@ -519,3 +545,270 @@ def _xp_searchsorted(x, y, *, side='left', xp=None):
     out = xp.where(xp.isnan(y), x.shape[-1], out) if side == 'right' else out
     out = xp.astype(out, xp_default_int, copy=False)
     return out
+
+
+@xp_capabilities(skip_backends=[("dask.array", "No take_along_axis yet.")],
+                 marray=True)
+def estimated_cdf(x, y, *, method='linear',
+                  axis=0, nan_policy='propagate', keepdims=None):
+    """
+    Estimate the cumulative distribution function of the data along the specified axis.
+
+    Parameters
+    ----------
+    x : array_like of real numbers
+        Data array.
+    y : array_like of real numbers
+        Datum or data for which to estimate the cumulative probabilities.
+        See `axis`, `keepdims`, and the examples for broadcasting behavior.
+    method : str, default: 'linear'
+        The method to use for estimating the cumulative distribution function.
+        The available options, numbered as they appear in [1]_, are:
+
+        1. 'inverted_cdf' (AKA *the* empirical cumulative distribution function)
+        2. 'averaged_inverted_cdf'
+        3. 'closest_observation'
+        4. 'interpolated_inverted_cdf'
+        5. 'hazen'
+        6. 'weibull'
+        7. 'linear'  (default)
+        8. 'median_unbiased'
+        9. 'normal_unbiased'
+
+        See Notes for details.
+    axis : int or None, default: 0
+        Axis along which the calculation is performed.
+        ``None`` ravels both `x` and `y` before performing the calculation,
+        without checking whether the original shapes were compatible.
+        As in other `scipy.stats` functions, a positive integer `axis` is resolved
+        after prepending 1s to the shape of `x` or `y` as needed until the two arrays
+        have the same dimensionality. When providing `x` and `y` with different
+        dimensionality, consider using negative `axis` integers for clarity.
+    nan_policy : str, default: 'propagate'
+        Defines how to handle NaNs in the input data `x`.
+
+        - ``propagate``: if a NaN is present in the axis slice (e.g. row) along
+          which the  statistic is computed, the corresponding slice of the output
+          will contain NaN(s).
+        - ``omit``: NaNs will be omitted when performing the calculation.
+          If insufficient data remains in the axis slice along which the
+          statistic is computed, the corresponding slice of the output will
+          contain NaN(s).
+        - ``raise``: if a NaN is present, a ``ValueError`` will be raised.
+
+        If NaNs are present in `y`, the corresponding entries in the output will be NaN.
+    keepdims : bool, optional
+        Consider the case in which `x` is 1-D and `y` is a scalar: the estimated
+        cumulative distribution function at a point is a reducing statistic, and the
+        default behavior is to return a scalar.
+        If `keepdims` is set to True, the axis will not be reduced away, and the
+        result will be a 1-D array with one element.
+
+        The general case is more subtle, since multiple values of `y` may be
+        specified for each axis-slice of `x`. For instance, if both `x` and `y`
+        are 1-D and ``y.size > 1``, no axis can be reduced away; there must be an
+        axis to contain the number of values given by ``y.size``. Therefore:
+
+        - By default, the axis will be reduced away if possible (i.e. if there is
+          exactly one element of `y` per axis-slice of `x`).
+        - If `keepdims` is set to True, the axis will not be reduced away.
+        - If `keepdims` is set to False, the axis will be reduced away
+          if possible, and an error will be raised otherwise.
+
+    Returns
+    -------
+    probability : scalar or ndarray
+        The resulting probabilities(s). The dtype is the result dtype of `x`, `y`, and
+        the Python ``float`` type.
+
+    See Also
+    --------
+    quantile
+
+    Notes
+    -----
+    Given a sample `x` from an underlying distribution, `estimated_cdf` provides a
+    nonparametric estimate of the cumulative distribution function.
+
+    By default, this is done by computing the "fractional index" ``p`` at which ``y``
+    would appear within ``z``, a sorted copy of `x`::
+
+        p = 1 / (n - 1) * (j +  (     y - z[j])
+                              / (z[j+1] - z[j]))
+
+    where the index ``j`` is that of the largest element of ``z`` that does not exceed
+    ``y``, and ``n`` is the number of elements in the sample. Note that if ``y`` is an
+    element of ``z``, then ``j`` is the index such that ``y = z[j]``, and the formula
+    simplifies to the intuitive ``j / (n - 1)``. The full formula linearly interpolates
+    between ``j / (n - 1)`` and ``(j + 1) / (n - 1)``.
+
+    This is a special case of the more general::
+
+        p = (j + (y - z[j]) / (z[j+1] - z[j] + 1 - m) / n
+
+    where ``m`` may be defined according to several different conventions.
+    The preferred convention may be selected using the ``method`` parameter:
+
+    =============================== =============== ===============
+    ``method``                      number in H&F   ``m``
+    =============================== =============== ===============
+    ``interpolated_inverted_cdf``   4               ``0``
+    ``hazen``                       5               ``1/2``
+    ``weibull``                     6               ``p``
+    ``linear`` (default)            7               ``1 - p``
+    ``median_unbiased``             8               ``p/3 + 1/3``
+    ``normal_unbiased``             9               ``p/4 + 3/8``
+    =============================== =============== ===============
+
+    Note that indices ``j`` and ``j + 1`` are clipped to the range ``0`` to
+    ``n - 1`` when the results of the formula would be outside the allowed
+    range of non-negative indices, and resulting ``p`` is clipped to the range
+    ``0`` to ``1``.
+
+    The table above includes only the estimators from [1]_ that are continuous
+    functions of probability `p` (estimators 4-9). SciPy also provides the
+    three discontinuous estimators from [1]_ (estimators 1-3), where ``j`` is
+    defined as above, ``m`` is defined as follows, and ``g`` is ``0`` when
+    ``index = p*n + m - 1`` is less than ``0`` and otherwise is defined below.
+
+    1. ``inverted_cdf``: ``m = 0`` and ``g = int(index - j > 0)``
+    2. ``averaged_inverted_cdf``: ``m = 0`` and
+       ``g = (1 + int(index - j > 0)) / 2``
+    3. ``closest_observation``: ``m = -1/2`` and
+       ``g = 1 - int((index == j) & (j%2 == 1))``
+
+    When all the data in ``x`` are unique, `estimated_cdf` and `quantile` are are
+    inverses of one another within a certain domain.
+    Although `quantile` with ``method='linear'`` is invertible over the whole domain
+    of ``p`` from ``0`` to ``1``, this is not true of other methods.
+
+    References
+    ----------
+    .. [1] R. J. Hyndman and Y. Fan,
+           "Sample quantiles in statistical packages,"
+           The American Statistician, 50(4), pp. 361-365, 1996
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy import stats
+    >>> x = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+    Estimate the cumulative distribution function of one sample at a single point.
+
+    >>> stats.estimated_cdf(x, 5, axis=-1)
+    np.float64(0.5)
+
+    Estimate the cumulative distribution function of one sample at two points.
+
+    >>> stats.estimated_cdf(x, [2.5, 7.5], axis=-1)
+    array([0.25, 0.75])
+
+    Estimate the cumulative distribution function of two samples at different points.
+
+    >>> x = np.stack((np.arange(0, 11), np.arange(10, 21)))
+    >>> stats.estimated_cdf(x, [[2.5], [17.5]], axis=-1, keepdims=True)
+    array([[0.25],
+           [0.75]])
+
+    Estimate the cumulative distribution function at many points for each of two
+    samples.
+
+    >>> import matplotlib.pyplot as plt
+    >>> rng = np.random.default_rng(6110515095)
+    >>> x = stats.Normal(mu=[-1, 1]).sample(10000)
+    >>> y = np.linspace(-4, 4, 5000)[:, np.newaxis]
+    >>> p = stats.estimated_cdf(x, y, axis=0)
+    >>> plt.plot(y, p)
+    >>> plt.show()
+
+    Note that the `quantile` and `estimated_cdf` functions are inverses of one another
+    within a certain domain.
+
+    >>> p = np.linspace(0, 1, 300)
+    >>> x = rng.standard_normal(300)
+    >>> y = stats.quantile(x, p)
+    >>> p2 = stats.estimated_cdf(x, y)
+    >>> np.testing.assert_allclose(p2, p)
+    >>> y2 = stats.quantile(x, p2)
+    >>> np.testing.assert_allclose(y2, y)
+
+    However, the domain over which `quantile` can be inverted by `estimated_cdf` depends
+    on the `method` used. This is most noticeable when there are few observations in the
+    sample.
+
+    >>> x = np.asarray([0, 1])
+    >>> y_linear = stats.quantile(x, p, method='linear')
+    >>> y_weibull = stats.quantile(x, p, method='weibull')
+    >>> y_iicdf = stats.quantile(x, p, method='interpolated_inverted_cdf')
+    >>> plt.plot(p, y_linear, p, y_weibull, p, y_iicdf)
+    >>> plt.legend(['linear', 'weibull', 'iicdf'])
+    >>> plt.xlabel('p')
+    >>> plt.ylabel('y = quantile(x, p)')
+    >>> plt.show()
+
+    For example, in the case above, `quantile` is only invertible from
+    ``p = 0.5`` to ``p = 1.0`` with ``method = 'interpolated_inverted_cdf'``. This is a
+    fundamental characteristic of the methods, not a shortcoming of `estimated_cdf`.
+
+    """
+    temp = _quantile_iv(x, y, method, axis, nan_policy, keepdims, weights=None,
+                        fun='estimated_cdf')
+    x, y, method, axis, nan_policy, keepdims, n, axis_none, ndim, y_mask, _, xp = temp
+
+    if xp_size(x) == 0:
+        res = xp.full_like(y, xp.nan)
+    else:
+        res = _estimated_cdf_hf(x, y, n, method, xp)
+
+    return _post_quantile(res, y_mask, axis, axis_none, ndim, keepdims, xp)
+
+
+_estimated_cdf_discontinuous_methods = dict(
+    inverted_cdf=0.0,
+    averaged_inverted_cdf=0.0,
+    closest_observation=0.5,
+)
+
+
+_estimated_cdf_continuous_methods = dict(
+    interpolated_inverted_cdf=(0, 1),
+    hazen=(0.5, 0.5),
+    weibull=(0, 0),
+    linear=(1, 1),
+    median_unbiased=(1 / 3, 1 / 3),
+    normal_unbiased=(3 / 8, 3 / 8),
+)
+
+
+_estimated_cdf_methods = (set(_estimated_cdf_continuous_methods).union(
+                          set(_estimated_cdf_discontinuous_methods)))
+
+
+def _estimated_cdf_hf(x, y, n, method, xp):
+    n_int = xp.astype(n, xp.int64)
+    j_max = n_int - 1
+    j_min = xp.minimum(j_max, xp.asarray(1, dtype=j_max.dtype))
+    jp1 = _xp_searchsorted(x, y, side='right')
+
+    if method in _estimated_cdf_discontinuous_methods:
+        dp = _estimated_cdf_discontinuous_methods[method]
+        p = (xp.astype(jp1, x.dtype)+dp)/n
+
+    else:
+        jp1 = xp.clip(jp1, j_min, j_max)
+        j = xp.clip(jp1-1, 0)
+        xj = xp.take_along_axis(x, j, axis=-1)
+        xjp1 = xp.take_along_axis(x, jp1, axis=-1)
+        with np.errstate(divide='ignore', invalid='ignore'):  # refactor to apply_where?
+            delta = xp.where((xjp1 > xj) & xp.isfinite(xj), (y - xj) / (xjp1 - xj), 1.)
+
+        a, b = _estimated_cdf_continuous_methods[method]
+        p = (xp.astype(jp1, x.dtype) + delta - a) / (n + 1 - a - b)
+
+    xmin = x[..., :1]
+    xmax = (x[..., -1:] if n.shape == () else xp.take_along_axis(x, j_max))
+    p = xpx.at(p)[y < xmin].set(0.)
+    p = xpx.at(p)[y > xmax].set(1.)
+
+    return xp.clip(p, 0., 1.)

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -2,12 +2,15 @@ import pytest
 import numpy as np
 
 from scipy import stats
-from scipy.stats._quantile import _xp_searchsorted
+from scipy.stats._quantile import (_xp_searchsorted, _estimated_cdf_methods,
+    _estimated_cdf_discontinuous_methods, _estimated_cdf_continuous_methods)
 from scipy._lib._array_api import (
     xp_default_dtype,
     is_numpy,
     is_torch,
     is_jax,
+    is_cupy,
+    is_array_api_strict,
     make_xp_test_case,
     SCIPY_ARRAY_API,
     xp_size,
@@ -15,6 +18,8 @@ from scipy._lib._array_api import (
 )
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 from scipy._lib._util import _apply_over_batch
+import scipy._external.array_api_extra as xpx
+from scipy.stats._axis_nan_policy import _broadcast_arrays
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
@@ -428,3 +433,342 @@ class Test_XPSearchsorted:
         x, y = xp.asarray(x), xp.asarray(y)
         res = _xp_searchsorted(x, y, side=side)
         xp_assert_equal(res, ref)
+
+
+@_apply_over_batch(('x', 1), ('y', 1))
+def estimated_cdf_reference_last_axis(x, y, nan_policy, method):
+    i_nan = np.isnan(x)
+    if nan_policy == 'propagate' and np.any(i_nan):
+        return np.full_like(y, np.nan)
+    elif nan_policy == 'omit':
+        x = x[~i_nan]
+    return stats.estimated_cdf(x, y, keepdims=True, method=method)
+
+
+def estimated_cdf_reference(x, y, *, axis=0, nan_policy='propagate',
+                        keepdims=None, method='linear'):
+    x, y = _broadcast_arrays((x, y), axis=axis)
+    x, y = np.moveaxis(x, axis, -1), np.moveaxis(y, axis, -1)
+    res = estimated_cdf_reference_last_axis(x, y, nan_policy, method)
+    res = np.moveaxis(res, -1, axis)
+    if not keepdims:
+        res = np.squeeze(res, axis=axis)
+    return res
+
+
+# avoid variable collection order issues
+_estimated_cdf_methods_list = sorted(list(_estimated_cdf_methods))
+
+
+@make_xp_test_case(stats.estimated_cdf)
+class TestEstimatedCDF:
+    def test_input_validation(self, xp):
+        x = xp.asarray([1, 2, 3])
+        y = xp.asarray(2)
+
+        message = "`x` must have real dtype."
+        with pytest.raises(ValueError, match=message):
+            stats.estimated_cdf(xp.asarray([True, False]), y)
+        with pytest.raises(ValueError):
+            stats.estimated_cdf(xp.asarray([1+1j, 2]), y)
+
+        message = "`y` must have real dtype."
+        with pytest.raises(ValueError, match=message):
+            stats.estimated_cdf(x, xp.asarray([0+1j, 1]))
+
+        message = "`axis` must be an integer or None."
+        with pytest.raises(ValueError, match=message):
+            stats.estimated_cdf(x, y, axis=0.5)
+        with pytest.raises(ValueError, match=message):
+            stats.estimated_cdf(x, y, axis=(0, -1))
+
+        message = "`axis` is not compatible with the shapes of the inputs."
+        with pytest.raises(ValueError, match=message):
+            stats.estimated_cdf(x, y, axis=2)
+
+        if not is_jax(xp):  # no data-dependent input validation for lazy arrays
+            message = "The input contains nan values"
+            with pytest.raises(ValueError, match=message):
+                stats.estimated_cdf(xp.asarray([xp.nan, 1, 2]), y, nan_policy='raise')
+
+        message = "method` must be one of..."
+        with pytest.raises(ValueError, match=message):
+            stats.estimated_cdf(x, y, method='a duck')
+
+        message = "If specified, `keepdims` must be True or False."
+        with pytest.raises(ValueError, match=message):
+            stats.estimated_cdf(x, y, keepdims=42)
+
+        message = "`keepdims` may be False only if the length of `y` along `axis` is 1."
+        with pytest.raises(ValueError, match=message):
+            stats.estimated_cdf(x, xp.asarray([0.5, 0.6]), keepdims=False)
+
+    @pytest.mark.parametrize('method', _estimated_cdf_methods_list)
+    @pytest.mark.parametrize('x_shape', [2, 10, 11, 100, 1001, (2, 10), (2, 3, 11)])
+    @pytest.mark.parametrize('y_shape', [None, 25])
+    @pytest.mark.parametrize('ties', [False, True])
+    def test_against_quantile(self, method, x_shape, y_shape, ties, xp):
+        discontinuous = method in _estimated_cdf_discontinuous_methods
+        dtype = xp_default_dtype(xp)  # removed parameterization to speed up tests
+        rng = np.random.default_rng(394529872549827485)
+        y_shape = x_shape if y_shape is None else y_shape
+
+        if ties:
+            x = xp.asarray(rng.integers(9, size=x_shape), dtype=dtype)
+        else:
+            x = xp.asarray(rng.standard_normal(size=x_shape), dtype=dtype)
+
+        p = xp.asarray(rng.random(size=y_shape), dtype=dtype)
+        y = stats.quantile(x, p, method=method, axis=-1)
+        res = stats.estimated_cdf(x, y, method=method, axis=-1)
+        ref = xp.broadcast_to(p, (*x.shape[:-1], y.shape[-1]))
+
+        # check that `quantile` is the inverse of `estimated_cdf`
+        # note that for discontinuous methods, res is right on the cusp of a transition,
+        # and there can be a tiny bit of error to the right or left. We shift it left
+        # to ensure we're on the correct side of the transition, producing the same `y2`
+        # as if the probability calculation were exact.
+        res = res - 1e-6 if discontinuous else res
+        y2 = stats.quantile(x, res, method=method, axis=-1)
+        atol = 1e-5 if dtype == xp.float32 else 1e-12
+        xp_assert_close(y2, y, atol=atol)
+
+        # if there are ties or method is discontinuous, `quantile` is not invertible
+        if ties or discontinuous:
+            return
+
+        # `quantile` is not invertible outside this domain
+        a, b = _estimated_cdf_continuous_methods[method]
+        n = x.shape[-1]
+        p_min = (1 - a) / (n + 1 - a - b)
+        p_max = (n - a) / (n + 1 - a - b)
+        i_very_low = y < xp.min(x, axis=-1, keepdims=True)
+        i_very_high = y > xp.max(x, axis=-1, keepdims=True)
+        i_low = (ref <= p_min) & ~i_very_low
+        i_high = (ref >= p_max) & ~i_very_high
+        i_ok = ~(i_low | i_high | i_very_low | i_very_high)
+
+        # check for correct inversion within the domain
+        xp_assert_close(res[i_ok], ref[i_ok])
+
+        # check that all other values get mapped to bottom or top of range
+        kwargs = dict(check_shape=False, check_dtype=False, check_0d=True)
+        xp_assert_close(res[i_low], xp.asarray(p_min), **kwargs)
+        xp_assert_close(res[i_high], xp.asarray(p_max), **kwargs)
+        xp_assert_close(res[i_very_low], xp.asarray(0.0), **kwargs)
+        xp_assert_close(res[i_very_high], xp.asarray(1.0), **kwargs)
+
+    @pytest.mark.filterwarnings("ignore:torch.searchsorted:UserWarning")
+    @pytest.mark.parametrize('axis', [0, 1])
+    @pytest.mark.parametrize('keepdims', [False, True])
+    @pytest.mark.parametrize('nan_policy', ['propagate', 'omit', 'marray'])
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    @pytest.mark.parametrize('nans', [False, True])
+    @pytest.mark.parametrize('meth', ['linear', 'inverted_cdf'])
+    def test_against_reference(self, axis, keepdims, nan_policy, dtype, nans, meth, xp):
+        if is_jax(xp) and nan_policy == 'marray':  # mdhaber/marray#146
+            pytest.skip("`marray` currently incompatible with JAX")
+        rng = np.random.default_rng(23458924568734956)
+        shape = (5, 6)
+        x = rng.standard_normal(size=shape).astype(dtype)
+        y = rng.standard_normal(size=shape).astype(dtype)
+
+        mask = None
+        if nans:
+            mask = rng.random(size=shape) > 0.8
+            assert np.any(mask)
+            x[mask] = np.nan
+
+        if not keepdims:
+            y = np.mean(y, axis=axis, keepdims=True)
+
+        dtype = getattr(xp, dtype)
+
+        if nan_policy == 'marray':
+            if not SCIPY_ARRAY_API:
+                pytest.skip("MArray is only available if SCIPY_ARRAY_API=1")
+            marray = pytest.importorskip('marray')
+            kwargs = dict(axis=axis, keepdims=keepdims, method=meth)
+            mxp = marray._get_namespace(xp)
+            x_mp = mxp.asarray(x, mask=mask)
+            res = stats.estimated_cdf(x_mp, mxp.asarray(y), **kwargs)
+            ref = estimated_cdf_reference(x, y, nan_policy='omit', **kwargs)
+            xp_assert_close(res.data, xp.asarray(ref, dtype=dtype))
+            return
+
+        kwargs = dict(axis=axis, keepdims=keepdims,
+                      nan_policy=nan_policy, method=meth)
+        res = stats.estimated_cdf(xp.asarray(x), xp.asarray(y), **kwargs)
+        ref = estimated_cdf_reference(x, y, **kwargs)
+        xp_assert_close(res, xp.asarray(ref, dtype=dtype))
+
+    @pytest.mark.skip_xp_backends('torch', reason='issues with sorting NaNs')
+    @pytest.mark.parametrize('n', [50, 500])
+    @pytest.mark.parametrize('method, ab', _estimated_cdf_continuous_methods.items())
+    def test_plotting_positions(self, n, method, ab, xp):
+        a, b = ab
+        rng = np.random.default_rng(539452987254982748)
+        x = rng.standard_normal(n)
+
+        mask = rng.random(n) < 0.1
+        x[mask] = np.nan
+        mask = xp.asarray(mask)
+
+        x_masked = np.ma.masked_invalid(x)
+        ref = stats.mstats.plotting_positions(x_masked, a, b)
+        ref = xp.asarray(ref.data)
+
+        x = xp.asarray(x)
+        res = stats.estimated_cdf(x, x, nan_policy='omit', method=method)
+
+        xp_assert_close(res[~mask], ref[~mask])
+        assert xp.all(xp.isnan(res[mask]))
+
+    @pytest.mark.parametrize('ties', [False, True])
+    def test_against_ecdf_percentileofscore(self, ties, xp):
+        rng = np.random.default_rng(853945298725498274)
+        n = 50
+        dtype = xp_default_dtype(xp)
+        x = rng.integers(10, size=n) if ties else rng.standard_normal(size=n)
+        y = rng.integers(10, size=25) if ties else rng.standard_normal(size=25)
+        ref = stats.ecdf(x).cdf.evaluate(y)
+        ref2 = stats.percentileofscore(x, y, 'weak')
+        x, y = xp.asarray(x, dtype=dtype), xp.asarray(y, dtype=dtype)
+        res = stats.estimated_cdf(x, y, method='inverted_cdf')
+        ref, ref2 = xp.asarray(ref, dtype=dtype), xp.asarray(ref2, dtype=dtype)
+        xp_assert_close(res, ref)
+        xp_assert_close(res, ref2 / 100)
+
+    def test_integer_input_output_dtype(self, xp):
+        x = xp.arange(10, dtype=xp.int64)
+        res = stats.estimated_cdf(x, x)
+        assert res.dtype == xp_default_dtype(xp)
+
+    @pytest.mark.parametrize('nan_policy', ['propagate', 'omit', 'marray'])
+    @pytest.mark.parametrize('method', _estimated_cdf_methods_list)
+    def test_size_one_sample(self, nan_policy, method, xp):
+        discontinuous = method in _estimated_cdf_discontinuous_methods
+        x = xp.arange(10.)
+        y = xp.asarray([0., -1., 1.])
+        n = np.asarray(1.) if is_array_api_strict(xp) else xp.asarray(1.)
+        with np.errstate(divide='ignore', invalid='ignore'):  # for method = 'linear'
+            if discontinuous:
+                ref = xp.asarray([1., 0., 1.])
+            else:
+                a, b = _estimated_cdf_continuous_methods[method]
+                ref = xp.asarray([float((n - a) / (n + 1 - a - b)), 0., 1.])
+
+        if nan_policy == 'propagate':
+            x = x[:1]
+            kwargs = {'nan_policy': 'propagate'}
+        elif nan_policy == 'omit':
+            x = xpx.at(x)[1:].set(xp.nan)
+            kwargs = {'nan_policy': 'omit'}
+        elif nan_policy == 'marray':
+            if is_jax(xp):
+                pytest.skip("JAX currently incompatible with `marray`")
+            if not SCIPY_ARRAY_API:
+                pytest.skip("MArray is only available if SCIPY_ARRAY_API=1")
+            marray = pytest.importorskip('marray')
+            mxp = marray._get_namespace(xp)
+            mask = (x > 0.)
+            x = mxp.asarray(x, mask=mask)
+            y = mxp.asarray(y)
+            kwargs = {}
+
+        with np.errstate(divide='ignore', invalid='ignore'):  # for method = 'linear'
+            res = stats.estimated_cdf(x, y, method=method, **kwargs)
+        res = res.data if nan_policy == 'marray' else res
+        xp_assert_close(res, ref)
+
+    # skipping marray due to mdhaber/marray#24
+    @pytest.mark.parametrize('nan_policy', ['propagate', 'omit'])
+    @pytest.mark.parametrize('method', _estimated_cdf_methods_list)
+    def test_size_zero_sample(self, nan_policy, method, xp):
+        x = xp.arange(10.)
+        y = xp.asarray([0., -1., 1.])  # this should work
+        ref = xp.full_like(y, xp.nan)
+
+        if nan_policy == 'propagate':
+            x = x[0:0]
+            kwargs = {'nan_policy': 'propagate'}
+        elif nan_policy == 'omit':
+            x = xpx.at(x)[:].set(xp.nan)
+            kwargs = {'nan_policy': 'omit'}
+        elif nan_policy == 'marray':
+            if not SCIPY_ARRAY_API:
+                pytest.skip("MArray is only available if SCIPY_ARRAY_API=1")
+            if is_jax(xp):
+                pytest.skip("JAX currently incompatible with `marray`")
+            marray = pytest.importorskip('marray')
+            mxp = marray._get_namespace(xp)
+            mask = (x >= 0.)
+            x = mxp.asarray(x, mask=mask)
+            y = mxp.asarray(y)
+            kwargs = {}
+
+        with np.errstate(divide='ignore', invalid='ignore'):  # for method = 'linear'
+            res = stats.estimated_cdf(x, y, method=method, **kwargs)
+
+        if nan_policy == 'marray':
+            assert xp.all(res.mask)
+        else:
+            xp_assert_close(res, ref)
+
+    @pytest.mark.parametrize('x, y, ref, kwargs',
+        [
+         ([], 0.5, np.nan, {}),
+         ([1, 2, 3], [0.999, 3.001, np.nan], [0., 1., np.nan], {}),
+         ([1, 2, 3], [], [], {}),
+         ([[np.nan, 2]], 2, [np.nan, 0.5], {'nan_policy': 'omit', 'method': 'weibull'}),
+         ([[], []], 0.5, np.full(2, np.nan), {'axis': -1}),
+         ([[], []], 0.5, np.zeros((0,)), {'axis': 0, 'keepdims': False}),
+         ([[], []], 0.5, np.zeros((1, 0)), {'axis': 0, 'keepdims': True}),
+         ([], [0.5, 0.6], np.full(2, np.nan), {}),
+         (np.arange(1, 28).reshape((3, 3, 3)), 14., [[[0.5]]],
+          {'axis': None, 'keepdims': True}),
+         ([[1, 2], [3, 4]], [1.75, 2.5, 3.25], [[0.25, 0.5, 0.75]],
+          {'axis': None, 'keepdims': True}),
+         ([1, 2, 3], [-np.inf, np.inf], [0.0, 1.0], {}),
+         # It is our choice how much effort and computational overhead we want to put
+         # into adjusting for insane edge cases like when `x` contains infinite values,
+         # especially when `y` does, too.
+         # One practical argument would be that y = +/- inf should produce the same
+         # results as an extremely large finite number, in which case the 0th element
+         # of the 'linear' result should be `0`.
+         # Another argument would be for producing NaN below wherever y = +/- inf.
+         # Another would be that it's not appropriate to spend significant computation
+         # correcting these edge cases; we should just document what we do.
+         # In any case, this is the current status.
+         ([-np.inf, -1, 0, 1, np.inf], [-np.inf, -2, -1, 0, 1, 2, np.inf],
+          [0.25, 0.25, 0.25, 0.5 , 0.75, 0.75, np.nan], {'method':'linear'}),
+         ([-np.inf, -1, 0, 1, np.inf], [-np.inf, -2, -1, 0, 1, 2, np.inf],
+          [0.2, 0.2, 0.4, 0.6, 0.8, 0.8, 1.], {'method': 'inverted_cdf'}),
+        ])
+    def test_edge_cases(self, x, y, ref, kwargs, xp):
+        if kwargs.get('method', None) == 'weibull' and is_torch(xp):
+            pytest.skip('data-apis/array-api-compat#360')
+        if kwargs.get('axis', None) == -1 and is_cupy(xp):
+            pytest.skip('Fails; need to investigate.')
+        default_dtype = xp_default_dtype(xp)
+        x, y, ref = xp.asarray(x), xp.asarray(y), xp.asarray(ref, dtype=default_dtype)
+        res = stats.estimated_cdf(x, y, **kwargs)
+        xp_assert_close(res, ref, rtol=1e-15)
+
+    @pytest.mark.skip_xp_backends('jax.numpy', reason="-1e-45 is not less than 0?")
+    @pytest.mark.parametrize('method', _estimated_cdf_discontinuous_methods.keys())
+    def test_transition(self, method, xp):
+        # test that values of discontinuous estimators are as expected around
+        # transition point
+        x = np.arange(8., dtype=np.float64)
+        xl, xr = np.nextafter(x, -np.inf), np.nextafter(x, np.inf)
+        offset = 0.5 if method == 'closest_observation' else 0.0
+        ref_r = (x + 1 + offset) / 8
+        ref_r[-1] = 1.0  # value is greater than or equal to the maximum observation
+        ref_l = (x + offset) / 8
+        ref_l[0] = 0.0  # value is less than the minimum observation
+        x, xl, xr = xp.asarray(x), xp.asarray(xl), xp.asarray(xr)
+        ref_l, ref_r = xp.asarray(ref_l), xp.asarray(ref_r)
+        xp_assert_equal(stats.estimated_cdf(x, x, method=method), ref_r)
+        xp_assert_equal(stats.estimated_cdf(x, xr, method=method), ref_r)
+        xp_assert_equal(stats.estimated_cdf(x, xl, method=method), ref_l)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544
Toward gh-22194
Addresses the enhancement request contained in gh-21563 (closed by documenting the limitation).

#### What does this implement/fix?
This introduces a function that reproduces much of the functionality of `stats.mstats.plotting_positions`, `stats.percentileofscore`, `stats.ecdf.cdf`, and `stats.cumfreq`. But It is also vectorized like `quantile`, and it currently works with all the backends we test (including `marray`) except for `dask.array` (which is missing the standard `take_along_axis`). It supports the usual options that we expect in `stats` functions: `axis`, `keepdims`, and `nan_policy` (without resorting to loops or masked arrays).

The working name has been `iquantile`, but it's more appropriate to think of the quantile function as the inverse of the CDF, and not the other way around. I think `ogive` would a descriptive name, since a piecewise linear ECDF is referred to as an [ogive](https://en.wikipedia.org/wiki/Ogive_(statistics)).

**Examples**
The ECDF is `ogive` with `method='inverted_cdf'`.
```python3
import numpy as np
from scipy import stats
rng = np.random.default_rng(3249825983458343)
x = rng.standard_normal(1000)
y = rng.standard_normal(100)

method = 'inverted_cdf'
ref = stats.ecdf(x).cdf.evaluate(y)
res = stats.ogive(x, y, method=method)
np.testing.assert_allclose(res, ref)
```

Plotting positions are `ogive` with the data passed as both first and second arguments. (`plotting_positions` allows the user to pass `alpha` and `beta` parameters instead of method names, but we can add that to `quantile` and this function easily.)

```python3
method = 'weibull'
ref = stats.mstats.plotting_positions(x, 0, 0)  # equivalent to 'weibull' 
res = stats.ogive(x, x, method=method)
np.testing.assert_allclose(res, ref)
```

Given gh-23948, I think this function makes it a lot easier to plot a cumulative histogram (smooth or step-wise).
```python3
import matplotlib.pyplot as plt
x_ = np.linspace(-4, 4, 300)
p = stats.ogive(x, x_)
plt.plot(x_, p)
plt.show()
```
<img width="820" height="285" alt="image" src="https://github.com/user-attachments/assets/b684047e-9a94-47ab-afac-a0ec888cdd4c" />
(Admittedly, `stats.ecdf(x).cdf.plot()` is even easier, but that is discontinuous.)

With plenty of caveats, this function and quantile are inverses (to the extent that the functions are invertible).

```python3
ref = rng.random(100)
q = stats.quantile(x, ref, method='hazen')
res = stats.ogive(x, q, method='hazen')
np.testing.assert_allclose(res, ref)
```

It's very easy to get the edge cases wrong, but I think I've been pretty careful.

#### Additional information
~~The function name need to be changed, the documentation needs to be adapted, and~~ The tests need to be trimmed down. ~~This function relies on `_xp_searchsorted`, so gh-23930 should merge first.~~ Support for weights can be added in a separate PR.