### PR TITLE
MAINT: stats: silence the "unused function" build noise from Cython

### DIFF
--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -36,7 +36,7 @@ ckdtree_src = [
 
 py3.extension_module('_ckdtree',
   ckdtree_src + [cython_gen_cpp.process('_ckdtree.pyx')],
-  cpp_args: cython_cpp_args,
+  cpp_args: [cython_cpp_args, _cpp_Wno_unused_function],
   include_directories: [
     '../_lib',
     '../_build_utils/src',

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -48,7 +48,7 @@ py3.install_sources([
 
 py3.extension_module('_qmc_cy',
   cython_gen_cpp.process('_qmc_cy.pyx'),
-  cpp_args: cython_cpp_args,
+  cpp_args: [cython_cpp_args, _cpp_Wno_unused_function],
   dependencies: [np_dep, thread_dep],
   link_args: version_link_args,
   install: true,


### PR DESCRIPTION
Silence noise from building `stats/qmc_cy` with -Werror:

```
FAILED: [code=1] scipy/stats/_qmc_cy.cpython-312-x86_64-linux-gnu.so.p/meson-generated__qmc_cy.cpp.o 
clang++-17 -Iscipy/stats/_qmc_cy.cpython-312-x86_64-linux-gnu.so.p -Iscipy/stats -I../scipy/stats -I../../../../../../opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/numpy/_core/include -I/opt/hostedtoolcache/Python/3.12.12/x64/include/python3.12 -fvisibility=hidden -fvisibility-inlines-hidden -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Werror -std=c++17 -O3 -fPIC -pthread -DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION -DCYTHON_CCOMPLEX=0 -MD -MQ scipy/stats/_qmc_cy.cpython-312-x86_64-linux-gnu.so.p/meson-generated__qmc_cy.cpp.o -MF scipy/stats/_qmc_cy.cpython-312-x86_64-linux-gnu.so.p/meson-generated__qmc_cy.cpp.o.d -o scipy/stats/_qmc_cy.cpython-312-x86_64-linux-gnu.so.p/meson-generated__qmc_cy.cpp.o -c scipy/stats/_qmc_cy.cpython-312-x86_64-linux-gnu.so.p/_qmc_cy.cpp
scipy/stats/_qmc_cy.cpython-312-x86_64-linux-gnu.so.p/_qmc_cy.cpp:13536:1: error: unused function '__pyx_memoryview_copy_new_contig' [-Werror,-Wunused-function]
 13536 | __pyx_memoryview_copy_new_contig(const __Pyx_memviewslice *from_mvs,
       | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

observed in https://github.com/scipy/scipy/pull/23921 and elsewhere.
