### PR TITLE
BENCH: interpolate: fix the RGI subclassing benchmark

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -431,7 +431,7 @@ class RegularGridInterpolatorValues(interpolate.RegularGridInterpolator):
         # check dimensionality
         self._check_dimensionality(self.grid, values)
         # flip, if needed
-        self.values = np.flip(values, axis=self._descending_dimensions)
+        self._values = np.flip(values, axis=self._descending_dimensions)
         return super().__call__(self.xi, method=method)
 
 


### PR DESCRIPTION
https://github.com/scipy/scipy/pull/23759 changed RGI.values attribute into a read-only property, and this broke the RegularGridInterpolatorSubclass benchmark.

The benchmark itself was added in https://github.com/scipy/scipy/pull/17230, for (somewhat unconventional) downstream usage, with a caveat: this downstream usage is reaching into the RGI internals, which is subject to change in future SciPy versions: https://github.com/scipy/scipy/pull/17230#issuecomment-1288041388. And this "future scipy version" has arrived, in scipy==1.17.0.
Of course I completely forgot about gh-17230, and found the whole story with `git blame`.

I tried adding a setter for the RGI.values property, but this does not seem to help unbreaking the benchmark.

closes gh-23953

heads up @kmuehlbauer @egouden 