### PR TITLE
DOC: list classes in Array API tables

### DIFF
--- a/scipy/_lib/_array_api_docs_tables.py
+++ b/scipy/_lib/_array_api_docs_tables.py
@@ -164,9 +164,14 @@ def _process_capabilities_table_entry(entry: dict | None) -> dict[str, dict[str,
     }
 
 
+def issubclass_(obj, Klass):
+    """issubclass which does not raise on non-classes."""
+    return isinstance(obj, type) and issubclass(obj, Klass)
+
+
 def is_named_function_like_object(obj):
     return (
-        not isinstance(obj, ModuleType | type)
+        not (isinstance(obj, ModuleType) or issubclass_(obj, Exception))
         and callable(obj) and hasattr(obj, "__name__")
     )
 


### PR DESCRIPTION
Tweak the Array API table listings to include classes (and exclude warnings and exceptions: we want RegularGridInterpolator and do not want LinAlgWarning).
