### PR TITLE
MAINT: add `xp-capabilities` to `BSpline`

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -67,7 +67,13 @@ def _diff_dual_poly(j, k, y, d, t):
                         if (j + p) not in comb[i//d]])
     return res
 
-
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[
+        ("dask.array",
+         "https://github.com/data-apis/array-api-extra/issues/488")
+    ]
+)
 class BSpline:
     r"""Univariate spline in the B-spline basis.
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -46,7 +46,7 @@ from scipy.interpolate import _dierckx
 skip_xp_backends = pytest.mark.skip_xp_backends
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(BSpline)
 class TestBSpline:
 
     def test_ctor(self, xp):
@@ -726,7 +726,7 @@ class TestBSpline:
         xp_assert_close(b(xx), expected)
 
 
-@skip_xp_backends(cpu_only=True)
+@make_xp_test_case(BSpline)
 class TestInsert:
 
     @pytest.mark.parametrize('xval', [0.0, 1.0, 2.5, 4, 6.5, 7.0])

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -130,22 +130,17 @@ class TestBSpline:
         splev_result = splev(x_np, (t_np, c_np, k))
         xp_assert_close(b(x), xp.asarray(splev_result), atol=1e-14)
 
-    @skip_xp_backends(np_only=True, reason="TODO convert BPoly")
     def test_bernstein(self, xp):
         # a special knot vector: Bernstein polynomials
         k = 3
         t = xp.asarray([0]*(k+1) + [1]*(k+1))
         c = xp.asarray([1., 2., 3., 4.])
-        bp = BPoly(c.reshape(-1, 1), [0, 1])
+        bp = BPoly(xp.reshape(c, (-1, 1)), xp.asarray([0, 1]))
         bspl = BSpline(t, c, k)
 
-        xx = np.linspace(-1., 2., 10)
+        xx = xp.linspace(-1., 2., 10)
         xp_assert_close(bp(xx, extrapolate=True),
                         bspl(xx, extrapolate=True), atol=1e-14)
-
-        t, c = map(np.asarray, (t, c))
-        xp_assert_close(splev(xx, (t, c, k)),
-                        bspl(xx), atol=1e-14)
 
     @skip_xp_backends("dask.array", reason="_naive_eval is not dask-compatible")
     @skip_xp_backends("jax.numpy", reason="too slow; XXX a slow-if marker?")


### PR DESCRIPTION
I was sure `BSpline` already has `xp_capabilities` but apparently not. Thus add it. While at it, unskip a test which does not need to be skipped anymore.