### PR TITLE
Revert DOC: list classes in Array API tables

### DIFF
--- a/scipy/_lib/_array_api_docs_tables.py
+++ b/scipy/_lib/_array_api_docs_tables.py
@@ -164,14 +164,9 @@ def _process_capabilities_table_entry(entry: dict | None) -> dict[str, dict[str,
     }
 
 
-def issubclass_(obj, Klass):
-    """issubclass which does not raise on non-classes."""
-    return isinstance(obj, type) and issubclass(obj, Klass)
-
-
 def is_named_function_like_object(obj):
     return (
-        not (isinstance(obj, ModuleType) or issubclass_(obj, Exception))
+        not isinstance(obj, ModuleType | type)
         and callable(obj) and hasattr(obj, "__name__")
     )
 


### PR DESCRIPTION
Reverts scipy/scipy#23955

I'm seeing some issues in the full run after gh-23955, e.g. [here](https://github.com/scipy/scipy/actions/runs/19236447321/job/54987570074?pr=23810). Thought I'd open this as a quick fix unless there is another easy patch.