### PR TITLE
ENH: list classes in Array API tables

### DIFF
--- a/scipy/_lib/_array_api_docs_tables.py
+++ b/scipy/_lib/_array_api_docs_tables.py
@@ -164,9 +164,14 @@ def _process_capabilities_table_entry(entry: dict | None) -> dict[str, dict[str,
     }
 
 
+def issubclass_(obj, Klass):
+    """issubclass which does not raise on non-classes."""
+    return isinstance(obj, type) and issubclass(obj, Klass)
+
+
 def is_named_function_like_object(obj):
     return (
-        not isinstance(obj, ModuleType | type)
+        not (isinstance(obj, ModuleType) or issubclass_(obj, Exception))
         and callable(obj) and hasattr(obj, "__name__")
     )
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Retry of https://github.com/scipy/scipy/pull/23955, which got reverted in https://github.com/scipy/scipy/pull/23957

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

gh-23955 was labelled as `docs only`; there is apparently a non-doc test, let's run a full CI battery.