### PR TITLE
MAINT: signal: remove an obsolete workaround in detrend

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4261,11 +4261,7 @@ def detrend(data: np.ndarray, axis: int = -1,
     if type not in ['linear', 'l', 'constant', 'c']:
         raise ValueError("Trend type must be 'linear' or 'constant'.")
 
-    # XXX simplify when data-apis/array-api-compat#147 is available
-    if isinstance(bp, int):
-       xp = array_namespace(data)
-    else:
-       xp = array_namespace(data, bp)
+    xp = array_namespace(data, bp)
 
     data = np.asarray(data)
     dtype = data.dtype.char


### PR DESCRIPTION
Just a drive-by cleanup in `signal.detrend`.