### PR TITLE
DOC: interpolate.interpn: add value comparison to example

### DIFF
--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -732,6 +732,13 @@ def interpn(points, values, xi, method="linear", bounds_error=True,
     >>> print(interpn(points, values, point))
     [12.63]
 
+    Compare with value at point by function
+
+    >>> value_func_3d(*point)
+    12.63 # up to rounding
+
+    Since the function is linear, the interpolation is exact using linear method.
+
     """
     # sanity check 'method' kwarg
     if method not in ["linear", "nearest", "cubic", "quintic", "pchip",


### PR DESCRIPTION
Added example to compare interpolated value with function output.

We could do this on several points also

```
point_test = np.array([[2.21, 3.12, 1.15], [3.5, 3.1, 2.7]])
np.allclose(interpn(points, values, point_test), value_func_3d(*point_test.T)) # True

```