### PR TITLE
DEV: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,7 +44,7 @@ scipy/interpolate/  @ev-br
 scipy/odr/  @rkern
 scipy/optimize/  @andyfaff
 scipy/signal/  @larsoner @ilayn @DietBru
-scipy/sparse/  @perimosocordiae
+scipy/sparse/  @perimosocordiae @dschult
 scipy/sparse/csgraph/
 scipy/sparse/linalg/
 scipy/spatial/  @tylerjereddy @peterbell10


### PR DESCRIPTION
Add Dan Schult as codeowner for /scipy/sparse

After checking with @perimosocordiae about what this entails I would like to request, as a follow-up to #23920, to be added as a code owner for scipy/sparse. It should help me keep better track of issues/PRs in that space.
