### PR TITLE
TYP: generic `scipy.odr` types

### DIFF
--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -41,6 +41,7 @@ from threading import Lock
 import numpy as np
 from warnings import warn
 from scipy.odr import __odrpack
+from types import GenericAlias
 
 __all__ = ['odr', 'OdrWarning', 'OdrError', 'OdrStop',
            'Data', 'RealData', 'Model', 'Output', 'ODR',
@@ -258,6 +259,8 @@ class Data:
     detrimental to the fit.
 
     """
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, x, y=None, we=None, wd=None, fix=None, meta=None):
         self.x = _conv(x)
@@ -354,6 +357,8 @@ class RealData(Data):
     exception. Same with `sy` and `covy`.
 
     """
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, x, y=None, sx=None, sy=None, covx=None, covy=None,
                  fix=None, meta=None):
@@ -505,6 +510,8 @@ class Model:
         ``m == 1``, the shape is (q, n). If `m == q == 1`, the shape is ``(n,)``.
 
     """
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, fcn, fjacb=None, fjacd=None,
                  extra_args=None, estimate=None, implicit=0, meta=None):
@@ -594,6 +601,8 @@ class Output:
     only present if `~scipy.odr.odr` was run with ``full_output=1``.
 
     """
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, output):
         self.beta = output[0]
@@ -732,6 +741,8 @@ class ODR:
         data from an invocation of ODR.run() or ODR.restart()
 
     """
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
 
     def __init__(self, data, model, beta0=None, delta0=None, ifixb=None,
         ifixx=None, job=None, iprint=None, errfile=None, rptfile=None,


### PR DESCRIPTION
Added GenericAlias for type compatibility with scipy-stubs.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes [gh-671](https://github.com/scipy/scipy-stubs/issues/671)

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds generic type compatibility to scipy.odr classes by adding __class_getitem__ = classmethod(GenericAlias) to the following classes:

- Data
- RealData
- Model
- Output
- ODR

#### Additional information
<!--Any additional information you think is important.-->
This change is purely for type-checking compatibility and has no runtime impact.