### PR TITLE
CI: lock file update workflow

### DIFF
--- a/.github/workflows/update_lock_file.yml
+++ b/.github/workflows/update_lock_file.yml
@@ -1,0 +1,41 @@
+name: Update lock file
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+  schedule:
+    # once a month
+    - cron: 0 5 25 * *
+
+jobs:
+  pixi-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@8ca4608ef7f4daeb54f5205b20d0b7cb42f11143 # v0.8.14
+        with:
+          run-install: false
+          pixi-version: v0.59.0
+          cache: false
+
+      - name: Update lock file
+        run: |
+          set -euo pipefail
+          pixi update --json --no-install | pixi exec pixi-diff-to-markdown >> diff.md
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "MAINT: update lock file"
+          title: "MAINT: update lock file"
+          body-path: "diff.md"
+          branch: lock-file-update
+          base: main
+          delete-branch: true
+          add-paths: pixi.lock

--- a/.github/workflows/update_pixi_lock_file.yml
+++ b/.github/workflows/update_pixi_lock_file.yml
@@ -1,29 +1,35 @@
-name: Update lock file
+name: Update Pixi lock file
 
 permissions:
-  contents: write
   pull-requests: write
 
 on:
   workflow_dispatch:
   schedule:
     # once a month
+    #       ┌───────────── minute (0 - 59)
+    #       │ ┌───────────── hour (0 - 23)
+    #       │ │ ┌───────────── day of the month (1 - 31)
+    #       │ │ │  ┌───────────── month (1 - 12 or JAN-DEC)
+    #       │ │ │  │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #       │ │ │  │ │
     - cron: 0 5 25 * *
 
 jobs:
   pixi-update:
+    if: "github.repository == 'scipy/scipy' || github.repository == ''"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up pixi
+      - name: Set up Pixi
         uses: prefix-dev/setup-pixi@8ca4608ef7f4daeb54f5205b20d0b7cb42f11143 # v0.8.14
         with:
           run-install: false
           pixi-version: v0.59.0
           cache: false
 
-      - name: Update lock file
+      - name: Update Pixi lock file
         run: |
           set -euo pipefail
           pixi update --json --no-install | pixi exec pixi-diff-to-markdown >> diff.md
@@ -32,8 +38,8 @@ jobs:
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "MAINT: update lock file"
-          title: "MAINT: update lock file"
+          commit-message: "MAINT: update Pixi lock file"
+          title: "MAINT: update Pixi lock file"
           body-path: "diff.md"
           branch: lock-file-update
           base: main

--- a/pixi.toml
+++ b/pixi.toml
@@ -557,3 +557,9 @@ platforms = ["linux-64", "osx-arm64", "win-64"]
 
 [feature.py311.dependencies]
 python = "3.11.*"
+
+
+### tool config
+
+[tool.pixi-diff-to-markdown]
+change-type-column = false


### PR DESCRIPTION
Towards gh-23637.

This PR introduces a workflow to automate updating the Pixi workspace lock file, set on monthly cron and available for manual workflow dispatch.

When the workflow runs, `pixi update` is executed to update the lock file. If that fails, the workflow fails. If that succeeds, the GHA bot opens a PR to the repo with the updated lock file, accompanied by tables detailing the upgrades of explicit and implicit dependencies.

We should merge this PR because it means we are reminded to stay somewhat up-to-date with new releases of our dependencies, even when there is no need to trigger a manual update for longer than a month.

Note that there are rough plans for a more frequent cron which could take place in the fork of a bot, repeatedly updating the lock file, running the other workflows, and reporting failures in an issue. See discussion at https://github.com/scipy/scipy/issues/23637#issuecomment-3356599227. This will be quite valuable as we will get much smaller and finer-grained diffs from more frequent runs, making it easier to see at a glance which dependency updates have caused failures. But this PR is independent of that proposed work for now.

ping @rgommers @andyfaff @larsoner

See example pull request triggered by this workflow at https://github.com/lucascolley/scipy/pull/39, with PR description pasted below:

---

# Dependencies

<details>
<summary>Explicit dependencies</summary>

|Dependency|Before|After|Environments|
|-|-|-|-|
|[blas-devel](https://prefix.dev/channels/conda-forge/packages/blas-devel)|3.9.0|3.11.0|{array-api-cpu, array-api-strict, build, build-cpu, dask-cpu, ipython, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{build-debug, jax-cpu, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{build-cuda, cupy, gdb, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, build-accelerate-ilp64, build-accelerate-lp64, lldb} on osx-arm64|
|[hypothesis](https://prefix.dev/channels/conda-forge/packages/hypothesis)|6.147.0|6.148.1|{array-api-cpu, array-api-strict, dask-cpu, ipython, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{jax-cpu, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{cupy, gdb, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, lldb} on osx-arm64|
|[libblas](https://prefix.dev/channels/conda-forge/packages/libblas)|3.9.0|3.11.0|{array-api-cpu, jax-cpu, jax-cuda, torch-cpu, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, build-accelerate-ilp64, build-accelerate-lp64} on osx-arm64|
|[cython](https://prefix.dev/channels/conda-forge/packages/cython)|3.2.0|3.2.1|{build, build-cpu, scipy-openblas} on *all platforms*<br/>{build-debug, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{build-accelerate-ilp64, build-accelerate-lp64} on osx-arm64<br/>build-cuda on linux-64|
|[matplotlib](https://prefix.dev/channels/conda-forge/packages/matplotlib)|3.10.7|3.10.8|docs on *all platforms*|
|[numpy](https://prefix.dev/channels/conda-forge/packages/numpy)|2.3.4|2.3.5|{array-api-cpu, array-api-strict, build, build-cpu, dask-cpu, ipython, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{build-cuda, build-debug, cupy, gdb, jax-cpu, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, build-accelerate-ilp64, build-accelerate-lp64, build-debug, jax-cpu, lldb} on osx-arm64|
|[pytest](https://prefix.dev/channels/conda-forge/packages/pytest)|9.0.0|9.0.1|{array-api-cpu, array-api-strict, dask-cpu, ipython, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{jax-cpu, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{cupy, gdb, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, lldb} on osx-arm64|
|[pythran](https://prefix.dev/channels/conda-forge/packages/pythran)|0.18.0|0.18.1|{build, build-cpu, scipy-openblas} on *all platforms*<br/>{build-debug, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{build-accelerate-ilp64, build-accelerate-lp64} on osx-arm64<br/>build-cuda on linux-64|
|[ruff](https://prefix.dev/channels/conda-forge/packages/ruff)|0.14.4|0.14.5|lint on *all platforms*|
|[gmpy2](https://prefix.dev/channels/conda-forge/packages/gmpy2)|py314h9f8d836_2|py314h44a91c2_2|scipy-openblas on win-64|
|[libboost-headers](https://prefix.dev/channels/conda-forge/packages/libboost-headers)|hce30654_2|hce30654_3|py311-system-libs-osx on osx-arm64|
|[libboost-headers](https://prefix.dev/channels/conda-forge/packages/libboost-headers)|ha770c72_2|ha770c72_3|py311-system-libs-osx on linux-64|
|[openblas](https://prefix.dev/channels/conda-forge/packages/openblas)|pthreads_h4a7f399_3|pthreads_h4a7f399_4|{build, test} on win-64|
|[python](https://prefix.dev/channels/conda-forge/packages/python)|h4b44e0e_102_cp314|h7c1dbca_2_cp314t|scipy-openblas on win-64|

</details>

<details>
<summary>Implicit dependencies</summary>

|Dependency|Before|After|Environments|
|-|-|-|-|
|[brotli](https://prefix.dev/channels/conda-forge/packages/brotli)||1.2.0|scipy-openblas on win-64|
|[brotli-bin](https://prefix.dev/channels/conda-forge/packages/brotli-bin)||1.2.0|scipy-openblas on win-64|
|[libbrotlicommon](https://prefix.dev/channels/conda-forge/packages/libbrotlicommon)||1.2.0|scipy-openblas on win-64|
|[libbrotlidec](https://prefix.dev/channels/conda-forge/packages/libbrotlidec)||1.2.0|scipy-openblas on win-64|
|[libbrotlienc](https://prefix.dev/channels/conda-forge/packages/libbrotlienc)||1.2.0|scipy-openblas on win-64|
|brotli-python|1.2.0||scipy-openblas on win-64|
|cffi|2.0.0||scipy-openblas on win-64|
|h2|4.3.0||scipy-openblas on win-64|
|hpack|4.1.0||scipy-openblas on win-64|
|hyperframe|6.1.0||scipy-openblas on win-64|
|pycparser|2.22||scipy-openblas on win-64|
|zstandard|0.25.0||scipy-openblas on win-64|
|[binutils](https://prefix.dev/channels/conda-forge/packages/binutils)|2.44|2.45|{build, build-cpu, build-cuda, build-debug, py311-system-libs-osx, scipy-openblas} on linux-64|
|[binutils_impl_linux-64](https://prefix.dev/channels/conda-forge/packages/binutils_impl_linux-64)|2.44|2.45|{build, build-cpu, build-cuda, build-debug, py311-system-libs-osx, scipy-openblas} on linux-64|
|[binutils_linux-64](https://prefix.dev/channels/conda-forge/packages/binutils_linux-64)|2.44|2.45|{build, build-cpu, build-cuda, build-debug, py311-system-libs-osx, scipy-openblas} on linux-64|
|[ca-certificates](https://prefix.dev/channels/conda-forge/packages/ca-certificates)|2025.10.5|2025.11.12|{array-api-cpu, array-api-strict, build, build-cpu, dask-cpu, default, docs, ipython, lint, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{build-debug, jax-cpu, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{build-cuda, cupy, gdb, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, build-accelerate-ilp64, build-accelerate-lp64, lldb} on osx-arm64|
|[certifi](https://prefix.dev/channels/conda-forge/packages/certifi)|2025.10.5|2025.11.12|{array-api-cpu, array-api-strict, dask-cpu, docs, ipython, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{jax-cpu, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{cupy, gdb, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, lldb} on osx-arm64|
|[ld_impl_linux-64](https://prefix.dev/channels/conda-forge/packages/ld_impl_linux-64)|2.44|2.45|{array-api-cpu, array-api-strict, build, build-cpu, build-cuda, build-debug, cupy, dask-cpu, default, docs, gdb, ipython, jax-cpu, jax-cuda, lint, py311-system-libs-osx, scipy-openblas, test, torch-cpu, torch-cuda} on linux-64|
|[libblas](https://prefix.dev/channels/conda-forge/packages/libblas)|3.9.0|3.11.0|{array-api-strict, build, build-cpu, dask-cpu, docs, ipython, scipy-openblas, test} on *all platforms*<br/>{build-debug, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{array-api-cpu, torch-cpu} on {osx-arm64, win-64}<br/>{build-cuda, cupy, gdb} on linux-64<br/>{jax-cpu, lldb} on osx-arm64|
|[libcap](https://prefix.dev/channels/conda-forge/packages/libcap)|2.76|2.77|torch-cuda on linux-64|
|[libcblas](https://prefix.dev/channels/conda-forge/packages/libcblas)|3.9.0|3.11.0|{array-api-cpu, array-api-strict, build, build-cpu, dask-cpu, docs, ipython, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{build-debug, jax-cpu, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{build-cuda, cupy, gdb, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, build-accelerate-ilp64, build-accelerate-lp64, lldb} on osx-arm64|
|[liblapack](https://prefix.dev/channels/conda-forge/packages/liblapack)|3.9.0|3.11.0|{array-api-cpu, array-api-strict, build, build-cpu, dask-cpu, docs, ipython, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{build-debug, jax-cpu, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{build-cuda, cupy, gdb, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, build-accelerate-ilp64, build-accelerate-lp64, lldb} on osx-arm64|
|[liblapacke](https://prefix.dev/channels/conda-forge/packages/liblapacke)|3.9.0|3.11.0|{array-api-cpu, array-api-strict, build, build-cpu, dask-cpu, ipython, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{build-debug, jax-cpu, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{build-cuda, cupy, gdb, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, build-accelerate-ilp64, build-accelerate-lp64, lldb} on osx-arm64|
|[libpq](https://prefix.dev/channels/conda-forge/packages/libpq)|18.0|18.1|docs on linux-64|
|[optree](https://prefix.dev/channels/conda-forge/packages/optree)|0.17.0|0.18.0|{array-api-cpu, torch-cpu} on *all platforms*<br/>torch-cuda on linux-64|
|[pyobjc-core](https://prefix.dev/channels/conda-forge/packages/pyobjc-core)|12.0|12.1|docs on osx-arm64|
|[pyobjc-framework-cocoa](https://prefix.dev/channels/conda-forge/packages/pyobjc-framework-cocoa)|12.0|12.1|docs on osx-arm64|
|[rpds-py](https://prefix.dev/channels/conda-forge/packages/rpds-py)|0.28.0|0.29.0|docs on *all platforms*|
|[urllib3](https://prefix.dev/channels/conda-forge/packages/urllib3)[^2]|2.5.0|2.0.3|scipy-openblas on win-64|
|[asttokens](https://prefix.dev/channels/conda-forge/packages/asttokens)|3.0.0|3.0.1|{docs, ipython} on *all platforms*|
|[cython](https://prefix.dev/channels/conda-forge/packages/cython)|3.2.0|3.2.1|lint on *all platforms*|
|[execnet](https://prefix.dev/channels/conda-forge/packages/execnet)|2.1.1|2.1.2|{array-api-cpu, array-api-strict, dask-cpu, ipython, scipy-openblas, test, torch-cpu} on *all platforms*<br/>{jax-cpu, py311-system-libs-osx} on {linux-64, osx-arm64}<br/>{cupy, gdb, jax-cuda, torch-cuda} on linux-64<br/>{accelerate-ilp64, accelerate-lp64, lldb} on osx-arm64|
|[libcxx](https://prefix.dev/channels/conda-forge/packages/libcxx)|21.1.5|21.1.6|{accelerate-ilp64, accelerate-lp64, array-api-cpu, array-api-strict, build, build-accelerate-ilp64, build-accelerate-lp64, build-cpu, build-debug, dask-cpu, docs, ipython, jax-cpu, lint, lldb, py311-system-libs-osx, scipy-openblas, test, torch-cpu} on osx-arm64|
|[matplotlib-base](https://prefix.dev/channels/conda-forge/packages/matplotlib-base)|3.10.7|3.10.8|docs on *all platforms*|
|[numpy](https://prefix.dev/channels/conda-forge/packages/numpy)|2.3.4|2.3.5|docs on *all platforms*|
|[pytest](https://prefix.dev/channels/conda-forge/packages/pytest)|9.0.0|9.0.1|docs on *all platforms*|
|[xcb-util-cursor](https://prefix.dev/channels/conda-forge/packages/xcb-util-cursor)|0.1.5|0.1.6|docs on linux-64|
|[gcc_linux-64](https://prefix.dev/channels/conda-forge/packages/gcc_linux-64)|h298d278_12|h298d278_13|{build, build-cpu, build-cuda, build-debug, py311-system-libs-osx, scipy-openblas} on linux-64|
|[gfortran_linux-64](https://prefix.dev/channels/conda-forge/packages/gfortran_linux-64)|h961de7f_12|h523a340_13|{build, build-cpu, build-cuda, build-debug, py311-system-libs-osx, scipy-openblas} on linux-64|
|[gxx_linux-64](https://prefix.dev/channels/conda-forge/packages/gxx_linux-64)|h95f728e_12|hed40740_13|{build, build-cpu, build-cuda, build-debug, py311-system-libs-osx, scipy-openblas} on linux-64|
|[libopenblas](https://prefix.dev/channels/conda-forge/packages/libopenblas)|pthreads_h94d23a6_3|pthreads_h94d23a6_4|{build, build-cuda, build-debug, cupy, docs, gdb, ipython, py311-system-libs-osx, scipy-openblas, test} on linux-64|
|[libopenblas](https://prefix.dev/channels/conda-forge/packages/libopenblas)|pthreads_ha4fe6b2_3|pthreads_h877e47f_4|{build, docs, ipython, test} on win-64|
|[libsystemd0](https://prefix.dev/channels/conda-forge/packages/libsystemd0)|h085a93f_1|hd0affe5_2|torch-cuda on linux-64|
|[libudev1](https://prefix.dev/channels/conda-forge/packages/libudev1)|h085a93f_1|hd0affe5_2|torch-cuda on linux-64|
|[llvm-openmp](https://prefix.dev/channels/conda-forge/packages/llvm-openmp)|hfa2b4ca_0|h4fa8253_2|{array-api-cpu, array-api-strict, build-cpu, dask-cpu, scipy-openblas, torch-cpu} on win-64|
|[llvm-openmp](https://prefix.dev/channels/conda-forge/packages/llvm-openmp)|h4a912ad_0|h4a912ad_2|{accelerate-ilp64, accelerate-lp64, array-api-cpu, array-api-strict, build, build-accelerate-ilp64, build-accelerate-lp64, build-cpu, build-debug, dask-cpu, docs, ipython, jax-cpu, lldb, py311-system-libs-osx, scipy-openblas, test, torch-cpu} on osx-arm64|
|[llvm-openmp](https://prefix.dev/channels/conda-forge/packages/llvm-openmp)|h4922eb0_0|h4922eb0_2|{array-api-cpu, array-api-strict, build-cpu, dask-cpu, jax-cpu, jax-cuda, torch-cpu, torch-cuda} on linux-64|
|[openblas](https://prefix.dev/channels/conda-forge/packages/openblas)|pthreads_h6ec200e_3|pthreads_h6ec200e_4|{build, build-cuda, build-debug, cupy, gdb, ipython, py311-system-libs-osx, scipy-openblas, test} on linux-64|
|[openblas](https://prefix.dev/channels/conda-forge/packages/openblas)|pthreads_h4a7f399_3|pthreads_h4a7f399_4|ipython on win-64|
|[python_abi](https://prefix.dev/channels/conda-forge/packages/python_abi)|8_cp314|8_cp314t|scipy-openblas on win-64|
|[scipy](https://prefix.dev/channels/conda-forge/packages/scipy)|py313h11c21cd_0|py313h11c21cd_1|{array-api-cpu, jax-cpu, jax-cuda} on linux-64|
|[scipy](https://prefix.dev/channels/conda-forge/packages/scipy)|py313h0d10b07_0|py313h0d10b07_1|{array-api-cpu, jax-cpu} on osx-arm64|
|[scipy](https://prefix.dev/channels/conda-forge/packages/scipy)|py311h2734c94_0|py311h2734c94_1|py311-system-libs-osx on osx-arm64|
|[scipy](https://prefix.dev/channels/conda-forge/packages/scipy)|py311h1e13796_0|py311h1e13796_1|py311-system-libs-osx on linux-64|
|[tk](https://prefix.dev/channels/conda-forge/packages/tk)|noxft_hd72426e_102|noxft_ha0e22de_103|{array-api-cpu, array-api-strict, build, build-cpu, build-cuda, build-debug, cupy, dask-cpu, default, docs, gdb, ipython, jax-cpu, jax-cuda, lint, py311-system-libs-osx, scipy-openblas, test, torch-cpu, torch-cuda} on linux-64|
|[tk](https://prefix.dev/channels/conda-forge/packages/tk)|h892fb3f_2|h892fb3f_3|{accelerate-ilp64, accelerate-lp64, array-api-cpu, array-api-strict, build, build-accelerate-ilp64, build-accelerate-lp64, build-cpu, build-debug, dask-cpu, default, docs, ipython, jax-cpu, lint, lldb, py311-system-libs-osx, scipy-openblas, test, torch-cpu} on osx-arm64|
|[tk](https://prefix.dev/channels/conda-forge/packages/tk)|h2c6b04d_2|h2c6b04d_3|{array-api-cpu, array-api-strict, build, build-cpu, dask-cpu, default, docs, ipython, lint, scipy-openblas, test, torch-cpu} on win-64|
|[unicodedata2](https://prefix.dev/channels/conda-forge/packages/unicodedata2)|py314h5bd0f2a_0|py314h5bd0f2a_1|docs on linux-64|
|[unicodedata2](https://prefix.dev/channels/conda-forge/packages/unicodedata2)|py314h5a2d7ad_0|py314h5a2d7ad_1|docs on win-64|
|[unicodedata2](https://prefix.dev/channels/conda-forge/packages/unicodedata2)|py314h0612a62_0|py314h0612a62_1|docs on osx-arm64|
|[xorg-libxau](https://prefix.dev/channels/conda-forge/packages/xorg-libxau)|h5505292_0|hc919400_1|docs on osx-arm64|
|[xorg-libxau](https://prefix.dev/channels/conda-forge/packages/xorg-libxau)|h0e40799_0|hba3369d_1|docs on win-64|
|[xorg-libxau](https://prefix.dev/channels/conda-forge/packages/xorg-libxau)|hb9d3cd8_0|hb03c661_1|docs on linux-64|
|[xorg-libxdmcp](https://prefix.dev/channels/conda-forge/packages/xorg-libxdmcp)|hd74edd7_0|hc919400_1|docs on osx-arm64|
|[xorg-libxdmcp](https://prefix.dev/channels/conda-forge/packages/xorg-libxdmcp)|h0e40799_0|hba3369d_1|docs on win-64|
|[xorg-libxdmcp](https://prefix.dev/channels/conda-forge/packages/xorg-libxdmcp)|hb9d3cd8_0|hb03c661_1|docs on linux-64|

</details>

[^1]: **Bold** means explicit dependency.
[^2]: Dependency got downgraded.
