### PR TITLE
MAINT: stats: re-enable the "unused function" warning in qmc and ckdtree

### DIFF
--- a/scipy/spatial/meson.build
+++ b/scipy/spatial/meson.build
@@ -36,7 +36,7 @@ ckdtree_src = [
 
 py3.extension_module('_ckdtree',
   ckdtree_src + [cython_gen_cpp.process('_ckdtree.pyx')],
-  cpp_args: [cython_cpp_args, _cpp_Wno_unused_function],
+  cpp_args: cython_cpp_args,
   include_directories: [
     '../_lib',
     '../_build_utils/src',

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -48,7 +48,7 @@ py3.install_sources([
 
 py3.extension_module('_qmc_cy',
   cython_gen_cpp.process('_qmc_cy.pyx'),
-  cpp_args: [cython_cpp_args, _cpp_Wno_unused_function],
+  cpp_args: cython_cpp_args,
   dependencies: [np_dep, thread_dep],
   link_args: version_link_args,
   install: true,


### PR DESCRIPTION
#### Reference issue

In order to fix issue #23932, PR #23952 silenced an "unused function" warning originating from Cython incorrectly detecting a dependency of some C code.


#### What does this implement/fix?


Cython has fixed this upstream in https://github.com/cython/cython/pull/7293, and the fix is included in Cython 3.2.1, so we don't need to ignore this any more. Re-enable the warning to catch future issues.

#### Additional information
<!--Any additional information you think is important.-->
