### PR TITLE
CI: use stable numpy release in free-threading job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -480,10 +480,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        # Needs nightly numpy build until the 2.3.x release for Python 3.14 support
-        # pip install -r requirements/build.txt
-        pip install -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy
-        pip install meson-python Cython pybind11 pythran ninja
+        pip install -r requirements/build.txt
         pip install -r requirements/openblas.txt
         pip install spin pytest pytest-xdist threadpoolctl pooch hypothesis "click<8.3.0"
 


### PR DESCRIPTION
This was an overdue change anyway, and also makes the job green again by avoiding the set of failures that's due to changes in `numpy`'s main branch visible on the pre-release job right now (see gh-23997).