### PR TITLE
MAINT: removes a reference cycle in `optimize.differential_evolution`

### DIFF
--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -796,6 +796,7 @@ class DifferentialEvolutionSolver:
                     'currenttobest1exp': '_currenttobest1',
                     'best2exp': '_best2',
                     'rand2exp': '_rand2'}
+    __combined = _binomial | _exponential
 
     __init_error_msg = ("The population initialization method must be one of "
                         "'latinhypercube' or 'random', or an array of shape "
@@ -813,9 +814,9 @@ class DifferentialEvolutionSolver:
             # a callable strategy is going to be stored in self.strategy anyway
             pass
         elif strategy in self._binomial:
-            self.mutation_func = getattr(self, self._binomial[strategy])
+            pass
         elif strategy in self._exponential:
-            self.mutation_func = getattr(self, self._exponential[strategy])
+            pass
         else:
             raise ValueError("Please select a valid mutation strategy")
         self.strategy = strategy
@@ -1027,6 +1028,10 @@ class DifferentialEvolutionSolver:
         # rather than repeatedly creating it in _select_samples.
         self._random_population_index = np.arange(self.num_population_members)
         self.disp = disp
+
+    @property
+    def mutation_func(self):
+        return getattr(self, self.__combined[self.strategy])
 
     def init_population_lhs(self):
         """

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -813,11 +813,7 @@ class DifferentialEvolutionSolver:
         if callable(strategy):
             # a callable strategy is going to be stored in self.strategy anyway
             pass
-        elif strategy in self._binomial:
-            pass
-        elif strategy in self._exponential:
-            pass
-        else:
+        elif strategy not in self.__combined:
             raise ValueError("Please select a valid mutation strategy")
         self.strategy = strategy
 

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -5,6 +5,7 @@ from multiprocessing.dummy import Pool as ThreadPool
 import platform
 import warnings
 
+from scipy._lib._gcutils import assert_deallocated
 from scipy.optimize._differentialevolution import (DifferentialEvolutionSolver,
                                                    _ConstraintWrapper)
 from scipy.optimize import differential_evolution, OptimizeResult
@@ -1751,3 +1752,7 @@ class TestDifferentialEvolutionSolver:
                 bounds,
                 strategy=custom_strategy_fn
             )
+
+    def test_reference_cycles(self):
+        with assert_deallocated(DifferentialEvolutionSolver, rosen, [(0, 10)]*2):
+            pass


### PR DESCRIPTION
Related to #23080.
See cycle in https://github.com/scipy/scipy/issues/23080#issuecomment-3539620010

Script used to detect cycle:
```python
import multiprocessing
import numpy as np
from scipy.optimize import rosen, differential_evolution
import refcycle
import gc


if __name__ == "__main__":
    rng = np.random.default_rng()
    
    for i in range(10):
        x0 = rng.uniform(-20, 20, size=6)
        differential_evolution(rosen, [(-20, 20)]*6, polish=False)

        graph = refcycle.garbage()
        print(graph)
        print(len(graph))
        graph.export_image(f'garbage{i}.svg')
        del graph
        gc.collect()
```