### PR TITLE
TST: optimize.least_squares: reduce process count and thread count in `BaseMixin.test_workers`

### DIFF
--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -405,7 +405,7 @@ class BaseMixin:
                 fun_trivial, 2.0, method=self.method, workers=workers
             )
             reses.append(res)
-        with Pool() as workers:
+        with Pool(2) as workers:
             res = least_squares(
                 fun_trivial, 2.0, method=self.method, workers=workers.map
             )

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -394,7 +394,9 @@ class BaseMixin:
                                 method=self.method)
             assert_allclose(res.x, x_opt)
 
-    @pytest.mark.parallel_threads(4)  # 0.4 GiB per thread RAM usage
+    # This test is thread safe, but it is too slow and opens
+    # too many file descriptors to run it in parallel.
+    @pytest.mark.parallel_threads(1)
     @pytest.mark.fail_slow(5.0)
     def test_workers(self):
         serial = least_squares(fun_trivial, 2.0, method=self.method)


### PR DESCRIPTION


#### Reference issue

Partial fix for #23080 

#### What does this implement/fix?

* Currently, the `test_workers` test case calls `multiprocessing.Pool()` without arguments. This causes it to open as many subprocesses as we have logical cores. Change this to only open two subprocesses.
* When `pytest-run-parallel` is installed, disable multithreaded test.

#### How this PR was tested

The following shell script was used to count the number of open pipes.

```
# Sum of open pipes over all processes matching some pattern
# Run this a few seconds after the collection phase of the test suite has completed,
# in order to pick out the right process ID
max=0
zero_count=0
while sleep 0.1; do
    ps -eo pid,pcpu,comm | grep python@3.13 | sort -k2 -nr | awk '{print $1}' > pids.txt
    fd_count=0
    while read PYTEST_PID; do 
        COUNT=$(lsof -p $PYTEST_PID 2>/dev/null | grep -E "(PSXSEM|PIPE)" | wc -l)
        # echo "$(date): $PYTEST_PID: PSXSEM+PIPE count: $COUNT"
        fd_count=$((fd_count + COUNT))
    done < pids.txt
    if [ "$fd_count" -ge "$max" ]; then
        max="$fd_count"
    fi
    if [ "$fd_count" -eq 0 ]; then
        zero_count=$((zero_count + 1))
    else
        zero_count=0
    fi
    if [ "$zero_count" -ge 50 ]; then
        echo "exiting, saw $zero_count zeros in a row"
        echo "max pipe count $max"
        exit
    fi
    echo
    echo "$(date): total: PSXSEM+PIPE count: $fd_count"
done
```

Save to `monitor.sh`

This was tested in the following manner.

```
./monitor.sh & spin test -s optimize -v -- -s -k workers
```

The maximum pipe usage is as follows.

Result on main: 582

Result after bf910cfe7e547b95eb9d13b5ab647fd440b9ea4b: 150

Result after 8429af4ceb75aeeb129d06c0c65a2d0ee1a5573c: 42

#### Are there reference cycles in least_squares?

I looked for a reference cycle `least_squares()` that keeps the `workers` argument alive and couldn't find one.

#### Additional information

Although this disables multithreaded testing of `least_squares` combined with multiprocessing, I would argue that this test is not particularly likely to find bugs, as `multiprocessing.Pool` is already extensively tested under multithreading. Other parts of the test cases, such as `test_convergence_with_only_one_tolerance_enabled`, can be used to identify threading issues in `least_squares` itself.

I think it is sufficient to test multithreading and multiprocessing separately, and we don't need a combined test.
<!--Any additional information you think is important.-->
