### PR TITLE
TST: optimize.minimize: make trust-constr test thread safe by not sharing HessianUpdateStrategy

### DIFF
--- a/scipy/optimize/tests/test_minimize_constrained.py
+++ b/scipy/optimize/tests/test_minimize_constrained.py
@@ -466,14 +466,14 @@ class TestTrustRegionConstr:
                         Elec(n_electrons=2, constr_jac='3-point',
                              constr_hess=SR1())]
 
-    @pytest.mark.thread_unsafe(reason="sometimes fails in parallel")
     @pytest.mark.parametrize('prob', list_of_problems)
     @pytest.mark.parametrize('grad', ('prob.grad', '3-point', False))
-    @pytest.mark.parametrize('hess', ("prob.hess", '3-point', SR1(),
-                                      BFGS(exception_strategy='damp_update'),
-                                      BFGS(exception_strategy='skip_update')))
+    @pytest.mark.parametrize('hess', ("prob.hess", '3-point', lambda: SR1(),
+                                      lambda: BFGS(exception_strategy='damp_update'),
+                                      lambda: BFGS(exception_strategy='skip_update')))
     def test_list_of_problems(self, prob, grad, hess):
         grad = prob.grad if grad == "prob.grad" else grad
+        hess = hess() if callable(hess) else hess
         hess = prob.hess if hess == "prob.hess" else hess
         # Remove exceptions
         if (grad in {'2-point', '3-point', 'cs', False} and


### PR DESCRIPTION
#### Reference issue

N/A

#### What does this implement/fix?

There is a test marked as thread-unsafe inside the optimize test suite with the reason `"sometimes fails in parallel"`.

Specifically, this test is thread unsafe because it is parameterized over an object which is mutated. One way to fix this is to create the HessianUpdateStrategy in each test, and avoid sharing them between threads.

If I remove this `thread_unsafe` marker, but don't add the code to avoid sharing HUS, I see the following failures on Python 3.14t when running in parallel.

```
scipy/optimize/tests/test_minimize_constrained.py:497: AssertionError
************************** pytest-run-parallel report **************************
10 tests were skipped because of use of thread-unsafe functionality, to list the tests that were skipped, re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1 in your shell environment
=========================== short test summary info ============================
PARALLEL FAILED scipy/optimize/tests/test__basinhopping.py::Test_Storage::test_lower_f_accepted[True] - assert False is True
PARALLEL FAILED scipy/optimize/tests/test_minimize_constrained.py::TestTrustRegionConstr::test_list_of_problems[hess2-False-prob10] - AssertionError: 
PARALLEL FAILED scipy/optimize/tests/test_minimize_constrained.py::TestTrustRegionConstr::test_list_of_problems[hess3-prob.grad-prob9] - AssertionError: 
PARALLEL FAILED scipy/optimize/tests/test_minimize_constrained.py::TestTrustRegionConstr::test_list_of_problems[hess3-3-point-prob9] - AssertionError: 
PARALLEL FAILED scipy/optimize/tests/test_minimize_constrained.py::TestTrustRegionConstr::test_list_of_problems[hess4-False-prob10] - AssertionError: 
= 3435 passed, 411 skipped, 7 deselected, 12 xfailed, 5 errors in 659.08s (0:10:59) =
```

(The `Test_Storage` error is due to an unrelated change.)

Since adding this work-around, I haven't seen this error re-occur.

#### Additional information
<!--Any additional information you think is important.-->
