### PR TITLE
BUG: Ensure C-contiguous inputs in ``_fitpack_repro._validate_inputs`` & add regression tests

### DIFF
--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -101,10 +101,17 @@ def _validate_inputs(x, y, w, k, s, xb, xe, parametric, periodic=False):
     x = np.asarray(x, dtype=float)
     y = np.asarray(y, dtype=float)
 
+    if not x.flags.c_contiguous:
+        x = x.copy()
+    if not y.flags.c_contiguous:
+        y = y.copy()
+
     if w is None:
         w = np.ones_like(x, dtype=float)
     else:
         w = np.asarray(w, dtype=float)
+        if not w.flags.c_contiguous:
+            w = w.copy()
         if w.ndim != 1:
             raise ValueError(f"{w.ndim = } not implemented yet.")
         if (w < 0).any():

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3697,6 +3697,7 @@ class _TestMakeSplrepBase:
 
     @pytest.mark.parametrize("bc_type", ["periodic", None])
     def test_make_splrep_with_non_c_contiguous_input(self, bc_type):
+          # regression test for https://github.com/scipy/scipy/issues/23371
 
         def check(spl, tck):
             xp_assert_close(spl.t, tck[0])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/23371

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR fixes an inconsistency in FITPACK-based spline construction (``make_splrep``) when users pass non-C-contiguous NumPy arrays (typically created as views such as from ``np.c_[...]``).

Users encounter:

```
ValueError: Expected a 1-dim C contiguous array of dtype = 12.
```

even though the provided inputs (`x`, `y`, `w`) are 1-D arrays of correct `dtype`.
The underlying issue is that `_dierckx`'s C++ routines expect C-contiguous memory, but user input may be a view rather than a base array.

The fix ensures that all input arrays are C-contiguous by copying only when necessary.

#### Additional information
<!--Any additional information you think is important.-->
