### PR TITLE
ENH:linalg: Switch to Cython backend for BLAS/LAPACK Python API

### DIFF
--- a/scipy/linalg/_cython_blas_wrappers.pyx.in
+++ b/scipy/linalg/_cython_blas_wrappers.pyx.in
@@ -1,0 +1,126 @@
+# cython: language_level=3
+# cython: boundscheck=False
+# cython: initializedcheck=False
+
+cimport cython
+cimport numpy as cnp
+cimport scipy.linalg.cython_blas as cblas, scipy.linalg.cython_lapack as clapack
+
+# Import NumPy C API
+cnp.import_array()
+
+import numpy as np
+from scipy.linalg._misc import _datacopied
+
+__all__ = [
+    'srotg', 'drotg', 'crotg', 'zrotg',
+    'srotmg', 'drotmg',
+    'scopy', 'dcopy', 'ccopy', 'zcopy',
+]
+
+{{py:
+
+# Tempita definitions for iterators
+NP = ['float32', 'float64', 'complex64', 'complex128']
+NPR = ['float32', 'float64']
+NPC = ['complex64', 'complex128']
+NPNPR = NP + NPR
+NPNPC = NP + NPC
+
+C = ['float', 'double', 'float complex', 'double complex']
+CR = ['float', 'double']
+CC = ['float complex', 'double complex']
+CCR = C + CR
+CCC = C + CC
+
+
+P = ['s', 'd', 'c', 'z']
+PR = ['s', 'd']
+PC = ['c', 'z']
+PEXT = P + ['cs', 'zd']
+
+CNP = ['NPY_FLOAT32', 'NPY_FLOAT64', 'NPY_COMPLEX64', 'NPY_COMPLEX128']
+}}
+
+
+# -------------------
+# (s,d,c,z)rotg
+# -------------------
+{{for PREFIX,CTYPE,CTYPEREAL in zip(P, C, CR*2)}}
+def {{PREFIX}}rotg({{CTYPE}} a, {{CTYPE}} b):
+    cdef {{CTYPEREAL}} c
+    cdef {{CTYPE}} s
+
+    cblas.{{PREFIX}}rotg(&a, &b, &c, &s)
+
+    return c, s
+{{endfor}}
+
+
+# -------------------
+# (s,d)rotmg
+# -------------------
+{{for PREFIX,CTYPE,NPYTYPE in zip(PR, CR, NPR)}}
+def {{PREFIX}}rotmg({{CTYPE}} d1, {{CTYPE}} d2, {{CTYPE}} b1, {{CTYPE}} b2):
+    cdef cnp.ndarray param = np.empty(5, dtype=np.{{NPYTYPE}})
+    cdef {{CTYPE}} c, s
+    cdef {{CTYPE}}* param_ptr = <{{CTYPE}}*>cnp.PyArray_DATA(param)
+    cblas.{{PREFIX}}rotmg(&d1, &d2, &b1, &b2, param_ptr)
+
+    return d1, d2, b1, param
+{{endfor}}
+
+
+# -------------------
+# (s,d,cs,zd)rot
+# For some reason crot and zrot are not included
+# -------------------
+{{for PREFIX,CTYPE,CARG,SARG,ARRTYPE in zip(P + ['cs', 'zd'], C + CC, CR*3, C + CR, NP + NPC)}}
+def {{PREFIX}}rot(x, y, {{CARG}} c, {{SARG}} s, n = None, bint overwrite_x=False, int offx=0, int incx=1, bint overwrite_y=False, int offy=0, int incy=1):
+    cdef {{CTYPE}}* x_ptr
+    cdef {{CTYPE}}* y_ptr
+    cdef int nn
+
+    xc = np.asfortranarray(x, dtype=np.{{ARRTYPE}})
+    yc = np.asfortranarray(y, dtype=np.{{ARRTYPE}})
+    if (not overwrite_x) and _datacopied(x, xc):
+        xc = xc.copy(order='F')
+
+    if (not overwrite_y) and _datacopied(y, yc):
+        yc = yc.copy(order='F')
+
+    # Validate parameters
+    if (offx < 0) or (offx >= xc.size):
+        raise ValueError(f"offx={offx} out of bounds")
+    if (offy < 0) or (offy >= yc.size):
+        raise ValueError(f"offx={offx} out of bounds")
+
+    # Calculate n if not given
+    if n is None:
+        nn = (xc.size - 1 - offx) // abs(incx) + 1
+    else:
+        nn = n
+
+    if not (nn >= 0):
+        raise ValueError(f"Input n={ n } must be nonpositive")
+
+    # Bounds check
+    if (xc.size - offx < (nn - 1)*abs(incx) + 1):
+        raise ValueError("x array is too short")
+
+    if (yc.size - offy < (nn - 1)*abs(incy) + 1):
+        raise ValueError("y array is too short")
+
+    x_ptr = <{{CTYPE}}*>cnp.PyArray_DATA(xc)
+    y_ptr = <{{CTYPE}}*>cnp.PyArray_DATA(yc)
+
+{{if PREFIX in ['c', 'z']}}
+    clapack.{{PREFIX}}rot(&nn, &x_ptr[offx], &incx, &y_ptr[offy], &incy, &c, &s)
+{{else}}
+    cblas.{{PREFIX}}rot(&nn, &x_ptr[offx], &incx, &y_ptr[offy], &incy, &c, &s)
+{{endif}}
+
+    return xc, yc
+
+{{endfor}}
+

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -61,6 +61,22 @@ fblas_module = custom_target('fblas_module',
     ]
 )
 
+_cython_blas_wrappers_pyx = custom_target('_cython_blas_wrappers',
+  output: '_cython_blas_wrappers.pyx',
+  input: '_cython_blas_wrappers.pyx.in',
+  command: [tempita, '@INPUT@', '-o', '@OUTDIR@']
+)
+
+# _cython_blas_wrappers: Pure Cython BLAS wrappers using C helper functions
+py3.extension_module('_cython_blas_wrappers',
+  linalg_cython_gen.process(_cython_blas_wrappers_pyx),
+  c_args: cython_c_args,
+  dependencies: [np_dep, lapack_dep, blas_dep],
+  link_args: version_link_args,
+  install: true,
+  subdir: 'scipy/linalg'
+)
+
 # Note: we're linking LAPACK on purpose here. For some routines (e.g., spmv)
 # the float/double routines are in BLAS while the complex routines are in
 # LAPACK - we have historically put these in `_fblas`.


### PR DESCRIPTION

#### Reference issue
This is a concrete implementation example for #20682


#### Implementation details

SciPy is very well-known for exposing the low-level blas/lapack routines to Python users with a convenient interface through f2py machinery with its custom wrappers. These are still the work-horse of the entire SciPy linear algebra layer if the code is using `get_blas_func` or `get_lapack_func`. Back in the day, I completed the entire BLAS catalogue but LAPACK is virtually endless and we wrap as requests come in. This was done manually until now to accomodate the most requested subroutines. 

The wrapper files live under `scipy/linalg` folder with the extension `pyf.src`, say an example of this is `fblas_l1.pyf.src`. Within these files we also use the tempita templating engine to wrap them in a concise but very obscure fashion. Obviously, while this has worked for decades, this f2py dependency creates a Fortran dependency. Meanwhile, SciPy also exposes the entire BLAS/LAPACK functions through its Cython wrappers to be used in Cythonized parts of the code. Hence the linkage is already available. Therefore this creates a very strange situation where Cython API exposes the entire BLAS/LAPACK catalogue, but to have it at the Python level, one needs to create f2py wrappers to expose it in the scipy.linalg.blas and scipy.linalg.lapack Python interface and recompile another fblas/flapack binary.

The proposal here is to remove this two headed solution and provide a single linkage and expose both the Cython and the Python API through Cython linkage. 

<img width="741" height="729" alt="image" src="https://github.com/user-attachments/assets/4337517a-3af2-4fde-9e48-2dd1e9007f6f" />



Unfortunately, things get slightly hairy if we were to switch to Cython directly. Cython versions of the subroutines are exposed as is; raw access to the low-level routines. However our Python layer provides a segfault-free interface just as any other module. The main bottleneck against this switch is the very convenient interface that f2py provides in these wrappers. More precisely, you can pass any non/contiguous, C major/Fortran major, arrays or scalar as integers for complex numbers etc. and all is normalized in an excellent fashion and if needed copies of the input arrguments are generated, the functions and the docs are generated automatically (albeit in a rather inflexible style), the arguments passed to BLAS/LAPACK and then the returning arrays are massaged to be returned to the Python user. 

Hence if this goal to succeed, this normalization has to take place at the entrance of each function provided. There should be helper functions that receive 1D arrays 2D arrays scalars and callbacks to accomodate the requirements of specific LAPACK functions. Also the inputs can be array-like or NumPy arrays with different dtypes, (`datetime` included) etc. So we would like to catch these before they cause Fortran segfaults. 

So overall proposed architecture: 

- Cython exposes identical Python wrapper API that currently live under `scipy.linalg.{blas,lapack}`. 
- Within these API members, the input is captured and passed through this normalization library and the input is either copied or passed as is depending on the properness.
- The proper BLAS/LAPACK subroutine is called
- The results are returned and the temporary copies and other auxililary objects are cleaned up.

And if all goes well, then LAPACK wrappers can also be converted as well. 

The main disadvantage of this switch is that we do everything; sanitizing inputs overwrite control etc. It's more work per wrapper. 

#### What is not in scope

Currently our wrappers are very inconsistent and some of them are just wrong. Moreover, some of them return 0-based indices, some return directly fortran indices. It is all over the place. At this point, since this is a copy of the existing API all those, the proposal is to copy everything as is.

Currently this works as follows 

```python
In [1]: import numpy as np
   ...: import scipy.linalg._cython_blas_wrappers as lac

In [2]: lac.crot?
Signature:     
lac.crot(
    x,
    y,
    c,
    s,
    n=None,
    overwrite_x=False,
    offx=0,
    incx=1,
    overwrite_y=False,
    offy=0,
    incy=1,
)
Call signature: lac.crot(*args, **kwargs)
Type:           cython_function_or_method
String form:    <cyfunction crot at 0x7f2d512baa40>
Docstring:      <no docstring>

In [3]: x = np.arange(20)

In [4]: y = np.zeros(20, dtype=int) # Check the conversion

In [5]: lac.crot(x, y, 0.3, 0.7)
Out[5]: 
(array([0.        +0.j, 0.3       +0.j, 0.6       +0.j, 0.90000004+0.j,
        1.2       +0.j, 1.5       +0.j, 1.8000001 +0.j, 2.1000001 +0.j,
        2.4       +0.j, 2.7       +0.j, 3.        +0.j, 3.3000002 +0.j,
        3.6000001 +0.j, 3.9       +0.j, 4.2000003 +0.j, 4.5       +0.j,
        4.8       +0.j, 5.1000004 +0.j, 5.4       +0.j, 5.7000003 +0.j],
       dtype=complex64),
 array([  0.       +0.j,  -0.7      +0.j,  -1.4      +0.j,  -2.1      +0.j,
         -2.8      +0.j,  -3.5      +0.j,  -4.2      +0.j,  -4.9      +0.j,
         -5.6      +0.j,  -6.2999997+0.j,  -7.       +0.j,  -7.7      +0.j,
         -8.4      +0.j,  -9.099999 +0.j,  -9.8      +0.j, -10.5      +0.j,
        -11.2      +0.j, -11.9      +0.j, -12.599999 +0.j, -13.3      +0.j],
       dtype=complex64))

In [6]: y
Out[6]: array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])

In [7]: y = np.arange(20).astype(np.complex64)  # Make y Fortran compliant

In [8]: lac.crot(x, y, 0.3, 0.7, overwrite_y=True)
Out[8]: 
(array([ 0.+0.j,  1.+0.j,  2.+0.j,  3.+0.j,  4.+0.j,  5.+0.j,  6.+0.j,
         7.+0.j,  8.+0.j,  9.+0.j, 10.+0.j, 11.+0.j, 12.+0.j, 13.+0.j,
        14.+0.j, 15.+0.j, 16.+0.j, 17.+0.j, 18.+0.j, 19.+0.j],
       dtype=complex64),
 array([ 0.        +0.j, -0.39999998+0.j, -0.79999995+0.j, -1.1999998 +0.j,
        -1.5999999 +0.j, -2.        +0.j, -2.3999996 +0.j, -2.8       +0.j,
        -3.1999998 +0.j, -3.5999997 +0.j, -4.        +0.j, -4.3999996 +0.j,
        -4.799999  +0.j, -5.1999993 +0.j, -5.6       +0.j, -6.        +0.j,
        -6.3999996 +0.j, -6.799999  +0.j, -7.1999993 +0.j, -7.6       +0.j],
       dtype=complex64))

In [9]: y  # Overwritten
Out[9]: 
array([ 0.        +0.j, -0.39999998+0.j, -0.79999995+0.j, -1.1999998 +0.j,
       -1.5999999 +0.j, -2.        +0.j, -2.3999996 +0.j, -2.8       +0.j,
       -3.1999998 +0.j, -3.5999997 +0.j, -4.        +0.j, -4.3999996 +0.j,
       -4.799999  +0.j, -5.1999993 +0.j, -5.6       +0.j, -6.        +0.j,
       -6.3999996 +0.j, -6.799999  +0.j, -7.1999993 +0.j, -7.6       +0.j],
      dtype=complex64)

```

The documentation and the function signatures are still not up to standards and need to be handled but that's a rather chore for now. The main focus here is to figure out the infra details. Moreover, Cython does not accept input arguments both typed and optional to `None` which is an annoyance if it is going to show up in BLAS calls (see `n` in ?rot example below). It is explicitly recommended to assume a non-value like -1 and test for it which is very C-like clunky band-aid. So that adds extra work in the wrappers

All feedback welcome. 