### PR TITLE
CI: run cache-heavy OneAPI job on main every 2 days to optimize cache usage

### DIFF
--- a/.github/workflows/linux_intel_oneAPI.yml
+++ b/.github/workflows/linux_intel_oneAPI.yml
@@ -8,6 +8,15 @@ on:
     branches:
       - main
       - maintenance/**
+  schedule:
+  #        ┌───────────── minute (0 - 59)
+  #        │  ┌───────────── hour (0 - 23)
+  #        │  │  ┌───────────── day of the month (1 - 31)
+  #        │  │  │  ┌───────────── month (1 - 12 or JAN-DEC)
+  #        │  │  │  │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+  #        │  │  │  │ │
+  - cron: "9  9 2/2 * *"
+  push:
 
 permissions:
    contents: read  # to fetch code (actions/checkout)

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -12,11 +12,11 @@ on:
   schedule:
   #        ┌───────────── minute (0 - 59)
   #        │  ┌───────────── hour (0 - 23)
-  #        │  │ ┌───────────── day of the month (1 - 31)
-  #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-  #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-  #        │  │ │ │ │
-  - cron: "9  9 * * *"
+  #        │  │  ┌──────────── day of the month (1 - 31)
+  #        │  │  │  ┌───────────── month (1 - 12 or JAN-DEC)
+  #        │  │  │  │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+  #        │  │  │  │ │
+  - cron: "9  9 */2 * *"
   push:
     branches:
       - maintenance/**


### PR DESCRIPTION
This will ensure that the GitHub cache is populated better, so CI jobs don't save their own cache per job. PRs from forks can use cache entries created by a previous run on the `main` branch, but not those created by another PR.

This particular job is by far the most cache space-hungry one, with one entry of 3.1 GB and another of 670 MB.

See gh-21491 for more details.

Also reduce the frequency of wheel build runs from daily to every other day. It seems unnecessary to run daily, that's a very heavy CI load nowadays for no real reason. The NumPy nightlies refresh every 4 days for example. Every 2 days is frequent enough.

EDIT: note that I changed only one job on purpose, to verify that it really works. Some of the other jobs with high cache space usage are being optimized in gh-23987.