### PR TITLE
TST: integrate.qmc_quad: tolerance bump

### DIFF
--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -445,7 +445,7 @@ class TestQMCQuad:
                           xp.asarray(a, dtype=dtype), xp.asarray(b, dtype=dtype),
                           n_points=n_points, n_estimates=n_estimates,
                           log=True, qrng=qrng)
-        rtol = 1e-14 if res.integral.dtype == xp.float64 else 1.1e-6
+        rtol = 1e-14 if res.integral.dtype == xp.float64 else 2e-6
         xp_assert_close(xp.real(xp.exp(logres.integral)), res.integral, rtol=rtol)
         assert xp.imag(logres.integral + 0j) == (xp.pi if np.prod(signs) < 0 else 0)
         xp_assert_close(xp.exp(logres.standard_error),


### PR DESCRIPTION
#### Reference issue
Addresses https://github.com/scipy/scipy/pull/23667#issuecomment-3543962761

#### What does this implement/fix?
Tolerance bump in `qmc_quad` test to address torch failure.