### PR TITLE
DOC: stats: add equations for Cramer von Mises functions

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -534,7 +534,7 @@ def _cvm_result_to_tuple(res, _):
 @_axis_nan_policy_factory(CramerVonMisesResult, n_samples=1, too_small=1,
                           result_to_tuple=_cvm_result_to_tuple)
 def cramervonmises(rvs, cdf, args=(), *, axis=0):
-    """Perform the one-sample Cramér-von Mises test for goodness of fit.
+    r"""Perform the one-sample Cramér-von Mises test for goodness of fit.
 
     This performs a test of the goodness of fit of a cumulative distribution
     function (cdf) :math:`F` compared to the empirical distribution function
@@ -542,6 +542,13 @@ def cramervonmises(rvs, cdf, args=(), *, axis=0):
     assumed to be independent and identically distributed ([1]_).
     The null hypothesis is that the :math:`X_i` have cumulative distribution
     :math:`F`.
+
+    The test statistic :math:`T` is defined as in [1]_, where :math:`\omega^2`
+    is the Cramér-von Mises criterion and :math:`x_i` are the observed values.
+
+    .. math::
+        T = n\omega^2 =
+        \frac{1}{12n} + \sum_{i=1}^n \left[ \frac{2i-1}{2n} - F(x_i) \right]^2
 
     Parameters
     ----------
@@ -565,7 +572,7 @@ def cramervonmises(rvs, cdf, args=(), *, axis=0):
     -------
     res : object with attributes
         statistic : float
-            Cramér-von Mises statistic.
+            Cramér-von Mises statistic :math:`T`.
         pvalue : float
             The p-value.
 
@@ -1629,12 +1636,26 @@ def _pval_cvm_2samp_asymptotic(t, N, nx, ny, k, *, xp):
 @_axis_nan_policy_factory(CramerVonMisesResult, n_samples=2, too_small=1,
                           result_to_tuple=_cvm_result_to_tuple)
 def cramervonmises_2samp(x, y, method='auto', *, axis=0):
-    """Perform the two-sample Cramér-von Mises test for goodness of fit.
+    r"""Perform the two-sample Cramér-von Mises test for goodness of fit.
 
     This is the two-sample version of the Cramér-von Mises test ([1]_):
     for two independent samples :math:`X_1, ..., X_n` and
     :math:`Y_1, ..., Y_m`, the null hypothesis is that the samples
     come from the same (unspecified) continuous distribution.
+
+    The test statistic :math:`T` is defined as in [1]_:
+
+    .. math::
+        T = \frac{nm}{n+m}\omega^2 =
+        \frac{U}{n m (n+m)} - \frac{4 m n - 1}{6(m+n)}
+
+    where :math:`U` is defined as below, and :math:`\omega^2` is the Cramér-von
+    Mises criterion. The function :math:`r(\cdot)` here denotes the rank of the
+    observed values :math:`x_i` and :math:`y_j` within the pooled sample of size
+    :math:`n + m`, with ties assigned mid-rank values:
+
+    .. math::
+        U = n \sum_{i=1}^n (r(x_i)-i)^2 + m \sum_{j=1}^m (r(y_j)-j)^2
 
     Parameters
     ----------
@@ -1657,7 +1678,7 @@ def cramervonmises_2samp(x, y, method='auto', *, axis=0):
     -------
     res : object with attributes
         statistic : float
-            Cramér-von Mises statistic.
+            Cramér-von Mises statistic :math:`T`.
         pvalue : float
             The p-value.
 


### PR DESCRIPTION
[docs only]

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Adds equations for the one-sample and two-sample Cramer-von Mises statistics. Previously it was a little ambiguous whether the sample-size-weighted or unweighted values were being calculated.

There are a lot of functions in stats that could use similar clarification, but this is the one I was working with today. :)

#### Additional information
Here's code showing the equivalence to a naive implementation that matches the equations:

```python
import numpy as np
from scipy.stats import cramervonmises, cramervonmises_2samp, rankdata, norm

def cvm_1sample_naive(x, cdf):
    x = np.sort(np.asarray(x))
    n = len(x)
    F = cdf(x)
    i = np.arange(1, n+1)
    return 1/(12*n) + np.sum(((2*i - 1)/(2*n) - F)**2)

def cvm_2sample_naive(x, y):
    n, m = len(x), len(y)

    z = np.concatenate([x, y])
    r = rankdata(z, method="average")
    rx = r[:n]
    ry = r[n:]

    rx_sorted = rx[np.argsort(x)]
    ry_sorted = ry[np.argsort(y)]
    i = np.arange(1, n+1)
    j = np.arange(1, m+1)

    U = n * np.sum((rx_sorted - i)**2) + m * np.sum((ry_sorted - j)**2)
    return U / (n*m*(n+m)) - (4*n*m - 1)/(6*(n+m))

rng = np.random.default_rng(0)

x = rng.normal(size=200)
s1 = cramervonmises(x, norm.cdf).statistic
n1 = cvm_1sample_naive(x, norm.cdf)

x = rng.normal(size=50)
y = rng.normal(size=40)
s2 = cramervonmises_2samp(x, y).statistic
n2 = cvm_2sample_naive(x, y)

errors = (s1 - n1, s2 - n2)
print((s1, n1, errors[0]))
print((s2, n2, errors[1]))
```

```
(0.04009744261640295, 0.04009744261640295, 0.0)
(0.05531481481481393, 0.05531481481481393, 0.0)
```
