### PR TITLE
ENH: stats.anderson: add `method` parameter

### DIFF
--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -968,7 +968,7 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
 
     >>> import numpy as np
     >>> from scipy import stats
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(1638083107694713882823079058616272161)
     >>> x = stats.uniform.rvs(size=75, random_state=rng)
 
     were sampled from a normal distribution. To perform a KS test, the
@@ -1028,8 +1028,7 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
     calculated exactly and is tyically approximated using Monte Carlo methods
     as described above. This is where `goodness_of_fit` excels.
 
-    >>> res = stats.goodness_of_fit(stats.norm, x, statistic='ks',
-    ...                             rng=rng)
+    >>> res = stats.goodness_of_fit(stats.norm, x, statistic='ks', rng=rng)
     >>> res.statistic, res.pvalue
     (0.1119257570456813, 0.0196)
 
@@ -1043,25 +1042,21 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
     statistic - resulting in a higher test power - can be used now that we can
     approximate the null distribution
     computationally. The Anderson-Darling statistic [1]_ tends to be more
-    sensitive, and critical values of the this statistic have been tabulated
+    sensitive, and critical values of this statistic have been tabulated
     for various significance levels and sample sizes using Monte Carlo methods.
 
-    >>> res = stats.anderson(x, 'norm')
+    >>> res = stats.anderson(x, 'norm', method='interpolate')
     >>> print(res.statistic)
     1.2139573337497467
-    >>> print(res.critical_values)
-    [0.555 0.625 0.744 0.864 1.024]
-    >>> print(res.significance_level)
-    [15.  10.   5.   2.5  1. ]
+    >>> print(res.pvalue)
+    0.01
 
     Here, the observed value of the statistic exceeds the critical value
     corresponding with a 1% significance level. This tells us that the p-value
-    of the observed data is less than 1%, but what is it? We could interpolate
-    from these (already-interpolated) values, but `goodness_of_fit` can
+    of the observed data is 1% or less, but what is it? `goodness_of_fit` can
     estimate it directly.
 
-    >>> res = stats.goodness_of_fit(stats.norm, x, statistic='ad',
-    ...                             rng=rng)
+    >>> res = stats.goodness_of_fit(stats.norm, x, statistic='ad', rng=rng)
     >>> res.statistic, res.pvalue
     (1.2139573337497467, 0.0034)
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2229,7 +2229,7 @@ def anderson(x, dist='norm', *, method=None):
         If `method` is an instance of `MonteCarloMetod`, the p-value is computed using
         `scipy.stats.monte_carlo_test` with the provided configuration options and other
         appropriate settings.
-        
+
         .. versionadded:: 1.17.0
             If `method` is not specified, `anderson` will emit a ``FutureWarning``
             specifying that the user must opt into a p-value calculation method.
@@ -2256,7 +2256,7 @@ def anderson(x, dist='norm', *, method=None):
         fit_result : `~scipy.stats._result_classes.FitResult`
             An object containing the results of fitting the distribution to
             the data.
-            
+
         If `method` is provided, this is an object with the following attributes:
 
         statistic : float
@@ -2264,7 +2264,7 @@ def anderson(x, dist='norm', *, method=None):
         pvalue: float
             The p-value corresponding with the test statistic, calculated according to
             the specified `method`.
-            
+
         .. deprecated :: 1.17.0
             The tuple-unpacking behavior of the return object and attributes
             ``critical_values``, ``significance_level``, and ``fit_result`` are
@@ -2452,14 +2452,14 @@ def anderson(x, dist='norm', *, method=None):
         elif isinstance(method, stats.MonteCarloMethod):
             method = method._asdict()
             if method.pop('rvs', False):
-                message = ("The `rvs` attribute of a `MonteCarloMethod` object passed "
-                           "as the `method` parameter of `scipy.stats.anderson` is "
-                           "ignored.")
+                message = ("The `rvs` attribute of a `MonteCarloMethod` object "
+                           "passed as the `method` parameter of `scipy.stats.anderson` "
+                           "is ignored.")
                 warnings.warn(message, UserWarning, stacklevel=2)
             if method.pop('batch', False):
-                message = ("The `batch` attribute of a `MonteCarloMethod` object passed "
-                           "as the `method` parameter of `scipy.stats.anderson` is "
-                           "ignored.")
+                message = ("The `batch` attribute of a `MonteCarloMethod` object "
+                           "passed as the `method` parameter of `scipy.stats.anderson` "
+                           "is ignored.")
                 warnings.warn(message, UserWarning, stacklevel=2)
             method['n_mc_samples'] = method.pop('n_resamples')
 
@@ -2469,7 +2469,6 @@ def anderson(x, dist='norm', *, method=None):
 
             dist = getattr(stats, dist)
             res = stats.goodness_of_fit(dist, x, statistic='ad', **kwargs, **method)
-            print(res.statistic, res.pvalue)
             pvalue = res.pvalue
         else:
             message = ("`method` must be either 'interpolate' or an instance of"

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -2242,6 +2242,14 @@ def anderson(x, dist='norm', *, method=None):
     Returns
     -------
     result : AndersonResult
+        If `method` is provided, this is an object with the following attributes:
+
+        statistic : float
+            The Anderson-Darling test statistic.
+        pvalue: float
+            The p-value corresponding with the test statistic, calculated according to
+            the specified `method`.
+
         If `method` is unspecified, this is an object with the following attributes:
 
         statistic : float
@@ -2256,14 +2264,6 @@ def anderson(x, dist='norm', *, method=None):
         fit_result : `~scipy.stats._result_classes.FitResult`
             An object containing the results of fitting the distribution to
             the data.
-
-        If `method` is provided, this is an object with the following attributes:
-
-        statistic : float
-            The Anderson-Darling test statistic.
-        pvalue: float
-            The p-value corresponding with the test statistic, calculated according to
-            the specified `method`.
 
         .. deprecated :: 1.17.0
             The tuple-unpacking behavior of the return object and attributes

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -916,11 +916,10 @@ class TestGoodnessOfFit:
         # c that produced critical value of statistic found w/ root_scalar
         x = stats.genextreme(0.051896837188595134, loc=0.5,
                              scale=1.5).rvs(size=1000, random_state=rng)
-        res = goodness_of_fit(stats.gumbel_r, x, statistic='ad',
-                              rng=rng)
-        ref = stats.anderson(x, dist='gumbel_r')
-        assert_allclose(res.statistic, ref.critical_values[0])
-        assert_allclose(res.pvalue, ref.significance_level[0]/100, atol=5e-3)
+        res = goodness_of_fit(stats.gumbel_r, x, statistic='ad', rng=rng)
+        ref = stats.anderson(x, dist='gumbel_r', method='interpolate')
+        assert_allclose(res.statistic, ref.statistic)
+        assert_allclose(res.pvalue, ref.pvalue, atol=5e-3)
 
     def test_against_filliben_norm(self):
         # Test against `stats.fit` ref. [7] Section 8 "Example"

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -252,6 +252,7 @@ class TestShapiro:
         assert_allclose(res.pvalue, 0.2313666489882, rtol=1e-6)
 
 
+@pytest.mark.filterwarnings("ignore: As of SciPy 1.17: FutureWarning")
 class TestAnderson:
     def test_normal(self):
         rs = RandomState(1234567890)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -406,7 +406,7 @@ class TestAndersonMethod:
     def test_method_input_validation(self):
         message = "`method` must be either..."
         with pytest.raises(ValueError, match=message):
-            stats.anderson([1, 2, 3], 'norm', method='ekki-ekii')
+            stats.anderson([1, 2, 3], 'norm', method='ekki-ekki')
 
     def test_monte_carlo_method(self):
         rng = np.random.default_rng(94982389149239)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -397,6 +397,88 @@ class TestAnderson:
         assert_equal(_get_As_weibull(1/m), _Avals_weibull[0])
 
 
+class TestAndersonMethod:
+    def test_warning(self):
+        message = "As of SciPy 1.17, users..."
+        with pytest.warns(FutureWarning, match=message):
+            stats.anderson([1, 2, 3], 'norm')
+
+    def test_method_input_validation(self):
+        message = "`method` must be either..."
+        with pytest.raises(ValueError, match=message):
+            stats.anderson([1, 2, 3], 'norm', method='ekki-ekii')
+
+    def test_monte_carlo_method(self):
+        rng = np.random.default_rng(94982389149239)
+
+        message = "The `rvs` attribute..."
+        with pytest.warns(UserWarning, match=message):
+            method = stats.MonteCarloMethod(rvs=rng.random)
+            stats.anderson([1, 2, 3], 'norm', method=method)
+
+        message = "The `batch` attribute..."
+        with pytest.warns(UserWarning, match=message):
+            method = stats.MonteCarloMethod(batch=10)
+            stats.anderson([1, 2, 3], 'norm', method=method)
+
+        method = stats.MonteCarloMethod(n_resamples=9, rng=rng)
+        res = stats.anderson([1, 2, 3], 'norm', method=method)
+        ten_p = res.pvalue * 10
+        # p-value will always be divisible by n_resamples + 1
+        assert np.round(ten_p) == ten_p
+
+        method = stats.MonteCarloMethod(rng=np.random.default_rng(23495984827))
+        ref = stats.anderson([1, 2, 3, 4, 5], 'norm', method=method)
+        method = stats.MonteCarloMethod(rng=np.random.default_rng(23495984827))
+        res = stats.anderson([1, 2, 3, 4, 5], 'norm', method=method)
+        assert res.pvalue == ref.pvalue  # same random state -> same p-value
+        method = stats.MonteCarloMethod(rng=np.random.default_rng(23495984828))
+        res = stats.anderson([1, 2, 3, 4, 5], 'norm', method=method)
+        assert res.pvalue != ref.pvalue  # different random state -> different p-value
+
+    @pytest.mark.parametrize('dist_name, seed',
+        [('norm', 4202165767275),
+         ('expon', 9094400417269),
+         pytest.param('logistic', 3776634590070, marks=pytest.mark.xslow),
+         pytest.param('gumbel_l', 7966588969335, marks=pytest.mark.xslow),
+         pytest.param('gumbel_r', 1886450383828, marks=pytest.mark.xslow)])
+    def test_method_consistency(self, dist_name, seed):
+        dist = getattr(stats, dist_name)
+        rng = np.random.default_rng(seed)
+        x = dist.rvs(size=50, random_state=rng)
+        ref = stats.anderson(x, dist_name, method='interpolate')
+        res = stats.anderson(x, dist_name, method=stats.MonteCarloMethod(rng=rng))
+        np.testing.assert_allclose(res.statistic, ref.statistic)
+        np.testing.assert_allclose(res.pvalue, ref.pvalue, atol=0.005)
+
+    @pytest.mark.parametrize('dist_name',
+        ['norm', 'expon', 'logistic', 'gumbel_l', 'gumbel_r', 'weibull_min'])
+    def test_interpolate_saturation(self, dist_name):
+        dist = getattr(stats, dist_name)
+        rng = np.random.default_rng(4202165767276)
+        args = (3.5,) if dist_name == 'weibull_min' else tuple()
+        x = dist.rvs(*args, size=50, random_state=rng)
+
+        with pytest.warns(FutureWarning):
+            res = stats.anderson(x, dist_name)
+        pvalues = (1 - np.asarray(res.significance_level) if dist_name == 'weibull_min'
+                   else np.asarray(res.significance_level) / 100)
+        pvalue_min = np.min(pvalues)
+        pvalue_max = np.max(pvalues)
+        statistic_min = np.min(res.critical_values)
+        statistic_max = np.max(res.critical_values)
+
+        # data drawn from distribution -> low statistic / high p-value
+        res = stats.anderson(x, dist_name, method='interpolate')
+        assert res.statistic < statistic_min
+        assert res.pvalue == pvalue_max
+
+        # data not from distribution -> high statistic / low p-value
+        res = stats.anderson(rng.random(size=50), dist_name, method='interpolate')
+        assert res.statistic > statistic_max
+        assert res.pvalue == pvalue_min
+
+
 class TestAndersonKSamp:
     def test_example1a(self):
         # Example data from Scholz & Stephens (1987), originally


### PR DESCRIPTION
#### Reference issue
Addresses `anderson` part of https://github.com/scipy/scipy/issues/23950#issuecomment-3529544183.

#### What does this implement/fix?
This adds a `method` parameter to `scipy.stats.anderson` to allow the user to choose how to compute a p-value. When `method` is not specified, it warns that the user must opt into a p-value calculation method explicitly, and when `method` is specified, it returns a different result object with attributes `statistic` and `pvalue`. See https://github.com/scipy/scipy/issues/23950#issuecomment-3529544183 for discussion.

#### Additional information
~~Marking as draft until I've come back to take a look, but @nickodell @tommie979 you're welcome to take an early look.~~ This is in pretty good shape; I should just investigate `weibull_min` a little.
