### PR TITLE
DEP: deprecate `scipy.odr`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -191,6 +191,9 @@ warnings.filterwarnings(
     category=Warning,
 )
 
+warnings.filterwarnings("ignore", message="`scipy.odr` is deprecated",
+                        category=DeprecationWarning)
+
 # See https://github.com/sphinx-doc/sphinx/issues/12589
 suppress_warnings = [
     'autosummary.import_cycle',
@@ -349,6 +352,7 @@ plot_pre_code = """
 import warnings
 for key in (
         '`kurtosistest` p-value may be',  # intentionally "bad" example in docstring
+        'odr'
         ):
     warnings.filterwarnings(action='ignore', message='.*' + key + '.*')
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,7 @@ filterwarnings =
     ignore:Using the slower implementation::cupy
     ignore:Jitify is performing a one-time only warm-up::cupy
     ignore:.*scipy.misc.*:DeprecationWarning
+    ignore:.*scipy.odr*:DeprecationWarning
     ignore:.*deprecated - use.*:DeprecationWarning
 
 # When updating the markers here, also update them in scipy/conftest.py

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -346,8 +346,6 @@ def test_api_importable():
                           ('scipy.ndimage.interpolation', None),
                           ('scipy.ndimage.measurements', None),
                           ('scipy.ndimage.morphology', None),
-                          ('scipy.odr.models', None),
-                          ('scipy.odr.odrpack', None),
                           ('scipy.optimize.cobyla', None),
                           ('scipy.optimize.lbfgsb', None),
                           ('scipy.optimize.linesearch', None),

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -606,6 +606,7 @@ if HAVE_SCPDT:
                     yield
                 else:
                     warnings.simplefilter('error', Warning)
+                    warnings.filterwarnings('ignore', ".*odr.*", DeprecationWarning)
                     yield
 
     dt_config.user_context_mgr = warnings_errors_and_rng

--- a/scipy/odr/__init__.py
+++ b/scipy/odr/__init__.py
@@ -7,7 +7,7 @@ Orthogonal distance regression (:mod:`scipy.odr`)
 
 .. deprecated:: 1.17.0
     `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-    `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+    `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
     instead.
 
     The following example shows a brief comparison of the APIs::
@@ -167,7 +167,7 @@ __all__ = [s for s in dir()
 
 import warnings
 msg = ("`scipy.odr` is deprecated as of version 1.17.0 and will be removed in "
-        "SciPy 1.19.0. Please use `https://github.com/HugoMVale/odrpack-python`"
+        "SciPy 1.19.0. Please use `https://pypi.org/project/odrpack/`"
         "instead.")
 warnings.warn(msg, DeprecationWarning, stacklevel=2)
 del warnings

--- a/scipy/odr/__init__.py
+++ b/scipy/odr/__init__.py
@@ -167,8 +167,7 @@ __all__ = [s for s in dir()
 
 import warnings
 msg = ("`scipy.odr` is deprecated as of version 1.17.0 and will be removed in "
-        "SciPy 1.19.0. Please use `https://pypi.org/project/odrpack/`"
-        "instead.")
+        "SciPy 1.19.0. Please use `https://pypi.org/project/odrpack/` instead.")
 warnings.warn(msg, DeprecationWarning, stacklevel=2)
 del warnings
 

--- a/scipy/odr/__init__.py
+++ b/scipy/odr/__init__.py
@@ -18,7 +18,7 @@ Orthogonal distance regression (:mod:`scipy.odr`)
 
         # Classic "Pearson data" that motivates ODR.
         # Errors are in both variables, and if you don't account for this,
-        # doing a linear fit of X vs. Y or Y vs. X will give you quit
+        # doing a linear fit of X vs. Y or Y vs. X will give you quite
         # different results.
         p_x = np.array([0., .9, 1.8, 2.6, 3.3, 4.4, 5.2, 6.1, 6.5, 7.4])
         p_y = np.array([5.9, 5.4, 4.4, 4.6, 3.5, 3.7, 2.8, 2.8, 2.4, 1.5])

--- a/scipy/odr/__init__.py
+++ b/scipy/odr/__init__.py
@@ -5,6 +5,45 @@ Orthogonal distance regression (:mod:`scipy.odr`)
 
 .. currentmodule:: scipy.odr
 
+.. deprecated:: 1.17.0
+    `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+    `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+    instead.
+
+    The following example shows a brief comparison of the APIs::
+
+        import numpy as np
+        import scipy.odr
+        import odrpack
+
+        # Classic "Pearson data" that motivates ODR.
+        # Errors are in both variables, and if you don't account for this,
+        # doing a linear fit of X vs. Y or Y vs. X will give you quit
+        # different results.
+        p_x = np.array([0., .9, 1.8, 2.6, 3.3, 4.4, 5.2, 6.1, 6.5, 7.4])
+        p_y = np.array([5.9, 5.4, 4.4, 4.6, 3.5, 3.7, 2.8, 2.8, 2.4, 1.5])
+        p_sx = np.array([.03, .03, .04, .035, .07, .11, .13, .22, .74, 1.])
+        p_sy = np.array([1., .74, .5, .35, .22, .22, .12, .12, .1, .04])
+
+        # Old-style
+        # The RealData class takes care of details like turning
+        # standard-deviation error bars into weights.
+        p_dat = scipy.odr.RealData(p_x, p_y, sx=p_sx, sy=p_sy)
+        # Note, parameters come before `x` in scipy.odr
+        p_mod = scipy.odr.Model(lambda beta, x: beta[0] + beta[1]*x)
+        p_odr = scipy.odr.ODR(p_dat, p_mod, beta0=[1., 1.])
+        old_out = p_odr.run()
+
+        # New-style
+        # Parameters come after data, in the new API.
+        # We must convert the error bars into weights ourselves.
+        new_out = odrpack.odr_fit(lambda x, beta: beta[0] + beta[1] * x,
+            p_x, p_y, beta0=np.array([1.0, 1.0]),
+            weight_x=p_sx**-2, weight_y=p_sy**-2)
+
+        assert np.isclose(old_out.beta, new_out.beta).all()
+
+
 Package Content
 ===============
 
@@ -125,6 +164,14 @@ from . import models, odrpack
 
 __all__ = [s for s in dir()
            if not (s.startswith('_') or s in ('odr_stop', 'odr_error'))]
+
+import warnings
+msg = ("`scipy.odr` is deprecated as of version 1.17.0 and will be removed in "
+        "SciPy 1.19.0. Please use `https://github.com/HugoMVale/odrpack-python`"
+        "instead.")
+warnings.warn(msg, DeprecationWarning, stacklevel=2)
+del warnings
+
 
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)

--- a/scipy/odr/_add_newdocs.py
+++ b/scipy/odr/_add_newdocs.py
@@ -11,7 +11,7 @@ add_newdoc('scipy.odr', 'odr',
 
     .. deprecated:: 1.17.0
         `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
         instead.
 
     See Also

--- a/scipy/odr/_add_newdocs.py
+++ b/scipy/odr/_add_newdocs.py
@@ -9,6 +9,11 @@ add_newdoc('scipy.odr', 'odr',
 
     Low-level function for ODR.
 
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        instead.
+
     See Also
     --------
     ODR : The ODR class gathers all information and coordinates the running of the

--- a/scipy/odr/_models.py
+++ b/scipy/odr/_models.py
@@ -83,6 +83,12 @@ class _MultilinearModel(Model):
     r"""
     Arbitrary-dimensional linear model
 
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
+        instead.
+
+
     This model is defined by :math:`y=\beta_0 + \sum_{i=1}^m \beta_i x_i`
 
     Examples

--- a/scipy/odr/_models.py
+++ b/scipy/odr/_models.py
@@ -119,7 +119,7 @@ def polynomial(order):
 
     .. deprecated:: 1.17.0
         `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
         instead.
 
     Parameters
@@ -185,7 +185,7 @@ class _ExponentialModel(Model):
 
     .. deprecated:: 1.17.0
         `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
         instead.
 
     This model is defined by :math:`y=\beta_0 + e^{\beta_1 x}`
@@ -257,7 +257,7 @@ class _UnilinearModel(Model):
 
     .. deprecated:: 1.17.0
         `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
         instead.
 
     This model is defined by :math:`y = \beta_0 x + \beta_1`
@@ -292,6 +292,11 @@ unilinear = _UnilinearModel()
 class _QuadraticModel(Model):
     r"""
     Quadratic model
+
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
+        instead.
 
     This model is defined by :math:`y = \beta_0 x^2 + \beta_1 x + \beta_2`
 

--- a/scipy/odr/_models.py
+++ b/scipy/odr/_models.py
@@ -117,6 +117,11 @@ def polynomial(order):
     """
     Factory function for a general polynomial model.
 
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        instead.
+
     Parameters
     ----------
     order : int or sequence
@@ -177,6 +182,11 @@ def polynomial(order):
 class _ExponentialModel(Model):
     r"""
     Exponential model
+
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        instead.
 
     This model is defined by :math:`y=\beta_0 + e^{\beta_1 x}`
 
@@ -244,6 +254,11 @@ def _quad_est(data):
 class _UnilinearModel(Model):
     r"""
     Univariate linear model
+
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        instead.
 
     This model is defined by :math:`y = \beta_0 x + \beta_1`
 

--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -187,7 +187,7 @@ class Data:
 
     .. deprecated:: 1.17.0
         `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
         instead.
 
     Parameters
@@ -306,7 +306,7 @@ class RealData(Data):
 
     .. deprecated:: 1.17.0
         `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
         instead.
 
     Parameters
@@ -444,9 +444,9 @@ class Model:
     """
     The Model class stores information about the function you wish to fit.
 
-        .. deprecated:: 1.17.0
+    .. deprecated:: 1.17.0
         `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
         instead.
 
     It stores the function itself, at the least, and optionally stores
@@ -563,7 +563,7 @@ class Output:
 
     .. deprecated:: 1.17.0
         `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
         instead.
 
     Attributes
@@ -647,7 +647,7 @@ class ODR:
 
     .. deprecated:: 1.17.0
         `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
-        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
         instead.
 
     Members of instances of the ODR class have the same names as the arguments

--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -185,6 +185,11 @@ class Data:
     """
     The data to fit.
 
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        instead.
+
     Parameters
     ----------
     x : array_like
@@ -298,6 +303,11 @@ class RealData(Data):
     """
     The data, with weightings as actual standard deviations and/or
     covariances.
+
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        instead.
 
     Parameters
     ----------
@@ -434,6 +444,11 @@ class Model:
     """
     The Model class stores information about the function you wish to fit.
 
+        .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        instead.
+
     It stores the function itself, at the least, and optionally stores
     functions which compute the Jacobians used during fitting. Also, one
     can provide a function that will provide reasonable starting values
@@ -546,6 +561,11 @@ class Output:
     """
     The Output class stores the output of an ODR run.
 
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        instead.
+
     Attributes
     ----------
     beta : ndarray
@@ -624,6 +644,11 @@ class ODR:
     """
     The ODR class gathers all information and coordinates the running of the
     main fitting routine.
+
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `github.com/HugoMVale/odrpack-python <https://github.com/HugoMVale/odrpack-python/>`_
+        instead.
 
     Members of instances of the ODR class have the same names as the arguments
     to the initialization routine.

--- a/scipy/odr/_odrpack.py
+++ b/scipy/odr/_odrpack.py
@@ -55,6 +55,12 @@ class OdrWarning(UserWarning):
     Warning indicating that the data passed into
     ODR will cause problems when passed into 'odr'
     that the user should be aware of.
+
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
+        instead.
+
     """
     pass
 
@@ -62,6 +68,12 @@ class OdrWarning(UserWarning):
 class OdrError(Exception):
     """
     Exception indicating an error in fitting.
+
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
+        instead.
+
 
     This is raised by `~scipy.odr.odr` if an error occurs during fitting.
     """
@@ -71,6 +83,12 @@ class OdrError(Exception):
 class OdrStop(Exception):
     """
     Exception stopping fitting.
+
+    .. deprecated:: 1.17.0
+        `scipy.odr` is deprecated and will be removed in SciPy 1.19.0. Please use
+        `pypi.org/project/odrpack/ <https://pypi.org/project/odrpack/>`_
+        instead.
+
 
     You can raise this exception in your objective function to tell
     `~scipy.odr.odr` to stop fitting.

--- a/scipy/odr/models.py
+++ b/scipy/odr/models.py
@@ -14,14 +14,14 @@ def __dir__():
 
 
 def __getattr__(name):
+    msg = ("`scipy.odr` is deprecated as of version 1.17.0 and will be removed in "
+           "SciPy 1.19.0. Please use `https://pypi.org/project/odrpack/` instead.")
     if name not in __all__:
         raise AttributeError(
-            "`scipy.odr.models` is deprecated and will be removed in SciPy 1.19.0 and "
-            f"has no attribute {name}.")
+            f"`scipy.odr.models` has no attribute {name}. In addition, {msg}")
 
     import warnings
     from . import _models
-    warnings.warn("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0",
-                  category=DeprecationWarning, stacklevel=2)
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
 
     return getattr(_models, name)

--- a/scipy/odr/models.py
+++ b/scipy/odr/models.py
@@ -2,7 +2,6 @@
 # Use the `scipy.odr` namespace for importing the functions
 # included below.
 
-from scipy._lib.deprecation import _sub_module_deprecation
 
 __all__ = [  # noqa: F822
     'Model', 'exponential', 'multilinear', 'unilinear',
@@ -15,6 +14,14 @@ def __dir__():
 
 
 def __getattr__(name):
-    return _sub_module_deprecation(sub_package="odr", module="models",
-                                   private_modules=["_models"], all=__all__,
-                                   attribute=name)
+    if name not in __all__:
+        raise AttributeError(
+            "`scipy.odr.models` is deprecated and will be removed in SciPy 1.19.0 and "
+            f"has no attribute {name}.")
+
+    import warnings
+    from . import _models
+    warnings.warn("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0",
+                  category=DeprecationWarning, stacklevel=2)
+
+    return getattr(_models, name)

--- a/scipy/odr/odrpack.py
+++ b/scipy/odr/odrpack.py
@@ -15,14 +15,14 @@ def __dir__():
 
 
 def __getattr__(name):
+    msg = ("`scipy.odr` is deprecated as of version 1.17.0 and will be removed in "
+           "SciPy 1.19.0. Please use `https://pypi.org/project/odrpack/` instead.")
     if name not in __all__:
         raise AttributeError(
-            "`scipy.odr.odrpack` is deprecated and will be removed in SciPy 1.19.0 and "
-            f"has no attribute {name}.")
+            f"`scipy.odr.odrpack` has no attribute {name}. In addition, {msg}")
 
     import warnings
-    from . import _models
-    warnings.warn("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0",
-                  category=DeprecationWarning, stacklevel=2)
+    from . import _odrpack
+    warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
 
-    return getattr(_models, name)
+    return getattr(_odrpack, name)

--- a/scipy/odr/odrpack.py
+++ b/scipy/odr/odrpack.py
@@ -2,7 +2,6 @@
 # Use the `scipy.odr` namespace for importing the functions
 # included below.
 
-from scipy._lib.deprecation import _sub_module_deprecation
 
 __all__ = [  # noqa: F822
     'odr', 'OdrWarning', 'OdrError', 'OdrStop',
@@ -16,6 +15,14 @@ def __dir__():
 
 
 def __getattr__(name):
-    return _sub_module_deprecation(sub_package="odr", module="odrpack",
-                                   private_modules=["_odrpack"], all=__all__,
-                                   attribute=name)
+    if name not in __all__:
+        raise AttributeError(
+            "`scipy.odr.odrpack` is deprecated and will be removed in SciPy 1.19.0 and "
+            f"has no attribute {name}.")
+
+    import warnings
+    from . import _models
+    warnings.warn("`scipy.odr` is deprecated and will be removed in SciPy 1.19.0",
+                  category=DeprecationWarning, stacklevel=2)
+
+    return getattr(_models, name)


### PR DESCRIPTION
closes #24065
closes #23926
closes #22287
closes #21308
closes #21249
closes #15857
closes #14435
closes #12420
closes #12105
closes #11859
closes #11810
closes #7107
closes #6048

As discussed at https://discuss.scientific-python.org/t/rfc-deprecating-scipy-odr/2166/9 it is time to say good by to `scipy.odr`!