### PR TITLE
TST/MAINT: optimize: thread-safety fixes for COBYQA and tests

### DIFF
--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -344,9 +344,8 @@ class TestBasinHopping:
         assert_almost_equal(res.x, self.sol[i], self.tol)
 
 
-#@pytest.mark.thread_unsafe(reason="unknown thread safety issue")
 class Test_Storage:
-    def setup_method(self):
+    def create_storage(self):
         self.x0 = np.array(1)
         self.f0 = 0
 
@@ -354,27 +353,29 @@ class Test_Storage:
         minres.x = self.x0
         minres.fun = self.f0
 
-        self.storage = Storage(minres)
+        return Storage(minres)
 
     def test_higher_f_rejected(self):
+        storage = self.create_storage()
         new_minres = OptimizeResult(success=True)
         new_minres.x = self.x0 + 1
         new_minres.fun = self.f0 + 1
 
-        ret = self.storage.update(new_minres)
-        minres = self.storage.get_lowest()
+        ret = storage.update(new_minres)
+        minres = storage.get_lowest()
         assert_equal(self.x0, minres.x)
         assert_equal(self.f0, minres.fun)
         assert_(not ret)
 
     @pytest.mark.parametrize('success', [True, False])
     def test_lower_f_accepted(self, success):
+        storage = self.create_storage()
         new_minres = OptimizeResult(success=success)
         new_minres.x = self.x0 + 1
         new_minres.fun = self.f0 - 1
 
-        ret = self.storage.update(new_minres)
-        minres = self.storage.get_lowest()
+        ret = storage.update(new_minres)
+        minres = storage.get_lowest()
         assert (self.x0 != minres.x) == success  # can't use `is`
         assert (self.f0 != minres.fun) == success  # left side is NumPy bool
         assert ret is success

--- a/scipy/optimize/tests/test__basinhopping.py
+++ b/scipy/optimize/tests/test__basinhopping.py
@@ -344,7 +344,7 @@ class TestBasinHopping:
         assert_almost_equal(res.x, self.sol[i], self.tol)
 
 
-@pytest.mark.thread_unsafe(reason="unknown thread safety issue")
+#@pytest.mark.thread_unsafe(reason="unknown thread safety issue")
 class Test_Storage:
     def setup_method(self):
         self.x0 = np.array(1)

--- a/scipy/optimize/tests/test__differential_evolution.py
+++ b/scipy/optimize/tests/test__differential_evolution.py
@@ -262,7 +262,7 @@ class TestDifferentialEvolutionSolver:
         # test that the getter property method for the best solution works.
         solver = DifferentialEvolutionSolver(self.quadratic, [(-2, 2)])
         result = solver.solve()
-        assert_equal(result.x, solver.x)
+        assert_allclose(result.x, solver.x, atol=1e-15, rtol=0)
 
     def test_intermediate_result(self):
         # Check that intermediate result object passed into the callback

--- a/scipy/optimize/tests/test_constraint_conversion.py
+++ b/scipy/optimize/tests/test_constraint_conversion.py
@@ -63,7 +63,7 @@ class TestOldToNew:
 
 class TestNewToOld:
     @pytest.mark.fail_slow(2)
-    def test_multiple_constraint_objects(self, num_parallel_threads):
+    def test_multiple_constraint_objects(self):
         def fun(x):
             return (x[0] - 1) ** 2 + (x[1] - 2.5) ** 2 + (x[2] - 0.75) ** 2
         x0 = [2, 0, 1]
@@ -89,12 +89,11 @@ class TestNewToOld:
                     funs[method] = result.fun
             assert_allclose(funs['slsqp'], funs['trust-constr'], rtol=1e-4)
             assert_allclose(funs['cobyla'], funs['trust-constr'], rtol=1e-4)
-            if num_parallel_threads == 1:
-                assert_allclose(funs['cobyqa'], funs['trust-constr'],
-                                rtol=1e-4)
+            assert_allclose(funs['cobyqa'], funs['trust-constr'],
+                            rtol=1e-4)
 
     @pytest.mark.fail_slow(20)
-    def test_individual_constraint_objects(self, num_parallel_threads):
+    def test_individual_constraint_objects(self):
         def fun(x):
             return (x[0] - 1) ** 2 + (x[1] - 2.5) ** 2 + (x[2] - 0.75) ** 2
         x0 = [2, 0, 1]
@@ -161,9 +160,8 @@ class TestNewToOld:
                     funs[method] = result.fun
             assert_allclose(funs['slsqp'], funs['trust-constr'], rtol=1e-3)
             assert_allclose(funs['cobyla'], funs['trust-constr'], rtol=1e-3)
-            if num_parallel_threads == 1:
-                assert_allclose(funs['cobyqa'], funs['trust-constr'],
-                                rtol=1e-3)
+            assert_allclose(funs['cobyqa'], funs['trust-constr'],
+                            rtol=1e-3)
 
         for con in cone:
             funs = {}
@@ -173,9 +171,8 @@ class TestNewToOld:
                     result = minimize(fun, x0, method=method, constraints=con)
                     funs[method] = result.fun
             assert_allclose(funs['slsqp'], funs['trust-constr'], rtol=1e-3)
-            if num_parallel_threads == 1:
-                assert_allclose(funs['cobyqa'], funs['trust-constr'],
-                                rtol=1e-3)
+            assert_allclose(funs['cobyqa'], funs['trust-constr'],
+                            rtol=1e-3)
 
 
 class TestNewToOldSLSQP:

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -1565,9 +1565,7 @@ class TestOptimizeSimple(CheckOptimize):
                                         'cobyqa', 'slsqp',
                                         'trust-constr', 'dogleg', 'trust-ncg',
                                         'trust-exact', 'trust-krylov'])
-    def test_nan_values(self, method, num_parallel_threads):
-        if num_parallel_threads > 1 and method == 'cobyqa':
-            pytest.skip('COBYQA does not support concurrent execution')
+    def test_nan_values(self, method):
 
         # Check nan values result to failed exit status
 


### PR DESCRIPTION
#### Reference issue

N/A

#### What does this implement/fix?

This PR contains all of the optimize-related fixes from my thread-safety branch.

* A test was marked as `thread_unsafe()` due to shared state. Remove the shared state and marker.
* Tests for COBYQA were being skipped due to a failing test in pytest-run-parallel. Later, we added a lock to prevent concurrent COBYQA calls. https://github.com/scipy/scipy/pull/21496#discussion_r1850653968

  IMO, adding the lock was the right decision. I think the COBYQA issue represented a real thread-safety problem. However, we never took the test skips out again.
* Pull in a thread-safety fix that I got merged upstream for COBYQA. (xref https://github.com/cobyqa/cobyqa/pull/183) I've tested this change in the COBYQA and SciPy test suite. However, the issue it fixes is not reachable when COBYQA's lock is enabled, so it is a low-priority update.
* Fix test tolerance for `test_best_solution_retrieval`. See 27602bc for details.

#### Additional information

I am still seeing pytest-run-parallel test failures on my branch, approx 10% of the time.

```
==> test-optimize-20251121_12:18.log <==
            niter: 1000
self       = <scipy.optimize.tests.test_minimize_constrained.TestTrustRegionConstr object at 0x329d58b74f0>
sensitive  = False

scipy/optimize/tests/test_minimize_constrained.py:497: AssertionError
************************** pytest-run-parallel report **************************
13 tests were skipped because of use of thread-unsafe functionality, to list the tests that were skipped, re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1 in your shell environment
=========================== short test summary info ============================
PARALLEL FAILED scipy/optimize/tests/test_minimize_constrained.py::TestTrustRegionConstr::test_list_of_problems[3-point-prob.grad-prob3] - AssertionError: 
====== 3444 passed, 413 skipped, 14 xfailed, 1 error in 701.32s (0:11:41) ======

==> test-optimize-20251121_15:29.log <==
                 jac: [-1.614e-08]
self       = <scipy.optimize.tests.test__differential_evolution.TestDifferentialEvolutionSolver object at 0x575480c2930>
solver     = <scipy.optimize._differentialevolution.DifferentialEvolutionSolver object at 0x5754e512290>

scipy/optimize/tests/test__differential_evolution.py:265: AssertionError
************************** pytest-run-parallel report **************************
13 tests were skipped because of use of thread-unsafe functionality, to list the tests that were skipped, re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1 in your shell environment
=========================== short test summary info ============================
PARALLEL FAILED scipy/optimize/tests/test__differential_evolution.py::TestDifferentialEvolutionSolver::test_best_solution_retrieval - AssertionError: 
====== 3444 passed, 413 skipped, 14 xfailed, 1 error in 687.46s (0:11:27) ======
```

I've not nailed down why. I am not sure if this is caused by a problem in the test or a problem in the underlying code.
