### PR TITLE
ENH: Add spherical_jn_zeros to scipy.special for educational purpose …

### DIFF
--- a/scipy/special/__init__.py
+++ b/scipy/special/__init__.py
@@ -840,3 +840,6 @@ __all__ += [
 from scipy._lib._testutils import PytestTester
 test = PytestTester(__name__)
 del PytestTester
+
+from .spherical_jn_zeros import spherical_jn_zeros
+

--- a/scipy/special/spherical_jn_zeros.py
+++ b/scipy/special/spherical_jn_zeros.py
@@ -1,0 +1,49 @@
+import numpy as np
+import scipy as scp
+
+def spherical_jn_zeros(l, n_zeros):
+	'''
+ 	 --------------------------------------------------------
+	| Find the first n zeros of the spherical Bessel function |
+ 	 --------------------------------------------------------
+
+	Parameters :
+	--> l : int -- spherical Bessel function's order
+	--> n_zeros : int -- number of roots to find
+
+	Returns :
+	--> zeros : ndarray -- array of roots from the spherical Bessel function
+
+	Notes : 
+	--> Roots are found by using Brent's method
+	--> Each root is searched in an interval estimated by n : [(n+1/2)*pi;(1+n+1/2)*pi
+
+	Examples :
+	---------------
+
+	>>> from scipy.special import spherical_jn_zeros
+	>>> spherical_jn_zeros(0,10)
+	array[ 3.14159265  6.28318531  9.42477796]
+
+	---------------
+
+	>>> from scipy.special import spherical_jn_zeros and spherical_jn
+	>>> spherical_jn(0 ,spherical_jn_zeros(0,3))
+	array[ 3.89804309e-17 -3.89804309e-17  3.89804309e-17]
+	This test confirms the zeros, results are in an order of 10^(-17) so insignificant.
+
+	---------------
+	'''
+	if not isinstance(l, int) or not isinstance(n_zeros, int) or l < 0 or n_zeros < 1:
+		raise ValueError("`l` and `n_zeros` have to be natural integers")
+
+	zeros = []
+	for n in range(1, n_zeros + 1):
+		x_min = (n + l/2) * np.pi
+		x_max = (n + l/2 + 1) * np.pi
+		root = scp.optimize.brentq(lambda x: scp.special.spherical_jn(l, x), x_min, x_max)
+		zeros.append(root)
+    
+	return np.array(zeros)
+
+

--- a/scipy/special/tests/test_spherical_jn_zeros.py
+++ b/scipy/special/tests/test_spherical_jn_zeros.py
@@ -1,0 +1,26 @@
+import numpy as np
+from scipy.special import spherical_jn_zeros
+
+def test_spherical_jn_zeros():
+    # Test with  l=0 and n_zeros=3
+    zeros = spherical_jn_zeros(0, 3)
+    assert len(zeros) == 3
+    assert np.allclose(zeros, [np.pi, 2*np.pi, 3*np.pi], atol=1e-6)
+
+    # Test with l=1 and n_zeros=2
+    zeros = spherical_jn_zeros(1, 2)
+    assert len(zeros) == 2
+    assert np.allclose(zeros, [4.49340945790906, 7.72525183693770], atol=1e-6)
+
+    # Test with invalid values
+    try:
+        spherical_jn_zeros(-1, 3)
+        assert False, "ValueError: `l` and `n_zeros` have to be natural integers"
+    except ValueError:
+        pass
+
+    try:
+        spherical_jn_zeros(0, 0)
+        assert False, "ValueError: `l` and `n_zeros` have to be natural integers"
+    except ValueError:
+        pass


### PR DESCRIPTION
…mostly, it allows a fastest finding of spherical Bessel zeros in quantum physics (so when students aren't studying Bessel's function but have to use it)

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
- Added `spherical_jn_zeros` in `scipy/special/spherical_jn_zeros.py`.
- Added tests in `scipy/special/tests/test_spherical_jn_zeros.py`.
- Updated `scipy/special/__init__.py` to expose the function.

#### Additional information
Added the `spherical_jn_zeros` function to `scipy.special`. This function finds the first `n_zeros` roots of the spherical Bessel function \( j_l(x) \), which is useful for solving the Schrödinger equation in an infinite spherical potential well.

It is my first request and I don't really konw how it works. If you wan't to discuss to rewrite  the function, I'm open. This function is more dedicated to students in quantum physics, it shortens codes that are used.


