### PR TITLE
DOC: optimize.minimize: fix `subproblem_maxiter` docs for `trust-exact` method

### DIFF
--- a/scipy/optimize/_trustregion_exact.py
+++ b/scipy/optimize/_trustregion_exact.py
@@ -28,6 +28,11 @@ def _minimize_trustregion_exact(fun, x0, args=(), jac=None, hess=None,
     gtol : float
         Gradient norm must be less than ``gtol`` before successful
         termination.
+    subproblem_maxiter : int, optional
+        Maximum number of iterations to perform per subproblem. Only affects
+        trust-exact. Default is 25.
+
+        .. versionadded:: 1.17.0
     """
     if jac is None:
         raise ValueError('Jacobian is required for trust region '


### PR DESCRIPTION
https://github.com/scipy/scipy/pull/19668#issuecomment-3565431122

In contrast to the dev docs, this now shows in the `trust-exact` page:

<img width="913" height="761" alt="image" src="https://github.com/user-attachments/assets/b6bae488-f318-423e-a855-715cae275a2a" />

The problem was that the parameter had been added to the `_trustregion._minimize_trust_region` docstring, but not the `_trustregion_exact._minimize_trustregion_exact` docstring from which the page is generated.