### PR TITLE
MAINT: speed up `xp_promote` and `xp_result_type` for big torch tensors

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -488,8 +488,8 @@ def xp_result_type(*args, force_floating=False, xp):
     Typically, this function will be called shortly after `array_namespace`
     on a subset of the arguments passed to `array_namespace`.
     """
-    args = [(_asarray(arg, subok=True, xp=xp) if np.iterable(arg) else arg)
-            for arg in args]
+    args = [(_asarray(arg, subok=True, xp=xp) if is_torch_array(arg) or np.iterable(arg)
+            else arg) for arg in args]
     args_not_none = [arg for arg in args if arg is not None]
     if force_floating:
         args_not_none.append(1.0)
@@ -539,8 +539,8 @@ def xp_promote(*args, broadcast=False, force_floating=False, xp):
     if not args:
         return args
 
-    args = [(_asarray(arg, subok=True, xp=xp) if np.iterable(arg) else arg)
-            for arg in args]  # solely to prevent double conversion of iterable to array
+    args = [(_asarray(arg, subok=True, xp=xp) if is_torch_array(arg) or np.iterable(arg)
+            else arg) for arg in args]  # solely to prevent double conversion of iterable to array
 
     dtype = xp_result_type(*args, force_floating=force_floating, xp=xp)
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -488,6 +488,9 @@ def xp_result_type(*args, force_floating=False, xp):
     Typically, this function will be called shortly after `array_namespace`
     on a subset of the arguments passed to `array_namespace`.
     """
+    # prevent double conversion of iterable to array
+    # avoid `np.iterable` for torch arrays due to pytorch/pytorch#143334
+    # don't use `array_api_compat.is_array_api_obj` as it returns True for NumPy scalars
     args = [(_asarray(arg, subok=True, xp=xp) if is_torch_array(arg) or np.iterable(arg)
             else arg) for arg in args]
     args_not_none = [arg for arg in args if arg is not None]
@@ -539,8 +542,11 @@ def xp_promote(*args, broadcast=False, force_floating=False, xp):
     if not args:
         return args
 
+    # prevent double conversion of iterable to array
+    # avoid `np.iterable` for torch arrays due to pytorch/pytorch#143334
+    # don't use `array_api_compat.is_array_api_obj` as it returns True for NumPy scalars
     args = [(_asarray(arg, subok=True, xp=xp) if is_torch_array(arg) or np.iterable(arg)
-            else arg) for arg in args]  # solely to prevent double conversion of iterable to array
+            else arg) for arg in args]
 
     dtype = xp_result_type(*args, force_floating=force_floating, xp=xp)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-23670

#### What does this implement/fix?
In `xp_promote` and `xp_result_type`, we are using `np.iterable` to determine whether objects should be treated as arrays for the sake of dtype assessment. `np.iterable` - and just calling `iter` - is really slow for PyTorch tensors, so short-circuit if the object is a tensor.

#### Additional information
Please commit fixes directly to this branch.