### PR TITLE
BUG: signal: fix a GetWindow test

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -915,8 +915,9 @@ class TestGetWindow:
         sig = xp.arange(128)
 
         win = windows.get_window(('kaiser', 8.0), osfactor // 2, xp=xp)
-        with assert_raises(ValueError, match='^window.shape='):
-            resample(sig, sig.shape[0] * osfactor, window=_xp_copy_to_numpy(win))
+        mesg = "^window must" if is_cupy(xp) else "^window.shape="
+        with assert_raises(ValueError, match=mesg):
+            resample(sig, sig.shape[0] * osfactor, window=win)
 
     @make_xp_test_case(windows.general_cosine)
     def test_general_cosine(self, xp):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

fixes https://github.com/scipy/scipy/issues/24052

#### What does this implement/fix?
<!--Please explain your changes.-->

Two tweaks:

1. Stop transferring the `win` array to numpy in a call to `resample`: the signal is `xp`-namespaced, so the window should be too.
2. adapt the regex to a slightly different wording of `cupyx.scipy.signal.resample`, which  `scipy.signal.resample` version delegates to.

#### Additional information
<!--Any additional information you think is important.-->
