### PR TITLE
ENH: sparse.linalg.spsolve: reduce memory footprint and increase speed

### DIFF
--- a/benchmarks/benchmarks/sparse_linalg_spsolve.py
+++ b/benchmarks/benchmarks/sparse_linalg_spsolve.py
@@ -12,10 +12,10 @@ with safe_import():
 class SolveSparseRHS(Benchmark):
     param_names = ["Nsq", "K", "density", "batch_size", "use_umfpack"]
     params = [
-        [5000],  # (Nsq, Nsq) matrix for (N, N) grid
-        [2000],  # (Nsq, K) RHS
+        [500],  # (Nsq, Nsq) matrix for (N, N) grid
+        [5_003],  # (Nsq, K) RHS matrix, arbitrary K
         [0.01, 0.1, 0.5],  # density of the sparse RHS
-        [1, 10, 100, 5000],  # batch size
+        [1, 10, 100, 6000],  # batch size
         [True, False],  # use umfpack or not
     ]
 

--- a/benchmarks/benchmarks/sparse_linalg_spsolve.py
+++ b/benchmarks/benchmarks/sparse_linalg_spsolve.py
@@ -1,0 +1,40 @@
+"""Check the speed of the sparse solve function with many RHS."""
+
+import numpy as np
+
+from .common import Benchmark, safe_import
+
+with safe_import():
+    from scipy import sparse
+    from scipy.sparse.linalg import LaplacianNd, spsolve
+
+
+class SolveSparseRHS(Benchmark):
+    param_names = ["Nsq", "K", "density", "use_umfpack"]
+    params = [
+        [5000],  # (Nsq, Nsq) matrix for (N, N) grid
+        [2000],  # (Nsq, K) RHS
+        [0.01, 0.1, 0.5],  # density of the sparse RHS
+        # [1, 100, 1000],  # batch size
+        # [True, False],  # use umfpack or not
+        [False],  # use umfpack or not
+    ]
+
+    def setup(self, Nsq, K, density, use_umfpack):
+        Ng = np.sqrt(Nsq).astype(int)
+        self.A = -LaplacianNd((Ng, Ng), dtype=float).tosparse().tocsc()
+        N = self.A.shape[0]
+        self.A[-1, -1] += 1  # make A non-singular
+        self.b = sparse.random_array((N, K), density=density, format="csc", dtype=float)
+        # self.batch_size = batch_size
+        self.use_umfpack = use_umfpack
+
+    def time_solve(self, Nsq, K, density, use_umfpack):
+        spsolve(
+            self.A, self.b, use_umfpack=self.use_umfpack
+        )
+
+    def peakmem_solve(self, Nsq, K, density, use_umfpack):
+        spsolve(
+            self.A, self.b, use_umfpack=self.use_umfpack
+        )

--- a/benchmarks/benchmarks/sparse_linalg_spsolve.py
+++ b/benchmarks/benchmarks/sparse_linalg_spsolve.py
@@ -10,7 +10,7 @@ with safe_import():
 
 
 class SolveSparseRHS(Benchmark):
-    param_names = ["Nsq", "K", "density", "batch_size", "use_umfpack"]
+    param_names = ["Nsq", "K", "density", "block_size", "use_umfpack"]
     params = [
         [500],  # (Nsq, Nsq) matrix for (N, N) grid
         [5_003],  # (Nsq, K) RHS matrix, arbitrary K
@@ -19,29 +19,32 @@ class SolveSparseRHS(Benchmark):
         [True, False],  # use umfpack or not
     ]
 
-    def setup(self, Nsq, K, density, batch_size, use_umfpack):
+    def setup(self, Nsq, K, density, block_size, use_umfpack):
         Ng = np.sqrt(Nsq).astype(int)
         self.A = -LaplacianNd((Ng, Ng), dtype=float).tosparse().tocsc()
         N = self.A.shape[0]
         self.A[-1, -1] += 1  # make A non-singular
         self.b = sparse.random_array((N, K), density=density, format="csc", dtype=float)
-        self.batch_size = batch_size
+        self.block_size = block_size
         self.use_umfpack = use_umfpack
 
-    def _run_solver(self, Nsq, K, density, batch_size, use_umfpack):
+    def _run_solver(self, Nsq, K, density, block_size, use_umfpack):
         try:
             spsolve(
-                self.A, self.b, batch_size=self.batch_size, use_umfpack=self.use_umfpack
+                self.A,
+                self.b,
+                rhs_block_size=self.block_size,
+                use_umfpack=self.use_umfpack,
             )
         except TypeError:
-            # older versions do not have batch_size
-            if self.batch_size == 1:
+            # older versions do not have block_size
+            if self.block_size == 1:
                 spsolve(self.A, self.b, use_umfpack=self.use_umfpack)
             else:
                 pass  # skip benchmark
 
-    def time_solve(self, Nsq, K, density, batch_size, use_umfpack):
-        self._run_solver(Nsq, K, density, batch_size, use_umfpack)
+    def time_solve(self, Nsq, K, density, block_size, use_umfpack):
+        self._run_solver(Nsq, K, density, block_size, use_umfpack)
 
-    def peakmem_solve(self, Nsq, K, density, batch_size, use_umfpack):
-        self._run_solver(Nsq, K, density, batch_size, use_umfpack)
+    def peakmem_solve(self, Nsq, K, density, block_size, use_umfpack):
+        self._run_solver(Nsq, K, density, block_size, use_umfpack)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -1,5 +1,6 @@
 from warnings import warn, catch_warnings, simplefilter
 
+from numbers import Integral
 import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
@@ -257,6 +258,9 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
         useUmfpack.u = not noScikit
 
     use_umfpack = use_umfpack and useUmfpack.u
+
+    if not isinstance(rhs_batch_size, Integral) or rhs_batch_size <= 0:
+        raise ValueError("rhs_batch_size must be a positive integer")
 
     if b_is_vector and use_umfpack:
         if b_is_sparse:

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -163,6 +163,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
         ``use_umfpack=False``, since the low-level scikit-umfpack routines do
         not support multiple right-hand sides. In that case, ``rhs_batch_size=1``.
 
+        .. versionadded:: 1.18.0
+
     Returns
     -------
     x : ndarray or sparse array or matrix

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -132,7 +132,7 @@ def _get_umf_family(A):
 
     return family, A_new
 
-def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -1,6 +1,5 @@
 from warnings import warn, catch_warnings, simplefilter
 
-from numbers import Integral
 import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
@@ -8,6 +7,7 @@ from scipy.sparse import (issparse, SparseEfficiencyWarning,
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
                                    safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
+from scipy._lib._util import _validate_int
 import copy
 import threading
 
@@ -261,8 +261,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
 
     use_umfpack = use_umfpack and useUmfpack.u
 
-    if not isinstance(rhs_batch_size, Integral) or rhs_batch_size <= 0:
-        raise ValueError("rhs_batch_size must be a positive integer")
+    _validate_int(rhs_batch_size, "rhs_batch_size", minimum=1)
 
     if b_is_vector and use_umfpack:
         if b_is_sparse:

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -131,7 +131,7 @@ def _get_umf_family(A):
 
     return family, A_new
 
-def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters
@@ -154,13 +154,13 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
         if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
         [6]_ . This is only referenced if b is a vector and
         ``scikits.umfpack`` is installed.
-    batch_size : int, optional
+    rhs_batch_size : int, optional
         If ``b`` is a 2D sparse array, this parameter controls the number of
         columns to be solved simultaneously. A larger number will increase
         memory consumption by converting more columns at a time to dense
         arrays, but may improve runtime. This option only applies when
         ``use_umfpack=False``, since the low-level scikit-umfpack routines do
-        not support multiple right-hand sides. In that case, ``batch_size=1``.
+        not support multiple right-hand sides. In that case, ``rhs_batch_size=1``.
 
     Returns
     -------
@@ -315,18 +315,18 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
                      SparseEfficiencyWarning, stacklevel=2)
                 b = csc_array(b)
 
-            if use_umfpack and batch_size > 1:
-                batch_size = 1
+            if use_umfpack and rhs_batch_size > 1:
+                rhs_batch_size = 1
 
             # Solve in batches to reduce memory consumption
             K = b.shape[1]
             x_blocks = []
 
             # Pre-allocate arrays to avoid repeated allocations
-            b_batch = np.empty((N, min(batch_size, K)), dtype=b.dtype, order="F")
+            b_batch = np.empty((N, min(rhs_batch_size, K)), dtype=b.dtype, order="F")
 
-            for k in range(0, K, batch_size):
-                batch_end = min(k + batch_size, K)
+            for k in range(0, K, rhs_batch_size):
+                batch_end = min(k + rhs_batch_size, K)
                 width = batch_end - k
                 # Convert sparse to dense in the buffer
                 b_view = b_batch[:, :width]

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -132,7 +132,7 @@ def _get_umf_family(A):
 
     return family, A_new
 
-def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_block_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters
@@ -155,13 +155,13 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
         if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
         [6]_ . This is only referenced if b is a vector and
         ``scikits.umfpack`` is installed.
-    rhs_batch_size : int, optional
+    rhs_block_size : int, optional
         If ``b`` is a 2D sparse array, this parameter controls the number of
         columns to be solved simultaneously. A larger number will increase
         memory consumption by converting more columns at a time to dense
         arrays, but may improve runtime. This option only applies when
         ``use_umfpack=False``, since the low-level scikit-umfpack routines do
-        not support multiple right-hand sides. In that case, ``rhs_batch_size=1``.
+        not support multiple right-hand sides. In that case, ``rhs_block_size=1``.
 
         .. versionadded:: 1.18.0
 
@@ -228,6 +228,11 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
     A = convert_pydata_sparse_to_scipy(A)
     b = convert_pydata_sparse_to_scipy(b)
 
+    # TODO generalize spsolve to use batched arrays, like:
+    # A.shape == (2, 3, N, N)
+    # b.shape == (2, 3, N, K) =>
+    # x.shape == (2, 3, N, K)
+
     if not (issparse(A) and A.format in ("csc", "csr")):
         A = csc_array(A)
         warn('spsolve requires A be CSC or CSR matrix format',
@@ -261,7 +266,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
 
     use_umfpack = use_umfpack and useUmfpack.u
 
-    _validate_int(rhs_batch_size, "rhs_batch_size", minimum=1)
+    _validate_int(rhs_block_size, "rhs_block_size", minimum=1)
 
     if b_is_vector and use_umfpack:
         if b_is_sparse:
@@ -320,22 +325,22 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
                      SparseEfficiencyWarning, stacklevel=2)
                 b = csc_array(b)
 
-            if use_umfpack and rhs_batch_size > 1:
-                rhs_batch_size = 1
+            if use_umfpack and rhs_block_size > 1:
+                rhs_block_size = 1
 
-            # Solve in batches to reduce memory consumption
+            # Solve in blocks to reduce memory consumption
             K = b.shape[1]
             x_blocks = []
 
             # Pre-allocate arrays to avoid repeated allocations
-            b_batch = np.empty((N, min(rhs_batch_size, K)), dtype=b.dtype, order="F")
+            b_block = np.empty((N, min(rhs_block_size, K)), dtype=b.dtype, order="F")
 
-            for k in range(0, K, rhs_batch_size):
-                batch_end = min(k + rhs_batch_size, K)
-                width = batch_end - k
+            for k in range(0, K, rhs_block_size):
+                block_end = min(k + rhs_block_size, K)
+                width = block_end - k
                 # Convert sparse to dense in the buffer
-                b_view = b_batch[:, :width]
-                b[:, k:batch_end].toarray(out=b_view)
+                b_view = b_block[:, :width]
+                b[:, k:block_end].toarray(out=b_view)
                 # Solve the linear systems
                 x_dense = Afactsolve(b_view)
                 x_blocks.append(csc_array(x_dense, dtype=b.dtype))

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -131,7 +131,7 @@ def _get_umf_family(A):
 
     return family, A_new
 
-def spsolve(A, b, permc_spec=None, use_umfpack=True):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters
@@ -154,6 +154,13 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
         [6]_ . This is only referenced if b is a vector and
         ``scikits.umfpack`` is installed.
+    batch_size : int, optional
+        If ``b`` is a 2D sparse array, this parameter controls the number of
+        columns to be solved simultaneously. A larger number will increase
+        memory consumption by converting more columns at a time to dense
+        arrays, but may improve runtime. This option only applies when
+        ``use_umfpack=False``, since the low-level scikit-umfpack routines do
+        not support multiple right-hand sides. In that case, ``batch_size=1``.
 
     Returns
     -------
@@ -308,14 +315,23 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
                      SparseEfficiencyWarning, stacklevel=2)
                 b = csc_array(b)
 
-            # Create a sparse output matrix by repeatedly applying
-            # the sparse factorization to solve columns of b.
-            x_cols = []
-            for j in range(b.shape[1]):
-                bj = b[:, j].toarray().ravel()
-                xj = Afactsolve(bj)
-                x_cols.append(csc_array(xj.reshape(-1, 1)))
-            x = hstack(x_cols)
+            if use_umfpack and batch_size > 1:
+                batch_size = 1
+
+            # Solve in batches to reduce memory consumption
+            num_cols = b.shape[1]
+            x_blocks = []
+
+            for k in range(0, num_cols, batch_size):
+                batch_end = min(k + batch_size, num_cols)
+                b_batch = b[:, k:batch_end].toarray(order="C")
+                x_dense_batch = Afactsolve(b_batch)
+                x_sparse_batch = csc_array(x_dense_batch)
+                x_blocks.append(x_sparse_batch)
+
+            x = hstack(x_blocks)
+
+            # Convert back to consistent sparse class
             x = A.__class__(x)
 
             if is_pydata_sparse:

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -319,15 +319,21 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
                 batch_size = 1
 
             # Solve in batches to reduce memory consumption
-            num_cols = b.shape[1]
+            K = b.shape[1]
             x_blocks = []
 
-            for k in range(0, num_cols, batch_size):
-                batch_end = min(k + batch_size, num_cols)
-                b_batch = b[:, k:batch_end].toarray(order="C")
-                x_dense_batch = Afactsolve(b_batch)
-                x_sparse_batch = csc_array(x_dense_batch)
-                x_blocks.append(x_sparse_batch)
+            # Pre-allocate arrays to avoid repeated allocations
+            b_batch = np.empty((N, min(batch_size, K)), dtype=b.dtype, order="F")
+
+            for k in range(0, K, batch_size):
+                batch_end = min(k + batch_size, K)
+                width = batch_end - k
+                # Convert sparse to dense in the buffer
+                b_view = b_batch[:, :width]
+                b[:, k:batch_end].toarray(out=b_view)
+                # Solve the linear systems
+                x_dense = Afactsolve(b_view)
+                x_blocks.append(csc_array(x_dense, dtype=b.dtype))
 
             x = hstack(x_blocks)
 

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -3,9 +3,9 @@ from warnings import warn, catch_warnings, simplefilter
 import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
-                          csr_array, csc_array, eye_array, diags_array)
+                          csr_array, csc_array, eye_array, diags_array, hstack)
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
-                                   get_index_dtype, safely_cast_index_arrays)
+                                   safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
 import copy
 import threading
@@ -310,22 +310,12 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
 
             # Create a sparse output matrix by repeatedly applying
             # the sparse factorization to solve columns of b.
-            itype = get_index_dtype(maxval=max(b.shape))
-            indptr = np.zeros(b.shape[1] + 1, dtype=itype)
-            data_segs = []
-            indices_segs = []
+            x_cols = []
             for j in range(b.shape[1]):
                 bj = b[:, j].toarray().ravel()
                 xj = Afactsolve(bj)
-                w = np.flatnonzero(xj)
-                indptr[j+1] = indptr[j] + len(w)
-                indices_segs.append(w)
-                data_segs.append(np.asarray(xj[w], dtype=A.dtype))
-            data = np.concatenate(data_segs)
-            indices = np.concatenate(indices_segs, dtype=itype)
-            assert len(indices) == len(data)
-            assert indptr[-1] == len(data)
-            x = csc_array((data, indices, indptr), shape=b.shape, dtype=A.dtype)
+                x_cols.append(csc_array(xj.reshape(-1, 1)))
+            x = hstack(x_cols)
             x = A.__class__(x)
 
             if is_pydata_sparse:

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -310,23 +310,23 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
 
             # Create a sparse output matrix by repeatedly applying
             # the sparse factorization to solve columns of b.
+            itype = get_index_dtype(maxval=max(b.shape))
+            indptr = np.zeros(b.shape[1] + 1, dtype=itype)
             data_segs = []
-            row_segs = []
-            col_segs = []
+            indices_segs = []
             for j in range(b.shape[1]):
                 bj = b[:, j].toarray().ravel()
                 xj = Afactsolve(bj)
                 w = np.flatnonzero(xj)
-                segment_length = w.shape[0]
-                row_segs.append(w)
-                col_segs.append(np.full(segment_length, j, dtype=int))
+                indptr[j+1] = indptr[j] + len(w)
+                indices_segs.append(w)
                 data_segs.append(np.asarray(xj[w], dtype=A.dtype))
-            sparse_data = np.concatenate(data_segs)
-            idx_dtype = get_index_dtype(maxval=max(b.shape))
-            sparse_row = np.concatenate(row_segs, dtype=idx_dtype)
-            sparse_col = np.concatenate(col_segs, dtype=idx_dtype)
-            x = A.__class__((sparse_data, (sparse_row, sparse_col)),
-                           shape=b.shape, dtype=A.dtype)
+            data = np.concatenate(data_segs)
+            indices = np.concatenate(indices_segs, dtype=itype)
+            assert len(indices) == len(data)
+            assert indptr[-1] == len(data)
+            x = csc_array((data, indices, indptr), shape=b.shape, dtype=A.dtype)
+            x = A.__class__(x)
 
             if is_pydata_sparse:
                 x = pydata_sparse_cls.from_scipy_sparse(x)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -1,5 +1,6 @@
 from warnings import warn, catch_warnings, simplefilter
 
+from numbers import Integral
 import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
@@ -260,6 +261,9 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
         useUmfpack.u = not noScikit
 
     use_umfpack = use_umfpack and useUmfpack.u
+
+    if not isinstance(rhs_batch_size, Integral) or rhs_batch_size <= 0:
+        raise ValueError("rhs_batch_size must be a positive integer")
 
     if b_is_vector and use_umfpack:
         if b_is_sparse:

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -322,15 +322,21 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
                 batch_size = 1
 
             # Solve in batches to reduce memory consumption
-            num_cols = b.shape[1]
+            K = b.shape[1]
             x_blocks = []
 
-            for k in range(0, num_cols, batch_size):
-                batch_end = min(k + batch_size, num_cols)
-                b_batch = b[:, k:batch_end].toarray(order="C")
-                x_dense_batch = Afactsolve(b_batch)
-                x_sparse_batch = csc_array(x_dense_batch)
-                x_blocks.append(x_sparse_batch)
+            # Pre-allocate arrays to avoid repeated allocations
+            b_batch = np.empty((N, min(batch_size, K)), dtype=b.dtype, order="F")
+
+            for k in range(0, K, batch_size):
+                batch_end = min(k + batch_size, K)
+                width = batch_end - k
+                # Convert sparse to dense in the buffer
+                b_view = b_batch[:, :width]
+                b[:, k:batch_end].toarray(out=b_view)
+                # Solve the linear systems
+                x_dense = Afactsolve(b_view)
+                x_blocks.append(csc_array(x_dense, dtype=b.dtype))
 
             x = hstack(x_blocks)
 

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -135,7 +135,7 @@ def _get_umf_family(A):
 
     return family, A_new
 
-def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -313,23 +313,23 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
 
             # Create a sparse output matrix by repeatedly applying
             # the sparse factorization to solve columns of b.
+            itype = get_index_dtype(maxval=max(b.shape))
+            indptr = np.zeros(b.shape[1] + 1, dtype=itype)
             data_segs = []
-            row_segs = []
-            col_segs = []
+            indices_segs = []
             for j in range(b.shape[1]):
                 bj = b[:, j].toarray().ravel()
                 xj = Afactsolve(bj)
                 w = np.flatnonzero(xj)
-                segment_length = w.shape[0]
-                row_segs.append(w)
-                col_segs.append(np.full(segment_length, j, dtype=int))
+                indptr[j+1] = indptr[j] + len(w)
+                indices_segs.append(w)
                 data_segs.append(np.asarray(xj[w], dtype=A.dtype))
-            sparse_data = np.concatenate(data_segs)
-            idx_dtype = get_index_dtype(maxval=max(b.shape))
-            sparse_row = np.concatenate(row_segs, dtype=idx_dtype)
-            sparse_col = np.concatenate(col_segs, dtype=idx_dtype)
-            x = A.__class__((sparse_data, (sparse_row, sparse_col)),
-                           shape=b.shape, dtype=A.dtype)
+            data = np.concatenate(data_segs)
+            indices = np.concatenate(indices_segs, dtype=itype)
+            assert len(indices) == len(data)
+            assert indptr[-1] == len(data)
+            x = csc_array((data, indices, indptr), shape=b.shape, dtype=A.dtype)
+            x = A.__class__(x)
 
             if is_pydata_sparse:
                 x = pydata_sparse_cls.from_scipy_sparse(x)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -1,6 +1,5 @@
 from warnings import warn, catch_warnings, simplefilter
 
-from numbers import Integral
 import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
@@ -8,6 +7,7 @@ from scipy.sparse import (issparse, SparseEfficiencyWarning,
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
                                    safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
+from scipy._lib._util import _validate_int
 import copy
 import threading
 
@@ -264,8 +264,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
 
     use_umfpack = use_umfpack and useUmfpack.u
 
-    if not isinstance(rhs_batch_size, Integral) or rhs_batch_size <= 0:
-        raise ValueError("rhs_batch_size must be a positive integer")
+    _validate_int(rhs_batch_size, "rhs_batch_size", minimum=1)
 
     if b_is_vector and use_umfpack:
         if b_is_sparse:

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -166,6 +166,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
         ``use_umfpack=False``, since the low-level scikit-umfpack routines do
         not support multiple right-hand sides. In that case, ``rhs_batch_size=1``.
 
+        .. versionadded:: 1.18.0
+
     Returns
     -------
     x : ndarray or sparse array or matrix

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -134,7 +134,7 @@ def _get_umf_family(A):
 
     return family, A_new
 
-def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters
@@ -157,13 +157,13 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
         if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
         [6]_ . This is only referenced if b is a vector and
         ``scikits.umfpack`` is installed.
-    batch_size : int, optional
+    rhs_batch_size : int, optional
         If ``b`` is a 2D sparse array, this parameter controls the number of
         columns to be solved simultaneously. A larger number will increase
         memory consumption by converting more columns at a time to dense
         arrays, but may improve runtime. This option only applies when
         ``use_umfpack=False``, since the low-level scikit-umfpack routines do
-        not support multiple right-hand sides. In that case, ``batch_size=1``.
+        not support multiple right-hand sides. In that case, ``rhs_batch_size=1``.
 
     Returns
     -------
@@ -318,18 +318,18 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
                      SparseEfficiencyWarning, stacklevel=2)
                 b = csc_array(b)
 
-            if use_umfpack and batch_size > 1:
-                batch_size = 1
+            if use_umfpack and rhs_batch_size > 1:
+                rhs_batch_size = 1
 
             # Solve in batches to reduce memory consumption
             K = b.shape[1]
             x_blocks = []
 
             # Pre-allocate arrays to avoid repeated allocations
-            b_batch = np.empty((N, min(batch_size, K)), dtype=b.dtype, order="F")
+            b_batch = np.empty((N, min(rhs_batch_size, K)), dtype=b.dtype, order="F")
 
-            for k in range(0, K, batch_size):
-                batch_end = min(k + batch_size, K)
+            for k in range(0, K, rhs_batch_size):
+                batch_end = min(k + rhs_batch_size, K)
                 width = batch_end - k
                 # Convert sparse to dense in the buffer
                 b_view = b_batch[:, :width]

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -135,7 +135,7 @@ def _get_umf_family(A):
 
     return family, A_new
 
-def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_block_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters
@@ -158,13 +158,13 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
         if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
         [6]_ . This is only referenced if b is a vector and
         ``scikits.umfpack`` is installed.
-    rhs_batch_size : int, optional
+    rhs_block_size : int, optional
         If ``b`` is a 2D sparse array, this parameter controls the number of
         columns to be solved simultaneously. A larger number will increase
         memory consumption by converting more columns at a time to dense
         arrays, but may improve runtime. This option only applies when
         ``use_umfpack=False``, since the low-level scikit-umfpack routines do
-        not support multiple right-hand sides. In that case, ``rhs_batch_size=1``.
+        not support multiple right-hand sides. In that case, ``rhs_block_size=1``.
 
         .. versionadded:: 1.18.0
 
@@ -231,6 +231,11 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
     A = convert_pydata_sparse_to_scipy(A)
     b = convert_pydata_sparse_to_scipy(b)
 
+    # TODO generalize spsolve to use batched arrays, like:
+    # A.shape == (2, 3, N, N)
+    # b.shape == (2, 3, N, K) =>
+    # x.shape == (2, 3, N, K)
+
     if not (issparse(A) and A.format in ("csc", "csr")):
         A = csc_array(A)
         warn('spsolve requires A be CSC or CSR matrix format',
@@ -264,7 +269,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
 
     use_umfpack = use_umfpack and useUmfpack.u
 
-    _validate_int(rhs_batch_size, "rhs_batch_size", minimum=1)
+    _validate_int(rhs_block_size, "rhs_block_size", minimum=1)
 
     if b_is_vector and use_umfpack:
         if b_is_sparse:
@@ -323,22 +328,22 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, *, rhs_batch_size=10):
                      SparseEfficiencyWarning, stacklevel=2)
                 b = csc_array(b)
 
-            if use_umfpack and rhs_batch_size > 1:
-                rhs_batch_size = 1
+            if use_umfpack and rhs_block_size > 1:
+                rhs_block_size = 1
 
-            # Solve in batches to reduce memory consumption
+            # Solve in blocks to reduce memory consumption
             K = b.shape[1]
             x_blocks = []
 
             # Pre-allocate arrays to avoid repeated allocations
-            b_batch = np.empty((N, min(rhs_batch_size, K)), dtype=b.dtype, order="F")
+            b_block = np.empty((N, min(rhs_block_size, K)), dtype=b.dtype, order="F")
 
-            for k in range(0, K, rhs_batch_size):
-                batch_end = min(k + rhs_batch_size, K)
-                width = batch_end - k
+            for k in range(0, K, rhs_block_size):
+                block_end = min(k + rhs_block_size, K)
+                width = block_end - k
                 # Convert sparse to dense in the buffer
-                b_view = b_batch[:, :width]
-                b[:, k:batch_end].toarray(out=b_view)
+                b_view = b_block[:, :width]
+                b[:, k:block_end].toarray(out=b_view)
                 # Solve the linear systems
                 x_dense = Afactsolve(b_view)
                 x_blocks.append(csc_array(x_dense, dtype=b.dtype))

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -3,9 +3,9 @@ from warnings import warn, catch_warnings, simplefilter
 import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
-                          csr_array, csc_array, eye_array, diags_array)
+                          csr_array, csc_array, eye_array, diags_array, hstack)
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
-                                   get_index_dtype, safely_cast_index_arrays)
+                                   safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
 import copy
 import threading
@@ -313,22 +313,12 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
 
             # Create a sparse output matrix by repeatedly applying
             # the sparse factorization to solve columns of b.
-            itype = get_index_dtype(maxval=max(b.shape))
-            indptr = np.zeros(b.shape[1] + 1, dtype=itype)
-            data_segs = []
-            indices_segs = []
+            x_cols = []
             for j in range(b.shape[1]):
                 bj = b[:, j].toarray().ravel()
                 xj = Afactsolve(bj)
-                w = np.flatnonzero(xj)
-                indptr[j+1] = indptr[j] + len(w)
-                indices_segs.append(w)
-                data_segs.append(np.asarray(xj[w], dtype=A.dtype))
-            data = np.concatenate(data_segs)
-            indices = np.concatenate(indices_segs, dtype=itype)
-            assert len(indices) == len(data)
-            assert indptr[-1] == len(data)
-            x = csc_array((data, indices, indptr), shape=b.shape, dtype=A.dtype)
+                x_cols.append(csc_array(xj.reshape(-1, 1)))
+            x = hstack(x_cols)
             x = A.__class__(x)
 
             if is_pydata_sparse:

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -134,7 +134,7 @@ def _get_umf_family(A):
 
     return family, A_new
 
-def spsolve(A, b, permc_spec=None, use_umfpack=True):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, batch_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters
@@ -157,6 +157,13 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
         [6]_ . This is only referenced if b is a vector and
         ``scikits.umfpack`` is installed.
+    batch_size : int, optional
+        If ``b`` is a 2D sparse array, this parameter controls the number of
+        columns to be solved simultaneously. A larger number will increase
+        memory consumption by converting more columns at a time to dense
+        arrays, but may improve runtime. This option only applies when
+        ``use_umfpack=False``, since the low-level scikit-umfpack routines do
+        not support multiple right-hand sides. In that case, ``batch_size=1``.
 
     Returns
     -------
@@ -311,14 +318,23 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
                      SparseEfficiencyWarning, stacklevel=2)
                 b = csc_array(b)
 
-            # Create a sparse output matrix by repeatedly applying
-            # the sparse factorization to solve columns of b.
-            x_cols = []
-            for j in range(b.shape[1]):
-                bj = b[:, j].toarray().ravel()
-                xj = Afactsolve(bj)
-                x_cols.append(csc_array(xj.reshape(-1, 1)))
-            x = hstack(x_cols)
+            if use_umfpack and batch_size > 1:
+                batch_size = 1
+
+            # Solve in batches to reduce memory consumption
+            num_cols = b.shape[1]
+            x_blocks = []
+
+            for k in range(0, num_cols, batch_size):
+                batch_end = min(k + batch_size, num_cols)
+                b_batch = b[:, k:batch_end].toarray(order="C")
+                x_dense_batch = Afactsolve(b_batch)
+                x_sparse_batch = csc_array(x_dense_batch)
+                x_blocks.append(x_sparse_batch)
+
+            x = hstack(x_blocks)
+
+            # Convert back to consistent sparse class
             x = A.__class__(x)
 
             if is_pydata_sparse:

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -327,8 +327,10 @@ class TestLinsolve:
         for b in bs:
             x = np.linalg.solve(A.toarray(), toarray(b))
             for spmattype in [csc_array, csr_array, dok_array, lil_array]:
-                x1 = spsolve(spmattype(A), b, use_umfpack=True)
-                x2 = spsolve(spmattype(A), b, use_umfpack=False)
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', SparseEfficiencyWarning)
+                    x1 = spsolve(spmattype(A), b, use_umfpack=True)
+                    x2 = spsolve(spmattype(A), b, use_umfpack=False)
 
                 # check solution
                 if x.ndim == 2 and x.shape[1] == 1:

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -479,7 +479,7 @@ class TestLinsolve:
         x = spsolve(A, b, rhs_batch_size=rhs_batch_size, use_umfpack=False)
         if K == 1:
             x_true = x_true.ravel()
-        assert_array_almost_equal(x, x_true)
+        assert_allclose(x, x_true)
 
 
 class TestSplu:

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -451,13 +451,20 @@ class TestLinsolve:
         x = spsolve(A, b)
         assert_array_almost_equal(A @ x, b)
 
-    @pytest.mark.parametrize("bad_rhs_batch_size", [0, -1, 'foo', None])
-    def test_bad_rhs_batch_size(self, bad_rhs_batch_size):
+    @pytest.mark.parametrize("bad_rhs_batch_size", ['foo', None])
+    def test_bad_rhs_batch_size_type(self, bad_rhs_batch_size):
         N = 5
         A = eye_array(N, dtype=float, format='csc')
         b = np.arange(N)
+        with assert_raises(TypeError, match="must be an integer"):
+            spsolve(A, b, rhs_batch_size=bad_rhs_batch_size)
 
-        with assert_raises(ValueError, match="must be a positive integer"):
+    @pytest.mark.parametrize("bad_rhs_batch_size", [0, -1])
+    def test_bad_rhs_batch_size_value(self, bad_rhs_batch_size):
+        N = 5
+        A = eye_array(N, dtype=float, format='csc')
+        b = np.arange(N)
+        with assert_raises(ValueError, match="must be an integer not less than 1"):
             spsolve(A, b, rhs_batch_size=bad_rhs_batch_size)
 
     @pytest.mark.parametrize("K", [0, 1, 10])

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -451,32 +451,32 @@ class TestLinsolve:
         x = spsolve(A, b)
         assert_array_almost_equal(A @ x, b)
 
-    @pytest.mark.parametrize("bad_rhs_batch_size", ['foo', None])
-    def test_bad_rhs_batch_size_type(self, bad_rhs_batch_size):
+    @pytest.mark.parametrize("bad_rhs_block_size", ['foo', None])
+    def test_bad_rhs_block_size_type(self, bad_rhs_block_size):
         N = 5
         A = eye_array(N, dtype=float, format='csc')
         b = np.arange(N)
         with assert_raises(TypeError, match="must be an integer"):
-            spsolve(A, b, rhs_batch_size=bad_rhs_batch_size)
+            spsolve(A, b, rhs_block_size=bad_rhs_block_size)
 
-    @pytest.mark.parametrize("bad_rhs_batch_size", [0, -1])
-    def test_bad_rhs_batch_size_value(self, bad_rhs_batch_size):
+    @pytest.mark.parametrize("bad_rhs_block_size", [0, -1])
+    def test_bad_rhs_block_size_value(self, bad_rhs_block_size):
         N = 5
         A = eye_array(N, dtype=float, format='csc')
         b = np.arange(N)
         with assert_raises(ValueError, match="must be an integer not less than 1"):
-            spsolve(A, b, rhs_batch_size=bad_rhs_batch_size)
+            spsolve(A, b, rhs_block_size=bad_rhs_block_size)
 
     @pytest.mark.parametrize("K", [0, 1, 10])
-    @pytest.mark.parametrize("rhs_batch_size", [1, 2, 3, 10, 20])
-    def test_rhs_batch_size(self, K, rhs_batch_size):
+    @pytest.mark.parametrize("rhs_block_size", [1, 2, 3, 10, 20])
+    def test_rhs_block_size(self, K, rhs_block_size):
         rng = np.random.default_rng(56)
         N = 5
         A = eye_array(N, dtype=float, format='csc')
         s = rng.random(N)
         x_true = np.outer(s, 1 + np.arange(K))  # (N, K)
         b = A @ x_true
-        x = spsolve(A, b, rhs_batch_size=rhs_batch_size, use_umfpack=False)
+        x = spsolve(A, b, rhs_block_size=rhs_block_size, use_umfpack=False)
         if K == 1:
             x_true = x_true.ravel()
         assert_allclose(x, x_true)

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -481,7 +481,7 @@ class TestLinsolve:
         x = spsolve(A, b, rhs_batch_size=rhs_batch_size, use_umfpack=False)
         if K == 1:
             x_true = x_true.ravel()
-        assert_array_almost_equal(x, x_true)
+        assert_allclose(x, x_true)
 
 
 class TestSplu:

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -453,32 +453,32 @@ class TestLinsolve:
         x = spsolve(A, b)
         assert_array_almost_equal(A @ x, b)
 
-    @pytest.mark.parametrize("bad_rhs_batch_size", ['foo', None])
-    def test_bad_rhs_batch_size_type(self, bad_rhs_batch_size):
+    @pytest.mark.parametrize("bad_rhs_block_size", ['foo', None])
+    def test_bad_rhs_block_size_type(self, bad_rhs_block_size):
         N = 5
         A = eye_array(N, dtype=float, format='csc')
         b = np.arange(N)
         with assert_raises(TypeError, match="must be an integer"):
-            spsolve(A, b, rhs_batch_size=bad_rhs_batch_size)
+            spsolve(A, b, rhs_block_size=bad_rhs_block_size)
 
-    @pytest.mark.parametrize("bad_rhs_batch_size", [0, -1])
-    def test_bad_rhs_batch_size_value(self, bad_rhs_batch_size):
+    @pytest.mark.parametrize("bad_rhs_block_size", [0, -1])
+    def test_bad_rhs_block_size_value(self, bad_rhs_block_size):
         N = 5
         A = eye_array(N, dtype=float, format='csc')
         b = np.arange(N)
         with assert_raises(ValueError, match="must be an integer not less than 1"):
-            spsolve(A, b, rhs_batch_size=bad_rhs_batch_size)
+            spsolve(A, b, rhs_block_size=bad_rhs_block_size)
 
     @pytest.mark.parametrize("K", [0, 1, 10])
-    @pytest.mark.parametrize("rhs_batch_size", [1, 2, 3, 10, 20])
-    def test_rhs_batch_size(self, K, rhs_batch_size):
+    @pytest.mark.parametrize("rhs_block_size", [1, 2, 3, 10, 20])
+    def test_rhs_block_size(self, K, rhs_block_size):
         rng = np.random.default_rng(56)
         N = 5
         A = eye_array(N, dtype=float, format='csc')
         s = rng.random(N)
         x_true = np.outer(s, 1 + np.arange(K))  # (N, K)
         b = A @ x_true
-        x = spsolve(A, b, rhs_batch_size=rhs_batch_size, use_umfpack=False)
+        x = spsolve(A, b, rhs_block_size=rhs_block_size, use_umfpack=False)
         if K == 1:
             x_true = x_true.ravel()
         assert_allclose(x, x_true)

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -329,8 +329,10 @@ class TestLinsolve:
         for b in bs:
             x = np.linalg.solve(A.toarray(), toarray(b))
             for spmattype in [csc_array, csr_array, dok_array, lil_array]:
-                x1 = spsolve(spmattype(A), b, use_umfpack=True)
-                x2 = spsolve(spmattype(A), b, use_umfpack=False)
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', SparseEfficiencyWarning)
+                    x1 = spsolve(spmattype(A), b, use_umfpack=True)
+                    x2 = spsolve(spmattype(A), b, use_umfpack=False)
 
                 # check solution
                 if x.ndim == 2 and x.shape[1] == 1:

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -453,13 +453,20 @@ class TestLinsolve:
         x = spsolve(A, b)
         assert_array_almost_equal(A @ x, b)
 
-    @pytest.mark.parametrize("bad_rhs_batch_size", [0, -1, 'foo', None])
-    def test_bad_rhs_batch_size(self, bad_rhs_batch_size):
+    @pytest.mark.parametrize("bad_rhs_batch_size", ['foo', None])
+    def test_bad_rhs_batch_size_type(self, bad_rhs_batch_size):
         N = 5
         A = eye_array(N, dtype=float, format='csc')
         b = np.arange(N)
+        with assert_raises(TypeError, match="must be an integer"):
+            spsolve(A, b, rhs_batch_size=bad_rhs_batch_size)
 
-        with assert_raises(ValueError, match="must be a positive integer"):
+    @pytest.mark.parametrize("bad_rhs_batch_size", [0, -1])
+    def test_bad_rhs_batch_size_value(self, bad_rhs_batch_size):
+        N = 5
+        A = eye_array(N, dtype=float, format='csc')
+        b = np.arange(N)
+        with assert_raises(ValueError, match="must be an integer not less than 1"):
             spsolve(A, b, rhs_batch_size=bad_rhs_batch_size)
 
     @pytest.mark.parametrize("K", [0, 1, 10])

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -453,6 +453,29 @@ class TestLinsolve:
         x = spsolve(A, b)
         assert_array_almost_equal(A @ x, b)
 
+    @pytest.mark.parametrize("bad_rhs_batch_size", [0, -1, 'foo', None])
+    def test_bad_rhs_batch_size(self, bad_rhs_batch_size):
+        N = 5
+        A = eye_array(N, dtype=float, format='csc')
+        b = np.arange(N)
+
+        with assert_raises(ValueError, match="must be a positive integer"):
+            spsolve(A, b, rhs_batch_size=bad_rhs_batch_size)
+
+    @pytest.mark.parametrize("K", [0, 1, 10])
+    @pytest.mark.parametrize("rhs_batch_size", [1, 2, 3, 10, 20])
+    def test_rhs_batch_size(self, K, rhs_batch_size):
+        rng = np.random.default_rng(56)
+        N = 5
+        A = eye_array(N, dtype=float, format='csc')
+        s = rng.random(N)
+        x_true = np.outer(s, 1 + np.arange(K))  # (N, K)
+        b = A @ x_true
+        x = spsolve(A, b, rhs_batch_size=rhs_batch_size, use_umfpack=False)
+        if K == 1:
+            x_true = x_true.ravel()
+        assert_array_almost_equal(x, x_true)
+
 
 class TestSplu:
     def setup_method(self):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

## What does this implement/fix?
This PR makes a substantial improvement to the peak memory usage and a reduction in run-time of `sparse.linalg.spsolve` when solving systems with many sparse right-hand sides. The original implementation looped over each column of the input, converted it to a dense column, and computed the full coordinates of the output with calls to `np.full`. The new implementation uses the `sparse.csc_array` format to avoid those full array creations.

This PR also introduces the `batch_size` kwarg that can be used to control the number of columns solved at one time. The `SuperLU` solver can handle dense matrix inputs natively at the C level, so instead of using a python loop over each column of the sparse RHS matrix input to `spsolve`, we can convert, *e.g.*, 100 columns at a time to dense and pass them to `SuperLU`. The input `batch_size=1` retains the original `spsolve` behavior. The `batch_size` argument does not apply to `use_umfpack=True` cases, because the low-level `scikit-umfpack` routines used in `spsolve` cannot handle matrix inputs.


## Additional information
[Benchmark results](https://broesler.github.io/scipy/#summarylist?sort=0&dir=asc) show a 35-50% reduction in peak memory use, with no change in run time for `batch_size=1`.

#### Peak memory use vs commit, `batch_size=1`
<img width="2531" height="1251" alt="image" src="https://github.com/user-attachments/assets/7ae693db-11c5-4ba3-a373-cf5f75bce086" />

#### Runtime vs commit, `batch_size=1`
<img width="2539" height="1250" alt="image" src="https://github.com/user-attachments/assets/9d918b53-1efe-4524-b690-eb7d3e480751" />

Note that the benchmarks across commits are only valid for `batch_size=1`, since that option was introduced in the latest commit.


### Default Batch Size
I chose the default batch size to optimize runtime and memory use. Plots of peak memory use and timing shows minimums for `batch_size=10` on my local machine. Peak memory use is not significantly changed vs. `batch_size=1`, but the benchmark shows a 50% reduction in runtime by using `batch_size=10`.

#### Peak memory use vs batch_size
<img width="2537" height="1244" alt="image" src="https://github.com/user-attachments/assets/6b7378ed-029b-4e98-992d-bf4bf24b8f80" />

#### Runtime vs commit vs batch_size
<img width="2532" height="1249" alt="image" src="https://github.com/user-attachments/assets/efea5594-6a02-4f2c-b9a3-db2b65c50e44" />

Memory and Runtime tables filtered to show only the `use_umfpack=False` results (SuperLU):

#### Peak Memory Usage (`peakmem_solve`)
*Lower is better. `batch_size=10` uses the least memory.*

| Nsq | K | Density | Batch=1 (Baseline) | Batch=10 | Batch=100 | Batch=5000 (Full) |
|---:|---:|---:|---:|---:|---:|---:|
| 5000 | 2000 | 0.01 | 331M | **318M** | 385M | 550M |
| 5000 | 2000 | 0.1 | 358M | **349M** | 413M | 606M |
| 5000 | 2000 | 0.5 | 501M | **487M** | 541M | 641M |

#### Execution Time (`time_solve`)
*Lower is better. `batch_size=10` is consistently the fastest.*

| Nsq | K | Density | Batch=1 (Baseline) | Batch=10 | Batch=100 | Batch=5000 (Full) |
|---:|---:|---:|---:|---:|---:|---:|
| 5000 | 2000 | 0.01 | 810±40ms | **391±3ms** | 441±8ms | 498±8ms |
| 5000 | 2000 | 0.1 | 843±40ms | **395±20ms** | 437±10ms | 491±4ms |
| 5000 | 2000 | 0.5 | 864±60ms | **423±30ms** | 458±5ms | 530±20ms |

