### PR TITLE
ENH: spatial: factor out `from_matrix` orthogonalization for speedup on known orthogonal matrices

### DIFF
--- a/scipy/spatial/transform/_rigid_transform_cy.pyx
+++ b/scipy/spatial/transform/_rigid_transform_cy.pyx
@@ -2,6 +2,7 @@
 
 import numpy as np
 from ._rotation_cy import from_matrix as from_rot_matrix
+from ._rotation_cy import _from_matrix_orthogonal as from_rot_matrix_orthogonal
 from ._rotation_cy import inv as rot_inv
 from ._rotation_cy import from_quat, from_rotvec
 from ._rotation_cy import as_matrix, as_quat, as_rotvec, compose_quat
@@ -151,7 +152,7 @@ def from_dual_quat(dual_quat, *, bint scalar_first=False):
 @cython.wraparound(False)
 def as_exp_coords(double[:, :, :] matrix):
     exp_coords = np.empty((matrix.shape[0], 6), dtype=float)
-    rot_vec = as_rotvec(from_rot_matrix(matrix[:, :3, :3]))
+    rot_vec = as_rotvec(from_rot_matrix_orthogonal(matrix[:, :3, :3]))
     exp_coords[:, :3] = rot_vec
     exp_coords[:, 3:] = np.einsum('ijk,ik->ij',
                                   _compute_se3_log_translation_transform(rot_vec),
@@ -163,7 +164,7 @@ def as_exp_coords(double[:, :, :] matrix):
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def as_dual_quat(double[:, :, :] matrix, *, bint scalar_first=False):
-    real_parts = as_quat(from_rot_matrix(matrix[:, :3, :3]))
+    real_parts = as_quat(from_rot_matrix_orthogonal(matrix[:, :3, :3]))
 
     pure_translation_quats = np.empty((len(matrix), 4), dtype=float)
     pure_translation_quats[:, :3] = matrix[:, :3, 3]
@@ -271,7 +272,7 @@ def mean(double[:, :, :] matrix, weights=None, axis=None):
     # error during validation.
     axis = 0
 
-    quat = as_quat(from_rot_matrix(matrix[:, :3, :3]))
+    quat = as_quat(from_rot_matrix_orthogonal(matrix[:, :3, :3]))
     t = np.asarray(matrix[:, :3, 3])
 
     if weights is None:

--- a/scipy/spatial/transform/_rigid_transform_xp.py
+++ b/scipy/spatial/transform/_rigid_transform_xp.py
@@ -14,6 +14,7 @@ import scipy._lib.array_api_extra as xpx
 from scipy.spatial.transform._rotation_xp import (
     as_matrix as quat_as_matrix,
     from_matrix as quat_from_matrix,
+    _from_matrix_orthogonal as quat_from_matrix_orthogonal,
     from_rotvec as quat_from_rotvec,
     as_rotvec as quat_as_rotvec,
     compose_quat,
@@ -136,7 +137,7 @@ def from_dual_quat(dual_quat: Array, *, scalar_first: bool = False) -> Array:
 
 def as_exp_coords(matrix: Array) -> Array:
     xp = array_namespace(matrix)
-    rot_vec = quat_as_rotvec(quat_from_matrix(matrix[..., :3, :3]))
+    rot_vec = quat_as_rotvec(quat_from_matrix_orthogonal(matrix[..., :3, :3]))
     translation_transform = _compute_se3_log_translation_transform(rot_vec)
     translations = (translation_transform @ matrix[..., :3, 3][..., None])[..., 0]
     exp_coords = xp.concat([rot_vec, translations], axis=-1)
@@ -145,7 +146,7 @@ def as_exp_coords(matrix: Array) -> Array:
 
 def as_dual_quat(matrix: Array, *, scalar_first: bool = False) -> Array:
     xp = array_namespace(matrix)
-    real_parts = quat_from_matrix(matrix[..., :3, :3])
+    real_parts = quat_from_matrix_orthogonal(matrix[..., :3, :3])
 
     pure_translation_quats = xp.empty(
         (*matrix.shape[:-2], 4), dtype=matrix.dtype, device=xp_device(matrix)
@@ -276,7 +277,7 @@ def mean(
     axis = tuple(sorted(set(x % (matrix.ndim - 2) for x in axis)))
 
     lazy = is_lazy_array(matrix)
-    quats = quat_from_matrix(matrix[..., :3, :3])
+    quats = quat_from_matrix_orthogonal(matrix[..., :3, :3])
     if weights is None:
         quats_mean = quat_mean(quats, axis=axis)
     else:

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -71,6 +71,14 @@ def from_matrix(matrix: Array) -> Array:
     orthogonal_matrix = U @ Vt
     matrix = xp.where(is_orthogonal, matrix, orthogonal_matrix)
 
+    return _from_matrix_orthogonal(matrix)
+
+
+def _from_matrix_orthogonal(matrix: Array) -> Array:
+    """Convert known orthogonal rotation matrix to quaternion"""
+    xp = array_namespace(matrix)
+    device = xp_device(matrix)
+
     matrix_trace = matrix[..., 0, 0] + matrix[..., 1, 1] + matrix[..., 2, 2]
     decision = xp.stack(
         [matrix[..., 0, 0], matrix[..., 1, 1], matrix[..., 2, 2], matrix_trace],
@@ -759,7 +767,7 @@ def _align_vectors(a: Array, b: Array, weights: Array) -> tuple[Array, Array, Ar
     kappa = s[..., 0] * s[..., 1] + s[..., 1] * s[..., 2] + s[..., 2] * s[..., 0]
     eye = xp.eye(3, dtype=a.dtype, device=device)
     sensitivity = xp.mean(weights) / zeta * (kappa * eye + B @ B.mT)
-    q_opt = from_matrix(C)
+    q_opt = _from_matrix_orthogonal(C)
     return q_opt, rssd, sensitivity
 
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
This factors out matrix orthogonalization when generating quaternions from matrices into a private function. This allows us to skip some moderately expensive checks (determinants and matmuls) when working with internal matrices that we know are already orthogonal, and should provide a speed boost. These checks were added in https://github.com/scipy/scipy/pull/22418

This also now skips singular value decomposition in `Rotation.from_matrix()` on eager backends when applicable.

Note that the algorithm to convert the matrix to quaternion still does include a small-angle orthogonalization which corrects for round-off error. See the reference from the docs: [F. Landis Markley, "Unit Quaternion from Rotation Matrix", Journal of guidance, control, and dynamics vol. 31.2, pp. 440-442, 2008.](https://arc.aiaa.org/doi/abs/10.2514/1.31730)

Originally suggested by @amacati in this comment: https://github.com/scipy/scipy/pull/23718#discussion_r2440576137

#### Additional information
<!--Any additional information you think is important.-->
