### PR TITLE
MAINT: Fix a deprecation warning coming from pytest-run-parallel

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -40,6 +40,6 @@ markers =
     xfail_xp_backends(backends, reason=None, np_only=False, cpu_only=False, eager_only=False, exceptions=None): mark the desired xfail configuration for the `xfail_xp_backends` fixture
     timeout: mark a test for a non-default timeout
     fail_slow: mark a test for a non-default timeout failure
-    parallel_threads(n): run the given test function in parallel
+    parallel_threads_limit(n): run the given test function in parallel
     thread_unsafe: mark the test function as single-threaded
     iterations(n): run the given test function `n` times in each thread

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -80,7 +80,7 @@ def pytest_configure(config):
     if not PARALLEL_RUN_AVAILABLE:
         config.addinivalue_line(
             'markers',
-            'parallel_threads(n): run the given test function in parallel '
+            'parallel_threads_limit(n): run the given test function in parallel '
             'using `n` threads.')
         config.addinivalue_line(
             "markers",

--- a/scipy/integrate/tests/test__quad_vec.py
+++ b/scipy/integrate/tests/test__quad_vec.py
@@ -127,9 +127,10 @@ class TestQuadVec:
 
     @pytest.mark.fail_slow(10)
     @pytest.mark.parametrize('extra_args', [2, (2,)])
-    @pytest.mark.parametrize('workers',
-                             [1,
-                              pytest.param(10, marks=pytest.mark.parallel_threads(4))])
+    @pytest.mark.parametrize(
+        'workers',
+        [1, pytest.param(10, marks=pytest.mark.parallel_threads_limit(4))]
+    )
     def test_quad_vec_pool_args(self, extra_args, workers):
         f = _func_with_args
         exact = np.array([0, 4/3, 8/3])

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1215,7 +1215,7 @@ class TestSVD_GESVD(TestSVD_GESDD):
 # since the maximum memory that can be in 32-bit (WASM) is 4GB
 @pytest.mark.skipif(IS_WASM, reason="out of memory in WASM")
 @pytest.mark.xfail_on_32bit("out of memory in 32-bit CI workflow")
-@pytest.mark.parallel_threads(2)  # 1.9 GiB per thread RAM usage
+@pytest.mark.parallel_threads_limit(2)  # 1.9 GiB per thread RAM usage
 @pytest.mark.fail_slow(10)
 def test_svd_gesdd_nofegfault():
     # svd(a) with {U,VT}.size > INT_MAX does not segfault

--- a/scipy/linalg/tests/test_extending.py
+++ b/scipy/linalg/tests/test_extending.py
@@ -10,7 +10,7 @@ from scipy.linalg.blas import cdotu  # type: ignore[attr-defined]
 from scipy.linalg.lapack import dgtsv  # type: ignore[attr-defined]
 
 
-@pytest.mark.parallel_threads(4)  # 0.35 GiB per thread RAM usage
+@pytest.mark.parallel_threads_limit(4)  # 0.35 GiB per thread RAM usage
 @pytest.mark.fail_slow(120)
 # essential per https://github.com/scipy/scipy/pull/20487#discussion_r1567057247
 @pytest.mark.skipif(IS_EDITABLE,

--- a/scipy/optimize/tests/test_least_squares.py
+++ b/scipy/optimize/tests/test_least_squares.py
@@ -396,7 +396,7 @@ class BaseMixin:
 
     # This test is thread safe, but it is too slow and opens
     # too many file descriptors to run it in parallel.
-    @pytest.mark.parallel_threads(1)
+    @pytest.mark.parallel_threads_limit(1)
     @pytest.mark.fail_slow(5.0)
     def test_workers(self):
         serial = least_squares(fun_trivial, 2.0, method=self.method)

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -669,7 +669,7 @@ class SVDSCommonTests:
 
     @pytest.mark.filterwarnings("ignore:Exited at iteration")
     @pytest.mark.filterwarnings("ignore:Exited postprocessing")
-    @pytest.mark.parallel_threads(4)  # Very slow
+    @pytest.mark.parallel_threads_limit(4)  # Very slow
     @pytest.mark.parametrize("shape", SHAPES)
     @pytest.mark.parametrize("dtype", (np.float32, np.float64,
                                        np.complex64, np.complex128))

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -1114,7 +1114,7 @@ class TestNumericalInverseHermite:
 
     @pytest.mark.fail_slow(5)
     @pytest.mark.filterwarnings('ignore::RuntimeWarning')
-    @pytest.mark.parallel_threads(4)  # Very slow
+    @pytest.mark.parallel_threads_limit(4)  # Very slow
     def test_basic_truncnorm_gh17155(self):
         self.basic_test_all_scipy_dists("truncnorm", (0.1, 2))
 


### PR DESCRIPTION
In `pytest-run-parallel` 0.8.0, released November 24, the mark `parallel_threads(n)` is deprecated; `parallel_threads_limit(n)` is the recommended replacement.

See https://github.com/Quansight-Labs/pytest-run-parallel/pull/149 and https://github.com/Quansight-Labs/pytest-run-parallel/pull/146.