### PR TITLE
MAINT: Use pytest-run-parallel==0.7.1 until deprecations warnings can be fixed.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -478,7 +478,7 @@ jobs:
     - name: Install pytest-run-parallel
       if: ${{ matrix.parallel == '1'}}
       run: |
-        pip install pytest-run-parallel
+        pip install pytest-run-parallel==0.7.1
         pip uninstall --yes pytest-xdist
 
     - name: Build SciPy


### PR DESCRIPTION
`pytest-run-parallel` 0.8.0 was released today, and it results in deprecation warnings in the linux free-threaded CI job.