### PR TITLE
DEV: tach: use `respect_gitignore = "if_git_repo"`

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3639,7 +3639,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/linux-64/ruff-0.14.4-h813ae00_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/spin-0.15-pyh8f84b5b_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/tach-0.32.0-py310h1570de5_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tach-0.32.1-py310h1570de5_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://prefix.dev/conda-forge/noarch/tokenize-rt-6.2.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
@@ -3746,7 +3746,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-arm64/ruff-0.14.4-h382de68_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/spin-0.15-pyh8f84b5b_0.conda
-      - conda: https://prefix.dev/conda-forge/osx-arm64/tach-0.32.0-py310h06fc29a_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/tach-0.32.1-py310h06fc29a_0.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/tokenize-rt-6.2.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
@@ -3830,7 +3830,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/ruff-0.14.4-h15e3a1f_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/smmap-5.0.2-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/spin-0.15-pyha7b4d00_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/tach-0.32.0-py310hdba2031_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/tach-0.32.1-py310hdba2031_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/tokenize-rt-6.2.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/tomli-2.3.0-pyhcf101f3_0.conda
@@ -15680,10 +15680,10 @@ packages:
   license_family: MIT
   size: 37554
   timestamp: 1733589854804
-- conda: https://prefix.dev/conda-forge/linux-64/tach-0.32.0-py310h1570de5_0.conda
+- conda: https://prefix.dev/conda-forge/linux-64/tach-0.32.1-py310h1570de5_0.conda
   noarch: python
-  sha256: 0e4ca2aa8d6e88cc7c4c4a5af520b6cfee37b0cc1791cac4da3c61c626335468
-  md5: 1fbc9cfd706575c48419bfab533c2521
+  sha256: b67cc20a7a0c301a2327eecaaebc80c8c358a95abe985995d4303400af5f6d9d
+  md5: 013326350b2efcf8861fb26ea2f99286
   depends:
   - gitpython >=3.1,<4.0
   - networkx >=2.6,<4.0
@@ -15694,20 +15694,19 @@ packages:
   - rich >=13.0,<15.0
   - tomli >=1.2.2
   - tomli-w >=1.0,<2.0
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   - _python_abi3_support 1.*
   - cpython >=3.10
   constrains:
   - __glibc >=2.17
   license: MIT
-  license_family: MIT
-  size: 3099005
-  timestamp: 1763563955687
-- conda: https://prefix.dev/conda-forge/osx-arm64/tach-0.32.0-py310h06fc29a_0.conda
+  size: 3095564
+  timestamp: 1764166638729
+- conda: https://prefix.dev/conda-forge/osx-arm64/tach-0.32.1-py310h06fc29a_0.conda
   noarch: python
-  sha256: cda38b0d3a40ff836e7ecd5a9825201c62f4000a4a4d84436a45434e55633a2b
-  md5: aaea13dfab79a4f242c233213b808988
+  sha256: e9ddeed592d67e1f6c472c04a1598ac843ec81ceb2d1ffc567512f940b8830ef
+  md5: 6286a3242365bddc7aa5ad51de954a3c
   depends:
   - gitpython >=3.1,<4.0
   - networkx >=2.6,<4.0
@@ -15724,13 +15723,12 @@ packages:
   constrains:
   - __osx >=11.0
   license: MIT
-  license_family: MIT
-  size: 2897998
-  timestamp: 1763564082756
-- conda: https://prefix.dev/conda-forge/win-64/tach-0.32.0-py310hdba2031_0.conda
+  size: 2893509
+  timestamp: 1764166788530
+- conda: https://prefix.dev/conda-forge/win-64/tach-0.32.1-py310hdba2031_0.conda
   noarch: python
-  sha256: 46f1c9eaa013f92e6e525321a1892b957562e2b8d2df00826e523c9aac1e4161
-  md5: eeb06f8d205d85017b3ec2f17e9457c3
+  sha256: dbc562a35e9f5dcf6653c28b2786cbb9ab4586429f6d794a6043b102a751917f
+  md5: cab1c18931fd7d3a59bb627687b7af24
   depends:
   - gitpython >=3.1,<4.0
   - networkx >=2.6,<4.0
@@ -15750,9 +15748,8 @@ packages:
   - _python_abi3_support 1.*
   - cpython >=3.10
   license: MIT
-  license_family: MIT
-  size: 3178143
-  timestamp: 1763563964655
+  size: 3173523
+  timestamp: 1764166631246
 - conda: https://prefix.dev/conda-forge/osx-arm64/tapi-1300.6.5-h03f4b80_0.conda
   sha256: 37cd4f62ec023df8a6c6f9f6ffddde3d6620a83cbcab170a8fff31ef944402e5
   md5: b703bc3e6cba5943acf0e5f987b5d0e2

--- a/tach.toml
+++ b/tach.toml
@@ -1,3 +1,5 @@
+respect_gitignore = "if_git_repo"
+
 exclude = [
   "scipy/_lib/array_api_compat",
   "scipy/_lib/array_api_extra",


### PR DESCRIPTION
When running from within a gitignored directory, like in `scipystack`,

after:

```
❯ pixi run tach-check
✨ Pixi task (tach-check in lint): tach check --exact: (Check inter-module dependencies)
✅ All modules validated!
```

before:

```
❯ pixi run tach-check
✨ Pixi task (tach-check in lint): tach check --exact: (Check inter-module dependencies)                               Configuration
⚠️  Warning: No first-party imports were found. You may need to use 'tach mod' to update your Python source roots. Docs: https://docs.gauge.sh/usage/configuration#source-roots
Unused Dependencies
❌ 'scipy' does not depend on: ['scipy._lib']
❌ 'scipy._lib' does not depend on: ['scipy']
❌ 'scipy.cluster' does not depend on: ['scipy._lib', 'scipy.cluster.hierarchy', 'scipy.cluster.vq']
❌ 'scipy.cluster.hierarchy' does not depend on: ['scipy._lib', 'scipy.cluster', 'scipy.spatial.distance']
❌ 'scipy.cluster.vq' does not depend on: ['scipy._lib', 'scipy.cluster', 'scipy.spatial.distance']
❌ 'scipy.constants' does not depend on: ['scipy._lib']
❌ 'scipy.datasets' does not depend on: ['scipy._lib']
❌ 'scipy.differentiate' does not depend on: ['scipy._lib']
❌ 'scipy.fft' does not depend on: ['scipy._lib', 'scipy.special']
❌ 'scipy.fftpack' does not depend on: ['scipy._lib', 'scipy.fft']
❌ 'scipy.integrate' does not depend on: ['scipy._lib', 'scipy.interpolate', 'scipy.linalg', 'scipy.optimize',
'scipy.sparse', 'scipy.sparse.linalg', 'scipy.special', 'scipy.stats']
❌ 'scipy.interpolate' does not depend on: ['scipy', 'scipy._lib', 'scipy.linalg', 'scipy.linalg.lapack',
'scipy.optimize', 'scipy.sparse', 'scipy.sparse.linalg', 'scipy.spatial', 'scipy.spatial.distance', 'scipy.special']
❌ 'scipy.io' does not depend on: ['scipy._lib', 'scipy.io.arff', 'scipy.io.matlab', 'scipy.io.wavfile',
'scipy.sparse']
❌ 'scipy.io.arff' does not depend on: ['scipy._lib']
❌ 'scipy.io.matlab' does not depend on: ['scipy._lib', 'scipy.sparse']
❌ 'scipy.linalg' does not depend on: ['scipy._lib', 'scipy.fft', 'scipy.linalg.blas', 'scipy.linalg.lapack',
'scipy.sparse', 'scipy.sparse.linalg', 'scipy.special']
❌ 'scipy.linalg.blas' does not depend on: ['scipy.linalg']
❌ 'scipy.linalg.interpolative' does not depend on: ['scipy.linalg', 'scipy.sparse.linalg']
❌ 'scipy.linalg.lapack' does not depend on: ['scipy.linalg', 'scipy.linalg.blas']
❌ 'scipy.ndimage' does not depend on: ['scipy._lib', 'scipy.special']
❌ 'scipy.odr' does not depend on: ['scipy._lib', 'scipy.linalg']
❌ 'scipy.optimize' does not depend on: ['scipy', 'scipy._lib', 'scipy.linalg', 'scipy.linalg.blas',
'scipy.linalg.interpolative', 'scipy.sparse', 'scipy.sparse.linalg', 'scipy.spatial', 'scipy.special',
'scipy.stats.qmc']
❌ 'scipy.optimize.elementwise' does not depend on: ['scipy.optimize']
❌ 'scipy.signal' does not depend on: ['scipy._lib', 'scipy.fft', 'scipy.interpolate', 'scipy.linalg', 'scipy.ndimage',
'scipy.optimize', 'scipy.signal.windows', 'scipy.spatial', 'scipy.special', 'scipy.stats']
❌ 'scipy.signal.windows' does not depend on: ['scipy._lib', 'scipy.fft', 'scipy.linalg', 'scipy.special']
❌ 'scipy.sparse' does not depend on: ['scipy', 'scipy._lib', 'scipy.sparse.linalg']
❌ 'scipy.sparse.csgraph' does not depend on: ['scipy._lib', 'scipy.sparse', 'scipy.sparse.linalg']
❌ 'scipy.sparse.linalg' does not depend on: ['scipy._lib', 'scipy.linalg', 'scipy.sparse']
❌ 'scipy.spatial' does not depend on: ['scipy', 'scipy._lib', 'scipy.linalg', 'scipy.spatial.distance',
'scipy.spatial.transform']
❌ 'scipy.spatial.distance' does not depend on: ['scipy._lib', 'scipy.linalg', 'scipy.spatial', 'scipy.special']
❌ 'scipy.spatial.transform' does not depend on: ['scipy._lib', 'scipy.constants', 'scipy.interpolate', 'scipy.linalg']
❌ 'scipy.special' does not depend on: ['scipy._lib', 'scipy.linalg', 'scipy.optimize.elementwise']
❌ 'scipy.stats' does not depend on: ['scipy._lib', 'scipy.fft', 'scipy.integrate', 'scipy.interpolate',
'scipy.linalg', 'scipy.linalg.blas', 'scipy.ndimage', 'scipy.optimize', 'scipy.sparse', 'scipy.sparse.csgraph',
'scipy.spatial', 'scipy.spatial.distance', 'scipy.special', 'scipy.stats.contingency', 'scipy.stats.distributions',
'scipy.stats.mstats', 'scipy.stats.qmc']
❌ 'scipy.stats.contingency' does not depend on: ['scipy._lib', 'scipy.stats']
❌ 'scipy.stats.distributions' does not depend on: ['scipy.stats']
❌ 'scipy.stats.mstats' does not depend on: ['scipy.stats']
❌ 'scipy.stats.qmc' does not depend on: ['scipy.stats']
❌ 'scipy.stats.sampling' does not depend on: ['scipy.stats']
❌ 'scipy.conftest' does not depend on: ['scipy._lib', 'scipy.integrate']
❌ 'scipy.special._precompute' does not depend on: ['scipy.special', 'scipy.optimize', 'scipy.integrate']

Remove the unused dependencies from tach.toml, or consider running 'tach sync' to update module configuration and
remove all unused dependencies.
```