### PR TITLE
MAINT: interpolate/RBF: use fixed-width ints with pythran

### DIFF
--- a/scipy/interpolate/_rbfinterp_np.py
+++ b/scipy/interpolate/_rbfinterp_np.py
@@ -24,7 +24,7 @@ def polynomial_matrix(x, powers, xp):
 
 def _monomial_powers(ndim, degree, xp):
     out = _monomial_powers_impl(ndim, degree)
-    out = np.asarray(out, dtype=np.dtype("long"))
+    out = np.asarray(out, dtype=np.int64)
     if len(out) == 0:
         out = out.reshape(0, ndim)
     return out

--- a/scipy/interpolate/_rbfinterp_pythran.py
+++ b/scipy/interpolate/_rbfinterp_pythran.py
@@ -84,7 +84,7 @@ def _kernel_matrix(x, kernel):
     return out
 
 
-# pythran export _polynomial_matrix(float[:, :], int[:, :])
+# pythran export _polynomial_matrix(float[:, :], int64[:, :])
 def _polynomial_matrix(x, powers):
     """Return monomials, with exponents from `powers`, evaluated at `x`."""
     out = np.empty((x.shape[0], powers.shape[0]), dtype=float)
@@ -97,7 +97,7 @@ def _polynomial_matrix(x, powers):
 #                              float[:],
 #                              str,
 #                              float,
-#                              int[:, :])
+#                              int64[:, :])
 def _build_system(y, d, smoothing, kernel, epsilon, powers):
     """Build the system used to solve for the RBF interpolant coefficients.
 
@@ -168,7 +168,7 @@ def _build_system(y, d, smoothing, kernel, epsilon, powers):
 #                          float[:, :],
 #                          str,
 #                          float,
-#                          int[:, :],
+#                          int64[:, :],
 #                          float[:],
 #                          float[:])
 def _build_evaluation_coefficients(x, y, kernel, epsilon, powers,


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

a part of gh-19462

#### What does this implement/fix?
<!--Please explain your changes.-->

Use fixed-width integer dtypes in the python/pythran interface, instead of `np.dtype("long")`  in the python side and `int[:]` in the pythran side.

#### Additional information
<!--Any additional information you think is important.-->

The whole `np.dtype("long")` thing is a remnant of the NumPy 2.0 transition. There's no reason to keep using it if we can help it.