### PR TITLE
ENH: sparse.sparray: add utility functions

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -19,7 +19,8 @@ SciPy 2-D sparse array package for numeric data.
    This package is switching to an array interface, compatible with
    NumPy arrays, from the older matrix interface.  We recommend that
    you use the array objects (`bsr_array`, `coo_array`, etc.) for
-   all new work.
+   all new work. You can check if an object is a sparse array or 
+   sparse matrix using `issparray` and `isspmatrix`, respectively.
 
    When using the array interface, please note that:
 
@@ -117,8 +118,14 @@ Identifying sparse arrays
 .. autosummary::
    :toctree: generated/
 
-   issparse - Check if the argument is a sparse object (array or matrix).
    issparray
+   issparray_csc
+   issparray_csr
+   issparray_bsr
+   issparray_lil
+   issparray_dok
+   issparray_coo
+   issparray_dia
 
 
 Sparse matrix classes
@@ -158,7 +165,6 @@ Identifying sparse matrices
 .. autosummary::
    :toctree: generated/
 
-   issparse
    isspmatrix
    isspmatrix_csc
    isspmatrix_csr
@@ -167,6 +173,23 @@ Identifying sparse matrices
    isspmatrix_dok
    isspmatrix_coo
    isspmatrix_dia
+   
+
+Identifying sparse objects (arrays and matrices)
+------------------------------------------------
+
+
+.. autosummary::
+   :toctree: generated/
+
+   issparse
+   issparse_csc
+   issparse_csr
+   issparse_bsr
+   issparse_lil
+   issparse_dok
+   issparse_coo
+   issparse_dia
 
 
 Warnings

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -118,6 +118,7 @@ Identifying sparse arrays
    :toctree: generated/
 
    issparse - Check if the argument is a sparse object (array or matrix).
+   issparray
 
 
 Sparse matrix classes

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -12,7 +12,7 @@ from scipy._lib._sparse import SparseABC, issparse
 
 from ._matrix import spmatrix
 
-__all__ = ['isspmatrix', 'issparse', 'sparray',
+__all__ = ['isspmatrix', 'issparray', 'issparse', 'sparray',
            'SparseWarning', 'SparseEfficiencyWarning']
 
 
@@ -1604,3 +1604,32 @@ def isspmatrix(x):
     False
     """
     return isinstance(x, spmatrix)
+
+
+def issparray(x):
+    """Is `x` of a sparse array type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a sparse array
+
+    Returns
+    -------
+    bool
+        True if `x` is a sparse array, False otherwise
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.sparse import csr_array, csr_matrix, issparray
+    >>> issparray(csr_matrix([[5]]))
+    False
+    >>> issparray(csr_array([[5]]))
+    True
+    >>> issparray(np.array([[5]]))
+    False
+    >>> issparray(5)
+    False
+    """
+    return isinstance(x, sparray)

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1282,6 +1282,20 @@ class _spbase(SparseABC):
 
         With copy=False, the data/indices may be shared between this array/matrix and
         the resultant `sparray`.
+        
+                Examples
+        --------
+        >>> from scipy.sparse import csr_array, csr_matrix, csc_array, csc_matrix
+        >>> type(csr_array([[1, 0], [0, 2]]).tosparray())
+        <class 'scipy.sparse._csr.csr_array'>
+        >>> type(csc_array([[1, 0], [0, 2]]).tosparray())
+        <class 'scipy.sparse._csc.csc_array'>
+        >>> type(csr_matrix([[1, 0], [0, 2]]).tosparray())
+        <class 'scipy.sparse._csr.csr_array'>
+        >>> type(csc_matrix([[1, 0], [0, 2]]).tosparray())
+        <class 'scipy.sparse._csc.csc_array'>
+        
+        .. versionadded:: 1.16.4
         """
         if issparray(self):
             if copy:
@@ -1298,6 +1312,20 @@ class _spbase(SparseABC):
 
         With copy=False, the data/indices may be shared between this array/matrix and
         the resultant `spmatrix`.
+        
+        Examples
+        --------
+        >>> from scipy.sparse import csr_array, csr_matrix, csc_array, csc_matrix
+        >>> type(csr_array([[1, 0], [0, 2]]).tospmatrix())
+        <class 'scipy.sparse._csr.csr_matrix'>
+        >>> type(csc_array([[1, 0], [0, 2]]).tospmatrix())
+        <class 'scipy.sparse._csc.csc_matrix'>
+        >>> type(csr_matrix([[1, 0], [0, 2]]).tospmatrix())
+        <class 'scipy.sparse._csr.csr_matrix'>
+        >>> type(csc_matrix([[1, 0], [0, 2]]).tospmatrix())
+        <class 'scipy.sparse._csc.csc_matrix'>
+        
+        .. versionadded:: 1.16.4
         """
         if isspmatrix(self):
             if copy:

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1294,8 +1294,6 @@ class _spbase(SparseABC):
         <class 'scipy.sparse._csr.csr_array'>
         >>> type(csc_matrix([[1, 0], [0, 2]]).tosparray())
         <class 'scipy.sparse._csc.csc_array'>
-        
-        .. versionadded:: 1.16.4
         """
         if issparray(self):
             if copy:
@@ -1324,8 +1322,6 @@ class _spbase(SparseABC):
         <class 'scipy.sparse._csr.csr_matrix'>
         >>> type(csc_matrix([[1, 0], [0, 2]]).tospmatrix())
         <class 'scipy.sparse._csc.csc_matrix'>
-        
-        .. versionadded:: 1.16.4
         """
         if isspmatrix(self):
             if copy:

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -5,6 +5,8 @@ import math
 import numpy as np
 import operator
 
+import scipy
+
 from ._sputils import (asmatrix, check_reshape_kwargs, check_shape,
                        get_sum_dtype, isdense, isscalarlike, _todata,
                        matrix, validateaxis, getdtype, is_pydata_spmatrix)

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1276,6 +1276,37 @@ class _spbase(SparseABC):
         the resultant csc_array/matrix.
         """
         return self.tocsr(copy=copy).tocsc(copy=False)
+    
+    def tosparray(self, copy=False):
+        """Convert this array/matrix to a sparse array of the same format.
+
+        With copy=False, the data/indices may be shared between this array/matrix and
+        the resultant `sparray`.
+        """
+        if issparray(self):
+            if copy:
+                return self.copy()
+            else:
+                return self
+        else:
+            cls = getattr(scipy.sparse, f'{self.format}_array')
+            return cls(self, copy=copy)
+        
+        
+    def tospmatrix(self, copy=False):
+        """Convert this array/matrix to a sparse matrix of the same format.
+
+        With copy=False, the data/indices may be shared between this array/matrix and
+        the resultant `spmatrix`.
+        """
+        if isspmatrix(self):
+            if copy:
+                return self.copy()
+            else:
+                return self
+        else:
+            cls = getattr(scipy.sparse, f'{self.format}_matrix')
+            return cls(self, copy=copy)
 
     def copy(self):
         """Returns a copy of this array/matrix.

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -2,7 +2,7 @@
 
 __docformat__ = "restructuredtext en"
 
-__all__ = ['bsr_array', 'bsr_matrix', 'isspmatrix_bsr']
+__all__ = ['bsr_array', 'bsr_matrix', 'isspmatrix_bsr', 'issparray_bsr', 'issparse_bsr']
 
 from warnings import warn
 
@@ -656,6 +656,58 @@ def isspmatrix_bsr(x):
     False
     """
     return isinstance(x, bsr_matrix)
+
+def issparray_bsr(x):
+    """Is `x` of a bsr_array type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a bsr array
+
+    Returns
+    -------
+    bool
+        True if `x` is a bsr array, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import bsr_array, bsr_matrix, csr_array, issparray_bsr
+    >>> issparray_bsr(bsr_matrix([[5]]))
+    False
+    >>> issparray_bsr(bsr_array([[5]]))
+    True
+    >>> issparray_bsr(csr_array([[5]]))
+    False
+    """
+    return isinstance(x, bsr_array)
+
+def issparse_bsr(x):
+    """Is `x` of bsr format, i.e. of bsr_array or bsr_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being of bsr formar
+
+    Returns
+    -------
+    bool
+        True if `x` is of bsr format, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import bsr_array, bsr_matrix, csr_array, csr_matrix, issparse_bsr
+    >>> issparse_bsr(bsr_matrix([[5]]))
+    True
+    >>> issparse_bsr(bsr_array([[5]]))
+    True
+    >>> issparse_bsr(csr_array([[5]]))
+    False
+    >>> issparse_bsr(csr_matrix([[5]]))
+    False
+    """
+    return isinstance(x, _bsr_base)
 
 
 # This namespace class separates array from matrix with isinstance

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -2,7 +2,7 @@
 
 __docformat__ = "restructuredtext en"
 
-__all__ = ['coo_array', 'coo_matrix', 'isspmatrix_coo']
+__all__ = ['coo_array', 'coo_matrix', 'isspmatrix_coo', 'issparray_coo', 'issparse_coo']
 
 import math
 from warnings import warn
@@ -1640,6 +1640,58 @@ def isspmatrix_coo(x):
     False
     """
     return isinstance(x, coo_matrix)
+
+def issparray_coo(x):
+    """Is `x` of a coo_array type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a coo array
+
+    Returns
+    -------
+    bool
+        True if `x` is a coo array, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import coo_array, coo_matrix, csr_array, issparray_coo
+    >>> issparray_coo(coo_matrix([[5]]))
+    False
+    >>> issparray_coo(coo_array([[5]]))
+    True
+    >>> issparray_coo(csr_array([[5]]))
+    False
+    """
+    return isinstance(x, coo_array)
+
+def issparse_coo(x):
+    """Is `x` of coo format, i.e. of coo_array or coo_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being of coo formar
+
+    Returns
+    -------
+    bool
+        True if `x` is of coo format, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import coo_array, coo_matrix, csr_array, csr_matrix, issparse_coo
+    >>> issparse_coo(coo_matrix([[5]]))
+    True
+    >>> issparse_coo(coo_array([[5]]))
+    True
+    >>> issparse_coo(csr_array([[5]]))
+    False
+    >>> issparse_coo(csr_matrix([[5]]))
+    False
+    """
+    return isinstance(x, _coo_base)
 
 
 # This namespace class separates array from matrix with isinstance

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -1,7 +1,7 @@
 """Compressed Sparse Column matrix format"""
 __docformat__ = "restructuredtext en"
 
-__all__ = ['csc_array', 'csc_matrix', 'isspmatrix_csc']
+__all__ = ['csc_array', 'csc_matrix', 'isspmatrix_csc', 'issparray_csc', 'issparse_csc']
 
 
 import numpy as np
@@ -173,6 +173,58 @@ def isspmatrix_csc(x):
     False
     """
     return isinstance(x, csc_matrix)
+
+def issparray_csc(x):
+    """Is `x` of a csc_array type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a csc array
+
+    Returns
+    -------
+    bool
+        True if `x` is a csc array, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import csc_array, csc_matrix, coo_array, issparray_csc
+    >>> issparray_csc(csc_matrix([[5]]))
+    False
+    >>> issparray_csc(csc_array([[5]]))
+    True
+    >>> issparray_csc(coo_array([[5]]))
+    False
+    """
+    return isinstance(x, csc_array)
+
+def issparse_csc(x):
+    """Is `x` of csc format, i.e. of csc_array or csc_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being of csc formar
+
+    Returns
+    -------
+    bool
+        True if `x` is of csc format, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import csc_array, csc_matrix, coo_array, coo_matrix, issparse_csc
+    >>> issparse_csc(csc_matrix([[5]]))
+    True
+    >>> issparse_csc(csc_array([[5]]))
+    True
+    >>> issparse_csc(coo_array([[5]]))
+    False
+    >>> issparse_csc(coo_matrix([[5]]))
+    False
+    """
+    return isinstance(x, _csc_base)
 
 
 # This namespace class separates array from matrix with isinstance

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -2,7 +2,7 @@
 
 __docformat__ = "restructuredtext en"
 
-__all__ = ['csr_array', 'csr_matrix', 'isspmatrix_csr']
+__all__ = ['csr_array', 'csr_matrix', 'isspmatrix_csr', 'issparray_csr', 'issparse_csr']
 
 import numpy as np
 
@@ -318,6 +318,58 @@ def isspmatrix_csr(x):
     False
     """
     return isinstance(x, csr_matrix)
+
+def issparray_csr(x):
+    """Is `x` of a csr_array type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a csr array
+
+    Returns
+    -------
+    bool
+        True if `x` is a csr array, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_array, csr_matrix, coo_array, issparray_csr
+    >>> issparray_csr(csr_matrix([[5]]))
+    False
+    >>> issparray_csr(csr_array([[5]]))
+    True
+    >>> issparray_csr(coo_array([[5]]))
+    False
+    """
+    return isinstance(x, csr_array)
+
+def issparse_csr(x):
+    """Is `x` of csr format, i.e. of csr_array or csr_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being of csr formar
+
+    Returns
+    -------
+    bool
+        True if `x` is of csr format, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_array, csr_matrix, coo_array, coo_matrix, issparse_csr
+    >>> issparse_csr(csr_matrix([[5]]))
+    True
+    >>> issparse_csr(csr_array([[5]]))
+    True
+    >>> issparse_csr(coo_array([[5]]))
+    False
+    >>> issparse_csr(coo_matrix([[5]]))
+    False
+    """
+    return isinstance(x, _csr_base)
 
 
 # This namespace class separates array from matrix with isinstance

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -2,7 +2,7 @@
 
 __docformat__ = "restructuredtext en"
 
-__all__ = ['dia_array', 'dia_matrix', 'isspmatrix_dia']
+__all__ = ['dia_array', 'dia_matrix', 'isspmatrix_dia', 'issparray_dia', 'issparse_dia']
 
 import numpy as np
 
@@ -498,6 +498,58 @@ def isspmatrix_dia(x):
     False
     """
     return isinstance(x, dia_matrix)
+
+def issparray_dia(x):
+    """Is `x` of a dia_array type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a dia array
+
+    Returns
+    -------
+    bool
+        True if `x` is a dia array, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import dia_array, dia_matrix, coo_array, issparray_dia
+    >>> issparray_dia(dia_matrix([[5]]))
+    False
+    >>> issparray_dia(dia_array([[5]]))
+    True
+    >>> issparray_dia(coo_array([[5]]))
+    False
+    """
+    return isinstance(x, dia_array)
+
+def issparse_dia(x):
+    """Is `x` of dia format, i.e. of dia_array or dia_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being of dia formar
+
+    Returns
+    -------
+    bool
+        True if `x` is of dia format, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import dia_array, dia_matrix, coo_array, coo_matrix, issparse_dia
+    >>> issparse_dia(dia_matrix([[5]]))
+    True
+    >>> issparse_dia(dia_array([[5]]))
+    True
+    >>> issparse_dia(coo_array([[5]]))
+    False
+    >>> issparse_dia(coo_matrix([[5]]))
+    False
+    """
+    return isinstance(x, _dia_base)
 
 
 # This namespace class separates array from matrix with isinstance

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -2,7 +2,7 @@
 
 __docformat__ = "restructuredtext en"
 
-__all__ = ['dok_array', 'dok_matrix', 'isspmatrix_dok']
+__all__ = ['dok_array', 'dok_matrix', 'isspmatrix_dok', 'issparray_dok', 'issparse_dok']
 
 import itertools
 import numpy as np
@@ -556,6 +556,58 @@ def isspmatrix_dok(x):
     False
     """
     return isinstance(x, dok_matrix)
+
+def issparray_dok(x):
+    """Is `x` of a dok_array type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a dok array
+
+    Returns
+    -------
+    bool
+        True if `x` is a dok array, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import dok_array, dok_matrix, coo_array, issparray_dok
+    >>> issparray_dok(dok_matrix([[5]]))
+    False
+    >>> issparray_dok(dok_array([[5]]))
+    True
+    >>> issparray_dok(coo_array([[5]]))
+    False
+    """
+    return isinstance(x, dok_array)
+
+def issparse_dok(x):
+    """Is `x` of dok format, i.e. of dok_array or dok_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being of dok formar
+
+    Returns
+    -------
+    bool
+        True if `x` is of dok format, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import dok_array, dok_matrix, coo_array, coo_matrix, issparse_dok
+    >>> issparse_dok(dok_matrix([[5]]))
+    True
+    >>> issparse_dok(dok_array([[5]]))
+    True
+    >>> issparse_dok(coo_array([[5]]))
+    False
+    >>> issparse_dok(coo_matrix([[5]]))
+    False
+    """
+    return isinstance(x, _dok_base)
 
 
 # This namespace class separates array from matrix with isinstance

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -3,7 +3,7 @@
 
 __docformat__ = "restructuredtext en"
 
-__all__ = ['lil_array', 'lil_matrix', 'isspmatrix_lil']
+__all__ = ['lil_array', 'lil_matrix', 'isspmatrix_lil', 'issparray_lil', 'issparse_lil']
 
 from bisect import bisect_left
 
@@ -492,6 +492,58 @@ def isspmatrix_lil(x):
     False
     """
     return isinstance(x, lil_matrix)
+
+def issparray_lil(x):
+    """Is `x` of a lil_array type?
+
+    Parameters
+    ----------
+    x
+        object to check for being a lil array
+
+    Returns
+    -------
+    bool
+        True if `x` is a lil array, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import lil_array, lil_matrix, coo_array, issparray_lil
+    >>> issparray_lil(lil_matrix([[5]]))
+    False
+    >>> issparray_lil(lil_array([[5]]))
+    True
+    >>> issparray_lil(coo_array([[5]]))
+    False
+    """
+    return isinstance(x, lil_array)
+
+def issparse_lil(x):
+    """Is `x` of lil format, i.e. of lil_array or lil_matrix type?
+
+    Parameters
+    ----------
+    x
+        object to check for being of lil formar
+
+    Returns
+    -------
+    bool
+        True if `x` is of lil format, False otherwise
+
+    Examples
+    --------
+    >>> from scipy.sparse import lil_array, lil_matrix, coo_array, coo_matrix, issparse_lil
+    >>> issparse_lil(lil_matrix([[5]]))
+    True
+    >>> issparse_lil(lil_array([[5]]))
+    True
+    >>> issparse_lil(coo_array([[5]]))
+    False
+    >>> issparse_lil(coo_matrix([[5]]))
+    False
+    """
+    return isinstance(x, _lil_base)
 
 
 # This namespace class separates array from matrix with isinstance

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -521,7 +521,7 @@ def test_issparse():
 def test_isspmatrix():
     m = scipy.sparse.eye(3)
     a = scipy.sparse.csr_array(m)
-    assert not isinstance(m, scipy.sparse.sparray)
+    assert isinstance(m, scipy.sparse.spmatrix)
     assert isinstance(a, scipy.sparse.sparray)
 
     # Should only be true for sparse matrices, not sparse arrays
@@ -531,6 +531,20 @@ def test_isspmatrix():
     # ndarray and array_likes are not sparse
     assert not scipy.sparse.isspmatrix(a.todense())
     assert not scipy.sparse.isspmatrix(m.todense())
+    
+def test_issparray():
+    m = scipy.sparse.eye(3)
+    a = scipy.sparse.csr_array(m)
+    assert isinstance(m, scipy.sparse.spmatrix)
+    assert isinstance(a, scipy.sparse.sparray)
+
+    # Should only be true for sparse matrices, not sparse arrays
+    assert scipy.sparse.issparray(a)
+    assert not scipy.sparse.issparray(m)
+
+    # ndarray and array_likes are not sparse
+    assert not scipy.sparse.issparray(a.todense())
+    assert not scipy.sparse.issparray(m.todense())
 
 
 @pytest.mark.parametrize(

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -538,7 +538,7 @@ def test_issparray():
     assert isinstance(m, scipy.sparse.spmatrix)
     assert isinstance(a, scipy.sparse.sparray)
 
-    # Should only be true for sparse matrices, not sparse arrays
+    # Should only be true for sparse arrays, not sparse matrices
     assert scipy.sparse.issparray(a)
     assert not scipy.sparse.issparray(m)
 
@@ -562,11 +562,65 @@ def test_issparray():
 def test_isspmatrix_format(fmt, fn):
     m = scipy.sparse.eye(3, format=fmt)
     a = scipy.sparse.csr_array(m).asformat(fmt)
-    assert not isinstance(m, scipy.sparse.sparray)
+    assert isinstance(m, scipy.sparse.spmatrix)
     assert isinstance(a, scipy.sparse.sparray)
 
     # Should only be true for sparse matrices, not sparse arrays
     assert not fn(a)
+    assert fn(m)
+
+    # ndarray and array_likes are not sparse
+    assert not fn(a.todense())
+    assert not fn(m.todense())
+    
+    
+@pytest.mark.parametrize(
+    ("fmt", "fn"),
+    (
+        ("bsr", scipy.sparse.issparray_bsr),
+        ("coo", scipy.sparse.issparray_coo),
+        ("csc", scipy.sparse.issparray_csc),
+        ("csr", scipy.sparse.issparray_csr),
+        ("dia", scipy.sparse.issparray_dia),
+        ("dok", scipy.sparse.issparray_dok),
+        ("lil", scipy.sparse.issparray_lil),
+    ),
+)
+def test_issparray_format(fmt, fn):
+    m = scipy.sparse.eye(3, format=fmt)
+    a = scipy.sparse.csr_array(m).asformat(fmt)
+    assert isinstance(m, scipy.sparse.spmatrix)
+    assert isinstance(a, scipy.sparse.sparray)
+
+    # Should only be true for sparse arrays, not sparse matrices
+    assert fn(a)
+    assert not fn(m)
+
+    # ndarray and array_likes are not sparse
+    assert not fn(a.todense())
+    assert not fn(m.todense())
+    
+    
+@pytest.mark.parametrize(
+    ("fmt", "fn"),
+    (
+        ("bsr", scipy.sparse.issparse_bsr),
+        ("coo", scipy.sparse.issparse_coo),
+        ("csc", scipy.sparse.issparse_csc),
+        ("csr", scipy.sparse.issparse_csr),
+        ("dia", scipy.sparse.issparse_dia),
+        ("dok", scipy.sparse.issparse_dok),
+        ("lil", scipy.sparse.issparse_lil),
+    ),
+)
+def test_issparse_format(fmt, fn):
+    m = scipy.sparse.eye(3, format=fmt)
+    a = scipy.sparse.csr_array(m).asformat(fmt)
+    assert isinstance(m, scipy.sparse.spmatrix)
+    assert isinstance(a, scipy.sparse.sparray)
+
+    # Should be true for sparse arrays and sparse matrices
+    assert fn(a)
     assert fn(m)
 
     # ndarray and array_likes are not sparse

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -5906,3 +5906,47 @@ def test_broadcast_to():
 
         with pytest.raises(ValueError, match="cannot be broadcast"):
             container([[0, 1, 2]])._broadcast_to(shape=(3, 2))
+
+
+@pytest.mark.parametrize(
+    ("fmt"),
+    (
+        ("bsr"),
+        ("coo"),
+        ("csc"),
+        ("csr"),
+        ("dia"),
+        ("dok"),
+        ("lil"),
+    ),
+)
+def test_tosparray(fmt):
+    m = sparse.eye(3, format=fmt)
+    a = sparse.csr_array(m).asformat(fmt)
+    assert isinstance(m, sparse.spmatrix)
+    assert isinstance(a, sparse.sparray)
+    
+    assert isinstance(m.tosparray(), sparse.sparray)
+    assert isinstance(a.tosparray(), sparse.sparray)
+    
+
+@pytest.mark.parametrize(
+    ("fmt"),
+    (
+        ("bsr"),
+        ("coo"),
+        ("csc"),
+        ("csr"),
+        ("dia"),
+        ("dok"),
+        ("lil"),
+    ),
+)
+def test_tospmatrix(fmt):
+    m = sparse.eye(3, format=fmt)
+    a = sparse.csr_array(m).asformat(fmt)
+    assert isinstance(m, sparse.spmatrix)
+    assert isinstance(a, sparse.sparray)
+    
+    assert isinstance(m.tospmatrix(), sparse.spmatrix)
+    assert isinstance(a.tospmatrix(), sparse.spmatrix)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #15849

#### What does this implement/fix?
<!--Please explain your changes.-->
I felt that the new `scipy.sparse.sparray` lacked some utility support compared to the now deprecated `scipy.sparse.spmatrix`, in particular, there were only functions to check for `spmatrix` such as `isspmatrix` and `isspmatrix_{format}`. I extended that to also include `issparray` and `issparray_{format}` to check for the new classes. In addition to the already existing `issparse` function i also added `issparse_{format}` to check for a given format, independent of the array or matrix type.

Further, it was quite hard to switch to the new `sparray` format when developing new code, because most of the existing libraries are still based on the deprecated `spmatrix` format. Thus, when getting a sparse object `A` from a library, one had to first check if it is an `spmatrix` and if so figure out the format to then manually call `A = sparray_{format}(A)`. Thus i also added to new methods to `_spbase` that allow now to conveniently switch between these two formats by calling  `A = A.tosparray(copy=?)` or `A = A.tospmatrix(copy=?)`.

#### Additional information
<!--Any additional information you think is important.-->
I fully documented them and wrote pytests for all new functions, should be ready to go.
