### PR TITLE
BUG: Return zero for out-of-range derivative orders in `NdBSpline`; add C++ guard for excessive derivative `m` in `_deBoor_D`

### DIFF
--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -180,6 +180,10 @@ class NdBSpline:
         if xi_shape[-1] != ndim:
             raise ValueError(f"Shapes: xi.shape={xi_shape} and ndim={ndim}")
 
+        if any(nu > np.asarray(self.k, dtype=np.int64) + 1):
+            return np.zeros(xi_shape[:-1] + self._c.shape[ndim:],
+                            dtype=self._c.dtype)
+
         # complex -> double
         was_complex = self._c.dtype.kind == 'c'
         cc = self._c

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -180,10 +180,6 @@ class NdBSpline:
         if xi_shape[-1] != ndim:
             raise ValueError(f"Shapes: xi.shape={xi_shape} and ndim={ndim}")
 
-        if any(nu > np.asarray(self.k, dtype=np.int64) + 1):
-            return np.zeros(xi_shape[:-1] + self._c.shape[ndim:],
-                            dtype=self._c.dtype)
-
         # complex -> double
         was_complex = self._c.dtype.kind == 'c'
         cc = self._c

--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -15,18 +15,6 @@ namespace fitpack{
 void
 _deBoor_D(const double *t, double x, int k, int ell, int m, double *result) {
     /*
-     * If m > k+1, the B-spline derivative is identically zero.
-     * Avoid the de Boor recursion (which assumes m <= k+1) and
-     * return a zero-filled result directly.
-     */
-    if( m > k + 1 ) {
-        for( size_t i = 0; i < 2*k + 2; i++ ) {
-            result[i] = 0.0;
-        }
-        return ;
-    }
-
-    /*
      * On completion the result array stores
      * the k+1 non-zero values of beta^(m)_i,k(x):  for i=ell, ell-1, ell-2, ell-k.
      * Where t[ell] <= x < t[ell+1].
@@ -1217,7 +1205,18 @@ _evaluate_spline(
         else {
             // Evaluate (k+1) b-splines which are non-zero on the interval.
             // on return, first k+1 elements of work are B_{m-k},..., B_{m}
-            _deBoor_D(t.data, xval, k, interval, nu, wrk);
+            /*
+             * If nu > k+1, the B-spline derivative is identically zero.
+             * Avoid the de Boor recursion (which assumes m <= k+1) and
+             * return a zero-filled result directly.
+             */
+            if( nu > k + 1 ) {
+                for( size_t i = 0; i < 2*k + 2; i++ ) {
+                    wrk[i] = 0.0;
+                }
+            } else {
+                _deBoor_D(t.data, xval, k, interval, nu, wrk);
+            }
 
             // Form linear combinations
             for (int64_t jp=0; jp < m; jp++) {
@@ -1387,7 +1386,18 @@ _evaluate_ndbspline(const double *xi_ptr, int64_t npts, int64_t ndim,  // xi, sh
             }
 
             // compute non-zero b-splines at this value of xd in dimension d
-            _deBoor_D(td, xd, kd, i_d, nu(d), wrk.data());
+            /*
+             * If nu(d) > kd+1, the B-spline derivative is identically zero.
+             * Avoid the de Boor recursion (which assumes m <= k+1) and
+             * return a zero-filled result directly.
+             */
+            if( nu(d) > kd + 1 ) {
+                for( size_t i = 0; i < wrk.size(); i++ ) {
+                    wrk[i] = 0.0;
+                }
+            } else {
+                _deBoor_D(td, xd, kd, i_d, nu(d), wrk.data());
+            }
 
             for (int s=0; s < kd + 1; s++) {
                 b(d, s) = wrk[s];

--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -55,6 +55,12 @@ _deBoor_D(const double *t, double x, int k, int ell, int m, double *result) {
      * Now do m "derivative" recursions
      * to convert the values of beta into the mth derivative
      */
+    if (m > k + 1) {
+        throw std::runtime_error(
+            "Requested derivative order m exceeds the maximum allowed (k+1). "
+            "Cannot compute derivative of order m for spline of order k."
+        );
+    }
     for (j = k - m + 1; j <= k; j++) {
         memcpy(hh, h, j*sizeof(double));
         h[0] = 0.0;

--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -55,12 +55,6 @@ _deBoor_D(const double *t, double x, int k, int ell, int m, double *result) {
      * Now do m "derivative" recursions
      * to convert the values of beta into the mth derivative
      */
-    if (m > k + 1) {
-        throw std::runtime_error(
-            "Requested derivative order m exceeds the maximum allowed (k+1). "
-            "Cannot compute derivative of order m for spline of order k."
-        );
-    }
     for (j = k - m + 1; j <= k; j++) {
         memcpy(hh, h, j*sizeof(double));
         h[0] = 0.0;
@@ -1211,6 +1205,12 @@ _evaluate_spline(
         else {
             // Evaluate (k+1) b-splines which are non-zero on the interval.
             // on return, first k+1 elements of work are B_{m-k},..., B_{m}
+            if (nu > k + 1) {
+                throw std::runtime_error(
+                    "Requested derivative order nu exceeds the maximum allowed (k+1). "
+                    "Cannot compute derivative of order nu for spline of order k."
+                );
+            }
             _deBoor_D(t.data, xval, k, interval, nu, wrk);
 
             // Form linear combinations
@@ -1381,6 +1381,12 @@ _evaluate_ndbspline(const double *xi_ptr, int64_t npts, int64_t ndim,  // xi, sh
             }
 
             // compute non-zero b-splines at this value of xd in dimension d
+            if (nu(d) > kd + 1) {
+                throw std::runtime_error(
+                    "Requested derivative order nu(d) exceeds the maximum allowed (k+1). "
+                    "Cannot compute derivative of order nu(d) for spline of order k."
+                );
+            }
             _deBoor_D(td, xd, kd, i_d, nu(d), wrk.data());
 
             for (int s=0; s < kd + 1; s++) {

--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -15,6 +15,18 @@ namespace fitpack{
 void
 _deBoor_D(const double *t, double x, int k, int ell, int m, double *result) {
     /*
+     * If m > k+1, the B-spline derivative is identically zero.
+     * Avoid the de Boor recursion (which assumes m <= k+1) and
+     * return a zero-filled result directly.
+     */
+    if( m > k + 1 ) {
+        for( size_t i = 0; i < 2*k + 2; i++ ) {
+            result[i] = 0.0;
+        }
+        return ;
+    }
+
+    /*
      * On completion the result array stores
      * the k+1 non-zero values of beta^(m)_i,k(x):  for i=ell, ell-1, ell-2, ell-k.
      * Where t[ell] <= x < t[ell+1].
@@ -1205,12 +1217,6 @@ _evaluate_spline(
         else {
             // Evaluate (k+1) b-splines which are non-zero on the interval.
             // on return, first k+1 elements of work are B_{m-k},..., B_{m}
-            if (nu > k + 1) {
-                throw std::runtime_error(
-                    "Requested derivative order nu exceeds the maximum allowed (k+1). "
-                    "Cannot compute derivative of order nu for spline of order k."
-                );
-            }
             _deBoor_D(t.data, xval, k, interval, nu, wrk);
 
             // Form linear combinations
@@ -1381,12 +1387,6 @@ _evaluate_ndbspline(const double *xi_ptr, int64_t npts, int64_t ndim,  // xi, sh
             }
 
             // compute non-zero b-splines at this value of xd in dimension d
-            if (nu(d) > kd + 1) {
-                throw std::runtime_error(
-                    "Requested derivative order nu(d) exceeds the maximum allowed (k+1). "
-                    "Cannot compute derivative of order nu(d) for spline of order k."
-                );
-            }
             _deBoor_D(td, xd, kd, i_d, nu(d), wrk.data());
 
             for (int s=0; s < kd + 1; s++) {

--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -1047,19 +1047,19 @@ py_evaluate_all_bspl(PyObject* self, PyObject* args)
 
     // compute non-zero bsplines
     if (nu > k + 1) {
-        throw std::runtime_error(
-            "Requested derivative order nu exceeds the maximum allowed (k+1). "
-            "Cannot compute derivative of order nu for spline of order k."
+        for( size_t i = 0; i < wrk.size(); i++ ) {
+            wrk[i] = 0.0;
+        }
+    } else {
+        fitpack::_deBoor_D(
+            static_cast<const double*>(PyArray_DATA(a_t)),
+            xval,
+            k,
+            m,
+            nu,
+            wrk.data()
         );
     }
-    fitpack::_deBoor_D(
-        static_cast<const double*>(PyArray_DATA(a_t)),
-        xval,
-        k,
-        m,
-        nu,
-        wrk.data()
-    );
 
     // allocate and fill the output
     npy_intp dims[1] = {k+1};

--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -1046,20 +1046,14 @@ py_evaluate_all_bspl(PyObject* self, PyObject* args)
     std::vector<double> wrk(2*k + 2);
 
     // compute non-zero bsplines
-    if (nu > k + 1) {
-        for( size_t i = 0; i < wrk.size(); i++ ) {
-            wrk[i] = 0.0;
-        }
-    } else {
-        fitpack::_deBoor_D(
-            static_cast<const double*>(PyArray_DATA(a_t)),
-            xval,
-            k,
-            m,
-            nu,
-            wrk.data()
-        );
-    }
+    fitpack::_deBoor_D(
+        static_cast<const double*>(PyArray_DATA(a_t)),
+        xval,
+        k,
+        m,
+        nu,
+        wrk.data()
+    );
 
     // allocate and fill the output
     npy_intp dims[1] = {k+1};

--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -1046,6 +1046,12 @@ py_evaluate_all_bspl(PyObject* self, PyObject* args)
     std::vector<double> wrk(2*k + 2);
 
     // compute non-zero bsplines
+    if (nu > k + 1) {
+        throw std::runtime_error(
+            "Requested derivative order nu exceeds the maximum allowed (k+1). "
+            "Cannot compute derivative of order nu for spline of order k."
+        );
+    }
     fitpack::_deBoor_D(
         static_cast<const double*>(PyArray_DATA(a_t)),
         xval,

--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -1045,15 +1045,26 @@ py_evaluate_all_bspl(PyObject* self, PyObject* args)
     // allocate temp storage
     std::vector<double> wrk(2*k + 2);
 
-    // compute non-zero bsplines
-    fitpack::_deBoor_D(
-        static_cast<const double*>(PyArray_DATA(a_t)),
-        xval,
-        k,
-        m,
-        nu,
-        wrk.data()
-    );
+    /*
+     * If nu > k+1, the B-spline derivative is identically zero.
+     * Avoid the de Boor recursion (which assumes m <= k+1) and
+     * return a zero-filled result directly.
+     */
+    if( nu > k + 1 ) {
+        for( size_t i = 0; i < wrk.size(); i++ ) {
+            wrk[i] = 0.0;
+        }
+    } else {
+        // compute non-zero bsplines
+        fitpack::_deBoor_D(
+            static_cast<const double*>(PyArray_DATA(a_t)),
+            xval,
+            k,
+            m,
+            nu,
+            wrk.data()
+        );
+    }
 
     // allocate and fill the output
     npy_intp dims[1] = {k+1};

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2175,10 +2175,12 @@ class TestGivensQR:
     def test_evaluate_all_bspl(self):
         n = 10
         x, _, t, k = self._get_xyt(n)
+        zero_array = np.zeros((k + 1,), dtype=float)
         for xval in x:
-            assert (_dierckx.evaluate_all_bspl(t, k, xval, n, k + 2) == 0.0).all()
-        for xval in x:
-            assert (_dierckx.evaluate_all_bspl(t, k, xval, n, 2*k) == 0.0).all()
+            xp_assert_equal(
+                _dierckx.evaluate_all_bspl(t, k, xval, n, k + 2), zero_array)
+            xp_assert_equal(
+                _dierckx.evaluate_all_bspl(t, k, xval, n, 2*k), zero_array)
 
 
 def data_file(basename):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2172,6 +2172,14 @@ class TestGivensQR:
 
         xp_assert_close(cc, c, atol=1e-14)
 
+    def test_evaluate_all_bspl(self):
+        n = 10
+        x, _, t, k = self._get_xyt(n)
+        for xval in x:
+            assert (_dierckx.evaluate_all_bspl(t, k, xval, n, k + 2) == 0.0).all()
+        for xval in x:
+            assert (_dierckx.evaluate_all_bspl(t, k, xval, n, 2*k) == 0.0).all()
+
 
 def data_file(basename):
     return os.path.join(os.path.abspath(os.path.dirname(__file__)),

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2614,6 +2614,11 @@ class TestNdBSpline:
             (1, 0): lambda x, y: 3 * x**2 * (y**2 + 2*y),
             (1, 1): lambda x, y: 3 * x**2 * (2*y + 2),
             (0, 0): lambda x, y: x**3 * (y**2 + 2*y),
+            (2*kx, 1): lambda x, y: 0,
+            (2*kx, 0): lambda x, y: 0,
+            (1, 3*ky): lambda x, y: 0,
+            (0, 3*ky): lambda x, y: 0,
+            (3*kx, 2*ky): lambda x, y: 0,
         }
 
         for nu, expected_fn in test_cases.items():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/23510

#### What does this implement/fix?
<!--Please explain your changes.-->

**Summary**

This PR introduces two complementary improvements to derivative handling in NdBSpline and the underlying FITPACK-style C++ routine _deBoor_D:

1. **Python-side safeguard** — When users request derivative orders `nu` larger than the maximum supported `(k+1)` for any dimension, `NdBSpline.__call__` now returns a zero array of the correct broadcasted shape instead of raising or producing undefined behaviour.

2. **C++-side validation** — `_deBoor_D` now explicitly checks that the derivative order m does not exceed `k+1`, raising a clear `runtime_error` if violated. This prevents undefined memory usage inside the derivative recursion loop.

Together, these changes make the derivative behaviour consistent, safer, and aligned with standard B-spline mathematical properties.

#### Additional information
<!--Any additional information you think is important.-->

@ev-br 
