### PR TITLE
DEP: signal.lombscargle: deprecate positional args, warn on `precenter=False`

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -3,6 +3,7 @@
 import numpy as np
 import numpy.typing as npt
 from scipy import fft as sp_fft
+from scipy._lib.deprecation import _deprecate_positional_args
 from . import _signaltools
 from ._short_time_fft import ShortTimeFFT, FFT_MODE_TYPE
 from .windows import get_window
@@ -15,13 +16,14 @@ __all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
            'spectrogram', 'stft', 'istft', 'check_COLA', 'check_NOLA']
 
 
+@_deprecate_positional_args(version="1.19.0")
 def lombscargle(
     x: npt.ArrayLike,
     y: npt.ArrayLike,
     freqs: npt.ArrayLike,
-    precenter: bool = False,
-    normalize: bool | Literal["power", "normalize", "amplitude"] = False,
     *,
+    precenter: bool | None = None,
+    normalize: bool | Literal["power", "normalize", "amplitude"] = False,
     weights: npt.NDArray | None = None,
     floating_mean: bool = False,
 ) -> npt.NDArray:
@@ -255,13 +257,15 @@ def lombscargle(
     weights = weights * (1.0 / weights.sum())
 
     # if requested, perform precenter
-    if precenter:
+    if precenter is not None:
         msg = ("Use of parameter 'precenter' is deprecated as of SciPy 1.17.0 and "
                "will be removed in 1.19.0. Please leave 'precenter' unspecified. "
-               "It can be exactly substituted by passing 'y = (y - y.mean())' into "
+               "Passing True to 'precenter' "
+               "can be exactly substituted by passing 'y = (y - y.mean())' into "
                "the input. Consider setting `floating_mean` to True instead.")
         warnings.warn(msg, DeprecationWarning, stacklevel=2)
-        y = y - y.mean()
+        if precenter:
+            y = y - y.mean()
 
     # transform arrays
     # row vector

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -3,7 +3,7 @@
 import numpy as np
 import numpy.typing as npt
 from scipy import fft as sp_fft
-from scipy._lib.deprecation import _deprecate_positional_args
+from scipy._lib.deprecation import _deprecate_positional_args, _NoValue
 from . import _signaltools
 from ._short_time_fft import ShortTimeFFT, FFT_MODE_TYPE
 from .windows import get_window
@@ -22,7 +22,7 @@ def lombscargle(
     y: npt.ArrayLike,
     freqs: npt.ArrayLike,
     *,
-    precenter: bool | None = None,
+    precenter: bool = _NoValue,
     normalize: bool | Literal["power", "normalize", "amplitude"] = False,
     weights: npt.NDArray | None = None,
     floating_mean: bool = False,
@@ -257,7 +257,7 @@ def lombscargle(
     weights = weights * (1.0 / weights.sum())
 
     # if requested, perform precenter
-    if precenter is not None:
+    if precenter is not _NoValue:
         msg = ("Use of parameter 'precenter' is deprecated as of SciPy 1.17.0 and "
                "will be removed in 1.19.0. Please leave 'precenter' unspecified. "
                "Passing True to 'precenter' "

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1574,8 +1574,17 @@ class TestLombscargle:
         f = np.linspace(0.01, 10., nout)
 
         # Calculate Lomb-Scargle periodogram
-        with pytest.deprecated_call():
+        with pytest.deprecated_call(match="leave 'precenter' unspecified"):
             lombscargle(t, y, f, precenter=True)
+        # Should warn for explicit `False` too
+        with pytest.deprecated_call(match="leave 'precenter' unspecified"):
+            lombscargle(t, y, f, precenter=False)
+            
+    def test_positional_args_deprecation(self):
+        with pytest.deprecated_call(match="use keyword arguments"):
+            one = np.asarray([1.0])
+            lombscargle(one, one, one, None)
+
 
 class TestSTFT:
     def test_input_validation(self):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1580,7 +1580,9 @@ class TestLombscargle:
         with pytest.deprecated_call(match="leave 'precenter' unspecified"):
             lombscargle(t, y, f, precenter=False)
             
-    @pytest.mark.filterwarnings("ignore:.*leave 'precenter' unspecified.*:DeprecationWarning")
+    @pytest.mark.filterwarnings(
+        "ignore:.*leave 'precenter' unspecified.*:DeprecationWarning"
+    )
     def test_positional_args_deprecation(self):
         with pytest.deprecated_call(match="use keyword arguments"):
             one = np.asarray([1.0])

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1580,10 +1580,11 @@ class TestLombscargle:
         with pytest.deprecated_call(match="leave 'precenter' unspecified"):
             lombscargle(t, y, f, precenter=False)
             
+    @pytest.mark.filterwarnings("ignore:.*leave 'precenter' unspecified.*:DeprecationWarning")
     def test_positional_args_deprecation(self):
         with pytest.deprecated_call(match="use keyword arguments"):
             one = np.asarray([1.0])
-            lombscargle(one, one, one, None)
+            lombscargle(one, one, one, False)
 
 
 class TestSTFT:


### PR DESCRIPTION
Towards gh-18703, follow-up to gh-23476.

- take the opportunity to deprecate passing `normalize` positionally
- warn also on `precenter=False`, not just `precenter=True`

FYI @adammj @DietBru @tylerjereddy 