### PR TITLE
MAINT: remove old numpy warning filters from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -20,8 +20,6 @@ filterwarnings =
     ignore:'environmentfilter' is renamed to 'pass_environment'
     ignore:'contextfunction' is renamed to 'pass_context'
     ignore:.*The distutils.* is deprecated.*:DeprecationWarning
-    ignore:\s*.*numpy.distutils.*:DeprecationWarning
-    ignore:.*`numpy.core` has been made officially private.*:DeprecationWarning
     ignore:.*In the future `np.long` will be defined as.*:FutureWarning
     ignore:.*JAX is multithreaded.*:RuntimeWarning
     ignore:^Using the slower implmentation::cupy


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Related to numpy/numpy#30340

#### What does this implement/fix?
<!--Please explain your changes.-->

NumPy has removed `numpy.distutils`, so it should no longer warn. Also remove older `numpy.core` warning. There is no harm in having the filters, but it would be nice to not carry baggage.

#### Additional information
<!--Any additional information you think is important.-->

There are more harmless warning filters here that probably can be removed.