### PR TITLE
ENH: spatial.transform: Add `assume_valid` argument to `Rotation.from_matrix`

### DIFF
--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -596,7 +596,7 @@ class Rotation:
         matrix = _promote(matrix, xp=xp)
         # Resulting quat will have 1 less dimension than matrix
         backend = select_backend(xp, cython_compatible=matrix.ndim < 4)
-        quat = backend.from_matrix(matrix, normalize=normalize)
+        quat = backend.from_matrix(matrix, assume_valid=assume_valid)
         return Rotation._from_raw_quat(quat, xp=xp, backend=backend)
 
     @staticmethod

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -477,7 +477,7 @@ class Rotation:
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]
     )
-    def from_matrix(matrix: ArrayLike, *, normalize: bool = True) -> Rotation:
+    def from_matrix(matrix: ArrayLike, *, assume_valid: bool = False) -> Rotation:
         """Initialize from rotation matrix.
 
         Rotations in 3 dimensions can be represented with 3 x 3 orthogonal
@@ -492,11 +492,12 @@ class Rotation:
         matrix : array_like, shape (..., 3, 3)
             A single matrix or an ND array of matrices, where the last two dimensions
             contain the rotation matrices.
-        normalize : bool, optional
-            Must be True unless users can guarantee the input is a valid rotation
+        assume_valid : bool, optional
+            Must be False unless users can guarantee the input is a valid rotation
             matrix, i.e. it is orthogonal, rows and columns have unit norm and the
-            determinant is 1. Setting this to False without ensuring these properties
-            is unsafe behavior. Default is True.
+            determinant is 1. Setting this to True without ensuring these properties
+            is unsafe behavior. If True, normalization steps are skipped, which can
+            improve runtime performance. Default is False.
 
         Returns
         -------

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -477,7 +477,7 @@ class Rotation:
     @xp_capabilities(
         skip_backends=[("dask.array", "missing linalg.cross/det functions")]
     )
-    def from_matrix(matrix: ArrayLike) -> Rotation:
+    def from_matrix(matrix: ArrayLike, *, normalize: bool = True) -> Rotation:
         """Initialize from rotation matrix.
 
         Rotations in 3 dimensions can be represented with 3 x 3 orthogonal
@@ -492,6 +492,10 @@ class Rotation:
         matrix : array_like, shape (..., 3, 3)
             A single matrix or an ND array of matrices, where the last two dimensions
             contain the rotation matrices.
+        normalize : bool, optional
+            If True, then the given matrices are orthogonalized via Singular Value
+            Decomposition (SVD) to form a valid rotation matrix before the conversion.
+            Default is True.
 
         Returns
         -------
@@ -590,7 +594,7 @@ class Rotation:
         matrix = _promote(matrix, xp=xp)
         # Resulting quat will have 1 less dimension than matrix
         backend = select_backend(xp, cython_compatible=matrix.ndim < 4)
-        quat = backend.from_matrix(matrix)
+        quat = backend.from_matrix(matrix, normalize=normalize)
         return Rotation._from_raw_quat(quat, xp=xp, backend=backend)
 
     @staticmethod

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -496,8 +496,9 @@ class Rotation:
             Must be False unless users can guarantee the input is a valid rotation
             matrix, i.e. it is orthogonal, rows and columns have unit norm and the
             determinant is 1. Setting this to True without ensuring these properties
-            is unsafe behavior. If True, normalization steps are skipped, which can
-            improve runtime performance. Default is False.
+            is unsafe and will silently lead to incorrect results. If True,
+            normalization steps are skipped, which can improve runtime performance.
+            Default is False.
 
         Returns
         -------

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -493,9 +493,10 @@ class Rotation:
             A single matrix or an ND array of matrices, where the last two dimensions
             contain the rotation matrices.
         normalize : bool, optional
-            If True, then the given matrices are orthogonalized via Singular Value
-            Decomposition (SVD) to form a valid rotation matrix before the conversion.
-            Default is True.
+            Must be True unless users can guarantee the input is a valid rotation
+            matrix, i.e. it is orthogonal, rows and columns have unit norm and the
+            determinant is 1. Setting this to False without ensuring these properties
+            is unsafe behavior. Default is True.
 
         Returns
         -------

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -458,7 +458,7 @@ def from_euler(seq, angles, bint degrees=False):
 @cython.embedsignature(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def from_matrix(matrix):
+def from_matrix(matrix, bint normalize=True):
     cdef int ind
     is_single = False
     matrix = np.array(matrix, dtype=float)
@@ -475,29 +475,30 @@ def from_matrix(matrix):
         matrix = matrix[np.newaxis, :, :]
         is_single = True
 
-    # Calculate the determinant of the rotation matrix
-    # (should be positive for right-handed rotations)
-    dets = np.linalg.det(matrix)
-    if np.any(dets <= 0):
-        ind = np.where(dets <= 0)[0][0]
-        raise ValueError("Non-positive determinant (left-handed or null "
-                            f"coordinate frame) in rotation matrix {ind}: "
-                            f"{matrix[ind]}.")
+    if normalize:
+        # Calculate the determinant of the rotation matrix
+        # (should be positive for right-handed rotations)
+        dets = np.linalg.det(matrix)
+        if np.any(dets <= 0):
+            ind = np.where(dets <= 0)[0][0]
+            raise ValueError("Non-positive determinant (left-handed or null "
+                                f"coordinate frame) in rotation matrix {ind}: "
+                                f"{matrix[ind]}.")
 
-    # Gramian orthogonality check
-    # (should be the identity matrix for orthogonal matrices)
-    # Note that we have already ruled out left-handed cases above
-    gramians = matrix @ np.transpose(matrix, (0, 2, 1))
-    is_orthogonal = np.all(np.isclose(gramians, np.eye(3), atol=1e-12),
-                            axis=(1, 2))
-    indices_to_orthogonalize = np.where(~is_orthogonal)[0]
+        # Gramian orthogonality check
+        # (should be the identity matrix for orthogonal matrices)
+        # Note that we have already ruled out left-handed cases above
+        gramians = matrix @ np.transpose(matrix, (0, 2, 1))
+        is_orthogonal = np.all(np.isclose(gramians, np.eye(3), atol=1e-12),
+                                axis=(1, 2))
+        indices_to_orthogonalize = np.where(~is_orthogonal)[0]
 
-    # Orthogonalize the rotation matrices where necessary
-    if len(indices_to_orthogonalize) > 0:
-        # Exact solution to the orthogonal Procrustes problem using singular
-        # value decomposition
-        U, _, Vt = np.linalg.svd(matrix[indices_to_orthogonalize, :, :])
-        matrix[indices_to_orthogonalize, :, :] = U @ Vt
+        # Orthogonalize the rotation matrices where necessary
+        if len(indices_to_orthogonalize) > 0:
+            # Exact solution to the orthogonal Procrustes problem using singular
+            # value decomposition
+            U, _, Vt = np.linalg.svd(matrix[indices_to_orthogonalize, :, :])
+            matrix[indices_to_orthogonalize, :, :] = U @ Vt
 
     # Convert the orthogonal rotation matrices to quaternions using the
     # algorithm described in [3]_. This will also apply another

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -458,7 +458,7 @@ def from_euler(seq, angles, bint degrees=False):
 @cython.embedsignature(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def from_matrix(matrix, bint normalize=True):
+def from_matrix(matrix, bint assume_valid=False):
     cdef int ind
     is_single = False
     matrix = np.array(matrix, dtype=float)
@@ -475,7 +475,7 @@ def from_matrix(matrix, bint normalize=True):
         matrix = matrix[np.newaxis, :, :]
         is_single = True
 
-    if normalize:
+    if not assume_valid:
         # Calculate the determinant of the rotation matrix
         # (should be positive for right-handed rotations)
         dets = np.linalg.det(matrix)

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -73,7 +73,7 @@ def from_matrix(matrix: Array, assume_valid: bool = False) -> Array:
             # computation without statically known shapes, so we always compute SVD and
             # use xp.where to select the result.
             U, _, Vt = xp.linalg.svd(matrix, full_matrices=False)
-            matrix = U @ Vt
+            matrix = xp.where(is_orthogonal[..., None, None], matrix, U @ Vt)
         elif not xp.all(is_orthogonal):
             # For eager frameworks, only compute SVD if needed.
             is_not_orthogonal = ~is_orthogonal

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -45,13 +45,14 @@ def from_quat(
     return quat
 
 
-def from_matrix(matrix: Array, normalize: bool = True) -> Array:
+def from_matrix(matrix: Array, assume_valid: bool = False) -> Array:
     xp = array_namespace(matrix)
     device = xp_device(matrix)
-    # Only non-lazy backends raise an error for non-positive determinants.
-    if normalize:
+
+    if not assume_valid:
         mask = xp.linalg.det(matrix) <= 0
         lazy = is_lazy_array(mask)
+        # Only non-lazy backends raise an error for non-positive determinants.
         if not lazy and xp.any(mask):
             ind = int(xp.nonzero(xpx.atleast_nd(mask, ndim=1, xp=xp))[0][0])
             raise ValueError(

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -45,36 +45,39 @@ def from_quat(
     return quat
 
 
-def from_matrix(matrix: Array) -> Array:
+def from_matrix(matrix: Array, normalize: bool = True) -> Array:
     xp = array_namespace(matrix)
     device = xp_device(matrix)
     # Only non-lazy backends raise an error for non-positive determinants.
-    mask = xp.linalg.det(matrix) <= 0
-    lazy = is_lazy_array(mask)
-    if not lazy and xp.any(mask):
-        ind = int(xp.nonzero(xpx.atleast_nd(mask, ndim=1, xp=xp))[0][0])
-        raise ValueError(
-            "Non-positive determinant (left-handed or null coordinate frame) in "
-            f"rotation matrix {ind}: {matrix[ind, ...]}."
+    if normalize:
+        mask = xp.linalg.det(matrix) <= 0
+        lazy = is_lazy_array(mask)
+        if not lazy and xp.any(mask):
+            ind = int(xp.nonzero(xpx.atleast_nd(mask, ndim=1, xp=xp))[0][0])
+            raise ValueError(
+                "Non-positive determinant (left-handed or null coordinate frame) in "
+                f"rotation matrix {ind}: {matrix[ind, ...]}."
+            )
+        elif lazy:
+            matrix = xp.where(mask[..., None, None], xp.nan, matrix)
+
+        gramians = matrix @ xp.matrix_transpose(matrix)
+        eye = xp.eye(3, dtype=matrix.dtype, device=device)
+        is_orthogonal = xp.all(
+            xpx.isclose(gramians, eye, atol=1e-12, xp=xp), axis=(-2, -1)
         )
-    elif lazy:
-        matrix = xp.where(mask[..., None, None], xp.nan, matrix)
 
-    gramians = matrix @ xp.matrix_transpose(matrix)
-    eye = xp.eye(3, dtype=matrix.dtype, device=device)
-    is_orthogonal = xp.all(xpx.isclose(gramians, eye, atol=1e-12, xp=xp))
-
-    if lazy:
-        # Lazy backends do not support non-concrete boolean indexing or any form of
-        # computation without statically known shapes, so we always compute SVD and
-        # use xp.where to select the result.
-        U, _, Vt = xp.linalg.svd(matrix, full_matrices=False)
-        orthogonal_matrix = U @ Vt
-        matrix = xp.where(is_orthogonal, matrix, orthogonal_matrix)
-    elif not is_orthogonal:
-        # For eager frameworks, only compute SVD if needed.
-        U, _, Vt = xp.linalg.svd(matrix, full_matrices=False)
-        matrix = U @ Vt
+        if lazy:
+            # Lazy backends do not support non-concrete boolean indexing or any form of
+            # computation without statically known shapes, so we always compute SVD and
+            # use xp.where to select the result.
+            U, _, Vt = xp.linalg.svd(matrix, full_matrices=False)
+            matrix = U @ Vt
+        elif not xp.all(is_orthogonal):
+            # For eager frameworks, only compute SVD if needed.
+            is_not_orthogonal = ~is_orthogonal
+            U, _, Vt = xp.linalg.svd(matrix[is_not_orthogonal], full_matrices=False)
+            matrix = xpx.at(matrix)[is_not_orthogonal].set(U @ Vt)
 
     return _from_matrix_orthogonal(matrix)
 
@@ -503,10 +506,9 @@ def mean(
     if not isinstance(axis, tuple):
         raise ValueError("`axis` must be None, int, or tuple of ints.")
     # Ensure all axes are within bounds
-    if axis != () and ( min(axis) < -(quat.ndim - 1) or max(axis) > (quat.ndim - 2)):
+    if axis != () and (min(axis) < -(quat.ndim - 1) or max(axis) > (quat.ndim - 2)):
         raise ValueError(
-            f"axis {axis} is out of bounds for rotation with shape "
-            f"{quat.shape[:-1]}."
+            f"axis {axis} is out of bounds for rotation with shape {quat.shape[:-1]}."
         )
     # Ensure all axes are positive and unique
     axis = tuple(sorted(set(x % (quat.ndim - 1) for x in axis)))

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -418,6 +418,24 @@ def test_from_matrix_normalize(xp):
                            [  0,  0, 1]])
     xp_assert_close(Rotation.from_matrix(mat).as_matrix(), expected, atol=1e-6)
 
+    # Test a mix of normalized and non-normalized matrices
+    mat = xp.stack([mat, xp.eye(3)])
+    expected = xp.stack([expected, xp.eye(3)])
+    xp_assert_close(Rotation.from_matrix(mat).as_matrix(), expected, atol=1e-6)
+
+
+@make_xp_test_case(Rotation.from_matrix, Rotation.as_matrix)
+def test_from_matrix_unnormalized(xp):
+    rng = np.random.default_rng(0)
+    # Test that normal matrices remain unchanged
+    rot = rotation_to_xp(Rotation.from_quat(rng.normal(size=(10, 4))), xp)
+    rot_unnorm = Rotation.from_matrix(rot.as_matrix(), normalize=False)
+    assert xp.all(rot.approx_equal(rot_unnorm, atol=1e-12))
+    # Test that non-normal matrices do not lead to errors, but do not make any
+    # assumptions on the output
+    mat = xp.asarray(rng.random((10, 3, 3)))
+    Rotation.from_matrix(mat, normalize=False)  # Valid, but no guarantees
+
 
 @make_xp_test_case(Rotation.from_matrix, Rotation.as_matrix)
 def test_from_matrix_non_positive_determinant(xp):

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -427,14 +427,13 @@ def test_from_matrix_normalize(xp):
 @make_xp_test_case(Rotation.from_matrix, Rotation.as_matrix)
 def test_from_matrix_unnormalized(xp):
     rng = np.random.default_rng(0)
+    atol = 1e-12 if dtype == xp.float64 else 1e-6
     # Test that normal matrices remain unchanged
     rot = rotation_to_xp(Rotation.from_quat(rng.normal(size=(10, 4))), xp)
     rot_unnorm = Rotation.from_matrix(rot.as_matrix(), normalize=False)
-    assert xp.all(rot.approx_equal(rot_unnorm, atol=1e-12))
-    # Test that non-normal matrices do not lead to errors, but do not make any
-    # assumptions on the output
-    mat = xp.asarray(rng.random((10, 3, 3)))
-    Rotation.from_matrix(mat, normalize=False)  # Valid, but no guarantees
+    assert xp.all(rot.approx_equal(rot_unnorm, atol=atol))
+    # We make no guarantees about matrices that are not orthogonal or do not
+    # have unit norm
 
 
 @make_xp_test_case(Rotation.from_matrix, Rotation.as_matrix)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -427,6 +427,7 @@ def test_from_matrix_normalize(xp):
 @make_xp_test_case(Rotation.from_matrix, Rotation.as_matrix)
 def test_from_matrix_unnormalized(xp):
     rng = np.random.default_rng(0)
+    dtype = xpx.default_dtype(xp)
     atol = 1e-12 if dtype == xp.float64 else 1e-6
     # Test that normal matrices remain unchanged
     rot = rotation_to_xp(Rotation.from_quat(rng.normal(size=(10, 4))), xp)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -425,14 +425,14 @@ def test_from_matrix_normalize(xp):
 
 
 @make_xp_test_case(Rotation.from_matrix, Rotation.as_matrix)
-def test_from_matrix_unnormalized(xp):
+def test_from_matrix_assume_valid(xp):
     rng = np.random.default_rng(0)
     dtype = xpx.default_dtype(xp)
     atol = 1e-12 if dtype == xp.float64 else 1e-6
     # Test that normal matrices remain unchanged
     rot = rotation_to_xp(Rotation.from_quat(rng.normal(size=(10, 4))), xp)
-    rot_unnorm = Rotation.from_matrix(rot.as_matrix(), normalize=False)
-    assert xp.all(rot.approx_equal(rot_unnorm, atol=atol))
+    rot_no_norm = Rotation.from_matrix(rot.as_matrix(), assume_valid=True)
+    assert xp.all(rot.approx_equal(rot_no_norm, atol=atol))
     # We make no guarantees about matrices that are not orthogonal or do not
     # have unit norm
 


### PR DESCRIPTION
This PR adds an `assume_valid` keyword-only argument to `Rotation.from_matrix` which optionally disables the SVD projection. Users that can guarantee their matrix input is valid can save considerable time by skipping the SVD on eager and especially lazy frameworks. This should close the gap to the jax native performance seen in the benchmarks from #23391.

It also optimizes the existing projection to perform the SVD only where necessary on eager frameworks (suggested in https://github.com/scipy/scipy/issues/24089#issuecomment-3597166650).

#### Example
```python
from scipy.spatial.transform import Rotation as R
import numpy as np

# This is valid and significantly faster
r = R.from_matrix(np.eye(3), assume_valid=True)  

# This is invalid, but still works. Using assume_valid=True puts the responsibility
# on the user to ensure the inputs fulfill all conditions of rotation matrices
# The default remains False, of course, and assume_valid is a keyword-only argument
r_invalid = R.from_matrix(np.random.normal((3, 3)), assume_valid=True)
```


#### Implementation
The only required change is that we skip checks and projections and directly take the `_from_matrix_orthogonal` code path introduced in https://github.com/scipy/scipy/pull/24056.

#### Reference issue
Closes #24089

#### Correction
I said earlier that we already have a `normalize` kwarg for `from_quat`. Turns out I misremembered, we only have it for `Rotation.__init__()`. Should we add this to `from_quat`? Contrary to the rather expensive SVD, getting rid of the norm is a minor optimization, but it still has its use cases, e.g. when users want to transfer rotations between frameworks with

```python
from scipy.spatial.transform import Rotation as R
import torch
import jax.numpy as jnp

rot_torch = R.from_quat(torch.ones((3, 5, 4)))
rot_jax = R.from_quat(jnp.from_dlpack(rot_torch.as_quat()), assume_valid=True)
```
As previously mentioned, this is a minor optimization. If any, it should go into a separate PR to not mix things up.