### PR TITLE
TST: fft: `allow_dask_compute` for all `uarray`-using funcs

### DIFF
--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -22,7 +22,7 @@ def _dispatch(func):
     return generate_multimethod(func, _x_replacer, domain="numpy.scipy.fft")
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
         plan=None):
@@ -168,7 +168,7 @@ def fft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
          plan=None):
@@ -275,7 +275,7 @@ def ifft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities(allow_dask_compute=1)
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
          plan=None):
@@ -370,7 +370,7 @@ def rfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
           plan=None):
@@ -556,7 +556,7 @@ def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities(allow_dask_compute=1)
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
           plan=None):
@@ -730,7 +730,7 @@ def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
           plan=None):
@@ -835,7 +835,7 @@ def ifftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
          plan=None):
@@ -935,7 +935,7 @@ def fft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
           plan=None):
@@ -1133,7 +1133,7 @@ def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
           plan=None):
@@ -1195,7 +1195,7 @@ def rfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
            plan=None):
@@ -1303,7 +1303,7 @@ def irfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
            plan=None):
@@ -1354,7 +1354,7 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
           plan=None):
@@ -1468,7 +1468,7 @@ def hfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
           plan=None):
@@ -1526,7 +1526,7 @@ def hfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
            plan=None):
@@ -1621,7 +1621,7 @@ def ihfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, *,
            plan=None):

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -15,7 +15,7 @@ import numpy as np
 __all__ = ['fht', 'ifht', 'fhtoffset']
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def fht(a, dln, mu, offset=0.0, bias=0.0):
     r'''Compute the fast Hankel transform.
@@ -176,7 +176,7 @@ def fht(a, dln, mu, offset=0.0, bias=0.0):
     return (Dispatchable(a, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def ifht(A, dln, mu, offset=0.0, bias=0.0):
     r"""Compute the inverse fast Hankel transform.

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -6,7 +6,7 @@ import numpy as np
 __all__ = ['dct', 'idct', 'dst', 'idst', 'dctn', 'idctn', 'dstn', 'idstn']
 
 
-@xp_capabilities(cpu_only=True)
+@xp_capabilities(cpu_only=True, allow_dask_compute=True)
 @_dispatch
 def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          workers=None, *, orthogonalize=None):
@@ -72,7 +72,7 @@ def dctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities(cpu_only=True)
+@xp_capabilities(cpu_only=True, allow_dask_compute=True)
 @_dispatch
 def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           workers=None, orthogonalize=None):
@@ -138,7 +138,7 @@ def idctn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities(cpu_only=True)
+@xp_capabilities(cpu_only=True, allow_dask_compute=True)
 @_dispatch
 def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
          workers=None, orthogonalize=None):
@@ -204,7 +204,7 @@ def dstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities(cpu_only=True)
+@xp_capabilities(cpu_only=True, allow_dask_compute=True)
 @_dispatch
 def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
           workers=None, orthogonalize=None):
@@ -270,7 +270,7 @@ def idstn(x, type=2, s=None, axes=None, norm=None, overwrite_x=False,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities(cpu_only=True, allow_dask_compute=1,
+@xp_capabilities(cpu_only=True, allow_dask_compute=True,
                  skip_backends=[('jax.numpy', 'XXX large tolerance violations')])
 @_dispatch
 def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
@@ -422,7 +422,7 @@ def dct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities(cpu_only=True)
+@xp_capabilities(cpu_only=True, allow_dask_compute=True)
 @_dispatch
 def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          workers=None, orthogonalize=None):
@@ -503,7 +503,7 @@ def idct(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities(cpu_only=True,
+@xp_capabilities(cpu_only=True, allow_dask_compute=True,
                  skip_backends=[('jax.numpy', 'XXX large tolerance violations')])
 @_dispatch
 def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
@@ -653,7 +653,7 @@ def dst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False, workers=None,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities(cpu_only=True)
+@xp_capabilities(cpu_only=True, allow_dask_compute=True)
 @_dispatch
 def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
          workers=None, orthogonalize=None):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds `allow_dask_compute=True` to the `xp_capabilities` of all functions in `fft` which rely on dispatch with `uarray` in attempt to fix the test failures noted by @lucascolley here: https://github.com/scipy/scipy/pull/24039#issuecomment-3602457415. For mysterious reasons, these failures did not occur in the CI #24039 but are now occurring on main. I found they did not occur on `main` for my current local dev environment, even with the bump to `array_api_extra`, but I was able to reproduce locally after creating a fresh `venv` with the same Python version used in CI (Python 3.13.9) and with a fresh install of all dependencies. The Python version did not change in CI, so Python version appears to be unrelated to why the tests suddenly started failing. It appears to be due to some change in dependencies or other but I did not investigate further.

A vexing thing is that, contrary to@lucascolley's suspicion about this relating to functions which depend on offending functions in `fft`, I've found the failures actually occur in tests for which there is no dependence on `fft` whatsoever, for instance `test_romb` in `integrate`

```
2025-12-02T14:36:09.6294603Z FAILED scipy/integrate/tests/test_quadrature.py::TestRomb::test_romb[dask.array] - AssertionError: Called `dask.compute()` or `dask.persist()` 1 times, but no calls are allowed. Set `lazy_xp_function(ifft, allow_dask_compute=1)` to allow for more (but note that this will harm performance).
```

and many more places. My guess is this is some kind of bizarre thread safety issue in the `lazy_xp_function` machinery causing failures to bleed through into other tests. I do not know why this is happening, my gut tells me it probably has something to do with the interaction of `uarray` and the `lazy_xp_function` machinery. I've added `allow_dask_compute=True` to every `xp_capabilities` for functions in `fft` which use `uarray` and this makes the tests pass for me locally. I've used `allow_dask_compute=True` instead of `allow_dask_compute=1` because I've found that the number of dask computes used can be flaky: I was actually seeing some failures locally where 2 dask computes occurred, possibly due to bleeding between threads.

#### Additional information
<!--Any additional information you think is important.-->
