### PR TITLE
TST: linalg: unskip a test

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -838,55 +838,41 @@ class TestSolve:
     def test_assume_a_keyword(self):
         assert_raises(ValueError, solve, 1, 1, assume_a='zxcv')
 
-    @pytest.mark.skip(reason="Failure on OS X (gh-7500), "
-                             "crash on Windows (gh-8064)")
-    def test_all_type_size_routine_combinations(self):
+    @pytest.mark.parametrize("size", [10, 100])
+    @pytest.mark.parametrize("assume_a", ['gen', 'sym', 'pos', 'her'])
+    @pytest.mark.parametrize(
+        "dtype", [np.float32, np.float64, np.complex64, np.complex128]
+    )
+    def test_all_type_size_routine_combinations(self, size, dtype, assume_a):
         rng = np.random.default_rng(1234)
-        sizes = [10, 100]
-        assume_as = ['gen', 'sym', 'pos', 'her']
-        dtypes = [np.float32, np.float64, np.complex64, np.complex128]
-        for size, assume_a, dtype in itertools.product(sizes, assume_as,
-                                                       dtypes):
-            is_complex = dtype in (np.complex64, np.complex128)
-            if assume_a == 'her' and not is_complex:
-                continue
+        is_complex = dtype in (np.complex64, np.complex128)
 
-            err_msg = (f"Failed for size: {size}, assume_a: {assume_a},"
-                       f"dtype: {dtype}")
+        a = rng.standard_normal((size, size)).astype(dtype)
+        b = rng.standard_normal(size).astype(dtype)
+        if is_complex:
+            a += (1j*rng.standard_normal((size, size))).astype(dtype)
 
-            a = rng.standard_normal((size, size)).astype(dtype)
-            b = rng.standard_normal(size).astype(dtype)
-            if is_complex:
-                a += (1j*rng.standard_normal((size, size))).astype(dtype)
+        if assume_a == 'sym':  # Can still be complex but only symmetric
+            a = a + a.T
+        elif assume_a == 'her':  # Handle hermitian matrices here instead
+            a = a + a.T.conj()
+        elif assume_a == 'pos':
+            a = a.T.conj() @ a + 0.1*np.eye(size)
 
-            if assume_a == 'sym':  # Can still be complex but only symmetric
-                a = a + a.T
-            elif assume_a == 'her':  # Handle hermitian matrices here instead
-                a = a + a.T.conj()
-            elif assume_a == 'pos':
-                a = a.conj().T.dot(a) + 0.1*np.eye(size)
+        tol = 1e-12 if dtype in (np.float64, np.complex128) else 1e-6
 
-            tol = 1e-12 if dtype in (np.float64, np.complex128) else 1e-6
+        if assume_a in ['gen', 'sym', 'her']:
+            # We revert the tolerance from before
+            #   4b4a6e7c34fa4060533db38f9a819b98fa81476c
+            if dtype in (np.float32, np.complex64):
+                tol *= 10
 
-            if assume_a in ['gen', 'sym', 'her']:
-                # We revert the tolerance from before
-                #   4b4a6e7c34fa4060533db38f9a819b98fa81476c
-                if dtype in (np.float32, np.complex64):
-                    tol *= 10
+        x = solve(a, b, assume_a=assume_a)
+        assert_allclose(a @ x, b, atol=tol * size, rtol=tol * size)
 
-            x = solve(a, b, assume_a=assume_a)
-            assert_allclose(a.dot(x), b,
-                            atol=tol * size,
-                            rtol=tol * size,
-                            err_msg=err_msg)
-
-            if assume_a == 'sym' and dtype not in (np.complex64,
-                                                   np.complex128):
-                x = solve(a, b, assume_a=assume_a, transposed=True)
-                assert_allclose(a.dot(x), b,
-                                atol=tol * size,
-                                rtol=tol * size,
-                                err_msg=err_msg)
+        if assume_a == 'sym' and not is_complex:
+            x = solve(a, b, assume_a=assume_a, transposed=True)
+            assert_allclose(a @ x, b, atol=tol * size, rtol=tol * size)
 
     @pytest.mark.parametrize('dt_a', [int, float, np.float32, complex, np.complex64])
     @pytest.mark.parametrize('dt_b', [int, float, np.float32, complex, np.complex64])


### PR DESCRIPTION
The test was problematic, and was permanently skipped in 2018 for scipy 1.2.0 (cf https://github.com/scipy/scipy/issues/8064)
The problematic versions were MSVC <2015 and we are at 2019 now.
Implementation of `solve` changed a little, too. Eyeballing the test, there is nothing immediately wrong with it, so hopefully it just fixed itself?

Unskip the test and trivially refactor it so that if it segfaults again, it's easier to see which mode/dtype does.
The refactor is clearer under "hide whitespace changes" view mode.

[wheel build]

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
