### PR TITLE
ENH: Add support for scikit-sparse v0.5.0

### DIFF
--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -507,7 +507,9 @@ def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):
     vals_shape = (prod(v_shape[:ndim]), prod(v_shape[ndim:]))
     vals = values.reshape(vals_shape)
 
-    if solver != ssl.spsolve:
+    if solver == ssl.spsolve:
+        matr = matr.tocsc()  # spsolve requires CSC format
+    else:
         solver = functools.partial(_iter_solve, solver=solver)
         if "atol" not in solver_args:
             # avoid a DeprecationWarning, grumble grumble

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -1002,7 +1002,7 @@ def _linprog_ip_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
     1. ``sksparse.cholmod.CholeskyFactor.solve`` (if scikit-sparse and
        SuiteSparse are installed)
 
-    2. ``scipy.sparse.linalg.factorized`` (if scikit-umfpack and SuiteSparse
+    2. ``sksparse.umfpack.UMFFactor.solve`` (if scikit-sparse and SuiteSparse
        are installed)
 
     3. ``scipy.sparse.linalg.splu`` (which uses SuperLU distributed with SciPy)

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -999,8 +999,8 @@ def _linprog_ip_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
     For sparse problems:
 
-    1. ``sksparse.cholmod.cholesky`` (if scikit-sparse and SuiteSparse are
-       installed)
+    1. ``sksparse.cholmod.CholeskyFactor.solve`` (if scikit-sparse and
+       SuiteSparse are installed)
 
     2. ``scipy.sparse.linalg.factorized`` (if scikit-umfpack and SuiteSparse
        are installed)

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -319,7 +319,7 @@ def _remove_redundancy_pivot_sparse(A, rhs):
         if i > 0:
             e[i-1] = 0
 
-        pi = scipy.sparse.linalg.spsolve(B.transpose(), e).reshape(-1, 1)
+        pi = scipy.sparse.linalg.splu(B).solve(e, trans='T').reshape(-1, 1)
 
         js = list(k-set(b))  # not efficient, but this is not the time sink...
 

--- a/scipy/optimize/_remove_redundancy.py
+++ b/scipy/optimize/_remove_redundancy.py
@@ -319,7 +319,7 @@ def _remove_redundancy_pivot_sparse(A, rhs):
         if i > 0:
             e[i-1] = 0
 
-        pi = scipy.sparse.linalg.splu(B).solve(e, trans='T').reshape(-1, 1)
+        pi = scipy.sparse.linalg.spsolve(B, e, trans='T').reshape(-1, 1)
 
         js = list(k-set(b))  # not efficient, but this is not the time sink...
 

--- a/scipy/optimize/_trustregion_constr/tests/test_projections.py
+++ b/scipy/optimize/_trustregion_constr/tests/test_projections.py
@@ -7,7 +7,7 @@ from numpy.testing import (TestCase, assert_array_almost_equal,
                            assert_equal, assert_allclose)
 
 try:
-    from sksparse.cholmod import cholesky_AAt  # noqa: F401
+    from sksparse import cholmod  # noqa: F401
     sksparse_available = True
     available_sparse_methods = ("NormalEquation", "AugmentedSystem")
 except ImportError:

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -12,7 +12,6 @@ from numpy.testing import (assert_, assert_allclose, assert_equal,
 from pytest import raises as assert_raises
 from scipy.optimize import linprog, OptimizeWarning
 from scipy.optimize._numdiff import approx_derivative
-from scipy.sparse.linalg import MatrixRankWarning
 from scipy.linalg import LinAlgWarning
 import scipy.sparse
 import pytest
@@ -2103,8 +2102,6 @@ class TestLinprogIPSparse(LinprogIPTests):
         bounds = (0, 1)
 
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", "Matrix is exactly singular", MatrixRankWarning)
             warnings.filterwarnings(
                 "ignore", "Solving system with option...", OptimizeWarning)
 

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -19,7 +19,7 @@ import pytest
 
 has_umfpack = True
 try:
-    from scikits.umfpack import UmfpackWarning
+    from sksparse.umfpack import UMFPACKWarning
 except ImportError:
     has_umfpack = False
 
@@ -1146,9 +1146,10 @@ class LinprogCommonTests:
         b_eq = [-4, 0, 0, 4]
 
         with warnings.catch_warnings():
-            # this is an UmfpackWarning but I had trouble importing it
             if has_umfpack:
-                warnings.simplefilter("ignore", UmfpackWarning)
+                warnings.filterwarnings(
+                    "ignore", "Matrix is nearly singular", UMFPACKWarning
+                )
             if has_cholmod:
                 warnings.filterwarnings(
                     "ignore", "Matrix is nearly singular", CholmodWarning
@@ -1399,7 +1400,9 @@ class LinprogCommonTests:
 
         with warnings.catch_warnings():
             if has_umfpack:
-                warnings.simplefilter("ignore", UmfpackWarning)
+                warnings.filterwarnings(
+                    "ignore", "Matrix is nearly singular", UMFPACKWarning
+                )
             if has_cholmod:
                 warnings.filterwarnings(
                     "ignore", "Matrix is nearly singular", CholmodWarning
@@ -1526,8 +1529,6 @@ class LinprogCommonTests:
         b_eq = np.array([[100], [0], [0], [0], [0]])
 
         with warnings.catch_warnings():
-            if has_umfpack:
-                warnings.simplefilter("ignore", UmfpackWarning)
             warnings.filterwarnings(
                 "ignore", "A_eq does not appear...", OptimizeWarning)
             res = linprog(c, A_ub, b_ub, A_eq, b_eq, bounds,
@@ -1564,8 +1565,6 @@ class LinprogCommonTests:
         desired_fun = 36.0000000000
 
         with warnings.catch_warnings():
-            if has_umfpack:
-                warnings.simplefilter("ignore", UmfpackWarning)
             warnings.filterwarnings(
                 "ignore", "invalid value encountered", RuntimeWarning)
             warnings.simplefilter("ignore", LinAlgWarning)
@@ -1578,8 +1577,6 @@ class LinprogCommonTests:
         bounds[2] = (None, None)
 
         with warnings.catch_warnings():
-            if has_umfpack:
-                warnings.simplefilter("ignore", UmfpackWarning)
             warnings.filterwarnings(
                 "ignore", "invalid value encountered", RuntimeWarning)
             warnings.simplefilter("ignore", LinAlgWarning)
@@ -1722,8 +1719,6 @@ class LinprogCommonTests:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", "Solving system with option...", OptimizeWarning)
-            if has_umfpack:
-                warnings.simplefilter("ignore", UmfpackWarning)
             warnings.filterwarnings(
                 "ignore", "scipy.linalg.solve\nIll...", RuntimeWarning)
             warnings.filterwarnings(
@@ -2108,8 +2103,6 @@ class TestLinprogIPSparse(LinprogIPTests):
         bounds = (0, 1)
 
         with warnings.catch_warnings():
-            if has_umfpack:
-                warnings.simplefilter("ignore", UmfpackWarning)
             warnings.filterwarnings(
                 "ignore", "Matrix is exactly singular", MatrixRankWarning)
             warnings.filterwarnings(

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -25,8 +25,7 @@ except ImportError:
 
 has_cholmod = True
 try:
-    import sksparse  # noqa: F401
-    from sksparse.cholmod import cholesky as cholmod  # noqa: F401
+    from sksparse.cholmod import CholmodWarning
 except ImportError:
     has_cholmod = False
 
@@ -1150,6 +1149,10 @@ class LinprogCommonTests:
             # this is an UmfpackWarning but I had trouble importing it
             if has_umfpack:
                 warnings.simplefilter("ignore", UmfpackWarning)
+            if has_cholmod:
+                warnings.filterwarnings(
+                    "ignore", "Matrix is nearly singular", CholmodWarning
+                )
             warnings.filterwarnings(
                 "ignore", "scipy.linalg.solve\nIll...", RuntimeWarning)
             warnings.filterwarnings(
@@ -1397,6 +1400,10 @@ class LinprogCommonTests:
         with warnings.catch_warnings():
             if has_umfpack:
                 warnings.simplefilter("ignore", UmfpackWarning)
+            if has_cholmod:
+                warnings.filterwarnings(
+                    "ignore", "Matrix is nearly singular", CholmodWarning
+                )
             warnings.filterwarnings(
                 "ignore", "Solving system with option 'cholesky'", OptimizeWarning)
             warnings.filterwarnings(

--- a/scipy/optimize/tests/test_nonlin.py
+++ b/scipy/optimize/tests/test_nonlin.py
@@ -7,7 +7,7 @@ import pytest
 from functools import partial
 
 from scipy.optimize import _nonlin as nonlin, root
-from scipy.sparse import csr_array
+from scipy.sparse import csc_array
 from numpy import diag, dot
 from numpy.linalg import inv
 import numpy as np
@@ -387,7 +387,7 @@ class TestLinear:
         np.testing.assert_allclose(A @ sol, b, atol=1e-6)
 
     def test_jac_sparse(self):
-        A = csr_array([[1, 2], [2, 1]])
+        A = csc_array([[1, 2], [2, 1]])
         b = np.array([1, -1])
         self._check_autojac(A, b)
         self._check_autojac((1 + 2j) * A, (2 + 2j) * b)

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -245,9 +245,9 @@ Construct a 1000x1000 `lil_array` and add some values to it:
 >>> A[0, :100] = rand(100)
 >>> A.setdiag(rand(1000))
 
-Now convert it to CSR format and solve A x = b for x:
+Now convert it to CSC format and solve A x = b for x:
 
->>> A = A.tocsr()
+>>> A = A.tocsc()
 >>> b = rand(1000)
 >>> x = spsolve(A, b)
 

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -187,9 +187,9 @@ Construct a 1000x1000 `lil_array` and add some values to it:
 >>> A[0, :100] = rand(100)
 >>> A.setdiag(rand(1000))
 
-Now convert it to CSR format and solve A x = b for x:
+Now convert it to CSC format and solve A x = b for x:
 
->>> A = A.tocsr()
+>>> A = A.tocsc()
 >>> b = rand(1000)
 >>> x = spsolve(A, b)
 

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -48,7 +48,6 @@ Direct methods for linear equation systems:
    spbandwidth -- Find the bandwidth of a sparse matrix.
    factorized -- Pre-factorize matrix to a function solving a linear system
    MatrixRankWarning -- Warning on exactly singular matrices
-   use_solver -- Select direct solver to use
 
 Iterative methods for linear equation systems:
 

--- a/scipy/sparse/linalg/__init__.py
+++ b/scipy/sparse/linalg/__init__.py
@@ -47,7 +47,6 @@ Direct methods for linear equation systems:
    is_sptriangular -- Check if sparse A is triangular.
    spbandwidth -- Find the bandwidth of a sparse matrix.
    factorized -- Pre-factorize matrix to a function solving a linear system
-   MatrixRankWarning -- Warning on exactly singular matrices
 
 Iterative methods for linear equation systems:
 

--- a/scipy/sparse/linalg/_dsolve/__init__.py
+++ b/scipy/sparse/linalg/_dsolve/__init__.py
@@ -6,12 +6,12 @@ The default solver is SuperLU (included in the scipy distribution),
 which can solve real or complex linear systems in both single and
 double precisions.  It is automatically replaced by UMFPACK, if
 available.  Note that UMFPACK works in double precision only, so
-switch it off by::
+switch it off by using::
 
-    >>> from scipy.sparse.linalg import spsolve, use_solver
-    >>> use_solver(useUmfpack=False)
+    >>> from scipy.sparse.linalg import spsolve
+    >>> spsolve(..., use_umfpack=False)
 
-to solve in the single precision. See also use_solver documentation.
+to solve in the single precision.
 
 Example session::
 
@@ -23,16 +23,14 @@ Example session::
     >>> a = dia_array(([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1]), shape=(5, 5))
     >>> b = array([1, 2, 3, 4, 5])
     >>> print("Solve: single precision complex:")
-    >>> use_solver( useUmfpack = False )
     >>> a = a.astype('F')
-    >>> x = spsolve(a, b)
+    >>> x = spsolve(a, b, use_umfpack=False)
     >>> print(x)
     >>> print("Error: ", a@x-b)
     >>>
     >>> print("Solve: double precision complex:")
-    >>> use_solver( useUmfpack = True )
     >>> a = a.astype('D')
-    >>> x = spsolve(a, b)
+    >>> x = spsolve(a, b, use_umfpack=True)
     >>> print(x)
     >>> print("Error: ", a@x-b)
     >>>
@@ -43,9 +41,8 @@ Example session::
     >>> print("Error: ", a@x-b)
     >>>
     >>> print("Solve: single precision:")
-    >>> use_solver( useUmfpack = False )
     >>> a = a.astype('f')
-    >>> x = spsolve(a, b.astype('f'))
+    >>> x = spsolve(a, b.astype('f'), use_umfpack=False)
     >>> print(x)
     >>> print("Error: ", a@x-b)
 
@@ -63,7 +60,7 @@ from . import linsolve
 __all__ = [
     'MatrixRankWarning', 'SuperLU', 'factorized',
     'spilu', 'splu', 'spsolve', 'is_sptriangular',
-    'spsolve_triangular', 'use_solver', 'spbandwidth',
+    'spsolve_triangular', 'spbandwidth',
 ]
 
 from scipy._lib._testutils import PytestTester

--- a/scipy/sparse/linalg/_dsolve/__init__.py
+++ b/scipy/sparse/linalg/_dsolve/__init__.py
@@ -58,7 +58,7 @@ from . import _add_newdocs
 from . import linsolve
 
 __all__ = [
-    'MatrixRankWarning', 'SuperLU', 'factorized',
+    'SuperLU', 'factorized',
     'spilu', 'splu', 'spsolve', 'is_sptriangular',
     'spsolve_triangular', 'spbandwidth',
 ]

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -59,9 +59,9 @@ def spsolve(A, b, permc_spec=None, trans='N', use_umfpack=True, rhs_batch_size=1
         If ``b`` is a 2D sparse array, this parameter controls the number of
         columns to be solved simultaneously. A larger number will increase
         memory consumption by converting more columns at a time to dense
-        arrays, but may improve runtime. This option only applies when
-        ``use_umfpack=False``, since the low-level scikit-umfpack routines do
-        not support multiple right-hand sides. In that case, ``rhs_batch_size=1``.
+        arrays, but may improve runtime.
+
+        .. versionadded:: 1.18.0
 
     Returns
     -------

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -3,20 +3,19 @@ from warnings import warn, catch_warnings, simplefilter
 import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
-                          csr_array, csc_array, eye_array, diags_array)
+                          csr_array, csc_array, eye_array, diags_array, hstack)
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
-                                   get_index_dtype, safely_cast_index_arrays)
+                                   safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
-import copy
 import threading
 
 from . import _superlu
 
-noScikit = False
 try:
-    import scikits.umfpack as umfpack
+    from sksparse import umfpack
+    has_umfpack = True
 except ImportError:
-    noScikit = True
+    has_umfpack = False
 
 useUmfpack = threading.local()
 
@@ -38,16 +37,16 @@ def use_solver(**kwargs):
     ----------
     useUmfpack : bool, optional
         Use UMFPACK [1]_, [2]_, [3]_, [4]_. over SuperLU. Has effect only
-        if ``scikits.umfpack`` is installed. Default: True
+        if ``sksparse.umfpack`` is installed. Default: True
     assumeSortedIndices : bool, optional
         Allow UMFPACK to skip the step of sorting indices for a CSR/CSC matrix.
-        Has effect only if useUmfpack is True and ``scikits.umfpack`` is
+        Has effect only if useUmfpack is True and ``sksparse.umfpack`` is
         installed. Default: False
 
     Notes
     -----
     The default sparse solver is UMFPACK when available
-    (``scikits.umfpack`` is installed). This can be changed by passing
+    (``sksparse.umfpack`` is installed). This can be changed by passing
     useUmfpack = False, which then causes the always present SuperLU
     based solver to be used.
 
@@ -94,44 +93,9 @@ def use_solver(**kwargs):
     global useUmfpack
     if 'useUmfpack' in kwargs:
         useUmfpack.u = kwargs['useUmfpack']
-    if useUmfpack.u and 'assumeSortedIndices' in kwargs:
-        umfpack.configure(assumeSortedIndices=kwargs['assumeSortedIndices'])
 
-def _get_umf_family(A):
-    """Get umfpack family string given the sparse matrix dtype."""
-    _families = {
-        (np.float64, np.int32): 'di',
-        (np.complex128, np.int32): 'zi',
-        (np.float64, np.int64): 'dl',
-        (np.complex128, np.int64): 'zl'
-    }
 
-    # A.dtype.name can only be "float64" or
-    # "complex128" in control flow
-    f_type = getattr(np, A.dtype.name)
-    # control flow may allow for more index
-    # types to get through here
-    i_type = getattr(np, A.indices.dtype.name)
-
-    try:
-        family = _families[(f_type, i_type)]
-
-    except KeyError as e:
-        msg = ('only float64 or complex128 matrices with int32 or int64 '
-               f'indices are supported! (got: matrix: {f_type}, indices: {i_type})')
-        raise ValueError(msg) from e
-
-    # See gh-8278. Considered converting only if
-    # A.shape[0]*A.shape[1] > np.iinfo(np.int32).max,
-    # but that didn't always fix the issue.
-    family = family[0] + "l"
-    A_new = copy.copy(A)
-    A_new.indptr = np.asarray(A.indptr, dtype=np.int64)
-    A_new.indices = np.asarray(A.indices, dtype=np.int64)
-
-    return family, A_new
-
-def spsolve(A, b, permc_spec=None, use_umfpack=True):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters
@@ -153,7 +117,14 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     use_umfpack : bool, optional
         if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
         [6]_ . This is only referenced if b is a vector and
-        ``scikits.umfpack`` is installed.
+        ``sksparse.umfpack`` is installed.
+    rhs_batch_size : int, optional
+        If ``b`` is a 2D sparse array, this parameter controls the number of
+        columns to be solved simultaneously. A larger number will increase
+        memory consumption by converting more columns at a time to dense
+        arrays, but may improve runtime. This option only applies when
+        ``use_umfpack=False``, since the low-level scikit-umfpack routines do
+        not support multiple right-hand sides. In that case, ``rhs_batch_size=1``.
 
     Returns
     -------
@@ -223,11 +194,11 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         warn('spsolve requires A be CSC or CSR matrix format',
              SparseEfficiencyWarning, stacklevel=2)
 
-    # b is a vector only if b have shape (n,) or (n, 1)
+    # b is a vector only if b have shape (n,)
     b_is_sparse = issparse(b)
     if not b_is_sparse:
         b = asarray(b)
-    b_is_vector = ((b.ndim == 1) or (b.ndim == 2 and b.shape[1] == 1))
+    b_is_vector = b.ndim == 1
 
     # sum duplicates for non-canonical format
     A.sum_duplicates()
@@ -247,93 +218,86 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         raise ValueError(f"matrix - rhs dimension mismatch ({A.shape} - {b.shape[0]})")
 
     if not hasattr(useUmfpack, 'u'):
-        useUmfpack.u = not noScikit
+        useUmfpack.u = has_umfpack
 
     use_umfpack = use_umfpack and useUmfpack.u
 
-    if b_is_vector and use_umfpack:
-        if b_is_sparse:
-            b_vec = b.toarray()
+    if use_umfpack:
+        # sksparse.umfpack handles 1D and 2D, sparse or dense b
+        x = umfpack.umf_solve(A, b, rhs_batch_size=rhs_batch_size)
+
+        # Convert back to consistent sparse class
+        if b_is_sparse and not b_is_vector:
+            x = A.__class__(x)
+
+        # Return the same type as b
+        if is_pydata_sparse:
+            x = pydata_sparse_cls.from_scipy_sparse(x)
+    elif not b_is_sparse:
+        # Dense SuperLU solver
+        if A.format == "csc":
+            flag = 1  # CSC format
         else:
-            b_vec = b
-        b_vec = asarray(b_vec, dtype=A.dtype).ravel()
+            flag = 0  # CSR format
 
-        if noScikit:
-            raise RuntimeError('Scikits.umfpack not installed.')
-
-        if A.dtype.char not in 'dD':
-            raise ValueError("convert matrix data to double, please, using"
-                  " .astype(), or set linsolve.useUmfpack.u = False")
-
-        umf_family, A = _get_umf_family(A)
-        umf = umfpack.UmfpackContext(umf_family)
-        x = umf.linsolve(umfpack.UMFPACK_A, A, b_vec,
-                         autoTranspose=True)
+        indices = A.indices.astype(np.intc, copy=False)
+        indptr = A.indptr.astype(np.intc, copy=False)
+        options = dict(ColPerm=permc_spec)
+        x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
+                                b, flag, options=options)
+        if info != 0:
+            # TODO raise? splu raises, and la.solve raises LinAlgError.
+            warn("Matrix is exactly singular", MatrixRankWarning, stacklevel=2)
+            x.fill(np.nan)
     else:
-        if b_is_vector and b_is_sparse:
-            b = b.toarray()
-            b_is_sparse = False
+        # Sparse SuperLU solver
+        Afactsolve = splu(A, permc_spec=permc_spec).solve
 
-        if not b_is_sparse:
-            if A.format == "csc":
-                flag = 1  # CSC format
-            else:
-                flag = 0  # CSR format
+        if b_is_vector:
+            # convert to 2D sparse matrix with one column
+            b = b[:, np.newaxis]
 
-            indices = A.indices.astype(np.intc, copy=False)
-            indptr = A.indptr.astype(np.intc, copy=False)
-            options = dict(ColPerm=permc_spec)
-            x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
-                                    b, flag, options=options)
-            if info == 0:
-                pass  # Success
-            elif 0 < info <= N:
-                warn("Matrix is exactly singular", MatrixRankWarning, stacklevel=2)
-                x.fill(np.nan)
-            elif info > N:
-                raise MemoryError("Out of memory during gssv")
-            else:
-                # gssv is not supposed to return any info < 0
-                # However, it calls gstrf, which can set info < 0
-                raise Exception(f"gssv exited with unknown exit code {info}")
-            if b_is_vector:
-                x = x.ravel()
-        else:
-            # b is sparse
-            Afactsolve = factorized(A)
+        if not (b.format == "csc" or is_pydata_spmatrix(b)):
+            warn('spsolve is more efficient when sparse b '
+                    'is in the CSC matrix format',
+                    SparseEfficiencyWarning, stacklevel=2)
+            b = csc_array(b)
 
-            if not (b.format == "csc" or is_pydata_spmatrix(b)):
-                warn('spsolve is more efficient when sparse b '
-                     'is in the CSC matrix format',
-                     SparseEfficiencyWarning, stacklevel=2)
-                b = csc_array(b)
+        if use_umfpack and rhs_batch_size > 1:
+            rhs_batch_size = 1
 
-            # Create a sparse output matrix by repeatedly applying
-            # the sparse factorization to solve columns of b.
-            data_segs = []
-            row_segs = []
-            col_segs = []
-            for j in range(b.shape[1]):
-                bj = b[:, j].toarray().ravel()
-                xj = Afactsolve(bj)
-                w = np.flatnonzero(xj)
-                segment_length = w.shape[0]
-                row_segs.append(w)
-                col_segs.append(np.full(segment_length, j, dtype=int))
-                data_segs.append(np.asarray(xj[w], dtype=A.dtype))
-            sparse_data = np.concatenate(data_segs)
-            idx_dtype = get_index_dtype(maxval=max(b.shape))
-            sparse_row = np.concatenate(row_segs, dtype=idx_dtype)
-            sparse_col = np.concatenate(col_segs, dtype=idx_dtype)
-            x = A.__class__((sparse_data, (sparse_row, sparse_col)),
-                           shape=b.shape, dtype=A.dtype)
+        # Solve in batches to reduce memory consumption
+        K = b.shape[1]
+        x_blocks = []
 
-            if is_pydata_sparse:
-                x = pydata_sparse_cls.from_scipy_sparse(x)
+        # Pre-allocate arrays to avoid repeated allocations
+        b_batch = np.empty((N, min(rhs_batch_size, K)), dtype=b.dtype, order="F")
+
+        for k in range(0, K, rhs_batch_size):
+            batch_end = min(k + rhs_batch_size, K)
+            width = batch_end - k
+            # Convert sparse to dense in the buffer
+            b_view = b_batch[:, :width]
+            b[:, k:batch_end].toarray(out=b_view)
+            # Solve the linear systems
+            x_dense = Afactsolve(b_view)
+            x_blocks.append(csc_array(x_dense, dtype=b.dtype))
+
+        x = hstack(x_blocks)
+
+        # Convert back to consistent sparse class
+        x = A.__class__(x)
+
+        if b_is_vector:
+            x = x[:, 0]  # convert back to 1D sparse array
+
+        if is_pydata_sparse:
+            x = pydata_sparse_cls.from_scipy_sparse(x)
 
     return x
 
 
+# TODO use_umfpack?
 def splu(A, permc_spec=None, diag_pivot_thresh=None,
          relax=None, panel_size=None, options=None):
     """
@@ -576,37 +540,13 @@ def factorized(A):
         A = A.to_scipy_sparse().tocsc()
 
     if not hasattr(useUmfpack, 'u'):
-        useUmfpack.u = not noScikit
+        useUmfpack.u = has_umfpack
 
     if useUmfpack.u:
-        if noScikit:
-            raise RuntimeError('Scikits.umfpack not installed.')
+        if not has_umfpack:
+            raise RuntimeError('sksparse.umfpack not installed.')
 
-        if not (issparse(A) and A.format == "csc"):
-            A = csc_array(A)
-            warn('splu converted its input to CSC format',
-                 SparseEfficiencyWarning, stacklevel=2)
-
-        A = A._asfptype()  # upcast to a floating point format
-
-        if A.dtype.char not in 'dD':
-            raise ValueError("convert matrix data to double, please, using"
-                  " .astype(), or set linsolve.useUmfpack.u = False")
-
-        umf_family, A = _get_umf_family(A)
-        umf = umfpack.UmfpackContext(umf_family)
-
-        # Make LU decomposition.
-        umf.numeric(A)
-
-        def solve(b):
-            with np.errstate(divide="ignore", invalid="ignore"):
-                # Ignoring warnings with numpy >= 1.23.0, see gh-16523
-                result = umf.solve(umfpack.UMFPACK_A, A, b, autoTranspose=True)
-
-            return result
-
-        return solve
+        return umfpack.umf_factor(A).solve
     else:
         return splu(A).solve
 

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -7,7 +7,6 @@ from scipy.sparse import (issparse, SparseEfficiencyWarning,
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
                                    safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
-import threading
 
 from . import _superlu
 
@@ -17,82 +16,14 @@ try:
 except ImportError:
     has_umfpack = False
 
-useUmfpack = threading.local()
 
-
-__all__ = ['use_solver', 'spsolve', 'splu', 'spilu', 'factorized',
+__all__ = ['spsolve', 'splu', 'spilu', 'factorized',
            'MatrixRankWarning', 'spsolve_triangular', 'is_sptriangular', 'spbandwidth']
 
 
 class MatrixRankWarning(UserWarning):
     """Warning for exactly singular matrices."""
     pass
-
-
-def use_solver(**kwargs):
-    """
-    Select default sparse direct solver to be used.
-
-    Parameters
-    ----------
-    useUmfpack : bool, optional
-        Use UMFPACK [1]_, [2]_, [3]_, [4]_. over SuperLU. Has effect only
-        if ``sksparse.umfpack`` is installed. Default: True
-    assumeSortedIndices : bool, optional
-        Allow UMFPACK to skip the step of sorting indices for a CSR/CSC matrix.
-        Has effect only if useUmfpack is True and ``sksparse.umfpack`` is
-        installed. Default: False
-
-    Notes
-    -----
-    The default sparse solver is UMFPACK when available
-    (``sksparse.umfpack`` is installed). This can be changed by passing
-    useUmfpack = False, which then causes the always present SuperLU
-    based solver to be used.
-
-    UMFPACK requires a CSR/CSC matrix to have sorted column/row indices. If
-    sure that the matrix fulfills this, pass ``assumeSortedIndices=True``
-    to gain some speed.
-
-    References
-    ----------
-    .. [1] T. A. Davis, Algorithm 832:  UMFPACK - an unsymmetric-pattern
-           multifrontal method with a column pre-ordering strategy, ACM
-           Trans. on Mathematical Software, 30(2), 2004, pp. 196--199.
-           :doi:`10.1145/992200.992206`.
-
-    .. [2] T. A. Davis, A column pre-ordering strategy for the
-           unsymmetric-pattern multifrontal method, ACM Trans.
-           on Mathematical Software, 30(2), 2004, pp. 165--195.
-           :doi:`10.1145/992200.992205`.
-
-    .. [3] T. A. Davis and I. S. Duff, A combined unifrontal/multifrontal
-           method for unsymmetric sparse matrices, ACM Trans. on
-           Mathematical Software, 25(1), 1999, pp. 1--19.
-           :doi:`10.1145/305658.287640`.
-
-    .. [4] T. A. Davis and I. S. Duff, An unsymmetric-pattern multifrontal
-           method for sparse LU factorization, SIAM J. Matrix Analysis and
-           Computations, 18(1), 1997, pp. 140--158.
-           :doi:`10.1137/S0895479894246905T`.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from scipy.sparse.linalg import use_solver, spsolve
-    >>> from scipy.sparse import csc_array
-    >>> R = np.random.randn(5, 5)
-    >>> A = csc_array(R)
-    >>> b = np.random.randn(5)
-    >>> use_solver(useUmfpack=False) # enforce superLU over UMFPACK
-    >>> x = spsolve(A, b)
-    >>> np.allclose(A.dot(x), b)
-    True
-    >>> use_solver(useUmfpack=True) # reset umfPack usage to default
-    """
-    global useUmfpack
-    if 'useUmfpack' in kwargs:
-        useUmfpack.u = kwargs['useUmfpack']
 
 
 def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
@@ -115,9 +46,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
         - ``COLAMD``: approximate minimum degree column ordering [1]_, [2]_.
 
     use_umfpack : bool, optional
-        if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
-        [6]_ . This is only referenced if b is a vector and
-        ``sksparse.umfpack`` is installed.
+        If True, then use UMFPACK for the solution [3]_, [4]_, [5]_,
+        [6]_ . This input is only valid if ``sksparse.umfpack`` is installed.
     rhs_batch_size : int, optional
         If ``b`` is a 2D sparse array, this parameter controls the number of
         columns to be solved simultaneously. A larger number will increase
@@ -217,10 +147,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
     if M != b.shape[0]:
         raise ValueError(f"matrix - rhs dimension mismatch ({A.shape} - {b.shape[0]})")
 
-    if not hasattr(useUmfpack, 'u'):
-        useUmfpack.u = has_umfpack
-
-    use_umfpack = use_umfpack and useUmfpack.u
+    use_umfpack = use_umfpack and has_umfpack  # only use it if available
 
     if use_umfpack:
         # sksparse.umfpack handles 1D and 2D, sparse or dense b
@@ -297,7 +224,6 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
     return x
 
 
-# TODO use_umfpack?
 def splu(A, permc_spec=None, diag_pivot_thresh=None,
          relax=None, panel_size=None, options=None):
     """
@@ -506,7 +432,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
                           ilu=True, options=_options)
 
 
-def factorized(A):
+def factorized(A, use_umfpack=True):
     """
     Return a function for solving a sparse linear system, with A pre-factorized.
 
@@ -515,12 +441,38 @@ def factorized(A):
     A : (N, N) array_like
         Input. A in CSC format is most efficient. A CSR format matrix will
         be converted to CSC before factorization.
+    use_umfpack : bool, optional
+        If True, use UMFPACK for the factorization [1]_, [2]_, [3]_, [4]_. This
+        input is only valid if ``sksparse.umfpack`` is installed.
 
     Returns
     -------
     solve : callable
         To solve the linear system of equations given in `A`, the `solve`
         callable should be passed an ndarray of shape (N,).
+
+    References
+    ----------
+    .. [1] T. A. Davis, Algorithm 832:  UMFPACK - an unsymmetric-pattern
+           multifrontal method with a column pre-ordering strategy, ACM
+           Trans. on Mathematical Software, 30(2), 2004, pp. 196--199.
+           https://dl.acm.org/doi/abs/10.1145/992200.992206
+
+    .. [2] T. A. Davis, A column pre-ordering strategy for the
+           unsymmetric-pattern multifrontal method, ACM Trans.
+           on Mathematical Software, 30(2), 2004, pp. 165--195.
+           https://dl.acm.org/doi/abs/10.1145/992200.992205
+
+    .. [3] T. A. Davis and I. S. Duff, A combined unifrontal/multifrontal
+           method for unsymmetric sparse matrices, ACM Trans. on
+           Mathematical Software, 25(1), 1999, pp. 1--19.
+           https://doi.org/10.1145/305658.287640
+
+    .. [4] T. A. Davis and I. S. Duff, An unsymmetric-pattern multifrontal
+           method for sparse LU factorization, SIAM J. Matrix Analysis and
+           Computations, 18(1), 1997, pp. 140--158.
+           https://doi.org/10.1137/S0895479894246905T.
+
 
     Examples
     --------
@@ -539,13 +491,9 @@ def factorized(A):
     if is_pydata_spmatrix(A):
         A = A.to_scipy_sparse().tocsc()
 
-    if not hasattr(useUmfpack, 'u'):
-        useUmfpack.u = has_umfpack
+    use_umfpack = use_umfpack and has_umfpack  # only use it if available
 
-    if useUmfpack.u:
-        if not has_umfpack:
-            raise RuntimeError('sksparse.umfpack not installed.')
-
+    if use_umfpack:
         return umfpack.umf_factor(A).solve
     else:
         return splu(A).solve

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -7,7 +7,6 @@ from scipy.sparse import (issparse, SparseEfficiencyWarning,
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
                                    safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
-import threading
 
 from . import _superlu
 
@@ -17,82 +16,14 @@ try:
 except ImportError:
     has_umfpack = False
 
-useUmfpack = threading.local()
 
-
-__all__ = ['use_solver', 'spsolve', 'splu', 'spilu', 'factorized',
+__all__ = ['spsolve', 'splu', 'spilu', 'factorized',
            'MatrixRankWarning', 'spsolve_triangular', 'is_sptriangular', 'spbandwidth']
 
 
 class MatrixRankWarning(UserWarning):
     """Warning for exactly singular matrices."""
     pass
-
-
-def use_solver(**kwargs):
-    """
-    Select default sparse direct solver to be used.
-
-    Parameters
-    ----------
-    useUmfpack : bool, optional
-        Use UMFPACK [1]_, [2]_, [3]_, [4]_. over SuperLU. Has effect only
-        if ``sksparse.umfpack`` is installed. Default: True
-    assumeSortedIndices : bool, optional
-        Allow UMFPACK to skip the step of sorting indices for a CSR/CSC matrix.
-        Has effect only if useUmfpack is True and ``sksparse.umfpack`` is
-        installed. Default: False
-
-    Notes
-    -----
-    The default sparse solver is UMFPACK when available
-    (``sksparse.umfpack`` is installed). This can be changed by passing
-    useUmfpack = False, which then causes the always present SuperLU
-    based solver to be used.
-
-    UMFPACK requires a CSR/CSC matrix to have sorted column/row indices. If
-    sure that the matrix fulfills this, pass ``assumeSortedIndices=True``
-    to gain some speed.
-
-    References
-    ----------
-    .. [1] T. A. Davis, Algorithm 832:  UMFPACK - an unsymmetric-pattern
-           multifrontal method with a column pre-ordering strategy, ACM
-           Trans. on Mathematical Software, 30(2), 2004, pp. 196--199.
-           :doi:`10.1145/992200.992206`.
-
-    .. [2] T. A. Davis, A column pre-ordering strategy for the
-           unsymmetric-pattern multifrontal method, ACM Trans.
-           on Mathematical Software, 30(2), 2004, pp. 165--195.
-           :doi:`10.1145/992200.992205`.
-
-    .. [3] T. A. Davis and I. S. Duff, A combined unifrontal/multifrontal
-           method for unsymmetric sparse matrices, ACM Trans. on
-           Mathematical Software, 25(1), 1999, pp. 1--19.
-           :doi:`10.1145/305658.287640`.
-
-    .. [4] T. A. Davis and I. S. Duff, An unsymmetric-pattern multifrontal
-           method for sparse LU factorization, SIAM J. Matrix Analysis and
-           Computations, 18(1), 1997, pp. 140--158.
-           :doi:`10.1137/S0895479894246905T`.
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from scipy.sparse.linalg import use_solver, spsolve
-    >>> from scipy.sparse import csc_array
-    >>> R = np.random.randn(5, 5)
-    >>> A = csc_array(R)
-    >>> b = np.random.randn(5)
-    >>> use_solver(useUmfpack=False) # enforce superLU over UMFPACK
-    >>> x = spsolve(A, b)
-    >>> np.allclose(A.dot(x), b)
-    True
-    >>> use_solver(useUmfpack=True) # reset umfPack usage to default
-    """
-    global useUmfpack
-    if 'useUmfpack' in kwargs:
-        useUmfpack.u = kwargs['useUmfpack']
 
 
 def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
@@ -115,9 +46,8 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
         - ``COLAMD``: approximate minimum degree column ordering [1]_, [2]_.
 
     use_umfpack : bool, optional
-        if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
-        [6]_ . This is only referenced if b is a vector and
-        ``sksparse.umfpack`` is installed.
+        If True, then use UMFPACK for the solution [3]_, [4]_, [5]_,
+        [6]_ . This input is only valid if ``sksparse.umfpack`` is installed.
     rhs_batch_size : int, optional
         If ``b`` is a 2D sparse array, this parameter controls the number of
         columns to be solved simultaneously. A larger number will increase
@@ -217,10 +147,7 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
     if M != b.shape[0]:
         raise ValueError(f"matrix - rhs dimension mismatch ({A.shape} - {b.shape[0]})")
 
-    if not hasattr(useUmfpack, 'u'):
-        useUmfpack.u = has_umfpack
-
-    use_umfpack = use_umfpack and useUmfpack.u
+    use_umfpack = use_umfpack and has_umfpack  # only use it if available
 
     if use_umfpack:
         # sksparse.umfpack handles 1D and 2D, sparse or dense b
@@ -297,7 +224,6 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
     return x
 
 
-# TODO use_umfpack?
 def splu(A, permc_spec=None, diag_pivot_thresh=None,
          relax=None, panel_size=None, options=None):
     """
@@ -545,7 +471,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
                           ilu=True, options=_options)
 
 
-def factorized(A):
+def factorized(A, use_umfpack=True):
     """
     Return a function for solving a sparse linear system, with A pre-factorized.
 
@@ -554,12 +480,38 @@ def factorized(A):
     A : (N, N) array_like
         Input. A in CSC format is most efficient. A CSR format matrix will
         be converted to CSC before factorization.
+    use_umfpack : bool, optional
+        If True, use UMFPACK for the factorization [1]_, [2]_, [3]_, [4]_. This
+        input is only valid if ``sksparse.umfpack`` is installed.
 
     Returns
     -------
     solve : callable
         To solve the linear system of equations given in `A`, the `solve`
         callable should be passed an ndarray of shape (N,).
+
+    References
+    ----------
+    .. [1] T. A. Davis, Algorithm 832:  UMFPACK - an unsymmetric-pattern
+           multifrontal method with a column pre-ordering strategy, ACM
+           Trans. on Mathematical Software, 30(2), 2004, pp. 196--199.
+           https://dl.acm.org/doi/abs/10.1145/992200.992206
+
+    .. [2] T. A. Davis, A column pre-ordering strategy for the
+           unsymmetric-pattern multifrontal method, ACM Trans.
+           on Mathematical Software, 30(2), 2004, pp. 165--195.
+           https://dl.acm.org/doi/abs/10.1145/992200.992205
+
+    .. [3] T. A. Davis and I. S. Duff, A combined unifrontal/multifrontal
+           method for unsymmetric sparse matrices, ACM Trans. on
+           Mathematical Software, 25(1), 1999, pp. 1--19.
+           https://doi.org/10.1145/305658.287640
+
+    .. [4] T. A. Davis and I. S. Duff, An unsymmetric-pattern multifrontal
+           method for sparse LU factorization, SIAM J. Matrix Analysis and
+           Computations, 18(1), 1997, pp. 140--158.
+           https://doi.org/10.1137/S0895479894246905T.
+
 
     Examples
     --------
@@ -578,13 +530,9 @@ def factorized(A):
     if is_pydata_spmatrix(A):
         A = A.to_scipy_sparse().tocsc()
 
-    if not hasattr(useUmfpack, 'u'):
-        useUmfpack.u = has_umfpack
+    use_umfpack = use_umfpack and has_umfpack  # only use it if available
 
-    if useUmfpack.u:
-        if not has_umfpack:
-            raise RuntimeError('sksparse.umfpack not installed.')
-
+    if use_umfpack:
         return umfpack.umf_factor(A).solve
     else:
         return splu(A).solve

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -8,6 +8,7 @@ from scipy.sparse import (issparse, SparseEfficiencyWarning,
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
                                    safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
+from scipy._lib._util import _validate_int
 
 from . import _superlu
 
@@ -22,7 +23,7 @@ __all__ = ['spsolve', 'splu', 'spilu', 'factorized',
            'spsolve_triangular', 'is_sptriangular', 'spbandwidth']
 
 
-def spsolve(A, b, permc_spec=None, trans='N', use_umfpack=True, rhs_batch_size=10):
+def spsolve(A, b, permc_spec=None, trans='N', use_umfpack=True, rhs_block_size=10):
     r"""Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters
@@ -55,7 +56,7 @@ def spsolve(A, b, permc_spec=None, trans='N', use_umfpack=True, rhs_batch_size=1
     use_umfpack : bool, optional
         If True, then use UMFPACK for the solution [3]_, [4]_, [5]_,
         [6]_ . This input is only valid if ``sksparse.umfpack`` is installed.
-    rhs_batch_size : int, optional
+    rhs_block_size : int, optional
         If ``b`` is a 2D sparse array, this parameter controls the number of
         columns to be solved simultaneously. A larger number will increase
         memory consumption by converting more columns at a time to dense
@@ -156,10 +157,12 @@ def spsolve(A, b, permc_spec=None, trans='N', use_umfpack=True, rhs_batch_size=1
 
     use_umfpack = use_umfpack and has_umfpack  # only use it if available
 
+    _validate_int(rhs_block_size, "rhs_block_size", minimum=1)
+
     if use_umfpack:
         # sksparse.umfpack handles 1D and 2D, sparse or dense b
         try:
-            x = umfpack.umf_solve(A, b, trans=trans, rhs_batch_size=rhs_batch_size)
+            x = umfpack.umf_solve(A, b, trans=trans, rhs_batch_size=rhs_block_size)
         except umfpack.UMFPACKSingularMatrixError as e:
             raise LinAlgError("A is singular.") from e
     else:
@@ -184,19 +187,19 @@ def spsolve(A, b, permc_spec=None, trans='N', use_umfpack=True, rhs_batch_size=1
                         SparseEfficiencyWarning, stacklevel=2)
                 b = csc_array(b)
 
-            # Solve in batches to reduce memory consumption
+            # Solve in blocks to reduce memory consumption
             K = b.shape[1]
             x_blocks = []
 
             # Pre-allocate arrays to avoid repeated allocations
-            b_batch = np.empty((N, min(rhs_batch_size, K)), dtype=b.dtype, order="F")
+            b_block = np.empty((N, min(rhs_block_size, K)), dtype=b.dtype, order="F")
 
-            for k in range(0, K, rhs_batch_size):
-                batch_end = min(k + rhs_batch_size, K)
-                width = batch_end - k
+            for k in range(0, K, rhs_block_size):
+                block_end = min(k + rhs_block_size, K)
+                width = block_end - k
                 # Convert sparse to dense in the buffer
-                b_view = b_batch[:, :width]
-                b[:, k:batch_end].toarray(out=b_view)
+                b_view = b_block[:, :width]
+                b[:, k:block_end].toarray(out=b_view)
                 # Solve the linear systems
                 x_dense = lu_solve(b_view)
                 x_blocks.append(csc_array(x_dense, dtype=b.dtype))

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -3,20 +3,19 @@ from warnings import warn, catch_warnings, simplefilter
 import numpy as np
 from numpy import asarray
 from scipy.sparse import (issparse, SparseEfficiencyWarning,
-                          csr_array, csc_array, eye_array, diags_array)
+                          csr_array, csc_array, eye_array, diags_array, hstack)
 from scipy.sparse._sputils import (is_pydata_spmatrix, convert_pydata_sparse_to_scipy,
-                                   get_index_dtype, safely_cast_index_arrays)
+                                   safely_cast_index_arrays)
 from scipy.linalg import LinAlgError
-import copy
 import threading
 
 from . import _superlu
 
-noScikit = False
 try:
-    import scikits.umfpack as umfpack
+    from sksparse import umfpack
+    has_umfpack = True
 except ImportError:
-    noScikit = True
+    has_umfpack = False
 
 useUmfpack = threading.local()
 
@@ -36,21 +35,18 @@ def use_solver(**kwargs):
 
     Parameters
     ----------
-    **kwargs
-        The following options may be passed as keyword arguments.
-
-        useUmfpack : bool, optional
-            Use UMFPACK [1]_, [2]_, [3]_, [4]_. over SuperLU. Has effect only
-            if ``scikits.umfpack`` is installed. Default: True
-        assumeSortedIndices : bool, optional
-            Allow UMFPACK to skip the step of sorting indices for a CSR/CSC matrix.
-            Has effect only if useUmfpack is True and ``scikits.umfpack`` is
-            installed. Default: False
+    useUmfpack : bool, optional
+        Use UMFPACK [1]_, [2]_, [3]_, [4]_. over SuperLU. Has effect only
+        if ``sksparse.umfpack`` is installed. Default: True
+    assumeSortedIndices : bool, optional
+        Allow UMFPACK to skip the step of sorting indices for a CSR/CSC matrix.
+        Has effect only if useUmfpack is True and ``sksparse.umfpack`` is
+        installed. Default: False
 
     Notes
     -----
     The default sparse solver is UMFPACK when available
-    (``scikits.umfpack`` is installed). This can be changed by passing
+    (``sksparse.umfpack`` is installed). This can be changed by passing
     useUmfpack = False, which then causes the always present SuperLU
     based solver to be used.
 
@@ -97,44 +93,9 @@ def use_solver(**kwargs):
     global useUmfpack
     if 'useUmfpack' in kwargs:
         useUmfpack.u = kwargs['useUmfpack']
-    if useUmfpack.u and 'assumeSortedIndices' in kwargs:
-        umfpack.configure(assumeSortedIndices=kwargs['assumeSortedIndices'])
 
-def _get_umf_family(A):
-    """Get umfpack family string given the sparse matrix dtype."""
-    _families = {
-        (np.float64, np.int32): 'di',
-        (np.complex128, np.int32): 'zi',
-        (np.float64, np.int64): 'dl',
-        (np.complex128, np.int64): 'zl'
-    }
 
-    # A.dtype.name can only be "float64" or
-    # "complex128" in control flow
-    f_type = getattr(np, A.dtype.name)
-    # control flow may allow for more index
-    # types to get through here
-    i_type = getattr(np, A.indices.dtype.name)
-
-    try:
-        family = _families[(f_type, i_type)]
-
-    except KeyError as e:
-        msg = ('only float64 or complex128 matrices with int32 or int64 '
-               f'indices are supported! (got: matrix: {f_type}, indices: {i_type})')
-        raise ValueError(msg) from e
-
-    # See gh-8278. Considered converting only if
-    # A.shape[0]*A.shape[1] > np.iinfo(np.int32).max,
-    # but that didn't always fix the issue.
-    family = family[0] + "l"
-    A_new = copy.copy(A)
-    A_new.indptr = np.asarray(A.indptr, dtype=np.int64)
-    A_new.indices = np.asarray(A.indices, dtype=np.int64)
-
-    return family, A_new
-
-def spsolve(A, b, permc_spec=None, use_umfpack=True):
+def spsolve(A, b, permc_spec=None, use_umfpack=True, rhs_batch_size=10):
     """Solve the sparse linear system Ax=b, where b may be a vector or a matrix.
 
     Parameters
@@ -156,7 +117,14 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
     use_umfpack : bool, optional
         if True (default) then use UMFPACK for the solution [3]_, [4]_, [5]_,
         [6]_ . This is only referenced if b is a vector and
-        ``scikits.umfpack`` is installed.
+        ``sksparse.umfpack`` is installed.
+    rhs_batch_size : int, optional
+        If ``b`` is a 2D sparse array, this parameter controls the number of
+        columns to be solved simultaneously. A larger number will increase
+        memory consumption by converting more columns at a time to dense
+        arrays, but may improve runtime. This option only applies when
+        ``use_umfpack=False``, since the low-level scikit-umfpack routines do
+        not support multiple right-hand sides. In that case, ``rhs_batch_size=1``.
 
     Returns
     -------
@@ -226,11 +194,11 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         warn('spsolve requires A be CSC or CSR matrix format',
              SparseEfficiencyWarning, stacklevel=2)
 
-    # b is a vector only if b have shape (n,) or (n, 1)
+    # b is a vector only if b have shape (n,)
     b_is_sparse = issparse(b)
     if not b_is_sparse:
         b = asarray(b)
-    b_is_vector = ((b.ndim == 1) or (b.ndim == 2 and b.shape[1] == 1))
+    b_is_vector = b.ndim == 1
 
     # sum duplicates for non-canonical format
     A.sum_duplicates()
@@ -250,93 +218,86 @@ def spsolve(A, b, permc_spec=None, use_umfpack=True):
         raise ValueError(f"matrix - rhs dimension mismatch ({A.shape} - {b.shape[0]})")
 
     if not hasattr(useUmfpack, 'u'):
-        useUmfpack.u = not noScikit
+        useUmfpack.u = has_umfpack
 
     use_umfpack = use_umfpack and useUmfpack.u
 
-    if b_is_vector and use_umfpack:
-        if b_is_sparse:
-            b_vec = b.toarray()
+    if use_umfpack:
+        # sksparse.umfpack handles 1D and 2D, sparse or dense b
+        x = umfpack.umf_solve(A, b, rhs_batch_size=rhs_batch_size)
+
+        # Convert back to consistent sparse class
+        if b_is_sparse and not b_is_vector:
+            x = A.__class__(x)
+
+        # Return the same type as b
+        if is_pydata_sparse:
+            x = pydata_sparse_cls.from_scipy_sparse(x)
+    elif not b_is_sparse:
+        # Dense SuperLU solver
+        if A.format == "csc":
+            flag = 1  # CSC format
         else:
-            b_vec = b
-        b_vec = asarray(b_vec, dtype=A.dtype).ravel()
+            flag = 0  # CSR format
 
-        if noScikit:
-            raise RuntimeError('Scikits.umfpack not installed.')
-
-        if A.dtype.char not in 'dD':
-            raise ValueError("convert matrix data to double, please, using"
-                  " .astype(), or set linsolve.useUmfpack.u = False")
-
-        umf_family, A = _get_umf_family(A)
-        umf = umfpack.UmfpackContext(umf_family)
-        x = umf.linsolve(umfpack.UMFPACK_A, A, b_vec,
-                         autoTranspose=True)
+        indices = A.indices.astype(np.intc, copy=False)
+        indptr = A.indptr.astype(np.intc, copy=False)
+        options = dict(ColPerm=permc_spec)
+        x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
+                                b, flag, options=options)
+        if info != 0:
+            # TODO raise? splu raises, and la.solve raises LinAlgError.
+            warn("Matrix is exactly singular", MatrixRankWarning, stacklevel=2)
+            x.fill(np.nan)
     else:
-        if b_is_vector and b_is_sparse:
-            b = b.toarray()
-            b_is_sparse = False
+        # Sparse SuperLU solver
+        Afactsolve = splu(A, permc_spec=permc_spec).solve
 
-        if not b_is_sparse:
-            if A.format == "csc":
-                flag = 1  # CSC format
-            else:
-                flag = 0  # CSR format
+        if b_is_vector:
+            # convert to 2D sparse matrix with one column
+            b = b[:, np.newaxis]
 
-            indices = A.indices.astype(np.intc, copy=False)
-            indptr = A.indptr.astype(np.intc, copy=False)
-            options = dict(ColPerm=permc_spec)
-            x, info = _superlu.gssv(N, A.nnz, A.data, indices, indptr,
-                                    b, flag, options=options)
-            if info == 0:
-                pass  # Success
-            elif 0 < info <= N:
-                warn("Matrix is exactly singular", MatrixRankWarning, stacklevel=2)
-                x.fill(np.nan)
-            elif info > N:
-                raise MemoryError("Out of memory during gssv")
-            else:
-                # gssv is not supposed to return any info < 0
-                # However, it calls gstrf, which can set info < 0
-                raise Exception(f"gssv exited with unknown exit code {info}")
-            if b_is_vector:
-                x = x.ravel()
-        else:
-            # b is sparse
-            Afactsolve = factorized(A)
+        if not (b.format == "csc" or is_pydata_spmatrix(b)):
+            warn('spsolve is more efficient when sparse b '
+                    'is in the CSC matrix format',
+                    SparseEfficiencyWarning, stacklevel=2)
+            b = csc_array(b)
 
-            if not (b.format == "csc" or is_pydata_spmatrix(b)):
-                warn('spsolve is more efficient when sparse b '
-                     'is in the CSC matrix format',
-                     SparseEfficiencyWarning, stacklevel=2)
-                b = csc_array(b)
+        if use_umfpack and rhs_batch_size > 1:
+            rhs_batch_size = 1
 
-            # Create a sparse output matrix by repeatedly applying
-            # the sparse factorization to solve columns of b.
-            data_segs = []
-            row_segs = []
-            col_segs = []
-            for j in range(b.shape[1]):
-                bj = b[:, j].toarray().ravel()
-                xj = Afactsolve(bj)
-                w = np.flatnonzero(xj)
-                segment_length = w.shape[0]
-                row_segs.append(w)
-                col_segs.append(np.full(segment_length, j, dtype=int))
-                data_segs.append(np.asarray(xj[w], dtype=A.dtype))
-            sparse_data = np.concatenate(data_segs)
-            idx_dtype = get_index_dtype(maxval=max(b.shape))
-            sparse_row = np.concatenate(row_segs, dtype=idx_dtype)
-            sparse_col = np.concatenate(col_segs, dtype=idx_dtype)
-            x = A.__class__((sparse_data, (sparse_row, sparse_col)),
-                           shape=b.shape, dtype=A.dtype)
+        # Solve in batches to reduce memory consumption
+        K = b.shape[1]
+        x_blocks = []
 
-            if is_pydata_sparse:
-                x = pydata_sparse_cls.from_scipy_sparse(x)
+        # Pre-allocate arrays to avoid repeated allocations
+        b_batch = np.empty((N, min(rhs_batch_size, K)), dtype=b.dtype, order="F")
+
+        for k in range(0, K, rhs_batch_size):
+            batch_end = min(k + rhs_batch_size, K)
+            width = batch_end - k
+            # Convert sparse to dense in the buffer
+            b_view = b_batch[:, :width]
+            b[:, k:batch_end].toarray(out=b_view)
+            # Solve the linear systems
+            x_dense = Afactsolve(b_view)
+            x_blocks.append(csc_array(x_dense, dtype=b.dtype))
+
+        x = hstack(x_blocks)
+
+        # Convert back to consistent sparse class
+        x = A.__class__(x)
+
+        if b_is_vector:
+            x = x[:, 0]  # convert back to 1D sparse array
+
+        if is_pydata_sparse:
+            x = pydata_sparse_cls.from_scipy_sparse(x)
 
     return x
 
 
+# TODO use_umfpack?
 def splu(A, permc_spec=None, diag_pivot_thresh=None,
          relax=None, panel_size=None, options=None):
     """
@@ -618,37 +579,13 @@ def factorized(A):
         A = A.to_scipy_sparse().tocsc()
 
     if not hasattr(useUmfpack, 'u'):
-        useUmfpack.u = not noScikit
+        useUmfpack.u = has_umfpack
 
     if useUmfpack.u:
-        if noScikit:
-            raise RuntimeError('Scikits.umfpack not installed.')
+        if not has_umfpack:
+            raise RuntimeError('sksparse.umfpack not installed.')
 
-        if not (issparse(A) and A.format == "csc"):
-            A = csc_array(A)
-            warn('splu converted its input to CSC format',
-                 SparseEfficiencyWarning, stacklevel=2)
-
-        A = A._asfptype()  # upcast to a floating point format
-
-        if A.dtype.char not in 'dD':
-            raise ValueError("convert matrix data to double, please, using"
-                  " .astype(), or set linsolve.useUmfpack.u = False")
-
-        umf_family, A = _get_umf_family(A)
-        umf = umfpack.UmfpackContext(umf_family)
-
-        # Make LU decomposition.
-        umf.numeric(A)
-
-        def solve(b):
-            with np.errstate(divide="ignore", invalid="ignore"):
-                # Ignoring warnings with numpy >= 1.23.0, see gh-16523
-                result = umf.solve(umfpack.UMFPACK_A, A, b, autoTranspose=True)
-
-            return result
-
-        return solve
+        return umfpack.umf_factor(A).solve
     else:
         return splu(A).solve
 

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -202,11 +202,10 @@ class TestLinsolve:
         except RuntimeError:
             pass
 
-    @pytest.mark.parametrize('format', ['csc', 'csr'])
     @pytest.mark.parametrize('idx_dtype', [np.int32, np.int64])
-    def test_twodiags(self, format: str, idx_dtype: np.dtype):
+    def test_twodiags(self, idx_dtype: np.dtype):
         A = dia_array(([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1]),
-                        shape=(5, 5)).asformat(format)
+                        shape=(5, 5)).tocsc()
         b = array([1, 2, 3, 4, 5])
 
         # condition number of A
@@ -390,10 +389,10 @@ class TestLinsolve:
         assert_allclose(x.toarray(), b.toarray(), atol=1e-12, rtol=1e-12)
 
     def test_dtype_cast(self):
-        A_real = scipy.sparse.csr_array([[1, 2, 0],
+        A_real = scipy.sparse.csc_array([[1, 2, 0],
                                           [0, 0, 3],
                                           [4, 0, 5]])
-        A_complex = scipy.sparse.csr_array([[1, 2, 0],
+        A_complex = scipy.sparse.csc_array([[1, 2, 0],
                                              [0, 0, 3],
                                              [4, 0, 5 + 1j]])
         b_real = np.array([1,1,1])
@@ -708,7 +707,7 @@ class TestSplu:
     def test_singular_matrix(self):
         # Test that SuperLU does not print to stdout when a singular matrix is
         # passed. See gh-20993.
-        A = eye_array(10, format='csr')
+        A = eye_array(10, format='csc')
         A[-1, -1] = 0
         b = np.zeros(10)
         with assert_raises(scipy.linalg.LinAlgError, match="A is singular"):

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -15,7 +15,7 @@ import scipy.linalg
 from scipy.linalg import norm, inv
 from scipy.sparse import (dia_array, SparseEfficiencyWarning, csc_array,
         csr_array, eye_array, issparse, dok_array, lil_array, bsr_array,
-        coo_array, random_array, kron)
+        coo_array, random_array, tril, triu, kron)
 from scipy.sparse.linalg import SuperLU
 from scipy.sparse.linalg._dsolve import (spsolve, splu, spilu,
         _superlu, spsolve_triangular, factorized,

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -1,3 +1,4 @@
+from functools import partial
 import sys
 import threading
 import warnings
@@ -17,7 +18,7 @@ from scipy.sparse import (issparse, SparseEfficiencyWarning,
                           dok_array, lil_array, bsr_array,
                           eye_array, random_array, tril, triu, kron)
 from scipy.sparse.linalg import SuperLU
-from scipy.sparse.linalg._dsolve import (spsolve, use_solver, splu, spilu,
+from scipy.sparse.linalg._dsolve import (spsolve, splu, spilu,
         MatrixRankWarning, _superlu, spsolve_triangular, factorized,
         is_sptriangular, spbandwidth)
 import scipy.sparse
@@ -25,7 +26,7 @@ import scipy.sparse
 from scipy._lib._testutils import check_free_memory
 
 
-# scikits.umfpack is not a SciPy dependency but it is optionally used in
+# sksparse.umfpack is not a SciPy dependency but it is optionally used in
 # dsolve, so check whether it's available
 try:
     from sksparse.umfpack import UMFPACKError, UMFPACKSingularMatrixWarning
@@ -59,12 +60,12 @@ class TestFactorized:
         self.n = n
         self.A = dia_array(((d, 2*d, d[::-1]), (-3, 0, 5)), shape=(n,n)).tocsc()
 
-    def _check_singular(self):
+    def _check_singular(self, use_umfpack=False):
         A = csc_array((5,5), dtype='d')
         b = ones(5)
-        assert_array_almost_equal(0. * b, factorized(A)(b))
+        assert_array_almost_equal(0. * b, factorized(A, use_umfpack)(b))
 
-    def _check_non_singular(self):
+    def _check_non_singular(self, use_umfpack=False):
         # Make a diagonal dominant, to make sure it is not singular
         n = 5
         rng = np.random.default_rng(14332)
@@ -72,16 +73,14 @@ class TestFactorized:
         b = ones(n)
 
         expected = splu(a).solve(b)
-        assert_array_almost_equal(factorized(a)(b), expected)
+        assert_array_almost_equal(factorized(a, use_umfpack)(b), expected)
 
     def test_singular_without_umfpack(self):
-        use_solver(useUmfpack=False)
         with assert_raises(RuntimeError, match="Factor is exactly singular"):
-            self._check_singular()
+            self._check_singular(use_umfpack=False)
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_singular_with_umfpack(self):
-        use_solver(useUmfpack=True)
         # FIXME? umf_factor will warn with UMFPACKSingularMatrixWarning, but
         # then the solve will raise UMFPACKError for exactly singular matrix.
         #   * SuperLU raises a RuntimeError on factorization.
@@ -94,32 +93,27 @@ class TestFactorized:
             with assert_raises(
                 UMFPACKError, match="indefinite or singular to working precision"
             ):
-                self._check_singular()
+                self._check_singular(use_umfpack=True)
 
     def test_non_singular_without_umfpack(self):
-        use_solver(useUmfpack=False)
-        self._check_non_singular()
+        self._check_non_singular(use_umfpack=False)
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_non_singular_with_umfpack(self):
-        use_solver(useUmfpack=True)
-        self._check_non_singular()
+        self._check_non_singular(use_umfpack=True)
 
     def test_cannot_factorize_nonsquare_matrix_without_umfpack(self):
-        use_solver(useUmfpack=False)
         msg = "can only factor square matrices"
         with assert_raises(ValueError, match=msg):
-            factorized(self.A[:, :4])
+            factorized(self.A[:, :4], use_umfpack=False)
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_factorizes_nonsquare_matrix_with_umfpack(self):
-        use_solver(useUmfpack=True)
         # does not raise
-        factorized(self.A[:,:4])
+        factorized(self.A[:,:4], use_umfpack=True)
 
     def test_call_with_incorrectly_sized_matrix_without_umfpack(self):
-        use_solver(useUmfpack=False)
-        solve = factorized(self.A)
+        solve = factorized(self.A, use_umfpack=False)
 
         rng = np.random.default_rng(230498)
         b = rng.random(4)
@@ -136,8 +130,7 @@ class TestFactorized:
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_call_with_incorrectly_sized_matrix_with_umfpack(self):
-        use_solver(useUmfpack=True)
-        solve = factorized(self.A)
+        solve = factorized(self.A, use_umfpack=True)
 
         rng = np.random.default_rng(643095823)
         b = rng.random(4)
@@ -153,8 +146,7 @@ class TestFactorized:
             solve(BB)
 
     def test_call_with_cast_to_complex_without_umfpack(self):
-        use_solver(useUmfpack=False)
-        solve = factorized(self.A)
+        solve = factorized(self.A, use_umfpack=False)
         rng = np.random.default_rng(23454)
         b = rng.random(5)
         for t in [np.complex64, np.complex128]:
@@ -163,52 +155,27 @@ class TestFactorized:
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_call_with_cast_to_complex_with_umfpack(self):
-        use_solver(useUmfpack=True)
-        solve = factorized(self.A)
+        solve = factorized(self.A, use_umfpack=True)
         rng = np.random.default_rng(23454)
         b = rng.random(5)
         for t in [np.complex64, np.complex128]:
             with assert_raises(TypeError, match="Cannot safely cast"):
                 solve(b.astype(t))
 
-    @pytest.mark.skip(reason="option not implemented in sksparse.umfpack")
-    @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
-    def test_assume_sorted_indices_flag(self):
-        # a sparse matrix with unsorted indices
-        unsorted_inds = np.array([2, 0, 1, 0])
-        data = np.array([10, 16, 5, 0.4])
-        indptr = np.array([0, 1, 2, 4])
-        A = csc_array((data, unsorted_inds, indptr), (3, 3))
-        b = ones(3)
-
-        # should raise when incorrectly assuming indices are sorted
-        use_solver(useUmfpack=True, assumeSortedIndices=True)
-        with assert_raises(RuntimeError,
-                           match="UMFPACK_ERROR_invalid_matrix"):
-            factorized(A)
-
-        # should sort indices and succeed when not assuming indices are sorted
-        use_solver(useUmfpack=True, assumeSortedIndices=False)
-        expected = splu(A.copy()).solve(b)
-
-        assert_equal(A.has_sorted_indices, 0)
-        assert_array_almost_equal(factorized(A)(b), expected)
-
     @pytest.mark.slow
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_bug_8278(self):
         check_free_memory(8000)
-        use_solver(useUmfpack=True)
         A, b = setup_bug_8278()
         A = A.tocsc()
-        f = factorized(A)
+        f = factorized(A, use_umfpack=True)
         x = f(b)
         assert_array_almost_equal(A @ x, b)
 
 
 class TestLinsolve:
     def setup_method(self):
-        use_solver(useUmfpack=False)
+        self.spsolve = partial(spsolve, use_umfpack=False)
 
     def test_singular(self):
         A = csc_array((5,5), dtype='d')
@@ -216,7 +183,7 @@ class TestLinsolve:
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", "Matrix is exactly singular", MatrixRankWarning)
-            x = spsolve(A, b)
+            x = self.spsolve(A, b)
         assert_(not np.isfinite(x).any())
 
     def test_singular_gh_3312(self):
@@ -233,7 +200,7 @@ class TestLinsolve:
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore", "Matrix is exactly singular", MatrixRankWarning)
-                x = spsolve(A, b)
+                x = self.spsolve(A, b)
             assert not np.isfinite(x).any()
         except RuntimeError:
             pass
@@ -255,7 +222,7 @@ class TestLinsolve:
             Asp.indices = Asp.indices.astype(idx_dtype, copy=False)
             Asp.indptr = Asp.indptr.astype(idx_dtype, copy=False)
 
-            x = spsolve(Asp, b)
+            x = self.spsolve(Asp, b)
             assert_(norm(b - Asp@x) < 10 * cond_A * eps)
 
     def test_bvector_smoketest(self):
@@ -266,7 +233,7 @@ class TestLinsolve:
         rng = np.random.default_rng(1234)
         x = rng.standard_normal(3)
         b = As@x
-        x2 = spsolve(As, b)
+        x2 = self.spsolve(As, b)
 
         assert_array_almost_equal(x, x2)
 
@@ -279,7 +246,7 @@ class TestLinsolve:
         x = rng.standard_normal((3, 4))
         Bdense = As.dot(x)
         Bs = csc_array(Bdense)
-        x2 = spsolve(As, Bs)
+        x2 = self.spsolve(As, Bs)
         assert_array_almost_equal(x, x2.toarray())
 
     def test_non_square(self):
@@ -288,11 +255,11 @@ class TestLinsolve:
             # A is not square.
             A = ones((3, 4))
             b = ones((4, 1))
-            assert_raises(ValueError, spsolve, A, b)
+            assert_raises(ValueError, self.spsolve, A, b)
             # A2 and b2 have incompatible shapes.
             A2 = csc_array(eye(3))
             b2 = array([1.0, 2.0])
-            assert_raises(ValueError, spsolve, A2, b2)
+            assert_raises(ValueError, self.spsolve, A2, b2)
 
     def test_example_comparison(self):
         with warnings.catch_warnings():
@@ -309,7 +276,7 @@ class TestLinsolve:
             sN = csr_array((data, (row,col)), shape=(3,3), dtype=float)
             N = sN.toarray()
 
-            sX = spsolve(sM, sN)
+            sX = self.spsolve(sM, sN)
             X = scipy.linalg.solve(M, N)
 
             assert_array_almost_equal(X, sX.toarray())
@@ -318,7 +285,6 @@ class TestLinsolve:
     def test_shape_compatibility(self):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', SparseEfficiencyWarning)
-            use_solver(useUmfpack=True)
             A = csc_array([[1., 0], [0, 2]])
             bs = [
                 [1, 6],
@@ -342,8 +308,8 @@ class TestLinsolve:
             for spmattype in [csc_array, csr_array, dok_array, lil_array]:
                 with warnings.catch_warnings():
                     warnings.simplefilter('ignore', SparseEfficiencyWarning)
-                    x1 = spsolve(spmattype(A), b, use_umfpack=True)
-                    x2 = spsolve(spmattype(A), b, use_umfpack=False)
+                    x1 = self.spsolve(spmattype(A), b, use_umfpack=True)
+                    x2 = self.spsolve(spmattype(A), b, use_umfpack=False)
 
                 assert_array_almost_equal(toarray(x1), x,
                                           err_msg=repr((b, spmattype, 1)))
@@ -364,7 +330,7 @@ class TestLinsolve:
 
         A = csc_array((3, 3))
         b = csc_array((1, 3))
-        assert_raises(ValueError, spsolve, A, b)
+        assert_raises(ValueError, self.spsolve, A, b)
 
     def test_ndarray_support(self):
         with warnings.catch_warnings():
@@ -373,7 +339,7 @@ class TestLinsolve:
             x = array([[1., 1.], [0.5, -0.5]])
             b = array([[2., 0.], [2., 2.]])
 
-            assert_array_almost_equal(x, spsolve(A, b))
+            assert_array_almost_equal(x, self.spsolve(A, b))
 
     def test_gssv_badinput(self):
         N = 10
@@ -420,7 +386,7 @@ class TestLinsolve:
             [0, 1],
             [1, 0],
             [0, 0]])
-        x = spsolve(ident, b)
+        x = self.spsolve(ident, b)
         assert_equal(ident.nnz, 3)
         assert_equal(b.nnz, 2)
         assert_equal(x.nnz, 2)
@@ -435,32 +401,31 @@ class TestLinsolve:
                                [4, 0, 5 + 1j]])
         b_real = np.array([1,1,1])
         b_complex = np.array([1,1,1]) + 1j*np.array([1,1,1])
-        x = spsolve(A_real, b_real)
+        x = self.spsolve(A_real, b_real)
         assert_(np.issubdtype(x.dtype, np.floating))
-        x = spsolve(A_real, b_complex)
+        x = self.spsolve(A_real, b_complex)
         assert_(np.issubdtype(x.dtype, np.complexfloating))
-        x = spsolve(A_complex, b_real)
+        x = self.spsolve(A_complex, b_real)
         assert_(np.issubdtype(x.dtype, np.complexfloating))
-        x = spsolve(A_complex, b_complex)
+        x = self.spsolve(A_complex, b_complex)
         assert_(np.issubdtype(x.dtype, np.complexfloating))
 
     @pytest.mark.slow
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_bug_8278(self):
         check_free_memory(8000)
-        use_solver(useUmfpack=True)
         A, b = setup_bug_8278()
-        x = spsolve(A, b)
+        x = self.spsolve(A, b, use_umfpack=True)
         assert_array_almost_equal(A @ x, b)
 
 
 class TestSplu:
     def setup_method(self):
-        use_solver(useUmfpack=False)
         n = 40
         d = arange(n) + 1
         self.n = n
         self.A = dia_array(((d, 2*d, d[::-1]), (-3, 0, 5)), shape=(n, n)).tocsc()
+        self.spsolve = partial(spsolve, use_umfpack=False)
 
     def _smoketest(self, spxlu, check, dtype, idx_dtype):
         if np.issubdtype(dtype, np.complexfloating):
@@ -750,7 +715,7 @@ class TestSplu:
         A[-1, -1] = 0
         b = np.zeros(10)
         with pytest.warns(MatrixRankWarning):
-            res = spsolve(A, b)
+            res = self.spsolve(A, b)
             assert np.isnan(res).all()
 
 
@@ -796,10 +761,8 @@ class TestGstrsErrors:
                                 U.shape[0], U.nnz, U.data, U.indices, U.indptr,
                                 self.b.astype(np.uint8))
 
-class TestSpsolveTriangular:
-    def setup_method(self):
-        use_solver(useUmfpack=False)
 
+class TestSpsolveTriangular:
     @pytest.mark.parametrize("fmt",["csr","csc"])
     def test_zero_diagonal(self,fmt):
         n = 5

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -4,7 +4,6 @@ import warnings
 
 import numpy as np
 from numpy import array, finfo, arange, eye, all, unique, ones, dot
-from numpy.exceptions import ComplexWarning
 from numpy.testing import (
         assert_array_almost_equal, assert_almost_equal,
         assert_equal, assert_array_equal, assert_, assert_allclose)
@@ -29,7 +28,7 @@ from scipy._lib._testutils import check_free_memory
 # scikits.umfpack is not a SciPy dependency but it is optionally used in
 # dsolve, so check whether it's available
 try:
-    import scikits.umfpack as umfpack
+    from sksparse.umfpack import UMFPACKError, UMFPACKSingularMatrixWarning
     has_umfpack = True
 except ImportError:
     has_umfpack = False
@@ -83,10 +82,19 @@ class TestFactorized:
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_singular_with_umfpack(self):
         use_solver(useUmfpack=True)
-        with warnings.catch_warnings():
-            msg = "divide by zero encountered in double_scalars"
-            warnings.filterwarnings("ignore", msg, RuntimeWarning)
-            assert_warns(umfpack.UmfpackWarning, self._check_singular)
+        # FIXME? umf_factor will warn with UMFPACKSingularMatrixWarning, but
+        # then the solve will raise UMFPACKError for exactly singular matrix.
+        #   * SuperLU raises a RuntimeError on factorization.
+        #   * scipy.linalg.lu(A) does not raise or warn
+        #   * scipy.linalg.solve(A, b) raises a LinAlgError on solve.
+        # Returning the factors is helpful for debugging, so keep the current
+        # behavior for now... but might want to filter within dsolve so only
+        # one of these is raised?
+        with assert_warns(UMFPACKSingularMatrixWarning, match="Matrix is singular"):
+            with assert_raises(
+                UMFPACKError, match="indefinite or singular to working precision"
+            ):
+                self._check_singular()
 
     def test_non_singular_without_umfpack(self):
         use_solver(useUmfpack=False)
@@ -136,19 +144,19 @@ class TestFactorized:
         B = rng.random((4, 3))
         BB = rng.random((self.n, 3, 9))
 
-        # does not raise
-        solve(b)
-        msg = "object too deep for desired array"
+        msg = "Right-hand side b must have the same number of rows as A"
+        with assert_raises(ValueError, match=msg):
+            solve(b)
         with assert_raises(ValueError, match=msg):
             solve(B)
-        with assert_raises(ValueError, match=msg):
+        with assert_raises(ValueError, match="b must be a 1D or 2D array"):
             solve(BB)
 
     def test_call_with_cast_to_complex_without_umfpack(self):
         use_solver(useUmfpack=False)
         solve = factorized(self.A)
         rng = np.random.default_rng(23454)
-        b = rng.random(4)
+        b = rng.random(5)
         for t in [np.complex64, np.complex128]:
             with assert_raises(TypeError, match="Cannot cast array data"):
                 solve(b.astype(t))
@@ -158,10 +166,12 @@ class TestFactorized:
         use_solver(useUmfpack=True)
         solve = factorized(self.A)
         rng = np.random.default_rng(23454)
-        b = rng.random(4)
+        b = rng.random(5)
         for t in [np.complex64, np.complex128]:
-            assert_warns(ComplexWarning, solve, b.astype(t))
+            with assert_raises(TypeError, match="Cannot safely cast"):
+                solve(b.astype(t))
 
+    @pytest.mark.skip(reason="option not implemented in sksparse.umfpack")
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_assume_sorted_indices_flag(self):
         # a sparse matrix with unsorted indices
@@ -313,6 +323,7 @@ class TestLinsolve:
             bs = [
                 [1, 6],
                 array([1, 6]),
+                dok_array([1, 6]),
                 [[1], [6]],
                 array([[1], [6]]),
                 csc_array([[1], [6]]),
@@ -329,21 +340,18 @@ class TestLinsolve:
         for b in bs:
             x = np.linalg.solve(A.toarray(), toarray(b))
             for spmattype in [csc_array, csr_array, dok_array, lil_array]:
-                x1 = spsolve(spmattype(A), b, use_umfpack=True)
-                x2 = spsolve(spmattype(A), b, use_umfpack=False)
-
-                # check solution
-                if x.ndim == 2 and x.shape[1] == 1:
-                    # interprets also these as "vectors"
-                    x = x.ravel()
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', SparseEfficiencyWarning)
+                    x1 = spsolve(spmattype(A), b, use_umfpack=True)
+                    x2 = spsolve(spmattype(A), b, use_umfpack=False)
 
                 assert_array_almost_equal(toarray(x1), x,
                                           err_msg=repr((b, spmattype, 1)))
                 assert_array_almost_equal(toarray(x2), x,
                                           err_msg=repr((b, spmattype, 2)))
 
-                # dense vs. sparse output  ("vectors" are always dense)
-                if issparse(b) and x.ndim > 1:
+                # dense vs. sparse output
+                if issparse(b):
                     assert_(issparse(x1), repr((b, spmattype, 1)))
                     assert_(issparse(x2), repr((b, spmattype, 2)))
                 else:
@@ -351,14 +359,8 @@ class TestLinsolve:
                     assert_(isinstance(x2, np.ndarray), repr((b, spmattype, 2)))
 
                 # check output shape
-                if x.ndim == 1:
-                    # "vector"
-                    assert_equal(x1.shape, (A.shape[1],))
-                    assert_equal(x2.shape, (A.shape[1],))
-                else:
-                    # "matrix"
-                    assert_equal(x1.shape, x.shape)
-                    assert_equal(x2.shape, x.shape)
+                assert_equal(x1.shape, x.shape)
+                assert_equal(x2.shape, x.shape)
 
         A = csc_array((3, 3))
         b = csc_array((1, 3))

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -204,11 +204,10 @@ class TestLinsolve:
         except RuntimeError:
             pass
 
-    @pytest.mark.parametrize('format', ['csc', 'csr'])
     @pytest.mark.parametrize('idx_dtype', [np.int32, np.int64])
-    def test_twodiags(self, format: str, idx_dtype: np.dtype):
+    def test_twodiags(self, idx_dtype: np.dtype):
         A = dia_array(([[1, 2, 3, 4, 5], [6, 5, 8, 9, 10]], [0, 1]),
-                        shape=(5, 5)).asformat(format)
+                        shape=(5, 5)).tocsc()
         b = array([1, 2, 3, 4, 5])
 
         # condition number of A
@@ -392,12 +391,12 @@ class TestLinsolve:
         assert_allclose(x.toarray(), b.toarray(), atol=1e-12, rtol=1e-12)
 
     def test_dtype_cast(self):
-        A_real = csr_array([[1, 2, 0],
-                            [0, 0, 3],
-                            [4, 0, 5]])
-        A_complex = csr_array([[1, 2, 0],
-                               [0, 0, 3],
-                               [4, 0, 5 + 1j]])
+        A_real = scipy.sparse.csc_array([[1, 2, 0],
+                                          [0, 0, 3],
+                                          [4, 0, 5]])
+        A_complex = scipy.sparse.csc_array([[1, 2, 0],
+                                             [0, 0, 3],
+                                             [4, 0, 5 + 1j]])
         b_real = np.array([1,1,1])
         b_complex = np.array([1,1,1]) + 1j*np.array([1,1,1])
         x = self.spsolve(A_real, b_real)
@@ -710,7 +709,7 @@ class TestSplu:
     def test_singular_matrix(self):
         # Test that SuperLU does not print to stdout when a singular matrix is
         # passed. See gh-20993.
-        A = eye_array(10, format='csr')
+        A = eye_array(10, format='csc')
         A[-1, -1] = 0
         b = np.zeros(10)
         with assert_raises(scipy.linalg.LinAlgError, match="A is singular"):

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -19,7 +19,7 @@ from scipy.sparse import (issparse, SparseEfficiencyWarning,
                           eye_array, random_array, tril, triu, kron)
 from scipy.sparse.linalg import SuperLU
 from scipy.sparse.linalg._dsolve import (spsolve, splu, spilu,
-        MatrixRankWarning, _superlu, spsolve_triangular, factorized,
+        _superlu, spsolve_triangular, factorized,
         is_sptriangular, spbandwidth)
 import scipy.sparse
 
@@ -29,7 +29,10 @@ from scipy._lib._testutils import check_free_memory
 # sksparse.umfpack is not a SciPy dependency but it is optionally used in
 # dsolve, so check whether it's available
 try:
-    from sksparse.umfpack import UMFPACKError, UMFPACKSingularMatrixWarning
+    from sksparse.umfpack import (
+        UMFPACKSingularMatrixError,
+        UMFPACKSingularMatrixWarning,
+    )
     has_umfpack = True
 except ImportError:
     has_umfpack = False
@@ -81,8 +84,9 @@ class TestFactorized:
 
     @pytest.mark.skipif(not has_umfpack, reason="umfpack not available")
     def test_singular_with_umfpack(self):
-        # FIXME? umf_factor will warn with UMFPACKSingularMatrixWarning, but
-        # then the solve will raise UMFPACKError for exactly singular matrix.
+        # NOTE umf_factor (called by factorized) will warn with
+        # UMFPACKSingularMatrixWarning, but then the solve will raise
+        # UMFPACKSingularMatrixError for an exactly singular matrix.
         #   * SuperLU raises a RuntimeError on factorization.
         #   * scipy.linalg.lu(A) does not raise or warn
         #   * scipy.linalg.solve(A, b) raises a LinAlgError on solve.
@@ -91,7 +95,8 @@ class TestFactorized:
         # one of these is raised?
         with assert_warns(UMFPACKSingularMatrixWarning, match="Matrix is singular"):
             with assert_raises(
-                UMFPACKError, match="indefinite or singular to working precision"
+                UMFPACKSingularMatrixError,
+                match="indefinite or singular to working precision"
             ):
                 self._check_singular(use_umfpack=True)
 
@@ -180,11 +185,8 @@ class TestLinsolve:
     def test_singular(self):
         A = csc_array((5,5), dtype='d')
         b = array([1, 2, 3, 4, 5],dtype='d')
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", "Matrix is exactly singular", MatrixRankWarning)
-            x = self.spsolve(A, b)
-        assert_(not np.isfinite(x).any())
+        with assert_raises(scipy.linalg.LinAlgError, match="A is singular"):
+            self.spsolve(A, b)
 
     def test_singular_gh_3312(self):
         # "Bad" test case that leads SuperLU to call LAPACK with invalid
@@ -197,11 +199,8 @@ class TestLinsolve:
         try:
             # should either raise a runtime error or return value
             # appropriate for singular input (which yields the warning)
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore", "Matrix is exactly singular", MatrixRankWarning)
-                x = self.spsolve(A, b)
-            assert not np.isfinite(x).any()
+            with assert_raises(scipy.linalg.LinAlgError, match="A is singular"):
+                self.spsolve(A, b)
         except RuntimeError:
             pass
 
@@ -714,9 +713,8 @@ class TestSplu:
         A = eye_array(10, format='csr')
         A[-1, -1] = 0
         b = np.zeros(10)
-        with pytest.warns(MatrixRankWarning):
-            res = self.spsolve(A, b)
-            assert np.isnan(res).all()
+        with assert_raises(scipy.linalg.LinAlgError, match="A is singular"):
+            self.spsolve(A, b)
 
 
 class TestGstrsErrors:

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -13,10 +13,9 @@ from pytest import raises as assert_raises, warns as assert_warns
 
 import scipy.linalg
 from scipy.linalg import norm, inv
-from scipy.sparse import (issparse, SparseEfficiencyWarning,
-                          csc_array, csr_array, coo_array, dia_array,
-                          dok_array, lil_array, bsr_array,
-                          eye_array, random_array, tril, triu, kron)
+from scipy.sparse import (dia_array, SparseEfficiencyWarning, csc_array,
+        csr_array, eye_array, issparse, dok_array, lil_array, bsr_array,
+        coo_array, random_array, kron)
 from scipy.sparse.linalg import SuperLU
 from scipy.sparse.linalg._dsolve import (spsolve, splu, spilu,
         _superlu, spsolve_triangular, factorized,
@@ -415,6 +414,40 @@ class TestLinsolve:
         A, b = setup_bug_8278()
         x = self.spsolve(A, b, use_umfpack=True)
         assert_array_almost_equal(A @ x, b)
+
+    @pytest.mark.parametrize("trans", ["N", "T", "H"])
+    @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
+    @pytest.mark.parametrize("is_sparse", [False, True], ids=["dense", "sparse"])
+    @pytest.mark.parametrize(
+        "use_umfpack", [False, True], ids=["no_umfpack", "with_umfpack"]
+    )
+    def test_solve_trans(self, trans, dtype, is_sparse, use_umfpack):
+        N = 10
+        A = random_array((N, N), density=0.6, dtype=dtype)
+        A.setdiag(A.diagonal() + N)  # make A well-conditioned
+        A = A.tocsc()
+
+        expect_x = np.arange(1, N + 1, dtype=dtype)
+
+        if is_sparse:
+            expect_x = coo_array(expect_x)
+
+        # Solve the system
+        if trans == "N":
+            b = A @ expect_x
+        elif trans == "T":
+            b = A.T @ expect_x
+        else:  # trans == "H"
+            b = A.conj().T @ expect_x
+
+        x = spsolve(A, b, trans=trans, use_umfpack=use_umfpack)
+
+        # Compare
+        atol = 1e-10
+        if is_sparse:
+            assert_allclose(x.toarray(), expect_x.toarray(), atol=atol)
+        else:
+            assert_allclose(x, expect_x, atol=atol)
 
 
 class TestSplu:

--- a/scipy/sparse/linalg/dsolve.py
+++ b/scipy/sparse/linalg/dsolve.py
@@ -6,7 +6,7 @@ from scipy._lib.deprecation import _sub_module_deprecation
 
 
 __all__ = [  # noqa: F822
-    'MatrixRankWarning', 'SuperLU', 'factorized',
+    'SuperLU', 'factorized',
     'spilu', 'splu', 'spsolve',
     'spsolve_triangular', 'use_solver', 'test'
 ]

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -160,6 +160,16 @@ class TestExpmActionSimple:
                     "CSC matrix format",
                     SparseEfficiencyWarning,
                 )
+                warnings.filterwarnings(
+                    "ignore",
+                    "spsolve requires A be CSC format",
+                    SparseEfficiencyWarning,
+                )
+                warnings.filterwarnings(
+                    "ignore",
+                    r"Input.*not in CSC format",
+                    SparseEfficiencyWarning,
+                )
                 expected = sp_expm(A).dot(B)
             assert_allclose(observed, expected)
             with estimated_warns():
@@ -210,6 +220,16 @@ class TestExpmActionInterval:
                         "ignore",
                         "spsolve is more efficient when sparse b is in"
                         " the CSC matrix format",
+                        SparseEfficiencyWarning,
+                    )
+                    warnings.filterwarnings(
+                        "ignore",
+                        "spsolve requires A be CSC format",
+                        SparseEfficiencyWarning,
+                    )
+                    warnings.filterwarnings(
+                        "ignore",
+                        r"Input.*not in CSC format",
                         SparseEfficiencyWarning,
                     )
                     for solution, t in zip(X, samples):

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -159,6 +159,16 @@ class TestExpmActionSimple:
                     "CSC matrix format",
                     SparseEfficiencyWarning,
                 )
+                warnings.filterwarnings(
+                    "ignore",
+                    "spsolve requires A be CSC format",
+                    SparseEfficiencyWarning,
+                )
+                warnings.filterwarnings(
+                    "ignore",
+                    r"Input.*not in CSC format",
+                    SparseEfficiencyWarning,
+                )
                 expected = sp_expm(A).dot(B)
             assert_allclose(observed, expected)
             with estimated_warns():
@@ -209,6 +219,16 @@ class TestExpmActionInterval:
                         "ignore",
                         "spsolve is more efficient when sparse b is in"
                         " the CSC matrix format",
+                        SparseEfficiencyWarning,
+                    )
+                    warnings.filterwarnings(
+                        "ignore",
+                        "spsolve requires A be CSC format",
+                        SparseEfficiencyWarning,
+                    )
+                    warnings.filterwarnings(
+                        "ignore",
+                        r"Input.*not in CSC format",
                         SparseEfficiencyWarning,
                     )
                     for solution, t in zip(X, samples):

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -242,7 +242,7 @@ def test_onenormest(B):
 
 @parametrize_square_sparrays
 def test_spsolve(B):
-    if B.__class__.__name__[:3] not in ('csc', 'csr'):
+    if B.__class__.__name__[:3] != 'csc':
         return
 
     npt.assert_allclose(

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1265,7 +1265,12 @@ class _TestCommon:
             )
             warnings.filterwarnings(
                 "ignore",
-                "spsolve requires A be CSC or CSR matrix format",
+                "spsolve requires A be CSC format",
+                SparseEfficiencyWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                r"Input.*not in CSC format",
                 SparseEfficiencyWarning,
             )
             sMexp = expm(sM).toarray()
@@ -1280,7 +1285,7 @@ class _TestCommon:
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    "spsolve requires A be CSC or CSR matrix format",
+                    "spsolve requires A be CSC format",
                     SparseEfficiencyWarning,
                 )
                 warnings.filterwarnings(
@@ -1292,6 +1297,11 @@ class _TestCommon:
                 warnings.filterwarnings(
                     "ignore",
                     "splu converted its input to CSC format",
+                    SparseEfficiencyWarning,
+                )
+                warnings.filterwarnings(
+                    "ignore",
+                    r"Input.*not in CSC format",
                     SparseEfficiencyWarning,
                 )
                 sM = self.spcreator(M, shape=(3,3), dtype=dtype)

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1330,7 +1330,12 @@ class _TestCommon:
             )
             warnings.filterwarnings(
                 "ignore",
-                "spsolve requires A be CSC or CSR matrix format",
+                "spsolve requires A be CSC format",
+                SparseEfficiencyWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                r"Input.*not in CSC format",
                 SparseEfficiencyWarning,
             )
             sMexp = expm(sM).toarray()
@@ -1345,7 +1350,7 @@ class _TestCommon:
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    "spsolve requires A be CSC or CSR matrix format",
+                    "spsolve requires A be CSC format",
                     SparseEfficiencyWarning,
                 )
                 warnings.filterwarnings(
@@ -1357,6 +1362,11 @@ class _TestCommon:
                 warnings.filterwarnings(
                     "ignore",
                     "splu converted its input to CSC format",
+                    SparseEfficiencyWarning,
+                )
+                warnings.filterwarnings(
+                    "ignore",
+                    r"Input.*not in CSC format",
                     SparseEfficiencyWarning,
                 )
                 sM = self.spcreator(M, shape=(3,3), dtype=dtype)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
This PR adds support for [scikit-sparse v0.5.0](https://github.com/scikit-sparse/scikit-sparse), namely, the `cholmod` and `umfpack` submodules. The `cholmod` module in scikit-sparse v0.4.16 has been largely rewritten to remove bugs and run more efficiently with a Cython interface. The scikit-sparse `umfpack` submodule is new as of v0.5.0, and replaces the [scikits-umfpack](https://github.com/scikit-umfpack/scikit-umfpack) project, which is largely dormant. See [this SciPy forum discussion](https://discuss.scientific-python.org/t/improve-interface-to-suitesparse-umfpack/2138) for more details.

The only external API change in SciPy is that the `sparse.linalg.use_solver` function has been removed along with the global variable `useUmfpack` used in `sparse.linalg._dsolve`. The `use_umfpack` kwarg alone controls the use of UMFPACK. This PR keeps the existing behavior of using the UMFPACK factorization/solver if scikit-sparse is installed, but silently defaulting to SuperLU factorization/solver otherwise.

Additional changes:
* `sparse.linalg.spsolve` raises `LinAlgError` for a singular matrix, regardless of the RHS input type (sparse vs. dense, 1D vs. 2D). Previously, a dense RHS would *not* raise, but return a vector of `np.nan`, whereas a sparse RHS would raise `RuntimeError` when `use_umfpack=False`.
* The `sparse.linalg.MatrixRankWarning` class has been removed.


#### Additional information
This PR will remain a draft until the scikit-sparse v0.5.0 changes are all merged into master. The development branch is available [on my fork](https://github.com/broesler/scikit-sparse).