### PR TITLE
BUG: interpolate: Fix h[m] -> h[n] typo in _deBoor_D derivative loop

### DIFF
--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -63,7 +63,7 @@ _deBoor_D(const double *t, double x, int k, int ell, int m, double *result) {
             xb = t[ind];
             xa = t[ind - j];
             if (xb == xa) {
-                h[m] = 0.0;
+                h[n] = 0.0;
                 continue;
             }
             w = j*hh[n - 1]/(xb - xa);


### PR DESCRIPTION
#### Reference issue
Addresses gh-23936 (comment https://github.com/scipy/scipy/pull/23936#discussion_r2559893084)

#### What does this implement/fix?
Fixes a 20-year-old typo in the `_deBoor_D` function that was causing uninitialized memory access. In the derivative recursion loop, the code was incorrectly using `h[m]` instead of `h[n]` when handling repeated knots (`xb == xa`).

This is the same bug that was fixed in CuPy (cupy/cupy#9486). The uninitialized memory access is typically masked in SciPy because `std::vector<double>` zero-initializes memory, but it triggers ASAN violations.

#### Additional information
This fix applies the suggestion from @ev-br to port Sebastian Berg's fix from CuPy to SciPy.