### PR TITLE
ENH: linalg/solve: move the tridiagonal solve slice iteration to C

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -208,7 +208,7 @@ def solve(a, b, lower=False, overwrite_a=False,
            [ 3. , -2.5],
            [ 5. , -4.5]])
     """
-    if assume_a in ['tridiagonal', 'banded']:
+    if assume_a in ['banded']:
         # TODO: handle these structures in this function
         return solve0(
             a, b, lower=lower, overwrite_a=overwrite_a, overwrite_b=overwrite_b,
@@ -220,6 +220,7 @@ def solve(a, b, lower=False, overwrite_a=False,
         None: -1,
         'general': 0, 'gen': 0,
         'diagonal': 11,
+        'tridiagonal': 31,
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101, 'positive definite': 101,

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -148,6 +148,26 @@ void BLAS_FUNC(zhecon)(char *uplo, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *l
 void BLAS_FUNC(chetrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 void BLAS_FUNC(zhetrs)(char *uplo, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *ipiv, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
 
+
+/* ?GTTRF */
+void BLAS_FUNC(sgttrf)(CBLAS_INT *n, float *dl, float *d, float *du, float *du2, CBLAS_INT *ipiv, CBLAS_INT *info);
+void BLAS_FUNC(dgttrf)(CBLAS_INT *n, double *dl, double *d, double *du, double *du2, CBLAS_INT *ipiv, CBLAS_INT *info);
+void BLAS_FUNC(cgttrf)(CBLAS_INT *n, npy_complex64 *dl, npy_complex64 *d, npy_complex64 *du, npy_complex64 *du2, CBLAS_INT *ipiv, CBLAS_INT *info);
+void BLAS_FUNC(zgttrf)(CBLAS_INT *n, npy_complex128 *dl, npy_complex128 *d, npy_complex128 *du, npy_complex128 *du2, CBLAS_INT *ipiv, CBLAS_INT *info);
+
+/* ?GTTRS */
+void BLAS_FUNC(sgttrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, float *dl, float *d, float *du, float *du2, CBLAS_INT *ipiv, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(dgttrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, double *dl, double *d, double *du, double *du2, CBLAS_INT *ipiv, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(cgttrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *dl, npy_complex64 *d, npy_complex64 *du, npy_complex64 *du2, CBLAS_INT *ipiv, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zgttrs)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *dl, npy_complex128 *d, npy_complex128 *du, npy_complex128 *du2, CBLAS_INT *ipiv, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+
+
+/* ?GTCON */
+void BLAS_FUNC(sgtcon)(char *norm, CBLAS_INT *n, float *dl, float *d, float *du, float *du2, CBLAS_INT *ipiv, float *anorm, float *rcond, float *work, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(dgtcon)(char *norm, CBLAS_INT *n, double *dl, double *d, double *du, double *du2, CBLAS_INT *ipiv, double *anorm, double *rcond, double *work, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(cgtcon)(char *norm, CBLAS_INT *n, npy_complex64 *dl, npy_complex64 *d, npy_complex64 *du, npy_complex64 *du2, CBLAS_INT *ipiv, float *anorm, float *rcond, npy_complex64 *work, CBLAS_INT *info);
+void BLAS_FUNC(zgtcon)(char *norm, CBLAS_INT *n, npy_complex128 *dl, npy_complex128 *d, npy_complex128 *du, npy_complex128 *du2, CBLAS_INT *ipiv, double *anorm, double *rcond, npy_complex128 *work, CBLAS_INT *info);
+
 } // extern "C"
 
 
@@ -425,12 +445,64 @@ GEN_HETRS(c, he, npy_complex64)
 GEN_HETRS(z, he, npy_complex128)
 
 
+#define GEN_GTTRF(PREFIX, TYPE) \
+inline void \
+gttrf(CBLAS_INT *n, TYPE *dl, TYPE *d, TYPE *du, TYPE *du2, CBLAS_INT *ipiv, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gttrf)(n, dl, d, du, du2, ipiv, info); \
+};
+
+GEN_GTTRF(s, float)
+GEN_GTTRF(d, double)
+GEN_GTTRF(c, npy_complex64)
+GEN_GTTRF(z, npy_complex128)
+
+
+#define GEN_GTTRS(PREFIX, TYPE) \
+inline void \
+gttrs(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *dl, TYPE *d, TYPE *du, TYPE *du2, CBLAS_INT *ipiv, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gttrs)(trans, n, nrhs, dl, d, du, du2, ipiv, b, ldb, info); \
+};
+
+GEN_GTTRS(s, float)
+GEN_GTTRS(d, double)
+GEN_GTTRS(c, npy_complex64)
+GEN_GTTRS(z, npy_complex128)
+
+
+#define GEN_GTCON(PREFIX, TYPE) \
+inline void \
+gtcon(char *norm, CBLAS_INT *n, TYPE *dl, TYPE *d, TYPE *du, TYPE *du2, CBLAS_INT *ipiv, TYPE *anorm, TYPE *rcond, TYPE *work, CBLAS_INT *iwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gtcon)(norm, n, dl, d, du, du2, ipiv, anorm, rcond, work, iwork, info); \
+};
+
+GEN_GTCON(s, float)
+GEN_GTCON(d, double)
+
+
+// NB: `iwork` is not used for c- and z- variants of ?gtcon
+#define GEN_GTCON_CZ(PREFIX, TYPE, RTYPE) \
+inline void \
+gtcon(char *norm, CBLAS_INT *n, TYPE *dl, TYPE *d, TYPE *du, TYPE *du2, CBLAS_INT *ipiv, RTYPE *anorm, RTYPE *rcond, TYPE *work, CBLAS_INT *iwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gtcon)(norm, n, dl, d, du, du2, ipiv, anorm, rcond, work, info); \
+};
+
+GEN_GTCON_CZ(c, npy_complex64, float)
+GEN_GTCON_CZ(z, npy_complex128, double)
+
+
+
+
 // Structure tags; python side maps assume_a strings to these values
 enum St : Py_ssize_t
 {
     NONE = -1,
     GENERAL = 0,
     DIAGONAL = 11,
+    TRIDIAGONAL = 31,
     UPPER_TRIANGULAR = 21,
     LOWER_TRIANGULAR = 22,
     POS_DEF = 101,
@@ -649,6 +721,34 @@ norm1_sym_herm(char uplo, T *A, T *work, const npy_intp n) {
 }
 
 
+template<typename T>
+typename type_traits<T>::real_type
+norm1_tridiag(T* dl, T *d, T *du, T *work, const npy_intp n) {
+    using real_type = typename type_traits<T>::real_type;
+    using value_type = typename type_traits<T>::value_type;
+
+    value_type *pd = reinterpret_cast<value_type *>(d);
+    value_type *pdu = reinterpret_cast<value_type *>(du);
+    value_type *pdl = reinterpret_cast<value_type *>(dl);
+    real_type *rwork = (real_type *)work;
+
+    npy_intp i;
+    for (i=0; i<n; i++) {
+        rwork[i] = std::abs(pd[i]);
+    }
+    for (i=0; i<n-1; i++) {
+        rwork[i] += std::abs(pdl[i]);
+    }
+    for (i=1; i<n-1; i++) {
+        rwork[i] += std::abs(pdu[i-1]);
+    }
+
+    real_type temp = 0.0;
+    for (i = 0; i < n; i++) { if (rwork[i] > temp) { temp = rwork[i]; } }
+    return temp;
+}
+
+
 /***************************
  ***  Structure detection
  ***************************/
@@ -787,6 +887,28 @@ fill_other_triangle_noconj(char uplo, T *data, npy_intp n) {
     }
 }
 
+
+/*
+ * Helper for converting an NxN matrix to tridiagonal form:
+ * extract the diagonals of `data` (a full NxN matrix) into du, d, dl
+ *
+ * the upper and lower subdiagonals, `dl` and `du`, are have length N-1
+ * the main diagonal, `d`, has length N
+ *
+ */
+template<typename T>
+inline void
+to_tridiag(const T *data, npy_intp N, T *du, T *d, T *dl) {
+    for (npy_intp i=0; i<N; i++) {
+        d[i] = data[i + i*N];
+    }
+    for (npy_intp i=0; i<N-1; i++) {
+        dl[i] = data[i*N + i + 1];
+    }
+    for (npy_intp i=0; i<N-1; i++) {
+        du[i] = data[(i+1)*N + i];
+    }
+}
 
 
 template<typename T>


### PR DESCRIPTION
Convert the slice iteration in the tridiagonal mode of `linalg.solve` to C. 

This PR follows up on https://github.com/scipy/scipy/pull/23547, https://github.com/scipy/scipy/pull/23357 and https://github.com/scipy/scipy/pull/23071, so that only "banded" mode uses f2py / `apply_over_batch`. 

The added benchmark shows up to ~20x speed-ups for deep batches of small matrices, the full benchmark log vs 1.16.3 is under the fold. 
cc https://github.com/scipy/scipy/issues/23141#issuecomment-3580668628 for a general note on benchmarking budget.

<details>

```
$ spin bench --compare v1.16.3 -t BatchedSolveBench
$ cd benchmarks
$ asv continuous --factor 1.05 --bench BatchedSolveBench 56e567e70ccad213d04ab04e7cfe7365562a71f1 938476cce304525d100eec1b31b732f46aa497fe
Couldn't load asv.plugins._mamba_helpers because
No module named 'libmambapy'
· Creating environments
· Discovering benchmarks.
·· Uninstalling from virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran
·· Installing 938476cc <solve_tridiag> into virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran..
· Running 2 total benchmarks (2 commits * 1 environments * 1 benchmarks)
[ 0.00%] · For scipy commit b9105ccc <v1.16.3^0> (round 1/2):
[ 0.00%] ·· Building for virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran...............................................................................................................................................................................................................................................................................................................................
[ 0.00%] ·· Benchmarking virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran
[25.00%] ··· Running (linalg.BatchedSolveBench.time_solve--).
[25.00%] · For scipy commit 938476cc <solve_tridiag> (round 1/2):
[25.00%] ·· Building for virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran...
[25.00%] ·· Benchmarking virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran
[50.00%] ··· Running (linalg.BatchedSolveBench.time_solve--).
[50.00%] · For scipy commit 938476cc <solve_tridiag> (round 2/2):
[50.00%] ·· Benchmarking virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran
[75.00%] ··· linalg.BatchedSolveBench.time_solve                                                                                                                                       ok
[75.00%] ··· =============== ============= ============== ============== ==========
             --                                             module                 
             ----------------------------- ----------------------------------------
                  shape        structure    scipy/detect   scipy/assume    numpy   
             =============== ============= ============== ============== ==========
              (100, 10, 10)       gen        738±100μs       699±90μs     146±20μs 
              (100, 10, 10)       pos        670±100μs       646±90μs     165±30μs 
              (100, 10, 10)       sym         667±90μs      1.39±0.2ms    162±10μs 
              (100, 10, 10)     diagonal      85.0±8μs       75.9±9μs     161±20μs 
              (100, 10, 10)   tridiagonal     291±20μs       238±30μs     159±30μs 
              (100, 20, 20)       gen        1.80±0.2ms    1.68±0.08ms    451±10μs 
              (100, 20, 20)       pos         1.22±0ms     1.15±0.02ms    542±9μs  
              (100, 20, 20)       sym       1.42±0.06ms    2.70±0.03ms    480±20μs 
              (100, 20, 20)     diagonal      184±4μs        128±1μs      439±7μs  
              (100, 20, 20)   tridiagonal     425±7μs        369±7μs      413±10μs 
                (100, 100)        gen         212±10μs       217±6μs      91.9±2μs 
                (100, 100)        pos         195±20μs       186±20μs     98.6±8μs 
                (100, 100)        sym         352±10μs       274±10μs     96.3±2μs 
                (100, 100)      diagonal      65.7±1μs      52.9±0.7μs    96.0±7μs 
                (100, 100)    tridiagonal     84.0±8μs       69.4±4μs     92.7±4μs 
             =============== ============= ============== ============== ==========

[75.00%] · For scipy commit b9105ccc <v1.16.3^0> (round 2/2):
[75.00%] ·· Building for virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran...
[75.00%] ·· Benchmarking virtualenv-py3.12-Cython-meson-python-numpy-pybind11-pytest-pythran
[100.00%] ··· linalg.BatchedSolveBench.time_solve                                                                                                                                       ok
[100.00%] ··· =============== ============= ============== ============== ===========
              --                                              module                 
              ----------------------------- -----------------------------------------
                   shape        structure    scipy/detect   scipy/assume     numpy   
              =============== ============= ============== ============== ===========
               (100, 10, 10)       gen       5.73±0.05ms    3.17±0.04ms     129±2μs  
               (100, 10, 10)       pos        6.81±0.1ms     2.90±0.1ms     140±3μs  
               (100, 10, 10)       sym        6.64±0.6ms     3.91±0.2ms     131±5μs  
               (100, 10, 10)     diagonal    4.60±0.07ms    3.24±0.09ms     124±2μs  
               (100, 10, 10)   tridiagonal    6.48±0.1ms    5.12±0.06ms    122±0.1μs 
               (100, 20, 20)       gen       6.57±0.03ms    3.82±0.02ms     396±8μs  
               (100, 20, 20)       pos       7.83±0.04ms    3.30±0.02ms     476±3μs  
               (100, 20, 20)       sym        7.96±0.1ms    5.00±0.02ms    388±0.6μs 
               (100, 20, 20)     diagonal    4.30±0.02ms    3.11±0.04ms     403±20μs 
               (100, 20, 20)   tridiagonal   6.77±0.03ms     5.60±0.2ms     420±10μs 
                 (100, 100)        gen         238±1μs        215±10μs      105±20μs 
                 (100, 100)        pos         299±10μs       169±20μs      107±3μs  
                 (100, 100)        sym         309±10μs       270±7μs       99.0±3μs 
                 (100, 100)      diagonal     59.3±0.6μs      39.5±2μs      103±3μs  
                 (100, 100)    tridiagonal     103±1μs        75.7±1μs      95.1±1μs 
              =============== ============= ============== ============== ===========

| Change   | Before [b9105ccc] <v1.16.3^0>   | After [938476cc] <solve_tridiag>   |   Ratio | Benchmark (Parameter)                                                             |
|----------|---------------------------------|------------------------------------|---------|-----------------------------------------------------------------------------------|
| +        | 39.5±2μs                        | 52.9±0.7μs                         |    1.34 | linalg.BatchedSolveBench.time_solve((100, 100), 'diagonal', 'scipy/assume')       |
| +        | 122±0.1μs                       | 159±30μs                           |    1.3  | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'tridiagonal', 'numpy')        |
| +        | 124±2μs                         | 161±20μs                           |    1.29 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'diagonal', 'numpy')           |
| +        | 131±5μs                         | 162±10μs                           |    1.24 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'sym', 'numpy')                |
| +        | 388±0.6μs                       | 480±20μs                           |    1.24 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'sym', 'numpy')                |
| +        | 309±10μs                        | 352±10μs                           |    1.14 | linalg.BatchedSolveBench.time_solve((100, 100), 'sym', 'scipy/detect')            |
| +        | 396±8μs                         | 451±10μs                           |    1.14 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'gen', 'numpy')                |
| +        | 476±3μs                         | 542±9μs                            |    1.14 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'pos', 'numpy')                |
| -        | 75.7±1μs                        | 69.4±4μs                           |    0.92 | linalg.BatchedSolveBench.time_solve((100, 100), 'tridiagonal', 'scipy/assume')    |
| -        | 238±1μs                         | 212±10μs                           |    0.89 | linalg.BatchedSolveBench.time_solve((100, 100), 'gen', 'scipy/detect')            |
| -        | 103±1μs                         | 84.0±8μs                           |    0.81 | linalg.BatchedSolveBench.time_solve((100, 100), 'tridiagonal', 'scipy/detect')    |
| -        | 299±10μs                        | 195±20μs                           |    0.65 | linalg.BatchedSolveBench.time_solve((100, 100), 'pos', 'scipy/detect')            |
| -        | 5.00±0.02ms                     | 2.70±0.03ms                        |    0.54 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'sym', 'scipy/assume')         |
| -        | 3.82±0.02ms                     | 1.68±0.08ms                        |    0.44 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'gen', 'scipy/assume')         |
| -        | 3.91±0.2ms                      | 1.39±0.2ms                         |    0.36 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'sym', 'scipy/assume')         |
| -        | 3.30±0.02ms                     | 1.15±0.02ms                        |    0.35 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'pos', 'scipy/assume')         |
| -        | 6.57±0.03ms                     | 1.80±0.2ms                         |    0.27 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'gen', 'scipy/detect')         |
| -        | 3.17±0.04ms                     | 699±90μs                           |    0.22 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'gen', 'scipy/assume')         |
| -        | 2.90±0.1ms                      | 646±90μs                           |    0.22 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'pos', 'scipy/assume')         |
| -        | 7.96±0.1ms                      | 1.42±0.06ms                        |    0.18 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'sym', 'scipy/detect')         |
| -        | 7.83±0.04ms                     | 1.22±0ms                           |    0.16 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'pos', 'scipy/detect')         |
| -        | 5.73±0.05ms                     | 738±100μs                          |    0.13 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'gen', 'scipy/detect')         |
| -        | 6.81±0.1ms                      | 670±100μs                          |    0.1  | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'pos', 'scipy/detect')         |
| -        | 6.64±0.6ms                      | 667±90μs                           |    0.1  | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'sym', 'scipy/detect')         |
| -        | 5.60±0.2ms                      | 369±7μs                            |    0.07 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'tridiagonal', 'scipy/assume') |
| -        | 6.77±0.03ms                     | 425±7μs                            |    0.06 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'tridiagonal', 'scipy/detect') |
| -        | 5.12±0.06ms                     | 238±30μs                           |    0.05 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'tridiagonal', 'scipy/assume') |
| -        | 6.48±0.1ms                      | 291±20μs                           |    0.04 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'tridiagonal', 'scipy/detect') |
| -        | 3.11±0.04ms                     | 128±1μs                            |    0.04 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'diagonal', 'scipy/assume')    |
| -        | 4.30±0.02ms                     | 184±4μs                            |    0.04 | linalg.BatchedSolveBench.time_solve((100, 20, 20), 'diagonal', 'scipy/detect')    |
| -        | 3.24±0.09ms                     | 75.9±9μs                           |    0.02 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'diagonal', 'scipy/assume')    |
| -        | 4.60±0.07ms                     | 85.0±8μs                           |    0.02 | linalg.BatchedSolveBench.time_solve((100, 10, 10), 'diagonal', 'scipy/detect')    |

```

</details> 