### PR TITLE
MAINT: version pins/prep for 1.17.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,18 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.15.0",
-    "Cython>=3.0.8",        # when updating version, also update check in meson.build
-    "pybind11>=2.13.2",     # when updating version, also update check in scipy/meson.build
-    "pythran>=0.14.0",
+    # The upper bound on meson-python is pre-emptive only; 0.18.0
+    # is working at the time of writing, and chance of breakage
+    # in 0.19/0.20 is low
+    "meson-python>=0.15.0,<0.21.0",
+    # We need at least Cython 3.1.0 for free-threaded CPython;
+    # for other CPython versions, the regular pre-emptive
+    # Cython version bounds policy applies
+    "Cython>=3.0.8,<3.3.0",
+    # The upper bound on pybind11 is pre-emptive only
+    "pybind11>=2.13.2,<3.1.0",
+    # The upper bound on pythran is pre-emptive only;
+    "pythran>=0.14.0,<0.19.0",
 
     # numpy requirement for wheel builds for distribution on PyPI - building
     # against 2.x yields wheels that are also compatible with numpy 1.x at
@@ -28,7 +36,8 @@ requires = [
     # Note that building against numpy 1.x works fine too - users and
     # redistributors can do this by installing the numpy version they like and
     # disabling build isolation.
-    "numpy>=2.0.0",
+    # NOTE: need numpy>=2.1.3 for free-threaded CPython support
+    "numpy>=2.0.0,<2.7",
 ]
 
 [project]
@@ -46,7 +55,9 @@ maintainers = [
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
 requires-python = ">=3.11"  # keep in sync with `min_python_version` in meson.build
 dependencies = [
-    "numpy>=1.26.4",
+    # free-threaded CPython support requires more
+    # recent NumPy release at runtime (>= 2.1.3)
+    "numpy>=1.26.4,<2.7",
 ] # keep in sync with `min_numpy_version` in meson.build
 readme = "README.rst"
 classifiers = [

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -64,7 +64,7 @@ del _distributor_init
 from scipy._lib import _pep440
 # In maintenance branch, change to np_maxversion N+3 if numpy is at N
 np_minversion = '1.26.4'
-np_maxversion = '9.9.99'
+np_maxversion = '2.7.0'
 if (_pep440.parse(__numpy_version__) < _pep440.Version(np_minversion) or
         _pep440.parse(__numpy_version__) >= _pep440.Version(np_maxversion)):
     import warnings


### PR DESCRIPTION
* Adjust the build and runtime dependency version upper bounds (on maintenance branch) as we prepare for the release of SciPy `1.17.0rc1`.

* Many of the decisions are based on the previous PR for the last release cycle that aimed to do the same: gh-23013.

[skip circle]
