### PR TITLE
ENH: linalg.solve: implement banded solver in cpp

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -111,7 +111,7 @@ class Bench(Benchmark):
 class BatchedSolveBench(Benchmark):
     params = [
         [(100, 10, 10), (100, 20, 20), (100, 100)],
-        ["gen", "pos", "sym", "diagonal", "tridiagonal"],
+        ["gen", "pos", "sym", "diagonal", "tridiagonal", "banded"],
         ["scipy/detect", "scipy/assume", "numpy"]
     ]
     param_names = ["shape", "structure" ,"module"]
@@ -138,6 +138,9 @@ class BatchedSolveBench(Benchmark):
                 self.a[..., i+1, i] = a[..., i+1, i]
             for i in range(shape[-1]-1):
                 self.a[..., i, i+1] = a[..., i, i+1]
+        elif structure == "banded":
+            self.a = np.zeros_like(a)
+            self.a += np.triu(np.tril(a, k=5), k=-5)
         else:
             self.a = a
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -9,8 +9,8 @@ from itertools import product
 import numpy as np
 from scipy._lib._util import _apply_over_batch
 from .lapack import (
-    get_lapack_funcs, _compute_lwork,
-    _normalize_lapack_dtype, _ensure_aligned_and_native, _ensure_dtype_cdsz,
+    get_lapack_funcs, _normalize_lapack_dtype,
+    _ensure_aligned_and_native, _ensure_dtype_cdsz,
 )
 from ._misc import LinAlgError, _datacopied, LinAlgWarning
 from ._decomp import _asarray_validated

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -8,7 +8,6 @@ import warnings
 from warnings import warn
 from itertools import product
 import numpy as np
-from numpy import atleast_1d, atleast_2d
 from scipy._lib._util import _apply_over_batch
 from .lapack import (
     get_lapack_funcs, _compute_lwork,
@@ -211,19 +210,13 @@ def solve(a, b, lower=False, overwrite_a=False,
            [ 3. , -2.5],
            [ 5. , -4.5]])
     """
-    if assume_a in ['banded']:
-        # TODO: handle these structures in this function
-        return solve0(
-            a, b, lower=lower, overwrite_a=overwrite_a, overwrite_b=overwrite_b,
-            check_finite=check_finite, assume_a=assume_a, transposed=transposed
-        )
-
     # keep the numbers in sync with C
     structure = {
         None: -1,
         'general': 0, 'gen': 0,
         'diagonal': 11,
         'tridiagonal': 31,
+        'banded': 41,
         'upper triangular': 21,
         'lower triangular': 22,
         'pos' : 101, 'positive definite': 101,
@@ -251,6 +244,17 @@ def solve(a, b, lower=False, overwrite_a=False,
                                   'not solve a^T x = b or a^H x = b '
                                   'for complex matrices.')
 
+<<<<<<< HEAD
+=======
+    if not (a1.flags['ALIGNED'] or a1.dtype.byteorder == '='):
+        overwrite_a = True
+        a1 = a1.copy()
+
+    if not (b1.flags['ALIGNED'] or b1.dtype.byteorder == '='):
+        overwrite_b = True
+        b1 = b1.copy()
+
+>>>>>>> fcb27b461b (Implemented banded solver in cpp)
     # align the shape of b with a: 1. make b1 at least 2D
     b_is_1D = b1.ndim == 1
     if b_is_1D:
@@ -288,282 +292,6 @@ def solve(a, b, lower=False, overwrite_a=False,
 
     if b_is_1D:
         x = x[..., 0]
-    return x
-
-
-@_apply_over_batch(('a', 2), ('b', '1|2'))
-def solve0(a, b, lower=False, overwrite_a=False,
-          overwrite_b=False, check_finite=True, assume_a=None,
-          transposed=False):
-    """
-    Solve the equation ``a @ x = b`` for  ``x``,
-    where `a` is a square matrix.
-
-    If the data matrix is known to be a particular type then supplying the
-    corresponding string to ``assume_a`` key chooses the dedicated solver.
-    The available options are
-
-    =============================  ================================
-     diagonal                       'diagonal'
-     tridiagonal                    'tridiagonal'
-     banded                         'banded'
-     upper triangular               'upper triangular'
-     lower triangular               'lower triangular'
-     symmetric                      'symmetric' (or 'sym')
-     hermitian                      'hermitian' (or 'her')
-     symmetric positive definite    'positive definite' (or 'pos')
-     general                        'general' (or 'gen')
-    =============================  ================================
-
-    Parameters
-    ----------
-    a : (N, N) array_like
-        Square input data
-    b : (N, NRHS) array_like
-        Input data for the right hand side.
-    lower : bool, default: False
-        Ignored unless ``assume_a`` is one of ``'sym'``, ``'her'``, or ``'pos'``.
-        If True, the calculation uses only the data in the lower triangle of `a`;
-        entries above the diagonal are ignored. If False (default), the
-        calculation uses only the data in the upper triangle of `a`; entries
-        below the diagonal are ignored.
-    overwrite_a : bool, default: False
-        Allow overwriting data in `a` (may enhance performance).
-    overwrite_b : bool, default: False
-        Allow overwriting data in `b` (may enhance performance).
-    check_finite : bool, default: True
-        Whether to check that the input matrices contain only finite numbers.
-        Disabling may give a performance gain, but may result in problems
-        (crashes, non-termination) if the inputs do contain infinities or NaNs.
-    assume_a : str, optional
-        Valid entries are described above.
-        If omitted or ``None``, checks are performed to identify structure so the
-        appropriate solver can be called.
-    transposed : bool, default: False
-        If True, solve ``a.T @ x == b``. Raises `NotImplementedError`
-        for complex `a`.
-
-    Returns
-    -------
-    x : (N, NRHS) ndarray
-        The solution array.
-
-    Raises
-    ------
-    ValueError
-        If size mismatches detected or input a is not square.
-    LinAlgError
-        If the computation fails because of matrix singularity.
-    LinAlgWarning
-        If an ill-conditioned input a is detected.
-    NotImplementedError
-        If transposed is True and input a is a complex matrix.
-
-    Notes
-    -----
-    If the input b matrix is a 1-D array with N elements, when supplied
-    together with an NxN input a, it is assumed as a valid column vector
-    despite the apparent size mismatch. This is compatible with the
-    numpy.dot() behavior and the returned result is still 1-D array.
-
-    The general, symmetric, Hermitian and positive definite solutions are
-    obtained via calling ?GESV, ?SYSV, ?HESV, and ?POSV routines of
-    LAPACK respectively.
-
-    The datatype of the arrays define which solver is called regardless
-    of the values. In other words, even when the complex array entries have
-    precisely zero imaginary parts, the complex solver will be called based
-    on the data type of the array.
-
-    Examples
-    --------
-    Given `a` and `b`, solve for `x`:
-
-    >>> import numpy as np
-    >>> a = np.array([[3, 2, 0], [1, -1, 0], [0, 5, 1]])
-    >>> b = np.array([2, 4, -1])
-    >>> from scipy import linalg
-    >>> x = linalg.solve(a, b)
-    >>> x
-    array([ 2., -2.,  9.])
-    >>> np.dot(a, x) == b
-    array([ True,  True,  True], dtype=bool)
-
-    """
-    # Flags for 1-D or N-D right-hand side
-    b_is_1D = False
-
-    # check finite after determining structure
-    a1 = atleast_2d(_asarray_validated(a, check_finite=False))
-    b1 = atleast_1d(_asarray_validated(b, check_finite=False))
-    a1, b1 = _ensure_dtype_cdsz(a1, b1)
-    n = a1.shape[0]
-
-    overwrite_a = overwrite_a or _datacopied(a1, a)
-    overwrite_b = overwrite_b or _datacopied(b1, b)
-
-    if a1.shape[0] != a1.shape[1]:
-        raise ValueError('Input a needs to be a square matrix.')
-
-    if n != b1.shape[0]:
-        # Last chance to catch 1x1 scalar a and 1-D b arrays
-        if not (n == 1 and b1.size != 0):
-            raise ValueError('Input b has to have same number of rows as '
-                             'input a')
-
-    # accommodate empty arrays
-    if b1.size == 0:
-        dt = solve(np.eye(2, dtype=a1.dtype), np.ones(2, dtype=b1.dtype)).dtype
-        return np.empty_like(b1, dtype=dt)
-
-    # regularize 1-D b arrays to 2D
-    if b1.ndim == 1:
-        if n == 1:
-            b1 = b1[None, :]
-        else:
-            b1 = b1[:, None]
-        b_is_1D = True
-
-    if assume_a not in {None, 'diagonal', 'tridiagonal', 'banded', 'lower triangular',
-                        'upper triangular', 'symmetric', 'hermitian',
-                        'positive definite', 'general', 'sym', 'her', 'pos', 'gen'}:
-        raise ValueError(f'{assume_a} is not a recognized matrix structure')
-
-    # for a real matrix, describe it as "symmetric", not "hermitian"
-    # (lapack doesn't know what to do with real hermitian matrices)
-    if assume_a in {'hermitian', 'her'} and not np.iscomplexobj(a1):
-        assume_a = 'symmetric'
-
-    n_below, n_above = None, None
-    if assume_a is None:
-        assume_a, n_below, n_above = _find_matrix_structure(a1)
-
-    # Get the correct lamch function.
-    # The LAMCH functions only exists for S and D
-    # So for complex values we have to convert to real/double.
-    if a1.dtype.char in 'fF':  # single precision
-        lamch = get_lapack_funcs('lamch', dtype='f')
-    else:
-        lamch = get_lapack_funcs('lamch', dtype='d')
-
-
-    # Since the I-norm and 1-norm are the same for symmetric matrices
-    # we can collect them all in this one call
-    # Note however, that when issuing 'gen' and form!='none', then
-    # the I-norm should be used
-    if transposed:
-        trans = 1
-        norm = 'I'
-        if np.iscomplexobj(a1):
-            raise NotImplementedError('scipy.linalg.solve can currently '
-                                      'not solve a^T x = b or a^H x = b '
-                                      'for complex matrices.')
-    else:
-        trans = 0
-        norm = '1'
-
-    # Currently we do not have the other forms of the norm calculators
-    #   lansy, lanpo, lanhe.
-    # However, in any case they only reduce computations slightly...
-    if assume_a == 'diagonal':
-        anorm = _matrix_norm_diagonal(a1, check_finite)
-    elif assume_a == 'tridiagonal':
-        anorm = _matrix_norm_tridiagonal(norm, a1, check_finite)
-    elif assume_a == 'banded':
-        n_below, n_above = bandwidth(a1) if n_below is None else (n_below, n_above)
-        a2, n_below, n_above = ((a1.T, n_above, n_below) if transposed
-                                else (a1, n_below, n_above))
-        ab = _to_banded(n_below, n_above, a2)
-        anorm = _matrix_norm_banded(n_below, n_above, norm, ab, check_finite)
-    elif assume_a in {'lower triangular', 'upper triangular'}:
-        anorm = _matrix_norm_triangular(assume_a, norm, a1, check_finite)
-    else:
-        anorm = _matrix_norm_general(norm, a1, check_finite)
-
-    info, rcond = 0, np.inf
-
-    # Generalized case 'gesv'
-    if assume_a in {'general', 'gen'}:
-        gecon, getrf, getrs = get_lapack_funcs(('gecon', 'getrf', 'getrs'),
-                                               (a1, b1))
-        lu, ipvt, info = getrf(a1, overwrite_a=overwrite_a)
-        _solve_check(n, info)
-        x, info = getrs(lu, ipvt, b1,
-                        trans=trans, overwrite_b=overwrite_b)
-        _solve_check(n, info)
-        rcond, info = gecon(lu, anorm, norm=norm)
-    # Hermitian case 'hesv'
-    elif assume_a in {'hermitian', 'her'}:
-        hecon, hesv, hesv_lw = get_lapack_funcs(('hecon', 'hesv',
-                                                 'hesv_lwork'), (a1, b1))
-        lwork = _compute_lwork(hesv_lw, n, lower)
-        lu, ipvt, x, info = hesv(a1, b1, lwork=lwork,
-                                 lower=lower,
-                                 overwrite_a=overwrite_a,
-                                 overwrite_b=overwrite_b)
-        _solve_check(n, info)
-        rcond, info = hecon(lu, ipvt, anorm, lower=lower)
-    # Symmetric case 'sysv'
-    elif assume_a in {'symmetric', 'sym'}:
-        sycon, sysv, sysv_lw = get_lapack_funcs(('sycon', 'sysv',
-                                                 'sysv_lwork'), (a1, b1))
-        lwork = _compute_lwork(sysv_lw, n, lower)
-        lu, ipvt, x, info = sysv(a1, b1, lwork=lwork,
-                                 lower=lower,
-                                 overwrite_a=overwrite_a,
-                                 overwrite_b=overwrite_b)
-        _solve_check(n, info)
-        rcond, info = sycon(lu, ipvt, anorm, lower=lower)
-    # Diagonal case
-    elif assume_a == 'diagonal':
-        diag_a = np.diag(a1)
-        x = (b1.T / diag_a).T
-        abs_diag_a = np.abs(diag_a)
-        diag_min = abs_diag_a.min()
-        rcond = diag_min if diag_min == 0 else diag_min / abs_diag_a.max()
-    # Tri-diagonal case
-    elif assume_a == 'tridiagonal':
-        a1 = a1.T if transposed else a1
-        dl, d, du = np.diag(a1, -1), np.diag(a1, 0), np.diag(a1, 1)
-        _gttrf, _gttrs, _gtcon = get_lapack_funcs(('gttrf', 'gttrs', 'gtcon'), (a1, b1))
-        dl, d, du, du2, ipiv, info = _gttrf(dl, d, du)
-        _solve_check(n, info)
-        x, info = _gttrs(dl, d, du, du2, ipiv, b1, overwrite_b=overwrite_b)
-        _solve_check(n, info)
-        rcond, info = _gtcon(dl, d, du, du2, ipiv, anorm)
-    # Banded case
-    elif assume_a == 'banded':
-        gbsv, gbcon = get_lapack_funcs(('gbsv', 'gbcon'), (a1, b1))
-        # Next two lines copied from `solve_banded`
-        a2 = np.zeros((2*n_below + n_above + 1, ab.shape[1]), dtype=gbsv.dtype)
-        a2[n_below:, :] = ab
-        lu, piv, x, info = gbsv(n_below, n_above, a2, b1,
-                                overwrite_ab=True, overwrite_b=overwrite_b)
-        _solve_check(n, info)
-        rcond, info = gbcon(n_below, n_above, lu, piv, anorm)
-    # Triangular case
-    elif assume_a in {'lower triangular', 'upper triangular'}:
-        lower = assume_a == 'lower triangular'
-        x, info = _solve_triangular(a1, b1, lower=lower, overwrite_b=overwrite_b,
-                                    trans=transposed)
-        _solve_check(n, info)
-        _trcon = get_lapack_funcs(('trcon'), (a1, b1))
-        rcond, info = _trcon(a1, uplo='L' if lower else 'U')
-    # Positive definite case 'posv'
-    else:
-        pocon, posv = get_lapack_funcs(('pocon', 'posv'),
-                                       (a1, b1))
-        lu, x, info = posv(a1, b1, lower=lower,
-                           overwrite_a=overwrite_a,
-                           overwrite_b=overwrite_b)
-        _solve_check(n, info)
-        rcond, info = pocon(lu, anorm)
-
-    _solve_check(n, info, lamch, rcond)
-
-    if b_is_1D:
-        x = x.ravel()
-
     return x
 
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -10,7 +10,7 @@
 static PyObject* _linalg_inv_error;
 
 
-PyObject* 
+PyObject*
 convert_vec_status(SliceStatusVec& vec_status);
 
 std::string
@@ -110,11 +110,12 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
     SliceStatusVec vec_status;
     St structure = St::NONE;
     int overwrite_a = 0;
+    int overwrite_b = 0;
     int transposed = 0;
     int lower=0;
 
     // Get the input array
-    if (!PyArg_ParseTuple(args, "O!O!|nppp", &PyArray_Type, (PyObject **)&ap_Am, &PyArray_Type, (PyObject **)&ap_b, &structure, &lower, &transposed, &overwrite_a)) {
+    if (!PyArg_ParseTuple(args, "O!O!|npppp", &PyArray_Type, (PyObject **)&ap_Am, &PyArray_Type, (PyObject **)&ap_b, &structure, &lower, &transposed, &overwrite_a, &overwrite_b)) {
         return NULL;
     }
 
@@ -137,7 +138,7 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-    // At the python call site, 
+    // At the python call site,
     // 1) 1D `b` must have been converted in to 2D, and
     // 2) batch dimensions of `a` and `b` have been broadcast
     // Therefore, if `a.shape == (s, p, r, n, n)`, then `b.shape == (s, p, r, n, k)`
@@ -599,7 +600,7 @@ fail:
 /*
  * Helper: convert a vector of slice error statuses to list of dicts
  */
-PyObject* 
+PyObject*
 convert_vec_status(SliceStatusVec& vec_status) {
     PyObject *ret_dct = NULL;
     PyObject *ret_lst = PyList_New(0);

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -4,6 +4,7 @@
 #ifndef _SCIPY_COMMON_ARRAY_UTILS_H
 #define _SCIPY_COMMON_ARRAY_UTILS_H
 #include "Python.h"
+#include <cfloat>
 #include <tuple>
 #include "numpy/npy_math.h"
 #include "npy_cblas.h"
@@ -167,6 +168,24 @@ void BLAS_FUNC(sgtcon)(char *norm, CBLAS_INT *n, float *dl, float *d, float *du,
 void BLAS_FUNC(dgtcon)(char *norm, CBLAS_INT *n, double *dl, double *d, double *du, double *du2, CBLAS_INT *ipiv, double *anorm, double *rcond, double *work, CBLAS_INT *iwork, CBLAS_INT *info);
 void BLAS_FUNC(cgtcon)(char *norm, CBLAS_INT *n, npy_complex64 *dl, npy_complex64 *d, npy_complex64 *du, npy_complex64 *du2, CBLAS_INT *ipiv, float *anorm, float *rcond, npy_complex64 *work, CBLAS_INT *info);
 void BLAS_FUNC(zgtcon)(char *norm, CBLAS_INT *n, npy_complex128 *dl, npy_complex128 *d, npy_complex128 *du, npy_complex128 *du2, CBLAS_INT *ipiv, double *anorm, double *rcond, npy_complex128 *work, CBLAS_INT *info);
+
+/* ?GBTRF */
+void BLAS_FUNC(sgbtrf)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, float *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, CBLAS_INT *info);
+void BLAS_FUNC(dgbtrf)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, double *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, CBLAS_INT *info);
+void BLAS_FUNC(cgbtrf)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, npy_complex64 *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, CBLAS_INT *info);
+void BLAS_FUNC(zgbtrf)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, npy_complex128 *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, CBLAS_INT *info);
+
+/* ?GBTRS */
+void BLAS_FUNC(sgbtrs)(char *trans, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, CBLAS_INT *nrhs, float *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, float *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(dgbtrs)(char *trans, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, CBLAS_INT *nrhs, double *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(cgbtrs)(char *trans, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, CBLAS_INT *nrhs, npy_complex64 *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+void BLAS_FUNC(zgbtrs)(char *trans, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, CBLAS_INT *nrhs, npy_complex128 *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *info);
+
+/* ?GBCON */
+void BLAS_FUNC(sgbcon)(char *norm, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, float *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, float *anorm, float *rcond, float *work, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(dgbcon)(char *norm, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, double *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, double *anorm, double *rcond, double *work, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(cgbcon)(char *norm, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, npy_complex64 *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, float *anorm, float *rcond, npy_complex64 *work, float *rwork, CBLAS_INT *info);
+void BLAS_FUNC(zgbcon)(char *norm, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, npy_complex128 *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, double *anorm, double *rcond, npy_complex128 *work, double *rwork, CBLAS_INT *info);
 
 
 /* ?GESVD*/
@@ -570,6 +589,54 @@ GEN_GTCON_CZ(c, npy_complex64, float)
 GEN_GTCON_CZ(z, npy_complex128, double)
 
 
+#define GEN_GBTRF(PREFIX, TYPE) \
+inline void \
+gbtrf(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, TYPE *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gbtrf)(m, n, kl, ku, ab, ldab, ipiv, info); \
+};
+
+GEN_GBTRF(s, float)
+GEN_GBTRF(d, double)
+GEN_GBTRF(c, npy_complex64)
+GEN_GBTRF(z, npy_complex128)
+
+
+#define GEN_GBTRS(PREFIX, TYPE) \
+inline void \
+gbtrs(char *trans, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, CBLAS_INT *nrhs, TYPE *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gbtrs)(trans, n, kl, ku, nrhs, ab, ldab, ipiv, b, ldb, info); \
+};
+
+GEN_GBTRS(s, float)
+GEN_GBTRS(d, double)
+GEN_GBTRS(c, npy_complex64)
+GEN_GBTRS(z, npy_complex128)
+
+
+#define GEN_GBCON(PREFIX, TYPE) \
+inline void \
+gbcon(char *norm, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, TYPE *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, TYPE *anorm, TYPE *rcond, TYPE *work, void *irwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gbcon)(norm, n, kl, ku, ab, ldab, ipiv, anorm, rcond, work, (CBLAS_INT *)irwork, info); \
+};
+
+GEN_GBCON(s, float)
+GEN_GBCON(d, double)
+
+
+// c- and z- variants need rwork instead of iwork
+#define GEN_GBCON_CZ(PREFIX, TYPE, RTYPE) \
+inline void \
+gbcon(char *norm, CBLAS_INT *n, CBLAS_INT *kl, CBLAS_INT *ku, TYPE *ab, CBLAS_INT *ldab, CBLAS_INT *ipiv, RTYPE *anorm, RTYPE *rcond, TYPE *work, void *irwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gbcon)(norm, n, kl, ku, ab, ldab, ipiv, anorm, rcond, work, (RTYPE *)irwork, info); \
+};
+
+GEN_GBCON_CZ(c, npy_complex64, float)
+GEN_GBCON_CZ(z, npy_complex128, double)
+
 
 /*
  * ?GESVD wrappers.
@@ -826,6 +893,7 @@ enum St : Py_ssize_t
     GENERAL = 0,
     DIAGONAL = 11,
     TRIDIAGONAL = 31,
+    BANDED = 41,
     UPPER_TRIANGULAR = 21,
     LOWER_TRIANGULAR = 22,
     POS_DEF = 101,
@@ -978,6 +1046,7 @@ void copy_slice_F(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp m
     }
 }
 
+
 /*
  * Copy n-by-m F-ordered `src` to C-ordered `dst`.
  *
@@ -997,9 +1066,6 @@ void copy_slice_F_to_C(T* dst, const T* src, const npy_intp n, const npy_intp m,
         }
     }
 }
-
-
-
 
 
 /*
@@ -1124,6 +1190,45 @@ norm1_tridiag(T* dl, T *d, T *du, T *work, const npy_intp n) {
     return temp;
 }
 
+/*
+ * Compute the 1 norm of a matrix `A`, but assume it is already in its banded
+ * form `ab` as constructed by `to_banded`. It is assumed that the size of `ab`
+ * is always such that its number of rows is `2 * kl + ku + 1`.
+ */
+template <typename T>
+typename type_traits<T>::real_type
+norm1_banded(T* ab, const npy_intp kl, const npy_intp ku, T* work, const npy_intp n) {
+    using real_type = typename type_traits<T>::real_type;
+    using value_type = typename type_traits<T>::value_type;
+
+    value_type *pab = reinterpret_cast<value_type *>(ab);
+    real_type *rwork = (real_type *)work;
+
+    npy_intp i, j;
+    npy_intp ldab = 2 * kl + ku + 1;
+
+    for (i = 0; i < n; i++) {
+        rwork[i] = std::abs(pab[i * ldab + kl + ku]);
+    }
+
+    for (i = 0; i < kl; i++) { // run over lower bands
+        for (j = 0; j < n - i - 1; j++) {
+            rwork[j] += std::abs(pab[j * ldab + kl + ku + i + 1]);
+        }
+    }
+
+
+    for (i = 0; i < ku; i++) { // run over upper bands
+        for (j = i + 1; j < n; j++) {
+            rwork[j] += std::abs(pab[j * ldab + kl + ku - i - 1]);
+        }
+    }
+
+    real_type temp = 0.0;
+    for (i = 0; i < n; i++) {if (rwork[i] > temp) {temp = rwork[i];} }
+    return temp;
+}
+
 
 /***************************
  ***  Structure detection
@@ -1159,6 +1264,25 @@ bandwidth(T* data, npy_intp n, npy_intp m, npy_intp* lower_band, npy_intp* upper
     *upper_band = ub;
 }
 
+template<typename T>
+void
+detect_bandwidths(T* data, npy_intp ndim, npy_intp outer_size, npy_intp *shape, npy_intp *strides, npy_intp *kl, npy_intp *ku, npy_intp *kl_max, npy_intp *ku_max) {
+    // Looping mechanism copied from `_solve`
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+        npy_intp offset = 0;
+        npy_intp temp_idx = idx;
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset += (temp_idx % shape[i]) * strides[i];
+            temp_idx /= shape[i];
+        }
+
+        T* slice_ptr = (T *)(data + offset/sizeof(T));
+
+        bandwidth(slice_ptr, shape[ndim-2], shape[ndim-1], &kl[idx], &ku[idx]);
+        if (kl[idx] > *kl_max) {*kl_max = kl[idx];}
+        if (ku[idx] > *ku_max) {*ku_max = ku[idx];}
+    }
+}
 
 template<typename T>
 std::tuple<bool, bool>
@@ -1283,6 +1407,39 @@ to_tridiag(const T *data, npy_intp N, T *du, T *d, T *dl) {
     }
 }
 
+/*
+ * Helper function for reshuffling a banded matrix into the appropriate
+ * structure for ?gbcon and ?gbtrf.
+ *
+ * It is assumed that `ab` provides at least `ldab` x `n` memory elements,
+ * where ldab = 2 * `kl` + `ku` + 1
+ *
+ * Reference: https://www.netlib.org/lapack/explore-html/df/dd6/group__gbtrf_ga682f53142f0398f83f5461c277d23ba2.html#ga682f53142f0398f83f5461c277d23ba2
+ */
+ template<typename T>
+ inline void
+ to_banded(const T *data, npy_intp n, npy_intp kl, npy_intp ku, npy_intp ldab, T *ab) {
+    npy_intp i, j;
+
+    // fill in the diagonal at row ldab - kl
+    for (i = 0; i < n; i++) {
+        ab[(i + 1) * ldab - kl - 1] = data[i * (n + 1)];
+    }
+
+    // lower bands
+    for (i = 0; i < kl; i++) {
+        for (j = 0; j < n - 1 - i; j++) {
+            ab[(j + 1) * ldab - kl + i] = data[j * (n + 1) + i + 1];
+        }
+    }
+
+    // upper bands
+    for (i = 0; i < ku; i++) {
+        for (j = i + 1; j < n; j++) {
+            ab[(j + 1) * ldab - kl - i - 2] = data[j * (n + 1) - i - 1];
+        }
+    }
+ }
 
 template<typename T>
 inline void
@@ -1313,7 +1470,3 @@ nan_matrix(T * data, npy_intp n) {
     }
 }
 #endif
-
-
-
-


### PR DESCRIPTION
#### Reference issue
This PR contributes to #23774 by moving the last structure for `solve` into the lower level implementation.

#### What does this implement/fix?
The `gbsv` - `gbcon` sequence previously performed in `solve0` is now also implemented directly in the lower-level implementation, meaning all necessary calls can be made directly from `solve` and the need for `solve0` is removed.

#### Additional information
There are still a few questions left unanswered about this implementation, cfr. https://github.com/scipy/scipy/issues/23774#issuecomment-3630774818

Of these questions, two have been answered already:
1. `np.atleast_2d()` is not a ready-made substitution for the sequence laid out as it appears to append dimensions in the front rather than the back as would be necessary.
2. The comment about the fact that structure detection is commonly left out has been addressed.
