### PR TITLE
DOC: release notes: fix two unintentionally combined highlight bullets in rel notes

### DIFF
--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -27,10 +27,10 @@ Highlights of this release
   array input and additional support for the array API standard. An overall
   summary of the latter is now available in a
   :ref:`set of tables <dev-arrayapi_coverage>`.
-- In `scipy.sparse`, ``coo_array`` now has full support for indexing across
-  dimensions without needing to convert between sparse formats. ARPACK
-  and PROPACK rewrites from Fortran77 to C now empower the use of external
-  pseudorandom number generators.
+- In scipy.sparse, ``coo_array`` now supports indexing. This includes integers,
+  slices, arrays, np.newaxis, Ellipsis, in 1D, 2D and the relatively new nD.
+- ARPACK and PROPACK rewrites from Fortran77 to C now empower the use of
+  external pseudorandom number generators.
 - In `scipy.spatial`, ``transform.Rotation`` and ``transform.RigidTransform``
   have been extended to support N-D arrays. ``geometric_slerp`` now has support
   for extrapolation.


### PR DESCRIPTION
I have a suggestion to split two highlights from the 1.17.0 rel notes that somehow got combined due to whitespace issues. It also repairs some wording about the sparse coo_array indexing that we discussed at yesterday's sparse array meeting.

@tylerjereddy I'm not sure if this should be a PR to main or to the maintenance branch. Let me know what is best for you. 
