### PR TITLE
BUG: integrate: fix no module named 'scipy.integrate._lsoda'

### DIFF
--- a/scipy/integrate/lsoda.py
+++ b/scipy/integrate/lsoda.py
@@ -11,5 +11,5 @@ def __dir__():
 
 def __getattr__(name):
     return _sub_module_deprecation(sub_package="integrate", module="lsoda",
-                                   private_modules=["_lsoda"], all=__all__,
+                                   private_modules=["_odepack"], all=__all__,
                                    attribute=name)


### PR DESCRIPTION
closes #24131 

A pretty easy fix just need to point at the new file

```
In [1]: import scipy
meson-python: building scipy: /home/up19056/.local/share/mamba/envs/scipy-dev/bin/ninja
[2/338] Generating subprojects/highs/src/HConfig.h with a custom command

In [2]: scipy.integrate.lsoda.lsoda
<ipython-input-2-f0126213b734>:1: DeprecationWarning: Please import `lsoda` from the `scipy.integrate` namespace; the `scipy.integrate.lsoda` namespace is deprecated and will be removed in SciPy 2.0.0.
  scipy.integrate.lsoda.lsoda
Out[2]: <function scipy.integrate._odepack.lsoda>
```