### PR TITLE
DOC: release notes: improve wording of sparse highlight 

### DIFF
--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -30,7 +30,7 @@ Highlights of this release
 - In `scipy.sparse`, ``coo_array`` now supports indexing. This includes integers,
   slices, arrays, np.newaxis, Ellipsis, in 1D, 2D and the relatively new nD.
   In `scipy.sparse.linalg`, ARPACK and PROPACK rewrites from Fortran77 to C now
-  empower the use of external pseudorandom number generators.
+  empower the use of external pseudorandom number generators, e.g. from numpy.
 - In `scipy.spatial`, ``transform.Rotation`` and ``transform.RigidTransform``
   have been extended to support N-D arrays. ``geometric_slerp`` now has support
   for extrapolation.

--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -27,10 +27,10 @@ Highlights of this release
   array input and additional support for the array API standard. An overall
   summary of the latter is now available in a
   :ref:`set of tables <dev-arrayapi_coverage>`.
-- In `scipy.sparse`, ``coo_array`` now has full support for indexing across
-  dimensions without needing to convert between sparse formats. ARPACK
-  and PROPACK rewrites from Fortran77 to C now empower the use of external
-  pseudorandom number generators.
+- In `scipy.sparse`, ``coo_array`` now supports indexing. This includes integers,
+  slices, arrays, np.newaxis, Ellipsis, in 1D, 2D and the relatively new nD.
+  In `scipy.sparse.linalg`, ARPACK and PROPACK rewrites from Fortran77 to C now
+  empower the use of external pseudorandom number generators.
 - In `scipy.spatial`, ``transform.Rotation`` and ``transform.RigidTransform``
   have been extended to support N-D arrays. ``geometric_slerp`` now has support
   for extrapolation.


### PR DESCRIPTION
This PR adds suggested improved wording for the sparse highlight about COO array indexing.
The sentence improvements come from the discussion at the sparse arrays meeting this week.
A few word transition to the ARPACK and PROPACK improvements seems helpful to me.
But feel free to change/correct anything with that.

Thanks!