### PR TITLE
API: ``linalg.inv``: keyword-only ``assume_a`` and ``lower`` params

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1337,7 +1337,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
 
 
 # matrix inversion
-def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
+def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     r"""
     Compute the inverse of a matrix.
 


### PR DESCRIPTION
The [1.17.0rc1 release notes](https://github.com/scipy/scipy/releases/tag/v1.17.0rc1) describe these newly added parameters as keyword-only, but the code does not reflect this. Changing this *after* the 1.17.0 final release will be a lot more difficult.