### PR TITLE
API: ``signal.savgol_coeffs``: keyword-only ``xp`` and ``device``

### DIFF
--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -9,7 +9,7 @@ from ._arraytools import axis_slice
 
 
 def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
-                  use="conv", xp=None, device=None):
+                  use="conv", *, xp=None, device=None):
     """Compute the coefficients for a 1-D Savitzky-Golay FIR filter.
 
     Parameters


### PR DESCRIPTION
Pretty much the story as #24139; Changing this after the 1.17.0 final release will be a lot more difficult, so better do it now. There's also the consistency argument (pun intended), seeing as all others functions that accept `xp` and `device` in `scipgy.signal` have them as keyword-only parameters.