### PR TITLE
TYP: generic ``signal.LinearTimeInvariant`` type

### DIFF
--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -20,6 +20,7 @@ time invariant systems.
 #   Merged discrete systems and added dlti
 
 import warnings
+from types import GenericAlias
 
 # np.linalg.qr fails on some tests with LinAlgError: zgeqrf returns -7
 # use scipy's qr until this is solved
@@ -44,6 +45,9 @@ __all__ = ['lti', 'dlti', 'TransferFunction', 'ZerosPolesGain', 'StateSpace',
 
 
 class LinearTimeInvariant:
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     def __new__(cls, *system, **kwargs):
         """Create a new object, don't allow direct instances."""
         if cls is LinearTimeInvariant:

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1,7 +1,8 @@
 import warnings
-
+from types import GenericAlias
 
 import numpy as np
+import pytest
 from pytest import raises as assert_raises
 from scipy._lib._array_api import(
     assert_almost_equal, xp_assert_equal, xp_assert_close, make_xp_test_case
@@ -1236,3 +1237,9 @@ class Test_freqresp:
         expected = 1 / (s + 1)**4
         assert_almost_equal(H.real, expected.real)
         assert_almost_equal(H.imag, expected.imag)
+
+@pytest.mark.parametrize(
+    "cls", [StateSpace, TransferFunction, ZerosPolesGain, lti, dlti]
+)
+def test_subscriptable_generic_types(cls):
+    assert isinstance(cls[np.float64], GenericAlias)


### PR DESCRIPTION
I seem to have forgotten this one in #23118, which we need for runtime typing compatibility with scipy-stubs: https://github.com/scipy/scipy-stubs/#scipysignal 

By inheritance, this also makes the subclasses of `LinearTimeInvariant` generic types, including the public API classes `StateSpace`, `TransferFunction`, `ZerosPolesGain`, `lti`, and `dlti`.

Any chance this can be snuck in before the 1.17.0 final release? 