### PR TITLE
MAINT/BLD: Don't undef `_BEGIN_EXTERN_C` and `_END_EXTERN_C`

### DIFF
--- a/scipy/special/ellint_carlson_wrap.hh
+++ b/scipy/special/ellint_carlson_wrap.hh
@@ -1,26 +1,15 @@
 #ifndef ELLINT_CARLSON_WRAP_HH_INCLUDED
 #define ELLINT_CARLSON_WRAP_HH_INCLUDED
 
-
-#undef _BEGIN_EXTERN_C
-#undef _END_EXTERN_C
-#ifdef __cplusplus
-#define _BEGIN_EXTERN_C	extern "C" {
-#define _END_EXTERN_C	}
-#else
-#define _BEGIN_EXTERN_C	/* nothing */
-#define _END_EXTERN_C	/* nothing */
-#endif
-
-_BEGIN_EXTERN_C
+extern "C" {
 #include <numpy/npy_math.h>
-_END_EXTERN_C
+}
 
 #define ELLINT_NO_VALIDATE_RELATIVE_ERROR_BOUND
 #include "ellint_carlson_cpp_lite/ellint_carlson.hh"
 
 
-_BEGIN_EXTERN_C
+extern "C" {
 
 
 extern double fellint_RC(double x, double y);
@@ -39,11 +28,7 @@ extern double fellint_RJ(double x, double y, double z, double p);
 extern npy_cdouble cellint_RJ(npy_cdouble x, npy_cdouble y, npy_cdouble z, npy_cdouble p);
 
 
-_END_EXTERN_C
-
-
-#undef _BEGIN_EXTERN_C
-#undef _END_EXTERN_C
+}
 
 
 #endif /* ELLINT_CARLSON_WRAP_HH_INCLUDED */


### PR DESCRIPTION
Some code in scipy redfined `_BEGIN_EXTERN_C` and `_END_EXTERN_C` for a header file and then #undefs them at the end of the header.

If system headers happens to provide these #defines then they are gone for any subsequent header #include'd in the compilation unit. This can then break those system headers as they will expect these symbols to exist.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
