### PR TITLE
BUG: ``sparse``: fix ``coo_matrix.__setitem__`` signature

### DIFF
--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -1877,5 +1877,5 @@ class coo_matrix(spmatrix, _coo_base):
     def __getitem__(self, key):
         raise TypeError("'coo_matrix' object is not subscriptable")
 
-    def __setitem__(self, key):
+    def __setitem__(self, key, x):
         raise TypeError("'coo_matrix' object does not support item assignment")


### PR DESCRIPTION
Even though it always raises (which is type-unsafe btw), I'm guessing that this invalid `__setitem__` signature was intentional, because the intended `TypeError` message isn't shown right now:

```
In [1]: scipy.sparse.coo_matrix([[]])[1] = 1
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], line 1
----> 1 scipy.sparse.coo_matrix([[]])[1] = 1

TypeError: coo_matrix.__setitem__() takes 2 positional arguments but 3 were given
```