### PR TITLE
DOC: sparse: clarify DIA data format and alignment

### DIFF
--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -614,11 +614,32 @@ class dia_matrix(spmatrix, _dia_base):
 
     Notes
     -----
-
     Sparse matrices can be used in arithmetic operations: they support
     addition, subtraction, multiplication, division, and matrix power.
-    Sparse matrices with DIAgonal storage do not support slicing.
 
+    **Format details**
+
+    The ``data`` array stores the diagonal elements. The alignment of these
+    elements within the rows of ``data`` depends on their position relative
+    to the main diagonal:
+
+    * **Main diagonal** (``offsets[i] == 0``): Elements start at column 0.
+    * **Super-diagonals** (``offsets[i] > 0``): Elements are right-aligned
+      (padded with zeros on the left).
+    * **Sub-diagonals** (``offsets[i] < 0``): Elements are left-aligned
+      (padded with zeros on the right).
+
+    Each column of ``data`` corresponds to a column in the resulting sparse
+    matrix.
+
+    Mathematically, the element at row `r` and column `c` of the matrix is
+    stored in the ``data`` array at row `i` and column
+    ``c - max(0, -offsets[i])``, where `i` is the index of the diagonal
+    in ``offsets``.
+
+    Note that if ``offsets`` is provided in decreasing order, this format
+    matches the BLAS/LAPACK general band format (e.g., as used in `dgbmv`).
+    
     Examples
     --------
 

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -629,8 +629,7 @@ class dia_matrix(spmatrix, _dia_base):
     * **Sub-diagonals** (``offsets[i] < 0``): Elements are left-aligned
       (padded with zeros on the right).
 
-    Each column of ``data`` corresponds to a column in the resulting sparse
-    matrix.
+    Each column of ``data`` corresponds to a diagonal in the resulting matrix.
 
     Mathematically, the element at row `r` and column `c` of the matrix is
     stored in the ``data`` array at row `i` and column

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -562,6 +562,28 @@ class dia_array(_dia_base, sparray):
     addition, subtraction, multiplication, division, and matrix power.
     Sparse arrays with DIAgonal storage do not support slicing.
 
+    **Format details**
+
+    The ``data`` array stores the diagonal elements. The alignment of these
+    elements within the rows of ``data`` depends on their position relative
+    to the main diagonal:
+
+    * **Main diagonal** (``offsets[i] == 0``): Elements start at column 0.
+    * **Super-diagonals** (``offsets[i] > 0``): Elements are right-aligned
+      (padded with zeros on the left).
+    * **Sub-diagonals** (``offsets[i] < 0``): Elements are left-aligned
+      (padded with zeros on the right).
+
+    Each column of ``data`` corresponds to a diagonal in the resulting matrix.
+
+    Mathematically, the element at row `r` and column `c` of the matrix is
+    stored in the ``data`` array at row `i` and column
+    ``c - max(0, -offsets[i])``, where `i` is the index of the diagonal
+    in ``offsets``.
+
+    Note that if ``offsets`` is provided in decreasing order, this format
+    matches the BLAS/LAPACK general band format (e.g., as used in `dgbmv`).
+
     Examples
     --------
 
@@ -651,6 +673,7 @@ class dia_matrix(spmatrix, _dia_base):
     -----
     Sparse matrices can be used in arithmetic operations: they support
     addition, subtraction, multiplication, division, and matrix power.
+    Sparse arrays with DIAgonal storage do not support slicing.
 
     **Format details**
 
@@ -673,7 +696,7 @@ class dia_matrix(spmatrix, _dia_base):
 
     Note that if ``offsets`` is provided in decreasing order, this format
     matches the BLAS/LAPACK general band format (e.g., as used in `dgbmv`).
-    
+
     Examples
     --------
 

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -576,13 +576,13 @@ class dia_array(_dia_base, sparray):
 
     Each column of ``data`` corresponds to a diagonal in the resulting matrix.
 
-    Mathematically, the element at row `r` and column `c` of the matrix is
-    stored in the ``data`` array at row `i` and column
-    ``c - max(0, -offsets[i])``, where `i` is the index of the diagonal
+    Mathematically, the element at row ``r`` and column ``c`` of the matrix is
+    stored in the ``data`` array at row ``i`` and column
+    ``c - max(0, -offsets[i])``, where ``i`` is the index of the diagonal
     in ``offsets``.
 
     Note that if ``offsets`` is provided in decreasing order, this format
-    matches the BLAS/LAPACK general band format (e.g., as used in `dgbmv`).
+    matches the BLAS/LAPACK general band format (e.g., as used in ``dgbmv``).
 
     Examples
     --------
@@ -689,13 +689,13 @@ class dia_matrix(spmatrix, _dia_base):
 
     Each column of ``data`` corresponds to a diagonal in the resulting matrix.
 
-    Mathematically, the element at row `r` and column `c` of the matrix is
-    stored in the ``data`` array at row `i` and column
-    ``c - max(0, -offsets[i])``, where `i` is the index of the diagonal
+    Mathematically, the element at row ``r`` and column ``c`` of the matrix is
+    stored in the ``data`` array at row ``i`` and column
+    ``c - max(0, -offsets[i])``, where ``i`` is the index of the diagonal
     in ``offsets``.
 
     Note that if ``offsets`` is provided in decreasing order, this format
-    matches the BLAS/LAPACK general band format (e.g., as used in `dgbmv`).
+    matches the BLAS/LAPACK general band format (e.g., as used in ``dgbmv``).
 
     Examples
     --------

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -649,11 +649,32 @@ class dia_matrix(spmatrix, _dia_base):
 
     Notes
     -----
-
     Sparse matrices can be used in arithmetic operations: they support
     addition, subtraction, multiplication, division, and matrix power.
-    Sparse matrices with DIAgonal storage do not support slicing.
 
+    **Format details**
+
+    The ``data`` array stores the diagonal elements. The alignment of these
+    elements within the rows of ``data`` depends on their position relative
+    to the main diagonal:
+
+    * **Main diagonal** (``offsets[i] == 0``): Elements start at column 0.
+    * **Super-diagonals** (``offsets[i] > 0``): Elements are right-aligned
+      (padded with zeros on the left).
+    * **Sub-diagonals** (``offsets[i] < 0``): Elements are left-aligned
+      (padded with zeros on the right).
+
+    Each column of ``data`` corresponds to a column in the resulting sparse
+    matrix.
+
+    Mathematically, the element at row `r` and column `c` of the matrix is
+    stored in the ``data`` array at row `i` and column
+    ``c - max(0, -offsets[i])``, where `i` is the index of the diagonal
+    in ``offsets``.
+
+    Note that if ``offsets`` is provided in decreasing order, this format
+    matches the BLAS/LAPACK general band format (e.g., as used in `dgbmv`).
+    
     Examples
     --------
 

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -664,8 +664,7 @@ class dia_matrix(spmatrix, _dia_base):
     * **Sub-diagonals** (``offsets[i] < 0``): Elements are left-aligned
       (padded with zeros on the right).
 
-    Each column of ``data`` corresponds to a column in the resulting sparse
-    matrix.
+    Each column of ``data`` corresponds to a diagonal in the resulting matrix.
 
     Mathematically, the element at row `r` and column `c` of the matrix is
     stored in the ``data`` array at row `i` and column


### PR DESCRIPTION
#### Reference issue
Closes #18871

#### What does this implement/fix?
This PR clarifies the documentation for `dia_matrix` and `dia_array` regarding diagonal alignment and column mapping.

It adds explicit details on:
- How the `offsets` array maps to the main diagonal (0), super-diagonals (>0), and sub-diagonals (<0).
- How the data array should be aligned corresponding to these offsets.

#### Additional information
Documentation update based on the suggestion in the issue.