### PR TITLE
MAINT: linalg: raise for zero-size batch

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -11,7 +11,7 @@ import os
 import sys
 import textwrap
 from types import ModuleType
-from typing import Literal, TypeAlias, TypeVar
+from typing import Literal, TypeVar
 
 import numpy as np
 from scipy._lib._array_api import (Array, array_namespace, is_lazy_array, is_numpy,
@@ -79,8 +79,8 @@ else:
     wrapped_inspect_signature = inspect.signature
 
 
-_RNG: TypeAlias = np.random.Generator | np.random.RandomState
-SeedType: TypeAlias = IntNumber | _RNG | None
+_RNG: type = np.random.Generator | np.random.RandomState
+SeedType: type = IntNumber | _RNG | None
 
 GeneratorType = TypeVar("GeneratorType", bound=_RNG)
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1111,6 +1111,7 @@ The documentation is written assuming array arguments are of specified
 "core" shapes. However, array argument(s) of this function may have additional
 "batch" dimensions prepended to the core shape. In this case, the array is treated
 as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+Note that calls with zero-size batches are unsupported and will raise a ``ValueError``.
 """
 
 
@@ -1181,6 +1182,13 @@ def _apply_over_batch(*argdefs):
 
             # Determine broadcasted batch shape
             batch_shape = np.broadcast_shapes(*batch_shapes)  # Gives OK error message
+
+            # We can't support zero-size batches right now because without data with
+            # which to call the function, the decorator doesn't even know the *number*
+            # of outputs, let alone their core shapes or dtypes.
+            if math.prod(batch_shape) == 0:
+                message = f'`{f.__name__}` does not support zero-size batches.'
+                raise ValueError(message)
 
             # Broadcast arrays to appropriate shape
             for i, (array, core_shape) in enumerate(zip(arrays, core_shapes)):

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -609,3 +609,12 @@ class TestBatch:
         message = "Batch support for sparse arrays is not available."
         with pytest.raises(NotImplementedError, match=message):
             linalg.clarkson_woodruff_transform(A, sketch_size=3, rng=rng)
+
+    @pytest.mark.parametrize('f, args', [
+        (linalg.toeplitz, (np.ones((0, 4)),)),
+        (linalg.eig, (np.ones((3, 0, 5, 5)),)),
+    ])
+    def test_zero_size_batch(self, f, args):
+        message = "does not support zero-size batches."
+        with pytest.raises(ValueError, match=message):
+            f(*args)


### PR DESCRIPTION
#### Reference issue
Addresses bug/docs part of gh-24148.

#### What does this implement/fix?
SciPy 1.16.0 introduced support for N-dimensional arrays to be processed as a batch. gh-24148 notes that the output of `toeplitz` (and other functions) is incorrect for batches of zero size. This is currently an undocumented limitation of the decorator, so this PR adds the appropriate documentation and error message.

#### Additional information 
Not sure what to do about the lint failure. That error must have been there already - is it just being caught now due to unrelated changes in the file?