### PR TITLE
ENH: sparse: implement `matrix_transpose` and `.mT`

### DIFF
--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -96,6 +96,7 @@ Combining arrays
    hstack - Stack sparse arrays horizontally (column wise)
    vstack - Stack sparse arrays vertically (row wise)
    swapaxes - swap two axes of a sparse array
+   matrix_transpose - Transpose a matrix (or a batch of matrices)
    expand_dims - add a new (trivial) axis to a sparse array
    permute_dims - reorder the axes of a sparse array
 

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -398,6 +398,16 @@ class _spbase(SparseABC):
     def T(self):
         """Transpose."""
         return self.transpose()
+    
+    @property
+    def mT(self):
+        """Matrix transpose.
+        
+        See Also
+        --------
+        sparse.matrix_transpose : equivalent function
+        """
+        return self.transpose()
 
     @property
     def real(self):

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -405,7 +405,7 @@ class _spbase(SparseABC):
         
         See Also
         --------
-        sparse.matrix_transpose : equivalent function
+        scipy.sparse.matrix_transpose : equivalent function
         """
         return self.transpose()
 

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -409,7 +409,7 @@ class _spbase(SparseABC):
         """
         if (n := self.ndim) < 2:
             raise ValueError(f"Array must be at least 2-dimensional, but it is {n}-D")
-        assert self.ndim == 2
+        assert n == 2
         return self.transpose()
 
     @property

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -407,6 +407,9 @@ class _spbase(SparseABC):
         --------
         scipy.sparse.matrix_transpose : equivalent function
         """
+        if (n := self.ndim) < 2:
+            raise ValueError(f"Array must be at least 2-dimensional, but it is {n}-D")
+        assert self.ndim == 2
         return self.transpose()
 
     @property

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -720,6 +720,8 @@ class bsr_array(_bsr_base, sparray):
         Number of values stored in the array
     T : bsr_array
         The transpose of the array
+    mT : bsr_array
+        The matrix transpose of the array
 
     Notes
     -----
@@ -837,6 +839,8 @@ class bsr_matrix(spmatrix, _bsr_base):
         Number of values stored in the matrix
     T : bsr_matrix
         The transpose of the matrix
+    mT : bsr_matrix
+        The matrix transpose
 
     Notes
     -----

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -207,16 +207,16 @@ def permute_dims(A, axes=None, copy=False):
 
 def matrix_transpose(A):
     """Return the matrix transpose of `A`.
-    
+
     Parameters
     ----------
     A : sparse array
-    
+
     Returns
     -------
     sparse array
         The matrix transpose of `A`
-        
+
     Notes
     -----
     This is equivalent to ``A.T`` for 2-D arrays, and interprets
@@ -238,16 +238,13 @@ def matrix_transpose(A):
     >>> array.T.toarray()
     array([[[1, 5],
             [3, 7]],
-    
            [[2, 6],
             [4, 8]]])
     >>> matrix_transpose(array).toarray()
     array([[[1, 3],
             [2, 4]],
-    
            [[5, 7],
             [6, 8]]])
-
     """
     return A.mT
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -6,7 +6,7 @@ __docformat__ = "restructuredtext en"
 __all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
            'hstack', 'vstack', 'bmat', 'rand', 'random', 'diags', 'block_diag',
            'diags_array', 'block_array', 'eye_array', 'random_array',
-           'expand_dims', 'permute_dims', 'swapaxes']
+           'expand_dims', 'permute_dims', 'swapaxes', 'matrix_transpose']
 
 import numbers
 import math
@@ -203,6 +203,52 @@ def permute_dims(A, axes=None, copy=False):
     A.coords = tuple(A.coords[idx] for idx in axes)
     A.has_canonical_format = False  # data usually no longer sorted
     return A
+
+
+def matrix_transpose(A):
+    """Return the matrix transpose of `A`.
+    
+    Parameters
+    ----------
+    A : sparse array
+    
+    Returns
+    -------
+    sparse array
+        The matrix transpose of `A`
+        
+    Notes
+    -----
+    This is equivalent to ``A.T`` for 2-D arrays, and interprets
+    greater dimensional `A` as a stack of 2-D arrays on which
+    to perform the transpose.
+
+    See Also
+    --------
+    coo_array.mT : equivalent attribute
+    coo_array.T : full transposition reversing all dimensions
+    numpy.matrix_transpose : equivalent function in NumPy
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.sparse import coo_array, matrix_transpose
+    >>> data = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+    >>> array = coo_array(data)
+    >>> array.T.toarray()
+    array([[[1, 5],
+            [3, 7]],
+    
+           [[2, 6],
+            [4, 8]]])
+    >>> matrix_transpose(array).toarray()
+    array([[[1, 3],
+            [2, 4]],
+    
+           [[5, 7],
+            [6, 8]]])  
+    """
+    return A.mT
 
 
 def spdiags(data, diags, m=None, n=None, format=None):

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -238,11 +238,13 @@ def matrix_transpose(A):
     >>> array.T.toarray()
     array([[[1, 5],
             [3, 7]],
+    <BLANKLINE>
            [[2, 6],
             [4, 8]]])
     >>> matrix_transpose(array).toarray()
     array([[[1, 3],
             [2, 4]],
+    <BLANKLINE>
            [[5, 7],
             [6, 8]]])
     """

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -211,23 +211,24 @@ def matrix_transpose(A):
     Parameters
     ----------
     A : sparse array
+        Input array.
 
     Returns
     -------
     sparse array
-        The matrix transpose of `A`
-
-    Notes
-    -----
-    This is equivalent to ``A.T`` for 2-D arrays, and interprets
-    greater dimensional `A` as a stack of 2-D arrays on which
-    to perform the transpose.
+        The matrix transpose of `A`.
 
     See Also
     --------
     coo_array.mT : equivalent attribute
     coo_array.T : full transposition reversing all dimensions
     numpy.matrix_transpose : equivalent function in NumPy
+
+    Notes
+    -----
+    This is equivalent to ``A.T`` for 2-D arrays, and interprets
+    greater dimensional `A` as a stack of 2-D arrays on which
+    to perform the transpose.
 
     Examples
     --------

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -246,7 +246,8 @@ def matrix_transpose(A):
             [2, 4]],
     
            [[5, 7],
-            [6, 8]]])  
+            [6, 8]]])
+
     """
     return A.mT
 

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -244,6 +244,13 @@ class _coo_base(_data_matrix, _minmax_mixin):
                               shape=permuted_shape, copy=copy)
 
     transpose.__doc__ = _spbase.transpose.__doc__
+    
+    @property
+    def mT(self):
+        axes = None if self.ndim <= 2 else tuple(range(self.ndim - 2)) + (-1, -2)
+        return self.transpose(axes=axes)
+    
+    mT.__doc__ = _spbase.mT.__doc__
 
     def resize(self, *shape) -> None:
         shape = check_shape(shape, allow_nd=self._allow_nd)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -1716,6 +1716,8 @@ class coo_array(_coo_base, sparray):
         Number of values stored in the array
     T : coo_array
         The transpose of the array
+    mT : coo_array
+        The matrix transpose of the array
 
     Notes
     -----
@@ -1832,6 +1834,8 @@ class coo_matrix(spmatrix, _coo_base):
         Number of values stored in the matrix
     T : coo_matrix
         The transpose of the matrix
+    mT : coo_matrix
+        The matrix transpose
 
     Notes
     -----

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -247,7 +247,9 @@ class _coo_base(_data_matrix, _minmax_mixin):
     
     @property
     def mT(self):
-        axes = None if self.ndim <= 2 else tuple(range(self.ndim - 2)) + (-1, -2)
+        if (n := self.ndim) < 2:
+            raise ValueError(f"Array must be at least 2-dimensional, but it is {n}-D")
+        axes = None if n == 2 else tuple(range(n - 2)) + (-1, -2)
         return self.transpose(axes=axes)
     
     mT.__doc__ = _spbase.mT.__doc__

--- a/scipy/sparse/_csc.py
+++ b/scipy/sparse/_csc.py
@@ -229,6 +229,8 @@ class csc_array(_csc_base, sparray):
         Number of values stored in the array
     T : csc_array
         The transpose of the array
+    mT : csc_array
+        The matrix transpose of the array
 
     Notes
     -----
@@ -331,6 +333,8 @@ class csc_matrix(spmatrix, _csc_base):
         Number of values stored in the matrix
     T : csc_matrix
         The transpose of the matrix
+    mT : csc_matrix
+        The matrix transpose
 
     Notes
     -----

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -373,6 +373,8 @@ class csr_array(_csr_base, sparray):
         Number of values stored in the array
     T : csr_array
         The transpose of the array
+    mT : csr_array
+        The matrix transpose of the array
 
     Notes
     -----
@@ -503,6 +505,8 @@ class csr_matrix(spmatrix, _csr_base):
         Number of values stored in the matrix
     T : csr_matrix
         The transpose of the matrix
+    mT : csr_matrix
+        The matrix transpose
 
     Notes
     -----

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -543,6 +543,8 @@ class dia_array(_dia_base, sparray):
         Number of values stored in the array
     T : dia_array
         The transpose of the array
+    mT : dia_array
+        The matrix transpose of the array
 
     Notes
     -----
@@ -624,6 +626,8 @@ class dia_matrix(spmatrix, _dia_base):
         Number of values stored in the matrix
     T : dia_matrix
         The transpose of the matrix
+    mT : dia_matrix
+        The matrix transpose
 
     Notes
     -----

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -689,6 +689,8 @@ class dok_array(_dok_base, sparray):
         Number of values stored in the array
     T : dok_array
         The transpose of the array
+    mT : dok_array
+        The matrix transpose of the array
 
     Notes
     -----
@@ -746,6 +748,8 @@ class dok_matrix(spmatrix, _dok_base):
         Number of values stored in the matrix
     T : dok_matrix
         The transpose of the matrix
+    mT : dok_matrix
+        The matrix transpose
 
     Notes
     -----

--- a/scipy/sparse/_lil.py
+++ b/scipy/sparse/_lil.py
@@ -544,6 +544,8 @@ class lil_array(_lil_base, sparray):
         Number of values stored in the array
     T : lil_array
         The transpose of the array
+    mT : lil_array
+        The matrix transpose of the array
 
     Notes
     -----
@@ -613,6 +615,8 @@ class lil_matrix(spmatrix, _lil_base):
     size : int
         Number of values stored in the matrix
     T : lil_matrix
+        The transpose of the matrix
+    mT : lil_array
         The transpose of the matrix
 
     Notes

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2106,6 +2106,8 @@ class _TestCommon:
             assert_array_equal(a.toarray(), b)
             assert_array_equal(a.transpose().toarray(), dat)
             assert_array_equal(datsp.transpose(axes=(1, 0)).toarray(), b)
+            assert_array_equal(datsp.mT.toarray(), b)
+            assert_array_equal(matrix_transpose(datsp).toarray(), b)
             assert_equal(a.dtype, b.dtype)
 
         # See gh-5987

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -40,7 +40,8 @@ from scipy.sparse import (csc_matrix, csr_matrix, dok_matrix,
         coo_matrix, lil_matrix, dia_matrix, bsr_matrix,
         csc_array, csr_array, dok_array,
         coo_array, lil_array, dia_array, bsr_array,
-        eye, issparse, SparseEfficiencyWarning, sparray, spmatrix)
+        eye, issparse, SparseEfficiencyWarning, sparray, spmatrix,
+        matrix_transpose,)
 from scipy.sparse._base import _formats
 from scipy.sparse._sputils import (supported_dtypes, isscalarlike,
                                    get_index_dtype, asmatrix, matrix)
@@ -2112,6 +2113,8 @@ class _TestCommon:
         assert_array_equal(np.transpose(empty).toarray(),
                            np.transpose(zeros((3, 4))))
         assert_array_equal(empty.T.toarray(), zeros((4, 3)))
+        assert_array_equal(empty.mT.toarray(), empty.T.toarray())
+        assert_array_equal(matrix_transpose(empty).toarray(), empty.T.toarray())
         assert_raises(ValueError, empty.transpose, axes=0)
 
         for dtype in self.checked_dtypes:

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -5,7 +5,9 @@ import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 import pytest
 from scipy.linalg import block_diag
-from scipy.sparse import coo_array, random_array, SparseEfficiencyWarning
+from scipy.sparse import (
+    coo_array, random_array, SparseEfficiencyWarning, matrix_transpose
+)
 from scipy.sparse._csr import csr_array
 from .._coo import _block_diag, _extract_block_diag
 
@@ -190,9 +192,12 @@ def test_transpose():
     assert arr1d.shape == (3,)
     assert_equal(arr1d.toarray(), np.array([1, 0, 3]))
 
-    arr2d = coo_array([[1, 2, 0], [0, 0, 3]]).T
-    assert arr2d.shape == (3, 2)
-    assert_equal(arr2d.toarray(), np.array([[1, 0], [2, 0], [0, 3]]))
+    arr2d = coo_array([[1, 2, 0], [0, 0, 3]])
+    assert arr2d.T.shape == (3, 2)
+    desired = np.array([[1, 0], [2, 0], [0, 3]])
+    assert_equal(arr2d.T.toarray(), desired)
+    assert_equal(arr2d.mT.toarray(), desired)
+    assert_equal(matrix_transpose(arr2d).toarray(), desired)
 
 
 def test_transpose_with_axis():
@@ -465,7 +470,17 @@ def test_nd_transpose(shape):
     exp_arr = arr.toarray().T
     trans_arr = arr.transpose()
     assert trans_arr.shape == shape[::-1]
-    assert_equal(exp_arr, trans_arr.toarray())
+    assert_equal(trans_arr.toarray(), exp_arr)
+
+    if len(shape) >= 2:
+        exp_arr = arr.toarray().mT
+        trans_arr = arr.mT
+        assert trans_arr.shape == exp_arr.shape
+        assert_equal(trans_arr.toarray(), exp_arr)
+    
+        trans_arr = matrix_transpose(arr)
+        assert trans_arr.shape == exp_arr.shape
+        assert_equal(trans_arr.toarray(), exp_arr)
 
 
 @pytest.mark.parametrize(('shape', 'axis_perm'), [((3,), (0,)),

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -481,6 +481,11 @@ def test_nd_transpose(shape):
         trans_arr = matrix_transpose(arr)
         assert trans_arr.shape == exp_arr.shape
         assert_equal(trans_arr.toarray(), exp_arr)
+    else:
+        with pytest.raises(ValueError, match="2-dimensional"):
+            arr.mT
+        with pytest.raises(ValueError, match="2-dimensional"):
+            matrix_transpose(arr)
 
 
 @pytest.mark.parametrize(('shape', 'axis_perm'), [((3,), (0,)),


### PR DESCRIPTION
Found myself wanting to use this in gh-23836!

Reference:
- https://data-apis.org/array-api/latest/API_specification/generated/array_api.matrix_transpose.html
- https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.mT.html

@dschult should we implement `mT` for all formats?