### PR TITLE
BUG:linalg.interpolative: Fix two edge cases for id_dist Cython code

### DIFF
--- a/scipy/linalg/_decomp_interpolative.pyx
+++ b/scipy/linalg/_decomp_interpolative.pyx
@@ -207,10 +207,10 @@ def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: fl
 
         rta = rta[rng.permutation(m), :]
 
-    # idd_subselect pick randomly n2-many rows
-    subselect = rng.choice(m, n2, replace=False)
-    rta = rta[subselect, :]
-
+    # idd_subselect pick randomly n2-many rows if there are more than one row
+    if m > 1:
+        subselect = rng.choice(m, n2, replace=False)
+        rta = rta[subselect, :]
     # Perform rfft on each column. Note that the first and the last
     # element of the result is real valued (n2 is power of 2).
     #

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -563,6 +563,7 @@ def reconstruct_matrix_from_id(B, idx, proj):
     :class:`numpy.ndarray`
         Reconstructed matrix.
     """
+    B = np.atleast_2d(_C_contiguous_copy(B))
     if _is_real(B):
         return _backend.idd_reconid(B, idx, proj)
     else:


### PR DESCRIPTION

#### Reference issue
Closes #23272
Closes #23195 

Very basic guards to keep id_dist running. 

#### Additional information
cc @tylerjereddy 

I included two separate commits for each fix, hence in case you would like to take them in for 1.17 hope this helps. I will check the 500->5000 step increase in LSODA issue next. 
