### PR TITLE
DOC: stats.gennorm: mention AKAs in documentation

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -11449,7 +11449,7 @@ wrapcauchy = wrapcauchy_gen(a=0.0, b=2*np.pi, name='wrapcauchy')
 
 
 class gennorm_gen(rv_continuous):
-    r"""A generalized normal continuous random variable.
+    r"""A (symmetric) generalized normal continuous random variable.
 
     %(before_notes)s
 
@@ -11460,6 +11460,10 @@ class gennorm_gen(rv_continuous):
 
     Notes
     -----
+    The (symmetric) generalized normal distribution is also known as the
+    Subbotin distribution, exponential power distribution, and generalized
+    error distribution [1]_.
+    
     The probability density function for `gennorm` is [1]_:
 
     .. math::


### PR DESCRIPTION
#### Reference issue
Closes gh-24165

#### What does this implement/fix?
Implements the suggestion in gh-24165 by documenting alternative names of the generalized normal distribution.
