### PR TITLE
TYP: fix some typing issues in ``_lib._array_api.xp_vector_norm``

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -62,8 +62,8 @@ __all__ = [
 ]
 
 
-Array: type = Any  # To be changed to a Protocol later (see array-api#589)
-ArrayLike: type = Array | npt.ArrayLike
+type Array = Any  # To be changed to a Protocol later (see array-api#589)
+type ArrayLike = Array | npt.ArrayLike
 
 
 def _check_finite(array: Array, xp: ModuleType) -> None:

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -425,7 +425,7 @@ def scipy_namespace_for(xp: ModuleType) -> ModuleType | None:
 
 # maybe use `scipy.linalg` if/when array API support is added
 def xp_vector_norm(x: Array, /, *,
-                   axis: int | tuple[int] | None = None,
+                   axis: int | tuple[int, int] | None = None,
                    keepdims: bool = False,
                    ord: int | float = 2,
                    xp: ModuleType | None = None) -> Array:
@@ -886,7 +886,7 @@ def make_xp_test_case(*funcs, capabilities_table=None):
 
     The above is equivalent to::
         @pytest.mark.skip_xp_backends(...)
-        @pytest.mark.skip_xp_backends(...)        
+        @pytest.mark.skip_xp_backends(...)
         @pytest.mark.xfail_xp_backends(...)
         @pytest.mark.xfail_xp_backends(...)
         def test_f1(xp):
@@ -978,7 +978,7 @@ def make_xp_pytest_marks(*funcs, capabilities_table=None):
 
         def test(xp):
             ...
-    
+
     See Also
     --------
     xp_capabilities


### PR DESCRIPTION
The invalid `axis` annotation showed up in the mypy_primer output in https://github.com/numpy/numpy/pull/30446#issuecomment-3661498551, and while addressing it, I noticed the invalid type alias defininitions (which is an easy mistake to make, seeing as `type Array = Any` is valid in Python 3.12+)