### PR TITLE
BUG: stats.yeojohnson_llf: fix precision loss and overflow

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1824,6 +1824,10 @@ def _yeojohnson_llf(data, *, lmb, axis=0):
     xp = array_namespace(data)
     dtype = xp_result_type(lmb, data, force_floating=True, xp=xp)
     data = xp.asarray(data, dtype=dtype)
+
+    n = data.shape[axis]
+    if n == 0:
+        return _get_nan(data, xp=xp)
     eps = xp.finfo(dtype).eps
     pos = data >= 0  # binary mask
 
@@ -1869,7 +1873,6 @@ def _yeojohnson_llf(data, *, lmb, axis=0):
 
         logvar = _log_var(logyj, xp, axis)
 
-    n = data.shape[axis]
     loglike = (-n / 2 * logvar
                + (lmb - 1) * xp.sum(xp.sign(data) * xp.log1p(xp.abs(data)), axis=axis))
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1829,6 +1829,7 @@ def _yeojohnson_llf(data, *, lmb, axis=0):
     if n == 0:
         return _get_nan(data, xp=xp)
     eps = xp.finfo(dtype).eps
+    # Special case all-positive/negative data to avoid overflow and precision loss
     pos = data >= 0  # binary mask
 
     # There exists numerical instability when abs(lmb) or abs(lmb - 2) is very small

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1831,6 +1831,7 @@ def _yeojohnson_llf(data, *, lmb, axis=0):
     eps = xp.finfo(dtype).eps
     pos = data >= 0  # binary mask
 
+    # There exists numerical instability when abs(lmb) or abs(lmb - 2) is very small
     if xp.all(pos):
         if abs(lmb) < eps:
             logvar = xp.log(xp.var(xp.log1p(data), axis=axis))
@@ -1846,32 +1847,12 @@ def _yeojohnson_llf(data, *, lmb, axis=0):
             )
 
     else:  # mixed positive and negative data
-        dtypemix = xp.result_type(dtype, 1j)
-        logyj = xp.zeros_like(data, dtype=dtypemix)
+        y = _yeojohnson_transform(data, lmb, xp=xp)
+        sigma = xp.var(y, axis=axis)
 
-        # x >= 0
-        if abs(lmb) < eps:
-            logyj = xpx.at(logyj)[pos].set(xp.log(xp.log1p(data[pos]) + 0j))
-        else:  # lmbda != 0
-            logm1_pos = xp.full_like(data[pos], pi * 1j, dtype=dtypemix)
-            logyj = xpx.at(logyj)[pos].set(
-                special.logsumexp([lmb * xp.log1p(data[pos]), logm1_pos], axis=0)
-                - xp.log(lmb + 0j)
-            )
-
-        # x < 0
-        if abs(lmb - 2) < eps:
-            logyj = xpx.at(logyj)[~pos].set(xp.log(-xp.log1p(-data[~pos]) + 0j))
-        else:  # lmbda != 2
-            logm1_neg = xp.full_like(data[~pos], pi * 1j, dtype=dtypemix)
-            logyj = xpx.at(logyj)[~pos].set(
-                special.logsumexp(
-                    [(2 - lmb) * xp.log1p(-data[~pos]), logm1_neg], axis=0
-                )
-                - xp.log(lmb - 2 + 0j)
-            )
-
-        logvar = _log_var(logyj, xp, axis)
+        # Suppress RuntimeWarning raised by np.log when the variance is too low
+        finite_variance = sigma >= xp.finfo(sigma.dtype).smallest_normal
+        logvar = xpx.apply_where(finite_variance, (sigma,), xp.log, fill_value=-xp.inf)
 
     loglike = (-n / 2 * logvar
                + (lmb - 1) * xp.sum(xp.sign(data) * xp.log1p(xp.abs(data)), axis=axis))

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1847,6 +1847,7 @@ def _yeojohnson_llf(data, *, lmb, axis=0):
                 abs(2 - lmb)
             )
 
+    # overflow/precision loss not reported for mixed data; calculate `logvar` directly
     else:  # mixed positive and negative data
         y = _yeojohnson_transform(data, lmb, xp=xp)
         sigma = xp.var(y, axis=axis)

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2663,6 +2663,21 @@ class TestYeojohnson_llf:
         message = "One or more sample arguments is too small..."
         with eager_warns(SmallSampleWarning, match=message, xp=xp):
             assert xp.isnan(stats.yeojohnson_llf(1, xp.asarray([])))
+    
+    def test_gh24172(self, xp):
+        # Test all negative and all positive data
+        data = xp.asarray([10, 10, 10, 9.9], dtype=xp.float64)
+        # The expected value was computed with mpsci, set mpmath.mp.dps=100
+        # 1. Test precision loss
+        xp_assert_close(stats.yeojohnson_llf(-14, data),
+                        xp.asarray(12.418595783381280, dtype=xp.float64), rtol=1e-7)
+        xp_assert_close(stats.yeojohnson_llf(16, -data),
+                        xp.asarray(12.418595783381280, dtype=xp.float64), rtol=1e-7)
+        # 2. Test overflow
+        xp_assert_close(stats.yeojohnson_llf(-20, data),
+                        xp.asarray(12.360966379200528, dtype=xp.float64), rtol=1e-7)
+        xp_assert_close(stats.yeojohnson_llf(20, -data),
+                        xp.asarray(12.380287243698629, dtype=xp.float64), rtol=1e-7)
 
 
 class TestYeojohnson:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2663,7 +2663,7 @@ class TestYeojohnson_llf:
         message = "One or more sample arguments is too small..."
         with eager_warns(SmallSampleWarning, match=message, xp=xp):
             assert xp.isnan(stats.yeojohnson_llf(1, xp.asarray([])))
-    
+
     def test_gh24172(self, xp):
         # Test all negative and all positive data
         data = xp.asarray([10, 10, 10, 9.9], dtype=xp.float64)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#10072 and #19016

#### What does this implement/fix?
<!--Please explain your changes.-->
1. Remove constant term to avoid precision loss
2. Compute the log-variance term in log-domain to avoid overflow

#### Additional information
<!--Any additional information you think is important.-->
Before
<img width="640" height="480" alt="Figure_1" src="https://github.com/user-attachments/assets/214fd081-d725-41d7-b45f-e17f3d11c944" />

After
<img width="640" height="480" alt="Figure_2" src="https://github.com/user-attachments/assets/0ed52cc0-f7b6-4e55-aed1-a3da28a2d53d" />

```python
import numpy as np
from scipy.stats import yeojohnson_llf
import matplotlib.pyplot as plt

data = np.array([10, 10, 10, 9.9])
lmbs = np.linspace(-20, -10, 300)

llf_pos = [yeojohnson_llf(lmb, data) for lmb in lmbs]
llf_neg = [yeojohnson_llf(-lmb, -data) for lmb in lmbs]

fig, ax = plt.subplots(1, 2)
ax[0].plot(lmbs, llf_pos)
ax[1].plot(-lmbs, llf_neg)
fig.tight_layout()
plt.show()

print(yeojohnson_llf(-14, data))
print(yeojohnson_llf(16, -data))
print(yeojohnson_llf(-20, data))
print(yeojohnson_llf(20, -data))
```
