### PR TITLE
MAINT: NumPy 2.x cleanups

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -25,39 +25,23 @@ from numpy.exceptions import AxisError
 np_long: type
 np_ulong: type
 
-if np.lib.NumpyVersion(np.__version__) >= "2.0.0.dev0":
-    try:
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                r".*In the future `np\.long` will be defined as.*",
-                FutureWarning,
-            )
-            np_long = np.long  # type: ignore[attr-defined]
-            np_ulong = np.ulong  # type: ignore[attr-defined]
-    except AttributeError:
-            np_long = np.int_
-            np_ulong = np.uint
-else:
-    np_long = np.int_
-    np_ulong = np.uint
+try:
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            r".*In the future `np\.long` will be defined as.*",
+            FutureWarning,
+        )
+        np_long = np.long  # type: ignore[attr-defined]
+        np_ulong = np.ulong  # type: ignore[attr-defined]
+except AttributeError:
+        np_long = np.int_
+        np_ulong = np.uint
 
 IntNumber = int | np.integer
 DecimalNumber = float | np.floating | np.integer
 
-copy_if_needed: bool | None
-
-if np.lib.NumpyVersion(np.__version__) >= "2.0.0":
-    copy_if_needed = None
-elif np.lib.NumpyVersion(np.__version__) < "1.28.0":
-    copy_if_needed = False
-else:
-    # 2.0.0 dev versions, handle cases where copy may or may not exist
-    try:
-        np.array([1]).__array__(copy=None)  # type: ignore[call-overload]
-        copy_if_needed = None
-    except TypeError:
-        copy_if_needed = False
+copy_if_needed: bool | None = None
 
 
 # Wrapped function for inspect.signature for compatibility with Python 3.14+
@@ -1231,12 +1215,7 @@ def np_vecdot(x1, x2, /, *, axis=-1):
     # `np.vecdot` has advantages (e.g. see gh-22462), so let's use it when
     # available. As functions are translated to Array API, `np_vecdot` can be
     # replaced with `xp.vecdot`.
-    if np.__version__ > "2.0":
-        return np.vecdot(x1, x2, axis=axis)
-    else:
-        # of course there are other fancy ways of doing this (e.g. `einsum`)
-        # but let's keep it simple since it's temporary
-        return np.sum(x1.conj() * x2, axis=axis)
+    return np.vecdot(x1, x2, axis=axis)
 
 
 def _dedent_for_py313(s):

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1211,13 +1211,6 @@ def _apply_over_batch(*argdefs):
     return decorator
 
 
-def np_vecdot(x1, x2, /, *, axis=-1):
-    # `np.vecdot` has advantages (e.g. see gh-22462), so let's use it when
-    # available. As functions are translated to Array API, `np_vecdot` can be
-    # replaced with `xp.vecdot`.
-    return np.vecdot(x1, x2, axis=axis)
-
-
 def _dedent_for_py313(s):
     """Apply textwrap.dedent to s for Python versions 3.13 or later."""
     return s if sys.version_info < (3, 13) else textwrap.dedent(s)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -629,28 +629,6 @@ if HAVE_SCPDT:
         'scipy.io.matlab.MatlabFunction.dtype'
     ])
 
-    # these are affected by NumPy 2.0 scalar repr: rely on string comparison
-    if np.__version__ < "2":
-        dt_config.skiplist.update(set([
-            'scipy.io.hb_read',
-            'scipy.io.hb_write',
-            'scipy.sparse.csgraph.connected_components',
-            'scipy.sparse.csgraph.depth_first_order',
-            'scipy.sparse.csgraph.shortest_path',
-            'scipy.sparse.csgraph.floyd_warshall',
-            'scipy.sparse.csgraph.dijkstra',
-            'scipy.sparse.csgraph.bellman_ford',
-            'scipy.sparse.csgraph.johnson',
-            'scipy.sparse.csgraph.yen',
-            'scipy.sparse.csgraph.breadth_first_order',
-            'scipy.sparse.csgraph.reverse_cuthill_mckee',
-            'scipy.sparse.csgraph.structural_rank',
-            'scipy.sparse.csgraph.construct_dist_matrix',
-            'scipy.sparse.csgraph.reconstruct_path',
-            'scipy.ndimage.value_indices',
-            'scipy.stats.mstats.describe',
-    ]))
-
     # help pytest collection a bit: these names are either private
     # (distributions), or just do not need doctesting.
     dt_config.pytest_extra_ignore = [

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -976,9 +976,6 @@ class TestSolve:
             assert_equal(A, A_copy)
             assert_equal(b, b_copy)
 
-    @pytest.mark.skipif(
-        np.__version__ < '2', reason="solve chokes on b.ndim == 1 in numpy < 2"
-    )
     @pytest.mark.parametrize(
         "assume_a",
         [

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -22,8 +22,6 @@ from . import types
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
-IS_WINDOWS_AND_NP1 = os.name == 'nt' and np.__version__ < '2'
-
 
 @skip_xp_backends(np_only=True, reason='test internal numpy-only helpers')
 class Test_measurements_stats:
@@ -42,7 +40,7 @@ class Test_measurements_stats:
             counts, sums = ndimage._measurements._stats(
                 x, labels=labels, index=index)
 
-            dtype_arg = {'dtype': np.int64} if IS_WINDOWS_AND_NP1 else {}
+            dtype_arg = {}
             xp_assert_equal(counts, np.asarray([2, 2], **dtype_arg))
             xp_assert_equal(sums, np.asarray([1.0, 8.0]))
 
@@ -58,7 +56,7 @@ class Test_measurements_stats:
             counts, sums = ndimage._measurements._stats(
                 x, labels=labels, index=index)
 
-            dtype_arg = {'dtype': np.int64} if IS_WINDOWS_AND_NP1 else {}
+            dtype_arg = {}
             xp_assert_equal(counts, np.asarray([2, 2], **dtype_arg))
             xp_assert_equal(sums, np.asarray([1.0, 8.0]))
 
@@ -72,7 +70,7 @@ class Test_measurements_stats:
             counts, sums, centers = ndimage._measurements._stats(
                 x, labels=labels, index=index, centered=True)
 
-            dtype_arg = {'dtype': np.int64} if IS_WINDOWS_AND_NP1 else {}
+            dtype_arg = {}
             xp_assert_equal(counts, np.asarray([2, 2], **dtype_arg))
             xp_assert_equal(sums, np.asarray([1.0, 8.0]))
             xp_assert_equal(centers, np.asarray([0.5, 8.0]))
@@ -87,7 +85,7 @@ class Test_measurements_stats:
             counts, sums, centers = ndimage._measurements._stats(
                 x, labels=labels, index=index, centered=True)
 
-            dtype_arg = {'dtype': np.int64} if IS_WINDOWS_AND_NP1 else {}
+            dtype_arg = {}
             xp_assert_equal(counts, np.asarray([2, 2], **dtype_arg))
             xp_assert_equal(sums, np.asarray([1.0, 8.0]))
             xp_assert_equal(centers, np.asarray([0.5, 8.0]))
@@ -102,7 +100,7 @@ class Test_measurements_stats:
             counts, sums, centers = ndimage._measurements._stats(
                 x, labels=labels, index=index, centered=True)
 
-            dtype_arg = {'dtype': np.int64} if IS_WINDOWS_AND_NP1 else {}
+            dtype_arg = {}
             xp_assert_equal(counts, np.asarray([2, 2], **dtype_arg))
             xp_assert_equal(sums, np.asarray([1.0, 8.0]))
             xp_assert_equal(centers, np.asarray([0.5, 8.0]))

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -348,8 +348,6 @@ def test_failure_to_run_iterations_nonsymmetric():
     assert np.max(eigenvalues) > 0
 
 
-@pytest.mark.skipif(_IS_32BIT and np.lib.NumpyVersion(np.__version__) < "2.0.0",
-                  reason="Was failing in CI, see gh-23077")
 @pytest.mark.filterwarnings("ignore:The problem size")
 def test_hermitian():
     """Check complex-value Hermitian cases.

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -15,7 +15,6 @@ import scipy.sparse as sparse
 import scipy.sparse.linalg._interface as interface
 from scipy.sparse._sputils import matrix
 from scipy._lib._gcutils import assert_deallocated, IS_PYPY
-from scipy._lib._util import np_vecdot
 
 
 class TestLinearOperator:
@@ -304,8 +303,8 @@ class TestDotTests:
             assert_allclose(op_u, op.dot(u))
             assert_allclose(opH_v, op.H.dot(v))
 
-        op_u_H_v = np_vecdot(op_u, v, axis=-1)
-        uH_opH_v = np_vecdot(u, opH_v, axis=-1)
+        op_u_H_v = np.vecdot(op_u, v, axis=-1)
+        uH_opH_v = np.vecdot(u, opH_v, axis=-1)
 
         rtol = 1e-12 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
         assert_allclose(op_u_H_v, uH_opH_v, rtol=rtol)

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2489,7 +2489,7 @@ class TestFactorialFunctions:
             if exact:
                 # avoid attempting huge calculation
                 pass
-            elif np.lib.NumpyVersion(np.__version__) >= "2.0.0":
+            else:
                 # N does not fit into int64 --> cannot use _check
                 _check_inf(dtype(N-1))
                 _check_inf(np.array(N-1, dtype=dtype))

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -49,12 +49,6 @@ def _skip_or_tweak_alternative_backends(xp, nfo, dtypes, int_only):
     if f_name in {'betaincinv'} and is_cupy(xp):
         pytest.xfail("CuPy uses different convention for out of domain input.")
 
-    if (
-            f_name == "sinc" and "float32" in dtypes
-            and version.parse(np.__version__) < version.parse("2")
-    ):
-        pytest.xfail("https://github.com/numpy/numpy/issues/11204")
-
     if not any('int' in dtype for dtype in dtypes):
         return positive_only, dtypes
 

--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -19,7 +19,7 @@
 
 # SciPy imports.
 from scipy import linalg, special
-from scipy._lib._util import check_random_state, np_vecdot
+from scipy._lib._util import check_random_state
 
 from numpy import (asarray, atleast_2d, reshape, zeros, newaxis, exp, pi,
                    sqrt, ravel, power, atleast_1d, squeeze, sum, transpose,
@@ -220,7 +220,7 @@ class gaussian_kde:
                 raise ValueError("`weights` input should be one-dimensional.")
             if len(self._weights) != self.n:
                 raise ValueError("`weights` input should be of length n")
-            self._neff = 1/np_vecdot(self._weights, self._weights)
+            self._neff = 1/np.vecdot(self._weights, self._weights)
 
         # This can be converted to a warning once gh-10205 is resolved
         if self.d > self.n:
@@ -334,8 +334,8 @@ class gaussian_kde:
         sqrt_det = np.prod(np.diagonal(sum_cov_chol[0]))
         norm_const = power(2 * pi, sum_cov.shape[0] / 2.0) * sqrt_det
 
-        energies = np_vecdot(diff, tdiff, axis=0) / 2.0
-        result = np_vecdot(exp(-energies), self.weights, axis=0) / norm_const
+        energies = np.vecdot(diff, tdiff, axis=0) / 2.0
+        result = np.vecdot(exp(-energies), self.weights, axis=0) / norm_const
 
         return result
 
@@ -370,7 +370,7 @@ class gaussian_kde:
         normalized_high = ravel((high - self.dataset) / stdev)
 
         delta = special.ndtr(normalized_high) - special.ndtr(normalized_low)
-        value = np_vecdot(self.weights, delta)
+        value = np.vecdot(self.weights, delta)
         return value
 
     def integrate_box(self, low_bounds, high_bounds, maxpts=None, *, rng=None):
@@ -401,7 +401,7 @@ class gaussian_kde:
             high, lower_limit=low, cov=self.covariance, maxpts=maxpts,
             rng=rng
         )
-        return np_vecdot(values, self.weights, axis=-1)
+        return np.vecdot(values, self.weights, axis=-1)
 
     def integrate_kde(self, other):
         """
@@ -443,8 +443,8 @@ class gaussian_kde:
             diff = large.dataset - mean
             tdiff = linalg.cho_solve(sum_cov_chol, diff)
 
-            energies = np_vecdot(diff, tdiff, axis=0) / 2.0
-            result += np_vecdot(exp(-energies), large.weights, axis=0)*small.weights[i]
+            energies = np.vecdot(diff, tdiff, axis=0) / 2.0
+            result += np.vecdot(exp(-energies), large.weights, axis=0)*small.weights[i]
 
         sqrt_det = np.prod(np.diagonal(sum_cov_chol[0]))
         norm_const = power(2 * pi, sum_cov.shape[0] / 2.0) * sqrt_det
@@ -706,7 +706,7 @@ class gaussian_kde:
         try:
             return self._neff
         except AttributeError:
-            self._neff = 1/np_vecdot(self.weights, self.weights)
+            self._neff = 1/np.vecdot(self.weights, self.weights)
             return self._neff
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -40,7 +40,7 @@ from scipy import sparse
 from scipy.spatial import distance_matrix
 
 from scipy.optimize import milp, LinearConstraint
-from scipy._lib._util import _get_nan, _rename_parameter, _contains_nan, np_vecdot
+from scipy._lib._util import _get_nan, _rename_parameter, _contains_nan
 
 import scipy.special as special
 # Import unused here but needs to stay until end of deprecation periode
@@ -9856,10 +9856,10 @@ def _cdf_distance(p, u_values, v_values, u_weights=None, v_weights=None):
     # If p = 1 or p = 2, we avoid using np.power, which introduces an overhead
     # of about 15%.
     if p == 1:
-        return np_vecdot(np.abs(u_cdf - v_cdf), deltas)
+        return np.vecdot(np.abs(u_cdf - v_cdf), deltas)
     if p == 2:
-        return np.sqrt(np_vecdot(np.square(u_cdf - v_cdf), deltas))
-    return np.power(np_vecdot(np.power(np.abs(u_cdf - v_cdf), p), deltas), 1/p)
+        return np.sqrt(np.vecdot(np.square(u_cdf - v_cdf), deltas))
+    return np.power(np.vecdot(np.power(np.abs(u_cdf - v_cdf), p), deltas), 1/p)
 
 
 def _validate_distribution(values, weights):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1173,8 +1173,7 @@ def _demean(a, mean, axis, *, xp, precision_warning=True):
 
     n = _length_nonmasked(a, axis, xp=xp)
     with np.errstate(invalid='ignore'):
-        # Old NumPy doesn't accept `device` arg
-        device = {} if xp is np and np.__version__ < '2.0' else {'device': xp_device(a)}
+        device = {'device': xp_device(a)}
         precision_loss = xp.any(xp.asarray(rel_diff < eps, **device)
                                 & xp.asarray(n > 1, **device))
 

--- a/scipy/stats/tests/test_continued_fraction.py
+++ b/scipy/stats/tests/test_continued_fraction.py
@@ -25,8 +25,6 @@ class TestContinuedFraction:
             y = x
         else:
             y = -x**2
-        if np.isscalar(y) and np.__version__ < "2.0":
-            y = np.full_like(x, y)  # preserve dtype pre NEP 50
         return y
 
     def b1(self, n, x=1.5):
@@ -35,8 +33,6 @@ class TestContinuedFraction:
         else:
             one = x/x  # gets array of correct type, dtype, and shape
             y = one * (2*n - 1)
-        if np.isscalar(y) and np.__version__ < "2.0":
-            y = np.full_like(x, y)  # preserve dtype pre NEP 50
         return y
 
     def log_a1(self, n, x):
@@ -113,8 +109,6 @@ class TestContinuedFraction:
     @pytest.mark.parametrize('dtype', ['float32', 'float64'])
     @pytest.mark.parametrize('shape', [(), (1,), (3,), (3, 2)])
     def test_log(self, shape, dtype, xp):
-        if (np.__version__ < "2") and (dtype == 'float32'):
-            pytest.skip("Scalar dtypes only respected after NEP 50.")
         np_dtype = getattr(np, dtype)
         rng = np.random.default_rng(2435908729190400)
         x = rng.random(shape).astype(np_dtype)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1238,10 +1238,8 @@ class TestMakeDistribution:
         X = LogUniform(a=1., b=np.e)
         Y = stats.exp(Uniform(a=0., b=1.))
 
-        # pre-2.0 support is not needed for much longer, so let's just test with 2.0+
-        if np.__version__ >= "2.0":
-            assert str(X) == f"MyLogUniform(a=1.0, b={np.e})"
-            assert repr(X) == f"MyLogUniform(a=np.float64(1.0), b=np.float64({np.e}))"
+        assert str(X) == f"MyLogUniform(a=1.0, b={np.e})"
+        assert repr(X) == f"MyLogUniform(a=np.float64(1.0), b=np.float64({np.e}))"
 
         x = X.sample(shape=10, rng=rng)
         p = X.cdf(x)
@@ -1437,14 +1435,12 @@ class TestMakeDistribution:
 
         dist = stats.make_distribution(stats.gamma)
         assert str(dist(a=2)) == "Gamma(a=2.0)"
-        if np.__version__ >= "2":
-            assert repr(dist(a=2)) == "Gamma(a=np.float64(2.0))"
+        assert repr(dist(a=2)) == "Gamma(a=np.float64(2.0))"
         assert 'Gamma' in dist.__doc__
 
         dist = stats.make_distribution(stats.halfgennorm)
         assert str(dist(beta=2)) == "HalfGeneralizedNormal(beta=2.0)"
-        if np.__version__ >= "2":
-            assert repr(dist(beta=2)) == "HalfGeneralizedNormal(beta=np.float64(2.0))"
+        assert repr(dist(beta=2)) == "HalfGeneralizedNormal(beta=np.float64(2.0))"
         assert 'HalfGeneralizedNormal' in dist.__doc__
 
 
@@ -1972,17 +1968,11 @@ class TestFullCoverage:
 
     def test_ContinuousDistribution__repr__(self):
         X = Uniform(a=0, b=1)
-        if np.__version__ < "2":
-            assert repr(X) == "Uniform(a=0.0, b=1.0)"
-        else:
-            assert repr(X) == "Uniform(a=np.float64(0.0), b=np.float64(1.0))"
-        if np.__version__ < "2":
-            assert repr(X*3 + 2) == "3.0*Uniform(a=0.0, b=1.0) + 2.0"
-        else:
-            assert repr(X*3 + 2) == (
-                "np.float64(3.0)*Uniform(a=np.float64(0.0), b=np.float64(1.0))"
-                " + np.float64(2.0)"
-            )
+        assert repr(X) == "Uniform(a=np.float64(0.0), b=np.float64(1.0))"
+        assert repr(X*3 + 2) == (
+            "np.float64(3.0)*Uniform(a=np.float64(0.0), b=np.float64(1.0))"
+            " + np.float64(2.0)"
+        )
 
         X = Uniform(a=np.zeros(4), b=1)
         assert repr(X) == "Uniform(a=array([0., 0., 0., 0.]), b=1)"
@@ -2006,20 +1996,8 @@ class TestReprs:
         [
             U,
             U - np.array([1.0, 2.0]),
-            pytest.param(
-                V,
-                marks=pytest.mark.skipif(
-                    np.__version__ < "2",
-                    reason="numpy 1.x didn't have dtype in repr",
-                )
-            ),
-            pytest.param(
-                np.ones(2, dtype=np.float32)*V + np.zeros(2, dtype=np.float64),
-                marks=pytest.mark.skipif(
-                    np.__version__ < "2",
-                    reason="numpy 1.x didn't have dtype in repr",
-                )
-            ),
+            V,
+            np.ones(2, dtype=np.float32)*V + np.zeros(2, dtype=np.float64),
             3*U + 2,
             U**4,
             (3*U + 2)**4,

--- a/scipy/stats/tests/test_correlation.py
+++ b/scipy/stats/tests/test_correlation.py
@@ -26,8 +26,6 @@ class TestChatterjeeXi:
         #       0.7620801065573549, 0.31410063302647495, 0.7935620302236199,
         #       0.5423085761365468)
         # xicor(x, y, ties=FALSE, pvalue=TRUE)
-        if dtype == 'float32' and np.__version__ < "2":
-            pytest.skip("Scalar dtypes only respected after NEP 50.")
         dtype = xp_default_dtype(xp) if dtype is None else getattr(xp, dtype)
         rng = np.random.default_rng(25982435982346983)
         x = rng.random(size=10)
@@ -110,8 +108,6 @@ class TestSpearmanRho:
         #       0.7620801065573549, 0.31410063302647495, 0.7935620302236199,
         #       0.5423085761365468)
         # cor.test(x, y, method='spearman', alternative='t', exact=FALSE)
-        if dtype == 'float32' and np.__version__ < "2":
-            pytest.skip("Scalar dtypes only respected after NEP 50.")
         dtype = xp_default_dtype(xp) if dtype is None else getattr(xp, dtype)
         rng = np.random.default_rng(25982435982346983)
         x = rng.random(size=10)

--- a/scipy/stats/tests/test_device_dtype.py
+++ b/scipy/stats/tests/test_device_dtype.py
@@ -10,10 +10,6 @@ skip_xp_backends = pytest.mark.skip_xp_backends
 dtypes = ['float32', 'float64']
 
 
-if np.__version__ < "2":  # need NEP 50 dtype behavior
-    pytest.skip(allow_module_level=True)
-
-
 def get_arrays(n_arrays, *, dtype=np.float64, xp=np, shape=(30,), device=None,
                seed=84912165484321):
     rng = np.random.default_rng(seed)

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 from scipy import stats
-from packaging import version
 
 from scipy._lib._array_api import xp_assert_close, xp_assert_equal, _length_nonmasked
 from scipy._lib._array_api import make_xp_pytest_param, make_xp_test_case
@@ -299,8 +298,6 @@ def test_ttest_ind_from_stats(xp):
     assert res.pvalue.shape == shape
 
 
-@pytest.mark.skipif(version.parse(np.__version__) < version.parse("2"),
-                    reason="Call to _getnamespace fails with AttributeError")
 def test_length_nonmasked_marray_iterable_axis_raises():
     xp = marray._get_namespace(np)
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -5013,8 +5013,6 @@ class TestNormalInverseGamma:
 
     @pytest.mark.parametrize('dtype', [np.int32, np.float16, np.float32, np.float64])
     def test_dtype(self, dtype):
-        if np.__version__ < "2":
-            pytest.skip("Scalar dtypes only respected after NEP 50.")
         rng = np.random.default_rng(8925849245)
         x, s2, mu, lmbda, a, b = rng.uniform(3, 10, size=6).astype(dtype)
         dtype_out = np.result_type(1.0, dtype)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7891,8 +7891,6 @@ class TestKruskal:
 
     @pytest.mark.parametrize("dtype", ['float32', 'float64', None])
     def test_basic(self, xp, dtype):
-        if dtype == 'float32' and np.__version__ < "2":
-            pytest.skip("Scalar dtypes only respected after NEP 50.")
         dtype = xp_default_dtype(xp) if dtype is None else getattr(xp, dtype)
         x = xp.asarray([1, 3, 5, 7, 9], dtype=dtype)
         y = xp.asarray([2, 4, 6, 8, 10], dtype=dtype)

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -1,16 +1,9 @@
 #!/usr/bin/env python
 """Generate requirements/*.txt files from pyproject.toml."""
 
-import sys
 from pathlib import Path
 
-try:  # standard module since Python 3.11
-    import tomllib as toml
-except ImportError:
-    try:  # available for older Python via pip
-        import tomli as toml
-    except ImportError:
-        sys.exit("Please install `tomli` first: `{mamba, pip} install tomli`")
+import tomllib as toml
 
 script_pth = Path(__file__)
 repo_dir = script_pth.parent.parent


### PR DESCRIPTION
* A batch of cleanups following the bump in minimum required NumPy/Python versions in gh-24119.

