### PR TITLE
REV:integrate: Revert the stepsize change in LSODA

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -1254,7 +1254,7 @@ class lsoda(IntegratorBase):
                  with_jacobian=False,
                  rtol=1e-6, atol=1e-12,
                  lband=None, uband=None,
-                 nsteps=5000,  # Increased default for tighter tolerances
+                 nsteps=500,
                  max_step=0.0,  # corresponds to infinite
                  min_step=0.0,
                  first_step=0.0,  # determined by solver


### PR DESCRIPTION
#### Reference issue
#24152 

#### What does this implement/fix?
As discovered by the meticulous work of @jorenham , I accidentally changed the default max step count to 5000 (probably out of desperation at some point), and hid a bug under it. Reverting back to 500 revealed a typo that was causing a test failure. This fixes both issues. Apologies for the mistake. As a bonus added some missing docstrings to complete the func catalogue. 

cc @tylerjereddy 


