### PR TITLE
ENH: linalg/lstsq: move the batching loop to C

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -165,6 +165,20 @@ class BatchedSVDBench(Benchmark):
             sl.svd(self.a)
 
 
+class BatchedLstsqBench(Benchmark):
+    params = [
+        [(10, 10, 50, 2), (100, 20, 5), (100, 10, 10), (100, 5, 20), (100, 2, 50)],
+    ]
+    param_names = ['shape']
+
+    def setup(self, shape):
+         self.a = random(shape)
+         self.b = random((shape[-2],))
+
+    def time_lstsq(self, shape):
+        sl.lstsq(self.a, self.b, check_finite=False)
+
+
 class Norm(Benchmark):
     params = [
         [(20, 20), (100, 100), (1000, 1000), (20, 1000), (1000, 20)],

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1623,9 +1623,8 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     x : (N,) or (..., N, K) ndarray
         Least-squares solution.
     residues : (K,) ndarray or float
-        Square of the 2-norm for each column in ``b - a x``, if ``M > N`` and
-        ``rank(A) == n`` (returns a scalar if ``b`` is 1-D). Otherwise a
-        (0,)-shaped array is returned.
+        Square of the 2-norm for each column in ``b - a x``, if ``M > N`` (returns a
+        scalar if ``b`` is 1-D). Otherwise a (0,)-shaped array is returned.
     rank : int
         Effective rank of `a`.
     s : (min(M, N),) ndarray or None
@@ -1646,8 +1645,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 
     Notes
     -----
-    When ``'gelsy'`` is used as a driver, `residues` is set to a (0,)-shaped
-    array and `s` is always ``None``.
+    When ``'gelsy'`` is used as a driver, `s` is always ``None``.
 
     Examples
     --------

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1582,7 +1582,8 @@ def det(a, overwrite_a=False, check_finite=True):
 
 
 # Linear Least Squares
-@_apply_over_batch(('a', 2), ('b', '1|2'))
+
+
 def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
           check_finite=True, lapack_driver=None):
     """
@@ -1592,9 +1593,9 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 
     Parameters
     ----------
-    a : (M, N) array_like
+    a : (..., M, N) array_like
         Left-hand side array
-    b : (M,) or (M, K) array_like
+    b : (M,) or (..., M, K) array_like
         Right hand side array
     cond : float, optional
         Cutoff for 'small' singular values; used to determine effective
@@ -1619,7 +1620,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 
     Returns
     -------
-    x : (N,) or (N, K) ndarray
+    x : (N,) or (..., N, K) ndarray
         Least-squares solution.
     residues : (K,) ndarray or float
         Square of the 2-norm for each column in ``b - a x``, if ``M > N`` and
@@ -1694,25 +1695,6 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     >>> plt.show()
 
     """
-    a1 = _asarray_validated(a, check_finite=check_finite)
-    b1 = _asarray_validated(b, check_finite=check_finite)
-    if len(a1.shape) != 2:
-        raise ValueError('Input array a should be 2D')
-    m, n = a1.shape
-    if len(b1.shape) == 2:
-        nrhs = b1.shape[1]
-    else:
-        nrhs = 1
-    if m != b1.shape[0]:
-        raise ValueError('Shape mismatch: a and b should have the same number'
-                         f' of rows ({m} != {b1.shape[0]}).')
-    if m == 0 or n == 0:  # Zero-sized problem, confuses LAPACK
-        x = np.zeros((n,) + b1.shape[1:], dtype=np.common_type(a1, b1))
-        if n == 0:
-            residues = np.linalg.norm(b1, axis=0)**2
-        else:
-            residues = np.empty((0,))
-        return x, residues, 0, np.empty((0,))
 
     driver = lapack_driver
     if driver is None:
@@ -1720,70 +1702,70 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     if driver not in ('gelsd', 'gelsy', 'gelss'):
         raise ValueError(f'LAPACK driver "{driver}" is not found')
 
-    lapack_func, lapack_lwork = get_lapack_funcs((driver,
-                                                 f'{driver}_lwork'),
-                                                 (a1, b1))
-    real_data = True if (lapack_func.dtype.kind == 'f') else False
+    if len(a.shape) < 2:
+        raise ValueError('Input array a should be at least 2D, got {a.shape = }')
 
-    if m < n:
-        # need to extend b matrix as it will be filled with
-        # a larger solution matrix
-        if len(b1.shape) == 2:
-            b2 = np.zeros((n, nrhs), dtype=lapack_func.dtype)
-            b2[:m, :] = b1
+    a1 = np.atleast_2d(_asarray_validated(a, check_finite=check_finite))
+    b1 = np.atleast_1d(_asarray_validated(b, check_finite=check_finite))
+    a1, b1 = _ensure_dtype_cdsz(a1, b1)   # NB: makes a1.dtype == b1.dtype, if needed
+    a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
+
+    m, n = a1.shape[-2:]
+
+    # Zero-sized problem, confuses LAPACK; bail out straight away
+    if m == 0 or n == 0:
+        x = np.zeros((n,) + b1.shape[1:], dtype=np.common_type(a1, b1))
+        if n == 0:
+            residues = np.linalg.norm(b1, axis=0)**2
         else:
-            b2 = np.zeros(n, dtype=lapack_func.dtype)
-            b2[:m] = b1
-        b1 = b2
+            residues = np.empty((0,))
+        return x, residues, 0, np.empty((0,))
 
-    overwrite_a = overwrite_a or _datacopied(a1, a)
-    overwrite_b = overwrite_b or _datacopied(b1, b)
+    if not (a1.flags['ALIGNED'] or a1.dtype.byteorder == '='):
+        overwrite_a = True
+        a1 = a1.copy()
+
+    if not (b1.flags['ALIGNED'] or b1.dtype.byteorder == '='):
+        # overwrite_b = True
+        b1 = b1.copy()
+
+    # align the shape of b with a
+    # 1. make b1 at least 2D
+    b_is_1D = b1.ndim == 1
+    if b_is_1D:
+        b1 = b1[:, None]
+
+    if m != b1.shape[-2]:
+        raise ValueError('Shape mismatch: a and b should have the same number'
+                         f' of rows ({m} != {b1.shape[-2]}).')
+
+    # 2. broadcast the batch dimensions of b1 and a1
+    batch_shape = np.broadcast_shapes(a1.shape[:-2], b1.shape[:-2])
+    a1 = np.broadcast_to(a1, batch_shape + a1.shape[-2:])
+    b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
     if cond is None:
-        cond = np.finfo(lapack_func.dtype).eps
+        cond = np.finfo(a1.dtype).eps
+    else:
+        cond = float(cond)
 
-    if driver in ('gelss', 'gelsd'):
-        if driver == 'gelss':
-            lwork = _compute_lwork(lapack_lwork, m, n, nrhs, cond)
-            v, x, s, rank, work, info = lapack_func(a1, b1, cond, lwork,
-                                                    overwrite_a=overwrite_a,
-                                                    overwrite_b=overwrite_b)
+    x, rank, S, err_lst = _batched_linalg._lstsq(a1, b1, cond, driver)
 
-        elif driver == 'gelsd':
-            if real_data:
-                lwork, iwork = _compute_lwork(lapack_lwork, m, n, nrhs, cond)
-                x, s, rank, info = lapack_func(a1, b1, lwork,
-                                               iwork, cond, False, False)
-            else:  # complex data
-                lwork, rwork, iwork = _compute_lwork(lapack_lwork, m, n,
-                                                     nrhs, cond)
-                x, s, rank, info = lapack_func(a1, b1, lwork, rwork, iwork,
-                                               cond, False, False)
-        if info > 0:
-            raise LinAlgError("SVD did not converge in Linear Least Squares")
-        if info < 0:
-            raise ValueError(
-                f'illegal value in {-info}-th argument of internal {lapack_driver}'
-            )
-        resids = np.asarray([], dtype=x.dtype)
-        if m > n:
-            x1 = x[:n]
-            if rank == n:
-                resids = np.sum(np.abs(x[n:])**2, axis=0)
-            x = x1
-        return x, resids, rank, s
+    if err_lst:
+        _format_emit_errors_warnings(err_lst)
 
-    elif driver == 'gelsy':
-        lwork = _compute_lwork(lapack_lwork, m, n, nrhs, cond)
-        jptv = np.zeros((a1.shape[1], 1), dtype=np.int32)
-        v, x, j, rank, info = lapack_func(a1, b1, jptv, cond,
-                                          lwork, False, False)
-        if info < 0:
-            raise ValueError(f'illegal value in {-info}-th argument of internal gelsy')
-        if m > n:
-            x1 = x[:n]
-            x = x1
-        return x, np.array([], x.dtype), rank, None
+    residuals = np.asarray([], dtype=x.dtype)
+    if m > n:
+        # can get the residuals from the GELSS/GELSD output instead, if _really_ wanted
+        res = b1 - a1 @ x
+        residuals = np.sum(res * res.conj(), axis=len(batch_shape))
+
+    if b_is_1D:
+        x = x[..., 0]
+        if residuals.size > 0:
+            residuals = residuals[..., 0]
+
+    return x, residuals, rank, S
 
 
 lstsq.default_lapack_driver = 'gelsd'

--- a/scipy/linalg/_testutils.py
+++ b/scipy/linalg/_testutils.py
@@ -6,6 +6,10 @@ class _FakeMatrix:
         self._data = data
         self.__array_interface__ = data.__array_interface__
 
+    @property
+    def shape(self):
+        return self._data.shape
+
 
 class _FakeMatrix2:
     def __init__(self, data):
@@ -15,6 +19,10 @@ class _FakeMatrix2:
         if copy:
             return self._data.copy()
         return self._data
+
+    @property
+    def shape(self):
+        return self._data.shape
 
 
 def _get_array(shape, dtype):

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -184,6 +184,7 @@ py3.extension_module('_batched_linalg',
   ],
   dependencies: [np_dep, lapack_dep],
   include_directories: ['../_build_utils/src'],
+  link_args: version_link_args,
   install: true,
   subdir: 'scipy/linalg'
 )

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -1,8 +1,8 @@
 #include <cstring>
-
 #include "_linalg_inv.hh"
 #include "_linalg_solve.hh"
 #include "_linalg_svd.hh"
+#include "_linalg_lstsq.hh"
 #include "_common_array_utils.hh"
 
 
@@ -11,6 +11,9 @@ static PyObject* _linalg_inv_error;
 
 PyObject* 
 convert_vec_status(SliceStatusVec& vec_status);
+
+std::string
+get_err_mesg(const std::string routine, const std::string func_name, int info);
 
 
 static PyObject*
@@ -316,6 +319,146 @@ fail:
 }
 
 
+
+static PyObject*
+_linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
+
+    PyArrayObject *ap_Am = NULL;
+    PyArrayObject *ap_b = NULL;
+    PyArrayObject *ap_S = NULL;
+    PyArrayObject *ap_x = NULL;
+    PyArrayObject *ap_rank = NULL;
+    double rcond;
+    const char *lapack_driver = NULL;
+
+    int info = 0;
+    SliceStatusVec vec_status;
+
+    // Get the input array
+    if (!PyArg_ParseTuple(args, "O!O!ds", &PyArray_Type, (PyObject **)&ap_Am,  &PyArray_Type, (PyObject **)&ap_b, &rcond, &lapack_driver)) {
+        return NULL;
+    }
+
+    // Check for dtype compatibility & array flags
+    int typenum = PyArray_TYPE(ap_Am);
+    bool dtype_ok = (typenum == NPY_FLOAT32)
+                     || (typenum == NPY_FLOAT64)
+                     || (typenum == NPY_COMPLEX64)
+                     || (typenum == NPY_COMPLEX128);
+    if(!dtype_ok || !PyArray_ISALIGNED(ap_Am)) {
+        PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
+        return NULL;
+    }
+
+    if (rcond < 0) {
+        PyErr_SetString(PyExc_ValueError, "Expected rcond >= 0.");
+        return NULL;
+    }
+
+    // Sanity checks of array dimensions
+    int ndim = PyArray_NDIM(ap_Am);
+    npy_intp *shape = PyArray_SHAPE(ap_Am);
+    if (ndim < 2) {
+        PyErr_SetString(PyExc_ValueError, "Expected at least a 2D array.");
+        return NULL;
+    }
+
+    // At the python call site, 
+    // 1) 1D `b` must have been converted into 2D, and
+    // 2) batch dimensions of `a` and `b` have been broadcast
+    // Therefore, if `a.shape == (s, p, r, m, n)`, then `b.shape == (s, p, r, m, nrhs)`
+    // where `nrhs` is the number of right-hand-sides.
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+
+    bool dims_match = ndim_b == ndim;
+    if (dims_match) {
+        for (int i=0; i<ndim-2; i++) {
+            dims_match = dims_match && (shape[i] == shape_b[i]);
+        }
+    }
+    if (!dims_match){
+        PyErr_SetString(PyExc_ValueError, "`a` and `b` shape mismatch.");
+        return NULL;
+    }
+
+    npy_intp m = shape[ndim - 2];
+    npy_intp n = shape[ndim - 1];
+    npy_intp min_mn = m < n ? m : n;
+    npy_intp nrhs = PyArray_DIM(ap_b, ndim-1);
+
+    // Allocate the output(s)
+    npy_intp shape_1[NPY_MAXDIMS];
+    for(int i=0; i<PyArray_NDIM(ap_Am); i++) {
+        shape_1[i] = PyArray_DIM(ap_Am, i);
+    }
+
+    // x.shape = (..., N, NRHS)
+    shape_1[ndim-2] = n;
+    shape_1[ndim-1] = nrhs;
+    ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
+    if (!ap_x) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    // S array is not used by ?gelsy
+    if (strcmp(lapack_driver, "gelsy") != 0) {
+        // S.dtype is real if A.dtype is complex
+        npy_intp typenum_S = typenum;
+        if (typenum_S == NPY_COMPLEX64) { typenum_S = NPY_FLOAT32; }
+        else if (typenum_S == NPY_COMPLEX128) { typenum_S = NPY_FLOAT64; }
+
+        // S.shape = (..., min_mn)
+        shape_1[ndim - 2] = min_mn;
+        ap_S = (PyArrayObject *)PyArray_SimpleNew(ndim-1, shape_1, typenum_S);
+        if (!ap_S) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+    }
+
+    // rank.shape = batch_shape
+    ap_rank = (PyArrayObject *)PyArray_SimpleNew(ndim-2, shape_1, NPY_INT64);
+    if (!ap_rank) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    switch(typenum) {
+        case(NPY_FLOAT32):
+            info = _lstsq<float>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, vec_status);
+            break;
+        case(NPY_FLOAT64):
+            info = _lstsq<double>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, vec_status);
+            break;
+        case(NPY_COMPLEX64):
+            info = _lstsq<npy_complex64>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, vec_status);
+            break;
+        case(NPY_COMPLEX128):
+            info = _lstsq<npy_complex128>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, vec_status);
+            break;
+        default:
+            PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");
+            return NULL;
+    }
+
+    if (info < 0) {
+        // Some fatal error: OOM, LWORK query failed or lwork needed is too large
+        Py_DECREF(ap_x);
+        Py_DECREF(ap_rank);
+        Py_XDECREF(ap_S);
+        PyErr_SetString(PyExc_MemoryError, get_err_mesg("lstsq", lapack_driver, info).c_str());
+        return NULL;
+    }
+    PyObject *ret_lst = convert_vec_status(vec_status);
+    // with 'gelsy', we return None for `s`
+    PyObject *s_ret = ap_S != NULL ? PyArray_Return(ap_S) : Py_None;  // XXX incref None on python==3.11?
+
+    return Py_BuildValue("NNNN", PyArray_Return(ap_x), PyArray_Return(ap_rank), s_ret, ret_lst);
+}
+
+
 /*
  * Helper: convert a vector of slice error statuses to list of dicts
  */
@@ -348,14 +491,28 @@ convert_vec_status(SliceStatusVec& vec_status) {
 }
 
 
+/*
+ * Helper for fatal errors (memory errors, mostly).
+ */
+std::string
+get_err_mesg(const std::string routine, const std::string func_name, int info) {
+    std::string mesg;
+    mesg = "Memory error in scipy.linalg." + routine;
+    mesg += " (Internal " + func_name + " returned " + std::to_string(info) + ").";
+    return mesg;
+}
+
+
 static char doc_inv[] = ("Compute the matrix inverse.");
 static char doc_solve[] = ("Solve the linear system of equations.");
 static char doc_svd[] = ("SVD factorization.");
+static char doc_lstsq[] = ("linear least squares.");
 
 static struct PyMethodDef inv_module_methods[] = {
   {"_inv", _linalg_inv, METH_VARARGS, doc_inv},
   {"_solve", _linalg_solve, METH_VARARGS, doc_solve},
   {"_svd", _linalg_svd, METH_VARARGS, doc_svd},
+  {"_lstsq", _linalg_lstsq, METH_VARARGS, doc_lstsq},
   {NULL, NULL, 0, NULL}
 };
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -175,11 +175,49 @@ void BLAS_FUNC(dgesvd)(char *jobu, char *jobvt, CBLAS_INT *m, CBLAS_INT *n, doub
 void BLAS_FUNC(cgesvd)(char *jobu, char *jobvt, CBLAS_INT *m, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, float *s, npy_complex64 *u, CBLAS_INT *ldu, npy_complex64 *vt, CBLAS_INT *ldvt, npy_complex64 *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *info);
 void BLAS_FUNC(zgesvd)(char *jobu, char *jobvt, CBLAS_INT *m, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, double *s, npy_complex128 *u, CBLAS_INT *ldu, npy_complex128 *vt, CBLAS_INT *ldvt, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
 
+
 /* ?GESDD*/
 void BLAS_FUNC(sgesdd)(char *jobz, CBLAS_INT *m, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *s, float *u, CBLAS_INT *ldu, float *vt, CBLAS_INT *ldvt, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
 void BLAS_FUNC(dgesdd)(char *jobz, CBLAS_INT *m, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *s, double *u, CBLAS_INT *ldu, double *vt, CBLAS_INT *ldvt, double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
 void BLAS_FUNC(cgesdd)(char *jobz, CBLAS_INT *m, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, float *s, npy_complex64 *u, CBLAS_INT *ldu, npy_complex64 *vt, CBLAS_INT *ldvt, npy_complex64 *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *iwork, CBLAS_INT *info);
 void BLAS_FUNC(zgesdd)(char *jobz, CBLAS_INT *m, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, double *s, npy_complex128 *u, CBLAS_INT *ldu, npy_complex128 *vt, CBLAS_INT *ldvt, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *iwork, CBLAS_INT *info);
+
+
+/* ?GEQRF */
+void BLAS_FUNC(sgeqrf)(CBLAS_INT *m, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *tau, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dgeqrf)(CBLAS_INT *m, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *tau, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(cgeqrf)(CBLAS_INT *m, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, npy_complex64 *tau, npy_complex64 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(zgeqrf)(CBLAS_INT *m, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *tau, npy_complex128 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+
+
+/* ?GEQP3 */
+void BLAS_FUNC(sgeqp3)(CBLAS_INT *m, CBLAS_INT *n, float *a, CBLAS_INT *lda, CBLAS_INT *jpvt, float *tau, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dgeqp3)(CBLAS_INT *m, CBLAS_INT *n, double *a, CBLAS_INT *lda, CBLAS_INT *jpvt, double *tau, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(cgeqp3)(CBLAS_INT *m, CBLAS_INT *n, npy_complex64 *a, CBLAS_INT *lda, CBLAS_INT *jpvt, npy_complex64 *tau, npy_complex64 *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *info);
+void BLAS_FUNC(zgeqp3)(CBLAS_INT *m, CBLAS_INT *n, npy_complex128 *a, CBLAS_INT *lda, CBLAS_INT *jpvt, npy_complex128 *tau, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
+
+
+/* ?ORGQR, ?UNGQR */
+void BLAS_FUNC(sorgqr)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *k, float *a, CBLAS_INT *lda, float *tau, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dorgqr)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *k, double *a, CBLAS_INT *lda, double *tau, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(cungqr)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *k, npy_complex64 *a, CBLAS_INT *lda, npy_complex64 *tau, npy_complex64 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(zungqr)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *k, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *tau, npy_complex128 *work, CBLAS_INT *lwork, CBLAS_INT *info);
+
+
+
+/* ?GELSS*/
+void BLAS_FUNC(sgelss)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, float *s, float *rcond, CBLAS_INT *rank, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dgelss)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, double *s, double *rcond, CBLAS_INT *rank, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(cgelss)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a,  CBLAS_INT *lda, npy_complex64 *b,  CBLAS_INT *ldb, float *s,  float *rcond,  CBLAS_INT *rank, npy_complex64 *work,  CBLAS_INT *lwork, float *rwork,  CBLAS_INT *info);
+void BLAS_FUNC(zgelss)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *b, CBLAS_INT *ldb, double *s, double *rcond, CBLAS_INT *rank, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
+
+
+/* ?GELSD*/
+void BLAS_FUNC(sgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, float *s, float *rcond, CBLAS_INT *rank, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(dgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, double *s, double *rcond, CBLAS_INT *rank, double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(cgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, npy_complex64 *b, CBLAS_INT *ldb, float *s, float *rcond, CBLAS_INT *rank, npy_complex64 *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *iwork, CBLAS_INT *info);
+void BLAS_FUNC(zgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *b, CBLAS_INT *ldb, double *s, double *rcond, CBLAS_INT *rank, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, int *iwork, int *info);
+
 
 } // extern "C"
 
@@ -591,6 +629,83 @@ inline void call_gesdd(
 };
 
 
+
+
+#define GEN_GEQRF(PREFIX, TYPE) \
+inline void \
+geqrf(CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *tau, TYPE *work, CBLAS_INT *lwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## geqrf)(m, n, a, lda, tau, work, lwork, info); \
+};
+
+GEN_GEQRF(s, float)
+GEN_GEQRF(d, double)
+GEN_GEQRF(c, npy_complex64)
+GEN_GEQRF(z, npy_complex128)
+
+
+
+// NB: wrap {s-,d-}orgqr for reals and {c-,z-}ungqr for complex
+#define GEN_OR_UN_GQR(PREFIX, TYPE) \
+inline void \
+or_un_gqr(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *k, TYPE *a, CBLAS_INT *lda, TYPE *tau, TYPE *work, CBLAS_INT *lwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gqr)(m, n, k, a, lda, tau, work, lwork, info); \
+};
+
+GEN_OR_UN_GQR(sor, float)
+GEN_OR_UN_GQR(dor, double)
+GEN_OR_UN_GQR(cun, npy_complex64)
+GEN_OR_UN_GQR(zun, npy_complex128)
+
+
+
+// NB: s- and d- variants ignore the rwork argument (because LAPACK routines do not have it
+#define GEN_GELSS_SD(PREFIX, TYPE, RTYPE) \
+inline void \
+gelss(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gelss)(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, info); \
+};
+
+GEN_GELSS_SD(s, float, float)
+GEN_GELSS_SD(d, double, double)
+
+
+#define GEN_GELSS_CZ(PREFIX, TYPE, RTYPE) \
+inline void \
+gelss(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gelss)(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, rwork, info); \
+};
+
+GEN_GELSS_CZ(c, npy_complex64, float)
+GEN_GELSS_CZ(z, npy_complex128, double)
+
+
+//void BLAS_FUNC(sgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, float *s, float *rcond, CBLAS_INT *rank, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
+
+// NB: s- and d- variants ignore the rwork argument (because LAPACK routines do not have it
+#define GEN_GELSD_SD(PREFIX, TYPE, RTYPE) \
+inline void \
+gelsd(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gelsd)(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, iwork, info); \
+};
+
+GEN_GELSD_SD(s, float, float)
+GEN_GELSD_SD(d, double, double)
+
+
+#define GEN_GELSD_CZ(PREFIX, TYPE, RTYPE) \
+inline void \
+gelsd(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gelsd)(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, rwork, iwork, info); \
+};
+
+GEN_GELSD_CZ(c, npy_complex64, float)
+GEN_GELSD_CZ(z, npy_complex128, double)
 
 
 // Structure tags; python side maps assume_a strings to these values

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -670,7 +670,7 @@ GEN_OR_UN_GQR(zun, npy_complex128)
 // NB: s- and d- variants ignore the rwork argument (because LAPACK routines do not have it
 #define GEN_GELSS_SD(PREFIX, TYPE, RTYPE) \
 inline void \
-gelss(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+call_gelss(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## gelss)(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, info); \
 };
@@ -681,7 +681,7 @@ GEN_GELSS_SD(d, double, double)
 
 #define GEN_GELSS_CZ(PREFIX, TYPE, RTYPE) \
 inline void \
-gelss(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+call_gelss(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## gelss)(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, rwork, info); \
 };
@@ -693,7 +693,7 @@ GEN_GELSS_CZ(z, npy_complex128, double)
 // NB: s- and d- variants ignore the rwork argument (because LAPACK routines do not have it
 #define GEN_GELSD_SD(PREFIX, TYPE, RTYPE) \
 inline void \
-gelsd(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *info) \
+call_gelsd(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## gelsd)(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, iwork, info); \
 };
@@ -704,7 +704,7 @@ GEN_GELSD_SD(d, double, double)
 
 #define GEN_GELSD_CZ(PREFIX, TYPE, RTYPE) \
 inline void \
-gelsd(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *info) \
+call_gelsd(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *s, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## gelsd)(m, n, nrhs, a, lda, b, ldb, s, rcond, rank, work, lwork, rwork, iwork, info); \
 };
@@ -713,17 +713,10 @@ GEN_GELSD_CZ(c, npy_complex64, float)
 GEN_GELSD_CZ(z, npy_complex128, double)
 
 
-/*
-void sgelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, s *a, CBLAS_INT *lda, s *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, s *rcond, CBLAS_INT *rank, s *work, CBLAS_INT *lwork, CBLAS_INT *info);
-void dgelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, d *a, CBLAS_INT *lda, d *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, d *rcond, CBLAS_INT *rank, d *work, CBLAS_INT *lwork, CBLAS_INT *info);
-void cgelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, c *a, CBLAS_INT *lda, c *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, s *rcond, CBLAS_INT *rank, c *work, CBLAS_INT *lwork, s *rwork, CBLAS_IT *info);
-void zgelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, z *a, CBLAS_INT *lda, z *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, d *rcond, CBLAS_INT *rank, z *work, CBLAS_INT *lwork, d *rwork, CBLAS_INT *info);
-*/
-
 // NB: s- and d- variants ignore the rwork argument (because LAPACK routines do not have it
 #define GEN_GELSY_SD(PREFIX, TYPE, RTYPE) \
 inline void \
-gelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+call_gelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## gelsy)(m, n, nrhs, a, lda, b, ldb, jpvt, rcond, rank, work, lwork, info); \
 };
@@ -734,7 +727,7 @@ GEN_GELSY_SD(d, double, double)
 
 #define GEN_GELSY_CZ(PREFIX, TYPE, RTYPE) \
 inline void \
-gelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+call_gelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## gelsy)(m, n, nrhs, a, lda, b, ldb, jpvt, rcond, rank, work, lwork, rwork, info); \
 };

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -216,7 +216,14 @@ void BLAS_FUNC(zgelss)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex1
 void BLAS_FUNC(sgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, float *s, float *rcond, CBLAS_INT *rank, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
 void BLAS_FUNC(dgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, double *s, double *rcond, CBLAS_INT *rank, double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
 void BLAS_FUNC(cgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, npy_complex64 *b, CBLAS_INT *ldb, float *s, float *rcond, CBLAS_INT *rank, npy_complex64 *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *iwork, CBLAS_INT *info);
-void BLAS_FUNC(zgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *b, CBLAS_INT *ldb, double *s, double *rcond, CBLAS_INT *rank, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, int *iwork, int *info);
+void BLAS_FUNC(zgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *b, CBLAS_INT *ldb, double *s, double *rcond, CBLAS_INT *rank, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *iwork, CBLAS_INT *info);
+
+
+/* ?GELSY*/
+void BLAS_FUNC(sgelsy)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, float *rcond, CBLAS_INT *rank, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dgelsy)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, double *rcond, CBLAS_INT *rank, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(cgelsy)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex64 *a, CBLAS_INT *lda, npy_complex64 *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, float *rcond, CBLAS_INT *rank, npy_complex64 *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *info);
+void BLAS_FUNC(zgelsy)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, npy_complex128 *a, CBLAS_INT *lda, npy_complex128 *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, double *rcond, CBLAS_INT *rank, npy_complex128 *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
 
 
 } // extern "C"
@@ -683,8 +690,6 @@ GEN_GELSS_CZ(c, npy_complex64, float)
 GEN_GELSS_CZ(z, npy_complex128, double)
 
 
-//void BLAS_FUNC(sgelsd)(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, float *s, float *rcond, CBLAS_INT *rank, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *info);
-
 // NB: s- and d- variants ignore the rwork argument (because LAPACK routines do not have it
 #define GEN_GELSD_SD(PREFIX, TYPE, RTYPE) \
 inline void \
@@ -706,6 +711,39 @@ gelsd(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE
 
 GEN_GELSD_CZ(c, npy_complex64, float)
 GEN_GELSD_CZ(z, npy_complex128, double)
+
+
+/*
+void sgelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, s *a, CBLAS_INT *lda, s *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, s *rcond, CBLAS_INT *rank, s *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void dgelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, d *a, CBLAS_INT *lda, d *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, d *rcond, CBLAS_INT *rank, d *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void cgelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, c *a, CBLAS_INT *lda, c *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, s *rcond, CBLAS_INT *rank, c *work, CBLAS_INT *lwork, s *rwork, CBLAS_IT *info);
+void zgelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, z *a, CBLAS_INT *lda, z *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, d *rcond, CBLAS_INT *rank, z *work, CBLAS_INT *lwork, d *rwork, CBLAS_INT *info);
+*/
+
+// NB: s- and d- variants ignore the rwork argument (because LAPACK routines do not have it
+#define GEN_GELSY_SD(PREFIX, TYPE, RTYPE) \
+inline void \
+gelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gelsy)(m, n, nrhs, a, lda, b, ldb, jpvt, rcond, rank, work, lwork, info); \
+};
+
+GEN_GELSY_SD(s, float, float)
+GEN_GELSY_SD(d, double, double)
+
+
+#define GEN_GELSY_CZ(PREFIX, TYPE, RTYPE) \
+inline void \
+gelsy(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *nrhs, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, CBLAS_INT *jpvt, RTYPE *rcond, CBLAS_INT *rank, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gelsy)(m, n, nrhs, a, lda, b, ldb, jpvt, rcond, rank, work, lwork, rwork, info); \
+};
+
+GEN_GELSY_CZ(c, npy_complex64, float)
+GEN_GELSY_CZ(z, npy_complex128, double)
+
+
+
 
 
 // Structure tags; python side maps assume_a strings to these values
@@ -787,7 +825,7 @@ CBLAS_INT _calc_lwork(T _lwrk, double fudge_factor=1.0) {
         lwork = -1;
     }
     else {
-        lwork = (CBLAS_INT)value;
+        lwork = value > 0 ? (CBLAS_INT)value : 1;
     }
     return lwork;
 }
@@ -825,26 +863,40 @@ void copy_slice(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp m, 
 
 /*
  * Copy n-by-m C-order slice from slice_ptr to dst in F-order.
+ *
+ * `src` is n-by-m, strided
+ * `dst` is ldb-by-m, F-ordered.
+ *
+ * The default is to have src and dst of the same size (ldb=-1 means ldb=n).
  */
 template<typename T>
-void copy_slice_F(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp m, const npy_intp s2, const npy_intp s1) {
+void copy_slice_F(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp m, const npy_intp s2, const npy_intp s1, npy_intp ldb=-1) {
+
+    if (ldb == -1) {ldb = n;}
 
     for (npy_intp i = 0; i < n; i++) {
         for (npy_intp j = 0; j < m; j++) {
-            dst[i + j*n] = *(slice_ptr + (i*s2/sizeof(T)) + (j*s1/sizeof(T)));  // == src[i*m + j]
+            dst[i + j*ldb] = *(slice_ptr + (i*s2/sizeof(T)) + (j*s1/sizeof(T)));  // == src[i*m + j]
         }
     }
 }
 
 /*
  * Copy n-by-m F-ordered `src` to C-ordered `dst`.
+ *
+ * `src` is ldb-by-m, F-ordered
+ * `dst` is n-by-m, C-ordered
+ *
+ * The default is to have src and dst of the same size (ldb=-1 means ldb=n)
  */
 template<typename T>
-void copy_slice_F_to_C(T* dst, const T* src, const npy_intp n, const npy_intp m) {
+void copy_slice_F_to_C(T* dst, const T* src, const npy_intp n, const npy_intp m, npy_intp ldb=-1) {
+
+    if (ldb == -1) {ldb = n;}
 
     for (npy_intp i = 0; i < n; i++) {
         for (npy_intp j = 0; j < m; j++) {
-            dst[i*m + j] = src[i + j*n];
+            dst[i*m + j] = src[i + j*ldb];
         }
     }
 }

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -75,7 +75,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     T *work = &buffer[m*n + ldb*nrhs];
 
     real_type *rwork = NULL;
-    if (type_traits<T>::is_complex) {
+    if constexpr (type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -200,7 +200,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     T *work = &buffer[m*n + ldb*nrhs];
 
     real_type *rwork = NULL;
-    if (type_traits<T>::is_complex) {
+    if constexpr (type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(lrwork*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -224,7 +224,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
         T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
         copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
 
-        // copy the r.h.s, too; NB: gelss needs LDB=max(1, m, n)
+        // copy the r.h.s, too; NB: gelsd needs LDB=max(1, m, n)
         T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
         copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
 
@@ -325,7 +325,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     T *work = &buffer[m*n + ldb*nrhs];
 
     real_type *rwork = NULL;
-    if (type_traits<T>::is_complex) {
+    if constexpr (type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(2*n*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -368,12 +368,12 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
             goto done;
         }
 
-        // copy results from temp buffers (S is filled in-place already)
+        // copy results from temp buffers
         copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
         *ptr_rank = (npy_int64)rank;
         // XXX we discard the column residuals, b[n:]
 
-        // advance the output pointers: S, x and rank arrays are C-ordered by construction
+        // advance the output pointers: x and rank arrays are C-ordered by construction
         ptr_x += n*nrhs;
         ptr_rank += 1;
     }

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -1,0 +1,408 @@
+/*
+ * Templated loops for linalg.lstsq
+ */
+
+template<typename T>
+int
+_lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, SliceStatusVec& vec_status)
+{
+    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    SliceStatus slice_status;
+
+    // --------------------------------------------------------------------
+    // Input Array Attributes
+    // --------------------------------------------------------------------
+    T* Am_data = (T *)PyArray_DATA(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);              // Number of dimensions
+    npy_intp* shape = PyArray_SHAPE(ap_Am);      // Array shape
+    npy_intp m = shape[ndim - 2];                // Slice size
+    npy_intp n = shape[ndim - 1];
+    npy_intp* strides = PyArray_STRIDES(ap_Am);
+    // Get the number of slices to traverse if more than one; np.prod(shape[:-2])
+    npy_intp outer_size = 1;
+    if (ndim > 2)
+    {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
+    }
+
+    T *bm_data = (T *)PyArray_DATA(ap_b);
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+    npy_intp *strides_b = PyArray_STRIDES(ap_b);
+    npy_intp nrhs = PyArray_DIM(ap_b, ndim_b -1); // Number of right-hand-sides
+
+    // XXX: the call site ensured that
+    // 1. a.ndim == b.ndim
+    // 2. a.shape = batch_shape + (m, n), and
+    //    b.shape = batch_shape + (m, nrhs)
+    // so we are not checking this again.
+
+    // Outputs
+    real_type *ptr_S = (real_type *)PyArray_DATA(ap_S);
+    T *ptr_x = (T *)PyArray_DATA(ap_x);
+    npy_int64 *ptr_rank = (npy_int64 *)PyArray_DATA(ap_rank);
+
+    // --------------------------------------------------------------------
+    // Workspace computation and allocation
+    // --------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, int_nrhs = (CBLAS_INT)nrhs;
+    CBLAS_INT lwork = -1, info;
+    CBLAS_INT lda = intm > 1 ? intm : 1;
+
+    CBLAS_INT max_mn = intm > intn ? intm : intn;
+    CBLAS_INT min_mn = intm > intn ? intn : intm;
+    CBLAS_INT ldb = max_mn > 1 ? max_mn : 1;
+    real_type r_rcond = (real_type)rcond;
+    CBLAS_INT rank = min_mn;
+
+    // query LWORK
+    T tmp = numeric_limits<T>::zero;
+    gelss(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
+    if(info != 0) { return -100; }
+
+    lwork = _calc_lwork(tmp);
+    if (lwork < 0) {return -111;}
+
+    // allocate
+    npy_intp bufsize = m*n + ldb*nrhs + lwork;
+
+    T* buffer = (T *)malloc((bufsize)*sizeof(T));
+    if (NULL == buffer) { return -101; }
+
+    // Chop the buffer into parts
+    T* data = &buffer[0];
+    T *data_b = &buffer[m*n];
+    T *work = &buffer[m*n + ldb*nrhs];
+
+    real_type *rwork = NULL;
+    if (type_traits<T>::is_complex) {
+        rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
+
+        if (rwork == NULL) {
+            free(buffer);
+            return -102;
+        }
+    }
+
+    // Main loop to traverse the slices
+    for (npy_intp idx = 0; idx < outer_size; idx++){
+        init_status(slice_status, idx, St::GENERAL);
+
+        // copy the slice to `data` in F order
+        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+
+        // copy the r.h.s, too; NB: gelss needs LDB=max(1, m, n)
+        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
+        copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
+
+        // perform the least squares
+        gelss(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, &info);
+
+        if(info != 0) {
+            slice_status.lapack_info = (Py_ssize_t)info;
+            vec_status.push_back(slice_status);
+
+            // cut it short on error in any slice
+            goto done;
+        }
+
+        // copy results from temp buffers (S is filled in-place already)
+        copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
+        *ptr_rank = (npy_int64)rank;
+        // NB: we discard the column residuals, b[n:]
+
+        // advance the output pointers: S, x and rank arrays are C-ordered by construction
+        ptr_S += min_mn;
+        ptr_x += n*nrhs;
+        ptr_rank += 1;
+    }
+
+done:
+    free(buffer);
+    free(rwork);
+
+    return 1;
+}
+
+
+// XXX consider deduplicating _gelsd, gelss and gelss loops.
+
+template<typename T>
+int
+_lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, SliceStatusVec& vec_status)
+{
+    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    SliceStatus slice_status;
+
+    // --------------------------------------------------------------------
+    // Input Array Attributes
+    // --------------------------------------------------------------------
+    T* Am_data = (T *)PyArray_DATA(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);              // Number of dimensions
+    npy_intp* shape = PyArray_SHAPE(ap_Am);      // Array shape
+    npy_intp m = shape[ndim - 2];                // Slice size
+    npy_intp n = shape[ndim - 1];
+    npy_intp* strides = PyArray_STRIDES(ap_Am);
+    // Get the number of slices to traverse if more than one; np.prod(shape[:-2])
+    npy_intp outer_size = 1;
+    if (ndim > 2)
+    {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
+    }
+
+    T *bm_data = (T *)PyArray_DATA(ap_b);
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+    npy_intp *strides_b = PyArray_STRIDES(ap_b);
+    npy_intp nrhs = PyArray_DIM(ap_b, ndim_b -1); // Number of right-hand-sides
+
+    // Outputs
+    real_type *ptr_S = (real_type *)PyArray_DATA(ap_S);
+    T *ptr_x = (T *)PyArray_DATA(ap_x);
+    npy_int64 *ptr_rank = (npy_int64 *)PyArray_DATA(ap_rank);
+
+    // --------------------------------------------------------------------
+    // Workspace computation and allocation
+    // --------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, int_nrhs = (CBLAS_INT)nrhs;
+    CBLAS_INT lwork = -1, info;
+    CBLAS_INT lda = intm > 1 ? intm : 1;
+
+    CBLAS_INT max_mn = intm > intn ? intm : intn;
+    CBLAS_INT min_mn = intm > intn ? intn : intm;
+    CBLAS_INT ldb = max_mn > 1 ? max_mn : 1;
+    real_type r_rcond = (real_type)rcond;
+    CBLAS_INT rank = min_mn;
+
+    // query LWORK, LRWORK and LIWORK
+    // XXX: bump LRWORK and LIWORK up to improve perf? lwork=-1 query returns the *minimum* values
+    T tmp = numeric_limits<T>::zero;
+    real_type tmp_lrwork = 0;
+    CBLAS_INT liwork = 0, lrwork = 0;
+    gelsd(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, &tmp_lrwork, &liwork, &info);
+
+    if(info != 0) { return -100; }
+    lwork = _calc_lwork(tmp);
+    lrwork = type_traits<T>::is_complex ? _calc_lwork(tmp_lrwork) : 0 ; 
+
+    if ((lwork < 0) || (lrwork < 0) || (liwork < 0)) {return -111;}
+
+    // allocate
+    npy_intp bufsize = m*n + ldb*nrhs + lwork;
+
+    T* buffer = (T *)malloc((bufsize)*sizeof(T));
+    if (NULL == buffer) { return -101; }
+
+    // Chop the buffer into parts
+    T* data = &buffer[0];
+    T *data_b = &buffer[m*n];
+    T *work = &buffer[m*n + ldb*nrhs];
+
+    real_type *rwork = NULL;
+    if (type_traits<T>::is_complex) {
+        rwork = (real_type *)malloc(lrwork*sizeof(real_type));
+
+        if (rwork == NULL) {
+            free(buffer);
+            return -102;
+        }
+    }
+
+    CBLAS_INT *iwork = (CBLAS_INT *)malloc(liwork*sizeof(CBLAS_INT));
+    if (iwork == NULL) {
+        free(buffer);
+        free(rwork);
+        return -103;
+    }
+
+    // Main loop to traverse the slices
+    for (npy_intp idx = 0; idx < outer_size; idx++){
+        init_status(slice_status, idx, St::GENERAL);
+
+        // copy the slice to `data` in F order
+        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+
+        // copy the r.h.s, too; NB: gelss needs LDB=max(1, m, n)
+        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
+        copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
+
+        // perform the least squares
+        gelsd(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, iwork, &info);
+
+        if(info != 0) {
+            slice_status.lapack_info = (Py_ssize_t)info;
+            vec_status.push_back(slice_status);
+
+            // cut it short on error in any slice
+            goto done;
+        }
+
+        // copy results from temp buffers (S is filled in-place already)
+        copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
+        *ptr_rank = (npy_int64)rank;
+        // XXX we discard the column residuals, b[n:]
+
+        // advance the output pointers: S, x and rank arrays are C-ordered by construction
+        ptr_S += min_mn;
+        ptr_x += n*nrhs;
+        ptr_rank += 1;
+    }
+
+done:
+    free(buffer);
+    free(rwork);
+    free(iwork);
+    return 1;
+}
+
+
+
+template<typename T>
+int
+_lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, SliceStatusVec& vec_status)
+{
+    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    SliceStatus slice_status;
+
+    // --------------------------------------------------------------------
+    // Input Array Attributes
+    // --------------------------------------------------------------------
+    T* Am_data = (T *)PyArray_DATA(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);              // Number of dimensions
+    npy_intp* shape = PyArray_SHAPE(ap_Am);      // Array shape
+    npy_intp m = shape[ndim - 2];                // Slice size
+    npy_intp n = shape[ndim - 1];
+    npy_intp* strides = PyArray_STRIDES(ap_Am);
+    // Get the number of slices to traverse if more than one; np.prod(shape[:-2])
+    npy_intp outer_size = 1;
+    if (ndim > 2)
+    {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
+    }
+
+    T *bm_data = (T *)PyArray_DATA(ap_b);
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+    npy_intp *strides_b = PyArray_STRIDES(ap_b);
+    npy_intp nrhs = PyArray_DIM(ap_b, ndim_b -1); // Number of right-hand-sides
+
+    // Outputs
+    T *ptr_x = (T *)PyArray_DATA(ap_x);
+    npy_int64 *ptr_rank = (npy_int64 *)PyArray_DATA(ap_rank);
+
+    // --------------------------------------------------------------------
+    // Workspace computation and allocation
+    // --------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, int_nrhs = (CBLAS_INT)nrhs;
+    CBLAS_INT lwork = -1, info;
+    CBLAS_INT lda = intm > 1 ? intm : 1;
+
+    CBLAS_INT max_mn = intm > intn ? intm : intn;
+    CBLAS_INT min_mn = intm > intn ? intn : intm;
+    CBLAS_INT ldb = max_mn > 1 ? max_mn : 1;
+    real_type r_rcond = (real_type)rcond;
+    CBLAS_INT rank = min_mn;
+
+    // query LWORK
+    T tmp = numeric_limits<T>::zero;
+    gelsy(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
+    if(info != 0) { return -100; }
+
+    lwork = _calc_lwork(tmp);
+    if (lwork < 0) {return -111;}
+
+    // allocate
+    npy_intp bufsize = m*n + ldb*nrhs + lwork;
+
+    T* buffer = (T *)malloc((bufsize)*sizeof(T));
+    if (NULL == buffer) { return -101; }
+
+    // Chop the buffer into parts
+    T* data = &buffer[0];
+    T *data_b = &buffer[m*n];
+    T *work = &buffer[m*n + ldb*nrhs];
+
+    real_type *rwork = NULL;
+    if (type_traits<T>::is_complex) {
+        rwork = (real_type *)malloc(2*n*sizeof(real_type));
+
+        if (rwork == NULL) {
+            free(buffer);
+            return -102;
+        }
+    }
+
+    CBLAS_INT *jpvt = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
+    if (jpvt == NULL) {
+        free(buffer);
+        free(rwork);
+        return -103;
+    }
+    for(npy_intp i=0; i<n; i++) {jpvt[i] = 0;}
+
+
+    // Main loop to traverse the slices
+    for (npy_intp idx = 0; idx < outer_size; idx++){
+        init_status(slice_status, idx, St::GENERAL);
+
+        // copy the slice to `data` in F order
+        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+
+        // copy the r.h.s, too; NB: gelss needs LDB=max(1, m, n)
+        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
+        copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
+
+        for(npy_intp i=0; i<n; i++) {jpvt[i] = 0;}
+
+        // perform the least squares
+        gelsy(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, jpvt, &r_rcond, &rank, work, &lwork, rwork, &info);
+
+        if(info != 0) {
+            slice_status.lapack_info = (Py_ssize_t)info;
+            vec_status.push_back(slice_status);
+
+            // cut it short on error in any slice
+            goto done;
+        }
+
+        // copy results from temp buffers (S is filled in-place already)
+        copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
+        *ptr_rank = (npy_int64)rank;
+        // XXX we discard the column residuals, b[n:]
+
+        // advance the output pointers: S, x and rank arrays are C-ordered by construction
+        ptr_x += n*nrhs;
+        ptr_rank += 1;
+    }
+
+done:
+    free(buffer);
+    free(rwork);
+    free(jpvt);
+    return 1;
+}
+
+
+template<typename T>
+int
+_lstsq(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const char * lapack_driver, SliceStatusVec& vec_status)
+{
+    int info;
+    if (strcmp(lapack_driver, "gelss") == 0) {
+        info = _lstsq_gelss<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, vec_status);
+    }
+    else if (strcmp(lapack_driver, "gelsd") == 0) {
+        info = _lstsq_gelsd<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, vec_status);
+    }
+    else if (strcmp(lapack_driver, "gelsy") == 0) {
+        info = _lstsq_gelsy<T>(ap_Am, ap_b, ap_x, ap_rank, rcond, vec_status);
+    }
+    else {
+        // should have been validated at call site, really
+        info = -110;
+    }
+    return info;
+}

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -57,7 +57,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
 
     // query LWORK
     T tmp = numeric_limits<T>::zero;
-    gelss(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
+    call_gelss(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
     if(info != 0) { return -100; }
 
     lwork = _calc_lwork(tmp);
@@ -97,7 +97,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
         copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
 
         // perform the least squares
-        gelss(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, &info);
+        call_gelss(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;
@@ -180,7 +180,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     T tmp = numeric_limits<T>::zero;
     real_type tmp_lrwork = 0;
     CBLAS_INT liwork = 0, lrwork = 0;
-    gelsd(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, &tmp_lrwork, &liwork, &info);
+    call_gelsd(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, &tmp_lrwork, &liwork, &info);
 
     if(info != 0) { return -100; }
     lwork = _calc_lwork(tmp);
@@ -229,7 +229,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
         copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
 
         // perform the least squares
-        gelsd(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, iwork, &info);
+        call_gelsd(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, iwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;
@@ -307,7 +307,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
 
     // query LWORK
     T tmp = numeric_limits<T>::zero;
-    gelsy(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
+    call_gelsy(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
     if(info != 0) { return -100; }
 
     lwork = _calc_lwork(tmp);
@@ -358,7 +358,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
         for(npy_intp i=0; i<n; i++) {jpvt[i] = 0;}
 
         // perform the least squares
-        gelsy(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, jpvt, &r_rcond, &rank, work, &lwork, rwork, &info);
+        call_gelsy(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, jpvt, &r_rcond, &rank, work, &lwork, rwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1,3 +1,4 @@
+import math
 import itertools
 import warnings
 
@@ -1910,6 +1911,10 @@ class TestLstsq:
                                     atol=25 * _eps_cast(a1.dtype),
                                     err_msg=f"driver: {lapack_driver}")
 
+                    # as documented, residuals is empty for an underdetermined problem
+                    residuals = out[1]
+                    assert residuals.size == 0
+
     @pytest.mark.parametrize("dtype", REAL_DTYPES)
     @pytest.mark.parametrize("n", (20, 200))
     @pytest.mark.parametrize("lapack_driver", lapack_drivers)
@@ -2120,8 +2125,6 @@ class TestLstsq:
                                      [ 0.05  ,  0.05  ],
                                      [ 0.0875, -0.1   ]]]), atol=1e-15
         )
-
-        # TODO: add a batched dim of `a` 
 
     @pytest.mark.parametrize('driver', ['gelss', 'gelsy', 'gelsd'])
     def test_m_larger_than_n(self, driver):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2147,11 +2147,6 @@ class TestLstsq:
     @pytest.mark.parametrize('driver', ['gelss', 'gelsy', 'gelsd'])
     def test_residuals(self, driver):
         # assert the (quirky) behavior of the `residuals` return
-        # this is the backwards-compat part
-
-        if driver == 'gelsy':
-            pytest.xfail('driver="gelsy" does not return residuals')
-
         a = np.array([[1, 2], [4, 5], [3, 4]], dtype=float)
         b = np.array([1, 2, 3], dtype=float)
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Move the `lstsq` LAPACK wrappers from `apply_over_batch`-decorated f2py wrappers into a C loop. Is similar to https://github.com/scipy/scipy/pull/23919 --- is in fact on top of it, to simiplify rebasing.

The only technical (if somewhat annoying) difference relative to gh-23919 and previous "move a loop over a LAPACK call to C" PRs is that `lstsq` drivers need the rhs with non-trivial leading dimension. In main, this incurs a manual copy; in this PR there's some minor gymnastics to save said copy.
