### PR TITLE
ENH: spatial: Automatically promote a Rotation when composing with a RigidTransform

### DIFF
--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1210,6 +1210,31 @@ def test_composition_validation(xp):
         tf2 * tf4
 
 
+@make_xp_test_case(RigidTransform.__mul__, RigidTransform.__rmul__)
+def test_rotation_promotion(xp):
+    """Test that Rotation is promoted to RigidTransform in composition."""
+    atol = 1e-12
+    dtype = xpx.default_dtype(xp)
+    rng = np.random.default_rng(0)
+
+    t = xp.asarray(rng.normal(size=(3,)), dtype=dtype)
+    r1 = rotation_to_xp(Rotation.random(rng=rng), xp)
+    r2 = rotation_to_xp(Rotation.random(rng=rng), xp)
+    tf = RigidTransform.from_components(t, r2)
+
+    # RigidTransform * Rotation
+    result = tf * r1
+    expected = tf * RigidTransform.from_rotation(r1)
+    assert isinstance(result, RigidTransform)
+    xp_assert_close(result.as_matrix(), expected.as_matrix(), atol=atol)
+
+    # Rotation * RigidTransform
+    result = r1 * tf
+    expected = RigidTransform.from_rotation(r1) * tf
+    assert isinstance(result, RigidTransform)
+    xp_assert_close(result.as_matrix(), expected.as_matrix(), atol=atol)
+
+
 @make_xp_test_case(RigidTransform.concatenate)
 def test_concatenate_validation(xp):
     tf = RigidTransform.from_matrix(xp.eye(4))


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
This allows for composing Rotations and RigidTransforms directly, by automatically promoting Rotations when the two are composed with the `__mul__` operator.

```python
from scipy.spatial.transform import RigidTransform as Tf
from scipy.spatial.transform import Rotation as R

tf1 = Tf.identity()
r = R.identity()

# Instead of:
tf2 = Tf.from_rotation(r) * tf1

# We can now just write:
tf2 = r * tf1
```

#### Additional information
I would like to do something similar with automatically composing shape (..., 3) arrays to represent translations, but it's less clear what the operator should be in that instance (see some discussion in https://github.com/scipy/scipy/issues/19254). I think `__add__` makes the most sense, but we can defer that to a later discussion. 

@lucascolley @amacati FYI
