### PR TITLE
ENH: special.eval_jacobi() for n integer and alpha=-1 and beta=1 

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -73,6 +73,14 @@ cdef inline number_t eval_jacobi(double n, double alpha, double beta, number_t x
     cdef double a, b, c, d
     cdef number_t g
 
+    if alpha == -1 and beta == 1:
+        if n == 0:
+            return 1.0
+        elif n == 1:
+            return x-1
+        elif n > 1:
+            return ((n + 1) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, 1, x)
+
     d = xsf_binom(n+alpha, n)
     a = -n
     b = n + alpha + beta + 1
@@ -92,6 +100,8 @@ cdef inline double eval_jacobi_l(Py_ssize_t n, double alpha, double beta, double
         return 1.0
     elif n == 1:
         return 0.5*(2*(alpha+1)+(alpha+beta+2)*(x-1))
+    elif alpha == -1 and beta == 1:
+        return ((n + 1) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, 1, x)
     else:
         d = (alpha+beta+2)*(x - 1) / (2*(alpha+1))
         p = d + 1

--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -73,13 +73,13 @@ cdef inline number_t eval_jacobi(double n, double alpha, double beta, number_t x
     cdef double a, b, c, d
     cdef number_t g
 
-    if alpha == -1 and beta == 1:
+    if alpha == -1 and abs(beta) == 1:
         if n == 0:
             return 1.0
         elif n == 1:
-            return x-1
+            return 0.5 * (1.0 + beta) * (x - 1.0)
         elif n > 1:
-            return ((n + 1) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, 1, x)
+            return ((n + beta) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, beta, x)
 
     d = xsf_binom(n+alpha, n)
     a = -n
@@ -100,8 +100,8 @@ cdef inline double eval_jacobi_l(Py_ssize_t n, double alpha, double beta, double
         return 1.0
     elif n == 1:
         return 0.5*(2*(alpha+1)+(alpha+beta+2)*(x-1))
-    elif alpha == -1 and beta == 1:
-        return ((n + 1) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, 1, x)
+    elif alpha == -1 and abs(beta) == 1:
+        return ((n + beta) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, beta, x)
     else:
         d = (alpha+beta+2)*(x - 1) / (2*(alpha+1))
         p = d + 1

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -307,5 +307,61 @@ def test_jacobi_alpha_minus_one_beta_plus_one(n, expected):
     # gh-7001 - expected values were computed with mathematica
     x = np.linspace(-1.0, 1.0, 11)
     a, b = -1, 1  # alpha, beta
-    assert_allclose(_ufuncs.eval_jacobi(n, a, b, x), expected)
-    assert_allclose(_ufuncs.eval_jacobi(float(n), a, b, x), expected)
+    assert_allclose(_ufuncs.eval_jacobi(n, a, b, x), expected, rtol=1e-10, atol=1e-14)
+    assert_allclose(
+        _ufuncs.eval_jacobi(float(n), a, b, x), expected, rtol=1e-10, atol=1e-14
+    )
+
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        (0, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+        (1, [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
+        (2, [0.0, -0.09, -0.16, -0.21, -0.24, -0.25, -0.24, -0.21, -0.16, -0.09, 0.0]),
+        (
+            3,
+            [0.0, 0.144, 0.192, 0.168, 0.096, 0.0, -0.096, -0.168, -0.192, -0.144, 0.0],
+        ),
+        (
+            4,
+            [
+                0.0,
+                -0.1485,
+                -0.096,
+                0.0315,
+                0.144,
+                0.1875,
+                0.144,
+                0.0315,
+                -0.096,
+                -0.1485,
+                0.0,
+            ],
+        ),
+        (
+            5,
+            [
+                0.0,
+                0.10656,
+                -0.04608,
+                -0.15792,
+                -0.13056,
+                0.0,
+                0.13056,
+                0.15792,
+                0.04608,
+                -0.10656,
+                0.0,
+            ],
+        ),
+    ],
+)
+def test_jacobi_alpha_minus_one_beta_minus_one(n, expected):
+    # gh-7001 - expected values were computed with mathematica
+    x = np.linspace(-1.0, 1.0, 11)
+    a, b = -1, -1  # alpha, beta
+    assert_allclose(_ufuncs.eval_jacobi(n, a, b, x), expected, rtol=1e-10, atol=1e-14)
+    assert_allclose(
+        _ufuncs.eval_jacobi(float(n), a, b, x), expected, rtol=1e-10, atol=1e-14
+    )

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -273,3 +273,39 @@ def test_gegenbauer_nan(n, alpha, x):
     nan_gegenbauer = np.isnan(_ufuncs.eval_gegenbauer(n, alpha, x))
     nan_arg = np.any(np.isnan([n, alpha, x]))
     assert nan_gegenbauer == nan_arg
+
+@pytest.mark.parametrize(
+    "n, expected",
+    [
+        (0, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]),
+        (1, [-2.0, -1.8, -1.6, -1.4, -1.2, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0]),
+        (2, [3.0, 2.16, 1.44, 0.84, 0.36, 0.0, -0.24, -0.36, -0.36, -0.24, 0.0]),
+        (3, [-4.0, -1.98, -0.64, 0.14, 0.48, 0.5, 0.32, 0.06, -0.16, -0.22, 0.0]),
+        (
+            4,
+            [5.0, 1.332, -0.288, -0.658, -0.408, 0.0, 0.272, 0.282, 0.072, -0.148, 0.0],
+        ),
+        (
+            5,
+            [
+                -6.0,
+                -0.43308,
+                0.79104,
+                0.36876,
+                -0.21312,
+                -0.375,
+                -0.14208,
+                0.15804,
+                0.19776,
+                -0.04812,
+                0.0,
+            ],
+        ),
+    ],
+)
+def test_jacobi_alpha_minus_one_beta_plus_one(n, expected):
+    # gh-7001 - expected values were computed with mathematica
+    x = np.linspace(-1.0, 1.0, 11)
+    a, b = -1, 1  # alpha, beta
+    assert_allclose(_ufuncs.eval_jacobi(n, a, b, x), expected)
+    assert_allclose(_ufuncs.eval_jacobi(float(n), a, b, x), expected)


### PR DESCRIPTION
Reference #7001. Implements correct behavior for $alpha=-1$ and $|\beta|=1$

I have used (Szegö's Orthogonal Polynomials, formula 4.22.2)

$$
P_n^{(-1,\beta)}(x) = (n+\beta) \frac{x-1}{2n} P_{n-1}^{(1,\beta)}(x)
$$

<img width="760" height="80" alt="Screenshot 2026-01-12 at 8 03 38 PM" src="https://github.com/user-attachments/assets/c349730a-36aa-4df1-8f49-08336cfbbe08" />

----


Another proof for

$$
P_{n}^{(-1,1)}(x) = \frac{n+1}{2n} (x-1) P_{n-1}^{(1,1)} (x)
$$

Use $\frac{d}{dx} P_{n}^{(0,0)} (x) = \frac{n+1}{2} P_{n-1}^{(1,1)}(x)$
and $P_{n}^{(-1,1)}(x) = \frac{x-1}{n} \frac{d}{dx} P_{n}^{(0,0)} (x)$ 

Set $\alpha=\beta=0$ in

<img width="814" height="364" alt="Screenshot 2025-12-18 at 8 32 22 PM" src="https://github.com/user-attachments/assets/f53b816e-793b-4fe7-9bbe-13de34e0b4f8" />

Source: https://en.wikipedia.org/wiki/Jacobi_polynomials