### PR TITLE
MAINT: interpolate.NearestNDInterpolator: use `KDTree` instead of `cKDTree`

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -84,7 +84,7 @@ class GridData(Benchmark):
     def time_evaluation(self, n_grids, method):
         interpolate.griddata(self.points, self.values, (self.grid_x, self.grid_y),
                              method=method)
-        
+
 class GridDataPeakMem(Benchmark):
     """
     Benchmark based on https://github.com/scipy/scipy/issues/20357
@@ -100,17 +100,17 @@ class GridDataPeakMem(Benchmark):
 
         random_values = rng.random(num_nonzero, dtype=np.float32)
 
-        sparse_matrix = csr_matrix((random_values, (random_rows, random_cols)), 
+        sparse_matrix = csr_matrix((random_values, (random_rows, random_cols)),
                                    shape=shape, dtype=np.float32)
         sparse_matrix = sparse_matrix.toarray()
 
         self.coords = np.column_stack(np.nonzero(sparse_matrix))
         self.values = sparse_matrix[self.coords[:, 0], self.coords[:, 1]]
-        self.grid_x, self.grid_y = np.mgrid[0:sparse_matrix.shape[0], 
+        self.grid_x, self.grid_y = np.mgrid[0:sparse_matrix.shape[0],
                                             0:sparse_matrix.shape[1]]
 
     def peakmem_griddata(self):
-        interpolate.griddata(self.coords, self.values, (self.grid_x, self.grid_y), 
+        interpolate.griddata(self.coords, self.values, (self.grid_x, self.grid_y),
                              method='cubic')
 
 class Interpolate1d(Benchmark):
@@ -496,7 +496,7 @@ class CloughTocherInterpolatorValues(interpolate.CloughTocher2DInterpolator):
                 interpolate.CloughTocher2DInterpolator._preprocess_xi(self, *args)
             )
         return self.xi, self.interpolation_points_shape
-    
+
     def __call__(self, values):
         self._set_values(values)
         return super().__call__(self.xi)
@@ -543,3 +543,33 @@ class AAA(Benchmark):
         r.poles()
         r.residues()
         r.roots()
+
+
+class NearestNDInterpolator(Benchmark):
+    """
+    Benchmark NearestNDInterpolator.
+
+    Derived from the docstring example,
+    https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.NearestNDInterpolator.html
+    """
+    param_names = ['n_samples', 'grid']
+    params = [
+        [10, 100, 1000],
+        [50, 100, 500]
+    ]
+
+    def setup(self, n_samples, grid):
+        rng = np.random.default_rng(20191102)
+
+        self.x = x = rng.random(n_samples) - 0.5
+        self.y = y = rng.random(n_samples) - 0.5
+        self.z = np.hypot(x, y)
+
+        X = np.linspace(min(x), max(x), num=grid)
+        Y = np.linspace(min(y), max(y), num=grid)
+        self.X, self.Y = np.meshgrid(X, Y)
+
+    def time_nearest_ND_interpolator(self, n_samples, grid):
+           interp = interpolate.NearestNDInterpolator(
+               list(zip(self.x, self.y)), self.z)
+           interp(self.X, self.Y)

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -7,7 +7,7 @@ Convenience interface to N-D interpolation
 import numpy as np
 from ._interpnd import (LinearNDInterpolator, NDInterpolatorBase,
      CloughTocher2DInterpolator, _ndim_coords_from_arrays)
-from scipy.spatial import cKDTree
+from scipy.spatial import KDTree
 
 __all__ = ['griddata', 'NearestNDInterpolator', 'LinearNDInterpolator',
            'CloughTocher2DInterpolator']
@@ -38,7 +38,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
 
         .. versionadded:: 0.14.0
     tree_options : dict, optional
-        Options passed to the underlying ``cKDTree``.
+        Options passed to the underlying ``KDTree``.
 
         .. versionadded:: 0.17.0
 
@@ -57,7 +57,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
 
     Notes
     -----
-    Uses ``scipy.spatial.cKDTree``
+    Uses ``scipy.spatial.KDTree``
 
     .. note:: For data on a regular grid use `interpn` instead.
 
@@ -92,7 +92,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
                                     need_values=False)
         if tree_options is None:
             tree_options = dict()
-        self.tree = cKDTree(self.points, **tree_options)
+        self.tree = KDTree(self.points, **tree_options)
         self.values = np.asarray(y)
 
     def __call__(self, *args, **query_options):
@@ -107,14 +107,14 @@ class NearestNDInterpolator(NDInterpolatorBase):
             or x1 can be array-like of float with shape ``(..., ndim)``
         **query_options
             This allows ``eps``, ``p``, ``distance_upper_bound``, and ``workers``
-            being passed to the cKDTree's query function to be explicitly set.
-            See `scipy.spatial.cKDTree.query` for an overview of the different options.
+            being passed to the KDTree's query function to be explicitly set.
+            See `scipy.spatial.KDTree.query` for an overview of the different options.
 
             .. versionadded:: 1.12.0
 
         """
         # For the sake of enabling subclassing, NDInterpolatorBase._set_xi performs
-        # some operations which are not required by NearestNDInterpolator.__call__, 
+        # some operations which are not required by NearestNDInterpolator.__call__,
         # hence here we operate on xi directly, without calling a parent class function.
         xi = _ndim_coords_from_arrays(args, ndim=self.points.shape[1])
         xi = self._check_call_shape(xi)
@@ -133,7 +133,7 @@ class NearestNDInterpolator(NDInterpolatorBase):
         flattened_shape = xi_flat.shape
 
         # if distance_upper_bound is set to not be infinite,
-        # then we need to consider the case where cKDtree
+        # then we need to consider the case where KDtree
         # does not find any points within distance_upper_bound to return.
         # It marks those points as having infinte distance, which is what will be used
         # below to mask the array and return only the points that were deemed


### PR DESCRIPTION
according to the documentation (https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.html), cKDTree exists only for backwards compatibility and new code should use KDTree which has the same functionality.

Note that KDtree has a default value of leafsize=10, cKDTree has 16.
