### PR TITLE
MAINT: stats: apply `xp_capabilities(out_of_scope=True)` to several functions

### DIFF
--- a/scipy/stats/_crosstab.py
+++ b/scipy/stats/_crosstab.py
@@ -1,6 +1,7 @@
 import numpy as np
 from scipy.sparse import coo_matrix
 from scipy._lib._bunch import _make_tuple_bunch
+from scipy._lib._array_api import xp_capabilities
 
 
 CrosstabResult = _make_tuple_bunch(
@@ -8,6 +9,7 @@ CrosstabResult = _make_tuple_bunch(
 )
 
 
+@xp_capabilities(np_only=True)
 def crosstab(*args, levels=None, sparse=False):
     """
     Return table of counts for each possible unique combination in ``*args``.

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -175,7 +175,7 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8), *, axis=0):
     return Epps_Singleton_2sampResult(w, p)
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def poisson_means_test(k1, n1, k2, n2, *, diff=0, alternative='two-sided'):
     r"""
     Performs the Poisson means test, AKA the "E-test".
@@ -772,7 +772,7 @@ class SomersDResult:
     table: np.ndarray
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def somersd(x, y=None, alternative='two-sided'):
     r"""Calculates Somers' D, an asymmetric measure of ordinal association.
 
@@ -984,7 +984,7 @@ class BarnardExactResult:
     pvalue: float
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def barnard_exact(table, alternative="two-sided", pooled=True, n=32):
     r"""Perform a Barnard exact test on a 2x2 contingency table.
 
@@ -1256,7 +1256,7 @@ class BoschlooExactResult:
     pvalue: float
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def boschloo_exact(table, alternative="two-sided", n=32):
     r"""Perform Boschloo's exact test on a 2x2 contingency table.
 
@@ -1946,7 +1946,7 @@ def _tukey_hsd_iv(args, equal_var):
     return args
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def tukey_hsd(*args, equal_var=True):
     """Perform Tukey's HSD test for equality of means over multiple treatments.
 

--- a/scipy/stats/_mgc.py
+++ b/scipy/stats/_mgc.py
@@ -96,7 +96,7 @@ MGCResult = _make_tuple_bunch('MGCResult',
                               ['statistic', 'pvalue', 'mgc_dict'], [])
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
                          workers=1, is_twosamp=False, random_state=None):
     r"""Computes the Multiscale Graph Correlation (MGC) test statistic.

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -516,7 +516,7 @@ def _add_axis_labels_title(plot, xlabel, ylabel, title):
         pass
 
 
-@xp_capabilities(out_of_scope=True)
+@xp_capabilities(np_only=True)
 def probplot(x, sparams=(), dist='norm', fit=True, plot=None, rvalue=False):
     """
     Calculate quantiles for a probability plot, and optionally show the plot.
@@ -680,7 +680,7 @@ def probplot(x, sparams=(), dist='norm', fit=True, plot=None, rvalue=False):
         return osm, osr
 
 
-@xp_capabilities(out_of_scope=True)
+@xp_capabilities(np_only=True)
 def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
     """Calculate the shape parameter that maximizes the PPCC.
 
@@ -769,7 +769,7 @@ def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
                           args=(osm_uniform, osr, dist.ppf))
 
 
-@xp_capabilities(out_of_scope=True)
+@xp_capabilities(np_only=True)
 def ppcc_plot(x, a, b, dist='tukeylambda', plot=None, N=80):
     """Calculate and optionally plot probability plot correlation coefficient.
 
@@ -1502,7 +1502,7 @@ def _normplot(method, x, la, lb, plot=None, N=80):
     return lmbdas, ppcc
 
 
-@xp_capabilities(out_of_scope=True)
+@xp_capabilities(np_only=True)
 def boxcox_normplot(x, la, lb, plot=None, N=80):
     """Compute parameters for a Box-Cox normality plot, optionally show it.
 
@@ -1926,7 +1926,7 @@ def yeojohnson_normmax(x, brack=None):
         return optimize.fminbound(_neg_llf, lb, ub, args=(x,), xtol=tol_brent)
 
 
-@xp_capabilities(out_of_scope=True)
+@xp_capabilities(np_only=True)
 def yeojohnson_normplot(x, la, lb, plot=None, N=80):
     """Compute parameters for a Yeo-Johnson normality plot, optionally show it.
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -159,7 +159,7 @@ def bayes_mvs(data, alpha=0.90):
     return m_res, v_res, s_res
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def mvsdist(data):
     """
     'Frozen' distributions for mean, variance, and standard deviation of data.
@@ -516,7 +516,7 @@ def _add_axis_labels_title(plot, xlabel, ylabel, title):
         pass
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def probplot(x, sparams=(), dist='norm', fit=True, plot=None, rvalue=False):
     """
     Calculate quantiles for a probability plot, and optionally show the plot.
@@ -680,7 +680,7 @@ def probplot(x, sparams=(), dist='norm', fit=True, plot=None, rvalue=False):
         return osm, osr
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
     """Calculate the shape parameter that maximizes the PPCC.
 
@@ -769,7 +769,7 @@ def ppcc_max(x, brack=(0.0, 1.0), dist='tukeylambda'):
                           args=(osm_uniform, osr, dist.ppf))
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def ppcc_plot(x, a, b, dist='tukeylambda', plot=None, N=80):
     """Calculate and optionally plot probability plot correlation coefficient.
 
@@ -1502,7 +1502,7 @@ def _normplot(method, x, la, lb, plot=None, N=80):
     return lmbdas, ppcc
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def boxcox_normplot(x, la, lb, plot=None, N=80):
     """Compute parameters for a Box-Cox normality plot, optionally show it.
 
@@ -1926,7 +1926,7 @@ def yeojohnson_normmax(x, brack=None):
         return optimize.fminbound(_neg_llf, lb, ub, args=(x,), xtol=tol_brent)
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def yeojohnson_normplot(x, la, lb, plot=None, N=80):
     """Compute parameters for a Yeo-Johnson normality plot, optionally show it.
 

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -180,7 +180,7 @@ class DunnettResult:
         return self._ci
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 @_transition_to_rng('random_state', replace_doc=False)
 def dunnett(
     *samples: "npt.ArrayLike",  # noqa: D417

--- a/scipy/stats/_odds_ratio.py
+++ b/scipy/stats/_odds_ratio.py
@@ -4,6 +4,7 @@ from scipy.special import ndtri
 from scipy.optimize import brentq
 from ._discrete_distns import nchypergeom_fisher
 from ._common import ConfidenceInterval
+from scipy._lib._array_api import xp_capabilities
 
 
 def _sample_odds_ratio(table):
@@ -321,6 +322,7 @@ class OddsRatioResult:
         return ConfidenceInterval(low=ci[0], high=ci[1])
 
 
+@xp_capabilities(np_only=True)
 def odds_ratio(table, *, kind='conditional'):
     r"""
     Compute the odds ratio for a 2x2 contingency table.

--- a/scipy/stats/_page_trend_test.py
+++ b/scipy/stats/_page_trend_test.py
@@ -17,7 +17,7 @@ class PageTrendTestResult:
     method: str
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def page_trend_test(data, ranked=False, predicted_ranks=None, method='auto'):
     r"""
     Perform Page's Test, a measure of trend in observations between treatments.

--- a/scipy/stats/_relative_risk.py
+++ b/scipy/stats/_relative_risk.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import numpy as np
 from scipy.special import ndtri
 from ._common import ConfidenceInterval
+from scipy._lib._array_api import xp_capabilities
 
 
 def _validate_int(n, bound, name):
@@ -122,6 +123,7 @@ class RelativeRiskResult:
         return ConfidenceInterval(low=katz_lo, high=katz_hi)
 
 
+@xp_capabilities(np_only=True)
 def relative_risk(exposed_cases, exposed_total, control_cases, control_total):
     """
     Compute the relative risk (also known as the risk ratio).

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8063,7 +8063,7 @@ def _kstest_n_samples(kwargs):
     return 1 if (isinstance(cdf, str) or callable(cdf)) else 2
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=_kstest_n_samples,
                           n_outputs=4, result_to_tuple=_KstestResult_to_tuple)
 @_rename_parameter("mode", "method")

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1969,7 +1969,7 @@ def jarque_bera(x, *, axis=None):
 #####################################
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
                       axis=None):
     """Calculate the score at a given percentile of the input sequence.
@@ -2094,7 +2094,7 @@ def _compute_qth_percentile(sorted_, per, interpolation_method, axis):
     return np.add.reduce(sorted_[tuple(indexer)] * weights, axis=axis) / sumval
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def percentileofscore(a, score, kind='rank', nan_policy='propagate'):
     """Compute the percentile rank of a score relative to a list of scores.
 
@@ -3458,7 +3458,7 @@ def sigmaclip(a, low=4., high=4.):
     return SigmaclipResult(c, critlower, critupper)
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def trimboth(a, proportiontocut, axis=0):
     """Slice off a proportion of items from both ends of an array.
 
@@ -3545,7 +3545,7 @@ def trimboth(a, proportiontocut, axis=0):
     return atmp[tuple(sl)]
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def trim1(a, proportiontocut, tail='right', axis=0):
     """Slice off a proportion from ONE end of the passed array distribution.
 
@@ -5170,7 +5170,7 @@ def _untabulate(table):
     return np.concatenate(x), np.concatenate(y)
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def spearmanr(a, b=None, axis=0, nan_policy='propagate',
               alternative='two-sided'):
     r"""Calculate a Spearman correlation coefficient with associated p-value.
@@ -5750,7 +5750,7 @@ def _weightedtau_n_samples(kwargs):
     return 2 if (isinstance(rank, bool) or rank is None) else 3
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 @_axis_nan_policy_factory(_pack_CorrelationResult, default_axis=None,
                           n_samples=_weightedtau_n_samples,
                           result_to_tuple=_unpack_CorrelationResult, paired=True,
@@ -8063,7 +8063,7 @@ def _kstest_n_samples(kwargs):
     return 1 if (isinstance(cdf, str) or callable(cdf)) else 2
 
 
-@xp_capabilities(out_of_scope=True)
+@xp_capabilities(np_only=True)
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=_kstest_n_samples,
                           n_outputs=4, result_to_tuple=_KstestResult_to_tuple)
 @_rename_parameter("mode", "method")
@@ -8260,7 +8260,7 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', method='auto'):
                     _no_deco=True)
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def tiecorrect(rankvals):
     """Tie correction factor for Mann-Whitney U and Kruskal-Wallis H tests.
 
@@ -8309,7 +8309,7 @@ def tiecorrect(rankvals):
 RanksumsResult = namedtuple('RanksumsResult', ('statistic', 'pvalue'))
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 @_axis_nan_policy_factory(RanksumsResult, n_samples=2)
 def ranksums(x, y, alternative='two-sided'):
     """Compute the Wilcoxon rank-sum statistic for two samples.
@@ -9389,7 +9389,7 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided'):
 #####################################
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def wasserstein_distance_nd(u_values, v_values, u_weights=None, v_weights=None):
     r"""
     Compute the Wasserstein-1 distance between two N-D discrete distributions.

--- a/scipy/stats/_survival.py
+++ b/scipy/stats/_survival.py
@@ -250,7 +250,7 @@ def _iv_CensoredData(
     return sample
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def ecdf(sample: "npt.ArrayLike | CensoredData") -> ECDFResult:
     """Empirical cumulative distribution function of a sample.
 
@@ -485,7 +485,7 @@ class LogRankResult:
     pvalue: np.ndarray
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(out_of_scope=True)
 def logrank(
     x: "npt.ArrayLike | CensoredData",
     y: "npt.ArrayLike | CensoredData",


### PR DESCRIPTION
#### Reference issue
gh-20544
https://github.com/scipy/scipy/pull/23851#pullrequestreview-3546447808

#### What does this implement/fix?
This applies `xp_capabilities(out_of_scope=True)` to several stats functions. 

#### Additional information
Comments about particular functions inline.

There are a lot of contingency table functions that we might want to add array API support for, but I currently have no plans to adddress them in gh-20544. We (e.g. another motivated maintainer and I) would need to discuss whether we want to vectorize these. If not, it is probably not worth the effort to translate them to the array API.