### PR TITLE
MAINT: sparse.linalg: add `rng` argument to onenormest, expm_multiply, and expm

### DIFF
--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -41,7 +41,7 @@ def _trace(A):
         return A.trace()
 
 
-def traceest(A, m3, rng):
+def _traceest(A, *, m3, rng):
     """Estimate `np.trace(A)` using `3*m3` matrix-vector products.
 
     The result is not deterministic.
@@ -267,7 +267,7 @@ def _expm_multiply_simple(A, B, t=1.0, traceA=None, balance=False, rng=None):
                  " Provide `traceA` to ensure performance.", stacklevel=3)
         # m3=1 is bit arbitrary choice, a more accurate trace (larger m3) might
         # speed up exponential calculation, but trace estimation is more costly
-        traceA = traceest(A, m3=1, rng=rng) if is_linear_operator else _trace(A)
+        traceA = _traceest(A, m3=1, rng=rng) if is_linear_operator else _trace(A)
     mu = traceA / float(n)
     A = A - mu * ident
     A_1_norm = onenormest(A, rng=rng) if is_linear_operator else _exact_1_norm(A)
@@ -628,7 +628,7 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
         # m3=5 is bit arbitrary choice, a more accurate trace (larger m3) might
         # speed up exponential calculation, but trace estimation is also costly
         # an educated guess would need to consider the number of time points
-        traceA = traceest(A, m3=5, rng=rng) if is_linear_operator else _trace(A)
+        traceA = _traceest(A, m3=5, rng=rng) if is_linear_operator else _trace(A)
     mu = traceA / float(n)
 
     # Get the linspace samples, attempting to preserve the linspace defaults.

--- a/scipy/sparse/linalg/_expm_multiply.py
+++ b/scipy/sparse/linalg/_expm_multiply.py
@@ -7,7 +7,6 @@ import scipy.linalg
 import scipy.sparse.linalg
 from scipy.linalg._decomp_qr import qr
 from scipy.sparse._sputils import is_pydata_spmatrix
-from scipy.sparse.linalg import aslinearoperator
 from scipy.sparse.linalg._interface import IdentityOperator
 from scipy.sparse.linalg._onenormest import onenormest
 
@@ -42,7 +41,7 @@ def _trace(A):
         return A.trace()
 
 
-def traceest(A, m3, seed=None):
+def traceest(A, m3, rng):
     """Estimate `np.trace(A)` using `3*m3` matrix-vector products.
 
     The result is not deterministic.
@@ -54,9 +53,7 @@ def traceest(A, m3, seed=None):
     m3 : int
         Number of matrix-vector products divided by 3 used to estimate the
         trace.
-    seed : optional
-        Seed for `numpy.random.default_rng`.
-        Can be provided to obtain deterministic results.
+    rng : `numpy.random.Generator`
 
     Returns
     -------
@@ -76,7 +73,6 @@ def traceest(A, m3, seed=None):
        :doi:`10.1137/1.9781611976496.16`.
 
     """
-    rng = np.random.default_rng(seed)
     if len(A.shape) != 2 or A.shape[-1] != A.shape[-2]:
         raise ValueError("Expected A to be like a square matrix.")
     n = A.shape[-1]
@@ -106,17 +102,17 @@ def _ident_like(A):
         return np.eye(A.shape[0], A.shape[1], dtype=A.dtype)
 
 
-def expm_multiply(A, B, start=None, stop=None, num=None,
-                  endpoint=None, traceA=None):
-    """
-    Compute the action of the matrix exponential of A on B.
+def expm_multiply(A, B, start=None, stop=None, num=None, endpoint=None, traceA=None, *,
+                  rng=None):
+    r"""
+    Compute the action of the matrix exponential of `A` on `B`.
 
     Parameters
     ----------
     A : transposable linear operator
         The operator whose exponential is of interest.
     B : ndarray, sparse array
-        The matrix or vector to be multiplied by the matrix exponential of A.
+        The matrix or vector to be multiplied by the matrix exponential of `A`.
     start : scalar, optional
         The starting time point of the sequence.
     stop : scalar, optional
@@ -136,11 +132,17 @@ def expm_multiply(A, B, start=None, stop=None, num=None,
         as the estimation is not guaranteed to be reliable for all cases.
 
         .. versionadded:: 1.9.0
+    rng : `numpy.random.Generator`, optional
+        Pseudorandom number generator state. When `rng` is None, a new
+        `numpy.random.Generator` is created using entropy from the
+        operating system. Types other than `numpy.random.Generator` are
+        passed to `numpy.random.default_rng` to instantiate a ``Generator``.
+        If `rand` is ``False``, the argument is ignored.
 
     Returns
     -------
     expm_A_B : ndarray
-         The result of the action :math:`e^{t_k A} B`.
+         The result of the action :math:`\exp(t_k A) B`.
 
     Warns
     -----
@@ -152,18 +154,18 @@ def expm_multiply(A, B, start=None, stop=None, num=None,
     The optional arguments defining the sequence of evenly spaced time points
     are compatible with the arguments of `numpy.linspace`.
 
-    The output ndarray shape is somewhat complicated so I explain it here.
-    The ndim of the output could be either 1, 2, or 3.
-    It would be 1 if you are computing the expm action on a single vector
-    at a single time point.
-    It would be 2 if you are computing the expm action on a vector
-    at multiple time points, or if you are computing the expm action
-    on a matrix at a single time point.
-    It would be 3 if you want the action on a matrix with multiple
-    columns at multiple time points.
-    If multiple time points are requested, expm_A_B[0] will always
-    be the action of the expm at the first time point,
-    regardless of whether the action is on a vector or a matrix.
+    The output shape is somewhat complicated so it is explained here.
+    The number of dimensions of the output can be either 1, 2, or 3:
+
+    * It is 1D if you are computing the action on a single vector at a single time
+      point.
+    * It is 2D if you are computing the action on a vector at multiple time points,
+      or if you are computing the action on a matrix at a single time point.
+    * It is 3 if you are computing the action on a matrix with multiple columns at
+      multiple time points.
+
+    If multiple time points are requested, ``expm_A_B[0]`` will always be the action at
+    the first time point, regardless of whether the action is on a vector or a matrix.
 
     References
     ----------
@@ -203,15 +205,16 @@ def expm_multiply(A, B, start=None, stop=None, num=None,
     >>> expm(2*A).dot(B)                # Verify 3rd timestep
     array([ 2.71828183,  1.        ])
     """
+    rng = np.random.default_rng(rng)
     if all(arg is None for arg in (start, stop, num, endpoint)):
-        X = _expm_multiply_simple(A, B, traceA=traceA)
+        X = _expm_multiply_simple(A, B, traceA=traceA, rng=rng)
     else:
-        X, status = _expm_multiply_interval(A, B, start, stop, num,
-                                            endpoint, traceA=traceA)
+        X, status = _expm_multiply_interval(A, B, start, stop, num, endpoint,
+                                            traceA=traceA, rng=rng)
     return X
 
 
-def _expm_multiply_simple(A, B, t=1.0, traceA=None, balance=False):
+def _expm_multiply_simple(A, B, t=1.0, traceA=None, balance=False, rng=None):
     """
     Compute the action of the matrix exponential at a single time point.
 
@@ -264,10 +267,10 @@ def _expm_multiply_simple(A, B, t=1.0, traceA=None, balance=False):
                  " Provide `traceA` to ensure performance.", stacklevel=3)
         # m3=1 is bit arbitrary choice, a more accurate trace (larger m3) might
         # speed up exponential calculation, but trace estimation is more costly
-        traceA = traceest(A, m3=1) if is_linear_operator else _trace(A)
+        traceA = traceest(A, m3=1, rng=rng) if is_linear_operator else _trace(A)
     mu = traceA / float(n)
     A = A - mu * ident
-    A_1_norm = onenormest(A) if is_linear_operator else _exact_1_norm(A)
+    A_1_norm = onenormest(A, rng=rng) if is_linear_operator else _exact_1_norm(A)
     if t*A_1_norm == 0:
         m_star, s = 0, 1
     else:
@@ -350,49 +353,6 @@ _theta = {
         }
 
 
-def _onenormest_matrix_power(A, p,
-        t=2, itmax=5, compute_v=False, compute_w=False):
-    """
-    Efficiently estimate the 1-norm of A^p.
-
-    Parameters
-    ----------
-    A : ndarray
-        Matrix whose 1-norm of a power is to be computed.
-    p : int
-        Non-negative integer power.
-    t : int, optional
-        A positive parameter controlling the tradeoff between
-        accuracy versus time and memory usage.
-        Larger values take longer and use more memory
-        but give more accurate output.
-    itmax : int, optional
-        Use at most this many iterations.
-    compute_v : bool, optional
-        Request a norm-maximizing linear operator input vector if True.
-    compute_w : bool, optional
-        Request a norm-maximizing linear operator output vector if True.
-
-    Returns
-    -------
-    est : float
-        An underestimate of the 1-norm of the sparse matrix.
-    v : ndarray, optional
-        The vector such that ||Av||_1 == est*||v||_1.
-        It can be thought of as an input to the linear operator
-        that gives an output with particularly large norm.
-    w : ndarray, optional
-        The vector Av which has relatively large 1-norm.
-        It can be thought of as an output of the linear operator
-        that is relatively large in norm compared to the input.
-
-    """
-    #XXX Eventually turn this into an API function in the  _onenormest module,
-    #XXX and remove its underscore,
-    #XXX but wait until expm_multiply goes into scipy.
-    from scipy.sparse.linalg._onenormest import onenormest
-    return onenormest(aslinearoperator(A) ** p)
-
 class LazyOperatorNormInfo:
     """
     Information about an operator is lazily computed.
@@ -405,7 +365,7 @@ class LazyOperatorNormInfo:
 
     """
 
-    def __init__(self, A, A_1_norm=None, ell=2, scale=1):
+    def __init__(self, A, A_1_norm=None, ell=2, scale=1, rng=None):
         """
         Provide the operator and some norm-related information.
 
@@ -426,6 +386,7 @@ class LazyOperatorNormInfo:
         self._ell = ell
         self._d = {}
         self._scale = scale
+        self._rng = rng
 
     def set_scale(self,scale):
         """
@@ -447,7 +408,7 @@ class LazyOperatorNormInfo:
         where :math:`||.||` is the 1-norm.
         """
         if p not in self._d:
-            est = _onenormest_matrix_power(self._A, p, self._ell)
+            est = onenormest(self._A**p, rng=self._rng)
             self._d[p] = est ** (1.0 / p)
         return self._scale*self._d[p]
 
@@ -456,6 +417,7 @@ class LazyOperatorNormInfo:
         Lazily compute max(d(p), d(p+1)).
         """
         return max(self.d(p), self.d(p+1))
+
 
 def _compute_cost_div_m(m, p, norm_info):
     """
@@ -596,7 +558,7 @@ def _condition_3_13(A_1_norm, n0, m_max, ell):
 
 def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
                             endpoint=None, traceA=None, balance=False,
-                            status_only=False):
+                            status_only=False, rng=None):
     """
     Compute the action of the matrix exponential at multiple time points.
 
@@ -666,7 +628,7 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
         # m3=5 is bit arbitrary choice, a more accurate trace (larger m3) might
         # speed up exponential calculation, but trace estimation is also costly
         # an educated guess would need to consider the number of time points
-        traceA = traceest(A, m3=5) if is_linear_operator else _trace(A)
+        traceA = traceest(A, m3=5, rng=rng) if is_linear_operator else _trace(A)
     mu = traceA / float(n)
 
     # Get the linspace samples, attempting to preserve the linspace defaults.
@@ -693,7 +655,7 @@ def _expm_multiply_interval(A, B, start=None, stop=None, num=None,
     X = np.empty(X_shape, dtype=np.result_type(A.dtype, B.dtype, float))
     t = t_q - t_0
     A = A - mu * ident
-    A_1_norm = onenormest(A) if is_linear_operator else _exact_1_norm(A)
+    A_1_norm = onenormest(A, rng=rng) if is_linear_operator else _exact_1_norm(A)
     ell = 2
     norm_info = LazyOperatorNormInfo(t*A, A_1_norm=t*A_1_norm, ell=ell)
     if t*A_1_norm == 0:

--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -76,12 +76,13 @@ def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False, *, rng=None):
     >>> import numpy as np
     >>> from scipy.sparse import csc_array
     >>> from scipy.sparse.linalg import onenormest
+    >>> rng = np.random.default_rng()
     >>> A = csc_array([[1., 0., 0.], [5., 8., 2.], [0., -1., 0.]], dtype=float)
     >>> A.toarray()
     array([[ 1.,  0.,  0.],
            [ 5.,  8.,  2.],
            [ 0., -1.,  0.]])
-    >>> onenormest(A)
+    >>> onenormest(A, rng=rng)
     9.0
     >>> np.linalg.norm(A.toarray(), ord=1)
     9.0

--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -220,10 +220,6 @@ def resample_column(i, X, rng):
     X[:, i] = rng.integers(0, 2, size=X.shape[0])*2 - 1
 
 
-def less_than_or_close(a, b):
-    return np.allclose(a, b) or (a < b)
-
-
 def _onenormest_core(A, AT, t, itmax, rng):
     """
     Compute a lower bound of the 1-norm of a sparse array.

--- a/scipy/sparse/linalg/_onenormest.py
+++ b/scipy/sparse/linalg/_onenormest.py
@@ -18,7 +18,7 @@ def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False, *, rng=None):
         A linear operator that can be transposed and that can
         produce matrix products.
     t : int, optional
-        A positive parameter controlling the tradeoff between
+        A positive parameter controlling the trade-off between
         accuracy versus time and memory usage.
         Larger values take longer and use more memory
         but give more accurate output.
@@ -40,11 +40,11 @@ def onenormest(A, t=2, itmax=5, compute_v=False, compute_w=False, *, rng=None):
     est : float
         An underestimate of the 1-norm of the sparse array.
     v : ndarray, optional
-        The vector such that ||Av||_1 == est*||v||_1.
+        The vector such that ``||Av||_1 == est*||v||_1``.
         It can be thought of as an input to the linear operator
         that gives an output with particularly large norm.
     w : ndarray, optional
-        The vector Av which has relatively large 1-norm.
+        The vector ``Av`` which has relatively large 1-norm.
         It can be thought of as an output of the linear operator
         that is relatively large in norm compared to the input.
 

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -65,7 +65,7 @@ class TestExpmActionSimple:
             A = scipy.linalg.inv(rng.standard_normal((n, n)))
             B = rng.standard_normal((n, k))
             observed = expm_multiply(A, B, rng=rng)
-            expected = np.dot(sp_expm(A), B)
+            expected = np.dot(sp_expm(A, rng=rng), B)
             assert_allclose(observed, expected)
             with estimated_warns():
                 observed = expm_multiply(aslinearoperator(A), B, rng=rng)
@@ -82,7 +82,7 @@ class TestExpmActionSimple:
             A = scipy.linalg.inv(rng.standard_normal((n, n)))
             v = rng.standard_normal(n)
             observed = expm_multiply(A, v, rng=rng)
-            expected = np.dot(sp_expm(A), v)
+            expected = np.dot(sp_expm(A, rng=rng), v)
             assert_allclose(observed, expected)
             with estimated_warns():
                 observed = expm_multiply(aslinearoperator(A), v, rng=rng)
@@ -98,7 +98,7 @@ class TestExpmActionSimple:
                 A = scipy.linalg.inv(rng.standard_normal((n, n)))
                 B = rng.standard_normal((n, k))
                 observed = _expm_multiply_simple(A, B, t=t, rng=rng)
-                expected = np.dot(sp_expm(t*A), B)
+                expected = np.dot(sp_expm(t*A, rng=rng), B)
                 assert_allclose(observed, expected)
                 with estimated_warns():
                     observed = _expm_multiply_simple(aslinearoperator(A), B, t=t,
@@ -113,7 +113,7 @@ class TestExpmActionSimple:
         A = rng.standard_normal((n, n))
         B = rng.standard_normal((n, k))
         observed = _expm_multiply_simple(A, B, t=t, rng=rng)
-        expected = sp_expm(t*A).dot(B)
+        expected = sp_expm(t*A, rng=rng).dot(B)
         assert_allclose(observed, expected)
         with estimated_warns():
             observed = _expm_multiply_simple(aslinearoperator(A), B, t=t, rng=rng)
@@ -140,7 +140,7 @@ class TestExpmActionSimple:
                     "CSC matrix format",
                     SparseEfficiencyWarning,
                 )
-                expected = sp_expm(A).dot(B)
+                expected = sp_expm(A, rng=rng).dot(B)
             assert_allclose(observed, expected)
             with estimated_warns():
                 observed = expm_multiply(aslinearoperator(A), B, rng=rng)
@@ -194,7 +194,7 @@ class TestExpmActionInterval:
                         SparseEfficiencyWarning,
                     )
                     for solution, t in zip(X, samples):
-                        assert_allclose(solution, sp_expm(t*A).dot(target))
+                        assert_allclose(solution, sp_expm(t*A, rng=rng).dot(target))
 
     @pytest.mark.fail_slow(20)
     def test_expm_multiply_interval_vector(self):
@@ -206,7 +206,7 @@ class TestExpmActionInterval:
             samples = np.linspace(num=num, **interval)
             X = expm_multiply(A, v, num=num, rng=rng, **interval)
             for solution, t in zip(X, samples):
-                assert_allclose(solution, sp_expm(t*A).dot(v))
+                assert_allclose(solution, sp_expm(t*A, rng=rng).dot(v))
             # test for linear operator with unknown trace -> estimate trace
             with estimated_warns():
                 Xguess = expm_multiply(aslinearoperator(A), v, num=num, rng=rng,
@@ -219,7 +219,7 @@ class TestExpmActionInterval:
                                    traceA=np.trace(A)*5, rng=rng)
             for sol_guess, sol_given, sol_wrong, t in zip(Xguess, Xgiven,
                                                           Xwrong, samples):
-                correct = sp_expm(t*A).dot(v)
+                correct = sp_expm(t*A, rng=rng).dot(v)
                 assert_allclose(sol_guess, correct)
                 assert_allclose(sol_given, correct)
                 assert_allclose(sol_wrong, correct)
@@ -234,11 +234,11 @@ class TestExpmActionInterval:
             samples = np.linspace(num=num, **interval)
             X = expm_multiply(A, B, num=num, rng=rng, **interval)
             for solution, t in zip(X, samples):
-                assert_allclose(solution, sp_expm(t*A).dot(B))
+                assert_allclose(solution, sp_expm(t*A, rng=rng).dot(B))
             with estimated_warns():
                 X = expm_multiply(aslinearoperator(A), B, num=num, rng=rng, **interval)
             for solution, t in zip(X, samples):
-                assert_allclose(solution, sp_expm(t*A).dot(B))
+                assert_allclose(solution, sp_expm(t*A, rng=rng).dot(B))
 
     def test_sparse_expm_multiply_interval_dtypes(self):
         rng = np.random.default_rng(7489274932784)
@@ -304,7 +304,7 @@ class TestExpmActionInterval:
                 samples = np.linspace(start=start, stop=stop, num=num,
                                       endpoint=endpoint)
                 for solution, t in zip(X, samples):
-                    assert_allclose(solution, sp_expm(t*A).dot(B))
+                    assert_allclose(solution, sp_expm(t*A, rng=rng).dot(B))
                 nsuccesses += 1
         if not nsuccesses:
             msg = 'failed to find a status-' + str(target_status) + ' interval'
@@ -337,7 +337,7 @@ def test_expm_multiply_dtype(dtype_a, dtype_b, b_is_matrix):
     sol_mat = expm_multiply(A, B, rng=rng)
     with estimated_warns():
         sol_op = expm_multiply(aslinearoperator(A), B, rng=rng)
-    direct_sol = np.dot(sp_expm(A), B)
+    direct_sol = np.dot(sp_expm(A, rng=rng), B)
     assert_allclose_(sol_mat, direct_sol)
     assert_allclose_(sol_op, direct_sol)
     sol_op = expm_multiply(aslinearoperator(A), B, traceA=np.trace(A), rng=rng)
@@ -350,7 +350,7 @@ def test_expm_multiply_dtype(dtype_a, dtype_b, b_is_matrix):
     with estimated_warns():
         X_op = expm_multiply(aslinearoperator(A), B, **interval, rng=rng)
     for sol_mat, sol_op, t in zip(X_mat, X_op, samples):
-        direct_sol = sp_expm(t*A).dot(B)
+        direct_sol = sp_expm(t*A, rng=rng).dot(B)
         assert_allclose_(sol_mat, direct_sol)
         assert_allclose_(sol_op, direct_sol)
 

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -281,7 +281,7 @@ class TestExpmActionInterval:
         self._help_test_specific_expm_interval_status(2)
 
     def _help_test_specific_expm_interval_status(self, target_status):
-        rng = np.random.RandomState(1234)
+        rng = np.random.default_rng(1234)
         start = 0.1
         stop = 3.2
         num = 13

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -292,7 +292,7 @@ class TestExpmActionInterval:
         nsuccesses = 0
         for num in [14, 13, 2] * nrepeats:
             A = rng.randn(n, n)
-            B = rng.randn(n, k)
+            B = rng.random((n, k))
             status = _expm_multiply_interval(A, B,
                     start=start, stop=stop, num=num, endpoint=endpoint,
                     status_only=True, rng=rng)

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -291,7 +291,7 @@ class TestExpmActionInterval:
         nrepeats = 10
         nsuccesses = 0
         for num in [14, 13, 2] * nrepeats:
-            A = rng.randn(n, n)
+            A = rng.random((n, n))
             B = rng.random((n, k))
             status = _expm_multiply_interval(A, B,
                     start=start, stop=stop, num=num, endpoint=endpoint,

--- a/scipy/sparse/linalg/tests/test_matfuncs.py
+++ b/scipy/sparse/linalg/tests/test_matfuncs.py
@@ -84,31 +84,36 @@ def test_matrix_power():
 
 class TestExpM:
     def test_zero_ndarray(self):
+        rng = np.random.default_rng(2792478598247)
         a = array([[0.,0],[0,0]])
-        assert_array_almost_equal(expm(a),[[1,0],[0,1]])
+        assert_array_almost_equal(expm(a, rng=rng), [[1, 0], [0, 1]])
 
     def test_zero_sparse(self):
+        rng = np.random.default_rng(2792478598247)
         a = csc_array([[0.,0],[0,0]])
-        assert_array_almost_equal(expm(a).toarray(),[[1,0],[0,1]])
+        assert_array_almost_equal(expm(a, rng=rng).toarray(), [[1, 0], [0, 1]])
 
     def test_zero_matrix(self):
+        rng = np.random.default_rng(2792478598247)
         a = matrix([[0.,0],[0,0]])
-        assert_array_almost_equal(expm(a),[[1,0],[0,1]])
+        assert_array_almost_equal(expm(a, rng=rng), [[1, 0], [0, 1]])
 
     def test_misc_types(self):
-        A = expm(np.array([[1]]))
-        assert_allclose(expm(((1,),)), A)
-        assert_allclose(expm([[1]]), A)
-        assert_allclose(expm(matrix([[1]])), A)
-        assert_allclose(expm(np.array([[1]])), A)
-        assert_allclose(expm(csc_array([[1]])).toarray(), A)
-        B = expm(np.array([[1j]]))
-        assert_allclose(expm(((1j,),)), B)
-        assert_allclose(expm([[1j]]), B)
-        assert_allclose(expm(matrix([[1j]])), B)
-        assert_allclose(expm(csc_array([[1j]])).toarray(), B)
+        rng = np.random.default_rng(2792478598247)
+        A = expm(np.array([[1]]), rng=rng)
+        assert_allclose(expm(((1,),), rng=rng), A)
+        assert_allclose(expm([[1]], rng=rng), A)
+        assert_allclose(expm(matrix([[1]]), rng=rng), A)
+        assert_allclose(expm(np.array([[1]]), rng=rng), A)
+        assert_allclose(expm(csc_array([[1]]), rng=rng).toarray(), A)
+        B = expm(np.array([[1j]]), rng=rng)
+        assert_allclose(expm(((1j,),), rng=rng), B)
+        assert_allclose(expm([[1j]], rng=rng), B)
+        assert_allclose(expm(matrix([[1j]]), rng=rng), B)
+        assert_allclose(expm(csc_array([[1j]]), rng=rng).toarray(), B)
 
     def test_bidiagonal_sparse(self):
+        rng = np.random.default_rng(2792478598247)
         A = csc_array([
             [1, 3, 0],
             [0, 1, 5],
@@ -119,26 +124,29 @@ class TestExpM:
             [e1, 3*e1, 15*(e2 - 2*e1)],
             [0, e1, 5*(e2 - e1)],
             [0, 0, e2]], dtype=float)
-        observed = expm(A).toarray()
+        observed = expm(A, rng=rng).toarray()
         assert_array_almost_equal(observed, expected)
 
     def test_padecases_dtype_float(self):
+        rng = np.random.default_rng(2792478598247)
         for dtype in [np.float32, np.float64]:
             for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
                 A = scale * eye(3, dtype=dtype)
-                observed = expm(A)
+                observed = expm(A, rng=rng)
                 expected = exp(scale, dtype=dtype) * eye(3, dtype=dtype)
                 assert_array_almost_equal_nulp(observed, expected, nulp=100)
 
     def test_padecases_dtype_complex(self):
+        rng = np.random.default_rng(2792478598247)
         for dtype in [np.complex64, np.complex128]:
             for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
                 A = scale * eye(3, dtype=dtype)
-                observed = expm(A)
+                observed = expm(A, rng=rng)
                 expected = exp(scale, dtype=dtype) * eye(3, dtype=dtype)
                 assert_array_almost_equal_nulp(observed, expected, nulp=100)
 
     def test_padecases_dtype_sparse_float(self):
+        rng = np.random.default_rng(2792478598247)
         # float32 and complex64 lead to errors in spsolve/UMFpack
         dtype = np.float64
         for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
@@ -147,12 +155,13 @@ class TestExpM:
             with warnings.catch_warnings():
                 msg = "Changing the sparsity structure"
                 warnings.filterwarnings("ignore", msg, SparseEfficiencyWarning)
-                exact_onenorm = _expm(a, use_exact_onenorm=True).toarray()
-                inexact_onenorm = _expm(a, use_exact_onenorm=False).toarray()
+                exact_onenorm = _expm(a, use_exact_onenorm=True, rng=rng).toarray()
+                inexact_onenorm = _expm(a, use_exact_onenorm=False, rng=rng).toarray()
             assert_array_almost_equal_nulp(exact_onenorm, e, nulp=100)
             assert_array_almost_equal_nulp(inexact_onenorm, e, nulp=100)
 
     def test_padecases_dtype_sparse_complex(self):
+        rng = np.random.default_rng(2792478598247)
         # float32 and complex64 lead to errors in spsolve/UMFpack
         dtype = np.complex128
         for scale in [1e-2, 1e-1, 5e-1, 1, 10]:
@@ -161,9 +170,10 @@ class TestExpM:
             with warnings.catch_warnings():
                 msg = "Changing the sparsity structure"
                 warnings.filterwarnings("ignore", msg, SparseEfficiencyWarning)
-                assert_array_almost_equal_nulp(expm(a).toarray(), e, nulp=100)
+                assert_array_almost_equal_nulp(expm(a, rng=rng).toarray(), e, nulp=100)
 
     def test_logm_consistency(self):
+        rng = np.random.default_rng(2792478598247)
         random.seed(1234)
         for dtype in [np.float64, np.complex128]:
             for n in range(1, 10):
@@ -172,28 +182,31 @@ class TestExpM:
                     A = (eye(n) + random.rand(n, n) * scale).astype(dtype)
                     if np.iscomplexobj(A):
                         A = A + 1j * random.rand(n, n) * scale
-                    assert_array_almost_equal(expm(logm(A)), A)
+                    assert_array_almost_equal(expm(logm(A), rng=rng), A)
 
     def test_integer_matrix(self):
+        rng = np.random.default_rng(2792478598247)
         Q = np.array([
             [-3, 1, 1, 1],
             [1, -3, 1, 1],
             [1, 1, -3, 1],
             [1, 1, 1, -3]])
-        assert_allclose(expm(Q), expm(1.0 * Q))
+        assert_allclose(expm(Q, rng=rng), expm(1.0 * Q, rng=rng))
 
     def test_integer_matrix_2(self):
+        rng = np.random.default_rng(2792478598247)
         # Check for integer overflows
         Q = np.array([[-500, 500, 0, 0],
                       [0, -550, 360, 190],
                       [0, 630, -630, 0],
                       [0, 0, 0, 0]], dtype=np.int16)
-        assert_allclose(expm(Q), expm(1.0 * Q))
+        assert_allclose(expm(Q, rng=rng), expm(1.0 * Q, rng=rng))
 
         Q = csc_array(Q)
-        assert_allclose(expm(Q).toarray(), expm(1.0 * Q).toarray())
+        assert_allclose(expm(Q, rng=rng).toarray(), expm(1.0 * Q, rng=rng).toarray())
 
     def test_triangularity_perturbation(self):
+        rng = np.random.default_rng(2792478598247)
         # Experiment (1) of
         # Awad H. Al-Mohy and Nicholas J. Higham (2012)
         # Improved Inverse Scaling and Squaring Algorithms
@@ -214,7 +227,7 @@ class TestExpM:
             [0.00000000000000000e+00, 0.00000000000000000e+00,
              0.00000000000000000e+00, -1.17947533272554850e+00]],
             dtype=float)
-        assert_allclose(expm(A_logm), A, rtol=1e-4)
+        assert_allclose(expm(A_logm, rng=rng), A, rtol=1e-4)
 
         # Perturb the upper triangular matrix by tiny amounts,
         # so that it becomes technically not upper triangular.
@@ -226,12 +239,13 @@ class TestExpM:
             warnings.filterwarnings("ignore", "Ill-conditioned.*", RuntimeWarning)
             warnings.filterwarnings("ignore", "An ill-conditioned.*", RuntimeWarning)
 
-            A_expm_logm_perturbed = expm(A_logm_perturbed)
+            A_expm_logm_perturbed = expm(A_logm_perturbed, rng=rng)
         rtol = 1e-4
         atol = 100 * tiny
         assert_(not np.allclose(A_expm_logm_perturbed, A, rtol=rtol, atol=atol))
 
     def test_burkardt_1(self):
+        rng = np.random.default_rng(2792478598247)
         # This matrix is diagonal.
         # The calculation of the matrix exponential is simple.
         #
@@ -268,10 +282,11 @@ class TestExpM:
             [exp1, 0],
             [0, exp2],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_2(self):
+        rng = np.random.default_rng(2792478598247)
         # This matrix is symmetric.
         # The calculation of the matrix exponential is straightforward.
         A = np.array([
@@ -282,10 +297,11 @@ class TestExpM:
             [39.322809708033859, 46.166301438885753],
             [46.166301438885768, 54.711576854329110],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_3(self):
+        rng = np.random.default_rng(2792478598247)
         # This example is due to Laub.
         # This matrix is ill-suited for the Taylor series approach.
         # As powers of A are computed, the entries blow up too quickly.
@@ -303,10 +319,11 @@ class TestExpM:
                 39*np.expm1(-38) / (38*exp1),
                 -1/(38*exp1) + 39/(38*exp39)],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_4(self):
+        rng = np.random.default_rng(2792478598247)
         # This example is due to Moler and Van Loan.
         # The example will cause problems for the series summation approach,
         # as well as for diagonal Pade approximations.
@@ -318,10 +335,11 @@ class TestExpM:
         V = np.array([[1, -1/2], [-2, 3/2]], dtype=float)
         w = np.array([-17, -1], dtype=float)
         desired = np.dot(U * np.exp(w), V)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_5(self):
+        rng = np.random.default_rng(2792478598247)
         # This example is due to Moler and Van Loan.
         # This matrix is strictly upper triangular
         # All powers of A are zero beyond some (low) limit.
@@ -338,10 +356,11 @@ class TestExpM:
             [0, 0, 1, 6],
             [0, 0, 0, 1],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_6(self):
+        rng = np.random.default_rng(2792478598247)
         # This example is due to Moler and Van Loan.
         # This matrix does not have a complete set of eigenvectors.
         # That means the eigenvector approach will fail.
@@ -354,10 +373,11 @@ class TestExpM:
             [exp1, exp1],
             [0, exp1],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_7(self):
+        rng = np.random.default_rng(2792478598247)
         # This example is due to Moler and Van Loan.
         # This matrix is very close to example 5.
         # Mathematically, it has a complete set of eigenvectors.
@@ -372,10 +392,11 @@ class TestExpM:
             [exp1, exp1],
             [0, exp1],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_8(self):
+        rng = np.random.default_rng(2792478598247)
         # This matrix was an example in Wikipedia.
         exp4 = np.exp(4)
         exp16 = np.exp(16)
@@ -389,10 +410,11 @@ class TestExpM:
             [-9*exp16 + exp4, -9*exp16 + 5*exp4, -2*exp16 + 2*exp4],
             [16*exp16, 16*exp16, 4*exp16],
             ], dtype=float) * 0.25
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_9(self):
+        rng = np.random.default_rng(2792478598247)
         # This matrix is due to the NAG Library.
         # It is an example for function F01ECF.
         A = np.array([
@@ -407,10 +429,11 @@ class TestExpM:
             [823.7630, 679.4257, 603.5524, 610.8500],
             [998.4355, 823.7630, 731.2510, 740.7038],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_10(self):
+        rng = np.random.default_rng(2792478598247)
         # This is Ward's example #1.
         # It is defective and nonderogatory.
         A = np.array([
@@ -424,10 +447,11 @@ class TestExpM:
             [127.7810855231823, 183.7651386463682, 91.88256932318415],
             [127.7810855231824, 163.6796017231806, 111.9681062463718],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_11(self):
+        rng = np.random.default_rng(2792478598247)
         # This is Ward's example #2.
         # It is a symmetric matrix.
         A = np.array([
@@ -450,10 +474,11 @@ class TestExpM:
                 1.012918429302482E+17,
                 1.692944112408493E+17],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_12(self):
+        rng = np.random.default_rng(2792478598247)
         # This is Ward's example #3.
         # Ward's algorithm has difficulty estimating the accuracy
         # of its results.
@@ -468,7 +493,7 @@ class TestExpM:
             [-5.632570799891469, 1.471517758499875, 0.4060058435250609],
             [-4.934938326088363, 1.103638317328798, 0.5413411267617766],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_burkardt_13(self):
@@ -503,6 +528,7 @@ class TestExpM:
             assert_allclose(actual, desired)
 
     def test_burkardt_14(self):
+        rng = np.random.default_rng(2792478598247)
         # This is Moler's example.
         # This badly scaled matrix caused problems for MATLAB's expm().
         A = np.array([
@@ -515,10 +541,11 @@ class TestExpM:
             [-5743067.77947947, -0.0152830038686819, -4526542.71278401],
             [0.447722977849494, 1.54270484519591e-09, 0.463480648837651],
             ], dtype=float)
-        actual = expm(A)
+        actual = expm(A, rng=rng)
         assert_allclose(actual, desired)
 
     def test_pascal(self):
+        rng = np.random.default_rng(2792478598247)
         # Test pascal triangle.
         # Nilpotent exponential, used to trigger a failure (gh-8029)
 
@@ -529,7 +556,7 @@ class TestExpM:
                     break
 
                 A = np.diag(np.arange(1, n + 1), -1) * scale
-                B = expm(A)
+                B = expm(A, rng=rng)
 
                 got = B
                 expected = binom(np.arange(n + 1)[:,None],
@@ -538,19 +565,21 @@ class TestExpM:
                 assert_allclose(got, expected, atol=atol)
 
     def test_matrix_input(self):
+        rng = np.random.default_rng(2792478598247)
         # Large np.matrix inputs should work, gh-5546
         A = np.zeros((200, 200))
         A[-1,0] = 1
-        B0 = expm(A)
+        B0 = expm(A, rng=rng)
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore", "the matrix subclass.*", DeprecationWarning)
             warnings.filterwarnings(
                 "ignore", "the matrix subclass.*", PendingDeprecationWarning)
-            B = expm(np.matrix(A))
+            B = expm(np.matrix(A), rng=rng)
         assert_allclose(B, B0)
 
     def test_exp_sinch_overflow(self):
+        rng = np.random.default_rng(2792478598247)
         # Check overflow in intermediate steps is fixed (gh-11839)
         L = np.array([[1.0, -0.5, -0.5, 0.0, 0.0, 0.0, 0.0],
                       [0.0, 1.0, 0.0, -0.5, -0.5, 0.0, 0.0],
@@ -560,8 +589,8 @@ class TestExpM:
                       [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
                       [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]])
 
-        E0 = expm(-L)
-        E1 = expm(-2**11 * L)
+        E0 = expm(-L, rng=rng)
+        E1 = expm(-2**11 * L, rng=rng)
         E2 = E0
         for j in range(11):
             E2 = E2 @ E2

--- a/scipy/sparse/linalg/tests/test_onenormest.py
+++ b/scipy/sparse/linalg/tests/test_onenormest.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_allclose, assert_equal, assert_
 import pytest
 import scipy.linalg
 import scipy.sparse.linalg
-from scipy.sparse.linalg._onenormest import _onenormest_core, _algorithm_2_2
+from scipy.sparse.linalg._onenormest import _onenormest_core
 
 
 class MatrixProductOperator(scipy.sparse.linalg.LinearOperator):
@@ -44,7 +44,7 @@ class TestOnenormest:
     def test_onenormest_table_3_t_2(self):
         # This will take multiple seconds if your computer is slow like mine.
         # It is stochastic, so the tolerance could be too strict.
-        np.random.seed(1234)
+        rng = np.random.default_rng(1749823759)
         t = 2
         n = 100
         itmax = 5
@@ -55,7 +55,7 @@ class TestOnenormest:
         nresample_list = []
         for i in range(nsamples):
             A = scipy.linalg.inv(np.random.randn(n, n))
-            est, v, w, nmults, nresamples = _onenormest_core(A, A.T, t, itmax)
+            est, v, w, nmults, nresamples = _onenormest_core(A, A.T, t, itmax, rng)
             observed.append(est)
             expected.append(scipy.linalg.norm(A, 1))
             nmult_list.append(nmults)
@@ -84,7 +84,7 @@ class TestOnenormest:
     def test_onenormest_table_4_t_7(self):
         # This will take multiple seconds if your computer is slow like mine.
         # It is stochastic, so the tolerance could be too strict.
-        np.random.seed(1234)
+        rng = np.random.default_rng(289572975298)
         t = 7
         n = 100
         itmax = 5
@@ -95,7 +95,7 @@ class TestOnenormest:
         nresample_list = []
         for i in range(nsamples):
             A = np.random.randint(-1, 2, size=(n, n))
-            est, v, w, nmults, nresamples = _onenormest_core(A, A.T, t, itmax)
+            est, v, w, nmults, nresamples = _onenormest_core(A, A.T, t, itmax, rng)
             observed.append(est)
             expected.append(scipy.linalg.norm(A, 1))
             nmult_list.append(nmults)
@@ -121,6 +121,7 @@ class TestOnenormest:
 
     def test_onenormest_table_5_t_1(self):
         # "note that there is no randomness and hence only one estimate for t=1"
+        rng = np.random.default_rng(1894719874198)
         t = 1
         n = 100
         itmax = 5
@@ -130,14 +131,14 @@ class TestOnenormest:
         first_row = np.array([(-alpha)**i for i in range(n)])
         B = -scipy.linalg.toeplitz(first_col, first_row)
         assert_allclose(A, B)
-        est, v, w, nmults, nresamples = _onenormest_core(B, B.T, t, itmax)
+        est, v, w, nmults, nresamples = _onenormest_core(B, B.T, t, itmax, rng)
         exact_value = scipy.linalg.norm(B, 1)
         underest_ratio = est / exact_value
         assert_allclose(underest_ratio, 0.05, rtol=1e-4)
         assert_equal(nmults, 11)
         assert_equal(nresamples, 0)
         # check the non-underscored version of onenormest
-        est_plain = scipy.sparse.linalg.onenormest(B, t=t, itmax=itmax)
+        est_plain = scipy.sparse.linalg.onenormest(B, t=t, itmax=itmax, rng=rng)
         assert_allclose(est, est_plain)
 
     @pytest.mark.xslow
@@ -147,7 +148,7 @@ class TestOnenormest:
         #TODO complex numbers in the one-norm estimation.
         # This will take multiple seconds if your computer is slow like mine.
         # It is stochastic, so the tolerance could be too strict.
-        np.random.seed(1234)
+        rng = np.random.default_rng(789237923735932)
         t = 2
         n = 100
         itmax = 5
@@ -159,7 +160,7 @@ class TestOnenormest:
         for i in range(nsamples):
             A_inv = np.random.rand(n, n) + 1j * np.random.rand(n, n)
             A = scipy.linalg.inv(A_inv)
-            est, v, w, nmults, nresamples = _onenormest_core(A, A.T, t, itmax)
+            est, v, w, nmults, nresamples = _onenormest_core(A, A.T, t, itmax, rng)
             observed.append(est)
             expected.append(scipy.linalg.norm(A, 1))
             nmult_list.append(nmults)
@@ -191,12 +192,12 @@ class TestOnenormest:
         C = np.dot(A, B)
         return scipy.linalg.norm(C, 1)
 
-    def _help_product_norm_fast(self, A, B):
+    def _help_product_norm_fast(self, A, B, rng):
         # for profiling
         t = 2
         itmax = 5
         D = MatrixProductOperator(A, B)
-        est, v, w, nmults, nresamples = _onenormest_core(D, D.T, t, itmax)
+        est, v, w, nmults, nresamples = _onenormest_core(D, D.T, t, itmax, rng)
         return est
 
     @pytest.mark.slow
@@ -206,12 +207,12 @@ class TestOnenormest:
         # it could be easy to multiply this product by a small matrix,
         # but it could be annoying to look at all of
         # the entries of the product explicitly.
-        np.random.seed(1234)
+        rng = np.random.default_rng(7982374927359287359)
         n = 6000
         k = 3
         A = np.random.randn(n, k)
         B = np.random.randn(k, n)
-        fast_estimate = self._help_product_norm_fast(A, B)
+        fast_estimate = self._help_product_norm_fast(A, B, rng)
         exact_value = self._help_product_norm_slow(A, B)
         assert_(fast_estimate <= exact_value <= 3*fast_estimate,
                 f'fast: {fast_estimate:g}\nexact:{exact_value:g}')
@@ -228,25 +229,3 @@ class TestOnenormest:
         assert_allclose(s1, s0, rtol=1e-9)
         assert_allclose(np.linalg.norm(A.dot(v), 1), s0*np.linalg.norm(v, 1), rtol=1e-9)
         assert_allclose(A.dot(v), w, rtol=1e-9)
-
-
-class TestAlgorithm_2_2:
-
-    @pytest.mark.thread_unsafe(reason="Fails in parallel for unknown reasons")
-    def test_randn_inv(self):
-        rng = np.random.RandomState(1234)
-        n = 20
-        nsamples = 100
-        for i in range(nsamples):
-
-            # Choose integer t uniformly between 1 and 3 inclusive.
-            t = rng.randint(1, 4)
-
-            # Choose n uniformly between 10 and 40 inclusive.
-            n = rng.randint(10, 41)
-
-            # Sample the inverse of a matrix with random normal entries.
-            A = scipy.linalg.inv(rng.randn(n, n))
-
-            # Compute the 1-norm bounds.
-            g, ind = _algorithm_2_2(A, A.T, t)

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -228,9 +228,10 @@ def test_inv(matrices):
 
 
 def test_expm(matrices):
+    rng = np.random.default_rng(2842387598417907)
     A_dense, A_sparse, b = matrices
-    x0 = splin.expm(sp.csc_array(A_dense))
-    x = splin.expm(A_sparse)
+    x0 = splin.expm(sp.csc_array(A_dense), rng=rng)
+    x = splin.expm(A_sparse, rng=rng)
     assert_allclose(x.todense(), x0.todense())
 
 

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -206,9 +206,10 @@ def test_spsolve_triangular(matrices):
 
 
 def test_onenormest(matrices):
+    rng = np.random.default_rng(827592875982)
     A_dense, A_sparse, b = matrices
-    est0 = splin.onenormest(A_dense)
-    est = splin.onenormest(A_sparse)
+    est0 = splin.onenormest(A_dense, rng=rng)
+    est = splin.onenormest(A_sparse, rng=rng)
     assert_allclose(est, est0)
 
 
@@ -234,9 +235,10 @@ def test_expm(matrices):
 
 
 def test_expm_multiply(matrices):
+    rng = np.random.default_rng(2842387598417907)
     A_dense, A_sparse, b = matrices
-    x0 = splin.expm_multiply(A_dense, b)
-    x = splin.expm_multiply(A_sparse, b)
+    x0 = splin.expm_multiply(A_dense, b, rng=rng)
+    x = splin.expm_multiply(A_sparse, b, rng=rng)
     assert_allclose(x, x0)
 
     x0 = splin.expm_multiply(A_dense, A_dense)

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -203,28 +203,30 @@ def test_inv(B):
 
 @parametrize_square_sparrays
 def test_expm(B):
+    rng = np.random.default_rng(2842387598417907)
     if B.__class__.__name__[:3] != 'csc':
         return
 
     Bmat = scipy.sparse.csc_matrix(B)
 
-    C = spla.expm(B)
+    C = spla.expm(B, rng=rng)
 
     assert isinstance(C, scipy.sparse.sparray)
     npt.assert_allclose(
         C.todense(),
-        spla.expm(Bmat).todense()
+        spla.expm(Bmat, rng=rng).todense()
     )
 
 
 @parametrize_square_sparrays
 def test_expm_multiply(B):
+    rng = np.random.default_rng(2842387598417907)
     if B.__class__.__name__[:3] != 'csc':
         return
 
     npt.assert_allclose(
-        spla.expm_multiply(B, np.array([1, 2])),
-        spla.expm(B) @ [1, 2]
+        spla.expm_multiply(B, np.array([1, 2]), rng=rng),
+        spla.expm(B, rng=rng) @ [1, 2]
     )
 
 

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -238,7 +238,8 @@ def test_norm(A):
 
 @parametrize_square_sparrays
 def test_onenormest(B):
-    C = spla.onenormest(B)
+    rng = np.random.default_rng(2842387598417907)
+    C = spla.onenormest(B, rng=rng)
     npt.assert_allclose(C, np.linalg.norm(B.todense(), 1))
 
 

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -1244,6 +1244,7 @@ class _TestCommon:
         assert_equal(dat_mean.dtype, datsp_mean.dtype)
 
     def test_expm(self):
+        rng = np.random.default_rng(2842387598417907)
         M = array([[1, 0, 2], [0, 0, 3], [-4, 5, 6]], float)
         sM = self.spcreator(M, shape=(3,3), dtype=float)
         Mexp = scipy.linalg.expm(M)
@@ -1268,8 +1269,8 @@ class _TestCommon:
                 "spsolve requires A be CSC or CSR matrix format",
                 SparseEfficiencyWarning,
             )
-            sMexp = expm(sM).toarray()
-            sNexp = expm(sN).toarray()
+            sMexp = expm(sM, rng=rng).toarray()
+            sNexp = expm(sN, rng=rng).toarray()
 
         assert_array_almost_equal((sMexp - Mexp), zeros((3, 3)))
         assert_array_almost_equal((sNexp - Nexp), zeros((3, 3)))


### PR DESCRIPTION
closes #24188

Both these functions were missing a `rng` argument to control their randomness. Closes the above issue as by documenting the `rng` argument it is clear the function is not deterministic.

Various other additional cleanups