### PR TITLE
ENH: signal.square: add array api support

### DIFF
--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -515,7 +515,7 @@ def spline_filter_signature(Iin, lmbda=5.0):
 
 
 def square_signature(t, duty=0.5):
-    return array_namespace(t)
+    return array_namespace(t, duty)
 
 
 def ss2tf_signature(A, B, C, D, input=0):

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -96,7 +96,6 @@ untested = {
     "place_pols",
     "sawtooth",
     "sepfir2d",
-    "square",
     "ss2tf",
     "ss2zpk",
     "step",

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -135,6 +135,7 @@ def square(t, duty=0.5):
     """
     xp = array_namespace(t, duty)
     t, w = xp_promote(t, duty, xp=xp)
+    t, w = xp.broadcast_arrays(t, w)
 
     y = xp.zeros(t.shape, dtype=xp.float64)
 
@@ -147,8 +148,6 @@ def square(t, duty=0.5):
     mask2 = ~mask1 & (tmod < w*2*xp.pi)
     y = xpx.at(y, mask2).set(1)
 
-    # on the interval duty*2*pi to 2*pi function is
-    #  (pi*(w+1)-tmod) / (pi*(1-w))
     mask3 = ~mask1 & ~mask2
     y = xpx.at(y, mask3).set(-1)
     return y

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -148,6 +148,7 @@ def square(t, duty=0.5):
     mask2 = ~mask1 & (tmod < w*2*xp.pi)
     y = xpx.at(y, mask2).set(1)
 
+    # on the interval duty*2*pi to 2*pi function is -1
     mask3 = ~mask1 & ~mask2
     y = xpx.at(y, mask3).set(-1)
     return y

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -148,7 +148,7 @@ def square(t, duty=0.5):
     y = xpx.at(y, mask2).set(1)
 
     # on the interval duty*2*pi to 2*pi function is -1
-    mask3 = ~mask1 & ~mask2
+    mask3 = ~(mask1 | mask2)
     y = xpx.at(y, mask3).set(-1)
     return y
 

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -8,6 +8,9 @@ import numpy as np
 from numpy import asarray, zeros, place, nan, mod, pi, extract, log, sqrt, \
     exp, cos, sin, polyval, polyint
 
+from scipy._lib._array_api import array_namespace, xp_promote
+import scipy._lib.array_api_extra as xpx
+
 
 __all__ = ['sawtooth', 'square', 'gausspulse', 'chirp', 'sweep_poly',
            'unit_impulse']
@@ -87,7 +90,7 @@ def square(t, duty=0.5):
 
     The square wave has a period ``2*pi``, has value +1 from 0 to
     ``2*pi*duty`` and -1 from ``2*pi*duty`` to ``2*pi``. `duty` must be in
-    the interval [0,1].
+    the interval ``[0,1]``.
 
     Note that this is not band-limited.  It produces an infinite number
     of harmonics, which are aliased back and forth across the frequency
@@ -130,24 +133,24 @@ def square(t, duty=0.5):
     >>> plt.ylim(-1.5, 1.5)
 
     """
-    t, w = asarray(t), asarray(duty)
-    w = asarray(w + (t - t))
-    t = asarray(t + (w - w))
-    y = zeros(t.shape, dtype="d")
+    xp = array_namespace(t, duty)
+    t, w = xp_promote(t, duty, xp=xp)
+
+    y = xp.zeros(t.shape, dtype=xp.float64)
 
     # width must be between 0 and 1 inclusive
     mask1 = (w > 1) | (w < 0)
-    place(y, mask1, nan)
+    y = xpx.at(y, mask1).set(xp.nan)
 
     # on the interval 0 to duty*2*pi function is 1
-    tmod = mod(t, 2 * pi)
-    mask2 = (1 - mask1) & (tmod < w * 2 * pi)
-    place(y, mask2, 1)
+    tmod = t % (2 * xp.pi)
+    mask2 = ~mask1 & (tmod < w * 2 * pi)
+    y = xpx.at(y, mask2).set(1)
 
     # on the interval duty*2*pi to 2*pi function is
     #  (pi*(w+1)-tmod) / (pi*(1-w))
-    mask3 = (1 - mask1) & (1 - mask2)
-    place(y, mask3, -1)
+    mask3 = ~mask1 & ~mask2
+    y = xpx.at(y, mask3).set(-1)
     return y
 
 

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -144,7 +144,7 @@ def square(t, duty=0.5):
 
     # on the interval 0 to duty*2*pi function is 1
     tmod = t % (2 * xp.pi)
-    mask2 = ~mask1 & (tmod < w * 2 * pi)
+    mask2 = ~mask1 & (tmod < w*2*xp.pi)
     y = xpx.at(y, mask2).set(1)
 
     # on the interval duty*2*pi to 2*pi function is

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -134,8 +134,7 @@ def square(t, duty=0.5):
 
     """
     xp = array_namespace(t, duty)
-    t, w = xp_promote(t, duty, xp=xp, force_floating=True)
-    t, w = xp.broadcast_arrays(t, w)
+    t, w = xp_promote(t, duty, xp=xp, force_floating=True, broadcast=True)
 
     y = xp.zeros(t.shape, dtype=t.dtype)
 

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -134,10 +134,10 @@ def square(t, duty=0.5):
 
     """
     xp = array_namespace(t, duty)
-    t, w = xp_promote(t, duty, xp=xp)
+    t, w = xp_promote(t, duty, xp=xp, force_floating=True)
     t, w = xp.broadcast_arrays(t, w)
 
-    y = xp.zeros(t.shape, dtype=xp.float64)
+    y = xp.zeros(t.shape, dtype=t.dtype)
 
     # width must be between 0 and 1 inclusive
     mask1 = (w > 1) | (w < 0)

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -404,13 +404,14 @@ class TestSquareWaveform:
         assert set(unique).issubset({-1.0, 1.0})
 
     @pytest.mark.xfail_xp_backends("cupy", reason="cupy/cupy/issues/9541")
-    def test_dtype(self, xp):
-        waveform = square(xp.asarray(1, dtype=xp.float32),
-                                    duty=xp.asarray(0.5, dtype=xp.float32))
-        assert waveform.dtype == xp.float64
-
-        waveform = square(xp.asarray(1, dtype=xp.float64))
-        assert waveform.dtype == xp.float64
+    @pytest.mark.parametrize("t_dtype", ["float32", "float64"])
+    @pytest.mark.parametrize("duty_dtype", ["float32", "float64"])
+    def test_dtype(self, t_dtype, duty_dtype, xp):
+        t_dtype = getattr(xp, t_dtype)
+        duty_dtype = getattr(xp, duty_dtype)
+        waveform = square(xp.asarray(1, dtype=t_dtype),
+                          duty=xp.asarray(0.5, dtype=duty_dtype))
+        assert waveform.dtype == xp.result_type(t_dtype, duty_dtype)
 
     @pytest.mark.parametrize("duty", [0.1, 0.25, 0.5, 0.75])
     def test_duty_cycle_fraction(self, duty, xp):

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._array_api import (
-    assert_almost_equal, xp_assert_equal, xp_assert_close
+    assert_almost_equal, xp_assert_equal, xp_assert_close, _xp_copy_to_numpy
 )
 
 import scipy.signal._waveforms as waveforms
@@ -397,7 +397,7 @@ class TestSquareWaveform:
         t = xp.linspace(0, 2*np.pi, 1000)
         y = waveforms.square(t)
         assert y.shape == t.shape
-        unique = xp.unique(y)
+        unique = np.unique(_xp_copy_to_numpy(y))
         assert set(unique).issubset({-1.0, 1.0})
 
     def test_dtype(self, xp):
@@ -414,7 +414,8 @@ class TestSquareWaveform:
         y = waveforms.square(t, duty=duty)
 
         fraction_high = xp.mean(xp.asarray(y == 1.0, dtype=xp.float64))
-        xp_assert_close(fraction_high, xp.asarray(duty, dtype=xp.float64)[()], rtol=1e-8)
+        xp_assert_close(fraction_high, xp.asarray(duty, dtype=xp.float64)[()],
+                        rtol=1e-8)
         xp_assert_close(xp.mean(y), xp.asarray(2*duty - 1, dtype=xp.float64)[()])
 
     @pytest.mark.parametrize("duty,expected", [(1, 1), (0, -1)])

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -413,6 +413,7 @@ class TestSquareWaveform:
                           duty=xp.asarray(0.5, dtype=duty_dtype))
         assert waveform.dtype == xp.result_type(t_dtype, duty_dtype)
 
+    @pytest.mark.xfail_xp_backends("cupy", reason="cupy/cupy/issues/9541")
     @pytest.mark.parametrize("dtype", [None, "float32", "float64"])
     @pytest.mark.parametrize("duty", [0.1, 0.25, 0.5, 0.75])
     def test_duty_cycle_fraction(self, dtype, duty, xp):

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -2,7 +2,8 @@ import numpy as np
 import pytest
 from pytest import raises as assert_raises
 from scipy._lib._array_api import (
-    assert_almost_equal, xp_assert_equal, xp_assert_close, _xp_copy_to_numpy
+    assert_almost_equal, xp_assert_equal, xp_assert_close, _xp_copy_to_numpy,
+    make_xp_test_case
 )
 
 import scipy.signal._waveforms as waveforms
@@ -392,6 +393,7 @@ class TestSawtoothWaveform:
         assert waveform.dtype == np.float64
 
 
+@make_xp_test_case(waveforms.square)
 class TestSquareWaveform:
     def test_unique(self, xp):
         t = xp.linspace(0, 2*np.pi, 1000)

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -7,6 +7,7 @@ from scipy._lib._array_api import (
 )
 
 import scipy.signal._waveforms as waveforms
+from scipy.signal import square
 
 
 # These chirp_* functions are the instantaneous frequencies of the signals
@@ -393,27 +394,27 @@ class TestSawtoothWaveform:
         assert waveform.dtype == np.float64
 
 
-@make_xp_test_case(waveforms.square)
+@make_xp_test_case(square)
 class TestSquareWaveform:
     def test_unique(self, xp):
         t = xp.linspace(0, 2*np.pi, 1000)
-        y = waveforms.square(t)
+        y = square(t)
         assert y.shape == t.shape
         unique = np.unique(_xp_copy_to_numpy(y))
         assert set(unique).issubset({-1.0, 1.0})
 
     def test_dtype(self, xp):
-        waveform = waveforms.square(xp.asarray(1, dtype=xp.float32),
+        waveform = square(xp.asarray(1, dtype=xp.float32),
                                     duty=xp.asarray(0.5, dtype=xp.float32))
         assert waveform.dtype == xp.float64
 
-        waveform = waveforms.square(xp.asarray(1, dtype=xp.float64))
+        waveform = square(xp.asarray(1, dtype=xp.float64))
         assert waveform.dtype == xp.float64
 
     @pytest.mark.parametrize("duty", [0.1, 0.25, 0.5, 0.75])
     def test_duty_cycle_fraction(self, duty, xp):
         t = xp.linspace(0, 2*xp.pi, 10_000, endpoint=False, dtype=xp.float64)
-        y = waveforms.square(t, duty=duty)
+        y = square(t, duty=duty)
 
         fraction_high = xp.mean(xp.asarray(y == 1.0, dtype=xp.float64))
         xp_assert_close(fraction_high, xp.asarray(duty, dtype=xp.float64)[()],
@@ -423,19 +424,19 @@ class TestSquareWaveform:
     @pytest.mark.parametrize("duty,expected", [(1, 1), (0, -1)])
     def test_duty_edge_cases(self, duty, expected, xp):
         t = xp.linspace(0, 2*xp.pi, 100)
-        y = waveforms.square(t, duty=duty)
+        y = square(t, duty=duty)
         xp_assert_equal(y, xp.full_like(t, expected, dtype=xp.float64))
 
     def test_periodic(self, xp):
         t = xp.linspace(0, 2*xp.pi, 10, endpoint=False, dtype=xp.float64)
-        y1 = waveforms.square(t, duty=0.4)
-        y2 = waveforms.square(t + 2*xp.pi, duty=0.4)
+        y1 = square(t, duty=0.4)
+        y2 = square(t + 2*xp.pi, duty=0.4)
 
         xp_assert_equal(y1, y2)
 
     @pytest.mark.parametrize("duty", [-0.1, 1.1, 2.0])
     def test_invalid_duty(self, duty, xp):
         t = xp.linspace(0, 2*np.pi, 10)
-        y = waveforms.square(t, duty=duty)
+        y = square(t, duty=duty)
 
         assert xp.all(xp.isnan(y))

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -421,7 +421,7 @@ class TestSquareWaveform:
                         rtol=1e-8)
         xp_assert_close(xp.mean(y), xp.asarray(2*duty - 1, dtype=xp.float64)[()])
 
-    @pytest.mark.parametrize("duty,expected", [(1, 1), (0, -1)])
+    @pytest.mark.parametrize("duty,expected", [(1., 1), (0., -1)])
     def test_duty_edge_cases(self, duty, expected, xp):
         t = xp.linspace(0, 2*xp.pi, 100)
         y = square(t, duty=duty)

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -425,9 +425,9 @@ class TestSquareWaveform:
 
     @pytest.mark.parametrize("duty,expected", [(1., 1), (0., -1)])
     def test_duty_edge_cases(self, duty, expected, xp):
-        t = xp.linspace(0, 2*xp.pi, 100)
+        t = xp.linspace(0, 2*xp.pi, 100, dtype=xp.float64)
         y = square(t, duty=duty)
-        xp_assert_equal(y, xp.full_like(t, expected, dtype=xp.float64))
+        xp_assert_equal(y, xp.full_like(t, expected))
 
     def test_periodic(self, xp):
         t = xp.linspace(0, 2*xp.pi, 10, endpoint=False, dtype=xp.float64)

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -397,7 +397,7 @@ class TestSquareWaveform:
         t = xp.linspace(0, 2*np.pi, 1000)
         y = waveforms.square(t)
         assert y.shape == t.shape
-        unique = np.unique(y)
+        unique = xp.unique(y)
         assert set(unique).issubset({-1.0, 1.0})
 
     def test_dtype(self, xp):
@@ -414,7 +414,7 @@ class TestSquareWaveform:
         y = waveforms.square(t, duty=duty)
 
         fraction_high = xp.mean(xp.asarray(y == 1.0, dtype=xp.float64))
-        xp_assert_close(fraction_high, xp.asarray(duty, dtype=xp.float64)[()])
+        xp_assert_close(fraction_high, xp.asarray(duty, dtype=xp.float64)[()], rtol=1e-8)
         xp_assert_close(xp.mean(y), xp.asarray(2*duty - 1, dtype=xp.float64)[()])
 
     @pytest.mark.parametrize("duty,expected", [(1, 1), (0, -1)])
@@ -424,7 +424,7 @@ class TestSquareWaveform:
         xp_assert_equal(y, expected*xp.ones_like(t, dtype=xp.float64))
 
     def test_periodic(self, xp):
-        t = xp.linspace(0, 2*xp.pi, 50, endpoint=False)
+        t = xp.linspace(0, 2*xp.pi, 10, endpoint=False)
         y1 = waveforms.square(t, duty=0.4)
         y2 = waveforms.square(t + 2*xp.pi, duty=0.4)
 

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -410,7 +410,7 @@ class TestSquareWaveform:
 
     @pytest.mark.parametrize("duty", [0.1, 0.25, 0.5, 0.75])
     def test_duty_cycle_fraction(self, duty, xp):
-        t = xp.linspace(0, 2*xp.pi, 10_000, endpoint=False)
+        t = xp.linspace(0, 2*xp.pi, 10_000, endpoint=False, dtype=xp.float64)
         y = waveforms.square(t, duty=duty)
 
         fraction_high = xp.mean(xp.asarray(y == 1.0, dtype=xp.float64))
@@ -425,7 +425,7 @@ class TestSquareWaveform:
         xp_assert_equal(y, xp.full_like(t, expected, dtype=xp.float64))
 
     def test_periodic(self, xp):
-        t = xp.linspace(0, 2*xp.pi, 10, endpoint=False)
+        t = xp.linspace(0, 2*xp.pi, 10, endpoint=False, dtype=xp.float64)
         y1 = waveforms.square(t, duty=0.4)
         y2 = waveforms.square(t + 2*xp.pi, duty=0.4)
 

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -434,7 +434,7 @@ class TestSquareWaveform:
         xp_assert_equal(y, xp.full(t.shape, expected))
 
     def test_periodic(self, xp):
-        t = xp.linspace(0, 2*xp.pi, 10, endpoint=False)
+        t = xp.linspace(0, 2*xp.pi, 10, endpoint=False, dtype=xp.float64)
         y1 = square(t, duty=0.4)
         y2 = square(t + 2*xp.pi, duty=0.4)
 

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -403,6 +403,7 @@ class TestSquareWaveform:
         unique = np.unique(_xp_copy_to_numpy(y))
         assert set(unique).issubset({-1.0, 1.0})
 
+    @pytest.mark.xfail_xp_backends("cupy", reason="cupy/cupy/issues/9541")
     def test_dtype(self, xp):
         waveform = square(xp.asarray(1, dtype=xp.float32),
                                     duty=xp.asarray(0.5, dtype=xp.float32))

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -421,7 +421,7 @@ class TestSquareWaveform:
     def test_duty_edge_cases(self, duty, expected, xp):
         t = xp.linspace(0, 2*xp.pi, 100)
         y = waveforms.square(t, duty=duty)
-        xp_assert_equal(y, expected*xp.ones_like(t, dtype=xp.float64))
+        xp_assert_equal(y, xp.full_like(t, expected, dtype=xp.float64))
 
     def test_periodic(self, xp):
         t = xp.linspace(0, 2*xp.pi, 10, endpoint=False)


### PR DESCRIPTION
Adds array api support and also beefs up the tests a little bit.