### PR TITLE
BUG: ndimage: fix potential double-free in NI_InitFilterOffsets

### DIFF
--- a/scipy/ndimage/src/ni_support.c
+++ b/scipy/ndimage/src/ni_support.c
@@ -734,8 +734,10 @@ int NI_InitFilterOffsets(PyArrayObject *array, npy_bool *footprint,
  exit:
     if (PyErr_Occurred()) {
         free(*offsets);
+        *offsets = NULL;
         if (coordinate_offsets) {
             free(*coordinate_offsets);
+            *coordinate_offsets = NULL;
         }
         return 0;
     } else {


### PR DESCRIPTION
Null out offset pointers after freeing them in the error path of NI_InitFilterOffsets. Without this, callers that also free these pointers in their cleanup code could trigger a double-free if the function fails after allocation.

Found by Coverity static analysis.
