### PR TITLE
BUG: signal/_firfilter.cc: fix out-of-bounds read in pylab_convolve_2d

### DIFF
--- a/scipy/signal/_firfilter.cc
+++ b/scipy/signal/_firfilter.cc
@@ -180,10 +180,11 @@ int pylab_convolve_2d (char  *in,        /* Input data Ns[0] x Ns[1] */
   const int type_num = (flag & TYPE_MASK) >> TYPE_SHIFT;
   /*type_size*/
 
+  if (type_num < 0 || type_num >= MAXTYPES) return -4;  /* Invalid type */
+
   OneMultAddFunction *mult_and_add = OneMultAdd[type_num];
   if (mult_and_add == NULL) return -5;  /* Not available for this type */
 
-  if (type_num < 0 || type_num > MAXTYPES) return -4;  /* Invalid type */
   const int type_size = elsizes[type_num];
 
   int64_t Os[2];


### PR DESCRIPTION
Move the type_num bounds check before using it as an array index. Previously, OneMultAdd[type_num] was accessed before validating that type_num was within bounds, which could cause an out-of-bounds read when passed an unsupported array dtype.

Also fix off-by-one error via changing > MAXTYPES to >= MAXTYPES since the arrays have MAXTYPES-1 elements.

Found by Coverity static analysis scan.