### PR TITLE
BUG: optimize/__lbfgsb.c: fix pointer arithmetic bug in cauchy function

### DIFF
--- a/scipy/optimize/src/lbfgsb.c
+++ b/scipy/optimize/src/lbfgsb.c
@@ -1590,7 +1590,7 @@ cauchy(int n, double* x, double* l, double* u,
         }
 
         // Update the derivative information.
-        nseg += 1;
+        *nseg += 1;
         dibp2 = pow(dibp, 2.0);
 
         // Update f1 and f2


### PR DESCRIPTION
Change nseg += 1 to *nseg += 1 to increment the segment counter value rather than performing pointer arithmetic on the pointer itself.

Found by Coverity static analysis.
