### PR TITLE
MAINT: backports for SciPy 1.17.0rc2

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -129,7 +129,7 @@ jobs:
         pip install git+https://github.com/numpy/meson.git@main-numpymeson
         # pin scipy-openblas on release branch--see:
         # https://github.com/scipy/scipy/pull/24207#issuecomment-3687862055
-        pip install "scipy-openblas32==0.3.30.0.8" "scipy-openblas64=="0.3.30.0.8"
+        pip install "scipy-openblas32==0.3.30.0.8" "scipy-openblas64==0.3.30.0.8"
 
     - name: Write out scipy-openblas64.pc
       run: |

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -127,7 +127,9 @@ jobs:
         pip install cython numpy pybind11 pythran pytest hypothesis pytest-xdist pooch
         pip install -r requirements/dev.txt
         pip install git+https://github.com/numpy/meson.git@main-numpymeson
-        pip install scipy-openblas32 scipy-openblas64
+        # pin scipy-openblas on release branch--see:
+        # https://github.com/scipy/scipy/pull/24207#issuecomment-3687862055
+        pip install "scipy-openblas32==0.3.30.0.8" "scipy-openblas64=="0.3.30.0.8"
 
     - name: Write out scipy-openblas64.pc
       run: |

--- a/.mailmap
+++ b/.mailmap
@@ -276,6 +276,7 @@ Jakub Dyczek <34447984+JDkuba@users.noreply.github.com> JDkuba <34447984+JDkuba@
 James T. Webber <jamestwebber@gmail.com> jamestwebber <jamestwebber@gmail.com>
 James T. Webber <jamestwebber@gmail.com> James Webber <jamestwebber@users.noreply.github.com>
 James T. Webber <jamestwebber@gmail.com> James Webber <j@meswebber.com>
+Jan Möseritz-Schmidt <jaro.schmidt@gmail.com> JaRoSchm <jaro.schmidt@gmail.com>
 Jan Schlüter <jan.schlueter@ofai.at> Jan Schlueter <jan.schlueter@ofai.at>
 Jan Schlüter <jan.schlueter@ofai.at> Jan Schlüter <github@jan-schlueter.de>
 Jan Soedingrekso <jan.soedingrekso@tu-dortmund.de> sudojan <jan.soedingrekso@tu-dortmund.de>
@@ -285,7 +286,6 @@ Janani Padmanabhan <jenny.stone125@gmail.com> janani <janani@janani-Vostro-3446.
 Janani Padmanabhan <jenny.stone125@gmail.com> Janani <jenny.stone125@gmail.com>
 Janez Demšar <janez.demsar@fri.uni-lj.si> janez <janez.demsar@fri.uni-lj.si>
 Janez Demšar <janez.demsar@fri.uni-lj.si> janezd <janez.demsar@fri.uni-lj.si>
-Jaro Schmidt <jaro.schmidt@gmail.com> JaRoSchm <jaro.schmidt@gmail.com>
 Jarrod Millman <jarrod.millman@gmail.com> Jarrod Millman <millman@berkeley.edu>
 Jean-François B. <jfbu@free.fr> jfbu <jfbu@free.fr>
 Jean-François B. <jfbu@free.fr> Jean-François B <jfbu@free.fr>

--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -323,9 +323,9 @@ class Getset(Benchmark):
         v = np.random.rand(n)
 
         if N == 1:
-            i = int(i)
-            j = int(j)
-            v = float(v)
+            i = int(i[0])
+            j = int(j[0])
+            v = float(v[0])
 
         base = A.asformat(format)
 

--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -28,9 +28,10 @@ Highlights of this release
   summary of the latter is now available in a
   :ref:`set of tables <dev-arrayapi_coverage>`.
 - In `scipy.sparse`, ``coo_array`` now supports indexing. This includes integers,
-  slices, arrays, np.newaxis, Ellipsis, in 1D, 2D and the relatively new nD.
-  In `scipy.sparse.linalg`, ARPACK and PROPACK rewrites from Fortran77 to C now
-  empower the use of external pseudorandom number generators, e.g. from numpy.
+  slices, arrays, ``np.newaxis``, ``Ellipsis``, in 1D, 2D and the relatively
+  new nD. In `scipy.sparse.linalg`, ARPACK and PROPACK rewrites from Fortran77
+  to C now empower the use of external pseudorandom number generators, e.g.
+  from numpy.
 - In `scipy.spatial`, ``transform.Rotation`` and ``transform.RigidTransform``
   have been extended to support N-D arrays. ``geometric_slerp`` now has support
   for extrapolation.
@@ -52,6 +53,9 @@ New features
   ``zvode`` have been ported from Fortran77 to C.
 - `scipy.integrate.quad` now has a fast path for returning 0 when the integration
   interval is empty.
+- The ``BDF``, ``DOP853``, ``RK23``, ``RK45``, ``OdeSolver``, ``DenseOutput``,
+  ``ode``, and ``complex_ode`` classes now support subscription, making them
+  generic types, for compatibility with ``scipy-stubs``.
 
 ``scipy.cluster`` improvements
 ==============================
@@ -60,22 +64,30 @@ New features
 
 ``scipy.interpolate`` improvements
 ==================================
-- A new ``bc_type`` argument has been added to `scipy.interpolate.make_splrep`
-  and `scipy.interpolate.make_splprep` to control the boundary conditions for
-  spline fitting. Allowed values are ``"not-a-knot"`` (default) and
-  ``"periodic"``.
+- A new ``bc_type`` argument has been added to `scipy.interpolate.make_splrep`,
+  `scipy.interpolate.make_splprep`, and `scipy.interpolate.generate_knots` to
+  control the boundary conditions for spline fitting. Allowed values are
+  ``"not-a-knot"`` (default) and ``"periodic"``.
 - A new ``derivative`` method has been added to the
   `scipy.interpolate.NdBSpline` class, to construct a new spline representing a
   partial derivative of the given spline. This method is similar to the
-  ``BSpline.derivative`` method of 1-D spline objects.
+  ``BSpline.derivative`` method of 1-D spline objects. In addition, the
+  ``NdBSpline`` mutable instance attribute ``.c`` was changed into a read-only
+  ``@property``.
 - Performance of ``"cubic"`` and ``"quintic"`` modes of
-  `scipy.interpolate.RegularGridInterpolator` has been improved.
-- Numerical stability of `scipy.interpolate.AAA` has been improved.
+  `scipy.interpolate.RegularGridInterpolator` has been improved. Furthermore,
+  the (mutable) instance attributes ``.grid`` and ``.values`` were changed into
+  (read-only) properties.
+- Numerical stability of `scipy.interpolate.AAA` has been improved and it has
+  gained a new ``axis`` parameter.
 - `scipy.interpolate.FloaterHormannInterpolator` added support for
   multidimensional, batched inputs and gained a new ``axis`` parameter to
   select the interpolation axis.
 - ``RBFInterpolator`` has gained an array API standard compatible backend, with an
   improved support for GPU arrays. 
+- The ``AAA``, ``*Interpolator``, ``*Poly``, and ``*Spline`` classes now
+  support subscription, making them generic types, for compatibility with
+  ``scipy-stubs``.
 
 
 ``scipy.linalg`` improvements
@@ -107,6 +119,9 @@ New features
 - Callback functions used by ``optimize.minimize(method="slsqp")`` can
   opt into the new callback interface by accepting a single keyword argument
   ``intermediate_result``.
+- The ``BroydenFirst``, ``*Jacobian``, and ``Bounds`` classes now support
+  subscription, making them generic types, for compatibility with
+  ``scipy-stubs``.
 
 
 ``scipy.signal`` improvements
@@ -124,6 +139,8 @@ New features
   axes along which the two-dimensional analytic signal should be calculated.
   Furthermore, the documentation of `~scipy.signal.hilbert` and
   `~scipy.signal.hilbert2` was significantly improved.
+- The ``ShortTimeFFT`` class now support subscription, making it a generic
+  type, for compatibility with ``scipy-stubs``.
 
 
 ``scipy.sparse`` improvements
@@ -145,10 +162,15 @@ New features
   or another ``dok_array`` matrix. It performs additional validation that keys
   are valid index tuples.
 - `~scipy.sparse.dia_array.tocsr` is approximately three times faster and
-  some unneccesary copy operations have been removed from sparse format
+  some unneccessary copy operations have been removed from sparse format
   interconversions more broadly.
 - Added `scipy.sparse.linalg.funm_multiply_krylov`, a restarted Krylov method
   for evaluating ``y = f(tA) b``.
+- In ``sparse.linalg``, the ``LinearOperator``, ``LaplacianNd``, and ``SuperLU``
+  classes now support subscription, making them generic types, for
+  compatibility with ``scipy-stubs``.
+- In ``sparse.linalg`` the ``eigs`` and ``eigsh`` functions now accept a new
+  ``rng`` parameter.
 
 ``scipy.spatial`` improvements
 ==============================
@@ -185,6 +207,8 @@ New features
   point at the south pole.
 - ``Rotation.as_euler`` and ``Rotation.as_davenport`` methods have gained a
   ``suppress_warnings`` parameter to enable suppression of gimbal lock warnings.
+- ``Rotation.__init__`` has gained a new optional ``scalar_first`` parameter and
+  there is a new ``Rotation.__setitem__`` method.
 
 ``scipy.special`` improvements
 ==============================
@@ -230,13 +254,25 @@ New features
 - The default guess of ``scipy.stats.trapezoid.fit`` has been improved.
 - The accuracy and range of the ``cdf``, ``sf``, ``isf``, and ``ppf`` methods
   of `scipy.stats.binom` and `scipy.stats.nbinom` has been improved.
-
+- The ``Covariance``, ``Uniform``, ``Normal``, ``Binomial``, ``Mixture``,
+  ``rv_frozen``, and ``multi_rv_frozen`` classes now support subscription,
+  making them generic types, for compatibility with ``scipy-stubs``.
+- The ``multivariate_t`` and ``multivariate_normal`` distributions have gained
+  a new ``marginal`` method.
+- ``yeojohnson_llf`` gained new parameters ``axis``, ``nan_policy``,
+  and ``keepdims``, and now returns a numpy scalar where it would previously
+  return a 0D array.
+- The new ``spearmanrho`` function is an array API compatible substitute for
+  ``spearmanr``.
+- The ``median_abs_deviation`` function has gained a ``keepdims`` parameter.
+- The ``trim_mean`` function has gained new ``nan_policy`` and ``keepdims``
+  parameters.
 
 **************************
 Array API Standard Support
 **************************
 - An overall summary table for our array API standard support/coverage is
-  :ref:`now availalble <dev-arrayapi_coverage>`.
+  :ref:`now available <dev-arrayapi_coverage>`.
 - The overhead associated with array namespace determination has been reduced,
   providing improved performance in dispatching to different backends.
 - `scipy.cluster.hierarchy.is_isomorphic` has gained support.
@@ -371,8 +407,8 @@ Authors
 * Marco Berzborn (1) +
 * Ole Bialas (1) +
 * Om Biradar (1) +
-* Florian Bourgey (1)
-* Jake Bowhay (102)
+* Florian Bourgey (2)
+* Jake Bowhay (103)
 * Matteo Brivio (1) +
 * Dietrich Brunn (34)
 * Johannes Buchner (2) +
@@ -400,14 +436,15 @@ Authors
 * Ralf Gommers (121)
 * Nicolas Guidotti (1) +
 * Geoffrey Gunter (1) +
-* Matt Haberland (177)
-* Joren Hammudoglu (56)
+* Matt Haberland (181)
+* Joren Hammudoglu (60)
 * Jacob Hass (2) +
 * Nick Hodgskin (1) +
 * Stephen Huan (1) +
 * Guido Imperiale (41)
 * Gert-Ludwig Ingold (1)
 * Jaime Rodríguez-Guerra (2) +
+* Jan Möseritz-Schmidt (2) +
 * JBlitzar (1) +
 * Adam Jones (2)
 * Dustin Kenefake (1) +
@@ -444,21 +481,20 @@ Authors
 * Gilles Peiffer (3) +
 * Matti Picus (1)
 * Jonas Pleyer (2) +
-* Ilhan Polat (116)
+* Ilhan Polat (119)
 * Akshay Priyadarshi (2) +
 * Mohammed Abdul Rahman (1) +
 * Daniele Raimondi (2) +
 * Ritesh Rana (1) +
 * Adrian Raso (1) +
 * Dan Raviv (1) +
-* Tyler Reddy (116)
+* Tyler Reddy (108)
 * Lucas Roberts (4)
 * Bernard Roesler (1) +
 * Mikhail Ryazanov (27)
-* Jan Möseritz-Schmidt (1) +
 * Daniel Schmitz (25)
 * Martin Schuck (25)
-* Dan Schult (29)
+* Dan Schult (33)
 * Mugunthan Selvanayagam (1) +
 * Scott Shambaugh (14)
 * Rodrigo Silva (1) +
@@ -530,6 +566,7 @@ Issues closed for 1.17.0
 * `#22310 <https://github.com/scipy/scipy/issues/22310>`__: BUG: scipy.sparse.linalg.eigsh returns an error when LinearOperator.dtype=None
 * `#22365 <https://github.com/scipy/scipy/issues/22365>`__: BUG: ndimage: C++ memory management issues in ``_rank_filter_1d.cpp``
 * `#22412 <https://github.com/scipy/scipy/issues/22412>`__: RFC/API: move ``clarkson_woodruff_transform`` from ``linalg``...
+* `#22436 <https://github.com/scipy/scipy/issues/22436>`__: BUG: special.itj0y0: regression for ``t > 19``
 * `#22500 <https://github.com/scipy/scipy/issues/22500>`__: ENH: spatial.transform: Add array API standard support
 * `#22510 <https://github.com/scipy/scipy/issues/22510>`__: performance: _construct_docstrings slow in scipy.stats
 * `#22682 <https://github.com/scipy/scipy/issues/22682>`__: BUG: special.betainc: inaccurate/incorrect for small a and b...
@@ -551,11 +588,13 @@ Issues closed for 1.17.0
 * `#23160 <https://github.com/scipy/scipy/issues/23160>`__: DOC: signal.medfilt: remove outdated note
 * `#23166 <https://github.com/scipy/scipy/issues/23166>`__: BENCH/DEV: ``spin bench`` option ``--quick`` is useless (always...
 * `#23171 <https://github.com/scipy/scipy/issues/23171>`__: BUG: ``interpolate.RegularGridInterpolator`` fails on a 2D grid...
+* `#23195 <https://github.com/scipy/scipy/issues/23195>`__: BUG: New backend for interpolative decomposition breaks for (1xn)...
 * `#23204 <https://github.com/scipy/scipy/issues/23204>`__: BUG/TST: stats: XSLOW test failures of ``ttest_ind``
 * `#23208 <https://github.com/scipy/scipy/issues/23208>`__: DOC: Missing docstrings for some warnings in scipy.io
 * `#23231 <https://github.com/scipy/scipy/issues/23231>`__: DOC: Fix bug in release notes for scipy v1.12.0
 * `#23237 <https://github.com/scipy/scipy/issues/23237>`__: DOC: Breadcrumbs missing and sidebar different in API reference...
 * `#23248 <https://github.com/scipy/scipy/issues/23248>`__: BUG/TST: ``differentiate`` ``test_dtype`` fails with ``float16``...
+* `#23272 <https://github.com/scipy/scipy/issues/23272>`__: BUG: linalg.interpolative.reconstruct_matrix_from_id: segfault...
 * `#23297 <https://github.com/scipy/scipy/issues/23297>`__: BUG [nightly]: spatial.transform.Rotation.from_quat: fails for...
 * `#23301 <https://github.com/scipy/scipy/issues/23301>`__: BUG: free-threading: functionality based on multiprocessing.Pool...
 * `#23303 <https://github.com/scipy/scipy/issues/23303>`__: BUG: spatial.transform.Rotation: Warning Inconsistency
@@ -625,6 +664,7 @@ Issues closed for 1.17.0
 * `#24046 <https://github.com/scipy/scipy/issues/24046>`__: TST: stats: TestStudentT.test_moments_t failure
 * `#24052 <https://github.com/scipy/scipy/issues/24052>`__: CI: TypeError: Multiple namespaces for array inputs
 * `#24089 <https://github.com/scipy/scipy/issues/24089>`__: ENH: spatial.transform: Add ``normalize`` argument to ``Rotation.from_matrix``
+* `#24131 <https://github.com/scipy/scipy/issues/24131>`__: BUG: ``1.17.0rc1``\ : ModuleNotFoundError: No module named 'scipy.integrate._lso...
 
 ************************
 Pull requests for 1.17.0
@@ -1096,6 +1136,8 @@ Pull requests for 1.17.0
 * `#24025 <https://github.com/scipy/scipy/pull/24025>`__: DOC: stats: add equations for Cramer von Mises functions
 * `#24028 <https://github.com/scipy/scipy/pull/24028>`__: MAINT:integrate: Initialize variable to silence compiler warnings
 * `#24029 <https://github.com/scipy/scipy/pull/24029>`__: ENH: stats.mood: add array API support
+* `#24030 <https://github.com/scipy/scipy/pull/24030>`__: ENH: stats.anderson: add ``method`` parameter
+* `#24031 <https://github.com/scipy/scipy/pull/24031>`__: ENH: stats.anderson_ksamp: add ``variant`` parameter
 * `#24033 <https://github.com/scipy/scipy/pull/24033>`__: DEP: deprecate ``scipy.odr``
 * `#24036 <https://github.com/scipy/scipy/pull/24036>`__: CI: run Windows OneAPI job on main every 2 days to prefetch cache
 * `#24039 <https://github.com/scipy/scipy/pull/24039>`__: DOC/TST: fft: mark array api coverage with ``xp_capabilities``
@@ -1126,6 +1168,20 @@ Pull requests for 1.17.0
 * `#24095 <https://github.com/scipy/scipy/pull/24095>`__: DOC: differential_evolution - fix typo in custom strategy example
 * `#24097 <https://github.com/scipy/scipy/pull/24097>`__: ENH: stats: added marginal function to ``stats.multivariate_t``
 * `#24098 <https://github.com/scipy/scipy/pull/24098>`__: TST: linalg: unskip a test
+* `#24100 <https://github.com/scipy/scipy/pull/24100>`__: DOC: SciPy 1.17.0 release notes
 * `#24106 <https://github.com/scipy/scipy/pull/24106>`__: BUG: interpolate: Fix h[m] -> h[n] typo in _deBoor_D derivative...
 * `#24107 <https://github.com/scipy/scipy/pull/24107>`__: ENH: linalg/solve: move the tridiagonal solve slice iteration...
 * `#24113 <https://github.com/scipy/scipy/pull/24113>`__: DOC: signal: mark some legacy functions as out of scope for array...
+* `#24118 <https://github.com/scipy/scipy/pull/24118>`__: MAINT: version pins/prep for 1.17.0rc1
+* `#24129 <https://github.com/scipy/scipy/pull/24129>`__: REL: set 1.17.0rc2 unreleased
+* `#24132 <https://github.com/scipy/scipy/pull/24132>`__: DOC: update mailmap
+* `#24133 <https://github.com/scipy/scipy/pull/24133>`__: BUG: integrate: fix no module named 'scipy.integrate._lsoda'
+* `#24138 <https://github.com/scipy/scipy/pull/24138>`__: DOC: release notes: improve wording of sparse highlight
+* `#24139 <https://github.com/scipy/scipy/pull/24139>`__: API: ``linalg.inv``\ : keyword-only ``assume_a`` and ``lower``...
+* `#24140 <https://github.com/scipy/scipy/pull/24140>`__: API: ``signal.savgol_coeffs``\ : keyword-only ``xp`` and ``device``
+* `#24143 <https://github.com/scipy/scipy/pull/24143>`__: TYP: generic ``signal.LinearTimeInvariant`` type
+* `#24145 <https://github.com/scipy/scipy/pull/24145>`__: BUG: ``sparse``\ : fix ``coo_matrix.__setitem__`` signature
+* `#24151 <https://github.com/scipy/scipy/pull/24151>`__: MAINT: linalg: raise for zero-size batch
+* `#24155 <https://github.com/scipy/scipy/pull/24155>`__: MAINT: bump ``xsf`` to fix ``special.itj0y0`` regression
+* `#24161 <https://github.com/scipy/scipy/pull/24161>`__: BUG:linalg.interpolative: Fix two edge cases for id_dist Cython...
+* `#24174 <https://github.com/scipy/scipy/pull/24174>`__: REV:integrate: Revert the stepsize change in LSODA

--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -421,12 +421,12 @@ Authors
 * Matteo Brivio (1) +
 * Dietrich Brunn (34)
 * Johannes Buchner (2) +
-* Evgeni Burovski (288)
+* Evgeni Burovski (290)
 * Nicholas Carlini (1) +
 * Luca Cerina (1) +
 * Christine P. Chai (35)
 * Saransh Chopra (1)
-* Lucas Colley (119)
+* Lucas Colley (121)
 * Björn Ingvar Dahlgren (2) +
 * Sumit Das (1) +
 * Hans Dembinski (1)
@@ -497,7 +497,7 @@ Authors
 * Ritesh Rana (1) +
 * Adrian Raso (1) +
 * Dan Raviv (1) +
-* Tyler Reddy (115)
+* Tyler Reddy (122)
 * Lucas Roberts (4)
 * Bernard Roesler (1) +
 * Mikhail Ryazanov (27)
@@ -1200,3 +1200,5 @@ Pull requests for 1.17.0
 * `#24214 <https://github.com/scipy/scipy/pull/24214>`__: DOC: update 1.17.0 notes for RBFInterpolator
 * `#24218 <https://github.com/scipy/scipy/pull/24218>`__: BENCH, MAINT: NumPy 2.4.0 bench compat
 * `#24223 <https://github.com/scipy/scipy/pull/24223>`__: BLD: linalg: ``link_language: 'fortran'`` for ``_fblas``
+* `#24239 <https://github.com/scipy/scipy/pull/24239>`__: MAINT: bump array-api-compat for JAX>=0.8.2 compat
+* `#24240 <https://github.com/scipy/scipy/pull/24240>`__: MAINT: bump array-api-compat to 1.13 tag

--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -455,7 +455,7 @@ Authors
 * Lucas Roberts (4)
 * Bernard Roesler (1) +
 * Mikhail Ryazanov (27)
-* Jaro Schmidt (1) +
+* Jan Möseritz-Schmidt (1) +
 * Daniel Schmitz (25)
 * Martin Schuck (25)
 * Dan Schult (29)

--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -139,8 +139,9 @@ New features
   axes along which the two-dimensional analytic signal should be calculated.
   Furthermore, the documentation of `~scipy.signal.hilbert` and
   `~scipy.signal.hilbert2` was significantly improved.
-- The ``ShortTimeFFT`` class now support subscription, making it a generic
-  type, for compatibility with ``scipy-stubs``.
+- The ``ShortTimeFFT`` and ``LinearTimeInvariant`` classes now support
+  subscription, making them generic types, for compatibility with
+  ``scipy-stubs``.
 
 
 ``scipy.sparse`` improvements
@@ -162,7 +163,7 @@ New features
   or another ``dok_array`` matrix. It performs additional validation that keys
   are valid index tuples.
 - `~scipy.sparse.dia_array.tocsr` is approximately three times faster and
-  some unneccessary copy operations have been removed from sparse format
+  some unnecessary copy operations have been removed from sparse format
   interconversions more broadly.
 - Added `scipy.sparse.linalg.funm_multiply_krylov`, a restarted Krylov method
   for evaluating ``y = f(tA) b``.
@@ -328,6 +329,14 @@ Deprecated features and future changes
 - The ``precenter`` argument of `scipy.signal.lombscargle` is deprecated and
   will be removed in v1.19.0. Furthermore, some arguments will become keyword
   only.
+- For `scipy.stats.anderson`, the tuple-unpacking behavior of the return object
+  and attributes ``critical_values``, ``significance_level``, and
+  ``fit_result`` are deprecated. Beginning in SciPy 1.19.0, these features will
+  no longer be available, and the object returned will have attributes
+  ``statistic`` and ``pvalue``.
+- For `scipy.stats.anderson_ksamp`, the ``midrank`` parameter is deprecated
+  and the new ``variant`` parameter should be preferred. This also means that
+  the presence of the ``critical_values`` return array is deprecated.
 
 ********************
 Expired deprecations
@@ -417,7 +426,7 @@ Authors
 * Luca Cerina (1) +
 * Christine P. Chai (35)
 * Saransh Chopra (1)
-* Lucas Colley (117)
+* Lucas Colley (119)
 * Björn Ingvar Dahlgren (2) +
 * Sumit Das (1) +
 * Hans Dembinski (1)
@@ -488,7 +497,7 @@ Authors
 * Ritesh Rana (1) +
 * Adrian Raso (1) +
 * Dan Raviv (1) +
-* Tyler Reddy (108)
+* Tyler Reddy (115)
 * Lucas Roberts (4)
 * Bernard Roesler (1) +
 * Mikhail Ryazanov (27)
@@ -500,7 +509,7 @@ Authors
 * Rodrigo Silva (1) +
 * Samaresh Kumar Singh (8) +
 * Kartik Sirohi (1) +
-* Albert Steppi (178)
+* Albert Steppi (179)
 * Matthias Straka (1) +
 * Theo Teske (1) +
 * Noam Teyssier (1) +
@@ -665,6 +674,7 @@ Issues closed for 1.17.0
 * `#24052 <https://github.com/scipy/scipy/issues/24052>`__: CI: TypeError: Multiple namespaces for array inputs
 * `#24089 <https://github.com/scipy/scipy/issues/24089>`__: ENH: spatial.transform: Add ``normalize`` argument to ``Rotation.from_matrix``
 * `#24131 <https://github.com/scipy/scipy/issues/24131>`__: BUG: ``1.17.0rc1``\ : ModuleNotFoundError: No module named 'scipy.integrate._lso...
+* `#24212 <https://github.com/scipy/scipy/issues/24212>`__: BENCH, MAINT: (sparse) asv suite compat with NumPy 2.4.0
 
 ************************
 Pull requests for 1.17.0
@@ -1171,6 +1181,7 @@ Pull requests for 1.17.0
 * `#24100 <https://github.com/scipy/scipy/pull/24100>`__: DOC: SciPy 1.17.0 release notes
 * `#24106 <https://github.com/scipy/scipy/pull/24106>`__: BUG: interpolate: Fix h[m] -> h[n] typo in _deBoor_D derivative...
 * `#24107 <https://github.com/scipy/scipy/pull/24107>`__: ENH: linalg/solve: move the tridiagonal solve slice iteration...
+* `#24111 <https://github.com/scipy/scipy/pull/24111>`__: BLD/DEV: fix windows build
 * `#24113 <https://github.com/scipy/scipy/pull/24113>`__: DOC: signal: mark some legacy functions as out of scope for array...
 * `#24118 <https://github.com/scipy/scipy/pull/24118>`__: MAINT: version pins/prep for 1.17.0rc1
 * `#24129 <https://github.com/scipy/scipy/pull/24129>`__: REL: set 1.17.0rc2 unreleased
@@ -1185,3 +1196,7 @@ Pull requests for 1.17.0
 * `#24155 <https://github.com/scipy/scipy/pull/24155>`__: MAINT: bump ``xsf`` to fix ``special.itj0y0`` regression
 * `#24161 <https://github.com/scipy/scipy/pull/24161>`__: BUG:linalg.interpolative: Fix two edge cases for id_dist Cython...
 * `#24174 <https://github.com/scipy/scipy/pull/24174>`__: REV:integrate: Revert the stepsize change in LSODA
+* `#24213 <https://github.com/scipy/scipy/pull/24213>`__: TST: fft: Add allow_dask_compute=True to more places in fft
+* `#24214 <https://github.com/scipy/scipy/pull/24214>`__: DOC: update 1.17.0 notes for RBFInterpolator
+* `#24218 <https://github.com/scipy/scipy/pull/24218>`__: BENCH, MAINT: NumPy 2.4.0 bench compat
+* `#24223 <https://github.com/scipy/scipy/pull/24223>`__: BLD: linalg: ``link_language: 'fortran'`` for ``_fblas``

--- a/pixi.lock
+++ b/pixi.lock
@@ -3,6 +3,8 @@ environments:
   accelerate-ilp64:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
@@ -78,6 +80,8 @@ environments:
   accelerate-lp64:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
@@ -153,6 +157,8 @@ environments:
   array-api-cpu:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-6_kmp_llvm.conda
@@ -436,7 +442,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-16-2.15.1-h692994f_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.1-h5d26750_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.5-hfa2b4ca_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.8-h4fa8253_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/markupsafe-3.0.3-py312h05f76fc_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/marray-python-0.0.12-pyh332efcf_0.conda
@@ -497,6 +503,8 @@ environments:
   array-api-strict:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-6_kmp_llvm.conda
@@ -697,7 +705,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-16-2.15.1-h692994f_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.1-h5d26750_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.5-hfa2b4ca_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.8-h4fa8253_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.0-hac47afa_454.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-devel-2025.3.0-h57928b3_454.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-include-2025.3.0-h57928b3_454.conda
@@ -741,6 +749,8 @@ environments:
   bench:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -945,43 +955,48 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/beniget-0.4.2.post1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/blas-devel-3.9.0-39_ha590de0_openblas.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
-      - conda: https://prefix.dev/conda-forge/win-64/c-compiler-1.11.0-h528c1b4_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ccache-4.11.3-h12b022e_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clang-19-19.1.7-default_hac490eb_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clang-19.1.7-default_hac490eb_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clangxx-19.1.7-default_hac490eb_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-21-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-format-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-tools-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clangdev-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clangxx-21.1.7-default_hac490eb_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.2.1-pyh7428d3b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorlog-6.10.1-pyh7428d3b_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt-19.1.7-h49e36cd_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-19.1.7-h49e36cd_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/compilers-1.11.0-h57928b3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/cxx-compiler-1.11.0-h1c1089f_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt-21.1.7-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt21-21.1.7-h49e36cd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt21_win-64-21.1.7-h49e36cd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-21.1.7-h57928b3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cython-3.2.0-py314h344ed54_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang-19.1.7-hbeecb71_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-19.1.7-h719f0c7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang_win-64-19.1.7-h719f0c7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/fortran-compiler-1.11.0-h95e3450_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang-21.1.7-h1b5488d_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/flang-rt_win-64-21.1.7-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-21.1.7-h719f0c7_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang_win-64-21.1.7-h719f0c7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/gast-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/json5-0.12.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.9.0-39_h0adab6e_openblas.conda
       - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.9.0-39_h2a8eebe_openblas.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang-cpp-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang13-21.1.7-default_ha2db4b5_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libflang-19.1.7-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libglib-2.86.1-hd9c3897_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhiredis-1.0.2-h0e60522_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapack-3.9.0-39_hd232482_openblas.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapacke-3.9.0-39_hbb0e6ff_openblas.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libllvm19-19.1.7-h830ff33_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libllvm-c21-21.1.7-h830ff33_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libllvm21-21.1.7-h830ff33_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopenblas-0.3.30-pthreads_ha4fe6b2_3.conda
@@ -990,7 +1005,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.1-ha29bfb0_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/lld-21.1.5-hc465015_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-tools-19.1.7-h752b59f_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.8-h4fa8253_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-tools-21.1.7-h752b59f_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvmdev-21.1.7-h830ff33_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-1.9.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.18.0-pyh70fd9c4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ninja-1.13.1-h477610d_0.conda
@@ -1022,14 +1039,14 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
       - conda: https://prefix.dev/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_32.conda
-      - conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_32.conda
-      - conda: https://prefix.dev/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
   build:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1208,40 +1225,45 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/beniget-0.4.2.post1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/blas-devel-3.9.0-39_ha590de0_openblas.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
-      - conda: https://prefix.dev/conda-forge/win-64/c-compiler-1.11.0-h528c1b4_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ccache-4.11.3-h12b022e_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clang-19-19.1.7-default_hac490eb_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clang-19.1.7-default_hac490eb_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clangxx-19.1.7-default_hac490eb_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-21-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-format-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-tools-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clangdev-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clangxx-21.1.7-default_hac490eb_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.2.1-pyh7428d3b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorlog-6.10.1-pyh7428d3b_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt-19.1.7-h49e36cd_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-19.1.7-h49e36cd_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/compilers-1.11.0-h57928b3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/cxx-compiler-1.11.0-h1c1089f_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt-21.1.7-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt21-21.1.7-h49e36cd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt21_win-64-21.1.7-h49e36cd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-21.1.7-h57928b3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cython-3.2.0-py314h344ed54_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang-19.1.7-hbeecb71_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-19.1.7-h719f0c7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang_win-64-19.1.7-h719f0c7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/fortran-compiler-1.11.0-h95e3450_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang-21.1.7-h1b5488d_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/flang-rt_win-64-21.1.7-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-21.1.7-h719f0c7_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang_win-64-21.1.7-h719f0c7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/gast-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/icu-75.1-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.9.0-39_h0adab6e_openblas.conda
       - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.9.0-39_h2a8eebe_openblas.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang-cpp-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang13-21.1.7-default_ha2db4b5_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libflang-19.1.7-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libglib-2.86.1-hd9c3897_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhiredis-1.0.2-h0e60522_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapack-3.9.0-39_hd232482_openblas.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapacke-3.9.0-39_hbb0e6ff_openblas.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libllvm19-19.1.7-h830ff33_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libllvm-c21-21.1.7-h830ff33_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libllvm21-21.1.7-h830ff33_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libopenblas-0.3.30-pthreads_ha4fe6b2_3.conda
@@ -1250,7 +1272,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.1-ha29bfb0_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/lld-21.1.5-hc465015_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-tools-19.1.7-h752b59f_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.8-h4fa8253_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-tools-21.1.7-h752b59f_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvmdev-21.1.7-h830ff33_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-1.9.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.18.0-pyh70fd9c4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ninja-1.13.1-h477610d_0.conda
@@ -1276,13 +1300,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_32.conda
-      - conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_32.conda
-      - conda: https://prefix.dev/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
   build-accelerate-ilp64:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/beniget-0.4.2.post1-pyhd8ed1ab_1.conda
@@ -1376,6 +1400,8 @@ environments:
   build-accelerate-lp64:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/beniget-0.4.2.post1-pyhd8ed1ab_1.conda
@@ -1469,6 +1495,8 @@ environments:
   build-cpu:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-6_kmp_llvm.conda
@@ -1653,32 +1681,36 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/beniget-0.4.2.post1-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/blas-devel-3.9.0-38_h85df5b5_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
-      - conda: https://prefix.dev/conda-forge/win-64/c-compiler-1.11.0-h528c1b4_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ccache-4.11.3-h12b022e_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clang-19-19.1.7-default_hac490eb_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clang-19.1.7-default_hac490eb_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clangxx-19.1.7-default_hac490eb_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-21-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-format-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-tools-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clangdev-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clangxx-21.1.7-default_hac490eb_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.2.1-pyh7428d3b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorlog-6.10.1-pyh7428d3b_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt-19.1.7-h49e36cd_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-19.1.7-h49e36cd_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/compilers-1.11.0-h57928b3_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/cxx-compiler-1.11.0-h1c1089f_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt-21.1.7-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt21-21.1.7-h49e36cd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt21_win-64-21.1.7-h49e36cd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-21.1.7-h57928b3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cython-3.2.0-py312hd245ac3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang-19.1.7-hbeecb71_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-19.1.7-h719f0c7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang_win-64-19.1.7-h719f0c7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/fortran-compiler-1.11.0-h95e3450_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang-21.1.7-h1b5488d_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/flang-rt_win-64-21.1.7-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-21.1.7-h719f0c7_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang_win-64-21.1.7-h719f0c7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/gast-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.9.0-38_hf2e6a31_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.9.0-38_h2a3cdd5_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang-cpp-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang13-21.1.7-default_ha2db4b5_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libflang-19.1.7-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libglib-2.86.1-hd9c3897_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libhiredis-1.0.2-h0e60522_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.12.1-default_h64bd3f2_1002.conda
@@ -1686,7 +1718,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapack-3.9.0-38_hf9ab0e9_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapacke-3.9.0-38_h3ae206f_mkl.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libllvm19-19.1.7-h830ff33_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libllvm-c21-21.1.7-h830ff33_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libllvm21-21.1.7-h830ff33_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
@@ -1694,8 +1727,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.1-h5d26750_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/lld-21.1.5-hc465015_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.5-hfa2b4ca_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-tools-19.1.7-h752b59f_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.8-h4fa8253_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-tools-21.1.7-h752b59f_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvmdev-21.1.7-h830ff33_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-1.9.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.18.0-pyh70fd9c4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.0-hac47afa_454.conda
@@ -1724,13 +1758,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_32.conda
-      - conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_32.conda
-      - conda: https://prefix.dev/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
   build-cuda:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1817,6 +1851,8 @@ environments:
   build-debug:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1994,6 +2030,8 @@ environments:
   cupy:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2093,6 +2131,8 @@ environments:
   dask-cpu:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-6_kmp_llvm.conda
@@ -2309,7 +2349,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-16-2.15.1-h692994f_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.1-h5d26750_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.5-hfa2b4ca_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.8-h4fa8253_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.0-hac47afa_454.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-devel-2025.3.0-h57928b3_454.conda
@@ -2358,6 +2398,8 @@ environments:
   default:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2442,6 +2484,8 @@ environments:
   docs:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3038,7 +3082,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlidec-1.2.0-h431afc6_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libbrotlienc-1.2.0-ha521d6b_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.9.0-39_h2a8eebe_openblas.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libclang13-21.1.5-default_ha2db4b5_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang13-21.1.7-default_ha2db4b5_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
@@ -3184,6 +3228,8 @@ environments:
   gdb:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3273,6 +3319,8 @@ environments:
   ipython:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3548,6 +3596,8 @@ environments:
   jax-cpu:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-6_kmp_llvm.conda
@@ -3732,6 +3782,8 @@ environments:
   jax-cuda:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-6_kmp_llvm.conda
@@ -3861,6 +3913,8 @@ environments:
   lint:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -4183,6 +4237,8 @@ environments:
   lldb:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyh71513ae_0.conda
@@ -4268,6 +4324,8 @@ environments:
   py311-system-libs-osx:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -4539,6 +4597,8 @@ environments:
     - url: https://prefix.dev/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -4793,31 +4853,33 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/blas-devel-3.9.0-38_h85df5b5_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/brotli-python-1.2.0-py314ha608bb1_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
-      - conda: https://prefix.dev/conda-forge/win-64/c-compiler-1.11.0-h528c1b4_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-h4c7d964_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/ccache-4.11.3-h12b022e_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/certifi-2025.10.5-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cffi-2.0.0-py314h5a2d7ad_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clang-19-19.1.7-default_hac490eb_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clang-19.1.7-default_hac490eb_5.conda
-      - conda: https://prefix.dev/conda-forge/win-64/clangxx-19.1.7-default_hac490eb_5.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-21-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-format-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clang-tools-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clangdev-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/clangxx-21.1.7-default_hac490eb_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/click-8.2.1-pyh7428d3b_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/colorlog-6.10.1-pyh7428d3b_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt-19.1.7-h49e36cd_1.conda
-      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-19.1.7-h49e36cd_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/compilers-1.11.0-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt-21.1.7-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/compiler-rt21-21.1.7-h49e36cd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt21_win-64-21.1.7-h49e36cd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-21.1.7-h57928b3_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/coverage-7.12.0-py314h2359020_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/cxx-compiler-1.11.0-h1c1089f_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/cython-3.2.0-py314h344ed54_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.1-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang-19.1.7-hbeecb71_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-19.1.7-h719f0c7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/flang_win-64-19.1.7-h719f0c7_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/fortran-compiler-1.11.0-h95e3450_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang-21.1.7-h1b5488d_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/flang-rt_win-64-21.1.7-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-21.1.7-h719f0c7_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/flang_win-64-21.1.7-h719f0c7_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/gast-0.6.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/gmp-6.3.0-hfeafd45_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/gmpy2-2.2.1-py314h9f8d836_2.conda
@@ -4830,9 +4892,11 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libblas-3.9.0-38_hf2e6a31_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.9.0-38_h2a3cdd5_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang-cpp-21.1.7-default_hac490eb_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libclang13-21.1.7-default_ha2db4b5_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.1-hac47afa_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libflang-19.1.7-he0c23c2_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgcc-15.2.0-h1383e82_7.conda
       - conda: https://prefix.dev/conda-forge/win-64/libglib-2.86.1-hd9c3897_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libgomp-15.2.0-h1383e82_7.conda
@@ -4842,7 +4906,8 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapack-3.9.0-38_hf9ab0e9_mkl.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblapacke-3.9.0-38_h3ae206f_mkl.conda
-      - conda: https://prefix.dev/conda-forge/win-64/libllvm19-19.1.7-h830ff33_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libllvm-c21-21.1.7-h830ff33_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libllvm21-21.1.7-h830ff33_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-h2466b09_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.51.0-hf5d6505_0.conda
@@ -4851,8 +4916,9 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.1-h5d26750_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://prefix.dev/conda-forge/win-64/lld-21.1.5-hc465015_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.5-hfa2b4ca_0.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-tools-19.1.7-h752b59f_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.8-h4fa8253_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-tools-21.1.7-h752b59f_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvmdev-21.1.7-h830ff33_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-1.9.1-pyhcf101f3_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.18.0-pyh70fd9c4_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.0-hac47afa_454.conda
@@ -4900,16 +4966,16 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
       - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_32.conda
-      - conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_32.conda
-      - conda: https://prefix.dev/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
       - conda: https://prefix.dev/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstandard-0.25.0-py314hc5dbbe4_1.conda
       - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
-      - pypi: https://files.pythonhosted.org/packages/cb/b5/f9bb06cd898eca12f2967fc50b9ef6b7e24a23f170578d456ce1132b6f3e/scipy_openblas32-0.3.30.0.8-py3-none-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/09/79/c92ac258765e35161cc9808838e728734286caa5f238a102a78312632c37/scipy_openblas32-0.3.30.359.2-py3-none-win_amd64.whl
   test:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -5142,6 +5208,8 @@ environments:
   torch-cpu:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-6_kmp_llvm.conda
@@ -5384,7 +5452,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-16-2.15.1-h692994f_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.1-h5d26750_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.5-hfa2b4ca_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.8-h4fa8253_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/markupsafe-3.0.3-py312h05f76fc_0.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.0-hac47afa_454.conda
       - conda: https://prefix.dev/conda-forge/win-64/mkl-devel-2025.3.0-h57928b3_454.conda
@@ -5439,6 +5507,8 @@ environments:
   torch-cuda:
     channels:
     - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-6_kmp_llvm.conda
@@ -6376,16 +6446,6 @@ packages:
   purls: []
   size: 6697
   timestamp: 1753098737760
-- conda: https://prefix.dev/conda-forge/win-64/c-compiler-1.11.0-h528c1b4_0.conda
-  sha256: 55e04bd4af61500cb8cae064386be57d18fbfdf676655ff1c97c7e5d146c6e34
-  md5: 6d994ff9ab924ba11c2c07e93afbe485
-  depends:
-  - vs2022_win-64
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 6938
-  timestamp: 1753098808371
 - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2025.10.5-h4c7d964_0.conda
   sha256: bfb7f9f242f441fdcd80f1199edd2ecf09acea0f2bcef6f07d7cbb1a8131a345
   md5: e54200a1cd1fe33d61c9df8d3b00b743
@@ -6712,12 +6772,13 @@ packages:
   purls: []
   size: 24502
   timestamp: 1759435412103
-- conda: https://prefix.dev/conda-forge/win-64/clang-19.1.7-default_hac490eb_5.conda
-  sha256: 05aaf18e0ecdff80dcf865354fafe39c713350b948bd7378b00c8ecbf3c97755
-  md5: 57f4b8f3549fec0be4c674a269e507b9
+- conda: https://prefix.dev/conda-forge/win-64/clang-21.1.7-default_hac490eb_2.conda
+  sha256: 8c6706d14cd9f259c7b37c9716ea50f89069bcb75ae133dcfc6a1fd57e0abf45
+  md5: 8a407d241ef3ed50d7b583166879ca74
   depends:
-  - clang-19 19.1.7 default_hac490eb_5
+  - clang-21 21.1.7 default_hac490eb_2
   - libzlib >=1.3.1,<2.0a0
+  - llvm-openmp >=21.1.7
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
@@ -6725,8 +6786,8 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 102209660
-  timestamp: 1759440377684
+  size: 108913370
+  timestamp: 1766020933068
 - conda: https://prefix.dev/conda-forge/osx-arm64/clang-19-19.1.7-default_h73dfc95_5.conda
   sha256: f1c8f4e8735918aacd7cab058fff389fc639d4537221753f0e9b44e120892f9a
   md5: 561b822bdb2c1bb41e16e59a090f1e36
@@ -6740,10 +6801,11 @@ packages:
   purls: []
   size: 763853
   timestamp: 1759435247449
-- conda: https://prefix.dev/conda-forge/win-64/clang-19-19.1.7-default_hac490eb_5.conda
-  sha256: e0053285b5685634c77b17f8ef13130b44042fe5fa56f1f95c3c8278149aa084
-  md5: 27ad94721c72e5118f9c498b1b83ab08
+- conda: https://prefix.dev/conda-forge/win-64/clang-21-21.1.7-default_hac490eb_2.conda
+  sha256: 3ed248000c8952978aa3bab6101292dc2983776354e7766d7e3c35e7ccb772f4
+  md5: 1c23cf90f9ee1323742632c3ef12381d
   depends:
+  - compiler-rt21 21.1.7.*
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
@@ -6752,8 +6814,40 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 68854476
-  timestamp: 1759440102943
+  size: 73387019
+  timestamp: 1766020627881
+- conda: https://prefix.dev/conda-forge/win-64/clang-format-21.1.7-default_hac490eb_2.conda
+  sha256: afa22671525e890a98445d1c2abc35e8b87c4c208d053e6527c5d2cbf6f7c938
+  md5: 8afc1288250ef6c77e8f7aa0df683a65
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 1233929
+  timestamp: 1766022144370
+- conda: https://prefix.dev/conda-forge/win-64/clang-tools-21.1.7-default_hac490eb_2.conda
+  sha256: ce0c13ecafdad963b3acdc9e3cd29dba2f3917e2d68ee4549faa3d841f5e6edf
+  md5: 5e53043ca5299682ac8d50aa65bea677
+  depends:
+  - clang-format 21.1.7 default_hac490eb_2
+  - libclang13 >=21.1.7
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - clangdev 21.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 308117429
+  timestamp: 1766022427555
 - conda: https://prefix.dev/conda-forge/osx-arm64/clang_impl_osx-arm64-19.1.7-h76e6a08_25.conda
   sha256: ee3c0976bde0ac19f84d29213ea3d9c3fd9c56d56c33ee471a8680cf69307ce1
   md5: a4e2f211f7c3cf582a6cb447bee2cad9
@@ -6778,6 +6872,28 @@ packages:
   purls: []
   size: 21337
   timestamp: 1748575949016
+- conda: https://prefix.dev/conda-forge/win-64/clangdev-21.1.7-default_hac490eb_2.conda
+  sha256: 8b5a3d34081459abae0d86febce09cb0778744f91edc89248b68a04120220ded
+  md5: 9d7e57cbf50cd8705615b218a5ad0be6
+  depends:
+  - clang 21.1.7 default_hac490eb_2
+  - clang-tools 21.1.7 default_hac490eb_2
+  - clangxx 21.1.7 default_hac490eb_2
+  - libclang 21.1.7 default_hac490eb_2
+  - libclang-cpp 21.1.7 default_hac490eb_2
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.1,<2.0a0
+  - llvmdev 21.1.7.*
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 56526332
+  timestamp: 1766023167242
 - conda: https://prefix.dev/conda-forge/osx-arm64/clangxx-19.1.7-default_h36137df_5.conda
   sha256: f8f94321aee9ad83cb1cdf90660885fccb482c34c82ba84c2c167d452376834f
   md5: c11a3a5a0cdb74d8ce58c6eac8d1f662
@@ -6789,11 +6905,11 @@ packages:
   purls: []
   size: 24587
   timestamp: 1759435427954
-- conda: https://prefix.dev/conda-forge/win-64/clangxx-19.1.7-default_hac490eb_5.conda
-  sha256: 892cdffc4c64fbff01a45eef1221c55434b78f86bc8b000539adea7bae530e9d
-  md5: ddf842de63eae5b511189bfbf23230c7
+- conda: https://prefix.dev/conda-forge/win-64/clangxx-21.1.7-default_hac490eb_2.conda
+  sha256: 3cdca3e5f9a03be7d373cb332df1da214763b4a13dcc18cdfb206a106b17b921
+  md5: b0ba60c95818d54e117c0ade167f5c2b
   depends:
-  - clang 19.1.7 default_hac490eb_5
+  - clang 21.1.7 default_hac490eb_2
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
@@ -6802,8 +6918,8 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 34080880
-  timestamp: 1759440655540
+  size: 36317097
+  timestamp: 1766021192823
 - conda: https://prefix.dev/conda-forge/osx-arm64/clangxx_impl_osx-arm64-19.1.7-h276745f_25.conda
   sha256: b997d325da6ca60e71937b9e28f114893401ca7cf94c4007d744e402a25c2c52
   md5: 5eeaa7b2dd32f62eb3beb0d6ba1e664f
@@ -6920,20 +7036,41 @@ packages:
   purls: []
   size: 97085
   timestamp: 1757411887557
-- conda: https://prefix.dev/conda-forge/win-64/compiler-rt-19.1.7-h49e36cd_1.conda
-  sha256: b942211b4557680dae103a6de69f411d85973b499bc7db9bf5dd0a66f0836f3b
-  md5: ebd0e08326cd166eb95a9956875303c3
+- conda: https://prefix.dev/conda-forge/win-64/compiler-rt-21.1.7-h57928b3_0.conda
+  sha256: a6dc94563f0cdc9e4c51a6afc2153d1933b278f4f068ef3eeca7f01d30c2badd
+  md5: 09e382e6939e0cb5c7a97428f4a17d21
   depends:
-  - clang 19.1.7.*
-  - compiler-rt_win-64 19.1.7.*
+  - compiler-rt21 21.1.7 h49e36cd_0
+  constrains:
+  - clang 21.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 16363
+  timestamp: 1764723333139
+- conda: https://prefix.dev/conda-forge/win-64/compiler-rt21-21.1.7-h49e36cd_0.conda
+  sha256: 2d62b0ebd02137b53a68748d1cedab2bb9e8cfc8cfe2f5d3e278eb88cf3e3bd1
+  md5: f42cf5f9b870a5fedf761982318e0bb1
+  depends:
+  - compiler-rt21_win-64 21.1.7.*
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 4688306
-  timestamp: 1757412257734
+  size: 4020208
+  timestamp: 1764723315890
+- conda: https://prefix.dev/conda-forge/noarch/compiler-rt21_win-64-21.1.7-h49e36cd_0.conda
+  sha256: d4a2c9ccb10e9cd35e1b0da45ad1e5f71b7c43a69ebdbe382a547bbc39e5786f
+  md5: 01bd2c8a061a394070403030a79adfc5
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 3885872
+  timestamp: 1764723237599
 - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-arm64-19.1.7-he32a8d3_1.conda
   sha256: 8c32a3db8adf18ed58197e8895ce4f24a83ed63c817512b9a26724753b116f2a
   md5: 8d99c82e0f5fed6cc36fcf66a11e03f0
@@ -6947,19 +7084,18 @@ packages:
   purls: []
   size: 10490535
   timestamp: 1757411851093
-- conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-19.1.7-h49e36cd_1.conda
-  sha256: 5d43e1f0e5b66edc43f57e8c3ea502ce976f86d8eec2de51d21a3a51802b2e72
-  md5: dd4b9fef3c46e061a1b5e6698b17d5ff
+- conda: https://prefix.dev/conda-forge/noarch/compiler-rt_win-64-21.1.7-h57928b3_0.conda
+  sha256: fcde45e2064c3c026476d93d8b1ae8edbf5892535fb32c821470c89297606916
+  md5: fae2d5c62076326ac3717276995dc3c4
   depends:
-  - clang 19.1.7.*
+  - compiler-rt21_win-64 21.1.7 h49e36cd_0
   constrains:
-  - compiler-rt 19.1.7
-  - clangxx 19.1.7
+  - clang 21.1.7
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 4516463
-  timestamp: 1757412208086
+  size: 16462
+  timestamp: 1764723332700
 - conda: https://prefix.dev/conda-forge/linux-64/compilers-1.11.0-ha770c72_0.conda
   sha256: 5709f2cbfeb8690317ba702611bdf711a502b417fecda6ad3313e501f6f8bd61
   md5: fdcf2e31dd960ef7c5daa9f2c95eff0e
@@ -6984,18 +7120,6 @@ packages:
   purls: []
   size: 7525
   timestamp: 1753098740763
-- conda: https://prefix.dev/conda-forge/win-64/compilers-1.11.0-h57928b3_0.conda
-  sha256: 37d51307f25e1d446b458881b366331e2c5b4c661b04c472f70408edac309b1f
-  md5: 13095e0e8944fcdecae4c16812c0a608
-  depends:
-  - c-compiler 1.11.0 h528c1b4_0
-  - cxx-compiler 1.11.0 h1c1089f_0
-  - fortran-compiler 1.11.0 h95e3450_0
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 7886
-  timestamp: 1753098810030
 - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-14.3.0-hb991d5c_7.conda
   sha256: d2fc6de5c21d92bf6a4c2f51040662ea34ed94baa7c2758ba685fd3b0032f7cb
   md5: 39586596e88259bae48f904fb1025b77
@@ -7484,16 +7608,6 @@ packages:
   purls: []
   size: 6715
   timestamp: 1753098739952
-- conda: https://prefix.dev/conda-forge/win-64/cxx-compiler-1.11.0-h1c1089f_0.conda
-  sha256: c888f4fe9ec117c1c01bfaa4c722ca475ebbb341c92d1718afa088bb0d710619
-  md5: 4d94d3c01add44dc9d24359edf447507
-  depends:
-  - vs2022_win-64
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 6957
-  timestamp: 1753098809481
 - conda: https://prefix.dev/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
   sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
   md5: 44600c4667a319d67dbe0681fc0bc833
@@ -7872,47 +7986,57 @@ packages:
   license: Unlicense
   size: 17976
   timestamp: 1759948208140
-- conda: https://prefix.dev/conda-forge/win-64/flang-19.1.7-hbeecb71_0.conda
-  sha256: 36cff091f0dc82c022225e51ebd1d2eba6269144c0c19580d3b313e430a70740
-  md5: a00b1ff46537989d170dda28dd99975f
+- conda: https://prefix.dev/conda-forge/win-64/flang-21.1.7-h1b5488d_0.conda
+  sha256: 77394ede4181cbbd7fbc1aab608c072263f9f0a00647fb861c093e262b3546c0
+  md5: 2096aab03c01229fa95faff8d3e07627
   depends:
-  - clang 19.1.7
-  - compiler-rt 19.1.7
-  - libflang 19.1.7 he0c23c2_0
+  - clang 21.1.7
+  - compiler-rt 21.1.7
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.6,<1.6.0a0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 104605360
-  timestamp: 1737060473360
-- conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-19.1.7-h719f0c7_0.conda
-  sha256: d6221674b51284ae2ec453b7f21e7411b480ed764af3f406ac4c3b9633c1f731
-  md5: cfe473c47c0cb5f30afd755710436e63
+  size: 144257252
+  timestamp: 1764833337232
+- conda: https://prefix.dev/conda-forge/noarch/flang-rt_win-64-21.1.7-h57928b3_0.conda
+  sha256: d797d53f16214e45b3b2ad1f5804077498ec091fb2dbfa2abd57e61d913d3ecb
+  md5: f81b003a7fbdd6f849907d0939f92698
   depends:
-  - compiler-rt_win-64 19.1.7.*
-  - flang 19.1.7.*
-  - libflang >=19.1.7
+  - clangdev 21.1.7
+  - flang 21.1.7
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 6138491
+  timestamp: 1764840557066
+- conda: https://prefix.dev/conda-forge/win-64/flang_impl_win-64-21.1.7-h719f0c7_0.conda
+  sha256: 222d61076806a5715c54826a4453a78a67469ecb2b1257a16e37fdb9fadb5367
+  md5: ef3727d4875a36e2e43a18ba8874ed53
+  depends:
+  - compiler-rt_win-64 21.1.7.*
+  - flang 21.1.7.*
+  - flang-rt_win-64 21.1.7.*
   - lld
   - llvm-tools
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 8816
-  timestamp: 1737072632358
-- conda: https://prefix.dev/conda-forge/win-64/flang_win-64-19.1.7-h719f0c7_0.conda
-  sha256: 7132f5b380c5795a15c5ec09f2bd0dd5c80cda88c9e2202e43cf17c727afd223
-  md5: 86fbc1060058bd120a9619b69d4c7bc9
+  size: 9495
+  timestamp: 1764844590138
+- conda: https://prefix.dev/conda-forge/win-64/flang_win-64-21.1.7-h719f0c7_0.conda
+  sha256: 30b2a29c515a9788a1fbef37f0e8a40a5f615428e1a493edb1f4857930b2ea96
+  md5: b6978cdb68efc96eeeee41f9d53cedc3
   depends:
-  - flang_impl_win-64 19.1.7 h719f0c7_0
+  - flang_impl_win-64 21.1.7 h719f0c7_0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 9707
-  timestamp: 1737072650963
+  size: 10375
+  timestamp: 1764844617543
 - conda: https://prefix.dev/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -8044,16 +8168,6 @@ packages:
   purls: []
   size: 6723
   timestamp: 1753098739029
-- conda: https://prefix.dev/conda-forge/win-64/fortran-compiler-1.11.0-h95e3450_0.conda
-  sha256: 9378136997003be05b4377bef00f414f73f6ed2ec3a8505467bd6eaf0dea2acb
-  md5: c9e93abb0200067d40aa42c96fe1a156
-  depends:
-  - flang_win-64 19.*
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 6980
-  timestamp: 1753098809764
 - conda: https://prefix.dev/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
   sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
   md5: d3549fd50d450b6d9e7dddff25dd2110
@@ -10167,6 +10281,39 @@ packages:
   license: BSD-3-Clause
   size: 66881
   timestamp: 1763190052239
+- conda: https://prefix.dev/conda-forge/win-64/libclang-21.1.7-default_hac490eb_2.conda
+  sha256: ac281180ec9af4099ce6545cace3cccba73d0357ba511cc63f3e2726cd40d83c
+  md5: fdc70159adfba9c90f4ac16d4694cb20
+  depends:
+  - libclang13 21.1.7 default_ha2db4b5_2
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 43262
+  timestamp: 1766021863911
+- conda: https://prefix.dev/conda-forge/win-64/libclang-cpp-21.1.7-default_hac490eb_2.conda
+  sha256: 8f1c341665fc4e3bd4f2596ca17f080873402d28209da72334fddc37e5efb20d
+  md5: 3e9434b7c7b41cf925498fd3a74191b2
+  depends:
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 27752
+  timestamp: 1766020806481
 - conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp19.1-19.1.7-default_h73dfc95_5.conda
   sha256: 6e62da7915a4a8b8bcd9a646e23c8a2180015d85a606c2a64e2385e6d0618949
   md5: 0b1110de04b80ea62e93fef6f8056fbb
@@ -10214,9 +10361,9 @@ packages:
   license_family: Apache
   size: 12340532
   timestamp: 1762471521823
-- conda: https://prefix.dev/conda-forge/win-64/libclang13-21.1.5-default_ha2db4b5_0.conda
-  sha256: 2586b309b3510a4747c354b65e0bc57255ab253eb2e3c7746ccd0c59d90ac9db
-  md5: 07bf98a42744eb814078fa25cc5c8013
+- conda: https://prefix.dev/conda-forge/win-64/libclang13-21.1.7-default_ha2db4b5_2.conda
+  sha256: 11976a22bff823b9993782f9e62fdb68cc951efb74c34ae098742c25f69426c8
+  md5: 367cc7b8c22f31a99935b35ff47b4d7e
   depends:
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
@@ -10225,8 +10372,9 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 28994467
-  timestamp: 1762339649932
+  purls: []
+  size: 28997647
+  timestamp: 1766021554932
 - conda: https://prefix.dev/conda-forge/linux-64/libcublas-12.9.1.4-h676940d_1.conda
   sha256: 671a5204ae983c775d17b3f55b2b0f8ee8cb73b8f0c8b6036070dfadc2770707
   md5: af0df9bc982b5ed2c67e8f5062d1f8c1
@@ -10668,18 +10816,6 @@ packages:
   purls: []
   size: 44866
   timestamp: 1760295760649
-- conda: https://prefix.dev/conda-forge/win-64/libflang-19.1.7-he0c23c2_0.conda
-  sha256: 4dac20c835ee06d779570b3bae9ff1310192c9d78b73a2451a5076192ef22973
-  md5: 52bd262ceddf6dec90b1bdb5472bb34e
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: Apache-2.0
-  license_family: APACHE
-  purls: []
-  size: 1165791
-  timestamp: 1737060291864
 - conda: https://prefix.dev/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
   sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
   md5: f4084e4e6577797150f9b04a4560ceb0
@@ -11468,6 +11604,22 @@ packages:
   license: BSD-3-Clause
   size: 83256
   timestamp: 1763190095972
+- conda: https://prefix.dev/conda-forge/win-64/libllvm-c21-21.1.7-h830ff33_0.conda
+  sha256: 57e12e95a7b5db8060b72e93c34a8d7b8223dca17e80ac80b44fc4ccde9148f4
+  md5: 6a3b8547627a9b98026a52364d81a04d
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - llvmdev 21.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 26385535
+  timestamp: 1764711744583
 - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm19-19.1.7-h8e0c9ce_2.conda
   sha256: 46f8ff3d86438c0af1bebe0c18261ce5de9878d58b4fe399a3a125670e4f0af5
   md5: d1d9b233830f6631800acc1e081a9444
@@ -11483,20 +11635,6 @@ packages:
   purls: []
   size: 26914852
   timestamp: 1757353228286
-- conda: https://prefix.dev/conda-forge/win-64/libllvm19-19.1.7-h830ff33_2.conda
-  sha256: a10457abcb83964bfaf6ba48dcae013823a3ed6ffa988623f744f56156e24721
-  md5: f5a11003ca45a1c81eb72d987cff65b5
-  depends:
-  - libzlib >=1.3.1,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - zstd >=1.5.7,<1.6.0a0
-  license: Apache-2.0 WITH LLVM-exception
-  license_family: Apache
-  purls: []
-  size: 55363
-  timestamp: 1757353124091
 - conda: https://prefix.dev/conda-forge/linux-64/libllvm21-21.1.5-hf7376ad_0.conda
   sha256: 180d77016c2eb5c8722f31a4750496b773e810529110d370ffc6d0cbbf6d15bb
   md5: 9d476d7712c3c78ace006017c83d3889
@@ -11526,6 +11664,20 @@ packages:
   license_family: Apache
   size: 29400991
   timestamp: 1762285527190
+- conda: https://prefix.dev/conda-forge/win-64/libllvm21-21.1.7-h830ff33_0.conda
+  sha256: e0d46c4751bda95c0eb898be51ddd91c53f05a4236c432ae498883586639f56e
+  md5: 1d45103de522a177cca45fff73412ac0
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 55468
+  timestamp: 1764711400236
 - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
   sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
   md5: 1a580f7796c7bf6393fddb8bbbde58dc
@@ -12672,21 +12824,21 @@ packages:
   purls: []
   size: 285516
   timestamp: 1762315951771
-- conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.5-hfa2b4ca_0.conda
-  sha256: 8c5106720e5414f48344fd28eae4db4f1a382336d8a0f30f71d41d8ae730fbb6
-  md5: 3bd3154b24a1b9489d4ab04d62ffcc86
+- conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.8-h4fa8253_0.conda
+  sha256: 145c4370abe870f10987efa9fc15a8383f1dab09abbc9ad4ff15a55d45658f7b
+  md5: 0d8b425ac862bcf17e4b28802c9351cb
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   constrains:
-  - openmp 21.1.5|21.1.5.*
   - intel-openmp <0.0a0
+  - openmp 21.1.8|21.1.8.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 347688
-  timestamp: 1762315988146
+  size: 347566
+  timestamp: 1765964942856
 - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-19.1.7-h855ad52_2.conda
   sha256: 09750c33b5d694c494cad9eafda56c61a62622264173d760341b49fb001afe82
   md5: 3e3ac06efc5fdc1aa675ca30bf7d53df
@@ -12704,28 +12856,28 @@ packages:
   purls: []
   size: 88390
   timestamp: 1757353535760
-- conda: https://prefix.dev/conda-forge/win-64/llvm-tools-19.1.7-h752b59f_2.conda
-  sha256: 439ce0b6c7e5e37b368fa1170b91b508b56a105e32b15d35d82cc3e964b83238
-  md5: 7f24c6c3a50f271f3a3af1ffc1cfff6c
+- conda: https://prefix.dev/conda-forge/win-64/llvm-tools-21.1.7-h752b59f_0.conda
+  sha256: 415267de94f3b1d928a0671305b6be437c74a56e1a9fc99b80269d27bbb6c632
+  md5: 16a5b99cf31d97fe8a4377a1ba1b3f96
   depends:
-  - libllvm19 19.1.7 h830ff33_2
+  - libllvm21 21.1.7 h830ff33_0
   - libxml2
-  - libxml2-16 >=2.14.5
+  - libxml2-16 >=2.14.6
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - clang       19.1.7
-  - clang-tools 19.1.7
-  - llvm        19.1.7
-  - llvmdev     19.1.7
+  - clang-tools 21.1.7
+  - clang       21.1.7
+  - llvm        21.1.7
+  - llvmdev     21.1.7
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 397402701
-  timestamp: 1757353585626
+  size: 444954427
+  timestamp: 1764712126216
 - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-19-19.1.7-h91fd4e7_2.conda
   sha256: 73f9506f7c32a448071340e73a0e8461e349082d63ecc4849e3eb2d1efc357dd
   md5: 8237b150fcd7baf65258eef9a0fc76ef
@@ -12740,6 +12892,28 @@ packages:
   purls: []
   size: 16376095
   timestamp: 1757353442671
+- conda: https://prefix.dev/conda-forge/win-64/llvmdev-21.1.7-h830ff33_0.conda
+  sha256: 1794d84150264cd927bfc1db3a3bb02d419232971d6a863267ff1aa49fe315b8
+  md5: 885008a855e33907b035feabc5d5588c
+  depends:
+  - libllvm-c21 21.1.7 h830ff33_0
+  - libllvm21 21.1.7 h830ff33_0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-tools 21.1.7 h752b59f_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  constrains:
+  - clang-tools 21.1.7
+  - llvm-tools  21.1.7
+  - llvm        21.1.7
+  - clang       21.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  purls: []
+  size: 115484987
+  timestamp: 1764713203747
 - conda: https://prefix.dev/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
   sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
   md5: 91e27ef3d05cc772ce627e51cff111c4
@@ -15823,15 +15997,15 @@ packages:
   version: 0.3.30.0.8
   sha256: b3e980185ab7d959c75c7f0f49b15209ec85434a09144f6cbfe3a45fa825b436
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/cb/b5/f9bb06cd898eca12f2967fc50b9ef6b7e24a23f170578d456ce1132b6f3e/scipy_openblas32-0.3.30.0.8-py3-none-win_amd64.whl
-  name: scipy-openblas32
-  version: 0.3.30.0.8
-  sha256: f8037e0f17f32711117136d98db64b735c4f295c72c9ee1e856748054328b964
-  requires_python: '>=3.7'
 - pypi: https://files.pythonhosted.org/packages/df/05/1de33020d05ec2bf310cc86c5e14e16f4326bc2fd39936cbdd18b86381f0/scipy_openblas32-0.3.30.0.8-py3-none-macosx_11_0_arm64.whl
   name: scipy-openblas32
   version: 0.3.30.0.8
   sha256: c52e267aa3191c053db367e8d202542ebbea476bd4c00fd7c67a2f54ee2e85c0
+  requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/09/79/c92ac258765e35161cc9808838e728734286caa5f238a102a78312632c37/scipy_openblas32-0.3.30.359.2-py3-none-win_amd64.whl
+  name: scipy-openblas32
+  version: 0.3.30.359.2
+  sha256: d3447c15e243ebf3e97e33e50aa29973634e45bca0318093b7642bea336fd5ae
   requires_python: '>=3.7'
 - conda: https://prefix.dev/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
   sha256: 00926652bbb8924e265caefdb1db100f86a479e8f1066efe395d5552dde54d02
@@ -16742,30 +16916,6 @@ packages:
   purls: []
   size: 18919
   timestamp: 1760418632059
-- conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_32.conda
-  sha256: 0694683d118d0d8448cd997fe776dbe33858c0f3957d9886b2b855220babe895
-  md5: c61ef6a81142ee3bd6c3b0c9a0c91e35
-  depends:
-  - vswhere
-  constrains:
-  - vs_win-64 2022.14
-  track_features:
-  - vc14
-  license: BSD-3-Clause
-  license_family: BSD
-  purls: []
-  size: 22206
-  timestamp: 1760418596437
-- conda: https://prefix.dev/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
-  sha256: b72270395326dc56de9bd6ca82f63791b3c8c9e2b98e25242a9869a4ca821895
-  md5: f622897afff347b715d046178ad745a5
-  depends:
-  - __win
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 238764
-  timestamp: 1745560912727
 - conda: https://prefix.dev/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
   sha256: 3aa04ae8e9521d9b56b562376d944c3e52b69f9d2a0667f77b8953464822e125
   md5: 035da2e4f5770f036ff704fa17aace24

--- a/pixi.toml
+++ b/pixi.toml
@@ -152,7 +152,6 @@ blas-devel = "*"
 ### Default building ###
 
 [feature.build-deps.dependencies]
-compilers = "*"
 ccache = "*"
 pkg-config = "*"
 ninja = "*"
@@ -165,9 +164,16 @@ pybind11 = "*"
 numpy = "*"
 blas-devel = "*"
 
+[feature.build-deps.target.unix.dependencies]
+compilers = "*"
+
+[feature.build-deps.target.win-64.dependencies]
+# force flang 21 until https://github.com/conda-forge/compilers-feedstock/pull/76 is in
+flang_win-64 = "21.*"
+
 [feature.win-openblas.target.win-64.dependencies]
 openblas = "*"
-blas-devel = { version = "*", build = "*openblas"}
+blas-devel = { version = "*", build = "*openblas" }
 
 # XXX: when updating this task, remember to update other build tasks if appropriate
 [feature.build-task.tasks.build]
@@ -177,7 +183,7 @@ description = "Build SciPy (default settings)"
 
 [feature.build-task.target.win-64.tasks.build]
 cmd = "spin build --setup-args=-Dblas=openblas --setup-args=-Dlapack=openblas --setup-args=-Duse-g77-abi=true && cp .pixi/envs/build/Library/bin/openblas.dll build-install/Lib/site-packages/scipy/linalg/openblas.dll"
-env = { CC = "ccache clang-cl", CXX = "ccache clang-cl", FC = "ccache $FC", FC_LD = "lld-link" }
+env = { CC = "ccache clang-cl", CXX = "ccache clang-cl", FC = "ccache $FC" }
 description = "Build SciPy (default settings)"
 
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -11,7 +11,7 @@ import os
 import sys
 import textwrap
 from types import ModuleType
-from typing import Literal, TypeAlias, TypeVar
+from typing import Literal, TypeVar
 
 import numpy as np
 from scipy._lib._array_api import (Array, array_namespace, is_lazy_array, is_numpy,
@@ -79,8 +79,8 @@ else:
     wrapped_inspect_signature = inspect.signature
 
 
-_RNG: TypeAlias = np.random.Generator | np.random.RandomState
-SeedType: TypeAlias = IntNumber | _RNG | None
+_RNG: type = np.random.Generator | np.random.RandomState
+SeedType: type = IntNumber | _RNG | None
 
 GeneratorType = TypeVar("GeneratorType", bound=_RNG)
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1111,6 +1111,7 @@ The documentation is written assuming array arguments are of specified
 "core" shapes. However, array argument(s) of this function may have additional
 "batch" dimensions prepended to the core shape. In this case, the array is treated
 as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+Note that calls with zero-size batches are unsupported and will raise a ``ValueError``.
 """
 
 
@@ -1181,6 +1182,13 @@ def _apply_over_batch(*argdefs):
 
             # Determine broadcasted batch shape
             batch_shape = np.broadcast_shapes(*batch_shapes)  # Gives OK error message
+
+            # We can't support zero-size batches right now because without data with
+            # which to call the function, the decorator doesn't even know the *number*
+            # of outputs, let alone their core shapes or dtypes.
+            if math.prod(batch_shape) == 0:
+                message = f'`{f.__name__}` does not support zero-size batches.'
+                raise ValueError(message)
 
             # Broadcast arrays to appropriate shape
             for i, (array, core_shape) in enumerate(zip(arrays, core_shapes)):

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -11,7 +11,7 @@ import os
 import sys
 import textwrap
 from types import ModuleType
-from typing import Literal, TypeVar
+from typing import Literal, TypeAlias, TypeVar
 
 import numpy as np
 from scipy._lib._array_api import (Array, array_namespace, is_lazy_array, is_numpy,
@@ -79,8 +79,8 @@ else:
     wrapped_inspect_signature = inspect.signature
 
 
-_RNG: type = np.random.Generator | np.random.RandomState
-SeedType: type = IntNumber | _RNG | None
+_RNG: TypeAlias = np.random.Generator | np.random.RandomState
+SeedType: TypeAlias = IntNumber | _RNG | None
 
 GeneratorType = TypeVar("GeneratorType", bound=_RNG)
 

--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -472,7 +472,7 @@ def irfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def hfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
          plan=None):
@@ -624,7 +624,7 @@ def ihfft(x, n=None, axis=-1, norm=None, overwrite_x=False, workers=None, *,
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def fftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
          plan=None):
@@ -1032,7 +1032,7 @@ def ifft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None, 
     return (Dispatchable(x, np.ndarray),)
 
 
-@xp_capabilities()
+@xp_capabilities(allow_dask_compute=True)
 @_dispatch
 def rfftn(x, s=None, axes=None, norm=None, overwrite_x=False, workers=None, *,
           plan=None):

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -1254,7 +1254,7 @@ class lsoda(IntegratorBase):
                  with_jacobian=False,
                  rtol=1e-6, atol=1e-12,
                  lband=None, uband=None,
-                 nsteps=5000,  # Increased default for tighter tolerances
+                 nsteps=500,
                  max_step=0.0,  # corresponds to infinite
                  min_step=0.0,
                  first_step=0.0,  # determined by solver

--- a/scipy/integrate/lsoda.py
+++ b/scipy/integrate/lsoda.py
@@ -11,5 +11,5 @@ def __dir__():
 
 def __getattr__(name):
     return _sub_module_deprecation(sub_package="integrate", module="lsoda",
-                                   private_modules=["_lsoda"], all=__all__,
+                                   private_modules=["_odepack"], all=__all__,
                                    attribute=name)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1337,7 +1337,7 @@ def solve_circulant(c, b, singular='raise', tol=None,
 
 
 # matrix inversion
-def inv(a, overwrite_a=False, check_finite=True, assume_a=None, lower=False):
+def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     r"""
     Compute the inverse of a matrix.
 

--- a/scipy/linalg/_decomp_interpolative.pyx
+++ b/scipy/linalg/_decomp_interpolative.pyx
@@ -207,10 +207,10 @@ def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: fl
 
         rta = rta[rng.permutation(m), :]
 
-    # idd_subselect pick randomly n2-many rows
-    subselect = rng.choice(m, n2, replace=False)
-    rta = rta[subselect, :]
-
+    # idd_subselect pick randomly n2-many rows if there are more than one row
+    if m > 1:
+        subselect = rng.choice(m, n2, replace=False)
+        rta = rta[subselect, :]
     # Perform rfft on each column. Note that the first and the last
     # element of the result is real valued (n2 is power of 2).
     #

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -563,6 +563,7 @@ def reconstruct_matrix_from_id(B, idx, proj):
     :class:`numpy.ndarray`
         Reconstructed matrix.
     """
+    B = np.atleast_2d(_C_contiguous_copy(B))
     if _is_real(B):
         return _backend.idd_reconid(B, idx, proj)
     else:

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -69,6 +69,7 @@ py3.extension_module('_fblas',
   link_args: version_link_args,
   dependencies: [lapack_lp64_dep, fortranobject_dep],
   install: true,
+  link_language: 'fortran',
   subdir: 'scipy/linalg'
 )
 

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -609,3 +609,12 @@ class TestBatch:
         message = "Batch support for sparse arrays is not available."
         with pytest.raises(NotImplementedError, match=message):
             linalg.clarkson_woodruff_transform(A, sketch_size=3, rng=rng)
+
+    @pytest.mark.parametrize('f, args', [
+        (linalg.toeplitz, (np.ones((0, 4)),)),
+        (linalg.eig, (np.ones((3, 0, 5, 5)),)),
+    ])
+    def test_zero_size_batch(self, f, args):
+        message = "does not support zero-size batches."
+        with pytest.raises(ValueError, match=message):
+            f(*args)

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -20,6 +20,7 @@ time invariant systems.
 #   Merged discrete systems and added dlti
 
 import warnings
+from types import GenericAlias
 
 # np.linalg.qr fails on some tests with LinAlgError: zgeqrf returns -7
 # use scipy's qr until this is solved
@@ -44,6 +45,9 @@ __all__ = ['lti', 'dlti', 'TransferFunction', 'ZerosPolesGain', 'StateSpace',
 
 
 class LinearTimeInvariant:
+    # generic type compatibility with scipy-stubs
+    __class_getitem__ = classmethod(GenericAlias)
+
     def __new__(cls, *system, **kwargs):
         """Create a new object, don't allow direct instances."""
         if cls is LinearTimeInvariant:

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -9,7 +9,7 @@ from ._arraytools import axis_slice
 
 
 def savgol_coeffs(window_length, polyorder, deriv=0, delta=1.0, pos=None,
-                  use="conv", xp=None, device=None):
+                  use="conv", *, xp=None, device=None):
     """Compute the coefficients for a 1-D Savitzky-Golay FIR filter.
 
     Parameters

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1,7 +1,8 @@
 import warnings
-
+from types import GenericAlias
 
 import numpy as np
+import pytest
 from pytest import raises as assert_raises
 from scipy._lib._array_api import(
     assert_almost_equal, xp_assert_equal, xp_assert_close, make_xp_test_case
@@ -1236,3 +1237,9 @@ class Test_freqresp:
         expected = 1 / (s + 1)**4
         assert_almost_equal(H.real, expected.real)
         assert_almost_equal(H.imag, expected.imag)
+
+@pytest.mark.parametrize(
+    "cls", [StateSpace, TransferFunction, ZerosPolesGain, lti, dlti]
+)
+def test_subscriptable_generic_types(cls):
+    assert isinstance(cls[np.float64], GenericAlias)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -1877,5 +1877,5 @@ class coo_matrix(spmatrix, _coo_base):
     def __getitem__(self, key):
         raise TypeError("'coo_matrix' object is not subscriptable")
 
-    def __setitem__(self, key):
+    def __setitem__(self, key, x):
         raise TypeError("'coo_matrix' object does not support item assignment")

--- a/scipy/stats/_fit.py
+++ b/scipy/stats/_fit.py
@@ -968,7 +968,7 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
 
     >>> import numpy as np
     >>> from scipy import stats
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(1638083107694713882823079058616272161)
     >>> x = stats.uniform.rvs(size=75, random_state=rng)
 
     were sampled from a normal distribution. To perform a KS test, the
@@ -1028,8 +1028,7 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
     calculated exactly and is tyically approximated using Monte Carlo methods
     as described above. This is where `goodness_of_fit` excels.
 
-    >>> res = stats.goodness_of_fit(stats.norm, x, statistic='ks',
-    ...                             rng=rng)
+    >>> res = stats.goodness_of_fit(stats.norm, x, statistic='ks', rng=rng)
     >>> res.statistic, res.pvalue
     (0.1119257570456813, 0.0196)
 
@@ -1043,25 +1042,21 @@ def goodness_of_fit(dist, data, *, known_params=None, fit_params=None,
     statistic - resulting in a higher test power - can be used now that we can
     approximate the null distribution
     computationally. The Anderson-Darling statistic [1]_ tends to be more
-    sensitive, and critical values of the this statistic have been tabulated
+    sensitive, and critical values of this statistic have been tabulated
     for various significance levels and sample sizes using Monte Carlo methods.
 
-    >>> res = stats.anderson(x, 'norm')
+    >>> res = stats.anderson(x, 'norm', method='interpolate')
     >>> print(res.statistic)
     1.2139573337497467
-    >>> print(res.critical_values)
-    [0.555 0.625 0.744 0.864 1.024]
-    >>> print(res.significance_level)
-    [15.  10.   5.   2.5  1. ]
+    >>> print(res.pvalue)
+    0.01
 
     Here, the observed value of the statistic exceeds the critical value
     corresponding with a 1% significance level. This tells us that the p-value
-    of the observed data is less than 1%, but what is it? We could interpolate
-    from these (already-interpolated) values, but `goodness_of_fit` can
+    of the observed data is 1% or less, but what is it? `goodness_of_fit` can
     estimate it directly.
 
-    >>> res = stats.goodness_of_fit(stats.norm, x, statistic='ad',
-    ...                             rng=rng)
+    >>> res = stats.goodness_of_fit(stats.norm, x, statistic='ad', rng=rng)
     >>> res.statistic, res.pvalue
     (1.2139573337497467, 0.0034)
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -12,6 +12,7 @@ from numpy import (isscalar, log, around, zeros,
 from scipy import optimize, special, interpolate, stats
 from scipy._lib._bunch import _make_tuple_bunch
 from scipy._lib._util import _rename_parameter, _contains_nan, _get_nan
+from scipy._lib.deprecation import _NoValue
 import scipy._lib.array_api_extra as xpx
 
 from scipy._lib._array_api import (
@@ -2472,6 +2473,41 @@ def _anderson_simulate_pvalue(x, dist, method):
     return res.pvalue
 
 
+def _anderson_ksamp_continuous(samples, Z, Zstar, k, n, N):
+    """Compute A2akN equation 3 of Scholz & Stephens.
+
+    Parameters
+    ----------
+    samples : sequence of 1-D array_like
+        Array of sample arrays.
+    Z : array_like
+        Sorted array of all observations.
+    Zstar : array_like
+        Sorted array of unique observations. Unused.
+    k : int
+        Number of samples.
+    n : array_like
+        Number of observations in each sample.
+    N : int
+        Total number of observations.
+
+    Returns
+    -------
+    A2KN : float
+        The A2KN statistics of Scholz and Stephens 1987.
+
+    """
+    A2kN = 0.
+
+    j = np.arange(1, N)
+    for i in arange(0, k):
+        s = np.sort(samples[i])
+        Mij = s.searchsorted(Z[:-1], side='right')
+        inner = (N*Mij - j*n[i])**2 / (j * (N - j))
+        A2kN += inner.sum() / n[i]
+    return A2kN / N
+
+
 def _anderson_ksamp_midrank(samples, Z, Zstar, k, n, N):
     """Compute A2akN equation 7 of Scholz and Stephens.
 
@@ -2558,7 +2594,7 @@ Anderson_ksampResult = _make_tuple_bunch(
 
 
 @xp_capabilities(np_only=True)
-def anderson_ksamp(samples, midrank=True, *, method=None):
+def anderson_ksamp(samples, midrank=_NoValue, *, variant=_NoValue, method=None):
     """The Anderson-Darling test for k-samples.
 
     The k-sample Anderson-Darling test is a modification of the
@@ -2572,10 +2608,20 @@ def anderson_ksamp(samples, midrank=True, *, method=None):
     samples : sequence of 1-D array_like
         Array of sample data in arrays.
     midrank : bool, optional
-        Type of Anderson-Darling test which is computed. Default
+        Variant of Anderson-Darling test which is computed. Default
         (True) is the midrank test applicable to continuous and
         discrete populations. If False, the right side empirical
         distribution is used.
+
+        .. deprecated::1.17.0
+            Use parameter `variant` instead.
+    variant : {'midrank', 'right', 'continuous'}
+        Variant of Anderson-Darling test to be computed. ``'midrank'`` is applicable
+        to both continuous and discrete populations. ``'discrete'`` and ``'continuous'``
+        perform alternative versions of the test for discrete  and continuous
+        populations, respectively.
+        When `variant` is specified, the return object will not be unpackable as a
+        tuple, and only attributes ``statistic`` and ``pvalue`` will be present.
     method : PermutationMethod, optional
         Defines the method used to compute the p-value. If `method` is an
         instance of `PermutationMethod`, the p-value is computed using
@@ -2593,6 +2639,10 @@ def anderson_ksamp(samples, midrank=True, *, method=None):
         critical_values : array
             The critical values for significance levels 25%, 10%, 5%, 2.5%, 1%,
             0.5%, 0.1%.
+
+            .. deprecated::1.17.0
+                 Present only when `variant` is unspecified.
+
         pvalue : float
             The approximate p-value of the test. If `method` is not
             provided, the value is floored / capped at 0.1% / 25%.
@@ -2615,11 +2665,12 @@ def anderson_ksamp(samples, midrank=True, *, method=None):
     distributions, in which ties between samples may occur. The
     default of this routine is to compute the version based on the
     midrank empirical distribution function. This test is applicable
-    to continuous and discrete data. If midrank is set to False, the
+    to continuous and discrete data. If `variant` is set to ``'discrete'``, the
     right side empirical distribution is used for a test for discrete
-    data. According to [1]_, the two discrete test statistics differ
-    only slightly if a few collisions due to round-off errors occur in
-    the test not adjusted for ties between samples.
+    data; if `variant` is ``'continuous'``, the same test statistic and p-value are
+    computed for data with no ties, but with less computation. According to [1]_,
+    the two discrete test statistics differ only slightly if a few collisions due
+    to round-off errors occur in the test not adjusted for ties between samples.
 
     The critical values corresponding to the significance levels from 0.01
     to 0.25 are taken from [1]_. p-values are floored / capped
@@ -2639,41 +2690,33 @@ def anderson_ksamp(samples, midrank=True, *, method=None):
     --------
     >>> import numpy as np
     >>> from scipy import stats
-    >>> rng = np.random.default_rng()
-    >>> res = stats.anderson_ksamp([rng.normal(size=50),
-    ... rng.normal(loc=0.5, size=30)])
+    >>> rng = np.random.default_rng(44925884305279435)
+    >>> res = stats.anderson_ksamp([rng.normal(size=50), rng.normal(loc=0.5, size=30)],
+    ...                            variant='midrank')
     >>> res.statistic, res.pvalue
-    (1.974403288713695, 0.04991293614572478)
-    >>> res.critical_values
-    array([0.325, 1.226, 1.961, 2.718, 3.752, 4.592, 6.546])
+    (3.4444310693448936, 0.013106682406720973)
 
     The null hypothesis that the two random samples come from the same
     distribution can be rejected at the 5% level because the returned
-    test value is greater than the critical value for 5% (1.961) but
-    not at the 2.5% level. The interpolation gives an approximate
-    p-value of 4.99%.
+    p-value is less than 0.05, but not at the 1% level.
 
     >>> samples = [rng.normal(size=50), rng.normal(size=30),
     ...            rng.normal(size=20)]
-    >>> res = stats.anderson_ksamp(samples)
+    >>> res = stats.anderson_ksamp(samples, variant='continuous')
     >>> res.statistic, res.pvalue
-    (-0.29103725200789504, 0.25)
-    >>> res.critical_values
-    array([ 0.44925884,  1.3052767 ,  1.9434184 ,  2.57696569,  3.41634856,
-      4.07210043, 5.56419101])
+    (-0.6309662273193832, 0.25)
 
-    The null hypothesis cannot be rejected for three samples from an
-    identical distribution. The reported p-value (25%) has been capped and
-    may not be very accurate (since it corresponds to the value 0.449
-    whereas the statistic is -0.291).
+    As we might expect, the null hypothesis cannot be rejected here for three samples
+    from an identical distribution. The reported p-value (25%) has been capped at the
+    maximum value for which pre-computed p-values are available.
 
     In such cases where the p-value is capped or when sample sizes are
     small, a permutation test may be more accurate.
 
     >>> method = stats.PermutationMethod(n_resamples=9999, random_state=rng)
-    >>> res = stats.anderson_ksamp(samples, method=method)
+    >>> res = stats.anderson_ksamp(samples, variant='continuous', method=method)
     >>> res.pvalue
-    0.5254
+    0.699
 
     """
     k = len(samples)
@@ -2693,10 +2736,28 @@ def anderson_ksamp(samples, midrank=True, *, method=None):
         raise ValueError("anderson_ksamp encountered sample without "
                          "observations")
 
-    if midrank:
+    if variant == _NoValue or midrank != _NoValue:
+        message = ("Parameter `variant` has been introduced to replace `midrank`; "
+                   "`midrank` will be removed in SciPy 1.19.0. Specify `variant` to "
+                   "silence this warning. Note that the returned object will no longer "
+                   "be unpackable as a tuple, and `critical_values` will be omitted.")
+        warnings.warn(message, category=UserWarning, stacklevel=2)
+
+    return_critical_values = False
+    if variant == _NoValue:
+        return_critical_values = True
+        variant = 'midrank' if midrank else 'right'
+
+    if variant == 'midrank':
         A2kN_fun = _anderson_ksamp_midrank
-    else:
+    elif variant == 'right':
         A2kN_fun = _anderson_ksamp_right
+    elif variant == 'continuous':
+        A2kN_fun = _anderson_ksamp_continuous
+    else:
+        message = "`variant` must be one of 'midrank', 'right', or 'continuous'."
+        raise ValueError(message)
+
     A2kN = A2kN_fun(samples, Z, Zstar, k, n, N)
 
     def statistic(*samples):
@@ -2747,10 +2808,15 @@ def anderson_ksamp(samples, midrank=True, *, method=None):
     else:
         p = res.pvalue if method is not None else p
 
-    # create result object with alias for backward compatibility
-    res = Anderson_ksampResult(A2, critical, p)
-    res.significance_level = p
+    if return_critical_values:
+        # create result object with alias for backward compatibility
+        res = Anderson_ksampResult(A2, critical, p)
+        res.significance_level = p
+    else:
+        res = SignificanceResult(statistic=A2, pvalue=p)
+
     return res
+
 
 
 AnsariResult = namedtuple('AnsariResult', ('statistic', 'pvalue'))

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -916,11 +916,10 @@ class TestGoodnessOfFit:
         # c that produced critical value of statistic found w/ root_scalar
         x = stats.genextreme(0.051896837188595134, loc=0.5,
                              scale=1.5).rvs(size=1000, random_state=rng)
-        res = goodness_of_fit(stats.gumbel_r, x, statistic='ad',
-                              rng=rng)
-        ref = stats.anderson(x, dist='gumbel_r')
-        assert_allclose(res.statistic, ref.critical_values[0])
-        assert_allclose(res.pvalue, ref.significance_level[0]/100, atol=5e-3)
+        res = goodness_of_fit(stats.gumbel_r, x, statistic='ad', rng=rng)
+        ref = stats.anderson(x, dist='gumbel_r', method='interpolate')
+        assert_allclose(res.statistic, ref.statistic)
+        assert_allclose(res.pvalue, ref.pvalue, atol=5e-3)
 
     def test_against_filliben_norm(self):
         # Test against `stats.fit` ref. [7] Section 8 "Example"


### PR DESCRIPTION
Note that this set of backports is quite large, and even includes two enhancement PRs to accommodate deprecations/plans in the array API space, so it may increase the chances of needing an RC3 (which I'm prepared to deal with, though still have my fingers crossed). 

* Update the SciPy `1.17.0` release notes following additional backport activity, including updates to the author list and issue/PR lists.  
* Address the comment at: https://github.com/scipy/scipy/pull/24138#discussion_r2615964668  
* Fix a few typos in the release notes that were noticed after RC1.
* Address the missing release notes entries based on the summary at: https://github.com/scipy/scipy/issues/24152

Backports included here (so far):

1. gh-24030
2. gh-24031
3. gh-24132
4. gh-24133
5. gh-24139
6. gh-24140
7. gh-24143
8. gh-24145
9. gh-24151
10. gh-24155
11. gh-24161
12. gh-24174
13. gh-24213
14. gh-24223
15. gh-24218
16. gh-24111 (pulled in the `pixi.toml` changes, discarded lock file changes, then ran `pixi lock`)
17. gh-24239
18. gh-24240

TODO:

- [x] ensure the regular CI is passing
- [x] probably do a dry-run of the wheel builds, I usually do that before starting the rel process proper
- [x] is there anything else left to address with `1.17.0` milestone (I think we're "ok" for those items after this backport PR?): https://github.com/scipy/scipy/issues?q=is%3Aissue%20state%3Aopen%20milestone%3A1.17.0