### PR TITLE
BUG: optimize/tnc/tnc.c: fix uninitialized xoffset when scale is provided

### DIFF
--- a/scipy/optimize/tnc/tnc.c
+++ b/scipy/optimize/tnc/tnc.c
@@ -353,6 +353,8 @@ int tnc(int n, double x[], double *f, double g[], tnc_function * function,
             xscale[i] = fabs(scale[i]);
             if (xscale[i] == 0.0) {
                 xoffset[i] = low[i] = up[i] = x[i];
+            } else {
+                xoffset[i] = x[i];
             }
         } else if (low[i] != -HUGE_VAL && up[i] != HUGE_VAL) {
             xscale[i] = up[i] - low[i];


### PR DESCRIPTION
When calling tnc() with a non-NULL scale array but NULL offset array, and scale[i] != 0.0, the xoffset[i] element was never initialized.

The uninitialized value was then read in tnc_minimize() -> scalex().

Found via Coverity scan analysis.