### PR TITLE
DOC: update 1.17.0 notes for RBFInterpolator

### DIFF
--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -74,6 +74,8 @@ New features
 - `scipy.interpolate.FloaterHormannInterpolator` added support for
   multidimensional, batched inputs and gained a new ``axis`` parameter to
   select the interpolation axis.
+- ``RBFInterpolator`` has gained an array API standard compatible backend, with an
+  improved support for GPU arrays. 
 
 
 ``scipy.linalg`` improvements


### PR DESCRIPTION
A small update to the 1.17.0 release notes: I think it's worth mentioning RBFInterpolator update explicitly, for its up to ~15x perf bump on GPU.