### PR TITLE
BENCH, MAINT: NumPy 2.4.0 bench compat

### DIFF
--- a/benchmarks/benchmarks/sparse.py
+++ b/benchmarks/benchmarks/sparse.py
@@ -323,9 +323,9 @@ class Getset(Benchmark):
         v = np.random.rand(n)
 
         if N == 1:
-            i = int(i)
-            j = int(j)
-            v = float(v)
+            i = int(i[0])
+            j = int(j[0])
+            v = float(v[0])
 
         base = A.asformat(format)
 


### PR DESCRIPTION
* Fixes gh-24212.

* The changes here allow the problematic benchmarking incantation described in the matching ticket to have a passing/zero exit code with NumPy `2.4.0`:
`asv run --quick -b "time_fancy_getitem" -e`

* I looked at the circleci failure log in the matching issue and this seems to be the only issue with NumPy `2.4.0` in the benchmark suite, but we'll see what the CI says..

[skip actions]