### PR TITLE
BUG: optimize.direct: fix two memory leaks

### DIFF
--- a/scipy/optimize/_direct/DIRect.c
+++ b/scipy/optimize/_direct/DIRect.c
@@ -455,7 +455,7 @@
         fmax, &ifeasiblef, &iinfesiblef, ierror, args, jones,
         force_stop);
     if (!ret) {
-        return NULL;
+        goto cleanup;
     }
 /* +-----------------------------------------------------------------------+ */
 /* | Added error checking.                                                 | */
@@ -773,7 +773,8 @@
         PyObject* callback_py = PyObject_CallObject(callback, arg_tuple);
         Py_DECREF(arg_tuple);
         if( !callback_py ) {
-            return NULL;
+            ret = NULL;
+            goto cleanup;
         }
     }
 /* L10: */


### PR DESCRIPTION
Two early return paths bypassed the cleanup section, leaking all allocated memory (13 malloc'd buffers).

After direct_dirinit_() failure changed return NULL to goto cleanup. The ret variable is already NULL in this case.

After Python callback failure set ret = NULL and goto cleanup to ensure proper memory deallocation.

Found by Coverity static analysis.