### PR TITLE
BLD: linalg: `link_language: 'fortran'` for `_fblas`

### DIFF
--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -69,6 +69,7 @@ py3.extension_module('_fblas',
   link_args: version_link_args,
   dependencies: [lapack_lp64_dep, fortranobject_dep],
   install: true,
+  link_language: 'fortran',
   subdir: 'scipy/linalg'
 )
 


### PR DESCRIPTION
Fixes https://github.com/scipy/scipy/pull/24207#issuecomment-3680704234. For https://github.com/conda-forge/scipy-feedstock/pull/315 and https://github.com/scipy/scipy/pull/24111.

Let's wait until it is confirmed over in https://github.com/conda-forge/scipy-feedstock/pull/315 that this helps, but the CI runs at https://github.com/lucascolley/scipy/pull/45 seem to say as much.

@rgommers any idea what kind of curse from the build system gods has caused this to be needed in the bump from `1.16.x` to `1.17.x`? @h-vetinari said at https://github.com/scipy/scipy/pull/24207#issuecomment-3680704234 that the same compiler setup works fine for `1.16.x`.