### PR TITLE
BUG: special.softmax: handle `np.inf`

### DIFF
--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -342,7 +342,7 @@ def softmax(x, axis=None):
     """
     xp = array_namespace(x)
     x = xp.asarray(x)
-    x = xp.where(xp.isinf(x), 1e308 * xp.sign(x), x)
+    x = xp.where(xp.isinf(x), xp.finfo(x.dtype).max * xp.sign(x), x)
     x_max = xp.max(x, axis=axis, keepdims=True)
     with np.errstate(over="ignore", under="ignore"):
         exp_x_shifted = xp.exp(x - x_max)

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -341,7 +341,7 @@ def softmax(x, axis=None):
 
     """
     xp = array_namespace(x)
-    x = xp.asarray(x)
+    x = xp_promote(x, force_floating=True, xp=xp)
     x = xp.where(xp.isinf(x), xp.finfo(x.dtype).max * xp.sign(x), x)
     x_max = xp.max(x, axis=axis, keepdims=True)
     with np.errstate(over="ignore", under="ignore"):

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -342,8 +342,10 @@ def softmax(x, axis=None):
     """
     xp = array_namespace(x)
     x = xp.asarray(x)
+    x = xp.where(xp.isinf(x), 1e308 * xp.sign(x), x)
     x_max = xp.max(x, axis=axis, keepdims=True)
-    exp_x_shifted = xp.exp(x - x_max)
+    with np.errstate(over="ignore", under="ignore"):
+        exp_x_shifted = xp.exp(x - x_max)
     return exp_x_shifted / xp.sum(exp_x_shifted, axis=axis, keepdims=True)
 
 

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -285,6 +285,10 @@ def softmax(x, axis=None):
     The implementation uses shifting to avoid overflow. See [1]_ for more
     details.
 
+    If exactly one ``+inf`` is present along the reduction axis, the output is 1 at that
+    position and 0 elsewhere. If multiple ``+inf`` values are present, or if all values
+    are ``-inf`` along the reduction axis, the output is ``NaN`` along that slice.
+
     .. versionadded:: 1.2.0
 
     References

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -3,6 +3,8 @@ import warnings
 import numpy as np
 from scipy._lib._array_api import (
     array_namespace,
+    is_dask,
+    is_jax,
     xp_capabilities,
     xp_device,
     xp_size,
@@ -353,17 +355,23 @@ def softmax(x, axis=None):
     n_pos_inf = xp.sum(xp.astype(pos_inf, x.dtype), axis=axis, keepdims=True)
     all_neginf = xp.all(x == -xp.inf, axis=axis, keepdims=True)
 
-    if xp.any(n_pos_inf > 1):
-        warnings.warn("multiple +inf in input", RuntimeWarning, stacklevel=2)
-    if xp.any(all_neginf):
-        warnings.warn("all values are -inf", RuntimeWarning, stacklevel=2)
+    if not (is_jax(xp) or is_dask(xp)):
+        if xp.any(n_pos_inf > 1):
+            warnings.warn("multiple +inf in input", RuntimeWarning, stacklevel=2)
+        if xp.any(all_neginf):
+            warnings.warn("all values are -inf", RuntimeWarning, stacklevel=2)
 
-    # Standard softmax with inf replaced by large finite values
-    x = xp.where(xp.isinf(x), xp.finfo(x.dtype).max * xp.sign(x), x)
+    # Standard softmax with +inf replaced by a large finite value. Leave -inf
+    # unchanged; replacing it by -finfo.max can overflow in the subsequent
+    # subtraction when the reduction contains +inf.
+    x = xp.where(pos_inf, xp.finfo(x.dtype).max, x)
     x_max = xp.max(x, axis=axis, keepdims=True)
+    x_max = xp.where(all_neginf, xp.zeros_like(x_max), x_max)
     with np.errstate(over="ignore", under="ignore"):
         exp_x_shifted = xp.exp(x - x_max)
-    out = exp_x_shifted / xp.sum(exp_x_shifted, axis=axis, keepdims=True)
+    denominator = xp.sum(exp_x_shifted, axis=axis, keepdims=True)
+    denominator = xp.where(all_neginf, xp.ones_like(denominator), denominator)
+    out = exp_x_shifted / denominator
 
     # If one single +inf, return 1 there and 0 elsewhere
     # If multiple +inf or all -inf, return NaN there

--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from scipy._lib._array_api import (
     array_namespace,
@@ -346,11 +348,32 @@ def softmax(x, axis=None):
     """
     xp = array_namespace(x)
     x = xp_promote(x, force_floating=True, xp=xp)
+
+    pos_inf = x == xp.inf
+    n_pos_inf = xp.sum(xp.astype(pos_inf, x.dtype), axis=axis, keepdims=True)
+    all_neginf = xp.all(x == -xp.inf, axis=axis, keepdims=True)
+
+    if xp.any(n_pos_inf > 1):
+        warnings.warn("multiple +inf in input", RuntimeWarning, stacklevel=2)
+    if xp.any(all_neginf):
+        warnings.warn("all values are -inf", RuntimeWarning, stacklevel=2)
+
+    # Standard softmax with inf replaced by large finite values
     x = xp.where(xp.isinf(x), xp.finfo(x.dtype).max * xp.sign(x), x)
     x_max = xp.max(x, axis=axis, keepdims=True)
     with np.errstate(over="ignore", under="ignore"):
         exp_x_shifted = xp.exp(x - x_max)
-    return exp_x_shifted / xp.sum(exp_x_shifted, axis=axis, keepdims=True)
+    out = exp_x_shifted / xp.sum(exp_x_shifted, axis=axis, keepdims=True)
+
+    # If one single +inf, return 1 there and 0 elsewhere
+    # If multiple +inf or all -inf, return NaN there
+    out = xp.where(
+        n_pos_inf == 1, xp.where(pos_inf, xp.ones_like(out), xp.zeros_like(out)), out
+    )
+    out = xp.where((n_pos_inf > 1) | all_neginf, xp.full_like(out, xp.nan), out)
+    if out.ndim == 0:
+        out = out[()]
+    return out
 
 
 @xp_capabilities()

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -4,8 +4,9 @@ import pytest
 
 import numpy as np
 
-from scipy._lib._array_api import (is_array_api_strict, make_xp_test_case,
-                                   xp_default_dtype, xp_device)
+from scipy._lib._array_api import (is_array_api_strict, is_dask, is_jax,
+                                   make_xp_test_case, xp_default_dtype,
+                                   xp_device)
 from scipy._lib._array_api_no_0d import (xp_assert_equal, xp_assert_close,
                                          xp_assert_less)
 
@@ -507,8 +508,12 @@ class TestSoftmax:
         dtype = getattr(xp, dtype)
         rtol = 1e-6 if dtype == xp.float32 else 1e-13
         x = xp.asarray(xp_input, dtype=dtype)
-        with pytest.warns(RuntimeWarning, match=warning):
+        # JAX and Dask do not emit value-dependent Python warnings.
+        if is_jax(xp) or is_dask(xp):
             result = softmax(x, axis=axis)
+        else:
+            with pytest.warns(RuntimeWarning, match=warning):
+                result = softmax(x, axis=axis)
         xp_assert_close(result, xp.asarray(expected, dtype=dtype), rtol=rtol)
 
 

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -479,3 +479,18 @@ class TestLogSoftmax:
         x = xp.reshape(x, (2, 2, 2))
         expect = xp.reshape(expect, (2, 2, 2))
         xp_assert_close(log_softmax(x, axis=(1, 2)), expect, rtol=1e-13)
+
+    @pytest.mark.parametrize(
+        "xp, expected",
+        [
+            ([1.0, 1.0, np.inf], [0.0, 0.0, 1.0]),
+            ([1.0, np.inf, np.inf], [0.0, 0.5, 0.5]),
+            ([np.inf, np.inf, np.inf], [1 / 3, 1 / 3, 1 / 3]),
+            ([-np.inf, np.inf], [0.0, 1.0]),
+            ([np.inf], [1.0]),
+            ([-np.inf], [1.0]),
+        ],
+    )
+    def test_softmax_inf_inputs(self, xp, expected):
+        # Handle infinite inputs without producing NaNs - see gh-23225
+        xp_assert_close(softmax(np.asarray(xp)), np.asarray(expected), rtol=1e-13)

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -481,7 +481,7 @@ class TestLogSoftmax:
         xp_assert_close(log_softmax(x, axis=(1, 2)), expect, rtol=1e-13)
 
     @pytest.mark.parametrize(
-        "xp, expected",
+        "xp_input, expected",
         [
             ([1.0, 1.0, np.inf], [0.0, 0.0, 1.0]),
             ([1.0, np.inf, np.inf], [0.0, 0.5, 0.5]),
@@ -491,6 +491,6 @@ class TestLogSoftmax:
             ([-np.inf], [1.0]),
         ],
     )
-    def test_softmax_inf_inputs(self, xp, expected):
+    def test_softmax_inf_inputs(self, xp_input, expected, xp):
         # Handle infinite inputs without producing NaNs - see gh-23225
-        xp_assert_close(softmax(np.asarray(xp)), np.asarray(expected), rtol=1e-13)
+        xp_assert_close(softmax(xp.asarray(xp_input)), xp.asarray(expected), rtol=1e-13)

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -396,22 +396,118 @@ class TestSoftmax:
                         np.asarray([1., 0., 0., 0.]), rtol=1e-13)
 
     @pytest.mark.parametrize(
-        "xp_input, expected",
+        "xp_input, expected, axis",
         [
-            ([1.0, 1.0, np.inf], [0.0, 0.0, 1.0]),
-            ([1.0, np.inf, np.inf], [0.0, 0.5, 0.5]),
-            ([np.inf, np.inf, np.inf], [1 / 3, 1 / 3, 1 / 3]),
-            ([-np.inf, np.inf], [0.0, 1.0]),
-            ([np.inf], [1.0]),
-            ([-np.inf], [1.0]),
+            ([-1.0, 3.0, np.inf], [0.0, 0.0, 1.0], None),
+            ([-np.inf, np.inf], [0.0, 1.0], None),
+            ([np.inf], [1.0], None),
+            ([-np.inf, 1.0, 2.0], [0.0, 0.26894142136999512, 0.7310585786300049], None),
+            ([[1.0, np.inf], [2.0, 3.0]], [[0.0, 1.0], [0.0, 0.0]], None),
+            (
+                [
+                    [2.0, -3.0, np.inf],
+                    [-np.inf, np.inf, 0.0],
+                ],
+                [
+                    [1.0, 0.0, 1.0],
+                    [0.0, 1.0, 0.0],
+                ],
+                0,
+            ),
+            (
+                [
+                    [2.0, -3.0, np.inf],
+                    [-np.inf, np.inf, 0.0],
+                ],
+                [
+                    [0.0, 0.0, 1.0],
+                    [0.0, 1.0, 0.0],
+                ],
+                1,
+            ),
         ],
     )
     @pytest.mark.parametrize("dtype", ["float32", "float64"])
-    def test_softmax_inf_inputs(self, xp_input, expected, dtype, xp):
+    def test_softmax_inf_inputs(self, xp_input, expected, axis, dtype, xp):
         dtype = getattr(xp, dtype)
-        # Handle infinite inputs without producing NaNs - see gh-23225
-        xp_assert_close(softmax(xp.asarray(xp_input, dtype=dtype)),
-                        xp.asarray(expected, dtype=dtype), rtol=1e-13)
+        # If exactly one +inf is present along the reduction axis, the output is 1
+        # at that position and 0 elsewhere - see gh-23225
+        xp_assert_close(
+            softmax(xp.asarray(xp_input, dtype=dtype), axis=axis),
+            xp.asarray(expected, dtype=dtype),
+            rtol=1e-13,
+        )
+
+    @pytest.mark.parametrize(
+        "xp_input, axis, warning, expected",
+        [
+            ([1.0, np.inf, np.inf], None, r"multiple \+inf", [np.nan, np.nan, np.nan]),
+            (
+                [np.inf, np.inf, np.inf],
+                None,
+                r"multiple \+inf",
+                [np.nan, np.nan, np.nan],
+            ),
+            ([-np.inf], None, r"all values are \-inf", [np.nan]),
+            ([-np.inf, -np.inf], None, r"all values are \-inf", [np.nan, np.nan]),
+            (
+                [[1.0, np.inf, np.inf], [0.0, 1.0, 2.0]],
+                1,
+                r"multiple \+inf",
+                [
+                    [np.nan, np.nan, np.nan],
+                    [0.09003057317038046, 0.24472847105479764, 0.6652409557748219],
+                ],
+            ),
+            (
+                [
+                    [np.inf, 1.0],
+                    [np.inf, np.inf],
+                ],
+                1,
+                r"multiple \+inf",
+                [
+                    [1.0, 0.0],
+                    [np.nan, np.nan],
+                ],
+            ),
+            (
+                [
+                    [-np.inf, -np.inf],
+                    [1.0, 2.0],
+                ],
+                1,
+                r"all values are \-inf",
+                [
+                    [np.nan, np.nan],
+                    [0.26894142136999512, 0.7310585786300049],
+                ],
+            ),
+            (
+                [
+                    [np.inf, 1.0],
+                    [np.inf, 2.0],
+                ],
+                0,
+                r"multiple \+inf",
+                [
+                    [np.nan, 0.26894142136999512],
+                    [np.nan, 0.7310585786300049],
+                ],
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", ["float32", "float64"])
+    def test_softmax_inf_indeterminate(
+        self, xp_input, axis, warning, expected, dtype, xp
+    ):
+        # If multiple +inf values are present, or if all values are -inf along the
+        # reduction axis, the output is NaN along that slice - see gh-23225
+        dtype = getattr(xp, dtype)
+        x = xp.asarray(xp_input, dtype=dtype)
+        with pytest.warns(RuntimeWarning, match=warning):
+            result = softmax(x, axis=axis)
+        xp_assert_close(result, xp.asarray(expected, dtype=dtype), rtol=1e-13)
 
 
 @make_xp_test_case(log_softmax)

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -384,7 +384,6 @@ class TestSoftmax:
         xp_assert_close(softmax(x3d, axis=(1, 2)),
                         xp.reshape(expected, (2, 2, 2)), rtol=1e-13)
 
-    @pytest.mark.xfail_xp_backends("array_api_strict", reason="int->float promotion")
     def test_softmax_int_array(self, xp):
         xp_assert_close(softmax(xp.asarray([1000, 0, 0, 0])),
                         xp.asarray([1., 0., 0., 0.]), rtol=1e-13)
@@ -395,6 +394,24 @@ class TestSoftmax:
     def test_softmax_array_like(self):
         xp_assert_close(softmax([1000, 0, 0, 0]),
                         np.asarray([1., 0., 0., 0.]), rtol=1e-13)
+
+    @pytest.mark.parametrize(
+        "xp_input, expected",
+        [
+            ([1.0, 1.0, np.inf], [0.0, 0.0, 1.0]),
+            ([1.0, np.inf, np.inf], [0.0, 0.5, 0.5]),
+            ([np.inf, np.inf, np.inf], [1 / 3, 1 / 3, 1 / 3]),
+            ([-np.inf, np.inf], [0.0, 1.0]),
+            ([np.inf], [1.0]),
+            ([-np.inf], [1.0]),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", ["float32", "float64"])
+    def test_softmax_inf_inputs(self, xp_input, expected, dtype, xp):
+        dtype = getattr(xp, dtype)
+        # Handle infinite inputs without producing NaNs - see gh-23225
+        xp_assert_close(softmax(xp.asarray(xp_input, dtype=dtype)),
+                        xp.asarray(expected, dtype=dtype), rtol=1e-13)
 
 
 @make_xp_test_case(log_softmax)
@@ -479,18 +496,3 @@ class TestLogSoftmax:
         x = xp.reshape(x, (2, 2, 2))
         expect = xp.reshape(expect, (2, 2, 2))
         xp_assert_close(log_softmax(x, axis=(1, 2)), expect, rtol=1e-13)
-
-    @pytest.mark.parametrize(
-        "xp_input, expected",
-        [
-            ([1.0, 1.0, np.inf], [0.0, 0.0, 1.0]),
-            ([1.0, np.inf, np.inf], [0.0, 0.5, 0.5]),
-            ([np.inf, np.inf, np.inf], [1 / 3, 1 / 3, 1 / 3]),
-            ([-np.inf, np.inf], [0.0, 1.0]),
-            ([np.inf], [1.0]),
-            ([-np.inf], [1.0]),
-        ],
-    )
-    def test_softmax_inf_inputs(self, xp_input, expected, xp):
-        # Handle infinite inputs without producing NaNs - see gh-23225
-        xp_assert_close(softmax(xp.asarray(xp_input)), xp.asarray(expected), rtol=1e-13)

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -430,12 +430,13 @@ class TestSoftmax:
     @pytest.mark.parametrize("dtype", ["float32", "float64"])
     def test_softmax_inf_inputs(self, xp_input, expected, axis, dtype, xp):
         dtype = getattr(xp, dtype)
+        rtol = 1e-6 if dtype == xp.float32 else 1e-13
         # If exactly one +inf is present along the reduction axis, the output is 1
         # at that position and 0 elsewhere - see gh-23225
         xp_assert_close(
             softmax(xp.asarray(xp_input, dtype=dtype), axis=axis),
             xp.asarray(expected, dtype=dtype),
-            rtol=1e-13,
+            rtol=rtol,
         )
 
     @pytest.mark.parametrize(
@@ -504,10 +505,11 @@ class TestSoftmax:
         # If multiple +inf values are present, or if all values are -inf along the
         # reduction axis, the output is NaN along that slice - see gh-23225
         dtype = getattr(xp, dtype)
+        rtol = 1e-6 if dtype == xp.float32 else 1e-13
         x = xp.asarray(xp_input, dtype=dtype)
         with pytest.warns(RuntimeWarning, match=warning):
             result = softmax(x, axis=axis)
-        xp_assert_close(result, xp.asarray(expected, dtype=dtype), rtol=1e-13)
+        xp_assert_close(result, xp.asarray(expected, dtype=dtype), rtol=rtol)
 
 
 @make_xp_test_case(log_softmax)


### PR DESCRIPTION
Closes #23225

Enable `special.softmax` to handle inputs containing `np.inf`. 

- If exactly one entry `np.inf`, the result is 1 at the index and 0 elsewhere. 

- If multiple entries are `np.inf`, the probability mass is distributed evenly among them.
For example `softmax([1.0, np.inf, np.inf])` returns `softmax([0.0, 0.5, 0.5])` (see added tests)