### PR TITLE
MAINT: add rudimentary 32 bit compatibility to minimize

### DIFF
--- a/scipy/optimize/_dcsrch.py
+++ b/scipy/optimize/_dcsrch.py
@@ -650,7 +650,10 @@ def dcstep(stx, fx, dx, sty, fy, dy, stp, fp, dp, brackt, stpmin, stpmax):
 
         # The case gamma = 0 only arises if the cubic does not tend
         # to infinity in the direction of the step.
-        gamma = s * np.sqrt(max(0, (theta / s) ** 2 - (dx / s) * (dp / s)))
+        gamma = max(0, (theta / s) ** 2 - (dx / s) * (dp / s))
+        if gamma > 0:
+            gamma = s * np.sqrt(gamma)
+
         if stp > stx:
             gamma = -gamma
         p = (gamma - dp) + theta

--- a/scipy/optimize/_dcsrch.py
+++ b/scipy/optimize/_dcsrch.py
@@ -480,7 +480,7 @@ class DCSRCH:
             self.stmax = stp + xtrapu * (stp - self.stx)
 
         # Force the step to be within the bounds stpmax and stpmin.
-        stp = np.clip(stp, self.stpmin, self.stpmax)
+        stp = max(min(stp, self.stpmax), self.stpmin)
 
         # If further progress is not possible, let stp be the best
         # point obtained during the search.

--- a/scipy/optimize/_dcsrch.py
+++ b/scipy/optimize/_dcsrch.py
@@ -688,7 +688,7 @@ def dcstep(stx, fx, dx, sty, fy, dy, stp, fp, dp, brackt, stpmin, stpmax):
                 stpf = stpc
             else:
                 stpf = stpq
-            stpf = np.clip(stpf, stpmin, stpmax)
+            stpf = max(min(stpf, stpmax), stpmin)
 
     else:
         # Fourth case: A lower function value, derivatives of the same sign,

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -365,7 +365,10 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None, maxcor=10,
                                   workers=workers)
 
     func_and_grad = sf.fun_and_grad
-    f_dtype = sf.fun(x0).dtype
+    f0 = sf.fun(x0)
+    if not hasattr(f0, "dtype"):
+        f0 = np.float64(f0)
+    f_dtype = f0.dtype
     g_dtype = sf.grad(x0).dtype
 
     nbd = zeros(n, np.int32)

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -428,7 +428,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None, maxcor=10,
 
             intermediate_result = OptimizeResult(
                 x=xp_asarray(x, dtype=x0.dtype, copy=False),
-                fun=np.astype(f, f_dtype)
+                fun=f_dtype.type(f)
             )
             if _call_callback_maybe_halt(callback, intermediate_result):
                 task[0] = 5
@@ -462,7 +462,7 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None, maxcor=10,
 
     msg = status_messages[task[0]] + ": " + task_messages[task[1]]
 
-    return OptimizeResult(fun=np.astype(f, f_dtype),
+    return OptimizeResult(fun=f_dtype.type(f),
                           jac=xp_asarray(g, dtype=g_dtype, copy=False),
                           nfev=sf.nfev,
                           njev=sf.ngev,

--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -269,7 +269,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(), approx_grad=0, bounds=None, m=
 
 
 def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None, maxcor=10,
-                     ftol=2.2204460492503131e-09, gtol=1e-5, eps=1e-8, maxfun=15000,
+                     ftol=2.2204460492503131e-09, gtol=1e-5, eps=None, maxfun=15000,
                      maxiter=15000, callback=None, maxls=20, finite_diff_rel_step=None,
                      workers=None, **unknown_options):
     """

--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -138,12 +138,12 @@ def scalar_search_wolfe1(phi, derphi, phi0=None, old_phi0=None, derphi0=None,
     Notes
     -----
     Uses routine DCSRCH from MINPACK.
-    
+
     Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1`` as described in [1]_.
 
     References
     ----------
-    
+
     .. [1] Nocedal, J., & Wright, S. J. (2006). Numerical optimization.
        In Springer Series in Operations Research and Financial Engineering.
        (Springer Series in Operations Research and Financial Engineering).
@@ -490,7 +490,7 @@ def _cubicmin(a, fa, fpa, b, fb, c, fc):
             db = b - a
             dc = c - a
             denom = (db * dc) ** 2 * (db - dc)
-            d1 = np.empty((2, 2))
+            d1 = np.empty_like(fpa, shape=(2, 2))
             d1[0, 0] = dc ** 2
             d1[0, 1] = -db ** 2
             d1[1, 0] = -dc ** 3

--- a/scipy/optimize/_linesearch.py
+++ b/scipy/optimize/_linesearch.py
@@ -157,7 +157,7 @@ def scalar_search_wolfe1(phi, derphi, phi0=None, old_phi0=None, derphi0=None,
     if derphi0 is None:
         derphi0 = derphi(0.)
 
-    if old_phi0 is not None and derphi0 != 0:
+    if old_phi0 is not None and abs(derphi0) > abs(phi0 - old_phi0):
         alpha1 = min(1.0, 1.01*2*(phi0 - old_phi0)/derphi0)
         if alpha1 < 0:
             alpha1 = 1.0
@@ -391,7 +391,7 @@ def scalar_search_wolfe2(phi, derphi, phi0=None,
         derphi0 = derphi(0.)
 
     alpha0 = 0
-    if old_phi0 is not None and derphi0 != 0:
+    if old_phi0 is not None and abs(derphi0) > abs(phi0 - old_phi0):
         alpha1 = min(1.0, 1.01*2*(phi0 - old_phi0)/derphi0)
     else:
         alpha1 = 1.0

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1172,6 +1172,9 @@ def _linesearch_defaults_for_dtype(dtype):
             kwargs['amin'] = 1e-30
             kwargs['amax'] = 1e30
             kwargs['xtol'] = 1e-6
+        case 16:
+            kwargs['amin'] = 1e-4
+            kwargs['amax'] = 1e4
 
     return kwargs
 
@@ -1862,6 +1865,7 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
 
         def polak_ribiere_powell_step(alpha, gfkp1=None):
             xkp1 = xk + alpha * pk
+
             if gfkp1 is None:
                 gfkp1 = myfprime(xkp1)
             yk = gfkp1 - gfk
@@ -1888,11 +1892,20 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
             return np.dot(pk, gfk) <= -sigma_3 * np.dot(gfk, gfk)
 
         try:
-            alpha_k, fc, gc, old_fval, old_old_fval, gfkp1 = \
-                     _line_search_wolfe12(f, myfprime, xk, pk, gfk, old_fval,
-                                          old_old_fval, c1=c1, c2=c2,
-                                          extra_condition=descent_condition,
-                                          **ls_args)
+            _res = _line_search_wolfe12(
+                f,
+                myfprime,
+                xk,
+                pk,
+                gfk,
+                old_fval,
+                old_old_fval,
+                c1=c1,
+                c2=c2,
+                extra_condition=descent_condition,
+                **ls_args
+            )
+            alpha_k, fc, gc, old_fval, old_old_fval, gfkp1 = _res
         except _LineSearchError:
             # Line search failed to find a better solution.
             warnflag = 2

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1869,7 +1869,10 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
             if gfkp1 is None:
                 gfkp1 = myfprime(xkp1)
             yk = gfkp1 - gfk
-            beta_k = max(0, np.dot(yk, gfkp1) / deltak)
+            if deltak != 0:
+                beta_k = max(0, np.dot(yk, gfkp1) / deltak)
+            else:
+                beta_k = 1.
             pkp1 = -gfkp1 + beta_k * pk
             gnorm = vecnorm(gfkp1, ord=norm)
             return (alpha, xkp1, pkp1, gfkp1, gnorm)

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1765,7 +1765,7 @@ def fmin_cg(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
 
 
 def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
-                 gtol=1e-5, norm=np.inf, eps=_epsilon, maxiter=None,
+                 gtol=1e-5, norm=np.inf, eps=None, maxiter=None,
                  disp=False, return_all=False, finite_diff_rel_step=None,
                  c1=1e-4, c2=0.4, workers=None,
                  **unknown_options):
@@ -1830,6 +1830,9 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
     old_fval = f(x0)
     gfk = myfprime(x0)
 
+    res_dtype = _result_dtype(x0.dtype, old_fval.dtype)
+    ls_args = _linesearch_defaults_for_dtype(res_dtype)
+
     k = 0
     xk = x0
     # Sets the initial step guess to dx ~ 1
@@ -1878,8 +1881,9 @@ def _minimize_cg(fun, x0, args=(), jac=None, callback=None,
         try:
             alpha_k, fc, gc, old_fval, old_old_fval, gfkp1 = \
                      _line_search_wolfe12(f, myfprime, xk, pk, gfk, old_fval,
-                                          old_old_fval, c1=c1, c2=c2, amin=1e-100,
-                                          amax=1e100, extra_condition=descent_condition)
+                                          old_old_fval, c1=c1, c2=c2,
+                                          extra_condition=descent_condition,
+                                          **ls_args)
         except _LineSearchError:
             # Line search failed to find a better solution.
             warnflag = 2

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -219,7 +219,7 @@ def fmin_slsqp(func, x0, eqcons=(), f_eqcons=None, ieqcons=(), f_ieqcons=None,
 def _minimize_slsqp(func, x0, args=(), jac=None, bounds=None,
                     constraints=(),
                     maxiter=100, ftol=1.0E-6, iprint=1, disp=False,
-                    eps=_epsilon, callback=None, finite_diff_rel_step=None,
+                    eps=None, callback=None, finite_diff_rel_step=None,
                     workers=None, **unknown_options):
     """
     Minimize a scalar function of one or more variables using Sequential

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3635,20 +3635,10 @@ def test_optimize_32bit(method):
     assert_allclose(result.x, [3, 2], rtol=1e-3)
 
 
-@pytest.mark.parametrize('method', MINIMIZE_METHODS)
-@pytest.mark.parametrize('_dtype', [np.float16, np.float32, np.float64])
+@pytest.mark.parametrize('method', ['BFGS', 'CG', 'L-BFGS-B', 'nelder-mead'])
+@pytest.mark.parametrize('_dtype', [np.float32])
 def test_minimize_float_precision(method, _dtype):
-    # purely a smoke test to check for overflow during operation
-    if method in ['slsqp', 'tnc']:
-        # code requires 64 bit inputs
-        pytest.skip(f"{method} requires 64 bit inputs for native code")
-    if method in ['trust-krylov', 'trust-ncg', 'trust-exact', 'dogleg']:
-        pytest.skip(f"{method} requires hessian, skipping")
-    elif method in ['newton-cg']:
-        pytest.skip(
-            f"{method} needs more work before it can be used with various bitnesses"
-        )
-
+    # purely a smoke test to check output dtypes
     def fun(x):
         return x**4 - x
 

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3653,7 +3653,7 @@ def test_minimize_float_precision(method, _dtype):
         g = None
 
     xx = np.array([2.], dtype=_dtype)**(-2/3)
-    for x0 in np.linspace(-1., 1, 21, dtype=_dtype):
-        res = optimize.minimize(fun, [x0], method=method, jac=g)
+    for x0 in np.linspace(-1., 1, 113, dtype=_dtype):
+        res = optimize.minimize(fun, [x0], method=method, jac=g, tol=1e-6)
         assert res.x.dtype == _dtype
-        # assert_allclose(fun(res.x), fun(xx), rtol=1e-3)
+        assert_allclose(fun(res.x), fun(xx), rtol=2e-3)

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3644,16 +3644,16 @@ def test_minimize_float_precision(method, _dtype):
     # uses an example from gh22865
     def fun(x):
         return x**4 - x
+
     def grad(x):
         return (4*x**3 - 1)
 
-    if method in ['CG']:
-        g = grad
-    else:
-        g = None
+    options = {}
+    if method in ['BFGS', 'CG']:
+        options['gtol'] = 1e-3
 
     xx = np.array([2.], dtype=_dtype)**(-2/3)
-    for x0 in np.linspace(-1., 1, 113, dtype=_dtype):
-        res = optimize.minimize(fun, [x0], method=method, jac=g, tol=1e-6)
+    for x0 in np.linspace(-1., 1, 91, dtype=_dtype):
+        res = optimize.minimize(fun, [x0], method=method, options=options)
         assert res.x.dtype == _dtype
-        assert_allclose(fun(res.x), fun(xx), rtol=2e-3)
+        assert_allclose(res.fun, fun(xx), rtol=2e-3)


### PR DESCRIPTION
Currently the 32-bit compatibility of `minimize` is patchy. Many of the methods were written with solely 64 bit operation in mind. When minimize methods are used with 32-bit x0 and 32-bit objective functions the results are patchy. For example, whilst L-BFGS-B may report success the result may be far away from a minimum. I would classify the current state as silently broken, or at least silently unsuited.

This PR is a follow-on to #24210 (which should be merged first), which adjusts `approx_derivative` to fix numerical differentiation of 32-bit functions. I think that PR is needed as it fixes bugs.
 
Merging that PR starts to highlight deficiencies in various minimize methods. For example, BFGS/L-BFGS-B/CG have hard-coded epsilon values which are ok for 64 bit operation, but aren't suited to 32 bit. When those epsilon values propagate down to `approx_derivative` they cause issues. This PR removes those hard-coded values, allowing `approx_derivative` to make a suitable choice for a 32-bit `x0` or `fun(x0)`.
The PR also adjusts line search parameters for a couple of methods (BFGS/CG) which are more suited to 32 bit. 

Following the change methods (focussing on BFGS/L-BFGS-B/CG that I mainly looked at) can approach a good solution, although they can still terminate with abnormal status due to loss of precision. That's still better than terminating far from a good solution with a clear status.

I would say that those methods are now improved (less broken) w.r.t 32-bit operation, this PR makes an overall improvement to `minimize`. An amendment to documentation is also probably needed: "You can try 32-bit operation but mileage may vary. Various tweaks may be necessary depending on the problem".

The alternative would be for us to forbid 32-bit operation.