### PR TITLE
Modified bspline basis_element to raise error for invalid number of knots

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -363,6 +363,11 @@ class BSpline:
         xp = array_namespace(t)
         t = np.asarray(t)
         k = t.shape[0] - 2
+        
+        if k < 0:
+            raise ValueError("BSpline.basis_element requires at least 2 knots")
+
+        
         t = _as_float_array(t)  # TODO: use concat_1d instead of np.r_
         t = np.r_[(t[0]-1,) * k, t, (t[-1]+1,) * k]
         c = np.zeros_like(t)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -327,6 +327,11 @@ class TestBSpline:
         # 2nd derivative is not guaranteed to be continuous either
         assert not np.allclose(b(x - 1e-10, nu=2), b(x + 1e-10, nu=2))
 
+    def test_basis_element_invalid_too_short(self):
+        # There should be atleast 2 knots
+        assert_raises(ValueError, BSpline.basis_element, **dict(t=[0]))
+        assert_raises(ValueError, BSpline.basis_element, **dict(t=[]))
+
     def test_basis_element_quadratic(self, xp):
         xx = xp.linspace(-1, 4, 20)
         b = BSpline.basis_element(t=xp.asarray([0, 1, 2, 3]))

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -327,10 +327,10 @@ class TestBSpline:
         # 2nd derivative is not guaranteed to be continuous either
         assert not np.allclose(b(x - 1e-10, nu=2), b(x + 1e-10, nu=2))
 
-    def test_basis_element_invalid_too_short(self):
-        # There should be atleast 2 knots
-        assert_raises(ValueError, BSpline.basis_element, **dict(t=[0]))
-        assert_raises(ValueError, BSpline.basis_element, **dict(t=[]))
+    def test_basis_element_invalid_too_short(self,xp):
+        # There should be at least 2 knots
+        assert_raises(ValueError, BSpline.basis_element, **dict(t=xp.asarray([0])))
+        assert_raises(ValueError, BSpline.basis_element, **dict(t=xp.asarray([])))
 
     def test_basis_element_quadratic(self, xp):
         xx = xp.linspace(-1, 4, 20)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -327,7 +327,7 @@ class TestBSpline:
         # 2nd derivative is not guaranteed to be continuous either
         assert not np.allclose(b(x - 1e-10, nu=2), b(x + 1e-10, nu=2))
 
-    def test_basis_element_invalid_too_short(self,xp):
+    def test_basis_element_invalid_too_short(self, xp):
         # There should be at least 2 knots
         assert_raises(ValueError, BSpline.basis_element, **dict(t=xp.asarray([0])))
         assert_raises(ValueError, BSpline.basis_element, **dict(t=xp.asarray([])))


### PR DESCRIPTION
…nots

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
closes https://github.com/scipy/scipy/issues/24192

#### What does this implement/fix?
Raises error when the number of knots passed is less than 2


