### PR TITLE
BUG: cluster.vq: ensure `_kmeans` returns distortion corresponding to final codebook

### DIFF
--- a/scipy/cluster/tests/test_vq.py
+++ b/scipy/cluster/tests/test_vq.py
@@ -384,6 +384,22 @@ class TestKMeans:
         xp_assert_close(res[0], xp.asarray([4.], dtype=xp.float64))
         xp_assert_close(res[1], xp.asarray(2.3999999999999999, dtype=xp.float64)[()])
 
+    def test_kmeans_distortion_matches_vq_mean_regression_24069(self, xp):
+        # Regression test for gh-24069
+        rows = [[8.0, 1e-5, 1e-5, 1e-5]]
+        rows += [[1e-5, 1e-5, 1e-5, 1e-5]] * 51
+        rows += [[0.0, 1e-5, 1e-5, 1e-5]]
+
+        wh = whiten(np.asarray(rows, dtype=np.float64))
+        wh = xp.asarray(wh, dtype=xp.float64)
+
+        rng = np.random.default_rng(1)
+        codebook, distortion = kmeans(wh, 3, iter=5, rng=rng)
+
+        _, dists = vq(wh, codebook, check_finite=False)
+        xp_assert_close(distortion, xp.mean(dists, axis=-1), rtol=1e-12, atol=1e-12)
+
+
     def test_kmeans2_kpp_low_dim(self, xp):
         # Regression test for gh-11462
         rng = np.random.default_rng(2358792345678234568)

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -325,7 +325,8 @@ def _kmeans(obs, guess, thresh=1e-5, xp=None):
         code_book = code_book[has_members]
         code_book = xp.asarray(code_book)
         diff = xp.abs(prev_avg_dists[0] - prev_avg_dists[1])
-    _,final_distortions = vq(obs, code_book, check_finite=False)
+
+    _, final_distortions = vq(obs, code_book, check_finite=False)
     final_distortions_avg = xp.mean(final_distortions, axis=-1)
     return code_book, final_distortions_avg
 

--- a/scipy/cluster/vq.py
+++ b/scipy/cluster/vq.py
@@ -325,8 +325,9 @@ def _kmeans(obs, guess, thresh=1e-5, xp=None):
         code_book = code_book[has_members]
         code_book = xp.asarray(code_book)
         diff = xp.abs(prev_avg_dists[0] - prev_avg_dists[1])
-
-    return code_book, prev_avg_dists[1]
+    _,final_distortions = vq(obs, code_book, check_finite=False)
+    final_distortions_avg = xp.mean(final_distortions, axis=-1)
+    return code_book, final_distortions_avg
 
 
 @xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/scipy/issues/24069

#### What does this implement/fix?
The internal _kmeans routine returned a distortion value computed for a previous iteration rather than for the final codebook (after centroid updates and empty-cluster removal). This led to cases where distortion did not match mean(vq(obs, codebook)[1]).

This change recomputes the distortion with respect to the final codebook before returning, ensuring the reported distortion is consistent with the returned centroids.
#### Additional information
<!--Any additional information you think is important.-->
