### PR TITLE
MAINT: signal: make abcd_normalize respect input dtype and remove dtype kwarg

### DIFF
--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -58,7 +58,7 @@ def _skip_if_poly1d(arg):
 
 ###################
 
-def abcd_normalize_signature(A=None, B=None, C=None, D=None, *, dtype=None):
+def abcd_normalize_signature(A=None, B=None, C=None, D=None):
     return array_namespace(A, B, C, D)
 
 def argrelextrema_signature(data, *args, **kwds):

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -140,6 +140,10 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     -------
     A, B, C, D : array
         State-space matrices as two-dimensional arrays with identical dtype.
+        The result dtype is determined based on the standard
+        `dtype promotion rules <https://numpy.org/doc/2.3/reference/arrays.promotion.html>`_
+        except for when the inputs are all of integer dtype, in which case the returned
+        arrays will have the default floating point dtype of ``float64``.
 
     Raises
     ------
@@ -258,9 +262,10 @@ def ss2tf(A, B, C, D, input=0):
     Notes
     -----
     Before calculating `num` and `den`, the function `abcd_normalize` is called to
-    convert the parameters `A`, `B`, `C`, `D` into two-dimesional arrays. Their dtypes
-    will be "complex128" if any of the matrices are complex-valued. Otherwise, they
-    will be of type "float64".
+    convert the parameters `A`, `B`, `C`, `D` into two-dimesional arrays of the
+    same dtype. The resulting dtype will be based on NumPy's dtype promotion rules,
+    except in the case where each of `A`, `B`, `C`, and `D` has integer dtype, in which
+    case the resulting dtype will be the default floating point dtype of ``float64``.
 
     The :ref:`tutorial_signal_state_space_representation` section of the
     :ref:`user_guide` presents the corresponding definitions of continuous-time and

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -135,15 +135,6 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
         Two-dimensional array of shape (q, n).
     D : array_like, optional
         Two-dimensional array of shape (q, p).
-    dtype : dtype | None, optional
-        Cast all matrices to the specified dtype. If set to ``None`` (default), their
-        dtypes will be "complex128" if any of the matrices are complex-valued.
-        Otherwise, they will be of the type "float64".
-
-        .. versionadded:: 1.18.0
-
-            With this new parameter, all return values have identical dtypes.
-            In previous versions the dtype of the input was preserved.
 
     Returns
     -------
@@ -194,20 +185,6 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     >>> CC
     array([[0., 0.]])
 
-    The following snippet shows the effect of the `dtype` parameter:
-
-    >>> import numpy as np
-    >>> from scipy.signal import abcd_normalize
-    >>> A, D = [[1, 2], [3, 4]], 2.5
-    ...
-    >>> AA, BB, CC, DD = abcd_normalize(A=A, D=D)  # default type casting
-    >>> print(f" AA: {AA.dtype}, BB: {BB.dtype}\n CC: {CC.dtype}, DD: {DD.dtype}")
-     AA: float64, BB: float64
-     CC: float64, DD: float64
-    >>> AA, BB, CC, DD = abcd_normalize(A=A, D=D, dtype=np.float32)  # Explicit dtype
-    >>> print(f" AA: {AA.dtype}, BB: {BB.dtype}\n CC: {CC.dtype}, DD: {DD.dtype}")
-     AA: float32, BB: float32
-     CC: float32, DD: float32
     """
     if A is None and B is None and C is None:
         raise ValueError("Dimension n is undefined for parameters A = B = C = None!")

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -232,12 +232,10 @@ def abcd_normalize(A=None, B=None, C=None, D=None):
     q = C.shape[0] or D.shape[0]
 
     # Create zero matrices as needed:
-    A = xp.zeros((n, n)) if xp_size(A) == 0 else A
-    B = xp.zeros((n, p)) if xp_size(B) == 0 else B
-    C = xp.zeros((q, n)) if xp_size(C) == 0 else C
-    D = xp.zeros((q, p)) if xp_size(D) == 0 else D
-
-    A, B, C, D = (xp.astype(M_, dtype, copy=False) for M_ in (A, B, C, D))
+    A = xp.zeros((n, n), dtype=dtype) if xp_size(A) == 0 else A
+    B = xp.zeros((n, p), dtype=dtype) if xp_size(B) == 0 else B
+    C = xp.zeros((q, n), dtype=dtype) if xp_size(C) == 0 else C
+    D = xp.zeros((q, p), dtype=dtype) if xp_size(D) == 0 else D
 
     if A.shape != (n, n):
         raise ValueError(f"Parameter A has shape {A.shape} but should be ({n}, {n})!")

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -1255,9 +1255,11 @@ class StateSpace(LinearTimeInvariant):
     Notes
     -----
     If the parameter `system` is a tuple (A, B, C, D) with four state space matrices,
-    then those matrices are converted into two-dimensional arrays by calling
-    `abcd_normalize`. Their dtypes will be "complex128" if any of the matrices are
-    complex-valued. Otherwise, they will be of type "float64".
+    then those matrices are converted into two-dimensional arrays of the same dtype
+    by calling `abcd_normalize`. The resulting dtype will be based on NumPy's dtype
+    promotion rules, except in the case where each of `A`, `B`, `C`, and `D` has
+    integer dtype, in which case the resulting dtype will be the default floating point
+    dtype of ``float64``.
 
     Changing the value of properties that are not part of the
     `StateSpace` system representation (such as `zeros` or `poles`) is very

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -162,7 +162,7 @@ abcd_normalize_extra_note = \
     """
 
 capabilities_overrides = {
-    "abcd_normalize": xp_capabilities(extra_note=abcd_normalize_extra_note)
+    "abcd_normalize": xp_capabilities(extra_note=abcd_normalize_extra_note),
     "bessel": xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True),
     "bilinear": xp_capabilities(cpu_only=True, exceptions=["cupy"],
                                 jax_jit=False, allow_dask_compute=True,

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -155,7 +155,14 @@ zpk2tf_extra_note = \
 
     """
 
+abcd_normalize_extra_note = \
+    """The result dtype when all array inputs are of integer dtype is the
+    backend's current default floating point dtype.
+
+    """
+
 capabilities_overrides = {
+    "abcd_normalize": xp_capabilities(extra_note=abcd_normalize_extra_note)
     "bessel": xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True),
     "bilinear": xp_capabilities(cpu_only=True, exceptions=["cupy"],
                                 jax_jit=False, allow_dask_compute=True,

--- a/scipy/signal/tests/test_cont2discrete.py
+++ b/scipy/signal/tests/test_cont2discrete.py
@@ -354,9 +354,9 @@ class TestC2D:
         xp_assert_close(den, den1, rtol=1e-13)
         xp_assert_close(den, den2, rtol=1e-13)
 
-@skip_xp_backends(np_only=True, reason="lti currently not supported")
+
 class TestC2dLti:
-    def test_c2d_ss(self, xp):
+    def test_c2d_ss(self):
         # StateSpace
         A = np.array([[-0.3, 0.1], [0.2, -0.7]])
         B = np.array([[0], [1]])
@@ -367,8 +367,7 @@ class TestC2dLti:
         A_res = np.array([[0.985136404135682, 0.004876671474795],
                           [0.009753342949590, 0.965629718236502]])
         B_res = np.array([[0.000122937599964], [0.049135527547844]])
-        # Resulting A, B, C, D are arrays of the same dtype due to abcd_normalize() use:
-        C_res = np.astype(C, A_res.dtype)
+        C_res = np.astype(C, np.float64)
 
         sys_ssc = lti(A, B, C, D)
         sys_ssd = sys_ssc.to_discrete(dt=dt)
@@ -385,7 +384,7 @@ class TestC2dLti:
         xp_assert_close(sys_ssd2.C, C_res)
         xp_assert_close(sys_ssd2.D, np.zeros_like(sys_ssd.D))
 
-    def test_c2d_tf(self, xp):
+    def test_c2d_tf(self):
 
         sys = lti([0.5, 0.3], [1.0, 0.4])
         sys = sys.to_discrete(0.005)

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -952,9 +952,11 @@ class Test_abcd_normalize:
                       self.A, [-1, 5], self.C, self.D)
 
     def test_normalized_matrices_unchanged(self, xp):
-        A_, B_, C_, D_ = map(xp.asarray, (self.A, self.B, self.C, self.D))
-        # On torch/float32: A_, B_, C_, D_ are of dtype float32 => set dtype:
-        A, B, C, D = abcd_normalize(A=A_, B=B_, C=C_, D=D_, dtype=A_.dtype)
+        A_, B_, C_, D_ = map(
+            lambda t: xp.asarray(t, dtype=xp.float64),
+            (self.A, self.B, self.C, self.D),
+        )
+        A, B, C, D = abcd_normalize(A=A_, B=B_, C=C_, D=D_)
         xp_assert_equal(A, A_)
         xp_assert_equal(B, B_)
         xp_assert_equal(C, C_)
@@ -969,11 +971,10 @@ class Test_abcd_normalize:
         assert B.shape[1] == D.shape[1]
 
     def test_zero_dimension_is_not_none1(self, xp):
-        A_ = xp.asarray(self.A)
-        B_ = xp.zeros((2, 0))
-        D_ = xp.zeros((0, 0))
-        # On torch/float32: A_, B_, C_, D_ are of dtype float32 => set dtype:
-        A, B, C, D = abcd_normalize(A=A_, B=B_, D=D_, dtype=A_.dtype)
+        A_ = xp.asarray(self.A, dtype=xp.float64)
+        B_ = xp.zeros((2, 0), dtype=xp.float64)
+        D_ = xp.zeros((0, 0), dtype=xp.float64)
+        A, B, C, D = abcd_normalize(A=A_, B=B_, D=D_)
         xp_assert_equal(A, A_)
         xp_assert_equal(B, B_)
         xp_assert_equal(D, D_)
@@ -981,11 +982,10 @@ class Test_abcd_normalize:
         assert C.shape[1] == A_.shape[0]
 
     def test_zero_dimension_is_not_none2(self, xp):
-        A_ = xp.asarray(self.A)
-        B_ = xp.zeros((2, 0))
-        C_ = xp.zeros((0, 2))
-        # On torch/float32: A_, B_, C_, D_ are of dtype float32 => set dtype:
-        A, B, C, D = abcd_normalize(A=A_, B=B_, C=C_, dtype=A_.dtype)
+        A_ = xp.asarray(self.A, dtype=xp.float64)
+        B_ = xp.zeros((2, 0), dtype=xp.float64)
+        C_ = xp.zeros((0, 2), dtype=xp.float64)
+        A, B, C, D = abcd_normalize(A=A_, B=B_, C=C_)
         xp_assert_equal(A, A_)
         xp_assert_equal(B, B_)
         xp_assert_equal(C, C_)
@@ -993,7 +993,10 @@ class Test_abcd_normalize:
         assert D.shape[1] == B_.shape[1]
 
     def test_missing_A(self, xp):
-        B_, C_, D_ = map(xp.asarray, (self.B, self.C, self.D))
+        B_, C_, D_ = map(
+            lambda t: xp.asarray(t, dtype=xp.float64),
+            (self.B, self.C, self.D),
+        )
         A, B, C, D = abcd_normalize(B=B_, C=C_, D=D_)
         assert A.shape[0] == A.shape[1]
         assert A.shape[0] == B.shape[0]
@@ -1007,7 +1010,10 @@ class Test_abcd_normalize:
         assert B.shape == (A_.shape[0], D_.shape[1])
 
     def test_missing_C(self, xp):
-        A_, B_, D_ = map(xp.asarray, (self.A, self.B, self.D))
+        A_, B_, D_ = map(
+            lambda t: xp.asarray(t, dtype=xp.float64),
+            (self.A, self.B, self.D),
+        )
         A, B, C, D = abcd_normalize(A=A_, B=B_, D=D_)
         assert C.shape[0] == D.shape[0]
         assert C.shape[1] == A.shape[0]
@@ -1069,26 +1075,6 @@ class Test_abcd_normalize:
     def test_missing_CD_fails(self, xp):
         A, B = xp.asarray(self.A), xp.asarray(self.B)
         assert_raises(ValueError, abcd_normalize, A=A, B=B)
-
-    def test_param_dtype_exceptions(self):
-        with pytest.raises(ValueError, match="^Parameter dtype='INVALID' must be"):
-            abcd_normalize(self.A, self.B, self.C, self.D, dtype='INVALID')
-        with pytest.raises(ValueError, match="^Parameter dtype=<class 'str'>"):
-            abcd_normalize(self.A, self.B, self.C, self.D, dtype=str)
-        with pytest.raises(ValueError, match="^Parameter dtype="):
-            abcd_normalize(self.A, self.B, self.C, self.D, dtype=np.datetime64)
-
-    def test_param_dtype(self, xp):
-        A, D = xp.asarray(self.A), xp.asarray(self.D)
-        AA, BB, CC, DD = abcd_normalize(A=A, D=D)
-        assert AA.dtype == BB.dtype == CC.dtype == DD.dtype == xp.float64
-
-        AA, BB, CC, DD = abcd_normalize(A=A, D=D, dtype=xp.int64)
-        assert AA.dtype == BB.dtype == CC.dtype == DD.dtype == xp.int64
-
-        DD_ = 1 + 2j  # converts to complex128
-        AA, BB, CC, DD = abcd_normalize(A=A, D=DD_)
-        assert AA.dtype == BB.dtype == CC.dtype == DD.dtype == xp.complex128
 
 
 class Test_bode:

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -1076,6 +1076,42 @@ class Test_abcd_normalize:
         A, B = xp.asarray(self.A), xp.asarray(self.B)
         assert_raises(ValueError, abcd_normalize, A=A, B=B)
 
+    @pytest.mark.parametrize(
+        "A_dtype,B_dtype,C_dtype,D_dtype,expected_dtype",
+        [
+            ("int64", "int64", "int64", "int64", "float64"),
+            ("float32", "float32", "float32", "float32", "float32"),
+            ("float32", "float32", "float32", "float64", "float64"),
+            ("complex64", "complex64", "complex64", "complex64", "complex64"),
+            ("complex128", "complex128", "complex128", "complex128", "complex128"),
+            ("float64", "float64", "complex128", "float64", "complex128"),
+            (None, "int64", "int64", "int64", "float64"),
+            (None, "float32", "float32", "float32", "float32"),
+            (None, "float32", "float32", "float64", "float64"),
+            (None, "complex64", "complex64", "complex64", "complex64"),
+            (None, "complex128", "complex128", "complex128", "complex128"),
+            (None, "float64", "complex128", "float64", "complex128"),
+        ]
+    )
+    # Also check case where one input array has size zero.
+    @pytest.mark.parametrize("D", [[[2.5]], [[]]])
+    def test_dtypes(
+            self, D, A_dtype, B_dtype, C_dtype, D_dtype, expected_dtype, xp
+    ):
+        args = []
+        for X, X_dtype in zip(
+                [self.A, self.B, self.C, D],
+                [A_dtype, B_dtype, C_dtype, D_dtype]
+        ):
+            args.append(
+                xp.asarray(X, dtype=getattr(xp, X_dtype))
+                if X_dtype is not None else None
+            )
+        A, B, C, D = args
+        A, B, C, D = abcd_normalize(A=A, B=B, C=C, D=D)
+        expected_dtype = getattr(xp, expected_dtype)
+        assert A.dtype == B.dtype == C.dtype == D.dtype == expected_dtype
+
 
 class Test_bode:
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
As promised here: https://github.com/scipy/scipy/pull/23554#issuecomment-3687517059, this PR removes the `dtype` kwarg that was added to `abcd_normalize` in #23544 and instead makes `abcd_normalize` respect input dtype, but convert integers to floating point numbers using `xp_promote` with `force_floating=True`. Note how this not only makes the behavior match a typical convention, but also makes the code simpler and easier to maintain.

I've also added a test that dtype is preserved which reveals something I must have been aware of but had previously glossed over. `xp_result_type` and `xp_promote` currently convert to PyTorch's default floating point type when the expected result would otherwise be an integer but `force_floating=True`. The array API standard allows type promotion rules for mixed integer and floating point numbers to be undefined, so I will think carefully about what could be done here. Having SciPy's behavior not depend on the default dtype seems valuable to me, but mixed integer and floating point cases seems like a source of edge cases that may always be thorny. @lucascolley, do you have any thoughts about what could be done? For now I've just added xfails for the failing tests.
#### Additional information
<!--Any additional information you think is important.-->
