### PR TITLE
MAINT: ScalarFunction returns same dtype as original function intended

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -589,8 +589,9 @@ class _ScalarFunctionWrapper:
 
         # Make sure the function returns a true scalar
         if not np.isscalar(fx):
+            _dt = getattr(fx, "dtype", np.dtype(np.float64))
             try:
-                fx = np.asarray(fx).item()
+                fx = _dt.type(np.asarray(fx).item())
             except (TypeError, ValueError) as e:
                 raise ValueError(
                     "The user-provided objective function "

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -531,8 +531,9 @@ def _wrap_scalar_function(function, args):
         # Ideally, we'd like to a have a true scalar returned from f(x). For
         # backwards-compatibility, also allow np.array([1.3]), np.array([[1.3]]) etc.
         if not np.isscalar(fx):
+            _dt = getattr(fx, "dtype", np.float64)
             try:
-                fx = np.asarray(fx).item()
+                fx = _dt.type(np.asarray(fx).item())
             except (TypeError, ValueError) as e:
                 raise ValueError("The user-provided objective function "
                                  "must return a scalar value.") from e
@@ -562,8 +563,9 @@ def _wrap_scalar_function_maxfun_validation(function, args, maxfun):
         # backwards-compatibility, also allow np.array([1.3]),
         # np.array([[1.3]]) etc.
         if not np.isscalar(fx):
+            _dt = getattr(fx, "dtype", np.dtype(np.float64))
             try:
-                fx = np.asarray(fx).item()
+                fx = _dt.type(np.asarray(fx).item())
             except (TypeError, ValueError) as e:
                 raise ValueError("The user-provided objective function "
                                  "must return a scalar value.") from e

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -451,6 +451,8 @@ class TestScalarFunction(TestCase):
         fx = sf.fun(x0)
         assert fun(x0).dtype == np.float32
         assert fx.dtype == np.float32
+        # check that the round trip cast works as intended
+        assert_equal(fx, fun(x0))
 
 
 class ExVectorialFunction:

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -440,6 +440,18 @@ class TestScalarFunction(TestCase):
         res = sf.fun(x0)
         assert res.dtype == np.float32
 
+        # checks that ScalarFunction.fun returns a value with the same float
+        # precision as the unwrapped function would call.
+        def fun(x):
+            return x**4 - x
+
+        x0 = np.array([1.2], dtype=np.float32)
+        sf = ScalarFunction(fun, x0, (), '2-point', lambda x: None,
+                            None, (-np.inf, np.inf))
+        fx = sf.fun(x0)
+        assert fun(x0).dtype == np.float32
+        assert fx.dtype == np.float32
+
 
 class ExVectorialFunction:
 


### PR DESCRIPTION
I found a bug, `ScalarFunction.fun(x0).dtype` is not necessarily the same as `fun(x0).dtype` if `fun` returns an array with one element, `np.array([1.234], dtype=np.float32)`. 

This is because there is an `np.ndarray.item()` call, which casts all float types less than or equal to 64 bits to a 64-bit Python scalar. Thus `fun(x0)` could return 32 bit, but `ScalarFunction.fun(x0)` would be 64 bit.

This PR ensures that ScalarFunction returns the correct dtype.