### PR TITLE
ENH: integrate.fixed_quad: add array API support

### DIFF
--- a/scipy/integrate/_lebedev.py
+++ b/scipy/integrate/_lebedev.py
@@ -5357,11 +5357,7 @@ def get_lebedev_recurrence_points(type_, start, a, b, v, leb):
     return leb, start
 
 
-_xp_note = ("This is because no arrays are accepted as input; simply convert the "
-            "output to the array type of choice.")
-
-
-@xp_capabilities(out_of_scope=True, extra_note=_xp_note)
+@xp_capabilities(np_only=True)
 def lebedev_rule(n):
     r"""Lebedev quadrature.
 

--- a/scipy/integrate/_lebedev.py
+++ b/scipy/integrate/_lebedev.py
@@ -5357,7 +5357,11 @@ def get_lebedev_recurrence_points(type_, start, a, b, v, leb):
     return leb, start
 
 
-@xp_capabilities(np_only=True)
+_xp_note = ("This is because no arrays are accepted as input; simply convert the "
+            "output to the array type of choice.")
+
+
+@xp_capabilities(out_of_scope=True, extra_note=_xp_note)
 def lebedev_rule(n):
     r"""Lebedev quadrature.
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -238,8 +238,8 @@ def fixed_quad(func, a, b, args=(), n=5):
     1.0
 
     """
-    xp = array_namespace(a, b, *args)
-    # for B.C., `args` shouldn't be forced to be floating point (or even numeric)
+    # `args` not necessarily numeric arrays, so don't pass to array_namespace/xp_promote
+    xp = array_namespace(a, b)
     a, b = xp_promote(a, b, force_floating=True, xp=xp)
     x, w = _cached_roots_legendre(n)
     x, w = xp.asarray(x, dtype=a.dtype), xp.asarray(w, dtype=a.dtype)
@@ -988,11 +988,7 @@ _builtincoeffs = {
     }
 
 
-_xp_note = ("This is because no arrays are accepted as input; simply convert the "
-            "output to the array type of choice.")
-
-
-@xp_capabilities(out_of_scope=True, extra_note=_xp_note)
+@xp_capabilities(np_only=True)
 def newton_cotes(rn, equal=0):
     r"""
     Return weights and error coefficient for Newton-Cotes integration.

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -19,10 +19,16 @@ from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
-
 @make_xp_test_case(fixed_quad)
 class TestFixedQuad:
-    def test_scalar(self, xp):
+    def test_scalar(self):
+        n = 4
+        expected = 1/(2*n)
+        got, _ = fixed_quad(lambda x: x**(2*n - 1), 0, 1, n=n)
+        # quadrature exact for this input
+        xp_assert_close(got, np.asarray(expected), rtol=1e-12)
+
+    def test_0d(self, xp):
         n = 4
         expected = 1/(2*n)
         got, _ = fixed_quad(lambda x: x**(2*n - 1), xp.asarray(0.), xp.asarray(1.), n=n)
@@ -36,8 +42,8 @@ class TestFixedQuad:
         p = xp.arange(1., 2*n, dtype=dtype)
         a, b = xp.asarray(0., dtype=dtype), xp.asarray(1., dtype=dtype)
         expected = 1/(p + 1)
-        got, _ = fixed_quad(lambda x, p: x**p[:, xp.newaxis],a, b, args=(p,), n=n)
-        rtol = 1e-12 if dtype == xp.float64 else 1e-7
+        got, _ = fixed_quad(lambda x, p: x**p[:, xp.newaxis], a, b, args=(p,), n=n)
+        rtol = 1e-12 if dtype == xp.float64 else 2e-7
         xp_assert_close(got, xp.asarray(expected), rtol=rtol)
 
     @skip_xp_backends('jax.numpy', reason="lazy -> limited input validation")


### PR DESCRIPTION
#### Reference issue
Toward https://github.com/scipy/scipy/issues/20930

#### What does this implement/fix?
Adds array API support to `scipy.integrate.fixed_quad`. Currently marks `newton_cotes` and `lebedev_rule` rule as `out_of_scope` because they accept no arrays, but see below.

#### Additional information
`newton_cotes` and `lebedev_rule` don't accept arrays, but they do some array calculations and return arrays. There are several functions like this in SciPy (e.g. in `linalg` like [`scipy.linalg.hilbert`](https://scipy.github.io/devdocs/reference/generated/scipy.linalg.hilbert.html)) that current accept a Python `int` and return a floating point array. Should these begin to accept a 0d - potentially floating point dtype - array containing a single integer and returning an array of the result (forced floating point) dtype?