### PR TITLE
ENH: stats: add Grenander estimator for monotone decreasing densities

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -588,13 +588,14 @@ Plot-tests
    boxcox_normplot
    yeojohnson_normplot
 
-Univariate and multivariate kernel density estimation
+Univariate and multivariate density estimation
 -----------------------------------------------------
 
 .. autosummary::
    :toctree: generated/
 
    gaussian_kde
+   grenander
 
 Warnings / Errors used in :mod:`scipy.stats`
 --------------------------------------------
@@ -633,6 +634,7 @@ from ._multicomp import *
 from ._binomtest import binomtest
 from ._binned_statistic import *
 from ._kde import gaussian_kde
+from ._grenander import grenander
 from . import mstats
 from . import qmc
 from ._multivariate import *

--- a/scipy/stats/_grenander.py
+++ b/scipy/stats/_grenander.py
@@ -81,10 +81,10 @@ class grenander:
     Estimate a decreasing density from exponential data.
 
     >>> import numpy as np
-    >>> from scipy.stats import expon, grenander
+    >>> from scipy import stats
     >>> rng = np.random.default_rng(1234567891)
     >>> x = rng.exponential(size=100)
-    >>> g = grenander(x)
+    >>> g = stats.grenander(x)
 
     The estimator provides the fitted density values at the observations:
 
@@ -190,7 +190,7 @@ class grenander:
             )
 
         # Collect gaps in order statistics
-        W = np.concat([[self.support_min], x])
+        W = np.concatenate([[self.support_min], x])
         w = np.diff(W)
 
         # Raw ECDF slopes on each interval are 1/(n*w); LCM slopes are the

--- a/scipy/stats/_grenander.py
+++ b/scipy/stats/_grenander.py
@@ -146,6 +146,7 @@ class grenander:
 
     def pdf(self, x):
         """Evaluate the estimated density at `x`."""
+        x = np.asarray(x, dtype=float)
         indices = np.searchsorted(self.knots, x, side='right') - 1
         indices = np.clip(indices, 0, len(self.slopes) - 1)
         
@@ -155,27 +156,15 @@ class grenander:
     
     __call__ = pdf
 
-    def logpdf(self, x):
-        """Evaluate log density, returning -inf where density is 0."""
-        p = self.pdf(x)
-        with np.errstate(divide="ignore"):
-            return np.log(p)
-
     def cdf(self, x):
         """Evaluate the estimated CDF at `x`."""
+        x = np.asarray(x, dtype=float)
         return np.interp(x, self.knots, self.heights, 
                          left=0.0, right=1.0)
-
-    def sf(self, x):
-        """Survival function 1 - CDF."""
-        return 1.0 - self.cdf(x)
-
-    def logcdf(self, x):
-        """Evaluate log CDF."""
-        return np.log(self.cdf(x))
     
-    def ppf(self, q):
+    def icdf(self, q):
         """Percent point function (inverse CDF)."""
+        q = np.asarray(q, dtype=float)
         return np.interp(q, self.heights, self.knots,
                          left=self.support_min,
                          right=self.knots[-1])

--- a/scipy/stats/_grenander.py
+++ b/scipy/stats/_grenander.py
@@ -234,8 +234,8 @@ class grenander:
             )
 
         # Collect gaps in order statistics
-        W = np.r_[self.support_min, x]
-        w = W[1:] - W[:-1]
+        W = np.concat([[self.support_min], x])
+        w = np.diff(W)
 
         # Raw ECDF slopes on each interval are 1/(n*w); LCM slopes are the
         # isotonic (nonincreasing) regression of these with weights w

--- a/scipy/stats/_grenander.py
+++ b/scipy/stats/_grenander.py
@@ -150,7 +150,7 @@ class grenander:
         indices = np.searchsorted(self.knots, x, side='right') - 1
         indices = np.clip(indices, 0, len(self.slopes) - 1)
         
-        in_support = (self.support_min <= x) & (x < self.knots[-1])
+        in_support = (self.support_min <= x) & (x <= self.knots[-1])
         
         return np.where(in_support, self.slopes[indices], 0.0)
     

--- a/scipy/stats/_grenander.py
+++ b/scipy/stats/_grenander.py
@@ -1,0 +1,260 @@
+import numpy as np
+from scipy.optimize import isotonic_regression
+from scipy.interpolate import interp1d
+
+class grenander:
+    """Grenander estimator of a nonincreasing density.
+
+    The Grenander estimator is the nonparametric maximum likelihood estimator 
+    of a nonincreasing density with a known lower bound on the support.
+
+    Parameters
+    ----------
+    dataset : array_like
+        1D sample of observations. Must lie strictly above `support_min`.
+        Duplicates are not allowed (ties create zero-width intervals).
+    support_min : float, default=0.0
+        Known lower bound of the support.
+    assume_sorted : bool, default=False
+        If True, assume `dataset` is already sorted ascending.
+
+    Attributes
+    ----------
+    fitted : ndarray, shape (n,)
+        Estimated density values corresponding to observations in `dataset`.
+    knots : ndarray, shape (B+1,)
+        Bin edges / knot locations of the least concave majorant (LCM) CDF.
+    heights : ndarray, shape (B+1,)
+        CDF values at `knots` (piecewise-linear between knots).
+    slopes : ndarray, shape (B,)
+        Density levels on intervals [knots[j], knots[j+1]).
+    support_min : float
+        Lower support bound.
+
+    See Also
+    --------
+    scipy.optimize.isotonic_regression : Isotonic regression 
+    scipy.stats.ecdf : Empirical cumulative distribution function
+    scipy.stats.gaussian_kde : Gaussian kernel density estimation
+
+    Notes
+    -----
+    The Grenander estimator [2]_ is the nonparametric maximum likelihood 
+    estimator of a nonincreasing density on a known, lower-bounded support. 
+    Equivalently, it solves
+
+    .. math::
+
+        \\text{maximize} \\frac{1}{n}\sum_{i=1}^n \log f(x_i)
+
+    subject to
+
+    .. math::
+        
+        f : [0,\infty) \\to [0,\infty) \\text{ nonincreasing, and } 
+        \int_0^\infty f(x)\,dx = 1.
+
+    The estimator may be characterized geometrically as the left derivative of 
+    the least concave majorant (LCM) of the empirical cumulative distribution 
+    function [3]_. As a result, the fitted density is a piecewise-constant 
+    function with data-adaptive bin widths, as well as a decreasing histogram 
+    whose breakpoints are determined by the pool-adjacent-violators algorithm.
+    Under mild regularity conditions, the Grenander estimator is consistent and
+    converges at the nonstandard rate :math:`n^{-1/3}` [1]_ [4]_. 
+    
+    References 
+    ---------- 
+    .. [1] L. Birgé. "Estimating a density under order restrictions: 
+           Nonasymptotic minimax risk", The Annals of Statistics, Vol. 15, pp. 
+           995-1012, 1987.
+
+    .. [2] U. Grenander, "On the theory of mortality measurement: part II", 
+           Scandinavian Actuarial Journal, Vol. 39, pp. 125-153, 1956. 
+           
+    .. [3] P. Groeneboom and G. Jongbloed, "Nonparametric estimation under 
+           shape constraints", Cambridge University Press, New York, 2014. 
+           
+    .. [4] B.L.S.P. Rao, "Estimation of a unimodal density", Sankhyā: The 
+           Indian Journal of Statistics, Series A, Vol. 31, pp. 23-36, 1969.
+
+    Examples
+    --------
+    Estimate a decreasing density from exponential data.
+
+    >>> import numpy as np
+    >>> from scipy.stats import expon, grenander
+    >>> rng = np.random.default_rng(1234567891)
+    >>> x = rng.exponential(size=100)
+    >>> g = grenander(x)
+
+    The estimator provides the fitted density values at the observations:
+
+    >>> g.fitted.shape
+    (100,)
+
+    Evaluate the PDF and CDF at specific points:
+
+    >>> g.pdf([0.5, 1.0, 2.0])
+    array([0.52828842, 0.23170026, 0.21893189])
+    >>> g.cdf([0.5, 1.0, 2.0])
+    array([0.37589365, 0.60242482, 0.83153771])
+
+    The estimator is piecewise constant with data-adaptive breakpoints:
+
+    >>> len(g.slopes)  # number of constant pieces
+    15
+    >>> g.knots  # breakpoints of the histogram
+    array([0.        , 0.00903572, 0.02683709, 0.05754583, 0.46991483,
+           0.73492159, 0.77473536, 0.98953465, 1.11901228, 1.9016237 ,
+           2.08432892, 2.29638573, 2.68628217, 3.38105853, 4.67484783,
+           5.93619219])
+
+    Draw new samples from the estimated density:
+
+    >>> y = g.rvs(size=1000, random_state=0)
+    >>> y.shape
+    (1000,)
+
+    Visualize the estimated density alongside the true exponential density
+    and the empirical CDF:
+
+    >>> import matplotlib.pyplot as plt
+    >>> fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
+
+    >>> # Plot density
+    >>> xs = np.linspace(0, 6, 500)
+    >>> ax1.plot(xs, expon.pdf(xs), 'k-', label='True density')
+    >>> g.plot_pdf(ax=ax1, fill=True, alpha=0.7, label='Grenander')
+    >>> ax1.set_xlabel('x')
+    >>> ax1.set_ylabel('Density')
+    >>> ax1.legend()
+
+    >>> # Plot CDF
+    >>> ax2.plot(xs, g.cdf(xs), label='Grenander CDF')
+    >>> ax2.step(np.sort(x), np.arange(1, len(x)+1)/len(x), 
+    ...          where='post', label='Empirical CDF')
+    >>> ax2.plot(xs, expon.cdf(xs), 'k-', label='True CDF')
+    >>> ax2.set_xlabel('x')
+    >>> ax2.set_ylabel('CDF')
+    >>> ax2.legend()
+    >>> plt.tight_layout()
+    >>> plt.show()
+    """
+    def __init__(self, 
+                 dataset, 
+                 support_min=0.0, 
+                 assume_sorted=False):
+        self.support_min = support_min
+        params = self._fit(dataset, assume_sorted)
+        self.__dict__.update(params)
+
+        self._cdf_interp = interp1d(
+            self.knots, self.heights, kind="linear",
+            bounds_error=False, fill_value=(0.0, 1.0),
+            assume_sorted=True
+        )
+
+        self._pdf_interp = interp1d(
+            self.knots[:-1],
+            self.slopes,
+            kind="previous",
+            bounds_error=False,
+            fill_value=(np.nan, 0.0),
+            assume_sorted=True
+        )
+
+    def pdf(self, x):
+        """Evaluate the estimated density at `x`."""
+        return np.asarray(self._pdf_interp(x), dtype=float)
+    
+    __call__ = pdf
+
+    def logpdf(self, x):
+        """Evaluate log density, returning -inf where density is 0."""
+        p = self.pdf(x)
+        with np.errstate(divide="ignore"):
+            return np.log(p)
+
+    def cdf(self, x):
+        """Evaluate the estimated CDF at `x`."""
+        return np.asarray(self._cdf_interp(x), dtype=float)
+
+    def sf(self, x):
+        """Survival function 1 - CDF."""
+        return 1.0 - self.cdf(x)
+
+    def rvs(self, size=None, random_state=None):
+        """Sample from the estimated density."""
+        rng = np.random.default_rng(random_state)
+        size = 1 if size is None else size
+
+        widths = np.diff(self.knots)
+        mass = widths * self.slopes
+        mass = mass / mass.sum()
+
+        j = rng.choice(len(mass), size=size, p=mass)
+        u = rng.random(size=size)
+        return self.knots[j] + u * widths[j]
+
+    def plot_pdf(self, ax=None, *, fill=True, **kwargs):
+        """Plot the estimated density as a histogram with variable bin widths.
+    
+        Parameters
+        ----------
+        ax : matplotlib.axes.Axes, optional
+            Axes object to plot on. If None, uses current axes.
+        fill : bool, default=True
+            Whether to fill the histogram.
+        **kwargs
+            Additional arguments passed to matplotlib's stairs function.
+        """
+        import matplotlib.pyplot as plt
+        if ax is None:
+            ax = plt.gca()
+        return ax.stairs(self.slopes, self.knots, fill=fill, **kwargs)
+
+    def _fit(self, dataset, assume_sorted=False):
+        """Internal fitting method."""
+        x = np.asarray(dataset, dtype=float)
+        n = x.size
+        if n == 0:
+            raise ValueError("`dataset` has no observations.")
+        if np.any(x <= self.support_min):
+            raise ValueError(
+                f"All observations in `dataset` must be strictly greater than "
+                f"support_min={self.support_min}"
+            )
+        if not assume_sorted:
+            I = x.argsort()
+            x = x[I]
+        if np.any(x[1:] == x[:-1]):
+            raise ValueError(
+                "`dataset` contains duplicate values. The Grenander estimator "
+                "requires strictly distinct observations."
+            )
+
+        # Collect gaps in order statistics
+        W = np.r_[self.support_min, x]
+        w = W[1:] - W[:-1]
+
+        # Raw ECDF slopes on each interval are 1/(n*w); LCM slopes are the
+        # isotonic (nonincreasing) regression of these with weights w
+        raw = np.ones(n)/(n*w)
+        res = isotonic_regression(raw, 
+                                weights=w.copy(), 
+                                increasing=False)
+        fitted = res.x
+        blocks  = res.blocks
+
+        params = dict()
+        params['knots']   = W[blocks]
+        params['heights'] = blocks/n
+        params['slopes']  = fitted[blocks[:-1]]
+
+        # Return fitted values in original order
+        if not assume_sorted:
+            fitted = fitted[I.argsort()]
+
+        params['fitted'] = fitted
+
+        return params

--- a/scipy/stats/meson.build
+++ b/scipy/stats/meson.build
@@ -127,6 +127,7 @@ py3.install_sources([
     '_entropy.py',
     '_finite_differences.py',
     '_fit.py',
+    '_grenander.py',
     '_hypotests.py',
     '_kde.py',
     '_ksstats.py',

--- a/scipy/stats/tests/meson.build
+++ b/scipy/stats/tests/meson.build
@@ -18,6 +18,7 @@ py3.install_sources([
     'test_entropy.py',
     'test_fast_gen_inversion.py',
     'test_fit.py',
+    'test_grenander.py',
     'test_hypotests.py',
     'test_kdeoth.py',
     'test_marray.py',

--- a/scipy/stats/tests/test_grenander.py
+++ b/scipy/stats/tests/test_grenander.py
@@ -1,0 +1,163 @@
+import numpy as np
+import pytest
+from numpy.testing import (
+    assert_allclose, assert_array_equal, assert_, assert_equal
+)
+
+from scipy.stats._grenander import grenander
+
+
+def _integral_of_hist(knots, slopes):
+    widths = np.diff(knots)
+    return np.sum(widths * slopes)
+
+def test_input_validation():
+    rng = np.random.default_rng(0)
+
+    # empty
+    with pytest.raises(ValueError, match="no observations"):
+        grenander([])
+
+    x = rng.exponential(size=10)
+
+    # support_min strict inequality
+    with pytest.raises(ValueError, match="strictly greater"):
+        grenander(np.r_[0.0, x], support_min=0.0)
+
+    with pytest.raises(ValueError, match="strictly greater"):
+        grenander(x, support_min=x.min())
+
+    # duplicates forbidden
+    x2 = np.array([0.1, 0.2, 0.2, 0.3])
+    with pytest.raises(ValueError, match="duplicate"):
+        grenander(x2)
+
+    # if assume_sorted=True, duplicates should still be caught
+    x3 = np.array([0.1, 0.2, 0.2, 0.3])
+    with pytest.raises(ValueError, match="duplicate"):
+        grenander(x3, assume_sorted=True)
+
+
+def test_assume_sorted_equivalence_and_fitted_ordering():
+    rng = np.random.default_rng(123)
+    x = rng.exponential(size=200)
+
+    g_unsorted = grenander(x, assume_sorted=False)
+
+    xs = np.sort(x)
+    g_sorted = grenander(xs, assume_sorted=True)
+
+    # "function" parts should agree (cdf/pdf), regardless of data ordering
+    grid = np.linspace(0, xs.max() * 1.1, 200)
+    assert_allclose(g_unsorted.cdf(grid), g_sorted.cdf(grid), 
+                    rtol=0, atol=1e-14)
+    assert_allclose(g_unsorted.pdf(grid), g_sorted.pdf(grid), 
+                    rtol=0, atol=1e-14)
+
+    # fitted is returned in original order for assume_sorted=False;
+    # it should match the sorted version when permuted by argsort.
+    I = np.argsort(x)
+    assert_allclose(g_unsorted.fitted[I], g_sorted.fitted, rtol=0, atol=0)
+
+
+def test_basic_shapes_and_monotonicity_invariants():
+    rng = np.random.default_rng(1)
+    x = rng.exponential(size=300)
+    g = grenander(x)
+
+    n = x.size
+
+    # shapes
+    assert_equal(g.fitted.shape, (n,))
+    assert_(g.knots.ndim == 1)
+    assert_(g.heights.ndim == 1)
+    assert_(g.slopes.ndim == 1)
+    assert_equal(g.knots.size, g.slopes.size + 1)
+    assert_equal(g.heights.size, g.knots.size)
+
+    # knots increasing, heights increasing, slopes nonincreasing
+    assert_(np.all(np.diff(g.knots) > 0))
+    assert_(np.all(np.diff(g.heights) > 0))
+    assert_(np.all(np.diff(g.slopes) < 0))
+
+    # first knot is support_min; last height is 1
+    assert_allclose(g.knots[0], g.support_min, rtol=0, atol=0)
+    assert_allclose(g.heights[-1], 1.0, rtol=0, atol=0)
+
+    # integral is 1 (up to float error)
+    assert_allclose(_integral_of_hist(g.knots, g.slopes), 1.0, 
+                    rtol=1e-13, atol=1e-13)
+
+
+def test_pdf_cdf_boundary_behavior_and_call_alias():
+    rng = np.random.default_rng(2)
+    x = rng.exponential(size=100)
+    g = grenander(x, support_min=0.0)
+
+    # below support_min: cdf=0, pdf=nan (per fill_value)
+    assert_allclose(g.cdf([-1.0, -0.5, 0.0]), [0.0, 0.0, 0.0], rtol=0, atol=0)
+    p = g.pdf([-1.0, -0.5])
+    assert_(np.all(np.isnan(p)))
+
+    # above last knot: cdf=1, pdf=0
+    big = g.knots[-1] + 10.0
+    assert_allclose(g.cdf(big), 1.0, rtol=0, atol=0)
+    assert_allclose(g.pdf(big), 0.0, rtol=0, atol=0)
+
+    # __call__ alias
+    grid = np.linspace(0.01, g.knots[-1], 50)
+    assert_allclose(g(grid), g.pdf(grid), rtol=0, atol=0)
+
+
+def test_logpdf_handles_zeros():
+    # construct a case where pdf(x) == 0 happens (x beyond last knot)
+    rng = np.random.default_rng(3)
+    x = rng.exponential(size=120)
+    g = grenander(x, support_min=0.0)
+
+    big = g.knots[-1] + 1.0
+    lp = g.logpdf(big)
+    assert_(np.isneginf(lp))
+
+    # below support_min => pdf is nan => logpdf is nan
+    lp2 = g.logpdf(-1.0)
+    assert_(np.isnan(lp2))
+
+
+def test_cdf_is_consistent_with_histogram_representation():
+    rng = np.random.default_rng(4)
+    x = rng.exponential(size=250)
+    g = grenander(x, support_min=0.0)
+
+    # On any point inside an interval [k_j, k_{j+1}),
+    # cdf(x) = height[j] + slope[j]*(x - k_j)
+    # We'll test midpoints of each bin.
+    mid = 0.5 * (g.knots[:-1] + g.knots[1:])
+    expected = g.heights[:-1] + g.slopes * (mid - g.knots[:-1])
+    assert_allclose(g.cdf(mid), expected, rtol=0, atol=2e-14)
+
+    # CDF right at knots should match heights (linear interpolation)
+    assert_allclose(g.cdf(g.knots), g.heights, rtol=0, atol=0)
+
+
+def test_rvs_reproducible_and_within_support():
+    rng = np.random.default_rng(5)
+    x = rng.exponential(size=200)
+    g = grenander(x, support_min=0.0)
+
+    y1 = g.rvs(size=1000, random_state=123)
+    y2 = g.rvs(size=1000, random_state=123)
+    assert_array_equal(y1, y2)
+
+    assert_equal(y1.shape, (1000,))
+    assert_(np.all(y1 >= g.support_min))
+    assert_(np.all(y1 <= g.knots[-1]))  
+
+
+def test_sf_identity():
+    rng = np.random.default_rng(6)
+    x = rng.exponential(size=150)
+    g = grenander(x, support_min=0.0)
+
+    grid = np.linspace(0.0, g.knots[-1] + 1.0, 200)
+    assert_allclose(g.sf(grid), 1.0 - g.cdf(grid), rtol=0, atol=0)

--- a/scipy/stats/tests/test_grenander.py
+++ b/scipy/stats/tests/test_grenander.py
@@ -89,39 +89,31 @@ def test_basic_shapes_and_monotonicity_invariants():
                     rtol=1e-13, atol=1e-13)
 
 
-def test_pdf_cdf_boundary_behavior_and_call_alias():
+def test_pdf_cdf_boundary_behavior():
     rng = np.random.default_rng(2)
     x = rng.exponential(size=100)
     g = grenander(x, support_min=0.0)
 
-    # below support_min: cdf=0, pdf=nan (per fill_value)
-    assert_allclose(g.cdf([-1.0, -0.5, 0.0]), [0.0, 0.0, 0.0], rtol=0, atol=0)
-    p = g.pdf([-1.0, -0.5])
-    assert_(np.all(np.isnan(p)))
+    # below support_min: cdf=0, pdf=0
+    assert_allclose(g.cdf([-1.0, -0.5, 0.0]), [0.0, 0.0, 0.0])
+    assert_allclose(g.pdf([-1.0, -0.5]), [0.0, 0.0])
 
     # above last knot: cdf=1, pdf=0
     big = g.knots[-1] + 10.0
-    assert_allclose(g.cdf(big), 1.0, rtol=0, atol=0)
-    assert_allclose(g.pdf(big), 0.0, rtol=0, atol=0)
-
-    # __call__ alias
-    grid = np.linspace(0.01, g.knots[-1], 50)
-    assert_allclose(g(grid), g.pdf(grid), rtol=0, atol=0)
+    assert_allclose(g.cdf(big), 1.0)
+    assert_allclose(g.pdf(big), 0.0)
 
 
 def test_logpdf_handles_zeros():
-    # construct a case where pdf(x) == 0 happens (x beyond last knot)
     rng = np.random.default_rng(3)
     x = rng.exponential(size=120)
     g = grenander(x, support_min=0.0)
 
+    # pdf=0 => logpdf=-inf both below and above support
     big = g.knots[-1] + 1.0
-    lp = g.logpdf(big)
-    assert_(np.isneginf(lp))
-
-    # below support_min => pdf is nan => logpdf is nan
-    lp2 = g.logpdf(-1.0)
-    assert_(np.isnan(lp2))
+    assert_(np.isneginf(g.logpdf(big)))
+    
+    assert_(np.isneginf(g.logpdf(-1.0)))
 
 
 def test_cdf_is_consistent_with_histogram_representation():


### PR DESCRIPTION
#### Reference issue
None.

#### What does this implement/fix?
This PR adds the Grenander estimator to `scipy.stats`, providing a nonparametric maximum likelihood estimator (MLE) of a probability density under a monotonicity constraint.

Whereas `scipy.stats.ecdf` gives the MLE of a distribution function, there is no corresponding MLE for a density without additional structure. Imposing monotonicity yields a well-defined and classical MLE known as _the Grenander estimator_, which this PR implements. The estimator can equivalently be viewed as a data-adaptive histogram with decreasing heights and variable bin widths, requiring no bandwidth or tuning parameters, in contrast to histograms or kernel density estimators.

The implementation follows the standard characterization as the left derivative of the least concave majorant of the ecdf and is built directly on `scipy.optimize.isotonic_regression`, making it a natural extension of existing SciPy functionality. A comprehensive test suite is included.

#### Additional information
- The implementation relies only on existing public SciPy methods, mainly `scipy.optimize.isotonic_regression` as well as `scipy.interpolate.interp1d`.
- All feedback, especially on API, placement, and scope, is very welcome.
