### PR TITLE
DOC: Add default values to optimize.root parameter documentation

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -200,31 +200,31 @@ def _root_hybr(func, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, default 0
         Specify whether the Jacobian function computes derivatives down
         the columns (faster, because there is no transpose operation).
-    xtol : float
+    xtol : float, default 1.49012e-08
         The calculation will terminate if the relative error between two
         consecutive iterates is at most `xtol`.
-    maxfev : int
+    maxfev : int, default 0
         The maximum number of calls to the function. If zero, then
         ``100*(N+1)`` is the maximum where N is the number of elements
         in `x0`.
-    band : tuple
+    band : tuple, default None
         If set to a two-sequence containing the number of sub- and
         super-diagonals within the band of the Jacobi matrix, the
         Jacobi matrix is considered banded (only for ``jac=None``).
-    eps : float
+    eps : float, default None
         A suitable step length for the forward-difference
         approximation of the Jacobian (for ``jac=None``). If
         `eps` is less than the machine precision, it is assumed
         that the relative errors in the functions are of the order of
         the machine precision.
-    factor : float
+    factor : float, default 100
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in the interval
         ``(0.1, 100)``.
-    diag : sequence
+    diag : sequence, default None
         N positive entries that serve as a scale factors for the
         variables.
 

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -286,28 +286,28 @@ def _root_leastsq(fun, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, default 0
         non-zero to specify that the Jacobian function computes derivatives
         down the columns (faster, because there is no transpose operation).
-    ftol : float
+    ftol : float, default 1.49012e-08
         Relative error desired in the sum of squares.
-    xtol : float
+    xtol : float, default 1.49012e-08
         Relative error desired in the approximate solution.
-    gtol : float
+    gtol : float, default 0.0
         Orthogonality desired between the function vector and the columns
         of the Jacobian.
-    maxiter : int
+    maxiter : int, default 0
         The maximum number of calls to the function. If zero, then
         100*(N+1) is the maximum where N is the number of elements in x0.
-    eps : float
+    eps : float, default 0.0
         A suitable step length for the forward-difference approximation of
         the Jacobian (for Dfun=None). If `eps` is less than the machine
         precision, it is assumed that the relative errors in the functions
         are of the order of the machine precision.
-    factor : float
+    factor : float, default 100
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in interval ``(0.1, 100)``.
-    diag : sequence
+    diag : sequence, default None
         N positive entries that serve as a scale factors for the variables.
     """
     nfev = 0


### PR DESCRIPTION
Fixes #22635

## Summary
Added default parameter values to the docstrings for `scipy.optimize.root` solver methods to improve documentation clarity.

## Changes
- Updated `scipy.optimize._root._root_leastsq` (lm method) docstring with default values
- Updated `scipy.optimize._minpack_py._root_hybr` (hybr method) docstring with default values

Parameters now clearly show their defaults (e.g., `xtol : float, default 1.49012e-08`)

This makes it easier for users to understand the default behavior without having to inspect the source code.

## Test plan
- Documentation changes only, no functional changes
- Verified docstrings render correctly