### PR TITLE
BUG: Improve error message in LinearOperator.rmatmat

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -429,6 +429,12 @@ class LinearOperator:
     def _rmatmat(self, X):
         """Default implementation of _rmatmat defers to rmatvec or adjoint."""
         if type(self)._adjoint == LinearOperator._adjoint:
+            # Check if rmatvec is properly defined before using it
+            if not hasattr(self, '_rmatvec') or self._rmatvec is None:
+                raise NotImplementedError(
+                    "rmatmat is not defined, and cannot be derived from rmatvec. "
+                    "Please define either rmatmat or rmatvec when creating the LinearOperator."
+                )
             return np.hstack([self.rmatvec(col.reshape(-1, 1)) for col in X.T])
         else:
             return self.H.matmat(X)


### PR DESCRIPTION
Fixes #18140

## Summary
Improves the error message when `LinearOperator.rmatmat` is called without a defined `rmatmat` or `rmatvec` implementation.

## Problem
Previously, when a `LinearOperator` was created with only `matvec` defined (no `rmatmat` or `rmatvec`), calling `rmatmat` would produce an obscure error:
```
TypeError: 'NoneType' object is not callable
```

## Solution
Now raises a clear `NotImplementedError` with a helpful message:
```
NotImplementedError: rmatmat is not defined, and cannot be derived from rmatvec. 
Please define either rmatmat or rmatvec when creating the LinearOperator.
```

## Changes
- Added explicit check in `LinearOperator._rmatmat()` before attempting to use `rmatvec`
- Raises `NotImplementedError` with descriptive message when neither method is available

## Test plan
```python
from scipy.sparse.linalg import LinearOperator
op = LinearOperator(matvec=lambda x: x, shape=(1, 1))
op.rmatmat([[1]])  # Now raises clear NotImplementedError
```