### PR TITLE
DOC: stats.rv_discrete: remove unsupported parameter 'scale' from documentation

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3989,10 +3989,7 @@ for method_name in _remove_scale_methods:
     # remove `scale` parameter from method documentation
     method = getattr(rv_discrete, method_name)
     doc = FunctionDoc(method)
-    for i, param in enumerate(doc['Parameters']):
-        if param.name == 'scale':
-            break
-    doc['Parameters'].pop(i)
+    doc['Parameters'] = [p for p in doc['Parameters'] if p.name != 'scale']
     doc = str(doc).split("\n", 1)[1].lstrip(" \n")  # remove signature
     method.__doc__ = str(doc)
 

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3951,6 +3951,37 @@ class rv_discrete(rv_generic):
         param_info = shape_info + [loc_info]
         return param_info
 
+    # these methods are identical to those of `rv_generic` except that
+    # they don't accept the `scale` parameter. They need their own copy
+    # of the methods so we can adjust the documentation.
+
+    def entropy(self, *args, **kwargs):
+        return super().entropy(*args, **kwargs)
+
+    def interval(self, confidence, *args, **kwargs):
+        return super().interval(confidence, *args, **kwargs)
+
+    def mean(self, *args, **kwargs):
+        return super().mean(*args, **kwargs)
+
+    def median(self, *args, **kwargs):
+        return super().median(*args, **kwargs)
+
+    def moment(self, order, *args, **kwargs):
+        return super().moment(order, *args, **kwargs)
+
+    def stats(self, *args, **kwargs):
+        return super().stats(*args, **kwargs)
+
+    def std(self, *args, **kwargs):
+        return super().std(*args, **kwargs)
+
+    def support(self, *args, **kwargs):
+        return super().support(*args, **kwargs)
+
+    def var(self, *args, **kwargs):
+        return super().var(*args, **kwargs)
+
 
 _remove_scale_methods = ['entropy', 'interval', 'mean', 'median',
                          'moment', 'stats', 'std', 'support', 'var']

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -12,6 +12,7 @@ import warnings
 from itertools import zip_longest
 
 from scipy._lib import doccer
+from scipy._lib._docscrape import FunctionDoc
 from ._distr_params import distcont, distdiscrete
 from scipy._lib._util import check_random_state
 import scipy._lib.array_api_extra as xpx
@@ -1155,7 +1156,7 @@ class rv_generic:
             instance object for more information)
         loc : array_like, optional
             location parameter (default=0)
-        scale : array_like, optional (continuous RVs only)
+        scale : array_like, optional
             scale parameter (default=1)
         moments : str, optional
             composed of letters ['mvsk'] defining which moments to compute:
@@ -1268,7 +1269,7 @@ class rv_generic:
             instance object for more information).
         loc : array_like, optional
             Location parameter (default=0).
-        scale : array_like, optional  (continuous distributions only).
+        scale : array_like, optional
             Scale parameter (default=1).
 
         Notes
@@ -3949,6 +3950,20 @@ class rv_discrete(rv_generic):
         loc_info = _ShapeInfo("loc", True, (-np.inf, np.inf), (False, False))
         param_info = shape_info + [loc_info]
         return param_info
+
+
+_remove_scale_methods = ['entropy', 'interval', 'mean', 'median',
+                         'moment', 'stats', 'std', 'support', 'var']
+for method_name in _remove_scale_methods:
+    # remove `scale` parameter from method documentation
+    method = getattr(rv_discrete, method_name)
+    doc = FunctionDoc(method)
+    for i, param in enumerate(doc['Parameters']):
+        if param.name == 'scale':
+            break
+    doc['Parameters'].pop(i)
+    doc = str(doc).split("\n", 1)[1].lstrip(" \n")  # remove signature
+    method.__doc__ = str(doc)
 
 
 def _expect(fun, lb, ub, x0, inc, maxcount=1000, tolerance=1e-10,


### PR DESCRIPTION
#### Reference issue
Closes gh-23868

#### What does this implement/fix?
Removes unsupported parameter 'scale' from documentation of `rv_discrete` methods

#### Additional information
Fortunately, `scale` does not seem to appear in the method lists of each distribution.

[Link to rendered docs](https://output.circle-artifacts.com/output/job/c83e3b1e-1203-42ec-b30a-939c8d6a4aeb/artifacts/0/html/reference/generated/scipy.stats.rv_discrete.html#scipy.stats.rv_discrete)

Example: `rv_discrete.entropy`
<img width="1044" height="428" alt="image" src="https://github.com/user-attachments/assets/357e2b19-a2d8-4b86-9a09-56ce75e9dc23" />

vs `rv_continuous.entropy`

<img width="1041" height="438" alt="image" src="https://github.com/user-attachments/assets/2f4be0d7-38f9-437d-81db-2b4564cce922" />
