### PR TITLE
TST: stats.gstd: remove JAX xfail of test_ddof_equal_to_number_of_observations

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7060,7 +7060,6 @@ class TestGSTD:
         gstd_actual = stats.gstd(a, axis=1)
         xp_assert_close(gstd_actual, xp.asarray([4, np.nan]))
 
-    @xfail_xp_backends("jax.numpy", reason="returns subnormal instead of nan")
     def test_ddof_equal_to_number_of_observations(self, xp):
         x = xp.asarray(self.array_1d)
         res = stats.gstd(x, ddof=x.shape[0])


### PR DESCRIPTION
#### Reference issue
Closes gh-23177

#### What does this implement/fix?
Removes an xfail. 

#### Additional information
The bug was fixed upstream.