### PR TITLE
BUG: stats._unuran: fix va_args memory corruption bug

### DIFF
--- a/scipy/stats/_unuran/unuran_callback.h
+++ b/scipy/stats/_unuran/unuran_callback.h
@@ -2,7 +2,7 @@
 #include "ccallback.h"
 #include "unuran.h"
 
-#define UNURAN_THUNK(CAST_FUNC, FUNCNAME, LEN)                                              \
+#define UNURAN_THUNK(CAST_FUNC, FUNCNAME);                                                  \
     PyGILState_STATE gstate = PyGILState_Ensure();                                          \
     /* If an error has occurred, return INFINITY. */                                        \
     if (PyErr_Occurred()) return UNUR_INFINITY;                                             \
@@ -18,7 +18,7 @@
         goto done;                                                                          \
     }                                                                                       \
                                                                                             \
-    funcname = Py_BuildValue("s#", FUNCNAME, LEN);                                          \
+    funcname = Py_BuildValue("s", FUNCNAME);                                                \
     if (funcname == NULL) {                                                                 \
         error = 1;                                                                          \
         goto done;                                                                          \
@@ -112,30 +112,30 @@ int release_unuran_callback(ccallback_t *callback) {
 
 double pmf_thunk(int x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyLong_FromLong, "pmf", 3);
+    UNURAN_THUNK(PyLong_FromLong, "pmf");
 }
 
 double pdf_thunk(double x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyFloat_FromDouble, "pdf", 3);
+    UNURAN_THUNK(PyFloat_FromDouble, "pdf");
 }
 
 double dpdf_thunk(double x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyFloat_FromDouble, "dpdf", 4);
+    UNURAN_THUNK(PyFloat_FromDouble, "dpdf");
 }
 
 double logpdf_thunk(double x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyFloat_FromDouble, "logpdf", 6);
+    UNURAN_THUNK(PyFloat_FromDouble, "logpdf");
 }
 
 double cont_cdf_thunk(double x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyFloat_FromDouble, "cdf", 3);
+    UNURAN_THUNK(PyFloat_FromDouble, "cdf");
 }
 
 double discr_cdf_thunk(int x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyLong_FromLong, "cdf", 3);
+    UNURAN_THUNK(PyLong_FromLong, "cdf");
 }


### PR DESCRIPTION
Avoid providing a va_args member which has a different size than the expected size by using the Py_BuildValue format code that does not require us to specify string length.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #23390

<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

When calling Py_BuildValue, it is undefined behavior to provide the string's length as a literal `3`, as this is an `int`, which is a different size from a `Py_ssize_t`. (See [Can I call va_arg with a larger type than the argument, then cast the value?](https://stackoverflow.com/q/48361814) for why this is undefined behavior.) Fix this by no longer providing the string's length, and passing it as a null-terminated string instead.

The current code is using undefined behavior on any 64-bit platform. I believe it only works on x86_64 because that platform passes these arguments in registers, so the length argument is silently zero extended.

#### Alternatives considered

Instead of the code in this PR, alternatively, this fix could be used:

```diff
diff --git a/scipy/stats/_unuran/unuran_callback.h b/scipy/stats/_unuran/unuran_callback.h
index 6aa61f7a8e..8c075335c6 100644
--- a/scipy/stats/_unuran/unuran_callback.h
+++ b/scipy/stats/_unuran/unuran_callback.h
@@ -18,7 +18,7 @@
         goto done;                                                                          \
     }                                                                                       \
                                                                                             \
-    funcname = Py_BuildValue("s#", FUNCNAME, LEN);                                          \
+    funcname = Py_BuildValue("s#", FUNCNAME, (Py_ssize_t) LEN);                             \
     if (funcname == NULL) {                                                                 \
         error = 1;                                                                          \
         goto done;                                                                          \
```

This fix is involves a smaller code change, but is in my opinion more complex: it requires the programmer to count how many characters the function's name contains, and keep this in sync with any changes to the function name.

##### Performance comparison to the code in this PR

Despite the CPython documentation's note that `s#` uses a "borrowed buffer," both options are equivalent in terms of the number of allocations. This is because these strings are short enough to trigger CPython's compact string optimization. The string is shorter than 127 bytes, so it becomes a PyCompactUnicodeObject, which copies the string into a buffer immediately after the string object structure.

Both options are equivalent in terms of performance, so we should choose based on maintainability / simplicity.


##### Assembly produced by this alternative

One helpful thing about this alternative one line patch is that it allows us to look at the change in assembly to verify that this is not a fluke, and is actually changing something that fixes the problem.

How does the assembly produced by gcc differ when we take the `(Py_ssize_t)` approach described above? It seems that in each thunk, it changes two instructions to use wider registers.

```diff
$ diff _pdf_thunk_bad.asm _pdf_thunk_good.asm 
37,38c37,38
<     1f34: 52800060     	mov	w0, #0x3                ; =3
<     1f38: b9000be0     	str	w0, [sp, #0x8]
---
>     1f34: d2800060     	mov	x0, #0x3                ; =3
>     1f38: f90007e0     	str	x0, [sp, #0x8]
```

My understanding is that `mov	w0` and `mov	x0` are exactly the same, but the change from `str w0` to `str x0` means that the instruction stores a 8 bytes value to the stack memory location, rather than storing a 4 byte value to that location. This means that it is explicitly zeroing an extra 4 bytes of memory.
