### PR TITLE
MAINT: update HiGHS subproject to v1.12.0

### DIFF
--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -352,7 +352,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
     >>> from scipy.optimize import milp
     >>> res = milp(c=c, constraints=constraints, integrality=integrality)
     >>> res.x
-    [2.0, 2.0]
+    array([1., 2.])
 
     Note that had we solved the relaxed problem (without integrality
     constraints):
@@ -360,7 +360,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
     >>> res = milp(c=c, constraints=constraints)  # OR:
     >>> # from scipy.optimize import linprog; res = linprog(c, A, b_u)
     >>> res.x
-    [1.8, 2.8]
+    array([1.8, 2.8])
 
     we would not have obtained the correct solution by rounding to the nearest
     integers.

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -440,7 +440,7 @@ def test_presolve_gh18907():
     r2 = milp(c=c, constraints=constraints, integrality=integrality, bounds=bounds,
               options={'presolve': False})
     assert r1.status == r2.status
-    assert_allclose(r1.x, r2.x)
+    assert_allclose(r1.fun, r2.fun)
 
     # another example from the same issue
     bounds = Bounds(lb=0, ub=1)

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -456,3 +456,22 @@ def test_presolve_gh18907():
               integrality=integrality, options={"presolve": False})
     assert r1.status == r2.status
     assert_allclose(r1.x, r2.x)
+
+def test_regression_gh24141():
+    c = np.ones(8, dtype=np.int64)
+    integrality = c.copy()
+
+    b = np.asarray([42, 252, 277, 41, 222, 48], dtype=np.int64)
+    a = np.asarray([
+        [0, 1, 1, 0, 1, 0, 0, 0],
+        [0, 0, 1, 1, 1, 0, 1, 1],
+        [1, 1, 1, 1, 1, 1, 0, 1],
+        [0, 1, 0, 1, 1, 1, 0, 0],
+        [0, 1, 0, 0, 1, 1, 0, 1],
+        [0, 1, 1, 1, 0, 1, 1, 0],
+    ], dtype=np.int64)
+
+    res = milp(c, integrality=integrality, constraints=(a, b, b))
+
+    assert res.success
+    assert_allclose(a @ res.x, b)


### PR DESCRIPTION
- Pulls in scipy/HiGHS#72 to upgrade to v1.10.0
- Pulls in scipy/HiGHS/pull/73 to upgrade to v1.12.0
- Adds a regression test for and closes gh-24141