### PR TITLE
REL: set 1.17.0rc3 unreleased

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.17.0rc2"
+version = "1.17.0rc3.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Set the version to SciPy `1.17.0rc3` "unreleased."

[ci skip] [skip ci]

This is mostly done for release process visibility--CI is skipped.

Note that we usually prefer to avoid RC3, and we will if we can. I've tentatively bumped the "final"
release date on my calendar to January 11, 2026, given the slight delay on RC2, and maybe to make
sure the dust settles on NumPy `2.4.1`.
