### PR TITLE
DOC: stats: fix indentation of lists

### DIFF
--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -39,25 +39,25 @@ def binned_statistic(x, values, statistic='mean',
         The statistic to compute (default is 'mean').
         The following statistics are available:
 
-          * 'mean' : compute the mean of values for points within each bin.
-            Empty bins will be represented by NaN.
-          * 'std' : compute the standard deviation within each bin. This
-            is implicitly calculated with ddof=0.
-          * 'median' : compute the median of values for points within each
-            bin. Empty bins will be represented by NaN.
-          * 'count' : compute the count of points within each bin.  This is
-            identical to an unweighted histogram.  `values` array is not
-            referenced.
-          * 'sum' : compute the sum of values for points within each bin.
-            This is identical to a weighted histogram.
-          * 'min' : compute the minimum of values for points within each bin.
-            Empty bins will be represented by NaN.
-          * 'max' : compute the maximum of values for point within each bin.
-            Empty bins will be represented by NaN.
-          * function : a user-defined function which takes a 1D array of
-            values, and outputs a single numerical statistic. This function
-            will be called on the values in each bin.  Empty bins will be
-            represented by function([]), or NaN if this returns an error.
+        * 'mean' : compute the mean of values for points within each bin.
+          Empty bins will be represented by NaN.
+        * 'std' : compute the standard deviation within each bin. This
+          is implicitly calculated with ddof=0.
+        * 'median' : compute the median of values for points within each
+          bin. Empty bins will be represented by NaN.
+        * 'count' : compute the count of points within each bin.  This is
+          identical to an unweighted histogram.  `values` array is not
+          referenced.
+        * 'sum' : compute the sum of values for points within each bin.
+          This is identical to a weighted histogram.
+        * 'min' : compute the minimum of values for points within each bin.
+          Empty bins will be represented by NaN.
+        * 'max' : compute the maximum of values for point within each bin.
+          Empty bins will be represented by NaN.
+        * function : a user-defined function which takes a 1D array of
+          values, and outputs a single numerical statistic. This function
+          will be called on the values in each bin.  Empty bins will be
+          represented by function([]), or NaN if this returns an error.
 
     bins : int or sequence of scalars, optional
         If `bins` is an int, it defines the number of equal-width bins in the
@@ -221,33 +221,33 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         The statistic to compute (default is 'mean').
         The following statistics are available:
 
-          * 'mean' : compute the mean of values for points within each bin.
-            Empty bins will be represented by NaN.
-          * 'std' : compute the standard deviation within each bin. This
-            is implicitly calculated with ddof=0.
-          * 'median' : compute the median of values for points within each
-            bin. Empty bins will be represented by NaN.
-          * 'count' : compute the count of points within each bin.  This is
-            identical to an unweighted histogram.  `values` array is not
-            referenced.
-          * 'sum' : compute the sum of values for points within each bin.
-            This is identical to a weighted histogram.
-          * 'min' : compute the minimum of values for points within each bin.
-            Empty bins will be represented by NaN.
-          * 'max' : compute the maximum of values for point within each bin.
-            Empty bins will be represented by NaN.
-          * function : a user-defined function which takes a 1D array of
-            values, and outputs a single numerical statistic. This function
-            will be called on the values in each bin.  Empty bins will be
-            represented by function([]), or NaN if this returns an error.
+        * 'mean' : compute the mean of values for points within each bin.
+          Empty bins will be represented by NaN.
+        * 'std' : compute the standard deviation within each bin. This
+           is implicitly calculated with ddof=0.
+        * 'median' : compute the median of values for points within each
+          bin. Empty bins will be represented by NaN.
+        * 'count' : compute the count of points within each bin.  This is
+          identical to an unweighted histogram.  `values` array is not
+          referenced.
+        * 'sum' : compute the sum of values for points within each bin.
+          This is identical to a weighted histogram.
+        * 'min' : compute the minimum of values for points within each bin.
+          Empty bins will be represented by NaN.
+        * 'max' : compute the maximum of values for point within each bin.
+          Empty bins will be represented by NaN.
+        * function : a user-defined function which takes a 1D array of
+          values, and outputs a single numerical statistic. This function
+          will be called on the values in each bin.  Empty bins will be
+          represented by function([]), or NaN if this returns an error.
 
     bins : int or [int, int] or array_like or [array, array], optional
         The bin specification:
 
-          * the number of bins for the two dimensions (nx = ny = bins),
-          * the number of bins in each dimension (nx, ny = bins),
-          * the bin edges for the two dimensions (x_edge = y_edge = bins),
-          * the bin edges in each dimension (x_edge, y_edge = bins).
+        * the number of bins for the two dimensions (nx = ny = bins),
+        * the number of bins in each dimension (nx, ny = bins),
+        * the bin edges for the two dimensions (x_edge = y_edge = bins),
+        * the bin edges in each dimension (x_edge, y_edge = bins).
 
         If the bin edges are specified, the number of bins will be,
         (nx = len(x_edge)-1, ny = len(y_edge)-1).
@@ -403,34 +403,35 @@ def binned_statistic_dd(sample, values, statistic='mean',
         The statistic to compute (default is 'mean').
         The following statistics are available:
 
-          * 'mean' : compute the mean of values for points within each bin.
-            Empty bins will be represented by NaN.
-          * 'median' : compute the median of values for points within each
-            bin. Empty bins will be represented by NaN.
-          * 'count' : compute the count of points within each bin.  This is
-            identical to an unweighted histogram.  `values` array is not
-            referenced.
-          * 'sum' : compute the sum of values for points within each bin.
-            This is identical to a weighted histogram.
-          * 'std' : compute the standard deviation within each bin. This
-            is implicitly calculated with ddof=0. If the number of values
-            within a given bin is 0 or 1, the computed standard deviation value
-            will be 0 for the bin.
-          * 'min' : compute the minimum of values for points within each bin.
-            Empty bins will be represented by NaN.
-          * 'max' : compute the maximum of values for point within each bin.
-            Empty bins will be represented by NaN.
-          * function : a user-defined function which takes a 1D array of
-            values, and outputs a single numerical statistic. This function
-            will be called on the values in each bin.  Empty bins will be
-            represented by function([]), or NaN if this returns an error.
+        * 'mean' : compute the mean of values for points within each bin.
+          Empty bins will be represented by NaN.
+        * 'median' : compute the median of values for points within each
+          bin. Empty bins will be represented by NaN.
+        * 'count' : compute the count of points within each bin.  This is
+          identical to an unweighted histogram.  `values` array is not
+          referenced.
+        * 'sum' : compute the sum of values for points within each bin.
+          This is identical to a weighted histogram.
+        * 'std' : compute the standard deviation within each bin. This
+          is implicitly calculated with ddof=0. If the number of values
+          within a given bin is 0 or 1, the computed standard deviation value
+          will be 0 for the bin.
+        * 'min' : compute the minimum of values for points within each bin.
+          Empty bins will be represented by NaN.
+        * 'max' : compute the maximum of values for point within each bin.
+          Empty bins will be represented by NaN.
+        * function : a user-defined function which takes a 1D array of
+          values, and outputs a single numerical statistic. This function
+          will be called on the values in each bin.  Empty bins will be
+          represented by function([]), or NaN if this returns an error.
 
     bins : sequence or positive int, optional
         The bin specification must be in one of the following forms:
 
-          * A sequence of arrays describing the bin edges along each dimension.
-          * The number of bins for each dimension (nx, ny, ... = bins).
-          * The number of bins for all dimensions (nx = ny = ... = bins).
+        * A sequence of arrays describing the bin edges along each dimension.
+        * The number of bins for each dimension (nx, ny, ... = bins).
+        * The number of bins for all dimensions (nx = ny = ... = bins).
+
     range : sequence, optional
         A sequence of lower and upper bin edges to be used if the edges are
         not given explicitly in `bins`. Defaults to the minimum and maximum

--- a/scipy/stats/_binned_statistic.py
+++ b/scipy/stats/_binned_statistic.py
@@ -224,7 +224,7 @@ def binned_statistic_2d(x, y, values, statistic='mean',
         * 'mean' : compute the mean of values for points within each bin.
           Empty bins will be represented by NaN.
         * 'std' : compute the standard deviation within each bin. This
-           is implicitly calculated with ddof=0.
+          is implicitly calculated with ddof=0.
         * 'median' : compute the median of values for points within each
           bin. Empty bins will be represented by NaN.
         * 'count' : compute the count of points within each bin.  This is

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -1541,9 +1541,9 @@ class chi_gen(rv_continuous):
 
     Special cases of `chi` are:
 
-        - ``chi(1, loc, scale)`` is equivalent to `halfnorm`
-        - ``chi(2, 0, scale)`` is equivalent to `rayleigh`
-        - ``chi(3, 0, scale)`` is equivalent to `maxwell`
+    - ``chi(1, loc, scale)`` is equivalent to `halfnorm`
+    - ``chi(2, 0, scale)`` is equivalent to `rayleigh`
+    - ``chi(3, 0, scale)`` is equivalent to `maxwell`
 
     `chi` takes ``df`` as a shape parameter.
 
@@ -5110,9 +5110,12 @@ class invgauss_gen(rv_continuous):
         SciPy's with the conversion `fshape_s = fshape / scale`.
 
         MLE formulas are not used in 3 conditions:
+
         - `loc` is not fixed
         - `mu` is fixed
+
         These cases fall back on the superclass fit method.
+
         - `loc` is fixed but translation results in negative data raises
           a `FitDataError`.
         '''
@@ -11463,7 +11466,7 @@ class gennorm_gen(rv_continuous):
     The (symmetric) generalized normal distribution is also known as the
     Subbotin distribution, exponential power distribution, and generalized
     error distribution [1]_.
-    
+
     The probability density function for `gennorm` is [1]_:
 
     .. math::

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1828,13 +1828,13 @@ class rv_continuous(rv_generic):
     Statistics are computed using numerical integration by default.
     For speed you can redefine this using ``_stats``:
 
-     - take shape parameters and return mu, mu2, g1, g2
-     - If you can't compute one of these, return it as None
-     - Can also be defined with a keyword argument ``moments``, which is a
-       string composed of "m", "v", "s", and/or "k".
-       Only the components appearing in string should be computed and
-       returned in the order "m", "v", "s", or "k"  with missing values
-       returned as None.
+    - take shape parameters and return mu, mu2, g1, g2
+    - If you can't compute one of these, return it as None
+    - Can also be defined with a keyword argument ``moments``, which is a
+      string composed of "m", "v", "s", and/or "k".
+      Only the components appearing in string should be computed and
+      returned in the order "m", "v", "s", or "k"  with missing values
+      returned as None.
 
     Alternatively, you can override ``_munp``, which takes ``n`` and shape
     parameters and returns the n-th non-central moment of the distribution.

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -202,12 +202,12 @@ def poisson_means_test(k1, n1, k2, n2, *, diff=0, alternative='two-sided'):
         Defines the alternative hypothesis.
         The following options are available (default is 'two-sided'):
 
-          * 'two-sided': the difference between distribution means is not
-            equal to `diff`
-          * 'less': the difference between distribution means is less than
-            `diff`
-          * 'greater': the difference between distribution means is greater
-            than `diff`
+        * 'two-sided': the difference between distribution means is not
+          equal to `diff`
+        * 'less': the difference between distribution means is less than
+          `diff`
+        * 'greater': the difference between distribution means is greater
+          than `diff`
 
     Returns
     -------
@@ -814,6 +814,7 @@ def somersd(x, y=None, alternative='two-sided'):
     alternative : {'two-sided', 'less', 'greater'}, optional
         Defines the alternative hypothesis. Default is 'two-sided'.
         The following options are available:
+
         * 'two-sided': the rank correlation is nonzero
         * 'less': the rank correlation is negative (less than zero)
         * 'greater':  the rank correlation is positive (greater than zero)
@@ -823,15 +824,15 @@ def somersd(x, y=None, alternative='two-sided'):
     res : SomersDResult
         A `SomersDResult` object with the following fields:
 
-            statistic : float
-               The Somers' :math:`D` statistic.
-            pvalue : float
-               The p-value for a hypothesis test whose null
-               hypothesis is an absence of association, :math:`D=0`.
-               See notes for more information.
-            table : 2D array
-               The contingency table formed from rankings `x` and `y` (or the
-               provided contingency table, if `x` is a 2D array)
+        statistic : float
+           The Somers' :math:`D` statistic.
+        pvalue : float
+           The p-value for a hypothesis test whose null
+           hypothesis is an absence of association, :math:`D=0`.
+           See notes for more information.
+        table : 2D array
+           The contingency table formed from rankings `x` and `y` (or the
+           provided contingency table, if `x` is a 2D array)
 
     See Also
     --------
@@ -1099,9 +1100,11 @@ def barnard_exact(table, alternative="two-sided", pooled=True, n=32):
             (1 - \pi)^{t - x_{11} - x_{12}}
 
     where the sum is over all  2x2 contingency tables :math:`X` such that:
+
     * :math:`T(X) \leq T(X_0)` when `alternative` = "less",
     * :math:`T(X) \geq T(X_0)` when `alternative` = "greater", or
     * :math:`T(X) \geq |T(X_0)|` when `alternative` = "two-sided".
+
     Above, :math:`c_1, c_2` are the sum of the columns 1 and 2,
     and :math:`t` the total (sum of the 4 sample's element).
 

--- a/scipy/stats/_mgc.py
+++ b/scipy/stats/_mgc.py
@@ -175,13 +175,13 @@ def multiscale_graphcorr(x, y, compute_distance=_euclidean_dist, reps=1000,
         mgc_dict : dict
             Contains additional useful results:
 
-                - mgc_map : ndarray
-                    A 2D representation of the latent geometry of the
-                    relationship.
-                - opt_scale : (int, int)
-                    The estimated optimal scale as a ``(x, y)`` pair.
-                - null_dist : list
-                    The null distribution derived from the permuted matrices.
+            - mgc_map : ndarray
+                A 2D representation of the latent geometry of the
+                relationship.
+            - opt_scale : (int, int)
+                The estimated optimal scale as a ``(x, y)`` pair.
+            - null_dist : list
+                The null distribution derived from the permuted matrices.
 
     See Also
     --------
@@ -398,10 +398,10 @@ def _mgc_stat(distx, disty):
         Contains additional useful additional returns containing the following
         keys:
 
-            - stat_mgc_map : ndarray
-                MGC-map of the statistics.
-            - opt_scale : (float, float)
-                The estimated optimal scale as a ``(x, y)`` pair.
+        - stat_mgc_map : ndarray
+            MGC-map of the statistics.
+        - opt_scale : (float, float)
+            The estimated optimal scale as a ``(x, y)`` pair.
 
     """
     # calculate MGC map and optimal scale

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -918,6 +918,7 @@ def boxcox_llf(lmb, data, *, axis=0, keepdims=False, nan_policy='propagate'):
           statistic is computed, the corresponding entry of the output will be
           NaN.
         - ``raise``: if a NaN is present, a ``ValueError`` will be raised.
+
     keepdims : bool, default: False
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
@@ -1729,6 +1730,7 @@ def yeojohnson_llf(lmb, data, *, axis=0, nan_policy='propagate', keepdims=False)
           statistic is computed, the corresponding entry of the output will be
           NaN.
         - ``raise``: if a NaN is present, a ``ValueError`` will be raised.
+
     keepdims : bool, default: False
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
@@ -3847,11 +3849,9 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     - When ``len(d)`` is sufficiently large, the null distribution of the
       normalized test statistic (`zstatistic` above) is approximately normal,
       and ``method = 'asymptotic'`` can be used to compute the p-value.
-
     - When ``len(d)`` is small, the normal approximation may not be accurate,
       and ``method='exact'`` is preferred (at the cost of additional
       execution time).
-
     - The default, ``method='auto'``, selects between the two:
       ``method='exact'`` is used when ``len(d) <= 50``, and
       ``method='asymptotic'`` is used otherwise.

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -1202,9 +1202,9 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
         Method to be used for computing estimate for intercept.
         Following methods are supported,
 
-            * 'joint': Uses np.median(y - slope * x) as intercept.
-            * 'separate': Uses np.median(y) - slope * np.median(x)
-                          as intercept.
+        * 'joint': Uses np.median(y - slope * x) as intercept.
+        * 'separate': Uses np.median(y) - slope * np.median(x)
+                      as intercept.
 
         The default is 'separate'.
 
@@ -1772,9 +1772,9 @@ def ks_1samp(x, cdf, args=(), alternative="two-sided", method='auto'):
         Defines the method used for calculating the p-value.
         The following options are available (default is 'auto'):
 
-          * 'auto' : use 'exact' for small size arrays, 'asymp' for large
-          * 'exact' : use approximation to exact distribution of test statistic
-          * 'asymp' : use asymptotic distribution of test statistic
+        * 'auto' : use 'exact' for small size arrays, 'asymp' for large
+        * 'exact' : use approximation to exact distribution of test statistic
+        * 'asymp' : use asymptotic distribution of test statistic
 
     Returns
     -------
@@ -1809,9 +1809,9 @@ def ks_2samp(data1, data2, alternative="two-sided", method='auto'):
         Defines the method used for calculating the p-value.
         The following options are available (default is 'auto'):
 
-          * 'auto' : use 'exact' for small size arrays, 'asymp' for large
-          * 'exact' : use approximation to exact distribution of test statistic
-          * 'asymp' : use asymptotic distribution of test statistic
+        * 'auto' : use 'exact' for small size arrays, 'asymp' for large
+        * 'exact' : use approximation to exact distribution of test statistic
+        * 'asymp' : use asymptotic distribution of test statistic
 
     Returns
     -------
@@ -2583,9 +2583,9 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': allows nan values and may overwrite or propagate them
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': allows nan values and may overwrite or propagate them
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
 
     Notes
     -----
@@ -3168,7 +3168,7 @@ def normaltest(a, axis=0):
         ``s^2 + k^2``, where ``s`` is the z-score returned by `skewtest` and
         ``k`` is the z-score returned by `kurtosistest`.
     pvalue : float or array
-       A 2-sided chi squared probability for the hypothesis test.
+         A 2-sided chi squared probability for the hypothesis test.
 
     Notes
     -----
@@ -3197,24 +3197,25 @@ def mquantiles(a, prob=(.25, .5, .75), alphap=.4, betap=.4, axis=None,
     equation: ``p(k) = (k - alphap)/(n + 1 - alphap - betap)``
 
     Typical values of (alphap,betap) are:
-        - (0,1)    : ``p(k) = k/n`` : linear interpolation of cdf
-          (**R** type 4)
-        - (.5,.5)  : ``p(k) = (k - 1/2.)/n`` : piecewise linear function
-          (**R** type 5)
-        - (0,0)    : ``p(k) = k/(n+1)`` :
-          (**R** type 6)
-        - (1,1)    : ``p(k) = (k-1)/(n-1)``: p(k) = mode[F(x[k])].
-          (**R** type 7, **R** default)
-        - (1/3,1/3): ``p(k) = (k-1/3)/(n+1/3)``: Then p(k) ~ median[F(x[k])].
-          The resulting quantile estimates are approximately median-unbiased
-          regardless of the distribution of x.
-          (**R** type 8)
-        - (3/8,3/8): ``p(k) = (k-3/8)/(n+1/4)``: Blom.
-          The resulting quantile estimates are approximately unbiased
-          if x is normally distributed
-          (**R** type 9)
-        - (.4,.4)  : approximately quantile unbiased (Cunnane)
-        - (.35,.35): APL, used with PWM
+
+    - (0,1)    : ``p(k) = k/n`` : linear interpolation of cdf
+      (**R** type 4)
+    - (.5,.5)  : ``p(k) = (k - 1/2.)/n`` : piecewise linear function
+      (**R** type 5)
+    - (0,0)    : ``p(k) = k/(n+1)`` :
+      (**R** type 6)
+    - (1,1)    : ``p(k) = (k-1)/(n-1)``: p(k) = mode[F(x[k])].
+      (**R** type 7, **R** default)
+    - (1/3,1/3): ``p(k) = (k-1/3)/(n+1/3)``: Then p(k) ~ median[F(x[k])].
+      The resulting quantile estimates are approximately median-unbiased
+      regardless of the distribution of x.
+      (**R** type 8)
+    - (3/8,3/8): ``p(k) = (k-3/8)/(n+1/4)``: Blom.
+      The resulting quantile estimates are approximately unbiased
+      if x is normally distributed
+      (**R** type 9)
+    - (.4,.4)  : approximately quantile unbiased (Cunnane)
+    - (.35,.35): APL, used with PWM
 
     Parameters
     ----------
@@ -3331,27 +3332,29 @@ def plotting_positions(data, alpha=0.4, beta=0.4):
     Returns plotting positions (or empirical percentile points) for the data.
 
     Plotting positions are defined as ``(i-alpha)/(n+1-alpha-beta)``, where:
-        - i is the rank order statistics
-        - n is the number of unmasked values along the given axis
-        - `alpha` and `beta` are two parameters.
+
+    - i is the rank order statistics
+    - n is the number of unmasked values along the given axis
+    - `alpha` and `beta` are two parameters.
 
     Typical values for `alpha` and `beta` are:
-        - (0,1)    : ``p(k) = k/n``, linear interpolation of cdf (R, type 4)
-        - (.5,.5)  : ``p(k) = (k-1/2.)/n``, piecewise linear function
-          (R, type 5)
-        - (0,0)    : ``p(k) = k/(n+1)``, Weibull (R type 6)
-        - (1,1)    : ``p(k) = (k-1)/(n-1)``, in this case,
-          ``p(k) = mode[F(x[k])]``. That's R default (R type 7)
-        - (1/3,1/3): ``p(k) = (k-1/3)/(n+1/3)``, then
-          ``p(k) ~ median[F(x[k])]``.
-          The resulting quantile estimates are approximately median-unbiased
-          regardless of the distribution of x. (R type 8)
-        - (3/8,3/8): ``p(k) = (k-3/8)/(n+1/4)``, Blom.
-          The resulting quantile estimates are approximately unbiased
-          if x is normally distributed (R type 9)
-        - (.4,.4)  : approximately quantile unbiased (Cunnane)
-        - (.35,.35): APL, used with PWM
-        - (.3175, .3175): used in scipy.stats.probplot
+
+    - (0,1)    : ``p(k) = k/n``, linear interpolation of cdf (R, type 4)
+    - (.5,.5)  : ``p(k) = (k-1/2.)/n``, piecewise linear function
+      (R, type 5)
+    - (0,0)    : ``p(k) = k/(n+1)``, Weibull (R type 6)
+    - (1,1)    : ``p(k) = (k-1)/(n-1)``, in this case,
+      ``p(k) = mode[F(x[k])]``. That's R default (R type 7)
+    - (1/3,1/3): ``p(k) = (k-1/3)/(n+1/3)``, then
+      ``p(k) ~ median[F(x[k])]``.
+      The resulting quantile estimates are approximately median-unbiased
+      regardless of the distribution of x. (R type 8)
+    - (3/8,3/8): ``p(k) = (k-3/8)/(n+1/4)``, Blom.
+      The resulting quantile estimates are approximately unbiased
+      if x is normally distributed (R type 9)
+    - (.4,.4)  : approximately quantile unbiased (Cunnane)
+    - (.35,.35): APL, used with PWM
+    - (.3175, .3175): used in scipy.stats.probplot
 
     Parameters
     ----------

--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -212,6 +212,7 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
         - If `keepdims` is set to True, the axis will not be reduced away.
         - If `keepdims` is set to False, the axis will be reduced away
           if possible, and an error will be raised otherwise.
+
     weights : array_like of finite, non-negative real numbers
         Frequency weights; e.g., for counting number weights,
         ``quantile(x, p, weights=weights)`` is equivalent to

--- a/scipy/stats/_sampling.py
+++ b/scipy/stats/_sampling.py
@@ -522,8 +522,10 @@ class FastGeneratorInversion:
     antithetic variates are be used ([2]_).
 
     In addition, inversion makes it possible to
+
     - to use a QMC generator from `scipy.stats.qmc` (method `qrvs`),
     - to generate random variates truncated to an interval. For example, if
+
     one aims to sample standard normal random variates from
     the interval (2, 4), this can be easily achieved by using the parameter
     `domain`.
@@ -1246,14 +1248,14 @@ class RatioUniforms:
     0.21121052054580314
 
     """
-    
+
     def __init__(self, pdf, *, umax, vmin, vmax, c=0, random_state=None):
         if vmin >= vmax:
             raise ValueError("vmin must be smaller than vmax.")
 
         if umax <= 0:
             raise ValueError("umax must be positive.")
-        
+
         self._pdf = pdf
         self._umax = umax
         self._vmin = vmin

--- a/scipy/stats/_sensitivity_analysis.py
+++ b/scipy/stats/_sensitivity_analysis.py
@@ -93,11 +93,13 @@ def sample_AB(A: np.ndarray, B: np.ndarray) -> np.ndarray:
     """AB matrix.
 
     AB: rows of B into A. Shape (d, d, n).
+
     - Copy A into d "pages"
     - In the first page, replace 1st rows of A with 1st row of B.
     ...
     - In the dth page, replace dth row of A with dth row of B.
     - return the stack of pages
+
     """
     d, n = A.shape
     AB = np.tile(A, (d, 1, 1))

--- a/scipy/stats/_stats_mstats_common.py
+++ b/scipy/stats/_stats_mstats_common.py
@@ -46,9 +46,9 @@ def theilslopes(y, x=None, alpha=0.95, method='separate'):
         Method to be used for computing estimate for intercept.
         Following methods are supported,
 
-            * 'joint': Uses np.median(y - slope * x) as intercept.
-            * 'separate': Uses np.median(y) - slope * np.median(x)
-                          as intercept.
+        * 'joint': Uses np.median(y - slope * x) as intercept.
+        * 'separate': Uses np.median(y) - slope * np.median(x)
+                      as intercept.
 
         The default is 'separate'.
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -500,9 +500,10 @@ def mode(a, axis=0, nan_policy='propagate', keepdims=False):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': treats nan as it would treat any other value
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': treats nan as it would treat any other value
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
+
     keepdims : bool, optional
         If set to ``False``, the `axis` over which the statistic is taken
         is consumed (eliminated from the output array). If set to ``True``,
@@ -1072,9 +1073,9 @@ def moment(a, order=1, axis=0, nan_policy='propagate', *, center=None):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
 
     center : float or None, optional
        The point about which moments are taken. This can be the sample mean,
@@ -1279,9 +1280,9 @@ def skew(a, axis=0, bias=True, nan_policy='propagate'):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
 
     Returns
     -------
@@ -1720,6 +1721,7 @@ def kurtosistest(a, axis=0, nan_policy='propagate', alternative='two-sided'):
         * 'propagate': returns nan
         * 'raise': throws an error
         * 'omit': performs the calculations ignoring nan values
+
     alternative : {'two-sided', 'less', 'greater'}, optional
         Defines the alternative hypothesis.
         The following options are available (default is 'two-sided'):
@@ -1829,9 +1831,9 @@ def normaltest(a, axis=0, nan_policy='propagate'):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-            * 'propagate': returns nan
-            * 'raise': throws an error
-            * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
 
     Returns
     -------
@@ -1995,10 +1997,10 @@ def scoreatpercentile(a, per, limit=(), interpolation_method='fraction',
         when the desired quantile lies between two data points `i` and `j`
         The following options are available (default is 'fraction'):
 
-          * 'fraction': ``i + (j - i) * fraction`` where ``fraction`` is the
+        * 'fraction': ``i + (j - i) * fraction`` where ``fraction`` is the
             fractional part of the index surrounded by ``i`` and ``j``
-          * 'lower': ``i``
-          * 'higher': ``j``
+        * 'lower': ``i``
+        * 'higher': ``j``
 
     axis : int, optional
         Axis along which the percentiles are computed. Default is None. If
@@ -2617,9 +2619,9 @@ def sem(a, axis=0, ddof=1, nan_policy='propagate'):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
 
     Returns
     -------
@@ -3099,8 +3101,8 @@ def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
         The numerical value of scale will be divided out of the final
         result. The following string value is also recognized:
 
-          * 'normal' : Scale by
-            :math:`2 \sqrt{2} erf^{-1}(\frac{1}{2}) \approx 1.349`.
+        * 'normal' : Scale by
+          :math:`2 \sqrt{2} erf^{-1}(\frac{1}{2}) \approx 1.349`.
 
         The default is 1.0.
         Array-like `scale` of real dtype is also allowed, as long
@@ -3112,21 +3114,22 @@ def iqr(x, axis=None, rng=(25, 75), scale=1.0, nan_policy='propagate',
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
+
     interpolation : str, optional
 
         Specifies the interpolation method to use when the percentile
         boundaries lie between two data points ``i`` and ``j``.
         The following options are available (default is 'linear'):
 
-          * 'linear': ``i + (j - i)*fraction``, where ``fraction`` is the
-            fractional part of the index surrounded by ``i`` and ``j``.
-          * 'lower': ``i``.
-          * 'higher': ``j``.
-          * 'nearest': ``i`` or ``j`` whichever is nearest.
-          * 'midpoint': ``(i + j)/2``.
+        * 'linear': ``i + (j - i)*fraction``, where ``fraction`` is the
+          fractional part of the index surrounded by ``i`` and ``j``.
+        * 'lower': ``i``.
+        * 'higher': ``j``.
+        * 'nearest': ``i`` or ``j`` whichever is nearest.
+        * 'midpoint': ``(i + j)/2``.
 
         For NumPy >= 1.22.0, the additional options provided by the ``method``
         keyword of `numpy.percentile` are also valid.
@@ -5374,7 +5377,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
 
     warn_msg = ("An input array is constant; the correlation coefficient "
                 "is not defined.")
-    
+
     constant_axis = False
     if axisout == 0:
         constant_columns = np.all(a == a[0, :], axis=0)
@@ -5408,7 +5411,7 @@ def spearmanr(a, b=None, axis=0, nan_policy='propagate',
                 variable_has_nan = np.isnan(a).any(axis=axisout)
 
     a_ranked = np.apply_along_axis(rankdata, axisout, a)
-    
+
     if constant_axis:
         with np.errstate(invalid='ignore'):
             rs = np.corrcoef(a_ranked, rowvar=axisout)
@@ -6065,9 +6068,9 @@ def ttest_1samp(a, popmean, axis=0, nan_policy="propagate", alternative="two-sid
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
 
     alternative : {'two-sided', 'less', 'greater'}, optional
         Defines the alternative hypothesis.
@@ -6504,9 +6507,9 @@ def ttest_ind(a, b, *, axis=0, equal_var=True, nan_policy='propagate',
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
 
         The 'omit' option is not currently available for one-sided asymptotic tests.
 
@@ -6881,9 +6884,10 @@ def ttest_rel(a, b, axis=0, nan_policy='propagate', alternative="two-sided"):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
+
     alternative : {'two-sided', 'less', 'greater'}, optional
         Defines the alternative hypothesis.
         The following options are available (default is 'two-sided'):
@@ -7400,10 +7404,10 @@ def _compute_d(cdfvals, x, sign, xp=None):
 
     Returns
     -------
-    res: Pair with the following elements:
-        - The maximum distance of the CDF values below/above (D+/D-) Uniform(0, 1).
-        - The location at which the maximum is reached.
-
+    D : float or array
+        The maximum distance of the CDF values below/above (D+/D-) Uniform(0, 1).
+    loc_max : float or array
+        The location at which the maximum is reached.
     """
     xp = array_namespace(cdfvals, x) if xp is None else xp
     n = cdfvals.shape[-1]
@@ -7454,11 +7458,12 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
         Defines the distribution used for calculating the p-value.
         The following options are available (default is 'auto'):
 
-          * 'auto' : selects one of the other options.
-          * 'exact' : uses the exact distribution of test statistic.
-          * 'approx' : approximates the two-sided probability with twice
-            the one-sided probability
-          * 'asymp': uses asymptotic distribution of test statistic
+        * 'auto' : selects one of the other options.
+        * 'exact' : uses the exact distribution of test statistic.
+        * 'approx' : approximates the two-sided probability with twice
+          the one-sided probability
+        * 'asymp': uses asymptotic distribution of test statistic
+
     axis : int or tuple of ints, default: 0
         If an int or tuple of ints, the axis or axes of the input along which
         to compute the statistic. The statistic of each axis-slice (e.g. row)
@@ -7808,9 +7813,9 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto'):
         Defines the method used for calculating the p-value.
         The following options are available (default is 'auto'):
 
-          * 'auto' : use 'exact' for small size arrays, 'asymp' for large
-          * 'exact' : use exact distribution of test statistic
-          * 'asymp' : use asymptotic distribution of test statistic
+        * 'auto' : use 'exact' for small size arrays, 'asymp' for large
+        * 'exact' : use exact distribution of test statistic
+        * 'asymp' : use asymptotic distribution of test statistic
 
     Returns
     -------
@@ -8111,11 +8116,11 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', method='auto'):
         Defines the distribution used for calculating the p-value.
         The following options are available (default is 'auto'):
 
-          * 'auto' : selects one of the other options.
-          * 'exact' : uses the exact distribution of test statistic.
-          * 'approx' : approximates the two-sided probability with twice the
-            one-sided probability
-          * 'asymp': uses asymptotic distribution of test statistic
+        * 'auto' : selects one of the other options.
+        * 'exact' : uses the exact distribution of test statistic.
+        * 'approx' : approximates the two-sided probability with twice the
+          one-sided probability
+        * 'asymp': uses asymptotic distribution of test statistic
 
     Returns
     -------
@@ -8423,9 +8428,10 @@ def kruskal(*samples, nan_policy='propagate', axis=0):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
+
     axis : int or tuple of ints, default: 0
         If an int or tuple of ints, the axis or axes of the input along which
         to compute the statistic. The statistic of each axis-slice (e.g. row)
@@ -8638,22 +8644,25 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
         Defines the alternative hypothesis.
         The following options are available (default is 'two-sided'):
 
-          * 'two-sided'
-          * 'less': one-sided
-          * 'greater': one-sided
+        * 'two-sided'
+        * 'less': one-sided
+        * 'greater': one-sided
+
     distribution : {'t', 'normal'}, optional
         Defines how to get the p-value.
         The following options are available (default is 't'):
 
-          * 't': get the p-value by t-distribution
-          * 'normal': get the p-value by standard normal distribution.
+        * 't': get the p-value by t-distribution
+        * 'normal': get the p-value by standard normal distribution.
+
     nan_policy : {'propagate', 'raise', 'omit'}, optional
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': returns nan
-          * 'raise': throws an error
-          * 'omit': performs the calculations ignoring nan values
+        * 'propagate': returns nan
+        * 'raise': throws an error
+        * 'omit': performs the calculations ignoring nan values
+
     axis : int or None, default=0
         If an int, the axis of the input along which to compute the statistic.
         The statistic of each axis-slice (e.g. row) of the input will appear
@@ -8783,6 +8792,7 @@ def combine_pvalues(pvalues, method='fisher', weights=None, *, axis=0):
         * 'mudholkar_george': Mudholkar's and George's method
         * 'tippett': Tippett's method
         * 'stouffer': Stouffer's Z-score method
+
     weights : array_like, optional
         Optional array of weights used only for Stouffer's Z-score method.
         Ignored by other methods.
@@ -9932,18 +9942,19 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
         The method used to assign ranks to tied elements.
         The following methods are available (default is 'average'):
 
-          * 'average': The average of the ranks that would have been assigned to
-            all the tied values is assigned to each value.
-          * 'min': The minimum of the ranks that would have been assigned to all
-            the tied values is assigned to each value.  (This is also
-            referred to as "competition" ranking.)
-          * 'max': The maximum of the ranks that would have been assigned to all
-            the tied values is assigned to each value.
-          * 'dense': Like 'min', but the rank of the next highest element is
-            assigned the rank immediately after those assigned to the tied
-            elements.
-          * 'ordinal': All values are given a distinct rank, corresponding to
-            the order that the values occur in `a`.
+        * 'average': The average of the ranks that would have been assigned to
+          all the tied values is assigned to each value.
+        * 'min': The minimum of the ranks that would have been assigned to all
+          the tied values is assigned to each value.  (This is also
+          referred to as "competition" ranking.)
+        * 'max': The maximum of the ranks that would have been assigned to all
+          the tied values is assigned to each value.
+        * 'dense': Like 'min', but the rank of the next highest element is
+          assigned the rank immediately after those assigned to the tied
+          elements.
+        * 'ordinal': All values are given a distinct rank, corresponding to
+          the order that the values occur in `a`.
+
     axis : {None, int}, optional
         Axis along which to perform the ranking. If ``None``, the data array
         is first flattened.
@@ -9951,9 +9962,9 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
         Defines how to handle when input contains nan.
         The following options are available (default is 'propagate'):
 
-          * 'propagate': propagates nans through the rank calculation
-          * 'omit': performs the calculations ignoring nan values
-          * 'raise': raises an error
+        * 'propagate': propagates nans through the rank calculation
+        * 'omit': performs the calculations ignoring nan values
+        * 'raise': raises an error
 
         .. note::
 

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -43,9 +43,9 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
         Defines how to handle when input contains ``nan``.
         The following options are available:
 
-          * 'propagate': return ``nan``
-          * 'raise': raise an exception
-          * 'omit': perform the calculation with ``nan`` values omitted
+        * 'propagate': return ``nan``
+        * 'raise': raise an exception
+        * 'omit': perform the calculation with ``nan`` values omitted
 
         The default is 'propagate'.
     ddof : int, optional


### PR DESCRIPTION
#### Reference issue
gh-21087

#### What does this implement/fix?
Many lists in stats documentation are indented relative to the surrounding text. The indentation indicates to Sphinx that the text is to be formatted as a block quote, and our theme represents that with a vertical bar and gray highlighting. Much of this appears to be unintentional.

<img width="1026" height="279" alt="image" src="https://github.com/user-attachments/assets/01a3f205-0bfc-41fb-932d-41d3ca8116af" />

vs

<img width="1066" height="238" alt="image" src="https://github.com/user-attachments/assets/7951c392-b760-46f0-8824-f56f06e58984" />


and

<img width="1017" height="387" alt="image" src="https://github.com/user-attachments/assets/45abf935-c07f-4411-bad5-35406872a247" />

vs

<img width="1010" height="341" alt="image" src="https://github.com/user-attachments/assets/7fb85ee2-cb56-4924-800d-c567629f6eb3" />

This PR removes unnecessary indentation to eliminate these vertical bars and gray highlighting.