### PR TITLE
TST: stats: skip tests involving complex input to special functions on sparc64

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -1,5 +1,6 @@
 import sys
 import warnings
+import platform
 
 import numpy as np
 import numpy.testing as npt
@@ -205,7 +206,8 @@ def test_cont_basic(distname, arg, sn, num_parallel_threads):
     check_meth_dtype(distfn, arg, meths)
     check_ppf_dtype(distfn, arg)
 
-    if distname not in fails_cmplx:
+    # complex special functions known to fail on sparc64 (gh-22577)
+    if distname not in fails_cmplx and platform.machine() != 'sparc64':
         check_cmplx_deriv(distfn, arg)
 
     if distname != 'truncnorm':

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -8756,6 +8756,8 @@ def test_ksone_fit_freeze():
             stats.ksone.fit(d)
 
 
+@pytest.mark.xfail(platform.machine() == "sparc64",
+    reason="complex special functions known to fail on sparc64 (gh-22577)")
 def test_norm_logcdf():
     # Test precision of the logcdf of the normal distribution.
     # This precision was enhanced in ticket 1614.


### PR DESCRIPTION
#### Reference issue
Resolves `stats` part of gh-22577

#### What does this implement/fix?
gh-22577 reports that tests involving complex arguments to special functions are failing on sparc64. Consequently, some `scipy.stats` tests  are failing, such as those that check for agreement between CDF and PDF methods of statistical distributions using a complex step derivative. This PR skips those failing tests on sparc64 until the underlying issues in `scipy.special` are resolved.

#### Additional information
@drew-parsons Does this resolve the `stats` failures for you?

BLAS tests failures seem unrelated (see e.g. gh-24263)