### PR TITLE
ENH: linalg.eig: move the batching loop to C

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -78,6 +78,12 @@ class Bench(Benchmark):
         else:
             sl.eigvals(self.a)
 
+    def time_geneig(self, size, contig, module):
+        if module == 'numpy':
+            pass
+        else:
+            sl.eig(self.a, self.a, check_finite=True)
+
     def time_svd(self, size, contig, module):
         if module == 'numpy':
             nl.svd(self.a)
@@ -177,6 +183,24 @@ class BatchedLstsqBench(Benchmark):
 
     def time_lstsq(self, shape):
         sl.lstsq(self.a, self.b, check_finite=False)
+
+
+class BatchedEigBench(Benchmark):
+    params = [
+        [(10, 10, 3, 3), (100, 10, 10), (100, 20, 20), (100, 100, 100)],
+        ["scipy", "numpy"]
+    ]
+    param_names = ['shape',  'module']
+
+    def setup(self, shape, module):
+        self.a = random(shape)
+
+    def time_eig(self, shape, module):
+        if module == 'numpy':
+            nl.eig(self.a)
+        else:
+            sl.eig(self.a)
+
 
 
 class Norm(Benchmark):

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -12,7 +12,7 @@ from numpy import atleast_1d, atleast_2d
 from scipy._lib._util import _apply_over_batch
 from .lapack import (
     get_lapack_funcs, _compute_lwork,
-    _normalize_lapack_dtype, _ensure_aligned_and_native
+    _normalize_lapack_dtype, _ensure_aligned_and_native, _ensure_dtype_cdsz,
 )
 from ._misc import LinAlgError, _datacopied, LinAlgWarning
 from ._decomp import _asarray_validated
@@ -617,21 +617,6 @@ def _to_banded(n_below, n_above, a):
     for i in range(1, n_below + 1):
         ab[n_above + i, :-i] = np.diag(a, -i)
     return ab
-
-
-def _ensure_dtype_cdsz(*arrays):
-    # Ensure that the dtype of arrays is one of the standard types
-    # compatible with LAPACK functions (single or double precision
-    # real or complex).
-    dtype = np.result_type(*arrays)
-    if not np.issubdtype(dtype, np.inexact):
-        return (array.astype(np.float64) for array in arrays)
-    complex = np.issubdtype(dtype, np.complexfloating)
-    if np.finfo(dtype).bits <= 32:
-        dtype = np.complex64 if complex else np.float32
-    elif np.finfo(dtype).bits >= 64:
-        dtype = np.complex128 if complex else np.float64
-    return (array.astype(dtype, copy=False) for array in arrays)
 
 
 @_apply_over_batch(('a', 2), ('b', '1|2'))

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -224,10 +224,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
 
     # Also check if dtype is LAPACK compatible
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
-
-    if not (a1.flags['ALIGNED'] or a1.dtype.byteorder == '='):
-        overwrite_a = True
-        a1 = a1.copy()
+    a1, overwrite_a = _ensure_aligned_and_native(a1, overwrite_a)
 
     # accommodate empty arrays
     if a1.shape[-1] == 0 or a1.shape[-2] == 0:

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -287,7 +287,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         batch_shape = a1.shape[:-2]
         w_n, vr_n = eig(np.eye(2, dtype=a1.dtype))
         w = np.empty(batch_shape + (0,), dtype=w_n.dtype)
-        w = _make_eigvals(w, None, homogeneous_eigvals)      # XXX
+        w = _make_eigvals(w, None, homogeneous_eigvals)
         vl = np.empty(batch_shape + (0, 0), dtype=vr_n.dtype)
         vr = np.empty(batch_shape + (0, 0), dtype=vr_n.dtype)
         if not (left or right):
@@ -313,10 +313,9 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         )
         raise LinAlgError(mesg)
 
-    # backwards compat: cast to reals if all eigenvalues have zero imaginary parts
+    # backwards compat: make eigvecs real if all eigenvalues have zero imaginary parts
     a_is_real = a1.dtype in (np.float32, np.float64)
     if a_is_real and (w.imag == 0).all():
-        w = w.real
         if left:
             vl = vl.real
         if right:

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -23,8 +23,9 @@ from numpy import (array, isfinite, inexact, nonzero, iscomplexobj,
 # Local imports
 from scipy._lib._util import _asarray_validated, _apply_over_batch
 from ._misc import LinAlgError, _datacopied, norm
-from ._basic import _ensure_dtyle_sdcz
-from .lapack import _normalize_lapack_dtype, _ensure_aligned_and_native
+from .lapack import (
+    _normalize_lapack_dtype, _ensure_aligned_and_native, _ensure_dtype_cdsz
+)
 from .lapack import get_lapack_funcs, _compute_lwork
 from . import _batched_linalg
 

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -6,7 +6,7 @@ from . import _batched_linalg
 
 # Local imports.
 from ._misc import LinAlgError, _datacopied
-from .lapack import _normalize_lapack_dtype, HAS_ILP64
+from .lapack import _normalize_lapack_dtype, _ensure_aligned_and_native, HAS_ILP64
 from scipy.linalg.lapack import get_lapack_funcs   # noqa: F401  (backwards compat)
 from ._decomp import _asarray_validated
 
@@ -144,10 +144,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
 
     # Also check if dtype is LAPACK compatible
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
-
-    if not (a1.flags['ALIGNED'] or a1.dtype.byteorder == '='):
-        overwrite_a = True
-        a1 = a1.copy()
+    a1, overwrite_a = _ensure_aligned_and_native(a1, overwrite_a)
 
     # accommodate empty matrix
     if a1.size == 0:

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -1104,3 +1104,12 @@ def _normalize_lapack_dtype(a, overwrite_a):
         a = a.astype(dtype_char[0])  # makes a copy, free to scratch
         overwrite_a = True
     return a, overwrite_a
+
+
+def _ensure_aligned_and_native(a, overwrite_a):
+    """Make sure an input array is aligned and not byteswapped, copy otherwise.
+    """
+    if not (a.flags['ALIGNED'] and a.dtype.byteorder == '='):
+        overwrite_a = True
+        a = a.copy()
+    return a, overwrite_a

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -1106,6 +1106,21 @@ def _normalize_lapack_dtype(a, overwrite_a):
     return a, overwrite_a
 
 
+def _ensure_dtype_cdsz(*arrays):
+    # Ensure that the dtype of arrays is one of the standard types
+    # compatible with LAPACK functions (single or double precision
+    # real or complex).
+    dtype = np.result_type(*arrays)
+    if not np.issubdtype(dtype, np.inexact):
+        return (array.astype(np.float64) for array in arrays)
+    complex = np.issubdtype(dtype, np.complexfloating)
+    if np.finfo(dtype).bits <= 32:
+        dtype = np.complex64 if complex else np.float32
+    elif np.finfo(dtype).bits >= 64:
+        dtype = np.complex128 if complex else np.float64
+    return (array.astype(dtype, copy=False) for array in arrays)
+
+
 def _ensure_aligned_and_native(a, overwrite_a):
     """Make sure an input array is aligned and not byteswapped, copy otherwise.
     """

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -3,6 +3,7 @@
 #include "_linalg_solve.hh"
 #include "_linalg_svd.hh"
 #include "_linalg_lstsq.hh"
+#include "_linalg_eig.hh"
 #include "_common_array_utils.hh"
 
 
@@ -463,6 +464,120 @@ fail:
 }
 
 
+
+static PyObject*
+_linalg_eig(PyObject* Py_UNUSED(dummy), PyObject* args) {
+    PyArrayObject *ap_Am = NULL;
+    PyArrayObject *ap_w = NULL;
+    PyArrayObject *ap_vr = NULL;
+    PyArrayObject *ap_vl = NULL;
+    int compute_vl=0;
+    int compute_vr=0;
+
+    int info = 0;
+    SliceStatusVec vec_status;
+
+    // Get the input array
+    if (!PyArg_ParseTuple(args, "O!pp", &PyArray_Type, (PyObject **)&ap_Am, &compute_vl, &compute_vr)) {
+        return NULL;
+    }
+
+    // Check for dtype compatibility & array flags
+    int typenum = PyArray_TYPE(ap_Am);
+    bool dtype_ok = (typenum == NPY_FLOAT32)
+                     || (typenum == NPY_FLOAT64)
+                     || (typenum == NPY_COMPLEX64)
+                     || (typenum == NPY_COMPLEX128);
+    if(!dtype_ok || !PyArray_ISALIGNED(ap_Am)) {
+        PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
+        return NULL;
+    }
+
+    // Basic checks of array dimensions
+    int ndim = PyArray_NDIM(ap_Am);
+    npy_intp *shape = PyArray_SHAPE(ap_Am);
+    if (ndim < 2) {
+        PyErr_SetString(PyExc_ValueError, "Expected at least a 2D array.");
+        return NULL;
+    }
+
+    npy_intp n = shape[ndim - 1];
+
+    if (PyArray_DIM(ap_Am, ndim-2) != n) {
+        PyErr_SetString(PyExc_ValueError, "Expected a square matrix");
+        return NULL;
+    }
+
+    // Allocate the output(s)
+    // NB: we always allocate/return complex eigvalues/eigvecs even if
+    // eigenvalues happen to be on the real axis (and then the python wrapper will
+    // cast them to reals for backwards compat.
+
+    npy_intp shape_1[NPY_MAXDIMS];
+    for(int i=0; i<ndim; i++) {shape_1[i] = shape[i]; }
+
+    // eigenvalues
+    int w_typenum = typenum;
+    if (typenum == NPY_FLOAT32) { w_typenum = NPY_COMPLEX64; }
+    else if (typenum == NPY_FLOAT64) { w_typenum = NPY_COMPLEX128; }
+
+    ap_w = (PyArrayObject *)PyArray_SimpleNew(ndim-1, shape_1, w_typenum);
+    if (ap_w == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    if (compute_vl) {
+        ap_vl = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, w_typenum);
+        if (ap_vl == NULL) {
+            Py_DECREF(ap_w);
+            PyErr_NoMemory();
+            return NULL;
+        }
+    }
+
+    if (compute_vr) {
+        ap_vr = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, w_typenum);
+        if (ap_vr == NULL) {
+            Py_DECREF(ap_w);
+            Py_XDECREF(ap_vl);
+            PyErr_NoMemory();
+            return NULL;
+        }
+    }
+
+    switch(typenum) {
+        case(NPY_FLOAT32):
+            info = _eig<float>(ap_Am, ap_w, ap_vl, ap_vr, vec_status);
+            break;
+        case(NPY_FLOAT64):
+            info = _eig<double>(ap_Am, ap_w, ap_vl, ap_vr, vec_status);
+            break;
+        case(NPY_COMPLEX64):
+            info = _eig<npy_complex64>(ap_Am, ap_w, ap_vl, ap_vr, vec_status);
+            break;
+        case(NPY_COMPLEX128):
+            info = _eig<npy_complex128>(ap_Am, ap_w, ap_vl, ap_vr, vec_status);
+            break;
+        default:
+            PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");
+    }
+
+    if (info < 0) {
+        // Either OOM or internal LAPACK error.
+        PyErr_SetString(PyExc_RuntimeError, "Memory error in scipy.linalg.eig.");
+        return NULL;
+    }
+
+    PyObject *ret_lst = convert_vec_status(vec_status);
+
+    PyObject *vl_ret = ap_vl == NULL ? Py_None : PyArray_Return(ap_vl);
+    PyObject *vr_ret = ap_vr == NULL ? Py_None : PyArray_Return(ap_vr);
+
+    return Py_BuildValue("NNNN", PyArray_Return(ap_w), vl_ret, vr_ret, ret_lst);
+}
+
+
 /*
  * Helper: convert a vector of slice error statuses to list of dicts
  */
@@ -511,12 +626,14 @@ static char doc_inv[] = ("Compute the matrix inverse.");
 static char doc_solve[] = ("Solve the linear system of equations.");
 static char doc_svd[] = ("SVD factorization.");
 static char doc_lstsq[] = ("linear least squares.");
+static char doc_eig[] = ("eigenvalue solver.");
 
 static struct PyMethodDef inv_module_methods[] = {
   {"_inv", _linalg_inv, METH_VARARGS, doc_inv},
   {"_solve", _linalg_solve, METH_VARARGS, doc_solve},
   {"_svd", _linalg_svd, METH_VARARGS, doc_svd},
   {"_lstsq", _linalg_lstsq, METH_VARARGS, doc_lstsq},
+  {"_eig", _linalg_eig, METH_VARARGS, doc_eig},
   {NULL, NULL, 0, NULL}
 };
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -534,21 +534,24 @@ _linalg_eig(PyObject* Py_UNUSED(dummy), PyObject* args) {
     else if (typenum == NPY_FLOAT64) { w_typenum = NPY_COMPLEX128; }
 
     ap_w = (PyArrayObject *)PyArray_SimpleNew(ndim-1, shape_1, w_typenum);
-    if (ap_w == NULL) { goto fail; }
+    if (ap_w == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
 
     if (ap_Bm != NULL) {
         ap_beta = (PyArrayObject *)PyArray_SimpleNew(ndim-1, shape_1, typenum);
-        if (ap_beta == NULL) { goto fail; }
+        if (ap_beta == NULL) { PyErr_NoMemory(); goto fail; }
     }
 
     if (compute_vl) {
         ap_vl = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, w_typenum);
-        if (ap_vl == NULL) { goto fail; }
+        if (ap_vl == NULL) { PyErr_NoMemory(); goto fail; }
     }
 
     if (compute_vr) {
         ap_vr = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, w_typenum);
-        if (ap_vr == NULL) { goto fail; }
+        if (ap_vr == NULL) { PyErr_NoMemory(); goto fail; }
     }
 
     switch(typenum) {
@@ -566,12 +569,13 @@ _linalg_eig(PyObject* Py_UNUSED(dummy), PyObject* args) {
             break;
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");
+            goto fail;
     }
 
     if (info < 0) {
         // Either OOM or internal LAPACK error.
         PyErr_SetString(PyExc_RuntimeError, "Memory error in scipy.linalg.eig.");
-        return NULL;
+        goto fail;
     }
 
     // normal return
@@ -585,9 +589,9 @@ _linalg_eig(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
 fail:
     Py_DECREF(ap_w);
+    Py_XDECREF(ap_beta);
     Py_XDECREF(ap_vl);
     Py_XDECREF(ap_vr);
-    PyErr_NoMemory();
     return NULL;
 }
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -472,13 +472,19 @@ _linalg_eig(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyArrayObject *ap_vr = NULL;
     PyArrayObject *ap_vl = NULL;
     int compute_vl=0;
-    int compute_vr=0;
+    int compute_vr=1;
+
+    PyArrayObject *ap_Bm = NULL; // FIXME
 
     int info = 0;
     SliceStatusVec vec_status;
 
     // Get the input array
-    if (!PyArg_ParseTuple(args, "O!pp", &PyArray_Type, (PyObject **)&ap_Am, &compute_vl, &compute_vr)) {
+    if (!PyArg_ParseTuple(args, "O!pp|O!",
+            &PyArray_Type, (PyObject **)&ap_Am,
+            &compute_vl, &compute_vr,
+            &PyArray_Type, (PyObject **)&ap_Bm)
+    ) {
         return NULL;
     }
 
@@ -548,16 +554,16 @@ _linalg_eig(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _eig<float>(ap_Am, ap_w, ap_vl, ap_vr, vec_status);
+            info = _eig<float>(ap_Am, ap_Bm, ap_w, ap_vl, ap_vr, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _eig<double>(ap_Am, ap_w, ap_vl, ap_vr, vec_status);
+            info = _eig<double>(ap_Am, ap_Bm, ap_w, ap_vl, ap_vr, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _eig<npy_complex64>(ap_Am, ap_w, ap_vl, ap_vr, vec_status);
+            info = _eig<npy_complex64>(ap_Am, ap_Bm, ap_w, ap_vl, ap_vr, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _eig<npy_complex128>(ap_Am, ap_w, ap_vl, ap_vr, vec_status);
+            info = _eig<npy_complex128>(ap_Am, ap_Bm, ap_w, ap_vl, ap_vr, vec_status);
             break;
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -772,7 +772,7 @@ GEN_GELSY_CZ(z, npy_complex128, double)
  */
 #define GEN_GEEV_SD(PREFIX, TYPE) \
 inline void \
-geev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *wr, TYPE *wi, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork,  TYPE *rwork, CBLAS_INT *info) \
+call_geev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *wr, TYPE *wi, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork,  TYPE *rwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## geev)(jobvl, jobvr, n, a, lda, wr, wi, vl, ldvl, vr, ldvr, work, lwork, info); \
 };
@@ -782,7 +782,7 @@ GEN_GEEV_SD(d, double)
 
 #define GEN_GEEV_CZ(PREFIX, TYPE, RTYPE) \
 inline void \
-geev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *wr, TYPE *wi, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+call_geev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *wr, TYPE *wi, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
 { \
     /* ignore wi */ \
     BLAS_FUNC(PREFIX ## geev)(jobvl, jobvr, n, a, lda, wr, vl, ldvl, vr, ldvr, work, lwork, rwork, info); \
@@ -799,7 +799,7 @@ GEN_GEEV_CZ(z, npy_complex128, double)
  */
 #define GEN_GGEV_SD(PREFIX, TYPE) \
 inline void \
-ggev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, TYPE *alphar, TYPE *alphai, TYPE *beta, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork, TYPE *rwork, CBLAS_INT *info) \
+call_ggev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, TYPE *alphar, TYPE *alphai, TYPE *beta, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork, TYPE *rwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## ggev)(jobvl, jobvr, n, a, lda, b, ldb, alphar, alphai, beta, vl, ldvl, vr, ldvr, work, lwork, info); \
 };
@@ -810,7 +810,7 @@ GEN_GGEV_SD(d, double)
 
 #define GEN_GGEV_CZ(PREFIX, TYPE, RTYPE) \
 inline void \
-ggev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, TYPE *alphar, TYPE *alphai, TYPE *beta, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+call_ggev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, TYPE *alphar, TYPE *alphai, TYPE *beta, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## ggev)(jobvl, jobvr, n, a, lda, b, ldb, alphar, beta, vl, ldvl, vr, ldvr, work, lwork, rwork, info); \
 };

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -236,12 +236,12 @@ void BLAS_FUNC(dgeev)(char *jobvl, char *jobvr, CBLAS_INT *n, double *a, CBLAS_I
 void BLAS_FUNC(cgeev)(char *jobvl, char *jobvr, CBLAS_INT *n, c64_t *a,  CBLAS_INT *lda, c64_t *w,               c64_t *vl,  CBLAS_INT *ldvl, c64_t *vr,  CBLAS_INT *ldvr, c64_t *work,  CBLAS_INT *lwork, float *rwork,  CBLAS_INT *info);
 void BLAS_FUNC(zgeev)(char *jobvl, char *jobvr, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, c128_t *w,              c128_t *vl, CBLAS_INT *ldvl, c128_t *vr, CBLAS_INT *ldvr, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
 
-//void BLAS_FUNC(sgeev)(char *jobvl, char *jobvr, int *n, s *a, int *lda, s *wr, s *wi, s *vl, int *ldvl, s *vr, int *ldvr, s *work, int *lwork,           int *info);
-//void BLAS_FUNC(dgeev)(char *jobvl, char *jobvr, int *n, d *a, int *lda, d *wr, d *wi, d *vl, int *ldvl, d *vr, int *ldvr, d *work, int *lwork,           int *info);
-//void BLAS_FUNC(cgeev)(char *jobvl, char *jobvr, int *n, c *a, int *lda, c *w,         c *vl, int *ldvl, c *vr, int *ldvr, c *work, int *lwork, s *rwork, int *info);
-//void BLAS_FUNC(zgeev)(char *jobvl, char *jobvr, int *n, z *a, int *lda, z *w,         z *vl, int *ldvl, z *vr, int *ldvr, z *work, int *lwork, d *rwork, int *info);
-//char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, void *w /*s *wr, s *wi */, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork,  TYPE *rwork, CBLAS_INT *info
 
+/* ?GGEV, generalized eigenvalue problem */
+void BLAS_FUNC(sggev)(char *jobvl, char *jobvr, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, float *alphar, float *alphai, float *beta, float *vl, CBLAS_INT *ldvl, float *vr, CBLAS_INT *ldvr, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dggev)(char *jobvl, char *jobvr, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, double *alphar, double *alphai, double *beta, double *vl, CBLAS_INT *ldvl, double *vr, CBLAS_INT *ldvr, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(cggev)(char *jobvl, char *jobvr, CBLAS_INT *n, c64_t *a, CBLAS_INT *lda, c64_t *b, CBLAS_INT *ldb, c64_t *alpha, c64_t *beta, c64_t *vl, CBLAS_INT *ldvl, c64_t *vr, CBLAS_INT *ldvr, c64_t *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *info);
+void BLAS_FUNC(zggev)(char *jobvl, char *jobvr, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, c128_t *b, CBLAS_INT *ldb, c128_t *alpha, c128_t *beta, c128_t *vl, CBLAS_INT *ldvl, c128_t *vr, CBLAS_INT *ldvr, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
 
 
 } // extern "C"
@@ -754,9 +754,22 @@ GEN_GELSY_CZ(c, npy_complex64, float)
 GEN_GELSY_CZ(z, npy_complex128, double)
 
 
-// NB: s- and d- variants ignore the rwork argument (because LAPACK routines do not have it)
-//     s- and d- variants receive *wr, *wi; c- and z- variants receive *w ;
-//     our type-overloaded wrappers always receive wr, wi : sd-variants fill in wr,wi; cz-variants only fill wr and ignore wi
+/*
+ * ?GEEV wrappers.
+ *
+ * We need to wrap over:
+ *   - four type variants, s-, d-, c-, and zgeev;
+ *   - complex variants, c- and z-, receive the `rwork` argument, while s- and d- variants do not.
+ *   - s- and d- variants return real and imaginary parts of eigenvalues separately, in *wr and *wi arrays
+ *     c- and z- variants return a single complex array, *w, instead
+ * Thus,
+ *   - `call_geev` has four overloads;
+ *   - all variants receive the `rwork` argument; c- and z- variants forward it to LAPACK,
+ *     and s- and d- variants swallow it.
+ *   - all variants have *wr and *wi arguments, both of the same type as *a
+ *     (real for real *a, complex for complex *a);
+ *     real-valued overloads, s- and d-, only fill *wr and ignore the *wi argument.
+ */
 #define GEN_GEEV_SD(PREFIX, TYPE) \
 inline void \
 geev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *wr, TYPE *wi, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork,  TYPE *rwork, CBLAS_INT *info) \
@@ -775,11 +788,35 @@ geev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *wr, 
     BLAS_FUNC(PREFIX ## geev)(jobvl, jobvr, n, a, lda, wr, vl, ldvl, vr, ldvr, work, lwork, rwork, info); \
 };
 
-//                      geev(&jobvr, &jobvl, &intn, NULL, &lda, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, NULL, &info);
-
-
 GEN_GEEV_CZ(c, npy_complex64, float)
 GEN_GEEV_CZ(z, npy_complex128, double)
+
+
+/*
+ * Wrappers for ?GGEV
+ *
+ * The design is similar to that of ?GGEV wrappers: all overloads receive *rwork and *alphar, *alphai,
+ */
+#define GEN_GGEV_SD(PREFIX, TYPE) \
+inline void \
+ggev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, TYPE *alphar, TYPE *alphai, TYPE *beta, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork, TYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## ggev)(jobvl, jobvr, n, a, lda, b, ldb, alphar, alphai, beta, vl, ldvl, vr, ldvr, work, lwork, info); \
+};
+
+GEN_GGEV_SD(s, float)
+GEN_GGEV_SD(d, double)
+
+
+#define GEN_GGEV_CZ(PREFIX, TYPE, RTYPE) \
+inline void \
+ggev(char *jobvl, char *jobvr, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, TYPE *alphar, TYPE *alphai, TYPE *beta, TYPE *vl, CBLAS_INT *ldvl, TYPE *vr, CBLAS_INT *ldvr, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## ggev)(jobvl, jobvr, n, a, lda, b, ldb, alphar, beta, vl, ldvl, vr, ldvr, work, lwork, rwork, info); \
+};
+
+GEN_GGEV_CZ(c, npy_complex64, float)
+GEN_GGEV_CZ(z, npy_complex128, double)
 
 
 // Structure tags; python side maps assume_a strings to these values

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -795,7 +795,7 @@ GEN_GEEV_CZ(z, npy_complex128, double)
 /*
  * Wrappers for ?GGEV
  *
- * The design is similar to that of ?GGEV wrappers: all overloads receive *rwork and *alphar, *alphai,
+ * The design is similar to that of ?GEEV wrappers: all overloads receive *rwork and *alphar, *alphai,
  */
 #define GEN_GGEV_SD(PREFIX, TYPE) \
 inline void \

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -1,0 +1,178 @@
+/*
+ * Templated loops for linalg.eig
+ */
+
+
+/*
+ * Copy eigenvectors from F-ordered real `v` (ldv, n)-shaped array in the ?GEEV convention
+ * into an (n, n)-shaped C-ordered complex array `dst`.
+ */
+template<typename real_type, typename cmplx_type>
+void
+transform_eigvecs(cmplx_type dst, real_type *v, CBLAS_INT ldv, CBLAS_INT n, real_type *wi) {
+    for (CBLAS_INT j=0; j < n; ) {
+        if(wi[j] == 0.) {
+            // If the j-th eigenvalue is real, then u(j) = VL(:,j), the j-th column of VL.
+            for (CBLAS_INT i=0; i<n; i++) {
+                dst[i*n + j] = cpack(v[i + j*ldv], real_type(0.));
+            }
+            j += 1;
+        }
+        else {
+            // If the j-th and (j+1)-st eigenvalues form a complex conjugate pair,
+            // then u(j) = VL(:,j) + i*VL(:,j+1) and u(j+1) = VL(:,j) - i*VL(:,j+1).
+            for (CBLAS_INT i=0; i<n; i++) {
+                real_type re = v[i + j*ldv], im = v[i + (j+1)*ldv];
+                dst[i*n + j] = cpack(re, im);     // VL(i, j)
+                dst[i*n + j + 1] = cpack(re, -im);  // VL(i, j+1)
+            }
+            j += 2;
+        }
+    }
+}
+
+
+template<typename T>
+int
+_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArrayObject *ap_vr, SliceStatusVec& vec_status)
+{
+    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using npy_complex_type = typename type_traits<T>::npy_complex_type;
+    SliceStatus slice_status;
+
+    // --------------------------------------------------------------------
+    // Input Array Attributes
+    // --------------------------------------------------------------------
+    T* Am_data = (T *)PyArray_DATA(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);              // Number of dimensions
+    npy_intp* shape = PyArray_SHAPE(ap_Am);      // Array shape
+    npy_intp n = shape[ndim - 1];
+    npy_intp* strides = PyArray_STRIDES(ap_Am);
+    
+    // Get the number of slices to traverse if more than one; np.prod(shape[:-2])
+    npy_intp outer_size = 1;
+    if (ndim > 2) {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i];}
+    }
+
+    // Output array pointers
+    npy_complex_type *ptr_W = (npy_complex_type *)PyArray_DATA(ap_w);
+
+    int compute_vl = (ap_vl != NULL);
+    int compute_vr = (ap_vr != NULL);
+
+    npy_complex_type *ptr_vl = compute_vl ? (npy_complex_type *)PyArray_DATA(ap_vl) : NULL;
+    npy_complex_type *ptr_vr = compute_vr ? (npy_complex_type *)PyArray_DATA(ap_vr) : NULL;
+
+    // --------------------------------------------------------------------
+    // Workspace computation and allocation
+    // --------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
+    T tmp = numeric_limits<T>::zero;
+
+    char jobvl = compute_vl ? 'V': 'N', jobvr = compute_vr ? 'V' : 'N';
+    CBLAS_INT lda = n;
+    CBLAS_INT ldvl = n;
+    CBLAS_INT ldvr = n;
+
+    // c- and z variants: lwork query segfaults with rwork=NULL, allocate it straight away
+    real_type *rwork = NULL;
+    if (type_traits<T>::is_complex) {
+        rwork = (real_type *)malloc(2*n*sizeof(real_type));
+        if (rwork == NULL) {
+            return -100;
+        }
+    }
+
+    // query LWORK
+    geev(&jobvr, &jobvl, &intn, NULL, &lda, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
+    if (info != 0) { free(rwork);  return -101; }
+
+    lwork = _calc_lwork(tmp);
+    if (lwork < 0) { free(rwork); return -102; }
+
+    // allocate
+    npy_intp bufsize = n*n + lwork + n;
+    npy_intp wi_size = type_traits<T>::is_complex ? 0 : n ;
+    bufsize += wi_size;
+
+    npy_intp vl_size = compute_vl ? ldvl*n : 0;
+    npy_intp vr_size = compute_vr ? ldvr*n : 0;
+    bufsize += vl_size + vr_size;
+
+    T *buf = (T *)malloc(bufsize*sizeof(T));
+    if (buf == NULL) { free(rwork); return -103; }
+
+    // partition the workspace
+    T *data = &buf[0];
+    T *work = &buf[n*n];
+    T *wr = &buf[n*n + lwork];
+
+    T *wi = NULL;
+    if(wi_size > 0) { wi = &buf[n*n + lwork + n]; }
+
+    T *buf_vl = NULL;
+    if(vl_size > 0) { buf_vl = &buf[n*n + lwork + n + wi_size]; }
+
+    T *buf_vr = NULL;
+    if(vr_size > 0) { buf_vr = &buf[n*n + lwork + n + wi_size + vl_size]; }
+
+    // --------------------------------------------------------------------
+    // Main loop to traverse the slices
+    // --------------------------------------------------------------------
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+        init_status(slice_status, idx, St::GENERAL);
+
+        // copy the slice to `data` in F order
+        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+        copy_slice_F(data, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
+
+        // compute eigenvalues for the slice
+        geev(&jobvl, &jobvr, &intn, data, &lda, wr, wi, buf_vl, &ldvl, buf_vr, &ldvr, work, &lwork, rwork, &info);
+
+        if(info != 0) {
+            slice_status.lapack_info = (Py_ssize_t)info;
+            vec_status.push_back(slice_status);
+
+            // cut it short on error in any slice
+            goto done;
+        }
+
+        // copy-and-tranpose W, VR and VL slices from temp buffers to the output;
+        if constexpr (type_traits<T>::is_complex) {
+            memcpy(ptr_W, wr, n*sizeof(T));
+            ptr_W += n;
+
+            if (compute_vl) {
+                copy_slice_F_to_C(ptr_vl, buf_vl, n, n, ldvl);
+                ptr_vl += n*n;
+            }
+            if (compute_vr) {
+                copy_slice_F_to_C(ptr_vr, buf_vr, n, n, ldvr);
+                ptr_vr += n*n;
+            }
+        }
+        else {
+            // convert wr,wi into w
+            for(npy_intp i=0; i<n; i++) {
+                ptr_W[i] = cpack(wr[i], wi[i]);
+            }
+            ptr_W += n;
+
+            if (compute_vl) {
+                transform_eigvecs(ptr_vl, buf_vl, ldvl, n, wi);
+                ptr_vl += n*n;
+            }
+            if (compute_vr) {
+                transform_eigvecs(ptr_vr, buf_vr, ldvr, n, wi);
+                ptr_vr += n*n;
+            }
+        }
+    }
+
+ done:
+    free(buf);
+    free(rwork);
+
+    return 0;
+}

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -1,3 +1,4 @@
+#pragma once
 /*
  * Templated loops for linalg.eig
  */
@@ -85,7 +86,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     }
 
     // query LWORK
-    call_geev(&jobvr, &jobvl, &intn, NULL, &lda, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
+    call_geev(&jobvl, &jobvr, &intn, NULL, &lda, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
     if (info != 0) { free(rwork);  return -101; }
 
     lwork = _calc_lwork(tmp);
@@ -237,7 +238,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
     }
 
     // query LWORK
-    call_ggev(&jobvr, &jobvl, &intn, NULL, &lda, NULL, &ldb, NULL, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
+    call_ggev(&jobvl, &jobvr, &intn, NULL, &lda, NULL, &ldb, NULL, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
     if (info != 0) { free(rwork);  return -101; }
 
     lwork = _calc_lwork(tmp);

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -77,7 +77,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
 
     // c- and z variants: lwork query segfaults with rwork=NULL, allocate it straight away
     real_type *rwork = NULL;
-    if (type_traits<T>::is_complex) {
+    if constexpr (type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(2*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
@@ -85,7 +85,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     }
 
     // query LWORK
-    geev(&jobvr, &jobvl, &intn, NULL, &lda, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
+    call_geev(&jobvr, &jobvl, &intn, NULL, &lda, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
     if (info != 0) { free(rwork);  return -101; }
 
     lwork = _calc_lwork(tmp);
@@ -128,7 +128,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
         copy_slice_F(data, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
 
         // compute eigenvalues for the slice
-        geev(&jobvl, &jobvr, &intn, data, &lda, wr, wi, buf_vl, &ldvl, buf_vr, &ldvr, work, &lwork, rwork, &info);
+        call_geev(&jobvl, &jobvr, &intn, data, &lda, wr, wi, buf_vl, &ldvl, buf_vr, &ldvr, work, &lwork, rwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;
@@ -229,7 +229,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
     // similar to geev, allocate rwork right away (not sure if ?ggev segfaults otherwise, too)
     real_type *rwork = NULL;
-    if (type_traits<T>::is_complex) {
+    if constexpr (type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(8*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
@@ -237,7 +237,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
     }
 
     // query LWORK
-    ggev(&jobvr, &jobvl, &intn, NULL, &lda, NULL, &ldb, NULL, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
+    call_ggev(&jobvr, &jobvl, &intn, NULL, &lda, NULL, &ldb, NULL, NULL, NULL, NULL, &ldvl, NULL, &ldvr, &tmp, &lwork, rwork, &info);
     if (info != 0) { free(rwork);  return -101; }
 
     lwork = _calc_lwork(tmp);
@@ -286,7 +286,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
         copy_slice_F(data_B, slice_ptr_B, n, n, strides_B[ndim-2], strides_B[ndim-1]);
 
         // compute eigenvalues for the slice
-        ggev(&jobvl, &jobvr, &intn, data_A, &lda, data_B, &ldb, alphar, alphai, beta, buf_vl, &ldvl, buf_vr, &ldvr, work, &lwork, rwork, &info);
+        call_ggev(&jobvl, &jobvr, &intn, data_A, &lda, data_B, &ldb, alphar, alphai, beta, buf_vl, &ldvl, buf_vr, &ldvr, work, &lwork, rwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -54,6 +54,7 @@ template<typename T> struct type_traits {};
 template<> struct type_traits<float> {
     using real_type = float;
     using value_type = float;
+    using npy_complex_type = npy_complex64;
     static constexpr int typenum = NPY_FLOAT;
     static constexpr bool is_complex = false;
 
@@ -61,18 +62,21 @@ template<> struct type_traits<float> {
 template<> struct type_traits<double> {
     using real_type = double;
     using value_type = double;
+    using npy_complex_type = npy_complex128;
     static constexpr int typenum = NPY_DOUBLE;
     static constexpr bool is_complex = false;
 };
 template<> struct type_traits<npy_complex64> {
     using real_type = float;
     using value_type = std::complex<float>;
+    using npy_complex_type = npy_complex64;
     static constexpr int typenum = NPY_COMPLEX64;
     static constexpr bool is_complex = true;
 };
 template<> struct type_traits<npy_complex128> {
     using real_type = double;
     using value_type = std::complex<double>;
+    using npy_complex_type = npy_complex128;
     static constexpr int typenum = NPY_COMPLEX128;
     static constexpr bool is_complex = true;
 };
@@ -92,6 +96,11 @@ inline float conj(float value){ return value; }
 inline double conj(double value){ return value; }
 inline npy_complex64 conj(npy_complex64 value){ return npy_cpackf(npy_crealf(value), -npy_cimagf(value)); }
 inline npy_complex128 conj(npy_complex128 value){return npy_cpack(npy_creal(value), -npy_cimag(value)); }
+
+
+// complex from two reals
+inline npy_complex64 cpack(float re, float im) {return npy_cpackf(re, im);}
+inline npy_complex128 cpack(double re, double im) {return npy_cpack(re, im);}
 
 
 /*

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -628,7 +628,6 @@ class TestBatch:
 
     @pytest.mark.parametrize('f, args', [
         (linalg.toeplitz, (np.ones((0, 4)),)),
-        (linalg.eig, (np.ones((3, 0, 5, 5)),)),
     ])
     def test_zero_size_batch(self, f, args):
         message = "does not support zero-size batches."

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -149,9 +149,31 @@ class TestEig:
         assert_array_almost_equal(v2, v[:, 2]*sign(v[0, 2]))
         for i in range(3):
             assert_array_almost_equal(a @ v[:, i], w[i]*v[:, i])
+
         w, v = eig(a, left=1, right=0)
         for i in range(3):
             assert_array_almost_equal(a.T @ v[:, i], w[i]*v[:, i])
+
+    def test_simple_dtype(self):
+        # Backwards compat: the input matrix is real, eigenvalues have zero
+        # imaginary part =>
+        #  - eigenvectors are real,
+        #  - *but* eigenvalues are still complex-valued!
+        # the `a` matrix is from test_simple
+        a = np.array([[1, 2, 3], [1, 2, 3], [2, 5, 6]])
+        w, vl, vr = eig(a, left=True, right=True)
+        assert w.dtype == np.complex128
+        assert (w.imag == 0).all()
+        assert vl.dtype == np.float64
+        assert vr.dtype == np.float64
+
+        # repeat for a generalized eigenvalue problem
+        b = np.diag([3, 2, 1])
+        w, vl, vr = eig(a, b, left=True, right=True)
+        assert w.dtype == np.complex128
+        assert (w.imag == 0.).all()
+        assert vl.dtype == np.float64
+        assert vr.dtype == np.float64
 
     def test_simple_complex_eig(self):
         a = array([[1, 2], [-2, 1]])
@@ -162,6 +184,18 @@ class TestEig:
         for i in range(2):
             assert_array_almost_equal(a.conj().T @ vl[:, i],
                                       w[i].conj()*vl[:, i])
+
+    def test_simple_complex_eig_dtype(self):
+        # Backwards compat: the matrix is real, the true eigenvalues are complex
+        # Thus, all of `w`, `vr` and `vl` arrays have a complex dtype
+        # The matrix `a` is from test_simple_complex_eig
+
+        a = np.asarray([[1, 2], [-2, 1]])
+        w, vl, vr = eig(a, left=True, right=True)
+        assert w.dtype == np.complex128
+        assert vl.dtype == np.complex128
+        assert vr.dtype == np.complex128
+
 
     def test_simple_complex(self):
         a = array([[1, 2, 3], [1, 2, 3], [2, 5, 6+1j]])


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

needs a rebase on gh-23919, gh-24177
The size of the PR "stack" starts getting large though.

#### What does this implement/fix?
<!--Please explain your changes.-->

Move the batch loop of `linalg.eig` to C.

TODO:
- [x] sort the _cast to real if eigenvalues happen to have zero imaginary parts_ dance
- [x] handle `homogeous_eigenvalues`
- [x] audit test coverage, esp for the generalized problem
- [x] generalized eigenvalue problem, wrap `ggev`
- [x] benchmarks

#### Additional information
<!--Any additional information you think is important.-->

A curious implementation detail: `cgeev` and `zgeev` require a non-NULL `rwork` array for the LWORK query. Other LAPACK routines, when `lwork=-1` only look at array sizes, so a typical pattern is to first call with `NULL` pointers to arrays and `lwork=-1`, then allocate all temp buffers, including work arrays, in one go.  For `?geev`, this segfaults, thus need to first allocate the `rwork`, then query the workspace and then allocate the rest. 
