### PR TITLE
MAINT: `PY_VERSION_HEX` cleanups

### DIFF
--- a/scipy/integrate/_dopmodule.c
+++ b/scipy/integrate/_dopmodule.c
@@ -345,10 +345,8 @@ doplib_module_exec(PyObject *module)
 
 static struct PyModuleDef_Slot doplib_module_slots[] = {
     {Py_mod_exec, doplib_module_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
     // signal that this module can be imported in isolated subinterpreters
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
 #if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},

--- a/scipy/integrate/_dzvodemodule.c
+++ b/scipy/integrate/_dzvodemodule.c
@@ -1132,9 +1132,7 @@ dzvode_module_exec(PyObject *module)
 
 static struct PyModuleDef_Slot dzvode_module_slots[] = {
     {Py_mod_exec, dzvode_module_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
 #if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif

--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -1148,10 +1148,8 @@ odepacklib_module_exec(PyObject *module)
 
 static struct PyModuleDef_Slot odepacklib_module_slots[] = {
     {Py_mod_exec, odepacklib_module_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
     // signal that this module can be imported in isolated subinterpreters
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
 #if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},

--- a/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
+++ b/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
@@ -1035,10 +1035,8 @@ PyMethodDef arpacklib_module_methods[] = {
 
 
 static struct PyModuleDef_Slot arpacklib_module_slots[] = {
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
     // signal that this module can be imported in isolated subinterpreters
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
 #if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},

--- a/scipy/sparse/linalg/_propack/_propackmodule.c
+++ b/scipy/sparse/linalg/_propack/_propackmodule.c
@@ -859,9 +859,7 @@ static int propack_exec(PyObject* module) {
 // Module slots for multi-phase initialization
 static PyModuleDef_Slot propack_slots[] = {
     {Py_mod_exec, propack_exec},
-#if PY_VERSION_HEX >= 0x030c00f0  // Python 3.12+
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
-#endif
 #if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif


### PR DESCRIPTION
* There were a few leftover `PY_VERSION_HEX` guards that we no longer need after bumping our minimum
CPython version.