### PR TITLE
DOC: signal.place_poles: fix xp_capabilites

### DIFF
--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -94,7 +94,7 @@ untested = {
     "peak_prominences",
     "peak_widths",
     "periodogram",
-    "place_pols",
+    "place_poles",
     "sawtooth",
     "sepfir2d",
     "ss2tf",


### PR DESCRIPTION
A small typo means the `place_poles` was showing up as having array api support
<img width="714" height="39" alt="image" src="https://github.com/user-attachments/assets/62e6a786-d35a-4ec5-8306-dd96261e7e35" />
when it doesn't