### PR TITLE
ENH: linalg.qr: move the batching loop to C

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -240,6 +240,29 @@ class BatchedCholeskyBench(Benchmark):
             sl.cholesky(self.a)
 
 
+class BatchedQRBench(Benchmark):
+    params = [
+        [(100, 10, 10), (100, 20, 20), (100, 100)],
+        ["full/complete", "economic/reduced", "r/r", "raw/raw"],
+        ["scipy", "numpy"]
+    ]
+    param_names = ["shape", "mode", "module"]
+
+    def setup(self, shape, mode, module):
+        self.a = random(shape)
+
+        if module == "scipy":
+            self.kwd = {"mode": mode.split("/")[0]}
+        elif module == "numpy":
+            self.kwd = {"mode": mode.split("/")[1]}
+
+    def time_solve(self, shape, mode, module):
+        if module == "numpy":
+            nl.qr(self.a, **self.kwd)
+        else:
+            sl.qr(self.a, **self.kwd)
+
+
 class Norm(Benchmark):
     params = [
         [(20, 20), (100, 100), (1000, 1000), (20, 1000), (1000, 20)],

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -2,10 +2,15 @@
 import numpy as np
 
 from scipy._lib._util import _apply_over_batch
+from scipy._lib.deprecation import _NoValue
+
+import warnings
 
 # Local imports
-from .lapack import get_lapack_funcs
+from .lapack import _normalize_lapack_dtype, get_lapack_funcs, HAS_ILP64
 from ._misc import _datacopied
+from ._basic import _format_emit_errors_warnings
+from . import _batched_linalg
 
 __all__ = ['qr', 'qr_multiply', 'rq']
 
@@ -24,9 +29,8 @@ def safecall(f, name, *args, **kwargs):
     return ret[:-2]
 
 
-@_apply_over_batch(('a', 2))
-def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
-       check_finite=True):
+def qr(a, overwrite_a=False, lwork=_NoValue, mode="full", pivoting=False,
+    check_finite=True):
     """
     Compute QR decomposition of a matrix.
 
@@ -35,7 +39,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
 
     Parameters
     ----------
-    a : (M, N) array_like
+    a : (..., M, N) array_like
         Matrix to be decomposed
     overwrite_a : bool, optional
         Whether data in `a` is overwritten (may improve performance if
@@ -44,6 +48,11 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
     lwork : int, optional
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
+
+        .. deprecated:: 1.18.0
+            This keyword is deprecated as well as no longer in use and will be
+            removed in 1.20.0.
+
     mode : {'full', 'r', 'economic', 'raw'}, optional
         Determines what information is to be returned: either both Q and R
         ('full', default), only R ('r') or both Q and R but computed in
@@ -53,7 +62,7 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
     pivoting : bool, optional
         Whether or not factorization should include pivoting for rank-revealing
         qr decomposition. If pivoting, compute the decomposition
-        ``A[:, P] = Q @ R`` as above, but where P is chosen such that the
+        ``A[..., :, P] = Q @ R`` as above, but where P is chosen such that the
         diagonal of R is non-increasing. Equivalently, albeit less efficiently,
         an explicit P matrix may be formed explicitly by permuting the rows or columns
         (depending on the side of the equation on which it is to be used) of
@@ -66,13 +75,13 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
     Returns
     -------
     Q : float or complex ndarray
-        Of shape (M, M), or (M, K) for ``mode='economic'``. Not returned
+        Of shape (..., M, M), or (..., M, K) for ``mode='economic'``. Not returned
         if ``mode='r'``. Replaced by tuple ``(Q, TAU)`` if ``mode='raw'``.
     R : float or complex ndarray
-        Of shape (M, N), or (K, N) for ``mode in ['economic', 'raw']``.
+        Of shape (..., M, N), or (..., K, N) for ``mode in ['economic', 'raw']``.
         ``K = min(M, N)``.
     P : int ndarray
-        Of shape (N,) for ``pivoting=True``. Not returned if
+        Of shape (..., N,) for ``pivoting=True``. Not returned if
         ``pivoting=False``.
 
     Raises
@@ -85,8 +94,8 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
     This is an interface to the LAPACK routines dgeqrf, zgeqrf,
     dorgqr, zungqr, dgeqp3, and zgeqp3.
 
-    If ``mode=economic``, the shapes of Q and R are (M, K) and (K, N) instead
-    of (M,M) and (M,N), with ``K=min(M,N)``.
+    If ``mode=economic``, the shapes of Q and R are (..., M, K) and (..., K, N) instead
+    of (..., M,M) and (..., M,N), with ``K=min(M,N)``.
 
     Examples
     --------
@@ -129,91 +138,102 @@ def qr(a, overwrite_a=False, lwork=None, mode='full', pivoting=False,
     >>> P = np.eye(6)[:, p5]
     >>> np.allclose(a @ P, np.dot(q5, r5))
     True
-
     """
+    # structure mappings, keep in sync with the C side
+    modes = {
+        "full": 1,
+        "qr": 1, # equivalent to `full`
+        "r": 11,
+        "raw": 21,
+        "economic": 31
+    }
+
     # 'qr' was the old default, equivalent to 'full'. Neither 'full' nor
     # 'qr' are used below.
     # 'raw' is used internally by qr_multiply
-    if mode not in ['full', 'qr', 'r', 'economic', 'raw']:
-        raise ValueError("Mode argument should be one of ['full', 'r', "
-                         "'economic', 'raw']")
+    if mode not in modes.keys():
+        raise ValueError(f"Mode argument should be one of {list(modes.keys())}")
+
+    modeFlag = modes[mode] # convert the string to an int for the C enum
 
     if check_finite:
         a1 = np.asarray_chkfinite(a)
     else:
         a1 = np.asarray(a)
-    if len(a1.shape) != 2:
-        raise ValueError("expected a 2-D array")
 
-    M, N = a1.shape
+    if a1.ndim < 2:
+        raise ValueError("Expected at least a 2-D array")
+
+    M, N = a1.shape[-2], a1.shape[-1]
+
+    # Throw error for backwards compat, else raise DeprecationWarning
+    if lwork is not _NoValue:
+        if lwork is not None and lwork != -1 and lwork <= M:
+            raise ValueError(f"lwork should be None, -1 or > M, got {lwork}")
+
+        else:
+            warnings.warn(
+                "scipy.linalg: the `lwork` keyword is deprecated and no longer in use"
+                " as of SciPy 1.18.0 and will be removed in SciPy 1.20.0",
+                DeprecationWarning,
+                stacklevel=2
+            )
+
+    # First normalize dtypes to ensure consistent return types
+    a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
 
     # accommodate empty arrays
     if a1.size == 0:
         K = min(M, N)
+        batch_shape = a1.shape[:-2]
 
         if mode not in ['economic', 'raw']:
-            Q = np.empty_like(a1, shape=(M, M))
-            Q[...] = np.identity(M)
+            Q = np.empty_like(a1, shape=batch_shape + (M, M))
+            Q[..., :, :] = np.identity(M)
             R = np.empty_like(a1)
         else:
-            Q = np.empty_like(a1, shape=(M, K))
-            R = np.empty_like(a1, shape=(K, N))
+            Q = np.empty_like(a1, shape=batch_shape + (M, K))
+            R = np.empty_like(a1, shape=batch_shape + (K, N))
 
         if pivoting:
-            Rj = R, np.arange(N, dtype=np.int32)
+            Rj = R, np.arange(N, dtype=np.int64 if HAS_ILP64 else np.int32)
         else:
             Rj = R,
 
         if mode == 'r':
             return Rj
         elif mode == 'raw':
-            qr = np.empty_like(a1, shape=(M, N))
-            tau = np.zeros_like(a1, shape=(K,))
+            qr = np.empty_like(a1, shape=batch_shape + (M, N))
+            tau = np.zeros_like(a1, shape=batch_shape + (K,))
             return ((qr, tau),) + Rj
+
         return (Q,) + Rj
+
+    if not (a1.flags['ALIGNED'] and a1.dtype.byteorder == '='):
+        overwrite_a = True
+        a1 = a1.copy()
 
     overwrite_a = overwrite_a or (_datacopied(a1, a))
 
-    if pivoting:
-        geqp3, = get_lapack_funcs(('geqp3',), (a1,))
-        qr, jpvt, tau = safecall(geqp3, "geqp3", a1, overwrite_a=overwrite_a)
-        jpvt -= 1  # geqp3 returns a 1-based index array, so subtract 1
-    else:
-        geqrf, = get_lapack_funcs(('geqrf',), (a1,))
-        qr, tau = safecall(geqrf, "geqrf", a1, lwork=lwork,
-                           overwrite_a=overwrite_a)
+    # heavy lifting
+    Q, R, tau, jpvt, err_lst = _batched_linalg._qr(a1, overwrite_a, modeFlag, pivoting)
 
-    if mode not in ['economic', 'raw'] or M < N:
-        R = np.triu(qr)
-    else:
-        R = np.triu(qr[:N, :])
+    if err_lst:
+        _format_emit_errors_warnings(err_lst)
 
+    # construct return objects
     if pivoting:
         Rj = R, jpvt
     else:
-        Rj = R,
+        Rj = (R,)
 
-    if mode == 'r':
+    if mode == "raw":
+        Q = (Q, tau)
+
+    if mode == "r":
         return Rj
-    elif mode == 'raw':
-        return ((qr, tau),) + Rj
-
-    gor_un_gqr, = get_lapack_funcs(('orgqr',), (qr,))
-
-    if M < N:
-        Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qr[:, :M], tau,
-                      lwork=lwork, overwrite_a=1)
-    elif mode == 'economic':
-        Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qr, tau, lwork=lwork,
-                      overwrite_a=1)
     else:
-        t = qr.dtype.char
-        qqr = np.empty((M, M), dtype=t)
-        qqr[:, :N] = qr
-        Q, = safecall(gor_un_gqr, "gorgqr/gungqr", qqr, tau, lwork=lwork,
-                      overwrite_a=1)
-
-    return (Q,) + Rj
+        return (Q,) + Rj
 
 
 @_apply_over_batch(('a', 2), ('c', '1|2'))
@@ -317,7 +337,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
             raise ValueError('Array shapes are not compatible for c @ Q'
                              f' operation: {c.shape} vs {a.shape}')
 
-    raw = qr(a, overwrite_a, None, "raw", pivoting)
+    raw = qr(a, overwrite_a, mode="raw", pivoting=pivoting)
     Q, tau = raw[0]
 
     # accommodate empty arrays

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -327,8 +327,7 @@ _linalg_qr(PyObject* Py_UNUSED(dummy), PyObject* args) {
         strides_Q[ndim-2] = sizeof_T;
         strides_Q[ndim-1] = M * sizeof_T;
 
-        PyArray_UpdateFlags(ap_Q, NPY_ARRAY_C_CONTIGUOUS);
-        PyArray_UpdateFlags(ap_Q, NPY_ARRAY_F_CONTIGUOUS);
+        PyArray_UpdateFlags(ap_Q, NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
     }
 
     // Set all elements to 0 immediately as the pivots are also used as inputs in `geqp3`.

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -5,6 +5,7 @@
 #include "_linalg_lstsq.hh"
 #include "_linalg_eig.hh"
 #include "_linalg_cholesky.hh"
+#include "_linalg_qr.hh"
 #include "_common_array_utils.hh"
 
 
@@ -96,6 +97,7 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     return Py_BuildValue("NN", PyArray_Return(ap_Ainv), ret_lst);
 }
+
 
 
 static PyObject*
@@ -205,6 +207,181 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     return Py_BuildValue("NN", PyArray_Return(ap_x), ret_lst);
 }
+
+
+
+static PyObject*
+_linalg_qr(PyObject* Py_UNUSED(dummy), PyObject* args) {
+    PyArrayObject *ap_A = NULL;
+
+    int info = 0;
+    SliceStatusVec vec_status;
+    int overwrite_a = 0;
+    QR_mode mode = QR_mode::FULL;
+    int pivoting = 0;
+
+    PyArrayObject *ap_Q = NULL, *ap_R = NULL, *ap_tau = NULL, *ap_jpvt = NULL;
+    PyObject *ret_lst = NULL, *ret_Q = NULL, *ret_tau = NULL, *ret_jpvt = NULL;
+
+    // Get the input array
+    if (!PyArg_ParseTuple(args, "O!|pnp", &PyArray_Type, (PyObject **)&ap_A, &overwrite_a, &mode, &pivoting)) {
+        return NULL;
+    }
+
+    // Check for dtype compatibility & array flags
+    int typenum = PyArray_TYPE(ap_A);
+    bool dtype_ok = (typenum == NPY_FLOAT32)
+                     || (typenum == NPY_FLOAT64)
+                     || (typenum == NPY_COMPLEX64)
+                     || (typenum == NPY_COMPLEX128);
+    if(!dtype_ok || !PyArray_ISALIGNED(ap_A)) {
+        PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
+        return NULL;
+    }
+
+    // Sanity checks
+    int ndim = PyArray_NDIM(ap_A);
+    npy_intp* shape = PyArray_SHAPE(ap_A);
+    if (ndim < 2) {
+        PyErr_SetString(PyExc_ValueError, "Matrix `a` should at least be 2D.");
+        return NULL;
+    }
+
+    // -------------------------------------------------------------------
+    // Conditionally allocate return objects
+    // -------------------------------------------------------------------
+    npy_intp M = shape[ndim-2], N = shape[ndim-1];
+    npy_intp K = std::min(M, N);
+
+    npy_intp shape_Q[NPY_MAXDIMS];
+    npy_intp shape_R[NPY_MAXDIMS];
+
+    for (npy_intp i = 0; i < ndim; i++) {
+        shape_Q[i] = shape[i];
+        shape_R[i] = shape[i];
+    }
+
+    switch (mode) {
+        case QR_mode::FULL:
+        {
+            shape_Q[ndim-1] = M;
+            shape_R[ndim-1] = N;
+            break;
+        }
+
+        case QR_mode::R:
+        {
+            // shape of `Q` irrelevant here
+            shape_R[ndim-1] = N;
+            break; // shape of `Q` irrelevant here
+        }
+
+        case QR_mode::RAW:
+        {
+            shape_Q[ndim-1] = N;
+            shape_R[ndim-2] = K;
+            shape_R[ndim-1] = N;
+            break;
+        }
+
+        case QR_mode::ECONOMIC:
+        {
+            shape_Q[ndim-1] = K;
+            shape_R[ndim-2] = K;
+            shape_R[ndim-1] = N;
+            break;
+        }
+    }
+
+    if (mode != QR_mode::R) { // Allocate Q if needed, if `mode == raw`, F-ordered array is required.
+        ap_Q = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_Q, typenum);
+        if (!ap_Q) {
+            PyErr_NoMemory();
+            goto fail_qr;
+        }
+    }
+
+    ap_R = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_R, typenum);
+    if (!ap_R) {
+        PyErr_NoMemory();
+        goto fail_qr;
+    }
+
+    if (mode == QR_mode::RAW) {
+        shape_Q[ndim-2] = K; // Just reuse `shape_Q`; not used any longer.
+        ap_tau = (PyArrayObject *)PyArray_SimpleNew(ndim-1, shape_Q, typenum); // Just a vector, so `ndim-1`.
+        if (!ap_tau) {
+            PyErr_NoMemory();
+            goto fail_qr;
+        }
+
+        /*
+         * Since the point of the `Q` returned if `mode="raw"` is mostly to call other LAPACK routines (e.g. `qr_multiply`),
+         * set the strides of `Q` to return F-ordered slices.
+         *
+         * Dimensions other than the last two are not affected so slice computation etc. stays intact.
+         */
+        npy_intp *strides_Q = PyArray_STRIDES(ap_Q);
+        int sizeof_T = PyArray_ITEMSIZE(ap_Q);
+
+        strides_Q[ndim-2] = sizeof_T;
+        strides_Q[ndim-1] = M * sizeof_T;
+
+        PyArray_UpdateFlags(ap_Q, NPY_ARRAY_C_CONTIGUOUS);
+        PyArray_UpdateFlags(ap_Q, NPY_ARRAY_F_CONTIGUOUS);
+    }
+
+    // Set all elements to 0 immediately as the pivots are also used as inputs in `geqp3`.
+    // Allocate a C-ordered array, (hence the `0` magic number).
+    if (pivoting) {
+        shape_Q[ndim-2] = N;
+        ap_jpvt = (PyArrayObject *)PyArray_ZEROS(ndim-1, shape_Q, sizeof(CBLAS_INT) == sizeof(NPY_INT32)? NPY_INT32 : NPY_INT64, 0);
+        if (!ap_jpvt) {
+            PyErr_NoMemory();
+            goto fail_qr;
+        }
+    }
+
+
+    switch(typenum) {
+        case(NPY_FLOAT32):
+            info = _qr<float>(ap_A, ap_Q, ap_R, ap_tau, ap_jpvt, overwrite_a, mode, pivoting, vec_status);
+            break;
+        case(NPY_FLOAT64):
+            info = _qr<double>(ap_A, ap_Q, ap_R, ap_tau, ap_jpvt, overwrite_a, mode, pivoting, vec_status);
+            break;
+        case(NPY_COMPLEX64):
+            info = _qr<npy_complex64>(ap_A, ap_Q, ap_R, ap_tau, ap_jpvt, overwrite_a, mode, pivoting, vec_status);
+            break;
+        case(NPY_COMPLEX128):
+            info = _qr<npy_complex128>(ap_A, ap_Q, ap_R, ap_tau, ap_jpvt, overwrite_a, mode, pivoting, vec_status);
+            break;
+        default:
+            PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");
+            return NULL;
+    }
+
+    if (info < 0) {
+        // Either OOM error or requiested lwork too large.
+        PyErr_SetString(PyExc_MemoryError, "Memory error in scipy.linalg.qr.");
+        goto fail_qr;
+    }
+
+    ret_lst = convert_vec_status(vec_status);
+
+    ret_Q = (mode != QR_mode::R) ? PyArray_Return(ap_Q) : Py_None;
+    ret_tau = (mode == QR_mode::RAW) ? PyArray_Return(ap_tau) : Py_None;
+    ret_jpvt = (pivoting) ? PyArray_Return(ap_jpvt): Py_None;
+    return Py_BuildValue("NNNNN", ret_Q, PyArray_Return(ap_R), ret_tau, ret_jpvt, ret_lst);
+
+fail_qr:
+    Py_XDECREF(ap_Q);
+    Py_XDECREF(ap_R);
+    Py_XDECREF(ap_tau);
+    Py_XDECREF(ap_jpvt);
+    return NULL;
+}
+
 
 
 static PyObject*
@@ -743,6 +920,7 @@ static char doc_svd[] = ("SVD factorization.");
 static char doc_lstsq[] = ("linear least squares.");
 static char doc_eig[] = ("eigenvalue solver.");
 static char doc_cholesky[] = ("Cholesky factorization.");
+static char doc_qr[] = ("Compute the qr decomposition.");
 
 static struct PyMethodDef inv_module_methods[] = {
   {"_inv", _linalg_inv, METH_VARARGS, doc_inv},
@@ -751,6 +929,7 @@ static struct PyMethodDef inv_module_methods[] = {
   {"_lstsq", _linalg_lstsq, METH_VARARGS, doc_lstsq},
   {"_eig", _linalg_eig, METH_VARARGS, doc_eig},
   {"_cholesky", _linalg_cholesky, METH_VARARGS, doc_cholesky},
+  {"_qr", _linalg_qr, METH_VARARGS, doc_qr},
   {NULL, NULL, 0, NULL}
 };
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -638,6 +638,56 @@ GEN_GBCON_CZ(c, npy_complex64, float)
 GEN_GBCON_CZ(z, npy_complex128, double)
 
 
+#define GEN_GEQRF(PREFIX, TYPE) \
+inline void \
+call_geqrf(CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *tau, TYPE *work, CBLAS_INT *lwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## geqrf)(m, n, a, lda, tau, work, lwork, info); \
+};
+
+GEN_GEQRF(s, float);
+GEN_GEQRF(d, double);
+GEN_GEQRF(c, npy_complex64);
+GEN_GEQRF(z, npy_complex128);
+
+
+// N.B. `rwork` is not used for `s` and `d` variants, so swallowed prior to calling LAPACK
+#define GEN_GEQP3(PREFIX, TYPE) \
+inline void \
+call_geqp3(CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *jpvt, TYPE *tau, TYPE *work, CBLAS_INT *lwork, void *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## geqp3)(m, n, a, lda, jpvt, tau, work, lwork, info); \
+};
+
+GEN_GEQP3(s, float);
+GEN_GEQP3(d, double);
+
+
+#define GEN_GEQP3_CZ(PREFIX, TYPE, RTYPE) \
+inline void \
+call_geqp3(CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, CBLAS_INT *jpvt, TYPE *tau, TYPE *work, CBLAS_INT *lwork, void *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## geqp3)(m, n, a, lda, jpvt, tau, work, lwork, (RTYPE *)rwork, info); \
+};
+
+GEN_GEQP3_CZ(c, npy_complex64, float);
+GEN_GEQP3_CZ(z, npy_complex128, double);
+
+
+// NB: wrap {s-,d-}orgqr for reals and {c-,z-}ungqr for complex
+#define GEN_OR_UN_GQR(PREFIX, TYPE) \
+inline void \
+call_or_un_gqr(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *k, TYPE *a, CBLAS_INT *lda, TYPE *tau, TYPE *work, CBLAS_INT *lwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## gqr)(m, n, k, a, lda, tau, work, lwork, info); \
+};
+
+GEN_OR_UN_GQR(sor, float)
+GEN_OR_UN_GQR(dor, double)
+GEN_OR_UN_GQR(cun, npy_complex64)
+GEN_OR_UN_GQR(zun, npy_complex128)
+
+
 /*
  * ?GESVD wrappers.
  *
@@ -719,37 +769,6 @@ inline void call_gesdd(
 {
     BLAS_FUNC(zgesdd)(jobz, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork, iwork, info);
 };
-
-
-
-
-#define GEN_GEQRF(PREFIX, TYPE) \
-inline void \
-geqrf(CBLAS_INT *m, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *tau, TYPE *work, CBLAS_INT *lwork, CBLAS_INT *info) \
-{ \
-    BLAS_FUNC(PREFIX ## geqrf)(m, n, a, lda, tau, work, lwork, info); \
-};
-
-GEN_GEQRF(s, float)
-GEN_GEQRF(d, double)
-GEN_GEQRF(c, npy_complex64)
-GEN_GEQRF(z, npy_complex128)
-
-
-
-// NB: wrap {s-,d-}orgqr for reals and {c-,z-}ungqr for complex
-#define GEN_OR_UN_GQR(PREFIX, TYPE) \
-inline void \
-or_un_gqr(CBLAS_INT *m, CBLAS_INT *n, CBLAS_INT *k, TYPE *a, CBLAS_INT *lda, TYPE *tau, TYPE *work, CBLAS_INT *lwork, CBLAS_INT *info) \
-{ \
-    BLAS_FUNC(PREFIX ## gqr)(m, n, k, a, lda, tau, work, lwork, info); \
-};
-
-GEN_OR_UN_GQR(sor, float)
-GEN_OR_UN_GQR(dor, double)
-GEN_OR_UN_GQR(cun, npy_complex64)
-GEN_OR_UN_GQR(zun, npy_complex128)
-
 
 
 // NB: s- and d- variants ignore the rwork argument (because LAPACK routines do not have it
@@ -899,6 +918,15 @@ enum St : Py_ssize_t
     POS_DEF = 101,
     SYM = 201,
     HER = 211
+};
+
+// QR mode tags; python side maps mode strings to these values
+enum QR_mode : Py_ssize_t
+{
+    FULL = 1,
+    R = 11,
+    RAW = 21,
+    ECONOMIC = 31
 };
 
 
@@ -1089,6 +1117,28 @@ void copy_triangle_F_to_C(T *dst, const T *src, const npy_intp n, const char upl
             for (npy_intp j = i; j < n; j++) {
                 dst[i + j * n] = src[i * n + j];
             }
+        }
+    }
+}
+
+
+/*
+ * Extract only the upper triangle of an F-ordered ldaxN `src` to a C-ordered MxN
+ * `dst`. The rest is put to 0. This function is reminiscent of `zero_other_triangle`,
+ * but contains copying, swapping of ordering and zeroing in one.
+ *
+ * It is assumed that `lda` >= M
+ */
+template<typename T>
+void extract_upper_triangle(T *dst, const T* src, const npy_intp m, const npy_intp n, const npy_intp lda) {
+    for (npy_intp i = 0; i < n; i++) {
+        npy_intp stop = std::min(i + 1, m);
+        for (npy_intp j = 0; j < stop; j++) {
+            dst[j*n + i] = src[i*lda + j];
+        }
+
+        for (npy_intp j = stop; j < m; j++) {
+            dst[j*n + i] = numeric_limits<T>::zero;
         }
     }
 }

--- a/scipy/linalg/src/_linalg_qr.hh
+++ b/scipy/linalg/src/_linalg_qr.hh
@@ -1,0 +1,192 @@
+/*
+ * Templated loops for `linalg.qr`
+ */
+
+#include "src/_common_array_utils.hh"
+template<typename T>
+int
+_qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObject *ap_tau, PyArrayObject *ap_jpvt, int overwrite_a, QR_mode mode, int pivoting, SliceStatusVec &vec_status)
+{
+    using real_type = typename type_traits<T>::real_type;
+    SliceStatus slice_status;
+
+    // ------------------------------------------------------------------------
+    // Input array attributes, some bookkeeping due to conditional allocations
+    // ------------------------------------------------------------------------
+    T *A_data = (T *)PyArray_DATA(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);
+    npy_intp *shape = PyArray_SHAPE(ap_Am);
+    npy_intp *strides = PyArray_STRIDES(ap_Am);
+    npy_intp M = shape[ndim-2];
+    npy_intp N = shape[ndim-1];
+
+    T *R_data = (T *)PyArray_DATA(ap_R);
+    npy_intp *strides_R = PyArray_STRIDES(ap_R);
+
+    // Conditional allocations based on the mode; not all data is always available.
+    T *Q_data = NULL, *tau_data = NULL;
+    CBLAS_INT *jpvt_data = NULL;
+    npy_intp *strides_Q = NULL, *strides_tau = NULL, *strides_jpvt = NULL;
+
+    if (mode != QR_mode::R) {
+        Q_data = (T *)PyArray_DATA(ap_Q);
+        strides_Q = PyArray_STRIDES(ap_Q);
+    }
+
+    if (mode == QR_mode::RAW) {
+        tau_data = (T *)PyArray_DATA(ap_tau);
+        strides_tau = PyArray_STRIDES(ap_tau);
+    }
+
+    if (pivoting) {
+        jpvt_data = (CBLAS_INT *)PyArray_DATA(ap_jpvt);
+        strides_jpvt = PyArray_STRIDES(ap_jpvt);
+    }
+
+    npy_intp outer_size = 1;
+    for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i]; }
+
+    // -------------------------------------------------------------------
+    // Workspace computation and allocation
+    // -------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)N, intm = (CBLAS_INT)M, info = 0;
+    CBLAS_INT K = std::min(intn, intm), max_dim = std::max(intn, intm);
+    CBLAS_INT middle_dim = (mode == QR_mode::ECONOMIC || mode == QR_mode::RAW) ? K : intm; // Final dimension: Q is [`M` x `middle_dim`], R is [`middle_dim` x `N`]
+
+
+    // Probe both the factorization as well as `or_un_gqr` to find the optimal lwork
+    T tmp_factor = numeric_limits<T>::zero;
+    T tmp_or_un_gqr = numeric_limits<T>::zero;
+    CBLAS_INT lwork = -1;
+
+    if (!pivoting) {
+        call_geqrf(&intm, &intn, NULL, &intm, NULL, &tmp_factor, &lwork, &info);
+    } else {
+        call_geqp3(&intm, &intn, NULL, &intm, NULL, NULL, &tmp_factor, &lwork, NULL, &info);
+    }
+    if (info != 0) { info = -100; return (int)info; }
+
+    // Also probe the Q construction step if required.
+    if (mode == QR_mode::FULL || mode == QR_mode::ECONOMIC) {
+        call_or_un_gqr(&intm, &middle_dim, &K, NULL, &intm, NULL, &tmp_or_un_gqr, &lwork, &info);
+    }
+    if (info != 0) { info = -100; return (int)info; }
+
+    CBLAS_INT lwork_factor = _calc_lwork(tmp_factor);
+    CBLAS_INT lwork_or_un_gqr = _calc_lwork(tmp_or_un_gqr);
+    lwork = std::max(lwork_factor, lwork_or_un_gqr);
+
+    if ((lwork < 0) || (pivoting && 3 * N + 1 >= std::numeric_limits<CBLAS_INT>::max())) {
+        // Too large lwork required - Computation cannot be performed.
+        // `geqrf` and `or_un_gqr` require an `lwork` of at least N,
+        // `geqp3` requires an `lwork` of at least 3N + 1. The former would not
+        // be detectable, but the latter is.
+        return -99;
+    }
+
+    // If mode == FULL, the resulting Q will be `M` x `M`, however, `max_dim` is used to
+    // allocate enough space for the entire `a` for `M` < `N`.
+    // If mode == RAW, the `tau` have to be returned, else a temporary buffer is sufficient.
+    CBLAS_INT buf_size = (mode == QR_mode::FULL) ? M * max_dim : M * N;
+    CBLAS_INT tau_size = (mode == QR_mode::RAW) ? 0 : K;
+    T *buffer = (T *)malloc((buf_size + lwork + tau_size) * sizeof(T));
+    if ( buffer == NULL ) { info = -101; return int(info); }
+
+    T *data_A = &buffer[0];
+    T *work = &buffer[buf_size];
+    T *tau_buffer = &buffer[buf_size + lwork];
+
+    // `c/zgeqp3` needs rwork
+    void *rwork = NULL;
+    if (pivoting && type_traits<T>::is_complex) {
+        rwork = malloc(2 * N * sizeof(real_type));
+
+        if (rwork == NULL) {
+            free(buffer);
+            info = -102;
+            return int(info);
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Main loop to traverse the slices
+    // -------------------------------------------------------------------
+    T *slice_ptr_A = NULL, *slice_ptr_Q = NULL, *slice_ptr_R = NULL, *slice_ptr_tau = NULL;
+    CBLAS_INT *slice_ptr_jpvt = NULL;
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+
+        // Compute slice pointers if necessary. `tau` and `jpvt` are vectors, so actually 1 dimension
+        // less, however, the looping to compute the slices should traverse the same number of dimensions.
+        // Hence, the use of `ndim` instead of `ndim-1`. Similarly, the shapes of `Q` and `R` might differ,
+        // but only the batching ones are relevant, which are identical.
+        slice_ptr_A = compute_slice_ptr(idx, A_data, ndim, shape, strides);
+        slice_ptr_R = compute_slice_ptr(idx, R_data, ndim, shape, strides_R);
+
+        if (mode != QR_mode::R) {
+            slice_ptr_Q = compute_slice_ptr(idx, Q_data, ndim, shape, strides_Q);
+        }
+        if (mode == QR_mode::RAW) {
+            slice_ptr_tau = compute_slice_ptr(idx, tau_data, ndim, shape, strides_tau);
+        } else { // `tau` might still be required, but should not be returned, so buffer is sufficient.
+            slice_ptr_tau = tau_buffer;
+        }
+        if (pivoting) {
+            slice_ptr_jpvt = compute_slice_ptr(idx, jpvt_data, ndim, shape, strides_jpvt);
+        }
+
+        copy_slice_F(data_A, slice_ptr_A, M, N, strides[ndim-2], strides[ndim-1]);
+
+        init_status(slice_status, idx, St::GENERAL);
+
+        // ---------------------------------------------------------------
+        // Heavy lifting: call appropriate LAPACK routines.
+        // ---------------------------------------------------------------
+
+        // Factorization step, identical for each of the modes so do jointly.
+        if (pivoting) {
+            call_geqp3(&intm, &intn, data_A, &intm, slice_ptr_jpvt, slice_ptr_tau, work, &lwork, rwork, &info);
+            for (CBLAS_INT i = 0; i < intn; i++) {
+                slice_ptr_jpvt[i] -= 1; // geqp3 returns a 1-based index array, so subtract 1
+            }
+        } else {
+            call_geqrf(&intm, &intn, data_A, &intm, slice_ptr_tau, work, &lwork, &info);
+        }
+
+        if (info != 0) {
+            slice_status.lapack_info = (Py_ssize_t)info;
+            vec_status.push_back(slice_status);
+
+            goto free_exit;
+        }
+
+        // Extract useful information and continue computation if needed.
+        // `R` is always required, the correct shape is ensured by `middle_dim`.
+        extract_upper_triangle(slice_ptr_R, data_A, middle_dim, intn, intm);
+
+        // Construct the Q matrix if required, same handling for both modes; dimensions are set already.
+        if (mode == QR_mode::FULL || mode == QR_mode::ECONOMIC) {
+            call_or_un_gqr(&intm, &middle_dim, &K, data_A, &intm, slice_ptr_tau, work, &lwork, &info);
+
+            if (info != 0) {
+                slice_status.lapack_info = (Py_ssize_t)info;
+                vec_status.push_back(slice_status);
+                goto free_exit;
+            }
+
+            copy_slice_F_to_C(slice_ptr_Q, data_A, intm, middle_dim);
+        }
+
+        // In the case of `raw` mode, the output of `geqrf`/`geqp3` is what is expected in `Q`.
+        // Since the usecase for `mode="raw"` will mostly be to use it for other LAPACK calls, keep in F-order.
+        if (mode == QR_mode::RAW) {
+            memcpy(slice_ptr_Q, data_A, intm * intn * sizeof(T));
+        }
+
+    } // End of batching loop
+
+free_exit:
+    free(buffer);
+    free(rwork);
+
+    return 1;
+}

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -202,12 +202,43 @@ class TestBatch:
             kwargs=dict(compute_uv=compute_uv, full_matrices=full_matrices)
         )
 
-    @pytest.mark.parametrize('fun', [linalg.polar, linalg.qr, linalg.rq])
+    @pytest.mark.parametrize('fun', [linalg.polar, linalg.rq])
     @pytest.mark.parametrize('dtype', floating)
     def test_polar_qr_rq(self, fun, dtype):
         rng = np.random.default_rng(8342310302941288912051)
         A = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
         self.batch_test(fun, A, n_out=2)
+
+    @pytest.mark.parametrize('pivoting', [True, False])
+    @pytest.mark.parametrize('dtype', floating)
+    @pytest.mark.parametrize('mode', ['full', 'economic', 'r'])
+    def test_qr(self, mode, dtype, pivoting):
+        rng = np.random.default_rng(12345)
+        a = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
+        self.batch_test(lambda x: linalg.qr(x, mode=mode, pivoting=pivoting), a,
+                        n_out=(1 if mode == 'r' else 2) + 1 if pivoting else 0)
+
+    @pytest.mark.parametrize('pivoting', [True, False])
+    @pytest.mark.parametrize('dtype', floating)
+    def test_qr_raw(self, dtype, pivoting):
+        rng = np.random.default_rng(12345)
+        a = get_random((5, 3, 2, 4), dtype=dtype, rng=rng)
+        (q_raw, tau), r, *other = linalg.qr(a, mode="raw", pivoting=pivoting)
+
+        # return argument contains a tuple, hence `batch_test` is not applicable.
+        for i in range(a.shape[0]):
+            for j in range(a.shape[1]):
+                (q_raw_ij, tau_ij), r_ij, *other_ij = linalg.qr(
+                    a[i, j, :, :], mode="raw", pivoting=pivoting
+                )
+
+                assert_allclose(q_raw[i, j, :, :], q_raw_ij)
+                assert_allclose(tau[i, j, :], tau_ij)
+                assert_allclose(r[i, j, :, :], r_ij)
+
+                if pivoting:
+                    assert_allclose(other[0][i, j, :], other_ij[0])
+
 
     @pytest.mark.parametrize('cdim', [(5,), (5, 4), (2, 3, 5, 4)])
     @pytest.mark.parametrize('dtype', floating)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -19,7 +19,8 @@ from scipy.linalg import (eig, eigvals, lu, svd, svdvals, cholesky, qr,
                           eigh_tridiagonal, null_space, cdf2rdf, LinAlgError)
 
 from scipy.linalg.lapack import (dgbtrf, dgbtrs, zgbtrf, zgbtrs, dsbev,
-                                 dsbevd, dsbevx, zhbevd, zhbevx)
+                                 dsbevd, dsbevx, zhbevd, zhbevx,
+                                 get_lapack_funcs)
 
 from scipy.linalg._misc import norm
 from scipy.linalg._decomp_qz import _select_function
@@ -1869,26 +1870,33 @@ class TestQR:
     def test_lwork(self):
         a = [[8, 2, 3], [2, 9, 3], [5, 3, 6]]
         # Get comparison values
-        q, r = qr(a, lwork=None)
+        with pytest.warns(DeprecationWarning):
+            q, r = qr(a, lwork=None)
 
         # Test against minimum valid lwork
-        q2, r2 = qr(a, lwork=3)
-        assert_array_almost_equal(q2, q)
-        assert_array_almost_equal(r2, r)
+        with pytest.warns(DeprecationWarning):
+            q2, r2 = qr(a, lwork=None)
+            assert_array_almost_equal(q2, q)
+            assert_array_almost_equal(r2, r)
 
         # Test against larger lwork
-        q3, r3 = qr(a, lwork=10)
-        assert_array_almost_equal(q3, q)
-        assert_array_almost_equal(r3, r)
+        with pytest.warns(DeprecationWarning):
+            q3, r3 = qr(a, lwork=10)
+            assert_array_almost_equal(q3, q)
+            assert_array_almost_equal(r3, r)
 
         # Test against explicit lwork=-1
-        q4, r4 = qr(a, lwork=-1)
-        assert_array_almost_equal(q4, q)
-        assert_array_almost_equal(r4, r)
+        with pytest.warns(DeprecationWarning):
+            q4, r4 = qr(a, lwork=-1)
+            assert_array_almost_equal(q4, q)
+            assert_array_almost_equal(r4, r)
 
         # Test against invalid lwork
-        assert_raises(Exception, qr, (a,), {'lwork': 0})
-        assert_raises(Exception, qr, (a,), {'lwork': 2})
+        with assert_raises(ValueError):
+            qr(a, lwork=0)
+
+        with assert_raises(ValueError):
+            qr(a, lwork=2)
 
     @pytest.mark.parametrize("m", [0, 1, 2])
     @pytest.mark.parametrize("n", [0, 1, 2])
@@ -1907,27 +1915,30 @@ class TestQR:
         if pivoting:
             p, = other
             assert_equal(p.shape, (n,))
-            assert_equal(p.dtype, np.int32)
+            assert_equal(p.dtype, np.int64 if HAS_ILP64 else np.int32)
 
-        r, *other = qr(a, mode='r', pivoting=pivoting)
-        assert_equal(r.shape, (m, n))
-        assert_equal(r.dtype, dtype)
+        r_r, *other = qr(a, mode='r', pivoting=pivoting)
+        assert_equal(r_r.shape, (m, n))
+        assert_equal(r_r.dtype, dtype)
+        assert_equal(r, r_r) # sanity check
         assert len(other) == (1 if pivoting else 0)
         if pivoting:
             p, = other
             assert_equal(p.shape, (n,))
-            assert_equal(p.dtype, np.int32)
+            assert_equal(p.dtype, np.int64 if HAS_ILP64 else np.int32)
 
-        q, r, *other = qr(a, mode='economic', pivoting=pivoting)
-        assert_equal(q.shape, (m, k))
-        assert_equal(q.dtype, dtype)
-        assert_equal(r.shape, (k, n))
-        assert_equal(r.dtype, dtype)
+        q_e, r_e, *other = qr(a, mode='economic', pivoting=pivoting)
+        assert_equal(q_e.shape, (m, k))
+        assert_equal(q_e.dtype, dtype)
+        assert_equal(r_e.shape, (k, n))
+        assert_equal(r_e.dtype, dtype)
+        assert_equal(q_e, q[:, :k])
+        assert_equal(r_e, r[:k, :])
         assert len(other) == (1 if pivoting else 0)
         if pivoting:
             p, = other
             assert_equal(p.shape, (n,))
-            assert_equal(p.dtype, np.int32)
+            assert_equal(p.dtype, np.int64 if HAS_ILP64 else np.int32)
 
         (raw, tau), r, *other = qr(a, mode='raw', pivoting=pivoting)
         assert_equal(raw.shape, (m, n))
@@ -1940,7 +1951,7 @@ class TestQR:
         if pivoting:
             p, = other
             assert_equal(p.shape, (n,))
-            assert_equal(p.dtype, np.int32)
+            assert_equal(p.dtype, np.int64 if HAS_ILP64 else np.int32)
 
     @pytest.mark.parametrize(("m", "n"), [(0, 0), (0, 2), (2, 0)])
     def test_empty(self, m, n):
@@ -1983,6 +1994,65 @@ class TestQR:
         c = np.empty((0, 2))
         cq, r = qr_multiply(a, c)
         assert_allclose(cq, np.empty((0, 2)))
+
+    @pytest.mark.parametrize("pivoting", [True, False])
+    @pytest.mark.parametrize("shape", [(3, 3), (3, 2), (2, 3), (0, 3), (3, 0)])
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_raw(self, shape, dtype, pivoting):
+        rng = np.random.default_rng(seed=12345)
+        K = min(shape)
+
+        a = rng.normal(size=shape)
+        if np.issubdtype(dtype, np.complexfloating):
+            a = a + 1j * rng.normal(size=shape)
+        a = a.astype(dtype)
+
+        (q_raw, tau), r, *other = qr(a, mode="raw", pivoting=pivoting)
+
+        assert q_raw.shape == shape
+        assert q_raw.dtype == dtype
+        assert tau.shape == (K,)
+        assert tau.dtype == dtype
+        assert r.shape  == (K, shape[1])
+        assert r.dtype == dtype
+
+        assert len(other) == (1 if pivoting else 0)
+        if pivoting:
+            jpvt = other[0]
+            assert jpvt.shape[0] == shape[1]
+            assert jpvt.dtype == np.int64 if HAS_ILP64 else np.int32
+
+        assert_array_almost_equal(np.triu(q_raw)[:K, :], r)
+
+        if shape[0] > 0: # `or_un_gqr` expects `ldab` (= `M` here) > 0
+            q_raw = q_raw[:, :K] # `or_un_gqr` expects tall/square matrices
+            or_un_gqr = get_lapack_funcs(("orgqr",), (q_raw,), ilp64="preferred")[0]
+            q, _, _ = or_un_gqr(q_raw, tau)
+
+            if pivoting:
+                assert_array_almost_equal(q @ r, a[:, jpvt])
+            else:
+                assert_array_almost_equal(q @ r, a)
+
+            if q.size != 0: # sanity check to prevent `q.T @ q` from being all zero
+                assert_array_almost_equal(np.conj(q.T) @ q, np.eye(q.shape[1]))
+
+    @pytest.mark.parametrize("dtype", DTYPES)
+    def test_smoke_economic(self, dtype):
+        # smoke test to check if buffer size if not all too large
+        rng = np.random.default_rng(seed=12345)
+
+        a = rng.normal(size=(10000, 2))
+        if np.issubdtype(dtype, np.complexfloating):
+            a = a + 1j * rng.normal(size=a.shape)
+        a = a.astype(dtype)
+
+        q, r = qr(a, mode="economic")
+
+        # lower precision to deal with the size of the matrices involved
+        decimal = 5 if dtype in (np.float32, np.complex64) else 13
+        assert_array_almost_equal(q @ r, a, decimal=decimal)
+        assert_array_almost_equal(np.conj(q.T) @ q, np.eye(q.shape[1]), decimal=decimal)
 
 
 class TestRQ:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2037,6 +2037,26 @@ class TestQR:
             if q.size != 0: # sanity check to prevent `q.T @ q` from being all zero
                 assert_array_almost_equal(np.conj(q.T) @ q, np.eye(q.shape[1]))
 
+    def test_raw_flags(self):
+        # internally, the implementation manipulates strides and flags; make sure
+        # that strides and flags are consistent
+        n = 3
+        a = np.eye(n, dtype=np.float32)
+        aa = np.stack([a, 2*a])
+
+        # 2D:
+        q = qr(a, mode="raw")[0][0]
+        itemsize = q.dtype.itemsize
+        assert q.strides == (itemsize, itemsize*n)    # F-ordered
+        assert q.flags.f_contiguous
+        assert q.flags.c_contiguous is False
+
+        # Batched case: core dims F-ordered
+        qq = qr(aa, mode="raw")[0][0]
+        assert qq.strides == (n*n*itemsize, itemsize, itemsize*n)
+        assert qq.flags.f_contiguous is False
+        assert q.flags.c_contiguous is False
+
     @pytest.mark.parametrize("dtype", DTYPES)
     def test_smoke_economic(self, dtype):
         # smoke test to check if buffer size if not all too large


### PR DESCRIPTION
## Reference issue
Towards #23774, moves the batching loop of `qr` from python to C, akin to other PRs like #24263 and #24177.

## Contributions
- Move the batching loop to C, giving rise to a significant speedup (through the added benchmark) as shown below the fold:
  <details>
  <summary> Benchmark results </summary>

  - At main:
    ```
    =============== ================== ============= =========
              --                                          module
              ---------------------------------- -----------------------
                   shape             mode            scipy       numpy
              =============== ================== ============= =========
               (100, 10, 10)    full/complete     1.52±0.01ms   226±3μs
               (100, 10, 10)   economic/reduced   1.41±0.01ms   228±5μs
               (100, 10, 10)         r/r          1.03±0.01ms   136±3μs
               (100, 20, 20)    full/complete     2.00±0.02ms   659±5μs
               (100, 20, 20)   economic/reduced   1.87±0.02ms   634±3μs
               (100, 20, 20)         r/r          1.33±0.01ms   372±5μs
                 (100, 100)     full/complete       221±5μs     219±2μs
                 (100, 100)    economic/reduced     215±2μs     216±1μs
                 (100, 100)          r/r           120±0.2μs    117±2μs
              =============== ================== ============= =========
    ```
  - After this PR:
    ```
    =============== ================== =========== ===========
             --                                          module
             ---------------------------------- -----------------------
                  shape             mode           scipy       numpy
             =============== ================== =========== ===========
              (100, 10, 10)    full/complete     196±0.5μs    222±1μs
              (100, 10, 10)   economic/reduced   193±0.4μs   222±0.9μs
              (100, 10, 10)         r/r          121±0.3μs   136±0.7μs
              (100, 20, 20)    full/complete      578±2μs     642±4μs
              (100, 20, 20)   economic/reduced    589±4μs     643±2μs
              (100, 20, 20)         r/r           355±3μs     374±2μs
                (100, 100)     full/complete      206±3μs    217±0.8μs
                (100, 100)    economic/reduced    203±2μs     218±1μs
                (100, 100)          r/r           109±2μs     118±2μs
             =============== ================== =========== ===========
    ```
  - Comparison:
    ```
    | Change   | Before [eefc1c39] <main>   | After [e70f5a31] <qr_speedup>   |   Ratio | Benchmark (Parameter)                                                            |
    |----------|----------------------------|---------------------------------|---------|------------------------------------------------------------------------------|
    | -        | 215±2μs                    | 203±2μs                         |    0.94 | linalg.BatchedQRBench.time_solve((100, 100), 'economic/reduced', 'scipy')    |
    | -        | 120±0.2μs                  | 109±2μs                         |    0.91 | linalg.BatchedQRBench.time_solve((100, 100), 'r/r', 'scipy')                 |
    | -        | 1.87±0.02ms                | 589±4μs                         |    0.32 | linalg.BatchedQRBench.time_solve((100, 20, 20), 'economic/reduced', 'scipy') |
    | -        | 2.00±0.02ms                | 578±2μs                         |    0.29 | linalg.BatchedQRBench.time_solve((100, 20, 20), 'full/complete', 'scipy')    |
    | -        | 1.33±0.01ms                | 355±3μs                         |    0.27 | linalg.BatchedQRBench.time_solve((100, 20, 20), 'r/r', 'scipy')              |
    | -        | 1.41±0.01ms                | 193±0.4μs                       |    0.14 | linalg.BatchedQRBench.time_solve((100, 10, 10), 'economic/reduced', 'scipy') |
    | -        | 1.52±0.01ms                | 196±0.5μs                       |    0.13 | linalg.BatchedQRBench.time_solve((100, 10, 10), 'full/complete', 'scipy')    |
    | -        | 1.03±0.01ms                | 121±0.3μs                       |    0.12 | linalg.BatchedQRBench.time_solve((100, 10, 10), 'r/r', 'scipy')              |
    ```
  </details>

- Slightly changed the test suite to also implement checks on correctness of `mode="r"` and `mode="economic"`; `TestQR::test_shape_dtype` now also validates the relevant parts of the results for these modes. For `mode="raw"` this is a bit more tough, cfr. "open questions".

## Open questions
- Blocking (cfr. #23774):
  - For some reason, `TestQR::test_lwork` does not accept the errors thrown in the current implementation when the passed in `lwork` argument is too small. (This is also causing a failure in the test suite and, as a corrolary, also causes CI failures.)
  - As mentioned above, checking the functional correctness of `mode="r"` and `mode="economic"` is quite straightforward. For `mode="raw"` this is a bit more complicated as it would almost require to call `orgqr/ungqr` to validate if the returned result is indeed the correct one. Alternatively, one could rely on the tests for `qr_multiply()` as this is internally using `qr(..., mode="raw")`, but this feels a bit hacky.
  - It seems like there is an error on main regarding the implementation of `mode="raw"`. This error is presumably related to the fact that the decorator just tries to stack all individual return arguments, but then encounters the tuple `Q, tau` which is, indeed, not trivially stackable. This prevents the addition of the `mode="raw/raw"` to the benchmark to assess the performance, but this PR should fix that issue.
- More general:
  - The checks for `lwork`, even if this is explicitly computed, are a bit coarse and could be refined (both the computation of the ideal `lwork` as well as the checks for the lower bounds) depending on which exact case you're in to improve memory consumption. On the flipside, this might make the code harder to read, so feedback on this is welcome.
  - The testsuite for `mode != "full"` is quite "thin": initially there were no tests checking the functional correctness for `mode="r"` and `mode="economic"`. An idea to improve the "coverage" is adding a few extra shapes to the `test_shape_dtype`. 
  - The current implementation always allocates both a return array for the pivoting elements `P` and for the reflector coefficients `tau`, even though these are not always necessary. This is purely done to ensure the same number of return arguments is always returned from the C side, after which the python side then does the ordering. This does, however, also imply that there are additional memory allocations. Nothing all too major I suppose, but still worth noting. (`ap_tau` is always used instead of allocating a specific array `tau` for the reflection coefficients to avoid requiring different loops for `mode="raw"` and else, `ap_P` is only used if `pivoting=True`.) 