### PR TITLE
MAINT:linalg: Remove dummy ?larf/?larfg parameters from wrappers

### DIFF
--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -2214,13 +2214,15 @@ function <prefix>lantr(norm, uplo, diag, m, n, a, lda, work) result(n2)
 
 end function <prefix>lantr
 
-subroutine <prefix>larfg(n, alpha, x, incx, tau, lx)
+subroutine <prefix>larfg(n, alpha, x, incx, tau)
+    callstatement (*f2py_func)(&n,&alpha,x,&incx,&info)
+    callprotoargument F_INT*, <ctype>*, <ctype>*, F_INT*, F_INT*
+
     integer intent(in), check(n>=1) :: n
     <ftype> intent(in,out) :: alpha
-    <ftype> intent(in,copy,out), dimension(lx) :: x
+    <ftype> intent(in,copy,out), dimension(1+(n-2)*abs(incx)), depend(n,incx) :: x
     integer intent(in), check(incx>0||incx<0) :: incx = 1
     <ftype> intent(out) :: tau
-    integer intent(hide),depend(x,n,incx),check(lx > (n-2)*incx) :: lx = len(x)
 end subroutine <prefix>larfg
 
 subroutine <prefix>larf(side,m,n,v,incv,tau,c,ldc,work,lwork)

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -2215,8 +2215,8 @@ function <prefix>lantr(norm, uplo, diag, m, n, a, lda, work) result(n2)
 end function <prefix>lantr
 
 subroutine <prefix>larfg(n, alpha, x, incx, tau)
-    callstatement (*f2py_func)(&n,&alpha,x,&incx,&info)
-    callprotoargument F_INT*, <ctype>*, <ctype>*, F_INT*, F_INT*
+    callstatement (*f2py_func)(&n,&alpha,x,&incx,&tau)
+    callprotoargument F_INT*, <ctype>*, <ctype>*, F_INT*, <ctype>*
 
     integer intent(in), check(n>=1) :: n
     <ftype> intent(in,out) :: alpha

--- a/scipy/linalg/flapack_other.pyf.src
+++ b/scipy/linalg/flapack_other.pyf.src
@@ -2225,7 +2225,10 @@ subroutine <prefix>larfg(n, alpha, x, incx, tau)
     <ftype> intent(out) :: tau
 end subroutine <prefix>larfg
 
-subroutine <prefix>larf(side,m,n,v,incv,tau,c,ldc,work,lwork)
+subroutine <prefix>larf(side,m,n,v,incv,tau,c,ldc,work)
+    callstatement (*f2py_func)(&side,&m,&n,v,&incv,&tau,c,&ldc,work)
+    callprotoargument char*, F_INT*, F_INT*, <ctype>*, F_INT*, <ctype>*, <ctype>*, F_INT*, <ctype>*
+
     character intent(in), check(side[0]=='L'||side[0]=='R') :: side = 'L'
     integer intent(in,hide), depend(c) :: m = shape(c,0)
     integer intent(in,hide), depend(c) :: n = shape(c,1)
@@ -2235,8 +2238,7 @@ subroutine <prefix>larf(side,m,n,v,incv,tau,c,ldc,work,lwork)
     <ftype> dimension(m,n), intent(in,copy,out) :: c
     integer intent(in,hide) :: ldc = max(1,shape(c,0))
     ! FIXME: work should not have been an input argument but kept here for backwards compatibility!
-    <ftype> intent(in),dimension(lwork),depend(side,m,n) :: work
-    integer intent(hide),depend(work),check(lwork >= (side[0]=='L'?n:m)) :: lwork = len(work)
+    <ftype> intent(in), dimension((side[0]=='L'?n:m)), depend(side,m,n) :: work
 end subroutine <prefix>larf
 
 subroutine <prefix>lartg(f,g,cs,sn,r)


### PR DESCRIPTION
Cross-ref: https://github.com/pyodide/pyodide/pull/5059 https://github.com/pyodide/pyodide/pull/5060

Back in the day, when I was cleaning up the compilation noise originating from BLAS wrappers, I introduced a parameter `lx` under the impression that it was hidden from the users. 

```bash
Signature:   la.lapack.dlarfg(*args, **kwargs)
Type:        fortran
String form: <fortran function dlarfg>
Docstring:  
alpha,x,tau = dlarfg(n,alpha,x,[incx,overwrite_x])

Wrapper for ``dlarfg``.

Parameters
----------
n : input int
alpha : input float
x : input rank-1 array('d') with bounds (lx)  <------------- This lx guy here 

Other Parameters
----------------
overwrite_x : input int, optional
    Default: 0
incx : input int, optional
    Default: 1

Returns
-------
alpha : float
x : rank-1 array('d') with bounds (lx)   <------------- and here 
tau : float
```

This was to silence `f2py` complaining about the Fortran "assumed-size array" warnings (it's a fortran thing). Also I did not know what I was exactly doing, though not much changed since.

The user indeed does not see the `lx` parameter but somehow this broke Pyodide workflows when they were parsing the wrappers and forced them to include a patch for it in their endless SciPy patches. This PR is to fix this issue and remove the dummy argument from the wrapper. As seen from the function signature, this has no effect on the public API and provides better compliance with the [official LAPACK function](https://netlib.org/lapack/explore-html/d8/d0d/group__larfg_gadc154fac2a92ae4c7405169a9d1f5ae9.html#gadc154fac2a92ae4c7405169a9d1f5ae9) 

Similarly, there was a seemingly official lwork parameter in the ?larf wrappers that do not exist in the LAPACK wrapper. Hence pretty much hallucinated there. That one is also removed.

cc @agriyakhetarpal; sorry for the delay, better late than never. 