### PR TITLE
MAINT: Fix heap-buffer-overflow in `scipy.interpolate._dierckx.qr_reduce_periodic`

### DIFF
--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -559,7 +559,7 @@ void qr_reduce_periodic(
                             std::tie(A1(j - 1, h1i), H1(it - 1, h1i)) = fprota(c, s, A1(j - 1, h1i), H1(it - 1, h1i));
                         }
 
-                        for( int64_t h1i = 1; h1i <= i2; h1i++ ) {
+                        for( int64_t h1i = 1; h1i < i2; h1i++ ) {
                             H1(it - 1, h1i - 1) = H1(it - 1, h1i);
                         }
                         H1(it - 1, i2 - 1) = 0.0;

--- a/tools/asan-ignore.txt
+++ b/tools/asan-ignore.txt
@@ -3,9 +3,6 @@
 # from scipy.optimize._minpack._lmdif
 fun:enorm
 
-# from scipy.interpolate._dierckx.qr_reduce_periodic
-fun:_ZN7fitpack18qr_reduce_periodic*
-
 # from scipy.ndimage._rank_filter_1d.rank_filter
 fun:_Z12_rank_filterIfEiPT_iiiS1_iS0_i
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Fixes a heap-buffer-overflow detected by AddressSanitizer in the `qr_reduce_periodic` function. The issue was caused by an off-by-one error in a loop condition at line 562 of `__fitpack.cc`, where the loop was iterating one element past the allocated buffer size.

**The fix**: Changed the loop condition from `h1i <= i2` to `h1i < i2` to prevent accessing memory beyond the buffer bounds.

#### Additional information
<!--Any additional information you think is important.-->

- This resolves the [discussion in gh-23936](https://github.com/scipy/scipy/pull/23936/changes#r2559893084) (the investigation flagged in the ASAN suppressions PR)
- The ASAN suppression for this function is now removed from `tools/asan-ignore.txt`
- The fix has been validated with AddressSanitizer (ASAN) testing (refer - https://github.com/czgdp1807/scipy/pull/26)

cc: @ev-br 