### PR TITLE
BUG: Fix interp1d numerical stability

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -499,8 +499,8 @@ class interp1d(_Interpolator1D):
         # Note that the following expression relies on the specifics of the
         # broadcasting semantics.
         y_new = (
-            ((x_new-x_lo)/(x_hi-x_lo))[:, None]*y_hi
-            +((x_hi-x_new)/(x_hi-x_lo))[:, None]*y_lo
+            ((x_new - x_lo)/(x_hi - x_lo))[:, None] * y_hi
+            + ((x_hi - x_new)/(x_hi - x_lo))[:, None] * y_lo
             )
         
         return y_new

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -487,7 +487,7 @@ class interp1d(_Interpolator1D):
         #    of x_new[n] = x[0]
         x_new_indices = x_new_indices.clip(1, len(self.x)-1).astype(int)
 
-        # 4. Calculate the slope of regions that each x_new value falls in.
+        # 4. Calculate y_new using de Boor's algorithm for linear interpolation.
         lo = x_new_indices - 1
         hi = x_new_indices
 
@@ -496,13 +496,13 @@ class interp1d(_Interpolator1D):
         y_lo = self._y[lo]
         y_hi = self._y[hi]
 
-        # Note that the following two expressions rely on the specifics of the
+        # Note that the following expression relies on the specifics of the
         # broadcasting semantics.
-        slope = (y_hi - y_lo) / (x_hi - x_lo)[:, None]
-
-        # 5. Calculate the actual value for each entry in x_new.
-        y_new = slope*(x_new - x_lo)[:, None] + y_lo
-
+        y_new = (
+            ((x_new-x_lo)/(x_hi-x_lo))[:, None]*y_hi
+            +((x_hi-x_new)/(x_hi-x_lo))[:, None]*y_lo
+            )
+        
         return y_new
 
     def _call_nearest(self, x_new):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -235,6 +235,14 @@ class TestInterp1D:
         yp = interp1d(x, y)(x)
         xp_assert_close(yp, y, atol=1e-15)
 
+    def test_linear_numerical_stability(self):
+        # Using de Boor's algorithm, there should be no floating point error
+        # for query points contained exactly in the x input array
+        x = np.array([0.0007499999999999, 0.002])
+        y = np.array([[0.0, 0.0], [0.0004164930555555557, 0.0]])
+        yp = interp1d(x, y)(x)
+        xp_assert_equal(yp, y)
+
     def test_slinear_dtypes(self):
         # regression test for gh-7273: 1D slinear interpolation fails with
         # float32 inputs

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -236,8 +236,9 @@ class TestInterp1D:
         xp_assert_close(yp, y, atol=1e-15)
 
     def test_linear_numerical_stability(self):
-        # Using de Boor's algorithm, there should be no floating point error
-        # for query points contained exactly in the x input array
+        # regression test for gh-24281: Using de Boor's algorithm, there 
+        # should be no floating point error for query points contained 
+        # exactly in the x input array
         x = np.array([0.0007499999999999, 0.002])
         y = np.array([[0.0, 0.0], [0.0004164930555555557, 0.0]])
         yp = interp1d(x, y)(x)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -243,6 +243,7 @@ class TestInterp1D:
         y = np.array([[0.0, 0.0], [0.0004164930555555557, 0.0]])
         yp = interp1d(x, y)(x)
         xp_assert_close(yp, y, atol=1e-20)
+        assert np.all(yp >= 0) # less stable computations result in yp[1,1] = -5e-20
 
     def test_slinear_dtypes(self):
         # regression test for gh-7273: 1D slinear interpolation fails with

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -242,7 +242,7 @@ class TestInterp1D:
         x = np.array([0.0007499999999999, 0.002])
         y = np.array([[0.0, 0.0], [0.0004164930555555557, 0.0]])
         yp = interp1d(x, y)(x)
-        xp_assert_equal(yp, y)
+        xp_assert_close(yp, y, atol=1e-20)
 
     def test_slinear_dtypes(self):
         # regression test for gh-7273: 1D slinear interpolation fails with

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -243,7 +243,7 @@ class TestInterp1D:
         y = np.array([[0.0, 0.0], [0.0004164930555555557, 0.0]])
         yp = interp1d(x, y)(x)
         xp_assert_close(yp, y, atol=1e-20)
-        assert np.all(yp >= 0) # less stable computations result in yp[1,1] = -5e-20
+        assert np.all(yp >= 0) # less stable computations give yp[1,1] = -5e-20
 
     def test_slinear_dtypes(self):
         # regression test for gh-7273: 1D slinear interpolation fails with


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-24281.

#### What does this implement/fix?
<!--Please explain your changes.-->
In interp1d._call_linear: implements the analytical expression for linear interpolation consistent with de Boor's algorithm instead of the current formulation, which can fail to return exact values when evaluated at existing data points, potentially returning negative values when interpolating between non-negative numbers. This change makes interp1d._call_linear consistent with the results of make_interp_spline. See [gh-24281](https://github.com/scipy/scipy/issues/24281) for an example and more detail.

#### Additional information
<!--Any additional information you think is important.-->

