### PR TITLE
CI: fix ILP64 jobs for build failures and unpinned scipy-openblas usage

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -57,7 +57,11 @@ jobs:
         sudo apt-get install -y gfortran
         pip install cython numpy pybind11 pythran pytest hypothesis pytest-xdist pooch
         pip install -r requirements/dev.txt
-        pip install git+https://github.com/numpy/meson.git@main-numpymeson
+        # numpy fork of meson with meson v1.8.2 - not public, but works for our
+        # purposes here, we need its BLAS ILP64 support until that is merged
+        # in Meson upstream. Note that a more recent commit on this fork didn't work,
+        # see gh-24251.
+        pip install git+https://github.com/numpy/meson.git@e72c717199fa18d34020c7c97f9de3f388c5e055
         pip install mkl mkl-devel
 
     - name: Build with defaults (LP64)
@@ -92,7 +96,7 @@ jobs:
         sudo apt-get install -y gfortran
         pip install cython numpy pybind11 pythran pytest hypothesis pytest-xdist pooch
         pip install -r requirements/dev.txt
-        pip install git+https://github.com/numpy/meson.git@main-numpymeson
+        pip install git+https://github.com/numpy/meson.git@e72c717199fa18d34020c7c97f9de3f388c5e055
         pip install mkl mkl-devel
 
     - name: Build with ILP64
@@ -126,7 +130,7 @@ jobs:
         sudo apt-get install -y gfortran
         pip install cython numpy pybind11 pythran pytest hypothesis pytest-xdist pooch
         pip install -r requirements/dev.txt
-        pip install git+https://github.com/numpy/meson.git@main-numpymeson
+        pip install git+https://github.com/numpy/meson.git@e72c717199fa18d34020c7c97f9de3f388c5e055
         pip install scipy-openblas32 scipy-openblas64
 
     - name: Write out scipy-openblas64.pc

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -131,7 +131,10 @@ jobs:
         pip install cython numpy pybind11 pythran pytest hypothesis pytest-xdist pooch
         pip install -r requirements/dev.txt
         pip install git+https://github.com/numpy/meson.git@e72c717199fa18d34020c7c97f9de3f388c5e055
-        pip install scipy-openblas32 scipy-openblas64
+        # Yes, we install both of scipy-openblas32|64, we need both LP64 and
+        # ILP64 (this is obviously a hack, and not supportable outside of SciPy
+        # CI and manual dev env setup; see gh-21889 for details).
+        pip install -r requirements/openblas64.txt
 
     - name: Write out scipy-openblas64.pc
       run: |

--- a/requirements/openblas64.txt
+++ b/requirements/openblas64.txt
@@ -1,0 +1,2 @@
+scipy-openblas32==0.3.30.0.8
+scipy-openblas64==0.3.30.0.8


### PR DESCRIPTION
The two commits are for two separate issues that both affect the OpenBLAS ILP64 job; the MKL jobs were only affected by the first issue. 

Closes gh-24251