### PR TITLE
BUG: stats.pmean: stabilize for small but finite p

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -464,7 +464,7 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
 
     # Linearized approximation for small p to avoid numerical issues; see gh-23407
     p_threshold = 2e-6
-    if p <= p_threshold:
+    if abs(p) <= p_threshold:
         return _linearized_pmean(a, p, axis=axis, weights=weights, xp=xp)
 
     with np.errstate(divide='ignore', invalid='ignore'):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -462,6 +462,11 @@ def pmean(a, p, *, axis=0, dtype=None, weights=None):
                    "non-negative; otherwise, the result is NaN.")
         warnings.warn(message, RuntimeWarning, stacklevel=2)
 
+    # Linearized approximation for small p to avoid numerical issues; see gh-23407
+    p_threshold = 2e-6
+    if p <= p_threshold:
+        return _linearized_pmean(a, p, axis=axis, weights=weights, xp=xp)
+
     with np.errstate(divide='ignore', invalid='ignore'):
         return _xp_mean(a**float(p), axis=axis, weights=weights)**(1/p)
 
@@ -10615,6 +10620,17 @@ def linregress(x, y, alternative='two-sided', *, axis=0):
     return LinregressResult(slope=slope[()], intercept=intercept[()], rvalue=r[()],
                             pvalue=prob[()], stderr=slope_stderr[()],
                             intercept_stderr=intercept_stderr[()])
+
+def _linearized_pmean(a, p, *, axis=None, weights=None, xp=None):
+    # pmean linearized as a function of p about p = 0; see gh-23407
+    M0 = gmean(a, axis=axis, weights=weights)
+
+    loga = xp.log(a)
+
+    ln_avg = _xp_mean(loga, axis=axis, weights=weights)
+    ln2_avg = _xp_mean(loga * loga, axis=axis, weights=weights)
+
+    return M0 * (1 + 0.5 * p * (ln2_avg - ln_avg * ln_avg))
 
 
 def _xp_mean(x, /, *, axis=None, weights=None, keepdims=False, nan_policy='propagate',

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -3043,8 +3043,8 @@ class TestOrthoGroup:
         # Test that the distribution of pairwise distances is close to correct.
         rng = np.random.RandomState(514)
 
-        def random_ortho(dim, random_state=None):
-            u, _s, v = np.linalg.svd(rng.normal(size=(dim, dim)))
+        def random_ortho(dim, random_state):
+            u, _s, v = np.linalg.svd(random_state.normal(size=(dim, dim)))
             return np.dot(u, v)
 
         for dim in range(2, 6):
@@ -3055,7 +3055,7 @@ class TestOrthoGroup:
                     for _ in range(N)
                 ])
                 # Add a bit of noise to account for numeric accuracy.
-                stats += np.random.uniform(-eps, eps, size=stats.shape)
+                stats += rng.uniform(-eps, eps, size=stats.shape)
                 return stats
 
             expected = generate_test_statistics(random_ortho)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6993,6 +6993,22 @@ class TestPMean:
             stats.pmean([2], np.inf)
 
 
+    @pytest.mark.parametrize(
+        "p, weights, ref",
+        [
+            (2e-16, None, 47.23984586445856),
+            (2e-16, [1., 2., 1., 1., 1., 2., 1.], 55.80644618389137),
+        ],
+    )
+    def test_small_p_gh23407(self, xp, p, weights, ref):
+        # gh-23407 reported that pmean had poor numerical behavior for very small nonzero p
+        x = xp.asarray([50., 100., 300., 70., 25., 100., 2.])
+        w = None if weights is None else xp.asarray(weights)
+
+        res = stats.pmean(x, p, weights=w)
+        xp_assert_close(res, xp.asarray(ref), rtol=1e-14)
+
+
 @make_xp_test_case(stats.gstd)
 class TestGSTD:
     # must add 1 as `gstd` is only defined for positive values

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -6996,13 +6996,33 @@ class TestPMean:
     @pytest.mark.parametrize(
         "p, weights, ref",
         [
+            # import numpy as np
+            # from mpmath import mp
+            # mp.dps = 1000
+            #
+            # x = [50., 100., 300., 70., 25., 100., 2.]
+            # w = [1., 2., 1., 1., 1., 2., 1.]
+            #
+            # x = np.asarray([mp.mpf(x_) for x_ in x])
+            # w = np.asarray([mp.mpf(w_) for w_ in w])
+            # p = mp.mpf(2e-16)
+            #
+            # res = np.average(x**p)**(1/p)
+            # float(res) # 47.23984586445856
+            #
             (2e-16, None, 47.23984586445856),
+            #
+            # res = np.average(x**p, weights=w)**(1/p)
+            # float(res) # 55.80644618389137
+            #
             (2e-16, [1., 2., 1., 1., 1., 2., 1.], 55.80644618389137),
         ],
     )
     def test_small_p_gh23407(self, xp, p, weights, ref):
         # gh-23407 reported that pmean had poor numerical behavior for very small nonzero p
-        x = xp.asarray([50., 100., 300., 70., 25., 100., 2.])
+        x = xp.asarray(
+            [50., 100., 300., 70., 25., 100., 2.]
+        )
         w = None if weights is None else xp.asarray(weights)
 
         res = stats.pmean(x, p, weights=w)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7027,7 +7027,7 @@ class TestPMean:
         w = None if weights is None else xp.asarray(weights)
 
         res = stats.pmean(x, p, weights=w)
-        xp_assert_close(res, xp.asarray(ref), rtol=1e-14)
+        xp_assert_close(res, xp.asarray(ref))
 
 
 @make_xp_test_case(stats.gstd)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -7019,7 +7019,8 @@ class TestPMean:
         ],
     )
     def test_small_p_gh23407(self, xp, p, weights, ref):
-        # gh-23407 reported that pmean had poor numerical behavior for very small nonzero p
+        # gh-23407 reported that pmean had
+        # poor numerical behavior for very small nonzero p
         x = xp.asarray(
             [50., 100., 300., 70., 25., 100., 2.]
         )


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-23407
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
This PR fixes numerical issues in `scipy.stats.pmean` for small but finite `p` values. A linearized approximation of the power mean around $p = 0$ is used, following the algorithm suggested by @mdhaber in the related issue (gh-23407). Regression tests are added too to cover weighted and unweighted cases with a parameterized test. 
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
