### PR TITLE
DOC: integrate: fix indentation of lists

### DIFF
--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -774,10 +774,10 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         parameters are present. The return must contain 1 or 2 elements in the
         following order:
 
-            * df_dy : array_like with shape (n, n, m), where an element
-              (i, j, q) equals to d f_i(x_q, y_q, p) / d (y_q)_j.
-            * df_dp : array_like with shape (n, k, m), where an element
-              (i, j, q) equals to d f_i(x_q, y_q, p) / d p_j.
+        * df_dy : array_like with shape ``(n, n, m)``, where an element
+            ``(i, j, q)`` equals to ``d f_i(x_q, y_q, p) / d (y_q)_j``.
+        * df_dp : array_like with shape ``(n, k, m)``, where an element
+            ``(i, j, q)`` equals to ``d f_i(x_q, y_q, p) / d p_j``.
 
         Here q numbers nodes at which x and y are defined, whereas i and j
         number vector components. If the problem is solved without unknown
@@ -791,12 +791,12 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
         if parameters are present. The return must contain 2 or 3 elements in
         the following order:
 
-            * dbc_dya : array_like with shape (n, n), where an element (i, j)
-              equals to d bc_i(ya, yb, p) / d ya_j.
-            * dbc_dyb : array_like with shape (n, n), where an element (i, j)
-              equals to d bc_i(ya, yb, p) / d yb_j.
-            * dbc_dp : array_like with shape (n, k), where an element (i, j)
-              equals to d bc_i(ya, yb, p) / d p_j.
+        * dbc_dya : array_like with shape ``(n, n)``, where an element ``(i, j)``
+            equals to ``d bc_i(ya, yb, p) / d ya_j``.
+        * dbc_dyb : array_like with shape ``(n, n)``, where an element ``(i, j)``
+            equals to ``d bc_i(ya, yb, p) / d yb_j``.
+        * dbc_dp : array_like with shape ``(n, k)``, where an element ``(i, j)``
+            equals to ``d bc_i(ya, yb, p) / d p_j``.
 
         If the problem is solved without unknown parameters, dbc_dp should not
         be returned.
@@ -815,9 +815,9 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
     verbose : {0, 1, 2}, optional
         Level of algorithm's verbosity:
 
-            * 0 (default) : work silently.
-            * 1 : display a termination report.
-            * 2 : display progress during iterations.
+        * 0 (default) : work silently.
+        * 1 : display a termination report.
+        * 2 : display progress during iterations.
     bc_tol : float, optional
         Desired absolute tolerance for the boundary condition residuals: `bc`
         value should satisfy ``abs(bc) < bc_tol`` component-wise.
@@ -847,10 +847,9 @@ def solve_bvp(fun, bc, x, y, p=None, S=None, fun_jac=None, bc_jac=None,
     status : int
         Reason for algorithm termination:
 
-            * 0: The algorithm converged to the desired accuracy.
-            * 1: The maximum number of mesh nodes is exceeded.
-            * 2: A singular Jacobian encountered when solving the collocation
-              system.
+        * 0: The algorithm converged to the desired accuracy.
+        * 1: The maximum number of mesh nodes is exceeded.
+        * 2: A singular Jacobian encountered when solving the collocation system.
 
     message : string
         Verbal description of the termination reason.

--- a/scipy/integrate/_ivp/base.py
+++ b/scipy/integrate/_ivp/base.py
@@ -31,39 +31,39 @@ class OdeSolver:
 
     In order to implement a new solver you need to follow the guidelines:
 
-        1. A constructor must accept parameters presented in the base class
-           (listed below) along with any other parameters specific to a solver.
-        2. A constructor must accept arbitrary extraneous arguments
-           ``**extraneous``, but warn that these arguments are irrelevant
-           using `common.warn_extraneous` function. Do not pass these
-           arguments to the base class.
-        3. A solver must implement a private method `_step_impl(self)` which
-           propagates a solver one step further. It must return tuple
-           ``(success, message)``, where ``success`` is a boolean indicating
-           whether a step was successful, and ``message`` is a string
-           containing description of a failure if a step failed or None
-           otherwise.
-        4. A solver must implement a private method `_dense_output_impl(self)`,
-           which returns a `DenseOutput` object covering the last successful
-           step.
-        5. A solver must have attributes listed below in Attributes section.
-           Note that ``t_old`` and ``step_size`` are updated automatically.
-        6. Use `fun(self, t, y)` method for the system rhs evaluation, this
-           way the number of function evaluations (`nfev`) will be tracked
-           automatically.
-        7. For convenience, a base class provides `fun_single(self, t, y)` and
-           `fun_vectorized(self, t, y)` for evaluating the rhs in
-           non-vectorized and vectorized fashions respectively (regardless of
-           how `fun` from the constructor is implemented). These calls don't
-           increment `nfev`.
-        8. If a solver uses a Jacobian matrix and LU decompositions, it should
-           track the number of Jacobian evaluations (`njev`) and the number of
-           LU decompositions (`nlu`).
-        9. By convention, the function evaluations used to compute a finite
-           difference approximation of the Jacobian should not be counted in
-           `nfev`, thus use `fun_single(self, t, y)` or
-           `fun_vectorized(self, t, y)` when computing a finite difference
-           approximation of the Jacobian.
+    1. A constructor must accept parameters presented in the base class
+        (listed below) along with any other parameters specific to a solver.
+    2. A constructor must accept arbitrary extraneous arguments
+        ``**extraneous``, but warn that these arguments are irrelevant
+        using `common.warn_extraneous` function. Do not pass these
+        arguments to the base class.
+    3. A solver must implement a private method `_step_impl(self)` which
+        propagates a solver one step further. It must return tuple
+        ``(success, message)``, where ``success`` is a boolean indicating
+        whether a step was successful, and ``message`` is a string
+        containing description of a failure if a step failed or None
+        otherwise.
+    4. A solver must implement a private method `_dense_output_impl(self)`,
+        which returns a `DenseOutput` object covering the last successful
+        step.
+    5. A solver must have attributes listed below in Attributes section.
+        Note that ``t_old`` and ``step_size`` are updated automatically.
+    6. Use `fun(self, t, y)` method for the system rhs evaluation, this
+        way the number of function evaluations (`nfev`) will be tracked
+        automatically.
+    7. For convenience, a base class provides `fun_single(self, t, y)` and
+        `fun_vectorized(self, t, y)` for evaluating the rhs in
+        non-vectorized and vectorized fashions respectively (regardless of
+        how `fun` from the constructor is implemented). These calls don't
+        increment `nfev`.
+    8. If a solver uses a Jacobian matrix and LU decompositions, it should
+        track the number of Jacobian evaluations (`njev`) and the number of
+        LU decompositions (`nlu`).
+    9. By convention, the function evaluations used to compute a finite
+        difference approximation of the Jacobian should not be counted in
+        `nfev`, thus use `fun_single(self, t, y)` or
+        `fun_vectorized(self, t, y)` when computing a finite difference
+        approximation of the Jacobian.
 
     Parameters
     ----------

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -121,14 +121,14 @@ class BDF(OdeSolver):
         element (i, j) is equal to ``d f_i / d y_j``.
         There are three ways to define the Jacobian:
 
-            * If array_like or sparse_matrix, the Jacobian is assumed to
-              be constant.
-            * If callable, the Jacobian is assumed to depend on both
-              t and y; it will be called as ``jac(t, y)`` as necessary.
-              For the 'Radau' and 'BDF' methods, the return value might be a
-              sparse matrix.
-            * If None (default), the Jacobian will be approximated by
-              finite differences.
+        * If array_like or sparse_matrix, the Jacobian is assumed to
+            be constant.
+        * If callable, the Jacobian is assumed to depend on both
+            t and y; it will be called as ``jac(t, y)`` as necessary.
+            For the 'Radau' and 'BDF' methods, the return value might be a
+            sparse matrix.
+        * If None (default), the Jacobian will be approximated by
+            finite differences.
 
         It is generally recommended to provide the Jacobian rather than
         relying on a finite-difference approximation.

--- a/scipy/integrate/_ivp/ivp.py
+++ b/scipy/integrate/_ivp/ivp.py
@@ -200,35 +200,35 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     method : string or `OdeSolver`, optional
         Integration method to use:
 
-            * 'RK45' (default): Explicit Runge-Kutta method of order 5(4) [1]_.
-              The error is controlled assuming accuracy of the fourth-order
-              method, but steps are taken using the fifth-order accurate
-              formula (local extrapolation is done). A quartic interpolation
-              polynomial is used for the dense output [2]_. Can be applied in
-              the complex domain.
-            * 'RK23': Explicit Runge-Kutta method of order 3(2) [3]_. The error
-              is controlled assuming accuracy of the second-order method, but
-              steps are taken using the third-order accurate formula (local
-              extrapolation is done). A cubic Hermite polynomial is used for the
-              dense output. Can be applied in the complex domain.
-            * 'DOP853': Explicit Runge-Kutta method of order 8 [13]_.
-              Python implementation of the "DOP853" algorithm originally
-              written in Fortran [14]_. A 7-th order interpolation polynomial
-              accurate to 7-th order is used for the dense output.
-              Can be applied in the complex domain.
-            * 'Radau': Implicit Runge-Kutta method of the Radau IIA family of
-              order 5 [4]_. The error is controlled with a third-order accurate
-              embedded formula. A cubic polynomial which satisfies the
-              collocation conditions is used for the dense output.
-            * 'BDF': Implicit multi-step variable-order (1 to 5) method based
-              on a backward differentiation formula for the derivative
-              approximation [5]_. The implementation follows the one described
-              in [6]_. A quasi-constant step scheme is used and accuracy is
-              enhanced using the NDF modification. Can be applied in the
-              complex domain.
-            * 'LSODA': Adams/BDF method with automatic stiffness detection and
-              switching [7]_, [8]_. This is a wrapper of the Fortran solver
-              from ODEPACK.
+        * 'RK45' (default): Explicit Runge-Kutta method of order 5(4) [1]_.
+            The error is controlled assuming accuracy of the fourth-order
+            method, but steps are taken using the fifth-order accurate
+            formula (local extrapolation is done). A quartic interpolation
+            polynomial is used for the dense output [2]_. Can be applied in
+            the complex domain.
+        * 'RK23': Explicit Runge-Kutta method of order 3(2) [3]_. The error
+            is controlled assuming accuracy of the second-order method, but
+            steps are taken using the third-order accurate formula (local
+            extrapolation is done). A cubic Hermite polynomial is used for the
+            dense output. Can be applied in the complex domain.
+        * 'DOP853': Explicit Runge-Kutta method of order 8 [13]_.
+            Python implementation of the "DOP853" algorithm originally
+            written in Fortran [14]_. A 7-th order interpolation polynomial
+            accurate to 7-th order is used for the dense output.
+            Can be applied in the complex domain.
+        * 'Radau': Implicit Runge-Kutta method of the Radau IIA family of
+            order 5 [4]_. The error is controlled with a third-order accurate
+            embedded formula. A cubic polynomial which satisfies the
+            collocation conditions is used for the dense output.
+        * 'BDF': Implicit multi-step variable-order (1 to 5) method based
+            on a backward differentiation formula for the derivative
+            approximation [5]_. The implementation follows the one described
+            in [6]_. A quasi-constant step scheme is used and accuracy is
+            enhanced using the NDF modification. Can be applied in the
+            complex domain.
+        * 'LSODA': Adams/BDF method with automatic stiffness detection and
+            switching [7]_, [8]_. This is a wrapper of the Fortran solver
+            from ODEPACK.
 
         Explicit Runge-Kutta methods ('RK23', 'RK45', 'DOP853') should be used
         for non-stiff problems and implicit methods ('Radau', 'BDF') for
@@ -261,16 +261,16 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         events may be missed. Additionally each `event` function might
         have the following attributes:
 
-            terminal: bool or int, optional
-                When boolean, whether to terminate integration if this event occurs.
-                When integral, termination occurs after the specified the number of
-                occurrences of this event.
-                Implicitly False if not assigned.
-            direction: float, optional
-                Direction of a zero crossing. If `direction` is positive,
-                `event` will only trigger when going from negative to positive,
-                and vice versa if `direction` is negative. If 0, then either
-                direction will trigger event. Implicitly 0 if not assigned.
+        terminal: bool or int, optional
+            When boolean, whether to terminate integration if this event occurs.
+            When integral, termination occurs after the specified the number of
+            occurrences of this event.
+            Implicitly False if not assigned.
+        direction: float, optional
+            Direction of a zero crossing. If `direction` is positive,
+            `event` will only trigger when going from negative to positive,
+            and vice versa if `direction` is negative. If 0, then either
+            direction will trigger event. Implicitly 0 if not assigned.
 
         You can assign attributes like ``event.terminal = True`` to any
         function in Python.
@@ -325,16 +325,16 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
         Jacobian matrix has shape (n, n) and its element (i, j) is equal to
         ``d f_i / d y_j``.  There are three ways to define the Jacobian:
 
-            * If array_like or sparse_matrix, the Jacobian is assumed to
-              be constant. Not supported by 'LSODA'.
-            * If callable, the Jacobian is assumed to depend on both
-              t and y; it will be called as ``jac(t, y)``, as necessary.
-              Additional arguments have to be passed if ``args`` is
-              used (see documentation of ``args`` argument).
-              For 'Radau' and 'BDF' methods, the return value might be a
-              sparse matrix.
-            * If None (default), the Jacobian will be approximated by
-              finite differences.
+        * If array_like or sparse_matrix, the Jacobian is assumed to
+            be constant. Not supported by 'LSODA'.
+        * If callable, the Jacobian is assumed to depend on both
+            t and y; it will be called as ``jac(t, y)``, as necessary.
+            Additional arguments have to be passed if ``args`` is
+            used (see documentation of ``args`` argument).
+            For 'Radau' and 'BDF' methods, the return value might be a
+            sparse matrix.
+        * If None (default), the Jacobian will be approximated by
+            finite differences.
 
         It is generally recommended to provide the Jacobian rather than
         relying on a finite-difference approximation.
@@ -386,9 +386,9 @@ def solve_ivp(fun, t_span, y0, method='RK45', t_eval=None, dense_output=False,
     status : int
         Reason for algorithm termination:
 
-            * -1: Integration step failed.
-            *  0: The solver successfully reached the end of `tspan`.
-            *  1: A termination event occurred.
+        * -1: Integration step failed.
+        *  0: The solver successfully reached the end of `tspan`.
+        *  1: A termination event occurred.
 
     message : string
         Human-readable description of the termination reason.

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -224,14 +224,14 @@ class Radau(OdeSolver):
         its element (i, j) is equal to ``d f_i / d y_j``.
         There are three ways to define the Jacobian:
 
-            * If array_like or sparse_matrix, the Jacobian is assumed to
-              be constant.
-            * If callable, the Jacobian is assumed to depend on both
-              t and y; it will be called as ``jac(t, y)`` as necessary.
-              For the 'Radau' and 'BDF' methods, the return value might be a
-              sparse matrix.
-            * If None (default), the Jacobian will be approximated by
-              finite differences.
+        * If array_like or sparse_matrix, the Jacobian is assumed to
+            be constant.
+        * If callable, the Jacobian is assumed to depend on both
+            t and y; it will be called as ``jac(t, y)`` as necessary.
+            For the 'Radau' and 'BDF' methods, the return value might be a
+            sparse matrix.
+        * If None (default), the Jacobian will be approximated by
+            finite differences.
 
         It is generally recommended to provide the Jacobian rather than
         relying on a finite-difference approximation.

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -1029,13 +1029,13 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         callable, the signature must be the same as for ``ranges``. The
         available options together with their default values are:
 
-          - epsabs = 1.49e-08
-          - epsrel = 1.49e-08
-          - limit  = 50
-          - points = None
-          - weight = None
-          - wvar   = None
-          - wopts  = None
+        - ``epsabs = 1.49e-08``
+        - ``epsrel = 1.49e-08``
+        - ``limit  = 50``
+        - ``points = None``
+        - ``weight = None``
+        - ``wvar   = None``
+        - ``wopts  = None``
 
         For more information on these options, see `quad`.
 
@@ -1091,7 +1091,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation, which will
         eliminate the effects of integrand singularities of
-        several types. The integration is is performed using a 21-point Gauss-Kronrod 
+        several types. The integration is is performed using a 21-point Gauss-Kronrod
         quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is


### PR DESCRIPTION
Along the lines of #24257, many lists in the integrate docs seem to be indented unintentionally.