### PR TITLE
DOC: signal: fix _calc_oa_lens in2_step description

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -727,7 +727,7 @@ def _calc_oa_lens(s1, s2):
     in1_step : int
         The size of each step for the first array.
     in2_step : int
-        The size of each step for the first array.
+        The size of each step for the second array.
 
     """
     # Set up the arguments for the conventional FFT approach.


### PR DESCRIPTION
## Summary
Fix docstring for `_calc_oa_lens` so `in2_step` correctly refers to the second array.

## Related Issue
Fixes #24289

## Testing
- Changed "first" to "second" in the docstring only 

Contribution by Gittensor, see my contribution statistics at https://gittensor.io/miners/details?githubId=105917501