### PR TITLE
DOC: remove block quotes from array api support note

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -770,7 +770,7 @@ def _make_capabilities_note(fun_name, capabilities, extra_note=None):
     Dask                  {capabilities['dask.array']              }
     ====================  ====================  ====================
 
-    """ + (extra_note or "") + "    See :ref:`dev-arrayapi` for more information."
+    """ + (extra_note or "") + "See :ref:`dev-arrayapi` for more information."
 
     return textwrap.dedent(note)
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -770,7 +770,9 @@ def _make_capabilities_note(fun_name, capabilities, extra_note=None):
     Dask                  {capabilities['dask.array']              }
     ====================  ====================  ====================
 
-    """ + (extra_note or "") + "See :ref:`dev-arrayapi` for more information."
+    {extra_note or ""}
+    See :ref:`dev-arrayapi` for more information.
+    """
 
     return textwrap.dedent(note)
 


### PR DESCRIPTION
It looks like at some point part of the text was turned into block quotes, this pr fixes that.