### PR TITLE
BUG: IndexError when giving a zero distance matrix to multiscale_graphcorr

### DIFF
--- a/scipy/stats/_mgc.py
+++ b/scipy/stats/_mgc.py
@@ -407,7 +407,7 @@ def _mgc_stat(distx, disty):
     # calculate MGC map and optimal scale
     stat_mgc_map = _local_correlations(distx, disty, global_corr='mgc')
 
-    n, m = stat_mgc_map.shape
+    m, n = stat_mgc_map.shape
     if m == 1 or n == 1:
         # the global scale at is the statistic calculated at maximal nearest
         # neighbors. There is not enough local scale to search over, so

--- a/scipy/stats/tests/test_mgc.py
+++ b/scipy/stats/tests/test_mgc.py
@@ -7,8 +7,6 @@ from numpy.testing import assert_approx_equal, assert_allclose, assert_equal
 from scipy.spatial.distance import cdist
 from scipy import stats
 
-from sklearn.metrics import pairwise_distances
-
 class TestMGCErrorWarnings:
     """ Tests errors and warnings derived from MGC.
     """

--- a/scipy/stats/tests/test_mgc.py
+++ b/scipy/stats/tests/test_mgc.py
@@ -7,6 +7,8 @@ from numpy.testing import assert_approx_equal, assert_allclose, assert_equal
 from scipy.spatial.distance import cdist
 from scipy import stats
 
+from sklearn.metrics import pairwise_distances
+
 class TestMGCErrorWarnings:
     """ Tests errors and warnings derived from MGC.
     """
@@ -206,6 +208,25 @@ class TestMGCStat:
         # test stat and pvalue
         _, pvalue, _ = stats.multiscale_graphcorr(x, y, random_state=1)
         assert_allclose(pvalue, 1/1001)
+
+    def test_zero_distance_matrix_index_error(self):
+        # regression test for zero distance
+        # matrix IndexError issue; see gh-19769
+        n = 6
+        x = np.arange(n).reshape(-1, 1)
+
+        # valid distance matrix
+        distx = cdist(x, x)
+
+        # degenerate all-zero distance matrix
+        disty = np.zeros((n, n))
+
+        stat, pvalue, _ = stats.multiscale_graphcorr(
+            distx,
+            disty,
+            compute_distance=None,
+            reps=0,
+        )
 
     @pytest.mark.xslow
     def test_alias(self):

--- a/scipy/stats/tests/test_mgc.py
+++ b/scipy/stats/tests/test_mgc.py
@@ -219,7 +219,10 @@ class TestMGCStat:
         # degenerate all-zero distance matrix
         disty = np.zeros((n, n))
 
-        stats.multiscale_graphcorr(distx, disty, compute_distance=None)
+        # test stat and pvalue
+        res = stats.multiscale_graphcorr(distx, disty, compute_distance=None)
+        assert_allclose(res.statistic, 0.0)
+        assert_allclose(res.pvalue, 1.0)
     
     @pytest.mark.xslow
     def test_alias(self):

--- a/scipy/stats/tests/test_mgc.py
+++ b/scipy/stats/tests/test_mgc.py
@@ -219,13 +219,8 @@ class TestMGCStat:
         # degenerate all-zero distance matrix
         disty = np.zeros((n, n))
 
-        stat, pvalue, _ = stats.multiscale_graphcorr(
-            distx,
-            disty,
-            compute_distance=None,
-            reps=0,
-        )
-
+        stats.multiscale_graphcorr(distx, disty, compute_distance=None)
+    
     @pytest.mark.xslow
     def test_alias(self):
         # generate x and y


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #19769

#### What does this implement/fix?
This PR fixes the `IndexError` raised when giving zero distance matrix to `multiscale_graphcorr`. It swaps the order of `n` and `m` so it follows the order of the rest of the helpers in the module. A regression test is added too. 

#### Additional information
<!--Any additional information you think is important.-->
