### PR TITLE
MAINT: prep for 1.17.0 "final" release

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -57,7 +57,11 @@ jobs:
         sudo apt-get install -y gfortran
         pip install cython numpy pybind11 pythran pytest hypothesis pytest-xdist pooch
         pip install -r requirements/dev.txt
-        pip install git+https://github.com/numpy/meson.git@main-numpymeson
+        # numpy fork of meson with meson v1.8.2 - not public, but works for our
+        # purposes here, we need its BLAS ILP64 support until that is merged
+        # in Meson upstream. Note that a more recent commit on this fork didn't work,
+        # see gh-24251.
+        pip install git+https://github.com/numpy/meson.git@e72c717199fa18d34020c7c97f9de3f388c5e055
         pip install mkl mkl-devel
 
     - name: Build with defaults (LP64)
@@ -92,7 +96,7 @@ jobs:
         sudo apt-get install -y gfortran
         pip install cython numpy pybind11 pythran pytest hypothesis pytest-xdist pooch
         pip install -r requirements/dev.txt
-        pip install git+https://github.com/numpy/meson.git@main-numpymeson
+        pip install git+https://github.com/numpy/meson.git@e72c717199fa18d34020c7c97f9de3f388c5e055
         pip install mkl mkl-devel
 
     - name: Build with ILP64
@@ -126,10 +130,8 @@ jobs:
         sudo apt-get install -y gfortran
         pip install cython numpy pybind11 pythran pytest hypothesis pytest-xdist pooch
         pip install -r requirements/dev.txt
-        pip install git+https://github.com/numpy/meson.git@main-numpymeson
-        # pin scipy-openblas on release branch--see:
-        # https://github.com/scipy/scipy/pull/24207#issuecomment-3687862055
-        pip install "scipy-openblas32==0.3.30.0.8" "scipy-openblas64==0.3.30.0.8"
+        pip install git+https://github.com/numpy/meson.git@e72c717199fa18d34020c7c97f9de3f388c5e055
+        pip install scipy-openblas32 scipy-openblas64
 
     - name: Write out scipy-openblas64.pc
       run: |

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -131,7 +131,10 @@ jobs:
         pip install cython numpy pybind11 pythran pytest hypothesis pytest-xdist pooch
         pip install -r requirements/dev.txt
         pip install git+https://github.com/numpy/meson.git@e72c717199fa18d34020c7c97f9de3f388c5e055
-        pip install scipy-openblas32 scipy-openblas64
+        # Yes, we install both of scipy-openblas32|64, we need both LP64 and
+        # ILP64 (this is obviously a hack, and not supportable outside of SciPy
+        # CI and manual dev env setup; see gh-21889 for details).
+        pip install -r requirements/openblas64.txt
 
     - name: Write out scipy-openblas64.pc
       run: |

--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -432,7 +432,7 @@ Authors
 * Matteo Brivio (1) +
 * Dietrich Brunn (34)
 * Johannes Buchner (2) +
-* Evgeni Burovski (290)
+* Evgeni Burovski (292)
 * Nicholas Carlini (1) +
 * Luca Cerina (1) +
 * Christine P. Chai (35)
@@ -453,10 +453,10 @@ Authors
 * Neil Girdhar (1)
 * Ilan Gold (35)
 * Nathan Goldbaum (3) +
-* Ralf Gommers (121)
+* Ralf Gommers (124)
 * Nicolas Guidotti (1) +
 * Geoffrey Gunter (1) +
-* Matt Haberland (181)
+* Matt Haberland (183)
 * Joren Hammudoglu (60)
 * Jacob Hass (2) +
 * Nick Hodgskin (1) +
@@ -495,7 +495,7 @@ Authors
 * Suriyaa MM (1) +
 * Andrew Nelson (72)
 * newyork_loki (2) +
-* Nick ODell (33)
+* Nick ODell (34)
 * Dimitri Papadopoulos Orfanos (2)
 * Drew Parsons (1)
 * Gilles Peiffer (3) +
@@ -508,7 +508,7 @@ Authors
 * Ritesh Rana (1) +
 * Adrian Raso (1) +
 * Dan Raviv (1) +
-* Tyler Reddy (122)
+* Tyler Reddy (136)
 * Lucas Roberts (4)
 * Bernard Roesler (1) +
 * Mikhail Ryazanov (27)
@@ -629,6 +629,7 @@ Issues closed for 1.17.0
 * `#23371 <https://github.com/scipy/scipy/issues/23371>`__: BUG: (interpolate) _dierckx.data_matrix gives ValueError if input...
 * `#23382 <https://github.com/scipy/scipy/issues/23382>`__: BUG: setting with ``sparse.xxx_{matrix,array}`` 2D singleton
 * `#23383 <https://github.com/scipy/scipy/issues/23383>`__: DOC/DEV: correct editable install ``spin`` guidance
+* `#23390 <https://github.com/scipy/scipy/issues/23390>`__: BUG: stats.sampling: segfault in various classes on osx-arm64
 * `#23391 <https://github.com/scipy/scipy/issues/23391>`__: ENH: spatial.transform: array API standard support tracker
 * `#23400 <https://github.com/scipy/scipy/issues/23400>`__: ENH: spatial.geometric_slerp: allow for extrapolation
 * `#23409 <https://github.com/scipy/scipy/issues/23409>`__: BUG: stats.qmc.Sobol: stuck in infinite loop in low_0_bit after...
@@ -685,7 +686,10 @@ Issues closed for 1.17.0
 * `#24052 <https://github.com/scipy/scipy/issues/24052>`__: CI: TypeError: Multiple namespaces for array inputs
 * `#24089 <https://github.com/scipy/scipy/issues/24089>`__: ENH: spatial.transform: Add ``normalize`` argument to ``Rotation.from_matrix``
 * `#24131 <https://github.com/scipy/scipy/issues/24131>`__: BUG: ``1.17.0rc1``\ : ModuleNotFoundError: No module named 'scipy.integrate._lso...
+* `#24152 <https://github.com/scipy/scipy/issues/24152>`__: DOC: 1.17 API changes not mentioned in the 1.17.0rc1 release...
 * `#24212 <https://github.com/scipy/scipy/issues/24212>`__: BENCH, MAINT: (sparse) asv suite compat with NumPy 2.4.0
+* `#24251 <https://github.com/scipy/scipy/issues/24251>`__: CI: linalg: several test failures for ILP64
+* `#24256 <https://github.com/scipy/scipy/issues/24256>`__: DOC: 1.17 API changes not mentioned in the 1.17.0rc2 release...
 
 ************************
 Pull requests for 1.17.0
@@ -1207,9 +1211,15 @@ Pull requests for 1.17.0
 * `#24155 <https://github.com/scipy/scipy/pull/24155>`__: MAINT: bump ``xsf`` to fix ``special.itj0y0`` regression
 * `#24161 <https://github.com/scipy/scipy/pull/24161>`__: BUG:linalg.interpolative: Fix two edge cases for id_dist Cython...
 * `#24174 <https://github.com/scipy/scipy/pull/24174>`__: REV:integrate: Revert the stepsize change in LSODA
+* `#24207 <https://github.com/scipy/scipy/pull/24207>`__: MAINT: backports for SciPy 1.17.0rc2
 * `#24213 <https://github.com/scipy/scipy/pull/24213>`__: TST: fft: Add allow_dask_compute=True to more places in fft
 * `#24214 <https://github.com/scipy/scipy/pull/24214>`__: DOC: update 1.17.0 notes for RBFInterpolator
 * `#24218 <https://github.com/scipy/scipy/pull/24218>`__: BENCH, MAINT: NumPy 2.4.0 bench compat
 * `#24223 <https://github.com/scipy/scipy/pull/24223>`__: BLD: linalg: ``link_language: 'fortran'`` for ``_fblas``
 * `#24239 <https://github.com/scipy/scipy/pull/24239>`__: MAINT: bump array-api-compat for JAX>=0.8.2 compat
 * `#24240 <https://github.com/scipy/scipy/pull/24240>`__: MAINT: bump array-api-compat to 1.13 tag
+* `#24250 <https://github.com/scipy/scipy/pull/24250>`__: BUG: stats._unuran: fix va_args memory corruption bug
+* `#24255 <https://github.com/scipy/scipy/pull/24255>`__: REL: set 1.17.0rc3 unreleased
+* `#24260 <https://github.com/scipy/scipy/pull/24260>`__: DOC: stats.anderson/anderson_ksamp: improve release notes
+* `#24284 <https://github.com/scipy/scipy/pull/24284>`__: CI: fix ILP64 jobs for build failures and unpinned scipy-openblas...
+* `#24304 <https://github.com/scipy/scipy/pull/24304>`__: DOC: clarify ILP64 support caveats in the release notes

--- a/doc/source/release/1.17.0-notes.rst
+++ b/doc/source/release/1.17.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.17.0 Release Notes
 ==========================
 
-.. note:: SciPy 1.17.0 is not released yet!
-
 .. contents::
 
 SciPy 1.17.0 is the culmination of 6 months of hard work. It contains
@@ -256,7 +254,7 @@ New features
   and ``fit_result`` attributes.
 - A new ``variant`` parameter of `scipy.stats.anderson_ksamp` allows the user
   to select between three different variants of the statistic, superseding the
-  ``midrank`` parameter which allowed toggling beteen two. The new ``'continuous'``
+  ``midrank`` parameter which allowed toggling between two. The new ``'continuous'``
   variant is equivalent to ``'discrete'`` when there are no ties in the sample, but
   the calculation is faster. The ``variant`` parameter must be passed explicitly to
   avoid a warning about the deprecation of the ``midrank`` attribute and the upcoming

--- a/requirements/openblas64.txt
+++ b/requirements/openblas64.txt
@@ -1,0 +1,2 @@
+scipy-openblas32==0.3.30.0.8
+scipy-openblas64==0.3.30.0.8

--- a/scipy/stats/_unuran/unuran_callback.h
+++ b/scipy/stats/_unuran/unuran_callback.h
@@ -2,7 +2,7 @@
 #include "ccallback.h"
 #include "unuran.h"
 
-#define UNURAN_THUNK(CAST_FUNC, FUNCNAME, LEN)                                              \
+#define UNURAN_THUNK(CAST_FUNC, FUNCNAME);                                                  \
     PyGILState_STATE gstate = PyGILState_Ensure();                                          \
     /* If an error has occurred, return INFINITY. */                                        \
     if (PyErr_Occurred()) return UNUR_INFINITY;                                             \
@@ -18,7 +18,7 @@
         goto done;                                                                          \
     }                                                                                       \
                                                                                             \
-    funcname = Py_BuildValue("s#", FUNCNAME, LEN);                                          \
+    funcname = Py_BuildValue("s", FUNCNAME);                                                \
     if (funcname == NULL) {                                                                 \
         error = 1;                                                                          \
         goto done;                                                                          \
@@ -112,30 +112,30 @@ int release_unuran_callback(ccallback_t *callback) {
 
 double pmf_thunk(int x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyLong_FromLong, "pmf", 3);
+    UNURAN_THUNK(PyLong_FromLong, "pmf");
 }
 
 double pdf_thunk(double x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyFloat_FromDouble, "pdf", 3);
+    UNURAN_THUNK(PyFloat_FromDouble, "pdf");
 }
 
 double dpdf_thunk(double x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyFloat_FromDouble, "dpdf", 4);
+    UNURAN_THUNK(PyFloat_FromDouble, "dpdf");
 }
 
 double logpdf_thunk(double x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyFloat_FromDouble, "logpdf", 6);
+    UNURAN_THUNK(PyFloat_FromDouble, "logpdf");
 }
 
 double cont_cdf_thunk(double x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyFloat_FromDouble, "cdf", 3);
+    UNURAN_THUNK(PyFloat_FromDouble, "cdf");
 }
 
 double discr_cdf_thunk(int x, const struct unur_distr *distr)
 {
-    UNURAN_THUNK(PyLong_FromLong, "cdf", 3);
+    UNURAN_THUNK(PyLong_FromLong, "cdf");
 }


### PR DESCRIPTION
This is a work in progress with CI disabled for now. It currently adjusts the release notes to remove the caution about `1.17.0` not being released as we prepare for the "final" release, and fixes the relnotes typo noted at https://github.com/scipy/scipy/pull/24260#discussion_r2655633061. I'll build up a TODO list below. Notes on overlapping NumPy release situation below, but tentatively planning for the SciPy "final" release on Sunday.

Backports included so far:
- gh-24250
- gh-24284

Backports intentionally **not** included:
- gh-24253 was suggested not to be backported at: https://github.com/scipy/scipy/pull/24253#issuecomment-3700256733
- gh-24275 was suggested for a `1.17.1` backport instead: https://github.com/scipy/scipy/pull/24275#issuecomment-3710503364

TODO:

- [x] gh-24284 had merge conflicts I need to check more closely if I'm to backport it
- [x] I talked to Chuck/NumPy team this morning about the `2.4.0` issues--sounds like they'll try to get `2.4.1` out by Saturday so we could build wheels against that rather than slightly-dubious `2.4.0`; that's not a hard blocker for us though; if they don't yank `2.4.0` after `2.4.1` release (it seemed like they might, given that Ralf and I both wanted that) I wonder if we'd consider a single-version runtime ban... maybe not since kind of narrow range of problem scenarios for `2.4.0` only..
- [x] update release notes again when all backports are done
- [x] gradually reactivate regular CI and make sure it is passing
- [x] dry run of wheel builds when ready
- [ ] the final rc3 version removal/change I usually do during the release process proper

cc @h-vetinari @jorenham 