### PR TITLE
DOC: fix incorrect block quotes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,12 +198,3 @@ PKG_CONFIG_PATH = "{project}"
   ".spin/cmds.py:authors"
 ]
 "Metrics" = [".spin/cmds.py:bench"]
-
-[tool.numpydoc_validation]
-checks = [
-  "SS01"
-]
-
-exclude_files = [
-  '.*test_*',
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,3 +198,12 @@ PKG_CONFIG_PATH = "{project}"
   ".spin/cmds.py:authors"
 ]
 "Metrics" = [".spin/cmds.py:bench"]
+
+[tool.numpydoc_validation]
+checks = [
+  "SS01"
+]
+
+exclude_files = [
+  '.*test_*',
+]

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -910,7 +910,7 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
       into a new cluster :math:`u`, the average of centroids s and t
       give the new centroid :math:`u`. This is also known as the
       WPGMC algorithm.
-      * method='ward' uses the Ward variance minimization algorithm.
+    * method='ward' uses the Ward variance minimization algorithm.
       The new entry :math:`d(u,v)` is computed as follows,
 
       .. math::

--- a/scipy/cluster/hierarchy.py
+++ b/scipy/cluster/hierarchy.py
@@ -615,19 +615,16 @@ def median(y):
     See `linkage` for more information on the return structure
     and algorithm.
 
-     The following are common calling conventions:
+    The following are common calling conventions:
 
-     1. ``Z = median(y)``
-
-        Performs median/WPGMC linkage on the condensed distance matrix
-        ``y``.  See ``linkage`` for more information on the return
-        structure and algorithm.
-
-     2. ``Z = median(X)``
-
-        Performs median/WPGMC linkage on the observation matrix ``X``
-        using Euclidean distance as the distance metric. See `linkage`
-        for more information on the return structure and algorithm.
+    1. ``Z = median(y)``:
+       Performs median/WPGMC linkage on the condensed distance matrix
+       ``y``.  See ``linkage`` for more information on the return
+       structure and algorithm.
+    2. ``Z = median(X)``:
+       Performs median/WPGMC linkage on the observation matrix ``X``
+       using Euclidean distance as the distance metric. See `linkage`
+       for more information on the return structure and algorithm.
 
     Parameters
     ----------
@@ -861,81 +858,75 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     The following are methods for calculating the distance between the
     newly formed cluster :math:`u` and each :math:`v`.
 
-      * method='single' assigns
+    * method='single' assigns
 
-        .. math::
-           d(u,v) = \\min(dist(u[i],v[j]))
+      .. math::
+          d(u,v) = \\min(dist(u[i],v[j]))
 
-        for all points :math:`i` in cluster :math:`u` and
-        :math:`j` in cluster :math:`v`. This is also known as the
-        Nearest Point Algorithm.
+      for all points :math:`i` in cluster :math:`u` and
+      :math:`j` in cluster :math:`v`. This is also known as the
+      Nearest Point Algorithm.
+    * method='complete' assigns
 
-      * method='complete' assigns
+      .. math::
+          d(u, v) = \\max(dist(u[i],v[j]))
 
-        .. math::
-           d(u, v) = \\max(dist(u[i],v[j]))
+      for all points :math:`i` in cluster u and :math:`j` in
+      cluster :math:`v`. This is also known by the Farthest Point
+      Algorithm or Voor Hees Algorithm.
+    * method='average' assigns
 
-        for all points :math:`i` in cluster u and :math:`j` in
-        cluster :math:`v`. This is also known by the Farthest Point
-        Algorithm or Voor Hees Algorithm.
+      .. math::
+          d(u,v) = \\sum_{ij} \\frac{d(u[i], v[j])}
+                                  {(|u|*|v|)}
 
-      * method='average' assigns
+      for all points :math:`i` and :math:`j` where :math:`|u|`
+      and :math:`|v|` are the cardinalities of clusters :math:`u`
+      and :math:`v`, respectively. This is also called the UPGMA
+      algorithm.
+    * method='weighted' assigns
 
-        .. math::
-           d(u,v) = \\sum_{ij} \\frac{d(u[i], v[j])}
-                                   {(|u|*|v|)}
+      .. math::
+          d(u,v) = (dist(s,v) + dist(t,v))/2
 
-        for all points :math:`i` and :math:`j` where :math:`|u|`
-        and :math:`|v|` are the cardinalities of clusters :math:`u`
-        and :math:`v`, respectively. This is also called the UPGMA
-        algorithm.
+      where cluster u was formed with cluster s and t and v
+      is a remaining cluster in the forest (also called WPGMA).
+    * method='centroid' assigns
 
-      * method='weighted' assigns
+      .. math::
+          dist(s,t) = ||c_s-c_t||_2
 
-        .. math::
-           d(u,v) = (dist(s,v) + dist(t,v))/2
-
-        where cluster u was formed with cluster s and t and v
-        is a remaining cluster in the forest (also called WPGMA).
-
-      * method='centroid' assigns
-
-        .. math::
-           dist(s,t) = ||c_s-c_t||_2
-
-        where :math:`c_s` and :math:`c_t` are the centroids of
-        clusters :math:`s` and :math:`t`, respectively. When two
-        clusters :math:`s` and :math:`t` are combined into a new
-        cluster :math:`u`, the new centroid is computed over all the
-        original objects in clusters :math:`s` and :math:`t`. The
-        distance then becomes the Euclidean distance between the
-        centroid of :math:`u` and the centroid of a remaining cluster
-        :math:`v` in the forest. This is also known as the UPGMC
-        algorithm.
-
-      * method='median' assigns :math:`d(s,t)` like the ``centroid``
-        method. When two clusters :math:`s` and :math:`t` are combined
-        into a new cluster :math:`u`, the average of centroids s and t
-        give the new centroid :math:`u`. This is also known as the
-        WPGMC algorithm.
-
+      where :math:`c_s` and :math:`c_t` are the centroids of
+      clusters :math:`s` and :math:`t`, respectively. When two
+      clusters :math:`s` and :math:`t` are combined into a new
+      cluster :math:`u`, the new centroid is computed over all the
+      original objects in clusters :math:`s` and :math:`t`. The
+      distance then becomes the Euclidean distance between the
+      centroid of :math:`u` and the centroid of a remaining cluster
+      :math:`v` in the forest. This is also known as the UPGMC
+      algorithm.
+    * method='median' assigns :math:`d(s,t)` like the ``centroid``
+      method. When two clusters :math:`s` and :math:`t` are combined
+      into a new cluster :math:`u`, the average of centroids s and t
+      give the new centroid :math:`u`. This is also known as the
+      WPGMC algorithm.
       * method='ward' uses the Ward variance minimization algorithm.
-        The new entry :math:`d(u,v)` is computed as follows,
+      The new entry :math:`d(u,v)` is computed as follows,
 
-        .. math::
+      .. math::
 
-           d(u,v) = \\sqrt{\\frac{|v|+|s|}
-                               {T}d(v,s)^2
-                        + \\frac{|v|+|t|}
-                               {T}d(v,t)^2
-                        - \\frac{|v|}
-                               {T}d(s,t)^2}
+          d(u,v) = \\sqrt{\\frac{|v|+|s|}
+                              {T}d(v,s)^2
+                      + \\frac{|v|+|t|}
+                              {T}d(v,t)^2
+                      - \\frac{|v|}
+                              {T}d(s,t)^2}
 
-        where :math:`u` is the newly joined cluster consisting of
-        clusters :math:`s` and :math:`t`, :math:`v` is an unused
-        cluster in the forest, :math:`T=|v|+|s|+|t|`, and
-        :math:`|*|` is the cardinality of its argument. This is also
-        known as the incremental algorithm.
+      where :math:`u` is the newly joined cluster consisting of
+      clusters :math:`s` and :math:`t`, :math:`v` is an unused
+      cluster in the forest, :math:`T=|v|+|s|+|t|`, and
+      :math:`|*|` is the cardinality of its argument. This is also
+      known as the incremental algorithm.
 
     Warning: When the minimum distance pair in the forest is chosen, there
     may be two or more pairs with the same minimum distance. This
@@ -1052,7 +1043,7 @@ def linkage(y, method='single', metric='euclidean', optimal_ordering=False):
     def cy_linkage(y, validate):
         if validate and not np.all(np.isfinite(y)):
             raise ValueError("The condensed distance matrix must contain only "
-                            "finite values.")            
+                            "finite values.")
 
         if method == 'single':
             return _hierarchy.mst_single_linkage(y, n)
@@ -1693,12 +1684,12 @@ def cophenet(Z, Y=None):
         zz = np.zeros((n * (n-1)) // 2, dtype=np.float64)
         _hierarchy.cophenetic_distances(Z, zz, n)
         return zz
-    
+
     n = Z.shape[0] + 1
     zz = xpx.lazy_apply(cy_cophenet, Z, validate=is_lazy_array(Z),
                         shape=((n * (n-1)) // 2, ), dtype=xp.float64,
                         as_numpy=True, xp=xp)
-                        
+
     if Y is None:
         return zz
 
@@ -2533,48 +2524,44 @@ def fcluster(Z, t, criterion='inconsistent', depth=2, R=None, monocrit=None):
         The criterion to use in forming flat clusters. This can
         be any of the following values:
 
-          ``inconsistent`` :
-              If a cluster node and all its
-              descendants have an inconsistent value less than or equal
-              to `t`, then all its leaf descendants belong to the
-              same flat cluster. When no non-singleton cluster meets
-              this criterion, every node is assigned to its own
-              cluster. (Default)
+        * ``inconsistent`` :
+          If a cluster node and all its
+          descendants have an inconsistent value less than or equal
+          to `t`, then all its leaf descendants belong to the
+          same flat cluster. When no non-singleton cluster meets
+          this criterion, every node is assigned to its own
+          cluster. (Default)
+        * ``distance`` :
+          Forms flat clusters so that the original
+          observations in each flat cluster have no greater a
+          cophenetic distance than `t`.
+        * ``maxclust`` :
+          Finds a minimum threshold ``r`` so that
+          the cophenetic distance between any two original
+          observations in the same flat cluster is no more than
+          ``r`` and no more than `t` flat clusters are formed.
+        * ``monocrit`` :
+          Forms a flat cluster from a cluster node c
+          with index i when ``monocrit[j] <= t``.
 
-          ``distance`` :
-              Forms flat clusters so that the original
-              observations in each flat cluster have no greater a
-              cophenetic distance than `t`.
+          For example, to threshold on the maximum mean distance
+          as computed in the inconsistency matrix R with a
+          threshold of 0.8 do::
 
-          ``maxclust`` :
-              Finds a minimum threshold ``r`` so that
-              the cophenetic distance between any two original
-              observations in the same flat cluster is no more than
-              ``r`` and no more than `t` flat clusters are formed.
+              MR = maxRstat(Z, R, 3)
+              fcluster(Z, t=0.8, criterion='monocrit', monocrit=MR)
+        * ``maxclust_monocrit`` :
+          Forms a flat cluster from a
+          non-singleton cluster node ``c`` when ``monocrit[i] <=
+          r`` for all cluster indices ``i`` below and including
+          ``c``. ``r`` is minimized such that no more than ``t``
+          flat clusters are formed. monocrit must be
+          monotonic. For example, to minimize the threshold t on
+          maximum inconsistency values so that no more than 3 flat
+          clusters are formed, do::
 
-          ``monocrit`` :
-              Forms a flat cluster from a cluster node c
-              with index i when ``monocrit[j] <= t``.
-
-              For example, to threshold on the maximum mean distance
-              as computed in the inconsistency matrix R with a
-              threshold of 0.8 do::
-
-                  MR = maxRstat(Z, R, 3)
-                  fcluster(Z, t=0.8, criterion='monocrit', monocrit=MR)
-
-          ``maxclust_monocrit`` :
-              Forms a flat cluster from a
-              non-singleton cluster node ``c`` when ``monocrit[i] <=
-              r`` for all cluster indices ``i`` below and including
-              ``c``. ``r`` is minimized such that no more than ``t``
-              flat clusters are formed. monocrit must be
-              monotonic. For example, to minimize the threshold t on
-              maximum inconsistency values so that no more than 3 flat
-              clusters are formed, do::
-
-                  MI = maxinconsts(Z, R)
-                  fcluster(Z, t=3, criterion='maxclust_monocrit', monocrit=MI)
+              MI = maxinconsts(Z, R)
+              fcluster(Z, t=3, criterion='maxclust_monocrit', monocrit=MI)
     depth : int, optional
         The maximum depth to perform the inconsistency calculation.
         It has no meaning for the other criteria. Default is 2.
@@ -4075,7 +4062,7 @@ def maxinconsts(Z, R):
     if Z.shape[0] != R.shape[0]:
         raise ValueError("The inconsistency matrix and linkage matrix each "
                          "have a different number of rows.")
-    
+
     def cy_maxinconsts(Z, R, validate):
         if validate:
             _is_valid_linkage(Z, throw=True, name='Z', xp=np)
@@ -4214,16 +4201,16 @@ def leaders(Z, T):
     this function finds the lowest cluster node :math:`i` in the linkage
     tree Z, such that:
 
-      * leaf descendants belong only to flat cluster j
-        (i.e., ``T[p]==j`` for all :math:`p` in :math:`S(i)`, where
-        :math:`S(i)` is the set of leaf ids of descendant leaf nodes
-        with cluster node :math:`i`)
+    * leaf descendants belong only to flat cluster j
+      (i.e., ``T[p]==j`` for all :math:`p` in :math:`S(i)`, where
+      :math:`S(i)` is the set of leaf ids of descendant leaf nodes
+      with cluster node :math:`i`)
 
-      * there does not exist a leaf that is not a descendant with
-        :math:`i` that also belongs to cluster :math:`j`
-        (i.e., ``T[q]!=j`` for all :math:`q` not in :math:`S(i)`). If
-        this condition is violated, ``T`` is not a valid cluster
-        assignment vector, and an exception will be thrown.
+    * there does not exist a leaf that is not a descendant with
+      :math:`i` that also belongs to cluster :math:`j`
+      (i.e., ``T[q]!=j`` for all :math:`q` not in :math:`S(i)`). If
+      this condition is violated, ``T`` is not a valid cluster
+      assignment vector, and an exception will be thrown.
 
     Parameters
     ----------

--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -37,6 +37,7 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
     u : array_like, optional
         An array of parameter values. If not given, these values are
         calculated automatically as ``M = len(x[0])``, where
+
         - ``v[0] = 0``
         - ``v[i] = v[i-1] + distance(`x[i]`, `x[i-1]`)``
         - ``u[i] = v[i] / v[M-1]``

--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -37,12 +37,9 @@ def splprep(x, w=None, u=None, ub=None, ue=None, k=3, task=0, s=None, t=None,
     u : array_like, optional
         An array of parameter values. If not given, these values are
         calculated automatically as ``M = len(x[0])``, where
-
-            v[0] = 0
-
-            v[i] = v[i-1] + distance(`x[i]`, `x[i-1]`)
-
-            u[i] = v[i] / v[M-1]
+        - ``v[0] = 0``
+        - ``v[i] = v[i-1] + distance(`x[i]`, `x[i-1]`)``
+        - ``u[i] = v[i] / v[M-1]``
 
     ub, ue : int, optional
         The end-points of the parameters interval.  Defaults to

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -152,14 +152,14 @@ class RBFInterpolator:
     The above system is uniquely solvable if the following requirements are
     met:
 
-        - :math:`P(y)` must have full column rank. :math:`P(y)` always has full
-          column rank when `degree` is -1 or 0. When `degree` is 1,
-          :math:`P(y)` has full column rank if the data point locations are not
-          all collinear (N=2), coplanar (N=3), etc.
-        - If `kernel` is 'multiquadric', 'linear', 'thin_plate_spline',
-          'cubic', or 'quintic', then `degree` must not be lower than the
-          minimum value listed above.
-        - If `smoothing` is 0, then each data point location must be distinct.
+    - :math:`P(y)` must have full column rank. :math:`P(y)` always has full
+      column rank when `degree` is -1 or 0. When `degree` is 1,
+      :math:`P(y)` has full column rank if the data point locations are not
+      all collinear (N=2), coplanar (N=3), etc.
+    - If `kernel` is 'multiquadric', 'linear', 'thin_plate_spline',
+      'cubic', or 'quintic', then `degree` must not be lower than the
+      minimum value listed above.
+    - If `smoothing` is 0, then each data point location must be distinct.
 
     When using an RBF that is not scale invariant ('multiquadric',
     'inverse_multiquadric', 'inverse_quadratic', or 'gaussian'), an appropriate

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -87,6 +87,7 @@ class RBFInterpolator:
         squares fit of a polynomial with the specified degree. Default is 0.
     kernel : str, optional
         Type of RBF. This should be one of
+
         - 'linear'               : ``-r``
         - 'thin_plate_spline'    : ``r**2 * log(r)``
         - 'cubic'                : ``r**3``
@@ -106,6 +107,7 @@ class RBFInterpolator:
         Degree of the added polynomial. For some RBFs the interpolant may not
         be well-posed if the polynomial degree is too small. Those RBFs and
         their corresponding minimum degrees are
+
         - 'multiquadric'      : 0
         - 'linear'            : 0
         - 'thin_plate_spline' : 1

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -87,15 +87,14 @@ class RBFInterpolator:
         squares fit of a polynomial with the specified degree. Default is 0.
     kernel : str, optional
         Type of RBF. This should be one of
-
-            - 'linear'               : ``-r``
-            - 'thin_plate_spline'    : ``r**2 * log(r)``
-            - 'cubic'                : ``r**3``
-            - 'quintic'              : ``-r**5``
-            - 'multiquadric'         : ``-sqrt(1 + r**2)``
-            - 'inverse_multiquadric' : ``1/sqrt(1 + r**2)``
-            - 'inverse_quadratic'    : ``1/(1 + r**2)``
-            - 'gaussian'             : ``exp(-r**2)``
+        - 'linear'               : ``-r``
+        - 'thin_plate_spline'    : ``r**2 * log(r)``
+        - 'cubic'                : ``r**3``
+        - 'quintic'              : ``-r**5``
+        - 'multiquadric'         : ``-sqrt(1 + r**2)``
+        - 'inverse_multiquadric' : ``1/sqrt(1 + r**2)``
+        - 'inverse_quadratic'    : ``1/(1 + r**2)``
+        - 'gaussian'             : ``exp(-r**2)``
 
         Default is 'thin_plate_spline'.
     epsilon : float, optional
@@ -107,12 +106,11 @@ class RBFInterpolator:
         Degree of the added polynomial. For some RBFs the interpolant may not
         be well-posed if the polynomial degree is too small. Those RBFs and
         their corresponding minimum degrees are
-
-            - 'multiquadric'      : 0
-            - 'linear'            : 0
-            - 'thin_plate_spline' : 1
-            - 'cubic'             : 1
-            - 'quintic'           : 2
+        - 'multiquadric'      : 0
+        - 'linear'            : 0
+        - 'thin_plate_spline' : 1
+        - 'cubic'             : 1
+        - 'quintic'           : 2
 
         The default value is the minimum degree for `kernel` or 0 if there is
         no minimum degree. Set this to -1 for no added polynomial.

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -478,6 +478,7 @@ def hb_read(path_or_open_file, *, spmatrix=True):
     -----
     At the moment not the full Harwell-Boeing format is supported. Supported
     features are:
+
     - assembled, non-symmetric, real matrices
     - integer for pointer/indices
     - exponential format for float values, and int format
@@ -533,6 +534,7 @@ def hb_write(path_or_open_file, m, hb_info=None):
     -----
     At the moment not the full Harwell-Boeing format is supported. Supported
     features are:
+
     - assembled, non-symmetric, real matrices
     - integer for pointer/indices
     - exponential format for float values, and int format

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -478,10 +478,9 @@ def hb_read(path_or_open_file, *, spmatrix=True):
     -----
     At the moment not the full Harwell-Boeing format is supported. Supported
     features are:
-
-        - assembled, non-symmetric, real matrices
-        - integer for pointer/indices
-        - exponential format for float values, and int format
+    - assembled, non-symmetric, real matrices
+    - integer for pointer/indices
+    - exponential format for float values, and int format
 
     Examples
     --------
@@ -534,10 +533,9 @@ def hb_write(path_or_open_file, m, hb_info=None):
     -----
     At the moment not the full Harwell-Boeing format is supported. Supported
     features are:
-
-        - assembled, non-symmetric, real matrices
-        - integer for pointer/indices
-        - exponential format for float values, and int format
+    - assembled, non-symmetric, real matrices
+    - integer for pointer/indices
+    - exponential format for float values, and int format
 
     Examples
     --------

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -890,7 +890,7 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
     matrices.
 
     The matrix ``a`` is stored in `ab` either in lower diagonal or upper
-    diagonal ordered form:
+    diagonal ordered form::
 
         ab[u + i - j, j] == a[i,j]        (if upper form; i <= j)
         ab[    i - j, j] == a[i,j]        (if lower form; i >= j)
@@ -1197,15 +1197,8 @@ def solve_circulant(c, b, singular='raise', tol=None,
 
     Notes
     -----
-    For a 1-D vector `c` with length `m`, and an array `b`
-    with shape ``(m, ...)``,
-
-        solve_circulant(c, b)
-
-    returns the same result as
-
-        solve(circulant(c), b)
-
+    For a 1-D vector `c` with length `m`, and an array `b` with shape ``(m, ...)``,
+    ``solve_circulant(c, b)`` returns the same result as ``solve(circulant(c), b)``
     where `solve` and `circulant` are from `scipy.linalg`.
 
     .. versionadded:: 0.16.0

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -670,7 +670,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
         v.H v    = identity
 
     The matrix a is stored in a_band either in lower diagonal or upper
-    diagonal ordered form:
+    diagonal ordered form::
 
         a_band[u + i - j, j] == a[i,j]        (if upper form; i <= j)
         a_band[    i - j, j] == a[i,j]        (if lower form; i >= j)
@@ -1045,7 +1045,7 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
         v.H v    = identity
 
     The matrix a is stored in a_band either in lower diagonal or upper
-    diagonal ordered form:
+    diagonal ordered form::
 
         a_band[u + i - j, j] == a[i,j]        (if upper form; i <= j)
         a_band[    i - j, j] == a[i,j]        (if lower form; i >= j)

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -193,10 +193,10 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
         (alpha, beta). The eigenvalue ``x = (alpha/beta)``.  Alternatively,
         string parameters may be used:
 
-            - 'lhp'   Left-hand plane (x.real < 0.0)
-            - 'rhp'   Right-hand plane (x.real > 0.0)
-            - 'iuc'   Inside the unit circle (x*x.conjugate() < 1.0)
-            - 'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
+        - 'lhp'   Left-hand plane (x.real < 0.0)
+        - 'rhp'   Right-hand plane (x.real > 0.0)
+        - 'iuc'   Inside the unit circle (x*x.conjugate() < 1.0)
+        - 'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
 
         Defaults to None (no sorting).
     overwrite_a : bool, optional
@@ -341,10 +341,10 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
         complex. The callable must be able to accept a NumPy
         array. Alternatively, string parameters may be used:
 
-            - 'lhp'   Left-hand plane (x.real < 0.0)
-            - 'rhp'   Right-hand plane (x.real > 0.0)
-            - 'iuc'   Inside the unit circle (x*x.conjugate() < 1.0)
-            - 'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
+        - 'lhp'   Left-hand plane (x.real < 0.0)
+        - 'rhp'   Right-hand plane (x.real > 0.0)
+        - 'iuc'   Inside the unit circle (x*x.conjugate() < 1.0)
+        - 'ouc'   Outside the unit circle (x*x.conjugate() > 1.0)
 
         With the predefined sorting functions, an infinite eigenvalue
         (i.e., ``alpha != 0`` and ``beta = 0``) is considered to lie in

--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -351,11 +351,11 @@ def solve_continuous_are(a, b, q, r, e=None, s=None, balanced=True):
 
     The limitations for a solution to exist are :
 
-        * All eigenvalues of :math:`A` on the right half plane, should be
-          controllable.
+    * All eigenvalues of :math:`A` on the right half plane, should be
+      controllable.
 
-        * The associated hamiltonian pencil (See Notes), should have
-          eigenvalues sufficiently away from the imaginary axis.
+    * The associated hamiltonian pencil (See Notes), should have
+      eigenvalues sufficiently away from the imaginary axis.
 
     Moreover, if ``e`` or ``s`` is not precisely ``None``, then the
     generalized version of CARE
@@ -566,11 +566,11 @@ def solve_discrete_are(a, b, q, r, e=None, s=None, balanced=True):
 
     The limitations for a solution to exist are :
 
-        * All eigenvalues of :math:`A` outside the unit disc, should be
-          controllable.
+    * All eigenvalues of :math:`A` outside the unit disc, should be
+      controllable.
 
-        * The associated symplectic pencil (See Notes), should have
-          eigenvalues sufficiently away from the unit circle.
+    * The associated symplectic pencil (See Notes), should have
+      eigenvalues sufficiently away from the unit circle.
 
     Moreover, if ``e`` and ``s`` are not both precisely ``None``, then the
     generalized version of DARE

--- a/scipy/ndimage/_interpolation.py
+++ b/scipy/ndimage/_interpolation.py
@@ -502,18 +502,18 @@ def affine_transform(input, matrix, offset=0.0, output_shape=None,
         dimensions of ``input``, the given matrix must have one of the
         following shapes:
 
-            - ``(ndim, ndim)``: the linear transformation matrix for each
-              output coordinate.
-            - ``(ndim,)``: assume that the 2-D transformation matrix is
-              diagonal, with the diagonal specified by the given value. A more
-              efficient algorithm is then used that exploits the separability
-              of the problem.
-            - ``(ndim + 1, ndim + 1)``: assume that the transformation is
-              specified using homogeneous coordinates [1]_. In this case, any
-              value passed to ``offset`` is ignored.
-            - ``(ndim, ndim + 1)``: as above, but the bottom row of a
-              homogeneous transformation matrix is always ``[0, 0, ..., 1]``,
-              and may be omitted.
+        - ``(ndim, ndim)``: the linear transformation matrix for each
+          output coordinate.
+        - ``(ndim,)``: assume that the 2-D transformation matrix is
+          diagonal, with the diagonal specified by the given value. A more
+          efficient algorithm is then used that exploits the separability
+          of the problem.
+        - ``(ndim + 1, ndim + 1)``: assume that the transformation is
+          specified using homogeneous coordinates [1]_. In this case, any
+          value passed to ``offset`` is ignored.
+        - ``(ndim, ndim + 1)``: as above, but the bottom row of a
+          homogeneous transformation matrix is always ``[0, 0, ..., 1]``,
+          and may be omitted.
 
     offset : float or sequence, optional
         The offset into the array where the transform is applied. If a float,

--- a/scipy/optimize/_cobyla_py.py
+++ b/scipy/optimize/_cobyla_py.py
@@ -97,10 +97,10 @@ def fmin_cobyla(func, x0, cons, args=(), consargs=None, rhobeg=1.0,
     how these issues are resolved, as well as how the points v_i are
     updated, refer to the source code or the references below.
 
-        .. versionchanged:: 1.16.0
-            The original Powell implementation was replaced by a pure
-            Python version from the PRIMA package, with bug fixes and
-            improvements being made.
+    .. versionchanged:: 1.16.0
+        The original Powell implementation was replaced by a pure
+        Python version from the PRIMA package, with bug fixes and
+        improvements being made.
 
 
     References

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1548,39 +1548,36 @@ def zpk2sos(z, p, k, pairing=None, *, analog=False):
     1. Take the (next remaining) pole (complex or real) closest to the
        unit circle (or imaginary axis, for ``analog=True``) to
        begin a new filter section.
-
     2. If the pole is real and there are no other remaining real poles [#]_,
        add the closest real zero to the section and leave it as a first
        order section. Note that after this step we are guaranteed to be
        left with an even number of real poles, complex poles, real zeros,
        and complex zeros for subsequent pairing iterations.
-
     3. Else:
-
         1. If the pole is complex and the zero is the only remaining real
-           zero*, then pair the pole with the *next* closest zero
-           (guaranteed to be complex). This is necessary to ensure that
-           there will be a real zero remaining to eventually create a
-           first-order section (thus keeping the odd order).
+            zero*, then pair the pole with the *next* closest zero
+            (guaranteed to be complex). This is necessary to ensure that
+            there will be a real zero remaining to eventually create a
+            first-order section (thus keeping the odd order).
 
         2. Else pair the pole with the closest remaining zero (complex or
-           real).
+            real).
 
         3. Proceed to complete the second-order section by adding another
-           pole and zero to the current pole and zero in the section:
+            pole and zero to the current pole and zero in the section:
 
             1. If the current pole and zero are both complex, add their
-               conjugates.
+                conjugates.
 
             2. Else if the pole is complex and the zero is real, add the
-               conjugate pole and the next closest real zero.
+                conjugate pole and the next closest real zero.
 
             3. Else if the pole is real and the zero is complex, add the
-               conjugate zero and the real pole closest to those zeros.
+                conjugate zero and the real pole closest to those zeros.
 
             4. Else (we must have a real pole and real zero) add the next
-               real pole closest to the unit circle, and then add the real
-               zero closest to that pole.
+                real pole closest to the unit circle, and then add the real
+                zero closest to that pole.
 
     .. [#] This conditional can only be met for specific odd-order inputs
            with the ``pairing = 'keep_odd'`` or ``'minimal'`` methods.
@@ -2506,10 +2503,10 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
         `fs` is 2 half-cycles/sample, so these are normalized from 0 to 1,
         where 1 is the Nyquist frequency. For example:
 
-            - Lowpass:   wp = 0.2,          ws = 0.3
-            - Highpass:  wp = 0.3,          ws = 0.2
-            - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
-            - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
+        - Lowpass:   wp = 0.2,          ws = 0.3
+        - Highpass:  wp = 0.3,          ws = 0.2
+        - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
+        - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g., rad/s).
         Note, that for bandpass and bandstop filters passband must lie strictly
@@ -2526,17 +2523,17 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
     ftype : str, optional
         The type of IIR filter to design:
 
-            - Butterworth   : 'butter'
-            - Chebyshev I   : 'cheby1'
-            - Chebyshev II  : 'cheby2'
-            - Cauer/elliptic: 'ellip'
+        - Butterworth   : 'butter'
+        - Chebyshev I   : 'cheby1'
+        - Chebyshev II  : 'cheby2'
+        - Cauer/elliptic: 'ellip'
 
     output : {'ba', 'zpk', 'sos'}, optional
         Filter form of the output:
 
-            - second-order sections (recommended): 'sos'
-            - numerator/denominator (default)    : 'ba'
-            - pole-zero                          : 'zpk'
+        - second-order sections (recommended): 'sos'
+        - numerator/denominator (default)    : 'ba'
+        - pole-zero                          : 'zpk'
 
         In general the second-order sections ('sos') form  is
         recommended because inferring the coefficients for the
@@ -2703,18 +2700,18 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     ftype : str, optional
         The type of IIR filter to design:
 
-            - Butterworth   : 'butter'
-            - Chebyshev I   : 'cheby1'
-            - Chebyshev II  : 'cheby2'
-            - Cauer/elliptic: 'ellip'
-            - Bessel/Thomson: 'bessel'
+        - Butterworth   : 'butter'
+        - Chebyshev I   : 'cheby1'
+        - Chebyshev II  : 'cheby2'
+        - Cauer/elliptic: 'ellip'
+        - Bessel/Thomson: 'bessel'
 
     output : {'ba', 'zpk', 'sos'}, optional
         Filter form of the output:
 
-            - second-order sections (recommended): 'sos'
-            - numerator/denominator (default)    : 'ba'
-            - pole-zero                          : 'zpk'
+        - second-order sections (recommended): 'sos'
+        - numerator/denominator (default)    : 'ba'
+        - pole-zero                          : 'zpk'
 
         In general the second-order sections ('sos') form  is
         recommended because inferring the coefficients for the
@@ -4217,10 +4214,10 @@ def buttord(wp, ws, gpass, gstop, analog=False, fs=None):
         where 1 is the Nyquist frequency. (`wp` and `ws` are thus in
         half-cycles / sample.) For example:
 
-            - Lowpass:   wp = 0.2,          ws = 0.3
-            - Highpass:  wp = 0.3,          ws = 0.2
-            - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
-            - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
+        - Lowpass:   wp = 0.2,          ws = 0.3
+        - Highpass:  wp = 0.3,          ws = 0.2
+        - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
+        - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g., rad/s).
     gpass : float
@@ -4350,10 +4347,10 @@ def cheb1ord(wp, ws, gpass, gstop, analog=False, fs=None):
         where 1 is the Nyquist frequency. (`wp` and `ws` are thus in
         half-cycles / sample.)  For example:
 
-            - Lowpass:   wp = 0.2,          ws = 0.3
-            - Highpass:  wp = 0.3,          ws = 0.2
-            - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
-            - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
+        - Lowpass:   wp = 0.2,          ws = 0.3
+        - Highpass:  wp = 0.3,          ws = 0.2
+        - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
+        - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g., rad/s).
     gpass : float
@@ -4446,10 +4443,10 @@ def cheb2ord(wp, ws, gpass, gstop, analog=False, fs=None):
         where 1 is the Nyquist frequency. (`wp` and `ws` are thus in
         half-cycles / sample.)  For example:
 
-            - Lowpass:   wp = 0.2,          ws = 0.3
-            - Highpass:  wp = 0.3,          ws = 0.2
-            - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
-            - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
+        - Lowpass:   wp = 0.2,          ws = 0.3
+        - Highpass:  wp = 0.3,          ws = 0.2
+        - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
+        - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g., rad/s).
     gpass : float
@@ -4574,10 +4571,10 @@ def ellipord(wp, ws, gpass, gstop, analog=False, fs=None):
         where 1 is the Nyquist frequency. (`wp` and `ws` are thus in
         half-cycles / sample.) For example:
 
-            - Lowpass:   wp = 0.2,          ws = 0.3
-            - Highpass:  wp = 0.3,          ws = 0.2
-            - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
-            - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
+        - Lowpass:   wp = 0.2,          ws = 0.3
+        - Highpass:  wp = 0.3,          ws = 0.2
+        - Bandpass:  wp = [0.2, 0.5],   ws = [0.1, 0.6]
+        - Bandstop:  wp = [0.1, 0.6],   ws = [0.2, 0.5]
 
         For analog filters, `wp` and `ws` are angular frequencies (e.g., rad/s).
     gpass : float

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1554,30 +1554,24 @@ def zpk2sos(z, p, k, pairing=None, *, analog=False):
        left with an even number of real poles, complex poles, real zeros,
        and complex zeros for subsequent pairing iterations.
     3. Else:
-        1. If the pole is complex and the zero is the only remaining real
-            zero*, then pair the pole with the *next* closest zero
-            (guaranteed to be complex). This is necessary to ensure that
-            there will be a real zero remaining to eventually create a
-            first-order section (thus keeping the odd order).
 
-        2. Else pair the pole with the closest remaining zero (complex or
-            real).
+       1. If the pole is complex and the zero is the only remaining real
+          zero*, then pair the pole with the *next* closest zero
+          (guaranteed to be complex). This is necessary to ensure that
+          there will be a real zero remaining to eventually create a
+          first-order section (thus keeping the odd order).
+       2. Else pair the pole with the closest remaining zero (complex or real).
+       3. Proceed to complete the second-order section by adding another
+          pole and zero to the current pole and zero in the section:
 
-        3. Proceed to complete the second-order section by adding another
-            pole and zero to the current pole and zero in the section:
-
-            1. If the current pole and zero are both complex, add their
-                conjugates.
-
-            2. Else if the pole is complex and the zero is real, add the
-                conjugate pole and the next closest real zero.
-
-            3. Else if the pole is real and the zero is complex, add the
-                conjugate zero and the real pole closest to those zeros.
-
-            4. Else (we must have a real pole and real zero) add the next
-                real pole closest to the unit circle, and then add the real
-                zero closest to that pole.
+          1. If the current pole and zero are both complex, add their conjugates.
+          2. Else if the pole is complex and the zero is real, add the
+             conjugate pole and the next closest real zero.
+          3. Else if the pole is real and the zero is complex, add the
+             conjugate zero and the real pole closest to those zeros.
+          4. Else (we must have a real pole and real zero) add the next
+             real pole closest to the unit circle, and then add the real
+             zero closest to that pole.
 
     .. [#] This conditional can only be met for specific odd-order inputs
            with the ``pairing = 'keep_odd'`` or ``'minimal'`` methods.

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -805,13 +805,10 @@ def remez(numtaps, bands, desired, *, weight=None, type='bandpass',
     type : {'bandpass', 'differentiator', 'hilbert'}, optional
         The type of filter:
 
-          * 'bandpass' : flat response in bands. This is the default.
-
-          * 'differentiator' : frequency proportional response in bands.
-
-          * 'hilbert' : filter with odd symmetry, that is, type III
-                        (for even order) or type IV (for odd order)
-                        linear phase filters.
+        * 'bandpass' : flat response in bands. This is the default.
+        * 'differentiator' : frequency proportional response in bands.
+        * 'hilbert' : filter with odd symmetry, that is, type III
+          (for even order) or type IV (for odd order) linear phase filters.
 
     maxiter : int, optional
         Maximum number of iterations of the algorithm. Default is 25.
@@ -1006,11 +1003,11 @@ def firls(numtaps, bands, desired, *, weight=None, fs=None):
     This implementation follows the algorithm given in [1]_.
     As noted there, least squares design has multiple advantages:
 
-        1. Optimal in a least-squares sense.
-        2. Simple, non-iterative method.
-        3. The general solution can obtained by solving a linear
-           system of equations.
-        4. Allows the use of a frequency dependent weighting function.
+    1. Optimal in a least-squares sense.
+    2. Simple, non-iterative method.
+    3. The general solution can obtained by solving a linear
+       system of equations.
+    4. Allows the use of a frequency dependent weighting function.
 
     This function constructs a Type I linear phase FIR filter, which
     contains an odd number of `coeffs` satisfying for :math:`n < numtaps`:
@@ -1209,19 +1206,18 @@ def minimum_phase(h,
     method : {'hilbert', 'homomorphic'}
         The provided methods are:
 
-            'homomorphic' (default)
-                This method [4]_ [5]_ works best with filters with an
-                odd number of taps, and the resulting minimum phase filter
-                will have a magnitude response that approximates the square
-                root of the original filter's magnitude response using half
-                the number of taps when ``half=True`` (default), or the
-                original magnitude spectrum using the same number of taps
-                when ``half=False``.
-
-            'hilbert'
-                This method [1]_ is designed to be used with equiripple
-                filters (e.g., from `remez`) with unity or zero gain
-                regions.
+        - 'homomorphic' (default):
+          This method [4]_ [5]_ works best with filters with an
+          odd number of taps, and the resulting minimum phase filter
+          will have a magnitude response that approximates the square
+          root of the original filter's magnitude response using half
+          the number of taps when ``half=True`` (default), or the
+          original magnitude spectrum using the same number of taps
+          when ``half=False``.
+        - 'hilbert'
+          This method [1]_ is designed to be used with equiripple
+          filters (e.g., from `remez`) with unity or zero gain
+          regions.
 
     n_fft : int
         The number of points to use for the FFT. Should be at least a

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -391,23 +391,23 @@ def cont2discrete(system, dt, method="zoh", alpha=None):
         The following gives the number of elements in the tuple and
         the interpretation:
 
-            * 1: (instance of `lti`)
-            * 2: (num, den)
-            * 3: (zeros, poles, gain)
-            * 4: (A, B, C, D)
+        * 1: (instance of `lti`)
+        * 2: (num, den)
+        * 3: (zeros, poles, gain)
+        * 4: (A, B, C, D)
 
     dt : float
         The discretization time step.
     method : str, optional
         Which method to use:
 
-            * gbt: generalized bilinear transformation
-            * bilinear: Tustin's approximation ("gbt" with alpha=0.5)
-            * euler: Euler (or forward differencing) method ("gbt" with alpha=0)
-            * backward_diff: Backwards differencing ("gbt" with alpha=1.0)
-            * zoh: zero-order hold (default)
-            * foh: first-order hold (*versionadded: 1.3.0*)
-            * impulse: equivalent impulse response (*versionadded: 1.3.0*)
+        * gbt: generalized bilinear transformation
+        * bilinear: Tustin's approximation ("gbt" with alpha=0.5)
+        * euler: Euler (or forward differencing) method ("gbt" with alpha=0)
+        * backward_diff: Backwards differencing ("gbt" with alpha=1.0)
+        * zoh: zero-order hold (default)
+        * foh: first-order hold (*versionadded: 1.3.0*)
+        * impulse: equivalent impulse response (*versionadded: 1.3.0*)
 
     alpha : float within [0, 1], optional
         The generalized bilinear transformation weighting parameter, which

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -144,9 +144,9 @@ class lti(LinearTimeInvariant):
         The following gives the number of arguments and the corresponding
         continuous-time subclass that is created:
 
-            * 2: `TransferFunction`:  (numerator, denominator)
-            * 3: `ZerosPolesGain`: (zeros, poles, gain)
-            * 4: `StateSpace`:  (A, B, C, D)
+        * 2: `TransferFunction`:  (numerator, denominator)
+        * 3: `ZerosPolesGain`: (zeros, poles, gain)
+        * 4: `StateSpace`:  (A, B, C, D)
 
         Each argument can be an array or a sequence.
 
@@ -311,9 +311,9 @@ class dlti(LinearTimeInvariant):
         The following gives the number of arguments and the corresponding
         discrete-time subclass that is created:
 
-            * 2: `TransferFunction`:  (numerator, denominator)
-            * 3: `ZerosPolesGain`: (zeros, poles, gain)
-            * 4: `StateSpace`:  (A, B, C, D)
+        * 2: `TransferFunction`:  (numerator, denominator)
+        * 3: `ZerosPolesGain`: (zeros, poles, gain)
+        * 4: `StateSpace`:  (A, B, C, D)
 
         Each argument can be an array or a sequence.
     dt: float, optional
@@ -511,9 +511,9 @@ class TransferFunction(LinearTimeInvariant):
         arguments. The following gives the number of input arguments and their
         interpretation:
 
-            * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
-              `ZerosPolesGain`)
-            * 2: array_like: (numerator, denominator)
+        * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
+           `ZerosPolesGain`)
+        * 2: array_like: (numerator, denominator)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `None`
         (continuous-time). Must be specified as a keyword argument, for
@@ -756,9 +756,8 @@ class TransferFunctionContinuous(TransferFunction, lti):
         arguments. The following gives the number of input arguments and their
         interpretation:
 
-            * 1: `lti` system: (`StateSpace`, `TransferFunction` or
-              `ZerosPolesGain`)
-            * 2: array_like: (numerator, denominator)
+        * 1: `lti` system: (`StateSpace`, `TransferFunction` or `ZerosPolesGain`)
+        * 2: array_like: (numerator, denominator)
 
     See Also
     --------
@@ -833,9 +832,8 @@ class TransferFunctionDiscrete(TransferFunction, dlti):
         arguments. The following gives the number of input arguments and their
         interpretation:
 
-            * 1: `dlti` system: (`StateSpace`, `TransferFunction` or
-              `ZerosPolesGain`)
-            * 2: array_like: (numerator, denominator)
+        * 1: `dlti` system: (`StateSpace`, `TransferFunction` or `ZerosPolesGain`)
+        * 2: array_like: (numerator, denominator)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `True`
         (unspecified sampling time). Must be specified as a keyword argument,
@@ -898,9 +896,9 @@ class ZerosPolesGain(LinearTimeInvariant):
         arguments. The following gives the number of input arguments and their
         interpretation:
 
-            * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
-              `ZerosPolesGain`)
-            * 3: array_like: (zeros, poles, gain)
+        * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
+          `ZerosPolesGain`)
+        * 3: array_like: (zeros, poles, gain)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `None`
         (continuous-time). Must be specified as a keyword argument, for
@@ -1099,9 +1097,8 @@ class ZerosPolesGainContinuous(ZerosPolesGain, lti):
         arguments. The following gives the number of input arguments and their
         interpretation:
 
-            * 1: `lti` system: (`StateSpace`, `TransferFunction` or
-              `ZerosPolesGain`)
-            * 3: array_like: (zeros, poles, gain)
+        * 1: `lti` system: (`StateSpace`, `TransferFunction` or `ZerosPolesGain`)
+        * 3: array_like: (zeros, poles, gain)
 
     See Also
     --------
@@ -1169,9 +1166,8 @@ class ZerosPolesGainDiscrete(ZerosPolesGain, dlti):
         arguments. The following gives the number of input arguments and their
         interpretation:
 
-            * 1: `dlti` system: (`StateSpace`, `TransferFunction` or
-              `ZerosPolesGain`)
-            * 3: array_like: (zeros, poles, gain)
+        * 1: `dlti` system: (`StateSpace`, `TransferFunction` or `ZerosPolesGain`)
+        * 3: array_like: (zeros, poles, gain)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `True`
         (unspecified sampling time). Must be specified as a keyword argument,
@@ -1239,9 +1235,9 @@ class StateSpace(LinearTimeInvariant):
         The following gives the number of input arguments and their
         interpretation:
 
-            * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
-              `ZerosPolesGain`)
-            * 4: array_like: (A, B, C, D)
+        * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
+            `ZerosPolesGain`)
+        * 4: array_like: (A, B, C, D)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `None`
         (continuous-time). Must be specified as a keyword argument, for
@@ -1654,9 +1650,9 @@ class StateSpaceContinuous(StateSpace, lti):
         The following gives the number of input arguments and their
         interpretation:
 
-            * 1: `lti` system: (`StateSpace`, `TransferFunction` or
-              `ZerosPolesGain`)
-            * 4: array_like: (A, B, C, D)
+        * 1: `lti` system: (`StateSpace`, `TransferFunction` or
+            `ZerosPolesGain`)
+        * 4: array_like: (A, B, C, D)
 
     See Also
     --------
@@ -1728,9 +1724,9 @@ class StateSpaceDiscrete(StateSpace, dlti):
         The following gives the number of input arguments and their
         interpretation:
 
-            * 1: `dlti` system: (`StateSpace`, `TransferFunction` or
-              `ZerosPolesGain`)
-            * 4: array_like: (A, B, C, D)
+        * 1: `dlti` system: (`StateSpace`, `TransferFunction` or
+            `ZerosPolesGain`)
+        * 4: array_like: (A, B, C, D)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `True`
         (unspecified sampling time). Must be specified as a keyword argument,
@@ -2030,10 +2026,10 @@ def impulse(system, X0=None, T=None, N=None):
         The following gives the number of elements in the tuple and
         the interpretation:
 
-            * 1 (instance of `lti`)
-            * 2 (num, den)
-            * 3 (zeros, poles, gain)
-            * 4 (A, B, C, D)
+        * 1 (instance of `lti`)
+        * 2 (num, den)
+        * 3 (zeros, poles, gain)
+        * 4 (A, B, C, D)
 
     X0 : array_like, optional
         Initial state-vector.  Defaults to zero.
@@ -2100,10 +2096,10 @@ def step(system, X0=None, T=None, N=None):
         The following gives the number of elements in the tuple and
         the interpretation:
 
-            * 1 (instance of `lti`)
-            * 2 (num, den)
-            * 3 (zeros, poles, gain)
-            * 4 (A, B, C, D)
+        * 1 (instance of `lti`)
+        * 2 (num, den)
+        * 3 (zeros, poles, gain)
+        * 4 (A, B, C, D)
 
     X0 : array_like, optional
         Initial state-vector (default is zero).
@@ -2167,10 +2163,10 @@ def bode(system, w=None, n=100):
         The following gives the number of elements in the tuple and
         the interpretation:
 
-            * 1 (instance of `lti`)
-            * 2 (num, den)
-            * 3 (zeros, poles, gain)
-            * 4 (A, B, C, D)
+        * 1 (instance of `lti`)
+        * 2 (num, den)
+        * 3 (zeros, poles, gain)
+        * 4 (A, B, C, D)
 
     w : array_like, optional
         Array of frequencies (in rad/s). Magnitude and phase data is calculated
@@ -2230,10 +2226,10 @@ def freqresp(system, w=None, n=10000):
         The following gives the number of elements in the tuple and
         the interpretation:
 
-            * 1 (instance of `lti`)
-            * 2 (num, den)
-            * 3 (zeros, poles, gain)
-            * 4 (A, B, C, D)
+        * 1 (instance of `lti`)
+        * 2 (num, den)
+        * 3 (zeros, poles, gain)
+        * 4 (A, B, C, D)
 
     w : array_like, optional
         Array of frequencies (in rad/s). Magnitude and phase data is
@@ -2718,8 +2714,8 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
     method: {'YT', 'KNV0'}, optional
         Which method to choose to find the gain matrix K. One of:
 
-            - 'YT': Yang Tits
-            - 'KNV0': Kautsky, Nichols, Van Dooren update method 0
+        - 'YT': Yang Tits
+        - 'KNV0': Kautsky, Nichols, Van Dooren update method 0
 
         See References and Notes for details on the algorithms.
     rtol: float, optional

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -512,7 +512,7 @@ class TransferFunction(LinearTimeInvariant):
         interpretation:
 
         * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
-           `ZerosPolesGain`)
+             `ZerosPolesGain`)
         * 2: array_like: (numerator, denominator)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `None`
@@ -1236,7 +1236,7 @@ class StateSpace(LinearTimeInvariant):
         interpretation:
 
         * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
-            `ZerosPolesGain`)
+             `ZerosPolesGain`)
         * 4: array_like: (A, B, C, D)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `None`
@@ -1650,8 +1650,7 @@ class StateSpaceContinuous(StateSpace, lti):
         The following gives the number of input arguments and their
         interpretation:
 
-        * 1: `lti` system: (`StateSpace`, `TransferFunction` or
-            `ZerosPolesGain`)
+        * 1: `lti` system: (`StateSpace`, `TransferFunction` or `ZerosPolesGain`)
         * 4: array_like: (A, B, C, D)
 
     See Also
@@ -1724,8 +1723,7 @@ class StateSpaceDiscrete(StateSpace, dlti):
         The following gives the number of input arguments and their
         interpretation:
 
-        * 1: `dlti` system: (`StateSpace`, `TransferFunction` or
-            `ZerosPolesGain`)
+        * 1: `dlti` system: (`StateSpace`, `TransferFunction` or `ZerosPolesGain`)
         * 4: array_like: (A, B, C, D)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `True`

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -512,7 +512,7 @@ class TransferFunction(LinearTimeInvariant):
         interpretation:
 
         * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
-             `ZerosPolesGain`)
+          `ZerosPolesGain`)
         * 2: array_like: (numerator, denominator)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `None`
@@ -1236,7 +1236,7 @@ class StateSpace(LinearTimeInvariant):
         interpretation:
 
         * 1: `lti` or `dlti` system: (`StateSpace`, `TransferFunction` or
-             `ZerosPolesGain`)
+          `ZerosPolesGain`)
         * 4: array_like: (A, B, C, D)
     dt: float, optional
         Sampling time [s] of the discrete-time systems. Defaults to `None`

--- a/scipy/signal/_savitzky_golay.py
+++ b/scipy/signal/_savitzky_golay.py
@@ -307,15 +307,15 @@ def savgol_filter(x, window_length, polyorder, deriv=0, delta=1.0,
     -----
     Details on the `mode` options:
 
-        'mirror':
-            Repeats the values at the edges in reverse order. The value
-            closest to the edge is not included.
-        'nearest':
-            The extension contains the nearest input value.
-        'constant':
-            The extension contains the value given by the `cval` argument.
-        'wrap':
-            The extension contains the values from the other end of the array.
+    - 'mirror':
+      Repeats the values at the edges in reverse order. The value
+      closest to the edge is not included.
+    - 'nearest':
+      The extension contains the nearest input value.
+    - 'constant':
+      The extension contains the value given by the `cval` argument.
+    - 'wrap':
+      The extension contains the values from the other end of the array.
 
     For example, if the input is [1, 2, 3, 4, 5, 6, 7, 8], and
     `window_length` is 7, the following shows the extended data for

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3039,9 +3039,9 @@ def unique_roots(p, tol=1e-3, rtype='min'):
         How to determine the returned root if multiple roots are within
         `tol` of each other.
 
-          - 'max', 'maximum': pick the maximum of those roots
-          - 'min', 'minimum': pick the minimum of those roots
-          - 'avg', 'mean': take the average of those roots
+        - 'max', 'maximum': pick the maximum of those roots
+        - 'min', 'minimum': pick the minimum of those roots
+        - 'avg', 'mean': take the average of those roots
 
         When finding minimum or maximum among complex roots they are compared
         first by the real part and then by the imaginary part.

--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -528,7 +528,7 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
 
     `dx` is the old sample-spacing while `x0` was the old origin. In
     other-words the old-sample points (knot-points) for which the `cj`
-    represent spline coefficients were at equally-spaced points of:
+    represent spline coefficients were at equally-spaced points of::
 
       oldx = x0 + j*dx  j=0...N-1, with N=len(cj)
 

--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -150,9 +150,9 @@ def square(t, duty=0.5):
 def gausspulse(t, fc=1000, bw=0.5, bwr=-6, tpr=-60, retquad=False,
                retenv=False):
     """
-    Return a Gaussian modulated sinusoid:
+    Return a Gaussian modulated sinusoid::
 
-        ``exp(-a t^2) exp(1j*2*pi*fc*t).``
+        exp(-a t^2) exp(1j*2*pi*fc*t)
 
     If `retquad` is True, then return the real and imaginary parts
     (in-phase and quadrature).
@@ -482,14 +482,14 @@ def sweep_poly(t, poly, phi=0):
         The desired frequency expressed as a polynomial.  If `poly` is
         a list or ndarray of length n, then the elements of `poly` are
         the coefficients of the polynomial, and the instantaneous
-        frequency is
+        frequency is::
 
-          ``f(t) = poly[0]*t**(n-1) + poly[1]*t**(n-2) + ... + poly[n-1]``
+            f(t) = poly[0]*t**(n-1) + poly[1]*t**(n-2) + ... + poly[n-1]
 
         If `poly` is an instance of numpy.poly1d, then the
-        instantaneous frequency is
+        instantaneous frequency is::
 
-          ``f(t) = poly(t)``
+            f(t) = poly(t)
 
     phi : float, optional
         Phase offset, in degrees, Default: 0.

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -183,13 +183,13 @@ Usage information
 
 There are seven available sparse array types:
 
-    1. csc_array: Compressed Sparse Column format
-    2. csr_array: Compressed Sparse Row format
-    3. bsr_array: Block Sparse Row format
-    4. lil_array: List of Lists format
-    5. dok_array: Dictionary of Keys format
-    6. coo_array: COOrdinate format (aka IJV, triplet format)
-    7. dia_array: DIAgonal format
+1. csc_array: Compressed Sparse Column format
+2. csr_array: Compressed Sparse Row format
+3. bsr_array: Block Sparse Row format
+4. lil_array: List of Lists format
+5. dok_array: Dictionary of Keys format
+6. coo_array: COOrdinate format (aka IJV, triplet format)
+7. dia_array: DIAgonal format
 
 To construct an array efficiently, use any of `coo_array`,
 `dok_array` or `lil_array`. `dok_array` and `lil_array`

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -66,32 +66,32 @@ def shortest_path(csgraph, method='auto',
     method : string ['auto'|'FW'|'D'], optional
         Algorithm to use for shortest paths.  Options are:
 
-           'auto' -- (default) select the best among 'FW', 'D', 'BF', or 'J'
-                     based on the input data.
+        'auto' -- (default) select the best among 'FW', 'D', 'BF', or 'J'
+                    based on the input data.
 
-           'FW'   -- Floyd-Warshall algorithm.
-                     Computational cost is approximately ``O[N^3]``.
-                     The input csgraph will be converted to a dense representation.
+        'FW'   -- Floyd-Warshall algorithm.
+                    Computational cost is approximately ``O[N^3]``.
+                    The input csgraph will be converted to a dense representation.
 
-           'D'    -- Dijkstra's algorithm with priority queue.
-                     Computational cost is approximately ``O[I * (E + N) * log(N)]``,
-                     where ``E`` is the number of edges in the graph,
-                     and ``I = len(indices)`` if ``indices`` is passed. Otherwise,
-                     ``I = N``.
-                     The input csgraph will be converted to a csr representation.
+        'D'    -- Dijkstra's algorithm with priority queue.
+                    Computational cost is approximately ``O[I * (E + N) * log(N)]``,
+                    where ``E`` is the number of edges in the graph,
+                    and ``I = len(indices)`` if ``indices`` is passed. Otherwise,
+                    ``I = N``.
+                    The input csgraph will be converted to a csr representation.
 
-           'BF'   -- Bellman-Ford algorithm.
-                     This algorithm can be used when weights are negative.
-                     If a negative cycle is encountered, an error will be raised.
-                     Computational cost is approximately ``O[N(N^2 k)]``, where
-                     ``k`` is the average number of connected edges per node.
-                     The input csgraph will be converted to a csr representation.
+        'BF'   -- Bellman-Ford algorithm.
+                    This algorithm can be used when weights are negative.
+                    If a negative cycle is encountered, an error will be raised.
+                    Computational cost is approximately ``O[N(N^2 k)]``, where
+                    ``k`` is the average number of connected edges per node.
+                    The input csgraph will be converted to a csr representation.
 
-           'J'    -- Johnson's algorithm.
-                     Like the Bellman-Ford algorithm, Johnson's algorithm is
-                     designed for use when the weights are negative. It combines
-                     the Bellman-Ford algorithm with Dijkstra's algorithm for
-                     faster computation.
+        'J'    -- Johnson's algorithm.
+                    Like the Bellman-Ford algorithm, Johnson's algorithm is
+                    designed for use when the weights are negative. It combines
+                    the Bellman-Ford algorithm with Dijkstra's algorithm for
+                    faster computation.
 
     directed : bool, optional
         If True (default), then find the shortest path on a directed graph:

--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -67,31 +67,27 @@ def shortest_path(csgraph, method='auto',
         Algorithm to use for shortest paths.  Options are:
 
         'auto' -- (default) select the best among 'FW', 'D', 'BF', or 'J'
-                    based on the input data.
-
+                  based on the input data.
         'FW'   -- Floyd-Warshall algorithm.
-                    Computational cost is approximately ``O[N^3]``.
-                    The input csgraph will be converted to a dense representation.
-
+                  Computational cost is approximately ``O[N^3]``.
+                  The input csgraph will be converted to a dense representation.
         'D'    -- Dijkstra's algorithm with priority queue.
-                    Computational cost is approximately ``O[I * (E + N) * log(N)]``,
-                    where ``E`` is the number of edges in the graph,
-                    and ``I = len(indices)`` if ``indices`` is passed. Otherwise,
-                    ``I = N``.
-                    The input csgraph will be converted to a csr representation.
-
+                  Computational cost is approximately ``O[I * (E + N) * log(N)]``,
+                  where ``E`` is the number of edges in the graph,
+                  and ``I = len(indices)`` if ``indices`` is passed. Otherwise,
+                  ``I = N``.
+                  The input csgraph will be converted to a csr representation.
         'BF'   -- Bellman-Ford algorithm.
-                    This algorithm can be used when weights are negative.
-                    If a negative cycle is encountered, an error will be raised.
-                    Computational cost is approximately ``O[N(N^2 k)]``, where
-                    ``k`` is the average number of connected edges per node.
-                    The input csgraph will be converted to a csr representation.
-
+                  This algorithm can be used when weights are negative.
+                  If a negative cycle is encountered, an error will be raised.
+                  Computational cost is approximately ``O[N(N^2 k)]``, where
+                  ``k`` is the average number of connected edges per node.
+                  The input csgraph will be converted to a csr representation.
         'J'    -- Johnson's algorithm.
-                    Like the Bellman-Ford algorithm, Johnson's algorithm is
-                    designed for use when the weights are negative. It combines
-                    the Bellman-Ford algorithm with Dijkstra's algorithm for
-                    faster computation.
+                  Like the Bellman-Ford algorithm, Johnson's algorithm is
+                  designed for use when the weights are negative. It combines
+                  the Bellman-Ford algorithm with Dijkstra's algorithm for
+                  faster computation.
 
     directed : bool, optional
         If True (default), then find the shortest path on a directed graph:

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1538,17 +1538,22 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         The sort order is also dependent on the `which` variable.
 
         - For which = 'LM' or 'SA':
-            - If `return_eigenvectors` is True, eigenvalues are sorted by
-              algebraic value.
-            - If `return_eigenvectors` is False, eigenvalues are sorted by
-              absolute value.
+
+          - If `return_eigenvectors` is True, eigenvalues are sorted by
+            algebraic value.
+          - If `return_eigenvectors` is False, eigenvalues are sorted by
+            absolute value.
+
         - For which = 'BE' or 'LA':
-            - eigenvalues are always sorted by algebraic value.
+
+          - eigenvalues are always sorted by algebraic value.
+
         - For which = 'SM':
-            - If `return_eigenvectors` is True, eigenvalues are sorted by
-              algebraic value.
-            - If `return_eigenvectors` is False, eigenvalues are sorted by
-              decreasing absolute value.
+
+          - If `return_eigenvectors` is True, eigenvalues are sorted by
+            algebraic value.
+          - If `return_eigenvectors` is False, eigenvalues are sorted by
+            decreasing absolute value.
 
     mode : string ['normal' | 'buckling' | 'cayley']
         Specify strategy to use for shift-invert mode.  This argument applies
@@ -1580,7 +1585,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
 
         The choice of mode will affect which eigenvalues are selected by
         the keyword 'which', and can also impact the stability of
-        convergence (see [2] for a discussion).
+        convergence (see [2]_ for a discussion).
     rng : `numpy.random.Generator`, optional
         Pseudorandom number generator state. When `rng` is None, a new
         `numpy.random.Generator` is created using entropy from the

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1191,7 +1191,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         eigenvectors of a matrix.
     M : ndarray, sparse matrix or LinearOperator, optional
         An array, sparse matrix, or LinearOperator representing
-        the operation M@x for the generalized eigenvalue problem
+        the operation M@x for the generalized eigenvalue problem::
 
             A @ x = w * M @ x.
 
@@ -1199,10 +1199,8 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         represent a complex Hermitian matrix if A is complex. For best
         results, the data type of M should be the same as that of A.
         Additionally:
-
-            If `sigma` is None, M is positive definite
-
-            If sigma is specified, M is positive semi-definite
+        - If `sigma` is None, M is positive definite
+        - If `sigma` is specified, M is positive semi-definite
 
         If sigma is None, eigs requires an operator to compute the solution
         of the linear equation ``M @ x = b``.  This is done internally via a
@@ -1224,13 +1222,11 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         Note that when sigma is specified, the keyword 'which' (below)
         refers to the shifted eigenvalues ``w'[i]`` where:
 
-            If A is real and OPpart == 'r' (default),
-              ``w'[i] = 1/2 * [1/(w[i]-sigma) + 1/(w[i]-conj(sigma))]``.
-
-            If A is real and OPpart == 'i',
-              ``w'[i] = 1/2i * [1/(w[i]-sigma) - 1/(w[i]-conj(sigma))]``.
-
-            If A is complex, ``w'[i] = 1/(w[i]-sigma)``.
+        - If A is real and OPpart == 'r' (default),
+          ``w'[i] = 1/2 * [1/(w[i]-sigma) + 1/(w[i]-conj(sigma))]``.
+        - If A is real and OPpart == 'i',
+          ``w'[i] = 1/2i * [1/(w[i]-sigma) - 1/(w[i]-conj(sigma))]``.
+        - If A is complex, ``w'[i] = 1/(w[i]-sigma)``.
 
     v0 : ndarray, optional
         Starting vector for iteration.
@@ -1242,17 +1238,12 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
     which : str, ['LM' | 'SM' | 'LR' | 'SR' | 'LI' | 'SI'], optional
         Which `k` eigenvectors and eigenvalues to find:
 
-            'LM' : largest magnitude
-
-            'SM' : smallest magnitude
-
-            'LR' : largest real part
-
-            'SR' : smallest real part
-
-            'LI' : largest imaginary part
-
-            'SI' : smallest imaginary part
+        - 'LM' : largest magnitude
+        - 'SM' : smallest magnitude
+        - 'LR' : largest real part
+        - 'SR' : smallest real part
+        - 'LI' : largest imaginary part
+        - 'SI' : smallest imaginary part
 
         When sigma != None, 'which' refers to the shifted eigenvalues w'[i]
         (see discussion in 'sigma', above).  ARPACK is generally better
@@ -1470,7 +1461,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
     Other Parameters
     ----------------
     M : An N x N matrix, array, sparse matrix, or linear operator representing
-        the operation ``M @ x`` for the generalized eigenvalue problem
+        the operation ``M @ x`` for the generalized eigenvalue problem::
 
             A @ x = w * M @ x.
 
@@ -1479,11 +1470,9 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         results, the data type of M should be the same as that of A.
         Additionally:
 
-            If sigma is None, M is symmetric positive definite.
-
-            If sigma is specified, M is symmetric positive semi-definite.
-
-            In buckling mode, M is symmetric indefinite.
+        - If sigma is None, M is symmetric positive definite.
+        - If sigma is specified, M is symmetric positive semi-definite.
+        - In buckling mode, M is symmetric indefinite.
 
         If sigma is None, eigsh requires an operator to compute the solution
         of the linear equation ``M @ x = b``. This is done internally via a
@@ -1506,11 +1495,9 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         Note that when sigma is specified, the keyword 'which' refers to
         the shifted eigenvalues ``w'[i]`` where:
 
-            if ``mode == 'normal'``: ``w'[i] = 1 / (w[i] - sigma)``.
-
-            if ``mode == 'cayley'``:  ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
-
-            if ``mode == 'buckling'``: ``w'[i] = w[i] / (w[i] - sigma)``.
+        - if ``mode == 'normal'``: ``w'[i] = 1 / (w[i] - sigma)``.
+        - if ``mode == 'cayley'``:  ``w'[i] = (w[i] + sigma) / (w[i] - sigma)``.
+        - if ``mode == 'buckling'``: ``w'[i] = w[i] / (w[i] - sigma)``.
 
         (see further discussion in 'mode' below)
     v0 : ndarray, optional
@@ -1524,15 +1511,11 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         If A is a complex Hermitian matrix, 'BE' is invalid.
         Which `k` eigenvectors and eigenvalues to find:
 
-            'LM' : Largest (in magnitude) eigenvalues.
-
-            'SM' : Smallest (in magnitude) eigenvalues.
-
-            'LA' : Largest (algebraic) eigenvalues.
-
-            'SA' : Smallest (algebraic) eigenvalues.
-
-            'BE' : Half (k/2) from each end of the spectrum.
+        - 'LM' : Largest (in magnitude) eigenvalues.
+        - 'SM' : Smallest (in magnitude) eigenvalues.
+        - 'LA' : Largest (algebraic) eigenvalues.
+        - 'SA' : Smallest (algebraic) eigenvalues.
+        - 'BE' : Half (k/2) from each end of the spectrum.
 
         When k is odd, return one more (k/2+1) from the high end.
         When sigma != None, 'which' refers to the shifted eigenvalues ``w'[i]``
@@ -1554,22 +1537,18 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         This value determines the order in which eigenvalues are sorted.
         The sort order is also dependent on the `which` variable.
 
-            For which = 'LM' or 'SA':
-                If `return_eigenvectors` is True, eigenvalues are sorted by
-                algebraic value.
-
-                If `return_eigenvectors` is False, eigenvalues are sorted by
-                absolute value.
-
-            For which = 'BE' or 'LA':
-                eigenvalues are always sorted by algebraic value.
-
-            For which = 'SM':
-                If `return_eigenvectors` is True, eigenvalues are sorted by
-                algebraic value.
-
-                If `return_eigenvectors` is False, eigenvalues are sorted by
-                decreasing absolute value.
+        - For which = 'LM' or 'SA':
+            - If `return_eigenvectors` is True, eigenvalues are sorted by
+              algebraic value.
+            - If `return_eigenvectors` is False, eigenvalues are sorted by
+              absolute value.
+        - For which = 'BE' or 'LA':
+            - eigenvalues are always sorted by algebraic value.
+        - For which = 'SM':
+            - If `return_eigenvectors` is True, eigenvalues are sorted by
+              algebraic value.
+            - If `return_eigenvectors` is False, eigenvalues are sorted by
+              decreasing absolute value.
 
     mode : string ['normal' | 'buckling' | 'cayley']
         Specify strategy to use for shift-invert mode.  This argument applies
@@ -1581,20 +1560,23 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
         ``A @ x[i] = w[i] * M @ x[i]``.
         The modes are as follows:
 
-            'normal' :
-                OP = [A - sigma * M]^-1 @ M,
-                B = M,
-                w'[i] = 1 / (w[i] - sigma)
+        - 'normal'::
 
-            'buckling' :
-                OP = [A - sigma * M]^-1 @ A,
-                B = A,
-                w'[i] = w[i] / (w[i] - sigma)
+            OP = [A - sigma * M]^-1 @ M,
+            B = M,
+            w'[i] = 1 / (w[i] - sigma)
 
-            'cayley' :
-                OP = [A - sigma * M]^-1 @ [A + sigma * M],
-                B = M,
-                w'[i] = (w[i] + sigma) / (w[i] - sigma)
+        -'buckling'::
+
+            OP = [A - sigma * M]^-1 @ A,
+            B = A,
+            w'[i] = w[i] / (w[i] - sigma)
+
+        - 'cayley'::
+
+            OP = [A - sigma * M]^-1 @ [A + sigma * M],
+            B = M,
+            w'[i] = (w[i] + sigma) / (w[i] - sigma)
 
         The choice of mode will affect which eigenvalues are selected by
         the keyword 'which', and can also impact the stability of

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -1199,6 +1199,7 @@ def eigs(A, k=6, M=None, sigma=None, which='LM', v0=None,
         represent a complex Hermitian matrix if A is complex. For best
         results, the data type of M should be the same as that of A.
         Additionally:
+
         - If `sigma` is None, M is positive definite
         - If `sigma` is specified, M is positive semi-definite
 
@@ -1571,7 +1572,7 @@ def eigsh(A, k=6, M=None, sigma=None, which='LM', v0=None,
             B = M,
             w'[i] = 1 / (w[i] - sigma)
 
-        -'buckling'::
+        - 'buckling'::
 
             OP = [A - sigma * M]^-1 @ A,
             B = A,

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -51,9 +51,9 @@ def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
     info : int
         Provides convergence information:
 
-            - 0  : successful exit
-            - >0 : convergence to tolerance not achieved, number of iterations
-            - <0 : illegal input or breakdown
+        - 0  : successful exit
+        - >0 : convergence to tolerance not achieved, number of iterations
+        - <0 : illegal input or breakdown
 
     Notes
     -----

--- a/scipy/sparse/linalg/_norm.py
+++ b/scipy/sparse/linalg/_norm.py
@@ -69,7 +69,7 @@ def norm(x, ord=None, axis=None):
 
     The Frobenius norm is given by [1]_:
 
-        :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
+    :math:`||A||_F = [\\sum_{i,j} abs(a_{i,j})^2]^{1/2}`
 
     References
     ----------


### PR DESCRIPTION
Fixes more accidental block quotes, mostly appearing in list.

I can split this PR up if it is too much.

I have now checked every doc of functions/classes except those in odr, special, and stats.