### PR TITLE
DOC: optimize.milp: add missing mip_rel_gap default

### DIFF
--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -360,10 +360,10 @@ def linprog(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         within `bounds`.
 
         ``2`` : Semi-continuous variable; decision variable must be within
-        `bounds` or take value ``0``.
+        `bounds` or ``0``.
 
         ``3`` : Semi-integer variable; decision variable must be an integer
-        within `bounds` or take value ``0``.
+        within `bounds` or ``0``.
 
         By default, all variables are continuous.
 

--- a/scipy/optimize/_linprog_doc.py
+++ b/scipy/optimize/_linprog_doc.py
@@ -89,10 +89,10 @@ def _linprog_highs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
         within `bounds`.
 
         ``2`` : Semi-continuous variable; decision variable must be within
-        `bounds` or take value ``0``.
+        `bounds` or ``0``.
 
         ``3`` : Semi-integer variable; decision variable must be an integer
-        within `bounds` or take value ``0``.
+        within `bounds` or ``0``.
 
         By default, all variables are continuous.
 
@@ -157,10 +157,10 @@ def _linprog_highs_doc(c, A_ub=None, b_ub=None, A_eq=None, b_eq=None,
 
         Currently, ``None`` always selects ``'steepest-devex'``, but this
         may change as new options become available.
-    mip_rel_gap : double (default: None)
+    mip_rel_gap : double, optional
         Termination criterion for MIP solver: solver will terminate when the
         gap between the primal objective value and the dual objective bound,
-        scaled by the primal objective value, is <= mip_rel_gap.
+        scaled by the primal objective value, is <= mip_rel_gap. Default: 0.0001.
     unknown_options : dict
         Optional arguments not used by this particular solver. If
         ``unknown_options`` is non-empty, a warning is issued listing

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -60,10 +60,10 @@ _LPProblem.__doc__ = \
         within `bounds`.
 
         ``2`` : Semi-continuous variable; decision variable must be within
-        `bounds` or take value ``0``.
+        `bounds` or ``0``.
 
         ``3`` : Semi-integer variable; decision variable must be an integer
-        within `bounds` or take value ``0``.
+        within `bounds` or ``0``.
 
         By default, all variables are continuous.
 

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -201,10 +201,10 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
         within `bounds`.
 
         ``2`` : Semi-continuous variable; decision variable must be within
-        `bounds` or take value ``0``.
+        `bounds` or ``0``.
 
         ``3`` : Semi-integer variable; decision variable must be an integer
-        within `bounds` or take value ``0``.
+        within `bounds` or ``0``.
 
         By default, all variables are continuous. `integrality` is converted
         to an array of integers before the problem is solved.
@@ -248,6 +248,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
             Termination criterion for MIP solver: solver will terminate when
             the gap between the primal objective value and the dual objective
             bound, scaled by the primal objective value, is <= mip_rel_gap.
+            Default: 0.0001.
 
     Returns
     -------


### PR DESCRIPTION
#### Reference issue
Closes gh-24311

#### What does this implement/fix?
Documents default `mip_rel_gap` value and adjust phrasing of `semi-continuous` and `semi-integer` variable descriptions to improve appearance.

<img width="1248" height="216" alt="image" src="https://github.com/user-attachments/assets/b8075931-2e16-48ba-a978-826622cb85f3" />
