### PR TITLE
DOC: stats.distributions: remove text from API definition TOC

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -154,7 +154,6 @@ change is made.
 * `scipy.stats`
 
   - `scipy.stats.contingency`
-  - ``scipy.stats.distributions``
   - `scipy.stats.mstats`
   - `scipy.stats.qmc`
   - `scipy.stats.sampling`


### PR DESCRIPTION
#### Reference issue
Closes gh-24321

#### What does this implement/fix?
gh-24321 notes that in the API definition TOC, the `stats.distributions` entry does not render with a hyperlink. One obvious solution would be to add a hyperlink, which would require creating the page to hyperlink *to*. 

Instead, this PR removes the text. The other sub-namespaces of `stats` are more or less necessary under the current import structure, with most attributes *only* being available from the sub-namespace, but all distributions can be imported directly from `scipy.stats`. We might want to use a sub-namespace for distributions in SciPy 2.0, but I think offering BOTH ways right now is a historical artifact rather than desired practice, and importing directly from `stats` is far more common, so let's only advertise that.
