### PR TITLE
DOC: add document file needed for autogeneration

### DIFF
--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -154,7 +154,7 @@ change is made.
 * `scipy.stats`
 
   - `scipy.stats.contingency`
-  - ``scipy.stats.distributions``
+  - `scipy.stats.distributions`
   - `scipy.stats.mstats`
   - `scipy.stats.qmc`
   - `scipy.stats.sampling`

--- a/doc/source/reference/stats.distributions.rst
+++ b/doc/source/reference/stats.distributions.rst
@@ -1,0 +1,4 @@
+.. automodule:: scipy.stats.distributions
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:


### PR DESCRIPTION
Reference issue
Closes #24321 

#### What does this implement/fix?
Added in ["doc/source/reference/"](https://github.com/nuryagli/scipy/tree/main/doc/source/reference) the file "stats.distributions.rst" needed for autogeneration of hyperlinks, that was the only file between the scipi.stats.*.rst to not be present.

#### Solution
Used the same template text of the other scipi.stats.*.rst files in the directory.
It is not needed to modify the [index page](https://github.com/nuryagli/scipy/blob/main/doc/source/reference/index.rst?plain=1) because as you can see it is already present as plain text.

#### Additional information
doc-fix only
[skip actions]