### PR TITLE
DOC: stats: adjust rendering of sub-namespace TOCs

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -460,10 +460,6 @@ tests) are listed above.
    combine_pvalues
    false_discovery_control
 
-
-The following functions are related to the tests above but do not belong in the
-above categories.
-
 Random Variables
 ================
 
@@ -488,20 +484,8 @@ Other statistical functionality
    :maxdepth: 1
 
    stats.qmc
-
-.. toctree::
-   :maxdepth: 1
-
    stats.contingency
-
-.. toctree::
-   :maxdepth: 1
-
    stats.mstats
-
-.. toctree::
-   :maxdepth: 1
-
    stats.sampling
 
 Transformations

--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -482,32 +482,27 @@ Random Variables
    exp
    log
 
-Quasi-Monte Carlo
-=================
-
+Other statistical functionality
+===============================
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 1
 
    stats.qmc
 
-Contingency Tables
-==================
-
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 1
 
    stats.contingency
 
-Masked statistics functions
-===========================
-
 .. toctree::
+   :maxdepth: 1
 
    stats.mstats
 
+.. toctree::
+   :maxdepth: 1
 
-Other statistical functionality
-===============================
+   stats.sampling
 
 Transformations
 ---------------
@@ -538,14 +533,6 @@ Statistical distances
    wasserstein_distance
    wasserstein_distance_nd
    energy_distance
-
-Sampling
---------
-
-.. toctree::
-   :maxdepth: 4
-
-   stats.sampling
 
 Fitting / Survival Analysis
 ---------------------------


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
In the main `stats` TOC, sub-namespaces render like:
<img width="781" height="375" alt="image" src="https://github.com/user-attachments/assets/8091e303-03f7-411a-9628-ba6a9609ddc6" />

They render nicely in the sub-namespace TOC:
<img width="761" height="549" alt="image" src="https://github.com/user-attachments/assets/64004593-ee1a-48b2-898d-09f22ddc8c40" />

That's a lot of redundancy in the main `stats` TOC:
- Duplicate of sub-namespace TOC (e.g. [here](https://docs.scipy.org/doc/scipy/reference/stats.mstats.html)) in main `stats` TOC  (e.g. [here](https://docs.scipy.org/doc/scipy/reference/stats.html#masked-statistics-functions))
- Heading for each sub-namespace (e.g. "Masked statistics functions" ) and separate link to sub-namespace (e.g. "Statistical functions for masked arrays (scipy.stats.mstats)"
- Heading for each attribute in plain-text (e.g. "describe") AND in teletype (`describe`)


Rather than fight with Sphinx, this PR eliminates the poor rendering and condenses things in the simplest way I can think of: remove the detailed sub-namespace listings from the main stats TOC. 