### PR TITLE
DEV/CI: add `spin check` command, and add check for `xp` marker usage to CI

### DIFF
--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -14,7 +14,6 @@ permissions:
 
 env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
-  INSTALLDIR: "build-install"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -14,7 +14,6 @@ permissions:
 
 env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
-  INSTALLDIR: "build-install"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -107,21 +106,26 @@ jobs:
       shell: bash -l {0}
       run: ccache -s
 
-    - name: Check installation
+    - name: Check installed files
       run: |
-        pushd tools
-        python check_installation.py ${{ env.INSTALLDIR }}
-        ./check_pyext_symbol_hiding.sh ../build
-        popd
+        spin check --installed-files --no-build
+
+    - name: Check symbol hiding
+      run: |
+        spin check --symbol-hiding --no-build
 
     - name: Check usage of install tags
       run: |
-        rm -r ${{ env.INSTALLDIR }}
+        rm -r build-install
         spin build --tags=runtime,python-runtime,devel
-        python tools/check_installation.py ${{ env.INSTALLDIR }} --no-tests
-        rm -r ${{ env.INSTALLDIR }}
+        python tools/check_installation.py build-install --no-tests
+        rm -r build-install
         spin build --tags=runtime,python-runtime,devel,tests
-        python tools/check_installation.py ${{ env.INSTALLDIR }}
+        spin check --installed-files --no-build
+
+    - name: Check xp markers
+      run: |
+        spin check --xp-markers --no-build
 
     - name: Check build-internal dependencies
       run: ninja -C build -t missingdeps

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -639,6 +639,75 @@ def lint(ctx, fix, diff_against, files, all, no_cython):
     util.run(cmd_check_test_name)
 
 
+@click.command()
+@click.option(
+    '--xp-markers', default=False, is_flag=True,
+    help='For each function using `xp_capabilities`, ensure non-numpy backends are '
+         'actually tested')
+@click.option(
+    '--installed-files', default=False, is_flag=True,
+    help='Ensure all test and stub files are installed correctly.')
+@click.option(
+    '--symbol-hiding', default=False, is_flag=True,
+    help='Check whether symbol hiding in extension modules is correct (GCC-only)')
+@click.option(
+    '--no-build', default=False, is_flag=True,
+    help='Build SciPy before running checks')
+@meson.build_dir_option
+@click.pass_context
+def check(ctx, xp_markers, installed_files, symbol_hiding, no_build, build_dir=None):
+    """🔧  Run checks specific to the SciPy code base.
+
+    Exactly one check can be run at once. Example:
+
+      \b
+      spin check --xp-markers
+
+    """
+    # Checks are typically useful enough to run in CI or maintain a custom script for,
+    # but not deserving of their own top-level command in the spin CLI interface.
+    #
+    # We only run a single check per invocation, since they're so different and not all
+    # checks are expected to pass on all platforms.
+    #
+    # These checks, unlike the `lint` ones, are allowed (but don't have to) require
+    # building or importing `scipy`.
+    options = [xp_markers, installed_files, symbol_hiding]
+    if not sum(options) == 1:
+        click.secho(
+            f"Exactly one option to `check` should be given, found {sum(options)} - "
+            "exiting",
+            fg="bright_red",
+        )
+        sys.exit(1)
+
+    if not no_build:
+        click.secho(
+                "Invoking `build` prior to running checks:",
+                bold=True, fg="bright_green"
+            )
+        ctx.invoke(build)
+
+    build_dir = os.path.abspath(build_dir)
+    install_dir = meson._get_site_packages(build_dir)
+    os.environ['PYTHONPATH'] = install_dir
+
+    if xp_markers:
+        os.environ['SCIPY_ARRAY_API'] = '1'
+        cmd = [sys.executable, os.path.join('tools', 'check_xp_untested.py')]
+        util.run(cmd)
+
+    if installed_files:
+        cmd = [sys.executable, os.path.join('tools', 'check_installation.py'),
+               install_dir]
+        util.run(cmd)
+
+    if symbol_hiding:
+        script = os.path.join(os.path.abspath('tools'),
+                              'check_pyext_symbol_hiding.sh')
+        util.run([script, install_dir])
+
+
 # From scipy: benchmarks/benchmarks/common.py
 def _set_mem_rlimit(max_mem=None):
     """

--- a/pixi.toml
+++ b/pixi.toml
@@ -217,6 +217,11 @@ depends-on = "build"
 env.SCIPY_XSLOW = "1"
 description = "Test SciPy (full and x-slow)"
 
+[feature.test-tasks.tasks.check]
+cmd = "spin check --no-build"
+depends-on = "build"
+description = "Run SciPy-specific checks"
+
 
 ### Type Stubs ###
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,11 +172,12 @@ PKG_CONFIG_PATH = "{project}"
 # set CIBW_ENVIRONMENT_WINDOWS=PKG_CONFIG_PATH=PWD.replace('\\', '/')
 
 [tool.spin.commands]
-"Build" = [
+"Build & Develop" = [
   ".spin/cmds.py:build",
   ".spin/cmds.py:test",
   ".spin/cmds.py:mypy",
   ".spin/cmds.py:lint",
+  ".spin/cmds.py:check",
   "spin.cmds.pip.install"
 ]
 "Environments" = [


### PR DESCRIPTION
This follows up on https://github.com/scipy/scipy/pull/24130#issuecomment-3724111113 for the `--xp-markers` command.

The main idea is a single `spin check` that we can give flags for various ad-hoc checks we have, making them more visible and easy to use in CI.