### PR TITLE
DOC: set `SCIPY_ARRAY_API` in notebook, not globally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,6 @@ jobs:
           no_output_timeout: 25m
           command: |
             export PYTHONPATH=$PWD/build-install/usr/lib/python3.13/site-packages
-            export SCIPY_ARRAY_API=1
             spin docs -j2 2>&1 | tee sphinx_log.txt
 
       - run:

--- a/doc/source/tutorial/stats/outliers.md
+++ b/doc/source/tutorial/stats/outliers.md
@@ -35,6 +35,8 @@ using tools available in SciPy, with an emphasis on transitioning from use of le
 In the past, SciPy has offered several "convenience functions" that combine trimming with computation of a statistic. Consider, for instance, {func}`scipy.stats.trim_mean`.
 
 ```{code-cell} ipython3
+import os
+os.environ['SCIPY_ARRAY_API'] = '1'
 import numpy as np
 from scipy import stats
 np.set_printoptions(linewidth=120)


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/24330#issuecomment-3734394186

#### What does this implement/fix?
I'm certain I've tried setting `SCIPY_ARRAY_API=1` in a notebook before and it didn't work - but it's possible that my test was invalid (e.g. order of `import` vs setting environment variable in code or failing to restart notebook). Let's try again in CI.
