### PR TITLE
DEP: optimize.nnls: remove atol

### DIFF
--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -1,14 +1,11 @@
 import numpy as np
 from ._slsqplib import nnls as _nnls
-from scipy._lib.deprecation import _deprecate_positional_args, _NoValue
 
 
 __all__ = ['nnls']
 
 
-@_deprecate_positional_args(version='1.18.0',
-                            deprecated_args={'atol'})
-def nnls(A, b, *, maxiter=None, atol=_NoValue):
+def nnls(A, b, *, maxiter=None):
     """
     Solve ``argmin_x || Ax - b ||_2^2`` for ``x>=0``.
 
@@ -25,10 +22,6 @@ def nnls(A, b, *, maxiter=None, atol=_NoValue):
         Right-hand side vector.
     maxiter: int, optional
         Maximum number of iterations, optional. Default value is ``3 * n``.
-    atol : float, optional
-        .. deprecated:: 1.18.0
-            This parameter is deprecated and will be removed in SciPy 1.18.0.
-            It is not used in the implementation.
 
     Returns
     -------

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -429,14 +429,6 @@ class TestNNLS:
                         atol=5e-14)
         assert np.abs(np.linalg.norm(A@sol - b) - res) < 5e-14
 
-    def test_atol_deprecation_warning(self):
-        """Test that using atol parameter triggers deprecation warning"""
-        a = np.array([[1, 0], [1, 0], [0, 1]])
-        b = np.array([2, 1, 1])
-
-        with pytest.warns(DeprecationWarning, match="{'atol'}"):
-            nnls(a, b, atol=1e-8)
-
     def test_2D_singleton_RHS_input(self):
         # Test that a 2D singleton RHS input is accepted
         A = np.array([[1.0, 0.5, -1.],


### PR DESCRIPTION
follow up to #22386

Removes the deprecated `atol` argument.