### PR TITLE
DEP: optimize: remove disp, iprint from L-BFGS-B

### DIFF
--- a/scipy/optimize/_lbfgsb_py.py
+++ b/scipy/optimize/_lbfgsb_py.py
@@ -42,8 +42,6 @@ from ._optimize import (MemoizeJac, OptimizeResult, _call_callback_maybe_halt,
 from ._constraints import old_bound_to_new
 
 from scipy.sparse.linalg import LinearOperator
-from scipy._lib.deprecation import _NoValue
-import warnings
 
 __all__ = ['fmin_l_bfgs_b', 'LbfgsInvHessProduct']
 
@@ -91,11 +89,8 @@ task_messages = {
     713 : "INVALID NBD",
 }
 
-def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
-                  approx_grad=0,
-                  bounds=None, m=10, factr=1e7, pgtol=1e-5,
-                  epsilon=1e-8,
-                  iprint=_NoValue, maxfun=15000, maxiter=15000, disp=_NoValue,
+def fmin_l_bfgs_b(func, x0, fprime=None, args=(), approx_grad=0, bounds=None, m=10,
+                  factr=1e7, pgtol=1e-5, epsilon=1e-8, maxfun=15000, maxiter=15000,
                   callback=None, maxls=20):
     """
     Minimize a function func using the L-BFGS-B algorithm.
@@ -140,22 +135,6 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
     epsilon : float, optional
         Step size used when `approx_grad` is True, for numerically
         calculating the gradient
-    iprint : int, optional
-        Deprecated option that previously controlled the text printed on the
-        screen during the problem solution. Now the code does not emit any
-        output and this keyword has no function.
-
-        .. deprecated:: 1.15.0
-            This keyword is deprecated and will be removed from SciPy 1.18.0.
-
-    disp : int, optional
-        Deprecated option that previously controlled the text printed on the
-        screen during the problem solution. Now the code does not emit any
-        output and this keyword has no function.
-
-        .. deprecated:: 1.15.0
-            This keyword is deprecated and will be removed from SciPy 1.18.0.
-
     maxfun : int, optional
         Maximum number of function evaluations. Note that this function
         may violate the limit because of evaluating gradients by numerical
@@ -267,9 +246,7 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
 
     # build options
     callback = _wrap_callback(callback)
-    opts = {'disp': disp,
-            'iprint': iprint,
-            'maxcor': m,
+    opts = {'maxcor': m,
             'ftol': factr * np.finfo(float).eps,
             'gtol': pgtol,
             'eps': epsilon,
@@ -291,26 +268,16 @@ def fmin_l_bfgs_b(func, x0, fprime=None, args=(),
     return x, f, d
 
 
-def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
-                     disp=_NoValue, maxcor=10, ftol=2.2204460492503131e-09,
-                     gtol=1e-5, eps=1e-8, maxfun=15000, maxiter=15000,
-                     iprint=_NoValue, callback=None, maxls=20,
-                     finite_diff_rel_step=None, workers=None,
-                     **unknown_options):
+def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None, maxcor=10,
+                     ftol=2.2204460492503131e-09, gtol=1e-5, eps=1e-8, maxfun=15000,
+                     maxiter=15000, callback=None, maxls=20, finite_diff_rel_step=None,
+                     workers=None, **unknown_options):
     """
     Minimize a scalar function of one or more variables using the L-BFGS-B
     algorithm.
 
     Options
     -------
-    disp : None or int
-        Deprecated option that previously controlled the text printed on the
-        screen during the problem solution. Now the code does not emit any
-        output and this keyword has no function.
-
-        .. deprecated:: 1.15.0
-            This keyword is deprecated and will be removed from SciPy 1.18.0.
-
     maxcor : int
         The maximum number of variable metric corrections used to
         define the limited memory matrix. (The limited memory BFGS
@@ -332,14 +299,6 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
         are evaluated by numerical differentiation.
     maxiter : int
         Maximum number of algorithm iterations.
-    iprint : int, optional
-        Deprecated option that previously controlled the text printed on the
-        screen during the problem solution. Now the code does not emit any
-        output and this keyword has no function.
-
-        .. deprecated:: 1.15.0
-            This keyword is deprecated and will be removed from SciPy 1.18.0.
-
     maxls : int, optional
         Maximum number of line search steps (per iteration). Default is 20.
     finite_diff_rel_step : None or array_like, optional
@@ -377,17 +336,6 @@ def _minimize_lbfgsb(fun, x0, args=(), jac=None, bounds=None,
 
     x0 = asarray(x0).ravel()
     n, = x0.shape
-    if disp is not _NoValue:
-        warnings.warn("scipy.optimize: The `disp` and `iprint` options of the "
-                      "L-BFGS-B solver are deprecated and will be removed in "
-                      "SciPy 1.18.0.",
-                      DeprecationWarning, stacklevel=3)
-
-    if iprint is not _NoValue:
-        warnings.warn("scipy.optimize: The `disp` and `iprint` options of the "
-                      "L-BFGS-B solver are deprecated and will be removed in "
-                      "SciPy 1.18.0.",
-                      DeprecationWarning, stacklevel=3)
 
     # historically old-style bounds were/are expected by lbfgsb.
     # That's still the case but we'll deal with new-style from here on,


### PR DESCRIPTION
Follow up to #23197

Removes deprecated arguments