### PR TITLE
DOC: fix ordering of documentation sections

### DIFF
--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -286,6 +286,13 @@ class ode:
 
         Options and references the same as "dopri5".
 
+    References
+    ----------
+    .. [HNW93] E. Hairer, S.P. Norsett and G. Wanner, Solving Ordinary
+        Differential Equations i. Nonstiff Problems. 2nd edition.
+        Springer Series in Computational Mathematics,
+        Springer-Verlag (1993)
+
     Examples
     --------
 
@@ -318,14 +325,6 @@ class ode:
     8.0 [-0.15986733-0.61234476j  0.06060616+0.j        ]
     9.0 [0.64850462+0.15048982j 0.05405414+0.j        ]
     10.0 [-0.38404699+0.56382299j  0.04878055+0.j        ]
-
-    References
-    ----------
-    .. [HNW93] E. Hairer, S.P. Norsett and G. Wanner, Solving Ordinary
-        Differential Equations i. Nonstiff Problems. 2nd edition.
-        Springer Series in Computational Mathematics,
-        Springer-Verlag (1993)
-
     """
 
     # generic type compatibility with scipy-stubs

--- a/scipy/interpolate/_interpnd.pyx
+++ b/scipy/interpolate/_interpnd.pyx
@@ -248,10 +248,6 @@ class LinearNDInterpolator(NDInterpolatorBase):
 
     .. versionadded:: 0.9
 
-    Methods
-    -------
-    __call__
-
     Parameters
     ----------
     points : ndarray of floats, shape (npoints, ndims); or Delaunay
@@ -269,6 +265,20 @@ class LinearNDInterpolator(NDInterpolatorBase):
         This is useful if some of the input dimensions have
         incommensurable units and differ by many orders of magnitude.
 
+    Methods
+    -------
+    __call__
+
+    See Also
+    --------
+    griddata : Interpolate unstructured D-D data.
+    NearestNDInterpolator : Nearest-neighbor interpolator in N dimensions.
+    CloughTocher2DInterpolator : Piecewise cubic, C1 smooth, curvature-minimizing
+                                 interpolator in 2D.
+    interpn : Interpolation on a regular grid or rectilinear grid.
+    RegularGridInterpolator : Interpolator on a regular or rectilinear grid
+                              in arbitrary dimensions (`interpn` wraps this class).
+
     Notes
     -----
     The interpolant is constructed by triangulating the input data
@@ -276,6 +286,10 @@ class LinearNDInterpolator(NDInterpolatorBase):
     barycentric interpolation.
 
     .. note:: For data on a regular grid use `interpn` instead.
+
+    References
+    ----------
+    .. [1] http://www.qhull.org/
 
     Examples
     --------
@@ -299,24 +313,6 @@ class LinearNDInterpolator(NDInterpolatorBase):
     >>> plt.colorbar()
     >>> plt.axis("equal")
     >>> plt.show()
-
-    See Also
-    --------
-    griddata :
-        Interpolate unstructured D-D data.
-    NearestNDInterpolator :
-        Nearest-neighbor interpolator in N dimensions.
-    CloughTocher2DInterpolator :
-        Piecewise cubic, C1 smooth, curvature-minimizing interpolator in 2D.
-    interpn : Interpolation on a regular grid or rectilinear grid.
-    RegularGridInterpolator : Interpolator on a regular or rectilinear grid
-                              in arbitrary dimensions (`interpn` wraps this
-                              class).
-
-    References
-    ----------
-    .. [1] http://www.qhull.org/
-
     """
 
     def __init__(self, points, values, fill_value=np.nan, rescale=False):
@@ -843,13 +839,10 @@ cdef double_or_complex _clough_tocher_2d_single(const qhull.DelaunayInfo_t *d,
     return w
 
 class CloughTocher2DInterpolator(NDInterpolatorBase):
-    """Piecewise cubic, C1 smooth, curvature-minimizing interpolator in N=2 dimensions.
+    """
+    Piecewise cubic, C1 smooth, curvature-minimizing interpolator in N=2 dimensions.
 
     .. versionadded:: 0.9
-
-    Methods
-    -------
-    __call__
 
     Parameters
     ----------
@@ -872,6 +865,19 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
         This is useful if some of the input dimensions have
         incommensurable units and differ by many orders of magnitude.
 
+    Methods
+    -------
+    __call__
+
+    See Also
+    --------
+    griddata : Interpolate unstructured D-D data.
+    LinearNDInterpolator : Piecewise linear interpolator in N > 1 dimensions.
+    NearestNDInterpolator : Nearest-neighbor interpolator in N > 1 dimensions.
+    interpn : Interpolation on a regular grid or rectilinear grid.
+    RegularGridInterpolator : Interpolator on a regular or rectilinear grid
+                              in arbitrary dimensions (`interpn` wraps thisclass).
+
     Notes
     -----
     The interpolant is constructed by triangulating the input data
@@ -886,6 +892,24 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     algorithm described in [Nielson83]_ and [Renka84]_.
 
     .. note:: For data on a regular grid use `interpn` instead.
+
+    References
+    ----------
+    .. [1] http://www.qhull.org/
+    .. [CT] See, for example,
+       P. Alfeld,
+       ''A trivariate Clough-Tocher scheme for tetrahedral data''.
+       Computer Aided Geometric Design, 1, 169 (1984);
+       G. Farin,
+       ''Triangular Bernstein-Bezier patches''.
+       Computer Aided Geometric Design, 3, 83 (1986).
+    .. [Nielson83] G. Nielson,
+       ''A method for interpolating scattered data based upon a minimum norm
+       network''.
+       Math. Comp., 40, 253 (1983).
+    .. [Renka84] R. J. Renka and A. K. Cline.
+       ''A Triangle-based C1 interpolation method.'',
+       Rocky Mountain J. Math., 14, 223 (1984).
 
     Examples
     --------
@@ -909,41 +933,6 @@ class CloughTocher2DInterpolator(NDInterpolatorBase):
     >>> plt.colorbar()
     >>> plt.axis("equal")
     >>> plt.show()
-
-    See Also
-    --------
-    griddata :
-        Interpolate unstructured D-D data.
-    LinearNDInterpolator :
-        Piecewise linear interpolator in N > 1 dimensions.
-    NearestNDInterpolator :
-        Nearest-neighbor interpolator in N > 1 dimensions.
-    interpn : Interpolation on a regular grid or rectilinear grid.
-    RegularGridInterpolator : Interpolator on a regular or rectilinear grid
-                              in arbitrary dimensions (`interpn` wraps this
-                              class).
-
-    References
-    ----------
-    .. [1] http://www.qhull.org/
-
-    .. [CT] See, for example,
-       P. Alfeld,
-       ''A trivariate Clough-Tocher scheme for tetrahedral data''.
-       Computer Aided Geometric Design, 1, 169 (1984);
-       G. Farin,
-       ''Triangular Bernstein-Bezier patches''.
-       Computer Aided Geometric Design, 3, 83 (1986).
-
-    .. [Nielson83] G. Nielson,
-       ''A method for interpolating scattered data based upon a minimum norm
-       network''.
-       Math. Comp., 40, 253 (1983).
-
-    .. [Renka84] R. J. Renka and A. K. Cline.
-       ''A Triangle-based C1 interpolation method.'',
-       Rocky Mountain J. Math., 14, 223 (1984).
-
     """
 
     def __init__(self, points, values, fill_value=np.nan,

--- a/scipy/interpolate/_ndgriddata.py
+++ b/scipy/interpolate/_ndgriddata.py
@@ -20,10 +20,6 @@ __all__ = ['griddata', 'NearestNDInterpolator', 'LinearNDInterpolator',
 class NearestNDInterpolator(NDInterpolatorBase):
     """Nearest-neighbor interpolator in N > 1 dimensions.
 
-    Methods
-    -------
-    __call__
-
     Parameters
     ----------
     x : (npoints, ndims) 2-D ndarray of floats
@@ -41,6 +37,10 @@ class NearestNDInterpolator(NDInterpolatorBase):
         Options passed to the underlying ``KDTree``.
 
         .. versionadded:: 0.17.0
+
+    Methods
+    -------
+    __call__
 
     See Also
     --------
@@ -83,7 +83,6 @@ class NearestNDInterpolator(NDInterpolatorBase):
     >>> plt.colorbar()
     >>> plt.axis("equal")
     >>> plt.show()
-
     """
 
     def __init__(self, x, y, rescale=False, tree_options=None):

--- a/scipy/io/arff/_arffread.py
+++ b/scipy/io/arff/_arffread.py
@@ -665,9 +665,21 @@ def read_header(ofile):
 
 
 class MetaData:
-    """Small container to keep useful information on a ARFF dataset.
+    """
+    Small container to keep useful information on a ARFF dataset.
 
     Knows about attributes names and types.
+
+    Methods
+    -------
+    names
+    types
+
+    Notes
+    -----
+    Also maintains the list of attributes in order, i.e., doing for i in
+    meta, where meta is an instance of MetaData, will return the
+    different attribute names in the order they were defined.
 
     Examples
     --------
@@ -681,17 +693,6 @@ class MetaData:
         meta.names()
         # Getting attribute type
         types = meta.types()
-
-    Methods
-    -------
-    names
-    types
-
-    Notes
-    -----
-    Also maintains the list of attributes in order, i.e., doing for i in
-    meta, where meta is an instance of MetaData, will return the
-    different attribute names in the order they were defined.
     """
     def __init__(self, rel, attr):
         self.name = rel

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1389,6 +1389,16 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     ValueError
         If `a` is not square, or not 2D.
 
+    Notes
+    -----
+
+    The input array ``a`` may represent a single matrix or a collection (a.k.a.
+    a "batch") of square matrices. For example, if ``a.shape == (4, 3, 2, 2)``, it is
+    interpreted as a ``(4, 3)``-shaped batch of :math:`2\times 2` matrices.
+
+    This routine checks the condition number of the `a` matrix and emits a
+    `LinAlgWarning` for ill-conditioned inputs.
+
     Examples
     --------
     >>> import numpy as np
@@ -1400,17 +1410,6 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     >>> np.dot(a, linalg.inv(a))
     array([[ 1.,  0.],
            [ 0.,  1.]])
-
-    Notes
-    -----
-
-    The input array ``a`` may represent a single matrix or a collection (a.k.a.
-    a "batch") of square matrices. For example, if ``a.shape == (4, 3, 2, 2)``, it is
-    interpreted as a ``(4, 3)``-shaped batch of :math:`2\times 2` matrices.
-
-    This routine checks the condition number of the `a` matrix and emits a
-    `LinAlgWarning` for ill-conditioned inputs.
-
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
 

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1311,11 +1311,6 @@ class ExcitingMixing(GenericBroyden):
        This algorithm may be useful for specific problems, but whether
        it will work may depend strongly on the problem.
 
-    See Also
-    --------
-    root : Interface to root finding algorithms for multivariate
-           functions. See ``method='excitingmixing'`` in particular.
-
     Parameters
     ----------
     %(params_basic)s
@@ -1325,6 +1320,11 @@ class ExcitingMixing(GenericBroyden):
         The entries of the diagonal Jacobian are kept in the range
         ``[alpha, alphamax]``.
     %(params_extra)s
+
+    See Also
+    --------
+    root : Interface to root finding algorithms for multivariate
+           functions. See ``method='excitingmixing'`` in particular.
     """
 
     def __init__(self, alpha=None, alphamax=1.0):

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -650,6 +650,17 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
     converge to the minimum, or how fast it will if it does. Both the ftol and
     xtol criteria must be met for convergence.
 
+    References
+    ----------
+    .. [1] Nelder, J.A. and Mead, R. (1965), "A simplex method for function
+           minimization", The Computer Journal, 7, pp. 308-313
+
+    .. [2] Wright, M.H. (1996), "Direct Search Methods: Once Scorned, Now
+           Respectable", in Numerical Analysis 1995, Proceedings of the
+           1995 Dundee Biennial Conference in Numerical Analysis, D.F.
+           Griffiths and G.A. Watson (Eds.), Addison Wesley Longman,
+           Harlow, UK, pp. 191-208.
+
     Examples
     --------
     >>> def f(x):
@@ -664,18 +675,6 @@ def fmin(func, x0, args=(), xtol=1e-4, ftol=1e-4, maxiter=None, maxfun=None,
              Function evaluations: 34
     >>> minimum[0]
     -8.8817841970012523e-16
-
-    References
-    ----------
-    .. [1] Nelder, J.A. and Mead, R. (1965), "A simplex method for function
-           minimization", The Computer Journal, 7, pp. 308-313
-
-    .. [2] Wright, M.H. (1996), "Direct Search Methods: Once Scorned, Now
-           Respectable", in Numerical Analysis 1995, Proceedings of the
-           1995 Dundee Biennial Conference in Numerical Analysis, D.F.
-           Griffiths and G.A. Watson (Eds.), Addison Wesley Longman,
-           Harlow, UK, pp. 191-208.
-
     """
     opts = {'xatol': xtol,
             'fatol': ftol,
@@ -1269,6 +1268,11 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
         The value of `xopt` at each iteration. Only returned if `retall` is
         True.
 
+    See Also
+    --------
+    minimize: Interface to minimization algorithms for multivariate
+        functions. See ``method='BFGS'`` in particular.
+
     Notes
     -----
     Optimize the function, `f`, whose gradient is given by `fprime`
@@ -1277,14 +1281,9 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
 
     Parameters `c1` and `c2` must satisfy ``0 < c1 < c2 < 1``.
 
-    See Also
-    --------
-    minimize: Interface to minimization algorithms for multivariate
-        functions. See ``method='BFGS'`` in particular.
-
     References
     ----------
-    Wright, and Nocedal 'Numerical Optimization', 1999, p. 198.
+    ..[1] Wright, and Nocedal 'Numerical Optimization', 1999, p. 198.
 
     Examples
     --------

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1283,7 +1283,7 @@ def fmin_bfgs(f, x0, fprime=None, args=(), gtol=1e-5, norm=np.inf,
 
     References
     ----------
-    ..[1] Wright, and Nocedal 'Numerical Optimization', 1999, p. 198.
+    .. [1] Wright, and Nocedal 'Numerical Optimization', 1999, p. 198.
 
     Examples
     --------

--- a/scipy/optimize/_zeros_py.py
+++ b/scipy/optimize/_zeros_py.py
@@ -500,18 +500,18 @@ def bisect(f, a, b, args=(),
     Find root of a function within an interval using bisection.
 
     Basic bisection routine to find a root of the function `f` between the
-    arguments `a` and `b`. `f(a)` and `f(b)` cannot have the same signs.
+    arguments `a` and `b`. ``f(a)`` and ``f(b)`` cannot have the same signs.
     Slow but sure.
 
     Parameters
     ----------
     f : function
         Python function returning a number.  `f` must be continuous, and
-        f(a) and f(b) must have opposite signs.
+        ``f(a)`` and ``f(b)`` must have opposite signs.
     a : scalar
-        One end of the bracketing interval [a,b].
+        One end of the bracketing interval ``[a,b]``.
     b : scalar
-        The other end of the bracketing interval [a,b].
+        The other end of the bracketing interval ``[a,b]``.
     xtol : number, optional
         The computed root ``x0`` will satisfy ``np.isclose(x, x0,
         atol=xtol, rtol=rtol)``, where ``x`` is the exact root. The
@@ -544,6 +544,13 @@ def bisect(f, a, b, args=(),
         Object containing information about the convergence. In particular,
         ``r.converged`` is True if the routine converged.
 
+    See Also
+    --------
+    brentq, brenth, bisect, newton
+    fixed_point : scalar fixed-point finder
+    fsolve : n-dimensional root-finding
+    elementwise.find_root : efficient elementwise 1-D root-finder
+
     Notes
     -----
     As mentioned in the parameter documentation, the computed root ``x0`` will
@@ -575,14 +582,6 @@ def bisect(f, a, b, args=(),
     >>> root = optimize.bisect(f, -2, 0)
     >>> root
     -1.0
-
-    See Also
-    --------
-    brentq, brenth, bisect, newton
-    fixed_point : scalar fixed-point finder
-    fsolve : n-dimensional root-finding
-    elementwise.find_root : efficient elementwise 1-D root-finder
-
     """
     if not isinstance(args, tuple):
         args = (args,)

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -236,18 +236,17 @@ def spdiags(data, diags, m=None, n=None, format=None):
     new_matrix : sparse matrix
         `dia_matrix` format with values in ``data`` on diagonals from ``diags``.
 
-    Notes
-    -----
-    This function can be replaced by an equivalent call to `dia_matrix`
-    as::
-
-        dia_matrix((data, diags), shape=(m, n)).asformat(format)
-
     See Also
     --------
-    diags_array : more convenient form of this function
-    diags : matrix version of diags_array
+    diags_array : more convenient form of this function.
+    diags : matrix version of diags_array.
     dia_matrix : the sparse DIAgonal format.
+
+    Notes
+    -----
+    This function can be replaced by an equivalent call to `dia_matrix` as::
+
+        dia_matrix((data, diags), shape=(m, n)).asformat(format)
 
     Examples
     --------
@@ -260,7 +259,6 @@ def spdiags(data, diags, m=None, n=None, format=None):
            [1, 2, 0, 4],
            [0, 2, 3, 0],
            [0, 0, 3, 4]])
-
     """
     if m is None and n is None:
         m = n = len(data[0])
@@ -300,13 +298,17 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=_NoVa
         behavior is deprecated, and in SciPy 1.19, the default behavior
         will be changed to return an array with the same data type as the
         input diagonals.  To adopt this behavior before version 1.19, use
-        `dtype=None`.
+        ``dtype=None``.
 
     Returns
     -------
     new_array : dia_array
         `dia_array` holding the values in `diagonals` offset from the main diagonal
         as indicated in `offsets`.
+
+    See Also
+    --------
+    dia_array : constructor for the sparse DIAgonal format.
 
     Notes
     -----
@@ -325,10 +327,6 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=_NoVa
     Each value in the input `diagonals` is used.
 
     .. versionadded:: 1.11
-
-    See Also
-    --------
-    dia_array : constructor for the sparse DIAgonal format.
 
     Examples
     --------
@@ -358,7 +356,6 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=_NoVa
            [ 0.,  0.,  2.,  0.],
            [ 0.,  0.,  0.,  3.],
            [ 0.,  0.,  0.,  0.]])
-
     """
     # if offsets is not a sequence, assume that there's only one diagonal
     if isscalarlike(offsets):
@@ -475,6 +472,11 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=_NoValue):
         `dia_matrix` holding the values in `diagonals` offset from the main diagonal
         as indicated in `offsets`.
 
+    See Also
+    --------
+    spdiags : construct matrix from diagonals
+    diags_array : construct sparse array instead of sparse matrix
+
     Notes
     -----
     Repeated diagonal offsets are disallowed.
@@ -492,11 +494,6 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=_NoValue):
     Each value in the input `diagonals` is used.
 
     .. versionadded:: 0.11
-
-    See Also
-    --------
-    spdiags : construct matrix from diagonals
-    diags_array : construct sparse array instead of sparse matrix
 
     Examples
     --------
@@ -526,7 +523,6 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=_NoValue):
            [ 0.,  0.,  2.,  0.],
            [ 0.,  0.,  0.,  3.],
            [ 0.,  0.,  0.,  0.]])
-
     """
     A = diags_array(diagonals, offsets=offsets, shape=shape, dtype=dtype)
     return dia_matrix(A).asformat(format)
@@ -1319,15 +1315,15 @@ def block_diag(mats, format=None, dtype=None):
         If at least one input is a sparse array, the output is a sparse array.
         Otherwise the output is a sparse matrix.
 
-    Notes
-    -----
-
-    .. versionadded:: 0.11.0
-
     See Also
     --------
     block_array
     diags_array
+
+    Notes
+    -----
+
+    .. versionadded:: 0.11.0
 
     Examples
     --------
@@ -1341,7 +1337,6 @@ def block_diag(mats, format=None, dtype=None):
            [0, 0, 5, 0],
            [0, 0, 6, 0],
            [0, 0, 0, 7]])
-
     """
     if any(isinstance(a, sparray) for a in mats):
         container = coo_array

--- a/scipy/sparse/linalg/_funm_multiply_krylov.py
+++ b/scipy/sparse/linalg/_funm_multiply_krylov.py
@@ -155,34 +155,27 @@ def funm_multiply_krylov(f, A, b, *, assume_a = "general", t = 1.0, atol = 0.0,
     ----------
     f : callable
         Callable object that computes the matrix function ``F = f(X)``.
-
     A : {sparse array, ndarray, LinearOperator}
         A real or complex N-by-N matrix.
         Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g., ``scipy.sparse.linalg.LinearOperator``.
-
     b : ndarray
         A vector to multiply the ``f(tA)`` with.
-
     assume_a : string, optional
         Indicate the structure of ``A``. The algorithm will use this information
         to select the appropriated code path. The available options are
         'hermitian'/'her' and 'general'/'gen'. If ommited, then it is assumed
         that ``A`` has a 'general' structure.
-
     t : float, optional
         The value to scale the matrix ``A`` with. The default is ``t = 1.0``
-
     atol, rtol : float, optional
         Parameters for the convergence test. For convergence,
         ``norm(||y_k - y_k-1||) <= max(rtol*norm(b), atol)`` should be satisfied.
         The default is ``atol=0.`` and ``rtol=1e-6``.
-
     restart_every_m : integer
         If the iteration number reaches this value a restart is triggered.
         Larger values increase iteration cost but may be necessary for convergence.
         If omitted, ``min(20, n)`` is used.
-
     max_restarts : int, optional
         Maximum number of restart cycles. The algorithm will stop
         after max_restarts cycles even if the specified tolerance has not been
@@ -199,6 +192,22 @@ def funm_multiply_krylov(f, A, b, *, assume_a = "general", t = 1.0, atol = 0.0,
     of ``A`` and the function ``f``. With restarting, there are only formal
     proofs for functions of order 1 (e.g., ``exp``, ``sin``, ``cos``) and
     Stieltjes functions [2]_ [3]_, while the general case remains an open problem.
+
+    References
+    ----------
+    .. [1] M. Afanasjew, M. Eiermann, O. G. Ernst, and S. Güttel,
+           "Implementation of a restarted Krylov subspace method for the
+           evaluation of matrix functions," Linear Algebra and its Applications,
+           vol. 429, no. 10, pp. 2293-2314, Nov. 2008, :doi:`10.1016/j.laa.2008.06.029`.
+
+    .. [2] M. Eiermann and O. G. Ernst, "A Restarted Krylov Subspace Method
+           for the Evaluation of Matrix Functions," SIAM J. Numer. Anal., vol. 44,
+           no. 6, pp. 2481-2504, Jan. 2006, :doi:`10.1137/050633846`.
+
+    .. [3] A. Frommer, S. Güttel, and M. Schweitzer, "Convergence of Restarted
+           Krylov Subspace Methods for Stieltjes Functions of Matrices," SIAM J.
+           Matrix Anal. Appl., vol. 35, no. 4, pp. 1602-1624,
+           Jan. 2014, :doi:`10.1137/140973463`.
 
     Examples
     --------
@@ -245,23 +254,6 @@ def funm_multiply_krylov(f, A, b, *, assume_a = "general", t = 1.0, atol = 0.0,
     >>> err = y - ref
     >>> err
     array([ 0.00000000e+00 , 8.88178420e-16 , -4.60742555e-15])
-
-    References
-    ----------
-    .. [1] M. Afanasjew, M. Eiermann, O. G. Ernst, and S. Güttel,
-          "Implementation of a restarted Krylov subspace method for the
-          evaluation of matrix functions," Linear Algebra and its Applications,
-          vol. 429, no. 10, pp. 2293-2314, Nov. 2008, :doi:`10.1016/j.laa.2008.06.029`.
-
-    .. [2] M. Eiermann and O. G. Ernst, "A Restarted Krylov Subspace Method
-           for the Evaluation of Matrix Functions," SIAM J. Numer. Anal., vol. 44,
-           no. 6, pp. 2481-2504, Jan. 2006, :doi:`10.1137/050633846`.
-
-    .. [3] A. Frommer, S. Güttel, and M. Schweitzer, "Convergence of Restarted
-           Krylov Subspace Methods for Stieltjes Functions of Matrices," SIAM J.
-           Matrix Anal. Appl., vol. 35, no. 4, pp. 1602-1624,
-           Jan. 2014, :doi:`10.1137/140973463`.
-
     """
 
     if assume_a not in {'hermitian', 'general', 'her', 'gen'}:

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -12,16 +12,16 @@ def minres(A, b, x0=None, *, rtol=1e-5, shift=0.0, maxiter=None,
     """
     Solve ``Ax = b`` with the MINimum RESidual method, for a symmetric `A`.
 
-    MINRES minimizes norm(Ax - b) for a real symmetric matrix A.  Unlike
-    the Conjugate Gradient method, A can be indefinite or singular.
+    MINRES minimizes ``norm(Ax - b)`` for a real symmetric matrix `A`.  Unlike
+    the Conjugate Gradient method, `A` can be indefinite or singular.
 
-    If shift != 0 then the method solves (A - shift*I)x = b
+    If ``shift != 0`` then the method solves ``(A - shift*I)x = b``.
 
     Parameters
     ----------
     A : {sparse array, ndarray, LinearOperator}
         The real symmetric N-by-N matrix of the linear system
-        Alternatively, ``A`` can be a linear operator which can
+        Alternatively, `A` can be a linear operator which can
         produce ``Ax`` using, e.g.,
         ``scipy.sparse.linalg.LinearOperator``.
     b : ndarray
@@ -50,19 +50,31 @@ def minres(A, b, x0=None, *, rtol=1e-5, shift=0.0, maxiter=None,
         Maximum number of iterations.  Iteration will stop after maxiter
         steps even if the specified tolerance has not been achieved.
     M : {sparse array, ndarray, LinearOperator}
-        Preconditioner for A.  The preconditioner should approximate the
-        inverse of A.  Effective preconditioning dramatically improves the
+        Preconditioner for `A`.  The preconditioner should approximate the
+        inverse of `A`.  Effective preconditioning dramatically improves the
         rate of convergence, which implies that fewer iterations are needed
         to reach a given error tolerance.
     callback : function
         User-supplied function to call after each iteration.  It is called
-        as callback(xk), where xk is the current solution vector.
+        as ``callback(xk)``, where ``xk`` is the current solution vector.
     show : bool
         If ``True``, print out a summary and metrics related to the solution
         during iterations. Default is ``False``.
     check : bool
         If ``True``, run additional input validation to check that `A` and
         `M` (if specified) are symmetric. Default is ``False``.
+
+    Notes
+    -----
+    This file is a translation of the MATLAB implementation [2]_.
+
+    References
+    ----------
+    ..[1] Solution of sparse indefinite systems of linear equations,
+          C. C. Paige and M. A. Saunders (1975),
+          SIAM J. Numer. Anal. 12(4), pp. 617-629.
+          https://web.stanford.edu/group/SOL/software/minres/
+    ..[2] https://web.stanford.edu/group/SOL/software/minres/minres-matlab.zip
 
     Examples
     --------
@@ -77,17 +89,6 @@ def minres(A, b, x0=None, *, rtol=1e-5, shift=0.0, maxiter=None,
     0
     >>> np.allclose(A.dot(x), b)
     True
-
-    References
-    ----------
-    Solution of sparse indefinite systems of linear equations,
-        C. C. Paige and M. A. Saunders (1975),
-        SIAM J. Numer. Anal. 12(4), pp. 617-629.
-        https://web.stanford.edu/group/SOL/software/minres/
-
-    This file is a translation of the following MATLAB implementation:
-        https://web.stanford.edu/group/SOL/software/minres/minres-matlab.zip
-
     """
     A, M, x, b = make_system(A, M, x0, b)
 

--- a/scipy/sparse/linalg/_isolve/minres.py
+++ b/scipy/sparse/linalg/_isolve/minres.py
@@ -70,11 +70,11 @@ def minres(A, b, x0=None, *, rtol=1e-5, shift=0.0, maxiter=None,
 
     References
     ----------
-    ..[1] Solution of sparse indefinite systems of linear equations,
+    .. [1] Solution of sparse indefinite systems of linear equations,
           C. C. Paige and M. A. Saunders (1975),
           SIAM J. Numer. Anal. 12(4), pp. 617-629.
           https://web.stanford.edu/group/SOL/software/minres/
-    ..[2] https://web.stanford.edu/group/SOL/software/minres/minres-matlab.zip
+    .. [2] https://web.stanford.edu/group/SOL/software/minres/minres-matlab.zip
 
     Examples
     --------

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -449,33 +449,6 @@ cdef class cKDTree:
         into :math:`[0, L_i)`. A ValueError is raised if any of the data is
         outside of this bound.
 
-    Notes
-    -----
-    The algorithm used is described in [1]_.
-    The general idea is that the kd-tree is a binary tree, each of whose
-    nodes represents an axis-aligned hyperrectangle. Each node specifies
-    an axis and splits the set of points based on whether their coordinate
-    along that axis is greater than or less than a particular value.
-
-    During construction, the axis and splitting point are chosen by the
-    "sliding midpoint" rule, which ensures that the cells do not all
-    become long and thin.
-
-    The tree can be queried for the r closest neighbors of any given point
-    (optionally returning only those within some maximum distance of the
-    point). It can also be queried, with a substantial gain in efficiency,
-    for the r approximate closest neighbors.
-
-    For large dimensions (20 is already large) do not expect this to run
-    significantly faster than brute force. High-dimensional nearest-neighbor
-    queries are a substantial open problem in computer science.
-
-    References
-    ----------
-    .. [1] S. Maneewongvatana and D.E. Mount, "Analysis of approximate
-           nearest neighbor searching with clustered point sets,"
-           Arxiv e-print, 1999, https://arxiv.org/pdf/cs.CG/9901013
-
     Attributes
     ----------
     data : ndarray, shape (n,m)
@@ -502,6 +475,32 @@ cdef class cKDTree:
     size : int
         The number of nodes in the tree.
 
+    Notes
+    -----
+    The algorithm used is described in [1]_.
+    The general idea is that the kd-tree is a binary tree, each of whose
+    nodes represents an axis-aligned hyperrectangle. Each node specifies
+    an axis and splits the set of points based on whether their coordinate
+    along that axis is greater than or less than a particular value.
+
+    During construction, the axis and splitting point are chosen by the
+    "sliding midpoint" rule, which ensures that the cells do not all
+    become long and thin.
+
+    The tree can be queried for the r closest neighbors of any given point
+    (optionally returning only those within some maximum distance of the
+    point). It can also be queried, with a substantial gain in efficiency,
+    for the r approximate closest neighbors.
+
+    For large dimensions (20 is already large) do not expect this to run
+    significantly faster than brute force. High-dimensional nearest-neighbor
+    queries are a substantial open problem in computer science.
+
+    References
+    ----------
+    .. [1] S. Maneewongvatana and D.E. Mount, "Analysis of approximate
+           nearest neighbor searching with clustered point sets,"
+           Arxiv e-print, 1999, https://arxiv.org/pdf/cs.CG/9901013
     """
     cdef:
         ckdtree * cself

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -261,27 +261,6 @@ class KDTree(cKDTree):
         The minimum value in each dimension of the n data points.
     size : int
         The number of nodes in the tree.
-    Attributes
-    ----------
-    data : ndarray, shape (n,m)
-        The n data points of dimension m to be indexed. This array is
-        not copied unless this is necessary to produce a contiguous
-        array of doubles. The data are also copied if the kd-tree is built
-        with ``copy_data=True``.
-    leafsize : positive int
-        The number of points at which the algorithm switches over to
-        brute-force.
-    m : int
-        The dimension of a single data-point.
-    n : int
-        The number of data points.
-    maxes : ndarray, shape (m,)
-        The maximum value in each dimension of the n data points.
-    mins : ndarray, shape (m,)
-        The minimum value in each dimension of the n data points.
-    size : int
-        The number of nodes in the tree.
-
     Notes
     -----
     The algorithm used is described in [1]_.

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -204,7 +204,8 @@ class Rectangle:
 
 
 class KDTree(cKDTree):
-    """kd-tree for quick nearest-neighbor lookup.
+    """
+    kd-tree for quick nearest-neighbor lookup.
 
     This class provides an index into a set of k-dimensional points
     which can be used to rapidly look up the nearest neighbors of any
@@ -240,6 +241,47 @@ class KDTree(cKDTree):
         into :math:`[0, L_i)`. A ValueError is raised if any of the data is
         outside of this bound.
 
+    Attributes
+    ----------
+    data : ndarray, shape (n,m)
+        The n data points of dimension m to be indexed. This array is
+        not copied unless this is necessary to produce a contiguous
+        array of doubles. The data are also copied if the kd-tree is built
+        with ``copy_data=True``.
+    leafsize : positive int
+        The number of points at which the algorithm switches over to
+        brute-force.
+    m : int
+        The dimension of a single data-point.
+    n : int
+        The number of data points.
+    maxes : ndarray, shape (m,)
+        The maximum value in each dimension of the n data points.
+    mins : ndarray, shape (m,)
+        The minimum value in each dimension of the n data points.
+    size : int
+        The number of nodes in the tree.
+    Attributes
+    ----------
+    data : ndarray, shape (n,m)
+        The n data points of dimension m to be indexed. This array is
+        not copied unless this is necessary to produce a contiguous
+        array of doubles. The data are also copied if the kd-tree is built
+        with ``copy_data=True``.
+    leafsize : positive int
+        The number of points at which the algorithm switches over to
+        brute-force.
+    m : int
+        The dimension of a single data-point.
+    n : int
+        The number of data points.
+    maxes : ndarray, shape (m,)
+        The maximum value in each dimension of the n data points.
+    mins : ndarray, shape (m,)
+        The minimum value in each dimension of the n data points.
+    size : int
+        The number of nodes in the tree.
+
     Notes
     -----
     The algorithm used is described in [1]_.
@@ -266,28 +308,6 @@ class KDTree(cKDTree):
     .. [1] S. Maneewongvatana and D.E. Mount, "Analysis of approximate
            nearest neighbor searching with clustered point sets,"
            Arxiv e-print, 1999, https://arxiv.org/pdf/cs.CG/9901013
-
-    Attributes
-    ----------
-    data : ndarray, shape (n,m)
-        The n data points of dimension m to be indexed. This array is
-        not copied unless this is necessary to produce a contiguous
-        array of doubles. The data are also copied if the kd-tree is built
-        with ``copy_data=True``.
-    leafsize : positive int
-        The number of points at which the algorithm switches over to
-        brute-force.
-    m : int
-        The dimension of a single data-point.
-    n : int
-        The number of data points.
-    maxes : ndarray, shape (m,)
-        The maximum value in each dimension of the n data points.
-    mins : ndarray, shape (m,)
-        The minimum value in each dimension of the n data points.
-    size : int
-        The number of nodes in the tree.
-
     """
 
     class node:

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -261,6 +261,7 @@ class KDTree(cKDTree):
         The minimum value in each dimension of the n data points.
     size : int
         The number of nodes in the tree.
+
     Notes
     -----
     The algorithm used is described in [1]_.

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -2403,6 +2403,10 @@ class ConvexHull(_QhullUser):
     The convex hull is computed using the
     `Qhull library <http://www.qhull.org/>`__.
 
+    References
+    ----------
+    .. [Qhull] http://www.qhull.org/
+
     Examples
     --------
 
@@ -2469,11 +2473,6 @@ class ConvexHull(_QhullUser):
     >>> convex_hull_plot_2d(hull, ax=ax)
         <Figure size 640x480 with 1 Axes> # may vary
     >>> plt.show()
-
-    References
-    ----------
-    .. [Qhull] http://www.qhull.org/
-
     """
 
     def __init__(self, points, incremental=False, qhull_options=None):
@@ -2775,6 +2774,12 @@ class HalfspaceIntersection(_QhullUser):
     `Qhull library <http://www.qhull.org/>`__.
     This reproduces the "qhalf" functionality of Qhull.
 
+    References
+    ----------
+    .. [Qhull] http://www.qhull.org/
+    .. [1] S. Boyd, L. Vandenberghe, Convex Optimization, available
+           at http://stanford.edu/~boyd/cvxbook/
+
     Examples
     --------
 
@@ -2847,13 +2852,6 @@ class HalfspaceIntersection(_QhullUser):
     >>> ax.add_patch(circle)
     >>> plt.legend(bbox_to_anchor=(1.6, 1.0))
     >>> plt.show()
-
-    References
-    ----------
-    .. [Qhull] http://www.qhull.org/
-    .. [1] S. Boyd, L. Vandenberghe, Convex Optimization, available
-           at http://stanford.edu/~boyd/cvxbook/
-
     """
 
     def __init__(self, halfspaces, interior_point,

--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -34,7 +34,8 @@ def calculate_solid_angles(R):
 
 
 class SphericalVoronoi:
-    """ Voronoi diagrams on the surface of a sphere.
+    """
+    Voronoi diagrams on the surface of a sphere.
 
     .. versionadded:: 0.18.0
 
@@ -80,6 +81,10 @@ class SphericalVoronoi:
         If there are duplicates in `points`.
         If the provided `radius` is not consistent with `points`.
 
+    See Also
+    --------
+    Voronoi : Conventional Voronoi diagrams in N dimensions.
+
     Notes
     -----
     The spherical Voronoi diagram algorithm proceeds as follows. The Convex
@@ -102,10 +107,6 @@ class SphericalVoronoi:
     .. [VanOosterom] Van Oosterom and Strackee. The solid angle of a plane
                      triangle. IEEE Transactions on Biomedical Engineering,
                      2, 1983, pp 125--126.
-
-    See Also
-    --------
-    Voronoi : Conventional Voronoi diagrams in N dimensions.
 
     Examples
     --------
@@ -162,7 +163,6 @@ class SphericalVoronoi:
     >>> _ = ax.set_zticks([])
     >>> fig.set_size_inches(4, 4)
     >>> plt.show()
-
     """
     def __init__(self, points, radius=1, center=None, threshold=1e-06):
 

--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -57,7 +57,8 @@ def normalize_dual_quaternion(dual_quat: ArrayLike) -> Array:
 
 
 class RigidTransform:
-    """Rigid transform in 3 dimensions.
+    """
+    Rigid transform in 3 dimensions.
 
     This class provides an interface to initialize from and represent rigid
     transforms (rotation and translation) in 3D space. In different fields,
@@ -119,6 +120,10 @@ class RigidTransform:
     inv
     identity
 
+    Notes
+    -----
+    .. versionadded:: 1.16.0
+
     References
     ----------
     .. [1] https://en.wikipedia.org/wiki/Rigid_transformation
@@ -130,10 +135,6 @@ class RigidTransform:
     .. [5] Paul Furgale, "Representing Robot Pose: The good, the bad, and the
            ugly", June 9, 2014.
            https://rpg.ifi.uzh.ch/docs/teaching/2024/FurgaleTutorial.pdf
-
-    Notes
-    -----
-    .. versionadded:: 1.16.0
 
     Examples
     --------

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -6247,6 +6247,12 @@ add_newdoc("pdtrik",
     scalar or ndarray
         The number of occurrences `k` such that ``pdtr(k, m) = p``
 
+    See Also
+    --------
+    pdtr : Poisson cumulative distribution function
+    pdtrc : Poisson survival function
+    pdtri : inverse of `pdtr` with respect to `m`
+
     Notes
     -----
     This function relies on the ``gamma_q_inva`` function from the Boost
@@ -6255,12 +6261,6 @@ add_newdoc("pdtrik",
     References
     ----------
     .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
-
-    See Also
-    --------
-    pdtr : Poisson cumulative distribution function
-    pdtrc : Poisson survival function
-    pdtri : inverse of `pdtr` with respect to `m`
 
     Examples
     --------

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3039,7 +3039,8 @@ def factorial(n, exact=False, extend="zero"):
 
 
 def factorial2(n, exact=False, extend="zero"):
-    """Double factorial.
+    """
+    Double factorial.
 
     This is the factorial with every second value skipped.  E.g., ``7!! = 7 * 5
     * 3 * 1``.  It can be approximated numerically as::
@@ -3078,6 +3079,11 @@ def factorial2(n, exact=False, extend="zero"):
         Double factorial of ``n``, as integer, float or complex (depending on
         ``exact`` and ``extend``). Array inputs are returned as arrays.
 
+    References
+    ----------
+    .. [1] Complex extension to double factorial
+            https://en.wikipedia.org/wiki/Double_factorial#Complex_arguments
+
     Examples
     --------
     >>> from scipy.special import factorial2
@@ -3085,11 +3091,6 @@ def factorial2(n, exact=False, extend="zero"):
     np.float64(105.00000000000001)
     >>> factorial2(7, exact=True)
     105
-
-    References
-    ----------
-    .. [1] Complex extension to double factorial
-            https://en.wikipedia.org/wiki/Double_factorial#Complex_arguments
     """
     return _factorialx_wrapper("factorial2", n, k=2, exact=exact, extend=extend)
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -3095,7 +3095,8 @@ def factorial2(n, exact=False, extend="zero"):
 
 
 def factorialk(n, k, exact=False, extend="zero"):
-    """Multifactorial of n of order k, n(!!...!).
+    """
+    Multifactorial of n of order k, n(!!...!).
 
     This is the multifactorial of n skipping k values.  For example,
 
@@ -3137,18 +3138,6 @@ def factorialk(n, k, exact=False, extend="zero"):
         Multifactorial (order ``k``) of ``n``, as integer, float or complex (depending
         on ``exact`` and ``extend``). Array inputs are returned as arrays.
 
-    Examples
-    --------
-    >>> from scipy.special import factorialk
-    >>> factorialk(5, k=1, exact=True)
-    120
-    >>> factorialk(5, k=3, exact=True)
-    10
-    >>> factorialk([5, 7, 9], k=3, exact=True)
-    array([ 10,  28, 162])
-    >>> factorialk([5, 7, 9], k=3, exact=False)
-    array([ 10.,  28., 162.])
-
     Notes
     -----
     While less straight-forward than for the double-factorial, it's possible to
@@ -3174,6 +3163,18 @@ def factorialk(n, k, exact=False, extend="zero"):
     ----------
     .. [1] Complex extension to multifactorial
             https://en.wikipedia.org/wiki/Double_factorial#Alternative_extension_of_the_multifactorial
+
+    Examples
+    --------
+    >>> from scipy.special import factorialk
+    >>> factorialk(5, k=1, exact=True)
+    120
+    >>> factorialk(5, k=3, exact=True)
+    10
+    >>> factorialk([5, 7, 9], k=3, exact=True)
+    array([ 10,  28, 162])
+    >>> factorialk([5, 7, 9], k=3, exact=False)
+    array([ 10.,  28., 162.])
     """
     return _factorialx_wrapper("factorialk", n, k=k, exact=exact, extend=extend)
 

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2559,7 +2559,8 @@ def roots_sh_legendre(n, mu=False):
 
 
 def sh_legendre(n, monic=False):
-    r"""Shifted Legendre polynomial.
+    r"""
+    Shifted Legendre polynomial.
 
     Defined as :math:`P^*_n(x) = P_n(2x - 1)` for :math:`P_n` the nth
     Legendre polynomial.
@@ -2576,6 +2577,11 @@ def sh_legendre(n, monic=False):
     -------
     P : orthopoly1d
         Shifted Legendre polynomial.
+
+    See Also
+    --------
+    scipy.special.legendre
+    scipy.special.roots_sh_legendre
 
     Notes
     -----
@@ -2600,9 +2606,9 @@ def sh_legendre(n, monic=False):
     The polynomials :math:`P_n^*` satisfy a recurrence
     relation obtained by the change of variables
     :math:`t = 2x - 1` in the standard Legendre recurrence:
-    
+
     .. math::
-    
+
         (n+1) P_{n+1}^*(x) = (2n+1)(2x-1)\,P_n^*(x) - n\,P_{n-1}^*(x).
 
     This can be easily checked on :math:`[0, 1]`
@@ -2626,11 +2632,6 @@ def sh_legendre(n, monic=False):
     >>> y = sh_legendre(2)(x) * sh_legendre(3)(x)
     >>> np.isclose(trapezoid(y, x), 0.0, atol=1e-12)
     True
-
-    See Also
-    --------
-    scipy.special.legendre
-    scipy.special.roots_sh_legendre
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8389,7 +8389,8 @@ lomax = lomax_gen(a=0.0, name="lomax")
 
 
 class pearson3_gen(rv_continuous):
-    r"""A pearson type III continuous random variable.
+    r"""
+    A pearson type III continuous random variable.
 
     %(before_notes)s
 
@@ -8419,8 +8420,6 @@ class pearson3_gen(rv_continuous):
 
     %(after_notes)s
 
-    %(example)s
-
     References
     ----------
     R.W. Vogel and D.E. McMartin, "Probability Plot Goodness-of-Fit and
@@ -8433,6 +8432,7 @@ class pearson3_gen(rv_continuous):
     "Using Modern Computing Tools to Fit the Pearson Type III Distribution to
     Aviation Loads Data", Office of Aviation Research (2003).
 
+    %(example)s
     """
     def _preprocess(self, x, skew):
         # The real 'loc' and 'scale' are handled in the calling pdf(...). The
@@ -9909,7 +9909,8 @@ skewnorm = skewnorm_gen(name='skewnorm')
 
 
 class trapezoid_gen(rv_continuous):
-    r"""A trapezoidal continuous random variable.
+    r"""
+    A trapezoidal continuous random variable.
 
     %(before_notes)s
 
@@ -9932,15 +9933,13 @@ class trapezoid_gen(rv_continuous):
     The location parameter shifts the start to `loc`.
     The scale parameter changes the width from 1 to `scale`.
 
-    %(example)s
-
     References
     ----------
     .. [1] Kacker, R.N. and Lawrence, J.F. (2007). Trapezoidal and triangular
        distributions for Type B evaluation of standard uncertainty.
        Metrologia 44, 117-127. :doi:`10.1088/0026-1394/44/2/003`
 
-
+    %(example)s
     """
     def _argcheck(self, c, d):
         return (c >= 0) & (c <= 1) & (d >= 0) & (d <= 1) & (d >= c)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -26,9 +26,14 @@ from ._stats_pythran import _poisson_binom
 
 
 class binom_gen(rv_discrete):
-    r"""A binomial discrete random variable.
+    r"""
+    A binomial discrete random variable.
 
     %(before_notes)s
+
+    See Also
+    --------
+    hypergeom, nbinom, nhypergeom
 
     Notes
     -----
@@ -55,11 +60,6 @@ class binom_gen(rv_discrete):
     .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
 
     %(example)s
-
-    See Also
-    --------
-    hypergeom, nbinom, nhypergeom
-
     """
     def _shape_info(self):
         return [_ShapeInfo("n", True, (0, np.inf), (True, False)),
@@ -193,9 +193,14 @@ bernoulli = bernoulli_gen(b=1, name='bernoulli')
 
 
 class betabinom_gen(rv_discrete):
-    r"""A beta-binomial discrete random variable.
+    r"""
+    A beta-binomial discrete random variable.
 
     %(before_notes)s
+
+    See Also
+    --------
+    beta, binom
 
     Notes
     -----
@@ -221,12 +226,7 @@ class betabinom_gen(rv_discrete):
 
     .. versionadded:: 1.4.0
 
-    See Also
-    --------
-    beta, binom
-
     %(example)s
-
     """
     def _shape_info(self):
         return [_ShapeInfo("n", True, (0, np.inf), (True, False)),
@@ -278,9 +278,14 @@ betabinom = betabinom_gen(name='betabinom')
 
 
 class nbinom_gen(rv_discrete):
-    r"""A negative binomial discrete random variable.
+    r"""
+    A negative binomial discrete random variable.
 
     %(before_notes)s
+
+    See Also
+    --------
+    hypergeom, binom, nhypergeom
 
     Notes
     -----
@@ -330,11 +335,6 @@ class nbinom_gen(rv_discrete):
     .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
 
     %(example)s
-
-    See Also
-    --------
-    hypergeom, binom, nhypergeom
-
     """
     def _shape_info(self):
         return [_ShapeInfo("n", True, (0, np.inf), (True, False)),
@@ -398,9 +398,14 @@ nbinom = nbinom_gen(name='nbinom')
 
 
 class betanbinom_gen(rv_discrete):
-    r"""A beta-negative-binomial discrete random variable.
+    r"""
+    A beta-negative-binomial discrete random variable.
 
     %(before_notes)s
+
+    See Also
+    --------
+    betabinom : Beta binomial distribution
 
     Notes
     -----
@@ -427,12 +432,7 @@ class betanbinom_gen(rv_discrete):
 
     .. versionadded:: 1.12.0
 
-    See Also
-    --------
-    betabinom : Beta binomial distribution
-
     %(example)s
-
     """
     def _shape_info(self):
         return [_ShapeInfo("n", True, (0, np.inf), (True, False)),
@@ -498,6 +498,10 @@ class geom_gen(rv_discrete):
 
     %(before_notes)s
 
+    See Also
+    --------
+    planck
+
     Notes
     -----
     The probability mass function for `geom` is:
@@ -519,12 +523,7 @@ class geom_gen(rv_discrete):
 
     %(after_notes)s
 
-    See Also
-    --------
-    planck
-
     %(example)s
-
     """
 
     def _shape_info(self):
@@ -587,6 +586,10 @@ class hypergeom_gen(rv_discrete):
 
     %(before_notes)s
 
+    See Also
+    --------
+    nhypergeom, binom, nbinom
+
     Notes
     -----
     The symbols used to denote the shape parameters (`M`, `n`, and `N`) are not
@@ -645,11 +648,6 @@ class hypergeom_gen(rv_discrete):
     And to generate random numbers:
 
     >>> R = hypergeom.rvs(M, n, N, size=10)
-
-    See Also
-    --------
-    nhypergeom, binom, nbinom
-
     """
     def _shape_info(self):
         return [_ShapeInfo("M", True, (0, np.inf), (True, False)),
@@ -746,6 +744,10 @@ class nhypergeom_gen(rv_discrete):
 
     %(before_notes)s
 
+    See Also
+    --------
+    hypergeom, binom, nbinom
+
     Notes
     -----
     The symbols used to denote the shape parameters (`M`, `n`, and `r`) are not
@@ -776,6 +778,14 @@ class nhypergeom_gen(rv_discrete):
     PMF of the hypergeometric distribution.
 
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Negative Hypergeometric Distribution on Wikipedia
+           https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution
+
+    .. [2] Negative Hypergeometric Distribution from
+           http://www.math.wm.edu/~leemis/chart/UDR/PDFs/Negativehypergeometric.pdf
 
     Examples
     --------
@@ -821,19 +831,6 @@ class nhypergeom_gen(rv_discrete):
     0.06180776620271643
     >>> hypergeom.pmf(k, M, n, k+r-1) * (M - n - (r-1)) / (M - (k+r-1))
     0.06180776620271644
-
-    See Also
-    --------
-    hypergeom, binom, nbinom
-
-    References
-    ----------
-    .. [1] Negative Hypergeometric Distribution on Wikipedia
-           https://en.wikipedia.org/wiki/Negative_hypergeometric_distribution
-
-    .. [2] Negative Hypergeometric Distribution from
-           http://www.math.wm.edu/~leemis/chart/UDR/PDFs/Negativehypergeometric.pdf
-
     """
 
     def _shape_info(self):
@@ -1038,6 +1035,10 @@ class planck_gen(rv_discrete):
 
     %(before_notes)s
 
+    See Also
+    --------
+    geom
+
     Notes
     -----
     The probability mass function for `planck` is:
@@ -1054,12 +1055,7 @@ class planck_gen(rv_discrete):
 
     %(after_notes)s
 
-    See Also
-    --------
-    geom
-
     %(example)s
-
     """
     def _shape_info(self):
         return [_ShapeInfo("lambda_", False, (0, np.inf), (False, False))]

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -416,6 +416,12 @@ def compare_medians_ms(group_1, group_2, axis=None):
         ndarray of floats with a length equal to the length of `group_1`
         along `axis`.
 
+    References
+    ----------
+    .. [1] McKean, Joseph W., and Ronald M. Schrader. "A comparison of methods
+       for studentizing the sample median." Communications in
+       Statistics-Simulation and Computation 13.6 (1984): 751-773.
+
     Examples
     --------
 
@@ -433,13 +439,6 @@ def compare_medians_ms(group_1, group_2, axis=None):
     >>> y = rng.random(size=(3, 8))
     >>> stats.mstats.compare_medians_ms(x, y, axis=1)
     array([0.36908985, 0.36092538, 0.2765313 ])
-
-    References
-    ----------
-    .. [1] McKean, Joseph W., and Ronald M. Schrader. "A comparison of methods
-       for studentizing the sample median." Communications in
-       Statistics-Simulation and Computation 13.6 (1984): 751-773.
-
     """
     (med_1, med_2) = (ma.median(group_1,axis=axis), ma.median(group_2,axis=axis))
     (std_1, std_2) = (mstats.stde_median(group_1, axis=axis),

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -4280,17 +4280,13 @@ for name in ['logpmf', 'pmf', 'mean', 'cov', 'rvs']:
 
 
 class special_ortho_group_gen(multi_rv_generic):
-    r"""A Special Orthogonal matrix (SO(N)) random variable.
+    r"""
+    A Special Orthogonal matrix (SO(N)) random variable.
 
     Return a random rotation matrix, drawn from the Haar distribution
     (the only uniform distribution on SO(N)) with a determinant of +1.
 
     The `dim` keyword specifies the dimension N.
-
-    Methods
-    -------
-    rvs(dim=None, size=1, random_state=None)
-        Draw random samples from SO(N).
 
     Parameters
     ----------
@@ -4304,6 +4300,15 @@ class special_ortho_group_gen(multi_rv_generic):
         If `seed` is already a ``RandomState`` or ``Generator`` instance,
         then that object is used.
         Default is `None`.
+
+    Methods
+    -------
+    rvs(dim=None, size=1, random_state=None)
+        Draw random samples from SO(N).
+
+    See Also
+    --------
+    ortho_group, scipy.spatial.transform.Rotation.random
 
     Notes
     -----
@@ -4339,11 +4344,6 @@ class special_ortho_group_gen(multi_rv_generic):
     >>> rv = special_ortho_group(5)
     >>> # Frozen object with the same methods but holding the
     >>> # dimension parameter fixed.
-
-    See Also
-    --------
-    ortho_group, scipy.spatial.transform.Rotation.random
-
     """
 
     def __init__(self, seed=None):
@@ -4425,17 +4425,13 @@ class special_ortho_group_frozen(multi_rv_frozen):
 
 
 class ortho_group_gen(multi_rv_generic):
-    r"""An Orthogonal matrix (O(N)) random variable.
+    r"""
+    An Orthogonal matrix (O(N)) random variable.
 
     Return a random orthogonal matrix, drawn from the O(N) Haar
     distribution (the only uniform distribution on O(N)).
 
     The `dim` keyword specifies the dimension N.
-
-    Methods
-    -------
-    rvs(dim=None, size=1, random_state=None)
-        Draw random samples from O(N).
 
     Parameters
     ----------
@@ -4449,6 +4445,15 @@ class ortho_group_gen(multi_rv_generic):
         If `seed` is already a ``RandomState`` or ``Generator`` instance,
         then that object is used.
         Default is `None`.
+
+    Methods
+    -------
+    rvs(dim=None, size=1, random_state=None)
+        Draw random samples from O(N).
+
+    See Also
+    --------
+    special_ortho_group
 
     Notes
     -----
@@ -4485,10 +4490,6 @@ class ortho_group_gen(multi_rv_generic):
     >>> rv = ortho_group(5)
     >>> # Frozen object with the same methods but holding the
     >>> # dimension parameter fixed.
-
-    See Also
-    --------
-    special_ortho_group
     """
 
     def __init__(self, seed=None):
@@ -4580,18 +4581,14 @@ class ortho_group_frozen(multi_rv_frozen):
 
 
 class random_correlation_gen(multi_rv_generic):
-    r"""A random correlation matrix.
+    r"""
+    A random correlation matrix.
 
     Return a random correlation matrix, given a vector of eigenvalues.
     The returned matrix is symmetric positive semidefinite with unit diagonal.
 
     The `eigs` keyword specifies the eigenvalues of the correlation matrix,
     and implies the dimension.
-
-    Methods
-    -------
-    rvs(eigs=None, random_state=None)
-        Draw random correlation matrices, all with eigenvalues eigs.
 
     Parameters
     ----------
@@ -4611,17 +4608,22 @@ class random_correlation_gen(multi_rv_generic):
         Tolerance for deviation of the diagonal of the resulting
         matrix. Default: 1e-7
 
-    Raises
-    ------
-    RuntimeError
-        Floating point error prevented generating a valid correlation
-        matrix.
+    Methods
+    -------
+    rvs(eigs=None, random_state=None)
+        Draw random correlation matrices, all with eigenvalues eigs.
 
     Returns
     -------
     rvs : ndarray or scalar
         Random size N-dimensional matrices, dimension (size, dim, dim),
         each having eigenvalues eigs.
+
+    Raises
+    ------
+    RuntimeError
+        Floating point error prevented generating a valid correlation
+        matrix.
 
     Notes
     -----
@@ -4654,7 +4656,6 @@ class random_correlation_gen(multi_rv_generic):
     >>> e, v = scipy.linalg.eigh(x)
     >>> e
     array([ 0.5,  0.8,  1.2,  1.5])
-
     """
 
     def __init__(self, seed=None):
@@ -4851,16 +4852,12 @@ class random_correlation_frozen(multi_rv_frozen):
 
 
 class unitary_group_gen(multi_rv_generic):
-    r"""A matrix-valued U(N) random variable.
+    r"""
+    A matrix-valued U(N) random variable.
 
     Return a random unitary matrix.
 
     The `dim` keyword specifies the dimension N.
-
-    Methods
-    -------
-    rvs(dim=None, size=1, random_state=None)
-        Draw random samples from U(N).
 
     Parameters
     ----------
@@ -4874,6 +4871,15 @@ class unitary_group_gen(multi_rv_generic):
         If `seed` is already a ``RandomState`` or ``Generator`` instance,
         then that object is used.
         Default is `None`.
+
+    Methods
+    -------
+    rvs(dim=None, size=1, random_state=None)
+        Draw random samples from U(N).
+
+    See Also
+    --------
+    ortho_group
 
     Notes
     -----
@@ -4902,11 +4908,6 @@ class unitary_group_gen(multi_rv_generic):
     parameter, return a "frozen" unitary_group random variable:
 
     >>> rv = unitary_group(5)
-
-    See Also
-    --------
-    ortho_group
-
     """
 
     def __init__(self, seed=None):
@@ -6098,7 +6099,8 @@ for name in ['logpmf', 'pmf', 'mean', 'var', 'cov', 'rvs']:
 
 
 class random_table_gen(multi_rv_generic):
-    r"""Contingency tables from independent samples with fixed marginal sums.
+    r"""
+    Contingency tables from independent samples with fixed marginal sums.
 
     This is the distribution of random tables with given row and column vector
     sums. This distribution represents the set of random tables under the null
@@ -6108,6 +6110,11 @@ class random_table_gen(multi_rv_generic):
     Because of assumed independence, the expected frequency of each table
     element can be computed from the row and column sums, so that the
     distribution is completely determined by these two vectors.
+
+    Parameters
+    ----------
+    %(_doc_row_col)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -6119,11 +6126,6 @@ class random_table_gen(multi_rv_generic):
         Mean table.
     rvs(row, col, size=None, method=None, random_state=None)
         Draw random tables with given row and column vector sums.
-
-    Parameters
-    ----------
-    %(_doc_row_col)s
-    %(_doc_random_state)s
 
     Notes
     -----
@@ -6139,6 +6141,11 @@ class random_table_gen(multi_rv_generic):
     Allowed values are "boyett" and "patefield".
 
     .. versionadded:: 1.10.0
+
+    References
+    ----------
+    .. [1] J. Boyett, AS 144 Appl. Statist. 28 (1979) 329-332
+    .. [2] W.M. Patefield, AS 159 Appl. Statist. 30 (1981) 91-97
 
     Examples
     --------
@@ -6157,11 +6164,6 @@ class random_table_gen(multi_rv_generic):
     >>> dist.rvs(random_state=123)
     array([[1, 0, 0],
            [1, 3, 1]])
-
-    References
-    ----------
-    .. [1] J. Boyett, AS 144 Appl. Statist. 28 (1979) 329-332
-    .. [2] W.M. Patefield, AS 159 Appl. Statist. 30 (1981) 91-97
     """
 
     def __init__(self, seed=None):
@@ -6535,15 +6537,11 @@ for name in ['logpmf', 'pmf', 'mean', 'rvs']:
 
 
 class uniform_direction_gen(multi_rv_generic):
-    r"""A vector-valued uniform direction.
+    r"""
+    A vector-valued uniform direction.
 
     Return a random direction (unit vector). The `dim` keyword specifies
     the dimensionality of the space.
-
-    Methods
-    -------
-    rvs(dim=None, size=1, random_state=None)
-        Draw random directions.
 
     Parameters
     ----------
@@ -6559,6 +6557,11 @@ class uniform_direction_gen(multi_rv_generic):
         If `seed` is already a ``RandomState`` or ``Generator`` instance,
         then that object is used.
         Default is `None`.
+
+    Methods
+    -------
+    rvs(dim=None, size=1, random_state=None)
+        Draw random directions.
 
     Notes
     -----
@@ -7023,23 +7026,11 @@ for name in ['logpmf', 'pmf', 'mean', 'var', 'cov']:
 
 
 class vonmises_fisher_gen(multi_rv_generic):
-    r"""A von Mises-Fisher variable.
+    r"""
+    A von Mises-Fisher variable.
 
     The `mu` keyword specifies the mean direction vector. The `kappa` keyword
     specifies the concentration parameter.
-
-    Methods
-    -------
-    pdf(x, mu=None, kappa=1)
-        Probability density function.
-    logpdf(x, mu=None, kappa=1)
-        Log of the probability density function.
-    rvs(mu=None, kappa=1, size=1, random_state=None)
-        Draw random samples from a von Mises-Fisher distribution.
-    entropy(mu=None, kappa=1)
-        Compute the differential entropy of the von Mises-Fisher distribution.
-    fit(data)
-        Fit a von Mises-Fisher distribution to data.
 
     Parameters
     ----------
@@ -7056,6 +7047,19 @@ class vonmises_fisher_gen(multi_rv_generic):
         If `seed` is already a ``RandomState`` or ``Generator`` instance,
         then that object is used.
         Default is `None`.
+
+    Methods
+    -------
+    pdf(x, mu=None, kappa=1)
+        Probability density function.
+    logpdf(x, mu=None, kappa=1)
+        Log of the probability density function.
+    rvs(mu=None, kappa=1, size=1, random_state=None)
+        Draw random samples from a von Mises-Fisher distribution.
+    entropy(mu=None, kappa=1)
+        Compute the differential entropy of the von Mises-Fisher distribution.
+    fit(data)
+        Fit a von Mises-Fisher distribution to data.
 
     See Also
     --------
@@ -7231,7 +7235,6 @@ class vonmises_fisher_gen(multi_rv_generic):
 
     We see that the estimated parameters `mu_fit` and `kappa_fit` are
     very close to the ground truth parameters.
-
     """
     def __init__(self, seed=None):
         super().__init__(seed)
@@ -7730,23 +7733,11 @@ class vonmises_fisher_frozen(multi_rv_frozen):
 
 
 class normal_inverse_gamma_gen(multi_rv_generic):
-    r"""Normal-inverse-gamma distribution.
+    r"""
+    Normal-inverse-gamma distribution.
 
     The normal-inverse-gamma distribution is the conjugate prior of a normal
     distribution with unknown mean and variance.
-
-    Methods
-    -------
-    pdf(x, s2, mu=0, lmbda=1, a=1, b=1)
-        Probability density function.
-    logpdf(x, s2, mu=0, lmbda=1, a=1, b=1)
-        Log of the probability density function.
-    mean(mu=0, lmbda=1, a=1, b=1)
-        Distribution mean.
-    var(mu=0, lmbda=1, a=1, b=1)
-        Distribution variance.
-    rvs(mu=0, lmbda=1, a=1, b=1, size=None, random_state=None)
-        Draw random samples.
 
     Parameters
     ----------
@@ -7760,6 +7751,19 @@ class normal_inverse_gamma_gen(multi_rv_generic):
         If `seed` is already a ``RandomState`` or ``Generator`` instance,
         then that object is used.
         Default is `None`.
+
+    Methods
+    -------
+    pdf(x, s2, mu=0, lmbda=1, a=1, b=1)
+        Probability density function.
+    logpdf(x, s2, mu=0, lmbda=1, a=1, b=1)
+        Log of the probability density function.
+    mean(mu=0, lmbda=1, a=1, b=1)
+        Distribution mean.
+    var(mu=0, lmbda=1, a=1, b=1)
+        Distribution variance.
+    rvs(mu=0, lmbda=1, a=1, b=1, size=None, random_state=None)
+        Draw random samples.
 
     See Also
     --------
@@ -7844,7 +7848,6 @@ class normal_inverse_gamma_gen(multi_rv_generic):
     (np.float64(1.0546150578185023), np.float64(0.061829865266330754))
     >>> norm_inv_gamma.var()
     (np.float64(1.0526315789473684), np.float64(0.061557402277623886))
-
     """
     def rvs(self, mu=0, lmbda=1, a=1, b=1, size=None, random_state=None):
         """Draw random samples from the distribution.

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -344,10 +344,16 @@ mvn_docdict_noparams = {
 
 
 class multivariate_normal_gen(multi_rv_generic):
-    r"""A multivariate normal random variable.
+    r"""
+    A multivariate normal random variable.
 
     The `mean` keyword specifies the mean. The `cov` keyword specifies the
     covariance matrix.
+
+    Parameters
+    ----------
+    %(_mvn_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -367,11 +373,6 @@ class multivariate_normal_gen(multi_rv_generic):
         Return a marginal multivariate normal distribution.
     fit(x, fix_mean=None, fix_cov=None)
         Fit a multivariate normal distribution to data.
-
-    Parameters
-    ----------
-    %(_mvn_doc_default_callparams)s
-    %(_doc_random_state)s
 
     Notes
     -----
@@ -441,7 +442,6 @@ class multivariate_normal_gen(multi_rv_generic):
     >>> fig2 = plt.figure()
     >>> ax2 = fig2.add_subplot(111)
     >>> ax2.contourf(x, y, rv.pdf(pos))
-
     """  # noqa: E501
 
     def __init__(self, seed=None):
@@ -1111,11 +1111,17 @@ matnorm_docdict_noparams = {
 
 
 class matrix_normal_gen(multi_rv_generic):
-    r"""A matrix normal random variable.
+    r"""
+    A matrix normal random variable.
 
     The `mean` keyword specifies the mean. The `rowcov` keyword specifies the
     among-row covariance matrix. The 'colcov' keyword specifies the
     among-column covariance matrix.
+
+    Parameters
+    ----------
+    %(_matnorm_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -1127,11 +1133,6 @@ class matrix_normal_gen(multi_rv_generic):
         Draw random samples.
     entropy(rowcol=1, colcov=1)
         Differential entropy.
-
-    Parameters
-    ----------
-    %(_matnorm_doc_default_callparams)s
-    %(_doc_random_state)s
 
     Notes
     -----
@@ -1208,7 +1209,6 @@ class matrix_normal_gen(multi_rv_generic):
     >>> rv = matrix_normal(mean=None, rowcov=1, colcov=1)
     >>> # Frozen object with the same methods but holding the given
     >>> # mean and covariance fixed.
-
     """
 
     def __init__(self, seed=None):
@@ -1577,11 +1577,17 @@ matrix_t_docdict_noparams = {
 
 
 class matrix_t_gen(multi_rv_generic):
-    r"""A matrix t-random variable.
+    r"""
+    A matrix t-random variable.
 
     The `mean` keyword specifies the mean.
     The `row_spread` keyword specifies the row-wise spread matrix.
     The `col_spread` keyword specifies the column-wise spread matrix.
+
+    Parameters
+    ----------
+    %(_matt_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -1591,11 +1597,6 @@ class matrix_t_gen(multi_rv_generic):
         Log of the probability density function.
     rvs(mean=None, row_spread=1, col_spread=1, df=1, size=1, random_state=None)
         Draw random samples.
-
-    Parameters
-    ----------
-    %(_matt_doc_default_callparams)s
-    %(_doc_random_state)s
 
     Notes
     -----
@@ -2258,12 +2259,18 @@ def _lnB(alpha):
 
 
 class dirichlet_gen(multi_rv_generic):
-    r"""A Dirichlet random variable.
+    r"""
+    A Dirichlet random variable.
 
     The ``alpha`` keyword specifies the concentration parameters of the
     distribution.
 
     .. versionadded:: 0.15.0
+
+    Parameters
+    ----------
+    %(_dirichlet_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -2281,11 +2288,6 @@ class dirichlet_gen(multi_rv_generic):
         The covariance of the Dirichlet distribution
     entropy(alpha)
         Compute the differential entropy of the Dirichlet distribution.
-
-    Parameters
-    ----------
-    %(_dirichlet_doc_default_callparams)s
-    %(_doc_random_state)s
 
     Notes
     -----
@@ -2362,7 +2364,6 @@ class dirichlet_gen(multi_rv_generic):
     >>> rv = dirichlet(alpha)
     >>> # Frozen object with the same methods but holding the given
     >>> # concentration parameters fixed.
-
     """
 
     def __init__(self, seed=None):
@@ -3293,12 +3294,18 @@ for name in ['logpdf', 'pdf', 'mean', 'mode', 'var', 'rvs', 'entropy']:
 
 
 class invwishart_gen(wishart_gen):
-    r"""An inverse Wishart random variable.
+    r"""
+    An inverse Wishart random variable.
 
     The `df` keyword specifies the degrees of freedom. The `scale` keyword
     specifies the scale matrix, which must be symmetric and positive definite.
     In this context, the scale matrix is often interpreted in terms of a
     multivariate normal covariance matrix.
+
+    Parameters
+    ----------
+    %(_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -3310,11 +3317,6 @@ class invwishart_gen(wishart_gen):
         Draw random samples from an inverse Wishart distribution.
     entropy(df, scale)
         Differential entropy of the distribution.
-
-    Parameters
-    ----------
-    %(_doc_default_callparams)s
-    %(_doc_random_state)s
 
     Raises
     ------
@@ -3405,7 +3407,6 @@ class invwishart_gen(wishart_gen):
     >>> rv = invwishart(df=1, scale=1)
     >>> # Frozen object with the same methods but holding the given
     >>> # degrees of freedom and scale fixed.
-
     """
 
     def __init__(self, seed=None):
@@ -3879,7 +3880,13 @@ multinomial_docdict_noparams = {
 
 
 class multinomial_gen(multi_rv_generic):
-    r"""A multinomial random variable.
+    r"""
+    A multinomial random variable.
+
+    Parameters
+    ----------
+    %(_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -3894,10 +3901,12 @@ class multinomial_gen(multi_rv_generic):
     cov(n, p)
         Compute the covariance matrix of the multinomial distribution.
 
-    Parameters
-    ----------
-    %(_doc_default_callparams)s
-    %(_doc_random_state)s
+    See Also
+    --------
+    scipy.stats.binom : The binomial distribution.
+    numpy.random.Generator.multinomial : Sampling from the multinomial distribution.
+    scipy.stats.multivariate_hypergeom :
+        The multivariate hypergeometric distribution.
 
     Notes
     -----
@@ -3974,13 +3983,6 @@ class multinomial_gen(multi_rv_generic):
     >>> rv = multinomial(n=7, p=[.3, .7])
     >>> # Frozen object with the same methods but holding the given
     >>> # degrees of freedom and scale fixed.
-
-    See Also
-    --------
-    scipy.stats.binom : The binomial distribution.
-    numpy.random.Generator.multinomial : Sampling from the multinomial distribution.
-    scipy.stats.multivariate_hypergeom :
-        The multivariate hypergeometric distribution.
     """
 
     def __init__(self, seed=None):
@@ -5035,7 +5037,8 @@ mvt_docdict_noparams = {
 
 
 class multivariate_t_gen(multi_rv_generic):
-    r"""A multivariate t-distributed random variable.
+    r"""
+    A multivariate t-distributed random variable.
 
     The `loc` parameter specifies the location. The `shape` parameter specifies
     the positive semidefinite shape matrix. The `df` parameter specifies the
@@ -5044,6 +5047,11 @@ class multivariate_t_gen(multi_rv_generic):
     In addition to calling the methods below, the object itself may be called
     as a function to fix the location, shape matrix, and degrees of freedom
     parameters, returning a "frozen" multivariate t-distribution random.
+
+    Parameters
+    ----------
+    %(_mvt_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -5060,11 +5068,6 @@ class multivariate_t_gen(multi_rv_generic):
         Differential entropy of a multivariate t-distribution.
     marginal(dimensions, loc=None, shape=1, df=1, allow_singular=False)
         Return a marginal multivariate t-distribution.
-
-    Parameters
-    ----------
-    %(_mvt_doc_default_callparams)s
-    %(_doc_random_state)s
 
     Notes
     -----
@@ -5116,7 +5119,6 @@ class multivariate_t_gen(multi_rv_generic):
     >>> fig, ax = plt.subplots(1, 1)
     >>> ax.set_aspect('equal')
     >>> plt.contourf(x, y, rv.pdf(pos))
-
     """
 
     def __init__(self, seed=None):
@@ -5646,7 +5648,13 @@ mhg_docdict_noparams = {
 
 
 class multivariate_hypergeom_gen(multi_rv_generic):
-    r"""A multivariate hypergeometric random variable.
+    r"""
+    A multivariate hypergeometric random variable.
+
+    Parameters
+    ----------
+    %(_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -5665,10 +5673,10 @@ class multivariate_hypergeom_gen(multi_rv_generic):
         Compute the covariance matrix of the multivariate
         hypergeometric distribution.
 
-    Parameters
-    ----------
-    %(_doc_default_callparams)s
-    %(_doc_random_state)s
+    See Also
+    --------
+    scipy.stats.hypergeom : The hypergeometric distribution.
+    scipy.stats.multinomial : The multinomial distribution.
 
     Notes
     -----
@@ -5689,6 +5697,14 @@ class multivariate_hypergeom_gen(multi_rv_generic):
     from the population.
 
     .. versionadded:: 1.6.0
+
+    References
+    ----------
+    .. [1] The Multivariate Hypergeometric Distribution,
+           http://www.randomservices.org/random/urn/MultiHypergeometric.html
+    .. [2] Thomas J. Sargent and John Stachurski, 2020,
+           Multivariate Hypergeometric Distribution
+           https://python.quantecon.org/multi_hyper.html
 
     Examples
     --------
@@ -5744,19 +5760,6 @@ class multivariate_hypergeom_gen(multi_rv_generic):
     >>> rv = multivariate_hypergeom(m=[10, 20], n=12)
     >>> rv.pmf(x=[8, 4])
     0.0025207176631464523
-
-    See Also
-    --------
-    scipy.stats.hypergeom : The hypergeometric distribution.
-    scipy.stats.multinomial : The multinomial distribution.
-
-    References
-    ----------
-    .. [1] The Multivariate Hypergeometric Distribution,
-           http://www.randomservices.org/random/urn/MultiHypergeometric.html
-    .. [2] Thomas J. Sargent and John Stachurski, 2020,
-           Multivariate Hypergeometric Distribution
-           https://python.quantecon.org/multi_hyper.html
     """
     def __init__(self, seed=None):
         super().__init__(seed)
@@ -6770,12 +6773,18 @@ def _dirichlet_multinomial_check_parameters(alpha, n, x=None):
 
 
 class dirichlet_multinomial_gen(multi_rv_generic):
-    r"""A Dirichlet multinomial random variable.
+    r"""
+    A Dirichlet multinomial random variable.
 
     The Dirichlet multinomial distribution is a compound probability
     distribution: it is the multinomial distribution with number of trials
     `n` and class probabilities ``p`` randomly sampled from a Dirichlet
     distribution with concentration parameters ``alpha``.
+
+    Parameters
+    ----------
+    %(_dirichlet_mn_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -6789,11 +6798,6 @@ class dirichlet_multinomial_gen(multi_rv_generic):
         Variance of the Dirichlet multinomial distribution.
     cov(alpha, n):
         The covariance of the Dirichlet multinomial distribution.
-
-    Parameters
-    ----------
-    %(_dirichlet_mn_doc_default_callparams)s
-    %(_doc_random_state)s
 
     See Also
     --------
@@ -6874,7 +6878,6 @@ class dirichlet_multinomial_gen(multi_rv_generic):
     >>> n = [[6], [7], [8]]
     >>> dirichlet_multinomial.mean(alpha, n).shape
     (3, 4, 2)
-
     """
     def __init__(self, seed=None):
         super().__init__(seed)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2610,7 +2610,8 @@ wishart_docdict_noparams = {
 
 
 class wishart_gen(multi_rv_generic):
-    r"""A Wishart random variable.
+    r"""
+    A Wishart random variable.
 
     The `df` keyword specifies the degrees of freedom. The `scale` keyword
     specifies the scale matrix, which must be symmetric and positive definite.
@@ -2619,6 +2620,11 @@ class wishart_gen(multi_rv_generic):
     matrix). These arguments must satisfy the relationship
     ``df > scale.ndim - 1``, but see notes on using the `rvs` method with
     ``df < scale.ndim``.
+
+    Parameters
+    ----------
+    %(_doc_default_callparams)s
+    %(_doc_random_state)s
 
     Methods
     -------
@@ -2630,11 +2636,6 @@ class wishart_gen(multi_rv_generic):
         Draw random samples from a Wishart distribution.
     entropy()
         Compute the differential entropy of the Wishart distribution.
-
-    Parameters
-    ----------
-    %(_doc_default_callparams)s
-    %(_doc_random_state)s
 
     Raises
     ------
@@ -2718,7 +2719,6 @@ class wishart_gen(multi_rv_generic):
     >>> rv = wishart(df=1, scale=1)
     >>> # Frozen object with the same methods but holding the given
     >>> # degrees of freedom and scale fixed.
-
     """
 
     def __init__(self, seed=None):

--- a/tools/numpydoc_lint.py
+++ b/tools/numpydoc_lint.py
@@ -12,7 +12,6 @@ skip_errors = [
     "GL02",
     "GL03",
     "GL05",
-    "GL07",
     "GL09",
     "SS02",
     "SS03",


### PR DESCRIPTION
Numpydoc defines what order sections in the documentation should appear in. SciPy mostly follow this although there are a few functions which don't This PR fixes these violations and enables a check to prevent future regressions.