### PR TITLE
DOC: integrate.nsum: correct documentation of `tolerances` argument

### DIFF
--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -1018,12 +1018,12 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
         The maximum number of terms to evaluate for direct summation.
         Additional function evaluations may be performed for input
         validation and integral evaluation.
-    atol, rtol : float, optional
-        Absolute termination tolerance (default: 0) and relative termination
-        tolerance (default: ``eps**0.5``, where ``eps`` is the precision of
-        the result dtype), respectively. Must be non-negative
-        and finite if `log` is False, and must be expressed as the log of a
-        non-negative and finite number if `log` is True.
+    tolerances : float, optional
+        Dictionary with recognized keys ``atol`` for absolute termination tolerance
+        (default: 0) and ``rtol`` for relative termination tolerance (default:
+        ``eps**0.5``, where ``eps`` is the precision of the result dtype), respectively.
+        Values must be non-negative and finite if `log` is False, and must be expressed
+        as the log of a non-negative and finite number if `log` is True.
 
     Returns
     -------

--- a/scipy/integrate/_tanhsinh.py
+++ b/scipy/integrate/_tanhsinh.py
@@ -1018,7 +1018,7 @@ def nsum(f, a, b, *, step=1, args=(), log=False, maxterms=int(2**20), tolerances
         The maximum number of terms to evaluate for direct summation.
         Additional function evaluations may be performed for input
         validation and integral evaluation.
-    tolerances : float, optional
+    tolerances : dict, optional
         Dictionary with recognized keys ``atol`` for absolute termination tolerance
         (default: 0) and ``rtol`` for relative termination tolerance (default:
         ``eps**0.5``, where ``eps`` is the precision of the result dtype), respectively.


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
Regarding gh-20834, @j-bowhay noted

> looks like we forgot to update the documentation here because the argument is actually called `tolerances`. Do you mind opening a PR to update the docs

This fixes the documentation of the `tolerances` argument.