### PR TITLE
DOC: enable YD01 check

### DIFF
--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -227,7 +227,7 @@ def set_workers(workers):
     >>> with fft.set_workers(4):
     ...     y = signal.fftconvolve(x, x)
 
-    """
+    """  # numpydoc ignore=YD01
     old_workers = get_workers()
     _config.default_workers = _workers(operator.index(workers))
     try:

--- a/tools/numpydoc_lint.py
+++ b/tools/numpydoc_lint.py
@@ -33,7 +33,6 @@ skip_errors = [
     "RT03",
     "RT04",
     "RT05",
-    "YD01",
     "SA01",
     "SA02",
     "SA03",


### PR DESCRIPTION
Enables the numpydoc validation doc `YD01` which requires the docstring to have a yields section if it yields anything.

Fixes the one violation by skipping the check as the use case is a slightly odd one where the `yield` is really being used to do something else rather then yielding an actual value.