### PR TITLE
DOC: enable PR10

### DIFF
--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -1417,7 +1417,7 @@ def qr_delete(Q, R, k, int p=1, which='row', overwrite_qr=False,
         Index of the first row or column to delete.
     p : int, optional
         Number of rows or columns to delete, defaults to 1.
-    which: {'row', 'col'}, optional
+    which : {'row', 'col'}, optional
         Determines if rows or columns will be deleted, defaults to 'row'
     overwrite_qr : bool, optional
         If True, consume Q and R, overwriting their contents with their
@@ -1634,7 +1634,7 @@ def qr_insert(Q, R, u, k, which='row', rcond=None, overwrite_qru=False, check_fi
         Rows or columns to insert
     k : int
         Index before which `u` is to be inserted.
-    which: {'row', 'col'}, optional
+    which : {'row', 'col'}, optional
         Determines if rows or columns will be inserted, defaults to 'row'
     rcond : float
         Lower bound on the reciprocal condition number of ``Q`` augmented with

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -74,11 +74,11 @@ class NonlinearConstraint:
         Whether to keep the constraint components feasible throughout
         iterations. A single value sets this property for all components.
         Default is False. Has no effect for equality constraints.
-    finite_diff_rel_step: None or array_like, optional
+    finite_diff_rel_step : None or array_like, optional
         Relative step size for the finite difference approximation. Default is
         None, which will select a reasonable value automatically depending
         on a finite difference scheme.
-    finite_diff_jac_sparsity: {None, array_like, sparse array}, optional
+    finite_diff_jac_sparsity : {None, array_like, sparse array}, optional
         Defines the sparsity structure of the Jacobian matrix for finite
         difference estimation, its shape must be (m, n). If the Jacobian has
         only few non-zero elements in *each* row, providing the sparsity

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -2709,19 +2709,19 @@ def place_poles(A, B, poles, method="YT", rtol=1e-3, maxiter=30):
     poles : array_like
         Desired real poles and/or complex conjugates poles.
         Complex poles are only supported with ``method="YT"`` (default).
-    method: {'YT', 'KNV0'}, optional
+    method : {'YT', 'KNV0'}, optional
         Which method to choose to find the gain matrix K. One of:
 
         - 'YT': Yang Tits
         - 'KNV0': Kautsky, Nichols, Van Dooren update method 0
 
         See References and Notes for details on the algorithms.
-    rtol: float, optional
+    rtol : float, optional
         After each iteration the determinant of the eigenvectors of
         ``A - B*K`` is compared to its previous value, when the relative
         error between these two values becomes lower than `rtol` the algorithm
         stops.  Default is 1e-3.
-    maxiter: int, optional
+    maxiter : int, optional
         Maximum number of iterations to compute the gain matrix.
         Default is 30.
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -1494,7 +1494,7 @@ def stft(x, fs=1.0, window='hann_periodic', nperseg=256, noverlap=None, nfft=Non
     axis : int, optional
         Axis along which the STFT is computed; the default is over the
         last axis (i.e. ``axis=-1``).
-    scaling: {'spectrum', 'psd'}
+    scaling : {'spectrum', 'psd'}
         The default 'spectrum' scaling allows each frequency line of `Zxx` to
         be interpreted as a magnitude spectrum. The 'psd' option scales each
         line to a power spectral density - it allows to calculate the signal's
@@ -1684,7 +1684,7 @@ def istft(Zxx, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft
     freq_axis : int, optional
         Where the frequency axis of the STFT is located; the default is
         the penultimate axis (i.e. ``axis=-2``).
-    scaling: {'spectrum', 'psd'}
+    scaling : {'spectrum', 'psd'}
         The default 'spectrum' scaling allows each frequency line of `Zxx` to
         be interpreted as a magnitude spectrum. The 'psd' option scales each
         line to a power spectral density - it allows to calculate the signal's

--- a/scipy/sparse/csgraph/_flow.pyx
+++ b/scipy/sparse/csgraph/_flow.pyx
@@ -50,7 +50,7 @@ def maximum_flow(csgraph, source, sink, *, method='dinic'):
         The source vertex from which the flow flows.
     sink : int
         The sink vertex to which the flow flows.
-    method: {'edmonds_karp', 'dinic'}, optional
+    method : {'edmonds_karp', 'dinic'}, optional
         The method/algorithm to be used for computing the maximum flow.
         Following methods are supported,
 

--- a/scipy/sparse/csgraph/_laplacian.py
+++ b/scipy/sparse/csgraph/_laplacian.py
@@ -38,11 +38,11 @@ def laplacian(
         If True, then use out-degree instead of in-degree.
         This distinction matters only if the graph is asymmetric.
         Default: False.
-    copy: bool, optional
+    copy : bool, optional
         If False, then change `csgraph` in place if possible,
         avoiding doubling the memory use.
         Default: True, for backward compatibility.
-    form: 'array', or 'function', or 'lo'
+    form : 'array', or 'function', or 'lo'
         Determines the format of the output Laplacian:
 
         * 'array' is a numpy array;
@@ -53,14 +53,14 @@ def laplacian(
         Choosing 'function' or 'lo' always avoids doubling
         the memory use, ignoring `copy` value.
         Default: 'array', for backward compatibility.
-    dtype: None or one of numeric numpy dtypes, optional
+    dtype : None or one of numeric numpy dtypes, optional
         The dtype of the output. If ``dtype=None``, the dtype of the
         output matches the dtype of the input csgraph, except for
         the case ``normed=True`` and integer-like csgraph, where
         the output dtype is 'float' allowing accurate normalization,
         but dramatically increasing the memory use.
         Default: None, for backward compatibility.
-    symmetrized: bool, optional
+    symmetrized : bool, optional
         If True, then the output Laplacian is symmetric/Hermitian.
         The symmetrization is done by ``csgraph + csgraph.T.conj``
         without dividing by 2 to preserve integer dtypes if possible

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -752,7 +752,7 @@ const char *binom_doc = R"(
 
     Parameters
     ----------
-    x, y: array_like
+    x, y : array_like
        Real arguments to :math:`\binom{x}{y}`.
     out : ndarray, optional
         Optional output array for the function values
@@ -1535,7 +1535,7 @@ const char *exp1_doc = R"(
 
     Parameters
     ----------
-    z: array_like
+    z : array_like
         Real or complex argument.
     out : ndarray, optional
         Optional output array for the function results

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3792,7 +3792,7 @@ def f_oneway(*samples, axis=0, equal_var=True):
     axis : int, optional
         Axis of the input arrays along which the test is applied.
         Default is 0.
-    equal_var: bool, optional
+    equal_var : bool, optional
         If True (default), perform a standard one-way ANOVA test that
         assumes equal population variances [2]_.
         If False, perform Welch's ANOVA test, which does not assume

--- a/scipy/stats/_unuran/unuran_wrapper.pyx
+++ b/scipy/stats/_unuran/unuran_wrapper.pyx
@@ -2464,7 +2464,7 @@ cdef class DiscreteGuideTable(Method):
           is used to relocate the distribution from ``(0, len(pv))`` to
           ``(domain[0], domain[0]+len(pv))`` and ``domain[1]`` is ignored. See Notes
           and tutorial for a more detailed explanation.
-    guide_factor: int, optional
+    guide_factor : int, optional
         Size of the guide table relative to length of PV. Larger guide tables
         result in faster generation time but require a more expensive setup.
         Sizes larger than 3 are not recommended. If the relative size is set to

--- a/tools/numpydoc_lint.py
+++ b/tools/numpydoc_lint.py
@@ -27,7 +27,6 @@ skip_errors = [
     "PR07",
     "PR08",
     "PR09",
-    "PR10",
     "RT01",
     "RT02",
     "RT03",


### PR DESCRIPTION
towards #24348

Ensures that there is a space before the colon which separates the parameter name and type.