### PR TITLE
BLD: Fix building on win32

### DIFF
--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -203,7 +203,7 @@ py_fpbacp(PyObject* self, PyObject *args)
     Py_ssize_t m = PyArray_DIM(a_x, 0);
     Py_ssize_t len_t = PyArray_DIM(a_t, 0);
 
-    int64_t nc = len_t - k - 1;
+    Py_ssize_t nc = len_t - k - 1;
 
     // allocate the output buffer
     npy_intp dims[2] = {nc, PyArray_DIM(a_y, 1)};


### PR DESCRIPTION
Fixes the following build error on win32:

```
[1110/1254] Compiling C++ object scipy/interpolate/_dierckx.cp314-win32.pyd.p/src__dierckxmodule.cc.obj
  FAILED: [code=1] scipy/interpolate/_dierckx.cp314-win32.pyd.p/src__dierckxmodule.cc.obj
  "clang-cl" "-Iscipy\interpolate\_dierckx.cp314-win32.pyd.p" "-Iscipy\interpolate" "-I..\scipy\interpolate" "-I..\scipy\interpolate\src" "-IX:\Python314-x32\Lib\site-packages\numpy\_core\include" "-IX:\Python314-x32\Include" "-DNDEBUG" "/MD" "/nologo" "/showIncludes" "/utf-8" "/W2" "/EHsc" "/std:c++17" "/permissive-" "/O2" "/Gw" "-Qunused-arguments" "-D_CRT_SECURE_NO_WARNINGS" "-DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION" "/Fdscipy\interpolate\_dierckx.cp314-win32.pyd.p\src__dierckxmodule.cc.pdb" /Foscipy/interpolate/_dierckx.cp314-win32.pyd.p/src__dierckxmodule.cc.obj "/c" ../scipy/interpolate/src/_dierckxmodule.cc
  ../scipy/interpolate/src/_dierckxmodule.cc(209,25): error: non-constant-expression cannot be narrowed from type 'int64_t' (aka 'long long') to 'npy_intp' (aka 'int') in initializer list [-Wc++11-narrowing]
    209 |     npy_intp dims[2] = {nc, PyArray_DIM(a_y, 1)};
        |                         ^~
  ../scipy/interpolate/src/_dierckxmodule.cc(209,25): note: insert an explicit cast to silence this issue
    209 |     npy_intp dims[2] = {nc, PyArray_DIM(a_y, 1)};
        |                         ^~
        |                         static_cast<npy_intp>( )
  1 error generated.
```