### PR TITLE
DOC: ensure all public function docstrings have Returns section; enforce RT01

### DIFF
--- a/scipy/fft/_backend.py
+++ b/scipy/fft/_backend.py
@@ -157,6 +157,11 @@ def set_backend(backend, coerce=False, only=False):
         BackendNotImplemented error will be raised immediately. Ignoring any
         lower priority backends.
 
+    Returns
+    -------
+    context : uarray._SetBackendContext
+        Context manager that sets the backend.
+
     Examples
     --------
     >>> import scipy.fft as fft
@@ -182,6 +187,11 @@ def skip_backend(backend):
         The backend to skip.
         Can either be a ``str`` containing the name of a known backend
         {'scipy'} or an object that implements the uarray protocol.
+
+    Returns
+    -------
+    context : uarray._SetBackendContext
+        Context manager that skips the backend.
 
     Examples
     --------

--- a/scipy/fft/_pocketfft/helper.py
+++ b/scipy/fft/_pocketfft/helper.py
@@ -240,6 +240,11 @@ def set_workers(workers):
 def get_workers():
     """Returns the default number of workers within the current context
 
+    Returns
+    -------
+    n_workers : int
+        The default number of workers
+
     Examples
     --------
     >>> from scipy import fft

--- a/scipy/fftpack/_basic.py
+++ b/scipy/fftpack/_basic.py
@@ -364,7 +364,7 @@ def ifftn(x, shape=None, axes=None, overwrite_x=False):
     >>> np.allclose(y, ifftn(fftn(y)))
     True
 
-    """
+    """  # numpydoc ignore=RT01
     shape = _good_shape(x, shape, axes)
     return _pocketfft.ifftn(x, shape, axes, None, overwrite_x)
 
@@ -393,7 +393,7 @@ def fft2(x, shape=None, axes=(-2,-1), overwrite_x=False):
            [4, 4, 4, 4, 4]])
     >>> np.allclose(y, ifft2(fft2(y)))
     True
-    """
+    """  # numpydoc ignore=RT01
     return fftn(x,shape,axes,overwrite_x)
 
 
@@ -424,5 +424,5 @@ def ifft2(x, shape=None, axes=(-2,-1), overwrite_x=False):
     >>> np.allclose(y, fft2(ifft2(y)))
     True
 
-    """
+    """  # numpydoc ignore=RT01
     return ifftn(x,shape,axes,overwrite_x)

--- a/scipy/fftpack/_pseudo_diffs.py
+++ b/scipy/fftpack/_pseudo_diffs.py
@@ -47,7 +47,7 @@ def diff(x,order=1,period=None, _cache=_cache):
 
     For odd order and even ``len(x)``, the Nyquist mode is taken zero.
 
-    """
+    """  # numpydoc ignore=RT01
     if isinstance(_cache, threading.local):
         if not hasattr(_cache, 'diff_cache'):
             _cache.diff_cache = {}
@@ -163,7 +163,7 @@ def itilbert(x,h,period=None, _cache=_cache):
 
     For more details, see `tilbert`.
 
-    """
+    """  # numpydoc ignore=RT01
     if isinstance(_cache, threading.local):
         if not hasattr(_cache, 'itilbert_cache'):
             _cache.itilbert_cache = {}
@@ -268,7 +268,7 @@ def ihilbert(x, _cache=_cache):
       y_j = -sqrt(-1)*sign(j) * x_j
       y_0 = 0
 
-    """
+    """  # numpydoc ignore=RT01
     if isinstance(_cache, threading.local):
         if not hasattr(_cache, 'ihilbert_cache'):
             _cache.ihilbert_cache = {}
@@ -360,7 +360,7 @@ def sc_diff(x, a, b, period=None, _cache=_cache):
     ``sc_diff(cs_diff(x,a,b),b,a) == x``
     For even ``len(x)``, the Nyquist mode of x is taken as zero.
 
-    """
+    """  # numpydoc ignore=RT01
     if isinstance(_cache, threading.local):
         if not hasattr(_cache, 'sc_diff_cache'):
             _cache.sc_diff_cache = {}
@@ -414,7 +414,7 @@ def ss_diff(x, a, b, period=None, _cache=_cache):
     -----
     ``ss_diff(ss_diff(x,a,b),b,a) == x``
 
-    """
+    """  # numpydoc ignore=RT01
     if isinstance(_cache, threading.local):
         if not hasattr(_cache, 'ss_diff_cache'):
             _cache.ss_diff_cache = {}
@@ -517,7 +517,7 @@ def shift(x, a, period=None, _cache=_cache):
         Defines the parameters of the sinh/sinh pseudo-differential
     period : float, optional
         The period of the sequences x and y. Default period is ``2*pi``.
-    """
+    """  # numpydoc ignore=RT01
     if isinstance(_cache, threading.local):
         if not hasattr(_cache, 'shift_cache'):
             _cache.shift_cache = {}

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -708,7 +708,7 @@ def sum(input, labels=None, index=None):
     reasons, for new code please prefer `sum_labels`.  See the `sum_labels`
     docstring for more details.
 
-    """
+    """  # numpydoc ignore=RT01
     return sum_labels(input, labels, index)
 
 

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -1136,14 +1136,14 @@ def fixed_point(func, x0, args=(), xtol=1e-8, maxiter=500, method='del2'):
     Find a fixed point of the function.
 
     Given a function of one or more variables and a starting point, find a
-    fixed point of the function: i.e., where ``func(x0) == x0``.
+    fixed point of the function: i.e., where ``func(xf) == xf``.
 
     Parameters
     ----------
     func : function
         Function to evaluate.
     x0 : array_like
-        Fixed point of function.
+        Guess of fixed point of function.
     args : tuple, optional
         Extra arguments to `func`.
     xtol : float, optional
@@ -1156,6 +1156,11 @@ def fixed_point(func, x0, args=(), xtol=1e-8, maxiter=500, method='del2'):
         convergence acceleration [1]_. The "iteration" method simply iterates
         the function until convergence is detected, without attempting to
         accelerate the convergence.
+
+    Returns
+    -------
+    xf : array
+        Fixed point of function.
 
     References
     ----------

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -976,7 +976,7 @@ def sosfreqz(*args, **kwargs):
         New code should use the function :func:`scipy.signal.freqz_sos`.
         This function became obsolete from version 1.15.0.
 
-    """
+    """  # numpydoc ignore=RT01
     return freqz_sos(*args, **kwargs)
 
 

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -870,14 +870,22 @@ class IdentityOperator(LinearOperator):
 def aslinearoperator(A):
     """Return A as a LinearOperator.
 
-    'A' may be any of the following types:
-     - ndarray
-     - matrix
-     - sparse array (e.g. csr_array, lil_array, etc.)
-     - LinearOperator
-     - An object with .shape and .matvec attributes
-
     See the LinearOperator documentation for additional information.
+
+    Parameters
+    ----------
+    A : object
+        Object to convert to a `LinearOperator`. May be any one of the following types:
+        - ndarray
+        - matrix
+        - sparse array (e.g. csr_array, lil_array, etc.)
+        - `LinearOperator`
+        - An object with .shape and .matvec attributes
+
+    Returns
+    -------
+    B : LinearOperator
+        A `LinearOperator` corresponding with `A`
 
     Notes
     -----

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -2454,8 +2454,11 @@ def keip_zeros(nt):
 def kelvin_zeros(nt):
     """Compute nt zeros of all Kelvin functions.
 
-    Returned in a length-8 tuple of arrays of length nt.  The tuple contains
-    the arrays of zeros of (ber, bei, ker, kei, ber', bei', ker', kei').
+    Returns
+    -------
+    zeros : tuple of arrays
+        Length-8 tuple of arrays of length nt.  The tuple contains the arrays of zeros
+        of (ber, bei, ker, kei, ber', bei', ker', kei').
 
     References
     ----------
@@ -2483,6 +2486,11 @@ def pro_cv_seq(m, n, c):
     spheroidal wave functions for mode m and n'=m..n and spheroidal
     parameter c.
 
+    Returns
+    -------
+    cv : array of floats
+        Characteristic values.
+
     References
     ----------
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
@@ -2506,6 +2514,11 @@ def obl_cv_seq(m, n, c):
     Compute a sequence of characteristic values for the oblate
     spheroidal wave functions for mode m and n'=m..n and spheroidal
     parameter c.
+
+    Returns
+    -------
+    cv : array of floats
+        Characteristic values.
 
     References
     ----------

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -284,7 +284,7 @@ def rankdata(data, axis=None, use_missing=False):
         Whether the masked values have a rank of 0 (False) or equal to the
         average rank of the unmasked values (True).
 
-    """
+    """  # numpydoc ignore=RT01
     def _rank1d(data, use_missing=False):
         n = data.count()
         rk = np.empty(data.size, dtype=float)
@@ -391,7 +391,7 @@ def _betai(a, b, x):
 
 
 def msign(x):
-    """Returns the sign of x, or 0 if x is masked."""
+    """Returns the sign of x, or 0 if x is masked."""  # numpydoc ignore=RT01
     return ma.filled(np.sign(x), 0)
 
 
@@ -925,7 +925,7 @@ def kendalltau_seasonal(x):
     x : 2-D ndarray
         Array of seasonal data, with seasons in columns.
 
-    """
+    """  # numpydoc ignore=RT01
     x = ma.array(x, subok=True, copy=False, ndmin=2)
     (n,m) = x.shape
     n_p = x.count(0)
@@ -2052,7 +2052,7 @@ def trima(a, limits=None, inclusive=(True,True)):
                         True,  True],
            fill_value=999999)
 
-    """
+    """  # numpydoc ignore=RT01
     a = ma.asarray(a)
     a.unshare_mask()
     if (limits is None) or (limits == (None, None)):
@@ -2102,7 +2102,7 @@ def trimr(a, limits=None, inclusive=(True, True), axis=None):
         Axis along which to trim. If None, the whole array is trimmed, but its
         shape is maintained.
 
-    """
+    """  # numpydoc ignore=RT01
     def _trimr1D(a, low_limit, up_limit, low_inclusive, up_inclusive):
         n = a.count()
         idx = a.argsort()
@@ -2194,7 +2194,7 @@ def trim(a, limits=None, inclusive=(True,True), relative=False, axis=None):
     >>> print(trim(z,(0.1,0.2),relative=True))
     [-- 2 3 4 5 6 7 8 -- --]
 
-    """
+    """  # numpydoc ignore=RT01
     if relative:
         return trimr(a, limits=limits, inclusive=inclusive, axis=axis)
     else:
@@ -2229,7 +2229,7 @@ def trimboth(data, proportiontocut=0.2, inclusive=(True,True), axis=None):
         Axis along which to perform the trimming.
         If None, the input array is first flattened.
 
-    """
+    """  # numpydoc ignore=RT01
     return trimr(data, limits=(proportiontocut,proportiontocut),
                  inclusive=inclusive, axis=axis)
 
@@ -2285,7 +2285,7 @@ def trimmed_mean(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
 
     %s
 
-    """
+    """  # numpydoc ignore=RT01
     if (not isinstance(limits,tuple)) and isinstance(limits,float):
         limits = (limits, limits)
     if relative:
@@ -2308,7 +2308,7 @@ def trimmed_var(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
         is (n-ddof). DDOF=0 corresponds to a biased estimate, DDOF=1 to an un-
         biased estimate of the variance.
 
-    """
+    """  # numpydoc ignore=RT01
     if (not isinstance(limits,tuple)) and isinstance(limits,float):
         limits = (limits, limits)
     if relative:
@@ -2333,7 +2333,7 @@ def trimmed_std(a, limits=(0.1,0.1), inclusive=(1,1), relative=True,
         is (n-ddof). DDOF=0 corresponds to a biased estimate, DDOF=1 to an un-
         biased estimate of the variance.
 
-    """
+    """  # numpydoc ignore=RT01
     if (not isinstance(limits,tuple)) and isinstance(limits,float):
         limits = (limits, limits)
     if relative:
@@ -2771,7 +2771,7 @@ def winsorize(a, limits=None, inclusive=(True, True), inplace=False,
                  mask=False,
            fill_value=999999)
 
-    """
+    """  # numpydoc ignore=RT01
     def _winsorize1D(a, low_limit, up_limit, low_include, up_include,
                      contains_nan, nan_policy):
         n = a.count()
@@ -3481,7 +3481,7 @@ def scoreatpercentile(data, per, limit=(), alphap=.4, betap=.4):
 
     This function is a shortcut to mquantile
 
-    """
+    """  # numpydoc ignore=RT01
     if (per < 0) or (per > 100.):
         raise ValueError(f"The percentile should be between 0. and 100. ! (got {per})")
 
@@ -3554,7 +3554,7 @@ def obrientransform(*args):
     Maxwell and Delaney, p.112.
 
     Returns: transformed data for use in an ANOVA
-    """
+    """  # numpydoc ignore=RT01
     data = argstoarray(*args).T
     v = data.var(axis=0,ddof=1)
     m = data.mean(0)

--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -276,7 +276,7 @@ def mjci(data, prob=(0.25, 0.5, 0.75), axis=None):
         Axis along which to compute the quantiles. If None, use a flattened
         array.
 
-    """
+    """  # numpydoc ignore=RT01
     def _mjci_1D(data, p):
         data = np.sort(data.compressed())
         n = data.size
@@ -502,7 +502,7 @@ def rsh(data, points=None):
         Sequence of points where to evaluate Rosenblatt shifted histogram.
         If None, use the data.
 
-    """
+    """  # numpydoc ignore=RT01
     data = ma.array(data, copy=False)
     if points is None:
         points = data

--- a/tools/numpydoc_lint.py
+++ b/tools/numpydoc_lint.py
@@ -8,13 +8,13 @@ from scipy._lib._public_api import PUBLIC_MODULES
 
 
 skip_errors = [
-    "GL01",
-    "GL02",
-    "GL03",
+    "GL01",  # inconsistent standards; see gh-24348
+    "GL02",  # inconsistent standards; see gh-24348
+    "GL03",  # overlaps with GL02; see gh-24348
     "GL09",
     "SS02",
     "SS03",
-    "SS05",
+    "SS05",  # inconsistent standards; see gh-24348
     "SS06",
     "ES01",
     "PR01",
@@ -25,12 +25,11 @@ skip_errors = [
     "PR07",
     "PR08",
     "PR09",
-    "RT01",
-    "RT02",
+    "RT02",  # questionable rule; see gh-24348
     "RT03",
     "RT04",
     "RT05",
-    "SA01",
+    "SA01",  # questionable rule; see gh-24348
     "SA02",
     "SA03",
     "SA04",


### PR DESCRIPTION
#### Reference issue
Toward gh-24348

#### What does this implement/fix?
- Enforces numpydoc rule `RT01`
- Adds `Returns` section to docstrings where needed.
- Ignores where appropriate (e.g. aliases / legacy functions)
