### PR TITLE
DOC: Remove non-existent 'periodic' parameter documentation from `make_splrep`

### DIFF
--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -1059,11 +1059,6 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
         The actual number of knots returned by this routine may be slightly
         larger than `nest`.
         Default is None (no limit, add up to ``m + k + 1`` knots).
-    periodic : bool, optional
-        If True, data points are considered periodic with period ``x[m-1]`` -
-        ``x[0]`` and a smooth periodic spline approximation is returned. Values of
-        ``y[m-1]`` and ``w[m-1]`` are not used.
-        The default is False, corresponding to boundary condition 'not-a-knot'.
     bc_type : str, optional
         Boundary conditions.
         Default is `"not-a-knot"`.


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Fixes: https://github.com/scipy/scipy/pull/23233#discussion_r2683139699

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR removes the documentation for the `periodic` parameter from the `make_splrep` function in `scipy.interpolate._fitpack_repro`. This parameter does not exist in the function signature and has been superseded by the `bc_type` parameter, which accepts `"periodic"` as one of its values.

#### Additional information
<!--Any additional information you think is important.-->

cc: @j-bowhay 
