### PR TITLE
DOC: ensure summaries begin with capital letters; enforce SS02

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -501,7 +501,7 @@ cdef class cKDTree:
     .. [1] S. Maneewongvatana and D.E. Mount, "Analysis of approximate
            nearest neighbor searching with clustered point sets,"
            Arxiv e-print, 1999, https://arxiv.org/pdf/cs.CG/9901013
-    """
+    """  # numpydoc ignore=SS02 - not ignoring, so special-case in numpydoc_lint.py
     cdef:
         ckdtree * cself
         object                   _python_tree

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -288,7 +288,7 @@ class KDTree(cKDTree):
     .. [1] S. Maneewongvatana and D.E. Mount, "Analysis of approximate
            nearest neighbor searching with clustered point sets,"
            Arxiv e-print, 1999, https://arxiv.org/pdf/cs.CG/9901013
-    """
+    """  # numpydoc ignore=SS02
 
     class node:
         @staticmethod

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -287,7 +287,7 @@ const char *cosdg_doc = R"(
 const char *cosm1_doc = R"(
     cosm1(x, out=None)
 
-    cos(x) - 1 for use when `x` is near zero.
+    Compute ``cos(x) - 1``, especially when `x` is near zero.
 
     Parameters
     ----------
@@ -2076,7 +2076,7 @@ const char *fresnel_doc = R"(
 const char *gamma_doc = R"(
     gamma(z, out=None)
 
-    gamma function.
+    Compute the gamma function.
 
     The gamma function is defined as
 

--- a/tools/numpydoc_lint.py
+++ b/tools/numpydoc_lint.py
@@ -12,7 +12,6 @@ skip_errors = [
     "GL02",  # inconsistent standards; see gh-24348
     "GL03",  # overlaps with GL02; see gh-24348
     "GL09",
-    "SS02",
     "SS03",
     "SS05",  # inconsistent standards; see gh-24348
     "SS06",
@@ -37,6 +36,11 @@ skip_errors = [
 ]
 
 
+skip_items = [
+    "scipy.spatial.cKDTree"  # numpydoc ignore comment removed during compilation?
+]
+
+
 def main():
     # load in numpydoc config
     to_check = []
@@ -56,6 +60,8 @@ def main():
 
     errors = 0
     for item in to_check:
+        if str(item) in skip_items:
+            continue
         try:
             res = validate(item)
         except AttributeError:


### PR DESCRIPTION
#### Reference issue
Toward gh-24348

#### What does this implement/fix?
- Enforces numpydoc rule `SS02`
- Ensures one-line summaries begin with a capital letter or ignores as needed
