### PR TITLE
DOC: Add section to array api support dev docs on `check --xp-markers`

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -986,6 +986,26 @@ functions without explicitly setting the dtype. At the time of writing, there ar
 tests in the test suite which do not follow this practice, and this could be a good source
 of first issues for new contributors.
 
+Tests are not optional
+``````````````````````
+
+It is not permitted for a function ``f`` to have an ``xp_capabilities``
+entry advertising some level of alternative backend support if there are
+no tests in the test suite for ``f`` that use the ``xp`` fixture along with
+``make_xp_test_case(f)`` or one of its equivalents. All documented alternative
+backend support must be tested and the only valid ``xp_capabilities`` entries
+for a function without tests of the form described above are ``np_only=True``
+with no ``exceptions``, or ``out_of_scope=True``.
+
+The command::
+
+  spin check --xp-markers
+
+can be used to check that all functions advertising alternative backend
+support have at least one test using the ``xp`` fixture that draws from
+``xp_capabilities`` through ``make_xp_test_case`` or one of its equivalents.
+This check is run in CI.
+
 .. _dev-arrayapi_backend_isolation:
 
 Backend isolation in tests


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#24130 added a check that all functions with `xp_capabilities` entry advertising some level of alternative backend support must have corresponding tests using the `xp` fixture. The way this check was integrated into `spin` and `CI` was clunky, and @rgommers suggested dropping the `spin` and `CI` integration from #24130 and offered to follow-up with his own PR implementing a better way of doing things in https://github.com/scipy/scipy/pull/24130#issuecomment-3724034095. Along with the `spin` and `CI` integration, I also removed any mention of this check in the documentation added in #24130. @rgommers' follow-up, https://github.com/scipy/scipy/pull/24328, has been merged. This PR adds a subsection describing this check back to the dev docs.

#### Additional information
<!--Any additional information you think is important.-->
