### PR TITLE
BUG: linalg: fix `inv`, `solve` for complex symmetric inputs

### DIFF
--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -810,6 +810,29 @@ is_sym_herm(const T *data, npy_intp n) {
 }
 
 
+template<typename T>
+std::tuple<bool, bool>
+is_sym_or_herm(const T *data, npy_intp n) {
+    // Return a pair of (is_symmetric, is_hermitian)
+    using value_type = typename type_traits<T>::value_type;
+    const value_type *p_data = reinterpret_cast<const value_type *>(data);
+    bool all_sym = true, all_herm = true;
+
+    for (npy_intp i=0; i < n; i++) {
+        for (npy_intp j=0; j < n; j++) {
+            value_type elem1 = p_data[i*n + j];
+            value_type elem2 = p_data[i + j*n];
+            all_sym = all_sym && (elem1 == elem2);
+            all_herm = all_herm && (elem1 == std::conj(elem2));
+            if(!(all_sym || all_herm)) {
+                // short-circuit : it's neither symmetric not hermitian
+                return std::make_tuple(false, false);
+            }
+        }
+    }
+    return std::make_tuple(all_sym, all_herm);
+}
+
 
 template<typename T>
 inline void

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -784,32 +784,6 @@ bandwidth(T* data, npy_intp n, npy_intp m, npy_intp* lower_band, npy_intp* upper
 }
 
 
-
-
-template<typename T>
-std::tuple<bool, bool>
-is_sym_herm(const T *data, npy_intp n) {
-    // Return a pair of (is_symmetric_or_hermitian, is_symmetric_not_hermitian)
-    using value_type = typename type_traits<T>::value_type;
-    const value_type *p_data = reinterpret_cast<const value_type *>(data);
-    bool all_sym = true, all_herm = true;
-
-    for (npy_intp i=0; i < n; i++) {
-        for (npy_intp j=0; j < n; j++) {
-            value_type elem1 = p_data[i*n + j];
-            value_type elem2 = p_data[i + j*n];
-            all_sym = all_sym && (elem1 == elem2);
-            all_herm = all_herm && (elem1 == std::conj(elem2));
-            if(!(all_sym || all_herm)) {
-                // short-circuit : it's neither symmetric not hermitian
-                return std::make_tuple(false, false);
-            }
-        }
-    }
-    return std::make_tuple(true, all_sym ? true : false);
-}
-
-
 template<typename T>
 std::tuple<bool, bool>
 is_sym_or_herm(const T *data, npy_intp n) {

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -336,14 +336,14 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                 // Check if symmetric/hermitian
                 std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
 
-                if(is_symm && type_traits<T>::is_complex) {
-                    // complex symmetric matrix
-                    slice_structure = St::SYM;
-                }
-                else if (is_symm || is_herm) {
+                if (is_herm || (is_symm && !type_traits<T>::is_complex)) {
                     // either real symmetric or complex hermitian; try Cholesky first,
                     // fall back to sym/her if it fails
                     slice_structure = St::POS_DEF;
+                }
+                else if (is_symm && type_traits<T>::is_complex) {
+                    // complex symmetric, not hermitian
+                    slice_structure = St::SYM;
                 }
                 else {
                     // give up auto-detection

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -201,7 +201,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     npy_intp lower_band = 0, upper_band = 0;
-    bool is_symm_or_herm = false, is_symm_not_herm = false;
+    bool is_symm = false, is_herm = false;
     char uplo = lower ? 'L' : 'U';
     St slice_structure = St::NONE;
     bool posdef_fallback = true;
@@ -292,10 +292,10 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
         posdef_fallback = false;
     }
     else if (structure == St::SYM) {
-        is_symm_not_herm = true;
+        is_symm = true;
     }
     else if (structure == St::HER) {
-        is_symm_not_herm = false;
+        is_herm = true;
     }
     if (structure == St::LOWER_TRIANGULAR) {
         uplo = 'L';
@@ -334,8 +334,15 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                 uplo = 'L';
             } else {
                 // Check if symmetric/hermitian
-                std::tie(is_symm_or_herm, is_symm_not_herm) = is_sym_herm(data, n);
-                if (is_symm_or_herm) {
+                std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
+
+                if(is_symm && type_traits<T>::is_complex) {
+                    // complex symmetric matrix
+                    slice_structure = St::SYM;
+                }
+                else if (is_symm || is_herm) {
+                    // either real symmetric or complex hermitian; try Cholesky first,
+                    // fall back to sym/her if it fails
                     slice_structure = St::POS_DEF;
                 }
                 else {
@@ -408,7 +415,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
             case St::SYM:     // NB: if POS_DEF failed, fall-through to here
             case St::HER:
             {
-                invert_slice_sym_herm(uplo, intn, data, ipiv, work, irwork, lwork, is_symm_not_herm, slice_status);
+                invert_slice_sym_herm(uplo, intn, data, ipiv, work, irwork, lwork, (is_symm && !is_herm), slice_status);
 
                 if ((slice_status.lapack_info < 0) || (slice_status.is_singular )) {
                     vec_status.push_back(slice_status);
@@ -418,7 +425,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                     vec_status.push_back(slice_status);
                 }
 
-                if (is_symm_not_herm) {
+                if (is_symm && !is_herm) {
                     fill_other_triangle_noconj(uplo, data, intn);
                 }
                 else {

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -391,14 +391,14 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
             } else {
                 // Check if symmetric/hermitian
                 std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
-                if (is_symm && type_traits<T>::is_complex) {
-                    // complex symmetrix matrix
-                    slice_structure = St::SYM;
-                }
-                else if (is_symm || is_herm) {
+                if (is_herm || (is_symm && !type_traits<T>::is_complex)) {
                     // either real symmetric or complex hermitian; try Cholesky first,
                     // fall back to sym/her if it fails
                     slice_structure = St::POS_DEF;
+                }
+                else if (is_symm && type_traits<T>::is_complex) {
+                    // complex symmetric, not hermitian
+                    slice_structure = St::SYM;
                 }
                 else {
                     // give up auto-detection


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-24359

#### What does this implement/fix?
<!--Please explain your changes.-->

Do not use a Cholesky solver for complex symmetric inputs.

#### Additional information
<!--Any additional information you think is important.-->

A larger refactor/simplification is possible. This patch however is deliberately minimal, only to fix a scipy 1.17 regression. 