### PR TITLE
BUG: fix freeing of uninitialized memory in error paths in ndimage

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -301,6 +301,8 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
         PyErr_NoMemory();
         goto exit;
     }
+    for(jj = 0; jj < irank; jj++)
+        data_offsets[jj] = NULL;
 
     if (mode == NI_EXTEND_GRID_CONSTANT) {
         // boolean indicating if the current point in the filter footprint is
@@ -323,8 +325,6 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
         }
     }
 
-    for(jj = 0; jj < irank; jj++)
-        data_offsets[jj] = NULL;
     for(jj = 0; jj < irank; jj++) {
         data_offsets[jj] = malloc((order + 1) * sizeof(npy_intp));
         if (NPY_UNLIKELY(!data_offsets[jj])) {
@@ -717,19 +717,25 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     }
     /* store offsets, along each axis: */
     offsets = malloc(rank * sizeof(npy_intp*));
-    /* store spline coefficients, along each axis: */
-    splvals = malloc(rank * sizeof(double**));
-    /* store offsets at all edges: */
-
-    if (NPY_UNLIKELY(!offsets || !splvals)) {
+    if (NPY_UNLIKELY(!offsets)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
         goto exit;
     }
-    for(jj = 0; jj < rank; jj++) {
+    for(jj = 0; jj < rank; jj++)
         offsets[jj] = NULL;
-        splvals[jj] = NULL;
+
+    /* store spline coefficients, along each axis: */
+    splvals = malloc(rank * sizeof(double**));
+    if (NPY_UNLIKELY(!splvals)) {
+        NPY_END_THREADS;
+        PyErr_NoMemory();
+        goto exit;
     }
+    for(jj = 0; jj < rank; jj++)
+        splvals[jj] = NULL;
+
+    /* store offsets at all edges: */
     for(jj = 0; jj < rank; jj++) {
         offsets[jj] = malloc(odimensions[jj] * sizeof(npy_intp));
         splvals[jj] = malloc(odimensions[jj] * sizeof(double*));


### PR DESCRIPTION
Initialize pointer arrays immediately after allocation and error check, before any jumps to cleanup code. Previously, if an allocation failed after data_offsets, offsets, or splvals were allocated but before their elements were initialized, the cleanup code would attempt to free uninitialized pointers.

Found via Coverity scan analysis

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->
