### PR TITLE
BUG: spatial.transform.Rotation.from_quat: handle `const` `np` arrays

### DIFF
--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -393,22 +393,25 @@ cdef double[:, :] _elementary_quat_compose(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def from_quat(double[:, :] quat, bint normalize=True, bint copy=True, bint scalar_first=False):
+def from_quat(const double[:, :] quat, bint normalize=True, bint copy=True, bint scalar_first=False):
     if quat.ndim != 2 or quat.shape[1] != 4:
         raise ValueError(f"Expected `quat` to have shape (N, 4), got {quat.shape}.")
 
+    cdef double[:, :] _quat  # Non-const to enable in-place normalization
     cdef Py_ssize_t num_rotations = quat.shape[0]
 
     if num_rotations > 0:  # Avoid 0-sized axis errors
         if scalar_first:
-            quat = np.roll(quat, -1, axis=1)
+            _quat = np.roll(quat, -1, axis=1)
         elif normalize or copy:
-            quat = quat.copy()
+            _quat = quat.copy()
 
         if normalize:
             for ind in range(num_rotations):
-                if isnan(_normalize4(quat[ind, :])):
+                if isnan(_normalize4(_quat[ind, :])):
                     raise ValueError("Found zero norm quaternions in `quat`.")
+
+        return np.asarray(_quat, dtype=float)
 
     return np.asarray(quat, dtype=float)
 

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -397,23 +397,24 @@ def from_quat(const double[:, :] quat, bint normalize=True, bint copy=True, bint
     if quat.ndim != 2 or quat.shape[1] != 4:
         raise ValueError(f"Expected `quat` to have shape (N, 4), got {quat.shape}.")
 
-    cdef double[:, :] _quat  # Non-const to enable in-place normalization
+    cdef double[:, :] quat_mut  # Non-const to enable in-place normalization
     cdef Py_ssize_t num_rotations = quat.shape[0]
 
     if num_rotations > 0:  # Avoid 0-sized axis errors
         if scalar_first:
-            _quat = np.roll(quat, -1, axis=1)
+            quat_mut = np.roll(quat, -1, axis=1)
         elif normalize or copy:
-            _quat = quat.copy()
-        else:
+            quat_mut = quat.copy()
+        else:  
+            # quat is not altered, so we return directly using quat instead of quat_mut
             return np.asarray(quat, dtype=float)
 
         if normalize:
             for ind in range(num_rotations):
-                if isnan(_normalize4(_quat[ind, :])):
+                if isnan(_normalize4(quat_mut[ind, :])):
                     raise ValueError("Found zero norm quaternions in `quat`.")
 
-        return np.asarray(_quat, dtype=float)
+        return np.asarray(quat_mut, dtype=float)
 
     return np.asarray(quat, dtype=float)
 

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -405,6 +405,8 @@ def from_quat(const double[:, :] quat, bint normalize=True, bint copy=True, bint
             _quat = np.roll(quat, -1, axis=1)
         elif normalize or copy:
             _quat = quat.copy()
+        else:
+            return np.asarray(quat, dtype=float)
 
         if normalize:
             for ind in range(num_rotations):

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -3149,3 +3149,9 @@ def test_rotation_shape(xp, ndim: int):
     quat = xp.ones(shape + (4,))
     r = Rotation.from_quat(quat)
     assert r.shape == shape, f"Got {r.shape}, expected {shape}"
+
+
+def test_non_writeable():
+    q = np.array([0, 0, 0, 1.0])
+    q.flags.writeable = False
+    Rotation.from_quat(q)  # Regression test against gh-24354, should not raise


### PR DESCRIPTION
Fixes #24354 caused by cython array views' incompatibility with non-writeable numpy arrays.

Changes the signature of `quat` in the cython backend to const. 

#### Reference issue
Closes #24354.
