### PR TITLE
MAINT:sparse.linalg: Fix a persistent state propagation issue in ARNAUD

### DIFF
--- a/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
+++ b/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
@@ -24,7 +24,7 @@ static PyObject* arpack_error_obj;
                                X(shift) X(getv0_first) X(getv0_iter) X(getv0_itry) X(getv0_orth) \
                                X(aitr_iter) X(aitr_j) X(aitr_orth1) X(aitr_orth2) X(aitr_restart) \
                                X(aitr_step3) X(aitr_step4) X(aitr_ierr) X(aup2_initv) X(aup2_iter) \
-                               X(aup2_getv0) X(aup2_cnorm) X(aup2_kplusp) X(aup2_nev0) X(aup2_np0) \
+                               X(aup2_getv0) X(aup2_cnorm) X(aup2_kplusp) X(aup2_nev) X(aup2_nev0) X(aup2_np0) \
                                X(aup2_numcnv) X(aup2_update) X(aup2_ushift)
 #define STRUCT_FIELD_NAMES STRUCT_INT_FIELD_NAMES STRUCT_INEXACT_FIELD_NAMES
 

--- a/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
+++ b/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
@@ -423,6 +423,9 @@ sneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
 
     ARNAUD_sneupd(&Vars, want_ev, howmny, select, dr, di, z, ldz, sigmar, sigmai, workev, resid, v, ldv, ipntr, workd, workl);
 
+    // Unpack the struct back to the dictionary
+    if (unpack_state_s_to_dict(&Vars, input_dict, "sneupd_wrap") != 0) { return NULL; }
+
     Py_RETURN_NONE;
 
 }
@@ -487,6 +490,9 @@ dneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
 
     ARNAUD_dneupd(&Vars, want_ev, howmny, select, dr, di, z, ldz, sigmar, sigmai, workev, resid, v, ldv, ipntr, workd, workl);
 
+    // Unpack the struct back to the dictionary
+    if (unpack_state_d_to_dict(&Vars, input_dict, "dneupd_wrap") != 0) { return NULL; }
+
     Py_RETURN_NONE;
 
 }
@@ -550,6 +556,9 @@ cneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
 
     ARNAUD_cneupd(&Vars, want_ev, howmny, select, d, z, ldz, sigmaC, workev, resid, v, ldv, ipntr, workd, workl, rwork);
 
+    // Unpack the struct back to the dictionary
+    if (unpack_state_s_to_dict(&Vars, input_dict, "cneupd_wrap") != 0) { return NULL; }
+
     Py_RETURN_NONE;
 }
 
@@ -611,6 +620,9 @@ zneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
     if (pack_dict_to_state_d(input_dict, &Vars, "zneupd_wrap") != 0) { return NULL; }
 
     ARNAUD_zneupd(&Vars, want_ev, howmny, select, d, z, ldz, sigmaC, workev, resid, v, ldv, ipntr, workd, workl, rwork);
+
+    // Unpack the struct back to the dictionary
+    if (unpack_state_d_to_dict(&Vars, input_dict, "zneupd_wrap") != 0) { return NULL; }
 
     Py_RETURN_NONE;
 }
@@ -751,6 +763,9 @@ sseupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
 
     ARNAUD_sseupd(&Vars, want_ev, howmny, select, d, z, ldz, sigma, resid, v, ldv, ipntr, workd, workl);
 
+    // Unpack the struct back to the dictionary
+    if (unpack_state_s_to_dict(&Vars, input_dict, "sseupd_wrap") != 0) { return NULL; }
+
     Py_RETURN_NONE;
 }
 
@@ -805,6 +820,9 @@ dseupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
     if (pack_dict_to_state_d(input_dict, &Vars, "dseupd_wrap") != 0) { return NULL; }
 
     ARNAUD_dseupd(&Vars, want_ev, howmny, select, d, z, ldz, sigma, resid, v, ldv, ipntr, workd, workl);
+
+    // Unpack the struct back to the dictionary
+    if (unpack_state_d_to_dict(&Vars, input_dict, "dseupd_wrap") != 0) { return NULL; }
 
     Py_RETURN_NONE;
 }

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
@@ -81,6 +81,7 @@ struct ARNAUD_state_s {
     int aup2_getv0;          /** naupd2 flow control              internal              */
     int aup2_cnorm;          /** naupd2 flow control              internal              */
     int aup2_kplusp;         /** naupd2 flow control              internal              */
+    int aup2_nev;            /** naupd2 working nev variable      internal              */
     int aup2_nev0;           /** naupd2 internal compute          internal              */
     int aup2_np0;            /** naupd2 internal compute          internal              */
     int aup2_numcnv;         /** naupd2 internal compute          internal              */
@@ -137,6 +138,7 @@ struct ARNAUD_state_d {
     int aup2_getv0;          /** naupd2 flow control              internal              */
     int aup2_cnorm;          /** naupd2 flow control              internal              */
     int aup2_kplusp;         /** naupd2 flow control              internal              */
+    int aup2_nev;            /** naupd2 working nev variable      internal              */
     int aup2_nev0;           /** naupd2 internal compute          internal              */
     int aup2_np0;            /** naupd2 internal compute          internal              */
     int aup2_numcnv;         /** naupd2 internal compute          internal              */

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double_complex.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double_complex.c
@@ -554,7 +554,8 @@ znaup2(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
 
     if (V->ido == ido_FIRST)
     {
-        V->aup2_nev0 = V->nev;
+        V->aup2_nev = V->nev;
+        V->aup2_nev0 = V->aup2_nev;
         V->aup2_np0 = V->np;
 
         //  kplusp is the bound on the largest
@@ -564,7 +565,7 @@ znaup2(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
         //  iter is the counter on the current
         //       iteration step.
 
-        V->aup2_kplusp = V->nev + V->np;
+        V->aup2_kplusp = V->aup2_nev + V->np;
         V->nconv = 0;
         V->aup2_iter = 0;
 
@@ -622,7 +623,7 @@ znaup2(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
 
     //  Compute the first NEV steps of the Arnoldi factorization
 
-    znaitr(V, 0, V->nev, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    znaitr(V, 0, V->aup2_nev, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
     //  ido .ne. 99 implies use of reverse communication
     //  to compute operations involving OP and possibly B
@@ -651,13 +652,13 @@ LINE1000:
     //  Adjust NP since NEV might have been updated by last call
     //  to the shift application routine dnapps .
 
-    V->np = V->aup2_kplusp - V->nev;
+    V->np = V->aup2_kplusp - V->aup2_nev;
     V->ido = ido_FIRST;
 
 LINE20:
     V->aup2_update = 1;
 
-    znaitr(V, V->nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    znaitr(V, V->aup2_nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
     //  ido .ne. 99 implies use of reverse communication
     //  to compute operations involving OP and possibly B
@@ -691,7 +692,7 @@ LINE20:
     //  error bounds are in the last NEV loc. of RITZ,
     //  and BOUNDS respectively.
 
-    V->nev = V->aup2_nev0;
+    V->aup2_nev = V->aup2_nev0;
     V->np = V->aup2_np0;
 
     //  Make a copy of Ritz values and the corresponding
@@ -707,7 +708,7 @@ LINE20:
     //  bounds are in the last NEV loc. of RITZ
     //  BOUNDS respectively.
 
-    zngets(V, &V->nev, &V->np, ritz, bounds);
+    zngets(V, &V->aup2_nev, &V->np, ritz, bounds);
 
     //  Convergence test: currently we use the following criteria.
     //  The relative accuracy of a Ritz value is considered
@@ -716,7 +717,7 @@ LINE20:
     //  error_bounds(i) .le. tol*max(eps23, magnitude_of_ritz(i)).
     //
     V->nconv = 0;
-    for (i = 0; i < V->nev; i++)
+    for (i = 0; i < V->aup2_nev; i++)
     {
         rtemp = fmax(eps23, cabs(ritz[V->np + i]));
         if (cabs(bounds[V->np + i]) <= V->tol*rtemp)
@@ -742,7 +743,7 @@ LINE20:
         if ((creal(bounds[j]) == 0.0) && (cimag(bounds[j]) == 0.0))
         {
             V->np -= 1;
-            V->nev += 1;
+            V->aup2_nev += 1;
         }
     }
     // 30
@@ -828,7 +829,7 @@ LINE20:
 
         V->np = V->nconv;
         V->iter = V->aup2_iter;
-        V->nev = V->nconv;
+        V->aup2_nev = V->nconv;
         V->ido = ido_DONE;
         return;
 
@@ -838,21 +839,21 @@ LINE20:
         //  To prevent possible stagnation, adjust the size
         //  of NEV.
 
-        int nevbef = V->nev;
-        V->nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
-        if ((V->nev == 1) && (V->aup2_kplusp >= 6)) {
-            V->nev = V->aup2_kplusp / 2;
-        } else if ((V->nev == 1) && (V->aup2_kplusp > 3)) {
-            V->nev = 2;
+        int nevbef = V->aup2_nev;
+        V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
+        if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6)) {
+            V->aup2_nev = V->aup2_kplusp / 2;
+        } else if ((V->aup2_nev == 1) && (V->aup2_kplusp > 3)) {
+            V->aup2_nev = 2;
         }
 
-        V->np = V->aup2_kplusp - V->nev;
+        V->np = V->aup2_kplusp - V->aup2_nev;
 
         // If the size of NEV was just increased
         // resort the eigenvalues.
 
-        if (nevbef < V->nev) {
-            zngets(V, &V->nev, &V->np, ritz, bounds);
+        if (nevbef < V->aup2_nev) {
+            zngets(V, &V->aup2_nev, &V->np, ritz, bounds);
         }
     }
 
@@ -890,7 +891,7 @@ LINE50:
     //  matrix H.
     //  The first 2*N locations of WORKD are used as workspace.
 
-    znapps(V->n, &V->nev, V->np, ritz, v, ldv, h, ldh, resid, q, ldq, workl, workd);
+    znapps(V->n, &V->aup2_nev, V->np, ritz, v, ldv, h, ldh, resid, q, ldq, workl, workd);
 
     //  Compute the B-norm of the updated residual.
     //  Keep B*RESID in WORKD(1:N) to be used in

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
@@ -617,7 +617,8 @@ snaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
 
     if (V->ido == ido_FIRST)
     {
-        V->aup2_nev0 = V->nev;
+        V->aup2_nev = V->nev;
+        V->aup2_nev0 = V->aup2_nev;
         V->aup2_np0 = V->np;
 
         //  kplusp is the bound on the largest
@@ -627,7 +628,7 @@ snaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
         //  iter is the counter on the current
         //       iteration step.
 
-        V->aup2_kplusp = V->nev + V->np;
+        V->aup2_kplusp = V->aup2_nev + V->np;
         V->nconv = 0;
         V->aup2_iter = 0;
 
@@ -685,7 +686,7 @@ snaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
 
     //  Compute the first NEV steps of the Arnoldi factorization
 
-    snaitr(V, 0, V->nev, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    snaitr(V, 0, V->aup2_nev, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
     //  ido .ne. 99 implies use of reverse communication
     //  to compute operations involving OP and possibly B
@@ -714,7 +715,7 @@ LINE1000:
     //  Adjust NP since NEV might have been updated by last call
     //  to the shift application routine dnapps .
 
-    V->np = V->aup2_kplusp - V->nev;
+    V->np = V->aup2_kplusp - V->aup2_nev;
 
     //  Compute NP additional steps of the Arnoldi factorization.
 
@@ -723,7 +724,7 @@ LINE1000:
 LINE20:
     V->aup2_update = 1;
 
-    snaitr(V, V->nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    snaitr(V, V->aup2_nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
     //  ido .ne. 99 implies use of reverse communication
     //  to compute operations involving OP and possibly B
@@ -772,18 +773,18 @@ LINE20:
     //  NOTE: The last two arguments of dngets  are no
     //  longer used as of version 2.1.
 
-    V->nev = V->aup2_nev0;
+    V->aup2_nev = V->aup2_nev0;
     V->np = V->aup2_np0;
-    V->aup2_numcnv = V->nev;
+    V->aup2_numcnv = V->aup2_nev;
 
-    sngets(V, &V->nev, &V->np, ritzr, ritzi, bounds);
+    sngets(V, &V->aup2_nev, &V->np, ritzr, ritzi, bounds);
 
-    if (V->nev == V->aup2_nev0 + 1) { V->aup2_numcnv = V->aup2_nev0 + 1;}
+    if (V->aup2_nev == V->aup2_nev0 + 1) { V->aup2_numcnv = V->aup2_nev0 + 1;}
 
     //  Convergence test.
 
-    scopy_(&V->nev, &bounds[V->np], &int1, &workl[2*V->np], &int1);
-    snconv(V->nev, &ritzr[V->np], &ritzi[V->np], &workl[2*V->np], V->tol, &V->nconv);
+    scopy_(&V->aup2_nev, &bounds[V->np], &int1, &workl[2*V->np], &int1);
+    snconv(V->aup2_nev, &ritzr[V->np], &ritzi[V->np], &workl[2*V->np], V->tol, &V->nconv);
 
     //  Count the number of unwanted Ritz values that have zero
     //  Ritz estimates. If any Ritz estimates are equal to zero
@@ -801,7 +802,7 @@ LINE20:
         if (bounds[j] == 0.0f)
         {
             V->np -= 1;
-            V->nev += 1;
+            V->aup2_nev += 1;
         }
     }
     // 30
@@ -898,7 +899,7 @@ LINE20:
 
         V->np = V->nconv;
         V->iter = V->aup2_iter;
-        V->nev = V->aup2_numcnv;
+        V->aup2_nev = V->aup2_numcnv;
         V->ido = ido_DONE;
         return;
 
@@ -908,12 +909,12 @@ LINE20:
         //  To prevent possible stagnation, adjust the size
         //  of NEV.
 
-        int nevbef = V->nev;
-        V->nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
-        if ((V->nev == 1) && (V->aup2_kplusp >= 6)) {
-            V->nev = V->aup2_kplusp / 2;
-        } else if ((V->nev == 1) && (V->aup2_kplusp > 3)) {
-            V->nev = 2;
+        int nevbef = V->aup2_nev;
+        V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
+        if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6)) {
+            V->aup2_nev = V->aup2_kplusp / 2;
+        } else if ((V->aup2_nev == 1) && (V->aup2_kplusp > 3)) {
+            V->aup2_nev = 2;
         }
 
         //  SciPy Fix
@@ -921,15 +922,15 @@ LINE20:
         //  np == 0 (note that dngets below can bump nev by 1). If np == 0,
         // the next call to `dnaitr` will write out-of-bounds.
 
-        if (V->nev > (V->aup2_kplusp - 2)) {
-            V->nev = V->aup2_kplusp - 2;
+        if (V->aup2_nev > (V->aup2_kplusp - 2)) {
+            V->aup2_nev = V->aup2_kplusp - 2;
         }
         //  SciPy Fix End
 
-        V->np = V->aup2_kplusp - V->nev;
+        V->np = V->aup2_kplusp - V->aup2_nev;
 
-        if (nevbef < V->nev) {
-            sngets(V, &V->nev, &V->np, ritzr, ritzi, bounds);
+        if (nevbef < V->aup2_nev) {
+            sngets(V, &V->aup2_nev, &V->np, ritzr, ritzi, bounds);
         }
 
     }
@@ -970,7 +971,7 @@ LINE50:
     //  matrix H.
     //  The first 2*N locations of WORKD are used as workspace.
 
-    snapps(V->n, &V->nev, V->np, ritzr, ritzi, v, ldv, h, ldh, resid, q, ldq, workl, workd);
+    snapps(V->n, &V->aup2_nev, V->np, ritzr, ritzi, v, ldv, h, ldh, resid, q, ldq, workl, workd);
 
     //  Compute the B-norm of the updated residual.
     //  Keep B*RESID in WORKD(1:N) to be used in

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.c
@@ -591,13 +591,14 @@ dsaup2(struct ARNAUD_state_d *V, double* resid, double* v, int ldv,
     if (V->ido == ido_FIRST)
     {
         // nev0 and np0 are integer variables hold the initial values of NEV & NP
-        V->aup2_nev0 = V->nev;
+        V->aup2_nev = V->nev;
+        V->aup2_nev0 = V->aup2_nev;
         V->aup2_np0 = V->np;
 
         // kplusp is the bound on the largest Lanczos factorization built.
         // nconv is the current number of "converged" eigenvalues.
         // iter is the counter on the current iteration step.
-        V->aup2_kplusp = V->nev + V->np;
+        V->aup2_kplusp = V->aup2_nev + V->np;
         V->nconv = 0;
         V->aup2_iter = 0;
 
@@ -685,7 +686,7 @@ LINE1000:
 LINE20:
     V->aup2_update = 1;
 
-    dsaitr(V, V->nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    dsaitr(V, V->aup2_nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
      /*--------------------------------------------------*
      | ido .ne. 99 implies use of reverse communication  |
@@ -730,15 +731,15 @@ LINE20:
     // * Wanted Ritz values := RITZ(NP+1:NEV+NP)
     // * Shifts := RITZ(1:NP) := WORKL(1:NP)
 
-    V->nev = V->aup2_nev0;
+    V->aup2_nev = V->aup2_nev0;
     V->np = V->aup2_np0;
 
-    dsgets(V, &V->nev, &V->np, ritz, bounds, workl);
+    dsgets(V, &V->aup2_nev, &V->np, ritz, bounds, workl);
 
     // Convergence test
 
-    dcopy_(&V->nev, &bounds[V->np], &int1, &workl[V->np], &int1);
-    dsconv(V->nev, &ritz[V->np], &workl[V->np], V->tol, &V->nconv);
+    dcopy_(&V->aup2_nev, &bounds[V->np], &int1, &workl[V->np], &int1);
+    dsconv(V->aup2_nev, &ritz[V->np], &workl[V->np], V->tol, &V->nconv);
 
     // Count the number of unwanted Ritz values that have zero
     // Ritz estimates. If any Ritz estimates are equal to zero
@@ -754,7 +755,7 @@ LINE20:
         if (bounds[j] == 0.0)
         {
             V->np -= 1;
-            V->nev += 1;
+            V->aup2_nev += 1;
         }
     }
     // 30
@@ -780,7 +781,7 @@ LINE20:
             dsortr(which_SA, 1, V->aup2_kplusp, ritz, bounds);
             nevd2 = V->aup2_nev0 / 2;
             nevm2 = V->aup2_nev0 - nevd2;
-            if (V->nev > 1)
+            if (V->aup2_nev > 1)
             {
                 V->np = V->aup2_kplusp - V->aup2_nev0;
 
@@ -865,7 +866,7 @@ LINE20:
 
         // Max iterations have been exceeded.
 
-        if ((V->aup2_iter > V->maxiter) && (V->nconv < V->nev))
+        if ((V->aup2_iter > V->maxiter) && (V->nconv < V->aup2_nev))
         {
             V->info = 1;
         }
@@ -878,33 +879,33 @@ LINE20:
         }
 
         V->np = V->nconv;
-        V->nev = V->nconv;
+        V->aup2_nev = V->nconv;
         V->iter = V->aup2_iter;
         V->ido = ido_DONE;
         return;
 
-    } else if ((V->nconv < V->nev) && (V->shift == 1)) {
+    } else if ((V->nconv < V->aup2_nev) && (V->shift == 1)) {
 
         // Do not have all the requested eigenvalues yet.
         // To prevent possible stagnation, adjust the number
         // of Ritz values and the shifts.
 
-        int nevbef = V->nev;
-        V->nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
-        if ((V->nev == 1) && (V->aup2_kplusp >= 6))
+        int nevbef = V->aup2_nev;
+        V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
+        if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6))
         {
-            V->nev = V->aup2_kplusp / 2;
-        } else if ((V->nev == 1) && (V->aup2_kplusp > 2))
+            V->aup2_nev = V->aup2_kplusp / 2;
+        } else if ((V->aup2_nev == 1) && (V->aup2_kplusp > 2))
         {
-            V->nev = 2;
+            V->aup2_nev = 2;
         }
-        V->np = V->aup2_kplusp - V->nev;
+        V->np = V->aup2_kplusp - V->aup2_nev;
 
         // If the size of NEV was just increased resort the eigenvalues.
 
-        if (nevbef < V->nev)
+        if (nevbef < V->aup2_nev)
         {
-            dsgets(V, &V->nev, &V->np, ritz, bounds, workl);
+            dsgets(V, &V->aup2_nev, &V->np, ritz, bounds, workl);
         }
     }
 
@@ -941,7 +942,7 @@ LINE50:
      | factorization of length NEV.                            |
      *--------------------------------------------------------*/
 
-    dsapps(V->n, &V->nev, V->np, ritz, v, ldv, h, ldh, resid, q, ldq, workd);
+    dsapps(V->n, &V->aup2_nev, V->np, ritz, v, ldv, h, ldh, resid, q, ldq, workd);
 
     // Compute the B-norm of the updated residual.
     // Keep B*RESID in WORKD(1:N) to be used in

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -396,6 +396,7 @@ class _ArpackParams:
             'aup2_getv0': 0,
             'aup2_cnorm': 0,
             'aup2_kplusp': 0,
+            'aup2_nev': 0,
             'aup2_nev0': 0,
             'aup2_np0': 0,
             'aup2_numcnv': 0,


### PR DESCRIPTION
#### Reference issue
Closes #24358 

#### What does this implement/fix?

Just for posterity to make sense of the changes. 

So `nev` is the requested eigenvalues from ARPACK. We make a call and naupd stores this in a `nev0` variable which is a persistent variable across calls. Then internally `naupd`, makes a call to `naup2` with `nev0`, but `naup2` calls this variable again as `nev` and creates its own local variable `nev0` which is also persistent. Still with me? So in the end all three are used and in the end discarded but original `nev` stays the same. Then this value is passed to `neupd` refinement routine and this should be the original user requested `nev` value. 

And I thought all `nev`s were the same and thus used the `V->nev` everywhere. This caused `neupd` to look for eigenvalues in the wrong positions of the sorted Ritz value arrays, resulting in zeros being returned for certain which options like "SR" where the sorting placed wanted eigenvalues at specific array positions that no longer aligned with the corrupted `nev` count. Wow, still with me? The fix introduces `V->aup2_nev` as a working copy that mirrors the Fortran semantics, initialized from `V->nev` at the start, used throughout `naup2`/`saup2`, but leaving `V->nev` untouched for `neupd/seupd` to read the original user-requested value.

This PR fixes that.  

Essentially, this could be fixed by a single line restoring the `nev` variable between `naupd` and `neupd` on the python side. However, this would be a very annoying bug to discover a few years later. 

I am marking as backport candidate but not sure if this applies. 