### PR TITLE
BUG: fix uninitialized variables in odr

### DIFF
--- a/scipy/odr/__odrpack.c
+++ b/scipy/odr/__odrpack.c
@@ -780,6 +780,10 @@ PyObject *odr(PyObject * self, PyObject * args, PyObject * kwds)
           PYERR(PyExc_ValueError, "could not convert we to a suitable array");
         }
     }                           /* we */
+  else
+    {
+      PYERR(PyExc_ValueError, "could not convert we to a suitable array");
+    }
 
   if (pwd == NULL)
     {
@@ -871,6 +875,10 @@ PyObject *odr(PyObject * self, PyObject * args, PyObject * kwds)
         }
 
     }                           /* wd */
+  else
+    {
+      PYERR(PyExc_ValueError, "could not convert wd to a suitable array");
+    }
 
 
   if (pifixb == NULL)


### PR DESCRIPTION
The if-else clauses handling pwe and pwd arrays had no terminal else clause. If an object passed validation but didn't match any handling branch, ldwe,ld2we,ldwd and ld2wd would be used uninitialized.

Add else clauses to ensure all code paths either initialize these variables or exit with an error.

Found via Coverity static analysis
