### PR TITLE
BUG: fix uninitialized variable in ILU complex copy at sparse/SuperLU

### DIFF
--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_ccopy_to_ucol.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_ccopy_to_ucol.c
@@ -190,7 +190,7 @@ ilu_ccopy_to_ucol(
 			c_add(sum, sum, &ucol[i]);
 			break;
 		    case SMILU_3:
-			sum->r += tmp;
+			sum->r += c_abs1(&ucol[i]);
 			break;
 		    case SILU:
 		    default:

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_zcopy_to_ucol.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/ilu_zcopy_to_ucol.c
@@ -190,7 +190,7 @@ ilu_zcopy_to_ucol(
 			z_add(sum, sum, &ucol[i]);
 			break;
 		    case SMILU_3:
-			sum->r += tmp;
+			sum->r += z_abs1(&ucol[i]);
 			break;
 		    case SILU:
 		    default:


### PR DESCRIPTION
The SMILU_3 case in the second loop of ilu_ccopy_to_ucol.c and ilu_zcopy_to_ucol.c used tmp which could be uninitialized. Compute the absolute value directly instead.

Found via Coverity static analysis