### PR TITLE
DOC: FFT: Improve the DFT section in the user guide.

### DIFF
--- a/doc/source/tutorial/_LaTeXMathMacros.rst
+++ b/doc/source/tutorial/_LaTeXMathMacros.rst
@@ -1,0 +1,35 @@
+.. This following environment provides LaTeX macros for math environments.
+   To use these macros add the following line to the applicable `.rst` file:
+
+   .. include:: MathMacros.rst
+
+   The macros are defined after this line to the end of the file.
+   Currently, this file is only included by the file `fft.rst`.
+
+
+.. math::
+
+    \newcommand{\IC}{{\mathbb{C}}}  % set of complex numbers
+    \newcommand{\IN}{{\mathbb{N}}}  % set of natural numbers
+    \newcommand{\IR}{{\mathbb{R}}}  % set of real numbers
+    \newcommand{\IZ}{{\mathbb{Z}}}  % set of integers
+    \newcommand{\jj}{{\mathbb{j}}}  % imaginary unit
+    \newcommand{\e}{\operatorname{e}}  % Euler's number
+    \newcommand{\dd}{\operatorname{d}} % infinitesimal operator
+    \newcommand{\abs}[1]{\left|#1\right|} % absolute value
+    \newcommand{\conj}[1]{\overline{#1}} % complex conjugate
+    \newcommand{\conjT}[1]{\overline{#1^T}} % transposed complex conjugate
+    \newcommand{\inv}[1]{\left(#1\right)^{\!-1}} % inverse
+    \newcommand{\rect}{\operatorname{rect}}  % rect or boxcar function
+    \newcommand{\sinc}{\operatorname{sinc}}  % sinc(t) := sin(pi*t) / (pi*t)
+    % overwrite macros:
+    \renewcommand{\Re}{\operatorname{Re}}  % real part of a complex number
+    \renewcommand{\Im}{\operatorname{Im}}  % imaginary part of a complex number
+    % Since the physics package is not loaded, we define the macros ourselves:
+    \newcommand{\vb}[1]{\mathbf{#1}} % vectors  are bold
+    \newcommand{\mat}[1]{\mathrm{#1}} % matrices are upright
+    %
+    % Abbreviations of matrices and vectors :
+    \newcommand{\mF}{\mat{F}}  % matrix with DFT coefficients
+    \newcommand{\mI}{\mat{I}}  % unity matrix
+

--- a/doc/source/tutorial/examples/fft_ParametricClosedCurve.py
+++ b/doc/source/tutorial/examples/fft_ParametricClosedCurve.py
@@ -1,0 +1,30 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.collections import LineCollection
+from scipy.fft import fft, fftshift
+
+z_pts = [  0.1-27.8j,  12.5-48.9j,  40.3-60.8j,  69.0-36.8j,  77.1- 8.1j,  77.5+24.1j,
+          62.2+54.2j,  37.8+67.4j,  41.7+56.2j,  53.1+29.6j,  55.3- 3.1j,  49.4-39.3j,
+          24.2-47.3j,   7.8-23.3j,   9.7+ 8.8j,   5.6+40.9j,  -5.2+40.5j,  -9.5+ 8.5j,
+          -7.7-23.5j, -24.4-47.7j, -49.6-39.2j, -55.6- 2.8j, -53.4+29.8j, -41.4+56.3j,
+         -37.8+67.6j, -62.3+54.7j, -77.4+24.2j, -77.3- 7.9j, -69.1-36.4j, -40.2-60.9j,
+         -12.4-48.9j]
+z_pts = np.asarray(z_pts)  # the samples
+cc = fftshift(fft(z_pts, norm='forward'))  # calculate Fourier coefficients
+
+# Use Fourier series to calculate curve points:
+N, k0 = len(z_pts), -(len(cc) // 2)  # number of samples, first Fourier series index
+t = np.linspace(0, 1, N * 8, endpoint=False)
+z = sum(c_k * np.exp(2j * np.pi * k * t) for k, c_k in enumerate(cc, start=k0))
+
+fg0, ax0 = plt.subplots(1, 1, tight_layout=True)
+ax0.set(title=f"Parametric Closed Curve $z(t)$ created from {N} Samples",
+        xlabel=r"Re$\{z(t)\}$", ylabel=r"Im$\{z(t)\}$")
+
+ax0.scatter(z_pts.real, z_pts.imag, c=np.arange(N) / N, s=8, cmap='twilight')
+
+lpts = np.stack((z.real, z.imag), axis=1)  # extract 2d points
+ln0 = ax0.add_collection(LineCollection(np.stack((lpts[:-1], lpts[1:]), axis=1),
+                                        array=t[:-1], cmap='twilight'))
+cb0 = fg0.colorbar(ln0, label="Parameter $t$")
+plt.show()

--- a/doc/source/tutorial/examples/fft_compare_DFT_fft_rfft.py
+++ b/doc/source/tutorial/examples/fft_compare_DFT_fft_rfft.py
@@ -1,0 +1,34 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.fft import fft, fftfreq, irfft, rfft, rfftfreq
+
+# Create signals:
+x0 = np.array([4, 1, 0, 1])
+x1 = irfft(rfft(x0), n=5)  # Here: rfft(x1) == rfft(x0)
+tau = 1  # signal duration in seconds
+
+ll = np.arange(-3, 6)  # indices of DFT coefficients
+_, ax01 = plt.subplots(3, 2, sharex='col', tight_layout=True, figsize=(6., 4.))
+for x, axx in zip((x1, x0), ax01.T):
+    N = len(x)  # number of samples
+    T, delta_f = tau / N, 1 / tau  # sampling interval and frequency resolution
+    kk = np.arange(0, N)  # sample indices of DFT
+
+    X_DFT = np.array([sum(x * np.exp(-2j * np.pi * l_ * kk / N)) for l_ in ll])
+    f_DFT = ll * delta_f  # frequencies of DFT
+
+    XX = fft(x), fft(x), rfft(x)  # DFT values and FFT values coincide
+    ff = np.arange(N) * delta_f, fftfreq(N, T), rfftfreq(N, T)
+
+    t_strs = ["DFT", "fft / fftfreq", "rfft / rfftfreq"]  # do the plotting:
+    for p, (ax, f, X, ts) in enumerate(zip(axx, ff, XX, t_strs)):
+        lns = axx[p].stem(f_DFT, abs(X_DFT), linefmt='k-', markerfmt="k.", basefmt=' ')
+        [ln_.set_alpha(0.1) for ln_ in lns]  # set transparency
+        axx[p].stem(f, abs(X), linefmt=f'C{p}-', markerfmt=f'C{p}.', basefmt=' ')
+        ax.set(title=f"{ts} for len(x) = {N}", yticks=[], ylim=(0, 6.5))
+    axx[-1].set(xticks=f_DFT, xlim=(f_DFT[0]-0.5, f_DFT[-1]+0.5))
+    axx[-1].set_xlabel(rf"Frequency $f$ in hertz ($\Delta f ={delta_f:g}\,$Hz)")
+plt.show()
+
+
+

--- a/doc/source/tutorial/examples/fft_remove_trend.py
+++ b/doc/source/tutorial/examples/fft_remove_trend.py
@@ -1,0 +1,38 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+from scipy.fft import rfft, rfftfreq
+from scipy.signal import detrend
+
+rng = np.random.default_rng()  # seeding with default seed for reproducibility
+
+N, tau = 1000, 0.1 # number of samples and signal duration in seconds
+T = tau / N  # sampling interval
+t = np.arange(N) * T  # sample times
+
+# Create signal:
+x_sines = sum(np.sin(2 * np.pi * f_ * t) for f_ in [200, 300, 400])
+x_drift = 1e3 * (1 - np.cos(2*t))  # almost linear drift
+x_noise = rng.normal(scale=np.sqrt(5), size=t.shape)  # Gaussian noise
+x = x_drift + x_sines + x_noise  # the signal
+x_d = detrend(x, type='linear')  # signal with linear trend removed
+
+f = rfftfreq(N, T)  # frequency values
+aX, aX_d = abs(rfft(x) / N), abs(rfft(x_d) / N)  # Magnitude spectrum
+
+fig = plt.figure(figsize=(6., 5.))
+ax0, ax1, ax2 = [fig.add_axes((0.11, bottom, .85, .2)) for bottom in [.7, .33, .1]]
+for c_, (x_, n_) in enumerate(zip((x, x_d), ("$x(t)$", "$x_d(t)$"))):
+    ax0.plot(t, x_, f'C{c_}-', alpha=0.5, label=n_)
+ax0.set(title="Signal $x(t)$ and detrended signal $x_d(t)$", ylabel="Amplitude",
+        xlabel=rf"Time $t$ in seconds ($T={1e3*T:g}\,$ms, {N} samples)", xlim=(0, tau))
+for c_, (ax_, aX_, n_) in enumerate(zip((ax1, ax2), (aX, aX_d), ("X", "X_d"))):
+    ax_.plot(f, aX_, f'C{c_}-', alpha=0.5, label=f"$|{n_}(f)|$")
+    ax_.set(xlim=(0, 500), ylim=(0, 1.3), ylabel="Magnitude")
+ax1.set(title="Magnitude Spectrum", xticklabels=[])
+ax2.set_xlabel(rf"Frequency $f$ in hertz ($Δf={f[1]:g}\,$Hz, $f_S={1e-3/T:g}\,$kHz)")
+for ax_ in (ax0, ax1, ax2):
+    ax_.grid(True)
+    ax_.legend()
+
+plt.show()

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2777,16 +2777,10 @@ def envelope(z, bp_in: tuple[int | None, int | None] = (1, None), *,
     which produces a complex-valued signal with the same envelope :math:`|a(t)|`.
 
     The implementation is based on computing the FFT of the input signal and then
-    performing the necessary operations in Fourier space. Hence, the typical FFT
-    caveats need to be taken into account:
-
-    * The signal is assumed to be periodic. Discontinuities between signal start and
-      end can lead to unwanted results due to Gibbs phenomenon.
-    * The FFT is slow if the signal length is prime or very long. Also, the memory
-      demands are typically higher than a comparable FIR/IIR filter based
-      implementation.
-    * The frequency spacing ``1 / (n*T)`` for corner frequencies of the bandpass filter
-      corresponds to the frequencies produced by ``scipy.fft.fftfreq(len(z), T)``.
+    performing the necessary operations in Fourier space. Hence, the typical :ref:`FFT
+    caveats <tutorial_FFT_Caveats>` need to be taken into account. The frequency
+    spacing ``1 / (n*T)`` for corner frequencies of the bandpass filter corresponds to
+    the frequencies produced by ``scipy.fft.fftfreq(len(z), T)``.
 
     If the envelope of a complex-valued signal `z` with no bandpass filtering is
     desired, i.e., ``bp_in=(None, None)``, then the envelope corresponds to the


### PR DESCRIPTION
The first section of the [Fourier transform (scipy.fft)] page was reworked. Now a clear distinction is made between the DFT as a purely discrete mapping and the Fourier series based continuous representation aka sampled signals. Further additions:

* Inner product and convolution properties of the DFT
* Consideration of the normalization factor from the `norm` parameter in the definitions.
* Various Fourier transform representations of Fourier series.
* A "Caveats" section discussing practical implications of DFT periodicity and providing recommendations for improving computational efficiency.

Changes:
* LaTeX Macros for math environments were put into a separate file
*  The sectioning was fixed and the references are linked by footnotes now. 
* A link from the `signal.envelope` docstr to the "Caveats" section was added.

This PR supersedes PR #23182. 

[docs only]

[Fourier transform (scipy.fft)]: https://scipy.github.io/devdocs/tutorial/fft.html 