### PR TITLE
BUG: spatial.transform.RigidTransform.from_matrix: handle `const` `np` arrays

### DIFF
--- a/scipy/spatial/transform/_rigid_transform_cy.pyx
+++ b/scipy/spatial/transform/_rigid_transform_cy.pyx
@@ -16,7 +16,7 @@ np.import_array()
 
 @cython.embedsignature(True)
 @cython.boundscheck(False)
-def from_matrix(double[:, :, :] matrix, bint normalize=True, bint copy=True):
+def from_matrix(const double[:, :, :] matrix, bint normalize=True, bint copy=True):
     mat = np.asarray(matrix, dtype=float)
 
     if mat.shape[-1] != 4 or mat.shape[-2] != 4:

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1510,4 +1510,4 @@ def test_shape_property(xp, dim: int):
 def test_non_writeable():
     mat = np.eye(4)
     mat.flags.writeable = False
-    RigidTransform.from_matrix(mat)  # Regression test against gh-24378, should not raise
+    RigidTransform.from_matrix(mat)  # Regression test against gh-24378

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1505,3 +1505,9 @@ def test_shape_property(xp, dim: int):
     shape = (dim,) * (dim - 1)
     tf = RigidTransform.from_translation(xp.zeros(shape + (3,)))
     assert tf.shape == shape
+
+
+def test_non_writeable():
+    mat = np.eye(4)
+    mat.flags.writeable = False
+    RigidTransform.from_matrix(mat)  # Regression test against gh-24378, should not raise


### PR DESCRIPTION
Fixes #24378 caused by cython array views' incompatibility with non-writeable numpy arrays.

Changes the signature of `matrix` in the cython backend to const.

#### Reference issue
Closes #24378.
