### PR TITLE
MAINT: optimize: Fix memory leaks in DIRECT solver and extension module

### DIFF
--- a/scipy/optimize/_direct/DIRect.c
+++ b/scipy/optimize/_direct/DIRect.c
@@ -595,11 +595,15 @@
 /* +-----------------------------------------------------------------------+ */
 /* | JG 01/22/01 Added variable to keep track of the maximum value found.  | */
 /* +-----------------------------------------------------------------------+ */
-        direct_dirsamplef_(c__, arrayi, &delta, &help, &start, length,
+        Py_XDECREF(ret);  /* DECREF previous return value before getting new one */
+        ret = direct_dirsamplef_(c__, arrayi, &delta, &help, &start, length,
             logfile, f, &ifree, &maxi, point, fcn, &x[
             1], x_seq, &l[1], minf, &minpos, &u[1], n, &MAXFUNC, &
             MAXDEEP, &oops, &fmax, &ifeasiblef, &iinfesiblef,
             args, force_stop);
+        if (!ret) {
+            goto cleanup;
+        }
         if (force_stop && *force_stop) {
              *ierror = -102;
              *numiter = t;

--- a/scipy/optimize/_direct/DIRect.c
+++ b/scipy/optimize/_direct/DIRect.c
@@ -780,6 +780,7 @@
             ret = NULL;
             goto cleanup;
         }
+        Py_DECREF(callback_py);  /* DECREF the callback's return value */
     }
 /* L10: */
     }

--- a/scipy/optimize/_direct/DIRserial.c
+++ b/scipy/optimize/_direct/DIRserial.c
@@ -87,6 +87,7 @@
     if (force_stop && *force_stop)  /* skip eval after forced stop */
          f[(pos << 1) + 1] = *fmax;
     else {
+        Py_XDECREF(ret);  /* DECREF previous iteration's return value */
         ret = direct_dirinfcn_(fcn, &x[1], x_seq, &l[1], &u[1], n, &f[(pos << 1) + 1],
                                           &kret, args);
         if (!ret) {

--- a/scipy/optimize/_direct/DIRsubrout.c
+++ b/scipy/optimize/_direct/DIRsubrout.c
@@ -7,8 +7,19 @@
 #include <math.h>
 // #include "numpy/ndarrayobject.h"
 
-/* Table of constant values */
-
+/*
+ * SCIPY NOTE (2026-01-15):
+ * The following are read-only variables after initialization.
+ *
+ * They exist because f2c passes all arguments by reference (Fortran convention),
+ * so literal constants need addresses. The code is still thread-safe since they
+ * are never modified.
+ *
+ * Note: Cannot mark as 'const' due to f2c function signatures expecting non-const
+ * pointers which makes the surgery more involved. Instead an f2c-free rewrite
+ * is better for long-term maintenance.
+ *
+ */
 static integer c__1 = 1;
 static integer c__32 = 32;
 static integer c__0 = 0;
@@ -1295,11 +1306,15 @@ L50:
 /* | JG 01/22/01 Added variable to keep track of the maximum value found.  | */
 /* |             Added variable to keep track if feasible point was found. | */
 /* +-----------------------------------------------------------------------+ */
-    direct_dirsamplef_(&c__[c_offset], &arrayi[1], &delta, &c__1, &new__, &length[
+    Py_DECREF(ret);  /* DECREF before overwriting with new return value */
+    ret = direct_dirsamplef_(&c__[c_offset], &arrayi[1], &delta, &c__1, &new__, &length[
         length_offset], logfile, &f[3], free, maxi, &point[
         1], fcn, &x[1], x_seq, &l[1], minf, minpos, &u[1], n, maxfunc,
         maxdeep, &oops, fmax, ifeasiblef, iinfeasible, args,
         force_stop);
+    if (!ret) {
+        return NULL;
+    }
     if (force_stop && *force_stop) {
      *ierror = -102;
      return ret;


### PR DESCRIPTION

#### Reference issue
Closes #23215

#### What does this implement/fix?
Various memory leaks have been patched. Also included the multi-phase initialization of the extension module. 

#### Additional information
I still think we need to rewrite this code free from f2c which is quite an unreadable mess and carries all the F77 quirks.