### PR TITLE
BUG: signal: fix zpk2tf with non-integer gain

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1294,7 +1294,7 @@ def zpk2tf(z, p, k):
         if k.shape[0] == 1:
             k = [k[0]] * z.shape[0]
         for i in range(z.shape[0]):
-            k_i = xp.asarray(k[i], dtype=xp.int64)
+            k_i = xp.asarray(k[i], dtype=b.dtype)
             b[i, ...] = xp.multiply(k_i, _pu.poly(z[i, ...], xp=xp))
     else:
         # Use xp.multiply to work around torch type promotion

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1295,7 +1295,8 @@ def zpk2tf(z, p, k):
             k = [k[0]] * z.shape[0]
         for i in range(z.shape[0]):
             k_i = xp.asarray(k[i], dtype=b.dtype)
-            b[i, ...] = xp.multiply(k_i, _pu.poly(z[i, ...], xp=xp))
+            b_i = k_i * _pu.poly(z[i, ...], xp=xp)
+            b = xpx.at(b)[i, ...].set(b_i)
     else:
         # Use xp.multiply to work around torch type promotion
         # non-compliance for operations between 0d and higher

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -215,7 +215,6 @@ class TestTf2zpk:
             assert_raises(BadCoefficients, tf2zpk, [1e-15], [1.0, 1.0])
 
 
-
 @make_xp_test_case(zpk2tf)
 class TestZpk2Tf:
 
@@ -287,6 +286,21 @@ class TestZpk2Tf:
         a_ref = xp.asarray([1, -3, 2])
         xp_assert_close(b, b_ref, check_dtype=False)
         xp_assert_close(a, a_ref, check_dtype=False)
+
+    def test_zpk2tf_int_truncation(self, xp):
+        # regression test for gh-24382
+        z =  xp.asarray([[ 1, 2.], [ 0., -1.]], dtype=xp.float64)
+        p = xp.asarray([3., 4.], dtype=xp.float64)
+        k = 2.5
+
+        b, a = zpk2tf(z, p, k)
+
+        # reference values from scipy 1.15.3
+        b_ref = xp.asarray([[ 2.5, -7.5,  5. ], [ 2.5,  2.5,  0. ]], dtype=xp.float64)
+        a_ref = xp.asarray([ 1., -7., 12.], dtype=xp.float64)
+
+        xp_assert_close(b, b_ref, atol=1e-14)
+        xp_assert_close(a, a_ref, atol=1e-14)
 
 
 @make_xp_test_case(sos2zpk)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -287,6 +287,8 @@ class TestZpk2Tf:
         xp_assert_close(b, b_ref, check_dtype=False)
         xp_assert_close(a, a_ref, check_dtype=False)
 
+    @skip_xp_backends("cupy",
+                      reason="multi-dim arrays not supported yet on cupy")
     def test_zpk2tf_int_truncation(self, xp):
         # regression test for gh-24382
         z =  xp.asarray([[ 1, 2.], [ 0., -1.]], dtype=xp.float64)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

fixes https://github.com/scipy/scipy/issues/24382

#### What does this implement/fix?
<!--Please explain your changes.-->

`zpk2tf` test coverage is apparently rather thin, and it did not catch an error we introduced during the array API transition.

#### Additional information
<!--Any additional information you think is important.-->

This is a 1.17.0 regression, thus the backport-candidate label.

EDIT: now that this code path is covered, `zpk2tf` itself needs to fix for jax, too.