### PR TITLE
BUG: linalg/solve: raise errors for "singular" matrices of one element

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -277,6 +277,9 @@ def solve(a, b, lower=False, overwrite_a=False,
         return x
 
     if a_is_scalar:
+        if a1.item() == 0:
+            raise LinAlgError("A singular matrix detected.")
+
         out = b1 / a1
         return out[..., 0] if b_is_1D else out
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -808,6 +808,22 @@ class TestSolve:
         with (pytest.raises(LinAlgError, match="singular"), np.errstate(all='ignore')):
             solve(A, b, assume_a=structure)
 
+
+    @pytest.mark.parametrize('b', [0, 1, [0, 1]])
+    def test_singular_scalar(self, b):
+        # regression test for gh-24355: scalar a=0 is singular
+        # thus should raise the same error 
+
+        with pytest.raises(LinAlgError):
+            a = np.zeros((1, 1))
+            solve(a, b)
+
+        with pytest.raises(LinAlgError):
+            solve(0, b)
+
+        with pytest.raises(LinAlgError):
+            solve([[0]], b)
+
     def test_multiple_rhs(self):
         a = np.eye(2)
         rng = np.random.default_rng(1234)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

fixes https://github.com/scipy/scipy/issues/24355

#### What does this implement/fix?
<!--Please explain your changes.-->

`linalg.solve(a, b)` has a shortcut for an edge case of `a.size=1`. This code path needs to raise the same LinAlgError as larger matrices if `a` is "singular", i.e. if `a` is in fact zero.

#### Additional information
<!--Any additional information you think is important.-->

