### PR TITLE
MAINT: optimize.quadratic_assignment: SPEC 7 follow-up

### DIFF
--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -1,11 +1,8 @@
 import numpy as np
 import operator
-import warnings
-import numbers
 from . import (linear_sum_assignment, OptimizeResult)
 from ._optimize import _check_unknown_options
 
-from scipy._lib._util import check_random_state
 import itertools
 
 QUADRATIC_ASSIGNMENT_METHODS = ['faq', '2opt']

--- a/scipy/optimize/_qap.py
+++ b/scipy/optimize/_qap.py
@@ -69,19 +69,6 @@ def quadratic_assignment(A, B, method="faq", options=None):
             operating system. Types other than `numpy.random.Generator` are
             passed to `numpy.random.default_rng` to instantiate a ``Generator``.
 
-            .. versionchanged:: 1.15.0
-                As part of the `SPEC-007 <https://scientific-python.org/specs/spec-0007/>`_
-                transition from use of `numpy.random.RandomState` to
-                `numpy.random.Generator` is occurring. Supplying
-                `np.random.RandomState` to this function will now emit a
-                `DeprecationWarning`. In SciPy 1.17 its use will raise an exception.
-                In addition relying on global state using `np.random.seed`
-                will emit a `FutureWarning`. In SciPy 1.17 the global random number
-                generator will no longer be used.
-                Use of an int-like seed will raise a `FutureWarning`, in SciPy 1.17 it
-                will be normalized via `np.random.default_rng` rather than
-                `np.random.RandomState`.
-
         For method-specific options, see
         :func:`show_options('quadratic_assignment') <show_options>`.
 
@@ -202,35 +189,8 @@ def quadratic_assignment(A, B, method="faq", options=None):
     if method not in methods:
         raise ValueError(f"method {method} must be in {methods}.")
 
-    _spec007_transition(options.get("rng", None))
     res = methods[method](A, B, **options)
     return res
-
-
-def _spec007_transition(rng):
-    if isinstance(rng, np.random.RandomState):
-        warnings.warn(
-            "Use of `RandomState` with `quadratic_assignment` is deprecated"
-            " and will result in an exception in SciPy 1.17",
-            DeprecationWarning,
-            stacklevel=2
-        )
-    if ((rng is None or rng is np.random) and
-            np.random.mtrand._rand._bit_generator._seed_seq is None):
-        warnings.warn(
-            "The NumPy global RNG was seeded by calling `np.random.seed`."
-            " From SciPy 1.17, this function will no longer use the global RNG.",
-            FutureWarning,
-            stacklevel=2
-        )
-    if isinstance(rng, numbers.Integral | np.integer):
-        warnings.warn(
-            "The behavior when the rng option is an integer is changing: the value"
-            " will be normalized using np.random.default_rng beginning in SciPy 1.17,"
-            " and the resulting Generator will be used to generate random numbers.",
-            FutureWarning,
-            stacklevel=2
-        )
 
 
 def _calc_score(A, B, perm):
@@ -446,7 +406,7 @@ def _quadratic_assignment_faq(A, B,
     if msg is not None:
         raise ValueError(msg)
 
-    rng = check_random_state(rng)
+    rng = np.random.default_rng(rng)
     n = len(A)  # number of vertices in graphs
     n_seeds = len(partial_match)  # number of seeds
     n_unseed = n - n_seeds
@@ -674,7 +634,7 @@ def _quadratic_assignment_2opt(A, B, maximize=False, rng=None,
 
     """
     _check_unknown_options(unknown_options)
-    rng = check_random_state(rng)
+    rng = np.random.default_rng(rng)
     A, B, partial_match = _common_input_validation(A, B, partial_match)
 
     N = len(A)

--- a/scipy/optimize/tests/test_quadratic_assignment.py
+++ b/scipy/optimize/tests/test_quadratic_assignment.py
@@ -47,7 +47,6 @@ def chr12c():
     return A, B, opt_perm
 
 
-@pytest.mark.filterwarnings("ignore:The NumPy global RNG was seeded by calling")
 class QAPCommonTests:
     """
     Base class for `quadratic_assignment` tests.
@@ -169,25 +168,6 @@ class QAPCommonTests:
         with pytest.warns(OptimizeWarning):
             quadratic_assignment(A, B, method=self.method,
                                  options={"ekki-ekki": True})
-
-    def test_deprecation_future_warnings(self):
-        # May be removed after SPEC-7 transition is complete in SciPy 1.17
-        A = np.arange(16).reshape((4, 4))
-        B = np.arange(16).reshape((4, 4))
-
-        with pytest.warns(DeprecationWarning, match="Use of `RandomState`*"):
-            rng = np.random.RandomState(0)
-            quadratic_assignment(A, B, method=self.method,
-                                 options={"rng": rng, "maximize": False})
-
-        with pytest.warns(FutureWarning, match="The NumPy global RNG was seeded*"):
-            np.random.seed(0)
-            quadratic_assignment(A, B, method=self.method,
-                                 options={"maximize": False})
-
-        with pytest.warns(FutureWarning, match="The behavior when the rng option*"):
-            quadratic_assignment(A, B, method=self.method,
-                                 options={"rng": 0, "maximize": False})
 
 
 class TestFAQ(QAPCommonTests):
@@ -346,7 +326,6 @@ class Test2opt(QAPCommonTests):
             )
 
 
-@pytest.mark.filterwarnings("ignore:The NumPy global RNG was seeded by calling")
 class TestQAPOnce:
 
     # these don't need to be repeated for each method


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/21848#pullrequestreview-3672776573
gh-21833

#### What does this implement/fix?
WRT SPEC 7 transition, `optimize.quadratic_assignment` is a little ahead of most functions because it already had an `rng` keyword argument and started emitting warnings in SciPy 1.15. This PR carries out the advertised change: the `rng` argument is always normalized using `np.random.default_rng`.

#### Additional information
I guess we're a version late. Oops!
