### PR TITLE
ENH: linalg: move 'solve_banded' to C

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -150,6 +150,39 @@ class BatchedSolveBench(Benchmark):
             sl.solve(self.a, self.b, check_finite=False, **self.kwd)
 
 
+class BatchedSolveBandedBench(Benchmark):
+    params = [
+        [(100, 10, 10), (100, 20, 20), (100, 100)],
+        [(0, 0), (5, 0), (0, 5), (5, 5)],
+        ["solve_banded", "solve"],
+    ]
+    param_names = ["shape", "l_and_u", "function"]
+
+    def setup(self, shape, l_and_u, function):
+        self.a = random(shape)
+        l, u = l_and_u
+
+        self.ab = np.zeros((*self.a.shape[:-2], l + u + 1, self.a.shape[-1]))
+        self.ab[..., u, :] = np.diagonal(self.a, axis1=-2, axis2=-1)
+        for i in range(l):
+            self.ab[..., u + i + 1, :-i-1] = np.diagonal(
+                self.a, offset=-i-1, axis1=-2, axis2=-1
+            )
+
+        for i in range(u):
+            self.ab[..., u - i - 1, i + 1:] = np.diagonal(
+                self.a, offset=i+1, axis1=-2, axis2=-1
+            )
+
+        self.b = random([shape[-1]])
+
+    def time_solve_banded(self, shape, l_and_u, function):
+        if function == "solve":
+            sl.solve(self.a, self.b, check_finite=False, assume_a="banded")
+        else:
+            sl.solve_banded(l_and_u, self.ab, self.b, check_finite=False)
+
+
 class BatchedSVDBench(Benchmark):
     params = [
         [(10, 10, 10, 2), (100, 10, 10), (100, 20, 20), (100, 100, 100)],

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -514,15 +514,11 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
             x = x[..., 0]
         return x
 
-    if ab_is_scalar:
-        if ab1.item() == 0:
-            raise LinAlgError("A singular matrix was detected")
-
-        out = b1 / ab1
-        return out[..., 0] if b_is_1D else out
-
     # Edge case
     if ab1.shape[-1] == 1:
+        if ab1[nupper, 0] == 0:
+            raise LinAlgError("A singular matrix was detected")
+
         b2 = np.array(b1, copy=(not overwrite_b))
         # a1.shape[-1] == 1 -> original matrix is 1x1. Typically, the user
         # will pass u = l = 0 and `a1` will be 1x1. However, the rest of the

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -510,15 +510,11 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
             x = x[..., 0]
         return x
 
-    if ab_is_scalar:
-        if ab1.item() == 0:
-            raise LinAlgError("A singular matrix was detected")
-
-        out = b1 / ab1
-        return out[..., 0] if b_is_1D else out
-
     # Edge case
     if ab1.shape[-1] == 1:
+        if ab1[nupper, 0] == 0:
+            raise LinAlgError("A singular matrix was detected")
+
         b2 = np.array(b1, copy=(not overwrite_b))
         # a1.shape[-1] == 1 -> original matrix is 1x1. Typically, the user
         # will pass u = l = 0 and `a1` will be 1x1. However, the rest of the

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -10,7 +10,7 @@ import numpy as np
 from scipy._lib._util import _apply_over_batch
 from .lapack import (
     get_lapack_funcs, _normalize_lapack_dtype, _normalize_lapack_dtype1,
-    _ensure_aligned_and_native, _ensure_dtype_cdsz,
+    _ensure_aligned_and_native, _ensure_dtype_cdsz, HAS_ILP64
 )
 from ._misc import LinAlgError, _datacopied, LinAlgWarning
 from ._decomp import _asarray_validated
@@ -494,9 +494,10 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
     ab1 = np.broadcast_to(ab1, batch_shape + ab1.shape[-2:])
     b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
-    # Convert to `int16` to have a known type at receiver side.
-    nlower = np.broadcast_to(nlower, batch_shape).astype(np.int16)
-    nupper = np.broadcast_to(nupper, batch_shape).astype(np.int16)
+    # Convert to the same size as `CBLAS_INT` on C side
+    dtype = np.int64 if HAS_ILP64 else np.int32
+    nlower = np.broadcast_to(nlower, batch_shape).astype(dtype)
+    nupper = np.broadcast_to(nupper, batch_shape).astype(dtype)
 
     if not np.all(nlower + nupper == ab1.shape[-2] - 1):
         raise ValueError("Sum of l and u should be equal to number of rows of ab")

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -528,7 +528,11 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
         return b2
 
     overwrite_ab = (overwrite_ab or _datacopied(ab1, ab))
-    overwrite_b = (overwrite_b or _datacopied(b1, b))
+    overwrite_b = (
+        (overwrite_b or _datacopied(b1, b)) and
+        b1.ndim <= 2 and
+        b1.flags["F_CONTIGUOUS"]
+    )
 
     # hand of to lower level routine
     x, err_lst = _batched_linalg._solve_banded(ab1, b1, nlower, nupper,

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy._lib._util import _apply_over_batch
 from .lapack import (
     get_lapack_funcs, _normalize_lapack_dtype, _normalize_lapack_dtype1,
-    _ensure_aligned_and_native, _ensure_dtype_cdsz,
+    _ensure_aligned_and_native, _ensure_dtype_cdsz, HAS_ILP64
 )
 from ._misc import LinAlgError, _datacopied, LinAlgWarning
 from ._decomp import _asarray_validated
@@ -498,9 +498,10 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
     ab1 = np.broadcast_to(ab1, batch_shape + ab1.shape[-2:])
     b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
-    # Convert to `int16` to have a known type at receiver side.
-    nlower = np.broadcast_to(nlower, batch_shape).astype(np.int16)
-    nupper = np.broadcast_to(nupper, batch_shape).astype(np.int16)
+    # Convert to the same size as `CBLAS_INT` on C side
+    dtype = np.int64 if HAS_ILP64 else np.int32
+    nlower = np.broadcast_to(nlower, batch_shape).astype(dtype)
+    nupper = np.broadcast_to(nupper, batch_shape).astype(dtype)
 
     if not np.all(nlower + nupper == ab1.shape[-2] - 1):
         raise ValueError("Sum of l and u should be equal to number of rows of ab")

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -468,59 +468,79 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
 
     """
     (nlower, nupper) = l_and_u
-    return _solve_banded(nlower, nupper, ab, b, overwrite_ab=overwrite_ab,
-                         overwrite_b=overwrite_b, check_finite=check_finite)
+    ab1 = np.atleast_2d(_asarray_validated(ab, check_finite=check_finite))
+    b1 = np.atleast_1d(_asarray_validated(b, check_finite=check_finite))
+    ab1, b1 = _ensure_dtype_cdsz(ab1, b1)
 
+    # Validate shapes
+    if ab1.ndim < 2:
+        raise ValueError(f"Expected at least ndim=2, got {ab1.ndim}")
 
-@_apply_over_batch(('nlower', 0), ('nupper', 0), ('ab', 2), ('b', '1|2'))
-def _solve_banded(nlower, nupper, ab, b, overwrite_ab, overwrite_b, check_finite):
-    a1 = _asarray_validated(ab, check_finite=check_finite, as_inexact=True)
-    b1 = _asarray_validated(b, check_finite=check_finite, as_inexact=True)
+    if not (ab1.flags["ALIGNED"] and ab1.dtype.byteorder == "="):
+        overwrite_ab = True
+        ab1 = ab1.copy()
 
-    # Validate shapes.
-    if a1.shape[-1] != b1.shape[0]:
-        raise ValueError("shapes of ab and b are not compatible.")
+    if not (b1.flags["ALIGNED"] and b1.dtype.byteorder == "="):
+        overwrite_b = True
+        b1 = b1.copy()
 
-    if nlower + nupper + 1 != a1.shape[0]:
-        raise ValueError(
-            f"invalid values for the number of lower and upper diagonals: l+u+1 "
-            f"({nlower + nupper + 1}) does not equal ab.shape[0] ({ab.shape[0]})"
-        )
+    # align the shape of b with ab:
+    b_is_1D = b1.ndim == 1
+    if b_is_1D:
+        b1 = b1[:, None]
 
-    # accommodate empty arrays
-    if b1.size == 0:
-        dt = solve(np.eye(1, dtype=a1.dtype), np.ones(1, dtype=b1.dtype)).dtype
-        return np.empty_like(b1, dtype=dt)
+    ab_is_scalar = ab1.size == 1
 
-    overwrite_b = overwrite_b or _datacopied(b1, b)
-    if a1.shape[-1] == 1:
+    if b1.shape[-2] != ab1.shape[-1] and not ab_is_scalar:
+        raise ValueError(f"Incompatible shapes: {ab1.shape} and {b1.shape}")
+
+    batch_shape = np.broadcast_shapes(ab1.shape[:-2], b1.shape[:-2])
+    ab1 = np.broadcast_to(ab1, batch_shape + ab1.shape[-2:])
+    b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
+
+    # Convert to `int16` to have a known type at receiver side.
+    nlower = np.broadcast_to(nlower, batch_shape).astype(np.int16)
+    nupper = np.broadcast_to(nupper, batch_shape).astype(np.int16)
+
+    # accomodate empty arrays
+    if ab1.size == 0 or b1.size == 0:
+        x = np.empty_like(b1)
+        if b_is_1D:
+            x = x[..., 0]
+        return x
+
+    if ab_is_scalar:
+        if ab1.item() == 0:
+            raise LinAlgError("A singular matrix was detected")
+
+        out = b1 / ab1
+        return out[..., 0] if b_is_1D else out
+
+    # Edge case
+    if ab1.shape[-1] == 1:
         b2 = np.array(b1, copy=(not overwrite_b))
         # a1.shape[-1] == 1 -> original matrix is 1x1. Typically, the user
         # will pass u = l = 0 and `a1` will be 1x1. However, the rest of the
         # function works with unnecessary rows in `a1` as long as
         # `a1[u + i - j, j] == a[i,j]`. In the 1x1 case, we want i = j = 0,
         # so the diagonal is in row `u` of `a1`. See gh-8906.
-        b2 /= a1[nupper, 0]
+        b2 /= ab1[nupper, 0]
         return b2
-    if nlower == nupper == 1:
-        overwrite_ab = overwrite_ab or _datacopied(a1, ab)
-        gtsv, = get_lapack_funcs(('gtsv',), (a1, b1))
-        du = a1[0, 1:]
-        d = a1[1, :]
-        dl = a1[2, :-1]
-        du2, d, du, x, info = gtsv(dl, d, du, b1, overwrite_ab, overwrite_ab,
-                                   overwrite_ab, overwrite_b)
-    else:
-        gbsv, = get_lapack_funcs(('gbsv',), (a1, b1))
-        a2 = np.zeros((2*nlower + nupper + 1, a1.shape[1]), dtype=gbsv.dtype)
-        a2[nlower:, :] = a1
-        lu, piv, x, info = gbsv(nlower, nupper, a2, b1, overwrite_ab=True,
-                                overwrite_b=overwrite_b)
-    if info == 0:
-        return x
-    if info > 0:
-        raise LinAlgError("singular matrix")
-    raise ValueError(f'illegal value in {-info}-th argument of internal gbsv/gtsv')
+
+    overwrite_ab = (overwrite_ab or _datacopied(ab1, ab))
+    overwrite_b = (overwrite_b or _datacopied(b1, b))
+
+    # hand of to lower level routine
+    x, err_lst = _batched_linalg._solve_banded(ab1, b1, nlower, nupper,
+                                                overwrite_ab, overwrite_b)
+
+    if err_lst:
+        _format_emit_errors_warnings(err_lst)
+
+    if b_is_1D:
+        x = x[..., 0]
+
+    return x
 
 
 @_apply_over_batch(('a', 2), ('b', '1|2'))

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -491,8 +491,9 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
         raise ValueError(f"Incompatible shapes: {ab1.shape} and {b1.shape}")
 
     batch_shape = np.broadcast_shapes(ab1.shape[:-2], b1.shape[:-2])
-    ab1 = np.broadcast_to(ab1, batch_shape + ab1.shape[-2:])
-    b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
+    if ab1.ndim > 2 or b1.ndim > 2:
+        ab1 = np.broadcast_to(ab1, batch_shape + ab1.shape[-2:])
+        b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
     # Convert to the same size as `CBLAS_INT` on C side
     dtype = np.int64 if HAS_ILP64 else np.int32
@@ -530,7 +531,7 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
     overwrite_ab = (overwrite_ab or _datacopied(ab1, ab))
     overwrite_b = (
         (overwrite_b or _datacopied(b1, b)) and
-        b1.ndim <= 2 and
+        (b1.ndim <= 2) and
         b1.flags["F_CONTIGUOUS"]
     )
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -498,6 +498,9 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
     nlower = np.broadcast_to(nlower, batch_shape).astype(np.int16)
     nupper = np.broadcast_to(nupper, batch_shape).astype(np.int16)
 
+    if not np.all(nlower + nupper == ab1.shape[-2] - 1):
+        raise ValueError("Sum of l and u should be equal to number of rows of ab")
+
     # accomodate empty arrays
     if ab1.size == 0 or b1.size == 0:
         x = np.empty_like(b1)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -502,6 +502,9 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
     nlower = np.broadcast_to(nlower, batch_shape).astype(np.int16)
     nupper = np.broadcast_to(nupper, batch_shape).astype(np.int16)
 
+    if not np.all(nlower + nupper == ab1.shape[-2] - 1):
+        raise ValueError("Sum of l and u should be equal to number of rows of ab")
+
     # accomodate empty arrays
     if ab1.size == 0 or b1.size == 0:
         x = np.empty_like(b1)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -532,7 +532,11 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
         return b2
 
     overwrite_ab = (overwrite_ab or _datacopied(ab1, ab))
-    overwrite_b = (overwrite_b or _datacopied(b1, b))
+    overwrite_b = (
+        (overwrite_b or _datacopied(b1, b)) and
+        b1.ndim <= 2 and
+        b1.flags["F_CONTIGUOUS"]
+    )
 
     # hand of to lower level routine
     x, err_lst = _batched_linalg._solve_banded(ab1, b1, nlower, nupper,

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -495,8 +495,9 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
         raise ValueError(f"Incompatible shapes: {ab1.shape} and {b1.shape}")
 
     batch_shape = np.broadcast_shapes(ab1.shape[:-2], b1.shape[:-2])
-    ab1 = np.broadcast_to(ab1, batch_shape + ab1.shape[-2:])
-    b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
+    if ab1.ndim > 2 or b1.ndim > 2:
+        ab1 = np.broadcast_to(ab1, batch_shape + ab1.shape[-2:])
+        b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
     # Convert to the same size as `CBLAS_INT` on C side
     dtype = np.int64 if HAS_ILP64 else np.int32
@@ -534,7 +535,7 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
     overwrite_ab = (overwrite_ab or _datacopied(ab1, ab))
     overwrite_b = (
         (overwrite_b or _datacopied(b1, b)) and
-        b1.ndim <= 2 and
+        (b1.ndim <= 2) and
         b1.flags["F_CONTIGUOUS"]
     )
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -464,59 +464,79 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
 
     """
     (nlower, nupper) = l_and_u
-    return _solve_banded(nlower, nupper, ab, b, overwrite_ab=overwrite_ab,
-                         overwrite_b=overwrite_b, check_finite=check_finite)
+    ab1 = np.atleast_2d(_asarray_validated(ab, check_finite=check_finite))
+    b1 = np.atleast_1d(_asarray_validated(b, check_finite=check_finite))
+    ab1, b1 = _ensure_dtype_cdsz(ab1, b1)
 
+    # Validate shapes
+    if ab1.ndim < 2:
+        raise ValueError(f"Expected at least ndim=2, got {ab1.ndim}")
 
-@_apply_over_batch(('nlower', 0), ('nupper', 0), ('ab', 2), ('b', '1|2'))
-def _solve_banded(nlower, nupper, ab, b, overwrite_ab, overwrite_b, check_finite):
-    a1 = _asarray_validated(ab, check_finite=check_finite, as_inexact=True)
-    b1 = _asarray_validated(b, check_finite=check_finite, as_inexact=True)
+    if not (ab1.flags["ALIGNED"] and ab1.dtype.byteorder == "="):
+        overwrite_ab = True
+        ab1 = ab1.copy()
 
-    # Validate shapes.
-    if a1.shape[-1] != b1.shape[0]:
-        raise ValueError("shapes of ab and b are not compatible.")
+    if not (b1.flags["ALIGNED"] and b1.dtype.byteorder == "="):
+        overwrite_b = True
+        b1 = b1.copy()
 
-    if nlower + nupper + 1 != a1.shape[0]:
-        raise ValueError(
-            f"invalid values for the number of lower and upper diagonals: l+u+1 "
-            f"({nlower + nupper + 1}) does not equal ab.shape[0] ({ab.shape[0]})"
-        )
+    # align the shape of b with ab:
+    b_is_1D = b1.ndim == 1
+    if b_is_1D:
+        b1 = b1[:, None]
 
-    # accommodate empty arrays
-    if b1.size == 0:
-        dt = solve(np.eye(1, dtype=a1.dtype), np.ones(1, dtype=b1.dtype)).dtype
-        return np.empty_like(b1, dtype=dt)
+    ab_is_scalar = ab1.size == 1
 
-    overwrite_b = overwrite_b or _datacopied(b1, b)
-    if a1.shape[-1] == 1:
+    if b1.shape[-2] != ab1.shape[-1] and not ab_is_scalar:
+        raise ValueError(f"Incompatible shapes: {ab1.shape} and {b1.shape}")
+
+    batch_shape = np.broadcast_shapes(ab1.shape[:-2], b1.shape[:-2])
+    ab1 = np.broadcast_to(ab1, batch_shape + ab1.shape[-2:])
+    b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
+
+    # Convert to `int16` to have a known type at receiver side.
+    nlower = np.broadcast_to(nlower, batch_shape).astype(np.int16)
+    nupper = np.broadcast_to(nupper, batch_shape).astype(np.int16)
+
+    # accomodate empty arrays
+    if ab1.size == 0 or b1.size == 0:
+        x = np.empty_like(b1)
+        if b_is_1D:
+            x = x[..., 0]
+        return x
+
+    if ab_is_scalar:
+        if ab1.item() == 0:
+            raise LinAlgError("A singular matrix was detected")
+
+        out = b1 / ab1
+        return out[..., 0] if b_is_1D else out
+
+    # Edge case
+    if ab1.shape[-1] == 1:
         b2 = np.array(b1, copy=(not overwrite_b))
         # a1.shape[-1] == 1 -> original matrix is 1x1. Typically, the user
         # will pass u = l = 0 and `a1` will be 1x1. However, the rest of the
         # function works with unnecessary rows in `a1` as long as
         # `a1[u + i - j, j] == a[i,j]`. In the 1x1 case, we want i = j = 0,
         # so the diagonal is in row `u` of `a1`. See gh-8906.
-        b2 /= a1[nupper, 0]
+        b2 /= ab1[nupper, 0]
         return b2
-    if nlower == nupper == 1:
-        overwrite_ab = overwrite_ab or _datacopied(a1, ab)
-        gtsv, = get_lapack_funcs(('gtsv',), (a1, b1))
-        du = a1[0, 1:]
-        d = a1[1, :]
-        dl = a1[2, :-1]
-        du2, d, du, x, info = gtsv(dl, d, du, b1, overwrite_ab, overwrite_ab,
-                                   overwrite_ab, overwrite_b)
-    else:
-        gbsv, = get_lapack_funcs(('gbsv',), (a1, b1))
-        a2 = np.zeros((2*nlower + nupper + 1, a1.shape[1]), dtype=gbsv.dtype)
-        a2[nlower:, :] = a1
-        lu, piv, x, info = gbsv(nlower, nupper, a2, b1, overwrite_ab=True,
-                                overwrite_b=overwrite_b)
-    if info == 0:
-        return x
-    if info > 0:
-        raise LinAlgError("singular matrix")
-    raise ValueError(f'illegal value in {-info}-th argument of internal gbsv/gtsv')
+
+    overwrite_ab = (overwrite_ab or _datacopied(ab1, ab))
+    overwrite_b = (overwrite_b or _datacopied(b1, b))
+
+    # hand of to lower level routine
+    x, err_lst = _batched_linalg._solve_banded(ab1, b1, nlower, nupper,
+                                                overwrite_ab, overwrite_b)
+
+    if err_lst:
+        _format_emit_errors_warnings(err_lst)
+
+    if b_is_1D:
+        x = x[..., 0]
+
+    return x
 
 
 @_apply_over_batch(('a', 2), ('b', '1|2'))

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -238,8 +238,14 @@ _linalg_solve_banded(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-    if (!(PyArray_TYPE(ap_kls) == NPY_INT16) || !PyArray_ISALIGNED(ap_kls)) {
-        PyErr_SetString(PyExc_TypeError, "Expected bounds to be integers.");
+    int bounds_typenum = sizeof(CBLAS_INT) == sizeof(NPY_INT32) ? NPY_INT32 : NPY_INT64;
+
+    if (!(PyArray_TYPE(ap_kls) == bounds_typenum) || !PyArray_ISALIGNED(ap_kls)) {
+        PyErr_SetString(PyExc_TypeError, "Expected lower bounds to be CBLAS_INT.");
+        return NULL;
+    }
+    if (!(PyArray_TYPE(ap_kus) == bounds_typenum) || !PyArray_ISALIGNED(ap_kus)) {
+        PyErr_SetString(PyExc_TypeError, "Expected upper bounds to be CBLAS_INT.");
         return NULL;
     }
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -492,11 +492,18 @@ _linalg_solve_banded(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-    // Allocate the output
-    ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim_b, shape_b, typenum);
-    if(!ap_x) {
-        PyErr_NoMemory();
-        return NULL;
+    // If `overwrite_b` is enabled, the conditions for which are checked at the python side, it is
+    // possible to reuse `ap_b`. If it is disabled, allocate a new array for the output.
+    if (!overwrite_b) {
+        ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim_b, shape_b, typenum);
+        if(!ap_x) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+    } else {
+        // Reuse the input
+        ap_x = ap_b;
+        Py_INCREF(ap_b);
     }
 
     void *buf = PyArray_DATA(ap_x);

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -272,11 +272,18 @@ _linalg_solve_banded(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-    // Allocate the output
-    ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim_b, shape_b, typenum);
-    if(!ap_x) {
-        PyErr_NoMemory();
-        return NULL;
+    // If `overwrite_b` is enabled, the conditions for which are checked at the python side, it is
+    // possible to reuse `ap_b`. If it is disabled, allocate a new array for the output.
+    if (!overwrite_b) {
+        ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim_b, shape_b, typenum);
+        if(!ap_x) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+    } else {
+        // Reuse the input
+        ap_x = ap_b;
+        Py_INCREF(ap_b);
     }
 
     void *buf = PyArray_DATA(ap_x);

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -208,6 +208,107 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
 
 static PyObject*
+_linalg_solve_banded(PyObject* Py_UNUSED(dummy), PyObject* args) {
+
+    PyArrayObject *ap_Ab = NULL;
+    PyArrayObject *ap_b = NULL;
+    PyArrayObject *ap_kls = NULL; // lower bands
+    PyArrayObject *ap_kus = NULL; // upper bands
+    PyArrayObject *ap_x = NULL; // return object
+
+    int overwrite_ab = 0;
+    int overwrite_b = 0;
+    int info;
+    SliceStatusVec vec_status;
+
+    // Get input data
+    if (!PyArg_ParseTuple(args, "O!O!O!O!|pp", &PyArray_Type, (PyObject **)&ap_Ab, &PyArray_Type, (PyObject **)&ap_b, &PyArray_Type, (PyObject **)&ap_kls, &PyArray_Type, (PyObject **)&ap_kus, &overwrite_ab, &overwrite_b)) {
+        PyErr_SetString(PyExc_ValueError, "Could not parse input.");
+        return NULL;
+    }
+
+    // Check for dtype compatibility & array flags
+    int typenum = PyArray_TYPE(ap_Ab);
+    bool dtype_ok = (typenum == NPY_FLOAT32)
+                     || (typenum == NPY_FLOAT64)
+                     || (typenum == NPY_COMPLEX64)
+                     || (typenum == NPY_COMPLEX128);
+    if(!dtype_ok || !PyArray_ISALIGNED(ap_Ab)) {
+        PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
+        return NULL;
+    }
+
+    if (!(PyArray_TYPE(ap_kls) == NPY_INT16) || !PyArray_ISALIGNED(ap_kls)) {
+        PyErr_SetString(PyExc_TypeError, "Expected bounds to be integers.");
+        return NULL;
+    }
+
+    // Sanity check shapes
+    int ndim = PyArray_NDIM(ap_Ab);
+    npy_intp* shape = PyArray_SHAPE(ap_Ab);
+    if (ndim < 2) { // Can not perform a check on the two last dimensions: should be related to the banding
+        PyErr_SetString(PyExc_ValueError, "Incorrect dimensions for ab.");
+        return NULL;
+    }
+
+    // Allocate output object
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+
+    bool dims_match = ndim_b == ndim;
+    if (dims_match) {
+        for (int i=0; i<ndim-2; i++) { // ndim - 2 can be different due to banded structure
+            dims_match = dims_match && (shape[i] == shape_b[i]);
+        }
+    }
+    if (!dims_match){
+        PyErr_SetString(PyExc_ValueError, "`ab` and `b` shape mismatch.");
+        return NULL;
+    }
+
+    // Allocate the output
+    ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim_b, shape_b, typenum);
+    if(!ap_x) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    void *buf = PyArray_DATA(ap_x);
+    switch (typenum) {
+        case (NPY_FLOAT32):
+            info = _solve_banded<float>(ap_Ab, ap_b, (float *)buf, ap_kls, ap_kus, overwrite_ab, overwrite_b, vec_status);
+            break;
+
+        case (NPY_FLOAT64):
+            info = _solve_banded<double>(ap_Ab, ap_b, (double *)buf, ap_kls, ap_kus, overwrite_ab, overwrite_b, vec_status);
+            break;
+
+        case (NPY_COMPLEX64):
+            info = _solve_banded<npy_complex64>(ap_Ab, ap_b, (npy_complex64 *)buf, ap_kls, ap_kus, overwrite_ab, overwrite_b, vec_status);
+            break;
+
+        case (NPY_COMPLEX128):
+            info = _solve_banded<npy_complex128>(ap_Ab, ap_b, (npy_complex128 *)buf, ap_kls, ap_kus, overwrite_ab, overwrite_b, vec_status);
+            break;
+
+        default:
+                PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");
+                return NULL;
+    }
+
+    if (info < 0) {
+        // Either OOM error or requiested lwork too large.
+        Py_DECREF(ap_x);
+        PyErr_SetString(PyExc_MemoryError, "Memory error in scipy.linalg.solve_banded.");
+        return NULL;
+    }
+    PyObject *ret_lst = convert_vec_status(vec_status);
+
+    return Py_BuildValue("NN", PyArray_Return(ap_x), ret_lst);
+}
+
+
+static PyObject*
 _linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyArrayObject *ap_Am = NULL;
     const char *lapack_driver = NULL;
@@ -739,6 +840,7 @@ get_err_mesg(const std::string routine, const std::string func_name, int info) {
 
 static char doc_inv[] = ("Compute the matrix inverse.");
 static char doc_solve[] = ("Solve the linear system of equations.");
+static char doc_solve_banded[] = ("Solve the banded linear system of equations.");
 static char doc_svd[] = ("SVD factorization.");
 static char doc_lstsq[] = ("linear least squares.");
 static char doc_eig[] = ("eigenvalue solver.");
@@ -747,6 +849,7 @@ static char doc_cholesky[] = ("Cholesky factorization.");
 static struct PyMethodDef inv_module_methods[] = {
   {"_inv", _linalg_inv, METH_VARARGS, doc_inv},
   {"_solve", _linalg_solve, METH_VARARGS, doc_solve},
+  {"_solve_banded", _linalg_solve_banded, METH_VARARGS, doc_solve_banded},
   {"_svd", _linalg_svd, METH_VARARGS, doc_svd},
   {"_lstsq", _linalg_lstsq, METH_VARARGS, doc_lstsq},
   {"_eig", _linalg_eig, METH_VARARGS, doc_eig},

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -458,8 +458,14 @@ _linalg_solve_banded(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-    if (!(PyArray_TYPE(ap_kls) == NPY_INT16) || !PyArray_ISALIGNED(ap_kls)) {
-        PyErr_SetString(PyExc_TypeError, "Expected bounds to be integers.");
+    int bounds_typenum = sizeof(CBLAS_INT) == sizeof(NPY_INT32) ? NPY_INT32 : NPY_INT64;
+
+    if (!(PyArray_TYPE(ap_kls) == bounds_typenum) || !PyArray_ISALIGNED(ap_kls)) {
+        PyErr_SetString(PyExc_TypeError, "Expected lower bounds to be CBLAS_INT.");
+        return NULL;
+    }
+    if (!(PyArray_TYPE(ap_kus) == bounds_typenum) || !PyArray_ISALIGNED(ap_kus)) {
+        PyErr_SetString(PyExc_TypeError, "Expected upper bounds to be CBLAS_INT.");
         return NULL;
     }
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -428,6 +428,107 @@ fail_qr:
 
 
 static PyObject*
+_linalg_solve_banded(PyObject* Py_UNUSED(dummy), PyObject* args) {
+
+    PyArrayObject *ap_Ab = NULL;
+    PyArrayObject *ap_b = NULL;
+    PyArrayObject *ap_kls = NULL; // lower bands
+    PyArrayObject *ap_kus = NULL; // upper bands
+    PyArrayObject *ap_x = NULL; // return object
+
+    int overwrite_ab = 0;
+    int overwrite_b = 0;
+    int info;
+    SliceStatusVec vec_status;
+
+    // Get input data
+    if (!PyArg_ParseTuple(args, "O!O!O!O!|pp", &PyArray_Type, (PyObject **)&ap_Ab, &PyArray_Type, (PyObject **)&ap_b, &PyArray_Type, (PyObject **)&ap_kls, &PyArray_Type, (PyObject **)&ap_kus, &overwrite_ab, &overwrite_b)) {
+        PyErr_SetString(PyExc_ValueError, "Could not parse input.");
+        return NULL;
+    }
+
+    // Check for dtype compatibility & array flags
+    int typenum = PyArray_TYPE(ap_Ab);
+    bool dtype_ok = (typenum == NPY_FLOAT32)
+                     || (typenum == NPY_FLOAT64)
+                     || (typenum == NPY_COMPLEX64)
+                     || (typenum == NPY_COMPLEX128);
+    if(!dtype_ok || !PyArray_ISALIGNED(ap_Ab)) {
+        PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
+        return NULL;
+    }
+
+    if (!(PyArray_TYPE(ap_kls) == NPY_INT16) || !PyArray_ISALIGNED(ap_kls)) {
+        PyErr_SetString(PyExc_TypeError, "Expected bounds to be integers.");
+        return NULL;
+    }
+
+    // Sanity check shapes
+    int ndim = PyArray_NDIM(ap_Ab);
+    npy_intp* shape = PyArray_SHAPE(ap_Ab);
+    if (ndim < 2) { // Can not perform a check on the two last dimensions: should be related to the banding
+        PyErr_SetString(PyExc_ValueError, "Incorrect dimensions for ab.");
+        return NULL;
+    }
+
+    // Allocate output object
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+
+    bool dims_match = ndim_b == ndim;
+    if (dims_match) {
+        for (int i=0; i<ndim-2; i++) { // ndim - 2 can be different due to banded structure
+            dims_match = dims_match && (shape[i] == shape_b[i]);
+        }
+    }
+    if (!dims_match){
+        PyErr_SetString(PyExc_ValueError, "`ab` and `b` shape mismatch.");
+        return NULL;
+    }
+
+    // Allocate the output
+    ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim_b, shape_b, typenum);
+    if(!ap_x) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+
+    void *buf = PyArray_DATA(ap_x);
+    switch (typenum) {
+        case (NPY_FLOAT32):
+            info = _solve_banded<float>(ap_Ab, ap_b, (float *)buf, ap_kls, ap_kus, overwrite_ab, overwrite_b, vec_status);
+            break;
+
+        case (NPY_FLOAT64):
+            info = _solve_banded<double>(ap_Ab, ap_b, (double *)buf, ap_kls, ap_kus, overwrite_ab, overwrite_b, vec_status);
+            break;
+
+        case (NPY_COMPLEX64):
+            info = _solve_banded<npy_complex64>(ap_Ab, ap_b, (npy_complex64 *)buf, ap_kls, ap_kus, overwrite_ab, overwrite_b, vec_status);
+            break;
+
+        case (NPY_COMPLEX128):
+            info = _solve_banded<npy_complex128>(ap_Ab, ap_b, (npy_complex128 *)buf, ap_kls, ap_kus, overwrite_ab, overwrite_b, vec_status);
+            break;
+
+        default:
+                PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");
+                return NULL;
+    }
+
+    if (info < 0) {
+        // Either OOM error or requiested lwork too large.
+        Py_DECREF(ap_x);
+        PyErr_SetString(PyExc_MemoryError, "Memory error in scipy.linalg.solve_banded.");
+        return NULL;
+    }
+    PyObject *ret_lst = convert_vec_status(vec_status);
+
+    return Py_BuildValue("NN", PyArray_Return(ap_x), ret_lst);
+}
+
+
+static PyObject*
 _linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyArrayObject *ap_Am = NULL;
     const char *lapack_driver = NULL;
@@ -1486,6 +1587,7 @@ static char doc_bandwidth[] = (
 );
 static char doc_inv[] = ("Compute the matrix inverse.");
 static char doc_solve[] = ("Solve the linear system of equations.");
+static char doc_solve_banded[] = ("Solve the banded linear system of equations.");
 static char doc_svd[] = ("SVD factorization.");
 static char doc_lstsq[] = ("linear least squares.");
 static char doc_eig[] = ("eigenvalue solver.");
@@ -1498,6 +1600,7 @@ static struct PyMethodDef module_methods[] = {
   {"_lu", _linalg_lu, METH_VARARGS, doc_lu},
   {"_inv", _linalg_inv, METH_VARARGS, doc_inv},
   {"_solve", _linalg_solve, METH_VARARGS, doc_solve},
+  {"_solve_banded", _linalg_solve_banded, METH_VARARGS, doc_solve_banded},
   {"_svd", _linalg_svd, METH_VARARGS, doc_svd},
   {"_lstsq", _linalg_lstsq, METH_VARARGS, doc_lstsq},
   {"_eig", _linalg_eig, METH_VARARGS, doc_eig},

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1334,9 +1334,8 @@ detect_bandwidths(T* data, npy_intp ndim, npy_intp outer_size, npy_intp *shape, 
         T* slice_ptr = compute_slice_ptr(idx, data, ndim, shape, strides);
 
         bandwidth_strided(slice_ptr, shape[ndim-2], shape[ndim-1], strides[ndim-2], strides[ndim-1], &kl[idx], &ku[idx]);
-        if (2 * kl[idx] + ku[idx] + 1 > *ldab_max) {
-            *ldab_max = 2 * kl[idx] + ku[idx] + 1;
-        }
+
+        if (2 * kl[idx] + ku[idx] + 1 > *ldab_max) { *ldab_max = 2 * kl[idx] + ku[idx] + 1; }
     }
 }
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1546,6 +1546,44 @@ to_banded(const T *data, npy_intp n, npy_intp kl, npy_intp ku, npy_intp ldab, T 
 }
 
 
+/*
+ * Copy the passed in matrix `data`, which is already in banded storage since
+ * it is passed from `solve_banded()` to a buffer of the apropriate size.
+ *
+ * Input matrix is of size `m` x `n` and the `dst` matrix is of size
+ * `ldab` x `n`.
+ *
+ * `s1` and `s2` are the strides along the first and second dimensions, respectively,
+ * of the array.
+ */
+template<typename T>
+inline void
+copy_banded(T *src, npy_intp m, npy_intp n, npy_intp kl, npy_intp ku, npy_intp ldab, T *dst, npy_intp s1, npy_intp s2) {
+    npy_intp i, j;
+    s1 = s1 / sizeof(T);
+    s2 = s2 / sizeof(T);
+
+    // main diagonal
+    for (i = 0; i < n; i++) {
+        dst[(i + 1) * ldab - kl - 1] = src[(m - kl - 1) * s1 + i * s2];
+    }
+
+    // lower bands
+    for (i = 0; i < kl; i++) {
+        for (j = 0; j < n - i - 1; j++) {
+            dst[(j + 1) * ldab - kl + i] = src[(m - kl + i) * s1 + j * s2];
+        }
+    }
+
+    // upper bands
+    for (i = 0; i < ku; i++) {
+        for (j = i + 1; j < n; j++) {
+            dst[(j + 1) * ldab - kl - 2 - i] = src[(m - kl - 2 - i) * s1 + j * s2];
+        }
+    }
+}
+
+
 template<typename T>
 inline void
 zero_other_triangle(char uplo, T *data, const npy_intp m, npy_intp n = -1, npy_intp lda = -1) {

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1335,7 +1335,9 @@ detect_bandwidths(T* data, npy_intp ndim, npy_intp outer_size, npy_intp *shape, 
 
         bandwidth_strided(slice_ptr, shape[ndim-2], shape[ndim-1], strides[ndim-2], strides[ndim-1], &kl[idx], &ku[idx]);
 
-        if (2 * kl[idx] + ku[idx] + 1 > *ldab_max) { *ldab_max = 2 * kl[idx] + ku[idx] + 1; }
+        if (2 * kl[idx] + ku[idx] + 1 > *ldab_max) {
+            *ldab_max = 2 * kl[idx] + ku[idx] + 1;
+        }
     }
 }
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1377,7 +1377,9 @@ detect_bandwidths(T* data, npy_intp ndim, npy_intp outer_size, npy_intp *shape, 
 
         bandwidth_strided(slice_ptr, shape[ndim-2], shape[ndim-1], strides[ndim-2], strides[ndim-1], &kl[idx], &ku[idx]);
 
-        if (2 * kl[idx] + ku[idx] + 1 > *ldab_max) { *ldab_max = 2 * kl[idx] + ku[idx] + 1; }
+        if (2 * kl[idx] + ku[idx] + 1 > *ldab_max) {
+            *ldab_max = 2 * kl[idx] + ku[idx] + 1;
+        }
     }
 }
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1504,6 +1504,44 @@ to_banded(const T *data, npy_intp n, npy_intp kl, npy_intp ku, npy_intp ldab, T 
 }
 
 
+/*
+ * Copy the passed in matrix `data`, which is already in banded storage since
+ * it is passed from `solve_banded()` to a buffer of the apropriate size.
+ *
+ * Input matrix is of size `m` x `n` and the `dst` matrix is of size
+ * `ldab` x `n`.
+ *
+ * `s1` and `s2` are the strides along the first and second dimensions, respectively,
+ * of the array.
+ */
+template<typename T>
+inline void
+copy_banded(T *src, npy_intp m, npy_intp n, npy_intp kl, npy_intp ku, npy_intp ldab, T *dst, npy_intp s1, npy_intp s2) {
+    npy_intp i, j;
+    s1 = s1 / sizeof(T);
+    s2 = s2 / sizeof(T);
+
+    // main diagonal
+    for (i = 0; i < n; i++) {
+        dst[(i + 1) * ldab - kl - 1] = src[(m - kl - 1) * s1 + i * s2];
+    }
+
+    // lower bands
+    for (i = 0; i < kl; i++) {
+        for (j = 0; j < n - i - 1; j++) {
+            dst[(j + 1) * ldab - kl + i] = src[(m - kl + i) * s1 + j * s2];
+        }
+    }
+
+    // upper bands
+    for (i = 0; i < ku; i++) {
+        for (j = i + 1; j < n; j++) {
+            dst[(j + 1) * ldab - kl - 2 - i] = src[(m - kl - 2 - i) * s1 + j * s2];
+        }
+    }
+}
+
+
 template<typename T>
 inline void
 zero_other_triangle(char uplo, T *data, npy_intp n) {

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1376,9 +1376,8 @@ detect_bandwidths(T* data, npy_intp ndim, npy_intp outer_size, npy_intp *shape, 
         T* slice_ptr = compute_slice_ptr(idx, data, ndim, shape, strides);
 
         bandwidth_strided(slice_ptr, shape[ndim-2], shape[ndim-1], strides[ndim-2], strides[ndim-1], &kl[idx], &ku[idx]);
-        if (2 * kl[idx] + ku[idx] + 1 > *ldab_max) {
-            *ldab_max = 2 * kl[idx] + ku[idx] + 1;
-        }
+
+        if (2 * kl[idx] + ku[idx] + 1 > *ldab_max) { *ldab_max = 2 * kl[idx] + ku[idx] + 1; }
     }
 }
 

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -756,6 +756,7 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
         return (int)info;
     }
 
+    // find size of the buffer
     npy_intp *kls = &ks[0];
     npy_intp *kus = &ks[outer_size];
 
@@ -822,19 +823,8 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     // Main loop traversal, taken from `_solve`
     // -------------------------------------------------------------------
     for (npy_intp idx = 0; idx < outer_size; idx++) {
-
-        npy_intp offset_ab = 0;
-        npy_intp offset_b = 0;
-        npy_intp temp_idx = idx; // Due to broadcasting identical for all involved slices
-        for (int i = ndim - 3; i >= 0; i--) {
-            offset_ab += (temp_idx % shape[i]) * strides[i];
-            offset_b += (temp_idx % shape_b[i]) * strides_b[i];
-
-            temp_idx /= shape[i];
-        }
-
-        T* slice_ptr_ab = (T *)(ab_data + (offset_ab / sizeof(T)));
-        T* slice_ptr_b = (T *)(bm_data + (offset_b / sizeof(T)));
+        T *slice_ptr_ab = compute_slice_ptr(idx, ab_data, ndim, shape, strides);
+        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
 
         CBLAS_INT ldab = 2 * kls[idx] + kus[idx] + 1;
 

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -774,8 +774,10 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     // -------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs;
 
-    // Data storage
-    T *buffer = (T *)malloc((n * nrhs + 3 * n + ldab_max * n) * sizeof(T));
+    // Temporary buffer. `overwrite_b` is only enabled when `b` has F-ordered slices.
+    // Therefore, it is possible to use `b` directly instead of requiring a buffer.
+    CBLAS_INT b_data_size = overwrite_b ? 0 : n * nrhs;
+    T *buffer = (T *)malloc((b_data_size + 3 * n + ldab_max * n) * sizeof(T));
 
     if (buffer == NULL) {
         free(ks);
@@ -783,9 +785,9 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
         return (int)info;
     }
 
-    T* b_data = &buffer[0];
-    T* work = &buffer[n * nrhs];
-    T* ab = &buffer[n * nrhs + 3 * n];
+    T* ab = &buffer[0];
+    T* work = &buffer[ldab_max * n];
+    T* b_data = &buffer[ldab_max * n + 3 * n];
 
     // Work and pivots
     CBLAS_INT *ipiv = (CBLAS_INT *)malloc(intn * sizeof(CBLAS_INT));
@@ -816,13 +818,18 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     // -------------------------------------------------------------------
     for (npy_intp idx = 0; idx < outer_size; idx++) {
         T *slice_ptr_ab = compute_slice_ptr(idx, ab_data, ndim, shape, strides);
-        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
-
         CBLAS_INT ldab = 2 * kls[idx] + kus[idx] + 1;
-
-        // Use the "one pass copy" strategy.
         copy_banded(slice_ptr_ab, shape[ndim-2], shape[ndim-1], kls[idx], kus[idx], ldab, ab, strides[ndim-2], strides[ndim-1]);
-        copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+
+        // `overwrite_b` is only enabled when `b` is 2D and F-contiguous. Therefore, it is possible
+        // use the data of the array directly instead of having to transfer to a buffer. Similarly,
+        // the result then also does not have to be copied.
+        if (overwrite_b) {
+            b_data = bm_data;
+        } else {
+            T* slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
+            copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+        }
 
         init_status(slice_status, idx, St::BANDED);
         solve_slice_banded(trans, intn, int_nrhs, ab, ipiv, b_data, work, irwork, kls[idx], kus[idx], slice_status);
@@ -834,7 +841,9 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
             vec_status.push_back(slice_status);
         }
 
-        copy_slice_F_to_C(&ret_data[idx * n * nrhs], b_data, n, nrhs);
+        if (!overwrite_b) {
+            copy_slice_F_to_C(&ret_data[idx * n * nrhs], b_data, n, nrhs);
+        }
     }
 
 free_exit_banded:

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -488,7 +488,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     CBLAS_INT buf_size_a = overwrite_a ? 0 : n*n;
     CBLAS_INT buf_size_b = overwrite_b ? 0 : n*nrhs;
     CBLAS_INT buf_size_trcon = 2*n; // // 2*n for tridiag trcon
-    CBLAS_INT buf_size = 2*buf_size_a + buf_size_b + buf_size_trcon + lwork; 
+    CBLAS_INT buf_size = 2*buf_size_a + buf_size_b + buf_size_trcon + lwork;
 
     T* buffer = (T *)malloc(buf_size*sizeof(T));
     if (NULL == buffer) { info = -101; return (int)info; }
@@ -710,5 +710,158 @@ free_exit:
     return 1;
 }
 
+
+template<typename T>
+int
+_solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObject *ap_kls, PyArrayObject *ap_kus, int overwrite_ab, int overwrite_b, SliceStatusVec vec_status)
+{
+    using real_type = typename detail::type_traits<T>::real_type;
+
+    char trans = 'N'; // `solve_banded` does not offer transposing.
+    SliceStatus slice_status;
+    npy_intp ldab_max = 0; // Maximal size required for LAPACK call format of `ab`
+    CBLAS_INT info;
+
+
+    // -------------------------------------------------------------------
+    // Input array attributes
+    // -------------------------------------------------------------------
+    T *ab_data = (T *)PyArray_DATA(ap_Ab);
+    int ndim = PyArray_NDIM(ap_Ab);
+    npy_intp *shape = PyArray_SHAPE(ap_Ab);
+    npy_intp n = shape[ndim - 1];
+    npy_intp *strides = PyArray_STRIDES(ap_Ab);
+
+    // Number of slices to traverse
+    npy_intp outer_size = 1;
+    if (ndim > 2) {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i]; }
+    }
+
+    T *bm_data = (T *)PyArray_DATA(ap_b);
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+    npy_intp *strides_b = PyArray_STRIDES(ap_b);
+    npy_intp nrhs = PyArray_DIM(ap_b, ndim_b - 1);
+
+    int16_t *kls_data = (int16_t *)PyArray_DATA(ap_kls);
+    int16_t *kus_data = (int16_t *)PyArray_DATA(ap_kus);
+    npy_intp *shape_kls = PyArray_SHAPE(ap_kls); // identical => only track one
+    npy_intp *strides_kls = PyArray_STRIDES(ap_kls);
+
+    // Find the maximum number of bands to use for allocation of buffer
+    npy_intp *ks = (npy_intp *)malloc(2 * outer_size * sizeof(npy_intp));
+    if (ks == NULL) {
+        info = -102;
+        return (int)info;
+    }
+
+    npy_intp *kls = &ks[0];
+    npy_intp *kus = &ks[outer_size];
+
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+        npy_intp offset = 0;
+        npy_intp temp_idx = idx;
+
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset += (temp_idx % shape_kls[i]) * strides_kls[i];
+            temp_idx /= shape_kls[i];
+        }
+
+        kls[idx] = (npy_intp)kls_data[offset / sizeof(int16_t)];
+        kus[idx] = (npy_intp)kus_data[offset / sizeof(int16_t)];
+
+        if (2 * kls[idx] + kus[idx] + 1 > ldab_max) {
+            ldab_max = 2 * kls[idx] + kus[idx] + 1;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Workspace computation and allocation
+    // -------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs;
+
+    // Data storage
+    T *buffer = (T *)malloc((n * nrhs + 3 * n + ldab_max * n) * sizeof(T));
+
+    if (buffer == NULL) {
+        free(ks);
+        info = -102;
+        return (int)info;
+    }
+
+    T* b_data = &buffer[0];
+    T* work = &buffer[n * nrhs];
+    T* ab = &buffer[n * nrhs + 3 * n];
+
+    // Work and pivots
+    CBLAS_INT *ipiv = (CBLAS_INT *)malloc(intn * sizeof(CBLAS_INT));
+    if (ipiv == NULL) {
+        free(ks);
+        free(buffer);
+        info = -102;
+        return int(info);
+    }
+
+    void *irwork;
+    if constexpr (detail::type_traits<T>::is_complex) {
+        irwork = malloc(intn * sizeof(real_type));
+    } else {
+        irwork = malloc(intn * sizeof(CBLAS_INT));
+    }
+
+    if (irwork == NULL) {
+        free(ks);
+        free(buffer);
+        free(ipiv);
+        info = -102;
+        return int(info);
+    }
+
+    // -------------------------------------------------------------------
+    // Main loop traversal, taken from `_solve`
+    // -------------------------------------------------------------------
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+
+        npy_intp offset_ab = 0;
+        npy_intp offset_b = 0;
+        npy_intp temp_idx = idx; // Due to broadcasting identical for all involved slices
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset_ab += (temp_idx % shape[i]) * strides[i];
+            offset_b += (temp_idx % shape_b[i]) * strides_b[i];
+
+            temp_idx /= shape[i];
+        }
+
+        T* slice_ptr_ab = (T *)(ab_data + (offset_ab / sizeof(T)));
+        T* slice_ptr_b = (T *)(bm_data + (offset_b / sizeof(T)));
+
+        CBLAS_INT ldab = 2 * kls[idx] + kus[idx] + 1;
+
+        // Use the "one pass copy" strategy.
+        copy_banded(slice_ptr_ab, shape[ndim-2], shape[ndim-1], kls[idx], kus[idx], ldab, ab, strides[ndim-2], strides[ndim-1]);
+        copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+
+        init_status(slice_status, idx, St::BANDED);
+        solve_slice_banded(trans, intn, int_nrhs, ab, ipiv, b_data, work, irwork, kls[idx], kus[idx], slice_status);
+
+        if ((slice_status.lapack_info < 0) || (slice_status.is_singular)) {
+            vec_status.push_back(slice_status);
+            goto free_exit_banded;
+        } else if (slice_status.is_ill_conditioned) {
+            vec_status.push_back(slice_status);
+        }
+
+        copy_slice_F_to_C(&ret_data[idx * n * nrhs], b_data, n, nrhs);
+    }
+
+free_exit_banded:
+    free(ks);
+    free(ipiv);
+    free(irwork);
+    free(buffer);
+
+    return 1;
+}
 
 } // namespace sp_linalg

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -744,9 +744,10 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     npy_intp *strides_b = PyArray_STRIDES(ap_b);
     npy_intp nrhs = PyArray_DIM(ap_b, ndim_b - 1);
 
-    int16_t *kls_data = (int16_t *)PyArray_DATA(ap_kls);
-    int16_t *kus_data = (int16_t *)PyArray_DATA(ap_kus);
-    npy_intp *shape_kls = PyArray_SHAPE(ap_kls); // identical => only track one
+    // The invariant is that `kl` + `ku` + 1 == `ldab` => only track one
+    // Assume that this is checked on the python side.
+    CBLAS_INT *kls_data = (CBLAS_INT *)PyArray_DATA(ap_kls);
+    npy_intp *shape_kls = PyArray_SHAPE(ap_kls);
     npy_intp *strides_kls = PyArray_STRIDES(ap_kls);
 
     // Find the maximum number of bands to use for allocation of buffer
@@ -756,21 +757,14 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
         return (int)info;
     }
 
-    // find size of the buffer
+    // find size of the buffer by determining the required leading dimension
     npy_intp *kls = &ks[0];
     npy_intp *kus = &ks[outer_size];
 
     for (npy_intp idx = 0; idx < outer_size; idx++) {
-        npy_intp offset = 0;
-        npy_intp temp_idx = idx;
-
-        for (int i = ndim - 3; i >= 0; i--) {
-            offset += (temp_idx % shape_kls[i]) * strides_kls[i];
-            temp_idx /= shape_kls[i];
-        }
-
-        kls[idx] = (npy_intp)kls_data[offset / sizeof(int16_t)];
-        kus[idx] = (npy_intp)kus_data[offset / sizeof(int16_t)];
+        CBLAS_INT *idx_kl = compute_slice_ptr(idx, kls_data, ndim, shape_kls, strides_kls);
+        kls[idx] = (npy_intp)*idx_kl;
+        kus[idx] = shape[ndim-2] - kls[idx] - 1;
 
         if (2 * kls[idx] + kus[idx] + 1 > ldab_max) {
             ldab_max = 2 * kls[idx] + kus[idx] + 1;

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -776,8 +776,10 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     // -------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs;
 
-    // Data storage
-    T *buffer = (T *)malloc((n * nrhs + 3 * n + ldab_max * n) * sizeof(T));
+    // Temporary buffer. `overwrite_b` is only enabled when `b` has F-ordered slices.
+    // Therefore, it is possible to use `b` directly instead of requiring a buffer.
+    CBLAS_INT b_data_size = overwrite_b ? 0 : n * nrhs;
+    T *buffer = (T *)malloc((b_data_size + 3 * n + ldab_max * n) * sizeof(T));
 
     if (buffer == NULL) {
         free(ks);
@@ -785,9 +787,9 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
         return (int)info;
     }
 
-    T* b_data = &buffer[0];
-    T* work = &buffer[n * nrhs];
-    T* ab = &buffer[n * nrhs + 3 * n];
+    T* ab = &buffer[0];
+    T* work = &buffer[ldab_max * n];
+    T* b_data = &buffer[ldab_max * n + 3 * n];
 
     // Work and pivots
     CBLAS_INT *ipiv = (CBLAS_INT *)malloc(intn * sizeof(CBLAS_INT));
@@ -818,13 +820,18 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     // -------------------------------------------------------------------
     for (npy_intp idx = 0; idx < outer_size; idx++) {
         T *slice_ptr_ab = compute_slice_ptr(idx, ab_data, ndim, shape, strides);
-        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
-
         CBLAS_INT ldab = 2 * kls[idx] + kus[idx] + 1;
-
-        // Use the "one pass copy" strategy.
         copy_banded(slice_ptr_ab, shape[ndim-2], shape[ndim-1], kls[idx], kus[idx], ldab, ab, strides[ndim-2], strides[ndim-1]);
-        copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+
+        // `overwrite_b` is only enabled when `b` is 2D and F-contiguous. Therefore, it is possible
+        // use the data of the array directly instead of having to transfer to a buffer. Similarly,
+        // the result then also does not have to be copied.
+        if (overwrite_b) {
+            b_data = bm_data;
+        } else {
+            T* slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
+            copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+        }
 
         init_status(slice_status, idx, St::BANDED);
         solve_slice_banded(trans, intn, int_nrhs, ab, ipiv, b_data, work, irwork, kls[idx], kus[idx], slice_status);
@@ -836,7 +843,9 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
             vec_status.push_back(slice_status);
         }
 
-        copy_slice_F_to_C(&ret_data[idx * n * nrhs], b_data, n, nrhs);
+        if (!overwrite_b) {
+            copy_slice_F_to_C(&ret_data[idx * n * nrhs], b_data, n, nrhs);
+        }
     }
 
 free_exit_banded:

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -742,9 +742,10 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     npy_intp *strides_b = PyArray_STRIDES(ap_b);
     npy_intp nrhs = PyArray_DIM(ap_b, ndim_b - 1);
 
-    int16_t *kls_data = (int16_t *)PyArray_DATA(ap_kls);
-    int16_t *kus_data = (int16_t *)PyArray_DATA(ap_kus);
-    npy_intp *shape_kls = PyArray_SHAPE(ap_kls); // identical => only track one
+    // The invariant is that `kl` + `ku` + 1 == `ldab` => only track one
+    // Assume that this is checked on the python side.
+    CBLAS_INT *kls_data = (CBLAS_INT *)PyArray_DATA(ap_kls);
+    npy_intp *shape_kls = PyArray_SHAPE(ap_kls);
     npy_intp *strides_kls = PyArray_STRIDES(ap_kls);
 
     // Find the maximum number of bands to use for allocation of buffer
@@ -754,21 +755,14 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
         return (int)info;
     }
 
-    // find size of the buffer
+    // find size of the buffer by determining the required leading dimension
     npy_intp *kls = &ks[0];
     npy_intp *kus = &ks[outer_size];
 
     for (npy_intp idx = 0; idx < outer_size; idx++) {
-        npy_intp offset = 0;
-        npy_intp temp_idx = idx;
-
-        for (int i = ndim - 3; i >= 0; i--) {
-            offset += (temp_idx % shape_kls[i]) * strides_kls[i];
-            temp_idx /= shape_kls[i];
-        }
-
-        kls[idx] = (npy_intp)kls_data[offset / sizeof(int16_t)];
-        kus[idx] = (npy_intp)kus_data[offset / sizeof(int16_t)];
+        CBLAS_INT *idx_kl = compute_slice_ptr(idx, kls_data, ndim, shape_kls, strides_kls);
+        kls[idx] = (npy_intp)*idx_kl;
+        kus[idx] = shape[ndim-2] - kls[idx] - 1;
 
         if (2 * kls[idx] + kus[idx] + 1 > ldab_max) {
             ldab_max = 2 * kls[idx] + kus[idx] + 1;

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -774,8 +774,20 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     // -------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs;
 
-    // Temporary buffer. `overwrite_b` is only enabled when `b` has F-ordered slices.
-    // Therefore, it is possible to use `b` directly instead of requiring a buffer.
+    /*
+     * Chop the buffer up into parts:
+     *   ldab_max * n    3 * n     b_data_size
+     * |--------------|----------|--------------|
+     * ^              ^          ^
+     * ab             work       b_data
+     *
+     * - `ab` is for the "padded" banded storage buffer
+     * - `work` is the temporary work buffer for `gbcon`, size = 3 * n
+     * - `b_data` is a buffer for `b`, if `overwrite_b` is enabled no need for the buffer (size = 0)
+     *
+     * NB. `overwrite_ab` can not trivially be enabled since the array always has to be
+     * "padded" with a set of zeros, meaning the buffer should be larger than the input array.
+     */
     CBLAS_INT b_data_size = overwrite_b ? 0 : n * nrhs;
     T *buffer = (T *)malloc((b_data_size + 3 * n + ldab_max * n) * sizeof(T));
 
@@ -787,7 +799,13 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
 
     T* ab = &buffer[0];
     T* work = &buffer[ldab_max * n];
-    T* b_data = &buffer[ldab_max * n + 3 * n];
+
+    T *b_data = NULL;
+    if (!overwrite_b) {
+        b_data = &buffer[ldab_max * n + 3 * n];
+    } else {
+        b_data = bm_data;
+    }
 
     // Work and pivots
     CBLAS_INT *ipiv = (CBLAS_INT *)malloc(intn * sizeof(CBLAS_INT));
@@ -824,9 +842,7 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
         // `overwrite_b` is only enabled when `b` is 2D and F-contiguous. Therefore, it is possible
         // use the data of the array directly instead of having to transfer to a buffer. Similarly,
         // the result then also does not have to be copied.
-        if (overwrite_b) {
-            b_data = bm_data;
-        } else {
+        if (!overwrite_b) {
             T* slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
             copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
         }

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -754,6 +754,7 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
         return (int)info;
     }
 
+    // find size of the buffer
     npy_intp *kls = &ks[0];
     npy_intp *kus = &ks[outer_size];
 
@@ -820,19 +821,8 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     // Main loop traversal, taken from `_solve`
     // -------------------------------------------------------------------
     for (npy_intp idx = 0; idx < outer_size; idx++) {
-
-        npy_intp offset_ab = 0;
-        npy_intp offset_b = 0;
-        npy_intp temp_idx = idx; // Due to broadcasting identical for all involved slices
-        for (int i = ndim - 3; i >= 0; i--) {
-            offset_ab += (temp_idx % shape[i]) * strides[i];
-            offset_b += (temp_idx % shape_b[i]) * strides_b[i];
-
-            temp_idx /= shape[i];
-        }
-
-        T* slice_ptr_ab = (T *)(ab_data + (offset_ab / sizeof(T)));
-        T* slice_ptr_b = (T *)(bm_data + (offset_b / sizeof(T)));
+        T *slice_ptr_ab = compute_slice_ptr(idx, ab_data, ndim, shape, strides);
+        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
 
         CBLAS_INT ldab = 2 * kls[idx] + kus[idx] + 1;
 

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -707,3 +707,157 @@ free_exit:
     free(ipiv);
     return 1;
 }
+
+
+template<typename T>
+int
+_solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObject *ap_kls, PyArrayObject *ap_kus, int overwrite_ab, int overwrite_b, SliceStatusVec vec_status)
+{
+    using real_type = typename type_traits<T>::real_type;
+
+    char trans = 'N'; // `solve_banded` does not offer transposing.
+    SliceStatus slice_status;
+    npy_intp ldab_max = 0; // Maximal size required for LAPACK call format of `ab`
+    CBLAS_INT info;
+
+
+    // -------------------------------------------------------------------
+    // Input array attributes
+    // -------------------------------------------------------------------
+    T *ab_data = (T *)PyArray_DATA(ap_Ab);
+    int ndim = PyArray_NDIM(ap_Ab);
+    npy_intp *shape = PyArray_SHAPE(ap_Ab);
+    npy_intp n = shape[ndim - 1];
+    npy_intp *strides = PyArray_STRIDES(ap_Ab);
+
+    // Number of slices to traverse
+    npy_intp outer_size = 1;
+    if (ndim > 2) {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i]; }
+    }
+
+    T *bm_data = (T *)PyArray_DATA(ap_b);
+    npy_intp ndim_b = PyArray_NDIM(ap_b);
+    npy_intp *shape_b = PyArray_SHAPE(ap_b);
+    npy_intp *strides_b = PyArray_STRIDES(ap_b);
+    npy_intp nrhs = PyArray_DIM(ap_b, ndim_b - 1);
+
+    int16_t *kls_data = (int16_t *)PyArray_DATA(ap_kls);
+    int16_t *kus_data = (int16_t *)PyArray_DATA(ap_kus);
+    npy_intp *shape_kls = PyArray_SHAPE(ap_kls); // identical => only track one
+    npy_intp *strides_kls = PyArray_STRIDES(ap_kls);
+
+    // Find the maximum number of bands to use for allocation of buffer
+    npy_intp *ks = (npy_intp *)malloc(2 * outer_size * sizeof(npy_intp));
+    if (ks == NULL) {
+        info = -102;
+        return (int)info;
+    }
+
+    npy_intp *kls = &ks[0];
+    npy_intp *kus = &ks[outer_size];
+
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+        npy_intp offset = 0;
+        npy_intp temp_idx = idx;
+
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset += (temp_idx % shape_kls[i]) * strides_kls[i];
+            temp_idx /= shape_kls[i];
+        }
+
+        kls[idx] = (npy_intp)kls_data[offset / sizeof(int16_t)];
+        kus[idx] = (npy_intp)kus_data[offset / sizeof(int16_t)];
+
+        if (2 * kls[idx] + kus[idx] + 1 > ldab_max) {
+            ldab_max = 2 * kls[idx] + kus[idx] + 1;
+        }
+    }
+
+    // -------------------------------------------------------------------
+    // Workspace computation and allocation
+    // -------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs;
+
+    // Data storage
+    T *buffer = (T *)malloc((n * nrhs + 3 * n + ldab_max * n) * sizeof(T));
+
+    if (buffer == NULL) {
+        free(ks);
+        info = -102;
+        return (int)info;
+    }
+
+    T* b_data = &buffer[0];
+    T* work = &buffer[n * nrhs];
+    T* ab = &buffer[n * nrhs + 3 * n];
+
+    // Work and pivots
+    CBLAS_INT *ipiv = (CBLAS_INT *)malloc(intn * sizeof(CBLAS_INT));
+    if (ipiv == NULL) {
+        free(ks);
+        free(buffer);
+        info = -102;
+        return int(info);
+    }
+
+    void *irwork;
+    if (type_traits<T>::is_complex) {
+        irwork = malloc(intn * sizeof(real_type));
+    } else {
+        irwork = malloc(intn * sizeof(CBLAS_INT));
+    }
+
+    if (irwork == NULL) {
+        free(ks);
+        free(buffer);
+        free(ipiv);
+        info = -102;
+        return int(info);
+    }
+
+    // -------------------------------------------------------------------
+    // Main loop traversal, taken from `_solve`
+    // -------------------------------------------------------------------
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+
+        npy_intp offset_ab = 0;
+        npy_intp offset_b = 0;
+        npy_intp temp_idx = idx; // Due to broadcasting identical for all involved slices
+        for (int i = ndim - 3; i >= 0; i--) {
+            offset_ab += (temp_idx % shape[i]) * strides[i];
+            offset_b += (temp_idx % shape_b[i]) * strides_b[i];
+
+            temp_idx /= shape[i];
+        }
+
+        T* slice_ptr_ab = (T *)(ab_data + (offset_ab / sizeof(T)));
+        T* slice_ptr_b = (T *)(bm_data + (offset_b / sizeof(T)));
+
+        CBLAS_INT ldab = 2 * kls[idx] + kus[idx] + 1;
+
+        // Use the "one pass copy" strategy.
+        copy_banded(slice_ptr_ab, shape[ndim-2], shape[ndim-1], kls[idx], kus[idx], ldab, ab, strides[ndim-2], strides[ndim-1]);
+        copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+
+        init_status(slice_status, idx, St::BANDED);
+        solve_slice_banded(trans, intn, int_nrhs, ab, ipiv, b_data, work, irwork, kls[idx], kus[idx], slice_status);
+
+        if ((slice_status.lapack_info < 0) || (slice_status.is_singular)) {
+            vec_status.push_back(slice_status);
+            goto free_exit_banded;
+        } else if (slice_status.is_ill_conditioned) {
+            vec_status.push_back(slice_status);
+        }
+
+        copy_slice_F_to_C(&ret_data[idx * n * nrhs], b_data, n, nrhs);
+    }
+
+free_exit_banded:
+    free(ks);
+    free(ipiv);
+    free(irwork);
+    free(buffer);
+
+    return 1;
+}

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -486,7 +486,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     CBLAS_INT buf_size_a = overwrite_a ? 0 : n*n;
     CBLAS_INT buf_size_b = overwrite_b ? 0 : n*nrhs;
     CBLAS_INT buf_size_trcon = 2*n; // // 2*n for tridiag trcon
-    CBLAS_INT buf_size = 2*buf_size_a + buf_size_b + buf_size_trcon + lwork; 
+    CBLAS_INT buf_size = 2*buf_size_a + buf_size_b + buf_size_trcon + lwork;
 
     T* buffer = (T *)malloc(buf_size*sizeof(T));
     if (NULL == buffer) { info = -101; return (int)info; }

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -776,8 +776,20 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
     // -------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs;
 
-    // Temporary buffer. `overwrite_b` is only enabled when `b` has F-ordered slices.
-    // Therefore, it is possible to use `b` directly instead of requiring a buffer.
+    /*
+     * Chop the buffer up into parts:
+     *   ldab_max * n    3 * n     b_data_size
+     * |--------------|----------|--------------|
+     * ^              ^          ^
+     * ab             work       b_data
+     *
+     * - `ab` is for the "padded" banded storage buffer
+     * - `work` is the temporary work buffer for `gbcon`, size = 3 * n
+     * - `b_data` is a buffer for `b`, if `overwrite_b` is enabled no need for the buffer (size = 0)
+     *
+     * NB. `overwrite_ab` can not trivially be enabled since the array always has to be
+     * "padded" with a set of zeros, meaning the buffer should be larger than the input array.
+     */
     CBLAS_INT b_data_size = overwrite_b ? 0 : n * nrhs;
     T *buffer = (T *)malloc((b_data_size + 3 * n + ldab_max * n) * sizeof(T));
 
@@ -789,7 +801,13 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
 
     T* ab = &buffer[0];
     T* work = &buffer[ldab_max * n];
-    T* b_data = &buffer[ldab_max * n + 3 * n];
+
+    T *b_data = NULL;
+    if (!overwrite_b) {
+        b_data = &buffer[ldab_max * n + 3 * n];
+    } else {
+        b_data = bm_data;
+    }
 
     // Work and pivots
     CBLAS_INT *ipiv = (CBLAS_INT *)malloc(intn * sizeof(CBLAS_INT));
@@ -826,9 +844,7 @@ _solve_banded(PyArrayObject *ap_Ab, PyArrayObject *ap_b, T *ret_data, PyArrayObj
         // `overwrite_b` is only enabled when `b` is 2D and F-contiguous. Therefore, it is possible
         // use the data of the array directly instead of having to transfer to a buffer. Similarly,
         // the result then also does not have to be copied.
-        if (overwrite_b) {
-            b_data = bm_data;
-        } else {
+        if (!overwrite_b) {
             T* slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
             copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
         }

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -250,6 +250,41 @@ class TestSolveBanded:
         assert x.shape == shape_b
         assert_allclose(a @ x, b, atol=atol)
 
+    @parametrize_overwrite_b_arg
+    @pytest.mark.parametrize("order_b", ["C", "F"])
+    @pytest.mark.parametrize("dtype_b", [int, float])
+    @pytest.mark.parametrize("nrhs", [1, 2])
+    def test_overwrite(self, nrhs, dtype_b, order_b, overwrite_b_kw):
+        rng = np.random.default_rng(seed=12345)
+        n = 10
+        l, u = 2, 1
+
+        a = rng.normal(size=(n, n))
+        a = np.triu(a, k=-l)
+        a = np.tril(a, k=u)
+        ab = np.zeros((l + u + 1, n))
+        ab[u, :] = np.diag(a)
+        for i in range(l):
+            ab[u+i+1, :-i-1] = np.diag(a, k=-i-1)
+        for i in range(u):
+            ab[u-i-1, i+1:] = np.diag(a, k=i+1)
+
+        b = rng.normal(size=(n, nrhs))
+        b = b.astype(dtype_b, order=order_b)
+
+        b_ref = b.copy()
+
+        # Check if the solution itself is correct
+        x = solve_banded((l, u), ab, b, **overwrite_b_kw)
+        assert_allclose(a @ x, b_ref, atol=1e-12)
+
+        # Validate in-place operation
+        overwrite_b = overwrite_b_kw.get("overwrite_b", False)
+        b_inplace = overwrite_b and (b.dtype != int) and b.flags["F_CONTIGUOUS"]
+
+        assert np.shares_memory(x, b) == b_inplace
+        assert np.all(b == b_ref) != b_inplace
+
 
 class TestSolveHBanded:
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -216,6 +216,40 @@ class TestSolveBanded:
         assert x.shape == (0, 0)
         assert x.dtype == solve(np.eye(1, dtype=dt_ab), np.ones(1, dtype=dt_b)).dtype
 
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64,
+                                       np.complex64, np.complex128])
+    @pytest.mark.parametrize("nrhs", [(), (1,), (5,)])
+    @pytest.mark.parametrize("n", [5, 10])
+    @pytest.mark.parametrize("l_and_u", [(1, 1), (0, 2), (2, 0), (3, 4), (4, 3)])
+    def test_shape_dtype(self, l_and_u, n, nrhs, dtype):
+        rng = np.random.default_rng(seed=12345)
+        shape_b = (n,) + nrhs
+
+        if np.issubdtype(dtype, np.complexfloating):
+            a = rng.normal(size=(n, n)) + 1j * rng.normal(size=(n, n))
+        else:
+            a = rng.normal(size=(n, n))
+        a = a.astype(dtype)
+
+        b = rng.normal(size=shape_b).astype(dtype)
+
+        l, u = l_and_u
+        a = np.triu(a, k=-l)
+        a = np.tril(a, k=u)
+        ab = np.zeros((l + u + 1, n), dtype=a.dtype)
+        ab[u, :] = np.diag(a)
+        for i in range(l):
+            ab[u+i+1, :-i-1] = np.diag(a, k=-i-1)
+        for i in range(u):
+            ab[u-i-1, i+1:] = np.diag(a, k=i+1)
+
+        x = solve_banded(l_and_u, ab, b)
+
+        atol = 1e-4 if dtype in (np.float32, np.complex64) else 1e-12
+        assert x.dtype == a.dtype
+        assert x.shape == shape_b
+        assert_allclose(a @ x, b, atol=atol)
+
 
 class TestSolveHBanded:
 


### PR DESCRIPTION
#### Reference issue
This PR continues the work of #23774 by moving the batching loop for `solve_banded()` into C/C++, similar to what is done in #24123 (which this PR is also branched from). Additionally, a benchmark has been added to assess the performance gains, the results of which can be found below the fold (note that it is compared to `solve(..., assume_a="banded")`  and this is also affected compared to main as this branch is based on the PR that lowers the implementation for that). ~~Remarkably, it seems like there is quite a significant performance regression for non-deep stacks of matrices.~~ (EDIT: this is probably a consequence of the fact that the implementation also computes the condition number, just like the `solve` function, which used to be not the case.) This might require further investigation.

<details>
<summary> Benchmark results </summary>

- on main:
  ```
              =============== ========= ============== =============
              --                                  function
              ------------------------- ----------------------------
                   shape       l_and_u   solve_banded      solve
              =============== ========= ============== =============
               (100, 10, 10)    (0, 0)     552±5μs      3.02±0.04ms
               (100, 10, 10)    (5, 0)     657±30μs      3.34±0.3ms
               (100, 10, 10)    (0, 5)     576±20μs     3.20±0.03ms
               (100, 10, 10)    (5, 5)     684±20μs      3.26±0.2ms
               (100, 20, 20)    (0, 0)     542±4μs       5.18±0.1ms
               (100, 20, 20)    (5, 0)     801±40μs     5.11±0.05ms
               (100, 20, 20)    (0, 5)     580±7μs      5.37±0.09ms
               (100, 20, 20)    (5, 5)     832±8μs       5.49±0.1ms
                 (100, 100)     (0, 0)    11.1±0.1μs      263±5μs
                 (100, 100)     (5, 0)    19.7±0.4μs      270±5μs
                 (100, 100)     (0, 5)    12.3±0.5μs      273±3μs
                 (100, 100)     (5, 5)    22.3±0.4μs      266±4μs
              =============== ========= ============== =============
  ```

- after this PR
  ```
             =============== ========= ============== ==========
             --                                 function
             ------------------------- -------------------------
                  shape       l_and_u   solve_banded    solve
             =============== ========= ============== ==========
              (100, 10, 10)    (0, 0)     85.9±1μs     251±10μs
              (100, 10, 10)    (5, 0)     231±10μs     258±5μs
              (100, 10, 10)    (0, 5)     132±5μs      247±3μs
              (100, 10, 10)    (5, 5)     257±4μs      247±4μs
              (100, 20, 20)    (0, 0)     104±3μs      595±20μs
              (100, 20, 20)    (5, 0)     455±6μs      601±10μs
              (100, 20, 20)    (0, 5)     198±3μs      599±8μs
              (100, 20, 20)    (5, 5)     476±6μs      588±20μs
                (100, 100)     (0, 0)     17.2±1μs     81.9±4μs
                (100, 100)     (5, 0)    31.2±0.8μs    82.9±1μs
                (100, 100)     (0, 5)    21.7±0.5μs    86.2±4μs
                (100, 100)     (5, 5)     38.1±2μs     81.0±2μs
             =============== ========= ============== ==========
  ```

- Comparison:

```
| Change   | Before [606e0dac] <main>   | After [e9ad0d0f] <solve_banded_speedup>   |   Ratio | Benchmark (Parameter)                                                                   |
|----------|----------------------------|-------------------------------------------|---------|-----------------------------------------------------------------------------------------|
| +        | 12.3±0.5μs                 | 21.7±0.5μs                                |    1.76 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 100), (0, 5), 'solve_banded')    |
| +        | 22.3±0.4μs                 | 38.1±2μs                                  |    1.71 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 100), (5, 5), 'solve_banded')    |
| +        | 19.7±0.4μs                 | 31.2±0.8μs                                |    1.58 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 100), (5, 0), 'solve_banded')    |
| +        | 11.1±0.1μs                 | 17.2±1μs                                  |    1.55 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 100), (0, 0), 'solve_banded')    |
| -        | 801±40μs                   | 455±6μs                                   |    0.57 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 20, 20), (5, 0), 'solve_banded') |
| -        | 832±8μs                    | 476±6μs                                   |    0.57 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 20, 20), (5, 5), 'solve_banded') |
| -        | 684±20μs                   | 257±4μs                                   |    0.38 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 10, 10), (5, 5), 'solve_banded') |
| -        | 657±30μs                   | 231±10μs                                  |    0.35 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 10, 10), (5, 0), 'solve_banded') |
| -        | 580±7μs                    | 198±3μs                                   |    0.34 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 20, 20), (0, 5), 'solve_banded') |
| -        | 273±3μs                    | 86.2±4μs                                  |    0.32 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 100), (0, 5), 'solve')           |
| -        | 263±5μs                    | 81.9±4μs                                  |    0.31 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 100), (0, 0), 'solve')           |
| -        | 270±5μs                    | 82.9±1μs                                  |    0.31 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 100), (5, 0), 'solve')           |
| -        | 266±4μs                    | 81.0±2μs                                  |    0.3  | linalg.BatchedSolveBandedBench.time_solve_banded((100, 100), (5, 5), 'solve')           |
| -        | 576±20μs                   | 132±5μs                                   |    0.23 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 10, 10), (0, 5), 'solve_banded') |
| -        | 542±4μs                    | 104±3μs                                   |    0.19 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 20, 20), (0, 0), 'solve_banded') |
| -        | 552±5μs                    | 85.9±1μs                                  |    0.16 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 10, 10), (0, 0), 'solve_banded') |
| -        | 5.11±0.05ms                | 601±10μs                                  |    0.12 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 20, 20), (5, 0), 'solve')        |
| -        | 5.18±0.1ms                 | 595±20μs                                  |    0.11 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 20, 20), (0, 0), 'solve')        |
| -        | 5.37±0.09ms                | 599±8μs                                   |    0.11 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 20, 20), (0, 5), 'solve')        |
| -        | 5.49±0.1ms                 | 588±20μs                                  |    0.11 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 20, 20), (5, 5), 'solve')        |
| -        | 3.02±0.04ms                | 251±10μs                                  |    0.08 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 10, 10), (0, 0), 'solve')        |
| -        | 3.20±0.03ms                | 247±3μs                                   |    0.08 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 10, 10), (0, 5), 'solve')        |
| -        | 3.34±0.3ms                 | 258±5μs                                   |    0.08 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 10, 10), (5, 0), 'solve')        |
| -        | 3.26±0.2ms                 | 247±4μs                                   |    0.08 | linalg.BatchedSolveBandedBench.time_solve_banded((100, 10, 10), (5, 5), 'solve')        |
```

 
</details>


#### Notes
- This function does all the looping, argument validation etc. on its own. However, once the slice has been transferred to the correct input for LAPACK using `copy_banded()`, there is no difference to the set of functions that has to be called from `solve(..., assume_a="banded")`. Therefore, the function that does the LAPACK calls are shared. (@ilayn had some opinions on this in #24123, hence adding him in CC. If needed we can always duplicate these function calls, but this shouldn't be all too controversial; it is literally only the LAPACK calls that lead to intertwining now. If this would have to be changed for one either of `solve` or `solve_banded`, it is 99% sure that the other one is affected too.) 
- Similarly, for simplicity the "single copy" strategy is used since some experiments in #24340 indicate that this is faster for the C++ side. If need be, this can always be changed.
- As of yet a check on the lower and upper banding is not yet performed (cfr. #23774), but this can easily be incorporated. The only question is where to best incorporate this and how to do this in a somewhat performant fashion.
- In 6b57a7f a fix was added to `solve` that prevented issues from happening when a scalar was passed in for `a` and it was zero. This was previously not present in this function, but it might be worth adding this into this function as well.
- Other validation should be fine, but having someone else take a glance at if all necessary validation is performed is always welcome; it might be that I missed something here.