### PR TITLE
MAINT: stats.PoissonDisk: fix "overlapping" sampling when using `l_bounds`

### DIFF
--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -2189,7 +2189,7 @@ class PoissonDisk(QMCEngine):
             `candidate` sample.
             """
             indices = ((candidate - self.l_bounds) / self.cell_size).astype(int)
-            ind_min = np.maximum(indices - n, self.l_bounds.astype(int))
+            ind_min = np.maximum(indices - n, 0)
             ind_max = np.minimum(indices + n + 1, self.grid_size)
 
             # Check if the center cell is empty


### PR DESCRIPTION
#### Reference issue
Closes gh-22819
gh-20767

#### What does this implement/fix?
Fixes gh-22819 per the suggestion in https://github.com/scipy/scipy/issues/22819#issuecomment-2799780956. Modifies `test_fill_space` so that it would have caught the bug. Adds another reasonable property-based test that would have caught the bug.

#### Additional information
Rather than computing *all* pairwise distances, this section of code is looking for potentially nearby ("in neighborhood") points only in adjacent pixels of a grid. `indices` identifies the pixel of the candidate point, and `ind_min`/`ind_max` identify the corners of a hypercube of pixels in which to look for nearby points. Just as the highest `ind_max` component can't be bigger than `grid_size`, the least `ind_min` component shouldn't be less than zero (According to Python indexing rules, a value less than zero would mean wrapping around to the opposite face of the hypercube, and we're not working in that sort of space.) This section of code should just be clipping indices to the valid range; the appearance of `self.l_bounds.astype(int)` here seems like a clear mistake.

