### PR TITLE
BUG:integrate:Fix a pointer dereference problem in DOPRI5

### DIFF
--- a/scipy/integrate/src/dop.c
+++ b/scipy/integrate/src/dop.c
@@ -760,7 +760,7 @@ dopri5(const int n, dopri_fcn* fcn, double *x, double* y, double *xend, double* 
         }
     }
     // -------- maximal step size
-    if (work[5] == 0.0) { hmax = xend - x; } else { hmax = work[5]; }
+    if (work[5] == 0.0) { hmax = *xend - *x; } else { hmax = work[5]; }
     // -------- initial step size
     h = work[6];
     // -------- when a fail has occurred, we return with wrong input error code


### PR DESCRIPTION
#### Reference issue
Closes #24403 

#### What does this implement/fix?
During the translation instead of the values, the pointer arithmetic is done leading to wrong results. I don't understand how this did not cause a compiler warning at all. 

