### PR TITLE
ENH: stats.rankdata: delegate to JAX

### DIFF
--- a/scipy/stats/_bws_test.py
+++ b/scipy/stats/_bws_test.py
@@ -83,8 +83,7 @@ def _bws_statistic(x, y, alternative, axis, xp):
 
 
 @xp_capabilities(skip_backends=[('cupy', 'no rankdata'),
-                                ('dask.array', 'no rankdata')],
-                 jax_jit=False)  # rankdata incompatible with JAX JIT
+                                ('dask.array', 'no rankdata')])
 def bws_test(x, y, *, alternative="two-sided", axis=0, method=None):
     r'''Perform the Baumgartner-Weiss-Schindler test on two independent samples.
 

--- a/scipy/stats/_correlation.py
+++ b/scipy/stats/_correlation.py
@@ -248,7 +248,6 @@ def chatterjeexi(x, y, *, axis=0, y_continuous=False, method='asymptotic'):
 
 @xp_capabilities(cpu_only=True, exceptions=['jax.numpy'],
     skip_backends=[('dask.array', 'not supported by rankdata (take_along_axis)')],
-    jax_jit=False  # rankdata not compatible with JAX JIT
 )
 @_axis_nan_policy_factory(SignificanceResult, paired=True, n_samples=2,
                           result_to_tuple=_unpack, n_outputs=2, too_small=1)

--- a/scipy/stats/_correlation.py
+++ b/scipy/stats/_correlation.py
@@ -88,8 +88,7 @@ def _unpack(res, _):
 
 
 @xp_capabilities(skip_backends=[('dask.array', 'no take_along_axis'),
-                                ('cupy', 'no rankdata (xp.repeats limitation)')],
-                 jax_jit=False)  # rankdata not compatible with JAX JIT
+                                ('cupy', 'no rankdata (xp.repeats limitation)')])
 @_axis_nan_policy_factory(SignificanceResult, paired=True, n_samples=2,
                           result_to_tuple=_unpack, n_outputs=2, too_small=1)
 def chatterjeexi(x, y, *, axis=0, y_continuous=False, method='asymptotic'):

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1637,7 +1637,7 @@ def _pval_cvm_2samp_asymptotic(t, N, nx, ny, k, *, xp):
 
 @xp_capabilities(skip_backends=[('cupy', 'needs rankdata'),
                                 ('dask.array', 'needs rankdata')],
-                 cpu_only=True, jax_jit=False)  # rankdata not compatible with JAX JIT
+                 cpu_only=True, jax_jit=False)  # due to p-value calculation
 @_axis_nan_policy_factory(CramerVonMisesResult, n_samples=2, too_small=1,
                           result_to_tuple=_cvm_result_to_tuple)
 def cramervonmises_2samp(x, y, method='auto', *, axis=0):

--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -217,6 +217,8 @@ MannwhitneyuResult = namedtuple('MannwhitneyuResult', ('statistic', 'pvalue'))
 @xp_capabilities(cpu_only=True,  # exact calculation only implemented in NumPy
                  skip_backends=[('cupy', 'needs rankdata'),
                                 ('dask.array', 'needs rankdata')],
+                 # getting ranks/ties with JAX JIT is no longer a problem, but
+                 # the exact null distribution is still NumPy-only
                  jax_jit=False)
 @_axis_nan_policy_factory(MannwhitneyuResult, n_samples=2)
 def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",

--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -217,8 +217,7 @@ MannwhitneyuResult = namedtuple('MannwhitneyuResult', ('statistic', 'pvalue'))
 @xp_capabilities(cpu_only=True,  # exact calculation only implemented in NumPy
                  skip_backends=[('cupy', 'needs rankdata'),
                                 ('dask.array', 'needs rankdata')],
-                 # getting ranks/ties with JAX JIT is no longer a problem, but
-                 # the exact null distribution is still NumPy-only
+                 # the exact null distribution is NumPy-only
                  jax_jit=False)
 @_axis_nan_policy_factory(MannwhitneyuResult, n_samples=2)
 def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3639,7 +3639,7 @@ def _mood_too_small(samples, kwargs, axis=-1):
 
 
 @xp_capabilities(skip_backends=[('cupy', 'no rankdata'), ('dask.array', 'no rankdata')],
-                 jax_jit=False)  # JAX JIT incompatible with rankdata
+                 jax_jit=False)  # _rankdata incompatible with JAX JIT (return_ties)
 @_axis_nan_policy_factory(SignificanceResult, n_samples=2, too_small=_mood_too_small)
 def mood(x, y, axis=0, alternative="two-sided"):
     """Perform Mood's test for equal scale parameters.

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3797,7 +3797,10 @@ def wilcoxon_outputs(kwds):
 
 @xp_capabilities(skip_backends=[("dask.array", "no rankdata"),
                                 ("cupy", "no rankdata")],
-                jax_jit=False, cpu_only=True)  # null distribution is CPU only
+                 # getting ranks/ties with JAX JIT is no longer a problem, but
+                 # the exact null distribution is still NumPy-only
+                 jax_jit=False,
+                 cpu_only=True)  # null distribution is CPU only
 @_rename_parameter("mode", "method")
 @_axis_nan_policy_factory(
     wilcoxon_result_object, paired=True,

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3410,7 +3410,7 @@ FlignerResult = namedtuple('FlignerResult', ('statistic', 'pvalue'))
 
 
 @xp_capabilities(skip_backends=[('dask.array', 'no rankdata'),
-                                ('cupy', 'no rankdata')], jax_jit=False)
+                                ('cupy', 'no rankdata')])
 @_axis_nan_policy_factory(FlignerResult, n_samples=None)
 def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
     r"""Perform Fligner-Killeen test for equality of variance.
@@ -3545,7 +3545,7 @@ def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
     Xibar = [func(sample) for sample in samples]
     Xij_Xibar = [xp.abs(sample - Xibar_) for sample, Xibar_ in zip(samples, Xibar)]
     Xij_Xibar = xp.concat(Xij_Xibar, axis=-1)
-    ranks = _stats_py._rankdata(Xij_Xibar, method='average', xp=xp)
+    ranks = stats.rankdata(Xij_Xibar, method='average')
     ranks = xp.astype(ranks, dtype)
     a_Ni = special.ndtri(ranks / (2*(N + 1.0)) + 0.5)
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3545,7 +3545,7 @@ def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
     Xibar = [func(sample) for sample in samples]
     Xij_Xibar = [xp.abs(sample - Xibar_) for sample, Xibar_ in zip(samples, Xibar)]
     Xij_Xibar = xp.concat(Xij_Xibar, axis=-1)
-    ranks = stats.rankdata(Xij_Xibar, method='average')
+    ranks = stats.rankdata(Xij_Xibar, method='average', axis=-1)
     ranks = xp.astype(ranks, dtype)
     a_Ni = special.ndtri(ranks / (2*(N + 1.0)) + 0.5)
 

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3609,11 +3609,7 @@ def _mood_statistic_with_ties(x, y, t, m, n, N, xp):
     x = xp.sort(x, axis=-1)
     xy = xp.concat((x, y), axis=-1)
     i = xp.argsort(xy, stable=True, axis=-1)
-    if is_jax(xp):
-        max_ranks = stats.rankdata(xp.sort(x, axis=-1), method='max', axis=-1)
-        a = xp.diff(max_ranks, axis=-1, prepend=0.)
-    else:
-        _, a = _stats_py._rankdata(x, method='average', return_ties=True)
+    _, a = _stats_py._rankdata(x, method='average', return_ties=True)
     a = xp.astype(a, phi.dtype)
 
     zeros = xp.zeros(a.shape[:-1] + (n,), dtype=a.dtype)
@@ -3751,12 +3747,7 @@ def mood(x, y, axis=0, alternative="two-sided"):
 
     # determine if any of the samples contain ties
     # `a` represents ties within `x`; `t` represents ties within `xy`
-    if is_jax(xp):
-        r = stats.rankdata(xy, method='average', axis=-1)
-        max_ranks = stats.rankdata(xp.sort(xy, axis=-1), method='max', axis=-1)
-        t = xp.diff(max_ranks, axis=-1, prepend=0.)
-    else:
-        r, t = _stats_py._rankdata(xy, method='average', return_ties=True)
+    r, t = _stats_py._rankdata(xy, method='average', return_ties=True)
     r, t = xp.asarray(r, dtype=dtype), xp.asarray(t, dtype=dtype)
 
     if is_lazy_array(t) or xp.any(t > 1):

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3788,8 +3788,7 @@ def wilcoxon_outputs(kwds):
 
 @xp_capabilities(skip_backends=[("dask.array", "no rankdata"),
                                 ("cupy", "no rankdata")],
-                 # getting ranks/ties with JAX JIT is no longer a problem, but
-                 # the exact null distribution is still NumPy-only
+                 # the exact null distribution is NumPy-only
                  jax_jit=False,
                  cpu_only=True)  # null distribution is CPU only
 @_rename_parameter("mode", "method")

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -71,6 +71,7 @@ from scipy._lib._array_api import (
     is_dask,
     is_numpy,
     is_cupy,
+    is_jax,
     is_marray,
     xp_size,
     xp_vector_norm,
@@ -9942,8 +9943,7 @@ def _validate_distribution(values, weights):
 
 
 @xp_capabilities(skip_backends=[("cupy", "`repeat` can't handle array second arg"),
-                                ("dask.array", "no `take_along_axis`")],
-                 jax_jit=False)
+                                ("dask.array", "no `take_along_axis`")])
 def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
     """Assign ranks to data, dealing with ties appropriately.
 
@@ -10037,6 +10037,11 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
         raise ValueError(f'unknown method "{method}"')
 
     xp = array_namespace(a)
+
+    if is_jax(xp):
+        import jax.scipy.stats as jax_stats
+        return jax_stats.rankdata(a, method=method, axis=axis, nan_policy=nan_policy)
+
     x = xp.asarray(a)
 
     if axis is None:

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -486,7 +486,7 @@ def _mode_result(mode, count):
 
 @xp_capabilities(skip_backends=[('dask.array', "can't compute chunk size"),
                                 ('cupy', "data-apis/array-api-compat#312")],
-                 jax_jit=False)  # doesn't really support unique_counts
+                 jax_jit=False)  # would delegate, but jax-ml/jax#34486
 @_axis_nan_policy_factory(_mode_result, override={'nan_propagation': False})
 def mode(a, axis=0, nan_policy='propagate', keepdims=False):
     r"""Return an array of the modal (most common) value in the passed array.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10051,7 +10051,7 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
     ranks = _rankdata(x, method, xp=xp)
 
     # JIT won't allow use of `contains_nan` for control flow here, so we have to choose
-    # whether to always or never run this block wit JIT.
+    # whether to always or never run this block with JIT.
     # For now, *never* run it; otherwise, it would change dtype of `ranks`.
     # When gh-19889 is resolved, dtype will already be `float`, so *always* run it.
     # TODO then: broadcast `i_nan` to the shape of ranks before using `at.set`

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8541,7 +8541,7 @@ FriedmanchisquareResult = namedtuple('FriedmanchisquareResult',
 
 
 @xp_capabilities(skip_backends=[("cupy", "no rankdata"), ("dask.array", "no rankdata")],
-                 jax_jit=False)  # rankdata incompatible with JIT
+                 jax_jit=False)  # _rankdata incompatible with JAX JIT (return_ties)
 @_axis_nan_policy_factory(FriedmanchisquareResult, n_samples=None, paired=True)
 def friedmanchisquare(*samples, axis=0):
     """Compute the Friedman test for repeated samples.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8429,7 +8429,7 @@ KruskalResult = namedtuple('KruskalResult', ('statistic', 'pvalue'))
 
 
 @xp_capabilities(skip_backends=[('cupy', 'no rankdata'), ('dask.array', 'no rankdata')],
-                 jax_jit=False)  # rankdata incompatible with JIT
+                 jax_jit=False)  # _rankdata incompatible with JAX JIT (return_ties)
 @_axis_nan_policy_factory(KruskalResult, n_samples=None)
 def kruskal(*samples, nan_policy='propagate', axis=0):
     """Compute the Kruskal-Wallis H-test for independent samples.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8643,8 +8643,7 @@ BrunnerMunzelResult = namedtuple('BrunnerMunzelResult',
 
 @xp_capabilities(cpu_only=True, # torch GPU can't use `stdtr`
                  skip_backends=[('dask.array', 'needs rankdata'),
-                                ('cupy', 'needs rankdata')],
-                 jax_jit=False)  # rankdata incompatible with JIT
+                                ('cupy', 'needs rankdata')])
 @_axis_nan_policy_factory(BrunnerMunzelResult, n_samples=2)
 def brunnermunzel(x, y, alternative="two-sided", distribution="t",
                   nan_policy='propagate', *, axis=0):
@@ -8763,7 +8762,8 @@ def brunnermunzel(x, y, alternative="two-sided", distribution="t",
         df_denom += xp.pow(ny * Sy, 2.0) / (ny - 1)
         df = df_numer / df_denom
 
-        if xp.any(df_numer == 0) and xp.any(df_denom == 0):
+        if not is_lazy_array(df_numer) and not is_lazy_array(df_denom) and (
+                xp.any(df_numer == 0) and xp.any(df_denom == 0)):
             message = ("p-value cannot be estimated with `distribution='t' "
                        "because degrees of freedom parameter is undefined "
                        "(0/0). Try using `distribution='normal'")

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1567,7 +1567,7 @@ class TestMood:
                         slice2 = x2[i, j, :]
 
                     ref = stats.mood(slice1, slice2)
-                    xp_assert_close(res.statistic[i, j], ref.statistic)
+                    xp_assert_close(res.statistic[i, j], ref.statistic, atol=1e-15)
                     xp_assert_close(res.pvalue[i, j], ref.pvalue)
 
     def test_mood_bad_arg(self, xp):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -8672,6 +8672,7 @@ class TestBrunnerMunzel:
         xp_assert_equal(statistic, xp.asarray(xp.nan))
         xp_assert_equal(pvalue, xp.asarray(xp.nan))
 
+    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
     def test_brunnermunzel_nan_input_propagate(self, xp):
         X = xp.asarray([1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1, xp.nan])
         Y = xp.asarray([3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4.])


### PR DESCRIPTION
#### Reference issue
Toward gh-20544
Follow-up to gh-24405

#### What does this implement/fix?
This PR allows `scipy.stats.rankdata` to delegate to `jax.scipy.stats.rankdata`, unblocking JIT for `bws_test`, `chatterjeexi`, and `spearmanrho`.
*Update: also `fligner`, `mood`, `kruskal`, `friedmanchisquare`, and `brunnermunzel`.*

#### Additional information
Also discovered jax-ml/jax#34486 when trying to delegate `mode`