### PR TITLE
CI, MAINT: few 3.11/pixi cleaups

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,7 +26,7 @@ jobs:
     uses: ./.github/workflows/commit_message.yml
 
   test_meson:
-    name: Conda & umfpack/scikit-sparse, fast, py3.11/npAny, spin
+    name: Conda & umfpack/scikit-sparse, fast, py3.12/npAny, spin
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
@@ -61,15 +61,12 @@ jobs:
         run: pixi exec ccache -s
 
   test_scipy_openblas:
-    name: M1 & OpenBLAS, fast, py3.11/npAny, spin
+    name: M1 & OpenBLAS, fast, py3.14/npAny, spin
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')
     runs-on: macos-14
-    strategy:
-      matrix:
-        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -86,7 +83,7 @@ jobs:
         run: pixi run test-scipy-openblas
 
   test_accelerate:
-    name: Accelerate, full, py3.13/npAny, spin
+    name: Accelerate, full, py3.14/npAny, spin
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -2,6 +2,7 @@
 # Distributed under the same license as SciPy.
 
 import inspect
+import os
 import sys
 import warnings
 
@@ -1533,10 +1534,8 @@ class KrylovJacobian(Jacobian):
                     " It will be ignored."
                     "Please check inner method documentation for valid options."
                     + suggestion_msg,
-                    stacklevel=3,
                     category=UserWarning,
-                    # using `skip_file_prefixes` would be a good idea
-                    # and should be added once we drop support for Python 3.11
+                    skip_file_prefixes=(os.path.dirname(__file__),)
                 )
                 # ignore this parameter and continue
                 continue


### PR DESCRIPTION
* A few CI jobs had stale references to Python 3.11--in several cases the environment setup is now handled by `pixi`, and is using a much newer version of Python. Those cases have been updated based on inspection of log outputs in recent CI runs.

* One case of modernization with `skip_file_prefixes` for warning stack level handling was added, based on a previous comment to do this. (this is all from `git grep ..` analysis)