### PR TITLE
ENH: stats.epps_singleton_2samp: enable JIT

### DIFF
--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -10,7 +10,8 @@ from . import distributions
 from ._common import ConfidenceInterval
 from ._continuous_distns import norm
 from scipy._lib._array_api import (xp_capabilities, array_namespace, xp_size,
-                                   xp_promote, xp_result_type, xp_copy, is_numpy)
+                                   xp_promote, xp_result_type, xp_copy, is_numpy,
+                                   is_lazy_array)
 import scipy._lib.array_api_extra as xpx
 from scipy.special import gamma, kv, gammaln
 from scipy.fft import ifft
@@ -29,8 +30,7 @@ Epps_Singleton_2sampResult = namedtuple('Epps_Singleton_2sampResult',
                                         ('statistic', 'pvalue'))
 
 
-@xp_capabilities(skip_backends=[("dask.array", "lazy -> no _axis_nan_policy")],
-                 jax_jit=False)  # value-dependent branching
+@xp_capabilities(skip_backends=[("dask.array", "lazy -> no _axis_nan_policy")])
 @_axis_nan_policy_factory(Epps_Singleton_2sampResult, n_samples=2, too_small=4)
 def epps_singleton_2samp(x, y, t=(0.4, 0.8), *, axis=0):
     """Compute the Epps-Singleton (ES) test statistic.
@@ -119,7 +119,9 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8), *, axis=0):
     # check if t is valid
     if t.ndim > 1:
         raise ValueError(f't must be 1d, but t.ndim equals {t.ndim}.')
-    if xp.any(t <= 0):
+    if is_lazy_array(t):
+        t = xpx.at(t)[t <= 0].set(xp.nan)
+    elif xp.any(t <= 0):
         raise ValueError('t must contain positive elements only.')
 
     # Previously, non-finite input caused an error in linalg functions.
@@ -149,7 +151,7 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8), *, axis=0):
     est_cov = (n/nx)*cov_x + (n/ny)*cov_y
     est_cov_inv = xp.linalg.pinv(est_cov)
     r = xp.asarray(xp.linalg.matrix_rank(est_cov_inv), dtype=est_cov_inv.dtype)
-    if xp.any(r < 2*xp_size(t)):
+    if not is_lazy_array(r) and xp.any(r < 2*xp_size(t)):
         warnings.warn('Estimated covariance matrix does not have full rank. '
                       'This indicates a bad choice of the input t and the '
                       'test might not be consistent.', # see p. 183 in [1]_

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -16,7 +16,7 @@ from scipy.stats._mannwhitneyu import mannwhitneyu, _mwu_state, _MWU
 from scipy._lib._testutils import _TestPythranFunc
 from scipy._lib import array_api_extra as xpx
 from scipy._lib._array_api import (make_xp_test_case, xp_default_dtype, is_numpy,
-                                   eager_warns, xp_ravel)
+                                   eager_warns, xp_ravel, is_jax)
 from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
 from scipy.stats._axis_nan_policy import SmallSampleWarning, too_small_1d_not_omit
 
@@ -25,6 +25,21 @@ lazy_xp_modules = [stats]
 
 @make_xp_test_case(epps_singleton_2samp)
 class TestEppsSingleton:
+    def test_epps_singleton_iv(self, xp):
+        # partial input validation test relevant to the addition of JIT support
+        # TODO: complete input validation tests
+        x = xp.asarray([-0.35, 2.55, 1.73, 0.73, 0.35])
+        y = xp.asarray([-1.15, -0.15, 2.48, 3.25, 3.71])
+        t = xp.asarray([0.4, -0.4])
+        if is_jax(xp):
+            w, p = epps_singleton_2samp(x, y, t=t)
+            xp_assert_equal(w, xp.asarray(xp.nan))
+            xp_assert_equal(p, xp.asarray(xp.nan))
+        else:
+            message = "t must contain positive elements only."
+            with pytest.raises(ValueError, match=message):
+                epps_singleton_2samp(x, y, t=t)
+
     @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
     def test_statistic_1(self, dtype, xp):
         # first example in Goerg & Kaiser, also in original paper of


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
This PR enables use of JAX JIT with `scipy.stats.epps_singleton_2samp`. 

#### Additional information
Only two limitations.
- There is some value-dependent input validation on `t` that JAX can't do. Instead, we ensure that the result is NaN when there is an invalid entry in `t`.
- There is value-dependent *output* validation that warns about a potentially invalid result. Not much we can do about that.