### PR TITLE
ENH: stats.yeojohnson_llf: enable JIT

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -1718,6 +1718,13 @@ def _yeojohnson_transform(x, lmbda, xp=None):
     out = xp.zeros_like(x, dtype=dtype)
     pos = x >= 0  # binary mask
 
+    if is_jax(xp):
+        return xp.select(
+            [(abs(lmbda) < eps) & pos, (abs(lmbda - 2) < eps) & ~pos, pos],
+            [xp.log1p(x), -xp.log1p(-x), xp.expm1(lmbda * xp.log1p(x)) / lmbda],
+            -xp.expm1((2 - lmbda) * xp.log1p(-x)) / (2 - lmbda),
+        )
+
     # when x >= 0
     if abs(lmbda) < eps:
         out = xpx.at(out)[pos].set(xp.log1p(x[pos]))
@@ -1735,8 +1742,7 @@ def _yeojohnson_transform(x, lmbda, xp=None):
     return out
 
 
-@xp_capabilities(skip_backends=[("dask.array", "Dask can't broadcast nan shapes")],
-                 jax_jit=False)  # branches based on presence of +/- values
+@xp_capabilities(skip_backends=[("dask.array", "Dask can't broadcast nan shapes")])
 def yeojohnson_llf(lmb, data, *, axis=0, nan_policy='propagate', keepdims=False):
     r"""The Yeo-Johnson log-likelihood function.
 
@@ -1868,13 +1874,13 @@ def _yeojohnson_llf(data, *, lmb, axis=0):
     pos = data >= 0  # binary mask
 
     # There exists numerical instability when abs(lmb) or abs(lmb - 2) is very small
-    if xp.all(pos):
+    if not is_lazy_array(pos) and xp.all(pos):
         if abs(lmb) < eps:
             logvar = xp.log(xp.var(xp.log1p(data), axis=axis))
         else:
             logvar = _log_var(lmb * xp.log1p(data), xp, axis) - 2 * math.log(abs(lmb))
 
-    elif xp.all(~pos):
+    elif not is_lazy_array(pos) and xp.all(~pos):
         if abs(lmb - 2) < eps:
             logvar = xp.log(xp.var(xp.log1p(-data), axis=axis))
         else:

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -2820,6 +2820,7 @@ class TestYeojohnson_llf:
         with eager_warns(SmallSampleWarning, match=message, xp=xp):
             assert xp.isnan(stats.yeojohnson_llf(1, xp.asarray([])))
 
+    @skip_xp_backends('jax.numpy', reason="JIT can't special-case for all >0 / <0")
     def test_gh24172(self, xp):
         # Test all negative and all positive data
         data = xp.asarray([10, 10, 10, 9.9], dtype=xp.float64)
@@ -2834,6 +2835,25 @@ class TestYeojohnson_llf:
                         xp.asarray(12.360966379200528, dtype=xp.float64), rtol=1e-7)
         xp_assert_close(stats.yeojohnson_llf(20, -data),
                         xp.asarray(12.380287243698629, dtype=xp.float64), rtol=1e-7)
+
+    @pytest.mark.parametrize("lmb, ref",
+                             [(-1.,  6.757930444097559),
+                              (0., 11.90755408530727),
+                              (1., 14.179952211901629),
+                              (2., 13.040657538043835)])
+    def test_against_reference(self, lmb, ref, xp):
+        # Reference values generated with mpsci, e.g.
+        # import numpy as np
+        # from mpmath import mp
+        # from mpsci.stats import yeojohnson_llf
+        # mp.dps = 100
+        # rng = np.random.default_rng(78435782834992002)
+        # x = rng.uniform(-1, 1, size=25)
+        # float(yeojohnson_llf(-1, x))  # 6.757930444097559
+        rng = np.random.default_rng(78435782834992002)
+        x = rng.uniform(-1, 1, size=25)
+        res = stats.yeojohnson_llf(lmb, xp.asarray(x.tolist()))
+        xp_assert_close(res, xp.asarray(ref))
 
 
 class TestYeojohnson(TransformTest):


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
This PR enables use of JAX JIT with `scipy.stats.yeojohnson_llf`. 

#### Additional information
I don't see any way around special-casing here. Even `xpx.apply_where` uses JAX's `where`- `xpx.at.set` doesn't work because it creates temporary arrays (e.g. `x[pos]`) with value-dependent size.