### PR TITLE
BUG: vq.kmeans segfaults with extreme values

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -72,13 +72,6 @@ def _check_finite(array: Array, xp: ModuleType) -> None:
         msg = "array must not contain infs or NaNs"
         raise ValueError(msg)
 
-def _check_extreme_val(array: Array, xp: ModuleType) -> None:
-    """ Check for extreme values."""
-    max_val = xp.max(xp.abs(array))
-    if max_val ** 2 > xp.finfo(xp.float64).max:
-        msg = "array must not contain very large or infs values"
-        raise ValueError(msg)
-
 def _asarray(
         array: ArrayLike,
         dtype: Any = None,
@@ -87,7 +80,6 @@ def _asarray(
         *,
         xp: ModuleType | None = None,
         check_finite: bool = False,
-        check_extreme_val: bool = False,
         subok: bool = False,
     ) -> Array:
     """SciPy-specific replacement for `np.asarray` with `order`, `check_finite`, and
@@ -123,9 +115,6 @@ def _asarray(
 
     if check_finite:
         _check_finite(array, xp)
-
-    if check_extreme_val:
-        _check_extreme_val(array, xp)
 
     return array
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -72,6 +72,13 @@ def _check_finite(array: Array, xp: ModuleType) -> None:
         msg = "array must not contain infs or NaNs"
         raise ValueError(msg)
 
+def _check_extreme_val(array: Array, xp: ModuleType) -> None:
+    """ Check for extreme values."""
+    max_val = xp.max(xp.abs(array))
+    if max_val ** 2 > xp.finfo(xp.float64).max:
+        msg = "array must not contain very large or infs values"
+        raise ValueError(msg)
+
 def _asarray(
         array: ArrayLike,
         dtype: Any = None,
@@ -80,6 +87,7 @@ def _asarray(
         *,
         xp: ModuleType | None = None,
         check_finite: bool = False,
+        check_extreme_val: bool = False,
         subok: bool = False,
     ) -> Array:
     """SciPy-specific replacement for `np.asarray` with `order`, `check_finite`, and
@@ -115,6 +123,9 @@ def _asarray(
 
     if check_finite:
         _check_finite(array, xp)
+
+    if check_extreme_val:
+        _check_extreme_val(array, xp)
 
     return array
 

--- a/scipy/cluster/vq/_vq_impl.py
+++ b/scipy/cluster/vq/_vq_impl.py
@@ -410,8 +410,14 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True,
         xp = array_namespace(obs)
     else:
         xp = array_namespace(obs, k_or_guess)
-    obs = _asarray(obs, xp=xp, check_finite=check_finite, check_extreme_val=True)
-    guess = _asarray(k_or_guess, xp=xp, check_finite=check_finite, check_extreme_val=True)
+    obs = _asarray(obs, xp=xp, check_finite=check_finite)
+    guess = _asarray(k_or_guess, xp=xp, check_finite=check_finite)
+
+    max_val = xp.max(xp.abs(obs))
+    max_float64 = xp.finfo(xp.float64).max
+    if max_val > xp.sqrt(max_float64):
+        raise ValueError("array must not contain very large or infs values")
+
     if iter < 1:
         raise ValueError(f"iter must be at least 1, got {iter}")
 
@@ -724,8 +730,14 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
         xp = array_namespace(data)
     else:
         xp = array_namespace(data, k)
-    data = _asarray(data, xp=xp, check_finite=check_finite, check_extreme_val=True)
+    data = _asarray(data, xp=xp, check_finite=check_finite)
     code_book = xp_copy(k, xp=xp)
+
+    max_val = xp.max(xp.abs(data))
+    max_float64 = xp.finfo(xp.float64).max
+    if max_val > xp.sqrt(max_float64):
+        raise ValueError("array must not contain very large or infs values")
+
     if data.ndim == 1:
         d = 1
     elif data.ndim == 2:

--- a/scipy/cluster/vq/_vq_impl.py
+++ b/scipy/cluster/vq/_vq_impl.py
@@ -410,8 +410,8 @@ def kmeans(obs, k_or_guess, iter=20, thresh=1e-5, check_finite=True,
         xp = array_namespace(obs)
     else:
         xp = array_namespace(obs, k_or_guess)
-    obs = _asarray(obs, xp=xp, check_finite=check_finite)
-    guess = _asarray(k_or_guess, xp=xp, check_finite=check_finite)
+    obs = _asarray(obs, xp=xp, check_finite=check_finite, check_extreme_val=True)
+    guess = _asarray(k_or_guess, xp=xp, check_finite=check_finite, check_extreme_val=True)
     if iter < 1:
         raise ValueError(f"iter must be at least 1, got {iter}")
 
@@ -724,7 +724,7 @@ def kmeans2(data, k, iter=10, thresh=1e-5, minit='random',
         xp = array_namespace(data)
     else:
         xp = array_namespace(data, k)
-    data = _asarray(data, xp=xp, check_finite=check_finite)
+    data = _asarray(data, xp=xp, check_finite=check_finite, check_extreme_val=True)
     code_book = xp_copy(k, xp=xp)
     if data.ndim == 1:
         d = 1

--- a/scipy/cluster/vq/tests/test_vq.py
+++ b/scipy/cluster/vq/tests/test_vq.py
@@ -77,6 +77,15 @@ CODET2 = np.array([[11.0/3, 8.0/3],
 
 LABEL1 = np.array([0, 1, 2, 2, 2, 2, 1, 2, 1, 1, 1])
 
+ext_val = np.array([
+        [
+            1.28000000e002,
+            3.27670000e004,
+            8.38822400e006,
+            3.13740168e057,
+            1.12357916e164,
+        ]
+])
 
 @make_xp_test_case(whiten)
 class TestWhiten:
@@ -87,7 +96,7 @@ class TestWhiten:
                             [4.51041982, 0.02640918],
                             [4.38567074, 0.95120889],
                             [2.32191480, 1.63195503]])
-
+)
         obs = xp.asarray([[0.98744510, 0.82766775],
                           [0.62093317, 0.19406729],
                           [0.87545741, 0.00735733],
@@ -365,6 +374,10 @@ class TestKMeans:
                 orig_cov = xpx.cov(data.T, xp=xp)
                 init_cov = xpx.cov(init.T, xp=xp)
                 xp_assert_close(orig_cov, init_cov, atol=1.1e-2)
+
+    def test_kmeans_extreme_values(self, xp):
+        assert_raises(ValueError, kmeans, xp.asarray(ext_val), 1)
+        assert_raises(ValueError, kmeans2, xp.asarray(ext_val), 1)
 
     def test_kmeans2_empty(self, xp):
         # Regression test for gh-1032.

--- a/scipy/cluster/vq/tests/test_vq.py
+++ b/scipy/cluster/vq/tests/test_vq.py
@@ -77,15 +77,11 @@ CODET2 = np.array([[11.0/3, 8.0/3],
 
 LABEL1 = np.array([0, 1, 2, 2, 2, 2, 1, 2, 1, 1, 1])
 
-ext_val = np.array([
-        [
-            1.28000000e002,
-            3.27670000e004,
-            8.38822400e006,
-            3.13740168e057,
-            1.12357916e164,
-        ]
-])
+ext_val = np.array([[1.28000000e002,
+                     3.27670000e004,
+                     8.38822400e006,
+                     3.13740168e057,
+                     1.12357916e164]])
 
 @make_xp_test_case(whiten)
 class TestWhiten:
@@ -376,6 +372,7 @@ class TestKMeans:
                 xp_assert_close(orig_cov, init_cov, atol=1.1e-2)
 
     def test_kmeans_extreme_values(self, xp):
+        # Regression test for gh-24216.
         assert_raises(ValueError, kmeans, xp.asarray(ext_val), 1)
         assert_raises(ValueError, kmeans2, xp.asarray(ext_val), 1)
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-24216
#### What does this implement/fix?
<!--Please explain your changes.-->
Euclidean distance involves squaring data values: distance² = Σ(x_i - c_i)² With large input values (like, 1e164), squaring can produce numbers like 1e328, which exceeds float64's maximum value (~1.8e308), causing overflow and potentially segmentation faults.
#### Additional information
<!--Any additional information you think is important.-->
This PR check for extreme values and raise ValueError, however we could fix or rescale the input data and pass it. but it would be more robust to raise a ValueError and explicitly require the user to scale the data rather than failing silently or crashing.