### PR TITLE
DOC: fix missing parameter descriptions in spatial and stats

### DIFF
--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -817,7 +817,7 @@ class KDTree(cKDTree):
         Parameters
         ----------
         other : KDTree
-
+            The other KDTree to compute distances against.
         max_distance : positive float
 
         p : float, 1<=p<=infinity

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -2433,6 +2433,7 @@ def _mask_to_limits(a, limits, inclusive):
     Parameters
     ----------
     a : array
+        The input array.
     limits : (float or None, float or None)
     A tuple consisting of the (lower limit, upper limit).  Values in the
     input array less than the lower limit or greater than the upper limit


### PR DESCRIPTION
This PR adds missing parameter descriptions in `scipy.spatial` and `scipy.stats`, addressing part of the documentation issues tracked in #24348 (specifically category PR07).

**Changes:**
* `scipy/spatial/_kdtree.py`: Added description for the `other` parameter in `sparse_distance_matrix`.
* `scipy/stats/_mstats_basic.py`: Added description for the `a` parameter in `_mask_to_limits`.

Relates to #24348.