### PR TITLE
BUG: spatial.transform: Fix leaking MemoryViews from cy backend

### DIFF
--- a/scipy/spatial/transform/_rigid_transform_cy.pyx
+++ b/scipy/spatial/transform/_rigid_transform_cy.pyx
@@ -241,7 +241,7 @@ def pow(double[:, :, :] matrix, float n):
     elif n == -1:
         return inv(matrix)
     elif n == 1:
-        return matrix
+        return np.asarray(matrix)
     return from_exp_coords(as_exp_coords(matrix) * n)
 
 

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -1295,7 +1295,7 @@ def pow(double[:, :] quat, n) -> double[:, :]:
     elif n == -1:
         return inv(quat)
     elif n == 1:
-        return quat
+        return np.asarray(quat)
     # general scaling of rotation angle
     return from_rotvec(n * as_rotvec(quat))
 

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -824,6 +824,8 @@ def test_pow(xp, ndim: int):
     # Test the short-cuts and other integers
     for n in [-5, -2, -1, 0, 1, 2, 5]:
         q = p**n
+        # Regression test for gh-24436
+        assert isinstance(q._matrix, type(p._matrix))
         r = RigidTransform.from_matrix(xp.tile(xp.eye(4), shape + (1, 1)))
         for _ in range(abs(n)):
             if n > 0:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2469,7 +2469,7 @@ def test_pow(xp, ndim: int):
         q = p ** n
         q_identity = xp.asarray([0., 0, 0, 1])
         # Regression test for gh-24436 
-        assert isinstance(q._quat, type(q_identity))  # still xp array
+        assert isinstance(q._quat, type(q_identity))
         r = Rotation.from_quat(xp.tile(q_identity, batch_shape + (1,)))
         for _ in range(abs(n)):
             if n > 0:

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2468,6 +2468,8 @@ def test_pow(xp, ndim: int):
         # Test accuracy
         q = p ** n
         q_identity = xp.asarray([0., 0, 0, 1])
+        # Regression test for gh-24436 
+        assert isinstance(q._quat, type(q_identity))  # still xp array
         r = Rotation.from_quat(xp.tile(q_identity, batch_shape + (1,)))
         for _ in range(abs(n)):
             if n > 0:


### PR DESCRIPTION
The cython backend was leaking MemoryViews when using the special cased pow(1) for `Rotation`s/`RigidTransform`s of shape (N,) in combination with the optimized `_from_raw` initializers. 

#### Reference issue
closes #24436

#### What does this implement/fix?
Prevents leaking the MemoryViews from the backend.

#### Additional information
Should be considered for back porting.
 