### PR TITLE
DOC: spatial.KDTree.sparse_distance_matrix: add descriptions to the arguments

### DIFF
--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -817,7 +817,7 @@ class KDTree(cKDTree):
         Parameters
         ----------
         other : KDTree
-
+            The other KDTree to compute distances against.
         max_distance : positive float
 
         p : float, 1<=p<=infinity

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -817,7 +817,7 @@ class KDTree(cKDTree):
         Parameters
         ----------
         other : KDTree
-            The other KDTree to compute distances against.
+            The other `KDTree` to compute distances against.
         max_distance : positive float
 
         p : float, 1<=p<=infinity

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -819,6 +819,7 @@ class KDTree(cKDTree):
         other : KDTree
             The other `KDTree` to compute distances against.
         max_distance : positive float
+        Maximum distance within which neighbors are returned.
 
         p : float, 1<=p<=infinity
             Which Minkowski p-norm to use.

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -819,15 +819,14 @@ class KDTree(cKDTree):
         other : KDTree
             The other `KDTree` to compute distances against.
         max_distance : positive float
-        Maximum distance within which neighbors are returned.
-
+            Maximum distance within which neighbors are returned. Distances above this
+            values are returned as zero.
         p : float, 1<=p<=infinity
             Which Minkowski p-norm to use.
             A finite large p may cause a ValueError if overflow can occur.
-
         output_type : string, optional
-            Which container to use for output data. Options: 'dok_matrix',
-            'coo_matrix', 'dict', or 'ndarray'. Default: 'dok_matrix'.
+            Which container to use for output data. Options: ``'dok_matrix'``,
+            ``'coo_matrix'``, ``'dict'``, or ``'ndarray'``. Default: ``'dok_matrix'``.
 
             .. versionadded:: 1.6.0
 
@@ -835,9 +834,9 @@ class KDTree(cKDTree):
         -------
         result : dok_matrix, coo_matrix, dict or ndarray
             Sparse matrix representing the results in "dictionary of keys"
-            format. If a dict is returned the keys are (i,j) tuples of indices.
-            If output_type is 'ndarray' a record array with fields 'i', 'j',
-            and 'v' is returned,
+            format. If a dict is returned the keys are ``(i,j)`` tuples of indices.
+            If output_type is ``'ndarray'`` a record array with fields ``'i'``, ``'j'``,
+            and ``'v'`` is returned,
 
         Examples
         --------

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -2433,6 +2433,7 @@ def _mask_to_limits(a, limits, inclusive):
     Parameters
     ----------
     a : array
+        The input array.
     limits : (float or None, float or None)
     A tuple consisting of the (lower limit, upper limit).  Values in the
     input array less than the lower limit or greater than the upper limit

--- a/scipy/stats/_mstats_basic.py
+++ b/scipy/stats/_mstats_basic.py
@@ -2433,7 +2433,6 @@ def _mask_to_limits(a, limits, inclusive):
     Parameters
     ----------
     a : array
-        The input array.
     limits : (float or None, float or None)
     A tuple consisting of the (lower limit, upper limit).  Values in the
     input array less than the lower limit or greater than the upper limit


### PR DESCRIPTION
This PR adds missing parameter descriptions in `scipy.spatial` and `scipy.stats`, addressing part of the documentation issues tracked in #24348 (specifically category PR07).

**Changes:**
* `scipy/spatial/_kdtree.py`: Added description for the `other` parameter in `sparse_distance_matrix`.

Relates to #24348.