### PR TITLE
ENH: linalg/inv: re-enable overwrite_a for 2D inputs

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -233,9 +233,15 @@ def solve(a, b, lower=False, overwrite_a=False,
         out = b1 / a1
         return out[..., 0] if b_is_1D else out
 
+    # XXX a1.ndim > 2 ; b1.ndim > 2
+    # XXX a1 C ordered & transposed==True ?
+    overwrite_a = overwrite_a and (a1.ndim == 2) and (a1.flags["F_CONTIGUOUS"]) and not transposed
+    overwrite_b = overwrite_b and (b1.ndim <= 2) and (b1.flags["F_CONTIGUOUS"])
+
     # heavy lifting
-    x, err_lst = _batched_linalg._solve(a1, b1, structure, lower, transposed,
-                                        overwrite_a, overwrite_b)
+    x, err_lst = _batched_linalg._solve(
+        a1, b1, structure, lower, transposed, overwrite_a, overwrite_b
+    )
 
     if err_lst:
         _format_emit_errors_warnings(err_lst)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -234,8 +234,8 @@ def solve(a, b, lower=False, overwrite_a=False,
         return out[..., 0] if b_is_1D else out
 
     # XXX a1.ndim > 2 ; b1.ndim > 2
-    # XXX a1 C ordered & transposed==True ?
-    overwrite_a = overwrite_a and (a1.ndim == 2) and (a1.flags["F_CONTIGUOUS"]) and not transposed
+    # XXX can do something if a1 C ordered & transposed==True ?
+    overwrite_a = overwrite_a and (a1.ndim == 2) and (a1.flags["F_CONTIGUOUS"])
     overwrite_b = overwrite_b and (b1.ndim <= 2) and (b1.flags["F_CONTIGUOUS"])
 
     # heavy lifting

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1050,6 +1050,9 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
     a1, overwrite_a = _ensure_aligned_and_native(a1, overwrite_a)
 
+    # XXX can relax a1.ndim == 2?
+    overwrite_a = overwrite_a and (a1.ndim == 2) and (a1.flags["F_CONTIGUOUS"])
+
     # keep the numbers in sync with C at `linalg/src/_common_array_utils.hh`
     structure = {
         None: -1,

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -52,8 +52,6 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-    overwrite_a = 0; // TODO: enable it
-
     if(!overwrite_a) {
         /* Allocate the output */
         ap_Ainv = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, typenum);

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -278,7 +278,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
      * It's a caller's responsibility to make sure that these pre-conditions are met,
      * none of them is checked here.
      * Therefore, if `overwrite_a = True`, we skip the copy-and-transpose steps above,
-     * and fill the output `ret_data` straight with the output from LAPACK.
+     * and `ret_data` will simply contain the result from the LAPACK call.
      *
      */
     CBLAS_INT buf_size = overwrite_a ? lwork : 2*n*n + lwork;

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -33,6 +33,12 @@ parametrize_overwrite_arg = pytest.mark.parametrize(
 )
 
 
+parametrize_overwrite_b_arg = pytest.mark.parametrize(
+    "overwrite_b_kw", [{"overwrite_b": True}, {"overwrite_b": False}, {}],
+    ids=["True", "False", "None"]
+)
+
+
 def _eps_cast(dtyp):
     """Get the epsilon for dtype, possibly downcast to BLAS types."""
     dt = dtyp
@@ -810,7 +816,6 @@ class TestSolve:
         with (pytest.raises(LinAlgError, match="singular"), np.errstate(all='ignore')):
             solve(A, b, assume_a=structure)
 
-
     @pytest.mark.parametrize('b', [0, 1, [0, 1]])
     def test_singular_scalar(self, b):
         # regression test for gh-24355: scalar a=0 is singular
@@ -1131,6 +1136,45 @@ class TestSolve:
         x = solve(a, b, **overwrite_kw)
         assert x.shape == a.shape[:-1]
         assert_allclose(a @ x[..., None] - b, 0, atol=1e-14)
+
+    @parametrize_overwrite_arg
+    @parametrize_overwrite_b_arg
+    @pytest.mark.parametrize('a_dtype', [int, float])
+    @pytest.mark.parametrize('a_order', ['C', 'F'])
+    @pytest.mark.parametrize('b_dtype', [int, float])
+    @pytest.mark.parametrize('b_order', ['C', 'F'])
+    @pytest.mark.parametrize('b_ndim', [1, 2])    # XXX ndim > 2
+    # XXX add transposed={True,False}
+    def test_overwrite_args(
+        self, overwrite_kw, overwrite_b_kw, a_dtype, a_order, b_dtype, b_order, b_ndim
+    ):
+        n = 3
+        a = np.arange(1, n**2 + 1).reshape(n, n) + np.eye(n)
+        a = a.astype(a_dtype, order=a_order)
+
+        b = np.arange(n)
+        if b_ndim > 1:
+            b = np.stack([b*j for j in range(b_ndim)]).T
+        b = b.astype(b_dtype, order=b_order)
+
+        a_ref = a.copy()
+        b_ref = b.copy()
+
+        # solve and check that the solution is correct for all parameters
+        x = solve(a, b, **overwrite_kw, **overwrite_b_kw)
+        assert_allclose(a_ref @ x, b_ref, atol=1e-14)
+
+        # now check that it worked in-place where expected
+        overwrite_a = overwrite_kw.get('overwrite_a', False)
+        a_inplace = overwrite_a and (a.dtype != int) and a.flags['F_CONTIGUOUS']
+
+        overwrite_b = overwrite_b_kw.get('overwrite_b', False)
+        b_inplace = overwrite_b and (b.dtype != int) and b.flags['F_CONTIGUOUS']
+
+        assert np.shares_memory(x, b) == b_inplace
+
+        assert (b == b_ref).all() != b_inplace
+        assert (a == a_ref).all() != a_inplace
 
     def test_posdef_not_posdef(self):
         # the `b` matrix is invertible but not positive definite

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1144,9 +1144,10 @@ class TestSolve:
     @pytest.mark.parametrize('b_dtype', [int, float])
     @pytest.mark.parametrize('b_order', ['C', 'F'])
     @pytest.mark.parametrize('b_ndim', [1, 2])    # XXX ndim > 2
-    # XXX add transposed={True,False}
+    @pytest.mark.parametrize('transposed', [True, False])
     def test_overwrite_args(
-        self, overwrite_kw, overwrite_b_kw, a_dtype, a_order, b_dtype, b_order, b_ndim
+        self, overwrite_kw, overwrite_b_kw, a_dtype, a_order,
+        b_dtype, b_order, b_ndim, transposed
     ):
         n = 3
         a = np.arange(1, n**2 + 1).reshape(n, n) + np.eye(n)
@@ -1161,8 +1162,9 @@ class TestSolve:
         b_ref = b.copy()
 
         # solve and check that the solution is correct for all parameters
-        x = solve(a, b, **overwrite_kw, **overwrite_b_kw)
-        assert_allclose(a_ref @ x, b_ref, atol=1e-14)
+        x = solve(a, b, **overwrite_kw, **overwrite_b_kw, transposed=transposed)
+        a_or_aT = a_ref.T if transposed else a_ref
+        assert_allclose(a_or_aT @ x, b_ref, atol=1e-14)
 
         # now check that it worked in-place where expected
         overwrite_a = overwrite_kw.get('overwrite_a', False)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/24345

#### What does this implement/fix?
<!--Please explain your changes.-->

Re-enable `overwrite_a` kwarg for `linalg.inv`: pre-scipy 1.17, `inv(a, overwrite_a=True)` was attempting to work in-place; 1.17 changes made it silently ignore the argument. 

This PR re-enables it and makes it reuse the input array for a single (non-batched) fortran-ordered input.

#### Additional information
<!--Any additional information you think is important.-->

cf https://github.com/scipy/scipy/issues/24345#issuecomment-3798682251 for an overview.

The change here looks small mainly because the needed infrastructure was mostly in place already. We almost had it in previous iterations on low-level `inv` rewrite, and then decided to kick the can down the road for "some time later". 

A probably key piece which is not visible in this PR is this branching is https://github.com/scipy/scipy/blob/main/scipy/linalg/src/_batched_linalg_module.cc#L56
which decides whether to reuse the input array for output or to allocate a new array instead.