### PR TITLE
Optimize _identify_ridge_lines by removing quadratic list deletion

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1113,15 +1113,15 @@ def _identify_ridge_lines(matr, max_distances, gap_thresh):
                             0]
                 ridge_lines.append(new_line)
 
-        # Remove the ridge lines with gap_number too high
-        # XXX Modifying a list while iterating over it.
-        # Should be safe, since we iterate backwards, but
-        # still tacky.
-        for ind in range(len(ridge_lines) - 1, -1, -1):
-            line = ridge_lines[ind]
+        # Partition ridge lines: move lines with high gap_number to final_lines,
+        # keep others in ridge_lines for further processing
+        keep_lines = []
+        for line in ridge_lines:
             if line[2] > gap_thresh:
                 final_lines.append(line)
-                del ridge_lines[ind]
+            else:
+                keep_lines.append(line)
+        ridge_lines = keep_lines
 
     out_lines = []
     for line in (final_lines + ridge_lines):


### PR DESCRIPTION
#### Reference issue
closes #24448

#### What does this implement/fix?
This PR replaces backward iteration with in-loop list deletion in
`scipy.signal._peak_finding._identify_ridge_lines`  with a single forward pass that partitions the list.

The previous approach performed repeated `del` operations on a Python list, leading to quadratic-time behavior. The new logic preserves ordering and behavior while reducing this step to linear time.
### Previous implementation
```python
# XXX Modifying a list while iterating over it.
for ind in range(len(ridge_lines) - 1, -1, -1):
    line = ridge_lines[ind]
    if line[2] > gap_thresh:
        final_lines.append(line)
        del ridge_lines[ind]
```
### New approach 
```python 
keep_lines = []
for line in ridge_lines:
    if line[2] > gap_thresh:
        final_lines.append(line)
    else:
        keep_lines.append(line)
ridge_lines = keep_lines

```
No API or behavioral changes are intended. 

#### Additional information
AI disclosure
AI assistance was used for wording and code clarity suggestions. The final code and analysis  were written, verified, and reviewed by me.