### PR TITLE
BUG: ndimage: Initialize icoor array in `NI_GeometricTransform`

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -265,7 +265,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     npy_intp ftmp[NPY_MAXDIMS], *fcoordinates = NULL, *foffsets = NULL;
     npy_intp cstride = 0, kk, hh, ll, jj;
     npy_intp size;
-    double **splvals = NULL, icoor[NPY_MAXDIMS], tmp;
+    double **splvals = NULL, icoor[NPY_MAXDIMS] = {0}, tmp;
     npy_intp idimensions[NPY_MAXDIMS], istrides[NPY_MAXDIMS];
     NI_Iterator io, ic;
     npy_double *matrix = matrix_ar ? (npy_double*)PyArray_DATA(matrix_ar) : NULL;
@@ -467,6 +467,11 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
                                 "coordinate array data type not supported");
                 goto exit;
             }
+        } else {
+            NPY_END_THREADS;
+            PyErr_SetString(PyExc_RuntimeError,
+                            "One of `map`, `matrix` or `coordinates` must be provided");
+            goto exit;
         }
 
         /* iterate over axes: */


### PR DESCRIPTION
The icoor array could be used uninitialized if a user-provided LowLevelCallable fails to write its output, or if the function is called without map, matrix, or coordinates set. Initialize to zero to ensure defined behavior in these edge cases.

Uncovered by Coverity static analysis

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes: #24208

