### PR TITLE
BUG: optimize: validate itmax in trlib_eigen_inverse

### DIFF
--- a/scipy/optimize/_trlib/trlib_eigen_inverse.c
+++ b/scipy/optimize/_trlib/trlib_eigen_inverse.c
@@ -78,7 +78,8 @@ trlib_int_t trlib_eigen_inverse(
     *lam_pert = -minuslam;
     
     if ( *iter_inv == TRLIB_EIR_FAIL_FACTOR ) { TRLIB_PRINTLN_2("Failure on factorizing in inverse correction!") TRLIB_RETURN(TRLIB_EIR_FAIL_FACTOR) }
-    
+    if ( itmax <= 0 ) { TRLIB_PRINTLN_2("Failure on solving inverse correction! (itmax <= 0)") TRLIB_RETURN(TRLIB_EIR_FAIL_LINSOLVE) }
+
     // try with TRLIB_EIR_N_STARTVEC different start vectors and hope that it converges for one
     seeds[0] = time(NULL);
     for(jj = 1; jj < TRLIB_EIR_N_STARTVEC; ++jj ) { seeds[jj] = rand(); }


### PR DESCRIPTION
Add early return when itmax <= 0 to prevent use of uninitialized residuals array. The inverse iteration loop sets residuals[jj] only after the first iteration completes. With itmax <= 0, the loop breaks immediately, leaving residuals uninitialized.

Uncovered by Coverity static analysis

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Fixes: #24446 