### PR TITLE
BUG: sparse.linalg.spsolve: avoid segfault when spsolve fails to allocate L and U matrices

### DIFF
--- a/scipy/sparse/linalg/_dsolve/_superlumodule.c
+++ b/scipy/sparse/linalg/_dsolve/_superlumodule.c
@@ -182,8 +182,8 @@ static PyObject *Py_gssv(PyObject * self, PyObject * args,
     SUPERLU_FREE((void*)perm_c);
     Destroy_SuperMatrix_Store((SuperMatrix*)&A);	/* holds just a pointer to the data */
     Destroy_SuperMatrix_Store((SuperMatrix*)&B);
-    Destroy_SuperNode_Matrix((SuperMatrix*)&L);
-    Destroy_CompCol_Matrix((SuperMatrix*)&U);
+    XDestroy_SuperNode_Matrix((SuperMatrix*)&L);
+    XDestroy_CompCol_Matrix((SuperMatrix*)&U);
     StatFree((SuperLUStat_t*)&stat);
 
     return Py_BuildValue("Ni", Py_X, info);


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #24445

#### What does this implement/fix?

When handling large matrices, and memory cannot be allocated, SciPy currently segfaults. When running the reproducer from the linked issue, I get the following output:

```
success? True
b norm 1414.4621401206837
x norm 1264.6189355609422
A@x norm 1414.4621401206837
err 2.4729222482294813e-13
nnz requested 80000000 nnz actual 79999955
Not enough memory to perform factorization.
Segmentation fault (core dumped)
```

With these changes, I get the following result:

```
success? True
b norm 1414.4408305046213
x norm 1265.264011207452
A@x norm 1414.4408305046213
err 2.4734040889619315e-13
nnz requested 80000000 nnz actual 79999955
Not enough memory to perform factorization.
Traceback (most recent call last):
  File "/home/nodell/scipy/../foo/bug-24445.py", line 43, in <module>
    try_matrix(base_nnz * mult)
    ~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/nodell/scipy/../foo/bug-24445.py", line 29, in try_matrix
    x = spsolve(A, b)
  File "/home/nodell/scipy/build-install/usr/lib/python3.13/site-packages/scipy/sparse/linalg/_dsolve/linsolve.py", line 294, in spsolve
    raise MemoryError("Out of memory during gssv")
MemoryError: Out of memory during gssv
```

This is not perfect - the better thing to do would be to fix the overflow in the variable within `nzlumax`, but I am not sure how to do that. See #15688 for background.

In addition to fixing the segfault, it also raises an error when it runs out of memory. Previously, it warned about singular matrices. However, only return values between 0 and ncols signify a singular matrix.

```
 * info    (output) int*
 *     = 0: successful exit
 *         > 0: if info = i, and i is
 *             <= A->ncol: U(i,i) is exactly zero. The factorization has
 *                been completed, but the factor U is exactly singular,
 *                so the solution could not be computed.
 *             > A->ncol: number of bytes allocated when memory allocation
 *                failure occurred, plus A->ncol.
 * 
```

#### Additional information

See reproducer from linked issue for test.
