### PR TITLE
DOC: signal.medfilt: add 1D array example

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1620,6 +1620,16 @@ def medfilt(volume, kernel_size=None):
     scipy.ndimage.median_filter
     scipy.signal.medfilt2d
 
+    Examples
+--------
+    Apply a median filter to a 1D array with an outlier:
+
+    >>> import numpy as np
+    >>> from scipy.signal import medfilt
+    >>> x = np.array([5, 2, 100, 2, 5])
+    >>> medfilt(x, kernel_size=3)
+    array([0, 5, 2, 5, 0])
+
     """
     xp = array_namespace(volume)
     volume = xp.asarray(volume)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1628,7 +1628,7 @@ def medfilt(volume, kernel_size=None):
     >>> from scipy.signal import medfilt
     >>> x = np.array([5, 2, 100, 2, 5])
     >>> medfilt(x, kernel_size=3)
-    array([0, 5, 2, 5, 0])
+    array([2, 5, 2, 5, 2])
 
     """
     xp = array_namespace(volume)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1621,8 +1621,8 @@ def medfilt(volume, kernel_size=None):
     scipy.signal.medfilt2d
 
     Examples
---------
-    Apply a median filter to a 1D array with an outlier:
+    --------
+    Use a median filter on an array with an outlier.
 
     >>> import numpy as np
     >>> from scipy.signal import medfilt
@@ -1630,6 +1630,12 @@ def medfilt(volume, kernel_size=None):
     >>> medfilt(x, kernel_size=3)
     array([2, 5, 2, 5, 2])
 
+    The input is zero-padded at both ends internally.
+    A median filter removes isolated spikes:
+
+    >>> x = np.array([10, 10, 10, 100, 10, 10, 10])
+    >>> medfilt(x, kernel_size=3)
+    array([10, 10, 10, 10, 10, 10, 10])
     """
     xp = array_namespace(volume)
     volume = xp.asarray(volume)


### PR DESCRIPTION
This PR adds an Examples section to `scipy.signal.medfilt`.

This PR adds a example to the `medfilt` docstring using a simple 1D array.
It shows how the median filter handles outliers and what happens at the edges due to zero-padding.

Related to #7168