### PR TITLE
DOC: clarify spilu drop_tol behavior with respect to fill-in

### DIFF
--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -450,7 +450,8 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     drop_tol : float, optional
         Drop tolerance (0 <= tol <= 1) for an incomplete LU decomposition.
         (default: 1e-4)
-        Note that `drop_tol` primarily affects entries generated as fill-in
+
+        Note that ``drop_tol`` primarily affects entries generated as fill-in
         during the ILU factorization; for matrices that produce little or no
         fill-in, changing this parameter may have no visible effect on the
         sparsity pattern of the factors.
@@ -482,13 +483,13 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     array to complex and then factorize.
 
     To improve the better approximation to the inverse, you may need to
-    increase `fill_factor` AND decrease `drop_tol`.
+    increase ``fill_factor`` AND decrease ``drop_tol``.
 
-    The effect of `drop_tol` is matrix-dependent. In particular, `drop_tol`
+    The effect of ``drop_tol`` is matrix-dependent. In particular, ``drop_tol``
     does not guarantee that existing off-diagonal entries will be removed;
     it controls dropping of candidate entries during factorization (often
     fill-in). For some sparsity patterns, the ILU factors can be identical
-    to the full LU factors even for large `drop_tol`.
+    to the full LU factors even for large ``drop_tol``.
 
     This function uses the SuperLU library.
 

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -451,7 +451,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
         Drop tolerance (0 <= tol <= 1) for an incomplete LU decomposition.
         (default: 1e-4)
 
-        Note that ``drop_tol`` primarily affects entries generated as fill-in
+        Note that `drop_tol` primarily affects entries generated as fill-in
         during the ILU factorization; for matrices that produce little or no
         fill-in, changing this parameter may have no visible effect on the
         sparsity pattern of the factors.

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -483,7 +483,7 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     array to complex and then factorize.
 
     To improve the better approximation to the inverse, you may need to
-    increase ``fill_factor`` AND decrease ``drop_tol``.
+    increase `fill_factor` AND decrease `drop_tol`.
 
     The effect of ``drop_tol`` is matrix-dependent. In particular, ``drop_tol``
     does not guarantee that existing off-diagonal entries will be removed;

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -450,6 +450,10 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     drop_tol : float, optional
         Drop tolerance (0 <= tol <= 1) for an incomplete LU decomposition.
         (default: 1e-4)
+        Note that `drop_tol` primarily affects entries generated as fill-in
+        during the ILU factorization; for matrices that produce little or no
+        fill-in, changing this parameter may have no visible effect on the
+        sparsity pattern of the factors.
     fill_factor : float, optional
         Specifies the fill ratio upper bound (>= 1.0) for ILU. (default: 10)
     drop_rule : str, optional
@@ -479,6 +483,12 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
 
     To improve the better approximation to the inverse, you may need to
     increase `fill_factor` AND decrease `drop_tol`.
+
+    The effect of `drop_tol` is matrix-dependent. In particular, `drop_tol`
+    does not guarantee that existing off-diagonal entries will be removed;
+    it controls dropping of candidate entries during factorization (often
+    fill-in). For some sparsity patterns, the ILU factors can be identical
+    to the full LU factors even for large `drop_tol`.
 
     This function uses the SuperLU library.
 

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -485,11 +485,11 @@ def spilu(A, drop_tol=None, fill_factor=None, drop_rule=None, permc_spec=None,
     To improve the better approximation to the inverse, you may need to
     increase `fill_factor` AND decrease `drop_tol`.
 
-    The effect of ``drop_tol`` is matrix-dependent. In particular, ``drop_tol``
+    The effect of `drop_tol` is matrix-dependent. In particular, `drop_tol`
     does not guarantee that existing off-diagonal entries will be removed;
     it controls dropping of candidate entries during factorization (often
     fill-in). For some sparsity patterns, the ILU factors can be identical
-    to the full LU factors even for large ``drop_tol``.
+    to the full LU factors even for large `drop_tol`.
 
     This function uses the SuperLU library.
 


### PR DESCRIPTION
This PR clarifies the documented behavior of the `drop_tol` parameter in `scipy.sparse.linalg.spilu`, with particular focus on its dependence on fill-in generated during ILU factorization.

The change is motivated by the discussion in #24171, where `drop_tol` appeared to have no effect for a small test matrix. After reproducing the report and varying ILU-related parameters, further investigation showed that for this matrix the ILU factors produced by `spilu` are bit-for-bit identical to the full LU factors produced by `splu`.

In this case, the matrix structure generates effectively no fill-in during factorization. Since SuperLU's dropping rules (controlled by `drop_tol`) operate on candidate entries generated during factorization, (often fill-in) there are no droppable candidates, and changing `drop_tol` has no visible effect.

This PR updates the `spilu` docstring to:
- clarify that `drop_tol` primarily affects fill-in entries,
- note that `drop_tol` does not guarantee removal of existing off-diagonal entries, and
- explain that for some sparsity patterns, ILU factors may remain identical to full LU factors even for large `drop_tol` values.

No runtime behavior is changed; this PR is documentation-only and aims to better align user expectations with the underlying SuperLU behavior.

Closes #24171