### PR TITLE
BUG: optimize.ridder: avoid underflow when fa is small

### DIFF
--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -56,7 +56,7 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
             return xm;
         }
 
-        /* * Implement Equation 6 from Ridders' paper to avoid underflow.
+        /* * Implementing the equation from Ridders' paper to avoid underflow.
          * We normalize by fa to avoid underflow in intermediate terms (fm*fm).
          */
         double ratio = fm / fa;

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -47,22 +47,22 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
         xm = xa + dm;
         fm = (*f)(xm, func_data_param);
         
-        /* * Exiting if the midpoint is the root, to avoid zero division errors
+        /* * If the midpoint lands exactly on the root, exit immediately.
+         * This prevents potential issues with ratio calculation if fm is 0.
          */
         if (fm == 0.0) {
             solver_stats->error_num = CONVERGED;
+            solver_stats->funcalls++;
             return xm;
         }
 
-        /* * FIX: Implement Equation 6 from Ridders' paper to avoid underflow.
-         * Normalizing by fa to avoid underflow in intermediate terms (fm*fm).
-         * Using -dm because the sign of (fm/fa) is opposite to 
-         * the logic used in the faulty SIGN(fb-fa) implementation.
+        /* * Implement Equation 6 from Ridders' paper to avoid underflow.
+         * We normalize by fa to avoid underflow in intermediate terms (fm*fm).
          */
         double ratio = fm / fa;
-        dn = -dm * ratio / sqrt(ratio * ratio - fb / fa);
+        dn = dm * ratio / sqrt(ratio * ratio - fb / fa);
 
-        xn = xm - SIGN(dn) * MIN(fabs(dn), fabs(dm) - .5*tol);
+        xn = xm + SIGN(dn) * MIN(fabs(dn), fabs(dm) - .5*tol);
         fn = (*f)(xn, func_data_param);
         solver_stats->funcalls += 2;
         if (signbit(fn) != signbit(fm)) {

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -88,3 +88,4 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
     return xn;
 }
 
+

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -21,11 +21,14 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
     int i;
     double dm,dn,xm,xn=0.0,fn,fm,fa,fb,tol;
     solver_stats->error_num = INPROGRESS;
+    solver_stats->funcalls = 0;
 
     tol = xtol + rtol*MIN(fabs(xa), fabs(xb));
+    solver_stats->funcalls++;
     fa = (*f)(xa, func_data_param);
+    solver_stats->funcalls++;
     fb = (*f)(xb, func_data_param);
-    solver_stats->funcalls = 2;
+    
     if (fa == 0) {
         solver_stats->error_num = CONVERGED;
         return xa;
@@ -45,6 +48,7 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
         
         dm = 0.5*(xb - xa);
         xm = xa + dm;
+        solver_stats->funcalls++;
         fm = (*f)(xm, func_data_param);
         
         /* * If the midpoint lands exactly on the root, exit immediately.
@@ -52,7 +56,6 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
          */
         if (fm == 0.0) {
             solver_stats->error_num = CONVERGED;
-            solver_stats->funcalls++;
             return xm;
         }
 
@@ -63,8 +66,9 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
         dn = dm * ratio / sqrt(ratio * ratio - fb / fa);
 
         xn = xm + SIGN(dn) * MIN(fabs(dn), fabs(dm) - .5*tol);
+        solver_stats->funcalls++;
         fn = (*f)(xn, func_data_param);
-        solver_stats->funcalls += 2;
+        
         if (signbit(fn) != signbit(fm)) {
             xa = xn; fa = fn; xb = xm; fb = fm;
         }

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -87,5 +87,3 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
     solver_stats->error_num = CONVERR;
     return xn;
 }
-
-

--- a/scipy/optimize/Zeros/ridder.c
+++ b/scipy/optimize/Zeros/ridder.c
@@ -87,3 +87,4 @@ ridder(callback_type f, double xa, double xb, double xtol, double rtol,
     solver_stats->error_num = CONVERR;
     return xn;
 }
+

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -213,9 +213,7 @@ class TestBracketMethods(TestScalarRootFinders):
     @pytest.mark.parametrize('method', [zeros.bisect, zeros.ridder,
                                         zeros.toms748])
     def test_chandrupatla_collection(self, method):
-        known_fail = {'fun7.4'} if method == zeros.ridder else {}
-        self.run_collection('chandrupatla', method, method.__name__,
-                            known_fail=known_fail)
+        self.run_collection('chandrupatla', method, method.__name__)
 
     @pytest.mark.parametrize('method', bracket_methods)
     def test_lru_cached_individual(self, method):

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -998,14 +998,10 @@ class TestRidderUnderflow:
     def test_gh_issue_underflow(self):
         # Regression test for underflow in Ridder's method.
         # Previously, intermediate calculations (fm*fm) would underflow 
-        # to zero before the ratio converged, causing the algorithm to 
-        # stall or fail. See Ridders' Eq 6.
+        # to zero before the ratio converged, causing a Runtime Error.
         
-        def f(x):
-            return x**5
+        def f(x): return x**5
 
-        # This specific configuration with tight tolerance forces 
-        # deep recursion where values get extremely small.
         # Before the fix, this raised a RuntimeError.
         root, result = optimize.ridder(
             f, -1, 5, 
@@ -1016,3 +1012,16 @@ class TestRidderUnderflow:
         
         assert result.converged
         assert abs(root) < 1e-10  # Ensuring zero is found
+
+    def test_early_exit_funcalls(self):
+        # Test case for when midpoint is reached early (fm == 0).
+        def f(x): return x
+
+        root, result = optimize.ridder(
+            f, -1, 1, 
+            full_output=True
+        )
+        
+        assert result.converged
+        assert root == 0.0
+        assert result.function_calls == 3

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -1029,3 +1029,5 @@ class TestRidderUnderflow:
         
         assert result.converged
         assert root == 0.0
+        assert result.function_calls == nfev
+        assert result.function_calls == 3

--- a/scipy/optimize/tests/test_zeros.py
+++ b/scipy/optimize/tests/test_zeros.py
@@ -1013,8 +1013,15 @@ class TestRidderUnderflow:
 
     def test_early_exit_funcalls(self):
         # Test case for when midpoint is reached early (fm == 0).
-        def f(x): return x
+        nfev = 0
+        def f(x):
+            nonlocal nfev
+            nfev += 1
+            return x
 
+        # Root == 0, the midpoint of [-1, 1].
+        # Calls: f(-1), f(1) [init], then f(0) [iter 1] -> Exit.
+        # Total = 3 calls.
         root, result = optimize.ridder(
             f, -1, 1, 
             full_output=True
@@ -1022,4 +1029,3 @@ class TestRidderUnderflow:
         
         assert result.converged
         assert root == 0.0
-        assert result.function_calls == 3


### PR DESCRIPTION
#### Reference issue
Closes #24425 

#### What does this implement/fix?
There was an underflow error in the Ridders' algorithm implementation. When finding zero roots, the algorithm runs into an underflow error in the denominator terms, causing a Zero Division error.

I have implemented Equation 6 from Ridders' paper. This formulation normalizes the expression by fa, calculating the ratio fm/fa. Since fm and fa scale down together, their ratio remains within a representable floating-point range, preventing the underflow.

#### Additional information
The file scipy/optimize/tests/test_zeros.py has now an extra class at the end called TestRidderUnderflow, to prove the correctness of the fix, and to ensure that any future changes do not run into the error once more.
