### PR TITLE
ENH: optimize: allow COBYQA optimization to run in parallel

### DIFF
--- a/scipy/optimize/_cobyqa_py.py
+++ b/scipy/optimize/_cobyqa_py.py
@@ -1,10 +1,8 @@
 import numpy as np
-from threading import Lock
 
 from ._optimize import _check_unknown_options
 
 
-COBYQA_LOCK = Lock()
 
 
 def _minimize_cobyqa(fun, x0, args=(), bounds=None, constraints=(),
@@ -68,5 +66,4 @@ def _minimize_cobyqa(fun, x0, args=(), bounds=None, constraints=(),
         'radius_final': float(final_tr_radius),
         'scale': bool(scale),
     }
-    with COBYQA_LOCK:
-        return minimize(fun, x0, args, bounds, constraints, callback, options)
+    return minimize(fun, x0, args, bounds, constraints, callback, options)

--- a/scipy/optimize/_cobyqa_py.py
+++ b/scipy/optimize/_cobyqa_py.py
@@ -3,8 +3,6 @@ import numpy as np
 from ._optimize import _check_unknown_options
 
 
-
-
 def _minimize_cobyqa(fun, x0, args=(), bounds=None, constraints=(),
                      callback=None, disp=False, maxfev=None, maxiter=None,
                      f_target=-np.inf, feasibility_tol=1e-8,

--- a/scipy/optimize/_cobyqa_py.py
+++ b/scipy/optimize/_cobyqa_py.py
@@ -51,7 +51,8 @@ def _minimize_cobyqa(fun, x0, args=(), bounds=None, constraints=(),
     .. [1] COBYQA
            https://www.cobyqa.com/stable/
     """
-    from .._external.cobyqa import minimize  # import here to avoid circular imports
+    # Import here to avoid circular imports
+    from .._external.cobyqa import minimize as _cobyqa_minimize
 
     _check_unknown_options(unknown_options)
     options = {
@@ -64,4 +65,4 @@ def _minimize_cobyqa(fun, x0, args=(), bounds=None, constraints=(),
         'radius_final': float(final_tr_radius),
         'scale': bool(scale),
     }
-    return minimize(fun, x0, args, bounds, constraints, callback, options)
+    return _cobyqa_minimize(fun, x0, args, bounds, constraints, callback, options)


### PR DESCRIPTION
#### Reference issue

Closes #24027

#### What does this implement/fix?

When COBYQA was first added to SciPy, there were a number of test suite failures where COBYQA would give different results randomly when run from multiple threads. COBYQA is supposed to be deterministic, so this was quite alarming. These issues went away when a lock was added in #21496, in commit dc73938784aa08ac6c3e00c850ed24a5cda24cb1.

In #24041, I fixed the issue that was causing these different results. The cause of this issue was that in order to make COBYQA faster, we asked upstream to put a cache in front of repeated calls to `scipy.linalg.eigh()`.

This cache was not locked, and could be modified concurrently by multiple threads, leading to eigh values from other threads being re-used. I solved this by submitting a patch to COBYQA which moved the eigh cache to an object that was not shared between threads.

I believe that this problem was the only remaining thread safety problem, for three reasons.

 * I have been testing the lock change using pytest-run-parallel and a free threading build, and I have seen no failures caused by removing the lock over 100 runs of the optimize test suite.
 * Upstream believes a lock is not required: they do not use a lock to serialize calls to COBYQA in their own package.
 * No-one has reported any thread safety problems to the upstream repository since the release of COBYQA 1.1.3 in November 2025.

#### Additional information