### PR TITLE
DOC: linalg: discuss batching, add examples, tutorial links

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1297,6 +1297,10 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     -----
     When ``'gelsy'`` is used as a driver, `s` is always ``None``.
 
+    Array arguments of this function, `a` and `b`, may have additional "batch"
+    dimensions prepended to the core shape. In this case, the array is treated as a
+    batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Examples
     --------
     >>> import numpy as np
@@ -1342,6 +1346,28 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     >>> plt.grid(alpha=0.25)
     >>> plt.show()
 
+    As an illustration of the "batching" feature (see :ref:`linalg_batch` for details),
+    suppose that we want to compare least-squares fits of the given data with two
+    models: a quadratic model above, and an additional linear term,
+    ``y = a + b*x**2 + c*x``.
+    To this end, we construct the design matrix for ``y = a + b*x**2 + c*x``, and
+    extend ``M`` to have three columns:
+
+    >>> M1 = np.hstack((M, np.zeros((7, 1))))
+    >>> M2 = x[:, np.newaxis] ** [0, 2, 1]
+    >>> MM = np.stack((M1, M2))
+    >>> x, res, rnk, s = lstsq(MM, y)
+    >>> x
+    array([[0.20925829, 0.12013861, 0.        ],
+           [0.0578403 , 0.11262261, 0.07701453]])
+    >>> rnk
+    array([2, 3])
+
+    Note that the rows of the ``x`` solution are equivalent to using ``M1`` and ``M2``,
+    respectively.
+    In a similar vein, to simulate an effect of random noise on ``y``, you can turn
+    it into an array with multiple columns, where each column corresponds to a specific
+    realization of the noise.
     """
 
     driver = lapack_driver

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1048,24 +1048,24 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     See :ref:`linalg_batch` for further details.
     To illustrate:
 
-    >>> a = np.stack((np.eye(2), 2*np.eye(2)))
+    >>> a = np.stack((np.eye(2), [[1, 2], [3, 4]]))
     >>> linalg.inv(a)
-    array([[[1. , 0. ],
-            [0. , 1. ]],
-           [[0.5, 0. ],
-            [0. , 0.5]]])
+    array([[[ 1. ,  0. ],
+            [ 0. ,  1. ]],
+           [[-2. ,  1. ],
+            [ 1.5, -0.5]]])
 
     Note that the structure detection runs per-slice: in the example above, each of the
     two slices will be independently discovered as being diagonal. Setting an explicit
     ``assume_a`` argument will bypass structure detection and use the provided value
     without checking:
 
-    >>> a = np.stack((np.eye(2), np.arange(1, 5).reshape(2, 2)))
+    >>> a = np.stack((np.eye(2), [[1, 2], [3, 4]]))
     >>> linalg.inv(a, assume_a="diagonal")
     array([[[1.  , 0.  ],
-        [0.  , 1.  ]],
-       [[1.  , 2.  ],      # off-diagonal elements are incorrect
-        [3.  , 0.25]]])
+            [0.  , 1.  ]],
+           [[1.  , 2.  ],   # off-diagonal elements are incorrect
+            [3.  , 0.25]]])
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
 
@@ -1348,7 +1348,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 
     As an illustration of the "batching" feature (see :ref:`linalg_batch` for details),
     suppose that we want to compare least-squares fits of the given data with two
-    models: a quadratic model above, and an additional linear term,
+    models: a quadratic model above, and one with an additional linear term,
     ``y = a + b*x**2 + c*x``.
     To this end, we construct the design matrix for ``y = a + b*x**2 + c*x``, and
     extend ``M`` to have three columns:

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -976,9 +976,9 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     Likewise, an explicit `assume_a='diagonal'` means that off-diagonal elements
     are not referenced.
 
-    Array argument(s) of this function may have additional
-    "batch" dimensions prepended to the core shape. In this case, the array is treated
-    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+    The `a` array argument may have additional "batch" dimensions prepended to the core
+    shape. In this case, the array is treated as a batch of lower-dimensional slices;
+    see :ref:`linalg_batch` for details.
 
     Parameters
     ----------
@@ -1015,10 +1015,6 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     Notes
     -----
 
-    The input array ``a`` may represent a single matrix or a collection (a.k.a.
-    a "batch") of square matrices. For example, if ``a.shape == (4, 3, 2, 2)``, it is
-    interpreted as a ``(4, 3)``-shaped batch of :math:`2\times 2` matrices.
-
     This routine checks the condition number of the `a` matrix and emits a
     `LinAlgWarning` for ill-conditioned inputs.
 
@@ -1030,9 +1026,34 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     >>> linalg.inv(a)
     array([[-2. ,  1. ],
            [ 1.5, -0.5]])
-    >>> np.dot(a, linalg.inv(a))
+    >>> a @ linalg.inv(a)
     array([[ 1.,  0.],
            [ 0.,  1.]])
+
+    The input array ``a`` may represent a single matrix or a collection (a.k.a.
+    a "batch") of square matrices. For example, if ``a.shape == (4, 3, 2, 2)``, it is
+    interpreted as a ``(4, 3)``-shaped batch of :math:`2\times 2` matrices.
+    See :ref:`linalg_batch` for further details.
+    To illustrate:
+
+    >>> a = np.stack((np.eye(2), 2*np.eye(2)))
+    >>> linalg.inv(a)
+    array([[[1. , 0. ],
+            [0. , 1. ]],
+           [[0.5, 0. ],
+            [0. , 0.5]]])
+
+    Note that the structure detection runs per-slice: in the example above, each of the
+    two slices will be independently discovered as being diagonal. Setting an explicit
+    ``assume_a`` argument will bypass structure detection and use the provided value
+    without checking:
+
+    >>> a = np.stack((np.eye(2), np.arange(1, 5).reshape(2, 2)))
+    >>> linalg.inv(a, assume_a="diagonal")
+    array([[[1.  , 0.  ],
+        [0.  , 1.  ]],
+       [[1.  , 2.  ],      # off-diagonal elements are incorrect
+        [3.  , 0.25]]])
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -157,6 +157,7 @@ def solve(a, b, lower=False, overwrite_a=False,
     array([ True,  True,  True], dtype=bool)
 
     Batches of matrices are supported, with and without structure detection:
+    (See :ref:`linalg_batch` for further details of handling batched inputs.)
 
     >>> a = np.arange(12).reshape(3, 2, 2)   # a batch of 3 2x2 matrices
     >>> A = a.transpose(0, 2, 1) @ a    # A is a batch of 3 positive definite matrices
@@ -169,6 +170,17 @@ def solve(a, b, lower=False, overwrite_a=False,
     array([[ 1. , -0.5],
            [ 3. , -2.5],
            [ 5. , -4.5]])
+
+    Note that the structure detection runs per-slice: in the example above, each of the
+    two slices will be independently discovered as being positive definite. Setting an
+    explicit ``assume_a`` argument bypasses structure detection and uses the provided
+    value without checking:
+
+    >>> a = np.stack((np.eye(2), np.arange(1, 5).reshape(2, 2)))
+    >>> b = [1, 1]
+    >>> solve(a, b, assume_a="diagonal")
+    array([[1.  , 1.  ],
+           [1.  , 0.25]])   # the second row is incorrect
     """
     # keep the numbers in sync with C
     structure = {

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -136,6 +136,12 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     eigh_tridiagonal : eigenvalues and right eigenvectors for
         symmetric/Hermitian tridiagonal matrices
 
+    Notes
+    -----
+    Array arguments of this function, `a` and `b`, may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Examples
     --------
     >>> import numpy as np

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -94,7 +94,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
 
     Notes
     -----
-    Array argument of this function, `a`, may have additional
+    The array argument of this function, `a`, may have additional
     "batch" dimensions prepended to the core shape. In this case, the array is treated
     as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
 

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -92,6 +92,12 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     svdvals : Compute singular values of a matrix.
     diagsvd : Construct the Sigma matrix, given the vector s.
 
+    Notes
+    -----
+    Array argument of this function, `a`, may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Examples
     --------
     >>> import numpy as np
@@ -126,6 +132,14 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     >>> np.allclose(s, s2)
     True
 
+    If the input matrix has more than two dimensions, it is interpreted as a batch of
+    two-dimensional matrices:
+
+    >>> aa = np.stack((a, 2*a))
+    >>> linalg.svdvals(aa)[0] == linalg.svdvals(a)
+    array([ True,  True,  True,  True,  True,  True])
+    >>> linalg.svdvals(aa)[1] == 2 * linalg.svdvals(a)
+    array([ True,  True,  True,  True,  True,  True])
     """
     if not isinstance(lapack_driver, str):
         raise TypeError('lapack_driver must be a string')
@@ -224,6 +238,12 @@ def svdvals(a, overwrite_a=False, check_finite=True):
     svd : Compute the full singular value decomposition of a matrix.
     diagsvd : Construct the Sigma matrix, given the vector s.
 
+    Notes
+    -----
+    Array argument of this function, `a`, may have additional
+    "batch" dimensions prepended to the core shape. In this case, the array is treated
+    as a batch of lower-dimensional slices; see :ref:`linalg_batch` for details.
+
     Examples
     --------
     >>> import numpy as np
@@ -235,6 +255,14 @@ def svdvals(a, overwrite_a=False, check_finite=True):
     ...               [1.0, 0.0]])
     >>> svdvals(m)
     array([ 4.28091555,  1.63516424])
+
+    If the input matrix has more than two dimensions, it is interpreted as a batch of
+    two-dimensional matrices:
+
+    >>> mm = np.stack((m, 2*m))
+    >>> svdvals(mm)
+    array([[4.28091555, 1.63516424],
+           [8.56183109, 3.27032847]])
 
     We can verify the maximum singular value of `m` by computing the maximum
     length of `m @ u` over all the unit vectors `u` in the (x,y) plane.
@@ -263,7 +291,6 @@ def svdvals(a, overwrite_a=False, check_finite=True):
     >>> orth = ortho_group.rvs(4)
     >>> svdvals(orth)
     array([ 1.,  1.,  1.,  1.])
-
     """
     return svd(a, compute_uv=0, overwrite_a=overwrite_a,
                check_finite=check_finite)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

As discussed at https://github.com/scipy/scipy/pull/24263#discussion_r2749252093

#### What does this implement/fix?
<!--Please explain your changes.-->

1. Add links to the batching tutorial, where missing after removing `@apply_over_batch`
2. Add examples
3. Add examples of `assume_a` interacting/interfering with batching.

#### Additional information
<!--Any additional information you think is important.-->

In most cases this placed the batching note in the `Notes` section. Especially where the extended description is one or two lines. Where it's already long, left it there and/or added a longer discussion closer to examples.
Don't have a strong opinion though.
