### PR TITLE
ENH: stats.moment: simplify implementation; enable JIT

### DIFF
--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -418,7 +418,7 @@ def _statistic_dunnett(
     all_means = np.concatenate([[mean_control], mean_samples])
 
     # Variance estimate s^2 from [1] Eq. 1
-    s2 = np.sum([_var(sample, center=mean)*sample.size
+    s2 = np.sum([_var(sample, mean=mean)*sample.size
                  for sample, mean in zip(all_samples, all_means)]) / df
     std = np.sqrt(s2)
 

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -418,7 +418,7 @@ def _statistic_dunnett(
     all_means = np.concatenate([[mean_control], mean_samples])
 
     # Variance estimate s^2 from [1] Eq. 1
-    s2 = np.sum([_var(sample, mean=mean)*sample.size
+    s2 = np.sum([_var(sample, center=mean)*sample.size
                  for sample, mean in zip(all_samples, all_means)]) / df
     std = np.sqrt(s2)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1180,10 +1180,11 @@ def _moment(a, order, axis, *, center=None, xp=None):
     """
     xp = array_namespace(a) if xp is None else xp
 
+    order = xp.asarray(order, dtype=a.dtype, device=xp_device(a))
     order_0 = order == 0
     order_1 = (order == 1) & (center is None)
     center = xp.mean(a, axis=axis, keepdims=True) if center is None else center
-    a_zero_mean = _demean(a, center, axis, precision_warning=False, xp=xp)
+    a_zero_mean = _demean(a, center, axis, xp=xp)
     res = xp.mean(a_zero_mean**order, axis=axis, keepdims=True)
     if is_lazy_array(res) or xp.any(order_0) or xp.any(order_1):
         res = xp.where(order_0, xp.ones_like(res), res)
@@ -1511,6 +1512,7 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
     mm = (xp.min(a, axis=axis), xp.max(a, axis=axis))
     m = xp.mean(a, axis=axis)
     v = _var(a, axis=axis, ddof=ddof, xp=xp)
+    v = v[()] if v.ndim == 0 else v
     sk = skew(a, axis, bias=bias)
     kurt = kurtosis(a, axis, bias=bias)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1186,7 +1186,8 @@ def _moment(a, order, axis, *, center=None, xp=None):
     center = xp.mean(a, axis=axis, keepdims=True) if center is None else center
     a_zero_mean = _demean(a, center, axis, xp=xp)
     res = xp.mean(a_zero_mean**order, axis=axis, keepdims=True)
-    if is_lazy_array(res) or xp.any(order_0) or xp.any(order_1):
+    if a.shape[-1] > 0 and (is_lazy_array(res)
+                                or xp.any(order_0) or xp.any(order_1)):
         res = xp.where(order_0, xp.ones_like(res), res)
         res = xp.where(order_1, xp.zeros_like(res), res)
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3687,16 +3687,20 @@ class TestMoments:
         y = stats.moment(x, order=order)
         xp_assert_equal(y, xp.asarray(expect, dtype=dtype))
 
-        y = stats.moment(xp.broadcast_to(x, (6, 5)), axis=0, order=order)
-        xp_assert_equal(y, xp.full((5,), expect, dtype=dtype))
+        message = "Precision loss occurred in moment calculation"
+        with eager_warns(RuntimeWarning, match=message, xp=xp):
+            y = stats.moment(xp.broadcast_to(x, (6, 5)), axis=0, order=order)
+            xp_assert_equal(y, xp.full((5,), expect, dtype=dtype))
 
-        y = stats.moment(xp.broadcast_to(x, (1, 2, 3, 4, 5)), axis=2,
-                         order=order)
-        xp_assert_equal(y, xp.full((1, 2, 4, 5), expect, dtype=dtype))
+        with eager_warns(RuntimeWarning, match=message, xp=xp):
+            y = stats.moment(xp.broadcast_to(x, (1, 2, 3, 4, 5)), axis=2,
+                             order=order)
+            xp_assert_equal(y, xp.full((1, 2, 4, 5), expect, dtype=dtype))
 
         y = stats.moment(xp.broadcast_to(x, (1, 2, 3, 4, 5)), axis=None,
                          order=order)
         xp_assert_equal(y, xp.full((), expect, dtype=dtype))
+
 
     def test_moment_propagate_nan(self, xp):
         # Check that the shape of the result is the same for inputs
@@ -3760,7 +3764,7 @@ class TestSkew(SkewKurtosisTest):
         return stats.skew(x)
 
     @pytest.mark.filterwarnings(
-        "ignore:invalid value encountered in scalar divide:RuntimeWarning:dask"
+        "ignore:invalid value encountered:RuntimeWarning:dask"
     )
     def test_skewness(self, xp):
         # Scalar test case
@@ -3857,7 +3861,7 @@ class TestKurtosis(SkewKurtosisTest):
     def stat_fun(self, x):
         return stats.kurtosis(x)
 
-    @pytest.mark.filterwarnings("ignore:invalid value encountered in scalar divide")
+    @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning:dask")
     def test_kurtosis(self, xp):
         # Scalar test case
         y = stats.kurtosis(xp.asarray(self.scalar_testcase))

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3724,7 +3724,7 @@ class TestMoments:
 
     @pytest.mark.parametrize('order', [0, 1, 2, 3])
     @pytest.mark.parametrize('axis', [-1, 0, 1])
-    @pytest.mark.parametrize('center', [None, 0])
+    @pytest.mark.parametrize('center', [None, 0.])
     @pytest.mark.filterwarnings(
         "ignore:divide by zero encountered in divide:RuntimeWarning:dask"
     )
@@ -3732,7 +3732,8 @@ class TestMoments:
         rng = np.random.default_rng(34823589259425)
         x = rng.random(size=(5, 6, 7))
         res = stats.moment(xp.asarray(x), order, axis=axis, center=center)
-        ref = xp.asarray(_moment(x, order, axis, mean=center))
+        center = center if center is None else np.asarray(center)
+        ref = xp.asarray(_moment(x, order, axis, center=center)[()])
         xp_assert_close(res, ref)
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3701,7 +3701,6 @@ class TestMoments:
                          order=order)
         xp_assert_equal(y, xp.full((), expect, dtype=dtype))
 
-
     def test_moment_propagate_nan(self, xp):
         # Check that the shape of the result is the same for inputs
         # with and without nans, cf gh-5817


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
This first commit simplifies the implementation of `_moment`. Previously, it used exponentiation by squares for each order separately. When `order` is an array, this is problematic for the JIT because it requires looping over values in `order`. I switched to taking the power with the `**` operator and no tests failed, so it must not have been that important. I sure hope we can trust the `**` operator to be fast and accurate for integral powers in modern array libraries.

The second commit enables use of JAX JIT with `scipy.stats.moment`.

#### Additional information
I also took the opportunity to rename the argument `mean` to `center`, since it is for use with arbitrary center, not necessarily the mean.


