### PR TITLE
ENH: stats.lmoment: enable JIT

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10366,8 +10366,8 @@ def _lmoment_iv(sample, order, axis, sorted, standardize, xp):
 
     message = "`order` must be a scalar or a non-empty array of positive integers."
     order = xp.arange(1, 5) if order is None else xp.asarray(order)
-    if (not xp.isdtype(order.dtype, "integral") or xp.any(order <= 0)
-            or order.size == 0 or order.ndim > 1):
+    if (not xp.isdtype(order.dtype, "integral") or order.size == 0 or order.ndim > 1
+            or (not is_lazy_array(order) and xp.any(order <= 0))):
         raise ValueError(message)
 
     # input validation of non-array types can still be performed with NumPy
@@ -10402,21 +10402,24 @@ def _br(x, *, r=0, xp):
     x = xp.triu(x)
     j = xp.arange(n, dtype=x.dtype)
     n = xp.asarray(n, dtype=x.dtype)[()]
-    return (xp.vecdot(special.binom(j, r[:, xp.newaxis]), x, axis=-1)
-            / special.binom(n-1, r) / n)
+    binom_j_r = xpx.lazy_apply(special.binom, j, r[:, xp.newaxis])
+    binom_nm1_r = xpx.lazy_apply(special.binom, n-1, r)
+    return xp.vecdot(binom_j_r, x, axis=-1) / binom_nm1_r / n
 
 
 def _prk(r, k):
     # Writen to match [1] Equation 27 closely to facilitate review.
     # This does not protect against overflow, so improvements to
     # robustness would be a welcome follow-up.
-    return (-1)**(r-k)*special.binom(r, k)*special.binom(r+k, k)
+    binom_r_k = xpx.lazy_apply(special.binom, r, k, as_numpy=True)
+    binom_rpk_k = xpx.lazy_apply(special.binom, r+k, k, as_numpy=True)
+    return (-1)**(r-k)*binom_r_k*binom_rpk_k
 
 
 @xp_capabilities(skip_backends=[('dask.array', "too many issues")],
-                 jax_jit=False,  # uses arange(max(order))
                  cpu_only=True,  # torch doesn't have `binom`
-                 exceptions=('cupy', 'jax.numpy'))
+                 exceptions=('cupy', 'jax.numpy'),
+                 extra_note="Lazy backends do not support `order` greater than 4.")
 @_axis_nan_policy_factory(  # noqa: E302
     _moment_result_object, n_samples=1, result_to_tuple=_moment_tuple,
     n_outputs=lambda kwds: _moment_outputs(kwds, [1, 2, 3, 4])
@@ -10495,7 +10498,7 @@ def lmoment(sample, order=None, *, axis=0, sorted=False, standardize=True):
     args = _lmoment_iv(sample, order, axis, sorted, standardize, xp=xp)
     sample, order, axis, sorted, standardize = args
 
-    n_moments = int(xp.max(order))
+    n_moments = 4 if is_lazy_array(order) else int(xp.max(order))
     k = xp.arange(n_moments, dtype=sample.dtype)
     prk = _prk(xpx.expand_dims(k, axis=tuple(range(1, sample.ndim+1))), k)
     bk = _br(sample, r=k, xp=xp)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10411,8 +10411,8 @@ def _prk(r, k):
     # Writen to match [1] Equation 27 closely to facilitate review.
     # This does not protect against overflow, so improvements to
     # robustness would be a welcome follow-up.
-    binom_r_k = xpx.lazy_apply(special.binom, r, k, as_numpy=True)
-    binom_rpk_k = xpx.lazy_apply(special.binom, r+k, k, as_numpy=True)
+    binom_r_k = xpx.lazy_apply(special.binom, r, k)
+    binom_rpk_k = xpx.lazy_apply(special.binom, r+k, k)
     return (-1)**(r-k)*binom_r_k*binom_rpk_k
 
 

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -41,7 +41,7 @@ from scipy.conftest import skip_xp_invalid_arg
 from scipy._lib._array_api import (array_namespace, eager_warns, is_lazy_array,
                                    is_numpy, is_torch, xp_default_dtype, xp_size,
                                    SCIPY_ARRAY_API, make_xp_test_case, xp_ravel,
-                                   xp_swapaxes, xp_result_type, xp_copy)
+                                   xp_swapaxes, xp_result_type, xp_copy, is_jax)
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal, xp_assert_less
 import scipy._external.array_api_extra as xpx
 
@@ -9300,6 +9300,8 @@ class TestLMoment:
 
     @pytest.mark.parametrize('order', not_integers + [0, -1, [], [[1, 2, 3]]])
     def test_order_iv(self, order, xp):
+        if is_jax(xp) and np.isscalar(order) and order < 1:
+            pytest.skip("Order is treated as an array; can't do value-based IV")
         message = '`order` must be a scalar or a non-empty...'
         with pytest.raises(ValueError, match=message):
             stats.lmoment(xp.asarray(self.data), order=order)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
This enables use of JAX JIT with `scipy.stats.lmoment`. 

#### Additional information
`lmoment` wants to use `arange` up to the maximum element of `order`. `order` is treated as an array, so this won't work with lazy backends. The solution here is to just use `4` for lazy backends, which is probably a reasonable bound on the orders of L-moments for typical use. We could bend over backwards to treat `order` separately as an `int`, non-array sequence, or array based on what is passed in, but I don't think it is worth the effort at this time. If someone requests it, we can always add the capability in the future.

