### PR TITLE
DOC: stats.nhypergeom: fix erratum in distribution support

### DIFF
--- a/doc/source/tutorial/stats/discrete_nhypergeom.rst
+++ b/doc/source/tutorial/stats/discrete_nhypergeom.rst
@@ -10,7 +10,7 @@ Consider a box containing :math:`M` balls: :math:`n` red and :math:`M-n` blue. W
    :nowrap:
 
     \begin{eqnarray*}
-    p(k;M,n,r) & = & \frac{\left(\begin{array}{c} k+r-1\\ k\end{array}\right)\left(\begin{array}{c} M-r-k\\ n-k\end{array}\right)}{\left(\begin{array}{c} M\\ n\end{array}\right)}\quad 0 \leq k \leq M-n,\\
+    p(k;M,n,r) & = & \frac{\left(\begin{array}{c} k+r-1\\ k\end{array}\right)\left(\begin{array}{c} M-r-k\\ n-k\end{array}\right)}{\left(\begin{array}{c} M\\ n\end{array}\right)}\quad 0 \leq k \leq n,\\
     F(x;M,n,r) & = & \sum_{k=0}^{\left\lfloor x\right\rfloor }p\left(k;M,n,r\right),\\
     \mu & = & \frac{rn}{M-n+1},\\
     \mu_{2} & = & \frac{rn(M+1)}{(M-n+1)(M-n+2)}\left(1-\frac{r}{M-n+1}\right)


### PR DESCRIPTION
#### Reference issue
Closes gh-24477

#### What does this implement/fix?
Fixes mistake in the support of the distribution shown in the tutorial.

#### Additional information
Implementation is correct:
https://github.com/scipy/scipy/blob/8c75ae75176236f233824e9a0483c26a69e6dfec/scipy/stats/_discrete_distns.py#L844-L845

Docstring is correct:
<img width="787" height="180" alt="image" src="https://github.com/user-attachments/assets/0c35724a-42ad-44c7-9f42-a8ff29796dc0" />
