### PR TITLE
ENH: stats.kstest: add array API support

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8149,7 +8149,8 @@ def _kstest_n_samples(kwargs):
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=_kstest_n_samples,
                           n_outputs=4, result_to_tuple=_KstestResult_to_tuple)
 @_rename_parameter("mode", "method")
-def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', method='auto'):
+def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', method='auto', *,
+           axis=0):
     """
     Performs the (one-sample or two-sample) Kolmogorov-Smirnov test for
     goodness of fit.
@@ -8337,9 +8338,9 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', method='auto'):
     xvals, yvals, cdf = _parse_kstest_args(rvs, cdf, args, N)
     if cdf:
         return ks_1samp(xvals, cdf, args=args, alternative=alternative,
-                        method=method, _no_deco=True)
+                        method=method, axis=axis, _no_deco=True)
     return ks_2samp(xvals, yvals, alternative=alternative, method=method,
-                    _no_deco=True)
+                    axis=axis, _no_deco=True)
 
 
 @xp_capabilities(np_only=True)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8126,7 +8126,8 @@ def _parse_kstest_args(data1, data2, args, N):
         rvsfunc = data1
 
     if isinstance(data2, str):
-        cdf = getattr(distributions, data2).cdf
+        special_distributions = {'norm': special.ndtr}
+        cdf = special_distributions.get(data2, getattr(distributions, data2).cdf)
         data2 = None
     elif callable(data2):
         cdf = data2
@@ -8142,7 +8143,9 @@ def _kstest_n_samples(kwargs):
     return 1 if (isinstance(cdf, str) or callable(cdf)) else 2
 
 
-@xp_capabilities(out_of_scope=True)
+@xp_capabilities(skip_backends=[('cupy', 'no rankdata'),
+                                ('dask.array', 'no rankdata')],
+                 jax_jit=False, cpu_only=True)  # see ks_1samp/ks_2samp
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=_kstest_n_samples,
                           n_outputs=4, result_to_tuple=_KstestResult_to_tuple)
 @_rename_parameter("mode", "method")

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -4631,6 +4631,8 @@ class TestKSTest:
                                       alternative=alternative, mode=mode)
         xp_assert_close(result.statistic, result_1samp.statistic)
         xp_assert_close(result.pvalue, result_1samp.pvalue)
+        xp_assert_equal(result.statistic_location, result.statistic_location)
+        xp_assert_equal(result.statistic_sign, result.statistic_sign)
 
     def test_namedtuple_attributes(self, xp):
         x = xp.linspace(-1, 1, 9)
@@ -4652,6 +4654,21 @@ class TestKSTest:
         self._test_kstest_and_ks1samp(x, 'greater', mode='exact')
         self._test_kstest_and_ks1samp(x, 'less', mode='exact')
 
+    # parametrize over function-specific options to make sure they're passed through;
+    # `test_axis_nan_policy` takes care of the rest.
+    @pytest.mark.parametrize("method", ["auto", "exact", "asymp"])
+    @pytest.mark.parametrize("alternative", ['two-sided', 'less', 'greater'])
+    def test_agree_with_ks_2samp(self, method, alternative, xp):
+        rng = np.random.default_rng(236114087)
+        x, y = rng.random((2, 9, 10))
+        x, y = xp.asarray(x), xp.asarray(y)
+        res = stats.kstest(x, y, alternative=alternative, method=method)
+        ref = stats.ks_2samp(x, y, alternative=alternative, method=method)
+        xp_assert_equal(res.statistic, ref.statistic)
+        xp_assert_equal(res.pvalue, ref.pvalue)
+        xp_assert_equal(res.statistic_location, ref.statistic_location)
+        xp_assert_equal(res.statistic_sign, ref.statistic_sign)
+
     def test_pm_inf_gh20386(self, xp):
         # Check that gh-20386 is resolved - `kstest` does not
         # return NaNs when both -inf and inf are in sample.
@@ -4664,7 +4681,7 @@ class TestKSTest:
         assert xp.isfinite(res.pvalue)
         assert xp.isfinite(res.statistic_location)
         assert xp.isfinite(res.statistic_sign)
-        xp_assert_equal(res.statistic, res.statistic)
+        xp_assert_equal(res.statistic, ref.statistic)
         xp_assert_equal(res.pvalue, ref.pvalue)
         xp_assert_equal(res.statistic_location, ref.statistic_location)
         xp_assert_equal(res.statistic_sign, ref.statistic_sign)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `scipy.stats.kstest`.

#### Additional information
~~I should probably add a test that this delegates to `ks_2samp` properly, then I'll mark as ready for review.~~ All set.
