### PR TITLE
BLD: add scipy-doctest dependency

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -444,9 +444,9 @@ def smoke_docs(*, parent_callback, pytest_args, **kwargs):
     # prevent obscure error later; cf https://github.com/numpy/numpy/pull/26691/
     if (
         not importlib.util.find_spec("scipy_doctest")
-        or importlib.metadata.version("scipy_doctest") < "1.8.0"
+        or importlib.metadata.version("scipy_doctest") < "2.0.0"
     ):
-        raise ModuleNotFoundError("Please install scipy-doctest>=1.8.0")
+        raise ModuleNotFoundError("Please install scipy-doctest>=2.0.0")
 
     tests = kwargs["tests"]
     if kwargs["submodule"]:

--- a/environment.yml
+++ b/environment.yml
@@ -55,6 +55,7 @@ dependencies:
   - mpmath
   - gmpy2
   - threadpoolctl
+  - scipy-doctest>=2.0.0
   # For CLI
   - spin
   - click<8.3.0  # transitive dependency of `spin`, 8.3.0 is breaking (see gh-23642)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ test = [
     "Cython",
     "meson",
     'ninja; sys_platform != "emscripten"',
+    "scipy-doctest>=2.0.0"
 ]
 doc = [
     "sphinx>=5.0.0,<8.2.0",

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,3 +15,4 @@ array-api-strict>=2.3.1
 Cython
 meson
 ninja; sys_platform != "emscripten"
+scipy-doctest>=2.0.0


### PR DESCRIPTION
#### Reference issue
Closes #24468 

#### What does this implement/fix?
Adds the `scipy-doctest` dependency to the build dependency files in the respective sections. With this change, I can run `spin smoke-docs` locally using the mamba environment.
