### PR TITLE
MAINT: stats: more tolerance adjustments to accommodate Accelerate

### DIFF
--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -494,8 +494,8 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
             res = hypotest(*data1d, *args, nan_policy=nan_policy, **kwds)
         res_1db = unpacker(res)
 
-        # changed from 1e-15 solely to appease macosx-x86_64+Accelerate
-        assert_allclose(res_1db, res_1da, rtol=4e-15)
+        # changed from 1e-15 and later from 4e-15 to appease macosx-x86_64+Accelerate
+        assert_allclose(res_1db, res_1da, rtol=1e-14)
         res_1d[i] = res_1db
 
     res_1d = np.moveaxis(res_1d, -1, 0)

--- a/scipy/stats/tests/test_qmc.py
+++ b/scipy/stats/tests/test_qmc.py
@@ -963,8 +963,9 @@ class TestPoisson(QMCEngineTests):
         engine = self.qmce(d=2, radius=radius, l_bounds=l_bounds, u_bounds=u_bounds)
 
         sample = engine.fill_space()
-        # circle packing problem is np complex
-        assert l2_norm(sample) >= radius
+        # rtol to accommodate Accelerate; see gh-24486
+        rtol = 1e-7
+        assert l2_norm(sample) >= radius * (1 - rtol)
 
     def test_bounds_shift_scale(self):
         # test a reasonable property: as long as shape of region is a hypercube,


### PR DESCRIPTION
#### Reference issue
Closes gh-24486
gh-24487

#### What does this implement/fix?
gh-24486 reported a test failure stemming from Accelerate's loose adherence to the rules of arithmetic. I saw a separate failure in gh-24487 today. This PR adjusts the tolerances to avoid red in CI.

#### Additional information
<!--Any additional information you think is important.-->
