### PR TITLE
MAINT: detach IS_PYPY from numpy.testing

### DIFF
--- a/scipy/_lib/_gcutils.py
+++ b/scipy/_lib/_gcutils.py
@@ -103,3 +103,23 @@ def assert_deallocated(func, *args, **kwargs):
         del obj
         if ref() is not None:
             raise ReferenceError("Remaining reference(s) to object")
+
+def break_cycles():
+    """
+    Break reference cycles by calling gc.collect
+    Objects can call other objects' methods (for instance, another object's
+     __del__) inside their own __del__. On PyPy, the interpreter only runs
+    between calls to gc.collect, so multiple calls are needed to completely
+    release all cycles.
+    """
+
+    gc.collect()
+    if IS_PYPY:
+        # a few more, just to make sure all the finalizers are called
+        gc.collect()
+        gc.collect()
+        gc.collect()
+        gc.collect()
+
+
+

--- a/scipy/io/tests/test_netcdf.py
+++ b/scipy/io/tests/test_netcdf.py
@@ -9,12 +9,13 @@ from glob import glob
 from contextlib import chdir, contextmanager
 
 import numpy as np
-from numpy.testing import (assert_, assert_allclose, assert_equal,
-                           break_cycles, IS_PYPY)
+from numpy.testing import assert_, assert_allclose, assert_equal
+
 import pytest
 from pytest import raises as assert_raises
 
 from scipy.io import netcdf_file
+from scipy._lib._gcutils import IS_PYPY, break_cycles
 
 TEST_DATA_PATH = pjoin(dirname(__file__), 'data')
 
@@ -163,7 +164,6 @@ def test_read_write_files():
         if IS_PYPY:
             # windows cannot remove a dead file held by a mmap
             # that has not been collected in PyPy
-            break_cycles()
             break_cycles()
         os.chdir(cwd)
         shutil.rmtree(tmpdir)

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -5,12 +5,13 @@ import threading
 import warnings
 
 import numpy as np
-from numpy.testing import (assert_equal, assert_, assert_array_equal,
-                           break_cycles, IS_PYPY)
+from numpy.testing import assert_equal, assert_, assert_array_equal
+
 import pytest
 from pytest import raises, warns
 
 from scipy.io import wavfile
+from scipy._lib._gcutils import IS_PYPY, break_cycles
 
 
 def datafile(fn):

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -5,7 +5,7 @@ import warnings
 import numpy as np
 import time
 from multiprocessing import Pool
-from numpy.testing import assert_allclose, IS_PYPY
+from numpy.testing import assert_allclose
 import pytest
 from pytest import raises as assert_raises, warns
 from scipy.optimize import (shgo, Bounds, minimize_scalar, minimize, rosen,
@@ -13,6 +13,8 @@ from scipy.optimize import (shgo, Bounds, minimize_scalar, minimize, rosen,
 from scipy.optimize._constraints import new_constraint_to_old
 from scipy.optimize._shgo import SHGO
 from scipy.optimize.tests.test_minimize_constrained import MaratosTestArgs
+
+IS_PYPY = sys.implementation.name == 'pypy'
 
 
 class StructTestFunction:


### PR DESCRIPTION
NumPy would like to drop support for PyPy, since PyPy will not be releasing a 3.12, and support will slowly bitrot. See numpy/numpy#30416. It turns out SciPy uses `IS_PYPY` for testing from `numpy.testing`, discovered in mypy from [this PR](https://github.com/numpy/numpy/pull/30764#issuecomment-3832326113) It is straight-forward to use a local definition of `IS_PYPY`, or to use `scipy._lib._gcutils`.


I could also submit a PR to drop PyPy support in Scipy. Whichever the maintainers prefer. Perhaps both this now, and another larger PR to drop PyPy support.