### PR TITLE
BLD: remove use of `xsimd_dep` to deal with unvendored xsimd from pythran

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,11 +183,7 @@ tempita = find_program('scipy/_build_utils/tempita.py')
 
 use_pythran = get_option('use-pythran')
 if use_pythran
-  pythran = find_program('pythran', native: true, version: '>=0.14.0')
-  # xsimd is unvendored from pythran by conda-forge, and due to a compiler
-  # activation bug the default <prefix>/include/ may not be visible (see
-  # gh-15698). Hence look for xsimd explicitly.
-  xsimd_dep = dependency('xsimd', required: false)
+  pythran = find_program('pythran', native: true, version: '>=0.18.1')
 endif
 
 # Subprojects

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires = [
     "meson-python>=0.15.0",
     "Cython>=3.0.8",        # when updating version, also update check in meson.build
     "pybind11>=2.13.2",     # when updating version, also update check in scipy/meson.build
-    "pythran>=0.14.0",
+    "pythran>=0.18.1",      # when updating version, also update check in meson.build
 
     # numpy requirement for wheel builds for distribution on PyPI - building
     # against 2.x yields wheels that are also compatible with numpy 1.x at

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -121,7 +121,6 @@ print(incdir)
   endif
   pythran_dep = declare_dependency(
     include_directories: incdir_pythran,
-    dependencies: xsimd_dep,
   )
 else
   pythran_dep = []


### PR DESCRIPTION
That can cause the build to break if `xsimd` is installed globally, as discussed in gh-19085 (hat tip to @rkern for explaining the root cause).

The reason for adding that `xsimd_dep` check was only to deal with conda-forge having unvendored xsimd from pythran at some point; that has been reverted for quite a while already.

Also using this change to bump the minimum `pythran` version; there's no need to support very old versions, and we may be running into issues that are not covered in CI.

Closes gh-19085