### PR TITLE
BUG: sparse: Fix CSR/C index broadcasting 

### DIFF
--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -89,10 +89,10 @@ class IndexMixin:
             elif isinstance(col, slice):
                 res = self._get_arrayXslice(row, col)
             # arrayXarray preprocess
-            elif (row.ndim == 2 and row.shape[1] == 1
-                and (col.ndim == 1 or col.shape[0] == 1)):
+            elif (row.ndim == 2 and (key0 := np.atleast_2d(key[0])).shape[1] == 1
+                  and (col.ndim == 1 or (key1 := np.array(key[1])).shape[0] == 1)):
                 # outer indexing
-                res = self._get_columnXarray(row[:, 0], col.ravel())
+                res = self._get_columnXarray(key0[:, 0], key1.reshape(-1))
             else:
                 # inner indexing
                 row, col = _broadcast_arrays(row, col)

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -114,12 +114,12 @@ def test_csr_bool_indexing():
     assert (slice_list3 == slice_array3).all()
 
 
-@pytest.mark.parametrize("cls", [csr_matrix, csr_array, csc_matrix, csc_array])
 @pytest.mark.timeout(2)  # only slow when broken (conversion to 2d index arrays)
+@pytest.mark.parametrize("cls", [csr_matrix, csr_array, csc_matrix, csc_array])
 def test_fancy_indexing_broadcasts_without_making_dense_2d(cls):
-    I = np.arange(100_000).reshape((100_000, 1))
+    I = np.arange(46340).reshape((46340, 1))
     J = I.T
-    S = cls((100_000, 100_000))
+    S = cls((46340, 46340))
     # testing nnz, but really testing indexing. Should blow up memory needs
     assert S[I, J].nnz == 0
 

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -114,6 +114,16 @@ def test_csr_bool_indexing():
     assert (slice_list3 == slice_array3).all()
 
 
+@pytest.mark.parametrize("cls", [csr_matrix, csr_array, csc_matrix, csc_array])
+@pytest.mark.timeout(2)  # only slow when broken (conversion to 2d index arrays)
+def test_fancy_indexing_broadcasts_without_making_dense_2d(cls):
+    I = np.arange(100_000).reshape((100_000, 1))
+    J = I.T
+    S = cls((100_000, 100_000))
+    # testing nnz, but really testing indexing. Should blow up memory needs
+    assert S[I, J].nnz == 0
+
+
 def test_csr_hstack_int64():
     """
     Tests if hstack properly promotes to indices and indptr arrays to np.int64

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -114,12 +114,13 @@ def test_csr_bool_indexing():
     assert (slice_list3 == slice_array3).all()
 
 
+@pytest.mark.xfail_on_32bit("Can't create large array for test")
 @pytest.mark.timeout(2)  # only slow when broken (conversion to 2d index arrays)
 @pytest.mark.parametrize("cls", [csr_matrix, csr_array, csc_matrix, csc_array])
 def test_fancy_indexing_broadcasts_without_making_dense_2d(cls):
-    I = np.arange(46340).reshape((46340, 1))
+    I = np.arange(100_000).reshape((100_000, 1))
     J = I.T
-    S = cls((46340, 46340))
+    S = cls((100_000, 100_000))
     # testing nnz, but really testing indexing. Should blow up memory needs
     assert S[I, J].nnz == 0
 


### PR DESCRIPTION
Avoid sparse index broadcasting. The goal is to use `_get_columnXarray` when possible as a way of broadcasting the index arrays without actually constructing/copying them in memory.

Fixes gh-24339 

With v1.17.0, we updated `_valiadte_indices()` to returns the preprocessed index values. That included broadcasting any arrays to match as prescribed for fancy indexing. But I didnt switch the logic for handling `_get_columnXarray` vs `_get_arrayXarray` to account for the  index changes. The resulting bug makes a full matrix copy of the full index arrays, while the correct path would have used the columns to represent the full matrix -- and then call the `_get_columnXarray` routine.

This PR adds a test for this case of "blowing up memory" with full index arrays. It also includes a fix for the logic that determines which function to use -- and that fix passes the test. The PR has two commits: one for the test and the other with the fix.

It would be nice to have this in a bugfix release since it fixes the behavior that broke in 1.17.0.
