### PR TITLE
ENH: stats.mannwhitneyu: enable JIT

### DIFF
--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -1,7 +1,9 @@
 import threading
 import numpy as np
 from collections import namedtuple
-from scipy._lib._array_api import array_namespace, xp_capabilities, xp_size, xp_promote
+from scipy._lib._array_api import (array_namespace, xp_capabilities, xp_size,
+                                   xp_promote, is_lazy_array, is_jax)
+import scipy._external.array_api_extra as xpx
 from scipy import special
 from scipy import stats
 from scipy.stats._stats_py import _rankdata
@@ -169,7 +171,7 @@ def _mwu_input_validation(x, y, use_continuity, alternative, axis, method):
     ''' Input validation and standardization for mannwhitneyu '''
     xp = array_namespace(x, y)
 
-    if xp.any(xp.isnan(x)) or xp.any(xp.isnan(y)):
+    if not is_lazy_array(x) and (xp.any(xp.isnan(x)) or xp.any(xp.isnan(y))):
         raise ValueError('`x` and `y` must not contain NaNs.')
     if xp_size(x) == 0 or xp_size(y) == 0:
         raise ValueError('`x` and `y` must be of nonzero size.')
@@ -217,8 +219,7 @@ MannwhitneyuResult = namedtuple('MannwhitneyuResult', ('statistic', 'pvalue'))
 @xp_capabilities(cpu_only=True,  # exact calculation only implemented in NumPy
                  skip_backends=[('cupy', 'needs rankdata'),
                                 ('dask.array', 'needs rankdata')],
-                 # the exact null distribution is NumPy-only
-                 jax_jit=False)
+                 extra_note="``method='auto'`` is incompatible with JAX arrays.")
 @_axis_nan_policy_factory(MannwhitneyuResult, n_samples=2)
 def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
                  axis=0, method="auto"):
@@ -460,13 +461,18 @@ def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
         U, f = xp.maximum(U1, U2), 2  # multiply SF by two for two-sided test
 
     if method == "auto":
+        if is_jax(xp):
+            message = "`method='auto'` is incompatible with JAX arrays."
+            raise ValueError(message)
         method = _mwu_choose_method(n1, n2, xp.any(t > 1))
 
     if method == "exact":
         if not hasattr(_mwu_state, 's'):
             _mwu_state.s = _MWU(0, 0)
         _mwu_state.s.set_shapes(n1, n2)
-        p = xp.asarray(_mwu_state.s.sf(np.asarray(U, np.int64)), dtype=x.dtype)
+        p = xpx.lazy_apply(_mwu_state.s.sf, xp.astype(U, xp.int64),
+                           as_numpy=True, dtype=xp.float64)
+        p = xp.astype(p, x.dtype, copy=False)
     elif method == "asymptotic":
         z = _get_mwu_z(U, n1, n2, t, continuity=use_continuity, xp=xp)
         p = special.ndtr(-z)

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -21,6 +21,7 @@ from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
 from scipy.stats._axis_nan_policy import SmallSampleWarning, too_small_1d_not_omit
 
 lazy_xp_modules = [stats]
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 
 @make_xp_test_case(epps_singleton_2samp)
@@ -239,6 +240,11 @@ class TestMannWhitneyU:
 
     def test_auto(self, xp):
         # Test that default method ('auto') chooses intended method
+        if is_jax(xp):
+            message = "`method='auto'` is incompatible with JAX arrays."
+            with pytest.raises(ValueError, match=message):
+                mannwhitneyu(xp.arange(10), xp.arange(10))
+            return
 
         rng = np.random.default_rng(923823782530925934)
         n = 8  # threshold to switch from exact to asymptotic
@@ -553,12 +559,12 @@ class TestMannWhitneyU:
         # Test for correct behavior with NaN/Inf in input
         x = [1, 2, 3, 4]
         y = [3, 6, 7, 8, 9, 3, 2, 1, 4, 4, 5]
-        res1 = mannwhitneyu(xp.asarray(x), xp.asarray(y))
+        res1 = mannwhitneyu(xp.asarray(x), xp.asarray(y), method='asymptotic')
 
         # Inf is not a problem. This is a rank test, and it's the largest value
         x[0] = 1.  # ensure floating point
         y[4] = np.inf
-        res2 = mannwhitneyu(xp.asarray(x), xp.asarray(y))
+        res2 = mannwhitneyu(xp.asarray(x), xp.asarray(y), method='asymptotic')
 
         xp_assert_equal(res1.statistic, res2.statistic)
         xp_assert_equal(res1.pvalue, res2.pvalue)
@@ -733,10 +739,11 @@ class TestMannWhitneyU:
 
     def test_mannwhitneyu_one_sided(self, xp):
         X, Y = xp.asarray(self.X), xp.asarray(self.Y)
-        u1, p1 = stats.mannwhitneyu(X, Y, alternative='less')
-        u2, p2 = stats.mannwhitneyu(Y, X, alternative='greater')
-        u3, p3 = stats.mannwhitneyu(X, Y, alternative='greater')
-        u4, p4 = stats.mannwhitneyu(Y, X, alternative='less')
+        kwargs = dict(method='asymptotic')
+        u1, p1 = stats.mannwhitneyu(X, Y, alternative='less', **kwargs)
+        u2, p2 = stats.mannwhitneyu(Y, X, alternative='greater', **kwargs)
+        u3, p3 = stats.mannwhitneyu(X, Y, alternative='greater', **kwargs)
+        u4, p4 = stats.mannwhitneyu(Y, X, alternative='less', **kwargs)
 
         xp_assert_equal(p1, p2)
         xp_assert_equal(p3, p4)
@@ -751,8 +758,9 @@ class TestMannWhitneyU:
 
     def test_mannwhitneyu_two_sided(self, xp):
         X, Y = xp.asarray(self.X), xp.asarray(self.Y)
-        u1, p1 = stats.mannwhitneyu(X, Y, alternative='two-sided')
-        u2, p2 = stats.mannwhitneyu(Y, X, alternative='two-sided')
+        kwargs = dict(alternative='two-sided', method='asymptotic')
+        u1, p1 = stats.mannwhitneyu(X, Y, **kwargs)
+        u2, p2 = stats.mannwhitneyu(Y, X, **kwargs)
 
         xp_assert_equal(p1, p2)
         xp_assert_equal(u1, xp.asarray(498.))
@@ -762,10 +770,11 @@ class TestMannWhitneyU:
 
     def test_mannwhitneyu_no_correct_one_sided(self, xp):
         X, Y = xp.asarray(self.X), xp.asarray(self.Y)
-        u1, p1 = stats.mannwhitneyu(X, Y, False, alternative='less')
-        u2, p2 = stats.mannwhitneyu(Y, X, False, alternative='greater')
-        u3, p3 = stats.mannwhitneyu(X, Y, False, alternative='greater')
-        u4, p4 = stats.mannwhitneyu(Y, X, False, alternative='less')
+        kwargs = dict(use_continuity=False, method='asymptotic')
+        u1, p1 = stats.mannwhitneyu(X, Y, alternative='less', **kwargs)
+        u2, p2 = stats.mannwhitneyu(Y, X, alternative='greater', **kwargs)
+        u3, p3 = stats.mannwhitneyu(X, Y, alternative='greater', **kwargs)
+        u4, p4 = stats.mannwhitneyu(Y, X, alternative='less', **kwargs)
 
         xp_assert_equal(p1, p2)
         xp_assert_equal(p3, p4)
@@ -780,8 +789,9 @@ class TestMannWhitneyU:
 
     def test_mannwhitneyu_no_correct_two_sided(self, xp):
         X, Y = xp.asarray(self.X), xp.asarray(self.Y)
-        u1, p1 = stats.mannwhitneyu(X, Y, False, alternative='two-sided')
-        u2, p2 = stats.mannwhitneyu(Y, X, False, alternative='two-sided')
+        kwargs = dict(use_continuity=False, method='asymptotic')
+        u1, p1 = stats.mannwhitneyu(X, Y, **kwargs)
+        u2, p2 = stats.mannwhitneyu(Y, X, **kwargs)
 
         xp_assert_equal(p1, p2)
         xp_assert_equal(u1, xp.asarray(498.))
@@ -824,13 +834,14 @@ class TestMannWhitneyU:
                         1., 1., 1., 1.])
 
         # p-value from R, e.g. wilcox.test(x, y, alternative="g")
-        res = stats.mannwhitneyu(x, y, alternative='less')
+        kwargs = dict(method='asymptotic')
+        res = stats.mannwhitneyu(x, y, alternative='less', **kwargs)
         xp_assert_close(res.statistic, xp.asarray(16980.5))
         xp_assert_close(res.pvalue, xp.asarray(2.8214327656317373e-5))
-        res = stats.mannwhitneyu(x, y, alternative='greater')
+        res = stats.mannwhitneyu(x, y, alternative='greater', **kwargs)
         xp_assert_close(res.statistic, xp.asarray(16980.5))
         xp_assert_close(res.pvalue, xp.asarray(0.9999719954296))
-        res = stats.mannwhitneyu(x, y, alternative='two-sided')
+        res = stats.mannwhitneyu(x, y, alternative='two-sided', **kwargs)
         xp_assert_close(res.statistic, xp.asarray(16980.5))
         xp_assert_close(res.pvalue, xp.asarray(5.642865531266e-5))
 


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
This PR enables use of JAX JIT with `scipy.stats.mannwhitneyu`. The limitation is that `method='auto'` is not available because the control flow would depend on values in the input; this is documented with `extra_note`.


