### PR TITLE
BUG: linalg: restore backwards compatibility with dtypes in inv, solve, det

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -9,7 +9,7 @@ from itertools import product
 import numpy as np
 from scipy._lib._util import _apply_over_batch
 from .lapack import (
-    get_lapack_funcs, _normalize_lapack_dtype,
+    get_lapack_funcs, _normalize_lapack_dtype, _normalize_lapack_dtype1,
     _ensure_aligned_and_native, _ensure_dtype_cdsz,
 )
 from ._misc import LinAlgError, _datacopied, LinAlgWarning
@@ -1148,7 +1148,7 @@ def det(a, overwrite_a=False, check_finite=True):
                          f' but received shape {a1.shape}.')
 
     # Also check if dtype is LAPACK compatible
-    a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
+    a1, overwrite_a = _normalize_lapack_dtype1(a1, overwrite_a)
 
     # Empty array has determinant 1 because math.
     if min(*a1.shape) == 0:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

x-ref https://github.com/scipy/scipy/issues/24505

#### What does this implement/fix?
<!--Please explain your changes.-->

Tweak dtype handling in `linalg.{solve,inv}` to restore backwards compatibility relative to scipy 1.16.3.

This is a minimal patch, only for functions we touched in 1.17. We can do similar things for `eig`, `lstsq`, and `svd`, which we touched in 1.18. However for 1.18 I'd prefer to wait for gh-24505 to reach some kind of agreement, and implement that.

#### Additional information
<!--Any additional information you think is important.-->

@tylerjereddy https://github.com/scipy/scipy/compare/maintenance/1.17.x...ev-br:scipy:short_and_long_dtypes_fix_117?expand=1 is the version of this patch which applies cleanly to maintenance/1.17.x