### PR TITLE
BUG: sparse: Fix CSR/C index broadcasting part 2

### DIFF
--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -20,7 +20,7 @@ from ._sputils import (upcast_char, to_native, isshape, getdtype,
                        getdata, downcast_intp_index, get_index_dtype,
                        check_shape, check_reshape_kwargs, isscalarlike,
                        isintlike, isdense)
-from ._index import _validate_indices
+from ._index import _validate_indices, _broadcast_arrays
 
 import operator
 
@@ -577,6 +577,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
 
         # handle array indices
         if arr_indices:
+            arr_indices = _broadcast_arrays(*arr_indices)
             arr_shape = arr_indices[0].shape  # already broadcast in validate_indices
             # There are three dimensions required to check array indices against coords
             # Their lengths are described as:
@@ -632,6 +633,14 @@ class _coo_base(_data_matrix, _minmax_mixin):
             for j in none_pos[::-1]:
                 new_shape.pop(j)
             new_shape = tuple(new_shape)
+
+        # broadcast arrays
+        if arr_int_pos:
+            index = list(index)
+            arr_pos = {i: arr for i in arr_int_pos if not isintlike(arr := index[i])}
+            arr_indices = _broadcast_arrays(*arr_pos.values())
+            for i, arr in zip(arr_pos, arr_indices):
+                index[i] = arr
 
         # get coords and data from x
         if issparse(x):

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -90,7 +90,7 @@ class IndexMixin:
                 res = self._get_arrayXslice(row, col)
             # arrayXarray preprocess
             elif (row.ndim == 2 and (key0 := np.atleast_2d(key[0])).shape[1] == 1
-                  and (col.ndim == 1 or (key1 := np.array(key[1])).shape[0] == 1)):
+                  and (col.ndim == 1 or (key1 := np.atleast_2d(key[1])).shape[0] == 1)):
                 # outer indexing
                 res = self._get_columnXarray(key0[:, 0], key1.reshape(-1))
             else:

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -89,10 +89,10 @@ class IndexMixin:
             elif isinstance(col, slice):
                 res = self._get_arrayXslice(row, col)
             # arrayXarray preprocess
-            elif (row.ndim == 2 and (key0 := np.atleast_2d(key[0])).shape[1] == 1
-                  and (col.ndim == 1 or (key1 := np.atleast_2d(key[1])).shape[0] == 1)):
+            elif (row.ndim == 2 and row.shape[1] == 1
+                  and (col.ndim == 1 or col.shape[0] == 1)):
                 # outer indexing
-                res = self._get_columnXarray(key0[:, 0], key1.reshape(-1))
+                res = self._get_columnXarray(row[:, 0], col.reshape(-1))
             else:
                 # inner indexing
                 row, col = _broadcast_arrays(row, col)
@@ -410,16 +410,14 @@ def _validate_indices(key, self_shape, self_format):
             array_indices.append(index_ndim)
             index_ndim += 1
     if len(array_indices) > 1:
-        idx_arrays = _broadcast_arrays(*(index[i] for i in array_indices))
-        if any(idx_arrays[0].shape != ix.shape for ix in idx_arrays[1:]):
-            shapes = " ".join(str(ix.shape) for ix in idx_arrays)
+        arr_shapes = [index[i].shape for i in array_indices]
+        try:
+            arr_shape = np.broadcast_shapes(*arr_shapes)
+        except ValueError:
+            shapes = " ".join(str(shp) for shp in arr_shapes)
             msg = (f'shape mismatch: indexing arrays could not be broadcast '
                    f'together with shapes {shapes}')
-            raise IndexError(msg)
-        # replace array indices with broadcast versions
-        for i, arr in zip(array_indices, idx_arrays):
-            index[i] = arr
-        arr_shape = idx_arrays[0].shape
+            raise ValueError(msg)
         # len(array_indices) implies arr_int_pos has at least one element
         # if arrays and ints not adjacent, move to front of shape
         if len(arr_int_pos) != (arr_int_pos[-1] - arr_int_pos[0] + 1):

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -417,7 +417,7 @@ def _validate_indices(key, self_shape, self_format):
             shapes = " ".join(str(shp) for shp in arr_shapes)
             msg = (f'shape mismatch: indexing arrays could not be broadcast '
                    f'together with shapes {shapes}')
-            raise ValueError(msg)
+            raise IndexError(msg)
         # len(array_indices) implies arr_int_pos has at least one element
         # if arrays and ints not adjacent, move to front of shape
         if len(arr_int_pos) != (arr_int_pos[-1] - arr_int_pos[0] + 1):
@@ -442,7 +442,7 @@ def _asindices(idx, length, format):
     except (ValueError, TypeError, MemoryError) as e:
         raise IndexError('invalid index') from e
 
-    if format != "coo" and ix.ndim not in (1, 2):
+    if format != "coo" and ix.ndim not in (1, 2) or format == "coo" and ix.ndim == 0:
         raise IndexError(f'Index dimension must be 1 or 2. Got {ix.ndim}')
 
     # LIL routines handle bounds-checking for us, so don't do it here.

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2927,7 +2927,7 @@ class _TestSlicing:
         assert_array_equal(toarray(a[..., ix5, ix10]), numpy_a[..., ix5, ix10])
         assert_array_equal(toarray(a[ix5, ix10, ...]), numpy_a[ix5, ix10, ...])
 
-        with assert_raises(ValueError, match="shape mismatch"):
+        with assert_raises(IndexError, match="shape mismatch"):
             a[ix5, ix10_6True]
 
     def test_ellipsis_fancy_slicing(self):
@@ -3082,7 +3082,7 @@ class _TestSlicingAssign:
         assert_raises(ValueError, A.__setitem__, (slice(None), 1), A.copy())
         assert_raises(ValueError, A.__setitem__,
                       ([[1, 2, 3], [0, 3, 4]], [1, 2, 3]), [1, 2, 3, 4])
-        assert_raises(ValueError, A.__setitem__,
+        assert_raises(IndexError, A.__setitem__,
                       ([[1, 2, 3], [0, 3, 4], [4, 1, 3]],
                        [[1, 2, 4], [0, 1, 3]]), [2, 3, 4])
         assert_raises(ValueError, A.__setitem__, (slice(4), 0),
@@ -3121,10 +3121,10 @@ class _TestFancyIndexing:
 
     def test_bad_index(self):
         A = self.spcreator(np.zeros([5, 5]))
-        assert_raises((IndexError, ValueError, TypeError), A.__getitem__, "foo")
-        assert_raises((IndexError, ValueError, TypeError), A.__getitem__, (2, "foo"))
-        assert_raises((IndexError, ValueError), A.__getitem__,
-                      ([1, 2, 3], [1, 2, 3, 4]))
+        assert_raises(IndexError, A.__getitem__, "foo").match('Index dimension')
+        assert_raises(IndexError, A.__getitem__, (2, "foo")).match('Index dimension')
+        idx = ([1, 2, 3], [1, 2, 3, 4])
+        assert_raises(IndexError, A.__getitem__, idx).match('shape mismatch')
 
     def test_fancy_indexing(self):
         B = self.asdense(arange(50).reshape(5,10))

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -118,11 +118,13 @@ def test_csr_bool_indexing():
 @pytest.mark.timeout(2)  # only slow when broken (conversion to 2d index arrays)
 @pytest.mark.parametrize("cls", [csr_matrix, csr_array, csc_matrix, csc_array])
 def test_fancy_indexing_broadcasts_without_making_dense_2d(cls):
-    I = np.arange(100_000).reshape((100_000, 1))
-    J = I.T
+    # Fixes Issue gh-24339
+    J = np.arange(100_000)
+    I = J.reshape((100_000, 1))
     S = cls((100_000, 100_000))
-    # testing nnz, but really testing indexing. Should blow up memory needs
-    assert S[I, J].nnz == 0
+    # checking nnz, but really testing indexing.
+    assert S[I, J].nnz == 0  # 1D row array for columns -> broadcasts to 2D
+    assert S[I, J.reshape(1, -1)].nnz == 0  # 2D row array as index for columns
 
 
 def test_csr_hstack_int64():

--- a/scipy/sparse/tests/test_indexing1d.py
+++ b/scipy/sparse/tests/test_indexing1d.py
@@ -338,15 +338,9 @@ class TestSlicingAndFancy1D:
 
     def test_bad_index(self, spcreator):
         A = spcreator(np.zeros(5))
-        with pytest.raises(
-            (IndexError, ValueError, TypeError),
-            match='Index dimension must be 1 or 2|only integers',
-        ):
+        with pytest.raises(IndexError, match='Index dimension must be 1 or 2'):
             A.__getitem__("foo")
-        with pytest.raises(
-            (IndexError, ValueError, TypeError),
-            match='tuple index out of range|only integers',
-        ):
+        with pytest.raises(IndexError, match='tuple index out of range'):
             A.__getitem__((2, "foo"))
 
     def test_fancy_indexing_2darray(self, spcreator):


### PR DESCRIPTION
This follow-up to #24499 adds another assert in the test and updates the fix to work for 1D column indices.

~~The previous fix used `np.array` where it should have used `np.atleast_2d`. So its a simple fix.~~
[Edit: I pulled the broadcasting out of `_validate_indices()` to avoid the cruft needed to refer to original keys but needing validated keys also. The cost of pulling out the braodcasting is we have to do it in each getitem/setitem method. Which isn't too bad.]

This was brought to my attention in the original issue #24339 after it was closed because the second report of the bug didn't get resolved after the fix.  So this now hopefully really fixes #24339

I've separated the test addition in the first commit from the fix in the next two commits.

Sorry @tylerjereddy for the continued churn.  Could you review this one (very similar to the last one).  I've also added a comment about the issue number in the test. And this should go into the backport for 1.17.1 along with the other PR.  Thanks!!

Looks like the remaining two failed tests are not related (one stats, one signal).

