### PR TITLE
BUG: Fix incorrect error message in LinearOperator.rmatmat

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -632,6 +632,8 @@ class _CustomLinearOperator(LinearOperator):
     def _rmatmat(self, X):
         if self.__rmatmat_impl is not None:
             return self.__rmatmat_impl(X)
+        elif self.__rmatvec_impl is None:
+            raise NotImplementedError("rmatmat is not defined")
         else:
             return super()._rmatmat(X)
 


### PR DESCRIPTION
When calling rmatmat on a LinearOperator that doesn't have rmatmat or rmatvec defined, the error was obscure (NoneType not callable). Now it raises a proper NotImplementedError with a clear message.

Fixes #18140