### PR TITLE
BUG: Fix error message in LinearOperator.rmatmat

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -632,6 +632,11 @@ class _CustomLinearOperator(LinearOperator):
     def _rmatmat(self, X):
         if self.__rmatmat_impl is not None:
             return self.__rmatmat_impl(X)
+        elif self.__rmatvec_impl is None:
+            raise NotImplementedError(
+                "rmatmat is not defined because neither rmatmat nor rmatvec "
+                "was specified when creating this LinearOperator."
+            )
         else:
             return super()._rmatmat(X)
 


### PR DESCRIPTION
Fixes confusing error message when calling rmatmat on LinearOperator without rmatvec defined.

Fixes #18140