### PR TITLE
DOC: Clarify RK45 coefficient documentation

### DIFF
--- a/scipy/integrate/_ivp/rk.py
+++ b/scipy/integrate/_ivp/rk.py
@@ -298,6 +298,12 @@ class RK45(RungeKutta):
     using the fifth-order accurate formula (local extrapolation is done).
     A quartic interpolation polynomial is used for the dense output [2]_.
 
+    This is the RK5(4)7M method from Dormand & Prince, using 7 stages
+    (including the first derivative evaluation which is reused from the
+    previous step). The coefficients correspond to the 5th order solution
+    (B) and the error estimator (E) which is the difference between the
+    5th and 4th order solutions.
+
     Can be applied in the complex domain.
 
     Parameters


### PR DESCRIPTION
Add documentation explaining that the RK45 implementation uses the RK5(4)7M method from Dormand & Prince with 7 stages. Clarify that B contains the 5th order solution coefficients and E contains the error estimator (difference between 5th and 4th order solutions).

This addresses the confusion noted in #24509 about the coefficient notation.

Closes #24509