### PR TITLE
DOC/BUG: Fix docstrings and error messages for issues #22635, #18140, #18871

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -200,13 +200,13 @@ def _root_hybr(func, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, default: False
         Specify whether the Jacobian function computes derivatives down
         the columns (faster, because there is no transpose operation).
-    xtol : float
+    xtol : float, default: 1.49012e-08
         The calculation will terminate if the relative error between two
         consecutive iterates is at most `xtol`.
-    maxfev : int
+    maxfev : int, default: 0
         The maximum number of calls to the function. If zero, then
         ``100*(N+1)`` is the maximum where N is the number of elements
         in `x0`.
@@ -214,13 +214,14 @@ def _root_hybr(func, x0, args=(), jac=None,
         If set to a two-sequence containing the number of sub- and
         super-diagonals within the band of the Jacobi matrix, the
         Jacobi matrix is considered banded (only for ``jac=None``).
-    eps : float
+    eps : float, default: None
         A suitable step length for the forward-difference
         approximation of the Jacobian (for ``jac=None``). If
         `eps` is less than the machine precision, it is assumed
         that the relative errors in the functions are of the order of
-        the machine precision.
-    factor : float
+        the machine precision. If `eps` is ``None`` (default), the
+        machine precision is used.
+    factor : float, default: 100
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in the interval
         ``(0.1, 100)``.

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -286,25 +286,25 @@ def _root_leastsq(fun, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, default: False
         non-zero to specify that the Jacobian function computes derivatives
         down the columns (faster, because there is no transpose operation).
-    ftol : float
+    ftol : float, default: 1.49012e-08
         Relative error desired in the sum of squares.
-    xtol : float
+    xtol : float, default: 1.49012e-08
         Relative error desired in the approximate solution.
-    gtol : float
+    gtol : float, default: 0.0
         Orthogonality desired between the function vector and the columns
         of the Jacobian.
-    maxiter : int
+    maxiter : int, default: 0
         The maximum number of calls to the function. If zero, then
         100*(N+1) is the maximum where N is the number of elements in x0.
-    eps : float
+    eps : float, default: 0.0
         A suitable step length for the forward-difference approximation of
         the Jacobian (for Dfun=None). If `eps` is less than the machine
         precision, it is assumed that the relative errors in the functions
         are of the order of the machine precision.
-    factor : float
+    factor : float, default: 100
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in interval ``(0.1, 100)``.
     diag : sequence

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -545,6 +545,16 @@ class dia_array(_dia_base, sparray):
     addition, subtraction, multiplication, division, and matrix power.
     Sparse arrays with DIAgonal storage do not support slicing.
 
+    **Structure of the data array:**
+
+    The format of ``data`` in the constructor is consistent with the
+    `BLAS/LAPACK general band format <https://netlib.org/lapack/lug/node124.html>`_
+    when ``offsets`` is a decreasing range.
+
+    * Sub-diagonals (negative offsets) are left-aligned with the main diagonal.
+    * Super-diagonals (positive offsets) are right-aligned with the main diagonal.
+    * Columns of ``data`` become columns of the generated sparse array.
+
     Examples
     --------
 
@@ -620,6 +630,16 @@ class dia_matrix(spmatrix, _dia_base):
     Sparse matrices can be used in arithmetic operations: they support
     addition, subtraction, multiplication, division, and matrix power.
     Sparse matrices with DIAgonal storage do not support slicing.
+
+    **Structure of the data array:**
+
+    The format of ``data`` in the constructor is consistent with the
+    `BLAS/LAPACK general band format <https://netlib.org/lapack/lug/node124.html>`_
+    when ``offsets`` is a decreasing range.
+
+    * Sub-diagonals (negative offsets) are left-aligned with the main diagonal.
+    * Super-diagonals (positive offsets) are right-aligned with the main diagonal.
+    * Columns of ``data`` become columns of the generated sparse matrix.
 
     Examples
     --------

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -429,6 +429,12 @@ class LinearOperator:
     def _rmatmat(self, X):
         """Default implementation of _rmatmat defers to rmatvec or adjoint."""
         if type(self)._adjoint == LinearOperator._adjoint:
+            # _adjoint not overridden, check if rmatvec is available
+            if type(self)._rmatvec == LinearOperator._rmatvec:
+                raise NotImplementedError(
+                    "rmatmat is not defined for this LinearOperator. "
+                    "Please define either _rmatmat, _rmatvec, or _adjoint."
+                )
             return np.hstack([self.rmatvec(col.reshape(-1, 1)) for col in X.T])
         else:
             return self.H.matmat(X)


### PR DESCRIPTION
This PR addresses three related issues:

## Fixes

### Issue #22635 - DOC: Add default values to optimize.root docstrings
- Added default values to documentation for \_root_hybr parameters: col_deriv, xtol, maxfev, eps, factor
- Added default values to documentation for \_root_leastsq parameters: col_deriv, ftol, xtol, gtol, maxiter, eps, factor

### Issue #18140 - BUG: Fix error message in LinearOperator.rmatmat  
- Added proper NotImplementedError when \_rmatmat is called but neither \_rmatvec nor \_adjoint is implemented
- Previously this would fail with a confusing TypeError when trying to call None

### Issue #18871 - DOC: Improve clarity of documentation for dia_array/dia_matrix
- Added documentation explaining the structure of the data array
- Clarified that sub-diagonals are left-aligned with the main diagonal
- Clarified that super-diagonals are right-aligned with the main diagonal  
- Noted that format is consistent with BLAS/LAPACK general band format when offsets is a decreasing range

Closes #22635
Closes #18140  
Closes #18871