### PR TITLE
BUG: Fix error message in LinearOperator.rmatmat when not defined

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -632,8 +632,10 @@ class _CustomLinearOperator(LinearOperator):
     def _rmatmat(self, X):
         if self.__rmatmat_impl is not None:
             return self.__rmatmat_impl(X)
-        else:
+        elif self.__rmatvec_impl is not None:
             return super()._rmatmat(X)
+        else:
+            raise NotImplementedError("rmatmat is not defined")
 
     def _adjoint(self):
         return _CustomLinearOperator(shape=(self.shape[1], self.shape[0]),


### PR DESCRIPTION
When `rmatmat` was not defined on a `LinearOperator`, calling it produced an obscure `TypeError: 'NoneType' object is not callable` instead of a clear `NotImplementedError`.

This PR adds proper error handling in `_CustomLinearOperator._rmatmat()` to raise `NotImplementedError("rmatmat is not defined")` when neither `rmatmat` nor `rmatvec` implementations are provided.

Closes #18140