### PR TITLE
DOC: Add default values to optimize.root docstrings

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -200,33 +200,35 @@ def _root_hybr(func, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, optional
         Specify whether the Jacobian function computes derivatives down
         the columns (faster, because there is no transpose operation).
-    xtol : float
+        Default is False.
+    xtol : float, optional
         The calculation will terminate if the relative error between two
-        consecutive iterates is at most `xtol`.
-    maxfev : int
+        consecutive iterates is at most `xtol`. Default is 1.49012e-08.
+    maxfev : int, optional
         The maximum number of calls to the function. If zero, then
         ``100*(N+1)`` is the maximum where N is the number of elements
-        in `x0`.
-    band : tuple
+        in `x0`. Default is 0.
+    band : tuple, optional
         If set to a two-sequence containing the number of sub- and
         super-diagonals within the band of the Jacobi matrix, the
         Jacobi matrix is considered banded (only for ``jac=None``).
-    eps : float
+        Default is None.
+    eps : float, optional
         A suitable step length for the forward-difference
         approximation of the Jacobian (for ``jac=None``). If
         `eps` is less than the machine precision, it is assumed
         that the relative errors in the functions are of the order of
-        the machine precision.
-    factor : float
+        the machine precision. Default is None.
+    factor : float, optional
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in the interval
-        ``(0.1, 100)``.
-    diag : sequence
+        ``(0.1, 100)``. Default is 100.
+    diag : sequence, optional
         N positive entries that serve as a scale factors for the
-        variables.
+        variables. Default is None.
 
     """
     _check_unknown_options(unknown_options)

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -286,29 +286,33 @@ def _root_leastsq(fun, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, optional
         non-zero to specify that the Jacobian function computes derivatives
         down the columns (faster, because there is no transpose operation).
-    ftol : float
-        Relative error desired in the sum of squares.
-    xtol : float
-        Relative error desired in the approximate solution.
-    gtol : float
+        Default is 0.
+    ftol : float, optional
+        Relative error desired in the sum of squares. Default is 1.49012e-08.
+    xtol : float, optional
+        Relative error desired in the approximate solution. Default is 1.49012e-08.
+    gtol : float, optional
         Orthogonality desired between the function vector and the columns
-        of the Jacobian.
-    maxiter : int
+        of the Jacobian. Default is 0.0.
+    maxiter : int, optional
         The maximum number of calls to the function. If zero, then
         100*(N+1) is the maximum where N is the number of elements in x0.
-    eps : float
+        Default is 0.
+    eps : float, optional
         A suitable step length for the forward-difference approximation of
         the Jacobian (for Dfun=None). If `eps` is less than the machine
         precision, it is assumed that the relative errors in the functions
-        are of the order of the machine precision.
-    factor : float
+        are of the order of the machine precision. Default is 0.0.
+    factor : float, optional
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in interval ``(0.1, 100)``.
-    diag : sequence
+        Default is 100.
+    diag : sequence, optional
         N positive entries that serve as a scale factors for the variables.
+        Default is None.
     """
     nfev = 0
     def _wrapped_fun(*fargs):


### PR DESCRIPTION
The `optimize.root` documentation for the 'hybr' and 'lm' methods didn't include default values for optional parameters like `xtol`, `eps`, `maxfev`, etc.

This PR adds default values to the docstrings of `_root_hybr` and `_root_leastsq`:
- `col_deriv`: Default is False/0
- `xtol`: Default is 1.49012e-08
- `maxfev`/`maxiter`: Default is 0
- `eps`: Default is None/0.0
- `factor`: Default is 100
- `diag`: Default is None

Closes #22635