### PR TITLE
ENH: special: use `lazy_apply` when falling back to NumPy in delegation

### DIFF
--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -6,7 +6,7 @@ from types import ModuleType
 
 import numpy as np
 from scipy._lib._array_api import (
-    array_namespace, scipy_namespace_for, is_numpy, is_dask, is_marray,
+    array_namespace, scipy_namespace_for, is_numpy, is_dask, is_marray, is_jax_array,
     is_jax, xp_promote, xp_capabilities, SCIPY_ARRAY_API, get_native_namespace_name
 )
 import scipy._external.array_api_extra as xpx

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -162,9 +162,26 @@ class _FuncInfo:
 
         # As a final resort, use the NumPy/SciPy implementation
         _f = self.func
+
         def f(*args, _f=_f, xp=xp, **kwargs):
-            # TODO use xpx.lazy_apply to add jax.jit support
-            # (but dtype propagation can be non-trivial)
+            if self.is_ufunc:
+                # if this is a ufunc, we can use the resolve_dtypes method to figure
+                # out what the output dtype should be and use lazy_apply to make this
+                # work with the JAX JIT.
+                out_dtype = kwargs.get("out")
+                out_dtype = (
+                    out_dtype if out_dtype is None else np.dtype(str(out_dtype.dtype))
+                )
+                npy_dtypes = (
+                    tuple(np.dtype(str(arg.dtype)) for arg in args)
+                    + (out_dtype, )
+                )
+                out_dtype = getattr(xp, str(_f.resolve_dtypes(npy_dtypes)[-1]))
+                return xpx.lazy_apply(_f, *args, xp=xp, as_numpy=True, dtype=out_dtype, **kwargs)
+            # If not a ufunc, we can't use lazy_apply, though the implementation may work with
+            # the JIT anyway if it is array-agnostic or mostly array-agnostic but depends on compiled
+            # functions with native JAX implementations that are delegated to.
+
             args = [np.asarray(arg) for arg in args]
             out = _f(*args, **kwargs)
             return xp.asarray(out)
@@ -307,7 +324,7 @@ _special_funcs = (
         _ufuncs.bdtr, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         int_only=(False, True, False), torch_native=False,
     ),
@@ -315,7 +332,7 @@ _special_funcs = (
         _ufuncs.bdtrc, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         int_only=(False, True, False), torch_native=False,
     ),
@@ -323,7 +340,7 @@ _special_funcs = (
         _ufuncs.bdtri, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         int_only=(False, True, False), torch_native=False,
     ),
@@ -334,7 +351,7 @@ _special_funcs = (
         _ufuncs.betaincinv, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         test_large_ints=False, positive_only=True, torch_native=False,
     ),
@@ -349,7 +366,7 @@ _special_funcs = (
         _ufuncs.binom, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -357,7 +374,7 @@ _special_funcs = (
         _ufuncs.boxcox, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -365,7 +382,7 @@ _special_funcs = (
         _ufuncs.boxcox1p, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -373,7 +390,7 @@ _special_funcs = (
         _ufuncs.cbrt, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -385,7 +402,7 @@ _special_funcs = (
         _ufuncs.chdtri, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -393,7 +410,7 @@ _special_funcs = (
         _ufuncs.cosdg, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         test_large_ints=False, torch_native=False,
     ),
@@ -401,7 +418,7 @@ _special_funcs = (
         _ufuncs.cosm1, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -409,7 +426,7 @@ _special_funcs = (
         _ufuncs.cotdg, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -417,7 +434,7 @@ _special_funcs = (
         _ufuncs.ellipk, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -425,7 +442,7 @@ _special_funcs = (
         _ufuncs.ellipkm1, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -436,7 +453,7 @@ _special_funcs = (
         _ufuncs.erfcx, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy", "torch"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -445,7 +462,7 @@ _special_funcs = (
         _ufuncs.exp1, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -453,7 +470,7 @@ _special_funcs = (
         _ufuncs.exp10, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -461,7 +478,7 @@ _special_funcs = (
         _ufuncs.exp2, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -469,7 +486,7 @@ _special_funcs = (
         _ufuncs.exprel, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -492,7 +509,7 @@ _special_funcs = (
         _ufuncs.fdtr, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -500,7 +517,7 @@ _special_funcs = (
         _ufuncs.fdtrc, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -508,7 +525,7 @@ _special_funcs = (
         _ufuncs.fdtri, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -527,7 +544,7 @@ _special_funcs = (
         _ufuncs.gammainccinv, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -535,7 +552,7 @@ _special_funcs = (
         _ufuncs.gammaincinv, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -549,7 +566,7 @@ _special_funcs = (
         _ufuncs.gdtr, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -557,7 +574,7 @@ _special_funcs = (
         _ufuncs.gdtrc, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -565,7 +582,7 @@ _special_funcs = (
         _ufuncs.huber, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -587,7 +604,7 @@ _special_funcs = (
         _ufuncs.inv_boxcox, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -595,7 +612,7 @@ _special_funcs = (
         _ufuncs.inv_boxcox1p, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -607,7 +624,7 @@ _special_funcs = (
         _ufuncs.j0, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy", "torch"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         alt_names_map={"torch": "bessel_j0"}, test_large_ints=False,
     ),
@@ -615,7 +632,7 @@ _special_funcs = (
         _ufuncs.j1, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy", "torch"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         alt_names_map={"torch": "bessel_j1"}, test_large_ints=False,
     ),
@@ -623,7 +640,7 @@ _special_funcs = (
         _ufuncs.k0, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy", "torch"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         alt_names_map={"torch": "modified_bessel_k0"},
     ),
@@ -631,7 +648,7 @@ _special_funcs = (
         _ufuncs.k0e, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy", "torch"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         alt_names_map={"torch": "scaled_modified_bessel_k0"},
         test_large_ints=False,
@@ -640,7 +657,7 @@ _special_funcs = (
         _ufuncs.k1, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy", "torch"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         alt_names_map={"torch": "modified_bessel_k1"},
     ),
@@ -648,7 +665,7 @@ _special_funcs = (
         _ufuncs.k1e, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy", "torch"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         alt_names_map={"torch": "scaled_modified_bessel_k1"},
         test_large_ints=False),
@@ -662,7 +679,7 @@ _special_funcs = (
         _ufuncs.loggamma, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -671,7 +688,7 @@ _special_funcs = (
         _ufuncs.lpmv, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
         test_large_ints=False,
@@ -697,7 +714,7 @@ _special_funcs = (
         _ufuncs.nbdtr, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         int_only=(True, True, False), positive_only=True,
         torch_native=False,
@@ -706,7 +723,7 @@ _special_funcs = (
         _ufuncs.nbdtrc, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         int_only=(True, True, False), positive_only=True,
         torch_native=False,
@@ -715,7 +732,7 @@ _special_funcs = (
         _ufuncs.nbdtri, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         int_only=(True, True, False), positive_only=True,
         torch_native=False,
@@ -726,7 +743,7 @@ _special_funcs = (
         _ufuncs.pdtr, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         positive_only=True, torch_native=False,
     ),
@@ -734,7 +751,7 @@ _special_funcs = (
         _ufuncs.pdtrc, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         positive_only=True, torch_native=False,
     ),
@@ -742,7 +759,7 @@ _special_funcs = (
         _ufuncs.pdtri, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         int_only=(True, False), positive_only=True,
         torch_native=False,
@@ -756,7 +773,7 @@ _special_funcs = (
         _ufuncs.pseudo_huber, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -771,7 +788,7 @@ _special_funcs = (
         _ufuncs.radian, 3,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -780,7 +797,7 @@ _special_funcs = (
         _ufuncs.rgamma, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),
@@ -796,7 +813,7 @@ _special_funcs = (
         _ufuncs.sindg, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         test_large_ints=False, torch_native=False,
     ),
@@ -819,7 +836,7 @@ _special_funcs = (
         _ufuncs.tandg, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         test_large_ints=False, torch_native=False,
     ),
@@ -829,7 +846,7 @@ _special_funcs = (
         _ufuncs.y0, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy", "torch"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         alt_names_map={"torch": "bessel_y0"}, test_large_ints=False,
     ),
@@ -837,7 +854,7 @@ _special_funcs = (
         _ufuncs.y1, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy", "torch"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         alt_names_map={"torch": "bessel_y1"}, test_large_ints=False,
     ),
@@ -845,7 +862,7 @@ _special_funcs = (
         _ufuncs.yn, 2,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         positive_only={"cupy": (True, False)}, int_only=(True, False),
         test_large_ints=False, torch_native=False,
@@ -859,7 +876,7 @@ _special_funcs = (
         _ufuncs.zetac, 1,
         xp_capabilities(
             cpu_only=True, exceptions=["cupy"],
-            jax_jit=False,
+            jax_jit=True,
         ),
         torch_native=False,
     ),

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -122,8 +122,9 @@ class _FuncInfo:
 
         # If a native implementation is available, use that
         spx = scipy_namespace_for(xp)
+        namespace = xp if self.in_xp else scipy_namespace_for(xp)
         f = _get_native_func(
-            xp, spx, self.name, alt_names_map=self.alt_names_map, in_xp=self.in_xp
+            xp, namespace, self.name, alt_names_map=self.alt_names_map,
         )
         if f is not None:
             return f

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -177,8 +177,8 @@ class _FuncInfo:
                 # JAX uses NumPy dtypes, so it's easy to get the dtypes for
                 # use in resolve_dtypes. Needs the is_jax_array arg to properly
                 # handle Python scalars. The (None, ) appended on the end is for the
-                # dtype of out, which resolve_dtypes needs. Since JAX arrays are immutable,
-                # there can be no out, so this will always be None.
+                # dtype of out, which resolve_dtypes needs. Since JAX arrays are
+                # immutable, there can be no out, so this will always be None.
                 dtypes = (
                     tuple(arg.dtype if is_jax_array(arg) else type(arg) for arg in args)
                     + (None, )

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -174,12 +174,14 @@ class _FuncInfo:
             # work with the JAX JIT. TODO: explore making this work for other
             # lazy backends.
             def f(*args, _f=_f, xp=xp, **kwargs):
-                out_dtype = kwargs.get("out")
                 # JAX uses NumPy dtypes, so it's easy to get the dtypes for
-                # use in resolve_dtypes.
+                # use in resolve_dtypes. Needs the is_jax_array arg to properly
+                # handle Python scalars. The (None, ) appended on the end is for the
+                # dtype of out, which resolve_dtypes needs. Since JAX arrays are immutable,
+                # there can be no out, so this will always be None.
                 dtypes = (
-                    tuple(arg.dtype for arg in args)
-                    + (out_dtype, )
+                    tuple(arg.dtype if is_jax_array(arg) else type(arg) for arg in args)
+                    + (None, )
                 )
                 out_dtype = getattr(xp, str(_f.resolve_dtypes(dtypes)[-1]))
                 return xpx.lazy_apply(

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -7,7 +7,8 @@ from types import ModuleType
 import numpy as np
 from scipy._lib._array_api import (
     array_namespace, scipy_namespace_for, is_numpy, is_dask, is_marray,
-    xp_promote, xp_capabilities, SCIPY_ARRAY_API, get_native_namespace_name
+    is_jax, is_cupy, xp_promote, xp_capabilities, SCIPY_ARRAY_API,
+    get_native_namespace_name
 )
 import scipy._external.array_api_extra as xpx
 from . import _basic
@@ -168,28 +169,36 @@ class _FuncInfo:
         # As a final resort, use the NumPy/SciPy implementation
         _f = self.func
 
-        def f(*args, _f=_f, xp=xp, **kwargs):
-            if self.is_ufunc:
-                # if this is a ufunc, we can use the resolve_dtypes method to figure
-                # out what the output dtype should be and use lazy_apply to make this
-                # work with the JAX JIT.
+        if self.is_ufunc:
+            # if this is a ufunc, we can use the resolve_dtypes method to figure
+            # out what the output dtype should be and use lazy_apply to make this
+            # work with the JAX JIT.
+            if is_jax(xp) or is_cupy(xp):
+                def _get_np_dtype(dtype):
+                    return dtype
+            else:
+                def _get_np_dtype(dtype):
+                    return np.dtype(str(dtype).split(".")[-1])
+
+            def f(*args, _f=_f, xp=xp, **kwargs):
                 out_dtype = kwargs.get("out")
                 out_dtype = (
-                    out_dtype if out_dtype is None else np.dtype(str(out_dtype.dtype))
+                    out_dtype if out_dtype is None else _get_np_dtype(out_dtype)
                 )
                 npy_dtypes = (
-                    tuple(np.dtype(str(arg.dtype)) for arg in args)
+                    tuple(_get_np_dtype(arg.dtype) for arg in args)
                     + (out_dtype, )
                 )
                 out_dtype = getattr(xp, str(_f.resolve_dtypes(npy_dtypes)[-1]))
-                return xpx.lazy_apply(_f, *args, xp=xp, as_numpy=True, dtype=out_dtype, **kwargs)
-            # If not a ufunc, we can't use lazy_apply, though the implementation may work with
-            # the JIT anyway if it is array-agnostic or mostly array-agnostic but depends on compiled
-            # functions with native JAX implementations that are delegated to.
-
-            args = [np.asarray(arg) for arg in args]
-            out = _f(*args, **kwargs)
-            return xp.asarray(out)
+                return xpx.lazy_apply(
+                    _f, *args, xp=xp, as_numpy=True, dtype=out_dtype, **kwargs
+                )
+        else:
+            # If not a ufunc, convert to numpy and hope for the best.
+            def f(*args, _f=_f, xp=xp, **kwargs):
+                args = [np.asarray(arg) for arg in args]
+                out = _f(*args, **kwargs)
+                return xp.asarray(out)
 
         return f
 

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -15,6 +15,11 @@ from . import _spfun_stats
 from . import _ufuncs
 
 
+def _special_namespace_for(xp):
+    spx = scipy_namespace_for(xp)
+    return getattr(spx, "special", None)
+
+
 @dataclass
 class _FuncInfo:
     # NumPy-only function. IT MUST BE ELEMENTWISE.
@@ -121,16 +126,16 @@ class _FuncInfo:
             return self.func
 
         # If a native implementation is available, use that
-        spx = scipy_namespace_for(xp)
+        namespace = xp if self.in_xp else _special_namespace_for(xp)
         f = _get_native_func(
-            xp, spx, self.name, alt_names_map=self.alt_names_map, in_xp=self.in_xp
+            xp, namespace, self.name, alt_names_map=self.alt_names_map
         )
         if f is not None:
             return f
 
         # If generic Array API implementation is available, use that
         if self.generic_impl is not None:
-            f = self.generic_impl(xp, spx)
+            f = self.generic_impl(xp, _special_namespace_for(xp))
             if f is not None:
                 return f
 
@@ -196,11 +201,11 @@ class _FuncInfo:
         return f
 
 
-def _get_native_func(xp, spx, f_name, *, alt_names_map=None, in_xp=False):
+def _get_native_func(xp, namespace, f_name, *, alt_names_map=None):
     if alt_names_map is None:
         alt_names_map = {}
     f_name = alt_names_map.get(get_native_namespace_name(xp), f_name)
-    f = getattr(xp if in_xp else spx.special, f_name, None) if spx else None
+    f = getattr(namespace, f_name, None)
     if f is None and hasattr(xp, 'special'):
         # Currently dead branch, in anticipation of 'special' Array API extension
         # https://github.com/data-apis/array-api/issues/725
@@ -208,7 +213,7 @@ def _get_native_func(xp, spx, f_name, *, alt_names_map=None, in_xp=False):
     return f
 
 
-def _rel_entr(xp, spx):
+def _rel_entr(xp, spsx):
     def __rel_entr(x, y, *, xp=xp):
         # https://github.com/data-apis/array-api-extra/issues/160
         mxp = array_namespace(x._meta, y._meta) if is_dask(xp) else xp
@@ -229,7 +234,7 @@ def _rel_entr(xp, spx):
     return __rel_entr
 
 
-def _xlogy(xp, spx):
+def _xlogy(xp, spsx):
     def __xlogy(x, y, *, xp=xp):
         x, y = xp_promote(x, y, force_floating=True, xp=xp)
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -239,12 +244,12 @@ def _xlogy(xp, spx):
 
 
 
-def _chdtr(xp, spx):
+def _chdtr(xp, spsx):
     # The difference between this and just using `gammainc`
     # defined by `get_array_special_func` is that if `gammainc`
     # isn't found, we don't want to use the SciPy version; we'll
     # return None here and use the SciPy version of `chdtr`.
-    gammainc = _get_native_func(xp, spx, 'gammainc')
+    gammainc = _get_native_func(xp, spsx, 'gammainc')
     if gammainc is None:
         return None
 
@@ -258,12 +263,12 @@ def _chdtr(xp, spx):
     return __chdtr
 
 
-def _chdtrc(xp, spx):
+def _chdtrc(xp, spsx):
     # The difference between this and just using `gammaincc`
     # defined by `get_array_special_func` is that if `gammaincc`
     # isn't found, we don't want to use the SciPy version; we'll
     # return None here and use the SciPy version of `chdtrc`.
-    gammaincc = _get_native_func(xp, spx, 'gammaincc')
+    gammaincc = _get_native_func(xp, spsx, 'gammaincc')
     if gammaincc is None:
         return None
 
@@ -275,8 +280,8 @@ def _chdtrc(xp, spx):
     return __chdtrc
 
 
-def _betaincc(xp, spx):
-    betainc = _get_native_func(xp, spx, 'betainc')
+def _betaincc(xp, spsx):
+    betainc = _get_native_func(xp, spsx, 'betainc')
     if betainc is None:
         return None
 
@@ -286,8 +291,8 @@ def _betaincc(xp, spx):
     return __betaincc
 
 
-def _stdtr(xp, spx):
-    betainc = _get_native_func(xp, spx, 'betainc')
+def _stdtr(xp, spsx):
+    betainc = _get_native_func(xp, spsx, 'betainc')
     if betainc is None:
         return None
 
@@ -299,9 +304,9 @@ def _stdtr(xp, spx):
     return __stdtr
 
 
-def _stdtrit(xp, spx):
+def _stdtrit(xp, spsx):
     # Need either native stdtr or native betainc
-    stdtr = _get_native_func(xp, spx, 'stdtr') or _stdtr(xp, spx)
+    stdtr = _get_native_func(xp, spsx, 'stdtr') or _stdtr(xp, spsx)
     # If betainc is not defined, the root-finding would be done with `xp`
     # despite `stdtr` being evaluated with SciPy/NumPy `stdtr`. Save the
     # conversions: in this case, just evaluate `stdtrit` with SciPy/NumPy.

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -138,7 +138,7 @@ class _FuncInfo:
 
         if in_xp:
             raise RuntimeError(
-                f"func {func} is not available as {xp.__name__}.{func}"
+                f"func {self.func} is not available as {xp.__name__}.{self.func}"
                 f" but {xp.__name__} was passed in ``in_xp``."
             )
 

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -196,8 +196,8 @@ class _FuncInfo:
                 # This needs to call `is_jax_array(arg)` in the
                 # ternary below to properly handle Python scalars.
                 dtypes = (arg.dtype if is_jax_array(arg) else type(arg) for arg in args)
-                # result_dtypes needs an arg for the dtype of the optional out param. Use
-                # `None` since `out` is incompatible with JAX's immutability.
+                # result_dtypes needs an arg for the dtype of the optional out param.
+                # Use `None` since `out` is incompatible with JAX's immutability.
                 dtypes = (*dtypes, None)
                 out_dtype = getattr(xp, str(_f.resolve_dtypes(dtypes)[-1]))
                 return xpx.lazy_apply(

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -76,10 +76,10 @@ class _FuncInfo:
     # but in the future I think it's likely we may want to add a warning to
     # xp_capabilities when not using native PyTorch on CPU.
     torch_native: bool = True
-    # Put backends in the `in_xp` list if `func` is available as `xp.func` in this
-    # backend but not available in the `scipy.special` namespace for this backend.
+    # Place a backend in this tuple if `func` is available as `xp.func` but not
+    # available in the `scipy.special` namespace for this backend.
     # One example is `jax.numpy.sinc` being available but not `jax.scipy.special.sinc`.
-    in_xp: list[str] | None = None
+    backends_with_func_in_xp: tuple[str] = ()
 
     @property
     def name(self):
@@ -127,8 +127,7 @@ class _FuncInfo:
             return self.func
 
         # If a native implementation is available, use that
-        in_xp = self.in_xp if self.in_xp is not None else []
-        in_xp = get_native_namespace_name(xp) in in_xp
+        in_xp = get_native_namespace_name(xp) in self.backends_with_func_in_xp
         namespace = xp if in_xp else _special_namespace_for(xp)
         f = _get_native_func(
             xp, namespace, self.name, alt_names_map=self.alt_names_map
@@ -137,6 +136,10 @@ class _FuncInfo:
             return f
 
         if in_xp:
+            # when namespace is passed to self.generic_impl below, we want to
+            # make sure that it is the special namespace for xp and not xp
+            # itself, so raise if xp was incorrectly placed in
+            # `backends_with_func_in_xp`.
             raise RuntimeError(
                 f"func {self.func} is not available as {xp.__name__}.{self.func}"
                 f" but {xp.__name__} was passed in ``in_xp``."
@@ -189,14 +192,13 @@ class _FuncInfo:
             # lazy backends.
             def f(*args, _f=_f, xp=xp, **kwargs):
                 # JAX uses NumPy dtypes, so it's easy to get the dtypes for
-                # use in resolve_dtypes. Needs the is_jax_array arg to properly
-                # handle Python scalars. The (None, ) appended on the end is for the
-                # dtype of out, which resolve_dtypes needs. Since JAX arrays are
-                # immutable, there can be no out, so this will always be None.
-                dtypes = (
-                    tuple(arg.dtype if is_jax_array(arg) else type(arg) for arg in args)
-                    + (None, )
-                )
+                # use in resolve_dtypes, which only works with NumPy dtypes.
+                # This needs to call `is_jax_array(arg)` in the
+                # ternary below to properly handle Python scalars.
+                dtypes = (arg.dtype if is_jax_array(arg) else type(arg) for arg in args)
+                # result_dtypes needs an arg for the dtype of the optional out param. Use
+                # `None` since `out` is incompatible with JAX's immutability.
+                dtypes = (*dtypes, None)
                 out_dtype = getattr(xp, str(_f.resolve_dtypes(dtypes)[-1]))
                 return xpx.lazy_apply(
                     _f, *args, xp=xp, as_numpy=True, dtype=out_dtype, **kwargs
@@ -829,7 +831,7 @@ _special_funcs = (
             jax_jit=True,
         ),
         is_ufunc=False,
-        in_xp=["jax.numpy"],
+        backends_with_func_in_xp=("jax.numpy",),
     ),
     _FuncInfo(
         _ufuncs.sindg, 1,

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -122,9 +122,8 @@ class _FuncInfo:
 
         # If a native implementation is available, use that
         spx = scipy_namespace_for(xp)
-        namespace = xp if self.in_xp else scipy_namespace_for(xp)
         f = _get_native_func(
-            xp, namespace, self.name, alt_names_map=self.alt_names_map,
+            xp, spx, self.name, alt_names_map=self.alt_names_map, in_xp=self.in_xp
         )
         if f is not None:
             return f

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -76,9 +76,10 @@ class _FuncInfo:
     # but in the future I think it's likely we may want to add a warning to
     # xp_capabilities when not using native PyTorch on CPU.
     torch_native: bool = True
-    # Set to True if the function to be delegated to is in the xp namespace instead of
-    # the xp.scipy.special namespace. One example is jax.numpy.sinc.
-    in_xp: bool = False
+    # Put backends in the `in_xp` list if `func` is available as `xp.func` in this
+    # backend but not available in the `scipy.special` namespace for this backend.
+    # One example is `jax.numpy.sinc` being available but not `jax.scipy.special.sinc`.
+    in_xp: list[str] | None = None
 
     @property
     def name(self):
@@ -126,16 +127,24 @@ class _FuncInfo:
             return self.func
 
         # If a native implementation is available, use that
-        namespace = xp if self.in_xp else _special_namespace_for(xp)
+        in_xp = self.in_xp if self.in_xp is not None else []
+        in_xp = get_native_namespace_name(xp) in in_xp
+        namespace = xp if in_xp else _special_namespace_for(xp)
         f = _get_native_func(
             xp, namespace, self.name, alt_names_map=self.alt_names_map
         )
         if f is not None:
             return f
 
+        if in_xp:
+            raise RuntimeError(
+                f"func {func} is not available as {xp.__name__}.{func}"
+                f" but {xp.__name__} was passed in ``in_xp``."
+            )
+
         # If generic Array API implementation is available, use that
         if self.generic_impl is not None:
-            f = self.generic_impl(xp, _special_namespace_for(xp))
+            f = self.generic_impl(xp, namespace)
             if f is not None:
                 return f
 
@@ -820,7 +829,7 @@ _special_funcs = (
             jax_jit=True,
         ),
         is_ufunc=False,
-        in_xp=True,
+        in_xp=["jax.numpy"],
     ),
     _FuncInfo(
         _ufuncs.sindg, 1,


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR updates delegation in `scipy.special` to use `xpx.lazy_apply` when falling back to NumPy for ufuncs withe JAX backend. There was a TODO message about doing this that noted it may be difficult to correctly propagate dtypes. In order to correctly resolve the output dtype, this PR relies on the `resolve_dtypes` method of ufuncs. Since non-ufuncs don't have this method, `lazy_apply` isn't used for these. Some overhead is incurred to handle the dtype resolution, but since this is just a fallback, I think that's fine. Because of the overhead, I've made it so dtype resolution and lazy_apply are only used with the JAX backend. I know there are other lazy backends and a potential for more, but it's simpler just to do this for JAX now since there's no need to worry about converting from `xp` dtypes` to NumPy dtypes in an `xp` agnostic way since JAX just uses NumPy dtypes.

#### Additional information
<!--Any additional information you think is important.-->
One functionin special where delegation is currently set up which is not a ufunc is `scipy.special.sinc` which, before wrapping through `_support_alternative_backends.py` is just an alias for `np.sinc`. `np.sinc` is not a ufunc but a `numpy._ArrayFunctionDispatcher`. I made it so we can delegate to something in the `xp` namespace instead of just `xp.scipy.special` so that we can delegate to `jax.numpy.sinc` and support the JIT (on CPU and GPU) that way.