### PR TITLE
TST: decrease resource usage (file handles, memory) of import cycles test

### DIFF
--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -12,7 +12,8 @@ from .test_public_api import PUBLIC_MODULES
 
 
 def _check_single_module(module):
-    pid = subprocess.Popen([sys.executable, '-c', f'import {module}'])
+    pid = subprocess.Popen([sys.executable, '-X', 'faulthandler', '-c',
+                            f'import {module}'])
     assert pid.wait() == 0, f'Failed to import {module}'
 
 


### PR DESCRIPTION
I also considered limiting this test to Linux x86-64 only, which would probably be fine given the purpose of this test, however there is some (very small) change of a platform-specific import cycle being introduced in the future, so I decided against that for now. Reducing resource usage by 6x without significantly increase runtime (measured as ~10% slower on my machine) should be fine.


*LLM tool usage disclosure: I used Warp for research, to check file handle limits across platforms and compare with estimate open handles for this test before making the change in this PR.* It concluded that Windows was the only problematic platform (RISC-V et al. may be memory pressure though):

<details>

Total concurrent resource usage with 40 parallel processes:
- Parent process: ~50-100 FDs (not a concern)
- 40 child processes × ~150 FDs each = ~6000 FDs system-wide

| Platform     | Default soft limit | Hard limit                 |
| ------------ | ------------------ | -------------------------- |
| Linux        | 1024               | 65536+                     |
| macOS        | 256                | 10240                      |
| Windows      | 512 (CRT)          | 8192 (with `_setmaxstdio`) |
| RISC-V Linux | Same as Linux      | Same as Linux              |

</details>

I did a quick search to confirm that Windows hard limit and couldn't find reliable info that was consistent, so 8192 could be too low. That said, reducing resource usage by 6x in this PR is clearly a win with no real downsize, so it's a good idea irrespective of whether open file handles or memory is specifically a problem for any given platform. Memory usage for 40x `import scipy` in parallel processes is clearly quite high.