### PR TITLE
MAINT: remove quirky PyPy support

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -982,7 +982,7 @@ def _cpu_count_affinity(os_cpu_count):
         except NotImplementedError:
             pass
 
-    # On PyPy and possibly other platforms, os.sched_getaffinity does not exist
+    # On some platforms, os.sched_getaffinity does not exist
     # or raises NotImplementedError, let's try with the psutil if installed.
     try:
         import psutil
@@ -996,10 +996,10 @@ def _cpu_count_affinity(os_cpu_count):
             sys.platform == "linux"
             and os.environ.get("LOKY_MAX_CPU_COUNT") is None
         ):
-            # PyPy does not implement os.sched_getaffinity on Linux which
-            # can cause severe oversubscription problems. Better warn the
-            # user in this particularly pathological case which can wreck
-            # havoc, typically on CI workers.
+            # On Linux no cpu_affinity can cause severe oversubscription
+            # problems. Better warn the user in this particularly
+            # pathological case which can wreck havoc, typically on CI
+            # workers.
             warnings.warn(
                 "Failed to inspect CPU affinity constraints on this system. "
                 "Please install psutil or explicitly set LOKY_MAX_CPU_COUNT.",

--- a/scipy/_lib/tests/test__gcutils.py
+++ b/scipy/_lib/tests/test__gcutils.py
@@ -4,7 +4,7 @@ import gc
 from threading import Lock
 
 from scipy._lib._gcutils import (set_gc_state, gc_state, assert_deallocated,
-                                 ReferenceError, IS_PYPY)
+                                 ReferenceError)
 
 from numpy.testing import assert_equal
 
@@ -55,7 +55,6 @@ def test_gc_state(gc_lock):
                 gc.enable()
 
 
-@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_assert_deallocated(gc_lock):
     # Ordinary use
     class C:
@@ -74,7 +73,6 @@ def test_assert_deallocated(gc_lock):
                 assert_equal(gc.isenabled(), gc_current)
 
 
-@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_assert_deallocated_nodel():
     class C:
         pass
@@ -88,7 +86,6 @@ def test_assert_deallocated_nodel():
             pass
 
 
-@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_assert_deallocated_circular():
     class C:
         def __init__(self):
@@ -99,7 +96,6 @@ def test_assert_deallocated_circular():
             del c
 
 
-@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_assert_deallocated_circular2():
     class C:
         def __init__(self):

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -82,16 +82,6 @@ def _max_norm(x):
     return np.amax(abs(x))
 
 
-def _get_sizeof(obj):
-    try:
-        return sys.getsizeof(obj)
-    except TypeError:
-        # occurs on pypy
-        if hasattr(obj, '__sizeof__'):
-            return int(obj.__sizeof__())
-        return 64
-
-
 class _Bunch:
     def __init__(self, **kwargs):
         self.__keys = kwargs.keys()
@@ -350,7 +340,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
             global_error = float(err)
             rounding_error = float(rnd)
 
-            cache_count = cache_size // _get_sizeof(ig)
+            cache_count = cache_size // sys.getsizeof(ig)
             interval_cache = LRUDict(cache_count)
         else:
             global_integral += ig

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -16,7 +16,7 @@ from scipy.special import poch, gamma
 
 from scipy.interpolate import _ppoly
 
-from scipy._lib._gcutils import assert_deallocated, IS_PYPY
+from scipy._lib._gcutils import assert_deallocated
 from scipy._lib._testutils import _run_concurrent_barrier
 
 from scipy.integrate import nquad
@@ -756,7 +756,6 @@ class TestInterp1D:
             self._check_complex(np.complex64, kind)
             self._check_complex(np.complex128, kind)
 
-    @pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
     def test_circular_refs(self):
         # Test interp1d can be automatically garbage collected
         x = np.linspace(0, 1)

--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -37,7 +37,6 @@ __all__ = ['netcdf_file', 'netcdf_variable']
 import warnings
 import weakref
 from operator import mul
-from platform import python_implementation
 
 import mmap as mm
 
@@ -46,8 +45,6 @@ from numpy import frombuffer, dtype, empty, array, asarray
 from numpy import little_endian as LITTLE_ENDIAN
 from functools import reduce
 
-
-IS_PYPY = python_implementation() == 'PyPy'
 
 ABSENT = b'\x00\x00\x00\x00\x00\x00\x00\x00'
 ZERO = b'\x00\x00\x00\x00'
@@ -250,10 +247,7 @@ class netcdf_file:
             omode = 'r+' if mode == 'a' else mode
             self.fp = open(self.filename, f'{omode}b')
             if mmap is None:
-                # Mmapped files on PyPy cannot be usually closed
-                # before the GC runs, so it's better to use mmap=False
-                # as the default.
-                mmap = (not IS_PYPY)
+                mmap = True
 
         if mode != 'r':
             # Cannot read write-only files

--- a/scipy/io/matlab/_mio5.py
+++ b/scipy/io/matlab/_mio5.py
@@ -472,7 +472,7 @@ def to_writeable(source):
                   hasattr(source, 'items'))
     # Objects that don't implement mappings, but do have dicts
     if isinstance(source, np.generic):
-        # NumPy scalars are never mappings (PyPy issue workaround)
+        # NumPy scalars are never mappings
         pass
     elif not is_mapping and hasattr(source, '__dict__'):
         source = {key: value for key, value in source.__dict__.items()

--- a/scipy/io/tests/test_wavfile.py
+++ b/scipy/io/tests/test_wavfile.py
@@ -11,7 +11,6 @@ import pytest
 from pytest import raises, warns
 
 from scipy.io import wavfile
-from scipy._lib._gcutils import IS_PYPY, break_cycles
 
 
 def datafile(fn):
@@ -487,12 +486,6 @@ def test_write_roundtrip(realfile, mmap, rate, channels, dt_str, tmpdir):
     else:
         with pytest.raises(ValueError, match='read-only'):
             data2[0] = 0
-
-    if realfile and mmap and IS_PYPY and sys.platform == 'win32':
-        # windows cannot remove a dead file held by a mmap but not collected
-        # in PyPy; since the filename gets reused in this test, clean this up
-        break_cycles()
-        break_cycles()
 
 
 @pytest.mark.parametrize("dtype", [np.float16])

--- a/scipy/optimize/_zerosmodule.c
+++ b/scipy/optimize/_zerosmodule.c
@@ -12,17 +12,8 @@
  * Caller entry point functions
  */
 
-#ifdef PYPY_VERSION
-    /*
-     * As described in http://doc.pypy.org/en/latest/cpython_differences.html#c-api-differences,
-     * "assignment to a PyTupleObject is not supported after the tuple is used internally,
-     * even by another C-API function call."
-     */
-    #define PyArgs(Operation) PyList_##Operation
-#else
-    /* Using a list in CPython raises "TypeError: argument list must be a tuple" */
-    #define PyArgs(Operation) PyTuple_##Operation
-#endif
+/* Using a list in CPython raises "TypeError: argument list must be a tuple" */
+#define PyArgs(Operation) PyTuple_##Operation
 
 typedef struct {
     PyObject *function;

--- a/scipy/optimize/tests/test__shgo.py
+++ b/scipy/optimize/tests/test__shgo.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import warnings
 
 import numpy as np
@@ -13,8 +12,6 @@ from scipy.optimize import (shgo, Bounds, minimize_scalar, minimize, rosen,
 from scipy.optimize._constraints import new_constraint_to_old
 from scipy.optimize._shgo import SHGO
 from scipy.optimize.tests.test_minimize_constrained import MaratosTestArgs
-
-IS_PYPY = sys.implementation.name == 'pypy'
 
 
 class StructTestFunction:
@@ -747,8 +744,6 @@ class TestShgoArguments:
         """Test single function constraint passing"""
         SHGO(test3_1.f, test3_1.bounds, constraints=test3_1.cons[0])
 
-    @pytest.mark.xfail(IS_PYPY and sys.platform == 'win32',
-            reason="Failing and fix in PyPy not planned (see gh-18632)")
     def test_10_finite_time(self):
         """Test single function constraint passing"""
         options = {'maxtime': 1e-15}

--- a/scipy/optimize/tests/test_differentiable_functions.py
+++ b/scipy/optimize/tests/test_differentiable_functions.py
@@ -1,5 +1,4 @@
 import pytest
-import platform
 import numpy as np
 from numpy.testing import (TestCase, assert_array_almost_equal,
                            assert_array_equal, assert_, assert_allclose,
@@ -995,10 +994,6 @@ def test_IdentityVectorFunction():
     assert_array_equal(f1.hess(x, v).toarray(), np.zeros((3, 3)))
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy",
-    reason="assert_deallocate not available on PyPy"
-)
 def test_ScalarFunctionNoReferenceCycle():
     """Regression test for gh-20768."""
     ex = ExScalarFunction()
@@ -1008,10 +1003,6 @@ def test_ScalarFunctionNoReferenceCycle():
         pass
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy",
-    reason="assert_deallocate not available on PyPy"
-)
 def test_VectorFunctionNoReferenceCycle():
     """Regression test for gh-20768."""
     ex = ExVectorialFunction()
@@ -1021,10 +1012,6 @@ def test_VectorFunctionNoReferenceCycle():
         pass
 
 
-@pytest.mark.skipif(
-    platform.python_implementation() == "PyPy",
-    reason="assert_deallocate not available on PyPy"
-)
 def test_LinearVectorFunctionNoReferenceCycle():
     """Regression test for gh-20768."""
     A_dense = np.array([

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -16,7 +16,7 @@ from scipy.sparse.linalg._eigen.arpack import (eigs, eigsh, arpack,
                                               ArpackNoConvergence)
 
 
-from scipy._lib._gcutils import assert_deallocated, IS_PYPY
+from scipy._lib._gcutils import assert_deallocated
 
 
 # precision for tests
@@ -522,7 +522,6 @@ def test_ticket_1459_arpack_crash():
         evals, evecs = eigs(A, k, v0=v0)
 
 
-@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_linearoperator_deallocation():
     # Check that the linear operators used by the Arpack wrappers are
     # deallocatable by reference counting -- they are big objects, so

--- a/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_lgmres.py
@@ -5,8 +5,6 @@ import warnings
 
 from numpy.testing import (assert_, assert_allclose, assert_equal)
 
-import pytest
-from platform import python_implementation
 
 import numpy as np
 from numpy import zeros, array, allclose
@@ -105,8 +103,6 @@ class TestLGMRES:
         assert_(count_1 < count_0/2)
         assert_(allclose(x1, x0, rtol=1e-14))
 
-    @pytest.mark.skipif(python_implementation() == 'PyPy',
-                        reason="Fails on PyPy CI runs. See #9507")
     def test_arnoldi(self):
         rng = np.random.default_rng(123)
 

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -14,7 +14,7 @@ import scipy.sparse as sparse
 
 import scipy.sparse.linalg._interface as interface
 from scipy.sparse._sputils import matrix
-from scipy._lib._gcutils import assert_deallocated, IS_PYPY
+from scipy._lib._gcutils import assert_deallocated
 
 
 class TestLinearOperator:
@@ -829,7 +829,6 @@ def test_sparse_matmat_exception():
         np.identity(4) @ A
 
 
-@pytest.mark.skipif(IS_PYPY, reason="Test not meaningful on PyPy")
 def test_MatrixLinearOperator_refcycle():
     # gh-10634
     # Test that MatrixLinearOperator can be automatically garbage collected

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -398,8 +398,7 @@ cdef class _Qhull:
         # Note: this is direct copypaste from __dealloc__(), keep it
         # in sync with that.  The code must be written directly in
         # __dealloc__, because otherwise the generated C code tries to
-        # call PyObject_GetAttrStr(self, "close") which on Pypy
-        # crashes.
+        # call PyObject_GetAttrStr(self, "close") which resuscitates self
 
         cdef int curlong, totlong
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -43,8 +43,7 @@ import numpy as np
 from numpy.linalg import norm
 from numpy.testing import (verbose, assert_,
                            assert_array_equal, assert_equal,
-                           assert_almost_equal, assert_allclose,
-                           break_cycles, IS_PYPY)
+                           assert_almost_equal, assert_allclose)
 import pytest
 
 import scipy.spatial.distance
@@ -689,8 +688,6 @@ class TestCdist:
         weak_refs = [weakref.ref(v) for v in (x1, x2, out)]
         del x1, x2, out
 
-        if IS_PYPY:
-            break_cycles()
         assert all(weak_ref() is None for weak_ref in weak_refs)
 
 

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -7,7 +7,6 @@ from numpy.testing import (assert_equal, assert_array_equal, assert_,
                            assert_allclose)
 from pytest import raises as assert_raises
 import pytest
-from platform import python_implementation
 import numpy as np
 from scipy.spatial import KDTree, Rectangle, distance_matrix, cKDTree
 from scipy.spatial._ckdtree import cKDTreeNode
@@ -1058,8 +1057,6 @@ def simulate_periodic_box(kdtree, data, k, boxsize, p):
     return result['dd'][:, :k], result['ii'][:, :k]
 
 
-@pytest.mark.skipif(python_implementation() == 'PyPy',
-                    reason="Fails on PyPy CI runs. See #9507")
 def test_ckdtree_memuse():
     # unit test adaptation of gh-5630
 

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -52,12 +52,7 @@ all_methods = [
     ("SimpleRatioUniforms", {"dist": StandardNormal(), "mode": 0})
 ]
 
-if (sys.implementation.name == 'pypy'
-        and sys.implementation.version < (7, 3, 10)):
-    # changed in PyPy for v7.3.10
-    floaterr = r"unsupported operand type for float\(\): 'list'"
-else:
-    floaterr = r"must be real number, not list"
+floaterr = r"must be real number, not list"
 # Make sure an internal error occurs in UNU.RAN when invalid callbacks are
 # passed. Moreover, different generators throw different error messages.
 # So, in case of an `UNURANError`, we do not validate the error message.


### PR DESCRIPTION
Continuation of #24491, completely remove support for PyPy.

Unfortunately it seems PyPy development has stalled, and these shims can be removed. Since this will be done in one PR, it should be easy to revert in the unlikely case it will be needed.