### PR TITLE
BUG: special: get JAX delegation under the JIT to work with mixed python scalar and array inputs

### DIFF
--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -189,18 +189,26 @@ class _FuncInfo:
         if is_jax(xp) and self.is_ufunc:
             # if this is a ufunc, we can use the resolve_dtypes method to figure
             # out what the output dtype should be and use lazy_apply to make this
-            # work with the JAX JIT. TODO: explore making this work for other
-            # lazy backends.
+            # work with the JAX JIT. Since pure_callback used in lazy_apply will
+            # convert all of the inputs to eager JAX arrays, we will also need to
+            # get the input dtypes inferred from resolve_dtypes so that Python
+            # scalar inputs can be cast to the correct dtype under NEP50 weak
+            # promotion rules rather than getting promoted to the default currently
+            # set in JAX. One cannot just use xp_promote for the input dtypes because
+            # some ufuncs have integer only args.
             def f(*args, _f=_f, xp=xp, **kwargs):
-                # JAX uses NumPy dtypes, so it's easy to get the dtypes for
-                # use in resolve_dtypes, which only works with NumPy dtypes.
-                # This needs to call `is_jax_array(arg)` in the
-                # ternary below to properly handle Python scalars.
                 dtypes = (arg.dtype if is_jax_array(arg) else type(arg) for arg in args)
                 # result_dtypes needs an arg for the dtype of the optional out param.
                 # Use `None` since `out` is incompatible with JAX's immutability.
                 dtypes = (*dtypes, None)
-                out_dtype = getattr(xp, str(_f.resolve_dtypes(dtypes)[-1]))
+                # JAX uses NumPy dtypes so we can just pass these directly to
+                # resolve_dtypes. TODO: generalize to other lazy backends.
+                dtypes = _f.resolve_dtypes(dtypes)
+                out_dtype = dtypes[-1]
+                args = [
+                    xp.asarray(arg, dtype=dtype)
+                    for arg, dtype in zip(args, dtypes[:-1])
+                ]
                 return xpx.lazy_apply(
                     _f, *args, xp=xp, as_numpy=True, dtype=out_dtype, **kwargs
                 )

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -7,7 +7,8 @@ from types import ModuleType
 import numpy as np
 from scipy._lib._array_api import (
     array_namespace, scipy_namespace_for, is_numpy, is_dask, is_marray, is_jax_array,
-    is_jax, xp_promote, xp_capabilities, SCIPY_ARRAY_API, get_native_namespace_name
+    is_jax, xp_promote, xp_capabilities, SCIPY_ARRAY_API, get_native_namespace_name,
+    is_array_api_obj
 )
 import scipy._external.array_api_extra as xpx
 from . import _basic
@@ -205,7 +206,11 @@ class _FuncInfo:
                 )
         else:
             def f(*args, _f=_f, xp=xp, **kwargs):
-                args = [np.asarray(arg) for arg in args]
+                # Check with `is_array_api_obj` to keep Python scalars untouched so that
+                # NEP50 can be followed.
+                args = [
+                    np.asarray(arg) if is_array_api_obj(arg) else arg for arg in args
+                ]
                 out = _f(*args, **kwargs)
                 return xp.asarray(out)
 

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -394,3 +394,11 @@ def test_chdtr_gh21311(xp):
     ref = special.chdtr(v, x)
     res = special.chdtr(xp.asarray(v), xp.asarray(x))
     xp_assert_close(res, xp.asarray(ref))
+
+
+@make_xp_test_case(special.fdtrc)
+def test_mixed_arrays_and_python_scalars(xp):
+    # Tests that the delegation infrastructure respects NEP50.
+    res = special.fdtrc(1.1, 2., xp.asarray(1., dtype=xp.float32))
+    ref = xp.asarray(0.4349004, dtype=xp.float32)
+    xp_assert_close(res, ref)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
[`jax.pure_callback`](https://docs.jax.dev/en/latest/_autosummary/jax.pure_callback.html) used in [`xpx.lazy_apply`](https://data-apis.org/array-api-extra/generated/array_api_extra.lazy_apply.html) converts inputs passed as `*args` to eager JAX arrays. This means that when the args passed to `lazy_apply` contain a mix of Python scalars and JAX arrays, then NEP50 weak-promotion of Python scalars will be violated. Under the JAX JIT, this can be catastrophic, because `pure_callback` makes a promise that the output dtype will be as expected, but because the args are promoted incorrectly, the output can be something else, resulting in runtime errors like the following

```
RuntimeError: Incorrect output dtype for return value #0: Expected: float32, Actual: float64
```

This PR adds a workaround in `scipy/special/_support_alternative_backends.py` which casts each of the input args to arrays of the dtype found through the `resolve_dtypes` method of the ufunc being wrapped for delegation. It seems like it may be useful to add a workaround in `lazy_apply` itself, but for now I think this works. Perhaps in the long run, the JAX devs may be receptive to changing the behavior of `pure_callback` to allow adherence to NEP50 style promotion.

I've added a test case containing an example pointed out to me by @mdhaber, who first noticed that mixing float32 arrays with python scalars in `args` passed to `lazy_apply` doesn't work under the JAX JIT when float64 mode is enabled.

#### Additional information
<!--Any additional information you think is important.-->
