### PR TITLE
BUG: special: ensure that ufuncs follow NEP50 promotion rules

### DIFF
--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -62,22 +62,22 @@ _gufuncs_module_exec(PyObject *module)
     PyObject *legendre_p_all =
         Py_BuildValue("(N, N, N)",
                       xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff()},
-                                          static_cast<xsf::numpy::autodiff0_d_d1>(xsf::legendre_p_all),
                                           static_cast<xsf::numpy::autodiff0_f_f1>(xsf::legendre_p_all),
-                                          static_cast<xsf::numpy::autodiff0_D_D1>(xsf::legendre_p_all),
-                                          static_cast<xsf::numpy::autodiff0_F_F1>(xsf::legendre_p_all)},
+                                          static_cast<xsf::numpy::autodiff0_d_d1>(xsf::legendre_p_all),
+                                          static_cast<xsf::numpy::autodiff0_F_F1>(xsf::legendre_p_all),
+                                          static_cast<xsf::numpy::autodiff0_D_D1>(xsf::legendre_p_all)},
                                          1, "legendre_p_all", nullptr, "()->(np1,1)", new_legendre_map_dims),
                       xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff()},
-                                          static_cast<xsf::numpy::autodiff1_d_d1>(xsf::legendre_p_all),
                                           static_cast<xsf::numpy::autodiff1_f_f1>(xsf::legendre_p_all),
-                                          static_cast<xsf::numpy::autodiff1_D_D1>(xsf::legendre_p_all),
-                                          static_cast<xsf::numpy::autodiff1_F_F1>(xsf::legendre_p_all)},
+                                          static_cast<xsf::numpy::autodiff1_d_d1>(xsf::legendre_p_all),
+                                          static_cast<xsf::numpy::autodiff1_F_F1>(xsf::legendre_p_all),
+                                          static_cast<xsf::numpy::autodiff1_D_D1>(xsf::legendre_p_all)},
                                          1, "legendre_p_all", nullptr, "()->(np1,2)", new_legendre_map_dims),
                       xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff()},
-                                          static_cast<xsf::numpy::autodiff2_d_d1>(xsf::legendre_p_all),
                                           static_cast<xsf::numpy::autodiff2_f_f1>(xsf::legendre_p_all),
-                                          static_cast<xsf::numpy::autodiff2_D_D1>(xsf::legendre_p_all),
-                                          static_cast<xsf::numpy::autodiff2_F_F1>(xsf::legendre_p_all)},
+                                          static_cast<xsf::numpy::autodiff2_d_d1>(xsf::legendre_p_all),
+                                          static_cast<xsf::numpy::autodiff2_F_F1>(xsf::legendre_p_all),
+                                          static_cast<xsf::numpy::autodiff2_D_D1>(xsf::legendre_p_all)},
                                          1, "legendre_p_all", nullptr, "()->(np1,3)", new_legendre_map_dims));
     PyModule_AddObjectRef(module, "legendre_p_all", legendre_p_all);
 
@@ -85,91 +85,91 @@ _gufuncs_module_exec(PyObject *module)
     PyObject *assoc_legendre_p_all = Py_BuildValue(
         "{(O, i): N, (O, i): N, (O, i): N, (O, i): N, (O, i): N, (O, i): N}", Py_True, 0,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](xsf::numpy::autodiff0_double z, int branch_cut, xsf::numpy::autodiff0_double_2d res) {
-                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
-                            },
                             [](xsf::numpy::autodiff0_float z, int branch_cut, xsf::numpy::autodiff0_float_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
                             },
-                            [](xsf::numpy::autodiff0_cdouble z, int branch_cut, xsf::numpy::autodiff0_cdouble_2d res) {
+                            [](xsf::numpy::autodiff0_double z, int branch_cut, xsf::numpy::autodiff0_double_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
                             },
                             [](xsf::numpy::autodiff0_cfloat z, int branch_cut, xsf::numpy::autodiff0_cfloat_2d res) {
+                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
+                            },
+                            [](xsf::numpy::autodiff0_cdouble z, int branch_cut, xsf::numpy::autodiff0_cdouble_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
                             }},
                            1, "assoc_legendre_p_all", nullptr, "(),()->(np1,mpmp1,1)", assoc_legendre_map_dims<1>),
         Py_True, 1,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](xsf::numpy::autodiff1_double z, int branch_cut, xsf::numpy::autodiff1_double_2d res) {
-                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
-                            },
                             [](xsf::numpy::autodiff1_float z, int branch_cut, xsf::numpy::autodiff1_float_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
                             },
-                            [](xsf::numpy::autodiff1_cdouble z, int branch_cut, xsf::numpy::autodiff1_cdouble_2d res) {
+                            [](xsf::numpy::autodiff1_double z, int branch_cut, xsf::numpy::autodiff1_double_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
                             },
                             [](xsf::numpy::autodiff1_cfloat z, int branch_cut, xsf::numpy::autodiff1_cfloat_2d res) {
+                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
+                            },
+                            [](xsf::numpy::autodiff1_cdouble z, int branch_cut, xsf::numpy::autodiff1_cdouble_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
                             }},
                            1, "assoc_legendre_p_all", nullptr, "(),()->(np1,mpmp1,2)", assoc_legendre_map_dims<1>),
         Py_True, 2,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](xsf::numpy::autodiff2_double z, int branch_cut, xsf::numpy::autodiff2_double_2d res) {
-                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
-                            },
                             [](xsf::numpy::autodiff2_float z, int branch_cut, xsf::numpy::autodiff2_float_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
                             },
-                            [](xsf::numpy::autodiff2_cdouble z, int branch_cut, xsf::numpy::autodiff2_cdouble_2d res) {
+                            [](xsf::numpy::autodiff2_double z, int branch_cut, xsf::numpy::autodiff2_double_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
                             },
                             [](xsf::numpy::autodiff2_cfloat z, int branch_cut, xsf::numpy::autodiff2_cfloat_2d res) {
+                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
+                            },
+                            [](xsf::numpy::autodiff2_cdouble z, int branch_cut, xsf::numpy::autodiff2_cdouble_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_norm, z, branch_cut, res);
                             }},
                            1, "assoc_legendre_p_all", nullptr, "(),()->(np1,mpmp1,3)", assoc_legendre_map_dims<1>),
         Py_False, 0,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](xsf::numpy::autodiff0_double z, int branch_cut, xsf::numpy::autodiff0_double_2d res) {
-                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
-                            },
                             [](xsf::numpy::autodiff0_float z, int branch_cut, xsf::numpy::autodiff0_float_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
                             },
-                            [](xsf::numpy::autodiff0_cdouble z, int branch_cut, xsf::numpy::autodiff0_cdouble_2d res) {
+                            [](xsf::numpy::autodiff0_double z, int branch_cut, xsf::numpy::autodiff0_double_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
                             },
                             [](xsf::numpy::autodiff0_cfloat z, int branch_cut, xsf::numpy::autodiff0_cfloat_2d res) {
+                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
+                            },
+                            [](xsf::numpy::autodiff0_cdouble z, int branch_cut, xsf::numpy::autodiff0_cdouble_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
                             }},
                            1, "assoc_legendre_p_all", nullptr, "(),()->(np1,mpmp1,1)", assoc_legendre_map_dims<1>),
         Py_False, 1,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](xsf::numpy::autodiff1_double z, int branch_cut, xsf::numpy::autodiff1_double_2d res) {
-                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
-                            },
                             [](xsf::numpy::autodiff1_float z, int branch_cut, xsf::numpy::autodiff1_float_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
                             },
-                            [](xsf::numpy::autodiff1_cdouble z, int branch_cut, xsf::numpy::autodiff1_cdouble_2d res) {
+                            [](xsf::numpy::autodiff1_double z, int branch_cut, xsf::numpy::autodiff1_double_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
                             },
                             [](xsf::numpy::autodiff1_cfloat z, int branch_cut, xsf::numpy::autodiff1_cfloat_2d res) {
+                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
+                            },
+                            [](xsf::numpy::autodiff1_cdouble z, int branch_cut, xsf::numpy::autodiff1_cdouble_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
                             }},
                            1, "assoc_legendre_p_all", nullptr, "(),()->(np1,mpmp1,2)", assoc_legendre_map_dims<1>),
         Py_False, 2,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](xsf::numpy::autodiff2_double z, int branch_cut, xsf::numpy::autodiff2_double_2d res) {
-                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
-                            },
                             [](xsf::numpy::autodiff2_float z, int branch_cut, xsf::numpy::autodiff2_float_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
                             },
-                            [](xsf::numpy::autodiff2_cdouble z, int branch_cut, xsf::numpy::autodiff2_cdouble_2d res) {
+                            [](xsf::numpy::autodiff2_double z, int branch_cut, xsf::numpy::autodiff2_double_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
                             },
                             [](xsf::numpy::autodiff2_cfloat z, int branch_cut, xsf::numpy::autodiff2_cfloat_2d res) {
+                                xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
+                            },
+                            [](xsf::numpy::autodiff2_cdouble z, int branch_cut, xsf::numpy::autodiff2_cdouble_2d res) {
                                 xsf::assoc_legendre_p_all(xsf::assoc_legendre_unnorm, z, branch_cut, res);
                             }},
                            1, "assoc_legendre_p_all", nullptr, "(),()->(np1,mpmp1,3)", assoc_legendre_map_dims<1>));
@@ -178,54 +178,54 @@ _gufuncs_module_exec(PyObject *module)
     PyObject *sph_legendre_p_all = Py_BuildValue(
         "(N, N, N)",
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff()},
-                            static_cast<xsf::numpy::autodiff0_d_d2>(xsf::sph_legendre_p_all),
-                            static_cast<xsf::numpy::autodiff0_f_f2>(xsf::sph_legendre_p_all)},
+                            static_cast<xsf::numpy::autodiff0_f_f2>(xsf::sph_legendre_p_all),
+                            static_cast<xsf::numpy::autodiff0_d_d2>(xsf::sph_legendre_p_all)},
                            1, "sph_legendre_p_all", nullptr, "()->(np1,mpmp1,1)", assoc_legendre_map_dims<1>),
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff()},
-                            static_cast<xsf::numpy::autodiff1_d_d2>(xsf::sph_legendre_p_all),
-                            static_cast<xsf::numpy::autodiff1_f_f2>(xsf::sph_legendre_p_all)},
+                            static_cast<xsf::numpy::autodiff1_f_f2>(xsf::sph_legendre_p_all),
+                            static_cast<xsf::numpy::autodiff1_d_d2>(xsf::sph_legendre_p_all)},
                            1, "sph_legendre_p_all", nullptr, "()->(np1,mpmp1,2)", assoc_legendre_map_dims<1>),
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff()},
-                            static_cast<xsf::numpy::autodiff2_d_d2>(xsf::sph_legendre_p_all),
-                            static_cast<xsf::numpy::autodiff2_f_f2>(xsf::sph_legendre_p_all)},
+                            static_cast<xsf::numpy::autodiff2_f_f2>(xsf::sph_legendre_p_all),
+                            static_cast<xsf::numpy::autodiff2_d_d2>(xsf::sph_legendre_p_all)},
                            1, "sph_legendre_p_all", nullptr, "()->(np1,mpmp1,3)", assoc_legendre_map_dims<1>));
     PyModule_AddObjectRef(module, "sph_legendre_p_all", sph_legendre_p_all);
 
     PyObject *_lqn =
-        xsf::numpy::gufunc({static_cast<xsf::numpy::d_d1d1>(xsf::lqn), static_cast<xsf::numpy::f_f1f1>(xsf::lqn),
-                            static_cast<xsf::numpy::D_D1D1>(xsf::lqn), static_cast<xsf::numpy::F_F1F1>(xsf::lqn)},
+        xsf::numpy::gufunc({static_cast<xsf::numpy::f_f1f1>(xsf::lqn), static_cast<xsf::numpy::d_d1d1>(xsf::lqn),
+                            static_cast<xsf::numpy::F_F1F1>(xsf::lqn), static_cast<xsf::numpy::D_D1D1>(xsf::lqn)},
                            2, "_lqn", lqn_doc, "()->(np1),(np1)", legendre_map_dims<2>);
     PyModule_AddObjectRef(module, "_lqn", _lqn);
 
     PyObject *_lqmn =
-        xsf::numpy::gufunc({static_cast<xsf::numpy::d_d2d2>(xsf::lqmn), static_cast<xsf::numpy::f_f2f2>(xsf::lqmn),
-                            static_cast<xsf::numpy::D_D2D2>(xsf::lqmn), static_cast<xsf::numpy::F_F2F2>(xsf::lqmn)},
+        xsf::numpy::gufunc({static_cast<xsf::numpy::f_f2f2>(xsf::lqmn), static_cast<xsf::numpy::d_d2d2>(xsf::lqmn),
+                            static_cast<xsf::numpy::F_F2F2>(xsf::lqmn), static_cast<xsf::numpy::D_D2D2>(xsf::lqmn)},
                            2, "_lqmn", lqmn_doc, "()->(mp1,np1),(mp1,np1)", assoc_legendre_map_dims<2>);
     PyModule_AddObjectRef(module, "_lqmn", _lqmn);
 
     PyObject *sph_harm_y_all =
         Py_BuildValue("(N, N, N)",
                       xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff()},
-                                          static_cast<xsf::numpy::autodiff00_dd_D2>(xsf::sph_harm_y_all),
-                                          static_cast<xsf::numpy::autodiff00_ff_F2>(xsf::sph_harm_y_all)},
+                                          static_cast<xsf::numpy::autodiff00_ff_F2>(xsf::sph_harm_y_all),
+                                          static_cast<xsf::numpy::autodiff00_dd_D2>(xsf::sph_harm_y_all)},
                                          1, "sph_harm_y_all", nullptr, "(),()->(np1,mpmp1,1,1)", sph_harm_map_dims),
                       xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff()},
-                                          static_cast<xsf::numpy::autodiff11_dd_D2>(xsf::sph_harm_y_all),
-                                          static_cast<xsf::numpy::autodiff11_ff_F2>(xsf::sph_harm_y_all)},
+                                          static_cast<xsf::numpy::autodiff11_ff_F2>(xsf::sph_harm_y_all),
+                                          static_cast<xsf::numpy::autodiff11_dd_D2>(xsf::sph_harm_y_all)},
                                          1, "sph_harm_y_all", nullptr, "(),()->(np1,mpmp1,2,2)", sph_harm_map_dims),
                       xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff()},
-                                          static_cast<xsf::numpy::autodiff22_dd_D2>(xsf::sph_harm_y_all),
-                                          static_cast<xsf::numpy::autodiff22_ff_F2>(xsf::sph_harm_y_all)},
+                                          static_cast<xsf::numpy::autodiff22_ff_F2>(xsf::sph_harm_y_all),
+                                          static_cast<xsf::numpy::autodiff22_dd_D2>(xsf::sph_harm_y_all)},
                                          1, "sph_harm_y_all", nullptr, "(),()->(np1,mpmp1,3,3)", sph_harm_map_dims));
     PyModule_AddObjectRef(module, "sph_harm_y_all", sph_harm_y_all);
 
     PyObject *_rctj =
-        xsf::numpy::gufunc({static_cast<xsf::numpy::d_d1d1>(xsf::rctj), static_cast<xsf::numpy::f_f1f1>(xsf::rctj)}, 2,
+        xsf::numpy::gufunc({static_cast<xsf::numpy::f_f1f1>(xsf::rctj), static_cast<xsf::numpy::d_d1d1>(xsf::rctj)}, 2,
                            "_rctj", rctj_doc, "()->(np1),(np1)", legendre_map_dims<2>);
     PyModule_AddObjectRef(module, "_rctj", _rctj);
 
     PyObject *_rcty =
-        xsf::numpy::gufunc({static_cast<xsf::numpy::d_d1d1>(xsf::rcty), static_cast<xsf::numpy::f_f1f1>(xsf::rcty)}, 2,
+        xsf::numpy::gufunc({static_cast<xsf::numpy::f_f1f1>(xsf::rcty), static_cast<xsf::numpy::d_d1d1>(xsf::rcty)}, 2,
                            "_rcty", rcty_doc, "()->(np1),(np1)", legendre_map_dims<2>);
     PyModule_AddObjectRef(module, "_rcty", _rcty);
 

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -247,7 +247,7 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "_lambertw", _lambertw);
 
     PyObject *_scaled_exp1 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::scaled_exp1), static_cast<xsf::numpy::f_f>(xsf::scaled_exp1)},
+	{static_cast<xsf::numpy::f_f>(xsf::scaled_exp1), static_cast<xsf::numpy::d_d>(xsf::scaled_exp1)},
         "_scaled_exp1", scaled_exp1_doc);
     PyModule_AddObjectRef(module, "_scaled_exp1", _scaled_exp1);
 
@@ -292,16 +292,16 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "berp", berp);
 
     PyObject *besselpoly = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ddd_d>(xsf::besselpoly), static_cast<xsf::numpy::fff_f>(xsf::besselpoly)},
+	{static_cast<xsf::numpy::fff_f>(xsf::besselpoly), static_cast<xsf::numpy::ddd_d>(xsf::besselpoly)},
         "besselpoly", besselpoly_doc);
     PyModule_AddObjectRef(module, "besselpoly", besselpoly);
 
     PyObject *beta = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::dd_d>(xsf::beta), static_cast<xsf::numpy::ff_f>(xsf::beta)}, "beta", beta_doc);
+	{static_cast<xsf::numpy::ff_f>(xsf::beta), static_cast<xsf::numpy::dd_d>(xsf::beta)}, "beta", beta_doc);
     PyModule_AddObjectRef(module, "beta", beta);
 
     PyObject *betaln = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::dd_d>(xsf::betaln), static_cast<xsf::numpy::ff_f>(xsf::betaln)}, "betaln", betaln_doc);
+	{static_cast<xsf::numpy::ff_f>(xsf::betaln), static_cast<xsf::numpy::dd_d>(xsf::betaln)}, "betaln", betaln_doc);
     PyModule_AddObjectRef(module, "betaln", betaln);
 
     PyObject *binom = xsf::numpy::ufunc(
@@ -309,28 +309,28 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "binom", binom);
 
     PyObject *cbrt = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cbrt), static_cast<xsf::numpy::f_f>(xsf::cbrt)}, "cbrt", cbrt_doc);
+	{static_cast<xsf::numpy::f_f>(xsf::cbrt), static_cast<xsf::numpy::d_d>(xsf::cbrt)}, "cbrt", cbrt_doc);
     PyModule_AddObjectRef(module, "cbrt", cbrt);
 
     PyObject *cosdg = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cosdg), static_cast<xsf::numpy::f_f>(xsf::cosdg)}, "cosdg", cosdg_doc);
+	{static_cast<xsf::numpy::f_f>(xsf::cosdg), static_cast<xsf::numpy::d_d>(xsf::cosdg)}, "cosdg", cosdg_doc);
     PyModule_AddObjectRef(module, "cosdg", cosdg);
 
     PyObject *cosm1 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cosm1), static_cast<xsf::numpy::f_f>(xsf::cosm1)}, "cosm1", cosm1_doc);
+	{static_cast<xsf::numpy::f_f>(xsf::cosm1), static_cast<xsf::numpy::d_d>(xsf::cosm1)}, "cosm1", cosm1_doc);
     PyModule_AddObjectRef(module, "cosm1", cosm1);
 
     PyObject *cotdg = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cotdg), static_cast<xsf::numpy::f_f>(xsf::cotdg)}, "cotdg", cotdg_doc);
+	{static_cast<xsf::numpy::f_f>(xsf::cotdg), static_cast<xsf::numpy::d_d>(xsf::cotdg)}, "cotdg", cotdg_doc);
     PyModule_AddObjectRef(module, "cotdg", cotdg);
 
     PyObject *ellipj = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::dd_dddd>(xsf::ellipj), static_cast<xsf::numpy::ff_ffff>(xsf::ellipj)}, 4, "ellipj",
+	{static_cast<xsf::numpy::ff_ffff>(xsf::ellipj), static_cast<xsf::numpy::dd_dddd>(xsf::ellipj)}, 4, "ellipj",
         ellipj_doc);
     PyModule_AddObjectRef(module, "ellipj", ellipj);
 
     PyObject *ellipe = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::ellipe), static_cast<xsf::numpy::f_f>(xsf::ellipe)}, "ellipe", ellipe_doc);
+	{static_cast<xsf::numpy::f_f>(xsf::ellipe), static_cast<xsf::numpy::d_d>(xsf::ellipe)}, "ellipe", ellipe_doc);
     PyModule_AddObjectRef(module, "ellipe", ellipe);
 
     PyObject *ellipeinc = xsf::numpy::ufunc(
@@ -339,16 +339,16 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "ellipeinc", ellipeinc);
 
     PyObject *ellipk = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::ellipk), static_cast<xsf::numpy::f_f>(xsf::ellipk)}, "ellipk", ellipk_doc);
+	{static_cast<xsf::numpy::f_f>(xsf::ellipk), static_cast<xsf::numpy::d_d>(xsf::ellipk)}, "ellipk", ellipk_doc);
     PyModule_AddObjectRef(module, "ellipk", ellipk);
 
     PyObject *ellipkinc = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::dd_d>(xsf::ellipkinc), static_cast<xsf::numpy::ff_f>(xsf::ellipkinc)}, "ellipkinc",
+	{static_cast<xsf::numpy::ff_f>(xsf::ellipkinc), static_cast<xsf::numpy::dd_d>(xsf::ellipkinc)}, "ellipkinc",
         ellipkinc_doc);
     PyModule_AddObjectRef(module, "ellipkinc", ellipkinc);
 
     PyObject *ellipkm1 =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::ellipkm1), static_cast<xsf::numpy::f_f>(xsf::ellipkm1)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::ellipkm1), static_cast<xsf::numpy::d_d>(xsf::ellipkm1)},
                           "ellipkm1", ellipkm1_doc);
     PyModule_AddObjectRef(module, "ellipkm1", ellipkm1);
 
@@ -365,124 +365,124 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "expi", expi);
 
     PyObject *expit =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::expit), static_cast<xsf::numpy::f_f>(xsf::expit),
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::expit), static_cast<xsf::numpy::d_d>(xsf::expit),
                            static_cast<xsf::numpy::g_g>(xsf::expit)},
                           "expit", expit_doc);
     PyModule_AddObjectRef(module, "expit", expit);
 
     PyObject *exprel = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::exprel), static_cast<xsf::numpy::f_f>(xsf::exprel)}, "exprel", exprel_doc);
+        {static_cast<xsf::numpy::f_f>(xsf::exprel), static_cast<xsf::numpy::d_d>(xsf::exprel)}, "exprel", exprel_doc);
     PyModule_AddObjectRef(module, "exprel", exprel);
 
     PyObject *expm1 =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::expm1), static_cast<xsf::numpy::f_f>(xsf::expm1),
-                           static_cast<xsf::numpy::D_D>(xsf::expm1), static_cast<xsf::numpy::F_F>(xsf::expm1)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::expm1), static_cast<xsf::numpy::d_d>(xsf::expm1),
+                           static_cast<xsf::numpy::F_F>(xsf::expm1), static_cast<xsf::numpy::D_D>(xsf::expm1)},
                           "expm1", expm1_doc);
     PyModule_AddObjectRef(module, "expm1", expm1);
 
     PyObject *exp2 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::exp2), static_cast<xsf::numpy::f_f>(xsf::exp2)}, "exp2", exp2_doc);
+        {static_cast<xsf::numpy::f_f>(xsf::exp2), static_cast<xsf::numpy::d_d>(xsf::exp2)}, "exp2", exp2_doc);
     PyModule_AddObjectRef(module, "exp2", exp2);
 
     PyObject *exp10 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::exp10), static_cast<xsf::numpy::f_f>(xsf::exp10)}, "exp10", exp10_doc);
+        {static_cast<xsf::numpy::f_f>(xsf::exp10), static_cast<xsf::numpy::d_d>(xsf::exp10)}, "exp10", exp10_doc);
     PyModule_AddObjectRef(module, "exp10", exp10);
 
-    PyObject *erf = xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::erf), static_cast<xsf::numpy::f_f>(xsf::erf),
-                                       static_cast<xsf::numpy::D_D>(xsf::erf), static_cast<xsf::numpy::F_F>(xsf::erf)},
+    PyObject *erf = xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::erf), static_cast<xsf::numpy::d_d>(xsf::erf),
+                                       static_cast<xsf::numpy::F_F>(xsf::erf), static_cast<xsf::numpy::D_D>(xsf::erf)},
                                       "erf", erf_doc);
     PyModule_AddObjectRef(module, "erf", erf);
 
     PyObject *erfc =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::erfc), static_cast<xsf::numpy::f_f>(xsf::erfc),
-                           static_cast<xsf::numpy::D_D>(xsf::erfc), static_cast<xsf::numpy::F_F>(xsf::erfc)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::erfc), static_cast<xsf::numpy::d_d>(xsf::erfc),
+                           static_cast<xsf::numpy::F_F>(xsf::erfc), static_cast<xsf::numpy::D_D>(xsf::erfc)},
                           "erfc", erfc_doc);
     PyModule_AddObjectRef(module, "erfc", erfc);
 
     PyObject *erfcx =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::erfcx), static_cast<xsf::numpy::f_f>(xsf::erfcx),
-                           static_cast<xsf::numpy::D_D>(xsf::erfcx), static_cast<xsf::numpy::F_F>(xsf::erfcx)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::erfcx), static_cast<xsf::numpy::d_d>(xsf::erfcx),
+                           static_cast<xsf::numpy::F_F>(xsf::erfcx), static_cast<xsf::numpy::D_D>(xsf::erfcx)},
                           "erfcx", erfcx_doc);
     PyModule_AddObjectRef(module, "erfcx", erfcx);
 
     PyObject *erfi =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::erfi), static_cast<xsf::numpy::f_f>(xsf::erfi),
-                           static_cast<xsf::numpy::D_D>(xsf::erfi), static_cast<xsf::numpy::F_F>(xsf::erfi)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::erfi), static_cast<xsf::numpy::d_d>(xsf::erfi),
+                           static_cast<xsf::numpy::F_F>(xsf::erfi), static_cast<xsf::numpy::D_D>(xsf::erfi)},
                           "erfi", erfi_doc);
     PyModule_AddObjectRef(module, "erfi", erfi);
 
     PyObject *voigt_profile = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ddd_d>(xsf::voigt_profile), static_cast<xsf::numpy::fff_f>(xsf::voigt_profile)},
+        {static_cast<xsf::numpy::fff_f>(xsf::voigt_profile), static_cast<xsf::numpy::ddd_d>(xsf::voigt_profile)},
         "voigt_profile", voigt_profile_doc);
     PyModule_AddObjectRef(module, "voigt_profile", voigt_profile);
 
     PyObject *wofz = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::D_D>(xsf::wofz), static_cast<xsf::numpy::F_F>(xsf::wofz)}, "wofz", wofz_doc);
+        {static_cast<xsf::numpy::F_F>(xsf::wofz), static_cast<xsf::numpy::D_D>(xsf::wofz)}, "wofz", wofz_doc);
     PyModule_AddObjectRef(module, "wofz", wofz);
 
     PyObject *dawsn =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::dawsn), static_cast<xsf::numpy::f_f>(xsf::dawsn),
-                           static_cast<xsf::numpy::D_D>(xsf::dawsn), static_cast<xsf::numpy::F_F>(xsf::dawsn)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::dawsn), static_cast<xsf::numpy::d_d>(xsf::dawsn),
+                           static_cast<xsf::numpy::F_F>(xsf::dawsn), static_cast<xsf::numpy::D_D>(xsf::dawsn)},
                           "dawsn", dawsn_doc);
     PyModule_AddObjectRef(module, "dawsn", dawsn);
 
     PyObject *ndtr =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::ndtr), static_cast<xsf::numpy::f_f>(xsf::ndtr),
-                           static_cast<xsf::numpy::D_D>(xsf::ndtr), static_cast<xsf::numpy::F_F>(xsf::ndtr)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::ndtr), static_cast<xsf::numpy::d_d>(xsf::ndtr),
+                           static_cast<xsf::numpy::F_F>(xsf::ndtr), static_cast<xsf::numpy::D_D>(xsf::ndtr)},
                           "ndtr", ndtr_doc);
     PyModule_AddObjectRef(module, "ndtr", ndtr);
 
     PyObject *log_ndtr =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::log_ndtr), static_cast<xsf::numpy::f_f>(xsf::log_ndtr),
-                           static_cast<xsf::numpy::D_D>(xsf::log_ndtr), static_cast<xsf::numpy::F_F>(xsf::log_ndtr)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::log_ndtr), static_cast<xsf::numpy::d_d>(xsf::log_ndtr),
+                           static_cast<xsf::numpy::F_F>(xsf::log_ndtr), static_cast<xsf::numpy::D_D>(xsf::log_ndtr)},
                           "log_ndtr", log_ndtr_doc);
     PyModule_AddObjectRef(module, "log_ndtr", log_ndtr);
 
     PyObject *fresnel =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_dd>(xsf::fresnel), static_cast<xsf::numpy::f_ff>(xsf::fresnel),
-                           static_cast<xsf::numpy::D_DD>(xsf::fresnel), static_cast<xsf::numpy::F_FF>(xsf::fresnel)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_ff>(xsf::fresnel), static_cast<xsf::numpy::d_dd>(xsf::fresnel),
+                           static_cast<xsf::numpy::F_FF>(xsf::fresnel), static_cast<xsf::numpy::D_DD>(xsf::fresnel)},
                           2, "fresnel", fresnel_doc);
     PyModule_AddObjectRef(module, "fresnel", fresnel);
 
     PyObject *gamma =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::gamma), static_cast<xsf::numpy::D_D>(xsf::gamma),
-                           static_cast<xsf::numpy::f_f>(xsf::gamma), static_cast<xsf::numpy::F_F>(xsf::gamma)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::gamma), static_cast<xsf::numpy::d_d>(xsf::gamma),
+                           static_cast<xsf::numpy::F_F>(xsf::gamma), static_cast<xsf::numpy::D_D>(xsf::gamma)},
                           "gamma", gamma_doc);
     PyModule_AddObjectRef(module, "gamma", gamma);
 
     PyObject *gammainc =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::dd_d>(xsf::gammainc), static_cast<xsf::numpy::ff_f>(xsf::gammainc)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::ff_f>(xsf::gammainc), static_cast<xsf::numpy::dd_d>(xsf::gammainc)},
                           "gammainc", gammainc_doc);
     PyModule_AddObjectRef(module, "gammainc", gammainc);
 
     PyObject *gammaincinv = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::dd_d>(xsf::gammaincinv), static_cast<xsf::numpy::ff_f>(xsf::gammaincinv)},
+        {static_cast<xsf::numpy::ff_f>(xsf::gammaincinv), static_cast<xsf::numpy::dd_d>(xsf::gammaincinv)},
         "gammaincinv", gammaincinv_doc);
     PyModule_AddObjectRef(module, "gammaincinv", gammaincinv);
 
     PyObject *gammaincc = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::dd_d>(xsf::gammaincc), static_cast<xsf::numpy::ff_f>(xsf::gammaincc)}, "gammaincc",
+        {static_cast<xsf::numpy::ff_f>(xsf::gammaincc), static_cast<xsf::numpy::dd_d>(xsf::gammaincc)}, "gammaincc",
         gammaincc_doc);
     PyModule_AddObjectRef(module, "gammaincc", gammaincc);
 
     PyObject *gammainccinv = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::dd_d>(xsf::gammainccinv), static_cast<xsf::numpy::ff_f>(xsf::gammainccinv)},
+        {static_cast<xsf::numpy::ff_f>(xsf::gammainccinv), static_cast<xsf::numpy::dd_d>(xsf::gammainccinv)},
         "gammainccinv", gammainccinv_doc);
     PyModule_AddObjectRef(module, "gammainccinv", gammainccinv);
 
     PyObject *gammaln =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::gammaln), static_cast<xsf::numpy::f_f>(xsf::gammaln)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::gammaln), static_cast<xsf::numpy::d_d>(xsf::gammaln)},
                           "gammaln", gammaln_doc);
     PyModule_AddObjectRef(module, "gammaln", gammaln);
 
     PyObject *gammasgn =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::gammasgn), static_cast<xsf::numpy::f_f>(xsf::gammasgn)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::gammasgn), static_cast<xsf::numpy::d_d>(xsf::gammasgn)},
                           "gammasgn", gammasgn_doc);
     PyModule_AddObjectRef(module, "gammasgn", gammasgn);
 
     PyObject *hyp2f1 =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::dddd_d>(xsf::hyp2f1), static_cast<xsf::numpy::dddD_D>(xsf::hyp2f1),
-                           static_cast<xsf::numpy::ffff_f>(xsf::hyp2f1), static_cast<xsf::numpy::fffF_F>(xsf::hyp2f1)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::ffff_f>(xsf::hyp2f1), static_cast<xsf::numpy::dddd_d>(xsf::hyp2f1),
+                           static_cast<xsf::numpy::fffF_F>(xsf::hyp2f1), static_cast<xsf::numpy::dddD_D>(xsf::hyp2f1)},
                           "hyp2f1", hyp2f1_doc);
     PyModule_AddObjectRef(module, "hyp2f1", hyp2f1);
 
@@ -547,22 +547,22 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "itstruve0", itstruve0);
 
     PyObject *i0 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_i0), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_i0)}, "i0",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_i0), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_i0)}, "i0",
         i0_doc);
     PyModule_AddObjectRef(module, "i0", i0);
 
     PyObject *i0e = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_i0e), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_i0e)}, "i0e",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_i0e), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_i0e)}, "i0e",
         i0e_doc);
     PyModule_AddObjectRef(module, "i0e", i0e);
 
     PyObject *i1 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_i1), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_i1)}, "i1",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_i1), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_i1)}, "i1",
         i1_doc);
     PyModule_AddObjectRef(module, "i1", i1);
 
     PyObject *i1e = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_i1e), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_i1e)}, "i1e",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_i1e), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_i1e)}, "i1e",
         i1e_doc);
     PyModule_AddObjectRef(module, "i1e", i1e);
 
@@ -573,12 +573,12 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "iv", iv);
 
     PyObject *iv_ratio =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::dd_d>(xsf::iv_ratio), static_cast<xsf::numpy::ff_f>(xsf::iv_ratio)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::ff_f>(xsf::iv_ratio), static_cast<xsf::numpy::dd_d>(xsf::iv_ratio)},
                           "_iv_ratio", iv_ratio_doc);
     PyModule_AddObjectRef(module, "_iv_ratio", iv_ratio);
 
     PyObject *iv_ratio_c = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::dd_d>(xsf::iv_ratio_c), static_cast<xsf::numpy::ff_f>(xsf::iv_ratio_c)}, "_iv_ratio_c",
+        {static_cast<xsf::numpy::ff_f>(xsf::iv_ratio_c), static_cast<xsf::numpy::dd_d>(xsf::iv_ratio_c)}, "_iv_ratio_c",
         iv_ratio_c_doc);
     PyModule_AddObjectRef(module, "_iv_ratio_c", iv_ratio_c);
 
@@ -589,12 +589,12 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "ive", ive);
 
     PyObject *j0 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_j0), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_j0)}, "j0",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_j0), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_j0)}, "j0",
         j0_doc);
     PyModule_AddObjectRef(module, "j0", j0);
 
     PyObject *j1 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_j1), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_j1)}, "j1",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_j1), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_j1)}, "j1",
         j1_doc);
     PyModule_AddObjectRef(module, "j1", j1);
 
@@ -632,22 +632,22 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "kerp", kerp);
 
     PyObject *k0 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_k0), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_k0)}, "k0",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_k0), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_k0)}, "k0",
         k0_doc);
     PyModule_AddObjectRef(module, "k0", k0);
 
     PyObject *k0e = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_k0e), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_k0e)}, "k0e",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_k0e), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_k0e)}, "k0e",
         k0e_doc);
     PyModule_AddObjectRef(module, "k0e", k0e);
 
     PyObject *k1 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_k1), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_k1)}, "k1",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_k1), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_k1)}, "k1",
         k1_doc);
     PyModule_AddObjectRef(module, "k1", k1);
 
     PyObject *k1e = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_k1e), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_k1e)}, "k1e",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_k1e), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_k1e)}, "k1e",
         k1e_doc);
     PyModule_AddObjectRef(module, "k1e", k1e);
 
@@ -664,41 +664,41 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "kve", kve);
 
     PyObject *log1p =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::log1p), static_cast<xsf::numpy::f_f>(xsf::log1p),
-                           static_cast<xsf::numpy::D_D>(xsf::log1p), static_cast<xsf::numpy::F_F>(xsf::log1p)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::log1p), static_cast<xsf::numpy::d_d>(xsf::log1p),
+                           static_cast<xsf::numpy::F_F>(xsf::log1p), static_cast<xsf::numpy::D_D>(xsf::log1p)},
                           "log1p", log1p_doc);
     PyModule_AddObjectRef(module, "log1p", log1p);
 
     PyObject *_log1mexp =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::log1mexp), static_cast<xsf::numpy::f_f>(xsf::log1mexp)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::log1mexp), static_cast<xsf::numpy::d_d>(xsf::log1mexp)},
                           "_log1mexp", _log1mexp_doc);
     PyModule_AddObjectRef(module, "_log1mexp", _log1mexp);
 
     PyObject *_log1pmx =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::log1pmx), static_cast<xsf::numpy::f_f>(xsf::log1pmx)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::log1pmx), static_cast<xsf::numpy::d_d>(xsf::log1pmx)},
                           "_log1pmx", _log1pmx_doc);
     PyModule_AddObjectRef(module, "_log1pmx", _log1pmx);
 
     PyObject *xlogy =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::dd_d>(xsf::xlogy), static_cast<xsf::numpy::ff_f>(xsf::xlogy),
-                           static_cast<xsf::numpy::DD_D>(xsf::xlogy), static_cast<xsf::numpy::FF_F>(xsf::xlogy)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::ff_f>(xsf::xlogy), static_cast<xsf::numpy::dd_d>(xsf::xlogy),
+                           static_cast<xsf::numpy::FF_F>(xsf::xlogy), static_cast<xsf::numpy::DD_D>(xsf::xlogy)},
                           "xlogy", xlogy_doc);
     PyModule_AddObjectRef(module, "xlogy", xlogy);
 
     PyObject *xlog1py =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::dd_d>(xsf::xlog1py), static_cast<xsf::numpy::ff_f>(xsf::xlog1py),
-                           static_cast<xsf::numpy::DD_D>(xsf::xlog1py), static_cast<xsf::numpy::FF_F>(xsf::xlog1py)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::ff_f>(xsf::xlog1py), static_cast<xsf::numpy::dd_d>(xsf::xlog1py),
+                           static_cast<xsf::numpy::FF_F>(xsf::xlog1py), static_cast<xsf::numpy::DD_D>(xsf::xlog1py)},
                           "xlog1py", xlog1py_doc);
     PyModule_AddObjectRef(module, "xlog1py", xlog1py);
 
     PyObject *log_expit =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::log_expit), static_cast<xsf::numpy::f_f>(xsf::log_expit),
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::log_expit), static_cast<xsf::numpy::d_d>(xsf::log_expit),
                            static_cast<xsf::numpy::g_g>(xsf::log_expit)},
                           "log_expit", log_expit_doc);
     PyModule_AddObjectRef(module, "log_expit", log_expit);
 
-    PyObject *log_wright_bessel = xsf::numpy::ufunc({static_cast<xsf::numpy::ddd_d>(xsf::log_wright_bessel),
-                                                     static_cast<xsf::numpy::fff_f>(xsf::log_wright_bessel)},
+    PyObject *log_wright_bessel = xsf::numpy::ufunc({static_cast<xsf::numpy::fff_f>(xsf::log_wright_bessel),
+                                                     static_cast<xsf::numpy::ddd_d>(xsf::log_wright_bessel)},
                                                     "log_wright_bessel", log_wright_bessel_doc);
     PyModule_AddObjectRef(module, "log_wright_bessel", log_wright_bessel);
 
@@ -709,120 +709,120 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "logit", logit);
 
     PyObject *loggamma =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::loggamma), static_cast<xsf::numpy::D_D>(xsf::loggamma),
-                           static_cast<xsf::numpy::f_f>(xsf::loggamma), static_cast<xsf::numpy::F_F>(xsf::loggamma)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::loggamma), static_cast<xsf::numpy::d_d>(xsf::loggamma),
+                           static_cast<xsf::numpy::F_F>(xsf::loggamma), static_cast<xsf::numpy::D_D>(xsf::loggamma)},
                           "loggamma", loggamma_doc);
     PyModule_AddObjectRef(module, "loggamma", loggamma);
 
     PyObject *legendre_p = Py_BuildValue(
         "(N, N, N)",
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            static_cast<xsf::numpy::autodiff0_id_d>(xsf::legendre_p),
-                            static_cast<xsf::numpy::autodiff0_if_f>(xsf::legendre_p)},
+                            static_cast<xsf::numpy::autodiff0_if_f>(xsf::legendre_p),
+                            static_cast<xsf::numpy::autodiff0_id_d>(xsf::legendre_p)},
                            "legendre_p", nullptr, "(),()->(1)", [](const npy_intp *dims, npy_intp *new_dims) {}),
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            static_cast<xsf::numpy::autodiff1_id_d>(xsf::legendre_p),
-                            static_cast<xsf::numpy::autodiff1_if_f>(xsf::legendre_p)},
+                            static_cast<xsf::numpy::autodiff1_if_f>(xsf::legendre_p),
+                            static_cast<xsf::numpy::autodiff1_id_d>(xsf::legendre_p)},
                            "legendre_p", nullptr, "(),()->(2)", [](const npy_intp *dims, npy_intp *new_dims) {}),
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            static_cast<xsf::numpy::autodiff2_id_d>(xsf::legendre_p),
-                            static_cast<xsf::numpy::autodiff2_if_f>(xsf::legendre_p)},
+                            static_cast<xsf::numpy::autodiff2_if_f>(xsf::legendre_p),
+                            static_cast<xsf::numpy::autodiff2_id_d>(xsf::legendre_p)},
                            "legendre_p", nullptr, "(),()->(3)", [](const npy_intp *dims, npy_intp *new_dims) {}));
     PyModule_AddObjectRef(module, "legendre_p", legendre_p);
 
     PyObject *assoc_legendre_p = Py_BuildValue(
         "{(O, i): N, (O, i): N, (O, i): N, (O, i): N, (O, i): N,(O, i): N}", Py_True, 0,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
+		            [](int n, int m, xsf::dual<float, 0> z, int branch_cut) {
+                                return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
+                            },
                             [](int n, int m, xsf::dual<double, 0> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
                             },
-                            [](int n, int m, xsf::dual<float, 0> z, int branch_cut) {
+		            [](int n, int m, xsf::dual<xsf::numpy::cfloat, 0> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
                             },
                             [](int n, int m, xsf::dual<xsf::numpy::cdouble, 0> z, int branch_cut) {
-                                return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
-                            },
-                            [](int n, int m, xsf::dual<xsf::numpy::cfloat, 0> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
                             }},
                            1, "assoc_legendre_p", nullptr, "(),(),(),()->(1)",
                            [](const npy_intp *dims, npy_intp *new_dims) {}),
         Py_True, 1,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](int n, int m, xsf::dual<double, 1> z, int branch_cut) {
-                                return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
-                            },
                             [](int n, int m, xsf::dual<float, 1> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
                             },
-                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 1> z, int branch_cut) {
+                            [](int n, int m, xsf::dual<double, 1> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
                             },
                             [](int n, int m, xsf::dual<xsf::numpy::cfloat, 1> z, int branch_cut) {
+                                return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
+                            },
+                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 1> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
                             }},
                            1, "assoc_legendre_p", nullptr, "(),(),(),()->(2)",
                            [](const npy_intp *dims, npy_intp *new_dims) {}),
         Py_True, 2,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](int n, int m, xsf::dual<double, 2> z, int branch_cut) {
-                                return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
-                            },
                             [](int n, int m, xsf::dual<float, 2> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
                             },
-                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 2> z, int branch_cut) {
+                            [](int n, int m, xsf::dual<double, 2> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
                             },
                             [](int n, int m, xsf::dual<xsf::numpy::cfloat, 2> z, int branch_cut) {
+                                return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
+                            },
+                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 2> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z, branch_cut);
                             }},
                            1, "assoc_legendre_p", nullptr, "(),(),(),()->(3)",
                            [](const npy_intp *dims, npy_intp *new_dims) {}),
         Py_False, 0,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](int n, int m, xsf::dual<double, 0> z, int branch_cut) {
-                                return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
-                            },
                             [](int n, int m, xsf::dual<float, 0> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
                             },
-                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 0> z, int branch_cut) {
+                            [](int n, int m, xsf::dual<double, 0> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
                             },
                             [](int n, int m, xsf::dual<xsf::numpy::cfloat, 0> z, int branch_cut) {
+                                return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
+                            },
+                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 0> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
                             }},
                            1, "assoc_legendre_p", nullptr, "(),(),(),()->(1)",
                            [](const npy_intp *dims, npy_intp *new_dims) {}),
         Py_False, 1,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](int n, int m, xsf::dual<double, 1> z, int branch_cut) {
-                                return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
-                            },
                             [](int n, int m, xsf::dual<float, 1> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
                             },
-                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 1> z, int branch_cut) {
+                            [](int n, int m, xsf::dual<double, 1> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
                             },
                             [](int n, int m, xsf::dual<xsf::numpy::cfloat, 1> z, int branch_cut) {
+                                return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
+                            },
+                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 1> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
                             }},
                            1, "assoc_legendre_p", nullptr, "(),(),(),()->(2)",
                            [](const npy_intp *dims, npy_intp *new_dims) {}),
         Py_False, 2,
         xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                            [](int n, int m, xsf::dual<double, 2> z, int branch_cut) {
-                                return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
-                            },
                             [](int n, int m, xsf::dual<float, 2> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
                             },
-                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 2> z, int branch_cut) {
+                            [](int n, int m, xsf::dual<double, 2> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
                             },
                             [](int n, int m, xsf::dual<xsf::numpy::cfloat, 2> z, int branch_cut) {
+                                return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
+                            },
+                            [](int n, int m, xsf::dual<xsf::numpy::cdouble, 2> z, int branch_cut) {
                                 return xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z, branch_cut);
                             }},
                            1, "assoc_legendre_p", nullptr, "(),(),(),()->(3)",
@@ -880,7 +880,7 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "modfresnelp", modfresnelp);
 
     PyObject *modstruve =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::dd_d>(xsf::struve_l), static_cast<xsf::numpy::ff_f>(xsf::struve_l)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::ff_f>(xsf::struve_l), static_cast<xsf::numpy::dd_d>(xsf::struve_l)},
                           "modstruve", struve_l_doc);
     PyModule_AddObjectRef(module, "modstruve", modstruve);
 
@@ -967,77 +967,77 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "pro_rad2_cv", pro_rad2_cv);
 
     PyObject *psi =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::digamma), static_cast<xsf::numpy::D_D>(xsf::digamma),
-                           static_cast<xsf::numpy::f_f>(xsf::digamma), static_cast<xsf::numpy::F_F>(xsf::digamma)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::digamma), static_cast<xsf::numpy::d_d>(xsf::digamma),
+                           static_cast<xsf::numpy::F_F>(xsf::digamma), static_cast<xsf::numpy::D_D>(xsf::digamma)},
                           "psi", psi_doc);
     PyModule_AddObjectRef(module, "psi", psi);
 
     PyObject *radian =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::ddd_d>(xsf::radian), static_cast<xsf::numpy::fff_f>(xsf::radian)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::fff_f>(xsf::radian), static_cast<xsf::numpy::ddd_d>(xsf::radian)},
                           "radian", radian_doc);
     PyModule_AddObjectRef(module, "radian", radian);
 
     PyObject *rgamma =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::d_d>(xsf::rgamma), static_cast<xsf::numpy::D_D>(xsf::rgamma),
-                           static_cast<xsf::numpy::f_f>(xsf::rgamma), static_cast<xsf::numpy::F_F>(xsf::rgamma)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::rgamma), static_cast<xsf::numpy::d_d>(xsf::rgamma),
+                           static_cast<xsf::numpy::F_F>(xsf::rgamma), static_cast<xsf::numpy::D_D>(xsf::rgamma)},
                           "rgamma", rgamma_doc);
     PyModule_AddObjectRef(module, "rgamma", rgamma);
 
     PyObject *_riemann_zeta = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::riemann_zeta), static_cast<xsf::numpy::D_D>(xsf::riemann_zeta),
-         static_cast<xsf::numpy::f_f>(xsf::riemann_zeta), static_cast<xsf::numpy::F_F>(xsf::riemann_zeta)},
+        {static_cast<xsf::numpy::f_f>(xsf::riemann_zeta), static_cast<xsf::numpy::d_d>(xsf::riemann_zeta),
+         static_cast<xsf::numpy::F_F>(xsf::riemann_zeta), static_cast<xsf::numpy::D_D>(xsf::riemann_zeta)},
         "_riemann_zeta", _riemann_zeta_doc);
     PyModule_AddObjectRef(module, "_riemann_zeta", _riemann_zeta);
 
     PyObject *sindg = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::sindg), static_cast<xsf::numpy::f_f>(xsf::sindg)}, "sindg", sindg_doc);
+        {static_cast<xsf::numpy::f_f>(xsf::sindg), static_cast<xsf::numpy::d_d>(xsf::sindg)}, "sindg", sindg_doc);
     PyModule_AddObjectRef(module, "sindg", sindg);
 
     PyObject *_spherical_jn = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_j), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_j),
-         static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_j), static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_j)},
+        {static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_j), static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_j),
+         static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_j), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_j)},
         "_spherical_jn", spherical_jn_doc);
     PyModule_AddObjectRef(module, "_spherical_jn", _spherical_jn);
 
     PyObject *_spherical_jn_d = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_j_jac), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_j_jac),
-         static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_j_jac), static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_j_jac)},
+        {static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_j_jac), static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_j_jac),
+         static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_j_jac), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_j_jac)},
         "_spherical_jn_d", spherical_jn_d_doc);
     PyModule_AddObjectRef(module, "_spherical_jn_d", _spherical_jn_d);
 
     PyObject *_spherical_yn = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_y), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_y),
-         static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_y), static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_y)},
+        {static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_y), static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_y),
+         static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_y), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_y)},
         "_spherical_yn", spherical_yn_doc);
     PyModule_AddObjectRef(module, "_spherical_yn", _spherical_yn);
 
     PyObject *_spherical_yn_d = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_y_jac), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_y_jac),
-         static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_y_jac), static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_y_jac)},
+        {static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_y_jac), static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_y_jac),
+         static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_y_jac), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_y_jac)},
         "_spherical_yn_d", spherical_yn_d_doc);
     PyModule_AddObjectRef(module, "_spherical_yn_d", _spherical_yn_d);
 
     PyObject *_spherical_in = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_i), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_i),
-         static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_i), static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_i)},
+        {static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_i), static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_i),
+         static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_i), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_i)},
         "_spherical_in", spherical_in_doc);
     PyModule_AddObjectRef(module, "_spherical_in", _spherical_in);
 
     PyObject *_spherical_in_d = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_i_jac), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_i_jac),
-         static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_i_jac), static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_i_jac)},
+        {static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_i_jac), static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_i_jac),
+         static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_i_jac), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_i_jac)},
         "_spherical_in_d", spherical_in_d_doc);
     PyModule_AddObjectRef(module, "_spherical_in_d", _spherical_in_d);
 
     PyObject *_spherical_kn = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_k), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_k),
-         static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_k), static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_k)},
+        {static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_k), static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_k),
+         static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_k), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_k)},
         "_spherical_kn", spherical_kn_doc);
     PyModule_AddObjectRef(module, "_spherical_kn", _spherical_kn);
 
     PyObject *_spherical_kn_d = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_k_jac), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_k_jac),
-         static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_k_jac), static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_k_jac)},
+        {static_cast<xsf::numpy::lf_f>(xsf::sph_bessel_k_jac), static_cast<xsf::numpy::ld_d>(xsf::sph_bessel_k_jac),
+         static_cast<xsf::numpy::lF_F>(xsf::sph_bessel_k_jac), static_cast<xsf::numpy::lD_D>(xsf::sph_bessel_k_jac)},
         "_spherical_kn_d", spherical_kn_d_doc);
     PyModule_AddObjectRef(module, "_spherical_kn_d", _spherical_kn_d);
 
@@ -1061,43 +1061,43 @@ _special_ufuncs_module_exec(PyObject *module)
     PyObject *sph_harm_y =
         Py_BuildValue("(N, N, N)",
                       xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                                          static_cast<xsf::numpy::autodiff00_iidd_D>(xsf::sph_harm_y),
-                                          static_cast<xsf::numpy::autodiff00_iiff_F>(xsf::sph_harm_y)},
+                                          static_cast<xsf::numpy::autodiff00_iiff_F>(xsf::sph_harm_y),
+                                          static_cast<xsf::numpy::autodiff00_iidd_D>(xsf::sph_harm_y)},
                                          "sph_harm_y", nullptr, "(),(),(),()->(1,1)",
                                          [](const npy_intp *dims, npy_intp *new_dims) {}),
                       xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                                          static_cast<xsf::numpy::autodiff11_iidd_D>(xsf::sph_harm_y),
-                                          static_cast<xsf::numpy::autodiff11_iiff_F>(xsf::sph_harm_y)},
+                                          static_cast<xsf::numpy::autodiff11_iiff_F>(xsf::sph_harm_y),
+                                          static_cast<xsf::numpy::autodiff11_iidd_D>(xsf::sph_harm_y)},
                                          "sph_harm_y", nullptr, "(),(),(),()->(2,2)",
                                          [](const npy_intp *dims, npy_intp *new_dims) {}),
                       xsf::numpy::gufunc({xsf::numpy::compose{xsf::numpy::autodiff(), xsf::numpy::use_long_long_int()},
-                                          static_cast<xsf::numpy::autodiff22_iidd_D>(xsf::sph_harm_y),
-                                          static_cast<xsf::numpy::autodiff22_iiff_F>(xsf::sph_harm_y)},
+                                          static_cast<xsf::numpy::autodiff22_iiff_F>(xsf::sph_harm_y),
+                                          static_cast<xsf::numpy::autodiff22_iidd_D>(xsf::sph_harm_y)},
                                          "sph_harm_y", nullptr, "(),(),(),()->(3,3)",
                                          [](const npy_intp *dims, npy_intp *new_dims) {}));
     PyModule_AddObjectRef(module, "sph_harm_y", sph_harm_y);
 
     PyObject *struve =
-        xsf::numpy::ufunc({static_cast<xsf::numpy::dd_d>(xsf::struve_h), static_cast<xsf::numpy::ff_f>(xsf::struve_h)},
+        xsf::numpy::ufunc({static_cast<xsf::numpy::ff_f>(xsf::struve_h), static_cast<xsf::numpy::dd_d>(xsf::struve_h)},
                           "struve", struve_h_doc);
     PyModule_AddObjectRef(module, "struve", struve);
 
     PyObject *tandg = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::tandg), static_cast<xsf::numpy::f_f>(xsf::tandg)}, "tandg", tandg_doc);
+        {static_cast<xsf::numpy::f_f>(xsf::tandg), static_cast<xsf::numpy::d_d>(xsf::tandg)}, "tandg", tandg_doc);
     PyModule_AddObjectRef(module, "tandg", tandg);
 
     PyObject *wright_bessel = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::ddd_d>(xsf::wright_bessel), static_cast<xsf::numpy::fff_f>(xsf::wright_bessel)},
+        {static_cast<xsf::numpy::fff_f>(xsf::wright_bessel), static_cast<xsf::numpy::ddd_d>(xsf::wright_bessel)},
         "wright_bessel", wright_bessel_doc);
     PyModule_AddObjectRef(module, "wright_bessel", wright_bessel);
 
     PyObject *y0 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_y0), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_y0)}, "y0",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_y0), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_y0)}, "y0",
         y0_doc);
     PyModule_AddObjectRef(module, "y0", y0);
 
     PyObject *y1 = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_y1), static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_y1)}, "y1",
+        {static_cast<xsf::numpy::f_f>(xsf::cyl_bessel_y1), static_cast<xsf::numpy::d_d>(xsf::cyl_bessel_y1)}, "y1",
         y1_doc);
     PyModule_AddObjectRef(module, "y1", y1);
 
@@ -1114,7 +1114,7 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "yve", yve);
 
     PyObject *zetac = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::d_d>(xsf::zetac), static_cast<xsf::numpy::f_f>(xsf::zetac)}, "zetac", zetac_doc);
+        {static_cast<xsf::numpy::f_f>(xsf::zetac), static_cast<xsf::numpy::d_d>(xsf::zetac)}, "zetac", zetac_doc);
     PyModule_AddObjectRef(module, "zetac", zetac);
 
     return 0;

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -334,7 +334,7 @@ _special_ufuncs_module_exec(PyObject *module)
     PyModule_AddObjectRef(module, "ellipe", ellipe);
 
     PyObject *ellipeinc = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::dd_d>(xsf::ellipeinc), static_cast<xsf::numpy::ff_f>(xsf::ellipeinc)}, "ellipeinc",
+        {static_cast<xsf::numpy::ff_f>(xsf::ellipeinc), static_cast<xsf::numpy::dd_d>(xsf::ellipeinc)}, "ellipeinc",
         ellipeinc_doc);
     PyModule_AddObjectRef(module, "ellipeinc", ellipeinc);
 

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -113,4 +113,6 @@ def test_nep50(ufunc):
         
         # Test that the output is an appropriately typed nan. This also implicitly
         # tests that ufuncs propagate nans correctly.
-        assert_equal(result, np.asarray([_get_nan_val(typecode) for typecode in output_types]))
+        assert_equal(
+            result, np.asarray([_get_nan_val(typecode) for typecode in output_types])
+        )

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -58,16 +58,10 @@ def _get_nan_val(typecode):
     return {
         "f": np.asarray(np.nan, dtype=np.float32),
         "d": np.asarray(np.nan, dtype=np.float64),
-        # float128 not available on some platforms
-        "g": np.asarray(
-            np.nan, dtype=np.float128 if hasattr(np, "float128") else np.float64
-        ),
+        "g": np.asarray(np.nan, dtype=np.longdouble),
         "F": np.asarray(np.nan + np.nan*1j, dtype=np.complex64),
         "D": np.asarray(np.nan + np.nan*1j, dtype=np.complex128),
-        "G": np.asarray(
-            np.nan + np.nan*1j,
-            dtype=np.complex256 if hasattr(np, "complex256") else np.complex128,
-        ),
+        "G": np.asarray(np.nan + np.nan*1j, dtype=np.clongdouble),
     }[typecode]
 
 skips = {

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -12,6 +12,7 @@ import numpy as np
 import pytest
 import scipy.special._ufuncs
 import scipy.special._gufuncs
+import scipy.special as special
 
 from numpy.testing import assert_equal
 
@@ -55,19 +56,43 @@ def test_ufunc_signatures(ufunc):
 
 def _get_nan_val(typecode):
     return {
-        "f": np.float32("nan"),
-        "d": np.float64("nan"),
-        "g": np.float128("nan"),
-        "F": np.complex64("nan"),
-        "D": np.complex128("nan"),
-        "G": np.complex256("nan"),
+        "f": np.asarray(np.nan, dtype=np.float32),
+        "d": np.asarray(np.nan, dtype=np.float64),
+        "g": np.asarray(np.nan, dtype=np.float128),
+        "F": np.asarray(np.nan + np.nan*1j, dtype=np.complex64),
+        "D": np.asarray(np.nan + np.nan*1j, dtype=np.complex128),
+        "G": np.asarray(np.nan + np.nan*1j, dtype=np.complex256),
     }[typecode]
 
+skips = {
+    # These hit https://github.com/scipy/xsf/issues/94
+    special.eval_chebyc,
+    special.eval_chebys,
+    special.eval_chebyt,
+    special.eval_chebyu,
+    special.eval_gegenbauer,
+    special.eval_genlaguerre,
+    special.eval_jacobi,
+    special.eval_laguerre,
+    special.eval_legendre,
+    special.eval_sh_chebyt,
+    special.eval_sh_chebyu,
+    special.eval_sh_jacobi,
+    special.eval_sh_legendre,
+    special.hyp1f1,
+    special.hyp2f1,
+    # warns if called with noninteger values of some args
+    special.bdtr,
+    special.bdtrc,
+    special.bdtri,
+}
+_multi_arg_public_ufuncs = [
+    ufunc for ufunc in _ufuncs if ufunc.nargs > 2 and ufunc not in skips
+    and ufunc.__name__ in special.__all__
+]
 
-_multi_arg_ufuncs = [ufunc for ufunc in _ufuncs if ufunc.nargs > 1]
 
-
-@pytest.mark.parametrize("ufunc", _multi_arg_ufuncs)
+@pytest.mark.parametrize("ufunc", _multi_arg_public_ufuncs)
 def test_nep50(ufunc):
     # Test that functions with multiple arguments respect nep50 promotion rules.
     rng = np.random.default_rng(1234)
@@ -84,6 +109,8 @@ def test_nep50(ufunc):
         args[idx] = float("nan") if np.isrealobj(args[idx]) else complex("nan")
         result = ufunc(*args)
         result = [result] if len(output_types) == 1 else result
+        result = np.asarray(result)
+        
         # Test that the output is an appropriately typed nan. This also implicitly
         # tests that ufuncs propagate nans correctly.
-        assert_equal(result, [_get_nan_val(typecode) for typecode in output_types])
+        assert_equal(result, np.asarray([_get_nan_val(typecode) for typecode in output_types]))

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -13,6 +13,8 @@ import pytest
 import scipy.special._ufuncs
 import scipy.special._gufuncs
 
+from numpy.testing import assert_equal
+
 
 # Single precision is not implemented for these ufuncs;
 # floating point inputs must be float64.
@@ -49,3 +51,39 @@ def test_ufunc_signatures(ufunc):
              sig.replace("f", "d").replace("F", "D")]
         )
     assert types == expanded_types
+
+
+def _get_nan_val(typecode):
+    return {
+        "f": np.float32("nan"),
+        "d": np.float64("nan"),
+        "g": np.float128("nan"),
+        "F": np.complex64("nan"),
+        "D": np.complex128("nan"),
+        "G": np.complex256("nan"),
+    }[typecode]
+
+
+_multi_arg_ufuncs = [ufunc for ufunc in _ufuncs if ufunc.nargs > 1]
+
+
+@pytest.mark.parametrize("ufunc", _multi_arg_ufuncs)
+def test_nep50(ufunc):
+    # Test that functions with multiple arguments respect nep50 promotion rules.
+    rng = np.random.default_rng(1234)
+    # As in test_ufunc_signatures, filter out functions with integer arguments.
+    types = set(sig for sig in ufunc.types
+                if not ("l" in sig or "i" in sig or "q" in sig or "p" in sig))
+    for sig in types:
+        input_types, output_types = sig.split("->")
+        # since we only care about dtypes and not values here, just use an appropriately
+        # typed nan for each argument.
+        args = [_get_nan_val(typecode) for typecode in input_types]
+        # swap out a random one of the nans with an appropriately typed numpy scalar.
+        idx = rng.choice(len(args))
+        args[idx] = float("nan") if np.isrealobj(args[idx]) else complex("nan")
+        result = ufunc(*args)
+        result = [result] if len(output_types) == 1 else result
+        # Test that the output is an appropriately typed nan. This also implicitly
+        # tests that ufuncs propagate nans correctly.
+        assert_equal(result, [_get_nan_val(typecode) for typecode in output_types])

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -96,7 +96,7 @@ _multi_arg_public_ufuncs = [
 def test_nep50(ufunc):
     # Test that functions with multiple arguments respect nep50 promotion rules.
     rng = np.random.default_rng(1234)
-    # As in test_ufunc_signatures, filter out functions with integer arguments.
+    # As in test_ufunc_signatures, filter out signatures involving integers.
     types = set(sig for sig in ufunc.types
                 if not ("l" in sig or "i" in sig or "q" in sig or "p" in sig))
     for sig in types:
@@ -114,5 +114,6 @@ def test_nep50(ufunc):
         # Test that the output is an appropriately typed nan. This also implicitly
         # tests that ufuncs propagate nans correctly.
         assert_equal(
-            result, np.asarray([_get_nan_val(typecode) for typecode in output_types])
+            result, np.asarray([_get_nan_val(typecode) for typecode in output_types],
+            strict=True)
         )

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -66,28 +66,28 @@ def _get_nan_val(typecode):
 
 skips = {
     # These hit https://github.com/scipy/xsf/issues/94
-    special.eval_chebyc,
-    special.eval_chebys,
-    special.eval_chebyt,
-    special.eval_chebyu,
-    special.eval_gegenbauer,
-    special.eval_genlaguerre,
-    special.eval_jacobi,
-    special.eval_laguerre,
-    special.eval_legendre,
-    special.eval_sh_chebyt,
-    special.eval_sh_chebyu,
-    special.eval_sh_jacobi,
-    special.eval_sh_legendre,
-    special.hyp1f1,
-    special.hyp2f1,
+    "eval_chebyc",
+    "eval_chebys",
+    "eval_chebyt",
+    "eval_chebyu",
+    "eval_gegenbauer",
+    "eval_genlaguerre",
+    "eval_jacobi",
+    "eval_laguerre",
+    "eval_legendre",
+    "eval_sh_chebyt",
+    "eval_sh_chebyu",
+    "eval_sh_jacobi",
+    "eval_sh_legendre",
+    "hyp1f1",
+    "hyp2f1",
     # warns if called with noninteger values of some args
-    special.bdtr,
-    special.bdtrc,
-    special.bdtri,
+    "bdtr",
+    "bdtrc",
+    "bdtri",
 }
 _multi_arg_public_ufuncs = [
-    ufunc for ufunc in _ufuncs if ufunc.nargs > 2 and ufunc not in skips
+    ufunc for ufunc in _ufuncs if ufunc.nargs > 2 and ufunc.__name__ not in skips
     and ufunc.__name__ in special.__all__
 ]
 

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -87,8 +87,8 @@ skips = {
     "bdtri",
 }
 _multi_arg_public_ufuncs = [
-    ufunc for ufunc in _ufuncs if ufunc.nargs - ufunc.nout > 1 and ufunc.__name__ not in skips
-    and ufunc.__name__ in special.__all__
+    ufunc for ufunc in _ufuncs if ufunc.nargs - ufunc.nout > 1
+    and ufunc.__name__ not in skips and ufunc.__name__ in special.__all__
 ]
 
 

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -114,6 +114,6 @@ def test_nep50(ufunc):
         # Test that the output is an appropriately typed nan. This also implicitly
         # tests that ufuncs propagate nans correctly.
         assert_equal(
-            result, np.asarray([_get_nan_val(typecode) for typecode in output_types],
-            strict=True)
+            result, np.asarray([_get_nan_val(typecode) for typecode in output_types]),
+            strict=True
         )

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -87,7 +87,7 @@ skips = {
     "bdtri",
 }
 _multi_arg_public_ufuncs = [
-    ufunc for ufunc in _ufuncs if ufunc.nargs > 2 and ufunc.__name__ not in skips
+    ufunc for ufunc in _ufuncs if ufunc.nargs - ufunc.nout > 1 and ufunc.__name__ not in skips
     and ufunc.__name__ in special.__all__
 ]
 

--- a/scipy/special/tests/test_ufunc_signatures.py
+++ b/scipy/special/tests/test_ufunc_signatures.py
@@ -58,10 +58,16 @@ def _get_nan_val(typecode):
     return {
         "f": np.asarray(np.nan, dtype=np.float32),
         "d": np.asarray(np.nan, dtype=np.float64),
-        "g": np.asarray(np.nan, dtype=np.float128),
+        # float128 not available on some platforms
+        "g": np.asarray(
+            np.nan, dtype=np.float128 if hasattr(np, "float128") else np.float64
+        ),
         "F": np.asarray(np.nan + np.nan*1j, dtype=np.complex64),
         "D": np.asarray(np.nan + np.nan*1j, dtype=np.complex128),
-        "G": np.asarray(np.nan + np.nan*1j, dtype=np.complex256),
+        "G": np.asarray(
+            np.nan + np.nan*1j,
+            dtype=np.complex256 if hasattr(np, "complex256") else np.complex128,
+        ),
     }[typecode]
 
 skips = {


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In #24535 and #24557, the delegation in `scipy/special/_support_alternative_backends.py` was updated to use `lazy_apply` for ufuncs, using the `resolve_dtypes` ufunc method to figure out the correct input and output dtypes to pass in `jax.pure_callback`. One needs to figure out the correct input dtypes, because `pure_callback` converts even Python scalar input to eager JAX arrays, making it so Python scalars do not promote weakly. 

While working on this, I noticed that some ufuncs in `special` do not follow NEP50. One example is

```
import numpy as np
import scipy.special

hyp2f1(1.1, 2.1, 1.5, np.float32(0.2))
# np.float64(1.2522098344052157) but should be a float32
```

I figured out that this is because in order for NEP50 to hold, the ufunc loops need to be sorted by type from narrowest to widest to ensure that when Python scalars are passed along with arrays of a narrower type, the narrower typed loop is preferred. In the old ufunc infra, this seems to be handled by sorting the loops like this

https://github.com/scipy/scipy/blob/21466c94aa0b589704a4c34d4a7822b74ec07c6d/scipy/special/_generate_pyx.py#L568-L571

by cast order

https://github.com/scipy/scipy/blob/21466c94aa0b589704a4c34d4a7822b74ec07c6d/scipy/special/_generate_pyx.py#L217-L218

but though new infrastructure using `xsf/numpy.h` is more flexible and opens up more possibilities, it is up to the developer to ensure the loops are placed in the correct order. I found that some were not in the correct order and have fixed them here. I've also added a test to ensure that nep50 is satisfied at least for public ufuncs.


#### Additional information
<!--Any additional information you think is important.-->
While working on this I discovered an unfortunate bug where

```python
import numpy as np 
import scipy.special as special

special.hyp2f1(np.nan, np.nan, np.nan, np.complex128(np.nan))
```

causes the Python interpreter to crash with the following error in debug builds of SciPy when using gcc.

```
In [7]: special.hyp2f1(np.nan, np.nan, np.nan, np.complex128("nan"))
/usr/include/c++/13/complex:964: std::complex<_Tp> std::polar(const _Tp&, const _Tp&) [with _Tp = double]: Assertion '__rho >= 0' failed.
Aborted (core dumped)
```

this seems to be due to asserts that get baked in by gcc when compiling the debug build. I submitted an issue to xsf here, https://github.com/scipy/xsf/issues/94, and will add specific handling for nan inputs to `hyp2f1` and `hyp1f1` to avoid this. For now I'm just excluding functions from the test that triggers these failures. 