### PR TITLE
BUG: spatial.transform.Rotation.from_mrp: fix leaking Cython memview

### DIFF
--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -644,8 +644,8 @@ def from_mrp(mrp):
         quat[ind, 3] = (2 - mrp_squared_plus_1) / mrp_squared_plus_1
 
     if is_single:
-        return quat[0]
-    return quat
+        return np.asarray(quat, dtype=float)[0]
+    return np.asarray(quat, dtype=float)
     
 
 @cython.embedsignature(True)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 import warnings
 from scipy._lib._array_api import (
     xp_assert_equal,
+    array_namespace,
     is_numpy,
     is_lazy_array,
     xp_vector_norm,
@@ -642,6 +643,8 @@ def test_from_mrp_single_nd_input(xp, ndim: int):
     expected_quat = xp.reshape(expected_quat, (1,) * (ndim - 1) + (4,))
     result = Rotation.from_mrp(mrp)
     xp_assert_close(result.as_quat(), expected_quat, atol=1e-12)
+    # Regression test for gh-24555
+    assert isinstance(result._quat, type(array_namespace(mrp).empty(0)))
 
 
 def test_from_mrp_array_like():


### PR DESCRIPTION
closes gh-24555