### PR TITLE
docs: fix missing colons in math directives for order_statistic

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4939,9 +4939,9 @@ class OrderStatisticDistribution(TransformedDistribution):
     :math:`X_{(1)}, \dots, X_{(r)}, \dots, X_{(n)}`,
     :math:`X_{(r)}` is known as the :math:`r^{\text{th}}` order statistic.
 
-    If the PDF, CDF, and CCDF underlying math:`X` are denoted :math:`f`,
+    If the PDF, CDF, and CCDF underlying :math:`X` are denoted :math:`f`,
     :math:`F`, and :math:`F'`, respectively, then the PDF underlying
-    math:`X_{(r)}` is given by:
+    :math:`X_{(r)}` is given by:
 
     .. math::
 
@@ -5086,9 +5086,9 @@ def order_statistic(X, /, *, r, n):
     :math:`X_{(1)}, \dots, X_{(r)}, \dots, X_{(n)}`,
     :math:`X_{(r)}` is known as the :math:`r^{\text{th}}` order statistic.
 
-    If the PDF, CDF, and CCDF underlying math:`X` are denoted :math:`f`,
+    If the PDF, CDF, and CCDF underlying :math:`X` are denoted :math:`f`,
     :math:`F`, and :math:`F'`, respectively, then the PDF underlying
-    math:`X_{(r)}` is given by:
+    :math:`X_{(r)}` is given by:
 
     .. math::
 


### PR DESCRIPTION
Fixes #24545

Fixed reStructuredText syntax errors in  documentation where math directives were missing the leading colon:
- Changed `math:` to `:math:` (4 occurrences in 2 locations)

These typos prevented proper rendering of the mathematical notation in the documentation.

**Changes:**
- Fixed in `OrderStatisticDistribution` class docstring (lines 4942, 4944)
- Fixed in `order_statistic` function docstring (lines 5089, 5091)

Straightforward docs-only fix, no code changes.