### PR TITLE
DOC: io: remove redundant @docfiller decorator usage

### DIFF
--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -49,17 +49,9 @@ def _open_file(file_like, appendmat, mode='rb'):
             ) from e
 
 
-@docfiller
 def mat_reader_factory(file_name, appendmat=True, **kwargs):
     """
     Create reader for matlab .mat format files.
-
-    Parameters
-    ----------
-    %(file_arg)s
-    %(append_arg)s
-    %(load_args)s
-    %(struct_arg)s
 
     Returns
     -------
@@ -83,7 +75,6 @@ def mat_reader_factory(file_name, appendmat=True, **kwargs):
         raise TypeError(f'Did not recognize version {mjv}')
 
 
-@docfiller
 def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=True, **kwargs):
     """
     Load MATLAB file.
@@ -249,7 +240,6 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=True, **kwargs):
     return mdict
 
 
-@docfiller
 def savemat(file_name, mdict,
             appendmat=True,
             format='5',


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None
#### What does this implement/fix?
<!--Please explain your changes.-->
I noticed these uses of `@docfiller` were entirely redundant so I have cleaned them up. 
#### Additional information
<!--Any additional information you think is important.-->
