### PR TITLE
MAINT: sparse.dok_array/matrix.pop: restore signature

### DIFF
--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -14,6 +14,9 @@ from ._sputils import (isdense, getdtype, isshape, isintlike, isscalarlike,
                        upcast, upcast_scalar, check_shape)
 
 
+_NoValue = object()
+
+
 class _dok_base(_spbase, IndexMixin, dict):
     _format = 'dok'
     _allow_nd = (1, 2)
@@ -134,7 +137,7 @@ class _dok_base(_spbase, IndexMixin, dict):
         """Remove all items from the dok_array."""
         self._dict.clear()
 
-    def pop(self, /, *args):
+    def pop(self, key, default=_NoValue, /):
         """Remove specified key and return the corresponding value.
 
         Parameters
@@ -155,7 +158,10 @@ class _dok_base(_spbase, IndexMixin, dict):
         KeyError
             If the key is not found and default is not provided.
         """
-        return self._dict.pop(*args)
+        if default is _NoValue:
+            return self._dict.pop(key)
+        else:
+            return self._dict.pop(key, default)
 
     def __reversed__(self):
         raise TypeError("reversed is not defined for dok_array type")

--- a/scipy/sparse/tests/test_dok.py
+++ b/scipy/sparse/tests/test_dok.py
@@ -92,7 +92,8 @@ def test_pop(d, Asp):
     assert Asp.pop((22, 21), "other") == "other"
     with pytest.raises(KeyError, match="(22, 21)"):
         Asp.pop((22, 21))
-    with pytest.raises(TypeError, match="got an unexpected keyword argument"):
+    msg = "got some positional-only arguments passed as keyword arguments: 'default'"
+    with pytest.raises(TypeError, match=msg):
         Asp.pop((22, 21), default=5)
 
 def test_popitem(d, Asp):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None
#### What does this implement/fix?
<!--Please explain your changes.-->
#20322 fixed a bug which meant that if the `key` was not in the `dok_array` and `default` was not specified, `pop` would return `None` rather than raising and error.

However, in fixing this bug the signature was changed to `*args`. This slightly obscures how the user is meant to call the function. This PR restores the signature while retaining backwards compatibility.
#### Additional information
<!--Any additional information you think is important.-->
