### PR TITLE
ENH: stats.DiscreteDistribution.icdf/iccdf: improve performance when solution is left endpoint of support

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3772,14 +3772,57 @@ class DiscreteDistribution(UnivariateDistribution):
             "for continuous distributions.")
 
     def _solve_bounded_discrete(self, func, p, params, comp):
-        res = self._solve_bounded(func, p, params=params, xatol=0.9)
-        x = np.asarray(np.floor(res.xr))
+        # The calling function, `_base_discrete_inversion` is solving either:
+        # a) find the smallest integer x* within the support s.t. F(x*) >= p
+        # b) find the smallest integer x* within the support s.t. G(x*) = 1 - F(x*) <= p
+        # The job of `_solve_bounded_discrete` is to narrow the solution down to an
+        # integer x s.t. either x* = x or x* = x + 1; `_base_discrete_inversion` will
+        # choose between them.
 
-        # if _chandrupatla finds exact inverse, the bracket may not have been reduced
-        # enough for `np.floor(res.x)` to be the appropriate value of `x`.
+        # First try to find where func(x) == p where func is the continuous extension
+        # of either the monotone increasing F or monotone decreasing G.
+        res = self._solve_bounded(func, p, params=params, xatol=0.9)
+        # Here, `_solve_bounded` can terminate for one of three reasons:
+        # 1. func(res.x) == p (`fatol = 0` is satisfied),
+        # 2. res.xl and res.xr bracket the root and |res.xr - res.xl| <= xatol, or
+        # 3. There is no solution within the support.
+        # There are several possible strategies for using `res.xl`, `res.x`, and/or
+        # `res.xr` to find a solution to the original, discrete problem. Here is ours.
+
+        # First let's consider case 2a. Because F is an increasing function, we know
+        # that F(xr) >= p (and F(xl) <= p), so F(floor(xr) + 1) >= p.
+        # F(floor(xr)) *may* be >= p, but we can't know until we evaluate it.
+        # F(floor(xr) - 1) < p (strictly) because floor(xr) - 1 < xl and F decreases
+        # monotonically as the argument decreases. So we choose x = floor(xr), and
+        # `_base_discrete_inversion` will choose between x* = x and x* = x + 1.
+        x = np.asarray(np.floor(res.xr))
+        # This is also suitable for case 2b. Because G is a *decreasing* function, we
+        # know that G(xr) <= p (and G(xl) >= p), so G(floor(xr) + 1) <= p.
+        # G(floor(xr)) *may* be <= p, but we can't know until we evaluate it.
+        # G(floor(xr) - 1) > p (strictly) because floor(xr) - 1 < xl and G increases
+        # as the argument decreases. So we would still want to choose x = floor(xr), and
+        # again, `_base_discrete_inversion` will choose between x* = x and x* = x + 1.
+
+        # Now we consider case 1a/b. In this case, `res.x` solved the equation
+        # *exactly*, so the algorithm may have terminated before the bracket is tight
+        # enough to rely on `res.xr`. If `res.x` happens to be integral, `res.x` is
+        # the solution to the discrete problem, and floor(res.x) == res.x, so
+        # floor(res.x) is the solution to the discrete problem. If not:
+        # a) F(floor(res.x)) < p (strictly) and F(floor(res.x) + 1) > p (strictly). So
+        #    floor(res.x) + 1 is the solution to the discrete problem.
+        # b) G(floor(res.x)) > p (strictly) and G(floor(res.x) + 1) < p (strictly). So
+        #    floor(res.x) + 1 is again the solution to the discrete problem.
+        # Either way, we can choose x = res.x, and `_base_discrete_inversion` will
+        # choose between x* = x and x* = x + 1.
         mask = res.fun == 0
         x[mask] = np.floor(res.x[mask])
 
+        # For case 3, let xmin be the left endpoint of the support, and note that in
+        # general, F(xmin) > 0 and G(xmin) < 1. Therefore we have these possibilities:
+        # a) F(xmin) > p (e.g. because p ~ 0)
+        # a) G(xmin) < p (e.g. because p ~ 1)
+        # In either case, the solution to the discrete problem (by convention) is the
+        # left endpoint of the support, so we let x = xmin.
         xmin, xmax = self._support(**params)
         p, xmin, xmax = np.broadcast_arrays(p, xmin, xmax)
         mask = comp(func(xmin, **params), p)
@@ -3788,23 +3831,20 @@ class DiscreteDistribution(UnivariateDistribution):
         return x
 
     def _base_discrete_inversion(self, p, func, comp, /, **params):
-        # For discrete distributions, icdf(p) is defined as the minimum n
-        # such that cdf(n) >= p. iccdf(p) is defined as the minimum n such
-        # that ccdf(n) <= p, or equivalently as iccdf(p) = icdf(1 - p).
-
-        # First try to find where cdf(x) == p for the continuous extension of the
-        # cdf. res.xl and res.xr will be a bracket for this root. The parameter
-        # xatol in solve_bounded controls the bracket width. We thus know that
-        # know cdf(res.xr) >= p, cdf(res.xl) <= p, and |res.xr - res.xl| <= 0.9.
-        # This means the minimum integer n such that cdf(n) >= p is either floor(x)
-        # or floor(x) + 1.
+        # For discrete distributions, icdf(p) is defined as the smallest integer x*
+        # within the support such that F(x*) >= p; iccdf(p) is the smallest integer x*
+        # within the support such that G(x*) <= p. `_solve_bounded_discrete` narrows the
+        # solution down to an integer x s.t. either x* = x or x* = x + 1.
         x = self._solve_bounded_discrete(func, p, params=params, comp=comp)
-        # comp should be <= for ccdf, >= for cdf.
+
+        # Now, we choose between them: if func(x) satisfies the comparison `comp`
+        # (>= for cdf, <= for ccdf), the solution is x* = x; otherwise the solution must
+        # be x* = x + 1.
         f = func(x, **params)
         res = np.where(comp(f, p), x, x + 1.0)
-        # xr is a bracket endpoint, and will usually be a finite value even when
-        # the computed result should be nan. We need to explicitly handle this
-        # case.
+
+        # It turns out that x above may be a finite value even when p or func(x) is NaN,
+        # so the returned value should be NaN. We need to handle this as a special case.
         res[np.isnan(f) | np.isnan(p)] = np.nan
         return res[()]
 

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3772,36 +3772,36 @@ class DiscreteDistribution(UnivariateDistribution):
             "for continuous distributions.")
 
     def _solve_bounded_discrete(self, func, p, params, comp):
-        # The calling function, `_base_discrete_inversion` is solving either:
+        # We're trying to solve one of these two problems:
         # a) find the smallest integer x* within the support s.t. F(x*) >= p
         # b) find the smallest integer x* within the support s.t. G(x*) = 1 - F(x*) <= p
-        # The job of `_solve_bounded_discrete` is to narrow the solution down to an
-        # integer x s.t. either x* = x or x* = x + 1; `_base_discrete_inversion` will
-        # choose between them.
+        # Our approach is to solve a continuous version of the problem that narrows the
+        # solution down to an integer x s.t. either x* = x or x* = x + 1. At the end,
+        # we'll choose between them.
 
-        # First try to find where func(x) == p where func is the continuous extension
+        # First, solve func(x) == p where func is a continuous, monotone interpolant
         # of either the monotone increasing F or monotone decreasing G.
         res = self._solve_bounded(func, p, params=params, xatol=0.9)
         # Here, `_solve_bounded` can terminate for one of three reasons:
-        # 1. func(res.x) == p (`fatol = 0` is satisfied),
-        # 2. res.xl and res.xr bracket the root and |res.xr - res.xl| <= xatol, or
+        # 1. `func(res.x) == p` (`fatol = 0` is satisfied),
+        # 2. `res.xl` and `res.xr` bracket the root and `|res.xr - res.xl| <= xatol`, or
         # 3. There is no solution within the support.
         # There are several possible strategies for using `res.xl`, `res.x`, and/or
         # `res.xr` to find a solution to the original, discrete problem. Here is ours.
 
-        # First let's consider case 2a. Because F is an increasing function, we know
+        # Consider case 2a. Because F is an increasing function, we know
         # that F(xr) >= p (and F(xl) <= p), so F(floor(xr) + 1) >= p.
         # F(floor(xr)) *may* be >= p, but we can't know until we evaluate it.
         # F(floor(xr) - 1) < p (strictly) because floor(xr) - 1 < xl and F decreases
         # monotonically as the argument decreases. So we choose x = floor(xr), and
-        # `_base_discrete_inversion` will choose between x* = x and x* = x + 1.
+        # later we'll choose between x* = x and x* = x + 1.
         x = np.asarray(np.floor(res.xr))
         # This is also suitable for case 2b. Because G is a *decreasing* function, we
         # know that G(xr) <= p (and G(xl) >= p), so G(floor(xr) + 1) <= p.
         # G(floor(xr)) *may* be <= p, but we can't know until we evaluate it.
         # G(floor(xr) - 1) > p (strictly) because floor(xr) - 1 < xl and G increases
         # as the argument decreases. So we would still want to choose x = floor(xr), and
-        # again, `_base_discrete_inversion` will choose between x* = x and x* = x + 1.
+        # later we'll choose between x* = x and x* = x + 1.
 
         # Now we consider case 1a/b. In this case, `res.x` solved the equation
         # *exactly*, so the algorithm may have terminated before the bracket is tight
@@ -3812,41 +3812,52 @@ class DiscreteDistribution(UnivariateDistribution):
         #    floor(res.x) + 1 is the solution to the discrete problem.
         # b) G(floor(res.x)) > p (strictly) and G(floor(res.x) + 1) < p (strictly). So
         #    floor(res.x) + 1 is again the solution to the discrete problem.
-        # Either way, we can choose x = res.x, and `_base_discrete_inversion` will
-        # choose between x* = x and x* = x + 1.
+        # Either way, we can choose x = res.x, and at the end we'll choose between
+        # x* = x and x* = x + 1.
         mask = res.fun == 0
         x[mask] = np.floor(res.x[mask])
 
         # For case 3, let xmin be the left endpoint of the support, and note that in
-        # general, F(xmin) > 0 and G(xmin) < 1. Therefore we have these possibilities:
-        # a) F(xmin) > p (e.g. because p ~ 0)
-        # a) G(xmin) < p (e.g. because p ~ 1)
-        # In either case, the solution to the discrete problem (by convention) is the
-        # left endpoint of the support, so we let x = xmin.
-        xmin, xmax = self._support(**params)
-        p, xmin, xmax = np.broadcast_arrays(p, xmin, xmax)
-        mask = comp(func(xmin, **params), p)
-        x[mask] = xmin[mask]
+        # general, F(xmin) > 0 and G(xmin) < 1. Therefore it is possible that:
+        # a) F(x) > p for all x in the support (e.g. because p ~ 0)
+        # a) G(x) < p for all x in the support (e.g. because p ~ 1)
+        # In these cases, `_solve_bounded` would fail to find a root of the continuous
+        # equation above, but the solution to the original, discrete problem is the left
+        # endpoint of the support.
+        # This case is handled before we get to this function; otherwise,
+        # `_solve_bounded` may spin its wheels for a long time in vain.
+
+        # Now, we choose between x* = x and x* = x + 1: if func(x) satisfies the
+        # comparison `comp` (>= for cdf, <= for ccdf), the solution is x* = x;
+        # otherwise the solution must be x* = x + 1.
+        f = func(x, **params)
+        x = np.where(comp(f, p), x, x + 1.0)
+        x[np.isnan(f)] = np.nan  # needed? why would func(x) be NaN within support?
 
         return x
 
     def _base_discrete_inversion(self, p, func, comp, /, **params):
-        # For discrete distributions, icdf(p) is defined as the smallest integer x*
-        # within the support such that F(x*) >= p; iccdf(p) is the smallest integer x*
-        # within the support such that G(x*) <= p. `_solve_bounded_discrete` narrows the
-        # solution down to an integer x s.t. either x* = x or x* = x + 1.
-        x = self._solve_bounded_discrete(func, p, params=params, comp=comp)
+        # For discrete distributions, icdf(p) is defined as the minimum integer x*
+        # within the support such that F(x*) >= p; iccdf(p) is the minimum integer x*
+        # within the support such that G(x*) <= p.
 
-        # Now, we choose between them: if func(x) satisfies the comparison `comp`
-        # (>= for cdf, <= for ccdf), the solution is x* = x; otherwise the solution must
-        # be x* = x + 1.
-        f = func(x, **params)
-        res = np.where(comp(f, p), x, x + 1.0)
+        # Identify where the solution is xmin.
+        # (See rationale in `_solve_bounded_discrete`.)
+        xmin, xmax = self._support(**params)
+        p, xmin, _ = np.broadcast_arrays(p, xmin, xmax)
+        mask = comp(func(xmin, **params), p)
 
-        # It turns out that x above may be a finite value even when p or func(x) is NaN,
-        # so the returned value should be NaN. We need to handle this as a special case.
-        res[np.isnan(f) | np.isnan(p)] = np.nan
-        return res[()]
+        # Use `apply_where` to perform the inversion only when necessary.
+        def f1(p, *args):
+            return self._solve_bounded_discrete(
+                func, p, params=dict(zip(params.keys(), args)), comp=comp)
+
+        x = xpx.apply_where(~mask, (p, *params.values()), f1, fill_value=xmin)
+
+        # x above may be a finite value even when p is NaN, so the returned value
+        # should be NaN. We need to handle this as a special case.
+        x[np.isnan(p)] = np.nan
+        return x[()]
 
     def _icdf_inversion(self, x, **params):
         return self._base_discrete_inversion(x, self._cdf_dispatch,

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -650,14 +650,7 @@ def check_nans_and_edges(dist, fname, arg, res):
     if isinstance(dist, DiscreteDistribution):
         exclude.update({'pdf', 'logpdf'})
 
-    if (
-            fname not in exclude
-            and not (isinstance(dist, Binomial)
-                     and np.any((dist.n == 0) | (dist.p == 0) | (dist.p == 1)))):
-        # This can fail in degenerate case where Binomial distribution is a point
-        # distribution. Further on, we could factor out an is_degenerate function
-        # for the tests, or think about storing info about degeneracy in the
-        # instances.
+    if fname not in exclude:
         assert np.isfinite(res[all_valid & (endpoint_arg == 0)]).all()
 
 
@@ -765,13 +758,7 @@ def check_moment_funcs(dist, result_shape):
         assert ref.shape == result_shape
         check(i, 'standardized', 'formula', ref,
               success=has_formula(i, 'standardized'))
-        if not (
-                isinstance(dist, Binomial)
-                and np.any((dist.n == 0) | (dist.p == 0) | (dist.p == 1))
-        ):
-            # This test will fail for degenerate case where binomial distribution
-            # is a point distribution.
-            check(i, 'standardized', 'general', ref, success=i <= 2)
+        check(i, 'standardized', 'general', ref, success=i <= 2)
         check(i, 'standardized', 'normalize', ref)
 
     dist.reset_cache()
@@ -1146,7 +1133,7 @@ class TestMakeDistribution:
                 'johnsonsb', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'norminvgauss',
                 'powerlognorm', 'powernorm', 'recipinvgauss', 'studentized_range',
                 'vonmises_line', # continuous
-                'betanbinom', 'logser', 'skellam', 'zipf'}  # discrete
+                'skellam'}  # discrete
         if not int(os.environ.get('SCIPY_XSLOW', '0')) and distname in slow:
             pytest.skip('Skipping as XSLOW')
 


### PR DESCRIPTION
#### Reference issue
Follow-up to gh-22970.

#### What does this implement/fix?
As noted in https://github.com/scipy/scipy/pull/22312#issuecomment-2865467085 and https://github.com/scipy/scipy/pull/22970#issue-3054643450, the generic `DiscreteDistribution.icdf` and `DiscreteDistribution.iccdf` (`method='inversion'`) can be slow when the distribution support is unbounded to the right and the correct solution is the left endpoint of the support.

This occurs because the main strategy for `icdf`/`iccdf` involves locating the root of a continuous relaxation of the problem, but if the root does not exist within the support and the support is unbounded to the right, `_bracket_root` must continually expand the bracket until it can conclude that there is no zero crossing within the support. (It does not take advantage of the monotonicity of the function.) This takes many iterations.

The simple solution, implemented in gh-22970, was to let this happen and correct for it afterwards.  (In this case, the solution to the original, discrete problem is the left endpoint of the support.)
The more performant solution, implemented here, is to recognize the condition from the outset and perform the root-finding only when necessary.

```python3
from scipy import stats
Poisson = stats.make_distribution(stats.poisson)
X = Poisson(mu=10)
X.icdf(1e-6, method='inversion')  # np.float64(0.0)
# main: 77.9 ms ± 832 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
# PR: 891 μs ± 4.49 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```
#### Additional information
The first commit carefully documents the solution strategy. (It's easy enough to read the code and believe that it's doing the right thing, but seeing that it does *exactly* the right thing is more subtle. In fact, maybe there is an undetected bug, so please check me!)

The second commit implements the enhancement.

The third commit unskips some tests.

@dschmitz89, I thought looking at this might help with gh-24554.