### PR TITLE
DOC: fixed some typo

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -374,15 +374,15 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
         Function that unpacks the results of the function being wrapped into
         a tuple. This is essentially the inverse of `tuple_to_result`. Default
         is `None`, which is appropriate for statistical tests that return a
-        statistic, pvalue tuple (rather than, e.g., a non-iterable datalass).
+        statistic, pvalue tuple (rather than, e.g., a non-iterable dataclass).
     too_small : int or callable, default: 0
-        The largest unnacceptably small sample for the function being wrapped.
+        The largest unacceptably small sample for the function being wrapped.
         For example, some functions require samples of size two or more or they
         raise an error. This argument prevents the error from being raised when
         input is not 1D and instead places a NaN in the corresponding element
         of the result. If callable, it must accept a list of samples, axis,
         and a dictionary of keyword arguments passed to the wrapper function as
-        arguments and return a bool indicating weather the samples passed are
+        arguments and return a bool indicating whether the samples passed are
         too small.
     n_outputs : int or callable, default: 2
         The number of outputs produced by the function given 1d sample(s). For


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR fixes several spelling errors in the docstrings of scipy/stats/_axis_nan_policy.py:

datalass → dataclass

unnacceptably → unacceptably

weather → whether

These changes are purely textual and do not modify any runtime behavior, APIs, or tests.
#### Additional information
<!--Any additional information you think is important.-->
