### PR TITLE
BUG: fix numerical instability in exponnorm for small K

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -2212,22 +2212,56 @@ class exponnorm_gen(rv_continuous):
     def _pdf(self, x, K):
         return np.exp(self._logpdf(x, K))
 
-    def _logpdf(self, x, K):
+    def _logpdf_negative_u(self, x, K):
         invK = 1.0 / K
         exparg = invK * (0.5 * invK - x)
         return exparg + _norm_logcdf(x - invK) - np.log(K)
 
-    def _cdf(self, x, K):
+    def _logpdf_nonnegative_u(self, x, K):
+        u = (-x + 1.0 / K) / np.sqrt(2)
+        return -np.log(2) - 0.5 * (x ** 2) - np.log(K) + np.log(sc.erfcx(u))
+
+    def _logpdf(self, x, K):
+        u = (-x + 1.0 / K) / np.sqrt(2)
+        return xpx.apply_where(
+            u >= 0, (x, K), self._logpdf_nonnegative_u,
+            self._logpdf_negative_u)
+
+    def _cdf_negative_u(self, x, K):
         invK = 1.0 / K
         expval = invK * (0.5 * invK - x)
         logprod = expval + _norm_logcdf(x - invK)
         return _norm_cdf(x) - np.exp(logprod)
 
-    def _sf(self, x, K):
+    def _cdf_nonnegative_u(self, x, K):
+        normal_term = _norm_cdf(x)
+        correction = -0.5 * np.exp(-0.5 * x ** 2) * sc.erfcx(
+            (-x + 1.0 / K) / np.sqrt(2))
+        return normal_term + correction
+
+    def _cdf(self, x, K):
+        u = (-x + 1.0 / K) / np.sqrt(2)
+        return xpx.apply_where(
+            u >= 0, (x, K), self._cdf_nonnegative_u,
+            self._cdf_negative_u)
+
+    def _sf_negative_u(self, x, K):
         invK = 1.0 / K
         expval = invK * (0.5 * invK - x)
         logprod = expval + _norm_logcdf(x - invK)
         return _norm_cdf(-x) + np.exp(logprod)
+
+    def _sf_nonnegative_u(self, x, K):
+        normal_term = _norm_cdf(-x)
+        correction = 0.5 * np.exp(-0.5 * x ** 2) * sc.erfcx(
+            (-x + 1.0 / K) / np.sqrt(2))
+        return normal_term + correction
+
+    def _sf(self, x, K):
+        u = (-x + 1.0 / K) / np.sqrt(2)
+        return xpx.apply_where(
+            u >= 0, (x, K), self._sf_nonnegative_u,
+            self._sf_negative_u)
 
     def _stats(self, K):
         K2 = K * K


### PR DESCRIPTION
Closes #24551

The `logpdf`, `cdf`, and `sf` methods of `exponnorm` produce incorrect results (e.g. negative CDF values) for small K values (< ~1e-8) due to catastrophic cancellation when `log_ndtr` is evaluated on large arguments.

**Fix:** For each of the three methods, the existing implementation is kept as the branch for negative `u = (-x + 1/K) / sqrt(2)`, where it remains numerically accurate. A new branch using the scaled complementary error function (`erfcx`) handles the non-negative `u` case, avoiding the cancellation. The two branches are selected via `apply_where`.

**Reproducer from the issue (now gives correct results):**
```python
from scipy.stats import exponnorm, norm
import numpy as np

K = 1e-11
x_values = np.array([-4, 4])

norm_cdf = norm.cdf(x_values)
exponnorm_cdf = exponnorm(K).cdf(x_values)

print(f"normal:     [{norm_cdf[0]:.5e}, {norm_cdf[1]:.5e}]")
print(f"exponnorm:  [{exponnorm_cdf[0]:.5e}, {exponnorm_cdf[1]:.5e}]")
# Before fix: exponnorm gives [-9.99968e-01, -3.16712e-05]
# After fix:  exponnorm gives [ 3.16712e-05,  9.99968e-01]
```

Only `_logpdf`, `_cdf`, and `_sf` are modified, per the guidance in #24551.