### PR TITLE
BUG: ndimage.label: raise on boolean output dtype

### DIFF
--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -200,6 +200,11 @@ def label(input, structure=None, output=None):
         else:
             output = np.empty(input.shape, output)
 
+    if output.dtype == np.bool_:
+        raise RuntimeError(
+            "output dtype of bool is insufficient to store labels"
+        )
+
     # handle scalars, 0-D arrays
     if input.ndim == 0 or input.size == 0:
         if input.ndim == 0:

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -389,6 +389,26 @@ def test_label_output_wrong_size(xp):
         assert_raises(ValueError, ndimage.label, data, output=output)
 
 
+
+@skip_xp_backends(np_only=True, reason="in-place output is numpy-specific")
+@make_xp_test_case(ndimage.label)
+def test_label_output_bool_dtype(xp):
+    # gh-24502: boolean output cannot store labels > 1
+    data = xp.ones([5])
+    # passing a boolean array as output should raise
+    output = xp.zeros([5], dtype=xp.bool_)
+    assert_raises(RuntimeError, ndimage.label, data, output=output)
+
+
+@skip_xp_backends(np_only=True, exceptions=["cupy"],
+                  reason='output=dtype is numpy-specific')
+@make_xp_test_case(ndimage.label)
+def test_label_output_bool_dtype_kwarg(xp):
+    # gh-24502: boolean dtype passed as output keyword should raise
+    data = xp.ones([5])
+    assert_raises(RuntimeError, ndimage.label, data, output=xp.bool_)
+
+
 @make_xp_test_case(ndimage.label)
 def test_label_structuring_elements(xp):
     data = np.loadtxt(os.path.join(os.path.dirname(


### PR DESCRIPTION
Closes #24502

`ndimage.label()` silently returns a boolean result when called with `output=input` on a boolean array. The Cython layer views `bool` as `uint8`, so `NeedMoreBits` is never raised, and the caller gets back a boolean array where all labels are collapsed to `True`.

This PR adds an early dtype check in `label()` that raises `RuntimeError` when the output dtype is boolean, since a boolean array cannot store label values greater than 1. This matches the existing documentation which states that the output must be able to store the largest label.

**Changes:**
- `scipy/ndimage/_measurements.py`: Add validation that rejects boolean output dtype before labeling
- `scipy/ndimage/tests/test_measurements.py`: Add tests for both boolean array output and boolean dtype keyword