### PR TITLE
DOC: update security vulnerability report link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,8 @@ ODE solvers, and more.
 - **Contributing:** https://scipy.github.io/devdocs/dev/index.html
 - **Bug reports:** https://github.com/scipy/scipy/issues
 - **Code of Conduct:** https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html
-- **Report a security vulnerability:** via Tidelift, as explained in [our docs on Security](https://scipy.github.io/devdocs/tutorial/security.html)
+- **Report a security vulnerability:** via Tidelift, as explained in
+  `our docs on Security <https://scipy.github.io/devdocs/tutorial/security.html>`__
 - **Citing in your work:** https://www.scipy.org/citing-scipy/
 
 SciPy is built to work with

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
   :target: https://scipy.org
   :width: 110
   :height: 110
-  :align: left 
+  :align: left
 
 .. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
   :target: https://numfocus.org
@@ -36,7 +36,7 @@ ODE solvers, and more.
 - **Contributing:** https://scipy.github.io/devdocs/dev/index.html
 - **Bug reports:** https://github.com/scipy/scipy/issues
 - **Code of Conduct:** https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html
-- **Report a security vulnerability:** https://tidelift.com/docs/security
+- **Report a security vulnerability:** https://scipy.github.io/devdocs/tutorial/security.html
 - **Citing in your work:** https://www.scipy.org/citing-scipy/
 
 SciPy is built to work with

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ ODE solvers, and more.
 - **Contributing:** https://scipy.github.io/devdocs/dev/index.html
 - **Bug reports:** https://github.com/scipy/scipy/issues
 - **Code of Conduct:** https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html
-- **Report a security vulnerability:** https://scipy.github.io/devdocs/tutorial/security.html
+- **Report a security vulnerability:** via Tidelift, as explained in [our docs on Security](https://scipy.github.io/devdocs/tutorial/security.html)
 - **Citing in your work:** https://www.scipy.org/citing-scipy/
 
 SciPy is built to work with

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,0 @@
-To report a security vulnerability in SciPy, please read
-our [security doc](https://scipy.github.io/devdocs/tutorial/security.html)
-for our security framework reporting destination.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,3 @@
+To report a security vulnerability in SciPy, please read
+our [security doc](https://scipy.github.io/devdocs/tutorial/security.html)
+for our security framework reporting destination.


### PR DESCRIPTION
#### Reference issue

[As requested](https://github.com/scipy/scipy/pull/24514#pullrequestreview-3761688498)

#### What does this implement/fix?
Now that we have the `security.rst` file in our docs, we want our `SECURITY.md` file
on the repo to point to this doc. This PR adds that pointer file to the scipy repo. 

#### Additional information

I am assuming we also want to update the direct link to tidelift in the `README.rst` file
to point to the same `security.rst`. 