### PR TITLE
MAINT: preparation/backports for SciPy 1.17.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,6 @@ jobs:
           no_output_timeout: 25m
           command: |
             export PYTHONPATH=$PWD/build-install/usr/lib/python3.11/site-packages
-            export SCIPY_ARRAY_API=1
             spin docs -j2 2>&1 | tee sphinx_log.txt
 
       - run:

--- a/doc/source/release/1.17.1-notes.rst
+++ b/doc/source/release/1.17.1-notes.rst
@@ -12,15 +12,15 @@ compared to 1.17.0.
 Authors
 =======
 * Name (commits)
-* Evgeni Burovski (3)
+* Evgeni Burovski (5)
 * Lucas Colley (1)
 * Christoph Gohlke (1)
 * Ralf Gommers (6)
 * Matt Haberland (5)
 * Matthias Koeppe (1)
 * Nick ODell (1)
-* Ilhan Polat (4)
-* Tyler Reddy (27)
+* Ilhan Polat (10)
+* Tyler Reddy (37)
 * Martin Schuck (3)
 * Dan Schult (2)
 * stratakis (1) +
@@ -40,6 +40,7 @@ Issues closed for 1.17.1
 * `#24141 <https://github.com/scipy/scipy/issues/24141>`__: BUG: ``milp`` solver claims optimality but returns an infeasible...
 * `#24208 <https://github.com/scipy/scipy/issues/24208>`__: BUG: ndimage: uninitialized variable "icoor" in NI_GeometricTransform
 * `#24339 <https://github.com/scipy/scipy/issues/24339>`__: BUG: sparse: Sparse array slicing (CSC Matrix) seemingly initializes...
+* `#24345 <https://github.com/scipy/scipy/issues/24345>`__: BUG: linalg.solve: ``overwrite_b=True`` ignored in 1.17.0
 * `#24354 <https://github.com/scipy/scipy/issues/24354>`__: BUG: spatial: ``Rotation.from_quat``\ : fails with read-only...
 * `#24355 <https://github.com/scipy/scipy/issues/24355>`__: BUG: linalg solve behavior change breaking downstream tests
 * `#24358 <https://github.com/scipy/scipy/issues/24358>`__: BUG: ``sparse.linalg.eigs`` results differ in``1.17.0``
@@ -50,6 +51,7 @@ Issues closed for 1.17.1
 * `#24403 <https://github.com/scipy/scipy/issues/24403>`__: BUG: integrate.dop: C dop implementation not calculating max...
 * `#24406 <https://github.com/scipy/scipy/issues/24406>`__: BUG: Regression in 1.17.0: generate_f2py mod is called by the...
 * `#24436 <https://github.com/scipy/scipy/issues/24436>`__: BUG: _quat become a MemoryView of 'ndarray' object after applying...
+* `#24508 <https://github.com/scipy/scipy/issues/24508>`__: BUG: ``linalg.sqrtm`` does not issue warning on sigularity at...
 * `#24555 <https://github.com/scipy/scipy/issues/24555>`__: BUG: spatial.transform.Rotation.from_mrp: leaked Cython memoryview
 * `#24574 <https://github.com/scipy/scipy/issues/24574>`__: BUG: scipy.stats.gengamma.logpdf ValueError when c < 0 and 0...
 
@@ -73,10 +75,13 @@ Pull requests for 1.17.1
 * `#24404 <https://github.com/scipy/scipy/pull/24404>`__: BUG:integrate:Fix a pointer dereference problem in DOPRI5
 * `#24407 <https://github.com/scipy/scipy/pull/24407>`__: BLD: tools/generate_f2pymod.py: Do not try to invoke f2py via...
 * `#24440 <https://github.com/scipy/scipy/pull/24440>`__: BUG: spatial.transform: Fix leaking MemoryViews from cy backend
+* `#24442 <https://github.com/scipy/scipy/pull/24442>`__: ENH: linalg/inv: re-enable overwrite_a for 2D inputs
 * `#24453 <https://github.com/scipy/scipy/pull/24453>`__: BUG: ndimage: Initialize icoor array in ``NI_GeometricTransform``
 * `#24499 <https://github.com/scipy/scipy/pull/24499>`__: BUG: sparse: Fix CSR/C index broadcasting
+* `#24507 <https://github.com/scipy/scipy/pull/24507>`__: BUG: linalg: restore backwards compatibility with dtypes in inv,...
 * `#24511 <https://github.com/scipy/scipy/pull/24511>`__: BUG: sparse: Fix CSR/C index broadcasting part 2
 * `#24537 <https://github.com/scipy/scipy/pull/24537>`__: TST: decrease resource usage (file handles, memory) of import...
+* `#24558 <https://github.com/scipy/scipy/pull/24558>`__: BUG:linalg: Improve linalg.sqrtm singularity catching logic
 * `#24564 <https://github.com/scipy/scipy/pull/24564>`__: BUG: spatial.transform.Rotation.from_mrp: fix leaking Cython...
 * `#24573 <https://github.com/scipy/scipy/pull/24573>`__: ENH: stats.DiscreteDistribution.icdf/iccdf: improve performance...
 * `#24576 <https://github.com/scipy/scipy/pull/24576>`__: MAINT: stats.gengamma.logpdf: fix broadcasting bug

--- a/doc/source/release/1.17.1-notes.rst
+++ b/doc/source/release/1.17.1-notes.rst
@@ -20,9 +20,9 @@ Authors
 * Matthias Koeppe (1)
 * Nick ODell (1)
 * Ilhan Polat (10)
-* Tyler Reddy (37)
+* Tyler Reddy (44)
 * Martin Schuck (3)
-* Dan Schult (2)
+* Dan Schult (3)
 * stratakis (1) +
 * ਗਗਨਦੀਪ ਸਿੰਘ (Gagandeep Singh) (1)
 
@@ -54,6 +54,7 @@ Issues closed for 1.17.1
 * `#24508 <https://github.com/scipy/scipy/issues/24508>`__: BUG: ``linalg.sqrtm`` does not issue warning on sigularity at...
 * `#24555 <https://github.com/scipy/scipy/issues/24555>`__: BUG: spatial.transform.Rotation.from_mrp: leaked Cython memoryview
 * `#24574 <https://github.com/scipy/scipy/issues/24574>`__: BUG: scipy.stats.gengamma.logpdf ValueError when c < 0 and 0...
+* `#24629 <https://github.com/scipy/scipy/issues/24629>`__: MAINT: CI failures with new ``pydata/sparse`` release
 
 Pull requests for 1.17.1
 ------------------------
@@ -86,3 +87,4 @@ Pull requests for 1.17.1
 * `#24573 <https://github.com/scipy/scipy/pull/24573>`__: ENH: stats.DiscreteDistribution.icdf/iccdf: improve performance...
 * `#24576 <https://github.com/scipy/scipy/pull/24576>`__: MAINT: stats.gengamma.logpdf: fix broadcasting bug
 * `#24607 <https://github.com/scipy/scipy/pull/24607>`__: ENH: stats.DiscreteDistribution: entropy speedup
+* `#24646 <https://github.com/scipy/scipy/pull/24646>`__: BUG: sparse: csgraph and superLU index dtype need 32bit

--- a/doc/source/release/1.17.1-notes.rst
+++ b/doc/source/release/1.17.1-notes.rst
@@ -12,12 +12,72 @@ compared to 1.17.0.
 Authors
 =======
 * Name (commits)
+* Evgeni Burovski (3)
+* Lucas Colley (1)
+* Christoph Gohlke (1)
+* Ralf Gommers (6)
+* Matt Haberland (5)
+* Matthias Koeppe (1)
+* Nick ODell (1)
+* Ilhan Polat (4)
+* Tyler Reddy (27)
+* Martin Schuck (3)
+* Dan Schult (2)
+* stratakis (1) +
+* ਗਗਨਦੀਪ ਸਿੰਘ (Gagandeep Singh) (1)
+
+    A total of 13 people contributed to this release.
+    People with a "+" by their names contributed a patch for the first time.
+    This list of names is automatically generated, and may not be fully complete.
 
 
 Issues closed for 1.17.1
 ------------------------
 
-
+* `#22819 <https://github.com/scipy/scipy/issues/22819>`__: BUG: ``stats.qmc.PoissonDisk``\ : overlapping sampling for negative...
+* `#23215 <https://github.com/scipy/scipy/issues/23215>`__: BUG: optimize.direct: memory leak while returning from user function
+* `#23612 <https://github.com/scipy/scipy/issues/23612>`__: BUG: optimize: crash in win-arm64 CI job in ``optimize.root(method='lm')``
+* `#24141 <https://github.com/scipy/scipy/issues/24141>`__: BUG: ``milp`` solver claims optimality but returns an infeasible...
+* `#24208 <https://github.com/scipy/scipy/issues/24208>`__: BUG: ndimage: uninitialized variable "icoor" in NI_GeometricTransform
+* `#24339 <https://github.com/scipy/scipy/issues/24339>`__: BUG: sparse: Sparse array slicing (CSC Matrix) seemingly initializes...
+* `#24354 <https://github.com/scipy/scipy/issues/24354>`__: BUG: spatial: ``Rotation.from_quat``\ : fails with read-only...
+* `#24355 <https://github.com/scipy/scipy/issues/24355>`__: BUG: linalg solve behavior change breaking downstream tests
+* `#24358 <https://github.com/scipy/scipy/issues/24358>`__: BUG: ``sparse.linalg.eigs`` results differ in``1.17.0``
+* `#24359 <https://github.com/scipy/scipy/issues/24359>`__: BUG: calculation of inverse is wrong in scipy 1.17.0
+* `#24366 <https://github.com/scipy/scipy/issues/24366>`__: BUG: ``sparse.linalg.expm`` incorrect for some inputs since 1.17.0
+* `#24378 <https://github.com/scipy/scipy/issues/24378>`__: BUG: RigidTransform.from_matrix doesn't allow read-only arrays
+* `#24382 <https://github.com/scipy/scipy/issues/24382>`__: BUG: ``scipy.signal.zpk2tf`` yield incorrect results with complex/non-integer...
+* `#24403 <https://github.com/scipy/scipy/issues/24403>`__: BUG: integrate.dop: C dop implementation not calculating max...
+* `#24406 <https://github.com/scipy/scipy/issues/24406>`__: BUG: Regression in 1.17.0: generate_f2py mod is called by the...
+* `#24436 <https://github.com/scipy/scipy/issues/24436>`__: BUG: _quat become a MemoryView of 'ndarray' object after applying...
+* `#24555 <https://github.com/scipy/scipy/issues/24555>`__: BUG: spatial.transform.Rotation.from_mrp: leaked Cython memoryview
+* `#24574 <https://github.com/scipy/scipy/issues/24574>`__: BUG: scipy.stats.gengamma.logpdf ValueError when c < 0 and 0...
 
 Pull requests for 1.17.1
 ------------------------
+
+* `#24253 <https://github.com/scipy/scipy/pull/24253>`__: MAINT: update HiGHS subproject to v1.12.0
+* `#24275 <https://github.com/scipy/scipy/pull/24275>`__: MAINT: Fix heap-buffer-overflow in ``scipy.interpolate._dierckx.qr_reduce_period``...
+* `#24323 <https://github.com/scipy/scipy/pull/24323>`__: MAINT:optimize: Fix an off-by-one error in MINPACK and re-enable...
+* `#24332 <https://github.com/scipy/scipy/pull/24332>`__: DOC: set ``SCIPY_ARRAY_API`` in notebook, not globally
+* `#24338 <https://github.com/scipy/scipy/pull/24338>`__: REL, MAINT: prepare for SciPy 1.17.1
+* `#24352 <https://github.com/scipy/scipy/pull/24352>`__: BLD: Fix building on win32
+* `#24367 <https://github.com/scipy/scipy/pull/24367>`__: BUG: linalg: fix ``inv``\ , ``solve`` for complex symmetric inputs
+* `#24370 <https://github.com/scipy/scipy/pull/24370>`__: BUG: spatial.transform.Rotation.from_quat: handle ``const`` ``np``...
+* `#24371 <https://github.com/scipy/scipy/pull/24371>`__: MAINT:sparse.linalg: Fix a persistent state propagation issue...
+* `#24380 <https://github.com/scipy/scipy/pull/24380>`__: BUG: spatial.transform.RigidTransform.from_matrix: handle ``const``...
+* `#24384 <https://github.com/scipy/scipy/pull/24384>`__: MAINT: optimize: Fix memory leaks in DIRECT solver and extension...
+* `#24385 <https://github.com/scipy/scipy/pull/24385>`__: BUG: signal: fix zpk2tf with non-integer gain
+* `#24386 <https://github.com/scipy/scipy/pull/24386>`__: BUG: linalg/solve: raise errors for "singular" matrices of one...
+* `#24399 <https://github.com/scipy/scipy/pull/24399>`__: MAINT: stats.PoissonDisk: fix "overlapping" sampling when using...
+* `#24404 <https://github.com/scipy/scipy/pull/24404>`__: BUG:integrate:Fix a pointer dereference problem in DOPRI5
+* `#24407 <https://github.com/scipy/scipy/pull/24407>`__: BLD: tools/generate_f2pymod.py: Do not try to invoke f2py via...
+* `#24440 <https://github.com/scipy/scipy/pull/24440>`__: BUG: spatial.transform: Fix leaking MemoryViews from cy backend
+* `#24453 <https://github.com/scipy/scipy/pull/24453>`__: BUG: ndimage: Initialize icoor array in ``NI_GeometricTransform``
+* `#24499 <https://github.com/scipy/scipy/pull/24499>`__: BUG: sparse: Fix CSR/C index broadcasting
+* `#24511 <https://github.com/scipy/scipy/pull/24511>`__: BUG: sparse: Fix CSR/C index broadcasting part 2
+* `#24537 <https://github.com/scipy/scipy/pull/24537>`__: TST: decrease resource usage (file handles, memory) of import...
+* `#24564 <https://github.com/scipy/scipy/pull/24564>`__: BUG: spatial.transform.Rotation.from_mrp: fix leaking Cython...
+* `#24573 <https://github.com/scipy/scipy/pull/24573>`__: ENH: stats.DiscreteDistribution.icdf/iccdf: improve performance...
+* `#24576 <https://github.com/scipy/scipy/pull/24576>`__: MAINT: stats.gengamma.logpdf: fix broadcasting bug
+* `#24607 <https://github.com/scipy/scipy/pull/24607>`__: ENH: stats.DiscreteDistribution: entropy speedup

--- a/doc/source/tutorial/stats/outliers.md
+++ b/doc/source/tutorial/stats/outliers.md
@@ -35,6 +35,8 @@ using tools available in SciPy, with an emphasis on transitioning from use of le
 In the past, SciPy has offered several "convenience functions" that combine trimming with computation of a statistic. Consider, for instance, {func}`scipy.stats.trim_mean`.
 
 ```{code-cell} ipython3
+import os
+os.environ['SCIPY_ARRAY_API'] = '1'
 import numpy as np
 from scipy import stats
 np.set_printoptions(linewidth=120)

--- a/scipy/_lib/tests/test_import_cycles.py
+++ b/scipy/_lib/tests/test_import_cycles.py
@@ -1,6 +1,8 @@
-import pytest
-import sys
+import multiprocessing
 import subprocess
+import sys
+
+import pytest
 
 from .test_public_api import PUBLIC_MODULES
 
@@ -8,10 +10,17 @@ from .test_public_api import PUBLIC_MODULES
 # Check that all modules are importable in a new Python process.
 # This is not necessarily true if there are import cycles present.
 
+
+def _check_single_module(module):
+    pid = subprocess.Popen([sys.executable, '-X', 'faulthandler', '-c',
+                            f'import {module}'])
+    assert pid.wait() == 0, f'Failed to import {module}'
+
+
 @pytest.mark.fail_slow(40)
 @pytest.mark.slow
-def test_public_modules_importable():
-    pids = [subprocess.Popen([sys.executable, '-c', f'import {module}'])
-            for module in PUBLIC_MODULES]
-    for i, pid in enumerate(pids):
-        assert pid.wait() == 0, f'Failed to import {PUBLIC_MODULES[i]}'
+def test_public_modules_importable_2():
+    # Ensure we use max 6 processes, to limit peak resource usage (memory, file handles)
+    # on resource-constrained systems (e.g., RISC-V - see gh-24163).
+    with multiprocessing.Pool(processes=6) as pool:
+        pool.map(_check_single_module, PUBLIC_MODULES)

--- a/scipy/integrate/src/dop.c
+++ b/scipy/integrate/src/dop.c
@@ -760,7 +760,7 @@ dopri5(const int n, dopri_fcn* fcn, double *x, double* y, double *xend, double* 
         }
     }
     // -------- maximal step size
-    if (work[5] == 0.0) { hmax = xend - x; } else { hmax = work[5]; }
+    if (work[5] == 0.0) { hmax = *xend - *x; } else { hmax = work[5]; }
     // -------- initial step size
     h = work[6];
     // -------- when a fail has occurred, we return with wrong input error code

--- a/scipy/interpolate/src/__fitpack.cc
+++ b/scipy/interpolate/src/__fitpack.cc
@@ -559,7 +559,7 @@ void qr_reduce_periodic(
                             std::tie(A1(j - 1, h1i), H1(it - 1, h1i)) = fprota(c, s, A1(j - 1, h1i), H1(it - 1, h1i));
                         }
 
-                        for( int64_t h1i = 1; h1i <= i2; h1i++ ) {
+                        for( int64_t h1i = 1; h1i < i2; h1i++ ) {
                             H1(it - 1, h1i - 1) = H1(it - 1, h1i);
                         }
                         H1(it - 1, i2 - 1) = 0.0;

--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -203,7 +203,7 @@ py_fpbacp(PyObject* self, PyObject *args)
     Py_ssize_t m = PyArray_DIM(a_x, 0);
     Py_ssize_t len_t = PyArray_DIM(a_t, 0);
 
-    int64_t nc = len_t - k - 1;
+    Py_ssize_t nc = len_t - k - 1;
 
     // allocate the output buffer
     npy_intp dims[2] = {nc, PyArray_DIM(a_y, 1)};

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -277,6 +277,9 @@ def solve(a, b, lower=False, overwrite_a=False,
         return x
 
     if a_is_scalar:
+        if a1.item() == 0:
+            raise LinAlgError("A singular matrix detected.")
+
         out = b1 / a1
         return out[..., 0] if b_is_1D else out
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -10,7 +10,10 @@ from itertools import product
 import numpy as np
 from numpy import atleast_1d, atleast_2d
 from scipy._lib._util import _apply_over_batch
-from .lapack import get_lapack_funcs, _compute_lwork, _normalize_lapack_dtype
+from .lapack import (
+    get_lapack_funcs, _normalize_lapack_dtype, _normalize_lapack_dtype1,
+    _compute_lwork
+)
 from ._misc import LinAlgError, _datacopied, LinAlgWarning
 from ._decomp import _asarray_validated
 from . import _decomp, _decomp_svd
@@ -1539,7 +1542,7 @@ def det(a, overwrite_a=False, check_finite=True):
                          f' but received shape {a1.shape}.')
 
     # Also check if dtype is LAPACK compatible
-    a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
+    a1, overwrite_a = _normalize_lapack_dtype1(a1, overwrite_a)
 
     # Empty array has determinant 1 because math.
     if min(*a1.shape) == 0:

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -286,8 +286,15 @@ def solve(a, b, lower=False, overwrite_a=False,
         out = b1 / a1
         return out[..., 0] if b_is_1D else out
 
+    # XXX a1.ndim > 2 ; b1.ndim > 2
+    # XXX can do something if a1 C ordered & transposed==True ?
+    overwrite_a = overwrite_a and (a1.ndim == 2) and (a1.flags["F_CONTIGUOUS"])
+    overwrite_b = overwrite_b and (b1.ndim <= 2) and (b1.flags["F_CONTIGUOUS"])
+
     # heavy lifting
-    x, err_lst = _batched_linalg._solve(a1, b1, structure, lower, transposed)
+    x, err_lst = _batched_linalg._solve(
+        a1, b1, structure, lower, transposed, overwrite_a, overwrite_b
+    )
 
     if err_lst:
         _format_emit_errors_warnings(err_lst)
@@ -1443,6 +1450,9 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
     if not (a1.flags['ALIGNED'] or a1.dtype.byteorder == '='):
         overwrite_a = True
         a1 = a1.copy()
+
+    # XXX can relax a1.ndim == 2?
+    overwrite_a = overwrite_a and (a1.ndim == 2) and (a1.flags["F_CONTIGUOUS"])
 
     # keep the numbers in sync with C at `linalg/src/_common_array_utils.hh`
     structure = {

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -48,8 +48,6 @@ _linalg_inv(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-    overwrite_a = 0; // TODO: enable it
-
     if(!overwrite_a) {
         /* Allocate the output */
         ap_Ainv = (PyArrayObject *)PyArray_SimpleNew(ndim, shape, typenum);
@@ -106,11 +104,17 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
     SliceStatusVec vec_status;
     St structure = St::NONE;
     int overwrite_a = 0;
+    int overwrite_b = 0;
     int transposed = 0;
     int lower=0;
 
-    // Get the input array
-    if (!PyArg_ParseTuple(args, "O!O!|nppp", &PyArray_Type, (PyObject **)&ap_Am, &PyArray_Type, (PyObject **)&ap_b, &structure, &lower, &transposed, &overwrite_a)) {
+    if (!PyArg_ParseTuple(args, "O!O!|npppp",
+        &PyArray_Type, (PyObject **)&ap_Am,
+        &PyArray_Type, (PyObject **)&ap_b,
+        &structure,
+        &lower, &transposed,
+        &overwrite_a, &overwrite_b)
+    ){
         return NULL;
     }
 
@@ -152,26 +156,33 @@ _linalg_solve(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-    // Allocate the output
-    ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim_b, shape_b, typenum);
-    if(!ap_x) {
-        PyErr_NoMemory();
-        return NULL;
+    if (!overwrite_b) {
+        /* Allocate the output */
+        ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim_b, shape_b, typenum);
+        if(!ap_x) {
+            PyErr_NoMemory();
+            return NULL;
+        }
+    }
+    else {
+        /* Reuse the memory buffer of the input array. */
+        ap_x = ap_b;
+        Py_INCREF(ap_b);
     }
 
     void *buf = PyArray_DATA(ap_x);
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _solve<float>(ap_Am, ap_b, (float *)buf, structure, lower, transposed, overwrite_a, vec_status);
+            info = _solve<float>(ap_Am, ap_b, (float *)buf, structure, lower, transposed, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _solve<double>(ap_Am, ap_b, (double *)buf, structure, lower, transposed, overwrite_a, vec_status);
+            info = _solve<double>(ap_Am, ap_b, (double *)buf, structure, lower, transposed, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _solve<npy_complex64>(ap_Am, ap_b, (npy_complex64 *)buf, structure, lower, transposed, overwrite_a, vec_status);
+            info = _solve<npy_complex64>(ap_Am, ap_b, (npy_complex64 *)buf, structure, lower, transposed, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _solve<npy_complex128>(ap_Am, ap_b, (npy_complex128 *)buf, structure, lower, transposed, overwrite_a, vec_status);
+            info = _solve<npy_complex128>(ap_Am, ap_b, (npy_complex128 *)buf, structure, lower, transposed, overwrite_a, overwrite_b, vec_status);
             break;
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -784,12 +784,10 @@ bandwidth(T* data, npy_intp n, npy_intp m, npy_intp* lower_band, npy_intp* upper
 }
 
 
-
-
 template<typename T>
 std::tuple<bool, bool>
-is_sym_herm(const T *data, npy_intp n) {
-    // Return a pair of (is_symmetric_or_hermitian, is_symmetric_not_hermitian)
+is_sym_or_herm(const T *data, npy_intp n) {
+    // Return a pair of (is_symmetric, is_hermitian)
     using value_type = typename type_traits<T>::value_type;
     const value_type *p_data = reinterpret_cast<const value_type *>(data);
     bool all_sym = true, all_herm = true;
@@ -806,9 +804,8 @@ is_sym_herm(const T *data, npy_intp n) {
             }
         }
     }
-    return std::make_tuple(true, all_sym ? true : false);
+    return std::make_tuple(all_sym, all_herm);
 }
-
 
 
 template<typename T>

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -257,14 +257,47 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
 
     lwork = (4*n > lwork ? 4*n : lwork);
 
-    // Finally, can start allocating memory
-    T* buffer = (T *)malloc((2*n*n + lwork)*sizeof(T));
+    /*
+     * Finally, we can start allocating memory.
+     *
+     * The key point is that LAPACK always operates on F-ordered arrays.
+     * The memory strategy thus depends on the `overwrite_a` value.
+     *
+     * For `overwrite_a=False` (default), we:
+     *   - allocate a temp buffer (`scratch` and `data` below) once
+     *   - for each slice, we
+     *       - copy-and-transpose the slice into the temp buffer,
+     *       - feed the buffer to LAPACK
+     *       - copy-and-transpose the result back to the C-ordered result array
+     *
+     * For `overwrite_a=True`, we assume that
+     *   - `ret_data` may point to the same memory as `ap_Am` array
+     *   - the caller had ensured that the input array is Fortran-ordered
+     *   - the caller wants to get the result also Fortran ordered
+     *
+     * It's a caller's responsibility to make sure that these pre-conditions are met,
+     * none of them is checked here.
+     * Therefore, if `overwrite_a = True`, we skip the copy-and-transpose steps above,
+     * and `ret_data` will simply contain the result from the LAPACK call.
+     *
+     */
+    CBLAS_INT buf_size = overwrite_a ? lwork : 2*n*n + lwork;
+
+    T* buffer = (T *)malloc(buf_size*sizeof(T));
     if (NULL == buffer) { info = -101; return (int)info; }
 
-    // Chop buffer into parts, one for data and one for work
-    T* data = &buffer[0];
-    T* scratch = &buffer[n*n];
-    T* work = &buffer[2*n*n];
+    T *data=NULL, *scratch=NULL, *work=NULL;
+    if (overwrite_a) {
+        // work in-place 
+        data = ret_data;
+        work = &buffer[0];
+    }
+    else {
+        // Chop buffer into parts, one for data and one for work
+        data = &buffer[0];
+        scratch = &buffer[n*n];
+        work = &buffer[2*n*n];
+    }
 
     CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
     if (ipiv == NULL) {
@@ -287,7 +320,9 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
         return (int)info;
     }
 
-    // normalize the structure detection inputs
+    /*
+     * Normalize the structure detection inputs.
+     */
     if (structure == St::POS_DEF) {
         posdef_fallback = false;
     }
@@ -304,7 +339,9 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
         uplo = 'U';
     }
 
-    // Main loop to traverse the slices
+    /*
+     * Main loop to traverse the slices.
+     */
     for (npy_intp idx = 0; idx < outer_size; idx++) {
 
         npy_intp offset = 0;
@@ -314,8 +351,10 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
             temp_idx /= shape[i];
         }
         T* slice_ptr = (T *)(Am_data + (offset/sizeof(T)));
-        copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]); // XXX: make it in one go
-        swap_cf(scratch, data, n, n, n);
+        if (!overwrite_a) {
+            copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]); // XXX: make it in one go
+            swap_cf(scratch, data, n, n, n);
+        }
 
         // detect the structure if not given
         slice_structure = structure;
@@ -366,6 +405,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
 
         init_status(slice_status, idx, slice_structure);
 
+        // Use the appropriate LAPACK function for the `slice_structure`.
         switch(slice_structure) {
             case St::DIAGONAL:
             {
@@ -469,16 +509,18 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                     vec_status.push_back(slice_status);
                 }
             }
-        }
+        } // end of `switch(slice_structure)`
 
         if (slice_status.is_singular == 1) {
             // nan_matrix(data, n);
             goto free_exit;     // fail fast and loud
         }
 
-        // Swap back to original order
-        swap_cf(data, &ret_data[idx*n*n], n, n, n);
-    }
+        if (!overwrite_a) {
+            // Swap back to original order
+            swap_cf(data, &ret_data[idx*n*n], n, n, n);
+        }
+    } // end of `for(idx=...)`
 
 free_exit:
     free(buffer);

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -249,7 +249,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
 
     char trans = transposed ? 'T' : 'N'; 
     npy_intp lower_band = 0, upper_band = 0;
-    bool is_symm_or_herm = false, is_symm_not_herm = false;
+    bool is_symm = false, is_herm = false;
     char uplo = lower ? 'L' : 'U';
     St slice_structure = St::NONE;
     bool posdef_fallback = true;
@@ -334,10 +334,10 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
         posdef_fallback = false;
     }
     else if (structure == St::SYM) {
-        is_symm_not_herm = true;
+        is_symm = true;
     }
     else if (structure == St::HER) {
-        is_symm_not_herm = false;
+        is_herm = true;
     }
     if (structure == St::LOWER_TRIANGULAR) {
         uplo = 'L';
@@ -390,9 +390,15 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
                 uplo = 'L';
             } else {
                 // Check if symmetric/hermitian
-                std::tie(is_symm_or_herm, is_symm_not_herm) = is_sym_herm(data, n);
-                if (is_symm_or_herm) {
+                std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
+                if (is_herm || (is_symm && !type_traits<T>::is_complex)) {
+                    // either real symmetric or complex hermitian; try Cholesky first,
+                    // fall back to sym/her if it fails
                     slice_structure = St::POS_DEF;
+                }
+                else if (is_symm && type_traits<T>::is_complex) {
+                    // complex symmetric, not hermitian
+                    slice_structure = St::SYM;
                 }
                 else {
                     // give up auto-detection
@@ -480,7 +486,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
             case St::SYM:  // pos def fails, fall through to here
             case St::HER:
             {
-                solve_slice_sym_herm(uplo, intn, int_nrhs, data, data_b, ipiv, work, irwork, lwork, is_symm_not_herm, slice_status);
+                solve_slice_sym_herm(uplo, intn, int_nrhs, data, data_b, ipiv, work, irwork, lwork, (is_symm && !is_herm), slice_status);
 
                 if ((slice_status.lapack_info < 0) || (slice_status.is_singular )) {
                     vec_status.push_back(slice_status);
@@ -490,7 +496,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
                     vec_status.push_back(slice_status);
                 }
 
-                if (is_symm_not_herm) {
+                if (is_symm && !is_herm) {
                     fill_other_triangle_noconj(uplo, data, intn);
                 }
                 else {

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -243,7 +243,7 @@ inline void solve_slice_diagonal(
 
 template<typename T>
 int
-_solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int lower, int transposed, int overwrite_a, SliceStatusVec& vec_status)
+_solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int lower, int transposed, int overwrite_a, int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
 
@@ -297,16 +297,49 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     // gecon needs lwork of at least 4*n
     lwork = (4*n > lwork ? 4*n : lwork);
 
-    T* buffer = (T *)malloc((2*n*n + n*nrhs + 2*n + lwork)*sizeof(T));
+    CBLAS_INT buf_size_a = overwrite_a ? 0 : n*n;
+    CBLAS_INT buf_size_b = overwrite_b ? 0 : n*nrhs;
+    CBLAS_INT buf_size_trcon = 2*n; // // 2*n for tridiag trcon
+    CBLAS_INT buf_size = 2*buf_size_a + buf_size_b + buf_size_trcon + lwork; 
+
+    T* buffer = (T *)malloc(buf_size*sizeof(T));
     if (NULL == buffer) { info = -101; return (int)info; }
 
-    // Chop the buffer into parts
-    T* data = &buffer[0];
-    T* scratch = &buffer[n*n];
+    /*
+     * Chop the buffer into parts:
+     *
+     *    size_a     size_a    size_b     2n     lwork
+     * |----------|---------|----------|------|---------|
+     * ^          ^         ^          ^      ^
+     * scratch    data      data_b     work2  work
+     *
+     * - scrach & data are for A (lhs)
+     * - data_b is for b (rhs)
+     * - work2 is for the tridiag solver, trcon's work array
+     * - work is for all other LAPACK functions
+     *
+     */
 
-    T *data_b = &buffer[2*n*n];
-    T *work2 = &buffer[2*n*n + n*nrhs]; // 2*n for is for tridiag's trcon; XXX malloc it only if needed?
-    T* work = &buffer[2*n*n + n*nrhs + 2*n];
+    T *scratch = NULL, *data = NULL;
+    if (overwrite_a) {
+        data = (T *)Am_data;
+    }
+    else {
+        scratch = &buffer[0];
+        data = &buffer[buf_size_a];
+    }
+
+    T *data_b = NULL;
+    if(overwrite_b) {
+        // work in-place
+        data_b = ret_data;
+    }
+    else {
+        data_b = &buffer[2*buf_size_a];
+    }
+
+    T *work2 = &buffer[2*buf_size_a + buf_size_b]; // 2*n for is for tridiag's trcon; XXX malloc it only if needed?
+    T* work = &buffer[2*buf_size_a + buf_size_b + 2*n];
 
     CBLAS_INT* ipiv = (CBLAS_INT *)malloc(n*sizeof(CBLAS_INT));
     if (ipiv == NULL) {
@@ -356,18 +389,22 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
             temp_idx /= shape[i];
         }
         T* slice_ptr = (T *)(Am_data + (offset/sizeof(T)));
-        copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]); // XXX: make it in one go
-        swap_cf(scratch, data, n, n, n);
-
-        // copy the r.h.s, too; XXX: dedupe
-        offset = 0;
-        temp_idx = idx;
-        for (int i = ndim_b - 3; i >= 0; i--) {
-            offset += (temp_idx % shape_b[i]) * strides_b[i];
-            temp_idx /= shape_b[i];
+        if (!overwrite_a) {
+            copy_slice(scratch, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]); // XXX: make it in one go
+            swap_cf(scratch, data, n, n, n);
         }
-        T *slice_ptr_b = (T *)(bm_data + (offset/sizeof(T)));
-        copy_slice_F(data_b, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+
+        if (!overwrite_b) {
+            // copy the r.h.s, too; XXX: dedupe
+            offset = 0;
+            temp_idx = idx;
+            for (int i = ndim_b - 3; i >= 0; i--) {
+                offset += (temp_idx % shape_b[i]) * strides_b[i];
+                temp_idx /= shape_b[i];
+            }
+            T *slice_ptr_b = (T *)(bm_data + (offset/sizeof(T)));
+            copy_slice_F(data_b, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+        }
 
         // detect the structure if not given
         slice_structure = structure;
@@ -522,8 +559,10 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
             goto free_exit;     // fail fast and loud
         }
 
-        // Swap back to the C order
-        copy_slice_F_to_C(&ret_data[idx*n*nrhs], data_b, n, nrhs);
+        if (!overwrite_b) {
+            // Swap back to the C order
+            copy_slice_F_to_C(&ret_data[idx*n*nrhs], data_b, n, nrhs);
+        }
     }
 
 free_exit:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -808,6 +808,22 @@ class TestSolve:
         with (pytest.raises(LinAlgError, match="singular"), np.errstate(all='ignore')):
             solve(A, b, assume_a=structure)
 
+
+    @pytest.mark.parametrize('b', [0, 1, [0, 1]])
+    def test_singular_scalar(self, b):
+        # regression test for gh-24355: scalar a=0 is singular
+        # thus should raise the same error 
+
+        with pytest.raises(LinAlgError):
+            a = np.zeros((1, 1))
+            solve(a, b)
+
+        with pytest.raises(LinAlgError):
+            solve(0, b)
+
+        with pytest.raises(LinAlgError):
+            solve([[0]], b)
+
     def test_multiple_rhs(self):
         a = np.eye(2)
         rng = np.random.default_rng(1234)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1,3 +1,5 @@
+import os
+import platform
 import itertools
 import warnings
 
@@ -1338,6 +1340,24 @@ class TestInv:
         a_inv = inv(a, overwrite_a=True)
         assert np.shares_memory(a, a_inv)
 
+    @pytest.mark.parametrize(
+        "dtyp", [np.float16, np.float32, np.longdouble, np.clongdouble]
+    )
+    def test_dtypes(self, dtyp):
+        # backwards compat: inv(float16)->float32 ; inv(clongdouble)->complex128 etc
+        a = np.arange(4).reshape(2, 2).astype(dtyp)
+
+        a_inv = inv(a)
+        assert_allclose(a @ a_inv, np.eye(a.shape[0]), atol=100*np.finfo(a.dtype).eps)
+
+        dt_map = {
+            'e': 'f',  # float16 -> float32
+            'f': 'f',
+            'g': 'd',  # longdouble -> float64
+            'G': 'D'   # clongdouble -> complex128
+        }
+        assert a_inv.dtype.char == dt_map[a.dtype.char]
+
     def test_readonly(self):
         a = np.eye(3)
         a.flags.writeable = False
@@ -2604,3 +2624,79 @@ class TestMatrix_Balance:
         assert b.dtype == b_n.dtype
         assert scale.dtype == scale_n.dtype
         assert perm.dtype == perm_n.dtype
+
+
+class TestDTypes:
+    """Check backwards compatibility for dtypes vs scipy 1.16."""
+
+    def get_arr2D(self, tcode):
+        # return a valid 2D array for the typecode
+        if tcode == 'M':
+            return np.eye(2, dtype='datetime64[ms]')
+        elif tcode == 'V':
+            return np.asarray([[b'a', b'b'], [b'c', b'd']], dtype='V')
+        else:
+            return np.eye(2, dtype=tcode)
+
+    def get_arr1D(self, tcode):
+        # return a valid 1D array for the typecode
+        if tcode == 'M':
+            return np.ones(2, dtype='datetime64[ms]')
+        elif tcode == 'V':
+            return np.asarray([b'a', b'b'], dtype='V')
+        else:
+            return np.ones(2, dtype=tcode)
+
+    @pytest.mark.parametrize("tcode", np.typecodes['All'])
+    def test_inv(self, tcode):
+        # check backwards compat vs scipy 1.16
+        a = self.get_arr2D(tcode)
+        if tcode in 'SUVO':
+            # raises
+            with pytest.raises(ValueError):
+                inv(a)
+        else:
+            # passes
+            inv(a)
+
+    @pytest.mark.parametrize("tcode", np.typecodes['All'])
+    def test_det(self, tcode):
+        a = self.get_arr2D(tcode)
+
+        is_arm = platform.machine() == 'arm64'
+        is_windows = os.name == 'nt'
+
+        failing_tcodes = 'SUVOmM'
+        if not (is_arm or is_windows):
+            failing_tcodes += 'gG'
+
+        if tcode in failing_tcodes:
+            # raises
+            with pytest.raises(TypeError):
+                det(a)
+        else:
+            # passes
+            det(a)
+
+    @pytest.mark.filterwarnings("ignore:Casting complex values")
+    @pytest.mark.parametrize("tcode_a", np.typecodes['All'])
+    @pytest.mark.parametrize("tcode_b", np.typecodes['All'])
+    def test_solve(self, tcode_a, tcode_b):
+        a = self.get_arr2D(tcode_a)
+        b = self.get_arr1D(tcode_b)
+
+        can_combine = True
+        try:
+            np.result_type(tcode_a, tcode_b)
+        except TypeError:
+            can_combine = False
+
+        if not can_combine:
+            # np.exceptions.DTypePromotionError subclasses TypeError
+            with pytest.raises(TypeError):
+                solve(a, b)
+        elif tcode_a in 'SUVO' or tcode_b in 'VO':
+            with pytest.raises(ValueError):
+                solve(a, b)
+        else:
+            solve(a, b)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -29,7 +29,14 @@ DTYPES = REAL_DTYPES + COMPLEX_DTYPES
 
 
 parametrize_overwrite_arg = pytest.mark.parametrize(
-    "overwrite_kw", [{"overwrite_a": True}, {"overwrite_a": False}, {}]
+    "overwrite_kw", [{"overwrite_a": True}, {"overwrite_a": False}, {}],
+    ids=["True", "False", "None"]
+)
+
+
+parametrize_overwrite_b_arg = pytest.mark.parametrize(
+    "overwrite_b_kw", [{"overwrite_b": True}, {"overwrite_b": False}, {}],
+    ids=["True", "False", "None"]
 )
 
 
@@ -810,7 +817,6 @@ class TestSolve:
         with (pytest.raises(LinAlgError, match="singular"), np.errstate(all='ignore')):
             solve(A, b, assume_a=structure)
 
-
     @pytest.mark.parametrize('b', [0, 1, [0, 1]])
     def test_singular_scalar(self, b):
         # regression test for gh-24355: scalar a=0 is singular
@@ -1135,6 +1141,47 @@ class TestSolve:
         assert x.shape == a.shape[:-1]
         assert_allclose(a @ x[..., None] - b, 0, atol=1e-14)
 
+    @parametrize_overwrite_arg
+    @parametrize_overwrite_b_arg
+    @pytest.mark.parametrize('a_dtype', [int, float])
+    @pytest.mark.parametrize('a_order', ['C', 'F'])
+    @pytest.mark.parametrize('b_dtype', [int, float])
+    @pytest.mark.parametrize('b_order', ['C', 'F'])
+    @pytest.mark.parametrize('b_ndim', [1, 2])    # XXX ndim > 2
+    @pytest.mark.parametrize('transposed', [True, False])
+    def test_overwrite_args(
+        self, overwrite_kw, overwrite_b_kw, a_dtype, a_order,
+        b_dtype, b_order, b_ndim, transposed
+    ):
+        n = 3
+        a = np.arange(1, n**2 + 1).reshape(n, n) + np.eye(n)
+        a = a.astype(a_dtype, order=a_order)
+
+        b = np.arange(n)
+        if b_ndim > 1:
+            b = np.stack([b*j for j in range(b_ndim)]).T
+        b = b.astype(b_dtype, order=b_order)
+
+        a_ref = a.copy()
+        b_ref = b.copy()
+
+        # solve and check that the solution is correct for all parameters
+        x = solve(a, b, **overwrite_kw, **overwrite_b_kw, transposed=transposed)
+        a_or_aT = a_ref.T if transposed else a_ref
+        assert_allclose(a_or_aT @ x, b_ref, atol=1e-14)
+
+        # now check that it worked in-place where expected
+        overwrite_a = overwrite_kw.get('overwrite_a', False)
+        a_inplace = overwrite_a and (a.dtype != int) and a.flags['F_CONTIGUOUS']
+
+        overwrite_b = overwrite_b_kw.get('overwrite_b', False)
+        b_inplace = overwrite_b and (b.dtype != int) and b.flags['F_CONTIGUOUS']
+
+        assert np.shares_memory(x, b) == b_inplace
+
+        assert (b == b_ref).all() != b_inplace
+        assert (a == a_ref).all() != a_inplace
+
     def test_posdef_not_posdef(self):
         # the `b` matrix is invertible but not positive definite
         a = np.arange(9).reshape(3, 3)
@@ -1328,17 +1375,35 @@ class TestInv:
         a_inv = inv(a)
         assert a_inv.shape == (3, 1, 0, 0)
 
-    @pytest.mark.xfail(reason="TODO: re-enable overwrite_a")
-    def test_overwrite_a(self):
-        a = np.arange(1, 5).reshape(2, 2)
-        a_inv = inv(a, overwrite_a=True)
-        assert_allclose(a_inv @ a, np.eye(2), atol=1e-14)
-        assert not np.shares_memory(a, a_inv)    # int arrays are copied internally
+    @parametrize_overwrite_arg
+    def test_overwrite_a(self, overwrite_kw):
+        n = 3
+        a0 = np.arange(1, n**2 + 1).reshape(n, n) + np.eye(n)
 
-        # 2D F-ordered arrays of LAPACK-compatible dtypes: works inplace
-        a = a.astype(float).copy(order='F')
-        a_inv = inv(a, overwrite_a=True)
-        assert np.shares_memory(a, a_inv)
+        # int arrays are copied internally
+        a = a0.copy()
+        a_inv = inv(a, **overwrite_kw)
+        assert_allclose(a_inv @ a, np.eye(n), atol=1e-14)
+        assert_equal(a, a0)
+        assert not np.shares_memory(a, a_inv)
+
+        # float C ordered arrays are copied, too
+        a = a0.copy().astype(float)
+        a_inv = inv(a, **overwrite_kw)
+        assert_allclose(a_inv @ a0, np.eye(n), atol=1e-14)
+        assert_equal(a, a0)
+        assert not np.shares_memory(a, a_inv)
+
+        # 2D F-ordered arrays of LAPACK-compatible dtypes: inv works inplace.
+        # IOW, the output is always the inverse, and the original input may be
+        # destroyed, depending on the `overwrite_a` kwarg value
+        a = a0.astype(float).copy(order='F')
+        a_inv = inv(a, **overwrite_kw)
+        assert_allclose(a_inv @ a0, np.eye(n), atol=1e-14)
+
+        overwrite_a = overwrite_kw.get("overwrite_a", False)
+        assert (a == a0).all() != overwrite_a
+        assert np.shares_memory(a, a_inv) == overwrite_a
 
     @pytest.mark.parametrize(
         "dtyp", [np.float16, np.float32, np.longdouble, np.clongdouble]

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1015,6 +1015,30 @@ class TestSolve:
         out = solve(a.T, b, assume_a='pos', lower=False)
         assert_allclose(out, result_np, atol=1e-15)
 
+    def test_pos_fails_sym_complex(self):
+        # regression test for the `solve` analog of gh-24359
+        # the matrix is 1) symmetric not hermitian, and 2) not positive definite:
+        a = np.asarray([[ 182.56985285-64.28859483j, -177.24879835+11.0780499j ],
+                        [-177.24879835+11.0780499j ,  177.24879835-11.0780499j ]])
+        b = np.eye(2)
+
+        ainv = solve(a, b)
+        assert_allclose(ainv @ a, np.eye(2), atol=1e-14)
+
+        ainv_sym = solve(a, b, assume_a="sym")
+        assert_allclose(ainv_sym, ainv, atol=1e-14)
+
+        # Specifying assume_a="pos" disables the structure detection, and directly
+        # calls LAPACK routines zportf and zpotri.
+        # Since zportf(a) does not error out, neither does solve.
+        ainv_chol = solve(a, b, assume_a="pos")
+        assert not np.allclose(ainv, ainv_chol, atol=1e-14)
+
+        # Setting assume_a="pos" with a non-pos def matrix returned nonsense.
+        # This is at least consistent with inv.
+        ainv_inv = inv(a, assume_a="pos")
+        assert_allclose(ainv_chol, ainv_inv, atol=1e-14)
+
     def test_readonly(self):
         a = np.eye(3)
         a.flags.writeable = False
@@ -1293,7 +1317,7 @@ class TestInv:
         assert_allclose(a_inv @ a, np.eye(2), atol=1e-14)
         assert not np.shares_memory(a, a_inv)    # int arrays are copied internally
 
-        # 2D F-ordered arrays of LAPACK-compatible dtypes: works inplace 
+        # 2D F-ordered arrays of LAPACK-compatible dtypes: works inplace
         a = a.astype(float).copy(order='F')
         a_inv = inv(a, overwrite_a=True)
         assert np.shares_memory(a, a_inv)
@@ -1436,6 +1460,86 @@ class TestInv:
             a = a + 1j*a
             b = a + a.T.conj() + np.eye(3)
             assert_allclose(inv(b) @ b, np.eye(3), atol=3e-15)
+
+    def test_pos_fails_sym_complex(self):
+        # regression test for gh-24359
+        # the matrix is 1) symmetric not hermitian, and 2) not positive definite:
+        a = np.asarray([[ 182.56985285-64.28859483j, -177.24879835+11.0780499j ],
+                        [-177.24879835+11.0780499j ,  177.24879835-11.0780499j ]])
+
+        ainv = inv(a)
+        assert_allclose(ainv @ a, np.eye(2), atol=1e-14)
+
+        ainv_sym = inv(a, assume_a="sym")
+        assert_allclose(ainv_sym, ainv, atol=1e-14)
+
+        # Specifying assume_a="pos" disables the structure detection, and directly
+        # calls LAPACK routines zportf and zpotri.
+        # Since zportf(a) does not error out, neither does inv
+        ainv_chol = inv(a, assume_a="pos")
+        assert not np.allclose(ainv, ainv_chol, atol=1e-14)
+
+        # Setting assume_a="pos" with a non-pos def matrix returned nonsense.
+        # This is at least consistent with solve.
+        ainv_slv = solve(a, np.eye(2), assume_a="pos")
+        assert_allclose(ainv_chol, ainv_slv, atol=1e-14)
+
+        # Repeat it for bunch of simple cases to cover more branches
+        # Real symmetric, positive definite
+        a = np.eye(4) + np.ones(4)
+        res = inv(a)
+        assert_allclose(res @ a, np.eye(4), atol=1e-14)
+
+        # Real symmetric, NOT positive definite
+        a = -np.eye(4) + np.ones(4)
+        res = inv(a)
+        assert_allclose(res @ a, np.eye(4), atol=1e-14)
+
+        # Real, not symmetric
+        a = -np.eye(4) + np.ones(4)
+        a[0, -1] = 2.
+        res = inv(a)
+        assert_allclose(res @ a, np.eye(4), atol=1e-14)
+
+        # | Test                                  | is_symm | is_herm | pos def |
+        # |---------------------------------------|---------|---------|---------|
+        # | Complex, both sym+herm, pos def       |    1    |    1    |   yes   |
+        # | Complex, symmetric only               |    1    |    0    |    -    |
+        # | Complex, both sym+herm, NOT pos def   |    1    |    1    |   no    |
+        # | Complex, neither                      |    0    |    0    |    -    |
+        # | Complex, hermitian only, pos def      |    0    |    1    |   yes   |
+        # | Complex, hermitian only, NOT pos def  |    0    |    1    |   no    |
+
+        # Complex, both symmetric and hermitian, positive definite
+        a = (np.eye(4) + np.ones(4)).astype(np.complex128)
+        res = inv(a)
+        assert_allclose(res @ a, np.eye(4), atol=1e-14)
+
+        # Complex, symmetric only (not hermitian)
+        a = (np.eye(4)*1.0j + np.ones(4)).astype(np.complex128)
+        res = inv(a)
+        assert_allclose(res @ a, np.eye(4), atol=1e-14)
+
+        # Complex, both symmetric and hermitian, NOT positive definite
+        a = (-np.eye(4) + np.ones(4)).astype(np.complex128)
+        res = inv(a)
+        assert_allclose(res @ a, np.eye(4), atol=1e-14)
+
+        # Complex, neither symmetric nor hermitian
+        a = (-np.eye(4) + np.ones(4)).astype(np.complex128)
+        a[0, -1] = 2.
+        res = inv(a)
+        assert_allclose(res @ a, np.eye(4), atol=1e-14)
+
+        # Complex, hermitian only, positive definite
+        a = np.array([[2, 1+1j], [1-1j, 2]], dtype=np.complex128)
+        res = inv(a)
+        assert_allclose(res @ a, np.eye(2), atol=1e-14)
+
+        # Complex, hermitian only, NOT positive definite
+        a = np.array([[-1, 1+1j], [1-1j, -1]], dtype=np.complex128)
+        res = inv(a)
+        assert_allclose(res @ a, np.eye(2), atol=1e-14)
 
     @pytest.mark.parametrize('complex_', [False, True])
     @pytest.mark.parametrize('sym_herm', ['sym', 'her'])

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -265,7 +265,7 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
     npy_intp ftmp[NPY_MAXDIMS], *fcoordinates = NULL, *foffsets = NULL;
     npy_intp cstride = 0, kk, hh, ll, jj;
     npy_intp size;
-    double **splvals = NULL, icoor[NPY_MAXDIMS], tmp;
+    double **splvals = NULL, icoor[NPY_MAXDIMS] = {0}, tmp;
     npy_intp idimensions[NPY_MAXDIMS], istrides[NPY_MAXDIMS];
     NI_Iterator io, ic;
     npy_double *matrix = matrix_ar ? (npy_double*)PyArray_DATA(matrix_ar) : NULL;
@@ -467,6 +467,11 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
                                 "coordinate array data type not supported");
                 goto exit;
             }
+        } else {
+            NPY_END_THREADS;
+            PyErr_SetString(PyExc_RuntimeError,
+                            "One of `map`, `matrix` or `coordinates` must be provided");
+            goto exit;
         }
 
         /* iterate over axes: */

--- a/scipy/optimize/_direct/DIRect.c
+++ b/scipy/optimize/_direct/DIRect.c
@@ -595,11 +595,15 @@
 /* +-----------------------------------------------------------------------+ */
 /* | JG 01/22/01 Added variable to keep track of the maximum value found.  | */
 /* +-----------------------------------------------------------------------+ */
-        direct_dirsamplef_(c__, arrayi, &delta, &help, &start, length,
+        Py_XDECREF(ret);  /* DECREF previous return value before getting new one */
+        ret = direct_dirsamplef_(c__, arrayi, &delta, &help, &start, length,
             logfile, f, &ifree, &maxi, point, fcn, &x[
             1], x_seq, &l[1], minf, &minpos, &u[1], n, &MAXFUNC, &
             MAXDEEP, &oops, &fmax, &ifeasiblef, &iinfesiblef,
             args, force_stop);
+        if (!ret) {
+            goto cleanup;
+        }
         if (force_stop && *force_stop) {
              *ierror = -102;
              *numiter = t;

--- a/scipy/optimize/_direct/DIRect.c
+++ b/scipy/optimize/_direct/DIRect.c
@@ -775,6 +775,7 @@
         if( !callback_py ) {
             return NULL;
         }
+        Py_DECREF(callback_py);  /* DECREF the callback's return value */
     }
 /* L10: */
     }

--- a/scipy/optimize/_direct/DIRserial.c
+++ b/scipy/optimize/_direct/DIRserial.c
@@ -87,6 +87,7 @@
     if (force_stop && *force_stop)  /* skip eval after forced stop */
          f[(pos << 1) + 1] = *fmax;
     else {
+        Py_XDECREF(ret);  /* DECREF previous iteration's return value */
         ret = direct_dirinfcn_(fcn, &x[1], x_seq, &l[1], &u[1], n, &f[(pos << 1) + 1],
                                           &kret, args);
         if (!ret) {

--- a/scipy/optimize/_direct/DIRsubrout.c
+++ b/scipy/optimize/_direct/DIRsubrout.c
@@ -7,8 +7,19 @@
 #include <math.h>
 // #include "numpy/ndarrayobject.h"
 
-/* Table of constant values */
-
+/*
+ * SCIPY NOTE (2026-01-15):
+ * The following are read-only variables after initialization.
+ *
+ * They exist because f2c passes all arguments by reference (Fortran convention),
+ * so literal constants need addresses. The code is still thread-safe since they
+ * are never modified.
+ *
+ * Note: Cannot mark as 'const' due to f2c function signatures expecting non-const
+ * pointers which makes the surgery more involved. Instead an f2c-free rewrite
+ * is better for long-term maintenance.
+ *
+ */
 static integer c__1 = 1;
 static integer c__32 = 32;
 static integer c__0 = 0;
@@ -1295,11 +1306,15 @@ L50:
 /* | JG 01/22/01 Added variable to keep track of the maximum value found.  | */
 /* |             Added variable to keep track if feasible point was found. | */
 /* +-----------------------------------------------------------------------+ */
-    direct_dirsamplef_(&c__[c_offset], &arrayi[1], &delta, &c__1, &new__, &length[
+    Py_DECREF(ret);  /* DECREF before overwriting with new return value */
+    ret = direct_dirsamplef_(&c__[c_offset], &arrayi[1], &delta, &c__1, &new__, &length[
         length_offset], logfile, &f[3], free, maxi, &point[
         1], fcn, &x[1], x_seq, &l[1], minf, minpos, &u[1], n, maxfunc,
         maxdeep, &oops, fmax, ifeasiblef, iinfeasible, args,
         force_stop);
+    if (!ret) {
+        return NULL;
+    }
     if (force_stop && *force_stop) {
      *ierror = -102;
      return ret;

--- a/scipy/optimize/_directmodule.c
+++ b/scipy/optimize/_directmodule.c
@@ -93,7 +93,9 @@ static int module_exec(PyObject *module) {
 
 static struct PyModuleDef_Slot direct_slots[] = {
     {Py_mod_exec, module_exec},
+#if PY_VERSION_HEX >= 0x030c00f0
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
 #if PY_VERSION_HEX >= 0x030d00f0  /* Python 3.13+ */
     /* signal that this module supports running without an active GIL */
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},

--- a/scipy/optimize/_milp.py
+++ b/scipy/optimize/_milp.py
@@ -352,7 +352,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
     >>> from scipy.optimize import milp
     >>> res = milp(c=c, constraints=constraints, integrality=integrality)
     >>> res.x
-    [2.0, 2.0]
+    array([1., 2.])
 
     Note that had we solved the relaxed problem (without integrality
     constraints):
@@ -360,7 +360,7 @@ def milp(c, *, integrality=None, bounds=None, constraints=None, options=None):
     >>> res = milp(c=c, constraints=constraints)  # OR:
     >>> # from scipy.optimize import linprog; res = linprog(c, A, b_u)
     >>> res.x
-    [1.8, 2.8]
+    array([1.8, 2.8])
 
     we would not have obtained the correct solution by rounding to the nearest
     integers.

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -440,7 +440,7 @@ def test_presolve_gh18907():
     r2 = milp(c=c, constraints=constraints, integrality=integrality, bounds=bounds,
               options={'presolve': False})
     assert r1.status == r2.status
-    assert_allclose(r1.x, r2.x)
+    assert_allclose(r1.fun, r2.fun)
 
     # another example from the same issue
     bounds = Bounds(lb=0, ub=1)

--- a/scipy/optimize/tests/test_milp.py
+++ b/scipy/optimize/tests/test_milp.py
@@ -456,3 +456,22 @@ def test_presolve_gh18907():
               integrality=integrality, options={"presolve": False})
     assert r1.status == r2.status
     assert_allclose(r1.x, r2.x)
+
+def test_regression_gh24141():
+    c = np.ones(8, dtype=np.int64)
+    integrality = c.copy()
+
+    b = np.asarray([42, 252, 277, 41, 222, 48], dtype=np.int64)
+    a = np.asarray([
+        [0, 1, 1, 0, 1, 0, 0, 0],
+        [0, 0, 1, 1, 1, 0, 1, 1],
+        [1, 1, 1, 1, 1, 1, 0, 1],
+        [0, 1, 0, 1, 1, 1, 0, 0],
+        [0, 1, 0, 0, 1, 1, 0, 1],
+        [0, 1, 1, 1, 0, 1, 1, 0],
+    ], dtype=np.int64)
+
+    res = milp(c, integrality=integrality, constraints=(a, b, b))
+
+    assert res.success
+    assert_allclose(a @ res.x, b)

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1294,8 +1294,9 @@ def zpk2tf(z, p, k):
         if k.shape[0] == 1:
             k = [k[0]] * z.shape[0]
         for i in range(z.shape[0]):
-            k_i = xp.asarray(k[i], dtype=xp.int64)
-            b[i, ...] = xp.multiply(k_i, _pu.poly(z[i, ...], xp=xp))
+            k_i = xp.asarray(k[i], dtype=b.dtype)
+            b_i = k_i * _pu.poly(z[i, ...], xp=xp)
+            b = xpx.at(b)[i, ...].set(b_i)
     else:
         # Use xp.multiply to work around torch type promotion
         # non-compliance for operations between 0d and higher

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -215,7 +215,6 @@ class TestTf2zpk:
             assert_raises(BadCoefficients, tf2zpk, [1e-15], [1.0, 1.0])
 
 
-
 @make_xp_test_case(zpk2tf)
 class TestZpk2Tf:
 
@@ -287,6 +286,23 @@ class TestZpk2Tf:
         a_ref = xp.asarray([1, -3, 2])
         xp_assert_close(b, b_ref, check_dtype=False)
         xp_assert_close(a, a_ref, check_dtype=False)
+
+    @skip_xp_backends("cupy",
+                      reason="multi-dim arrays not supported yet on cupy")
+    def test_zpk2tf_int_truncation(self, xp):
+        # regression test for gh-24382
+        z =  xp.asarray([[ 1, 2.], [ 0., -1.]], dtype=xp.float64)
+        p = xp.asarray([3., 4.], dtype=xp.float64)
+        k = 2.5
+
+        b, a = zpk2tf(z, p, k)
+
+        # reference values from scipy 1.15.3
+        b_ref = xp.asarray([[ 2.5, -7.5,  5. ], [ 2.5,  2.5,  0. ]], dtype=xp.float64)
+        a_ref = xp.asarray([ 1., -7., 12.], dtype=xp.float64)
+
+        xp_assert_close(b, b_ref, atol=1e-14)
+        xp_assert_close(a, a_ref, atol=1e-14)
 
 
 @make_xp_test_case(sos2zpk)

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -89,10 +89,10 @@ class IndexMixin:
             elif isinstance(col, slice):
                 res = self._get_arrayXslice(row, col)
             # arrayXarray preprocess
-            elif (row.ndim == 2 and (key0 := np.atleast_2d(key[0])).shape[1] == 1
-                  and (col.ndim == 1 or (key1 := np.array(key[1])).shape[0] == 1)):
+            elif (row.ndim == 2 and row.shape[1] == 1
+                  and (col.ndim == 1 or col.shape[0] == 1)):
                 # outer indexing
-                res = self._get_columnXarray(key0[:, 0], key1.reshape(-1))
+                res = self._get_columnXarray(row[:, 0], col.reshape(-1))
             else:
                 # inner indexing
                 row, col = _broadcast_arrays(row, col)
@@ -410,16 +410,14 @@ def _validate_indices(key, self_shape, self_format):
             array_indices.append(index_ndim)
             index_ndim += 1
     if len(array_indices) > 1:
-        idx_arrays = _broadcast_arrays(*(index[i] for i in array_indices))
-        if any(idx_arrays[0].shape != ix.shape for ix in idx_arrays[1:]):
-            shapes = " ".join(str(ix.shape) for ix in idx_arrays)
+        arr_shapes = [index[i].shape for i in array_indices]
+        try:
+            arr_shape = np.broadcast_shapes(*arr_shapes)
+        except ValueError:
+            shapes = " ".join(str(shp) for shp in arr_shapes)
             msg = (f'shape mismatch: indexing arrays could not be broadcast '
                    f'together with shapes {shapes}')
             raise IndexError(msg)
-        # replace array indices with broadcast versions
-        for i, arr in zip(array_indices, idx_arrays):
-            index[i] = arr
-        arr_shape = idx_arrays[0].shape
         # len(array_indices) implies arr_int_pos has at least one element
         # if arrays and ints not adjacent, move to front of shape
         if len(arr_int_pos) != (arr_int_pos[-1] - arr_int_pos[0] + 1):
@@ -444,7 +442,7 @@ def _asindices(idx, length, format):
     except (ValueError, TypeError, MemoryError) as e:
         raise IndexError('invalid index') from e
 
-    if format != "coo" and ix.ndim not in (1, 2):
+    if format != "coo" and ix.ndim not in (1, 2) or format == "coo" and ix.ndim == 0:
         raise IndexError(f'Index dimension must be 1 or 2. Got {ix.ndim}')
 
     # LIL routines handle bounds-checking for us, so don't do it here.

--- a/scipy/sparse/_index.py
+++ b/scipy/sparse/_index.py
@@ -89,10 +89,10 @@ class IndexMixin:
             elif isinstance(col, slice):
                 res = self._get_arrayXslice(row, col)
             # arrayXarray preprocess
-            elif (row.ndim == 2 and row.shape[1] == 1
-                and (col.ndim == 1 or col.shape[0] == 1)):
+            elif (row.ndim == 2 and (key0 := np.atleast_2d(key[0])).shape[1] == 1
+                  and (col.ndim == 1 or (key1 := np.array(key[1])).shape[0] == 1)):
                 # outer indexing
-                res = self._get_columnXarray(row[:, 0], col.ravel())
+                res = self._get_columnXarray(key0[:, 0], key1.reshape(-1))
             else:
                 # inner indexing
                 row, col = _broadcast_arrays(row, col)

--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -7,7 +7,7 @@ cimport cython
 
 from scipy.sparse import csr_array, csr_matrix, spmatrix
 from scipy.sparse.csgraph._validation import validate_graph
-from scipy.sparse._sputils import is_pydata_spmatrix
+from scipy.sparse._sputils import is_pydata_spmatrix, safely_cast_index_arrays
 
 np.import_array()
 
@@ -100,8 +100,7 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     cdef int N = csgraph.shape[0]
 
     data = csgraph.data
-    indices = csgraph.indices
-    indptr = csgraph.indptr
+    indices, indptr = safely_cast_index_arrays(csgraph, np.intc, "csgraph")
 
     rank = np.zeros(N, dtype=ITYPE)
     predecessors = np.arange(N, dtype=ITYPE)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -730,9 +730,12 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         U = A
         U.setdiag(0)
 
+    L_indices, L_indptr = safely_cast_index_arrays(L, np.intc, "SuperLU")
+    U_indices, U_indptr = safely_cast_index_arrays(U, np.intc, "SuperLU")
+
     x, info = _superlu.gstrs(trans,
-                             N, L.nnz, L.data, L.indices, L.indptr,
-                             N, U.nnz, U.data, U.indices, U.indptr,
+                             N, L.nnz, L.data, L_indices, L_indptr,
+                             N, U.nnz, U.data, U_indices, U_indptr,
                              b)
     if info:
         raise LinAlgError('A is singular.')

--- a/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
+++ b/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
@@ -24,7 +24,7 @@ static PyObject* arpack_error_obj;
                                X(shift) X(getv0_first) X(getv0_iter) X(getv0_itry) X(getv0_orth) \
                                X(aitr_iter) X(aitr_j) X(aitr_orth1) X(aitr_orth2) X(aitr_restart) \
                                X(aitr_step3) X(aitr_step4) X(aitr_ierr) X(aup2_initv) X(aup2_iter) \
-                               X(aup2_getv0) X(aup2_cnorm) X(aup2_kplusp) X(aup2_nev0) X(aup2_np0) \
+                               X(aup2_getv0) X(aup2_cnorm) X(aup2_kplusp) X(aup2_nev) X(aup2_nev0) X(aup2_np0) \
                                X(aup2_numcnv) X(aup2_update) X(aup2_ushift)
 #define STRUCT_FIELD_NAMES STRUCT_INT_FIELD_NAMES STRUCT_INEXACT_FIELD_NAMES
 

--- a/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
+++ b/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
@@ -423,6 +423,9 @@ sneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
 
     ARNAUD_sneupd(&Vars, want_ev, howmny, select, dr, di, z, ldz, sigmar, sigmai, workev, resid, v, ldv, ipntr, workd, workl);
 
+    // Unpack the struct back to the dictionary
+    if (unpack_state_s_to_dict(&Vars, input_dict, "sneupd_wrap") != 0) { return NULL; }
+
     Py_RETURN_NONE;
 
 }
@@ -487,6 +490,9 @@ dneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
 
     ARNAUD_dneupd(&Vars, want_ev, howmny, select, dr, di, z, ldz, sigmar, sigmai, workev, resid, v, ldv, ipntr, workd, workl);
 
+    // Unpack the struct back to the dictionary
+    if (unpack_state_d_to_dict(&Vars, input_dict, "dneupd_wrap") != 0) { return NULL; }
+
     Py_RETURN_NONE;
 
 }
@@ -550,6 +556,9 @@ cneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
 
     ARNAUD_cneupd(&Vars, want_ev, howmny, select, d, z, ldz, sigmaC, workev, resid, v, ldv, ipntr, workd, workl, rwork);
 
+    // Unpack the struct back to the dictionary
+    if (unpack_state_s_to_dict(&Vars, input_dict, "cneupd_wrap") != 0) { return NULL; }
+
     Py_RETURN_NONE;
 }
 
@@ -611,6 +620,9 @@ zneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
     if (pack_dict_to_state_d(input_dict, &Vars, "zneupd_wrap") != 0) { return NULL; }
 
     ARNAUD_zneupd(&Vars, want_ev, howmny, select, d, z, ldz, sigmaC, workev, resid, v, ldv, ipntr, workd, workl, rwork);
+
+    // Unpack the struct back to the dictionary
+    if (unpack_state_d_to_dict(&Vars, input_dict, "zneupd_wrap") != 0) { return NULL; }
 
     Py_RETURN_NONE;
 }
@@ -751,6 +763,9 @@ sseupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
 
     ARNAUD_sseupd(&Vars, want_ev, howmny, select, d, z, ldz, sigma, resid, v, ldv, ipntr, workd, workl);
 
+    // Unpack the struct back to the dictionary
+    if (unpack_state_s_to_dict(&Vars, input_dict, "sseupd_wrap") != 0) { return NULL; }
+
     Py_RETURN_NONE;
 }
 
@@ -805,6 +820,9 @@ dseupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
     if (pack_dict_to_state_d(input_dict, &Vars, "dseupd_wrap") != 0) { return NULL; }
 
     ARNAUD_dseupd(&Vars, want_ev, howmny, select, d, z, ldz, sigma, resid, v, ldv, ipntr, workd, workl);
+
+    // Unpack the struct back to the dictionary
+    if (unpack_state_d_to_dict(&Vars, input_dict, "dseupd_wrap") != 0) { return NULL; }
 
     Py_RETURN_NONE;
 }

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
@@ -81,6 +81,7 @@ struct ARNAUD_state_s {
     int aup2_getv0;          /** naupd2 flow control              internal              */
     int aup2_cnorm;          /** naupd2 flow control              internal              */
     int aup2_kplusp;         /** naupd2 flow control              internal              */
+    int aup2_nev;            /** naupd2 working nev variable      internal              */
     int aup2_nev0;           /** naupd2 internal compute          internal              */
     int aup2_np0;            /** naupd2 internal compute          internal              */
     int aup2_numcnv;         /** naupd2 internal compute          internal              */
@@ -137,6 +138,7 @@ struct ARNAUD_state_d {
     int aup2_getv0;          /** naupd2 flow control              internal              */
     int aup2_cnorm;          /** naupd2 flow control              internal              */
     int aup2_kplusp;         /** naupd2 flow control              internal              */
+    int aup2_nev;            /** naupd2 working nev variable      internal              */
     int aup2_nev0;           /** naupd2 internal compute          internal              */
     int aup2_np0;            /** naupd2 internal compute          internal              */
     int aup2_numcnv;         /** naupd2 internal compute          internal              */

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double_complex.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double_complex.c
@@ -554,7 +554,8 @@ znaup2(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
 
     if (V->ido == ido_FIRST)
     {
-        V->aup2_nev0 = V->nev;
+        V->aup2_nev = V->nev;
+        V->aup2_nev0 = V->aup2_nev;
         V->aup2_np0 = V->np;
 
         //  kplusp is the bound on the largest
@@ -564,7 +565,7 @@ znaup2(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
         //  iter is the counter on the current
         //       iteration step.
 
-        V->aup2_kplusp = V->nev + V->np;
+        V->aup2_kplusp = V->aup2_nev + V->np;
         V->nconv = 0;
         V->aup2_iter = 0;
 
@@ -622,7 +623,7 @@ znaup2(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
 
     //  Compute the first NEV steps of the Arnoldi factorization
 
-    znaitr(V, 0, V->nev, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    znaitr(V, 0, V->aup2_nev, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
     //  ido .ne. 99 implies use of reverse communication
     //  to compute operations involving OP and possibly B
@@ -651,13 +652,13 @@ LINE1000:
     //  Adjust NP since NEV might have been updated by last call
     //  to the shift application routine dnapps .
 
-    V->np = V->aup2_kplusp - V->nev;
+    V->np = V->aup2_kplusp - V->aup2_nev;
     V->ido = ido_FIRST;
 
 LINE20:
     V->aup2_update = 1;
 
-    znaitr(V, V->nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    znaitr(V, V->aup2_nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
     //  ido .ne. 99 implies use of reverse communication
     //  to compute operations involving OP and possibly B
@@ -691,7 +692,7 @@ LINE20:
     //  error bounds are in the last NEV loc. of RITZ,
     //  and BOUNDS respectively.
 
-    V->nev = V->aup2_nev0;
+    V->aup2_nev = V->aup2_nev0;
     V->np = V->aup2_np0;
 
     //  Make a copy of Ritz values and the corresponding
@@ -707,7 +708,7 @@ LINE20:
     //  bounds are in the last NEV loc. of RITZ
     //  BOUNDS respectively.
 
-    zngets(V, &V->nev, &V->np, ritz, bounds);
+    zngets(V, &V->aup2_nev, &V->np, ritz, bounds);
 
     //  Convergence test: currently we use the following criteria.
     //  The relative accuracy of a Ritz value is considered
@@ -716,7 +717,7 @@ LINE20:
     //  error_bounds(i) .le. tol*max(eps23, magnitude_of_ritz(i)).
     //
     V->nconv = 0;
-    for (i = 0; i < V->nev; i++)
+    for (i = 0; i < V->aup2_nev; i++)
     {
         rtemp = fmax(eps23, cabs(ritz[V->np + i]));
         if (cabs(bounds[V->np + i]) <= V->tol*rtemp)
@@ -742,7 +743,7 @@ LINE20:
         if ((creal(bounds[j]) == 0.0) && (cimag(bounds[j]) == 0.0))
         {
             V->np -= 1;
-            V->nev += 1;
+            V->aup2_nev += 1;
         }
     }
     // 30
@@ -828,7 +829,7 @@ LINE20:
 
         V->np = V->nconv;
         V->iter = V->aup2_iter;
-        V->nev = V->nconv;
+        V->aup2_nev = V->nconv;
         V->ido = ido_DONE;
         return;
 
@@ -838,21 +839,21 @@ LINE20:
         //  To prevent possible stagnation, adjust the size
         //  of NEV.
 
-        int nevbef = V->nev;
-        V->nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
-        if ((V->nev == 1) && (V->aup2_kplusp >= 6)) {
-            V->nev = V->aup2_kplusp / 2;
-        } else if ((V->nev == 1) && (V->aup2_kplusp > 3)) {
-            V->nev = 2;
+        int nevbef = V->aup2_nev;
+        V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
+        if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6)) {
+            V->aup2_nev = V->aup2_kplusp / 2;
+        } else if ((V->aup2_nev == 1) && (V->aup2_kplusp > 3)) {
+            V->aup2_nev = 2;
         }
 
-        V->np = V->aup2_kplusp - V->nev;
+        V->np = V->aup2_kplusp - V->aup2_nev;
 
         // If the size of NEV was just increased
         // resort the eigenvalues.
 
-        if (nevbef < V->nev) {
-            zngets(V, &V->nev, &V->np, ritz, bounds);
+        if (nevbef < V->aup2_nev) {
+            zngets(V, &V->aup2_nev, &V->np, ritz, bounds);
         }
     }
 
@@ -890,7 +891,7 @@ LINE50:
     //  matrix H.
     //  The first 2*N locations of WORKD are used as workspace.
 
-    znapps(V->n, &V->nev, V->np, ritz, v, ldv, h, ldh, resid, q, ldq, workl, workd);
+    znapps(V->n, &V->aup2_nev, V->np, ritz, v, ldv, h, ldh, resid, q, ldq, workl, workd);
 
     //  Compute the B-norm of the updated residual.
     //  Keep B*RESID in WORKD(1:N) to be used in

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
@@ -617,7 +617,8 @@ snaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
 
     if (V->ido == ido_FIRST)
     {
-        V->aup2_nev0 = V->nev;
+        V->aup2_nev = V->nev;
+        V->aup2_nev0 = V->aup2_nev;
         V->aup2_np0 = V->np;
 
         //  kplusp is the bound on the largest
@@ -627,7 +628,7 @@ snaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
         //  iter is the counter on the current
         //       iteration step.
 
-        V->aup2_kplusp = V->nev + V->np;
+        V->aup2_kplusp = V->aup2_nev + V->np;
         V->nconv = 0;
         V->aup2_iter = 0;
 
@@ -685,7 +686,7 @@ snaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
 
     //  Compute the first NEV steps of the Arnoldi factorization
 
-    snaitr(V, 0, V->nev, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    snaitr(V, 0, V->aup2_nev, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
     //  ido .ne. 99 implies use of reverse communication
     //  to compute operations involving OP and possibly B
@@ -714,7 +715,7 @@ LINE1000:
     //  Adjust NP since NEV might have been updated by last call
     //  to the shift application routine dnapps .
 
-    V->np = V->aup2_kplusp - V->nev;
+    V->np = V->aup2_kplusp - V->aup2_nev;
 
     //  Compute NP additional steps of the Arnoldi factorization.
 
@@ -723,7 +724,7 @@ LINE1000:
 LINE20:
     V->aup2_update = 1;
 
-    snaitr(V, V->nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    snaitr(V, V->aup2_nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
     //  ido .ne. 99 implies use of reverse communication
     //  to compute operations involving OP and possibly B
@@ -772,18 +773,18 @@ LINE20:
     //  NOTE: The last two arguments of dngets  are no
     //  longer used as of version 2.1.
 
-    V->nev = V->aup2_nev0;
+    V->aup2_nev = V->aup2_nev0;
     V->np = V->aup2_np0;
-    V->aup2_numcnv = V->nev;
+    V->aup2_numcnv = V->aup2_nev;
 
-    sngets(V, &V->nev, &V->np, ritzr, ritzi, bounds);
+    sngets(V, &V->aup2_nev, &V->np, ritzr, ritzi, bounds);
 
-    if (V->nev == V->aup2_nev0 + 1) { V->aup2_numcnv = V->aup2_nev0 + 1;}
+    if (V->aup2_nev == V->aup2_nev0 + 1) { V->aup2_numcnv = V->aup2_nev0 + 1;}
 
     //  Convergence test.
 
-    scopy_(&V->nev, &bounds[V->np], &int1, &workl[2*V->np], &int1);
-    snconv(V->nev, &ritzr[V->np], &ritzi[V->np], &workl[2*V->np], V->tol, &V->nconv);
+    scopy_(&V->aup2_nev, &bounds[V->np], &int1, &workl[2*V->np], &int1);
+    snconv(V->aup2_nev, &ritzr[V->np], &ritzi[V->np], &workl[2*V->np], V->tol, &V->nconv);
 
     //  Count the number of unwanted Ritz values that have zero
     //  Ritz estimates. If any Ritz estimates are equal to zero
@@ -801,7 +802,7 @@ LINE20:
         if (bounds[j] == 0.0f)
         {
             V->np -= 1;
-            V->nev += 1;
+            V->aup2_nev += 1;
         }
     }
     // 30
@@ -898,7 +899,7 @@ LINE20:
 
         V->np = V->nconv;
         V->iter = V->aup2_iter;
-        V->nev = V->aup2_numcnv;
+        V->aup2_nev = V->aup2_numcnv;
         V->ido = ido_DONE;
         return;
 
@@ -908,12 +909,12 @@ LINE20:
         //  To prevent possible stagnation, adjust the size
         //  of NEV.
 
-        int nevbef = V->nev;
-        V->nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
-        if ((V->nev == 1) && (V->aup2_kplusp >= 6)) {
-            V->nev = V->aup2_kplusp / 2;
-        } else if ((V->nev == 1) && (V->aup2_kplusp > 3)) {
-            V->nev = 2;
+        int nevbef = V->aup2_nev;
+        V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
+        if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6)) {
+            V->aup2_nev = V->aup2_kplusp / 2;
+        } else if ((V->aup2_nev == 1) && (V->aup2_kplusp > 3)) {
+            V->aup2_nev = 2;
         }
 
         //  SciPy Fix
@@ -921,15 +922,15 @@ LINE20:
         //  np == 0 (note that dngets below can bump nev by 1). If np == 0,
         // the next call to `dnaitr` will write out-of-bounds.
 
-        if (V->nev > (V->aup2_kplusp - 2)) {
-            V->nev = V->aup2_kplusp - 2;
+        if (V->aup2_nev > (V->aup2_kplusp - 2)) {
+            V->aup2_nev = V->aup2_kplusp - 2;
         }
         //  SciPy Fix End
 
-        V->np = V->aup2_kplusp - V->nev;
+        V->np = V->aup2_kplusp - V->aup2_nev;
 
-        if (nevbef < V->nev) {
-            sngets(V, &V->nev, &V->np, ritzr, ritzi, bounds);
+        if (nevbef < V->aup2_nev) {
+            sngets(V, &V->aup2_nev, &V->np, ritzr, ritzi, bounds);
         }
 
     }
@@ -970,7 +971,7 @@ LINE50:
     //  matrix H.
     //  The first 2*N locations of WORKD are used as workspace.
 
-    snapps(V->n, &V->nev, V->np, ritzr, ritzi, v, ldv, h, ldh, resid, q, ldq, workl, workd);
+    snapps(V->n, &V->aup2_nev, V->np, ritzr, ritzi, v, ldv, h, ldh, resid, q, ldq, workl, workd);
 
     //  Compute the B-norm of the updated residual.
     //  Keep B*RESID in WORKD(1:N) to be used in

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.c
@@ -591,13 +591,14 @@ dsaup2(struct ARNAUD_state_d *V, double* resid, double* v, int ldv,
     if (V->ido == ido_FIRST)
     {
         // nev0 and np0 are integer variables hold the initial values of NEV & NP
-        V->aup2_nev0 = V->nev;
+        V->aup2_nev = V->nev;
+        V->aup2_nev0 = V->aup2_nev;
         V->aup2_np0 = V->np;
 
         // kplusp is the bound on the largest Lanczos factorization built.
         // nconv is the current number of "converged" eigenvalues.
         // iter is the counter on the current iteration step.
-        V->aup2_kplusp = V->nev + V->np;
+        V->aup2_kplusp = V->aup2_nev + V->np;
         V->nconv = 0;
         V->aup2_iter = 0;
 
@@ -685,7 +686,7 @@ LINE1000:
 LINE20:
     V->aup2_update = 1;
 
-    dsaitr(V, V->nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
+    dsaitr(V, V->aup2_nev, V->np, resid, &V->aup2_rnorm, v, ldv, h, ldh, ipntr, workd);
 
      /*--------------------------------------------------*
      | ido .ne. 99 implies use of reverse communication  |
@@ -730,15 +731,15 @@ LINE20:
     // * Wanted Ritz values := RITZ(NP+1:NEV+NP)
     // * Shifts := RITZ(1:NP) := WORKL(1:NP)
 
-    V->nev = V->aup2_nev0;
+    V->aup2_nev = V->aup2_nev0;
     V->np = V->aup2_np0;
 
-    dsgets(V, &V->nev, &V->np, ritz, bounds, workl);
+    dsgets(V, &V->aup2_nev, &V->np, ritz, bounds, workl);
 
     // Convergence test
 
-    dcopy_(&V->nev, &bounds[V->np], &int1, &workl[V->np], &int1);
-    dsconv(V->nev, &ritz[V->np], &workl[V->np], V->tol, &V->nconv);
+    dcopy_(&V->aup2_nev, &bounds[V->np], &int1, &workl[V->np], &int1);
+    dsconv(V->aup2_nev, &ritz[V->np], &workl[V->np], V->tol, &V->nconv);
 
     // Count the number of unwanted Ritz values that have zero
     // Ritz estimates. If any Ritz estimates are equal to zero
@@ -754,7 +755,7 @@ LINE20:
         if (bounds[j] == 0.0)
         {
             V->np -= 1;
-            V->nev += 1;
+            V->aup2_nev += 1;
         }
     }
     // 30
@@ -780,7 +781,7 @@ LINE20:
             dsortr(which_SA, 1, V->aup2_kplusp, ritz, bounds);
             nevd2 = V->aup2_nev0 / 2;
             nevm2 = V->aup2_nev0 - nevd2;
-            if (V->nev > 1)
+            if (V->aup2_nev > 1)
             {
                 V->np = V->aup2_kplusp - V->aup2_nev0;
 
@@ -865,7 +866,7 @@ LINE20:
 
         // Max iterations have been exceeded.
 
-        if ((V->aup2_iter > V->maxiter) && (V->nconv < V->nev))
+        if ((V->aup2_iter > V->maxiter) && (V->nconv < V->aup2_nev))
         {
             V->info = 1;
         }
@@ -878,33 +879,33 @@ LINE20:
         }
 
         V->np = V->nconv;
-        V->nev = V->nconv;
+        V->aup2_nev = V->nconv;
         V->iter = V->aup2_iter;
         V->ido = ido_DONE;
         return;
 
-    } else if ((V->nconv < V->nev) && (V->shift == 1)) {
+    } else if ((V->nconv < V->aup2_nev) && (V->shift == 1)) {
 
         // Do not have all the requested eigenvalues yet.
         // To prevent possible stagnation, adjust the number
         // of Ritz values and the shifts.
 
-        int nevbef = V->nev;
-        V->nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
-        if ((V->nev == 1) && (V->aup2_kplusp >= 6))
+        int nevbef = V->aup2_nev;
+        V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
+        if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6))
         {
-            V->nev = V->aup2_kplusp / 2;
-        } else if ((V->nev == 1) && (V->aup2_kplusp > 2))
+            V->aup2_nev = V->aup2_kplusp / 2;
+        } else if ((V->aup2_nev == 1) && (V->aup2_kplusp > 2))
         {
-            V->nev = 2;
+            V->aup2_nev = 2;
         }
-        V->np = V->aup2_kplusp - V->nev;
+        V->np = V->aup2_kplusp - V->aup2_nev;
 
         // If the size of NEV was just increased resort the eigenvalues.
 
-        if (nevbef < V->nev)
+        if (nevbef < V->aup2_nev)
         {
-            dsgets(V, &V->nev, &V->np, ritz, bounds, workl);
+            dsgets(V, &V->aup2_nev, &V->np, ritz, bounds, workl);
         }
     }
 
@@ -941,7 +942,7 @@ LINE50:
      | factorization of length NEV.                            |
      *--------------------------------------------------------*/
 
-    dsapps(V->n, &V->nev, V->np, ritz, v, ldv, h, ldh, resid, q, ldq, workd);
+    dsapps(V->n, &V->aup2_nev, V->np, ritz, v, ldv, h, ldh, resid, q, ldq, workd);
 
     // Compute the B-norm of the updated residual.
     // Keep B*RESID in WORKD(1:N) to be used in

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -396,6 +396,7 @@ class _ArpackParams:
             'aup2_getv0': 0,
             'aup2_cnorm': 0,
             'aup2_kplusp': 0,
+            'aup2_nev': 0,
             'aup2_nev0': 0,
             'aup2_np0': 0,
             'aup2_numcnv': 0,

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2927,7 +2927,7 @@ class _TestSlicing:
         assert_array_equal(toarray(a[..., ix5, ix10]), numpy_a[..., ix5, ix10])
         assert_array_equal(toarray(a[ix5, ix10, ...]), numpy_a[ix5, ix10, ...])
 
-        with assert_raises(ValueError, match="shape mismatch"):
+        with assert_raises(IndexError, match="shape mismatch"):
             a[ix5, ix10_6True]
 
     def test_ellipsis_fancy_slicing(self):
@@ -3082,7 +3082,7 @@ class _TestSlicingAssign:
         assert_raises(ValueError, A.__setitem__, (slice(None), 1), A.copy())
         assert_raises(ValueError, A.__setitem__,
                       ([[1, 2, 3], [0, 3, 4]], [1, 2, 3]), [1, 2, 3, 4])
-        assert_raises(ValueError, A.__setitem__,
+        assert_raises(IndexError, A.__setitem__,
                       ([[1, 2, 3], [0, 3, 4], [4, 1, 3]],
                        [[1, 2, 4], [0, 1, 3]]), [2, 3, 4])
         assert_raises(ValueError, A.__setitem__, (slice(4), 0),
@@ -3121,10 +3121,10 @@ class _TestFancyIndexing:
 
     def test_bad_index(self):
         A = self.spcreator(np.zeros([5, 5]))
-        assert_raises((IndexError, ValueError, TypeError), A.__getitem__, "foo")
-        assert_raises((IndexError, ValueError, TypeError), A.__getitem__, (2, "foo"))
-        assert_raises((IndexError, ValueError), A.__getitem__,
-                      ([1, 2, 3], [1, 2, 3, 4]))
+        assert_raises(IndexError, A.__getitem__, "foo").match('Index dimension')
+        assert_raises(IndexError, A.__getitem__, (2, "foo")).match('Index dimension')
+        idx = ([1, 2, 3], [1, 2, 3, 4])
+        assert_raises(IndexError, A.__getitem__, idx).match('shape mismatch')
 
     def test_fancy_indexing(self):
         B = self.asdense(arange(50).reshape(5,10))

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -118,11 +118,13 @@ def test_csr_bool_indexing():
 @pytest.mark.timeout(2)  # only slow when broken (conversion to 2d index arrays)
 @pytest.mark.parametrize("cls", [csr_matrix, csr_array, csc_matrix, csc_array])
 def test_fancy_indexing_broadcasts_without_making_dense_2d(cls):
-    I = np.arange(100_000).reshape((100_000, 1))
-    J = I.T
+    # Fixes Issue gh-24339
+    J = np.arange(100_000)
+    I = J.reshape((100_000, 1))
     S = cls((100_000, 100_000))
-    # testing nnz, but really testing indexing. Should blow up memory needs
-    assert S[I, J].nnz == 0
+    # checking nnz, but really testing indexing.
+    assert S[I, J].nnz == 0  # 1D row array for columns -> broadcasts to 2D
+    assert S[I, J.reshape(1, -1)].nnz == 0  # 2D row array as index for columns
 
 
 def test_csr_hstack_int64():

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -114,6 +114,17 @@ def test_csr_bool_indexing():
     assert (slice_list3 == slice_array3).all()
 
 
+@pytest.mark.xfail_on_32bit("Can't create large array for test")
+@pytest.mark.timeout(2)  # only slow when broken (conversion to 2d index arrays)
+@pytest.mark.parametrize("cls", [csr_matrix, csr_array, csc_matrix, csc_array])
+def test_fancy_indexing_broadcasts_without_making_dense_2d(cls):
+    I = np.arange(100_000).reshape((100_000, 1))
+    J = I.T
+    S = cls((100_000, 100_000))
+    # testing nnz, but really testing indexing. Should blow up memory needs
+    assert S[I, J].nnz == 0
+
+
 def test_csr_hstack_int64():
     """
     Tests if hstack properly promotes to indices and indptr arrays to np.int64

--- a/scipy/sparse/tests/test_indexing1d.py
+++ b/scipy/sparse/tests/test_indexing1d.py
@@ -338,15 +338,9 @@ class TestSlicingAndFancy1D:
 
     def test_bad_index(self, spcreator):
         A = spcreator(np.zeros(5))
-        with pytest.raises(
-            (IndexError, ValueError, TypeError),
-            match='Index dimension must be 1 or 2|only integers',
-        ):
+        with pytest.raises(IndexError, match='Index dimension must be 1 or 2'):
             A.__getitem__("foo")
-        with pytest.raises(
-            (IndexError, ValueError, TypeError),
-            match='tuple index out of range|only integers',
-        ):
+        with pytest.raises(IndexError, match='tuple index out of range'):
             A.__getitem__((2, "foo"))
 
     def test_fancy_indexing_2darray(self, spcreator):

--- a/scipy/spatial/transform/_rigid_transform_cy.pyx
+++ b/scipy/spatial/transform/_rigid_transform_cy.pyx
@@ -16,7 +16,7 @@ np.import_array()
 
 @cython.embedsignature(True)
 @cython.boundscheck(False)
-def from_matrix(double[:, :, :] matrix, bint normalize=True, bint copy=True):
+def from_matrix(const double[:, :, :] matrix, bint normalize=True, bint copy=True):
     mat = np.asarray(matrix, dtype=float)
 
     if mat.shape[-1] != 4 or mat.shape[-2] != 4:

--- a/scipy/spatial/transform/_rigid_transform_cy.pyx
+++ b/scipy/spatial/transform/_rigid_transform_cy.pyx
@@ -241,7 +241,7 @@ def pow(double[:, :, :] matrix, float n):
     elif n == -1:
         return inv(matrix)
     elif n == 1:
-        return matrix
+        return np.asarray(matrix)
     return from_exp_coords(as_exp_coords(matrix) * n)
 
 

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -393,22 +393,28 @@ cdef double[:, :] _elementary_quat_compose(
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def from_quat(double[:, :] quat, bint normalize=True, bint copy=True, bint scalar_first=False):
+def from_quat(const double[:, :] quat, bint normalize=True, bint copy=True, bint scalar_first=False):
     if quat.ndim != 2 or quat.shape[1] != 4:
         raise ValueError(f"Expected `quat` to have shape (N, 4), got {quat.shape}.")
 
+    cdef double[:, :] quat_mut  # Non-const to enable in-place normalization
     cdef Py_ssize_t num_rotations = quat.shape[0]
 
     if num_rotations > 0:  # Avoid 0-sized axis errors
         if scalar_first:
-            quat = np.roll(quat, -1, axis=1)
+            quat_mut = np.roll(quat, -1, axis=1)
         elif normalize or copy:
-            quat = quat.copy()
+            quat_mut = quat.copy()
+        else:  
+            # quat is not altered, so we return directly using quat instead of quat_mut
+            return np.asarray(quat, dtype=float)
 
         if normalize:
             for ind in range(num_rotations):
-                if isnan(_normalize4(quat[ind, :])):
+                if isnan(_normalize4(quat_mut[ind, :])):
                     raise ValueError("Found zero norm quaternions in `quat`.")
+
+        return np.asarray(quat_mut, dtype=float)
 
     return np.asarray(quat, dtype=float)
 

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -644,8 +644,8 @@ def from_mrp(mrp):
         quat[ind, 3] = (2 - mrp_squared_plus_1) / mrp_squared_plus_1
 
     if is_single:
-        return quat[0]
-    return quat
+        return np.asarray(quat, dtype=float)[0]
+    return np.asarray(quat, dtype=float)
     
 
 @cython.embedsignature(True)

--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -1295,7 +1295,7 @@ def pow(double[:, :] quat, n) -> double[:, :]:
     elif n == -1:
         return inv(quat)
     elif n == 1:
-        return quat
+        return np.asarray(quat)
     # general scaling of rotation angle
     return from_rotvec(n * as_rotvec(quat))
 

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -824,6 +824,8 @@ def test_pow(xp, ndim: int):
     # Test the short-cuts and other integers
     for n in [-5, -2, -1, 0, 1, 2, 5]:
         q = p**n
+        # Regression test for gh-24436
+        assert isinstance(q._matrix, type(p._matrix))
         r = RigidTransform.from_matrix(xp.tile(xp.eye(4), shape + (1, 1)))
         for _ in range(abs(n)):
             if n > 0:

--- a/scipy/spatial/transform/tests/test_rigid_transform.py
+++ b/scipy/spatial/transform/tests/test_rigid_transform.py
@@ -1476,3 +1476,9 @@ def test_shape_property(xp, dim: int):
     shape = (dim,) * (dim - 1)
     tf = RigidTransform.from_translation(xp.zeros(shape + (3,)))
     assert tf.shape == shape
+
+
+def test_non_writeable():
+    mat = np.eye(4)
+    mat.flags.writeable = False
+    RigidTransform.from_matrix(mat)  # Regression test against gh-24378

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 import warnings
 from scipy._lib._array_api import (
     xp_assert_equal,
+    array_namespace,
     is_numpy,
     is_lazy_array,
     xp_vector_norm,
@@ -642,6 +643,8 @@ def test_from_mrp_single_nd_input(xp, ndim: int):
     expected_quat = xp.reshape(expected_quat, (1,) * (ndim - 1) + (4,))
     result = Rotation.from_mrp(mrp)
     xp_assert_close(result.as_quat(), expected_quat, atol=1e-12)
+    # Regression test for gh-24555
+    assert isinstance(result._quat, type(array_namespace(mrp).empty(0)))
 
 
 def test_from_mrp_array_like():

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -3148,3 +3148,9 @@ def test_rotation_shape(xp, ndim: int):
     quat = xp.ones(shape + (4,))
     r = Rotation.from_quat(quat)
     assert r.shape == shape, f"Got {r.shape}, expected {shape}"
+
+
+def test_non_writeable():
+    q = np.array([0, 0, 0, 1.0])
+    q.flags.writeable = False
+    Rotation.from_quat(q)  # Regression test against gh-24354, should not raise

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -2467,6 +2467,8 @@ def test_pow(xp, ndim: int):
         # Test accuracy
         q = p ** n
         q_identity = xp.asarray([0., 0, 0, 1])
+        # Regression test for gh-24436 
+        assert isinstance(q._quat, type(q_identity))
         r = Rotation.from_quat(xp.tile(q_identity, batch_shape + (1,)))
         for _ in range(abs(n)):
             if n > 0:

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3871,8 +3871,9 @@ class gengamma_gen(rv_continuous):
 
     def _logpdf(self, x, a, c):
         return xpx.apply_where(
-            (x != 0) | (c > 0), (x, c),
-            lambda x, c: (np.log(abs(c)) + sc.xlogy(c*a - 1, x) - x**c - sc.gammaln(a)),
+            (x != 0) | (c > 0), (x, c, a),
+            lambda x, c, a: (np.log(abs(c)) + sc.xlogy(c*a - 1, x)
+                             - x**c - sc.gammaln(a)),
             fill_value=-np.inf)
 
     def _cdf(self, x, a, c):

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3687,41 +3687,92 @@ class DiscreteDistribution(UnivariateDistribution):
             "continuous distributions.")
 
     def _solve_bounded_discrete(self, func, p, params, comp):
-        res = self._solve_bounded(func, p, params=params, xatol=0.9)
-        x = np.asarray(np.floor(res.xr))
+        # We're trying to solve one of these two problems:
+        # a) find the smallest integer x* within the support s.t. F(x*) >= p
+        # b) find the smallest integer x* within the support s.t. G(x*) = 1 - F(x*) <= p
+        # Our approach is to solve a continuous version of the problem that narrows the
+        # solution down to an integer x s.t. either x* = x or x* = x + 1. At the end,
+        # we'll choose between them.
 
-        # if _chandrupatla finds exact inverse, the bracket may not have been reduced
-        # enough for `np.floor(res.x)` to be the appropriate value of `x`.
+        # First, solve func(x) == p where func is a continuous, monotone interpolant
+        # of either the monotone increasing F or monotone decreasing G.
+        res = self._solve_bounded(func, p, params=params, xatol=0.9)
+        # Here, `_solve_bounded` can terminate for one of three reasons:
+        # 1. `func(res.x) == p` (`fatol = 0` is satisfied),
+        # 2. `res.xl` and `res.xr` bracket the root and `|res.xr - res.xl| <= xatol`, or
+        # 3. There is no solution within the support.
+        # There are several possible strategies for using `res.xl`, `res.x`, and/or
+        # `res.xr` to find a solution to the original, discrete problem. Here is ours.
+
+        # Consider case 2a. Because F is an increasing function, we know
+        # that F(xr) >= p (and F(xl) <= p), so F(floor(xr) + 1) >= p.
+        # F(floor(xr)) *may* be >= p, but we can't know until we evaluate it.
+        # F(floor(xr) - 1) < p (strictly) because floor(xr) - 1 < xl and F decreases
+        # monotonically as the argument decreases. So we choose x = floor(xr), and
+        # later we'll choose between x* = x and x* = x + 1.
+        x = np.asarray(np.floor(res.xr))
+        # This is also suitable for case 2b. Because G is a *decreasing* function, we
+        # know that G(xr) <= p (and G(xl) >= p), so G(floor(xr) + 1) <= p.
+        # G(floor(xr)) *may* be <= p, but we can't know until we evaluate it.
+        # G(floor(xr) - 1) > p (strictly) because floor(xr) - 1 < xl and G increases
+        # as the argument decreases. So we would still want to choose x = floor(xr), and
+        # later we'll choose between x* = x and x* = x + 1.
+
+        # Now we consider case 1a/b. In this case, `res.x` solved the equation
+        # *exactly*, so the algorithm may have terminated before the bracket is tight
+        # enough to rely on `res.xr`. If `res.x` happens to be integral, `res.x` is
+        # the solution to the discrete problem, and floor(res.x) == res.x, so
+        # floor(res.x) is the solution to the discrete problem. If not:
+        # a) F(floor(res.x)) < p (strictly) and F(floor(res.x) + 1) > p (strictly). So
+        #    floor(res.x) + 1 is the solution to the discrete problem.
+        # b) G(floor(res.x)) > p (strictly) and G(floor(res.x) + 1) < p (strictly). So
+        #    floor(res.x) + 1 is again the solution to the discrete problem.
+        # Either way, we can choose x = res.x, and at the end we'll choose between
+        # x* = x and x* = x + 1.
         mask = res.fun == 0
         x[mask] = np.floor(res.x[mask])
 
-        xmin, xmax = self._support(**params)
-        p, xmin, xmax = np.broadcast_arrays(p, xmin, xmax)
-        mask = comp(func(xmin, **params), p)
-        x[mask] = xmin[mask]
+        # For case 3, let xmin be the left endpoint of the support, and note that in
+        # general, F(xmin) > 0 and G(xmin) < 1. Therefore it is possible that:
+        # a) F(x) > p for all x in the support (e.g. because p ~ 0)
+        # a) G(x) < p for all x in the support (e.g. because p ~ 1)
+        # In these cases, `_solve_bounded` would fail to find a root of the continuous
+        # equation above, but the solution to the original, discrete problem is the left
+        # endpoint of the support.
+        # This case is handled before we get to this function; otherwise,
+        # `_solve_bounded` may spin its wheels for a long time in vain.
+
+        # Now, we choose between x* = x and x* = x + 1: if func(x) satisfies the
+        # comparison `comp` (>= for cdf, <= for ccdf), the solution is x* = x;
+        # otherwise the solution must be x* = x + 1.
+        f = func(x, **params)
+        x = np.where(comp(f, p), x, x + 1.0)
+        x[np.isnan(f)] = np.nan  # needed? why would func(x) be NaN within support?
 
         return x
 
     def _base_discrete_inversion(self, p, func, comp, /, **params):
-        # For discrete distributions, icdf(p) is defined as the minimum n
-        # such that cdf(n) >= p. iccdf(p) is defined as the minimum n such
-        # that ccdf(n) <= p, or equivalently as iccdf(p) = icdf(1 - p).
+        # For discrete distributions, icdf(p) is defined as the minimum integer x*
+        # within the support such that F(x*) >= p; iccdf(p) is the minimum integer x*
+        # within the support such that G(x*) <= p.
 
-        # First try to find where cdf(x) == p for the continuous extension of the
-        # cdf. res.xl and res.xr will be a bracket for this root. The parameter
-        # xatol in solve_bounded controls the bracket width. We thus know that
-        # know cdf(res.xr) >= p, cdf(res.xl) <= p, and |res.xr - res.xl| <= 0.9.
-        # This means the minimum integer n such that cdf(n) >= p is either floor(x)
-        # or floor(x) + 1.
-        x = self._solve_bounded_discrete(func, p, params=params, comp=comp)
-        # comp should be <= for ccdf, >= for cdf.
-        f = func(x, **params)
-        res = np.where(comp(f, p), x, x + 1.0)
-        # xr is a bracket endpoint, and will usually be a finite value even when
-        # the computed result should be nan. We need to explicitly handle this
-        # case.
-        res[np.isnan(f) | np.isnan(p)] = np.nan
-        return res[()]
+        # Identify where the solution is xmin.
+        # (See rationale in `_solve_bounded_discrete`.)
+        xmin, xmax = self._support(**params)
+        p, xmin, _ = np.broadcast_arrays(p, xmin, xmax)
+        mask = comp(func(xmin, **params), p)
+
+        # Use `apply_where` to perform the inversion only when necessary.
+        def f1(p, *args):
+            return self._solve_bounded_discrete(
+                func, p, params=dict(zip(params.keys(), args)), comp=comp)
+
+        x = xpx.apply_where(~mask, (p, *params.values()), f1, fill_value=xmin)
+
+        # x above may be a finite value even when p is NaN, so the returned value
+        # should be NaN. We need to handle this as a special case.
+        x[np.isnan(p)] = np.nan
+        return x[()]
 
     def _icdf_inversion(self, x, **params):
         return self._base_discrete_inversion(x, self._cdf_dispatch,

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -11,6 +11,7 @@ from numpy import inf
 from scipy._lib._array_api import xp_capabilities, xp_promote
 from scipy._lib._util import _rng_spawn, _RichResult
 from scipy._lib._docscrape import ClassDoc, NumpyDocString
+import scipy._lib.array_api_extra as xpx
 from scipy import special, stats
 from scipy.special._ufuncs import _log1mexp
 from scipy.integrate import tanhsinh as _tanhsinh, nsum

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -2328,9 +2328,9 @@ class UnivariateDistribution(_ProbabilityDistribution):
             logpxf = self._logpxf_dispatch(x, **params)
             temp = np.asarray(pxf)
             i = (pxf != 0)  # 0 * inf -> nan; should be 0
-            temp[i] = pxf[i]*logpxf[i]
+            temp[i] = -pxf[i]*logpxf[i]
             return temp
-        return -self._quadrature(integrand, params=params)
+        return self._quadrature(integrand, params=params)
 
     @_set_invalid_nan_property
     def median(self, *, method=None):

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -2189,7 +2189,7 @@ class PoissonDisk(QMCEngine):
             `candidate` sample.
             """
             indices = ((candidate - self.l_bounds) / self.cell_size).astype(int)
-            ind_min = np.maximum(indices - n, self.l_bounds.astype(int))
+            ind_min = np.maximum(indices - n, 0)
             ind_max = np.minimum(indices + n + 1, self.grid_size)
 
             # Check if the center cell is empty

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -649,14 +649,7 @@ def check_nans_and_edges(dist, fname, arg, res):
     if isinstance(dist, DiscreteDistribution):
         exclude.update({'pdf', 'logpdf'})
 
-    if (
-            fname not in exclude
-            and not (isinstance(dist, Binomial)
-                     and np.any((dist.n == 0) | (dist.p == 0) | (dist.p == 1)))):
-        # This can fail in degenerate case where Binomial distribution is a point
-        # distribution. Further on, we could factor out an is_degenerate function
-        # for the tests, or think about storing info about degeneracy in the
-        # instances.
+    if fname not in exclude:
         assert np.isfinite(res[all_valid & (endpoint_arg == 0)]).all()
 
 
@@ -764,13 +757,7 @@ def check_moment_funcs(dist, result_shape):
         assert ref.shape == result_shape
         check(i, 'standardized', 'formula', ref,
               success=has_formula(i, 'standardized'))
-        if not (
-                isinstance(dist, Binomial)
-                and np.any((dist.n == 0) | (dist.p == 0) | (dist.p == 1))
-        ):
-            # This test will fail for degenerate case where binomial distribution
-            # is a point distribution.
-            check(i, 'standardized', 'general', ref, success=i <= 2)
+        check(i, 'standardized', 'general', ref, success=i <= 2)
         check(i, 'standardized', 'normalize', ref)
 
     if isinstance(dist, ShiftedScaledDistribution):
@@ -1107,8 +1094,7 @@ class TestMakeDistribution:
         slow = {'argus', 'exponpow', 'exponweib', 'genexpon', 'gompertz', 'halfgennorm',
                 'johnsonsb', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'norminvgauss',
                 'powerlognorm', 'powernorm', 'recipinvgauss', 'studentized_range',
-                'vonmises_line', # continuous
-                'betanbinom', 'logser', 'skellam', 'zipf'}  # discrete
+                'vonmises_line'}  # continuous
         if not int(os.environ.get('SCIPY_XSLOW', '0')) and distname in slow:
             pytest.skip('Skipping as XSLOW')
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1094,7 +1094,8 @@ class TestMakeDistribution:
         slow = {'argus', 'exponpow', 'exponweib', 'genexpon', 'gompertz', 'halfgennorm',
                 'johnsonsb', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'norminvgauss',
                 'powerlognorm', 'powernorm', 'recipinvgauss', 'studentized_range',
-                'vonmises_line'}  # continuous
+                'vonmises_line', # continuous
+                'betanbinom', 'logser', 'zipf'}  # discrete
         if not int(os.environ.get('SCIPY_XSLOW', '0')) and distname in slow:
             pytest.skip('Skipping as XSLOW')
 

--- a/tools/asan-ignore.txt
+++ b/tools/asan-ignore.txt
@@ -3,9 +3,6 @@
 # from scipy.optimize._minpack._lmdif
 fun:enorm
 
-# from scipy.interpolate._dierckx.qr_reduce_periodic
-fun:_ZN7fitpack18qr_reduce_periodic*
-
 # from scipy.ndimage._rank_filter_1d.rank_filter
 fun:_Z12_rank_filterIfEiPT_iiiS1_iS0_i
 


### PR DESCRIPTION
We've accumulated a large number of backports for this bug fix release.

TODO:

- [x]  `test_gh24358` is failing -- @ilayn some of your large backported PRs were cherry-picked in with surprisingly small diffs relative to the PRs against `main`, not sure why, but maybe that is connected to why this test fails locally on this backport branch? They do look like like legit squash merges unless I'm missing something...
- [x] update release notes to reflect backport activity
- [x] deal with: https://github.com/scipy/scipy/pull/24507
- [x] deal with: https://github.com/scipy/scipy/pull/24442
- [x] reactivate the CI (skipped for now) and have it passing
- [x] dry run of the wheel build CI (apparently not switching to "trusted releases" for `1.17.1` in separate repo in the end?)
- [x] I should carefully read the diff to check for unintended things

Backports included (so far):

1. gh-24253
2. gh-24275
3. gh-24332
4. gh-24352
5. gh-24367
6. gh-24370
7. gh-24371
8. gh-24380
9. gh-24384
10. gh-24385
11. gh-24386
12. gh-24399
13. gh-24404
14. gh-24440
15. gh-24453
16. gh-24499
17. gh-24511
18. gh-24564
19. gh-24576
20. gh-24537
21. gh-24573
22. gh-24607
23. gh-24507
24. gh-24442
25. gh-24646