### PR TITLE
DOC: signal: add Examples to 20 functions missing docstring examples

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -977,6 +977,12 @@ def sosfreqz(*args, **kwargs):
         New code should use the function :func:`scipy.signal.freqz_sos`.
         This function became obsolete from version 1.15.0.
 
+    Examples
+    --------
+    This function is a legacy alias for `freqz_sos`. New code should use
+    `scipy.signal.freqz_sos` directly. See `freqz_sos` for full
+    documentation and examples.
+
     """  # numpydoc ignore=RT01
     return freqz_sos(*args, **kwargs)
 
@@ -1446,6 +1452,23 @@ def sos2zpk(sos):
     even if some of these are (effectively) zero.
 
     .. versionadded:: 0.16.0
+
+    Examples
+    --------
+    Convert a system of two second-order sections to zero-pole-gain form:
+
+    >>> from scipy.signal import sos2zpk
+    >>> import numpy as np
+    >>> sos = np.array([[1, 0, -1, 1, 0, -0.81],
+    ...                 [1, 0,  0, 1, 0, -0.49]])
+    >>> z, p, k = sos2zpk(sos)
+    >>> z
+    array([-1.+0.j,  1.+0.j,  0.+0.j,  0.+0.j])
+    >>> p
+    array([-0.9+0.j,  0.9+0.j, -0.7+0.j,  0.7+0.j])
+    >>> k
+    1.0
+
     """
     xp = array_namespace(sos)
     sos = xp.asarray(sos)
@@ -4673,6 +4696,25 @@ def buttap(N, *, xp=None, device=None):
     --------
     butter : Filter design function using this prototype
 
+    Examples
+    --------
+    Design a 5th-order Butterworth analog prototype and plot the poles
+    in the complex plane. All poles lie on the unit circle in the left
+    half-plane:
+
+    >>> from scipy.signal import buttap
+    >>> import numpy as np
+    >>> z, p, k = buttap(5)
+    >>> z  # Butterworth has no zeros
+    array([], dtype=float64)
+    >>> k
+    1.0
+
+    The poles are evenly spaced on the left half of the unit circle:
+
+    >>> np.abs(p)  # all magnitudes are 1
+    array([1., 1., 1., 1., 1.])
+
     """
     if xp is None:
         xp = np_compat
@@ -4715,6 +4757,22 @@ def cheb1ap(N, rp, *, xp=None, device=None):
     See Also
     --------
     cheby1 : Filter design function using this prototype
+
+    Examples
+    --------
+    Design a 4th-order Chebyshev type I analog prototype with 1 dB passband
+    ripple:
+
+    >>> from scipy.signal import cheb1ap
+    >>> z, p, k = cheb1ap(4, 1)
+    >>> z  # Chebyshev type I has no zeros
+    array([], dtype=float64)
+
+    The poles lie on an ellipse in the left half of the complex plane:
+
+    >>> p  # doctest: +NORMALIZE_WHITESPACE
+    array([-0.139536  +0.98337916j, -0.33686969+0.40732899j,
+           -0.33686969-0.40732899j, -0.139536  -0.98337916j])
 
     """
     if xp is None:
@@ -4776,6 +4834,20 @@ def cheb2ap(N, rs, *, xp=None, device=None):
     See Also
     --------
     cheby2 : Filter design function using this prototype
+
+    Examples
+    --------
+    Design a 4th-order Chebyshev type II analog prototype with 40 dB
+    stopband attenuation:
+
+    >>> from scipy.signal import cheb2ap
+    >>> z, p, k = cheb2ap(4, 40)
+
+    Unlike Chebyshev type I, type II has finite zeros:
+
+    >>> z  # doctest: +NORMALIZE_WHITESPACE
+    array([-0.        -1.0823922j , -0.        -2.61312593j,
+            0.        +2.61312593j,  0.        +1.0823922j ])
 
     """
     if xp is None:
@@ -4981,6 +5053,21 @@ def ellipap(N, rp, rs, *, xp=None, device=None):
 
     .. [2] Orfanidis, "Lecture Notes on Elliptic Filter Design",
            https://www.ece.rutgers.edu/~orfanidi/ece521/notes.pdf
+
+    Examples
+    --------
+    Design a 4th-order elliptic analog prototype with 1 dB passband ripple
+    and 40 dB stopband attenuation:
+
+    >>> from scipy.signal import ellipap
+    >>> z, p, k = ellipap(4, 1, 40)
+
+    Elliptic filters have both finite zeros and poles:
+
+    >>> len(z), len(p)
+    (4, 4)
+    >>> k
+    0.009999999999999997
 
     """
     if xp is None:
@@ -5333,6 +5420,24 @@ def besselap(N, norm='phase', *, xp=None, device=None):
     .. [6] Miller and Bohn, "A Bessel Filter Crossover, and Its Relation to
            Others", RaneNote 147, 1998,
            https://www.ranecommercial.com/legacy/note147.html
+
+    Examples
+    --------
+    Design a 4th-order Bessel analog prototype with the default phase-matched
+    normalization:
+
+    >>> from scipy.signal import besselap
+    >>> z, p, k = besselap(4)
+    >>> z  # Bessel filters have no finite zeros
+    array([], dtype=float64)
+    >>> k  # Phase normalization always gives unity gain
+    1.0
+
+    With delay normalization, the group delay in the passband is 1:
+
+    >>> _, _, k_delay = besselap(4, norm='delay')
+    >>> k_delay
+    105.0
 
     """
     if xp is None:

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -347,6 +347,24 @@ def zpk2ss(z, p, k):
         State space representation of the system, in controller canonical
         form.
 
+    Examples
+    --------
+    Convert a system with a zero at s = -1, poles at s = -2 and s = -3,
+    and gain 5 to state-space form:
+
+    >>> from scipy.signal import zpk2ss
+    >>> A, B, C, D = zpk2ss([-1], [-2, -3], 5)
+    >>> A
+    array([[-5., -6.],
+           [ 1.,  0.]])
+    >>> B
+    array([[1.],
+           [0.]])
+    >>> C
+    array([[5., 5.]])
+    >>> D
+    array([[0.]])
+
     """
     return tf2ss(*zpk2tf(z, p, k))
 
@@ -376,6 +394,24 @@ def ss2zpk(A, B, C, D, input=0):
         Zeros and poles.
     k : float
         System gain.
+
+    Examples
+    --------
+    Convert state-space matrices back to zero-pole-gain form:
+
+    >>> from scipy.signal import ss2zpk
+    >>> import numpy as np
+    >>> A = np.array([[-5., -6.], [1., 0.]])
+    >>> B = np.array([[1.], [0.]])
+    >>> C = np.array([[5., 5.]])
+    >>> D = np.array([[0.]])
+    >>> z, p, k = ss2zpk(A, B, C, D)
+    >>> z
+    array([-1.])
+    >>> p
+    array([-3., -2.])
+    >>> k
+    5.0
 
     """
     return tf2zpk(*ss2tf(A, B, C, D, input=input))

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1620,6 +1620,24 @@ def medfilt(volume, kernel_size=None):
     scipy.ndimage.median_filter
     scipy.signal.medfilt2d
 
+    Examples
+    --------
+    Apply a median filter with a window size of 3 to a 1-D signal:
+
+    >>> from scipy.signal import medfilt
+    >>> import numpy as np
+    >>> x = np.array([1, 10, 2, 3, 4])
+    >>> medfilt(x, 3)
+    array([1, 2, 3, 3, 3])
+
+    Apply a 3x3 median filter to a 2-D array:
+
+    >>> x2 = np.array([[1, 10, 2], [3, 4, 5], [6, 7, 8]])
+    >>> medfilt(x2, 3)
+    array([[0, 2, 0],
+           [3, 5, 4],
+           [0, 4, 0]])
+
     """
     xp = array_namespace(volume)
     volume = xp.asarray(volume)
@@ -2284,6 +2302,27 @@ def lfiltic(b, a, y, x=None):
     See Also
     --------
     lfilter, lfilter_zi
+
+    Examples
+    --------
+    Construct initial conditions for a first-order IIR filter with known
+    previous output:
+
+    >>> from scipy.signal import lfiltic, lfilter
+    >>> import numpy as np
+    >>> b = [1, 0]
+    >>> a = [1, -0.5]
+    >>> y = [1.0]  # previous output y[-1] = 1.0
+    >>> zi = lfiltic(b, a, y)
+    >>> zi
+    array([0.5])
+
+    Use these initial conditions to filter a signal:
+
+    >>> x = np.ones(5)
+    >>> y, _ = lfilter(b, a, x, zi=zi)
+    >>> y
+    array([1.5    , 1.75   , 1.875  , 1.9375 , 1.96875])
 
     """
     xp = array_namespace(a, b, y, x)
@@ -3160,6 +3199,21 @@ def invres(r, p, k, tol=1e-3, rtype='avg'):
     --------
     residue, invresz, unique_roots
 
+    Examples
+    --------
+    Reconstruct a transfer function from its partial fraction expansion.
+    Given H(s) = -1/(s-1) + 2/(s-2):
+
+    >>> from scipy.signal import invres
+    >>> r = [-1, 2]
+    >>> p = [1, 2]
+    >>> k = []
+    >>> b, a = invres(r, p, k)
+    >>> b
+    array([1., 0.])
+    >>> a
+    array([ 1., -3.,  2.])
+
     """
     r = np.atleast_1d(r)
     p = np.atleast_1d(p)
@@ -3307,6 +3361,31 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     .. [1] J. F. Mahoney, B. D. Sivazlian, "Partial fractions expansion: a
            review of computational methodology and efficiency", Journal of
            Computational and Applied Mathematics, Vol. 9, 1983.
+
+    Examples
+    --------
+    Compute the partial fraction expansion of
+    H(s) = s / (s^2 - 3s + 2) = s / ((s-1)(s-2)):
+
+    >>> from scipy.signal import residue
+    >>> r, p, k = residue([1, 0], [1, -3, 2])
+    >>> r
+    array([-1.,  2.])
+    >>> p
+    array([1., 2.])
+    >>> k
+    array([], dtype=float64)
+
+    This means H(s) = -1/(s-1) + 2/(s-2).  We can verify by
+    reconstructing the transfer function with `invres`:
+
+    >>> from scipy.signal import invres
+    >>> b, a = invres(r, p, k)
+    >>> b
+    array([1., 0.])
+    >>> a
+    array([ 1., -3.,  2.])
+
     """
     b = np.asarray(b)
     a = np.asarray(a)
@@ -3402,6 +3481,30 @@ def residuez(b, a, tol=1e-3, rtype='avg'):
     See Also
     --------
     invresz, residue, unique_roots
+
+    Examples
+    --------
+    Compute the partial fraction expansion of the discrete-time transfer
+    function H(z) = 1 / (1 - 0.5z^{-1}):
+
+    >>> from scipy.signal import residuez
+    >>> r, p, k = residuez([1], [1, -0.5])
+    >>> r
+    array([1.])
+    >>> p
+    array([0.5])
+    >>> k
+    array([], dtype=float64)
+
+    Reconstruct the transfer function with `invresz`:
+
+    >>> from scipy.signal import invresz
+    >>> b, a = invresz(r, p, k)
+    >>> b
+    array([1.])
+    >>> a
+    array([ 1. , -0.5])
+
     """
     b = np.asarray(b)
     a = np.asarray(a)
@@ -3536,6 +3639,21 @@ def invresz(r, p, k, tol=1e-3, rtype='avg'):
     See Also
     --------
     residuez, unique_roots, invres
+
+    Examples
+    --------
+    Reconstruct a discrete-time transfer function from its partial fraction
+    expansion. Given H(z) = 1 / (1 - 0.5z^{-1}):
+
+    >>> from scipy.signal import invresz
+    >>> r = [1.0]
+    >>> p = [0.5]
+    >>> k = []
+    >>> b, a = invresz(r, p, k)
+    >>> b
+    array([1.])
+    >>> a
+    array([ 1. , -0.5])
 
     """
     r = np.atleast_1d(r)
@@ -4129,6 +4247,27 @@ def vectorstrength(events, period):
         when we vary the "probing" frequency while keeping the spike times
         fixed.  Biol Cybern. 2013 Aug;107(4):491-94.
         :doi:`10.1007/s00422-013-0560-8`.
+
+    Examples
+    --------
+    Events perfectly synchronized to a period of 1.0 give a vector strength
+    of 1.0:
+
+    >>> from scipy.signal import vectorstrength
+    >>> import numpy as np
+    >>> events = np.array([0.0, 1.0, 2.0, 3.0])
+    >>> strength, phase = vectorstrength(events, 1.0)
+    >>> np.isclose(strength, 1.0)
+    True
+
+    Events uniformly spread across one period produce a vector strength
+    near zero:
+
+    >>> events = np.array([0.0, 0.25, 0.5, 0.75])
+    >>> strength, phase = vectorstrength(events, 1.0)
+    >>> np.isclose(strength, 0.0, atol=1e-10)
+    True
+
     '''
     xp = array_namespace(events, period)
 

--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -455,6 +455,19 @@ def qspline2d(signal, lamb=0.0, precision=-1.0):
     -------
     output : ndarray
         The filtered signal.
+
+    Examples
+    --------
+    Compute quadratic B-spline coefficients for a 2-D signal:
+
+    >>> from scipy.signal import qspline2d
+    >>> import numpy as np
+    >>> x = np.linspace(0, 2 * np.pi, 20)
+    >>> img = np.sin(x[:, None]) * np.cos(x[None, :])
+    >>> coeffs = qspline2d(img)
+    >>> coeffs.shape
+    (20, 20)
+
     """
     if precision < 0.0 or precision >= 1.0:
         if signal.dtype in [float32, complex64]:
@@ -496,6 +509,19 @@ def cspline2d(signal, lamb=0.0, precision=-1.0):
     -------
     output : ndarray
         The filtered signal.
+
+    Examples
+    --------
+    Compute cubic B-spline coefficients for a 2-D signal:
+
+    >>> from scipy.signal import cspline2d
+    >>> import numpy as np
+    >>> x = np.linspace(0, 2 * np.pi, 20)
+    >>> img = np.sin(x[:, None]) * np.cos(x[None, :])
+    >>> coeffs = cspline2d(img)
+    >>> coeffs.shape
+    (20, 20)
+
     """
     xp = array_namespace(signal)
     signal = np.asarray(signal)
@@ -717,6 +743,18 @@ def symiirorder1(signal, c0, z1, precision=-1.0):
     -------
     output : ndarray
         The filtered signal.
+
+    Examples
+    --------
+    Apply a first-order symmetric IIR filter to a ramp signal:
+
+    >>> from scipy.signal import symiirorder1
+    >>> import numpy as np
+    >>> sig = np.arange(10, dtype=float)
+    >>> out = symiirorder1(sig, 6.0, 0.2, precision=1e-6)
+    >>> out.shape
+    (10,)
+
     """
     xp = array_namespace(signal)
     signal = xp_promote(signal, force_floating=True, xp=xp)
@@ -797,6 +835,18 @@ def symiirorder2(input, r, omega, precision=-1.0):
     -------
     output : ndarray
         The filtered signal.
+
+    Examples
+    --------
+    Apply a second-order symmetric IIR filter to a ramp signal:
+
+    >>> from scipy.signal import symiirorder2
+    >>> import numpy as np
+    >>> sig = np.arange(50, dtype=float)
+    >>> out = symiirorder2(sig, 0.5, 0.3)
+    >>> out.shape
+    (50,)
+
     """
     xp = array_namespace(input)
     input = xp_promote(input, force_floating=True, xp=xp)


### PR DESCRIPTION
## Summary
- Add `Examples` sections to all 20 `scipy.signal` functions identified in #7168 as missing examples
- Functions covered: `buttap`, `cheb1ap`, `cheb2ap`, `ellipap`, `besselap`, `sos2zpk`, `sosfreqz`, `zpk2ss`, `ss2zpk`, `medfilt`, `lfiltic`, `residue`, `invres`, `residuez`, `invresz`, `vectorstrength`, `symiirorder1`, `symiirorder2`, `qspline2d`, `cspline2d`
- All examples verified against scipy 1.17.0

Closes the `signal` section of #7168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)