### PR TITLE
DOC: special: add Examples to 106 functions

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -272,6 +272,15 @@ add_newdoc("bdtr",
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
 
+    Examples
+    --------
+    Compute the probability of 1 or fewer successes in 3 trials with
+    p = 0.5:
+
+    >>> from scipy.special import bdtr
+    >>> bdtr(1, 3, 0.5)
+    0.5
+
     """)
 
 add_newdoc("bdtrc",
@@ -324,6 +333,16 @@ add_newdoc("bdtrc",
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
 
+    Examples
+    --------
+    The survival function is the complement of the CDF:
+
+    >>> from scipy.special import bdtr, bdtrc
+    >>> bdtrc(1, 3, 0.5)
+    0.5
+    >>> 1 - bdtr(1, 3, 0.5)
+    0.5
+
     """)
 
 add_newdoc("bdtri",
@@ -371,6 +390,15 @@ add_newdoc("bdtri",
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    Find the event probability such that ``bdtr(1, 3, p) = 0.5``:
+
+    >>> from scipy.special import bdtri
+    >>> bdtri(1, 3, 0.5)
+    0.5
+
     """)
 
 add_newdoc("bdtrik",
@@ -424,6 +452,14 @@ add_newdoc("bdtrik",
     .. [3] Barry Brown, James Lovato, and Kathy Russell,
            CDFLIB: Library of Fortran Routines for Cumulative Distribution
            Functions, Inverses, and Other Parameters.
+
+    Examples
+    --------
+    Find the number of successes ``k`` such that ``bdtr(k, 3, 0.5) = 0.5``:
+
+    >>> from scipy.special import bdtrik
+    >>> bdtrik(0.5, 3, 0.5)
+    0.9999999999999961
 
     """)
 
@@ -2347,6 +2383,12 @@ add_newdoc("eval_jacobi",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E7
 
+    Examples
+    --------
+    >>> from scipy.special import eval_jacobi
+    >>> eval_jacobi(3, 0.5, 0.5, 0.5)
+    -0.546875
+
     """)
 
 add_newdoc("eval_sh_jacobi",
@@ -2396,6 +2438,12 @@ add_newdoc("eval_sh_jacobi",
         Graphs, and Mathematical Tables. New York: Dover, 1972.
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.1.E2
+
+    Examples
+    --------
+    >>> from scipy.special import eval_sh_jacobi
+    >>> eval_sh_jacobi(3, 2, 1, 0.25)
+    0.013839285714285714
 
     """)
 
@@ -2448,6 +2496,12 @@ add_newdoc("eval_gegenbauer",
         Graphs, and Mathematical Tables. New York: Dover, 1972.
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E9
+
+    Examples
+    --------
+    >>> from scipy.special import eval_gegenbauer
+    >>> eval_gegenbauer(3, 1.5, 0.5)
+    -1.5625
 
     """)
 
@@ -2505,6 +2559,12 @@ add_newdoc("eval_chebyt",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E11_2
 
+    Examples
+    --------
+    >>> from scipy.special import eval_chebyt
+    >>> eval_chebyt(3, 0.5)
+    -1.0
+
     """)
 
 add_newdoc("eval_chebyu",
@@ -2554,6 +2614,12 @@ add_newdoc("eval_chebyu",
         Graphs, and Mathematical Tables. New York: Dover, 1972.
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E11_4
+
+    Examples
+    --------
+    >>> from scipy.special import eval_chebyu
+    >>> eval_chebyu(3, 0.5)
+    -1.0
 
     """)
 
@@ -2729,6 +2795,12 @@ add_newdoc("eval_sh_chebyt",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.7.E7
 
+    Examples
+    --------
+    >>> from scipy.special import eval_sh_chebyt
+    >>> eval_sh_chebyt(3, 0.25)
+    1.0
+
     """)
 
 add_newdoc("eval_sh_chebyu",
@@ -2776,6 +2848,12 @@ add_newdoc("eval_sh_chebyu",
         Graphs, and Mathematical Tables. New York: Dover, 1972.
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.7.E8
+
+    Examples
+    --------
+    >>> from scipy.special import eval_sh_chebyu
+    >>> eval_sh_chebyu(3, 0.25)
+    1.0
 
     """)
 
@@ -2912,6 +2990,12 @@ add_newdoc("eval_sh_legendre",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.7.E10
 
+    Examples
+    --------
+    >>> from scipy.special import eval_sh_legendre
+    >>> eval_sh_legendre(3, 0.25)
+    0.4375
+
     """)
 
 add_newdoc("eval_genlaguerre",
@@ -2967,6 +3051,12 @@ add_newdoc("eval_genlaguerre",
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E12
 
+    Examples
+    --------
+    >>> from scipy.special import eval_genlaguerre
+    >>> eval_genlaguerre(3, 1, 0.5)
+    1.479166666666667
+
     """)
 
 add_newdoc("eval_laguerre",
@@ -3020,6 +3110,12 @@ add_newdoc("eval_laguerre",
     .. [DLMF2] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.E12
 
+    Examples
+    --------
+    >>> from scipy.special import eval_laguerre
+    >>> eval_laguerre(3, 0.5)
+    -0.14583333333333331
+
      """)
 
 add_newdoc("eval_hermite",
@@ -3066,6 +3162,12 @@ add_newdoc("eval_hermite",
         Graphs, and Mathematical Tables. New York: Dover, 1972.
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.T1
+
+    Examples
+    --------
+    >>> from scipy.special import eval_hermite
+    >>> eval_hermite(3, 0.5)
+    -5.000000000000001
 
     """)
 
@@ -3114,6 +3216,12 @@ add_newdoc("eval_hermitenorm",
         Graphs, and Mathematical Tables. New York: Dover, 1972.
     .. [DLMF] NIST Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/18.5.T1
+
+    Examples
+    --------
+    >>> from scipy.special import eval_hermitenorm
+    >>> eval_hermitenorm(3, 0.5)
+    -1.375
 
     """)
 
@@ -4390,6 +4498,18 @@ add_newdoc("kl_div",
     .. [1] Boyd, Stephen and Lieven Vandenberghe. *Convex optimization*.
            Cambridge University Press, 2004.
            :doi:`10.1017/CBO9780511804441`.
+
+    Examples
+    --------
+    >>> from scipy.special import kl_div
+
+    When both arguments are equal, the divergence is zero:
+
+    >>> kl_div(0.5, 0.5)
+    0.0
+
+    >>> kl_div(0.5, 1.0)
+    0.1534264097200273
 
     """)
 
@@ -6597,6 +6717,18 @@ add_newdoc("rel_entr",
            :doi:`10.1017/CBO9780511804441`.
     .. [2] Kullback-Leibler divergence,
            https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence
+
+    Examples
+    --------
+    >>> from scipy.special import rel_entr
+
+    When both arguments are equal, the relative entropy is zero:
+
+    >>> rel_entr(0.5, 0.5)
+    0.0
+
+    >>> rel_entr(0.5, 1.0)
+    -0.34657359027997264
 
     """)
 

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -226,6 +226,13 @@ def jnjnp_zeros(nt):
            Functions", John Wiley and Sons, 1996, chapter 5.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import jnjnp_zeros
+    >>> jn, jnp, yn, ynp = jnjnp_zeros(3)
+    >>> jn
+    array([0.        , 1.84118378, 2.40482556])
+
     """
     if not isscalar(nt) or (floor(nt) != nt) or (nt > 1200):
         raise ValueError("Number must be integer <= 1200.")
@@ -1315,6 +1322,15 @@ def riccati_jn(n, x):
     .. [2] NIST Digital Library of Mathematical Functions.
            https://dlmf.nist.gov/10.51.E1
 
+    Examples
+    --------
+    >>> from scipy.special import riccati_jn
+    >>> jn, djn = riccati_jn(2, 1.0)
+    >>> jn
+    array([0.84147098, 0.30116868, 0.06203505])
+    >>> djn
+    array([0.54030231, 0.54030231, 0.17709857])
+
     """
     if not (isscalar(n) and isscalar(x)):
         raise ValueError("arguments must be scalars.")
@@ -1371,6 +1387,15 @@ def riccati_yn(n, x):
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
     .. [2] NIST Digital Library of Mathematical Functions.
            https://dlmf.nist.gov/10.51.E1
+
+    Examples
+    --------
+    >>> from scipy.special import riccati_yn
+    >>> yn, dyn = riccati_yn(2, 1.0)
+    >>> yn
+    array([-0.54030231, -1.38177329, -3.60501757])
+    >>> dyn
+    array([0.84147098, 0.84147098, 5.82826184])
 
     """
     if not (isscalar(n) and isscalar(x)):
@@ -1447,6 +1472,13 @@ def fresnelc_zeros(nt):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import fresnelc_zeros
+    >>> fresnelc_zeros(3)
+    array([1.74366749+0.30573506j, 2.6514596 +0.25290396j,
+           3.32035934+0.22395346j])
+
     """
     if (floor(nt) != nt) or (nt <= 0) or not isscalar(nt):
         raise ValueError("Argument must be positive scalar integer.")
@@ -1471,6 +1503,13 @@ def fresnels_zeros(nt):
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import fresnels_zeros
+    >>> fresnels_zeros(3)
+    array([2.00925701+0.2885479j , 2.83347723+0.24428524j,
+           3.46753308+0.21849268j])
 
     """
     if (floor(nt) != nt) or (nt <= 0) or not isscalar(nt):
@@ -1498,6 +1537,13 @@ def fresnel_zeros(nt):
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import fresnel_zeros
+    >>> zs, zc = fresnel_zeros(3)
+    >>> len(zs), len(zc)
+    (3, 3)
 
     """
     if (floor(nt) != nt) or (nt <= 0) or not isscalar(nt):
@@ -1529,6 +1575,12 @@ def assoc_laguerre(x, n, k=0.0):
     -----
     `assoc_laguerre` is a simple wrapper around `eval_genlaguerre`, with
     reversed argument order ``(x, n, k=0.0) --> (n, k, x)``.
+
+    Examples
+    --------
+    >>> from scipy.special import assoc_laguerre
+    >>> assoc_laguerre(1.0, 2, 1)
+    0.5
 
     """
     return _ufuncs.eval_genlaguerre(n, k, x)
@@ -1615,6 +1667,13 @@ def mathieu_even_coef(m, q):
     .. [2] NIST Digital Library of Mathematical Functions
            https://dlmf.nist.gov/28.4#i
 
+    Examples
+    --------
+    >>> from scipy.special import mathieu_even_coef
+    >>> c = mathieu_even_coef(2, 5)
+    >>> c[:3]
+    array([ 0.43873717,  0.65364026, -0.42657894])
+
     """
     if not (isscalar(m) and isscalar(q)):
         raise ValueError("m and q must be scalars.")
@@ -1674,6 +1733,13 @@ def mathieu_odd_coef(m, q):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import mathieu_odd_coef
+    >>> c = mathieu_odd_coef(2, 5)
+    >>> c[:3]
+    array([ 0.93342944, -0.35480392,  0.05296373])
+
     """
     if not (isscalar(m) and isscalar(q)):
         raise ValueError("m and q must be scalars.")
@@ -1730,6 +1796,15 @@ def lqmn(m, n, z):
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import lqmn
+    >>> Lz, Lz_d = lqmn(1, 2, 0.5)
+    >>> Lz.shape
+    (2, 3)
+    >>> Lz[0, 0]
+    0.5493061443340549
 
     """
     if not isscalar(m) or (m < 0):
@@ -2082,6 +2157,14 @@ def lmbda(v, x):
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
     .. [2] Jahnke, E. and Emde, F. "Tables of Functions with Formulae and
            Curves" (4th ed.), Dover, 1945
+
+    Examples
+    --------
+    >>> from scipy.special import lmbda
+    >>> lam, lam_d = lmbda(2, 1.0)
+    >>> lam
+    array([0.76519769, 0.88010117, 0.91922788])
+
     """
     if not (isscalar(v) and isscalar(x)):
         raise ValueError("arguments must be scalars.")
@@ -2124,6 +2207,13 @@ def pbdv_seq(v, x):
            Functions", John Wiley and Sons, 1996, chapter 13.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import pbdv_seq
+    >>> dv, dp = pbdv_seq(2, 0.5)
+    >>> dv
+    array([ 0.93941306,  0.46970653, -0.7045598 ])
+
     """
     if not (isscalar(v) and isscalar(x)):
         raise ValueError("arguments must be scalars.")
@@ -2160,6 +2250,13 @@ def pbvv_seq(v, x):
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996, chapter 13.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import pbvv_seq
+    >>> vv, vp = pbvv_seq(2, 0.5)
+    >>> vv
+    array([ 0.39099051, -0.65384844, -0.35895737])
 
     """
     if not (isscalar(v) and isscalar(x)):
@@ -2198,6 +2295,15 @@ def pbdn_seq(n, z):
            Functions", John Wiley and Sons, 1996, chapter 13.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import pbdn_seq
+    >>> dv, dp = pbdn_seq(2, 0.5+0.5j)
+    >>> dv.shape
+    (3,)
+    >>> dv[0]
+    (0.9645049185174789+0.04757888523894056j)
+
     """
     if not (isscalar(n) and isscalar(z)):
         raise ValueError("arguments must be scalars.")
@@ -2234,6 +2340,12 @@ def ber_zeros(nt):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import ber_zeros
+    >>> ber_zeros(3)
+    array([ 2.84891782,  7.23882945, 11.67396355])
+
     """
     if not isscalar(nt) or (floor(nt) != nt) or (nt <= 0):
         raise ValueError("nt must be positive integer scalar.")
@@ -2262,6 +2374,12 @@ def bei_zeros(nt):
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import bei_zeros
+    >>> bei_zeros(3)
+    array([ 5.02622395,  9.4554063 , 13.89348785])
 
     """
     if not isscalar(nt) or (floor(nt) != nt) or (nt <= 0):
@@ -2292,6 +2410,12 @@ def ker_zeros(nt):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import ker_zeros
+    >>> ker_zeros(3)
+    array([ 1.71854296,  6.12727913, 10.56294271])
+
     """
     if not isscalar(nt) or (floor(nt) != nt) or (nt <= 0):
         raise ValueError("nt must be positive integer scalar.")
@@ -2320,6 +2444,12 @@ def kei_zeros(nt):
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import kei_zeros
+    >>> kei_zeros(3)
+    array([ 3.91466761,  8.34422506, 12.78255715])
 
     """
     if not isscalar(nt) or (floor(nt) != nt) or (nt <= 0):
@@ -2388,6 +2518,12 @@ def beip_zeros(nt):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import beip_zeros
+    >>> beip_zeros(3)
+    array([ 3.7726733 ,  8.28098785, 12.74214752])
+
     """
     if not isscalar(nt) or (floor(nt) != nt) or (nt <= 0):
         raise ValueError("nt must be positive integer scalar.")
@@ -2416,6 +2552,12 @@ def kerp_zeros(nt):
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import kerp_zeros
+    >>> kerp_zeros(3)
+    array([ 2.66583979,  7.17212212, 11.63218639])
 
     """
     if not isscalar(nt) or (floor(nt) != nt) or (nt <= 0):
@@ -2446,6 +2588,12 @@ def keip_zeros(nt):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import keip_zeros
+    >>> keip_zeros(3)
+    array([ 4.93181194,  9.40405458, 13.85826916])
+
     """
     if not isscalar(nt) or (floor(nt) != nt) or (nt <= 0):
         raise ValueError("nt must be positive integer scalar.")
@@ -2466,6 +2614,15 @@ def kelvin_zeros(nt):
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import kelvin_zeros
+    >>> result = kelvin_zeros(3)
+    >>> len(result)
+    8
+    >>> result[0]
+    array([ 2.84891782,  7.23882945, 11.67396355])
 
     """
     if not isscalar(nt) or (floor(nt) != nt) or (nt <= 0):
@@ -2498,6 +2655,12 @@ def pro_cv_seq(m, n, c):
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
 
+    Examples
+    --------
+    >>> from scipy.special import pro_cv_seq
+    >>> pro_cv_seq(0, 3, 1.0)
+    array([ 0.31900006,  2.59308458,  6.5334718 , 12.51446215])
+
     """
     if not (isscalar(m) and isscalar(n) and isscalar(c)):
         raise ValueError("Arguments must be scalars.")
@@ -2526,6 +2689,12 @@ def obl_cv_seq(m, n, c):
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import obl_cv_seq
+    >>> obl_cv_seq(0, 3, 1.0)
+    array([-0.3486024 ,  1.39320631,  5.48680005, 11.4921209 ])
 
     """
     if not (isscalar(m) and isscalar(n) and isscalar(c)):

--- a/scipy/special/_multiufuncs.py
+++ b/scipy/special/_multiufuncs.py
@@ -175,6 +175,21 @@ sph_legendre_p = MultiUFunc(
 
     It is the same as the spherical harmonic :math:`Y_{n}^{m}(\theta, \phi)`
     with :math:`\phi = 0`.
+
+    Examples
+    --------
+    Compute the spherical Legendre polynomial of degree 2, order 0
+    at :math:`\theta = \pi/4`:
+
+    >>> import numpy as np
+    >>> from scipy.special import sph_legendre_p
+    >>> sph_legendre_p(2, 0, np.pi / 4)
+    array([0.15769578])
+
+    Include the first derivative by setting ``diff_n=1``:
+
+    >>> sph_legendre_p(2, 0, np.pi / 4, diff_n=1)
+    array([ 0.15769578, -0.9461747 ])
     """, diff_n=0
 )
 
@@ -212,6 +227,21 @@ sph_legendre_p_all = MultiUFunc(
     See Also
     --------
     sph_legendre_p
+
+    Examples
+    --------
+    Compute all spherical Legendre polynomials up to degree 2 and
+    order 1. The output shape is ``(diff_n + 1, n + 1, 2*m + 1)``:
+
+    >>> import numpy as np
+    >>> from scipy.special import sph_legendre_p_all
+    >>> result = sph_legendre_p_all(2, 1, np.pi / 4)
+    >>> result.shape
+    (1, 3, 3)
+    >>> result[0]
+    array([[ 0.28209479,  0.        ,  0.        ],
+           [ 0.34549415, -0.24430126,  0.24430126],
+           [ 0.15769578, -0.3862742 ,  0.3862742 ]])
     """, diff_n=0
 )
 
@@ -284,6 +314,19 @@ assoc_legendre_p = MultiUFunc(
     .. math::
 
         \sqrt{\frac{(2 n + 1) (n - m)!}{2 (n + m)!}}
+
+    Examples
+    --------
+    Compute the associated Legendre polynomial :math:`P_2^1(0.5)`:
+
+    >>> from scipy.special import assoc_legendre_p
+    >>> assoc_legendre_p(2, 1, 0.5)
+    array([-1.29903811])
+
+    Compute the normalized variant:
+
+    >>> assoc_legendre_p(2, 1, 0.5, norm=True)
+    array([-0.83852549])
     """, branch_cut=2, norm=False, diff_n=0
 )
 
@@ -326,6 +369,21 @@ assoc_legendre_p_all = MultiUFunc(
     See Also
     --------
     assoc_legendre_p
+
+    Examples
+    --------
+    Compute all associated Legendre polynomials up to degree 2 and
+    order 1. The output shape is ``(diff_n + 1, n + 1, 2*m + 1)``,
+    where the last axis ranges over orders from ``-m`` to ``m``:
+
+    >>> from scipy.special import assoc_legendre_p_all
+    >>> result = assoc_legendre_p_all(2, 1, 0.5)
+    >>> result.shape
+    (1, 3, 3)
+    >>> result[0]
+    array([[ 1.        ,  0.        ,  0.        ],
+           [ 0.5       , -0.8660254 ,  0.4330127 ],
+           [-0.125     , -1.29903811,  0.21650635]])
     """, branch_cut=2, norm=False, diff_n=0
 )
 
@@ -404,6 +462,20 @@ legendre_p = MultiUFunc(
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    Compute the Legendre polynomial :math:`P_2(x)` at ``x = 0.5``:
+
+    >>> from scipy.special import legendre_p
+    >>> legendre_p(2, 0.5)
+    array([-0.125])
+
+    Include the first derivative by setting ``diff_n=1``.
+    :math:`P_2'(x) = 3x`, so :math:`P_2'(0.5) = 1.5`:
+
+    >>> legendre_p(2, 0.5, diff_n=1)
+    array([-0.125,  1.5  ])
     """, diff_n=0
 )
 
@@ -442,6 +514,18 @@ legendre_p_all = MultiUFunc(
     See Also
     --------
     legendre_p
+
+    Examples
+    --------
+    Compute all Legendre polynomials up to degree 3 at ``x = 0.5``.
+    The output shape is ``(diff_n + 1, n + 1)``:
+
+    >>> from scipy.special import legendre_p_all
+    >>> result = legendre_p_all(3, 0.5)
+    >>> result.shape
+    (1, 4)
+    >>> result[0]
+    array([ 1.    ,  0.5   , -0.125 , -0.4375])
     """, diff_n=0
 )
 
@@ -540,6 +624,26 @@ sph_harm_y = MultiUFunc(
     .. [1] Digital Library of Mathematical Functions, 14.30.
            https://dlmf.nist.gov/14.30
     .. [2] https://en.wikipedia.org/wiki/Spherical_harmonics#Condon.E2.80.93Shortley_phase
+
+    Examples
+    --------
+    Verify that :math:`Y_0^0 = \frac{1}{2\sqrt{\pi}}`:
+
+    >>> import numpy as np
+    >>> from scipy.special import sph_harm_y
+    >>> sph_harm_y(0, 0, 0.0, 0.0)
+    array(0.28209479+0.j)
+    >>> np.allclose(sph_harm_y(0, 0, 0.0, 0.0), 1 / (2 * np.sqrt(np.pi)))
+    True
+
+    Verify the conjugate symmetry
+    :math:`Y_n^{-m} = (-1)^m \overline{Y_n^m}`:
+
+    >>> theta, phi = np.pi / 4, np.pi / 3
+    >>> y = sph_harm_y(2, 1, theta, phi)
+    >>> y_neg = sph_harm_y(2, -1, theta, phi)
+    >>> np.allclose(y_neg, (-1) * np.conj(y))
+    True
     """, force_complex_output=True, diff_n=0
 )
 
@@ -587,6 +691,21 @@ sph_harm_y_all = MultiUFunc(
     See Also
     --------
     sph_harm_y
+
+    Examples
+    --------
+    Compute all spherical harmonics up to degree 2 and order 1.
+    The output shape is ``(n + 1, 2*m + 1)``:
+
+    >>> import numpy as np
+    >>> from scipy.special import sph_harm_y_all
+    >>> result = sph_harm_y_all(2, 1, np.pi / 4, 0.0)
+    >>> result.shape
+    (3, 3)
+    >>> result
+    array([[ 0.28209479+0.j,  0.        +0.j,  0.        +0.j],
+           [ 0.34549415+0.j, -0.24430126+0.j,  0.24430126+0.j],
+           [ 0.15769578+0.j, -0.3862742 +0.j,  0.3862742 +0.j]])
     """, force_complex_output=True, diff_n=0
 )
 

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -443,6 +443,15 @@ def roots_sh_jacobi(n, p1, q1, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Examples
+    --------
+    >>> from scipy.special import roots_sh_jacobi
+    >>> x, w = roots_sh_jacobi(3, 2, 1)
+    >>> x
+    array([0.08858796, 0.40946686, 0.78765946])
+    >>> w
+    array([0.20093191, 0.22924111, 0.06982698])
+
     """
     if (p1-q1) <= -1 or q1 <= 0:
         message = "(p - q) must be greater than -1, and q must be greater than 0."
@@ -492,6 +501,13 @@ def sh_jacobi(n, p, q, monic=False):
     For fixed :math:`p, q`, the polynomials :math:`G_n^{(p, q)}` are
     orthogonal over :math:`[0, 1]` with weight function :math:`(1 -
     x)^{p - q}x^{q - 1}`.
+
+    Examples
+    --------
+    >>> from scipy.special import sh_jacobi
+    >>> poly = sh_jacobi(3, 2, 1)
+    >>> poly.order
+    3
 
     """
     if n < 0:
@@ -553,6 +569,15 @@ def roots_genlaguerre(n, alpha, mu=False):
     .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
+
+    Examples
+    --------
+    >>> from scipy.special import roots_genlaguerre
+    >>> x, w = roots_genlaguerre(3, 1)
+    >>> x
+    array([0.93582223, 3.30540729, 7.75877048])
+    >>> w
+    array([0.58868148, 0.39121606, 0.02010246])
 
     """
     m = int(n)
@@ -724,6 +749,15 @@ def roots_laguerre(n, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Examples
+    --------
+    >>> from scipy.special import roots_laguerre
+    >>> x, w = roots_laguerre(3)
+    >>> x
+    array([0.41577456, 2.29428036, 6.28994508])
+    >>> w
+    array([0.71109301, 0.27851773, 0.01038926])
+
     """
     return roots_genlaguerre(n, 0.0, mu=mu)
 
@@ -884,6 +918,15 @@ def roots_hermite(n, mu=False):
     .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
+
+    Examples
+    --------
+    >>> from scipy.special import roots_hermite
+    >>> x, w = roots_hermite(3)
+    >>> x
+    array([-1.22474487,  0.        ,  1.22474487])
+    >>> w
+    array([0.29540898, 1.1816359 , 0.29540898])
 
     """
     m = int(n)
@@ -1405,6 +1448,15 @@ def roots_hermitenorm(n, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Examples
+    --------
+    >>> from scipy.special import roots_hermitenorm
+    >>> x, w = roots_hermitenorm(3)
+    >>> x
+    array([-1.73205081,  0.        ,  1.73205081])
+    >>> w
+    array([0.41777138, 1.67108552, 0.41777138])
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -1460,6 +1512,12 @@ def hermitenorm(n, monic=False):
 
     The polynomials :math:`He_n` are orthogonal over :math:`(-\infty,
     \infty)` with weight function :math:`e^{-x^2/2}`.
+
+    Examples
+    --------
+    >>> from scipy.special import hermitenorm
+    >>> hermitenorm(3)(1)
+    -2.0
 
     """
     if n < 0:
@@ -1523,6 +1581,15 @@ def roots_gegenbauer(n, alpha, mu=False):
     .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
+
+    Examples
+    --------
+    >>> from scipy.special import roots_gegenbauer
+    >>> x, w = roots_gegenbauer(3, 1.5)
+    >>> x
+    array([-0.65465367,  0.        ,  0.65465367])
+    >>> w
+    array([0.31111111, 0.71111111, 0.31111111])
 
     """
     m = int(n)
@@ -1686,6 +1753,15 @@ def roots_chebyt(n, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Examples
+    --------
+    >>> from scipy.special import roots_chebyt
+    >>> x, w = roots_chebyt(3)
+    >>> x
+    array([-0.8660254,  0.       ,  0.8660254])
+    >>> w
+    array([1.04719755, 1.04719755, 1.04719755])
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -1845,6 +1921,16 @@ def roots_chebyu(n, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import roots_chebyu
+    >>> x, w = roots_chebyu(3)
+    >>> np.allclose(x, [-np.sqrt(2)/2, 0, np.sqrt(2)/2])
+    True
+    >>> w
+    array([0.39269908, 0.78539816, 0.39269908])
+
     """
     m = int(n)
     if n < 1 or n != m:
@@ -1994,6 +2080,15 @@ def roots_chebyc(n, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Examples
+    --------
+    >>> from scipy.special import roots_chebyc
+    >>> x, w = roots_chebyc(3)
+    >>> x
+    array([-1.73205081,  0.        ,  1.73205081])
+    >>> w
+    array([2.0943951, 2.0943951, 2.0943951])
+
     """
     x, w, m = roots_chebyt(n, True)
     x *= 2
@@ -2037,6 +2132,12 @@ def chebyc(n, monic=False):
     ----------
     .. [1] Abramowitz and Stegun, "Handbook of Mathematical Functions"
            Section 22. National Bureau of Standards, 1972.
+
+    Examples
+    --------
+    >>> from scipy.special import chebyc
+    >>> chebyc(3)(1)
+    -2.0
 
     """
     if n < 0:
@@ -2099,6 +2200,16 @@ def roots_chebys(n, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.special import roots_chebys
+    >>> x, w = roots_chebys(3)
+    >>> np.allclose(x, [-np.sqrt(2), 0, np.sqrt(2)])
+    True
+    >>> w
+    array([0.78539816, 1.57079633, 0.78539816])
+
     """
     x, w, m = roots_chebyu(n, True)
     x *= 2
@@ -2142,6 +2253,12 @@ def chebys(n, monic=False):
     ----------
     .. [1] Abramowitz and Stegun, "Handbook of Mathematical Functions"
            Section 22. National Bureau of Standards, 1972.
+
+    Examples
+    --------
+    >>> from scipy.special import chebys
+    >>> chebys(3)(1)
+    -1.0
 
     """
     if n < 0:
@@ -2205,6 +2322,15 @@ def roots_sh_chebyt(n, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Examples
+    --------
+    >>> from scipy.special import roots_sh_chebyt
+    >>> x, w = roots_sh_chebyt(3)
+    >>> x
+    array([0.0669873, 0.5      , 0.9330127])
+    >>> w
+    array([1.04719755, 1.04719755, 1.04719755])
+
     """
     xw = roots_chebyt(n, mu)
     return ((xw[0] + 1) / 2,) + xw[1:]
@@ -2233,6 +2359,12 @@ def sh_chebyt(n, monic=False):
     -----
     The polynomials :math:`T^*_n` are orthogonal over :math:`[0, 1]`
     with weight function :math:`(x - x^2)^{-1/2}`.
+
+    Examples
+    --------
+    >>> from scipy.special import sh_chebyt
+    >>> sh_chebyt(3)(1)
+    1.0
 
     """
     base = sh_jacobi(n, 0.0, 0.5, monic=monic)
@@ -2284,6 +2416,15 @@ def roots_sh_chebyu(n, mu=False):
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
 
+    Examples
+    --------
+    >>> from scipy.special import roots_sh_chebyu
+    >>> x, w = roots_sh_chebyu(3)
+    >>> x
+    array([0.14644661, 0.5       , 0.85355339])
+    >>> w
+    array([0.09817477, 0.19634954, 0.09817477])
+
     """
     x, w, m = roots_chebyu(n, True)
     x = (x + 1) / 2
@@ -2318,6 +2459,12 @@ def sh_chebyu(n, monic=False):
     -----
     The polynomials :math:`U^*_n` are orthogonal over :math:`[0, 1]`
     with weight function :math:`(x - x^2)^{1/2}`.
+
+    Examples
+    --------
+    >>> from scipy.special import sh_chebyu
+    >>> sh_chebyu(3)(1)
+    4.0
 
     """
     base = sh_jacobi(n, 2.0, 1.5, monic=monic)
@@ -2547,6 +2694,15 @@ def roots_sh_legendre(n, mu=False):
     .. [AS] Milton Abramowitz and Irene A. Stegun, eds.
         Handbook of Mathematical Functions with Formulas,
         Graphs, and Mathematical Tables. New York: Dover, 1972.
+
+    Examples
+    --------
+    >>> from scipy.special import roots_sh_legendre
+    >>> x, w = roots_sh_legendre(3)
+    >>> x
+    array([0.11270167, 0.5       , 0.88729833])
+    >>> w
+    array([0.27777778, 0.44444444, 0.27777778])
 
     """
     x, w = roots_legendre(n)

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -654,6 +654,12 @@ const char *beip_doc = R"(
     .. [dlmf] NIST, Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/10#PT5
 
+    Examples
+    --------
+    >>> from scipy.special import beip
+    >>> beip(1.0)
+    0.49739651146809727
+
     )";
 
 const char *ber_doc = R"(
@@ -732,6 +738,12 @@ const char *berp_doc = R"(
     ----------
     .. [dlmf] NIST, Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/10#PT5
+
+    Examples
+    --------
+    >>> from scipy.special import berp
+    >>> berp(1.0)
+    -0.06244575217903096
 
     )";
 
@@ -1076,6 +1088,13 @@ const char *ellipj_doc = R"(
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> from scipy.special import ellipj
+    >>> sn, cn, dn, ph = ellipj(0.5, 0.5)
+    >>> sn
+    0.47075047365565736
     )";
 
 const char *ellipkm1_doc = R"(
@@ -1130,6 +1149,12 @@ const char *ellipkm1_doc = R"(
     ----------
     .. [1] Cephes Mathematical Functions Library,
            http://www.netlib.org/cephes/
+
+    Examples
+    --------
+    >>> from scipy.special import ellipkm1
+    >>> ellipkm1(0.5)
+    1.8540746773013719
     )";
 
 const char *ellipk_doc = R"(
@@ -1185,6 +1210,12 @@ const char *ellipk_doc = R"(
     .. [2] NIST Digital Library of Mathematical
            Functions. http://dlmf.nist.gov/, Release 1.0.28 of
            2020-09-15. See Sec. 19.25(i) https://dlmf.nist.gov/19.25#i
+
+    Examples
+    --------
+    >>> from scipy.special import ellipk
+    >>> ellipk(0.5)
+    1.8540746773013719
     )";
 
 const char *ellipkinc_doc = R"(
@@ -1247,6 +1278,12 @@ const char *ellipkinc_doc = R"(
     .. [3] NIST Digital Library of Mathematical
            Functions. http://dlmf.nist.gov/, Release 1.0.28 of
            2020-09-15. See Sec. 19.25(i) https://dlmf.nist.gov/19.25#i
+
+    Examples
+    --------
+    >>> from scipy.special import ellipkinc
+    >>> ellipkinc(0.5, 0.5)
+    0.5104671356280046
     )";
 
 const char *xlogy_doc = R"(
@@ -2684,6 +2721,12 @@ const char *hankel1e_doc = R"(
     .. [1] Donald E. Amos, "AMOS, A Portable Package for Bessel Functions
            of a Complex Argument and Nonnegative Order",
            http://netlib.org/amos/
+
+    Examples
+    --------
+    >>> from scipy.special import hankel1e
+    >>> hankel1e(1, 1.0)
+    (-0.41960757590749614-0.792380888474382j)
     )";
 
 const char *hankel2_doc = R"(
@@ -2729,6 +2772,12 @@ const char *hankel2_doc = R"(
     .. [1] Donald E. Amos, "AMOS, A Portable Package for Bessel Functions
            of a Complex Argument and Nonnegative Order",
            http://netlib.org/amos/
+
+    Examples
+    --------
+    >>> from scipy.special import hankel2
+    >>> hankel2(1, 1.0)
+    (0.44005058574493355+0.7812128213002889j)
     )";
 
 const char *hankel2e_doc = R"(
@@ -2774,6 +2823,12 @@ const char *hankel2e_doc = R"(
     .. [1] Donald E. Amos, "AMOS, A Portable Package for Bessel Functions
            of a Complex Argument and Nonnegative Order",
            http://netlib.org/amos/
+
+    Examples
+    --------
+    >>> from scipy.special import hankel2e
+    >>> hankel2e(1, 1.0)
+    (-0.41960757590749614+0.792380888474382j)
 
     )";
 
@@ -4389,6 +4444,12 @@ const char *keip_doc = R"(
     .. [dlmf] NIST, Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/10#PT5
 
+    Examples
+    --------
+    >>> from scipy.special import keip
+    >>> keip(1.0)
+    0.3523699133361705
+
     )";
 
 const char *kelvin_doc = R"(
@@ -4411,6 +4472,13 @@ const char *kelvin_doc = R"(
         derivatives evaluated at `x`.  For example, kelvin(x)[0].real =
         ber x and kelvin(x)[0].imag = bei x with similar relationships
         for ker and kei.
+
+    Examples
+    --------
+    >>> from scipy.special import kelvin
+    >>> ber, bei, ker, kei = kelvin(1.0)
+    >>> ber
+    (0.984381781213087+0.24956604003665972j)
     )";
 
 const char *ker_doc = R"(
@@ -4490,6 +4558,12 @@ const char *kerp_doc = R"(
     ----------
     .. [dlmf] NIST, Digital Library of Mathematical Functions,
         https://dlmf.nist.gov/10#PT5
+
+    Examples
+    --------
+    >>> from scipy.special import kerp
+    >>> kerp(1.0)
+    -0.6946038911006908
 
     )";
 
@@ -5370,6 +5444,12 @@ const char *mathieu_a_doc = R"(
     --------
     mathieu_b, mathieu_cem, mathieu_sem
 
+    Examples
+    --------
+    >>> from scipy.special import mathieu_a
+    >>> mathieu_a(1, 1.0)
+    1.8591080725143634
+
     )";
 
 const char *mathieu_b_doc = R"(
@@ -5395,6 +5475,12 @@ const char *mathieu_b_doc = R"(
     See Also
     --------
     mathieu_a, mathieu_cem, mathieu_sem
+
+    Examples
+    --------
+    >>> from scipy.special import mathieu_b
+    >>> mathieu_b(1, 1.0)
+    -0.11024881699209521
 
     )";
 
@@ -5498,6 +5584,13 @@ const char *mathieu_modcem1_doc = R"(
     --------
     mathieu_modsem1
 
+    Examples
+    --------
+    >>> from scipy.special import mathieu_modcem1
+    >>> val, deriv = mathieu_modcem1(1, 1.0, 1.0)
+    >>> val
+    0.40718809884858753
+
     )";
 
 const char *mathieu_modcem2_doc = R"(
@@ -5530,6 +5623,13 @@ const char *mathieu_modcem2_doc = R"(
     See Also
     --------
     mathieu_modsem2
+
+    Examples
+    --------
+    >>> from scipy.special import mathieu_modcem2
+    >>> val, deriv = mathieu_modcem2(1, 1.0, 1.0)
+    >>> val
+    0.3023577458361811
 
     )";
 
@@ -5564,6 +5664,13 @@ const char *mathieu_modsem1_doc = R"(
     --------
     mathieu_modcem1
 
+    Examples
+    --------
+    >>> from scipy.special import mathieu_modsem1
+    >>> val, deriv = mathieu_modsem1(1, 1.0, 1.0)
+    >>> val
+    0.4571569664985514
+
     )";
 
 const char *mathieu_modsem2_doc = R"(
@@ -5596,6 +5703,13 @@ const char *mathieu_modsem2_doc = R"(
     See Also
     --------
     mathieu_modcem2
+
+    Examples
+    --------
+    >>> from scipy.special import mathieu_modsem2
+    >>> val, deriv = mathieu_modsem2(1, 1.0, 1.0)
+    >>> val
+    0.1379349011479173
 
     )";
 
@@ -5691,6 +5805,11 @@ const char *modfresnelm_doc = R"(
     --------
     modfresnelp
 
+    Examples
+    --------
+    >>> from scipy.special import modfresnelm
+    >>> fm, km = modfresnelm(1.0)
+
     )";
 
 const char *modfresnelp_doc = R"(
@@ -5715,6 +5834,11 @@ const char *modfresnelp_doc = R"(
     See Also
     --------
     modfresnelm
+
+    Examples
+    --------
+    >>> from scipy.special import modfresnelp
+    >>> fp, kp = modfresnelp(1.0)
 
     )";
 
@@ -5750,6 +5874,13 @@ const char *obl_ang1_doc = R"(
     See Also
     --------
     obl_ang1_cv
+
+    Examples
+    --------
+    >>> from scipy.special import obl_ang1
+    >>> val, deriv = obl_ang1(0, 0, 1.0, 0.5)
+    >>> val
+    1.0441336969542285
 
     )";
 
@@ -5846,6 +5977,14 @@ const char *obl_ang1_cv_doc = R"(
     --------
     obl_ang1
 
+    Examples
+    --------
+    >>> from scipy.special import obl_ang1_cv, obl_cv
+    >>> cv = obl_cv(0, 0, 1.0)
+    >>> val, deriv = obl_ang1_cv(0, 0, 1.0, cv, 0.5)
+    >>> val
+    1.0441336969542285
+
     )";
 
 const char *obl_cv_doc = R"(
@@ -5871,6 +6010,12 @@ const char *obl_cv_doc = R"(
     -------
     cv : scalar or ndarray
         Characteristic value
+
+    Examples
+    --------
+    >>> from scipy.special import obl_cv
+    >>> obl_cv(0, 0, 1.0)
+    -0.34860239947026983
 
     )";
 
@@ -5906,6 +6051,13 @@ const char *obl_rad1_doc = R"(
     See Also
     --------
     obl_rad1_cv
+
+    Examples
+    --------
+    >>> from scipy.special import obl_rad1
+    >>> val, deriv = obl_rad1(0, 0, 1.0, 1.0)
+    >>> val
+    0.7472999495632598
 
     )";
 
@@ -5945,6 +6097,14 @@ const char *obl_rad1_cv_doc = R"(
     --------
     obl_rad1
 
+    Examples
+    --------
+    >>> from scipy.special import obl_rad1_cv, obl_cv
+    >>> cv = obl_cv(0, 0, 1.0)
+    >>> val, deriv = obl_rad1_cv(0, 0, 1.0, cv, 1.0)
+    >>> val
+    0.7472999495632598
+
     )";
 
 const char *obl_rad2_doc = R"(
@@ -5979,6 +6139,13 @@ const char *obl_rad2_doc = R"(
     See Also
     --------
     obl_rad2_cv
+
+    Examples
+    --------
+    >>> from scipy.special import obl_rad2
+    >>> val, deriv = obl_rad2(0, 0, 1.0, 2.0)
+    >>> val
+    0.2547979316777333
 
     )";
 
@@ -6017,6 +6184,14 @@ const char *obl_rad2_cv_doc = R"(
     See Also
     --------
     obl_rad2
+
+    Examples
+    --------
+    >>> from scipy.special import obl_rad2_cv, obl_cv
+    >>> cv = obl_cv(0, 0, 1.0)
+    >>> val, deriv = obl_rad2_cv(0, 0, 1.0, cv, 2.0)
+    >>> val
+    0.2547979316777333
     )";
 
 const char *pbdv_doc = R"(
@@ -6042,6 +6217,13 @@ const char *pbdv_doc = R"(
         Value of the function
     dp : scalar or ndarray
         Value of the derivative vs x
+
+    Examples
+    --------
+    >>> from scipy.special import pbdv
+    >>> val, deriv = pbdv(1, 0.5)
+    >>> val
+    0.4697065314067379
     )";
 
 const char *pbvv_doc = R"(
@@ -6067,6 +6249,13 @@ const char *pbvv_doc = R"(
         Value of the function
     vp : scalar or ndarray
         Value of the derivative vs x
+
+    Examples
+    --------
+    >>> from scipy.special import pbvv
+    >>> val, deriv = pbvv(1, 0.5)
+    >>> val
+    -0.6538484371138077
     )";
 
 const char *pbwa_doc = R"(
@@ -6111,6 +6300,13 @@ const char *pbwa_doc = R"(
     .. [2] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    >>> from scipy.special import pbwa
+    >>> val, deriv = pbwa(1, 0.5)
+    >>> val
+    0.4679105355315857
     )";
 
 const char *pro_ang1_doc = R"(
@@ -6141,6 +6337,13 @@ const char *pro_ang1_doc = R"(
         Value of the function
     sp : scalar or ndarray
         Value of the derivative vs x
+
+    Examples
+    --------
+    >>> from scipy.special import pro_ang1
+    >>> val, deriv = pro_ang1(0, 0, 1.0, 0.5)
+    >>> val
+    0.9606110837921175
     )";
 
 const char *pro_ang1_cv_doc = R"(
@@ -6174,6 +6377,14 @@ const char *pro_ang1_cv_doc = R"(
         Value of the function
     sp : scalar or ndarray
         Value of the derivative vs x
+
+    Examples
+    --------
+    >>> from scipy.special import pro_ang1_cv, pro_cv
+    >>> cv = pro_cv(0, 0, 1.0)
+    >>> val, deriv = pro_ang1_cv(0, 0, 1.0, cv, 0.5)
+    >>> val
+    0.9606110837921175
     )";
 
 const char *pro_cv_doc = R"(
@@ -6199,6 +6410,12 @@ const char *pro_cv_doc = R"(
     -------
     cv : scalar or ndarray
         Characteristic value
+
+    Examples
+    --------
+    >>> from scipy.special import pro_cv
+    >>> pro_cv(0, 0, 1.0)
+    0.31900005514689334
     )";
 
 const char *pro_rad1_doc = R"(
@@ -6229,6 +6446,13 @@ const char *pro_rad1_doc = R"(
         Value of the function
     sp : scalar or ndarray
         Value of the derivative vs x
+
+    Examples
+    --------
+    >>> from scipy.special import pro_rad1
+    >>> val, deriv = pro_rad1(0, 0, 1.0, 2.0)
+    >>> val
+    0.5322603846816454
     )";
 
 const char *pro_rad1_cv_doc = R"(
@@ -6262,6 +6486,14 @@ const char *pro_rad1_cv_doc = R"(
         Value of the function
     sp : scalar or ndarray
         Value of the derivative vs x
+
+    Examples
+    --------
+    >>> from scipy.special import pro_rad1_cv, pro_cv
+    >>> cv = pro_cv(0, 0, 1.0)
+    >>> val, deriv = pro_rad1_cv(0, 0, 1.0, cv, 2.0)
+    >>> val
+    0.5322603846816454
     )";
 
 const char *pro_rad2_doc = R"(
@@ -6292,6 +6524,13 @@ const char *pro_rad2_doc = R"(
         Value of the function
     sp : scalar or ndarray
         Value of the derivative vs x
+
+    Examples
+    --------
+    >>> from scipy.special import pro_rad2
+    >>> val, deriv = pro_rad2(0, 0, 1.0, 2.0)
+    >>> val
+    0.13356117654632796
     )";
 
 const char *pro_rad2_cv_doc = R"(
@@ -6325,6 +6564,14 @@ const char *pro_rad2_cv_doc = R"(
         Value of the function
     sp : scalar or ndarray
         Value of the derivative vs x
+
+    Examples
+    --------
+    >>> from scipy.special import pro_rad2_cv, pro_cv
+    >>> cv = pro_cv(0, 0, 1.0)
+    >>> val, deriv = pro_rad2_cv(0, 0, 1.0, cv, 2.0)
+    >>> val
+    0.13356117654632796
     )";
 
 const char *psi_doc = R"(


### PR DESCRIPTION
## Summary

- Add docstring `Examples` sections to 106 `scipy.special` functions (plus 13 root aliases that inherit examples from their `roots_*` counterparts)
- Covers Kelvin functions/zeros, Mathieu functions/coefficients, spheroidal wave functions, parabolic cylinder functions, elliptic integrals, Hankel functions, Bessel/Fresnel/Riccati-Bessel zeros, binomial distribution (`bdtr` family), orthogonal polynomial roots/constructors, `eval_*` polynomial functions, information theory (`kl_div`, `rel_entr`), Legendre polynomials, associated Legendre polynomials, spherical Legendre polynomials, and spherical harmonics
- All examples verified to run correctly

Ref #7168

## Files changed

| File | Functions | Lines |
|------|-----------|-------|
| `_special_ufuncs_docs.cpp` | 37 | +247 |
| `_basic.py` | 24 | +169 |
| `_orthogonal.py` | 19 | +156 |
| `_add_newdocs.py` | 18 | +132 |
| `_multiufuncs.py` | 8 | +119 |

[docs only]