### PR TITLE
DOC: fft: add Examples to idst, ifht, irfft2, ihfft2

### DIFF
--- a/scipy/fft/_basic.py
+++ b/scipy/fft/_basic.py
@@ -1350,6 +1350,15 @@ def irfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
     This is really `irfftn` with different defaults.
     For more details see `irfftn`.
 
+    Examples
+    --------
+    >>> import scipy.fft
+    >>> import numpy as np
+    >>> x = np.broadcast_to([1, 0, -1, 0], (4, 4)).copy()
+    >>> X = scipy.fft.rfft2(x)
+    >>> np.allclose(scipy.fft.irfft2(X, s=x.shape), x)
+    True
+
     """
     return (Dispatchable(x, np.ndarray),)
 
@@ -1665,6 +1674,15 @@ def ihfft2(x, s=None, axes=(-2, -1), norm=None, overwrite_x=False, workers=None,
     -----
     This is really `ihfftn` with different defaults.
     For more details see `ihfftn`.
+
+    Examples
+    --------
+    >>> import scipy.fft
+    >>> import numpy as np
+    >>> x = np.array([[1+0j, 2+0j], [2+0j, 1+0j]])
+    >>> h = scipy.fft.hfft2(x, s=(2, 2))
+    >>> np.allclose(scipy.fft.ihfft2(h, s=(2, 2)), x)
+    True
 
     """
     return (Dispatchable(x, np.ndarray),)

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -223,5 +223,23 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     mathematical inverse Hankel transform is commonly defined using :math:`k \, dk`.
 
     See `fht` for further details.
+
+    Examples
+    --------
+    This example shows that `ifht` inverts `fht`.  We set up a
+    logarithmically spaced grid and transform a Gaussian with `fht`,
+    then recover it with `ifht`:
+
+    >>> import numpy as np
+    >>> from scipy.fft import fht, ifht, fhtoffset
+    >>> r = np.logspace(-4, 4, 16)
+    >>> dln = np.log(r[1] / r[0])
+    >>> mu = 0.0
+    >>> offset = fhtoffset(dln, initial=0, mu=mu)
+    >>> a = np.exp(-r**2 / 2)
+    >>> A = fht(a, dln, mu, offset=offset)
+    >>> a_roundtrip = ifht(A, dln, mu, offset=offset)
+    >>> np.allclose(a_roundtrip, a)
+    True
     """
     return (Dispatchable(A, np.ndarray),)

--- a/scipy/fft/_realtransforms.py
+++ b/scipy/fft/_realtransforms.py
@@ -713,5 +713,15 @@ def idst(x, type=2, n=None, axis=-1, norm=None, overwrite_x=False,
     type. DST type 1 and 4 are their own inverse and DSTs 2 and 3 are each
     other's inverses.
 
+    Examples
+    --------
+    The IDST is the inverse of the DST:
+
+    >>> import numpy as np
+    >>> from scipy.fft import dst, idst
+    >>> x = np.array([1.0, 2.0, 3.0, 4.0])
+    >>> np.allclose(idst(dst(x, type=2), type=2), x)
+    True
+
     """
     return (Dispatchable(x, np.ndarray),)


### PR DESCRIPTION
## Summary

- Add docstring `Examples` sections to the 4 remaining `scipy.fft` functions that were missing them: `idst`, `ifht`, `irfft2`, `ihfft2`
- Each example demonstrates a round-trip with the corresponding forward transform

Ref #7168

[docs only]