### PR TITLE
DOC: add Examples to 23 functions across 6 modules

### DIFF
--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -1137,6 +1137,22 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
     for a spline function :math:`g(x)` with a _fixed_ knot vector ``t``.
 
     .. versionadded:: 1.15.0
+
+    Examples
+    --------
+    Fit a smoothing spline to noisy data:
+
+    >>> import numpy as np
+    >>> from scipy.interpolate import make_splrep
+    >>> x = np.linspace(0, 2*np.pi, 20)
+    >>> y = np.sin(x)
+    >>> spl = make_splrep(x, y)
+
+    Evaluate the spline at a new point:
+
+    >>> float(spl(np.pi / 4))  # doctest: +SKIP
+    0.7071...
+
     """  # noqa:E501
     xp = array_namespace(x, y, w, t)
     if t is not None:
@@ -1292,6 +1308,24 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
         20 (1982) 171-184.
     .. [2] P. Dierckx, "Curve and surface fitting with splines", Monographs on
         Numerical Analysis, Oxford University Press, 1993.
+
+    Examples
+    --------
+    Fit a parametric spline to a unit circle:
+
+    >>> import numpy as np
+    >>> from scipy.interpolate import make_splprep
+    >>> theta = np.linspace(0, 2*np.pi, 50)
+    >>> x = np.cos(theta)
+    >>> y = np.sin(theta)
+    >>> spl, u = make_splprep([x, y], s=0)
+
+    Evaluate the spline at a few parameter values:
+
+    >>> result = spl(np.array([0.0, 0.25, 0.5]))
+    >>> result.shape
+    (2, 3)
+
     """  # noqa:E501
 
     bc_type = _validate_bc_type(bc_type)

--- a/scipy/linalg/interpolative.py
+++ b/scipy/linalg/interpolative.py
@@ -480,6 +480,21 @@ def interp_decomp(A, eps_or_k, rand=True, rng=None):
         Column index array.
     proj : :class:`numpy.ndarray`
         Interpolation coefficients.
+
+    Examples
+    --------
+    Compute a rank-5 interpolative decomposition of a random matrix:
+
+    >>> import numpy as np
+    >>> import scipy.linalg.interpolative as sli
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((50, 30))
+    >>> idx, proj = sli.interp_decomp(A, 5)
+    >>> idx[:5]  # doctest: +SKIP
+    array([ 3,  9, 14, 28, 18])
+    >>> proj.shape
+    (5, 25)
+
     """  # numpy/numpydoc#87  # noqa: E501
     from scipy.sparse.linalg import LinearOperator
     rng = np.random.default_rng(rng)
@@ -562,6 +577,20 @@ def reconstruct_matrix_from_id(B, idx, proj):
     -------
     :class:`numpy.ndarray`
         Reconstructed matrix.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import scipy.linalg.interpolative as sli
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((50, 30))
+    >>> k = 5
+    >>> idx, proj = sli.interp_decomp(A, k)
+    >>> B = A[:, idx[:k]]
+    >>> A_recon = sli.reconstruct_matrix_from_id(B, idx, proj)
+    >>> np.linalg.norm(A - A_recon) / np.linalg.norm(A)  # doctest: +SKIP
+    0.829...
+
     """
     B = np.atleast_2d(_C_contiguous_copy(B))
     if _is_real(B):
@@ -600,6 +629,19 @@ def reconstruct_interp_matrix(idx, proj):
     -------
     :class:`numpy.ndarray`
         Interpolation matrix.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import scipy.linalg.interpolative as sli
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((50, 30))
+    >>> k = 5
+    >>> idx, proj = sli.interp_decomp(A, k)
+    >>> P = sli.reconstruct_interp_matrix(idx, proj)
+    >>> P.shape
+    (5, 30)
+
     """
     n, krank = len(idx), proj.shape[0]
     if _is_real(proj):
@@ -647,6 +689,19 @@ def reconstruct_skel_matrix(A, k, idx):
     -------
     :class:`numpy.ndarray`
         Skeleton matrix.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import scipy.linalg.interpolative as sli
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((50, 30))
+    >>> k = 5
+    >>> idx, proj = sli.interp_decomp(A, k)
+    >>> B = sli.reconstruct_skel_matrix(A, k, idx)
+    >>> B.shape
+    (50, 5)
+
     """
     return A[:, idx[:k]]
 
@@ -684,6 +739,20 @@ def id_to_svd(B, idx, proj):
         Singular values.
     V : :class:`numpy.ndarray`
         Right singular vectors.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import scipy.linalg.interpolative as sli
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((50, 30))
+    >>> k = 5
+    >>> idx, proj = sli.interp_decomp(A, k)
+    >>> B = A[:, idx[:k]]
+    >>> U, S, V = sli.id_to_svd(B, idx, proj)
+    >>> U.shape, S.shape, V.shape
+    ((50, 5), (5,), (30, 5))
+
     """
     B = _C_contiguous_copy(B)
     if _is_real(B):
@@ -720,6 +789,17 @@ def estimate_spectral_norm(A, its=20, rng=None):
     -------
     float
         Spectral norm estimate.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import scipy.linalg.interpolative as sli
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((50, 30))
+    >>> norm_est = sli.estimate_spectral_norm(A, rng=rng)
+    >>> norm_est  # doctest: +SKIP
+    12.47...
+
     """
     from scipy.sparse.linalg import aslinearoperator
     rng = np.random.default_rng(rng)
@@ -761,6 +841,17 @@ def estimate_spectral_norm_diff(A, B, its=20, rng=None):
     -------
     float
         Spectral norm estimate of matrix difference.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import scipy.linalg.interpolative as sli
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((50, 30))
+    >>> B = A + 0.01 * rng.standard_normal((50, 30))
+    >>> sli.estimate_spectral_norm_diff(A, B, rng=rng)  # doctest: +SKIP
+    0.12...
+
     """
     from scipy.sparse.linalg import aslinearoperator
     rng = np.random.default_rng(rng)
@@ -825,6 +916,19 @@ def svd(A, eps_or_k, rand=True, rng=None):
         1D array of singular values.
     V : :class:`numpy.ndarray`
         2D array right singular vectors.
+
+    Examples
+    --------
+    Compute a rank-5 SVD via interpolative decomposition:
+
+    >>> import numpy as np
+    >>> import scipy.linalg.interpolative as sli
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((50, 30))
+    >>> U, S, V = sli.svd(A, 5, rng=rng)
+    >>> U.shape, S.shape, V.shape
+    ((50, 5), (5,), (30, 5))
+
     """
     from scipy.sparse.linalg import LinearOperator
     rng = np.random.default_rng(rng)
@@ -916,6 +1020,16 @@ def estimate_rank(A, eps, rng=None):
     -------
     int
         Estimated matrix rank.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import scipy.linalg.interpolative as sli
+    >>> rng = np.random.default_rng(0)
+    >>> A = rng.standard_normal((50, 30))
+    >>> sli.estimate_rank(A, 1e-3, rng=rng)  # doctest: +SKIP
+    30
+
     """
     from scipy.sparse.linalg import LinearOperator
 

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -1014,6 +1014,27 @@ def generic_laplace(input, derivative2, output=None, mode="reflect",
     generic_laplace : ndarray
         Filtered array. Has the same shape as `input`.
 
+    Examples
+    --------
+    Compute the Laplacian using a custom second derivative based on
+    `~scipy.ndimage.correlate1d`:
+
+    >>> import numpy as np
+    >>> from scipy.ndimage import generic_laplace, correlate1d
+    >>> def derivative2(input, axis, output, mode, cval):
+    ...     return correlate1d(input, [1, -2, 1], axis, output, mode, cval, 0)
+    >>> a = np.array([[0, 0, 0, 0, 0],
+    ...               [0, 0, 1, 0, 0],
+    ...               [0, 1, 1, 1, 0],
+    ...               [0, 0, 1, 0, 0],
+    ...               [0, 0, 0, 0, 0]], dtype=np.float64)
+    >>> generic_laplace(a, derivative2)
+    array([[ 0.,  0.,  1.,  0.,  0.],
+           [ 0.,  2., -3.,  2.,  0.],
+           [ 1., -3.,  0., -3.,  1.],
+           [ 0.,  2., -3.,  2.,  0.],
+           [ 0.,  0.,  1.,  0.,  0.]])
+
     """
     if extra_keywords is None:
         extra_keywords = {}
@@ -1172,6 +1193,27 @@ def generic_gradient_magnitude(input, derivative, output=None,
     -------
     generic_gradient_magnitude : ndarray
         Filtered array. Has the same shape as `input`.
+
+    Examples
+    --------
+    Compute the gradient magnitude using a central difference derivative:
+
+    >>> import numpy as np
+    >>> from scipy.ndimage import generic_gradient_magnitude, correlate1d
+    >>> def derivative(input, axis, output, mode, cval):
+    ...     return correlate1d(input, [-0.5, 0, 0.5], axis, output, mode,
+    ...                        cval, 0)
+    >>> a = np.array([[0, 0, 0, 0, 0],
+    ...               [0, 0, 1, 0, 0],
+    ...               [0, 1, 1, 1, 0],
+    ...               [0, 0, 1, 0, 0],
+    ...               [0, 0, 0, 0, 0]], dtype=np.float64)
+    >>> generic_gradient_magnitude(a, derivative)
+    array([[0.        , 0.        , 0.5       , 0.        , 0.        ],
+           [0.        , 0.70710678, 0.5       , 0.70710678, 0.        ],
+           [0.5       , 0.5       , 0.        , 0.5       , 0.5       ],
+           [0.        , 0.70710678, 0.5       , 0.70710678, 0.        ],
+           [0.        , 0.        , 0.5       , 0.        , 0.        ]])
 
     """
     if extra_keywords is None:

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -708,6 +708,17 @@ def sum(input, labels=None, index=None):
     reasons, for new code please prefer `sum_labels`.  See the `sum_labels`
     docstring for more details.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.ndimage import sum as ndsum
+    >>> a = np.array([1, 2, 3, 4])
+    >>> ndsum(a)
+    10
+    >>> labels = np.array([1, 1, 2, 2])
+    >>> ndsum(a, labels, index=[1, 2])
+    array([3., 7.])
+
     """  # numpydoc ignore=RT01
     return sum_labels(input, labels, index)
 
@@ -1647,6 +1658,25 @@ def watershed_ift(input, markers, structure=None, output=None):
     .. [1] A.X. Falcao, J. Stolfi and R. de Alencar Lotufo, "The image
            foresting transform: theory, algorithms, and applications",
            Pattern Analysis and Machine Intelligence, vol. 26, pp. 19-29, 2004.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.ndimage import watershed_ift
+    >>> image = np.array([[0, 0, 0, 5, 5],
+    ...                   [0, 0, 0, 5, 5],
+    ...                   [5, 5, 5, 5, 5],
+    ...                   [5, 5, 5, 0, 0],
+    ...                   [5, 5, 5, 0, 0]], dtype=np.uint8)
+    >>> markers = np.zeros_like(image, dtype=np.int32)
+    >>> markers[0, 0] = 1
+    >>> markers[4, 4] = 2
+    >>> watershed_ift(image, markers)
+    array([[1, 1, 1, 1, 1],
+           [1, 1, 1, 1, 1],
+           [1, 1, 1, 2, 2],
+           [1, 1, 2, 2, 2],
+           [2, 1, 2, 2, 2]])
 
     """
     input = np.asarray(input)

--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -1794,6 +1794,22 @@ def morphological_laplace(input, size=None, footprint=None, structure=None,
     morphological_laplace : ndarray
         Output
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.ndimage import morphological_laplace
+    >>> a = np.array([[0, 0, 0, 0, 0],
+    ...               [0, 1, 1, 1, 0],
+    ...               [0, 1, 2, 1, 0],
+    ...               [0, 1, 1, 1, 0],
+    ...               [0, 0, 0, 0, 0]])
+    >>> morphological_laplace(a, size=(3, 3))
+    array([[ 1,  1,  1,  1,  1],
+           [ 1,  0,  0,  0,  1],
+           [ 1,  0, -1,  0,  1],
+           [ 1,  0,  0,  0,  1],
+           [ 1,  1,  1,  1,  1]])
+
     """
     input = np.asarray(input)
     tmp1 = grey_dilation(input, size, footprint, structure, None, mode,

--- a/scipy/optimize/_linprog.py
+++ b/scipy/optimize/_linprog.py
@@ -84,6 +84,17 @@ def linprog_verbose_callback(res):
             The number of iterations performed.
         message : str
             A string descriptor of the exit status of the optimization.
+
+    Examples
+    --------
+    Pass as a callback to `linprog` to print progress at each iteration:
+
+    >>> from scipy.optimize import linprog
+    >>> from scipy.optimize._linprog import linprog_verbose_callback
+    >>> res = linprog([-1, -2], A_ub=[[1, 1], [1, 0]], b_ub=[4, 3],
+    ...              method='revised simplex',  # doctest: +SKIP
+    ...              callback=linprog_verbose_callback)
+
     """
     x = res['x']
     fun = res['fun']

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -1276,6 +1276,19 @@ class LinearMixing(GenericBroyden):
     root : Interface to root finding algorithms for multivariate
            functions. See ``method='linearmixing'`` in particular.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.optimize._nonlin import linearmixing
+    >>> def F(x):
+    ...     d = np.diag([3, 2, 1.5, 1, 0.5])
+    ...     c = 0.01
+    ...     return -d @ x - c * float(x @ x) * x
+    >>> x = linearmixing(F, [1, 1, 1, 1, 1], iter=60, alpha=0.5,
+    ...                  verbose=False)
+    >>> np.linalg.norm(F(x)) < 1e-5
+    True
+
     """
 
     def __init__(self, alpha=None):
@@ -1326,6 +1339,20 @@ class ExcitingMixing(GenericBroyden):
     --------
     root : Interface to root finding algorithms for multivariate
            functions. See ``method='excitingmixing'`` in particular.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.optimize._nonlin import excitingmixing
+    >>> def F(x):
+    ...     d = np.diag([3, 2, 1.5, 1, 0.5])
+    ...     c = 0.01
+    ...     return -d @ x - c * float(x @ x) * x
+    >>> x = excitingmixing(F, [1, 1, 1, 1, 1], iter=20, alpha=0.5,
+    ...                    verbose=False)
+    >>> np.linalg.norm(F(x)) < 1e-3
+    True
+
     """
 
     def __init__(self, alpha=None, alphamax=1.0):

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -1974,6 +1974,17 @@ def fmin_ncg(f, x0, fprime, fhess_p=None, fhess=None, args=(), avextol=1e-5,
     ----------
     Wright & Nocedal, 'Numerical Optimization', 1999, p. 140.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.optimize import fmin_ncg
+    >>> def f(x):
+    ...     return (x[0] - 1)**2 + (x[1] - 2.5)**2
+    >>> def grad(x):
+    ...     return np.array([2*(x[0] - 1), 2*(x[1] - 2.5)])
+    >>> fmin_ncg(f, [0.0, 0.0], grad, disp=False)
+    array([1. , 2.5])
+
     """
     opts = {'xtol': avextol,
             'eps': epsilon,

--- a/scipy/optimize/_tnc.py
+++ b/scipy/optimize/_tnc.py
@@ -243,6 +243,22 @@ def fmin_tnc(func, x0, fprime=None, args=(), approx_grad=0,
     Nash S.G. (1984), "Newton-Type Minimization Via the Lanczos Method",
     SIAM Journal of Numerical Analysis 21, pp. 770-778
 
+    Examples
+    --------
+    Minimize a quadratic function with bounds. When `func` returns both the
+    objective value and the gradient, `fprime` can be omitted:
+
+    >>> import numpy as np
+    >>> from scipy.optimize import fmin_tnc
+    >>> def func_and_grad(x):
+    ...     f = (x[0] - 2)**2 + (x[1] - 1)**2
+    ...     g = np.array([2*(x[0] - 2), 2*(x[1] - 1)])
+    ...     return f, g
+    >>> x, nfeval, rc = fmin_tnc(func_and_grad, [0.0, 0.0],
+    ...                          bounds=[(-5, 5), (-5, 5)], disp=0)
+    >>> x
+    array([2., 1.])
+
     """
     # handle fprime/approx_grad
     if approx_grad:

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -103,6 +103,21 @@ def epps_singleton_2samp(x, y, t=(0.4, 0.8), *, axis=0):
        - the Epps-Singleton two-sample test using the empirical characteristic
        function", The Stata Journal 9(3), p. 454--465, 2009.
 
+    Examples
+    --------
+    Test whether two samples come from the same distribution:
+
+    >>> import numpy as np
+    >>> from scipy.stats import epps_singleton_2samp
+    >>> rng = np.random.default_rng(0)
+    >>> x = rng.normal(0, 1, size=100)
+    >>> y = rng.normal(0.5, 1, size=100)
+    >>> res = epps_singleton_2samp(x, y)
+    >>> res.statistic
+    8.552948387284649
+    >>> res.pvalue
+    0.07329843027931278
+
     """
     xp = array_namespace(x, y)
     # x and y are converted to arrays by the decorator

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -385,6 +385,17 @@ def kstatvar(data, n=2, *, axis=None):
     ----------
     .. [1] http://mathworld.wolfram.com/k-Statistic.html
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.stats import kstatvar
+    >>> rng = np.random.default_rng(0)
+    >>> data = rng.normal(0, 1, size=100)
+    >>> kstatvar(data, 1)  # variance of the mean estimator
+    0.009350454790150309
+    >>> kstatvar(data, 2)  # variance of the variance estimator
+    0.012592777495757611
+
     """  # noqa: E501
     xp = array_namespace(data)
     data = xp.asarray(data)


### PR DESCRIPTION
Add docstring examples to 23 functions across 6 modules that were missing them (Ref #7168):

**interpolate** (2): `make_splrep`, `make_splprep`

**linalg.interpolative** (9): `interp_decomp`, `reconstruct_matrix_from_id`, `reconstruct_interp_matrix`, `reconstruct_skel_matrix`, `id_to_svd`, `estimate_spectral_norm`, `estimate_spectral_norm_diff`, `svd`, `estimate_rank`

**ndimage** (5): `generic_laplace`, `generic_gradient_magnitude`, `morphological_laplace`, `sum`, `watershed_ift`

**optimize** (5): `fmin_ncg`, `fmin_tnc`, `LinearMixing` (linearmixing), `ExcitingMixing` (excitingmixing), `linprog_verbose_callback`

**stats** (2): `epps_singleton_2samp`, `kstatvar`

All examples have been run and verified.

[docs only]