### PR TITLE
BUG: signal: fix homomorphic mask in minimum_phase

### DIFF
--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -1397,8 +1397,8 @@ def minimum_phase(h,
         win = xp.zeros(n_fft)
         win[0] = 1
         stop = n_fft // 2
-        win[1:stop] = 2
-        if n_fft % 2:
+        win[1:stop + 1] = 2
+        if n_fft % 2 == 0:
             win[stop] = 1
         h_temp *= win
         h_temp = ifft(xp.exp(fft(h_temp)))

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -762,6 +762,21 @@ class TestMinimumPhase:
         m = minimum_phase(h, 'hilbert', n_fft=2**19)
         xp_assert_close(m, k, rtol=2e-3)
 
+    def test_homomorphic_mask_gh22752(self):
+        # Regression test for gh-22752: the homomorphic method's analytic
+        # signal mask had an off-by-one error and a flipped even/odd check,
+        # causing incorrect magnitude response in the passband.
+        freq = [0, 0.2, 0.3, 1.0]
+        desired = [1, 0]
+        for order in (31, 64, 101):
+            h_linear = remez(order, freq, desired, fs=2.)
+            # Test with both even and odd n_fft to exercise both code paths
+            for n_fft in (len(h_linear), len(h_linear) + 1):
+                h_min = minimum_phase(h_linear, method='homomorphic',
+                                      n_fft=n_fft, half=False)
+                xp_assert_close(np.abs(fft(h_min, n_fft)),
+                                np.abs(fft(h_linear, n_fft)), rtol=0.05)
+
 
 class Testfirwin_2d:
     def test_invalid_args(self):


### PR DESCRIPTION
Fixes the analytic signal mask construction in the `homomorphic` method of `minimum_phase`. There are two bugs in the current code:

**1. Off-by-one in positive frequency doubling**

`win[1:stop]` misses the last positive frequency bin. Should be `win[1:stop + 1]`.

**2. Inverted even/odd parity check**

`if n_fft % 2:` sets the Nyquist bin to 1 for *odd*-length DFTs (which don't have a Nyquist bin) and skips it for *even*-length DFTs (which do). Flipping to `if n_fft % 2 == 0:` corrects this.

Both bugs cause the mask sum to be `n_fft - 1` instead of `n_fft`, violating the `lmin[n] = 2u[n] - d[n]` identity (Oppenheim+Schafer 3rd ed, eq 13.42b). The result is a noticeable ripple artifact in the passband magnitude response.

**Before fix** (passband error with odd `n_fft=963`): `1.25e-03`
**After fix**: `1.38e-14` (machine epsilon)

Closes #22752