### PR TITLE
DOC: signal: add Examples to sos2zpk, zpk2ss, and ss2zpk

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1440,12 +1440,45 @@ def sos2zpk(sos):
     k : float
         System gain.
 
+    See Also
+    --------
+    zpk2sos, sosfilt, sos2tf
+
     Notes
     -----
     The number of zeros and poles returned will be ``n_sections * 2``
     even if some of these are (effectively) zero.
 
     .. versionadded:: 0.16.0
+
+    Examples
+    --------
+    Extract zeros, poles, and gain from a single second-order section
+    representing a discrete-time filter with a zero at `z = -1` and a
+    pole at `z = 0.5`:
+
+    >>> import numpy as np
+    >>> from scipy.signal import sos2zpk
+    >>> sos = np.array([[1, 1, 0, 1, -0.5, 0]])
+    >>> z, p, k = sos2zpk(sos)
+    >>> z
+    array([-1.+0.j,  0.+0.j])
+    >>> p
+    array([0.5+0.j, 0. +0.j])
+    >>> k
+    1.0
+
+    With multiple sections, the zeros and poles are concatenated and the
+    gains are multiplied. Note that ``n_sections * 2`` zeros and poles
+    are always returned, even if some are effectively zero:
+
+    >>> sos = np.array([[1, 1, 0, 1, -0.5, 0],
+    ...                 [1, -1, 0, 1, -0.9, 0]])
+    >>> z, p, k = sos2zpk(sos)
+    >>> z
+    array([-1.+0.j,  0.+0.j,  1.+0.j,  0.+0.j])
+    >>> p
+    array([0.5+0.j, 0. +0.j, 0.9+0.j, 0. +0.j])
     """
     xp = array_namespace(sos)
     sos = xp.asarray(sos)

--- a/scipy/signal/_lti_conversion.py
+++ b/scipy/signal/_lti_conversion.py
@@ -332,7 +332,7 @@ def ss2tf(A, B, C, D, input=0):
 
 
 def zpk2ss(z, p, k):
-    """Zero-pole-gain representation to state-space representation.
+    r"""Zero-pole-gain representation to state-space representation.
 
     Parameters
     ----------
@@ -346,6 +346,37 @@ def zpk2ss(z, p, k):
     A, B, C, D : ndarray
         State space representation of the system, in controller canonical
         form.
+
+    See Also
+    --------
+    ss2zpk, zpk2tf, tf2ss
+
+    Examples
+    --------
+    Convert a system with no zeros, one pole at `s = -3`, and a gain of 5:
+
+    .. math:: H(s) = \frac{5}{s + 3}
+
+    to state-space form:
+
+    >>> from scipy.signal import zpk2ss
+    >>> A, B, C, D = zpk2ss([], [-3], 5)
+    >>> A
+    array([[-3.]])
+    >>> B
+    array([[ 1.]])
+    >>> C
+    array([[ 5.]])
+    >>> D
+    array([[ 0.]])
+
+    A second-order system with complex conjugate poles:
+
+    >>> import numpy as np
+    >>> A, B, C, D = zpk2ss([], [-1+2j, -1-2j], 1)
+    >>> A
+    array([[-2., -5.],
+           [ 1.,  0.]])
 
     """
     return tf2ss(*zpk2tf(z, p, k))
@@ -376,6 +407,29 @@ def ss2zpk(A, B, C, D, input=0):
         Zeros and poles.
     k : float
         System gain.
+
+    See Also
+    --------
+    zpk2ss, ss2tf, tf2zpk
+
+    Examples
+    --------
+    Convert the state-space representation of a first-order lowpass filter
+    to zero-pole-gain form:
+
+    >>> import numpy as np
+    >>> from scipy.signal import ss2zpk
+    >>> A = np.array([[-2.]])
+    >>> B = np.array([[1.]])
+    >>> C = np.array([[3.]])
+    >>> D = np.array([[0.]])
+    >>> z, p, k = ss2zpk(A, B, C, D)
+    >>> z
+    array([], dtype=float64)
+    >>> p
+    array([-2.])
+    >>> k
+    3.0
 
     """
     return tf2zpk(*ss2tf(A, B, C, D, input=input))


### PR DESCRIPTION
## Summary

Add `Examples` sections to three `scipy.signal` functions that were
identified as missing them in #7168:

- **`sos2zpk`**: demonstrates extracting zeros, poles, and gain from
  single and multi-section SOS representations, highlighting that
  `n_sections * 2` zeros/poles are always returned
- **`zpk2ss`**: shows conversion from zero-pole-gain to state-space
  form for a first-order system and a second-order system with complex
  conjugate poles, includes LaTeX math for the transfer function
- **`ss2zpk`**: demonstrates the inverse conversion from state-space
  back to zero-pole-gain form

Also adds `See Also` sections to cross-reference related conversion
functions (`zpk2sos`, `sosfilt`, `sos2tf`, `ss2zpk`, `zpk2tf`, `tf2ss`,
`ss2tf`, `tf2zpk`).

All examples verified against scipy 1.16.x and produce exact (non-approximate)
output values suitable for doctests.

Partially addresses #7168 (signal section).