### PR TITLE
ENH: Add arc-length parameterization for B-splines

### DIFF
--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -36,6 +36,11 @@ New features
 ``scipy.interpolate`` improvements
 ==================================
 
+- Added `scipy.interpolate.splev_arclength` and `scipy.interpolate.spline_arclength`
+  for arc-length parameterization of B-splines. These functions enable sampling
+  splines at equal arc-length intervals and computing total arc length, useful for
+  shape analysis, motion planning, and computer graphics applications.
+
 
 ``scipy.linalg`` improvements
 =============================

--- a/scipy/interpolate/__init__.py
+++ b/scipy/interpolate/__init__.py
@@ -116,6 +116,8 @@ functional.
    splrep
    splprep
    splev
+   splev_arclength
+   spline_arclength
    splint
    sproot
    spalde
@@ -193,6 +195,8 @@ from ._interpolate import *
 from ._fitpack_py import *
 
 from ._fitpack2 import *
+
+from ._arclength import splev_arclength, spline_arclength
 
 from ._rbf import Rbf
 

--- a/scipy/interpolate/_arclength.py
+++ b/scipy/interpolate/_arclength.py
@@ -69,6 +69,8 @@ def splev_arclength(tck, n_samples, u_range=None):
     that are equally spaced along the curve's arc length, rather than equally
     spaced in the parameter domain.
 
+    .. versionadded:: 1.18.0
+
     Parameters
     ----------
     tck : tuple
@@ -139,7 +141,8 @@ def splev_arclength(tck, n_samples, u_range=None):
         raise ValueError("n_samples must be a positive integer")
     
     # Extract arc-length derivative and metadata
-    arc_deriv, parametric, ndim, u_min_default, u_max_default = _make_arc_derivative(tck)
+    result = _make_arc_derivative(tck)
+    arc_deriv, parametric, ndim, u_min_default, u_max_default = result
     t, c, k = tck
     
     # Use provided range or default
@@ -195,6 +198,8 @@ def splev_arclength(tck, n_samples, u_range=None):
 def spline_arclength(tck, u_range=None):
     """
     Compute the arc length of a B-spline curve.
+
+    .. versionadded:: 1.18.0
 
     Parameters
     ----------

--- a/scipy/interpolate/_arclength.py
+++ b/scipy/interpolate/_arclength.py
@@ -2,9 +2,63 @@
 Arc-length parameterization utilities for splines.
 """
 import numpy as np
-from scipy.integrate import quad
-from scipy.interpolate import splev
+from scipy.integrate import quad, cumulative_trapezoid
+from scipy.interpolate import splev, interp1d
 from scipy.optimize import brentq
+
+
+__all__ = ['splev_arclength', 'spline_arclength']
+
+
+def _make_arc_derivative(tck):
+    """Create arc-length derivative function for a spline.
+    
+    Parameters
+    ----------
+    tck : tuple
+        A tuple (t, c, k) containing the vector of knots, the B-spline
+        coefficients, and the degree of the spline.
+    
+    Returns
+    -------
+    arc_deriv : callable
+        Function that computes ||dC/du|| at parameter u.
+    parametric : bool
+        Whether the curve is parametric (multi-dimensional).
+    ndim : int
+        Number of dimensions.
+    u_min : float
+        Minimum parameter value.
+    u_max : float
+        Maximum parameter value.
+    """
+    t, c, k = tck
+    
+    # Determine if parametric and extract dimensions
+    try:
+        c[0][0]
+        parametric = True
+        ndim = len(c)
+    except (TypeError, IndexError):
+        parametric = False
+        ndim = 1
+    
+    # Get parameter range from knot vector
+    u_min = t[k]
+    u_max = t[-k-1]
+    
+    # Create appropriate derivative function
+    if parametric:
+        def arc_deriv(u):
+            """Compute ||dC/du|| for parametric curve."""
+            derivs = [splev(u, [t, c[i], k], der=1) for i in range(ndim)]
+            return np.sqrt(sum(d**2 for d in derivs))
+    else:
+        def arc_deriv(u):
+            """Compute |dy/du| for 1D curve."""
+            return np.abs(splev(u, tck, der=1))
+    
+    return arc_deriv, parametric, ndim, u_min, u_max
 
 
 def splev_arclength(tck, n_samples, u_range=None):
@@ -22,7 +76,7 @@ def splev_arclength(tck, n_samples, u_range=None):
         coefficients, and the degree of the spline. For parametric curves,
         c should be a list of coefficient arrays for each dimension.
     n_samples : int
-        Number of points to sample along the curve.
+        Number of points to sample along the curve. Must be at least 1.
     u_range : tuple of float, optional
         (u_min, u_max) parameter range to consider. If None, uses the
         full knot range (t[k], t[-k-1]).
@@ -45,10 +99,13 @@ def splev_arclength(tck, n_samples, u_range=None):
         s(u) = \\int_{u_0}^{u} \\sqrt{\\sum_{i=1}^{n} (dx_i/du)^2} du
 
     The algorithm:
-    1. Computes the total arc length of the curve
-    2. Divides it into n_samples equal segments
-    3. For each segment, finds the parameter value u that corresponds
-       to that arc length using root-finding
+    1. Pre-samples the curve densely to build a cumulative arc-length table
+    2. Inverts this table via interpolation to map target arc lengths to
+       parameter values
+    3. Evaluates the spline at these parameter values
+
+    This approach is O(n) in the number of samples, compared to O(n²) for
+    naive root-finding methods.
 
     Examples
     --------
@@ -70,88 +127,65 @@ def splev_arclength(tck, n_samples, u_range=None):
     --------
     splprep : Find the B-spline representation of an N-D curve.
     splev : Evaluate a B-spline or its derivatives.
+    spline_arclength : Compute total arc length of a spline.
 
     References
     ----------
     .. [1] de Boor, C. (1978). A Practical Guide to Splines.
            Springer-Verlag.
     """
+    # Input validation
+    if not isinstance(n_samples, (int, np.integer)) or n_samples < 1:
+        raise ValueError("n_samples must be a positive integer")
+    
+    # Extract arc-length derivative and metadata
+    arc_deriv, parametric, ndim, u_min_default, u_max_default = _make_arc_derivative(tck)
     t, c, k = tck
     
-    # Determine if this is a parametric curve
-    try:
-        c[0][0]
-        parametric = True
-        ndim = len(c)
-    except (TypeError, IndexError):
-        parametric = False
-        ndim = 1
-    
-    # Determine parameter range
+    # Use provided range or default
     if u_range is None:
-        u_min = t[k]
-        u_max = t[-k-1]
+        u_min, u_max = u_min_default, u_max_default
     else:
         u_min, u_max = u_range
     
-    # Function to compute the arc length derivative (speed) at parameter u
-    def arc_length_derivative(u):
-        """Compute ||dC/du|| at parameter u."""
+    # Special case: single sample
+    if n_samples == 1:
+        u_values = np.array([u_min])
         if parametric:
-            # Evaluate first derivative for each dimension
-            derivs = [splev(u, [t, c[i], k], der=1) for i in range(ndim)]
-            # Compute Euclidean norm
-            return np.sqrt(sum(d**2 for d in derivs))
+            points = np.array([splev(u_min, [t, c[i], k]) for i in range(ndim)]).T
         else:
-            # For 1D curves, just absolute value of derivative
-            deriv = splev(u, tck, der=1)
-            return np.abs(deriv)
+            points = np.array([splev(u_min, tck)])
+        return points, u_values
     
-    # Compute cumulative arc length from u_min to a given u
-    def cumulative_arc_length(u):
-        """Integrate arc length from u_min to u."""
-        if u <= u_min:
-            return 0.0
-        result, _ = quad(arc_length_derivative, u_min, u, limit=100)
-        return result
+    # Pre-sample the curve to build cumulative arc-length table
+    # Use adaptive density: more samples for longer curves
+    n_dense = max(500, n_samples * 5)
+    u_dense = np.linspace(u_min, u_max, n_dense)
     
-    # Compute total arc length
-    total_length = cumulative_arc_length(u_max)
+    # Compute speeds at sample points
+    speeds = np.array([arc_deriv(u) for u in u_dense])
     
+    # Compute cumulative arc length using trapezoidal rule
+    s_dense = cumulative_trapezoid(speeds, u_dense, initial=0)
+    total_length = s_dense[-1]
+    
+    # Handle degenerate case
     if total_length == 0:
-        # Degenerate case: curve has no length
         u_values = np.linspace(u_min, u_max, n_samples)
     else:
         # Target arc lengths for each sample
         target_lengths = np.linspace(0, total_length, n_samples)
         
-        # Find parameter values corresponding to each target arc length
-        u_values = np.zeros(n_samples)
-        u_values[0] = u_min
-        u_values[-1] = u_max
-        
-        for i in range(1, n_samples - 1):
-            target = target_lengths[i]
-            
-            # Find u such that cumulative_arc_length(u) = target
-            # Use previous u as starting point for search
-            u_search_min = u_values[i-1]
-            u_search_max = u_max
-            
-            try:
-                # Root finding: find u where cumulative_arc_length(u) - target = 0
-                u_values[i] = brentq(
-                    lambda u: cumulative_arc_length(u) - target,
-                    u_search_min, u_search_max,
-                    xtol=1e-8
-                )
-            except ValueError:
-                # If root finding fails, fall back to linear interpolation
-                u_values[i] = u_min + (u_max - u_min) * target / total_length
+        # Invert cumulative arc length via interpolation
+        # Use cubic interpolation for smooth parameter distribution
+        s_to_u = interp1d(s_dense, u_dense, kind='cubic', 
+                         bounds_error=False, fill_value=(u_min, u_max))
+        u_values = s_to_u(target_lengths)
     
     # Evaluate the spline at the computed parameter values
     if parametric:
-        points = np.column_stack([splev(u_values, [t, c[i], k]) for i in range(ndim)])
+        points = np.column_stack([splev(u_values, [t, c[i], k]) 
+                                 for i in range(ndim)])
     else:
         points = splev(u_values, tck)
     
@@ -175,46 +209,38 @@ def spline_arclength(tck, u_range=None):
     length : float
         The arc length of the curve.
 
+    Notes
+    -----
+    The arc length is computed by numerical integration of the curve's
+    speed (magnitude of derivative) over the parameter domain.
+
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.interpolate import splprep
-    >>> from scipy.interpolate import spline_arclength
+    >>> from scipy.interpolate import splprep, spline_arclength
     >>> # Create a quarter circle
     >>> theta = np.linspace(0, np.pi/2, 10)
     >>> x = np.cos(theta)
     >>> y = np.sin(theta)
     >>> tck, u = splprep([x, y], s=0)
     >>> length = spline_arclength(tck)
-    >>> print(f"Arc length: {length:.4f}")  # Should be close to pi/2
+    >>> np.abs(length - np.pi/2) < 0.01
+    True
+
+    See Also
+    --------
+    splev_arclength : Sample spline at equal arc-length intervals.
+    splint : Integrate a B-spline between two points.
     """
-    t, c, k = tck
+    # Extract arc-length derivative and parameter range
+    arc_deriv, _, _, u_min_default, u_max_default = _make_arc_derivative(tck)
     
-    # Determine if parametric
-    try:
-        c[0][0]
-        parametric = True
-        ndim = len(c)
-    except (TypeError, IndexError):
-        parametric = False
-        ndim = 1
-    
-    # Determine parameter range
+    # Use provided range or default
     if u_range is None:
-        u_min = t[k]
-        u_max = t[-k-1]
+        u_min, u_max = u_min_default, u_max_default
     else:
         u_min, u_max = u_range
     
-    # Arc length derivative
-    def arc_length_derivative(u):
-        if parametric:
-            derivs = [splev(u, [t, c[i], k], der=1) for i in range(ndim)]
-            return np.sqrt(sum(d**2 for d in derivs))
-        else:
-            deriv = splev(u, tck, der=1)
-            return np.abs(deriv)
-    
-    # Integrate to get total length
-    length, _ = quad(arc_length_derivative, u_min, u_max, limit=100)
+    # Integrate speed to get total length
+    length, _ = quad(arc_deriv, u_min, u_max, limit=100)
     return length

--- a/scipy/interpolate/_arclength.py
+++ b/scipy/interpolate/_arclength.py
@@ -1,0 +1,220 @@
+"""
+Arc-length parameterization utilities for splines.
+"""
+import numpy as np
+from scipy.integrate import quad
+from scipy.interpolate import splev
+from scipy.optimize import brentq
+
+
+def splev_arclength(tck, n_samples, u_range=None):
+    """
+    Evaluate a B-spline at points equally spaced along the arc length.
+
+    Given a parametric spline curve, this function samples `n_samples` points
+    that are equally spaced along the curve's arc length, rather than equally
+    spaced in the parameter domain.
+
+    Parameters
+    ----------
+    tck : tuple
+        A tuple (t, c, k) containing the vector of knots, the B-spline
+        coefficients, and the degree of the spline. For parametric curves,
+        c should be a list of coefficient arrays for each dimension.
+    n_samples : int
+        Number of points to sample along the curve.
+    u_range : tuple of float, optional
+        (u_min, u_max) parameter range to consider. If None, uses the
+        full knot range (t[k], t[-k-1]).
+
+    Returns
+    -------
+    points : ndarray
+        Array of shape (n_samples, ndim) for parametric curves, or
+        (n_samples,) for 1D curves, containing the sampled points.
+    u_values : ndarray
+        Array of shape (n_samples,) containing the parameter values
+        corresponding to each sampled point.
+
+    Notes
+    -----
+    This function computes arc length by numerical integration of the
+    curve's derivative. For parametric curves in n dimensions:
+
+    .. math::
+        s(u) = \\int_{u_0}^{u} \\sqrt{\\sum_{i=1}^{n} (dx_i/du)^2} du
+
+    The algorithm:
+    1. Computes the total arc length of the curve
+    2. Divides it into n_samples equal segments
+    3. For each segment, finds the parameter value u that corresponds
+       to that arc length using root-finding
+
+    Examples
+    --------
+    Sample a 2D parametric curve (e.g., a circle) with equal arc-length spacing:
+
+    >>> import numpy as np
+    >>> from scipy.interpolate import splprep, splev_arclength
+    >>> # Create a circle
+    >>> theta = np.linspace(0, 2*np.pi, 20)
+    >>> x = np.cos(theta)
+    >>> y = np.sin(theta)
+    >>> # Fit a periodic spline
+    >>> tck, u = splprep([x, y], s=0, per=True)
+    >>> # Sample 100 equally-spaced points along arc length
+    >>> points, u_values = splev_arclength(tck, 100)
+    >>> # points[i] and points[i+1] are approximately the same distance apart
+
+    See Also
+    --------
+    splprep : Find the B-spline representation of an N-D curve.
+    splev : Evaluate a B-spline or its derivatives.
+
+    References
+    ----------
+    .. [1] de Boor, C. (1978). A Practical Guide to Splines.
+           Springer-Verlag.
+    """
+    t, c, k = tck
+    
+    # Determine if this is a parametric curve
+    try:
+        c[0][0]
+        parametric = True
+        ndim = len(c)
+    except (TypeError, IndexError):
+        parametric = False
+        ndim = 1
+    
+    # Determine parameter range
+    if u_range is None:
+        u_min = t[k]
+        u_max = t[-k-1]
+    else:
+        u_min, u_max = u_range
+    
+    # Function to compute the arc length derivative (speed) at parameter u
+    def arc_length_derivative(u):
+        """Compute ||dC/du|| at parameter u."""
+        if parametric:
+            # Evaluate first derivative for each dimension
+            derivs = [splev(u, [t, c[i], k], der=1) for i in range(ndim)]
+            # Compute Euclidean norm
+            return np.sqrt(sum(d**2 for d in derivs))
+        else:
+            # For 1D curves, just absolute value of derivative
+            deriv = splev(u, tck, der=1)
+            return np.abs(deriv)
+    
+    # Compute cumulative arc length from u_min to a given u
+    def cumulative_arc_length(u):
+        """Integrate arc length from u_min to u."""
+        if u <= u_min:
+            return 0.0
+        result, _ = quad(arc_length_derivative, u_min, u, limit=100)
+        return result
+    
+    # Compute total arc length
+    total_length = cumulative_arc_length(u_max)
+    
+    if total_length == 0:
+        # Degenerate case: curve has no length
+        u_values = np.linspace(u_min, u_max, n_samples)
+    else:
+        # Target arc lengths for each sample
+        target_lengths = np.linspace(0, total_length, n_samples)
+        
+        # Find parameter values corresponding to each target arc length
+        u_values = np.zeros(n_samples)
+        u_values[0] = u_min
+        u_values[-1] = u_max
+        
+        for i in range(1, n_samples - 1):
+            target = target_lengths[i]
+            
+            # Find u such that cumulative_arc_length(u) = target
+            # Use previous u as starting point for search
+            u_search_min = u_values[i-1]
+            u_search_max = u_max
+            
+            try:
+                # Root finding: find u where cumulative_arc_length(u) - target = 0
+                u_values[i] = brentq(
+                    lambda u: cumulative_arc_length(u) - target,
+                    u_search_min, u_search_max,
+                    xtol=1e-8
+                )
+            except ValueError:
+                # If root finding fails, fall back to linear interpolation
+                u_values[i] = u_min + (u_max - u_min) * target / total_length
+    
+    # Evaluate the spline at the computed parameter values
+    if parametric:
+        points = np.column_stack([splev(u_values, [t, c[i], k]) for i in range(ndim)])
+    else:
+        points = splev(u_values, tck)
+    
+    return points, u_values
+
+
+def spline_arclength(tck, u_range=None):
+    """
+    Compute the arc length of a B-spline curve.
+
+    Parameters
+    ----------
+    tck : tuple
+        A tuple (t, c, k) containing the vector of knots, the B-spline
+        coefficients, and the degree of the spline.
+    u_range : tuple of float, optional
+        (u_min, u_max) parameter range. If None, uses the full knot range.
+
+    Returns
+    -------
+    length : float
+        The arc length of the curve.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.interpolate import splprep
+    >>> from scipy.interpolate import spline_arclength
+    >>> # Create a quarter circle
+    >>> theta = np.linspace(0, np.pi/2, 10)
+    >>> x = np.cos(theta)
+    >>> y = np.sin(theta)
+    >>> tck, u = splprep([x, y], s=0)
+    >>> length = spline_arclength(tck)
+    >>> print(f"Arc length: {length:.4f}")  # Should be close to pi/2
+    """
+    t, c, k = tck
+    
+    # Determine if parametric
+    try:
+        c[0][0]
+        parametric = True
+        ndim = len(c)
+    except (TypeError, IndexError):
+        parametric = False
+        ndim = 1
+    
+    # Determine parameter range
+    if u_range is None:
+        u_min = t[k]
+        u_max = t[-k-1]
+    else:
+        u_min, u_max = u_range
+    
+    # Arc length derivative
+    def arc_length_derivative(u):
+        if parametric:
+            derivs = [splev(u, [t, c[i], k], der=1) for i in range(ndim)]
+            return np.sqrt(sum(d**2 for d in derivs))
+        else:
+            deriv = splev(u, tck, der=1)
+            return np.abs(deriv)
+    
+    # Integrate to get total length
+    length, _ = quad(arc_length_derivative, u_min, u_max, limit=100)
+    return length

--- a/scipy/interpolate/tests/test_arclength.py
+++ b/scipy/interpolate/tests/test_arclength.py
@@ -1,0 +1,239 @@
+"""
+Tests for arc-length parameterization of splines.
+"""
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_less
+import pytest
+from scipy.interpolate import splprep, splev, splev_arclength, spline_arclength
+
+
+class TestArcLength:
+    """Tests for arc-length spline functionality."""
+
+    def test_circle_arclength(self):
+        """Test that a circle has the correct arc length."""
+        # Create a unit circle
+        theta = np.linspace(0, 2*np.pi, 50, endpoint=False)
+        x = np.cos(theta)
+        y = np.sin(theta)
+        
+        # Fit a periodic spline
+        tck, u = splprep([x, y], s=0, per=True)
+        
+        # Compute arc length
+        length = spline_arclength(tck)
+        
+        # Should be close to 2*pi
+        assert_allclose(length, 2*np.pi, rtol=1e-3)
+
+    def test_equal_spacing_circle(self):
+        """Test that points sampled with equal arc length are equally spaced."""
+        # Create a circle
+        theta = np.linspace(0, 2*np.pi, 50, endpoint=False)
+        x = np.cos(theta)
+        y = np.sin(theta)
+        
+        # Fit a periodic spline
+        tck, u = splprep([x, y], s=0, per=True)
+        
+        # Sample with equal arc-length spacing
+        n_samples = 100
+        points, u_values = splev_arclength(tck, n_samples)
+        
+        # Compute distances between consecutive points
+        diffs = np.diff(points, axis=0)
+        distances = np.sqrt(np.sum(diffs**2, axis=1))
+        
+        # All distances should be approximately equal
+        mean_dist = np.mean(distances)
+        # Allow 5% tolerance
+        assert_allclose(distances, mean_dist, rtol=0.05)
+
+    def test_line_segment(self):
+        """Test arc-length sampling on a straight line."""
+        # Create a line from (0,0) to (3,4), length = 5
+        t_param = np.linspace(0, 1, 10)
+        x = 3 * t_param
+        y = 4 * t_param
+        
+        # Fit a spline
+        tck, u = splprep([x, y], s=0)
+        
+        # Compute arc length
+        length = spline_arclength(tck)
+        assert_allclose(length, 5.0, rtol=1e-3)
+        
+        # Sample with equal arc-length spacing
+        points, u_values = splev_arclength(tck, 11)
+        
+        # Compute distances
+        diffs = np.diff(points, axis=0)
+        distances = np.sqrt(np.sum(diffs**2, axis=1))
+        
+        # Should all be 0.5
+        assert_allclose(distances, 0.5, rtol=1e-2)
+
+    def test_1d_spline(self):
+        """Test that 1D splines work correctly."""
+        from scipy.interpolate import splrep
+        
+        # Simple 1D function
+        x = np.linspace(0, 2*np.pi, 20)
+        y = np.sin(x)
+        
+        # Fit spline
+        tck = splrep(x, y, s=0)
+        
+        # Compute arc length
+        length = spline_arclength(tck)
+        
+        # Arc length of sin from 0 to 2pi is approximately 7.64
+        assert length > 7.5
+        assert length < 8.0
+
+    def test_return_shapes(self):
+        """Test that return values have correct shapes."""
+        # 2D parametric curve
+        theta = np.linspace(0, np.pi, 20)
+        x = np.cos(theta)
+        y = np.sin(theta)
+        
+        tck, u = splprep([x, y], s=0)
+        
+        n_samples = 50
+        points, u_values = splev_arclength(tck, n_samples)
+        
+        # Check shapes
+        assert points.shape == (n_samples, 2)
+        assert u_values.shape == (n_samples,)
+        
+        # Check parameter ordering
+        assert np.all(np.diff(u_values) >= 0)  # Should be monotonically increasing
+
+    def test_partial_range(self):
+        """Test arc-length computation on a partial parameter range."""
+        # Create a circle
+        theta = np.linspace(0, 2*np.pi, 50, endpoint=False)
+        x = np.cos(theta)
+        y = np.sin(theta)
+        
+        tck, u = splprep([x, y], s=0, per=True)
+        
+        # Compute arc length for half the curve
+        u_min, u_max = 0.0, 0.5
+        half_length = spline_arclength(tck, u_range=(u_min, u_max))
+        
+        # Should be approximately pi (half of 2*pi)
+        full_length = spline_arclength(tck)
+        assert_allclose(half_length, full_length / 2, rtol=0.05)
+
+    def test_3d_curve(self):
+        """Test that 3D curves work correctly."""
+        # Create a helix
+        t = np.linspace(0, 4*np.pi, 100)
+        x = np.cos(t)
+        y = np.sin(t)
+        z = t
+        
+        # Fit spline
+        tck, u = splprep([x, y, z], s=0)
+        
+        # Sample with equal arc-length spacing
+        n_samples = 200
+        points, u_values = splev_arclength(tck, n_samples)
+        
+        # Check shape
+        assert points.shape == (n_samples, 3)
+        
+        # Compute distances
+        diffs = np.diff(points, axis=0)
+        distances = np.sqrt(np.sum(diffs**2, axis=1))
+        
+        # All distances should be approximately equal
+        mean_dist = np.mean(distances)
+        # Allow 10% tolerance for helix (more complex curve)
+        assert_allclose(distances, mean_dist, rtol=0.1)
+
+    def test_degenerate_curve(self):
+        """Test handling of degenerate (zero-length) curves."""
+        # All points the same
+        x = np.ones(10)
+        y = np.ones(10)
+        
+        tck, u = splprep([x, y], s=0)
+        
+        # Arc length should be zero
+        length = spline_arclength(tck)
+        assert_allclose(length, 0.0, atol=1e-10)
+        
+        # Sampling should not crash
+        points, u_values = splev_arclength(tck, 10)
+        assert points.shape == (10, 2)
+
+    def test_comparison_with_splev(self):
+        """Test that endpoints match regular splev evaluation."""
+        theta = np.linspace(0, np.pi, 20)
+        x = np.cos(theta)
+        y = np.sin(theta)
+        
+        tck, u = splprep([x, y], s=0)
+        
+        # Sample with arc-length
+        points, u_values = splev_arclength(tck, 50)
+        
+        # First and last points should match curve endpoints
+        t_knots = tck[0]
+        k = tck[2]
+        u_min = t_knots[k]
+        u_max = t_knots[-k-1]
+        
+        start_point = np.array(splev(u_min, tck))
+        end_point = np.array(splev(u_max, tck))
+        
+        assert_allclose(points[0], start_point, rtol=1e-5)
+        assert_allclose(points[-1], end_point, rtol=1e-5)
+
+
+class TestArcLengthEdgeCases:
+    """Test edge cases and error handling."""
+
+    def test_small_n_samples(self):
+        """Test with very small number of samples."""
+        theta = np.linspace(0, np.pi, 20)
+        x = np.cos(theta)
+        y = np.sin(theta)
+        
+        tck, u = splprep([x, y], s=0)
+        
+        # Should work with n_samples=2
+        points, u_values = splev_arclength(tck, 2)
+        assert points.shape == (2, 2)
+        
+        # Should work with n_samples=1
+        points, u_values = splev_arclength(tck, 1)
+        assert points.shape == (1, 2)
+
+    def test_high_curvature(self):
+        """Test with high curvature regions."""
+        # Create a sharp curve
+        t = np.linspace(0, 1, 100)
+        x = t
+        y = np.where(t < 0.5, 0, 10 * (t - 0.5)**2)
+        
+        tck, u = splprep([x, y], s=0)
+        
+        # Should handle high curvature
+        points, u_values = splev_arclength(tck, 100)
+        
+        # Check that spacing is more uniform than uniform parameter spacing
+        diffs = np.diff(points, axis=0)
+        arc_distances = np.sqrt(np.sum(diffs**2, axis=1))
+        
+        # Compare with uniform parameter spacing
+        u_uniform = np.linspace(u[0], u[-1], 100)
+        points_uniform = np.column_stack(splev(u_uniform, tck))
+        diffs_uniform = np.diff(points_uniform, axis=0)
+        uniform_distances = np.sqrt(np.sum(diffs_uniform**2, axis=1))
+        
+        # Arc-length spacing should be more uniform (lower std dev)
+        assert np.std(arc_distances) < np.std(uniform_distances)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->
N/A - This is a new feature enhancement without a corresponding issue.

#### What does this implement/fix?

Adds two functions for arc-length parameterization of B-splines to `scipy.interpolate`:

- `spline_arclength(tck)` — compute total arc length of a parametric curve
- `splev_arclength(tck, n_samples)` — sample points at equal arc-length intervals

**Motivation:**
Sampling splines at equal parameter intervals doesn't give equal spacing along the curve. This is needed for:
- Shape analysis (equal point contribution to descriptors)
- Motion planning (constant-speed traversal)  
- Computer graphics (uniform texture mapping)

**Implementation:**
Uses numerical integration of `||dC/du||` to compute cumulative arc length, then inverts via interpolation. O(n) complexity.

**Testing:**
Comprehensive tests including circle validation (arc length = 2π), equal spacing verification, edge cases, and 3D curves.

#### Additional information

**Prior art:**
Based on implementation in [uhlmanngroup/shape_embed](https://github.com/uhlmanngroup/shape_embed/blob/master/shape_embed/shapes/contours.py#L47).

**Documentation:**
- Added `.. versionadded:: 1.18.0` directives
- Full NumPy-style docstrings with examples
- Functions automatically included in API reference via `__all__` exports
