### PR TITLE
TST: cluster: fix flakiness in kmeans2 tests by using fixed RNG

### DIFF
--- a/scipy/cluster/vq/tests/test_vq.py
+++ b/scipy/cluster/vq/tests/test_vq.py
@@ -320,14 +320,16 @@ class TestKMeans:
     def test_kmeans2_rank1_2(self, xp):
         data = xp.asarray(TESTDATA_2D)
         data1 = data[:, 0]
-        kmeans2(data1, 2, iter=1)
+        rng = np.random.default_rng(42)
+        kmeans2(data1, 2, iter=1, rng=rng)
 
     def test_kmeans2_high_dim(self, xp):
         # test kmeans2 when the number of dimensions exceeds the number
         # of input points
         data = xp.asarray(TESTDATA_2D)
         data = xp.reshape(data, (20, 20))[:10, :]
-        kmeans2(data, 2)
+        rng = np.random.default_rng(42)
+        kmeans2(data, 2, rng=rng)     
 
     def test_kmeans2_init(self, xp):
         rng = np.random.default_rng(12345678)


### PR DESCRIPTION
This PR addresses the occasional failures in `test_kmeans2_rank1_2` and `test_kmeans2_high_dim` mentioned in #24002.

These tests occasionally failed (or raised a UserWarning) because random initialization could produce empty clusters. This PR makes the tests deterministic by using a fixed RNG so they behave consistently.

closes #24002