### PR TITLE
ENH: stats.DiscreteDistribution: entropy speedup

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -2334,9 +2334,9 @@ class UnivariateDistribution(_ProbabilityDistribution):
             logpxf = self._logpxf_dispatch(x, **params)
             temp = np.asarray(pxf)
             i = (pxf != 0)  # 0 * inf -> nan; should be 0
-            temp[i] = pxf[i]*logpxf[i]
+            temp[i] = -pxf[i]*logpxf[i]
             return temp
-        return -self._quadrature(integrand, params=params)
+        return self._quadrature(integrand, params=params)
 
     @_set_invalid_nan_property
     def median(self, *, method=None):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1146,7 +1146,7 @@ class TestMakeDistribution:
                 'johnsonsb', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'norminvgauss',
                 'powerlognorm', 'powernorm', 'recipinvgauss', 'studentized_range',
                 'vonmises_line', # continuous
-                'betanbinom', 'logser', 'skellam', 'zipf'}  # discrete
+                'betanbinom', 'logser', 'zipf'}  # discrete
         if not int(os.environ.get('SCIPY_XSLOW', '0')) and distname in slow:
             pytest.skip('Skipping as XSLOW')
 


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/24573#pullrequestreview-3806761887

#### What does this implement/fix?
https://github.com/scipy/scipy/pull/24573#pullrequestreview-3806761887 reminded me to take a closer look at why the `stats.make_distribution` version of `skellam.entropy` was so slow. This PR provides a very simple, objectively correct fix to speed it (and the entropy calculation of other discrete distributions) up.

#### Additional information
[`nsum`](https://docs.scipy.org/doc/scipy-1.16.2/reference/generated/scipy.integrate.nsum.html) expects the callable *f*  to be smooth, positive, and unimodal because it estimates the remainder of infinite sums using an integral, the accuracy of which is bounded using the same math as the [integral test for convergence](https://en.wikipedia.org/wiki/Integral_test_for_convergence) of an infinite series. It does not perform strict checks of this condition because it only *needs* to be satisfied for the portion of the sum that is not evaluated directly. The `DiscreteDistribution._entropy_quadrature` method did not satisfy this condition - the summand was *always* negative. This  led to `nsum` evaluating far too many terms directly instead of relying on the integral for the remainder. Perhaps I didn't notice the poor performance for other distribution entropies because those summands are less time consuming to evaluate, and so I attributed the slow speed to difficulties particular to `skellam`? In any case, the fix is to ensure that the summand is always negative and remove the negative sign that was applied to the result.