### PR TITLE
BUG: Split edge_offsets/data_offsets error checks in NI_GeometricTransform

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -295,8 +295,13 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
 
     /* offsets used at the borders: */
     edge_offsets = malloc(irank * sizeof(npy_intp*));
+    if (NPY_UNLIKELY(!edge_offsets)) {
+        NPY_END_THREADS;
+        PyErr_NoMemory();
+        goto exit;
+    }
     data_offsets = malloc(irank * sizeof(npy_intp*));
-    if (NPY_UNLIKELY(!edge_offsets || !data_offsets)) {
+    if (NPY_UNLIKELY(!data_offsets)) {
         NPY_END_THREADS;
         PyErr_NoMemory();
         goto exit;


### PR DESCRIPTION
The combined check allowed a path where edge_offsets fails but data_offsets succeeds, reaching cleanup before data_offsets elements are NULL-initialized.

Completes the fix in 339ccf65c3.

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->
