### PR TITLE
BUG: ndimage: fix aliasing in _init_causal_reflect for small arrays

### DIFF
--- a/scipy/ndimage/src/ni_splines.c
+++ b/scipy/ndimage/src/ni_splines.c
@@ -213,15 +213,14 @@ _init_causal_reflect(double *c, const npy_intp n, const double z)
     npy_intp i;
     double z_i = z;
     const double z_n = pow(z, n);
-    const double c0 = c[0];
+    double sum;
 
-    c[0] = c[0] + z_n * c[n - 1];
+    sum = c[0] + z_n * c[n - 1];
     for (i = 1; i < n; ++i) {
-        c[0] += z_i * (c[i] + z_n * c[n - 1 - i]);
+        sum += z_i * (c[i] + z_n * c[n - 1 - i]);
         z_i *= z;
     }
-    c[0] *= z / (1 - z_n * z_n);
-    c[0] += c0;
+    c[0] += sum * z / (1 - z_n * z_n);
 }
 
 

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -623,6 +623,35 @@ class TestMapCoordinates:
         except MemoryError as e:
             raise pytest.skip('Not enough memory available') from e
 
+    @xfail_xp_backends("cupy", reason="CuPy map_coordinates has the same aliasing bug")
+    @pytest.mark.parametrize('n_channels', range(1, 4))
+    @pytest.mark.parametrize('order', range(2, 6))
+    def test_map_coordinates_reflect_multichannel(self, n_channels, order, xp):
+        # Regression test for gh-24550: reflect mode spline prefilter had an
+        # aliasing bug that caused accuracy loss for multi-channel images.
+        if is_jax(xp) and order > 1:
+            pytest.xfail("jax map_coordinates requires order <= 1")
+
+        rng = np.random.default_rng(4567)
+        image = xp.asarray(rng.random((8, 8)), dtype=xp.float64)
+        coords = xp.asarray(rng.random((2, 5, 5)) * 7)
+
+        single = ndimage.map_coordinates(image, coords, order=order,
+                                         mode='reflect')
+
+        color = xp.stack([image] * n_channels, axis=-1)
+        channels = np.broadcast_to(np.arange(n_channels),
+                                   (1, 5, 5, n_channels))
+        coords_color = np.broadcast_to(
+            np.asarray(coords)[..., np.newaxis], (2, 5, 5, n_channels))
+        coords_color = xp.asarray(np.concatenate(
+            (coords_color, channels), axis=0))
+
+        multi = ndimage.map_coordinates(color, coords_color, order=order,
+                                        mode='reflect')
+        expected = xp.stack([single] * n_channels, axis=-1)
+        xp_assert_close(multi, expected)
+
 
 @make_xp_test_case(ndimage.affine_transform)
 class TestAffineTransform:

--- a/scipy/ndimage/tests/test_splines.py
+++ b/scipy/ndimage/tests/test_splines.py
@@ -2,9 +2,12 @@
 import pytest
 
 import numpy as np
-from scipy._lib._array_api import assert_almost_equal, make_xp_test_case
-
+from scipy._lib._array_api import (
+    assert_almost_equal, xp_assert_close, make_xp_test_case,
+)
 from scipy import ndimage
+
+xfail_xp_backends = pytest.mark.xfail_xp_backends
 
 
 def get_spline_knot_values(order):
@@ -66,3 +69,17 @@ def test_spline_filter_vs_matrix_solution(order, mode, xp):
     matrix = make_spline_knot_matrix(xp, n, order, mode=mode)
     assert_almost_equal(eye, spline_filter_axis_0 @ matrix)
     assert_almost_equal(eye, spline_filter_axis_1 @ matrix.T)
+
+
+@make_xp_test_case(ndimage.spline_filter1d)
+@xfail_xp_backends("cupy", reason="CuPy spline_filter1d has the same aliasing bug")
+@pytest.mark.parametrize('order', [2, 3, 4, 5])
+@pytest.mark.parametrize('n', [2, 3, 4, 5])
+def test_spline_filter_reflect_small_n(order, n, xp):
+    # Regression test for gh-24550: the causal reflect initialization had an
+    # aliasing bug where c[0] was read back after mutation via c[n-1-i].
+    # For large n the error is negligible, but for small n it is significant.
+    eye = xp.eye(n, dtype=xp.float64)
+    filtered = ndimage.spline_filter1d(eye, axis=0, order=order, mode='reflect')
+    matrix = make_spline_knot_matrix(xp, n, order, mode='reflect')
+    xp_assert_close(filtered @ matrix, eye, atol=1e-12)


### PR DESCRIPTION
#### Reference issue

Closes gh-24550

#### What does this implement/fix?

The causal reflect initialization in `_init_causal_reflect` accumulated
the sum directly into `c[0]`, but on the last loop iteration `c[n-1-i]`
aliases `c[0]`, reading the already-modified value. The error scales with
z^(2n), so it's negligible for large arrays but significant when n is
small (2 or 3), which happens with multi-channel images.

The fix accumulates into a local variable instead of mutating `c[0]`
during the loop.

#### Additional information

Regression test added in `test_splines.py` that verifies the spline
filter matrix identity for small n with reflect mode.