### PR TITLE
DOC: stats.UnivariateDistribution.sample: update documentation regarding QRNGs

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -2977,8 +2977,6 @@ class UnivariateDistribution(_ProbabilityDistribution):
     # See the note corresponding with the "Distribution Parameters" for more
     # information.
 
-    # TODO:
-    #  - should we accept a QRNG with `d != 1`?
     def sample(self, shape=(), *, method=None, rng=None):
         # needs output validation to ensure that developer returns correct
         # dtype and shape

--- a/scipy/stats/_probability_distribution.py
+++ b/scipy/stats/_probability_distribution.py
@@ -131,19 +131,22 @@ class _ProbabilityDistribution(ABC):
             Not all `method` options are available for all distributions.
             If the selected `method` is not available, a `NotImplementedError``
             will be raised.
-        rng : `numpy.random.Generator` or `scipy.stats.QMCEngine`, optional
+        rng : `numpy.random.Generator` or `scipy.stats.qmc.QMCEngine`, optional
             Pseudo- or quasi-random number generator state. When `rng` is None,
             a new `numpy.random.Generator` is created using entropy from the
             operating system. Types other than `numpy.random.Generator` and
-            `scipy.stats.QMCEngine` are passed to `numpy.random.default_rng`
+            `scipy.stats.qmc.QMCEngine` are passed to `numpy.random.default_rng`
             to instantiate a ``Generator``.
 
-            If `rng` is an instance of `scipy.stats.QMCEngine` configured to use
+            If `rng` is an instance of `scipy.stats.qmc.QMCEngine` configured to use
             scrambling and `shape` is not empty, then each slice along the zeroth
             axis of the result is a "quasi-independent", low-discrepancy sequence;
             that is, they are distinct sequences that can be treated as statistically
             independent for most practical purposes. Separate calls to `sample`
-            produce new quasi-independent, low-discrepancy sequences.
+            produce new quasi-independent, low-discrepancy sequences. The dimensionality
+            (``d``) of the provided ``QMCEngine`` is ignored; new instances of the same
+            class and configuration options (``scramble``, ``optimization``, and
+            ``bits``, where applicable) will be created with ``d=1``.
 
         References
         ----------


### PR DESCRIPTION
#### Reference issue
gh-21871 

#### What does this implement/fix?
While reading comments in the distribution infrastructure code, I noticed:

```
- should we accept a QRNG with `d != 1`?
```

In gh-21871, we *did* accept a `QMCEngine` with `d !=1`:

```python3
from scipy import stats
qrng = stats.qmc.Halton(d=2)
stats.Normal().sample(rng=qrng)
# np.float64(0.6253436215002092)
```

This is natural because we *have* to recreate `QMCEngine`s with spawned generators in order to get independent samples, and it only makes sense to generate them with `d=1`. We *could* go through the effort of rejecting `QMCEngine`s with `d != 1` , but I don't think the benefit (alerting the user to potential misunderstanding) is worth the cost (to me - someone else is welcome to spearhead a change in behavior, and I'd be willing to review it).

#### Additional information
This also fixes links to `scipy.stats.qmc.QMCEngine` in the `stats.UnivariateDistribution.sample` documentation.