### PR TITLE
MAINT: stats._logexpxmexpy: simplify implementation

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -1224,18 +1224,9 @@ def _logexpxmexpy(x, y):
 
     Avoids over/underflow, but does not prevent loss of precision otherwise.
     """
-    # TODO: properly avoid NaN when y is negative infinity
-    # TODO: silence warning with taking log of complex nan
-    # TODO: deal with x == y better
-    i = np.isneginf(np.real(y))
-    if np.any(i):
-        y = np.asarray(y.copy())
-        y[i] = np.finfo(y.dtype).min
-    x, y = np.broadcast_arrays(x, y)
-    res = np.asarray(special.logsumexp([x, y+np.pi*1j], axis=0))
-    i = (x == y)
-    res[i] = -np.inf
-    return res
+    return xpx.apply_where(x != y, (x, y),
+                           lambda x, y: special.logsumexp([x, y+np.pi*1j], axis=0),
+                           fill_value=-np.inf)
 
 
 def _guess_bracket(xmin, xmax):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -19,7 +19,7 @@ from scipy.stats._distr_params import distcont, distdiscrete
 from scipy.stats._distribution_infrastructure import (
     _Domain, _RealInterval, _Parameter, _Parameterization, _RealParameter,
     ContinuousDistribution, ShiftedScaledDistribution, _fiinfo,
-    _generate_domain_support, Mixture)
+    _generate_domain_support, Mixture, _logexpxmexpy)
 from scipy.stats._new_distributions import StandardNormal, _LogUniform, _Gamma
 from scipy.stats._new_distributions import DiscreteDistribution
 from scipy.stats import Normal, Logistic, Uniform, Binomial
@@ -2242,3 +2242,23 @@ def test_zipfian_distribution_wrapper():
     zdist = Zipfian(a=0.75, n=15)
     # This should not generate any warnings.
     assert_equal(zdist.cdf(15), 1.0)
+
+
+class Test_logexpxmexpy:
+    # Regression tests for some cases that the simplest version of `_logexpmexpy`
+    # did not originally handle correctly.
+
+    def test_x_equals_y(self):
+        # Test x - x == 0 in log-space
+        x = np.asarray(2.)
+        assert_equal(_logexpxmexpy(x, x), -np.inf)
+
+    def test_y_neg_inf(self):
+        # Test x - 0 == x in log-space
+        x, y = np.asarray(2.), np.asarray(-inf)
+        assert_equal(_logexpxmexpy(x, y), x)
+
+    def test_nan(self):
+        # operations involving NaNs should not produce warnings
+        x = np.asarray(np.nan)
+        assert_equal(_logexpxmexpy(x, x), x)


### PR DESCRIPTION
#### Reference issue
gh-24616

#### What does this implement/fix?
While reading comments in the distribution infrastructure code, I noticed several in `_logexpxmexpy`:
```
    # TODO: properly avoid NaN when y is negative infinity
    # TODO: silence warning with taking log of complex nan
    # TODO: deal with x == y better
```

This PR addresses the comments.

#### Additional information
I think the `y = -np.inf` issue was fixed by improvements in `scipy.special.logsumexp`. I am also not seeing any warnings when (real or complex) NaNs are involved. Dealing with `x == y` is the only thing that has a special case here. I tried to improve `logsumexp` in this regard, and I prototyped a fix the particular case of `logsumexp([x, x + 1j * np.pi])`, which is enough for this private function. However, that didn't fix more complicated cases of exact cancellation, so I chose not to add the extra complexity to `logsumexp` at this time.

Another option that I pursued was something using the `b` argument of `logsumexp`:
```python3
res, sign = special.logsumexp([x, y], b=[1, -1], return_sign=True, axis=0)
```
This avoids the need to special-case `x = y`, but we typically want the result to be complex, so I went this route. Otherwise, I would have been tempted to do something like:
```python3
return res + np.where(sign == -1, 1j * np.pi, 0j)
```
which doesn't look much simpler.