### PR TITLE
MAINT: stats.order_statistic: reinforce parameter integrality

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4949,12 +4949,10 @@ class OrderStatisticDistribution(TransformedDistribution):
 
     """
 
-    # These can be restricted to _IntegerInterval/_IntegerParameter in a separate
-    # PR if desired.
-    _r_domain = _RealInterval(endpoints=(1, 'n'), inclusive=(True, True))
+    _r_domain = _IntegerInterval(endpoints=(1, 'n'), inclusive=(True, True))
     _r_param = _RealParameter('r', domain=_r_domain, typical=(1, 2))
 
-    _n_domain = _RealInterval(endpoints=(1, np.inf), inclusive=(True, True))
+    _n_domain = _IntegerInterval(endpoints=(1, np.inf), inclusive=(True, True))
     _n_param = _RealParameter('n', domain=_n_domain, typical=(1, 4))
 
     _r_domain.define_parameters(_n_param)


### PR DESCRIPTION
#### Reference issue
gh-24616
gh-22312

#### What does this implement/fix?
While reading comments in the distribution infrastructure code, I noticed the comment in `OrderStatisticDistribution`:
```
These can be restricted to _IntegerInterval/_IntegerParameter in a separate PR if desired
```

I guess we missed the opportunity to change the `r` and `n` shape parameters of `OrderStatisticDistribution` to use `_IntegerInterval` when it was added in gh-22312. 

This PR addresses the comment. 

#### Additional information
We decided there was no need for an `_IntegerParameter`, only `_IntegerInterval`, so the suggested change is complete.

There is actually no functional difference since the public interface of `order_statistic` raises an error if any of the shape parameters are non-integral. (Otherwise, the difference between `_IntegerInterval` and `_RealInterval` is that non-integral values would be converted to NaNs.)