### PR TITLE
DOC: stats: hide private result classes toctree

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -578,17 +578,9 @@ Warnings / Errors used in :mod:`scipy.stats`
    NearConstantInputWarning
    FitError
 
-Result classes used in :mod:`scipy.stats`
------------------------------------------
-
-.. warning::
-
-    These classes are private, but they are included here because instances
-    of them are returned by other statistical functions. User import and
-    instantiation is not supported.
-
 .. toctree::
    :maxdepth: 2
+   :hidden:
 
    stats._result_classes
 

--- a/scipy/stats/_result_classes.py
+++ b/scipy/stats/_result_classes.py
@@ -21,13 +21,14 @@ Result classes
    TtestResult
    ECDFResult
    EmpiricalDistributionFunction
+   SignificanceResult
 
 """
 
 __all__ = ['BinomTestResult', 'RelativeRiskResult', 'TukeyHSDResult',
            'PearsonRResult', 'FitResult', 'OddsRatioResult',
            'TtestResult', 'DunnettResult', 'ECDFResult',
-           'EmpiricalDistributionFunction']
+           'EmpiricalDistributionFunction', 'SignificanceResult']
 
 
 from ._binomtest import BinomTestResult
@@ -38,3 +39,4 @@ from ._multicomp import DunnettResult
 from ._stats_py import PearsonRResult, TtestResult
 from ._fit import FitResult
 from ._survival import ECDFResult, EmpiricalDistributionFunction
+from ._stats_py import SignificanceResult


### PR DESCRIPTION
#### Reference issue
gh-24427

#### What does this implement/fix?
gh-24427 made me wonder why we describe classes as prive but show them on the main stats documentation page. This PR experiments with making them hidden but still allowing their documentation page and references to it to render.