### PR TITLE
TST: sparse.linalg.LinearOperator: prepare `test_interface` for array API

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -51,10 +51,12 @@ import numpy as np
 from scipy import sparse
 from scipy.sparse import issparse
 from scipy.sparse._sputils import asmatrix, is_pydata_spmatrix, isintlike, isshape
+from scipy._lib._array_api import xp_capabilities
 
 __all__ = ["LinearOperator", "aslinearoperator"]
 
 
+@xp_capabilities(np_only=True)
 class LinearOperator:
     """Common interface for performing matrix vector products.
 

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -14,7 +14,8 @@ from numpy.testing import assert_, assert_equal
 
 import numpy as np
 from scipy._lib._array_api import (
-    make_xp_test_case, xp_assert_close, xp_assert_equal, xp_ravel, is_numpy,
+    SCIPY_ARRAY_API, make_xp_test_case, xp_assert_close, xp_assert_equal, xp_ravel,
+    is_numpy,
 )
 from scipy._external import array_api_extra as xpx
 import scipy.sparse as sparse
@@ -87,7 +88,7 @@ class TestLinearOperator:
             xp_assert_equal(A.dot(_asarray([1,2,3])), _asarray([14,32]))
             xp_assert_equal(A.dot(_asarray([[1],[2],[3]])), _asarray([[14],[32]]))
 
-            if is_numpy(xp):
+            if not SCIPY_ARRAY_API:
                 xp_assert_equal(
                     A.matvec(matrix([[1],[2],[3]])),
                     _asarray([[14],[32]]),
@@ -150,7 +151,7 @@ class TestLinearOperator:
             assert isinstance(A.dot(_asarray([1,2,3])), array_object)
             assert isinstance(A.dot(_asarray([[1],[2],[3]])), array_object)
 
-            if is_numpy(xp):
+            if not SCIPY_ARRAY_API:
                 assert isinstance(A.matvec(matrix([[1],[2],[3]])), array_object)
                 assert isinstance(A @ matrix([[1],[2],[3]]), array_object)
                 assert isinstance(A.dot(matrix([[1],[2],[3]])), array_object)

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -5,13 +5,18 @@ import contextlib
 from functools import partial
 from itertools import product
 import operator
-from typing import NamedTuple, Literal
+from types import ModuleType
+from typing import NamedTuple
 
 import pytest
 from pytest import raises as assert_raises, warns
-from numpy.testing import assert_, assert_equal, assert_allclose
+from numpy.testing import assert_, assert_equal
 
 import numpy as np
+from scipy._lib._array_api import (
+    make_xp_test_case, xp_assert_close, xp_assert_equal, xp_ravel, is_numpy,
+)
+from scipy._external import array_api_extra as xpx
 import scipy.sparse as sparse
 
 import scipy.sparse.linalg._interface as interface
@@ -43,6 +48,7 @@ def generate_broadcastable_shapes(nshapes, *, ndim=2, min=0, max=10, rng=None):
     return [tuple(int(el) for el in shape) for shape in shapes]
 
 
+@make_xp_test_case(interface.LinearOperator)
 class TestLinearOperator:
     def setup_method(self):
         self.A = np.array([[1,2,3],
@@ -53,224 +59,245 @@ class TestLinearOperator:
         self.C = np.array([[1,2],
                            [3,4]])
 
-    def test_matvec(self):
+    def test_matvec(self, xp):
         def get_matvecs(A):
             return [{
-                        'shape': A.shape,
-                        'matvec': lambda x: np.dot(A, x).reshape(A.shape[0]),
-                        'rmatvec': lambda x: np.dot(A.T.conj(),
-                                                    x).reshape(A.shape[1])
-                    },
-                    {
-                        'shape': A.shape,
-                        'matvec': lambda x: np.dot(A, x),
-                        'rmatvec': lambda x: np.dot(A.T.conj(), x),
-                        'rmatmat': lambda x: np.dot(A.T.conj(), x),
-                        'matmat': lambda x: np.dot(A, x)
-                    }]
+                'shape': A.shape,
+                'matvec': lambda x: A @ x,
+                'rmatvec': lambda x: xp.conj(A.T) @ x,
+                'rmatmat': lambda x: xp.conj(A.T) @ x,
+                'matmat': lambda x: A @ x
+            }]
+        
+        _asarray = partial(xp.asarray, dtype=xp.complex128)
 
-        for matvecs in get_matvecs(self.A):
+        for matvecs in get_matvecs(_asarray(self.A)):
             A = interface.LinearOperator(**matvecs)
 
-            assert_(A.args == ())
+            assert A.args == ()
 
-            assert_equal(A.matvec(np.array([1,2,3])), [14,32])
+            xp_assert_equal(A.matvec(xp.asarray([1,2,3])), _asarray([14,32]))
             with pytest.warns(FutureWarning, match="column vectors"):
-                assert_equal(A.matvec(np.array([[1],[2],[3]])), [[14],[32]])
-            assert_equal(A @ np.array([1,2,3]), [14,32])
-            assert_equal(A @ np.array([[1],[2],[3]]), [[14],[32]])
-            assert_equal(A.dot(np.array([1,2,3])), [14,32])
-            assert_equal(A.dot(np.array([[1],[2],[3]])), [[14],[32]])
+                xp_assert_equal(
+                    A.matvec(xp.asarray([[1],[2],[3]])),
+                    _asarray([[14],[32]]),
+                )
+            xp_assert_equal(A @ _asarray([1,2,3]), _asarray([14,32]))
+            xp_assert_equal(A @ _asarray([[1],[2],[3]]), _asarray([[14],[32]]))
+            xp_assert_equal(A.dot(_asarray([1,2,3])), _asarray([14,32]))
+            xp_assert_equal(A.dot(_asarray([[1],[2],[3]])), _asarray([[14],[32]]))
 
-            assert_equal(A.matvec(matrix([[1],[2],[3]])), [[14],[32]])
-            assert_equal(A @ matrix([[1],[2],[3]]), [[14],[32]])
-            assert_equal(A.dot(matrix([[1],[2],[3]])), [[14],[32]])
+            # if is_numpy(xp):
+            #     xp_assert_equal(
+            #         A.matvec(matrix([[1],[2],[3]])),
+            #         _asarray([[14],[32]]),
+            #     )
+            #     xp_assert_equal(A @ matrix([[1],[2],[3]]), _asarray([[14],[32]]))
+            #     xp_assert_equal(A.dot(matrix([[1],[2],[3]])), _asarray([[14],[32]]))
 
-            assert_equal((2*A)@[1,1,1], [12,30])
-            assert_equal((2 * A).rmatvec([1, 1]), [10, 14, 18])
-            assert_equal((2*A).H.matvec([1,1]), [10, 14, 18])
-            assert_equal((2*A).adjoint().matvec([1,1]), [10, 14, 18])
-            assert_equal((2*A)@[[1],[1],[1]], [[12],[30]])
-            assert_equal((2 * A).matmat([[1], [1], [1]]), [[12], [30]])
-            assert_equal((A*2)@[1,1,1], [12,30])
-            assert_equal((A*2)@[[1],[1],[1]], [[12],[30]])
-            assert_equal((2j*A)@[1,1,1], [12j,30j])
-            assert_equal((A+A)@[1,1,1], [12, 30])
-            assert_equal((A + A).rmatvec([1, 1]), [10, 14, 18])
-            assert_equal((A+A).H.matvec([1,1]), [10, 14, 18])
-            assert_equal((A+A).adjoint().matvec([1,1]), [10, 14, 18])
-            assert_equal((A+A)@[[1],[1],[1]], [[12], [30]])
-            assert_equal((A+A).matmat([[1],[1],[1]]), [[12], [30]])
-            assert_equal((-A)@[1,1,1], [-6,-15])
-            assert_equal((-A)@[[1],[1],[1]], [[-6],[-15]])
-            assert_equal((A-A)@[1,1,1], [0,0])
-            assert_equal((A - A) @ [[1], [1], [1]], [[0], [0]])
+            xp_assert_equal((2*A) @ _asarray([1,1,1]), _asarray([12,30]))
+            xp_assert_equal((2 * A).rmatvec(_asarray([1, 1])), _asarray([10, 14, 18]))
+            xp_assert_equal((2*A).H.matvec(_asarray([1,1])), _asarray([10, 14, 18]))
+            xp_assert_equal(
+                (2*A).adjoint().matvec(_asarray([1,1])),
+                _asarray([10, 14, 18]),
+            )
+            xp_assert_equal((2*A) @ _asarray([[1],[1],[1]]), _asarray([[12],[30]]))
+            xp_assert_equal(
+                (2 * A).matmat(_asarray([[1], [1], [1]])),
+                _asarray([[12], [30]]),
+            )
+            xp_assert_equal((A*2) @ _asarray([1,1,1]), _asarray([12,30]))
+            xp_assert_equal((A*2) @ _asarray([[1],[1],[1]]), _asarray([[12],[30]]))
+            xp_assert_equal((2j*A) @ _asarray([1,1,1]), _asarray([12j,30j]))
+            xp_assert_equal((A+A) @ _asarray([1,1,1]), _asarray([12, 30]))
+            xp_assert_equal((A + A).rmatvec([1, 1]), _asarray([10, 14, 18]))
+            xp_assert_equal((A+A).H.matvec([1,1]), _asarray([10, 14, 18]))
+            xp_assert_equal((A+A).adjoint().matvec([1,1]), _asarray([10, 14, 18]))
+            xp_assert_equal((A+A) @ _asarray([[1],[1],[1]]), _asarray([[12], [30]]))
+            xp_assert_equal(
+                (A+A).matmat(_asarray([[1],[1],[1]])),
+                _asarray([[12], [30]])
+            )
+            xp_assert_equal((-A) @ _asarray([1,1,1]), _asarray([-6,-15]))
+            xp_assert_equal((-A) @ _asarray([[1],[1],[1]]), _asarray([[-6],[-15]]))
+            xp_assert_equal((A-A) @ _asarray([1,1,1]), _asarray([0,0]))
+            xp_assert_equal((A - A) @ _asarray([[1], [1], [1]]), _asarray([[0], [0]]))
 
-            X = np.array([[1, 2], [3, 4]])
-            # A_asarray = np.array([[1, 2, 3], [4, 5, 6]])
-            assert_equal((2 * A).rmatmat(X), np.dot((2 * self.A).T, X))
-            assert_equal((A * 2).rmatmat(X), np.dot((self.A * 2).T, X))
-            assert_equal((2j * A).rmatmat(X),
-                         np.dot((2j * self.A).T.conj(), X))
-            assert_equal((A * 2j).rmatmat(X),
-                         np.dot((self.A * 2j).T.conj(), X))
-            assert_equal((A + A).rmatmat(X),
-                         np.dot((self.A + self.A).T, X))
-            assert_equal((A + 2j * A).rmatmat(X),
-                         np.dot((self.A + 2j * self.A).T.conj(), X))
-            assert_equal((-A).rmatmat(X), np.dot((-self.A).T, X))
-            assert_equal((A - A).rmatmat(X),
-                         np.dot((self.A - self.A).T, X))
-            assert_equal((2j * A).rmatmat(2j * X),
-                         np.dot((2j * self.A).T.conj(), 2j * X))
+            A_ = xp.asarray(self.A, dtype=xp.complex128)
+            X = xp.asarray([[1, 2], [3, 4]], dtype=xp.complex128)
+            xp_assert_equal((2 * A).rmatmat(X), (2 * A_).T @ X)
+            xp_assert_equal((A * 2).rmatmat(X), (A_ * 2).T @ X)
+            xp_assert_equal((2j * A).rmatmat(X), xp.conj((2j * A_).T) @ X)
+            xp_assert_equal((A * 2j).rmatmat(X), xp.conj((A_ * 2j).T) @ X)
+            xp_assert_equal((A + A).rmatmat(X), (A_ + A_).T @ X)
+            xp_assert_equal((A + 2j * A).rmatmat(X), xp.conj((A_ + 2j * A_).T) @ X)
+            xp_assert_equal((-A).rmatmat(X), (-A_).T @ X)
+            xp_assert_equal((A - A).rmatmat(X), (A_ - A_).T @ X)
+            xp_assert_equal((2j * A).rmatmat(2j * X), xp.conj((2j * A_).T) @ (2j * X))
 
             z = A+A
-            assert_(len(z.args) == 2 and z.args[0] is A and z.args[1] is A)
+            assert len(z.args) == 2 and z.args[0] is A and z.args[1] is A
             z = 2*A
-            assert_(len(z.args) == 2 and z.args[0] is A and z.args[1] == 2)
+            assert len(z.args) == 2 and z.args[0] is A and z.args[1] == 2
 
-            assert_(isinstance(A.matvec([1, 2, 3]), np.ndarray))
+            array_object = type(xp.empty(0))
+            assert isinstance(A.matvec([1, 2, 3]), array_object)
             with pytest.warns(FutureWarning, match="column vectors"):
-                assert_(isinstance(A.matvec(np.array([[1],[2],[3]])), np.ndarray))
-            assert_(isinstance(A @ np.array([1,2,3]), np.ndarray))
-            assert_(isinstance(A @ np.array([[1],[2],[3]]), np.ndarray))
-            assert_(isinstance(A.dot(np.array([1,2,3])), np.ndarray))
-            assert_(isinstance(A.dot(np.array([[1],[2],[3]])), np.ndarray))
+                assert isinstance(A.matvec(_asarray([[1],[2],[3]])), array_object)
+            assert isinstance(A @ _asarray([1,2,3]), array_object)
+            assert isinstance(A @ _asarray([[1],[2],[3]]), array_object)
+            assert isinstance(A.dot(_asarray([1,2,3])), array_object)
+            assert isinstance(A.dot(_asarray([[1],[2],[3]])), array_object)
 
-            assert_(isinstance(A.matvec(matrix([[1],[2],[3]])), np.ndarray))
-            assert_(isinstance(A @ matrix([[1],[2],[3]]), np.ndarray))
-            assert_(isinstance(A.dot(matrix([[1],[2],[3]])), np.ndarray))
+            # if is_numpy(xp):
+            #     assert isinstance(A.matvec(matrix([[1],[2],[3]])), array_object)
+            #     assert isinstance(A @ matrix([[1],[2],[3]]), array_object)
+            #     assert isinstance(A.dot(matrix([[1],[2],[3]])), array_object)
 
-            assert_(isinstance(2*A, interface._ScaledLinearOperator))
-            assert_(isinstance(2j*A, interface._ScaledLinearOperator))
-            assert_(isinstance(A+A, interface._SumLinearOperator))
-            assert_(isinstance(-A, interface._ScaledLinearOperator))
-            assert_(isinstance(A-A, interface._SumLinearOperator))
-            assert_(isinstance(A/2, interface._ScaledLinearOperator))
-            assert_(isinstance(A/2j, interface._ScaledLinearOperator))
-            assert_(((A * 3) / 3).args[0] is A)  # check for simplification
+            assert isinstance(2*A, interface._ScaledLinearOperator)
+            assert isinstance(2j*A, interface._ScaledLinearOperator)
+            assert isinstance(A+A, interface._SumLinearOperator)
+            assert isinstance(-A, interface._ScaledLinearOperator)
+            assert isinstance(A-A, interface._SumLinearOperator)
+            assert isinstance(A/2, interface._ScaledLinearOperator)
+            assert isinstance(A/2j, interface._ScaledLinearOperator)
+
+            assert ((A * 3) / 3).args[0] is A  # check for simplification
 
             # Test that prefactor is of _ScaledLinearOperator is not mutated
             # when the operator is multiplied by a number
-            result = A @ np.array([1, 2, 3])
+            result = A @ _asarray([1, 2, 3])
             B = A * 3
             C = A / 5
-            assert_equal(A @ np.array([1, 2, 3]), result)
+            xp_assert_equal(A @ _asarray([1, 2, 3]), result)
 
-            assert_((2j*A).dtype == np.complex128)
+            assert (2j*A).dtype == xp.complex128
 
             # Test division by non-scalar
             msg = "Can only divide a linear operator by a scalar."
             with assert_raises(ValueError, match=msg):
-                A / np.array([1, 2])
+                _ = A / xp.asarray([1, 2])
 
-            assert_raises(ValueError, A.matvec, np.array([1,2]))
-            assert_raises(ValueError, A.matvec, np.array([1,2,3,4]))
-            assert_raises(ValueError, A.matvec, np.array([[1],[2]]))
-            assert_raises(ValueError, A.matvec, np.array([[1],[2],[3],[4]]))
+            assert_raises(ValueError, A.matvec, xp.asarray([1,2]))
+            assert_raises(ValueError, A.matvec, xp.asarray([1,2,3,4]))
+            assert_raises(ValueError, A.matvec, xp.asarray([[1],[2]]))
+            assert_raises(ValueError, A.matvec, xp.asarray([[1],[2],[3],[4]]))
 
             assert_raises(ValueError, lambda: A@A)
             assert_raises(ValueError, lambda: A**2)
 
-        for matvecsA, matvecsB in product(get_matvecs(self.A),
-                                          get_matvecs(self.B)):
+        for matvecsA, matvecsB in product(get_matvecs(_asarray(self.A)),
+                                          get_matvecs(_asarray(self.B))):
             A = interface.LinearOperator(**matvecsA)
             B = interface.LinearOperator(**matvecsB)
-            # AtimesB = np.array([[22, 28], [49, 64]])
-            AtimesB = self.A.dot(self.B)
-            X = np.array([[1, 2], [3, 4]])
+            AtimesB = _asarray(self.A @ self.B)
+            X = _asarray([[1, 2], [3, 4]])
 
-            assert_equal((A @ B).rmatmat(X), np.dot((AtimesB).T, X))
-            assert_equal((2j * A @ B).rmatmat(X),
-                         np.dot((2j * AtimesB).T.conj(), X))
+            xp_assert_equal((A @ B).rmatmat(X), AtimesB.T @ X)
+            xp_assert_equal((2j * A @ B).rmatmat(X), xp.conj((2j * AtimesB).T) @ X)
 
-            assert_equal((A@B)@[1,1], [50,113])
-            assert_equal((A@B)@[[1],[1]], [[50],[113]])
-            assert_equal((A@B).matmat([[1],[1]]), [[50],[113]])
+            xp_assert_equal((A @ B) @ _asarray([1,1]), _asarray([50,113]))
+            xp_assert_equal((A @ B) @ _asarray([[1],[1]]), _asarray([[50],[113]]))
+            xp_assert_equal((A @ B).matmat(_asarray([[1],[1]])), _asarray([[50],[113]]))
 
-            assert_equal((A @ B).rmatvec([1, 1]), [71, 92])
-            assert_equal((A @ B).H.matvec([1, 1]), [71, 92])
-            assert_equal((A @ B).adjoint().matvec([1, 1]), [71, 92])
+            xp_assert_equal((A @ B).rmatvec(_asarray([1, 1])), _asarray([71, 92]))
+            xp_assert_equal((A @ B).H.matvec(_asarray([1, 1])), _asarray([71, 92]))
+            xp_assert_equal(
+                (A @ B).adjoint().matvec(_asarray([1, 1])),
+                _asarray([71, 92]),
+            )
 
-            assert_(isinstance(A@B, interface._ProductLinearOperator))
+            assert isinstance(A@B, interface._ProductLinearOperator)
 
             assert_raises(ValueError, lambda: A+B)
             assert_raises(ValueError, lambda: A**2)
 
             z = A@B
-            assert_(len(z.args) == 2 and z.args[0] is A and z.args[1] is B)
+            assert len(z.args) == 2 and z.args[0] is A and z.args[1] is B
 
-        for matvecsC in get_matvecs(self.C):
+        for matvecsC in get_matvecs(xp.asarray(self.C)):
             C = interface.LinearOperator(**matvecsC)
-            X = np.array([[1, 2], [3, 4]])
+            X = xp.asarray([[1, 2], [3, 4]])
+            C_ = xp.asarray(self.C)
 
-            assert_equal(C.rmatmat(X), np.dot((self.C).T, X))
-            assert_equal((C**2).rmatmat(X),
-                         np.dot((np.dot(self.C, self.C)).T, X))
+            xp_assert_equal(C.rmatmat(X), (C_).T @ X)
+            xp_assert_equal((C**2).rmatmat(X), (C_ @ C_).T @ X)
 
-            assert_equal((C**2)@[1,1], [17,37])
-            assert_equal((C**2).rmatvec([1, 1]), [22, 32])
-            assert_equal((C**2).H.matvec([1, 1]), [22, 32])
-            assert_equal((C**2).adjoint().matvec([1, 1]), [22, 32])
-            assert_equal((C**2).matmat([[1],[1]]), [[17],[37]])
+            xp_assert_equal((C**2)@[1,1], xp.asarray([17,37]))
+            xp_assert_equal((C**2).rmatvec([1, 1]), xp.asarray([22, 32]))
+            xp_assert_equal((C**2).H.matvec([1, 1]), xp.asarray([22, 32]))
+            xp_assert_equal((C**2).adjoint().matvec([1, 1]), xp.asarray([22, 32]))
+            xp_assert_equal((C**2).matmat([[1],[1]]), xp.asarray([[17],[37]]))
 
-            assert_(isinstance(C**2, interface._PowerLinearOperator))
+            assert isinstance(C**2, interface._PowerLinearOperator)
 
-    def test_matmul(self):
-        D = {'shape': self.A.shape,
-             'matvec': lambda x: np.dot(self.A, x).reshape(self.A.shape[0]),
-             'rmatvec': lambda x: np.dot(self.A.T.conj(),
-                                         x).reshape(self.A.shape[1]),
-             'rmatmat': lambda x: np.dot(self.A.T.conj(), x),
-             'matmat': lambda x: np.dot(self.A, x)}
+    def test_matmul(self, xp):
+        A_ = xp.asarray(self.A, dtype=xp.complex128)
+        D = {'shape': A_.shape,
+             'dtype': xp.complex128,
+             'matvec': lambda x: xp.reshape(A_ @ x, (A_.shape[0],)),
+             'rmatvec': lambda x: xp.reshape(xp.conj(A_.T) @ x, (A_.shape[1],)),
+             'rmatmat': lambda x: xp.conj(A_.T) @ x,
+             'matmat': lambda x: A_ @ x}
         A = interface.LinearOperator(**D)
-        B = np.array([[1 + 1j, 2, 3],
-                      [4, 5, 6],
-                      [7, 8, 9]])
-        b = B[0]
+        B = xp.asarray([[1 + 1j, 2, 3],
+                        [4, 5, 6],
+                        [7, 8, 9]])
+        b = B[0, ...]
 
-        assert_equal(operator.matmul(A, b), A * b)
-        assert_equal(operator.matmul(A, b.reshape(-1, 1)), A * b.reshape(-1, 1))
-        assert_equal(operator.matmul(A, B), A @ B)
-        assert_equal(operator.matmul(b, A.H), b * A.H)
-        assert_equal(operator.matmul(b, A.adjoint()), b * A.adjoint())
-        assert_equal(operator.matmul(b.reshape(1, -1), A.H), b.reshape(1, -1) * A.H)
-        assert_equal(operator.matmul(b.reshape(1, -1), A.adjoint()),
-                     b.reshape(1, -1) * A.adjoint())
-        assert_equal(operator.matmul(B, A.H), B @ A.H)
-        assert_equal(operator.matmul(B, A.adjoint()), B @ A.adjoint())
+        xp_assert_equal(operator.matmul(A, b), A * b)
+        xp_assert_equal(
+            operator.matmul(A, xp.reshape(b, (-1, 1))),
+            A * xp.reshape(b, (-1, 1)),
+        )
+        xp_assert_equal(operator.matmul(A, B), A @ B)
+        xp_assert_equal(operator.matmul(b, A.H), b * A.H)
+        xp_assert_equal(operator.matmul(b, A.adjoint()), b * A.adjoint())
+        xp_assert_equal(
+            operator.matmul(xp.reshape(b, (1, -1)), A.H),
+            xp.reshape(b, (1, -1)) * A.H,
+        )
+        xp_assert_equal(
+            operator.matmul(b.reshape(1, -1), A.adjoint()),
+            b.reshape(1, -1) * A.adjoint(),
+        )
+        xp_assert_equal(operator.matmul(B, A.H), B @ A.H)
+        xp_assert_equal(operator.matmul(B, A.adjoint()), B @ A.adjoint())
         assert_raises(ValueError, operator.matmul, A, 2)
         assert_raises(ValueError, operator.matmul, 2, A)
 
-    def test_dimension_mismatch(self):
+    def test_dimension_mismatch(self, xp):
         msg = "(D|d)imension mismatch"
-        A = interface.aslinearoperator(np.ones((3, 4)))
+        A = interface.aslinearoperator(xp.ones((3, 4)))
         # matvec
-        A.matvec(np.ones(4))
+        A.matvec(xp.ones(4))
         with pytest.raises(ValueError, match=msg):
-            A.matvec(np.ones(3))
+            A.matvec(xp.ones(3))
         # rmatvec
-        A.rmatvec(np.ones(3))
+        A.rmatvec(xp.ones(3))
         with pytest.raises(ValueError, match=msg):
-            A.rmatvec(np.ones(4))
+            A.rmatvec(xp.ones(4))
         # matmat
-        A.matmat(np.ones((4, 3)))
+        A.matmat(xp.ones((4, 3)))
         with pytest.raises(ValueError, match=msg):
-            A.matmat(np.ones((3, 3)))
+            A.matmat(xp.ones((3, 3)))
         # rmatmat
-        A.rmatmat(np.ones((3, 3)))
+        A.rmatmat(xp.ones((3, 3)))
         with pytest.raises(ValueError, match=msg):
-            A.rmatmat(np.ones((4, 4)))
+            A.rmatmat(xp.ones((4, 4)))
         # dot
-        A.dot(np.ones((4, 3)))
+        A.dot(xp.ones((4, 3)))
         with pytest.raises(ValueError, match=msg):
-            A.dot(np.ones((3, 3)))
+            A.dot(xp.ones((3, 3)))
         # rdot
-        A.rdot(np.ones((3, 3)))
+        A.rdot(xp.ones((3, 3)))
         with pytest.raises(ValueError, match=msg):
-            A.rdot(np.ones((4, 4)))
+            A.rdot(xp.ones((4, 4)))
         
 
+@pytest.mark.skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11711")
+@make_xp_test_case(interface.LinearOperator)
 class TestDotTests:
     """
     This class aims to help ensure correctness of the LinearOperator
@@ -316,7 +343,8 @@ class TestDotTests:
     ]
 
     def check_matvec(
-        self, op: interface.LinearOperator, data_dtype: str, complex_data: bool = False,
+        self, xp: ModuleType, op: interface.LinearOperator, data_dtype: str,
+        complex_data: bool = False,
     ):
         """
         This check verifies the equivalence of the forward and adjoint computation,
@@ -357,20 +385,23 @@ class TestDotTests:
             if complex_data:
                 u = u + (1j * rng.standard_normal(u_shape, dtype=dtype))
                 v = v + (1j * rng.standard_normal(v_shape, dtype=dtype))
+            u = xp.asarray(u)
+            v = xp.asarray(v)
     
             op_u = op.matvec(u)
             opH_v = op.rmatvec(v)
     
-            op_u_H_v = np.vecdot(op_u, v, axis=-1)
-            uH_opH_v = np.vecdot(u, opH_v, axis=-1)
+            op_u_H_v = xp.vecdot(op_u, v, axis=-1)
+            uH_opH_v = xp.vecdot(u, opH_v, axis=-1)
     
             rtol = 1e-12 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
             atol = 2e-15 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
-            assert_allclose(op_u_H_v, uH_opH_v, rtol=rtol, atol=atol)
+            xp_assert_close(op_u_H_v, uH_opH_v, rtol=rtol, atol=atol)
 
     def check_matmat(
-        self, op: interface.LinearOperator, data_dtype: str, complex_data: bool = False,
-        check_operators: bool = False, check_dot: bool = False
+        self, xp, op: interface.LinearOperator, data_dtype: str,
+        complex_data: bool = False, check_operators: bool = False,
+        check_dot: bool = False,
     ):
         """
         This check verifies the equivalence of the forward and adjoint computation,
@@ -403,64 +434,71 @@ class TestDotTests:
         if complex_data:
             U = U + (1j * rng.standard_normal(size=(*batch_shape, N, k), dtype=dtype))
             V = V + (1j * rng.standard_normal(size=(*batch_shape, M, k), dtype=dtype))
+        U = xp.asarray(U)
+        V = xp.asarray(V)
 
         op_U = op.matmat(U)
         opH_V = op.rmatmat(V)
 
         if check_operators:
-            assert_allclose(op_U, op * U)
-            assert_allclose(op_U, op @ U)
-            assert_allclose(opH_V, op.H * V)
-            assert_allclose(opH_V, op.H @ V)
+            xp_assert_close(op_U, op * U)
+            xp_assert_close(op_U, op @ U)
+            xp_assert_close(opH_V, op.H * V)
+            xp_assert_close(opH_V, op.H @ V)
 
         if check_dot:
-            assert_allclose(op_U, op.dot(U))
-            assert_allclose(opH_V, op.H.dot(V))
+            xp_assert_close(op_U, op.dot(U))
+            xp_assert_close(opH_V, op.H.dot(V))
 
-        op_U_H = np.conj(op_U).mT
-        UH = np.conj(U).mT
+        op_U_H = xp.conj(op_U).mT
+        UH = xp.conj(U).mT
 
-        op_U_H_V = np.matmul(op_U_H, V)
-        UH_opH_V = np.matmul(UH, opH_V)
+        op_U_H_V = xp.matmul(op_U_H, V)
+        UH_opH_V = xp.matmul(UH, opH_V)
 
         rtol = 1e-12 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
         atol = 2e-15 if np.finfo(data_dtype).eps < 1e-8 else 1e-5
-        assert_allclose(op_U_H_V, UH_opH_V, rtol=rtol, atol=atol)
+        xp_assert_close(op_U_H_V, UH_opH_V, rtol=rtol, atol=atol)
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
     @pytest.mark.parametrize("args", square_args_list)
-    def test_identity_square(self, args: OperatorArgs, batch_shape: tuple[int, ...]):
+    def test_identity_square(
+        self, args: OperatorArgs, batch_shape: tuple[int, ...], xp
+    ):
         """
         Simple identity operator on square matrices.
         Tests batches of RHS via `args.batch_shape`.
         """
         def identity(x):
-            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
-            return np.full(shape, x)
+            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return xp.broadcast_to(x, shape)
 
         shape = batch_shape + args.shape
+        dtype = getattr(xp, args.op_dtype)
         op = interface.LinearOperator(
-            shape=shape, dtype=args.op_dtype,
+            shape=shape, dtype=dtype,
             matvec=identity, rmatvec=identity,
         )
 
-        self.check_matvec(op, data_dtype=args.data_dtype, complex_data=args.complex)
-        self.check_matmat(op, data_dtype=args.data_dtype, complex_data=args.complex)
+        self.check_matvec(xp, op, data_dtype=args.data_dtype, complex_data=args.complex)
+        self.check_matmat(xp, op, data_dtype=args.data_dtype, complex_data=args.complex)
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
     @pytest.mark.parametrize("args", all_args_list)
-    def test_identity_nonsquare(self, args: OperatorArgs, batch_shape: tuple[int, ...]):
+    def test_identity_nonsquare(
+        self, args: OperatorArgs, batch_shape: tuple[int, ...], xp
+    ):
         """
         Identity operator with zero-padding on non-square matrices.
         Tests batches of RHS via `args.batch_shape`.
         """
         M, N = args.shape
-        
+
         def pad_core_dim(x, target_size):
             pad_widths = [(0, 0)] * x.ndim # no padding for batch dims
             pad_widths[-1] = (0, target_size - x.shape[-1]) # padding for core dim
-            return np.pad(x, pad_widths, mode="constant")
-        
+            return xpx.pad(x, pad_widths, mode="constant")
+
         def mv(x):
             match np.sign(x.shape[-1] - M):
                 case 0:  # square
@@ -470,8 +508,8 @@ class TestDotTests:
                 case -1:  # pad with zeros
                     x = pad_core_dim(x, target_size=M)
 
-            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
-            return np.full(shape, x)
+            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return xp.broadcast_to(x, shape)
 
         def rmv(x):            
             match np.sign(N - x.shape[-1]):
@@ -482,43 +520,45 @@ class TestDotTests:
                 case -1:  # crop x to size
                     x = x[..., :N]
 
-            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
-            return np.full(shape, x)
+            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return xp.broadcast_to(x, shape)
 
         shape = batch_shape + args.shape
+        dtype = getattr(xp, args.op_dtype)
         op = interface.LinearOperator(
-            shape=shape, dtype=args.op_dtype, matvec=mv, rmatvec=rmv
+            shape=shape, dtype=dtype, matvec=mv, rmatvec=rmv
         )
         
-        self.check_matvec(op, data_dtype=args.data_dtype, complex_data=args.complex)
-        self.check_matmat(op, data_dtype=args.data_dtype, complex_data=args.complex)
+        self.check_matvec(xp, op, data_dtype=args.data_dtype, complex_data=args.complex)
+        self.check_matmat(xp, op, data_dtype=args.data_dtype, complex_data=args.complex)
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
     @pytest.mark.parametrize("args", square_args_list)
-    def test_scaling_square(self, args: OperatorArgs, batch_shape: tuple[int, ...]):
+    def test_scaling_square(self, args: OperatorArgs, batch_shape: tuple[int, ...], xp):
         """
         Simple (complex) scaling operator on square matrices.
         Tests batches of RHS via `args.batch_shape`.
         """
         def scale(x):
             b = (3 + 2j) * x
-            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
-            return np.full(shape, b)
+            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return xp.broadcast_to(b, shape)
 
         def r_scale(x):
             b = (3 - 2j) * x
-            shape = (*np.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
-            return np.full(shape, b)
+            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            return xp.broadcast_to(b, shape)
 
         shape = batch_shape + args.shape
+        dtype = getattr(xp, args.op_dtype)
         op = interface.LinearOperator(
-            shape=shape, dtype=args.op_dtype, matvec=scale, rmatvec=r_scale
+            shape=shape, dtype=dtype, matvec=scale, rmatvec=r_scale
         )
-        self.check_matvec(op, data_dtype=args.data_dtype, complex_data=args.complex)
-        self.check_matmat(op, data_dtype=args.data_dtype, complex_data=args.complex)
+        self.check_matvec(xp, op, data_dtype=args.data_dtype, complex_data=args.complex)
+        self.check_matmat(xp, op, data_dtype=args.data_dtype, complex_data=args.complex)
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
-    def test_subclass_matmat(self, batch_shape: tuple[int, ...]):
+    def test_subclass_matmat(self, batch_shape: tuple[int, ...], xp):
         """
         Simple rotation operator defined by `matmat` and `adjoint`,
         subclassing `LinearOperator`.
@@ -532,107 +572,143 @@ class TestDotTests:
 
             def _matmat(self, X):
                 theta = self._theta
-                R = np.array([
+                R = xp.asarray([
                     [np.cos(theta), -np.sin(theta)],
                     [np.sin(theta),  np.cos(theta)]
                 ])
                 B = R @ X
-                shape = np.broadcast_shapes(batch_shape, X.shape[:-2]) + X.shape[-2:]
-                return np.full(shape, B)
+                shape = xpx.broadcast_shapes(batch_shape, X.shape[:-2]) + X.shape[-2:]
+                return xp.broadcast_to(B, shape)
 
             def _adjoint(self):
                 negative_theta = -self._theta
                 return RotOp(self.dtype, self.shape, negative_theta)
 
-        theta = np.pi / 2
-        dtype = "float64"
-        op = RotOp(shape=(*batch_shape, 2, 2), dtype=dtype, theta=theta)
+        theta = xp.pi / 2
+        op = RotOp(shape=(*batch_shape, 2, 2), dtype=xp.float64, theta=theta)
 
-        self.check_matvec(op, data_dtype=dtype, complex_data=False)
-        self.check_matmat(op, data_dtype=dtype, complex_data=False)
+        data_dtype = "float64"
+        self.check_matvec(xp, op, data_dtype=data_dtype, complex_data=False)
+        self.check_matmat(xp, op, data_dtype=data_dtype, complex_data=False)
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
-    @pytest.mark.parametrize(
-        "format", ["dense", "sparse"]
-    )
-    def test_aslinearop(
-        self, format: Literal["dense", "sparse"], batch_shape: tuple[int, ...]
+    @pytest.mark.skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11711")
+    def test_aslinearop_dense(
+        self, batch_shape: tuple[int, ...], xp
     ):
         """
         Test operators coming from `aslinearoperator`,
         *including batched LHS*.
         """
         rng = np.random.default_rng(42)
-        constructor = sparse.random_array if format == "sparse" else rng.standard_normal
-        matrix = constructor((*batch_shape, 4, 4))
+        matrix = xp.asarray(
+            rng.standard_normal((*batch_shape, 4, 4)),
+            dtype=xp.complex128,
+        )
         op = interface.aslinearoperator(matrix)
         data_dtype = "float64"
-        self.check_matvec(op, data_dtype=data_dtype, complex_data=True)
-        self.check_matmat(op, data_dtype=data_dtype, complex_data=True)
+        self.check_matvec(xp, op, data_dtype=data_dtype, complex_data=True)
+        self.check_matmat(xp, op, data_dtype=data_dtype, complex_data=True)
+
+    @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
+    @pytest.mark.skip_xp_backends(np_only=True)
+    def test_aslinearop_sparse(self, batch_shape: tuple[int, ...], xp):
+        """
+        Test operators coming from `aslinearoperator` with sparse arrays,
+        *including batched LHS*
+        """
+        matrix = sparse.random_array((*batch_shape, 4, 4), dtype=xp.complex128)
+        op = interface.aslinearoperator(matrix)
+        data_dtype = "float64"
+        self.check_matvec(xp, op, data_dtype=data_dtype, complex_data=True)
+        self.check_matmat(xp, op, data_dtype=data_dtype, complex_data=True)
 
 
+@make_xp_test_case(interface.LinearOperator)
 class TestAsLinearOperator:
+    def make_cases(self, original, dtype, xp=None):
+        cases = []
+
+        # Test default implementations of _adjoint and _rmatvec, which
+        # refer to each other.
+        def mv(x, dtype):
+            y = original.dot(x)
+            if len(x.shape) == 2:
+                y = y.reshape(-1, 1)
+            return y
+
+        def rmv(x, dtype):
+            return original.T.conj().dot(x)
+
+        class BaseMatlike(interface.LinearOperator):
+            args = ()
+
+            def __init__(self, dtype):
+                super().__init__(
+                    dtype=np.dtype(dtype),
+                    shape=original.shape
+                )
+
+            def _matvec(self, x):
+                return mv(x, self.dtype)
+
+        class HasRmatvec(BaseMatlike):
+            args = ()
+
+            def _rmatvec(self,x):
+                return rmv(x, self.dtype)
+
+        class HasAdjoint(BaseMatlike):
+            args = ()
+
+            def _adjoint(self):
+                shape = self.shape[1], self.shape[0]
+                matvec = partial(rmv, dtype=self.dtype)
+                rmatvec = partial(mv, dtype=self.dtype)
+                return interface.LinearOperator(matvec=matvec,
+                                                rmatvec=rmatvec,
+                                                dtype=self.dtype,
+                                                shape=shape)
+
+        class HasRmatmat(HasRmatvec):
+            def _matmat(self, x):
+                return original.dot(x)
+
+            def _rmatmat(self, x):
+                return original.T.conj().dot(x)
+        
+        if xp:
+            cases.append((original, original))
+
+            # cases.append((HasRmatvec(dtype), original))
+            # cases.append((HasAdjoint(dtype), original))
+            # cases.append((HasRmatmat(dtype), original))
+            
+            cases.append((interface.aslinearoperator(original.T).T, original))
+            cases.append((
+                interface.aslinearoperator(original.T).H,
+                xp.conj(original),
+            ))
+            cases.append((
+                interface.aslinearoperator(original.T).adjoint(),
+                xp.conj(original)),
+            )
+            cases.append((interface.aslinearoperator(original.T).T, original))
+
+            return cases
+        
+        cases.append((matrix(original, dtype=dtype), original))
+        cases.append((np.array(original, dtype=dtype), original))
+        cases.append((sparse.csr_array(original, dtype=dtype), original))
+
+        cases.append((HasRmatvec(dtype), original))
+        cases.append((HasAdjoint(dtype), original))
+        cases.append((HasRmatmat(dtype), original))
+        return cases
+    
     def setup_method(self):
         self.cases = []
-
-        def make_cases(original, dtype):
-            cases = []
-
-            cases.append((matrix(original, dtype=dtype), original))
-            cases.append((np.array(original, dtype=dtype), original))
-            cases.append((sparse.csr_array(original, dtype=dtype), original))
-
-            # Test default implementations of _adjoint and _rmatvec, which
-            # refer to each other.
-            def mv(x, dtype):
-                y = original.dot(x)
-                if len(x.shape) == 2:
-                    y = y.reshape(-1, 1)
-                return y
-
-            def rmv(x, dtype):
-                return original.T.conj().dot(x)
-
-            class BaseMatlike(interface.LinearOperator):
-                args = ()
-
-                def __init__(self, dtype):
-                    self.dtype = np.dtype(dtype)
-                    self.shape = original.shape
-
-                def _matvec(self, x):
-                    return mv(x, self.dtype)
-
-            class HasRmatvec(BaseMatlike):
-                args = ()
-
-                def _rmatvec(self,x):
-                    return rmv(x, self.dtype)
-
-            class HasAdjoint(BaseMatlike):
-                args = ()
-
-                def _adjoint(self):
-                    shape = self.shape[1], self.shape[0]
-                    matvec = partial(rmv, dtype=self.dtype)
-                    rmatvec = partial(mv, dtype=self.dtype)
-                    return interface.LinearOperator(matvec=matvec,
-                                                    rmatvec=rmatvec,
-                                                    dtype=self.dtype,
-                                                    shape=shape)
-
-            class HasRmatmat(HasRmatvec):
-                def _matmat(self, x):
-                    return original.dot(x)
-
-                def _rmatmat(self, x):
-                    return original.T.conj().dot(x)
-
-            cases.append((HasRmatvec(dtype), original))
-            cases.append((HasAdjoint(dtype), original))
-            cases.append((HasRmatmat(dtype), original))
-            return cases
-
+        make_cases = self.make_cases
         original = np.array([[1,2,3], [4,5,6]])
         self.cases += make_cases(original, np.int32)
         self.cases += make_cases(original, np.float32)
@@ -653,11 +729,11 @@ class TestAsLinearOperator:
         self.cases += [(interface.aslinearoperator(M).adjoint(), A.T.conj())
                        for M, A in make_cases(original.T, np.complex128)]
 
-    def test_basic(self):
+    @pytest.mark.skip_xp_backends(np_only=True)
+    def test_basic(self, xp):
 
         for M, A_array in self.cases:
             A = interface.aslinearoperator(M)
-            M,N = A.shape
 
             xs = [np.array([1, 2, 3]),
                   np.array([[1], [2], [3]])]
@@ -709,11 +785,11 @@ class TestAsLinearOperator:
 
             assert_(hasattr(A, 'args'))
 
-    def test_dot(self):
+    @pytest.mark.skip_xp_backends(np_only=True)
+    def test_dot(self, xp):
 
         for M, A_array in self.cases:
             A = interface.aslinearoperator(M)
-            M,N = A.shape
 
             x0 = np.array([1, 2, 3])
             x1 = np.array([[1], [2], [3]])
@@ -723,54 +799,99 @@ class TestAsLinearOperator:
             assert_equal(A.dot(x1), A_array.dot(x1))
             assert_equal(A.dot(x2), A_array.dot(x2))
 
+    @pytest.mark.parametrize("dtype", ["int64", "float64", "complex128"])
+    def test_xp(self, dtype, xp):
+        dtype = getattr(xp, dtype)
+        original = xp.asarray([[1, 2, 3], [4, 5, 6]], dtype=dtype)
+        for M, A_array in self.make_cases(original, dtype, xp=xp):
+            A = interface.aslinearoperator(M)
 
-def test_repr():
-    A = interface.LinearOperator(shape=(1, 1), matvec=lambda x: np.asarray([1]))
+            xs = [xp.asarray([1, 2, 3]),
+                  xp.asarray([[1], [2], [3]])]
+            ys = [xp.asarray([1, 2]), xp.asarray([[1], [2]])]
+
+            if A.dtype == xp.complex128:
+                xs += [xp.asarray([1, 2j, 3j]),
+                       xp.asarray([[1], [2j], [3j]])]
+                ys += [xp.asarray([1, 2j]), xp.asarray([[1], [2j]])]
+
+            x2 = xp.asarray([[1, 4], [2, 5], [3, 6]], dtype=dtype)
+
+            for x in xs:
+                x = xp.astype(x, dtype)
+                xp_assert_equal(A @ x, A_array @ x)
+
+            xp_assert_equal(A.matmat(x2), A_array @ x2)
+            xp_assert_equal(A @ x2, A_array @ x2)
+
+            for y in ys:
+                if y.ndim < 2:
+                    continue
+                y = xp.astype(y, dtype)
+                xp_assert_equal(A.rmatmat(y), xp.conj(A_array.T) @ y)
+                xp_assert_equal(A.T.matmat(y), xp.conj(A_array.T) @ y)
+                xp_assert_equal(A.H.matmat(y), xp.conj(A_array.T) @ y)
+                xp_assert_equal(A.adjoint().matmat(y), xp.conj(A_array.T) @ y)
+
+            if hasattr(M, 'dtype'):
+                assert_equal(A.dtype, M.dtype)
+
+            assert hasattr(A, 'args')
+            
+
+@make_xp_test_case(interface.LinearOperator)
+def test_repr(xp):
+    A = interface.LinearOperator(shape=(1, 1), matvec=lambda x: xp.asarray([1]))
     repr_A = repr(A)
-    assert_('unspecified dtype' not in repr_A, repr_A)
+    assert 'unspecified dtype' not in repr_A, repr_A
 
 
-def test_identity():
+@make_xp_test_case(interface.LinearOperator)
+def test_identity(xp):
     ident = interface.IdentityOperator((3, 3))
-    assert_equal(ident @ [1, 2, 3], [1, 2, 3])
-    assert_equal(ident.dot(np.arange(9).reshape(3, 3)).ravel(), np.arange(9))
+    xp_assert_equal(ident @ xp.asarray([1, 2, 3]), xp.asarray([1, 2, 3]))
+    xp_assert_equal(xp_ravel(ident.dot(xp.reshape(xp.arange(9), (3, 3)))), xp.arange(9))
 
-    assert_raises(ValueError, ident.matvec, [1, 2, 3, 4])
+    assert_raises(ValueError, ident.matvec, xp.asarray([1, 2, 3, 4]))
 
 
-def test_attributes():
-    A = interface.aslinearoperator(np.arange(16).reshape(4, 4))
+@make_xp_test_case(interface.LinearOperator)
+def test_attributes(xp):
+    A = interface.aslinearoperator(xp.reshape(xp.arange(16, dtype=xp.float64), (4, 4)))
 
     def always_four_ones(x):
-        x = np.asarray(x)
-        assert_(x.shape == (3,) or x.shape == (3, 1))
-        return np.ones(4)
+        x = xp.asarray(x)
+        assert x.shape == (3,) or x.shape == (3, 1)
+        return xp.ones(4)
 
     B = interface.LinearOperator(shape=(4, 3), matvec=always_four_ones)
 
     ops = [A, B, A * B, A @ B, A.H, A.adjoint(), A + A, B + B, A**4]
     for op in ops:
-        assert_(hasattr(op, "dtype"))
-        assert_(hasattr(op, "shape"))
-        assert_(hasattr(op, "_matvec"))
+        assert hasattr(op, "dtype")
+        assert hasattr(op, "shape")
+        assert hasattr(op, "_matvec")
 
-def matvec(x):
+def matvec_for_pickle(x):
     """ Needed for test_pickle as local functions are not pickleable """
-    return np.zeros(3)
+    return x
 
-def test_pickle():
+@make_xp_test_case(interface.LinearOperator)
+def test_pickle(xp):
     import pickle
 
-    for protocol in range(pickle.HIGHEST_PROTOCOL + 1):
-        A = interface.LinearOperator((3, 3), matvec)
+    protocol_min = 0 if is_numpy(xp) else 2
+    for protocol in range(protocol_min, pickle.HIGHEST_PROTOCOL + 1):
+        A = interface.LinearOperator((3, 3), matvec_for_pickle)
         s = pickle.dumps(A, protocol=protocol)
         B = pickle.loads(s)
 
         for k in A.__dict__:
-            assert_equal(getattr(A, k), getattr(B, k))
+            assert getattr(A, k) == getattr(B, k)
 
 
-def test_inheritance():
+@make_xp_test_case(interface.LinearOperator)
+def test_inheritance(xp):
     class Empty(interface.LinearOperator):
         pass
 
@@ -785,8 +906,8 @@ def test_inheritance():
             return x
 
     id3 = Identity(3)
-    assert_equal(id3.matvec([1, 2, 3]), [1, 2, 3])
-    assert_raises(NotImplementedError, id3.rmatvec, [4, 5, 6])
+    xp_assert_equal(id3.matvec(xp.asarray([1, 2, 3])), xp.asarray([1, 2, 3]))
+    assert_raises(NotImplementedError, id3.rmatvec, xp.asarray([4, 5, 6]))
 
     class MatmatOnly(interface.LinearOperator):
         def __init__(self, A):
@@ -794,16 +915,18 @@ def test_inheritance():
             self.A = A
 
         def _matmat(self, x):
-            return self.A.dot(x)
+            return self.A @ x
 
-    mm = MatmatOnly(np.random.randn(5, 3))
-    assert_equal(mm.matvec(np.random.randn(3)).shape, (5,))
+    mm = MatmatOnly(xp.asarray(np.random.randn(5, 3)))
+    assert mm.matvec(xp.asarray(np.random.randn(3))).shape == (5,)
 
-def test_dtypes_of_operator_sum():
+
+@make_xp_test_case(interface.LinearOperator)
+def test_dtypes_of_operator_sum(xp):
     # gh-6078
 
-    mat_complex = np.random.rand(2,2) + 1j * np.random.rand(2,2)
-    mat_real = np.random.rand(2,2)
+    mat_complex = xp.asarray(np.random.rand(2,2) + 1j * np.random.rand(2,2))
+    mat_real = xp.asarray(np.random.rand(2,2))
 
     complex_operator = interface.aslinearoperator(mat_complex)
     real_operator = interface.aslinearoperator(mat_real)
@@ -811,10 +934,12 @@ def test_dtypes_of_operator_sum():
     sum_complex = complex_operator + complex_operator
     sum_real = real_operator + real_operator
 
-    assert_equal(sum_real.dtype, np.float64)
-    assert_equal(sum_complex.dtype, np.complex128)
+    assert sum_real.dtype == xp.float64
+    assert sum_complex.dtype == xp.complex128
 
-def test_no_double_init():
+
+@make_xp_test_case(interface.LinearOperator)
+def test_no_double_init(xp):
     call_count = [0]
 
     def matvec(v):
@@ -826,6 +951,7 @@ def test_no_double_init():
     interface.LinearOperator((2, 2), matvec=matvec)
     assert_equal(call_count[0], 1)
 
+
 INT_DTYPES = (np.int8, np.int16, np.int32, np.int64)
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
@@ -834,6 +960,7 @@ ALLDTYPES = INT_DTYPES + INEXACTDTYPES
 
 
 @pytest.mark.parametrize("test_dtype", ALLDTYPES)
+# TODO: convert this test after adjusting implementation (use `xp_result_type`?)
 def test_determine_lo_dtype_from_matvec(test_dtype):
     # gh-19209
     scalar = np.array(1, dtype=test_dtype)
@@ -843,69 +970,87 @@ def test_determine_lo_dtype_from_matvec(test_dtype):
     lo = interface.LinearOperator((2, 2), matvec=mv)
     assert lo.dtype == np.dtype(test_dtype)
 
-def test_determine_lo_dtype_for_int():
+
+@make_xp_test_case(interface.LinearOperator)
+def test_determine_lo_dtype_for_int(xp):
     # gh-19209
     # test Python int larger than int8 max cast to some int
     def mv(v):
-        return np.array([128 * v[0], v[1]])
+        return xp.asarray([128 * v[0], v[1]])
 
     lo = interface.LinearOperator((2, 2), matvec=mv)
-    assert lo.dtype in INT_DTYPES
+    assert xp.isdtype(lo.dtype, "integral")
 
-def test_adjoint_conjugate():
-    X = np.array([[1j]])
+
+@make_xp_test_case(interface.LinearOperator)
+def test_adjoint_conjugate(xp):
+    X = xp.asarray([[1j]])
     A = interface.aslinearoperator(X)
 
     B = 1j * A
     Y = 1j * X
 
-    v = np.array([1])
+    v = xp.asarray([1], dtype=xp.complex128)
 
-    assert_equal(B.dot(v), Y.dot(v))
-    assert_equal(B.H.dot(v), Y.T.conj().dot(v))
-    assert_equal(B.adjoint().dot(v), Y.T.conj().dot(v))
+    xp_assert_equal(B.dot(v), xp.vecdot(Y, v))
+    xp_assert_equal(B.H.dot(v), xp.vecdot(xp.conj(Y.T), v))
+    xp_assert_equal(B.adjoint().dot(v), xp.vecdot(xp.conj(Y.T), v))
 
-def test_ndim():
-    X = np.array([[1]])
+
+@make_xp_test_case(interface.LinearOperator)
+def test_ndim(xp):
+    X = xp.asarray([[1]])
     A = interface.aslinearoperator(X)
-    assert_equal(A.ndim, 2)
+    assert A.ndim == 2
 
-def test_transpose_noconjugate():
-    X = np.array([[1j]])
+
+@make_xp_test_case(interface.LinearOperator)
+def test_transpose_noconjugate(xp):
+    X = xp.asarray([[1j]])
     A = interface.aslinearoperator(X)
 
     B = 1j * A
     Y = 1j * X
 
-    v = np.array([1])
+    v = xp.asarray([1], dtype=xp.complex128)
 
-    assert_equal(B.dot(v), Y.dot(v))
-    assert_equal(B.T.dot(v), Y.T.dot(v))
+    xp_assert_equal(B.dot(v), xp.vecdot(Y, v))
+    xp_assert_equal(B.T.dot(v), xp.vecdot(Y.T, v))
 
-def test_transpose_multiplication():
+
+@pytest.mark.skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11711")
+@pytest.mark.skip_xp_backends(
+    "array_api_strict",
+    reason="https://github.com/data-apis/array-api-strict/issues/188"
+)
+@make_xp_test_case(interface.LinearOperator)
+def test_transpose_multiplication(xp):
     class MyMatrix(interface.LinearOperator):
         def __init__(self, A):
             super().__init__(A.dtype, A.shape)
             self.A = A
         def _matmat(self, other): return self.A @ other
-        def _rmatmat(self, other): return self.A.T @ other
+        def _rmatmat(self, other): return self.A.mT @ other
 
-    A = MyMatrix(np.array([[1, 2], [3, 4]]))
-    X = np.array([1, 2])
-    B = np.array([[10, 20], [30, 40]])
-    X2 = X.reshape(-1, 1)
-    Y = np.array([[1, 2], [3, 4]])
+    A = MyMatrix(xp.asarray([[1, 2], [3, 4]]))
+    X = xp.asarray([1, 2])
+    X_T = X
+    B = xp.asarray([[10, 20], [30, 40]])
+    X2 = xp.reshape(X, (-1, 1))
+    Y = xp.asarray([[1, 2], [3, 4]])
 
-    assert_equal(A @ B, Y @ B)
-    assert_equal(B.T @ A, B.T @ Y)
-    assert_equal(A.T @ B, Y.T @ B)
-    assert_equal(A @ X, Y @ X)
-    assert_equal(X.T @ A, X.T @ Y)
-    assert_equal(A.T @ X, Y.T @ X)
-    assert_equal(A @ X2, Y @ X2)
-    assert_equal(X2.T @ A, X2.T @ Y)
-    assert_equal(A.T @ X2, Y.T @ X2)
+    xp_assert_equal(A @ B, Y @ B)
+    xp_assert_equal(B.T @ A, B.T @ Y)
+    xp_assert_equal(A.T @ B, Y.mT @ B)
+    xp_assert_equal(A @ X, Y @ X)
+    xp_assert_equal(X_T @ A, X_T @ Y)
+    xp_assert_equal(A.T @ X, Y.mT @ X)
+    xp_assert_equal(A @ X2, Y @ X2)
+    xp_assert_equal(X2.mT @ A, X2.mT @ Y)
+    xp_assert_equal(A.T @ X2, Y.mT @ X2)
 
+
+@pytest.mark.skip_xp_backends(np_only=True)
 def test_sparse_matmat_exception():
     A = interface.LinearOperator((2, 2), matvec=lambda x: x)
     B = sparse.eye_array(2)
@@ -920,10 +1065,11 @@ def test_sparse_matmat_exception():
         np.identity(4) @ A
 
 
-def test_MatrixLinearOperator_refcycle():
+@make_xp_test_case(interface.LinearOperator)
+def test_MatrixLinearOperator_refcycle(xp):
     # gh-10634
     # Test that MatrixLinearOperator can be automatically garbage collected
-    A = np.eye(2)
+    A = xp.eye(2)
     with assert_deallocated(interface.MatrixLinearOperator, A) as op:
         op.adjoint()
         del op
@@ -936,7 +1082,13 @@ def test_MatrixLinearOperator_refcycle():
 @pytest.mark.parametrize("batch_A", [(), (5,), (0,)])
 @pytest.mark.parametrize("batch_x", [(), (6, 1), (0, 1)])
 @pytest.mark.parametrize("dtype", [np.float64, np.complex128])
-def test_batch(left, operator_definition, batch_A, batch_x, dtype):
+@make_xp_test_case(interface.LinearOperator)
+@pytest.mark.skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11711")
+@pytest.mark.skip_xp_backends(
+    "array_api_strict",
+    reason="https://github.com/data-apis/array-api-strict/issues/188"
+)
+def test_batch(left, operator_definition, batch_A, batch_x, dtype, xp):
     # TODO ideas:
     # - test lower-precision types
     # - test `transpose`, `adjoint`, `__mul__`, etc.
@@ -954,6 +1106,8 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
         x_row = x_row + 1j * rng.random(x_row.shape)
         x_col = x_col + 1j * rng.random(x_col.shape)
         x_mat = x_mat + 1j * rng.random(x_mat.shape)
+    
+    A_, x_row, x_col, x_mat = (xp.asarray(x) for x in (A_, x_row, x_col, x_mat))
 
     def matvec(A, x):
         if not batch_x:
@@ -966,7 +1120,7 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
             # w.r.t. one batch dimension rather than an arbitrary number of batch
             # dimensions. In this case, `x.ndim` would be exactly 2.
             assert x.ndim >= 2
-            return np.squeeze(A @ x[..., np.newaxis], axis=-1)
+            return (A @ (x[..., xp.newaxis]))[..., 0]
 
     def matmat(A, X):
         if not batch_x:
@@ -980,9 +1134,11 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
     if operator_definition == "aslinearoperator":
         A = interface.aslinearoperator(A_)
     elif operator_definition == "__init__matvec":
-        A = interface.LinearOperator(shape=A_.shape, dtype=A_.dtype,
-                                     matvec=lambda x: matvec(A_, x),
-                                     rmatvec=lambda x: matvec(A_.mT.conj(), x))
+        A = interface.LinearOperator(
+            shape=A_.shape, dtype=A_.dtype,
+            matvec=lambda x: matvec(A_, x),
+            rmatvec=lambda x: matvec(xp.conj(A_.mT), x),
+        )
     elif operator_definition == "__init__matmat":
         # A = interface.LinearOperator(shape=A_.shape, dtype=A_.dtype,
         #                              matmat=lambda X: matmat(A_, X))
@@ -992,21 +1148,21 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
             def _matvec(self, x):
                 return matvec(A_, x)
             def _rmatvec(self, x):
-                return matvec(A_.mT.conj(), x)
+                return matvec(xp.conj(A_.mT), x)
         A = MyLinearOperator(shape=A_.shape, dtype=A_.dtype)
     elif operator_definition == "subclass_matmat":
         class MyLinearOperator(interface.LinearOperator):
             def _matmat(self, X):
                 return matmat(A_, X)
             def _rmatmat(self, X):
-                return matmat(A_.mT.conj(), X)
+                return matmat(xp.conj(A_.mT), X)
         A = MyLinearOperator(shape=A_.shape, dtype=A_.dtype)
 
     # Test matvec
     # a. with row vector (or batch of row vectors)
-    np.testing.assert_allclose(
+    xp_assert_close(
         A.matvec(x_row) if left else A.rmatvec(x_row),
-        matvec(A_, x_row) if left else matvec(A_.mT.conj(), x_row)
+        matvec(A_, x_row) if left else matvec(xp.conj(A_.mT), x_row)
     )
     # b. with column vector (or batch of column vectors)
     if batch_x:
@@ -1017,8 +1173,10 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
         message = ("Calling `matvec` on 'column vectors'..." if left
                    else "Calling `rmatvec` on 'column vectors'...")
         with pytest.warns(FutureWarning, match=message):
-            np.testing.assert_allclose(A.matvec(x_col) if left else A.rmatvec(x_col),
-                                       A_ @ x_col if left else A_.mT.conj() @ x_col)
+            xp_assert_close(
+                A.matvec(x_col) if left else A.rmatvec(x_col),
+                A_ @ x_col if left else xp.conj(A_.mT) @ x_col,
+            )
     # c. with matrix (or batch of matrices)
     with pytest.raises(ValueError, match="Dimension mismatch:..."):
         A.matvec(x_mat) if left else A.rmatvec(x_mat)
@@ -1029,11 +1187,15 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
     with pytest.raises(ValueError, match=message):
         A.matmat(x_row) if left else A.rmatmat(x_row)
     # b. with column vector (or batch of column vectors)
-    np.testing.assert_allclose(A.matmat(x_col) if left else A.rmatmat(x_col),
-                               A_ @ x_col if left else A_.mT.conj() @ x_col)
+    xp_assert_close(
+        A.matmat(x_col) if left else A.rmatmat(x_col),
+        A_ @ x_col if left else xp.conj(A_.mT) @ x_col,
+    )
     # c. with matrix (or batch of matrices)
-    np.testing.assert_allclose(A.matmat(x_mat) if left else A.rmatmat(x_mat),
-                               A_ @ x_mat if left else A_.mT.conj() @ x_mat)
+    xp_assert_close(
+        A.matmat(x_mat) if left else A.rmatmat(x_mat),
+        A_ @ x_mat if left else xp.conj(A_.mT) @ x_mat,
+    )
 
     # test __matmul__ (via `@`), `__call__`, and `dot`
     if left:
@@ -1042,17 +1204,17 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
             with pytest.raises(ValueError, match="Dimension mismatch:..."):
                 A @ x_row
         else:
-            np.testing.assert_allclose(A @ x_row, A_ @ x_row)
-            np.testing.assert_allclose(A(x_row), A_ @ x_row)
-            np.testing.assert_allclose(A.dot(x_row), A_ @ x_row)
+            xp_assert_close(A @ x_row, A_ @ x_row)
+            xp_assert_close(A(x_row), A_ @ x_row)
+            xp_assert_close(A.dot(x_row), A_ @ x_row)
         # b. with column vector (or batch of column vectors)
-        np.testing.assert_allclose(A @ x_col, A_ @ x_col)
-        np.testing.assert_allclose(A(x_col), A_ @ x_col)
-        np.testing.assert_allclose(A.dot(x_col), A_ @ x_col)
+        xp_assert_close(A @ x_col, A_ @ x_col)
+        xp_assert_close(A(x_col), A_ @ x_col)
+        xp_assert_close(A.dot(x_col), A_ @ x_col)
         # c. with matrix (or batch of matrices)
-        np.testing.assert_allclose(A @ x_mat, A_ @ x_mat)
-        np.testing.assert_allclose(A(x_mat), A_ @ x_mat)
-        np.testing.assert_allclose(A.dot(x_mat), A_ @ x_mat)
+        xp_assert_close(A @ x_mat, A_ @ x_mat)
+        xp_assert_close(A(x_mat), A_ @ x_mat)
+        xp_assert_close(A.dot(x_mat), A_ @ x_mat)
     else:
         # a. with row vector (or batch of row vectors)
         broadcastable = True
@@ -1066,15 +1228,15 @@ def test_batch(left, operator_definition, batch_A, batch_x, dtype):
             broadcastable = False
         if not broadcastable:
             # Maybe should be "Dimension mismatch..."?
-            msg = "operands could not be broadcast..."
-            with pytest.raises(ValueError, match=msg):
+            msg = "Incompatible shapes|size of tensor|could not be broadcast..."
+            with pytest.raises((ValueError, RuntimeError), match=msg):
                 x_row @ A
         else:
-            np.testing.assert_allclose(x_row @ A, x_row @ A_)
-            np.testing.assert_allclose(A.rdot(x_row), x_row @ A_)
+            xp_assert_close(x_row @ A, x_row @ A_)
+            xp_assert_close(A.rdot(x_row), x_row @ A_)
         # b. with column vector (or batch of column vectors)
         with pytest.raises(ValueError, match="Dimension mismatch:..."):
             x_col @ A
         # c. with matrix (or batch of matrices)
-        np.testing.assert_allclose(x_mat.mT.conj() @ A, x_mat.mT.conj() @ A_)
-        np.testing.assert_allclose(A.rdot(x_mat.mT.conj()), x_mat.mT.conj() @ A_)
+        xp_assert_close(xp.conj(x_mat.mT) @ A, xp.conj(x_mat.mT) @ A_)
+        xp_assert_close(A.rdot(xp.conj(x_mat.mT)), xp.conj(x_mat.mT) @ A_)

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -645,10 +645,9 @@ class TestAsLinearOperator:
             args = ()
 
             def __init__(self, dtype):
-                xp_dtype = _xp.asarray(np.empty(0, dtype=dtype)).dtype
                 super().__init__(
-                    dtype=xp_dtype,
-                    shape=original.shape
+                    dtype=dtype,
+                    shape=original.shape,
                 )
 
             def _matvec(self, x):
@@ -667,19 +666,18 @@ class TestAsLinearOperator:
                 shape = self.shape[1], self.shape[0]
                 matvec = partial(rmv)
                 rmatvec = partial(mv)
-                xp_dtype = _xp.asarray(np.empty(0, dtype=self.dtype)).dtype
                 return interface.LinearOperator(matvec=matvec,
                                                 rmatvec=rmatvec,
-                                                dtype=xp_dtype,
-                                                shape=shape)
+                                                dtype=dtype,
+                                                shape=shape,)
 
         class HasRmatmat(HasRmatvec):
             def _matmat(self, x):
-                return original.dot(x)
+                return original @ x
 
             def _rmatmat(self, x):
-                return original.T.conj().dot(x)
-        
+                return _xp.conj(original.T) @ x
+
         if xp:
             cases.append((original, original))
 


### PR DESCRIPTION
For gh-24627.

This PR converts `test_interface` to modern test idioms while keeping the tests `np_only` for now. A future PR will run these tests through alternative backends while adding array API standard support to `LinearOperator`.