### PR TITLE
ENH: integrate.tanhsinh/nsum: add kwargs support

### DIFF
--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -694,7 +694,7 @@ class TestTanhSinh:
         def f(x, c):
             return x**c
 
-        res = _tanhsinh(f, a, b, args=29)
+        res = _tanhsinh(f, a, b, args=xp.asarray(29.))
         xp_assert_close(res.integral, xp.asarray(1/30))
 
         # Test NaNs
@@ -755,6 +755,20 @@ class TestTanhSinh:
         assert res.success
         assert res.maxlevel < 5
         xp_assert_close(res.integral, ref.integral, rtol=1e-15)
+
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    def test_kwargs(self, xp, dtype):
+        # test that `kwargs` is used, broadcasts correctly, and affects dtype
+        def f(x, c, *, p):
+            return x**p + c
+
+        a = xp.zeros((), dtype=xp.float32)
+        b = xp.ones((), dtype=xp.float32)
+        c = xp.asarray([1, 2, 3], dtype=xp.float32)
+        p = xp.asarray([2, 3, 4], dtype=getattr(xp, dtype))[:, xp.newaxis]
+        res = _tanhsinh(f, a, b, args=(c,), kwargs={'p': p})
+        ref = b**(p+1) / (p+1) + c
+        xp_assert_close(res.integral, ref)
 
 
 @make_xp_test_case(nsum)

--- a/scipy/integrate/tests/test_tanhsinh.py
+++ b/scipy/integrate/tests/test_tanhsinh.py
@@ -1170,3 +1170,18 @@ class TestNSum:
 
         res = nsum(f, 1, np.inf)
         assert_allclose(res.sum, ref)
+
+    @pytest.mark.parametrize('dtype', ['float32', 'float64'])
+    def test_kwargs(self, xp, dtype):
+        # test that `kwargs` is used, broadcasts correctly, and affects dtype
+        def f(x, c, *, p):
+            return x**-p + c
+
+        a = xp.ones((), dtype=xp.float32)
+        b = xp.full((), 10, dtype=xp.float32)
+        c = xp.asarray([1, 2, 3], dtype=xp.float32)
+        p = xp.asarray([2, 3, 4], dtype=getattr(xp, dtype))[:, xp.newaxis]
+        res = nsum(f, a, b, args=(c,), kwargs={'p': p})
+        x = xp.arange(1, 11, dtype=xp.float32)
+        ref = xp.sum(f(x, c[..., xp.newaxis], p=p[..., xp.newaxis]), axis=-1)
+        xp_assert_close(res.sum, ref)


### PR DESCRIPTION
#### Reference issue
gh-24616

#### What does this implement/fix?
While reading comments in the distribution infrastructure code, I noticed the comment in `_quadrature`:
```
# Much of this should be added to `_tanhsinh`.
```

This PR addresses the comment by adding `kwargs` support to `integrate.tanhsinh` and `integrate.nsum`, allowing substantial simplification of `_quadrature`.

#### Additional information
Unlike most other functions that accept `args` and `kwargs`, `tanhsinh` and `nsum` *do something* with them before passing them on to the callable. That is why the callable cannot simply be redefined like `lambda x: f(x, *args, **kwargs)`. Support for _at least_ `args` is essential if the callable accepts arrays besides the argument `x`. As one can see from `_quadrature` code, it is possible to hijack `args` to work with functions that require keyword arguments with a `_kwargs2args` wrapper, but in this case I think it's worth adding proper `kwargs` support to eliminate that complexity.

To keep things manageable, I'll do the equivalent for `solve_bounded` in a separate PR, adding `kwargs` support to `optimize.elementwise.bracket_root` and `optimize.elementwise.find_root`. Eventually, with support for `kwargs` throughout the elementwise iterative methods and in `apply_where` (data-apis/array-api-extra#624), we'll be able to remove the `_kwargs2args` wrapper. 