### PR TITLE
DOC: optimize.root: document default values of optional parameters

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -200,33 +200,37 @@ def _root_hybr(func, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, optional
         Specify whether the Jacobian function computes derivatives down
         the columns (faster, because there is no transpose operation).
-    xtol : float
+        Default is 0 (False).
+    xtol : float, optional
         The calculation will terminate if the relative error between two
-        consecutive iterates is at most `xtol`.
-    maxfev : int
+        consecutive iterates is at most `xtol`. Default is 1.49012e-08.
+    maxfev : int, optional
         The maximum number of calls to the function. If zero, then
         ``100*(N+1)`` is the maximum where N is the number of elements
-        in `x0`.
-    band : tuple
+        in `x0`. Default is 0.
+    band : tuple, optional
         If set to a two-sequence containing the number of sub- and
         super-diagonals within the band of the Jacobi matrix, the
         Jacobi matrix is considered banded (only for ``jac=None``).
-    eps : float
+        Default is None.
+    eps : float, optional
         A suitable step length for the forward-difference
         approximation of the Jacobian (for ``jac=None``). If
         `eps` is less than the machine precision, it is assumed
         that the relative errors in the functions are of the order of
-        the machine precision.
-    factor : float
+        the machine precision. Default is None, in which case the
+        machine precision of the dtype inferred from `func` and `x0`
+        is used.
+    factor : float, optional
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in the interval
-        ``(0.1, 100)``.
-    diag : sequence
+        ``(0.1, 100)``. Default is 100.
+    diag : sequence, optional
         N positive entries that serve as a scale factors for the
-        variables.
+        variables. Default is None.
 
     """
     _check_unknown_options(unknown_options)

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -286,29 +286,35 @@ def _root_leastsq(fun, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, optional
         non-zero to specify that the Jacobian function computes derivatives
         down the columns (faster, because there is no transpose operation).
-    ftol : float
+        Default is 0 (False).
+    ftol : float, optional
         Relative error desired in the sum of squares.
-    xtol : float
+        Default is 1.49012e-08.
+    xtol : float, optional
         Relative error desired in the approximate solution.
-    gtol : float
+        Default is 1.49012e-08.
+    gtol : float, optional
         Orthogonality desired between the function vector and the columns
-        of the Jacobian.
-    maxiter : int
+        of the Jacobian. Default is 0.0.
+    maxiter : int, optional
         The maximum number of calls to the function. If zero, then
         100*(N+1) is the maximum where N is the number of elements in x0.
-    eps : float
+        Default is 0.
+    eps : float, optional
         A suitable step length for the forward-difference approximation of
         the Jacobian (for Dfun=None). If `eps` is less than the machine
         precision, it is assumed that the relative errors in the functions
-        are of the order of the machine precision.
-    factor : float
+        are of the order of the machine precision. Default is 0.0.
+    factor : float, optional
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in interval ``(0.1, 100)``.
-    diag : sequence
+        Default is 100.
+    diag : sequence, optional
         N positive entries that serve as a scale factors for the variables.
+        Default is None.
     """
     nfev = 0
     def _wrapped_fun(*fargs):

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -21,36 +21,37 @@ def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
     Options
     -------
     ftol : float, optional
-        Relative norm tolerance.
+        Relative norm tolerance. Default is 1e-8.
     fatol : float, optional
         Absolute norm tolerance.
         Algorithm terminates when ``||func(x)|| < fatol + ftol ||func(x_0)||``.
+        Default is 1e-300.
     fnorm : callable, optional
         Norm to use in the convergence check. If None, 2-norm is used.
+        Default is None.
     maxfev : int, optional
-        Maximum number of function evaluations.
+        Maximum number of function evaluations. Default is 1000.
     disp : bool, optional
-        Whether to print convergence process to stdout.
+        Whether to print convergence process to stdout. Default is False.
     eta_strategy : callable, optional
         Choice of the ``eta_k`` parameter, which gives slack for growth
         of ``||F||**2``.  Called as ``eta_k = eta_strategy(k, x, F)`` with
         `k` the iteration number, `x` the current iterate and `F` the current
         residual. Should satisfy ``eta_k > 0`` and ``sum(eta, k=0..inf) < inf``.
-        Default: ``||F||**2 / (1 + k)**2``.
+        Default is ``||F||**2 / (1 + k)**2``.
     sigma_eps : float, optional
         The spectral coefficient is constrained to ``sigma_eps < sigma < 1/sigma_eps``.
-        Default: 1e-10
+        Default is 1e-10.
     sigma_0 : float, optional
-        Initial spectral coefficient.
-        Default: 1.0
+        Initial spectral coefficient. Default is 1.0.
     M : int, optional
         Number of iterates to include in the nonmonotonic line search.
-        Default: 10
-    line_search : {'cruz', 'cheng'}
+        Default is 10.
+    line_search : {'cruz', 'cheng'}, optional
         Type of line search to employ. 'cruz' is the original one defined in
         [Martinez & Raydan. Math. Comp. 75, 1429 (2006)], 'cheng' is
         a modified search defined in [Cheng & Li. IMA J. Numer. Anal. 29, 814 (2009)].
-        Default: 'cruz'
+        Default is 'cruz'.
 
     References
     ----------


### PR DESCRIPTION
#### Reference issue
Closes #22635

#### What does this implement/fix?
Documents the default values for optional parameters in the docstrings of:
- `_root_hybr()` in `_minpack_py.py`
- `_root_leastsq()` in `_root.py`
- `_root_df_sane()` in `_spectral.py`

Default values are added inline in the parameter descriptions following NumPy docstring conventions (e.g., "Default is ..."), making them visible in the rendered documentation.

Note: The other 7 root methods (broyden1, broyden2, anderson, linearmixing, diagbroyden, excitingmixing, krylov) already document their defaults adequately in their respective docstrings.