### PR TITLE
MAINT: stats.UnivariateDistribution: don't reset cache when transforming

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4473,7 +4473,6 @@ class TransformedDistribution(ContinuousDistribution):
                 or super()._overrides(method_name))
 
     def reset_cache(self):
-        self._dist.reset_cache()
         super().reset_cache()
 
     def _update_parameters(self, *, validation_policy=None, **params):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1021,6 +1021,12 @@ class TestAttributes:
         cached_mean = dist.mean(method='cache')
         assert_equal(cached_mean, mean)
 
+        # cache is not cleared when used in a TransformedDistribution
+        dist2 = stats.exp(dist)
+        assert_equal(dist.mean(method='cache'), cached_mean)
+        dist2.reset_cache()
+        assert_equal(dist.mean(method='cache'), cached_mean)
+
         # cache is overridden by latest evaluation
         quadrature_mean = dist.mean(method='quadrature')
         cached_mean = dist.mean(method='cache')


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/23766#issue-3508972523

#### What does this implement/fix?
In main, resetting the cache of a `TransformedDistribution` resets the cache of the underlying distribution. That was a bug, so this PR fixes it.

#### AI Generation Disclosure
No AI tools used