### PR TITLE
DOC: spatial.KDTree.query_ball_point: fix `Returns` section for `return_length=True`

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -896,7 +896,7 @@ cdef class cKDTree:
 
         Returns
         -------
-        results : list or array of lists or array or numpy.int64 or array of numpy.int64
+        results : list or array of list or int or array of int
             If `x` is a single point, returns a list of the indices of the
             neighbors of `x`. If `x` is an array of points, returns an object
             array of shape tuple containing lists of neighbors.

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -896,10 +896,11 @@ cdef class cKDTree:
 
         Returns
         -------
-        results : list or array of lists
+        results : list or array of lists or array or numpy.int64 or array of numpy.int64
             If `x` is a single point, returns a list of the indices of the
             neighbors of `x`. If `x` is an array of points, returns an object
             array of shape tuple containing lists of neighbors.
+            If return_length=True, returns an numpy.in64 or array of numpy.int64 respectively.
 
         Notes
         -----


### PR DESCRIPTION
#### What does this implement/fix?
Updates the documentation, for the option `return_length=True`

https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.KDTree.query_ball_point.html