### PR TITLE
TST: datasets: make tests runnable without pooch

### DIFF
--- a/scipy/datasets/tests/test_data.py
+++ b/scipy/datasets/tests/test_data.py
@@ -7,12 +7,7 @@ import os
 from threading import get_ident
 import pytest
 
-try:
-    import pooch
-except ImportError:
-    raise ImportError("Missing optional dependency 'pooch' required "
-                      "for scipy.datasets module. Please use pip or "
-                      "conda to install 'pooch'.")
+pooch = pytest.importorskip("pooch")
 
 
 data_dir = data_fetcher.path  # type: ignore


### PR DESCRIPTION
Gives a slightly better DX for `spin test`: otherwise it fails pytest collection if `pooch` is not installed.


#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure

No AI tools used
