### PR TITLE
BLD: add a build option to build without a Fortran compiler

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -656,3 +656,27 @@ jobs:
         export OMP_NUM_THREADS=2
         cd ..
         pytest --pyargs scipy -m 'not slow' --durations=0 --durations-min=0.5 --fail-slow=1.0
+
+  #################################################################################
+  test_without_fortran:
+    name: No Fortran, fast, py3.14/npAny, spin
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+
+      - uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659 # v0.8.1
+        with:
+          pixi-version: v0.63.2
+          cache: false
+
+      - name: Build SciPy
+        run: pixi run build --setup-args=-D_without-fortran=true
+
+      - name: Test SciPy
+        run: pixi run test

--- a/meson.build
+++ b/meson.build
@@ -86,24 +86,26 @@ if host_machine.system() == 'os400'
   add_project_link_arguments('-Wl,-bnotextro', language : ['c', 'cpp', 'fortran'])
 endif
 
-# Adding at project level causes many spurious -lgfortran flags.
-add_languages('fortran', native: false)
-ff = meson.get_compiler('fortran')
-if ff.get_id() == 'gcc'
-  # -std=legacy is not supported by all Fortran compilers, but very useful with
-  # gfortran since it avoids a ton of warnings that we don't care about.
-  # Needs fixing in Meson, see https://github.com/mesonbuild/meson/issues/11633.
-  add_project_arguments('-std=legacy', language: 'fortran')
-endif
+if not get_option('_without-fortran')
+  # Adding at project level causes many spurious -lgfortran flags.
+  add_languages('fortran', native: false)
+  ff = meson.get_compiler('fortran')
+  if ff.get_id() == 'gcc'
+    # -std=legacy is not supported by all Fortran compilers, but very useful with
+    # gfortran since it avoids a ton of warnings that we don't care about.
+    # Needs fixing in Meson, see https://github.com/mesonbuild/meson/issues/11633.
+    add_project_arguments('-std=legacy', language: 'fortran')
+  endif
 
-if ff.has_argument('-Wno-conversion')
-  add_project_arguments('-Wno-conversion', language: 'fortran')
-endif
+  if ff.has_argument('-Wno-conversion')
+    add_project_arguments('-Wno-conversion', language: 'fortran')
+  endif
 
-if ff.get_id() == 'llvm-flang'
-  add_project_arguments('-D_CRT_SECURE_NO_WARNINGS', language: ['fortran'])
-  # -Wall warnings are visible because Meson's warning_level defaults to 1 (-Wall)
-  # LLVM tracking issue: https://github.com/llvm/llvm-project/issues/89888
+  if ff.get_id() == 'llvm-flang'
+    add_project_arguments('-D_CRT_SECURE_NO_WARNINGS', language: ['fortran'])
+    # -Wall warnings are visible because Meson's warning_level defaults to 1 (-Wall)
+    # LLVM tracking issue: https://github.com/llvm/llvm-project/issues/89888
+  endif
 endif
 
 if cc.get_id() == 'clang-cl'
@@ -138,28 +140,31 @@ endif
 # detection logic below. You have to remove the wrong flags (only `-isystem`
 # is actually needed, everything else shouldn't be there).
 _intel_cflags = []
-_intel_fflags = []
 if cc.get_id() in ['intel', 'intel-llvm']
   _intel_cflags += cc.get_supported_arguments('-fp-model=strict')
 elif cc.get_id() in ['intel-cl', 'intel-llvm-cl']
   _intel_cflags += cc.get_supported_arguments('/fp:strict')
 endif
-if ff.get_id() in ['intel', 'intel-llvm']
-  _intel_fflags = ff.get_supported_arguments('-fp-model=strict')
-  minus0_arg = ['-assume', 'minus0']
-  if ff.has_multi_arguments(minus0_arg)
-    _intel_fflags += minus0_arg
-  endif
-elif ff.get_id() in ['intel-cl', 'intel-llvm-cl']
-  # Intel Fortran on Windows does things differently, so deal with that
-  # (also specify dynamic linking and the right name mangling)
-  _intel_fflags = ff.get_supported_arguments(
-    '/fp:strict', '/MD', '/names:lowercase', '/assume:underscore',
-    '/assume:minus0'
-  )
-endif
 add_global_arguments(_intel_cflags, language: ['c', 'cpp'])
-add_global_arguments(_intel_fflags, language: 'fortran')
+
+if not get_option('_without-fortran')
+  _intel_fflags = []
+  if ff.get_id() in ['intel', 'intel-llvm']
+    _intel_fflags = ff.get_supported_arguments('-fp-model=strict')
+    minus0_arg = ['-assume', 'minus0']
+    if ff.has_multi_arguments(minus0_arg)
+      _intel_fflags += minus0_arg
+    endif
+  elif ff.get_id() in ['intel-cl', 'intel-llvm-cl']
+    # Intel Fortran on Windows does things differently, so deal with that
+    # (also specify dynamic linking and the right name mangling)
+    _intel_fflags = ff.get_supported_arguments(
+      '/fp:strict', '/MD', '/names:lowercase', '/assume:underscore',
+      '/assume:minus0'
+    )
+  endif
+  add_global_arguments(_intel_fflags, language: 'fortran')
+endif
 
 # Hide symbols when building on Linux with GCC. For Python extension modules,
 # we only need `PyInit_*` to be public, anything else may cause problems. So we

--- a/meson.options
+++ b/meson.options
@@ -23,3 +23,6 @@ option('use-system-libraries', type: 'array',
         choices : ['none', 'all', 'auto', 'boost.math', 'qhull'], value : ['none'],
         description: 'Choose which system libraries for subprojects ' +
                      'if they are available.')
+option('_without-fortran', type: 'boolean', value: false,
+       description: 'If set to true, build without a Fortran compiler ' +
+                    '(the deprecated `scipy.odr` will be missing)')

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -114,6 +114,12 @@ submodules = [
     'stats'
 ]
 
+# Handle `_without-fortran` build option
+import os
+if not os.path.exists('odr'):
+    submodules.remove('odr')
+del os
+
 __all__ = submodules + [
     'LowLevelCallable',
     'test',

--- a/scipy/_lib/_public_api.py
+++ b/scipy/_lib/_public_api.py
@@ -10,6 +10,8 @@ scipy/doc/source/array_api_capabilities.py.
 # much.  This has resulted in lots of things that look like public modules
 # (i.e. things that can be imported as `import scipy.somesubmodule.somefile`),
 # but were never intended to be public.  The PUBLIC_MODULES list contains
+import pathlib
+
 # modules that are either public because they were meant to be, or because they
 # contain public functions/objects that aren't present in any other namespace
 # for whatever reason and therefore should be treated as public.
@@ -54,3 +56,9 @@ PUBLIC_MODULES = ["scipy." + s for s in [
     "stats.qmc",
     "stats.sampling"
 ]]
+
+# Handle the `_without-fortran` build option
+_without_fortran = False
+if not (pathlib.Path(__file__).parent.parent / 'odr').is_dir():
+    _without_fortran = True
+    PUBLIC_MODULES.remove('scipy.odr')

--- a/scipy/_lib/tests/test_public_api.py
+++ b/scipy/_lib/tests/test_public_api.py
@@ -13,7 +13,7 @@ import pytest
 
 import scipy
 
-from scipy._lib._public_api import PUBLIC_MODULES
+from scipy._lib._public_api import PUBLIC_MODULES, _without_fortran
 from scipy.conftest import xp_available_backends
 
 
@@ -145,6 +145,10 @@ PRIVATE_BUT_PRESENT_MODULES = [
     'scipy.stats.mvn',
     'scipy.stats.stats',
 ]
+
+if _without_fortran:
+    PRIVATE_BUT_PRESENT_MODULES.remove('scipy.odr.models')
+    PRIVATE_BUT_PRESENT_MODULES.remove('scipy.odr.odrpack')
 
 
 def is_unexpected(name):

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -54,7 +54,7 @@ linalg_cython_gen = generator(cython,
 
 # fblas
 fblas_module = custom_target('fblas_module',
-  output: ['_fblasmodule.c', '_fblas-f2pywrappers.f'],
+  output: ['_fblasmodule.c'],
   input: 'fblas.pyf.src',
   command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'] + f2py_freethreading_arg,
   depend_files:
@@ -65,6 +65,13 @@ fblas_module = custom_target('fblas_module',
     ]
 )
 
+link_language_blas_lapack = 'fortran'
+if get_option('_without-fortran')
+  link_language_blas_lapack = 'c'
+endif
+
+message(f'{fblas_module}')
+
 # Note: we're linking LAPACK on purpose here. For some routines (e.g., spmv)
 # the float/double routines are in BLAS while the complex routines are in
 # LAPACK - we have historically put these in `_fblas`.
@@ -73,7 +80,7 @@ py3.extension_module('_fblas',
   link_args: version_link_args,
   dependencies: [lapack_lp64_dep, fortranobject_dep],
   install: true,
-  link_language: 'fortran',
+  link_language: link_language_blas_lapack,
   subdir: 'scipy/linalg'
 )
 
@@ -121,7 +128,7 @@ py3.extension_module('_flapack',
 #       in azure-pipelines.yml if you want to check that).
 if use_ilp64
   fblas64_module = custom_target('fblas64_module',
-    output: ['_fblas_64module.c', '_fblas_64-f2pywrappers.f'],
+    output: ['_fblas_64module.c'],
     input: 'fblas_64.pyf.src',
     command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'] + f2py_ilp64_opts + f2py_freethreading_arg,
     depend_files:
@@ -138,12 +145,12 @@ if use_ilp64
     include_directories: ['../_build_utils/src'],   # for npy_cblas.h
     dependencies: [lapack_dep, fortranobject_dep],  # lapack_dep is ILP64 if use_ilp64==true
     install: true,
-    link_language: 'fortran',
+    link_language: link_language_blas_lapack,
     subdir: 'scipy/linalg'
   )
 
   flapack64_module = custom_target('flapack64_module',
-    output: ['_flapack_64module.c', '_flapack_64-f2pywrappers.f'],
+    output: ['_flapack_64module.c'],
     input: 'flapack_64.pyf.src',
     command: [generate_f2pymod, '@INPUT@', '-o', '@OUTDIR@'] + f2py_ilp64_opts + f2py_freethreading_arg,
   )
@@ -155,7 +162,7 @@ if use_ilp64
     include_directories: ['../_build_utils/src'],   # for npy_cblas.h
     dependencies: [lapack_dep, fortranobject_dep],
     install: true,
-    link_language: 'fortran',
+    link_language: link_language_blas_lapack,
     subdir: 'scipy/linalg'
   )
 endif

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -1,7 +1,9 @@
 # Platform detection
 is_mingw = is_windows and cc.get_id() == 'gcc'
-if is_mingw and ff.get_id() != 'gcc'
-  error('If you are using GCC on Windows, you must also use GFortran! Detected ' + ff.get_id())
+if not get_option('_without-fortran')
+  if is_mingw and ff.get_id() != 'gcc'
+    error('If you are using GCC on Windows, you must also use GFortran! Detected ' + ff.get_id())
+  endif
 endif
 
 cython_c_args = ['-DCYTHON_CCOMPLEX=0'] # see gh-18975 for why we need this
@@ -594,51 +596,54 @@ cpp_args_pythran += [
   _cpp_Wno_int_in_bool_context,
 ]
 
-# Fortran warning flags
-_fflag_Wno_argument_mismatch = ff.get_supported_arguments('-Wno-argument-mismatch')
-_fflag_Wno_conversion = ff.get_supported_arguments('-Wno-conversion')
-_fflag_Wno_intrinsic_shadow = ff.get_supported_arguments('-Wno-intrinsic-shadow')
-_fflag_Wno_maybe_uninitialized = ff.get_supported_arguments('-Wno-maybe-uninitialized')
-_fflag_Wno_surprising = ff.get_supported_arguments('-Wno-surprising')
-_fflag_Wno_uninitialized = ff.get_supported_arguments('-Wno-uninitialized')
-_fflag_Wno_unused_dummy_argument = ff.get_supported_arguments('-Wno-unused-dummy-argument')
-_fflag_Wno_unused_label = ff.get_supported_arguments('-Wno-unused-label')
-_fflag_Wno_unused_variable = ff.get_supported_arguments('-Wno-unused-variable')
-_fflag_Wno_tabs = ff.get_supported_arguments('-Wno-tabs')
-# The default list of warnings to ignore from Fortran code. There is a lot of
-# old, vendored code that is very bad and we want to compile it silently (at
-# least with GCC and Clang)
-fortran_ignore_warnings = ff.get_supported_arguments(
- _fflag_Wno_argument_mismatch,
- _fflag_Wno_conversion,
- _fflag_Wno_maybe_uninitialized,
- _fflag_Wno_unused_dummy_argument,
- _fflag_Wno_unused_label,
- _fflag_Wno_unused_variable,
- _fflag_Wno_tabs,
-)
+if not get_option('_without-fortran')
+  # Fortran warning flags
+  _fflag_Wno_argument_mismatch = ff.get_supported_arguments('-Wno-argument-mismatch')
+  _fflag_Wno_conversion = ff.get_supported_arguments('-Wno-conversion')
+  _fflag_Wno_intrinsic_shadow = ff.get_supported_arguments('-Wno-intrinsic-shadow')
+  _fflag_Wno_maybe_uninitialized = ff.get_supported_arguments('-Wno-maybe-uninitialized')
+  _fflag_Wno_surprising = ff.get_supported_arguments('-Wno-surprising')
+  _fflag_Wno_uninitialized = ff.get_supported_arguments('-Wno-uninitialized')
+  _fflag_Wno_unused_dummy_argument = ff.get_supported_arguments('-Wno-unused-dummy-argument')
+  _fflag_Wno_unused_label = ff.get_supported_arguments('-Wno-unused-label')
+  _fflag_Wno_unused_variable = ff.get_supported_arguments('-Wno-unused-variable')
+  _fflag_Wno_tabs = ff.get_supported_arguments('-Wno-tabs')
+  # The default list of warnings to ignore from Fortran code. There is a lot of
+  # old, vendored code that is very bad and we want to compile it silently (at
+  # least with GCC and Clang)
+  fortran_ignore_warnings = ff.get_supported_arguments(
+   _fflag_Wno_argument_mismatch,
+   _fflag_Wno_conversion,
+   _fflag_Wno_maybe_uninitialized,
+   _fflag_Wno_unused_dummy_argument,
+   _fflag_Wno_unused_label,
+   _fflag_Wno_unused_variable,
+   _fflag_Wno_tabs,
+  )
 
-# Intel Fortran (ifort) does not run the preprocessor by default, if Fortran
-# code uses preprocessor statements, add this compile flag to it.
+  # Intel Fortran (ifort) does not run the preprocessor by default, if Fortran
+  # code uses preprocessor statements, add this compile flag to it.
 
-# Gfortran does run the preprocessor for .F files, and PROPACK is the only
-# component which needs the preprocessor (unless we need symbol renaming for
-# blas_symbol_suffix).
-_fflag_preprocess = []
-_gfortran_preprocess = ['-cpp', '-ffree-line-length-none', '-ffixed-line-length-none']
-if ff.has_multi_arguments(_gfortran_preprocess)
-  _fflag_preprocess = _gfortran_preprocess
-else
-  _fflag_preprocess = ff.first_supported_argument(['-fpp', '/fpp', '-cpp'])
+  # Gfortran does run the preprocessor for .F files, and PROPACK is the only
+  # component which needs the preprocessor (unless we need symbol renaming for
+  # blas_symbol_suffix).
+  _fflag_preprocess = []
+  _gfortran_preprocess = ['-cpp', '-ffree-line-length-none', '-ffixed-line-length-none']
+  if ff.has_multi_arguments(_gfortran_preprocess)
+    _fflag_preprocess = _gfortran_preprocess
+  else
+    _fflag_preprocess = ff.first_supported_argument(['-fpp', '/fpp', '-cpp'])
+  endif
+  if use_ilp64
+    _fflag_ilp64 = []
+    # Gfortran and Clang use `-fdefault-integer-8` to switch to 64-bit integers by
+    # default, all other known compilers use `-i8`
+    _fflag_ilp64 = ff.first_supported_argument(['-fdefault-integer-8', '-i8'])
+  endif
 endif
 
-_fflag_ilp64 = []
 f2py_ilp64_opts = []
 if use_ilp64
-  # Gfortran and Clang use `-fdefault-integer-8` to switch to 64-bit integers by
-  # default, all other known compilers use `-i8`
-  _fflag_ilp64 = ff.first_supported_argument(['-fdefault-integer-8', '-i8'])
-
   # Write out a mapping file for f2py for defaulting to ILP64
   conf_data = configuration_data()
   if cc.sizeof('long') == 8
@@ -713,8 +718,12 @@ compilers = {
   'C': cc,
   'CPP': cpp,
   'CYTHON': meson.get_compiler('cython'),
-  'FORTRAN': meson.get_compiler('fortran')
 }
+if get_option('_without-fortran')
+  compilers += {'FORTRAN': meson.get_compiler('c')}
+else
+  compilers += {'FORTRAN': meson.get_compiler('fortran')}
+endif
 
 machines = {
   'HOST': host_machine,
@@ -729,14 +738,19 @@ foreach name, compiler : compilers
   conf_data.set(name + '_COMP_LINKER_ID', compiler.get_linker_id())
   conf_data.set(name + '_COMP_VERSION', compiler.version())
   conf_data.set(name + '_COMP_CMD_ARRAY', ', '.join(compiler.cmd_array()))
-  conf_data.set(name + '_COMP_ARGS', ', '.join(
-      get_option(name.to_lower() + '_args')
+  if get_option('_without-fortran') and name == 'FORTRAN'
+    conf_data.set('FORTRAN_COMP_ARGS', 'n/a')
+    conf_data.set('FORTRAN_COMP_LINK_ARGS', 'n/a')
+  else
+    conf_data.set(name + '_COMP_ARGS', ', '.join(
+        get_option(name.to_lower() + '_args')
+      )
     )
-  )
-  conf_data.set(name + '_COMP_LINK_ARGS', ', '.join(
-      get_option(name.to_lower() + '_link_args')
+    conf_data.set(name + '_COMP_LINK_ARGS', ', '.join(
+        get_option(name.to_lower() + '_link_args')
+      )
     )
-  )
+  endif
 endforeach
 # Add `pythran` information if present
 if use_pythran
@@ -844,6 +858,8 @@ subdir('differentiate')
 subdir('signal')
 subdir('interpolate')
 subdir('ndimage')
-subdir('odr')
+if not get_option('_without-fortran')
+  subdir('odr')
+endif
 subdir('datasets')
 subdir('misc')


### PR DESCRIPTION
This came out of a real-world need of building on a machine where a Fortran compiler couldn't easily be installed globally, and it was important to have a build setup with global compilers. Right now the only reason we still require a Fortran compiler is the deprecated `scipy.odr` module, hence this is anyway useful as a step in the right direction of shipping a fully Fortran-free SciPy.

The build option is private, starting with an underscore: `_without-fortran`. It seems useful for "at your own risk" dev tasks, but I don't want to promise any kind of stability for this kind of thing.

Also add a CI job, and a few small tweaks to the tests for `__all__` and the public API to account for `scipy.odr` not being installed when this build option is used.


#### Reference issue

Made possible by gh-18566


#### AI Generation Disclosure

No AI tools used