### PR TITLE
MAINT: replace usage of isspmatrix throughout scipy

### DIFF
--- a/doc/source/reference/sparse.migration_to_sparray.rst
+++ b/doc/source/reference/sparse.migration_to_sparray.rst
@@ -100,6 +100,8 @@ Recommended steps for migration
    -  Change any logic regarding ``issparse()`` and ``isspmatrix()`` as
       needed. Usually, this means replacing ``isspmatrix`` with ``issparse``,
       and ``isspmatrix_csr(G)`` with ``issparse(G) and G.format == "csr"``.
+      If you need to see whether a sparse object is a sparray or spmatrix
+      use ``isinstance(G, sparray)``, or ``issparse(G) and not isinstance(G, sparray)``
       Moreover ``isspmatrix_csr(G) or isspmatrix_csc(G)`` becomes
       ``issparse(G) and G.format in ['csr', 'csc']``.
       The git search idiom ``git grep 'isspm[a-z_]*('`` can help find these.

--- a/scipy/io/_harwell_boeing/tests/test_hb.py
+++ b/scipy/io/_harwell_boeing/tests/test_hb.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import assert_equal, \
     assert_array_almost_equal_nulp
 
-from scipy.sparse import coo_array, csc_array, random_array, isspmatrix
+from scipy.sparse import coo_array, csc_array, random_array, sparray, issparse
 
 from scipy.io import hb_read, hb_write
 
@@ -47,11 +47,11 @@ class TestHBReader:
     def test_simple(self):
         m = hb_read(StringIO(SIMPLE), spmatrix=False)
         assert_csc_almost_equal(m, SIMPLE_MATRIX)
-        assert not isspmatrix(m)
+        assert isinstance(m, sparray)
         m = hb_read(StringIO(SIMPLE), spmatrix=True)
-        assert isspmatrix(m)
+        assert issparse(m) and not isinstance(m, sparray)
         m = hb_read(StringIO(SIMPLE))  # default
-        assert isspmatrix(m)
+        assert issparse(m) and not isinstance(m, sparray)
 
 
 class TestHBReadWrite:

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -1185,11 +1185,12 @@ def test_empty_sparse():
     sio.seek(0)
 
     res = loadmat(sio, spmatrix=False)
-    assert not scipy.sparse.isspmatrix(res['x'])
+    sparray = scipy.sparse.sparray
+    assert isinstance(res['x'], sparray)
     res = loadmat(sio, spmatrix=True)
-    assert scipy.sparse.isspmatrix(res['x'])
+    assert scipy.sparse.issparse(res['x']) and not isinstance(res['x'], sparray)
     res = loadmat(sio)  # chk default
-    assert scipy.sparse.isspmatrix(res['x'])
+    assert scipy.sparse.issparse(res['x']) and not isinstance(res['x'], sparray)
 
     assert_array_equal(res['x'].shape, empty_sparse.shape)
     assert_array_equal(res['x'].toarray(), 0)

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -276,12 +276,12 @@ class TestMMIOSparseCSR(TestMMIOArray):
         assert_equal(mminfo(self.fn), info)
         b = mmread(self.fn, spmatrix=False)
         assert_array_almost_equal(p, b.toarray())
-        assert not scipy.sparse.isspmatrix(b)
+        assert isinstance(b, scipy.sparse.sparray)
 
         b = mmread(self.fn, spmatrix=True)
-        assert scipy.sparse.isspmatrix(b)
+        assert isinstance(b, scipy.sparse.spmatrix)
         b = mmread(self.fn)  # chk default
-        assert scipy.sparse.isspmatrix(b)
+        assert isinstance(b, scipy.sparse.spmatrix)
 
     def test_gh13634_non_skew_symmetric_int(self):
         a = scipy.sparse.csr_array([[1, 2], [-2, 99]], dtype=np.int32)

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.linalg import norm
 
 from scipy.sparse.linalg import LinearOperator
-from ..sparse import issparse, isspmatrix, find, csc_array, csr_array, csr_matrix
+from ..sparse import issparse, spmatrix, find, csc_array, csr_array, csr_matrix
 from ._group_columns import group_dense, group_sparse
 from scipy._lib._array_api import array_namespace, xp_result_type
 from scipy._lib._util import MapWrapper
@@ -880,7 +880,7 @@ def _sparse_difference(fun, x0, f0, h, use_one_sided,
     col_indices = np.hstack(col_indices)
     fractions = np.hstack(fractions)
 
-    if isspmatrix(structure):
+    if isinstance(structure, spmatrix):
         return csr_matrix(
             (fractions, (row_indices, col_indices)),
             shape=(m, n),

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1422,11 +1422,11 @@ class _spbase(SparseABC):
             if self.nnz == 0:
                 return np.sum(self._ascontainer([0]), dtype=dtype or res_dtype, out=out)
             return np.sum(self._ascontainer(_todata(self)), dtype=dtype, out=out)
-        elif isspmatrix(self):
+        elif isinstance(self, sparray):
+            new_shape = tuple(self.shape[i] for i in range(self.ndim) if i not in axis)
+        else:
             # Ensure spmatrix sums stay 2D
             new_shape = (1, self.shape[1]) if axis == (0,) else (self.shape[0], 1)
-        else:
-            new_shape = tuple(self.shape[i] for i in range(self.ndim) if i not in axis)
 
         if out is None:
             # create out array with desired dtype


### PR DESCRIPTION
This cleans up SciPy usage of `isspmatrix` and `isspmatrix_<fmt>`. It replaces them
with the encouraged `issparse(_)` its more specific cousin `isinstance(_, spmatrix)`.

It should make eventual deprecation easier -- and it no longer encourages calling `isspmatrix` by readers of this code.

#### AI Generation Disclosure
No AI tools used
