### PR TITLE
ENH: spatial.KDTree: `output_type` variant for sparray

### DIFF
--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1504,7 +1504,7 @@ cdef class cKDTree:
                    and will change to 'dok_array' in v1.20. The value
                    'dok_matrix' is available until that class is removed.
                    Unless you use * instead of @, ** for matrix power
-                   or depend on 2D shapes from e.g. `A.sum(axis=0)` it may
+                   or depend on 2D shapes from e.g. ``A.sum(axis=0)`` it may
                    not matter to you. See the sparray migration guide.
 
         Returns

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -10,6 +10,7 @@
 import numpy as np
 import scipy.sparse
 from scipy._lib._util import copy_if_needed
+from scipy._lib.deprecation import _NoValue
 
 cimport numpy as np
 
@@ -17,6 +18,7 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libcpp.vector cimport vector
 from libcpp cimport bool
 from libc.math cimport isinf, INFINITY
+from warnings import warn
 
 cimport cython
 import os
@@ -171,7 +173,7 @@ cdef class coo_entries:
         if self.buf != NULL:
             del self.buf
 
-    # The methods ndarray, dict, coo_matrix, and dok_matrix must only
+    # The methods ndarray, dict, coo_array, and dok_array must only
     # be called after the buffer is filled with coo_entry data. This
     # is because std::vector can reallocate its internal buffer when
     # push_back is called.
@@ -218,6 +220,15 @@ cdef class coo_entries:
             return res_dict
         else:
             return {}
+
+    def coo_array(coo_entries self, m, n):
+        res_arr = self.ndarray()
+        return scipy.sparse.coo_array(
+                       (res_arr['v'], (res_arr['i'], res_arr['j'])),
+                                       shape=(m, n))
+
+    def dok_array(coo_entries self, m, n):
+        return self.coo_array(m,n).todok()
 
     def coo_matrix(coo_entries self, m, n):
         res_arr = self.ndarray()
@@ -1465,7 +1476,7 @@ cdef class cKDTree:
     def sparse_distance_matrix(cKDTree self, cKDTree other,
                                np.float64_t max_distance,
                                np.float64_t p=2.0,
-                               output_type='dok_matrix'):
+                               output_type=_NoValue):
         """
         sparse_distance_matrix(self, other, max_distance, p=2.0)
 
@@ -1485,12 +1496,20 @@ cdef class cKDTree:
             A finite large p may cause a ValueError if overflow can occur.
 
         output_type : str, optional
-            Which container to use for output data. Options: 'dok_matrix',
-            'coo_matrix', 'dict', or 'ndarray'. Default: 'dok_matrix'.
+            Which container to use for output data. Options: 'dok_array',
+            'coo_array', 'dict', or 'ndarray'. Default: 'dok_matrix'.
+
+               .. deprecated:: 1.18.0
+                   The default value for output_type is deprecated
+                   and will change to 'dok_array' in v1.19. The value
+                   'dok_matrix' is available until that class is removed.
+                   Unless you use * instead of @, ** for matrix power
+                   or depend on 2D shapes from e.g. `A.sum(axis=0)` it may
+                   not matter to you. See the sparray migration guide.
 
         Returns
         -------
-        result : dok_matrix, coo_matrix, dict or ndarray
+        result : dok_array, coo_array, dict or ndarray
             Sparse matrix representing the results in "dictionary of keys"
             format. If a dict is returned the keys are (i,j) tuples of indices.
             If output_type is 'ndarray' a record array with fields 'i', 'j',
@@ -1540,14 +1559,28 @@ cdef class cKDTree:
             sparse_distance_matrix(
                 self.cself, other.cself, p, max_distance, res.buf)
 
+        if output_type == _NoValue:
+            msg = """The default value for output_type is changing to 'dok_array'
+            in v1.19. Unless you use * instead of @, ** for matrix power
+            or depend on 2D shapes for e.g. A.sum(axis=1) it may not matter to
+            you. See the spmatrix to sparray migration guide for details.
+            https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+            """
+            warn(msg, DeprecationWarning, stacklevel=2)
+            output_type = 'dok_matrix'
+
         if output_type == 'dict':
             return res.dict()
         elif output_type == 'ndarray':
             return res.ndarray()
-        elif output_type == 'coo_matrix':
-            return res.coo_matrix(self.n, other.n)
         elif output_type == 'dok_matrix':
             return res.dok_matrix(self.n, other.n)
+        elif output_type == 'dok_array':
+            return res.dok_array(self.n, other.n)
+        elif output_type == 'coo_matrix':
+            return res.coo_matrix(self.n, other.n)
+        elif output_type == 'coo_array':
+            return res.coo_array(self.n, other.n)
         else:
             raise ValueError('Invalid output type')
 

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1524,9 +1524,9 @@ cdef class cKDTree:
         >>> rng = np.random.default_rng()
         >>> points1 = rng.random((5, 2))
         >>> points2 = rng.random((5, 2))
-        >>> kd_tree1 = cKDTree(points1)
-        >>> kd_tree2 = cKDTree(points2)
-        >>> sdm = kd_tree1.sparse_distance_matrix(kd_tree2, 0.3)
+        >>> kdtree1 = cKDTree(points1)
+        >>> kdtree2 = cKDTree(points2)
+        >>> sdm = kdtree1.sparse_distance_matrix(kdtree2, 0.3, output_type="dok_array")
         >>> sdm.toarray()
         array([[0.        , 0.        , 0.12295571, 0.        , 0.        ],
            [0.        , 0.        , 0.        , 0.        , 0.        ],

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1505,9 +1505,8 @@ cdef class cKDTree:
                types 'dok_array' or 'coo_array'. The default value of
                `output_type` will be deprecated at v1.19 and switch from
                'dok_matrix' to 'dok_array' in v1.21.
-               The values 'dok_matrix' and 'coo_matrix' will continue
-               to work, but will go away when the sparse matrix classes
-               are removed.
+               The values 'dok_matrix' and 'coo_matrix' continue
+               to work, but will go away eventually.
 
         Returns
         -------

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1566,7 +1566,8 @@ cdef class cKDTree:
             you. See the spmatrix to sparray migration guide for details.
             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
             """
-            warn(msg, DeprecationWarning, stacklevel=2)
+            prefixes = (os.path.dirname(__file__),)
+            warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
             output_type = 'dok_matrix'
 
         if output_type == 'dict':

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1501,7 +1501,7 @@ cdef class cKDTree:
 
                .. deprecated:: 1.18.0
                    The default value for output_type is deprecated
-                   and will change to 'dok_array' in v1.19. The value
+                   and will change to 'dok_array' in v1.20. The value
                    'dok_matrix' is available until that class is removed.
                    Unless you use * instead of @, ** for matrix power
                    or depend on 2D shapes from e.g. `A.sum(axis=0)` it may
@@ -1561,7 +1561,7 @@ cdef class cKDTree:
 
         if output_type == _NoValue:
             msg = """The default value for output_type is changing to 'dok_array'
-            in v1.19. Unless you use * instead of @, ** for matrix power
+            in v1.20. Unless you use * instead of @, ** for matrix power
             or depend on 2D shapes for e.g. A.sum(axis=1) it may not matter to
             you. See the spmatrix to sparray migration guide for details.
             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -10,7 +10,6 @@
 import numpy as np
 import scipy.sparse
 from scipy._lib._util import copy_if_needed
-from scipy._lib.deprecation import _NoValue
 
 cimport numpy as np
 
@@ -18,7 +17,6 @@ from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libcpp.vector cimport vector
 from libcpp cimport bool
 from libc.math cimport isinf, INFINITY
-from warnings import warn
 
 cimport cython
 import os
@@ -1476,7 +1474,7 @@ cdef class cKDTree:
     def sparse_distance_matrix(cKDTree self, cKDTree other,
                                np.float64_t max_distance,
                                np.float64_t p=2.0,
-                               output_type=_NoValue):
+                               output_type='dok_matrix'):
         """
         sparse_distance_matrix(self, other, max_distance, p=2.0)
 
@@ -1497,15 +1495,20 @@ cdef class cKDTree:
 
         output_type : str, optional
             Which container to use for output data. Options: 'dok_array',
-            'coo_array', 'dict', or 'ndarray'. Default: 'dok_matrix'.
+            'coo_array', 'dict', or 'ndarray'. Legacy options 'dok_matrix'
+            and 'coo_matrix' are still available and the Default: 'dok_matrix'.
 
-               .. deprecated:: 1.18.0
-                   The default value for output_type is deprecated
-                   and will change to 'dok_array' in v1.20. The value
-                   'dok_matrix' is available until that class is removed.
+               .. warning:: dok_matrix and coo_matrix are being replaced.
+
+                   All new code should use sparse array types 'dok_array'
+                   and 'coo_array'. The default value of `output_type` is
+                   still 'dok_matrix' but will be deprecated at 1.19.0 and
+                   changed to 'dok_array' at v1.21.0.  The values 'dok_matrix'
+                   and 'coo_matrix' will continue to work, but will go away
+                   when the sparse matrix classes are removed.
                    Unless you use * instead of @, ** for matrix power
-                   or depend on 2D shapes from e.g. ``A.sum(axis=0)`` it may
-                   not matter to you. See the sparray migration guide.
+                   or depend on 2D shapes from e.g. `A.sum(axis=0)` it makes
+                   sense to use the array interface.
 
         Returns
         -------
@@ -1558,17 +1561,6 @@ cdef class cKDTree:
         with nogil:
             sparse_distance_matrix(
                 self.cself, other.cself, p, max_distance, res.buf)
-
-        if output_type == _NoValue:
-            msg = """The default value for output_type is changing to 'dok_array'
-            in v1.20. Unless you use * instead of @, ** for matrix power
-            or depend on 2D shapes for e.g. A.sum(axis=1) it may not matter to
-            you. See the spmatrix to sparray migration guide for details.
-            https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
-            """
-            prefixes = (os.path.dirname(__file__),)
-            warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
-            output_type = 'dok_matrix'
 
         if output_type == 'dict':
             return res.dict()

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1476,7 +1476,7 @@ cdef class cKDTree:
                                np.float64_t p=2.0,
                                output_type='dok_matrix'):
         """
-        sparse_distance_matrix(self, other, max_distance, p=2.0)
+        sparse_distance_matrix(other, max_distance, p=2.0, output_type='dok_matrix')
 
         Compute a sparse distance matrix
 
@@ -1486,37 +1486,36 @@ cdef class cKDTree:
         Parameters
         ----------
         other : cKDTree
-
+            The other `KDTree` to compute distances against.
         max_distance : positive float
-
+            Maximum distance within which neighbors are returned. Distances above this
+            value are returned as zero.
         p : float, 1<=p<=infinity
             Which Minkowski p-norm to use.
             A finite large p may cause a ValueError if overflow can occur.
-
         output_type : str, optional
-            Which container to use for output data. Options: 'dok_array',
-            'coo_array', 'dict', or 'ndarray'. Legacy options 'dok_matrix'
-            and 'coo_matrix' are still available and the Default: 'dok_matrix'.
+            Which container to use for output data. Options: ``'dok_array'``,
+            ``'coo_array'``, ``'dict'``, or ``'ndarray'``.
+            Legacy options ``'dok_matrix'`` and ``'coo_matrix'`` are still available.
+            Default: ``'dok_matrix'``.
 
-               .. warning:: dok_matrix and coo_matrix are being replaced.
+            .. warning:: dok_matrix and coo_matrix are being replaced.
 
-                   All new code should use sparse array types 'dok_array'
-                   and 'coo_array'. The default value of `output_type` is
-                   still 'dok_matrix' but will be deprecated at 1.19.0 and
-                   changed to 'dok_array' at v1.21.0.  The values 'dok_matrix'
-                   and 'coo_matrix' will continue to work, but will go away
-                   when the sparse matrix classes are removed.
-                   Unless you use * instead of @, ** for matrix power
-                   or depend on 2D shapes from e.g. `A.sum(axis=0)` it makes
-                   sense to use the array interface.
+               All new code using scipy sparse should use sparse array
+               types 'dok_array' or 'coo_array'. The default value of
+               `output_type` will be deprecated at v1.19 and switch from
+               'dok_matrix' to 'dok_array' in v1.21.
+               The values 'dok_matrix' and 'coo_matrix' will continue
+               to work, but will go away when the sparse matrix classes
+               are removed.
 
         Returns
         -------
         result : dok_array, coo_array, dict or ndarray
             Sparse matrix representing the results in "dictionary of keys"
-            format. If a dict is returned the keys are (i,j) tuples of indices.
-            If output_type is 'ndarray' a record array with fields 'i', 'j',
-            and 'v' is returned,
+            format. If a dict is returned the keys are ``(i,j)`` tuples of indices.
+            If output_type is ``'ndarray'`` a record array with fields ``'i'``, ``'j'``,
+            and ``'v'`` is returned,
 
         Examples
         --------

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -2,7 +2,7 @@
 # Released under the scipy license
 import numpy as np
 from ._ckdtree import cKDTree, cKDTreeNode  # type: ignore[import-not-found]
-from scipy._lib.deprecation import _deprecate_positional_args, _NoValue
+from scipy._lib.deprecation import _NoValue
 from warnings import warn
 
 __all__ = ['minkowski_distance_p', 'minkowski_distance',
@@ -914,7 +914,7 @@ class KDTree(cKDTree):
             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
             """
             warn(msg, DeprecationWarning, stacklevel=2)
-            output_dtype = "dok_matrix"
+            output_type = "dok_matrix"
         return super().sparse_distance_matrix(other, max_distance, p, output_type)
 
 

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -848,7 +848,7 @@ class KDTree(cKDTree):
             The other `KDTree` to compute distances against.
         max_distance : positive float
             Maximum distance within which neighbors are returned. Distances above this
-            values are returned as zero.
+            value are returned as zero.
         p : float, 1<=p<=infinity
             Which Minkowski p-norm to use.
             A finite large p may cause a ValueError if overflow can occur.
@@ -858,17 +858,15 @@ class KDTree(cKDTree):
             Legacy options ``'dok_matrix'`` and ``'coo_matrix'`` are still available.
             Default: ``'dok_matrix'``.
 
-               .. warning:: dok_matrix and coo_matrix are being replaced.
+            .. warning:: dok_matrix and coo_matrix are being replaced.
 
-                   All new code should use sparse array types 'dok_array'
-                   and 'coo_array'. The default value of `output_type` is
-                   still 'dok_matrix' but will be deprecated at 1.19.0 and
-                   changed to 'dok_array' at v1.21.0.  The values 'dok_matrix'
-'                  and 'coo_matrix' will continue to work, but will go away
-                   when the sparse matrix classes are removed.
-                   Unless you use * instead of @, ** for matrix power
-                   or depend on 2D shapes from e.g. `A.sum(axis=0)` it makes
-                   sense to use the array interface.
+               All new code using scipy sparse should use sparse array
+               types 'dok_array' or 'coo_array'. The default value of
+               `output_type` will be deprecated at v1.19 and switch from
+               'dok_matrix' to 'dok_array' in v1.21.
+               The values 'dok_matrix' and 'coo_matrix' will continue
+               to work, but will go away when the sparse matrix classes
+               are removed.
 
             .. versionadded:: 1.6.0
 

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -885,9 +885,9 @@ class KDTree(cKDTree):
         >>> rng = np.random.default_rng()
         >>> points1 = rng.random((5, 2))
         >>> points2 = rng.random((5, 2))
-        >>> kd_tree1 = KDTree(points1)
-        >>> kd_tree2 = KDTree(points2)
-        >>> sdm = kd_tree1.sparse_distance_matrix(kd_tree2, 0.3)
+        >>> kdtree1 = KDTree(points1)
+        >>> kdtree2 = KDTree(points2)
+        >>> sdm = kdtree1.sparse_distance_matrix(kdtree2, 0.3, output_type="dok_array")
         >>> sdm.toarray()
         array([[0.        , 0.        , 0.12295571, 0.        , 0.        ],
            [0.        , 0.        , 0.        , 0.        , 0.        ],

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -2,9 +2,6 @@
 # Released under the scipy license
 import numpy as np
 from ._ckdtree import cKDTree, cKDTreeNode  # type: ignore[import-not-found]
-from scipy._lib.deprecation import _NoValue
-import os
-from warnings import warn
 
 __all__ = ['minkowski_distance_p', 'minkowski_distance',
            'distance_matrix',
@@ -839,7 +836,7 @@ class KDTree(cKDTree):
         return super().count_neighbors(other, r, p, weights, cumulative)
 
     def sparse_distance_matrix(
-            self, other, max_distance, p=2.0, output_type=_NoValue):
+            self, other, max_distance, p=2.0, output_type='dok_matrix'):
         """Compute a sparse distance matrix.
 
         Computes a distance matrix between two KDTrees, leaving as zero
@@ -857,15 +854,21 @@ class KDTree(cKDTree):
             A finite large p may cause a ValueError if overflow can occur.
         output_type : str, optional
             Which container to use for output data. Options: ``'dok_array'``,
-            ``'coo_array'``, ``'dict'``, or ``'ndarray'``. Default: ``'dok_matrix'``.
+            ``'coo_array'``, ``'dict'``, or ``'ndarray'``.
+            Legacy options ``'dok_matrix'`` and ``'coo_matrix'`` are still available.
+            Default: ``'dok_matrix'``.
 
-               .. deprecated:: 1.18.0
-                   The default value for output_type is deprecated
-                   and will change to 'dok_array' in v1.20. The value
-                   'dok_matrix' is available until that class is removed.
+               .. warning:: dok_matrix and coo_matrix are being replaced.
+
+                   All new code should use sparse array types 'dok_array'
+                   and 'coo_array'. The default value of `output_type` is
+                   still 'dok_matrix' but will be deprecated at 1.19.0 and
+                   changed to 'dok_array' at v1.21.0.  The values 'dok_matrix'
+'                  and 'coo_matrix' will continue to work, but will go away
+                   when the sparse matrix classes are removed.
                    Unless you use * instead of @, ** for matrix power
-                   or depend on 2D shapes from e.g. `A.sum(axis=0)` it may
-                   not matter to you. See the sparray migration guide.
+                   or depend on 2D shapes from e.g. `A.sum(axis=0)` it makes
+                   sense to use the array interface.
 
             .. versionadded:: 1.6.0
 
@@ -907,16 +910,6 @@ class KDTree(cKDTree):
            [0.24617575, 0.29571802, 0.26836782, 0.57714465, 0.6473269 ]])
 
         """
-        if output_type is _NoValue:
-            msg = """The default value for output_type is changing to 'dok_array'
-            in v1.20. Unless you use * instead of @, ** for matrix power
-            or depend on 2D shapes for e.g. A.sum(axis=1) it may not matter to
-            you. See the spmatrix to sparray migration guide for details.
-            https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
-            """
-            prefixes = (os.path.dirname(__file__),)
-            warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
-            output_type = "dok_matrix"
         return super().sparse_distance_matrix(other, max_distance, p, output_type)
 
 

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -864,9 +864,8 @@ class KDTree(cKDTree):
                types 'dok_array' or 'coo_array'. The default value of
                `output_type` will be deprecated at v1.19 and switch from
                'dok_matrix' to 'dok_array' in v1.21.
-               The values 'dok_matrix' and 'coo_matrix' will continue
-               to work, but will go away when the sparse matrix classes
-               are removed.
+               The values 'dok_matrix' and 'coo_matrix' continue
+               to work, but will go away eventually.
 
             .. versionadded:: 1.6.0
 

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -860,7 +860,7 @@ class KDTree(cKDTree):
 
                .. deprecated:: 1.18.0
                    The default value for output_type is deprecated
-                   and will change to 'dok_array' in v1.19. The value
+                   and will change to 'dok_array' in v1.20. The value
                    'dok_matrix' is available until that class is removed.
                    Unless you use * instead of @, ** for matrix power
                    or depend on 2D shapes from e.g. `A.sum(axis=0)` it may
@@ -908,7 +908,7 @@ class KDTree(cKDTree):
         """
         if output_type is _NoValue:
             msg = """The default value for output_type is changing to 'dok_array'
-            in v1.19. Unless you use * instead of @, ** for matrix power
+            in v1.20. Unless you use * instead of @, ** for matrix power
             or depend on 2D shapes for e.g. A.sum(axis=1) it may not matter to
             you. See the spmatrix to sparray migration guide for details.
             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -3,6 +3,7 @@
 import numpy as np
 from ._ckdtree import cKDTree, cKDTreeNode  # type: ignore[import-not-found]
 from scipy._lib.deprecation import _NoValue
+import os
 from warnings import warn
 
 __all__ = ['minkowski_distance_p', 'minkowski_distance',
@@ -913,7 +914,8 @@ class KDTree(cKDTree):
             you. See the spmatrix to sparray migration guide for details.
             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
             """
-            warn(msg, DeprecationWarning, stacklevel=2)
+            prefixes = (os.path.dirname(__file__),)
+            warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
             output_type = "dok_matrix"
         return super().sparse_distance_matrix(other, max_distance, p, output_type)
 

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -2,6 +2,8 @@
 # Released under the scipy license
 import numpy as np
 from ._ckdtree import cKDTree, cKDTreeNode  # type: ignore[import-not-found]
+from scipy._lib.deprecation import _deprecate_positional_args, _NoValue
+from warnings import warn
 
 __all__ = ['minkowski_distance_p', 'minkowski_distance',
            'distance_matrix',
@@ -836,7 +838,7 @@ class KDTree(cKDTree):
         return super().count_neighbors(other, r, p, weights, cumulative)
 
     def sparse_distance_matrix(
-            self, other, max_distance, p=2.0, output_type='dok_matrix'):
+            self, other, max_distance, p=2.0, output_type=_NoValue):
         """Compute a sparse distance matrix.
 
         Computes a distance matrix between two KDTrees, leaving as zero
@@ -853,14 +855,22 @@ class KDTree(cKDTree):
             Which Minkowski p-norm to use.
             A finite large p may cause a ValueError if overflow can occur.
         output_type : str, optional
-            Which container to use for output data. Options: ``'dok_matrix'``,
-            ``'coo_matrix'``, ``'dict'``, or ``'ndarray'``. Default: ``'dok_matrix'``.
+            Which container to use for output data. Options: ``'dok_array'``,
+            ``'coo_array'``, ``'dict'``, or ``'ndarray'``. Default: ``'dok_matrix'``.
+
+               .. deprecated:: 1.18.0
+                   The default value for output_type is deprecated
+                   and will change to 'dok_array' in v1.19. The value
+                   'dok_matrix' is available until that class is removed.
+                   Unless you use * instead of @, ** for matrix power
+                   or depend on 2D shapes from e.g. `A.sum(axis=0)` it may
+                   not matter to you. See the sparray migration guide.
 
             .. versionadded:: 1.6.0
 
         Returns
         -------
-        result : dok_matrix, coo_matrix, dict or ndarray
+        result : dok_array, coo_array, dict or ndarray
             Sparse matrix representing the results in "dictionary of keys"
             format. If a dict is returned the keys are ``(i,j)`` tuples of indices.
             If output_type is ``'ndarray'`` a record array with fields ``'i'``, ``'j'``,
@@ -896,8 +906,16 @@ class KDTree(cKDTree):
            [0.24617575, 0.29571802, 0.26836782, 0.57714465, 0.6473269 ]])
 
         """
-        return super().sparse_distance_matrix(
-            other, max_distance, p, output_type)
+        if output_type is _NoValue:
+            msg = """The default value for output_type is changing to 'dok_array'
+            in v1.19. Unless you use * instead of @, ** for matrix power
+            or depend on 2D shapes for e.g. A.sum(axis=1) it may not matter to
+            you. See the spmatrix to sparray migration guide for details.
+            https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+            """
+            warn(msg, DeprecationWarning, stacklevel=2)
+            output_dtype = "dok_matrix"
+        return super().sparse_distance_matrix(other, max_distance, p, output_type)
 
 
 def distance_matrix(x, y, p=2.0, threshold=1000000):

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -11,6 +11,7 @@ import numpy as np
 from scipy.spatial import KDTree, Rectangle, distance_matrix, cKDTree
 from scipy.spatial._ckdtree import cKDTreeNode
 from scipy.spatial import minkowski_distance
+from scipy.sparse import dok_array, coo_array, dok_matrix, coo_matrix
 
 import itertools
 
@@ -678,10 +679,27 @@ class sparse_distance_matrix_consistency:
         r = self.T1.sparse_distance_matrix(self.T2, self.r,
             output_type='dok_array')
         assert_array_almost_equal(ref, r.toarray(), decimal=14)
+        assert isinstance(r, dok_array)
+        # test return type 'dok_matrix'
+        r = self.T1.sparse_distance_matrix(self.T2, self.r,
+            output_type='dok_matrix')
+        assert_array_almost_equal(ref, r.toarray(), decimal=14)
+        assert isinstance(r, dok_matrix)
         # test return type 'coo_array'
         r = self.T1.sparse_distance_matrix(self.T2, self.r,
             output_type='coo_array')
         assert_array_almost_equal(ref, r.toarray(), decimal=14)
+        assert isinstance(r, coo_array)
+        # test return type 'coo_matrix'
+        r = self.T1.sparse_distance_matrix(self.T2, self.r,
+            output_type='coo_matrix')
+        assert_array_almost_equal(ref, r.toarray(), decimal=14)
+        assert isinstance(r, coo_matrix)
+        # test default return type 'dok_matrix'
+        with pytest.warns(DeprecationWarning,
+                          match="The default value for output_type"):
+            r = self.T1.sparse_distance_matrix(self.T2, self.r)
+            assert isinstance(r, dok_matrix)
 
 
     def test_sparse_distance_matrix_output_type_deprecation(self):

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -696,15 +696,8 @@ class sparse_distance_matrix_consistency:
         assert_array_almost_equal(ref, r.toarray(), decimal=14)
         assert isinstance(r, coo_matrix)
         # test default return type 'dok_matrix'
-        with pytest.warns(DeprecationWarning,
-                          match="The default value for output_type"):
-            r = self.T1.sparse_distance_matrix(self.T2, self.r)
-            assert isinstance(r, dok_matrix)
-
-
-    def test_sparse_distance_matrix_output_type_deprecation(self):
-        with pytest.deprecated_call(match="The default value for output_type"):
-            self.T1.sparse_distance_matrix(self.T2, self.r)
+        r = self.T1.sparse_distance_matrix(self.T2, self.r)
+        assert isinstance(r, dok_matrix)
 
 
 @KDTreeTest

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -617,7 +617,7 @@ class sparse_distance_matrix_consistency:
         return minkowski_distance(a, b, p)
 
     def test_consistency_with_neighbors(self):
-        M = self.T1.sparse_distance_matrix(self.T2, self.r)
+        M = self.T1.sparse_distance_matrix(self.T2, self.r, output_type='dok_array')
         r = self.T1.query_ball_tree(self.T2, self.r)
         for i, l in enumerate(r):
             for j in l:
@@ -631,11 +631,11 @@ class sparse_distance_matrix_consistency:
 
     def test_zero_distance(self):
         # raises an exception for bug 870 (FIXME: Does it?)
-        self.T1.sparse_distance_matrix(self.T1, self.r)
+        self.T1.sparse_distance_matrix(self.T1, self.r, output_type='dok_array')
 
     def test_consistency(self):
         # Test consistency with a distance_matrix
-        M1 = self.T1.sparse_distance_matrix(self.T2, self.r)
+        M1 = self.T1.sparse_distance_matrix(self.T2, self.r, output_type='dok_array')
         expected = distance_matrix(self.T1.data, self.T2.data)
         expected[expected > self.r] = 0
         assert_array_almost_equal(M1.toarray(), expected, decimal=14)
@@ -646,7 +646,7 @@ class sparse_distance_matrix_consistency:
         too_many = np.array(np.random.randn(18, 2), dtype=int)
         tree = self.kdtree_type(
             too_many, balanced_tree=False, compact_nodes=False)
-        d = tree.sparse_distance_matrix(tree, 3).toarray()
+        d = tree.sparse_distance_matrix(tree, 3, output_type='dok_array').toarray()
         assert_array_almost_equal(d, d.T, decimal=14)
 
     def test_ckdtree_return_types(self):
@@ -674,14 +674,19 @@ class sparse_distance_matrix_consistency:
             v = r['v'][k]
             dist[i, j] = v
         assert_array_almost_equal(ref, dist, decimal=14)
-        # test return type 'dok_matrix'
+        # test return type 'dok_array'
         r = self.T1.sparse_distance_matrix(self.T2, self.r,
-            output_type='dok_matrix')
+            output_type='dok_array')
         assert_array_almost_equal(ref, r.toarray(), decimal=14)
-        # test return type 'coo_matrix'
+        # test return type 'coo_array'
         r = self.T1.sparse_distance_matrix(self.T2, self.r,
-            output_type='coo_matrix')
+            output_type='coo_array')
         assert_array_almost_equal(ref, r.toarray(), decimal=14)
+
+
+    def test_sparse_distance_matrix_output_type_deprecation(self):
+        with pytest.deprecated_call(match="The default value for output_type"):
+            self.T1.sparse_distance_matrix(self.T2, self.r)
 
 
 @KDTreeTest
@@ -1189,9 +1194,9 @@ def test_len0_arrays(kdtree_type):
     y = tree.count_neighbors(other, 0.1*mind)
     assert_(y == 0)
     # sparse_distance_matrix
-    y = tree.sparse_distance_matrix(other, 0.1*mind, output_type='dok_matrix')
+    y = tree.sparse_distance_matrix(other, 0.1*mind, output_type='dok_array')
     assert_array_equal(y == np.zeros((10, 10)), True)
-    y = tree.sparse_distance_matrix(other, 0.1*mind, output_type='coo_matrix')
+    y = tree.sparse_distance_matrix(other, 0.1*mind, output_type='coo_array')
     assert_array_equal(y == np.zeros((10, 10)), True)
     y = tree.sparse_distance_matrix(other, 0.1*mind, output_type='dict')
     assert_equal(y, {})
@@ -1349,7 +1354,7 @@ def test_kdtree_empty_input(kdtree_type, balanced_tree, compact_nodes):
     N = tree.count_neighbors(tree, [0, 1])
     assert_array_equal(N, [0, 0])
 
-    M = tree.sparse_distance_matrix(tree, 0.3)
+    M = tree.sparse_distance_matrix(tree, 0.3, output_type='dok_array')
     assert M.shape == (0, 0)
 
 @KDTreeTest


### PR DESCRIPTION
The default input value for `output_type` in `kdtree.sparse_distance_matrix` is `'dok_matrix'`.
This should switch to `dok_array`.  This PR deprecates the default value and makes `dok_array` and `coo_array` possible to use.

