### PR TITLE
DEP: io: deprecate default spmatrix kwargs values

### DIFF
--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -12,9 +12,12 @@ for information about the Matrix Market format.
 import io
 import os
 
+from warnings import warn
+
 import numpy as np
 from scipy.sparse import coo_array, issparse, coo_matrix
 from scipy.io import _mmio
+from scipy._lib.deprecation import _NoValue
 
 __all__ = ['mminfo', 'mmread', 'mmwrite']
 
@@ -295,7 +298,7 @@ def _validate_symmetry(symmetry):
     return symmetry
 
 
-def mmread(source, *, spmatrix=True):
+def mmread(source, *, spmatrix=_NoValue):
     """
     Reads the contents of a Matrix Market file-like 'source' into a matrix.
 
@@ -306,6 +309,13 @@ def mmread(source, *, spmatrix=True):
         or open file-like object.
     spmatrix : bool, optional (default: True)
         If ``True``, return sparse matrix. Otherwise return sparse array.
+
+        .. deprecated:: 1.18.0
+            The default value for `spmatrix` is changing to False in v1.19.
+            That means the default return value will be a sparse array.
+            Unless you use * instead of @, ** for matrix power, or you depend
+            on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+            See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
     Returns
     -------
@@ -368,6 +378,18 @@ def mmread(source, *, spmatrix=True):
         triplet, shape = _read_body_coo(cursor, generalize_symmetry=True)
         if stream_to_close:
             stream_to_close.close()
+
+        if spmatrix is _NoValue:
+            msg = """The default value for `spmatrix` is changing to `False` in v1.19.
+                That means the default return type will be a sparse array.
+                Unless you use * instead of @, ** for matrix power, or you depend
+                on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+                See the spmatrix to sparray migration guide for details.
+                https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+                """
+            warn(msg, DeprecationWarning, stacklevel=2)
+            spmatrix = True
+
         if spmatrix:
             return coo_matrix(triplet, shape=shape)
         return coo_array(triplet, shape=shape)

--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -314,7 +314,7 @@ def mmread(source, *, spmatrix=_NoValue):
             The default value for `spmatrix` is changing to False in v1.20.
             That means the default return value will be a sparse array.
             Unless you use * instead of @, ** for matrix power, or you depend
-            on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+            on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
     Returns
@@ -381,13 +381,14 @@ def mmread(source, *, spmatrix=_NoValue):
 
         if spmatrix is _NoValue:
             msg = """The default value for `spmatrix` is changing to `False` in v1.20.
-                That means the default return type will be a sparse array.
-                Unless you use * instead of @, ** for matrix power, or you depend
-                on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
-                See the spmatrix to sparray migration guide for details.
-                https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
-                """
-            warn(msg, DeprecationWarning, stacklevel=2)
+             That means the default return type will be a sparse array.
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+             See the spmatrix to sparray migration guide for details.
+             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+             """
+            prefixes = (os.path.dirname(__file__),)
+            warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
             spmatrix = True
 
         if spmatrix:

--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -311,7 +311,7 @@ def mmread(source, *, spmatrix=_NoValue):
         If ``True``, return sparse matrix. Otherwise return sparse array.
 
         .. deprecated:: 1.18.0
-            The default value for `spmatrix` is changing to False in v1.19.
+            The default value for `spmatrix` is changing to False in v1.20.
             That means the default return value will be a sparse array.
             Unless you use * instead of @, ** for matrix power, or you depend
             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
@@ -380,7 +380,7 @@ def mmread(source, *, spmatrix=_NoValue):
             stream_to_close.close()
 
         if spmatrix is _NoValue:
-            msg = """The default value for `spmatrix` is changing to `False` in v1.19.
+            msg = """The default value for `spmatrix` is changing to `False` in v1.20.
                 That means the default return type will be a sparse array.
                 Unless you use * instead of @, ** for matrix power, or you depend
                 on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -18,6 +18,7 @@ features are:
 # having reusable facilities to efficiently read/write fortran-formatted files
 # would be useful outside this module.
 
+import os
 import warnings
 
 import numpy as np
@@ -474,7 +475,7 @@ def hb_read(path_or_open_file, *, spmatrix=_NoValue):
             The default value for `spmatrix` is changing to False in v1.20.
             That means the default return value will be a sparse array.
             Unless you use * instead of @, ** for matrix power, or you depend
-            on 2D shapes from e.g. `A.sum(axis=0)`, it may not matter to you.
+            on 2D shapes from e.g. ``A.sum(axis=0)``, it may not matter to you.
             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
     Returns
@@ -525,7 +526,8 @@ def hb_read(path_or_open_file, *, spmatrix=_NoValue):
             See the spmatrix to sparray migration guide for details.
             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
             """
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        prefixes = (os.path.dirname(__file__),)
+        warnings.warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
         spmatrix = True
 
     if spmatrix:

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -471,7 +471,7 @@ def hb_read(path_or_open_file, *, spmatrix=_NoValue):
         If ``True``, return sparse matrix. Otherwise return sparse array.
 
         .. deprecated:: 1.18.0
-            The default value for `spmatrix` is changing to False in v1.19.
+            The default value for `spmatrix` is changing to False in v1.20.
             That means the default return value will be a sparse array.
             Unless you use * instead of @, ** for matrix power, or you depend
             on 2D shapes from e.g. `A.sum(axis=0)`, it may not matter to you.
@@ -518,7 +518,7 @@ def hb_read(path_or_open_file, *, spmatrix=_NoValue):
             data = _get_matrix(f)
 
     if spmatrix is _NoValue:
-        msg = """The default value for `spmatrix` is changing to `False` in v1.19.
+        msg = """The default value for `spmatrix` is changing to `False` in v1.20.
             That means the default return type will be a sparse array.
             Unless you use * instead of @, ** for matrix power, or you depend
             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.

--- a/scipy/io/_harwell_boeing/hb.py
+++ b/scipy/io/_harwell_boeing/hb.py
@@ -21,6 +21,7 @@ features are:
 import warnings
 
 import numpy as np
+from scipy._lib.deprecation import _NoValue
 from scipy.sparse import csc_array, csc_matrix
 from ._fortran_format_parser import FortranFormatParser, IntFormat, ExpFormat
 
@@ -458,7 +459,7 @@ class HBFile:
         return _write_data(m, self._fid, self._hb_info)
 
 
-def hb_read(path_or_open_file, *, spmatrix=True):
+def hb_read(path_or_open_file, *, spmatrix=_NoValue):
     """Read HB-format file.
 
     Parameters
@@ -468,6 +469,13 @@ def hb_read(path_or_open_file, *, spmatrix=True):
         before reading.
     spmatrix : bool, optional (default: True)
         If ``True``, return sparse matrix. Otherwise return sparse array.
+
+        .. deprecated:: 1.18.0
+            The default value for `spmatrix` is changing to False in v1.19.
+            That means the default return value will be a sparse array.
+            Unless you use * instead of @, ** for matrix power, or you depend
+            on 2D shapes from e.g. `A.sum(axis=0)`, it may not matter to you.
+            See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
     Returns
     -------
@@ -508,6 +516,18 @@ def hb_read(path_or_open_file, *, spmatrix=True):
     else:
         with open(path_or_open_file) as f:
             data = _get_matrix(f)
+
+    if spmatrix is _NoValue:
+        msg = """The default value for `spmatrix` is changing to `False` in v1.19.
+            That means the default return type will be a sparse array.
+            Unless you use * instead of @, ** for matrix power, or you depend
+            on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+            See the spmatrix to sparray migration guide for details.
+            https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+            """
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        spmatrix = True
+
     if spmatrix:
         return csc_matrix(data)
     return data

--- a/scipy/io/_harwell_boeing/tests/test_hb.py
+++ b/scipy/io/_harwell_boeing/tests/test_hb.py
@@ -1,4 +1,5 @@
 from io import StringIO
+import pytest
 import tempfile
 
 import numpy as np
@@ -50,8 +51,9 @@ class TestHBReader:
         assert isinstance(m, sparray)
         m = hb_read(StringIO(SIMPLE), spmatrix=True)
         assert issparse(m) and not isinstance(m, sparray)
-        m = hb_read(StringIO(SIMPLE))  # default
-        assert issparse(m) and not isinstance(m, sparray)
+        with pytest.deprecated_call(match="The default value for `spmatrix"):
+            m = hb_read(StringIO(SIMPLE))  # default
+            assert issparse(m) and not isinstance(m, sparray)
 
 
 class TestHBReadWrite:

--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -96,7 +96,7 @@ def mmread(source, *, spmatrix=_NoValue):
         If ``True``, return sparse matrix. Otherwise return sparse array.
 
         .. deprecated:: 1.18.0
-            The default value for `spmatrix` is changing to False in v1.19.
+            The default value for `spmatrix` is changing to False in v1.20.
             That means the default return value will be a sparse array.
             Unless you use * instead of @, ** for matrix power, or you depend
             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
@@ -579,7 +579,7 @@ class MMFile:
             If ``True``, return sparse matrix. Otherwise return sparse array.
 
             .. deprecated:: 1.18.0
-                The default value for `spmatrix` is changing to False in v1.19.
+                The default value for `spmatrix` is changing to False in v1.20.
                 That means the default return value will be a sparse array.
                 Unless you use * instead of @, ** for matrix power, or you depend
                 on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
@@ -602,7 +602,7 @@ class MMFile:
                 stream.close()
 
         if spmatrix is _NoValue:
-            msg = """The default value for `spmatrix` is changing to `False` in v1.19.
+            msg = """The default value for `spmatrix` is changing to `False` in v1.20.
                 That means the default return type will be a sparse array.
                 Unless you use * instead of @, ** for matrix power, or you depend
                 on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.

--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -11,12 +11,14 @@
 #  http://math.nist.gov/MatrixMarket/
 #
 import os
+from warnings import warn
 
 import numpy as np
 from numpy import (asarray, real, imag, conj, zeros, ndarray, concatenate,
                    ones, can_cast)
 
 from scipy.sparse import coo_array, issparse, coo_matrix
+from scipy._lib.deprecation import _NoValue
 
 __all__ = ['mminfo', 'mmread', 'mmwrite', 'MMFile']
 
@@ -81,7 +83,7 @@ def mminfo(source):
 # -----------------------------------------------------------------------------
 
 
-def mmread(source, *, spmatrix=True):
+def mmread(source, *, spmatrix=_NoValue):
     """
     Reads the contents of a Matrix Market file-like 'source' into a matrix.
 
@@ -92,6 +94,13 @@ def mmread(source, *, spmatrix=True):
         or open file-like object.
     spmatrix : bool, optional (default: True)
         If ``True``, return sparse matrix. Otherwise return sparse array.
+
+        .. deprecated:: 1.18.0
+            The default value for `spmatrix` is changing to False in v1.19.
+            That means the default return value will be a sparse array.
+            Unless you use * instead of @, ** for matrix power, or you depend
+            on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+            See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
     Returns
     -------
@@ -557,7 +566,7 @@ class MMFile:
         self._init_attrs(**kwargs)
 
     # -------------------------------------------------------------------------
-    def read(self, source, *, spmatrix=True):
+    def read(self, source, *, spmatrix=_NoValue):
         """
         Reads the contents of a Matrix Market file-like 'source' into a matrix.
 
@@ -568,6 +577,13 @@ class MMFile:
             or open file object.
         spmatrix : bool, optional (default: True)
             If ``True``, return sparse matrix. Otherwise return sparse array.
+
+            .. deprecated:: 1.18.0
+                The default value for `spmatrix` is changing to False in v1.19.
+                That means the default return value will be a sparse array.
+                Unless you use * instead of @, ** for matrix power, or you depend
+                on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+                See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
         Returns
         -------
@@ -584,6 +600,18 @@ class MMFile:
         finally:
             if close_it:
                 stream.close()
+
+        if spmatrix is _NoValue:
+            msg = """The default value for `spmatrix` is changing to `False` in v1.19.
+                That means the default return type will be a sparse array.
+                Unless you use * instead of @, ** for matrix power, or you depend
+                on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+                See the spmatrix to sparray migration guide for details.
+                https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+                """
+            warn(msg, DeprecationWarning, stacklevel=2)
+            spmatrix = True
+
         if spmatrix and isinstance(data, coo_array):
             data = coo_matrix(data)
         return data

--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -99,7 +99,7 @@ def mmread(source, *, spmatrix=_NoValue):
             The default value for `spmatrix` is changing to False in v1.20.
             That means the default return value will be a sparse array.
             Unless you use * instead of @, ** for matrix power, or you depend
-            on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+            on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
     Returns
@@ -582,7 +582,7 @@ class MMFile:
                 The default value for `spmatrix` is changing to False in v1.20.
                 That means the default return value will be a sparse array.
                 Unless you use * instead of @, ** for matrix power, or you depend
-                on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+                on 2D shapes from e.g. ``A.sum(axis=0)`` it may not matter to you.
                 See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
         Returns
@@ -603,13 +603,14 @@ class MMFile:
 
         if spmatrix is _NoValue:
             msg = """The default value for `spmatrix` is changing to `False` in v1.20.
-                That means the default return type will be a sparse array.
-                Unless you use * instead of @, ** for matrix power, or you depend
-                on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
-                See the spmatrix to sparray migration guide for details.
-                https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
-                """
-            warn(msg, DeprecationWarning, stacklevel=2)
+             That means the default return type will be a sparse array.
+             Unless you use * instead of @, ** for matrix power, or you depend
+             on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+             See the spmatrix to sparray migration guide for details.
+             https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+             """
+            prefixes = (os.path.dirname(__file__),)
+            warn(msg, DeprecationWarning, skip_file_prefixes=prefixes)
             spmatrix = True
 
         if spmatrix and isinstance(data, coo_array):

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -3,6 +3,7 @@ Module for reading and writing matlab (TM) .mat files
 """
 # Authors: Travis Oliphant, Matthew Brett
 
+import os
 import warnings
 
 from contextlib import contextmanager
@@ -101,7 +102,7 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=_NoValue, **kwarg
             The default value for `spmatrix` is changing to False in v1.20.
             That means the default return value will be a sparse array.
             Unless you use * instead of @, ** for matrix power, or you depend
-            on 2D shapes from e.g. `A.sum(axis=0)`, it may not matter to you.
+            on 2D shapes from e.g. ``A.sum(axis=0)``, it may not matter to you.
             See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
 
     **kwargs
@@ -252,7 +253,8 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=_NoValue, **kwarg
     for name, var in list(matfile_dict.items()):
         if issparse(var):
             if spmatrix is _NoValue:
-                warnings.warn(warn_msg, DeprecationWarning, stacklevel=2)
+                prefixes = (os.path.dirname(__file__),)
+                warnings.warn(warn_msg, DeprecationWarning, skip_file_prefixes=prefixes)
                 spmatrix = True
             if spmatrix:
                 fmt_matrix = coo_matrix if var.format == "coo" else csc_matrix

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -98,7 +98,7 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=_NoValue, **kwarg
         Only relevant for sparse variables.
 
         .. deprecated:: 1.18.0
-            The default value for `spmatrix` is changing to False in v1.19.
+            The default value for `spmatrix` is changing to False in v1.20.
             That means the default return value will be a sparse array.
             Unless you use * instead of @, ** for matrix power, or you depend
             on 2D shapes from e.g. `A.sum(axis=0)`, it may not matter to you.
@@ -240,7 +240,7 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=_NoValue, **kwarg
         MR, _ = mat_reader_factory(f, **kwargs)
         matfile_dict = MR.get_variables(variable_names)
 
-    warn_msg = """The default value for `spmatrix` is changing to `False` in v1.19.
+    warn_msg = """The default value for `spmatrix` is changing to `False` in v1.20.
         That means the default return type will be a sparse array.
         Unless you use * instead of @, ** for matrix power, or you depend
         on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -3,11 +3,14 @@ Module for reading and writing matlab (TM) .mat files
 """
 # Authors: Travis Oliphant, Matthew Brett
 
+import warnings
+
 from contextlib import contextmanager
 
 from ._miobase import _get_matfile_version, docfiller
 from ._mio4 import MatFile4Reader, MatFile4Writer
 from ._mio5 import MatFile5Reader, MatFile5Writer
+from scipy._lib.deprecation import _NoValue
 
 __all__ = ['loadmat', 'savemat', 'whosmat']
 
@@ -75,7 +78,7 @@ def mat_reader_factory(file_name, appendmat=True, **kwargs):
         raise TypeError(f'Did not recognize version {mjv}')
 
 
-def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=True, **kwargs):
+def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=_NoValue, **kwargs):
     """
     Load MATLAB file.
 
@@ -93,6 +96,14 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=True, **kwargs):
         If ``True``, return sparse matrix. Otherwise return sparse array.
         Format is `COO` for MatFile 4 and `CSC` for MatFile 5.
         Only relevant for sparse variables.
+
+        .. deprecated:: 1.18.0
+            The default value for `spmatrix` is changing to False in v1.19.
+            That means the default return value will be a sparse array.
+            Unless you use * instead of @, ** for matrix power, or you depend
+            on 2D shapes from e.g. `A.sum(axis=0)`, it may not matter to you.
+            See :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
+
     **kwargs
         The following aditional keyword arguments can be passed:
 
@@ -228,12 +239,26 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=True, **kwargs):
     with _open_file_context(file_name, appendmat) as f:
         MR, _ = mat_reader_factory(f, **kwargs)
         matfile_dict = MR.get_variables(variable_names)
-    if spmatrix:
-        from scipy.sparse import issparse, coo_matrix, csc_matrix
-        for name, var in list(matfile_dict.items()):
-            if issparse(var):
+
+    warn_msg = """The default value for `spmatrix` is changing to `False` in v1.19.
+        That means the default return type will be a sparse array.
+        Unless you use * instead of @, ** for matrix power, or you depend
+        on 2D shapes from e.g. `A.sum(axis=0)` it may not matter to you.
+        See the spmatrix to sparray migration guide for details.
+        https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+        """
+
+    from scipy.sparse import issparse, coo_matrix, csc_matrix, coo_array, csc_array
+    for name, var in list(matfile_dict.items()):
+        if issparse(var):
+            if spmatrix is _NoValue:
+                warnings.warn(warn_msg, DeprecationWarning, stacklevel=2)
+                spmatrix = True
+            if spmatrix:
                 fmt_matrix = coo_matrix if var.format == "coo" else csc_matrix
-                matfile_dict[name] = fmt_matrix(var)
+            else:
+                fmt_matrix = coo_array if var.format == "coo" else csc_array
+            matfile_dict[name] = fmt_matrix(var)
 
     if mdict is not None:
         mdict.update(matfile_dict)

--- a/scipy/io/matlab/tests/test_mio.py
+++ b/scipy/io/matlab/tests/test_mio.py
@@ -17,7 +17,7 @@ from pytest import raises as assert_raises, warns as assert_warns
 
 import numpy as np
 from numpy import array
-from scipy.sparse import issparse, eye_array, coo_array, csc_array
+from scipy.sparse import issparse, eye_array, coo_array, csc_array, sparray
 
 import scipy.io
 from scipy.io.matlab import MatlabOpaque, MatlabFunction, MatlabObject
@@ -1185,12 +1185,12 @@ def test_empty_sparse():
     sio.seek(0)
 
     res = loadmat(sio, spmatrix=False)
-    sparray = scipy.sparse.sparray
     assert isinstance(res['x'], sparray)
     res = loadmat(sio, spmatrix=True)
     assert scipy.sparse.issparse(res['x']) and not isinstance(res['x'], sparray)
-    res = loadmat(sio)  # chk default
-    assert scipy.sparse.issparse(res['x']) and not isinstance(res['x'], sparray)
+    with pytest.deprecated_call(match="The default value for `spmatrix"):
+        res = loadmat(sio)  # chk default
+        assert scipy.sparse.issparse(res['x']) and not isinstance(res['x'], sparray)
 
     assert_array_equal(res['x'].shape, empty_sparse.shape)
     assert_array_equal(res['x'].toarray(), 0)

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -274,14 +274,18 @@ class TestMMIOSparseCSR(TestMMIOArray):
         info = (2, 2, 3, 'coordinate', 'pattern', 'general')
         mmwrite(self.fn, a, field='pattern')
         assert_equal(mminfo(self.fn), info)
+
         b = mmread(self.fn, spmatrix=False)
         assert_array_almost_equal(p, b.toarray())
         assert isinstance(b, scipy.sparse.sparray)
 
         b = mmread(self.fn, spmatrix=True)
+        assert_array_almost_equal(p, b.toarray())
         assert isinstance(b, scipy.sparse.spmatrix)
-        b = mmread(self.fn)  # chk default
-        assert isinstance(b, scipy.sparse.spmatrix)
+
+        with pytest.deprecated_call(match="The default value"):
+            b = mmread(self.fn)  # chk default
+            assert not isinstance(b, scipy.sparse.sparray)
 
     def test_gh13634_non_skew_symmetric_int(self):
         a = scipy.sparse.csr_array([[1, 2], [-2, 99]], dtype=np.int32)


### PR DESCRIPTION
This PR deprecates the `spmatrix=True` kwarg values for the `io` readers that read sparse objects.
`mmio, FFM, hb, matlab/_mio`. Warning is raised if no default is given (using `_NoValue` technique).
Warning is written in doc_string. And tests of the warning (as well as the default behavior) are included.
