### PR TITLE
BUG: sparse: csgraph and superLU index dtype need 32bit

### DIFF
--- a/scipy/sparse/csgraph/_min_spanning_tree.pyx
+++ b/scipy/sparse/csgraph/_min_spanning_tree.pyx
@@ -7,7 +7,7 @@ cimport cython
 
 from scipy.sparse import csr_array, csr_matrix, spmatrix
 from scipy.sparse.csgraph._validation import validate_graph
-from scipy.sparse._sputils import is_pydata_spmatrix
+from scipy.sparse._sputils import is_pydata_spmatrix, safely_cast_index_arrays
 
 np.import_array()
 
@@ -100,8 +100,7 @@ def minimum_spanning_tree(csgraph, overwrite=False):
     cdef int N = csgraph.shape[0]
 
     data = csgraph.data
-    indices = csgraph.indices
-    indptr = csgraph.indptr
+    indices, indptr = safely_cast_index_arrays(csgraph, np.intc, "csgraph")
 
     rank = np.zeros(N, dtype=ITYPE)
     predecessors = np.arange(N, dtype=ITYPE)

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -749,9 +749,12 @@ def spsolve_triangular(A, b, lower=True, overwrite_A=False, overwrite_b=False,
         U = A
         U.setdiag(0)
 
+    L_indices, L_indptr = safely_cast_index_arrays(L, np.intc, "SuperLU")
+    U_indices, U_indptr = safely_cast_index_arrays(U, np.intc, "SuperLU")
+
     x, info = _superlu.gstrs(trans,
-                             N, L.nnz, L.data, L.indices, L.indptr,
-                             N, U.nnz, U.data, U.indices, U.indptr,
+                             N, L.nnz, L.data, L_indices, L_indptr,
+                             N, U.nnz, U.data, U_indices, U_indptr,
                              b)
     if info:
         raise LinAlgError('A is singular.')


### PR DESCRIPTION
Fixes #24629                (CI failures with new pydata/sparse release)

Using `sputils.safely_cast_index_arrays` to cast index arrays to intc just before calling superLU and csgraph library routines does the trick.  

We might consider whether to support int64 index dtypes for index arrays in csgraph and superLU. But this method works.