### PR TITLE
DOC: stats.wasserstein_distance: add explanatory text to examples.

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9712,7 +9712,8 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     >>> from scipy.stats import wasserstein_distance
 
     When no weights are provided, each value is treated as a single unit
-    mass at that location:
+    of probability mass at that location:
+
     >>> wasserstein_distance([0, 1, 3], [5, 6, 8])
     5.0
 
@@ -9720,7 +9721,7 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     (e.g. "shovelsful of dirt" in the Earth mover's distance analogy [2]_)
     at each location. Weights are normalized internally to sum to 1:
 
-    >>> wasserstein_distance([0, 1], [0, 1], [3, 1], [2, 2])
+    >>> wasserstein_distance([0, 1], [0, 1], u_weights=[3, 1], v_weights=[2, 2])
     0.25
     >>> wasserstein_distance([3.4, 3.9, 7.5, 7.8], [4.5, 1.4],
     ...                      [1.4, 0.9, 3.1, 7.2], [3.2, 3.5])

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9710,8 +9710,16 @@ def wasserstein_distance(u_values, v_values, u_weights=None, v_weights=None):
     Examples
     --------
     >>> from scipy.stats import wasserstein_distance
+
+    When no weights are provided, each value is treated as a single unit
+    mass at that location:
     >>> wasserstein_distance([0, 1, 3], [5, 6, 8])
     5.0
+
+    When weights are provided, they represent the probability mass
+    (e.g. "shovelsful of dirt" in the Earth mover's distance analogy [2]_)
+    at each location. Weights are normalized internally to sum to 1:
+
     >>> wasserstein_distance([0, 1], [0, 1], [3, 1], [2, 2])
     0.25
     >>> wasserstein_distance([3.4, 3.9, 7.5, 7.8], [4.5, 1.4],


### PR DESCRIPTION
Closes gh-23252 

What does this implement/fix?

Examples in wasserstein_distance didn't explain what each argument represents.
When both values and weights are involved  its not obvious which inputs are locations and which are probability masses.
This lack of clarity caused confusion when users tried to connect the docs to external references on the Wasserstein distance.

Additional information
No code or examples were changed  only explanatory documentation  was added.
No AI generated code was used .
