### PR TITLE
DOC/DEV: fix typo in release docs

### DIFF
--- a/doc/source/dev/core-dev/releasing.rst.inc
+++ b/doc/source/dev/core-dev/releasing.rst.inc
@@ -176,7 +176,7 @@ notes`` again.
 
 Uploading release artifacts
 ---------------------------
-For a release there are currently five places on the web to upload things to:
+For a release there are currently four places on the web to upload things to:
 
 - PyPI (sdist, wheels)
 - GitHub Releases (sdist, release notes, Changelog)


### PR DESCRIPTION
follow-up to 12aa460445a8f476a34f82f882bde6d0bc8a85d4