### PR TITLE
ENH: stats.contingency.crosstab: support `sparray`

### DIFF
--- a/scipy/stats/_crosstab.py
+++ b/scipy/stats/_crosstab.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_array
 from scipy._lib._bunch import _make_tuple_bunch
 
 
@@ -34,10 +34,9 @@ def crosstab(*args, levels=None, sparse=False):
         is ignored and not counted in the returned array `count`.  The default
         value of `levels` for ``args[i]`` is ``np.unique(args[i])``
     sparse : bool, optional
-        If True, return a sparse matrix.  The matrix will be an instance of
-        the `scipy.sparse.coo_matrix` class.  Because SciPy's sparse matrices
-        must be 2-d, only two input sequences are allowed when `sparse` is
-        True.  Default is False.
+        If True, return a sparse array.  The array will be an instance of
+        the `scipy.sparse.coo_array` class.
+        Default is False.
 
     Returns
     -------
@@ -50,7 +49,7 @@ def crosstab(*args, levels=None, sparse=False):
             labels of the corresponding dimensions of `count`. If `levels` was
             given, then if ``levels[i]`` is not None, ``elements[i]`` will
             hold the values given in ``levels[i]``.
-        count : numpy.ndarray or scipy.sparse.coo_matrix
+        count : numpy.ndarray or scipy.sparse.coo_array
             Counts of the unique elements in ``zip(*args)``, stored in an
             array. Also known as a *contingency table* when ``len(args) > 1``.
 
@@ -141,11 +140,11 @@ def crosstab(*args, levels=None, sparse=False):
            [1, 4],
            [0, 3]])
 
-    Finally, let's repeat the first example, but return a sparse matrix:
+    Finally, let's repeat the first example, but return a sparse array:
 
     >>> res = crosstab(a, x, sparse=True)
     >>> res.count
-    <COOrdinate sparse matrix of dtype 'int64'
+    <COOrdinate sparse array of dtype 'int64'
         with 4 stored elements and shape (2, 3)>
     >>> res.count.toarray()
     array([[2, 3, 0],
@@ -159,10 +158,6 @@ def crosstab(*args, levels=None, sparse=False):
     len0 = len(args[0])
     if not all(len(a) == len0 for a in args[1:]):
         raise ValueError("All input sequences must have the same length.")
-
-    if sparse and nargs != 2:
-        raise ValueError("When `sparse` is True, only two input sequences "
-                         "are allowed.")
 
     if levels is None:
         # Call np.unique with return_inverse=True on each argument.
@@ -193,7 +188,7 @@ def crosstab(*args, levels=None, sparse=False):
         indices = tuple(inv[:, mask_all])
 
     if sparse:
-        count = coo_matrix((np.ones(len(indices[0]), dtype=int),
+        count = coo_array((np.ones(len(indices[0]), dtype=int),
                             (indices[0], indices[1])))
         count.sum_duplicates()
     else:

--- a/scipy/stats/_crosstab.py
+++ b/scipy/stats/_crosstab.py
@@ -188,8 +188,7 @@ def crosstab(*args, levels=None, sparse=False):
         indices = tuple(inv[:, mask_all])
 
     if sparse:
-        count = coo_array((np.ones(len(indices[0]), dtype=int),
-                            (indices[0], indices[1])))
+        count = coo_array((np.ones(len(indices[0]), dtype=int), indices))
         count.sum_duplicates()
     else:
         shape = [len(u) for u in actual_levels]

--- a/scipy/stats/tests/test_crosstab.py
+++ b/scipy/stats/tests/test_crosstab.py
@@ -21,17 +21,22 @@ def test_crosstab_basic(sparse):
         assert_array_equal(count, expected_count)
 
 
-def test_crosstab_basic_1d():
+@pytest.mark.parametrize('sparse', [False, True])
+def test_crosstab_basic_1d(sparse):
     # Verify that a single input sequence works as expected.
     x = [1, 2, 3, 1, 2, 3, 3]
     expected_xvals = [1, 2, 3]
     expected_count = np.array([2, 2, 3])
-    (xvals,), count = crosstab(x)
+    (xvals,), count = crosstab(x, sparse=sparse)
     assert_array_equal(xvals, expected_xvals)
-    assert_array_equal(count, expected_count)
+    if sparse:
+        assert_array_equal(count.toarray(), expected_count)
+    else:
+        assert_array_equal(count, expected_count)
 
 
-def test_crosstab_basic_3d():
+@pytest.mark.parametrize('sparse', [False, True])
+def test_crosstab_basic_3d(sparse):
     # Verify the function for three input sequences.
     a = 'a'
     b = 'b'
@@ -45,11 +50,14 @@ def test_crosstab_basic_3d():
                                 [0, 1, 1]],
                                [[2, 0, 1],
                                 [0, 0, 1]]])
-    (xvals, yvals, zvals), count = crosstab(x, y, z)
+    (xvals, yvals, zvals), count = crosstab(x, y, z, sparse=sparse)
     assert_array_equal(xvals, expected_xvals)
     assert_array_equal(yvals, expected_yvals)
     assert_array_equal(zvals, expected_zvals)
-    assert_array_equal(count, expected_count)
+    if sparse:
+        assert_array_equal(count.toarray(), expected_count)
+    else:
+        assert_array_equal(count, expected_count)
 
 
 @pytest.mark.parametrize('sparse', [False, True])
@@ -98,11 +106,6 @@ def test_validation_at_least_one():
 def test_validation_same_lengths():
     with pytest.raises(ValueError, match='must have the same length'):
         crosstab([1, 2], [1, 2, 3, 4])
-
-
-def test_validation_sparse_only_two_args():
-    # no longer raises when not two input sequences because sparse arrays are 2D
-    crosstab([0, 1, 1], [8, 8, 9], [1, 3, 3], sparse=True)
 
 
 def test_validation_len_levels_matches_args():

--- a/scipy/stats/tests/test_crosstab.py
+++ b/scipy/stats/tests/test_crosstab.py
@@ -101,8 +101,8 @@ def test_validation_same_lengths():
 
 
 def test_validation_sparse_only_two_args():
-    with pytest.raises(ValueError, match='only two input sequences'):
-        crosstab([0, 1, 1], [8, 8, 9], [1, 3, 3], sparse=True)
+    # no longer raises when not two input sequences because sparse arrays are 2D
+    crosstab([0, 1, 1], [8, 8, 9], [1, 3, 3], sparse=True)
 
 
 def test_validation_len_levels_matches_args():


### PR DESCRIPTION
Currently the `sparse` kwarg for `crosstabs` is boolean with `False` meaning numpy.ndarray while `True` means coo_matrix.  This PR adds two other optional string values for the kwarg `sparse`. The options are "sparray" and "spmatrix".  The value `True` will continue to mean "spmatrix", but will presumably change at some point to mean "sparray".  This shouldn't affect existing code. A warning is added to the docs to encourage use of sparse arrays in new code.