### PR TITLE
ENH: integrate: support `sparray` in IVP and BVP

### DIFF
--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -4,7 +4,7 @@ from warnings import warn
 import numpy as np
 from numpy.linalg import pinv
 
-from scipy.sparse import coo_array
+from scipy.sparse import csc_array
 from scipy.sparse.linalg import splu
 from scipy.optimize import OptimizeResult
 from scipy._lib._array_api import xp_capabilities
@@ -270,8 +270,7 @@ def construct_global_jac(n, m, k, i_jac, j_jac, h, df_dy, df_dy_middle, df_dp,
         dPhi_dp = -h/6 * (df_dp[:-1] + df_dp[1:] + 4 * df_dp_middle)
         values = np.hstack((values, dPhi_dp.ravel(), dbc_dp.ravel()))
 
-    J = coo_array((values, (i_jac, j_jac)))
-    return J.tocsc()
+    return csc_array((values, (i_jac, j_jac)))
 
 
 def collocation_fun(fun, y, p, x, h):

--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -229,7 +229,7 @@ def construct_global_jac(n, m, k, i_jac, j_jac, h, df_dy, df_dy_middle, df_dp,
 
     Returns
     -------
-    J : csc_matrix or csc_array, shape (n * m + k, n * m + k)
+    J : csc_array, shape (n * m + k, n * m + k)
         Jacobian of the collocation system in a sparse form.
 
     References
@@ -377,7 +377,7 @@ def solve_newton(n, m, h, col_fun, bc, jac, y, p, B, bvp_tol, bc_tol):
     jac : callable
         Function computing the Jacobian of the whole system (including
         collocation and boundary condition residuals). It is supposed to
-        return csc_matrix or csc_array.
+        return csc_array or csc_matrix.
     y : ndarray, shape (n, m)
         Initial guess for the function values at the mesh nodes.
     p : ndarray, shape (k,)

--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -4,7 +4,7 @@ from warnings import warn
 import numpy as np
 from numpy.linalg import pinv
 
-from scipy.sparse import coo_matrix, csc_matrix
+from scipy.sparse import coo_array
 from scipy.sparse.linalg import splu
 from scipy.optimize import OptimizeResult
 from scipy._lib._array_api import xp_capabilities
@@ -229,7 +229,7 @@ def construct_global_jac(n, m, k, i_jac, j_jac, h, df_dy, df_dy_middle, df_dp,
 
     Returns
     -------
-    J : csc_matrix, shape (n * m + k, n * m + k)
+    J : csc_matrix or csc_array, shape (n * m + k, n * m + k)
         Jacobian of the collocation system in a sparse form.
 
     References
@@ -270,8 +270,8 @@ def construct_global_jac(n, m, k, i_jac, j_jac, h, df_dy, df_dy_middle, df_dp,
         dPhi_dp = -h/6 * (df_dp[:-1] + df_dp[1:] + 4 * df_dp_middle)
         values = np.hstack((values, dPhi_dp.ravel(), dbc_dp.ravel()))
 
-    J = coo_matrix((values, (i_jac, j_jac)))
-    return csc_matrix(J)
+    J = coo_array((values, (i_jac, j_jac)))
+    return J.tocsc()
 
 
 def collocation_fun(fun, y, p, x, h):
@@ -377,7 +377,7 @@ def solve_newton(n, m, h, col_fun, bc, jac, y, p, B, bvp_tol, bc_tol):
     jac : callable
         Function computing the Jacobian of the whole system (including
         collocation and boundary condition residuals). It is supposed to
-        return csc_matrix.
+        return csc_matrix or csc_array.
     y : ndarray, shape (n, m)
         Initial guess for the function values at the mesh nodes.
     p : ndarray, shape (k,)

--- a/scipy/integrate/_bvp.py
+++ b/scipy/integrate/_bvp.py
@@ -375,8 +375,8 @@ def solve_newton(n, m, h, col_fun, bc, jac, y, p, B, bvp_tol, bc_tol):
         Function computing boundary condition residuals.
     jac : callable
         Function computing the Jacobian of the whole system (including
-        collocation and boundary condition residuals). It is supposed to
-        return csc_array or csc_matrix.
+        collocation and boundary condition residuals). It must return
+        scipy.sparse in CSC format ready for use with `scipy.sparse.linalg.splu`.
     y : ndarray, shape (n, m)
         Initial guess for the function values at the mesh nodes.
     p : ndarray, shape (k,)

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
-from scipy.sparse import issparse, eye_array
+from scipy.sparse import issparse, eye_array, safely_cast_index_arrays
 from scipy.sparse.linalg import splu
 from scipy.optimize._numdiff import group_columns
 from .common import (validate_max_step, validate_tol, select_initial_step,
@@ -122,7 +122,7 @@ class BDF(OdeSolver):
           assumed to be constant.
         * If callable, the Jacobian is assumed to depend on both
           t and y; it will be called as ``jac(t, y)`` as necessary.
-          For the 'Radau' and 'BDF' methods, the return value can be a
+          For the 'Radau' and 'BDF' methods, the return value might be a
           sparse array or sparse matrix.
         * If None (default), the Jacobian will be approximated by
           finite differences.
@@ -265,6 +265,7 @@ class BDF(OdeSolver):
             if sparsity is not None:
                 if issparse(sparsity):
                     sparsity = sparsity.tocsc()
+                safely_cast_index_arrays(sparsity)
                 groups = group_columns(sparsity)
                 sparsity = (sparsity, groups)
 

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -285,6 +285,7 @@ class BDF(OdeSolver):
 
                 def jac_wrapped(t, y):
                     self.njev += 1
+                    # TODO: switch to csc_array after spmatrix is removed
                     return csc_constructor(jac(t, y), dtype=y0.dtype)
             else:
                 J = np.asarray(J, dtype=y0.dtype)

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
-from scipy.sparse import issparse, csc_matrix, eye
+from scipy.sparse import issparse, eye_array
 from scipy.sparse.linalg import splu
 from scipy.optimize._numdiff import group_columns
 from .common import (validate_max_step, validate_tol, select_initial_step,
@@ -112,24 +112,24 @@ class BDF(OdeSolver):
         beneficial to set different `atol` values for different components by
         passing array_like with shape (n,) for `atol`. Default values are
         1e-3 for `rtol` and 1e-6 for `atol`.
-    jac : {None, array_like, sparse_matrix, callable}, optional
+    jac : {None, array_like, sparse matrix or array, callable}, optional
         Jacobian matrix of the right-hand side of the system with respect to y,
         required by this method. The Jacobian matrix has shape (n, n) and its
         element (i, j) is equal to ``d f_i / d y_j``.
         There are three ways to define the Jacobian:
 
-        * If array_like or sparse_matrix, the Jacobian is assumed to
-          be constant.
+        * If array_like or sparse_matrix or sparse_array, the Jacobian is
+          assumed to be constant.
         * If callable, the Jacobian is assumed to depend on both
           t and y; it will be called as ``jac(t, y)`` as necessary.
           For the 'Radau' and 'BDF' methods, the return value might be a
-          sparse matrix.
+          sparse matrix or sparse array.
         * If None (default), the Jacobian will be approximated by
           finite differences.
 
         It is generally recommended to provide the Jacobian rather than
         relying on a finite-difference approximation.
-    jac_sparsity : {None, array_like, sparse matrix}, optional
+    jac_sparsity : {None, array_like, sparse matrix or array}, optional
         Defines a sparsity structure of the Jacobian matrix for a
         finite-difference approximation. Its shape must be (n, n). This argument
         is ignored if `jac` is not `None`. If the Jacobian has only few non-zero
@@ -228,7 +228,7 @@ class BDF(OdeSolver):
             def solve_lu(LU, b):
                 return LU.solve(b)
 
-            I = eye(self.n, format='csc', dtype=self.y.dtype)
+            I = eye_array(self.n, format='csc', dtype=self.y.dtype)
         else:
             def lu(A):
                 self.nlu += 1
@@ -264,7 +264,7 @@ class BDF(OdeSolver):
         if jac is None:
             if sparsity is not None:
                 if issparse(sparsity):
-                    sparsity = csc_matrix(sparsity)
+                    sparsity = sparsity.tocsc()
                 groups = group_columns(sparsity)
                 sparsity = (sparsity, groups)
 
@@ -280,11 +280,12 @@ class BDF(OdeSolver):
             J = jac(t0, y0)
             self.njev += 1
             if issparse(J):
-                J = csc_matrix(J, dtype=y0.dtype)
+                J = J.tocsc().astype(y0.dtype)
+                csc_constructor = J.__class__
 
                 def jac_wrapped(t, y):
                     self.njev += 1
-                    return csc_matrix(jac(t, y), dtype=y0.dtype)
+                    return csc_constructor(jac(t, y), dtype=y0.dtype)
             else:
                 J = np.asarray(J, dtype=y0.dtype)
 
@@ -297,7 +298,7 @@ class BDF(OdeSolver):
                                  f" but actually has {J.shape}.")
         else:
             if issparse(jac):
-                J = csc_matrix(jac, dtype=y0.dtype)
+                J = jac.tocsc().astype(y0.dtype)
             else:
                 J = np.asarray(jac, dtype=y0.dtype)
 

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -118,12 +118,10 @@ class BDF(OdeSolver):
         element (i, j) is equal to ``d f_i / d y_j``.
         There are three ways to define the Jacobian:
 
-        * If array_like or sparse_array or sparse_matrix, the Jacobian is
-          assumed to be constant.
+        * If array_like or sparse, the Jacobian is assumed to be constant.
         * If callable, the Jacobian is assumed to depend on both
           t and y; it will be called as ``jac(t, y)`` as necessary.
-          For the 'Radau' and 'BDF' methods, the return value might be a
-          sparse array or sparse matrix.
+          For the 'Radau' and 'BDF' methods, it can return dense or sparse.
         * If None (default), the Jacobian will be approximated by
           finite differences.
 
@@ -265,7 +263,9 @@ class BDF(OdeSolver):
             if sparsity is not None:
                 if issparse(sparsity):
                     sparsity = sparsity.tocsc()
-                safely_cast_index_arrays(sparsity)
+                    # this restricts self.n to fit in int32 for group_columns
+                    indices, indptr = safely_cast_index_arrays(sparsity)
+                    sparsity.indices, sparsity.indptr = indices, indptr
                 groups = group_columns(sparsity)
                 sparsity = (sparsity, groups)
 

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
-from scipy.sparse import issparse, eye_array, safely_cast_index_arrays
+from scipy.sparse import issparse, eye_array
 from scipy.sparse.linalg import splu
 from scipy.optimize._numdiff import group_columns
 from .common import (validate_max_step, validate_tol, select_initial_step,

--- a/scipy/integrate/_ivp/bdf.py
+++ b/scipy/integrate/_ivp/bdf.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
-from scipy.sparse import issparse, eye_array
+from scipy.sparse import issparse, eye_array, safely_cast_index_arrays
 from scipy.sparse.linalg import splu
 from scipy.optimize._numdiff import group_columns
 from .common import (validate_max_step, validate_tol, select_initial_step,
@@ -112,24 +112,24 @@ class BDF(OdeSolver):
         beneficial to set different `atol` values for different components by
         passing array_like with shape (n,) for `atol`. Default values are
         1e-3 for `rtol` and 1e-6 for `atol`.
-    jac : {None, array_like, sparse matrix or array, callable}, optional
+    jac : {None, array_like, sparse array or matrix, callable}, optional
         Jacobian matrix of the right-hand side of the system with respect to y,
         required by this method. The Jacobian matrix has shape (n, n) and its
         element (i, j) is equal to ``d f_i / d y_j``.
         There are three ways to define the Jacobian:
 
-        * If array_like or sparse_matrix or sparse_array, the Jacobian is
+        * If array_like or sparse_array or sparse_matrix, the Jacobian is
           assumed to be constant.
         * If callable, the Jacobian is assumed to depend on both
           t and y; it will be called as ``jac(t, y)`` as necessary.
-          For the 'Radau' and 'BDF' methods, the return value might be a
-          sparse matrix or sparse array.
+          For the 'Radau' and 'BDF' methods, the return value can be a
+          sparse array or sparse matrix.
         * If None (default), the Jacobian will be approximated by
           finite differences.
 
         It is generally recommended to provide the Jacobian rather than
         relying on a finite-difference approximation.
-    jac_sparsity : {None, array_like, sparse matrix or array}, optional
+    jac_sparsity : {None, array_like, sparse array or matrix}, optional
         Defines a sparsity structure of the Jacobian matrix for a
         finite-difference approximation. Its shape must be (n, n). This argument
         is ignored if `jac` is not `None`. If the Jacobian has only few non-zero
@@ -280,7 +280,7 @@ class BDF(OdeSolver):
             J = jac(t0, y0)
             self.njev += 1
             if issparse(J):
-                J = J.tocsc().astype(y0.dtype)
+                J = J.tocsc().astype(y0.dtype, copy=False)
                 csc_constructor = J.__class__
 
                 def jac_wrapped(t, y):
@@ -298,7 +298,7 @@ class BDF(OdeSolver):
                                  f" but actually has {J.shape}.")
         else:
             if issparse(jac):
-                J = jac.tocsc().astype(y0.dtype)
+                J = jac.tocsc().astype(y0.dtype, copy=False)
             else:
                 J = np.asarray(jac, dtype=y0.dtype)
 

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -1,7 +1,8 @@
 from itertools import groupby
 from warnings import warn
+import os
 import numpy as np
-from scipy.sparse import find, coo_array
+from scipy.sparse import find, csc_array, csc_matrix
 
 
 EPS = np.finfo(float).eps
@@ -299,7 +300,7 @@ def num_jac(fun, t, y, f, threshold, factor, sparsity=None):
         Factor to use for computing the step size. Pass None for the very
         evaluation, then use the value returned from this function.
     sparsity : tuple (structure, groups) or None
-        Sparsity structure of the Jacobian, `structure` must be csc_array or csc_matrix.
+        Sparsity structure of the Jacobian. To get dense Jacobian use `None`.
 
     Returns
     -------
@@ -395,7 +396,24 @@ def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
     df = f_new - f[:, None]
 
     i, j, _ = find(structure)
-    diff = coo_array((df[i, groups[j]], (i, j)), shape=(n, n)).tocsc()
+    if isinstance(structure, csc_array):
+        diff = csc_array((df[i, groups[j]], (i, j)), shape=(n, n))
+    else:
+        msg = """num_jac is switching to the sparse array interface.
+
+        The sparsity structure input can still be a csc_matrix. But the output
+        will be a csc_array. You can prepare for this by converting the structure
+        part of sparsity to csc_array (i.e. the first entry in the 2-tuple).
+        For example, sparsity=(csc_array(A), groups).
+        For more information, see the spmatrix to sparray migration guide
+        https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+
+        This default value will be changed no earlier than v1.20.
+        """
+        prefixes = (os.path.dirname(__file__),)
+        warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
+
+        diff = csc_matrix((df[i, groups[j]], (i, j)), shape=(n, n))
     max_ind = np.array(abs(diff).argmax(axis=0)).ravel()
     r = np.arange(n)
     max_diff = np.asarray(np.abs(diff[max_ind, r])).ravel()
@@ -422,8 +440,9 @@ def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
         f_new = fun(t, y[:, None] + h_vecs)
         df = f_new - f[:, None]
         i, j, _ = find(structure[:, ind])
-        diff_new = coo_array((df[i, groups_map[groups[ind[j]]]],
-                              (i, j)), shape=(n, ind.shape[0])).tocsc()
+        # this is same whether csc_array or csc_matrix. Not returned to user.
+        diff_new = csc_array((df[i, groups_map[groups[ind[j]]]], (i, j)),
+                             shape=(n, ind.shape[0]))
 
         max_ind_new = np.array(abs(diff_new).argmax(axis=0)).ravel()
         r = np.arange(ind.shape[0])

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -1,7 +1,7 @@
 from itertools import groupby
 from warnings import warn
 import numpy as np
-from scipy.sparse import find, coo_matrix
+from scipy.sparse import find, coo_array
 
 
 EPS = np.finfo(float).eps
@@ -299,11 +299,11 @@ def num_jac(fun, t, y, f, threshold, factor, sparsity=None):
         Factor to use for computing the step size. Pass None for the very
         evaluation, then use the value returned from this function.
     sparsity : tuple (structure, groups) or None
-        Sparsity structure of the Jacobian, `structure` must be csc_matrix.
+        Sparsity structure of the Jacobian, `structure` must be csc_matrix or csc_array.
 
     Returns
     -------
-    J : ndarray or csc_matrix, shape (n, n)
+    J : ndarray or csc_matrix or csc_array, shape (n, n)
         Jacobian matrix.
     factor : ndarray, shape (n,)
         Suggested `factor` for the next evaluation.
@@ -395,7 +395,7 @@ def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
     df = f_new - f[:, None]
 
     i, j, _ = find(structure)
-    diff = coo_matrix((df[i, groups[j]], (i, j)), shape=(n, n)).tocsc()
+    diff = coo_array((df[i, groups[j]], (i, j)), shape=(n, n)).tocsc()
     max_ind = np.array(abs(diff).argmax(axis=0)).ravel()
     r = np.arange(n)
     max_diff = np.asarray(np.abs(diff[max_ind, r])).ravel()
@@ -422,8 +422,8 @@ def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
         f_new = fun(t, y[:, None] + h_vecs)
         df = f_new - f[:, None]
         i, j, _ = find(structure[:, ind])
-        diff_new = coo_matrix((df[i, groups_map[groups[ind[j]]]],
-                               (i, j)), shape=(n, ind.shape[0])).tocsc()
+        diff_new = coo_array((df[i, groups_map[groups[ind[j]]]],
+                              (i, j)), shape=(n, ind.shape[0])).tocsc()
 
         max_ind_new = np.array(abs(diff_new).argmax(axis=0)).ravel()
         r = np.arange(ind.shape[0])

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -440,7 +440,6 @@ def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
         f_new = fun(t, y[:, None] + h_vecs)
         df = f_new - f[:, None]
         i, j, _ = find(structure[:, ind])
-        # this is same whether csc_array or csc_matrix. Not returned to user.
         diff_new = csc_array((df[i, groups_map[groups[ind[j]]]], (i, j)),
                              shape=(n, ind.shape[0]))
 

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -1,8 +1,7 @@
 from itertools import groupby
 from warnings import warn
-import os
 import numpy as np
-from scipy.sparse import find, csc_array, csc_matrix
+from scipy.sparse import find, csc_array, isspmatrix, csc_matrix
 
 
 EPS = np.finfo(float).eps
@@ -396,24 +395,7 @@ def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
     df = f_new - f[:, None]
 
     i, j, _ = find(structure)
-    if isinstance(structure, csc_array):
-        diff = csc_array((df[i, groups[j]], (i, j)), shape=(n, n))
-    else:
-        msg = """num_jac is switching to the sparse array interface.
-
-        The sparsity structure input can still be a csc_matrix. But the output
-        will be a csc_array. You can prepare for this by converting the structure
-        part of sparsity to csc_array (i.e. the first entry in the 2-tuple).
-        For example, sparsity=(csc_array(A), groups).
-        For more information, see the spmatrix to sparray migration guide
-        https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
-
-        This default value will be changed no earlier than v1.20.
-        """
-        prefixes = (os.path.dirname(__file__),)
-        warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
-
-        diff = csc_matrix((df[i, groups[j]], (i, j)), shape=(n, n))
+    diff = csc_array((df[i, groups[j]], (i, j)), shape=(n, n))
     max_ind = np.array(abs(diff).argmax(axis=0)).ravel()
     r = np.arange(n)
     max_diff = np.asarray(np.abs(diff[max_ind, r])).ravel()
@@ -466,4 +448,7 @@ def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
     factor[max_diff > NUM_JAC_DIFF_BIG * scale] *= NUM_JAC_FACTOR_DECREASE
     factor = np.maximum(factor, NUM_JAC_MIN_FACTOR)
 
+    # return spmatrix if structure is spmatrix
+    if isspmatrix(structure):
+        diff = csc_matrix(diff)
     return diff, factor

--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -299,11 +299,11 @@ def num_jac(fun, t, y, f, threshold, factor, sparsity=None):
         Factor to use for computing the step size. Pass None for the very
         evaluation, then use the value returned from this function.
     sparsity : tuple (structure, groups) or None
-        Sparsity structure of the Jacobian, `structure` must be csc_matrix or csc_array.
+        Sparsity structure of the Jacobian, `structure` must be csc_array or csc_matrix.
 
     Returns
     -------
-    J : ndarray or csc_matrix or csc_array, shape (n, n)
+    J : ndarray or csc_array or csc_matrix, shape (n, n)
         Jacobian matrix.
     factor : ndarray, shape (n,)
         Suggested `factor` for the next evaluation.

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -327,7 +327,8 @@ class Radau(OdeSolver):
             def solve_lu(LU, b):
                 return LU.solve(b)
 
-            I = eye_array(self.n, format='csc')
+            # TODO: use I = eye_array(self.n, format="csc") after spmatrix removed
+            I = self.J.__class__(eye_array(self.n)).tocsc()
         else:
             def lu(A):
                 self.nlu += 1
@@ -374,6 +375,7 @@ class Radau(OdeSolver):
 
                 def jac_wrapped(t, y, _=None):
                     self.njev += 1
+                    # TODO: Use csc_array after spmatrix removed
                     return csc_constructor(jac(t, y), dtype=float)
 
             else:

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -215,24 +215,24 @@ class Radau(OdeSolver):
         beneficial to set different `atol` values for different components by
         passing array_like with shape (n,) for `atol`. Default values are
         1e-3 for `rtol` and 1e-6 for `atol`.
-    jac : {None, array_like, sparse matrix or array, callable}, optional
+    jac : {None, array_like, sparse array or matrix, callable}, optional
         Jacobian matrix of the right-hand side of the system with respect to
         y, required by this method. The Jacobian matrix has shape (n, n) and
         its element (i, j) is equal to ``d f_i / d y_j``.
         There are three ways to define the Jacobian:
 
-        * If array_like or sparse_matrix or sparse_array, the Jacobian is
+        * If array_like or sparse_array or sparse_matrix, the Jacobian is
           assumed to be constant.
         * If callable, the Jacobian is assumed to depend on both
           t and y; it will be called as ``jac(t, y)`` as necessary.
           For the 'Radau' and 'BDF' methods, the return value might be a
-          sparse matrix or array.
+          sparse array or matrix.
         * If None (default), the Jacobian will be approximated by
           finite differences.
 
         It is generally recommended to provide the Jacobian rather than
         relying on a finite-difference approximation.
-    jac_sparsity : {None, array_like, sparse matrix or array}, optional
+    jac_sparsity : {None, array_like, sparse array or matrix}, optional
         Defines a sparsity structure of the Jacobian matrix for a
         finite-difference approximation. Its shape must be (n, n). This argument
         is ignored if `jac` is not `None`. If the Jacobian has only few non-zero

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
-from scipy.sparse import csc_matrix, issparse, eye
+from scipy.sparse import issparse, eye_array
 from scipy.sparse.linalg import splu
 from scipy.optimize._numdiff import group_columns
 from .common import (validate_max_step, validate_tol, select_initial_step,
@@ -215,24 +215,24 @@ class Radau(OdeSolver):
         beneficial to set different `atol` values for different components by
         passing array_like with shape (n,) for `atol`. Default values are
         1e-3 for `rtol` and 1e-6 for `atol`.
-    jac : {None, array_like, sparse_matrix, callable}, optional
+    jac : {None, array_like, sparse matrix or array, callable}, optional
         Jacobian matrix of the right-hand side of the system with respect to
         y, required by this method. The Jacobian matrix has shape (n, n) and
         its element (i, j) is equal to ``d f_i / d y_j``.
         There are three ways to define the Jacobian:
 
-        * If array_like or sparse_matrix, the Jacobian is assumed to
-          be constant.
+        * If array_like or sparse_matrix or sparse_array, the Jacobian is
+          assumed to be constant.
         * If callable, the Jacobian is assumed to depend on both
           t and y; it will be called as ``jac(t, y)`` as necessary.
           For the 'Radau' and 'BDF' methods, the return value might be a
-          sparse matrix.
+          sparse matrix or array.
         * If None (default), the Jacobian will be approximated by
           finite differences.
 
         It is generally recommended to provide the Jacobian rather than
         relying on a finite-difference approximation.
-    jac_sparsity : {None, array_like, sparse matrix}, optional
+    jac_sparsity : {None, array_like, sparse matrix or array}, optional
         Defines a sparsity structure of the Jacobian matrix for a
         finite-difference approximation. Its shape must be (n, n). This argument
         is ignored if `jac` is not `None`. If the Jacobian has only few non-zero
@@ -327,7 +327,7 @@ class Radau(OdeSolver):
             def solve_lu(LU, b):
                 return LU.solve(b)
 
-            I = eye(self.n, format='csc')
+            I = eye_array(self.n, format='csc')
         else:
             def lu(A):
                 self.nlu += 1
@@ -354,7 +354,7 @@ class Radau(OdeSolver):
         if jac is None:
             if sparsity is not None:
                 if issparse(sparsity):
-                    sparsity = csc_matrix(sparsity)
+                    sparsity = sparsity.tocsc()
                 groups = group_columns(sparsity)
                 sparsity = (sparsity, groups)
 
@@ -369,11 +369,12 @@ class Radau(OdeSolver):
             J = jac(t0, y0)
             self.njev = 1
             if issparse(J):
-                J = csc_matrix(J)
+                J = J.tocsc()
+                csc_constructor = J.__class__
 
                 def jac_wrapped(t, y, _=None):
                     self.njev += 1
-                    return csc_matrix(jac(t, y), dtype=float)
+                    return csc_constructor(jac(t, y), dtype=float)
 
             else:
                 J = np.asarray(J, dtype=float)
@@ -387,7 +388,7 @@ class Radau(OdeSolver):
                                  f" but actually has {J.shape}.")
         else:
             if issparse(jac):
-                J = csc_matrix(jac)
+                J = jac.tocsc()
             else:
                 J = np.asarray(jac, dtype=float)
 

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.linalg import lu_factor, lu_solve
-from scipy.sparse import issparse, eye_array
+from scipy.sparse import issparse, eye_array, safely_cast_index_arrays
 from scipy.sparse.linalg import splu
 from scipy.optimize._numdiff import group_columns
 from .common import (validate_max_step, validate_tol, select_initial_step,

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -354,6 +354,9 @@ class Radau(OdeSolver):
             if sparsity is not None:
                 if issparse(sparsity):
                     sparsity = sparsity.tocsc()
+                    # this restricts self.n to fit in int32 for group_columns
+                    indices, indptr = safely_cast_index_arrays(sparsity)
+                    sparsity.indices, sparsity.indptr = indices, indptr
                 groups = group_columns(sparsity)
                 sparsity = (sparsity, groups)
 

--- a/scipy/integrate/_ivp/radau.py
+++ b/scipy/integrate/_ivp/radau.py
@@ -221,12 +221,10 @@ class Radau(OdeSolver):
         its element (i, j) is equal to ``d f_i / d y_j``.
         There are three ways to define the Jacobian:
 
-        * If array_like or sparse_array or sparse_matrix, the Jacobian is
-          assumed to be constant.
+        * If array_like or sparse, the Jacobian is assumed to be constant.
         * If callable, the Jacobian is assumed to depend on both
           t and y; it will be called as ``jac(t, y)`` as necessary.
-          For the 'Radau' and 'BDF' methods, the return value might be a
-          sparse array or matrix.
+          For the 'Radau' and 'BDF' methods, it can return dense or sparse.
         * If None (default), the Jacobian will be approximated by
           finite differences.
 

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -12,7 +12,7 @@ from scipy.integrate import solve_ivp, RK23, RK45, DOP853, Radau, BDF, LSODA
 from scipy.integrate import OdeSolution
 from scipy.integrate._ivp.common import num_jac, select_initial_step
 from scipy.integrate._ivp.base import ConstantDenseOutput
-from scipy.sparse import coo_matrix, csc_matrix
+from scipy.sparse import csc_array
 
 
 def fun_zero(t, y):
@@ -51,7 +51,7 @@ def jac_rational(t, y):
 
 
 def jac_rational_sparse(t, y):
-    return csc_matrix([
+    return csc_array([
         [0, 1 / t],
         [-2 * y[1] ** 2 / (t * (y[0] - 1) ** 2),
          (y[0] + 4 * y[1] - 1) / (t * (y[0] - 1))]
@@ -118,7 +118,7 @@ def medazko_sparsity(n):
     cols = np.hstack(cols)
     rows = np.hstack(rows)
 
-    return coo_matrix((np.ones_like(cols), (cols, rows)))
+    return csc_array((np.ones_like(cols), (cols, rows)))
 
 
 def fun_complex(t, y):
@@ -130,7 +130,7 @@ def jac_complex(t, y):
 
 
 def jac_complex_sparse(t, y):
-    return csc_matrix(jac_complex(t, y))
+    return csc_array(jac_complex(t, y))
 
 
 def sol_complex(t):
@@ -337,7 +337,7 @@ def test_integration_const_jac():
     y0 = [0, 2]
     t_span = [0, 2]
     J = jac_linear()
-    J_sparse = csc_matrix(J)
+    J_sparse = csc_array(J)
 
     for method, jac in product(['Radau', 'BDF'], [J, J_sparse]):
         res = solve_ivp(fun_linear, t_span, y0, rtol=rtol, atol=atol,

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -12,7 +12,7 @@ from scipy.integrate import solve_ivp, RK23, RK45, DOP853, Radau, BDF, LSODA
 from scipy.integrate import OdeSolution
 from scipy.integrate._ivp.common import num_jac, select_initial_step
 from scipy.integrate._ivp.base import ConstantDenseOutput
-from scipy.sparse import coo_array, csc_array, safely_cast_index_arrays
+from scipy.sparse import coo_array, csc_array
 
 
 def fun_zero(t, y):
@@ -310,7 +310,6 @@ def test_integration_sparse_difference():
     y0 = np.zeros(2 * n)
     y0[1::2] = 1
     sparsity = medazko_sparsity(n)
-    sparsity.indices, sparsity.indptr = safely_cast_index_arrays(sparsity, np.intc)
 
     for method in ['BDF', 'Radau']:
         res = solve_ivp(fun_medazko, t_span, y0, method=method,

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -294,7 +294,7 @@ def test_integration_complex_sparse():
     atol = 1e-6
     y0 = [0.5 + 1j]
     t_span = [0, 1]
-    sparsity = csc_matrix(np.ones((1, 1)))
+    sparsity = csc_array(np.ones((1, 1)))
     res = solve_ivp(fun_complex, t_span, y0, method='BDF',
                     rtol=rtol, atol=atol, jac_sparsity=sparsity)
     assert res.success
@@ -1039,7 +1039,7 @@ def test_num_jac_sparse():
         A[-1, -1] = 1
         A[-1, -2] = 1
 
-        return A
+        return csc_array(A)
 
     np.random.seed(0)
     n = 20
@@ -1067,6 +1067,13 @@ def test_num_jac_sparse():
     assert_allclose(J_num_dense, J_num_sparse.toarray(),
                     rtol=1e-12, atol=1e-14)
     assert_allclose(factor_dense, factor_sparse, rtol=1e-12, atol=1e-14)
+
+    # test DeprecationWarning due to move from sparse matrix to sparse array
+    # in num_jac when structure is an ndarray.
+    with pytest.deprecated_call(match="num_jac is switching to the sparse array"):
+        J_num_sparse, factor_sparse = num_jac(fun, 0, y.ravel(), f, 1e-8, None,
+                                              sparsity=(A.toarray(), groups))
+
 
 
 def test_args():

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -12,7 +12,7 @@ from scipy.integrate import solve_ivp, RK23, RK45, DOP853, Radau, BDF, LSODA
 from scipy.integrate import OdeSolution
 from scipy.integrate._ivp.common import num_jac, select_initial_step
 from scipy.integrate._ivp.base import ConstantDenseOutput
-from scipy.sparse import csc_array, csc_matrix
+from scipy.sparse import csc_array, coo_array, csc_matrix
 
 
 def fun_zero(t, y):
@@ -118,7 +118,7 @@ def medazko_sparsity(n):
     cols = np.hstack(cols)
     rows = np.hstack(rows)
 
-    return csc_array((np.ones_like(cols), (cols, rows)))
+    return coo_array((np.ones_like(cols), (cols, rows)))
 
 
 def fun_complex(t, y):

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -12,7 +12,7 @@ from scipy.integrate import solve_ivp, RK23, RK45, DOP853, Radau, BDF, LSODA
 from scipy.integrate import OdeSolution
 from scipy.integrate._ivp.common import num_jac, select_initial_step
 from scipy.integrate._ivp.base import ConstantDenseOutput
-from scipy.sparse import coo_array, csc_array
+from scipy.sparse import csc_array, csc_matrix
 
 
 def fun_zero(t, y):
@@ -118,7 +118,7 @@ def medazko_sparsity(n):
     cols = np.hstack(cols)
     rows = np.hstack(rows)
 
-    return coo_array((np.ones_like(cols), (cols, rows)))
+    return csc_array((np.ones_like(cols), (cols, rows)))
 
 
 def fun_complex(t, y):
@@ -1024,7 +1024,8 @@ def test_num_jac():
     assert_allclose(J_num, J_true, rtol=1e-5, atol=1e-5)
 
 
-def test_num_jac_sparse():
+@pytest.mark.parametrize("structure_type", [csc_array, csc_matrix, np.array])
+def test_num_jac_sparse(structure_type):
     def fun(t, y):
         e = y[1:]**3 - y[:-1]**2
         z = np.zeros(y.shape[1])
@@ -1039,7 +1040,7 @@ def test_num_jac_sparse():
         A[-1, -1] = 1
         A[-1, -2] = 1
 
-        return csc_array(A)
+        return structure_type(A)
 
     np.random.seed(0)
     n = 20
@@ -1067,13 +1068,6 @@ def test_num_jac_sparse():
     assert_allclose(J_num_dense, J_num_sparse.toarray(),
                     rtol=1e-12, atol=1e-14)
     assert_allclose(factor_dense, factor_sparse, rtol=1e-12, atol=1e-14)
-
-    # test DeprecationWarning due to move from sparse matrix to sparse array
-    # in num_jac when structure is an ndarray.
-    with pytest.deprecated_call(match="num_jac is switching to the sparse array"):
-        J_num_sparse, factor_sparse = num_jac(fun, 0, y.ravel(), f, 1e-8, None,
-                                              sparsity=(A.toarray(), groups))
-
 
 
 def test_args():

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -12,7 +12,7 @@ from scipy.integrate import solve_ivp, RK23, RK45, DOP853, Radau, BDF, LSODA
 from scipy.integrate import OdeSolution
 from scipy.integrate._ivp.common import num_jac, select_initial_step
 from scipy.integrate._ivp.base import ConstantDenseOutput
-from scipy.sparse import csc_array
+from scipy.sparse import coo_array, csc_array, safely_cast_index_arrays
 
 
 def fun_zero(t, y):
@@ -118,7 +118,7 @@ def medazko_sparsity(n):
     cols = np.hstack(cols)
     rows = np.hstack(rows)
 
-    return csc_array((np.ones_like(cols), (cols, rows)))
+    return coo_array((np.ones_like(cols), (cols, rows)))
 
 
 def fun_complex(t, y):
@@ -310,6 +310,7 @@ def test_integration_sparse_difference():
     y0 = np.zeros(2 * n)
     y0[1::2] = 1
     sparsity = medazko_sparsity(n)
+    sparsity.indices, sparsity.indptr = safely_cast_index_arrays(sparsity, np.intc)
 
     for method in ['BDF', 'Radau']:
         res = solve_ivp(fun_medazko, t_span, y0, method=method,

--- a/scipy/integrate/tests/test_bvp.py
+++ b/scipy/integrate/tests/test_bvp.py
@@ -6,7 +6,7 @@ from numpy.testing import (assert_, assert_array_equal, assert_allclose,
                            assert_equal)
 from pytest import raises as assert_raises
 
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_array
 from scipy.special import erf
 from scipy.integrate._bvp import (modify_mesh, estimate_fun_jac,
                                   estimate_bc_jac, compute_jac_indices,
@@ -345,7 +345,7 @@ def test_compute_jac_indices():
     m = 4
     k = 2
     i, j = compute_jac_indices(n, m, k)
-    s = coo_matrix((np.ones_like(i), (i, j))).toarray()
+    s = coo_array((np.ones_like(i), (i, j))).toarray()
     s_true = np.array([
         [1, 1, 1, 1, 0, 0, 0, 0, 1, 1],
         [1, 1, 1, 1, 0, 0, 0, 0, 1, 1],

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -5,7 +5,6 @@ from numpy.linalg import norm
 
 from scipy.sparse.linalg import LinearOperator
 from ..sparse import issparse, spmatrix, find, csc_array, csr_array, csr_matrix
-from ..sparse import safely_cast_index_arrays
 from ._group_columns import group_dense, group_sparse
 from scipy._lib._array_api import array_namespace, xp_result_type
 from scipy._lib._util import MapWrapper
@@ -277,11 +276,6 @@ def group_columns(A, order=0):
     A = A[:, order]
 
     if issparse(A):
-        # TODO: Remove the index array cast to int32 if the Cython version is removed
-        # The index arrays only need to be int32 for the Cython version.
-        import scipy as sp
-        if not hasattr(sp.optimize._group_columns, "__pythran__"):
-            A.indices, A.indptr = safely_cast_index_arrays(A, np.int32)
         groups = group_sparse(m, n, A.indices, A.indptr)
     else:
         groups = group_dense(m, n, A)

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -277,6 +277,8 @@ def group_columns(A, order=0):
     A = A[:, order]
 
     if issparse(A):
+        # TODO: Remove the index array cast to int32 if the Cython version is removed
+        # The index arrays only need to be int32 for the Cython version.
         import scipy as sp
         if not hasattr(sp.optimize._group_columns, "__pythran__"):
             A.indices, A.indptr = safely_cast_index_arrays(A, np.int32)

--- a/scipy/optimize/_numdiff.py
+++ b/scipy/optimize/_numdiff.py
@@ -5,6 +5,7 @@ from numpy.linalg import norm
 
 from scipy.sparse.linalg import LinearOperator
 from ..sparse import issparse, spmatrix, find, csc_array, csr_array, csr_matrix
+from ..sparse import safely_cast_index_arrays
 from ._group_columns import group_dense, group_sparse
 from scipy._lib._array_api import array_namespace, xp_result_type
 from scipy._lib._util import MapWrapper
@@ -276,6 +277,9 @@ def group_columns(A, order=0):
     A = A[:, order]
 
     if issparse(A):
+        import scipy as sp
+        if not hasattr(sp.optimize._group_columns, "__pythran__"):
+            A.indices, A.indptr = safely_cast_index_arrays(A, np.int32)
         groups = group_sparse(m, n, A.indices, A.indptr)
     else:
         groups = group_dense(m, n, A)


### PR DESCRIPTION
[Edited to reflect change of focus toward returning same sparse type as input 4/3/26]

The sparse parts of integrate are focused on the jacobian matrices. These are computed internally. The two main functions are `num_jac` (in the `_ivp` suite) and `construct_global_jac` (in the `_bvp.py` module). They both appear to be private helper functions based on not being exposed beyond the private namespaces, not appearing in the docs, and their use pattern (within other helper functions). They currently return sparse matrix. This PR shifts `num_jac` to return the same sparse type as is input). For `construct_global_jac` this PR changes the output to csc_array and updates the docs for `solve_newton` (the only helper function to use it) to be clear that the output should be ready to input to `sparse.linalg.splu`. 

Most of this PR consists of changes to the docs and switching calls from `coo_matrix` to `coo_array`. Even better -- in many places we don't need either. We can just use the method `.tocsc()` which is the same for both classes.

This PR updates tests for `num_jac` to parametrize over the input type of `sparsity` (current tests used a dense numpy array even though docs said the input must be sparse. This PR now tests dense, sparray and spmatrix).