### PR TITLE
TST: special.erf: mark `test_erf_complex` as slow

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -246,6 +246,7 @@ def test_hyp2f1_real_random():
 # erf (complex)
 # ------------------------------------------------------------------------------
 
+@pytest.mark.slow()
 @check_version(mpmath, '0.14')
 def test_erf_complex():
     # need to increase mpmath precision for this test


### PR DESCRIPTION
#### Reference issue
gh-24659, gh-24658, gh-24657, etc.

#### What does this implement/fix?
The `aarch64` workflow of all recent PRs is failing with:
```
FAILED scipy/special/tests/test_mpmath.py::test_erf_complex - Test passed but took too long to run: Duration 1.060846545000004s > 1.0s
```
This test is reasonably slow (>0.5s locally), so this PR marks it as slow to give it more time before `fail_slow` complains. (Looking out for slow tests is what pytest_fail_slow is for, after all.)

#### Additional information
@steppi anything that would have caused a change recently?

https://github.com/scipy/scipy/actions/runs/22293603417 is the last run that passed; https://github.com/scipy/scipy/actions/runs/22294310877 is the first to fail.

#### AI Generation Disclosure
No AI