### PR TITLE
BUG: spatial.distance.jensenshannon: improve numerical stability

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -1277,6 +1277,12 @@ def jensenshannon(p, q, base=None, *, axis=0, keepdims=False):
     """
     p = np.asarray(p)
     q = np.asarray(q)
+   
+    # compute in float64-ish for stability
+    work_dtype = np.result_type(p.dtype, q.dtype, np.float64)
+    p = p.astype(work_dtype, copy=False)
+    q = q.astype(work_dtype, copy=False)
+
     p = p / np.sum(p, axis=axis, keepdims=True)
     q = q / np.sum(q, axis=axis, keepdims=True)
     m = (p + q) / 2.0
@@ -1286,7 +1292,8 @@ def jensenshannon(p, q, base=None, *, axis=0, keepdims=False):
     right_sum = np.sum(right, axis=axis, keepdims=keepdims)
     js = left_sum + right_sum
     if base is not None:
-        js /= np.log(base)
+        js /= np.log(work_dtype.type(base))
+    js = np.clip(js, 0.0, None) # Jensen-Shannon divergence is >= 0; clamp tiny negative due to rounding.
     return np.sqrt(js / 2.0)
 
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2106,6 +2106,27 @@ def test_jensenshannon():
                         [0.1954288, 0.1447697, 0.1138377, 0.0927636])
     assert_almost_equal(jensenshannon(a, b, axis=1),
                         [0.1402339, 0.0399106, 0.0201815])
+    
+    # Regression test: proportional vectors normalize to identical distributions.
+    # Jensen-Shannon distance must be finite (not NaN) and ~0.
+    for dtype, atol in [(np.float64, 1e-12), (np.float32, 1e-6)]:
+        p = np.full(10, 0.34, dtype=dtype)
+        q = np.full(10, 0.42, dtype=dtype)
+        d = jensenshannon(p, q)
+        assert np.isfinite(d)
+        assert_allclose(d, 0.0, atol=atol, rtol=0)
+
+        p = np.full(3, 0.1, dtype=dtype)
+        q = np.full(3, 0.32, dtype=dtype)
+        d = jensenshannon(p, q)
+        assert np.isfinite(d)
+        assert_allclose(d, 0.0, atol=atol, rtol=0)
+
+        p = np.full(21, 0.29, dtype=dtype)
+        q = np.full(21, 0.09, dtype=dtype)
+        d = jensenshannon(p, q)
+        assert np.isfinite(d)
+        assert_allclose(d, 0.0, atol=atol, rtol=0)
 
 
 def test_gh_17703():

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2107,27 +2107,28 @@ def test_jensenshannon():
     assert_almost_equal(jensenshannon(a, b, axis=1),
                         [0.1402339, 0.0399106, 0.0201815])
     
-    # Regression test: proportional vectors normalize to identical distributions.
-    # Jensen-Shannon distance must be finite (not NaN) and ~0.
-    for dtype, atol in [(np.float64, 1e-12), (np.float32, 1e-6)]:
-        p = np.full(10, 0.34, dtype=dtype)
-        q = np.full(10, 0.42, dtype=dtype)
-        d = jensenshannon(p, q)
-        assert np.isfinite(d)
-        assert_allclose(d, 0.0, atol=atol, rtol=0)
+def test_gh_20083():
+    # This is the ticket case in the original issue report gh-20083
+    c1 = np.array([0.027501475, 0.055202297], dtype=np.float32)
+    c2 = np.array([0.027537677, 0.055334348], dtype=np.float32)
+    d = jensenshannon(c1, c2)
+    assert_(np.isfinite(d))
 
-        p = np.full(3, 0.1, dtype=dtype)
-        q = np.full(3, 0.32, dtype=dtype)
-        d = jensenshannon(p, q)
-        assert np.isfinite(d)
-        assert_allclose(d, 0.0, atol=atol, rtol=0)
-
-        p = np.full(21, 0.29, dtype=dtype)
-        q = np.full(21, 0.09, dtype=dtype)
-        d = jensenshannon(p, q)
-        assert np.isfinite(d)
-        assert_allclose(d, 0.0, atol=atol, rtol=0)
-
+@pytest.mark.parametrize(
+    "dtype, atol",
+    [(np.float64, 1e-12), (np.float32, 1e-6)],
+)
+@pytest.mark.parametrize(
+    "n, a, b",
+    [(10, 0.34, 0.42), (3, 0.10, 0.32), (21, 0.29, 0.09)],
+)
+def test_gh_20083_proportional_vectors(dtype, atol, n, a, b):
+    # This is the enhanced test case for proportional vectors with different precisions
+    p = np.full(n, a, dtype=dtype)
+    q = np.full(n, b, dtype=dtype)
+    d = jensenshannon(p, q)
+    assert_(np.isfinite(d))
+    assert_allclose(d, 0.0, atol=atol, rtol=0)
 
 def test_gh_17703():
     arr_1 = np.array([1, 0, 0])


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes gh-20083.
See also gh-19436, gh-20414, gh-20786, gh-19438.

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR improves the numerical stability of `scipy.spatial.distance.jensenshannon` for proportional input vectors (i.e., vectors that normalize to identical probability distributions).

For such inputs, floating point round-off may produce a tiny negative value for the Jensen–Shannon divergence. Since the divergence is mathematically non-negative, this can result in taking the square root of a negative number, leading to a `RuntimeWarning` and returning `NaN`.

Additionally, under float32 precision, proportional inputs may yield a small but non-negligible positive distance, which may not be sufficiently close to zero.  For example, three-dimensional proportional vectors can produce a value on the order of approximately 2e-4 instead of 0.

This PR addresses the issue by:
- Promoting the internal computation to float64 for improved numerical stability.
- Clamping tiny negative divergence values using `np.clip(js, 0.0, None)` before taking the square root.

In addition, regression tests are added to ensure that proportional vectors (which normalize to identical distributions) produce a finite result numerically close to zero for both float64 and float32 inputs. This prevents similar regressions in the future.

#### Additional information
<!--Any additional information you think is important.-->

The added regression tests cover two reproducible numerical cases:
- For 10-dimensional proportional vectors (e.g., constant vectors that normalize to identical distributions), the computed divergence may become slightly negative (on the order of 1e-16) due to floating-point round-off, which can lead to taking the square root of a negative number.
- For 3-dimensional proportional float32 vectors, the resulting distance may deviate from zero by approximately 2e-4, despite the distributions being identical after normalization.

These tests ensure that proportional inputs consistently return a finite result that is numerically close to zero.
All existing tests pass locally with this change.

#### AI Generation Disclosure

ChatGPT (OpenAI) was used for discussion and drafting portions of the PR description.
All code modifications were written and validated manually.


<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
