### PR TITLE
TST: stats.epps_singleton_2samp: bump axis_nan_policy test tolerance

### DIFF
--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -33,6 +33,9 @@ def _using_accelerate():
 RTOL = 1e-6 if _using_accelerate() else 1e-15
 
 
+tolerance_overrides = {stats.epps_singleton_2samp: 1e-10}
+
+
 def unpack_ttest_result(res):
     low, high = res.confidence_interval()
     return (res.statistic, res.pvalue, res.df, res._standard_error,
@@ -529,7 +532,8 @@ def _axis_nan_policy_test(hypotest, args, kwds, n_samples, n_outputs, paired,
     # Compare against the output against looping over 1D slices
     res_nd = unpacker(res)
 
-    assert_allclose(res_nd, res_1d, rtol=RTOL)
+    rtol = max(tolerance_overrides.get(hypotest, RTOL), RTOL)
+    assert_allclose(res_nd, res_1d, rtol=rtol)
 
 # nan should not raise an exception in np.mean()
 # but does on some mips64el systems, triggering failure in some test cases


### PR DESCRIPTION
#### Reference issue
Closes gh-24662
gh-23929

#### What does this implement/fix?
gh-24662 reported failures in `test_axis_nan_policy_full` with `SCIPY_XSLOW=True` due to minor disagreement between a single vectorized call to `epps_singleton_2samp` vs looping over the slices. This is common, and although the discrepancies are a bit larger than most other functions, they are still quite small, so this bumps the tolerances as needed.

#### Additional information
gh-23929 is probably the cause - when the argument of `cov` has more than two dimensions, `cov` resorts to a naive implementation.

#### AI Generation Disclosure
No AI