### PR TITLE
BUG: special.gegenbauer: fix endpoint behavior

### DIFF
--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -129,36 +129,30 @@ cdef inline double eval_sh_jacobi_l(Py_ssize_t n, double p, double q, double x) 
 #-----------------------------------------------------------------------------
 
 @cython.cdivision(True)
-cdef inline number_t eval_gegenbauer(double n, double alpha, number_t x) noexcept nogil:
-    cdef double a, b, c, d
-    cdef number_t g
-
-    d = xsf_gamma(n+2*alpha)/xsf_gamma(1+n)/xsf_gamma(2*alpha)
-    a = -n
-    b = n + 2*alpha
-    c = alpha + 0.5
-    g = (1-x)/2.0
-    return d * hyp2f1(a, b, c, g)
-
-@cython.cdivision(True)
 cdef inline double eval_gegenbauer_l(Py_ssize_t n, double alpha, double x) noexcept nogil:
     cdef Py_ssize_t kk
     cdef Py_ssize_t a, b
     cdef double p, d
     cdef double k
+    cdef int sign
 
     if isnan(alpha) or isnan(x):
         return NAN
 
+    if alpha == 0.0:
+        return 0.0
     if n < 0:
         return 0.0
-    elif n == 0:
+    if n == 0:
         return 1.0
-    elif n == 1:
+    if n == 1:
         return 2*alpha*x
-    elif alpha == 0.0:
-        return eval_gegenbauer(n, alpha, x)
-    elif fabs(x) < 1e-5:
+
+    # Symmetry property: C_n^alpha(-x) = (-1)^n C_n^alpha(x) for integer n
+    sign = -1 if (x < 0 and (n & 1)) else 1
+    x = fabs(x)
+    
+    if fabs(x) < 1e-5:
         # Power series rather than recurrence due to loss of precision
         # http://functions.wolfram.com/Polynomials/GegenbauerC3/02/
         a = n//2
@@ -178,7 +172,7 @@ cdef inline double eval_gegenbauer_l(Py_ssize_t n, double alpha, double x) noexc
             if fabs(d) < 1e-20*fabs(p):
                 # converged
                 break
-        return p
+        return sign * p
     else:
         d = x - 1
         p = x
@@ -189,9 +183,28 @@ cdef inline double eval_gegenbauer_l(Py_ssize_t n, double alpha, double x) noexc
 
         if fabs(alpha/n) < 1e-8:
             # avoid loss of precision
-            return 2*alpha/n * p
+            return sign * 2*alpha/n * p
         else:
-            return xsf_binom(n+2*alpha-1, n)*p
+            return sign * xsf_binom(n+2*alpha-1, n)*p
+
+@cython.cdivision(True)
+cdef inline number_t eval_gegenbauer(double n, double alpha, number_t x) noexcept nogil:
+    cdef long long ni
+
+    # If n is an integer, use more stable `eval_gegenbauer_l`
+    ni = <long long> n
+    if number_t is double and n == ni:
+        return <number_t> eval_gegenbauer_l(<Py_ssize_t> ni, alpha, <double> x)
+
+    cdef double a, b, c, d
+    cdef number_t g
+    
+    d = xsf_gamma(n+2*alpha)/xsf_gamma(1+n)/xsf_gamma(2*alpha)
+    a = -n
+    b = n + 2*alpha
+    c = alpha + 0.5
+    g = (1-x)/2.0
+    return d * hyp2f1(a, b, c, g)
 
 #-----------------------------------------------------------------------------
 # Chebyshev 1st kind (T)

--- a/scipy/special/orthogonal_eval.pxd
+++ b/scipy/special/orthogonal_eval.pxd
@@ -149,10 +149,10 @@ cdef inline double eval_gegenbauer_l(Py_ssize_t n, double alpha, double x) noexc
         return 2*alpha*x
 
     # Symmetry property: C_n^alpha(-x) = (-1)^n C_n^alpha(x) for integer n
-    sign = -1 if (x < 0 and (n & 1)) else 1
+    sign = -1 if (x < 0 and n % 2) else 1
     x = fabs(x)
     
-    if fabs(x) < 1e-5:
+    if x < 1e-5:
         # Power series rather than recurrence due to loss of precision
         # http://functions.wolfram.com/Polynomials/GegenbauerC3/02/
         a = n//2
@@ -193,7 +193,7 @@ cdef inline number_t eval_gegenbauer(double n, double alpha, number_t x) noexcep
 
     # If n is an integer, use more stable `eval_gegenbauer_l`
     ni = <long long> n
-    if number_t is double and n == ni:
+    if number_t is double and n == ni and n < 1e10:
         return <number_t> eval_gegenbauer_l(<Py_ssize_t> ni, alpha, <double> x)
 
     cdef double a, b, c, d

--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1376,7 +1376,7 @@ class TestSystematic:
             # Deal with n=0, n=1 correctly; mpmath 0.17 doesn't do these
             # always correctly
             if n == 0:
-                r = 1.0
+                r = 0.0 if a == 0.0 else 1.0
             elif n == 1:
                 r = 2*a*x
             else:

--- a/scipy/special/tests/test_orthogonal_eval.py
+++ b/scipy/special/tests/test_orthogonal_eval.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.testing import assert_, assert_allclose
 import pytest
 
-from scipy.special import _ufuncs
+from scipy.special import _ufuncs, gammasgn
 import scipy.special._orthogonal as orth
 from scipy.special._testutils import FuncData
 
@@ -273,6 +273,22 @@ def test_gegenbauer_nan(n, alpha, x):
     nan_gegenbauer = np.isnan(_ufuncs.eval_gegenbauer(n, alpha, x))
     nan_arg = np.any(np.isnan([n, alpha, x]))
     assert nan_gegenbauer == nan_arg
+
+@pytest.mark.parametrize("n", np.arange(10))
+@pytest.mark.parametrize("alpha", [-0.45, -0.25, -0.125, 0.0, 0.25, 1.0, 2.0])
+@pytest.mark.parametrize("x", [-np.inf, np.inf])
+def test_gegenbauer_infinity(n, alpha, x):
+    # gh-11713 - check correct handling of x = +inf and x = -inf
+    if alpha == 0.0:
+        expected = 0.0
+    elif n == 0.0:
+        expected = 1.0
+    else:
+        # sign of leading coefficient: 2^n * Gamma(n+alpha) / (n! Gamma(alpha))
+        lead_sign = gammasgn(n + alpha) * gammasgn(alpha)
+        expected = lead_sign * (np.sign(x) ** n) * np.inf
+    assert_allclose(_ufuncs.eval_gegenbauer(int(n), alpha, x), expected, rtol=1e-10)
+    assert_allclose(_ufuncs.eval_gegenbauer(float(n), alpha, x), expected, rtol=1e-10)
 
 @pytest.mark.parametrize(
     "n, expected",


### PR DESCRIPTION
#### Reference issue
Closes <https://github.com/scipy/scipy/issues/11713>

#### What does this implement/fix?

Correctly evaluates the [Gegenbauer](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.eval_gegenbauer.html) (ultraspherical) polynomials in the limit $x \to \pm\infty$, for all integer $n$ and real $\alpha > -1/2$.

The implementation relies on the fact that the leading term of $C_n^{(\alpha)}(x)$ is given by

$$
    C_n^{(\alpha)}(x) \sim \frac{2^{n} \Gamma(n+\alpha)}{\Gamma(\alpha) n!} x^n,
    \qquad (|x| \to \infty)
$$

The following special cases are handled explicitly: for all $x$ and integer $n$,

- $C_0^{(\alpha)}(x) = 1$ for all $\alpha \neq 0$
- $C_n^{(0)}(x) = 0$

I have tried to follow @mdhaber's [suggestion](https://github.com/scipy/scipy/issues/11713#issuecomment-2371650099), taking advantage of the function's symmetry.

#### AI Generation Disclosure

No AI was used.