### PR TITLE
DOC: Improve and fix typos some scipy.special functions

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -2307,7 +2307,7 @@ add_newdoc("eval_jacobi",
     .. math::
 
         P_n^{(\alpha, \beta)}(x) = \frac{(\alpha + 1)_n}{\Gamma(n + 1)}
-          {}_2F_1(-n, 1 + \alpha + \beta + n; \alpha + 1; (1 - z)/2)
+          {}_2F_1(-n, 1 + \alpha + \beta + n; \alpha + 1; (1 - x)/2)
 
     where :math:`(\cdot)_n` is the Pochhammer symbol; see `poch`. When
     :math:`n` is an integer the result is a polynomial of degree
@@ -2320,18 +2320,18 @@ add_newdoc("eval_jacobi",
         determined via the relation to the Gauss hypergeometric
         function.
     alpha : array_like
-        Parameter
+        Parameter.
     beta : array_like
-        Parameter
+        Parameter.
     x : array_like
-        Points at which to evaluate the polynomial
+        Points at which to evaluate the polynomial.
     out : ndarray, optional
-        Optional output array for the function values
+        Optional output array for the function values.
 
     Returns
     -------
     P : scalar or ndarray
-        Values of the Jacobi polynomial
+        Values of the Jacobi polynomial.
 
     See Also
     --------
@@ -2403,17 +2403,18 @@ add_newdoc("eval_gegenbauer",
     r"""
     eval_gegenbauer(n, alpha, x, out=None)
 
-    Evaluate Gegenbauer polynomial at a point.
+    Evaluate Gegenbauer (ultraspherical) polynomial at a point.
 
     The Gegenbauer polynomials can be defined via the Gauss
     hypergeometric function :math:`{}_2F_1` as
 
     .. math::
 
-        C_n^{(\alpha)} = \frac{(2\alpha)_n}{\Gamma(n + 1)}
-          {}_2F_1(-n, 2\alpha + n; \alpha + 1/2; (1 - z)/2).
+        C_n^{(\alpha)}(x) = \frac{(2\alpha)_n}{\Gamma(n + 1)}
+          {}_2F_1(-n, 2\alpha + n; \alpha + 1/2; (1 - x)/2).
 
-    When :math:`n` is an integer the result is a polynomial of degree
+    where :math:`(\cdot)_n` is the Pochhammer symbol; see `poch`. When
+    :math:`n` is an integer the result is a polynomial of degree
     :math:`n`. See 22.5.46 in [AS]_ (or equivalently [DLMF]_) for details.
 
     Parameters
@@ -2423,16 +2424,16 @@ add_newdoc("eval_gegenbauer",
         determined via the relation to the Gauss hypergeometric
         function.
     alpha : array_like
-        Parameter
+        Parameter.
     x : array_like
-        Points at which to evaluate the Gegenbauer polynomial
+        Points at which to evaluate the Gegenbauer polynomial.
     out : ndarray, optional
-        Optional output array for the function values
+        Optional output array for the function values.
 
     Returns
     -------
     C : scalar or ndarray
-        Values of the Gegenbauer polynomial
+        Values of the Gegenbauer polynomial.
 
     See Also
     --------

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -1568,12 +1568,12 @@ def roots_gegenbauer(n, alpha, mu=False):
 def gegenbauer(n, alpha, monic=False):
     r"""Gegenbauer (ultraspherical) polynomial.
 
-    Defined to be the solution of
+    Defined to be the solution of the second-order linear ordinary differential equation
 
     .. math::
-        (1 - x^2)\frac{d^2}{dx^2}C_n^{(\alpha)}
-          - (2\alpha + 1)x\frac{d}{dx}C_n^{(\alpha)}
-          + n(n + 2\alpha)C_n^{(\alpha)} = 0
+        (1 - x^2)\frac{d^2}{dx^2}C_n^{(\alpha)}(x)
+          - (2\alpha + 1)x\frac{d}{dx}C_n^{(\alpha)}(x)
+          + n(n + 2\alpha)C_n^{(\alpha)}(x) = 0
 
     for :math:`\alpha > -1/2`; :math:`C_n^{(\alpha)}` is a polynomial
     of degree :math:`n`.
@@ -1595,8 +1595,8 @@ def gegenbauer(n, alpha, monic=False):
 
     Notes
     -----
-    The polynomials :math:`C_n^{(\alpha)}` are orthogonal over
-    :math:`[-1,1]` with weight function :math:`(1 - x^2)^{(\alpha -
+    The polynomials :math:`C_n^{(\alpha)}` are orthogonal on
+    :math:`[-1,1]` with respect to the weight function :math:`(1 - x^2)^{(\alpha -
     1/2)}`.
 
     Examples


### PR DESCRIPTION
#### What does this implement/fix?
Improve and fix typos in the documentation of [Gegenbauer](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.gegenbauer.html#scipy.special.gegenbauer), [eval_gegenbauer](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.eval_gegenbauer.html), [eval_jacobi](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.eval_jacobi.html)

#### Additional information
Came across those problems while working on PR https://github.com/scipy/scipy/pull/24667

#### AI Generation Disclosure
No AI was used.