### PR TITLE
DEP: linalg: deprecate using linalg functions with LAPACK-incompatible dtypes

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1038,6 +1038,28 @@ def _dict_formatter(d, n=0, mplus=1, sorter=None):
     return s
 
 
+
+def _deprecate_dtypes(func_name, *arrays):
+    """
+    A temporary helper for deprecating non-LAPACK dtypes.
+    """
+    # XXX Once the deprecation expires, merge
+    # linalg/lapack.py::_normalize_lapack_dtype and _normalize_lapack_dtype1, and
+    # simplify _ensure_dtype_cdsz
+    for a in arrays:
+        if a is None:
+            continue
+        if a.dtype.char not in np.typecodes['AllInteger'] + 'fdFD':
+            msg = (f"Calling {func_name} with arguments of dtype={a.dtype} "
+                   f"({a.dtype.char = }) is deprecated in SciPy 1.18.0 and "
+                    "will be removed in SciPy 1.20.0. Please cast array inputs to "
+                    "one of np.float{32,64} or np.complex{64,128} manually."
+            )
+            import warnings
+            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+            return
+
+
 _batch_note = """
 The documentation is written assuming array arguments are of specified
 "core" shapes. However, array argument(s) of this function may have additional
@@ -1107,6 +1129,10 @@ def _apply_over_batch(*argdefs):
                 arrays[i] = array
                 batch_shapes.append(shape[:-ndim] if ndim > 0 else shape)
                 core_shapes.append(shape[-ndim:] if ndim > 0 else ())
+
+            # complain on dtypes
+            if is_numpy(xp):
+                _deprecate_dtypes(f.__name__, *arrays)
 
             # Early exit if call is not batched
             if not any(batch_shapes):

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1056,7 +1056,7 @@ def _deprecate_dtypes(func_name, *arrays):
                     "one of np.float{32,64} or np.complex{64,128} manually."
             )
             import warnings
-            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+            warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
             return
 
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -6,7 +6,7 @@
 
 import warnings
 import numpy as np
-from scipy._lib._util import _apply_over_batch
+from scipy._lib._util import _apply_over_batch, _deprecate_dtypes
 from .lapack import (
     get_lapack_funcs, _normalize_lapack_dtype, _normalize_lapack_dtype1,
     _ensure_aligned_and_native, _ensure_dtype_cdsz,
@@ -199,6 +199,8 @@ def solve(a, b, lower=False, overwrite_a=False,
 
     a1 = np.atleast_2d(_asarray_validated(a, check_finite=check_finite))
     b1 = np.atleast_1d(_asarray_validated(b, check_finite=check_finite))
+    _deprecate_dtypes("linalg.solve", a1, b1)
+
     a1, b1 = _ensure_dtype_cdsz(a1, b1)   # XXX; b upcasts a?
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
     a1, overwrite_a = _ensure_aligned_and_native(a1, overwrite_a)
@@ -922,6 +924,8 @@ def solve_circulant(c, b, singular='raise', tol=None,
     if nc != nb:
         raise ValueError(f'Shapes of c {c.shape} and b {b.shape} are incompatible')
 
+    _deprecate_dtypes('solve_circulant', c, b)
+
     # accommodate empty arrays
     if b.size == 0:
         dt = solve_circulant(np.arange(3, dtype=c.dtype),
@@ -1073,6 +1077,7 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
             [3.  , 0.25]]])
     """
     a1 = _asarray_validated(a, check_finite=check_finite)
+    _deprecate_dtypes("linalg.inv", a1)
 
     if a1.ndim < 2:
         raise ValueError(f"Expected at least ndim=2, got {a1.ndim=}")
@@ -1182,6 +1187,8 @@ def det(a, overwrite_a=False, check_finite=True):
 
     # First we check and make arrays.
     a1 = np.asarray_chkfinite(a) if check_finite else np.asarray(a)
+    _deprecate_dtypes("linalg.det", a1)
+
     if a1.ndim < 2:
         raise ValueError('The input array must be at least two-dimensional.')
     if a1.shape[-1] != a1.shape[-2]:
@@ -1376,6 +1383,8 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
 
     a1 = np.atleast_2d(_asarray_validated(a, check_finite=check_finite))
     b1 = np.atleast_1d(_asarray_validated(b, check_finite=check_finite))
+    _deprecate_dtypes("linalg.lstsq", a1, b1)
+
     a1, b1 = _ensure_dtype_cdsz(a1, b1)   # NB: makes a1.dtype == b1.dtype, if needed
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
 

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -20,7 +20,7 @@ import numpy as np
 from numpy import (array, isfinite, inexact, nonzero, iscomplexobj,
                    asarray, argsort, empty, iscomplex, zeros, einsum, eye, inf)
 # Local imports
-from scipy._lib._util import _asarray_validated, _apply_over_batch
+from scipy._lib._util import _asarray_validated, _apply_over_batch, _deprecate_dtypes
 from ._misc import LinAlgError, _datacopied
 from scipy.linalg._misc import norm   # noqa: F401  (backwards compat)
 from .lapack import (
@@ -209,6 +209,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     """
     # basic sanity checks of the input matrix
     a1 = _asarray_validated(a, check_finite=check_finite)
+    _deprecate_dtypes("eig", a1)
 
     if len(a1.shape) < 2 or a1.shape[-1] != a1.shape[-2]:
         raise ValueError(
@@ -251,6 +252,8 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         # b is not None: generalized eigenvalue problem
 
         b1 = _asarray_validated(b, check_finite=check_finite)
+        _deprecate_dtypes("eig", b1)
+
         a1, b1 = _ensure_dtype_cdsz(a1, b1)  # NB: makes a1.dtype == b1.dtype, if needed
         b1, overwrite_b = _ensure_aligned_and_native(b1, overwrite_b)
 
@@ -1629,6 +1632,7 @@ def cdf2rdf(w, v):
            [ 0.     , -3.23942,  2.59153]])
     """
     w, v = _asarray_validated(w), _asarray_validated(v)
+    _deprecate_dtypes("cdf2rdf", w, v)
 
     # check dimensions
     if w.ndim < 1:

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy import asarray_chkfinite, asarray, empty_like
 
 # Local imports
-from scipy._lib._util import _asarray_validated, _apply_over_batch
+from scipy._lib._util import _asarray_validated, _apply_over_batch, _deprecate_dtypes
 from ._misc import LinAlgError, _datacopied
 from .lapack import (
     get_lapack_funcs, _normalize_lapack_dtype, _ensure_aligned_and_native
@@ -32,6 +32,8 @@ def _cholesky(a, lower=False, overwrite_a=False, clean=True,
     a1 = np.atleast_2d(a1)
     if a1.shape[-1] != a1.shape[-2]:
         raise ValueError(f"Expected a square matrix or batch thereof, got {a1.shape=}")
+
+    _deprecate_dtypes("linalg.cholesky", a1)
 
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
     a1, overwrite_a = _ensure_aligned_and_native(a1, overwrite_a)

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -5,7 +5,7 @@ from warnings import warn
 from numpy import asarray, asarray_chkfinite
 import numpy as np
 
-from scipy._lib._util import _apply_over_batch
+from scipy._lib._util import _apply_over_batch, _deprecate_dtypes
 
 # Local imports
 from ._misc import _datacopied, LinAlgWarning
@@ -195,6 +195,8 @@ def _lu_solve(lu, piv, b, trans, overwrite_b, check_finite):
     else:
         b1 = asarray(b)
 
+    _deprecate_dtypes("lu_solve", lu, b)
+
     overwrite_b = overwrite_b or _datacopied(b1, b)
 
     if lu.shape[0] != b1.shape[0]:
@@ -309,6 +311,7 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True,
 
     """
     a1 = np.asarray_chkfinite(a) if check_finite else np.asarray(a)
+    _deprecate_dtypes("lu", a1)
     if a1.ndim < 2:
         raise ValueError('The input array must be at least two-dimensional.')
 

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -1,7 +1,7 @@
 """QR decomposition functions."""
 import numpy as np
 
-from scipy._lib._util import _apply_over_batch
+from scipy._lib._util import _apply_over_batch, _deprecate_dtypes
 from scipy._lib.deprecation import _NoValue
 
 import warnings
@@ -160,6 +160,8 @@ def qr(a, overwrite_a=False, lwork=_NoValue, mode="full", pivoting=False,
         a1 = np.asarray_chkfinite(a)
     else:
         a1 = np.asarray(a)
+
+    _deprecate_dtypes("linalg.qr", a1)
 
     if a1.ndim < 2:
         raise ValueError("Expected at least a 2-D array")

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -1,7 +1,7 @@
 """SVD decomposition functions."""
 import numpy as np
 
-from scipy._lib._util import _apply_over_batch
+from scipy._lib._util import _apply_over_batch, _deprecate_dtypes
 from . import _batched_linalg
 
 # Local imports.
@@ -149,6 +149,7 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
 
     # basic sanity checks of the input matrix
     a1 = _asarray_validated(a, check_finite=check_finite)
+    _deprecate_dtypes("svd", a1)
 
     if a1.ndim < 2:
         raise ValueError(f"Expected at least ndim=2, got {a1.ndim=}")

--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy import (dot, diag, prod, logical_not, ravel, transpose,
                    conjugate, absolute, amax, sign, isfinite, triu)
 
-from scipy._lib._util import _apply_over_batch
+from scipy._lib._util import _apply_over_batch, _deprecate_dtypes
 
 # Local imports
 from scipy.linalg import LinAlgError, LinAlgWarning
@@ -279,6 +279,8 @@ def expm(A):
 
     """
     a = np.asarray(A)
+    _deprecate_dtypes("expm", a)
+
     if a.size == 1 and a.ndim < 2:
         return np.array([[np.exp(a.item())]])
 
@@ -385,6 +387,7 @@ def sqrtm(A):
 
     """
     a = np.asarray(A)
+    _deprecate_dtypes('sqrtm', a)
     if a.size == 1 and a.ndim < 2:
         return np.array([[np.exp(a.item())]])
 

--- a/scipy/linalg/_misc.py
+++ b/scipy/linalg/_misc.py
@@ -3,6 +3,7 @@ from numpy.linalg import LinAlgError
 from .blas import get_blas_funcs
 from .lapack import get_lapack_funcs
 from ._batched_linalg import _bandwidth
+from scipy._lib._util import _deprecate_dtypes
 
 __all__ = ['LinAlgError', 'LinAlgWarning', 'norm', 'bandwidth']
 
@@ -147,6 +148,7 @@ def norm(a, ord=None, axis=None, keepdims=False, check_finite=True):
         a = np.asarray_chkfinite(a)
     else:
         a = np.asarray(a)
+    _deprecate_dtypes('norm', a)
 
     if a.size and a.dtype.char in 'fdFD' and axis is None and not keepdims:
 

--- a/scipy/linalg/tests/meson.build
+++ b/scipy/linalg/tests/meson.build
@@ -25,7 +25,8 @@ python_sources = [
   'test_sketches.py',
   'test_solve_toeplitz.py',
   'test_solvers.py',
-  'test_special_matrices.py'
+  'test_special_matrices.py',
+  'test_deprecations.py',
 ]
 
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1434,6 +1434,7 @@ class TestInv:
         assert (a == a0).all() != overwrite_a
         assert np.shares_memory(a, a_inv) == overwrite_a
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @pytest.mark.parametrize(
         "dtyp", [np.float16, np.float32, np.longdouble, np.clongdouble]
     )
@@ -1838,12 +1839,14 @@ class TestDet:
     # g and G dtypes are handled differently in windows and other platforms
     @pytest.mark.parametrize('typ', [x for x in np.typecodes['All'][:20]
                                      if x not in 'gG'])
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_sample_compatible_dtype_input(self, typ):
         rng = np.random.default_rng(1680305949878959)
         n = 4
         a = rng.random([n, n]).astype(typ)  # value is not important
         assert isinstance(det(a), (np.float64 | np.complex128))
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_incompatible_dtype_input(self):
         # Double backslashes needed for escaping pytest regex.
         msg = 'cannot be cast to float\\(32, 64\\)'
@@ -1915,6 +1918,7 @@ def direct_lstsq(a, b, cmplx=0):
     return solve(a1, b1)
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestLstsq:
     lapack_drivers = ('gelsd', 'gelss', 'gelsy', None)
 
@@ -2612,6 +2616,7 @@ def test_auto_rcond(scale, pinv_):
 
 class TestVectorNorms:
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_types(self):
         for dtype in np.typecodes['AllFloat']:
             x = np.array([1, 2, 3], dtype=dtype)
@@ -2859,6 +2864,7 @@ class TestSolveCirculant:
 
 
 class TestMatrix_Balance:
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     @skip_xp_invalid_arg
     def test_string_arg(self):
         assert_raises(ValueError, matrix_balance, 'Some string for fail')
@@ -2945,6 +2951,7 @@ class TestMatrix_Balance:
         assert perm.dtype == perm_n.dtype
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestDTypes:
     """Check backwards compatibility for dtypes vs scipy 1.16."""
 

--- a/scipy/linalg/tests/test_cythonized_array_utils.py
+++ b/scipy/linalg/tests/test_cythonized_array_utils.py
@@ -15,6 +15,7 @@ BANDWIDTH_DTYPES = (
 
 
 @skip_xp_invalid_arg
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_bandwidth_dtypes():
     n = 5
     for dt in BANDWIDTH_DTYPES:
@@ -89,6 +90,7 @@ def test_bandwidth_rect_inputs(T):
 
 
 @skip_xp_invalid_arg
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_issymetric_ishermitian_dtypes():
     n = 5
     for t in np.typecodes['All']:

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -35,7 +35,7 @@ from scipy.linalg.blas import HAS_ILP64
 from scipy.conftest import skip_xp_invalid_arg
 from scipy.__config__ import CONFIG
 
-from .test_basic import parametrize_overwrite_arg, parametrize_overwrite_b_arg
+from .test_basic import parametrize_overwrite_arg
 
 IS_WASM = (sys.platform == "emscripten" or platform.machine() in ["wasm32", "wasm64"])
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1051,6 +1051,7 @@ class TestEigh:
         w, z = eigh(a, b)
 
     @skip_xp_invalid_arg
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_eigh_of_sparse(self):
         # This tests the rejection of inputs that eigh cannot currently handle.
         import scipy.sparse

--- a/scipy/linalg/tests/test_decomp_lu.py
+++ b/scipy/linalg/tests/test_decomp_lu.py
@@ -126,6 +126,7 @@ class TestLU:
         assert_allclose(l, np.ones(shape=(4, 5, 1, 1), dtype=np.complex64))
         assert_allclose(u, a)
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_empty_edge_cases(self):
         a = np.empty([0, 0])
         p, l, u = lu(a)

--- a/scipy/linalg/tests/test_decomp_update.py
+++ b/scipy/linalg/tests/test_decomp_update.py
@@ -1,4 +1,5 @@
 import itertools
+import pytest
 
 import numpy as np
 from numpy.testing import assert_, assert_allclose, assert_equal
@@ -573,6 +574,7 @@ class BaseQRdelete(BaseQRdeltas):
         r = r[1:]
         assert_raises(ValueError, qr_delete, q, r, 0, 1)
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_unsupported_dtypes(self):
         dts = ['int8', 'int16', 'int32', 'int64',
                'uint8', 'uint16', 'uint32', 'uint64',
@@ -1118,6 +1120,7 @@ class BaseQRinsert(BaseQRdeltas):
         assert_raises(ValueError, qr_insert, q[:-2], r, u, 0, 'col')
         assert_raises(ValueError, qr_insert, q, r, u[1:], 0, 'col')
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_unsupported_dtypes(self):
         dts = ['int8', 'int16', 'int32', 'int64',
                'uint8', 'uint16', 'uint32', 'uint64',
@@ -1552,6 +1555,7 @@ class BaseQRupdate(BaseQRdeltas):
         assert_raises(ValueError, qr_update, q, r, u[1:], v)
         assert_raises(ValueError, qr_update, q, r, u, v[1:])
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_unsupported_dtypes(self):
         dts = ['int8', 'int16', 'int32', 'int64',
                'uint8', 'uint16', 'uint32', 'uint64',

--- a/scipy/linalg/tests/test_deprecations.py
+++ b/scipy/linalg/tests/test_deprecations.py
@@ -1,0 +1,173 @@
+"""Test dtype deprecations.
+"""
+import numpy as np
+import scipy.linalg as linalg
+import pytest
+
+
+#
+# When the deprecation expires
+#     1. Change the test from asserting a DeprecationWarning to assert_raises
+#     2. Remove the `_skip_dict` dictionary: it is only used to tell things which
+#        already raise errors from things which now emit DeprecationWarnings
+
+
+# skip these completely
+_skip_names = [
+    # not functions
+    'LinAlgError', 'LinAlgWarning',
+    # do not touch the low-level `scipy.linalg.{blas,lapack}`
+    'get_lapack_funcs', 'get_blas_funcs', 'find_best_blas_type',
+    # qr_update skip for now
+    'qr_update', 'qr_insert', 'qr_delete',
+    # special matrix constructors do not use LAPACK
+    'block_diag',
+    'toeplitz', 'circulant', 'hankel', 'hadamard', 'leslie', 'companion',
+    'helmert', 'hilbert', 'invhilbert', 'pascal', 'invpascal', 'dft',
+    'fiedler', 'fiedler_companion', 'convolution_matrix',
+    # _sketches does not use LAPACK
+    'clarkson_woodruff_transform',
+    # these did not accepted weird dtypes already
+    'expm', 'tanm', 'tanhm', 'sinm', 'cosm', 'sinhm', 'coshm', 'expm_cond',
+    'solve_continuous_are',
+    'rsf2csf',
+]
+
+
+# use this for dtype-specific skips
+# (e.g. if something only accepts real arrays, add complex typecodes here.)
+_skip_dict = {
+    # TypeError: Only real arrays currently supported
+    'eigh_tridiagonal': 'G',
+    'eigvalsh_tridiagonal': 'G',
+    # TypeError: No matching signature found
+    'issymmetric': 'eGmM',
+    'ishermitian': 'eGmM',
+    'bandwidth': 'egGmM',
+    # already raise
+    'det': 'gGmM',
+    'expm': 'gG',
+
+    # datetime specific + float16 specific
+    'cdf2rdf' : 'mM',
+    'expm_frechet' : 'mM' + 'e',
+    'pinv': 'mM',
+    'signm': 'mM',
+    'fractional_matrix_power' : 'mM' + 'e',
+    'khatri_rao' : 'mM',
+    'logm' : 'mM' + 'e',
+    'orthogonal_procrustes' : 'mM' + 'e',
+    'solve_circulant' : 'mM',
+    'solve_continuous_lyapunov': 'M',
+    'solve_discrete_lyapunov': 'mM' + 'e',
+    'solve_lyapunov' : 'M',
+    'solve_sylvester' : 'mM',
+    'solve_discrete_are': 'mM',
+    'matmul_toeplitz': 'mM',
+    'solve_toeplitz': 'mM',
+}
+
+
+# loop over all names
+_names = linalg.__all__
+_objs = {name: getattr(linalg, name)
+    for name in _names
+    if name not in _skip_names
+}
+_objs = {name: obj for name,obj in _objs.items() if callable(obj)}
+
+
+# Some gymnastics to prepare a set of arguments which all functions can accept
+_two_arg_names = set([
+    'cdf2rdf', 'rsf2csf', 'solve', 'solve_triangular', 'lstsq', 'khatri_rao',
+    'subspace_angles', 'qz', 'ordqz', 'orthogonal_procrustes', 'solve_circulant',
+    'solve_discrete_lyapunov', 'solve_continuous_lyapunov', 'solve_lyapunov',
+    'expm_frechet',
+    'matmul_toeplitz', 'solve_toeplitz', 'lu_solve',
+    'eigh_tridiagonal', 'eigvalsh_tridiagonal',
+    'solveh_banded', 'solve_banded', 'solveh_banded', 'qr_multiply',
+])
+
+_three_arg_names = set(["solve_sylvester"])
+
+_four_arg_names = set(["solve_continuous_are", "solve_discrete_are"])
+
+_arr_and_int_names = set([
+    'clarkson_woodruff_transform', 'convolution_matrix', 'fractional_matrix_power',
+])
+
+_arr_and_two_int_names = set(['diagsvd', 'cossin'])
+
+
+def _patch_args(func_name, args):
+    """Make sure func(*args) does not raise because *args is wrong."""
+    if func_name == 'cdf2rdf':
+        args = (args[0][0], args[1])  # cdf2rd(1d, 2d)
+    elif func_name == "funm":
+        args = (args[0], lambda x: x)
+    elif func_name == "lu_solve":
+        a = args[0]
+        piv = np.arange(a.shape[0])
+        args = ((a, piv), args[1])
+    elif func_name in ('eigh_tridiagonal', 'eigvalsh_tridiagonal'):       
+        d, e = args
+        args = (d, e[:, :-1])
+    elif func_name == 'cossin':
+        a = args[0]
+        args = (a, a.shape[0]//2, a.shape[1]//2)
+    elif func_name == "solve_banded":
+        from scipy.linalg._basic import _to_banded
+        args = ((1, 2), _to_banded(1, 2, args[0]), args[0])
+    elif func_name == "solveh_banded":
+        from scipy.linalg._basic import _to_banded
+        args = (_to_banded(0, 2, args[0])[:, :-1], args[0][0, :-1])
+    elif func_name == "cholesky_banded":
+        from scipy.linalg._basic import _to_banded
+        args = (_to_banded(0, 2, args[0])[:, :-1],)
+    elif func_name == "solve_toeplitz":
+        c = args[0][1]
+        args = (c, np.ones_like(c))
+    return args
+
+
+@pytest.mark.skip_xp_backends(np_only=True)
+@pytest.mark.filterwarnings(
+    "ignore:attempting to conjugate non-numeric dtype:DeprecationWarning"
+)
+@pytest.mark.filterwarnings("ignore:overflow encountered in dot:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in dot:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:logm result may be inaccurate:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:overflow encountered in multiply:RuntimeWarning")
+@pytest.mark.parametrize("func_name", _objs.keys())
+@pytest.mark.parametrize("tcode", 'e' + 'mMgG')
+def test_deprecations(func_name, tcode):
+    func = _objs[func_name]
+
+    if tcode in _skip_dict.get(func_name, ''):
+        return
+
+    a = np.arange(16).reshape(4, 4) + 8*np.eye(4)
+    a = a.T @ a
+    a = a.astype(tcode)
+
+    if func_name in _two_arg_names:
+        b = a.copy()
+        args = (a, b)
+    elif func_name in _three_arg_names:
+        args = (a, a, a)
+    elif func_name in _four_arg_names:
+        args = (a, a, a, a)
+    elif func_name in _arr_and_int_names:
+        args = (a, a.shape[0])
+    elif func_name in _arr_and_two_int_names:
+        args = (a, a.shape[0], a.shape[1])
+    elif func_name in ['cho_solve', 'cho_solve_banded']:
+        args = ((a, True), a)
+    else:
+        args = (a,)
+
+    args = _patch_args(func_name, args)
+
+    with pytest.warns(DeprecationWarning):
+        func(*args)
+

--- a/scipy/linalg/tests/test_deprecations.py
+++ b/scipy/linalg/tests/test_deprecations.py
@@ -1,9 +1,10 @@
-"""Test dtype deprecations.
-"""
+'''Test dtype deprecations.
+'''
 import numpy as np
 import scipy.linalg as linalg
 import pytest
 
+from scipy._lib._array_api_override import SCIPY_ARRAY_API
 
 #
 # When the deprecation expires
@@ -68,6 +69,55 @@ _skip_dict = {
 }
 
 
+# these raise if SCIPY_ARRAY_API env var is defined
+_array_api_skip_dict = {
+    'cho_factor' : 'mM',
+    'cho_solve' : 'mM',
+    'cho_solve_banded' : 'mM',
+    'cholesky' : 'mM',
+    'cholesky_banded' : 'mM',
+    'cossin' : 'mM',
+    'diagsvd' : 'mM',
+    'eig_banded' : 'mM',
+    'eigh' : 'mM',
+    'eigh_tridiagonal' : 'mM',
+    'eigvals_banded' : 'mM',
+    'eigvalsh' : 'mM',
+    'eigvalsh_tridiagonal' : 'mM',
+    'funm' : 'mM',
+    'hessenberg' : 'mM',
+    'ldl' : 'mM',
+    'lu_factor' : 'mM',
+    'lu_solve' : 'mM',
+    'matrix_balance' : 'mM',
+    'null_space' : 'mM',
+    'ordqz' : 'mM',
+    'orth' : 'mM',
+    'pinvh' : 'mM',
+    'polar' : 'mM',
+    'qr' : 'mM',
+    'qr_multiply' : 'mM',
+    'qz' : 'mM',
+    'rq' : 'mM',
+    'schur' : 'mM',
+    'solve_banded' : 'mM',
+    'solve_continuous_lyapunov' : 'mM',
+    'solve_lyapunov' : 'mM',
+    'solve_triangular' : 'mM',
+    'solveh_banded' : 'mM',
+    'subspace_angles' : 'mM',
+}
+
+
+if SCIPY_ARRAY_API:
+    #_skip_dict.update(**_array_api_skip_dict)
+    for key, val in _array_api_skip_dict.items():
+        if key in _skip_dict:
+            _skip_dict[key] += val
+        else:
+            _skip_dict[key] = val
+
+
 # loop over all names
 _names = linalg.__all__
 _objs = {name: getattr(linalg, name)
@@ -88,9 +138,9 @@ _two_arg_names = set([
     'solveh_banded', 'solve_banded', 'solveh_banded', 'qr_multiply',
 ])
 
-_three_arg_names = set(["solve_sylvester"])
+_three_arg_names = set(['solve_sylvester'])
 
-_four_arg_names = set(["solve_continuous_are", "solve_discrete_are"])
+_four_arg_names = set(['solve_continuous_are', 'solve_discrete_are'])
 
 _arr_and_int_names = set([
     'clarkson_woodruff_transform', 'convolution_matrix', 'fractional_matrix_power',
@@ -100,12 +150,12 @@ _arr_and_two_int_names = set(['diagsvd', 'cossin'])
 
 
 def _patch_args(func_name, args):
-    """Make sure func(*args) does not raise because *args is wrong."""
+    '''Make sure func(*args) does not raise because *args is wrong.'''
     if func_name == 'cdf2rdf':
         args = (args[0][0], args[1])  # cdf2rd(1d, 2d)
-    elif func_name == "funm":
+    elif func_name == 'funm':
         args = (args[0], lambda x: x)
-    elif func_name == "lu_solve":
+    elif func_name == 'lu_solve':
         a = args[0]
         piv = np.arange(a.shape[0])
         args = ((a, piv), args[1])
@@ -115,16 +165,16 @@ def _patch_args(func_name, args):
     elif func_name == 'cossin':
         a = args[0]
         args = (a, a.shape[0]//2, a.shape[1]//2)
-    elif func_name == "solve_banded":
+    elif func_name == 'solve_banded':
         from scipy.linalg._basic import _to_banded
         args = ((1, 2), _to_banded(1, 2, args[0]), args[0])
-    elif func_name == "solveh_banded":
+    elif func_name == 'solveh_banded':
         from scipy.linalg._basic import _to_banded
         args = (_to_banded(0, 2, args[0])[:, :-1], args[0][0, :-1])
-    elif func_name == "cholesky_banded":
+    elif func_name == 'cholesky_banded':
         from scipy.linalg._basic import _to_banded
         args = (_to_banded(0, 2, args[0])[:, :-1],)
-    elif func_name == "solve_toeplitz":
+    elif func_name == 'solve_toeplitz':
         c = args[0][1]
         args = (c, np.ones_like(c))
     return args
@@ -132,14 +182,14 @@ def _patch_args(func_name, args):
 
 @pytest.mark.skip_xp_backends(np_only=True)
 @pytest.mark.filterwarnings(
-    "ignore:attempting to conjugate non-numeric dtype:DeprecationWarning"
+    'ignore:attempting to conjugate non-numeric dtype:DeprecationWarning'
 )
-@pytest.mark.filterwarnings("ignore:overflow encountered in dot:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore:invalid value encountered in dot:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore:logm result may be inaccurate:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore:overflow encountered in multiply:RuntimeWarning")
-@pytest.mark.parametrize("func_name", _objs.keys())
-@pytest.mark.parametrize("tcode", 'e' + 'mMgG')
+@pytest.mark.filterwarnings('ignore:overflow encountered in dot:RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:invalid value encountered in dot:RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:logm result may be inaccurate:RuntimeWarning')
+@pytest.mark.filterwarnings('ignore:overflow encountered in multiply:RuntimeWarning')
+@pytest.mark.parametrize('func_name', _objs.keys())
+@pytest.mark.parametrize('tcode', 'e' + 'mMgG')
 def test_deprecations(func_name, tcode):
     func = _objs[func_name]
 

--- a/scipy/linalg/tests/test_deprecations.py
+++ b/scipy/linalg/tests/test_deprecations.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.linalg as linalg
 import pytest
 
-from scipy._lib._array_api_override import SCIPY_ARRAY_API
+from scipy._lib._array_api import SCIPY_ARRAY_API
 
 #
 # When the deprecation expires

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -491,6 +491,7 @@ class TestSqrtM:
         M = np.array([[2, 4], [0, -2]], dtype=np.int64)
         assert sqrtm(M).dtype == np.complex128
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_data_size_preservation_float_in_float_out(self):
         M = np.eye(10, dtype=np.float16)
         assert sqrtm(M).dtype == np.float32
@@ -502,6 +503,7 @@ class TestSqrtM:
             M = np.eye(10, dtype=np.float128)
             assert sqrtm(M).dtype == np.float64
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_data_size_preservation_float_in_comp_out(self):
         M = np.array([[2, 4], [0, -2]], dtype=np.float16)
         assert sqrtm(M).dtype == np.complex64
@@ -513,6 +515,7 @@ class TestSqrtM:
             M = np.array([[2, 4], [0, -2]], dtype=np.float128)
             assert sqrtm(M).dtype == np.complex128
 
+    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_data_size_preservation_comp_in_comp_out(self):
         M = np.array([[2j, 4], [0, -2j]], dtype=np.complex64)
         assert sqrtm(M).dtype == np.complex64

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -75,6 +75,7 @@ def test_ElasticRod(n):
 @pytest.mark.parametrize("n", [50])
 @pytest.mark.parametrize("m", [1, 2, 10])
 @pytest.mark.filterwarnings("ignore:Casting complex values to real")
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.filterwarnings("ignore:An ill-conditioned matrix")
 @pytest.mark.parametrize("Vdtype", INEXACTDTYPES)
 @pytest.mark.parametrize("Bdtype", ALLDTYPES)
@@ -443,6 +444,7 @@ def test_tolerance_float32():
     assert_allclose(eigvals, -np.arange(1, 1 + m), atol=2e-5, rtol=1e-5)
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize("vdtype", INEXACTDTYPES)
 @pytest.mark.parametrize("mdtype", ALLDTYPES)
 @pytest.mark.parametrize("arr_type", [np.array,

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -326,6 +326,7 @@ class TestExpmActionInterval:
             raise Exception(msg)
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize("dtype_a", DTYPES)
 @pytest.mark.parametrize("dtype_b", DTYPES)
 @pytest.mark.parametrize("b_is_matrix", [False, True])

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -379,6 +379,7 @@ def test_kde_integer_input():
 _ftypes = ['float32', 'float64', 'float96', 'float128', 'int32', 'int64']
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 @pytest.mark.parametrize("bw_type", _ftypes + ["scott", "silverman"])
 @pytest.mark.parametrize("dtype", _ftypes)
 def test_kde_output_dtype(dtype, bw_type):


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/24505

#### What does this implement/fix?
<!--Please explain your changes.-->

Limit the dtypes allowed in linear algebra functions:
- integers (upcast to float)
- single/double precision float/complex dtypes,

and deprecate using the rest. 
This implements a "strict" variant of what's discussed in gh-24505 and makes scipy.linalg match numpy.linalg (which rejects everything other than integers + `{float32, float64, complex64, complex128}`.


#### Additional information
<!--Any additional information you think is important.-->

From gh-24505, removing support for longdoubles seems uncontroversial. One discussion point is what to do about `float16`. Currently, it is upcast to float32:

```
In [5]: import numpy as np

In [6]: from scipy.linalg import solve

In [7]: solve(np.eye(2, dtype=np.float16), np.ones(2, dtype=np.float16))
Out[7]: array([1., 1.], dtype=float32)
``` 

One suggestion was to do internal computations in float32 and downcast the results back to float16. 
This PR takes a view of not doing any of this. 
My reasoning is that whatever we do for `float16` is going to set the precedent for other "ML dtypes", bfloat16 and other more exotic ones. While they are not a concern today yet, they are very likely to become one tomorrow (or in a year's time). This comment from a `numpy-dtype` developer, https://github.com/scipy/scipy/issues/24505#issuecomment-3860083158, indicates that properly casting these narrow dtypes might take more than a simple `.astype` call, and that that the tooling is not mature yet.
Therefore, I suggest we explicitly declare all of them unsupported, at least for the time being. Once the ecosystem converges on some way of handling them, we'll be able to revisit. 


#### AI Generation Disclosure

No AI
