### PR TITLE
TST: remove skip for bug fixed in CuPy 14.0.0

### DIFF
--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3452,7 +3452,6 @@ class TestHilbert2:
         xp_assert_equal(x1_a, x0_a)
 
     @pytest.mark.parametrize('shape', [(4, 5), (5, 4), (4, 4), (5, 5)])
-    @skip_xp_backends("cupy", reason="Bug in cupy implementation, see cupy#9396")
     def test_quadrant_values(self, shape, xp):
         """Compare desired and calculated values in Fourier space. """
         x_f = xp.ones(shape, dtype=xp.complex128)  # FFT of input signal

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3,6 +3,7 @@ import math
 import warnings
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
+import importlib
 from itertools import product
 from math import gcd
 
@@ -37,6 +38,11 @@ skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
 
 lazy_xp_modules = [signal]
+
+try:
+    CUPY_VERSION = importlib.metadata.version('cupy')
+except ImportError:
+    CUPY_VERSION = None
 
 
 @make_xp_test_case(convolve)
@@ -3442,8 +3448,12 @@ class TestHilbert2:
         x1_a = hilbert2(x, N=(4, 4))
         xp_assert_equal(x1_a, x0_a)
 
+    @xfail_xp_backends(
+        "cupy",
+        CUPY_VERSION and CUPY_VERSION < "14",
+        reason="Bug in cupy implementation fixed in 14.0.0, see cupy#9396"
+    )
     @pytest.mark.parametrize('shape', [(4, 5), (5, 4), (4, 4), (5, 5)])
-    @skip_xp_backends("cupy", reason="Bug in cupy implementation, see cupy#9396")
     def test_quadrant_values(self, shape, xp):
         """Compare desired and calculated values in Fourier space. """
         x_f = xp.ones(shape, dtype=xp.complex128)  # FFT of input signal


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #23672.

#### What does this implement/fix?
<!--Please explain your changes.-->
Un-skips the CuPy backend now that [this](https://github.com/cupy/cupy/pull/9396) CuPy PR is part of a release.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used