### PR TITLE
ENH: stats.kendalltau: add array API support (via conversion to NumPy)

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5522,7 +5522,7 @@ def pointbiserialr(x, y, *, axis=0):
 
 @xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=2)
 def kendalltau(x, y, *, nan_policy='propagate',
-               method='auto', variant='b', alternative='two-sided'):
+               method='auto', variant='b', alternative='two-sided', axis=None):
     r"""Calculate Kendall's tau, a correlation measure for ordinal data.
 
     Kendall's tau is a measure of the correspondence between two rankings.
@@ -5643,8 +5643,22 @@ def kendalltau(x, y, *, nan_policy='propagate',
     For a more detailed example, see :ref:`hypothesis_kendalltau`.
     """  # add documentation, then convert tests
     xp = array_namespace(x, y)
-    dtype = xp_result_type(x, y, force_floating=True, xp=xp)
-    x, y = _asarray(x, subok=True, xp=np), _asarray(y, subok=True, xp=np)
+    x, y = xp_promote(x, y, force_floating=True, xp=xp)
+    dtype = x.dtype
+    if is_marray(xp):
+        mask_x, mask_y = np.asarray(x.mask), np.asarray(y.mask)
+        x, y = np.asarray(x.data).copy(), np.asarray(y.data).copy()
+        unmasked_nans = np.any(np.isnan(x[~mask_x])) | np.any(np.isnan(y[~mask_y]))
+        if unmasked_nans:
+            if nan_policy == 'propagate':
+                message = "`nan_policy='propagate'` is incompatible with MArray input."
+            elif nan_policy == 'raise':
+                message = "The input contains nan values."
+            raise ValueError(message)
+        nan_policy = 'omit'
+        x[mask_x], y[mask_y] = np.nan, np.nan
+    else:
+        x, y = _asarray(x, subok=True, xp=np), _asarray(y, subok=True, xp=np)
     res = _kendalltau(x, y, nan_policy=nan_policy, method=method,
                       variant=variant, alternative=alternative)
     vals = res.statistic, res.pvalue, res.statistic

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5521,8 +5521,8 @@ def pointbiserialr(x, y, *, axis=0):
 
 
 @xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=2)
-def kendalltau(x, y, *, nan_policy='propagate',
-               method='auto', variant='b', alternative='two-sided', axis=None):
+def kendalltau(x, y, *, nan_policy='propagate', method='auto', variant='b',
+               alternative='two-sided', axis=None, keepdims=False):
     r"""Calculate Kendall's tau, a correlation measure for ordinal data.
 
     Kendall's tau is a measure of the correspondence between two rankings.
@@ -5575,6 +5575,10 @@ def kendalltau(x, y, *, nan_policy='propagate',
         The statistic of each axis-slice (e.g. row) of the input will appear in a
         corresponding element of the output.
         If ``None``, the input will be raveled before computing the statistic.
+    keepdims : bool, optional
+        If this is set to ``True``, the axes which are reduced are left
+        in the result as dimensions with length one. With this option,
+        the result will broadcast correctly against the input array.
 
     Returns
     -------
@@ -5659,8 +5663,8 @@ def kendalltau(x, y, *, nan_policy='propagate',
         x[mask_x], y[mask_y] = np.nan, np.nan
     else:
         x, y = _asarray(x, subok=True, xp=np), _asarray(y, subok=True, xp=np)
-    res = _kendalltau(x, y, nan_policy=nan_policy, method=method,
-                      variant=variant, alternative=alternative)
+    res = _kendalltau(x, y, nan_policy=nan_policy, method=method, variant=variant,
+                      alternative=alternative, axis=axis, keepdims=keepdims)
     vals = res.statistic, res.pvalue, res.statistic
     vals = (xp.asarray(val, dtype=dtype)[()] if val.ndim == 0
             else xp.asarray(val, dtype=dtype) for val in vals)
@@ -5670,8 +5674,7 @@ def kendalltau(x, y, *, nan_policy='propagate',
 @_axis_nan_policy_factory(_pack_CorrelationResult, default_axis=None, n_samples=2,
                           result_to_tuple=_unpack_CorrelationResult, paired=True,
                           too_small=1, n_outputs=3)
-def _kendalltau(x, y, *, nan_policy='propagate',
-               method='auto', variant='b', alternative='two-sided'):
+def _kendalltau(x, y, *, method='auto', variant='b', alternative='two-sided'):
     x = np.asarray(x).ravel()
     y = np.asarray(y).ravel()
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5645,7 +5645,7 @@ def kendalltau(x, y, *, nan_policy='propagate', method='auto', variant='b',
     0.2827454599327748
 
     For a more detailed example, see :ref:`hypothesis_kendalltau`.
-    """  # add documentation, then convert tests
+    """
     xp = array_namespace(x, y)
     x, y = xp_promote(x, y, force_floating=True, xp=xp)
     dtype = x.dtype

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5520,7 +5520,7 @@ def pointbiserialr(x, y, *, axis=0):
     return res
 
 
-@xp_capabilities(cpu_only=True, jax_jit=False)
+@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=2)
 def kendalltau(x, y, *, nan_policy='propagate',
                method='auto', variant='b', alternative='two-sided'):
     r"""Calculate Kendall's tau, a correlation measure for ordinal data.
@@ -5643,12 +5643,12 @@ def kendalltau(x, y, *, nan_policy='propagate',
     For a more detailed example, see :ref:`hypothesis_kendalltau`.
     """  # add documentation, then convert tests
     xp = array_namespace(x, y)
-    x, y = _asarray(x, subok=True), _asarray(y, subok=True)
+    x, y = _asarray(x, subok=True, xp=np), _asarray(y, subok=True, xp=np)
     res = _kendalltau(x, y, nan_policy=nan_policy, method=method,
                       variant=variant, alternative=alternative)
-    return _pack_CorrelationResult(xp.asarray(res.statistic[()]),
-                                   xp.asarray(res.pvalue[()]),
-                                   xp.asarray(res.statistic[()]))
+    vals = res.statistic, res.pvalue, res.statistic
+    vals = (xp.asarray(val)[()] if val.ndim == 0 else xp.asarray(val) for val in vals)
+    return _pack_CorrelationResult(*vals)
 
 
 @_axis_nan_policy_factory(_pack_CorrelationResult, default_axis=None, n_samples=2,
@@ -5712,8 +5712,8 @@ def _kendalltau(x, y, *, nan_policy='propagate',
         minclasses = min(len(set(x)), len(set(y)))
         tau = 2*con_minus_dis / (size**2 * (minclasses-1)/minclasses)
     else:
-        raise ValueError(f"Unknown variant of the method chosen: {variant}. "
-                         "variant must be 'b' or 'c'.")
+        raise ValueError(f"Unknown `variant` '{variant}' specified. "
+                         "`variant` must be 'b' or 'c'.")
 
     # Limit range to fix computational errors
     tau = np.minimum(1., max(-1., tau))
@@ -5721,7 +5721,7 @@ def _kendalltau(x, y, *, nan_policy='propagate',
     # The p-value calculation is the same for all variants since the p-value
     # depends only on con_minus_dis.
     if method == 'exact' and (xtie != 0 or ytie != 0):
-        raise ValueError("Ties found, exact method cannot be used.")
+        raise ValueError("Ties found; exact method cannot be used.")
 
     if method == 'auto':
         if (xtie == 0 and ytie == 0) and (size <= 33 or
@@ -5740,8 +5740,8 @@ def _kendalltau(x, y, *, nan_policy='propagate',
         z = con_minus_dis / np.sqrt(var)
         pvalue = _get_pvalue(z, _SimpleNormal(), alternative, xp=np)
     else:
-        raise ValueError(f"Unknown method {method} specified.  Use 'auto', "
-                         "'exact' or 'asymptotic'.")
+        raise ValueError(f"Unknown `method` '{method}' specified.  `method` must be"
+                         "'auto', 'exact' or 'asymptotic'.")
 
     # create result object with alias for backward compatibility
     res = SignificanceResult(tau[()], pvalue[()])

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5643,11 +5643,13 @@ def kendalltau(x, y, *, nan_policy='propagate',
     For a more detailed example, see :ref:`hypothesis_kendalltau`.
     """  # add documentation, then convert tests
     xp = array_namespace(x, y)
+    dtype = xp_result_type(x, y, force_floating=True, xp=xp)
     x, y = _asarray(x, subok=True, xp=np), _asarray(y, subok=True, xp=np)
     res = _kendalltau(x, y, nan_policy=nan_policy, method=method,
                       variant=variant, alternative=alternative)
     vals = res.statistic, res.pvalue, res.statistic
-    vals = (xp.asarray(val)[()] if val.ndim == 0 else xp.asarray(val) for val in vals)
+    vals = (xp.asarray(val, dtype=dtype)[()] if val.ndim == 0
+            else xp.asarray(val, dtype=dtype) for val in vals)
     return _pack_CorrelationResult(*vals)
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5520,10 +5520,7 @@ def pointbiserialr(x, y, *, axis=0):
     return res
 
 
-@xp_capabilities(np_only=True)
-@_axis_nan_policy_factory(_pack_CorrelationResult, default_axis=None, n_samples=2,
-                          result_to_tuple=_unpack_CorrelationResult, paired=True,
-                          too_small=1, n_outputs=3)
+@xp_capabilities(cpu_only=True, jax_jit=False)
 def kendalltau(x, y, *, nan_policy='propagate',
                method='auto', variant='b', alternative='two-sided'):
     r"""Calculate Kendall's tau, a correlation measure for ordinal data.
@@ -5573,6 +5570,11 @@ def kendalltau(x, y, *, nan_policy='propagate',
         * 'two-sided': the rank correlation is nonzero
         * 'less': the rank correlation is negative (less than zero)
         * 'greater': the rank correlation is positive (greater than zero)
+    axis : int or None, default: None
+        If an int, the axis of the input along which to compute the statistic.
+        The statistic of each axis-slice (e.g. row) of the input will appear in a
+        corresponding element of the output.
+        If ``None``, the input will be raveled before computing the statistic.
 
     Returns
     -------
@@ -5639,7 +5641,21 @@ def kendalltau(x, y, *, nan_policy='propagate',
     0.2827454599327748
 
     For a more detailed example, see :ref:`hypothesis_kendalltau`.
-    """
+    """  # add documentation, then convert tests
+    xp = array_namespace(x, y)
+    x, y = _asarray(x, subok=True), _asarray(y, subok=True)
+    res = _kendalltau(x, y, nan_policy=nan_policy, method=method,
+                      variant=variant, alternative=alternative)
+    return _pack_CorrelationResult(xp.asarray(res.statistic[()]),
+                                   xp.asarray(res.pvalue[()]),
+                                   xp.asarray(res.statistic[()]))
+
+
+@_axis_nan_policy_factory(_pack_CorrelationResult, default_axis=None, n_samples=2,
+                          result_to_tuple=_unpack_CorrelationResult, paired=True,
+                          too_small=1, n_outputs=3)
+def _kendalltau(x, y, *, nan_policy='propagate',
+               method='auto', variant='b', alternative='two-sided'):
     x = np.asarray(x).ravel()
     y = np.asarray(y).ravel()
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -95,6 +95,12 @@ def yeojohnson_llf(data, lmb, axis=0, _no_deco=False, **kwargs):
     return stats.yeojohnson_llf(lmb, data, axis=axis, **kwargs)
 
 
+def kendalltau(*args, _no_deco=False, **kwargs):
+    if _no_deco:
+        return stats._stats_py._kendalltau(*args, _no_deco=_no_deco, **kwargs)
+    return stats.kendalltau(*args, **kwargs)
+
+
 axis_nan_policy_cases = [
     # function, args, kwds, number of samples, number of outputs,
     # ... paired, unpacker function
@@ -187,7 +193,7 @@ axis_nan_policy_cases = [
      lambda res: (res.statistic, res.pvalue)),
     (stats.pointbiserialr, tuple(), dict(), 2, 3, True,
      lambda res: (res.statistic, res.pvalue, res.correlation)),
-    (stats.kendalltau, tuple(), dict(), 2, 3, True,
+    (kendalltau, tuple(), dict(), 2, 3, True,
      lambda res: (res.statistic, res.pvalue, res.correlation)),
     (stats.weightedtau, tuple(), dict(), 2, 3, True,
      lambda res: (res.statistic, res.pvalue, res.correlation)),

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -351,6 +351,27 @@ def test_two_sample_tests(fun, kwargs, axis, xp):
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
 
 
+@make_xp_test_case(stats.kendalltau)
+class TestKendallTau:
+    @pytest.mark.parametrize('axis', [0, 1, None])
+    def test_omit_masked_elements(self, axis, xp):
+        mxp, marrays, narrays = get_arrays(2, xp=xp, seed=84912165484322)
+        res = stats.kendalltau(*marrays, axis=axis)
+        ref = stats.kendalltau(*narrays, nan_policy='omit', axis=axis)
+        xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
+        xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
+
+    @pytest.mark.parametrize('nan_policy, message', [
+        ('propagate', "`nan_policy='propagate'` is incompatible with MArray input."),
+        ('raise', 'The input contains nan values.')
+    ])
+    def test_input_validation(self, nan_policy, message, xp):
+        mxp = marray._get_namespace(xp)
+        x = mxp.asarray([1, 2, 3, xp.nan])
+        with pytest.raises(ValueError, match=message):
+            stats.kendalltau(x, x, nan_policy=nan_policy)
+
+
 @skip_backend('dask.array', reason='Arrays need `device` attribute: dask/dask#11711')
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.parametrize('fun, kwargs', [

--- a/scipy/stats/tests/test_mstats_basic.py
+++ b/scipy/stats/tests/test_mstats_basic.py
@@ -390,6 +390,29 @@ class TestCorr:
         attributes = ('correlation', 'pvalue')
         check_named_results(result, attributes, ma=True)
 
+    def test_overflow_gh6061(self):
+        # Regression test for GitHub issue #6061 - Overflow on Windows
+        x = np.arange(2000, dtype=float)
+        x = np.ma.masked_greater(x, 1995)
+        y = np.arange(2000, dtype=float)
+        y = np.concatenate((y[1000:], y[:1000]))
+        assert_(np.isfinite(stats.mstats.kendalltau(x,y)[1]))
+
+    def test_kendalltau_vs_mstats_basic(self):
+        rng = np.random.RandomState(42)
+        for s in range(3, 10):
+            a = []
+            # Generate rankings with ties
+            for i in range(s):
+                a += [i]*i
+            b = list(a)
+            rng.shuffle(a)
+            rng.shuffle(b)
+            expected = mstats.kendalltau(a, b)
+            actual = stats.kendalltau(a, b)
+            assert_almost_equal(actual[0], expected[0])
+            assert_almost_equal(actual[1], expected[1])
+
     @pytest.mark.skipif(platform.machine() == 'ppc64le',
                         reason="fails/crashes on ppc64le")
     @pytest.mark.slow

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -26,7 +26,6 @@ from numpy import array, arange, power
 import numpy as np
 
 import scipy.stats as stats
-import scipy.stats._mstats_basic as mstats_basic
 from scipy.stats._ksstats import kolmogn
 from scipy.special._testutils import FuncData
 from scipy import optimize, special
@@ -1666,8 +1665,8 @@ class TestKendallTau:
         x1 = xp.asarray(x[1], dtype=dtype)
         expected = (0.19291382765531062, 1.1337095377742629e-10)
         res = stats.kendalltau(x0, x1)
-        xp_assert_close(res[0], xp.asarray(expected[0]))
-        xp_assert_close(res[1], xp.asarray(expected[1]))
+        xp_assert_close(res[0], xp.asarray(expected[0], dtype=dtype))
+        xp_assert_close(res[1], xp.asarray(expected[1], dtype=dtype))
 
     def test_nan_policy(self, xp):
         # test nan_policy
@@ -1735,7 +1734,7 @@ class TestKendallTau:
 
 @make_xp_test_case(stats.kendalltau)
 class TestKendallTauAlternative:
-    def test_kendalltau_alternative_asymptotic(self):
+    def test_kendalltau_alternative_asymptotic(self, xp):
         # Test alternative parameter, asymptotic method (due to tie)
 
         # Based on TestCorrSpearman2::test_alternative
@@ -1743,38 +1742,40 @@ class TestKendallTauAlternative:
         x2 = [5, 6, 7, 8, 7]
 
         # strong positive correlation
-        expected = stats.kendalltau(x1, x2, alternative="two-sided")
+        expected = stats.kendalltau(xp.asarray(x1), xp.asarray(x2),
+                                    alternative="two-sided")
         assert expected[0] > 0
 
         # rank correlation > 0 -> large "less" p-value
-        res = stats.kendalltau(x1, x2, alternative="less")
-        assert_equal(res[0], expected[0])
-        assert_allclose(res[1], 1 - (expected[1] / 2))
+        res = stats.kendalltau(xp.asarray(x1), xp.asarray(x2), alternative="less")
+        xp_assert_equal(res[0], xp.asarray(expected[0]))
+        xp_assert_close(res[1], xp.asarray(1 - (expected[1] / 2)))
 
         # rank correlation > 0 -> small "greater" p-value
-        res = stats.kendalltau(x1, x2, alternative="greater")
-        assert_equal(res[0], expected[0])
-        assert_allclose(res[1], expected[1] / 2)
+        res = stats.kendalltau(xp.asarray(x1), xp.asarray(x2), alternative="greater")
+        xp_assert_equal(res[0], xp.asarray(expected[0]))
+        xp_assert_close(res[1], xp.asarray(expected[1] / 2))
 
         # reverse the direction of rank correlation
         x2.reverse()
 
         # strong negative correlation
-        expected = stats.kendalltau(x1, x2, alternative="two-sided")
+        expected = stats.kendalltau(xp.asarray(x1), xp.asarray(x2),
+                                    alternative="two-sided")
         assert expected[0] < 0
 
         # rank correlation < 0 -> large "greater" p-value
-        res = stats.kendalltau(x1, x2, alternative="greater")
-        assert_equal(res[0], expected[0])
-        assert_allclose(res[1], 1 - (expected[1] / 2))
+        res = stats.kendalltau(xp.asarray(x1), xp.asarray(x2), alternative="greater")
+        xp_assert_equal(res[0], xp.asarray(expected[0]))
+        xp_assert_close(res[1], xp.asarray(1 - (expected[1] / 2)))
 
         # rank correlation < 0 -> small "less" p-value
-        res = stats.kendalltau(x1, x2, alternative="less")
-        assert_equal(res[0], expected[0])
-        assert_allclose(res[1], expected[1] / 2)
+        res = stats.kendalltau(xp.asarray(x1), xp.asarray(x2), alternative="less")
+        xp_assert_equal(res[0], xp.asarray(expected[0]))
+        xp_assert_close(res[1], xp.asarray(expected[1] / 2))
 
         with pytest.raises(ValueError, match="`alternative` must be 'less'..."):
-            stats.kendalltau(x1, x2, alternative="ekki-ekki")
+            stats.kendalltau(xp.asarray(x1), xp.asarray(x2), alternative="ekki-ekki")
 
     # There are a lot of special cases considered in the calculation of the
     # exact p-value, so we test each separately. We also need to test
@@ -1789,152 +1790,154 @@ class TestKendallTauAlternative:
 
     alternatives = ('less', 'two-sided', 'greater')
     p_n1 = [np.nan, np.nan, np.nan]
-    p_n2 = [1, 1, 0.5]
-    p_c0 = [1, 0.3333333333333, 0.1666666666667]
+    p_n2 = [1.0, 1.0, 0.5]
+    p_c0 = [1.0, 0.3333333333333, 0.1666666666667]
     p_c1 = [0.9583333333333, 0.3333333333333, 0.1666666666667]
-    p_no_correlation = [0.5916666666667, 1, 0.5916666666667]
-    p_no_correlationb = [0.5475694444444, 1, 0.5475694444444]
+    p_no_correlation = [0.5916666666667, 1.0, 0.5916666666667]
+    p_no_correlationb = [0.5475694444444, 1.0, 0.5475694444444]
     p_n_lt_171 = [0.9624118165785, 0.1194389329806, 0.0597194664903]
     p_n_lt_171b = [0.246236925303, 0.4924738506059, 0.755634083327]
     p_n_lt_171c = [0.9847475308925, 0.03071385306533, 0.01535692653267]
 
-    def exact_test(self, x, y, alternative, rev, stat_expected, p_expected):
+    def exact_test(self, x, y, alternative, rev, stat_expected, p_expected, xp):
+        x, y = xp.asarray(x), xp.asarray(y)
         if rev:
-            y = -np.asarray(y)
+            y = -y
             stat_expected *= -1
         res = stats.kendalltau(x, y, method='exact', alternative=alternative)
-        res_expected = stat_expected, p_expected
-        assert_allclose(res, res_expected)
+        xp_assert_close(res.statistic, xp.asarray(stat_expected))
+        xp_assert_close(res.pvalue, xp.asarray(p_expected))
 
     case_R_n1 = (list(zip(alternatives, p_n1, [False]*3))
                  + list(zip(alternatives, reversed(p_n1), [True]*3)))
 
     @pytest.mark.parametrize("alternative, p_expected, rev", case_R_n1)
-    def test_against_R_n1(self, alternative, p_expected, rev):
+    def test_against_R_n1(self, alternative, p_expected, rev, xp):
         x, y = [1], [2]
         stat_expected = np.nan
         with pytest.warns(SmallSampleWarning, match="One or more sample..."):
-            self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+            self.exact_test(x, y, alternative, rev, stat_expected, p_expected, xp=xp)
 
     case_R_n2 = (list(zip(alternatives, p_n2, [False]*3))
                  + list(zip(alternatives, reversed(p_n2), [True]*3)))
 
     @pytest.mark.parametrize("alternative, p_expected, rev", case_R_n2)
-    def test_against_R_n2(self, alternative, p_expected, rev):
+    def test_against_R_n2(self, alternative, p_expected, rev, xp):
         x, y = [1, 2], [3, 4]
         stat_expected = 0.9999999999999998
-        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected, xp=xp)
 
     case_R_c0 = (list(zip(alternatives, p_c0, [False]*3))
                  + list(zip(alternatives, reversed(p_c0), [True]*3)))
 
     @pytest.mark.parametrize("alternative, p_expected, rev", case_R_c0)
-    def test_against_R_c0(self, alternative, p_expected, rev):
+    def test_against_R_c0(self, alternative, p_expected, rev, xp):
         x, y = [1, 2, 3], [1, 2, 3]
-        stat_expected = 1
-        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+        stat_expected = 1.
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected, xp=xp)
 
     case_R_c1 = (list(zip(alternatives, p_c1, [False]*3))
                  + list(zip(alternatives, reversed(p_c1), [True]*3)))
 
     @pytest.mark.parametrize("alternative, p_expected, rev", case_R_c1)
-    def test_against_R_c1(self, alternative, p_expected, rev):
+    def test_against_R_c1(self, alternative, p_expected, rev, xp):
         x, y = [1, 2, 3, 4], [1, 2, 4, 3]
         stat_expected = 0.6666666666666667
-        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected, xp=xp)
 
     case_R_no_corr = (list(zip(alternatives, p_no_correlation, [False]*3))
                       + list(zip(alternatives, reversed(p_no_correlation),
                                  [True]*3)))
 
     @pytest.mark.parametrize("alternative, p_expected, rev", case_R_no_corr)
-    def test_against_R_no_correlation(self, alternative, p_expected, rev):
+    def test_against_R_no_correlation(self, alternative, p_expected, rev, xp):
         x, y = [1, 2, 3, 4, 5], [1, 5, 4, 2, 3]
-        stat_expected = 0
-        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+        stat_expected = 0.
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected, xp=xp)
 
     case_no_cor_b = (list(zip(alternatives, p_no_correlationb, [False]*3))
                      + list(zip(alternatives, reversed(p_no_correlationb),
                                 [True]*3)))
 
     @pytest.mark.parametrize("alternative, p_expected, rev", case_no_cor_b)
-    def test_against_R_no_correlationb(self, alternative, p_expected, rev):
+    def test_against_R_no_correlationb(self, alternative, p_expected, rev, xp):
         x, y = [1, 2, 3, 4, 5, 6, 7, 8], [8, 6, 1, 3, 2, 5, 4, 7]
-        stat_expected = 0
-        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+        stat_expected = 0.
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected, xp=xp)
 
     case_R_lt_171 = (list(zip(alternatives, p_n_lt_171, [False]*3))
                      + list(zip(alternatives, reversed(p_n_lt_171), [True]*3)))
 
     @pytest.mark.parametrize("alternative, p_expected, rev", case_R_lt_171)
-    def test_against_R_lt_171(self, alternative, p_expected, rev):
+    def test_against_R_lt_171(self, alternative, p_expected, rev, xp):
         # Data from Hollander & Wolfe (1973), p. 187f.
         # Used from https://rdrr.io/r/stats/cor.test.html
         x = [44.4, 45.9, 41.9, 53.3, 44.7, 44.1, 50.7, 45.2, 60.1]
         y = [2.6, 3.1, 2.5, 5.0, 3.6, 4.0, 5.2, 2.8, 3.8]
         stat_expected = 0.4444444444444445
-        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected, xp=xp)
 
     case_R_lt_171b = (list(zip(alternatives, p_n_lt_171b, [False]*3))
                       + list(zip(alternatives, reversed(p_n_lt_171b),
                                  [True]*3)))
 
     @pytest.mark.parametrize("alternative, p_expected, rev", case_R_lt_171b)
-    def test_against_R_lt_171b(self, alternative, p_expected, rev):
+    def test_against_R_lt_171b(self, alternative, p_expected, rev, xp):
         rng = np.random.RandomState(0)
-        x = rng.rand(100)
-        y = rng.rand(100)
+        x = rng.rand(100).tolist()
+        y = rng.rand(100).tolist()
         stat_expected = -0.04686868686868687
-        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected, xp=xp)
 
     case_R_lt_171c = (list(zip(alternatives, p_n_lt_171c, [False]*3))
                       + list(zip(alternatives, reversed(p_n_lt_171c),
                                  [True]*3)))
 
     @pytest.mark.parametrize("alternative, p_expected, rev", case_R_lt_171c)
-    def test_against_R_lt_171c(self, alternative, p_expected, rev):
+    def test_against_R_lt_171c(self, alternative, p_expected, rev, xp):
         rng = np.random.RandomState(0)
-        x = rng.rand(170)
-        y = rng.rand(170)
+        x = rng.rand(170).tolist()
+        y = rng.rand(170).tolist()
         stat_expected = 0.1115906717716673
-        self.exact_test(x, y, alternative, rev, stat_expected, p_expected)
+        self.exact_test(x, y, alternative, rev, stat_expected, p_expected, xp=xp)
 
     case_gt_171 = (list(zip(alternatives, [False]*3)) +
                    list(zip(alternatives, [True]*3)))
 
     @pytest.mark.parametrize("alternative, rev", case_gt_171)
-    def test_gt_171(self, alternative, rev):
+    def test_gt_171(self, alternative, rev, xp):
         rng = np.random.RandomState(0)
-        x = rng.rand(400)
-        y = rng.rand(400)
-        res0 = stats.kendalltau(x, y, method='exact',
-                                alternative=alternative)
-        res1 = stats.kendalltau(x, y, method='asymptotic',
-                                alternative=alternative)
-        assert_equal(res0[0], res1[0])
-        assert_allclose(res0[1], res1[1], rtol=1e-3)
+        x = xp.asarray(rng.rand(400).tolist())
+        y = xp.asarray(rng.rand(400).tolist())
+        res0 = stats.kendalltau(x, y, method='exact', alternative=alternative)
+        res1 = stats.kendalltau(x, y, method='asymptotic', alternative=alternative)
+        xp_assert_equal(res0[0], res1[0])
+        xp_assert_close(res0[1], res1[1], rtol=1e-3)
 
     @pytest.mark.parametrize("method", ('exact', 'asymptotic'))
     @pytest.mark.parametrize("alternative", ('two-sided', 'less', 'greater'))
-    def test_nan_policy(self, method, alternative):
+    def test_nan_policy(self, method, alternative, xp):
         # Test nan policies
         x1 = [1, 2, 3, 4, 5]
         x2 = [5, 6, 7, 8, 9]
         x1nan = x1 + [np.nan]
         x2nan = x2 + [np.nan]
+        x1, x2 = xp.asarray(x1), xp.asarray(x2)
+        x1nan, x2nan = xp.asarray(x1nan), xp.asarray(x2nan)
 
         # test nan_policy="propagate"
         res_actual = stats.kendalltau(x1nan, x2nan,
                                       method=method, alternative=alternative)
-        res_expected = (np.nan, np.nan)
-        assert_allclose(res_actual, res_expected)
+        xp_assert_equal(res_actual.statistic, xp.asarray(xp.nan))
+        xp_assert_equal(res_actual.pvalue, xp.asarray(xp.nan))
 
         # test nan_policy="omit"
         res_actual = stats.kendalltau(x1nan, x2nan, nan_policy='omit',
                                       method=method, alternative=alternative)
         res_expected = stats.kendalltau(x1, x2, method=method,
                                         alternative=alternative)
-        assert_allclose(res_actual, res_expected)
+        xp_assert_equal(res_actual.statistic, res_expected.statistic)
+        xp_assert_equal(res_actual.pvalue, res_expected.pvalue)
 
         # test nan_policy="raise"
         message = 'The input contains nan values'

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1536,269 +1536,280 @@ class TestCorrSpearmanr2:
 
 # I need to figure out how to do this one.
 
-@pytest.mark.thread_unsafe(reason="fails in parallel")
-def test_kendalltau():
-    # For the cases without ties, both variants should give the same
-    # result.
-    variants = ('b', 'c')
+@make_xp_test_case(stats.kendalltau)
+class TestKendallTau:
+    @pytest.mark.thread_unsafe(reason="fails in parallel")
+    def test_kendalltau(self):
+        # For the cases without ties, both variants should give the same
+        # result.
+        variants = ('b', 'c')
 
-    # case without ties, con-dis equal zero
-    x = [5, 2, 1, 3, 6, 4, 7, 8]
-    y = [5, 2, 6, 3, 1, 8, 7, 4]
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (0.0, 1.0)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
+        # case without ties, con-dis equal zero
+        x = [5, 2, 1, 3, 6, 4, 7, 8]
+        y = [5, 2, 6, 3, 1, 8, 7, 4]
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (0.0, 1.0)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # case without ties, con-dis equal zero
+        x = [0, 5, 2, 1, 3, 6, 4, 7, 8]
+        y = [5, 2, 0, 6, 3, 1, 8, 7, 4]
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (0.0, 1.0)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # case without ties, con-dis close to zero
+        x = [5, 2, 1, 3, 6, 4, 7]
+        y = [5, 2, 6, 3, 1, 7, 4]
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (-0.14285714286, 0.77261904762)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # case without ties, con-dis close to zero
+        x = [2, 1, 3, 6, 4, 7, 8]
+        y = [2, 6, 3, 1, 8, 7, 4]
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (0.047619047619, 1.0)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # simple case without ties
+        x = np.arange(10)
+        y = np.arange(10)
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (1.0, 5.511463844797e-07)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # swap a couple of values
+        b = y[1]
+        y[1] = y[2]
+        y[2] = b
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (0.9555555555555556, 5.511463844797e-06)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # swap a couple more
+        b = y[5]
+        y[5] = y[6]
+        y[6] = b
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (0.9111111111111111, 2.976190476190e-05)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # same in opposite direction
+        x = np.arange(10)
+        y = np.arange(10)[::-1]
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (-1.0, 5.511463844797e-07)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # swap a couple of values
+        b = y[1]
+        y[1] = y[2]
+        y[2] = b
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (-0.9555555555555556, 5.511463844797e-06)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # swap a couple more
+        b = y[5]
+        y[5] = y[6]
+        y[6] = b
+        # Cross-check with exact result from R:
+        # cor.test(x,y,method="kendall",exact=1)
+        expected = (-0.9111111111111111, 2.976190476190e-05)
+        for taux in variants:
+            res = stats.kendalltau(x, y, variant=taux)
+            assert_approx_equal(res[0], expected[0])
+            assert_approx_equal(res[1], expected[1])
+
+        # Check a case where variants are different
+        # Example values found from Kendall (1970).
+        # P-value is the same for the both variants
+        x = array([1, 2, 2, 4, 4, 6, 6, 8, 9, 9])
+        y = array([1, 2, 4, 4, 4, 4, 8, 8, 8, 10])
+        expected = 0.85895569
+        assert_approx_equal(stats.kendalltau(x, y, variant='b')[0], expected)
+        expected = 0.825
+        assert_approx_equal(stats.kendalltau(x, y, variant='c')[0], expected)
+
+        # check exception in case of ties and method='exact' requested
+        y[2] = y[1]
+        assert_raises(ValueError, stats.kendalltau, x, y, method='exact')
+
+        # check exception in case of invalid method keyword
+        assert_raises(ValueError, stats.kendalltau, x, y, method='banana')
+
+        # check exception in case of invalid variant keyword
+        assert_raises(ValueError, stats.kendalltau, x, y, variant='rms')
+
+        # tau-b with some ties
+        # Cross-check with R:
+        # cor.test(c(12,2,1,12,2),c(1,4,7,1,0),method="kendall",exact=FALSE)
+        x1 = [12, 2, 1, 12, 2]
+        x2 = [1, 4, 7, 1, 0]
+        expected = (-0.47140452079103173, 0.28274545993277478)
+        res = stats.kendalltau(x1, x2)
         assert_approx_equal(res[0], expected[0])
         assert_approx_equal(res[1], expected[1])
 
-    # case without ties, con-dis equal zero
-    x = [0, 5, 2, 1, 3, 6, 4, 7, 8]
-    y = [5, 2, 0, 6, 3, 1, 8, 7, 4]
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (0.0, 1.0)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
+        # test for namedtuple attribute results
+        attributes = ('correlation', 'pvalue')
+        for taux in variants:
+            res = stats.kendalltau(x1, x2, variant=taux)
+            check_named_results(res, attributes)
+            assert_equal(res.correlation, res.statistic)
+
+        # with only ties in one or both inputs in tau-b or tau-c
+        for taux in variants:
+            assert_equal(stats.kendalltau([2, 2, 2], [2, 2, 2], variant=taux),
+                         (np.nan, np.nan))
+            assert_equal(stats.kendalltau([2, 0, 2], [2, 2, 2], variant=taux),
+                         (np.nan, np.nan))
+            assert_equal(stats.kendalltau([2, 2, 2], [2, 0, 2], variant=taux),
+                         (np.nan, np.nan))
+
+        # empty arrays provided as input
+        with pytest.warns(SmallSampleWarning, match="One or more sample..."):
+            assert_equal(stats.kendalltau([], []), (np.nan, np.nan))
+
+        # check with larger arrays
+        rng = np.random.RandomState(7546)
+        x = np.array([rng.normal(loc=1, scale=1, size=500),
+                      rng.normal(loc=1, scale=1, size=500)])
+        corr = [[1.0, 0.3],
+                [0.3, 1.0]]
+        x = np.dot(np.linalg.cholesky(corr), x)
+        expected = (0.19291382765531062, 1.1337095377742629e-10)
+        res = stats.kendalltau(x[0], x[1])
         assert_approx_equal(res[0], expected[0])
         assert_approx_equal(res[1], expected[1])
 
-    # case without ties, con-dis close to zero
-    x = [5, 2, 1, 3, 6, 4, 7]
-    y = [5, 2, 6, 3, 1, 7, 4]
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (-0.14285714286, 0.77261904762)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
+        # this should result in 1 for taub but not tau-c
+        assert_approx_equal(stats.kendalltau([1, 1, 2], [1, 1, 2], variant='b')[0],
+                            1.0)
+        assert_approx_equal(stats.kendalltau([1, 1, 2], [1, 1, 2], variant='c')[0],
+                            0.88888888)
 
-    # case without ties, con-dis close to zero
-    x = [2, 1, 3, 6, 4, 7, 8]
-    y = [2, 6, 3, 1, 8, 7, 4]
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (0.047619047619, 1.0)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
+        # test nan_policy
+        x = np.arange(10.)
+        x[9] = np.nan
+        assert_array_equal(stats.kendalltau(x, x), (np.nan, np.nan))
+        assert_allclose(stats.kendalltau(x, x, nan_policy='omit'),
+                        (1.0, 5.5114638e-6), rtol=1e-06)
+        assert_allclose(stats.kendalltau(x, x, nan_policy='omit', method='asymptotic'),
+                        (1.0, 0.00017455009626808976), rtol=1e-06)
+        assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='raise')
+        assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='foobar')
 
-    # simple case without ties
-    x = np.arange(10)
-    y = np.arange(10)
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (1.0, 5.511463844797e-07)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
+        # test unequal length inputs
+        x = np.arange(10.)
+        y = np.arange(20.)
+        assert_raises(ValueError, stats.kendalltau, x, y)
 
-    # swap a couple of values
-    b = y[1]
-    y[1] = y[2]
-    y[2] = b
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (0.9555555555555556, 5.511463844797e-06)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
+        # test all ties
+        with pytest.warns(SmallSampleWarning, match="One or more sample..."):
+            tau, p_value = stats.kendalltau([0], [0])
+        assert_equal(np.nan, tau)
+        assert_equal(np.nan, p_value)
 
-    # swap a couple more
-    b = y[5]
-    y[5] = y[6]
-    y[6] = b
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (0.9111111111111111, 2.976190476190e-05)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
+        # Regression test for GitHub issue #6061 - Overflow on Windows
+        x = np.arange(2000, dtype=float)
+        x = np.ma.masked_greater(x, 1995)
+        y = np.arange(2000, dtype=float)
+        y = np.concatenate((y[1000:], y[:1000]))
+        assert_(np.isfinite(stats.mstats.kendalltau(x,y)[1]))
 
-    # same in opposite direction
-    x = np.arange(10)
-    y = np.arange(10)[::-1]
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (-1.0, 5.511463844797e-07)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
-
-    # swap a couple of values
-    b = y[1]
-    y[1] = y[2]
-    y[2] = b
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (-0.9555555555555556, 5.511463844797e-06)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
-
-    # swap a couple more
-    b = y[5]
-    y[5] = y[6]
-    y[6] = b
-    # Cross-check with exact result from R:
-    # cor.test(x,y,method="kendall",exact=1)
-    expected = (-0.9111111111111111, 2.976190476190e-05)
-    for taux in variants:
-        res = stats.kendalltau(x, y, variant=taux)
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
-
-    # Check a case where variants are different
-    # Example values found from Kendall (1970).
-    # P-value is the same for the both variants
-    x = array([1, 2, 2, 4, 4, 6, 6, 8, 9, 9])
-    y = array([1, 2, 4, 4, 4, 4, 8, 8, 8, 10])
-    expected = 0.85895569
-    assert_approx_equal(stats.kendalltau(x, y, variant='b')[0], expected)
-    expected = 0.825
-    assert_approx_equal(stats.kendalltau(x, y, variant='c')[0], expected)
-
-    # check exception in case of ties and method='exact' requested
-    y[2] = y[1]
-    assert_raises(ValueError, stats.kendalltau, x, y, method='exact')
-
-    # check exception in case of invalid method keyword
-    assert_raises(ValueError, stats.kendalltau, x, y, method='banana')
-
-    # check exception in case of invalid variant keyword
-    assert_raises(ValueError, stats.kendalltau, x, y, variant='rms')
-
-    # tau-b with some ties
-    # Cross-check with R:
-    # cor.test(c(12,2,1,12,2),c(1,4,7,1,0),method="kendall",exact=FALSE)
-    x1 = [12, 2, 1, 12, 2]
-    x2 = [1, 4, 7, 1, 0]
-    expected = (-0.47140452079103173, 0.28274545993277478)
-    res = stats.kendalltau(x1, x2)
-    assert_approx_equal(res[0], expected[0])
-    assert_approx_equal(res[1], expected[1])
-
-    # test for namedtuple attribute results
-    attributes = ('correlation', 'pvalue')
-    for taux in variants:
-        res = stats.kendalltau(x1, x2, variant=taux)
-        check_named_results(res, attributes)
-        assert_equal(res.correlation, res.statistic)
-
-    # with only ties in one or both inputs in tau-b or tau-c
-    for taux in variants:
-        assert_equal(stats.kendalltau([2, 2, 2], [2, 2, 2], variant=taux),
-                     (np.nan, np.nan))
-        assert_equal(stats.kendalltau([2, 0, 2], [2, 2, 2], variant=taux),
-                     (np.nan, np.nan))
-        assert_equal(stats.kendalltau([2, 2, 2], [2, 0, 2], variant=taux),
-                     (np.nan, np.nan))
-
-    # empty arrays provided as input
-    with pytest.warns(SmallSampleWarning, match="One or more sample..."):
-        assert_equal(stats.kendalltau([], []), (np.nan, np.nan))
-
-    # check with larger arrays
-    rng = np.random.RandomState(7546)
-    x = np.array([rng.normal(loc=1, scale=1, size=500),
-                  rng.normal(loc=1, scale=1, size=500)])
-    corr = [[1.0, 0.3],
-            [0.3, 1.0]]
-    x = np.dot(np.linalg.cholesky(corr), x)
-    expected = (0.19291382765531062, 1.1337095377742629e-10)
-    res = stats.kendalltau(x[0], x[1])
-    assert_approx_equal(res[0], expected[0])
-    assert_approx_equal(res[1], expected[1])
-
-    # this should result in 1 for taub but not tau-c
-    assert_approx_equal(stats.kendalltau([1, 1, 2], [1, 1, 2], variant='b')[0],
-                        1.0)
-    assert_approx_equal(stats.kendalltau([1, 1, 2], [1, 1, 2], variant='c')[0],
-                        0.88888888)
-
-    # test nan_policy
-    x = np.arange(10.)
-    x[9] = np.nan
-    assert_array_equal(stats.kendalltau(x, x), (np.nan, np.nan))
-    assert_allclose(stats.kendalltau(x, x, nan_policy='omit'),
-                    (1.0, 5.5114638e-6), rtol=1e-06)
-    assert_allclose(stats.kendalltau(x, x, nan_policy='omit', method='asymptotic'),
-                    (1.0, 0.00017455009626808976), rtol=1e-06)
-    assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='raise')
-    assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='foobar')
-
-    # test unequal length inputs
-    x = np.arange(10.)
-    y = np.arange(20.)
-    assert_raises(ValueError, stats.kendalltau, x, y)
-
-    # test all ties
-    with pytest.warns(SmallSampleWarning, match="One or more sample..."):
-        tau, p_value = stats.kendalltau([0], [0])
-    assert_equal(np.nan, tau)
-    assert_equal(np.nan, p_value)
-
-    # Regression test for GitHub issue #6061 - Overflow on Windows
-    x = np.arange(2000, dtype=float)
-    x = np.ma.masked_greater(x, 1995)
-    y = np.arange(2000, dtype=float)
-    y = np.concatenate((y[1000:], y[:1000]))
-    assert_(np.isfinite(stats.mstats.kendalltau(x,y)[1]))
+    def test_kendalltau_vs_mstats_basic(self):
+        rng = np.random.RandomState(42)
+        for s in range(3, 10):
+            a = []
+            # Generate rankings with ties
+            for i in range(s):
+                a += [i]*i
+            b = list(a)
+            rng.shuffle(a)
+            rng.shuffle(b)
+            expected = mstats_basic.kendalltau(a, b)
+            actual = stats.kendalltau(a, b)
+            assert_approx_equal(actual[0], expected[0])
+            assert_approx_equal(actual[1], expected[1])
 
 
-def test_kendalltau_vs_mstats_basic():
-    rng = np.random.RandomState(42)
-    for s in range(3, 10):
-        a = []
-        # Generate rankings with ties
-        for i in range(s):
-            a += [i]*i
-        b = list(a)
-        rng.shuffle(a)
-        rng.shuffle(b)
-        expected = mstats_basic.kendalltau(a, b)
-        actual = stats.kendalltau(a, b)
-        assert_approx_equal(actual[0], expected[0])
-        assert_approx_equal(actual[1], expected[1])
+    def test_kendalltau_nan_2nd_arg(self):
+        # regression test for gh-6134: nans in the second arg were not handled
+        x = [1., 2., 3., 4.]
+        y = [np.nan, 2.4, 3.4, 3.4]
+
+        r1 = stats.kendalltau(x, y, nan_policy='omit')
+        r2 = stats.kendalltau(x[1:], y[1:])
+        assert_allclose(r1.statistic, r2.statistic, atol=1e-15)
 
 
-def test_kendalltau_nan_2nd_arg():
-    # regression test for gh-6134: nans in the second arg were not handled
-    x = [1., 2., 3., 4.]
-    y = [np.nan, 2.4, 3.4, 3.4]
+    @pytest.mark.thread_unsafe(reason="fails in parallel")
+    def test_kendalltau_gh18139_overflow(self):
+        # gh-18139 reported an overflow in `kendalltau` that appeared after
+        # SciPy 0.15.1. Check that this particular overflow does not occur.
+        # (Test would fail if warning were emitted.)
+        import random
+        random.seed(6272161)
+        classes = [1, 2, 3, 4, 5, 6, 7]
+        n_samples = 2 * 10 ** 5
+        x = random.choices(classes, k=n_samples)
+        y = random.choices(classes, k=n_samples)
+        res = stats.kendalltau(x, y)
+        # Reference value from SciPy 0.15.1
+        assert_allclose(res.statistic, 0.0011816493905730343)
+        # Reference p-value from `permutation_test` w/ n_resamples=9999 (default).
+        # Expected to be accurate to at least two digits.
+        assert_allclose(res.pvalue, 0.4894, atol=2e-3)
 
-    r1 = stats.kendalltau(x, y, nan_policy='omit')
-    r2 = stats.kendalltau(x[1:], y[1:])
-    assert_allclose(r1.statistic, r2.statistic, atol=1e-15)
+    def test_kendall_tau_large(self):
+        n = 172
+        # Test omit policy
+        x = np.arange(n + 1).astype(float)
+        y = np.arange(n + 1).astype(float)
+        y[-1] = np.nan
+        _, pval = stats.kendalltau(x, y, method='exact', nan_policy='omit')
+        assert_equal(pval, 0.0)
 
 
-@pytest.mark.thread_unsafe(reason="fails in parallel")
-def test_kendalltau_gh18139_overflow():
-    # gh-18139 reported an overflow in `kendalltau` that appeared after
-    # SciPy 0.15.1. Check that this particular overflow does not occur.
-    # (Test would fail if warning were emitted.)
-    import random
-    random.seed(6272161)
-    classes = [1, 2, 3, 4, 5, 6, 7]
-    n_samples = 2 * 10 ** 5
-    x = random.choices(classes, k=n_samples)
-    y = random.choices(classes, k=n_samples)
-    res = stats.kendalltau(x, y)
-    # Reference value from SciPy 0.15.1
-    assert_allclose(res.statistic, 0.0011816493905730343)
-    # Reference p-value from `permutation_test` w/ n_resamples=9999 (default).
-    # Expected to be accurate to at least two digits.
-    assert_allclose(res.pvalue, 0.4894, atol=2e-3)
-
-
+@make_xp_test_case(stats.kendalltau)
 class TestKendallTauAlternative:
     def test_kendalltau_alternative_asymptotic(self):
         # Test alternative parameter, asymptotic method (due to tie)
@@ -2116,16 +2127,6 @@ def test_segfault_issue_9710():
         stats.weightedtau([1], [1.0])
         # The code below also caused SEGFAULT
         stats.weightedtau([np.nan], [52])
-
-
-def test_kendall_tau_large():
-    n = 172
-    # Test omit policy
-    x = np.arange(n + 1).astype(float)
-    y = np.arange(n + 1).astype(float)
-    y[-1] = np.nan
-    _, pval = stats.kendalltau(x, y, method='exact', nan_policy='omit')
-    assert_equal(pval, 0.0)
 
 
 def test_weightedtau_vs_quadratic():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1538,251 +1538,174 @@ class TestCorrSpearmanr2:
 
 @make_xp_test_case(stats.kendalltau)
 class TestKendallTau:
-    @pytest.mark.thread_unsafe(reason="fails in parallel")
-    def test_kendalltau(self):
+    @pytest.mark.parametrize('x, y, statistic, pvalue', [
         # For the cases without ties, both variants should give the same
-        # result.
-        variants = ('b', 'c')
+        # result. Reference values result from R:
+        # cor.test(x, y, method="kendall", exact=1)
+        ([5, 2, 1, 3, 6, 4, 7, 8], [5, 2, 6, 3, 1, 8, 7, 4], 0.0, 1.0),
+        ([0, 5, 2, 1, 3, 6, 4, 7, 8], [5, 2, 0, 6, 3, 1, 8, 7, 4], 0.0, 1.0),
+        ([5, 2, 1, 3, 6, 4, 7], [5, 2, 6, 3, 1, 7, 4], -0.14285714286, 0.77261904762),
+        ([2, 1, 3, 6, 4, 7, 8], [2, 6, 3, 1, 8, 7, 4], 0.047619047619, 1.0),
+        ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+         1.0, 5.511463844797e-07),
+        ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 2, 1, 3, 4, 5, 6, 7, 8, 9],
+         0.9555555555555556, 5.511463844797e-06),
+        ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [0, 2, 1, 3, 4, 6, 5, 7, 8, 9],
+         0.9111111111111111, 2.976190476190e-05),
+        ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+         -1.0, 5.511463844797e-07),
+        ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [9, 7, 8, 6, 5, 4, 3, 2, 1, 0],
+         -0.9555555555555556, 5.511463844797e-06),
+        ([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], [9, 7, 8, 6, 5, 3, 4, 2, 1, 0],
+         -0.9111111111111111, 2.976190476190e-05),
+    ])
+    @pytest.mark.parametrize('variant', ['b', 'c'])
+    def test_kendalltau_no_ties(self, x, y, statistic, pvalue, variant, xp):
+        res = stats.kendalltau(xp.asarray(x), xp.asarray(y), variant=variant)
+        xp_assert_close(res[0], xp.asarray(statistic))
+        xp_assert_close(res[1], xp.asarray(pvalue))
 
-        # case without ties, con-dis equal zero
-        x = [5, 2, 1, 3, 6, 4, 7, 8]
-        y = [5, 2, 6, 3, 1, 8, 7, 4]
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (0.0, 1.0)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
-        # case without ties, con-dis equal zero
-        x = [0, 5, 2, 1, 3, 6, 4, 7, 8]
-        y = [5, 2, 0, 6, 3, 1, 8, 7, 4]
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (0.0, 1.0)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
-        # case without ties, con-dis close to zero
-        x = [5, 2, 1, 3, 6, 4, 7]
-        y = [5, 2, 6, 3, 1, 7, 4]
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (-0.14285714286, 0.77261904762)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
-        # case without ties, con-dis close to zero
-        x = [2, 1, 3, 6, 4, 7, 8]
-        y = [2, 6, 3, 1, 8, 7, 4]
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (0.047619047619, 1.0)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
-        # simple case without ties
-        x = np.arange(10)
-        y = np.arange(10)
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (1.0, 5.511463844797e-07)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
-        # swap a couple of values
-        b = y[1]
-        y[1] = y[2]
-        y[2] = b
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (0.9555555555555556, 5.511463844797e-06)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
-        # swap a couple more
-        b = y[5]
-        y[5] = y[6]
-        y[6] = b
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (0.9111111111111111, 2.976190476190e-05)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
-        # same in opposite direction
-        x = np.arange(10)
-        y = np.arange(10)[::-1]
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (-1.0, 5.511463844797e-07)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
-        # swap a couple of values
-        b = y[1]
-        y[1] = y[2]
-        y[2] = b
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (-0.9555555555555556, 5.511463844797e-06)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
-        # swap a couple more
-        b = y[5]
-        y[5] = y[6]
-        y[6] = b
-        # Cross-check with exact result from R:
-        # cor.test(x,y,method="kendall",exact=1)
-        expected = (-0.9111111111111111, 2.976190476190e-05)
-        for taux in variants:
-            res = stats.kendalltau(x, y, variant=taux)
-            assert_approx_equal(res[0], expected[0])
-            assert_approx_equal(res[1], expected[1])
-
+    def test_kendalltau_ties(self, xp):
         # Check a case where variants are different
         # Example values found from Kendall (1970).
         # P-value is the same for the both variants
-        x = array([1, 2, 2, 4, 4, 6, 6, 8, 9, 9])
-        y = array([1, 2, 4, 4, 4, 4, 8, 8, 8, 10])
+        x = xp.asarray([1, 2, 2, 4, 4, 6, 6, 8, 9, 9])
+        y = xp.asarray([1, 2, 4, 4, 4, 4, 8, 8, 8, 10])
         expected = 0.85895569
-        assert_approx_equal(stats.kendalltau(x, y, variant='b')[0], expected)
+        xp_assert_close(stats.kendalltau(x, y, variant='b')[0], xp.asarray(expected))
         expected = 0.825
-        assert_approx_equal(stats.kendalltau(x, y, variant='c')[0], expected)
-
-        # check exception in case of ties and method='exact' requested
-        y[2] = y[1]
-        assert_raises(ValueError, stats.kendalltau, x, y, method='exact')
-
-        # check exception in case of invalid method keyword
-        assert_raises(ValueError, stats.kendalltau, x, y, method='banana')
-
-        # check exception in case of invalid variant keyword
-        assert_raises(ValueError, stats.kendalltau, x, y, variant='rms')
+        xp_assert_close(stats.kendalltau(x, y, variant='c')[0], xp.asarray(expected))
 
         # tau-b with some ties
         # Cross-check with R:
-        # cor.test(c(12,2,1,12,2),c(1,4,7,1,0),method="kendall",exact=FALSE)
-        x1 = [12, 2, 1, 12, 2]
-        x2 = [1, 4, 7, 1, 0]
+        # cor.test(c(12, 2, 1, 12, 2), c(1, 4, 7, 1, 0), method="kendall", exact=FALSE)
+        x1 = xp.asarray([12, 2, 1, 12, 2])
+        x2 = xp.asarray([1, 4, 7, 1, 0])
         expected = (-0.47140452079103173, 0.28274545993277478)
         res = stats.kendalltau(x1, x2)
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
+        assert_approx_equal(res[0], xp.asarray(expected[0]))
+        assert_approx_equal(res[1], xp.asarray(expected[1]))
 
-        # test for namedtuple attribute results
-        attributes = ('correlation', 'pvalue')
-        for taux in variants:
-            res = stats.kendalltau(x1, x2, variant=taux)
-            check_named_results(res, attributes)
-            assert_equal(res.correlation, res.statistic)
+        # this should result in 1 for tau-b but not tau-c
+        x = xp.asarray([1, 1, 2])
+        xp_assert_close(stats.kendalltau(x, x, variant='b')[0], xp.asarray(1.0))
+        xp_assert_close(stats.kendalltau(x, x, variant='c')[0], xp.asarray(0.88888888))
 
-        # with only ties in one or both inputs in tau-b or tau-c
-        for taux in variants:
-            assert_equal(stats.kendalltau([2, 2, 2], [2, 2, 2], variant=taux),
-                         (np.nan, np.nan))
-            assert_equal(stats.kendalltau([2, 0, 2], [2, 2, 2], variant=taux),
-                         (np.nan, np.nan))
-            assert_equal(stats.kendalltau([2, 2, 2], [2, 0, 2], variant=taux),
-                         (np.nan, np.nan))
+    def test_input_validation_edge_cases(self, xp):
+        x = xp.asarray([1, 2, 2, 4, 4, 6, 6, 8, 9, 9])
+        y = xp.asarray([1, 2, 2, 4, 4, 4, 8, 8, 8, 10])
+
+        # check exception in case of ties and method='exact' requested
+        message = "Ties found; exact method cannot be used."
+        with pytest.raises(ValueError, match=message):
+            stats.kendalltau(x, y, method='exact')
+
+        # check exception in case of invalid method keyword
+        message = "Unknown `method` 'banana' specified."
+        with pytest.raises(ValueError, match=message):
+            stats.kendalltau(x, y, method='banana')
+
+        # check exception in case of invalid variant keyword
+        message = "Unknown `variant` 'rms' specified."
+        with pytest.raises(ValueError, match=message):
+            stats.kendalltau(x, y, variant='rms')
 
         # empty arrays provided as input
-        with pytest.warns(SmallSampleWarning, match="One or more sample..."):
-            assert_equal(stats.kendalltau([], []), (np.nan, np.nan))
+        with eager_warns(SmallSampleWarning, match="One or more sample...", xp=xp):
+            res = stats.kendalltau(xp.asarray([]), xp.asarray([]))
+        xp_assert_equal(res.statistic, xp.asarray(xp.nan))
+        xp_assert_equal(res.pvalue, xp.asarray(xp.nan))
 
+        # test too small
+        with pytest.warns(SmallSampleWarning, match="One or more sample..."):
+            tau, p_value = stats.kendalltau(xp.asarray([0]), xp.asarray([0]))
+        xp_assert_equal(tau, xp.asarray(np.nan))
+        xp_assert_equal(p_value, xp.asarray(np.nan))
+
+        # test unequal length inputs
+        x = np.arange(10.)
+        y = np.arange(20.)
+        message = "Array shapes are incompatible for broadcasting."
+        with pytest.raises(ValueError, match=message):
+            stats.kendalltau(x, y)
+
+    @pytest.mark.parametrize('variant', ['b', 'c'])
+    def test_attributes(self, variant, xp):
+        x1 = xp.asarray([1, 2, 2, 4, 4, 6, 6, 8, 9, 9])
+        x2 = xp.asarray([1, 2, 2, 4, 4, 4, 8, 8, 8, 10])
+        # test for namedtuple attribute results
+        attributes = ('correlation', 'pvalue')
+        res = stats.kendalltau(x1, x2, variant=variant)
+        check_named_results(res, attributes, xp=xp)
+        xp_assert_equal(res.correlation, res.statistic)
+
+    @pytest.mark.parametrize('x, y', [
+        ([2, 2, 2], [2, 2, 2]),
+        ([2, 0, 2], [2, 2, 2]),
+        ([2, 2, 2], [2, 0, 2]),
+    ])
+    @pytest.mark.parametrize('variant', ['b', 'c'])
+    def test_degenerate_input(self, x, y, variant, xp):
+        # with only ties in one or both inputs in tau-b or tau-c
+        x, y = xp.asarray(x), xp.asarray(y)
+        res = stats.kendalltau(x, y, variant=variant)
+        xp_assert_equal(res.statistic, xp.asarray(xp.nan))
+        xp_assert_equal(res.pvalue, xp.asarray(xp.nan))
+
+    @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
+    def test_large_arrays(self, dtype, xp):
         # check with larger arrays
+        dtype = xp_default_dtype(xp) if dtype is None else getattr(xp, dtype)
         rng = np.random.RandomState(7546)
         x = np.array([rng.normal(loc=1, scale=1, size=500),
                       rng.normal(loc=1, scale=1, size=500)])
         corr = [[1.0, 0.3],
                 [0.3, 1.0]]
         x = np.dot(np.linalg.cholesky(corr), x)
+        x0 = xp.asarray(x[0], dtype=dtype)
+        x1 = xp.asarray(x[1], dtype=dtype)
         expected = (0.19291382765531062, 1.1337095377742629e-10)
-        res = stats.kendalltau(x[0], x[1])
-        assert_approx_equal(res[0], expected[0])
-        assert_approx_equal(res[1], expected[1])
+        res = stats.kendalltau(x0, x1)
+        xp_assert_close(res[0], xp.asarray(expected[0]))
+        xp_assert_close(res[1], xp.asarray(expected[1]))
 
-        # this should result in 1 for taub but not tau-c
-        assert_approx_equal(stats.kendalltau([1, 1, 2], [1, 1, 2], variant='b')[0],
-                            1.0)
-        assert_approx_equal(stats.kendalltau([1, 1, 2], [1, 1, 2], variant='c')[0],
-                            0.88888888)
-
+    def test_nan_policy(self, xp):
         # test nan_policy
         x = np.arange(10.)
         x[9] = np.nan
-        assert_array_equal(stats.kendalltau(x, x), (np.nan, np.nan))
-        assert_allclose(stats.kendalltau(x, x, nan_policy='omit'),
-                        (1.0, 5.5114638e-6), rtol=1e-06)
-        assert_allclose(stats.kendalltau(x, x, nan_policy='omit', method='asymptotic'),
-                        (1.0, 0.00017455009626808976), rtol=1e-06)
-        assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='raise')
-        assert_raises(ValueError, stats.kendalltau, x, x, nan_policy='foobar')
+        x = xp.asarray(x.tolist())
 
-        # test unequal length inputs
-        x = np.arange(10.)
-        y = np.arange(20.)
-        assert_raises(ValueError, stats.kendalltau, x, y)
+        res = stats.kendalltau(x, x)
+        xp_assert_equal(res.statistic, xp.asarray(xp.nan))
+        xp_assert_equal(res.pvalue, xp.asarray(xp.nan))
 
-        # test all ties
-        with pytest.warns(SmallSampleWarning, match="One or more sample..."):
-            tau, p_value = stats.kendalltau([0], [0])
-        assert_equal(np.nan, tau)
-        assert_equal(np.nan, p_value)
+        res = stats.kendalltau(x, x, nan_policy='omit')
+        xp_assert_close(res.statistic, xp.asarray(1.0))
+        xp_assert_close(res.pvalue, xp.asarray(5.5114638e-6), rtol=1e-06)
 
-        # Regression test for GitHub issue #6061 - Overflow on Windows
-        x = np.arange(2000, dtype=float)
-        x = np.ma.masked_greater(x, 1995)
-        y = np.arange(2000, dtype=float)
-        y = np.concatenate((y[1000:], y[:1000]))
-        assert_(np.isfinite(stats.mstats.kendalltau(x,y)[1]))
+        res = stats.kendalltau(x, x, nan_policy='omit', method='asymptotic')
+        xp_assert_close(res.statistic, xp.asarray(1.0))
+        xp_assert_close(res.pvalue, xp.asarray(0.00017455009626808976), rtol=1e-06)
 
-    def test_kendalltau_vs_mstats_basic(self):
-        rng = np.random.RandomState(42)
-        for s in range(3, 10):
-            a = []
-            # Generate rankings with ties
-            for i in range(s):
-                a += [i]*i
-            b = list(a)
-            rng.shuffle(a)
-            rng.shuffle(b)
-            expected = mstats_basic.kendalltau(a, b)
-            actual = stats.kendalltau(a, b)
-            assert_approx_equal(actual[0], expected[0])
-            assert_approx_equal(actual[1], expected[1])
+        message = "The input contains nan values"
+        with pytest.raises(ValueError, match=message):
+            stats.kendalltau(x, x, nan_policy='raise')
 
+        message = "nan_policy must be one of..."
+        with pytest.raises(ValueError, match=message):
+            stats.kendalltau(x, x, nan_policy='foobar')
 
-    def test_kendalltau_nan_2nd_arg(self):
+    def test_kendalltau_nan_2nd_arg_gh6134(self, xp):
         # regression test for gh-6134: nans in the second arg were not handled
-        x = [1., 2., 3., 4.]
-        y = [np.nan, 2.4, 3.4, 3.4]
+        x = xp.asarray([1., 2., 3., 4.])
+        y = xp.asarray([np.nan, 2.4, 3.4, 3.4])
 
         r1 = stats.kendalltau(x, y, nan_policy='omit')
         r2 = stats.kendalltau(x[1:], y[1:])
-        assert_allclose(r1.statistic, r2.statistic, atol=1e-15)
-
+        xp_assert_close(r1.statistic, r2.statistic, atol=1e-15)
 
     @pytest.mark.thread_unsafe(reason="fails in parallel")
-    def test_kendalltau_gh18139_overflow(self):
+    def test_kendalltau_gh18139_overflow(self, xp):
         # gh-18139 reported an overflow in `kendalltau` that appeared after
         # SciPy 0.15.1. Check that this particular overflow does not occur.
         # (Test would fail if warning were emitted.)
@@ -1790,23 +1713,24 @@ class TestKendallTau:
         random.seed(6272161)
         classes = [1, 2, 3, 4, 5, 6, 7]
         n_samples = 2 * 10 ** 5
-        x = random.choices(classes, k=n_samples)
-        y = random.choices(classes, k=n_samples)
+        x = xp.asarray(random.choices(classes, k=n_samples))
+        y = xp.asarray(random.choices(classes, k=n_samples))
         res = stats.kendalltau(x, y)
         # Reference value from SciPy 0.15.1
-        assert_allclose(res.statistic, 0.0011816493905730343)
+        xp_assert_close(res.statistic, xp.asarray(0.0011816493905730343))
         # Reference p-value from `permutation_test` w/ n_resamples=9999 (default).
         # Expected to be accurate to at least two digits.
-        assert_allclose(res.pvalue, 0.4894, atol=2e-3)
+        xp_assert_close(res.pvalue, xp.asarray(0.4894), atol=2e-3)
 
-    def test_kendall_tau_large(self):
+    def test_kendall_tau_large_nan_policy(self, xp):
         n = 172
         # Test omit policy
         x = np.arange(n + 1).astype(float)
         y = np.arange(n + 1).astype(float)
         y[-1] = np.nan
+        x, y = xp.asarray(x.tolist()), xp.asarray(y.tolist())
         _, pval = stats.kendalltau(x, y, method='exact', nan_policy='omit')
-        assert_equal(pval, 0.0)
+        xp_assert_equal(pval, xp.asarray(0.0))
 
 
 @make_xp_test_case(stats.kendalltau)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544
Toward gh-22194 

#### What does this implement/fix?
Adds array API (including MArray) support to `stats.kendalltau`.

#### Additional information
Efficient implementation of the Kendall tau statistic in terms of the array API - especially a vectorized version that can omit masked values - would be challenging. An $O(n^2)$ algorithm is pretty simple, but the preferred long-term plan is to add both the statistic and p-value calculation to `xsf` so efficient, vectorized calculation is possible on any backend. In the meantime, this adds array API support by converting back and forth between the original array type and NumPy.

Translation of the first set of tests was quite ugly. Line by line review is welcome, but I'd be comfortable without it. 

#### AI Generation Disclosure
No AI