### PR TITLE
MAINT: optimize: lbfgs: replace `goto SAVEVARS` with `save_vars` function

### DIFF
--- a/scipy/optimize/src/lbfgsb.c
+++ b/scipy/optimize/src/lbfgsb.c
@@ -136,10 +136,17 @@ static void dcsrch(
     double gtol, double xtol, double stpmin,
     double stpmax, int* task, int* task_msg, int* isave, double* dsave
 );
-static void dcstep (
+static void dcstep(
     double* stx, double* fx, double* dx, double* sty, double* fy, double* dy,
     double* stp, double fp, double dp, int* brackt,
     double stpmin, double stpmax
+);
+
+// Helper functions
+void inline save_vars(
+    int brackt, int stage, double ginit, double gtest, double gx, double gy,
+    double finit, double fx, double fy, double stx, double sty, double stmin,
+    double stmax, double width, double width1, int* isave, double* dsave
 );
 
 static double epsmach = 2.220446049250313e-016;  /* np.finfo(np.float64).eps  */

--- a/scipy/optimize/src/lbfgsb.c
+++ b/scipy/optimize/src/lbfgsb.c
@@ -143,7 +143,7 @@ static void dcstep(
 );
 
 // Helper functions
-void inline save_vars(
+static inline void save_vars(
     int brackt, int stage, double ginit, double gtest, double gx, double gy,
     double finit, double fx, double fy, double stx, double sty, double stmin,
     double stmax, double width, double width1, int* isave, double* dsave
@@ -3392,7 +3392,7 @@ dcsrch(double f, double g, double* stp, double ftol, double gtol,
     return;
 }
 
-void inline save_vars(
+static inline void save_vars(
     int brackt, int stage, double ginit, double gtest, double gx, double gy,
     double finit, double fx, double fy, double stx, double sty, double stmin,
     double stmax, double width, double width1, int* isave, double* dsave) {

--- a/scipy/optimize/src/lbfgsb.c
+++ b/scipy/optimize/src/lbfgsb.c
@@ -3252,8 +3252,9 @@ dcsrch(double f, double g, double* stp, double ftol, double gtol,
 
         *task = FG;
         *task_msg = NO_MSG;
-        goto SAVEVARS;
-
+        save_vars(brackt, stage, ginit, gtest, gx, gy, finit, fx, fy, stx, sty, stmin,
+                  stmax, width, width1, isave, dsave);
+        return;
     } else {
         // Restore local variables.
         if (isave[0] == 1) {
@@ -3310,7 +3311,9 @@ dcsrch(double f, double g, double* stp, double ftol, double gtol,
     // Test for termination.
     if ((*task == WARNING) || (*task == CONVERGENCE))
     {
-        goto SAVEVARS;
+        save_vars(brackt, stage, ginit, gtest, gx, gy, finit, fx, fy, stx, sty, stmin,
+                  stmax, width, width1, isave, dsave);
+        return;
     }
 
     // A modified function is used to predict the step during the first stage if
@@ -3377,8 +3380,15 @@ dcsrch(double f, double g, double* stp, double ftol, double gtol,
     // Obtain another function and derivative.
     *task = FG;
     *task_msg = NO_MSG;
+    save_vars(brackt, stage, ginit, gtest, gx, gy, finit, fx, fy, stx, sty, stmin,
+              stmax, width, width1, isave, dsave);
+    return;
+}
 
-SAVEVARS:
+void inline save_vars(
+    int brackt, int stage, double ginit, double gtest, double gx, double gy,
+    double finit, double fx, double fy, double stx, double sty, double stmin,
+    double stmax, double width, double width1, int* isave, double* dsave) {
     if (brackt)
     {
         isave[0] = 1;


### PR DESCRIPTION
#### Reference issue
Continuation of #24659.

#### What does this implement/fix?
This PR replaces the `goto SAVEVARS` in C by a simple inline function `save_vars`.

#### Additional information

#### AI Generation Disclosure
None