### PR TITLE
MAINT: special: migrate `nrdtrimn/nrdtrisd` to xsf

### DIFF
--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -19,14 +19,10 @@ cdef extern from "cdflib.h" nogil:
         int i1
         double d3
 
-    TupleDID cdfchi_which3(double, double, double)
     TupleDID cdff_which4(double, double, double, double);
     TupleDID cdffnc_which3(double, double, double, double, double);
     TupleDID cdffnc_which4(double, double, double, double, double);
     TupleDID cdffnc_which5(double, double, double, double, double);
-    TupleDID cdfnor_which3(double, double, double, double);
-    TupleDID cdfnor_which4(double, double, double, double);
-    TupleDID cdfpoi_which2(double, double, double);
     TupleDID cdft_which3(double, double, double);
     TupleDID cdftnc_which3(double, double, double, double);
     TupleDID cdftnc_which4(double, double, double, double);
@@ -195,48 +191,6 @@ cdef inline double nctdtrinc(double df, double p, double t) noexcept nogil:
     ret = cdftnc_which4(p, q, t, df)
     result, status, bound = ret.d1, ret.i1, ret.d2
     return get_result("nctdtrinc", argnames, result, status, bound, 1)
-
-
-cdef inline double nrdtrimn(double p, double std, double x) noexcept nogil:
-    cdef:
-        double q = 1.0 - p
-        double result, bound
-        int status = 10
-        char *argnames[4]
-        TupleDID ret
-
-    if isnan(p) or isnan(std) or isnan(x):
-      return NAN
-
-    argnames[0] = "p"
-    argnames[1] = "q"
-    argnames[2] = "x"
-    argnames[3] = "std"
-
-    ret = cdfnor_which3(p, q, x, std)
-    result, status, bound = ret.d1, ret.i1, ret.d2
-    return get_result("nrdtrimn", argnames, result, status, bound, 1)
-
-
-cdef inline double nrdtrisd(double mn, double p, double x) noexcept nogil:
-    cdef:
-        double q = 1.0 - p
-        double result, bound
-        int status = 10
-        char *argnames[4]
-        TupleDID ret
-
-    if isnan(mn) or isnan(p) or isnan(x):
-      return NAN
-
-    argnames[0] = "p"
-    argnames[1] = "q"
-    argnames[2] = "x"
-    argnames[3] = "mn"
-
-    ret = cdfnor_which4(p, q, x, mn)
-    result, status, bound = ret.d1, ret.i1, ret.d2
-    return get_result("nrdtrisd", argnames, result, status, bound, 1)
 
 
 cdef inline double stdtridf(double p, double t) noexcept nogil:

--- a/scipy/special/cdflib.c
+++ b/scipy/special/cdflib.c
@@ -161,9 +161,7 @@ static struct TupleDD cumnor(double);
 static struct TupleDD cumt(double, double);
 static struct TupleDD cumtnc(double, double, double);
 static double devlpl(double *, int, double);
-static double dinvnr(double, double);
 static void dinvr(struct DinvrState *, struct DzrorState *);
-static double dt1(double, double, double);
 static void dzror(struct DzrorState *);
 static double cdflib_erf(double);
 static double erfc1(int, double);
@@ -183,7 +181,6 @@ static double rcomp(double, double);
 static double rexp(double);
 static double rlog(double);
 static double rlog1(double);
-static double stvaln(double);
 
 
 double algdiv(double a, double b)
@@ -1689,120 +1686,6 @@ struct TupleDID cdffnc_which5(double p, double q, double f, double dfn, double d
 
 
     //               Cumulative Distribution Function
-    //               NORmal distribution
-    //
-    //
-    //                              Function
-    //
-    //
-    //     Calculates any one parameter of the normal
-    //     distribution given values for the others.
-    //
-    //
-    //                              Arguments
-    //
-    //
-    //     WHICH  --> Integer indicating  which of the  next  parameter
-    //     values is to be calculated using values  of the others.
-    //     Legal range: 1..4
-    //               iwhich = 1 : Calculate P and Q from X,MEAN and SD
-    //               iwhich = 2 : Calculate X from P,Q,MEAN and SD
-    //               iwhich = 3 : Calculate MEAN from P,Q,X and SD
-    //               iwhich = 4 : Calculate SD from P,Q,X and MEAN
-    //                    INTEGER WHICH
-    //
-    //     P <--> The integral from -infinity to X of the normal density.
-    //            Input range: (0,1].
-    //                    DOUBLE PRECISION P
-    //
-    //     Q <--> 1-P.
-    //            Input range: (0, 1].
-    //            P + Q = 1.0.
-    //                    DOUBLE PRECISION Q
-    //
-    //     X < --> Upper limit of integration of the normal-density.
-    //             Input range: ( -infinity, +infinity)
-    //                    DOUBLE PRECISION X
-    //
-    //     MEAN <--> The mean of the normal density.
-    //               Input range: (-infinity, +infinity)
-    //                    DOUBLE PRECISION MEAN
-    //
-    //     SD <--> Standard Deviation of the normal density.
-    //             Input range: (0, +infinity).
-    //                    DOUBLE PRECISION SD
-    //
-    //     STATUS <-- 0 if calculation completed correctly
-    //               -I if input parameter number I is out of range
-    //                1 if answer appears to be lower than lowest
-    //                  search bound
-    //                2 if answer appears to be higher than greatest
-    //                  search bound
-    //                3 if P + Q .ne. 1
-    //                    INTEGER STATUS
-    //
-    //     BOUND <-- Undefined if STATUS is 0
-    //
-    //               Bound exceeded by parameter number I if STATUS
-    //               is negative.
-    //
-    //               Lower search bound if STATUS is 1.
-    //
-    //               Upper search bound if STATUS is 2.
-    //
-    //
-    //                              Method
-    //
-    //
-    //
-    //
-    //     A slightly modified version of ANORM from
-    //
-    //     Cody, W.D. (1993). "ALGORITHM 715: SPECFUN - A Portabel FORTRAN
-    //     Package of Special Function Routines and Test Drivers"
-    //     acm Transactions on Mathematical Software. 19, 22-32.
-    //
-    //     is used to calculate the cumulative standard normal distribution.
-    //
-    //     The rational functions from pages  90-95  of Kennedy and Gentle,
-    //     Statistical  Computing,  Marcel  Dekker, NY,  1980 are  used  as
-    //     starting values to Newton's Iterations which compute the inverse
-    //     standard normal.  Therefore no  searches  are necessary for  any
-    //     parameter.
-    //
-    //     For X < -15, the asymptotic expansion for the normal is used  as
-    //     the starting value in finding the inverse standard normal.
-    //     This is formula 26.2.12 of Abramowitz and Stegun.
-    //
-    //
-    //                              Note
-    //
-    //
-    //      The normal density is proportional to
-    //      exp( - 0.5 * (( X - MEAN)/SD)**2)
-    //
-    //
-    //**********************************************************************
-
-
-struct TupleDID cdfnor_which3(double p, double q, double x, double sd)
-{
-    if (!(sd > 0.0)) {
-        return (struct TupleDID){.d1 = 0.0, .i1 = -4, .d2 = 0.0};
-    }
-    double z = dinvnr(p, q);
-    return (struct TupleDID){.d1 = x - sd*z, .i1 = 0, .d2 = 0.0};
-}
-
-
-struct TupleDID cdfnor_which4(double p, double q, double x, double mean)
-{
-    double z = dinvnr(p, q);
-    return (struct TupleDID){.d1 = (x - mean)/z, .i1 = 0, .d2 = 0.0};
-}
-
-
-    //               Cumulative Distribution Function
     //                         T distribution
     //
     //
@@ -3022,63 +2905,6 @@ double devlpl(double *a, int n, double x)
 }
 
 
-double dinvnr(double p, double q)
-{
-    //    Double precision NoRmal distribution INVerse
-    //
-    //
-    //                            Function
-    //
-    //
-    //    Returns X  such that CUMNOR(X)  =   P,  i.e., the  integral from -
-    //    infinity to X of (1/SQRT(2*PI)) EXP(-U*U/2) dU is P
-    //
-    //
-    //                            Arguments
-    //
-    //
-    //    P --> The probability whose normal deviate is sought.
-    //                P is DOUBLE PRECISION
-    //
-    //    Q --> 1-P
-    //                P is DOUBLE PRECISION
-    //
-    //
-    //                            Method
-    //
-    //
-    //    The  rational   function   on  page 95    of Kennedy  and  Gentle,
-    //    Statistical Computing, Marcel Dekker, NY , 1980 is used as a start
-    //    value for the Newton method of finding roots.
-    //
-    //
-    //                            Note
-    //
-    //
-    //    If P or Q < machine EPS returns +/- DINVNR(EPS)
-
-    int i, maxit = 100;
-    double eps = 1e-13;
-    double r2pi = sqrt(1. / (2.*PI));
-    double strtx, xcur, cum, pp, dx;
-
-    pp = (p > q ? q : p);
-    strtx = stvaln(pp);
-    xcur = strtx;
-
-    for (i = 0; i < maxit; i++) {
-        struct TupleDD res = cumnor(xcur);
-        cum = res.d1;
-        dx = (cum - pp) / (r2pi * exp(-0.5*xcur*xcur));
-        xcur -= dx;
-        if (fabs(dx / xcur) < eps) {
-            return (p > q ? -xcur : xcur);
-        }
-    }
-    return (p > q ? -strtx : strtx);
-}
-
-
 void dinvr(DinvrState *S, DzrorState *DZ)
 {
     //        Double precision
@@ -3297,56 +3123,6 @@ void dinvr(DinvrState *S, DzrorState *DZ)
             return;
         }
     }
-}
-
-
-double dt1(double p, double q, double df)
-{
-    //    Double precision Initialize Approximation to
-    //        INVerse of the cumulative T distribution
-    //
-    //
-    //                            Function
-    //
-    //
-    //    Returns  the  inverse   of  the T   distribution   function, i.e.,
-    //    the integral from 0 to INVT of the T density is P. This is an
-    //    initial approximation
-    //
-    //
-    //                            Arguments
-    //
-    //
-    //    P --> The p-value whose inverse from the T distribution is
-    //        desired.
-    //                P is DOUBLE PRECISION
-    //
-    //    Q --> 1-P.
-    //                Q is DOUBLE PRECISION
-    //
-    //    DF --> Degrees of freedom of the T distribution.
-    //                DF is DOUBLE PRECISION
-
-    double ssum, term, x, xx;
-    double denpow = 1.0;
-    double coef[4][5] = {{1., 1., 0., 0., 0.},
-                              {3., 16., 5., 0., 0.},
-                              {-15., 17., 19., 3., 0.},
-                              {-945., -1920., 1482., 776., 79.}
-                             };
-    double denom[4] = {4., 96., 384.0, 92160.0};
-    int i, ideg[4] = {2, 3, 4, 5};
-
-    x = fabs(dinvnr(p, q));
-    xx = x*x;
-    ssum = x;
-    for (i = 0; i < 4; i++){
-        term = (devlpl(coef[i], ideg[i], xx))*x ;
-        denpow *= df;
-        ssum += term / (denpow*denom[i]);
-    }
-
-    return (p >= 0.5 ? ssum : -ssum);
 }
 
 
@@ -5260,36 +5036,4 @@ double rlog1(double x)
        return x - log((x + 0.5) + 0.5);
 
     }
-}
-
-
-double stvaln(double p)
-{
-    //                STarting VALue for Newton-Raphon
-    //            calculation of Normal distribution Inverse
-    //
-    //                          Function
-    //
-    // Returns X such that CUMNOR(X) = P,  i.e., the  integral from -
-    // infinity to X of (1/SQRT(2*PI)) EXP(-U*U/2) dU is P
-    //
-    //                          Arguments
-    //
-    // P --> The probability whose normal deviate is sought.
-    //                P is DOUBLE PRECISION
-    //
-    //                          Method
-    //
-    // The  rational   function   on  page 95    of Kennedy  and  Gentle,
-    // Statistical Computing, Marcel Dekker, NY , 1980.
-
-    double y, z;
-    double xnum[5] = {-0.322232431088, -1.000000000000, -0.342242088547,
-                      -0.204231210245e-1, -0.453642210148e-4};
-    double xden[5]  = {0.993484626060e-1, 0.588581570495, 0.531103462366,
-                       0.103537752850, 0.38560700634e-2};
-    z = (p > 0.5 ? 1.0 - p : p);
-    y = sqrt(-2.0 * log(z));
-    z = y + (devlpl(xnum, 5, y) / devlpl(xden, 5, y));
-    return (p > 0.5 ? z : -z);
 }

--- a/scipy/special/cdflib.h
+++ b/scipy/special/cdflib.h
@@ -109,8 +109,6 @@ struct TupleDID cdff_which4(double, double, double, double);
 struct TupleDID cdffnc_which3(double, double, double, double, double);
 struct TupleDID cdffnc_which4(double, double, double, double, double);
 struct TupleDID cdffnc_which5(double, double, double, double, double);
-struct TupleDID cdfnor_which3(double, double, double, double);
-struct TupleDID cdfnor_which4(double, double, double, double);
 struct TupleDID cdft_which3(double, double, double);
 struct TupleDID cdftnc_which3(double, double, double, double);
 struct TupleDID cdftnc_which4(double, double, double, double);

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -1361,6 +1361,8 @@ cdef extern from r"xsf_wrappers.h":
     double xsf_log_ndtr(double x) nogil
     npy_cdouble xsf_clog_ndtr(npy_cdouble x) nogil
     double xsf_ndtri(double x) nogil
+    double special_nrdtrimn(double p, double std, double x) nogil
+    double special_nrdtrisd(double mean, double p, double x) nogil
     double xsf_owens_t(double h, double a) nogil
     double xsf_pdtr(double k, double m) nogil
     double xsf_pdtrc(double k, double m) nogil
@@ -1715,14 +1717,6 @@ cdef _proto_nctdtridf_t *_proto_nctdtridf_t_var = &_func_nctdtridf
 from ._cdflib_wrappers cimport nctdtrinc as _func_nctdtrinc
 ctypedef double _proto_nctdtrinc_t(double, double, double) noexcept nogil
 cdef _proto_nctdtrinc_t *_proto_nctdtrinc_t_var = &_func_nctdtrinc
-
-from ._cdflib_wrappers cimport nrdtrimn as _func_nrdtrimn
-ctypedef double _proto_nrdtrimn_t(double, double, double) noexcept nogil
-cdef _proto_nrdtrimn_t *_proto_nrdtrimn_t_var = &_func_nrdtrimn
-
-from ._cdflib_wrappers cimport nrdtrisd as _func_nrdtrisd
-ctypedef double _proto_nrdtrisd_t(double, double, double) noexcept nogil
-cdef _proto_nrdtrisd_t *_proto_nrdtrisd_t_var = &_func_nrdtrisd
 
 from ._legacy cimport pdtri_unsafe as _func_pdtri_unsafe
 ctypedef double _proto_pdtri_unsafe_t(double, double) noexcept nogil
@@ -3203,11 +3197,11 @@ cpdef double ndtri(double x0) noexcept nogil:
 
 cpdef double nrdtrimn(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.nrdtrimn"""
-    return _func_nrdtrimn(x0, x1, x2)
+    return special_nrdtrimn(x0, x1, x2)
 
 cpdef double nrdtrisd(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.nrdtrisd"""
-    return _func_nrdtrisd(x0, x1, x2)
+    return special_nrdtrisd(x0, x1, x2)
 
 cdef void obl_ang1(double x0, double x1, double x2, double x3, double *y0, double *y1) noexcept nogil:
     """See the documentation for scipy.special.obl_ang1"""

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -588,12 +588,13 @@
         }
     },
     "nrdtrimn": {
-        "_cdflib_wrappers.pxd": {
-            "nrdtrimn": "ddd->d"        }
+        "xsf_wrappers.h": {
+            "special_nrdtrimn": "ddd->d"
+        }
     },
     "nrdtrisd": {
-        "_cdflib_wrappers.pxd": {
-            "nrdtrisd": "ddd->d"
+        "xsf_wrappers.h": {
+            "special_nrdtrisd": "ddd->d"
         }
     },
     "owens_t": {

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -765,10 +765,6 @@ class TestCephes:
     def test_nrdtrimn(self):
         assert_allclose(cephes.nrdtrimn(0.5, 1, 1), 1.0, atol=1e-6, rtol=0)
 
-    def test_nrdtrisd(self):
-        assert_allclose(cephes.nrdtrisd(0.5,0.5,0.5), 0.0,
-                         atol=0, rtol=0)
-
     def test_obl_ang1(self):
         cephes.obl_ang1(1,1,1,0)
 

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -955,3 +955,29 @@ def test_bdtrik(y, n, p, k):
     # Reference values for y were computed with mpmath using
     # the _binomial_cdf function from above.
     assert_allclose(sp.bdtrik(y, n, p), k, rtol=1e-11)
+
+
+@pytest.mark.parametrize("p, std, x, ref", [
+    (0, 0.1, 0, np.nan),
+    (0.1, np.inf, 1, np.inf),
+    (0.1, 1, np.inf, np.inf),
+    (0.1, 1, -np.inf, -np.inf),
+    (0.1, np.inf, np.inf, np.inf),
+    (0.1, 0.1, np.inf, np.inf),
+    (0.1, 1, -np.inf, -np.inf),
+    (0.3, -1, 1, np.nan)
+])
+def test_nrdtrimn_edge_cases(p, std, x, ref):
+    assert_equal(sp.nrdtrimn(p, std, x), ref)
+
+
+@pytest.mark.parametrize("mn, p, x, ref", [
+    (0, 0, 0, np.nan),
+    (0, 1, 0, np.nan),
+    (0, 1, np.inf, np.nan),
+    (0.1, 1, 1, np.nan),
+    (0.1, 0.1, np.inf, -np.inf),
+    (0.1, 0.1, -np.inf, np.inf),
+])
+def test_nrdtrisd_edge_cases(mn, p, x, ref):
+    assert_equal(sp.nrdtrisd(mn, p, x), ref)

--- a/scipy/special/xsf_wrappers.cpp
+++ b/scipy/special/xsf_wrappers.cpp
@@ -1,3 +1,5 @@
+#include <cmath>
+
 #include "xsf_wrappers.h"
 #include <xsf/airy.h>
 #include <xsf/amos.h>
@@ -641,6 +643,29 @@ double xsf_log_ndtr(double x) { return xsf::log_ndtr(x); }
 npy_cdouble xsf_clog_ndtr(npy_cdouble x) { return to_ccomplex(xsf::log_ndtr(to_complex(x))); }
 
 double xsf_ndtri(double x) { return xsf::ndtri(x); }
+
+double special_nrdtrimn(double p, double std, double x) { 
+    if (std::isnan(std) || std <= 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (std::isnan(p) || p <= 0 || p >= 1) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (std::isnan(x)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return x - std * xsf::ndtri(p);
+}
+
+double special_nrdtrisd(double mean, double p, double x) { 
+    if (std::isnan(mean) || std::isnan(p) || std::isnan(x)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (p <= 0 || p >= 1) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return (x - mean) / xsf::ndtri(p);
+}
 
 double xsf_owens_t(double h, double a) { return xsf::owens_t(h, a); }
 

--- a/scipy/special/xsf_wrappers.h
+++ b/scipy/special/xsf_wrappers.h
@@ -352,6 +352,8 @@ npy_cdouble xsf_cndtr(npy_cdouble x);
 double xsf_log_ndtr(double x);
 npy_cdouble xsf_clog_ndtr(npy_cdouble x);
 double xsf_ndtri(double x);
+double special_nrdtrimn(double p, double std, double x);
+double special_nrdtrisd(double mean, double p, double x);
 double xsf_owens_t(double h, double a);
 double xsf_pdtr(double k, double m);
 double xsf_pdtrc(double k, double m);


### PR DESCRIPTION
#### Reference issue
Towards #21966

#### What does this implement/fix?
Migrates normal distribution inverses to xsf/cephes.

#### Additional information
I could not get the new cpp based ufunc machinery to work so I stuck with what I did in #23758.

#### Accuracy benchmark

Accuracy stays the same

<img width="1200" height="500" alt="norm_funcs_bench" src="https://github.com/user-attachments/assets/8c46e717-47f2-4725-977b-f9c3cb48be5b" />

<details><summary>Details</summary>
<p>

```python
from mpmath import mp
import numpy as np
import matplotlib.pyplot as plt
from scipy.special import nrdtrimn, nrdtrisd
from scipy.stats import Normal


SUFFIX = "main"


# def calculate_rel_error(computed, reference):
#     """
#     Calculate the relative error between computed and reference values.
#     """
#     rel_error = np.abs(computed - reference) / np.abs(reference)
#     eps = np.finfo(float).eps
#     rel_error = np.clip(rel_error, eps/100, 1)
#     return rel_error

# @np.vectorize
# def norm_cdf_mpmath(x: float, mean: float, std: float) -> float:
#     mean, std, x = mp.mpf(mean), mp.mpf(std), mp.mpf(x)
#     return float(mp.ncdf(x, mean, std))


# rng = np.random.default_rng(124890778566236)

# x = rng.uniform(-10, 10, size=50)
# mn = rng.uniform(-5, 5, size=50)
# sd = rng.uniform(1e-10, 10, size=50)

# x, mn, sd = np.meshgrid(x, mn, sd)
# x = x.ravel()
# mn = mn.ravel()
# sd = sd.ravel()


# reference_p = norm_cdf_mpmath(x, mn, sd)
# scipy_nrdtrimn = nrdtrimn(reference_p, sd, x)
# scipy_nrdtrisd = nrdtrisd(mn, reference_p, x)

# rel_error_nrdtrimn = calculate_rel_error(scipy_nrdtrimn, mn)
# rel_error_nrdtrisd = calculate_rel_error(scipy_nrdtrisd, sd)

# np.save(f"rel_error_nrdtrimn_{SUFFIX}.npy", rel_error_nrdtrimn)
# np.save(f"rel_error_nrdtrisd_{SUFFIX}.npy", rel_error_nrdtrisd)


rel_error_nrdtrimn_main = np.load(f"rel_error_nrdtrimn_main.npy")
rel_error_nrdtrimn_pr = np.load(f"rel_error_nrdtrimn_PR.npy")

rel_error_nrdtrisd_main = np.load(f"rel_error_nrdtrisd_main.npy")
rel_error_nrdtrisd_pr = np.load(f"rel_error_nrdtrisd_PR.npy")

bins = int(np.sqrt(len(rel_error_nrdtrimn_main)))

fig, (left, right) = plt.subplots(1, 2, figsize=(12, 5))
# left plot: nrdtrimn
left.hist(np.log10(rel_error_nrdtrimn_main), bins=bins, cumulative=True, density=True, histtype='step', label="main")
left.hist(np.log10(rel_error_nrdtrimn_pr), bins=bins, cumulative=True, density=True, histtype='step', label="PR")
left.set_xlabel('log10(Relative Error)')
left.set_ylabel('Cumulative Density')
left.set_title('Cumulative Histogram of Relative Errors for nrdtrimn')
left.legend()

# right plot: nrdtrisd
right.hist(np.log10(rel_error_nrdtrisd_main), bins=bins, cumulative=True, density=True, label="main", histtype='step')
right.hist(np.log10(rel_error_nrdtrisd_pr), bins=bins, cumulative=True, density=True, label="PR", histtype='step')
right.set_xlabel('log10(Relative Error)')
right.set_ylabel('Cumulative Density')
right.set_title('Cumulative Histogram of Relative Errors for nrdtrisd')
right.legend()
plt.show()
``` 

</p>
</details> 

#### AI Generation Disclosure
No AI use.
