### PR TITLE
ENH: stats.quantile_test: add array API support

### DIFF
--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -392,13 +392,19 @@ class _SimpleBinomial:
 
     def f(self, x, fun):
         xp = self.xp
-        return xpx.lazy_apply(fun, xp.floor(x), self.n, self.p, as_numpy=True, xp=xp)
+        return xpx.lazy_apply(fun, x, self.n, self.p, as_numpy=True, xp=xp)
 
     def cdf(self, x):
-        return self.xp.where(x >= 0, self.f(x, scu._binom_cdf), 0.0)
+        return self.xp.where(x >= 0, self.f(self.xp.floor(x), scu._binom_cdf), 0.0)
 
     def sf(self, x):
-        return self.xp.where(x >= 0, self.f(x, scu._binom_sf), 1.0)
+        return self.xp.where(x >= 0, self.f(self.xp.floor(x), scu._binom_sf), 1.0)
+
+    def ppf(self, x):
+        return self.f(x, scu._binom_ppf)
+
+    def isf(self, x):
+        return self.f(x, scu._binom_isf)
 
     def pmf(self, x):
-        return self.f(x, scu._binom_pmf)
+        return self.f(self.xp.floor(x), scu._binom_pmf)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -61,7 +61,7 @@ from ._axis_nan_policy import (_axis_nan_policy_factory, _broadcast_shapes,
                                _broadcast_array_shapes_remove_axis, SmallSampleWarning,
                                too_small_1d_not_omit, too_small_1d_omit,
                                too_small_nd_not_omit, too_small_nd_omit)
-from ._binomtest import _binary_search_for_binom_tst as _binary_search
+from ._binomtest import _binary_search_for_binom_tst as _binary_search, _SimpleBinomial
 from scipy._lib._bunch import _make_tuple_bunch
 from scipy import stats
 from scipy._lib._array_api import (
@@ -9014,6 +9014,7 @@ class QuantileTestResult:
     _keepdims : bool = field(repr=False)
     _ndim : int = field(repr=False)
     _nan_out : bool = field(repr=False)
+    _xp : bool = field(repr=False)
 
 
     def confidence_interval(self, confidence_level=0.95):
@@ -9049,11 +9050,12 @@ class QuantileTestResult:
         (1.9542373206359396, 2.293318740264183)
         """
 
+        xp = self._xp
         alternative = self._alternative
         p = self._p
-        x = np.sort(self._x, axis=-1)
+        x = xp.sort(self._x, axis=-1)
         n = x.shape[-1]
-        bd = stats.binom(n, p)
+        bd = _SimpleBinomial(n=n, p=p)
         shape = p.shape
 
         if confidence_level <= 0 or confidence_level >= 1:
@@ -9061,66 +9063,69 @@ class QuantileTestResult:
             raise ValueError(message)
 
         if n == 0:
-            zeros = np.zeros(p.shape, dtype=x.dtype)
+            zeros = xp.zeros(p.shape, dtype=x.dtype)
             low, high = zeros, zeros
         elif alternative == 'less':
             p = 1 - confidence_level
-            low = np.full(shape, -np.inf)
+            low = xp.full(shape, -xp.inf)
             high_index = bd.isf(p).astype(int)
             valid_index = high_index < n
             high_index[~valid_index] = 0
-            x_high = np.take_along_axis(x, high_index, axis=-1)
-            high = np.where(valid_index, x_high, np.nan)
+            x_high = xp.take_along_axis(x, high_index, axis=-1)
+            high = xp.where(valid_index, x_high, xp.nan)
         elif alternative == 'greater':
             p = 1 - confidence_level
             low_index = (bd.ppf(p)).astype(int) - 1
             valid_index = low_index >= 0
             low_index[~valid_index] = 0
-            x_low = np.take_along_axis(x, low_index, axis=-1)
-            low = np.where(valid_index, x_low, np.nan)
-            high = np.full(shape, np.inf)
+            x_low = xp.take_along_axis(x, low_index, axis=-1)
+            low = xp.where(valid_index, x_low, xp.nan)
+            high = xp.full(shape, xp.inf)
         elif alternative == 'two-sided':
             p = (1 - confidence_level) / 2
             low_index = (bd.ppf(p)).astype(int) - 1
             valid_index = low_index >= 0
             low_index[~valid_index] = 0
-            x_low = np.take_along_axis(x, low_index, axis=-1)
-            low = np.where(valid_index, x_low, np.nan)
+            x_low = xp.take_along_axis(x, low_index, axis=-1)
+            low = xp.where(valid_index, x_low, xp.nan)
             high_index = bd.isf(p).astype(int)
             valid_index = high_index < n
             high_index[~valid_index] = 0
-            x_high = np.take_along_axis(x, high_index, axis=-1)
-            high = np.where(valid_index, x_high, np.nan)
+            x_high = xp.take_along_axis(x, high_index, axis=-1)
+            high = xp.where(valid_index, x_high, xp.nan)
 
-        args = self._axis, self._axis_none, self._keepdims, self._ndim, self._nan_out
+        args = (self._axis, self._axis_none, self._keepdims,
+                self._ndim, self._nan_out, self._xp)
         low = _quantile_test_postprocess(low, *args)
         high = _quantile_test_postprocess(high, *args)
         return ConfidenceInterval(low, high)
 
 
 def quantile_test_iv(x, q, p, alternative, axis, keepdims):
+    xp = array_namespace(x, q, p)
+    dtype = xp_result_type(x, q, p, force_floating=True, xp=xp)
 
-    x = np.atleast_1d(x)
+    x = xpx.atleast_nd(x, ndim=1, xp=xp)
     message = '`x` must be an array of numbers.'
-    if not np.issubdtype(x.dtype, np.number):
+    if not xp.isdtype(x.dtype, 'numeric'):
         raise ValueError(message)
 
-    q = np.array(q)[()]
+    q = xp.asarray(q)
     message = "`q` must be a scalar or array of numbers."
-    if not np.issubdtype(q.dtype, np.number):
+    if not xp.isdtype(q.dtype, 'numeric'):
         raise ValueError(message)
 
-    p = np.array(p)[()]
+    p = xp.asarray(p)
     message = "`p` must be a scalar or array of floats."
-    if not np.issubdtype(p.dtype, np.inexact):
+    if not xp.isdtype(p.dtype, 'real floating'):
         raise ValueError(message)
 
     axis_none = axis is None
     ndim = max(x.ndim, p.ndim)
     if axis_none:
-        x = np.ravel(x)
-        q = np.ravel(q)
-        p = np.ravel(p)
+        x = xp_ravel(x)
+        q = xp_ravel(q)
+        p = xp_ravel(p)
         axis = 0
     elif np.iterable(axis) or int(axis) != axis:
         message = "`axis` must be an integer or None."
@@ -9139,9 +9144,9 @@ def quantile_test_iv(x, q, p, alternative, axis, keepdims):
         message = "If specified, `keepdims` must be True or False."
         raise ValueError(message)
 
-    x = np.sort(x, axis=axis)
-    q, p = np.broadcast_arrays(q, p)  # length along axis matters for q and p
-    x, q, p = _broadcast_arrays((x, q, p), axis=axis)
+    x = xp.sort(x, axis=axis)
+    q, p = xp.broadcast_arrays(q, p)  # length along axis matters for q and p
+    x, q, p = _broadcast_arrays((x, q, p), axis=axis, xp=xp)
 
     if (keepdims is False) and (p.shape[axis] != 1):
         message = ("`keepdims` may be False only if `p` and `q` are scalars or the "
@@ -9149,39 +9154,39 @@ def quantile_test_iv(x, q, p, alternative, axis, keepdims):
         raise ValueError(message)
     keepdims = (p.shape[axis] != 1) if keepdims is None else keepdims
 
-    x = np.moveaxis(x, axis, -1)
-    q = np.moveaxis(q, axis, -1)
-    p = np.moveaxis(p, axis, -1)
+    x = xp.moveaxis(x, axis, -1)
+    q = xp.moveaxis(q, axis, -1)
+    p = xp.moveaxis(p, axis, -1)
 
-    nan_out = ((p >= 1) | (p <= 0) | np.isnan(p) | np.isnan(q)
-               | np.any(np.isnan(x), axis=-1, keepdims=True))
-    if np.any(nan_out):
+    nan_out = ((p >= 1) | (p <= 0) | xp.isnan(p) | xp.isnan(q)
+               | xp.any(xp.isnan(x), axis=-1, keepdims=True))
+    if xp.any(nan_out):
         # These get NaN-ed out at the end. In the meantime, we want them
         # to pass through calculations without warnings or errors
-        q = xpx.at(q, nan_out).set(0, copy=True)
+        q = xpx.at(q, nan_out).set(0.0, copy=True)
         p = xpx.at(p, nan_out).set(0.5, copy=True)
 
-    return x, q, p, alternative, axis, keepdims, axis_none, ndim, nan_out
+    return x, q, p, alternative, axis, keepdims, axis_none, ndim, nan_out, dtype, xp
 
 
-def _quantile_test_postprocess(res, axis, axis_none, keepdims, ndim, nan_out):
+def _quantile_test_postprocess(res, axis, axis_none, keepdims, ndim, nan_out, xp):
     # Reshape per axis/keepdims
 
-    res[nan_out] = -1 if np.issubdtype(res.dtype, np.integer) else np.nan
+    res[nan_out] = xp.nan
 
     if axis_none and keepdims:
         shape = (1,)*(ndim - 1) + res.shape
-        res = np.reshape(res, shape)
+        res = xp.reshape(res, shape)
         axis = -1
 
-    res = np.moveaxis(res, -1, axis)
+    res = xp.moveaxis(res, -1, axis)
 
     if not keepdims:
-        res = np.squeeze(res, axis=axis)
+        res = xp.squeeze(res, axis=axis)
     return res[()]
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities()
 def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=None):
     r"""
     Perform a quantile test and compute a confidence interval of the quantile.
@@ -9201,8 +9206,7 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
         The hypothesized value of the quantile.
     p : float, default: 0.5
         The probability associated with the quantile; i.e. the proportion of
-        the population less than `q` is `p`. Must be strictly between 0 and
-        1.
+        the population less than `q` is `p`. Must be strictly between 0 and 1.
     alternative : {'two-sided', 'less', 'greater'}, optional
         Defines the alternative hypothesis.
         The following options are available (default is 'two-sided'):
@@ -9245,9 +9249,9 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
 
         statistic : float
             One of two test statistics that may be used in the quantile test.
-            The first test statistic, ``T1``, is the proportion of observations in
+            The first test statistic, ``T1``, is the number of observations in
             `x` that are less than or equal to the hypothesized quantile
-            `q`. The second test statistic, ``T2``, is the proportion of
+            `q`. The second test statistic, ``T2``, is the number of
             observations in `x` that are strictly less than the hypothesized
             quantile `q`.
 
@@ -9260,8 +9264,8 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
             When ``alternative = 'two-sided'``, both ``T1`` and ``T2`` are
             considered, and the one that leads to the smallest p-value is used.
 
-        statistic_type : int
-            Either `1` or `2` depending on which of ``T1`` or ``T2`` was
+        statistic_type : float
+            Either ``1.`` or ``2.`` depending on which of ``T1`` or ``T2`` was
             used to calculate the p-value.
 
         pvalue : float
@@ -9483,19 +9487,19 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
     # "H0: the p*th quantile of X is x*"
     # To facilitate comparison with [1], we'll use variable names that
     # best match Conover's notation
-    X, x_star, p_star, H1, axis, keepdims, axis_none, ndim, nan_out = quantile_test_iv(
-        x, q, p, alternative, axis, keepdims)
+    X, x_star, p_star, H1, axis, keepdims, axis_none, ndim, nan_out, dtype, xp = (
+        quantile_test_iv(x, q, p, alternative, axis, keepdims))
     # `axis` is the original `axis`; the working axis is -1.
 
     # "We will use two test statistics in this test. Let T1 equal "
     # "the number of observations less than or equal to x*, and "
     # "let T2 equal the number of observations less than x*."
     if X.shape[-1] > 0:
-        T1 = _xp_searchsorted(X, x_star, side='right')
-        T2 = _xp_searchsorted(X, x_star, side='left')
+        T1 = _xp_searchsorted(X, x_star, side='right', xp=xp)
+        T2 = _xp_searchsorted(X, x_star, side='left', xp=xp)
     else:
-        nan_out = np.ones_like(nan_out)
-        T = np.zeros(x_star.shape, dtype=np.int64)
+        nan_out = xp.ones_like(nan_out)
+        T = xp.zeros(x_star.shape, dtype=dtype)
         T1, T2 = T, T
 
     # "The null distribution of the test statistics T1 and T2 is "
@@ -9503,22 +9507,22 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
     # "p = p* as given in the null hypothesis.... Y has the binomial "
     # "distribution with parameters n and p*."
     n = X.shape[-1]
-    Y = stats.binom(n=n, p=p_star)
+    Y = _SimpleBinomial(n=n, p=p_star)
 
     # "H1: the p* population quantile is less than x*"
     if H1 == 'less':
         # "The p-value is the probability that a binomial random variable Y "
         # "is greater than *or equal to* the observed value of T2...using p=p*"
         pvalue = Y.sf(T2-1)  # Y.pmf(T2) + Y.sf(T2)
-        statistic = np.full(pvalue.shape, T2)
-        statistic_type = np.full(pvalue.shape, 2)
+        statistic = xp.broadcast_to(T2, pvalue.shape)
+        statistic_type = xp.broadcast_to(2., pvalue.shape)
     # "H1: the p* population quantile is greater than x*"
     elif H1 == 'greater':
         # "The p-value is the probability that a binomial random variable Y "
         # "is less than or equal to the observed value of T1... using p = p*"
         pvalue = Y.cdf(T1)
-        statistic = np.full(pvalue.shape, T1)
-        statistic_type = np.full(pvalue.shape, 1)
+        statistic = xp.broadcast_to(T1, pvalue.shape)
+        statistic_type = xp.broadcast_to(1., pvalue.shape)
     # "H1: x* is not the p*th population quantile"
     elif H1 == 'two-sided':
         # "The p-value is twice the smaller of the probabilities that a
@@ -9527,14 +9531,17 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
         # using p=p*."
         # Note: both one-sided p-values can exceed 0.5 for the same data, so
         # `clip`
-        p_min = np.minimum(Y.cdf(T1), Y.sf(T2 - 1))
-        pvalue = np.clip(2*p_min, 0, 1)
+        p_min = xp.minimum(Y.cdf(T1), Y.sf(T2 - 1))
+        pvalue = xp.clip(2*p_min, 0, 1)
         i2 = Y.cdf(T1) > Y.sf(T2 - 1)
-        statistic = np.where(i2, T2, T1)
-        statistic_type = np.where(i2, 2, 1)
+        statistic = xp.where(i2, T2, T1)
+        statistic_type = xp.where(i2, 2, 1)
+
+    statistic = xp.astype(statistic, dtype)
+    statistic_type = xp.astype(statistic_type, dtype)
 
     _statistic, _statistic_type, _pvalue = statistic, statistic_type, pvalue
-    args = axis, axis_none, keepdims, ndim, nan_out
+    args = axis, axis_none, keepdims, ndim, nan_out, xp
     statistic = _quantile_test_postprocess(statistic, *args)
     statistic_type = _quantile_test_postprocess(statistic_type, *args)
     pvalue = _quantile_test_postprocess(pvalue, *args)
@@ -9554,6 +9561,7 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
         _keepdims=keepdims,
         _ndim=ndim,
         _nan_out=nan_out,
+        _xp=xp,
     )
 
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9186,7 +9186,8 @@ def _quantile_test_postprocess(res, axis, axis_none, keepdims, ndim, nan_out, xp
     return res[()] if res.ndim == 0 else res
 
 
-@xp_capabilities(skip_backends=[("dask.array", "no `take_along_axis`")])
+@xp_capabilities(skip_backends=[("dask.array", "no `take_along_axis`")], cpu_only=True,
+                 reason="binomial distribution ufuncs only available for NumPy")
 def quantile_test(x, *, q=0.0, p=0.5, alternative='two-sided', axis=0, keepdims=None):
     r"""
     Perform a quantile test and compute a confidence interval of the quantile.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9070,14 +9070,14 @@ class QuantileTestResult:
             low = xp.full(shape, -xp.inf)
             high_index = xp.astype(bd.isf(p), xp.int64)
             valid_index = high_index < n
-            high_index[~valid_index] = 0
+            high_index = xpx.at(high_index)[~valid_index].set(0)
             x_high = xp.take_along_axis(x, high_index, axis=-1)
             high = xp.where(valid_index, x_high, xp.nan)
         elif alternative == 'greater':
             p = 1 - confidence_level
             low_index = xp.astype(bd.ppf(p), xp.int64) - 1
             valid_index = low_index >= 0
-            low_index[~valid_index] = 0
+            low_index = xpx.at(low_index)[~valid_index].set(0)
             x_low = xp.take_along_axis(x, low_index, axis=-1)
             low = xp.where(valid_index, x_low, xp.nan)
             high = xp.full(shape, xp.inf)
@@ -9085,12 +9085,12 @@ class QuantileTestResult:
             p = (1 - confidence_level) / 2
             low_index =xp.astype(bd.ppf(p), xp.int64) - 1
             valid_index = low_index >= 0
-            low_index[~valid_index] = 0
+            low_index = xpx.at(low_index)[~valid_index].set(0)
             x_low = xp.take_along_axis(x, low_index, axis=-1)
             low = xp.where(valid_index, x_low, xp.nan)
             high_index = xp.astype(bd.isf(p), xp.int64)
             valid_index = high_index < n
-            high_index[~valid_index] = 0
+            high_index = xpx.at(high_index)[~valid_index].set(0)
             x_high = xp.take_along_axis(x, high_index, axis=-1)
             high = xp.where(valid_index, x_high, xp.nan)
 
@@ -9160,7 +9160,7 @@ def quantile_test_iv(x, q, p, alternative, axis, keepdims):
 
     nan_out = ((p >= 1) | (p <= 0) | xp.isnan(p) | xp.isnan(q)
                | xp.any(xp.isnan(x), axis=-1, keepdims=True))
-    if xp.any(nan_out):
+    if is_lazy_array(nan_out) or xp.any(nan_out):
         # These get NaN-ed out at the end. In the meantime, we want them
         # to pass through calculations without warnings or errors
         q = xpx.at(q, nan_out).set(0.0, copy=True)
@@ -9172,7 +9172,7 @@ def quantile_test_iv(x, q, p, alternative, axis, keepdims):
 def _quantile_test_postprocess(res, axis, axis_none, keepdims, ndim, nan_out, xp):
     # Reshape per axis/keepdims
 
-    res[nan_out] = xp.nan
+    res = xpx.at(res)[nan_out].set(xp.nan)
 
     if axis_none and keepdims:
         shape = (1,)*(ndim - 1) + res.shape

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9083,7 +9083,7 @@ class QuantileTestResult:
             high = xp.full(shape, xp.inf)
         elif alternative == 'two-sided':
             p = (1 - confidence_level) / 2
-            low_index =xp.astype(bd.ppf(p), xp.int64) - 1
+            low_index = xp.astype(bd.ppf(p), xp.int64) - 1
             valid_index = low_index >= 0
             low_index = xpx.at(low_index)[~valid_index].set(0)
             x_low = xp.take_along_axis(x, low_index, axis=-1)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9068,14 +9068,14 @@ class QuantileTestResult:
         elif alternative == 'less':
             p = 1 - confidence_level
             low = xp.full(shape, -xp.inf)
-            high_index = bd.isf(p).astype(int)
+            high_index = xp.astype(bd.isf(p), xp.int64)
             valid_index = high_index < n
             high_index[~valid_index] = 0
             x_high = xp.take_along_axis(x, high_index, axis=-1)
             high = xp.where(valid_index, x_high, xp.nan)
         elif alternative == 'greater':
             p = 1 - confidence_level
-            low_index = (bd.ppf(p)).astype(int) - 1
+            low_index = xp.astype(bd.ppf(p), xp.int64) - 1
             valid_index = low_index >= 0
             low_index[~valid_index] = 0
             x_low = xp.take_along_axis(x, low_index, axis=-1)
@@ -9083,12 +9083,12 @@ class QuantileTestResult:
             high = xp.full(shape, xp.inf)
         elif alternative == 'two-sided':
             p = (1 - confidence_level) / 2
-            low_index = (bd.ppf(p)).astype(int) - 1
+            low_index =xp.astype(bd.ppf(p), xp.int64) - 1
             valid_index = low_index >= 0
             low_index[~valid_index] = 0
             x_low = xp.take_along_axis(x, low_index, axis=-1)
             low = xp.where(valid_index, x_low, xp.nan)
-            high_index = bd.isf(p).astype(int)
+            high_index = xp.astype(bd.isf(p), xp.int64)
             valid_index = high_index < n
             high_index[~valid_index] = 0
             x_high = xp.take_along_axis(x, high_index, axis=-1)
@@ -9183,11 +9183,11 @@ def _quantile_test_postprocess(res, axis, axis_none, keepdims, ndim, nan_out, xp
 
     if not keepdims:
         res = xp.squeeze(res, axis=axis)
-    return res[()]
+    return res[()] if res.ndim == 0 else res
 
 
-@xp_capabilities()
-def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=None):
+@xp_capabilities(skip_backends=[("dask.array", "no `take_along_axis`")])
+def quantile_test(x, *, q=0.0, p=0.5, alternative='two-sided', axis=0, keepdims=None):
     r"""
     Perform a quantile test and compute a confidence interval of the quantile.
 
@@ -9497,6 +9497,7 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
     if X.shape[-1] > 0:
         T1 = _xp_searchsorted(X, x_star, side='right', xp=xp)
         T2 = _xp_searchsorted(X, x_star, side='left', xp=xp)
+        T1, T2 = xp.astype(T1, dtype), xp.astype(T2, dtype)
     else:
         nan_out = xp.ones_like(nan_out)
         T = xp.zeros(x_star.shape, dtype=dtype)
@@ -9515,14 +9516,14 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
         # "is greater than *or equal to* the observed value of T2...using p=p*"
         pvalue = Y.sf(T2-1)  # Y.pmf(T2) + Y.sf(T2)
         statistic = xp.broadcast_to(T2, pvalue.shape)
-        statistic_type = xp.broadcast_to(2., pvalue.shape)
+        statistic_type = xp.full_like(statistic, 2.)
     # "H1: the p* population quantile is greater than x*"
     elif H1 == 'greater':
         # "The p-value is the probability that a binomial random variable Y "
         # "is less than or equal to the observed value of T1... using p = p*"
         pvalue = Y.cdf(T1)
         statistic = xp.broadcast_to(T1, pvalue.shape)
-        statistic_type = xp.broadcast_to(1., pvalue.shape)
+        statistic_type = xp.full_like(statistic, 1.)
     # "H1: x* is not the p*th population quantile"
     elif H1 == 'two-sided':
         # "The p-value is twice the smaller of the probabilities that a
@@ -9532,13 +9533,15 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
         # Note: both one-sided p-values can exceed 0.5 for the same data, so
         # `clip`
         p_min = xp.minimum(Y.cdf(T1), Y.sf(T2 - 1))
-        pvalue = xp.clip(2*p_min, 0, 1)
+        pvalue = xp.clip(2*p_min, 0., 1.)
         i2 = Y.cdf(T1) > Y.sf(T2 - 1)
         statistic = xp.where(i2, T2, T1)
-        statistic_type = xp.where(i2, 2, 1)
+        statistic_type = xp.where(i2, xp.full_like(T2, 2.), xp.full_like(T1, 1.))
 
     statistic = xp.astype(statistic, dtype)
     statistic_type = xp.astype(statistic_type, dtype)
+    pvalue = xp.astype(pvalue, dtype)
+    X = xp.astype(X, dtype)
 
     _statistic, _statistic_type, _pvalue = statistic, statistic_type, pvalue
     args = axis, axis_none, keepdims, ndim, nan_out, xp
@@ -9547,9 +9550,9 @@ def quantile_test(x, *, q=0, p=0.5, alternative='two-sided', axis=0, keepdims=No
     pvalue = _quantile_test_postprocess(pvalue, *args)
 
     return QuantileTestResult(
-        statistic=statistic[()],
-        statistic_type=statistic_type[()],
-        pvalue=pvalue[()],
+        statistic=statistic,
+        statistic_type=statistic_type,
+        pvalue=pvalue,
         _alternative=H1,
         _x=X,
         _p=p_star,

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -8795,17 +8795,18 @@ def quantile_test_reference(x, q, p, alternative):
     return res.statistic, res.pvalue, *res.confidence_interval()
 
 
+@make_xp_test_case(stats.quantile_test)
 class TestQuantileTest:
     r""" Test the non-parametric quantile test,
     including the computation of confidence intervals
     """
 
-    def test_quantile_test_iv(self):
-        x = np.asarray([1, 2, 3])
+    def test_quantile_test_iv(self, xp):
+        x = xp.asarray([1, 2, 3])
 
         message = "`x` must be an array of numbers."
         with pytest.raises(ValueError, match=message):
-            stats.quantile_test(x.astype(bool))
+            stats.quantile_test(xp.astype(x, xp.bool))
 
         message = "`q` must be a scalar or array of numbers."
         with pytest.raises(ValueError, match=message):
@@ -8816,11 +8817,11 @@ class TestQuantileTest:
             stats.quantile_test(x, p=2)
 
         # should p == 0. / p == 1. be valid?
-        p = np.asarray([-1., 0., 1., 1.5, np.nan])
+        p = xp.asarray([-1., 0., 1., 1.5, xp.nan])
         res = stats.quantile_test(x, p=p)
-        assert_equal(res.statistic, np.full_like(p, np.nan))
-        assert_equal(res.statistic_type, np.full_like(p, np.nan))
-        assert_equal(res.pvalue, np.full_like(p, np.nan))
+        xp_assert_equal(res.statistic, xp.full_like(p, xp.nan))
+        xp_assert_equal(res.statistic_type, xp.full_like(p, xp.nan))
+        xp_assert_equal(res.pvalue, xp.full_like(p, xp.nan))
 
         message = "`axis` must be an integer or None."
         with pytest.raises(ValueError, match=message):
@@ -8836,7 +8837,7 @@ class TestQuantileTest:
 
         message = ("`keepdims` may be False only if...")
         with pytest.raises(ValueError, match=message):
-            stats.quantile_test(x, p=[0.1, 0.2], keepdims=False)
+            stats.quantile_test(x, p=xp.asarray([0.1, 0.2]), keepdims=False)
 
         message = "`alternative` must be one of..."
         with pytest.raises(ValueError, match=message):
@@ -8853,7 +8854,7 @@ class TestQuantileTest:
          [0.25, 0.95, -np.inf, 1.39096812846378, 'less'],
          [0.8, 0.9, 2.117000016612675, np.inf, 'greater']]
     )
-    def test_R_ci_quantile(self, p, alpha, lb, ub, alternative):
+    def test_R_ci_quantile(self, p, alpha, lb, ub, alternative, xp):
         # Test against R library `confintr` function `ci_quantile`, e.g.
         # library(confintr)
         # options(digits=16)
@@ -8862,29 +8863,31 @@ class TestQuantileTest:
         # ci_quantile(x, q = 0.5, probs = c(0.05, 0.95))$interval
         # ci_quantile(x, q = 0.25, probs = c(0, 0.95))$interval
         # ci_quantile(x, q = 0.8, probs = c(0.1, 1))$interval
-        x = np.exp(np.arange(0, 1.01, 0.01))
+        x = xp.exp(xp.arange(0.0, 1.01, 0.01))
         res = stats.quantile_test(x, p=p, alternative=alternative)
-        assert_allclose(res.confidence_interval(alpha), [lb, ub], rtol=1e-15)
+        ci = res.confidence_interval(alpha)
+        xp_assert_close(ci.low, xp.asarray(lb))
+        xp_assert_close(ci.high, xp.asarray(ub))
 
     @pytest.mark.parametrize(
         'q, p, alternative, ref',
         [[1.2, 0.3, 'two-sided', 0.01515567517648],
          [1.8, 0.5, 'two-sided', 0.1109183496606]]
     )
-    def test_R_pvalue(self, q, p, alternative, ref):
+    def test_R_pvalue(self, q, p, alternative, ref, xp):
         # Test against R library `snpar` function `quant.test`, e.g.
         # library(snpar)
         # options(digits=16)
         # x < - exp(seq(0, 1, by=0.01))
         # quant.test(x, q=1.2, p=0.3, exact=TRUE, alternative='t')
-        x = np.exp(np.arange(0, 1.01, 0.01))
+        x = xp.exp(xp.arange(0.0, 1.01, 0.01))
         res = stats.quantile_test(x, q=q, p=p, alternative=alternative)
-        assert_allclose(res.pvalue, ref, rtol=1e-12)
+        xp_assert_close(res.pvalue, xp.asarray(ref))
 
     @pytest.mark.parametrize('case', ['continuous', 'discrete'])
     @pytest.mark.parametrize('alternative', ['less', 'greater'])
     @pytest.mark.parametrize('alpha', [0.9, 0.95])
-    def test_pval_ci_match(self, case, alternative, alpha):
+    def test_pval_ci_match(self, case, alternative, alpha, xp):
         # Verify that the following statement holds:
 
         # The 95% confidence interval corresponding with alternative='less'
@@ -8905,14 +8908,15 @@ class TestQuantileTest:
             p = rng.random()
             q = rng.integers(1, 11)
 
+        rvs, p, q = xp.asarray(rvs.tolist()), float(p), float(q)
         res = stats.quantile_test(rvs, q=q, p=p, alternative=alternative)
         ci = res.confidence_interval(confidence_level=alpha)
 
         # select elements inside the confidence interval based on alternative
         if alternative == 'less':
-            i_inside = rvs <= ci.high
+            i_inside = xp.astype(rvs, ci.high.dtype) <= ci.high
         else:
-            i_inside = rvs >= ci.low
+            i_inside = xp.astype(rvs, ci.low.dtype) >= ci.low
 
         for x in rvs[i_inside]:
             res = stats.quantile_test(rvs, q=x, p=p, alternative=alternative)
@@ -8922,7 +8926,8 @@ class TestQuantileTest:
             res = stats.quantile_test(rvs, q=x, p=p, alternative=alternative)
             assert res.pvalue < 1 - alpha
 
-    def test_match_conover_examples(self):
+    @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
+    def test_match_conover_examples(self, dtype, xp):
         # Test against the examples in [1] (Conover Practical Nonparametric
         # Statistics Third Edition) pg 139
 
@@ -8933,11 +8938,12 @@ class TestQuantileTest:
         # (q=193). Conover shows that 7 of the observations are less than or
         # equal to 193, and "for the binomial random variable Y, P(Y<=7) =
         # 0.0173", so the two-sided p-value is twice that, 0.0346.
-        x = [189, 233, 195, 160, 212, 176, 231, 185, 199, 213, 202, 193,
-             174, 166, 248]
-        pvalue_expected = 0.0346
+        dtype = xp_default_dtype(xp) if dtype is None else getattr(xp, dtype)
+        x = xp.asarray([189, 233, 195, 160, 212, 176, 231, 185,
+                        199, 213, 202, 193, 174, 166, 248], dtype=dtype)
+        pvalue_ref = 0.0346
         res = stats.quantile_test(x, q=193, p=0.75, alternative='two-sided')
-        assert_allclose(res.pvalue, pvalue_expected, rtol=1e-5)
+        xp_assert_close(res.pvalue, xp.asarray(pvalue_ref, dtype=dtype), rtol=1e-5)
 
         # Example 2
         # Conover doesn't give explicit data, just that 8 out of 112
@@ -8947,18 +8953,21 @@ class TestQuantileTest:
         # distributed random variable, now with p=0.5 and n=112. Conover uses a
         # normal approximation, but we can easily calculate the CDF of the
         # binomial distribution.
-        x = [59]*8 + [61]*(112-8)
-        pvalue_expected = stats.binom(p=0.5, n=112).pmf(k=8)
+        x = xp.asarray([59]*8 + [61]*(112-8), dtype=dtype)
+        pvalue_ref = float(stats.binom(p=0.5, n=112).pmf(k=8))
         res = stats.quantile_test(x, q=60, p=0.5, alternative='greater')
-        assert_allclose(res.pvalue, pvalue_expected, atol=1e-10)
+        xp_assert_close(res.pvalue, xp.asarray(pvalue_ref, dtype=dtype), atol=1e-10)
 
+    @skip_xp_backends('array_api_strict', reason='indexing in _apply_over_batch')
     @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
     @pytest.mark.parametrize('axis', [0, 1])
-    def test_multidimensional(self, alternative, axis):
+    def test_multidimensional(self, alternative, axis, xp):
         rng = np.random.default_rng(85468924398205602)
         x = rng.random(size=(2, 20))
         p = rng.random(size=(1, 3,))
         q = p + rng.random(size=(2, 1))*0.01
+
+        x, p, q = (xp.asarray(arr.tolist()) for arr in (x, p, q))
 
         ref = quantile_test_reference(x, q, p, alternative=alternative)
         ref_statistic, ref_pvalue, ref_low, ref_high = ref
@@ -8972,12 +8981,12 @@ class TestQuantileTest:
             res_statistic, res_pvalue = res_statistic.T, res_pvalue.T
             res_low, res_high = res_low.T, res_high.T
 
-        assert_allclose(res_statistic, ref_statistic)
-        assert_allclose(res_pvalue, ref_pvalue)
-        assert_allclose(res_low, res_low)
-        assert_allclose(res_low, ref_low)
+        xp_assert_close(res_statistic, ref_statistic)
+        xp_assert_close(res_pvalue, ref_pvalue)
+        xp_assert_close(res_low, res_low)
+        xp_assert_close(res_low, ref_low)
 
-    def test_zero_size(self):
+    def test_zero_size(self, xp):
         rng = np.random.default_rng(883771738488451943)
         x_shape = (2, 50)
         qp_shape = (2, 10)
@@ -8985,136 +8994,138 @@ class TestQuantileTest:
         q = rng.random(qp_shape)
         p = q + rng.random(qp_shape) * 1e-2
 
+        x, p, q = (xp.asarray(arr.tolist()) for arr in (x, p, q))
+
         # case 1: p/q is size zero.
-        qp_zero = np.empty((0, *qp_shape))
+        qp_zero = xp.empty((0, *qp_shape))
         out = qp_zero
         res = stats.quantile_test(x, q=qp_zero, p=qp_zero, axis=-1)
         ci = res.confidence_interval()
         # different default int on different platforms
-        xp_assert_equal(res.statistic, np.asarray(out), check_dtype=False)
-        xp_assert_equal(res.statistic_type, np.asarray(out), check_dtype=False)
-        # assert np.isdtype(res.statistic.dtype, "integral")
-        # assert np.isdtype(res.statistic_type.dtype, "integral")
+        xp_assert_equal(res.statistic, xp.asarray(out))
+        xp_assert_equal(res.statistic_type, xp.asarray(out))
         xp_assert_equal(res.pvalue, out)
         xp_assert_equal(ci.low, out)
         xp_assert_equal(ci.high, out)
 
         # case 2: x is size zero with nonzero length along axis.
-        x_zero = np.empty((0, *x_shape))
-        out = np.empty((0, *qp_shape))
+        x_zero = xp.empty((0, *x_shape))
+        out = xp.empty((0, *qp_shape))
         res = stats.quantile_test(x_zero, q=q, p=p, axis=-1)
         ci = res.confidence_interval()
         # different default int on different platforms
-        xp_assert_equal(res.statistic, np.asarray(out), check_dtype=False)
-        xp_assert_equal(res.statistic_type, np.asarray(out), check_dtype=False)
-        # assert np.isdtype(res.statistic.dtype, "integral")
-        # assert np.isdtype(res.statistic_type.dtype, "integral")
+        xp_assert_equal(res.statistic, xp.asarray(out))
+        xp_assert_equal(res.statistic_type, xp.asarray(out))
         xp_assert_equal(res.pvalue, out)
         xp_assert_equal(ci.low, out)
         xp_assert_equal(ci.high, out)
 
         # case 3: x has zero length along axis.
-        x_zero = np.empty((x.shape[0], 0))
-        out = -np.ones(qp_shape, dtype=np.int64)*np.nan
+        x_zero = xp.empty((x.shape[0], 0))
+        out = xp.full(qp_shape, xp.nan)
         res = stats.quantile_test(x_zero, q=q, p=p, axis=-1)
         ci = res.confidence_interval()
         # different default int on different platforms
-        xp_assert_equal(res.statistic, np.asarray(out), check_dtype=False)
-        xp_assert_equal(res.statistic_type, np.asarray(out), check_dtype=False)
-        # assert np.isdtype(res.statistic.dtype, "integral")
-        # assert np.isdtype(res.statistic_type.dtype, "integral")
-        xp_assert_equal(res.pvalue, out*np.nan)
-        xp_assert_equal(ci.low, out*np.nan)
-        xp_assert_equal(ci.high, out*np.nan)
+        xp_assert_equal(res.statistic, out)
+        xp_assert_equal(res.statistic_type, out)
+        xp_assert_equal(res.pvalue, out)
+        xp_assert_equal(ci.low, out)
+        xp_assert_equal(ci.high, out)
 
-    def test_nans(self):
+    def test_nans(self, xp):
         rng = np.random.default_rng(2920028761208905)
         x = rng.random((10, 50))
         q = rng.random((10, 10))
         p = q + rng.random((10, 10)) * 1e-2
+        x, p, q = (xp.asarray(arr.tolist()) for arr in (x, p, q))
+
         ref = stats.quantile_test(x, q=q, p=p, axis=-1)
         ref_low, ref_high = ref.confidence_interval()
 
-        x_ = x.copy()
-        i_nan = rng.random(x.shape) < 0.01
-        x_[i_nan] = np.nan
-        i_nan_out = np.any(i_nan, axis=-1)
-        assert not np.all(i_nan_out)
+        x_ = xp_copy(x)
+        i_nan = xp.asarray(rng.random(x.shape) < 0.01)
+        x_[i_nan] = xp.nan
+        i_nan_out = xp.any(i_nan, axis=-1)
+        assert not xp.all(i_nan_out)
         res = stats.quantile_test(x_, q=q, p=p, axis=-1)
         res_low, res_high = res.confidence_interval()
-        assert_equal(res.statistic[i_nan_out], np.nan)
-        assert_equal(res.statistic_type[i_nan_out], np.nan)
-        assert_equal(res.pvalue[i_nan_out], np.nan)
-        assert_equal(res_low[i_nan_out], np.nan)
-        assert_equal(res_high[i_nan_out], np.nan)
-        assert_equal(res.statistic[~i_nan_out], ref.statistic[~i_nan_out])
-        assert_equal(res.statistic_type[~i_nan_out], ref.statistic_type[~i_nan_out])
-        assert_equal(res.pvalue[~i_nan_out], ref.pvalue[~i_nan_out])
-        assert_equal(res_low[~i_nan_out], ref_low[~i_nan_out])
-        assert_equal(res_high[~i_nan_out], ref_high[~i_nan_out])
 
-        i_nan_q = rng.random(q.shape) < 0.01
-        i_nan_p = rng.random(p.shape) < 0.01
-        assert np.any(i_nan_q)
-        assert np.any(i_nan_p)
-        q[i_nan_q] = np.nan
-        p[i_nan_p] = np.nan
+        assert xp.all(xp.isnan(res.statistic[i_nan_out]))
+        assert xp.all(xp.isnan(res.statistic_type[i_nan_out]))
+        assert xp.all(xp.isnan(res.pvalue[i_nan_out]))
+        assert xp.all(xp.isnan(res_low[i_nan_out]))
+        assert xp.all(xp.isnan(res_high[i_nan_out]))
+        xp_assert_equal(res.statistic[~i_nan_out], ref.statistic[~i_nan_out])
+        xp_assert_equal(res.statistic_type[~i_nan_out], ref.statistic_type[~i_nan_out])
+        xp_assert_equal(res.pvalue[~i_nan_out], ref.pvalue[~i_nan_out])
+        xp_assert_equal(res_low[~i_nan_out], ref_low[~i_nan_out])
+        xp_assert_equal(res_high[~i_nan_out], ref_high[~i_nan_out])
 
-        i_nan_out = i_nan_q | i_nan_p
-        assert not np.all(i_nan_out)
+        i_nan_q = xp.asarray(rng.random(q.shape) < 0.01)
+        i_nan_p = xp.asarray(rng.random(p.shape) < 0.01)
+        assert xp.any(i_nan_q)
+        assert xp.any(i_nan_p)
+        q[xp.broadcast_to(i_nan_q, q.shape)] = xp.nan
+        p[xp.broadcast_to(i_nan_p, p.shape)] = xp.nan
+
+        i_nan_out = xp.asarray(i_nan_q | i_nan_p)
+        assert not xp.all(i_nan_out)
 
         res = stats.quantile_test(x, q=q, p=p, axis=-1)
         res_low, res_high = res.confidence_interval()
-        assert_equal(res.statistic[i_nan_out], np.nan)
-        assert_equal(res.statistic_type[i_nan_out], np.nan)
-        assert_equal(res.pvalue[i_nan_out], np.nan)
-        assert_equal(res_low[i_nan_out], np.nan)
-        assert_equal(res_high[i_nan_out], np.nan)
-        assert_equal(res.statistic[~i_nan_out], ref.statistic[~i_nan_out])
-        assert_equal(res.statistic_type[~i_nan_out], ref.statistic_type[~i_nan_out])
-        assert_equal(res.pvalue[~i_nan_out], ref.pvalue[~i_nan_out])
-        assert_equal(res_low[~i_nan_out], ref_low[~i_nan_out])
-        assert_equal(res_high[~i_nan_out], ref_high[~i_nan_out])
+        assert xp.all(xp.isnan(res.statistic[i_nan_out]))
+        assert xp.all(xp.isnan(res.statistic_type[i_nan_out]))
+        assert xp.all(xp.isnan(res.pvalue[i_nan_out]))
+        assert xp.all(xp.isnan(res_low[i_nan_out]))
+        assert xp.all(xp.isnan(res_high[i_nan_out]))
+        xp_assert_equal(res.statistic[~i_nan_out], ref.statistic[~i_nan_out])
+        xp_assert_equal(res.statistic_type[~i_nan_out], ref.statistic_type[~i_nan_out])
+        xp_assert_equal(res.pvalue[~i_nan_out], ref.pvalue[~i_nan_out])
+        xp_assert_equal(res_low[~i_nan_out], ref_low[~i_nan_out])
+        xp_assert_equal(res_high[~i_nan_out], ref_high[~i_nan_out])
 
-    def test_axis_none(self):
+    def test_axis_none(self, xp):
         rng = np.random.default_rng(883771738488451943)
         x_shape = (2, 50)
         qp_shape = (2, 10)
         x = rng.random(x_shape)
         q = rng.random(qp_shape)
         p = q + rng.random(qp_shape) * 1e-2
+        x, p, q = (xp.asarray(arr.tolist()) for arr in (x, p, q))
 
         res = stats.quantile_test(x, q=q, p=p, axis=None)
         res_low, res_high = res.confidence_interval()
-        ref = stats.quantile_test(np.ravel(x), q=np.ravel(q), p=np.ravel(p), axis=None)
+        ref = stats.quantile_test(xp_ravel(x), q=xp_ravel(q), p=xp_ravel(p), axis=None)
         ref_low, ref_high = ref.confidence_interval()
-        assert_equal(res.statistic, ref.statistic[np.newaxis, :])
-        assert_equal(res.statistic_type, ref.statistic_type[np.newaxis, :])
-        assert_equal(res.pvalue, ref.pvalue[np.newaxis, :])
-        assert_equal(res_low, ref_low[np.newaxis, :])
-        assert_equal(res_high, ref_high[np.newaxis, :])
+        xp_assert_equal(res.statistic, ref.statistic[xp.newaxis, :])
+        xp_assert_equal(res.statistic_type, ref.statistic_type[xp.newaxis, :])
+        xp_assert_equal(res.pvalue, ref.pvalue[xp.newaxis, :])
+        xp_assert_equal(res_low, ref_low[xp.newaxis, :])
+        xp_assert_equal(res_high, ref_high[xp.newaxis, :])
 
         res = stats.quantile_test(x, q=0.5, p=0.5, axis=None)
         res_low, res_high = res.confidence_interval()
-        ref = stats.quantile_test(np.ravel(x), q=0.5, p=0.5, axis=None)
+        ref = stats.quantile_test(xp_ravel(x), q=0.5, p=0.5, axis=None)
         ref_low, ref_high = ref.confidence_interval()
-        assert_equal(res.statistic, ref.statistic)
-        assert_equal(res.statistic_type, ref.statistic_type)
-        assert_equal(res.pvalue, ref.pvalue)
-        assert_equal(res_low, ref_low)
-        assert_equal(res_high, ref_high)
+        xp_assert_equal(res.statistic, ref.statistic)
+        xp_assert_equal(res.statistic_type, ref.statistic_type)
+        xp_assert_equal(res.pvalue, ref.pvalue)
+        xp_assert_equal(res_low, ref_low)
+        xp_assert_equal(res_high, ref_high)
 
+    @pytest.mark.filterwarnings("ignore:torch.searchsorted(): boundary:UserWarning")
     @pytest.mark.parametrize("x_shape, qp_shape, axis, keepdims, res_shape", [
         ((1, 3), (1,), None, False, ()),
         ((1, 3), (1,), None, True, (1, 1)),
         ((1, 3), (2, 1), -1, False, (2,)),
         ((1, 3), (2, 1), -1, True, (2, 1)),
     ])
-    def test_keepdims(self, x_shape, qp_shape, axis, keepdims, res_shape):
+    def test_keepdims(self, x_shape, qp_shape, axis, keepdims, res_shape, xp):
         rng = np.random.default_rng(883771738488451943)
-        x, qp = rng.random(x_shape), rng.random(qp_shape)
+        x, qp = xp.asarray(rng.random(x_shape)), xp.asarray(rng.random(qp_shape))
         res = stats.quantile_test(x, q=qp, p=qp, axis=axis, keepdims=keepdims)
         assert res.statistic.shape == res_shape
+
 
 class TestPageTrendTest:
     def setup_method(self):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -9113,7 +9113,7 @@ class TestQuantileTest:
         xp_assert_equal(res_low, ref_low)
         xp_assert_equal(res_high, ref_high)
 
-    @pytest.mark.filterwarnings("ignore:torch.searchsorted(): boundary:UserWarning")
+    @pytest.mark.filterwarnings("ignore:torch:UserWarning")
     @pytest.mark.parametrize("x_shape, qp_shape, axis, keepdims, res_shape", [
         ((1, 3), (1,), None, False, ()),
         ((1, 3), (1,), None, True, (1, 1)),

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -8818,8 +8818,8 @@ class TestQuantileTest:
         # should p == 0. / p == 1. be valid?
         p = np.asarray([-1., 0., 1., 1.5, np.nan])
         res = stats.quantile_test(x, p=p)
-        assert_equal(res.statistic, np.full_like(p, -1, dtype=int))
-        assert_equal(res.statistic_type, np.full_like(p, -1, dtype=int))
+        assert_equal(res.statistic, np.full_like(p, np.nan))
+        assert_equal(res.statistic_type, np.full_like(p, np.nan))
         assert_equal(res.pvalue, np.full_like(p, np.nan))
 
         message = "`axis` must be an integer or None."
@@ -8993,8 +8993,8 @@ class TestQuantileTest:
         # different default int on different platforms
         xp_assert_equal(res.statistic, np.asarray(out), check_dtype=False)
         xp_assert_equal(res.statistic_type, np.asarray(out), check_dtype=False)
-        assert np.isdtype(res.statistic.dtype, "integral")
-        assert np.isdtype(res.statistic_type.dtype, "integral")
+        # assert np.isdtype(res.statistic.dtype, "integral")
+        # assert np.isdtype(res.statistic_type.dtype, "integral")
         xp_assert_equal(res.pvalue, out)
         xp_assert_equal(ci.low, out)
         xp_assert_equal(ci.high, out)
@@ -9007,22 +9007,22 @@ class TestQuantileTest:
         # different default int on different platforms
         xp_assert_equal(res.statistic, np.asarray(out), check_dtype=False)
         xp_assert_equal(res.statistic_type, np.asarray(out), check_dtype=False)
-        assert np.isdtype(res.statistic.dtype, "integral")
-        assert np.isdtype(res.statistic_type.dtype, "integral")
+        # assert np.isdtype(res.statistic.dtype, "integral")
+        # assert np.isdtype(res.statistic_type.dtype, "integral")
         xp_assert_equal(res.pvalue, out)
         xp_assert_equal(ci.low, out)
         xp_assert_equal(ci.high, out)
 
         # case 3: x has zero length along axis.
         x_zero = np.empty((x.shape[0], 0))
-        out = -np.ones(qp_shape, dtype=np.int64)
+        out = -np.ones(qp_shape, dtype=np.int64)*np.nan
         res = stats.quantile_test(x_zero, q=q, p=p, axis=-1)
         ci = res.confidence_interval()
         # different default int on different platforms
         xp_assert_equal(res.statistic, np.asarray(out), check_dtype=False)
         xp_assert_equal(res.statistic_type, np.asarray(out), check_dtype=False)
-        assert np.isdtype(res.statistic.dtype, "integral")
-        assert np.isdtype(res.statistic_type.dtype, "integral")
+        # assert np.isdtype(res.statistic.dtype, "integral")
+        # assert np.isdtype(res.statistic_type.dtype, "integral")
         xp_assert_equal(res.pvalue, out*np.nan)
         xp_assert_equal(ci.low, out*np.nan)
         xp_assert_equal(ci.high, out*np.nan)
@@ -9042,8 +9042,8 @@ class TestQuantileTest:
         assert not np.all(i_nan_out)
         res = stats.quantile_test(x_, q=q, p=p, axis=-1)
         res_low, res_high = res.confidence_interval()
-        assert_equal(res.statistic[i_nan_out], -1)
-        assert_equal(res.statistic_type[i_nan_out], -1)
+        assert_equal(res.statistic[i_nan_out], np.nan)
+        assert_equal(res.statistic_type[i_nan_out], np.nan)
         assert_equal(res.pvalue[i_nan_out], np.nan)
         assert_equal(res_low[i_nan_out], np.nan)
         assert_equal(res_high[i_nan_out], np.nan)
@@ -9065,8 +9065,8 @@ class TestQuantileTest:
 
         res = stats.quantile_test(x, q=q, p=p, axis=-1)
         res_low, res_high = res.confidence_interval()
-        assert_equal(res.statistic[i_nan_out], -1)
-        assert_equal(res.statistic_type[i_nan_out], -1)
+        assert_equal(res.statistic[i_nan_out], np.nan)
+        assert_equal(res.statistic_type[i_nan_out], np.nan)
         assert_equal(res.pvalue[i_nan_out], np.nan)
         assert_equal(res_low[i_nan_out], np.nan)
         assert_equal(res_high[i_nan_out], np.nan)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -9044,7 +9044,7 @@ class TestQuantileTest:
 
         x_ = xp_copy(x)
         i_nan = xp.asarray(rng.random(x.shape) < 0.01)
-        x_[i_nan] = xp.nan
+        x_ = xpx.at(x_)[i_nan].set(xp.nan)
         i_nan_out = xp.any(i_nan, axis=-1)
         assert not xp.all(i_nan_out)
         res = stats.quantile_test(x_, q=q, p=p, axis=-1)
@@ -9065,8 +9065,8 @@ class TestQuantileTest:
         i_nan_p = xp.asarray(rng.random(p.shape) < 0.01)
         assert xp.any(i_nan_q)
         assert xp.any(i_nan_p)
-        q[xp.broadcast_to(i_nan_q, q.shape)] = xp.nan
-        p[xp.broadcast_to(i_nan_p, p.shape)] = xp.nan
+        q = xpx.at(q)[xp.broadcast_to(i_nan_q, q.shape)].set(xp.nan)
+        p = xpx.at(p)[xp.broadcast_to(i_nan_p, p.shape)].set(xp.nan)
 
         i_nan_out = xp.asarray(i_nan_q | i_nan_p)
         assert not xp.all(i_nan_out)


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
Adds array API support to `stats.quantile_test`. Turned out quite clean / simple.

#### Additional information
Also converts `statistic` and `statistic_type` to floating point as discussed in gh-23972. Will need a forum post due to mild backward incompatibility.

#### AI Generation Disclosure
No AI