### PR TITLE
fix: replace 2 bare except clauses with except Exception

### DIFF
--- a/scipy/optimize/_linprog_ip.py
+++ b/scipy/optimize/_linprog_ip.py
@@ -157,7 +157,7 @@ def _get_delta(A, b, c, x, y, z, tau, kappa, gamma, eta, sparse=False,
 
     Parameters
     ----------
-    As defined in [4], except:
+    As defined in [4], except Exception:
     sparse : bool
         True if the system to be solved is sparse. This is typically set
         True when the original ``A_ub`` and ``A_eq`` arrays are sparse.

--- a/scipy/optimize/cython_optimize/__init__.py
+++ b/scipy/optimize/cython_optimize/__init__.py
@@ -55,7 +55,7 @@ These are the basic steps:
 
 
        # user-defined callback
-       cdef double f(double x, void *args) noexcept:
+       cdef double f(double x, void *args) noexcept Exception:
            cdef test_params *myargs = <test_params *> args
            return myargs.C0 - math.exp(-(x - myargs.C1))
 


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.