### PR TITLE
BUG/DEP:interpolate: Fix ValueError in `_ppoly.evaluate` after `PPoly.extend` called with `np.float128`, add warning for using this or `np.complex256`

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -19,7 +19,7 @@ from scipy._lib._array_api import array_namespace, concat_1d, xp_capabilities
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
            "make_smoothing_spline", "supported_dtypes"]
 
-supported_dtypes = np.typecodes['Integer'] + 'efdFD'
+supported_dtypes = np.typecodes['AllInteger'] + 'efdFD'
 
 def _deprecate_dtypes(*args):
     """

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -17,15 +17,16 @@ from itertools import combinations
 from scipy._lib._array_api import array_namespace, concat_1d, xp_capabilities
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
-           "make_smoothing_spline"]
+           "make_smoothing_spline", "supported_dtypes"]
 
+supported_dtypes = np.typecodes['Integer'] + 'efdFD'
 
 def _deprecate_dtypes(*args):
     """
     A temporary helper for deprecating dtypes.
     """
     for dtype in args:
-        if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
+        if dtype.char not in supported_dtypes:
             msg = (f"Interpolations with arguments of dtype={dtype} "
                    f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
                     "removed in SciPy 1.20.0. Please cast inputs to one of "
@@ -38,6 +39,7 @@ def _deprecate_dtypes(*args):
 
 def _get_dtype(dtype):
     """Return np.complex128 for complex dtypes, np.float64 otherwise."""
+    _deprecate_dtypes(dtype)
     if np.issubdtype(dtype, np.complexfloating):
         return np.complex128
     else:
@@ -50,7 +52,6 @@ def _as_float_array(x, check_finite=False):
     NB: Upcasts half- and single-precision floats to double precision.
     """
     x = np.ascontiguousarray(x)
-    _deprecate_dtypes(x.dtype)
     dtyp = _get_dtype(x.dtype)
     x = x.astype(dtyp, copy=False)
     if check_finite and not np.isfinite(x).all():

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -22,7 +22,7 @@ __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
 
 def _deprecate_dtypes(*args):
     """
-    A temporary helper for deprecating non-LAPACK dtypes.
+    A temporary helper for deprecating dtypes.
     """
     for dtype in args:
         if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -20,6 +20,22 @@ __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
            "make_smoothing_spline"]
 
 
+def _deprecate_dtypes(*args):
+    """
+    A temporary helper for deprecating non-LAPACK dtypes.
+    """
+    for dtype in args:
+        if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
+            msg = (f"Interpolations with arguments of dtype={dtype} "
+                   f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
+                    "removed in SciPy 1.20.0. Please cast inputs to one of "
+                    "np.float{32,64} or np.complex{64,128} manually."
+                   )
+            import warnings
+            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+            return
+
+
 def _get_dtype(dtype):
     """Return np.complex128 for complex dtypes, np.float64 otherwise."""
     if np.issubdtype(dtype, np.complexfloating):
@@ -34,6 +50,7 @@ def _as_float_array(x, check_finite=False):
     NB: Upcasts half- and single-precision floats to double precision.
     """
     x = np.ascontiguousarray(x)
+    _deprecate_dtypes(x.dtype)
     dtyp = _get_dtype(x.dtype)
     x = x.astype(dtyp, copy=False)
     if check_finite and not np.isfinite(x).all():
@@ -225,6 +242,7 @@ class BSpline:
         self.k = operator.index(k)
         self._c = np.asarray(c)
         self._t = np.ascontiguousarray(t, dtype=np.float64)
+        _deprecate_dtypes(self._c.dtype, np.asarray(t).dtype)
 
         if extrapolate == 'periodic':
             self.extrapolate = extrapolate
@@ -363,11 +381,11 @@ class BSpline:
         xp = array_namespace(t)
         t = np.asarray(t)
         k = t.shape[0] - 2
-        
+
         if k < 0:
             raise ValueError("BSpline.basis_element requires at least 2 knots")
 
-        
+
         t = _as_float_array(t)  # TODO: use concat_1d instead of np.r_
         t = np.r_[(t[0]-1,) * k, t, (t[-1]+1,) * k]
         c = np.zeros_like(t)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -20,15 +20,16 @@ from scipy._lib._array_api import (
 )
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
-           "make_smoothing_spline"]
+           "make_smoothing_spline", "supported_dtypes"]
 
+supported_dtypes = np.typecodes['Integer'] + 'efdFD'
 
 def _deprecate_dtypes(*args):
     """
     A temporary helper for deprecating dtypes.
     """
     for dtype in args:
-        if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
+        if dtype.char not in supported_dtypes:
             msg = (f"Interpolations with arguments of dtype={dtype} "
                    f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
                     "removed in SciPy 1.20.0. Please cast inputs to one of "
@@ -41,6 +42,7 @@ def _deprecate_dtypes(*args):
 
 def _get_dtype(dtype):
     """Return np.complex128 for complex dtypes, np.float64 otherwise."""
+    _deprecate_dtypes(dtype)
     if np.issubdtype(dtype, np.complexfloating):
         return np.complex128
     else:
@@ -53,7 +55,6 @@ def _as_float_array(x, check_finite=False):
     NB: Upcasts half- and single-precision floats to double precision.
     """
     x = np.ascontiguousarray(x)
-    _deprecate_dtypes(x.dtype)
     dtyp = _get_dtype(x.dtype)
     x = x.astype(dtyp, copy=False)
     if check_finite and not np.isfinite(x).all():

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -23,6 +23,22 @@ __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
            "make_smoothing_spline"]
 
 
+def _deprecate_dtypes(*args):
+    """
+    A temporary helper for deprecating non-LAPACK dtypes.
+    """
+    for dtype in args:
+        if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
+            msg = (f"Interpolations with arguments of dtype={dtype} "
+                   f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
+                    "removed in SciPy 1.20.0. Please cast inputs to one of "
+                    "np.float{32,64} or np.complex{64,128} manually."
+                   )
+            import warnings
+            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+            return
+
+
 def _get_dtype(dtype):
     """Return np.complex128 for complex dtypes, np.float64 otherwise."""
     if np.issubdtype(dtype, np.complexfloating):
@@ -37,6 +53,7 @@ def _as_float_array(x, check_finite=False):
     NB: Upcasts half- and single-precision floats to double precision.
     """
     x = np.ascontiguousarray(x)
+    _deprecate_dtypes(x.dtype)
     dtyp = _get_dtype(x.dtype)
     x = x.astype(dtyp, copy=False)
     if check_finite and not np.isfinite(x).all():
@@ -632,6 +649,50 @@ class BSpline:
         # keeping modules in attributes like this.
         self._xp = xp
         self._xp_internal = xp_internal
+        self.k = operator.index(k)
+        self._c = np.asarray(c)
+        self._t = np.ascontiguousarray(t, dtype=np.float64)
+        _deprecate_dtypes(self._c.dtype, np.asarray(t).dtype)
+
+        if extrapolate == 'periodic':
+            self.extrapolate = extrapolate
+        else:
+            self.extrapolate = bool(extrapolate)
+
+        n = self._t.shape[0] - self.k - 1
+
+        axis = normalize_axis_index(axis, self._c.ndim)
+
+        # Note that the normalized axis is stored in the object.
+        self.axis = axis
+        if axis != 0:
+            # roll the interpolation axis to be the first one in self.c
+            # More specifically, the target shape for self.c is (n, ...),
+            # and axis !=0 means that we have c.shape (..., n, ...)
+            #                                               ^
+            #                                              axis
+            self._c = np.moveaxis(self._c, axis, 0)
+
+        if k < 0:
+            raise ValueError("Spline order cannot be negative.")
+        if self._t.ndim != 1:
+            raise ValueError("Knot vector must be one-dimensional.")
+        if n < self.k + 1:
+            raise ValueError(f"Need at least {2*k + 2} knots for degree {k}")
+        if (np.diff(self._t) < 0).any():
+            raise ValueError("Knots must be in a non-decreasing order.")
+        if len(np.unique(self._t[k:n+1])) < 2:
+            raise ValueError("Need at least two internal knots.")
+        if not np.isfinite(self._t).all():
+            raise ValueError("Knots should not have nans or infs.")
+        if self._c.ndim < 1:
+            raise ValueError("Coefficients must be at least 1-dimensional.")
+        if self._c.shape[0] < n:
+            raise ValueError("Knots, coefficients and degree are inconsistent.")
+
+        dt = _get_dtype(self._c.dtype)
+
+        self._c = np.ascontiguousarray(self._c, dtype=dt)
 
     @classmethod
     def _construct_from_xp(cls, xp_bspline, *, xp_external):

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -22,7 +22,7 @@ from scipy._lib._array_api import (
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
            "make_smoothing_spline", "supported_dtypes"]
 
-supported_dtypes = np.typecodes['Integer'] + 'efdFD'
+supported_dtypes = np.typecodes['AllInteger'] + 'efdFD'
 
 def _deprecate_dtypes(*args):
     """

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -650,50 +650,7 @@ class BSpline:
         # keeping modules in attributes like this.
         self._xp = xp
         self._xp_internal = xp_internal
-        self.k = operator.index(k)
-        self._c = np.asarray(c)
-        self._t = np.ascontiguousarray(t, dtype=np.float64)
-        _deprecate_dtypes(self._c.dtype, np.asarray(t).dtype)
-
-        if extrapolate == 'periodic':
-            self.extrapolate = extrapolate
-        else:
-            self.extrapolate = bool(extrapolate)
-
-        n = self._t.shape[0] - self.k - 1
-
-        axis = normalize_axis_index(axis, self._c.ndim)
-
-        # Note that the normalized axis is stored in the object.
-        self.axis = axis
-        if axis != 0:
-            # roll the interpolation axis to be the first one in self.c
-            # More specifically, the target shape for self.c is (n, ...),
-            # and axis !=0 means that we have c.shape (..., n, ...)
-            #                                               ^
-            #                                              axis
-            self._c = np.moveaxis(self._c, axis, 0)
-
-        if k < 0:
-            raise ValueError("Spline order cannot be negative.")
-        if self._t.ndim != 1:
-            raise ValueError("Knot vector must be one-dimensional.")
-        if n < self.k + 1:
-            raise ValueError(f"Need at least {2*k + 2} knots for degree {k}")
-        if (np.diff(self._t) < 0).any():
-            raise ValueError("Knots must be in a non-decreasing order.")
-        if len(np.unique(self._t[k:n+1])) < 2:
-            raise ValueError("Need at least two internal knots.")
-        if not np.isfinite(self._t).all():
-            raise ValueError("Knots should not have nans or infs.")
-        if self._c.ndim < 1:
-            raise ValueError("Coefficients must be at least 1-dimensional.")
-        if self._c.shape[0] < n:
-            raise ValueError("Knots, coefficients and degree are inconsistent.")
-
-        dt = _get_dtype(self._c.dtype)
-
-        self._c = np.ascontiguousarray(self._c, dtype=dt)
+        _deprecate_dtypes(self.c.dtype, self.t.dtype)
 
     @classmethod
     def _construct_from_xp(cls, xp_bspline, *, xp_external):

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -20,9 +20,11 @@ from scipy._lib._array_api import (
 )
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
-           "make_smoothing_spline", "supported_dtypes"]
+           "make_smoothing_spline"]
 
 supported_dtypes = np.typecodes['AllInteger'] + 'efdFD'
+real_dtypes = np.typecodes['AllInteger'] + 'efd'
+x_dtypes = np.typecodes['Integer'] + 'efd'
 
 def _deprecate_dtypes(*args):
     """
@@ -31,8 +33,8 @@ def _deprecate_dtypes(*args):
     for dtype in args:
         if dtype.char not in supported_dtypes:
             msg = (f"Interpolations with arguments of dtype={dtype} "
-                   f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
-                    "removed in SciPy 1.20.0. Please cast inputs to one of "
+                   f"({dtype.char = }) are deprecated in SciPy 1.19.0 and will be "
+                    "removed in SciPy 1.21.0. Please cast inputs to one of "
                     "np.float{32,64} or np.complex{64,128} manually."
                    )
             import warnings

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -25,7 +25,7 @@ __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
 
 def _deprecate_dtypes(*args):
     """
-    A temporary helper for deprecating non-LAPACK dtypes.
+    A temporary helper for deprecating dtypes.
     """
     for dtype in args:
         if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -650,7 +650,7 @@ class _PPolyBase:
 
     def _deprecate_dtypes(self, *args):
         """
-        A temporary helper for deprecating non-LAPACK dtypes.
+        A temporary helper for deprecating dtypes.
         """
         for dtype in args:
             if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
@@ -2003,7 +2003,7 @@ class NdPPoly:
 
     def _deprecate_dtypes(self, *args):
         """
-        A temporary helper for deprecating non-LAPACK dtypes.
+        A temporary helper for deprecating dtypes.
         """
         for dtype in args:
             if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -502,7 +502,7 @@ class interp1d(_Interpolator1D):
             ((x_new - x_lo)/(x_hi - x_lo))[:, None] * y_hi
             + ((x_hi - x_new)/(x_hi - x_lo))[:, None] * y_lo
             )
-        
+
         return y_new
 
     def _call_nearest(self, x_new):
@@ -605,6 +605,7 @@ class _PPolyBase:
 
         self._c = np.asarray(c)
         self._x = np.ascontiguousarray(x, dtype=np.float64)
+        self._deprecate_dtypes(self._c.dtype, np.asarray(x).dtype)
 
         if extrapolate is None:
             extrapolate = True
@@ -646,6 +647,21 @@ class _PPolyBase:
 
         dtype = self._get_dtype(self._c.dtype)
         self._c = np.ascontiguousarray(self._c, dtype=dtype)
+
+    def _deprecate_dtypes(self, *args):
+        """
+        A temporary helper for deprecating non-LAPACK dtypes.
+        """
+        for dtype in args:
+            if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
+                msg = (f"Interpolations with arguments of dtype={dtype} "
+                       f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
+                        "removed in SciPy 1.20.0. Please cast inputs to one of "
+                        "np.float{32,64} or np.complex{64,128} manually."
+                       )
+                import warnings
+                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+                return
 
     def _get_dtype(self, dtype):
         if np.issubdtype(dtype, np.complexfloating) \
@@ -724,6 +740,7 @@ class _PPolyBase:
 
         c = np.asarray(c)
         x = np.asarray(x)
+        self._deprecate_dtypes(c.dtype, x.dtype)
 
         if c.ndim < 2:
             raise ValueError("invalid dimensions for c")
@@ -777,11 +794,11 @@ class _PPolyBase:
         if action == 'append':
             c2[k2-self._c.shape[0]:, :self._c.shape[1]] = self._c
             c2[k2-c.shape[0]:, self._c.shape[1]:] = c
-            self._x = np.r_[self._x, x]
+            self._x = np.ascontiguousarray(np.r_[self._x, x], dtype=np.float64)
         elif action == 'prepend':
             c2[k2-self._c.shape[0]:, :c.shape[1]] = c
             c2[k2-c.shape[0]:, c.shape[1]:] = self._c
-            self._x = np.r_[x, self._x]
+            self._x = np.ascontiguousarray(np.r_[x, self._x], dtype=np.float64)
 
         self._c = c2
 
@@ -1945,6 +1962,7 @@ class NdPPoly:
     def __init__(self, c, x, extrapolate=None):
         self.x = tuple(np.ascontiguousarray(v, dtype=np.float64) for v in x)
         self.c = np.asarray(c)
+        self._deprecate_dtypes(self.c.dtype, *[np.asarray(v).dtype for v in x])
         if extrapolate is None:
             extrapolate = True
         self.extrapolate = bool(extrapolate)
@@ -1982,6 +2000,21 @@ class NdPPoly:
             extrapolate = True
         self.extrapolate = extrapolate
         return self
+
+    def _deprecate_dtypes(self, *args):
+        """
+        A temporary helper for deprecating non-LAPACK dtypes.
+        """
+        for dtype in args:
+            if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
+                msg = (f"Interpolations with arguments of dtype={dtype} "
+                       f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
+                        "removed in SciPy 1.20.0. Please cast inputs to one of "
+                        "np.float{32,64} or np.complex{64,128} manually."
+                       )
+                import warnings
+                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+                return
 
     def _get_dtype(self, dtype):
         if np.issubdtype(dtype, np.complexfloating) \

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -16,7 +16,7 @@ from . import _fitpack_py
 from ._polyint import _Interpolator1D
 from . import _ppoly
 from ._interpnd import _ndim_coords_from_arrays
-from ._bsplines import make_interp_spline, BSpline
+from ._bsplines import make_interp_spline, BSpline, _get_dtype, _deprecate_dtypes
 
 
 def lagrange(x, w):
@@ -549,7 +549,7 @@ class interp1d(_Interpolator1D):
         # 1. Handle values in x_new that are outside of x. Throw error,
         #    or return a list of mask array indicating the outofbounds values.
         #    The behavior is set by the bounds_error variable.
-        x_new = asarray(x_new)
+        x_new = asarray(x_new, dtype=np.float64)
         y_new = self._call(self, x_new)
         if not self._extrapolate:
             below_bounds, above_bounds = self._check_bounds(x_new)
@@ -605,7 +605,7 @@ class _PPolyBase:
 
         self._c = np.asarray(c)
         self._x = np.ascontiguousarray(x, dtype=np.float64)
-        self._deprecate_dtypes(self._c.dtype, np.asarray(x).dtype)
+        _deprecate_dtypes(self._c.dtype, np.asarray(x).dtype)
 
         if extrapolate is None:
             extrapolate = True
@@ -645,30 +645,8 @@ class _PPolyBase:
         if not (np.all(dx >= 0) or np.all(dx <= 0)):
             raise ValueError("`x` must be strictly increasing or decreasing.")
 
-        dtype = self._get_dtype(self._c.dtype)
+        dtype = _get_dtype(self._c.dtype)
         self._c = np.ascontiguousarray(self._c, dtype=dtype)
-
-    def _deprecate_dtypes(self, *args):
-        """
-        A temporary helper for deprecating dtypes.
-        """
-        for dtype in args:
-            if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
-                msg = (f"Interpolations with arguments of dtype={dtype} "
-                       f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
-                        "removed in SciPy 1.20.0. Please cast inputs to one of "
-                        "np.float{32,64} or np.complex{64,128} manually."
-                       )
-                import warnings
-                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
-                return
-
-    def _get_dtype(self, dtype):
-        if np.issubdtype(dtype, np.complexfloating) \
-               or np.issubdtype(self._c.dtype, np.complexfloating):
-            return np.complex128
-        else:
-            return np.float64
 
     @property
     def x(self):
@@ -740,7 +718,7 @@ class _PPolyBase:
 
         c = np.asarray(c)
         x = np.asarray(x)
-        self._deprecate_dtypes(c.dtype, x.dtype)
+        _deprecate_dtypes(c.dtype, x.dtype)
 
         if c.ndim < 2:
             raise ValueError("invalid dimensions for c")
@@ -785,7 +763,7 @@ class _PPolyBase:
                 raise ValueError("`x` is neither on the left or on the right "
                                 "from `self.x`.")
 
-        dtype = self._get_dtype(c.dtype)
+        dtype = _get_dtype(c.dtype)
 
         k2 = max(c.shape[0], self._c.shape[0])
         c2 = np.zeros((k2, self._c.shape[1] + c.shape[1]) + self._c.shape[2:],
@@ -794,11 +772,11 @@ class _PPolyBase:
         if action == 'append':
             c2[k2-self._c.shape[0]:, :self._c.shape[1]] = self._c
             c2[k2-c.shape[0]:, self._c.shape[1]:] = c
-            self._x = np.ascontiguousarray(np.r_[self._x, x], dtype=np.float64)
+            self._x = np.r_[self._x, x].astype(np.float64)
         elif action == 'prepend':
             c2[k2-self._c.shape[0]:, :c.shape[1]] = c
             c2[k2-c.shape[0]:, c.shape[1]:] = self._c
-            self._x = np.ascontiguousarray(np.r_[x, self._x], dtype=np.float64)
+            self._x = np.r_[x, self._x].astype(np.float64)
 
         self._c = c2
 
@@ -1962,7 +1940,7 @@ class NdPPoly:
     def __init__(self, c, x, extrapolate=None):
         self.x = tuple(np.ascontiguousarray(v, dtype=np.float64) for v in x)
         self.c = np.asarray(c)
-        self._deprecate_dtypes(self.c.dtype, *[np.asarray(v).dtype for v in x])
+        _deprecate_dtypes(self.c.dtype, *[np.asarray(v).dtype for v in x])
         if extrapolate is None:
             extrapolate = True
         self.extrapolate = bool(extrapolate)
@@ -1979,7 +1957,7 @@ class NdPPoly:
         if any(a != b.size - 1 for a, b in zip(c.shape[ndim:2*ndim], self.x)):
             raise ValueError("x and c do not agree on the number of intervals")
 
-        dtype = self._get_dtype(self.c.dtype)
+        dtype = _get_dtype(self.c.dtype)
         self.c = np.ascontiguousarray(self.c, dtype=dtype)
 
     @classmethod
@@ -2000,28 +1978,6 @@ class NdPPoly:
             extrapolate = True
         self.extrapolate = extrapolate
         return self
-
-    def _deprecate_dtypes(self, *args):
-        """
-        A temporary helper for deprecating dtypes.
-        """
-        for dtype in args:
-            if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
-                msg = (f"Interpolations with arguments of dtype={dtype} "
-                       f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
-                        "removed in SciPy 1.20.0. Please cast inputs to one of "
-                        "np.float{32,64} or np.complex{64,128} manually."
-                       )
-                import warnings
-                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
-                return
-
-    def _get_dtype(self, dtype):
-        if np.issubdtype(dtype, np.complexfloating) \
-               or np.issubdtype(self.c.dtype, np.complexfloating):
-            return np.complex128
-        else:
-            return np.float64
 
     def _ensure_c_contiguous(self):
         if not self.c.flags.c_contiguous:

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -663,7 +663,7 @@ class _PPolyBase:
 
     def _deprecate_dtypes(self, *args):
         """
-        A temporary helper for deprecating non-LAPACK dtypes.
+        A temporary helper for deprecating dtypes.
         """
         for dtype in args:
             if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
@@ -2447,7 +2447,7 @@ class NdPPoly:
 
     def _deprecate_dtypes(self, *args):
         """
-        A temporary helper for deprecating non-LAPACK dtypes.
+        A temporary helper for deprecating dtypes.
         """
         for dtype in args:
             if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -514,7 +514,7 @@ class interp1d(_Interpolator1D):
             ((x_new - x_lo)/(x_hi - x_lo))[:, None] * y_hi
             + ((x_hi - x_new)/(x_hi - x_lo))[:, None] * y_lo
             )
-        
+
         return y_new
 
     def _call_nearest(self, x_new):
@@ -614,8 +614,11 @@ class _PPolyBase:
     __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, c, x, extrapolate=None, axis=0):
+        self._asarray  = array_namespace(c, x).asarray
+
         self.c = np.asarray(c)
         self.x = np.ascontiguousarray(x, dtype=np.float64)
+        self._deprecate_dtypes(self._c.dtype, np.asarray(x).dtype)
 
         if extrapolate is None:
             extrapolate = True
@@ -658,6 +661,21 @@ class _PPolyBase:
         dtype = self._get_dtype(self.c.dtype)
         self.c = np.ascontiguousarray(self.c, dtype=dtype)
 
+    def _deprecate_dtypes(self, *args):
+        """
+        A temporary helper for deprecating non-LAPACK dtypes.
+        """
+        for dtype in args:
+            if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
+                msg = (f"Interpolations with arguments of dtype={dtype} "
+                       f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
+                        "removed in SciPy 1.20.0. Please cast inputs to one of "
+                        "np.float{32,64} or np.complex{64,128} manually."
+                       )
+                import warnings
+                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+                return
+
     def _get_dtype(self, dtype):
         if np.issubdtype(dtype, np.complexfloating) \
                or np.issubdtype(self.c.dtype, np.complexfloating):
@@ -689,6 +707,7 @@ class _PPolyBase:
     def extend(self, c, x):
         c = np.asarray(c)
         x = np.asarray(x)
+        self._deprecate_dtypes(c.dtype, x.dtype)
 
         if c.ndim < 2:
             raise ValueError("invalid dimensions for c")
@@ -742,11 +761,11 @@ class _PPolyBase:
         if action == 'append':
             c2[k2-self.c.shape[0]:, :self.c.shape[1]] = self.c
             c2[k2-c.shape[0]:, self.c.shape[1]:] = c
-            self.x = np.r_[self.x, x]
+            self.x = np.ascontiguousarray(np.r_[self.x, x], dtype=np.float64)
         elif action == 'prepend':
             c2[k2-self.c.shape[0]:, :c.shape[1]] = c
             c2[k2-c.shape[0]:, c.shape[1]:] = self.c
-            self.x = np.r_[x, self.x]
+            self.x = np.ascontiguousarray(np.r_[x, self.x], dtype=np.float64)
 
         self.c = c2
 
@@ -2387,6 +2406,7 @@ class NdPPoly:
     def __init__(self, c, x, extrapolate=None):
         self.x = tuple(np.ascontiguousarray(v, dtype=np.float64) for v in x)
         self.c = np.asarray(c)
+        self._deprecate_dtypes(self.c.dtype, *[np.asarray(v).dtype for v in x])
         if extrapolate is None:
             extrapolate = True
         self.extrapolate = bool(extrapolate)
@@ -2424,6 +2444,21 @@ class NdPPoly:
             extrapolate = True
         self.extrapolate = extrapolate
         return self
+
+    def _deprecate_dtypes(self, *args):
+        """
+        A temporary helper for deprecating non-LAPACK dtypes.
+        """
+        for dtype in args:
+            if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
+                msg = (f"Interpolations with arguments of dtype={dtype} "
+                       f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
+                        "removed in SciPy 1.20.0. Please cast inputs to one of "
+                        "np.float{32,64} or np.complex{64,128} manually."
+                       )
+                import warnings
+                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+                return
 
     def _get_dtype(self, dtype):
         if np.issubdtype(dtype, np.complexfloating) \

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -618,7 +618,7 @@ class _PPolyBase:
 
         self.c = np.asarray(c)
         self.x = np.ascontiguousarray(x, dtype=np.float64)
-        _deprecate_dtypes(self._c.dtype, np.asarray(x).dtype)
+        _deprecate_dtypes(self.c.dtype, np.asarray(x).dtype)
 
         if extrapolate is None:
             extrapolate = True
@@ -657,24 +657,8 @@ class _PPolyBase:
         dx = np.diff(self.x)
         if not (np.all(dx >= 0) or np.all(dx <= 0)):
             raise ValueError("`x` must be strictly increasing or decreasing.")
-        dtype = self._get_dtype(self.c.dtype)
+        dtype = _get_dtype(self.c.dtype)
         self.c = np.ascontiguousarray(self.c, dtype=dtype)
-
-    @property
-    def x(self):
-        return self._asarray(self._x)
-
-    @x.setter
-    def x(self, xval):
-        self._x = np.asarray(xval)
-
-    @property
-    def c(self):
-        return self._asarray(self._c)
-
-    @c.setter
-    def c(self, cval):
-        self._c = np.asarray(cval)
 
     @classmethod
     def construct_fast(cls, c, x, extrapolate=None, axis=0):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -562,7 +562,7 @@ class interp1d(_Interpolator1D):
         # 1. Handle values in x_new that are outside of x. Throw error,
         #    or return a list of mask array indicating the outofbounds values.
         #    The behavior is set by the bounds_error variable.
-        x_new = asarray(x_new, dtype=np.float64)
+        x_new = asarray(x_new)
         y_new = self._call(self, x_new)
         if not self._extrapolate:
             below_bounds, above_bounds = self._check_bounds(x_new)
@@ -614,7 +614,6 @@ class _PPolyBase:
     __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, c, x, extrapolate=None, axis=0):
-        self._asarray  = array_namespace(c, x).asarray
 
         self.c = np.asarray(c)
         self.x = np.ascontiguousarray(x, dtype=np.float64)
@@ -738,11 +737,11 @@ class _PPolyBase:
         if action == 'append':
             c2[k2-self.c.shape[0]:, :self.c.shape[1]] = self.c
             c2[k2-c.shape[0]:, self.c.shape[1]:] = c
-            self.x = np.r_[self.x, x].astype(np.float64)
+            self.x = np.r_[self.x, x].astype(np.float64, copy=False)
         elif action == 'prepend':
             c2[k2-self.c.shape[0]:, :c.shape[1]] = c
             c2[k2-c.shape[0]:, c.shape[1]:] = self.c
-            self.x = np.r_[x, self.x].astype(np.float64)
+            self.x = np.r_[x, self.x].astype(np.float64, copy=False)
         self.c = c2
 
     def __call__(self, x, nu=0, extrapolate=None):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -20,7 +20,7 @@ from . import _fitpack_py
 from ._polyint import _Interpolator1D
 from . import _ppoly
 from ._interpnd import _ndim_coords_from_arrays
-from ._bsplines import make_interp_spline, BSpline
+from ._bsplines import make_interp_spline, BSpline, _get_dtype, _deprecate_dtypes
 
 
 @xp_capabilities(out_of_scope=True)
@@ -562,7 +562,7 @@ class interp1d(_Interpolator1D):
         # 1. Handle values in x_new that are outside of x. Throw error,
         #    or return a list of mask array indicating the outofbounds values.
         #    The behavior is set by the bounds_error variable.
-        x_new = asarray(x_new)
+        x_new = asarray(x_new, dtype=np.float64)
         y_new = self._call(self, x_new)
         if not self._extrapolate:
             below_bounds, above_bounds = self._check_bounds(x_new)
@@ -618,7 +618,7 @@ class _PPolyBase:
 
         self.c = np.asarray(c)
         self.x = np.ascontiguousarray(x, dtype=np.float64)
-        self._deprecate_dtypes(self._c.dtype, np.asarray(x).dtype)
+        _deprecate_dtypes(self._c.dtype, np.asarray(x).dtype)
 
         if extrapolate is None:
             extrapolate = True
@@ -657,31 +657,24 @@ class _PPolyBase:
         dx = np.diff(self.x)
         if not (np.all(dx >= 0) or np.all(dx <= 0)):
             raise ValueError("`x` must be strictly increasing or decreasing.")
-
         dtype = self._get_dtype(self.c.dtype)
         self.c = np.ascontiguousarray(self.c, dtype=dtype)
 
-    def _deprecate_dtypes(self, *args):
-        """
-        A temporary helper for deprecating dtypes.
-        """
-        for dtype in args:
-            if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
-                msg = (f"Interpolations with arguments of dtype={dtype} "
-                       f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
-                        "removed in SciPy 1.20.0. Please cast inputs to one of "
-                        "np.float{32,64} or np.complex{64,128} manually."
-                       )
-                import warnings
-                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
-                return
+    @property
+    def x(self):
+        return self._asarray(self._x)
 
-    def _get_dtype(self, dtype):
-        if np.issubdtype(dtype, np.complexfloating) \
-               or np.issubdtype(self.c.dtype, np.complexfloating):
-            return np.complex128
-        else:
-            return np.float64
+    @x.setter
+    def x(self, xval):
+        self._x = np.asarray(xval)
+
+    @property
+    def c(self):
+        return self._asarray(self._c)
+
+    @c.setter
+    def c(self, cval):
+        self._c = np.asarray(cval)
 
     @classmethod
     def construct_fast(cls, c, x, extrapolate=None, axis=0):
@@ -707,7 +700,7 @@ class _PPolyBase:
     def extend(self, c, x):
         c = np.asarray(c)
         x = np.asarray(x)
-        self._deprecate_dtypes(c.dtype, x.dtype)
+        _deprecate_dtypes(c.dtype, x.dtype)
 
         if c.ndim < 2:
             raise ValueError("invalid dimensions for c")
@@ -752,7 +745,7 @@ class _PPolyBase:
                 raise ValueError("`x` is neither on the left or on the right "
                                 "from `self.x`.")
 
-        dtype = self._get_dtype(c.dtype)
+        dtype = _get_dtype(c.dtype)
 
         k2 = max(c.shape[0], self.c.shape[0])
         c2 = np.zeros((k2, self.c.shape[1] + c.shape[1]) + self.c.shape[2:],
@@ -761,12 +754,11 @@ class _PPolyBase:
         if action == 'append':
             c2[k2-self.c.shape[0]:, :self.c.shape[1]] = self.c
             c2[k2-c.shape[0]:, self.c.shape[1]:] = c
-            self.x = np.ascontiguousarray(np.r_[self.x, x], dtype=np.float64)
+            self.x = np.r_[self.x, x].astype(np.float64)
         elif action == 'prepend':
             c2[k2-self.c.shape[0]:, :c.shape[1]] = c
             c2[k2-c.shape[0]:, c.shape[1]:] = self.c
-            self.x = np.ascontiguousarray(np.r_[x, self.x], dtype=np.float64)
-
+            self.x = np.r_[x, self.x].astype(np.float64)
         self.c = c2
 
     def __call__(self, x, nu=0, extrapolate=None):
@@ -2406,7 +2398,7 @@ class NdPPoly:
     def __init__(self, c, x, extrapolate=None):
         self.x = tuple(np.ascontiguousarray(v, dtype=np.float64) for v in x)
         self.c = np.asarray(c)
-        self._deprecate_dtypes(self.c.dtype, *[np.asarray(v).dtype for v in x])
+        _deprecate_dtypes(self.c.dtype, *[np.asarray(v).dtype for v in x])
         if extrapolate is None:
             extrapolate = True
         self.extrapolate = bool(extrapolate)
@@ -2423,7 +2415,7 @@ class NdPPoly:
         if any(a != b.size - 1 for a, b in zip(c.shape[ndim:2*ndim], self.x)):
             raise ValueError("x and c do not agree on the number of intervals")
 
-        dtype = self._get_dtype(self.c.dtype)
+        dtype = _get_dtype(self.c.dtype)
         self.c = np.ascontiguousarray(self.c, dtype=dtype)
 
     @classmethod
@@ -2444,28 +2436,6 @@ class NdPPoly:
             extrapolate = True
         self.extrapolate = extrapolate
         return self
-
-    def _deprecate_dtypes(self, *args):
-        """
-        A temporary helper for deprecating dtypes.
-        """
-        for dtype in args:
-            if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
-                msg = (f"Interpolations with arguments of dtype={dtype} "
-                       f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
-                        "removed in SciPy 1.20.0. Please cast inputs to one of "
-                        "np.float{32,64} or np.complex{64,128} manually."
-                       )
-                import warnings
-                warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
-                return
-
-    def _get_dtype(self, dtype):
-        if np.issubdtype(dtype, np.complexfloating) \
-               or np.issubdtype(self.c.dtype, np.complexfloating):
-            return np.complex128
-        else:
-            return np.float64
 
     def _ensure_c_contiguous(self):
         if not self.c.flags.c_contiguous:

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -17,6 +17,22 @@ from ._bsplines import _not_a_knot, BSpline
 __all__ = ["NdBSpline"]
 
 
+def _deprecate_dtypes(self, *args):
+    """
+    A temporary helper for deprecating non-LAPACK dtypes.
+    """
+    for dtype in args:
+        if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
+            msg = (f"Interpolations with arguments of dtype={dtype} "
+                   f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
+                    "removed in SciPy 1.20.0. Please cast inputs to one of "
+                    "np.float{32,64} or np.complex{64,128} manually."
+                   )
+            import warnings
+            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
+            return
+
+
 def _get_dtype(dtype):
     """Return np.complex128 for complex dtypes, np.float64 otherwise."""
     if np.issubdtype(dtype, np.complexfloating):
@@ -98,6 +114,7 @@ class NdBSpline:
         self.extrapolate = bool(extrapolate)
 
         self._c = np.asarray(c)
+        _deprecate_dtypes(*[np.asarray(v).dtype for v in t], self._c.dtype)
 
         ndim = self._t.shape[0]   # == len(self.t)
         if self._c.ndim < ndim:

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -12,33 +12,9 @@ import scipy.sparse.linalg as ssl
 from scipy.sparse import csr_array
 from scipy._lib._array_api import array_namespace, xp_capabilities
 
-from ._bsplines import _not_a_knot, BSpline
+from ._bsplines import _not_a_knot, BSpline, _get_dtype, _deprecate_dtypes
 
 __all__ = ["NdBSpline"]
-
-
-def _deprecate_dtypes(self, *args):
-    """
-    A temporary helper for deprecating dtypes.
-    """
-    for dtype in args:
-        if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':
-            msg = (f"Interpolations with arguments of dtype={dtype} "
-                   f"({dtype.char = }) are deprecated in SciPy 1.18.0 and will be "
-                    "removed in SciPy 1.20.0. Please cast inputs to one of "
-                    "np.float{32,64} or np.complex{64,128} manually."
-                   )
-            import warnings
-            warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
-            return
-
-
-def _get_dtype(dtype):
-    """Return np.complex128 for complex dtypes, np.float64 otherwise."""
-    if np.issubdtype(dtype, np.complexfloating):
-        return np.complex128
-    else:
-        return np.float64
 
 
 @xp_capabilities(

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -19,7 +19,7 @@ __all__ = ["NdBSpline"]
 
 def _deprecate_dtypes(self, *args):
     """
-    A temporary helper for deprecating non-LAPACK dtypes.
+    A temporary helper for deprecating dtypes.
     """
     for dtype in args:
         if dtype.char not in np.typecodes['AllInteger'] + 'efdFD':

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -83,6 +83,8 @@ def check_dtype(interpolator_cls, x_dtype, y_dtype, xi_dtype, deriv_shape=None,
 
 real_dtypes = "".join(["" if np.issubdtype(c, np.complexfloating)
                        else c for c in supported_dtypes])
+x_dtypes = "".join(["" if np.issubdtype(c, np.unsignedinteger)
+                       else c for c in real_dtypes])
 
 def test_dtypes():
 
@@ -90,7 +92,7 @@ def test_dtypes():
         return make_interp_spline(x, y, axis=axis)
 
     for ip in [KroghInterpolator, BarycentricInterpolator, CubicHermiteSpline]:
-        for d1 in real_dtypes:
+        for d1 in x_dtypes:
             for d2 in supported_dtypes:
                 for d3 in real_dtypes:
                     if ip != CubicSpline:
@@ -101,7 +103,7 @@ def test_dtypes():
                             check_dtype(ip, d1, d2, d3, None, extra)
 
     for ip in [pchip, Akima1DInterpolator, CubicSpline, spl_interp]:
-        for d1 in real_dtypes:
+        for d1 in x_dtypes:
             for d2 in real_dtypes:
                 for d3 in real_dtypes:
                     if ip != CubicSpline:
@@ -116,7 +118,7 @@ def test_derivs_dtypes():
         def interpolator_derivs(x, y, axis=0):
             return ip(x, y, axis).derivatives
 
-        for d1 in real_dtypes:
+        for d1 in x_dtypes:
             for d2 in supported_dtypes:
                 for d3 in real_dtypes:
                     check_dtype(interpolator_derivs, d1, d2, d3, (6,))
@@ -167,14 +169,14 @@ def test_deriv_dtypes():
 
     for ip in [krogh_deriv, bary_deriv, cspline_deriv, cspline_antideriv,
                bspl_deriv, bspl_antideriv]:
-        for d1 in real_dtypes:
+        for d1 in x_dtypes:
             for d2 in supported_dtypes:
                 for d3 in real_dtypes:
                     check_dtype(ip, d1, d2, d3, ())
 
     for ip in [pchip_deriv, pchip_deriv2, pchip_deriv_inplace,
                pchip_antideriv, pchip_antideriv2, akima_deriv, akima_antideriv]:
-        for d1 in real_dtypes:
+        for d1 in x_dtypes:
             for d2 in real_dtypes:
                 for d3 in real_dtypes:
                     check_dtype(ip, d1, d2, d3, ())

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -14,12 +14,170 @@ from scipy.interpolate import (
     BarycentricInterpolator, barycentric_interpolate,
     approximate_taylor_polynomial, CubicHermiteSpline, pchip,
     PchipInterpolator, pchip_interpolate, Akima1DInterpolator, CubicSpline,
-    make_interp_spline)
+    make_interp_spline, supported_dtypes)
 from scipy._lib._testutils import _run_concurrent_barrier
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
 
+def check_dtype(interpolator_cls, x_dtype, y_dtype, xi_dtype, deriv_shape=None,
+                extra_args=None):
+
+    axis = 0
+    x_shape = (1,)
+    y_shape = (1,)
+
+    if extra_args is None:
+        extra_args = {}
+    rng = np.random.RandomState(1234)
+
+    s = list(range(1, len(y_shape)+1))
+    s.insert(axis % (len(y_shape)+1), 0)
+
+    # make sure no negatives for unsigned integers
+    if np.issubdtype(x_dtype, np.unsignedinteger):
+        x = np.array([0, 1, 2, 3, 4, 5], dtype=x_dtype)
+    else:
+        x = np.array([-1, 0, 1, 2, 3, 4], dtype=x_dtype)
+
+    # if y is an integer type, scale values up to more "integer-y" data
+    if np.issubdtype(y_dtype, np.integer):
+        y = (rng.rand(*((6,) + y_shape)) * 1e3).astype(y_dtype).transpose(s)
+    else:
+        y = rng.rand(*((6,) + y_shape)).astype(y_dtype).transpose(s)
+
+    xi = np.zeros(x_shape, dtype=xi_dtype)
+    if interpolator_cls is CubicHermiteSpline:
+        if np.issubdtype(y_dtype, np.integer):
+            dydx = (rng.rand(*((6,) + y_shape)) * 1e3).astype(y_dtype).transpose(s)
+        else:
+            dydx = rng.rand(*((6,) + y_shape)).astype(y_dtype).transpose(s)
+        yi = interpolator_cls(x, y, dydx, axis=axis, **extra_args)(xi)
+    else:
+        yi = interpolator_cls(x, y, axis=axis, **extra_args)(xi)
+
+    if np.issubdtype(y_dtype, np.complexfloating):
+        expected_dtype = np.complex128
+    else:
+        expected_dtype = np.float64
+
+    assert yi.dtype == expected_dtype
+
+    # check it works also with lists
+    if x_shape and y.size > 0:
+        if interpolator_cls is CubicHermiteSpline:
+            interpolator_cls(list(x), list(y), list(dydx), axis=axis,
+                             **extra_args)(list(xi))
+        else:
+            interpolator_cls(list(x), list(y), axis=axis,
+                             **extra_args)(list(xi))
+
+    # check also values
+    if xi.size > 0 and deriv_shape is None:
+        bs_shape = y.shape[:axis] + (1,)*len(x_shape) + y.shape[axis:][1:]
+        yv = y[((slice(None,),)*(axis % y.ndim)) + (1,)]
+        yv = yv.reshape(bs_shape).astype(expected_dtype)
+
+        yi, y = np.broadcast_arrays(yi, yv)
+        xp_assert_close(yi, y)
+
+real_dtypes = "".join(["" if np.issubdtype(c, np.complexfloating)
+                       else c for c in supported_dtypes])
+
+def test_dtypes():
+
+    def spl_interp(x, y, axis):
+        return make_interp_spline(x, y, axis=axis)
+
+    for ip in [KroghInterpolator, BarycentricInterpolator, CubicHermiteSpline]:
+        for d1 in real_dtypes:
+            for d2 in supported_dtypes:
+                for d3 in real_dtypes:
+                    if ip != CubicSpline:
+                        check_dtype(ip, d1, d2, d3, None)
+                    else:
+                        for bc in ['natural', 'clamped']:
+                            extra = {'bc_type': bc}
+                            check_dtype(ip, d1, d2, d3, None, extra)
+
+    for ip in [pchip, Akima1DInterpolator, CubicSpline, spl_interp]:
+        for d1 in real_dtypes:
+            for d2 in real_dtypes:
+                for d3 in real_dtypes:
+                    if ip != CubicSpline:
+                        check_dtype(ip, d1, d2, d3, None)
+                    else:
+                        for bc in ['natural', 'clamped']:
+                            extra = {'bc_type': bc}
+                            check_dtype(ip, d1, d2, d3, None, extra)
+
+def test_derivs_dtypes():
+    for ip in [KroghInterpolator, BarycentricInterpolator]:
+        def interpolator_derivs(x, y, axis=0):
+            return ip(x, y, axis).derivatives
+
+        for d1 in real_dtypes:
+            for d2 in supported_dtypes:
+                for d3 in real_dtypes:
+                    check_dtype(interpolator_derivs, d1, d2, d3, (6,))
+
+def test_deriv_dtypes():
+    def krogh_deriv(x, y, axis=0):
+        return KroghInterpolator(x, y, axis).derivative
+
+    def bary_deriv(x, y, axis=0):
+        return BarycentricInterpolator(x, y, axis).derivative
+
+    def pchip_deriv(x, y, axis=0):
+        return pchip(x, y, axis).derivative()
+
+    def pchip_deriv2(x, y, axis=0):
+        return pchip(x, y, axis).derivative(2)
+
+    def pchip_antideriv(x, y, axis=0):
+        return pchip(x, y, axis).antiderivative()
+
+    def pchip_antideriv2(x, y, axis=0):
+        return pchip(x, y, axis).antiderivative(2)
+
+    def pchip_deriv_inplace(x, y, axis=0):
+        class P(PchipInterpolator):
+            def __call__(self, x):
+                return PchipInterpolator.__call__(self, x, 1)
+            pass
+        return P(x, y, axis)
+
+    def akima_deriv(x, y, axis=0):
+        return Akima1DInterpolator(x, y, axis).derivative()
+
+    def akima_antideriv(x, y, axis=0):
+        return Akima1DInterpolator(x, y, axis).antiderivative()
+
+    def cspline_deriv(x, y, axis=0):
+        return CubicSpline(x, y, axis).derivative()
+
+    def cspline_antideriv(x, y, axis=0):
+        return CubicSpline(x, y, axis).antiderivative()
+
+    def bspl_deriv(x, y, axis=0):
+        return make_interp_spline(x, y, axis=axis).derivative()
+
+    def bspl_antideriv(x, y, axis=0):
+        return make_interp_spline(x, y, axis=axis).antiderivative()
+
+    for ip in [krogh_deriv, bary_deriv, cspline_deriv, cspline_antideriv,
+               bspl_deriv, bspl_antideriv]:
+        for d1 in real_dtypes:
+            for d2 in supported_dtypes:
+                for d3 in real_dtypes:
+                    check_dtype(ip, d1, d2, d3, ())
+
+    for ip in [pchip_deriv, pchip_deriv2, pchip_deriv_inplace,
+               pchip_antideriv, pchip_antideriv2, akima_deriv, akima_antideriv]:
+        for d1 in real_dtypes:
+            for d2 in real_dtypes:
+                for d3 in real_dtypes:
+                    check_dtype(ip, d1, d2, d3, ())
 
 def check_shape(interpolator_cls, x_shape, y_shape, deriv_shape=None, axis=0,
                 extra_args=None):

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -14,12 +14,17 @@ from scipy.interpolate import (
     BarycentricInterpolator, barycentric_interpolate,
     approximate_taylor_polynomial, CubicHermiteSpline, pchip,
     PchipInterpolator, pchip_interpolate, Akima1DInterpolator, CubicSpline,
-    make_interp_spline, supported_dtypes)
+    make_interp_spline)
+from scipy.interpolate._bsplines import supported_dtypes, real_dtypes, x_dtypes
 from scipy._lib._testutils import _run_concurrent_barrier
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
 
+
+# check that, for a given interpolator, when constructed with data x and y and
+# evaluated with data xi, it produces a (numerically accurate) value yi of the
+# expected dtype, i.e. complex128 if y was complex, or float64 if not
 def check_dtype(interpolator_cls, x_dtype, y_dtype, xi_dtype, deriv_shape=None,
                 extra_args=None):
 
@@ -40,18 +45,11 @@ def check_dtype(interpolator_cls, x_dtype, y_dtype, xi_dtype, deriv_shape=None,
     else:
         x = np.array([-1, 0, 1, 2, 3, 4], dtype=x_dtype)
 
-    # if y is an integer type, scale values up to more "integer-y" data
-    if np.issubdtype(y_dtype, np.integer):
-        y = (rng.rand(*((6,) + y_shape)) * 1e3).astype(y_dtype).transpose(s)
-    else:
-        y = rng.rand(*((6,) + y_shape)).astype(y_dtype).transpose(s)
+    y = (rng.rand(*((6,) + y_shape)) * 1e3).astype(y_dtype).transpose(s)
 
     xi = np.zeros(x_shape, dtype=xi_dtype)
     if interpolator_cls is CubicHermiteSpline:
-        if np.issubdtype(y_dtype, np.integer):
-            dydx = (rng.rand(*((6,) + y_shape)) * 1e3).astype(y_dtype).transpose(s)
-        else:
-            dydx = rng.rand(*((6,) + y_shape)).astype(y_dtype).transpose(s)
+        dydx = (rng.rand(*((6,) + y_shape)) * 1e3).astype(y_dtype).transpose(s)
         yi = interpolator_cls(x, y, dydx, axis=axis, **extra_args)(xi)
     else:
         yi = interpolator_cls(x, y, axis=axis, **extra_args)(xi)
@@ -81,10 +79,6 @@ def check_dtype(interpolator_cls, x_dtype, y_dtype, xi_dtype, deriv_shape=None,
         yi, y = np.broadcast_arrays(yi, yv)
         xp_assert_close(yi, y)
 
-real_dtypes = "".join(["" if np.issubdtype(c, np.complexfloating)
-                       else c for c in supported_dtypes])
-x_dtypes = "".join(["" if np.issubdtype(c, np.unsignedinteger)
-                       else c for c in real_dtypes])
 
 def test_dtypes():
 


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
#24625

#### What does this implement/fix?
<!--Please explain your changes.-->
Fixed an error where, after calling `PPoly.extend` with `np.float128`/`np.longdouble`, 
`PPoly.x.dtype` would become `np.float128`, causing a ValueError upon attempting
to evaluate the polynomial. `PPoly.extend` now ensures `PPoly.x.dtype` remains `np.float64`.
In addition, added a helper function which raises a warning stating that noninteger, float32,
float64, or their complex counterparts are soon-to-be deprecated and potentially removed, 
in the vein of #24682, though the error is not raised for float16 inputs, unlike that example

#### Additional information
<!--Any additional information you think is important.-->
This is my first time contributing, so I'm unsure if the warning is raised everywhere it needs
to be, and I wasn't sure on the wording of the warning, I mostly copied the message from
#24682, assuming a similar motion would happen.

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used
