### PR TITLE
DOC: add default values documentation for optimize.root parameters

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,24 @@
+#### Reference issue
+Closes #22635
+
+#### What does this implement/fix?
+This PR adds documentation for default values of optional parameters in `scipy.optimize.root` and its method-specific implementations.
+
+The following changes were made:
+
+**Main `root` function** (`scipy/optimize/_root.py`):
+- Documented default values for all optional parameters: `args`, `method`, `jac`, `tol`, `callback`, `options`
+
+**`hybr` method** (`scipy/optimize/_minpack_py.py`):
+- Added defaults for: `col_deriv`, `xtol`, `maxfev`, `band`, `eps`, `factor`, `diag`
+
+**`lm` method** (`scipy/optimize/_root.py`):
+- Added defaults for: `col_deriv`, `ftol`, `xtol`, `gtol`, `maxiter`, `eps`, `factor`, `diag`
+
+**`df-sane` method** (`scipy/optimize/_spectral.py`):
+- Added/standardized defaults for: `ftol`, `fatol`, `fnorm`, `maxfev`, `disp`, `eta_strategy`, `sigma_eps`, `sigma_0`, `M`, `line_search`
+
+#### Additional information
+This addresses the issue where users couldn't determine default values like `xtol` and `eps` without looking at the source code. All default values are now explicitly documented in the docstrings following the pattern `parameter : type, optional, default: value`.
+
+This is a documentation-only change with no code modifications.

--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -200,33 +200,36 @@ def _root_hybr(func, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, optional
         Specify whether the Jacobian function computes derivatives down
         the columns (faster, because there is no transpose operation).
-    xtol : float
+        Default is False.
+    xtol : float, optional
         The calculation will terminate if the relative error between two
-        consecutive iterates is at most `xtol`.
-    maxfev : int
+        consecutive iterates is at most `xtol`. Default is 1.49012e-08.
+    maxfev : int, optional
         The maximum number of calls to the function. If zero, then
         ``100*(N+1)`` is the maximum where N is the number of elements
-        in `x0`.
-    band : tuple
+        in `x0`. Default is 0 (meaning the value described above is used).
+    band : tuple, optional
         If set to a two-sequence containing the number of sub- and
         super-diagonals within the band of the Jacobi matrix, the
         Jacobi matrix is considered banded (only for ``jac=None``).
-    eps : float
+        Default is None.
+    eps : float, optional
         A suitable step length for the forward-difference
         approximation of the Jacobian (for ``jac=None``). If
         `eps` is less than the machine precision, it is assumed
         that the relative errors in the functions are of the order of
-        the machine precision.
-    factor : float
+        the machine precision. Default is None, meaning the machine
+        precision is used.
+    factor : float, optional
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in the interval
-        ``(0.1, 100)``.
-    diag : sequence
+        ``(0.1, 100)``. Default is 100.
+    diag : sequence, optional
         N positive entries that serve as a scale factors for the
-        variables.
+        variables. Default is None.
 
     """
     _check_unknown_options(unknown_options)

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -42,6 +42,7 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
         Initial guess.
     args : tuple, optional
         Extra arguments passed to the objective function and its Jacobian.
+        Default is () (empty tuple).
     method : str, optional
         Type of solver. Should be one of
 
@@ -56,22 +57,25 @@ def root(fun, x0, args=(), method='hybr', jac=None, tol=None, callback=None,
         - 'krylov'           :ref:`(see here) <optimize.root-krylov>`
         - 'df-sane'          :ref:`(see here) <optimize.root-dfsane>`
 
+        Default is 'hybr'.
     jac : bool or callable, optional
         If `jac` is a Boolean and is True, `fun` is assumed to return the
         value of Jacobian along with the objective function. If False, the
         Jacobian will be estimated numerically.
         `jac` can also be a callable returning the Jacobian of `fun`. In
         this case, it must accept the same arguments as `fun`.
+        Default is None.
     tol : float, optional
         Tolerance for termination. For detailed control, use solver-specific
-        options.
+        options. Default is None.
     callback : function, optional
         Optional callback function. It is called on every iteration as
         ``callback(x, f)`` where `x` is the current solution and `f`
         the corresponding residual. For all methods but 'hybr' and 'lm'.
+        Default is None.
     options : dict, optional
         A dictionary of solver options. E.g., `xtol` or `maxiter`, see
-        :obj:`show_options()` for details.
+        :obj:`show_options()` for details. Default is None.
 
     Returns
     -------
@@ -286,29 +290,33 @@ def _root_leastsq(fun, x0, args=(), jac=None,
 
     Options
     -------
-    col_deriv : bool
+    col_deriv : bool, optional
         non-zero to specify that the Jacobian function computes derivatives
         down the columns (faster, because there is no transpose operation).
-    ftol : float
-        Relative error desired in the sum of squares.
-    xtol : float
-        Relative error desired in the approximate solution.
-    gtol : float
+        Default is 0 (False).
+    ftol : float, optional
+        Relative error desired in the sum of squares. Default is 1.49012e-08.
+    xtol : float, optional
+        Relative error desired in the approximate solution. Default is 1.49012e-08.
+    gtol : float, optional
         Orthogonality desired between the function vector and the columns
-        of the Jacobian.
-    maxiter : int
+        of the Jacobian. Default is 0.0.
+    maxiter : int, optional
         The maximum number of calls to the function. If zero, then
         100*(N+1) is the maximum where N is the number of elements in x0.
-    eps : float
+        Default is 0.
+    eps : float, optional
         A suitable step length for the forward-difference approximation of
         the Jacobian (for Dfun=None). If `eps` is less than the machine
         precision, it is assumed that the relative errors in the functions
-        are of the order of the machine precision.
-    factor : float
+        are of the order of the machine precision. Default is 0.0.
+    factor : float, optional
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in interval ``(0.1, 100)``.
-    diag : sequence
+        Default is 100.
+    diag : sequence, optional
         N positive entries that serve as a scale factors for the variables.
+        Default is None.
     """
     nfev = 0
     def _wrapped_fun(*fargs):

--- a/scipy/optimize/_spectral.py
+++ b/scipy/optimize/_spectral.py
@@ -21,36 +21,41 @@ def _root_df_sane(func, x0, args=(), ftol=1e-8, fatol=1e-300, maxfev=1000,
     Options
     -------
     ftol : float, optional
-        Relative norm tolerance.
+        Relative norm tolerance. Default is 1e-8.
     fatol : float, optional
         Absolute norm tolerance.
         Algorithm terminates when ``||func(x)|| < fatol + ftol ||func(x_0)||``.
+        Default is 1e-300.
     fnorm : callable, optional
         Norm to use in the convergence check. If None, 2-norm is used.
+        Default is None.
     maxfev : int, optional
-        Maximum number of function evaluations.
+        Maximum number of function evaluations. Default is 1000.
     disp : bool, optional
-        Whether to print convergence process to stdout.
+        Whether to print convergence process to stdout. Default is False.
+    callback : callable, optional
+        Optional callback function. Called on each iteration as ``callback(x, F)``
+        where `x` is the current iterate and `F` is the current residual.
+        Default is None.
     eta_strategy : callable, optional
         Choice of the ``eta_k`` parameter, which gives slack for growth
         of ``||F||**2``.  Called as ``eta_k = eta_strategy(k, x, F)`` with
         `k` the iteration number, `x` the current iterate and `F` the current
         residual. Should satisfy ``eta_k > 0`` and ``sum(eta, k=0..inf) < inf``.
-        Default: ``||F||**2 / (1 + k)**2``.
+        Default is None, which uses ``||F||**2 / (1 + k)**2``.
     sigma_eps : float, optional
         The spectral coefficient is constrained to ``sigma_eps < sigma < 1/sigma_eps``.
-        Default: 1e-10
+        Default is 1e-10.
     sigma_0 : float, optional
-        Initial spectral coefficient.
-        Default: 1.0
+        Initial spectral coefficient. Default is 1.0.
     M : int, optional
         Number of iterates to include in the nonmonotonic line search.
-        Default: 10
-    line_search : {'cruz', 'cheng'}
+        Default is 10.
+    line_search : {'cruz', 'cheng'}, optional
         Type of line search to employ. 'cruz' is the original one defined in
         [Martinez & Raydan. Math. Comp. 75, 1429 (2006)], 'cheng' is
         a modified search defined in [Cheng & Li. IMA J. Numer. Anal. 29, 814 (2009)].
-        Default: 'cruz'
+        Default is 'cruz'.
 
     References
     ----------


### PR DESCRIPTION
## Description
This PR adds documentation for default parameter values in `optimize.root` and its solver methods, addressing issue #22635.

## Changes Made
Documented default values for optional parameters in:

- **`root()` main function**: Added default values for `method`, `jac`, `tol`, `callback`, and `options` parameters
- **`_root_hybr` (hybr method)**: Added defaults for `col_deriv`, `xtol`, `maxfev`, `band`, `eps`, `factor`, and `diag`
- **`_root_leastsq` (lm method)**: Added defaults for `col_deriv`, `ftol`, `xtol`, `gtol`, `maxiter`, `eps`, `factor`, and `diag`
- **`_root_df_sane` (df-sane method)**: Added/clarified defaults for `ftol`, `fatol`, `fnorm`, `maxfev`, `disp`, `callback`, `eta_strategy`, `sigma_eps`, `sigma_0`, `M`, and `line_search`

## Example of Change
Before:
```
xtol : float
    The calculation will terminate if the relative error between two
    consecutive iterates is at most `xtol`.
```

After:
```
xtol : float, optional
    The calculation will terminate if the relative error between two
    consecutive iterates is at most `xtol`. Default is 1.49012e-08.
```

## Related Issue
Closes #22635