### PR TITLE
BUG: sparse.csgraph.connected_components: fix BSR blocksize != (1,1) …

### DIFF
--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -32,7 +32,12 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
 
     if issparse(csgraph):
         if csr_output:
-            csgraph = csgraph.tocsr(copy=copy_if_sparse).astype(DTYPE, copy=False)
+            if csgraph.format == "bsr":
+                csgraph = csgraph.tocsr(copy=copy_if_sparse)
+                csgraph.eliminate_zeros()
+                csgraph = csgraph.astype(DTYPE, copy=False)
+            else:
+                csgraph = csgraph.tocsr(copy=copy_if_sparse).astype(DTYPE, copy=False)
         else:
             csgraph = csgraph_to_dense(csgraph, null_value=null_value_out)
     elif np.ma.isMaskedArray(csgraph):

--- a/scipy/sparse/csgraph/_validation.py
+++ b/scipy/sparse/csgraph/_validation.py
@@ -35,15 +35,15 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
             if csgraph.format == "bsr":
                 csgraph = csgraph.tocsr(copy=copy_if_sparse)
                 csgraph.eliminate_zeros()
-                csgraph = csgraph.astype(DTYPE, copy=False)
+                csgraph = csgraph.astype(dtype, copy=False)
             else:
-                csgraph = csgraph.tocsr(copy=copy_if_sparse).astype(DTYPE, copy=False)
+                csgraph = csgraph.tocsr(copy=copy_if_sparse).astype(dtype, copy=False)
         else:
             csgraph = csgraph_to_dense(csgraph, null_value=null_value_out)
     elif np.ma.isMaskedArray(csgraph):
         if dense_output:
             mask = csgraph.mask
-            csgraph = np.array(csgraph.data, dtype=DTYPE, copy=copy_if_dense)
+            csgraph = np.array(csgraph.data, dtype=dtype, copy=copy_if_dense)
             csgraph[mask] = null_value_out
         else:
             csgraph = csgraph_from_masked(csgraph)
@@ -55,7 +55,7 @@ def validate_graph(csgraph, directed, dtype=DTYPE,
                                                 nan_null=nan_null,
                                                 infinity_null=infinity_null)
             mask = csgraph.mask
-            csgraph = np.asarray(csgraph.data, dtype=DTYPE)
+            csgraph = np.asarray(csgraph.data, dtype=dtype)
             csgraph[mask] = null_value_out
         else:
             csgraph = csgraph_from_dense(csgraph, null_value=null_value_in,

--- a/scipy/sparse/csgraph/tests/test_connected_components.py
+++ b/scipy/sparse/csgraph/tests/test_connected_components.py
@@ -1,5 +1,6 @@
 import numpy as np
-from numpy.testing import assert_equal, assert_array_almost_equal
+from numpy.testing import assert_allclose, assert_equal, assert_array_almost_equal
+import pytest
 from scipy.sparse import bsr_array, csgraph, csr_array
 
 
@@ -118,33 +119,32 @@ def test_int64_indices_directed():
     assert_array_almost_equal(labels, [1, 0])
 
 
-def test_bsr_blocksize_connected_components():
-    graphs = [
-        np.array([[1, 0, 1, 0],
-                  [0, 1, 0, 0],
-                  [0, 0, 1, 0],
-                  [0, 0, 0, 1]]),
-        np.array([[1, 0, 0, 0],
-                  [0, 1, 0, 0],
-                  [0, 0, 1, 0],
-                  [0, 0, 0, 1]]),
-        np.array([[1, 0, 0, 0],
-                  [0, 1, 0, 0],
-                  [0, 0, 0, 0],
-                  [0, 0, 0, 0]]),
-    ]
+# regression test for gh-23142
+@pytest.mark.parametrize("graph", [
+    np.array([[1, 0, 1, 0],
+              [0, 1, 0, 0],
+              [0, 0, 1, 0],
+              [0, 0, 0, 1]]),
+    np.array([[1, 0, 0, 0],
+              [0, 1, 0, 0],
+              [0, 0, 1, 0],
+              [0, 0, 0, 1]]),
+    np.array([[1, 0, 0, 0],
+              [0, 1, 0, 0],
+              [0, 0, 0, 0],
+              [0, 0, 0, 0]]),
+])
+def test_bsr_blocksize_connected_components(graph):
+    reference_graph = bsr_array(graph, blocksize=(1, 1)).astype(bool)
+    sparse_graph = bsr_array(graph, blocksize=(2, 2)).astype(bool)
 
-    for graph in graphs:
-        reference_graph = bsr_array(graph, blocksize=(1, 1)).astype(bool)
-        sparse_graph = bsr_array(graph, blocksize=(2, 2)).astype(bool)
+    n_expected, lbl_expected = csgraph.connected_components(
+        reference_graph, directed=False, return_labels=True, connection="weak"
+    )
+    n_actual, lbl_actual = csgraph.connected_components(
+        sparse_graph, directed=False, return_labels=True, connection="weak"
+    )
 
-        n_expected, lbl_expected = csgraph.connected_components(
-            reference_graph, directed=False, return_labels=True, connection="weak"
-        )
-        n_actual, lbl_actual = csgraph.connected_components(
-            sparse_graph, directed=False, return_labels=True, connection="weak"
-        )
-
-        assert_equal(n_actual, n_expected)
-        assert_array_almost_equal(lbl_actual, lbl_expected)
+    assert_equal(n_actual, n_expected)
+    assert_allclose(lbl_actual, lbl_expected)
 

--- a/scipy/sparse/csgraph/tests/test_connected_components.py
+++ b/scipy/sparse/csgraph/tests/test_connected_components.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.testing import assert_equal, assert_array_almost_equal
-from scipy.sparse import csgraph, csr_array
+from scipy.sparse import bsr_array, csgraph, csr_array
 
 
 def test_weak_connections():
@@ -116,4 +116,35 @@ def test_int64_indices_directed():
                                              connection='strong')
     assert n == 2
     assert_array_almost_equal(labels, [1, 0])
+
+
+def test_bsr_blocksize_connected_components():
+    graphs = [
+        np.array([[1, 0, 1, 0],
+                  [0, 1, 0, 0],
+                  [0, 0, 1, 0],
+                  [0, 0, 0, 1]]),
+        np.array([[1, 0, 0, 0],
+                  [0, 1, 0, 0],
+                  [0, 0, 1, 0],
+                  [0, 0, 0, 1]]),
+        np.array([[1, 0, 0, 0],
+                  [0, 1, 0, 0],
+                  [0, 0, 0, 0],
+                  [0, 0, 0, 0]]),
+    ]
+
+    for graph in graphs:
+        reference_graph = bsr_array(graph, blocksize=(1, 1)).astype(bool)
+        sparse_graph = bsr_array(graph, blocksize=(2, 2)).astype(bool)
+
+        n_expected, lbl_expected = csgraph.connected_components(
+            reference_graph, directed=False, return_labels=True, connection="weak"
+        )
+        n_actual, lbl_actual = csgraph.connected_components(
+            sparse_graph, directed=False, return_labels=True, connection="weak"
+        )
+
+        assert_equal(n_actual, n_expected)
+        assert_array_almost_equal(lbl_actual, lbl_expected)
 


### PR DESCRIPTION
#### Reference issue
Closes gh-23142

#### What does this implement/fix?
Fix incorrect results from scipy.sparse.csgraph.connected_components when given a bsr_array with blocksize != (1, 1).
This PR calls `eliminate_zeros()` after converting BSR matrices to CSR in `validate_graph()`, ensuring only structural nonzeros are treated as edges.

Changes:

- Modify scipy/sparse/csgraph/_validation.py to eliminate explicit zeros after BSR → CSR conversion.
- Add regression test test_bsr_blocksize_connected_components() covering multiple graph configurations.

#### AI Disclosure:
Used Github Copilot for helping me find relevant files and understanding context. Everything else was done and verified manually by me. 