### PR TITLE
ENH: `stats.quantile`: support `nan_policy='omit'` with JAX backend

### DIFF
--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -104,29 +104,26 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
     n = _count_nonmasked(y, -1, xp=xp, keepdims=True)
     n = n if n_zero_weight is None else n - n_zero_weight
 
-    # Ideally this code will always be run for lazy arrays, but JAX JIT is having
-    # some trouble. For now, it's useful to have the rest of `quantile` working with
-    # JIX, so we can come back to this later.
-    if not is_lazy_array(y) and contains_nans:
+    if is_lazy_array(y) or contains_nans:
         nans = xp.isnan(y)
 
         # Note that if length along `axis` were 0 to begin with,
         # it is now length 1 and filled with NaNs.
         if nan_policy == 'propagate':
-            nan_out = xp.any(nans, axis=-1)
+            nan_out = xp.any(nans, axis=-1, keepdims=True)
         else:  # 'omit'
             n_int = n - xp.count_nonzero(nans, axis=-1, keepdims=True)
             n = xp.astype(n_int, dtype)
             # NaNs are produced only if slice is empty after removing NaNs
-            nan_out = xp.any(n == 0, axis=-1)
+            nan_out = n == 0
             n = xpx.at(n, nan_out).set(y.shape[-1])  # avoids pytorch/pytorch#146211
 
-        if xp.any(nan_out):
-            y = xp.asarray(y, copy=True)  # ensure writable
-            y = xpx.at(y, nan_out).set(xp.nan)
-        elif xp.any(nans) and method == 'harrell-davis':
+        if (is_lazy_array(nans) or xp.any(nans)) and (method == 'harrell-davis'):
             y = xp.asarray(y, copy=True)  # ensure writable
             y = xpx.at(y, nans).set(0)  # any non-nan will prevent NaN from propagating
+        if is_lazy_array(nan_out) or xp.any(nan_out):
+            y = xp.asarray(y, copy=True)  # ensure writable
+            y = xpx.at(y, xp.broadcast_to(nan_out, y.shape)).set(xp.nan)
 
     n = xp.asarray(n, dtype=dtype, device=xp_device(y))
 

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -179,7 +179,6 @@ class TestQuantile:
 
         xp_assert_close(res, xp.asarray(ref, dtype=dtype))
 
-    @skip_xp_backends("jax.numpy", reason='currently incompatible with JIT')
     @pytest.mark.filterwarnings("ignore:torch.searchsorted:UserWarning")
     @skip_xp_backends(cpu_only=True, reason="PyTorch doesn't have `betainc`.",
                       exceptions=['cupy', 'jax.numpy'])
@@ -313,7 +312,6 @@ class TestQuantile:
         ref = np.quantile(x, p, method=method, weights=weights)
         xp_assert_close(res, xp.asarray(ref, dtype=dtype))
 
-    @skip_xp_backends("jax.numpy", reason='currently incompatible with JIT')
     @pytest.mark.parametrize('method',
         ['inverted_cdf', 'averaged_inverted_cdf', 'closest_observation', 'hazen',
          'interpolated_inverted_cdf', 'linear','median_unbiased', 'normal_unbiased',

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -363,6 +363,8 @@ class TestQuantile:
         ref = stats.quantile(x, p, method=method)
         xp_assert_close(res, ref)
 
+    @skip_xp_backends(cpu_only=True, reason="PyTorch doesn't have `betainc`.",
+                      exceptions=['cupy', 'jax.numpy'])
     def test_all_nan_harrell_davis_gh24707(self, xp):
         # While working on gh-24707, there was a case in which if *all* elements of one
         # slice were NaN, only some elements of another slice were NaN, and

--- a/scipy/stats/tests/test_quantile.py
+++ b/scipy/stats/tests/test_quantile.py
@@ -363,6 +363,22 @@ class TestQuantile:
         ref = stats.quantile(x, p, method=method)
         xp_assert_close(res, ref)
 
+    def test_all_nan_harrell_davis_gh24707(self, xp):
+        # While working on gh-24707, there was a case in which if *all* elements of one
+        # slice were NaN, only some elements of another slice were NaN, and
+        # `nan_policy='omit'`, then the NaNs would not be ignored in the other slice.
+        # The same test case could fail with `nan_policy='propagate'` for a different
+        # reason, if the fix were not made carefully. Check that both these cases are
+        # resolved.
+        kwargs = dict(method='harrell-davis', axis=-1)
+        x = xp.asarray([[xp.nan, xp.nan, xp.nan], [xp.nan, 2, 3]])
+
+        res = stats.quantile(x, 0.5, **kwargs, nan_policy='omit')
+        xp_assert_close(res, xp.asarray([xp.nan, 2.5]))
+
+        res = stats.quantile(x, 0.5, **kwargs, nan_policy='propagate')
+        xp_assert_close(res, xp.asarray([xp.nan, xp.nan]))
+
 
 @_apply_over_batch(('a', 1), ('v', 1))
 def np_searchsorted(a, v, side):


### PR DESCRIPTION
#### Reference issue
Toward gh-20544

#### What does this implement/fix?
This allows `stats.quantile` to support `nan_policy='omit'` when JAX is the backend.

#### Additional information
~~Still thinking about lines 121-126. They're probably fine; just wondering why there was `elif` before.~~ There was a reason, but switching the order (as I had done) and making both `if` is even better. Added a test case that would fail in main, would fail in `main` for _two_ reasons if both statements were `if`, and passes in this PR.

~~Also, I should check whether this allows us to remove any other JAX skips.~~ I don't see any.

#### AI Generation Disclosure
No AI