### PR TITLE
MAINT: linalg/{svd, eig}: re-enable overwrite_a

### DIFF
--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -238,10 +238,20 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
             return w, vl
         return w, vr
 
-    if b is not None:
+    if b is None:
+        # regular eigenvalue problem
+        w, beta, vl, vr, err_lst  = _batched_linalg._eig(
+            a1, left, right, overwrite_a, False
+        )
+
+        if err_lst:
+            _check_format_errors_warnings("geev", err_lst)
+
+    else:
+        # b is not None: generalized eigenvalue problem
+
         b1 = _asarray_validated(b, check_finite=check_finite)
         a1, b1 = _ensure_dtype_cdsz(a1, b1)  # NB: makes a1.dtype == b1.dtype, if needed
-        overwrite_b = overwrite_b or (_datacopied(b1, b))
         b1, overwrite_b = _ensure_aligned_and_native(b1, overwrite_b)
 
         if len(b1.shape) < 2 or b1.shape[-1] != b1.shape[-2]:
@@ -255,7 +265,15 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         a1 = np.broadcast_to(a1, batch_shape + a1.shape[-2:])
         b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
-        w, beta, vl, vr, err_lst = _batched_linalg._eig(a1, left, right, overwrite_a, False, b1)
+        # check if we can work in-place (a1 might have been broadcast by b1)
+        overwrite_a = overwrite_a and (a1.ndim == 2)
+
+        overwrite_b = overwrite_b or (_datacopied(b1, b))
+        overwrite_b = overwrite_b and (b1.ndim == 2) and (b1.flags["F_CONTIGUOUS"])
+
+        w, beta, vl, vr, err_lst = _batched_linalg._eig(
+            a1, left, right, overwrite_a, overwrite_b, b1
+        )
 
         if err_lst:
             _check_format_errors_warnings("ggev", err_lst)
@@ -265,12 +283,6 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
             vr /= np.linalg.vector_norm(vr, axis=-2, keepdims=True)
         if left:
             vl /= np.linalg.vector_norm(vl, axis=-2, keepdims=True)
-
-    else:
-        w, beta, vl, vr, err_lst  = _batched_linalg._eig(a1, left, right, overwrite_a, False)
-
-        if err_lst:
-            _check_format_errors_warnings("geev", err_lst)
 
     w = _make_eigvals(w, beta, homogeneous_eigvals)
 

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -215,11 +215,12 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
             f"Expected a square matrix or a batch of square matrices. Got {a.shape = }"
         )
 
-    overwrite_a = overwrite_a or (_datacopied(a1, a))
-
     # Also check if dtype is LAPACK compatible
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
     a1, overwrite_a = _ensure_aligned_and_native(a1, overwrite_a)
+
+    overwrite_a = overwrite_a or (_datacopied(a1, a))
+    overwrite_a = overwrite_a and (a1.ndim == 2) and (a1.flags["F_CONTIGUOUS"])
 
     # accommodate empty arrays
     if a1.shape[-1] == 0 or a1.shape[-2] == 0:
@@ -254,7 +255,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         a1 = np.broadcast_to(a1, batch_shape + a1.shape[-2:])
         b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
-        w, beta, vl, vr, err_lst = _batched_linalg._eig(a1, left, right, b1)
+        w, beta, vl, vr, err_lst = _batched_linalg._eig(a1, left, right, overwrite_a, False, b1)
 
         if err_lst:
             _check_format_errors_warnings("ggev", err_lst)
@@ -266,7 +267,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
             vl /= np.linalg.vector_norm(vl, axis=-2, keepdims=True)
 
     else:
-        w, beta, vl, vr, err_lst  = _batched_linalg._eig(a1, left, right)
+        w, beta, vl, vr, err_lst  = _batched_linalg._eig(a1, left, right, overwrite_a, False)
 
         if err_lst:
             _check_format_errors_warnings("geev", err_lst)

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -150,7 +150,6 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     # basic sanity checks of the input matrix
     a1 = _asarray_validated(a, check_finite=check_finite)
 
-    overwrite_a = overwrite_a or (_datacopied(a1, a))
     if a1.ndim < 2:
         raise ValueError(f"Expected at least ndim=2, got {a1.ndim=}")
 
@@ -159,6 +158,9 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
     # Also check if dtype is LAPACK compatible
     a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
     a1, overwrite_a = _ensure_aligned_and_native(a1, overwrite_a)
+
+    overwrite_a = overwrite_a or (_datacopied(a1, a))
+    overwrite_a = overwrite_a and (a1.ndim == 2) and (a1.flags["F_CONTIGUOUS"])
 
     # accommodate empty matrix
     if a1.size == 0:
@@ -195,7 +197,9 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
                                   "Instead, either use using numpy.linalg.svd or build"
                                   "SciPy with ILP64 support.")
 
-    res = _batched_linalg._svd(a1, lapack_driver, compute_uv, full_matrices)
+    res = _batched_linalg._svd(
+        a1, lapack_driver, compute_uv, full_matrices, overwrite_a
+    )
 
     err_lst = res[-1]
     if err_lst:

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -666,6 +666,8 @@ _linalg_eig(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyArrayObject *ap_vl = NULL;
     int compute_vl=0;
     int compute_vr=1;
+    int overwrite_a=0;
+    int overwrite_b=0;
 
     int info = 0;
     SliceStatusVec vec_status;
@@ -677,9 +679,10 @@ _linalg_eig(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyObject *beta_ret = NULL;
 
     // Get the input array
-    if (!PyArg_ParseTuple(args, "O!pp|O!",
+    if (!PyArg_ParseTuple(args, "O!pppp|O!",
             &PyArray_Type, (PyObject **)&ap_Am,
             &compute_vl, &compute_vr,
+            &overwrite_a, &overwrite_b,
             &PyArray_Type, (PyObject **)&ap_Bm)
     ) {
         return NULL;
@@ -747,16 +750,16 @@ _linalg_eig(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _eig<float>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, vec_status);
+            info = _eig<float>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _eig<double>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, vec_status);
+            info = _eig<double>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _eig<npy_complex64>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, vec_status);
+            info = _eig<npy_complex64>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _eig<npy_complex128>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, vec_status);
+            info = _eig<npy_complex128>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, overwrite_a, overwrite_b, vec_status);
             break;
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -390,6 +390,7 @@ _linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
     const char *lapack_driver = NULL;
     int compute_uv = 1;
     int full_matrices = 1;
+    int overwrite_a = 0;
     PyArrayObject *ap_S = NULL, *ap_U = NULL, *ap_Vh = NULL;
     PyObject *ret_lst;
 
@@ -397,7 +398,7 @@ _linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
     SliceStatusVec vec_status;
 
     // Get the input array
-    if (!PyArg_ParseTuple(args, "O!s|pp", &PyArray_Type, (PyObject **)&ap_Am,  &lapack_driver, &compute_uv, &full_matrices)) {
+    if (!PyArg_ParseTuple(args, "O!s|ppp", &PyArray_Type, (PyObject **)&ap_Am,  &lapack_driver, &compute_uv, &full_matrices, &overwrite_a)) {
         return NULL;
     }
 
@@ -472,16 +473,16 @@ _linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _svd<float>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, vec_status);
+            info = _svd<float>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, overwrite_a, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _svd<double>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, vec_status);
+            info = _svd<double>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, overwrite_a, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _svd<npy_complex64>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, vec_status);
+            info = _svd<npy_complex64>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, overwrite_a, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _svd<npy_complex128>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, vec_status);
+            info = _svd<npy_complex128>(ap_Am, ap_U, ap_S, ap_Vh, jobz, lapack_driver, overwrite_a, vec_status);
             break;
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -35,7 +35,7 @@ transform_eigvecs(cmplx_type dst, real_type *v, CBLAS_INT ldv, CBLAS_INT n, real
 
 template<typename T>
 int
-_reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArrayObject *ap_vr, SliceStatusVec& vec_status)
+_reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArrayObject *ap_vr, int overwrite_a, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     using npy_complex_type = typename sp_type_traits<T>::npy_complex_type;
@@ -92,8 +92,25 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     lwork = _calc_lwork(tmp);
     if (lwork < 0) { free(rwork); return -102; }
 
-    // allocate
-    npy_intp bufsize = n*n + lwork + n;
+    /*
+     * Allocate memory and chop the buffer into parts
+     *
+     *     lwork        n      data_size   wi_size
+     * |-----------|---------|-----------|----------|---------|-------|
+     * ^           ^         ^           ^          ^         ^
+     * work        wr        data        wi         buf_vl    buf_vr
+     *
+     * Here
+     *   - data is n*n if overwrite_a is False (and =0 otherwise)
+     *   - wr & wi are eigenvalues;
+     *     wr is always length n; wi is only used for real inputs (s- and d-geev
+     *     have both in `wr` and `wi` arguments, while c- and z-geev only have `wr`)
+     *   - `buf_vl` and `buf_vr` hold eigenvectors if requested via `compute_{vl,vr}`.
+     *
+     * NB: we do not implement jobz='O' yet, so we never reuse A for U or Vh.
+     */
+    npy_intp data_size= overwrite_a ? 0 : n*n ;
+    npy_intp bufsize = data_size + lwork + n;
     npy_intp wi_size = sp_type_traits<T>::is_complex ? 0 : n ;
     bufsize += wi_size;
 
@@ -105,18 +122,26 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     if (buf == NULL) { free(rwork); return -103; }
 
     // partition the workspace
-    T *data = &buf[0];
-    T *work = &buf[n*n];
-    T *wr = &buf[n*n + lwork];
+//    T *data=NULL, *work=NULL;
+    T *work = &buf[0];
+    T *wr = &buf[lwork];
+
+    T *data = NULL;
+    if (overwrite_a) {
+        // work in-place (2D only, ensured at the python call site)
+        data = (T *)Am_data;
+    } else {
+        data = &buf[lwork + n];
+    }
 
     T *wi = NULL;
-    if(wi_size > 0) { wi = &buf[n*n + lwork + n]; }
+    if(wi_size > 0) { wi = &buf[lwork + n + data_size]; }
 
     T *buf_vl = NULL;
-    if(vl_size > 0) { buf_vl = &buf[n*n + lwork + n + wi_size]; }
+    if(vl_size > 0) { buf_vl = &buf[lwork + n + data_size + wi_size]; }
 
     T *buf_vr = NULL;
-    if(vr_size > 0) { buf_vr = &buf[n*n + lwork + n + wi_size + vl_size]; }
+    if(vr_size > 0) { buf_vr = &buf[lwork + n + data_size + wi_size + vl_size]; }
 
     // --------------------------------------------------------------------
     // Main loop to traverse the slices
@@ -124,9 +149,13 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     for (npy_intp idx = 0; idx < outer_size; idx++) {
         init_status(slice_status, idx, St::GENERAL);
 
-        // copy the slice to `data` in F order
-        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
-        copy_slice_F(data, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
+        if (!overwrite_a) {
+            // copy the slice to `data` in F order
+            T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+            copy_slice_F(data, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
+        }
+        // NB: overwrite_a is for 2D only; if it is ever generalized to ndim>2,
+        // will need to adjust the data pointer here, too.
 
         // compute eigenvalues for the slice
         call_geev(&jobvl, &jobvr, &intn, data, &lda, wr, wi, buf_vl, &ldvl, buf_vr, &ldvr, work, &lwork, rwork, &info);
@@ -181,7 +210,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
 
 template<typename T>
 int
-_gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArrayObject *ap_beta, PyArrayObject *ap_vl, PyArrayObject *ap_vr, SliceStatusVec& vec_status)
+_gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArrayObject *ap_beta, PyArrayObject *ap_vl, PyArrayObject *ap_vr, int overwrite_a, int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     using npy_complex_type = typename sp_type_traits<T>::npy_complex_type;
@@ -346,19 +375,23 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
 template<typename T>
 int
-_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArrayObject *ap_beta, PyArrayObject *ap_vl, PyArrayObject *ap_vr, SliceStatusVec& vec_status)
-{
+_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm,
+     PyArrayObject *ap_w, PyArrayObject *ap_beta,
+     PyArrayObject *ap_vl, PyArrayObject *ap_vr,
+     int overwrite_a, int overwrite_b,
+     SliceStatusVec& vec_status
+) {
     int info;
     if (ap_Bm == NULL) {
         // sanity check: B and beta are either both NULL or both not NULL (for a generalized eig problem) 
         if (ap_beta != NULL) { return -222; }
 
-        info = _reg_eig<T>(ap_Am, ap_w, ap_vl, ap_vr, vec_status);
+        info = _reg_eig<T>(ap_Am, ap_w, ap_vl, ap_vr, overwrite_a, vec_status);
     }
     else {
         if (ap_beta == NULL) {return -223; }
 
-        info = _gen_eig<T>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, vec_status);
+        info = _gen_eig<T>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, overwrite_a, overwrite_b, vec_status);
     }
     return info;
 }

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -121,7 +121,6 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     if (buf == NULL) { free(rwork); return -103; }
 
     // partition the workspace
-//    T *data=NULL, *work=NULL;
     T *work = &buf[0];
     T *wr = &buf[lwork];
 
@@ -272,33 +271,63 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
     lwork = _calc_lwork(tmp);
     if (lwork < 0) { free(rwork); return -102; }
 
-    // allocate
-    npy_intp bufsize = n*n + n*n + lwork + n + n;
+    /*
+     * Allocate memory and chop the buffer into parts
+     *
+     *     lwork        n        n        n/0      n*n/0    n*n/0    n*n/0   n*n/0
+     * |-----------|---------|-------|----------|---------|-------|--------|--------|
+     * ^           ^         ^       ^          ^         ^       ^        ^
+     * work        alphar    beta    alphai     data_A    data_B  buf_vl   buf_vr
+     *
+     * Here
+     *   - A_size & B_size are n*n if overwrite_{a,b} is False (and =0 otherwise)
+     *   - alphar & beta are eigenvalues, size `n` (always allocated)
+     *   - alphai is the imaginary part of eigenvalues, size `n` if real, 0 otherwise
+     *     (s- and d-ggev have both in `alphar` and `alphai` arguments, while c- and
+     *     z-geev only have `alphar`)
+     *   - `buf_vl` and `buf_vr` hold eigenvectors if requested via `compute_{vl,vr}`.
+     *
+     * NB: we do not implement jobz='O' yet, so we never reuse A for U or Vh.
+     */
     npy_intp alphai_size = sp_type_traits<T>::is_complex ? 0 : n ;
-    bufsize += alphai_size;
-
+    npy_intp A_size = overwrite_a ? 0 : n*n;
+    npy_intp B_size = overwrite_b ? 0 : n*n;
     npy_intp vl_size = compute_vl ? ldvl*n : 0;
     npy_intp vr_size = compute_vr ? ldvr*n : 0;
-    bufsize += vl_size + vr_size;
+
+    npy_intp bufsize = lwork + n + n + alphai_size + A_size + B_size  + vl_size + vr_size;
 
     T *buf = (T *)malloc(bufsize*sizeof(T));
     if (buf == NULL) { free(rwork); return -103; }
 
-    // partition the workspace
-    T *data_A = &buf[0];
-    T *data_B = &buf[n*n];
-    T *work = &buf[2*n*n];
-    T *alphar = &buf[2*n*n + lwork];
-    T *beta = &buf[2*n*n + lwork + n];
+    T *work = &buf[0];
+    T *alphar = &buf[lwork];
+    T *beta = &buf[lwork + n];
 
     T *alphai = NULL;
-    if(alphai_size > 0) { alphai = &buf[2*n*n + lwork + 2*n ]; }
+    if(alphai_size > 0) { alphai = &buf[lwork + 2*n]; }
+
+    T *data_A = NULL;
+    if (overwrite_a) {
+        // work in-place (2D only, ensured at the python call site)
+        data_A = (T *)Am_data;
+    } else {
+        data_A = &buf[lwork + 2*n + alphai_size];
+    }
+
+    T *data_B = NULL;
+    if (overwrite_b) {
+        // work in-place (2D only, ensured at the python call site)
+        data_B = (T *)Bm_data;
+    } else {
+        data_B = &buf[lwork + 2*n + alphai_size + A_size];
+    }
 
     T *buf_vl = NULL;
-    if(vl_size > 0) { buf_vl = &buf[2*n*n + lwork + 2*n + alphai_size]; }
+    if(vl_size > 0) { buf_vl = &buf[lwork + 2*n + alphai_size + A_size + B_size]; }
 
     T *buf_vr = NULL;
-    if(vr_size > 0) { buf_vr = &buf[2*n*n + lwork + 2*n + alphai_size + vl_size]; }
+    if(vr_size > 0) { buf_vr = &buf[lwork + 2*n + alphai_size + vl_size + A_size + B_size]; }
 
 
     // --------------------------------------------------------------------
@@ -307,12 +336,20 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
     for (npy_intp idx = 0; idx < outer_size; idx++) {
         init_status(slice_status, idx, St::GENERAL);
 
-        // copy the slice to `data` in F order
-        T *slice_ptr_A = compute_slice_ptr(idx, Am_data, ndim, shape, strides_A);
-        copy_slice_F(data_A, slice_ptr_A, n, n, strides_A[ndim-2], strides_A[ndim-1]);
+        if (!overwrite_a) {
+            // copy the slice to `data` in F order
+            T *slice_ptr_A = compute_slice_ptr(idx, Am_data, ndim, shape, strides_A);
+            copy_slice_F(data_A, slice_ptr_A, n, n, strides_A[ndim-2], strides_A[ndim-1]);
+        }
+        // NB: overwrite_a is for 2D F-ordered input only; if it is ever generalized to ndim>2,
+        // will need to adjust the data pointer here, too.
 
-        T *slice_ptr_B = compute_slice_ptr(idx, Bm_data, ndim, shape, strides_B);
-        copy_slice_F(data_B, slice_ptr_B, n, n, strides_B[ndim-2], strides_B[ndim-1]);
+        if (!overwrite_b) {
+            T *slice_ptr_B = compute_slice_ptr(idx, Bm_data, ndim, shape, strides_B);
+            copy_slice_F(data_B, slice_ptr_B, n, n, strides_B[ndim-2], strides_B[ndim-1]);
+        }
+        // same deal as with overwrite_a
+
 
         // compute eigenvalues for the slice
         call_ggev(&jobvl, &jobvr, &intn, data_A, &lda, data_B, &ldb, alphar, alphai, beta, buf_vl, &ldvl, buf_vr, &ldvr, work, &lwork, rwork, &info);

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -109,10 +109,9 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
      *
      * NB: we do not implement jobz='O' yet, so we never reuse A for U or Vh.
      */
-    npy_intp data_size= overwrite_a ? 0 : n*n ;
-    npy_intp bufsize = data_size + lwork + n;
-    npy_intp wi_size = sp_type_traits<T>::is_complex ? 0 : n ;
-    bufsize += wi_size;
+    npy_intp data_size = overwrite_a ? 0 : n*n;
+    npy_intp wi_size = sp_type_traits<T>::is_complex ? 0 : n;
+    npy_intp bufsize = data_size + wi_size + lwork + n;
 
     npy_intp vl_size = compute_vl ? ldvl*n : 0;
     npy_intp vr_size = compute_vr ? ldvr*n : 0;
@@ -154,7 +153,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
             T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
             copy_slice_F(data, slice_ptr, n, n, strides[ndim-2], strides[ndim-1]);
         }
-        // NB: overwrite_a is for 2D only; if it is ever generalized to ndim>2,
+        // NB: overwrite_a is for 2D F-ordered input only; if it is ever generalized to ndim>2,
         // will need to adjust the data pointer here, too.
 
         // compute eigenvalues for the slice

--- a/scipy/linalg/src/_linalg_svd.hh
+++ b/scipy/linalg/src/_linalg_svd.hh
@@ -43,7 +43,7 @@ u_vh_shapes(npy_intp m, npy_intp n, char jobz,
 
 template<typename T>
 int
-_svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, SliceStatusVec& vec_status)
+_svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, int overwrite_a, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -94,8 +94,23 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     lwork = (CBLAS_INT)(real_part(tmp));
     if(lwork == 0) { lwork = 1; }
 
-    // allocate
-    npy_intp bufsize = m*n + lwork;
+    /*
+     * Allocate memory and chop the buffer into parts
+     *
+     *    lwork     data_size         
+     * |----------|-----------|----------|------|
+     * ^          ^           ^          ^      
+     * work       data        buf_U     buf_Vh
+     *
+     * Here
+     *   - data is m*n if overwrite_a is False (and =0 otherwise)
+     *   - buf_U is u_shape0*u_shape1 if jobz !='N' (and =0 otherwise)
+     *   - buf_Vh is vh_shape0*vh_shapw1 if jobz != 'N' (and =0 otherwise)
+     *
+     * NB: we do not implement jobz='O' yet, so we never reuse A for U or Vh.
+     */
+    npy_intp data_size = overwrite_a ? 0 : m*n;
+    npy_intp bufsize = data_size + lwork;
     if (jobz != 'N') {
         bufsize += u_shape0 * u_shape1 + vh_shape0 * vh_shape1;    // U and Vh, if referenced
     }
@@ -104,14 +119,19 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     if (buf == NULL) { info = -101; return (int)info; }
 
     // partition the workspace
-    T *data = &buf[0];
-    T *work = &buf[m*n];
+    T *work = &buf[0];
+    T *data;
+    if (overwrite_a) {
+        data = (T *)Am_data;
+    } else {
+        data = &buf[lwork];
+    }
 
     T *buf_U = NULL;
     T *buf_Vh = NULL;
     if (jobz != 'N') {
-        buf_U = &buf[m*n + lwork];
-        buf_Vh = &buf[m*n + lwork + u_shape0*u_shape1];
+        buf_U = &buf[data_size + lwork];
+        buf_Vh = &buf[data_size + lwork + u_shape0*u_shape1];
     }
 
     CBLAS_INT *iwork = NULL;
@@ -146,9 +166,11 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     for (npy_intp idx = 0; idx < outer_size; idx++) {
         init_status(slice_status, idx, St::GENERAL);
 
-        // copy the slice to `data` in F order
-        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
-        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        if (!overwrite_a) {
+            // copy the slice to `data` in F order
+            T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+            copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        }
 
         // SVD the slice
         call_gesdd(&jobz, &intm, &intn, data, &intm, ptr_S, buf_U, &ldu, buf_Vh, &ldvh, work, &lwork, rwork, iwork, &info);
@@ -185,7 +207,7 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
 
 template<typename T>
 int
-_svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, SliceStatusVec& vec_status)
+_svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, int overwrite_a, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -235,8 +257,23 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     lwork = (CBLAS_INT)(real_part(tmp));
     if(lwork == 0) { lwork = 1; }
 
-    // allocate
-    npy_intp bufsize = m*n + lwork;
+    /*
+     * Allocate memory and chop the buffer into parts
+     *
+     *    lwork     data_size         
+     * |----------|-----------|----------|------|
+     * ^          ^           ^          ^      
+     * work       data        buf_U     buf_Vh
+     *
+     * Here
+     *   - data is m*n if overwrite_a is False (and =0 otherwise)
+     *   - buf_U is u_shape0*u_shape1 if jobz !='N' (and =0 otherwise)
+     *   - buf_Vh is vh_shape0*vh_shapw1 if jobz != 'N' (and =0 otherwise)
+     *
+     * NB: we do not implement jobz='O' yet, so we never reuse A for U or Vh.
+     */
+    npy_intp data_size = overwrite_a ? 0 : m*n;
+    npy_intp bufsize = data_size + lwork;
     if (jobz != 'N') {
         bufsize += u_shape0 * u_shape1 + vh_shape0 * vh_shape1;    // U and Vh, if referenced
     }
@@ -245,14 +282,19 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     if (buf == NULL) { info = -101; return (int)info; }
 
     // partition the workspace
-    T *data = &buf[0];
-    T *work = &buf[m*n];
+    T *work = &buf[0];
+    T *data;
+    if (overwrite_a) {
+        data = (T *)Am_data;
+    } else {
+        data = &buf[lwork];
+    }
 
     T *buf_U = NULL;
     T *buf_Vh = NULL;
     if (jobz != 'N') {
-        buf_U = &buf[m*n + lwork];
-        buf_Vh = &buf[m*n + lwork + u_shape0*u_shape1];
+        buf_U = &buf[data_size + lwork];
+        buf_Vh = &buf[data_size + lwork + u_shape0*u_shape1];
     }
 
     real_type *rwork = NULL;
@@ -271,9 +313,11 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     for (npy_intp idx = 0; idx < outer_size; idx++) {
         init_status(slice_status, idx, St::GENERAL);
 
-        // copy the slice to `data` in F order
-        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
-        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        if (!overwrite_a) {
+            // copy the slice to `data` in F order
+            T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+            copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        }
 
         // SVD the slice
         call_gesvd(&jobz, &jobz, &intm, &intn, data, &intm, ptr_S, buf_U, &ldu, buf_Vh, &ldvh, work, &lwork, rwork, &info);
@@ -309,14 +353,14 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
 
 template<typename T>
 int
-_svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, const char * lapack_driver, SliceStatusVec& vec_status)
+_svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, const char * lapack_driver, int overwrite_a, SliceStatusVec& vec_status)
 {
     int info;
     if (strcmp(lapack_driver, "gesdd") == 0) {
-        info = _svd_gesdd<T>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+        info = _svd_gesdd<T>(ap_Am, ap_U, ap_S, ap_Vh, jobz, overwrite_a, vec_status);
     }
     else if (strcmp(lapack_driver, "gesvd") == 0) {
-        info = _svd_gesvd<T>(ap_Am, ap_U, ap_S, ap_Vh, jobz, vec_status);
+        info = _svd_gesvd<T>(ap_Am, ap_U, ap_S, ap_Vh, jobz, overwrite_a, vec_status);
     }
     else {
         // should have been validated at call site, really

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1260,6 +1260,52 @@ class TestSVD_GESDD:
 
         assert s.dtype == s0.dtype
 
+    @pytest.mark.parametrize("dtyp", [int, float, complex])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    @pytest.mark.parametrize("ndim", [2, 3])
+    @pytest.mark.parametrize("overwrite_a", [True, False])
+    @pytest.mark.parametrize("full_matrices", [True, False])
+    @pytest.mark.parametrize("mn", [(3, 5), (5, 3)])
+    def test_overwrite(self, dtyp, order, ndim, overwrite_a, full_matrices, mn):
+        m, n = mn
+        a = np.arange(m*n).reshape(m, n)
+        a = a.astype(dtype=dtyp, order=order)
+
+        if ndim == 3:
+            a = np.stack([a, 2*a])
+
+        a_ref = a.copy()
+
+        u, s, vh = svd(
+            a,
+            lapack_driver=self.lapack_driver,
+            full_matrices=full_matrices,
+            overwrite_a=overwrite_a,
+            compute_uv=True
+        )
+
+        # check that the result is correct
+        if full_matrices:
+            diag_s = diagsvd(s, m, n)
+        else:
+            if ndim == 2:
+                diag_s = np.diag(s)
+            else:
+                diag_s = np.stack([np.diag(x) for x in s])
+
+        assert_allclose(u @ diag_s @ vh, a_ref, atol=1e-12)
+
+        # see if the memory was reused
+        a_inplace = (
+            overwrite_a and
+            (a.dtype != int) and
+            (a.ndim == 2) and
+            a.flags['F_CONTIGUOUS']
+        )
+
+        assert (a == a_ref).all() != a_inplace
+
+
 class TestSVD_GESVD(TestSVD_GESDD):
     lapack_driver = 'gesvd'
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -469,6 +469,78 @@ class TestEig:
                 else:
                     assert_allclose(res[i, j], ref)
 
+    @pytest.mark.parametrize("dtyp", [int, float, complex])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    @pytest.mark.parametrize("ndim", [2, 3])
+    @pytest.mark.parametrize("overwrite_a", [True, False])
+    def test_overwrite_reg(self, dtyp, order, ndim, overwrite_a):
+        n = 3
+        a = np.arange(n*n).reshape(n, n)
+        a = a.astype(dtype=dtyp, order=order)
+
+        if ndim == 3:
+            a = np.stack([a, 2*a])
+
+        a_ref = a.copy()
+
+        w, v = eig(a, overwrite_a=overwrite_a)
+
+        # see if the memory was reused
+        a_inplace = (
+            overwrite_a and
+            (a.dtype != int) and
+            (a.ndim == 2) and
+            a.flags['F_CONTIGUOUS']
+        )
+
+        assert (a == a_ref).all() != a_inplace
+
+    @pytest.mark.parametrize("dtyp_a", [int, float, complex])
+    @pytest.mark.parametrize("dtyp_b", [int, float, complex])
+    @pytest.mark.parametrize("order_a", ["C", "F"])
+    @pytest.mark.parametrize("order_b", ["C", "F"])
+    @pytest.mark.parametrize("ndim_a", [2, 3])
+    @pytest.mark.parametrize("ndim_b", [2, 3])
+    @pytest.mark.parametrize("overwrite_a", [True, False])
+    @pytest.mark.parametrize("overwrite_b", [True, False])
+    def test_overwrite_gen(
+        self, dtyp_a, dtyp_b, order_a, order_b, ndim_a, ndim_b, overwrite_a, overwrite_b
+    ):
+        n = 3
+        a = np.arange(n*n).reshape(n, n)
+        a = a.astype(dtype=dtyp_a, order=order_a)
+
+        b = np.arange(n*n).reshape(n, n)
+        b = b.astype(dtype=dtyp_b, order=order_b)
+
+        if ndim_a == 3:
+            a = np.stack([a, 2*a])
+        if ndim_b == 3:
+            b = np.stack([b, 2*b])
+
+        a_ref = a.copy()
+        b_ref = b.copy()
+
+        w, v = eig(a, b, overwrite_a=overwrite_a, overwrite_b=overwrite_b)
+
+        # see if the memory was reused
+        a_inplace = (
+            overwrite_a and
+            (a.dtype != int) and
+            (a.ndim == 2) and
+            a.flags['F_CONTIGUOUS']
+        )
+
+        b_inplace = (
+            overwrite_b and
+            (b.dtype != int) and
+            (b.ndim == 2) and
+            b.flags['F_CONTIGUOUS']
+        )
+
+        assert (a == a_ref).all() != a_inplace
+        assert (b == b_ref).all() != b_inplace
+
 
 class TestEigBanded:
     def setup_method(self):

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -526,20 +526,20 @@ class TestEig:
         # see if the memory was reused
         a_inplace = (
             overwrite_a and
-            (a.dtype != int) and
-            (a.ndim == 2) and
+            (a.dtype != int) and (a.dtype == np.result_type(a, b)) and
+            (a.ndim == 2) and (b.ndim == 2) and
             a.flags['F_CONTIGUOUS']
         )
 
         b_inplace = (
             overwrite_b and
-            (b.dtype != int) and
-            (b.ndim == 2) and
+            (b.dtype != int) and (b.dtype == np.result_type(a, b)) and
+            (a.ndim == 2) and (b.ndim == 2) and
             b.flags['F_CONTIGUOUS']
         )
 
-        assert (a == a_ref).all() != a_inplace
-        assert (b == b_ref).all() != b_inplace
+        assert (a == a_ref).all() != a_inplace, 'A'
+        assert (b == b_ref).all() != b_inplace, 'B'
 
 
 class TestEigBanded:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/24645
Also cross-ref https://github.com/scipy/scipy/issues/9682 which talked about SVD specifically.

#### What does this implement/fix?
<!--Please explain your changes.-->

Implement `overwrite_a` for `linalg.svd` and `linalg.eig`, following the same approach as https://github.com/scipy/scipy/pull/24442
Since we only implement `?gesvd/?gesdd` options `job{u,vt} = 'A', 'S', 'N'` and do not implement `'O'`, so we never reuse A for U or Vh.  In scipy==1.17.x, the f2py wrappers did not implement `'O'` either, so this PR makes memory requirements same as in 1.17.x : we save `M*N` of memory if the input is 2D and fortran-ordered.


#### Additional information
<!--Any additional information you think is important.-->

Two potential enhancements are possible but are not attempted here:
- Actually implement  `jobu/jobvt = 'O'` so that we can further reuse A for U or Vh. This would be I believe similar to what https://github.com/scipy/scipy/pull/24268#issuecomment-3941554495 envisioned for QR.
- Implement `overwrite_a` for `ndim > 2`. https://github.com/scipy/scipy/issues/24645 has links to a related discussion.

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.