### PR TITLE
DEP: interpolate: deprecate "impractical" functions

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -353,7 +353,10 @@ plot_pre_code = """
 import warnings
 for key in (
         '`kurtosistest` p-value may be',  # intentionally "bad" example in docstring
-        'odr'
+        'odr',
+        'pade',
+        'lagrange',
+        'approximate_taylor_polynomial',
         ):
     warnings.filterwarnings(action='ignore', message='.*' + key + '.*')
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -646,7 +646,7 @@ if HAVE_SCPDT:
         'scipy.io.matlab.MatlabOpaque.dtype',
         'scipy.io.matlab.MatlabOpaque.strides',
         'scipy.io.matlab.MatlabFunction.strides',
-        'scipy.io.matlab.MatlabFunction.dtype'
+        'scipy.io.matlab.MatlabFunction.dtype',
         # deprecated
         'scipy.interpolate.lagrange',
         'scipy.interpolate.approximate_taylor_polynomial',

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -647,6 +647,10 @@ if HAVE_SCPDT:
         'scipy.io.matlab.MatlabOpaque.strides',
         'scipy.io.matlab.MatlabFunction.strides',
         'scipy.io.matlab.MatlabFunction.dtype'
+        # deprecated
+        'scipy.interpolate.lagrange',
+        'scipy.interpolate.approximate_taylor_polynomial',
+        'scipy.interpolate.pade'
     ])
 
     # help pytest collection a bit: these names are either private

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1,5 +1,5 @@
 __all__ = ['interp1d', 'interp2d', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
-
+import os
 from math import prod
 from types import GenericAlias
 import warnings
@@ -98,9 +98,10 @@ def lagrange(x, w):
     >>> plt.show()
 
     """
+    _warn_skips = (os.path.dirname(__file__),)
     msg = ("`lagrange` is deprecated and will be removed in SciPy 1.20.0. Use "
            "`scipy.interpolate.BarycentricInterpolator` instead.")
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    warnings.warn(msg, DeprecationWarning, skip_file_prefixes=_warn_skips)
     M = len(x)
     p = poly1d(0.0)
     for j in range(M):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2,6 +2,7 @@ __all__ = ['interp1d', 'interp2d', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
 
 from math import prod
 from types import GenericAlias
+import warnings
 
 import numpy as np
 from numpy import array, asarray, intp, poly1d, searchsorted
@@ -28,6 +29,10 @@ def lagrange(x, w):
 
     Warning: This implementation is numerically unstable. Do not expect to
     be able to use more than about 20 points even if they are chosen optimally.
+
+    .. deprecated:: 1.18.0
+        This function is deprecated and will be removed in SciPy 1.20.0. Use
+        `scipy.interpolate.BarycentricInterpolator` instead.
 
     Parameters
     ----------
@@ -92,7 +97,9 @@ def lagrange(x, w):
     >>> plt.show()
 
     """
-
+    msg = ("`lagrange` is deprecated and will be removed in SciPy 1.20.0. Use "
+           "`scipy.interpolate.BarycentricInterpolator` instead.")
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
     M = len(x)
     p = poly1d(0.0)
     for j in range(M):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -20,6 +20,7 @@ from ._interpnd import _ndim_coords_from_arrays
 from ._bsplines import make_interp_spline, BSpline
 
 
+@xp_capabilities(out_of_scope=True)
 def lagrange(x, w):
     r"""
     Return a Lagrange interpolating polynomial.

--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -1,3 +1,5 @@
+import warnings
+
 from numpy import zeros, asarray, eye, poly1d, hstack, r_
 from scipy import linalg
 
@@ -6,6 +8,10 @@ __all__ = ["pade"]
 def pade(an, m, n=None):
     """
     Return Pade approximation to a polynomial as the ratio of two polynomials.
+
+    .. deprecated:: 1.18.0
+        This function is deprecated and will be removed in SciPy 1.20.0. Use
+        `mpmath.pade` instead.
 
     Parameters
     ----------
@@ -42,6 +48,9 @@ def pade(an, m, n=None):
     2.7179487179487181
 
     """
+    msg = ("`pade` is deprecated and will be removed in SciPy 1.20.0. Use "
+           "`mpmath.pade` instead.")
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
     an = asarray(an)
     if n is None:
         n = len(an) - 1 - m

--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -2,9 +2,11 @@ import warnings
 
 from numpy import zeros, asarray, eye, poly1d, hstack, r_
 from scipy import linalg
+from scipy._lib._array_api import xp_capabilities
 
 __all__ = ["pade"]
 
+@xp_capabilities(out_of_scope=True)
 def pade(an, m, n=None):
     """
     Return Pade approximation to a polynomial as the ratio of two polynomials.

--- a/scipy/interpolate/_pade.py
+++ b/scipy/interpolate/_pade.py
@@ -1,4 +1,5 @@
 import warnings
+import os
 
 from numpy import zeros, asarray, eye, poly1d, hstack, r_
 from scipy import linalg
@@ -50,9 +51,10 @@ def pade(an, m, n=None):
     2.7179487179487181
 
     """
+    _warn_skips = (os.path.dirname(__file__),)
     msg = ("`pade` is deprecated and will be removed in SciPy 1.20.0. Use "
            "`mpmath.pade` instead.")
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    warnings.warn(msg, DeprecationWarning, skip_file_prefixes=_warn_skips)
     an = asarray(an)
     if n is None:
         n = len(an) - 1 - m

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -1,5 +1,6 @@
 import warnings
 from types import GenericAlias
+import os
 
 import numpy as np
 from scipy.special import factorial
@@ -466,7 +467,19 @@ def approximate_taylor_polynomial(f,x,degree,scale,order=None):
     Estimate the Taylor polynomial of f at x by polynomial fitting.
 
     .. deprecated:: 1.18.0
-        This function is deprecated and will be removed in SciPy 1.20.0.
+        This function is deprecated and will be removed in SciPy 1.20.0. Use the
+        following code instead:
+
+        .. code-block:: python
+
+            import numpy as np
+
+            def f(z): return np.exp(z**2)  # example function
+            N = 10  # number of terms in the Taylor expansion
+            zz = np.exp(2j * np.pi * np.arange(N) / N)  # roots of unity
+            c = np.fft.fft(f(zz)) / N
+            c = np.real(c)  # c must be real by symmetry
+
 
     Parameters
     ----------
@@ -523,9 +536,10 @@ def approximate_taylor_polynomial(f,x,degree,scale,order=None):
     >>> plt.show()
 
     """
+    _warn_skips = (os.path.dirname(__file__),)
     msg = ("`approximate_taylor_polynomial` is deprecated and will be removed in "
            "SciPy 1.20.0.")
-    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    warnings.warn(msg, DeprecationWarning, skip_file_prefixes=_warn_skips)
     if order is None:
         order = degree
 

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -463,6 +463,9 @@ def approximate_taylor_polynomial(f,x,degree,scale,order=None):
     """
     Estimate the Taylor polynomial of f at x by polynomial fitting.
 
+    .. deprecated:: 1.18.0
+        This function is deprecated and will be removed in SciPy 1.20.0.
+
     Parameters
     ----------
     f : callable
@@ -518,6 +521,9 @@ def approximate_taylor_polynomial(f,x,degree,scale,order=None):
     >>> plt.show()
 
     """
+    msg = ("`approximate_taylor_polynomial` is deprecated and will be removed in "
+           "SciPy 1.20.0.")
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
     if order is None:
         order = degree
 

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy.special import factorial
 from scipy._lib._util import (_asarray_validated, float_factorial, check_random_state,
                               _transition_to_rng)
+from scipy._lib._array_api import xp_capabilities
 
 
 __all__ = ["KroghInterpolator", "krogh_interpolate",
@@ -459,6 +460,7 @@ def krogh_interpolate(xi, yi, x, der=0, axis=0):
         return P.derivatives(x, der=np.amax(der)+1)[der]
 
 
+@xp_capabilities(out_of_scope=True)
 def approximate_taylor_polynomial(f,x,degree,scale,order=None):
     """
     Estimate the Taylor polynomial of f at x by polynomial fitting.

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -842,7 +842,8 @@ class TestLagrange:
         p = poly1d([5,2,1,4,3])
         xs = np.arange(len(p.coeffs))
         ys = p(xs)
-        pl = lagrange(xs,ys)
+        with pytest.warns(DeprecationWarning, match="`lagrange`"):
+            pl = lagrange(xs,ys)
         assert_array_almost_equal(p.coeffs,pl.coeffs)
 
 

--- a/scipy/interpolate/tests/test_pade.py
+++ b/scipy/interpolate/tests/test_pade.py
@@ -1,19 +1,24 @@
 import numpy as np
+import pytest
+
 from scipy.interpolate import pade
 from scipy._lib._array_api import (
     xp_assert_equal, assert_array_almost_equal
 )
 
 def test_pade_trivial():
-    nump, denomp = pade([1.0], 0)
+    with pytest.warns(DeprecationWarning, match="`pade` is deprecated"):
+        nump, denomp = pade([1.0], 0)
     xp_assert_equal(nump.c, np.asarray([1.0]))
     xp_assert_equal(denomp.c, np.asarray([1.0]))
 
-    nump, denomp = pade([1.0], 0, 0)
+    with pytest.warns(DeprecationWarning, match="`pade` is deprecated"):
+        nump, denomp = pade([1.0], 0, 0)
     xp_assert_equal(nump.c, np.asarray([1.0]))
     xp_assert_equal(denomp.c, np.asarray([1.0]))
 
 
+@pytest.mark.filterwarnings("ignore: `pade` is deprecated")
 def test_pade_4term_exp():
     # First four Taylor coefficients of exp(x).
     # Unlike poly1d, the first array element is the zero-order term.
@@ -66,6 +71,7 @@ def test_pade_4term_exp():
     assert_array_almost_equal(denomp.c, [1.0/2, -1.0, 1.0])
 
 
+@pytest.mark.filterwarnings("ignore: `pade` is deprecated")
 def test_pade_ints():
     # Simple test sequences (one of ints, one of floats).
     an_int = [1, 2, 3, 4]
@@ -84,6 +90,7 @@ def test_pade_ints():
             xp_assert_equal(denomp_int.c, denomp_flt.c)
 
 
+@pytest.mark.filterwarnings("ignore: `pade` is deprecated")
 def test_pade_complex():
     # Test sequence with known solutions - see page 6 of 10.1109/PESGM.2012.6344759.
     # Variable x is parameter - these tests will work with any complex number.

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -334,7 +334,8 @@ class TestKrogh:
 class TestTaylor:
     def test_exponential(self):
         degree = 5
-        p = approximate_taylor_polynomial(np.exp, 0, degree, 1, 15)
+        with pytest.warns(DeprecationWarning, match="`approximate_taylor_polynomial`"):
+            p = approximate_taylor_polynomial(np.exp, 0, degree, 1, 15)
         for i in range(degree+1):
             assert_almost_equal(p(0),1)
             p = p.deriv()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
I would like propose to deprecating the following functions as they all have flaws (explained bellow) that mean they aren't really useful for practical computing and as a result also have very little use.

- `pade`: The implementation is too unstable to be useful. I did originally propose rewriting in #20064 however that would be unlikely to fit exactly within the same API and for now I think we should just recommend to use `mpmath.pade`.
- `lagrange`: This function is not practically useful as `BarycentricInterpolator` is the numerically "correct" way to do Lagrange interpolation.
- `approximate_taylor_polynomial`: Again I just don't think this is that useful. If you really do need to compute a taylor series numerically the correctly way would be using an fft not this weird interpolation scheme:
```
In [3]: import numpy as np
   ...: from scipy.special import gamma
   ...:
   ...: def f(z):
   ...:     return np.exp(z)
   ...:
   ...: N = 10
   ...:
   ...: # roots of unity
   ...: zz = np.exp(2j * np.pi * np.arange(N) / N)
   ...:
   ...: # FFT of f evaluated at roots of unity
   ...: c = np.fft.fft(f(zz)) / N
   ...:
   ...: # c must be real by symmetry
   ...: c = np.real(c)
   ...: print(" computed        exact")
   ...: exact = 1 / gamma(np.arange(1, N + 1))
   ...: print(np.column_stack((c, exact)))
 computed        exact
[[1.00000028e+00 1.00000000e+00]
 [1.00000003e+00 1.00000000e+00]
 [5.00000002e-01 5.00000000e-01]
 [1.66666667e-01 1.66666667e-01]
 [4.16666667e-02 4.16666667e-02]
 [8.33333333e-03 8.33333333e-03]
 [1.38888889e-03 1.38888889e-03]
 [1.98412698e-04 1.98412698e-04]
 [2.48015873e-05 2.48015873e-05]
 [2.75573192e-06 2.75573192e-06]]
```

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

None