### PR TITLE
MAINT: optimize: convert trlib to use ILP64

### DIFF
--- a/scipy/_build_utils/src/npy_cblas.h
+++ b/scipy/_build_utils/src/npy_cblas.h
@@ -84,9 +84,11 @@ enum CBLAS_SIDE {CblasLeft=141, CblasRight=142};
 #ifdef HAVE_BLAS_ILP64
 #define CBLAS_INT npy_int64
 #define CBLAS_INT_MAX NPY_MAX_INT64
+#define CBLAS_INT_FMT NPY_INT64_FMT
 #else
 #define CBLAS_INT int
 #define CBLAS_INT_MAX INT_MAX
+#define CBLAS_INT_FMT "i"
 #endif
 
 #define BLASNAME(name) CBLAS_FUNC(name)

--- a/scipy/optimize/_trlib/_trlib.pyx
+++ b/scipy/optimize/_trlib/_trlib.pyx
@@ -1,7 +1,12 @@
 from scipy.optimize._trustregion import BaseQuadraticSubproblem
 import numpy as np
+from scipy.linalg.lapack import HAS_ILP64
 from . cimport ctrlib
 cimport numpy as np
+
+cdef extern from 'trlib/trlib_types.h':
+    ctypedef long trlib_int_t
+
 
 from scipy._lib.messagestream cimport MessageStream
 
@@ -16,7 +21,7 @@ class TRLIBQuadraticSubproblem(BaseQuadraticSubproblem):
         self.tol_rel_b = tol_rel_b
         self.disp = disp
         self.itmax = int(min(1e9/self.jac.shape[0], 2*self.jac.shape[0]))
-        cdef long itmax, iwork_size, fwork_size, h_pointer
+        cdef trlib_int_t itmax, iwork_size, fwork_size, h_pointer
         itmax = self.itmax
         ctrlib.trlib_krylov_memory_size(itmax, &iwork_size, &fwork_size,
                                         &h_pointer)
@@ -27,7 +32,7 @@ class TRLIBQuadraticSubproblem(BaseQuadraticSubproblem):
         if fwork_view.shape[0] > 0:
             fwork_ptr = &fwork_view[0]
         ctrlib.trlib_krylov_prepare_memory(itmax, fwork_ptr)
-        self.iwork = np.zeros([iwork_size], dtype=np.dtype("long"))
+        self.iwork = np.zeros([iwork_size], dtype=np.int64 if HAS_ILP64 else np.int32)
         self.s  = np.empty(self.jac.shape)
         self.g  = np.empty(self.jac.shape)
         self.v  = np.empty(self.jac.shape)
@@ -36,44 +41,44 @@ class TRLIBQuadraticSubproblem(BaseQuadraticSubproblem):
         self.Hp = np.empty(self.jac.shape)
         self.Q  = np.empty([self.itmax+1, self.jac.shape[0]])
         self.timing = np.zeros([ctrlib.trlib_krylov_timing_size()],
-                               dtype=np.dtype("long"))
+                               dtype=np.int64 if HAS_ILP64 else np.int32)
         self.init = ctrlib._TRLIB_CLS_INIT
 
     def solve(self, double trust_radius):
 
-        cdef long equality = 0
-        cdef long itmax_lanczos = 100
+        cdef trlib_int_t equality = 0
+        cdef trlib_int_t itmax_lanczos = 100
         cdef double tol_r_i = self.tol_rel_i
         cdef double tol_a_i =  0.0 
         cdef double tol_r_b = self.tol_rel_b
         cdef double tol_a_b =  0.0 
         cdef double zero = 2e-16
         cdef double obj_lb = -1e20
-        cdef long ctl_invariant = 0
-        cdef long convexify = 1
-        cdef long earlyterm = 1
+        cdef trlib_int_t ctl_invariant = 0
+        cdef trlib_int_t convexify = 1
+        cdef trlib_int_t earlyterm = 1
         cdef double g_dot_g = 0.0
         cdef double v_dot_g = 0.0
         cdef double p_dot_Hp = 0.0
-        cdef long refine = 1
-        cdef long verbose = 0
-        cdef long unicode = 1
-        cdef long ret = 0
-        cdef long action = 0
-        cdef long it = 0
-        cdef long ityp = 0
-        cdef long itmax = self.itmax
-        cdef long init  = self.init
+        cdef trlib_int_t refine = 1
+        cdef trlib_int_t verbose = 0
+        cdef trlib_int_t unicode = 1
+        cdef trlib_int_t ret = 0
+        cdef trlib_int_t action = 0
+        cdef trlib_int_t it = 0
+        cdef trlib_int_t ityp = 0
+        cdef trlib_int_t itmax = self.itmax
+        cdef trlib_int_t init  = self.init
         cdef double flt1 = 0.0
         cdef double flt2 = 0.0
         cdef double flt3 = 0.0
         prefix = b""
-        cdef long   [:] iwork_view  = self.iwork
+        cdef trlib_int_t   [:] iwork_view  = self.iwork
         cdef double [:] fwork_view  = self.fwork
-        cdef long   [:] timing_view = self.timing
-        cdef long   *iwork_ptr = NULL
+        cdef trlib_int_t   [:] timing_view = self.timing
+        cdef trlib_int_t   *iwork_ptr = NULL
         cdef double *fwork_ptr = NULL
-        cdef long   *timing_ptr = NULL
+        cdef trlib_int_t   *timing_ptr = NULL
 
         if self.disp:
             verbose = 2

--- a/scipy/optimize/_trlib/meson.build
+++ b/scipy/optimize/_trlib/meson.build
@@ -12,7 +12,7 @@ py3.extension_module('_trlib',
     '../../_lib',
     '../../_build_utils/src'
   ],
-  dependencies: [lapack_lp64_dep, np_dep],
+  dependencies: [lapack_dep, np_dep],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/optimize/_trlib'

--- a/scipy/optimize/_trlib/trlib/trlib_private.h
+++ b/scipy/optimize/_trlib/trlib/trlib_private.h
@@ -12,18 +12,18 @@
 #include <time.h>
 
 // blas
-void daxpy_(trlib_int_t *n, trlib_flt_t *alpha, trlib_flt_t *x, trlib_int_t *incx, trlib_flt_t *y, trlib_int_t *incy);
-void dscal_(trlib_int_t *n, trlib_flt_t *alpha, trlib_flt_t *x, trlib_int_t *incx);
-void dcopy_(trlib_int_t *n, trlib_flt_t *x, trlib_int_t *incx, trlib_flt_t *y, trlib_int_t *incy);
-trlib_flt_t dnrm2_(trlib_int_t *n, trlib_flt_t *x, trlib_int_t *incx);
-trlib_flt_t ddot_(trlib_int_t *n, trlib_flt_t *x, trlib_int_t *incx, trlib_flt_t *y, trlib_int_t *incy);
+void BLAS_FUNC(daxpy)(trlib_int_t *n, trlib_flt_t *alpha, trlib_flt_t *x, trlib_int_t *incx, trlib_flt_t *y, trlib_int_t *incy);
+void BLAS_FUNC(dscal)(trlib_int_t *n, trlib_flt_t *alpha, trlib_flt_t *x, trlib_int_t *incx);
+void BLAS_FUNC(dcopy)(trlib_int_t *n, trlib_flt_t *x, trlib_int_t *incx, trlib_flt_t *y, trlib_int_t *incy);
+trlib_flt_t BLAS_FUNC(dnrm2)(trlib_int_t *n, trlib_flt_t *x, trlib_int_t *incx);
+trlib_flt_t BLAS_FUNC(ddot)(trlib_int_t *n, trlib_flt_t *x, trlib_int_t *incx, trlib_flt_t *y, trlib_int_t *incy);
 
 // lapack
-void dpttrf_(trlib_int_t *n, trlib_flt_t *d, trlib_flt_t *e, trlib_int_t *info);
-void dpttrs_(trlib_int_t *n, trlib_int_t *nrhs, trlib_flt_t *d, trlib_flt_t *e, trlib_flt_t *b, trlib_int_t *ldb, trlib_int_t *info);
-void dptrfs_(trlib_int_t *n, trlib_int_t *nrhs, trlib_flt_t *d, trlib_flt_t *e, trlib_flt_t *df, trlib_flt_t *ef, trlib_flt_t *b, trlib_int_t *ldb, trlib_flt_t *x, trlib_int_t *ldx, trlib_flt_t *ferr, trlib_flt_t *berr, trlib_flt_t *work, trlib_int_t *info);
-void dlagtm_(char *trans, trlib_int_t *n, trlib_int_t *nrhs, trlib_flt_t *alpha, trlib_flt_t *dl, trlib_flt_t *d, trlib_flt_t *du, trlib_flt_t *x, trlib_int_t *ldx, trlib_flt_t *beta, trlib_flt_t *b, trlib_int_t *ldb);
-void dgtsv_(trlib_int_t *n, trlib_int_t *nrhs, trlib_flt_t *dl, trlib_flt_t *d, trlib_flt_t *du, trlib_flt_t *b, trlib_int_t *ldb, trlib_int_t *info);
+void BLAS_FUNC(dpttrf)(trlib_int_t *n, trlib_flt_t *d, trlib_flt_t *e, trlib_int_t *info);
+void BLAS_FUNC(dpttrs)(trlib_int_t *n, trlib_int_t *nrhs, trlib_flt_t *d, trlib_flt_t *e, trlib_flt_t *b, trlib_int_t *ldb, trlib_int_t *info);
+void BLAS_FUNC(dptrfs)(trlib_int_t *n, trlib_int_t *nrhs, trlib_flt_t *d, trlib_flt_t *e, trlib_flt_t *df, trlib_flt_t *ef, trlib_flt_t *b, trlib_int_t *ldb, trlib_flt_t *x, trlib_int_t *ldx, trlib_flt_t *ferr, trlib_flt_t *berr, trlib_flt_t *work, trlib_int_t *info);
+void BLAS_FUNC(dlagtm)(char *trans, trlib_int_t *n, trlib_int_t *nrhs, trlib_flt_t *alpha, trlib_flt_t *dl, trlib_flt_t *d, trlib_flt_t *du, trlib_flt_t *x, trlib_int_t *ldx, trlib_flt_t *beta, trlib_flt_t *b, trlib_int_t *ldb);
+void BLAS_FUNC(dgtsv)(trlib_int_t *n, trlib_int_t *nrhs, trlib_flt_t *dl, trlib_flt_t *d, trlib_flt_t *du, trlib_flt_t *b, trlib_int_t *ldb, trlib_int_t *info);
 
 #if TRLIB_MEASURE_TIME
     #define TRLIB_TIC(X) { clock_gettime(CLOCK_MONOTONIC, &X); }

--- a/scipy/optimize/_trlib/trlib/trlib_types.h
+++ b/scipy/optimize/_trlib/trlib/trlib_types.h
@@ -25,7 +25,8 @@
 #ifndef TRLIB_TYPES_H
 #define TRLIB_TYPES_H
 
-typedef long trlib_int_t;
+#include "npy_cblas.h"
+typedef CBLAS_INT trlib_int_t;
 typedef double trlib_flt_t;
 
 #define TRLIB_EPS            ((trlib_flt_t)2.2204460492503131e-16)

--- a/scipy/optimize/_trlib/trlib_krylov.c
+++ b/scipy/optimize/_trlib/trlib_krylov.c
@@ -317,10 +317,10 @@ trlib_int_t trlib_krylov_min_internal(
                     *iter_last_head = *ii;
                 }
                 if (*interior) {
-                    TRLIB_PRINTLN_1("%6ld%6ld%6s%14e%14e%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, "cg_i", *obj, sqrt(*v_g), *leftmost, *lam, *ii == 0 ? -neglin[0] : gamma[*ii-1], delta[*ii], alpha[*ii], beta[*ii])
+                    TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT "%6s%14e%14e%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, "cg_i", *obj, sqrt(*v_g), *leftmost, *lam, *ii == 0 ? -neglin[0] : gamma[*ii-1], delta[*ii], alpha[*ii], beta[*ii])
                 }
                 else {
-                    TRLIB_PRINTLN_2("%s","") TRLIB_PRINTLN_1("%6ld%6ld%6s%14e%14e%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, "cg_b", *obj, gamma[*ii]*fabs(h[*ii]), *leftmost, *lam, *ii == 0 ? -neglin[0] : gamma[*ii-1], delta[*ii], alpha[*ii], beta[*ii]) TRLIB_PRINTLN_2("%s", "")
+                    TRLIB_PRINTLN_2("%s","") TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT "%6s%14e%14e%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, "cg_b", *obj, gamma[*ii]*fabs(h[*ii]), *leftmost, *lam, *ii == 0 ? -neglin[0] : gamma[*ii-1], delta[*ii], alpha[*ii], beta[*ii]) TRLIB_PRINTLN_2("%s", "")
                 }
 
                 // test for convergence
@@ -366,7 +366,7 @@ trlib_int_t trlib_krylov_min_internal(
                 // print iteration details
                 // first print headline if necessary
                 TRLIB_PRINTLN_2("%s","") TRLIB_PRINTLN_1("%6s%6s%6s%14s%14s%14s%14s", " iter ", "inewton", " type ", "   objective  ", "||g(lam)||_iM", "   leftmost   ", "     lam      ")
-                TRLIB_PRINTLN_2("%s","") TRLIB_PRINTLN_1("%6ld%6ld%6s%14e%14e%14e%14e", *ii, *iter_tri, "cg_h", *obj, v_dot_g, *leftmost, *lam) TRLIB_PRINTLN_2("%s", "")
+                TRLIB_PRINTLN_2("%s","") TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT "%6s%14e%14e%14e%14e", *ii, *iter_tri, "cg_h", *obj, v_dot_g, *leftmost, *lam) TRLIB_PRINTLN_2("%s", "")
                 // check for convergence
                 if (ctl_invariant <= TRLIB_CLC_EXP_INV_LOC && v_dot_g <= *stop_b) { *ityp = TRLIB_CLT_CG; *action = TRLIB_CLA_TRIVIAL; returnvalue = TRLIB_CLR_APPROX_HARD; break; }
                 // if no convergence or want to force to investigate all invariant subspaces, continue with next invariant Krylov subspace
@@ -409,7 +409,7 @@ trlib_int_t trlib_krylov_min_internal(
                     else { TRLIB_PRINTLN_2("%s","") TRLIB_PRINTLN_1("%6s%6s%6s%14s%14s%14s%14s%14s%14s", " iter ", "inewton", " type ", "   objective  ", "gam(i+1)|h(i)|", "   leftmost   ", "     lam      ", "    gamma     ", "    delta     ") }
                     *type_last_head = TRLIB_CLT_HOTSTART;
                     *iter_last_head = *ii;
-                    TRLIB_PRINTLN_1("%6ld%6ld%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, "hnbk", *obj, gamma[*ii]*fabs(h[*ii]), *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
+                    TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT "%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, "hnbk", *obj, gamma[*ii]*fabs(h[*ii]), *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
 
                     *ityp = TRLIB_CLT_CG; *action = TRLIB_CLA_RETRANSF; returnvalue = TRLIB_CLR_FAIL_TTR; break;
                 }
@@ -423,7 +423,7 @@ trlib_int_t trlib_krylov_min_internal(
                     else { TRLIB_PRINTLN_2("%s","") TRLIB_PRINTLN_1("%6s%6s%6s%14s%14s%14s%14s%14s%14s", " iter ", "inewton", " type ", "   objective  ", "gam(i+1)|h(i)|", "   leftmost   ", "     lam      ", "    gamma     ", "    delta     ") }
                     *type_last_head = TRLIB_CLT_HOTSTART;
                     *iter_last_head = *ii;
-                    TRLIB_PRINTLN_1("%6ld%6ld%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, "hlfl", *obj, gamma[*ii]*fabs(h[*ii]), *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
+                    TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT "%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, "hlfl", *obj, gamma[*ii]*fabs(h[*ii]), *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
 
                     *ityp = TRLIB_CLT_CG; *action = TRLIB_CLA_RETRANSF; returnvalue = TRLIB_CLR_HARD_INIT_LAM; break;
                 }
@@ -434,7 +434,7 @@ trlib_int_t trlib_krylov_min_internal(
                 *type_last_head = TRLIB_CLT_HOTSTART;
                 *iter_last_head = *ii;
 
-                TRLIB_PRINTLN_1("%6ld%6ld%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, " hot", *obj, gamma[*ii]*fabs(h[*ii]), *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
+                TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT "%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, " hot", *obj, gamma[*ii]*fabs(h[*ii]), *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
 
                 if ( earlyterm ) {
                     TRLIB_PRINTLN_2("Early exit as hotstart with early termination on")
@@ -523,7 +523,7 @@ trlib_int_t trlib_krylov_min_internal(
                 *type_last_head = TRLIB_CLT_HOTSTART;
                 *iter_last_head = *ii;
 
-                TRLIB_PRINTLN_1("%6ld%6ld%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, " hot_g", *obj, 0.0, *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
+                TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT "%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, " hot_g", *obj, 0.0, *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
 
                 // return without convergence check as indicated in API doc
                 *ityp = TRLIB_CLT_CG; *action = TRLIB_CLA_RETRANSF; returnvalue = *exit_tri; break;
@@ -642,7 +642,7 @@ trlib_int_t trlib_krylov_min_internal(
                     *type_last_head = TRLIB_CLT_LANCZOS;
                     *iter_last_head = *ii;
                 }
-                TRLIB_PRINTLN_2("%s","") TRLIB_PRINTLN_1("%6ld%6ld%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, " lcz", *obj, sqrt(*v_g), *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
+                TRLIB_PRINTLN_2("%s","") TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT "%6s%14e%14e%14e%14e%14e%14e", *ii, *iter_tri, " lcz", *obj, sqrt(*v_g), *leftmost, *lam, *ii == 0 ? neglin[0] : gamma[*ii-1], delta[*ii]) TRLIB_PRINTLN_2("%s", "")
 
                 // test for convergence
                 // note convergence criterion

--- a/scipy/optimize/_trlib/trlib_leftmost.c
+++ b/scipy/optimize/_trlib/trlib_leftmost.c
@@ -161,7 +161,7 @@ trlib_int_t trlib_leftmost_irreducible(
         if (*iter_pr % 10 == 1) {
             TRLIB_PRINTLN_1("%6s%8s%14s%14s%14s%14s%14s%6s%6s", "  it  ", " action ", "     low      ", "   leftmost   ", "      up      ", "   dleftmost  ", "      prlp    ", " nneg ", "  br  ")
         }
-        TRLIB_PRINTLN_1("%6ld%8s%14e%14e%14e", *iter_pr, "  entry ", low, *leftmost, up)
+        TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%8s%14e%14e%14e", *iter_pr, "  entry ", low, *leftmost, up)
 
         // compute pivot and derivative of LDL^T factorization of T - leftmost I
         continue_outer_loop = 0;
@@ -207,7 +207,7 @@ trlib_int_t trlib_leftmost_irreducible(
         }
 
         if (continue_outer_loop) {
-            TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14s%14e%6ld%6ld", "", " bisecp ", low, *leftmost, up, "", prlp, n_neg_piv, jj)
+            TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14s%14e%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT, "", " bisecp ", low, *leftmost, up, "", prlp, n_neg_piv, jj)
             continue;
         }
 
@@ -219,7 +219,7 @@ trlib_int_t trlib_leftmost_irreducible(
 
         // test if bracket interval is small or last pivot has converged to zero
         if (up-low <= tol_abs * fmax(1.0, fmax(fabs(low), fabs(up))) || fabs(prlp) <= tol_abs) {
-            TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14s%14e%6ld%6ld", "", "  conv  ", low, *leftmost, up, "", prlp, n_neg_piv, jj)
+            TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14s%14e%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT, "", "  conv  ", low, *leftmost, up, "", prlp, n_neg_piv, jj)
             TRLIB_RETURN(TRLIB_LMR_CONV)
         }
 
@@ -280,11 +280,11 @@ trlib_int_t trlib_leftmost_irreducible(
             }
         }
         if ( verbose > 0 ) {
-            if ( model_type == 0 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6ld%6ld", "", " bisecs ", low, *leftmost, up, .5*(up-low), prlp, n_neg_piv, jj) }
-            if ( model_type == 1 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6ld%6ld", "", "  piv 1 ", low, *leftmost, up, dleftmost, prlp, n_neg_piv, jj) }
-            if ( model_type == 2 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6ld%6ld", "", " lpiv q ", low, *leftmost, up, dleftmost, prlp, n_neg_piv, jj) }
-            if ( model_type == 3 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6ld%6ld", "", " lpiv 1 ", low, *leftmost, up, dleftmost, prlp, n_neg_piv, jj) }
-            if ( model_type == 4 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6ld%6ld", "", " lpiv 2 ", low, *leftmost, up, dleftmost, prlp, n_neg_piv, jj) }
+            if ( model_type == 0 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT, "", " bisecs ", low, *leftmost, up, .5*(up-low), prlp, n_neg_piv, jj) }
+            if ( model_type == 1 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT, "", "  piv 1 ", low, *leftmost, up, dleftmost, prlp, n_neg_piv, jj) }
+            if ( model_type == 2 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT, "", " lpiv q ", low, *leftmost, up, dleftmost, prlp, n_neg_piv, jj) }
+            if ( model_type == 3 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT, "", " lpiv 1 ", low, *leftmost, up, dleftmost, prlp, n_neg_piv, jj) }
+            if ( model_type == 4 ) { TRLIB_PRINTLN_1("%6s%8s%14e%14e%14e%14e%14e%6" CBLAS_INT_FMT "%6" CBLAS_INT_FMT, "", " lpiv 2 ", low, *leftmost, up, dleftmost, prlp, n_neg_piv, jj) }
         }
 
     }

--- a/scipy/optimize/_trlib/trlib_tri_factor.c
+++ b/scipy/optimize/_trlib/trlib_tri_factor.c
@@ -170,7 +170,7 @@ trlib_int_t trlib_tri_factor_min(
                         TRLIB_DPTTRS(&n0, &inc, diag_fac0, offdiag_fac0, sol0, &n0, &info_fac) // sol0 <-- T0^-1 sol0
                         if (info_fac != 0) { TRLIB_PRINTLN_2("Failure on computing h\u2080 in safeguarded initialization iteration") TRLIB_RETURN(TRLIB_TTR_FAIL_LINSOLVE) }
                         TRLIB_DNRM2(norm_sol0, &n0, sol0, &inc)
-                        TRLIB_PRINTLN_2(" %2ld%14e%14e%14e%3s%14e", jj, pert_low, lam_pert, pert_up, " +", norm_sol0 - radius)
+                        TRLIB_PRINTLN_2(" %2" CBLAS_INT_FMT "%14e%14e%14e%3s%14e", jj, pert_low, lam_pert, pert_up, " +", norm_sol0 - radius)
                         if(norm_sol0 >= radius) {
                             break;
                         }
@@ -180,7 +180,7 @@ trlib_int_t trlib_tri_factor_min(
                         }
                     }
                     else {
-                        TRLIB_PRINTLN_2(" %2ld%14e%14e%14e%3s", jj, pert_low, lam_pert, pert_up, " -")
+                        TRLIB_PRINTLN_2(" %2" CBLAS_INT_FMT "%14e%14e%14e%3s", jj, pert_low, lam_pert, pert_up, " -")
                         pert_low = lam_pert; // as factorization fails, it provides a upper bound
                         // now increase perturbation, either by bisection if there is a useful upper bound,
                         // otherwise by a small increment
@@ -285,7 +285,7 @@ trlib_int_t trlib_tri_factor_min(
                 if (unicode) { TRLIB_PRINTLN_1("%6s%14s%14s%14s", " iter ", "       \u03bb      ", "      d\u03bb      ", " \u2016h\u2080(\u03bb)\u2016-radius") }
                 else { TRLIB_PRINTLN_1("%6s%14s%14s%14s", " iter ", "     lam      ", "     dlam     ", "  tr resdidual") }
             }
-            TRLIB_PRINTLN_1("%6ld%14e%14e%14e", *iter_newton, *lam0, dlam, norm_sol0-radius)
+            TRLIB_PRINTLN_1("%6" CBLAS_INT_FMT "%14e%14e%14e", *iter_newton, *lam0, dlam, norm_sol0-radius)
 
             // test for convergence
             if (norm_sol0 - radius <= tol_rel * radius) {
@@ -309,7 +309,7 @@ trlib_int_t trlib_tri_factor_min(
                     *leftmost, 10, TRLIB_EPS_POW_5, ones,
                     diag_fac, offdiag_fac, sol,
                     verbose-2, unicode, " EI", fout, eigen_timing, &ferr, &berr, &jj); // can safely overwrite ferr, berr, jj with results. only interesting: eigenvector
-            if (*sub_fail != 0 && *sub_fail != -1) { TRLIB_PRINTLN_2("Failure in eigenvector computation: %ld", *sub_fail) TRLIB_RETURN(TRLIB_TTR_FAIL_EIG) }
+            if (*sub_fail != 0 && *sub_fail != -1) { TRLIB_PRINTLN_2("Failure in eigenvector computation: %" CBLAS_INT_FMT "", *sub_fail) TRLIB_RETURN(TRLIB_TTR_FAIL_EIG) }
             if (*sub_fail == -1) { TRLIB_PRINTLN_2("In eigenvector computation itmax reached, continue with approximate eigenvector") }
             // compute solution as linear combination of h0 and eigenvector
             // ||h0 + t*eig||^2 = ||h_0||^2 + t * <h0, eig> + t^2 = radius^2
@@ -354,7 +354,7 @@ trlib_int_t trlib_tri_factor_min(
         *sub_fail = trlib_leftmost(nirblk, irblk, diag, offdiag, 0, leftmost[nirblk-1], 1000, TRLIB_EPS_POW_75, verbose-2, unicode, " LM ", fout, leftmost_timing, ileftmost, leftmost);
         *warm_leftmost = 1;
     }
-    TRLIB_PRINTLN_1("    leftmost = %e (block %ld)", leftmost[*ileftmost], *ileftmost)
+    TRLIB_PRINTLN_1("    leftmost = %e (block %" CBLAS_INT_FMT ")", leftmost[*ileftmost], *ileftmost)
     if(*lam0 >= -leftmost[*ileftmost]) {
         if (unicode) { TRLIB_PRINTLN_1("  \u03bb\u2080 \u2265 -leftmost \u21d2 \u03bb = \u03bb\u2080, exit: h\u2080(\u03bb\u2080)") }
         else { TRLIB_PRINTLN_1("  lam0 >= -leftmost => lam = lam0, exit: h0(lam0)") }
@@ -518,7 +518,7 @@ trlib_int_t trlib_tri_factor_get_regularization(
     TRLIB_DNRM2(*norm_sol, &n, sol, &inc)
 
     jj = 0;
-    TRLIB_PRINTLN_2("%ld\t Reg %e\t Reg/Norm %e\t lb %e ub %e", jj, *lam, *lam/(*norm_sol), sigma_l, sigma_u);
+    TRLIB_PRINTLN_2("%" CBLAS_INT_FMT "\t Reg %e\t Reg/Norm %e\t lb %e ub %e", jj, *lam, *lam/(*norm_sol), sigma_l, sigma_u);
 
     // check if accetable
     if( *norm_sol * sigma_l <= *lam && *lam <= *norm_sol * sigma_u ) {
@@ -570,7 +570,7 @@ trlib_int_t trlib_tri_factor_get_regularization(
             TRLIB_DNRM2(*norm_sol, &n, sol, &inc)
 
             jj++;
-            TRLIB_PRINTLN_2("%ld\t Reg %e\t Reg/Norm %e\t lb %e ub %e", jj, *lam, *lam/(*norm_sol), sigma_l, sigma_u);
+            TRLIB_PRINTLN_2("%" CBLAS_INT_FMT "\t Reg %e\t Reg/Norm %e\t lb %e ub %e", jj, *lam, *lam/(*norm_sol), sigma_l, sigma_u);
 
             // check if accetable
             if( *norm_sol * sigma_l <= *lam && *lam <= *norm_sol * sigma_u ) {


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/23351

#### What does this implement/fix?
<!--Please explain your changes.-->

Make `trlib` ILP64-aware.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai