### PR TITLE
TST: linalg: bump test tolerance for openblas on x86 MacOS

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2392,7 +2392,7 @@ class TestPinv:
         # Now adiff1 should be around atol value while adiff2 should be
         # relatively tiny
         assert_allclose(np.linalg.norm(adiff1), 5e-4, atol=5.e-4)
-        assert_allclose(np.linalg.norm(adiff2), 5e-14, atol=5.e-14)
+        assert_allclose(np.linalg.norm(adiff2), 5e-14, atol=7.e-14)
 
         # Now do the same but remove another sv ~4.234 via rtol
         a_p = pinv(a_m, atol=atol, rtol=rtol)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/pull/24476#issuecomment-3984219541

#### What does this implement/fix?
<!--Please explain your changes.-->

Bump the tolerance in a test to avoid an atol violation on x86 MacOS with `scipy-openblas32==0.3.31.22.0` (released Feb 1, 2026).

The comment in the test only says that the result should be "relatively tiny", and the previous values are from https://github.com/scipy/scipy/pull/13831

I think the violation is small enough to bump and forget.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai