### PR TITLE
TST: bump to CuPy 14

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -2175,13 +2175,13 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart-static_linux-64-13.1.80-h376f20c_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cuda-cudart_linux-64-13.1.80-h376f20c_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/cuda-nvrtc-13.1.80-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/cuda-pathfinder-1.4.0-pyhc364b38_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/cuda-version-13.1-h2ff5cdb_3.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/cupy-13.6.0-py313h727d180_2.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/cupy-core-13.6.0-py313h0630d88_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cupy-14.0.1-py313h7122472_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cupy-core-14.0.1-py313h75444f8_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
-      - conda: https://prefix.dev/conda-forge/linux-64/fastrlock-0.8.3-py313h5d5ffb9_2.conda
       - conda: https://prefix.dev/conda-forge/noarch/filelock-3.20.3-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.2.1-py313h86d8783_2.conda
@@ -8454,6 +8454,17 @@ packages:
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   size: 24246736
   timestamp: 1753975332907
+- conda: https://prefix.dev/conda-forge/noarch/cuda-pathfinder-1.4.0-pyhc364b38_0.conda
+  sha256: edf16fdfbcce5bbb445118fd8d070dda8afe36b4b437a94f472fde153bc38151
+  md5: 2d13e524da66b60e6e7d5c6585729ea8
+  depends:
+  - python >=3.10
+  - cuda-version >=12.0,<14
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 39327
+  timestamp: 1772059437166
 - conda: https://prefix.dev/conda-forge/noarch/cuda-version-12.9-h4f385c5_3.conda
   sha256: 5f5f428031933f117ff9f7fcc650e6ea1b3fef5936cf84aa24af79167513b656
   md5: b6d5d7f1c171cbd228ea06b556cfa859
@@ -8486,14 +8497,14 @@ packages:
   license: LicenseRef-cuDNN-Software-License-Agreement
   size: 19646
   timestamp: 1762823905292
-- conda: https://prefix.dev/conda-forge/linux-64/cupy-13.6.0-py313h727d180_2.conda
-  sha256: 0cf7e5f9461b144320ff2d30f1e7d74c7990e69aa15ec8211cc117f1214a9985
-  md5: 9a9af89f20555cbb1892f81d096b937d
+- conda: https://prefix.dev/conda-forge/linux-64/cupy-14.0.1-py313h7122472_0.conda
+  sha256: 15d283040f1c038aae6874fabb1f3ab421fe0e44a16e9fab82d0be2a24e13ab1
+  md5: f35ca8c4a4a18dc8ea2f8e9d396a8206
   depends:
   - cuda-cudart-dev_linux-64
   - cuda-nvrtc
   - cuda-version >=13,<14.0a0
-  - cupy-core 13.6.0 py313h0630d88_2
+  - cupy-core 14.0.1 py313h75444f8_0
   - libcublas
   - libcufft
   - libcurand
@@ -8503,37 +8514,38 @@ packages:
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
-  size: 359195
-  timestamp: 1757731600945
-- conda: https://prefix.dev/conda-forge/linux-64/cupy-core-13.6.0-py313h0630d88_2.conda
-  sha256: 82c950c3118d81368ad0dee224ab946c963b57ccad34911cacdcc52fc046d792
-  md5: a2a6a0df7ef6e9ae482bae698cfd7476
+  size: 385178
+  timestamp: 1771604711937
+- conda: https://prefix.dev/conda-forge/linux-64/cupy-core-14.0.1-py313h75444f8_0.conda
+  sha256: fe9ff6f2082acfab05aab1463455cbc5a27b734974146d671ab1a2675c2d7715
+  md5: 3dff057b457d1a19263750d69a117f0a
   depends:
   - __glibc >=2.28,<3.0.a0
-  - fastrlock >=0.8.3,<0.9.0a0
+  - cuda-pathfinder >=1.3.3,<2.0a0
   - libgcc >=14
   - libstdcxx >=14
-  - numpy >=1.22
+  - numpy >=1.23,<3
+  - numpy >=2.0
   - python >=3.13,<3.14.0a0
   - python_abi 3.13.* *_cp313
   constrains:
-  - libcusolver >=12,<13.0a0
-  - cuda-nvrtc >=13,<14.0a0
-  - cupy >=13.6.0,<13.7.0a0
-  - libcublas >=13,<14.0a0
-  - __cuda >=13.0
   - libcufft >=12,<13.0a0
-  - optuna ~=3.0
-  - nccl >=2.27.7.1,<3.0a0
-  - cutensor >=2.3.1.0,<3.0a0
   - libcurand >=10,<11.0a0
-  - scipy >=1.7,<1.17
-  - cuda-version >=13,<14.0a0
+  - libcusolver >=12,<13.0a0
   - libcusparse >=12,<13.0a0
+  - cutensor >=2.5.0.2,<3.0a0
+  - nccl >=2.29.3.1,<3.0a0
+  - libcublas >=13,<14.0a0
+  - scipy >=1.10,<1.17
+  - cupy >=14.0.1,<14.1.0a0
+  - optuna ~=3.0
+  - __cuda >=13.0
+  - cuda-nvrtc >=13,<14.0a0
+  - cuda-version >=13,<14.0a0
   license: MIT
   license_family: MIT
-  size: 31734692
-  timestamp: 1757731531047
+  size: 33845732
+  timestamp: 1771604638130
 - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
   sha256: 3fcc97ae3e89c150401a50a4de58794ffc67b1ed0e1851468fcc376980201e25
   md5: 5da8c935dca9186673987f79cef0b2a5
@@ -8921,19 +8933,6 @@ packages:
   license_family: MIT
   size: 30753
   timestamp: 1756729456476
-- conda: https://prefix.dev/conda-forge/linux-64/fastrlock-0.8.3-py313h5d5ffb9_2.conda
-  sha256: 30498ed45133f457fd9ed14d5fac6512347f05d11fe1ed89842c7dfdb516f78f
-  md5: 9bcbd351966dc56a24fc0c368da5ad99
-  depends:
-  - python
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  size: 41201
-  timestamp: 1756729160955
 - conda: https://prefix.dev/conda-forge/noarch/filelock-3.20.0-pyhd8ed1ab_0.conda
   sha256: 19025a4078ff3940d97eb0da29983d5e0deac9c3e09b0eabf897daeaf9d1114e
   md5: 66b8b26023b8efdf8fcb23bac4b6325d

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -4,6 +4,7 @@ import itertools
 import re
 import contextlib
 import warnings
+import importlib
 
 import numpy as np
 import pytest
@@ -35,6 +36,11 @@ uses_output_dtype = skip_xp_backends(
     np_only=True, exceptions=["cupy"],
     reason="output=dtype is numpy-specific"
 )
+
+try:
+    CUPY_VERSION = importlib.metadata.version('cupy')
+except ImportError:
+    CUPY_VERSION = None
 
 
 def uses_output_array(f):
@@ -498,7 +504,7 @@ class TestNdimageFilters:
 
     @make_xp_test_case(ndimage.correlate, ndimage.convolve)
     def test_correlate_mode_sequence(self, xp):
-        if is_cupy(xp):
+        if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
             pytest.xfail("multiple modes work in CuPy 14")
 
         kernel = xp.ones((2, 2))
@@ -1710,7 +1716,7 @@ class TestNdimageFilters:
 
     @make_xp_test_case(ndimage.minimum_filter)
     def test_minimum_filter07(self, xp):
-        if is_cupy(xp):
+        if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
             pytest.xfail("multiple modes work in CuPy 14")
 
         array = xp.asarray([[3, 2, 5, 1, 4],
@@ -1805,7 +1811,7 @@ class TestNdimageFilters:
 
     @make_xp_test_case(ndimage.maximum_filter)
     def test_maximum_filter07(self, xp):
-        if is_cupy(xp):
+        if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
             pytest.xfail("multiple modes work in CuPy 14")
 
         array = xp.asarray([[3, 2, 5, 1, 4],
@@ -1998,7 +2004,7 @@ class TestNdimageFilters:
         ndimage.rank_filter, ndimage.percentile_filter, ndimage.median_filter
     )
     def test_rank08_1(self, xp):
-        if is_cupy(xp):
+        if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
             pytest.xfail("multiple modes work in CuPy 14")
 
         array = xp.asarray([[3, 2, 5, 1, 4],

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -498,6 +498,9 @@ class TestNdimageFilters:
 
     @make_xp_test_case(ndimage.correlate, ndimage.convolve)
     def test_correlate_mode_sequence(self, xp):
+        if is_cupy(xp):
+            pytest.xfail("multiple modes work in CuPy 14")
+
         kernel = xp.ones((2, 2))
         array = xp.ones((3, 3), dtype=xp.float64)
         with assert_raises(RuntimeError):
@@ -1707,6 +1710,9 @@ class TestNdimageFilters:
 
     @make_xp_test_case(ndimage.minimum_filter)
     def test_minimum_filter07(self, xp):
+        if is_cupy(xp):
+            pytest.xfail("multiple modes work in CuPy 14")
+
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
                             [5, 8, 3, 7, 1]])
@@ -1715,6 +1721,7 @@ class TestNdimageFilters:
         assert_array_almost_equal(xp.asarray([[2, 2, 1, 1, 1],
                                               [2, 3, 1, 3, 1],
                                               [5, 5, 3, 3, 1]]), output)
+
         with assert_raises(RuntimeError):
             ndimage.minimum_filter(array, footprint=footprint,
                                    mode=['reflect', 'constant'])
@@ -1798,6 +1805,9 @@ class TestNdimageFilters:
 
     @make_xp_test_case(ndimage.maximum_filter)
     def test_maximum_filter07(self, xp):
+        if is_cupy(xp):
+            pytest.xfail("multiple modes work in CuPy 14")
+
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
                             [5, 8, 3, 7, 1]])
@@ -1983,6 +1993,17 @@ class TestNdimageFilters:
         xp_assert_equal(expected, output)
         output = ndimage.median_filter(array, size=(2, 3))
         xp_assert_equal(expected, output)
+
+    @make_xp_test_case(
+        ndimage.rank_filter, ndimage.percentile_filter, ndimage.median_filter
+    )
+    def test_rank08_1(self, xp):
+        if is_cupy(xp):
+            pytest.xfail("multiple modes work in CuPy 14")
+
+        array = xp.asarray([[3, 2, 5, 1, 4],
+                            [5, 8, 3, 7, 1],
+                            [5, 6, 9, 3, 5]])
 
         # non-separable: does not allow mode sequence
         with assert_raises(RuntimeError):
@@ -2544,6 +2565,8 @@ def test_multiple_modes(xp, filter_func, args, kwargs):
     arr = xp.asarray([[1., 0., 0.],
                       [1., 1., 0.],
                       [0., 0., 0.]])
+    if is_cupy(xp) and filter_func.__name__ in ['prewitt', 'sobel']:
+        pytest.xfail("https://github.com/cupy/cupy/issues/9760")
 
     mode1 = 'reflect'
     mode2 = ['reflect', 'reflect']
@@ -2594,6 +2617,9 @@ def test_multiple_modes_sequentially(xp):
 @make_xp_test_case(ndimage.prewitt)
 def test_multiple_modes_prewitt(xp):
     # Test prewitt filter for multiple extrapolation modes
+    if is_cupy(xp):
+        pytest.xfail("https://github.com/cupy/cupy/issues/9760")
+
     arr = xp.asarray([[1., 0., 0.],
                       [1., 1., 0.],
                       [0., 0., 0.]])
@@ -2611,6 +2637,9 @@ def test_multiple_modes_prewitt(xp):
 @make_xp_test_case(ndimage.sobel)
 def test_multiple_modes_sobel(xp):
     # Test sobel filter for multiple extrapolation modes
+    if is_cupy(xp):
+        pytest.xfail("https://github.com/cupy/cupy/issues/9760")
+
     arr = xp.asarray([[1., 0., 0.],
                       [1., 1., 0.],
                       [0., 0., 0.]])

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -2714,6 +2714,7 @@ class TestNdimageMorphology:
 
     @skip_xp_backends("jax.numpy", reason="output=array requires buffer view")
     @skip_xp_backends("dask.array", reason="output=array requires buffer view")
+    @skip_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/9756")
     @make_xp_test_case(ndimage.white_tophat)
     def test_white_tophat04(self, xp):
         array = np.eye(5, dtype=bool)
@@ -2785,6 +2786,7 @@ class TestNdimageMorphology:
 
     @skip_xp_backends("jax.numpy", reason="output=array requires buffer view")
     @skip_xp_backends("dask.array", reason="output=array requires buffer view")
+    @skip_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/9756")
     @make_xp_test_case(ndimage.black_tophat)
     def test_black_tophat04(self, xp):
         array = xp.asarray(np.eye(5, dtype=bool))
@@ -2959,7 +2961,7 @@ class TestDilateFix:
         else:
             self.dilated3x3 = xp.astype(dilated3x3, xp.uint8)
 
-
+    @skip_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/9756")
     def test_dilation_square_structure(self, xp):
         self._setup(xp)
         result = ndimage.grey_dilation(self.array, structure=self.sq3x3)

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -73,6 +73,7 @@ class TestBSplines:
         xp_assert_close(signal.spline_filter(data_array_real, 0),
                         result_array_real)
 
+    @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/9758")
     @make_xp_test_case(signal.spline_filter)
     def test_spline_filter_complex(self, xp):
         rng = np.random.RandomState(12457)

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -916,7 +916,7 @@ class TestGetWindow:
         sig = xp.arange(128)
 
         win = windows.get_window(('kaiser', 8.0), osfactor // 2, xp=xp)
-        mesg = "^window must" if is_cupy(xp) else "^window.shape="
+        mesg = "^window must|^window.shape="
         with assert_raises(ValueError, match=mesg):
             resample(sig, sig.shape[0] * osfactor, window=win)
 


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/24670

#### What does this implement/fix?
<!--Please explain your changes.-->

<s>On top of https://github.com/scipy/scipy/pull/24638</s> rebased
Add xfails/skips for tests failing with CuPy 14.0.1.

With this, locally I get 
```
$ spin test scipy -j 12 -b cupy
....
====== 65738 passed, 13295 skipped, 1131 xfailed, 18 xpassed in 191.52s (0:03:11) ======
```

#### Additional information
<!--Any additional information you think is important.-->



#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai