### PR TITLE
TST/DOC: Set `jax_default_matmul_precision` to `float32` for tests using the JAX backend

### DIFF
--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -351,6 +351,18 @@ and PyTorch with the
 on ARM Mac. We are open to expanding and improving ``float32``-only
 support in cases where this is feasible and there is sufficient user interest.
 
+It is therefore recommended that those using SciPy with the JAX backend set the X64 flag by one
+of the means JAX provides since the default ``float32``-only configuration is not
+currently tested.
+
+Though not directly related to default dtypes, it may be useful to know that JAX defaults to using
+[TensorFloat32](https://github.com/jax-ml/jax/issues/4873)
+precision for matrix multiplication of ``float32`` arrays on GPUs that support TensorFloat32.
+The half-precision mantissas used in this format can cause accuracy issues in scientific applications.
+SciPy sets [jax_default_matmul_precision](https://docs.jax.dev/en/latest/_autosummary/jax.default_matmul_precision.html) to ``"float32"`` in its JAX GPU tests and we recommend this configuration for users
+of the JAX backend. This configuration option does not affect matrix multiplications of ``float64``
+arrays when the X64 flag is enabled.
+
 
 Array creation functions without array inputs
 `````````````````````````````````````````````

--- a/doc/source/dev/api-dev/array_api.rst
+++ b/doc/source/dev/api-dev/array_api.rst
@@ -356,10 +356,11 @@ of the means JAX provides since the default ``float32``-only configuration is no
 currently tested.
 
 Though not directly related to default dtypes, it may be useful to know that JAX defaults to using
-[TensorFloat32](https://github.com/jax-ml/jax/issues/4873)
+`TensorFloat32 <https://github.com/jax-ml/jax/issues/4873>`_
 precision for matrix multiplication of ``float32`` arrays on GPUs that support TensorFloat32.
 The half-precision mantissas used in this format can cause accuracy issues in scientific applications.
-SciPy sets [jax_default_matmul_precision](https://docs.jax.dev/en/latest/_autosummary/jax.default_matmul_precision.html) to ``"float32"`` in its JAX GPU tests and we recommend this configuration for users
+SciPy sets `jax_default_matmul_precision <https://docs.jax.dev/en/latest/_autosummary/jax.default_matmul_precision.html>`_ to
+``"float32"`` in its JAX GPU tests and we recommend this configuration for users
 of the JAX backend. This configuration option does not affect matrix multiplications of ``float64``
 arrays when the X64 flag is enabled.
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -247,6 +247,10 @@ if SCIPY_ARRAY_API:
                    pytest.mark.thread_unsafe]))
 
         jax.config.update("jax_enable_x64", True)
+        # Make sure JAX won't default to less accurate TensorFloat32 precision
+        # in matmuls with float32 inputs on GPUs that support this floating
+        # point format.
+        jax.config.update("jax_default_matmul_precision", "float32")
         jax.config.update("jax_default_device", jax.devices(SCIPY_DEVICE)[0])
         if SCIPY_DEVICE != "cpu":
             xp_skip_cpu_only_backends.add('jax.numpy')

--- a/scipy/differentiate/tests/test_differentiate.py
+++ b/scipy/differentiate/tests/test_differentiate.py
@@ -255,7 +255,7 @@ class TestDerivative:
         for i in range(h0.shape[0]):
             ref = derivative(f, x, initial_step=h0[i, 0], order=2, maxiter=1,
                              step_direction=step_direction)
-            xp_assert_close(res.df[i, :], ref.df, rtol=1e-14)
+            xp_assert_close(res.df[i, :], ref.df, rtol=5e-13)
 
     def test_maxiter_callback(self, xp):
         # Test behavior of `maxiter` parameter and `callback` interface


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In @lucascolley's PR https://github.com/scipy/scipy/pull/24714, some tests for `LinearOperator` were showing very large relative error on order of `1e-2` when using the JAX backend on GPU. I determined that this is because JAX defaults to using [TensorFloat32](https://en.wikipedia.org/wiki/TensorFloat-32) when multiplying `float32` arrays on GPUs that support this floating point format, as described here: https://github.com/jax-ml/jax/issues/4873.

Though very useful for neural networks, the half precision mantissas of the `TensorFloat32` format can cause serious accuracy issues in scientific applications, so I think it's a good idea to set `jax_default_matmul_precision="float32"` in `conftest.py` and document this is the Array API docs. I've done both of these things here.

#### Additional information
<!--Any additional information you think is important.-->
There is a test in `scipy.differentiate.tests.test_differentiate` which passes before this option has changed and fails afterwards. The failure is due to a 1 ulp discrepancy in the value of a vectorized `jax.numpy.exp` vs separate applications of the scalar `jax.numpy.exp` on GPU. I don't think there is a good reason why adjusting the `jax_default_matmul_precision` would cause this discrepancy. It seems to be due to some strange quirk in code generated by the JAX compiler. I simply adjusted the tolerance.

#### AI Generation Disclosure
This PR contains no AI generated code or text. I did however ask Google Gemini  "why might JAX be less accurate for float32 matrix multiplications on GPU than PyTorch or CuPy?" and it was what suggested default `TensorFloat32` precision as a potential underlying reason. I did not know this fact off-hand. In the pre-AI era I likely would have found this information through a traditional search engine query.

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
