### PR TITLE
ENH: stats.ks_1samp/ks_2samp/kstest: add MArray support

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8035,7 +8035,6 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
         dtype = xp_result_type(data1, data2, force_floating=True, xp=xp)
         n1 = xp.astype(_count_nonmasked(data1, axis=-1), dtype)
         n2 = xp.astype(_count_nonmasked(data2, axis=-1), dtype)
-        data_all = xp.sort(data_all, axis=-1)
         cdf1 = xp.astype(_xp_searchsorted(data1, data_all, side='right'), dtype)
         cdf2 = xp.astype(_xp_searchsorted(data2, data_all, side='right'), dtype)
         cddiffs = cdf1/n1[..., xp.newaxis] - cdf2/n2[..., xp.newaxis]

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7616,6 +7616,8 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     if alternative not in ['two-sided', 'greater', 'less']:
         raise ValueError(f"Unexpected value {alternative=}")
 
+    x = xp.sort(x, axis=-1)
+    x = xp_promote(x, force_floating=True, xp=xp)
     N = _count_nonmasked(x, axis=-1, xp=xp)
     # Here and below, we currently have to do some unmasking/re-masking of masked arrays
     # because stats distributions don't work with MArrays natively. The dance for
@@ -7624,8 +7626,6 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     # the null distribution functions are replaced with scipy.special versions that
     # handle the unmasking/re-masking.
     N = N.data if is_marray(xp) else N
-    x = xp.sort(x, axis=-1)
-    x = xp_promote(x, force_floating=True, xp=xp)
     cdfvals = cdf(x.data if is_marray(xp) else x, *args)
     cdfvals = xp.asarray(cdfvals, mask=x.mask) if is_marray(xp) else cdfvals
     ones = xp.ones(x.shape[:-1], dtype=xp.int8)
@@ -7665,7 +7665,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     if mode == 'exact':
         prob = distributions.kstwo.sf(D, N)
     elif mode == 'asymp':
-        prob = distributions.kstwobign.sf(D * math.sqrt(N))
+        prob = distributions.kstwobign.sf(D * N**0.5)
     else:
         # mode == 'approx'
         prob = 2 * distributions.ksone.sf(D, N)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7445,12 +7445,14 @@ def _compute_d(cdfvals, x, sign, xp=None):
         The location at which the maximum is reached.
     """
     xp = array_namespace(cdfvals, x) if xp is None else xp
-    n = cdfvals.shape[-1]
-    D = (xp.arange(1.0, n + 1, dtype=x.dtype) / n - cdfvals if sign == +1
-         else (cdfvals - xp.arange(0.0, n, dtype=x.dtype)/n))
+    length = cdfvals.shape[-1]
+    n = _count_nonmasked(cdfvals, axis=-1, keepdims=True)
+    D = (xp.arange(1.0, length + 1, dtype=x.dtype) / n - cdfvals if sign == +1
+         else (cdfvals - xp.arange(0.0, length, dtype=x.dtype) / n))
     amax = xp.argmax(D, axis=-1, keepdims=True)
     loc_max = xp.squeeze(xp.take_along_axis(x, amax, axis=-1), axis=-1)
     D = xp.squeeze(xp.take_along_axis(D, amax, axis=-1), axis=-1)
+    D = D.data if is_marray(xp) else D
     return D[()] if D.ndim == 0 else D, loc_max[()] if loc_max.ndim == 0 else loc_max
 
 
@@ -7614,10 +7616,18 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     if alternative not in ['two-sided', 'greater', 'less']:
         raise ValueError(f"Unexpected value {alternative=}")
 
-    N = x.shape[-1]
+    N = _count_nonmasked(x, axis=-1, xp=xp)
+    # Here and below, we currently have to do some unmasking/re-masking of masked arrays
+    # because stats distributions don't work with MArrays natively. The dance for
+    # CDF evaluation below will probably have to stay if we want to continue to accept
+    # distribution cdf methods, but the rest of the conversions can be removed when
+    # the null distribution functions are replaced with scipy.special versions that
+    # handle the unmasking/re-masking.
+    N = N.data if is_marray(xp) else N
     x = xp.sort(x, axis=-1)
     x = xp_promote(x, force_floating=True, xp=xp)
-    cdfvals = cdf(x, *args)
+    cdfvals = cdf(x.data if is_marray(xp) else x, *args)
+    cdfvals = xp.asarray(cdfvals, mask=x.mask) if is_marray(xp) else cdfvals
     ones = xp.ones(x.shape[:-1], dtype=xp.int8)
     ones = ones[()] if ones.ndim == 0 else ones
 
@@ -7625,6 +7635,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
         Dplus, d_location = _compute_d(cdfvals, x, +1)
         pvalue = xp.asarray(distributions.ksone.sf(Dplus, N), dtype=x.dtype)
         pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
+        Dplus = xp.asarray(Dplus) if is_marray(xp) else Dplus
         return KstestResult(Dplus, pvalue,
                             statistic_location=d_location,
                             statistic_sign=ones)
@@ -7633,6 +7644,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
         Dminus, d_location = _compute_d(cdfvals, x, -1)
         pvalue = xp.asarray(distributions.ksone.sf(Dminus, N), dtype=x.dtype)
         pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
+        Dminus = xp.asarray(Dminus) if is_marray(xp) else Dminus
         return KstestResult(Dminus, pvalue,
                             statistic_location=d_location,
                             statistic_sign=-ones)
@@ -7647,6 +7659,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     if D.ndim == 0:
         D, d_location, d_sign = D[()], d_location[()], d_sign[()]
 
+    D = D.data if is_marray(xp) else D
     if mode == 'auto':  # Always select exact
         mode = 'exact'
     if mode == 'exact':
@@ -7657,6 +7670,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
         # mode == 'approx'
         prob = 2 * distributions.ksone.sf(D, N)
     prob = xp.clip(xp.asarray(prob, dtype=x.dtype), 0., 1.)
+    D = xp.asarray(D) if is_marray(xp) else D
     return KstestResult(D, prob,
                         statistic_location=d_location,
                         statistic_sign=d_sign)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8026,38 +8026,45 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
     n2 = data2.shape[-1]
     if min(n1, n2) == 0:
         raise ValueError('Data passed to ks_2samp must not be empty')
-    n = n1 + n2
 
     data_all = xp.concat((data1, data2), axis=-1)
     batch_shape = data_all.shape[:-1]
 
-    # Previously, this part of the code was just:
-    # cdf1 = _xp_searchsorted(data1, data_all, side='right') / n1
-    # cdf2 = _xp_searchsorted(data2, data_all, side='right') / n2
-    # cddiffs = cdf1 - cdf2
-    # but the switch from `xp.searchsorted` to `_xp_searchsorted` would come with a
-    # pretty steep performance hit. When `xp.searchsorted` is vectorized, we can
-    # probably use that. In the meantime, the following algorithm is typically faster.
+    if is_marray(xp):
+        # Previously, we used this algorithm for all backends:
+        dtype = xp_result_type(data1, data2, force_floating=True, xp=xp)
+        n1 = xp.astype(_count_nonmasked(data1, axis=-1), dtype)
+        n2 = xp.astype(_count_nonmasked(data2, axis=-1), dtype)
+        data_all = xp.sort(data_all, axis=-1)
+        cdf1 = xp.astype(_xp_searchsorted(data1, data_all, side='right'), dtype)
+        cdf2 = xp.astype(_xp_searchsorted(data2, data_all, side='right'), dtype)
+        cddiffs = cdf1/n1[..., xp.newaxis] - cdf2/n2[..., xp.newaxis]
+        # but the switch from `xp.searchsorted` to `_xp_searchsorted` would come with a
+        # pretty steep performance hit, so the algorithm below is faster.
+        # When `xp.searchsorted` is vectorized, we can revert.
+    else:
+        n = n1 + n2
 
-    # We want the ECDF of each sample evaluated at *all* the points in the pooled
-    # sample. The values each ECDF can assume are given by:
-    cdf1_vals = xp.broadcast_to(xp.linspace(0, 1, n1 + 1), batch_shape + (n1 + 1,))
-    cdf2_vals = xp.broadcast_to(xp.linspace(0, 1, n2 + 1), batch_shape + (n2 + 1,))
-    # Now we "just" need to know how many times each of these values *will* be assumed
-    # when we evaluate the ECDFs at all points in the pooled sample.
-    # These counts are given by the differences between consecutive ("min" or "max")
-    # ranks corresponding with the observations in the (sorted) samples.
-    ranks, data_all = _rankdata(data_all, method='min', return_sorted=True)  # axis=-1
-    ranks = xp.astype(ranks, xp.asarray(1).dtype)  # default int type
-    one = xp.ones((*ranks.shape[:-1], 1), dtype=ranks.dtype, device=xp_device(ranks))
-    cdf1_counts = xp.diff(ranks[..., :n1], prepend=one, append=n + one, axis=-1)
-    cdf2_counts = xp.diff(ranks[..., -n2:], prepend=one, append=n + one, axis=-1)
-    # Repeat isn't vectorized - in general, this would produce a ragged array. However,
-    # In our case, the sum of repeats for each slice is the same, so we can do a
-    # vectorized repeat by raveling, repeating, then restoring the shape.
-    cdf1 = xp.repeat(xp_ravel(cdf1_vals), xp_ravel(cdf1_counts), axis=-1)
-    cdf2 = xp.repeat(xp_ravel(cdf2_vals), xp_ravel(cdf2_counts), axis=-1)
-    cddiffs = xp.reshape(cdf1 - cdf2, ranks.shape[:-1] + (-1,))
+        # We want the ECDF of each sample evaluated at *all* the points in the pooled
+        # sample. The values each ECDF can assume are given by:
+        cdf1_vals = xp.broadcast_to(xp.linspace(0, 1, n1 + 1), batch_shape + (n1 + 1,))
+        cdf2_vals = xp.broadcast_to(xp.linspace(0, 1, n2 + 1), batch_shape + (n2 + 1,))
+        # Now we "just" need to know how many times each of these values *will* be
+        # assumed when we evaluate the ECDFs at all points in the pooled sample.
+        # These counts are given by the differences between consecutive ("min" or "max")
+        # ranks corresponding with the observations in the (sorted) samples.
+        ranks, data_all = _rankdata(data_all, method='min', return_sorted=True)
+        ranks = xp.astype(ranks, xp.asarray(1).dtype)  # default int type
+        one = xp.ones((*ranks.shape[:-1], 1), dtype=ranks.dtype,
+                      device=xp_device(ranks))
+        cdf1_counts = xp.diff(ranks[..., :n1], prepend=one, append=n + one, axis=-1)
+        cdf2_counts = xp.diff(ranks[..., -n2:], prepend=one, append=n + one, axis=-1)
+        # Repeat isn't vectorized - in general, this would produce a ragged array.
+        # However, in our case, the sum of repeats for each slice is the same, so we can
+        # do a vectorized repeat by raveling, repeating, then restoring the shape.
+        cdf1 = xp.repeat(xp_ravel(cdf1_vals), xp_ravel(cdf1_counts), axis=-1)
+        cdf2 = xp.repeat(xp_ravel(cdf2_vals), xp_ravel(cdf2_counts), axis=-1)
+        cddiffs = xp.reshape(cdf1 - cdf2, ranks.shape[:-1] + (-1,))
 
     # Identify the location of the statistic
     argminS = xp.argmin(cddiffs, axis=-1, keepdims=True)
@@ -8081,16 +8088,20 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
     d_location = xp.where(selector, loc_minS, loc_maxS)
     one = xp.asarray(1, dtype=xp.int8)
     d_sign = xp.where(selector, -one, one)
+
+    if is_marray(xp):
+        d = d.data  # converted to NumPy below
+        n1, n2 = np.asarray(n1.data, dtype=int), np.asarray(n2.data, dtype=int)
     prob = _ks_2samp_prob(np.asarray(d), n1, n2, mode, MAX_AUTO_N, alternative)
     dtype = xp_result_type(data1, data2, force_floating=True, xp=xp)
     prob = xp.asarray(prob, dtype=dtype)
-    d = xp.astype(d, dtype, copy=False)
+    d = xp.asarray(d, dtype=dtype)
     if d.ndim == 0:
         d, prob, d_location, d_sign = d[()], prob[()], d_location[()], d_sign[()]
     return KstestResult(d, prob, statistic_location=d_location, statistic_sign=d_sign)
 
 
-@np.vectorize(excluded={1, 2, 3, 4, 5}, otypes=[np.float64])
+@np.vectorize(excluded={3, 4, 5}, otypes=[np.float64])
 def _ks_2samp_prob(d, n1, n2, mode, MAX_AUTO_N, alternative):
     # math.gcd used to return an `int`, but now that these return arrays, NumPy can
     # return an int32. Unless we want the pythranized functions to be compiled for

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -346,6 +346,23 @@ def test_one_sample_tests(fun, kwargs, axis, xp):
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
 
 
+@make_xp_test_case(stats.ks_1samp)
+@skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
+@pytest.mark.parametrize('method', ['exact', 'asymptotic'])  # auto == exact
+@pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
+@pytest.mark.parametrize('axis', [0, 1, None])
+def test_ks_1samp(method, alternative, axis, xp):
+    mxp, marrays, narrays = get_arrays(1, xp=xp, seed=84912165484322)
+    kwargs = dict(method=method, alternative=alternative, axis=axis)
+    res = stats.ks_1samp(*marrays, stats.norm.cdf, **kwargs)
+    ref = stats.ks_1samp(*narrays, stats.norm.cdf, nan_policy='omit', **kwargs)
+    xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
+    xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
+    xp_assert_close(res.statistic_location.data, xp.asarray(ref.statistic_location))
+    xp_assert_close(res.statistic_sign.data,
+                    xp.asarray(ref.statistic_sign, dtype=xp.int8))
+
+
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.parametrize('fun, kwargs', [
     make_xp_pytest_param(stats.brunnermunzel, {}),

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -358,8 +358,8 @@ def test_ks_1samp(method, alternative, axis, xp):
     ref = stats.ks_1samp(*narrays, stats.norm.cdf, nan_policy='omit', **kwargs)
     xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
-    xp_assert_close(res.statistic_location.data, xp.asarray(ref.statistic_location))
-    xp_assert_close(res.statistic_sign.data,
+    xp_assert_equal(res.statistic_location.data, xp.asarray(ref.statistic_location))
+    xp_assert_equal(res.statistic_sign.data,
                     xp.asarray(ref.statistic_sign, dtype=xp.int8))
 
 
@@ -380,6 +380,25 @@ def test_two_sample_tests(fun, kwargs, axis, xp):
     ref = fun(*narrays, nan_policy='omit', axis=axis, **kwargs)
     xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
+
+
+@make_xp_test_case(stats.ks_2samp)
+@skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
+@pytest.mark.parametrize('method', ['exact', 'asymp', 'auto'])  # auto == exact
+@pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
+@pytest.mark.parametrize('axis', [0, 1, None])
+def test_ks_2samp(method, alternative, axis, xp):
+    mxp, marrays, narrays = get_arrays(2, xp=xp, seed=84912165484322)
+    kwargs = dict(method=method, alternative=alternative, axis=axis)
+    res = stats.ks_2samp(*marrays, **kwargs)
+    ref = stats.ks_2samp(*narrays, nan_policy='omit', **kwargs)
+    xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
+    xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
+    # with this random data, there often multiple locations where the statistic assumes
+    # the most extreme value, so we can't expect these to always match
+    # xp_assert_equal(res.statistic_location.data, xp.asarray(ref.statistic_location))
+    xp_assert_equal(res.statistic_sign.data,
+                    xp.asarray(ref.statistic_sign, dtype=xp.int8))
 
 
 @make_xp_test_case(stats.kendalltau)

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -346,15 +346,16 @@ def test_one_sample_tests(fun, kwargs, axis, xp):
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
 
 
-@make_xp_test_case(stats.ks_1samp)
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
-@pytest.mark.parametrize('method', ['exact', 'asymptotic'])  # auto == exact
+@pytest.mark.parametrize('fun', [make_xp_pytest_param(stats.ks_1samp),
+                                 make_xp_pytest_param(stats.kstest)])
+@pytest.mark.parametrize('method', ['exact', 'approx', 'asymptotic'])  # auto == exact
 @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_ks_1samp(method, alternative, axis, xp):
+def test_ks_1samp(fun, method, alternative, axis, xp):
     mxp, marrays, narrays = get_arrays(1, xp=xp, seed=84912165484322)
     kwargs = dict(method=method, alternative=alternative, axis=axis)
-    res = stats.ks_1samp(*marrays, stats.norm.cdf, **kwargs)
+    res = fun(*marrays, stats.norm.cdf, **kwargs)
     ref = stats.ks_1samp(*narrays, stats.norm.cdf, nan_policy='omit', **kwargs)
     xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
@@ -384,13 +385,15 @@ def test_two_sample_tests(fun, kwargs, axis, xp):
 
 @make_xp_test_case(stats.ks_2samp)
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
+@pytest.mark.parametrize('fun', [make_xp_pytest_param(stats.ks_2samp),
+                                 make_xp_pytest_param(stats.kstest)])
 @pytest.mark.parametrize('method', ['exact', 'asymp', 'auto'])  # auto == exact
 @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_ks_2samp(method, alternative, axis, xp):
+def test_ks_2samp(fun, method, alternative, axis, xp):
     mxp, marrays, narrays = get_arrays(2, xp=xp, seed=84912165484322)
     kwargs = dict(method=method, alternative=alternative, axis=axis)
-    res = stats.ks_2samp(*marrays, **kwargs)
+    res = fun(*marrays, **kwargs)
     ref = stats.ks_2samp(*narrays, nan_policy='omit', **kwargs)
     xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))


### PR DESCRIPTION
#### Reference issue
Toward gh-20544
Toward gh-22194 

#### What does this implement/fix?
Adds support for MArrays to `stats.ks_1samp` and `stats.ks_2samp`.

#### Additional information
Hide whitespace for cleaner diff.

#### AI Generation Disclosure
No AI