### PR TITLE
CI: needs get_commit_message

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,12 +30,12 @@ jobs:
     name: Get commit message
     uses: ./.github/workflows/commit_message.yml
 
-
   build_wheels:
     name: Wheel, ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
       ${{ matrix.buildplat[2] }} ${{ matrix.buildplat[3] }}
       ${{ matrix.buildplat[4] }}
     runs-on: ${{ matrix.buildplat[0] }}
+    needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')


### PR DESCRIPTION
I missed this in #24536. Without it the wheel.yml will never run.