### PR TITLE
ENH: stats.gaussian_kde: add Sheather-Jones bandwidth selection

### DIFF
--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -52,10 +52,11 @@ class gaussian_kde:
         array, otherwise a 2-D array with shape (# of dims, # of data).
     bw_method : str, scalar or callable, optional
         The method used to calculate the bandwidth factor.  This can be
-        'scott', 'silverman', a scalar constant or a callable.  If a scalar,
-        this will be used directly as `factor`.  If a callable, it should
-        take a `gaussian_kde` instance as only parameter and return a scalar.
-        If None (default), 'scott' is used.  See Notes for more details.
+        'scott', 'silverman', 'sheather-jones', a scalar constant or a
+        callable.  If a scalar, this will be used directly as `factor`.  If
+        a callable, it should take a `gaussian_kde` instance as only
+        parameter and return a scalar.  If None (default), 'scott' is used.
+        See Notes for more details.
     weights : array_like, optional
         weights of datapoints. This must be the same shape as dataset.
         If None (default), the samples are assumed to be equally weighted
@@ -127,6 +128,14 @@ class gaussian_kde:
     may be more robust in the univariate case; see documentation of the
     ``set_bandwidth`` method for implementing a custom bandwidth rule.
 
+    The Sheather-Jones method [7]_ [8]_, selected via
+    ``bw_method='sheather-jones'``, is a plug-in bandwidth selector that
+    estimates the optimal bandwidth by computing the roughness of the second
+    derivative of the KDE using a closed-form solution for the Gaussian kernel.
+    It is available only for univariate data and does not support weighted
+    samples.  It generally provides better bandwidth selection than Scott's or
+    Silverman's rules for a variety of density shapes.
+
     Good general descriptions of kernel density estimation can be found in [1]_
     and [2]_, the mathematics for this multi-dimensional implementation can be
     found in [1]_.
@@ -159,6 +168,12 @@ class gaussian_kde:
            Series A (General), 132, 272
     .. [6] Kernel density estimation. *Wikipedia.*
            https://en.wikipedia.org/wiki/Kernel_density_estimation
+    .. [7] S.J. Sheather and M.C. Jones, "A Reliable Data-Based Bandwidth
+           Selection Method for Kernel Density Estimation", Journal of the
+           Royal Statistical Society. Series B (Methodological), Vol. 53,
+           No. 3, pp. 683-690, 1991.
+    .. [8] G.H. Givens and J.A. Hoeting, "Computational Statistics",
+           2nd ed., John Wiley & Sons, Hoboken, NJ, 2013.
 
     Examples
     --------
@@ -514,6 +529,119 @@ class gaussian_kde:
         """
         return power(self.neff*(self.d+2.0)/4.0, -1./(self.d+4))
 
+    def sheather_jones_factor(self):
+        """Compute the Sheather-Jones plug-in bandwidth factor.
+
+        Uses a closed-form solution for the roughness of the second
+        derivative of the Gaussian KDE to derive the optimal bandwidth.
+        Only supports univariate, unweighted data.
+
+        Returns
+        -------
+        s : float
+            The Sheather-Jones bandwidth factor.
+
+        Raises
+        ------
+        ValueError
+            If the data is multivariate (d > 1).
+        NotImplementedError
+            If the data is weighted.
+
+        References
+        ----------
+        .. [1] S.J. Sheather and M.C. Jones, "A Reliable Data-Based
+               Bandwidth Selection Method for Kernel Density Estimation",
+               J. R. Stat. Soc. B, Vol. 53, No. 3, pp. 683-690, 1991.
+        .. [2] G.H. Givens and J.A. Hoeting, "Computational Statistics",
+               2nd ed., Wiley, 2013.
+        """
+        if self.d != 1:
+            raise ValueError(
+                "Sheather-Jones bandwidth selection is only supported "
+                "for univariate data (d=1)."
+            )
+        if hasattr(self, '_weights') and not np.allclose(
+                self._weights, 1.0 / self.n):
+            raise NotImplementedError(
+                "Sheather-Jones bandwidth selection is not implemented "
+                "for weighted data."
+            )
+
+        n = self.n
+        X = self.dataset.ravel()
+        R_K = 1.0 / (2.0 * sqrt(pi))
+
+        # Pilot bandwidth: Silverman's rule of thumb (absolute bandwidth)
+        sigma_hat = np.std(X, ddof=1)
+        h_0 = ((4.0 / (3.0 * n)) ** (1.0 / 5.0)) * sigma_hat
+
+        # Compute roughness of f''(x) using the closed-form solution
+        # for the Gaussian kernel.
+        #
+        # For each pair (X_i, X_j), compute:
+        #   mu = (X_i + X_j) / 2
+        #   s  = h_0 / sqrt(2)
+        #   D  = 1 / sqrt(2 * pi * s^2)
+        #   H  = exp(-(X_i - X_j)^2 / (4 * h_0^2))
+        #
+        # Then the 4th-degree Hermite polynomial term B' involves the
+        # raw moments E[Z^k] for Z ~ N(mu, s^2) evaluated against the
+        # kernel second derivative product.
+        #
+        # roughness = (1 / (n^2 * h_0^6)) * sum_{i,j} B(X_i, X_j)
+        # h_hat = (R_K / (n * roughness))^(1/5)
+
+        # Vectorized pairwise computation using outer products
+        Xi = X[:, np.newaxis]  # (n, 1)
+        Xj = X[np.newaxis, :]  # (1, n)
+
+        mean_mu = (Xi + Xj) / 2.0
+        sd_sigma_sq = (h_0 ** 2) / 2.0  # s^2
+
+        D = 1.0 / sqrt(2.0 * pi * sd_sigma_sq)
+        H = exp(-(Xi - Xj) ** 2 / (4.0 * h_0 ** 2))
+
+        # Raw moments of Z ~ N(mu, s^2)
+        m1 = mean_mu
+        m2 = mean_mu ** 2 + sd_sigma_sq
+        m3 = mean_mu ** 3 + 3.0 * mean_mu * sd_sigma_sq
+        m4 = (mean_mu ** 4 + 6.0 * mean_mu ** 2 * sd_sigma_sq
+              + 3.0 * sd_sigma_sq ** 2)
+
+        h4 = h_0 ** 4
+        h2 = h_0 ** 2
+        u = Xi
+        v = Xj
+
+        # 4th-degree polynomial from the second derivative product
+        B_prime = (
+            -2.0 * m3 * v / h4
+            + m2 * v ** 2 / h4
+            + 4.0 * u * m2 * v / h4
+            - 2.0 * u * m1 * v ** 2 / h4
+            - 2.0 * u ** 2 * m1 * v / h4
+            + u ** 2 * v ** 2 / h4
+            + m4 / h4
+            - 2.0 * u * m3 / h4
+            + u ** 2 * m2 / h4
+            + 2.0 * m1 * v / h2
+            - v ** 2 / h2
+            - 2.0 * m2 / h2
+            + 2.0 * u * m1 / h2
+            - u ** 2 / h2
+            + 1.0
+        )
+
+        A_B = (B_prime / D) * (H / (2.0 * pi))
+
+        roughness = (1.0 / (n ** 2 * h_0 ** 6)) * np.sum(A_B)
+        h_hat = (R_K / (n * roughness)) ** (1.0 / 5.0)
+
+        # Return as a factor relative to the data standard deviation,
+        # since _compute_covariance multiplies factor by sqrt(data_cov)
+        return h_hat / sigma_hat
+
     #  Default method to calculate bandwidth, can be overwritten by subclass
     covariance_factor = scotts_factor
     covariance_factor.__doc__ = """Computes the bandwidth factor `factor`.
@@ -537,11 +665,15 @@ class gaussian_kde:
         ----------
         bw_method : str, scalar or callable, optional
             The method used to calculate the bandwidth factor.  This can be
-            'scott', 'silverman', a scalar constant or a callable.  If a
-            scalar, this will be used directly as `factor`.  If a callable,
-            it should take a `gaussian_kde` instance as only parameter and
-            return a scalar.  If None (default), nothing happens; the current
-            `covariance_factor` method is kept.
+            'scott', 'silverman', 'sheather-jones', a scalar constant or a
+            callable.  If a scalar, this will be used directly as `factor`.
+            If a callable, it should take a `gaussian_kde` instance as only
+            parameter and return a scalar.  If None (default), nothing
+            happens; the current `covariance_factor` method is kept.
+
+            The 'sheather-jones' method implements the Sheather-Jones plug-in
+            bandwidth selector, which is only available for univariate,
+            unweighted data.
 
         Notes
         -----
@@ -577,6 +709,8 @@ class gaussian_kde:
             self.covariance_factor = self.scotts_factor
         elif bw_method == 'silverman':
             self.covariance_factor = self.silverman_factor
+        elif bw_method == 'sheather-jones':
+            self.covariance_factor = self.sheather_jones_factor
         elif np.isscalar(bw_method) and not isinstance(bw_method, str):
             self._bw_method = 'use constant'
             self.covariance_factor = lambda: bw_method
@@ -584,8 +718,8 @@ class gaussian_kde:
             self._bw_method = bw_method
             self.covariance_factor = lambda: self._bw_method(self)
         else:
-            msg = "`bw_method` should be 'scott', 'silverman', a scalar " \
-                  "or a callable."
+            msg = "`bw_method` should be 'scott', 'silverman', " \
+                  "'sheather-jones', a scalar or a callable."
             raise ValueError(msg)
 
         self._compute_covariance()

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -675,3 +675,102 @@ def test_fewer_points_than_dimensions_gh17436():
     message = "Number of dimensions is greater than number of samples..."
     with pytest.raises(ValueError, match=message):
         stats.gaussian_kde(rvs)
+
+
+def test_kde_sheather_jones_basic():
+    # Test that bw_method='sheather-jones' produces a KDE without error and that the
+    # bandwidth is a positive finite number.
+    rng = np.random.default_rng(42)
+    xn = rng.normal(0, 1, 200)
+    gkde = stats.gaussian_kde(xn, bw_method='sheather-jones')
+    assert np.isfinite(gkde.factor)
+    assert gkde.factor > 0
+
+    # Verify that the KDE integrates to approximately 1
+    xs = np.linspace(-5, 5, 1000)
+    integral = np.trapezoid(gkde(xs), xs)
+    assert_almost_equal(integral, 1.0, decimal=2)
+
+
+def test_kde_sheather_jones_string_accepted():
+    # Verify 'sheather-jones' is accepted in both constructor and set_bandwidth
+    x1 = np.array([-7, -5, 1, 4, 5.])
+    kde = stats.gaussian_kde(x1, bw_method='sheather-jones')
+    assert np.isfinite(kde.factor)
+
+    # Also accepted via set_bandwidth
+    kde2 = stats.gaussian_kde(x1)
+    kde2.set_bandwidth(bw_method='sheather-jones')
+    assert np.isfinite(kde2.factor)
+
+
+def test_kde_sheather_jones_1d_only():
+    # Verify that 'sheather-jones' raises ValueError for multivariate data
+    rng = np.random.default_rng(42)
+    xn_2d = rng.normal(size=(2, 50))
+    message = "Sheather-Jones bandwidth selection is only supported"
+    with pytest.raises(ValueError, match=message):
+        stats.gaussian_kde(xn_2d, bw_method='sheather-jones')
+
+
+def test_kde_sheather_jones_weighted_raises():
+    # Verify that 'sheather-jones' raises NotImplementedError for weighted data
+    rng = np.random.default_rng(42)
+    xn = rng.normal(0, 1, 50)
+    wn = rng.random(50)
+    message = "Sheather-Jones bandwidth selection is not implemented"
+    with pytest.raises(NotImplementedError, match=message):
+        stats.gaussian_kde(xn, bw_method='sheather-jones', weights=wn)
+
+
+def test_kde_sheather_jones_small_dataset():
+    # Verify no numerical issues with a small dataset
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    kde = stats.gaussian_kde(x, bw_method='sheather-jones')
+    assert np.isfinite(kde.factor)
+    assert kde.factor > 0
+
+
+def test_kde_sheather_jones_set_bandwidth():
+    # Verify that switching to SJ via set_bandwidth after construction works
+    rng = np.random.default_rng(42)
+    xn = rng.normal(0, 1, 100)
+
+    kde = stats.gaussian_kde(xn)
+    scott_factor = kde.factor
+
+    kde.set_bandwidth(bw_method='sheather-jones')
+    sj_factor = kde.factor
+
+    # SJ factor should be different from Scott's
+    assert sj_factor != scott_factor
+    assert np.isfinite(sj_factor)
+    assert sj_factor > 0
+
+
+def test_kde_sheather_jones_vs_scott():
+    # Verify that SJ bandwidth differs from Scott's rule and produces
+    # a reasonable KDE for standard normal data
+    rng = np.random.default_rng(12345)
+    xn = rng.normal(0, 1, 500)
+
+    kde_scott = stats.gaussian_kde(xn, bw_method='scott')
+    kde_sj = stats.gaussian_kde(xn, bw_method='sheather-jones')
+
+    # Bandwidths should differ
+    assert kde_scott.factor != kde_sj.factor
+
+    # Both should produce a valid KDE that integrates to ~1
+    xs = np.linspace(-5, 5, 1000)
+    for kde in [kde_scott, kde_sj]:
+        integral = np.trapezoid(kde(xs), xs)
+        assert_almost_equal(integral, 1.0, decimal=2)
+
+
+def test_kde_sheather_jones_error_message():
+    # Verify the error message for invalid bw_method strings includes
+    # 'sheather-jones'
+    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    message = "'sheather-jones'"
+    with pytest.raises(ValueError, match=message):
+        stats.gaussian_kde(x, bw_method='wrongstring')

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -678,13 +678,26 @@ def test_fewer_points_than_dimensions_gh17436():
 
 
 def test_kde_sheather_jones_basic():
-    # Test that bw_method='sheather-jones' produces a KDE without error and that the
-    # bandwidth is a positive finite number.
+    # Test that bw_method='sheather-jones' produces a KDE without error and that
+    # the bandwidth is a positive finite number.
     rng = np.random.default_rng(42)
     xn = rng.normal(0, 1, 200)
     gkde = stats.gaussian_kde(xn, bw_method='sheather-jones')
     assert np.isfinite(gkde.factor)
     assert gkde.factor > 0
+
+    # Verify value against {locfit} silverman pilot bandwidth from R
+    h = gkde.factor * np.std(xn, ddof=1)
+    
+    # locfit from R result (using silverman as initial bandwidth)
+    # Note: locfit uses a slightly different definition of pilot bandwidth due
+    # to binned approximations
+    expected_h_locfit = 0.3251302
+    assert_allclose(h, expected_h_locfit, rtol=1e-2)
+    
+    # Exact closed-form analytical solution from original R code
+    expected_h_exact = 0.3254563
+    assert_allclose(h, expected_h_exact, rtol=1e-5)
 
     # Verify that the KDE integrates to approximately 1
     xs = np.linspace(-5, 5, 1000)
@@ -724,12 +737,27 @@ def test_kde_sheather_jones_weighted_raises():
 
 
 def test_kde_sheather_jones_small_dataset():
-    # Verify no numerical issues with a small dataset
-    x = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0])
+    # Verify value against {locfit} silverman pilot bandwidth from R
+    x = np.array([
+        50, 31, 32, 21, 33, 30, 26, 29, 53, 54,
+        30, 34, 57, 59, 51, 32, 31, 31, 33, 32,
+        27, 50, 41, 29, 51, 41, 43, 22, 57, 38,
+        60, 28, 22, 28, 45, 33, 35, 46, 27, 56,
+        26, 37, 48, 54, 40, 25, 29, 22, 31, 24,
+    ])
     kde = stats.gaussian_kde(x, bw_method='sheather-jones')
-    assert np.isfinite(kde.factor)
-    assert kde.factor > 0
+    
+    # R locfit sj method returns absolute bandwidth (h), so we compare against 
+    # kde.factor * np.std(x, ddof=1)
+    h = kde.factor * np.std(x, ddof=1)
+    
+    # locfit from R result (using silverman as initial bandwidth)
+    expected_h = 4.288694
+    assert_allclose(h, expected_h, rtol=1e-2)
 
+    # Exact closed-form analytical solution from original R code
+    expected_h_exact = 4.306058
+    assert_allclose(h, expected_h_exact, rtol=1e-5)
 
 def test_kde_sheather_jones_set_bandwidth():
     # Verify that switching to SJ via set_bandwidth after construction works
@@ -746,26 +774,6 @@ def test_kde_sheather_jones_set_bandwidth():
     assert sj_factor != scott_factor
     assert np.isfinite(sj_factor)
     assert sj_factor > 0
-
-
-def test_kde_sheather_jones_vs_scott():
-    # Verify that SJ bandwidth differs from Scott's rule and produces
-    # a reasonable KDE for standard normal data
-    rng = np.random.default_rng(12345)
-    xn = rng.normal(0, 1, 500)
-
-    kde_scott = stats.gaussian_kde(xn, bw_method='scott')
-    kde_sj = stats.gaussian_kde(xn, bw_method='sheather-jones')
-
-    # Bandwidths should differ
-    assert kde_scott.factor != kde_sj.factor
-
-    # Both should produce a valid KDE that integrates to ~1
-    xs = np.linspace(-5, 5, 1000)
-    for kde in [kde_scott, kde_sj]:
-        integral = np.trapezoid(kde(xs), xs)
-        assert_allclose(integral, 1.0, atol=1e-2)
-
 
 def test_kde_sheather_jones_error_message():
     # Verify the error message for invalid bw_method strings includes

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -689,7 +689,7 @@ def test_kde_sheather_jones_basic():
     # Verify that the KDE integrates to approximately 1
     xs = np.linspace(-5, 5, 1000)
     integral = np.trapezoid(gkde(xs), xs)
-    assert_almost_equal(integral, 1.0, decimal=2)
+    assert_allclose(integral, 1.0, atol=1e-2)
 
 
 def test_kde_sheather_jones_string_accepted():
@@ -764,7 +764,7 @@ def test_kde_sheather_jones_vs_scott():
     xs = np.linspace(-5, 5, 1000)
     for kde in [kde_scott, kde_sj]:
         integral = np.trapezoid(kde(xs), xs)
-        assert_almost_equal(integral, 1.0, decimal=2)
+        assert_allclose(integral, 1.0, atol=1e-2)
 
 
 def test_kde_sheather_jones_error_message():


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #19330

#### What does this implement/fix?
<!--Please explain your changes.-->
Add the Sheather-Jones plug-in bandwidth selection method to scipy.stats.gaussian_kde. Users can now specify
bw_method='sheather-jones' alongside the existing 'scott' and 'silverman' options.

The implementation uses a closed-form solution for the roughness of the second derivative of the Gaussian KDE, ported from a rigorously derived R implementation. Results validated against R on two datasets (diabetes Age, wine volatile acidity) with exact matches.

#### Additional information
<!--Any additional information you think is important.-->
Restrictions:
- Univariate data only (raises ValueError for d > 1)
- Unweighted data only (raises NotImplementedError for weighted data)

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
The original R code and derivations were all written manually. The porting of the code from R to Python was done using Claude Opus 4.6. The code was validated by comparing the results with original results (using two distinct datasets with results matching up to 6 significant figures) obtained from the R code and they were shown to match. From this it was shown that the Python code matches the original R implementation.

Further validation was done locally, seeing that the Sheather-Jones bandwidth creates KDE that (visually) match or outperform the existing Scott and Silverman KDE's (in particular for skewed and multimodal distributions).