### PR TITLE
DOC: Add link to extrapolation tutorial in BSpline and PPoly docstrings

### DIFF
--- a/doc/source/tutorial/interpolate/extrapolation_examples.rst
+++ b/doc/source/tutorial/interpolate/extrapolation_examples.rst
@@ -33,6 +33,15 @@ are deliberately pared down to bare essentials needed to demonstrate the
 main ideas, in a hope that they serve as an inspiration for your
 handling of your particular problem.
 
+Many interpolation classes in SciPy support extrapolation behavior, including
+:class:`scipy.interpolate.BSpline`,
+:class:`scipy.interpolate.PPoly`,
+:class:`scipy.interpolate.CubicSpline`,
+and :class:`scipy.interpolate.BPoly`.
+
+These classes provide different representations of piecewise polynomials and
+splines, and expose parameters that control how extrapolation outside the
+data range is handled.
 
 .. _tutorial-extrapolation-left-right:
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -201,7 +201,7 @@ class BSpline:
     >>> ax.plot(xx, [bspline(x, t, c ,k) for x in xx], 'r-', lw=3, label='naive')
     >>> ax.plot(xx, spl(xx), 'b-', lw=4, alpha=0.7, label='BSpline')
     >>> ax.grid(True)
-    >>> ax.legend(loc='best') 
+    >>> ax.legend(loc='best')
     >>> plt.show()
     
     See Also

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -201,8 +201,12 @@ class BSpline:
     >>> ax.plot(xx, [bspline(x, t, c ,k) for x in xx], 'r-', lw=3, label='naive')
     >>> ax.plot(xx, spl(xx), 'b-', lw=4, alpha=0.7, label='BSpline')
     >>> ax.grid(True)
-    >>> ax.legend(loc='best')
+    >>> ax.legend(loc='best') 
     >>> plt.show()
+    
+    See Also
+    --------
+    :doc:`/tutorial/interpolate/extrapolation_examples`
 
 
     References

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -203,10 +203,6 @@ class BSpline:
     >>> ax.grid(True)
     >>> ax.legend(loc='best')
     >>> plt.show()
-    
-    See Also
-    --------
-    :doc:`/tutorial/interpolate/extrapolation_examples`
 
 
     References

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -281,11 +281,6 @@ class interp1d(_Interpolator1D):
     >>> ynew = f(xnew)   # use interpolation function returned by `interp1d`
     >>> plt.plot(x, y, 'o', xnew, ynew, '-')
     >>> plt.show()
-    See Also
-    --------
-    :doc:`/tutorial/interpolate/extrapolation_examples`
-    """
-
     def __init__(self, x, y, kind='linear', axis=-1,
                  copy=True, bounds_error=None, fill_value=np.nan,
                  assume_sorted=False):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -281,6 +281,7 @@ class interp1d(_Interpolator1D):
     >>> ynew = f(xnew)   # use interpolation function returned by `interp1d`
     >>> plt.plot(x, y, 'o', xnew, ynew, '-')
     >>> plt.show()
+    """
     def __init__(self, x, y, kind='linear', axis=-1,
                  copy=True, bounds_error=None, fill_value=np.nan,
                  assume_sorted=False):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -281,6 +281,9 @@ class interp1d(_Interpolator1D):
     >>> ynew = f(xnew)   # use interpolation function returned by `interp1d`
     >>> plt.plot(x, y, 'o', xnew, ynew, '-')
     >>> plt.show()
+    See Also
+    --------
+    :doc:`/tutorial/interpolate/extrapolation_examples`
     """
 
     def __init__(self, x, y, kind='linear', axis=-1,

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -282,6 +282,7 @@ class interp1d(_Interpolator1D):
     >>> plt.plot(x, y, 'o', xnew, ynew, '-')
     >>> plt.show()
     """
+    
     def __init__(self, x, y, kind='linear', axis=-1,
                  copy=True, bounds_error=None, fill_value=np.nan,
                  assume_sorted=False):


### PR DESCRIPTION
<!--
 Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/scipy/issues/24694

#### What does this implement/fix?

Adds a reference link to the extrapolation tutorial in the `BSpline` and `PPoly` docstrings to improve discoverability.

This is a documentation-only change and does not modify any functionality.
#### Additional information
No additional change

#### AI Generation Disclosure

I used ChatGPT to assist with improving the wording of the documentation changes.

No AI tools were used to generate or modify functional code. All changes were reviewed and verified manually by me in accordance with SciPy’s AI policy.

