### PR TITLE
CI: cache CuPy kernels in GPU job

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -86,6 +86,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gpu-ccache
 
+      - name: Define default CuPy cache path
+        run: |
+          # We don't want to change the directory, and $HOME isn't available in
+          # `env:` above
+          echo "CUPY_CACHE_DIR=$HOME/.cupy/kernel_cache" >> $GITHUB_ENV
+
+      - name: Cache CuPy kernels
+        uses: cirruslabs/cache@v4 #caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
+        with:
+          path: ${{ env.CUPY_CACHE_DIR }}
+          # Same as for ccache above
+          key: ${{ runner.os }}-gpu-cupy-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gpu-cupy
+
       - name: run nvidia-smi
         run: nvidia-smi
 

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -123,8 +123,8 @@ jobs:
       - name: Run PyTorch GPU tests
         run: pixi run --skip-deps test-torch-cuda -v
 
-      - name: Run JAX GPU tests
-        run: pixi run --skip-deps test-jax-cuda -v
-
       - name: Run CuPy tests
         run: pixi run --skip-deps test-cupy -v
+
+      - name: Run JAX GPU tests
+        run: pixi run --skip-deps test-jax-cuda -v


### PR DESCRIPTION
This yields a major speedup, the CuPy tests now take about 2 minutes instead of 20 minutes. See gh-24685 for more context.

Cache size from a clean cache is 13 MB. See [this log](https://github.com/scipy/scipy/actions/runs/22641523288/job/65674461259) for a successful with-cache run. 

#### AI Generation Disclosure

Used Deepseek for some quick research to figure out why it's not possible to use `$HOME` in the `env:` block in GHA (it doesn't get evaluated, and `~` or other tries also don't work, and there's no built-in way to refer to that location). 