### PR TITLE
CI: CI/CD hardening

### DIFF
--- a/.github/workflows/circle_artifacts.yml
+++ b/.github/workflows/circle_artifacts.yml
@@ -3,7 +3,6 @@ name: Redirect circleci artifacts
 on: [status]
 
 permissions:
-  contents: read  # to fetch code (actions/checkout)
   statuses: write  # to report circleci status (scientific-python/circleci-artifacts-redirector-action)
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -97,6 +97,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,8 @@ on:
   schedule:
     - cron: '33 21 * * 3'
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
 
       - name: Cache pixi
-        uses: cirruslabs/cache@caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
+        uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4
         with:
           path: ${{ env.PIXI_CACHE_DIR }}
           # Cache hit if lock file did not change. If it did, still restore the cache,
@@ -77,7 +77,7 @@ jobs:
             ${{ runner.os }}-gpu-pixi
 
       - name: Setup compiler cache
-        uses: cirruslabs/cache@caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
+        uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4
         with:
           path: ${{ env.CCACHE_DIR }}
           # Make primary key unique by using `run_id`, this ensures the cache
@@ -93,7 +93,7 @@ jobs:
           echo "CUPY_CACHE_DIR=$HOME/.cupy/kernel_cache" >> $GITHUB_ENV
 
       - name: Cache CuPy kernels
-        uses: cirruslabs/cache@caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
+        uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4
         with:
           path: ${{ env.CUPY_CACHE_DIR }}
           # Same as for ccache above

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -65,7 +65,7 @@ jobs:
           submodules: recursive
 
       - name: Cache pixi
-        uses: cirruslabs/cache@v4 #caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
+        uses: cirruslabs/cache@caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
         with:
           path: ${{ env.PIXI_CACHE_DIR }}
           # Cache hit if lock file did not change. If it did, still restore the cache,
@@ -77,7 +77,7 @@ jobs:
             ${{ runner.os }}-gpu-pixi
 
       - name: Setup compiler cache
-        uses: cirruslabs/cache@v4 #caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
+        uses: cirruslabs/cache@caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
         with:
           path: ${{ env.CCACHE_DIR }}
           # Make primary key unique by using `run_id`, this ensures the cache
@@ -93,7 +93,7 @@ jobs:
           echo "CUPY_CACHE_DIR=$HOME/.cupy/kernel_cache" >> $GITHUB_ENV
 
       - name: Cache CuPy kernels
-        uses: cirruslabs/cache@v4 #caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
+        uses: cirruslabs/cache@caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
         with:
           path: ${{ env.CUPY_CACHE_DIR }}
           # Same as for ccache above

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -3,6 +3,8 @@ on:
   issues:
     types: [opened]
 
+permissions: {}
+
 jobs:
   label_issue:
     # Permissions needed for labelling issues automatically

--- a/.github/workflows/label-pr-on-close.yml
+++ b/.github/workflows/label-pr-on-close.yml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     types: [closed]
 
+permissions: {}
+
 jobs:
   label_pull_request:
     name: "Label PR on Close"

--- a/.github/workflows/label-pr-on-open.yml
+++ b/.github/workflows/label-pr-on-open.yml
@@ -3,6 +3,8 @@ on:
   pull_request_target:
     types: [opened]
 
+permissions: {}
+
 jobs:
   label_pull_request:
     # Permissions needed for labelling Pull Requests automatically

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -602,6 +602,12 @@ jobs:
         run: |
           sudo apt-get -y update
           wget https://apt.llvm.org/llvm.sh
+          expected_hash="d2ccd623e05645d96d85df09d9898a0ae7ba6ec917ae64731f0c1e49573b6426"
+          file_hash=$(sha256sum llvm.sh | cut -d ' ' -f 1)
+          if [ "$file_hash" != "$expected_hash" ]; then
+            echo "Checksum verification failed for llvm.sh. The downloaded file may be corrupted or tampered with."
+            exit 1
+          fi
           chmod u+x llvm.sh
           sudo ./llvm.sh 17
           sudo apt install -y libopenblas-dev liblapack-dev

--- a/.github/workflows/linux_intel_oneAPI.yml
+++ b/.github/workflows/linux_intel_oneAPI.yml
@@ -75,17 +75,17 @@ jobs:
         if: steps.cache-install.outputs.cache-hit != 'true'
         run: |
           printenv LINUX_CPPKIT_URL
-          bash tools/install_intel_oneAPI_linux.sh $LINUX_CPPKIT_URL
+          bash tools/install_intel_oneAPI_linux.sh $LINUX_CPPKIT_URL "" a585655669cee57a0965eba46d96b1081d9ab86e3e4b421505ebec651b41564b  # 2025.0.1.27
       - name: Install oneAPI Fortran kit
         if: steps.cache-install.outputs.cache-hit != 'true'
         run: |
           printenv LINUX_FORTRANKIT_URL
-          bash tools/install_intel_oneAPI_linux.sh $LINUX_FORTRANKIT_URL
+          bash tools/install_intel_oneAPI_linux.sh $LINUX_FORTRANKIT_URL "" ff9eb5a639c0fcc3d386f5798cc4259103842d783f34c08da27155431215ed0c  # 2025.0.1.27
       - name: Install oneAPI HPC kit
         if: steps.cache-install.outputs.cache-hit != 'true'
         run: |
           printenv LINUX_HPCKIT_URL
-          bash tools/install_intel_oneAPI_linux.sh $LINUX_HPCKIT_URL
+          bash tools/install_intel_oneAPI_linux.sh $LINUX_HPCKIT_URL "" 941a4d4ccc05cfb60f5edbe7c2c5e34197cce561c12d565cd8c6fefe6b752fb6  # 2025.0.1.47
 
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0

--- a/.github/workflows/windows_intel_oneAPI.yml
+++ b/.github/workflows/windows_intel_oneAPI.yml
@@ -68,12 +68,12 @@ jobs:
         if: steps.cache-install.outputs.cache-hit != 'true'
         run: |
           echo %WINDOWS_BASEKIT_URL%
-          tools/install_intel_oneAPI_windows.bat %WINDOWS_BASEKIT_URL%
+          tools/install_intel_oneAPI_windows.bat %WINDOWS_BASEKIT_URL% "" 491dbc593cbcf02570b2ccc1f31656e2aa6fd195bd3191e5d111b1dafb35a45c  # 2025.0.1.28
       - name: Install oneAPI HPC kit
         if: steps.cache-install.outputs.cache-hit != 'true'
         run: |
           echo %WINDOWS_HPC_URL%
-          tools/install_intel_oneAPI_windows.bat %WINDOWS_HPC_URL%
+          tools/install_intel_oneAPI_windows.bat %WINDOWS_HPC_URL% "" dfbf8487f6ee5b9c1bb2cad19f2ef8dd842529a533670ce21582d39c303bf979  # 2025.0.1.48
 
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0

--- a/tools/install_intel_oneAPI_linux.sh
+++ b/tools/install_intel_oneAPI_linux.sh
@@ -6,8 +6,20 @@
 
 URL=$1
 COMPONENTS=$2
+EXPECTED_SHA256=$3
 
 curl --output webimage.sh --url "$URL" --retry 5 --retry-delay 5
+
+if [ -n "$EXPECTED_SHA256" ]; then
+  file_hash=$(sha256sum webimage.sh | cut -d ' ' -f 1)
+  if [ "$file_hash" != "$EXPECTED_SHA256" ]; then
+    echo "Checksum verification failed for $URL"
+    echo "Expected: $EXPECTED_SHA256"
+    echo "Got:      $file_hash"
+    exit 1
+  fi
+fi
+
 chmod +x webimage.sh
 ./webimage.sh -x -f webimage_extracted --log extract.log
 rm -rf webimage.sh

--- a/tools/install_intel_oneAPI_windows.bat
+++ b/tools/install_intel_oneAPI_windows.bat
@@ -6,10 +6,23 @@ REM SPDX-License-Identifier: MIT
 
 set URL=%1
 set COMPONENTS=%2
-
+set EXPECTED_SHA256=%3
 
 :: download installer from intel
 curl.exe --output %TEMP%\webimage.exe --url %URL% --retry 5 --retry-delay 5
+
+:: verify checksum if provided
+if not "%EXPECTED_SHA256%"=="" (
+  for /f "tokens=1" %%h in ('certutil -hashfile %TEMP%\webimage.exe SHA256 ^| findstr /v "hash"') do set FILE_HASH=%%h
+  if /i not "%FILE_HASH%"=="%EXPECTED_SHA256%" (
+    echo Checksum verification failed for %URL%
+    echo Expected: %EXPECTED_SHA256%
+    echo Got:      %FILE_HASH%
+    del %TEMP%\webimage.exe
+    exit /b 1
+  )
+)
+
 start /b /wait %TEMP%\webimage.exe -s -x -f webimage_extracted
 del %TEMP%\webimage.exe
 if "%COMPONENTS%"=="" (


### PR DESCRIPTION
#### Reference issue
Inspired by recent CI attacks: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation

#### What does this implement/fix?
This hardens CI with a few changes:
* All actions are now pinned with SHA rather than version tags. Notably, `cirruslabs/cache@v4` does **not** point to `caa3ad0624c6c2acd8ba50ad452d1f44bba078bb` as the comment indicated, it points to [`1251dca905f872d6420b06b8d7f9e7fc85589448`](https://github.com/cirruslabs/cache/commit/1251dca905f872d6420b06b8d7f9e7fc85589448). Here's the diff: https://github.com/cirruslabs/cache/compare/caa3ad0624c6c2acd8ba50ad452d1f44bba078bb...1251dca905f872d6420b06b8d7f9e7fc85589448. This updates to point towards the actual v4 SHA.
* Add checksums to direct downloads that don't pass through package managers: `llvm.sh` in the `linux.yml` runner, and the Intel oneAPI installers.
* Default to no permissions for runners. Each job scopes this right now, so this is more of a protective gate than a change in behavior. Descoped read permissions for one job.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure

Claude was used to run the audit. All SHAs were manually verified.