### PR TITLE
BUG: signal.minimum_phase: correct calculation

### DIFF
--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -1394,15 +1394,15 @@ def minimum_phase(h,
         # lmin[n] = 2u[n] - d[n]
         # i.e., double the positive frequencies and zero out the negative ones;
         # Oppenheim+Shafer 3rd ed p991 eq13.42b and p1004 fig13.7
-        win = xp.zeros(n_fft)
-        win[0] = 1
+        # To facilitate ease and readability, start with ndarray then cast
+        win = xp.zeros(n_fft, dtype=h_temp.dtype)
+        win = xpx.at(win)[0].set(1)
         stop = n_fft // 2
-        win[1:stop] = 2
-        if n_fft % 2:
-            win[stop] = 1
+        win = xpx.at(win)[1:stop].set(2)
+        win = xpx.at(win)[stop].set(1 + (n_fft % 2))  # Nyquist freq: odd use 2, even use 1
         h_temp *= win
         h_temp = ifft(xp.exp(fft(h_temp)))
-        h_minimum = h_temp.real
+        h_minimum = xp.real(h_temp)
     n_out = (n_half + h.shape[0] % 2) if half else h.shape[0]
     return h_minimum[:n_out]
 

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -1394,7 +1394,6 @@ def minimum_phase(h,
         # lmin[n] = 2u[n] - d[n]
         # i.e., double the positive frequencies and zero out the negative ones;
         # Oppenheim+Shafer 3rd ed p991 eq13.42b and p1004 fig13.7
-        # To facilitate ease and readability, start with ndarray then cast
         win = xp.zeros(n_fft, dtype=h_temp.dtype)
         win = xpx.at(win)[0].set(1)
         stop = n_fft // 2

--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -1399,7 +1399,8 @@ def minimum_phase(h,
         win = xpx.at(win)[0].set(1)
         stop = n_fft // 2
         win = xpx.at(win)[1:stop].set(2)
-        win = xpx.at(win)[stop].set(1 + (n_fft % 2))  # Nyquist freq: odd use 2, even use 1
+        # Nyquist freq: odd use 2, even use 1
+        win = xpx.at(win)[stop].set(1 + (n_fft % 2))
         h_temp *= win
         h_temp = ifft(xp.exp(fft(h_temp)))
         h_minimum = xp.real(h_temp)

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -10,7 +10,7 @@ from scipy._lib._array_api import (
     xp_assert_close, xp_assert_equal, assert_almost_equal, assert_array_almost_equal,
     array_namespace, xp_default_dtype, make_xp_test_case, _xp_copy_to_numpy
 )
-from scipy.fft import fft, fft2
+from scipy.fft import fft, fft2, rfft
 from scipy.signal import (kaiser_beta, kaiser_atten, kaiserord,
     firwin, firwin2, freqz, remez, firls, minimum_phase, convolve2d, firwin_2d
 )
@@ -761,6 +761,21 @@ class TestMinimumPhase:
         k = xp.asarray(k, dtype=xp.float64)
         m = minimum_phase(h, 'hilbert', n_fft=2**19)
         xp_assert_close(m, k, rtol=2e-3)
+
+    @pytest.mark.parametrize("N", (963, 964))
+    @pytest.mark.parametrize("dtype", ("float32", "float64"))
+    def test_nyquist(self, N, dtype, xp):
+        fc = xp.asarray(10)
+        fs = 100
+        h = firwin(N, fc, window="hann", pass_zero="lowpass", scale=False, fs=fs)
+        xp_dtype = getattr(xp, dtype)
+        h = xp.astype(h, xp_dtype)
+        h_min_sig = minimum_phase(h, method="homomorphic", n_fft=N, half=False)
+        H_mag = xp.abs(rfft(h, N))
+        H_min_mag = xp.abs(rfft(h_min_sig, N))
+        error = H_mag - H_min_mag
+        atol = dict(float32=1e-5, float64=1e-13)[dtype]
+        xp_assert_close(error, xp.zeros_like(error), atol=atol)
 
 
 class Testfirwin_2d:

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -762,6 +762,7 @@ class TestMinimumPhase:
         m = minimum_phase(h, 'hilbert', n_fft=2**19)
         xp_assert_close(m, k, rtol=2e-3)
 
+    @xfail_xp_backends("cupy", reason="cupy/cupy#9795")
     @pytest.mark.parametrize("N", (963, 964))
     @pytest.mark.parametrize("dtype", ("float32", "float64"))
     def test_nyquist(self, N, dtype, xp):


### PR DESCRIPTION
Closes #22752

Steps: eliminated `Torch` from the example in #22752, verified the ripple (more easily seen with `float32`), distilled to test, added test, test failed (TDD, hooray!), added a version of the fixes suggested in #22752, tests passed. `atol`s chosen empirically on my hardware but are reasonable, might need to be tweaked for CIs, we'll see.

My first PR in a long time -- first one after all the `xp` business ( :scream: ) so entirely possible I did something wrong or could do something better there!