### PR TITLE
MAINT: linalg.solve: reenable 'overwrite_b' for solve(..., assume_a="banded")

### DIFF
--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1303,13 +1303,14 @@ bandwidth_strided(T* data, npy_intp n, npy_intp m, npy_intp s1, npy_intp s2, npy
 
 template<typename T>
 void
-detect_bandwidths(T* data, npy_intp ndim, npy_intp outer_size, npy_intp *shape, npy_intp *strides, npy_intp *kl, npy_intp *ku, npy_intp *kl_max, npy_intp *ku_max) {
+detect_bandwidths(T* data, npy_intp ndim, npy_intp outer_size, npy_intp *shape, npy_intp *strides, npy_intp *kl, npy_intp *ku, npy_intp *ldab_max) {
     for (npy_intp idx = 0; idx < outer_size; idx++) {
         T* slice_ptr = compute_slice_ptr(idx, data, ndim, shape, strides);
 
         bandwidth_strided(slice_ptr, shape[ndim-2], shape[ndim-1], strides[ndim-2], strides[ndim-1], &kl[idx], &ku[idx]);
-        if (kl[idx] > *kl_max) {*kl_max = kl[idx];}
-        if (ku[idx] > *ku_max) {*ku_max = ku[idx];}
+        if (2 * kl[idx] + ku[idx] + 1 > *ldab_max) {
+            *ldab_max = 2 * kl[idx] + ku[idx] + 1;
+        }
     }
 }
 

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -280,7 +280,7 @@ inline void solve_slice_diagonal(
 // cluttering the main loop in `_solve` by branching to this function early.
 template<typename T>
 int
-_solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, char trans, int overwrite_a, SliceStatus slice_status, SliceStatusVec &vec_status)
+_solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, char trans, int overwrite_a, int overwrite_b, SliceStatus slice_status, SliceStatusVec &vec_status)
 {
     using real_type = typename type_traits<T>::real_type;
 
@@ -335,8 +335,7 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
     // maximal `kl` and `ku` to find the minimal size the array will need to
     // have. To avoid having to call `bandwidth` twice per slice, the results
     // are stored in these arrays.
-    npy_intp kl_max = 0;
-    npy_intp ku_max = 0;
+    npy_intp ldab_max = 0;
     ks = (npy_intp *)malloc(2 * outer_size * sizeof(npy_intp));
 
     if (ks == NULL) {
@@ -348,9 +347,22 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
 
     npy_intp *kls = &ks[0]; // Lower bandwidths
     npy_intp *kus = &ks[outer_size]; // Upper bandwidths
-    detect_bandwidths(Am_data, ndim, outer_size, shape, strides, kls, kus, &kl_max, &ku_max);
+    detect_bandwidths(Am_data, ndim, outer_size, shape, strides, kls, kus, &ldab_max);
 
-    buffer = (T *)malloc((n * nrhs + 3 * n + (2 * kl_max + ku_max + 1) * n) * sizeof(T));
+    /*
+     * Chop up buffer in parts:
+     *
+     *   ldab_max * n       3 * n       b_data_size
+     * |---------------|-------------|---------------|
+     * ^               ^             ^
+     * ab              work          b_data
+     *
+     * - `ab` is a buffer holding the "padded" banded form of matrix `a`
+     * - `work` is needed for `gbcon` (fixed size)
+     * - `b_data` is a buffer for the rhs of the system, not needed if `overwrite_b` is set (size = 0 then)
+     */
+    npy_intp b_data_size = overwrite_b ? 0 : n * nrhs;
+    buffer = (T *)malloc((ldab_max * n + 3 * n + b_data_size) * sizeof(T));
 
     if (buffer == NULL) {
         free(ipiv);
@@ -361,22 +373,31 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
     }
 
     // Chop up buffer
-    T* b_data = &buffer[0];
-    T* work = &buffer[n * nrhs]; // for `gbcon` call
-    T *ab = &buffer[n * nrhs + 3 * n];
+    T *ab = &buffer[0];
+    T *work = &buffer[ldab_max * n];
+
+    T *b_data = NULL;
+    if (!overwrite_b) {
+        b_data = &buffer[ldab_max * n + 3 * n];
+    } else {
+        b_data = bm_data;
+    }
 
     // Main loop traversal, taken from `_solve`
     for (npy_intp idx = 0; idx < outer_size; idx++) {
 
         T* slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
-        T* slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
 
         // Directly take into banded storage
         npy_intp ldab = 2 * kls[idx] + kus[idx] + 1;
         to_banded(slice_ptr, n, kls[idx], kus[idx], ldab, ab, strides[ndim-2], strides[ndim-1]);
 
-        // Copy slice of b
-        copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+        if (!overwrite_b) {
+            T* slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim, shape_b, strides_b);
+            copy_slice_F(b_data, slice_ptr_b, n, nrhs, strides_b[ndim-2], strides_b[ndim-1]);
+        }
+        // NB. `overwrite_b` is only set when the input is 2D F-ordered, so no copy needed then.
+        // A generalization to ndim > 2 will also require computing the pointer here.
 
         // structure is known to be banded
         init_status(slice_status, idx, St::BANDED);
@@ -384,8 +405,10 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
 
         if (_detect_problems(slice_status, vec_status) != 0) { goto free_exit_banded; }
 
-        // Put result in C-order in return buffer
-        copy_slice_F_to_C(&ret_data[idx * n * nrhs], b_data, n, nrhs);
+        if (!overwrite_b) {
+            // Put result in C-order in return buffer
+            copy_slice_F_to_C(&ret_data[idx * n * nrhs], b_data, n, nrhs);
+        } // If `overwrite_b` is true the result is already set.
     }
 
 free_exit_banded:
@@ -413,7 +436,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
 
     // branch early for `assume_a = banded`
     if (structure == St::BANDED) {
-        return _solve_assume_banded(ap_Am, ap_b, ret_data, trans, overwrite_a, slice_status, vec_status);
+        return _solve_assume_banded(ap_Am, ap_b, ret_data, trans, overwrite_a, overwrite_b, slice_status, vec_status);
     }
 
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -821,7 +821,7 @@ class TestSolve:
     @pytest.mark.parametrize('b', [0, 1, [0, 1]])
     def test_singular_scalar(self, b):
         # regression test for gh-24355: scalar a=0 is singular
-        # thus should raise the same error 
+        # thus should raise the same error
 
         with pytest.raises(LinAlgError):
             a = np.zeros((1, 1))
@@ -1179,9 +1179,9 @@ class TestSolve:
 
         assert np.shares_memory(x, b) == b_inplace
 
+        # for `assume_a="banded"`, the `overwrite_a` argument is ignored for now
         assert (b == b_ref).all() != b_inplace
-        if assume_a is None: # `overwrite_a` unused for `assume_a="banded"`
-            assert (a == a_ref).all() != a_inplace
+        assert (a == a_ref).all() != a_inplace or assume_a == "banded"
 
     def test_posdef_not_posdef(self):
         # the `b` matrix is invertible but not positive definite

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -1147,9 +1147,10 @@ class TestSolve:
     @pytest.mark.parametrize('b_order', ['C', 'F'])
     @pytest.mark.parametrize('b_ndim', [1, 2])    # XXX ndim > 2
     @pytest.mark.parametrize('transposed', [True, False])
+    @pytest.mark.parametrize('assume_a', [None, "banded"]) # separate branches in C code
     def test_overwrite_args(
         self, overwrite_kw, overwrite_b_kw, a_dtype, a_order,
-        b_dtype, b_order, b_ndim, transposed
+        b_dtype, b_order, b_ndim, transposed, assume_a
     ):
         n = 3
         a = np.arange(1, n**2 + 1).reshape(n, n) + np.eye(n)
@@ -1164,7 +1165,8 @@ class TestSolve:
         b_ref = b.copy()
 
         # solve and check that the solution is correct for all parameters
-        x = solve(a, b, **overwrite_kw, **overwrite_b_kw, transposed=transposed)
+        x = solve(a, b, **overwrite_kw, **overwrite_b_kw,
+                transposed=transposed, assume_a=assume_a)
         a_or_aT = a_ref.T if transposed else a_ref
         assert_allclose(a_or_aT @ x, b_ref, atol=1e-14)
 
@@ -1178,7 +1180,8 @@ class TestSolve:
         assert np.shares_memory(x, b) == b_inplace
 
         assert (b == b_ref).all() != b_inplace
-        assert (a == a_ref).all() != a_inplace
+        if assume_a is None: # `overwrite_a` unused for `assume_a="banded"`
+            assert (a == a_ref).all() != a_inplace
 
     def test_posdef_not_posdef(self):
         # the `b` matrix is invertible but not positive definite


### PR DESCRIPTION
#### Reference issue
Towards #24645

#### What does this implement/fix?
Reenable the `overwrite_b` kwarg for the case where `assume_a="banded"`. Since this is a separate branch in the lower-level implementation this was not covered in #24442.

#### Additional information
As mentioned before in https://github.com/scipy/scipy/pull/24123#issuecomment-3822262432 it is somewhat tricky to reenable `overwrite_a` in this case due to the fact that the required bufferspace could grow larger than the size of `a` itself, but this can be fixed as per the suggestion in that same comment.

EDIT: not directly related to this PR, but should the thing w.r.t. the `writeable` flag of the returned array if `overwrite_b` discovered in #24396 also be handled here?

#### AI Generation Disclosure
No AI
