### PR TITLE
ENH: stats.cramervonmises: add MArray support

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -666,20 +666,15 @@ def _masked_elementwise(f, *, args, kwargs=None, xp):
     # Could/should combine with `xpx.lazy_apply`
     kwargs = {} if kwargs is None else kwargs
 
-    arrays = list(arr for arr in (*args, *kwargs.values()) if hasattr(arr, 'mask'))
-    if not is_marray(xp) or len(arrays) == 0:
+    if not is_marray(xp):
         return f(*args, **kwargs)
-    _xp = arrays[0]._xp
 
     arg_data = (getattr(arg, 'data', arg) for arg in args)
     kwarg_data = (getattr(val, 'data', val) for val in kwargs.values())
     res = f(*arg_data, **dict(zip(kwarg_data, kwargs.keys())))
 
-    arg_masks = (arg.mask for arg in args if hasattr(arg, 'mask'))
-    kwarg_masks = (kwarg.mask for kwarg in kwargs.values() if hasattr(kwarg, 'mask'))
-    mask = functools.reduce(_xp.logical_or, (*arg_masks, *kwarg_masks))
-
-    return xp.asarray(res, mask=mask)
+    masks = (arr.mask for arr in (*args, *kwargs.values()) if hasattr(arr, 'mask'))
+    return xp.asarray(res, mask=functools.reduce(operator.or_, masks))
 
 
 ### End MArray Helpers ###

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -609,7 +609,6 @@ def xp_default_dtype(xp):
         return xp.float64
 
 
-### MArray Helpers ###
 def xp_result_device(*args):
     """Return the device of an array in `args`, for the purpose of
     input-output device propagation.
@@ -631,6 +630,9 @@ def concat_1d(xp: ModuleType | None, *arrays: Iterable[ArrayLike]) -> Array:
     """
     arys = [xpx.atleast_nd(xp.asarray(a), ndim=1, xp=xp) for a in arrays]
     return xp.concat(arys)
+
+
+### MArray Helpers ###
 
 
 def is_marray(xp):
@@ -655,6 +657,30 @@ def _share_masks(*args, xp):
         mask = functools.reduce(operator.or_, (arg.mask for arg in args))
         args = [xp.asarray(arg.data, mask=mask) for arg in args]
     return args[0] if len(args) == 1 else args
+
+
+def _masked_elementwise(f, *, args, kwargs=None, xp):
+    # Unmask array arguments, evaluate function, and apply result mask to output
+    # Assumes that *when `xp` is an MArray namespace*, MArrays are the only objects
+    # in `args` and `kwargs` with `data` and `mask` attributes.
+    # Could/should combine with `xpx.lazy_apply`
+    kwargs = {} if kwargs is None else kwargs
+
+    arrays = list(arr for arr in (*args, *kwargs.values()) if hasattr(arr, 'mask'))
+    if not is_marray(xp) or len(arrays) == 0:
+        return f(*args, **kwargs)
+    _xp = arrays[0]._xp
+
+    arg_data = (getattr(arg, 'data', arg) for arg in args)
+    kwarg_data = (getattr(val, 'data', val) for val in kwargs.values())
+    res = f(*arg_data, **dict(zip(kwarg_data, kwargs.keys())))
+
+    arg_masks = (arg.mask for arg in args if hasattr(arg, 'mask'))
+    kwarg_masks = (kwarg.mask for kwarg in kwargs.values() if hasattr(kwarg, 'mask'))
+    mask = functools.reduce(_xp.logical_or, (*arg_masks, *kwarg_masks))
+
+    return xp.asarray(res, mask=mask)
+
 
 ### End MArray Helpers ###
 

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -659,7 +659,7 @@ def _share_masks(*args, xp):
     return args[0] if len(args) == 1 else args
 
 
-def _masked_elementwise(f, *, args, kwargs=None, xp):
+def _masked_apply(f, *, args, kwargs=None, xp):
     # Unmask array arguments, evaluate function, and apply result mask to outputs.
     # Assumes that when `xp` is an MArray namespace, there is at least one MArray
     # in `args`/`kwargs` and MArrays are the only objects in `args`/`kwargs` with

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -660,10 +660,10 @@ def _share_masks(*args, xp):
 
 
 def _masked_elementwise(f, *, args, kwargs=None, xp):
-    # Unmask array arguments, evaluate function, and apply result mask to output
-    # Assumes that *when `xp` is an MArray namespace*, MArrays are the only objects
-    # in `args` and `kwargs` with `data` and `mask` attributes.
-    # Could/should combine with `xpx.lazy_apply`
+    # Unmask array arguments, evaluate function, and apply result mask to outputs.
+    # Assumes that when `xp` is an MArray namespace, there is at least one MArray
+    # in `args`/`kwargs` and MArrays are the only objects in `args`/`kwargs` with
+    # `data` and `mask` attributes. Could/should combine with `xpx.lazy_apply`.
     kwargs = {} if kwargs is None else kwargs
 
     if not is_marray(xp):
@@ -674,7 +674,9 @@ def _masked_elementwise(f, *, args, kwargs=None, xp):
     res = f(*arg_data, **dict(zip(kwarg_data, kwargs.keys())))
 
     masks = (arr.mask for arr in (*args, *kwargs.values()) if hasattr(arr, 'mask'))
-    return xp.asarray(res, mask=functools.reduce(operator.or_, masks))
+    mask = functools.reduce(operator.or_, masks)
+    return ((xp.asarray(out, mask=mask) for out in res) if isinstance(res, tuple)
+            else xp.asarray(res, mask=mask))
 
 
 ### End MArray Helpers ###

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import special
 from ._axis_nan_policy import _axis_nan_policy_factory
 from scipy._lib._array_api import (array_namespace, xp_promote, xp_device,
-                                   is_marray, _share_masks, xp_capabilities)
+                                   _masked_elementwise, _share_masks, xp_capabilities)
 
 __all__ = ['entropy', 'differential_entropy']
 
@@ -153,11 +153,7 @@ def entropy(pk: np.typing.ArrayLike,
     if qk is None:
         vec = special.entr(pk)
     else:
-        if is_marray(xp):  # compensate for mdhaber/marray#97
-            vec = special.rel_entr(pk.data, qk.data)  # type: ignore[union-attr]
-            vec = xp.asarray(vec, mask=pk.mask)  #  type: ignore[union-attr]
-        else:
-            vec = special.rel_entr(pk, qk)
+        vec = _masked_elementwise(special.rel_entr, args=(pk, qk), xp=xp)
 
     S = xp.sum(vec, axis=axis)
     if base is not None:

--- a/scipy/stats/_entropy.py
+++ b/scipy/stats/_entropy.py
@@ -9,7 +9,7 @@ import numpy as np
 from scipy import special
 from ._axis_nan_policy import _axis_nan_policy_factory
 from scipy._lib._array_api import (array_namespace, xp_promote, xp_device,
-                                   _masked_elementwise, _share_masks, xp_capabilities)
+                                   _masked_apply, _share_masks, xp_capabilities)
 
 __all__ = ['entropy', 'differential_entropy']
 
@@ -153,7 +153,7 @@ def entropy(pk: np.typing.ArrayLike,
     if qk is None:
         vec = special.entr(pk)
     else:
-        vec = _masked_elementwise(special.rel_entr, args=(pk, qk), xp=xp)
+        vec = _masked_apply(special.rel_entr, args=(pk, qk), xp=xp)
 
     S = xp.sum(vec, axis=axis)
     if base is not None:

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -12,7 +12,7 @@ from ._continuous_distns import norm
 from scipy._lib._array_api import (xp_capabilities, array_namespace, xp_size,
                                    xp_promote, xp_result_type, xp_copy, is_numpy,
                                    is_lazy_array, _count_nonmasked, is_marray,
-                                   _masked_elementwise)
+                                   _masked_apply)
 import scipy._external.array_api_extra as xpx
 from scipy.special import gamma, kv, gammaln
 from scipy.fft import ifft
@@ -660,14 +660,14 @@ def cramervonmises(rvs, cdf, args=(), *, axis=0):
 
     rvs = xp_promote(rvs, force_floating=True, xp=xp)
     vals = xp.sort(rvs, axis=-1)
-    cdfvals = _masked_elementwise(cdf, args=(vals, *args), xp=xp)
+    cdfvals = _masked_apply(cdf, args=(vals, *args), xp=xp)
     n_count = xp.asarray(_count_nonmasked(rvs, axis=-1, xp=xp), dtype=rvs.dtype)
 
     u = (2*xp.arange(1, n_length+1, dtype=rvs.dtype) - 1)/(2*n_count[..., xp.newaxis])
     w = 1/(12*n_count) + xp.sum((u - cdfvals)**2, axis=-1)
 
     # avoid small negative values that can occur due to the approximation
-    p = xp.clip(1. - _masked_elementwise(_cdf_cvm, args=(w, n_count), xp=xp), 0., None)
+    p = xp.clip(1. - _masked_apply(_cdf_cvm, args=(w, n_count), xp=xp), 0., None)
 
     return CramerVonMisesResult(statistic=w, pvalue=p)
 

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -11,7 +11,8 @@ from ._common import ConfidenceInterval
 from ._continuous_distns import norm
 from scipy._lib._array_api import (xp_capabilities, array_namespace, xp_size,
                                    xp_promote, xp_result_type, xp_copy, is_numpy,
-                                   is_lazy_array, _count_nonmasked, is_marray)
+                                   is_lazy_array, _count_nonmasked, is_marray,
+                                   _masked_elementwise)
 import scipy._external.array_api_extra as xpx
 from scipy.special import gamma, kv, gammaln
 from scipy.fft import ifft
@@ -653,20 +654,20 @@ def cramervonmises(rvs, cdf, args=(), *, axis=0):
         message = "`cdf` must be a callable if `rvs` is a non-NumPy array."
         raise ValueError(message)
 
-    n = rvs.shape[-1]
-    if n <= 1:  # only needed for `test_axis_nan_policy.py`; not user-facing
+    n_length = rvs.shape[-1]
+    if n_length <= 1:  # only needed for `test_axis_nan_policy.py`; not user-facing
         raise ValueError('The sample must contain at least two observations.')
 
     rvs = xp_promote(rvs, force_floating=True, xp=xp)
-    n = float(n)
     vals = xp.sort(rvs, axis=-1)
-    cdfvals = cdf(vals, *args)
+    cdfvals = _masked_elementwise(cdf, args=(vals, *args), xp=xp)
+    n_count = xp.asarray(_count_nonmasked(rvs, axis=-1, xp=xp), dtype=rvs.dtype)
 
-    u = (2*xp.arange(1, n+1, dtype=rvs.dtype) - 1)/(2*n)
-    w = 1/(12*n) + xp.sum((u - cdfvals)**2, axis=-1)
+    u = (2*xp.arange(1, n_length+1, dtype=rvs.dtype) - 1)/(2*n_count[..., xp.newaxis])
+    w = 1/(12*n_count) + xp.sum((u - cdfvals)**2, axis=-1)
 
     # avoid small negative values that can occur due to the approximation
-    p = xp.clip(1. - _cdf_cvm(w, n), 0., None)
+    p = xp.clip(1. - _masked_elementwise(_cdf_cvm, args=(w, n_count), xp=xp), 0., None)
 
     return CramerVonMisesResult(statistic=w, pvalue=p)
 

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -81,7 +81,7 @@ from scipy._lib._array_api import (
     xp_ravel,
     _count_nonmasked,
     _share_masks,
-    _masked_elementwise,
+    _masked_apply,
     xp_swapaxes,
     xp_device,
 )
@@ -7619,14 +7619,14 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     x = xp.sort(x, axis=-1)
     x = xp_promote(x, force_floating=True, xp=xp)
     N = _count_nonmasked(x, axis=-1, xp=xp)
-    cdfvals = _masked_elementwise(cdf, args=(x, *args), xp=xp)
+    cdfvals = _masked_apply(cdf, args=(x, *args), xp=xp)
 
     ones = xp.ones(x.shape[:-1], dtype=xp.int8)
     ones = ones[()] if ones.ndim == 0 else ones
 
     if alternative == 'greater':
         Dplus, d_location = _compute_d(cdfvals, x, +1)
-        pvalue = _masked_elementwise(distributions.ksone.sf, args=(Dplus, N), xp=xp)
+        pvalue = _masked_apply(distributions.ksone.sf, args=(Dplus, N), xp=xp)
         pvalue = xp.asarray(pvalue, dtype=x.dtype)
         pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
         Dplus = xp.asarray(Dplus) if is_marray(xp) else Dplus
@@ -7636,7 +7636,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
 
     if alternative == 'less':
         Dminus, d_location = _compute_d(cdfvals, x, -1)
-        pvalue = _masked_elementwise(distributions.ksone.sf, args=(Dminus, N), xp=xp)
+        pvalue = _masked_apply(distributions.ksone.sf, args=(Dminus, N), xp=xp)
         pvalue = xp.asarray(pvalue, dtype=x.dtype)
         pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
         Dminus = xp.asarray(Dminus) if is_marray(xp) else Dminus
@@ -7657,12 +7657,12 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     if mode == 'auto':  # Always select exact
         mode = 'exact'
     if mode == 'exact':
-        prob = _masked_elementwise(distributions.kstwo.sf, args=(D, N), xp=xp)
+        prob = _masked_apply(distributions.kstwo.sf, args=(D, N), xp=xp)
     elif mode == 'asymp':
-        prob = _masked_elementwise(distributions.kstwobign.sf, args=(D * N**0.5), xp=xp)
+        prob = _masked_apply(distributions.kstwobign.sf, args=(D * N ** 0.5), xp=xp)
     else:
         # mode == 'approx'
-        prob = 2 * _masked_elementwise(distributions.ksone.sf, args=(D, N), xp=xp)
+        prob = 2 * _masked_apply(distributions.ksone.sf, args=(D, N), xp=xp)
     prob = xp.clip(xp.asarray(prob, dtype=x.dtype), 0., 1.)
     return KstestResult(D, prob,
                         statistic_location=d_location,

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -81,6 +81,7 @@ from scipy._lib._array_api import (
     xp_ravel,
     _count_nonmasked,
     _share_masks,
+    _masked_elementwise,
     xp_swapaxes,
     xp_device,
 )
@@ -7452,7 +7453,6 @@ def _compute_d(cdfvals, x, sign, xp=None):
     amax = xp.argmax(D, axis=-1, keepdims=True)
     loc_max = xp.squeeze(xp.take_along_axis(x, amax, axis=-1), axis=-1)
     D = xp.squeeze(xp.take_along_axis(D, amax, axis=-1), axis=-1)
-    D = D.data if is_marray(xp) else D
     return D[()] if D.ndim == 0 else D, loc_max[()] if loc_max.ndim == 0 else loc_max
 
 
@@ -7619,21 +7619,15 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     x = xp.sort(x, axis=-1)
     x = xp_promote(x, force_floating=True, xp=xp)
     N = _count_nonmasked(x, axis=-1, xp=xp)
-    # Here and below, we currently have to do some unmasking/re-masking of masked arrays
-    # because stats distributions don't work with MArrays natively. The dance for
-    # CDF evaluation below will probably have to stay if we want to continue to accept
-    # distribution cdf methods, but the rest of the conversions can be removed when
-    # the null distribution functions are replaced with scipy.special versions that
-    # handle the unmasking/re-masking.
-    N = N.data if is_marray(xp) else N
-    cdfvals = cdf(x.data if is_marray(xp) else x, *args)
-    cdfvals = xp.asarray(cdfvals, mask=x.mask) if is_marray(xp) else cdfvals
+    cdfvals = _masked_elementwise(cdf, args=(x, *args), xp=xp)
+
     ones = xp.ones(x.shape[:-1], dtype=xp.int8)
     ones = ones[()] if ones.ndim == 0 else ones
 
     if alternative == 'greater':
         Dplus, d_location = _compute_d(cdfvals, x, +1)
-        pvalue = xp.asarray(distributions.ksone.sf(Dplus, N), dtype=x.dtype)
+        pvalue = _masked_elementwise(distributions.ksone.sf, args=(Dplus, N), xp=xp)
+        pvalue = xp.asarray(pvalue, dtype=x.dtype)
         pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
         Dplus = xp.asarray(Dplus) if is_marray(xp) else Dplus
         return KstestResult(Dplus, pvalue,
@@ -7642,7 +7636,8 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
 
     if alternative == 'less':
         Dminus, d_location = _compute_d(cdfvals, x, -1)
-        pvalue = xp.asarray(distributions.ksone.sf(Dminus, N), dtype=x.dtype)
+        pvalue = _masked_elementwise(distributions.ksone.sf, args=(Dminus, N), xp=xp)
+        pvalue = xp.asarray(pvalue, dtype=x.dtype)
         pvalue = pvalue[()] if pvalue.ndim == 0 else pvalue
         Dminus = xp.asarray(Dminus) if is_marray(xp) else Dminus
         return KstestResult(Dminus, pvalue,
@@ -7659,18 +7654,16 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     if D.ndim == 0:
         D, d_location, d_sign = D[()], d_location[()], d_sign[()]
 
-    D = D.data if is_marray(xp) else D
     if mode == 'auto':  # Always select exact
         mode = 'exact'
     if mode == 'exact':
-        prob = distributions.kstwo.sf(D, N)
+        prob = _masked_elementwise(distributions.kstwo.sf, args=(D, N), xp=xp)
     elif mode == 'asymp':
-        prob = distributions.kstwobign.sf(D * N**0.5)
+        prob = _masked_elementwise(distributions.kstwobign.sf, args=(D * N**0.5), xp=xp)
     else:
         # mode == 'approx'
-        prob = 2 * distributions.ksone.sf(D, N)
+        prob = 2 * _masked_elementwise(distributions.ksone.sf, args=(D, N), xp=xp)
     prob = xp.clip(xp.asarray(prob, dtype=x.dtype), 0., 1.)
-    D = xp.asarray(D) if is_marray(xp) else D
     return KstestResult(D, prob,
                         statistic_location=d_location,
                         statistic_sign=d_sign)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7659,7 +7659,7 @@ def ks_1samp(x, cdf, args=(), alternative='two-sided', method='auto', *, axis=0)
     if mode == 'exact':
         prob = _masked_apply(distributions.kstwo.sf, args=(D, N), xp=xp)
     elif mode == 'asymp':
-        prob = _masked_apply(distributions.kstwobign.sf, args=(D * N ** 0.5), xp=xp)
+        prob = _masked_apply(distributions.kstwobign.sf, args=(D * N**0.5,), xp=xp)
     else:
         # mode == 'approx'
         prob = 2 * _masked_apply(distributions.ksone.sf, args=(D, N), xp=xp)

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -336,6 +336,7 @@ def test_directional_stats(xp, axis):
 @pytest.mark.parametrize('fun, kwargs', [
     make_xp_pytest_param(stats.wilcoxon,
                          {'method': 'asymptotic', 'zero_method': 'zsplit'}),
+    make_xp_pytest_param(stats.cramervonmises, {'cdf': stats.norm.cdf}),
 ])
 @pytest.mark.parametrize('axis', [0, 1, None])
 def test_one_sample_tests(fun, kwargs, axis, xp):


### PR DESCRIPTION
#### Reference issue
Toward gh-20544
Toward gh-22194 

#### What does this implement/fix?
Adds support for MArrays to `stats.cramervonmises`.

Also uses new MArray helper, `_masked_apply`, to simplify `stats.entropy` and `stats.ks_1samp` MArray treatment.

#### Additional information
The functionality of `_masked_apply` would be nice to add to `xpx.lazy_apply`.

#### AI Generation Disclosure
No AI