### PR TITLE
WIP: stats.quantile: add Maritz-Jarrett standard error?

### DIFF
--- a/scipy/stats/_quantile.py
+++ b/scipy/stats/_quantile.py
@@ -1,6 +1,7 @@
 import math
 import numpy as np
 from scipy.special import betainc
+from scipy._lib._util import _RichResult
 from scipy._lib._array_api import (
     xp_capabilities,
     xp_ravel,
@@ -15,7 +16,7 @@ import scipy._external.array_api_extra as xpx
 from scipy.stats._axis_nan_policy import _broadcast_arrays, _contains_nan
 
 
-def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
+def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights, rich_result):
     xp = array_namespace(x, p, weights)
 
     if not xp.isdtype(xp.asarray(x).dtype, ('integral', 'real floating')):
@@ -59,6 +60,15 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
                   'round_nearest', 'round_inward', 'round_outward'}
     if weights is not None and method in no_weights:
         message = f"`method='{method}'` does not support `weights`."
+        raise ValueError(message)
+
+    rich_result = False if rich_result is None else rich_result
+    if rich_result not in {True, False}:
+        message = "If specified, `rich_result` must be True or False"
+        raise ValueError(message)
+
+    if rich_result and method in no_weights:
+        message = f"`method='{method}'` is incompatible with `rich_result=True`."
         raise ValueError(message)
 
     contains_nans = _contains_nan(x, nan_policy, xp_omit_okay=True, xp=xp)
@@ -134,12 +144,12 @@ def _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights):
     p = xp.where(p_mask, 0.5, p)
 
     return (y, p, method, axis, nan_policy, keepdims,
-            n, axis_none, ndim, p_mask, weights, xp)
+            n, axis_none, ndim, p_mask, weights, rich_result, xp)
 
 
 @xp_capabilities(skip_backends=[("dask.array", "No take_along_axis yet.")])
 def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=None,
-             weights=None):
+             weights=None, rich_result=None):
     """
     Compute the p-th quantile of the data along the specified axis.
 
@@ -221,6 +231,13 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
         numbers are accepted, but may not have valid statistical interpretations.
         Not compatible with ``method='harrell-davis'`` or those that begin with
         ``'round_'``.
+
+    rich_result : bool, optional
+        By default, `quantile` returns a point estimate as a scalar or array.
+        When True, `quantile` will return a result object including attributes
+        ``estimate``, the point estimate, and ``standard_error``, the Maritz-Jarrett
+        estimate of the standard error. Not compatible with ``method='harrell-davis'``
+        or those that begin with ``'round_'``.
 
     Returns
     -------
@@ -319,6 +336,19 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
     These methods are also useful for trimming data: removing ``p*n`` of the most
     extreme observations. See :ref:`outliers` for example applications.
 
+    When ``rich_result=True`` and `method` is one of the options corresponding with
+    1-9 from H&F [1]_, attribute ``standard_error`` of the returned object is a
+    Maritz-Jarrett [3]_ estimate of the standard error. Specifically, we follow
+    Wilcox [4]_ Section 3.5.3 to compute the standard error ``s`` corresponding with
+    order statistics at indices ``j`` and ``j + 1``. The standard error of the quantile
+    estimate is taken as the weighted sum ``(1-g)*s[j] + g*s[j+1]`` (as defined above),
+    which assumes worst-case correlation between the order statistics. Note that we
+    have generalized from Wilcox's discrete quantile estimate to any of those from
+    [1]_, and we correct for the difference between Wilcox's parameterization of the
+    beta distribution and the standard parameterization when computing the beta CDF,
+    which [4]_ neglects. The theory assumes that the underlying distribution is
+    continuous; no corrections are made for ties in the sample.
+
     Examples
     --------
     >>> import numpy as np
@@ -365,18 +395,23 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
     .. [2] Harrell, Frank E., and C. E. Davis.
        "A new distribution-free quantile estimator."
        Biometrika 69.3 (1982): 635-640.
-
+    .. [3] Maritz, J. S., and R. G. Jarrett.
+       "A note on estimating the variance of the sample median."
+       Journal of the American Statistical Association 73.361 (1978): 194-196.
+    .. [4] Wilcox, Rand R.
+       "Introduction to robust estimation and hypothesis testing".
+       Academic Press, 2012.
     """
     # Input validation / standardization
 
-    temp = _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights)
+    temp = _quantile_iv(x, p, method, axis, nan_policy, keepdims, weights, rich_result)
     (y, p, method, axis, nan_policy, keepdims,
-     n, axis_none, ndim, p_mask, weights, xp) = temp
+     n, axis_none, ndim, p_mask, weights, rich_result, xp) = temp
 
     if method in {'inverted_cdf', 'averaged_inverted_cdf', 'closest_observation',
                   'hazen', 'interpolated_inverted_cdf', 'linear',
                   'median_unbiased', 'normal_unbiased', 'weibull'}:
-        res = _quantile_hf(y, p, n, method, weights, xp)
+        res, se = _quantile_hf(y, p, n, method, weights, rich_result, xp)
     elif method in {'harrell-davis'}:
         res = _quantile_hd(y, p, n, xp)
     elif method in {'_lower', '_midpoint', '_higher', '_nearest'}:
@@ -397,10 +432,20 @@ def quantile(x, p, *, method='linear', axis=0, nan_policy='propagate', keepdims=
     if not keepdims:
         res = xp.squeeze(res, axis=axis)
 
-    return res[()] if res.ndim == 0 else res
+    res = res[()] if res.ndim == 0 else res
+
+    if rich_result:
+        se = xpx.at(se, p_mask).set(xp.nan)
+        se = xp.reshape(se, shape) if axis_none and keepdims else se
+        se = xp.moveaxis(se, -1, axis)
+        se = xp.squeeze(se, axis=axis) if not keepdims else se
+        se = se[()] if se.ndim == 0 else se
+        res = _RichResult(estimate=res, standard_error=se)
+
+    return res
 
 
-def _quantile_hf(y, p, n, method, weights, xp):
+def _quantile_hf(y, p, n, method, weights, rich_result, xp):
     ms = dict(inverted_cdf=0, averaged_inverted_cdf=0, closest_observation=-0.5,
               interpolated_inverted_cdf=0, hazen=0.5, weibull=p, linear=1 - p,
               median_unbiased=p/3 + 1/3, normal_unbiased=p/4 + 3/8)
@@ -435,8 +480,20 @@ def _quantile_hf(y, p, n, method, weights, xp):
     j = xp.clip(j, 0., n - 1)
     jp1 = xp.clip(jp1, 0., n - 1)
 
-    return ((1 - g) * xp.take_along_axis(y, xp.astype(j, xp.int64), axis=-1)
-            + g * xp.take_along_axis(y, xp.astype(jp1, xp.int64), axis=-1))
+    estimate = ((1 - g) * xp.take_along_axis(y, xp.astype(j, xp.int64), axis=-1)
+                + g * xp.take_along_axis(y, xp.astype(jp1, xp.int64), axis=-1))
+
+    standard_error = None
+    if rich_result:
+        # Compute Maritz-Jarrett [3, 4] estimates of the standard errors of the order
+        # statistics at indices `j` and `jp1`. The quantile estimate is a weighted sum
+        # of these order statistics, so a (conservative) approximation of the quantile
+        # standard error is the weighted sum of the order statistic standard errors.
+        sj = _maritz_jarrett(y, j, n, xp=xp)
+        sjp1 = _maritz_jarrett(y, jp1, n, xp=xp)
+        standard_error = (1 - g)*sj + g*sjp1
+
+    return estimate, standard_error
 
 
 def _quantile_hd(y, p, n, xp):
@@ -480,6 +537,17 @@ def _quantile_bc(y, p, n, method, xp):
     elif method == '_nearest':
         k = xp.round(ij)
     return xp.take_along_axis(y, xp.astype(k, xp.int64), axis=-1)
+
+
+def _maritz_jarrett(y, m, n, *, xp):
+    a = m + 1
+    b = n - m
+    i = xp.arange(y.shape[-1] + 1, dtype=y.dtype, device=xp_device(y))
+    w = betainc(a, b, i / n)
+    Wi = w[..., 1:] - w[..., :-1]
+    C1 = xp.vecdot(Wi, y, axis=-1)
+    C2 = xp.vecdot(Wi, y**2, axis=-1)
+    return xp.sqrt(C2 - C1 ** 2)
 
 
 @xp_capabilities(skip_backends=[("dask.array", "No take_along_axis yet.")])


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/22194#issuecomment-4014528168

#### What does this implement/fix?
This is a draft of a PR that would add Maritz-Jarrett standard errors to the output of `stats.quantile`, replacing [`scipy.stats.mstats.mjci`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.mstats.mjci.html).

Why draft? Interface:

In https://github.com/scipy/scipy/issues/22194#issue-2760316976, I suggested that we could add a `method` argument to `quantile_test` to work in this feature. What I had in mind is that the existing `confidence_interval` method of the result object could produce either the current confidence interval (based on theory involving the binomial distribution) or a confidence interval like `mstats.mquantiles_cimj` (based on theory involving the beta distribution / Maritz-Jarrett standard error). Since the Maritz-Jarrett confidence interval would assume a normal distribution of the statistic, it would also be natural to define a Maritz-Jarrett-based NSHT about the value of a quantile. 

Now I understand that the Maritz-Jarrett theory most naturally estimates the standard error of a sample *order statistic*. With that in mind, I think it would actually be pretty awkward to combine it with `quantile_test`, which really is about *quantiles* of the underlying distribution. The theory of `quantile_test` really isn't associated with any point estimator of a quantile. The Maritz-Jarrett idea, on the other hand, _only_ connects to quantiles when you estimate them as order statistics - or linear combinations of order statistics. 

But that's exactly what `quantile` does. And you can see from the diff that computing the standard error is just a few lines more once we have the point estimate.

Here's the snag: `quantile` only returns an array right now, so there's no good way of working in additional attributes. (We've already been through that with numpy/numpy#28397...) So here, I do the somewhat terrible thing of adding an argument (tentatively called `rich_result`) that changes what the function returns to a very flexible object, which we can continue to extend in the future (if needed). Other options:

- Creating a new function with essentially the same interface as `quantile`, except that it returns the standard error (or confidence interval) instead of the point estimate. This would mean a lot of redundant API surface and calculation.
- Adding an option to `quantile` that changes what the function returns to the standard error. This would avoid the redundant API surface, but there is still the redundant calculation, and the interface doesn't seem much better to me than this PR.
- Adding an option that changes the number of array outputs. This avoids the redundant API surface and calculation, but the interface seems the worst of all the options. (Yeah, this used to be common, but we've learned from mistakes of the past.)

If we don't like this argument long-term, perhaps we could figure out a deprecation strategy that leads to the rich result object being the default and only behavior.

#### Additional information

The significant bug in `mstats.mjci`/`mstats.mquantiles_cimj` (*all* results are inaccurate):

<details>

[Maritz and Jarrett](https://www.jstor.org/stable/2286545?seq=1) (MJ) gives the following procedure for estimating the median from a sample with an odd number of observations:

<img width="1087" height="722" alt="image" src="https://github.com/user-attachments/assets/08144f45-27a0-4186-94d7-c932c587a49e" />

$\hat{X}_n$ is the estimate of the median of $X$ from a sample with $n$ observations. The natural point estimate is the $(m + 1)\text{th}$ order statistic $X_{(m + 1)}$, and there is theory for estimating the expected values of powers of order statistics. 

Here's a direct implementation of that procedure:
```python3
import numpy as np
from scipy import special, integrate
rng = np.random.default_rng(32489235982345234)
m = 5
n = 2*m + 1
X = np.sort(rng.random(n))
i = np.arange(1, n + 1)
Wj = special.factorial(2*m + 1) / special.factorial(m)**2 * integrate.tanhsinh(lambda y: y**m * (1-y)**m, (i - 1)/n, i/n).integral
A2n = X**2 @ Wj
A1n = X @ Wj
np.sqrt(A2n - A1n**2)
# np.float64(0.13527637618483918)
```

`mstats.mjci` "Returns the Maritz-Jarrett estimators of the standard error of selected experimental quantiles of the data." Yet:

```python3
from scipy import stats
stats.mstats.mjci(X, 0.5)[0]
# np.float64(0.1469548658677711)
```

We might think, "maybe that's just a documentation interpretation issue - really, these are both the result of equally valid, but different, procedures". So we check the code of `mstats.mjci`, and it follows the generalization of hte Maritz-Jarrett procedure presented by Wilcox:

<img width="1021" height="887" alt="image" src="https://github.com/user-attachments/assets/7f9a4557-8c65-4927-b7da-8bdcfb4ec51c" />

Here's a very direct implementation of that in Python.
```python3
n = X.shape[-1]
m = np.floor(p*n + 0.5)
a = m - 1
b = n - m
B = stats.beta(a, b)
i = np.arange(1, n + 1)
x = i / n
y = (i - 1) / n
Wi = B.cdf(x) - B.cdf(y)
C1 = Wi @ X
C2 = Wi @ X**2
s = (C2 - C1**2)**0.5
s  # np.float64(0.1469548658677705)
```
OK, essentially identical to the output of `mstats.mjci`, so `mjci` followed Wilcox's procedure faithfully. 

To rule out a possible source of the discrepancy, let's note that `m` in the code above is `6`, whereas $m$ as defined in the Maritz-Jarrett paper would be $5$ in this case. But that's not the cause of the discrepancy: either way, the point estimate of the median is the _sixth order statistic_; the two just disagree on the definition of $m$.

A funny thing happens when we play around with `m` and `n` in the Maritz-Jarrett code:
```python3
n = 11  # the actual number of observations
m = 4  # a clearly wrong value of `m`
# ...
np.sqrt(A2n - A1n**2)
# np.float64(0.1469548658677705)
```

Whoa, there's that number again, coming from `m = 4`, with everything else the same. That smells funny!

Another thing that suggests something is wrong with the Wilcox procedure: if $p$ is too small or too big, one of the parameters of the beta distribution can be non-positive, and the result is NaN.

```python3
stats.mstats.mjci(X, 0.099)[0]  # np.float64(nan)
stats.mstats.mjci(X, 0.99)[0]  # np.float64(nan)
```
You can see it in the math: if $p$ is too small, $m$ will be $0$, so $a = -1$. If $p$ is too big, $m = n$, and $b = 0$. No good.

Chat GPT helped me find the source of the discrepancy. Note that at the top of Wilcox's description, the definition of the beta PDF has exponents $a$ and $b$. The typical definition of the beta PDF (e.g. [Wikipedia](https://en.wikipedia.org/wiki/Beta_distribution), [SciPy](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.beta.html), [R Beta distribution](https://stat.ethz.ch/R-manual/R-devel/library/stats/html/Beta.html)) has exponents $\alpha - 1$ and $\beta - 1$. If we set $\alpha = a + 1$ and $\beta = b + 1$, the two definitions would agree. Let's try the Wilcox code with that adjustment:

```python3
a = m - 1 + 1
b = n - m + 1
# ...
s = (C2 - C1**2)**0.5
s  # np.float64(0.13527637618483895)
```

And I wouldn't blame SciPy's implementation for not noticing the discrepancy and adjusting for it: Wilcox explicitly states that R's `pbeta` can be used with his $a$ and $b$.

</details>

The shortcoming of the method `mstats.mjci`/`mstats.mquantiles_cimj` *intend* to implement (even if the bug were corrected), and the improvement here.

<details>
The Wilcox procedure is based on a point estimate of the quantile as the $m^\text{th}$ order statistic, with $m = \lfloor pn + 0.5 \rfloor$. This works fine for the median of an odd-sized sample, but breaks down when it recomends $m = 0$ for small $p$. There is no $0^\text{th}$ order statistic; they are 1-indexed.

Even if we correct for that somehow, we still end up with the standard error being a step function of $p$ because it is based on a median estimate that is a step function of $p$, since it's just a single order statistic. 

And for samples of even size, it clearly doesn't follow the Maritz and Jarrett recomendation, which is based on $\hat{X}_n = \frac{X_(m) + X_{(m+1)}{2}$, which is a linear combination of two order statistics.

The improvement here is to generalize this even further to consider the linear combinations of order statistics returned by `quantile`. The MJ procedure lets us estimate the standard error of each order statistic, and then theory of error propagation gives us a formula for the standard error of the linear combination. We simplify things a bit by assuming that the covariance is maximal, giving us a slightly conservative approximation of the resulting standard error. I'll bet that we can find a formula for the exact covariance and implement that in a follow-up.
</details>


#### AI Generation Disclosure

Chat GPT helped me understand aspects of references [3] and [4] and track down the source of disagreement between `scipy.stats.mjci` and theory. 