### PR TITLE
ENH: linalg.cholesky: move batching loop to C

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -222,6 +222,23 @@ class BatchedEigBench(Benchmark):
             sl.eig(self.a)
 
 
+class BatchedCholeskyBench(Benchmark):
+    params = [
+        [(100, 3, 3), (100, 10, 10), (100, 20, 20), (100, 100, 100), (100, 100)],
+        ["scipy", "numpy"]
+    ]
+    param_names  = ["shape", "module"]
+
+    def setup(self, shape, module):
+        x = random(shape[:-1] + (1000,))
+        self.a = x @ np.swapaxes(x, axis1=-2, axis2=-1)
+
+    def time_cholesky(self, shape, module):
+        if module == "numpy":
+            nl.cholesky(self.a)
+        else:
+            sl.cholesky(self.a)
+
 
 class Norm(Benchmark):
     params = [

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -1,53 +1,57 @@
 """Cholesky decomposition functions."""
 
 import numpy as np
-from numpy import asarray_chkfinite, asarray, atleast_2d, empty_like
+from numpy import asarray_chkfinite, asarray, empty_like
 
 # Local imports
-from scipy._lib._util import _apply_over_batch
+from scipy._lib._util import _asarray_validated, _apply_over_batch
 from ._misc import LinAlgError, _datacopied
-from .lapack import get_lapack_funcs
+from .lapack import (
+    get_lapack_funcs, _normalize_lapack_dtype, _ensure_aligned_and_native
+)
+from . import _batched_linalg
 
 __all__ = ['cholesky', 'cho_factor', 'cho_solve', 'cholesky_banded',
            'cho_solve_banded']
+
+
+def _check_format_errors_warnings(routine_name, err_lst):
+    msg = (
+        f"Internal {routine_name} return info = {[e['lapack_info'] for e in err_lst]} "
+        f"for slices {[e['num'] for e in err_lst]}."
+    )
+    raise LinAlgError(msg)
 
 
 def _cholesky(a, lower=False, overwrite_a=False, clean=True,
               check_finite=True):
     """Common code for cholesky() and cho_factor()."""
 
-    a1 = asarray_chkfinite(a) if check_finite else asarray(a)
-    a1 = atleast_2d(a1)
+    # sanity checks
+    a1 = _asarray_validated(a, check_finite=check_finite)
+    a1 = np.atleast_2d(a1)
+    if a1.shape[-1] != a1.shape[-2]:
+        raise ValueError(f"Expected a square matrix or batch thereof, got {a1.shape=}")
 
-    # Dimension check
-    if a1.ndim != 2:
-        raise ValueError(f'Input array needs to be 2D but received a {a1.ndim}d-array.')
-    # Squareness check
-    if a1.shape[0] != a1.shape[1]:
-        raise ValueError('Input array is expected to be square but has '
-                         f'the shape: {a1.shape}.')
+    a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
+    a1, overwrite_a = _ensure_aligned_and_native(a1, overwrite_a)
+    overwrite_a = overwrite_a and (a1.ndim == 2) and a1.flags["F_CONTIGUOUS"]
 
-    # Quick return for square empty array
-    if a1.size == 0:
-        dt = cholesky(np.eye(1, dtype=a1.dtype)).dtype
-        return empty_like(a1, dtype=dt), lower
+    # accomodate empty arrays
+    if a1.shape[-1] == 0:
+        batch_shape = a1.shape[:-2]
+        c = np.zeros(batch_shape + (0, 0), dtype=a1.dtype)
+        return c
 
-    overwrite_a = overwrite_a or _datacopied(a1, a)
-    potrf, = get_lapack_funcs(('potrf',), (a1,))
-    c, info = potrf(a1, lower=lower, overwrite_a=overwrite_a, clean=clean)
-    if info > 0:
-        raise LinAlgError(
-            f"{info}-th leading minor of the array is not positive definite"
-        )
-    if info < 0:
-        raise ValueError(
-            f'LAPACK reported an illegal value in {-info}-th argument '
-            f'on entry to "POTRF".'
-        )
-    return c, lower
+    # Heavy lifting
+    c, err_lst = _batched_linalg._cholesky(a1, lower, overwrite_a, clean)
+
+    if err_lst:
+        _check_format_errors_warnings("potrf", err_lst)
+
+    return c
 
 
-@_apply_over_batch(('a', 2))
 def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
     """
     Compute the Cholesky decomposition of a matrix.
@@ -57,7 +61,7 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
 
     Parameters
     ----------
-    a : (M, M) array_like
+    a : (..., M, M) array_like
         Matrix to be decomposed
     lower : bool, optional
         Whether to compute the upper- or lower-triangular Cholesky
@@ -72,12 +76,17 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
 
     Returns
     -------
-    c : (M, M) ndarray
+    c : (..., M, M) ndarray
         Upper- or lower-triangular Cholesky factor of `a`.
 
     Raises
     ------
     LinAlgError : if decomposition fails.
+
+    See Also
+    --------
+    cho_factor : Compute the Cholesky decomposition without explicitly setting
+                    the other triangle to 0.
 
     Notes
     -----
@@ -103,12 +112,12 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
            [ 0.+2.j,  5.+0.j]])
 
     """
-    c, lower = _cholesky(a, lower=lower, overwrite_a=overwrite_a, clean=True,
-                         check_finite=check_finite)
+    # `clean = True` represents setting other triangle to 0.
+    c = _cholesky(a, lower=lower, overwrite_a=overwrite_a, clean=True,
+                check_finite=check_finite)
     return c
 
 
-@_apply_over_batch(("a", 2))
 def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
     """
     Compute the Cholesky decomposition of a matrix, to use in cho_solve.
@@ -118,13 +127,15 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
     The return value can be directly used as the first parameter to cho_solve.
 
     .. warning::
-        The returned matrix also contains random data in the entries not
-        used by the Cholesky decomposition. If you need to zero these
-        entries, use the function `cholesky` instead.
+        If `overwrite_a` is disabled, this function matches `cholesky` and
+        zeros the other triangle. If it is enabled, the returned matrix may
+        contain random data in the entries not used by the Cholesky
+        decomposition, saving out on the explicit putting to 0 done by
+        `cholesky`.
 
     Parameters
     ----------
-    a : (M, M) array_like
+    a : (..., M, M) array_like
         Matrix to be decomposed
     lower : bool, optional
         Whether to compute the upper or lower triangular Cholesky factorization.
@@ -139,10 +150,10 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
 
     Returns
     -------
-    c : (M, M) ndarray
+    c : (..., M, M) ndarray
         Matrix whose upper or lower triangle contains the Cholesky factor
         of `a`. Other parts of the matrix contain random data.
-    lower : bool
+    lower : ndarray, bool
         Flag indicating whether the factor is in the lower or upper triangle
 
     Raises
@@ -152,6 +163,8 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
 
     See Also
     --------
+    cholesky : Compute the Cholesky decomposition and explicitly put the
+                other triangle to 0.
     cho_solve : Solve a linear set equations using the Cholesky factorization
                 of a matrix.
 
@@ -169,20 +182,36 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
     --------
     >>> import numpy as np
     >>> from scipy.linalg import cho_factor
-    >>> A = np.array([[9, 3, 1, 5], [3, 7, 5, 1], [1, 5, 9, 2], [5, 1, 2, 6]])
+    >>> A = np.array([[9, 3, 1, 5], [3, 7, 5, 1], [1, 5, 9, 2], [5, 1, 2, 6]],
+    ...             dtype=float, order="F")
+    >>> A_ref = np.copy(A)
     >>> c, low = cho_factor(A)
+    >>> c
+    array([[3.        , 1.        , 0.33333333, 1.66666667],
+           [0.        , 2.44948974, 1.90515869, -0.27216553],
+           [0.        , 0.        , 2.29330749, 0.8559528 ],
+           [0.        , 0.        , 0.        , 1.55418563]])
+    >>> np.allclose(c.T @ c - A, np.zeros((4, 4)))
+    True
+    >>> c, low = cho_factor(A, overwrite_a=True)
     >>> c
     array([[3.        , 1.        , 0.33333333, 1.66666667],
            [3.        , 2.44948974, 1.90515869, -0.27216553],
            [1.        , 5.        , 2.29330749, 0.8559528 ],
            [5.        , 1.        , 2.        , 1.55418563]])
-    >>> np.allclose(np.triu(c).T @ np. triu(c) - A, np.zeros((4, 4)))
+    >>> np.allclose(np.triu(c).T @ np.triu(c) - A_ref, np.zeros((4, 4)))
     True
 
     """
-    c, lower = _cholesky(a, lower=lower, overwrite_a=overwrite_a, clean=False,
-                         check_finite=check_finite)
-    return c, lower
+    # `clean=False` to represent that it is not necessary to set other triangle to 0.
+    c = _cholesky(a, lower=lower, overwrite_a=overwrite_a, clean=False,
+                    check_finite=check_finite)
+
+    # broadcast `lower` argument for backwards compat
+    batch_shape = a.shape[:-2]
+    ret_lower = np.tile(lower, reps=batch_shape)
+
+    return c, ret_lower
 
 
 def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -4,6 +4,7 @@
 #include "_linalg_svd.hh"
 #include "_linalg_lstsq.hh"
 #include "_linalg_eig.hh"
+#include "_linalg_cholesky.hh"
 #include "_common_array_utils.hh"
 
 
@@ -244,7 +245,7 @@ _linalg_svd(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     npy_intp m = shape[ndim - 2];
     npy_intp n = shape[ndim - 1];
-    npy_intp k = m < n ? m : n; 
+    npy_intp k = m < n ? m : n;
 
     // Allocate the output(s)
 
@@ -377,7 +378,7 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
         return NULL;
     }
 
-    // At the python call site, 
+    // At the python call site,
     // 1) 1D `b` must have been converted into 2D, and
     // 2) batch dimensions of `a` and `b` have been broadcast
     // Therefore, if `a.shape == (s, p, r, m, n)`, then `b.shape == (s, p, r, m, nrhs)`
@@ -608,6 +609,90 @@ fail:
 }
 
 
+
+static PyObject*
+_linalg_cholesky(PyObject* Py_UNUSED(dummy), PyObject* args) {
+    PyArrayObject *ap_Am = NULL;
+    PyArrayObject *ap_Cm = NULL;
+    PyObject *ret_lst = NULL;
+    int lower=0, overwrite_a=0, clean=1;
+
+    int info = 0;
+    SliceStatusVec vec_status;
+
+    // Get input
+    if (!PyArg_ParseTuple(args, "O!|ppp", &PyArray_Type, (PyObject **)&ap_Am, &lower, &overwrite_a, &clean)) {
+        return NULL;
+    }
+
+    int typenum = PyArray_TYPE(ap_Am);
+    bool dtype_ok = (typenum == NPY_FLOAT32)
+                    || (typenum == NPY_FLOAT64)
+                    || (typenum == NPY_COMPLEX64)
+                    || (typenum == NPY_COMPLEX128);
+    if(!dtype_ok || !PyArray_ISALIGNED(ap_Am)) {
+        PyErr_SetString(PyExc_TypeError, "Expected a real or complex array.");
+        return NULL;
+    }
+
+    // Basic checks of array dimensions
+    int ndim = PyArray_NDIM(ap_Am);
+    npy_intp *shape = PyArray_SHAPE(ap_Am);
+    if (ndim < 2) {
+        PyErr_SetString(PyExc_ValueError, "Expected at least a 2D array.");
+        return NULL;
+    }
+
+    npy_intp n = shape[ndim - 1];
+
+    if (PyArray_DIM(ap_Am, ndim-2) != n) {
+        PyErr_SetString(PyExc_ValueError, "Expected a square matrix");
+        return NULL;
+    }
+
+    // Allocate the output array if needed
+    if (!overwrite_a) {
+        ap_Cm = (PyArrayObject *)PyArray_ZEROS(ndim, shape, typenum, 0); // 0 to obtain C-ordered input
+        if (ap_Cm == NULL) {
+            PyErr_NoMemory();
+            goto fail;
+        }
+    } else {
+        Py_INCREF(ap_Am);
+        ap_Cm = ap_Am;
+    }
+
+    switch(typenum) {
+        case(NPY_FLOAT32):
+            info = _cholesky<float>(ap_Am, ap_Cm, lower, overwrite_a, clean, vec_status);
+            break;
+        case(NPY_FLOAT64):
+            info = _cholesky<double>(ap_Am, ap_Cm, lower, overwrite_a, clean, vec_status);
+            break;
+        case(NPY_COMPLEX64):
+            info = _cholesky<npy_complex64>(ap_Am, ap_Cm, lower, overwrite_a, clean, vec_status);
+            break;
+        case(NPY_COMPLEX128):
+            info = _cholesky<npy_complex128>(ap_Am, ap_Cm, lower, overwrite_a, clean, vec_status);
+            break;
+    }
+
+    if (info < 0) {
+        // Out-of-memory or scipy internal error
+        PyErr_SetString(PyExc_RuntimeError, "Memory error in scipy.linalg.cholesky.");
+        goto fail;
+    }
+
+    // normal return
+    ret_lst = convert_vec_status(vec_status);
+    return Py_BuildValue("NN", PyArray_Return(ap_Cm), ret_lst);
+
+fail:
+    Py_XDECREF(ap_Cm);
+    return NULL;
+}
+
+
 /*
  * Helper: convert a vector of slice error statuses to list of dicts
  */
@@ -657,6 +742,7 @@ static char doc_solve[] = ("Solve the linear system of equations.");
 static char doc_svd[] = ("SVD factorization.");
 static char doc_lstsq[] = ("linear least squares.");
 static char doc_eig[] = ("eigenvalue solver.");
+static char doc_cholesky[] = ("Cholesky factorization.");
 
 static struct PyMethodDef inv_module_methods[] = {
   {"_inv", _linalg_inv, METH_VARARGS, doc_inv},
@@ -664,6 +750,7 @@ static struct PyMethodDef inv_module_methods[] = {
   {"_svd", _linalg_svd, METH_VARARGS, doc_svd},
   {"_lstsq", _linalg_lstsq, METH_VARARGS, doc_lstsq},
   {"_eig", _linalg_eig, METH_VARARGS, doc_eig},
+  {"_cholesky", _linalg_cholesky, METH_VARARGS, doc_cholesky},
   {NULL, NULL, 0, NULL}
 };
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1069,6 +1069,32 @@ void copy_slice_F_to_C(T* dst, const T* src, const npy_intp n, const npy_intp m,
 
 
 /*
+ * Copy only a specific triangle of F-ordered `src` to C-ordered `dst`.
+ *
+ * `src` is n x n, F-ordered
+ * `dst` is n x n, C-ordered
+ *
+ * `uplo` determines which triangle gets copied over,
+ */
+template<typename T>
+void copy_triangle_F_to_C(T *dst, const T *src, const npy_intp n, const char uplo) {
+    if (uplo == 'U') {
+        for (npy_intp i = 0; i < n; i++) {
+            for (npy_intp j = 0; j <= i; j++) {
+                dst[i + j * n] = src[i * n + j];
+            }
+        }
+    } else {
+        for (npy_intp i = 0; i < n; i++) {
+            for (npy_intp j = i; j < n; j++) {
+                dst[i + j * n] = src[i * n + j];
+            }
+        }
+    }
+}
+
+
+/*
  * 1-norm of a matrix
  */
 

--- a/scipy/linalg/src/_linalg_cholesky.hh
+++ b/scipy/linalg/src/_linalg_cholesky.hh
@@ -1,0 +1,86 @@
+template<typename T>
+int
+_cholesky(PyArrayObject *ap_Am, PyArrayObject *ap_Cm, int lower, int overwrite_a, int clean, SliceStatusVec &vec_status) {
+    char uplo = lower ? 'L' : 'U';
+    St slice_structure = St::NONE;
+    SliceStatus slice_status;
+
+    //-------------------------------------------------------------------
+    // Input array attributes
+    //-------------------------------------------------------------------
+    T *Am_data = (T *)PyArray_DATA(ap_Am);
+    npy_intp ndim = PyArray_NDIM(ap_Am);
+    npy_intp *shape = PyArray_SHAPE(ap_Am);
+    npy_intp *strides = PyArray_STRIDES(ap_Am);
+    npy_intp n = shape[ndim-1];
+
+    T *ret_data = (T *)PyArray_DATA(ap_Cm); // Identical shape as input, C-ordered
+
+    // Determine number of slices (np.prod(dim[:-2]))
+    npy_intp outer_size = 1;
+    if (ndim > 2) {
+        for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i]; }
+    }
+
+    //--------------------------------------------------------------------
+    // Workspace computation and allocation
+    //--------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)n, info = 0;
+
+    /*
+     * Only need a buffer for `a`, but if `overwrite_a` is enabled this is not the case.
+     *
+     * No `work` buffer required for `potrf`.
+     */
+    npy_intp buf_size = overwrite_a ? 0 : n * n;
+    T *buffer = (T *)malloc(buf_size * sizeof(T));
+    if (buffer == NULL) { info = -104; return info; }
+
+    T *data_a = NULL;
+    if (!overwrite_a) {
+        data_a = &buffer[0];
+    } else {
+        data_a = Am_data;
+    }
+
+    // Main loop to traverse the slices
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+
+        if (!overwrite_a) {
+            T *slice_ptr_A = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+            copy_slice_F(data_a, slice_ptr_A, n, n, strides[ndim-2], strides[ndim-1]);
+        }
+        // NB. `overwrite_a` is only enabled when the input is 2D F-ordered so data is
+        // already correctly ordered in input array. If generalized to `ndim > 2` this
+        // should be updated accordingly.
+
+        init_status(slice_status, idx, slice_structure);
+        call_potrf(&uplo, &intn, data_a, &intn, &info);
+
+        if (info != 0) {
+            slice_status.lapack_info = (Py_ssize_t)info;
+            vec_status.push_back(slice_status);
+
+            goto done;
+        }
+
+        /*
+         * Only copy over relevant part of the triangle. Other part is already
+         * put to 0 by construction. For `overwrite_a` the story is a biff different
+         * since the input array should then still be cleaned after the fact.
+         *
+         * NB. this `zero_other_triangle` only works since `overwrite_a` is only enabled
+         * for 2D F-ordered arrays. Otherwise some other measures have to be taken.
+         */
+        if (!overwrite_a) {
+            copy_triangle_F_to_C(&ret_data[idx * n * n], data_a, n, uplo);
+        } else if (clean) {
+            zero_other_triangle(uplo, data_a, n);
+        }
+
+    } // end of batching loop
+
+done:
+    free(buffer);
+    return 1;
+}

--- a/scipy/linalg/tests/test_batch.py
+++ b/scipy/linalg/tests/test_batch.py
@@ -704,4 +704,3 @@ def test_shapes_solve_like(func, core_shape):
     with pytest.raises(ValueError, match=pattern):
         # fails to broadcast `b` vs `a` (to fix: append a length-1 trailing dim)
         func(a, b)
-

--- a/scipy/linalg/tests/test_decomp_cholesky.py
+++ b/scipy/linalg/tests/test_decomp_cholesky.py
@@ -1,14 +1,14 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_allclose
 from pytest import raises as assert_raises
 
-from numpy import array, transpose, dot, conjugate, zeros_like, empty
-from numpy.random import random
+from numpy import array, transpose, zeros_like, empty
 from scipy.linalg import (cholesky, cholesky_banded, cho_solve_banded,
-     cho_factor, cho_solve)
+     cho_factor, cho_solve, LinAlgError)
 
 from scipy.linalg._testutils import assert_no_overwrite
+from .test_basic import parametrize_overwrite_arg
 
 
 class TestCholesky:
@@ -16,56 +16,53 @@ class TestCholesky:
     def test_simple(self):
         a = [[8, 2, 3], [2, 9, 3], [3, 3, 6]]
         c = cholesky(a)
-        assert_array_almost_equal(dot(transpose(c), c), a)
+        assert_allclose(c.T @ c, a, atol=1e-14)
         c = transpose(c)
-        a = dot(c, transpose(c))
-        assert_array_almost_equal(cholesky(a, lower=1), c)
+        a = c @ c.T
+        assert_allclose(cholesky(a, lower=1), c, atol=1e-14)
 
     def test_check_finite(self):
         a = [[8, 2, 3], [2, 9, 3], [3, 3, 6]]
         c = cholesky(a, check_finite=False)
-        assert_array_almost_equal(dot(transpose(c), c), a)
+        assert_allclose(c.T @ c, a, atol=1e-14)
         c = transpose(c)
-        a = dot(c, transpose(c))
-        assert_array_almost_equal(cholesky(a, lower=1, check_finite=False), c)
+        a = c @ c.T
+        assert_allclose(cholesky(a, lower=1, check_finite=False), c, atol=1e-14)
 
     def test_simple_complex(self):
         m = array([[3+1j, 3+4j, 5], [0, 2+2j, 2+7j], [0, 0, 7+4j]])
-        a = dot(transpose(conjugate(m)), m)
+        a = np.conj(m.T) @ m
         c = cholesky(a)
-        a1 = dot(transpose(conjugate(c)), c)
-        assert_array_almost_equal(a, a1)
+        a1 = np.conj(c.T) @ c
+        assert_allclose(a, a1)
         c = transpose(c)
-        a = dot(c, transpose(conjugate(c)))
-        assert_array_almost_equal(cholesky(a, lower=1), c)
+        a = c @ np.conj(c.T)
+        assert_allclose(cholesky(a, lower=1), c, atol=1e-14)
 
-    def test_random(self):
-        n = 20
+    @pytest.mark.parametrize("n", [5, 10, 20])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64,
+                                        np.complex64, np.complex128])
+    @pytest.mark.parametrize("order", ["F", "C"])
+    def test_random(self, n, dtype, order):
+        atol = 5e-4 if dtype in [np.float32, np.complex64] else 1e-12
+        rng = np.random.default_rng(seed=12345)
+
         for k in range(2):
-            m = random([n, n])
+            m = rng.normal(size=(n, n)).astype(dtype)
+            if np.issubdtype(dtype, np.complexfloating):
+                m += 1j * rng.normal(size=(n, n)).astype(dtype)
             for i in range(n):
                 m[i, i] = 20*(.1+m[i, i])
-            a = dot(transpose(m), m)
-            c = cholesky(a)
-            a1 = dot(transpose(c), c)
-            assert_array_almost_equal(a, a1)
-            c = transpose(c)
-            a = dot(c, transpose(c))
-            assert_array_almost_equal(cholesky(a, lower=1), c)
 
-    def test_random_complex(self):
-        n = 20
-        for k in range(2):
-            m = random([n, n])+1j*random([n, n])
-            for i in range(n):
-                m[i, i] = 20*(.1+abs(m[i, i]))
-            a = dot(transpose(conjugate(m)), m)
-            c = cholesky(a)
-            a1 = dot(transpose(conjugate(c)), c)
-            assert_array_almost_equal(a, a1)
+            a = np.asarray(np.conj(m.T) @ m, order=order)
+
+            c = cholesky(a, lower=0)
+            a1 = np.conj(c.T) @ c
+            assert_allclose(a, a1, atol=atol)
+
             c = transpose(c)
-            a = dot(c, transpose(conjugate(c)))
-            assert_array_almost_equal(cholesky(a, lower=1), c)
+            a = c @ np.conj(c.T)
+            assert_allclose(cholesky(a, lower=1), c, atol=atol)
 
     @pytest.mark.xslow
     def test_int_overflow(self):
@@ -111,6 +108,71 @@ class TestCholesky:
         for x in ([a1, a2, a3, a4]):
             assert_raises(ValueError, cholesky, x)
 
+    @pytest.mark.parametrize("shape", [(3,), (2, 3), (3, 2)])
+    def test_invalid_shape(self, shape):
+        rng = np.random.default_rng(seed=12345)
+        a = rng.normal(size=shape)
+
+        with pytest.raises(ValueError, match="Expected a square matrix"):
+            cholesky(a)
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64,
+                             np.complex64, np.complex128])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    def test_non_posdef(self, dtype, order):
+        n = 10
+        rng = np.random.default_rng(seed=12345)
+
+        lmbd = np.diag(-np.abs(rng.normal(size=(n,))).astype(dtype))
+        x = rng.normal(size=(n, n)).astype(dtype)
+        if np.issubdtype(dtype, np.complexfloating):
+            x += 1j * rng.normal(size=(n, n)).astype(dtype)
+
+        a = np.asarray(x @ lmbd @ np.conj(x.T), order=order)
+
+        with pytest.raises(LinAlgError, match="Internal potrf return info"):
+            cholesky(a)
+
+    @parametrize_overwrite_arg
+    @pytest.mark.parametrize("dtype", [int, float])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    def test_overwrite_args(self, overwrite_kw, dtype, order):
+        rng = np.random.default_rng(seed=12345)
+        n = 5
+
+        x = rng.normal(size=(n, n))
+        x = x.astype(dtype)
+        a = x @ x.T
+        a = a.astype(dtype, order=order)
+        a_ref = np.copy(a)
+
+        c = cholesky(a, **overwrite_kw)
+        overwrite_a = overwrite_kw.get("overwrite_a", False)
+        a_inplace = overwrite_a and (dtype is not int) and a.flags["F_CONTIGUOUS"]
+
+        assert np.shares_memory(a, c) == a_inplace
+        assert np.all(a == a_ref) != a_inplace
+
+    @pytest.mark.parametrize("lower", [True, False])
+    def test_overwrite_cleaning(self, lower):
+        # Since only half the array is copied over, this checks if the other
+        # half is correctly put to 0 when the input array is passed in instead.
+        rng = np.random.default_rng(seed=12345)
+        n = 5
+
+        x = rng.normal(size=(n, n))
+        a = np.asfortranarray(x @ x.T)
+        a_ref = np.copy(a)
+
+        c = cholesky(a, lower=lower, overwrite_a=True)
+
+        if lower:
+            assert_allclose(np.triu(a, k=1), np.zeros_like(a), atol=1e-14)
+            assert_allclose(c @ c.T, a_ref, atol=1e-14)
+        else:
+            assert_allclose(np.tril(a, k=-1), np.zeros_like(a), atol=1e-14)
+            assert_allclose(c.T @ c, a_ref, atol=1e-14)
+
 
 class TestCholeskyBanded:
     """Tests for cholesky_banded() and cho_solve_banded."""
@@ -128,11 +190,11 @@ class TestCholeskyBanded:
         ufac = zeros_like(a)
         ufac[list(range(4)), list(range(4))] = c[-1]
         ufac[(0, 1, 2), (1, 2, 3)] = c[0, 1:]
-        assert_array_almost_equal(a, dot(ufac.T, ufac))
+        assert_allclose(a, ufac.T @ ufac, atol=1e-14)
 
         b = array([0.0, 0.5, 4.2, 4.2])
         x = cho_solve_banded((c, False), b, check_finite=False)
-        assert_array_almost_equal(x, [0.0, 0.0, 1.0, 1.0])
+        assert_allclose(x, [0.0, 0.0, 1.0, 1.0], atol=1e-14)
 
     def test_upper_real(self):
         # Symmetric positive definite banded matrix `a`
@@ -147,11 +209,11 @@ class TestCholeskyBanded:
         ufac = zeros_like(a)
         ufac[list(range(4)), list(range(4))] = c[-1]
         ufac[(0, 1, 2), (1, 2, 3)] = c[0, 1:]
-        assert_array_almost_equal(a, dot(ufac.T, ufac))
+        assert_allclose(a, ufac.T @ ufac, atol=1e-14)
 
         b = array([0.0, 0.5, 4.2, 4.2])
         x = cho_solve_banded((c, False), b)
-        assert_array_almost_equal(x, [0.0, 0.0, 1.0, 1.0])
+        assert_allclose(x, [0.0, 0.0, 1.0, 1.0], atol=1e-14)
 
     def test_upper_complex(self):
         # Hermitian positive definite banded matrix `a`
@@ -166,11 +228,11 @@ class TestCholeskyBanded:
         ufac = zeros_like(a)
         ufac[list(range(4)), list(range(4))] = c[-1]
         ufac[(0, 1, 2), (1, 2, 3)] = c[0, 1:]
-        assert_array_almost_equal(a, dot(ufac.conj().T, ufac))
+        assert_allclose(a, np.conj(ufac.T) @ ufac, atol=1e-14)
 
         b = array([0.0, 0.5, 4.0-0.2j, 0.2j + 4.0])
         x = cho_solve_banded((c, False), b)
-        assert_array_almost_equal(x, [0.0, 0.0, 1.0, 1.0])
+        assert_allclose(x, [0.0, 0.0, 1.0, 1.0], atol=1e-14)
 
     def test_lower_real(self):
         # Symmetric positive definite banded matrix `a`
@@ -185,11 +247,11 @@ class TestCholeskyBanded:
         lfac = zeros_like(a)
         lfac[list(range(4)), list(range(4))] = c[0]
         lfac[(1, 2, 3), (0, 1, 2)] = c[1, :3]
-        assert_array_almost_equal(a, dot(lfac, lfac.T))
+        assert_allclose(a, lfac @ lfac.T, atol=1e-14)
 
         b = array([0.0, 0.5, 4.2, 4.2])
         x = cho_solve_banded((c, True), b)
-        assert_array_almost_equal(x, [0.0, 0.0, 1.0, 1.0])
+        assert_allclose(x, [0.0, 0.0, 1.0, 1.0], atol=1e-14)
 
     def test_lower_complex(self):
         # Hermitian positive definite banded matrix `a`
@@ -204,11 +266,11 @@ class TestCholeskyBanded:
         lfac = zeros_like(a)
         lfac[list(range(4)), list(range(4))] = c[0]
         lfac[(1, 2, 3), (0, 1, 2)] = c[1, :3]
-        assert_array_almost_equal(a, dot(lfac, lfac.conj().T))
+        assert_allclose(a, lfac @ np.conj(lfac.T), atol=1e-14)
 
         b = array([0.0, 0.5j, 3.8j, 3.8])
         x = cho_solve_banded((c, True), b)
-        assert_array_almost_equal(x, [0.0, 0.0, 1.0j, 1.0])
+        assert_allclose(x, [0.0, 0.0, 1.0j, 1.0], atol=1e-14)
 
     @pytest.mark.parametrize('dt', [int, float, np.float32, complex, np.complex64])
     @pytest.mark.parametrize('dt_b', [int, float, np.float32, complex, np.complex64])
@@ -256,6 +318,7 @@ class TestOverwrite:
         assert_no_overwrite(lambda b: cho_solve_banded((xcho, False), b),
                             [(3,)])
 
+
 class TestChoFactor:
     @pytest.mark.parametrize('dt', [int, float, np.float32, complex, np.complex64])
     def test_empty(self, dt):
@@ -266,3 +329,80 @@ class TestChoFactor:
 
         xx, lower = cho_factor(np.eye(2, dtype=dt))
         assert x.dtype == xx.dtype
+
+    @pytest.mark.parametrize("n", [5, 10, 20])
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64,
+                                np.complex64, np.complex128])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    @pytest.mark.parametrize("lower", [True, False])
+    def test_random(self, n, dtype, order, lower):
+        atol = 1e-5 if dtype in [np.float32, np.complex64] else 1e-12
+        rng = np.random.default_rng(seed=12345)
+
+        lmbd = np.diag(np.abs(rng.normal(size=(n,)).astype(dtype)))
+        x = rng.normal(size=(n, n)).astype(dtype)
+        if np.issubdtype(dtype, np.complexfloating):
+            x += 1j * rng.normal(size=(n, n)).astype(dtype)
+
+        a = np.asarray(x @ lmbd @ np.conj(x.T), order=order)
+        c = cholesky(a, lower=lower)
+        c_f, lower_out = cho_factor(a, lower=lower)
+
+        assert lower_out == lower
+
+        # Theoretically exactly equal
+        # For `cho_factor` the other half of the matrix is irrelevant.
+        if lower:
+            l = np.tril(c_f)
+            assert_allclose(c, l, atol=atol)
+            assert_allclose(a, l @ np.conj(l.T), atol=atol)
+        else:
+            u = np.triu(c_f)
+            assert_allclose(c, u, atol=atol)
+            assert_allclose(a, np.conj(u.T) @ u, atol=atol)
+
+    @pytest.mark.parametrize("shape", [(3,), (3, 2), (2, 3)])
+    def test_invalid_shape(self, shape):
+        rng = np.random.default_rng(seed=12345)
+        a = rng.normal(size=shape)
+
+        with pytest.raises(ValueError, match="Expected a square matrix or batch"):
+            cho_factor(a)
+
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64,
+                             np.complex64, np.complex128])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    def test_non_posdef(self, dtype, order):
+        n = 10
+        rng = np.random.default_rng(seed=12345)
+
+        lmbd = np.diag(-np.abs(rng.normal(size=(n,))).astype(dtype))
+        x = rng.normal(size=(n, n)).astype(dtype)
+        if np.issubdtype(dtype, np.complexfloating):
+            x += 1j * rng.normal(size=(n, n)).astype(dtype)
+
+        a = np.asarray(x @ lmbd @ np.conj(x.T), order=order)
+
+        with pytest.raises(LinAlgError, match="Internal potrf return info"):
+            cho_factor(a)
+
+    @parametrize_overwrite_arg
+    @pytest.mark.parametrize("dtype", [int, float])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    @pytest.mark.parametrize("lower", [True, False])
+    def test_overwrite_args(self, overwrite_kw, dtype, order, lower):
+        rng = np.random.default_rng(seed=12345)
+        n = 5
+
+        x = rng.normal(size=(n, n))
+        x = x.astype(dtype)
+        a = x @ x.T
+        a = a.astype(dtype, order=order)
+        a_ref = np.copy(a)
+
+        c, lower = cho_factor(a, **overwrite_kw, lower=lower)
+        overwrite_a = overwrite_kw.get("overwrite_a", False)
+        a_inplace = overwrite_a and (dtype is not int) and a.flags["F_CONTIGUOUS"]
+
+        assert np.shares_memory(a, c) == a_inplace
+        assert np.all(a == a_ref) != a_inplace

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -1596,13 +1596,13 @@ class TestMatrixT:
 
         with pytest.raises(
             np.linalg.LinAlgError,
-            match="2-th leading minor of the array is not positive definite",
+            match="Internal potrf return info",
         ):
             matrix_t.rvs(M, U, np.ones((num_cols, num_cols)), df)
 
         with pytest.raises(
             np.linalg.LinAlgError,
-            match="2-th leading minor of the array is not positive definite",
+            match="Internal potrf return info",
         ):
             matrix_t.rvs(M, np.ones((num_rows, num_rows)), V, df)
 


### PR DESCRIPTION
#### Reference issue
Towards #24474 by lowering `cholesky`.

#### What does this implement/fix?
Removes the decorator and instead moves the batching loop to C.

A benchmark has been added (results under the fold): remarkably for 2D arrays this implementation is slower than before, but this conflicts the fact that batches of small matrices are now equally fast. Also, the performance is still inferior to that of numpy, but that might be because of some extra checks.

<details>
<summary> Benchmark results </summary>

- On main:

```
              ================= ============ =============
              --                          module
              ----------------- --------------------------
                    shape          scipy         numpy
              ================= ============ =============
                 (100, 3, 3)      365±7μs      10.7±0.2μs
                (100, 10, 10)     388±1μs      33.3±0.4μs
                (100, 20, 20)     488±7μs       91.8±3μs
               (100, 100, 100)    6.24±1ms    2.44±0.03ms
                  (100, 100)     27.5±0.2μs    25.4±0.4μs
              ================= ============ =============
```

- After this PR:

```
             ================= ============= =============
             --                           module
             ----------------- ---------------------------
                   shape           scipy         numpy
             ================= ============= =============
                (100, 3, 3)     10.2±0.05μs    10.5±0.2μs
               (100, 10, 10)     34.7±0.3μs    33.3±0.8μs
               (100, 20, 20)     109±0.8μs      90.0±1μs
              (100, 100, 100)   3.09±0.01ms   2.42±0.02ms
                 (100, 100)      31.9±0.4μs    25.3±0.1μs
             ================= ============= =============
```

- Comparison

```
| Change   | Before [5710093b] <main>   | After [6b289a9a] <cholesky_speedup>   |   Ratio | Benchmark (Parameter)                                               |
|----------|----------------------------|---------------------------------------|---------|---------------------------------------------------------------------|
| +        | 27.5±0.2μs                 | 31.9±0.4μs                            |    1.16 | linalg.BatchedCholeskyBench.time_cholesky((100, 100), 'scipy')      |
| -        | 6.24±1ms                   | 3.09±0.01ms                           |    0.49 | linalg.BatchedCholeskyBench.time_cholesky((100, 100, 100), 'scipy') |
| -        | 488±7μs                    | 109±0.8μs                             |    0.22 | linalg.BatchedCholeskyBench.time_cholesky((100, 20, 20), 'scipy')   |
| -        | 388±1μs                    | 34.7±0.3μs                            |    0.09 | linalg.BatchedCholeskyBench.time_cholesky((100, 10, 10), 'scipy')   |
| -        | 365±7μs                    | 10.2±0.05μs                           |    0.03 | linalg.BatchedCholeskyBench.time_cholesky((100, 3, 3), 'scipy')     |
```

</details>

The testsuite has also been expanded to be a little more comprehensive. (The error messages were updated to match the style of other related PRs, which caused a test failure in `stats`, which is why that module was also touched.)

#### Additional information
The entire `decomp_cholesky` file seems like it might be "compressed" a bit; there are two implementations details I don't fully comprehend where they come from:
- Why is there a `clean` keyword in the call to `potrf` in `_cholesky`? This PR currently does not include it, but it doesn't seem to change the testsuite.
- It feels a bit redundant to also return the `lower` keyword in `_cholesky` since it is just passing back an input argument.

If those two things are cleared out `_cholesky` can normally safely be deleted and `_cho_factor` can also be altered to simply call the lowered implementation of `cholesky` and then additionally pass back the `lower` input argument, also speeding that one up. (At first glance that works when checking that locally, but should probably be kept as an enhancement instead of lumping that one into this PR.)

#### AI Generation Disclosure
No AI
