### PR TITLE
BUG: integrate: fix ComplexWarning in _sparse_num_jac with complex ODE

### DIFF
--- a/scipy/integrate/_ivp/common.py
+++ b/scipy/integrate/_ivp/common.py
@@ -385,7 +385,7 @@ def _dense_num_jac(fun, t, y, f, h, factor, y_scale):
 def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
     n = y.shape[0]
     n_groups = np.max(groups) + 1
-    h_vecs = np.empty((n_groups, n))
+    h_vecs = np.empty((n_groups, n), dtype=h.dtype)
     for group in range(n_groups):
         e = np.equal(group, groups)
         h_vecs[group] = h * e
@@ -407,12 +407,12 @@ def _sparse_num_jac(fun, t, y, f, h, factor, y_scale, structure, groups):
         ind, = np.nonzero(diff_too_small)
         new_factor = NUM_JAC_FACTOR_INCREASE * factor[ind]
         h_new = (y[ind] + new_factor * y_scale[ind]) - y[ind]
-        h_new_all = np.zeros(n)
+        h_new_all = np.zeros(n, dtype=h.dtype)
         h_new_all[ind] = h_new
 
         groups_unique = np.unique(groups[ind])
         groups_map = np.empty(n_groups, dtype=int)
-        h_vecs = np.empty((groups_unique.shape[0], n))
+        h_vecs = np.empty((groups_unique.shape[0], n), dtype=h.dtype)
         for k, group in enumerate(groups_unique):
             e = np.equal(group, groups)
             h_vecs[k] = h_new_all * e

--- a/scipy/integrate/_ivp/tests/test_ivp.py
+++ b/scipy/integrate/_ivp/tests/test_ivp.py
@@ -287,6 +287,22 @@ def test_integration_complex():
         assert np.all(e < 5)
 
 
+def test_integration_complex_sparse():
+    # Regression test for gh-24671: solve_ivp with a complex ODE and
+    # jac_sparsity should not emit ComplexWarning.
+    rtol = 1e-3
+    atol = 1e-6
+    y0 = [0.5 + 1j]
+    t_span = [0, 1]
+    sparsity = csc_matrix(np.ones((1, 1)))
+    res = solve_ivp(fun_complex, t_span, y0, method='BDF',
+                    rtol=rtol, atol=atol, jac_sparsity=sparsity)
+    assert res.success
+    y_true = sol_complex(res.t)
+    e = compute_error(res.y, y_true, rtol, atol)
+    assert np.all(e < 5)
+
+
 @pytest.mark.fail_slow(5)
 def test_integration_sparse_difference():
     n = 200


### PR DESCRIPTION
#### Reference issue

Closes gh-24671.

#### What does this implement/fix?

`_sparse_num_jac` in `scipy/integrate/_ivp/common.py` creates `h_vecs` and `h_new_all` as float64 arrays (NumPy's default), but when the ODE state vector `y` is complex, the perturbation step `h` is complex128 — even though its imaginary part is numerically zero. This causes NumPy to emit a spurious `ComplexWarning: Casting complex values to real discards the imaginary part` whenever complex values are assigned into those float64 arrays.

The fix is straightforward: add `dtype=h.dtype` to the three `np.empty`/`np.zeros` calls in `_sparse_num_jac`:

- `h_vecs = np.empty((n_groups, n), dtype=h.dtype)`
- `h_new_all = np.zeros(n, dtype=h.dtype)`
- `h_vecs = np.empty((groups_unique.shape[0], n), dtype=h.dtype)`

The dense path (`_dense_num_jac`) already handles this correctly because `np.diag(h)` naturally inherits the dtype of `h`. This change makes the sparse path consistent with the dense path.

A regression test `test_integration_complex_sparse` is added. Since `pytest.ini` sets `filterwarnings = error`, the test would fail before the fix and passes cleanly after.

#### Additional information

The warning is spurious: the imaginary part being cast away is always exactly zero (the step `h` is computed from real arithmetic even though `y` is complex), so results are numerically correct both before and after the fix. The only change in behavior is the absence of the spurious warning.

#### AI Generation Disclosure

No AI tools used.