### PR TITLE
BUG: `from_rotvec` read-only support

### DIFF
--- a/scipy/spatial/transform/_rotation_cy.pyx
+++ b/scipy/spatial/transform/_rotation_cy.pyx
@@ -580,7 +580,7 @@ def from_rotvec(rotvec, bint degrees=False):
     # If a single vector is given, convert it to a 2D 1 x 3 matrix but
     # set self._single to True so that we can return appropriate objects
     # in the `as_...` methods
-    cdef double[:, :] crotvec
+    cdef const double[:, :] crotvec
     if rotvec.shape == (3,):
         crotvec = rotvec[None, :]
         is_single = True

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -3196,3 +3196,9 @@ def test_gh_24751():
     points.flags.writeable = False
     rot = Rotation.from_euler("z", 0.0)
     rot.apply(points)
+
+
+def test_rotvec_non_writeable():
+    rotvec = np.array([0, 0, 1]) * np.pi / 2
+    rotvec.flags.writeable = False
+    Rotation.from_rotvec(rotvec)


### PR DESCRIPTION
* Follow up to gh-24753 requested by Evgeni. Similar to the approach in that PR, this patch sets a Cython memoryview to `const` so that it may additionally accept read-only buffers, allowing the new regression test to pass.

#### AI Generation Disclosure

No AI tools used
