### PR TITLE
DOC: ``spatial.transform``: fix docstring for return type of ``Rotation.approx_equal``

### DIFF
--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1969,10 +1969,10 @@ class Rotation:
 
         Returns
         -------
-        approx_equal : ndarray or bool
-            Whether the rotations are approximately equal, bool if object
-            contains a single rotation and ndarray if object contains multiple
-            rotations.
+        approx_equal : bool ndarray
+            Whether the rotations are approximately equal, shape ``(1,)`` if object
+            contains a single rotation and shape ``(N, ...)`` if object contains 
+            multiple rotations.
 
         Examples
         --------
@@ -1986,7 +1986,7 @@ class Rotation:
         Approximate equality for a single rotation:
 
         >>> p.approx_equal(q[0])
-        False
+        array([False])
         """
         cython_compatible = self._quat.ndim < 3 and other._quat.ndim < 3
         backend = select_backend(self._xp, cython_compatible=cython_compatible)


### PR DESCRIPTION
I'm not sure if this was accidentally changed at some point, or if it always has been the case. Either way, the docs did not match the runtime behavior, so this fixes it.