### PR TITLE
DOC: fix typos in /tutorial/interpolate

### DIFF
--- a/doc/source/tutorial/interpolate/1D.rst
+++ b/doc/source/tutorial/interpolate/1D.rst
@@ -43,10 +43,10 @@ Cubic splines
 =============
 
 Of course, piecewise linear interpolation produces corners at data points,
-where linear pieces join. To produce a smoother curve, you can use cubic
+where the linear pieces join. To produce a smoother curve, you can use cubic
 splines, where the interpolating curve is made of cubic pieces with matching
-first and second derivatives. In code, these objects are represented via the
-``CubicSpline`` class instances. An instance is constructed with the ``x`` and
+first and second derivatives. In code, these objects are represented by instances of the 
+``CubicSpline`` class. An instance is constructed with the ``x`` and
 ``y`` arrays of data, and then it can be evaluated using the target ``xnew``
 values:
 
@@ -92,7 +92,7 @@ data points. In these situations, an alternative is to use the so-called
 *monotone* cubic interpolants: these are constructed to be only once
 continuously differentiable, and attempt to preserve the local shape implied
 by the data. `scipy.interpolate` provides two objects of this kind:
-`PchipInterpolator` and `Akima1DInterpolator` . To illustrate, let's consider
+`PchipInterpolator` and `Akima1DInterpolator`. To illustrate, let's consider
 data with an outlier:
 
 .. plot::
@@ -117,7 +117,7 @@ data with an outlier:
 Interpolation with B-splines
 ============================
 
-B-splines form an alternative (if formally equivalent) representation of piecewise polynomials. This basis is generally more computationally stable than the power basis and is useful for a variety of applications which include interpolation, regression and curve representation. Details are given in the :ref:`piecewise polynomials section <tutorial-interpolate_ppoly>`, and here we illustrate their usage by constructing the interpolation of a sine function: 
+B-splines form an alternative (though formally equivalent) representation of piecewise polynomials. This basis is generally more computationally stable than the power basis and is useful for a variety of applications which include interpolation, regression and curve representation. Details are given in the :ref:`piecewise polynomials section <tutorial-interpolate_ppoly>`, and here we illustrate their usage by constructing the interpolation of a sine function: 
 
 
 .. plot::
@@ -226,7 +226,7 @@ Second, the interpolation axis can be controlled by an optional ``axis`` argumen
 example above uses the default value of ``axis=0``. For a non-default values, the
 following is true:
 
-- ``y.shape[axis] == x.size`` (otherwise en error is raised)
+- ``y.shape[axis] == x.size`` (otherwise an error is raised)
 - the shape of ``spl(xv)`` is ``y.shape[axis:] + xv.shape + y.shape[:axis]``
 
 
@@ -279,7 +279,7 @@ Chapter 6 of Ref [1] listed in the `BSpline` docstring:
 
     >>> u_unif = x
 
-    Second, we consider the so-called *cord length* parametrization, which is
+    Second, we consider the so-called *chord length* parametrization, which is
     nothing but a cumulative length of straight line segments connecting the
     data points:
 
@@ -292,13 +292,13 @@ Chapter 6 of Ref [1] listed in the `BSpline` docstring:
 
     >>> dp = p[:, 1:] - p[:, :-1]      # 2-vector distances between points
     >>> l = (dp**2).sum(axis=0)        # squares of lengths of 2-vectors between points
-    >>> u_cord = np.sqrt(l).cumsum()   # cumulative sums of 2-norms
-    >>> u_cord = np.r_[0, u_cord]      # the first point is parameterized at zero
+    >>> u_chord = np.sqrt(l).cumsum()   # cumulative sums of 2-norms
+    >>> u_chord = np.r_[0, u_chord]      # the first point is parameterized at zero
 
     Finally, we consider what is sometimes called the *centripetal*
     parametrization: :math:`u_j = u_{j-1} + |\mathbf{p}_j - \mathbf{p}_{j-1}|^{1/2}`.
     Due to the extra square root, the difference between consecutive values
-    :math:`u_j - u_{j-1}` will be smaller than for the cord length parametrization: 
+    :math:`u_j - u_{j-1}` will be smaller than for the chord length parametrization: 
 
     >>> u_c = np.r_[0, np.cumsum((dp**2).sum(axis=0)**0.25)]
 
@@ -307,9 +307,9 @@ Chapter 6 of Ref [1] listed in the `BSpline` docstring:
     >>> from scipy.interpolate import make_interp_spline
     >>> import matplotlib.pyplot as plt
     >>> fig, ax = plt.subplots(1, 3, figsize=(8, 3))
-    >>> parametrizations = ['uniform', 'cord length', 'centripetal']
+    >>> parametrizations = ['uniform', 'chord length', 'centripetal']
     >>>
-    >>> for j, u in enumerate([u_unif, u_cord, u_c]):
+    >>> for j, u in enumerate([u_unif, u_chord, u_c]):
     ...    spl = make_interp_spline(u, p, axis=1)    # note p is a 2D array
     ...    
     ...    uu = np.linspace(u[0], u[-1], 51)

--- a/doc/source/tutorial/interpolate/1D.rst
+++ b/doc/source/tutorial/interpolate/1D.rst
@@ -45,7 +45,7 @@ Cubic splines
 Of course, piecewise linear interpolation produces corners at data points,
 where the linear pieces join. To produce a smoother curve, you can use cubic
 splines, where the interpolating curve is made of cubic pieces with matching
-first and second derivatives. In code, these objects are represented by instances of the 
+first and second derivatives. In code, these objects are represented by instances of the
 ``CubicSpline`` class. An instance is constructed with the ``x`` and
 ``y`` arrays of data, and then it can be evaluated using the target ``xnew``
 values:

--- a/doc/source/tutorial/interpolate/ND_regular_grid.rst
+++ b/doc/source/tutorial/interpolate/ND_regular_grid.rst
@@ -3,7 +3,7 @@
 .. currentmodule:: scipy.interpolate
 
 =====================================================================================
-Multivariate data interpolation on a regular grid  (:class:`RegularGridInterpolator`)
+Multivariate data interpolation on a regular grid (:class:`RegularGridInterpolator`)
 =====================================================================================
 
 Suppose you have N-dimensional data on a regular grid, and you
@@ -120,7 +120,7 @@ In accordance with how :ref:`1D interpolators
 interpret multidimensional arrays <tutorial-interpolate_batching>`, the interpretation is
 that the first :math:`N` dimensions of the ``values`` arrays are data dimensions
 (i.e. they correspond to the points defined by the ``grid`` argument), and the *trailing*
-dimensions are batch axes. Note that this disagrees with a usual NumPy broadcasting
+dimensions are batch axes. Note that this disagrees with the usual NumPy broadcasting
 conventions, where broadcasting proceeds along the *leading* dimensions.
 
 To illustrate:
@@ -173,8 +173,10 @@ using `scipy.ndimage.map_coordinates` instead.
 
 For floating-point data on grids with equal spacing, ``map_coordinates`` can
 be easily wrapped into a `RegularGridInterpolator` look-alike. The following is
-a bare-bones example originating from `the Johanness Buchner's
+a bare-bones example originating from `the Johannes Buchner's
 'regulargrid' package <https://github.com/JohannesBuchner/regulargrid/>`_::
+
+    from scipy.ndimage import map_coordinates
 
     class CartesianGridInterpolator:
         def __init__(self, points, values, method='linear'):

--- a/doc/source/tutorial/interpolate/ND_unstructured.rst
+++ b/doc/source/tutorial/interpolate/ND_unstructured.rst
@@ -115,7 +115,7 @@ classes from the `scipy.interpolate` module.
     >>> ius = InterpolatedUnivariateSpline(x, y)
     >>> yi = ius(xi)
 
-    >>> fix, (ax1, ax2) = plt.subplots(2, 1)
+    >>> fig, (ax1, ax2) = plt.subplots(2, 1)
     >>> ax1.plot(x, y, 'bo')
     >>> ax1.plot(xi, yi, 'g')
     >>> ax1.plot(xi, np.sin(xi), 'r')

--- a/doc/source/tutorial/interpolate/extrapolation_examples.rst
+++ b/doc/source/tutorial/interpolate/extrapolation_examples.rst
@@ -77,7 +77,7 @@ To illustrate:
     xnew = np.linspace(-np.pi, 2.5*np.pi, 51)
     ynew = clipped(xnew, bare_func, x, y)
 
-    fix, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4))
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(8, 4))
     ax1.plot(xnew, ynew[:, 0])
     ax1.plot(x, y[:, 0], 'o')
 
@@ -86,7 +86,7 @@ To illustrate:
     plt.tight_layout()
 
 
-The snippet above is straightforward to adapt for other ways of handing out-of-bounds
+The snippet above is straightforward to adapt for other ways of handling out-of-bounds
 values, such as raising errors; see also :ref:`tutorial-extrapolation-asymptotics` for a
 variation where we match in-bounds interpolation with known out-of-bounds asymptotic
 functions.
@@ -206,7 +206,7 @@ extrapolation proceeds using these two additional intervals.
     # not-a-knot does not require additional intervals
 
     natural = CubicSpline(xs,ys, bc_type='natural')
-    # extend the natural natural spline with linear extrapolating knots
+    # extend the natural spline with linear extrapolating knots
     add_boundary_knots(natural)
 
     clamped = CubicSpline(xs,ys, bc_type='clamped')
@@ -283,7 +283,7 @@ of roots due to periodicity of the ``tan`` function), repeated calls to
 
 To circumvent this difficulty, we tabulate :math:`y = ax - 1/\tan{x}`
 and interpolate it on the tabulated grid. In fact, we will use the *inverse*
-interpolation: we interpolate the values of :math:`x` versus :math:`у`.
+interpolation: we interpolate the values of :math:`x` versus :math:`y`.
 This way, solving the original equation becomes simply an evaluation of
 the interpolated function at zero :math:`y` argument.
 
@@ -374,7 +374,7 @@ implementation may look like this
         def root(self):
             out = self.spl(0)
             asympt = 1./np.sqrt(self.a)
-            return np.where(spl.x.min() < asympt, out, asympt)
+            return np.where(self.spl.x.min() < asympt, out, asympt)
 
 And then
 

--- a/doc/source/tutorial/interpolate/interp_transition_guide.md
+++ b/doc/source/tutorial/interpolate/interp_transition_guide.md
@@ -9,7 +9,7 @@ This page contains three sets of demonstrations:
 
 ## 1. How to transition away from using  `interp2d`
 
-`interp2d` silently switches between interpolation on a 2D regular grid and interpolating 2D scattered data. The switch is based on the lengths of the (raveled) `x`, `y`, and `z` arrays. In short, for regular grid use {class}`scipy.interpolate.RectBivariateSpline`; for scattered interpolation, use the `bisprep/bisplev` combo. Below we give examples of the literal point-for-point transition, which should preserve the `interp2d` results exactly.
+`interp2d` silently switches between interpolation on a 2D regular grid and interpolating 2D scattered data. The switch is based on the lengths of the (raveled) `x`, `y`, and `z` arrays. In short, for regular grid use {class}`scipy.interpolate.RectBivariateSpline`; for scattered interpolation, use the `bisplrep/bisplev` combo. Below we give examples of the literal point-for-point transition, which should preserve the `interp2d` results exactly.
 
 ### 1.1 `interp2d` on a regular grid
 
@@ -208,7 +208,7 @@ interpolation function.](plots/output_28_1.png)
 
 ## 3. Scattered 2D linear interpolation: prefer `LinearNDInterpolator` to `SmoothBivariateSpline`  or `bisplrep`
 
-For 2D scattered linear interpolation, both `SmoothBivariateSpline` and `biplrep` may either emit warnings, or fail to interpolate the data, or produce splines which with knots away from the data points. Instead, prefer `LinearNDInterpolator`, which is based on triangulating the data via `QHull`.
+For 2D scattered linear interpolation, both `SmoothBivariateSpline` and `bisplrep` may either emit warnings, or fail to interpolate the data, or produce splines with knots away from the data points. Instead, prefer `LinearNDInterpolator`, which is based on triangulating the data via `QHull`.
 
 ```
 # TestSmoothBivariateSpline::test_integral

--- a/doc/source/tutorial/interpolate/smoothing_splines.rst
+++ b/doc/source/tutorial/interpolate/smoothing_splines.rst
@@ -11,10 +11,10 @@ Spline smoothing in 1D
 
 For the interpolation problem, the task is to construct a curve which passes
 through a given set of data points. This may be not appropriate if the data is
-noisy: we then want to construct a smooth curve, :math:`g(x)`, which *approximates*
-input data without passing through each point exactly.
+noisy: we may instead want to construct a smooth curve, :math:`g(x)`, 
+which *approximates* the input data without passing through each point exactly.
 
-To this end, `scipy.interpolate` allows constructing *smoothing splines* which
+To this end, `scipy.interpolate` allows constructing *smoothing splines* that
 balance how close the resulting curve, :math:`g(x)`, is to the data, and 
 the smoothness of :math:`g(x)`. Mathematically, the task is to solve
 a penalized least-squares problem, where the penalty controls the smoothness of
@@ -296,7 +296,7 @@ where :math:`\sigma` is an estimate for the standard deviation of the data.
 
 .. note::
 
-    The number of knots a very strongly dependent on ``s``. It is possible that
+    The number of knots is very strongly dependent on ``s``. It is possible that
     small variations of ``s`` lead to drastic changes in the knot number.
 
 .. note::
@@ -350,7 +350,7 @@ The main user-visible difference of the parametric case is the user interface:
 - the return value is pair: a `BSpline` instance and the array of parameter
   values, ``u``, which corresponds to the input data arrays.
 
-By default, `make_splprep` constructs and returns the cord length parametrization
+By default, `make_splprep` constructs and returns the chord length parametrization
 of input data (see the :ref:`Parametric spline curves <tutorial-interpolate_parametric>`
 section for details). Alternatively, you can provide your own array of
 parameter values, ``u``.
@@ -828,7 +828,7 @@ on the data while determining the appropriate spline. The recommended values
 for :math:`s` depend on the weights :math:`w_i`. If these are taken as :math:`1/d_i`,
 with :math:`d_i` an estimate of the standard deviation of :math:`z_i`, a
 good value of :math:`s` should be found in the range :math:`m- \sqrt{2m}, m + 
-\sqrt{2m}`, where where :math:`m` is the number of data points in the ``x``,
+\sqrt{2m}`, where :math:`m` is the number of data points in the ``x``,
 ``y``, and ``z`` vectors.
 
 The default value is :math:`s=m-\sqrt{2m}`.  As a result, **if no smoothing is

--- a/doc/source/tutorial/interpolate/splines_and_polynomials.rst
+++ b/doc/source/tutorial/interpolate/splines_and_polynomials.rst
@@ -19,7 +19,7 @@ A polynomial of degree :math:`k` can be thought of as a linear combination of
 In some applications, it is useful to consider alternative (if formally
 equivalent) bases. Two popular bases, implemented in `scipy.interpolate` are
 B-splines (`BSpline`) and Bernstein polynomials (`BPoly`).
-B-splines are often used for, for example, non-parametric regression problems,
+B-splines are often used, for example, in non-parametric regression problems,
 and Bernstein polynomials are used for constructing Bezier curves.
 
 `PPoly` objects represent piecewise polynomials in the 'usual' power basis.
@@ -75,9 +75,9 @@ the ``dspl`` object, we can find the zeros of the derivative of ``spl``:
     >>> dspl.roots() / np.pi
     array([-0.45480801,  0.50000034,  1.50000099,  2.5000016 ,  3.46249993])
 
-This agrees well with roots :math:`\pi/2 + \pi\,n` of
+This agrees well with the roots :math:`\pi/2 + \pi\,n` of
 :math:`\cos(x) = \sin'(x)`.
-Note that by default it computed the roots *extrapolated* to the outside of
+Note that by default it computes the roots *extrapolated* to the outside of
 the interpolation interval :math:`0 \leqslant x \leqslant 10`, and that
 the extrapolated results (the first and last values) are much less accurate.
 We can switch off the extrapolation and limit the root-finding to the
@@ -86,7 +86,7 @@ interpolation interval:
     >>> dspl.roots(extrapolate=False) / np.pi
     array([0.50000034,  1.50000099,  2.5000016])
 
-In fact, the ``root`` method is a special case of a more general ``solve``
+In fact, the ``roots`` method is a special case of a more general ``solve``
 method which finds for a given constant :math:`y` the solutions of the
 equation :math:`f(x) = y` , where :math:`f(x)` is the piecewise polynomial:
 
@@ -106,7 +106,7 @@ example, we compute an approximation to the complete elliptic integral
     1.8540746773013719
 
 To this end, we tabulate the integrand and interpolate it using the monotone
-PCHIP interpolant (we could as well used a `CubicSpline`):
+PCHIP interpolant (we could as well have used a `CubicSpline`):
 
     >>> from scipy.interpolate import PchipInterpolator
     >>> x = np.linspace(0, np.pi/2, 70)
@@ -121,7 +121,7 @@ and integrate
 which is indeed close to the value computed by `scipy.special.ellipk`.
 
 All piecewise polynomials can be constructed with N-dimensional ``y`` values.
-If ``y.ndim > 1``, it is understood as a stack of 1D ``y`` values, which are
+If ``y.ndim > 1``, it is interpreted as a stack of 1D ``y`` values, which are
 arranged along the interpolation axis (with the default value of 0).
 The latter is specified via the ``axis`` argument, and the invariant is that
 ``len(x) == y.shape[axis]``. As an example, we extend the elliptic integral


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
Fix typos in https://docs.scipy.org/doc/scipy/tutorial/interpolate.html

#### Additional information
<!--Any additional information you think is important.-->
None

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

ChatGPT helped me find some of the typos.
