### PR TITLE
BUG: linalg: fix int overflow in complex Cholesky wrappers

### DIFF
--- a/scipy/linalg/flapack_pos_def.pyf.src
+++ b/scipy/linalg/flapack_pos_def.pyf.src
@@ -149,7 +149,7 @@ subroutine <prefix2c>potrf(n,a,lda,info,lower,clean)
     ! C is triangular matrix of the corresponding Cholesky decomposition.
     ! clean==1 zeros strictly lower or upper parts of U or L, respectively
  
-    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){F_INT i,j,k;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=j*n+i;(a+k)->r=(a+k)->i=0.0;}} else {for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=i*n+j;(a+k)->r=(a+k)->i=0.0;}}}
+    callstatement (*f2py_func)((lower?"L":"U"),&n,a,&lda,&info); if(clean){Py_ssize_t i,j,k;if(lower){for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=j*n+i;(a+k)->r=(a+k)->i=0.0;}} else {for(i=0;i\<n;++i) for(j=i+1;j\<n;++j) {k=i*n+j;(a+k)->r=(a+k)->i=0.0;}}}
     callprotoargument char*,F_INT*,<ctype2c>*,F_INT*,F_INT*
  
     integer optional,intent(in),check(lower==0||lower==1) :: lower = 0


### PR DESCRIPTION
Indexing flat arrays with `F_INT` type overflows `INT_MAX` in the LP64 build. 

The fix is similar to https://github.com/scipy/scipy/pull/20229 which fixed the issue for real matrices, but missed the fact that f2py wrappers are duplicated for real and complex arrays (note `prefix2` and `prefix2c`, https://github.com/scipy/scipy/blob/main/scipy/linalg/flapack.pyf.src#L13-L14)

Am not adding a dedicated test: an exactly similar test has been added in gh-20229  and marked at `xslow` (thus does not really run unless with an env variable).

no AI.

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
