### PR TITLE
Fix formatting of error message in _minpack_py.py

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -34,7 +34,7 @@ def _check_func(checker, argname, thefunc, x0, args, numinputs,
                 msg += f" '{func_name}'."
             else:
                 msg += "."
-            msg += f'Shape should be {output_shape} but it is {shape(res)}.'
+            msg += f' Shape should be {output_shape} but it is {shape(res)}.'
             raise TypeError(msg)
     if issubdtype(res.dtype, inexact):
         dt = res.dtype


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### What does this implement/fix?
Error message may appear without a whitespace after the dot. For example:
`TypeError: fsolve: there is a mismatch between the input and output shape of the 'func' argument '_wrapped_func'.Shape should be (11,) but it is (9,).`

#### Reference issue
None found. [Link](https://github.com/scipy/scipy/issues?q=sort%3Aupdated-desc%20_minpack_py.py%20error%20message%20whitespace).

#### Additional information
Version:

```bash
venv ❯ pip list | grep scipy
scipy                   1.17.1
```
(docs still show 1.17.0 as latest stable release, thou)

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
Commit message was autogenerated.