### PR TITLE
DOC: fix typo in contributor guide

### DIFF
--- a/doc/source/dev/contributor/development_workflow.rst
+++ b/doc/source/dev/contributor/development_workflow.rst
@@ -10,7 +10,7 @@ reading to see an example of fixing a bug and submitting a pull request.*
 This guide assumes that you have created your own fork (copy) of the SciPy
 repository, cloned the repository on your own machine, and built SciPy from this
 source code. If you haven't, check the :ref:`building-from-source` pages appropriate to your
-system. Before getting started here, there are two other things you need to do
+system. Before getting started here, there are three other things you need to do
 just once before you start modifying SciPy.
 
 #. In a terminal, introduce yourself to Git::


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
The contributor guide describes a list of three items as having two items. Fix this.

#### AI Generation Disclosure
No AI tools used
