### PR TITLE
ENH: spatial.distance: add support for nd inputs to minkowski/euclidean/seuclidean

### DIFF
--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -460,7 +460,7 @@ def minkowski(u, v, p=2, w=None):
 
     Returns
     -------
-    minkowski : double
+    minkowski : float or ndarray
         The Minkowski distance between vectors `u` and `v`.
 
     Examples
@@ -525,7 +525,7 @@ def euclidean(u, v, w=None):
 
     Returns
     -------
-    euclidean : double
+    euclidean : float or ndarray
         The Euclidean distance between vectors `u` and `v`.
 
     Examples
@@ -562,7 +562,7 @@ def sqeuclidean(u, v, w=None):
 
     Returns
     -------
-    sqeuclidean : double
+    sqeuclidean : float or ndarray
         The squared Euclidean distance between vectors `u` and `v`.
 
     Examples

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -432,9 +432,9 @@ def directed_hausdorff(u, v, rng=0):
 
 def minkowski(u, v, p=2, w=None):
     """
-    Compute the Minkowski distance between two 1-D arrays.
+    Compute the Minkowski distance between two arrays.
 
-    The Minkowski distance between 1-D arrays `u` and `v`,
+    The Minkowski distance between arrays `u` and `v`,
     is defined as
 
     .. math::
@@ -446,9 +446,9 @@ def minkowski(u, v, p=2, w=None):
 
     Parameters
     ----------
-    u : (N,) array_like
+    u : (..., N) array_like
         Input array.
-    v : (N,) array_like
+    v : (..., N) array_like
         Input array.
     p : scalar
         The order of the norm of the difference :math:`{\\|u-v\\|}_p`. Note
@@ -480,8 +480,8 @@ def minkowski(u, v, p=2, w=None):
     1.0
 
     """
-    u = _validate_vector(u)
-    v = _validate_vector(v)
+    u = np.asarray(u)
+    v = np.asarray(v)
     if p <= 0:
         raise ValueError("p must be greater than 0")
     u_v = u - v
@@ -497,15 +497,15 @@ def minkowski(u, v, p=2, w=None):
         else:
             root_w = np.power(w, 1/p)
         u_v = root_w * u_v
-    dist = norm(u_v, ord=p)
+    dist = norm(u_v, ord=p, axis=-1)
     return dist
 
 
 def euclidean(u, v, w=None):
     """
-    Computes the Euclidean distance between two 1-D arrays.
+    Computes the Euclidean distance between two arrays.
 
-    The Euclidean distance between 1-D arrays `u` and `v`, is defined as
+    The Euclidean distance between arrays `u` and `v`, is defined as
 
     .. math::
 
@@ -515,9 +515,9 @@ def euclidean(u, v, w=None):
 
     Parameters
     ----------
-    u : (N,) array_like
+    u : (..., N) array_like
         Input array.
-    v : (N,) array_like
+    v : (..., N) array_like
         Input array.
     w : (N,) array_like, optional
         The weights for each value in `u` and `v`. Default is None,
@@ -542,7 +542,7 @@ def euclidean(u, v, w=None):
 
 def sqeuclidean(u, v, w=None):
     """
-    Compute the squared Euclidean distance between two 1-D arrays.
+    Compute the squared Euclidean distance between two arrays.
 
     The squared Euclidean distance between `u` and `v` is defined as
 
@@ -552,9 +552,9 @@ def sqeuclidean(u, v, w=None):
 
     Parameters
     ----------
-    u : (N,) array_like
+    u : (..., N) array_like
         Input array.
-    v : (N,) array_like
+    v : (..., N) array_like
         Input array.
     w : (N,) array_like, optional
         The weights for each value in `u` and `v`. Default is None,
@@ -582,14 +582,14 @@ def sqeuclidean(u, v, w=None):
     if not (hasattr(v, "dtype") and np.issubdtype(v.dtype, np.inexact)):
         vtype = np.float64
 
-    u = _validate_vector(u, dtype=utype)
-    v = _validate_vector(v, dtype=vtype)
+    u = np.asarray(u, dtype=utype)
+    v = np.asarray(v, dtype=vtype)
     u_v = u - v
     u_v_w = u_v  # only want weights applied once
     if w is not None:
         w = _validate_weights(w)
         u_v_w = w * u_v
-    return np.dot(u_v, u_v_w)
+    return np.vecdot(u_v, u_v_w)
 
 
 def correlation(u, v, w=None, centered=True):
@@ -2317,7 +2317,7 @@ def is_valid_dm(D, tol=0.0, throw=False, name="D", warning=False):
 
     The triangle inequality states that for any three points ``i``, ``j``, and ``k``:
     ``D[i,k] <= D[i,j] + D[j,k]``
-    
+
     Parameters
     ----------
     D : array_like
@@ -2333,7 +2333,7 @@ def is_valid_dm(D, tol=0.0, throw=False, name="D", warning=False):
         `throw` is True to identify the offending variable.
     warning : bool, optional
         If True, a warning message is raised instead of throwing an exception.
-        
+
     Returns
     -------
     valid : bool

--- a/scipy/spatial/distance.py
+++ b/scipy/spatial/distance.py
@@ -480,8 +480,8 @@ def minkowski(u, v, p=2, w=None):
     1.0
 
     """
-    u = np.asarray(u)
-    v = np.asarray(v)
+    u = _asarray(u, order='C')
+    v = _asarray(v, order='C')
     if p <= 0:
         raise ValueError("p must be greater than 0")
     u_v = u - v
@@ -582,8 +582,8 @@ def sqeuclidean(u, v, w=None):
     if not (hasattr(v, "dtype") and np.issubdtype(v.dtype, np.inexact)):
         vtype = np.float64
 
-    u = np.asarray(u, dtype=utype)
-    v = np.asarray(v, dtype=vtype)
+    u = _asarray(u, dtype=utype, order='C')
+    v = _asarray(v, dtype=vtype, order='C')
     u_v = u - v
     u_v_w = u_v  # only want weights applied once
     if w is not None:

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -60,7 +60,7 @@ from scipy.spatial.distance import (braycurtis, canberra, chebyshev, cityblock,
                                     minkowski, rogerstanimoto,
                                     russellrao, seuclidean,  # noqa: F401
                                     sokalsneath, sqeuclidean, yule)
-from scipy._lib._util import np_long, np_ulong
+from scipy._lib._util import np_long, np_ulong, _apply_over_batch
 from scipy.conftest import skip_xp_invalid_arg
 
 
@@ -2283,21 +2283,14 @@ class TestChebyshev:
 @pytest.mark.parametrize("weights", [True, False])
 def test_distance_nd(func, p, weights):
     rng = np.random.default_rng(6738657865438)
+    ref_func = _apply_over_batch(('u', 1), ('v', 1), ('p', 1), ('w', 1))(func)
 
     u = rng.random((5, 2, 4))
     v = rng.random((2, 4))
     w = rng.random(4) if weights else None
+    kwargs = {'w': w} if p is None else {'p': p, 'w': w}
 
-    if p is None:
-        res = func(u, v, w=w)
-    else:
-        res = func(u, v, p=p, w=w)
-
-    ref = np.empty((5, 2))
-    for i, j in np.ndindex(ref.shape):
-        if p is None:
-            ref[i, j] = func(u[i, j], v[j], w=w)
-        else:
-            ref[i, j] = func(u[i, j], v[j], p=p, w=w)
+    res = func(u, v, **kwargs)
+    ref = ref_func(u, v, **kwargs)
 
     assert_allclose(res, ref)

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2282,7 +2282,7 @@ class TestChebyshev:
 )
 @pytest.mark.parametrize("weights", [True, False])
 def test_distance_nd(func, p, weights):
-     # check that inputs broadcast correctly against a reference implementation
+    #  check that inputs broadcast correctly against a reference implementation
     rng = np.random.default_rng(6738657865438)
     ref_func = _apply_over_batch(('u', 1), ('v', 1), ('p', 1), ('w', 1))(func)
 

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -1883,21 +1883,6 @@ def test_euclideans():
     assert_almost_equal(wsqeuclidean(x1, x2), 3.0, decimal=14)
     assert_almost_equal(weuclidean(x1, x2), np.sqrt(3), decimal=14)
 
-    # Check flattening for (1, N) or (N, 1) inputs
-    with pytest.raises(ValueError, match="Input vector should be 1-D"):
-        weuclidean(x1[np.newaxis, :], x2[np.newaxis, :]), np.sqrt(3)
-    with pytest.raises(ValueError, match="Input vector should be 1-D"):
-        wsqeuclidean(x1[np.newaxis, :], x2[np.newaxis, :])
-    with pytest.raises(ValueError, match="Input vector should be 1-D"):
-        wsqeuclidean(x1[:, np.newaxis], x2[:, np.newaxis])
-
-    # Distance metrics only defined for vectors (= 1-D)
-    x = np.arange(4).reshape(2, 2)
-    with pytest.raises(ValueError):
-        weuclidean(x, x)
-    with pytest.raises(ValueError):
-        wsqeuclidean(x, x)
-
     # Another check, with random data.
     rs = np.random.RandomState(1234567890)
     x = rs.rand(10)
@@ -2282,3 +2267,37 @@ class TestChebyshev:
         assert_equal(chebyshev(x, y, w), 0)
         assert_equal(pdist([x, y], 'chebyshev', w=w), [0])
         assert_equal(cdist([x], [y], 'chebyshev', w=w), [[0]])
+
+
+@pytest.mark.parametrize(
+    "func,p",
+    [
+        (minkowski, 1),
+        (minkowski, 2),
+        (minkowski, 3.5),
+        (minkowski, np.inf),
+        (euclidean, None),
+        (sqeuclidean, None),
+    ],
+)
+@pytest.mark.parametrize("weights", [True, False])
+def test_distance_nd(func, p, weights):
+    rng = np.random.default_rng(6738657865438)
+
+    u = rng.random((5, 2, 4))
+    v = rng.random((2, 4))
+    w = rng.random(4) if weights else None
+
+    if p is None:
+        res = func(u, v, w=w)
+    else:
+        res = func(u, v, p=p, w=w)
+
+    ref = np.empty((5, 2))
+    for i, j in np.ndindex(ref.shape):
+        if p is None:
+            ref[i, j] = func(u[i, j], v[j], w=w)
+        else:
+            ref[i, j] = func(u[i, j], v[j], p=p, w=w)
+
+    assert_allclose(res, ref)

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -2282,6 +2282,7 @@ class TestChebyshev:
 )
 @pytest.mark.parametrize("weights", [True, False])
 def test_distance_nd(func, p, weights):
+     # check that inputs broadcast correctly against a reference implementation
     rng = np.random.default_rng(6738657865438)
     ref_func = _apply_over_batch(('u', 1), ('v', 1), ('p', 1), ('w', 1))(func)
 


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/pull/24710#pullrequestreview-3884987564
#### What does this implement/fix?
<!--Please explain your changes.-->
As discussed in the linked issue we would like to phase out `minkowski_distance` in favour of `scipy.spatial.distance.minkowski`. However the only advantage that `minkowski_distance` has in its favour is that it supports nd inputs. This PR adds feature parity between the two. 
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I originally had two separate tests which I asked ChatGPT to combine.