### PR TITLE
ENH: add `condition` to {skip,xfail}_xp_backends

### DIFF
--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -412,6 +412,26 @@ def _backends_kwargs_from_request(request, skip_or_xfail):
                 if kwarg in marker.kwargs:
                     raise ValueError(f"{kwarg} is mutually exclusive with {backend}")
 
+        elif len(marker.args) == 2 and isinstance(marker.args[1], bool | type(None)):
+            # condition is provided:
+            #   1. check it
+            #   2. reason is required (similar to pytest's xfail/skipif)
+            backend, condition = marker.args
+
+            if backend not in xp_known_backends:
+                raise ValueError(f"Unknown backend: {backend}; "
+                                 f"must be one of {list(xp_known_backends)}")
+
+            if condition:
+                reason = marker.kwargs.get("reason")
+                # reason overrides the ones from cpu_only, np_only, and eager_only.
+                # This is regardless of order of appearence of the markers.
+                reasons[backend].insert(0, reason)
+
+            for kwarg in ("cpu_only", "np_only", "eager_only", "exceptions"):
+                if kwarg in marker.kwargs:
+                    raise ValueError(f"{kwarg} is mutually exclusive with {backend}")
+
         elif len(marker.args) > 1:
             raise ValueError(
                 f"Please specify only one backend per marker: {marker.args}"
@@ -438,11 +458,13 @@ def skip_or_xfail_xp_backends(request: pytest.FixtureRequest,
         ...
 
         @skip_xp_backends(backend, *, reason=None)
+        @skip_xp_backends(backend, condition, /, *, reason='skip because condition')
         @skip_xp_backends(*, cpu_only=True, exceptions=(), reason=None)
         @skip_xp_backends(*, eager_only=True, exceptions=(), reason=None)
         @skip_xp_backends(*, np_only=True, exceptions=(), reason=None)
 
         @xfail_xp_backends(backend, *, reason=None)
+        @xfail_xp_backends(backend, condition, /, *, reason='xfail because condition')
         @xfail_xp_backends(*, cpu_only=True, exceptions=(), reason=None)
         @xfail_xp_backends(*, eager_only=True, exceptions=(), reason=None)
         @xfail_xp_backends(*, np_only=True, exceptions=(), reason=None)

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -425,7 +425,7 @@ def _backends_kwargs_from_request(request, skip_or_xfail):
             if condition:
                 reason = marker.kwargs.get("reason")
                 # reason overrides the ones from cpu_only, np_only, and eager_only.
-                # This is regardless of order of appearence of the markers.
+                # This is regardless of order of appearance of the markers.
                 reasons[backend].insert(0, reason)
 
             for kwarg in ("cpu_only", "np_only", "eager_only", "exceptions"):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -503,6 +503,10 @@ class TestNdimageFilters:
         assert output.dtype.type == xp.float32
 
     @make_xp_test_case(ndimage.correlate, ndimage.convolve)
+    @xfail_xp_backends(
+        "cupy", CUPY_VERSION and CUPY_VERSION >= "14",
+        reason="multiple modes work in CuPy 14"
+    )
     def test_correlate_mode_sequence(self, xp):
         if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
             pytest.xfail("multiple modes work in CuPy 14")
@@ -1715,6 +1719,10 @@ class TestNdimageFilters:
         assert_array_almost_equal(output2, output)
 
     @make_xp_test_case(ndimage.minimum_filter)
+    @xfail_xp_backends(
+        "cupy", CUPY_VERSION and CUPY_VERSION >= "14",
+        reason="multiple modes work in CuPy 14"
+    )
     def test_minimum_filter07(self, xp):
         if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
             pytest.xfail("multiple modes work in CuPy 14")
@@ -1810,6 +1818,10 @@ class TestNdimageFilters:
         assert_array_almost_equal(output2, output)
 
     @make_xp_test_case(ndimage.maximum_filter)
+    @xfail_xp_backends(
+        "cupy", CUPY_VERSION and CUPY_VERSION >= "14",
+        reason="multiple modes work in CuPy 14"
+    )
     def test_maximum_filter07(self, xp):
         if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
             pytest.xfail("multiple modes work in CuPy 14")
@@ -2003,10 +2015,11 @@ class TestNdimageFilters:
     @make_xp_test_case(
         ndimage.rank_filter, ndimage.percentile_filter, ndimage.median_filter
     )
+    @xfail_xp_backends(
+        "cupy", CUPY_VERSION and CUPY_VERSION >= "14",
+        reason="multiple modes work in CuPy 14"
+    )
     def test_rank08_1(self, xp):
-        if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
-            pytest.xfail("multiple modes work in CuPy 14")
-
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [5, 8, 3, 7, 1],
                             [5, 6, 9, 3, 5]])
@@ -2621,6 +2634,10 @@ def test_multiple_modes_sequentially(xp):
 
 
 @make_xp_test_case(ndimage.prewitt)
+@xfail_xp_backends(
+    "cupy", CUPY_VERSION and CUPY_VERSION >= "14",
+    reason="https://github.com/cupy/cupy/issues/9760"
+)
 def test_multiple_modes_prewitt(xp):
     # Test prewitt filter for multiple extrapolation modes
     if is_cupy(xp):
@@ -2641,6 +2658,10 @@ def test_multiple_modes_prewitt(xp):
 
 
 @make_xp_test_case(ndimage.sobel)
+@xfail_xp_backends(
+    "cupy", CUPY_VERSION and CUPY_VERSION >= "14",
+    reason="https://github.com/cupy/cupy/issues/9760"
+)
 def test_multiple_modes_sobel(xp):
     # Test sobel filter for multiple extrapolation modes
     if is_cupy(xp):

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -508,8 +508,6 @@ class TestNdimageFilters:
         reason="multiple modes work in CuPy 14"
     )
     def test_correlate_mode_sequence(self, xp):
-        if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
-            pytest.xfail("multiple modes work in CuPy 14")
 
         kernel = xp.ones((2, 2))
         array = xp.ones((3, 3), dtype=xp.float64)
@@ -1724,8 +1722,6 @@ class TestNdimageFilters:
         reason="multiple modes work in CuPy 14"
     )
     def test_minimum_filter07(self, xp):
-        if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
-            pytest.xfail("multiple modes work in CuPy 14")
 
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -1823,8 +1819,6 @@ class TestNdimageFilters:
         reason="multiple modes work in CuPy 14"
     )
     def test_maximum_filter07(self, xp):
-        if is_cupy(xp) and CUPY_VERSION and CUPY_VERSION >= "14":
-            pytest.xfail("multiple modes work in CuPy 14")
 
         array = xp.asarray([[3, 2, 5, 1, 4],
                             [7, 6, 9, 3, 5],
@@ -2641,7 +2635,6 @@ def test_multiple_modes_sequentially(xp):
 def test_multiple_modes_prewitt(xp):
     # Test prewitt filter for multiple extrapolation modes
     if is_cupy(xp):
-        pytest.xfail("https://github.com/cupy/cupy/issues/9760")
 
     arr = xp.asarray([[1., 0., 0.],
                       [1., 1., 0.],
@@ -2665,7 +2658,6 @@ def test_multiple_modes_prewitt(xp):
 def test_multiple_modes_sobel(xp):
     # Test sobel filter for multiple extrapolation modes
     if is_cupy(xp):
-        pytest.xfail("https://github.com/cupy/cupy/issues/9760")
 
     arr = xp.asarray([[1., 0., 0.],
                       [1., 1., 0.],

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2634,7 +2634,6 @@ def test_multiple_modes_sequentially(xp):
 )
 def test_multiple_modes_prewitt(xp):
     # Test prewitt filter for multiple extrapolation modes
-    if is_cupy(xp):
 
     arr = xp.asarray([[1., 0., 0.],
                       [1., 1., 0.],
@@ -2657,7 +2656,6 @@ def test_multiple_modes_prewitt(xp):
 )
 def test_multiple_modes_sobel(xp):
     # Test sobel filter for multiple extrapolation modes
-    if is_cupy(xp):
 
     arr = xp.asarray([[1., 0., 0.],
                       [1., 1., 0.],


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

follows up https://github.com/scipy/scipy/pull/24719 ; cf https://github.com/data-apis/array-api-compat/issues/366

#### What does this implement/fix?
<!--Please explain your changes.-->

Add a `condition` clause to `{skip,xfail}_xp_backends` to allow for e.g. version-dependent skips, as in: "this test fails with CuPy 13 and passes with CuPy 14".

Model the API after pytest's `skipif` and `xfail` marks: 
- `condition` argument is positional only
- if there's a condition, a `reason` is required

On top of that, `np_only=True, condition=...` can only accompany a specific backend, not `np_only` etc. I'd consider that interaction when we have a use case, which I don't see ATM.

#### Additional information
<!--Any additional information you think is important.-->

An alternative design would be to use the packaging.requirements syntax: `@skip_xp_backends("cupy<14", reason="...")`. This looks nicer in simpler cases, but gets clunky where a backend is a subpackage: `jax.numpy < 1` is wrong, because it is the top-level `jax` which is versioned, not its `jax.numpy` subpackage.

 

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai