### PR TITLE
DOC/DEV: Change instances of mamba to conda

### DIFF
--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -32,7 +32,7 @@ your system.
     If you are using Conda, you can skip the steps in this section - with the
     exception of installing compilers for Windows or the Apple Developer Tools
     for macOS. All other dependencies will be installed automatically by the
-    ``mamba env create -f environment.yml`` command.
+    ``conda env create -f environment.yml`` command.
 
 .. tab-set::
 
@@ -248,10 +248,10 @@ Building from source to use SciPy
     environment::
 
       # Either install all SciPy dev dependencies into a fresh conda environment
-      mamba env create -f environment.yml
+      conda env create -f environment.yml
 
       # Or, install only the required build dependencies
-      mamba install python numpy cython pythran pybind11 compilers openblas meson-python pkg-config
+      conda install python numpy cython pythran pybind11 compilers openblas meson-python pkg-config
 
       # To build the latest stable release:
       pip install scipy --no-build-isolation --no-binary scipy
@@ -326,8 +326,8 @@ virtual environments:
     To create a ``scipy-dev`` development environment with every required and
     optional dependency installed, run::
 
-        mamba env create -f environment.yml
-        mamba activate scipy-dev
+        conda env create -f environment.yml
+        conda activate scipy-dev
 
   .. tab-item:: Virtual env or system Python
     :sync: pip

--- a/doc/source/building/understanding_meson.rst
+++ b/doc/source/building/understanding_meson.rst
@@ -55,8 +55,8 @@ Assume we're starting from a clean repo and a fully set up conda environment::
 
   git clone git@github.com:scipy/scipy.git
   git submodule update --init
-  mamba env create -f environment.yml
-  mamba activate scipy-dev
+  conda env create -f environment.yml
+  conda activate scipy-dev
 
 To now run the configure stage of the build and instruct Meson to put the build
 artifacts in ``build/`` and a local install under ``build-install/`` relative

--- a/doc/source/dev/contributor/debugging_linalg_issues.rst
+++ b/doc/source/dev/contributor/debugging_linalg_issues.rst
@@ -138,20 +138,20 @@ distros. For example, to create a conda environment with the latest SciPy
 release installed and then switching between OpenBLAS, Netlib BLAS/LAPACK, and
 MKL is as simple as::
 
-    $ mamba create -n blas-switch scipy threadpoolctl
-    $ mamba activate blas-switch
+    $ conda create -n blas-switch scipy threadpoolctl
+    $ conda activate blas-switch
     $ python -m threadpoolctl -i scipy.linalg
     ...
         "user_api": "blas",
         "internal_api": "openblas",
 
-    $ mamba install "libblas=*=*netlib"
+    $ conda install "libblas=*=*netlib"
     ...
       libblas                         3.9.0-21_linux64_openblas --> 3.9.0-5_h92ddd45_netlib
       libcblas                        3.9.0-21_linux64_openblas --> 3.9.0-5_h92ddd45_netlib
       liblapack                       3.9.0-21_linux64_openblas --> 3.9.0-5_h92ddd45_netlib
 
-    $ mamba install "libblas=*=*mkl"
+    $ conda install "libblas=*=*mkl"
     ...
       libblas                           3.9.0-5_h92ddd45_netlib --> 3.9.0-21_linux64_mkl
       libcblas                          3.9.0-5_h92ddd45_netlib --> 3.9.0-21_linux64_mkl
@@ -167,14 +167,14 @@ in the exact same way as in `SciPy's conda-forge build recipe
 <https://github.com/conda-forge/scipy-feedstock/blob/main/recipe/build.sh>`__
 (outputs omitted for brevity, they're similar to the ones above)::
 
-    $ mamba env create -f environment.yml
-    $ mamba activate scipy-dev
-    $ mamba install "libblas=*=*netlib"  # necessary, we need to build against blas/lapack
+    $ conda env create -f environment.yml
+    $ conda activate scipy-dev
+    $ conda install "libblas=*=*netlib"  # necessary, we need to build against blas/lapack
     $ spin build -S-Dblas=blas -S-Dlapack=lapack -S-Duse-g77-abi=true
     $ spin test -s linalg  # run tests to verify
-    $ mamba install "libblas=*=*mkl"
+    $ conda install "libblas=*=*mkl"
     $ spin test -s linalg
-    $ mamba install "libblas=*=*openblas"
+    $ conda install "libblas=*=*openblas"
 
 
 Linux distro package managers

--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -9,7 +9,7 @@ steps to start contributing:
 
 1. **Set up a development environment**
 
-   Using ``mamba``, or some flavor of the many virtual environment management
+   Using ``conda``, or some flavor of the many virtual environment management
    tools, you can make sure the development version of SciPy does not interfere
    with any other local installations of SciPy on your machine.
 
@@ -34,7 +34,7 @@ Basic workflow
 
 Since SciPy contains parts written in C, C++, and Fortran that need to be
 compiled before use, make sure you have the necessary compilers and Python
-development headers installed. If you are using ``mamba``, these will be
+development headers installed. If you are using ``conda``, these will be
 installed automatically. If you are using ``pip``, check which
 :ref:`system-level dependencies <system-level>` you might need.
 


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #24781

#### What does this implement/fix?
The developer doc uses conda and mamba interchangeably. Mamba users typically know that conda commands work for mamba. For consistency, change instances of mamba to conda in developer doc.

#### AI Generation Disclosure
No AI tools used