### PR TITLE
MAINT: stats.UnivariateDistribution: fix typo in safe complement methods; use `typical` for `support` of custom distributions

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3930,8 +3930,7 @@ def make_distribution(dist):
         support : dict or tuple
             A dictionary describing the support of the distribution or a tuple
             describing the endpoints of the support. This behaves identically to
-            the values of the parameters dict described above, except that the key
-            ``typical`` is ignored.
+            the values of the parameters dict described above.
 
         The class **must** also define a ``pdf`` method and **may** define methods
         ``logentropy``, ``entropy``, ``median``, ``mode``, ``logpdf``,
@@ -4261,9 +4260,9 @@ def _make_distribution_custom(dist):
             parameters.append(param)
         parameterizations.append(_Parameterization(*parameters) if parameters else [])
 
-    domain_info, _ = _get_domain_info(dist.support)
+    domain_info, typical = _get_domain_info(dist.support)
     _x_support = _RealInterval(**domain_info)
-    _x_param = _RealParameter('x', domain=_x_support)
+    _x_param = _RealParameter('x', domain=_x_support, typical=typical)
     repr_str = dist.__class__.__name__
 
     class CustomDistribution(ContinuousDistribution):

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -2624,7 +2624,7 @@ class UnivariateDistribution(_ProbabilityDistribution):
             params_mask = {key: np.broadcast_to(val, mask.shape)[mask]
                            for key, val in params.items()}
             out = np.asarray(out)
-            out[mask] = self._cdf_quadrature(x[mask], *params_mask)
+            out[mask] = self._cdf_quadrature(x[mask], **params_mask)
         return out[()]
 
     def _cdf_quadrature(self, x, **params):
@@ -2824,7 +2824,7 @@ class UnivariateDistribution(_ProbabilityDistribution):
             params_mask = {key: np.broadcast_to(val, mask.shape)[mask]
                            for key, val in params.items()}
             out = np.asarray(out)
-            out[mask] = self._icdf_inversion(x[mask], *params_mask)
+            out[mask] = self._icdf_inversion(x[mask], **params_mask)
         return out[()]
 
     def _icdf_inversion(self, x, **params):
@@ -2882,7 +2882,7 @@ class UnivariateDistribution(_ProbabilityDistribution):
             params_mask = {key: np.broadcast_to(val, mask.shape)[mask]
                            for key, val in params.items()}
             out = np.asarray(out)
-            out[mask] = self._iccdf_inversion(x[mask], *params_mask)
+            out[mask] = self._iccdf_inversion(x[mask], **params_mask)
         return out[()]
 
     def _iccdf_inversion(self, x, **params):

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1496,6 +1496,34 @@ class TestMakeDistribution:
         assert repr(dist(beta=2)) == "HalfGeneralizedNormal(beta=np.float64(2.0))"
         assert 'HalfGeneralizedNormal' in dist.__doc__
 
+    @given(data=strategies.data())
+    def test_draw_distribution(self, data):
+        # `draw_distribution_from_family` is a private function right now, but we will
+        # want that functionality to be public someday. It was broken for custom
+        # distributions because the `typical` parameter of the support was ignored.
+        # Check that this is resolved.
+        rng = np.random.default_rng(8465652168548465121)
+        u_typical = tuple(np.sort(rng.standard_normal(2)))
+        s_typical = tuple(np.sort(rng.random(2)*2))
+        x_typical = tuple(np.sort(rng.standard_normal(2)))
+
+        class MyNormal:
+            __make_distribution_version__ = "1.16.0"
+            parameters = {'u': {'endpoints': (-np.inf, np.inf), 'typical': u_typical},
+                          's': {'endpoints': (0, np.inf), 'typical': s_typical}}
+            support = {'endpoints': (-np.inf, np.inf), 'typical': x_typical}
+
+            def pdf(self, x, a, b):
+                return 1 / (x * (np.log(b) - np.log(a)))
+
+        family = stats.make_distribution(MyNormal())
+        proportions = (1.0, 0., 0., 0.)
+        tmp = draw_distribution_from_family(family, data, rng, proportions, min_side=1)
+        dist, x, y, p, logp, result_shape, x_result_shape, xy_result_shape = tmp
+        assert u_typical[0] < np.min(dist.u) and np.max(dist.u) < u_typical[1]
+        assert s_typical[0] < np.min(dist.s) and np.max(dist.s) < s_typical[1]
+        assert x_typical[0] < np.min(x) and np.max(x) < x_typical[1]
+
 
 class TestTransforms:
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -288,7 +288,7 @@ class TestDistributions:
 
     @pytest.mark.parametrize('method_name', ['cdf', 'ccdf'])
     def test_complement_safe(self, method_name):
-        X = stats.Normal()
+        X = stats.Normal(mu=1, sigma=2)
         X.tol = 1e-12
         p = np.asarray([1e-4, 1e-3])
         func = getattr(X, method_name)
@@ -302,7 +302,7 @@ class TestDistributions:
 
     @pytest.mark.parametrize('method_name', ['cdf', 'ccdf'])
     def test_icomplement_safe(self, method_name):
-        X = stats.Normal()
+        X = stats.Normal(mu=1, sigma=2)
         X.tol = 1e-12
         p = np.asarray([1e-4, 1e-3])
         func = getattr(X, method_name)


### PR DESCRIPTION
#### What does this implement/fix?
There was a typo in the `UnivariateDistribution` `..._complement_safe` methods: kwargs were passed to a method as `*params_mask` instead of `**params_mask`. The tests didn't catch it because they involved a random variable without parameters. This modifies the tests such that they fail in `main` and modifies the functions so the tests pass again.

Also, `draw_distribution_from_family` is a private function right now, but we may want that sort of functionality to be public someday because it is very useful for property-based testing. It was broken for custom distributions because the `typical` parameter of the support was ignored. This fixes the problem and adds a regression test.

#### Additional information
Only three of the `_complement_safe` methods are modified; the fourth (`_ccdf_complement_safe`) was already fine.

Thanks @JacobHass8 for spotting the typo and the failure in `draw_distribution_from_family` when used with a custom distribution!

#### AI Generation Disclosure
No AI