### PR TITLE
DOC: clarify periodic bc_type requires y[0] == y[-1] in make_splrep

### DIFF
--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -190,7 +190,7 @@ def generate_knots(x, y, *, w=None, xb=None, xe=None,
         * ``"not-a-knot"`` (default): The first and second segments are the
           same polynomial. This is equivalent to having ``bc_type=None``.
         * ``"periodic"``: The values and the first ``k-1`` derivatives at the
-          ends are equivalent.
+          ends are equivalent. Requires that ``y[0]`` equals ``y[-1]``.
 
     Yields
     ------
@@ -1067,7 +1067,7 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
         * ``"not-a-knot"`` (default): The first and second segments are the
           same polynomial. This is equivalent to having ``bc_type=None``.
         * ``"periodic"``: The values and the first ``k-1`` derivatives at the
-          ends are equivalent.
+          ends are equivalent. Requires that ``y[0]`` equals ``y[-1]``.
 
     Returns
     -------
@@ -1227,7 +1227,7 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
         * ``"not-a-knot"`` (default): The first and second segments are the
           same polynomial. This is equivalent to having ``bc_type=None``.
         * ``"periodic"``: The values and the first ``k-1`` derivatives at the
-          ends are equivalent.
+          ends are equivalent. Requires that ``y[0]`` equals ``y[-1]``.
 
     Returns
     -------


### PR DESCRIPTION
#### Reference issue
Closes gh-24693.

#### What does this implement/fix?
- Update `bc_type='periodic'` description in `make_splrep` and `generate_knots` docstrings
- Explicitly state that `y[0]` must equal `y[-1]` when using periodic boundary conditions
- This requirement is enforced at runtime but was not documented

#### Additional information
The fix adds "Requires that ``y[0]`` equals ``y[-1]``." to the periodic boundary condition description in both `make_splrep` and `generate_knots` functions in `scipy/interpolate/_fitpack_repro.py`.

#### AI Generation Disclosure
No AI tools used.