### PR TITLE
BUG: use `CBLAS_INT` in `save_vars` in lbfgsb.c for ILP64 compatibility

### DIFF
--- a/scipy/optimize/src/lbfgsb.c
+++ b/scipy/optimize/src/lbfgsb.c
@@ -155,9 +155,9 @@ static inline void save_local_vars(
     CBLAS_INT* lsave, CBLAS_INT* isave, double* dsave
 );
 static inline void save_vars(
-    int brackt, int stage, double ginit, double gtest, double gx, double gy,
+    CBLAS_INT brackt, CBLAS_INT stage, double ginit, double gtest, double gx, double gy,
     double finit, double fx, double fy, double stx, double sty, double stmin,
-    double stmax, double width, double width1, int* isave, double* dsave
+    double stmax, double width, double width1, CBLAS_INT* isave, double* dsave
 );
 
 static double epsmach = 2.220446049250313e-016;  /* np.finfo(np.float64).eps  */
@@ -3455,9 +3455,9 @@ dcsrch(double f, double g, double* stp, double ftol, double gtol,
 }
 
 static inline void save_vars(
-    int brackt, int stage, double ginit, double gtest, double gx, double gy,
+    CBLAS_INT brackt, CBLAS_INT stage, double ginit, double gtest, double gx, double gy,
     double finit, double fx, double fy, double stx, double sty, double stmin,
-    double stmax, double width, double width1, int* isave, double* dsave) {
+    double stmax, double width, double width1, CBLAS_INT* isave, double* dsave) {
     if (brackt)
     {
         isave[0] = 1;


### PR DESCRIPTION
#### What does this implement/fix?

The `save_vars` function in `lbfgsb.c` used `int`/`int*` for several parameters, but `dcsrch` passes `CBLAS_INT` which becomes `npy_int64` in ILP64 mode, causing -Wincompatible-pointer-types errors.

This was a bug introduced as a cross-merge conflict between PR gh-24703, which moved the whole file over to ILP64, and PR gh-24691 which updated `save_vars` from a base commit that didn't yet have any `CBLAS_INT` usage.

I stumbled across this as part of working on ILP64 support. It should be easy to see that this is correct. Unsure why CI didn't pick it up before, but it will be covered by CI after I open the larger PR I'm still working on.

#### AI Generation Disclosure

I used Claude Opus 4.6 for this fix, after running into a build error locally. Making integer types match was all Claude, the investigation of how the bug was introduced was mine.
