### PR TITLE
MAINT/ENH: linalg: use `get_blas_lapack_funcs` not bare lapack calls

### DIFF
--- a/scipy/interpolate/_rbfinterp_np.py
+++ b/scipy/interpolate/_rbfinterp_np.py
@@ -1,6 +1,6 @@
 import numpy as np
 from numpy.linalg import LinAlgError
-from scipy.linalg.lapack import dgesv  # type: ignore[attr-defined]
+from scipy.linalg.lapack import get_lapack_funcs
 from ._rbfinterp_common import _monomial_powers_impl
 
 from ._rbfinterp_pythran import (
@@ -8,6 +8,9 @@ from ._rbfinterp_pythran import (
     _build_evaluation_coefficients as _pythran_build_evaluation_coefficients,
     _polynomial_matrix as _pythran_polynomial_matrix
 )
+
+
+dgesv = get_lapack_funcs('gesv', dtype=np.float64, ilp64="preferred")
 
 
 # trampolines for pythran-compiled functions to drop the `xp` argument

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2003,7 +2003,8 @@ def _qr_reduce_py(a_p, y, startrow=1):
     """This is a python counterpart of the `_qr_reduce` routine,
     declared in interpolate/src/__fitpack.h
     """
-    from scipy.linalg.lapack import dlartg
+    from scipy.linalg.lapack import get_lapack_funcs
+    dlartg = get_lapack_funcs('lartg', dtype=np.float64, ilp64='preferred')
 
     # unpack the packed format
     a = a_p.a

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -10,7 +10,7 @@ from scipy._lib._util import _apply_over_batch
 
 # Local imports
 from ._misc import _datacopied, LinAlgWarning
-from .lapack import get_lapack_funcs, _normalize_lapack_dtype
+from .lapack import get_lapack_funcs, _normalize_lapack_dtype, HAS_ILP64
 from ._decomp_lu_cython import lu_dispatcher
 
 
@@ -111,7 +111,7 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
     # accommodate empty arrays
     if a1.size == 0:
         lu = np.empty_like(a1)
-        piv = np.arange(0, dtype=np.int32)
+        piv = np.arange(0, dtype=np.int64 if HAS_ILP64 else np.int32)
         return lu, piv
 
     overwrite_a = overwrite_a or (_datacopied(a1, a))

--- a/scipy/linalg/_matfuncs_sqrtm.py
+++ b/scipy/linalg/_matfuncs_sqrtm.py
@@ -9,7 +9,7 @@ __all__ = []
 import numpy as np
 
 # Local imports
-from .lapack import ztrsyl, dtrsyl
+from .lapack import get_lapack_funcs
 
 class SqrtmError(np.linalg.LinAlgError):
     pass
@@ -56,6 +56,8 @@ def _sqrtm_triu(T, blocksize=64):
 
     R = np.diag(np.sqrt(T_diag))
 
+    trsyl = get_lapack_funcs('trsyl', (R,), ilp64="preferred")
+
     # Compute the number of blocks to use; use at least one block.
     n, n = T.shape
     nblocks = max(n // blocksize, 1)
@@ -97,10 +99,7 @@ def _sqrtm_triu(T, blocksize=64):
             # and the fortran dtrsyl and ztrsyl docs.
             Rii = R[istart:istop, istart:istop]
             Rjj = R[jstart:jstop, jstart:jstop]
-            if keep_it_real:
-                x, scale, info = dtrsyl(Rii, Rjj, S)
-            else:
-                x, scale, info = ztrsyl(Rii, Rjj, S)
+            x, scale, info = trsyl(Rii, Rjj, S)
             R[istart:istop, jstart:jstop] = x * scale
 
     # Return the matrix square root.

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -340,7 +340,7 @@ def find_best_blas_type(arrays=(), dtype=None):
 def _get_funcs(names, arrays, dtype,
                lib_name, fmodule, cmodule,
                fmodule_name, cmodule_name, alias,
-               ilp64=False):
+               ilp64="preferred"):
     """
     Return available BLAS/LAPACK functions.
 
@@ -396,7 +396,7 @@ def _memoize_get_funcs(func):
     func.memo = memo
 
     @functools.wraps(func)
-    def getter(names, arrays=(), dtype=None, ilp64=False):
+    def getter(names, arrays=(), dtype=None, ilp64="preferred"):
         key = (names, dtype, ilp64)
         for array in arrays:
             # cf. find_blas_funcs
@@ -423,7 +423,7 @@ def _memoize_get_funcs(func):
 
 
 @_memoize_get_funcs
-def get_blas_funcs(names, arrays=(), dtype=None, ilp64=False):
+def get_blas_funcs(names, arrays=(), dtype=None, ilp64="preferred"):
     """Return available BLAS function objects from names.
 
     Arrays are used to determine the optimal prefix of BLAS routines.
@@ -444,7 +444,7 @@ def get_blas_funcs(names, arrays=(), dtype=None, ilp64=False):
     ilp64 : {True, False, 'preferred'}, optional
         Whether to return ILP64 routine variant.
         Choosing 'preferred' returns ILP64 routine if available,
-        and otherwise the 32-bit routine. Default: False
+        and otherwise the 32-bit routine. Default: ``'preferred'``.
 
     Returns
     -------

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -221,7 +221,10 @@ __all__ = ['get_blas_funcs', 'find_best_blas_type']
 import numpy as np
 import functools
 
+# TODO: fold to __config__
 from scipy.linalg import _fblas
+HAS_LP64 = True
+
 try:
     from scipy.linalg import _cblas
 except ImportError:

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -30,6 +30,20 @@ This module contains low-level functions from the BLAS library.
    It is possible to cause crashes by mis-using them,
    so prefer using the higher-level routines in `scipy.linalg`.
 
+.. note::
+
+    Prefer using ``get_blas_funcs`` to importing the bare functions directly.
+    If you do, for example, ``from scipy.linalg.blas import dgemm``, the ``dgemm``
+    function may be either LP64 or ILP64, depending on how SciPy is built.
+
+    The following is more robust:
+
+    >>> from scipy.linalg.blas import get_blas_funcs
+    >>> dgemm = get_blas_funcs('gemm', dtype='float64', ilp64='preferred')
+    >>> dgemm.int_dtype
+    dtype('int32')    # may vary
+
+
 Finding functions
 -----------------
 
@@ -443,25 +457,30 @@ def get_blas_funcs(names, arrays=(), dtype=None, ilp64="preferred"):
 
     ilp64 : {True, False, 'preferred'}, optional
         Whether to return ILP64 routine variant.
-        Choosing 'preferred' returns ILP64 routine if available,
-        and otherwise the 32-bit routine. Default: ``'preferred'``.
+        Choosing ``'preferred'`` returns ILP64 routine if available,
+        and otherwise the 32-bit (LP64) routine. Default: ``'preferred'``.
 
     Returns
     -------
     funcs : list
         List containing the found function(s).
 
+    Raises
+    ------
+    RuntimeError
+        If the requested LP64/ILP64 variant is not available.
+
+    See Also
+    --------
+    scipy.linalg.lapack.get_lapack_funcs
+        a similar routine for selecting LAPACK functions.
 
     Notes
     -----
-    This routine automatically chooses between Fortran/C
-    interfaces. Fortran code is used whenever possible for arrays with
-    column major order. In all other cases, C code is preferred.
-
     In BLAS, the naming convention is that all functions start with a
     type prefix, which depends on the type of the principal
-    matrix. These can be one of {'s', 'd', 'c', 'z'} for the NumPy
-    types {float32, float64, complex64, complex128} respectively.
+    matrix. These can be one of ``{'s', 'd', 'c', 'z'}`` for the NumPy
+    types ``{float32, float64, complex64, complex128}`` respectively.
     The code and the dtype are stored in attributes `typecode` and `dtype`
     of the returned functions.
 
@@ -470,14 +489,37 @@ def get_blas_funcs(names, arrays=(), dtype=None, ilp64="preferred"):
     >>> import numpy as np
     >>> import scipy.linalg as LA
     >>> rng = np.random.default_rng()
-    >>> a = rng.random((3,2))
+    >>> a = rng.random((3, 2))
     >>> x_gemv = LA.get_blas_funcs('gemv', (a,))
+
+    Note that ``x_gemv`` string representation shows the exact BLAS function with the
+    prefix (here, ``d-`` because ``a`` is double precision real):
+
+    >>> x_gemv
+    <fortran function dgemv>
+
+    The BLAS variant information is also available from the ``typecode`` attribute:
+
     >>> x_gemv.typecode
     'd'
-    >>> x_gemv = LA.get_blas_funcs('gemv',(a*1j,))
+
+    For double precision complex arrays, we select the ``z-`` variant, ``zgemv``
+
+    >>> x_gemv = LA.get_blas_funcs('gemv', (a*1j,))
     >>> x_gemv.typecode
     'z'
 
+    If you want to select a specific BLAS variant instead of relying on array types, use
+    the ``dtype=`` argument:
+
+    >>> LA.get_blas_funcs('gemv', dtype=np.float32)
+    <fortran function sgemv>
+
+    The ``int_dtype`` attribute stores whether the routine is ILP64 (integer arguments
+    and outputs are 64-bit) or LP64 (integer arguments and outputs are 32-bit):
+
+    >>> x_gemv.int_dtype
+    dtype('int32')   # may vary
     """
     if isinstance(ilp64, str):
         if ilp64 == 'preferred':

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -234,8 +234,9 @@ __all__ = ['get_blas_funcs', 'find_best_blas_type']
 
 import numpy as np
 import functools
+from scipy.__config__ import CONFIG
 
-# TODO: fold to __config__
+# TODO: fold HAS_LP64 into __config__, allow for _fblas not being available
 from scipy.linalg import _fblas
 HAS_LP64 = True
 
@@ -244,7 +245,6 @@ try:
 except ImportError:
     _cblas = None
 
-from scipy.__config__ import CONFIG
 HAS_ILP64 = CONFIG['Build Dependencies']['blas']['has ilp64']
 del CONFIG
 _fblas_64 = None

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -886,10 +886,6 @@ from .blas import (
     find_best_blas_type as find_best_lapack_type   # to appease the name test
 )
 
-# TODO: fold into __config__
-from scipy.linalg import _flapack
-HAS_LP64 = True
-
 from re import compile as regex_compile
 try:
     from scipy.linalg import _clapack
@@ -897,6 +893,11 @@ except ImportError:
     _clapack = None
 
 from scipy.__config__ import CONFIG
+
+# TODO: fold HAS_LP64 into __config__, allow for _flapack not being available
+from scipy.linalg import _flapack
+HAS_LP64 = True
+
 HAS_ILP64 = CONFIG['Build Dependencies']['lapack']['has ilp64']
 del CONFIG
 _flapack_64 = None
@@ -1010,8 +1011,8 @@ def get_lapack_funcs(names, arrays=(), dtype=None, ilp64="preferred"):
     >>> x_lange.typecode
     'z'
 
-    If you want to select a specific BLAS variant instead of relying on array types, use
-    the ``dtype=`` argument:
+    If you want to select a specific LAPACK variant instead of relying on array types,
+    use the ``dtype=`` argument:
 
     >>> LA.get_lapack_funcs('lange', dtype=np.float32)
     <fortran function slange>
@@ -1052,7 +1053,7 @@ def get_lapack_funcs(names, arrays=(), dtype=None, ilp64="preferred"):
     else:
         if not HAS_ILP64:
             raise RuntimeError("LAPACK ILP64 routine requested, but Scipy "
-                               "compiled only with 32-bit BLAS")
+                               "compiled only with 32-bit LAPACK")
         return _get_funcs(names, arrays, dtype,
                           "LAPACK", _flapack_64, None,
                           "flapack_64", None, _lapack_alias,

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -932,7 +932,7 @@ del regex_compile, p1, p2, backtickrepl
 
 
 @_memoize_get_funcs
-def get_lapack_funcs(names, arrays=(), dtype=None, ilp64=False):
+def get_lapack_funcs(names, arrays=(), dtype=None, ilp64="preferred"):
     """Return available LAPACK function objects from names.
 
     Arrays are used to determine the optimal prefix of LAPACK routines.
@@ -953,7 +953,7 @@ def get_lapack_funcs(names, arrays=(), dtype=None, ilp64=False):
     ilp64 : {True, False, 'preferred'}, optional
         Whether to return ILP64 routine variant.
         Choosing 'preferred' returns ILP64 routine if available, and
-        otherwise the 32-bit routine. Default: False
+        otherwise the 32-bit routine. Default: ``'preferred'``.
 
     Returns
     -------

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -30,6 +30,20 @@ This module contains low-level functions from the LAPACK library.
    It is possible to cause crashes by mis-using them,
    so prefer using the higher-level routines in `scipy.linalg`.
 
+.. note::
+
+    Prefer using ``get_lapack_funcs`` to importing the bare functions directly.
+    If you do, for example, ``from scipy.linalg.lapack import dsysv``, the ``dsysv``
+    function may be either LP64 or ILP64, depending on how SciPy is built.
+
+    The following is more robust:
+
+    >>> from scipy.linalg.lapack import get_lapack_funcs
+    >>> dsysv = get_lapack_funcs('sysv', dtype='float64', ilp64='preferred')
+    >>> dsysv.int_dtype
+    dtype('int32')    # may vary
+
+
 Finding functions
 -----------------
 
@@ -960,16 +974,22 @@ def get_lapack_funcs(names, arrays=(), dtype=None, ilp64="preferred"):
     funcs : list
         List containing the found function(s).
 
+    Raises
+    ------
+    RuntimeError
+        If the requested LP64/ILP64 variant is not available.
+
+    See Also
+    --------
+    scipy.linalg.blas.get_blas_funcs
+        A similar routine for selecting BLAS functions.
+
     Notes
     -----
-    This routine automatically chooses between Fortran/C
-    interfaces. Fortran code is used whenever possible for arrays with
-    column major order. In all other cases, C code is preferred.
-
     In LAPACK, the naming convention is that all functions start with a
     type prefix, which depends on the type of the principal
-    matrix. These can be one of {'s', 'd', 'c', 'z'} for the NumPy
-    types {float32, float64, complex64, complex128} respectively, and
+    matrix. These can be one of ``{'s', 'd', 'c', 'z'}`` for the NumPy
+    types ``{float32, float64, complex64, complex128}`` respectively, and
     are stored in attribute ``typecode`` of the returned functions.
 
     Examples
@@ -982,13 +1002,27 @@ def get_lapack_funcs(names, arrays=(), dtype=None, ilp64="preferred"):
     >>> import scipy.linalg as LA
     >>> rng = np.random.default_rng()
 
-    >>> a = rng.random((3,2))
+    >>> a = rng.random((3, 2))
     >>> x_lange = LA.get_lapack_funcs('lange', (a,))
     >>> x_lange.typecode
     'd'
-    >>> x_lange = LA.get_lapack_funcs('lange',(a*1j,))
+    >>> x_lange = LA.get_lapack_funcs('lange', (a*1j,))
     >>> x_lange.typecode
     'z'
+
+    If you want to select a specific BLAS variant instead of relying on array types, use
+    the ``dtype=`` argument:
+
+    >>> LA.get_lapack_funcs('lange', dtype=np.float32)
+    <fortran function slange>
+
+    The ``int_dtype`` attribute stores whether the routine is ILP64 (integer arguments
+    and outputs are 64-bit) or LP64 (integer arguments and outputs are 32-bit):
+
+    >>> x_lange.int_dtype
+    dtype('int32')   # may vary
+
+    **Work size computations**
 
     Several LAPACK routines work best when its internal WORK array has
     the optimal size (big enough for fast computation and small enough to

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -871,7 +871,11 @@ from .blas import (
     _get_funcs, _memoize_get_funcs,
     find_best_blas_type as find_best_lapack_type   # to appease the name test
 )
+
+# TODO: fold into __config__
 from scipy.linalg import _flapack
+HAS_LP64 = True
+
 from re import compile as regex_compile
 try:
     from scipy.linalg import _clapack

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -14,6 +14,7 @@ from numpy import (arange, triu, tril, zeros, tril_indices, ones,
 
 import scipy
 from scipy.linalg import _fblas as fblas, get_blas_funcs, toeplitz, solve
+from scipy.linalg.lapack import HAS_ILP64
 
 try:
     from scipy.linalg import _cblas as cblas
@@ -1027,11 +1028,13 @@ def test_gh_169309():
     assert_allclose(actual, expected)
 
 
+@pytest.mark.xfail(HAS_ILP64, reason='does not fail with ILP64 MKL')
 def test_dnrm2_neg_incx():
     # check that dnrm2(..., incx < 0) raises
     # XXX: remove the test after the lowest supported BLAS implements
     # negative incx (new in LAPACK 3.10)
     x = np.repeat(10, 9)
     incx = -1
+    dnrm2 = scipy.linalg.blas.get_blas_funcs('nrm2', (x,), ilp64='preferred')
     with assert_raises(fblas.__fblas_error):
-        scipy.linalg.blas.dnrm2(x, 5, 3, incx)
+        dnrm2(x, 5, 3, incx)

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -14,7 +14,7 @@ from numpy import (arange, triu, tril, zeros, tril_indices, ones,
 
 import scipy
 from scipy.linalg import _fblas as fblas, get_blas_funcs, toeplitz, solve
-from scipy.linalg.lapack import HAS_ILP64
+from scipy.linalg.blas import HAS_ILP64
 
 try:
     from scipy.linalg import _cblas as cblas
@@ -77,6 +77,32 @@ def test_get_blas_funcs():
                          np.empty((2, 2), dtype=np.complex64))
                         )
     assert_equal(f1.typecode, 'z')
+
+
+@pytest.mark.skipif(fblas is None, reason="32-bit BLAS is not available")
+def test_get_blas_funcs_lp64():
+    # default is LP64
+    gemm = get_blas_funcs('gemm', (np.eye(3),))
+    assert gemm.int_dtype == np.int32
+
+    gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64=False)
+    assert gemm.int_dtype == np.int32
+
+    gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64="preferred")
+    assert gemm.int_dtype == np.int64 if HAS_ILP64 else np.int32
+
+
+@pytest.mark.skipif(fblas_64 is None, reason="64-bit BLAS is not available")
+def test_get_blas_funcs_ilp64():
+    # default is LP64
+    gemm = get_blas_funcs('gemm', (np.eye(3),))
+    assert gemm.int_dtype == np.int32
+
+    gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64=True)
+    assert gemm.int_dtype == np.int32
+
+    gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64="preferred")
+    assert gemm.int_dtype == np.int64
 
 
 def test_get_blas_funcs_alias():

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -21,6 +21,20 @@ try:
 except ImportError:
     cblas = None
 
+try:
+    from scipy.linalg import _fblas as fblas
+except ImportError:
+    fblas = None
+
+try:
+    from scipy.linalg import _fblas_64 as fblas_64
+except ImportError:
+    fblas_64 = None
+
+
+print(f"{fblas = }  {fblas_64 = }  {cblas = }")
+
+
 REAL_DTYPES = [np.float32, np.float64]
 COMPLEX_DTYPES = [np.complex64, np.complex128]
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES
@@ -76,29 +90,48 @@ def test_get_blas_funcs_alias():
     assert f is h
 
 
-def parametrize_blas(mod, func_name, prefixes):
-    if mod is None:
-        return pytest.mark.skip(reason="cblas not available")
+def _dt_from_prefix(prefix):
+    """Array dtype from a blas-style prefix."""
+    if prefix.startswith('i'):
+        prefix = prefix[1:]   # isamax, idamax etc
+    elif prefix in ['sc', 'dz']:
+        prefix = prefix[0]   # scasum, dzasum
+    elif prefix in ['cs', 'zd']:
+        prefix = prefix[0]  # zdscal, csscal
+
+    dt_map = {'z': np.complex128, 'c': np.complex64, 'd': np.float64, 's': np.float32}
+    return dt_map[prefix]
+
+
+def parametrize_blas(func_name, prefixes, modules=None):
+    if modules is None:
+        modules = [(fblas, "fblas"), (fblas_64, "fblas_64")]
+
     params = []
-    for prefix in prefixes:
-        if 'z' in prefix:
-            dtype = np.complex128
-        elif 'c' in prefix:
-            dtype = np.complex64
-        elif 'd' in prefix:
-            dtype = np.float64
-        else:
-            assert 's' in prefix
-            dtype = np.float32
+    for mod, mod_name in modules:
+        for prefix in prefixes:
+            dtype = _dt_from_prefix(prefix)
+            if mod is None:
+                param_ = pytest.param(
+                    None, dtype,
+                    id=f"{mod_name}.{prefix}{func_name}",
+                    marks=pytest.mark.skip(reason=f"{mod_name} is not available")
+                )
+            else:
+                # Fetch the BLAS function from the BLAS module. NB: if the name is not
+                # found in the module, it's a hard failure (all names must be present).
+                f = getattr(mod, prefix + func_name)
+                mark_kwd = {}
+                param_ = pytest.param(f, dtype, id=f"{mod_name}.{prefix}{func_name}")
 
-        f = getattr(mod, prefix + func_name)
-        params.append(pytest.param(f, dtype, id=prefix + func_name))
+            params.append(param_)
 
-    return pytest.mark.parametrize("f,dtype", params)
+    return pytest.mark.parametrize("f, dtype", params)
 
 
 class TestCBLAS1Simple:
-    @parametrize_blas(cblas, "axpy", "sdcz")
+
+    @parametrize_blas("axpy", "sdcz", modules=[(cblas, "cblas")])
     def test_axpy(self, f, dtype):
         assert_array_almost_equal(f([1, 2, 3], [2, -1, 3], a=5),
                                   [7, 9, 18])
@@ -109,7 +142,7 @@ class TestCBLAS1Simple:
 
 class TestFBLAS1Simple:
 
-    @parametrize_blas(fblas, "axpy", "sdcz")
+    @parametrize_blas("axpy", "sdcz")
     def test_axpy(self, f, dtype):
         assert_array_almost_equal(f([1, 2, 3], [2, -1, 3], a=5),
                                   [7, 9, 18])
@@ -117,43 +150,43 @@ class TestFBLAS1Simple:
             assert_array_almost_equal(f([1, 2j, 3], [2, -1, 3], a=5),
                                       [7, 10j-1, 18])
 
-    @parametrize_blas(fblas, "copy", "sdcz")
+    @parametrize_blas("copy", "sdcz")
     def test_copy(self, f, dtype):
         assert_array_almost_equal(f([3, 4, 5], [8]*3), [3, 4, 5])
         if dtype in COMPLEX_DTYPES:
             assert_array_almost_equal(f([3, 4j, 5+3j], [8]*3), [3, 4j, 5+3j])
 
-    @parametrize_blas(fblas, "asum", ["s", "d", "sc", "dz"])
+    @parametrize_blas("asum", ["s", "d", "sc", "dz"])
     def test_asum(self, f, dtype):
         assert_almost_equal(f([3, -4, 5]), 12)
         if dtype in COMPLEX_DTYPES:
             assert_almost_equal(f([3j, -4, 3-4j]), 14)
 
-    @parametrize_blas(fblas, "dot", "sd")
+    @parametrize_blas("dot", "sd")
     def test_dot(self, f, dtype):
         assert_almost_equal(f([3, -4, 5], [2, 5, 1]), -9)
 
-    @parametrize_blas(fblas, "dotu", "cz")
+    @parametrize_blas("dotu", "cz")
     def test_dotu(self, f, dtype):
         assert_almost_equal(f([3j, -4, 3-4j], [2, 3, 1]), -9+2j)
 
-    @parametrize_blas(fblas, "dotc", "cz")
+    @parametrize_blas("dotc", "cz")
     def test_dotc(self, f, dtype):
         assert_almost_equal(f([3j, -4, 3-4j], [2, 3j, 1]), 3-14j)
 
-    @parametrize_blas(fblas, "nrm2", ["s", "d", "sc", "dz"])
+    @parametrize_blas("nrm2", ["s", "d", "sc", "dz"])
     def test_nrm2(self, f, dtype):
         assert_almost_equal(f([3, -4, 5]), math.sqrt(50))
         if dtype in COMPLEX_DTYPES:
             assert_almost_equal(f([3j, -4, 3-4j]), math.sqrt(50))
 
-    @parametrize_blas(fblas, "scal", ["s", "d", "cs", "zd"])
+    @parametrize_blas("scal", ["s", "d", "cs", "zd"])
     def test_scal(self, f, dtype):
         assert_array_almost_equal(f(2, [3, -4, 5]), [6, -8, 10])
         if dtype in COMPLEX_DTYPES:
             assert_array_almost_equal(f(3, [3j, -4, 3-4j]), [9j, -12, 9-12j])
 
-    @parametrize_blas(fblas, "swap", "sdcz")
+    @parametrize_blas("swap", "sdcz")
     def test_swap(self, f, dtype):
         x, y = [2, 3, 1], [-2, 3, 7]
         x1, y1 = f(x, y)
@@ -166,7 +199,7 @@ class TestFBLAS1Simple:
             assert_array_almost_equal(x1, y)
             assert_array_almost_equal(y1, x)
 
-    @parametrize_blas(fblas, "amax", ["is", "id", "ic", "iz"])
+    @parametrize_blas("amax", ["is", "id", "ic", "iz"])
     def test_amax(self, f, dtype):
         assert_equal(f([-2, 4, 3]), 1)
         if dtype in COMPLEX_DTYPES:
@@ -176,7 +209,7 @@ class TestFBLAS1Simple:
 
 
 class TestFBLAS2Simple:
-    @parametrize_blas(fblas, "gemv", "sdcz")
+    @parametrize_blas("gemv", "sdcz")
     def test_gemv(self, f, dtype):
         assert_array_almost_equal(f(3, [[3]], [-4]), [-36])
         assert_array_almost_equal(f(3, [[3]], [-4], 3, [5]), [-21])
@@ -185,7 +218,7 @@ class TestFBLAS2Simple:
             assert_array_almost_equal(f(3j, [[3-4j]], [-4], 3, [5j]),
                                       [-48-21j])
 
-    @parametrize_blas(fblas, "ger", "sd")
+    @parametrize_blas("ger", "sd")
     def test_ger(self, f, dtype):
         assert_array_almost_equal(f(1, [1, 2], [3, 4]), [[3, 4], [6, 8]])
         assert_array_almost_equal(f(2, [1, 2, 3], [3, 4]),
@@ -198,21 +231,21 @@ class TestFBLAS2Simple:
             assert_array_almost_equal(f(2, [1j, 2j, 3j], [3j, 4j]),
                                       [[6, 8], [12, 16], [18, 24]])
 
-    @parametrize_blas(fblas, "geru", "cz")
+    @parametrize_blas("geru", "cz")
     def test_geru(self, f, dtype):
         assert_array_almost_equal(f(1, [1j, 2], [3, 4]),
                                   [[3j, 4j], [6, 8]])
         assert_array_almost_equal(f(-2, [1j, 2j, 3j], [3j, 4j]),
                                   [[6, 8], [12, 16], [18, 24]])
 
-    @parametrize_blas(fblas, "gerc", "cz")
+    @parametrize_blas("gerc", "cz")
     def test_gerc(self, f, dtype):
         assert_array_almost_equal(f(1, [1j, 2], [3, 4]),
                                   [[3j, 4j], [6, 8]])
         assert_array_almost_equal(f(2, [1j, 2j, 3j], [3j, 4j]),
                                   [[6, 8], [12, 16], [18, 24]])
 
-    @parametrize_blas(fblas, "syr", "sdcz")
+    @parametrize_blas("syr", "sdcz")
     def test_syr(self, f, dtype):
         x = np.arange(1, 5, dtype='d')
         resx = np.triu(x[:, np.newaxis] * x)
@@ -263,7 +296,7 @@ class TestFBLAS2Simple:
         assert_raises(Exception, f, 1.0, x, lower=2)
         assert_raises(Exception, f, 1.0, x, a=np.zeros((2, 2), 'd', 'F'))
 
-    @parametrize_blas(fblas, "her", "cz")
+    @parametrize_blas("her", "cz")
     def test_her(self, f, dtype):
         x = np.arange(1, 5, dtype='d')
         z = np.arange(1, 9, dtype='d').view('D')
@@ -296,7 +329,7 @@ class TestFBLAS2Simple:
         assert_raises(Exception, f, 1.0, x, lower=2)
         assert_raises(Exception, f, 1.0, x, a=np.zeros((2, 2), 'd', 'F'))
 
-    @parametrize_blas(fblas, "syr2", "sd")
+    @parametrize_blas("syr2", "sd")
     def test_syr2(self, f, dtype):
         x = np.arange(1, 5, dtype='d')
         y = np.arange(5, 9, dtype='d')
@@ -338,7 +371,7 @@ class TestFBLAS2Simple:
         assert_raises(Exception, f, 1.0, x, y, lower=2)
         assert_raises(Exception, f, 1.0, x, y, a=np.zeros((2, 2), 'd', 'F'))
 
-    @parametrize_blas(fblas, "her2", "cz")
+    @parametrize_blas("her2", "cz")
     def test_her2(self, f, dtype):
         x = np.arange(1, 9, dtype='d').view('D')
         y = np.arange(9, 17, dtype='d').view('D')
@@ -387,8 +420,8 @@ class TestFBLAS2Simple:
         assert_raises(Exception, f, 1.0, x, y,
                       a=np.zeros((2, 2), 'd', 'F'))
 
-    @pytest.mark.parametrize("dtype", DTYPES)
-    def test_gbmv(self, dtype):
+    @parametrize_blas("gbmv", "sdcz")
+    def test_gbmv(self, f, dtype):
         rng = np.random.default_rng(1234)
         n = 7
         m = 5
@@ -410,7 +443,7 @@ class TestFBLAS2Simple:
         y = rng.random(m).astype(dtype)
         alpha, beta = dtype(3), dtype(-5)
 
-        func, = get_blas_funcs(('gbmv',), dtype=dtype)
+        func = f
         y1 = func(m=m, n=n, ku=ku, kl=kl, alpha=alpha, a=Ab,
                   x=x, y=y, beta=beta)
         y2 = alpha * A.dot(x) + beta * y
@@ -421,8 +454,14 @@ class TestFBLAS2Simple:
         y2 = alpha * A.T.dot(y) + beta * x
         assert_array_almost_equal(y1, y2)
 
+    @pytest.mark.parametrize("ilp64", [True, False])
     @pytest.mark.parametrize("dtype", DTYPES)
-    def test_sbmv_hbmv(self, dtype):
+    def test_sbmv_hbmv(self, dtype, ilp64):
+        mod = fblas_64 if ilp64 else fblas
+        if mod is None:
+            mod_name = "fblas_64" if ilp64 else "fblas"
+            pytest.skip(f"{mod_name} is not available")
+
         rng = np.random.default_rng(1234)
         n = 6
         k = 2
@@ -438,10 +477,10 @@ class TestFBLAS2Simple:
         A = A.astype(dtype)
         if dtype in COMPLEX_DTYPES:
             A += A.conj().T
-            func, = get_blas_funcs(('hbmv',), dtype=dtype)
+            func, = get_blas_funcs(('hbmv',), dtype=dtype, ilp64="preferred")
         else:
             A += A.T
-            func, = get_blas_funcs(('sbmv',), dtype=dtype)
+            func, = get_blas_funcs(('sbmv',), dtype=dtype, ilp64="preferred")
 
         Ab[-1, :] = diag(A)
         x = rng.random(n).astype(dtype)
@@ -452,11 +491,17 @@ class TestFBLAS2Simple:
         y2 = alpha * A.dot(x) + beta * y
         assert_array_almost_equal(y1, y2)
 
+    @pytest.mark.parametrize("ilp64", [True, False])
     @pytest.mark.parametrize("fname,dtype", [
         *[('spmv', dtype) for dtype in REAL_DTYPES + COMPLEX_DTYPES],
         *[('hpmv', dtype) for dtype in COMPLEX_DTYPES],
     ])
-    def test_spmv_hpmv(self, fname, dtype):
+    def test_spmv_hpmv(self, fname, dtype, ilp64):
+        mod = fblas_64 if ilp64 else fblas
+        if mod is None:
+            mod_name = "fblas_64" if ilp64 else "fblas"
+            pytest.skip(f"{mod_name} is not available")
+
         rng = np.random.default_rng(1234)
         n = 3
         A = rng.random((n, n)).astype(dtype)
@@ -471,7 +516,7 @@ class TestFBLAS2Simple:
         ylong = ones(2*n).astype(dtype)
         alpha, beta = dtype(1.25), dtype(2)
 
-        func, = get_blas_funcs((fname,), dtype=dtype)
+        func, = get_blas_funcs((fname,), dtype=dtype, ilp64="preferred")
         y1 = func(n=n, alpha=alpha, ap=Ap, x=x, y=y, beta=beta)
         y2 = alpha * A.dot(x) + beta * y
         assert_array_almost_equal(y1, y2)
@@ -483,11 +528,17 @@ class TestFBLAS2Simple:
         assert_array_almost_equal(y1[3::2], y2)
         assert_almost_equal(y1[4], ylong[4])
 
+    @pytest.mark.parametrize("ilp64", [True, False])
     @pytest.mark.parametrize("fname,dtype", [
         *[('spr', dtype) for dtype in REAL_DTYPES + COMPLEX_DTYPES],
         *[('hpr', dtype) for dtype in COMPLEX_DTYPES],
     ])
-    def test_spr_hpr(self, fname, dtype):
+    def test_spr_hpr(self, fname, dtype, ilp64):
+        mod = fblas_64 if ilp64 else fblas
+        if mod is None:
+            mod_name = "fblas_64" if ilp64 else "fblas"
+            pytest.skip(f"{mod_name} is not available")
+
         rng = np.random.default_rng(1234)
         n = 3
         A = rng.random((n, n)).astype(dtype)
@@ -500,10 +551,10 @@ class TestFBLAS2Simple:
 
         alpha = np.finfo(dtype).dtype.type(2.5)
         if fname == 'hpr':
-            func, = get_blas_funcs(('hpr',), dtype=dtype)
+            func, = get_blas_funcs(('hpr',), dtype=dtype, ilp64="preferred")
             y2 = alpha * x[:, None].dot(x[None, :].conj()) + A
         else:
-            func, = get_blas_funcs(('spr',), dtype=dtype)
+            func, = get_blas_funcs(('spr',), dtype=dtype, ilp64="preferred")
             y2 = alpha * x[:, None].dot(x[None, :]) + A
 
         y1 = func(n=n, alpha=alpha, ap=Ap, x=x)
@@ -512,18 +563,24 @@ class TestFBLAS2Simple:
         y1f[c, r] = y1.conj() if fname == 'hpr' else y1
         assert_array_almost_equal(y1f, y2)
 
+    @pytest.mark.parametrize("ilp64", [True, False])
     @pytest.mark.parametrize("dtype", DTYPES)
-    def test_spr2_hpr2(self, dtype):
+    def test_spr2_hpr2(self, dtype, ilp64):
+        mod = fblas_64 if ilp64 else fblas
+        if mod is None:
+            mod_name = "fblas_64" if ilp64 else "fblas"
+            pytest.skip(f"{mod_name} is not available")
+
         rng = np.random.default_rng(1234)
         n = 3
         A = rng.random((n, n)).astype(dtype)
         if dtype in COMPLEX_DTYPES:
             A += rng.random((n, n))*1j
             A += A.conj().T
-            func, = get_blas_funcs(('hpr2',), dtype=dtype)
+            func, = get_blas_funcs(('hpr2',), dtype=dtype, ilp64="preferred")
         else:
             A += A.T
-            func, = get_blas_funcs(('spr2',), dtype=dtype)
+            func, = get_blas_funcs(('spr2',), dtype=dtype, ilp64="preferred")
 
         c, r = tril_indices(n)
         Ap = A[r, c]
@@ -539,8 +596,8 @@ class TestFBLAS2Simple:
         y1f[[1, 2, 2], [0, 0, 1]] = y1[[1, 3, 4]].conj()
         assert_array_almost_equal(y1f, y2)
 
-    @pytest.mark.parametrize("dtype", DTYPES)
-    def test_tbmv(self, dtype):
+    @parametrize_blas('tbmv', 'sdcz')
+    def test_tbmv(self, f, dtype):
         rng = np.random.default_rng(1234)
         n = 10
         k = 3
@@ -558,7 +615,8 @@ class TestFBLAS2Simple:
         Ab = zeros((k+1, n), dtype=dtype)
         for row in range(k+1):
             Ab[-row-1, row:] = diag(A, k=row)
-        func, = get_blas_funcs(('tbmv',), dtype=dtype)
+        #func, = get_blas_funcs(('tbmv',), dtype=dtype)
+        func = f
 
         y1 = func(k=k, a=Ab, x=x)
         y2 = A.dot(x)
@@ -577,8 +635,8 @@ class TestFBLAS2Simple:
         y2 = A.conj().T.dot(x)
         assert_array_almost_equal(y1, y2)
 
-    @pytest.mark.parametrize("dtype", DTYPES)
-    def test_tbsv(self, dtype):
+    @parametrize_blas('tbsv', 'sdcz')
+    def test_tbsv(self, f, dtype):
         rng = np.random.default_rng(12345)
         n = 6
         k = 3
@@ -596,7 +654,7 @@ class TestFBLAS2Simple:
         Ab = zeros((k+1, n), dtype=dtype)
         for row in range(k+1):
             Ab[-row-1, row:] = diag(A, k=row)
-        func, = get_blas_funcs(('tbsv',), dtype=dtype)
+        func = f
 
         y1 = func(k=k, a=Ab, x=x)
         y2 = solve(A, x)
@@ -615,8 +673,8 @@ class TestFBLAS2Simple:
         y2 = solve(A.conj().T, x)
         assert_array_almost_equal(y1, y2)
 
-    @pytest.mark.parametrize("dtype", DTYPES)
-    def test_tpmv(self, dtype):
+    @parametrize_blas('tpmv', 'sdcz')
+    def test_tpmv(self, f, dtype):
         rng = np.random.default_rng(1234)
         n = 10
         x = rng.random(n).astype(dtype)
@@ -629,7 +687,7 @@ class TestFBLAS2Simple:
         # Form the packed storage
         c, r = tril_indices(n)
         Ap = A[r, c]
-        func, = get_blas_funcs(('tpmv',), dtype=dtype)
+        func = f
 
         y1 = func(n=n, ap=Ap, x=x)
         y2 = A.dot(x)
@@ -648,8 +706,8 @@ class TestFBLAS2Simple:
         y2 = A.conj().T.dot(x)
         assert_array_almost_equal(y1, y2)
 
-    @pytest.mark.parametrize("dtype", DTYPES)
-    def test_tpsv(self, dtype):
+    @parametrize_blas('tpsv', 'sdcz')
+    def test_tpsv(self, f, dtype):
         rng = np.random.default_rng(1234)
         n = 10
         x = rng.random(n).astype(dtype)
@@ -662,7 +720,7 @@ class TestFBLAS2Simple:
         # Form the packed storage
         c, r = tril_indices(n)
         Ap = A[r, c]
-        func, = get_blas_funcs(('tpsv',), dtype=dtype)
+        func = f
 
         y1 = func(n=n, ap=Ap, x=x)
         y2 = solve(A, x)
@@ -681,13 +739,13 @@ class TestFBLAS2Simple:
         y2 = solve(A.conj().T, x)
         assert_array_almost_equal(y1, y2)
 
-    @pytest.mark.parametrize("dtype", DTYPES)
-    def test_trmv(self, dtype):
+    @parametrize_blas('trmv', 'sdcz')
+    def test_trmv(self, f, dtype):
         rng = np.random.default_rng(1234)
         n = 3
         A = (rng.random((n, n))+eye(n)).astype(dtype)
         x = rng.random(3).astype(dtype)
-        func, = get_blas_funcs(('trmv',), dtype=dtype)
+        func = f
 
         y1 = func(a=A, x=x)
         y2 = triu(A).dot(x)
@@ -706,13 +764,13 @@ class TestFBLAS2Simple:
         y2 = triu(A).conj().T.dot(x)
         assert_array_almost_equal(y1, y2)
 
-    @pytest.mark.parametrize("dtype", DTYPES)
-    def test_trsv(self, dtype):
+    @parametrize_blas('trsv', 'sdcz')
+    def test_trsv(self, f, dtype):
         rng = np.random.default_rng(1234)
         n = 15
         A = (rng.random((n, n))+eye(n)).astype(dtype)
         x = rng.random(n).astype(dtype)
-        func, = get_blas_funcs(('trsv',), dtype=dtype)
+        func = f
 
         y1 = func(a=A, x=x)
         y2 = solve(triu(A), x)
@@ -737,7 +795,7 @@ class TestFBLAS2Simple:
 
 
 class TestFBLAS3Simple:
-    @parametrize_blas(fblas, "gemm", "sdcz")
+    @parametrize_blas("gemm", "sdcz")
     def test_gemm(self, f, dtype):
         assert_array_almost_equal(f(3, [3], [-4]), [[-36]])
         assert_array_almost_equal(f(3, [3], [-4], 3, [5]), [-21])
@@ -757,7 +815,7 @@ class TestBLAS3Symm:
         self.t = np.array([[2., -1., 8.],
                            [3., 0., 9.]])
 
-    @parametrize_blas(fblas, "symm", "sdcz")
+    @parametrize_blas("symm", "sdcz")
     def test_symm(self, f, dtype):
         res = f(a=self.a, b=self.b, c=self.c, alpha=1., beta=1.)
         assert_array_almost_equal(res, self.t)
@@ -769,7 +827,7 @@ class TestBLAS3Symm:
                 alpha=1., beta=1.)
         assert_array_almost_equal(res, self.t.T)
 
-    @parametrize_blas(fblas, "symm", "sdcz")
+    @parametrize_blas("symm", "sdcz")
     def test_symm_wrong_side(self, f, dtype):
         """`side=1` means C <- B*A, hence shapes of A and B are to be
         compatible. Otherwise, f2py exception is raised.
@@ -778,7 +836,7 @@ class TestBLAS3Symm:
         with pytest.raises(Exception):
             f(a=self.a, b=self.b, alpha=1, side=1)
 
-    @parametrize_blas(fblas, "symm", "sdcz")
+    @parametrize_blas("symm", "sdcz")
     def test_symm_wrong_uplo(self, f, dtype):
         """SYMM only considers the upper/lower part of A. Hence setting
         wrong value for `lower` (default is lower=0, meaning upper triangle)
@@ -801,7 +859,7 @@ class TestBLAS3Syrk:
         self.tt = np.array([[5., 6.],
                             [6., 13.]])
 
-    @parametrize_blas(fblas, "syrk", "sdcz")
+    @parametrize_blas("syrk", "sdcz")
     def test_syrk(self, f, dtype):
         c = f(a=self.a, alpha=1.)
         assert_array_almost_equal(np.triu(c), np.triu(self.t))
@@ -818,7 +876,7 @@ class TestBLAS3Syrk:
 
     # prints '0-th dimension must be fixed to 3 but got 5',
     # FIXME: suppress?
-    @parametrize_blas(fblas, "syrk", "sdcz")
+    @parametrize_blas("syrk", "sdcz")
     def test_syrk_wrong_c(self, f, dtype):
         # FIXME narrow down to _fblas.error
         with pytest.raises(Exception):
@@ -840,7 +898,7 @@ class TestBLAS3Syr2k:
         self.tt = np.array([[0., 1.],
                             [1., 6]])
 
-    @parametrize_blas(fblas, "syr2k", "sdcz")
+    @parametrize_blas("syr2k", "sdcz")
     def test_syr2k(self, f, dtype):
         c = f(a=self.a, b=self.b, alpha=1.)
         assert_array_almost_equal(np.triu(c), np.triu(self.t))
@@ -856,7 +914,7 @@ class TestBLAS3Syr2k:
         assert_array_almost_equal(np.triu(c), np.triu(self.tt))
 
     # prints '0-th dimension must be fixed to 3 but got 5', FIXME: suppress?
-    @parametrize_blas(fblas, "syr2k", "sdcz")
+    @parametrize_blas("syr2k", "sdcz")
     def test_syr2k_wrong_c(self, f, dtype):
         with pytest.raises(Exception):
             f(a=self.a, b=self.b, alpha=1., c=np.zeros((15, 8)))
@@ -870,34 +928,34 @@ class TestSyHe:
         self.sigma_y = np.array([[0., -1.j],
                                  [1.j, 0.]])
 
-    @parametrize_blas(fblas, "symm", "zc")
+    @parametrize_blas("symm", "zc")
     def test_symm(self, f, dtype):
         # NB: a is symmetric w/upper diag of ONLY
         res = f(a=self.sigma_y, b=self.sigma_y, alpha=1.)
         assert_array_almost_equal(np.triu(res), np.diag([1, -1]))
 
-    @parametrize_blas(fblas, "hemm", "zc")
+    @parametrize_blas("hemm", "zc")
     def test_hemm(self, f, dtype):
         # NB: a is hermitian w/upper diag of ONLY
         res = f(a=self.sigma_y, b=self.sigma_y, alpha=1.)
         assert_array_almost_equal(np.triu(res), np.diag([1, 1]))
 
-    @parametrize_blas(fblas, "syrk", "zc")
+    @parametrize_blas("syrk", "zc")
     def test_syrk(self, f, dtype):
         res = f(a=self.sigma_y, alpha=1.)
         assert_array_almost_equal(np.triu(res), np.diag([-1, -1]))
 
-    @parametrize_blas(fblas, "herk", "zc")
+    @parametrize_blas("herk", "zc")
     def test_herk(self, f, dtype):
         res = f(a=self.sigma_y, alpha=1.)
         assert_array_almost_equal(np.triu(res), np.diag([1, 1]))
 
-    @parametrize_blas(fblas, "syr2k", "zc")
+    @parametrize_blas("syr2k", "zc")
     def test_syr2k_zr(self, f, dtype):
         res = f(a=self.sigma_y, b=self.sigma_y, alpha=1.)
         assert_array_almost_equal(np.triu(res), 2.*np.diag([-1, -1]))
 
-    @parametrize_blas(fblas, "her2k", "zc")
+    @parametrize_blas("her2k", "zc")
     def test_her2k_zr(self, f, dtype):
         res = f(a=self.sigma_y, b=self.sigma_y, alpha=1.)
         assert_array_almost_equal(np.triu(res), 2.*np.diag([1, 1]))
@@ -919,9 +977,9 @@ class TestTRMM:
         self.b2 = np.array([[1, 4], [2, 5], [3, 6], [7, 8], [9, 10]],
                            order="f")
 
-    @pytest.mark.parametrize("dtype", DTYPES)
-    def test_side(self, dtype):
-        trmm = get_blas_funcs("trmm", dtype=dtype)
+    @parametrize_blas("trmm", "zc")
+    def test_side(self, f, dtype):
+        trmm = f
         # Provide large A array that works for side=1 but not 0 (see gh-10841)
         assert_raises(Exception, trmm, 1.0, self.a2, self.b2)
         res = trmm(1.0, self.a2.astype(dtype), self.b2.astype(dtype),
@@ -930,7 +988,7 @@ class TestTRMM:
         assert_allclose(res, self.b2 @ self.a2[:k, :k], rtol=0.,
                         atol=100*np.finfo(dtype).eps)
 
-    @parametrize_blas(fblas, "trmm", "sdcz")
+    @parametrize_blas("trmm", "sdcz")
     def test_ab(self, f, dtype):
         result = f(1., self.a, self.b)
         # default a is upper triangular
@@ -938,14 +996,14 @@ class TestTRMM:
                              [ 5.,  6., -2.]])
         assert_array_almost_equal(result, expected)
 
-    @parametrize_blas(fblas, "trmm", "sdcz")
+    @parametrize_blas("trmm", "sdcz")
     def test_ab_lower(self, f, dtype):
         result = f(1., self.a, self.b, lower=True)
         expected = np.array([[ 3.,  4., -1.],
                              [-1., -2.,  0.]])  # now a is lower triangular
         assert_array_almost_equal(result, expected)
 
-    @parametrize_blas(fblas, "trmm", "sdcz")
+    @parametrize_blas("trmm", "sdcz")
     def test_b_overwrites(self, f, dtype):
         # BLAS *trmm modifies B argument in-place.
         # Here the default is to copy, but this can be overridden
@@ -965,11 +1023,11 @@ class TestTRMM:
         assert_array_almost_equal(bcopy, result)
 
 
-@pytest.mark.parametrize("dtype", DTYPES)
-def test_trsm(dtype):
+@parametrize_blas("trsm", "sdcz")
+def test_trsm(f, dtype):
     rng = np.random.default_rng(1234)
     tol = np.finfo(dtype).eps*1000
-    func, = get_blas_funcs(('trsm',), dtype=dtype)
+    func = f #, = get_blas_funcs(('trsm',), dtype=dtype)
 
     # Test protection against size mismatches
     A = rng.random((4, 5)).astype(dtype)

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -13,7 +13,7 @@ from numpy import (arange, triu, tril, zeros, tril_indices, ones,
                    diag, append, eye, nonzero)
 
 import scipy
-from scipy.linalg import _fblas as fblas, get_blas_funcs, toeplitz, solve
+from scipy.linalg import get_blas_funcs, toeplitz, solve
 from scipy.linalg.blas import HAS_ILP64, HAS_LP64
 
 try:
@@ -23,16 +23,15 @@ except ImportError:
 
 try:
     from scipy.linalg import _fblas as fblas
+    FBLAS_ERROR = fblas.__fblas_error
 except ImportError:
     fblas = None
 
 try:
     from scipy.linalg import _fblas_64 as fblas_64
+    FBLAS_ERROR = fblas_64.__fblas_64_error
 except ImportError:
     fblas_64 = None
-
-
-print(f"{fblas = }  {fblas_64 = }  {cblas = }")
 
 
 REAL_DTYPES = [np.float32, np.float64]
@@ -138,6 +137,30 @@ def _dt_from_prefix(prefix):
 
 
 def parametrize_blas(func_name, prefixes, modules=None):
+    """Parametrize a test over BLAS prefixes, "sdcz", and over the BLAS modules,
+    `fblas,fblas_64,cblas`.
+
+    Given a func_name "gemm", this generates a pytest parametrization over up to 12
+    variants: sgemm, dgemm, cgemm, zgemm, each loaded from `fblas` (i.e. 32-bit LP64
+    variants), `fblas_64` (i.e. 64-bit ILP64 variants) and `cblas` (LP64 probably).
+
+    If a module is not available, the pytest parameter has a skip mark, so that the
+    test is skipped with a descriptive message.
+
+    The `cblas` variant here is historical, there's only a single test below, and
+    SciPy does not really use the cblas interface.
+
+    Parameters
+    ----------
+    func_name : str
+        The base name of a BLAS function, e.g. "gemm"
+    prefixes : str or sequence
+        BLAS prefixes to prepend to `func_name`.
+        E.g. ``func_name='gemm', prefixes='cz'`` generates `cgemm` and `zgemm`.
+    modules : sequence of ``(module, str)`` pairs
+        BLAS modules to fetch functions from. By default, use `fblas` (LP64 variant)
+        and fblas_64 (ILP64 variant).
+    """
     if modules is None:
         modules = [(fblas, "fblas"), (fblas_64, "fblas_64")]
 
@@ -155,7 +178,6 @@ def parametrize_blas(func_name, prefixes, modules=None):
                 # Fetch the BLAS function from the BLAS module. NB: if the name is not
                 # found in the module, it's a hard failure (all names must be present).
                 f = getattr(mod, prefix + func_name)
-                mark_kwd = {}
                 param_ = pytest.param(f, dtype, id=f"{mod_name}.{prefix}{func_name}")
 
             params.append(param_)
@@ -649,7 +671,6 @@ class TestFBLAS2Simple:
         Ab = zeros((k+1, n), dtype=dtype)
         for row in range(k+1):
             Ab[-row-1, row:] = diag(A, k=row)
-        #func, = get_blas_funcs(('tbmv',), dtype=dtype)
         func = f
 
         y1 = func(k=k, a=Ab, x=x)
@@ -1011,7 +1032,7 @@ class TestTRMM:
         self.b2 = np.array([[1, 4], [2, 5], [3, 6], [7, 8], [9, 10]],
                            order="f")
 
-    @parametrize_blas("trmm", "zc")
+    @parametrize_blas("trmm", "sdzc")
     def test_side(self, f, dtype):
         trmm = f
         # Provide large A array that works for side=1 but not 0 (see gh-10841)
@@ -1061,7 +1082,7 @@ class TestTRMM:
 def test_trsm(f, dtype):
     rng = np.random.default_rng(1234)
     tol = np.finfo(dtype).eps*1000
-    func = f #, = get_blas_funcs(('trsm',), dtype=dtype)
+    func = f
 
     # Test protection against size mismatches
     A = rng.random((4, 5)).astype(dtype)
@@ -1128,5 +1149,5 @@ def test_dnrm2_neg_incx():
     x = np.repeat(10, 9)
     incx = -1
     dnrm2 = scipy.linalg.blas.get_blas_funcs('nrm2', (x,), ilp64='preferred')
-    with assert_raises(fblas.__fblas_error):
+    with assert_raises(FBLAS_ERROR):
         dnrm2(x, 5, 3, incx)

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -14,7 +14,7 @@ from numpy import (arange, triu, tril, zeros, tril_indices, ones,
 
 import scipy
 from scipy.linalg import _fblas as fblas, get_blas_funcs, toeplitz, solve
-from scipy.linalg.blas import HAS_ILP64
+from scipy.linalg.blas import HAS_ILP64, HAS_LP64
 
 try:
     from scipy.linalg import _cblas as cblas
@@ -79,30 +79,38 @@ def test_get_blas_funcs():
     assert_equal(f1.typecode, 'z')
 
 
-@pytest.mark.skipif(fblas is None, reason="32-bit BLAS is not available")
-def test_get_blas_funcs_lp64():
-    # default is LP64
-    gemm = get_blas_funcs('gemm', (np.eye(3),))
-    assert gemm.int_dtype == np.int32
-
-    gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64=False)
-    assert gemm.int_dtype == np.int32
-
+def test_get_blas_funcs_ilp_preferred():
+    # "preferred" mean ILP64 if available LP64 otherwise
     gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64="preferred")
     assert gemm.int_dtype == np.int64 if HAS_ILP64 else np.int32
+    assert gemm.module_name == 'fblas_64' if HAS_ILP64 else 'fblas'
 
-
-@pytest.mark.skipif(fblas_64 is None, reason="64-bit BLAS is not available")
-def test_get_blas_funcs_ilp64():
-    # default is LP64
+    # default is "preferred"
     gemm = get_blas_funcs('gemm', (np.eye(3),))
-    assert gemm.int_dtype == np.int32
+    assert gemm.int_dtype == np.int64 if HAS_ILP64 else np.int32
+    assert gemm.module_name == 'fblas_64' if HAS_ILP64 else 'fblas'
 
-    gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64=True)
-    assert gemm.int_dtype == np.int32
 
-    gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64="preferred")
-    assert gemm.int_dtype == np.int64
+def test_get_blas_funcs_ilp_true():
+    # True is ILP64 or fail if not available
+    if HAS_ILP64:
+        gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64=True)
+        assert gemm.int_dtype == np.int64
+        assert gemm.module_name == 'fblas_64'
+    else:
+        with pytest.raises(RuntimeError):
+            get_blas_funcs('gemm', (np.eye(3),), ilp64=True)
+
+
+def test_get_blas_funcs_ilp_false():
+    # False is LP64 or fail if not available
+    if HAS_LP64:
+        gemm = get_blas_funcs('gemm', (np.eye(3),), ilp64=False)
+        assert gemm.int_dtype == np.int32
+        assert gemm.module_name == 'fblas'
+    else:
+        with pytest.raises(RuntimeError):
+            get_blas_funcs('gemm', (np.eye(3),), ilp64=False)
 
 
 def test_get_blas_funcs_alias():

--- a/scipy/linalg/tests/test_cython_lapack.py
+++ b/scipy/linalg/tests/test_cython_lapack.py
@@ -6,14 +6,21 @@ from scipy.linalg import lapack
 class TestLamch:
 
     def test_slamch(self):
+        lapack_slamch = lapack.get_lapack_funcs(
+            'lamch', dtype='float32', ilp64='preferred'
+        )
         for c in [b'e', b's', b'b', b'p', b'n', b'r', b'm', b'u', b'l', b'o']:
             assert_allclose(cython_lapack._test_slamch(c),
-                            lapack.slamch(c))
+                            lapack_slamch(c))
 
     def test_dlamch(self):
+        lapack_dlamch = lapack.get_lapack_funcs(
+            'lamch', dtype='float64', ilp64='preferred'
+        )
+
         for c in [b'e', b's', b'b', b'p', b'n', b'r', b'm', b'u', b'l', b'o']:
             assert_allclose(cython_lapack._test_dlamch(c),
-                            lapack.dlamch(c))
+                            lapack_dlamch(c))
 
     def test_complex_ladiv(self):
         cx = .5 + 1.j

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1943,13 +1943,11 @@ class TestQR:
             assert_equal(p.shape, (n,))
             assert_equal(p.dtype, np.int64 if HAS_ILP64 else np.int32)
 
-        q_e, r_e, *other = qr(a, mode='economic', pivoting=pivoting)
-        assert_equal(q_e.shape, (m, k))
-        assert_equal(q_e.dtype, dtype)
-        assert_equal(r_e.shape, (k, n))
-        assert_equal(r_e.dtype, dtype)
-        assert_equal(q_e, q[:, :k])
-        assert_equal(r_e, r[:k, :])
+        q, r, *other = qr(a, mode='economic', pivoting=pivoting)
+        assert_equal(q.shape, (m, k))
+        assert_equal(q.dtype, dtype)
+        assert_equal(r.shape, (k, n))
+        assert_equal(r.dtype, dtype)
         assert len(other) == (1 if pivoting else 0)
         if pivoting:
             p, = other

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -17,11 +17,7 @@ from scipy.linalg import (eig, eigvals, lu, svd, svdvals, cholesky, qr,
                           eigvalsh, qr_multiply, qz, orth, ordqz,
                           subspace_angles, hadamard, eigvalsh_tridiagonal,
                           eigh_tridiagonal, null_space, cdf2rdf, LinAlgError)
-
-from scipy.linalg.lapack import (dgbtrf, dgbtrs, zgbtrf, zgbtrs, dsbev,
-                                 dsbevd, dsbevx, zhbevd, zhbevx,
-                                 get_lapack_funcs)
-
+from scipy.linalg.lapack import get_lapack_funcs
 from scipy.linalg._misc import norm
 from scipy.linalg._decomp_qz import _select_function
 from scipy.stats import ortho_group
@@ -560,6 +556,8 @@ class TestEigBanded:
     def test_dsbev(self):
         """Compare dsbev eigenvalues and eigenvectors with
            the result of linalg.eig."""
+        dsbev = get_lapack_funcs('sbev', dtype=np.float64, ilp64="preferred")
+
         w, evec, info = dsbev(self.bandmat_sym, compute_v=1)
         evec_ = evec[:, argsort(w)]
         assert_array_almost_equal(sort(w), self.w_sym_lin)
@@ -568,6 +566,8 @@ class TestEigBanded:
     def test_dsbevd(self):
         """Compare dsbevd eigenvalues and eigenvectors with
            the result of linalg.eig."""
+        dsbevd = get_lapack_funcs('sbevd', dtype=np.float64, ilp64="preferred")
+
         w, evec, info = dsbevd(self.bandmat_sym, compute_v=1)
         evec_ = evec[:, argsort(w)]
         assert_array_almost_equal(sort(w), self.w_sym_lin)
@@ -577,6 +577,8 @@ class TestEigBanded:
         """Compare dsbevx eigenvalues and eigenvectors
            with the result of linalg.eig."""
         N, N = shape(self.sym_mat)
+        dsbevx = get_lapack_funcs('sbevx', dtype=np.float64, ilp64="preferred")
+
         # Achtung: Argumente 0.0,0.0,range?
         w, evec, num, ifail, info = dsbevx(self.bandmat_sym, 0.0, 0.0, 1, N,
                                            compute_v=1, range=2)
@@ -587,6 +589,8 @@ class TestEigBanded:
     def test_zhbevd(self):
         """Compare zhbevd eigenvalues and eigenvectors
            with the result of linalg.eig."""
+        zhbevd = get_lapack_funcs('hbevd', dtype=np.complex128, ilp64="preferred")
+
         w, evec, info = zhbevd(self.bandmat_herm, compute_v=1)
         evec_ = evec[:, argsort(w)]
         assert_array_almost_equal(sort(w), self.w_herm_lin)
@@ -596,6 +600,8 @@ class TestEigBanded:
         """Compare zhbevx eigenvalues and eigenvectors
            with the result of linalg.eig."""
         N, N = shape(self.herm_mat)
+        zhbevx = get_lapack_funcs('hbevx', dtype=np.complex128, ilp64="preferred")
+
         # Achtung: Argumente 0.0,0.0,range?
         w, evec, num, ifail, info = zhbevx(self.bandmat_herm, 0.0, 0.0, 1, N,
                                            compute_v=1, range=2)
@@ -706,6 +712,8 @@ class TestEigBanded:
     def test_dgbtrf(self):
         """Compare dgbtrf  LU factorisation with the LU factorisation result
            of linalg.lu."""
+        dgbtrf = get_lapack_funcs('gbtrf', dtype=np.float64, ilp64="preferred")
+
         M, N = shape(self.real_mat)
         lu_symm_band, ipiv, info = dgbtrf(self.bandmat_real, self.KL, self.KU)
 
@@ -721,6 +729,8 @@ class TestEigBanded:
         """Compare zgbtrf  LU factorisation with the LU factorisation result
            of linalg.lu."""
         M, N = shape(self.comp_mat)
+        zgbtrf = get_lapack_funcs('gbtrf', dtype=np.complex128, ilp64="preferred")
+
         lu_symm_band, ipiv, info = zgbtrf(self.bandmat_comp, self.KL, self.KU)
 
         # extract matrix u from lu_symm_band
@@ -734,6 +744,9 @@ class TestEigBanded:
     def test_dgbtrs(self):
         """Compare dgbtrs  solutions for linear equation system  A*x = b
            with solutions of linalg.solve."""
+        dgbtrf, dgbtrs = get_lapack_funcs(
+            ('gbtrf', 'gbtrs'), dtype=np.float64, ilp64="preferred"
+        )
 
         lu_symm_band, ipiv, info = dgbtrf(self.bandmat_real, self.KL, self.KU)
         y, info = dgbtrs(lu_symm_band, self.KL, self.KU, self.b, ipiv)
@@ -744,6 +757,9 @@ class TestEigBanded:
     def test_zgbtrs(self):
         """Compare zgbtrs  solutions for linear equation system  A*x = b
            with solutions of linalg.solve."""
+        zgbtrf, zgbtrs = get_lapack_funcs(
+            ('gbtrf', 'gbtrs'), dtype=np.complex128, ilp64="preferred"
+        )
 
         lu_symm_band, ipiv, info = zgbtrf(self.bandmat_comp, self.KL, self.KU)
         y, info = zgbtrs(lu_symm_band, self.KL, self.KU, self.bc, ipiv)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -17,6 +17,8 @@ from scipy.linalg import (eig, eigvals, lu, svd, svdvals, cholesky, qr,
                           eigvalsh, qr_multiply, qz, orth, ordqz,
                           subspace_angles, hadamard, eigvalsh_tridiagonal,
                           eigh_tridiagonal, null_space, cdf2rdf, LinAlgError)
+
+
 from scipy.linalg.lapack import get_lapack_funcs
 from scipy.linalg._misc import norm
 from scipy.linalg._decomp_qz import _select_function

--- a/scipy/linalg/tests/test_decomp_lu.py
+++ b/scipy/linalg/tests/test_decomp_lu.py
@@ -6,6 +6,7 @@ from scipy.linalg import lu, lu_factor, lu_solve, get_lapack_funcs, solve
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 from scipy.linalg.lapack import HAS_ILP64
 
+
 REAL_DTYPES = [np.float32, np.float64]
 COMPLEX_DTYPES = [np.complex64, np.complex128]
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES

--- a/scipy/linalg/tests/test_decomp_lu.py
+++ b/scipy/linalg/tests/test_decomp_lu.py
@@ -4,7 +4,7 @@ from pytest import raises as assert_raises
 import numpy as np
 from scipy.linalg import lu, lu_factor, lu_solve, get_lapack_funcs, solve
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
-
+from scipy.linalg.lapack import HAS_ILP64
 
 REAL_DTYPES = [np.float32, np.float64]
 COMPLEX_DTYPES = [np.complex64, np.complex128]
@@ -258,7 +258,7 @@ class TestLUFactor:
         assert_equal(lu.shape, (m, n))
         assert_equal(lu.dtype, dtype)
         assert_equal(p.shape, (k,))
-        assert_equal(p.dtype, np.int32)
+        assert_equal(p.dtype, np.int64 if HAS_ILP64 else np.int32)
 
     @pytest.mark.parametrize(("m", "n"), [(0, 0), (0, 2), (2, 0)])
     def test_empty(self, m, n):

--- a/scipy/linalg/tests/test_extending.py
+++ b/scipy/linalg/tests/test_extending.py
@@ -29,7 +29,7 @@ def test_cython(tmp_path):
     b = np.ones(9)
     c = np.ones(8) * 4
     x = np.ones(9)
-    dgtsv = get_lapack_funcs('gtsv', dtype=np.float64, ilp64="preferred")   # XXX: check ILP64 build
+    dgtsv = get_lapack_funcs('gtsv', dtype=np.float64, ilp64="preferred")
     _, _, _, x, _ = dgtsv(a, b, c, x)
     a = np.ones(8) * 3
     b = np.ones(9)

--- a/scipy/linalg/tests/test_extending.py
+++ b/scipy/linalg/tests/test_extending.py
@@ -6,8 +6,8 @@ import numpy as np
 import pytest
 
 from scipy._lib._testutils import IS_EDITABLE, _test_cython_extension, cython
-from scipy.linalg.blas import cdotu  # type: ignore[attr-defined]
-from scipy.linalg.lapack import dgtsv  # type: ignore[attr-defined]
+from scipy.linalg.blas import get_blas_funcs
+from scipy.linalg.lapack import get_lapack_funcs
 
 
 @pytest.mark.parallel_threads_limit(4)  # 0.35 GiB per thread RAM usage
@@ -29,6 +29,7 @@ def test_cython(tmp_path):
     b = np.ones(9)
     c = np.ones(8) * 4
     x = np.ones(9)
+    dgtsv = get_lapack_funcs('gtsv', dtype=np.float64, ilp64="preferred")   # XXX: check ILP64 build
     _, _, _, x, _ = dgtsv(a, b, c, x)
     a = np.ones(8) * 3
     b = np.ones(9)
@@ -43,5 +44,6 @@ def test_cython(tmp_path):
     np.testing.assert_array_equal(x, x_cpp)
     cx = np.array([1-1j, 2+2j, 3-3j], dtype=np.complex64)
     cy = np.array([4+4j, 5-5j, 6+6j], dtype=np.complex64)
+    cdotu = get_blas_funcs('dotu', dtype=np.complex64, ilp64="preferred")
     np.testing.assert_array_equal(cdotu(cx, cy), extensions.complex_dot(cx, cy))
     np.testing.assert_array_equal(cdotu(cx, cy), extensions_cpp.complex_dot(cx, cy))

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -81,7 +81,6 @@ def test_lp64_ilp64_blas_lapack_both_or_none():
     assert blas_has_lp64 == lapack_has_lp64
 
 
-
 class TestFlapackSimple:
 
     def test_gebal(self):

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -60,6 +60,7 @@ def test_lapack_documented():
         "flapack",
         "print_function",
         "HAS_ILP64",
+        "HAS_LP64",
         "np",
     }
     missing = list()
@@ -70,10 +71,15 @@ def test_lapack_documented():
     assert missing == [], 'Name(s) missing from lapack.__doc__ or ignore_list'
 
 
-def test_ilp64_blas_lapack_both_or_none():
+def test_lp64_ilp64_blas_lapack_both_or_none():
     from scipy.linalg.blas import HAS_ILP64 as blas_has_ilp64
     from scipy.linalg.lapack import HAS_ILP64 as lapack_has_ilp64
     assert blas_has_ilp64 == lapack_has_ilp64
+
+    from scipy.linalg.blas import HAS_LP64 as blas_has_lp64
+    from scipy.linalg.lapack import HAS_LP64 as lapack_has_lp64
+    assert blas_has_lp64 == lapack_has_lp64
+
 
 
 class TestFlapackSimple:

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -84,8 +84,8 @@ class TestFlapackSimple:
               [4, 0, 0, 2e-3],
               [7, 1, 0, 0],
               [0, 1, 0, 0]]
-        for p in 'sdzc':
-            f = getattr(flapack, p+'gebal', None)
+        for dtype in DTYPES:
+            f = get_lapack_funcs('gebal', dtype=dtype)
             if f is None:
                 continue
             ba, lo, hi, pivscale, info = f(a)
@@ -103,8 +103,8 @@ class TestFlapackSimple:
         a = [[-149, -50, -154],
              [537, 180, 546],
              [-27, -9, -25]]
-        for p in 'd':
-            f = getattr(flapack, p+'gehrd', None)
+        for dtype in [np.float64]:
+            f = get_lapack_funcs('gehrd', dtype=dtype)
             if f is None:
                 continue
             ht, tau, info = f(a)

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -13,7 +13,7 @@ from scipy.special import (gammaln, psi, multigammaln, xlogy, entr, betaln,
 from scipy import special
 import scipy._external.array_api_extra as xpx
 from scipy._lib._util import check_random_state
-from scipy.linalg.blas import drot, get_blas_funcs
+from scipy.linalg.blas import get_blas_funcs
 from ._continuous_distns import norm, invgamma
 from ._discrete_distns import binom
 from . import _covariance, _rcont
@@ -4732,6 +4732,8 @@ class random_correlation_gen(multi_rv_generic):
         if not (m.flags.c_contiguous and m.dtype == np.float64 and
                 m.shape[0] == m.shape[1]):
             raise ValueError()
+
+        drot = get_blas_funcs('rot', dtype=np.float64, ilp64='preferred')
 
         d = m.shape[0]
         for i in range(d-1):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/23351

#### What does this implement/fix?
<!--Please explain your changes.-->

- Replace bare imports from `scipy.linalg.{blas,lapack}` by `get_{blas,lapack}_funcs` instead, so that LAPACK usage ILP64-ready. 
- change the default to `ilp64="preferred"` from `False`. The current default does not make much sense if LP64 is not always available (gh-24800)

While at it, expand testing, parametrize tests for LP64 and ILP64.


#### Additional information
<!--Any additional information you think is important.-->

This will need a follow-up PR, after this one and gh-24800, to
- plumb the new `HAS_LP64` flag to `__config__`, similar to `HAS_ILP64`
- grab the BLAS symbols from `_fblas_64` if `_fblas` is not available, same for LAPACK.
- add the docs to stress the use `get_lapack_funcs` instead of bare symbols. 

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.