### PR TITLE
TST: stats.make_distribution: avoid fail-slow failures

### DIFF
--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1496,6 +1496,8 @@ class TestMakeDistribution:
         assert repr(dist(beta=2)) == "HalfGeneralizedNormal(beta=np.float64(2.0))"
         assert 'HalfGeneralizedNormal' in dist.__doc__
 
+    @pytest.mark.slow  # just in case
+    @settings(max_examples=20)  # no need for more
     @given(data=strategies.data())
     def test_draw_distribution(self, data):
         # `draw_distribution_from_family` is a private function right now, but we will


### PR DESCRIPTION
#### Reference issue
gh-24785

#### What does this implement/fix?
Applies comment from gh-24785 to avoid some pytest-fail-slow failures in CI.

#### AI Generation Disclosure
No AI
