### PR TITLE
CI: avoid saving cache on non-main branches, include job name in cache key

### DIFF
--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -2,7 +2,10 @@ name: Setup Compiler Cache
 description: Prepare and restore compiler cache using ccache
 inputs:
   workflow_name:
-    description: "Unique name of the calling workflow to use as cache key prefix"
+    description: "Name of the calling workflow to use as cache key prefix"
+    required: true
+  job_name:
+    description: "Name of the calling job, used as cache key prefix"
     required: true
 
 runs:
@@ -21,4 +24,4 @@ runs:
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}
         key: ${{ inputs.workflow_name }}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}
-        restore-keys: ${{ inputs.workflow_name }}-ccache-linux-
+        restore-keys: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-

--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -23,5 +23,5 @@ runs:
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}
-        key: ${{ inputs.workflow_name }}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}
+        key: ${{ inputs.workflow_name }}-${{ inputs.job_name}}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}
         restore-keys: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-

--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -19,8 +19,20 @@ runs:
         echo "dir=${CCACHE_DIR:-$HOME/.ccache}" >> $GITHUB_OUTPUT
         NOW=$(date -u +"%F-%T")
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-    - name: Setup compiler cache
+    - name: Setup compiler cache and save it
+      # Run a restore and save if running on main
+      # Note: we can't simply use restore followed by save because composite actions
+      # are not capable of running post job steps.
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
+      with:
+        path: ${{ steps.prep-ccache.outputs.dir }}
+        key: ${{ inputs.workflow_name }}-${{ inputs.job_name}}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}
+        restore-keys: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-
+    - name: Setup compiler cache
+      # Run just the restore if not running on main
+      if: ${{ github.ref != 'refs/heads/main' }}
+      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}
         key: ${{ inputs.workflow_name }}-${{ inputs.job_name}}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -54,6 +54,7 @@ jobs:
         uses: ./.github/ccache
         with:
           workflow_name: ${{ github.workflow }}
+          job_name: ${{ github.job }}
 
       - name: Build
         run: pixi run build-cpu

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,6 +78,7 @@ jobs:
       uses: ./.github/ccache
       with:
         workflow_name: ${{ github.workflow }}
+        job_name: ${{ github.job }}
 
     - name: Setup build and install scipy
       run: |
@@ -151,6 +152,7 @@ jobs:
       uses: ./.github/ccache
       with:
         workflow_name: ${{ github.workflow }}
+        job_name: ${{ github.job }}
 
     - name: Create venv, install SciPy
       run: |
@@ -219,6 +221,7 @@ jobs:
         uses: ./.github/ccache
         with:
           workflow_name: ${{ github.workflow }}
+          job_name: ${{ github.job }}
 
       - name: Build SciPy
         run: |
@@ -271,6 +274,7 @@ jobs:
         uses: ./.github/ccache
         with:
           workflow_name: ${{ github.workflow }}
+          job_name: ${{ github.job }}
 
       - name: Build wheel and install
         run: |
@@ -338,6 +342,7 @@ jobs:
       uses: ./.github/ccache
       with:
         workflow_name: ${{ github.workflow }}
+        job_name: ${{ github.job }}
 
     - name: Build and install SciPy
       run: |
@@ -383,6 +388,7 @@ jobs:
       uses: ./.github/ccache
       with:
         workflow_name: ${{ github.workflow }}
+        job_name: ${{ github.job }}
 
     - name: build + test
       run: |
@@ -441,6 +447,7 @@ jobs:
         uses: ./.github/ccache
         with:
           workflow_name: ${{ github.workflow }}
+          job_name: ${{ github.job }}
 
       - name: Setup Python build deps
         run: |
@@ -495,6 +502,7 @@ jobs:
         uses: ./.github/ccache
         with:
           workflow_name: ${{ github.workflow }}
+          job_name: ${{ github.job }}
 
       - name: Install global meson
         run: |
@@ -564,6 +572,7 @@ jobs:
       uses: ./.github/ccache
       with:
         workflow_name: ${{ github.workflow }}
+        job_name: ${{ github.job }}
 
     - name: Install Python dependencies
       run: |
@@ -735,6 +744,7 @@ jobs:
         uses: ./.github/ccache
         with:
           workflow_name: ${{ github.workflow }}
+          job_name: ${{ github.job }}
 
       - name: Build SciPy
         run: pixi run build --setup-args=-D_without-fortran=true


### PR DESCRIPTION
This PR makes two changes:

 * To prevent one Linux job from restoring another job's cache, it includes the job name in the cache key.
 * It avoids saving cache contents on non-main branches to hopefully lower cache usage. (Cache entries on main are available to all jobs, but cache entries on other branches are only available to that job.)

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #24795
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

AI was used to research this issue, and provided the `${{ github.job }}` syntax, which I verified with documentation.