### PR TITLE
ENH: stats.contingency: add array API support for `margins` and `expected_freq`

### DIFF
--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -69,6 +69,8 @@ New features
 ``scipy.stats`` improvements
 ============================
 
+- `scipy.stats.contingency.margins` and `scipy.stats.contingency.expected_freq`
+  now support the array API standard.
 
 
 *******************

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -28,7 +28,7 @@ from ._stats_py import power_divergence, _untabulate
 from ._relative_risk import relative_risk
 from ._crosstab import crosstab
 from ._odds_ratio import odds_ratio
-from scipy._lib._array_api import xp_capabilities
+from scipy._lib._array_api import xp_capabilities, array_namespace, xp_promote
 from scipy._lib._bunch import _make_tuple_bunch
 from scipy import stats
 
@@ -37,7 +37,7 @@ __all__ = ['margins', 'expected_freq', 'chi2_contingency', 'crosstab',
            'association', 'relative_risk', 'odds_ratio']
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities()
 def margins(a):
     """Return a list of the marginal sums of the array `a`.
 
@@ -82,15 +82,16 @@ def margins(a):
     >>> m2
     array([[[60, 66, 72, 78]]])
     """
+    xp = array_namespace(a)
     margsums = []
     ranged = list(range(a.ndim))
     for k in ranged:
-        marg = np.apply_over_axes(np.sum, a, [j for j in ranged if j != k])
+        marg = xp.sum(a, axis=tuple(j for j in ranged if j != k), keepdims=True)
         margsums.append(marg)
     return margsums
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities()
 def expected_freq(observed):
     """
     Compute the expected frequencies from a contingency table.
@@ -126,16 +127,17 @@ def expected_freq(observed):
     # Typically `observed` is an integer array. If `observed` has a large
     # number of dimensions or holds large values, some of the following
     # computations may overflow, so we first switch to floating point.
-    observed = np.asarray(observed, dtype=np.float64)
+    xp = array_namespace(observed)
+    observed = xp_promote(observed, force_floating=True, xp=xp)
 
     # Create a list of the marginal sums.
     margsums = margins(observed)
 
     # Create the array of expected frequencies.  The shapes of the
-    # marginal sums returned by apply_over_axes() are just what we
-    # need for broadcasting in the following product.
+    # marginal sums returned by margins() are just what we need for
+    # broadcasting in the following product.
     d = observed.ndim
-    expected = reduce(np.multiply, margsums) / observed.sum() ** (d - 1)
+    expected = reduce(xp.multiply, margsums) / observed.sum() ** (d - 1)
     return expected
 
 

--- a/scipy/stats/contingency.py
+++ b/scipy/stats/contingency.py
@@ -137,7 +137,7 @@ def expected_freq(observed):
     # marginal sums returned by margins() are just what we need for
     # broadcasting in the following product.
     d = observed.ndim
-    expected = reduce(xp.multiply, margsums) / observed.sum() ** (d - 1)
+    expected = reduce(xp.multiply, margsums) / xp.sum(observed) ** (d - 1)
     return expected
 
 

--- a/scipy/stats/tests/test_contingency.py
+++ b/scipy/stats/tests/test_contingency.py
@@ -1,7 +1,6 @@
 import numpy as np
 from numpy.testing import (assert_equal, assert_array_equal,
-                           assert_array_almost_equal, assert_approx_equal,
-                           assert_allclose)
+                           assert_approx_equal, assert_allclose)
 import pytest
 from pytest import raises as assert_raises
 from scipy import stats

--- a/scipy/stats/tests/test_contingency.py
+++ b/scipy/stats/tests/test_contingency.py
@@ -9,49 +9,61 @@ from scipy.special import xlogy
 from scipy.stats.contingency import (margins, expected_freq,
                                      chi2_contingency, association)
 
+from scipy._lib._array_api import make_xp_test_case
+from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 
-def test_margins():
-    a = np.array([1])
-    m = margins(a)
-    assert_equal(len(m), 1)
-    m0 = m[0]
-    assert_array_equal(m0, np.array([1]))
-
-    a = np.array([[1]])
-    m0, m1 = margins(a)
-    expected0 = np.array([[1]])
-    expected1 = np.array([[1]])
-    assert_array_equal(m0, expected0)
-    assert_array_equal(m1, expected1)
-
-    a = np.arange(12).reshape(2, 6)
-    m0, m1 = margins(a)
-    expected0 = np.array([[15], [51]])
-    expected1 = np.array([[6, 8, 10, 12, 14, 16]])
-    assert_array_equal(m0, expected0)
-    assert_array_equal(m1, expected1)
-
-    a = np.arange(24).reshape(2, 3, 4)
-    m0, m1, m2 = margins(a)
-    expected0 = np.array([[[66]], [[210]]])
-    expected1 = np.array([[[60], [92], [124]]])
-    expected2 = np.array([[[60, 66, 72, 78]]])
-    assert_array_equal(m0, expected0)
-    assert_array_equal(m1, expected1)
-    assert_array_equal(m2, expected2)
+lazy_xp_modules = [stats]
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 
-def test_expected_freq():
-    assert_array_equal(expected_freq([1]), np.array([1.0]))
+@make_xp_test_case(margins)
+class TestMargins:
 
-    observed = np.array([[[2, 0], [0, 2]], [[0, 2], [2, 0]], [[1, 1], [1, 1]]])
-    e = expected_freq(observed)
-    assert_array_equal(e, np.ones_like(observed))
+    def test_1d(self, xp):
+        a = xp.asarray([1])
+        m = margins(a)
+        assert_equal(len(m), 1)
+        xp_assert_equal(m[0], xp.asarray([1]))
 
-    observed = np.array([[10, 10, 20], [20, 20, 20]])
-    e = expected_freq(observed)
-    correct = np.array([[12., 12., 16.], [18., 18., 24.]])
-    assert_array_almost_equal(e, correct)
+    def test_2d_trivial(self, xp):
+        a = xp.asarray([[1]])
+        m0, m1 = margins(a)
+        xp_assert_equal(m0, xp.asarray([[1]]))
+        xp_assert_equal(m1, xp.asarray([[1]]))
+
+    def test_2d(self, xp):
+        a = xp.reshape(xp.arange(12), (2, 6))
+        m0, m1 = margins(a)
+        xp_assert_equal(m0, xp.asarray([[15], [51]]))
+        xp_assert_equal(m1, xp.asarray([[6, 8, 10, 12, 14, 16]]))
+
+    def test_3d(self, xp):
+        a = xp.reshape(xp.arange(24), (2, 3, 4))
+        m0, m1, m2 = margins(a)
+        xp_assert_equal(m0, xp.asarray([[[66]], [[210]]]))
+        xp_assert_equal(m1, xp.asarray([[[60], [92], [124]]]))
+        xp_assert_equal(m2, xp.asarray([[[60, 66, 72, 78]]]))
+
+
+@make_xp_test_case(expected_freq)
+class TestExpectedFreq:
+
+    def test_1d(self, xp):
+        obs = xp.asarray([1])
+        xp_assert_close(expected_freq(obs), xp.asarray([1.0]))
+
+    def test_3d(self, xp):
+        observed = xp.asarray([[[2, 0], [0, 2]],
+                                [[0, 2], [2, 0]],
+                                [[1, 1], [1, 1]]])
+        e = expected_freq(observed)
+        xp_assert_close(e, xp.ones_like(e))
+
+    def test_2d(self, xp):
+        observed = xp.asarray([[10, 10, 20], [20, 20, 20]])
+        e = expected_freq(observed)
+        correct = xp.asarray([[12., 12., 16.], [18., 18., 24.]])
+        xp_assert_close(e, correct)
 
 
 class TestChi2Contingency:


### PR DESCRIPTION
- [ ] Towards gh-20544

## What does this implement/fix?

Adds array API standard support to `scipy.stats.contingency.margins` and `scipy.stats.contingency.expected_freq`.

Changes:
- `margins`: Replace `np.apply_over_axes(np.sum, ...)` with `xp.sum(..., keepdims=True)`
- `expected_freq`: Replace `np.asarray(..., dtype=np.float64)` with `xp_promote(..., force_floating=True)` and `np.multiply` with `xp.multiply`
- Both decorated with `@xp_capabilities()` instead of `@xp_capabilities(np_only=True)`
- Tests converted to `@make_xp_test_case` class pattern with `xp` fixture
- Release note added for 1.18.0

## Additional information

`chi2_contingency` remains `np_only=True` and always passes numpy arrays to these functions, so it continues to work identically.

The original observation was that this seemed to be an unwritten rule being followed in https://github.com/scipy/scipy/commit/93d4114a3889c66121e90d36411e9159a64e6bd7

## AI Generation Disclosure

AI tools were used in developing this PR. Their primary usage was via a proprietary research pipeline of my own authorship that I ran to find unwritten rules that could be better enforced via enhancements and/or tests. Beyond that, I relied upon a commercial coding agent to assist in the planning and implementation of the feature as well as the documentation of this comment. At no point was it operating autonomously. I am the sole and responsible author. I believe this to be a useful submission, in support of the larger array API effort, and I understand its technical approach and can speak to concerns if raised.