### PR TITLE
ENH: add ILP64 support to cython_blas/cython_lapack Cython API

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -661,17 +661,51 @@ def lint(ctx, fix, diff_against, files, all, no_cython):
     '--symbol-hiding', default=False, is_flag=True,
     help='Check whether symbol hiding in extension modules is correct (GCC-only)')
 @click.option(
+    '--loaded-sharedlibs', default=False, is_flag=True,
+    help='Show shared libraries loaded by numpy/scipy imports (see examples '
+         'for options)')
+@click.option(
     '--no-build', default=False, is_flag=True,
     help='Build SciPy before running checks')
 @meson.build_dir_option
+@click.argument('extra_args', nargs=-1)
 @click.pass_context
-def check(ctx, xp_markers, installed_files, symbol_hiding, no_build, build_dir=None):
+def check(ctx, xp_markers, installed_files, symbol_hiding, loaded_sharedlibs, no_build,
+          build_dir=None, extra_args=()):
     """🔧  Run checks specific to the SciPy code base.
 
     Exactly one check can be run at once. Example:
 
       \b
-      spin check --xp-markers
+      $ spin check --xp-markers
+
+    The --loaded-sharedlibs check takes positional arguments for imports to use, and has
+    two options to expand the amount of detail shown:
+
+      \b
+      -s, --show-stdlib      Show Python stdlib extension modules (lib-dynload/)
+      -e, --show-extensions  Show numpy/scipy extension modules
+
+    Examples (see `tools/verify_loaded_sharedlibs.py` for more examples):
+
+      \b
+      $ spin check --loaded-sharedlibs numpy scipy.linalg -- -s
+      $ spin check --loaded-sharedlibs numpy scipy.linalg
+
+      \b
+      numpy pulled in:
+        <prefix>/lib/libffi.so.8.2.0
+        <prefix>/lib/libgcc_s.so.1
+        <prefix>/lib/libgfortran.so.5.0.0
+        <prefix>/lib/libopenblasp-r0.3.30.so
+        <prefix>/lib/libquadmath.so.0.0.0
+        <prefix>/lib/libstdc++.so.6.0.34
+        (4 stdlib + 2 numpy/scipy extension modules hidden)
+
+      \b
+      scipy.linalg pulled in:
+        <prefix>/lib/libcrypto.so.3
+        (12 stdlib + 23 numpy/scipy extension modules hidden)
 
     """
     # Checks are typically useful enough to run in CI or maintain a custom script for,
@@ -682,7 +716,7 @@ def check(ctx, xp_markers, installed_files, symbol_hiding, no_build, build_dir=N
     #
     # These checks, unlike the `lint` ones, are allowed (but don't have to) require
     # building or importing `scipy`.
-    options = [xp_markers, installed_files, symbol_hiding]
+    options = [xp_markers, installed_files, symbol_hiding, loaded_sharedlibs]
     if not sum(options) == 1:
         click.secho(
             f"Exactly one option to `check` should be given, found {sum(options)} - "
@@ -716,6 +750,11 @@ def check(ctx, xp_markers, installed_files, symbol_hiding, no_build, build_dir=N
         script = os.path.join(os.path.abspath('tools'),
                               'check_pyext_symbol_hiding.sh')
         util.run([script, install_dir])
+
+    if loaded_sharedlibs:
+        cmd = [sys.executable, os.path.join('tools', 'verify_loaded_sharedlibs.py')]
+        cmd.extend(extra_args)
+        util.run(cmd)
 
 
 # From scipy: benchmarks/benchmarks/common.py

--- a/doc/source/building/blas_lapack.rst
+++ b/doc/source/building/blas_lapack.rst
@@ -99,14 +99,21 @@ user wants to override this autodetection mechanism for building against plain
 64-bit integer (ILP64) BLAS/LAPACK
 ----------------------------------
 
-Support for ILP64 BLAS and LAPACK is still experimental; at the time of writing
-(July 2025) it is only available for two BLAS/LAPACK configurations: MKL and
-``scipy-openblas``.
+Support for ILP64 BLAS and LAPACK is still **experimental**; at the time of
+writing (March 2026) it is only available for three BLAS/LAPACK configurations:
+MKL, Accelerate, and ``scipy-openblas``.
 
 SciPy always requires LP64 (32-bit integer size) BLAS/LAPACK. You can build SciPy
 with *additional* ILP64 support. This will result in SciPy requiring both BLAS and
 LAPACK variants, where some extensions link to the ILP64 variant, while other
 extensions link to the LP64 variant.
+
+.. note::
+   The requirement that SciPy always requires LP64 is very likely changing for the
+   1.18.0 release. Once all SciPy internals support ILP64, the default will be
+   to make a build from source that requests ILP64 with ``-Duse-ilp64=true``
+   use ILP64 for the low-level Python and Cython APIs in ``scipy.linalg`` as well
+   (more on that in the next section below).
 
 Building with ILP64 support requires BLAS/LAPACK support in ``meson``, which isn't
 yet merged upstream (see `meson#10921
@@ -132,11 +139,9 @@ for the ILP64 variant::
 From Python, low-level BLAS and LAPACK functions are available from ``scipy.linalg.blas``
 and ``scipy.linalg.lapack`` namespaces. For backwards compatibility, importing a name
 from either of these namespaces always gives you an LP64 variant, regardless of
-whether SciPy is built with or without the ILP64 support:
+whether SciPy is built with or without the ILP64 support::
 
-```
->>> from scipy.linalg.blas import dgemm     # this is an LP64 function
-```
+    >>> from scipy.linalg.blas import dgemm     # this is an LP64 function
 
 To choose the variant of a low-level routine, use ``get_blas_funcs`` and
 ``get_lapack_funcs`` functions::
@@ -148,6 +153,39 @@ To choose the variant of a low-level routine, use ``get_blas_funcs`` and
 
 High-level linear algebra functions (``norm``, ``solve`` and so on) should use this
 mechanism under the hood.
+
+
+Cython BLAS/LAPACK integer ABI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Cython BLAS and LAPACK API (``scipy.linalg.cython_blas`` and
+``scipy.linalg.cython_lapack``) uses the ``blas_int`` type for all integer
+parameters. By default, ``blas_int`` follows the ``use-ilp64`` setting: it is
+``int`` (32-bit) for LP64 builds and ``int64_t`` (64-bit) for ILP64 builds.
+
+This can be overridden with the ``-Dcython-blas-abi`` build option, which
+accepts three values:
+
+- ``auto`` (default): follows the ``use-ilp64`` setting
+- ``lp64``: always use 32-bit integers, even when ``use-ilp64=true``
+- ``ilp64``: always use 64-bit integers
+
+For example, to build with ILP64 BLAS/LAPACK but keep the Cython API at LP64
+(for downstream compatibility)::
+
+    $ spin build -S-Dblas=accelerate -S-Duse-ilp64=true -S-Dcython-blas-abi=lp64
+
+This is useful primarily for Accelerate, which has good support for using both
+LP64 and ILP64 at the same time. That is the only library with solid support though;
+MKL has some support but it's more fragile (because it uses un-suffixed symbols for LP64,
+hence another library loading those same symbols in the same process may result in
+symbol clashes). Other BLAS libraries don't currently have this "dual ABI"
+build option. It may be useful to have SciPy itself use ILP64 but keeping the
+Cython API at LP64 because downstream packages may not yet support 64-bit
+integers in their Cython BLAS/LAPACK calls.
+
+The build configuration can be checked at runtime via
+``scipy.show_config()`` — look for the ``blas_cython_ilp64`` entry.
 
 
 Work-in-progress

--- a/meson.options
+++ b/meson.options
@@ -7,6 +7,10 @@ option('lapack', type: 'string', value: 'openblas',
 # See https://scipy.github.io/devdocs/building/blas_lapack.html for details
 option('use-ilp64', type: 'boolean', value: false,
        description: 'Use ILP64 (64-bit integer) BLAS and LAPACK interfaces')
+option('cython-blas-abi', type: 'combo', choices: ['auto', 'lp64', 'ilp64'],
+       value: 'auto',
+       description: 'Integer ABI for the cython_blas/cython_lapack Cython ' +
+                    'API. Default (auto) matches use-ilp64.')
 option('blas-symbol-suffix', type: 'string', value: 'auto',
         description: 'BLAS and LAPACK symbol suffix to use, if any')
 option('mkl-threading', type: 'string', value: 'auto',

--- a/pixi.lock
+++ b/pixi.lock
@@ -2148,6 +2148,190 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+  build-mkl-ilp64:
+    channels:
+    - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beniget-0.4.2.post1-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils-2.45.1-default_h4852527_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/blas-devel-3.11.0-5_hcf00494_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ccache-4.13-hedf47ba_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorlog-6.10.1-pyh707e725_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/compilers-1.11.0-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cython-3.2.4-py314h3f98dc2_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fortran-compiler-1.11.0-h9bea470_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/gast-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-14.3.0-h0dff253_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hbdf3cc3_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_21.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gfortran-14.3.0-h76987e4_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gfortran_impl_linux-64-14.3.0-h1a219da_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gfortran_linux-64-14.3.0-hfa02b96_21.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-14.3.0-h76987e4_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-he467f4b_21.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-5_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-5_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_118.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhiredis-1.3.0-h5888daf_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-5_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-5_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_118.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.0-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/meson-1.10.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2025.3.0-h0e700b2_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-devel-2025.3.0-ha770c72_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-include-2025.3.0-hf2ce2f3_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.2-py314hd4f4903_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.2-pyh7a1b43c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.2-pyhc7ab6ef_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyproject-metadata-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.3-he1279bd_1_cp314t.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pythran-0.18.1-pyha804496_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xxhash-0.8.3-hb47aa4a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  build-mkl-lp64:
+    channels:
+    - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/noarch/beniget-0.4.2.post1-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils-2.45.1-default_h4852527_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/blas-devel-3.11.0-5_hcf00494_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/c-compiler-1.11.0-h4d9bdce_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ccache-4.13-hedf47ba_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorlog-6.10.1-pyh707e725_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/compilers-1.11.0-ha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/cython-3.2.4-py314h3f98dc2_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/fortran-compiler-1.11.0-h9bea470_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/gast-0.6.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc-14.3.0-h0dff253_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hbdf3cc3_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_21.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gfortran-14.3.0-h76987e4_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gfortran_impl_linux-64-14.3.0-h1a219da_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gfortran_linux-64-14.3.0-hfa02b96_21.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx-14.3.0-h76987e4_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-he467f4b_21.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-5_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-5_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_118.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhiredis-1.3.0-h5888daf_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-5_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-5_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_118.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.0-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/meson-1.10.1-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2025.3.0-h0e700b2_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-devel-2025.3.0-ha770c72_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-include-2025.3.0-hf2ce2f3_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ninja-1.13.2-h171cf75_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.2-py314hd4f4903_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/pkg-config-0.29.2-h4bc722e_1009.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.2-pyh7a1b43c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.2-pyhc7ab6ef_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pyproject-metadata-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.3-he1279bd_1_cp314t.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pythran-0.18.1-pyha804496_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/xxhash-0.8.3-hb47aa4a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
   cupy:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -4551,6 +4735,486 @@ environments:
       - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
       - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+  mkl-ilp64:
+    channels:
+    - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/blas-devel-3.11.0-5_hcf00494_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py314he299d4b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.13.4-pyh7db6752_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.0-py314h1d7fe96_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.9-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-5_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-5_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-5_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-5_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.0-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2025.3.0-h0e700b2_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-devel-2025.3.0-ha770c72_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-include-2025.3.0-hf2ce2f3_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.3.1-h24ddda3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.2-py314hd4f4903_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.3-he1279bd_1_cp314t.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      osx-arm64:
+      - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/blas-devel-3.11.0-5_h11c0a38_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.13.4-py314h6e9b3f0_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/gmpy2-2.3.0-py314hf9f5e1b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.9-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.2-hef89b57_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-5_h51639a9_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libcblas-3.11.0-5_hb0561ab_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_18.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_18.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_18.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/liblapack-3.11.0-5_hd9741b5_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/liblapacke-3.11.0-5_h1b118fd_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_ha158390_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-22.1.0-hc7d1edf_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.2-py314hae46ccb_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openblas-0.3.30-openmp_hea878ba_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      win-64:
+      - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/blas-devel-3.11.0-5_h85df5b5_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/brotli-python-1.2.0-py314he701e3d_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-h4c7d964_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyha7b4d00_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.13.4-py314h2359020_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/gmp-6.3.0-hfeafd45_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/gmpy2-2.3.0-py314h9f8d836_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.9-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-5_hf2e6a31_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.11.0-5_h2a3cdd5_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.4-hac47afa_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgcc-15.2.0-h8ee18e1_18.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgomp-15.2.0-h8ee18e1_18.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.12.2-default_h4379cf1_1000.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/liblapack-3.11.0-5_hf9ab0e9_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/liblapacke-3.11.0-5_h3ae206f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.52.0-hf5d6505_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libxml2-16-2.15.2-h692994f_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.2-h5d26750_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-22.1.0-h4fa8253_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.0-hac47afa_455.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mkl-devel-2025.3.0-h57928b3_455.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mkl-include-2025.3.0-h57928b3_455.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mpc-1.3.1-h72bc38f_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mpfr-4.2.1-hbc20e70_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.2-py314h06c3c77_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.1-hf411b9b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/python-3.14.3-h4b44e0e_101_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyha7b4d00_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
+      - conda: https://prefix.dev/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+  mkl-lp64:
+    channels:
+    - url: https://prefix.dev/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/blas-devel-3.11.0-5_hcf00494_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py314he299d4b_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/coverage-7.13.4-pyh7db6752_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.0-py314h1d7fe96_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.9-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-5_h5875eb1_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-5_hfef963f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-5_h5e43f62_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-5_hdba1596_mkl.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/llvm-openmp-22.1.0-h4922eb0_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-2025.3.0-h0e700b2_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-devel-2025.3.0-ha770c72_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mkl-include-2025.3.0-hf2ce2f3_463.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpc-1.3.1-h24ddda3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.2-py314hd4f4903_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/python-3.14.3-he1279bd_1_cp314t.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      osx-arm64:
+      - conda: https://prefix.dev/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/blas-devel-3.11.0-5_h11c0a38_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-python-1.2.0-py314h3daef5d_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyh8f84b5b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.13.4-py314h6e9b3f0_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/gmpy2-2.3.0-py314hf9f5e1b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.9-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/icu-78.2-hef89b57_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-5_h51639a9_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libcblas-3.11.0-5_hb0561ab_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libexpat-2.7.4-hf6b4638_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_18.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_18.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_18.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/liblapack-3.11.0-5_hd9741b5_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/liblapacke-3.11.0-5_h1b118fd_openblas.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.2-h8088a28_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_ha158390_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-22.1.0-hc7d1edf_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/mpc-1.3.1-h8f1351a_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.2-py314hae46ccb_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openblas-0.3.30-openmp_hea878ba_4.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.14.3-h4c637c5_101_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyh8f84b5b_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      win-64:
+      - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://prefix.dev/conda-forge/noarch/attrs-25.4.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/blas-devel-3.11.0-5_h85df5b5_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/brotli-python-1.2.0-py314he701e3d_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.2.25-h4c7d964_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/click-8.3.1-pyha7b4d00_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/coverage-7.13.4-py314h2359020_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/gmp-6.3.0-hfeafd45_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/gmpy2-2.3.0-py314h9f8d836_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.9-pyha770c72_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/iniconfig-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-5_hf2e6a31_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.11.0-5_h2a3cdd5_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libexpat-2.7.4-hac47afa_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgcc-15.2.0-h8ee18e1_18.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libgomp-15.2.0-h8ee18e1_18.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.12.2-default_h4379cf1_1000.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/liblapack-3.11.0-5_hf9ab0e9_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/liblapacke-3.11.0-5_h3ae206f_mkl.conda
+      - conda: https://prefix.dev/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libmpdec-4.0.0-hfd05255_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.52.0-hf5d6505_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libwinpthread-12.0.0.r4.gg4f2fc60ca-h57928b3_10.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libxml2-16-2.15.2-h692994f_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.2-h5d26750_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-22.1.0-h4fa8253_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.0-hac47afa_455.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mkl-devel-2025.3.0-h57928b3_455.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mkl-include-2025.3.0-h57928b3_455.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mpc-1.3.1-h72bc38f_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/mpfr-4.2.1-hbc20e70_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.2-py314h06c3c77_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.1-hf411b9b_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-9.0.2-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-cov-7.0.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-timeout-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/python-3.14.3-h4b44e0e_101_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+      - conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyha7b4d00_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
+      - conda: https://prefix.dev/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
+      - conda: https://prefix.dev/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
+      - conda: https://prefix.dev/conda-forge/noarch/zipp-3.23.0-pyhcf101f3_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
   py312-system-libs-osx:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -6560,6 +7224,20 @@ packages:
   purls: []
   size: 8325
   timestamp: 1764092507920
+- conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-20_gnu.conda
+  build_number: 20
+  sha256: 8a1cee28bd0ee7451ada1cd50b64720e57e17ff994fc62dd8329bef570d382e4
+  md5: 1626967b574d1784b578b52eaeb071e7
+  depends:
+  - libgomp >=7.5.0
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - openmp_impl <0.0a0
+  - msys2-conda-epoch <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 52252
+  timestamp: 1770943776666
 - conda: https://prefix.dev/conda-forge/win-64/_openmp_mutex-4.5-2_gnu.conda
   build_number: 8
   sha256: 1a62cd1f215fe0902e7004089693a78347a30ad687781dfda2289cab000e652d
@@ -7009,6 +7687,15 @@ packages:
   purls: []
   size: 7512
   timestamp: 1765057691766
+- conda: https://prefix.dev/conda-forge/noarch/backports.zstd-1.3.0-py314h680f03e_0.conda
+  noarch: generic
+  sha256: c31ab719d256bc6f89926131e88ecd0f0c5d003fe8481852c6424f4ec6c7eb29
+  md5: a2ac7763a9ac75055b68f325d3255265
+  depends:
+  - python >=3.14
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  size: 7514
+  timestamp: 1767044983590
 - conda: https://prefix.dev/conda-forge/osx-arm64/backports.zstd-1.2.0-py312h84d6f5f_0.conda
   sha256: 833370729199ef55f3f9efd024e28bba87fcd8b5c397d8afecefde63851e6997
   md5: c0ca697637ef6cf0ac768a50964e4af6
@@ -7092,6 +7779,15 @@ packages:
   purls: []
   size: 35316
   timestamp: 1764007880473
+- conda: https://prefix.dev/conda-forge/linux-64/binutils-2.45.1-default_h4852527_101.conda
+  sha256: 2851d34944b056d028543f0440fb631aeeff204151ea09589d8d9c13882395de
+  md5: 9902aeb08445c03fb31e01beeb173988
+  depends:
+  - binutils_impl_linux-64 >=2.45.1,<2.45.2.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 35128
+  timestamp: 1770267175160
 - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45-default_hfdba357_104.conda
   sha256: 054a77ccab631071a803737ea8e5d04b5b18e57db5b0826a04495bd3fdf39a7c
   md5: a7a67bf132a4a2dea92a7cb498cdc5b1
@@ -7104,6 +7800,17 @@ packages:
   purls: []
   size: 3747046
   timestamp: 1764007847963
+- conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_101.conda
+  sha256: 74341b26a2b9475dc14ba3cf12432fcd10a23af285101883e720216d81d44676
+  md5: 83aa53cb3f5fc849851a84d777a60551
+  depends:
+  - ld_impl_linux-64 2.45.1 default_hbd61a6d_101
+  - sysroot_linux-64
+  - zstd >=1.5.7,<1.6.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 3744895
+  timestamp: 1770267152681
 - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45-default_h4852527_104.conda
   sha256: ed23fee4db69ad82320cca400fc77404c3874cd866606651a20bf743acd1a9b1
   md5: e30e71d685e23cc1e5ac1c1990ba1f81
@@ -7114,6 +7821,15 @@ packages:
   purls: []
   size: 36180
   timestamp: 1764007883258
+- conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_101.conda
+  sha256: 4826f97d33cbe54459970a1e84500dbe0cccf8326aaf370e707372ae20ec5a47
+  md5: dec96579f9a7035a59492bf6ee613b53
+  depends:
+  - binutils_impl_linux-64 2.45.1 default_hfdba357_101
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 36060
+  timestamp: 1770267177798
 - conda: https://prefix.dev/conda-forge/linux-64/blas-devel-3.11.0-4_h1ea3ea9_openblas.conda
   build_number: 4
   sha256: 16c22b7843bb4f145305da55768d72655a7bb13b3a56718bef13b1f3b13a7bf7
@@ -7144,6 +7860,21 @@ packages:
   license_family: BSD
   size: 18321
   timestamp: 1764823865149
+- conda: https://prefix.dev/conda-forge/linux-64/blas-devel-3.11.0-5_hcf00494_mkl.conda
+  build_number: 5
+  sha256: 0f64d485dd98a339a0ba2407f26aaf3087a76189672044949d699e0457d44d4e
+  md5: ee0c98906ad5470b933af806095008ba
+  depends:
+  - libblas 3.11.0 5_h5875eb1_mkl
+  - libcblas 3.11.0 5_hfef963f_mkl
+  - liblapack 3.11.0 5_h5e43f62_mkl
+  - liblapacke 3.11.0 5_hdba1596_mkl
+  - mkl >=2025.3.0,<2026.0a0
+  - mkl-devel 2025.3.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18040
+  timestamp: 1765818608729
 - conda: https://prefix.dev/conda-forge/osx-arm64/blas-devel-3.11.0-4_h11c0a38_openblas.conda
   build_number: 4
   sha256: bce5a7b13a201079d8a984d62a0727f064598ee4c23746e01cd45ea3cd275ad5
@@ -7172,6 +7903,20 @@ packages:
   license_family: BSD
   size: 18287
   timestamp: 1764824814158
+- conda: https://prefix.dev/conda-forge/osx-arm64/blas-devel-3.11.0-5_h11c0a38_openblas.conda
+  build_number: 5
+  sha256: 3306f850ef26262b66bbc97e59b6f526afc777f737e91fa1c28aaa6d8cb10eb4
+  md5: 607b94cf13beae353847892c5192d390
+  depends:
+  - libblas 3.11.0 5_h51639a9_openblas
+  - libcblas 3.11.0 5_hb0561ab_openblas
+  - liblapack 3.11.0 5_hd9741b5_openblas
+  - liblapacke 3.11.0 5_h1b118fd_openblas
+  - openblas 0.3.30.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18474
+  timestamp: 1765819151656
 - conda: https://prefix.dev/conda-forge/win-64/blas-devel-3.11.0-4_h85df5b5_mkl.conda
   build_number: 4
   sha256: c312c0c1f1b47f9bf9cb81e8b8f4b1828b68c2e41e1b99c36d38069e2398298c
@@ -7202,6 +7947,21 @@ packages:
   license_family: BSD
   size: 18711
   timestamp: 1764824567731
+- conda: https://prefix.dev/conda-forge/win-64/blas-devel-3.11.0-5_h85df5b5_mkl.conda
+  build_number: 5
+  sha256: 82abd32342b85c12f03d24f495bf8dcc3b04fab151db2b579ec25314f4b59a92
+  md5: 6d28905ee5506bbef79de2f94e1b310d
+  depends:
+  - libblas 3.11.0 5_hf2e6a31_mkl
+  - libcblas 3.11.0 5_h2a3cdd5_mkl
+  - liblapack 3.11.0 5_hf9ab0e9_mkl
+  - liblapacke 3.11.0 5_h3ae206f_mkl
+  - mkl >=2025.3.0,<2026.0a0
+  - mkl-devel 2025.3.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18592
+  timestamp: 1765819189183
 - conda: https://prefix.dev/conda-forge/noarch/bleach-6.3.0-pyhcf101f3_0.conda
   sha256: e03ba1a2b93fe0383c57920a9dc6b4e0c2c7972a3f214d531ed3c21dc8f8c717
   md5: b1a27250d70881943cca0dd6b4ba0956
@@ -7345,6 +8105,21 @@ packages:
   - pkg:pypi/brotli?source=hash-mapping
   size: 367376
   timestamp: 1764017265553
+- conda: https://prefix.dev/conda-forge/linux-64/brotli-python-1.2.0-py314he299d4b_1.conda
+  sha256: e79b64671f990ba466507bc274e04e1b625e8638b3d29bbae8a50d63c5189dbe
+  md5: 5d2f42dd83e7886a7351a89c62855df4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314t
+  constrains:
+  - libbrotlicommon 1.2.0 hb03c661_1
+  license: MIT
+  license_family: MIT
+  size: 368195
+  timestamp: 1764017336719
 - conda: https://prefix.dev/conda-forge/osx-arm64/brotli-python-1.2.0-py312h0dfefe5_1.conda
   sha256: 6178775a86579d5e8eec6a7ab316c24f1355f6c6ccbe84bb341f342f1eda2440
   md5: 311fcf3f6a8c4eb70f912798035edd35
@@ -7681,6 +8456,20 @@ packages:
   purls: []
   size: 708908
   timestamp: 1746271484780
+- conda: https://prefix.dev/conda-forge/linux-64/ccache-4.13-hedf47ba_0.conda
+  sha256: 35ad12e966e2df70567eabb7e2749a157e90afdff4191b585a55c985e6582682
+  md5: 92a194f6d6511e91afbdd2944491ea8e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - zstd >=1.5.7,<1.6.0a0
+  - libhiredis >=1.3.0,<1.4.0a0
+  - xxhash >=0.8.3,<0.8.4.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 844357
+  timestamp: 1772777717021
 - conda: https://prefix.dev/conda-forge/osx-arm64/ccache-4.11.3-hd7c7cec_0.conda
   sha256: ea06d8117291952c2c4cc8435080a0d3afd411b8751a85c3bbd288735fb5d4f4
   md5: 7fe1ee81492f43731ea583b4bee50b8b
@@ -7767,6 +8556,14 @@ packages:
   - pkg:pypi/certifi?source=compressed-mapping
   size: 157131
   timestamp: 1762976260320
+- conda: https://prefix.dev/conda-forge/noarch/certifi-2026.2.25-pyhd8ed1ab_0.conda
+  sha256: a6b118fd1ed6099dc4fc03f9c492b88882a780fadaef4ed4f93dc70757713656
+  md5: 765c4d97e877cdbbb88ff33152b86125
+  depends:
+  - python >=3.10
+  license: ISC
+  size: 151445
+  timestamp: 1772001170301
 - conda: https://prefix.dev/conda-forge/linux-64/cffi-2.0.0-py314h4a8dc5f_1.conda
   sha256: c6339858a0aaf5d939e00d345c98b99e4558f285942b27232ac098ad17ac7f8e
   md5: cf45f4278afd6f4e6d03eda0f435d527
@@ -7820,6 +8617,15 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 50965
   timestamp: 1760437331772
+- conda: https://prefix.dev/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
+  sha256: 05ea76a016c77839b64f9f8ec581775f6c8a259044bd5b45a177e46ab4e7feac
+  md5: beb628209b2b354b98203066f90b3287
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 53210
+  timestamp: 1772816516728
 - conda: https://prefix.dev/conda-forge/osx-arm64/clang-19.1.7-default_hf9bcbb7_5.conda
   sha256: 6e9cb7e80a41dbbfd95e86d87c8e5dafc3171aadda16ca33a1e2136748267318
   md5: 6773a2b7d7d1b0a8d0e0f3bf4e928936
@@ -8214,6 +9020,15 @@ packages:
   purls: []
   size: 31314
   timestamp: 1765256147792
+- conda: https://prefix.dev/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_18.conda
+  sha256: b90ec0e6a9eb22f7240b3584fe785457cff961fec68d40e6aece5d596f9bbd9a
+  md5: 0e3e144115c43c9150d18fa20db5f31c
+  depends:
+  - gcc_impl_linux-64 >=14.3.0,<14.3.1.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 31705
+  timestamp: 1771378159534
 - conda: https://prefix.dev/conda-forge/linux-64/contourpy-1.3.3-py314h9891dd4_3.conda
   sha256: 54c79736927c787e535db184bb7f3bce13217cb7d755c50666cfc0da7c6c86f3
   md5: 72d57382d0f63c20a16b1d514fcde6ff
@@ -8297,6 +9112,18 @@ packages:
   - pkg:pypi/coverage?source=hash-mapping
   size: 408240
   timestamp: 1765203383473
+- conda: https://prefix.dev/conda-forge/noarch/coverage-7.13.4-pyh7db6752_0.conda
+  sha256: 8d8d4b55d352bdb8f19ba5ebeb2f588580d18b7068380f7ca6de985f4740704b
+  md5: 9f4b0b8ee16448957a0fbead6e81eeb6
+  depends:
+  - python >=3.10
+  - tomli
+  track_features:
+  - coverage_no_compile
+  license: Apache-2.0
+  license_family: APACHE
+  size: 166562
+  timestamp: 1770720392132
 - conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.13.0-py312h5748b74_0.conda
   sha256: fc898ebd3e8faeb56314ec4b7996c7d28cb37330a5e70e122b86f6152c8ea4f8
   md5: aa4e0f5ae7200c4add1b1c9d4a586eba
@@ -8338,6 +9165,19 @@ packages:
   - pkg:pypi/coverage?source=hash-mapping
   size: 406412
   timestamp: 1765203549502
+- conda: https://prefix.dev/conda-forge/osx-arm64/coverage-7.13.4-py314h6e9b3f0_0.conda
+  sha256: e8ef991376e43f1248f0a16108b29534b24ad633cc4848927d7cf74622961ee9
+  md5: 96c7bf4f2b5010d29604a62e91e634bb
+  depends:
+  - __osx >=11.0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  size: 412030
+  timestamp: 1770720628409
 - conda: https://prefix.dev/conda-forge/win-64/coverage-7.13.0-py312h05f76fc_0.conda
   sha256: 3ed2f6d5b2b988d9faeebd68c68411e74b6b0dd4d3d8f8aa25368c9bde142367
   md5: 54a1ead847baeb406001161398657cd1
@@ -8382,6 +9222,20 @@ packages:
   - pkg:pypi/coverage?source=hash-mapping
   size: 433902
   timestamp: 1765203441253
+- conda: https://prefix.dev/conda-forge/win-64/coverage-7.13.4-py314h2359020_0.conda
+  sha256: be570faa6580aa8ddeead7f3639ae27c46e02446613c85af9c3eab395f8dedd6
+  md5: ac7417dc27e19765fd50f547d9a9e445
+  depends:
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - tomli
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: APACHE
+  size: 438221
+  timestamp: 1770720521756
 - conda: https://prefix.dev/conda-forge/noarch/cpython-3.12.12-py312hd8ed1ab_1.conda
   noarch: generic
   sha256: b88c76a6d6b45378552ccfd9e88b2a073161fe83fd1294c8fa103ffd32f7934a
@@ -8797,6 +9651,19 @@ packages:
   - pkg:pypi/cython?source=hash-mapping
   size: 3793342
   timestamp: 1764543513846
+- conda: https://prefix.dev/conda-forge/linux-64/cython-3.2.4-py314h3f98dc2_0.conda
+  sha256: 6d5e1ca576c062e432bf914949bd3b5100f669f9b31211a870dc177ce9caa287
+  md5: cc2fcbfdf0628b5ad05b319866187bbc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314t
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2253785
+  timestamp: 1767577094398
 - conda: https://prefix.dev/conda-forge/osx-arm64/cython-3.2.2-py312h6868a3c_0.conda
   sha256: b72a2a4c6c687d03a5bb939a9ea057bd0fa5cbe622a8c01e115a89c8a71da591
   md5: 0d05bc82570e1429a756f5f2560c5ff8
@@ -9421,6 +10288,32 @@ packages:
   purls: []
   size: 29022
   timestamp: 1765256332962
+- conda: https://prefix.dev/conda-forge/linux-64/gcc-14.3.0-h0dff253_18.conda
+  sha256: 9b34b57b06b485e33a40d430f71ac88c8f381673592507cf7161c50ff0832772
+  md5: 52d6457abc42e320787ada5f9033fa99
+  depends:
+  - conda-gcc-specs
+  - gcc_impl_linux-64 14.3.0 hbdf3cc3_18
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 29506
+  timestamp: 1771378321585
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-hbdf3cc3_18.conda
+  sha256: 3b31a273b806c6851e16e9cf63ef87cae28d19be0df148433f3948e7da795592
+  md5: 30bb690150536f622873758b0e8d6712
+  depends:
+  - binutils_impl_linux-64 >=2.45
+  - libgcc >=14.3.0
+  - libgcc-devel_linux-64 14.3.0 hf649bbc_118
+  - libgomp >=14.3.0
+  - libsanitizer 14.3.0 h8f1669f_18
+  - libstdcxx >=14.3.0
+  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_118
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 76302378
+  timestamp: 1771378056505
 - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-14.3.0-he8b2097_16.conda
   sha256: 4acf50b7d5673250d585a256a40aabdd922e0947ca12cdbad0cef960ee1a9509
   md5: d274bf1343507683e6eb2954d1871569
@@ -9448,6 +10341,17 @@ packages:
   purls: []
   size: 28824
   timestamp: 1765306123456
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-14.3.0-h298d278_21.conda
+  sha256: 27ad0cd10dccffca74e20fb38c9f8643ff8fce56eee260bf89fa257d5ab0c90a
+  md5: 1403ed5fe091bd7442e4e8a229d14030
+  depends:
+  - gcc_impl_linux-64 14.3.0.*
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28946
+  timestamp: 1770908213807
 - conda: https://prefix.dev/conda-forge/linux-64/gdb-16.3-py314h7c795f0_6.conda
   sha256: dc24eb31eed73e0e88b1b1bdf9085d2c995663fea0c963201e85912dea16ddc9
   md5: 1ddf10b952abd92be798636488e7f46b
@@ -9530,6 +10434,17 @@ packages:
   purls: []
   size: 28426
   timestamp: 1765256352017
+- conda: https://prefix.dev/conda-forge/linux-64/gfortran-14.3.0-h76987e4_18.conda
+  sha256: c216b97f00973fc6c37af16d1d974635e81cfc93462123b1d0ffc93fe509ea01
+  md5: 958a6ecb4188cce9edbd9bbd2831a61d
+  depends:
+  - gcc 14.3.0 h0dff253_18
+  - gcc_impl_linux-64 14.3.0 hbdf3cc3_18
+  - gfortran_impl_linux-64 14.3.0 h1a219da_18
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28880
+  timestamp: 1771378338951
 - conda: https://prefix.dev/conda-forge/osx-arm64/gfortran-14.3.0-h3ef1dbf_0.conda
   sha256: cfdf9b4dd37ddfc15ea1c415619d4137004fa135d7192e5cdcea8e3944dc9df7
   md5: e148e0bc9bbc90b6325a479a5501786d
@@ -9555,6 +10470,19 @@ packages:
   purls: []
   size: 18569038
   timestamp: 1765256219467
+- conda: https://prefix.dev/conda-forge/linux-64/gfortran_impl_linux-64-14.3.0-h1a219da_18.conda
+  sha256: d8c8ba10471d4ec6e9d28b5a61982b0f49cb6ad55a6c84cb85b71f026329bd09
+  md5: 91531d5176126c652e8b8dfcfa263dcd
+  depends:
+  - gcc_impl_linux-64 >=14.3.0
+  - libgcc >=14.3.0
+  - libgfortran5 >=14.3.0
+  - libstdcxx >=14.3.0
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 18544424
+  timestamp: 1771378230570
 - conda: https://prefix.dev/conda-forge/osx-arm64/gfortran_impl_osx-arm64-14.3.0-h6d03799_1.conda
   sha256: c05c634388e180f79c70a5989d2b25977716b7f6d5e395119ad0007cf4a7bcbf
   md5: 1e9ec88ecc684d92644a45c6df2399d0
@@ -9589,6 +10517,18 @@ packages:
   purls: []
   size: 27062
   timestamp: 1765306123456
+- conda: https://prefix.dev/conda-forge/linux-64/gfortran_linux-64-14.3.0-hfa02b96_21.conda
+  sha256: 406e1b10478b29795377cc2ad561618363aaf37b208e5cb3de7858256f73276a
+  md5: 234863e90d09d229043af1075fcf8204
+  depends:
+  - gfortran_impl_linux-64 14.3.0.*
+  - gcc_linux-64 ==14.3.0 h298d278_21
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27130
+  timestamp: 1770908213808
 - conda: https://prefix.dev/conda-forge/osx-arm64/gfortran_osx-arm64-14.3.0-h3c33bd0_0.conda
   sha256: 2644e5f4b4eed171b12afb299e2413be5877db92f30ec03690621d1ae648502c
   md5: 8db8c0061c0f3701444b7b9cc9966511
@@ -9737,6 +10677,21 @@ packages:
   - pkg:pypi/gmpy2?source=hash-mapping
   size: 214694
   timestamp: 1762946982171
+- conda: https://prefix.dev/conda-forge/linux-64/gmpy2-2.3.0-py314h1d7fe96_1.conda
+  sha256: ecdd65385a9c562630a291fbb119ca63cb8e639250f6c76e243dde79f17e049b
+  md5: 9d493faafe3759d77a5cebd9df37a684
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  - mpc >=1.3.1,<2.0a0
+  - mpfr >=4.2.1,<5.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314t
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 237076
+  timestamp: 1773245108096
 - conda: https://prefix.dev/conda-forge/osx-arm64/gmpy2-2.2.1-py312hee6aa52_2.conda
   sha256: e2f72ddb929fcd161d68729891f25241d62ab1a9d4e37d0284f2b2fce88935fa
   md5: bed6eebc8d1690f205a781c993f9bc65
@@ -9784,6 +10739,21 @@ packages:
   - pkg:pypi/gmpy2?source=hash-mapping
   size: 163104
   timestamp: 1762947639858
+- conda: https://prefix.dev/conda-forge/osx-arm64/gmpy2-2.3.0-py314hf9f5e1b_1.conda
+  sha256: 1cc805249850208d4e1de8beb17c58aa116fc518ca1b075285b403dbc1c002c9
+  md5: 036584b863246f278f4057327c36a94d
+  depends:
+  - __osx >=11.0
+  - gmp >=6.3.0,<7.0a0
+  - mpc >=1.3.1,<2.0a0
+  - mpfr >=4.2.1,<5.0a0
+  - python >=3.14,<3.15.0a0
+  - python >=3.14,<3.15.0a0 *_cp314
+  - python_abi 3.14.* *_cp314
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 195457
+  timestamp: 1773245350476
 - conda: https://prefix.dev/conda-forge/win-64/gmpy2-2.2.1-py312he85694f_2.conda
   sha256: 4012f0f921a0b119ee697d41e8a878138a74e138a59a9ec20dd13c41205f2362
   md5: 20c353248fca99f94a0a0d707ff708b7
@@ -9834,6 +10804,22 @@ packages:
   - pkg:pypi/gmpy2?source=hash-mapping
   size: 155798
   timestamp: 1762946994950
+- conda: https://prefix.dev/conda-forge/win-64/gmpy2-2.3.0-py314h9f8d836_1.conda
+  sha256: 91c23e30f3919127abe6feb594caa28945cf01d371ac7109cfc800c7a0faef04
+  md5: 0a12acb60f25b68377913d880b7602c4
+  depends:
+  - gmp >=6.3.0,<7.0a0
+  - mpc >=1.3.1,<2.0a0
+  - mpfr >=4.2.1,<5.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  size: 188607
+  timestamp: 1773245185271
 - conda: https://prefix.dev/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
   sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
   md5: 2cd94587f3a401ae05e03a6caf09539d
@@ -10078,6 +11064,16 @@ packages:
   purls: []
   size: 28403
   timestamp: 1765256369945
+- conda: https://prefix.dev/conda-forge/linux-64/gxx-14.3.0-h76987e4_18.conda
+  sha256: 1b490c9be9669f9c559db7b2a1f7d8b973c58ca0c6f21a5d2ba3f0ab2da63362
+  md5: 19189121d644d4ef75fed05383bc75f5
+  depends:
+  - gcc 14.3.0 h0dff253_18
+  - gxx_impl_linux-64 14.3.0 h2185e75_18
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 28883
+  timestamp: 1771378355605
 - conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_16.conda
   sha256: 71a6672af972c4d072d79514e9755c9e9ea359d46613fd9333adcb3b08c0c008
   md5: 8729b9d902631b9ee604346a90a50031
@@ -10090,6 +11086,18 @@ packages:
   purls: []
   size: 15255410
   timestamp: 1765256273332
+- conda: https://prefix.dev/conda-forge/linux-64/gxx_impl_linux-64-14.3.0-h2185e75_18.conda
+  sha256: 38ffca57cc9c264d461ac2ce9464a9d605e0f606d92d831de9075cb0d95fc68a
+  md5: 6514b3a10e84b6a849e1b15d3753eb22
+  depends:
+  - gcc_impl_linux-64 14.3.0 hbdf3cc3_18
+  - libstdcxx-devel_linux-64 14.3.0 h9f08a49_118
+  - sysroot_linux-64
+  - tzdata
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 14566100
+  timestamp: 1771378271421
 - conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-hdb5f4f1_15.conda
   sha256: d64a4afd400306e7692d494744a414e1bc09783c2fbf6b0358b32a63a13945f8
   md5: 9a242c1265c796f30fcdd04066d0ea5d
@@ -10102,6 +11110,18 @@ packages:
   purls: []
   size: 27421
   timestamp: 1765306123460
+- conda: https://prefix.dev/conda-forge/linux-64/gxx_linux-64-14.3.0-he467f4b_21.conda
+  sha256: 1e07c197e0779fa9105e59cd55a835ded96bfde59eb169439736a89b27b48e5d
+  md5: 7b51f4ff82eeb1f386bfee20a7bed3ed
+  depends:
+  - gxx_impl_linux-64 14.3.0.*
+  - gcc_linux-64 ==14.3.0 h298d278_21
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27503
+  timestamp: 1770908213813
 - conda: https://prefix.dev/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
   sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
   md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
@@ -10224,6 +11244,20 @@ packages:
   - pkg:pypi/hypothesis?source=hash-mapping
   size: 382777
   timestamp: 1764903748476
+- conda: https://prefix.dev/conda-forge/noarch/hypothesis-6.151.9-pyha770c72_0.conda
+  sha256: 1555bc18d732eb0e006d14ad546a7dd34b014c76bc0e2f19dee14b68132ae71b
+  md5: 619894788d63f3d5c0327fa28cc04a4d
+  depends:
+  - attrs >=22.2.0
+  - click >=7.0
+  - exceptiongroup >=1.0.0
+  - python >=3.10
+  - setuptools
+  - sortedcontainers >=2.1.0,<3.0.0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 377448
+  timestamp: 1771297072392
 - conda: https://prefix.dev/conda-forge/linux-64/icu-75.1-he02047a_0.conda
   sha256: 71e750d509f5fa3421087ba88ef9a7b9be11c53174af3aa4d06aff4c18b38e8e
   md5: 8b189310083baabfb622af68fd9d3ae3
@@ -10936,6 +11970,15 @@ packages:
   purls: []
   size: 1272697
   timestamp: 1752669126073
+- conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  sha256: 41557eeadf641de6aeae49486cef30d02a6912d8da98585d687894afd65b356a
+  md5: 86d9cba083cd041bfbf242a01a7a1999
+  constrains:
+  - sysroot_linux-64 ==2.28
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  size: 1278712
+  timestamp: 1765578681495
 - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
   sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
   md5: b38117a3c920364aff79f870c984b4a3
@@ -11279,6 +12322,24 @@ packages:
   license_family: BSD
   size: 18887
   timestamp: 1764823790196
+- conda: https://prefix.dev/conda-forge/linux-64/libblas-3.11.0-5_h5875eb1_mkl.conda
+  build_number: 5
+  sha256: 328d64d4eb51047c39a8039a30eb47695855829d0a11b72d932171cb1dcdfad3
+  md5: 9d2f2e3a943d38f972ceef9cde8ba4bf
+  depends:
+  - mkl >=2025.3.0,<2026.0a0
+  constrains:
+  - liblapack  3.11.0   5*_mkl
+  - liblapacke 3.11.0   5*_mkl
+  - libcblas   3.11.0   5*_mkl
+  - blas 2.305   mkl
+  track_features:
+  - blas_mkl
+  - blas_mkl_2
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18744
+  timestamp: 1765818556597
 - conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-4_h51639a9_openblas.conda
   build_number: 4
   sha256: db31cdcd24b9f4be562c37a780d6a665f5eddc88a97d59997e293d91c522ffc1
@@ -11318,6 +12379,23 @@ packages:
   license_family: BSD
   size: 2832204
   timestamp: 1764824744718
+- conda: https://prefix.dev/conda-forge/osx-arm64/libblas-3.11.0-5_h51639a9_openblas.conda
+  build_number: 5
+  sha256: 620a6278f194dcabc7962277da6835b1e968e46ad0c8e757736255f5ddbfca8d
+  md5: bcc025e2bbaf8a92982d20863fe1fb69
+  depends:
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
+  constrains:
+  - libcblas   3.11.0   5*_openblas
+  - liblapack  3.11.0   5*_openblas
+  - liblapacke 3.11.0   5*_openblas
+  - blas 2.305   openblas
+  - mkl <2026
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18546
+  timestamp: 1765819094137
 - conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-4_h0adab6e_openblas.conda
   build_number: 4
   sha256: e1769c9923da54964be5216c39383606e42a1a096598ea17eb72e214f872a81a
@@ -11354,6 +12432,21 @@ packages:
   purls: []
   size: 67784
   timestamp: 1764824188313
+- conda: https://prefix.dev/conda-forge/win-64/libblas-3.11.0-5_hf2e6a31_mkl.conda
+  build_number: 5
+  sha256: f0cb7b2697461a306341f7ff32d5b361bb84f3e94478464c1e27ee01fc8f276b
+  md5: f9decf88743af85c9c9e05556a4c47c0
+  depends:
+  - mkl >=2025.3.0,<2026.0a0
+  constrains:
+  - liblapack  3.11.0   5*_mkl
+  - libcblas   3.11.0   5*_mkl
+  - blas 2.305   mkl
+  - liblapacke 3.11.0   5*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 67438
+  timestamp: 1765819100043
 - conda: https://prefix.dev/conda-forge/linux-64/libboost-headers-1.89.0-ha770c72_3.conda
   sha256: 0720a747b51953b6ffcb1d3c5af766a6e34d3b7c4f0f1160d414951ba3f0d343
   md5: e8913467ec252af573eb66b4b46dd023
@@ -11585,6 +12678,22 @@ packages:
   license_family: BSD
   size: 18521
   timestamp: 1764823809419
+- conda: https://prefix.dev/conda-forge/linux-64/libcblas-3.11.0-5_hfef963f_mkl.conda
+  build_number: 5
+  sha256: 8352f472c49c42a83a20387b5f6addab1f910c5a62f4f5b8998d7dc89131ba2e
+  md5: 9b6cb3aa4b7912121c64b97a76ca43d5
+  depends:
+  - libblas 3.11.0 5_h5875eb1_mkl
+  constrains:
+  - liblapack  3.11.0   5*_mkl
+  - liblapacke 3.11.0   5*_mkl
+  - blas 2.305   mkl
+  track_features:
+  - blas_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18385
+  timestamp: 1765818571086
 - conda: https://prefix.dev/conda-forge/osx-arm64/libcblas-3.11.0-4_h752f6bc_accelerate.conda
   build_number: 4
   sha256: 128d6015e5c6fa1f39c7f1cf19433aea8747c45f07001f66c18b7849bba8db3e
@@ -11616,6 +12725,20 @@ packages:
   purls: []
   size: 18722
   timestamp: 1764824449333
+- conda: https://prefix.dev/conda-forge/osx-arm64/libcblas-3.11.0-5_hb0561ab_openblas.conda
+  build_number: 5
+  sha256: 38809c361bbd165ecf83f7f05fae9b791e1baa11e4447367f38ae1327f402fc0
+  md5: efd8bd15ca56e9d01748a3beab8404eb
+  depends:
+  - libblas 3.11.0 5_h51639a9_openblas
+  constrains:
+  - liblapacke 3.11.0   5*_openblas
+  - liblapack  3.11.0   5*_openblas
+  - blas 2.305   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18548
+  timestamp: 1765819108956
 - conda: https://prefix.dev/conda-forge/win-64/libcblas-3.11.0-4_h2a3cdd5_mkl.conda
   build_number: 4
   sha256: 4cd0f2ec9823995a74b73c0119201dcf9a28444bdc2f0a824dfa938b5bdd5601
@@ -11647,6 +12770,20 @@ packages:
   license_family: BSD
   size: 68000
   timestamp: 1764824465138
+- conda: https://prefix.dev/conda-forge/win-64/libcblas-3.11.0-5_h2a3cdd5_mkl.conda
+  build_number: 5
+  sha256: 49dc59d8e58360920314b8d276dd80da7866a1484a9abae4ee2760bc68f3e68d
+  md5: b3fa8e8b55310ba8ef0060103afb02b5
+  depends:
+  - libblas 3.11.0 5_hf2e6a31_mkl
+  constrains:
+  - liblapack  3.11.0   5*_mkl
+  - liblapacke 3.11.0   5*_mkl
+  - blas 2.305   mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 68079
+  timestamp: 1765819124349
 - conda: https://prefix.dev/conda-forge/linux-64/libccolamd-3.3.4-hf02c80a_7100101.conda
   sha256: cc90aa5e0ad1f7ae9a29d9a42aacd7f7f02aba0bf5467513bfda7e6b18a4cbc8
   md5: e5107e02dc4c2f9f41eef72d72c23517
@@ -12179,6 +13316,15 @@ packages:
   purls: []
   size: 568715
   timestamp: 1764676451068
+- conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.0-h55c6f16_1.conda
+  sha256: ce1049fa6fda9cf08ff1c50fb39573b5b0ea6958375d8ea7ccd8456ab81a0bcb
+  md5: e9c56daea841013e7774b5cd46f41564
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  size: 568910
+  timestamp: 1772001095642
 - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-devel-19.1.7-h6dc3340_2.conda
   sha256: ec07ebaa226792f4e2bf0f5dba50325632a7474d5f04b951d8291be70af215da
   md5: 9f7810b7c0a731dbc84d46d6005890ef
@@ -12532,6 +13678,18 @@ packages:
   purls: []
   size: 402197
   timestamp: 1765258985740
+- conda: https://prefix.dev/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_18.conda
+  sha256: 1d9c4f35586adb71bcd23e31b68b7f3e4c4ab89914c26bed5f2859290be5560e
+  md5: 92df6107310b1fff92c4cc84f0de247b
+  depends:
+  - _openmp_mutex
+  constrains:
+  - libgcc-ng ==15.2.0=*_18
+  - libgomp 15.2.0 18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 401974
+  timestamp: 1771378877463
 - conda: https://prefix.dev/conda-forge/win-64/libgcc-15.2.0-h8ee18e1_16.conda
   sha256: 24984e1e768440ba73021f08a1da0c1ec957b30d7071b9a89b877a273d17cae8
   md5: 1edb8bd8e093ebd31558008e9cb23b47
@@ -12546,6 +13704,20 @@ packages:
   purls: []
   size: 819696
   timestamp: 1765260437409
+- conda: https://prefix.dev/conda-forge/win-64/libgcc-15.2.0-h8ee18e1_18.conda
+  sha256: da2c96563c76b8c601746f03e03ac75d2b4640fa2ee017cb23d6c9fc31f1b2c6
+  md5: b085746891cca3bd2704a450a7b4b5ce
+  depends:
+  - _openmp_mutex >=4.5
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - libgcc-ng ==15.2.0=*_18
+  - msys2-conda-epoch <0.0a0
+  - libgomp 15.2.0 h8ee18e1_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 820022
+  timestamp: 1771382190160
 - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_116.conda
   sha256: 812f2b3f523fc0aabaf4e5e1b44a029c5205671179e574dd32dc57b65e072e0f
   md5: 0141e19cb0cd5602c49c84f920e81921
@@ -12555,6 +13727,15 @@ packages:
   purls: []
   size: 3082749
   timestamp: 1765255729247
+- conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-14.3.0-hf649bbc_118.conda
+  sha256: 1abc6a81ee66e8ac9ac09a26e2d6ad7bba23f0a0cc3a6118654f036f9c0e1854
+  md5: 06901733131833f5edd68cf3d9679798
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 3084533
+  timestamp: 1771377786730
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
   sha256: 5f07f9317f596a201cc6e095e5fc92621afca64829785e483738d935f8cab361
   md5: 5a68259fac2da8f2ee6f7bfe49c9eb8b
@@ -12564,6 +13745,15 @@ packages:
   purls: []
   size: 27256
   timestamp: 1765256804124
+- conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
+  sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
+  md5: d5e96b1ed75ca01906b3d2469b4ce493
+  depends:
+  - libgcc 15.2.0 he0feb66_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 27526
+  timestamp: 1771378224552
 - conda: https://prefix.dev/conda-forge/linux-64/libgd-2.3.3-h6f5c62b_11.conda
   sha256: 19e5be91445db119152217e8e8eec4fd0499d854acc7d8062044fb55a70971cd
   md5: 68fc66282364981589ef36868b1a7c78
@@ -12648,6 +13838,17 @@ packages:
   purls: []
   size: 138630
   timestamp: 1765259217400
+- conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_18.conda
+  sha256: 63f89087c3f0c8621c5c89ecceec1e56e5e1c84f65fc9c5feca33a07c570a836
+  md5: 26981599908ed2205366e8fc91b37fc6
+  depends:
+  - libgfortran5 15.2.0 hdae7583_18
+  constrains:
+  - libgfortran-ng ==15.2.0=*_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 138973
+  timestamp: 1771379054939
 - conda: https://prefix.dev/conda-forge/noarch/libgfortran-devel_osx-arm64-14.3.0-hc965647_1.conda
   sha256: f6ecc12e02a30ab7ee7a8b7285e4ffe3c2452e43885ce324b85827b97659a8c8
   md5: c1b69e537b3031d0f5af780b432ce511
@@ -12677,6 +13878,18 @@ packages:
   purls: []
   size: 2480559
   timestamp: 1765256819588
+- conda: https://prefix.dev/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
+  sha256: 539b57cf50ec85509a94ba9949b7e30717839e4d694bc94f30d41c9d34de2d12
+  md5: 646855f357199a12f02a87382d429b75
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 2482475
+  timestamp: 1771378241063
 - conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_16.conda
   sha256: 9fb7f4ff219e3fb5decbd0ee90a950f4078c90a86f5d8d61ca608c913062f9b0
   md5: 265a9d03461da24884ecc8eb58396d57
@@ -12688,6 +13901,17 @@ packages:
   purls: []
   size: 598291
   timestamp: 1765258993165
+- conda: https://prefix.dev/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_18.conda
+  sha256: 91033978ba25e6a60fb86843cf7e1f7dc8ad513f9689f991c9ddabfaf0361e7e
+  md5: c4a6f7989cffb0544bfd9207b6789971
+  depends:
+  - libgcc >=15.2.0
+  constrains:
+  - libgfortran 15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 598634
+  timestamp: 1771378886363
 - conda: https://prefix.dev/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
   sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
   md5: 928b8be80851f5d8ffb016f9c81dae7a
@@ -12848,6 +14072,17 @@ packages:
   purls: []
   size: 663567
   timestamp: 1765260367147
+- conda: https://prefix.dev/conda-forge/win-64/libgomp-15.2.0-h8ee18e1_18.conda
+  sha256: 94981bc2e42374c737750895c6fdcfc43b7126c4fc788cad0ecc7281745931da
+  md5: 939fb173e2a4d4e980ef689e99b35223
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  constrains:
+  - msys2-conda-epoch <0.0a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 663864
+  timestamp: 1771382118742
 - conda: https://prefix.dev/conda-forge/linux-64/libgrpc-1.73.1-h3288cfb_1.conda
   sha256: bc9d32af6167b1f5bcda216dc44eddcb27f3492440571ab12f6e577472a05e34
   md5: ff63bb12ac31c176ff257e3289f20770
@@ -12902,6 +14137,17 @@ packages:
   purls: []
   size: 147325
   timestamp: 1633982069195
+- conda: https://prefix.dev/conda-forge/linux-64/libhiredis-1.3.0-h5888daf_1.conda
+  sha256: 5638e321719590b00826d218431d5028d1a22a76f281532ce621d9a40d5e0f42
+  md5: aa342fcf3bc583660dbfdb2eae6be48e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 140759
+  timestamp: 1748219397797
 - conda: https://prefix.dev/conda-forge/osx-arm64/libhiredis-1.0.2-hbec66e7_0.tar.bz2
   sha256: a77b7097b3a557e8bc2c2a6e5257bde72e6c828ab8dd9996cec3895cc6cbcf9e
   md5: 37ca71a16015b17397da4a5e6883f66f
@@ -12938,6 +14184,19 @@ packages:
   license_family: BSD
   size: 2449346
   timestamp: 1765089858592
+- conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+  sha256: 2cf160794dda62cf93539adf16d26cfd31092829f2a2757dbdd562984c1b110a
+  md5: 0ed3aa3e3e6bc85050d38881673a692f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2449916
+  timestamp: 1765103845133
 - conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.12.1-default_h4379cf1_1003.conda
   sha256: 2d534c09f92966b885acb3f4a838f7055cea043165a03079a539b06c54e20a49
   md5: d1699ce4fe195a9f61264a1c29b87035
@@ -12953,6 +14212,20 @@ packages:
   purls: []
   size: 2412642
   timestamp: 1765090345611
+- conda: https://prefix.dev/conda-forge/win-64/libhwloc-2.12.2-default_h4379cf1_1000.conda
+  sha256: 8cdf11333a81085468d9aa536ebb155abd74adc293576f6013fc0c85a7a90da3
+  md5: 3b576f6860f838f950c570f4433b086e
+  depends:
+  - libwinpthread >=12.0.0.r4.gg4f2fc60ca
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2411241
+  timestamp: 1765104337762
 - conda: https://prefix.dev/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
   sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
   md5: 915f5995e94f60e9a4826e0b0920ee88
@@ -13130,6 +14403,22 @@ packages:
   license_family: BSD
   size: 18515
   timestamp: 1764823828068
+- conda: https://prefix.dev/conda-forge/linux-64/liblapack-3.11.0-5_h5e43f62_mkl.conda
+  build_number: 5
+  sha256: b411a9dccb21cd6231f8f66b63916a6520a7b23363e6f9d1d111e8660f2798b0
+  md5: 88155c848e1278b0990692e716c9eab4
+  depends:
+  - libblas 3.11.0 5_h5875eb1_mkl
+  constrains:
+  - liblapacke 3.11.0   5*_mkl
+  - libcblas   3.11.0   5*_mkl
+  - blas 2.305   mkl
+  track_features:
+  - blas_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18398
+  timestamp: 1765818583873
 - conda: https://prefix.dev/conda-forge/osx-arm64/liblapack-3.11.0-4_hcb0d94e_accelerate.conda
   build_number: 4
   sha256: 790cd8bf73797ea3733109f5a35817f9e5cace3fc21f2c49a1d6515cae38ef57
@@ -13161,6 +14450,20 @@ packages:
   purls: []
   size: 18764
   timestamp: 1764824468301
+- conda: https://prefix.dev/conda-forge/osx-arm64/liblapack-3.11.0-5_hd9741b5_openblas.conda
+  build_number: 5
+  sha256: 735a6e6f7d7da6f718b6690b7c0a8ae4815afb89138aa5793abe78128e951dbb
+  md5: ca9d752201b7fa1225bca036ee300f2b
+  depends:
+  - libblas 3.11.0 5_h51639a9_openblas
+  constrains:
+  - libcblas   3.11.0   5*_openblas
+  - blas 2.305   openblas
+  - liblapacke 3.11.0   5*_openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18551
+  timestamp: 1765819121855
 - conda: https://prefix.dev/conda-forge/win-64/liblapack-3.11.0-4_hd232482_openblas.conda
   build_number: 4
   sha256: 454a66466d1976fba6c32b3f1f33d476bbb80d3b6eccd32aa648cf05e21d5f0f
@@ -13192,6 +14495,20 @@ packages:
   purls: []
   size: 80387
   timestamp: 1764824249543
+- conda: https://prefix.dev/conda-forge/win-64/liblapack-3.11.0-5_hf9ab0e9_mkl.conda
+  build_number: 5
+  sha256: a2d33f5cc2b8a9042f2af6981c6733ab1a661463823eaa56595a9c58c0ab77e1
+  md5: e62c42a4196dee97d20400612afcb2b1
+  depends:
+  - libblas 3.11.0 5_hf2e6a31_mkl
+  constrains:
+  - libcblas   3.11.0   5*_mkl
+  - blas 2.305   mkl
+  - liblapacke 3.11.0   5*_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 80225
+  timestamp: 1765819148014
 - conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-4_h6ae95b6_openblas.conda
   build_number: 4
   sha256: 9d9eee5540f973367755dd6579c8e7ad8710408345732e11462f9c4830f6974a
@@ -13223,6 +14540,22 @@ packages:
   license_family: BSD
   size: 18554
   timestamp: 1764823846640
+- conda: https://prefix.dev/conda-forge/linux-64/liblapacke-3.11.0-5_hdba1596_mkl.conda
+  build_number: 5
+  sha256: 40b2dbf4edf9e4e44d02c901d48c596cd6be42fd9729cfe2a1306811c3894002
+  md5: d7e79a90df7e39c11296053a8d6ffd2b
+  depends:
+  - libblas 3.11.0 5_h5875eb1_mkl
+  - libcblas 3.11.0 5_hfef963f_mkl
+  - liblapack 3.11.0 5_h5e43f62_mkl
+  constrains:
+  - blas 2.305   mkl
+  track_features:
+  - blas_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18389
+  timestamp: 1765818596393
 - conda: https://prefix.dev/conda-forge/osx-arm64/liblapacke-3.11.0-4_h1b118fd_openblas.conda
   build_number: 4
   sha256: 07c40391748aff16dcffca0d82e8eac1d4bc6b51b261c1ecf474ab4dee50c637
@@ -13254,6 +14587,20 @@ packages:
   license_family: BSD
   size: 18673
   timestamp: 1764824807967
+- conda: https://prefix.dev/conda-forge/osx-arm64/liblapacke-3.11.0-5_h1b118fd_openblas.conda
+  build_number: 5
+  sha256: 782720d40d38f075389d0a49e51a38f892dfb928652bf4a44ddade45a1cf0fcd
+  md5: f77f540d134d9edec0dbf69dba56a4ad
+  depends:
+  - libblas 3.11.0 5_h51639a9_openblas
+  - libcblas 3.11.0 5_hb0561ab_openblas
+  - liblapack 3.11.0 5_hd9741b5_openblas
+  constrains:
+  - blas 2.305   openblas
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18540
+  timestamp: 1765819136654
 - conda: https://prefix.dev/conda-forge/win-64/liblapacke-3.11.0-4_h3ae206f_mkl.conda
   build_number: 4
   sha256: 036953687e8fd9a7d39a3b20b59f0772d5c3b3c861f3404af8c91bd73512895e
@@ -13285,6 +14632,20 @@ packages:
   license_family: BSD
   size: 84378
   timestamp: 1764824537699
+- conda: https://prefix.dev/conda-forge/win-64/liblapacke-3.11.0-5_h3ae206f_mkl.conda
+  build_number: 5
+  sha256: 72f312334765605cc456faa1a818d2fb6697fddc6fda798eed8408c20df19ad6
+  md5: d2abec9d4ffacb43dbd389d5c2279222
+  depends:
+  - libblas 3.11.0 5_hf2e6a31_mkl
+  - libcblas 3.11.0 5_h2a3cdd5_mkl
+  - liblapack 3.11.0 5_hf9ab0e9_mkl
+  constrains:
+  - blas 2.305   mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84330
+  timestamp: 1765819171828
 - conda: https://prefix.dev/conda-forge/linux-64/libldl-3.3.2-hf02c80a_7100101.conda
   sha256: 590232cd302047023ab31b80458833a71b10aeabee7474304dc65db322b5cd70
   md5: 19b71122fea7f6b1c4815f385b2da419
@@ -13639,6 +15000,20 @@ packages:
   purls: []
   size: 4285762
   timestamp: 1761749506256
+- conda: https://prefix.dev/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_ha158390_4.conda
+  sha256: ebbbc089b70bcde87c4121a083c724330f02a690fb9d7c6cd18c30f1b12504fa
+  md5: a6f6d3a31bb29e48d37ce65de54e2df0
+  depends:
+  - __osx >=11.0
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - llvm-openmp >=19.1.7
+  constrains:
+  - openblas >=0.3.30,<0.3.31.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4284132
+  timestamp: 1768547079205
 - conda: https://prefix.dev/conda-forge/win-64/libopenblas-0.3.30-pthreads_h877e47f_4.conda
   sha256: 95dd7508c2a9b866adf9cf9256403cad3755184b334c9624039b04448f6c8362
   md5: f551f8ae0ae6535be1ffde181f9377f3
@@ -13909,6 +15284,17 @@ packages:
   purls: []
   size: 7946383
   timestamp: 1765255939536
+- conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-14.3.0-h8f1669f_18.conda
+  sha256: e03ed186eefb46d7800224ad34bad1268c9d19ecb8f621380a50601c6221a4a7
+  md5: ad3a0e2dc4cce549b2860e2ef0e6d75b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14.3.0
+  - libstdcxx >=14.3.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 7949259
+  timestamp: 1771377982207
 - conda: https://prefix.dev/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
   sha256: 0105bd108f19ea8e6a78d2d994a6d4a8db16d19a41212070d2d1d48a63c34161
   md5: a587892d3c13b6621a6091be690dbca2
@@ -14056,6 +15442,17 @@ packages:
   purls: []
   size: 942808
   timestamp: 1768147973361
+- conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.52.0-hf4e2dac_0.conda
+  sha256: d716847b7deca293d2e49ed1c8ab9e4b9e04b9d780aea49a97c26925b28a7993
+  md5: fd893f6a3002a635b5e50ceb9dd2c0f4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.2,<79.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  size: 951405
+  timestamp: 1772818874251
 - conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.51.1-h9a5124b_0.conda
   sha256: a46b167447e2a9e38586320c30b29e3b68b6f7e6b873c18d6b1aa2efd2626917
   md5: 67e50e5bd4e5e2310d66b88c4da50096
@@ -14077,6 +15474,16 @@ packages:
   purls: []
   size: 909777
   timestamp: 1768148320535
+- conda: https://prefix.dev/conda-forge/osx-arm64/libsqlite-3.52.0-h1ae2325_0.conda
+  sha256: beb0fd5594d6d7c7cd42c992b6bb4d66cbb39d6c94a8234f15956da99a04306c
+  md5: f6233a3fddc35a2ec9f617f79d6f3d71
+  depends:
+  - __osx >=11.0
+  - icu >=78.2,<79.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: blessing
+  size: 918420
+  timestamp: 1772819478684
 - conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.51.1-hf5d6505_0.conda
   sha256: a976c8b455d9023b83878609bd68c3b035b9839d592bd6c7be7552c523773b62
   md5: f92bef2f8e523bb0eabe60099683617a
@@ -14099,6 +15506,16 @@ packages:
   purls: []
   size: 1291616
   timestamp: 1768148278261
+- conda: https://prefix.dev/conda-forge/win-64/libsqlite-3.52.0-hf5d6505_0.conda
+  sha256: 5fccf1e4e4062f8b9a554abf4f9735a98e70f82e2865d0bfdb47b9de94887583
+  md5: 8830689d537fda55f990620680934bb1
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: blessing
+  size: 1297302
+  timestamp: 1772818899033
 - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
   sha256: 813427918316a00c904723f1dfc3da1bbc1974c5cfe1ed1e704c6f4e0798cbc6
   md5: 68f68355000ec3f1d6f26ea13e8f525f
@@ -14133,6 +15550,15 @@ packages:
   purls: []
   size: 20538116
   timestamp: 1765255773242
+- conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h9f08a49_118.conda
+  sha256: b1c3824769b92a1486bf3e2cc5f13304d83ae613ea061b7bc47bb6080d6dfdba
+  md5: 865a399bce236119301ebd1532fced8d
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 20171098
+  timestamp: 1771377827750
 - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
   sha256: 81f2f246c7533b41c5e0c274172d607829019621c4a0823b5c0b4a8c7028ee84
   md5: 1b3152694d236cf233b76b8c56bf0eae
@@ -14142,6 +15568,15 @@ packages:
   purls: []
   size: 27300
   timestamp: 1765256885128
+- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
+  sha256: 3c902ffd673cb3c6ddde624cdb80f870b6c835f8bf28384b0016e7d444dd0145
+  md5: 6235adb93d064ecdf3d44faee6f468de
+  depends:
+  - libstdcxx 15.2.0 h934c35e_18
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 27575
+  timestamp: 1771378314494
 - conda: https://prefix.dev/conda-forge/linux-64/libsuitesparseconfig-7.10.1-h901830b_7100101.conda
   sha256: d8f32a0b0ee17fbace7af4bd34ad554cc855b9c18e0aeccf8395e1478c161f37
   md5: 57ae1dd979da7aa88a9b38bfa2e1d6b2
@@ -14649,6 +16084,21 @@ packages:
   license_family: MIT
   size: 45283
   timestamp: 1761015644057
+- conda: https://prefix.dev/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
+  sha256: 275c324f87bda1a3b67d2f4fcc3555eeff9e228a37655aa001284a7ceb6b0392
+  md5: e49238a1609f9a4a844b09d9926f2c3d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.2,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libxml2-16 2.15.2 hca6bf5a_0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 45968
+  timestamp: 1772704614539
 - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.15.1-hba2cd1d_0.conda
   sha256: fa01101fe7d95085846c16825f0e7dc0efe1f1c7438a96fe7395c885d6179495
   md5: a53d5f7fff38853ddb6bdc8fb609c039
@@ -14699,6 +16149,23 @@ packages:
   license_family: MIT
   size: 43042
   timestamp: 1761016261024
+- conda: https://prefix.dev/conda-forge/win-64/libxml2-2.15.2-h5d26750_0.conda
+  sha256: f905eb7046987c336122121759e7f09144729f6898f48cd06df2a945b86998d8
+  md5: 1007e1bfe181a2aee214779ee7f13d30
+  depends:
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libxml2-16 2.15.2 h692994f_0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 43681
+  timestamp: 1772704748950
 - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
   sha256: 71436e72a286ef8b57d6f4287626ff91991eb03c7bdbe835280521791efd1434
   md5: e7733bc6785ec009e47a224a71917e84
@@ -14731,6 +16198,22 @@ packages:
   license_family: MIT
   size: 554734
   timestamp: 1761015772672
+- conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
+  sha256: 08d2b34b49bec9613784f868209bb7c3bb8840d6cf835ff692e036b09745188c
+  md5: f3bc152cb4f86babe30f3a4bf0dbef69
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.2,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.2
+  license: MIT
+  license_family: MIT
+  size: 557492
+  timestamp: 1772704601644
 - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-16-2.15.1-h0ff4647_0.conda
   sha256: ebe2dd9da94280ad43da936efa7127d329b559f510670772debc87602b49b06d
   md5: 438c97d1e9648dd7342f86049dd44638
@@ -14797,6 +16280,23 @@ packages:
   purls: []
   size: 518135
   timestamp: 1761016320405
+- conda: https://prefix.dev/conda-forge/win-64/libxml2-16-2.15.2-h692994f_0.conda
+  sha256: b8c71b3b609c7cfe17f3f2a47c75394d7b30acfb8b34ad7a049ea8757b4d33df
+  md5: e365238134188e42ed36ee996159d482
+  depends:
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libxml2 2.15.2
+  - icu <0.0a0
+  license: MIT
+  license_family: MIT
+  size: 520078
+  timestamp: 1772704728534
 - conda: https://prefix.dev/conda-forge/linux-64/libxslt-1.1.43-h711ed8c_1.conda
   sha256: 0694760a3e62bdc659d90a14ae9c6e132b525a7900e59785b18a08bb52a5d7e5
   md5: 87e6096ec6d542d1c1f8b33245fe8300
@@ -14938,6 +16438,18 @@ packages:
   purls: []
   size: 286129
   timestamp: 1764721670250
+- conda: https://prefix.dev/conda-forge/osx-arm64/llvm-openmp-22.1.0-hc7d1edf_0.conda
+  sha256: 0daeedb3872ad0fdd6f0d7e7165c63488e8a315d7057907434145fba0c1e7b3d
+  md5: ff0820b5588b20be3b858552ecf8ffae
+  depends:
+  - __osx >=11.0
+  constrains:
+  - openmp 22.1.0|22.1.0.*
+  - intel-openmp <0.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  size: 285558
+  timestamp: 1772028716784
 - conda: https://prefix.dev/conda-forge/win-64/llvm-openmp-21.1.7-h4fa8253_0.conda
   sha256: 79121242419bf8b485c313fa28697c5c61ec207afa674eac997b3cb2fd1ff892
   md5: 5823741f7af732cd56036ae392396ec6
@@ -15399,6 +16911,17 @@ packages:
   - pkg:pypi/meson?source=compressed-mapping
   size: 759977
   timestamp: 1765221106896
+- conda: https://prefix.dev/conda-forge/noarch/meson-1.10.1-pyhcf101f3_0.conda
+  sha256: c97f42730fcab178be043f7de3093f419b5ad179370c00494d46a472971f7bf7
+  md5: 6c07238c531b1f93603c6908d1a4ef4f
+  depends:
+  - python >=3.10
+  - ninja >=1.8.2
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 760481
+  timestamp: 1768994208765
 - conda: https://prefix.dev/conda-forge/noarch/meson-python-0.18.0-pyh70fd9c4_0.conda
   sha256: e4866b9d6609cc69ac01822ae92caee8ec6533a1b770baadc26157f24e363de3
   md5: 576c04b9d9f8e45285fb4d9452c26133
@@ -15415,6 +16938,21 @@ packages:
   - pkg:pypi/meson-python?source=hash-mapping
   size: 81997
   timestamp: 1746449677114
+- conda: https://prefix.dev/conda-forge/noarch/meson-python-0.19.0-pyh7e86bf3_2.conda
+  sha256: f608b7ee5ef089c31a80ea3b5dd42765f6792438a5c23efaad8419ad4e47b96d
+  md5: 369afcc2d4965e7a6a075ab82e2a26b8
+  depends:
+  - meson >=0.64.0
+  - ninja
+  - packaging >=23.2
+  - pyproject-metadata >=0.9.0
+  - python >=3.10
+  - tomli >=1.0.0
+  - python
+  license: MIT
+  license_family: MIT
+  size: 94339
+  timestamp: 1769082901525
 - conda: https://prefix.dev/conda-forge/linux-64/metis-5.1.0-hd0bcaf9_1007.conda
   sha256: e8a00971e6d00bd49f375c5d8d005b37a9abba0b1768533aed0f90a422bf5cc7
   md5: 28eb714416de4eb83e2cbc47e99a1b45
@@ -15472,6 +17010,21 @@ packages:
   license_family: Proprietary
   size: 125177250
   timestamp: 1761668323993
+- conda: https://prefix.dev/conda-forge/linux-64/mkl-2025.3.0-h0e700b2_463.conda
+  sha256: 659d79976f06d2b796a0836414573a737a0856b05facfa77e5cc114081a8b3d4
+  md5: f121ddfc96e6a93a26d85906adf06208
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - llvm-openmp >=21.1.8
+  - tbb >=2022.3.0
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 125728406
+  timestamp: 1767634121080
 - conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.0-hac47afa_454.conda
   sha256: 3c432e77720726c6bd83e9ee37ac8d0e3dd7c4cf9b4c5805e1d384025f9e9ab6
   md5: c83ec81713512467dfe1b496a8292544
@@ -15486,6 +17039,19 @@ packages:
   purls: []
   size: 99909095
   timestamp: 1761668703167
+- conda: https://prefix.dev/conda-forge/win-64/mkl-2025.3.0-hac47afa_455.conda
+  sha256: b2b4c84b95210760e4d12319416c60ab66e03674ccdcbd14aeb59f82ebb1318d
+  md5: fd05d1e894497b012d05a804232254ed
+  depends:
+  - llvm-openmp >=21.1.8
+  - tbb >=2022.3.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 100224829
+  timestamp: 1767634557029
 - conda: https://prefix.dev/conda-forge/linux-64/mkl-devel-2025.3.0-ha770c72_462.conda
   sha256: a55f2024accc8fd5c65da5d59108917d68da8806cb92515cf05d9917a1d583af
   md5: 619188d87dc94ed199e790d906d74bc3
@@ -15496,6 +17062,16 @@ packages:
   license_family: Proprietary
   size: 38774
   timestamp: 1761668875241
+- conda: https://prefix.dev/conda-forge/linux-64/mkl-devel-2025.3.0-ha770c72_463.conda
+  sha256: 9ba3f1af5adfb9910864525d678aec91abab2161c65155bf8150528ad794f2c3
+  md5: 325ca2c86964e8f96db949c98d21a5ad
+  depends:
+  - mkl 2025.3.0 h0e700b2_463
+  - mkl-include 2025.3.0 hf2ce2f3_463
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 311098
+  timestamp: 1767634594151
 - conda: https://prefix.dev/conda-forge/win-64/mkl-devel-2025.3.0-h57928b3_454.conda
   sha256: 825a67cf1bc9f396546355a224f158064bab0c5ff49dbc9d9b55c97c0f300705
   md5: dde464abf6aab016bcf070dda4d23f2b
@@ -15507,6 +17083,16 @@ packages:
   purls: []
   size: 5468545
   timestamp: 1761669630453
+- conda: https://prefix.dev/conda-forge/win-64/mkl-devel-2025.3.0-h57928b3_455.conda
+  sha256: 40d074286eef5bd5bd152892cf4d3cfc1b0d20ca3f1e30889d70fd59bb6cfdaf
+  md5: 838103526056d0c7f98997468f8f512e
+  depends:
+  - mkl 2025.3.0 hac47afa_455
+  - mkl-include 2025.3.0 h57928b3_455
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 5720942
+  timestamp: 1767635147036
 - conda: https://prefix.dev/conda-forge/linux-64/mkl-include-2025.3.0-hf2ce2f3_462.conda
   sha256: d536e307dd394f07b238cadc5d0a2ac0e868cc2f309abd9ebcf20d6512c83cf6
   md5: 0ec3505e9b16acc124d1ec6e5ae8207c
@@ -15514,6 +17100,13 @@ packages:
   license_family: Proprietary
   size: 705309
   timestamp: 1761668527120
+- conda: https://prefix.dev/conda-forge/linux-64/mkl-include-2025.3.0-hf2ce2f3_463.conda
+  sha256: f7fdbfb233e5d560b94e13af5ba82a38810e9cd6b9214c3112ce5a3857598b48
+  md5: 291727757c8a8613312aaa4b52e82ad8
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 981721
+  timestamp: 1767634363058
 - conda: https://prefix.dev/conda-forge/win-64/mkl-include-2025.3.0-h57928b3_454.conda
   sha256: 76576dd314735de99ccc9443c7f7c900c85783f797d2102617498fbbfc404041
   md5: 763d029dbaa14187a29ca55433221003
@@ -15522,6 +17115,13 @@ packages:
   purls: []
   size: 700532
   timestamp: 1761668942468
+- conda: https://prefix.dev/conda-forge/win-64/mkl-include-2025.3.0-h57928b3_455.conda
+  sha256: d9e8b095fabbdacf375c389dd74455d10fff9d957c43de04a16868159cf6fc4d
+  md5: 60a88e17a01bb4afbaa103e7cf0b7f72
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  size: 965435
+  timestamp: 1767634789522
 - conda: https://prefix.dev/conda-forge/linux-64/ml_dtypes-0.5.4-np2py312h0f77346_0.conda
   sha256: a85c18c5526acce27758943a33d440bcb33aa73a31aae01cbb9b5a088ba4b963
   md5: e595b02dca6bcc8257df8f94eb3d9903
@@ -15648,6 +17248,15 @@ packages:
   - pkg:pypi/mpmath?source=hash-mapping
   size: 439705
   timestamp: 1733302781386
+- conda: https://prefix.dev/conda-forge/noarch/mpmath-1.4.0-pyhd8ed1ab_0.conda
+  sha256: 0f6f76159c40af2c7ae483934513e27a9e4137364ec717c1d69511dd4bbc6a68
+  md5: 74149a38e723261f9f61bddd69e90022
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 464419
+  timestamp: 1771870721583
 - conda: https://prefix.dev/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -15978,6 +17587,24 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 8983459
   timestamp: 1763350996398
+- conda: https://prefix.dev/conda-forge/linux-64/numpy-2.4.2-py314hd4f4903_1.conda
+  sha256: 691c94f9d0002903baebc193b19407e6adb5b27c703f7f62785e1b4702ed51b7
+  md5: f626ab4f8adec5ea04a13558822e92f9
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - liblapack >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314t
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8970751
+  timestamp: 1770098542690
 - conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.3.5-py312h85ea64e_0.conda
   sha256: 095dc7f15d2f8d9970a6a4e9d4a1980989a4209cd34c2b756fbd40e71f6990cc
   md5: ee4c185ae9c1edeb8e8cd26273c90a9a
@@ -16034,6 +17661,24 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 6861174
   timestamp: 1763350930747
+- conda: https://prefix.dev/conda-forge/osx-arm64/numpy-2.4.2-py314hae46ccb_1.conda
+  sha256: 43b5ed0ead36e5133ee8462916d23284f0bce0e5f266fa4bd31a020a6cc22f14
+  md5: 0f0ddf0575b98d91cda9e3ca9eaeb9a2
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.14.* *_cp314
+  - libcxx >=19
+  - libblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6992958
+  timestamp: 1770098398327
 - conda: https://prefix.dev/conda-forge/win-64/numpy-2.3.5-py312ha72d056_0.conda
   sha256: 1db03d0b892a196351544dabf8ac93a7f9f78dc85d3732de31ecb52c0da65d1b
   md5: 1c96af76fd575e8dcc48eea3e851579f
@@ -16099,6 +17744,24 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 7588219
   timestamp: 1763350950306
+- conda: https://prefix.dev/conda-forge/win-64/numpy-2.4.2-py314h06c3c77_1.conda
+  sha256: 34fc25b81cfa987e1825586ddb1a4ac76a246fdef343c9171109017674ad6503
+  md5: 2fccd2c4e9feb4e4c2a90043015525d6
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.14.* *_cp314
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7309134
+  timestamp: 1770098414535
 - conda: https://prefix.dev/conda-forge/noarch/numpy-typing-compat-20250818.2.3-pyh5fd51be_0.conda
   sha256: 9afac6caacb7d4f7e7728c4956370d9f3eea63e25aaee5308de244c3cf2cc76d
   md5: 7f8dcd6656020ae887d2995878ea7a1a
@@ -16145,6 +17808,15 @@ packages:
   purls: []
   size: 3147047
   timestamp: 1761749519013
+- conda: https://prefix.dev/conda-forge/osx-arm64/openblas-0.3.30-openmp_hea878ba_4.conda
+  sha256: e8308ec73dd6a745afebc3d53d57474fc8209fdd690edfa7fdbe318e7423b0d0
+  md5: 5ddea21df4fed5b5830aeb402efbe036
+  depends:
+  - libopenblas 0.3.30 openmp_ha158390_4
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3144413
+  timestamp: 1768547084685
 - conda: https://prefix.dev/conda-forge/win-64/openblas-0.3.30-pthreads_h4a7f399_4.conda
   sha256: 1e858d2c5ea9108c2c4437a61570b53089177bbe9f96d78ed6474aeb7237b4ea
   md5: 482e61f83248a880d180629bf8ed36b2
@@ -16395,6 +18067,16 @@ packages:
   - pkg:pypi/packaging?source=hash-mapping
   size: 62477
   timestamp: 1745345660407
+- conda: https://prefix.dev/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+  sha256: c1fc0f953048f743385d31c468b4a678b3ad20caffdeaa94bed85ba63049fd58
+  md5: b76541e68fea4d511b1ac46a28dcd2c6
+  depends:
+  - python >=3.8
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  size: 72010
+  timestamp: 1769093650580
 - conda: https://prefix.dev/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
   sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
   md5: 457c2c8c08e54905d6954e79cb5b5db9
@@ -16724,6 +18406,16 @@ packages:
   - pkg:pypi/platformdirs?source=hash-mapping
   size: 23922
   timestamp: 1764950726246
+- conda: https://prefix.dev/conda-forge/noarch/platformdirs-4.9.2-pyhcf101f3_0.conda
+  sha256: 7f263219cecf0ba6d74c751efa60c4676ce823157ca90aa43ebba5ac615ca0fa
+  md5: 4fefefb892ce9cc1539405bec2f1a6cd
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 25643
+  timestamp: 1771233827084
 - conda: https://prefix.dev/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
   sha256: e14aafa63efa0528ca99ba568eaf506eb55a0371d12e6250aaaa61718d2eb62e
   md5: d7585b6550ad04c8c5e21097ada2888e
@@ -16761,6 +18453,18 @@ packages:
   - pkg:pypi/pooch?source=hash-mapping
   size: 55588
   timestamp: 1754941801129
+- conda: https://prefix.dev/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
+  sha256: 081e52c4612830bf1fd4a9c78eebaf335d1385d74ddfd328b1b2f26b983848eb
+  md5: dd4b6337bf8886855db6905b336db3c8
+  depends:
+  - packaging >=20.0
+  - platformdirs >=2.5.0
+  - python >=3.10
+  - requests >=2.19.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 56833
+  timestamp: 1769816568869
 - conda: https://prefix.dev/conda-forge/noarch/prometheus_client-0.23.1-pyhd8ed1ab_0.conda
   sha256: 13dc67de68db151ff909f2c1d2486fa7e2d51355b25cee08d26ede1b62d48d40
   md5: a1e91db2d17fd258c64921cb38e6745a
@@ -16884,6 +18588,19 @@ packages:
   - pkg:pypi/pybind11?source=hash-mapping
   size: 232875
   timestamp: 1755953378112
+- conda: https://prefix.dev/conda-forge/noarch/pybind11-3.0.2-pyh7a1b43c_0.conda
+  sha256: c2d16e61270efeea13102836e0f1d3f758fb093207fbda561290fa1951c6051f
+  md5: 44dff15b5d850481807888197b254b46
+  depends:
+  - python >=3.8
+  - pybind11-global ==3.0.2 *_0
+  - python
+  constrains:
+  - pybind11-abi ==11
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 245509
+  timestamp: 1771365898778
 - conda: https://prefix.dev/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
   sha256: 9e7fe12f727acd2787fb5816b2049cef4604b7a00ad3e408c5e709c298ce8bf1
   md5: f0599959a2447c1e544e216bddf393fa
@@ -16921,6 +18638,19 @@ packages:
   - pkg:pypi/pybind11-global?source=hash-mapping
   size: 228871
   timestamp: 1755953338243
+- conda: https://prefix.dev/conda-forge/noarch/pybind11-global-3.0.2-pyhc7ab6ef_0.conda
+  sha256: b97f25f7856b96ae187c17801d2536ff86a968da12f579bbc318f2367e365a02
+  md5: 0c2d37c332453bd66b254bc71311fa30
+  depends:
+  - python >=3.8
+  - __unix
+  - python
+  constrains:
+  - pybind11-abi ==11
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 241244
+  timestamp: 1771365839659
 - conda: https://prefix.dev/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
   sha256: 1950f71ff44e64163e176b1ca34812afc1a104075c3190de50597e1623eb7d53
   md5: 85815c6a22905c080111ec8d56741454
@@ -17063,6 +18793,16 @@ packages:
   - pkg:pypi/pyproject-metadata?source=hash-mapping
   size: 23260
   timestamp: 1763745539018
+- conda: https://prefix.dev/conda-forge/noarch/pyproject-metadata-0.11.0-pyhd8ed1ab_0.conda
+  sha256: 7e709bde682104c241674f8005fd560d7ea8599458c94d03ed51ef8a4ae7d737
+  md5: cd6dae6c673c8f12fe7267eac3503961
+  depends:
+  - packaging >=23.2
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 25200
+  timestamp: 1770672303277
 - conda: https://prefix.dev/conda-forge/linux-64/pyside6-6.9.3-py314hf36963e_1.conda
   sha256: 54051f72018c7a980578859e3340ba2e4d529f064e5850db4314995ca0d6fc56
   md5: 8d1ffa0a622e8dda170beeadd1795e88
@@ -17303,6 +19043,35 @@ packages:
   size: 36702440
   timestamp: 1770675584356
   python_site_packages_path: lib/python3.14/site-packages
+- conda: https://prefix.dev/conda-forge/linux-64/python-3.14.3-he1279bd_1_cp314t.conda
+  build_number: 1
+  sha256: 4212a85ccc69264eaf9e68b77ff9b504e78935a53d0923fa409900084418edce
+  md5: 19b5d632d02f56f9f95ce07dc1e086b5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.7.3,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.2,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.51.2,<4.0a0
+  - libuuid >=2.41.3,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.5.5,<4.0a0
+  - python_abi 3.14.* *_cp314t
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  track_features:
+  - py_freethreading
+  license: Python-2.0
+  size: 47583647
+  timestamp: 1770675516163
+  python_site_packages_path: lib/python3.14t/site-packages
 - conda: https://prefix.dev/conda-forge/osx-arm64/python-3.12.12-h18782d2_1_cpython.conda
   build_number: 1
   sha256: 626da9bb78459ce541407327d1e22ee673fd74e9103f1a0e0f4e3967ad0a23a7
@@ -17572,6 +19341,16 @@ packages:
   purls: []
   size: 6989
   timestamp: 1752805904792
+- conda: https://prefix.dev/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+  build_number: 8
+  sha256: d9ed2538fba61265a330ee1b1afe99a4bb23ace706172b9464546c7e01259d63
+  md5: 3251796e09870c978e0f69fa05e38fb6
+  constrains:
+  - python 3.14.* *_cp314t
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7020
+  timestamp: 1752805919426
 - conda: https://prefix.dev/conda-forge/noarch/pythran-0.18.1-pyh534df25_0.conda
   sha256: 1728debd3461073a3a379ea70744435bfa003b2d7cc31c0b04101cdf89853519
   md5: 4a1476a62a7dd7670b54466410459eb0
@@ -18205,6 +19984,22 @@ packages:
   license_family: MIT
   size: 51788
   timestamp: 1760379115194
+- conda: https://prefix.dev/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+  sha256: 7813c38b79ae549504b2c57b3f33394cea4f2ad083f0994d2045c2e24cb538c5
+  md5: c65df89a0b2e321045a9e01d1337b182
+  depends:
+  - python >=3.10
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - urllib3 >=1.21.1,<3
+  - python
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 63602
+  timestamp: 1766926974520
 - conda: https://prefix.dev/conda-forge/noarch/requests-2.32.5-pyhd8ed1ab_0.conda
   sha256: 8dc54e94721e9ab545d7234aa5192b74102263d3e704e6d0c8aa7008f2da2a7b
   md5: db0c6b99149880c8ba515cf4abe93ee4
@@ -18635,6 +20430,15 @@ packages:
   - pkg:pypi/setuptools?source=hash-mapping
   size: 748788
   timestamp: 1748804951958
+- conda: https://prefix.dev/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  sha256: 82088a6e4daa33329a30bc26dc19a98c7c1d3f05c0f73ce9845d4eab4924e9e1
+  md5: 8e194e7b992f99a5015edbd4ebd38efd
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 639697
+  timestamp: 1773074868565
 - conda: https://prefix.dev/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
   sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
   md5: 4a2cac04f86a4540b8c9b8d8f597848f
@@ -18874,6 +20678,35 @@ packages:
   - pkg:pypi/spin?source=hash-mapping
   size: 31696
   timestamp: 1758339417810
+- conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyh8f84b5b_0.conda
+  sha256: 997d1f9c742a4b802f56b83606bdc0967a85e15b3f0244e89a7b150e62f8b375
+  md5: 10cbf9a593f3b15c4da6099d8a221339
+  depends:
+  - python >=3.10
+  - click >=8,!=8.3.0,<8.4
+  - tomli
+  - importlib-metadata >=7.0
+  - __unix
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 33326
+  timestamp: 1770991894955
+- conda: https://prefix.dev/conda-forge/noarch/spin-0.17-pyha7b4d00_0.conda
+  sha256: 6da79a341cdef2d31bcaecab82c7a814f8069655fbb91c1eefad443f67f3a8fb
+  md5: 53306230e1cefaecba2ae16253542f9a
+  depends:
+  - python >=3.10
+  - click >=8,!=8.3.0,<8.4
+  - tomli
+  - importlib-metadata >=7.0
+  - colorama
+  - __win
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 32266
+  timestamp: 1770991952
 - conda: https://prefix.dev/conda-forge/linux-64/sqlalchemy-2.0.44-py314h5bd0f2a_0.conda
   sha256: b294d3b2ce032c55cefe30b79912e6ee6e55bd0d5283ef12617b7bdbe628b7e9
   md5: 82327fd3a951d713637da7a4d98a2866
@@ -19030,6 +20863,17 @@ packages:
   purls: []
   size: 24210909
   timestamp: 1752669140965
+- conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  sha256: c47299fe37aebb0fcf674b3be588e67e4afb86225be4b0d452c7eb75c086b851
+  md5: 13dc3adbc692664cd3beabd216434749
+  depends:
+  - __glibc >=2.28
+  - kernel-headers_linux-64 4.18.0 he073ed8_9
+  - tzdata
+  license: LGPL-2.0-or-later AND LGPL-2.0-or-later WITH exceptions AND GPL-2.0-or-later
+  license_family: GPL
+  size: 24008591
+  timestamp: 1765578833462
 - conda: https://prefix.dev/conda-forge/noarch/tabulate-0.9.0-pyhcf101f3_3.conda
   sha256: 795e03d14ce50ae409e86cf2a8bd8441a8c459192f97841449f33d2221066fef
   md5: de98449f11d48d4b52eefb354e2bfe35
@@ -19133,6 +20977,30 @@ packages:
   license_family: APACHE
   size: 181262
   timestamp: 1762509955687
+- conda: https://prefix.dev/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+  sha256: 975710e4b7f1b13c3c30b7fbf21e22f50abe0463b6b47a231582fdedcc45c961
+  md5: 8f7278ca5f7456a974992a8b34284737
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libhwloc >=2.12.2,<2.12.3.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  size: 181329
+  timestamp: 1767886632911
+- conda: https://prefix.dev/conda-forge/win-64/tbb-2022.3.0-h3155e25_2.conda
+  sha256: abd9a489f059fba85c8ffa1abdaa4d515d6de6a3325238b8e81203b913cf65a9
+  md5: 0f9817ffbe25f9e69ceba5ea70c52606
+  depends:
+  - libhwloc >=2.12.2,<2.12.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: APACHE
+  size: 155869
+  timestamp: 1767886839029
 - conda: https://prefix.dev/conda-forge/win-64/tbb-2022.3.0-hd094cb3_1.conda
   sha256: c31cac57913a699745d124cdc016a63e31c5749f16f60b3202414d071fc50573
   md5: 17c38aaf14c640b85c4617ccb59c1146
@@ -19299,6 +21167,16 @@ packages:
   - pkg:pypi/tomli?source=compressed-mapping
   size: 20973
   timestamp: 1760014679845
+- conda: https://prefix.dev/conda-forge/noarch/tomli-2.4.0-pyhcf101f3_0.conda
+  sha256: 62940c563de45790ba0f076b9f2085a842a65662268b02dd136a8e9b1eaf47a8
+  md5: 72e780e9aa2d0a3295f59b1874e3768b
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 21453
+  timestamp: 1768146676791
 - conda: https://prefix.dev/conda-forge/noarch/tomli-w-1.2.0-pyhd8ed1ab_0.conda
   sha256: 304834f2438017921d69f05b3f5a6394b42dc89a90a6128a46acbf8160d377f6
   md5: 32e37e8fe9ef45c637ee38ad51377769
@@ -19510,6 +21388,19 @@ packages:
   - pkg:pypi/urllib3?source=compressed-mapping
   size: 102817
   timestamp: 1765212810619
+- conda: https://prefix.dev/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+  sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
+  md5: 9272daa869e03efe68833e3dc7a02130
+  depends:
+  - backports.zstd >=1.0.0
+  - brotli-python >=1.2.0
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  size: 103172
+  timestamp: 1767817860341
 - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h2b53caa_33.conda
   sha256: 7036945b5fff304064108c22cbc1bb30e7536363782b0456681ee6cf209138bd
   md5: 2d1c042360c09498891809a3765261be
@@ -20086,6 +21977,16 @@ packages:
   license_family: MIT
   size: 565425
   timestamp: 1726846388217
+- conda: https://prefix.dev/conda-forge/linux-64/xxhash-0.8.3-hb47aa4a_0.conda
+  sha256: 08e12f140b1af540a6de03dd49173c0e5ae4ebc563cabdd35ead0679835baf6f
+  md5: 607e13a8caac17f9a664bcab5302ce06
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 108219
+  timestamp: 1746457673761
 - conda: https://prefix.dev/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
   sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
   md5: a77f85f77be52ff59391544bfe73390a

--- a/pixi.toml
+++ b/pixi.toml
@@ -431,6 +431,11 @@ cmd = "spin test --no-build --build-dir=build-mkl-lp64"
 depends-on = "build-mkl-lp64"
 description = "Test SciPy with MKL (LP64)"
 
+[feature.mkl-lp64.tasks.check-mkl-lp64-sharedlibs]
+cmd = "spin check --no-build --build-dir=build-mkl-lp64 --loaded-sharedlibs"
+depends-on = "build-mkl-lp64"
+description = "Check loaded shared libraries with MKL (LP64)"
+
 [feature.build-mkl-ilp64]
 platforms = ["linux-64"]
 
@@ -443,6 +448,11 @@ description = "Build SciPy with MKL (ILP64)"
 cmd = "spin test --no-build --build-dir=build-mkl-ilp64"
 depends-on = "build-mkl-ilp64"
 description = "Test SciPy with MKL (ILP64)"
+
+[feature.mkl-ilp64.tasks.check-mkl-ilp64-sharedlibs]
+cmd = "spin check --no-build --build-dir=build-mkl-ilp64 --loaded-sharedlibs"
+depends-on = "build-mkl-ilp64"
+description = "Check loaded shared libraries with MKL (ILP64)"
 
 
 [feature.scipy-openblas.pypi-dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -131,6 +131,22 @@ solve-group = "accelerate-ilp64"
 features = ["run-deps", "test-deps", "accelerate", "accelerate-ilp64"]
 solve-group = "accelerate-ilp64"
 
+[environments.build-mkl-lp64]
+features = ["build-deps", "mkl", "build-mkl-lp64"]
+solve-group = "mkl-lp64"
+
+[environments.mkl-lp64]
+features = ["run-deps", "test-deps", "mkl", "mkl-lp64"]
+solve-group = "mkl-lp64"
+
+[environments.build-mkl-ilp64]
+features = ["build-deps", "mkl", "build-mkl-ilp64"]
+solve-group = "mkl-ilp64"
+
+[environments.mkl-ilp64]
+features = ["run-deps", "test-deps", "mkl", "mkl-ilp64"]
+solve-group = "mkl-ilp64"
+
 [environments.py312-system-libs-osx]
 # tasks: build-system-libs, test-system-libs
 features = ["build-deps", "run-deps", "test-deps", "py312", "scikit-sparse", "system-libs"]
@@ -400,6 +416,33 @@ description = "Build SciPy with accelerate (ilp64)"
 cmd = "spin test --no-build --build-dir=build-accelerate-ilp64"
 depends-on = "build-accelerate-ilp64"
 description = "Test SciPy with accelerate (ilp64)"
+
+[feature.build-mkl-lp64]
+platforms = ["linux-64"]
+
+# Note: we need BLAS support in Meson merged before we can simply use `-Dblas=mkl`
+[feature.build-mkl-lp64.tasks.build-mkl-lp64]
+cmd = "spin build --build-dir=build-mkl-lp64 --setup-args=-Dblas=mkl-dynamic-lp64-seq --setup-args=-Duse-g77-abi=true"
+env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" }
+description = "Build SciPy with MKL (LP64)"
+
+[feature.mkl-lp64.tasks.test-mkl-lp64]
+cmd = "spin test --no-build --build-dir=build-mkl-lp64"
+depends-on = "build-mkl-lp64"
+description = "Test SciPy with MKL (LP64)"
+
+[feature.build-mkl-ilp64]
+platforms = ["linux-64"]
+
+[feature.build-mkl-ilp64.tasks.build-mkl-ilp64]
+cmd = "spin build --build-dir=build-mkl-ilp64 --setup-args=-Duse-ilp64=true --setup-args=-Dblas=mkl-dynamic-ilp64-seq --setup-args=-Duse-g77-abi=true"
+env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" }
+description = "Build SciPy with MKL (ILP64)"
+
+[feature.mkl-ilp64.tasks.test-mkl-ilp64]
+cmd = "spin test --no-build --build-dir=build-mkl-ilp64"
+depends-on = "build-mkl-ilp64"
+description = "Test SciPy with MKL (ILP64)"
 
 
 [feature.scipy-openblas.pypi-dependencies]

--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -88,6 +88,7 @@ CONFIG = _cleanup(
                 "openblas configuration": r"@BLAS_OPENBLAS_CONFIG@",
                 "pc file directory": r"@BLAS_PCFILEDIR@",
                 "has ilp64": bool(r"@BLAS_HAS_ILP64@".lower().replace('false', '')),
+                "cython blas ilp64": bool(r"@BLAS_CYTHON_ILP64@".lower().replace('false', '')),
             },
             "lapack": {
                 "name": "@LAPACK_NAME@",

--- a/scipy/_build_utils/_wrappers_common.py
+++ b/scipy/_build_utils/_wrappers_common.py
@@ -7,6 +7,7 @@ from stat import ST_MTIME
 
 # Used to convert from types in signature files to C types
 C_TYPES = {'int': 'int',
+           'blas_int': 'CBLAS_INT',
            'c': 'npy_complex64',
            'd': 'double',
            's': 'float',
@@ -40,17 +41,19 @@ USE_OLD_ACCELERATE = ['lsame', 'dcabs1']
 C_PREAMBLE = """
 #include "npy_cblas.h"
 #include "fortran_defs.h"
+
+#include "_mkl_ilp64_fixes.h"
 """
 
 LAPACK_DECLS = """
-typedef int (*_cselect1)(npy_complex64*);
-typedef int (*_cselect2)(npy_complex64*, npy_complex64*);
-typedef int (*_dselect2)(double*, double*);
-typedef int (*_dselect3)(double*, double*, double*);
-typedef int (*_sselect2)(float*, float*);
-typedef int (*_sselect3)(float*, float*, float*);
-typedef int (*_zselect1)(npy_complex128*);
-typedef int (*_zselect2)(npy_complex128*, npy_complex128*);
+typedef CBLAS_INT (*_cselect1)(npy_complex64*);
+typedef CBLAS_INT (*_cselect2)(npy_complex64*, npy_complex64*);
+typedef CBLAS_INT (*_dselect2)(double*, double*);
+typedef CBLAS_INT (*_dselect3)(double*, double*, double*);
+typedef CBLAS_INT (*_sselect2)(float*, float*);
+typedef CBLAS_INT (*_sselect3)(float*, float*, float*);
+typedef CBLAS_INT (*_zselect1)(npy_complex128*);
+typedef CBLAS_INT (*_zselect2)(npy_complex128*, npy_complex128*);
 """
 
 CPP_GUARD_BEGIN = """
@@ -119,7 +122,7 @@ def all_newer(dst_files, src_files):
                for dst in dst_files for src in src_files)
 
 
-def get_blas_macro_and_name(name, accelerate):
+def get_blas_macro_and_name(name, accelerate, ilp64=False):
     """Complex-valued and some Accelerate functions have special symbols."""
     if accelerate:
         if name in USE_OLD_ACCELERATE:
@@ -129,6 +132,9 @@ def get_blas_macro_and_name(name, accelerate):
             return '', name + '__'
     if name in WRAPPED_FUNCS:
         name = name + 'wrp'
+        if ilp64:
+            # ILP64 wrapper libs use BLAS_FUNC for all symbols including wrappers
+            return 'BLAS_FUNC', name
         return 'F_FUNC', f'{name},{name.upper()}'
     return 'BLAS_FUNC', name
 

--- a/scipy/_build_utils/src/_blas64_defines.h
+++ b/scipy/_build_utils/src/_blas64_defines.h
@@ -47,16 +47,7 @@
 #include "npy_cblas.h"
 #define F_FUNC(f, F) BLAS_FUNC(f)
 
-// https://community.intel.com/t5/Intel-oneAPI-Math-Kernel-Library/Missing-cspr-64-symbol-in-ILP64-MKL/td-p/1703471
-#ifdef FIX_MKL_2025_ILP64_MISSING_SYMBOL
-#define cspr_64_ cspr_64
-#define sgetc2_64_ sgetc2_64
-#define dgetc2_64_ dgetc2_64
-#define cgetc2_64_ cgetc2_64
-#define zgetc2_64_ zgetc2_64
-#define slasd4_64_ slasd4_64
-#define dlasd4_64_ dlasd4_64
-#endif
+#include "_mkl_ilp64_fixes.h"
 
 #define F_INT npy_int64
 

--- a/scipy/_build_utils/src/_mkl_ilp64_fixes.h
+++ b/scipy/_build_utils/src/_mkl_ilp64_fixes.h
@@ -1,0 +1,34 @@
+/*
+ * Fix missing ILP64 symbols in MKL (symbols without trailing underscore).
+ * See https://community.intel.com/t5/Intel-oneAPI-Math-Kernel-Library/Missing-cspr-64-symbol-in-ILP64-MKL/td-p/1703471
+ *
+ * MKL ILP64 provides these symbols as `foo_64` instead of `foo_64_`
+ * (i.e. without the Fortran trailing underscore after the ILP64 suffix).
+ *
+ * Include this header wherever BLAS/LAPACK ILP64 symbols are referenced.
+ */
+#ifdef FIX_MKL_2025_ILP64_MISSING_SYMBOL
+#define cgetc2_64_ cgetc2_64
+#define cgtts2_64_ cgtts2_64
+#define clarfx_64_ clarfx_64
+#define clartv_64_ clartv_64
+#define cptts2_64_ cptts2_64
+#define cspr_64_ cspr_64
+#define dgetc2_64_ dgetc2_64
+#define dgtts2_64_ dgtts2_64
+#define dlarfx_64_ dlarfx_64
+#define dlartv_64_ dlartv_64
+#define dlasd3_64_ dlasd3_64
+#define dlasd4_64_ dlasd4_64
+#define dptts2_64_ dptts2_64
+#define sgetc2_64_ sgetc2_64
+#define sgtts2_64_ sgtts2_64
+#define slartv_64_ slartv_64
+#define slasd3_64_ slasd3_64
+#define slasd4_64_ slasd4_64
+#define sptts2_64_ sptts2_64
+#define zgetc2_64_ zgetc2_64
+#define zgtts2_64_ zgtts2_64
+#define zlartv_64_ zlartv_64
+#define zptts2_64_ zptts2_64
+#endif

--- a/scipy/cluster/vq/_vq.pyx
+++ b/scipy/cluster/vq/_vq.pyx
@@ -10,7 +10,7 @@ Translated to Cython by David Warde-Farley, October 2009.
 cimport cython
 import numpy as np
 cimport numpy as np
-from scipy.linalg.cython_blas cimport dgemm, sgemm
+from scipy.linalg.cython_blas cimport blas_int, dgemm, sgemm
 
 from libc.math cimport sqrt
 
@@ -36,8 +36,8 @@ cdef inline vq_type vec_sqr(int n, vq_type *p) noexcept:
     return result
 
 
-cdef inline void cal_M(int nobs, int ncodes, int nfeat, vq_type *obs,
-                       vq_type *code_book, vq_type *M) noexcept:
+cdef inline void cal_M(blas_int nobs, blas_int ncodes, blas_int nfeat,
+                       vq_type *obs, vq_type *code_book, vq_type *M) noexcept:
     """
     Calculate M = obs * code_book.T
     """

--- a/scipy/interpolate/_ppoly.pyx
+++ b/scipy/interpolate/_ppoly.pyx
@@ -12,7 +12,7 @@ cimport cython
 cimport libc.stdlib
 cimport libc.math
 
-from scipy.linalg.cython_lapack cimport dgeev
+from scipy.linalg.cython_lapack cimport blas_int, dgeev
 
 include "_poly_common.pxi"
 
@@ -745,8 +745,9 @@ cdef int croots_poly1(const double[:,:,::1] c, double y, int ci, int cj,
     cdef double *a
     cdef double *work
     cdef double a0, a1, a2, d, br, bi, cc
-    cdef int lwork, n, i, j, order
-    cdef int nworkspace, info
+    cdef int n, i, j
+    cdef blas_int order, lwork, info
+    cdef int nworkspace
 
     n = c.shape[0]
 

--- a/scipy/linalg/_cythonized_array_utils.pyx
+++ b/scipy/linalg/_cythonized_array_utils.pyx
@@ -6,7 +6,7 @@ from scipy.linalg._cythonized_array_utils cimport (
     np_complex_numeric_t,
     np_numeric_t
     )
-from scipy.linalg.cython_lapack cimport sgetrf, dgetrf, cgetrf, zgetrf
+from scipy.linalg.cython_lapack cimport blas_int, sgetrf, dgetrf, cgetrf, zgetrf
 from libc.stdlib cimport malloc, free
 from scipy._lib._util import _apply_over_batch
 

--- a/scipy/linalg/_decomp_interpolative.pyx
+++ b/scipy/linalg/_decomp_interpolative.pyx
@@ -117,7 +117,7 @@ from scipy.fft import rfft, fft
 from scipy.sparse.linalg import LinearOperator
 
 from scipy.linalg.cython_lapack cimport dlarfgp, dorm2r, zunm2r, zlarfgp
-from scipy.linalg.cython_blas cimport dnrm2, dtrsm, dznrm2, ztrsm
+from scipy.linalg.cython_blas cimport blas_int, dnrm2, dtrsm, dznrm2, ztrsm
 
 
 __all__ = ['idd_estrank', 'idd_reconid', 'iddp_aid',
@@ -133,7 +133,8 @@ __all__ = ['idd_estrank', 'idd_reconid', 'iddp_aid',
 
 
 def idd_diffsnorm(A: LinearOperator, B: LinearOperator, *, rng, int its=20):
-    cdef int n = A.shape[1], j = 0, intone = 1
+    cdef blas_int n = A.shape[1], intone = 1
+    cdef int j = 0
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] v1
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] v2
@@ -163,7 +164,8 @@ def idd_diffsnorm(A: LinearOperator, B: LinearOperator, *, rng, int its=20):
 def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: float, *,
                 rng):
     cdef int m = a.shape[0], n = a.shape[1]
-    cdef int intone = 1, n2, nsteps = 3, row, r, nstep, cols, k, nulls
+    cdef int n2, nsteps = 3, nstep, k, nulls
+    cdef blas_int intone = 1, row, r, cols
     cdef cnp.float64_t h, alpha, beta
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=3] albetas
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] tau_arr
@@ -279,8 +281,8 @@ def idd_estrank(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, eps: fl
 def idd_findrank(A: LinearOperator, cnp.float64_t eps, *, rng):
     # Estimate the rank of A by repeatedly using A.rmatvec(random vec)
 
-    cdef int m = A.shape[0], n = A.shape[1], k = 0, kk = 0,r = n, krank
-    cdef int no_of_cols = 4, intone = 1, info = 0
+    cdef int m = A.shape[0], k = 0, kk = 0, no_of_cols = 4
+    cdef blas_int n = A.shape[1], r, krank, intone = 1, info = 0
     cdef cnp.float64_t[::1] tau = cnp.PyArray_ZEROS(1, [min(m, n)], cnp.NPY_FLOAT64, 0)
     cdef cnp.float64_t[::1] y = cnp.PyArray_ZEROS(1, [n], cnp.NPY_FLOAT64, 0)
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] retarr
@@ -372,8 +374,9 @@ def idd_id2svd(
     cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms,
     cnp.ndarray[cnp.float64_t, ndim=2] proj,
     ):
-    cdef int m = cols.shape[0], krank = cols.shape[1]
-    cdef int n = proj.shape[1] + krank, info, ci
+    cdef blas_int m = cols.shape[0], krank = cols.shape[1]
+    cdef blas_int n = proj.shape[1] + krank, info
+    cdef int ci
     cdef cnp.ndarray[cnp.float64_t, mode='fortran', ndim=2] C
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] tau1
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] tau2
@@ -457,8 +460,8 @@ def idd_reconid(B, idx, proj):
 
 
 def idd_snorm(A: LinearOperator, *, rng, int its=20):
-    cdef int n = A.shape[1]
-    cdef int j = 0, intone = 1
+    cdef blas_int n = A.shape[1], intone = 1
+    cdef int j = 0
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] v
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] u
@@ -488,8 +491,9 @@ def iddp_aid(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, *, rng):
 
 
 def iddp_asvd(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, *, rng):
-    cdef int m = a.shape[0], n = a.shape[1]
-    cdef int krank, info, ci
+    cdef blas_int m = a.shape[0], n = a.shape[1]
+    cdef blas_int krank, info
+    cdef int ci
     cdef cnp.ndarray[cnp.float64_t, mode='fortran', ndim=2] C
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] tau1
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] tau2
@@ -552,7 +556,8 @@ def iddp_asvd(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float, *, rng)
 
 
 def iddp_id(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float):
-    cdef int n = a.shape[1], krank, tmp_int, p
+    cdef blas_int n = a.shape[1], krank, tmp_int
+    cdef int p
     cdef cnp.float64_t one = 1
     krank, _, inds = iddp_qrpiv(a, eps)
 
@@ -598,9 +603,10 @@ def iddp_qrpiv(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a, cnp.float64_t eps
     This function overwrites entries of "a" !
     """
 
-    cdef int m = a.shape[0], n = a.shape[1]
+    cdef blas_int m = a.shape[0], n = a.shape[1]
     cdef cnp.ndarray col_norms = cnp.PyArray_ZEROS(1, [n], cnp.NPY_FLOAT64, 0)
-    cdef int k = 0, kpiv = 0, i = 0, tmp_int = 0, int_n = 0
+    cdef int k = 0, kpiv = 0, i = 0
+    cdef blas_int tmp_int = 0, int_n = 0
     cdef cnp.float64_t tmp_sca = 0.
     cdef cnp.ndarray taus = cnp.PyArray_ZEROS(1, [m], cnp.NPY_FLOAT64, 0)
     cdef cnp.ndarray ind = cnp.PyArray_ZEROS(1, [n], cnp.NPY_INT64, 0)
@@ -629,9 +635,8 @@ def iddp_qrpiv(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a, cnp.float64_t eps
         if k < m-1:
             # Compute the householder reflector for column k
             tmp_sca = a[k, k]
-            # FIX: Convert these to F_INT
-            tmp_int = <int>(m - k)
-            int_n = <int>n
+            tmp_int = m - k
+            int_n = n
             dlarfgp(&tmp_int, &tmp_sca, &a[k+1, k], &int_n, &taus_v[k])
 
             # Overwrite with 1. for easy matmul
@@ -702,7 +707,7 @@ def iddp_rsvd(A: LinearOperator, cnp.float64_t eps, *, rng):
 
 def iddp_svd(cnp.ndarray[cnp.float64_t, ndim=2] a: NDArray, eps: float):
     """a is overwritten"""
-    cdef int m = a.shape[0], krank, info
+    cdef blas_int m = a.shape[0], krank, info
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] taus
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] UU
     cdef cnp.ndarray[cnp.float64_t, mode='fortran', ndim=2] C
@@ -887,8 +892,9 @@ def iddr_aid(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank,
 
 def iddr_asvd(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank, *,
               rng):
-    cdef int m = a.shape[0], n = a.shape[1]
-    cdef int info, ci
+    cdef blas_int m = a.shape[0], n = a.shape[1]
+    cdef blas_int _krank = krank, info
+    cdef int ci
     cdef cnp.ndarray[cnp.float64_t, mode='fortran', ndim=2] C
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] tau1
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] tau2
@@ -935,22 +941,22 @@ def iddr_asvd(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank
     # Apply Q of col to U from the left
     C = col[:, :krank].copy(order='F')
     dorm2r(<char*>'R', <char*>'T',
-           &krank, &m, &krank, &C[0, 0], &m, &tau1[0],
-           &UU[0,0], &krank, &a[0, 0], &info)
+           &_krank, &m, &_krank, &C[0, 0], &m, &tau1[0],
+           &UU[0,0], &_krank, &a[0, 0], &info)
 
     VV[:krank, :krank] = V[:, :].T
     # Apply Q of t to V from the left
     C = t[:, :krank].copy(order='F')
     dorm2r(<char*>'R', <char*>'T',
-           &krank, &n, &krank, &C[0, 0], &n, &tau2[0],
-           &VV[0, 0], &krank, &a[0, 0], &info)
+           &_krank, &n, &_krank, &C[0, 0], &n, &tau2[0],
+           &VV[0, 0], &_krank, &a[0, 0], &info)
 
     return UU, S, VV
 
 
 def iddr_id(cnp.ndarray[cnp.float64_t, ndim=2] a, int krank):
-    cdef int n = a.shape[1]
-    cdef int tmp_int
+    cdef blas_int n = a.shape[1]
+    cdef blas_int tmp_int, _krank = krank
     cdef cnp.float64_t one = 1.0
     cdef cnp.ndarray[cnp.npy_int64, ndim=1] inds
     cdef cnp.ndarray[cnp.npy_int64, ndim=1] perms
@@ -969,15 +975,16 @@ def iddr_id(cnp.ndarray[cnp.float64_t, ndim=2] a, int krank):
     tmp_int = n - krank
     # SIDE,UPLO,TRANSA,DIAG,M,N,ALPHA,A,LDA,B,LDB
     dtrsm(<char*>'R', <char*>'L', <char*>'N', <char*>'N',
-          &tmp_int, &krank, &one, &a[0, 0], &n, &a[0, krank], &n)
+          &tmp_int, &_krank, &one, &a[0, 0], &n, &a[0, krank], &n)
 
     return perms, a[:krank, krank:]
 
 
 def iddr_qrpiv(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, krank: int):
-    cdef int m = a.shape[0], n = a.shape[1]
+    cdef blas_int m = a.shape[0], n = a.shape[1]
     cdef cnp.ndarray col_norms = cnp.PyArray_ZEROS(1, [n], cnp.NPY_FLOAT64, 0)
-    cdef int loop = 0, loops, kpiv = 0, i = 0, tmp_int = 0, int_n = 0
+    cdef int loop = 0, loops, kpiv = 0, i = 0
+    cdef blas_int tmp_int = 0, int_n = 0
     cdef cnp.float64_t tmp_sca = 0.
     cdef cnp.ndarray taus = cnp.PyArray_ZEROS(1, [m], cnp.NPY_FLOAT64, 0)
     cdef cnp.ndarray ind = cnp.PyArray_ZEROS(1, [n], cnp.NPY_INT64, 0)
@@ -1004,9 +1011,8 @@ def iddr_qrpiv(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, krank: i
 
         if loop < m-1:
             tmp_sca = a[loop, loop]
-            # FIX: Convert these to F_INT
-            tmp_int = <int>(m - loop)
-            int_n = <int>n
+            tmp_int = m - loop
+            int_n = n
             dlarfgp(&tmp_int, &tmp_sca, &a[loop+1, loop], &int_n, &taus_v[loop])
 
             # Overwrite with 1. for easy matmul
@@ -1075,7 +1081,8 @@ def iddr_rsvd(A: LinearOperator, int krank, *, rng):
 
 
 def iddr_svd(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank):
-    cdef int m = a.shape[0], info = 0
+    cdef blas_int m = a.shape[0], info = 0
+    cdef blas_int _krank = krank
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=1] taus
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=2] UU
     cdef cnp.ndarray[cnp.float64_t, mode='fortran', ndim=2] C
@@ -1099,14 +1106,15 @@ def iddr_svd(cnp.ndarray[cnp.float64_t, mode="c", ndim=2] a: NDArray, int krank)
     # Do the transpose dance for C-layout, use a for scratch
     C = a[:, :krank].copy(order='F')
     dorm2r(<char*>'R', <char*>'T',
-           &krank, &m, &krank, &C[0, 0], &m, &taus[0],
-           &UU[0,0], &krank, &a[0, 0], &info)
+           &_krank, &m, &_krank, &C[0, 0], &m, &taus[0],
+           &UU[0,0], &_krank, &a[0, 0], &info)
 
     return UU, S, V
 
 
 def idz_diffsnorm(A: LinearOperator, B: LinearOperator, *, rng, int its=20):
-    cdef int n = A.shape[1], j = 0, intone = 1
+    cdef blas_int n = A.shape[1], intone = 1
+    cdef int j = 0
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] v1
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] v2
@@ -1135,7 +1143,8 @@ def idz_diffsnorm(A: LinearOperator, B: LinearOperator, *, rng, int its=20):
 
 def idz_estrank(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: float, *,
                 rng):
-    cdef int m = a.shape[0], n = a.shape[1], n2, nsteps = 3, row, r, nstep, cols, k
+    cdef int m = a.shape[0], n = a.shape[1], n2, nsteps = 3, nstep, k
+    cdef blas_int row, r, cols
     cdef cnp.float64_t h, alpha, beta
     cdef cnp.ndarray[cnp.float64_t, mode='c', ndim=3] albetas
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] tau_arr
@@ -1226,8 +1235,8 @@ def idz_estrank(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps:
 def idz_findrank(A: LinearOperator, cnp.float64_t eps, *, rng):
     # Estimate the rank of A by repeatedly using A.rmatvec(random vec)
 
-    cdef int m = A.shape[0], n = A.shape[1], k = 0, kk = 0,r = n, krank
-    cdef int no_of_cols = 4, intone = 1, info = 0
+    cdef int m = A.shape[0], k = 0, kk = 0, no_of_cols = 4
+    cdef blas_int n = A.shape[1], r, krank, intone = 1, info = 0
     cdef cnp.complex128_t[::1] tau = cnp.PyArray_ZEROS(1, [min(m, n)],
                                                        cnp.NPY_COMPLEX128, 0)
     cdef cnp.complex128_t[::1] y = cnp.PyArray_ZEROS(1, [n], cnp.NPY_COMPLEX128, 0)
@@ -1322,8 +1331,9 @@ def idz_id2svd(
     cnp.ndarray[cnp.int64_t, mode='c', ndim=1] perms,
     cnp.ndarray[cnp.complex128_t, ndim=2] proj,
     ):
-    cdef int m = cols.shape[0], krank = cols.shape[1]
-    cdef int n = proj.shape[1] + krank, info, ci
+    cdef blas_int m = cols.shape[0], krank = cols.shape[1]
+    cdef blas_int n = proj.shape[1] + krank, info
+    cdef int ci
     cdef cnp.ndarray[cnp.complex128_t, mode='fortran', ndim=2] C
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] tau1
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] tau2
@@ -1393,8 +1403,8 @@ def idz_reconid(B, idx, proj):
 
 
 def idz_snorm(A: LinearOperator, *, rng, int its=20):
-    cdef int n = A.shape[1]
-    cdef int j = 0, intone = 1
+    cdef blas_int n = A.shape[1], intone = 1
+    cdef int j = 0
     cdef cnp.float64_t snorm = 0.0
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] v
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] u
@@ -1426,8 +1436,9 @@ def idzp_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, eps: fl
 
 def idzp_asvd(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a, cnp.float64_t eps, *,
               rng):
-    cdef int m = a.shape[0], n = a.shape[1]
-    cdef int krank, info, ci
+    cdef blas_int m = a.shape[0], n = a.shape[1]
+    cdef blas_int krank, info
+    cdef int ci
     cdef cnp.ndarray[cnp.complex128_t, mode='fortran', ndim=2] C
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] tau1
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] tau2
@@ -1492,7 +1503,8 @@ def idzp_asvd(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a, cnp.float64_t e
 
 
 def idzp_id(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, cnp.float64_t eps):
-    cdef int n = a.shape[1], krank, tmp_int, p
+    cdef blas_int n = a.shape[1], krank, tmp_int
+    cdef int p
     cdef double complex one = 1
     krank, _, inds = idzp_qrpiv(a, eps)
 
@@ -1515,9 +1527,10 @@ def idzp_id(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, cnp.float64_t eps
 
 
 def idzp_qrpiv(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, cnp.float64_t eps):
-    cdef int m = a.shape[0], n = a.shape[1]
+    cdef blas_int m = a.shape[0], n = a.shape[1]
     cdef cnp.ndarray col_norms = cnp.PyArray_ZEROS(1, [n], cnp.NPY_FLOAT64, 0)
-    cdef int k = 0, kpiv = 0, i = 0, tmp_int = 0, int_n = 0
+    cdef int k = 0, kpiv = 0, i = 0
+    cdef blas_int tmp_int = 0, int_n = 0
     cdef double complex tmp_sca = 0.
     cdef cnp.ndarray taus = cnp.PyArray_ZEROS(1, [m], cnp.NPY_COMPLEX128, 0)
     cdef cnp.ndarray ind = cnp.PyArray_ZEROS(1, [n], cnp.NPY_INT64, 0)
@@ -1546,9 +1559,8 @@ def idzp_qrpiv(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, cnp.float64_t 
         if k < m-1:
             # Compute the householder reflector for column k
             tmp_sca = a[k, k]
-            # FIX: Convert these to F_INT
-            tmp_int = <int>(m - k)
-            int_n = <int>n
+            tmp_int = m - k
+            int_n = n
             zlarfgp(&tmp_int, &tmp_sca, &a[k+1, k], &int_n, &taus_v[k])
 
             # Overwrite with 1. for easy matmul
@@ -1624,7 +1636,7 @@ def idzp_rsvd(A: LinearOperator, cnp.float64_t eps, *, rng):
 
 
 def idzp_svd(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a, cnp.float64_t eps):
-    cdef int m = a.shape[0], krank, info
+    cdef blas_int m = a.shape[0], krank, info
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] taus
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] UU
     cdef cnp.ndarray[cnp.complex128_t, ndim=2] V
@@ -1742,8 +1754,9 @@ def idzr_aid(cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] a: NDArray, int kra
 
 
 def idzr_asvd(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank, *, rng):
-    cdef int m = a.shape[0], n = a.shape[1]
-    cdef int info, ci
+    cdef blas_int m = a.shape[0], n = a.shape[1]
+    cdef blas_int _krank = krank, info
+    cdef int ci
     cdef cnp.ndarray[cnp.complex128_t, mode='fortran', ndim=2] C
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] tau1
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] tau2
@@ -1789,8 +1802,8 @@ def idzr_asvd(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank, *, r
     np.conjugate(tau1, out=tau1)
     C = col[:, :krank].conj().copy(order='F')
     zunm2r(<char*>'R', <char*>'C',
-           &krank, &m, &krank, &C[0, 0], &m, &tau1[0],
-           &UU[0,0], &krank, &a[0, 0], &info)
+           &_krank, &m, &_krank, &C[0, 0], &m, &tau1[0],
+           &UU[0,0], &_krank, &a[0, 0], &info)
 
     VV[:krank, :krank] = V[:, :].conj().T
 
@@ -1799,14 +1812,15 @@ def idzr_asvd(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank, *, r
     np.conjugate(tau2, out=tau2)
     C = t[:, :krank].conj().copy(order='F')
     zunm2r(<char*>'R', <char*>'C',
-           &krank, &n, &krank, &C[0, 0], &n, &tau2[0],
-           &VV[0, 0], &krank, &a[0, 0], &info)
+           &_krank, &n, &_krank, &C[0, 0], &n, &tau2[0],
+           &VV[0, 0], &_krank, &a[0, 0], &info)
 
     return UU, S, VV
 
 
 def idzr_id(cnp.ndarray[cnp.complex128_t, ndim=2] a, int krank):
-    cdef int n = a.shape[1], tmp_int, p
+    cdef blas_int n = a.shape[1], tmp_int, _krank = krank
+    cdef int p
     cdef double complex one = 1.0
     cdef cnp.ndarray[cnp.int64_t, ndim=1] inds
     cdef cnp.ndarray[cnp.int64_t, ndim=1] perms
@@ -1823,14 +1837,15 @@ def idzr_id(cnp.ndarray[cnp.complex128_t, ndim=2] a, int krank):
     tmp_int = n - krank
     # SIDE,UPLO,TRANSA,DIAG,M,N,ALPHA,A,LDA,B,LDB
     ztrsm(<char*>'R', <char*>'L', <char*>'N', <char*>'N',
-          &tmp_int, &krank, &one, &a[0, 0], &n, &a[0, krank], &n)
+          &tmp_int, &_krank, &one, &a[0, 0], &n, &a[0, krank], &n)
 
     return perms, a[:krank, krank:]
 
 
 def idzr_qrpiv(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank):
-    cdef int m = a.shape[0], n = a.shape[1]
-    cdef int loop = 0, loops, kpiv = 0, i = 0, tmp_int = 0
+    cdef blas_int m = a.shape[0], n = a.shape[1]
+    cdef int loop = 0, loops, kpiv = 0, i = 0
+    cdef blas_int tmp_int = 0
     cdef cnp.ndarray col_norms = cnp.PyArray_ZEROS(1, [n], cnp.NPY_FLOAT64, 0)
     cdef double complex tmp_sca = 0.
     cdef cnp.ndarray taus = cnp.PyArray_ZEROS(1, [m], cnp.NPY_COMPLEX128, 0)
@@ -1858,8 +1873,7 @@ def idzr_qrpiv(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank):
 
         if loop < m-1:
             tmp_sca = a[loop, loop]
-            # FIX: Convert these to F_INT
-            tmp_int = (m - loop)
+            tmp_int = m - loop
             zlarfgp(&tmp_int, &tmp_sca, &a[loop+1, loop], &n, &taus_v[loop])
 
             # Overwrite with 1. for easy matmul
@@ -1929,7 +1943,9 @@ def idzr_rsvd(A: LinearOperator, int krank, *, rng):
 
 
 def idzr_svd(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank):
-    cdef int m = a.shape[0], n = a.shape[1], info = 0
+    cdef blas_int m = a.shape[0], info = 0
+    cdef blas_int _krank = krank
+    cdef int n = a.shape[1]
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=1] taus
     cdef cnp.ndarray[cnp.int64_t, mode='c', ndim=1] inds
     cdef cnp.ndarray[cnp.complex128_t, mode='c', ndim=2] UU
@@ -1953,7 +1969,7 @@ def idzr_svd(cnp.ndarray[cnp.complex128_t, mode="c", ndim=2] a, int krank):
     # But do the adjoint dance for LAPACK via U.H @ Q.H; use a for scratch
     C = a[:, :krank].conj().copy(order='F')
     zunm2r(<char*>'R', <char*>'C',
-           &krank, &m, &krank, &C[0, 0], &m, &taus[0],
-           &UU[0,0], &krank, &a[0, 0], &info)
+           &_krank, &m, &_krank, &C[0, 0], &m, &taus[0],
+           &UU[0,0], &_krank, &a[0, 0], &info)
 
     return UU, S, V

--- a/scipy/linalg/_decomp_update.pyx.in
+++ b/scipy/linalg/_decomp_update.pyx.in
@@ -69,6 +69,7 @@ cdef extern from *:
 
 from . cimport cython_blas as blas_pointers
 from . cimport cython_lapack as lapack_pointers
+from .cython_blas cimport blas_int
 
 import numpy as np
 from scipy._lib._util import _apply_over_batch
@@ -97,32 +98,32 @@ cdef inline blas_t* row(blas_t* a, int* as, int i) noexcept nogil:
 cdef inline blas_t* col(blas_t* a, int* as, int j) noexcept nogil:
     return a + j*as[1]
 
-cdef inline void copy(int n, blas_t* x, int incx, blas_t* y, int incy) noexcept nogil:
+cdef inline void copy(blas_int n, blas_t* x, blas_int incx, blas_t* y, blas_int incy) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         blas_pointers.{{C}}copy(&n, x, &incx, y, &incy)
     {{endfor}}
 
-cdef inline void swap(int n, blas_t* x, int incx, blas_t* y, int incy) noexcept nogil:
+cdef inline void swap(blas_int n, blas_t* x, blas_int incx, blas_t* y, blas_int incy) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         blas_pointers.{{C}}swap(&n, x, &incx, y, &incy)
     {{endfor}}
 
-cdef inline void scal(int n, blas_t a, blas_t* x, int incx) noexcept nogil:
+cdef inline void scal(blas_int n, blas_t a, blas_t* x, blas_int incx) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         blas_pointers.{{C}}scal(&n, &a, x, &incx)
     {{endfor}}
 
-cdef inline void axpy(int n, blas_t a, blas_t* x, int incx,
-                      blas_t* y, int incy) noexcept nogil:
+cdef inline void axpy(blas_int n, blas_t a, blas_t* x, blas_int incx,
+                      blas_t* y, blas_int incy) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         blas_pointers.{{C}}axpy(&n, &a, x, &incx, y, &incy)
     {{endfor}}
 
-cdef inline blas_t nrm2(int n, blas_t* x, int incx) noexcept nogil:
+cdef inline blas_t nrm2(blas_int n, blas_t* x, blas_int incx) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, ['s', 'd', 'sc', 'dz'])}}
     {{COND}} blas_t is {{CNAME}}:
         return blas_pointers.{{C}}nrm2(&n, x, &incx)
@@ -144,7 +145,7 @@ cdef inline void lartg(blas_t* a, blas_t* b, blas_t* c, blas_t* s) noexcept nogi
     a[0] = g
     b[0] = 0
 
-cdef inline void rot(int n, blas_t* x, int incx, blas_t* y, int incy,
+cdef inline void rot(blas_int n, blas_t* x, blas_int incx, blas_t* y, blas_int incy,
                      blas_t c, blas_t s) noexcept nogil:
     if blas_t is float:
         blas_pointers.srot(&n, x, &incx, y, &incy, &c, &s)
@@ -155,22 +156,22 @@ cdef inline void rot(int n, blas_t* x, int incx, blas_t* y, int incy,
     else:
         lapack_pointers.zrot(&n, x, &incx, y, &incy, <double*>&c, &s)
 
-cdef inline void larfg(int n, blas_t* alpha, blas_t* x, int incx,
+cdef inline void larfg(blas_int n, blas_t* alpha, blas_t* x, blas_int incx,
                        blas_t* tau) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         lapack_pointers.{{C}}larfg(&n, alpha, x, &incx, tau)
     {{endfor}}
 
-cdef inline void larf(char* side, int m, int n, blas_t* v, int incv, blas_t tau,
-    blas_t* c, int ldc, blas_t* work) noexcept nogil:
+cdef inline void larf(char* side, blas_int m, blas_int n, blas_t* v, blas_int incv, blas_t tau,
+    blas_t* c, blas_int ldc, blas_t* work) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         lapack_pointers.{{C}}larf(side, &m, &n, v, &incv, &tau, c, &ldc, work)
     {{endfor}}
 
-cdef inline void ger(int m, int n, blas_t alpha, blas_t* x, int incx, blas_t* y,
-        int incy, blas_t* a, int lda) noexcept nogil:
+cdef inline void ger(blas_int m, blas_int n, blas_t alpha, blas_t* x, blas_int incx, blas_t* y,
+        blas_int incy, blas_t* a, blas_int lda) noexcept nogil:
     if blas_t is float:
         blas_pointers.sger(&m, &n, &alpha, x, &incx, y, &incy, a, &lda)
     elif blas_t is double:
@@ -180,43 +181,43 @@ cdef inline void ger(int m, int n, blas_t alpha, blas_t* x, int incx, blas_t* y,
     else:
         blas_pointers.zgeru(&m, &n, &alpha, x, &incx, y, &incy, a, &lda)
 
-cdef inline void gemv(char* trans, int m, int n, blas_t alpha, blas_t* a,
-        int lda, blas_t* x, int incx, blas_t beta, blas_t* y, int incy) noexcept nogil:
+cdef inline void gemv(char* trans, blas_int m, blas_int n, blas_t alpha, blas_t* a,
+        blas_int lda, blas_t* x, blas_int incx, blas_t beta, blas_t* y, blas_int incy) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         blas_pointers.{{C}}gemv(trans, &m, &n, &alpha, a, &lda, x, &incx,
                 &beta, y, &incy)
     {{endfor}}
 
-cdef inline void gemm(char* transa, char* transb, int m, int n, int k,
-        blas_t alpha, blas_t* a, int lda, blas_t* b, int ldb, blas_t beta,
-        blas_t* c, int ldc) noexcept nogil:
+cdef inline void gemm(char* transa, char* transb, blas_int m, blas_int n, blas_int k,
+        blas_t alpha, blas_t* a, blas_int lda, blas_t* b, blas_int ldb, blas_t beta,
+        blas_t* c, blas_int ldc) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         blas_pointers.{{C}}gemm(transa, transb, &m, &n, &k, &alpha, a, &lda,
                 b, &ldb, &beta, c, &ldc)
     {{endfor}}
 
-cdef inline void trmm(char* side, char* uplo, char* transa, char* diag, int m,
-        int n, blas_t alpha, blas_t* a, int lda, blas_t* b, int ldb) noexcept nogil:
+cdef inline void trmm(char* side, char* uplo, char* transa, char* diag, blas_int m,
+        blas_int n, blas_t alpha, blas_t* a, blas_int lda, blas_t* b, blas_int ldb) noexcept nogil:
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         blas_pointers.{{C}}trmm(side, uplo, transa, diag, &m, &n, &alpha, a, &lda,
                 b, &ldb)
     {{endfor}}
 
-cdef inline int geqrf(int m, int n, blas_t* a, int lda, blas_t* tau,
-                      blas_t* work, int lwork) noexcept nogil:
-    cdef int info
+cdef inline int geqrf(blas_int m, blas_int n, blas_t* a, blas_int lda, blas_t* tau,
+                      blas_t* work, blas_int lwork) noexcept nogil:
+    cdef blas_int info
     {{for COND, CNAME, C in zip(CONDS, CNAMES, PREFIX)}}
     {{COND}} blas_t is {{CNAME}}:
         lapack_pointers.{{C}}geqrf(&m, &n, a, &lda, tau, work, &lwork, &info)
     {{endfor}}
     return info
 
-cdef inline int ormqr(char* side, char* trans, int m, int n, int k, blas_t* a,
-    int lda, blas_t* tau, blas_t* c, int ldc, blas_t* work, int lwork) noexcept nogil:
-    cdef int info = 0
+cdef inline int ormqr(char* side, char* trans, blas_int m, blas_int n, blas_int k, blas_t* a,
+    blas_int lda, blas_t* tau, blas_t* c, blas_int ldc, blas_t* work, blas_int lwork) noexcept nogil:
+    cdef blas_int info = 0
     if blas_t is float:
         lapack_pointers.sormqr(side, trans, &m, &n, &k, a, &lda, tau, c, &ldc,
                 work, &lwork, &info)

--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -352,6 +352,10 @@ cpdef double complex _test_zdotu(double complex[:] zx, double complex[:] zy) noe
         blas_int incx = zx.strides[0] // sizeof(zx[0])
         blas_int incy = zy.strides[0] // sizeof(zy[0])
     return zdotu(&n, &zx[0], &incx, &zy[0], &incy)
+
+def _blas_int_size():
+    # Return the size of blas_int in bytes.
+    return sizeof(blas_int)
 """
 
 lapack_py_wrappers = """

--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -71,11 +71,55 @@ example, in a ``meson.build`` file when using Meson::
         ...
     )
 
+
+ILP64 support
+-------------
+
+All integer parameters in this module use the ``blas_int`` type, which is
+a typedef for either ``int`` (LP64, the default) or ``int64_t`` (ILP64),
+depending on how SciPy was built. The build configuration can be checked
+at runtime via ``scipy.show_config()`` - look for the ``blas_cython_ilp64``
+entry.
+
+Downstream packages that want to support both LP64 and ILP64 builds of SciPy
+should follow this pattern:
+
+1. Use ``blas_int`` for all integer variables passed to BLAS functions.
+2. For backwards compatibility with scipy <=1.17.0 (if desired), perform a
+   **build-time check** for whether ``blas_int`` is available, and typedef
+   it as ``int`` otherwise. Example for Meson:
+
+.. code::
+
+    # Check if scipy's cython_blas exports blas_int (ILP64 support).
+    _blas_int_conf = configuration_data()
+    if cython.compiles('from scipy.linalg.cython_blas cimport blas_int')
+      _blas_int_conf.set('BLAS_INT_DEF', 'from scipy.linalg.cython_blas cimport blas_int')
+    else
+      _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
+    endif
+
+    _blas_int_pxi = configure_file(
+      input: '_blas_int.pxi.in',
+      output: '_blas_int.pxi',
+      configuration: _blas_int_conf,
+    )
+
+With the file ``_blas_int.pxi.in`` containing the single line::
+
+    @BLAS_INT_DEF@
+
+
+``cython_blas`` API
+-------------------
+
+Integer type:
+
+- blas_int: type alias for either ``int`` or ``int64_t``
+
 Raw function pointers (Fortran-style pointer arguments):
 
 - {}
-
-
 """
 
 # Within SciPy, these wrappers can be used via relative or absolute cimport.
@@ -116,11 +160,55 @@ fixed-api auxiliary routines.
 These wrappers do not check for alignment of arrays.
 Alignment should be checked before these wrappers are used.
 
+
+ILP64 support
+-------------
+
+All integer parameters in this module use the ``blas_int`` type, which is
+a typedef for either ``int`` (LP64, the default) or ``int64_t`` (ILP64),
+depending on how SciPy was built. The build configuration can be checked
+at runtime via ``scipy.show_config()`` - look for the ``blas_cython_ilp64``
+entry.
+
+Downstream packages that want to support both LP64 and ILP64 builds of SciPy
+should follow this pattern:
+
+1. Use ``blas_int`` for all integer variables passed to LAPACK functions.
+2. For backwards compatibility with scipy <=1.17.0 (if desired), perform a
+   **build-time check** for whether ``blas_int`` is available, and typedef
+   it as ``int`` otherwise. Example for Meson:
+
+.. code::
+
+    # Check if scipy's cython_lapack exports blas_int (ILP64 support).
+    _blas_int_conf = configuration_data()
+    if cython.compiles('from scipy.linalg.cython_lapack cimport blas_int')
+      _blas_int_conf.set('BLAS_INT_DEF', 'from scipy.linalg.cython_lapack cimport blas_int')
+    else
+      _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
+    endif
+
+    _blas_int_pxi = configure_file(
+      input: '_blas_int.pxi.in',
+      output: '_blas_int.pxi',
+      configuration: _blas_int_conf,
+    )
+
+With the file ``_blas_int.pxi.in`` containing the single line::
+
+    @BLAS_INT_DEF@
+
+
+``cython_lapack`` API
+---------------------
+
+Integer type:
+
+- blas_int: type alias for either ``int`` or ``int64_t``
+
 Raw function pointers (Fortran-style pointer arguments):
 
 - {}
-
-
 """
 
 # Within SciPy, these wrappers can be used via relative or absolute cimport.
@@ -578,7 +666,7 @@ def _sigs_replace_int(sigs):
     """Replace 'int' and 'bint' types with 'blas_int' in parsed signatures.
 
     This makes BLAS/LAPACK integer parameters use the ``blas_int`` typedef,
-    which resolves to ``int`` for LP64 and ``npy_int64`` for ILP64 builds.
+    which resolves to ``int`` for LP64 and ``int64_t`` for ILP64 builds.
     """
     for sig in sigs:
         sig['argtypes'] = [

--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -96,7 +96,11 @@ from numpy cimport npy_complex64, npy_complex128
 
 '''
 
-lapack_pyx_preamble = '''"""
+lapack_pyx_preamble = '''# cython: boundscheck = False
+# cython: wraparound = False
+# cython: cdivision = True
+
+"""
 LAPACK functions for Cython
 ===========================
 
@@ -138,14 +142,14 @@ from numpy cimport npy_complex64, npy_complex128
 cdef extern from "_lapack_subroutines.h":
     # Function pointer type declarations for
     # gees and gges families of functions.
-    ctypedef bint _cselect1(npy_complex64*)
-    ctypedef bint _cselect2(npy_complex64*, npy_complex64*)
-    ctypedef bint _dselect2(d*, d*)
-    ctypedef bint _dselect3(d*, d*, d*)
-    ctypedef bint _sselect2(s*, s*)
-    ctypedef bint _sselect3(s*, s*, s*)
-    ctypedef bint _zselect1(npy_complex128*)
-    ctypedef bint _zselect2(npy_complex128*, npy_complex128*)
+    ctypedef blas_int _cselect1(npy_complex64*)
+    ctypedef blas_int _cselect2(npy_complex64*, npy_complex64*)
+    ctypedef blas_int _dselect2(d*, d*)
+    ctypedef blas_int _dselect3(d*, d*, d*)
+    ctypedef blas_int _sselect2(s*, s*)
+    ctypedef blas_int _sselect3(s*, s*, s*)
+    ctypedef blas_int _zselect1(npy_complex128*)
+    ctypedef blas_int _zselect2(npy_complex128*, npy_complex128*)
 
 '''
 
@@ -158,37 +162,37 @@ cdef inline bint _is_contiguous(double[:,:] a, int axis) noexcept nogil:
 
 cpdef float complex _test_cdotc(float complex[:] cx, float complex[:] cy) noexcept nogil:
     cdef:
-        int n = cx.shape[0]
-        int incx = cx.strides[0] // sizeof(cx[0])
-        int incy = cy.strides[0] // sizeof(cy[0])
+        blas_int n = cx.shape[0]
+        blas_int incx = cx.strides[0] // sizeof(cx[0])
+        blas_int incy = cy.strides[0] // sizeof(cy[0])
     return cdotc(&n, &cx[0], &incx, &cy[0], &incy)
 
 cpdef float complex _test_cdotu(float complex[:] cx, float complex[:] cy) noexcept nogil:
     cdef:
-        int n = cx.shape[0]
-        int incx = cx.strides[0] // sizeof(cx[0])
-        int incy = cy.strides[0] // sizeof(cy[0])
+        blas_int n = cx.shape[0]
+        blas_int incx = cx.strides[0] // sizeof(cx[0])
+        blas_int incy = cy.strides[0] // sizeof(cy[0])
     return cdotu(&n, &cx[0], &incx, &cy[0], &incy)
 
 cpdef double _test_dasum(double[:] dx) noexcept nogil:
     cdef:
-        int n = dx.shape[0]
-        int incx = dx.strides[0] // sizeof(dx[0])
+        blas_int n = dx.shape[0]
+        blas_int incx = dx.strides[0] // sizeof(dx[0])
     return dasum(&n, &dx[0], &incx)
 
 cpdef double _test_ddot(double[:] dx, double[:] dy) noexcept nogil:
     cdef:
-        int n = dx.shape[0]
-        int incx = dx.strides[0] // sizeof(dx[0])
-        int incy = dy.strides[0] // sizeof(dy[0])
+        blas_int n = dx.shape[0]
+        blas_int incx = dx.strides[0] // sizeof(dx[0])
+        blas_int incy = dy.strides[0] // sizeof(dy[0])
     return ddot(&n, &dx[0], &incx, &dy[0], &incy)
 
-cpdef int _test_dgemm(double alpha, double[:,:] a, double[:,:] b, double beta,
+cpdef blas_int _test_dgemm(double alpha, double[:,:] a, double[:,:] b, double beta,
                 double[:,:] c) except -1 nogil:
     cdef:
         char *transa
         char *transb
-        int m, n, k, lda, ldb, ldc
+        blas_int m, n, k, lda, ldb, ldc
         double *a0=&a[0,0]
         double *b0=&b[0,0]
         double *c0=&c[0,0]
@@ -264,89 +268,89 @@ cpdef int _test_dgemm(double alpha, double[:,:] a, double[:,:] b, double beta,
 
 cpdef double _test_dnrm2(double[:] x) noexcept nogil:
     cdef:
-        int n = x.shape[0]
-        int incx = x.strides[0] // sizeof(x[0])
+        blas_int n = x.shape[0]
+        blas_int incx = x.strides[0] // sizeof(x[0])
     return dnrm2(&n, &x[0], &incx)
 
 cpdef double _test_dzasum(double complex[:] zx) noexcept nogil:
     cdef:
-        int n = zx.shape[0]
-        int incx = zx.strides[0] // sizeof(zx[0])
+        blas_int n = zx.shape[0]
+        blas_int incx = zx.strides[0] // sizeof(zx[0])
     return dzasum(&n, &zx[0], &incx)
 
 cpdef double _test_dznrm2(double complex[:] x) noexcept nogil:
     cdef:
-        int n = x.shape[0]
-        int incx = x.strides[0] // sizeof(x[0])
+        blas_int n = x.shape[0]
+        blas_int incx = x.strides[0] // sizeof(x[0])
     return dznrm2(&n, &x[0], &incx)
 
-cpdef int _test_icamax(float complex[:] cx) noexcept nogil:
+cpdef blas_int _test_icamax(float complex[:] cx) noexcept nogil:
     cdef:
-        int n = cx.shape[0]
-        int incx = cx.strides[0] // sizeof(cx[0])
+        blas_int n = cx.shape[0]
+        blas_int incx = cx.strides[0] // sizeof(cx[0])
     return icamax(&n, &cx[0], &incx)
 
-cpdef int _test_idamax(double[:] dx) noexcept nogil:
+cpdef blas_int _test_idamax(double[:] dx) noexcept nogil:
     cdef:
-        int n = dx.shape[0]
-        int incx = dx.strides[0] // sizeof(dx[0])
+        blas_int n = dx.shape[0]
+        blas_int incx = dx.strides[0] // sizeof(dx[0])
     return idamax(&n, &dx[0], &incx)
 
-cpdef int _test_isamax(float[:] sx) noexcept nogil:
+cpdef blas_int _test_isamax(float[:] sx) noexcept nogil:
     cdef:
-        int n = sx.shape[0]
-        int incx = sx.strides[0] // sizeof(sx[0])
+        blas_int n = sx.shape[0]
+        blas_int incx = sx.strides[0] // sizeof(sx[0])
     return isamax(&n, &sx[0], &incx)
 
-cpdef int _test_izamax(double complex[:] zx) noexcept nogil:
+cpdef blas_int _test_izamax(double complex[:] zx) noexcept nogil:
     cdef:
-        int n = zx.shape[0]
-        int incx = zx.strides[0] // sizeof(zx[0])
+        blas_int n = zx.shape[0]
+        blas_int incx = zx.strides[0] // sizeof(zx[0])
     return izamax(&n, &zx[0], &incx)
 
 cpdef float _test_sasum(float[:] sx) noexcept nogil:
     cdef:
-        int n = sx.shape[0]
-        int incx = sx.strides[0] // sizeof(sx[0])
+        blas_int n = sx.shape[0]
+        blas_int incx = sx.strides[0] // sizeof(sx[0])
     return sasum(&n, &sx[0], &incx)
 
 cpdef float _test_scasum(float complex[:] cx) noexcept nogil:
     cdef:
-        int n = cx.shape[0]
-        int incx = cx.strides[0] // sizeof(cx[0])
+        blas_int n = cx.shape[0]
+        blas_int incx = cx.strides[0] // sizeof(cx[0])
     return scasum(&n, &cx[0], &incx)
 
 cpdef float _test_scnrm2(float complex[:] x) noexcept nogil:
     cdef:
-        int n = x.shape[0]
-        int incx = x.strides[0] // sizeof(x[0])
+        blas_int n = x.shape[0]
+        blas_int incx = x.strides[0] // sizeof(x[0])
     return scnrm2(&n, &x[0], &incx)
 
 cpdef float _test_sdot(float[:] sx, float[:] sy) noexcept nogil:
     cdef:
-        int n = sx.shape[0]
-        int incx = sx.strides[0] // sizeof(sx[0])
-        int incy = sy.strides[0] // sizeof(sy[0])
+        blas_int n = sx.shape[0]
+        blas_int incx = sx.strides[0] // sizeof(sx[0])
+        blas_int incy = sy.strides[0] // sizeof(sy[0])
     return sdot(&n, &sx[0], &incx, &sy[0], &incy)
 
 cpdef float _test_snrm2(float[:] x) noexcept nogil:
     cdef:
-        int n = x.shape[0]
-        int incx = x.strides[0] // sizeof(x[0])
+        blas_int n = x.shape[0]
+        blas_int incx = x.strides[0] // sizeof(x[0])
     return snrm2(&n, &x[0], &incx)
 
 cpdef double complex _test_zdotc(double complex[:] zx, double complex[:] zy) noexcept nogil:
     cdef:
-        int n = zx.shape[0]
-        int incx = zx.strides[0] // sizeof(zx[0])
-        int incy = zy.strides[0] // sizeof(zy[0])
+        blas_int n = zx.shape[0]
+        blas_int incx = zx.strides[0] // sizeof(zx[0])
+        blas_int incy = zy.strides[0] // sizeof(zy[0])
     return zdotc(&n, &zx[0], &incx, &zy[0], &incy)
 
 cpdef double complex _test_zdotu(double complex[:] zx, double complex[:] zy) noexcept nogil:
     cdef:
-        int n = zx.shape[0]
-        int incx = zx.strides[0] // sizeof(zx[0])
-        int incy = zy.strides[0] // sizeof(zy[0])
+        blas_int n = zx.shape[0]
+        blas_int incx = zx.strides[0] // sizeof(zx[0])
+        blas_int incy = zy.strides[0] // sizeof(zy[0])
     return zdotu(&n, &zx[0], &incx, &zy[0], &incy)
 """
 
@@ -385,7 +389,8 @@ def arg_casts(argtype):
     return ''
 
 
-def generate_decl_pyx(name, return_type, argnames, argtypes, accelerate, header_name):
+def generate_decl_pyx(name, return_type, argnames, argtypes, accelerate,
+                      header_name, ilp64=False):
     """Create Cython declaration for BLAS/LAPACK function."""
     pyx_input_args = ', '.join([' *'.join(arg) for arg in zip(argtypes, argnames)])
     # By default, nothing is returned
@@ -410,7 +415,7 @@ def generate_decl_pyx(name, return_type, argnames, argtypes, accelerate, header_
     if name in WRAPPED_FUNCS:
         pyx_call_args[0] = ''.join([arg_casts(c_argtypes[0]), '&', argnames[0]])
     pyx_call_args = ', '.join(pyx_call_args)
-    blas_macro, blas_name = get_blas_macro_and_name(name, accelerate)
+    blas_macro, blas_name = get_blas_macro_and_name(name, accelerate, ilp64)
     return f"""
 cdef extern from "{header_name}":
     {blas_return_type} _fortran_{name} "{blas_macro}({blas_name})"({c_proto}) nogil
@@ -421,7 +426,7 @@ cdef {return_type} {name}({pyx_input_args}) noexcept nogil:
 """
 
 
-def generate_file_pyx(sigs, lib_name, header_name, accelerate):
+def generate_file_pyx(sigs, lib_name, header_name, accelerate, ilp64=False):
     """Generate content for pyx file with BLAS/LAPACK declarations and tests."""
     if lib_name == 'BLAS':
         preamble_template = blas_pyx_preamble
@@ -435,13 +440,14 @@ def generate_file_pyx(sigs, lib_name, header_name, accelerate):
     comment = ['# ' + c for c in COMMENT_TEXT]
     preamble = comment + [preamble_template.format(names)]
     decls = [
-        generate_decl_pyx(**sig, accelerate=accelerate, header_name=header_name)
+        generate_decl_pyx(**sig, accelerate=accelerate, header_name=header_name,
+                          ilp64=ilp64)
         for sig in sigs]
     content = preamble + decls + [epilog]
     return ''.join(content)
 
 
-blas_pxd_preamble = """
+_pxd_blas_comments = """\
 # Within scipy, these wrappers can be used via relative or absolute cimport.
 # Examples:
 # from ..linalg cimport cython_blas
@@ -453,14 +459,9 @@ blas_pxd_preamble = """
 # these wrappers should not be used.
 # The original libraries should be linked directly.
 
-ctypedef float s
-ctypedef double d
-ctypedef float complex c
-ctypedef double complex z
-
 """
 
-lapack_pxd_preamble = """
+_pxd_lapack_comments = """\
 # Within SciPy, these wrappers can be used via relative or absolute cimport.
 # Examples:
 # from ..linalg cimport cython_lapack
@@ -472,23 +473,55 @@ lapack_pxd_preamble = """
 # these wrappers should not be used.
 # The original libraries should be linked directly.
 
+"""
+
+_pxd_types_lp64 = """\
 ctypedef float s
 ctypedef double d
 ctypedef float complex c
 ctypedef double complex z
 
-# Function pointer type declarations for
-# gees and gges families of functions.
-ctypedef bint cselect1(c*)
-ctypedef bint cselect2(c*, c*)
-ctypedef bint dselect2(d*, d*)
-ctypedef bint dselect3(d*, d*, d*)
-ctypedef bint sselect2(s*, s*)
-ctypedef bint sselect3(s*, s*, s*)
-ctypedef bint zselect1(z*)
-ctypedef bint zselect2(z*, z*)
+ctypedef int blas_int
 
 """
+
+_pxd_types_ilp64 = """\
+from libc.stdint cimport int64_t
+
+ctypedef float s
+ctypedef double d
+ctypedef float complex c
+ctypedef double complex z
+
+ctypedef int64_t blas_int
+
+"""
+
+_pxd_lapack_select_typedefs = """\
+# Function pointer type declarations for
+# gees and gges families of functions.
+ctypedef blas_int cselect1(c*)
+ctypedef blas_int cselect2(c*, c*)
+ctypedef blas_int dselect2(d*, d*)
+ctypedef blas_int dselect3(d*, d*, d*)
+ctypedef blas_int sselect2(s*, s*)
+ctypedef blas_int sselect3(s*, s*, s*)
+ctypedef blas_int zselect1(z*)
+ctypedef blas_int zselect2(z*, z*)
+
+"""
+
+
+def _get_pxd_preamble(lib_name, ilp64=False):
+    """Build a pxd preamble from shared building blocks."""
+    if lib_name == 'BLAS':
+        comments = _pxd_blas_comments
+        suffix = ""
+    else:
+        comments = _pxd_lapack_comments
+        suffix = _pxd_lapack_select_typedefs
+    types = _pxd_types_ilp64 if ilp64 else _pxd_types_lp64
+    return f"\n{comments}{types}{suffix}"
 
 
 def generate_decl_pxd(name, return_type, argnames, argtypes):
@@ -497,21 +530,17 @@ def generate_decl_pxd(name, return_type, argnames, argtypes):
     return f"cdef {return_type} {name}({args}) noexcept nogil\n"
 
 
-def generate_file_pxd(sigs, lib_name):
+def generate_file_pxd(sigs, lib_name, ilp64=False):
     """Create content for Cython header file for generated pyx."""
-    if lib_name == 'BLAS':
-        preamble = blas_pxd_preamble
-    elif lib_name == 'LAPACK':
-        preamble = lapack_pxd_preamble
-    else:
-        raise RuntimeError(f'Unrecognized lib_name: {lib_name}.')
+    preamble = _get_pxd_preamble(lib_name, ilp64)
     preamble = ['"""\n', *COMMENT_TEXT, '"""\n', preamble]
     decls = [generate_decl_pxd(**sig)for sig in sigs]
     content = preamble + decls
     return ''.join(content)
 
 
-def generate_decl_c(name, return_type, argnames, argtypes, accelerate):
+def generate_decl_c(name, return_type, argnames, argtypes, accelerate,
+                    ilp64=False):
     """Create C header declarations for Cython to import."""
     c_return_type = C_TYPES[return_type]
     c_argtypes = [C_TYPES[t] for t in argtypes]
@@ -521,12 +550,12 @@ def generate_decl_c(name, return_type, argnames, argtypes, accelerate):
         argnames = ['out'] + argnames
         c_argtypes = [c_return_type] + c_argtypes
         c_return_type = 'void'
-    blas_macro, blas_name = get_blas_macro_and_name(name, accelerate)
+    blas_macro, blas_name = get_blas_macro_and_name(name, accelerate, ilp64)
     c_args = ', '.join(f'{t} *{n}' for t, n in zip(c_argtypes, argnames))
     return f"{c_return_type} {blas_macro}({blas_name})({c_args});\n"
 
 
-def generate_file_c(sigs, lib_name, accelerate):
+def generate_file_c(sigs, lib_name, accelerate, ilp64=False):
     """Generate content for C header file for Cython to import."""
     if lib_name == 'BLAS':
         preamble = [C_PREAMBLE]
@@ -535,9 +564,26 @@ def generate_file_c(sigs, lib_name, accelerate):
     else:
         raise RuntimeError(f'Unrecognized lib_name: {lib_name}.')
     preamble = ['/*\n', *COMMENT_TEXT, '*/\n'] + preamble + [CPP_GUARD_BEGIN]
-    decls = [generate_decl_c(**sig, accelerate=accelerate) for sig in sigs]
+    decls = [generate_decl_c(**sig, accelerate=accelerate, ilp64=ilp64)
+             for sig in sigs]
     content = preamble + decls + [CPP_GUARD_END]
     return ''.join(content)
+
+
+def _sigs_replace_int(sigs):
+    """Replace 'int' and 'bint' types with 'blas_int' in parsed signatures.
+
+    This makes BLAS/LAPACK integer parameters use the ``blas_int`` typedef,
+    which resolves to ``int`` for LP64 and ``npy_int64`` for ILP64 builds.
+    """
+    for sig in sigs:
+        sig['argtypes'] = [
+            'blas_int' if t in ('int', 'bint') else t
+            for t in sig['argtypes']
+        ]
+        if sig['return_type'] in ('int', 'bint'):
+            sig['return_type'] = 'blas_int'
+    return sigs
 
 
 def make_all(outdir,
@@ -547,7 +593,8 @@ def make_all(outdir,
              lapack_name="cython_lapack",
              blas_header_name="_blas_subroutines.h",
              lapack_header_name="_lapack_subroutines.h",
-             accelerate=False):
+             accelerate=False,
+             ilp64=False):
     src_files = (os.path.abspath(__file__),
                  blas_signature_file,
                  lapack_signature_file)
@@ -565,18 +612,20 @@ def make_all(outdir,
     with open(blas_signature_file) as f:
         blas_sigs = f.readlines()
     blas_sigs = read_signatures(blas_sigs)
+    blas_sigs = _sigs_replace_int(blas_sigs)
     with open(lapack_signature_file) as f:
         lapack_sigs = f.readlines()
     lapack_sigs = read_signatures(lapack_sigs)
+    lapack_sigs = _sigs_replace_int(lapack_sigs)
     to_write = {
         dst_files[0]: generate_file_pyx(
-            blas_sigs, 'BLAS', blas_header_name, accelerate),
-        dst_files[1]: generate_file_pxd(blas_sigs, 'BLAS'),
-        dst_files[2]: generate_file_c(blas_sigs, 'BLAS', accelerate),
+            blas_sigs, 'BLAS', blas_header_name, accelerate, ilp64),
+        dst_files[1]: generate_file_pxd(blas_sigs, 'BLAS', ilp64),
+        dst_files[2]: generate_file_c(blas_sigs, 'BLAS', accelerate, ilp64),
         dst_files[3]: generate_file_pyx(
-            lapack_sigs, 'LAPACK', lapack_header_name, accelerate),
-        dst_files[4]: generate_file_pxd(lapack_sigs, 'LAPACK'),
-        dst_files[5]: generate_file_c(lapack_sigs, 'LAPACK', accelerate)
+            lapack_sigs, 'LAPACK', lapack_header_name, accelerate, ilp64),
+        dst_files[4]: generate_file_pxd(lapack_sigs, 'LAPACK', ilp64),
+        dst_files[5]: generate_file_c(lapack_sigs, 'LAPACK', accelerate, ilp64)
     }
     write_files(to_write)
 
@@ -587,6 +636,8 @@ if __name__ == '__main__':
                         help="Path to the output directory")
     parser.add_argument("-a", "--accelerate", action="store_true",
                         help="Whether to use new Accelerate (macOS 13.3+)")
+    parser.add_argument("--ilp64", action="store_true",
+                        help="Use ILP64 (64-bit integer) BLAS/LAPACK interfaces")
     args = parser.parse_args()
 
     if not args.outdir:
@@ -594,4 +645,4 @@ if __name__ == '__main__':
     else:
         outdir_abs = os.path.join(os.getcwd(), args.outdir)
 
-    make_all(outdir_abs, accelerate=args.accelerate)
+    make_all(outdir_abs, accelerate=args.accelerate, ilp64=args.ilp64)

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -4,7 +4,14 @@ _cy_array_utils_pxd = fs.copyfile('_cythonized_array_utils.pxd')
 _cython_tree += fs.copyfile('__init__.pxd')
 
 _generate_pyx = find_program('_generate_pyx.py')
-ilp64_flag = use_ilp64 ? '--ilp64' : []
+# Resolve cython-blas-abi: 'auto' follows use-ilp64, otherwise explicit
+_cython_blas_abi = get_option('cython-blas-abi')
+if _cython_blas_abi == 'auto'
+  _cython_blas_ilp64 = use_ilp64
+else
+  _cython_blas_ilp64 = (_cython_blas_abi == 'ilp64')
+endif
+ilp64_flag = _cython_blas_ilp64 ? '--ilp64' : []
 cython_linalg = custom_target('cython_linalg',
   output: [
     'cython_blas.pyx',
@@ -219,10 +226,7 @@ py3.extension_module('_matfuncs_sqrtm_triu',
   subdir: 'scipy/linalg'
 )
 
-# When use_ilp64 is true, cython_blas/cython_lapack use ILP64 (64-bit integer)
-# BLAS/LAPACK interfaces via `lapack_dep`; otherwise they use LP64 via
-# `lapack_lp64_dep`.
-cython_blas_lapack_dep = use_ilp64 ? lapack_dep : lapack_lp64_dep
+cython_blas_lapack_dep = _cython_blas_ilp64 ? lapack_dep : lapack_lp64_dep
 cython_blas = py3.extension_module('cython_blas',
   [
     linalg_cython_gen.process(cython_linalg[0]),  # cython_blas.pyx

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -4,6 +4,7 @@ _cy_array_utils_pxd = fs.copyfile('_cythonized_array_utils.pxd')
 _cython_tree += fs.copyfile('__init__.pxd')
 
 _generate_pyx = find_program('_generate_pyx.py')
+ilp64_flag = use_ilp64 ? '--ilp64' : []
 cython_linalg = custom_target('cython_linalg',
   output: [
     'cython_blas.pyx',
@@ -14,10 +15,11 @@ cython_linalg = custom_target('cython_linalg',
     '_lapack_subroutines.h'
   ],
   input: '_generate_pyx.py',
-  command: [_generate_pyx, '-o', '@OUTDIR@', accelerate_flag],
+  command: [_generate_pyx, '-o', '@OUTDIR@', accelerate_flag, ilp64_flag],
   depend_files: [
     'cython_blas_signatures.txt',
     'cython_lapack_signatures.txt',
+    '../_build_utils/_wrappers_common.py',
   ],
   install: true,
   # Install only the .pxd files
@@ -217,6 +219,10 @@ py3.extension_module('_matfuncs_sqrtm_triu',
   subdir: 'scipy/linalg'
 )
 
+# When use_ilp64 is true, cython_blas/cython_lapack use ILP64 (64-bit integer)
+# BLAS/LAPACK interfaces via `lapack_dep`; otherwise they use LP64 via
+# `lapack_lp64_dep`.
+cython_blas_lapack_dep = use_ilp64 ? lapack_dep : lapack_lp64_dep
 cython_blas = py3.extension_module('cython_blas',
   [
     linalg_cython_gen.process(cython_linalg[0]),  # cython_blas.pyx
@@ -224,7 +230,7 @@ cython_blas = py3.extension_module('cython_blas',
   ],
   c_args: cython_c_args,
   link_args: version_link_args,
-  dependencies: [lapack_lp64_dep, np_dep],
+  dependencies: [cython_blas_lapack_dep, np_dep],
   install: true,
   include_directories: ['../_build_utils/src'],
   subdir: 'scipy/linalg'
@@ -237,7 +243,7 @@ cython_lapack = py3.extension_module('cython_lapack',
   ],
   c_args: cython_c_args,
   link_args: version_link_args,
-  dependencies: [lapack_lp64_dep, np_dep],
+  dependencies: [cython_blas_lapack_dep, np_dep],
   install: true,
   include_directories: ['../_build_utils/src'],
   subdir: 'scipy/linalg'

--- a/scipy/linalg/tests/_cython_examples/extending.pyx
+++ b/scipy/linalg/tests/_cython_examples/extending.pyx
@@ -21,3 +21,7 @@ cpdef float complex complex_dot(float complex[:] cx, float complex[:] cy):
         blas_int incx = cx.strides[0] // sizeof(cx[0])
         blas_int incy = cy.strides[0] // sizeof(cy[0])
     return cdotu(&n, &cx[0], &incx, &cy[0], &incy)
+
+cpdef int get_blas_int_size():
+    """Return sizeof(blas_int) to verify correct type at compile+runtime."""
+    return sizeof(blas_int)

--- a/scipy/linalg/tests/_cython_examples/extending.pyx
+++ b/scipy/linalg/tests/_cython_examples/extending.pyx
@@ -4,20 +4,20 @@
 #cython: wraparound=False
 
 cimport scipy.linalg
-from scipy.linalg.cython_blas cimport cdotu
+from scipy.linalg.cython_blas cimport blas_int, cdotu
 from scipy.linalg.cython_lapack cimport dgtsv
 
 cpdef tridiag(double[:] a, double[:] b, double[:] c, double[:] x):
     """ Solve the system A y = x for y where A is the tridiagonal matrix with
     subdiagonal 'a', diagonal 'b', and superdiagonal 'c'. """
-    cdef int n=b.shape[0], nrhs=1, info
+    cdef blas_int n=b.shape[0], nrhs=1, info
     # Solution is written over the values in x.
     dgtsv(&n, &nrhs, &a[0], &b[0], &c[0], &x[0], &n, &info)
 
 cpdef float complex complex_dot(float complex[:] cx, float complex[:] cy):
     """ Take dot product of two complex vectors """
     cdef:
-        int n = cx.shape[0]
-        int incx = cx.strides[0] // sizeof(cx[0])
-        int incy = cy.strides[0] // sizeof(cy[0])
+        blas_int n = cx.shape[0]
+        blas_int incx = cx.strides[0] // sizeof(cx[0])
+        blas_int incy = cy.strides[0] // sizeof(cy[0])
     return cdotu(&n, &cx[0], &incx, &cy[0], &incy)

--- a/scipy/linalg/tests/test_cython_blas.py
+++ b/scipy/linalg/tests/test_cython_blas.py
@@ -3,13 +3,36 @@ from numpy.testing import (assert_allclose,
                            assert_equal)
 import scipy.linalg.cython_blas as blas
 
+
+class TestBlasInt:
+    """Tests for blas_int type used in cython_blas/cython_lapack."""
+
+    def test_blas_int_size(self):
+        """Verify blas_int size matches the build configuration."""
+        from scipy.__config__ import CONFIG
+        size = blas._blas_int_size()
+        cython_blas_ilp64 = CONFIG['Build Dependencies']['blas']['cython blas ilp64']
+        if cython_blas_ilp64:
+            assert size == 8, f"ILP64 build but blas_int is {size} bytes"
+        else:
+            assert size == 4, f"LP64 build but blas_int is {size} bytes"
+
+    def test_dgemm_with_blas_int_dimensions(self):
+        """Test dgemm works correctly - exercises blas_int for dimensions."""
+        a = np.eye(3, dtype=np.float64)
+        b = np.arange(9, dtype=np.float64).reshape((3, 3))
+        c = np.empty((3, 3), dtype=np.float64)
+        blas._test_dgemm(1., a, b, 0., c)
+        assert_allclose(c, b)
+
+
 class TestDGEMM:
-    
+
     def test_transposes(self):
 
-        a = np.arange(12, dtype='d').reshape((3, 4))[:2,:2]
-        b = np.arange(1, 13, dtype='d').reshape((4, 3))[:2,:2]
-        c = np.empty((2, 4))[:2,:2]
+        a = np.arange(12, dtype=np.float64).reshape((3, 4))[:2,:2]
+        b = np.arange(1, 13, dtype=np.float64).reshape((4, 3))[:2,:2]
+        c = np.empty((2, 4), dtype=np.float64)[:2,:2]
 
         blas._test_dgemm(1., a, b, 0., c)
         assert_allclose(c, a.dot(b))
@@ -34,18 +57,18 @@ class TestDGEMM:
 
         blas._test_dgemm(1., a.T, b.T, 0., c.T)
         assert_allclose(c, a.T.dot(b.T).T)
-    
+
     def test_shapes(self):
-        a = np.arange(6, dtype='d').reshape((3, 2))
-        b = np.arange(-6, 2, dtype='d').reshape((2, 4))
-        c = np.empty((3, 4))
+        a = np.arange(6, dtype=np.float64).reshape((3, 2))
+        b = np.arange(-6, 2, dtype=np.float64).reshape((2, 4))
+        c = np.empty((3, 4), dtype=np.float64)
 
         blas._test_dgemm(1., a, b, 0., c)
         assert_allclose(c, a.dot(b))
 
         blas._test_dgemm(1., b.T, a.T, 0., c.T)
         assert_allclose(c, b.T.dot(a.T).T)
-        
+
 class TestWfuncPointers:
     """ Test the function pointers that are expected to fail on
     Mac OS X without the additional entry statement in their definitions
@@ -72,7 +95,7 @@ class TestWfuncPointers:
                         -6.10000038147+30.7999992371j)
         assert_allclose(blas._test_scasum(cx[::2]), 18.)
         assert_allclose(blas._test_scnrm2(cx[::2]), 13.1719398499)
-    
+
     def test_double_args(self):
 
         x = np.array([5., -3, -.5], np.float64)
@@ -115,4 +138,3 @@ class TestWfuncPointers:
 
         assert_allclose(blas._test_zdotc(cx[::2], cy[::2]), -18.5625+22.125j)
         assert_allclose(blas._test_zdotu(cx[::2], cy[::2]), -6.5625+31.875j)
-

--- a/scipy/linalg/tests/test_extending.py
+++ b/scipy/linalg/tests/test_extending.py
@@ -8,6 +8,7 @@ import pytest
 from scipy._lib._testutils import IS_EDITABLE, _test_cython_extension, cython
 from scipy.linalg.blas import get_blas_funcs
 from scipy.linalg.lapack import get_lapack_funcs
+import scipy.linalg.cython_blas as cython_blas
 
 
 @pytest.mark.parallel_threads_limit(4)  # 0.35 GiB per thread RAM usage
@@ -47,3 +48,8 @@ def test_cython(tmp_path):
     cdotu = get_blas_funcs('dotu', dtype=np.complex64, ilp64="preferred")
     np.testing.assert_array_equal(cdotu(cx, cy), extensions.complex_dot(cx, cy))
     np.testing.assert_array_equal(cdotu(cx, cy), extensions_cpp.complex_dot(cx, cy))
+
+    # Verify blas_int size consistency between installed and JIT-compiled modules
+    expected_size = cython_blas._blas_int_size()
+    assert extensions.get_blas_int_size() == expected_size
+    assert extensions_cpp.get_blas_int_size() == expected_size

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -249,6 +249,16 @@ endif
 _args_blas_lapack = []
 accelerate_flag = []
 generate_blas_wrappers = false
+
+# If an exact MKL .pc name with 'ilp64' is given and use-ilp64 is true,
+# derive the LP64 .pc name by replacing 'ilp64' with 'lp64' in the name.
+# The original ILP64 name is saved for the ILP64 detection pass below.
+_blas_name_ilp64 = ''
+if use_ilp64 and blas_name.contains('ilp64')
+  _blas_name_ilp64 = blas_name
+  blas_name = blas_name.replace('ilp64', 'lp64')
+endif
+
 if blas_name == 'accelerate'
   if not macOS13_3_or_later
     error('macOS Accelerate is only supported on macOS >=13.3')
@@ -374,7 +384,16 @@ if use_ilp64
   endif
 
   # Run the detection
-  if uses_mkl
+  if _blas_name_ilp64 != ''
+    # Exact MKL .pc name was given — use it directly via pkg-config
+    blas_ilp64 = dependency(_blas_name_ilp64)
+    lapack_ilp64 = blas_ilp64
+    _args_blas_ilp64 += [
+      '-DBLAS_SYMBOL_SUFFIX=_64',
+      '-DFIX_MKL_2025_ILP64_MISSING_SYMBOL'
+    ]
+    c_flags_ilp64 += ['-DBLAS_SYMBOL_SUFFIX=_64']
+  elif uses_mkl
     mkl_uses_sdl = false   # FIXME, why
     if mkl_uses_sdl
       mkl_opts = ['sdl: true']

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -785,6 +785,15 @@ foreach name, dep : dependency_map
 endforeach
 
 
+# Resolve cython-blas-abi for config: 'auto' follows use-ilp64
+_cython_blas_abi = get_option('cython-blas-abi')
+if _cython_blas_abi == 'auto'
+  _cython_blas_ilp64 = use_ilp64
+else
+  _cython_blas_ilp64 = (_cython_blas_abi == 'ilp64')
+endif
+conf_data.set('BLAS_CYTHON_ILP64', _cython_blas_ilp64.to_string())
+
 configure_file(
   input: '__config__.py.in',
   output: '__config__.py',

--- a/scipy/optimize/_bglu_dense.pyx
+++ b/scipy/optimize/_bglu_dense.pyx
@@ -5,7 +5,7 @@ import numpy as np
 cimport numpy as np
 from scipy.linalg import (solve, lu_solve, lu_factor, solve_triangular,
                           LinAlgError)
-from scipy.linalg.cython_blas cimport daxpy, dswap
+from scipy.linalg.cython_blas cimport blas_int, daxpy, dswap
 try:
     from time import process_time as timer
 except ImportError:
@@ -25,8 +25,8 @@ cdef void swap_rows(self, double[:, ::1] H, int i) noexcept:
     # Python
     # H[[i, i+1]] = H[[i+1, i]]
     # Cython, using BLAS
-    cdef int n = H.shape[1]-i
-    cdef int one = 1
+    cdef blas_int n = H.shape[1]-i
+    cdef blas_int one = 1
     dswap(&n, &H[i, i], &one, &H[i+1, i], &one)
 
 @cython.boundscheck(False)
@@ -43,9 +43,9 @@ cdef double row_subtract(self, double[:, ::1] H, int i) noexcept:
     # Python
     # H[i+1, i:] -= g*H[i, i:]
     # Cython, using BLAS
-    cdef int n = H.shape[1]-i
+    cdef blas_int n = H.shape[1]-i
     cdef double ng = -g
-    cdef int one = 1
+    cdef blas_int one = 1
     daxpy(&n, &ng, &H[i, i], &one, &H[i+1, i], &one)
 
     return g

--- a/scipy/optimize/_lsq/givens_elimination.pyx
+++ b/scipy/optimize/_lsq/givens_elimination.pyx
@@ -1,6 +1,6 @@
 cimport cython
 from scipy.linalg.cython_lapack cimport dlartg
-from scipy.linalg.cython_blas cimport drot
+from scipy.linalg.cython_blas cimport blas_int, drot
 
 import numpy as np
 
@@ -32,13 +32,13 @@ def givens_elimination(double[:, ::1] S, double[:] v, const double[:] diag):
     mentioned vector after rotations were applied.
     """
     cdef int n = diag.shape[0]
-    cdef int k
+    cdef blas_int k
 
     cdef int i, j
 
     cdef double f, g, r
     cdef double cs, sn
-    cdef int one = 1
+    cdef blas_int one = 1
 
     cdef double [:] diag_row = np.empty(n)
     cdef double u  # For `v` rotations.

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -27,7 +27,7 @@ from libc.math cimport NAN
 from scipy._lib.messagestream cimport MessageStream
 from libc.stdio cimport FILE
 
-from scipy.linalg.cython_lapack cimport dgetrf, dgetrs, dgecon
+from scipy.linalg.cython_lapack cimport blas_int, dgetrf, dgetrs, dgecon
 
 np.import_array()
 
@@ -176,7 +176,6 @@ cdef extern from "<libqhull_r/libqhull_r.h>":
     coordT* qh_sethalfspace_all(qhT *, int dim, int count, coordT* halfspaces, pointT *feasible)
 
 cdef extern from "qhull_misc.h":
-    ctypedef int CBLAS_INT   # actual type defined in the header file
     void qhull_misc_lib_check()
     int qh_new_qhull_scipy(qhT *, int dim, int numpoints, realT *points,
                            boolT ismalloc, char* qhull_cmd, void *outfile,
@@ -1134,16 +1133,16 @@ def _get_barycentric_transforms(np.ndarray[np.double_t, ndim=2] points,
     cdef np.ndarray[np.double_t, ndim=3] Tinvs
     cdef int isimplex
     cdef int i, j
-    cdef CBLAS_INT n, nrhs, lda, ldb
-    cdef CBLAS_INT info = 0
-    cdef CBLAS_INT ipiv[NPY_MAXDIMS+1]
+    cdef blas_int n, nrhs, lda, ldb
+    cdef blas_int info = 0
+    cdef blas_int ipiv[NPY_MAXDIMS+1]
     cdef int ndim, nsimplex
     cdef double anorm
     cdef double rcond = 0.0
     cdef double rcond_limit
 
     cdef double work[4*NPY_MAXDIMS]
-    cdef CBLAS_INT iwork[NPY_MAXDIMS]
+    cdef blas_int iwork[NPY_MAXDIMS]
 
     ndim = points.shape[1]
     nsimplex = simplices.shape[0]

--- a/tools/verify_loaded_sharedlibs.py
+++ b/tools/verify_loaded_sharedlibs.py
@@ -1,0 +1,169 @@
+"""
+Show which shared libraries are loaded by numpy and scipy imports.
+
+Reads /proc/self/maps before and after each import to determine which .so
+files were pulled in. Libraries are categorized into:
+
+- Shared libraries: "real" shared libs (BLAS, compilers, system libs)
+- Stdlib extensions: CPython extension modules from lib-dynload/
+- numpy/scipy extensions: extension modules from site-packages or build dirs
+
+By default, only shared libraries are shown. Use -s and -e to include the
+other categories.
+
+Usage::
+
+    # Via spin check:
+    spin check --loaded-sharedlibs
+
+    # Via pixi task (builds automatically if needed):
+    pixi run check-mkl-lp64-sharedlibs
+    pixi run check-mkl-ilp64-sharedlibs
+
+    # Direct invocation with extra options:
+    spin python -- tools/verify_loaded_sharedlibs.py [-s] [-e] [IMPORT ...]
+
+Positional arguments (direct invocation only)::
+
+    IMPORT  Dotted import names to check (default: numpy). Each import is
+            performed in order; new shared libraries are reported per import.
+
+Options (direct invocation only)::
+
+    -s, --show-stdlib      Show Python stdlib extension modules (lib-dynload/)
+    -e, --show-extensions  Show numpy/scipy extension modules
+
+Examples::
+
+    # Check with MKL LP64 build:
+    pixi run -e mkl-lp64 spin check --no-build --build-dir=build-mkl-lp64 \
+            --loaded-sharedlibs
+
+    # Or use the pixi task shorthand:
+    pixi run check-mkl-lp64-sharedlibs
+
+    # Direct invocation for numpy then scipy.linalg:
+    spin python -- tools/verify_loaded_sharedlibs.py numpy scipy.linalg
+
+    # Single scipy submodule:
+    spin python -- tools/verify_loaded_sharedlibs.py scipy.sparse
+
+Sample output from ``pixi run check-mkl-lp64-sharedlibs numpy scipy.linalg``::
+
+    numpy pulled in:
+      .pixi/envs/mkl-lp64/lib/libffi.so.8.2.0
+      .pixi/envs/mkl-lp64/lib/libgcc_s.so.1
+      .pixi/envs/mkl-lp64/lib/libmkl_avx512.so.2
+      .pixi/envs/mkl-lp64/lib/libmkl_core.so.2
+      .pixi/envs/mkl-lp64/lib/libmkl_gf_lp64.so.2
+      .pixi/envs/mkl-lp64/lib/libmkl_intel_thread.so.2
+      .pixi/envs/mkl-lp64/lib/libmkl_rt.so.2
+      .pixi/envs/mkl-lp64/lib/libmkl_vml_avx512.so.2
+      .pixi/envs/mkl-lp64/lib/libomp.so
+      .pixi/envs/mkl-lp64/lib/libstdc++.so.6.0.34
+      /usr/lib/librt.so.1
+      (4 stdlib + 2 numpy/scipy extension modules hidden)
+
+    scipy.linalg pulled in:
+      .pixi/envs/build-mkl-lp64/lib/libmkl_intel_lp64.so.2
+      .pixi/envs/build-mkl-lp64/lib/libmkl_sequential.so.2
+      .pixi/envs/mkl-lp64/lib/libcrypto.so.3
+      (14 stdlib + 23 numpy/scipy extension modules hidden)
+"""
+import argparse
+import importlib
+import re
+
+
+def loaded_libs():
+    with open("/proc/self/maps") as f:
+        return {
+            line.split()[-1]
+            for line in f
+            if ".so" in line and line.split()[-1].startswith("/")
+        }
+
+
+def strip_prefix(path):
+    """Strip the repo root prefix, keeping paths starting from .pixi/ or build-*."""
+    m = re.search(r'(\.pixi/|build-)', path)
+    if m:
+        return path[m.start():]
+    return path
+
+
+def classify_libs(libs):
+    """Classify libraries into shared libs, stdlib extensions, and package extensions"""
+    shared = []
+    stdlib = []
+    extensions = []
+    for lib in libs:
+        if '/lib-dynload/' in lib:
+            stdlib.append(lib)
+        elif '/site-packages/' in lib or re.search(r'/build-[^/]*-install/', lib):
+            extensions.append(lib)
+        else:
+            shared.append(lib)
+    return {
+        'shared': sorted(shared, key=strip_prefix),
+        'stdlib': sorted(stdlib, key=strip_prefix),
+        'extensions': sorted(extensions, key=strip_prefix),
+    }
+
+
+def print_section(name, libs, args):
+    """Print one import section with categorized libraries."""
+    categorized = classify_libs(libs)
+
+    print(f"\n{name} pulled in:")
+    for lib in categorized['shared']:
+        print(f"  {strip_prefix(lib)}")
+
+    if args.show_stdlib and categorized['stdlib']:
+        print(f"\n  stdlib extensions ({len(categorized['stdlib'])}):")
+        for lib in categorized['stdlib']:
+            print(f"    {strip_prefix(lib)}")
+
+    if args.show_extensions and categorized['extensions']:
+        print(f"\n  numpy/scipy extensions ({len(categorized['extensions'])}):")
+        for lib in categorized['extensions']:
+            print(f"    {strip_prefix(lib)}")
+
+    hidden = []
+    if not args.show_stdlib and categorized['stdlib']:
+        hidden.append(f"{len(categorized['stdlib'])} stdlib")
+    if not args.show_extensions and categorized['extensions']:
+        hidden.append(f"{len(categorized['extensions'])} numpy/scipy")
+    if hidden:
+        print(f"  ({' + '.join(hidden)} extension modules hidden)")
+    print()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Show shared libraries loaded by numpy and scipy imports."
+    )
+    parser.add_argument(
+        '-s', '--show-stdlib', action='store_true',
+        help="Show Python stdlib extension modules (lib-dynload/)"
+    )
+    parser.add_argument(
+        '-e', '--show-extensions', action='store_true',
+        help="Show numpy/scipy extension modules"
+    )
+    parser.add_argument(
+        'imports', nargs='*', default=['numpy'], metavar='IMPORT',
+        help="Dotted import names to check (default: numpy)"
+    )
+    args = parser.parse_args()
+
+    prev = loaded_libs()
+    for name in args.imports:
+        importlib.import_module(name)
+        curr = loaded_libs()
+        print_section(name, curr - prev, args)
+        prev = curr
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Reference issue

Closes gh-21889

#### What does this implement/fix?

This PR adds ILP64 support to `scipy.linalg.cython_blas` and `scipy.linalg.cython_lapack`, following the design choice motivated in https://github.com/scipy/scipy/issues/21889#issuecomment-4040727795. This will ensure that if SciPy is built with `-Duse-ilp64=true`, these APIs re-export an ILP64 ABI with `blas_int` (meaning `npy_int64`) instead of `int` in all signatures. This is necessary to be able to build an ILP64-only version of SciPy.

Note: this is opt-in when building from source only, we *will not break the ABI of wheels we ship on PyPI*. That would simply be too disruptive, and it isn't necessary. Instead, this allows users and distro to ship this as an option. A number of distros will want to provide this option - see for example gh-24261 for Nixpkgs. We've had that request from Spack already as well. And I also know of use cases in industry - large companies tend to build everything from source, so they'll be unblocked from switching their environments over to ILP64. 

I think this is a significant improvement, and will finally get us (once we've converted all SciPy internals) to usable/robust ILP64 support.

This PR contains:
- The codegen changes needed (see `scipy/linalg/_generate_pyx.py`)
- Adding support to add internal usages in Cython code
- Improved test coverage (not comprehensive, because compile tests are very slow - just enough to build confidence)
- Documentation updates
- Pixi tasks, using MKL to match what we already had for Accelerate: `build-mkl-lp64`, `test-mkl-lp64`, `build-mkl-ilp64`, `test-mkl-ilp64`
- A useful script to verify what shared libraries are being loaded by which `import` statements: `spin check --loaded-sharedlibs`. Note: not specific to ILP64, it will be generally useful.
- A few small BLAS-related build improvements

I didn't add new CI jobs on purpose. What we have suffices for now, and the test coverage of `cython_blas`/`cython_lapack` is low so one-off issues that only show up there are unlikely to be caught. The much better test is using downstream test suites (see section below).  More ILP64 improvements are in the works (xref gh-23351), so we'll probably get some new jobs before that's all done.


#### Additional information

The two main consumers of these Cython APIs are `scikit-learn` and `statsmodels`. I updated both of those packages so they're compatible with an ILP64 `scipy`. This turned out pretty nicely, and will just "do the right thing" without the user having to pay attention to how they build those packages (important, because matching `use-ilp64=true` build flags by hand would be fragile). And is backwards compatible too of course. Branches:

- https://github.com/rgommers/scikit-learn/tree/cython-blas-ilp64
- https://github.com/rgommers/statsmodels/tree/cython-blas-ilp64

Finally, here is a little test repo that uses `pixi-build` to build `scipy` against MKL ILP64, and then `sklearn`/`statsmodels` against that `scipy` build: https://github.com/rgommers/pixi-sklearn-ilp64. If you check out the `main` branches of scikit-learn/statsmodels, their builds will fail with Cython signature mismatches; if you check out the `cython-blas-ilp64` branches the full test suite will pass.


#### AI Generation Disclosure

I used Claude Opus 4.6 extensively, first with the Oz agent from Warp and then with Claude Code. This topic turned out to be very suitable for using AI coding tools: the basic idea is quite simple ("all `int`'s in this API become `blas_int`), it's just very tedious to have to do all that by hand. I described exactly what I wanted in terms of codegen changes, and set up the Pixi tasks by hand so `build-mkl-ilp64` was failing, then asked Claude to work through the codegen to fix the build. Took a few iterations to get exactly what I wanted, but that was still way faster than if I had done it all by hand.

All the ideas and the development/testing approach are mine. Most of the code is generated by Claude. I did fix some things up by hand, wrote most of the docs, and heavily edited the git history for conciseness and making each commit atomic. 

There shouldn't be anything too unique in this PR that it'd be a copyright concern. It's mostly "advanced plumbing". 