### PR TITLE
CI: rtools45

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -73,12 +73,11 @@ jobs:
         with:
           python-version: 3.12
 
-      - name: win_amd64 - install rtools
+      - name: win_amd64 - configure rtools
         if: ${{ matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'AMD64' }}
         run: |
           # mingw-w64
-          choco install rtools -y --no-progress --force --version=4.0.0.20220206
-          echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
+          echo "c:\rtools45\ucrt64\bin;" >> $env:GITHUB_PATH
 
       - name: Set environment variables for ARM64
         if: matrix.buildplat[1] == 'win' && matrix.buildplat[2] == 'ARM64'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,15 +74,14 @@ jobs:
           cache: "pip"
           cache-dependency-path: "environment.yml"
 
-      - name: Install rtools (mingw-w64)
+      - name: Set rtools location location (mingw-w64)
         run: |
-          choco install rtools -y --no-progress --force --version=4.0.0.20220206
-          echo "c:\rtools40\ucrt64\bin;" >> $env:GITHUB_PATH
+          echo "c:\rtools45\ucrt64\bin" >> $env:GITHUB_PATH
 
       - name: pip-packages
         run: |
           # 2.0.0 is currently our oldest supported NumPy version
-          python -m pip install numpy==2.0.0 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch spin hypothesis "click<8.3.0"
+          python -m pip install numpy==2.0.0 cython pybind11 pythran meson-python meson ninja pytest pytest-xdist pytest-timeout pooch spin hypothesis "click<8.3.0" pkgconf
           python -m pip install -r requirements/openblas.txt
 
       - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,7 +74,7 @@ jobs:
           cache: "pip"
           cache-dependency-path: "environment.yml"
 
-      - name: Set rtools location location (mingw-w64)
+      - name: Set rtools location (mingw-w64)
         run: |
           echo "c:\rtools45\ucrt64\bin" >> $env:GITHUB_PATH
 

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -153,7 +153,7 @@ Currently, SciPy wheels are being built as follows:
  OSX x86_64 (Accelerate)     ``macos-15-intel``               Apple clang 15.0.0/gfortran 13.2.0     ``cibuildwheel``
  OSX arm64 (OpenBLAS)        ``macos-14``                     Apple clang 15.0.0/gfortran 12.1.0     ``cibuildwheel``
  OSX arm64 (Accelerate)      ``macos-14``                     Apple clang 15.0.0/gfortran 13.2.0     ``cibuildwheel``
- Windows                     ``windows-2019``                 GCC 10.3.0 (`rtools`_)                 ``cibuildwheel``
+ Windows                     ``windows-2025``                 GCC 10.3.0 (`rtools`_)                 ``cibuildwheel``
 =========================   ==============================   ====================================   =============================
 
 .. _CI: https://github.com/actions/runner-images

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -153,7 +153,7 @@ Currently, SciPy wheels are being built as follows:
  OSX x86_64 (Accelerate)     ``macos-15-intel``               Apple clang 15.0.0/gfortran 13.2.0     ``cibuildwheel``
  OSX arm64 (OpenBLAS)        ``macos-14``                     Apple clang 15.0.0/gfortran 12.1.0     ``cibuildwheel``
  OSX arm64 (Accelerate)      ``macos-14``                     Apple clang 15.0.0/gfortran 13.2.0     ``cibuildwheel``
- Windows                     ``windows-2025``                 GCC 10.3.0 (`rtools`_)                 ``cibuildwheel``
+ Windows                     ``windows-2025``                 GCC 15.2.0 (`rtools`_)                 ``cibuildwheel``
 =========================   ==============================   ====================================   =============================
 
 .. _CI: https://github.com/actions/runner-images

--- a/requirements/pkgconf.txt
+++ b/requirements/pkgconf.txt
@@ -1,0 +1,1 @@
+pkgconf==2.5.1.post1

--- a/tools/wheels/cibw_before_build.sh
+++ b/tools/wheels/cibw_before_build.sh
@@ -73,4 +73,7 @@ fi
 # cibuildwheel doesn't install delvewheel by default
 if [[ $RUNNER_OS == "Windows" ]]; then
     python -m pip install -r $PROJECT_DIR/requirements/delvewheel_requirements.txt
+    # pkgconf - carries out the role of pkg-config.
+    # Alternative is pkgconfiglite that you have to install with choco
+    python -m pip install -r $PROJECT_DIR/requirements/pkgconf.txt
 fi


### PR DESCRIPTION
Uses the rtools45 toolchain in a Github Actions run. This saves rtools40 having to be downloaded and installed (rtools45 is preinstalled on the Windows images), and also shows that a more modern rtools toolchain can be used for scipy development on windows.

#### Reference issue
Closes #24786. 
Enabled by #24788.

#### AI Generation Disclosure
No AI tools used
