### PR TITLE
ENH: interpolate: add CuPy delegation for BSpline

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -68,6 +68,29 @@ class BenchPPoly(Benchmark):
         self.pp(self.xp)
 
 
+class BenchBSpline(Benchmark):
+    param_names = ['npts']
+    params = [10, 100, 1000, 10000]
+
+    def setup(self, npts):
+        rng = np.random.default_rng(1234)
+        self.k = 3
+        self.n = 55
+
+        self.t = np.sort(rng.random(self.n + self.k + 1))
+        self.c = rng.random(self.n)
+
+        self.bspl = interpolate.BSpline(self.t, self.c, self.k)
+        self.xp = np.linspace(self.t[self.k], self.t[-self.k-1], npts)
+
+    def time_evaluation(self, npts):
+        self.bspl(self.xp)
+
+    def time_creation(self, npts):
+        interpolate.BSpline(self.t, self.c, self.k)
+
+
+
 class GridData(Benchmark):
     param_names = ['n_grids', 'method']
     params = [

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -169,7 +169,8 @@ def _xp_copy_to_numpy(x: Array) -> np.ndarray:
     """
     xp = array_namespace(x)
     if is_numpy(xp):
-        return x.copy()
+        # Just return x if it is a Python scalar without a copy attribute.
+        return x.copy() if hasattr(x, "copy") else x
     if is_cupy(xp):
         return x.get()
     if is_torch(xp):

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -612,6 +612,7 @@ class BSpline:
 
         """
         if self._delegate_to is not None:
+            x = self._asarray(x)
             return self._delegate_to(x, nu=nu, extrapolate=extrapolate)
 
         if extrapolate is None:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -83,6 +83,11 @@ _bspline_extra_note = (
     """The methods ``design_matrix`` and ``from_power_basis`` are currently
     NumPy only. `insert_knot`` is currently not supported with CuPy.
 
+    If the spline is called on an array ``x`` with namespace different from the
+    namespace ``xp`` of the knots ``t`` and coefficients ``c``, an attempt will
+    be made to coerce ``x`` to the ``xp`` namespace. Mixing namespaces in this
+    way is not recommended.
+
     """
 )
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1061,6 +1061,11 @@ class BSpline:
         array([ 0.,  0.,  0.,  0.,  5.,  8.,  8.,  8., 10., 10., 10., 10.])
 
         """
+        if self._delegate_to is not None:
+            # insert_knot isn't available in CuPy as of version 14 causing this to
+            # raise with an AttributeError.
+            return self._construct_from_xp(self._delegate_to.insert_knot(x, m=m))
+
         x = float(x)
 
         if x < self._t[self.k] or x > self._t[-self.k-1]:

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -1,3 +1,4 @@
+import functools
 import operator
 from math import prod
 from types import GenericAlias
@@ -14,7 +15,9 @@ from scipy.sparse import csr_array
 from scipy.special import poch
 from itertools import combinations
 
-from scipy._lib._array_api import array_namespace, concat_1d, xp_capabilities
+from scipy._lib._array_api import (
+    array_namespace, concat_1d, xp_capabilities, scipy_namespace_for, is_numpy
+)
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
            "make_smoothing_spline"]
@@ -67,8 +70,25 @@ def _diff_dual_poly(j, k, y, d, t):
                         if (j + p) not in comb[i//d]])
     return res
 
+@functools.lru_cache(16)
+def _get_xp_bspline_cls(xp):
+    if is_numpy(xp):
+    # return None because we will not delegate in this case.
+        return None
+    spx = scipy_namespace_for(xp)
+    return getattr(getattr(spx, "interpolate", None), "BSpline", None)
+
+
 @xp_capabilities(
     cpu_only=True, jax_jit=False,
+    exceptions=["cupy"],
+    method_capabilities={
+        "design_matrix": dict(np_only=True),
+        "from_power_basis": dict(np_only=True),
+        "insert_knot": dict(
+            cpu_only=True, jax_jit=False, skip_backends=[("dask.array", "")]
+        ),
+    },
     skip_backends=[
         ("dask.array",
          "https://github.com/data-apis/array-api-extra/issues/488")
@@ -220,7 +240,19 @@ class BSpline:
     def __init__(self, t, c, k, extrapolate=True, axis=0):
         super().__init__()
 
-        self._asarray = array_namespace(c, t).asarray
+        xp = array_namespace(c, t)
+        xp_bspline_cls = _get_xp_bspline_cls(xp)
+
+        if xp_bspline_cls is not None:
+            obj = xp_bspline_cls(t, c, k, extrapolate=extrapolate, axis=axis)
+            self._delegate_to = obj
+            self.k = obj.k
+            self.extrapolate = obj.extrapolate
+            self.axis = obj.axis
+            return
+
+        self._delegate_to = None
+        self._asarray = xp.asarray
 
         self.k = operator.index(k)
         self._c = np.asarray(c)
@@ -267,17 +299,38 @@ class BSpline:
         self._c = np.ascontiguousarray(self._c, dtype=dt)
 
     @classmethod
+    def _construct_from_xp(cls, xp_bspline):
+        self = object.__new__(cls)
+        self._delegate_to = xp_bspline
+        self.k = xp_bspline.k
+        self.axis = xp_bspline.axis
+        self.extrapolate = xp_bspline.extrapolate
+        return self
+
+    @classmethod
     def construct_fast(cls, t, c, k, extrapolate=True, axis=0):
         """Construct a spline without making checks.
 
         Accepts same parameters as the regular constructor. Input arrays
         `t` and `c` must of correct shape and dtype.
         """
+        xp = array_namespace(t, c)
+        xp_bspline_cls = _get_xp_bspline_cls(xp)
+
         self = object.__new__(cls)
-        self._t, self._c, self.k = np.asarray(t), np.asarray(c), k
-        self.extrapolate = extrapolate
+        self.k = k
         self.axis = axis
-        self._asarray = array_namespace(t, c).asarray
+        self.extrapolate = extrapolate
+
+        if xp_bspline_cls is not None:
+            self._delegate_to = xp_bspline_cls.construct_fast(
+                t, c, k, extrapolate=extrapolate, axis=axis
+            )
+            return self
+
+        self._delegate_to = None
+        self._t, self._c = np.asarray(t), np.asarray(c)
+        self._asarray = xp.asarray
         return self
 
     @property
@@ -290,18 +343,28 @@ class BSpline:
     # because they are used in a C extension expecting numpy arrays.
     @property
     def t(self):
+        if self._delegate_to is not None:
+            return self._delegate_to.t
         return self._asarray(self._t)
 
     @t.setter
     def t(self, t):
+        if self._delegate_to is not None:
+            self._delegate_to.t = t
+            return
         self._t = np.asarray(t)
 
     @property
     def c(self):
+        if self._delegate_to is not None:
+            return self._delegate_to.c
         return self._asarray(self._c)
 
     @c.setter
     def c(self, c):
+        if self._delegate_to is not None:
+            self._delegate_to.c = c
+            return
         self._c = np.asarray(c)
 
     @classmethod
@@ -361,13 +424,19 @@ class BSpline:
 
         """
         xp = array_namespace(t)
+        xp_bspline_cls = _get_xp_bspline_cls(xp)
+        if xp_bspline_cls is not None:
+            return cls._construct_from_xp(
+                xp_bspline_cls.basis_element(t, extrapolate=extrapolate)
+            )
+
         t = np.asarray(t)
         k = t.shape[0] - 2
-        
+
         if k < 0:
             raise ValueError("BSpline.basis_element requires at least 2 knots")
 
-        
+
         t = _as_float_array(t)  # TODO: use concat_1d instead of np.r_
         t = np.r_[(t[0]-1,) * k, t, (t[-1]+1,) * k]
         c = np.zeros_like(t)
@@ -533,6 +602,9 @@ class BSpline:
             in the coefficient array with the shape of `x`.
 
         """
+        if self._delegate_to is not None:
+            return self._delegate_to(x, nu=nu, extrapolate=extrapolate)
+
         if extrapolate is None:
             extrapolate = self.extrapolate
         x = np.asarray(x)
@@ -609,6 +681,9 @@ class BSpline:
         splder, splantider
 
         """
+        if self._delegate_to is not None:
+            return self._construct_from_xp(self._delegate_to.derivative(nu=nu))
+
         c = self._asarray(self.c, copy=True)
         t = self.t
         xp = array_namespace(t, c)
@@ -646,6 +721,9 @@ class BSpline:
         outside of the initially given x interval is difficult.
 
         """
+        if self._delegate_to is not None:
+            return self._construct_from_xp(self._delegate_to.antiderivative(nu=nu))
+
         c = self._asarray(self.c, copy=True)
         t = self.t
         xp = array_namespace(t, c)
@@ -712,6 +790,9 @@ class BSpline:
         >>> plt.show()
 
         """
+        if self._delegate_to is not None:
+            return self._delegate_to.integrate(a, b, extrapolate=extrapolate)
+
         if extrapolate is None:
             extrapolate = self.extrapolate
 

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -79,6 +79,14 @@ def _get_xp_bspline_cls(xp):
     return getattr(getattr(spx, "interpolate", None), "BSpline", None)
 
 
+_bspline_extra_note = (
+    """The methods ``design_matrix`` and ``from_power_basis`` are currently
+    NumPy only. `insert_knot`` is currently not supported with CuPy.
+
+    """
+)
+
+
 @xp_capabilities(
     cpu_only=True, jax_jit=False,
     exceptions=["cupy"],
@@ -92,7 +100,8 @@ def _get_xp_bspline_cls(xp):
     skip_backends=[
         ("dask.array",
          "https://github.com/data-apis/array-api-extra/issues/488")
-    ]
+    ],
+    extra_note=_bspline_extra_note,
 )
 class BSpline:
     r"""Univariate spline in the B-spline basis.

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -260,6 +260,7 @@ class BSpline:
 
         xp = array_namespace(c, t)
         xp_bspline_cls = _get_xp_bspline_cls(xp)
+        self._asarray = xp.asarray
 
         if xp_bspline_cls is not None:
             obj = xp_bspline_cls(t, c, k, extrapolate=extrapolate, axis=axis)
@@ -270,7 +271,7 @@ class BSpline:
             return
 
         self._delegate_to = None
-        self._asarray = xp.asarray
+
 
         self.k = operator.index(k)
         self._c = np.asarray(c)
@@ -320,6 +321,8 @@ class BSpline:
     def _construct_from_xp(cls, xp_bspline):
         self = object.__new__(cls)
         self._delegate_to = xp_bspline
+        xp = array_namespace(xp_bspline.t)
+        self._asarray = xp.asarray
         self.k = xp_bspline.k
         self.axis = xp_bspline.axis
         self.extrapolate = xp_bspline.extrapolate
@@ -335,16 +338,17 @@ class BSpline:
         xp = array_namespace(t, c)
         xp_bspline_cls = _get_xp_bspline_cls(xp)
 
+        if xp_bspline_cls is not None:
+            return cls._construct_from_xp(
+                xp_bspline_cls.construct_fast(
+                    t, c, k, extrapolate=extrapolate, axis=axis
+                )
+            )
+
         self = object.__new__(cls)
         self.k = k
         self.axis = axis
         self.extrapolate = extrapolate
-
-        if xp_bspline_cls is not None:
-            self._delegate_to = xp_bspline_cls.construct_fast(
-                t, c, k, extrapolate=extrapolate, axis=axis
-            )
-            return self
 
         self._delegate_to = None
         self._t, self._c = np.asarray(t), np.asarray(c)

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -99,12 +99,16 @@ _bspline_extra_note = (
         "design_matrix": dict(np_only=True),
         "from_power_basis": dict(np_only=True),
         "insert_knot": dict(
-            cpu_only=True, jax_jit=False, skip_backends=[("dask.array", "")]
+            cpu_only=True,
+            jax_jit=False,
+            skip_backends=[
+                ("dask.array", "https://github.com/scipy/scipy/issues/24205")
+            ]
         ),
     },
     skip_backends=[
         ("dask.array",
-         "https://github.com/data-apis/array-api-extra/issues/488")
+         "https://github.com/scipy/scipy/issues/24205")
     ],
     extra_note=_bspline_extra_note,
 )

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -11,7 +11,7 @@ import sys
 import numpy as np
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, xp_default_dtype, concat_1d, make_xp_test_case,
-    xp_ravel, _xp_copy_to_numpy
+    xp_ravel, _xp_copy_to_numpy, array_namespace
 )
 import scipy._external.array_api_extra as xpx
 from pytest import raises as assert_raises
@@ -105,6 +105,11 @@ class TestBSpline:
 
         expected = xp.where(xx < 1., xp.asarray(3., dtype=xp.float64), 4.0)
         xp_assert_close(b(xx), expected)
+
+    def test_attributes_have_correct_namespace(self, xp):
+        b = BSpline(t=xp.asarray([0, 1., 2]), c=xp.asarray([3., 4]), k=0)
+        assert array_namespace(b.t) is xp
+        assert array_namespace(b.c) is xp
 
     def test_degree_0(self):
         xx = np.linspace(0, 1, 10)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -11,7 +11,7 @@ import sys
 import numpy as np
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, xp_default_dtype, concat_1d, make_xp_test_case,
-    xp_ravel
+    xp_ravel, _xp_copy_to_numpy
 )
 import scipy._external.array_api_extra as xpx
 from pytest import raises as assert_raises
@@ -44,6 +44,7 @@ from scipy.interpolate import _bsplines as _b
 from scipy.interpolate import _dierckx
 
 skip_xp_backends = pytest.mark.skip_xp_backends
+xfail_xp_backends = pytest.mark.xfail_xp_backends
 
 
 @make_xp_test_case(BSpline)
@@ -126,7 +127,7 @@ class TestBSpline:
             c[0]*B_012(x, xp=xp) + c[1]*B_012(x-1, xp=xp) + c[2]*B_012(x-2, xp=xp),
             atol=1e-14
         )
-        x_np, t_np, c_np = map(np.asarray, (x, t, c))
+        x_np, t_np, c_np = map(_xp_copy_to_numpy, (x, t, c))
         splev_result = splev(x_np, (t_np, c_np, k))
         xp_assert_close(b(x), xp.asarray(splev_result), atol=1e-14)
 
@@ -135,12 +136,18 @@ class TestBSpline:
         k = 3
         t = xp.asarray([0]*(k+1) + [1]*(k+1))
         c = xp.asarray([1., 2., 3., 4.])
-        bp = BPoly(xp.reshape(c, (-1, 1)), xp.asarray([0, 1]))
+        bp = BPoly(
+            _xp_copy_to_numpy(xp.reshape(c, (-1, 1))),
+            _xp_copy_to_numpy(xp.asarray([0, 1])),
+        )
         bspl = BSpline(t, c, k)
 
         xx = xp.linspace(-1., 2., 10)
-        xp_assert_close(bp(xx, extrapolate=True),
-                        bspl(xx, extrapolate=True), atol=1e-14)
+        xp_assert_close(
+            bspl(xx, extrapolate=True),
+            xp.asarray(bp(_xp_copy_to_numpy(xx), extrapolate=True)),
+            atol=1e-14,
+        )
 
     @skip_xp_backends("dask.array", reason="_naive_eval is not dask-compatible")
     @skip_xp_backends("jax.numpy", reason="too slow; XXX a slow-if marker?")
@@ -241,7 +248,7 @@ class TestBSpline:
                         b(xx[mask], extrapolate=False))
 
         # extrapolated values agree with FITPACK
-        xx_np, t_np, c_np = map(np.asarray, (xx, t, c))
+        xx_np, t_np, c_np = map(_xp_copy_to_numpy, (xx, t, c))
         splev_result = xp.asarray(splev(xx_np, (t_np, c_np, k), ext=0))
         xp_assert_close(b(xx, extrapolate=True), splev_result)
 
@@ -265,7 +272,7 @@ class TestBSpline:
         dt = t[-1] - t[0]
         xx = xp.linspace(t[k] - dt, t[n] + dt, 50)
         xy = t[k] + (xx - t[k]) % (t[n] - t[k])
-        xy_np, t_np, c_np = map(np.asarray, (xy, t, c))
+        xy_np, t_np, c_np = map(_xp_copy_to_numpy, (xy, t, c))
         atol = 1e-12 if xp_default_dtype(xp) == xp.float64 else 2e-7
         xp_assert_close(
             b(xx), xp.asarray(splev(xy_np, (t_np, c_np, k))), atol=atol
@@ -327,6 +334,7 @@ class TestBSpline:
         # 2nd derivative is not guaranteed to be continuous either
         assert not np.allclose(b(x - 1e-10, nu=2), b(x + 1e-10, nu=2))
 
+    @skip_xp_backends("cupy", reason="CuPy doesn't raise")
     def test_basis_element_invalid_too_short(self, xp):
         # There should be at least 2 knots
         assert_raises(ValueError, BSpline.basis_element, **dict(t=xp.asarray([0])))
@@ -336,7 +344,7 @@ class TestBSpline:
         xx = xp.linspace(-1, 4, 20)
         b = BSpline.basis_element(t=xp.asarray([0, 1, 2, 3]))
 
-        xx_np, t_np, c_np = map(np.asarray, (xx, b.t, b.c))
+        xx_np, t_np, c_np = map(_xp_copy_to_numpy, (xx, b.t, b.c))
         splev_result = xp.asarray(splev(xx_np, (t_np, c_np, b.k)))
         xp_assert_close(b(xx), splev_result, atol=1e-14)
 
@@ -414,9 +422,13 @@ class TestBSpline:
 
         # Test ``_fitpack._splint()``
         assert math.isclose(b.integrate(1, -1, extrapolate=False),
-                            _impl.splint(1, -1, b.tck), abs_tol=1e-14)
+                            _impl.splint(1, -1, map(_xp_copy_to_numpy, b.tck)),
+                            abs_tol=1e-14)
 
+    @xfail_xp_backends("cupy", reason="CuPy periodic extrapolation seems broken")
+    def test_integral_periodic(self, xp):
         # Test ``extrapolate='periodic'``.
+        b = BSpline.basis_element(xp.asarray([0, 1, 2]))  # x for x < 1 else 2 - x
         b.extrapolate = 'periodic'
         i = b.antiderivative()
         period_int = xp.asarray(i(2) - i(0), dtype=xp.float64)
@@ -726,7 +738,7 @@ class TestBSpline:
         xp_assert_close(b(xx), expected)
 
 
-@make_xp_test_case(BSpline)
+@make_xp_test_case((BSpline, "insert_knot"))
 class TestInsert:
 
     @pytest.mark.parametrize('xval', [0.0, 1.0, 2.5, 4, 6.5, 7.0])
@@ -953,7 +965,7 @@ def _sum_basis_elements(x, t, c, k):
 
 def B_012(x, xp=np):
     """ A linear B-spline function B(x | 0, 1, 2)."""
-    x = np.atleast_1d(x)
+    x = np.atleast_1d(_xp_copy_to_numpy(x))
     result = np.piecewise(x, [(x < 0) | (x > 2),
                             (x >= 0) & (x < 1),
                             (x >= 1) & (x <= 2)],
@@ -963,7 +975,7 @@ def B_012(x, xp=np):
 
 def B_0123(x, der=0):
     """A quadratic B-spline function B(x | 0, 1, 2, 3)."""
-    x = np.atleast_1d(x)
+    x = np.atleast_1d(_xp_copy_to_numpy(x))
     conds = [x < 1, (x > 1) & (x < 2), x > 2]
     if der == 0:
         funcs = [lambda x: x*x/2.,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #24738 

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds delegation to `cupyx.scipy.interpolate.BSpline` to `scipy.interpolate.BSpline`. This is implemented by having `BSpline` hold on to a private `cupyx.scipy.interpolate.BSpline` instance when it is constructed based on CuPy arrays, and delegating to the methods of the CuPy BSpline. I did this in what I think is an obvious straightforward way, by adding appropriate `if` checks in each method. I added a benchmark that I hope shows additional overhead is negligible even with this naive approach.

`design_matrix` has been marked `np_only` since it returns a sparse `csr_array`. There is a `design_matrix` method of CuPy's BSPline that returns a CuPy `csr_matrix`, but I think that is too different to use as the output. `from_power_basis` is also marked `np_only` and is not available in CuPy. `insert_knot` is also not available in CuPy, but is still supported on CPU-only backends by doing calculations internally with NumPy and converting.

It looks like CuPy's `integrate` with extrapolate="periodic" has numerical issues in some cases when integrating outside of the base interval. For now, I separated the relevant test cases into a separate test method and added a CuPy specific `xfail`.

@ev-br, let me know what you think and if you see any ways to improve this. Marking as draft for now since this is intended as a proof of concept. When we settle down a design, I will follow-up with additional PRs adding delegation for more classes in `interpolate`.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI generated code is used here, but I used Google's Gemini Pro as a search engine and rubber duck, prompting it not to generate code.
