### PR TITLE
CI: avoid win-arm64 failure, re-enable silently skipped meson-global job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -482,6 +482,7 @@ jobs:
     # (i.e., we're using it as a binary). This isn't a normal setup, but it's
     # sometimes being used that way - see gh-20535 and gh-24406
     name: build with global meson
+    needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
       && (github.repository == 'scipy/scipy' || github.repository == '')

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -120,7 +120,8 @@ jobs:
 
       - name: pip-packages
         run: |
-          pip install numpy cython pybind11 meson ninja pytest pytest-xdist pytest-timeout pooch spin hypothesis "click<8.3.0"
+          # `numpy<2.4.3` pin is due to np.linalg.solve crash, see gh-24774
+          pip install "numpy<2.4.3" cython pybind11 meson ninja pytest pytest-xdist pytest-timeout pooch spin hypothesis "click<8.3.0"
           python -m pip install -r requirements/openblas.txt
 
       - name: Build


### PR DESCRIPTION
Addresses the crash in the Windows arm64 job in `np.linalg.solve`, reported in gh-24774. I'll leave that issue open until the upstream bug report is submitted.

Also re-enables a Linux CI job that was silently being skipped because of a missing `needs:` line.

#### AI Generation Disclosure

No AI tools used