### PR TITLE
CI: Fix windows checksum for intel oneapi downloads

### DIFF
--- a/.github/workflows/windows_intel_oneAPI.yml
+++ b/.github/workflows/windows_intel_oneAPI.yml
@@ -66,14 +66,16 @@ jobs:
           key: install-${{ env.WINDOWS_HPC_URL }}-${{ env.WINDOWS_BASEKIT_URL }}-compiler
       - name: Install oneAPI Base kit
         if: steps.cache-install.outputs.cache-hit != 'true'
+        shell: cmd /C call {0}
         run: |
           echo %WINDOWS_BASEKIT_URL%
-          tools/install_intel_oneAPI_windows.bat %WINDOWS_BASEKIT_URL% "" 491dbc593cbcf02570b2ccc1f31656e2aa6fd195bd3191e5d111b1dafb35a45c  # 2025.0.1.28
+          tools\install_intel_oneAPI_windows.bat "%WINDOWS_BASEKIT_URL%" "" "491dbc593cbcf02570b2ccc1f31656e2aa6fd195bd3191e5d111b1dafb35a45c"  &REM 2025.0.1.28
       - name: Install oneAPI HPC kit
         if: steps.cache-install.outputs.cache-hit != 'true'
+        shell: cmd /C call {0}
         run: |
           echo %WINDOWS_HPC_URL%
-          tools/install_intel_oneAPI_windows.bat %WINDOWS_HPC_URL% "" dfbf8487f6ee5b9c1bb2cad19f2ef8dd842529a533670ce21582d39c303bf979  # 2025.0.1.48
+          tools\install_intel_oneAPI_windows.bat "%WINDOWS_HPC_URL%" "" "dfbf8487f6ee5b9c1bb2cad19f2ef8dd842529a533670ce21582d39c303bf979"  &REM 2025.0.1.48
 
       - name: Setup Conda
         uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3.3.0

--- a/tools/install_intel_oneAPI_windows.bat
+++ b/tools/install_intel_oneAPI_windows.bat
@@ -3,10 +3,11 @@ REM SPDX-FileCopyrightText: 2022 Intel Corporation
 REM
 REM SPDX-License-Identifier: MIT
 
+setlocal enabledelayedexpansion
 
-set URL=%1
-set COMPONENTS=%2
-set EXPECTED_SHA256=%3
+set URL=%~1
+set COMPONENTS=%~2
+set EXPECTED_SHA256=%~3
 
 :: download installer from intel
 curl.exe --output %TEMP%\webimage.exe --url %URL% --retry 5 --retry-delay 5
@@ -14,10 +15,10 @@ curl.exe --output %TEMP%\webimage.exe --url %URL% --retry 5 --retry-delay 5
 :: verify checksum if provided
 if not "%EXPECTED_SHA256%"=="" (
   for /f "tokens=1" %%h in ('certutil -hashfile %TEMP%\webimage.exe SHA256 ^| findstr /v "hash"') do set FILE_HASH=%%h
-  if /i not "%FILE_HASH%"=="%EXPECTED_SHA256%" (
+  if /i not "!FILE_HASH!"=="%EXPECTED_SHA256%" (
     echo Checksum verification failed for %URL%
     echo Expected: %EXPECTED_SHA256%
-    echo Got:      %FILE_HASH%
+    echo Got:      !FILE_HASH!
     del %TEMP%\webimage.exe
     exit /b 1
   )


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/24806

#### What does this implement/fix?
Looks like the windows checksum checks for intel oneapi downloads that I added in https://github.com/scipy/scipy/pull/24740 weren't ever working, and CI was passing because that download was cached. Now the cache is reset, so we're seeing the failure. The SHA is unchanged.

Switched over to windows locally and verified this is working.

#### Additional information
Example failure: https://github.com/scipy/scipy/actions/runs/23035205588/job/66963458688?pr=24804

#### AI Generation Disclosure
Claude used to diagnose, manually verified
