### PR TITLE
MAINT: signal.resample: fix typo in docstring

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3788,7 +3788,7 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
     `resample_poly` (``padtype='wrap'``) on the other hand produces significant
     deviations. This is caused by the disconiuity at the beginning of the signal, for
     which the default filter of `resample_poly` is not suited well. This example
-    illustrates that for some use cases, adpating the `resample_poly` parameters may
+    illustrates that for some use cases, adapting the `resample_poly` parameters may
     be beneficial. `resample` has a big advantage in this regard: It uses the ideal
     antialiasing filter with the maximum bandwidth by default.
 


### PR DESCRIPTION
#### Reference issue
none

#### What does this implement/fix?
Fix a simple typo ("adpating" where it should be "adapting") in the docstring of `signal.resample`

#### AI Generation Disclosure
No AI tools used


[skip ci]
(not sure if this is necessary here if it is in the commit message, but just making sure)