### PR TITLE
BUG: sparse.csgraph.reconstruct_path: raise for non-integral predecessors

### DIFF
--- a/scipy/sparse/csgraph/_tools.pyx
+++ b/scipy/sparse/csgraph/_tools.pyx
@@ -429,13 +429,13 @@ def reconstruct_path(csgraph, predecessors, directed=True):
         The N x N matrix representing the directed or undirected graph
         from which the predecessors are drawn.
     predecessors : array_like, one dimension
-        The length-N array of indices of predecessors for the tree.  The
-        index of the parent of node i is given by predecessors[i].
+        The length-N array of indices of predecessors for the tree. The
+        index of the parent of node ``i`` is given by ``predecessors[i]``.
     directed : bool, optional
         If True (default), then operate on a directed graph: only move from
-        point i to point j along paths csgraph[i, j].
+        point ``i`` to point ``j`` along paths ``csgraph[i, j]``.
         If False, then operate on an undirected graph: the algorithm can
-        progress from point i to j along csgraph[i, j] or csgraph[j, i].
+        progress from point ``i`` to ``j`` along ``csgraph[i, j]`` or ``csgraph[j, i]``.
 
     Returns
     -------
@@ -478,6 +478,10 @@ def reconstruct_path(csgraph, predecessors, directed=True):
     from ._validation import validate_graph
     csgraph_orig = csgraph
     csgraph = validate_graph(csgraph, directed, dense_output=False)
+    predecessors = np.asarray(predecessors)
+    if not np.isdtype(predecessors.dtype, "integral"):
+        msg = "`predecessors` must be of an integral dtype"
+        raise ValueError(msg)
 
     N = csgraph.shape[0]
 

--- a/scipy/sparse/csgraph/tests/test_conversions.py
+++ b/scipy/sparse/csgraph/tests/test_conversions.py
@@ -1,7 +1,8 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal
 from scipy.sparse import csr_array
-from scipy.sparse.csgraph import csgraph_from_dense, csgraph_to_dense
+from scipy.sparse.csgraph import csgraph_from_dense, csgraph_to_dense, reconstruct_path
 
 
 def test_csgraph_from_dense():
@@ -59,3 +60,16 @@ def test_multiple_edges():
     Xdense = csgraph_to_dense(Xcsr)
     assert_array_almost_equal(Xdense[:, 1::2],
                               np.minimum(X[:, ::2], X[:, 1::2]))
+
+
+class TestReconstructPath:
+    def test_gh23577(self):
+        row_indices = [0, 1, 1, 3, 3]
+        col_indices = [0, 2, 3, 1, 4]
+        data = [9, -6, -8, 6, 8]
+        matrix = csr_array((data, (row_indices, col_indices)), shape=(5, 5),
+                           dtype=np.int64)
+        predecessors = np.array([np.nan, np.nan, np.nan])
+        with pytest.raises(ValueError, match="integral"):
+            reconstruct_path(matrix, predecessors)
+


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes  #23577
#### What does this implement/fix?
<!--Please explain your changes.-->
As discussed in the issues raises for non-integral `predecessors` as these are not valid indices.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI