### PR TITLE
MAINT: special: Use two C++ function types from xsf.

### DIFF
--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -230,13 +230,9 @@ _special_ufuncs_module_exec(PyObject *module)
                            "_gen_harmonic", _gen_harmonic_doc);
     PyModule_AddObjectRef(module, "_gen_harmonic", _gen_harmonic);
 
-    // Define llld_d and qqqd_d here until they are added to xsf::numpy.
-    using llld_d = double (*)(long int, long int, long int, double);
-    using qqqd_d = double (*)(long long int, long long int, long long int, double);
-
     PyObject *_normalized_gen_harmonic =
-        xsf::numpy::ufunc({static_cast<llld_d>(normalized_gen_harmonic),
-                           static_cast<qqqd_d>(normalized_gen_harmonic),
+        xsf::numpy::ufunc({static_cast<xsf::numpy::llld_d>(normalized_gen_harmonic),
+                           static_cast<xsf::numpy::qqqd_d>(normalized_gen_harmonic),
                            static_cast<xsf::numpy::dddd_d>(normalized_gen_harmonic)},
                           "_normalized_gen_harmonic", _normalized_gen_harmonic_doc);
     PyModule_AddObjectRef(module, "_normalized_gen_harmonic", _normalized_gen_harmonic);


### PR DESCRIPTION
The types `llld_d` and `qqqd_d` are now available in `xsf`.

The types were added to `xsf` in https://github.com/scipy/xsf/pull/77.

#### AI Generation Disclosure

No AI tools used.