### PR TITLE
MAINT: special: add robust CMPLX fallbacks for non-MSVC compilers

### DIFF
--- a/scipy/special/_complexstuff.h
+++ b/scipy/special/_complexstuff.h
@@ -24,7 +24,15 @@
 #else
     typedef double complex _scipy_dz;
     #ifndef CMPLX
-        #define CMPLX(x, y) __builtin_complex((double)(x), (double)(y))
+        #if defined(__has_builtin)
+            #if __has_builtin(__builtin_complex)
+                #define CMPLX(x, y) __builtin_complex((double)(x), (double)(y))
+            #endif
+        #endif
+        #ifndef CMPLX
+            /* Last resort: type-pun via union to avoid real + imag*I pitfalls */
+            #define CMPLX(x, y) ((union { double a[2]; double complex z; }){{(x), (y)}}).z
+        #endif
     #endif
 #endif
 


### PR DESCRIPTION
Add `__has_builtin` check for `__builtin_complex`, with a union type-pun fallback for compilers where `<complex.h>` doesn't define `CMPLX` as a macro. 

I expect that there will be some very niche compilers that might hit the last fallback; better to have it than error out.

This is a follow-up to gh-24826.

#### AI Generation Disclosure

Use Claude Opus 4.6 to prepare and reason through compiler support and the fix, after noticing the unconditional use of `__builtin_complex` in gh-24826.