### PR TITLE
ENH: sparse.linalg: add ILP64 support to `arpack`

### DIFF
--- a/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
+++ b/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
@@ -5,6 +5,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "numpy/arrayobject.h"
+#include "npy_cblas.h"
 #include "arnaud/include/arnaud/arnaud.h"
 
 #if defined(_MSC_VER)
@@ -19,14 +20,15 @@ static PyObject* arpack_error_obj;
 
 // The following macros are used to define the field names in the ARPACK struct.
 #define STRUCT_INEXACT_FIELD_NAMES X(tol) X(getv0_rnorm0) X(aitr_betaj) X(aitr_rnorm1) X(aitr_wnorm) X(aup2_rnorm)
-#define STRUCT_INT_FIELD_NAMES X(ido) X(which) X(bmat) X(info) X(iter) X(maxiter) X(mode) \
-                               X(n) X(nconv) X(ncv) X(nev) X(np) \
-                               X(shift) X(getv0_first) X(getv0_iter) X(getv0_itry) X(getv0_orth) \
-                               X(aitr_iter) X(aitr_j) X(aitr_orth1) X(aitr_orth2) X(aitr_restart) \
-                               X(aitr_step3) X(aitr_step4) X(aitr_ierr) X(aup2_initv) X(aup2_iter) \
-                               X(aup2_getv0) X(aup2_cnorm) X(aup2_kplusp) X(aup2_nev) X(aup2_nev0) X(aup2_np0) \
-                               X(aup2_numcnv) X(aup2_update) X(aup2_ushift)
-#define STRUCT_FIELD_NAMES STRUCT_INT_FIELD_NAMES STRUCT_INEXACT_FIELD_NAMES
+#define STRUCT_INT_FIELD_NAMES X(info) X(n) X(nconv) X(ncv) X(nev) X(np) \
+                               X(aitr_iter) X(aitr_j) X(aup2_kplusp) X(aup2_nev) X(aup2_nev0) X(aup2_np0) \
+                               X(aup2_numcnv)
+#define STRUCT_PLAIN_INT_FIELD_NAMES X(ido) X(which) X(bmat) X(iter) X(maxiter) X(mode) X(shift) \
+                               X(getv0_first) X(getv0_iter) X(getv0_itry) X(getv0_orth) \
+                               X(aitr_orth1) X(aitr_orth2) X(aitr_restart) X(aitr_step3) X(aitr_step4) \
+                               X(aitr_ierr) X(aup2_initv) X(aup2_iter) X(aup2_getv0) X(aup2_cnorm) \
+                               X(aup2_update) X(aup2_ushift)
+#define STRUCT_FIELD_NAMES STRUCT_INT_FIELD_NAMES STRUCT_PLAIN_INT_FIELD_NAMES STRUCT_INEXACT_FIELD_NAMES
 
 // Error reporting macro
 #define ARPACK_ERROR(func_name, field_name, operation) \
@@ -56,6 +58,17 @@ pack_dict_to_state_s(PyObject* dict, struct ARNAUD_state_s* vars, const char* fu
     STRUCT_INEXACT_FIELD_NAMES
     #undef X
 
+    // Pack CBLAS integer fields
+    #define X(name) \
+        do { \
+            PyObject* field_obj = PyDict_GetItemString(dict, #name); \
+            if (!field_obj) { ARPACK_ERROR(func_name, #name, "Missing required"); return -1; } \
+            vars->name = (CBLAS_INT)PyLong_AsSsize_t(field_obj); \
+            if (PyErr_Occurred()) { ARPACK_ERROR(func_name, #name, "Failed to convert"); return -1; } \
+        } while(0);
+    STRUCT_INT_FIELD_NAMES
+    #undef X
+
     // Pack integer fields
     #define X(name) \
         do { \
@@ -64,7 +77,7 @@ pack_dict_to_state_s(PyObject* dict, struct ARNAUD_state_s* vars, const char* fu
             vars->name = (int)PyLong_AsLong(field_obj); \
             if (PyErr_Occurred()) { ARPACK_ERROR(func_name, #name, "Failed to convert"); return -1; } \
         } while(0);
-    STRUCT_INT_FIELD_NAMES
+    STRUCT_PLAIN_INT_FIELD_NAMES
     #undef X
 
     return 0;
@@ -90,6 +103,17 @@ pack_dict_to_state_d(PyObject* dict, struct ARNAUD_state_d* vars, const char* fu
     STRUCT_INEXACT_FIELD_NAMES
     #undef X
 
+    // Pack CBLAS integer fields
+    #define X(name) \
+        do { \
+            PyObject* field_obj = PyDict_GetItemString(dict, #name); \
+            if (!field_obj) { ARPACK_ERROR(func_name, #name, "Missing required"); return -1; } \
+            vars->name = (CBLAS_INT)PyLong_AsSsize_t(field_obj); \
+            if (PyErr_Occurred()) { ARPACK_ERROR(func_name, #name, "Failed to convert"); return -1; } \
+        } while(0);
+    STRUCT_INT_FIELD_NAMES
+    #undef X
+
     // Pack integer fields
     #define X(name) \
         do { \
@@ -98,7 +122,7 @@ pack_dict_to_state_d(PyObject* dict, struct ARNAUD_state_d* vars, const char* fu
             vars->name = (int)PyLong_AsLong(field_obj); \
             if (PyErr_Occurred()) { ARPACK_ERROR(func_name, #name, "Failed to convert"); return -1; } \
         } while(0);
-    STRUCT_INT_FIELD_NAMES
+    STRUCT_PLAIN_INT_FIELD_NAMES
     #undef X
 
     return 0;
@@ -127,6 +151,20 @@ unpack_state_s_to_dict(const struct ARNAUD_state_s* vars, PyObject* dict, const 
     STRUCT_INEXACT_FIELD_NAMES
     #undef X
 
+    // Unpack CBLAS integer fields
+    #define X(name) \
+        do { \
+            PyObject* tmp_obj = PyLong_FromSsize_t((Py_ssize_t)vars->name); \
+            if ((!tmp_obj) || (PyDict_SetItemString(dict, #name, tmp_obj) < 0)) { \
+                Py_XDECREF(tmp_obj); \
+                ARPACK_ERROR(func_name, #name, "Failed to set"); \
+                return -1; \
+            } \
+            Py_DECREF(tmp_obj); \
+        } while(0);
+    STRUCT_INT_FIELD_NAMES
+    #undef X
+
     // Unpack integer fields
     #define X(name) \
         do { \
@@ -138,7 +176,7 @@ unpack_state_s_to_dict(const struct ARNAUD_state_s* vars, PyObject* dict, const 
             } \
             Py_DECREF(tmp_obj); \
         } while(0);
-    STRUCT_INT_FIELD_NAMES
+    STRUCT_PLAIN_INT_FIELD_NAMES
     #undef X
 
     return 0;
@@ -167,6 +205,20 @@ unpack_state_d_to_dict(const struct ARNAUD_state_d* vars, PyObject* dict, const 
     STRUCT_INEXACT_FIELD_NAMES
     #undef X
 
+    // Unpack CBLAS integer fields
+    #define X(name) \
+        do { \
+            PyObject* tmp_obj = PyLong_FromSsize_t((Py_ssize_t)vars->name); \
+            if ((!tmp_obj) || (PyDict_SetItemString(dict, #name, tmp_obj) < 0)) { \
+                Py_XDECREF(tmp_obj); \
+                ARPACK_ERROR(func_name, #name, "Failed to set"); \
+                return -1; \
+            } \
+            Py_DECREF(tmp_obj); \
+        } while(0);
+    STRUCT_INT_FIELD_NAMES
+    #undef X
+
     // Unpack integer fields
     #define X(name) \
         do { \
@@ -178,7 +230,7 @@ unpack_state_d_to_dict(const struct ARNAUD_state_d* vars, PyObject* dict, const 
             } \
             Py_DECREF(tmp_obj); \
         } while(0);
-    STRUCT_INT_FIELD_NAMES
+    STRUCT_PLAIN_INT_FIELD_NAMES
     #undef X
 
     return 0;
@@ -209,7 +261,7 @@ snaupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = PyArray_DATA(ap_ipntr);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
     float* resid = PyArray_DATA(ap_resid);
     float* v = PyArray_DATA(ap_v);
     float* workd = PyArray_DATA(ap_workd);
@@ -252,7 +304,7 @@ dnaupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
     double* resid = (double*)PyArray_DATA(ap_resid);
     double* v = (double*)PyArray_DATA(ap_v);
     double* workd = (double*)PyArray_DATA(ap_workd);
@@ -297,7 +349,7 @@ cnaupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
     ARNAUD_CPLXF_TYPE* resid = (ARNAUD_CPLXF_TYPE*)PyArray_DATA(ap_resid);
     ARNAUD_CPLXF_TYPE* v = (ARNAUD_CPLXF_TYPE*)PyArray_DATA(ap_v);
     ARNAUD_CPLXF_TYPE* workd = (ARNAUD_CPLXF_TYPE*)PyArray_DATA(ap_workd);
@@ -343,7 +395,7 @@ znaupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
     ARNAUD_CPLX_TYPE* resid = (ARNAUD_CPLX_TYPE*)PyArray_DATA(ap_resid);
     ARNAUD_CPLX_TYPE* v = (ARNAUD_CPLX_TYPE*)PyArray_DATA(ap_v);
     ARNAUD_CPLX_TYPE* workd = (ARNAUD_CPLX_TYPE*)PyArray_DATA(ap_workd);
@@ -405,8 +457,8 @@ sneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
-    int* select = (int*)PyArray_DATA(ap_select);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
+    CBLAS_INT* select = PyArray_DATA(ap_select);
     float* dr = (float*)PyArray_DATA(ap_dr);
     float* di = (float*)PyArray_DATA(ap_di);
     float* workev = (float*)PyArray_DATA(ap_workev);
@@ -472,8 +524,8 @@ dneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
-    int* select = (int*)PyArray_DATA(ap_select);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
+    CBLAS_INT* select = PyArray_DATA(ap_select);
     double* dr = (double*)PyArray_DATA(ap_dr);
     double* di = (double*)PyArray_DATA(ap_di);
     double* workev = (double*)PyArray_DATA(ap_workev);
@@ -537,8 +589,8 @@ cneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
-    int* select = (int*)PyArray_DATA(ap_select);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
+    CBLAS_INT* select = PyArray_DATA(ap_select);
     ARNAUD_CPLXF_TYPE* d = (ARNAUD_CPLXF_TYPE*)PyArray_DATA(ap_d);
     ARNAUD_CPLXF_TYPE* workev = (ARNAUD_CPLXF_TYPE*)PyArray_DATA(ap_workev);
     ARNAUD_CPLXF_TYPE* z = (ARNAUD_CPLXF_TYPE*)PyArray_DATA(ap_z);
@@ -602,8 +654,8 @@ zneupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
-    int* select = (int*)PyArray_DATA(ap_select);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
+    CBLAS_INT* select = PyArray_DATA(ap_select);
     ARNAUD_CPLX_TYPE* d = (ARNAUD_CPLX_TYPE*)PyArray_DATA(ap_d);
     ARNAUD_CPLX_TYPE* workev = (ARNAUD_CPLX_TYPE*)PyArray_DATA(ap_workev);
     ARNAUD_CPLX_TYPE* z = (ARNAUD_CPLX_TYPE*)PyArray_DATA(ap_z);
@@ -652,7 +704,7 @@ ssaupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = PyArray_DATA(ap_ipntr);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
     float* resid = PyArray_DATA(ap_resid);
     float* v = PyArray_DATA(ap_v);
     float* workd = PyArray_DATA(ap_workd);
@@ -694,7 +746,7 @@ dsaupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
     double* resid = (double*)PyArray_DATA(ap_resid);
     double* v = (double*)PyArray_DATA(ap_v);
     double* workd = (double*)PyArray_DATA(ap_workd);
@@ -747,8 +799,8 @@ sseupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
-    int* select = (int*)PyArray_DATA(ap_select);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
+    CBLAS_INT* select = PyArray_DATA(ap_select);
     float* d = (float*)PyArray_DATA(ap_d);
     float* z = (float*)PyArray_DATA(ap_z);
     float* resid = (float*)PyArray_DATA(ap_resid);
@@ -805,8 +857,8 @@ dseupd_wrap(PyObject* Py_UNUSED(dummy), PyObject* args)
         return NULL;
     }
 
-    int* ipntr = (int*)PyArray_DATA(ap_ipntr);
-    int* select = (int*)PyArray_DATA(ap_select);
+    CBLAS_INT* ipntr = PyArray_DATA(ap_ipntr);
+    CBLAS_INT* select = PyArray_DATA(ap_select);
     double* d = (double*)PyArray_DATA(ap_d);
     double* z = (double*)PyArray_DATA(ap_z);
     double* resid = (double*)PyArray_DATA(ap_resid);
@@ -1082,5 +1134,6 @@ PyInit__arpacklib(void)
 
 
 #undef STRUCT_FIELD_NAMES
+#undef STRUCT_PLAIN_INT_FIELD_NAMES
 #undef STRUCT_INT_FIELD_NAMES
 #undef STRUCT_INEXACT_FIELD_NAMES

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/arnaud.h
@@ -53,23 +53,23 @@ struct ARNAUD_state_s {
     float aup2_rnorm;        /** naup2 internal compute           internal              */
     enum ARNAUD_which which; /** naupd flow control               input                 */
     enum ARNAUD_ido ido;     /** naupd flow control               input/output          */
-    int info;                /** problem outcome,                 input/output          */
+    CBLAS_INT info;                /** problem outcome,                 input/output          */
     int bmat;                /** problem parameter, boolean       input                 */
     int mode;                /** problem parameter,               input                 */
-    int n;                   /** problem parameter,               input                 */
-    int ncv;                 /** problem parameter,               input                 */
-    int nev;                 /** problem parameter,               input                 */
+    CBLAS_INT n;             /** problem parameter,               input                 */
+    CBLAS_INT ncv;           /** problem parameter,               input                 */
+    CBLAS_INT nev;           /** problem parameter,               input                 */
     int shift;               /** problem parameter, boolean       input                 */
-    int maxiter;             /** problem parameter,               input                 */
-    int nconv;               /** problem outcome,                 output                */
-    int iter;                /** problem intermediate,            internal              */
-    int np;                  /** problem intermediate,            internal              */
+    int maxiter;       /** problem parameter,               input                 */
+    CBLAS_INT nconv;         /** problem outcome,                 output                */
+    int iter;          /** problem intermediate,            internal              */
+    CBLAS_INT np;            /** problem intermediate,            internal              */
     int getv0_first;         /** getv0 flow control               internal              */
-    int getv0_iter;          /** getv0 flow control               internal              */
-    int getv0_itry;          /** getv0 flow control               internal              */
+    int getv0_iter;    /** getv0 flow control               internal              */
+    int getv0_itry;    /** getv0 flow control               internal              */
     int getv0_orth;          /** getv0 flow control               internal              */
-    int aitr_iter;           /** naitr flow control               internal              */
-    int aitr_j;              /** naitr flow control               internal              */
+    CBLAS_INT aitr_iter;     /** naitr flow control               internal              */
+    CBLAS_INT aitr_j;        /** naitr flow control               internal              */
     int aitr_orth1;          /** naitr flow control               internal              */
     int aitr_orth2;          /** naitr flow control               internal              */
     int aitr_restart;        /** naitr flow control               internal              */
@@ -80,11 +80,11 @@ struct ARNAUD_state_s {
     int aup2_iter;           /** naupd2 flow control              internal              */
     int aup2_getv0;          /** naupd2 flow control              internal              */
     int aup2_cnorm;          /** naupd2 flow control              internal              */
-    int aup2_kplusp;         /** naupd2 flow control              internal              */
-    int aup2_nev;            /** naupd2 working nev variable      internal              */
-    int aup2_nev0;           /** naupd2 internal compute          internal              */
-    int aup2_np0;            /** naupd2 internal compute          internal              */
-    int aup2_numcnv;         /** naupd2 internal compute          internal              */
+    CBLAS_INT aup2_kplusp;   /** naupd2 flow control              internal              */
+    CBLAS_INT aup2_nev;      /** naupd2 working nev variable      internal              */
+    CBLAS_INT aup2_nev0;     /** naupd2 internal compute          internal              */
+    CBLAS_INT aup2_np0;      /** naupd2 internal compute          internal              */
+    CBLAS_INT aup2_numcnv;   /** naupd2 internal compute          internal              */
     int aup2_update;         /** naupd2 flow control              internal              */
     int aup2_ushift;         /** naupd2 flow control              internal              */
 };
@@ -110,23 +110,23 @@ struct ARNAUD_state_d {
     double aup2_rnorm;       /** naup2 internal compute           internal              */
     enum ARNAUD_which which; /** naupd flow control               input                 */
     enum ARNAUD_ido ido;     /** naupd flow control               input/output          */
-    int info;                /** problem outcome,                 input/output          */
+    CBLAS_INT info;                /** problem outcome,                 input/output          */
     int bmat;                /** problem parameter, boolean       input                 */
     int mode;                /** problem parameter,               input                 */
-    int n;                   /** problem parameter,               input                 */
-    int ncv;                 /** problem parameter,               input                 */
-    int nev;                 /** problem parameter,               input                 */
+    CBLAS_INT n;             /** problem parameter,               input                 */
+    CBLAS_INT ncv;           /** problem parameter,               input                 */
+    CBLAS_INT nev;           /** problem parameter,               input                 */
     int shift;               /** problem parameter, boolean       input                 */
-    int maxiter;             /** problem parameter,               input                 */
-    int nconv;               /** problem outcome,                 output                */
-    int iter;                /** problem intermediate,            internal              */
-    int np;                  /** problem intermediate,            internal              */
+    int maxiter;       /** problem parameter,               input                 */
+    CBLAS_INT nconv;         /** problem outcome,                 output                */
+    int iter;          /** problem intermediate,            internal              */
+    CBLAS_INT np;            /** problem intermediate,            internal              */
     int getv0_first;         /** getv0 flow control               internal              */
-    int getv0_iter;          /** getv0 flow control               internal              */
-    int getv0_itry;          /** getv0 flow control               internal              */
+    int getv0_iter;    /** getv0 flow control               internal              */
+    int getv0_itry;    /** getv0 flow control               internal              */
     int getv0_orth;          /** getv0 flow control               internal              */
-    int aitr_iter;           /** naitr flow control               internal              */
-    int aitr_j;              /** naitr flow control               internal              */
+    CBLAS_INT aitr_iter;     /** naitr flow control               internal              */
+    CBLAS_INT aitr_j;        /** naitr flow control               internal              */
     int aitr_orth1;          /** naitr flow control               internal              */
     int aitr_orth2;          /** naitr flow control               internal              */
     int aitr_restart;        /** naitr flow control               internal              */
@@ -137,11 +137,11 @@ struct ARNAUD_state_d {
     int aup2_iter;           /** naupd2 flow control              internal              */
     int aup2_getv0;          /** naupd2 flow control              internal              */
     int aup2_cnorm;          /** naupd2 flow control              internal              */
-    int aup2_kplusp;         /** naupd2 flow control              internal              */
-    int aup2_nev;            /** naupd2 working nev variable      internal              */
-    int aup2_nev0;           /** naupd2 internal compute          internal              */
-    int aup2_np0;            /** naupd2 internal compute          internal              */
-    int aup2_numcnv;         /** naupd2 internal compute          internal              */
+    CBLAS_INT aup2_kplusp;   /** naupd2 flow control              internal              */
+    CBLAS_INT aup2_nev;      /** naupd2 working nev variable      internal              */
+    CBLAS_INT aup2_nev0;     /** naupd2 internal compute          internal              */
+    CBLAS_INT aup2_np0;      /** naupd2 internal compute          internal              */
+    CBLAS_INT aup2_numcnv;   /** naupd2 internal compute          internal              */
     int aup2_update;         /** naupd2 flow control              internal              */
     int aup2_ushift;         /** naupd2 flow control              internal              */
 };
@@ -162,7 +162,7 @@ struct ARNAUD_state_d {
  * @param workd    Work array, float, >= 3*n; workspace for user-supplied operations (input/output).
  * @param workl    Work array, float, >= 3*ncv*(ncv+2); internal solver workspace (input/output).
  */
-void ARNAUD_snaupd(struct ARNAUD_state_s *V, float* resid, float* v, int ldv, int* ipntr, float* workd, float* workl);
+void ARNAUD_snaupd(struct ARNAUD_state_s *V, float* resid, float* v, CBLAS_INT ldv, CBLAS_INT* ipntr, float* workd, float* workl);
 
 /**
  * @brief Main reverse communication loop for solving the standard or generalized
@@ -178,7 +178,7 @@ void ARNAUD_snaupd(struct ARNAUD_state_s *V, float* resid, float* v, int ldv, in
  * @param workd    Work array, double, >= 3*n; workspace for user-supplied operations (input/output).
  * @param workl    Work array, double, >= 3*ncv*(ncv+2); internal solver workspace (input/output).
  */
-void ARNAUD_dnaupd(struct ARNAUD_state_d *V, double* resid, double* v, int ldv, int* ipntr, double* workd, double* workl);
+void ARNAUD_dnaupd(struct ARNAUD_state_d *V, double* resid, double* v, CBLAS_INT ldv, CBLAS_INT* ipntr, double* workd, double* workl);
 
 /**
  * @brief Main reverse communication loop for solving the standard or generalized
@@ -195,7 +195,7 @@ void ARNAUD_dnaupd(struct ARNAUD_state_d *V, double* resid, double* v, int ldv, 
  * @param workl    Work array, float complex, >= 3*ncv*(ncv+2); internal solver workspace (input/output).
  * @param rwork    Work array, float, >= 3*ncv; additional workspace for real valued computations (input/output).
  */
-void ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork);
+void ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, CBLAS_INT ldv, CBLAS_INT* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork);
 
 /**
  * @brief Main reverse communication loop for solving the standard or generalized
@@ -212,7 +212,7 @@ void ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CP
  * @param workl    Work array, double complex, >= 3*ncv*(ncv+2); internal solver workspace (input/output).
  * @param rwork    Work array, double, >= 3*ncv; additional workspace for real valued computations (input/output).
  */
-void ARNAUD_znaupd(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPLX_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLX_TYPE* workd, ARNAUD_CPLX_TYPE* workl, double* rwork);
+void ARNAUD_znaupd(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPLX_TYPE* v, CBLAS_INT ldv, CBLAS_INT* ipntr, ARNAUD_CPLX_TYPE* workd, ARNAUD_CPLX_TYPE* workl, double* rwork);
 
 /**
  * @brief Computes the eigenvalues and eigenvectors of the matrix in single precision.
@@ -235,7 +235,7 @@ void ARNAUD_znaupd(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPL
  * @param workd    Work array, float, >= 3*n; workspace (input).
  * @param workl    Work array, float, >= 3*ncv*(ncv+2); holds the results of snaupd (input/output).
  */
-void ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select, float* dr, float* di, float* z, int ldz, float sigmar, float sigmai, float* workev, float* resid, float* v, int ldv, int* ipntr, float* workd, float* workl);
+void ARNAUD_sneupd(struct ARNAUD_state_s *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select, float* dr, float* di, float* z, CBLAS_INT ldz, float sigmar, float sigmai, float* workev, float* resid, float* v, CBLAS_INT ldv, CBLAS_INT* ipntr, float* workd, float* workl);
 
 /**
  * @brief Computes the eigenvalues and eigenvectors of the matrix in double precision.
@@ -258,7 +258,7 @@ void ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select, 
  * @param workd    Work array, double, >= 3*n; workspace (input).
  * @param workl    Work array, double, >= 3*ncv*(ncv+2); holds the results of dnaupd (input/output).
  */
-void ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select, double* dr, double* di, double* z, int ldz, double sigmar, double sigmai, double* workev, double* resid, double* v, int ldv, int* ipntr, double* workd, double* workl);
+void ARNAUD_dneupd(struct ARNAUD_state_d *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select, double* dr, double* di, double* z, CBLAS_INT ldz, double sigmar, double sigmai, double* workev, double* resid, double* v, CBLAS_INT ldv, CBLAS_INT* ipntr, double* workd, double* workl);
 
 /**
  * @brief Computes the eigenvalues and eigenvectors of the matrix in single precision complex arithmetic.
@@ -280,7 +280,7 @@ void ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select, 
  * @param workl    Work array, float complex, >= 3*ncv*(ncv+2); holds the results of cnaupd (input/output).
  * @param rwork    Work array, float, >= 3*ncv; additional workspace for real valued computations (input/output).
  */
-void ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select, ARNAUD_CPLXF_TYPE* d, ARNAUD_CPLXF_TYPE* z, int ldz, ARNAUD_CPLXF_TYPE sigma, ARNAUD_CPLXF_TYPE* workev, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork);
+void ARNAUD_cneupd(struct ARNAUD_state_s *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select, ARNAUD_CPLXF_TYPE* d, ARNAUD_CPLXF_TYPE* z, CBLAS_INT ldz, ARNAUD_CPLXF_TYPE sigma, ARNAUD_CPLXF_TYPE* workev, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, CBLAS_INT ldv, CBLAS_INT* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork);
 
 /**
  * @brief Computes the eigenvalues and eigenvectors of the matrix in double precision complex arithmetic.
@@ -302,7 +302,7 @@ void ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select, 
  * @param workl    Work array, double complex, >= 3*ncv*(ncv+2); holds the results of znaupd (input/output).
  * @param rwork    Work array, float, >= 3*ncv; additional workspace for real valued computations (input/output).
  */
-void ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select, ARNAUD_CPLX_TYPE* d, ARNAUD_CPLX_TYPE* z, int ldz, ARNAUD_CPLX_TYPE sigma, ARNAUD_CPLX_TYPE* workev, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPLX_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLX_TYPE* workd, ARNAUD_CPLX_TYPE* workl, double* rwork);
+void ARNAUD_zneupd(struct ARNAUD_state_d *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select, ARNAUD_CPLX_TYPE* d, ARNAUD_CPLX_TYPE* z, CBLAS_INT ldz, ARNAUD_CPLX_TYPE sigma, ARNAUD_CPLX_TYPE* workev, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPLX_TYPE* v, CBLAS_INT ldv, CBLAS_INT* ipntr, ARNAUD_CPLX_TYPE* workd, ARNAUD_CPLX_TYPE* workl, double* rwork);
 
 /**
  * @brief Computes the eigenvalues and eigenvectors of the symmetric matrix in single precision.
@@ -315,7 +315,7 @@ void ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select, 
  * @param workd    Work array, float, >= 3*n; workspace (input/output).
  * @param workl    Work array, float, >= ncv*(ncv+8); holds the results of snaupd (input/output).
  */
-void ARNAUD_ssaupd(struct ARNAUD_state_s *V, float* resid, float* v, int ldv, int* ipntr, float* workd, float* workl);
+void ARNAUD_ssaupd(struct ARNAUD_state_s *V, float* resid, float* v, CBLAS_INT ldv, CBLAS_INT* ipntr, float* workd, float* workl);
 
 /**
  * @brief Computes the eigenvalues and eigenvectors of the symmetric matrix in double precision.
@@ -328,7 +328,7 @@ void ARNAUD_ssaupd(struct ARNAUD_state_s *V, float* resid, float* v, int ldv, in
  * @param workd    Work array, double, >= 3*n; workspace (input/output).
  * @param workl    Work array, double, >= ncv*(ncv+8); holds the results of dnaupd (input/output).
  */
-void ARNAUD_dsaupd(struct ARNAUD_state_d *V, double* resid, double* v, int ldv, int* ipntr, double* workd, double* workl);
+void ARNAUD_dsaupd(struct ARNAUD_state_d *V, double* resid, double* v, CBLAS_INT ldv, CBLAS_INT* ipntr, double* workd, double* workl);
 
 /**
  * @brief Computes the eigenvalues and eigenvectors of the symmetric matrix in single precision arithmetic.
@@ -348,7 +348,7 @@ void ARNAUD_dsaupd(struct ARNAUD_state_d *V, double* resid, double* v, int ldv, 
  * @param workd    Work array, float complex, >= 3*n; workspace (input).
  * @param workl    Work array, float complex, >= 3*ncv*(ncv+2); holds the results of ssaupd (input/output).
  */
-void ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select, float* d, float* z, int ldz, float sigma, float* resid, float* v, int ldv, int* ipntr, float* workd, float* workl);
+void ARNAUD_sseupd(struct ARNAUD_state_s *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select, float* d, float* z, CBLAS_INT ldz, float sigma, float* resid, float* v, CBLAS_INT ldv, CBLAS_INT* ipntr, float* workd, float* workl);
 
 /**
  * @brief Computes the eigenvalues and eigenvectors of the symmetric matrix in double precision arithmetic.
@@ -368,6 +368,6 @@ void ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select, 
  * @param workd    Work array, double complex, >= 3*n; workspace (input).
  * @param workl    Work array, double complex, >= 3*ncv*(ncv+2); holds the results of dsaupd (input/output).
  */
-void ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select, double* d, double* z, int ldz, double sigma, double* resid, double* v, int ldv, int* ipntr, double* workd, double* workl);
+void ARNAUD_dseupd(struct ARNAUD_state_d *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select, double* d, double* z, CBLAS_INT ldz, double sigma, double* resid, double* v, CBLAS_INT ldv, CBLAS_INT* ipntr, double* workd, double* workl);
 
 #endif

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/types.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/types.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <complex.h>
+#include "npy_cblas.h"
 
 
 #if defined(_MSC_VER)

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double.c
@@ -1,27 +1,27 @@
 #include "arnaud_n_double.h"
 #include <float.h>
 
-typedef int ARNAUD_compare_cfunc(const double, const double, const double, const double);
+typedef CBLAS_INT ARNAUD_compare_cfunc(const double, const double, const double, const double);
 
-static int sortc_LM(const double, const double, const double, const double);
-static int sortc_SM(const double, const double, const double, const double);
-static int sortc_LR(const double, const double, const double, const double);
-static int sortc_SR(const double, const double, const double, const double);
-static int sortc_LI(const double, const double, const double, const double);
-static int sortc_SI(const double, const double, const double, const double);
+static CBLAS_INT sortc_LM(const double, const double, const double, const double);
+static CBLAS_INT sortc_SM(const double, const double, const double, const double);
+static CBLAS_INT sortc_LR(const double, const double, const double, const double);
+static CBLAS_INT sortc_SR(const double, const double, const double, const double);
+static CBLAS_INT sortc_LI(const double, const double, const double, const double);
+static CBLAS_INT sortc_SI(const double, const double, const double, const double);
 
 static const double unfl = DBL_MIN;    // 2.2250738585072014e-308
 // static const double ovfl = DBL_MAX; // 1.0 / 2.2250738585072014e-308;
 static const double ulp = DBL_EPSILON; // 2.220446049250313e-16;
 
-static void dnaup2(struct ARNAUD_state_d*, double*, double*, int, double*, int, double*, double*, double*, double*, int, double*, int*, double*);
-static void dnconv(int n, double* ritzr, double* ritzi, double* bounds, const double tol, int* nconv);
-static void dneigh(double*,int,double*,int,double*,double*,double*,double*,int,double*,int*);
-static void dnaitr(struct ARNAUD_state_d*,int,int,double*,double*,double*,int,double*,int,int*,double*);
-static void dnapps(int,int*,int,double*,double*,double*,int,double*,int,double*,double*,int,double*,double*);
-static void dngets(struct ARNAUD_state_d*,int*,int*,double*,double*,double*);
-static void dsortc(const enum ARNAUD_which w, const int apply, const int n, double* xreal, double* ximag, double* y);
-static void dgetv0(struct ARNAUD_state_d *V, int initv, int n, int j, double* v, int ldv, double* resid, double* rnorm, int* ipntr, double* workd);
+static void dnaup2(struct ARNAUD_state_d*, double*, double*, CBLAS_INT, double*, CBLAS_INT, double*, double*, double*, double*, CBLAS_INT, double*, CBLAS_INT*, double*);
+static void dnconv(CBLAS_INT n, double* ritzr, double* ritzi, double* bounds, const double tol, CBLAS_INT* nconv);
+static void dneigh(double*,CBLAS_INT,double*,CBLAS_INT,double*,double*,double*,double*,CBLAS_INT,double*,CBLAS_INT*);
+static void dnaitr(struct ARNAUD_state_d*,CBLAS_INT,CBLAS_INT,double*,double*,double*,CBLAS_INT,double*,CBLAS_INT,CBLAS_INT*,double*);
+static void dnapps(CBLAS_INT,CBLAS_INT*,CBLAS_INT,double*,double*,double*,CBLAS_INT,double*,CBLAS_INT,double*,double*,CBLAS_INT,double*,double*);
+static void dngets(struct ARNAUD_state_d*,CBLAS_INT*,CBLAS_INT*,double*,double*,double*);
+static void dsortc(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, double* xreal, double* ximag, double* y);
+static void dgetv0(struct ARNAUD_state_d *V, CBLAS_INT initv, CBLAS_INT n, CBLAS_INT j, double* v, CBLAS_INT ldv, double* resid, double* rnorm, CBLAS_INT* ipntr, double* workd);
 
 enum ARNAUD_neupd_type {
     REGULAR = 0,
@@ -32,16 +32,16 @@ enum ARNAUD_neupd_type {
 
 
 void
-ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
-       double* dr, double* di, double* z, int ldz, double sigmar, double sigmai,
-       double* workev, double* resid, double* v, int ldv, int* ipntr, double* workd,
+ARNAUD_dneupd(struct ARNAUD_state_d *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select,
+       double* dr, double* di, double* z, CBLAS_INT ldz, double sigmar, double sigmai,
+       double* workev, double* resid, double* v, CBLAS_INT ldv, CBLAS_INT* ipntr, double* workd,
        double* workl)
 {
     const double eps23 = pow(ulp, 2.0 / 3.0);
-    int ibd, iconj, ih, iheigr, iheigi, ihbds, iuptri, invsub, iri, irr, j, jj;
-    int bounds, k, ldh, ldq, np, numcnv, reord, ritzr, ritzi;
-    int iwork[1] = { 0 };
-    int ierr = 0, int1 = 1, tmp_int = 0, nconv2 = 0, outncv;
+    CBLAS_INT ibd, iconj, ih, iheigr, iheigi, ihbds, iuptri, invsub, iri, irr, j, jj;
+    CBLAS_INT bounds, k, ldh, ldq, np, numcnv, reord, ritzr, ritzi;
+    CBLAS_INT iwork[1] = { 0 };
+    CBLAS_INT ierr = 0; CBLAS_INT int1 = 1; CBLAS_INT  tmp_int = 0, nconv2 = 0, outncv;
     double conds, rnorm, sep, temp, temp1, dbl0 = 0.0, dbl1 = 1.0, dblm1 = -1.0;
     double vl[1] = { 0.0 };
     enum ARNAUD_neupd_type TYP;
@@ -166,7 +166,7 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         {
             temp1 = fmax(eps23, hypot(workl[irr + V->ncv - j], workl[iri + V->ncv - j]));
 
-            jj = (int)workl[bounds + V->ncv - j];
+            jj = (CBLAS_INT)workl[bounds + V->ncv - j];
 
             if ((numcnv < V->nconv) && (workl[ibd + jj] <= V->tol*temp1))
             {
@@ -194,12 +194,12 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  Initialize the Schur vector matrix Q to the identity.
 
         tmp_int = ldh*V->ncv;
-        dcopy_(&tmp_int, &workl[ih], &int1, &workl[iuptri], &int1);
-        dlaset_("A", &V->ncv, &V->ncv, &dbl0, &dbl1, &workl[invsub], &ldq);
-        dlahqr_(&int1, &int1, &V->ncv, &int1, &V->ncv, &workl[iuptri], &ldh,
+        BLAS_FUNC(dcopy)(&tmp_int, &workl[ih], &int1, &workl[iuptri], &int1);
+        BLAS_FUNC(dlaset)("A", &V->ncv, &V->ncv, &dbl0, &dbl1, &workl[invsub], &ldq);
+        BLAS_FUNC(dlahqr)(&int1, &int1, &V->ncv, &int1, &V->ncv, &workl[iuptri], &ldh,
                 &workl[iheigr], &workl[iheigi], &int1, &V->ncv, &workl[invsub],
                 &ldq, &ierr);
-        dcopy_(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
+        BLAS_FUNC(dcopy)(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
 
         if (ierr != 0)
         {
@@ -209,7 +209,7 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
         if (reord)
         {
-            dtrsen_("N", "V", select, &V->ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq,
+            BLAS_FUNC(dtrsen)("N", "V", select, &V->ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq,
                     &workl[iheigr], &workl[iheigi], &nconv2, &conds, &sep, &workl[ihbds],
                     &V->ncv, iwork, &int1, &ierr);
 
@@ -225,21 +225,21 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  to compute the Ritz estimates of
         //  converged Ritz values.
 
-        dcopy_(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
+        BLAS_FUNC(dcopy)(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
 
         //  Place the computed eigenvalues of H into DR and DI
         //  if a spectral transformation was not used.
 
         if (TYP == REGULAR) {
-            dcopy_(&V->nconv, &workl[iheigr], &int1, dr, &int1);
-            dcopy_(&V->nconv, &workl[iheigi], &int1, di, &int1);
+            BLAS_FUNC(dcopy)(&V->nconv, &workl[iheigr], &int1, dr, &int1);
+            BLAS_FUNC(dcopy)(&V->nconv, &workl[iheigi], &int1, di, &int1);
         }
 
         //  Compute the QR factorization of the matrix representing
         //  the wanted invariant subspace located in the first NCONV
         //  columns of workl(invsub,ldq).
 
-        dgeqr2_(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
+        BLAS_FUNC(dgeqr2)(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
 
         //  * Postmultiply V by Q using dorm2r .
         //  * Copy the first NCONV columns of VQ into Z.
@@ -251,10 +251,10 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  vectors associated with the real upper quasi-triangular
         //  matrix of order NCONV in workl(iuptri)
 
-        dorm2r_("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq, workev,
+        BLAS_FUNC(dorm2r)("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq, workev,
                 v, &ldv, &workd[V->n], &ierr);
 
-        dlacpy_("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
+        BLAS_FUNC(dlacpy)("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
 
         //  Perform both a column and row scaling if the
         //  diagonal element of workl(invsub,ldq) is negative
@@ -267,8 +267,8 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         {
             if (workl[invsub + j*ldq + j] < 0.0)
             {
-                dscal_(&V->nconv, &dblm1, &workl[iuptri + j], &ldq);
-                dscal_(&V->nconv, &dblm1, &workl[iuptri + j*ldq], &int1);
+                BLAS_FUNC(dscal)(&V->nconv, &dblm1, &workl[iuptri + j], &ldq);
+                BLAS_FUNC(dscal)(&V->nconv, &dblm1, &workl[iuptri + j*ldq], &int1);
             }
         }
         // 20
@@ -290,7 +290,7 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
             }
             // 30
 
-            dtrevc_("R", "S", select, &V->ncv, &workl[iuptri], &ldq, vl, &int1,
+            BLAS_FUNC(dtrevc)("R", "S", select, &V->ncv, &workl[iuptri], &ldq, vl, &int1,
                     &workl[invsub], &ldq, &V->ncv, &outncv, workev, &ierr);
 
             if (ierr != 0)
@@ -313,8 +313,8 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
                     //  real eigenvalue case
 
-                    temp = 1.0 / dnrm2_(&V->ncv, &workl[invsub + j*ldq], &int1);
-                    dscal_(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
+                    temp = 1.0 / BLAS_FUNC(dnrm2)(&V->ncv, &workl[invsub + j*ldq], &int1);
+                    BLAS_FUNC(dscal)(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
 
                 } else {
 
@@ -326,10 +326,10 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
                     if (iconj == 0)
                     {
-                        temp = 1.0 / hypot(dnrm2_(&V->ncv, &workl[invsub + j*ldq], &int1),
-                                           dnrm2_(&V->ncv, &workl[invsub + (j+1)*ldq], &int1));
-                        dscal_(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
-                        dscal_(&V->ncv, &temp, &workl[invsub + (j+1)*ldq], &int1);
+                        temp = 1.0 / hypot(BLAS_FUNC(dnrm2)(&V->ncv, &workl[invsub + j*ldq], &int1),
+                                           BLAS_FUNC(dnrm2)(&V->ncv, &workl[invsub + (j+1)*ldq], &int1));
+                        BLAS_FUNC(dscal)(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
+                        BLAS_FUNC(dscal)(&V->ncv, &temp, &workl[invsub + (j+1)*ldq], &int1);
                         iconj = 1;
                     } else {
                         iconj = 0;
@@ -338,7 +338,7 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
             }
             // 40
 
-            dgemv_("T", &V->ncv, &V->nconv, &dbl1, &workl[invsub], &ldq, &workl[ihbds], &int1, &dbl0, workev, &int1);
+            BLAS_FUNC(dgemv)("T", &V->ncv, &V->nconv, &dbl1, &workl[invsub], &ldq, &workl[ihbds], &int1, &dbl0, workev, &int1);
 
             iconj = 0;
             for (j = 0; j < V->nconv; j++)
@@ -364,13 +364,13 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
             //  Copy Ritz estimates into workl(ihbds)
 
-            dcopy_(&V->nconv, workev, &int1, &workl[ihbds], &int1);
+            BLAS_FUNC(dcopy)(&V->nconv, workev, &int1, &workl[ihbds], &int1);
 
             //  Compute the QR factorization of the eigenvector matrix
             //  associated with leading portion of T in the first NCONV
             //  columns of workl(invsub,ldq).
 
-            dgeqr2_(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
+            BLAS_FUNC(dgeqr2)(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
 
             //  * Postmultiply Z by Q.
             //  * Postmultiply Z by R.
@@ -378,10 +378,10 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
             //  Ritz vectors associated with the Ritz values
             //  in workl(iheigr) and workl(iheigi).
 
-            dorm2r_("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq,
+            BLAS_FUNC(dorm2r)("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq,
                     workev, z, &ldz, &workd[V->n], &ierr);
 
-            dtrmm_("R", "U", "N", "N", &V->n, &V->nconv, &dbl1, &workl[invsub], &ldq, z, &ldz);
+            BLAS_FUNC(dtrmm)("R", "U", "N", "N", &V->n, &V->nconv, &dbl1, &workl[invsub], &ldq, z, &ldz);
 
         }
 
@@ -390,11 +390,11 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  An approximate invariant subspace is not needed.
         //  Place the Ritz values computed DNAUPD  into DR and DI
 
-        dcopy_(&V->nconv, &workl[ritzr], &int1, dr, &int1);
-        dcopy_(&V->nconv, &workl[ritzi], &int1, di, &int1);
-        dcopy_(&V->nconv, &workl[ritzr], &int1, &workl[iheigr], &int1);
-        dcopy_(&V->nconv, &workl[ritzi], &int1, &workl[iheigi], &int1);
-        dcopy_(&V->nconv, &workl[bounds], &int1, &workl[ihbds], &int1);
+        BLAS_FUNC(dcopy)(&V->nconv, &workl[ritzr], &int1, dr, &int1);
+        BLAS_FUNC(dcopy)(&V->nconv, &workl[ritzi], &int1, di, &int1);
+        BLAS_FUNC(dcopy)(&V->nconv, &workl[ritzr], &int1, &workl[iheigr], &int1);
+        BLAS_FUNC(dcopy)(&V->nconv, &workl[ritzi], &int1, &workl[iheigi], &int1);
+        BLAS_FUNC(dcopy)(&V->nconv, &workl[bounds], &int1, &workl[ihbds], &int1);
     }
 
     //  Transform the Ritz values and possibly vectors
@@ -405,7 +405,7 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
     {
         if (rvec)
         {
-            dscal_(&V->ncv, &rnorm, &workl[ihbds], &int1);
+            BLAS_FUNC(dscal)(&V->ncv, &rnorm, &workl[ihbds], &int1);
         }
     } else {
 
@@ -417,7 +417,7 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         {
             if (rvec)
             {
-                dscal_(&V->ncv, &rnorm, &workl[ihbds], &int1);
+                BLAS_FUNC(dscal)(&V->ncv, &rnorm, &workl[ihbds], &int1);
             }
 
             for (k = 0; k < V->ncv; k++)
@@ -447,12 +447,12 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
             }
             // 80
 
-            dcopy_(&V->nconv, &workl[iheigr], &int1, dr, &int1);
-            dcopy_(&V->nconv, &workl[iheigi], &int1, di, &int1);
+            BLAS_FUNC(dcopy)(&V->nconv, &workl[iheigr], &int1, dr, &int1);
+            BLAS_FUNC(dcopy)(&V->nconv, &workl[iheigi], &int1, di, &int1);
 
         } else if ((TYP == REALPART) || (TYP == IMAGPART)) {
-            dcopy_(&V->nconv, &workl[iheigr], &int1, dr, &int1);
-            dcopy_(&V->nconv, &workl[iheigi], &int1, di, &int1);
+            BLAS_FUNC(dcopy)(&V->nconv, &workl[iheigr], &int1, dr, &int1);
+            BLAS_FUNC(dcopy)(&V->nconv, &workl[iheigi], &int1, di, &int1);
         }
     }
 
@@ -500,7 +500,7 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  Perform a rank one update to Z and
         //  purify all the Ritz vectors together.
 
-        dger_(&V->n, &V->nconv, &dbl1, resid, &int1, workev, &int1, z, &ldz);
+        BLAS_FUNC(dger)(&V->n, &V->nconv, &dbl1, resid, &int1, workev, &int1, z, &ldz);
     }
 
     return;
@@ -508,9 +508,9 @@ ARNAUD_dneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
 void
 ARNAUD_dnaupd(struct ARNAUD_state_d *V, double* resid, double* v,
-              int ldv, int* ipntr, double* workd, double* workl)
+              CBLAS_INT ldv, CBLAS_INT* ipntr, double* workd, double* workl)
 {
-    int bounds, ih, iq, iw, j, ldh, ldq, next, iritzi, iritzr;
+    CBLAS_INT bounds, ih, iq, iw, j, ldh, ldq, next, iritzi, iritzr;
 
     if (V->ido == ido_FIRST)
     {
@@ -606,12 +606,12 @@ ARNAUD_dnaupd(struct ARNAUD_state_d *V, double* resid, double* v,
 }
 
 void
-dnaup2(struct ARNAUD_state_d *V, double* resid, double* v, int ldv,
-       double* h, int ldh, double* ritzr, double* ritzi, double* bounds,
-       double* q, int ldq, double* workl, int* ipntr, double* workd)
+dnaup2(struct ARNAUD_state_d *V, double* resid, double* v, CBLAS_INT ldv,
+       double* h, CBLAS_INT ldh, double* ritzr, double* ritzi, double* bounds,
+       double* q, CBLAS_INT ldq, double* workl, CBLAS_INT* ipntr, double* workd)
 {
     enum ARNAUD_which temp_which;
-    int int1 = 1, j, tmp_int;
+    CBLAS_INT int1 = 1, j, tmp_int;
     const double eps23 = pow(ulp, 2.0 / 3.0);
     double temp = 0.0;
 
@@ -756,11 +756,11 @@ LINE20:
     //  bounds obtained from dneigh.
 
     tmp_int = V->aup2_kplusp * V->aup2_kplusp;
-    dcopy_(&V->aup2_kplusp, ritzr, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(dcopy)(&V->aup2_kplusp, ritzr, &int1, &workl[tmp_int], &int1);
     tmp_int += V->aup2_kplusp;
-    dcopy_(&V->aup2_kplusp, ritzi, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(dcopy)(&V->aup2_kplusp, ritzi, &int1, &workl[tmp_int], &int1);
     tmp_int += V->aup2_kplusp;
-    dcopy_(&V->aup2_kplusp, bounds, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(dcopy)(&V->aup2_kplusp, bounds, &int1, &workl[tmp_int], &int1);
 
     //  Select the wanted Ritz values and their bounds
     //  to be used in the convergence test.
@@ -783,7 +783,7 @@ LINE20:
 
     //  Convergence test.
 
-    dcopy_(&V->aup2_nev, &bounds[V->np], &int1, &workl[2*V->np], &int1);
+    BLAS_FUNC(dcopy)(&V->aup2_nev, &bounds[V->np], &int1, &workl[2*V->np], &int1);
     dnconv(V->aup2_nev, &ritzr[V->np], &ritzi[V->np], &workl[2*V->np], V->tol, &V->nconv);
 
     //  Count the number of unwanted Ritz values that have zero
@@ -795,7 +795,7 @@ LINE20:
     //  no shifts may be applied, then prepare to exit
 
     // We are modifying V->np hence the temporary variable.
-    int nptemp = V->np;
+    CBLAS_INT nptemp = V->np;
 
     for (j = 0; j < nptemp; j++)
     {
@@ -909,7 +909,7 @@ LINE20:
         //  To prevent possible stagnation, adjust the size
         //  of NEV.
 
-        int nevbef = V->aup2_nev;
+        CBLAS_INT nevbef = V->aup2_nev;
         V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
         if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6)) {
             V->aup2_nev = V->aup2_kplusp / 2;
@@ -962,8 +962,8 @@ LINE50:
         //  RITZR, RITZI to free up WORKL
         //  for non-exact shift case.
 
-        dcopy_(&V->np, workl, &int1, ritzr, &int1);
-        dcopy_(&V->np, &workl[V->np], &int1, ritzi, &int1);
+        BLAS_FUNC(dcopy)(&V->np, workl, &int1, ritzr, &int1);
+        BLAS_FUNC(dcopy)(&V->np, &workl[V->np], &int1, ritzi, &int1);
     }
 
     //  Apply the NP implicit shifts by QR bulge chasing.
@@ -980,7 +980,7 @@ LINE50:
     V->aup2_cnorm = 1;
     if (V->bmat)
     {
-        dcopy_(&V->n, resid, &int1, &workd[V->n], &int1);
+        BLAS_FUNC(dcopy)(&V->n, resid, &int1, &workd[V->n], &int1);
         ipntr[0] = V->n;
         ipntr[1] = 0;
         V->ido = ido_BX;
@@ -989,7 +989,7 @@ LINE50:
 
         return;
     } else {
-        dcopy_(&V->n, resid, &int1, workd, &int1);
+        BLAS_FUNC(dcopy)(&V->n, resid, &int1, workd, &int1);
     }
 
 LINE100:
@@ -999,10 +999,10 @@ LINE100:
 
     if (V->bmat)
     {
-        V->aup2_rnorm = ddot_(&V->n, resid, &int1, workd, &int1);
+        V->aup2_rnorm = BLAS_FUNC(ddot)(&V->n, resid, &int1, workd, &int1);
         V->aup2_rnorm = sqrt(fabs(V->aup2_rnorm));
     } else {
-        V->aup2_rnorm = dnrm2_(&V->n, resid, &int1);
+        V->aup2_rnorm = BLAS_FUNC(dnrm2)(&V->n, resid, &int1);
     }
     V->aup2_cnorm = 0;
 
@@ -1015,13 +1015,13 @@ LINE100:
 }
 
 void
-dnconv(int n, double* ritzr, double* ritzi, double* bounds, const double tol, int* nconv)
+dnconv(CBLAS_INT n, double* ritzr, double* ritzi, double* bounds, const double tol, CBLAS_INT* nconv)
 {
     const double eps23 = pow(ulp, 2.0 / 3.0);
     double temp;
 
     *nconv = 0;
-    for (int i = 0; i < n; i++)
+    for (CBLAS_INT i = 0; i < n; i++)
     {
         temp = fmax(eps23, hypot(ritzr[i], ritzi[i]));
         if (bounds[i] <= tol*temp)
@@ -1034,11 +1034,11 @@ dnconv(int n, double* ritzr, double* ritzi, double* bounds, const double tol, in
 }
 
 void
-dneigh(double* rnorm, int n, double* h, int ldh, double* ritzr, double* ritzi,
-       double* bounds, double* q, int ldq, double* workl, int* ierr)
+dneigh(double* rnorm, CBLAS_INT n, double* h, CBLAS_INT ldh, double* ritzr, double* ritzi,
+       double* bounds, double* q, CBLAS_INT ldq, double* workl, CBLAS_INT* ierr)
 {
-    int select[1] = { 0 };
-    int i, iconj, int1 = 1, j;
+    CBLAS_INT select[1] = { 0 };
+    CBLAS_INT i, iconj; CBLAS_INT int1 = 1; CBLAS_INT  j;
     double dbl1 = 1.0, dbl0 = 0.0, temp, tmp_dbl, vl[1] = { 0.0 };
 
     //  1. Compute the eigenvalues, the last components of the
@@ -1047,13 +1047,13 @@ dneigh(double* rnorm, int n, double* h, int ldh, double* ritzr, double* ritzi,
     //  dlahqr returns the full Schur form of H in WORKL(1:N**2)
     //  and the last components of the Schur vectors in BOUNDS.
 
-    dlacpy_("A", &n, &n, h, &ldh, workl, &n);
+    BLAS_FUNC(dlacpy)("A", &n, &n, h, &ldh, workl, &n);
     for (j = 0; j < n-1; j++)
     {
         bounds[j] = 0.0;
     }
     bounds[n-1] = 1.0;
-    dlahqr_(&int1, &int1, &n, &int1, &n, workl, &n, ritzr, ritzi, &int1, &int1, bounds, &int1, ierr);
+    BLAS_FUNC(dlahqr)(&int1, &int1, &n, &int1, &n, workl, &n, ritzr, ritzi, &int1, &int1, bounds, &int1, ierr);
 
     if (*ierr != 0) { return; }
 
@@ -1065,7 +1065,7 @@ dneigh(double* rnorm, int n, double* h, int ldh, double* ritzr, double* ritzi,
     //  of the eigenvector components are split across adjacent
     //  columns of Q.
 
-    dtrevc_("R", "A", select, &n, workl, &n, vl, &n, q, &ldq, &n, &n, &workl[n*n], ierr);
+    BLAS_FUNC(dtrevc)("R", "A", select, &n, workl, &n, vl, &n, q, &ldq, &n, &n, &workl[n*n], ierr);
     if (*ierr != 0) { return; }
 
     //  Scale the returning eigenvectors so that their
@@ -1083,9 +1083,9 @@ dneigh(double* rnorm, int n, double* h, int ldh, double* ritzr, double* ritzi,
 
             //  Real eigenvalue case
 
-            temp = dnrm2_(&n, &q[ldq*i], &int1);
+            temp = BLAS_FUNC(dnrm2)(&n, &q[ldq*i], &int1);
             tmp_dbl = 1.0 / temp;
-            dscal_(&n, &tmp_dbl, &q[ldq*i], &int1);
+            BLAS_FUNC(dscal)(&n, &tmp_dbl, &q[ldq*i], &int1);
 
         } else {
 
@@ -1097,11 +1097,11 @@ dneigh(double* rnorm, int n, double* h, int ldh, double* ritzr, double* ritzi,
 
             if (iconj == 0)
             {
-                temp = hypot(dnrm2_(&n, &q[ldq*i], &int1),
-                             dnrm2_(&n, &q[ldq*(i+1)], &int1));
+                temp = hypot(BLAS_FUNC(dnrm2)(&n, &q[ldq*i], &int1),
+                             BLAS_FUNC(dnrm2)(&n, &q[ldq*(i+1)], &int1));
                 tmp_dbl = 1.0 / temp;
-                dscal_(&n, &tmp_dbl, &q[ldq*i], &int1);
-                dscal_(&n, &tmp_dbl, &q[ldq*(i+1)], &int1);
+                BLAS_FUNC(dscal)(&n, &tmp_dbl, &q[ldq*i], &int1);
+                BLAS_FUNC(dscal)(&n, &tmp_dbl, &q[ldq*(i+1)], &int1);
                 iconj = 1;
             } else {
                 iconj = 0;
@@ -1110,7 +1110,7 @@ dneigh(double* rnorm, int n, double* h, int ldh, double* ritzr, double* ritzi,
     }
     // 10
 
-    dgemv_("T", &n, &n, &dbl1, q, &ldq, bounds, &int1, &dbl0, workl, &int1);
+    BLAS_FUNC(dgemv)("T", &n, &n, &dbl1, q, &ldq, bounds, &int1, &dbl0, workl, &int1);
 
     //  Compute the Ritz estimates
 
@@ -1148,14 +1148,14 @@ dneigh(double* rnorm, int n, double* h, int ldh, double* ritzr, double* ritzi,
 }
 
 void
-dnaitr(struct ARNAUD_state_d *V, int k, int np, double* resid, double* rnorm,
-       double* v, int ldv, double* h, int ldh, int* ipntr, double* workd)
+dnaitr(struct ARNAUD_state_d *V, CBLAS_INT k, CBLAS_INT np, double* resid, double* rnorm,
+       double* v, CBLAS_INT ldv, double* h, CBLAS_INT ldh, CBLAS_INT* ipntr, double* workd)
 {
-    int i = 0, infol, ipj, irj, ivj, jj, n, tmp_int;
+    CBLAS_INT i = 0, infol, ipj, irj, ivj, jj, n, tmp_int;
     double smlnum = unfl * ( V->n / ulp);
     const double sq2o2 = sqrt(2.0) / 2.0;
 
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
     double dbl1 = 1.0, dbl0 = 0.0, dblm1 = -1.0, temp1, tst1;
 
     n = V->n;  // n is constant, this is just for typing convenience
@@ -1249,22 +1249,22 @@ LINE40:
     //  when reciprocating a small RNORM, test against lower
     //  machine bound.
 
-    dcopy_(&n, resid, &int1, &v[ldv*(V->aitr_j)], &int1);
+    BLAS_FUNC(dcopy)(&n, resid, &int1, &v[ldv*(V->aitr_j)], &int1);
     if (*rnorm >= unfl)
     {
         temp1 = 1.0 / *rnorm;
-        dscal_(&n, &temp1, &v[ldv*(V->aitr_j)], &int1);
-        dscal_(&n, &temp1, &workd[ipj], &int1);
+        BLAS_FUNC(dscal)(&n, &temp1, &v[ldv*(V->aitr_j)], &int1);
+        BLAS_FUNC(dscal)(&n, &temp1, &workd[ipj], &int1);
     } else {
-        dlascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*(V->aitr_j)], &n, &infol);
-        dlascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
+        BLAS_FUNC(dlascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*(V->aitr_j)], &n, &infol);
+        BLAS_FUNC(dlascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
     }
 
     //  STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j}
     //  Note that this is not quite yet r_{j}. See STEP 4
 
     V->aitr_step3 = 1;
-    dcopy_(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
+    BLAS_FUNC(dcopy)(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
     ipntr[0] = ivj;
     ipntr[1] = irj;
     ipntr[2] = ipj;
@@ -1284,7 +1284,7 @@ LINE50:
 
     //  Put another copy of OP*v_{j} into RESID.
 
-    dcopy_(&n, &workd[irj], &int1, resid, &int1);
+    BLAS_FUNC(dcopy)(&n, &workd[irj], &int1, resid, &int1);
 
     //  STEP 4:  Finish extending the Arnoldi
     //           factorization to length j.
@@ -1300,7 +1300,7 @@ LINE50:
 
         return;
     } else {
-        dcopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE60:
@@ -1316,10 +1316,10 @@ LINE60:
 
     if (V->bmat)
     {
-        V->aitr_wnorm = ddot_(&n, resid, &int1, &workd[ipj], &int1);
+        V->aitr_wnorm = BLAS_FUNC(ddot)(&n, resid, &int1, &workd[ipj], &int1);
         V->aitr_wnorm = sqrt(fabs(V->aitr_wnorm));
     } else {
-        V->aitr_wnorm = dnrm2_(&n, resid, &int1);
+        V->aitr_wnorm = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
 
     //  Compute the j-th residual corresponding
@@ -1331,19 +1331,19 @@ LINE60:
     //  Compute the j Fourier coefficients w_{j}
     //  WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.
     tmp_int = V->aitr_j + 1;
-    dgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &h[ldh*(V->aitr_j)], &int1);
+    BLAS_FUNC(dgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &h[ldh*(V->aitr_j)], &int1);
 
     //  Orthogonalize r_{j} against V_{j}.
     //  RESID contains OP*v_{j}. See STEP 3.
 
-    dgemv_("N", &n, &tmp_int, &dblm1, v, &ldv, &h[ldh*(V->aitr_j)], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(dgemv)("N", &n, &tmp_int, &dblm1, v, &ldv, &h[ldh*(V->aitr_j)], &int1, &dbl1, resid, &int1);
 
     if (V->aitr_j > 0) { h[V->aitr_j + ldh*(V->aitr_j-1)] = V->aitr_betaj; }
 
     V->aitr_orth1 = 1;
     if (V->bmat)
     {
-        dcopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1352,7 +1352,7 @@ LINE60:
 
         return;
     } else {
-        dcopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE70:
@@ -1366,10 +1366,10 @@ LINE70:
 
     if (V->bmat)
     {
-        *rnorm = ddot_(&n, resid, &int1, &workd[ipj], &int1);
+        *rnorm = BLAS_FUNC(ddot)(&n, resid, &int1, &workd[ipj], &int1);
         *rnorm = sqrt(fabs(*rnorm));
     } else {
-        *rnorm = dnrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
 
     //  STEP 5: Re-orthogonalization / Iterative refinement phase
@@ -1401,21 +1401,21 @@ LINE80:
     //  Compute V_{j}^T * B * r_{j}.
     //  WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1).
     tmp_int = V->aitr_j + 1;
-    dgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
+    BLAS_FUNC(dgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
 
     //  Compute the correction to the residual:
     //  r_{j} = r_{j} - V_{j} * WORKD(IRJ:IRJ+J-1).
     //  The correction to H is v(:,1:J)*H(1:J,1:J)
     //  + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.
 
-    dgemv_("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
-    daxpy_(&tmp_int, &dbl1, &workd[irj], &int1, &h[ldh*(V->aitr_j)], &int1);
+    BLAS_FUNC(dgemv)("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(daxpy)(&tmp_int, &dbl1, &workd[irj], &int1, &h[ldh*(V->aitr_j)], &int1);
 
     V->aitr_orth2 = 1;
 
     if (V->bmat)
     {
-        dcopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1425,7 +1425,7 @@ LINE80:
 
         return;
     } else {
-        dcopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE90:
@@ -1436,10 +1436,10 @@ LINE90:
 
     if (V->bmat)
     {
-        V->aitr_rnorm1 = ddot_(&n, resid, &int1, &workd[ipj], &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(ddot)(&n, resid, &int1, &workd[ipj], &int1);
         V->aitr_rnorm1 = sqrt(fabs(V->aitr_rnorm1));
     } else {
-        V->aitr_rnorm1 = dnrm2_(&n, resid, &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
 
     //  Determine if we need to perform another
@@ -1502,7 +1502,7 @@ LINE100:
             if (tst1 == 0.0)
             {
                 tmp_int = k + np;
-                tst1 = dlanhs_("1", &tmp_int, h, &ldh, &workd[n]);
+                tst1 = BLAS_FUNC(dlanhs)("1", &tmp_int, h, &ldh, &workd[n]);
             }
             if (fabs(h[i+1 + ldh*i]) <= fmax(ulp*tst1, smlnum))
             {
@@ -1518,13 +1518,13 @@ LINE100:
 
 
 void
-dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
-       int ldv, double* h, int ldh, double* resid, double* q, int ldq, double* workl,
+dnapps(CBLAS_INT n, CBLAS_INT* kev, CBLAS_INT np, double* shiftr, double* shifti, double* v,
+       CBLAS_INT ldv, double* h, CBLAS_INT ldh, double* resid, double* q, CBLAS_INT ldq, double* workl,
        double* workd)
 {
-    int cconj;
-    int i, ir, j, jj, int1 = 1, istart, iend = 0, nr, tmp_int;
-    int kplusp = *kev + np;
+    CBLAS_INT cconj;
+    CBLAS_INT i, ir, j, jj; CBLAS_INT int1 = 1; CBLAS_INT  istart, iend = 0, nr, tmp_int;
+    CBLAS_INT kplusp = *kev + np;
     double smlnum = unfl * ( n / ulp);
     double c, f, g, h11, h21, h12, h22, h32, s, sigmar, sigmai, r, t, tau, tst1;
     double dbl1 = 1.0, dbl0 = 0.0, dblm1 = -1.0;
@@ -1532,7 +1532,7 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
 
     //  Initialize Q to the identity to accumulate
     //  the rotations and reflections
-    dlaset_("A", &kplusp, &kplusp, &dbl0, &dbl1, q, &ldq);
+    BLAS_FUNC(dlaset)("A", &kplusp, &kplusp, &dbl0, &dbl1, q, &ldq);
 
     //  Quick return if there are no shifts to apply
 
@@ -1593,7 +1593,7 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
                 if (tst1 == 0.0)
                 {
                     tmp_int = kplusp - jj;
-                    tst1 = dlanhs_("1", &tmp_int, h, &ldh, workl);
+                    tst1 = BLAS_FUNC(dlanhs)("1", &tmp_int, h, &ldh, workl);
                 }
                 if (fabs(h[iend+1 + (iend * ldh)]) <= fmax(smlnum, ulp * tst1))
                 {
@@ -1622,18 +1622,18 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
                 g = h21;
                 for (i = istart; i < iend; i++)
                 {
-                    dlartgp_(&f, &g, &c, &s, &r);
+                    BLAS_FUNC(dlartgp)(&f, &g, &c, &s, &r);
                     if (i > istart)
                     {
                         h[i + (i - 1) * ldh] = r;
                         h[i + 1 + (i - 1) * ldh] = 0.0;
                     }
                     tmp_int = kplusp - i;
-                    drot_(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
+                    BLAS_FUNC(drot)(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
                     tmp_int = (i+2 > iend ? iend : i + 2) + 1;
-                    drot_(&tmp_int, &h[ldh*i], &int1, &h[ldh*(i+1)], &int1, &c, &s);
+                    BLAS_FUNC(drot)(&tmp_int, &h[ldh*i], &int1, &h[ldh*(i+1)], &int1, &c, &s);
                     tmp_int = (i+jj+2 > kplusp ? kplusp : i + jj + 2);
-                    drot_(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s);
+                    BLAS_FUNC(drot)(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s);
 
                     if (i < iend - 1)
                     {
@@ -1657,7 +1657,7 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
                 {
                     nr = iend - i + 1;
                     nr = (nr > 3? 3 : nr);
-                    dlarfg_(&nr, &u[0], &u[1], &int1, &tau);
+                    BLAS_FUNC(dlarfg)(&nr, &u[0], &u[1], &int1, &tau);
                     if (i > istart)
                     {
                         h[i + (i - 1) * ldh] = u[0];
@@ -1667,10 +1667,10 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
                     u[0] = 1.0;
 
                     tmp_int = kplusp - i;
-                    dlarf_("L", &nr, &tmp_int, u, &int1, &tau, &h[i + ldh*i], &ldh, workl);
+                    BLAS_FUNC(dlarf)("L", &nr, &tmp_int, u, &int1, &tau, &h[i + ldh*i], &ldh, workl);
                     ir = (i + 3 > iend ? iend : i + 3) + 1;
-                    dlarf_("R", &ir, &nr, u, &int1, &tau, &h[ldh*i], &ldh, workl);
-                    dlarf_("R", &kplusp, &nr, u, &int1, &tau, &q[ldq*i], &ldq, workl);
+                    BLAS_FUNC(dlarf)("R", &ir, &nr, u, &int1, &tau, &h[ldh*i], &ldh, workl);
+                    BLAS_FUNC(dlarf)("R", &kplusp, &nr, u, &int1, &tau, &q[ldq*i], &ldq, workl);
                     if (i < iend - 1)
                     {
                         u[0] = h[i+1 + i * ldh];
@@ -1690,11 +1690,11 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
         if (h[j+1 + ldh*j] < 0.0)
         {
             tmp_int = kplusp - j;
-            dscal_(&tmp_int, &dblm1, &h[j+1 + ldh*j], &ldh);
+            BLAS_FUNC(dscal)(&tmp_int, &dblm1, &h[j+1 + ldh*j], &ldh);
             tmp_int = (j+3 > kplusp ? kplusp : j+3);
-            dscal_(&tmp_int, &dblm1, &h[ldh*(j+1)], &int1);
+            BLAS_FUNC(dscal)(&tmp_int, &dblm1, &h[ldh*(j+1)], &int1);
             tmp_int = (j+np+2 > kplusp ? kplusp : j+np+2);
-            dscal_(&tmp_int, &dblm1, &q[ldq*(j+1)], &int1);
+            BLAS_FUNC(dscal)(&tmp_int, &dblm1, &q[ldq*(j+1)], &int1);
         }
     }
     // 120
@@ -1709,7 +1709,7 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
         tst1 = fabs(h[i + ldh*i]) + fabs(h[i+1 + ldh*(i+1)]);
         if (tst1 == 0.0)
         {
-            tst1 = dlanhs_("1", kev, h, &ldh, workl);
+            tst1 = BLAS_FUNC(dlanhs)("1", kev, h, &ldh, workl);
         }
         if (h[i+1 + ldh*i] <= fmax(ulp*tst1, smlnum))
         {
@@ -1726,7 +1726,7 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
 
     if (h[*kev + ldh*(*kev-1)] > 0.0)
     {
-        dgemv_("N", &n, &kplusp, &dbl1, v, &ldv, &q[(*kev)*ldq], &int1, &dbl0, &workd[n], &int1);
+        BLAS_FUNC(dgemv)("N", &n, &kplusp, &dbl1, v, &ldv, &q[(*kev)*ldq], &int1, &dbl0, &workd[n], &int1);
     }
 
     //  Compute column 1 to kev of (V*Q) in backward order
@@ -1735,21 +1735,21 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
     for (i = 0; i < *kev; i++)
     {
         tmp_int = kplusp - i;
-        dgemv_("N", &n, &tmp_int, &dbl1, v, &ldv, &q[(*kev-i-1)*ldq], &int1, &dbl0, workd, &int1);
-        dcopy_(&n, workd, &int1, &v[(kplusp-i-1)*ldv], &int1);
+        BLAS_FUNC(dgemv)("N", &n, &tmp_int, &dbl1, v, &ldv, &q[(*kev-i-1)*ldq], &int1, &dbl0, workd, &int1);
+        BLAS_FUNC(dcopy)(&n, workd, &int1, &v[(kplusp-i-1)*ldv], &int1);
     }
 
     //   Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev).
 
     for (i = 0; i < *kev; i++)
     {
-        dcopy_(&n, &v[(kplusp-*kev+i)*ldv], &int1, &v[i*ldv], &int1);
+        BLAS_FUNC(dcopy)(&n, &v[(kplusp-*kev+i)*ldv], &int1, &v[i*ldv], &int1);
     }
 
     //  Copy the (kev+1)-st column of (V*Q) in the appropriate place
 
     if (h[*kev + ldh*(*kev-1)] > 0.0){
-        dcopy_(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
+        BLAS_FUNC(dcopy)(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
     }
 
     //  Update the residual vector:
@@ -1758,11 +1758,11 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
     //     sigmak = (e_{kplusp}'*Q)*e_{kev}
     //     betak = e_{kev+1}'*H*e_{kev}
 
-    dscal_(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
+    BLAS_FUNC(dscal)(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
 
     if (h[*kev + ldh*(*kev-1)] > 0.0)
     {
-        daxpy_(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
+        BLAS_FUNC(daxpy)(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
     }
 
     return;
@@ -1771,7 +1771,7 @@ dnapps(int n, int* kev, int np, double* shiftr, double* shifti, double* v,
 
 
 void
-dngets(struct ARNAUD_state_d *V, int* kev, int* np,
+dngets(struct ARNAUD_state_d *V, CBLAS_INT* kev, CBLAS_INT* np,
        double* ritzr, double* ritzi, double* bounds)
 {
 
@@ -1837,10 +1837,10 @@ dngets(struct ARNAUD_state_d *V, int* kev, int* np,
 }
 
 void
-dgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
-       double* v, int ldv, double* resid, double* rnorm, int* ipntr, double* workd)
+dgetv0(struct ARNAUD_state_d *V, CBLAS_INT initv, CBLAS_INT n, CBLAS_INT j,
+       double* v, CBLAS_INT ldv, double* resid, double* rnorm, CBLAS_INT* ipntr, double* workd)
 {
-    int jj, int1 = 1;
+    CBLAS_INT jj; CBLAS_INT int1 = 1;
     const double sq2o2 = sqrt(2.0) / 2.0;
     double dbl1 = 1.0, dbl0 = 0.0, dblm1 = -1.0;
 
@@ -1874,12 +1874,12 @@ dgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
         {
             ipntr[0] = 0;
             ipntr[1] = n;
-            dcopy_(&n, resid, &int1, workd, &int1);
+            BLAS_FUNC(dcopy)(&n, resid, &int1, workd, &int1);
             V->ido = ido_RANDOM_OPX;
             return;
         } else if ((V->getv0_itry > 1) && (V->bmat == 1))
         {
-            dcopy_(&n, resid, &int1, &workd[n], &int1);
+            BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[n], &int1);
         }
     }
 
@@ -1897,7 +1897,7 @@ dgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
     V->getv0_first = 1;
     if (V->getv0_itry == 1)
     {
-        dcopy_(&n, &workd[n], &int1, resid, &int1);
+        BLAS_FUNC(dcopy)(&n, &workd[n], &int1, resid, &int1);
     }
     if (V->bmat)
     {
@@ -1906,7 +1906,7 @@ dgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
         V->ido = ido_BX;
         return;
     } else {
-        dcopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE20:
@@ -1914,10 +1914,10 @@ LINE20:
     V->getv0_first = 0;
     if (V->bmat)
     {
-        V->getv0_rnorm0 = ddot_(&n, resid, &int1, workd, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(ddot)(&n, resid, &int1, workd, &int1);
         V->getv0_rnorm0 = sqrt(fabs(V->getv0_rnorm0));
     } else {
-        V->getv0_rnorm0 = dnrm2_(&n, resid, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
     *rnorm = V->getv0_rnorm0;
 
@@ -1943,29 +1943,29 @@ LINE20:
 
 LINE30:
 
-    dgemv_("T", &n, &j, &dbl1, v, &ldv, workd, &int1, &dbl0, &workd[n], &int1);
-    dgemv_("N", &n, &j, &dblm1, v, &ldv, &workd[n], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(dgemv)("T", &n, &j, &dbl1, v, &ldv, workd, &int1, &dbl0, &workd[n], &int1);
+    BLAS_FUNC(dgemv)("N", &n, &j, &dblm1, v, &ldv, &workd[n], &int1, &dbl1, resid, &int1);
 
     //  Compute the B-norm of the orthogonalized starting vector
 
     if (V->bmat)
     {
-        dcopy_(&n, resid, &int1, &workd[n], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[n], &int1);
         ipntr[0] = n;
         ipntr[1] = 0;
         V->ido = ido_BX;
         return;
     } else {
-        dcopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE40:
     if (V->bmat)
     {
-        *rnorm = ddot_(&n, resid, &int1, workd, &int1);
+        *rnorm = BLAS_FUNC(ddot)(&n, resid, &int1, workd, &int1);
         *rnorm = sqrt(fabs(*rnorm));
     } else {
-        *rnorm = dnrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
 
     //  Check for further orthogonalization.
@@ -2000,9 +2000,9 @@ LINE40:
 
 
 static void
-dsortc(const enum ARNAUD_which w, const int apply, const int n, double* xreal, double* ximag, double* y)
+dsortc(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, double* xreal, double* ximag, double* y)
 {
-    int i, gap, pos;
+    CBLAS_INT i, gap, pos;
     double temp;
     ARNAUD_compare_cfunc *f;
 
@@ -2062,40 +2062,40 @@ dsortc(const enum ARNAUD_which w, const int apply, const int n, double* xreal, d
 
 
 // The void casts are to avoid compiler warnings for unused parameters
-int
+CBLAS_INT
 sortc_LM(const double xre, const double xim, const double xreigap, const double ximigap)
 {
     return (hypot(xre, xim) > hypot(xreigap, ximigap));
 }
 
-int
+CBLAS_INT
 sortc_SM(const double xre, const double xim, const double xreigap, const double ximigap)
 {
     return (hypot(xre, xim) < hypot(xreigap, ximigap));
 }
 
-int
+CBLAS_INT
 sortc_LR(const double xre, const double xim, const double xreigap, const double ximigap)
 {
     (void)xim; (void)ximigap;
     return (xre > xreigap);
 }
 
-int
+CBLAS_INT
 sortc_SR(const double xre, const double xim, const double xreigap, const double ximigap)
 {
     (void)xim; (void)ximigap;
     return (xre < xreigap);
 }
 
-int
+CBLAS_INT
 sortc_LI(const double xre, const double xim, const double xreigap, const double ximigap)
 {
     (void)xre; (void)xreigap;
     return (fabs(xim) > fabs(ximigap));
 }
 
-int
+CBLAS_INT
 sortc_SI(const double xre, const double xim, const double xreigap, const double ximigap)
 {
     (void)xre; (void)xreigap;

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double_complex.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_double_complex.c
@@ -1,27 +1,27 @@
 #include "arnaud_n_double_complex.h"
 #include <float.h>
 
-typedef int ARNAUD_compare_cfunc(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
-typedef int ARNAUD_compare_rfunc(const double, const double);
+typedef CBLAS_INT ARNAUD_compare_cfunc(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
+typedef CBLAS_INT ARNAUD_compare_rfunc(const double, const double);
 
 static const double unfl = DBL_MIN;    // 2.2250738585072014e-308
 // static const double ovfl = DBL_MAX; // 1.0 / 2.2250738585072014e-308;
 static const double ulp = DBL_EPSILON; // 2.220446049250313e-16;
 
-static ARNAUD_CPLX_TYPE zdotc_(const int* n, const ARNAUD_CPLX_TYPE* restrict x, const int* incx, const ARNAUD_CPLX_TYPE* restrict y, const int* incy);
-static void zgetv0(struct ARNAUD_state_d*, int, int, int, ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, double*, int*, ARNAUD_CPLX_TYPE*);
-static void znaup2(struct ARNAUD_state_d*, ARNAUD_CPLX_TYPE* , ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, int*, ARNAUD_CPLX_TYPE*, double*);
-static void znaitr(struct ARNAUD_state_d*, int, int, ARNAUD_CPLX_TYPE*, double*, ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, int, int*, ARNAUD_CPLX_TYPE*);
-static void znapps(int, int*, int, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*);
-static void zneigh(double*, int, ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, int, ARNAUD_CPLX_TYPE*, double*, int*);
-static void zngets(struct ARNAUD_state_d*, int*, int*, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*);
-static void zsortc(const enum ARNAUD_which w, const int apply, const int n, ARNAUD_CPLX_TYPE* x, ARNAUD_CPLX_TYPE* y);
-static int sortc_LM(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
-static int sortc_SM(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
-static int sortc_LR(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
-static int sortc_SR(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
-static int sortc_LI(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
-static int sortc_SI(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
+static ARNAUD_CPLX_TYPE zdotc_(const CBLAS_INT* n, const ARNAUD_CPLX_TYPE* restrict x, const CBLAS_INT* incx, const ARNAUD_CPLX_TYPE* restrict y, const CBLAS_INT* incy);
+static void zgetv0(struct ARNAUD_state_d*, CBLAS_INT, CBLAS_INT, CBLAS_INT, ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, double*, CBLAS_INT*, ARNAUD_CPLX_TYPE*);
+static void znaup2(struct ARNAUD_state_d*, ARNAUD_CPLX_TYPE* , ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, CBLAS_INT*, ARNAUD_CPLX_TYPE*, double*);
+static void znaitr(struct ARNAUD_state_d*, CBLAS_INT, CBLAS_INT, ARNAUD_CPLX_TYPE*, double*, ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, CBLAS_INT, CBLAS_INT*, ARNAUD_CPLX_TYPE*);
+static void znapps(CBLAS_INT, CBLAS_INT*, CBLAS_INT, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*);
+static void zneigh(double*, CBLAS_INT, ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*, CBLAS_INT, ARNAUD_CPLX_TYPE*, double*, CBLAS_INT*);
+static void zngets(struct ARNAUD_state_d*, CBLAS_INT*, CBLAS_INT*, ARNAUD_CPLX_TYPE*, ARNAUD_CPLX_TYPE*);
+static void zsortc(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, ARNAUD_CPLX_TYPE* x, ARNAUD_CPLX_TYPE* y);
+static CBLAS_INT sortc_LM(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
+static CBLAS_INT sortc_SM(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
+static CBLAS_INT sortc_LR(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
+static CBLAS_INT sortc_SR(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
+static CBLAS_INT sortc_LI(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
+static CBLAS_INT sortc_SI(const ARNAUD_CPLX_TYPE, const ARNAUD_CPLX_TYPE);
 
 enum ARNAUD_neupd_type {
     REGULAR,
@@ -32,15 +32,15 @@ enum ARNAUD_neupd_type {
 
 
 void
-ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
-       ARNAUD_CPLX_TYPE* d, ARNAUD_CPLX_TYPE* z, int ldz, ARNAUD_CPLX_TYPE sigma,
-       ARNAUD_CPLX_TYPE* workev, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPLX_TYPE* v, int ldv,
-       int* ipntr, ARNAUD_CPLX_TYPE* workd, ARNAUD_CPLX_TYPE* workl, double* rwork)
+ARNAUD_zneupd(struct ARNAUD_state_d *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select,
+       ARNAUD_CPLX_TYPE* d, ARNAUD_CPLX_TYPE* z, CBLAS_INT ldz, ARNAUD_CPLX_TYPE sigma,
+       ARNAUD_CPLX_TYPE* workev, ARNAUD_CPLX_TYPE* resid, ARNAUD_CPLX_TYPE* v, CBLAS_INT ldv,
+       CBLAS_INT* ipntr, ARNAUD_CPLX_TYPE* workd, ARNAUD_CPLX_TYPE* workl, double* rwork)
 {
     const double eps23 = pow(ulp, 2.0 / 3.0);
-    int ibd, ih, iheig, ihbds, iuptri, invsub, irz, j, jj;
-    int bounds, k, ldh, ldq, np, numcnv, outncv, reord, ritz;
-    int ierr = 0, int1 = 1, tmp_int = 0, nconv2 = 0;
+    CBLAS_INT ibd, ih, iheig, ihbds, iuptri, invsub, irz, j, jj;
+    CBLAS_INT bounds, k, ldh, ldq, np, numcnv, outncv, reord, ritz;
+    CBLAS_INT ierr = 0; CBLAS_INT int1 = 1; CBLAS_INT  tmp_int = 0, nconv2 = 0;
     double conds, sep, temp1, rtemp;
     ARNAUD_CPLX_TYPE rnorm, temp;
     ARNAUD_CPLX_TYPE cdbl0 = ARNAUD_cplx(0.0, 0.0);
@@ -165,7 +165,7 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         for (j = 1; j <= V->ncv; j++)
         {
             temp1 = fmax(eps23, cabs(workl[irz + V->ncv - j]));
-            jj = (int)creal(workl[bounds + V->ncv - j]);
+            jj = (CBLAS_INT)creal(workl[bounds + V->ncv - j]);
 
             if ((numcnv < V->nconv) && (cabs(workl[ibd + jj]) <= V->tol*temp1))
             {
@@ -193,11 +193,11 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  Initialize the Schur vector matrix Q to the identity.
 
         tmp_int = ldh*V->ncv;
-        zcopy_(&tmp_int, &workl[ih], &int1, &workl[iuptri], &int1);
-        zlaset_("A", &V->ncv, &V->ncv, &cdbl0, &cdbl1, &workl[invsub], &ldq);
-        zlahqr_(&int1, &int1, &V->ncv, &int1, &V->ncv, &workl[iuptri], &ldh,
+        BLAS_FUNC(zcopy)(&tmp_int, &workl[ih], &int1, &workl[iuptri], &int1);
+        BLAS_FUNC(zlaset)("A", &V->ncv, &V->ncv, &cdbl0, &cdbl1, &workl[invsub], &ldq);
+        BLAS_FUNC(zlahqr)(&int1, &int1, &V->ncv, &int1, &V->ncv, &workl[iuptri], &ldh,
                 &workl[iheig], &int1, &V->ncv, &workl[invsub], &ldq, &ierr);
-        zcopy_(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
+        BLAS_FUNC(zcopy)(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
 
         if (ierr != 0)
         {
@@ -210,7 +210,7 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
             //  Reorder the computed upper triangular matrix.
 
-            ztrsen_("N", "V", select, &V->ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq,
+            BLAS_FUNC(ztrsen)("N", "V", select, &V->ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq,
                     &workl[iheig], &nconv2, &conds, &sep, workev, &V->ncv, &ierr);
 
             if (nconv2 < V->nconv) { V->nconv = nconv2; }
@@ -225,21 +225,21 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  to compute the Ritz estimates of converged
         //  Ritz values.
 
-        zcopy_(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
+        BLAS_FUNC(zcopy)(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
 
         //  Place the computed eigenvalues of H into D
         //  if a spectral transformation was not used.
 
         if (TYP == REGULAR)
         {
-            zcopy_(&V->nconv, &workl[iheig], &int1, d, &int1);
+            BLAS_FUNC(zcopy)(&V->nconv, &workl[iheig], &int1, d, &int1);
         }
 
         //  Compute the QR factorization of the matrix representing
         //  the wanted invariant subspace located in the first NCONV
         //  columns of workl(invsub,ldq).
 
-        zgeqr2_(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
+        BLAS_FUNC(zgeqr2)(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
 
         //  * Postmultiply V by Q using zunm2r.
         //  * Copy the first NCONV columns of VQ into Z.
@@ -251,10 +251,10 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  associated with the upper triangular matrix of order
         //  NCONV in workl(iuptri).
 
-        zunm2r_("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq, workev, v, &ldv, &workd[V->n], &ierr);
-        zlacpy_("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
+        BLAS_FUNC(zunm2r)("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq, workev, v, &ldv, &workd[V->n], &ierr);
+        BLAS_FUNC(zlacpy)("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
 
-        for (int j = 0; j < V->nconv; j++)
+        for (CBLAS_INT j = 0; j < V->nconv; j++)
         {
 
             //  Perform both a column and row scaling if the
@@ -266,8 +266,8 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
             if (creal(workl[invsub + j*ldq + j]) < 0.0)
             {
-                zscal_(&V->nconv, &cdblm1, &workl[iuptri + j], &ldq);
-                zscal_(&V->nconv, &cdblm1, &workl[iuptri + j*ldq], &int1);
+                BLAS_FUNC(zscal)(&V->nconv, &cdblm1, &workl[iuptri + j], &ldq);
+                BLAS_FUNC(zscal)(&V->nconv, &cdblm1, &workl[iuptri + j*ldq], &int1);
             }
         }
         // 20
@@ -278,7 +278,7 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
             //  Compute the NCONV wanted eigenvectors of T
             //  located in workl(iuptri,ldq).
 
-            for (int j = 0; j < V->ncv; j++)
+            for (CBLAS_INT j = 0; j < V->ncv; j++)
             {
                 if (j < V->nconv)
                 {
@@ -289,7 +289,7 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
             }
             // 30
 
-            ztrevc_("R", "S", select, &V->ncv, &workl[iuptri], &ldq, vl, &int1,
+            BLAS_FUNC(ztrevc)("R", "S", select, &V->ncv, &workl[iuptri], &ldq, vl, &int1,
                     &workl[invsub], &ldq, &V->ncv, &outncv, workev, rwork, &ierr);
             if (ierr != 0)
             {
@@ -305,8 +305,8 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
             for (j = 0; j < V->nconv; j++)
             {
-                rtemp = 1.0 / dznrm2_(&V->ncv, &workl[invsub + j*ldq], &int1);
-                zdscal_(&V->ncv, &rtemp, &workl[invsub + j*ldq], &int1);
+                rtemp = 1.0 / BLAS_FUNC(dznrm2)(&V->ncv, &workl[invsub + j*ldq], &int1);
+                BLAS_FUNC(zdscal)(&V->ncv, &rtemp, &workl[invsub + j*ldq], &int1);
 
                 //  Ritz estimates can be obtained by taking
                 //  the inner product of the last row of the
@@ -321,11 +321,11 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
             //  Copy Ritz estimates into workl(ihbds)
 
-            zcopy_(&V->nconv, workev, &int1, &workl[ihbds], &int1);
+            BLAS_FUNC(zcopy)(&V->nconv, workev, &int1, &workl[ihbds], &int1);
 
             //  The eigenvector mactirx Q of T is triangular. Form Z*Q
 
-            ztrmm_("R", "U", "N", "N", &V->n, &V->nconv, &cdbl1, &workl[invsub], &ldq, z, &ldz);
+            BLAS_FUNC(ztrmm)("R", "U", "N", "N", &V->n, &V->nconv, &cdbl1, &workl[invsub], &ldq, z, &ldz);
 
         }
 
@@ -334,9 +334,9 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         // An approximate invariant subspace is not needed.
         // Place the Ritz values computed ZNAUPD into D.
 
-        zcopy_(&V->nconv, &workl[ritz], &int1, d, &int1);
-        zcopy_(&V->nconv, &workl[ritz], &int1, &workl[iheig], &int1);
-        zcopy_(&V->nconv, &workl[bounds], &int1, &workl[ihbds], &int1);
+        BLAS_FUNC(zcopy)(&V->nconv, &workl[ritz], &int1, d, &int1);
+        BLAS_FUNC(zcopy)(&V->nconv, &workl[ritz], &int1, &workl[iheig], &int1);
+        BLAS_FUNC(zcopy)(&V->nconv, &workl[bounds], &int1, &workl[ihbds], &int1);
 
     }
 
@@ -348,7 +348,7 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
     {
         if (rvec)
         {
-            zscal_(&V->ncv, &rnorm, &workl[ihbds], &int1);
+            BLAS_FUNC(zscal)(&V->ncv, &rnorm, &workl[ihbds], &int1);
         }
     } else {
 
@@ -358,7 +358,7 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
         if (rvec)
         {
-            zscal_(&V->ncv, &rnorm, &workl[ihbds], &int1);
+            BLAS_FUNC(zscal)(&V->ncv, &rnorm, &workl[ihbds], &int1);
         }
         for (k = 0; k < V->ncv; k++)
         {
@@ -430,7 +430,7 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  Perform a rank one update to Z and
         //  purify all the Ritz vectors together.
 
-        zgeru_(&V->n, &V->nconv, &cdbl1, resid, &int1, workev, &int1, z, &ldz);
+        BLAS_FUNC(zgeru)(&V->n, &V->nconv, &cdbl1, resid, &int1, workev, &int1, z, &ldz);
     }
 
     return;
@@ -439,10 +439,10 @@ ARNAUD_zneupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
 void
 ARNAUD_znaupd(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
-       ARNAUD_CPLX_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLX_TYPE* workd,
+       ARNAUD_CPLX_TYPE* v, CBLAS_INT ldv, CBLAS_INT* ipntr, ARNAUD_CPLX_TYPE* workd,
        ARNAUD_CPLX_TYPE* workl, double* rwork)
 {
-    int bounds, ierr = 0, ih, iq, iw, ldh, ldq, next, iritz;
+    CBLAS_INT bounds, ierr = 0, ih, iq, iw, ldh, ldq, next, iritz;
 
     if (V->ido == ido_FIRST)
     {
@@ -488,7 +488,7 @@ ARNAUD_znaupd(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
 
         V->np = V->ncv - V->nev;
 
-        for (int j = 0; j < 3 * (V->ncv*V->ncv) + 6*V->ncv; j++)
+        for (CBLAS_INT j = 0; j < 3 * (V->ncv*V->ncv) + 6*V->ncv; j++)
         {
             workl[j] = ARNAUD_cplx(0.0, 0.0);
         }
@@ -542,13 +542,13 @@ ARNAUD_znaupd(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
 
 static void
 znaup2(struct ARNAUD_state_d *V, ARNAUD_CPLX_TYPE* resid,
-       ARNAUD_CPLX_TYPE* v, int ldv, ARNAUD_CPLX_TYPE* h, int ldh,
+       ARNAUD_CPLX_TYPE* v, CBLAS_INT ldv, ARNAUD_CPLX_TYPE* h, CBLAS_INT ldh,
        ARNAUD_CPLX_TYPE* ritz, ARNAUD_CPLX_TYPE* bounds,
-       ARNAUD_CPLX_TYPE* q, int ldq, ARNAUD_CPLX_TYPE* workl, int* ipntr,
+       ARNAUD_CPLX_TYPE* q, CBLAS_INT ldq, ARNAUD_CPLX_TYPE* workl, CBLAS_INT* ipntr,
        ARNAUD_CPLX_TYPE* workd, double* rwork)
 {
     enum ARNAUD_which temp_which;
-    int i, int1 = 1, j, tmp_int;
+    CBLAS_INT i; CBLAS_INT int1 = 1; CBLAS_INT  j, tmp_int;
     const double eps23 = pow(ulp, 2.0 / 3.0);
     double temp = 0.0, rtemp;
 
@@ -698,9 +698,9 @@ LINE20:
     //  Make a copy of Ritz values and the corresponding
     //  Ritz estimates obtained from zneigh .
     tmp_int = V->aup2_kplusp * V->aup2_kplusp;
-    zcopy_(&V->aup2_kplusp, ritz, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(zcopy)(&V->aup2_kplusp, ritz, &int1, &workl[tmp_int], &int1);
     tmp_int += V->aup2_kplusp;
-    zcopy_(&V->aup2_kplusp, bounds, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(zcopy)(&V->aup2_kplusp, bounds, &int1, &workl[tmp_int], &int1);
 
     //  Select the wanted Ritz values and their bounds
     //  to be used in the convergence test.
@@ -736,7 +736,7 @@ LINE20:
     //  no shifts may be applied, then prepare to exit
 
     // We are modifying V->np hence the temporary variable.
-    int nptemp = V->np;
+    CBLAS_INT nptemp = V->np;
 
     for (j = 0; j < nptemp; j++)
     {
@@ -839,7 +839,7 @@ LINE20:
         //  To prevent possible stagnation, adjust the size
         //  of NEV.
 
-        int nevbef = V->aup2_nev;
+        CBLAS_INT nevbef = V->aup2_nev;
         V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
         if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6)) {
             V->aup2_nev = V->aup2_kplusp / 2;
@@ -883,7 +883,7 @@ LINE50:
         //  RITZR, RITZI to free up WORKL
         //  for non-exact shift case.
 
-        zcopy_(&V->np, workl, &int1, ritz, &int1);
+        BLAS_FUNC(zcopy)(&V->np, workl, &int1, ritz, &int1);
     }
 
     //  Apply the NP implicit shifts by QR bulge chasing.
@@ -900,7 +900,7 @@ LINE50:
     V->aup2_cnorm = 1;
     if (V->bmat)
     {
-        zcopy_(&V->n, resid, &int1, &workd[V->n], &int1);
+        BLAS_FUNC(zcopy)(&V->n, resid, &int1, &workd[V->n], &int1);
         ipntr[0] = V->n;
         ipntr[1] = 0;
         V->ido = ido_BX;
@@ -909,7 +909,7 @@ LINE50:
 
         return;
     } else {
-        zcopy_(&V->n, resid, &int1, workd, &int1);
+        BLAS_FUNC(zcopy)(&V->n, resid, &int1, workd, &int1);
     }
 
 LINE100:
@@ -921,7 +921,7 @@ LINE100:
     {
         V->aup2_rnorm = sqrt(cabs(zdotc_(&V->n, resid, &int1, workd, &int1)));
     } else {
-        V->aup2_rnorm = dznrm2_(&V->n, resid, &int1);
+        V->aup2_rnorm = BLAS_FUNC(dznrm2)(&V->n, resid, &int1);
     }
     V->aup2_cnorm = 0;
 
@@ -935,15 +935,15 @@ LINE100:
 
 
 static void
-znaitr(struct ARNAUD_state_d *V, int k, int np, ARNAUD_CPLX_TYPE* resid,
-       double* rnorm, ARNAUD_CPLX_TYPE* v, int ldv, ARNAUD_CPLX_TYPE* h, int ldh,
-       int* ipntr, ARNAUD_CPLX_TYPE* workd)
+znaitr(struct ARNAUD_state_d *V, CBLAS_INT k, CBLAS_INT np, ARNAUD_CPLX_TYPE* resid,
+       double* rnorm, ARNAUD_CPLX_TYPE* v, CBLAS_INT ldv, ARNAUD_CPLX_TYPE* h, CBLAS_INT ldh,
+       CBLAS_INT* ipntr, ARNAUD_CPLX_TYPE* workd)
 {
-    int i, infol, ipj, irj, ivj, jj, n, tmp_int;
+    CBLAS_INT i, infol, ipj, irj, ivj, jj, n, tmp_int;
     double smlnum = unfl * ( V->n / ulp);
     const double sq2o2 = sqrt(2.0) / 2.0;
 
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
     double dbl1 = 1.0, temp1, tst1;
     ARNAUD_CPLX_TYPE cdbl1 = ARNAUD_cplx(1.0, 0.0);
     ARNAUD_CPLX_TYPE cdblm1 = ARNAUD_cplx(-1.0, 0.0);
@@ -1040,23 +1040,23 @@ LINE40:
     //  when reciprocating a small RNORM, test against lower
     //  machine bound.
 
-    zcopy_(&n, resid, &int1, &v[ldv*V->aitr_j], &int1);
+    BLAS_FUNC(zcopy)(&n, resid, &int1, &v[ldv*V->aitr_j], &int1);
 
     if (*rnorm >= unfl)
     {
         temp1 = 1.0 / *rnorm;
-        zdscal_(&n, &temp1, &v[ldv*V->aitr_j], &int1);
-        zdscal_(&n, &temp1, &workd[ipj], &int1);
+        BLAS_FUNC(zdscal)(&n, &temp1, &v[ldv*V->aitr_j], &int1);
+        BLAS_FUNC(zdscal)(&n, &temp1, &workd[ipj], &int1);
     } else {
-        zlascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*V->aitr_j], &n, &infol);
-        zlascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
+        BLAS_FUNC(zlascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*V->aitr_j], &n, &infol);
+        BLAS_FUNC(zlascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
     }
 
     //  STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j}
     //  Note that this is not quite yet r_{j}. See STEP 4
 
     V->aitr_step3 = 1;
-    zcopy_(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
+    BLAS_FUNC(zcopy)(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
     ipntr[0] = ivj;
     ipntr[1] = irj;
     ipntr[2] = ipj;
@@ -1076,7 +1076,7 @@ LINE50:
 
     //  Put another copy of OP*v_{j} into RESID.
 
-    zcopy_(&n, &workd[irj], &int1, resid, &int1);
+    BLAS_FUNC(zcopy)(&n, &workd[irj], &int1, resid, &int1);
 
     //  STEP 4:  Finish extending the Arnoldi
     //           factorization to length j.
@@ -1092,7 +1092,7 @@ LINE50:
 
         return;
     } else {
-        zcopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(zcopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE60:
@@ -1110,7 +1110,7 @@ LINE60:
     {
         V->aitr_wnorm = sqrt(cabs(zdotc_(&n, resid, &int1, &workd[ipj], &int1)));
     } else {
-        V->aitr_wnorm = dznrm2_(&n, resid, &int1);
+        V->aitr_wnorm = BLAS_FUNC(dznrm2)(&n, resid, &int1);
     }
 
     //  Compute the j-th residual corresponding
@@ -1122,19 +1122,19 @@ LINE60:
     //  Compute the j Fourier coefficients w_{j}
     //  WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.
     tmp_int = V->aitr_j + 1;
-    zgemv_("C", &n, &tmp_int, &cdbl1, v, &ldv, &workd[ipj], &int1, &cdbl0, &h[ldh*(V->aitr_j)], &int1);
+    BLAS_FUNC(zgemv)("C", &n, &tmp_int, &cdbl1, v, &ldv, &workd[ipj], &int1, &cdbl0, &h[ldh*(V->aitr_j)], &int1);
 
     //  Orthogonalize r_{j} against V_{j}.
     //  RESID contains OP*v_{j}. See STEP 3.
 
-    zgemv_("N", &n, &tmp_int, &cdblm1, v, &ldv, &h[ldh*(V->aitr_j)], &int1, &cdbl1, resid, &int1);
+    BLAS_FUNC(zgemv)("N", &n, &tmp_int, &cdblm1, v, &ldv, &h[ldh*(V->aitr_j)], &int1, &cdbl1, resid, &int1);
 
     if (V->aitr_j > 0) { h[V->aitr_j + ldh*(V->aitr_j-1)] = ARNAUD_cplx(V->aitr_betaj, 0.0); }
 
     V->aitr_orth1 = 1;
     if (V->bmat)
     {
-        zcopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(zcopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1143,7 +1143,7 @@ LINE60:
 
         return;
     } else {
-        zcopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(zcopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE70:
@@ -1159,7 +1159,7 @@ LINE70:
     {
         *rnorm = sqrt(cabs(zdotc_(&n, resid, &int1, &workd[ipj], &int1)));
     } else {
-        *rnorm = dznrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(dznrm2)(&n, resid, &int1);
     }
 
     //  STEP 5: Re-orthogonalization / Iterative refinement phase
@@ -1191,21 +1191,21 @@ LINE80:
     //  Compute V_{j}^T * B * r_{j}.
     //  WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1).
     tmp_int = V->aitr_j + 1;
-    zgemv_("C", &n, &tmp_int, &cdbl1, v, &ldv, &workd[ipj], &int1, &cdbl0, &workd[irj], &int1);
+    BLAS_FUNC(zgemv)("C", &n, &tmp_int, &cdbl1, v, &ldv, &workd[ipj], &int1, &cdbl0, &workd[irj], &int1);
 
     //  Compute the correction to the residual:
     //  r_{j} = r_{j} - V_{j} * WORKD(IRJ:IRJ+J-1).
     //  The correction to H is v(:,1:J)*H(1:J,1:J)
     //  + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.
 
-    zgemv_("N", &n, &tmp_int, &cdblm1, v, &ldv, &workd[irj], &int1, &cdbl1, resid, &int1);
-    zaxpy_(&tmp_int, &cdbl1, &workd[irj], &int1, &h[ldh*(V->aitr_j)], &int1);
+    BLAS_FUNC(zgemv)("N", &n, &tmp_int, &cdblm1, v, &ldv, &workd[irj], &int1, &cdbl1, resid, &int1);
+    BLAS_FUNC(zaxpy)(&tmp_int, &cdbl1, &workd[irj], &int1, &h[ldh*(V->aitr_j)], &int1);
 
     V->aitr_orth2 = 1;
 
     if (V->bmat)
     {
-        zcopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(zcopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1215,7 +1215,7 @@ LINE80:
 
         return;
     } else {
-        zcopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(zcopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE90:
@@ -1227,7 +1227,7 @@ LINE90:
     {
         V->aitr_rnorm1 = sqrt(cabs(zdotc_(&n, resid, &int1, &workd[ipj], &int1)));
     } else {
-        V->aitr_rnorm1 = dznrm2_(&n, resid, &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(dznrm2)(&n, resid, &int1);
     }
 
     //  Determine if we need to perform another
@@ -1289,7 +1289,7 @@ LINE100:
                 tmp_int = k + np;
                 // zlanhs(norm, n, a, lda, work) with "work" being double type
                 // Recasting complex workspace to double for scratch space.
-                tst1 = zlanhs_("1", &tmp_int, h, &ldh, (double*)&workd[n]);
+                tst1 = BLAS_FUNC(zlanhs)("1", &tmp_int, h, &ldh, (double*)&workd[n]);
             }
             if (cabs(h[i+1 + ldh*i]) <= fmax(ulp*tst1, smlnum))
             {
@@ -1305,12 +1305,12 @@ LINE100:
 
 
 static void
-znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
-       int ldv, ARNAUD_CPLX_TYPE* h, int ldh, ARNAUD_CPLX_TYPE* resid,
-       ARNAUD_CPLX_TYPE* q, int ldq, ARNAUD_CPLX_TYPE* workl,
+znapps(CBLAS_INT n, CBLAS_INT* kev, CBLAS_INT np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
+       CBLAS_INT ldv, ARNAUD_CPLX_TYPE* h, CBLAS_INT ldh, ARNAUD_CPLX_TYPE* resid,
+       ARNAUD_CPLX_TYPE* q, CBLAS_INT ldq, ARNAUD_CPLX_TYPE* workl,
        ARNAUD_CPLX_TYPE* workd)
 {
-    int i, j, jj, int1 = 1, istart, iend = 0, tmp_int;
+    CBLAS_INT i, j, jj; CBLAS_INT int1 = 1; CBLAS_INT  istart, iend = 0, tmp_int;
     double smlnum = unfl * ( n / ulp);
     double c, tst1;
     double tmp_dbl;
@@ -1319,11 +1319,11 @@ znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
     ARNAUD_CPLX_TYPE cdbl1 = ARNAUD_cplx(1.0, 0.0);
     ARNAUD_CPLX_TYPE cdbl0 = ARNAUD_cplx(0.0, 0.0);
 
-    int kplusp = *kev + np;
+    CBLAS_INT kplusp = *kev + np;
 
     //  Initialize Q to the identity to accumulate
     //  the rotations and reflections
-    zlaset_("G", &kplusp, &kplusp, &cdbl0, &cdbl1, q, &ldq);
+    BLAS_FUNC(zlaset)("G", &kplusp, &kplusp, &cdbl0, &cdbl1, q, &ldq);
 
     //  Quick return if there are no shifts to apply
 
@@ -1347,7 +1347,7 @@ znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
                 if (tst1 == 0.0)
                 {
                     tmp_int = kplusp - jj;
-                    zlanhs_("1", &tmp_int, h, &ldh, (double*)workl);
+                    BLAS_FUNC(zlanhs)("1", &tmp_int, h, &ldh, (double*)workl);
                 }
                 if (fabs(creal(h[iend+1 + ldh*iend])) <= fmax(ulp*tst1, smlnum))
                 {
@@ -1383,20 +1383,20 @@ znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
 
                 //  Construct the plane rotation G to zero out the bulge
 
-                zlartg_(&f, &g, &c, &s, &r);
+                BLAS_FUNC(zlartg)(&f, &g, &c, &s, &r);
                 if (i > istart)
                 {
                     h[i + ldh*(i-1)] = r;
                     h[i + 1 + ldh*(i-1)] = ARNAUD_cplx(0.0, 0.0);
                 }
                 tmp_int = kplusp - i;
-                zrot_(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
+                BLAS_FUNC(zrot)(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
                 // z = a + bi, -conj(z) = -a + bi
                 s2 = conj(s);
                 tmp_int = (i + 2 > iend ? iend : i + 2) + 1;
-                zrot_(&tmp_int, &h[ldh*i], &int1, &h[ldh*(i+1)], &int1, &c, &s2);
+                BLAS_FUNC(zrot)(&tmp_int, &h[ldh*i], &int1, &h[ldh*(i+1)], &int1, &c, &s2);
                 tmp_int = (i + jj + 2 > kplusp ? kplusp : i + jj + 2);
-                zrot_(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s2);
+                BLAS_FUNC(zrot)(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s2);
 
                 if (i < iend - 1)
                 {
@@ -1421,13 +1421,13 @@ znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
 
             tmp_cplx = conj(t);
             tmp_int = kplusp - j;
-            zscal_(&tmp_int, &tmp_cplx, &h[j+1 + ldh*j], &ldh);
+            BLAS_FUNC(zscal)(&tmp_int, &tmp_cplx, &h[j+1 + ldh*j], &ldh);
 
             tmp_int = (j+3 > kplusp ? kplusp : j+3);
-            zscal_(&tmp_int, &t, &h[ldh*(j+1)], &int1);
+            BLAS_FUNC(zscal)(&tmp_int, &t, &h[ldh*(j+1)], &int1);
 
             tmp_int = (j+np+2 > kplusp ? kplusp : j+np+2);
-            zscal_(&tmp_int, &t, &q[ldq*(j+1)], &int1);
+            BLAS_FUNC(zscal)(&tmp_int, &t, &q[ldq*(j+1)], &int1);
 
             h[j+1 + ldh*j] = ARNAUD_cplx(creal(h[j+1 + ldh*j]), 0.0);
         }
@@ -1448,7 +1448,7 @@ znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
                fabs(cimag(h[i + ldh*i])) + fabs(cimag(h[i+1 + ldh*(i+1)]));
         if (tst1 == 0.0)
         {
-            tst1 = zlanhs_("1", kev, h, &ldh, (double*)workl);
+            tst1 = BLAS_FUNC(zlanhs)("1", kev, h, &ldh, (double*)workl);
         }
         if (creal(h[i+1 + ldh*i]) <= fmax(ulp*tst1, smlnum))
         {
@@ -1465,7 +1465,7 @@ znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
 
     if (creal(h[*kev + ldh*(*kev-1)]) > 0.0)
     {
-        zgemv_("N", &n, &kplusp, &cdbl1, v, &ldv, &q[(*kev)*ldq], &int1, &cdbl0, &workd[n], &int1);
+        BLAS_FUNC(zgemv)("N", &n, &kplusp, &cdbl1, v, &ldv, &q[(*kev)*ldq], &int1, &cdbl0, &workd[n], &int1);
     }
 
     //  Compute column 1 to kev of (V*Q) in backward order
@@ -1474,18 +1474,18 @@ znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
     for (i = 0; i < *kev; i++)
     {
         tmp_int = kplusp - i;
-        zgemv_("N", &n, &tmp_int, &cdbl1, v, &ldv, &q[(*kev-i-1)*ldq], &int1, &cdbl0, workd, &int1);
-        zcopy_(&n, workd, &int1, &v[(kplusp-i-1)*ldv], &int1);
+        BLAS_FUNC(zgemv)("N", &n, &tmp_int, &cdbl1, v, &ldv, &q[(*kev-i-1)*ldq], &int1, &cdbl0, workd, &int1);
+        BLAS_FUNC(zcopy)(&n, workd, &int1, &v[(kplusp-i-1)*ldv], &int1);
     }
 
     //   Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev).
 
-    zlacpy_("A", &n, kev, &v[ldv*(kplusp - *kev)], &ldv, v, &ldv);
+    BLAS_FUNC(zlacpy)("A", &n, kev, &v[ldv*(kplusp - *kev)], &ldv, v, &ldv);
 
     //  Copy the (kev+1)-st column of (V*Q) in the appropriate place
 
     if (creal(h[*kev + ldh*(*kev-1)]) > 0.0) {
-        zcopy_(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
+        BLAS_FUNC(zcopy)(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
     }
 
     //  Update the residual vector:
@@ -1494,11 +1494,11 @@ znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
     //     sigmak = (e_{kplusp}'*Q)*e_{kev}
     //     betak = e_{kev+1}'*H*e_{kev}
 
-    zscal_(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
+    BLAS_FUNC(zscal)(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
 
     if (creal(h[*kev + ldh*(*kev-1)]) > 0.0)
     {
-        zaxpy_(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
+        BLAS_FUNC(zaxpy)(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
     }
 
     return;
@@ -1506,12 +1506,12 @@ znapps(int n, int* kev, int np, ARNAUD_CPLX_TYPE* shift, ARNAUD_CPLX_TYPE* v,
 
 
 static void
-zneigh(double* rnorm, int n, ARNAUD_CPLX_TYPE* h, int ldh, ARNAUD_CPLX_TYPE* ritz,
-       ARNAUD_CPLX_TYPE* bounds, ARNAUD_CPLX_TYPE* q, int ldq, ARNAUD_CPLX_TYPE* workl,
-       double* rwork, int* ierr)
+zneigh(double* rnorm, CBLAS_INT n, ARNAUD_CPLX_TYPE* h, CBLAS_INT ldh, ARNAUD_CPLX_TYPE* ritz,
+       ARNAUD_CPLX_TYPE* bounds, ARNAUD_CPLX_TYPE* q, CBLAS_INT ldq, ARNAUD_CPLX_TYPE* workl,
+       double* rwork, CBLAS_INT* ierr)
 {
-    int select[1] = { 0 };
-    int int1 = 1, j;
+    CBLAS_INT select[1] = { 0 };
+    CBLAS_INT int1 = 1, j;
     double temp;
     ARNAUD_CPLX_TYPE vl[1];
     vl[0] = ARNAUD_cplx(0.0, 0.0);
@@ -1523,19 +1523,19 @@ zneigh(double* rnorm, int n, ARNAUD_CPLX_TYPE* h, int ldh, ARNAUD_CPLX_TYPE* rit
     //     zlahqr returns the full Schur form of H
     //     in WORKL(1:N**2), and the Schur vectors in q.
 
-    zlacpy_("A", &n, &n, h, &ldh, workl, &n);
-    zlaset_("A", &n, &n, &c0, &c1, q, &ldq);
-    zlahqr_(&int1, &int1, &n, &int1, &n, workl, &ldh, ritz, &int1, &n, q, &ldq, ierr);
+    BLAS_FUNC(zlacpy)("A", &n, &n, h, &ldh, workl, &n);
+    BLAS_FUNC(zlaset)("A", &n, &n, &c0, &c1, q, &ldq);
+    BLAS_FUNC(zlahqr)(&int1, &int1, &n, &int1, &n, workl, &ldh, ritz, &int1, &n, q, &ldq, ierr);
 
     if (*ierr != 0) { return; }
 
-    zcopy_(&n, &q[n-2], &ldq, bounds, &int1);
+    BLAS_FUNC(zcopy)(&n, &q[n-2], &ldq, bounds, &int1);
 
     //  2. Compute the eigenvectors of the full Schur form T and
     //     apply the Schur vectors to get the corresponding
     //     eigenvectors.
 
-    ztrevc_("R", "B", select, &n, workl, &n, vl, &n, q, &ldq, &n, &n, &workl[n*n], rwork, ierr);
+    BLAS_FUNC(ztrevc)("R", "B", select, &n, workl, &n, vl, &n, q, &ldq, &n, &n, &workl[n*n], rwork, ierr);
 
     if (*ierr != 0) { return; }
 
@@ -1548,21 +1548,21 @@ zneigh(double* rnorm, int n, ARNAUD_CPLX_TYPE* h, int ldh, ARNAUD_CPLX_TYPE* rit
 
     for (j = 0; j < n; j++)
     {
-        temp = 1.0 / dznrm2_(&n, &q[j*ldq], &int1);
-        zdscal_(&n, &temp, &q[j*ldq], &int1);
+        temp = 1.0 / BLAS_FUNC(dznrm2)(&n, &q[j*ldq], &int1);
+        BLAS_FUNC(zdscal)(&n, &temp, &q[j*ldq], &int1);
     }
 
     //  Compute the Ritz estimates
 
-    zcopy_(&n, &q[n-1], &n, bounds, &int1);
-    zdscal_(&n, rnorm, bounds, &int1);
+    BLAS_FUNC(zcopy)(&n, &q[n-1], &n, bounds, &int1);
+    BLAS_FUNC(zdscal)(&n, rnorm, bounds, &int1);
 
     return;
 }
 
 
 static void
-zngets(struct ARNAUD_state_d *V, int* kev, int* np,
+zngets(struct ARNAUD_state_d *V, CBLAS_INT* kev, CBLAS_INT* np,
        ARNAUD_CPLX_TYPE* ritz, ARNAUD_CPLX_TYPE* bounds)
 {
 
@@ -1586,11 +1586,11 @@ zngets(struct ARNAUD_state_d *V, int* kev, int* np,
 
 
 static void
-zgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
-       ARNAUD_CPLX_TYPE* v, int ldv, ARNAUD_CPLX_TYPE* resid, double* rnorm,
-       int* ipntr, ARNAUD_CPLX_TYPE* workd)
+zgetv0(struct ARNAUD_state_d *V, CBLAS_INT initv, CBLAS_INT n, CBLAS_INT j,
+       ARNAUD_CPLX_TYPE* v, CBLAS_INT ldv, ARNAUD_CPLX_TYPE* resid, double* rnorm,
+       CBLAS_INT* ipntr, ARNAUD_CPLX_TYPE* workd)
 {
-    int jj, int1 = 1;
+    CBLAS_INT jj; CBLAS_INT int1 = 1;
     const double sq2o2 = sqrt(2.0) / 2.0;
     ARNAUD_CPLX_TYPE c0 = ARNAUD_cplx(0.0, 0.0);
     ARNAUD_CPLX_TYPE c1 = ARNAUD_cplx(1.0, 0.0);
@@ -1629,12 +1629,12 @@ zgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
         {
             ipntr[0] = 0;
             ipntr[1] = n;
-            zcopy_(&n, resid, &int1, workd, &int1);
+            BLAS_FUNC(zcopy)(&n, resid, &int1, workd, &int1);
             V->ido = ido_RANDOM_OPX;
             return;
         } else if ((V->getv0_itry > 1) && (V->bmat == 1))
         {
-            zcopy_(&n, resid, &int1, &workd[n], &int1);
+            BLAS_FUNC(zcopy)(&n, resid, &int1, &workd[n], &int1);
         }
     }
 
@@ -1652,7 +1652,7 @@ zgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
     V->getv0_first = 1;
     if (V->getv0_itry == 1)
     {
-        zcopy_(&n, &workd[n], &int1, resid, &int1);
+        BLAS_FUNC(zcopy)(&n, &workd[n], &int1, resid, &int1);
     }
     if (V->bmat)
     {
@@ -1661,7 +1661,7 @@ zgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
         V->ido = ido_BX;
         return;
     } else {
-        zcopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(zcopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE20:
@@ -1670,7 +1670,7 @@ LINE20:
     {
         V->getv0_rnorm0 = sqrt(cabs(zdotc_(&n, resid, &int1, workd, &int1)));
     } else {
-        V->getv0_rnorm0 = dznrm2_(&n, resid, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(dznrm2)(&n, resid, &int1);
     }
     *rnorm = V->getv0_rnorm0;
 
@@ -1696,20 +1696,20 @@ LINE20:
 
 LINE30:
 
-    zgemv_("C", &n, &j, &c1, v, &ldv, workd, &int1, &c0, &workd[n], &int1);
-    zgemv_("N", &n, &j, &cm1, v, &ldv, &workd[n], &int1, &c1, resid, &int1);
+    BLAS_FUNC(zgemv)("C", &n, &j, &c1, v, &ldv, workd, &int1, &c0, &workd[n], &int1);
+    BLAS_FUNC(zgemv)("N", &n, &j, &cm1, v, &ldv, &workd[n], &int1, &c1, resid, &int1);
 
     //  Compute the B-norm of the orthogonalized starting vector
 
     if (V->bmat)
     {
-        zcopy_(&n, resid, &int1, &workd[n], &int1);
+        BLAS_FUNC(zcopy)(&n, resid, &int1, &workd[n], &int1);
         ipntr[0] = n;
         ipntr[1] = 0;
         V->ido = ido_BX;
         return;
     } else {
-        zcopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(zcopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE40:
@@ -1718,7 +1718,7 @@ LINE40:
     {
         *rnorm = sqrt(cabs(zdotc_(&n, resid, &int1, workd, &int1)));
     } else {
-        *rnorm = dznrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(dznrm2)(&n, resid, &int1);
     }
 
     //  Check for further orthogonalization.
@@ -1753,9 +1753,9 @@ LINE40:
 
 
 static void
-zsortc(const enum ARNAUD_which w, const int apply, const int n, ARNAUD_CPLX_TYPE* x, ARNAUD_CPLX_TYPE* y)
+zsortc(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, ARNAUD_CPLX_TYPE* x, ARNAUD_CPLX_TYPE* y)
 {
-    int i, gap, pos;
+    CBLAS_INT i, gap, pos;
     ARNAUD_CPLX_TYPE temp;
     ARNAUD_compare_cfunc *f;
 
@@ -1811,19 +1811,19 @@ zsortc(const enum ARNAUD_which w, const int apply, const int n, ARNAUD_CPLX_TYPE
 }
 
 
-static int sortc_LM(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (cabs(x) > cabs(y)); }
-static int sortc_SM(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (cabs(x) < cabs(y)); }
-static int sortc_LR(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (creal(x) > creal(y)); }
-static int sortc_SR(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (creal(x) < creal(y)); }
-static int sortc_LI(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (cimag(x) > cimag(y)); }
-static int sortc_SI(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (cimag(x) < cimag(y)); }
+static CBLAS_INT sortc_LM(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (cabs(x) > cabs(y)); }
+static CBLAS_INT sortc_SM(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (cabs(x) < cabs(y)); }
+static CBLAS_INT sortc_LR(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (creal(x) > creal(y)); }
+static CBLAS_INT sortc_SR(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (creal(x) < creal(y)); }
+static CBLAS_INT sortc_LI(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (cimag(x) > cimag(y)); }
+static CBLAS_INT sortc_SI(const ARNAUD_CPLX_TYPE x, const ARNAUD_CPLX_TYPE y) { return (cimag(x) < cimag(y)); }
 
 
 // zdotc is the complex conjugate dot product of two complex vectors.
 // Due some historical reasons, this function can cause segfaults on some
 // platforms. Hence implemented here instead of using the BLAS version.
 static ARNAUD_CPLX_TYPE
-zdotc_(const int* n, const ARNAUD_CPLX_TYPE* restrict x, const int* incx, const ARNAUD_CPLX_TYPE* restrict y, const int* incy)
+zdotc_(const CBLAS_INT* n, const ARNAUD_CPLX_TYPE* restrict x, const CBLAS_INT* incx, const ARNAUD_CPLX_TYPE* restrict y, const CBLAS_INT* incy)
 {
     ARNAUD_CPLX_TYPE result = ARNAUD_cplx(0.0, 0.0);
 #ifdef _MSC_VER
@@ -1831,10 +1831,10 @@ zdotc_(const int* n, const ARNAUD_CPLX_TYPE* restrict x, const int* incx, const 
 #endif
     if (*n <= 0) { return result; }
 
-    int ix, iy;
+    CBLAS_INT ix, iy;
     if ((*incx == 1) && (*incy == 1))
     {
-        for (int i = 0; i < *n; i++)
+        for (CBLAS_INT i = 0; i < *n; i++)
         {
 #ifdef _MSC_VER
             temp = _Cmulcc(x[i], conj(y[i]));
@@ -1849,7 +1849,7 @@ zdotc_(const int* n, const ARNAUD_CPLX_TYPE* restrict x, const int* incx, const 
         ix = (*incx >= 0) ? 0 : (-(*n-1) * (*incx));
         iy = (*incy >= 0) ? 0 : (-(*n-1) * (*incy));
 
-        for (int i = 0; i < *n; i++)
+        for (CBLAS_INT i = 0; i < *n; i++)
         {
 #ifdef _MSC_VER
             temp = _Cmulcc(x[ix], conj(y[iy]));

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single.c
@@ -1,27 +1,27 @@
 #include "arnaud_n_single.h"
 #include <float.h>
 
-typedef int ARNAUD_compare_cfunc(const float, const float, const float, const float);
+typedef CBLAS_INT ARNAUD_compare_cfunc(const float, const float, const float, const float);
 
-static int sortc_LM(const float, const float, const float, const float);
-static int sortc_SM(const float, const float, const float, const float);
-static int sortc_LR(const float, const float, const float, const float);
-static int sortc_SR(const float, const float, const float, const float);
-static int sortc_LI(const float, const float, const float, const float);
-static int sortc_SI(const float, const float, const float, const float);
+static CBLAS_INT sortc_LM(const float, const float, const float, const float);
+static CBLAS_INT sortc_SM(const float, const float, const float, const float);
+static CBLAS_INT sortc_LR(const float, const float, const float, const float);
+static CBLAS_INT sortc_SR(const float, const float, const float, const float);
+static CBLAS_INT sortc_LI(const float, const float, const float, const float);
+static CBLAS_INT sortc_SI(const float, const float, const float, const float);
 
 static const float unfl = FLT_MIN;    // 1.1754943508222875e-38;
 // static const float ovfl = FLT_MAX; // 1.0 / 1.1754943508222875e-38;
 static const float ulp = FLT_EPSILON; // 1.1920928955078125e-07;
 
-static void snaup2(struct ARNAUD_state_s*, float*, float*, int, float*, int, float*, float*, float*, float*, int, float*, int*, float*);
-static void snconv(int n, float* ritzr, float* ritzi, float* bounds, const float tol, int* nconv);
-static void sneigh(float*,int,float*,int,float*,float*,float*,float*,int,float*,int*);
-static void snaitr(struct ARNAUD_state_s*,int,int,float*,float*,float*,int,float*,int,int*,float*);
-static void snapps(int,int*,int,float*,float*,float*,int,float*,int,float*,float*,int,float*,float*);
-static void sngets(struct ARNAUD_state_s*,int*,int*,float*,float*,float*);
-static void ssortc(const enum ARNAUD_which w, const int apply, const int n, float* xreal, float* ximag, float* y);
-static void sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j, float* v, int ldv, float* resid, float* rnorm, int* ipntr, float* workd);
+static void snaup2(struct ARNAUD_state_s*, float*, float*, CBLAS_INT, float*, CBLAS_INT, float*, float*, float*, float*, CBLAS_INT, float*, CBLAS_INT*, float*);
+static void snconv(CBLAS_INT n, float* ritzr, float* ritzi, float* bounds, const float tol, CBLAS_INT* nconv);
+static void sneigh(float*,CBLAS_INT,float*,CBLAS_INT,float*,float*,float*,float*,CBLAS_INT,float*,CBLAS_INT*);
+static void snaitr(struct ARNAUD_state_s*,CBLAS_INT,CBLAS_INT,float*,float*,float*,CBLAS_INT,float*,CBLAS_INT,CBLAS_INT*,float*);
+static void snapps(CBLAS_INT,CBLAS_INT*,CBLAS_INT,float*,float*,float*,CBLAS_INT,float*,CBLAS_INT,float*,float*,CBLAS_INT,float*,float*);
+static void sngets(struct ARNAUD_state_s*,CBLAS_INT*,CBLAS_INT*,float*,float*,float*);
+static void ssortc(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, float* xreal, float* ximag, float* y);
+static void sgetv0(struct ARNAUD_state_s *V, CBLAS_INT initv, CBLAS_INT n, CBLAS_INT j, float* v, CBLAS_INT ldv, float* resid, float* rnorm, CBLAS_INT* ipntr, float* workd);
 
 enum ARNAUD_neupd_type {
     REGULAR = 0,
@@ -32,16 +32,16 @@ enum ARNAUD_neupd_type {
 
 
 void
-ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
-       float* dr, float* di, float* z, int ldz, float sigmar, float sigmai,
-       float* workev, float* resid, float* v, int ldv, int* ipntr, float* workd,
+ARNAUD_sneupd(struct ARNAUD_state_s *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select,
+       float* dr, float* di, float* z, CBLAS_INT ldz, float sigmar, float sigmai,
+       float* workev, float* resid, float* v, CBLAS_INT ldv, CBLAS_INT* ipntr, float* workd,
        float* workl)
 {
     const float eps23 = powf(ulp, 2.0f / 3.0f);
-    int ibd, iconj, ih, iheigr, iheigi, ihbds, iuptri, invsub, iri, irr, j, jj;
-    int bounds, k, ldh, ldq, np, numcnv, reord, ritzr, ritzi;
-    int iwork[1] = { 0 };
-    int ierr = 0, int1 = 1, tmp_int = 0, nconv2 = 0, outncv;
+    CBLAS_INT ibd, iconj, ih, iheigr, iheigi, ihbds, iuptri, invsub, iri, irr, j, jj;
+    CBLAS_INT bounds, k, ldh, ldq, np, numcnv, reord, ritzr, ritzi;
+    CBLAS_INT iwork[1] = { 0 };
+    CBLAS_INT ierr = 0; CBLAS_INT int1 = 1; CBLAS_INT  tmp_int = 0, nconv2 = 0, outncv;
     float conds, rnorm, sep, temp, temp1, dbl0 = 0.0f, dbl1 = 1.0f, dblm1 = -1.0f;
     float vl[1] = { 0.0f };
     enum ARNAUD_neupd_type TYP;
@@ -166,7 +166,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         {
             temp1 = fmaxf(eps23, hypotf(workl[irr + V->ncv - j], workl[iri + V->ncv - j]));
 
-            jj = (int)workl[bounds + V->ncv - j];
+            jj = (CBLAS_INT)workl[bounds + V->ncv - j];
 
             if ((numcnv < V->nconv) && (workl[ibd + jj] <= V->tol*temp1))
             {
@@ -194,12 +194,12 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  Initialize the Schur vector matrix Q to the identity.
 
         tmp_int = ldh*V->ncv;
-        scopy_(&tmp_int, &workl[ih], &int1, &workl[iuptri], &int1);
-        slaset_("A", &V->ncv, &V->ncv, &dbl0, &dbl1, &workl[invsub], &ldq);
-        slahqr_(&int1, &int1, &V->ncv, &int1, &V->ncv, &workl[iuptri], &ldh,
+        BLAS_FUNC(scopy)(&tmp_int, &workl[ih], &int1, &workl[iuptri], &int1);
+        BLAS_FUNC(slaset)("A", &V->ncv, &V->ncv, &dbl0, &dbl1, &workl[invsub], &ldq);
+        BLAS_FUNC(slahqr)(&int1, &int1, &V->ncv, &int1, &V->ncv, &workl[iuptri], &ldh,
                 &workl[iheigr], &workl[iheigi], &int1, &V->ncv, &workl[invsub],
                 &ldq, &ierr);
-        scopy_(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
+        BLAS_FUNC(scopy)(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
 
         if (ierr != 0)
         {
@@ -209,7 +209,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
         if (reord)
         {
-            strsen_("N", "V", select, &V->ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq,
+            BLAS_FUNC(strsen)("N", "V", select, &V->ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq,
                     &workl[iheigr], &workl[iheigi], &nconv2, &conds, &sep, &workl[ihbds],
                     &V->ncv, iwork, &int1, &ierr);
 
@@ -225,21 +225,21 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  to compute the Ritz estimates of
         //  converged Ritz values.
 
-        scopy_(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
+        BLAS_FUNC(scopy)(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
 
         //  Place the computed eigenvalues of H into DR and DI
         //  if a spectral transformation was not used.
 
         if (TYP == REGULAR) {
-            scopy_(&V->nconv, &workl[iheigr], &int1, dr, &int1);
-            scopy_(&V->nconv, &workl[iheigi], &int1, di, &int1);
+            BLAS_FUNC(scopy)(&V->nconv, &workl[iheigr], &int1, dr, &int1);
+            BLAS_FUNC(scopy)(&V->nconv, &workl[iheigi], &int1, di, &int1);
         }
 
         //  Compute the QR factorization of the matrix representing
         //  the wanted invariant subspace located in the first NCONV
         //  columns of workl(invsub,ldq).
 
-        sgeqr2_(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
+        BLAS_FUNC(sgeqr2)(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
 
         //  * Postmultiply V by Q using dorm2r .
         //  * Copy the first NCONV columns of VQ into Z.
@@ -251,10 +251,10 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  vectors associated with the real upper quasi-triangular
         //  matrix of order NCONV in workl(iuptri)
 
-        sorm2r_("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq, workev,
+        BLAS_FUNC(sorm2r)("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq, workev,
                 v, &ldv, &workd[V->n], &ierr);
 
-        slacpy_("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
+        BLAS_FUNC(slacpy)("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
 
         //  Perform both a column and row scaling if the
         //  diagonal element of workl(invsub,ldq) is negative
@@ -267,8 +267,8 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         {
             if (workl[invsub + j*ldq + j] < 0.0f)
             {
-                sscal_(&V->nconv, &dblm1, &workl[iuptri + j], &ldq);
-                sscal_(&V->nconv, &dblm1, &workl[iuptri + j*ldq], &int1);
+                BLAS_FUNC(sscal)(&V->nconv, &dblm1, &workl[iuptri + j], &ldq);
+                BLAS_FUNC(sscal)(&V->nconv, &dblm1, &workl[iuptri + j*ldq], &int1);
             }
         }
         // 20
@@ -290,7 +290,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             }
             // 30
 
-            strevc_("R", "S", select, &V->ncv, &workl[iuptri], &ldq, vl, &int1,
+            BLAS_FUNC(strevc)("R", "S", select, &V->ncv, &workl[iuptri], &ldq, vl, &int1,
                     &workl[invsub], &ldq, &V->ncv, &outncv, workev, &ierr);
 
             if (ierr != 0)
@@ -313,8 +313,8 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
                     //  real eigenvalue case
 
-                    temp = 1.0f / snrm2_(&V->ncv, &workl[invsub + j*ldq], &int1);
-                    sscal_(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
+                    temp = 1.0f / BLAS_FUNC(snrm2)(&V->ncv, &workl[invsub + j*ldq], &int1);
+                    BLAS_FUNC(sscal)(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
 
                 } else {
 
@@ -326,10 +326,10 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
                     if (iconj == 0)
                     {
-                        temp = 1.0f / hypotf(snrm2_(&V->ncv, &workl[invsub + j*ldq], &int1),
-                                           snrm2_(&V->ncv, &workl[invsub + (j+1)*ldq], &int1));
-                        sscal_(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
-                        sscal_(&V->ncv, &temp, &workl[invsub + (j+1)*ldq], &int1);
+                        temp = 1.0f / hypotf(BLAS_FUNC(snrm2)(&V->ncv, &workl[invsub + j*ldq], &int1),
+                                           BLAS_FUNC(snrm2)(&V->ncv, &workl[invsub + (j+1)*ldq], &int1));
+                        BLAS_FUNC(sscal)(&V->ncv, &temp, &workl[invsub + j*ldq], &int1);
+                        BLAS_FUNC(sscal)(&V->ncv, &temp, &workl[invsub + (j+1)*ldq], &int1);
                         iconj = 1;
                     } else {
                         iconj = 0;
@@ -338,7 +338,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             }
             // 40
 
-            sgemv_("T", &V->ncv, &V->nconv, &dbl1, &workl[invsub], &ldq, &workl[ihbds], &int1, &dbl0, workev, &int1);
+            BLAS_FUNC(sgemv)("T", &V->ncv, &V->nconv, &dbl1, &workl[invsub], &ldq, &workl[ihbds], &int1, &dbl0, workev, &int1);
 
             iconj = 0;
             for (j = 0; j < V->nconv; j++)
@@ -364,13 +364,13 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
             //  Copy Ritz estimates into workl(ihbds)
 
-            scopy_(&V->nconv, workev, &int1, &workl[ihbds], &int1);
+            BLAS_FUNC(scopy)(&V->nconv, workev, &int1, &workl[ihbds], &int1);
 
             //  Compute the QR factorization of the eigenvector matrix
             //  associated with leading portion of T in the first NCONV
             //  columns of workl(invsub,ldq).
 
-            sgeqr2_(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
+            BLAS_FUNC(sgeqr2)(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
 
             //  * Postmultiply Z by Q.
             //  * Postmultiply Z by R.
@@ -378,10 +378,10 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             //  Ritz vectors associated with the Ritz values
             //  in workl(iheigr) and workl(iheigi).
 
-            sorm2r_("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq,
+            BLAS_FUNC(sorm2r)("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq,
                     workev, z, &ldz, &workd[V->n], &ierr);
 
-            strmm_("R", "U", "N", "N", &V->n, &V->nconv, &dbl1, &workl[invsub], &ldq, z, &ldz);
+            BLAS_FUNC(strmm)("R", "U", "N", "N", &V->n, &V->nconv, &dbl1, &workl[invsub], &ldq, z, &ldz);
 
         }
 
@@ -390,11 +390,11 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  An approximate invariant subspace is not needed.
         //  Place the Ritz values computed DNAUPD  into DR and DI
 
-        scopy_(&V->nconv, &workl[ritzr], &int1, dr, &int1);
-        scopy_(&V->nconv, &workl[ritzi], &int1, di, &int1);
-        scopy_(&V->nconv, &workl[ritzr], &int1, &workl[iheigr], &int1);
-        scopy_(&V->nconv, &workl[ritzi], &int1, &workl[iheigi], &int1);
-        scopy_(&V->nconv, &workl[bounds], &int1, &workl[ihbds], &int1);
+        BLAS_FUNC(scopy)(&V->nconv, &workl[ritzr], &int1, dr, &int1);
+        BLAS_FUNC(scopy)(&V->nconv, &workl[ritzi], &int1, di, &int1);
+        BLAS_FUNC(scopy)(&V->nconv, &workl[ritzr], &int1, &workl[iheigr], &int1);
+        BLAS_FUNC(scopy)(&V->nconv, &workl[ritzi], &int1, &workl[iheigi], &int1);
+        BLAS_FUNC(scopy)(&V->nconv, &workl[bounds], &int1, &workl[ihbds], &int1);
     }
 
     //  Transform the Ritz values and possibly vectors
@@ -405,7 +405,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
     {
         if (rvec)
         {
-            sscal_(&V->ncv, &rnorm, &workl[ihbds], &int1);
+            BLAS_FUNC(sscal)(&V->ncv, &rnorm, &workl[ihbds], &int1);
         }
     } else {
 
@@ -417,7 +417,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         {
             if (rvec)
             {
-                sscal_(&V->ncv, &rnorm, &workl[ihbds], &int1);
+                BLAS_FUNC(sscal)(&V->ncv, &rnorm, &workl[ihbds], &int1);
             }
 
             for (k = 0; k < V->ncv; k++)
@@ -447,12 +447,12 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             }
             // 80
 
-            scopy_(&V->nconv, &workl[iheigr], &int1, dr, &int1);
-            scopy_(&V->nconv, &workl[iheigi], &int1, di, &int1);
+            BLAS_FUNC(scopy)(&V->nconv, &workl[iheigr], &int1, dr, &int1);
+            BLAS_FUNC(scopy)(&V->nconv, &workl[iheigi], &int1, di, &int1);
 
         } else if ((TYP == REALPART) || (TYP == IMAGPART)) {
-            scopy_(&V->nconv, &workl[iheigr], &int1, dr, &int1);
-            scopy_(&V->nconv, &workl[iheigi], &int1, di, &int1);
+            BLAS_FUNC(scopy)(&V->nconv, &workl[iheigr], &int1, dr, &int1);
+            BLAS_FUNC(scopy)(&V->nconv, &workl[iheigi], &int1, di, &int1);
         }
     }
 
@@ -500,7 +500,7 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  Perform a rank one update to Z and
         //  purify all the Ritz vectors together.
 
-        sger_(&V->n, &V->nconv, &dbl1, resid, &int1, workev, &int1, z, &ldz);
+        BLAS_FUNC(sger)(&V->n, &V->nconv, &dbl1, resid, &int1, workev, &int1, z, &ldz);
     }
 
     return;
@@ -508,9 +508,9 @@ ARNAUD_sneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
 void
 ARNAUD_snaupd(struct ARNAUD_state_s *V, float* resid, float* v,
-              int ldv, int* ipntr, float* workd, float* workl)
+              CBLAS_INT ldv, CBLAS_INT* ipntr, float* workd, float* workl)
 {
-    int bounds, ih, iq, iw, j, ldh, ldq, next, iritzi, iritzr;
+    CBLAS_INT bounds, ih, iq, iw, j, ldh, ldq, next, iritzi, iritzr;
 
     if (V->ido == ido_FIRST)
     {
@@ -606,12 +606,12 @@ ARNAUD_snaupd(struct ARNAUD_state_s *V, float* resid, float* v,
 }
 
 void
-snaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
-       float* h, int ldh, float* ritzr, float* ritzi, float* bounds,
-       float* q, int ldq, float* workl, int* ipntr, float* workd)
+snaup2(struct ARNAUD_state_s *V, float* resid, float* v, CBLAS_INT ldv,
+       float* h, CBLAS_INT ldh, float* ritzr, float* ritzi, float* bounds,
+       float* q, CBLAS_INT ldq, float* workl, CBLAS_INT* ipntr, float* workd)
 {
     enum ARNAUD_which temp_which;
-    int int1 = 1, j, tmp_int;
+    CBLAS_INT int1 = 1, j, tmp_int;
     const float eps23 = powf(ulp, 2.0f / 3.0f);
     float temp = 0.0f;
 
@@ -756,11 +756,11 @@ LINE20:
     //  bounds obtained from dneigh.
 
     tmp_int = V->aup2_kplusp * V->aup2_kplusp;
-    scopy_(&V->aup2_kplusp, ritzr, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(scopy)(&V->aup2_kplusp, ritzr, &int1, &workl[tmp_int], &int1);
     tmp_int += V->aup2_kplusp;
-    scopy_(&V->aup2_kplusp, ritzi, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(scopy)(&V->aup2_kplusp, ritzi, &int1, &workl[tmp_int], &int1);
     tmp_int += V->aup2_kplusp;
-    scopy_(&V->aup2_kplusp, bounds, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(scopy)(&V->aup2_kplusp, bounds, &int1, &workl[tmp_int], &int1);
 
     //  Select the wanted Ritz values and their bounds
     //  to be used in the convergence test.
@@ -783,7 +783,7 @@ LINE20:
 
     //  Convergence test.
 
-    scopy_(&V->aup2_nev, &bounds[V->np], &int1, &workl[2*V->np], &int1);
+    BLAS_FUNC(scopy)(&V->aup2_nev, &bounds[V->np], &int1, &workl[2*V->np], &int1);
     snconv(V->aup2_nev, &ritzr[V->np], &ritzi[V->np], &workl[2*V->np], V->tol, &V->nconv);
 
     //  Count the number of unwanted Ritz values that have zero
@@ -795,7 +795,7 @@ LINE20:
     //  no shifts may be applied, then prepare to exit
 
     // We are modifying V->np hence the temporary variable.
-    int nptemp = V->np;
+    CBLAS_INT nptemp = V->np;
 
     for (j = 0; j < nptemp; j++)
     {
@@ -909,7 +909,7 @@ LINE20:
         //  To prevent possible stagnation, adjust the size
         //  of NEV.
 
-        int nevbef = V->aup2_nev;
+        CBLAS_INT nevbef = V->aup2_nev;
         V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
         if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6)) {
             V->aup2_nev = V->aup2_kplusp / 2;
@@ -962,8 +962,8 @@ LINE50:
         //  RITZR, RITZI to free up WORKL
         //  for non-exact shift case.
 
-        scopy_(&V->np, workl, &int1, ritzr, &int1);
-        scopy_(&V->np, &workl[V->np], &int1, ritzi, &int1);
+        BLAS_FUNC(scopy)(&V->np, workl, &int1, ritzr, &int1);
+        BLAS_FUNC(scopy)(&V->np, &workl[V->np], &int1, ritzi, &int1);
     }
 
     //  Apply the NP implicit shifts by QR bulge chasing.
@@ -980,7 +980,7 @@ LINE50:
     V->aup2_cnorm = 1;
     if (V->bmat)
     {
-        scopy_(&V->n, resid, &int1, &workd[V->n], &int1);
+        BLAS_FUNC(scopy)(&V->n, resid, &int1, &workd[V->n], &int1);
         ipntr[0] = V->n;
         ipntr[1] = 0;
         V->ido = ido_BX;
@@ -989,7 +989,7 @@ LINE50:
 
         return;
     } else {
-        scopy_(&V->n, resid, &int1, workd, &int1);
+        BLAS_FUNC(scopy)(&V->n, resid, &int1, workd, &int1);
     }
 
 LINE100:
@@ -999,10 +999,10 @@ LINE100:
 
     if (V->bmat)
     {
-        V->aup2_rnorm = sdot_(&V->n, resid, &int1, workd, &int1);
+        V->aup2_rnorm = BLAS_FUNC(sdot)(&V->n, resid, &int1, workd, &int1);
         V->aup2_rnorm = sqrtf(fabsf(V->aup2_rnorm));
     } else {
-        V->aup2_rnorm = snrm2_(&V->n, resid, &int1);
+        V->aup2_rnorm = BLAS_FUNC(snrm2)(&V->n, resid, &int1);
     }
     V->aup2_cnorm = 0;
 
@@ -1015,13 +1015,13 @@ LINE100:
 }
 
 void
-snconv(int n, float* ritzr, float* ritzi, float* bounds, const float tol, int* nconv)
+snconv(CBLAS_INT n, float* ritzr, float* ritzi, float* bounds, const float tol, CBLAS_INT* nconv)
 {
     const float eps23 = powf(ulp, 2.0f / 3.0f);
     float temp;
 
     *nconv = 0;
-    for (int i = 0; i < n; i++)
+    for (CBLAS_INT i = 0; i < n; i++)
     {
         temp = fmaxf(eps23, hypotf(ritzr[i], ritzi[i]));
         if (bounds[i] <= tol*temp)
@@ -1034,11 +1034,11 @@ snconv(int n, float* ritzr, float* ritzi, float* bounds, const float tol, int* n
 }
 
 void
-sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
-       float* bounds, float* q, int ldq, float* workl, int* ierr)
+sneigh(float* rnorm, CBLAS_INT n, float* h, CBLAS_INT ldh, float* ritzr, float* ritzi,
+       float* bounds, float* q, CBLAS_INT ldq, float* workl, CBLAS_INT* ierr)
 {
-    int select[1] = { 0 };
-    int i, iconj, int1 = 1, j;
+    CBLAS_INT select[1] = { 0 };
+    CBLAS_INT i, iconj; CBLAS_INT int1 = 1; CBLAS_INT  j;
     float dbl1 = 1.0f, dbl0 = 0.0f, temp, tmp_dbl, vl[1] = { 0.0f };
 
     //  1. Compute the eigenvalues, the last components of the
@@ -1047,13 +1047,13 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
     //  dlahqr returns the full Schur form of H in WORKL(1:N**2)
     //  and the last components of the Schur vectors in BOUNDS.
 
-    slacpy_("A", &n, &n, h, &ldh, workl, &n);
+    BLAS_FUNC(slacpy)("A", &n, &n, h, &ldh, workl, &n);
     for (j = 0; j < n-1; j++)
     {
         bounds[j] = 0.0f;
     }
     bounds[n-1] = 1.0f;
-    slahqr_(&int1, &int1, &n, &int1, &n, workl, &n, ritzr, ritzi, &int1, &int1, bounds, &int1, ierr);
+    BLAS_FUNC(slahqr)(&int1, &int1, &n, &int1, &n, workl, &n, ritzr, ritzi, &int1, &int1, bounds, &int1, ierr);
 
     if (*ierr != 0) { return; }
 
@@ -1065,7 +1065,7 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
     //  of the eigenvector components are split across adjacent
     //  columns of Q.
 
-    strevc_("R", "A", select, &n, workl, &n, vl, &n, q, &ldq, &n, &n, &workl[n*n], ierr);
+    BLAS_FUNC(strevc)("R", "A", select, &n, workl, &n, vl, &n, q, &ldq, &n, &n, &workl[n*n], ierr);
     if (*ierr != 0) { return; }
 
     //  Scale the returning eigenvectors so that their
@@ -1083,9 +1083,9 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
 
             //  Real eigenvalue case
 
-            temp = snrm2_(&n, &q[ldq*i], &int1);
+            temp = BLAS_FUNC(snrm2)(&n, &q[ldq*i], &int1);
             tmp_dbl = 1.0f / temp;
-            sscal_(&n, &tmp_dbl, &q[ldq*i], &int1);
+            BLAS_FUNC(sscal)(&n, &tmp_dbl, &q[ldq*i], &int1);
 
         } else {
 
@@ -1097,11 +1097,11 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
 
             if (iconj == 0)
             {
-                temp = hypotf(snrm2_(&n, &q[ldq*i], &int1),
-                             snrm2_(&n, &q[ldq*(i+1)], &int1));
+                temp = hypotf(BLAS_FUNC(snrm2)(&n, &q[ldq*i], &int1),
+                             BLAS_FUNC(snrm2)(&n, &q[ldq*(i+1)], &int1));
                 tmp_dbl = 1.0f / temp;
-                sscal_(&n, &tmp_dbl, &q[ldq*i], &int1);
-                sscal_(&n, &tmp_dbl, &q[ldq*(i+1)], &int1);
+                BLAS_FUNC(sscal)(&n, &tmp_dbl, &q[ldq*i], &int1);
+                BLAS_FUNC(sscal)(&n, &tmp_dbl, &q[ldq*(i+1)], &int1);
                 iconj = 1;
             } else {
                 iconj = 0;
@@ -1110,7 +1110,7 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
     }
     // 10
 
-    sgemv_("T", &n, &n, &dbl1, q, &ldq, bounds, &int1, &dbl0, workl, &int1);
+    BLAS_FUNC(sgemv)("T", &n, &n, &dbl1, q, &ldq, bounds, &int1, &dbl0, workl, &int1);
 
     //  Compute the Ritz estimates
 
@@ -1148,14 +1148,14 @@ sneigh(float* rnorm, int n, float* h, int ldh, float* ritzr, float* ritzi,
 }
 
 void
-snaitr(struct ARNAUD_state_s *V, int k, int np, float* resid, float* rnorm,
-       float* v, int ldv, float* h, int ldh, int* ipntr, float* workd)
+snaitr(struct ARNAUD_state_s *V, CBLAS_INT k, CBLAS_INT np, float* resid, float* rnorm,
+       float* v, CBLAS_INT ldv, float* h, CBLAS_INT ldh, CBLAS_INT* ipntr, float* workd)
 {
-    int i = 0, infol, ipj, irj, ivj, jj, n, tmp_int;
+    CBLAS_INT i = 0, infol, ipj, irj, ivj, jj, n, tmp_int;
     float smlnum = unfl * ( V->n / ulp);
     const float sq2o2 = sqrtf(2.0) / 2.0;
 
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
     float dbl1 = 1.0f, dbl0 = 0.0f, dblm1 = -1.0f, temp1, tst1;
 
     n = V->n;  // n is constant, this is just for typing convenience
@@ -1249,22 +1249,22 @@ LINE40:
     //  when reciprocating a small RNORM, test against lower
     //  machine bound.
 
-    scopy_(&n, resid, &int1, &v[ldv*(V->aitr_j)], &int1);
+    BLAS_FUNC(scopy)(&n, resid, &int1, &v[ldv*(V->aitr_j)], &int1);
     if (*rnorm >= unfl)
     {
         temp1 = 1.0f / *rnorm;
-        sscal_(&n, &temp1, &v[ldv*(V->aitr_j)], &int1);
-        sscal_(&n, &temp1, &workd[ipj], &int1);
+        BLAS_FUNC(sscal)(&n, &temp1, &v[ldv*(V->aitr_j)], &int1);
+        BLAS_FUNC(sscal)(&n, &temp1, &workd[ipj], &int1);
     } else {
-        slascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*(V->aitr_j)], &n, &infol);
-        slascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
+        BLAS_FUNC(slascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*(V->aitr_j)], &n, &infol);
+        BLAS_FUNC(slascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
     }
 
     //  STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j}
     //  Note that this is not quite yet r_{j}. See STEP 4
 
     V->aitr_step3 = 1;
-    scopy_(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
+    BLAS_FUNC(scopy)(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
     ipntr[0] = ivj;
     ipntr[1] = irj;
     ipntr[2] = ipj;
@@ -1284,7 +1284,7 @@ LINE50:
 
     //  Put another copy of OP*v_{j} into RESID.
 
-    scopy_(&n, &workd[irj], &int1, resid, &int1);
+    BLAS_FUNC(scopy)(&n, &workd[irj], &int1, resid, &int1);
 
     //  STEP 4:  Finish extending the Arnoldi
     //           factorization to length j.
@@ -1300,7 +1300,7 @@ LINE50:
 
         return;
     } else {
-        scopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE60:
@@ -1316,10 +1316,10 @@ LINE60:
 
     if (V->bmat)
     {
-        V->aitr_wnorm = sdot_(&n, resid, &int1, &workd[ipj], &int1);
+        V->aitr_wnorm = BLAS_FUNC(sdot)(&n, resid, &int1, &workd[ipj], &int1);
         V->aitr_wnorm = sqrtf(fabsf(V->aitr_wnorm));
     } else {
-        V->aitr_wnorm = snrm2_(&n, resid, &int1);
+        V->aitr_wnorm = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
 
     //  Compute the j-th residual corresponding
@@ -1331,19 +1331,19 @@ LINE60:
     //  Compute the j Fourier coefficients w_{j}
     //  WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.
     tmp_int = V->aitr_j + 1;
-    sgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &h[ldh*(V->aitr_j)], &int1);
+    BLAS_FUNC(sgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &h[ldh*(V->aitr_j)], &int1);
 
     //  Orthogonalize r_{j} against V_{j}.
     //  RESID contains OP*v_{j}. See STEP 3.
 
-    sgemv_("N", &n, &tmp_int, &dblm1, v, &ldv, &h[ldh*(V->aitr_j)], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(sgemv)("N", &n, &tmp_int, &dblm1, v, &ldv, &h[ldh*(V->aitr_j)], &int1, &dbl1, resid, &int1);
 
     if (V->aitr_j > 0) { h[V->aitr_j + ldh*(V->aitr_j-1)] = V->aitr_betaj; }
 
     V->aitr_orth1 = 1;
     if (V->bmat)
     {
-        scopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1352,7 +1352,7 @@ LINE60:
 
         return;
     } else {
-        scopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE70:
@@ -1366,10 +1366,10 @@ LINE70:
 
     if (V->bmat)
     {
-        *rnorm = sdot_(&n, resid, &int1, &workd[ipj], &int1);
+        *rnorm = BLAS_FUNC(sdot)(&n, resid, &int1, &workd[ipj], &int1);
         *rnorm = sqrtf(fabsf(*rnorm));
     } else {
-        *rnorm = snrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
 
     //  STEP 5: Re-orthogonalization / Iterative refinement phase
@@ -1401,21 +1401,21 @@ LINE80:
     //  Compute V_{j}^T * B * r_{j}.
     //  WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1).
     tmp_int = V->aitr_j + 1;
-    sgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
+    BLAS_FUNC(sgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
 
     //  Compute the correction to the residual:
     //  r_{j} = r_{j} - V_{j} * WORKD(IRJ:IRJ+J-1).
     //  The correction to H is v(:,1:J)*H(1:J,1:J)
     //  + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.
 
-    sgemv_("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
-    saxpy_(&tmp_int, &dbl1, &workd[irj], &int1, &h[ldh*(V->aitr_j)], &int1);
+    BLAS_FUNC(sgemv)("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(saxpy)(&tmp_int, &dbl1, &workd[irj], &int1, &h[ldh*(V->aitr_j)], &int1);
 
     V->aitr_orth2 = 1;
 
     if (V->bmat)
     {
-        scopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1425,7 +1425,7 @@ LINE80:
 
         return;
     } else {
-        scopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE90:
@@ -1436,10 +1436,10 @@ LINE90:
 
     if (V->bmat)
     {
-        V->aitr_rnorm1 = sdot_(&n, resid, &int1, &workd[ipj], &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(sdot)(&n, resid, &int1, &workd[ipj], &int1);
         V->aitr_rnorm1 = sqrtf(fabsf(V->aitr_rnorm1));
     } else {
-        V->aitr_rnorm1 = snrm2_(&n, resid, &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
 
     //  Determine if we need to perform another
@@ -1502,7 +1502,7 @@ LINE100:
             if (tst1 == 0.0f)
             {
                 tmp_int = k + np;
-                tst1 = slanhs_("1", &tmp_int, h, &ldh, &workd[n]);
+                tst1 = BLAS_FUNC(slanhs)("1", &tmp_int, h, &ldh, &workd[n]);
             }
             if (fabsf(h[i+1 + ldh*i]) <= fmaxf(ulp*tst1, smlnum))
             {
@@ -1518,13 +1518,13 @@ LINE100:
 
 
 void
-snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
-       int ldv, float* h, int ldh, float* resid, float* q, int ldq, float* workl,
+snapps(CBLAS_INT n, CBLAS_INT* kev, CBLAS_INT np, float* shiftr, float* shifti, float* v,
+       CBLAS_INT ldv, float* h, CBLAS_INT ldh, float* resid, float* q, CBLAS_INT ldq, float* workl,
        float* workd)
 {
-    int cconj;
-    int i, ir, j, jj, int1 = 1, istart, iend = 0, nr, tmp_int;
-    int kplusp = *kev + np;
+    CBLAS_INT cconj;
+    CBLAS_INT i, ir, j, jj; CBLAS_INT int1 = 1; CBLAS_INT  istart, iend = 0, nr, tmp_int;
+    CBLAS_INT kplusp = *kev + np;
     float smlnum = unfl * ( n / ulp);
     float c, f, g, h11, h21, h12, h22, h32, s, sigmar, sigmai, r, t, tau, tst1;
     float dbl1 = 1.0f, dbl0 = 0.0f, dblm1 = -1.0f;
@@ -1532,7 +1532,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
 
     //  Initialize Q to the identity to accumulate
     //  the rotations and reflections
-    slaset_("A", &kplusp, &kplusp, &dbl0, &dbl1, q, &ldq);
+    BLAS_FUNC(slaset)("A", &kplusp, &kplusp, &dbl0, &dbl1, q, &ldq);
 
     //  Quick return if there are no shifts to apply
 
@@ -1593,7 +1593,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
                 if (tst1 == 0.0f)
                 {
                     tmp_int = kplusp - jj;
-                    tst1 = slanhs_("1", &tmp_int, h, &ldh, workl);
+                    tst1 = BLAS_FUNC(slanhs)("1", &tmp_int, h, &ldh, workl);
                 }
                 if (fabsf(h[iend+1 + (iend * ldh)]) <= fmaxf(smlnum, ulp * tst1))
                 {
@@ -1622,18 +1622,18 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
                 g = h21;
                 for (i = istart; i < iend; i++)
                 {
-                    slartgp_(&f, &g, &c, &s, &r);
+                    BLAS_FUNC(slartgp)(&f, &g, &c, &s, &r);
                     if (i > istart)
                     {
                         h[i + (i - 1) * ldh] = r;
                         h[i + 1 + (i - 1) * ldh] = 0.0f;
                     }
                     tmp_int = kplusp - i;
-                    srot_(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
+                    BLAS_FUNC(srot)(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
                     tmp_int = (i+2 > iend ? iend : i + 2) + 1;
-                    srot_(&tmp_int, &h[ldh*i], &int1, &h[ldh*(i+1)], &int1, &c, &s);
+                    BLAS_FUNC(srot)(&tmp_int, &h[ldh*i], &int1, &h[ldh*(i+1)], &int1, &c, &s);
                     tmp_int = (i+jj+2 > kplusp ? kplusp : i + jj + 2);
-                    srot_(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s);
+                    BLAS_FUNC(srot)(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s);
 
                     if (i < iend - 1)
                     {
@@ -1657,7 +1657,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
                 {
                     nr = iend - i + 1;
                     nr = (nr > 3? 3 : nr);
-                    slarfg_(&nr, &u[0], &u[1], &int1, &tau);
+                    BLAS_FUNC(slarfg)(&nr, &u[0], &u[1], &int1, &tau);
                     if (i > istart)
                     {
                         h[i + (i - 1) * ldh] = u[0];
@@ -1667,10 +1667,10 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
                     u[0] = 1.0f;
 
                     tmp_int = kplusp - i;
-                    slarf_("L", &nr, &tmp_int, u, &int1, &tau, &h[i + ldh*i], &ldh, workl);
+                    BLAS_FUNC(slarf)("L", &nr, &tmp_int, u, &int1, &tau, &h[i + ldh*i], &ldh, workl);
                     ir = (i + 3 > iend ? iend : i + 3) + 1;
-                    slarf_("R", &ir, &nr, u, &int1, &tau, &h[ldh*i], &ldh, workl);
-                    slarf_("R", &kplusp, &nr, u, &int1, &tau, &q[ldq*i], &ldq, workl);
+                    BLAS_FUNC(slarf)("R", &ir, &nr, u, &int1, &tau, &h[ldh*i], &ldh, workl);
+                    BLAS_FUNC(slarf)("R", &kplusp, &nr, u, &int1, &tau, &q[ldq*i], &ldq, workl);
                     if (i < iend - 1)
                     {
                         u[0] = h[i+1 + i * ldh];
@@ -1690,11 +1690,11 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
         if (h[j+1 + ldh*j] < 0.0f)
         {
             tmp_int = kplusp - j;
-            sscal_(&tmp_int, &dblm1, &h[j+1 + ldh*j], &ldh);
+            BLAS_FUNC(sscal)(&tmp_int, &dblm1, &h[j+1 + ldh*j], &ldh);
             tmp_int = (j+3 > kplusp ? kplusp : j+3);
-            sscal_(&tmp_int, &dblm1, &h[ldh*(j+1)], &int1);
+            BLAS_FUNC(sscal)(&tmp_int, &dblm1, &h[ldh*(j+1)], &int1);
             tmp_int = (j+np+2 > kplusp ? kplusp : j+np+2);
-            sscal_(&tmp_int, &dblm1, &q[ldq*(j+1)], &int1);
+            BLAS_FUNC(sscal)(&tmp_int, &dblm1, &q[ldq*(j+1)], &int1);
         }
     }
     // 120
@@ -1709,7 +1709,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
         tst1 = fabsf(h[i + ldh*i]) + fabsf(h[i+1 + ldh*(i+1)]);
         if (tst1 == 0.0f)
         {
-            tst1 = slanhs_("1", kev, h, &ldh, workl);
+            tst1 = BLAS_FUNC(slanhs)("1", kev, h, &ldh, workl);
         }
         if (h[i+1 + ldh*i] <= fmaxf(ulp*tst1, smlnum))
         {
@@ -1726,7 +1726,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
 
     if (h[*kev + ldh*(*kev-1)] > 0.0f)
     {
-        sgemv_("N", &n, &kplusp, &dbl1, v, &ldv, &q[(*kev)*ldq], &int1, &dbl0, &workd[n], &int1);
+        BLAS_FUNC(sgemv)("N", &n, &kplusp, &dbl1, v, &ldv, &q[(*kev)*ldq], &int1, &dbl0, &workd[n], &int1);
     }
 
     //  Compute column 1 to kev of (V*Q) in backward order
@@ -1735,21 +1735,21 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
     for (i = 0; i < *kev; i++)
     {
         tmp_int = kplusp - i;
-        sgemv_("N", &n, &tmp_int, &dbl1, v, &ldv, &q[(*kev-i-1)*ldq], &int1, &dbl0, workd, &int1);
-        scopy_(&n, workd, &int1, &v[(kplusp-i-1)*ldv], &int1);
+        BLAS_FUNC(sgemv)("N", &n, &tmp_int, &dbl1, v, &ldv, &q[(*kev-i-1)*ldq], &int1, &dbl0, workd, &int1);
+        BLAS_FUNC(scopy)(&n, workd, &int1, &v[(kplusp-i-1)*ldv], &int1);
     }
 
     //   Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev).
 
     for (i = 0; i < *kev; i++)
     {
-        scopy_(&n, &v[(kplusp-*kev+i)*ldv], &int1, &v[i*ldv], &int1);
+        BLAS_FUNC(scopy)(&n, &v[(kplusp-*kev+i)*ldv], &int1, &v[i*ldv], &int1);
     }
 
     //  Copy the (kev+1)-st column of (V*Q) in the appropriate place
 
     if (h[*kev + ldh*(*kev-1)] > 0.0f){
-        scopy_(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
+        BLAS_FUNC(scopy)(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
     }
 
     //  Update the residual vector:
@@ -1758,11 +1758,11 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
     //     sigmak = (e_{kplusp}'*Q)*e_{kev}
     //     betak = e_{kev+1}'*H*e_{kev}
 
-    sscal_(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
+    BLAS_FUNC(sscal)(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
 
     if (h[*kev + ldh*(*kev-1)] > 0.0f)
     {
-        saxpy_(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
+        BLAS_FUNC(saxpy)(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
     }
 
     return;
@@ -1771,7 +1771,7 @@ snapps(int n, int* kev, int np, float* shiftr, float* shifti, float* v,
 
 
 void
-sngets(struct ARNAUD_state_s *V, int* kev, int* np,
+sngets(struct ARNAUD_state_s *V, CBLAS_INT* kev, CBLAS_INT* np,
        float* ritzr, float* ritzi, float* bounds)
 {
 
@@ -1837,10 +1837,10 @@ sngets(struct ARNAUD_state_s *V, int* kev, int* np,
 }
 
 void
-sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
-       float* v, int ldv, float* resid, float* rnorm, int* ipntr, float* workd)
+sgetv0(struct ARNAUD_state_s *V, CBLAS_INT initv, CBLAS_INT n, CBLAS_INT j,
+       float* v, CBLAS_INT ldv, float* resid, float* rnorm, CBLAS_INT* ipntr, float* workd)
 {
-    int jj, int1 = 1;
+    CBLAS_INT jj; CBLAS_INT int1 = 1;
     const float sq2o2 = sqrtf(2.0) / 2.0;
     float dbl1 = 1.0f, dbl0 = 0.0f, dblm1 = -1.0f;;
 
@@ -1874,12 +1874,12 @@ sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
         {
             ipntr[0] = 0;
             ipntr[1] = n;
-            scopy_(&n, resid, &int1, workd, &int1);
+            BLAS_FUNC(scopy)(&n, resid, &int1, workd, &int1);
             V->ido = ido_RANDOM_OPX;
             return;
         } else if ((V->getv0_itry > 1) && (V->bmat == 1))
         {
-            scopy_(&n, resid, &int1, &workd[n], &int1);
+            BLAS_FUNC(scopy)(&n, resid, &int1, &workd[n], &int1);
         }
     }
 
@@ -1897,7 +1897,7 @@ sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
     V->getv0_first = 1;
     if (V->getv0_itry == 1)
     {
-        scopy_(&n, &workd[n], &int1, resid, &int1);
+        BLAS_FUNC(scopy)(&n, &workd[n], &int1, resid, &int1);
     }
     if (V->bmat)
     {
@@ -1906,7 +1906,7 @@ sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
         V->ido = ido_BX;
         return;
     } else {
-        scopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE20:
@@ -1914,10 +1914,10 @@ LINE20:
     V->getv0_first = 0;
     if (V->bmat)
     {
-        V->getv0_rnorm0 = sdot_(&n, resid, &int1, workd, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(sdot)(&n, resid, &int1, workd, &int1);
         V->getv0_rnorm0 = sqrtf(fabsf(V->getv0_rnorm0));
     } else {
-        V->getv0_rnorm0 = snrm2_(&n, resid, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
     *rnorm = V->getv0_rnorm0;
 
@@ -1943,29 +1943,29 @@ LINE20:
 
 LINE30:
 
-    sgemv_("T", &n, &j, &dbl1, v, &ldv, workd, &int1, &dbl0, &workd[n], &int1);
-    sgemv_("N", &n, &j, &dblm1, v, &ldv, &workd[n], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(sgemv)("T", &n, &j, &dbl1, v, &ldv, workd, &int1, &dbl0, &workd[n], &int1);
+    BLAS_FUNC(sgemv)("N", &n, &j, &dblm1, v, &ldv, &workd[n], &int1, &dbl1, resid, &int1);
 
     //  Compute the B-norm of the orthogonalized starting vector
 
     if (V->bmat)
     {
-        scopy_(&n, resid, &int1, &workd[n], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[n], &int1);
         ipntr[0] = n;
         ipntr[1] = 0;
         V->ido = ido_BX;
         return;
     } else {
-        scopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE40:
     if (V->bmat)
     {
-        *rnorm = sdot_(&n, resid, &int1, workd, &int1);
+        *rnorm = BLAS_FUNC(sdot)(&n, resid, &int1, workd, &int1);
         *rnorm = sqrtf(fabsf(*rnorm));
     } else {
-        *rnorm = snrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
 
     //  Check for further orthogonalization.
@@ -2000,9 +2000,9 @@ LINE40:
 
 
 static void
-ssortc(const enum ARNAUD_which w, const int apply, const int n, float* xreal, float* ximag, float* y)
+ssortc(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, float* xreal, float* ximag, float* y)
 {
-    int i, gap, pos;
+    CBLAS_INT i, gap, pos;
     float temp;
     ARNAUD_compare_cfunc *f;
 
@@ -2062,40 +2062,40 @@ ssortc(const enum ARNAUD_which w, const int apply, const int n, float* xreal, fl
 
 
 // The void casts are to avoid compiler warnings for unused parameters
-int
+CBLAS_INT
 sortc_LM(const float xre, const float xim, const float xreigap, const float ximigap)
 {
     return (hypotf(xre, xim) > hypotf(xreigap, ximigap));
 }
 
-int
+CBLAS_INT
 sortc_SM(const float xre, const float xim, const float xreigap, const float ximigap)
 {
     return (hypotf(xre, xim) < hypotf(xreigap, ximigap));
 }
 
-int
+CBLAS_INT
 sortc_LR(const float xre, const float xim, const float xreigap, const float ximigap)
 {
     (void)xim; (void)ximigap;
     return (xre > xreigap);
 }
 
-int
+CBLAS_INT
 sortc_SR(const float xre, const float xim, const float xreigap, const float ximigap)
 {
     (void)xim; (void)ximigap;
     return (xre < xreigap);
 }
 
-int
+CBLAS_INT
 sortc_LI(const float xre, const float xim, const float xreigap, const float ximigap)
 {
     (void)xre; (void)xreigap;
     return (fabsf(xim) > fabsf(ximigap));
 }
 
-int
+CBLAS_INT
 sortc_SI(const float xre, const float xim, const float xreigap, const float ximigap)
 {
     (void)xre; (void)xreigap;

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single_complex.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_n_single_complex.c
@@ -1,27 +1,27 @@
 #include "arnaud_n_single_complex.h"
 #include <float.h>
 
-typedef int ARNAUD_compare_cfunc(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
-typedef int ARNAUD_compare_rfunc(const float, const float);
+typedef CBLAS_INT ARNAUD_compare_cfunc(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
+typedef CBLAS_INT ARNAUD_compare_rfunc(const float, const float);
 
 static const float unfl = FLT_MIN;    // 1.1754943508222875e-38;
 // static const float ovfl = FLT_MAX; // 1.0 / 1.1754943508222875e-38;
 static const float ulp = FLT_EPSILON; // 1.1920928955078125e-07;
 
-static ARNAUD_CPLXF_TYPE cdotc_(const int* n, const ARNAUD_CPLXF_TYPE* restrict x, const int* incx, const ARNAUD_CPLXF_TYPE* restrict y, const int* incy);
-static void cgetv0(struct ARNAUD_state_s*, int, int, int, ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, float*, int*, ARNAUD_CPLXF_TYPE*);
-static void cnaup2(struct ARNAUD_state_s*, ARNAUD_CPLXF_TYPE* , ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, int*, ARNAUD_CPLXF_TYPE*, float*);
-static void cnaitr(struct ARNAUD_state_s*, int, int, ARNAUD_CPLXF_TYPE*,float*, ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, int, int*, ARNAUD_CPLXF_TYPE*);
-static void cnapps(int, int*, int, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*);
-static void cneigh(float*, int, ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, int, ARNAUD_CPLXF_TYPE*, float*, int*);
-static void cngets(struct ARNAUD_state_s*, int*, int*, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*);
-static void csortc(const enum ARNAUD_which w, const int, const int, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*);
-static int sortc_LM(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
-static int sortc_SM(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
-static int sortc_LR(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
-static int sortc_SR(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
-static int sortc_LI(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
-static int sortc_SI(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
+static ARNAUD_CPLXF_TYPE cdotc_(const CBLAS_INT* n, const ARNAUD_CPLXF_TYPE* restrict x, const CBLAS_INT* incx, const ARNAUD_CPLXF_TYPE* restrict y, const CBLAS_INT* incy);
+static void cgetv0(struct ARNAUD_state_s*, CBLAS_INT, CBLAS_INT, CBLAS_INT, ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, float*, CBLAS_INT*, ARNAUD_CPLXF_TYPE*);
+static void cnaup2(struct ARNAUD_state_s*, ARNAUD_CPLXF_TYPE* , ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, CBLAS_INT*, ARNAUD_CPLXF_TYPE*, float*);
+static void cnaitr(struct ARNAUD_state_s*, CBLAS_INT, CBLAS_INT, ARNAUD_CPLXF_TYPE*,float*, ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, CBLAS_INT, CBLAS_INT*, ARNAUD_CPLXF_TYPE*);
+static void cnapps(CBLAS_INT, CBLAS_INT*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*);
+static void cneigh(float*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*, CBLAS_INT, ARNAUD_CPLXF_TYPE*, float*, CBLAS_INT*);
+static void cngets(struct ARNAUD_state_s*, CBLAS_INT*, CBLAS_INT*, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*);
+static void csortc(const enum ARNAUD_which w, const CBLAS_INT, const CBLAS_INT, ARNAUD_CPLXF_TYPE*, ARNAUD_CPLXF_TYPE*);
+static CBLAS_INT sortc_LM(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
+static CBLAS_INT sortc_SM(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
+static CBLAS_INT sortc_LR(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
+static CBLAS_INT sortc_SR(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
+static CBLAS_INT sortc_LI(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
+static CBLAS_INT sortc_SI(const ARNAUD_CPLXF_TYPE, const ARNAUD_CPLXF_TYPE);
 
 enum ARNAUD_neupd_type {
     REGULAR,
@@ -32,15 +32,15 @@ enum ARNAUD_neupd_type {
 
 
 void
-ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
-       ARNAUD_CPLXF_TYPE* d, ARNAUD_CPLXF_TYPE* z, int ldz, ARNAUD_CPLXF_TYPE sigma,
-       ARNAUD_CPLXF_TYPE* workev, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, int ldv,
-       int* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork)
+ARNAUD_cneupd(struct ARNAUD_state_s *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select,
+       ARNAUD_CPLXF_TYPE* d, ARNAUD_CPLXF_TYPE* z, CBLAS_INT ldz, ARNAUD_CPLXF_TYPE sigma,
+       ARNAUD_CPLXF_TYPE* workev, ARNAUD_CPLXF_TYPE* resid, ARNAUD_CPLXF_TYPE* v, CBLAS_INT ldv,
+       CBLAS_INT* ipntr, ARNAUD_CPLXF_TYPE* workd, ARNAUD_CPLXF_TYPE* workl, float* rwork)
 {
     const float eps23 = powf(ulp, 2.0f / 3.0f);
-    int ibd, ih, iheig, ihbds, iuptri, invsub, irz, j, jj;
-    int bounds, k, ldh, ldq, np, numcnv, outncv, reord, ritz;
-    int ierr = 0, int1 = 1, tmp_int = 0, nconv2 = 0;
+    CBLAS_INT ibd, ih, iheig, ihbds, iuptri, invsub, irz, j, jj;
+    CBLAS_INT bounds, k, ldh, ldq, np, numcnv, outncv, reord, ritz;
+    CBLAS_INT ierr = 0; CBLAS_INT int1 = 1; CBLAS_INT  tmp_int = 0, nconv2 = 0;
     float conds, sep, temp1, rtemp;
     ARNAUD_CPLXF_TYPE rnorm, temp;
     ARNAUD_CPLXF_TYPE cdbl0 = ARNAUD_cplxf(0.0f, 0.0f);
@@ -165,7 +165,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         for (j = 1; j <= V->ncv; j++)
         {
             temp1 = fmaxf(eps23, cabsf(workl[irz + V->ncv - j]));
-            jj = (int)crealf(workl[bounds + V->ncv - j]);
+            jj = (CBLAS_INT)crealf(workl[bounds + V->ncv - j]);
 
             if ((numcnv < V->nconv) && (cabsf(workl[ibd + jj]) <= V->tol*temp1))
             {
@@ -193,11 +193,11 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  Initialize the Schur vector matrix Q to the identity.
 
         tmp_int = ldh*V->ncv;
-        ccopy_(&tmp_int, &workl[ih], &int1, &workl[iuptri], &int1);
-        claset_("A", &V->ncv, &V->ncv, &cdbl0, &cdbl1, &workl[invsub], &ldq);
-        clahqr_(&int1, &int1, &V->ncv, &int1, &V->ncv, &workl[iuptri], &ldh,
+        BLAS_FUNC(ccopy)(&tmp_int, &workl[ih], &int1, &workl[iuptri], &int1);
+        BLAS_FUNC(claset)("A", &V->ncv, &V->ncv, &cdbl0, &cdbl1, &workl[invsub], &ldq);
+        BLAS_FUNC(clahqr)(&int1, &int1, &V->ncv, &int1, &V->ncv, &workl[iuptri], &ldh,
                 &workl[iheig], &int1, &V->ncv, &workl[invsub], &ldq, &ierr);
-        ccopy_(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
+        BLAS_FUNC(ccopy)(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
 
         if (ierr != 0)
         {
@@ -210,7 +210,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
             //  Reorder the computed upper triangular matrix.
 
-            ctrsen_("N", "V", select, &V->ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq,
+            BLAS_FUNC(ctrsen)("N", "V", select, &V->ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq,
                     &workl[iheig], &nconv2, &conds, &sep, workev, &V->ncv, &ierr);
 
             if (nconv2 < V->nconv) { V->nconv = nconv2; }
@@ -225,21 +225,21 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  to compute the Ritz estimates of converged
         //  Ritz values.
 
-        ccopy_(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
+        BLAS_FUNC(ccopy)(&V->ncv, &workl[invsub + V->ncv - 1], &ldq, &workl[ihbds], &int1);
 
         //  Place the computed eigenvalues of H into D
         //  if a spectral transformation was not used.
 
         if (TYP == REGULAR)
         {
-            ccopy_(&V->nconv, &workl[iheig], &int1, d, &int1);
+            BLAS_FUNC(ccopy)(&V->nconv, &workl[iheig], &int1, d, &int1);
         }
 
         //  Compute the QR factorization of the matrix representing
         //  the wanted invariant subspace located in the first NCONV
         //  columns of workl(invsub,ldq).
 
-        cgeqr2_(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
+        BLAS_FUNC(cgeqr2)(&V->ncv, &V->nconv, &workl[invsub], &ldq, workev, &workev[V->ncv], &ierr);
 
         //  * Postmultiply V by Q using zunm2r.
         //  * Copy the first NCONV columns of VQ into Z.
@@ -251,10 +251,10 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  associated with the upper triangular matrix of order
         //  NCONV in workl(iuptri).
 
-        cunm2r_("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq, workev, v, &ldv, &workd[V->n], &ierr);
-        clacpy_("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
+        BLAS_FUNC(cunm2r)("R", "N", &V->n, &V->ncv, &V->nconv, &workl[invsub], &ldq, workev, v, &ldv, &workd[V->n], &ierr);
+        BLAS_FUNC(clacpy)("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
 
-        for (int j = 0; j < V->nconv; j++)
+        for (CBLAS_INT j = 0; j < V->nconv; j++)
         {
 
             //  Perform both a column and row scaling if the
@@ -266,8 +266,8 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
             if (crealf(workl[invsub + j*ldq + j]) < 0.0f)
             {
-                cscal_(&V->nconv, &cdblm1, &workl[iuptri + j], &ldq);
-                cscal_(&V->nconv, &cdblm1, &workl[iuptri + j*ldq], &int1);
+                BLAS_FUNC(cscal)(&V->nconv, &cdblm1, &workl[iuptri + j], &ldq);
+                BLAS_FUNC(cscal)(&V->nconv, &cdblm1, &workl[iuptri + j*ldq], &int1);
             }
         }
         // 20
@@ -278,7 +278,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             //  Compute the NCONV wanted eigenvectors of T
             //  located in workl(iuptri,ldq).
 
-            for (int j = 0; j < V->ncv; j++)
+            for (CBLAS_INT j = 0; j < V->ncv; j++)
             {
                 if (j < V->nconv)
                 {
@@ -289,7 +289,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             }
             // 30
 
-            ctrevc_("R", "S", select, &V->ncv, &workl[iuptri], &ldq, vl, &int1,
+            BLAS_FUNC(ctrevc)("R", "S", select, &V->ncv, &workl[iuptri], &ldq, vl, &int1,
                     &workl[invsub], &ldq, &V->ncv, &outncv, workev, rwork, &ierr);
             if (ierr != 0)
             {
@@ -305,8 +305,8 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
             for (j = 0; j < V->nconv; j++)
             {
-                rtemp = 1.0f / scnrm2_(&V->ncv, &workl[invsub + j*ldq], &int1);
-                csscal_(&V->ncv, &rtemp, &workl[invsub + j*ldq], &int1);
+                rtemp = 1.0f / BLAS_FUNC(scnrm2)(&V->ncv, &workl[invsub + j*ldq], &int1);
+                BLAS_FUNC(csscal)(&V->ncv, &rtemp, &workl[invsub + j*ldq], &int1);
 
                 //  Ritz estimates can be obtained by taking
                 //  the inner product of the last row of the
@@ -321,11 +321,11 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
             //  Copy Ritz estimates into workl(ihbds)
 
-            ccopy_(&V->nconv, workev, &int1, &workl[ihbds], &int1);
+            BLAS_FUNC(ccopy)(&V->nconv, workev, &int1, &workl[ihbds], &int1);
 
             //  The eigenvector mactirx Q of T is triangular. Form Z*Q
 
-            ctrmm_("R", "U", "N", "N", &V->n, &V->nconv, &cdbl1, &workl[invsub], &ldq, z, &ldz);
+            BLAS_FUNC(ctrmm)("R", "U", "N", "N", &V->n, &V->nconv, &cdbl1, &workl[invsub], &ldq, z, &ldz);
 
         }
 
@@ -334,9 +334,9 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         // An approximate invariant subspace is not needed.
         // Place the Ritz values computed ZNAUPD into D.
 
-        ccopy_(&V->nconv, &workl[ritz], &int1, d, &int1);
-        ccopy_(&V->nconv, &workl[ritz], &int1, &workl[iheig], &int1);
-        ccopy_(&V->nconv, &workl[bounds], &int1, &workl[ihbds], &int1);
+        BLAS_FUNC(ccopy)(&V->nconv, &workl[ritz], &int1, d, &int1);
+        BLAS_FUNC(ccopy)(&V->nconv, &workl[ritz], &int1, &workl[iheig], &int1);
+        BLAS_FUNC(ccopy)(&V->nconv, &workl[bounds], &int1, &workl[ihbds], &int1);
 
     }
 
@@ -348,7 +348,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
     {
         if (rvec)
         {
-            cscal_(&V->ncv, &rnorm, &workl[ihbds], &int1);
+            BLAS_FUNC(cscal)(&V->ncv, &rnorm, &workl[ihbds], &int1);
         }
     } else {
 
@@ -358,7 +358,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
         if (rvec)
         {
-            cscal_(&V->ncv, &rnorm, &workl[ihbds], &int1);
+            BLAS_FUNC(cscal)(&V->ncv, &rnorm, &workl[ihbds], &int1);
         }
         for (k = 0; k < V->ncv; k++)
         {
@@ -430,7 +430,7 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  Perform a rank one update to Z and
         //  purify all the Ritz vectors together.
 
-        cgeru_(&V->n, &V->nconv, &cdbl1, resid, &int1, workev, &int1, z, &ldz);
+        BLAS_FUNC(cgeru)(&V->n, &V->nconv, &cdbl1, resid, &int1, workev, &int1, z, &ldz);
     }
 
     return;
@@ -439,10 +439,10 @@ ARNAUD_cneupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
 void
 ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid,
-       ARNAUD_CPLXF_TYPE* v, int ldv, int* ipntr, ARNAUD_CPLXF_TYPE* workd,
+       ARNAUD_CPLXF_TYPE* v, CBLAS_INT ldv, CBLAS_INT* ipntr, ARNAUD_CPLXF_TYPE* workd,
        ARNAUD_CPLXF_TYPE* workl, float* rwork)
 {
-    int bounds, ierr = 0, ih, iq, iw, ldh, ldq, next, iritz;
+    CBLAS_INT bounds, ierr = 0, ih, iq, iw, ldh, ldq, next, iritz;
 
     if (V->ido == ido_FIRST)
     {
@@ -488,7 +488,7 @@ ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid,
 
         V->np = V->ncv - V->nev;
 
-        for (int j = 0; j < 3 * (V->ncv*V->ncv) + 6*V->ncv; j++)
+        for (CBLAS_INT j = 0; j < 3 * (V->ncv*V->ncv) + 6*V->ncv; j++)
         {
             workl[j] = ARNAUD_cplxf(0.0f, 0.0f);
         }
@@ -542,13 +542,13 @@ ARNAUD_cnaupd(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid,
 
 static void
 cnaup2(struct ARNAUD_state_s *V, ARNAUD_CPLXF_TYPE* resid,
-       ARNAUD_CPLXF_TYPE* v, int ldv, ARNAUD_CPLXF_TYPE* h, int ldh,
+       ARNAUD_CPLXF_TYPE* v, CBLAS_INT ldv, ARNAUD_CPLXF_TYPE* h, CBLAS_INT ldh,
        ARNAUD_CPLXF_TYPE* ritz, ARNAUD_CPLXF_TYPE* bounds,
-       ARNAUD_CPLXF_TYPE* q, int ldq, ARNAUD_CPLXF_TYPE* workl, int* ipntr,
+       ARNAUD_CPLXF_TYPE* q, CBLAS_INT ldq, ARNAUD_CPLXF_TYPE* workl, CBLAS_INT* ipntr,
        ARNAUD_CPLXF_TYPE* workd, float* rwork)
 {
     enum ARNAUD_which temp_which;
-    int i, int1 = 1, j, tmp_int;
+    CBLAS_INT i; CBLAS_INT int1 = 1; CBLAS_INT  j, tmp_int;
     const float eps23 = powf(ulp, 2.0f / 3.0f);
     float temp = 0.0f, rtemp;
 
@@ -698,9 +698,9 @@ LINE20:
     //  Make a copy of Ritz values and the corresponding
     //  Ritz estimates obtained from zneigh .
     tmp_int = V->aup2_kplusp * V->aup2_kplusp;
-    ccopy_(&V->aup2_kplusp, ritz, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(ccopy)(&V->aup2_kplusp, ritz, &int1, &workl[tmp_int], &int1);
     tmp_int += V->aup2_kplusp;
-    ccopy_(&V->aup2_kplusp, bounds, &int1, &workl[tmp_int], &int1);
+    BLAS_FUNC(ccopy)(&V->aup2_kplusp, bounds, &int1, &workl[tmp_int], &int1);
 
     //  Select the wanted Ritz values and their bounds
     //  to be used in the convergence test.
@@ -736,7 +736,7 @@ LINE20:
     //  no shifts may be applied, then prepare to exit
 
     // We are modifying V->np hence the temporary variable.
-    int nptemp = V->np;
+    CBLAS_INT nptemp = V->np;
 
     for (j = 0; j < nptemp; j++)
     {
@@ -839,7 +839,7 @@ LINE20:
         //  To prevent possible stagnation, adjust the size
         //  of NEV.
 
-        int nevbef = V->aup2_nev;
+        CBLAS_INT nevbef = V->aup2_nev;
         V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
         if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6)) {
             V->aup2_nev = V->aup2_kplusp / 2;
@@ -883,7 +883,7 @@ LINE50:
         //  RITZR, RITZI to free up WORKL
         //  for non-exact shift case.
 
-        ccopy_(&V->np, workl, &int1, ritz, &int1);
+        BLAS_FUNC(ccopy)(&V->np, workl, &int1, ritz, &int1);
     }
 
     //  Apply the NP implicit shifts by QR bulge chasing.
@@ -900,7 +900,7 @@ LINE50:
     V->aup2_cnorm = 1;
     if (V->bmat)
     {
-        ccopy_(&V->n, resid, &int1, &workd[V->n], &int1);
+        BLAS_FUNC(ccopy)(&V->n, resid, &int1, &workd[V->n], &int1);
         ipntr[0] = V->n;
         ipntr[1] = 0;
         V->ido = ido_BX;
@@ -909,7 +909,7 @@ LINE50:
 
         return;
     } else {
-        ccopy_(&V->n, resid, &int1, workd, &int1);
+        BLAS_FUNC(ccopy)(&V->n, resid, &int1, workd, &int1);
     }
 
 LINE100:
@@ -921,7 +921,7 @@ LINE100:
     {
         V->aup2_rnorm = sqrt(cabsf(cdotc_(&V->n, resid, &int1, workd, &int1)));
     } else {
-        V->aup2_rnorm = scnrm2_(&V->n, resid, &int1);
+        V->aup2_rnorm = BLAS_FUNC(scnrm2)(&V->n, resid, &int1);
     }
     V->aup2_cnorm = 0;
 
@@ -935,15 +935,15 @@ LINE100:
 
 
 static void
-cnaitr(struct ARNAUD_state_s *V, int k, int np, ARNAUD_CPLXF_TYPE* resid,
-       float* rnorm, ARNAUD_CPLXF_TYPE* v, int ldv, ARNAUD_CPLXF_TYPE* h, int ldh,
-       int* ipntr, ARNAUD_CPLXF_TYPE* workd)
+cnaitr(struct ARNAUD_state_s *V, CBLAS_INT k, CBLAS_INT np, ARNAUD_CPLXF_TYPE* resid,
+       float* rnorm, ARNAUD_CPLXF_TYPE* v, CBLAS_INT ldv, ARNAUD_CPLXF_TYPE* h, CBLAS_INT ldh,
+       CBLAS_INT* ipntr, ARNAUD_CPLXF_TYPE* workd)
 {
-    int i, infol, ipj, irj, ivj, jj, n, tmp_int;
+    CBLAS_INT i, infol, ipj, irj, ivj, jj, n, tmp_int;
     float smlnum = unfl * ( V->n / ulp);
     const float sq2o2 = sqrt(2.0) / 2.0;
 
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
     float dbl1 = 1.0f, temp1, tst1;
     ARNAUD_CPLXF_TYPE cdbl1 = ARNAUD_cplxf(1.0f, 0.0f);
     ARNAUD_CPLXF_TYPE cdblm1 = ARNAUD_cplxf(-1.0f, 0.0f);
@@ -1040,23 +1040,23 @@ LINE40:
     //  when reciprocating a small RNORM, test against lower
     //  machine bound.
 
-    ccopy_(&n, resid, &int1, &v[ldv*V->aitr_j], &int1);
+    BLAS_FUNC(ccopy)(&n, resid, &int1, &v[ldv*V->aitr_j], &int1);
 
     if (*rnorm >= unfl)
     {
         temp1 = 1.0f / *rnorm;
-        csscal_(&n, &temp1, &v[ldv*V->aitr_j], &int1);
-        csscal_(&n, &temp1, &workd[ipj], &int1);
+        BLAS_FUNC(csscal)(&n, &temp1, &v[ldv*V->aitr_j], &int1);
+        BLAS_FUNC(csscal)(&n, &temp1, &workd[ipj], &int1);
     } else {
-        clascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*V->aitr_j], &n, &infol);
-        clascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
+        BLAS_FUNC(clascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*V->aitr_j], &n, &infol);
+        BLAS_FUNC(clascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
     }
 
     //  STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j}
     //  Note that this is not quite yet r_{j}. See STEP 4
 
     V->aitr_step3 = 1;
-    ccopy_(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
+    BLAS_FUNC(ccopy)(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
     ipntr[0] = ivj;
     ipntr[1] = irj;
     ipntr[2] = ipj;
@@ -1076,7 +1076,7 @@ LINE50:
 
     //  Put another copy of OP*v_{j} into RESID.
 
-    ccopy_(&n, &workd[irj], &int1, resid, &int1);
+    BLAS_FUNC(ccopy)(&n, &workd[irj], &int1, resid, &int1);
 
     //  STEP 4:  Finish extending the Arnoldi
     //           factorization to length j.
@@ -1092,7 +1092,7 @@ LINE50:
 
         return;
     } else {
-        ccopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(ccopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE60:
@@ -1110,7 +1110,7 @@ LINE60:
     {
         V->aitr_wnorm = sqrt(cabsf(cdotc_(&n, resid, &int1, &workd[ipj], &int1)));
     } else {
-        V->aitr_wnorm = scnrm2_(&n, resid, &int1);
+        V->aitr_wnorm = BLAS_FUNC(scnrm2)(&n, resid, &int1);
     }
 
     //  Compute the j-th residual corresponding
@@ -1122,19 +1122,19 @@ LINE60:
     //  Compute the j Fourier coefficients w_{j}
     //  WORKD(IPJ:IPJ+N-1) contains B*OP*v_{j}.
     tmp_int = V->aitr_j + 1;
-    cgemv_("C", &n, &tmp_int, &cdbl1, v, &ldv, &workd[ipj], &int1, &cdbl0, &h[ldh*(V->aitr_j)], &int1);
+    BLAS_FUNC(cgemv)("C", &n, &tmp_int, &cdbl1, v, &ldv, &workd[ipj], &int1, &cdbl0, &h[ldh*(V->aitr_j)], &int1);
 
     //  Orthogonalize r_{j} against V_{j}.
     //  RESID contains OP*v_{j}. See STEP 3.
 
-    cgemv_("N", &n, &tmp_int, &cdblm1, v, &ldv, &h[ldh*(V->aitr_j)], &int1, &cdbl1, resid, &int1);
+    BLAS_FUNC(cgemv)("N", &n, &tmp_int, &cdblm1, v, &ldv, &h[ldh*(V->aitr_j)], &int1, &cdbl1, resid, &int1);
 
     if (V->aitr_j > 0) { h[V->aitr_j + ldh*(V->aitr_j-1)] = ARNAUD_cplxf(V->aitr_betaj, 0.0f); }
 
     V->aitr_orth1 = 1;
     if (V->bmat)
     {
-        ccopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(ccopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1143,7 +1143,7 @@ LINE60:
 
         return;
     } else {
-        ccopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(ccopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE70:
@@ -1159,7 +1159,7 @@ LINE70:
     {
         *rnorm = sqrt(cabsf(cdotc_(&n, resid, &int1, &workd[ipj], &int1)));
     } else {
-        *rnorm = scnrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(scnrm2)(&n, resid, &int1);
     }
 
     //  STEP 5: Re-orthogonalization / Iterative refinement phase
@@ -1191,21 +1191,21 @@ LINE80:
     //  Compute V_{j}^T * B * r_{j}.
     //  WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1).
     tmp_int = V->aitr_j + 1;
-    cgemv_("C", &n, &tmp_int, &cdbl1, v, &ldv, &workd[ipj], &int1, &cdbl0, &workd[irj], &int1);
+    BLAS_FUNC(cgemv)("C", &n, &tmp_int, &cdbl1, v, &ldv, &workd[ipj], &int1, &cdbl0, &workd[irj], &int1);
 
     //  Compute the correction to the residual:
     //  r_{j} = r_{j} - V_{j} * WORKD(IRJ:IRJ+J-1).
     //  The correction to H is v(:,1:J)*H(1:J,1:J)
     //  + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.
 
-    cgemv_("N", &n, &tmp_int, &cdblm1, v, &ldv, &workd[irj], &int1, &cdbl1, resid, &int1);
-    caxpy_(&tmp_int, &cdbl1, &workd[irj], &int1, &h[ldh*(V->aitr_j)], &int1);
+    BLAS_FUNC(cgemv)("N", &n, &tmp_int, &cdblm1, v, &ldv, &workd[irj], &int1, &cdbl1, resid, &int1);
+    BLAS_FUNC(caxpy)(&tmp_int, &cdbl1, &workd[irj], &int1, &h[ldh*(V->aitr_j)], &int1);
 
     V->aitr_orth2 = 1;
 
     if (V->bmat)
     {
-        ccopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(ccopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1215,7 +1215,7 @@ LINE80:
 
         return;
     } else {
-        ccopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(ccopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE90:
@@ -1227,7 +1227,7 @@ LINE90:
     {
         V->aitr_rnorm1 = sqrt(cabsf(cdotc_(&n, resid, &int1, &workd[ipj], &int1)));
     } else {
-        V->aitr_rnorm1 = scnrm2_(&n, resid, &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(scnrm2)(&n, resid, &int1);
     }
 
     //  Determine if we need to perform another
@@ -1289,7 +1289,7 @@ LINE100:
                 tmp_int = k + np;
                 // clanhs(norm, n, a, lda, work) with "work" being float type
                 // Recasting complex workspace to float for scratch space.
-                tst1 = clanhs_("1", &tmp_int, h, &ldh, (float*)&workd[n]);
+                tst1 = BLAS_FUNC(clanhs)("1", &tmp_int, h, &ldh, (float*)&workd[n]);
             }
             if (cabsf(h[i+1 + ldh*i]) <= fmaxf(ulp*tst1, smlnum))
             {
@@ -1305,12 +1305,12 @@ LINE100:
 
 
 static void
-cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
-       int ldv, ARNAUD_CPLXF_TYPE* h, int ldh, ARNAUD_CPLXF_TYPE* resid,
-       ARNAUD_CPLXF_TYPE* q, int ldq, ARNAUD_CPLXF_TYPE* workl,
+cnapps(CBLAS_INT n, CBLAS_INT* kev, CBLAS_INT np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
+       CBLAS_INT ldv, ARNAUD_CPLXF_TYPE* h, CBLAS_INT ldh, ARNAUD_CPLXF_TYPE* resid,
+       ARNAUD_CPLXF_TYPE* q, CBLAS_INT ldq, ARNAUD_CPLXF_TYPE* workl,
        ARNAUD_CPLXF_TYPE* workd)
 {
-    int i, j, jj, int1 = 1, istart, iend = 0, tmp_int;
+    CBLAS_INT i, j, jj; CBLAS_INT int1 = 1; CBLAS_INT  istart, iend = 0, tmp_int;
     float smlnum = unfl * ( n / ulp);
     float c, tst1;
     float tmp_dbl;
@@ -1319,11 +1319,11 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
     ARNAUD_CPLXF_TYPE cdbl1 = ARNAUD_cplxf(1.0f, 0.0f);
     ARNAUD_CPLXF_TYPE cdbl0 = ARNAUD_cplxf(0.0f, 0.0f);
 
-    int kplusp = *kev + np;
+    CBLAS_INT kplusp = *kev + np;
 
     //  Initialize Q to the identity to accumulate
     //  the rotations and reflections
-    claset_("G", &kplusp, &kplusp, &cdbl0, &cdbl1, q, &ldq);
+    BLAS_FUNC(claset)("G", &kplusp, &kplusp, &cdbl0, &cdbl1, q, &ldq);
 
     //  Quick return if there are no shifts to apply
 
@@ -1347,7 +1347,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
                 if (tst1 == 0.0f)
                 {
                    tmp_int = kplusp - jj;
-                    clanhs_("1", &tmp_int, h, &ldh, (float*)workl);
+                    BLAS_FUNC(clanhs)("1", &tmp_int, h, &ldh, (float*)workl);
                 }
                 if (fabsf(crealf(h[iend+1 + ldh*iend])) <= fmaxf(ulp*tst1, smlnum))
                 {
@@ -1383,20 +1383,20 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
 
                 //  Construct the plane rotation G to zero out the bulge
 
-                clartg_(&f, &g, &c, &s, &r);
+                BLAS_FUNC(clartg)(&f, &g, &c, &s, &r);
                 if (i > istart)
                 {
                     h[i + ldh*(i-1)] = r;
                     h[i + 1 + ldh*(i-1)] = ARNAUD_cplxf(0.0f, 0.0f);
                 }
                 tmp_int = kplusp - i;
-                crot_(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
+                BLAS_FUNC(crot)(&tmp_int, &h[i + ldh*i], &ldh, &h[i + 1 + ldh*i], &ldh, &c, &s);
                 // z = a + bi, -conj(z) = -a + bi
                 s2 = conjf(s);
                 tmp_int = (i + 2 > iend ? iend : i + 2) + 1;
-                crot_(&tmp_int, &h[ldh*i], &int1, &h[ldh*(i+1)], &int1, &c, &s2);
+                BLAS_FUNC(crot)(&tmp_int, &h[ldh*i], &int1, &h[ldh*(i+1)], &int1, &c, &s2);
                 tmp_int = (i + jj + 2 > kplusp ? kplusp : i + jj + 2);
-                crot_(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s2);
+                BLAS_FUNC(crot)(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s2);
 
                 if (i < iend - 1)
                 {
@@ -1421,13 +1421,13 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
 
             tmp_cplx = conjf(t);
             tmp_int = kplusp - j;
-            cscal_(&tmp_int, &tmp_cplx, &h[j+1 + ldh*j], &ldh);
+            BLAS_FUNC(cscal)(&tmp_int, &tmp_cplx, &h[j+1 + ldh*j], &ldh);
 
             tmp_int = (j+3 > kplusp ? kplusp : j+3);
-            cscal_(&tmp_int, &t, &h[ldh*(j+1)], &int1);
+            BLAS_FUNC(cscal)(&tmp_int, &t, &h[ldh*(j+1)], &int1);
 
             tmp_int = (j+np+2 > kplusp ? kplusp : j+np+2);
-            cscal_(&tmp_int, &t, &q[ldq*(j+1)], &int1);
+            BLAS_FUNC(cscal)(&tmp_int, &t, &q[ldq*(j+1)], &int1);
 
             h[j+1 + ldh*j] = ARNAUD_cplxf(crealf(h[j+1 + ldh*j]), 0.0f);
         }
@@ -1448,7 +1448,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
                fabsf(cimagf(h[i + ldh*i])) + fabsf(cimagf(h[i+1 + ldh*(i+1)]));
         if (tst1 == 0.0f)
         {
-            tst1 = clanhs_("1", kev, h, &ldh, (float*)workl);
+            tst1 = BLAS_FUNC(clanhs)("1", kev, h, &ldh, (float*)workl);
         }
         if (crealf(h[i+1 + ldh*i]) <= fmaxf(ulp*tst1, smlnum))
         {
@@ -1465,7 +1465,7 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
 
     if (crealf(h[*kev + ldh*(*kev-1)]) > 0.0f)
     {
-        cgemv_("N", &n, &kplusp, &cdbl1, v, &ldv, &q[(*kev)*ldq], &int1, &cdbl0, &workd[n], &int1);
+        BLAS_FUNC(cgemv)("N", &n, &kplusp, &cdbl1, v, &ldv, &q[(*kev)*ldq], &int1, &cdbl0, &workd[n], &int1);
     }
 
     //  Compute column 1 to kev of (V*Q) in backward order
@@ -1474,18 +1474,18 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
     for (i = 0; i < *kev; i++)
     {
         tmp_int = kplusp - i;
-        cgemv_("N", &n, &tmp_int, &cdbl1, v, &ldv, &q[(*kev-i-1)*ldq], &int1, &cdbl0, workd, &int1);
-        ccopy_(&n, workd, &int1, &v[(kplusp-i-1)*ldv], &int1);
+        BLAS_FUNC(cgemv)("N", &n, &tmp_int, &cdbl1, v, &ldv, &q[(*kev-i-1)*ldq], &int1, &cdbl0, workd, &int1);
+        BLAS_FUNC(ccopy)(&n, workd, &int1, &v[(kplusp-i-1)*ldv], &int1);
     }
 
     //   Move v(:,kplusp-kev+1:kplusp) into v(:,1:kev).
 
-    clacpy_("A", &n, kev, &v[ldv*(kplusp - *kev)], &ldv, v, &ldv);
+    BLAS_FUNC(clacpy)("A", &n, kev, &v[ldv*(kplusp - *kev)], &ldv, v, &ldv);
 
     //  Copy the (kev+1)-st column of (V*Q) in the appropriate place
 
     if (crealf(h[*kev + ldh*(*kev-1)]) > 0.0f) {
-        ccopy_(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
+        BLAS_FUNC(ccopy)(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
     }
 
     //  Update the residual vector:
@@ -1494,11 +1494,11 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
     //     sigmak = (e_{kplusp}'*Q)*e_{kev}
     //     betak = e_{kev+1}'*H*e_{kev}
 
-    cscal_(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
+    BLAS_FUNC(cscal)(&n, &q[kplusp-1 + ldq*(*kev-1)], resid, &int1);
 
     if (crealf(h[*kev + ldh*(*kev-1)]) > 0.0f)
     {
-        caxpy_(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
+        BLAS_FUNC(caxpy)(&n, &h[*kev + ldh*(*kev-1)], &v[ldv*(*kev)], &int1, resid, &int1);
     }
 
     return;
@@ -1506,12 +1506,12 @@ cnapps(int n, int* kev, int np, ARNAUD_CPLXF_TYPE* shift, ARNAUD_CPLXF_TYPE* v,
 
 
 static void
-cneigh(float* rnorm, int n, ARNAUD_CPLXF_TYPE* h, int ldh, ARNAUD_CPLXF_TYPE* ritz,
-       ARNAUD_CPLXF_TYPE* bounds, ARNAUD_CPLXF_TYPE* q, int ldq, ARNAUD_CPLXF_TYPE* workl,
-       float* rwork, int* ierr)
+cneigh(float* rnorm, CBLAS_INT n, ARNAUD_CPLXF_TYPE* h, CBLAS_INT ldh, ARNAUD_CPLXF_TYPE* ritz,
+       ARNAUD_CPLXF_TYPE* bounds, ARNAUD_CPLXF_TYPE* q, CBLAS_INT ldq, ARNAUD_CPLXF_TYPE* workl,
+       float* rwork, CBLAS_INT* ierr)
 {
-    int select[1] = { 0 };
-    int int1 = 1, j;
+    CBLAS_INT select[1] = { 0 };
+    CBLAS_INT int1 = 1, j;
     float temp;
     ARNAUD_CPLXF_TYPE vl[1];
     vl[0] = ARNAUD_cplxf(0.0f, 0.0f);
@@ -1523,19 +1523,19 @@ cneigh(float* rnorm, int n, ARNAUD_CPLXF_TYPE* h, int ldh, ARNAUD_CPLXF_TYPE* ri
     //     zlahqr returns the full Schur form of H
     //     in WORKL(1:N**2), and the Schur vectors in q.
 
-    clacpy_("A", &n, &n, h, &ldh, workl, &n);
-    claset_("A", &n, &n, &c0, &c1, q, &ldq);
-    clahqr_(&int1, &int1, &n, &int1, &n, workl, &ldh, ritz, &int1, &n, q, &ldq, ierr);
+    BLAS_FUNC(clacpy)("A", &n, &n, h, &ldh, workl, &n);
+    BLAS_FUNC(claset)("A", &n, &n, &c0, &c1, q, &ldq);
+    BLAS_FUNC(clahqr)(&int1, &int1, &n, &int1, &n, workl, &ldh, ritz, &int1, &n, q, &ldq, ierr);
 
     if (*ierr != 0) { return; }
 
-    ccopy_(&n, &q[n-2], &ldq, bounds, &int1);
+    BLAS_FUNC(ccopy)(&n, &q[n-2], &ldq, bounds, &int1);
 
     //  2. Compute the eigenvectors of the full Schur form T and
     //     apply the Schur vectors to get the corresponding
     //     eigenvectors.
 
-    ctrevc_("R", "B", select, &n, workl, &n, vl, &n, q, &ldq, &n, &n, &workl[n*n], rwork, ierr);
+    BLAS_FUNC(ctrevc)("R", "B", select, &n, workl, &n, vl, &n, q, &ldq, &n, &n, &workl[n*n], rwork, ierr);
 
     if (*ierr != 0) { return; }
 
@@ -1548,21 +1548,21 @@ cneigh(float* rnorm, int n, ARNAUD_CPLXF_TYPE* h, int ldh, ARNAUD_CPLXF_TYPE* ri
 
     for (j = 0; j < n; j++)
     {
-        temp = 1.0f / scnrm2_(&n, &q[j*ldq], &int1);
-        csscal_(&n, &temp, &q[j*ldq], &int1);
+        temp = 1.0f / BLAS_FUNC(scnrm2)(&n, &q[j*ldq], &int1);
+        BLAS_FUNC(csscal)(&n, &temp, &q[j*ldq], &int1);
     }
 
     //  Compute the Ritz estimates
 
-    ccopy_(&n, &q[n-1], &n, bounds, &int1);
-    csscal_(&n, rnorm, bounds, &int1);
+    BLAS_FUNC(ccopy)(&n, &q[n-1], &n, bounds, &int1);
+    BLAS_FUNC(csscal)(&n, rnorm, bounds, &int1);
 
     return;
 }
 
 
 static void
-cngets(struct ARNAUD_state_s *V, int* kev, int* np,
+cngets(struct ARNAUD_state_s *V, CBLAS_INT* kev, CBLAS_INT* np,
        ARNAUD_CPLXF_TYPE* ritz, ARNAUD_CPLXF_TYPE* bounds)
 {
 
@@ -1586,11 +1586,11 @@ cngets(struct ARNAUD_state_s *V, int* kev, int* np,
 
 
 static void
-cgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
-       ARNAUD_CPLXF_TYPE* v, int ldv, ARNAUD_CPLXF_TYPE* resid, float* rnorm,
-       int* ipntr, ARNAUD_CPLXF_TYPE* workd)
+cgetv0(struct ARNAUD_state_s *V, CBLAS_INT initv, CBLAS_INT n, CBLAS_INT j,
+       ARNAUD_CPLXF_TYPE* v, CBLAS_INT ldv, ARNAUD_CPLXF_TYPE* resid, float* rnorm,
+       CBLAS_INT* ipntr, ARNAUD_CPLXF_TYPE* workd)
 {
-    int jj, int1 = 1;
+    CBLAS_INT jj; CBLAS_INT int1 = 1;
     const float sq2o2 = sqrt(2.0) / 2.0;
     ARNAUD_CPLXF_TYPE c0 = ARNAUD_cplxf(0.0f, 0.0f);
     ARNAUD_CPLXF_TYPE c1 = ARNAUD_cplxf(1.0f, 0.0f);
@@ -1629,12 +1629,12 @@ cgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
         {
             ipntr[0] = 0;
             ipntr[1] = n;
-            ccopy_(&n, resid, &int1, workd, &int1);
+            BLAS_FUNC(ccopy)(&n, resid, &int1, workd, &int1);
             V->ido = ido_RANDOM_OPX;
             return;
         } else if ((V->getv0_itry > 1) && (V->bmat == 1))
         {
-            ccopy_(&n, resid, &int1, &workd[n], &int1);
+            BLAS_FUNC(ccopy)(&n, resid, &int1, &workd[n], &int1);
         }
     }
 
@@ -1652,7 +1652,7 @@ cgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
     V->getv0_first = 1;
     if (V->getv0_itry == 1)
     {
-        ccopy_(&n, &workd[n], &int1, resid, &int1);
+        BLAS_FUNC(ccopy)(&n, &workd[n], &int1, resid, &int1);
     }
     if (V->bmat)
     {
@@ -1661,7 +1661,7 @@ cgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
         V->ido = ido_BX;
         return;
     } else {
-        ccopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(ccopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE20:
@@ -1671,7 +1671,7 @@ LINE20:
     {
         V->getv0_rnorm0 = sqrt(cabsf(cdotc_(&n, resid, &int1, workd, &int1)));
     } else {
-        V->getv0_rnorm0 = scnrm2_(&n, resid, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(scnrm2)(&n, resid, &int1);
     }
     *rnorm = V->getv0_rnorm0;
 
@@ -1697,20 +1697,20 @@ LINE20:
 
 LINE30:
 
-    cgemv_("C", &n, &j, &c1, v, &ldv, workd, &int1, &c0, &workd[n], &int1);
-    cgemv_("N", &n, &j, &cm1, v, &ldv, &workd[n], &int1, &c1, resid, &int1);
+    BLAS_FUNC(cgemv)("C", &n, &j, &c1, v, &ldv, workd, &int1, &c0, &workd[n], &int1);
+    BLAS_FUNC(cgemv)("N", &n, &j, &cm1, v, &ldv, &workd[n], &int1, &c1, resid, &int1);
 
     //  Compute the B-norm of the orthogonalized starting vector
 
     if (V->bmat)
     {
-        ccopy_(&n, resid, &int1, &workd[n], &int1);
+        BLAS_FUNC(ccopy)(&n, resid, &int1, &workd[n], &int1);
         ipntr[0] = n;
         ipntr[1] = 0;
         V->ido = ido_BX;
         return;
     } else {
-        ccopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(ccopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE40:
@@ -1718,7 +1718,7 @@ LINE40:
     {
         *rnorm = sqrt(cabsf(cdotc_(&n, resid, &int1, workd, &int1)));
     } else {
-        *rnorm = scnrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(scnrm2)(&n, resid, &int1);
     }
 
     //  Check for further orthogonalization.
@@ -1753,9 +1753,9 @@ LINE40:
 
 
 static void
-csortc(const enum ARNAUD_which w, const int apply, const int n, ARNAUD_CPLXF_TYPE *x, ARNAUD_CPLXF_TYPE *y)
+csortc(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, ARNAUD_CPLXF_TYPE *x, ARNAUD_CPLXF_TYPE *y)
 {
-    int i, gap, pos;
+    CBLAS_INT i, gap, pos;
     ARNAUD_CPLXF_TYPE temp;
     ARNAUD_compare_cfunc *f;
 
@@ -1811,19 +1811,19 @@ csortc(const enum ARNAUD_which w, const int apply, const int n, ARNAUD_CPLXF_TYP
 }
 
 
-static int sortc_LM(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (cabsf(x) > cabsf(y)); }
-static int sortc_SM(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (cabsf(x) < cabsf(y)); }
-static int sortc_LR(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (crealf(x) > crealf(y)); }
-static int sortc_SR(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (crealf(x) < crealf(y)); }
-static int sortc_LI(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (cimagf(x) > cimagf(y)); }
-static int sortc_SI(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (cimagf(x) < cimagf(y)); }
+static CBLAS_INT sortc_LM(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (cabsf(x) > cabsf(y)); }
+static CBLAS_INT sortc_SM(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (cabsf(x) < cabsf(y)); }
+static CBLAS_INT sortc_LR(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (crealf(x) > crealf(y)); }
+static CBLAS_INT sortc_SR(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (crealf(x) < crealf(y)); }
+static CBLAS_INT sortc_LI(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (cimagf(x) > cimagf(y)); }
+static CBLAS_INT sortc_SI(const ARNAUD_CPLXF_TYPE x, const ARNAUD_CPLXF_TYPE y) { return (cimagf(x) < cimagf(y)); }
 
 
 // cdotc is the complex conjugate dot product of two complex vectors.
 // Due some historical reasons, this function can cause segfaults on some
 // platforms. Hence implemented here instead of using the BLAS version.
 static ARNAUD_CPLXF_TYPE
-cdotc_(const int* n, const ARNAUD_CPLXF_TYPE* restrict x, const int* incx, const ARNAUD_CPLXF_TYPE* restrict y, const int* incy)
+cdotc_(const CBLAS_INT* n, const ARNAUD_CPLXF_TYPE* restrict x, const CBLAS_INT* incx, const ARNAUD_CPLXF_TYPE* restrict y, const CBLAS_INT* incy)
 {
     ARNAUD_CPLXF_TYPE result = ARNAUD_cplxf(0.0f, 0.0f);
 #ifdef _MSC_VER
@@ -1831,10 +1831,10 @@ cdotc_(const int* n, const ARNAUD_CPLXF_TYPE* restrict x, const int* incx, const
 #endif
     if (*n <= 0) { return result; }
 
-    int ix, iy;
+    CBLAS_INT ix, iy;
     if ((*incx == 1) && (*incy == 1))
     {
-        for (int i = 0; i < *n; i++)
+        for (CBLAS_INT i = 0; i < *n; i++)
         {
 #ifdef _MSC_VER
             temp = _FCmulcc(x[i], conjf(y[i]));
@@ -1849,7 +1849,7 @@ cdotc_(const int* n, const ARNAUD_CPLXF_TYPE* restrict x, const int* incx, const
         ix = (*incx >= 0) ? 0 : (-(*n-1) * (*incx));
         iy = (*incy >= 0) ? 0 : (-(*n-1) * (*incy));
 
-        for (int i = 0; i < *n; i++)
+        for (CBLAS_INT i = 0; i < *n; i++)
         {
 #ifdef _MSC_VER
             temp = _FCmulcc(x[ix], conjf(y[iy]));

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_double.c
@@ -1,26 +1,26 @@
 #include "arnaud_s_double.h"
 #include <float.h>
 
-typedef int ARNAUD_compare_rfunc(const double, const double);
+typedef CBLAS_INT ARNAUD_compare_rfunc(const double, const double);
 
-static int sortr_LM(const double, const double);
-static int sortr_SM(const double, const double);
-static int sortr_LA(const double, const double);
-static int sortr_SA(const double, const double);
+static CBLAS_INT sortr_LM(const double, const double);
+static CBLAS_INT sortr_SM(const double, const double);
+static CBLAS_INT sortr_LA(const double, const double);
+static CBLAS_INT sortr_SA(const double, const double);
 
 static const double unfl = DBL_MIN;    // 2.2250738585072014e-308;
 static const double ulp = DBL_EPSILON; // 2.220446049250313e-16;
 
-static void dsaup2(struct ARNAUD_state_d*, double*, double*, int, double*, int, double*, double*, double*, int, double*, int*, double*);
-static void dsconv(int, double*, double*, double, int*);
-static void dseigt(double, int, double*, int, double*, double*, double*, int*);
-static void dsaitr(struct ARNAUD_state_d*, int, int, double*, double*, double*, int, double*, int, int*, double*);
-static void dsapps(int, int*, int, double*, double*, int, double*, int, double*, double* , int, double*);
-static void dsgets(struct ARNAUD_state_d*, int*, int*, double*, double*, double*);
-static void dgetv0(struct ARNAUD_state_d *, int, int, int, double*, int, double*, double*, int*, double*);
-static void dsortr(const enum ARNAUD_which w, const int apply, const int n, double* x1, double* x2);
-static void dsesrt(const enum ARNAUD_which w, const int apply, const int n, double* x, int na, double* a, const int lda);
-static void dstqrb(int n, double* d, double* e, double* z, double* work, int* info);
+static void dsaup2(struct ARNAUD_state_d*, double*, double*, CBLAS_INT, double*, CBLAS_INT, double*, double*, double*, CBLAS_INT, double*, CBLAS_INT*, double*);
+static void dsconv(CBLAS_INT, double*, double*, double, CBLAS_INT*);
+static void dseigt(double, CBLAS_INT, double*, CBLAS_INT, double*, double*, double*, CBLAS_INT*);
+static void dsaitr(struct ARNAUD_state_d*, CBLAS_INT, CBLAS_INT, double*, double*, double*, CBLAS_INT, double*, CBLAS_INT, CBLAS_INT*, double*);
+static void dsapps(CBLAS_INT, CBLAS_INT*, CBLAS_INT, double*, double*, CBLAS_INT, double*, CBLAS_INT, double*, double* , CBLAS_INT, double*);
+static void dsgets(struct ARNAUD_state_d*, CBLAS_INT*, CBLAS_INT*, double*, double*, double*);
+static void dgetv0(struct ARNAUD_state_d *, CBLAS_INT, CBLAS_INT, CBLAS_INT, double*, CBLAS_INT, double*, double*, CBLAS_INT*, double*);
+static void dsortr(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, double* x1, double* x2);
+static void dsesrt(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, double* x, CBLAS_INT na, double* a, const CBLAS_INT lda);
+static void dstqrb(CBLAS_INT n, double* d, double* e, double* z, double* work, CBLAS_INT* info);
 
 enum ARNAUD_seupd_type {
     REGULAR,
@@ -31,14 +31,14 @@ enum ARNAUD_seupd_type {
 
 
 void
-ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
-       double* d, double* z, int ldz, double sigma, double* resid, double* v,
-       int ldv, int* ipntr, double* workd, double* workl)
+ARNAUD_dseupd(struct ARNAUD_state_d *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select,
+       double* d, double* z, CBLAS_INT ldz, double sigma, double* resid, double* v,
+       CBLAS_INT ldv, CBLAS_INT* ipntr, double* workd, double* workl)
 {
     const double eps23 = pow(ulp, 2.0 / 3.0);
-    int j, jj, k;
-    int ibd, ih, ihb, ihd, iq, irz, iw, ldh, ldq, ritz, bounds, next, np;
-    int ierr = 0, int1 = 1, tmp_int = 0, numcnv, reord;
+    CBLAS_INT j, jj, k;
+    CBLAS_INT ibd, ih, ihb, ihd, iq, irz, iw, ldh, ldq, ritz, bounds, next, np;
+    CBLAS_INT ierr = 0; CBLAS_INT int1 = 1; CBLAS_INT  tmp_int = 0, numcnv, reord;
     double bnorm2, rnorm, temp, temp1, dbl1 = 1.0;
 
     if (V->nconv == 0) { return; }
@@ -159,7 +159,7 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
     rnorm = workl[ih];
     if (V->bmat)
     {
-        bnorm2 = dnrm2_(&V->n, workd, &int1);
+        bnorm2 = BLAS_FUNC(dnrm2)(&V->n, workd, &int1);
     } else {
         bnorm2 = rnorm;
     }
@@ -197,7 +197,7 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         {
             temp1 = fmax(eps23, fabs(workl[irz + V->ncv - j]));
 
-            jj = (int)workl[bounds + V->ncv - j];
+            jj = (CBLAS_INT)workl[bounds + V->ncv - j];
 
             if ((numcnv < V->nconv) && (workl[ibd + jj] <= V->tol*temp1))
             {
@@ -224,10 +224,10 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         // Initialize the eigenvector matrix Q to the identity.
 
         tmp_int = V->ncv - 1;
-        dcopy_(&tmp_int, &workl[ih+1], &int1, &workl[ihb], &int1);
-        dcopy_(&V->ncv, &workl[ih+ldh], &int1, &workl[ihd], &int1);
+        BLAS_FUNC(dcopy)(&tmp_int, &workl[ih+1], &int1, &workl[ihb], &int1);
+        BLAS_FUNC(dcopy)(&V->ncv, &workl[ih+ldh], &int1, &workl[ihd], &int1);
 
-        dsteqr_("I", &V->ncv, &workl[ihd], &workl[ihb], &workl[iq], &ldq, &workl[iw], &ierr);
+        BLAS_FUNC(dsteqr)("I", &V->ncv, &workl[ihd], &workl[ihb], &workl[iq], &ldq, &workl[iw], &ierr);
 
         if (ierr != 0)
         {
@@ -245,8 +245,8 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
             // eigenvectors appear in the first NCONV
             // columns.
 
-            int leftptr = 0;
-            int rightptr = V->ncv - 1;
+            CBLAS_INT leftptr = 0;
+            CBLAS_INT rightptr = V->ncv - 1;
 
             if (V->ncv > 1)
             {
@@ -277,9 +277,9 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
                         workl[ihd + leftptr] = workl[ihd + rightptr];
                         workl[ihd + rightptr] = temp;
 
-                        dcopy_(&V->ncv, &workl[iq + V->ncv*leftptr], &int1, &workl[iw], &int1);
-                        dcopy_(&V->ncv, &workl[iq + V->ncv*rightptr], &int1, &workl[iq + V->ncv*leftptr], &int1);
-                        dcopy_(&V->ncv, &workl[iw], &int1, &workl[iq + V->ncv*rightptr], &int1);
+                        BLAS_FUNC(dcopy)(&V->ncv, &workl[iq + V->ncv*leftptr], &int1, &workl[iw], &int1);
+                        BLAS_FUNC(dcopy)(&V->ncv, &workl[iq + V->ncv*rightptr], &int1, &workl[iq + V->ncv*leftptr], &int1);
+                        BLAS_FUNC(dcopy)(&V->ncv, &workl[iw], &int1, &workl[iq + V->ncv*rightptr], &int1);
 
                         leftptr += 1;
                         rightptr -= 1;
@@ -290,14 +290,14 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
         // Load the converged Ritz values into D.
 
-        dcopy_(&V->nconv, &workl[ihd], &int1, d, &int1);
+        BLAS_FUNC(dcopy)(&V->nconv, &workl[ihd], &int1, d, &int1);
 
     } else {
 
         // Ritz vectors not required. Load Ritz values into D.
 
-        dcopy_(&V->nconv, &workl[ritz], &int1, d, &int1);
-        dcopy_(&V->ncv, &workl[ritz], &int1, &workl[ihd], &int1);
+        BLAS_FUNC(dcopy)(&V->nconv, &workl[ritz], &int1, d, &int1);
+        BLAS_FUNC(dcopy)(&V->ncv, &workl[ritz], &int1, &workl[ihd], &int1);
     }
 
     // Transform the Ritz values and possibly vectors and corresponding
@@ -313,7 +313,7 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         if (rvec) {
             dsesrt(which_LA, rvec, V->nconv, d, V->ncv, &workl[iq], ldq);
         } else {
-            dcopy_(&V->ncv, &workl[bounds], &int1, &workl[ihb], &int1);
+            BLAS_FUNC(dcopy)(&V->ncv, &workl[bounds], &int1, &workl[ihb], &int1);
         }
 
     } else {
@@ -331,19 +331,19 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         // *The Ritz vectors are not affected by the transformation.
         //  They are only reordered.
 
-        dcopy_(&V->ncv, &workl[ihd], &int1, &workl[iw], &int1);
+        BLAS_FUNC(dcopy)(&V->ncv, &workl[ihd], &int1, &workl[iw], &int1);
         if (TYP == SHIFTI)
         {
-            for (int k = 0; k < V->ncv; k++)
+            for (CBLAS_INT k = 0; k < V->ncv; k++)
             {
                 workl[ihd + k] = 1.0 / workl[ihd + k] + sigma;
             }
         } else if (TYP == BUCKLE) {
-            for (int k = 0; k < V->ncv; k++) {
+            for (CBLAS_INT k = 0; k < V->ncv; k++) {
                 workl[ihd + k] = sigma * workl[ihd + k] / (workl[ihd + k] - 1.0);
             }
         } else if (TYP == CAYLEY) {
-            for (int k = 0; k < V->ncv; k++) {
+            for (CBLAS_INT k = 0; k < V->ncv; k++) {
                 workl[ihd + k] = sigma * (workl[ihd + k] + 1.0) / (workl[ihd + k] - 1.0);
             }
         }
@@ -361,14 +361,14 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         //  match the ordering of the lambda. We`ll use them again for
         //  Ritz vector purification.
 
-        dcopy_(&V->nconv, &workl[ihd], &int1, d, &int1);
+        BLAS_FUNC(dcopy)(&V->nconv, &workl[ihd], &int1, d, &int1);
         dsortr(which_LA, 1, V->nconv, &workl[ihd], &workl[iw]);
         if (rvec) {
             dsesrt(which_LA, rvec, V->nconv, d, V->ncv, &workl[iq], ldq);
         } else {
-            dcopy_(&V->ncv, &workl[bounds], &int1, &workl[ihb], &int1);
+            BLAS_FUNC(dcopy)(&V->ncv, &workl[bounds], &int1, &workl[ihb], &int1);
             temp = bnorm2 / rnorm;
-            dscal_(&V->ncv, &temp, &workl[ihb], &int1);
+            BLAS_FUNC(dscal)(&V->ncv, &temp, &workl[ihb], &int1);
             dsortr(which_LA, 1, V->nconv, d, &workl[ihb]);
         }
     }
@@ -384,7 +384,7 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         // the wanted invariant subspace located in the first NCONV
         // columns of workl(iq, ldq).
 
-        dgeqr2_(&V->ncv, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], &workl[ihb], &ierr);
+        BLAS_FUNC(dgeqr2)(&V->ncv, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], &workl[ihb], &ierr);
 
         // * Postmultiply V by Q.
         // * Copy the first NCONV columns of VQ into Z.
@@ -392,25 +392,25 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         // of the approximate invariant subspace associated with
         // the Ritz values in workl(ihd).
 
-        dorm2r_("R", "N", &V->n, &V->ncv, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], v, &ldv, &workd[V->n], &ierr);
-        dlacpy_("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
+        BLAS_FUNC(dorm2r)("R", "N", &V->n, &V->ncv, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], v, &ldv, &workd[V->n], &ierr);
+        BLAS_FUNC(dlacpy)("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
 
         // In order to compute the Ritz estimates for the Ritz
         // values in both systems, need the last row of the
         // eigenvector matrix. Remember, it's in factored form.
 
-        for (int j = 0; j < V->ncv - 1; j++)
+        for (CBLAS_INT j = 0; j < V->ncv - 1; j++)
         {
             workl[ihb + j] = 0.0;
         }
         workl[ihb + V->ncv - 1] = 1.0;
-        dorm2r_("L", "T", &V->ncv, &int1, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], &workl[ihb], &V->ncv, &temp, &ierr);
+        BLAS_FUNC(dorm2r)("L", "T", &V->ncv, &int1, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], &workl[ihb], &V->ncv, &temp, &ierr);
 
         //  Make a copy of the last row into
         //  workl(iw+ncv:iw+2*ncv), as it is needed again in
         //  the Ritz vector purification step below
 
-        for (int j = 0; j < V->nconv; j++)
+        for (CBLAS_INT j = 0; j < V->nconv; j++)
         {
             workl[iw + V->ncv + j] = workl[ihb + j];
         }
@@ -438,7 +438,7 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
         // *  Determine Ritz estimates of the lambda.
 
 
-        dscal_(&V->ncv, &bnorm2, &workl[ihb], &int1);
+        BLAS_FUNC(dscal)(&V->ncv, &bnorm2, &workl[ihb], &int1);
 
         for (k = 0; k < V->ncv; k++)
         {
@@ -476,7 +476,7 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
     if ((rvec) && (TYP != REGULAR))
     {
-        dger_(&V->n, &V->nconv, &dbl1, resid, &int1, &workl[iw], &int1, z, &ldz);
+        BLAS_FUNC(dger)(&V->n, &V->nconv, &dbl1, resid, &int1, &workl[iw], &int1, z, &ldz);
     }
 
     return;
@@ -484,11 +484,11 @@ ARNAUD_dseupd(struct ARNAUD_state_d *V, int rvec, int howmny, int* select,
 
 
 void
-ARNAUD_dsaupd(struct ARNAUD_state_d *V, double* resid, double* v, int ldv,
-       int* ipntr, double* workd, double* workl)
+ARNAUD_dsaupd(struct ARNAUD_state_d *V, double* resid, double* v, CBLAS_INT ldv,
+       CBLAS_INT* ipntr, double* workd, double* workl)
 {
 
-    int bounds = 0, ih = 0, iq = 0, iw = 0, j = 0, ldh = 0, ldq = 0, next = 0, ritz = 0;
+    CBLAS_INT bounds = 0, ih = 0, iq = 0, iw = 0, j = 0, ldh = 0, ldq = 0, next = 0, ritz = 0;
 
     if (V->ido == ido_FIRST)
     {
@@ -578,11 +578,11 @@ ARNAUD_dsaupd(struct ARNAUD_state_d *V, double* resid, double* v, int ldv,
 
 
 void
-dsaup2(struct ARNAUD_state_d *V, double* resid, double* v, int ldv,
-       double* h, int ldh, double* ritz, double* bounds,
-       double* q, int ldq, double* workl, int* ipntr, double* workd)
+dsaup2(struct ARNAUD_state_d *V, double* resid, double* v, CBLAS_INT ldv,
+       double* h, CBLAS_INT ldh, double* ritz, double* bounds,
+       double* q, CBLAS_INT ldq, double* workl, CBLAS_INT* ipntr, double* workd)
 {
-    int int1 = 1, j, tmp_int, nevd2, nevm2;
+    CBLAS_INT int1 = 1, j, tmp_int, nevd2, nevm2;
     const double eps23 = pow(ulp, 2.0 / 3.0);
     double temp = 0.0;
     // Initialize to silence the compiler warning
@@ -720,8 +720,8 @@ LINE20:
     // Make a copy of eigenvalues and corresponding error
     // bounds obtained from _seigt.
 
-    dcopy_(&V->aup2_kplusp, ritz, &int1, &workl[V->aup2_kplusp], &int1);
-    dcopy_(&V->aup2_kplusp, bounds, &int1, &workl[2*V->aup2_kplusp], &int1);
+    BLAS_FUNC(dcopy)(&V->aup2_kplusp, ritz, &int1, &workl[V->aup2_kplusp], &int1);
+    BLAS_FUNC(dcopy)(&V->aup2_kplusp, bounds, &int1, &workl[2*V->aup2_kplusp], &int1);
 
     // Select the wanted Ritz values and their bounds
     // to be used in the convergence test.
@@ -738,7 +738,7 @@ LINE20:
 
     // Convergence test
 
-    dcopy_(&V->aup2_nev, &bounds[V->np], &int1, &workl[V->np], &int1);
+    BLAS_FUNC(dcopy)(&V->aup2_nev, &bounds[V->np], &int1, &workl[V->np], &int1);
     dsconv(V->aup2_nev, &ritz[V->np], &workl[V->np], V->tol, &V->nconv);
 
     // Count the number of unwanted Ritz values that have zero
@@ -786,10 +786,10 @@ LINE20:
                 V->np = V->aup2_kplusp - V->aup2_nev0;
 
                 tmp_int = (nevd2 < V->np ? nevd2 : V->np);
-                int tmp_int2 = V->aup2_kplusp - tmp_int;
+                CBLAS_INT tmp_int2 = V->aup2_kplusp - tmp_int;
 
-                dswap_(&tmp_int, &ritz[nevm2], &int1, &ritz[tmp_int2], &int1);
-                dswap_(&tmp_int, &bounds[nevm2], &int1, &bounds[tmp_int2], &int1);
+                BLAS_FUNC(dswap)(&tmp_int, &ritz[nevm2], &int1, &ritz[tmp_int2], &int1);
+                BLAS_FUNC(dswap)(&tmp_int, &bounds[nevm2], &int1, &bounds[tmp_int2], &int1);
             }
 
         } else {
@@ -890,7 +890,7 @@ LINE20:
         // To prevent possible stagnation, adjust the number
         // of Ritz values and the shifts.
 
-        int nevbef = V->aup2_nev;
+        CBLAS_INT nevbef = V->aup2_nev;
         V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
         if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6))
         {
@@ -932,7 +932,7 @@ LINE50:
     // free up WORKL.  This is for the non-exact shift case;
     // in the exact shift case, dsgets already handles this.
 
-    if (V->shift == 0) { dcopy_(&V->np, workl, &int1, ritz, &int1); }
+    if (V->shift == 0) { BLAS_FUNC(dcopy)(&V->np, workl, &int1, ritz, &int1); }
 
      /*--------------------------------------------------------*
      | Apply the NP0 implicit shifts by QR bulge chasing.      |
@@ -952,7 +952,7 @@ LINE50:
 
     if (V->bmat)
     {
-        dcopy_(&V->n, resid, &int1, &workd[V->n], &int1);
+        BLAS_FUNC(dcopy)(&V->n, resid, &int1, &workd[V->n], &int1);
         ipntr[0] = V->n;
         ipntr[1] = 0;
         V->ido = ido_BX;
@@ -961,7 +961,7 @@ LINE50:
 
         return;
     } else {
-        dcopy_(&V->n, resid, &int1, workd, &int1);
+        BLAS_FUNC(dcopy)(&V->n, resid, &int1, workd, &int1);
     }
 
 LINE100:
@@ -973,9 +973,9 @@ LINE100:
 
     if (V->bmat)
     {
-        V->aup2_rnorm = sqrt(fabs(ddot_(&V->n, resid, &int1, workd, &int1)));
+        V->aup2_rnorm = sqrt(fabs(BLAS_FUNC(ddot)(&V->n, resid, &int1, workd, &int1)));
     } else {
-        V->aup2_rnorm = dnrm2_(&V->n, resid, &int1);
+        V->aup2_rnorm = BLAS_FUNC(dnrm2)(&V->n, resid, &int1);
     }
 
     V->aup2_cnorm = 0;
@@ -990,14 +990,14 @@ LINE100:
 
 
 void
-dsconv(int n, double *ritz, double *bounds, double tol, int* nconv)
+dsconv(CBLAS_INT n, double *ritz, double *bounds, double tol, CBLAS_INT* nconv)
 {
     const double eps23 = pow(ulp, 2.0 / 3.0);
     double temp = 0.0;
 
     *nconv = 0;
     // Convergence test
-    for (int i = 0; i < n; i++)
+    for (CBLAS_INT i = 0; i < n; i++)
     {
         temp = fmax(eps23, fabs(ritz[i]));
         if (fabs(bounds[i]) <= tol * temp) { *nconv += 1; }
@@ -1008,28 +1008,28 @@ dsconv(int n, double *ritz, double *bounds, double tol, int* nconv)
 
 
 void
-dseigt(double rnorm, int n, double* h, int ldh, double* eig, double* bounds,
-       double* workl, int* ierr)
+dseigt(double rnorm, CBLAS_INT n, double* h, CBLAS_INT ldh, double* eig, double* bounds,
+       double* workl, CBLAS_INT* ierr)
 {
-    int int1 = 1, tmp_int;
-    dcopy_(&n, &h[ldh], &int1, eig, &int1);
+    CBLAS_INT int1 = 1, tmp_int;
+    BLAS_FUNC(dcopy)(&n, &h[ldh], &int1, eig, &int1);
     tmp_int = n - 1;
-    dcopy_(&tmp_int, &h[1], &int1, workl, &int1);
+    BLAS_FUNC(dcopy)(&tmp_int, &h[1], &int1, workl, &int1);
     dstqrb(n, eig, workl, bounds, &workl[n], ierr);
     if (*ierr != 0) { return; }
-    for (int k = 0; k < n; k++) { bounds[k] = rnorm * fabs(bounds[k]); }
+    for (CBLAS_INT k = 0; k < n; k++) { bounds[k] = rnorm * fabs(bounds[k]); }
     return;
 }
 
 
 void
-dsaitr(struct ARNAUD_state_d *V, int k, int np, double* resid, double* rnorm,
-       double* v, int ldv, double* h, int ldh, int* ipntr, double* workd)
+dsaitr(struct ARNAUD_state_d *V, CBLAS_INT k, CBLAS_INT np, double* resid, double* rnorm,
+       double* v, CBLAS_INT ldv, double* h, CBLAS_INT ldh, CBLAS_INT* ipntr, double* workd)
 {
-    int i, infol, ipj, irj, ivj, jj, n, tmp_int;
+    CBLAS_INT i, infol, ipj, irj, ivj, jj, n, tmp_int;
     const double sq2o2 = sqrt(2.0) / 2.0;
 
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
     double dbl1 = 1.0, dbl0 = 0.0, dblm1 = -1.0, temp1;
 
     n = V->n;  // n is constant, this is just for typing convenience
@@ -1121,22 +1121,22 @@ LINE40:
     //  when reciprocating a small RNORM, test against lower
     //  machine bound.
 
-    dcopy_(&n, resid, &int1, &v[ldv*(V->aitr_j)], &int1);
+    BLAS_FUNC(dcopy)(&n, resid, &int1, &v[ldv*(V->aitr_j)], &int1);
     if (*rnorm >= unfl)
     {
         temp1 = 1.0 / *rnorm;
-        dscal_(&n, &temp1, &v[ldv*(V->aitr_j)], &int1);
-        dscal_(&n, &temp1, &workd[ipj], &int1);
+        BLAS_FUNC(dscal)(&n, &temp1, &v[ldv*(V->aitr_j)], &int1);
+        BLAS_FUNC(dscal)(&n, &temp1, &workd[ipj], &int1);
     } else {
-        dlascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*(V->aitr_j)], &n, &infol);
-        dlascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
+        BLAS_FUNC(dlascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*(V->aitr_j)], &n, &infol);
+        BLAS_FUNC(dlascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
     }
 
     //  STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j}
     //  Note that this is not quite yet r_{j}. See STEP 4
 
     V->aitr_step3 = 1;
-    dcopy_(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
+    BLAS_FUNC(dcopy)(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
     ipntr[0] = ivj;
     ipntr[1] = irj;
     ipntr[2] = ipj;
@@ -1155,7 +1155,7 @@ LINE50:
 
     // Put another copy of OP*v_{j} into RESID.
 
-    dcopy_(&n, &workd[irj], &int1, resid, &int1);
+    BLAS_FUNC(dcopy)(&n, &workd[irj], &int1, resid, &int1);
 
     // STEP 4:  Finish extending the symmetric
     //          Arnoldi to length j. If MODE = 2
@@ -1176,7 +1176,7 @@ LINE50:
 
         return;
     } else {
-        dcopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE60:
@@ -1197,13 +1197,13 @@ LINE65:
         // Note that the B-norm of OP*v_{j}
         // is the inv(B)-norm of A*v_{j}.
 
-        V->aitr_wnorm = ddot_(&n, resid, &int1, &workd[ivj], &int1);
+        V->aitr_wnorm = BLAS_FUNC(ddot)(&n, resid, &int1, &workd[ivj], &int1);
         V->aitr_wnorm = sqrt(fabs(V->aitr_wnorm));
     } else if (V->bmat) {
-        V->aitr_wnorm = ddot_(&n, resid, &int1, &workd[ipj], &int1);
+        V->aitr_wnorm = BLAS_FUNC(ddot)(&n, resid, &int1, &workd[ipj], &int1);
         V->aitr_wnorm = sqrt(fabs(V->aitr_wnorm));
     } else {
-        V->aitr_wnorm = dnrm2_(&n, resid, &int1);
+        V->aitr_wnorm = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
 
     //  Compute the j-th residual corresponding
@@ -1217,15 +1217,15 @@ LINE65:
     tmp_int = V->aitr_j + 1;
     if (V->mode != 2)
     {
-        dgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
     } else {
-        dgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ivj], &int1, &dbl0, &workd[irj], &int1);
+        BLAS_FUNC(dgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ivj], &int1, &dbl0, &workd[irj], &int1);
     }
 
     //  Orthogonalize r_{j} against V_{j}.
     //  RESID contains OP*v_{j}. See STEP 3.
 
-    dgemv_("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(dgemv)("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
 
     // Extend H to have j rows and columns.
 
@@ -1243,7 +1243,7 @@ LINE65:
 
     if (V->bmat)
     {
-        dcopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1252,7 +1252,7 @@ LINE65:
 
         return;
     } else {
-        dcopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE70:
@@ -1266,10 +1266,10 @@ LINE70:
 
     if (V->bmat)
     {
-        *rnorm = ddot_(&n, resid, &int1, &workd[ipj], &int1);
+        *rnorm = BLAS_FUNC(ddot)(&n, resid, &int1, &workd[ipj], &int1);
         *rnorm = sqrt(fabs(*rnorm));
     } else {
-        *rnorm = dnrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
 
     // STEP 5: Re-orthogonalization / Iterative refinement phase
@@ -1297,14 +1297,14 @@ LINE80:
     //  Compute V_{j}^T * B * r_{j}.
     //  WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1).
     tmp_int = V->aitr_j + 1;
-    dgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
+    BLAS_FUNC(dgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
 
     //  Compute the correction to the residual:
     //  r_{j} = r_{j} - V_{j} * WORKD(IRJ:IRJ+J-1).
     //  The correction to H is v(:,1:J)*H(1:J,1:J)
     //  + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.
 
-    dgemv_("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(dgemv)("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
 
     if ((V->aitr_j == 0) || (V->aitr_restart))
     {
@@ -1316,7 +1316,7 @@ LINE80:
 
     if (V->bmat)
     {
-        dcopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1326,7 +1326,7 @@ LINE80:
 
         return;
     } else {
-        dcopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE90:
@@ -1337,10 +1337,10 @@ LINE90:
 
     if (V->bmat)
     {
-        V->aitr_rnorm1 = ddot_(&n, resid, &int1, &workd[ipj], &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(ddot)(&n, resid, &int1, &workd[ipj], &int1);
         V->aitr_rnorm1 = sqrt(fabs(V->aitr_rnorm1));
     } else {
-        V->aitr_rnorm1 = dnrm2_(&n, resid, &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
 
     //  Determine if we need to perform another
@@ -1388,9 +1388,9 @@ LINE100:
         h[V->aitr_j] = -h[V->aitr_j];
         if (V->aitr_j < k + np - 1)
         {
-            dscal_(&n, &dblm1, &v[V->aitr_j + 1], &int1);
+            BLAS_FUNC(dscal)(&n, &dblm1, &v[V->aitr_j + 1], &int1);
         } else {
-            dscal_(&n, &dblm1, resid, &int1);
+            BLAS_FUNC(dscal)(&n, &dblm1, resid, &int1);
         }
     }
 
@@ -1411,10 +1411,10 @@ LINE100:
 
 
 void
-dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, int ldh,
-       double* resid, double* q, int ldq, double* workd)
+dsapps(CBLAS_INT n, CBLAS_INT* kev, CBLAS_INT np, double* shift, double* v, CBLAS_INT ldv, double* h, CBLAS_INT ldh,
+       double* resid, double* q, CBLAS_INT ldq, double* workd)
 {
-    int i, iend, istart, jj, kplusp, tmp_int, int1 = 1;
+    CBLAS_INT i, iend, istart, jj, kplusp, tmp_int; CBLAS_INT int1 = 1;
     double a1, a2, a3, a4, c, f, g, r, s, sigma, tst1;
     double dbl0 = 0.0, dbl1 = 1.0, dblm1 = -1.0;
 
@@ -1424,7 +1424,7 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
     // Initialize Q to the identity to accumulate
     // the rotations and reflections
 
-    dlaset_("A", &kplusp, &kplusp, &dbl0, &dbl1, q, &ldq);
+    BLAS_FUNC(dlaset)("A", &kplusp, &kplusp, &dbl0, &dbl1, q, &ldq);
 
     // Quick return if there are no shifts to apply
 
@@ -1462,7 +1462,7 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
                 if (h[iend] < 0.0)
                 {
                     h[iend] = -h[iend];
-                    dscal_(&kplusp, &dblm1, &q[ldq*(iend)], &int1);
+                    BLAS_FUNC(dscal)(&kplusp, &dblm1, &q[ldq*(iend)], &int1);
                 }
                 continue;
             }
@@ -1490,7 +1490,7 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
                 // [-s, c] [ m n ] [s,  c]    [-s*k + c*m, -s*m + c*n] [s,  c]
                 //                                  a3          a4
 
-                dlartgp_(&f, &g, &c, &s, &r);
+                BLAS_FUNC(dlartgp)(&f, &g, &c, &s, &r);
                 if (i > istart)
                 {
                     h[i] = r;
@@ -1505,7 +1505,7 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
 
                 // Accumulate the rotation also in Q
                 tmp_int = (i + jj + 2 > kplusp ? kplusp : i + jj + 2);
-                drot_(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s);
+                BLAS_FUNC(drot)(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s);
 
                 if (i < iend - 1)
                 {
@@ -1519,7 +1519,7 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
             if (h[iend] < 0.0)
             {
                 h[iend] = -h[iend];
-                dscal_(&kplusp, &dblm1, &q[ldq*(iend)], &int1);
+                BLAS_FUNC(dscal)(&kplusp, &dblm1, &q[ldq*(iend)], &int1);
             }
         }
     }
@@ -1545,7 +1545,7 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
 
     if (h[*kev] > 0.0)
     {
-        dgemv_("N", &n, &kplusp, &dbl1, v, &ldv, &q[ldq*(*kev)], &int1, &dbl0, &workd[n], &int1);
+        BLAS_FUNC(dgemv)("N", &n, &kplusp, &dbl1, v, &ldv, &q[ldq*(*kev)], &int1, &dbl0, &workd[n], &int1);
     }
 
     // Compute column 1 to kev of (V*Q) in backward order
@@ -1556,8 +1556,8 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
     for (i = 0; i < *kev; i++)
     {
         tmp_int = kplusp - i;
-        dgemv_("N", &n, &tmp_int, &dbl1, v, &ldv, &q[ldq*(*kev-i-1)], &int1, &dbl0, workd, &int1);
-        dcopy_(&n, workd, &int1, &v[ldv*(kplusp-i-1)], &int1);
+        BLAS_FUNC(dgemv)("N", &n, &tmp_int, &dbl1, v, &ldv, &q[ldq*(*kev-i-1)], &int1, &dbl0, workd, &int1);
+        BLAS_FUNC(dcopy)(&n, workd, &int1, &v[ldv*(kplusp-i-1)], &int1);
     }
     // 130
 
@@ -1565,13 +1565,13 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
 
     for (i = 0; i < *kev; i++)
     {
-        dcopy_(&n, &v[ldv*(np+i)], &int1, &v[ldv*i], &int1);
+        BLAS_FUNC(dcopy)(&n, &v[ldv*(np+i)], &int1, &v[ldv*i], &int1);
     }
     // 140
 
     if (h[*kev] > 0.0)
     {
-        dcopy_(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
+        BLAS_FUNC(dcopy)(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
     }
 
     // Update the residual vector:
@@ -1580,10 +1580,10 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
     //    sigmak = (e_{kev+p}'*Q)*e_{kev}
     //    betak = e_{kev+1}'*H*e_{kev}
 
-    dscal_(&n, &q[kplusp-1 + (*kev-1)*ldq], resid, &int1);
+    BLAS_FUNC(dscal)(&n, &q[kplusp-1 + (*kev-1)*ldq], resid, &int1);
     if (h[*kev] > 0.0)
     {
-        daxpy_(&n, &h[*kev], &v[ldv*(*kev)], &int1, resid, &int1);
+        BLAS_FUNC(daxpy)(&n, &h[*kev], &v[ldv*(*kev)], &int1, resid, &int1);
     }
 
     return;
@@ -1591,10 +1591,10 @@ dsapps(int n, int* kev, int np, double* shift, double* v, int ldv, double* h, in
 
 
 void
-dsgets(struct ARNAUD_state_d *V, int* kev, int* np, double* ritz,
+dsgets(struct ARNAUD_state_d *V, CBLAS_INT* kev, CBLAS_INT* np, double* ritz,
        double* bounds, double* shifts)
 {
-    int kevd2, tmp1, tmp2, int1 = 1;
+    CBLAS_INT kevd2, tmp1, tmp2; CBLAS_INT int1 = 1;
     if (V->which == which_BE)
     {
         // Both ends of the spectrum are requested.
@@ -1610,8 +1610,8 @@ dsgets(struct ARNAUD_state_d *V, int* kev, int* np, double* ritz,
         {
             tmp1 = (kevd2 > *np ? *np : kevd2);
             tmp2 = (kevd2 > *np ? kevd2 : *np);
-            dswap_(&tmp1, ritz, &int1, &ritz[tmp2], &int1);
-            dswap_(&tmp1, bounds, &int1, &bounds[tmp2], &int1);
+            BLAS_FUNC(dswap)(&tmp1, ritz, &int1, &ritz[tmp2], &int1);
+            BLAS_FUNC(dswap)(&tmp1, bounds, &int1, &bounds[tmp2], &int1);
         }
     } else {
 
@@ -1634,16 +1634,16 @@ dsgets(struct ARNAUD_state_d *V, int* kev, int* np, double* ritz,
         // are applied in subroutine dsapps.
 
         dsortr(which_SM, 1, *np, bounds, ritz);
-        dcopy_(np, ritz, &int1, shifts, &int1);
+        BLAS_FUNC(dcopy)(np, ritz, &int1, shifts, &int1);
     }
 }
 
 
 void
-dgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
-       double* v, int ldv, double* resid, double* rnorm, int* ipntr, double* workd)
+dgetv0(struct ARNAUD_state_d *V, CBLAS_INT initv, CBLAS_INT n, CBLAS_INT j,
+       double* v, CBLAS_INT ldv, double* resid, double* rnorm, CBLAS_INT* ipntr, double* workd)
 {
-    int jj, int1 = 1;
+    CBLAS_INT jj; CBLAS_INT int1 = 1;
     const double sq2o2 = sqrt(2.0) / 2.0;
     double dbl1 = 1.0, dbl0 = 0.0, dblm1 = -1.0;
 
@@ -1677,12 +1677,12 @@ dgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
         {
             ipntr[0] = 0;
             ipntr[1] = n;
-            dcopy_(&n, resid, &int1, workd, &int1);
+            BLAS_FUNC(dcopy)(&n, resid, &int1, workd, &int1);
             V->ido = ido_RANDOM_OPX;
             return;
         } else if ((V->getv0_itry > 1) && (V->bmat == 1))
         {
-            dcopy_(&n, resid, &int1, &workd[n], &int1);
+            BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[n], &int1);
         }
     }
 
@@ -1700,7 +1700,7 @@ dgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
     V->getv0_first = 1;
     if (V->getv0_itry == 1)
     {
-        dcopy_(&n, &workd[n], &int1, resid, &int1);
+        BLAS_FUNC(dcopy)(&n, &workd[n], &int1, resid, &int1);
     }
     if (V->bmat)
     {
@@ -1709,7 +1709,7 @@ dgetv0(struct ARNAUD_state_d *V, int initv, int n, int j,
         V->ido = ido_BX;
         return;
     } else {
-        dcopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE20:
@@ -1717,10 +1717,10 @@ LINE20:
     V->getv0_first = 0;
     if (V->bmat)
     {
-        V->getv0_rnorm0 = ddot_(&n, resid, &int1, workd, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(ddot)(&n, resid, &int1, workd, &int1);
         V->getv0_rnorm0 = sqrt(fabs(V->getv0_rnorm0));
     } else {
-        V->getv0_rnorm0 = dnrm2_(&n, resid, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
     *rnorm = V->getv0_rnorm0;
 
@@ -1746,29 +1746,29 @@ LINE20:
 
 LINE30:
 
-    dgemv_("T", &n, &j, &dbl1, v, &ldv, workd, &int1, &dbl0, &workd[n], &int1);
-    dgemv_("N", &n, &j, &dblm1, v, &ldv, &workd[n], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(dgemv)("T", &n, &j, &dbl1, v, &ldv, workd, &int1, &dbl0, &workd[n], &int1);
+    BLAS_FUNC(dgemv)("N", &n, &j, &dblm1, v, &ldv, &workd[n], &int1, &dbl1, resid, &int1);
 
     //  Compute the B-norm of the orthogonalized starting vector
 
     if (V->bmat)
     {
-        dcopy_(&n, resid, &int1, &workd[n], &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, &workd[n], &int1);
         ipntr[0] = n;
         ipntr[1] = 0;
         V->ido = ido_BX;
         return;
     } else {
-        dcopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(dcopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE40:
     if (V->bmat)
     {
-        *rnorm = ddot_(&n, resid, &int1, workd, &int1);
+        *rnorm = BLAS_FUNC(ddot)(&n, resid, &int1, workd, &int1);
         *rnorm = sqrt(fabs(*rnorm));
     } else {
-        *rnorm = dnrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(dnrm2)(&n, resid, &int1);
     }
 
     //  Check for further orthogonalization.
@@ -1803,9 +1803,9 @@ LINE40:
 
 
 static void
-dsortr(const enum ARNAUD_which w, const int apply, const int n, double* x1, double* x2)
+dsortr(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, double* x1, double* x2)
 {
-    int i, gap, pos;
+    CBLAS_INT i, gap, pos;
     double temp;
     ARNAUD_compare_rfunc *f;
 
@@ -1856,9 +1856,9 @@ dsortr(const enum ARNAUD_which w, const int apply, const int n, double* x1, doub
 
 
 static void
-dsesrt(const enum ARNAUD_which w, const int apply, const int n, double* x, int na, double* a, const int lda)
+dsesrt(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, double* x, CBLAS_INT na, double* a, const CBLAS_INT lda)
 {
-    int i, gap, pos, int1 = 1;
+    CBLAS_INT i, gap, pos; CBLAS_INT int1 = 1;
     double temp;
     ARNAUD_compare_rfunc *f;
 
@@ -1896,7 +1896,7 @@ dsesrt(const enum ARNAUD_which w, const int apply, const int n, double* x, int n
 
                 if (apply)
                 {
-                    dswap_(&na, &a[lda*pos], &int1, &a[lda*(pos+gap)], &int1);
+                    BLAS_FUNC(dswap)(&na, &a[lda*pos], &int1, &a[lda*(pos+gap)], &int1);
                 }
                 pos -= gap;
             }
@@ -1907,16 +1907,16 @@ dsesrt(const enum ARNAUD_which w, const int apply, const int n, double* x, int n
 
 
 void
-dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
+dstqrb(CBLAS_INT n, double* d, double* e, double* z, double* work, CBLAS_INT* info)
 {
-    int int1 = 1, int0 = 0;
+    CBLAS_INT int1 = 1, int0 = 0;
     double eps2 = pow(ulp, 2.0);
     double safmin = unfl;
     double safmax = (1.0 / safmin);
     double ssfmax = sqrt(safmax) / 3.0;
     double ssfmin = sqrt(safmin) / eps2;
 
-    int nmaxit, jtot, i, ii, j, k, l1, m = 0, tmp_int = 0, l, lsv, lend, lendsv, iscale;
+    CBLAS_INT nmaxit, jtot, i, ii, j, k, l1, m = 0, tmp_int = 0, l, lsv, lend, lendsv, iscale;
     double anorm = 0.0, rt1 = 0.0, rt2 = 0.0, c = 0.0, s = 0.0, g = 0.0, r = 0.0, p = 0.0;
     double b, f, tst;
 
@@ -1976,7 +1976,7 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
 
         // Scale submatrix in rows and columns L to LEND
         tmp_int = lend - l + 1;
-        anorm = dlanst_("I", &tmp_int, &d[l-1], &e[l-1]);
+        anorm = BLAS_FUNC(dlanst)("I", &tmp_int, &d[l-1], &e[l-1]);
         iscale = 0;
 
         if (anorm == 0.0) { continue; }
@@ -1984,14 +1984,14 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
         if (anorm > ssfmax)
         {
             iscale = 1;
-            dlascl_("G", &int0, &int0, &anorm, &ssfmax, &tmp_int, &int1, &d[l-1], &n, info);
+            BLAS_FUNC(dlascl)("G", &int0, &int0, &anorm, &ssfmax, &tmp_int, &int1, &d[l-1], &n, info);
             tmp_int -= 1;
-            dlascl_("G", &int0, &int0, &anorm, &ssfmax, &tmp_int, &int1, &e[l-1], &n, info);
+            BLAS_FUNC(dlascl)("G", &int0, &int0, &anorm, &ssfmax, &tmp_int, &int1, &e[l-1], &n, info);
         } else if (anorm < ssfmin) {
             iscale = 2;
-            dlascl_("G", &int0, &int0, &anorm, &ssfmin, &tmp_int, &int1, &d[l-1], &n, info);
+            BLAS_FUNC(dlascl)("G", &int0, &int0, &anorm, &ssfmin, &tmp_int, &int1, &d[l-1], &n, info);
             tmp_int -= 1;
-            dlascl_("G", &int0, &int0, &anorm, &ssfmin, &tmp_int, &int1, &e[l-1], &n, info);
+            BLAS_FUNC(dlascl)("G", &int0, &int0, &anorm, &ssfmin, &tmp_int, &int1, &e[l-1], &n, info);
         }
         // Choose between QL and QR iteration
 
@@ -2035,7 +2035,7 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
                 // If remaining matrix is 2x2, use dlaev2 to compute its eigensystem
                 if (m == l + 1)
                 {
-                    dlaev2_(&d[l - 1], &e[l - 1], &d[l], &rt1, &rt2, &c, &s);
+                    BLAS_FUNC(dlaev2)(&d[l - 1], &e[l - 1], &d[l], &rt1, &rt2, &c, &s);
                     work[l - 1] = c;
                     work[n - 1 + l - 1] = s;
                     tst    = z[l];
@@ -2066,7 +2066,7 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
                 {
                     f = s * e[i-1];
                     b = c * e[i-1];
-                    dlartg_(&g, &f, &c, &s, &r);
+                    BLAS_FUNC(dlartg)(&g, &f, &c, &s, &r);
                     if (i != m - 1) { e[i] = r; }
                     g = d[i] - p;
                     r = (d[i-1] - g)*s + 2.0*c*b;
@@ -2078,7 +2078,7 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
                 }
                 // 70
                 tmp_int = m - l + 1;
-                dlasr_("R", "V", "B", &int1, &tmp_int, &work[l-1], &work[n-1+l-1], &z[l-1], &int1);
+                BLAS_FUNC(dlasr)("R", "V", "B", &int1, &tmp_int, &work[l-1], &work[n-1+l-1], &z[l-1], &int1);
 
                 d[l-1] = d[l-1] - p;
                 e[l-1] = g;
@@ -2117,7 +2117,7 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
                 // If remaining matrix is 2x2, use dlaev2 to compute its eigensystem
                 if (m == l - 1)
                 {
-                    dlaev2_(&d[l-2], &e[l-2], &d[l-1], &rt1, &rt2, &c, &s);
+                    BLAS_FUNC(dlaev2)(&d[l-2], &e[l-2], &d[l-1], &rt1, &rt2, &c, &s);
                     tst    = z[l-1];
                     z[l-1] = c*tst - s*z[l-2];
                     z[l-2] = s*tst + c*z[l-2];
@@ -2147,7 +2147,7 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
                 {
                     f = s * e[i-1];
                     b = c * e[i-1];
-                    dlartg_(&g, &f, &c, &s, &r);
+                    BLAS_FUNC(dlartg)(&g, &f, &c, &s, &r);
                     if (i != m) { e[i-2] = r; }
                     g = d[i-1] - p;
                     r = (d[i] - g)*s + 2.0*c*b;
@@ -2162,7 +2162,7 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
                 // 120
                 // Apply saved rotations.
                 tmp_int = l - m + 1;
-                dlasr_("R", "V", "F", &int1, &tmp_int, &work[m-1], &work[n-1+m-1], &z[m-1], &int1);
+                BLAS_FUNC(dlasr)("R", "V", "F", &int1, &tmp_int, &work[m-1], &work[n-1+m-1], &z[m-1], &int1);
 
                 d[l-1] = d[l-1] - p;
                 e[l - 2] = g;
@@ -2176,15 +2176,15 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
         if (iscale == 1)
         {
 
-            dlascl_("G", &int0, &int0, &ssfmax, &anorm, &tmp_int, &int1, &d[lsv-1], &n, info);
+            BLAS_FUNC(dlascl)("G", &int0, &int0, &ssfmax, &anorm, &tmp_int, &int1, &d[lsv-1], &n, info);
             tmp_int -= 1;
-            dlascl_("G", &int0, &int0, &ssfmax, &anorm, &tmp_int, &int1, &e[lsv-1], &n, info);
+            BLAS_FUNC(dlascl)("G", &int0, &int0, &ssfmax, &anorm, &tmp_int, &int1, &e[lsv-1], &n, info);
 
         } else if (iscale == 2) {
 
-            dlascl_("G", &int0, &int0, &ssfmin, &anorm, &tmp_int, &int1, &d[lsv-1], &n, info);
+            BLAS_FUNC(dlascl)("G", &int0, &int0, &ssfmin, &anorm, &tmp_int, &int1, &d[lsv-1], &n, info);
             tmp_int -= 1;
-            dlascl_("G", &int0, &int0, &ssfmin, &anorm, &tmp_int, &int1, &e[lsv-1], &n, info);
+            BLAS_FUNC(dlascl)("G", &int0, &int0, &ssfmin, &anorm, &tmp_int, &int1, &e[lsv-1], &n, info);
 
         }
 
@@ -2229,7 +2229,7 @@ dstqrb(int n, double* d, double* e, double* z, double* work, int* info)
 }
 
 
-int sortr_LM(const double x1, const double x2) { return (fabs(x1) > fabs(x2)); }
-int sortr_SM(const double x1, const double x2) { return (fabs(x1) < fabs(x2)); }
-int sortr_LA(const double x1, const double x2) { return (x1 > x2); }
-int sortr_SA(const double x1, const double x2) { return (x1 < x2); }
+CBLAS_INT sortr_LM(const double x1, const double x2) { return (fabs(x1) > fabs(x2)); }
+CBLAS_INT sortr_SM(const double x1, const double x2) { return (fabs(x1) < fabs(x2)); }
+CBLAS_INT sortr_LA(const double x1, const double x2) { return (x1 > x2); }
+CBLAS_INT sortr_SA(const double x1, const double x2) { return (x1 < x2); }

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_single.c
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/arnaud_s_single.c
@@ -1,26 +1,26 @@
 #include "arnaud_s_single.h"
 #include <float.h>
 
-typedef int ARNAUD_compare_rfunc(const float, const float);
+typedef CBLAS_INT ARNAUD_compare_rfunc(const float, const float);
 
-static int sortr_LM(const float, const float);
-static int sortr_SM(const float, const float);
-static int sortr_LA(const float, const float);
-static int sortr_SA(const float, const float);
+static CBLAS_INT sortr_LM(const float, const float);
+static CBLAS_INT sortr_SM(const float, const float);
+static CBLAS_INT sortr_LA(const float, const float);
+static CBLAS_INT sortr_SA(const float, const float);
 
 static const float unfl = FLT_MIN;    // 1.1754943508222875e-38;
 static const float ulp = FLT_EPSILON; // 1.1920928955078125e-07;
 
-static void ssaup2(struct ARNAUD_state_s*, float*, float*, int, float*, int, float*, float*, float*, int, float*, int*, float*);
-static void ssconv(int, float*, float*, float, int*);
-static void sseigt(float, int, float*, int, float*, float*, float*, int*);
-static void ssaitr(struct ARNAUD_state_s*, int, int, float*, float*, float*, int, float*, int, int*, float*);
-static void ssapps(int, int*, int, float*, float*, int, float*, int, float*, float* , int, float*);
-static void ssgets(struct ARNAUD_state_s*, int*, int*, float*, float*, float*);
-static void sgetv0(struct ARNAUD_state_s *, int, int, int, float*, int, float*, float*, int*, float*);
-static void ssortr(const enum ARNAUD_which w, const int apply, const int n, float* x1, float* x2);
-static void ssesrt(const enum ARNAUD_which w, const int apply, const int n, float* x, int na, float* a, const int lda);
-static void sstqrb(int n, float* d, float* e, float* z, float* work, int* info);
+static void ssaup2(struct ARNAUD_state_s*, float*, float*, CBLAS_INT, float*, CBLAS_INT, float*, float*, float*, CBLAS_INT, float*, CBLAS_INT*, float*);
+static void ssconv(CBLAS_INT, float*, float*, float, CBLAS_INT*);
+static void sseigt(float, CBLAS_INT, float*, CBLAS_INT, float*, float*, float*, CBLAS_INT*);
+static void ssaitr(struct ARNAUD_state_s*, CBLAS_INT, CBLAS_INT, float*, float*, float*, CBLAS_INT, float*, CBLAS_INT, CBLAS_INT*, float*);
+static void ssapps(CBLAS_INT, CBLAS_INT*, CBLAS_INT, float*, float*, CBLAS_INT, float*, CBLAS_INT, float*, float* , CBLAS_INT, float*);
+static void ssgets(struct ARNAUD_state_s*, CBLAS_INT*, CBLAS_INT*, float*, float*, float*);
+static void sgetv0(struct ARNAUD_state_s *, CBLAS_INT, CBLAS_INT, CBLAS_INT, float*, CBLAS_INT, float*, float*, CBLAS_INT*, float*);
+static void ssortr(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, float* x1, float* x2);
+static void ssesrt(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, float* x, CBLAS_INT na, float* a, const CBLAS_INT lda);
+static void sstqrb(CBLAS_INT n, float* d, float* e, float* z, float* work, CBLAS_INT* info);
 
 enum ARNAUD_seupd_type {
     REGULAR,
@@ -31,14 +31,14 @@ enum ARNAUD_seupd_type {
 
 
 void
-ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
-       float* d, float* z, int ldz, float sigma, float* resid, float* v,
-       int ldv, int* ipntr, float* workd, float* workl)
+ARNAUD_sseupd(struct ARNAUD_state_s *V, CBLAS_INT rvec, CBLAS_INT howmny, CBLAS_INT* select,
+       float* d, float* z, CBLAS_INT ldz, float sigma, float* resid, float* v,
+       CBLAS_INT ldv, CBLAS_INT* ipntr, float* workd, float* workl)
 {
     const float eps23 = powf(ulp, 2.0f / 3.0f);
-    int j, jj, k;
-    int ibd, ih, ihb, ihd, iq, irz, iw, ldh, ldq, ritz, bounds, next, np;
-    int ierr = 0, int1 = 1, tmp_int = 0, numcnv, reord;
+    CBLAS_INT j, jj, k;
+    CBLAS_INT ibd, ih, ihb, ihd, iq, irz, iw, ldh, ldq, ritz, bounds, next, np;
+    CBLAS_INT ierr = 0; CBLAS_INT int1 = 1; CBLAS_INT  tmp_int = 0, numcnv, reord;
     float bnorm2, rnorm, temp, temp1, dbl1 = 1.0f;
 
     if (V->nconv == 0) { return; }
@@ -159,7 +159,7 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
     rnorm = workl[ih];
     if (V->bmat)
     {
-        bnorm2 = snrm2_(&V->n, workd, &int1);
+        bnorm2 = BLAS_FUNC(snrm2)(&V->n, workd, &int1);
     } else {
         bnorm2 = rnorm;
     }
@@ -197,7 +197,7 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         {
             temp1 = fmaxf(eps23, fabsf(workl[irz + V->ncv - j]));
 
-            jj = (int)workl[bounds + V->ncv - j];
+            jj = (CBLAS_INT)workl[bounds + V->ncv - j];
 
             if ((numcnv < V->nconv) && (workl[ibd + jj] <= V->tol*temp1))
             {
@@ -224,10 +224,10 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         // Initialize the eigenvector matrix Q to the identity.
 
         tmp_int = V->ncv - 1;
-        scopy_(&tmp_int, &workl[ih+1], &int1, &workl[ihb], &int1);
-        scopy_(&V->ncv, &workl[ih+ldh], &int1, &workl[ihd], &int1);
+        BLAS_FUNC(scopy)(&tmp_int, &workl[ih+1], &int1, &workl[ihb], &int1);
+        BLAS_FUNC(scopy)(&V->ncv, &workl[ih+ldh], &int1, &workl[ihd], &int1);
 
-        ssteqr_("I", &V->ncv, &workl[ihd], &workl[ihb], &workl[iq], &ldq, &workl[iw], &ierr);
+        BLAS_FUNC(ssteqr)("I", &V->ncv, &workl[ihd], &workl[ihb], &workl[iq], &ldq, &workl[iw], &ierr);
 
         if (ierr != 0)
         {
@@ -245,8 +245,8 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
             // eigenvectors appear in the first NCONV
             // columns.
 
-            int leftptr = 0;
-            int rightptr = V->ncv - 1;
+            CBLAS_INT leftptr = 0;
+            CBLAS_INT rightptr = V->ncv - 1;
 
             if (V->ncv > 1)
             {
@@ -277,9 +277,9 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
                         workl[ihd + leftptr] = workl[ihd + rightptr];
                         workl[ihd + rightptr] = temp;
 
-                        scopy_(&V->ncv, &workl[iq + V->ncv*leftptr], &int1, &workl[iw], &int1);
-                        scopy_(&V->ncv, &workl[iq + V->ncv*rightptr], &int1, &workl[iq + V->ncv*leftptr], &int1);
-                        scopy_(&V->ncv, &workl[iw], &int1, &workl[iq + V->ncv*rightptr], &int1);
+                        BLAS_FUNC(scopy)(&V->ncv, &workl[iq + V->ncv*leftptr], &int1, &workl[iw], &int1);
+                        BLAS_FUNC(scopy)(&V->ncv, &workl[iq + V->ncv*rightptr], &int1, &workl[iq + V->ncv*leftptr], &int1);
+                        BLAS_FUNC(scopy)(&V->ncv, &workl[iw], &int1, &workl[iq + V->ncv*rightptr], &int1);
 
                         leftptr += 1;
                         rightptr -= 1;
@@ -290,14 +290,14 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
         // Load the converged Ritz values into D.
 
-        scopy_(&V->nconv, &workl[ihd], &int1, d, &int1);
+        BLAS_FUNC(scopy)(&V->nconv, &workl[ihd], &int1, d, &int1);
 
     } else {
 
         // Ritz vectors not required. Load Ritz values into D.
 
-        scopy_(&V->nconv, &workl[ritz], &int1, d, &int1);
-        scopy_(&V->ncv, &workl[ritz], &int1, &workl[ihd], &int1);
+        BLAS_FUNC(scopy)(&V->nconv, &workl[ritz], &int1, d, &int1);
+        BLAS_FUNC(scopy)(&V->ncv, &workl[ritz], &int1, &workl[ihd], &int1);
     }
 
     // Transform the Ritz values and possibly vectors and corresponding
@@ -313,7 +313,7 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         if (rvec) {
             ssesrt(which_LA, rvec, V->nconv, d, V->ncv, &workl[iq], ldq);
         } else {
-            scopy_(&V->ncv, &workl[bounds], &int1, &workl[ihb], &int1);
+            BLAS_FUNC(scopy)(&V->ncv, &workl[bounds], &int1, &workl[ihb], &int1);
         }
 
     } else {
@@ -331,19 +331,19 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         // *The Ritz vectors are not affected by the transformation.
         //  They are only reordered.
 
-        scopy_(&V->ncv, &workl[ihd], &int1, &workl[iw], &int1);
+        BLAS_FUNC(scopy)(&V->ncv, &workl[ihd], &int1, &workl[iw], &int1);
         if (TYP == SHIFTI)
         {
-            for (int k = 0; k < V->ncv; k++)
+            for (CBLAS_INT k = 0; k < V->ncv; k++)
             {
                 workl[ihd + k] = 1.0f / workl[ihd + k] + sigma;
             }
         } else if (TYP == BUCKLE) {
-            for (int k = 0; k < V->ncv; k++) {
+            for (CBLAS_INT k = 0; k < V->ncv; k++) {
                 workl[ihd + k] = sigma * workl[ihd + k] / (workl[ihd + k] - 1.0f);
             }
         } else if (TYP == CAYLEY) {
-            for (int k = 0; k < V->ncv; k++) {
+            for (CBLAS_INT k = 0; k < V->ncv; k++) {
                 workl[ihd + k] = sigma * (workl[ihd + k] + 1.0f) / (workl[ihd + k] - 1.0f);
             }
         }
@@ -361,14 +361,14 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         //  match the ordering of the lambda. We`ll use them again for
         //  Ritz vector purification.
 
-        scopy_(&V->nconv, &workl[ihd], &int1, d, &int1);
+        BLAS_FUNC(scopy)(&V->nconv, &workl[ihd], &int1, d, &int1);
         ssortr(which_LA, 1, V->nconv, &workl[ihd], &workl[iw]);
         if (rvec) {
             ssesrt(which_LA, rvec, V->nconv, d, V->ncv, &workl[iq], ldq);
         } else {
-            scopy_(&V->ncv, &workl[bounds], &int1, &workl[ihb], &int1);
+            BLAS_FUNC(scopy)(&V->ncv, &workl[bounds], &int1, &workl[ihb], &int1);
             temp = bnorm2 / rnorm;
-            sscal_(&V->ncv, &temp, &workl[ihb], &int1);
+            BLAS_FUNC(sscal)(&V->ncv, &temp, &workl[ihb], &int1);
             ssortr(which_LA, 1, V->nconv, d, &workl[ihb]);
         }
     }
@@ -384,7 +384,7 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         // the wanted invariant subspace located in the first NCONV
         // columns of workl(iq, ldq).
 
-        sgeqr2_(&V->ncv, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], &workl[ihb], &ierr);
+        BLAS_FUNC(sgeqr2)(&V->ncv, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], &workl[ihb], &ierr);
 
         // * Postmultiply V by Q.
         // * Copy the first NCONV columns of VQ into Z.
@@ -392,25 +392,25 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         // of the approximate invariant subspace associated with
         // the Ritz values in workl(ihd).
 
-        sorm2r_("R", "N", &V->n, &V->ncv, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], v, &ldv, &workd[V->n], &ierr);
-        slacpy_("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
+        BLAS_FUNC(sorm2r)("R", "N", &V->n, &V->ncv, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], v, &ldv, &workd[V->n], &ierr);
+        BLAS_FUNC(slacpy)("A", &V->n, &V->nconv, v, &ldv, z, &ldz);
 
         // In order to compute the Ritz estimates for the Ritz
         // values in both systems, need the last row of the
         // eigenvector matrix. Remember, it's in factored form.
 
-        for (int j = 0; j < V->ncv - 1; j++)
+        for (CBLAS_INT j = 0; j < V->ncv - 1; j++)
         {
             workl[ihb + j] = 0.0f;
         }
         workl[ihb + V->ncv - 1] = 1.0f;
-        sorm2r_("L", "T", &V->ncv, &int1, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], &workl[ihb], &V->ncv, &temp, &ierr);
+        BLAS_FUNC(sorm2r)("L", "T", &V->ncv, &int1, &V->nconv, &workl[iq], &ldq, &workl[iw + V->ncv], &workl[ihb], &V->ncv, &temp, &ierr);
 
         //  Make a copy of the last row into
         //  workl(iw+ncv:iw+2*ncv), as it is needed again in
         //  the Ritz vector purification step below
 
-        for (int j = 0; j < V->nconv; j++)
+        for (CBLAS_INT j = 0; j < V->nconv; j++)
         {
             workl[iw + V->ncv + j] = workl[ihb + j];
         }
@@ -438,7 +438,7 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
         // *  Determine Ritz estimates of the lambda.
 
 
-        sscal_(&V->ncv, &bnorm2, &workl[ihb], &int1);
+        BLAS_FUNC(sscal)(&V->ncv, &bnorm2, &workl[ihb], &int1);
 
         for (k = 0; k < V->ncv; k++)
         {
@@ -476,7 +476,7 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
     if ((rvec) && (TYP != REGULAR))
     {
-        sger_(&V->n, &V->nconv, &dbl1, resid, &int1, &workl[iw], &int1, z, &ldz);
+        BLAS_FUNC(sger)(&V->n, &V->nconv, &dbl1, resid, &int1, &workl[iw], &int1, z, &ldz);
     }
 
     return;
@@ -484,11 +484,11 @@ ARNAUD_sseupd(struct ARNAUD_state_s *V, int rvec, int howmny, int* select,
 
 
 void
-ARNAUD_ssaupd(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
-       int* ipntr, float* workd, float* workl)
+ARNAUD_ssaupd(struct ARNAUD_state_s *V, float* resid, float* v, CBLAS_INT ldv,
+       CBLAS_INT* ipntr, float* workd, float* workl)
 {
 
-    int bounds = 0, ih = 0, iq = 0, iw = 0, j = 0, ldh = 0, ldq = 0, next = 0, ritz = 0;
+    CBLAS_INT bounds = 0, ih = 0, iq = 0, iw = 0, j = 0, ldh = 0, ldq = 0, next = 0, ritz = 0;
 
     if (V->ido == ido_FIRST)
     {
@@ -578,11 +578,11 @@ ARNAUD_ssaupd(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
 
 
 void
-ssaup2(struct ARNAUD_state_s *V, float* resid, float* v, int ldv,
-       float* h, int ldh, float* ritz, float* bounds,
-       float* q, int ldq, float* workl, int* ipntr, float* workd)
+ssaup2(struct ARNAUD_state_s *V, float* resid, float* v, CBLAS_INT ldv,
+       float* h, CBLAS_INT ldh, float* ritz, float* bounds,
+       float* q, CBLAS_INT ldq, float* workl, CBLAS_INT* ipntr, float* workd)
 {
-    int int1 = 1, j, tmp_int, nevd2, nevm2;
+    CBLAS_INT int1 = 1, j, tmp_int, nevd2, nevm2;
     const float eps23 = powf(ulp, 2.0f / 3.0f);
     float temp = 0.0f;
     // Initialize to silence the compiler warning
@@ -720,8 +720,8 @@ LINE20:
     // Make a copy of eigenvalues and corresponding error
     // bounds obtained from _seigt.
 
-    scopy_(&V->aup2_kplusp, ritz, &int1, &workl[V->aup2_kplusp], &int1);
-    scopy_(&V->aup2_kplusp, bounds, &int1, &workl[2*V->aup2_kplusp], &int1);
+    BLAS_FUNC(scopy)(&V->aup2_kplusp, ritz, &int1, &workl[V->aup2_kplusp], &int1);
+    BLAS_FUNC(scopy)(&V->aup2_kplusp, bounds, &int1, &workl[2*V->aup2_kplusp], &int1);
 
     // Select the wanted Ritz values and their bounds
     // to be used in the convergence test.
@@ -738,7 +738,7 @@ LINE20:
 
     // Convergence test
 
-    scopy_(&V->aup2_nev, &bounds[V->np], &int1, &workl[V->np], &int1);
+    BLAS_FUNC(scopy)(&V->aup2_nev, &bounds[V->np], &int1, &workl[V->np], &int1);
     ssconv(V->aup2_nev, &ritz[V->np], &workl[V->np], V->tol, &V->nconv);
 
     // Count the number of unwanted Ritz values that have zero
@@ -786,10 +786,10 @@ LINE20:
                 V->np = V->aup2_kplusp - V->aup2_nev0;
 
                 tmp_int = (nevd2 < V->np ? nevd2 : V->np);
-                int tmp_int2 = V->aup2_kplusp - tmp_int;
+                CBLAS_INT tmp_int2 = V->aup2_kplusp - tmp_int;
 
-                sswap_(&tmp_int, &ritz[nevm2], &int1, &ritz[tmp_int2], &int1);
-                sswap_(&tmp_int, &bounds[nevm2], &int1, &bounds[tmp_int2], &int1);
+                BLAS_FUNC(sswap)(&tmp_int, &ritz[nevm2], &int1, &ritz[tmp_int2], &int1);
+                BLAS_FUNC(sswap)(&tmp_int, &bounds[nevm2], &int1, &bounds[tmp_int2], &int1);
             }
 
         } else {
@@ -890,7 +890,7 @@ LINE20:
         // To prevent possible stagnation, adjust the number
         // of Ritz values and the shifts.
 
-        int nevbef = V->aup2_nev;
+        CBLAS_INT nevbef = V->aup2_nev;
         V->aup2_nev += (V->nconv > (V->np / 2) ? (V->np / 2) : V->nconv);
         if ((V->aup2_nev == 1) && (V->aup2_kplusp >= 6))
         {
@@ -932,7 +932,7 @@ LINE50:
     // free up WORKL.  This is for the non-exact shift case;
     // in the exact shift case, dsgets already handles this.
 
-    if (V->shift == 0) { scopy_(&V->np, workl, &int1, ritz, &int1); }
+    if (V->shift == 0) { BLAS_FUNC(scopy)(&V->np, workl, &int1, ritz, &int1); }
 
      /*--------------------------------------------------------*
      | Apply the NP0 implicit shifts by QR bulge chasing.      |
@@ -952,7 +952,7 @@ LINE50:
 
     if (V->bmat)
     {
-        scopy_(&V->n, resid, &int1, &workd[V->n], &int1);
+        BLAS_FUNC(scopy)(&V->n, resid, &int1, &workd[V->n], &int1);
         ipntr[0] = V->n;
         ipntr[1] = 0;
         V->ido = ido_BX;
@@ -961,7 +961,7 @@ LINE50:
 
         return;
     } else {
-        scopy_(&V->n, resid, &int1, workd, &int1);
+        BLAS_FUNC(scopy)(&V->n, resid, &int1, workd, &int1);
     }
 
 LINE100:
@@ -973,9 +973,9 @@ LINE100:
 
     if (V->bmat)
     {
-        V->aup2_rnorm = sqrtf(fabsf(sdot_(&V->n, resid, &int1, workd, &int1)));
+        V->aup2_rnorm = sqrtf(fabsf(BLAS_FUNC(sdot)(&V->n, resid, &int1, workd, &int1)));
     } else {
-        V->aup2_rnorm = snrm2_(&V->n, resid, &int1);
+        V->aup2_rnorm = BLAS_FUNC(snrm2)(&V->n, resid, &int1);
     }
 
     V->aup2_cnorm = 0;
@@ -990,14 +990,14 @@ LINE100:
 
 
 void
-ssconv(int n, float *ritz, float *bounds, float tol, int* nconv)
+ssconv(CBLAS_INT n, float *ritz, float *bounds, float tol, CBLAS_INT* nconv)
 {
     const float eps23 = powf(ulp, 2.0f / 3.0f);
     float temp = 0.0f;
 
     *nconv = 0;
     // Convergence test
-    for (int i = 0; i < n; i++)
+    for (CBLAS_INT i = 0; i < n; i++)
     {
         temp = fmaxf(eps23, fabsf(ritz[i]));
         if (fabsf(bounds[i]) <= tol * temp) { *nconv += 1; }
@@ -1008,28 +1008,28 @@ ssconv(int n, float *ritz, float *bounds, float tol, int* nconv)
 
 
 void
-sseigt(float rnorm, int n, float* h, int ldh, float* eig, float* bounds,
-       float* workl, int* ierr)
+sseigt(float rnorm, CBLAS_INT n, float* h, CBLAS_INT ldh, float* eig, float* bounds,
+       float* workl, CBLAS_INT* ierr)
 {
-    int int1 = 1, tmp_int;
-    scopy_(&n, &h[ldh], &int1, eig, &int1);
+    CBLAS_INT int1 = 1, tmp_int;
+    BLAS_FUNC(scopy)(&n, &h[ldh], &int1, eig, &int1);
     tmp_int = n - 1;
-    scopy_(&tmp_int, &h[1], &int1, workl, &int1);
+    BLAS_FUNC(scopy)(&tmp_int, &h[1], &int1, workl, &int1);
     sstqrb(n, eig, workl, bounds, &workl[n], ierr);
     if (*ierr != 0) { return; }
-    for (int k = 0; k < n; k++) { bounds[k] = rnorm * fabsf(bounds[k]); }
+    for (CBLAS_INT k = 0; k < n; k++) { bounds[k] = rnorm * fabsf(bounds[k]); }
     return;
 }
 
 
 void
-ssaitr(struct ARNAUD_state_s *V, int k, int np, float* resid, float* rnorm,
-       float* v, int ldv, float* h, int ldh, int* ipntr, float* workd)
+ssaitr(struct ARNAUD_state_s *V, CBLAS_INT k, CBLAS_INT np, float* resid, float* rnorm,
+       float* v, CBLAS_INT ldv, float* h, CBLAS_INT ldh, CBLAS_INT* ipntr, float* workd)
 {
-    int i, infol, ipj, irj, ivj, jj, n, tmp_int;
+    CBLAS_INT i, infol, ipj, irj, ivj, jj, n, tmp_int;
     const float sq2o2 = sqrtf(2.0f) / 2.0f;
 
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
     float dbl1 = 1.0f, dbl0 = 0.0f, dblm1 = -1.0f, temp1;
 
     n = V->n;  // n is constant, this is just for typing convenience
@@ -1121,22 +1121,22 @@ LINE40:
     //  when reciprocating a small RNORM, test against lower
     //  machine bound.
 
-    scopy_(&n, resid, &int1, &v[ldv*(V->aitr_j)], &int1);
+    BLAS_FUNC(scopy)(&n, resid, &int1, &v[ldv*(V->aitr_j)], &int1);
     if (*rnorm >= unfl)
     {
         temp1 = 1.0f / *rnorm;
-        sscal_(&n, &temp1, &v[ldv*(V->aitr_j)], &int1);
-        sscal_(&n, &temp1, &workd[ipj], &int1);
+        BLAS_FUNC(sscal)(&n, &temp1, &v[ldv*(V->aitr_j)], &int1);
+        BLAS_FUNC(sscal)(&n, &temp1, &workd[ipj], &int1);
     } else {
-        slascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*(V->aitr_j)], &n, &infol);
-        slascl_("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
+        BLAS_FUNC(slascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &v[ldv*(V->aitr_j)], &n, &infol);
+        BLAS_FUNC(slascl)("G", &i, &i, rnorm, &dbl1, &n, &int1, &workd[ipj], &n, &infol);
     }
 
     //  STEP 3:  r_{j} = OP*v_{j}; Note that p_{j} = B*v_{j}
     //  Note that this is not quite yet r_{j}. See STEP 4
 
     V->aitr_step3 = 1;
-    scopy_(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
+    BLAS_FUNC(scopy)(&n, &v[ldv*(V->aitr_j)], &int1, &workd[ivj], &int1);
     ipntr[0] = ivj;
     ipntr[1] = irj;
     ipntr[2] = ipj;
@@ -1155,7 +1155,7 @@ LINE50:
 
     // Put another copy of OP*v_{j} into RESID.
 
-    scopy_(&n, &workd[irj], &int1, resid, &int1);
+    BLAS_FUNC(scopy)(&n, &workd[irj], &int1, resid, &int1);
 
     // STEP 4:  Finish extending the symmetric
     //          Arnoldi to length j. If MODE = 2
@@ -1176,7 +1176,7 @@ LINE50:
 
         return;
     } else {
-        scopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE60:
@@ -1197,13 +1197,13 @@ LINE65:
         // Note that the B-norm of OP*v_{j}
         // is the inv(B)-norm of A*v_{j}.
 
-        V->aitr_wnorm = sdot_(&n, resid, &int1, &workd[ivj], &int1);
+        V->aitr_wnorm = BLAS_FUNC(sdot)(&n, resid, &int1, &workd[ivj], &int1);
         V->aitr_wnorm = sqrtf(fabsf(V->aitr_wnorm));
     } else if (V->bmat) {
-        V->aitr_wnorm = sdot_(&n, resid, &int1, &workd[ipj], &int1);
+        V->aitr_wnorm = BLAS_FUNC(sdot)(&n, resid, &int1, &workd[ipj], &int1);
         V->aitr_wnorm = sqrtf(fabsf(V->aitr_wnorm));
     } else {
-        V->aitr_wnorm = snrm2_(&n, resid, &int1);
+        V->aitr_wnorm = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
 
     //  Compute the j-th residual corresponding
@@ -1217,15 +1217,15 @@ LINE65:
     tmp_int = V->aitr_j + 1;
     if (V->mode != 2)
     {
-        sgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
     } else {
-        sgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ivj], &int1, &dbl0, &workd[irj], &int1);
+        BLAS_FUNC(sgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ivj], &int1, &dbl0, &workd[irj], &int1);
     }
 
     //  Orthogonalize r_{j} against V_{j}.
     //  RESID contains OP*v_{j}. See STEP 3.
 
-    sgemv_("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(sgemv)("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
 
     // Extend H to have j rows and columns.
 
@@ -1243,7 +1243,7 @@ LINE65:
 
     if (V->bmat)
     {
-        scopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1252,7 +1252,7 @@ LINE65:
 
         return;
     } else {
-        scopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE70:
@@ -1266,10 +1266,10 @@ LINE70:
 
     if (V->bmat)
     {
-        *rnorm = sdot_(&n, resid, &int1, &workd[ipj], &int1);
+        *rnorm = BLAS_FUNC(sdot)(&n, resid, &int1, &workd[ipj], &int1);
         *rnorm = sqrtf(fabsf(*rnorm));
     } else {
-        *rnorm = snrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
 
     // STEP 5: Re-orthogonalization / Iterative refinement phase
@@ -1297,14 +1297,14 @@ LINE80:
     //  Compute V_{j}^T * B * r_{j}.
     //  WORKD(IRJ:IRJ+J-1) = v(:,1:J)'*WORKD(IPJ:IPJ+N-1).
     tmp_int = V->aitr_j + 1;
-    sgemv_("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
+    BLAS_FUNC(sgemv)("T", &n, &tmp_int, &dbl1, v, &ldv, &workd[ipj], &int1, &dbl0, &workd[irj], &int1);
 
     //  Compute the correction to the residual:
     //  r_{j} = r_{j} - V_{j} * WORKD(IRJ:IRJ+J-1).
     //  The correction to H is v(:,1:J)*H(1:J,1:J)
     //  + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.
 
-    sgemv_("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(sgemv)("N", &n, &tmp_int, &dblm1, v, &ldv, &workd[irj], &int1, &dbl1, resid, &int1);
 
     if ((V->aitr_j == 0) || (V->aitr_restart))
     {
@@ -1316,7 +1316,7 @@ LINE80:
 
     if (V->bmat)
     {
-        scopy_(&n, resid, &int1, &workd[irj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[irj], &int1);
         ipntr[0] = irj;
         ipntr[1] = ipj;
         V->ido = ido_BX;
@@ -1326,7 +1326,7 @@ LINE80:
 
         return;
     } else {
-        scopy_(&n, resid, &int1, &workd[ipj], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[ipj], &int1);
     }
 
 LINE90:
@@ -1337,10 +1337,10 @@ LINE90:
 
     if (V->bmat)
     {
-        V->aitr_rnorm1 = sdot_(&n, resid, &int1, &workd[ipj], &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(sdot)(&n, resid, &int1, &workd[ipj], &int1);
         V->aitr_rnorm1 = sqrtf(fabsf(V->aitr_rnorm1));
     } else {
-        V->aitr_rnorm1 = snrm2_(&n, resid, &int1);
+        V->aitr_rnorm1 = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
 
     //  Determine if we need to perform another
@@ -1388,9 +1388,9 @@ LINE100:
         h[V->aitr_j] = -h[V->aitr_j];
         if (V->aitr_j < k + np - 1)
         {
-            sscal_(&n, &dblm1, &v[V->aitr_j + 1], &int1);
+            BLAS_FUNC(sscal)(&n, &dblm1, &v[V->aitr_j + 1], &int1);
         } else {
-            sscal_(&n, &dblm1, resid, &int1);
+            BLAS_FUNC(sscal)(&n, &dblm1, resid, &int1);
         }
     }
 
@@ -1411,10 +1411,10 @@ LINE100:
 
 
 void
-ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int ldh,
-       float* resid, float* q, int ldq, float* workd)
+ssapps(CBLAS_INT n, CBLAS_INT* kev, CBLAS_INT np, float* shift, float* v, CBLAS_INT ldv, float* h, CBLAS_INT ldh,
+       float* resid, float* q, CBLAS_INT ldq, float* workd)
 {
-    int i, iend, istart, jj, kplusp, tmp_int, int1 = 1;
+    CBLAS_INT i, iend, istart, jj, kplusp, tmp_int; CBLAS_INT int1 = 1;
     float a1, a2, a3, a4, c, f, g, r, s, sigma, tst1;
     float dbl0 = 0.0f, dbl1 = 1.0f, dblm1 = -1.0f;
 
@@ -1424,7 +1424,7 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
     // Initialize Q to the identity to accumulate
     // the rotations and reflections
 
-    slaset_("A", &kplusp, &kplusp, &dbl0, &dbl1, q, &ldq);
+    BLAS_FUNC(slaset)("A", &kplusp, &kplusp, &dbl0, &dbl1, q, &ldq);
 
     // Quick return if there are no shifts to apply
 
@@ -1462,7 +1462,7 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
                 if (h[iend] < 0.0f)
                 {
                     h[iend] = -h[iend];
-                    sscal_(&kplusp, &dblm1, &q[ldq*(iend)], &int1);
+                    BLAS_FUNC(sscal)(&kplusp, &dblm1, &q[ldq*(iend)], &int1);
                 }
                 continue;
             }
@@ -1490,7 +1490,7 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
                 // [-s, c] [ m n ] [s,  c]    [-s*k + c*m, -s*m + c*n] [s,  c]
                 //                                  a3          a4
 
-                slartgp_(&f, &g, &c, &s, &r);
+                BLAS_FUNC(slartgp)(&f, &g, &c, &s, &r);
                 if (i > istart)
                 {
                     h[i] = r;
@@ -1505,7 +1505,7 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
 
                 // Accumulate the rotation also in Q
                 tmp_int = (i + jj + 2 > kplusp ? kplusp : i + jj + 2);
-                srot_(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s);
+                BLAS_FUNC(srot)(&tmp_int, &q[ldq*i], &int1, &q[ldq*(i+1)], &int1, &c, &s);
 
                 if (i < iend - 1)
                 {
@@ -1519,7 +1519,7 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
             if (h[iend] < 0.0f)
             {
                 h[iend] = -h[iend];
-                sscal_(&kplusp, &dblm1, &q[ldq*(iend)], &int1);
+                BLAS_FUNC(sscal)(&kplusp, &dblm1, &q[ldq*(iend)], &int1);
             }
         }
     }
@@ -1545,7 +1545,7 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
 
     if (h[*kev] > 0.0f)
     {
-        sgemv_("N", &n, &kplusp, &dbl1, v, &ldv, &q[ldq*(*kev)], &int1, &dbl0, &workd[n], &int1);
+        BLAS_FUNC(sgemv)("N", &n, &kplusp, &dbl1, v, &ldv, &q[ldq*(*kev)], &int1, &dbl0, &workd[n], &int1);
     }
 
     // Compute column 1 to kev of (V*Q) in backward order
@@ -1556,8 +1556,8 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
     for (i = 0; i < *kev; i++)
     {
         tmp_int = kplusp - i;
-        sgemv_("N", &n, &tmp_int, &dbl1, v, &ldv, &q[ldq*(*kev-i-1)], &int1, &dbl0, workd, &int1);
-        scopy_(&n, workd, &int1, &v[ldv*(kplusp-i-1)], &int1);
+        BLAS_FUNC(sgemv)("N", &n, &tmp_int, &dbl1, v, &ldv, &q[ldq*(*kev-i-1)], &int1, &dbl0, workd, &int1);
+        BLAS_FUNC(scopy)(&n, workd, &int1, &v[ldv*(kplusp-i-1)], &int1);
     }
     // 130
 
@@ -1565,13 +1565,13 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
 
     for (i = 0; i < *kev; i++)
     {
-        scopy_(&n, &v[ldv*(np+i)], &int1, &v[ldv*i], &int1);
+        BLAS_FUNC(scopy)(&n, &v[ldv*(np+i)], &int1, &v[ldv*i], &int1);
     }
     // 140
 
     if (h[*kev] > 0.0f)
     {
-        scopy_(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
+        BLAS_FUNC(scopy)(&n, &workd[n], &int1, &v[ldv*(*kev)], &int1);
     }
 
     // Update the residual vector:
@@ -1580,10 +1580,10 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
     //    sigmak = (e_{kev+p}'*Q)*e_{kev}
     //    betak = e_{kev+1}'*H*e_{kev}
 
-    sscal_(&n, &q[kplusp-1 + (*kev-1)*ldq], resid, &int1);
+    BLAS_FUNC(sscal)(&n, &q[kplusp-1 + (*kev-1)*ldq], resid, &int1);
     if (h[*kev] > 0.0f)
     {
-        saxpy_(&n, &h[*kev], &v[ldv*(*kev)], &int1, resid, &int1);
+        BLAS_FUNC(saxpy)(&n, &h[*kev], &v[ldv*(*kev)], &int1, resid, &int1);
     }
 
     return;
@@ -1591,10 +1591,10 @@ ssapps(int n, int* kev, int np, float* shift, float* v, int ldv, float* h, int l
 
 
 void
-ssgets(struct ARNAUD_state_s *V, int* kev, int* np, float* ritz,
+ssgets(struct ARNAUD_state_s *V, CBLAS_INT* kev, CBLAS_INT* np, float* ritz,
        float* bounds, float* shifts)
 {
-    int kevd2, tmp1, tmp2, int1 = 1;
+    CBLAS_INT kevd2, tmp1, tmp2; CBLAS_INT int1 = 1;
     if (V->which == which_BE)
     {
         // Both ends of the spectrum are requested.
@@ -1610,8 +1610,8 @@ ssgets(struct ARNAUD_state_s *V, int* kev, int* np, float* ritz,
         {
             tmp1 = (kevd2 > *np ? *np : kevd2);
             tmp2 = (kevd2 > *np ? kevd2 : *np);
-            sswap_(&tmp1, ritz, &int1, &ritz[tmp2], &int1);
-            sswap_(&tmp1, bounds, &int1, &bounds[tmp2], &int1);
+            BLAS_FUNC(sswap)(&tmp1, ritz, &int1, &ritz[tmp2], &int1);
+            BLAS_FUNC(sswap)(&tmp1, bounds, &int1, &bounds[tmp2], &int1);
         }
     } else {
 
@@ -1634,16 +1634,16 @@ ssgets(struct ARNAUD_state_s *V, int* kev, int* np, float* ritz,
         // are applied in subroutine dsapps.
 
         ssortr(which_SM, 1, *np, bounds, ritz);
-        scopy_(np, ritz, &int1, shifts, &int1);
+        BLAS_FUNC(scopy)(np, ritz, &int1, shifts, &int1);
     }
 }
 
 
 void
-sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
-       float* v, int ldv, float* resid, float* rnorm, int* ipntr, float* workd)
+sgetv0(struct ARNAUD_state_s *V, CBLAS_INT initv, CBLAS_INT n, CBLAS_INT j,
+       float* v, CBLAS_INT ldv, float* resid, float* rnorm, CBLAS_INT* ipntr, float* workd)
 {
-    int jj, int1 = 1;
+    CBLAS_INT jj; CBLAS_INT int1 = 1;
     const float sq2o2 = sqrtf(2.0f) / 2.0f;
     float dbl1 = 1.0f, dbl0 = 0.0f, dblm1 = -1.0f;
 
@@ -1677,12 +1677,12 @@ sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
         {
             ipntr[0] = 0;
             ipntr[1] = n;
-            scopy_(&n, resid, &int1, workd, &int1);
+            BLAS_FUNC(scopy)(&n, resid, &int1, workd, &int1);
             V->ido = ido_RANDOM_OPX;
             return;
         } else if ((V->getv0_itry > 1) && (V->bmat == 1))
         {
-            scopy_(&n, resid, &int1, &workd[n], &int1);
+            BLAS_FUNC(scopy)(&n, resid, &int1, &workd[n], &int1);
         }
     }
 
@@ -1700,7 +1700,7 @@ sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
     V->getv0_first = 1;
     if (V->getv0_itry == 1)
     {
-        scopy_(&n, &workd[n], &int1, resid, &int1);
+        BLAS_FUNC(scopy)(&n, &workd[n], &int1, resid, &int1);
     }
     if (V->bmat)
     {
@@ -1709,7 +1709,7 @@ sgetv0(struct ARNAUD_state_s *V, int initv, int n, int j,
         V->ido = ido_BX;
         return;
     } else {
-        scopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE20:
@@ -1717,10 +1717,10 @@ LINE20:
     V->getv0_first = 0;
     if (V->bmat)
     {
-        V->getv0_rnorm0 = sdot_(&n, resid, &int1, workd, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(sdot)(&n, resid, &int1, workd, &int1);
         V->getv0_rnorm0 = sqrtf(fabsf(V->getv0_rnorm0));
     } else {
-        V->getv0_rnorm0 = snrm2_(&n, resid, &int1);
+        V->getv0_rnorm0 = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
     *rnorm = V->getv0_rnorm0;
 
@@ -1746,29 +1746,29 @@ LINE20:
 
 LINE30:
 
-    sgemv_("T", &n, &j, &dbl1, v, &ldv, workd, &int1, &dbl0, &workd[n], &int1);
-    sgemv_("N", &n, &j, &dblm1, v, &ldv, &workd[n], &int1, &dbl1, resid, &int1);
+    BLAS_FUNC(sgemv)("T", &n, &j, &dbl1, v, &ldv, workd, &int1, &dbl0, &workd[n], &int1);
+    BLAS_FUNC(sgemv)("N", &n, &j, &dblm1, v, &ldv, &workd[n], &int1, &dbl1, resid, &int1);
 
     //  Compute the B-norm of the orthogonalized starting vector
 
     if (V->bmat)
     {
-        scopy_(&n, resid, &int1, &workd[n], &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, &workd[n], &int1);
         ipntr[0] = n;
         ipntr[1] = 0;
         V->ido = ido_BX;
         return;
     } else {
-        scopy_(&n, resid, &int1, workd, &int1);
+        BLAS_FUNC(scopy)(&n, resid, &int1, workd, &int1);
     }
 
 LINE40:
     if (V->bmat)
     {
-        *rnorm = sdot_(&n, resid, &int1, workd, &int1);
+        *rnorm = BLAS_FUNC(sdot)(&n, resid, &int1, workd, &int1);
         *rnorm = sqrtf(fabsf(*rnorm));
     } else {
-        *rnorm = snrm2_(&n, resid, &int1);
+        *rnorm = BLAS_FUNC(snrm2)(&n, resid, &int1);
     }
 
     //  Check for further orthogonalization.
@@ -1803,9 +1803,9 @@ LINE40:
 
 
 void
-ssortr(const enum ARNAUD_which w, const int apply, const int n, float* x1, float* x2)
+ssortr(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, float* x1, float* x2)
 {
-    int i, gap, pos;
+    CBLAS_INT i, gap, pos;
     float temp;
     ARNAUD_compare_rfunc *f;
 
@@ -1856,9 +1856,9 @@ ssortr(const enum ARNAUD_which w, const int apply, const int n, float* x1, float
 
 
 static void
-ssesrt(const enum ARNAUD_which w, const int apply, const int n, float* x, int na, float* a, const int lda)
+ssesrt(const enum ARNAUD_which w, const CBLAS_INT apply, const CBLAS_INT n, float* x, CBLAS_INT na, float* a, const CBLAS_INT lda)
 {
-    int i, gap, pos, int1 = 1;
+    CBLAS_INT i, gap, pos; CBLAS_INT int1 = 1;
     float temp;
     ARNAUD_compare_rfunc *f;
 
@@ -1896,7 +1896,7 @@ ssesrt(const enum ARNAUD_which w, const int apply, const int n, float* x, int na
 
                 if (apply)
                 {
-                    sswap_(&na, &a[lda*pos], &int1, &a[lda*(pos+gap)], &int1);
+                    BLAS_FUNC(sswap)(&na, &a[lda*pos], &int1, &a[lda*(pos+gap)], &int1);
                 }
                 pos -= gap;
             }
@@ -1907,16 +1907,16 @@ ssesrt(const enum ARNAUD_which w, const int apply, const int n, float* x, int na
 
 
 void
-sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
+sstqrb(CBLAS_INT n, float* d, float* e, float* z, float* work, CBLAS_INT* info)
 {
-    int int1 = 1, int0 = 0;
+    CBLAS_INT int1 = 1, int0 = 0;
     float eps2 = powf(ulp, 2.0f);
     float safmin = unfl;
     float safmax = (1.0f / safmin);
     float ssfmax = sqrtf(safmax) / 3.0f;
     float ssfmin = sqrtf(safmin) / eps2;
 
-    int nmaxit, jtot, i, ii, j, k, l1, m = 0, tmp_int = 0, l, lsv, lend, lendsv, iscale;
+    CBLAS_INT nmaxit, jtot, i, ii, j, k, l1, m = 0, tmp_int = 0, l, lsv, lend, lendsv, iscale;
     float anorm = 0.0f, rt1 = 0.0f, rt2 = 0.0f, c = 0.0f, s = 0.0f, g = 0.0f, r = 0.0f, p = 0.0f;
     float b, f, tst;
 
@@ -1976,7 +1976,7 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
 
         // Scale submatrix in rows and columns L to LEND
         tmp_int = lend - l + 1;
-        anorm = slanst_("I", &tmp_int, &d[l-1], &e[l-1]);
+        anorm = BLAS_FUNC(slanst)("I", &tmp_int, &d[l-1], &e[l-1]);
         iscale = 0;
 
         if (anorm == 0.0f) { continue; }
@@ -1984,14 +1984,14 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
         if (anorm > ssfmax)
         {
             iscale = 1;
-            slascl_("G", &int0, &int0, &anorm, &ssfmax, &tmp_int, &int1, &d[l-1], &n, info);
+            BLAS_FUNC(slascl)("G", &int0, &int0, &anorm, &ssfmax, &tmp_int, &int1, &d[l-1], &n, info);
             tmp_int -= 1;
-            slascl_("G", &int0, &int0, &anorm, &ssfmax, &tmp_int, &int1, &e[l-1], &n, info);
+            BLAS_FUNC(slascl)("G", &int0, &int0, &anorm, &ssfmax, &tmp_int, &int1, &e[l-1], &n, info);
         } else if (anorm < ssfmin) {
             iscale = 2;
-            slascl_("G", &int0, &int0, &anorm, &ssfmin, &tmp_int, &int1, &d[l-1], &n, info);
+            BLAS_FUNC(slascl)("G", &int0, &int0, &anorm, &ssfmin, &tmp_int, &int1, &d[l-1], &n, info);
             tmp_int -= 1;
-            slascl_("G", &int0, &int0, &anorm, &ssfmin, &tmp_int, &int1, &e[l-1], &n, info);
+            BLAS_FUNC(slascl)("G", &int0, &int0, &anorm, &ssfmin, &tmp_int, &int1, &e[l-1], &n, info);
         }
         // Choose between QL and QR iteration
 
@@ -2035,7 +2035,7 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
                 // If remaining matrix is 2x2, use dlaev2 to compute its eigensystem
                 if (m == l + 1)
                 {
-                    slaev2_(&d[l - 1], &e[l - 1], &d[l], &rt1, &rt2, &c, &s);
+                    BLAS_FUNC(slaev2)(&d[l - 1], &e[l - 1], &d[l], &rt1, &rt2, &c, &s);
                     work[l - 1] = c;
                     work[n - 1 + l - 1] = s;
                     tst    = z[l];
@@ -2066,7 +2066,7 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
                 {
                     f = s * e[i-1];
                     b = c * e[i-1];
-                    slartg_(&g, &f, &c, &s, &r);
+                    BLAS_FUNC(slartg)(&g, &f, &c, &s, &r);
                     if (i != m - 1) { e[i] = r; }
                     g = d[i] - p;
                     r = (d[i-1] - g)*s + 2.0f*c*b;
@@ -2078,7 +2078,7 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
                 }
                 // 70
                 tmp_int = m - l + 1;
-                slasr_("R", "V", "B", &int1, &tmp_int, &work[l-1], &work[n-1+l-1], &z[l-1], &int1);
+                BLAS_FUNC(slasr)("R", "V", "B", &int1, &tmp_int, &work[l-1], &work[n-1+l-1], &z[l-1], &int1);
 
                 d[l-1] = d[l-1] - p;
                 e[l-1] = g;
@@ -2117,7 +2117,7 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
                 // If remaining matrix is 2x2, use dlaev2 to compute its eigensystem
                 if (m == l - 1)
                 {
-                    slaev2_(&d[l-2], &e[l-2], &d[l-1], &rt1, &rt2, &c, &s);
+                    BLAS_FUNC(slaev2)(&d[l-2], &e[l-2], &d[l-1], &rt1, &rt2, &c, &s);
                     tst    = z[l-1];
                     z[l-1] = c*tst - s*z[l-2];
                     z[l-2] = s*tst + c*z[l-2];
@@ -2147,7 +2147,7 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
                 {
                     f = s * e[i-1];
                     b = c * e[i-1];
-                    slartg_(&g, &f, &c, &s, &r);
+                    BLAS_FUNC(slartg)(&g, &f, &c, &s, &r);
                     if (i != m) { e[i-2] = r; }
                     g = d[i-1] - p;
                     r = (d[i] - g)*s + 2.0f*c*b;
@@ -2162,7 +2162,7 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
                 // 120
                 // Apply saved rotations.
                 tmp_int = l - m + 1;
-                slasr_("R", "V", "F", &int1, &tmp_int, &work[m-1], &work[n-1+m-1], &z[m-1], &int1);
+                BLAS_FUNC(slasr)("R", "V", "F", &int1, &tmp_int, &work[m-1], &work[n-1+m-1], &z[m-1], &int1);
 
                 d[l-1] = d[l-1] - p;
                 e[l - 2] = g;
@@ -2176,15 +2176,15 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
         if (iscale == 1)
         {
 
-            slascl_("G", &int0, &int0, &ssfmax, &anorm, &tmp_int, &int1, &d[lsv-1], &n, info);
+            BLAS_FUNC(slascl)("G", &int0, &int0, &ssfmax, &anorm, &tmp_int, &int1, &d[lsv-1], &n, info);
             tmp_int -= 1;
-            slascl_("G", &int0, &int0, &ssfmax, &anorm, &tmp_int, &int1, &e[lsv-1], &n, info);
+            BLAS_FUNC(slascl)("G", &int0, &int0, &ssfmax, &anorm, &tmp_int, &int1, &e[lsv-1], &n, info);
 
         } else if (iscale == 2) {
 
-            slascl_("G", &int0, &int0, &ssfmin, &anorm, &tmp_int, &int1, &d[lsv-1], &n, info);
+            BLAS_FUNC(slascl)("G", &int0, &int0, &ssfmin, &anorm, &tmp_int, &int1, &d[lsv-1], &n, info);
             tmp_int -= 1;
-            slascl_("G", &int0, &int0, &ssfmin, &anorm, &tmp_int, &int1, &e[lsv-1], &n, info);
+            BLAS_FUNC(slascl)("G", &int0, &int0, &ssfmin, &anorm, &tmp_int, &int1, &e[lsv-1], &n, info);
 
         }
 
@@ -2229,7 +2229,7 @@ sstqrb(int n, float* d, float* e, float* z, float* work, int* info)
 }
 
 
-int sortr_LM(const float x1, const float x2) { return (fabsf(x1) > fabsf(x2)); }
-int sortr_SM(const float x1, const float x2) { return (fabsf(x1) < fabsf(x2)); }
-int sortr_LA(const float x1, const float x2) { return (x1 > x2); }
-int sortr_SA(const float x1, const float x2) { return (x1 < x2); }
+CBLAS_INT sortr_LM(const float x1, const float x2) { return (fabsf(x1) > fabsf(x2)); }
+CBLAS_INT sortr_SM(const float x1, const float x2) { return (fabsf(x1) < fabsf(x2)); }
+CBLAS_INT sortr_LA(const float x1, const float x2) { return (x1 > x2); }
+CBLAS_INT sortr_SA(const float x1, const float x2) { return (x1 < x2); }

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/src/blaslapack_declarations.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/src/blaslapack_declarations.h
@@ -3,119 +3,120 @@
 
 #include "arnaud/types.h"
 
+
 // BLAS
-void saxpy_(int* n, float* alpha, float* x, int* incx, float* y, int* incy);
-void scopy_(int* n, float* x, int* incx, float* y, int* incy);
-float sdot_(int* n, float* x, int* incx, float* y, int* incy);
-void sgemv_(char* trans, int* m, int* n, float* alpha, float* a, int* lda, float* x, int* incx, float* beta, float* y, int* incy);
-void sger_(int* m, int* n, float* alpha, float* x, int* incx, float* y, int* incy, float* a, int* lda);
-float snrm2_(int* n, float* x, int* incx);
-void srot_(int* n, float* sx, int* incx, float* sy, int* incy, float* c, float* s);
-void sscal_(int* n, float* alpha, float* x, int* incx);
-void sswap_(int* n, float* x, int* incx, float* y, int* incy);
-void strmm_(char* side, char* uplo, char* transa, char* diag, int* m, int* n, float* alpha, float* a, int* lda, float* b, int* ldb);
+void BLAS_FUNC(saxpy)(CBLAS_INT* n, float* alpha, float* x, CBLAS_INT* incx, float* y, CBLAS_INT* incy);
+void BLAS_FUNC(scopy)(CBLAS_INT* n, float* x, CBLAS_INT* incx, float* y, CBLAS_INT* incy);
+float BLAS_FUNC(sdot)(CBLAS_INT* n, float* x, CBLAS_INT* incx, float* y, CBLAS_INT* incy);
+void BLAS_FUNC(sgemv)(char* trans, CBLAS_INT* m, CBLAS_INT* n, float* alpha, float* a, CBLAS_INT* lda, float* x, CBLAS_INT* incx, float* beta, float* y, CBLAS_INT* incy);
+void BLAS_FUNC(sger)(CBLAS_INT* m, CBLAS_INT* n, float* alpha, float* x, CBLAS_INT* incx, float* y, CBLAS_INT* incy, float* a, CBLAS_INT* lda);
+float BLAS_FUNC(snrm2)(CBLAS_INT* n, float* x, CBLAS_INT* incx);
+void BLAS_FUNC(srot)(CBLAS_INT* n, float* sx, CBLAS_INT* incx, float* sy, CBLAS_INT* incy, float* c, float* s);
+void BLAS_FUNC(sscal)(CBLAS_INT* n, float* alpha, float* x, CBLAS_INT* incx);
+void BLAS_FUNC(sswap)(CBLAS_INT* n, float* x, CBLAS_INT* incx, float* y, CBLAS_INT* incy);
+void BLAS_FUNC(strmm)(char* side, char* uplo, char* transa, char* diag, CBLAS_INT* m, CBLAS_INT* n, float* alpha, float* a, CBLAS_INT* lda, float* b, CBLAS_INT* ldb);
 
 
-void daxpy_(int* n, double* alpha, double* x, int* incx, double* y, int* incy);
-void dcopy_(int* n, double* x, int* incx, double* y, int* incy);
-double ddot_(int* n, double* x, int* incx, double* y, int* incy);
-void dgemv_(char* trans, int* m, int* n, double* alpha, double* a, int* lda, double* x, int* incx, double* beta, double* y, int* incy);
-void dger_(int* m, int* n, double* alpha, double* x, int* incx, double* y, int* incy, double* a, int* lda);
-double dnrm2_(int* n, double* x, int* incx);
-void drot_(int* n, double* sx, int* incx, double* sy, int* incy, double* c, double* s);
-void dscal_(int* n, double* alpha, double* x, int* incx);
-void dswap_(int* n, double* x, int* incx, double* y, int* incy);
-void dtrmm_(char* side, char* uplo, char* transa, char* diag, int* m, int* n, double* alpha, double* a, int* lda, double* b, int* ldb);
+void BLAS_FUNC(daxpy)(CBLAS_INT* n, double* alpha, double* x, CBLAS_INT* incx, double* y, CBLAS_INT* incy);
+void BLAS_FUNC(dcopy)(CBLAS_INT* n, double* x, CBLAS_INT* incx, double* y, CBLAS_INT* incy);
+double BLAS_FUNC(ddot)(CBLAS_INT* n, double* x, CBLAS_INT* incx, double* y, CBLAS_INT* incy);
+void BLAS_FUNC(dgemv)(char* trans, CBLAS_INT* m, CBLAS_INT* n, double* alpha, double* a, CBLAS_INT* lda, double* x, CBLAS_INT* incx, double* beta, double* y, CBLAS_INT* incy);
+void BLAS_FUNC(dger)(CBLAS_INT* m, CBLAS_INT* n, double* alpha, double* x, CBLAS_INT* incx, double* y, CBLAS_INT* incy, double* a, CBLAS_INT* lda);
+double BLAS_FUNC(dnrm2)(CBLAS_INT* n, double* x, CBLAS_INT* incx);
+void BLAS_FUNC(drot)(CBLAS_INT* n, double* sx, CBLAS_INT* incx, double* sy, CBLAS_INT* incy, double* c, double* s);
+void BLAS_FUNC(dscal)(CBLAS_INT* n, double* alpha, double* x, CBLAS_INT* incx);
+void BLAS_FUNC(dswap)(CBLAS_INT* n, double* x, CBLAS_INT* incx, double* y, CBLAS_INT* incy);
+void BLAS_FUNC(dtrmm)(char* side, char* uplo, char* transa, char* diag, CBLAS_INT* m, CBLAS_INT* n, double* alpha, double* a, CBLAS_INT* lda, double* b, CBLAS_INT* ldb);
 
 
-void caxpy_(int* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* x, int* incx, ARNAUD_CPLXF_TYPE* y, int* incy);
-void ccopy_(int* n, ARNAUD_CPLXF_TYPE* x, int* incx, ARNAUD_CPLXF_TYPE* y, int* incy);
-void cgeru_(int* m, int* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* x, int* incx, ARNAUD_CPLXF_TYPE* y, int* incy, ARNAUD_CPLXF_TYPE* a, int* lda);
-float scnrm2_(int* n, ARNAUD_CPLXF_TYPE* x, int* incx);
-void cscal_(int* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* x, int* incx);
-void csscal_(int* n, float* da, ARNAUD_CPLXF_TYPE* zx, int* incx);
-void cgemv_(char* trans, int* m, int* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* a, int* lda, ARNAUD_CPLXF_TYPE* x, int* incx, ARNAUD_CPLXF_TYPE* beta, ARNAUD_CPLXF_TYPE* y, int* incy);
-void crot_(int* n, ARNAUD_CPLXF_TYPE* cx, int* incx, ARNAUD_CPLXF_TYPE* cy, int* incy, float* c, ARNAUD_CPLXF_TYPE* s);
-void ctrmm_(char* side, char* uplo, char* transa, char* diag, int* m, int* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* a, int* lda, ARNAUD_CPLXF_TYPE* b, int* ldb);
+void BLAS_FUNC(caxpy)(CBLAS_INT* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLXF_TYPE* y, CBLAS_INT* incy);
+void BLAS_FUNC(ccopy)(CBLAS_INT* n, ARNAUD_CPLXF_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLXF_TYPE* y, CBLAS_INT* incy);
+void BLAS_FUNC(cgeru)(CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLXF_TYPE* y, CBLAS_INT* incy, ARNAUD_CPLXF_TYPE* a, CBLAS_INT* lda);
+float BLAS_FUNC(scnrm2)(CBLAS_INT* n, ARNAUD_CPLXF_TYPE* x, CBLAS_INT* incx);
+void BLAS_FUNC(cscal)(CBLAS_INT* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* x, CBLAS_INT* incx);
+void BLAS_FUNC(csscal)(CBLAS_INT* n, float* da, ARNAUD_CPLXF_TYPE* zx, CBLAS_INT* incx);
+void BLAS_FUNC(cgemv)(char* trans, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLXF_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLXF_TYPE* beta, ARNAUD_CPLXF_TYPE* y, CBLAS_INT* incy);
+void BLAS_FUNC(crot)(CBLAS_INT* n, ARNAUD_CPLXF_TYPE* cx, CBLAS_INT* incx, ARNAUD_CPLXF_TYPE* cy, CBLAS_INT* incy, float* c, ARNAUD_CPLXF_TYPE* s);
+void BLAS_FUNC(ctrmm)(char* side, char* uplo, char* transa, char* diag, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLXF_TYPE* b, CBLAS_INT* ldb);
 
 
-void zaxpy_(int* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* x, int* incx, ARNAUD_CPLX_TYPE* y, int* incy);
-void zcopy_(int* n, ARNAUD_CPLX_TYPE* x, int* incx, ARNAUD_CPLX_TYPE* y, int* incy);
-void zgeru_(int* m, int* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* x, int* incx, ARNAUD_CPLX_TYPE* y, int* incy, ARNAUD_CPLX_TYPE* a, int* lda);
-double dznrm2_(int* n, ARNAUD_CPLX_TYPE* x, int* incx);
-void zscal_(int* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* x, int* incx);
-void zdscal_(int* n, double* da, ARNAUD_CPLX_TYPE* zx, int* incx);
-void zgemv_(char* trans, int* m, int* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* a, int* lda, ARNAUD_CPLX_TYPE* x, int* incx, ARNAUD_CPLX_TYPE* beta, ARNAUD_CPLX_TYPE* y, int* incy);
-void zrot_(int* n, ARNAUD_CPLX_TYPE* cx, int* incx, ARNAUD_CPLX_TYPE* cy, int* incy, double* c, ARNAUD_CPLX_TYPE* s);
-void ztrmm_(char* side, char* uplo, char* transa, char* diag, int* m, int* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* a, int* lda, ARNAUD_CPLX_TYPE* b, int* ldb);
+void BLAS_FUNC(zaxpy)(CBLAS_INT* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLX_TYPE* y, CBLAS_INT* incy);
+void BLAS_FUNC(zcopy)(CBLAS_INT* n, ARNAUD_CPLX_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLX_TYPE* y, CBLAS_INT* incy);
+void BLAS_FUNC(zgeru)(CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLX_TYPE* y, CBLAS_INT* incy, ARNAUD_CPLX_TYPE* a, CBLAS_INT* lda);
+double BLAS_FUNC(dznrm2)(CBLAS_INT* n, ARNAUD_CPLX_TYPE* x, CBLAS_INT* incx);
+void BLAS_FUNC(zscal)(CBLAS_INT* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* x, CBLAS_INT* incx);
+void BLAS_FUNC(zdscal)(CBLAS_INT* n, double* da, ARNAUD_CPLX_TYPE* zx, CBLAS_INT* incx);
+void BLAS_FUNC(zgemv)(char* trans, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLX_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLX_TYPE* beta, ARNAUD_CPLX_TYPE* y, CBLAS_INT* incy);
+void BLAS_FUNC(zrot)(CBLAS_INT* n, ARNAUD_CPLX_TYPE* cx, CBLAS_INT* incx, ARNAUD_CPLX_TYPE* cy, CBLAS_INT* incy, double* c, ARNAUD_CPLX_TYPE* s);
+void BLAS_FUNC(ztrmm)(char* side, char* uplo, char* transa, char* diag, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLX_TYPE* b, CBLAS_INT* ldb);
 
 
 
 // LAPACK
-void sgeqr2_(int* m, int* n, float* a, int* lda, float* tau, float* work, int* info);
-void slacpy_(char* uplo, int* m, int* n, float* a, int* lda, float* b, int* ldb);
-void slaev2_(float* a, float* b, float* c, float* rt1, float* rt2, float* cs1, float* sn1);
-void slahqr_(int* wantt, int* wantz, int* n, int* ilo, int* ihi, float* h, int* ldh, float* wr, float* wi, int* iloz, int* ihiz, float* z, int* ldz, int* info );
-float slanhs_(char* norm, int* n, float* a, int* lda, float* work);
-float slanst_(char* norm, int* n, float* d, float* e);
-void slarf_(char* side, int* m, int* n, float* v, int* incv, float* tau, float* c, int* ldc, float* work);
-void slarfg_(int* n, float* alpha, float* x, int* incx, float* tau);
-void slartg_(float* f, float* g, float* c, float* s, float* r);
-void slartgp_(float* f, float* g, float* c, float* s, float* r);
-void slascl_(char* mtype, int* kl, int* ku, float* cfrom, float* cto, int* m, int* n, float* a, int* lda, int* info);
-void slaset_(char* uplo, int* m, int* n, float* alpha, float* beta, float* a, int* lda);
-void slasr_(char* side, char* pivot, char* direct, int* m, int* n, float* c, float* s, float* a, int* lda);
-void sorm2r_(char* side, char* trans, int* m, int* n, int* k, float* a, int* lda, float* tau, float* c, int* ldc, float* work, int* info);
-void ssteqr_(char* compz, int* n, float* d, float* e, float* z, int* ldz, float* work, int* info);
-void strevc_(char* side, char* howmny, int* select, int* n, float* t, int* ldt, float* vl, int* ldvl, float* vr, int* ldvr, int* mm, int* m, float* work, int* info);
-void strsen_(char* job, char* compq, int* select, int* n, float* t, int* ldt, float* q, int* ldq, float* wr, float* wi, int* m, float* s, float* sep, float* work, int* lwork, int* iwork, int* liwork, int* info);
+void BLAS_FUNC(sgeqr2)(CBLAS_INT* m, CBLAS_INT* n, float* a, CBLAS_INT* lda, float* tau, float* work, CBLAS_INT* info);
+void BLAS_FUNC(slacpy)(char* uplo, CBLAS_INT* m, CBLAS_INT* n, float* a, CBLAS_INT* lda, float* b, CBLAS_INT* ldb);
+void BLAS_FUNC(slaev2)(float* a, float* b, float* c, float* rt1, float* rt2, float* cs1, float* sn1);
+void BLAS_FUNC(slahqr)(CBLAS_INT* wantt, CBLAS_INT* wantz, CBLAS_INT* n, CBLAS_INT* ilo, CBLAS_INT* ihi, float* h, CBLAS_INT* ldh, float* wr, float* wi, CBLAS_INT* iloz, CBLAS_INT* ihiz, float* z, CBLAS_INT* ldz, CBLAS_INT* info );
+float BLAS_FUNC(slanhs)(char* norm, CBLAS_INT* n, float* a, CBLAS_INT* lda, float* work);
+float BLAS_FUNC(slanst)(char* norm, CBLAS_INT* n, float* d, float* e);
+void BLAS_FUNC(slarf)(char* side, CBLAS_INT* m, CBLAS_INT* n, float* v, CBLAS_INT* incv, float* tau, float* c, CBLAS_INT* ldc, float* work);
+void BLAS_FUNC(slarfg)(CBLAS_INT* n, float* alpha, float* x, CBLAS_INT* incx, float* tau);
+void BLAS_FUNC(slartg)(float* f, float* g, float* c, float* s, float* r);
+void BLAS_FUNC(slartgp)(float* f, float* g, float* c, float* s, float* r);
+void BLAS_FUNC(slascl)(char* mtype, CBLAS_INT* kl, CBLAS_INT* ku, float* cfrom, float* cto, CBLAS_INT* m, CBLAS_INT* n, float* a, CBLAS_INT* lda, CBLAS_INT* info);
+void BLAS_FUNC(slaset)(char* uplo, CBLAS_INT* m, CBLAS_INT* n, float* alpha, float* beta, float* a, CBLAS_INT* lda);
+void BLAS_FUNC(slasr)(char* side, char* pivot, char* direct, CBLAS_INT* m, CBLAS_INT* n, float* c, float* s, float* a, CBLAS_INT* lda);
+void BLAS_FUNC(sorm2r)(char* side, char* trans, CBLAS_INT* m, CBLAS_INT* n, CBLAS_INT* k, float* a, CBLAS_INT* lda, float* tau, float* c, CBLAS_INT* ldc, float* work, CBLAS_INT* info);
+void BLAS_FUNC(ssteqr)(char* compz, CBLAS_INT* n, float* d, float* e, float* z, CBLAS_INT* ldz, float* work, CBLAS_INT* info);
+void BLAS_FUNC(strevc)(char* side, char* howmny, CBLAS_INT* select, CBLAS_INT* n, float* t, CBLAS_INT* ldt, float* vl, CBLAS_INT* ldvl, float* vr, CBLAS_INT* ldvr, CBLAS_INT* mm, CBLAS_INT* m, float* work, CBLAS_INT* info);
+void BLAS_FUNC(strsen)(char* job, char* compq, CBLAS_INT* select, CBLAS_INT* n, float* t, CBLAS_INT* ldt, float* q, CBLAS_INT* ldq, float* wr, float* wi, CBLAS_INT* m, float* s, float* sep, float* work, CBLAS_INT* lwork, CBLAS_INT* iwork, CBLAS_INT* liwork, CBLAS_INT* info);
 
 
-void dgeqr2_(int* m, int* n, double* a, int* lda, double* tau, double* work, int* info);
-void dlacpy_(char* uplo, int* m, int* n, double* a, int* lda, double* b, int* ldb);
-void dlaev2_(double* a, double* b, double* c, double* rt1, double* rt2, double* cs1, double* sn1);
-void dlahqr_(int* wantt, int* wantz, int* n, int* ilo, int* ihi, double* h, int* ldh, double* wr, double* wi, int* iloz, int* ihiz, double* z, int* ldz, int* info );
-double dlanhs_(char* norm, int* n, double* a, int* lda, double* work);
-double dlanst_(char* norm, int* n, double* d, double* e);
-void dlarf_(char* side, int* m, int* n, double* v, int* incv, double* tau, double* c, int* ldc, double* work);
-void dlarfg_(int* n, double* alpha, double* x, int* incx, double* tau);
-void dlartg_(double* f, double* g, double* c, double* s, double* r);
-void dlartgp_(double* f, double* g, double* c, double* s, double* r);
-void dlascl_(char* mtype, int* kl, int* ku, double* cfrom, double* cto, int* m, int* n, double* a, int* lda, int* info);
-void dlaset_(char* uplo, int* m, int* n, double* alpha, double* beta, double* a, int* lda);
-void dlasr_(char* side, char* pivot, char* direct, int* m, int* n, double* c, double* s, double* a, int* lda);
-void dorm2r_(char* side, char* trans, int* m, int* n, int* k, double* a, int* lda, double* tau, double* c, int* ldc, double* work, int* info);
-void dsteqr_(char* compz, int* n, double* d, double* e, double* z, int* ldz, double* work, int* info);
-void dtrevc_(char* side, char* howmny, int* select, int* n, double* t, int* ldt, double* vl, int* ldvl, double* vr, int* ldvr, int* mm, int* m, double* work, int* info);
-void dtrsen_(char* job, char* compq, int* select, int* n, double* t, int* ldt, double* q, int* ldq, double* wr, double* wi, int* m, double* s, double* sep, double* work, int* lwork, int* iwork, int* liwork, int* info);
+void BLAS_FUNC(dgeqr2)(CBLAS_INT* m, CBLAS_INT* n, double* a, CBLAS_INT* lda, double* tau, double* work, CBLAS_INT* info);
+void BLAS_FUNC(dlacpy)(char* uplo, CBLAS_INT* m, CBLAS_INT* n, double* a, CBLAS_INT* lda, double* b, CBLAS_INT* ldb);
+void BLAS_FUNC(dlaev2)(double* a, double* b, double* c, double* rt1, double* rt2, double* cs1, double* sn1);
+void BLAS_FUNC(dlahqr)(CBLAS_INT* wantt, CBLAS_INT* wantz, CBLAS_INT* n, CBLAS_INT* ilo, CBLAS_INT* ihi, double* h, CBLAS_INT* ldh, double* wr, double* wi, CBLAS_INT* iloz, CBLAS_INT* ihiz, double* z, CBLAS_INT* ldz, CBLAS_INT* info );
+double BLAS_FUNC(dlanhs)(char* norm, CBLAS_INT* n, double* a, CBLAS_INT* lda, double* work);
+double BLAS_FUNC(dlanst)(char* norm, CBLAS_INT* n, double* d, double* e);
+void BLAS_FUNC(dlarf)(char* side, CBLAS_INT* m, CBLAS_INT* n, double* v, CBLAS_INT* incv, double* tau, double* c, CBLAS_INT* ldc, double* work);
+void BLAS_FUNC(dlarfg)(CBLAS_INT* n, double* alpha, double* x, CBLAS_INT* incx, double* tau);
+void BLAS_FUNC(dlartg)(double* f, double* g, double* c, double* s, double* r);
+void BLAS_FUNC(dlartgp)(double* f, double* g, double* c, double* s, double* r);
+void BLAS_FUNC(dlascl)(char* mtype, CBLAS_INT* kl, CBLAS_INT* ku, double* cfrom, double* cto, CBLAS_INT* m, CBLAS_INT* n, double* a, CBLAS_INT* lda, CBLAS_INT* info);
+void BLAS_FUNC(dlaset)(char* uplo, CBLAS_INT* m, CBLAS_INT* n, double* alpha, double* beta, double* a, CBLAS_INT* lda);
+void BLAS_FUNC(dlasr)(char* side, char* pivot, char* direct, CBLAS_INT* m, CBLAS_INT* n, double* c, double* s, double* a, CBLAS_INT* lda);
+void BLAS_FUNC(dorm2r)(char* side, char* trans, CBLAS_INT* m, CBLAS_INT* n, CBLAS_INT* k, double* a, CBLAS_INT* lda, double* tau, double* c, CBLAS_INT* ldc, double* work, CBLAS_INT* info);
+void BLAS_FUNC(dsteqr)(char* compz, CBLAS_INT* n, double* d, double* e, double* z, CBLAS_INT* ldz, double* work, CBLAS_INT* info);
+void BLAS_FUNC(dtrevc)(char* side, char* howmny, CBLAS_INT* select, CBLAS_INT* n, double* t, CBLAS_INT* ldt, double* vl, CBLAS_INT* ldvl, double* vr, CBLAS_INT* ldvr, CBLAS_INT* mm, CBLAS_INT* m, double* work, CBLAS_INT* info);
+void BLAS_FUNC(dtrsen)(char* job, char* compq, CBLAS_INT* select, CBLAS_INT* n, double* t, CBLAS_INT* ldt, double* q, CBLAS_INT* ldq, double* wr, double* wi, CBLAS_INT* m, double* s, double* sep, double* work, CBLAS_INT* lwork, CBLAS_INT* iwork, CBLAS_INT* liwork, CBLAS_INT* info);
 
 
-void cgeqr2_(int* m, int* n, ARNAUD_CPLXF_TYPE* a, int* lda, ARNAUD_CPLXF_TYPE* tau, ARNAUD_CPLXF_TYPE* work, int* info);
-void clacpy_(char* uplo, int* m, int* n, ARNAUD_CPLXF_TYPE* a, int* lda, ARNAUD_CPLXF_TYPE* b, int* ldb);
-void clahqr_(int* wantt, int* wantz, int* n, int* ilo, int* ihi, ARNAUD_CPLXF_TYPE* h, int* ldh, ARNAUD_CPLXF_TYPE* w, int* iloz, int* ihiz, ARNAUD_CPLXF_TYPE* z, int* ldz, int* info );
-float clanhs_(char* norm, int* n, ARNAUD_CPLXF_TYPE* a, int* lda, float* work);
-void clarf_(char* side, int* m, int* n, ARNAUD_CPLXF_TYPE* v, int* incv, ARNAUD_CPLXF_TYPE* tau, ARNAUD_CPLXF_TYPE* c, int* ldc, ARNAUD_CPLXF_TYPE* work);
-void clarfg_(int* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* x, int* incx, ARNAUD_CPLXF_TYPE* tau);
-void clartg_(ARNAUD_CPLXF_TYPE* f, ARNAUD_CPLXF_TYPE* g, float* c, ARNAUD_CPLXF_TYPE* s, ARNAUD_CPLXF_TYPE* r);
-void clascl_(char* mtype, int* kl, int* ku, float* cfrom, float* cto, int* m, int* n, ARNAUD_CPLXF_TYPE* a, int* lda, int* info);
-void claset_(char* uplo, int* m, int* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* beta, ARNAUD_CPLXF_TYPE* a, int* lda);
-void ctrevc_(char* side, char* howmny, int* select, int* n, ARNAUD_CPLXF_TYPE* t, int* ldt, ARNAUD_CPLXF_TYPE* vl, int* ldvl, ARNAUD_CPLXF_TYPE* vr, int* ldvr, int* mm, int* m, ARNAUD_CPLXF_TYPE* work, float* rwork, int* info);
-void ctrsen_(char* job, char* compq, int* select, int* n, ARNAUD_CPLXF_TYPE* t, int* ldt, ARNAUD_CPLXF_TYPE* q, int* ldq, ARNAUD_CPLXF_TYPE* w, int* m, float* s, float* sep, ARNAUD_CPLXF_TYPE* work, int* lwork, int* info);
-void cunm2r_(char* side, char* trans, int* m, int* n, int* k, ARNAUD_CPLXF_TYPE* a, int* lda, ARNAUD_CPLXF_TYPE* tau, ARNAUD_CPLXF_TYPE* c, int* ldc, ARNAUD_CPLXF_TYPE* work, int* info);
+void BLAS_FUNC(cgeqr2)(CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLXF_TYPE* tau, ARNAUD_CPLXF_TYPE* work, CBLAS_INT* info);
+void BLAS_FUNC(clacpy)(char* uplo, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLXF_TYPE* b, CBLAS_INT* ldb);
+void BLAS_FUNC(clahqr)(CBLAS_INT* wantt, CBLAS_INT* wantz, CBLAS_INT* n, CBLAS_INT* ilo, CBLAS_INT* ihi, ARNAUD_CPLXF_TYPE* h, CBLAS_INT* ldh, ARNAUD_CPLXF_TYPE* w, CBLAS_INT* iloz, CBLAS_INT* ihiz, ARNAUD_CPLXF_TYPE* z, CBLAS_INT* ldz, CBLAS_INT* info );
+float BLAS_FUNC(clanhs)(char* norm, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* a, CBLAS_INT* lda, float* work);
+void BLAS_FUNC(clarf)(char* side, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* v, CBLAS_INT* incv, ARNAUD_CPLXF_TYPE* tau, ARNAUD_CPLXF_TYPE* c, CBLAS_INT* ldc, ARNAUD_CPLXF_TYPE* work);
+void BLAS_FUNC(clarfg)(CBLAS_INT* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLXF_TYPE* tau);
+void BLAS_FUNC(clartg)(ARNAUD_CPLXF_TYPE* f, ARNAUD_CPLXF_TYPE* g, float* c, ARNAUD_CPLXF_TYPE* s, ARNAUD_CPLXF_TYPE* r);
+void BLAS_FUNC(clascl)(char* mtype, CBLAS_INT* kl, CBLAS_INT* ku, float* cfrom, float* cto, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* a, CBLAS_INT* lda, CBLAS_INT* info);
+void BLAS_FUNC(claset)(char* uplo, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* alpha, ARNAUD_CPLXF_TYPE* beta, ARNAUD_CPLXF_TYPE* a, CBLAS_INT* lda);
+void BLAS_FUNC(ctrevc)(char* side, char* howmny, CBLAS_INT* select, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* t, CBLAS_INT* ldt, ARNAUD_CPLXF_TYPE* vl, CBLAS_INT* ldvl, ARNAUD_CPLXF_TYPE* vr, CBLAS_INT* ldvr, CBLAS_INT* mm, CBLAS_INT* m, ARNAUD_CPLXF_TYPE* work, float* rwork, CBLAS_INT* info);
+void BLAS_FUNC(ctrsen)(char* job, char* compq, CBLAS_INT* select, CBLAS_INT* n, ARNAUD_CPLXF_TYPE* t, CBLAS_INT* ldt, ARNAUD_CPLXF_TYPE* q, CBLAS_INT* ldq, ARNAUD_CPLXF_TYPE* w, CBLAS_INT* m, float* s, float* sep, ARNAUD_CPLXF_TYPE* work, CBLAS_INT* lwork, CBLAS_INT* info);
+void BLAS_FUNC(cunm2r)(char* side, char* trans, CBLAS_INT* m, CBLAS_INT* n, CBLAS_INT* k, ARNAUD_CPLXF_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLXF_TYPE* tau, ARNAUD_CPLXF_TYPE* c, CBLAS_INT* ldc, ARNAUD_CPLXF_TYPE* work, CBLAS_INT* info);
 
 
-void zgeqr2_(int* m, int* n, ARNAUD_CPLX_TYPE* a, int* lda, ARNAUD_CPLX_TYPE* tau, ARNAUD_CPLX_TYPE* work, int* info);
-void zlacpy_(char* uplo, int* m, int* n, ARNAUD_CPLX_TYPE* a, int* lda, ARNAUD_CPLX_TYPE* b, int* ldb);
-void zlahqr_(int* wantt, int* wantz, int* n, int* ilo, int* ihi, ARNAUD_CPLX_TYPE* h, int* ldh, ARNAUD_CPLX_TYPE* w, int* iloz, int* ihiz, ARNAUD_CPLX_TYPE* z, int* ldz, int* info );
-double zlanhs_(char* norm, int* n, ARNAUD_CPLX_TYPE* a, int* lda, double* work);
-void zlarf_(char* side, int* m, int* n, ARNAUD_CPLX_TYPE* v, int* incv, ARNAUD_CPLX_TYPE* tau, ARNAUD_CPLX_TYPE* c, int* ldc, ARNAUD_CPLX_TYPE* work);
-void zlarfg_(int* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* x, int* incx, ARNAUD_CPLX_TYPE* tau);
-void zlartg_(ARNAUD_CPLX_TYPE* f, ARNAUD_CPLX_TYPE* g, double* c, ARNAUD_CPLX_TYPE* s, ARNAUD_CPLX_TYPE* r);
-void zlascl_(char* mtype, int* kl, int* ku, double* cfrom, double* cto, int* m, int* n, ARNAUD_CPLX_TYPE* a, int* lda, int* info);
-void zlaset_(char* uplo, int* m, int* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* beta, ARNAUD_CPLX_TYPE* a, int* lda);
-void ztrevc_(char* side, char* howmny, int* select, int* n, ARNAUD_CPLX_TYPE* t, int* ldt, ARNAUD_CPLX_TYPE* vl, int* ldvl, ARNAUD_CPLX_TYPE* vr, int* ldvr, int* mm, int* m, ARNAUD_CPLX_TYPE* work, double* rwork, int* info);
-void ztrsen_(char* job, char* compq, int* select, int* n, ARNAUD_CPLX_TYPE* t, int* ldt, ARNAUD_CPLX_TYPE* q, int* ldq, ARNAUD_CPLX_TYPE* w, int* m, double* s, double* sep, ARNAUD_CPLX_TYPE* work, int* lwork, int* info);
-void zunm2r_(char* side, char* trans, int* m, int* n, int* k, ARNAUD_CPLX_TYPE* a, int* lda, ARNAUD_CPLX_TYPE* tau, ARNAUD_CPLX_TYPE* c, int* ldc, ARNAUD_CPLX_TYPE* work, int* info);
+void BLAS_FUNC(zgeqr2)(CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLX_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLX_TYPE* tau, ARNAUD_CPLX_TYPE* work, CBLAS_INT* info);
+void BLAS_FUNC(zlacpy)(char* uplo, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLX_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLX_TYPE* b, CBLAS_INT* ldb);
+void BLAS_FUNC(zlahqr)(CBLAS_INT* wantt, CBLAS_INT* wantz, CBLAS_INT* n, CBLAS_INT* ilo, CBLAS_INT* ihi, ARNAUD_CPLX_TYPE* h, CBLAS_INT* ldh, ARNAUD_CPLX_TYPE* w, CBLAS_INT* iloz, CBLAS_INT* ihiz, ARNAUD_CPLX_TYPE* z, CBLAS_INT* ldz, CBLAS_INT* info );
+double BLAS_FUNC(zlanhs)(char* norm, CBLAS_INT* n, ARNAUD_CPLX_TYPE* a, CBLAS_INT* lda, double* work);
+void BLAS_FUNC(zlarf)(char* side, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLX_TYPE* v, CBLAS_INT* incv, ARNAUD_CPLX_TYPE* tau, ARNAUD_CPLX_TYPE* c, CBLAS_INT* ldc, ARNAUD_CPLX_TYPE* work);
+void BLAS_FUNC(zlarfg)(CBLAS_INT* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* x, CBLAS_INT* incx, ARNAUD_CPLX_TYPE* tau);
+void BLAS_FUNC(zlartg)(ARNAUD_CPLX_TYPE* f, ARNAUD_CPLX_TYPE* g, double* c, ARNAUD_CPLX_TYPE* s, ARNAUD_CPLX_TYPE* r);
+void BLAS_FUNC(zlascl)(char* mtype, CBLAS_INT* kl, CBLAS_INT* ku, double* cfrom, double* cto, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLX_TYPE* a, CBLAS_INT* lda, CBLAS_INT* info);
+void BLAS_FUNC(zlaset)(char* uplo, CBLAS_INT* m, CBLAS_INT* n, ARNAUD_CPLX_TYPE* alpha, ARNAUD_CPLX_TYPE* beta, ARNAUD_CPLX_TYPE* a, CBLAS_INT* lda);
+void BLAS_FUNC(ztrevc)(char* side, char* howmny, CBLAS_INT* select, CBLAS_INT* n, ARNAUD_CPLX_TYPE* t, CBLAS_INT* ldt, ARNAUD_CPLX_TYPE* vl, CBLAS_INT* ldvl, ARNAUD_CPLX_TYPE* vr, CBLAS_INT* ldvr, CBLAS_INT* mm, CBLAS_INT* m, ARNAUD_CPLX_TYPE* work, double* rwork, CBLAS_INT* info);
+void BLAS_FUNC(ztrsen)(char* job, char* compq, CBLAS_INT* select, CBLAS_INT* n, ARNAUD_CPLX_TYPE* t, CBLAS_INT* ldt, ARNAUD_CPLX_TYPE* q, CBLAS_INT* ldq, ARNAUD_CPLX_TYPE* w, CBLAS_INT* m, double* s, double* sep, ARNAUD_CPLX_TYPE* work, CBLAS_INT* lwork, CBLAS_INT* info);
+void BLAS_FUNC(zunm2r)(char* side, char* trans, CBLAS_INT* m, CBLAS_INT* n, CBLAS_INT* k, ARNAUD_CPLX_TYPE* a, CBLAS_INT* lda, ARNAUD_CPLX_TYPE* tau, ARNAUD_CPLX_TYPE* c, CBLAS_INT* ldc, ARNAUD_CPLX_TYPE* work, CBLAS_INT* info);
 
 
 #endif

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -40,6 +40,7 @@ import warnings
 from scipy.sparse.linalg._interface import aslinearoperator, LinearOperator
 from scipy.sparse import eye, issparse
 from scipy.linalg import eig, eigh, lu_factor, lu_solve
+from scipy.linalg.lapack import HAS_ILP64
 from scipy.sparse._sputils import (
     convert_pydata_sparse_to_scipy, isdense, is_pydata_spmatrix,
 )
@@ -54,6 +55,8 @@ __all__ = ['eigs', 'eigsh', 'ArpackError', 'ArpackNoConvergence']
 
 _type_conv = {'f': 's', 'd': 'd', 'F': 'c', 'D': 'z'}
 _ndigits = {'f': 5, 'd': 12, 'F': 5, 'D': 12}
+
+_ARPACK_INT_DTYPE = np.int64 if HAS_ILP64 else np.int32
 
 DNAUPD_ERRORS = {
     0: "Normal exit.",
@@ -594,7 +597,7 @@ class _SymmetricArpackParams(_ArpackParams):
         self.iterate_infodict = _SAUPD_ERRORS[ltr]
         self.extract_infodict = _SEUPD_ERRORS[ltr]
 
-        self.ipntr = np.zeros(11, dtype=np.int32)
+        self.ipntr = np.zeros(11, dtype=_ARPACK_INT_DTYPE)
 
     def iterate(self):
         self._arpack_solver(self.arpack_dict, self.resid, self.v, self.ipntr,
@@ -648,7 +651,7 @@ class _SymmetricArpackParams(_ArpackParams):
         ierr = 0
         self.arpack_dict['info'] = 0  # Clear, if any, previous error from naupd
         howmny = HOWMNY_DICT["A"]  # return all eigenvectors
-        sselect = np.zeros(self.ncv, dtype=np.int32)
+        sselect = np.zeros(self.ncv, dtype=_ARPACK_INT_DTYPE)
         d = np.zeros(self.k, dtype=self.tp)
         z = np.zeros((self.n, self.ncv), dtype=self.tp, order='F')
 
@@ -788,7 +791,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
         self.iterate_infodict = _NAUPD_ERRORS[ltr]
         self.extract_infodict = _NEUPD_ERRORS[ltr]
 
-        self.ipntr = np.zeros(14, dtype=np.int32)
+        self.ipntr = np.zeros(14, dtype=_ARPACK_INT_DTYPE)
 
         if self.tp in 'FD':
             self.rwork = np.zeros(self.ncv, dtype=self.tp.lower())
@@ -855,7 +858,7 @@ class _UnsymmetricArpackParams(_ArpackParams):
         ierr = 0
         self.arpack_dict['info'] = 0  # Clear, if any, previous error from naupd
         howmny = HOWMNY_DICT['A']  # return all eigenvectors
-        sselect = np.zeros(self.ncv, dtype=np.int32)
+        sselect = np.zeros(self.ncv, dtype=_ARPACK_INT_DTYPE)
         sigmar = float(np.real(self.sigma))
         sigmai = float(np.imag(self.sigma))
         workev = np.zeros(3 * self.ncv, self.tp)

--- a/scipy/sparse/linalg/_eigen/arpack/meson.build
+++ b/scipy/sparse/linalg/_eigen/arpack/meson.build
@@ -6,19 +6,20 @@ arnaud_sources = [
   'arnaud/src/arnaud_s_single.c',
   'arnaud/src/arnaud_s_double.c'
 ]
-arnaud_incdir = include_directories('arnaud/include')
+arnaud_incdir = include_directories('arnaud/include', '../../../../_build_utils/src')
 
 
 arnaud_lib = static_library('arnaud',
   arnaud_sources,
   include_directories: arnaud_incdir,
-  dependencies: [m_dep, lapack_lp64_dep],
+  dependencies: [m_dep, lapack_dep, np_dep, py3_dep],
 )
 
 py3.extension_module('_arpacklib',
   '_arpackmodule.c',
+  include_directories: arnaud_incdir,
   link_with: arnaud_lib,
-  dependencies: [np_dep],
+  dependencies: [np_dep, lapack_dep],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/sparse/linalg/_eigen/arpack',


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/23351

#### What does this implement/fix?
<!--Please explain your changes.-->

Add ILP64 support to the `_arpack` extension. The approach is similar to https://github.com/scipy/scipy/pull/24841.
Of note, the desire to keep boolean flags and flow control variables as plain `int` adds a bit of ugly to the reverse communication interface.

One amusing "improvement" that the agent tried to do to minimize the patch size was to `# define foo_ BLAS_FUNC(foo)`. That's clearly undesirable, and not done here.


#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

The code is drafted by GPT 5.4 via Copilot. I gave it an initial prompt and drove it to make a couple of iterations to reduce the patch size. It picked up the coding conventions from other ILP64-related wrappers. After that, I reviewed the final patch and cleaned up the git history. 