### PR TITLE
TST: stats: add array API test coverage

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8018,10 +8018,10 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
 
     data_all = xp.concat((data1, data2), axis=-1)
     batch_shape = data_all.shape[:-1]
+    dtype = xp_result_type(data1, data2, force_floating=True, xp=xp)
 
     if is_marray(xp):
         # Previously, we used this algorithm for all backends:
-        dtype = xp_result_type(data1, data2, force_floating=True, xp=xp)
         n1 = xp.astype(_count_nonmasked(data1, axis=-1), dtype)
         n2 = xp.astype(_count_nonmasked(data2, axis=-1), dtype)
         cdf1 = xp.astype(_xp_searchsorted(data1, data_all, side='right'), dtype)
@@ -8035,8 +8035,10 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
 
         # We want the ECDF of each sample evaluated at *all* the points in the pooled
         # sample. The values each ECDF can assume are given by:
-        cdf1_vals = xp.broadcast_to(xp.linspace(0, 1, n1 + 1), batch_shape + (n1 + 1,))
-        cdf2_vals = xp.broadcast_to(xp.linspace(0, 1, n2 + 1), batch_shape + (n2 + 1,))
+        cdf1_vals = xp.broadcast_to(xp.linspace(0, 1, n1 + 1, dtype=dtype),
+                                    batch_shape + (n1 + 1,))
+        cdf2_vals = xp.broadcast_to(xp.linspace(0, 1, n2 + 1, dtype=dtype),
+                                    batch_shape + (n2 + 1,))
         # Now we "just" need to know how many times each of these values *will* be
         # assumed when we evaluate the ECDFs at all points in the pooled sample.
         # These counts are given by the differences between consecutive ("min" or "max")

--- a/scipy/stats/_variation.py
+++ b/scipy/stats/_variation.py
@@ -6,6 +6,7 @@ from scipy._lib._array_api import (
     xp_capabilities,
     xp_device,
     _count_nonmasked,
+    xp_promote,
 )
 import scipy._external.array_api_extra as xpx
 
@@ -102,7 +103,7 @@ def variation(a, axis=0, nan_policy='propagate', ddof=0, *, keepdims=False):
 
     """
     xp = array_namespace(a)
-    a = xp.asarray(a)
+    a = xp_promote(a, force_floating=True, xp=xp)
 
     # `nan_policy` and `keepdims` are handled by `_axis_nan_policy`
     if axis is None:

--- a/scipy/stats/tests/test_entropy.py
+++ b/scipy/stats/tests/test_entropy.py
@@ -305,7 +305,7 @@ class TestDifferentialEntropy:
 
     @methods
     @pytest.mark.parametrize('dtype', [None, 'float32', 'float64'])
-    def test_dtypes_gh21192(self, xp, method, dtype):
+    def test_dtypes_gh21192(self, method, dtype, xp):
         # gh-21192 noted a change in the output of method='ebrahimi'
         # with integer input. Check that the output is consistent regardless
         # of input dtype.

--- a/scipy/stats/tests/test_hypotests.py
+++ b/scipy/stats/tests/test_hypotests.py
@@ -569,7 +569,7 @@ class TestMannWhitneyU:
         xp_assert_equal(res1.statistic, res2.statistic)
         xp_assert_equal(res1.pvalue, res2.pvalue)
 
-    @pytest.mark.skip_xp_backends("jax.numpy", reason="lazy -> no nan_policy")
+    @skip_xp_backends("jax.numpy", reason="needs jax-ml/jax#34490")
     def test_gh11355_nan(self, xp):
         # NaNs should propagate by default.
         x = [1., 2., 3., 4.]
@@ -642,7 +642,7 @@ class TestMannWhitneyU:
         xp_assert_equal(res.statistic, xp.asarray(statistic_exp))
         xp_assert_close(res.pvalue, xp.asarray(pvalue_exp))
 
-    @pytest.mark.skip_xp_backends("jax.numpy", reason="lazy -> no nan_policy")
+    @skip_xp_backends("jax.numpy", reason="needs jax-ml/jax#34490")
     def test_gh_4067(self, xp):
         # Test for correct behavior with all NaN input - default is propagate
         nan = xp.asarray(xp.nan)
@@ -678,15 +678,15 @@ class TestMannWhitneyU:
         xp_assert_close(res.statistic, xp.asarray(expected[0]), rtol=rtol)
         xp_assert_close(res.pvalue, xp.asarray(expected[1]), rtol=rtol)
 
-    def test_gh19692_smaller_table(self):
+    def test_gh19692_smaller_table(self, xp):
         # In gh-19692, we noted that the shape of the cache used in calculating
         # p-values was dependent on the order of the inputs because the sample
         # sizes n1 and n2 changed. This was indicative of unnecessary cache
         # growth and redundant calculation. Check that this is resolved.
         rng = np.random.default_rng(7600451795963068007)
         m, n = 5, 11
-        x = rng.random(size=m)
-        y = rng.random(size=n)
+        x = xp.asarray(rng.random(size=m).tolist())
+        y = xp.asarray(rng.random(size=n).tolist())
 
         setattr(_mwu_state, 's', _MWU(0, 0))
         _mwu_state.s.reset()  # reset cache
@@ -708,16 +708,16 @@ class TestMannWhitneyU:
         assert shape == _mwu_state.s.configurations.shape
 
     @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
-    def test_permutation_method(self, alternative):
+    def test_permutation_method(self, alternative, xp):
         rng = np.random.default_rng(7600451795963068007)
-        x = rng.random(size=(2, 5))
-        y = rng.random(size=(2, 6))
+        x = xp.asarray(rng.random(size=(2, 5)))
+        y = xp.asarray(rng.random(size=(2, 6)))
         res = stats.mannwhitneyu(x, y, method=stats.PermutationMethod(),
                                  alternative=alternative, axis=1)
         res2 = stats.mannwhitneyu(x, y, method='exact',
                                   alternative=alternative, axis=1)
-        assert_allclose(res.statistic, res2.statistic, rtol=1e-15)
-        assert_allclose(res.pvalue, res2.pvalue, rtol=1e-15)
+        xp_assert_close(res.statistic, res2.statistic, rtol=1e-15)
+        xp_assert_close(res.pvalue, res2.pvalue, rtol=1e-15)
 
     # Old tests moved from test_stats. Source of magic numbers unknown.
     X = [19.8958398126694, 19.5452691647182, 19.0577309166425, 21.716543054589,

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1356,8 +1356,7 @@ class TestFligner:
         xp_assert_close(Xsq1, Xsq2)
         xp_assert_close(pval1, pval2)
 
-    @pytest.mark.skip_xp_backends(np_only=True,
-                                  reason="inconsistent tie-breaking across backends")
+    @skip_xp_backends(np_only=True, reason="inconsistent tie-breaking across backends")
     def test_trimmed_nonregression(self, xp):
         # This is a non-regression test
         # Expected results are *not* from an external gold standard,
@@ -1982,7 +1981,7 @@ class TestWilcoxon:
         xp_assert_equal(stats.wilcoxon(d, method="asymptotic").pvalue, xp.asarray(p))
 
     @pytest.mark.xslow
-    @pytest.mark.skip_xp_backends(np_only=True)
+    @skip_xp_backends("jax.numpy", reason="lazy -> limited `method` choices")
     def test_auto_permutation_edge_case(self, xp):
         # Check that `PermutationMethod()` is used and results are deterministic when
         # `method='auto'`, there are zeros or ties in `d = x-y`, and `len(d) <= 13`.
@@ -3150,7 +3149,7 @@ class TestCircFuncs:
     @pytest.mark.parametrize('circfunc', [stats.circmean,
                                           stats.circvar,
                                           stats.circstd])
-    def test_circmean_axis(self, xp, circfunc):
+    def test_circmean_axis(self, circfunc, xp):
         x = xp.asarray([[355, 5, 2, 359, 10, 350],
                         [351, 7, 4, 352, 9, 349],
                         [357, 9, 8, 358, 4, 356.]])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -40,8 +40,8 @@ from scipy.conftest import skip_xp_invalid_arg
 from scipy._lib._array_api import (array_namespace, eager_warns, is_lazy_array,
                                    is_numpy, is_torch, xp_default_dtype, xp_size,
                                    SCIPY_ARRAY_API, make_xp_test_case, xp_ravel,
-                                   xp_swapaxes, xp_result_type, is_cupy, is_jax,
-                                   xp_copy)
+                                   xp_swapaxes, xp_result_type, is_jax,
+                                   xp_copy, make_xp_pytest_param)
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal, xp_assert_less
 import scipy._external.array_api_extra as xpx
 from scipy._lib._util import _apply_over_batch
@@ -191,23 +191,25 @@ class TestTrimmedStats:
         res = stats.tmin(x, lowerlimit=4, axis=1)
         xp_assert_equal(res, xp.asarray([np.nan, 4, 8, 12]))
 
-    @skip_xp_backends(np_only=True,
-                      reason="Only NumPy arrays support scalar input/`nan_policy`.")
-    @make_xp_test_case(stats.tmin)
-    def test_tmin_scalar_and_nanpolicy(self, xp):
-        assert_equal(stats.tmin(4), 4)
+    @skip_xp_backends(np_only=True, reason="Only NumPy arrays support scalar input.")
+    @pytest.mark.parametrize('tfun', [make_xp_pytest_param(stats.tmin),
+                                      make_xp_pytest_param(stats.tmax)])
+    def test_tmin_tmax_scalar_input(self, tfun, xp):
+        assert_equal(tfun(4), 4)
 
-        x = np.arange(10.)
-        x[9] = np.nan
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "invalid value", RuntimeWarning)
-            assert_equal(stats.tmin(x, nan_policy='omit'), 0.)
-            msg = "The input contains nan values"
-            with assert_raises(ValueError, match=msg):
-                stats.tmin(x, nan_policy='raise')
-            msg = "nan_policy must be one of..."
-            with assert_raises(ValueError, match=msg):
-                stats.tmin(x, nan_policy='foobar')
+    @skip_xp_backends(eager_only=True, reason="lazy -> reduced nan_policy capabilities")
+    @pytest.mark.parametrize('tfun, ref', [make_xp_pytest_param(stats.tmin, 0.),
+                                           make_xp_pytest_param(stats.tmax, 9.)])
+    def test_tmin_tmax_nanpolicy(self, tfun, ref, xp):
+        x = xp.arange(10.)
+        x[8] = xp.nan
+        xp_assert_equal(tfun(x, nan_policy='omit'), xp.asarray(ref))
+        msg = "The input contains nan values"
+        with assert_raises(ValueError, match=msg):
+            tfun(x, nan_policy='raise')
+        msg = "nan_policy must be one of..."
+        with assert_raises(ValueError, match=msg):
+            tfun(x, nan_policy='foobar')
 
     @make_xp_test_case(stats.tmax)
     def test_tmax(self, xp):
@@ -233,24 +235,6 @@ class TestTrimmedStats:
             x = xp.reshape(xp.arange(16), (4, 4))
             res = stats.tmax(x, upperlimit=11, axis=1)
             xp_assert_equal(res, xp.asarray([3, 7, 11, np.nan]))
-
-    @skip_xp_backends(np_only=True,
-                      reason="Only NumPy arrays support scalar input/`nan_policy`.")
-    @make_xp_test_case(stats.tmax)
-    def test_tmax_scalar_and_nanpolicy(self, xp):
-        assert_equal(stats.tmax(4), 4)
-
-        x = np.arange(10.)
-        x[6] = np.nan
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", "invalid value", RuntimeWarning)
-            assert_equal(stats.tmax(x, nan_policy='omit'), 9.)
-            msg = "The input contains nan values"
-            with assert_raises(ValueError, match=msg):
-                stats.tmax(x, nan_policy='raise')
-            msg = "nan_policy must be one of..."
-            with assert_raises(ValueError, match=msg):
-                stats.tmax(x, nan_policy='foobar')
 
     @make_xp_test_case(stats.tmin, stats.tmax)
     def test_tmin_tmax_int_dtype(self, xp):
@@ -402,11 +386,11 @@ class TestPearsonrWilkinson:
 
 @make_xp_test_case(stats.pearsonr)
 class TestPearsonr:
-    def test_pearsonr_result_attributes(self):
-        res = stats.pearsonr(X, X)
+    def test_pearsonr_result_attributes(self, xp):
+        res = stats.pearsonr(xp.asarray(X), xp.asarray(X))
         attributes = ('correlation', 'pvalue')
-        check_named_results(res, attributes)
-        assert_equal(res.correlation, res.statistic)
+        check_named_results(res, attributes, xp=xp)
+        xp_assert_equal(res.correlation, res.statistic)
 
     def test_r_almost_exactly_pos1(self, xp):
         a = xp.arange(3.0)
@@ -447,7 +431,7 @@ class TestPearsonr:
             xp_assert_close(p, xp.asarray(xp.nan))
 
     @pytest.mark.parametrize('dtype', ['float32', 'float64'])
-    def test_near_constant_input(self, xp, dtype):
+    def test_near_constant_input(self, dtype, xp):
         npdtype = getattr(np, dtype)
         dtype = getattr(xp, dtype)
         # Near constant input (but not constant):
@@ -2819,14 +2803,17 @@ class TestSEM:
         x = xp.where(x == 9, xp.nan, x)
         xp_assert_equal(stats.sem(x), xp.asarray(xp.nan))
 
-    @skip_xp_backends(np_only=True,
-                      reason='`nan_policy` only supports NumPy backend')
+    @skip_xp_backends(eager_only=True, reason='lazy -> reduced nan_policy capabilities')
     def test_sem_nan_policy(self, xp):
-        x = np.arange(10.)
-        x[9] = np.nan
-        assert_equal(stats.sem(x, nan_policy='omit'), 0.9128709291752769)
-        assert_raises(ValueError, stats.sem, x, nan_policy='raise')
-        assert_raises(ValueError, stats.sem, x, nan_policy='foobar')
+        x = xp.arange(10.)
+        x[9] = xp.nan
+        xp_assert_equal(stats.sem(x, nan_policy='omit'), xp.asarray(0.9128709291752769))
+        message = "The input contains nan values"
+        with pytest.raises(ValueError, match=message):
+            stats.sem(x, nan_policy='raise')
+        message = "nan_policy must be one of..."
+        with pytest.raises(ValueError, match=message):
+            stats.sem(x, nan_policy='foobar')
 
 
 @make_xp_test_case(stats.zmap)
@@ -3149,19 +3136,18 @@ class TestMedianAbsDeviation:
         mad_expected = xp.asarray([0.435, 0.5, 0.45, 0.4])
         xp_assert_close(mad, mad_expected)
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy="omit"')
     def test_mad_nan_omit(self, xp):
         mad = stats.median_abs_deviation(xp.asarray(self.dat_nan), nan_policy='omit')
         xp_assert_close(mad, xp.asarray(0.34))
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
     def test_axis_and_nan(self, xp):
         x = xp.asarray([[1.0, 2.0, 3.0, 4.0, np.nan],
                         [1.0, 4.0, 5.0, 8.0, 9.0]])
         mad = stats.median_abs_deviation(x, axis=1)
         xp_assert_close(mad, xp.asarray([np.nan, 3.0]))
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy="omit"')
     def test_nan_policy_omit_with_inf(self, xp):
         z = xp.asarray([1, 3, 4, 6, 99, np.nan, np.inf])
         mad = stats.median_abs_deviation(z, nan_policy='omit')
@@ -3176,7 +3162,6 @@ class TestMedianAbsDeviation:
             mad = stats.median_abs_deviation(x, axis=axis)
         xp_assert_close(mad, xp.full_like(xp.sum(x, axis=axis), fill_value=xp.nan))
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
     @pytest.mark.parametrize('nan_policy, expected',
                              [('omit', [np.nan, 1.5, 1.5]),
                               ('propagate', [np.nan, np.nan, 1.5])])
@@ -3242,7 +3227,7 @@ class TestIQR:
         stats.iqr(d, None, (30, 20), 1.0)
         stats.iqr(d, None, (25, 75), 1.5, 'propagate')
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
     def test_api_eager(self, xp):
         d = xp.ones((5, 5))
         stats.iqr(d, None, (50, 50), 'normal', 'raise', 'linear')
@@ -3411,7 +3396,7 @@ class TestIQR:
         assert_equal(stats.iqr(x, (0, 1, 2, 3), keepdims=True).shape, (1, 1, 1, 1))
         assert_equal(stats.iqr(x, axis=(0, 1, 3), keepdims=True).shape, (1, 1, 7, 1))
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
     def test_nanpolicy(self, xp):
         x = xp.reshape(xp.arange(15.0), (3, 5))
 
@@ -3440,7 +3425,7 @@ class TestIQR:
         with pytest.raises(ValueError, match=message):
             stats.iqr(x, nan_policy='barfood')
 
-    @pytest.mark.skip_xp_backends(np_only=True,
+    @skip_xp_backends(np_only=True,
         reason="nan_policy w/ multidimensional arrays only available w/ NumPy")
     def test_nanpolicy_nd(self, xp):
         x = xp.reshape(xp.arange(15.0), (3, 5))
@@ -3462,7 +3447,6 @@ class TestIQR:
         xp_assert_close(stats.iqr(x, scale='normal'), xp.asarray(7 / 1.3489795))
         xp_assert_equal(stats.iqr(x, scale=2.0), xp.asarray(3.5))
 
-    @skip_xp_backends("jax.numpy", reason="lazy -> no nan_policy")
     def test_scale_with_nans(self, xp):
         x = xp.reshape(xp.arange(15.0), (3, 5))
         x = xpx.at(x)[1, 2].set(xp.nan)
@@ -3476,7 +3460,7 @@ class TestIQR:
         with pytest.raises(ValueError, match=message):
             stats.iqr(x, scale='foobar')
 
-    @pytest.mark.skip_xp_backends("jax.numpy", reason="lazy -> no nan_policy")
+    @skip_xp_backends("jax.numpy", reason="lazy -> no nan_policy")
     def test_scale_nan_policy_omit(self, xp):
         x = xp.reshape(xp.arange(15.0), (3, 5))
         x = xpx.at(x)[1, 2].set(xp.nan)
@@ -3485,8 +3469,6 @@ class TestIQR:
                         xp.asarray(7.5 / 1.3489795))
         xp_assert_equal(stats.iqr(x, scale=2.0, nan_policy='omit'), xp.asarray(3.75))
 
-    @pytest.mark.skip_xp_backends(np_only=True,
-        reason="nan_policy w/ multidimensional arrays only available w/ NumPy")
     def test_scale_nanpolicy_nd(self, xp):
         # axis=1 chosen to show behavior with both nans and without
         x = xp.reshape(xp.arange(15.0), (3, 5))
@@ -3611,7 +3593,8 @@ class TestMoments:
     @pytest.mark.parametrize('expect, order', [(0, 1), (1, 0)])
     def test_constant_moments(self, dtype, expect, order, xp):
         if dtype=='complex128' and is_torch(xp):
-            pytest.skip()
+            message = "torch can't round complex input; data-apis/array-api-compat#407"
+            pytest.skip(message)
         dtype = getattr(xp, dtype)
         rng = np.random.default_rng(3824693518)
         x = xp.asarray(rng.random(5), dtype=dtype)
@@ -5029,7 +5012,6 @@ class TestKSTwoSamples:
             res = stats.ks_2samp(data1, data2, alternative='less')
             xp_assert_close(res.pvalue, xp.asarray(0., dtype=dtype), atol=1e-14)
 
-    @skip_xp_backends("torch", reason="precision issues")
     @pytest.mark.parametrize("ksfunc", [stats.kstest, stats.ks_2samp])
     @pytest.mark.parametrize("alternative, x6val, ref_location, ref_sign",
                              [('greater', 5.9, 5.9, +1),
@@ -5205,25 +5187,29 @@ def test_ttest_rel():
         assert_allclose(p, converter(tr, pr, 'greater'), rtol=1e-14)
 
 
-def test_ttest_rel_nan_2nd_arg():
+@make_xp_test_case(stats.ttest_rel)
+@skip_xp_backends(eager_only=True, reason='lazy -> limited nan_policy support')
+def test_ttest_rel_nan_2nd_arg(xp):
     # regression test for gh-6134: nans in the second arg were not handled
-    x = [np.nan, 2.0, 3.0, 4.0]
-    y = [1.0, 2.0, 1.0, 2.0]
+    x = xp.asarray([np.nan, 2.0, 3.0, 4.0])
+    y = xp.asarray([1.0, 2.0, 1.0, 2.0])
 
     r1 = stats.ttest_rel(x, y, nan_policy='omit')
     r2 = stats.ttest_rel(y, x, nan_policy='omit')
-    assert_allclose(r2.statistic, -r1.statistic, atol=1e-15)
-    assert_allclose(r2.pvalue, r1.pvalue, atol=1e-15)
+    xp_assert_close(r2.statistic, -r1.statistic, atol=1e-15)
+    xp_assert_close(r2.pvalue, r1.pvalue, atol=1e-15)
 
     # NB: arguments are paired when NaNs are dropped
     r3 = stats.ttest_rel(y[1:], x[1:])
-    assert_allclose(r2, r3, atol=1e-15)
+    xp_assert_close(r2.statistic, r3.statistic, atol=1e-15)
+    xp_assert_close(r2.pvalue, r3.pvalue, atol=1e-15)
 
     # .. and this is consistent with R. R code:
     # x = c(NA, 2.0, 3.0, 4.0)
     # y = c(1.0, 2.0, 1.0, 2.0)
-    # t.test(x, y, paired=TRUE)
-    assert_allclose(r2, (-2, 0.1835), atol=1e-4)
+    # t.test(x, y, paired=TRUE),
+    xp_assert_close(r2.statistic, xp.asarray(-2.), atol=1e-4)
+    xp_assert_close(r2.pvalue, xp.asarray(0.1835), atol=1e-4)
 
 
 def test_ttest_rel_empty_1d_returns_nan():
@@ -6085,7 +6071,7 @@ class TestTTestIndFromStats:
         xp_assert_equal(res.pvalue, NaN)
 
 
-@pytest.mark.skip_xp_backends(cpu_only=True, reason='Test uses ks_1samp')
+@skip_xp_backends(cpu_only=True, reason='Test uses ks_1samp')
 @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning:dask")
 @pytest.mark.filterwarnings("ignore:divide by zero encountered:RuntimeWarning:dask")
 @pytest.mark.uses_xp_capabilities(False, reason="not used in this test yet")
@@ -6217,7 +6203,7 @@ def test_ttest_1samp_new_omit(xp):
 
 
 @make_xp_test_case(stats.ttest_1samp)
-@pytest.mark.skip_xp_backends('jax.numpy', reason='Generic stdtrit mutates array.')
+@skip_xp_backends('jax.numpy', reason='Generic stdtrit mutates array.')
 def test_ttest_1samp_popmean_array(xp):
     # when popmean.shape[axis] != 1, raise an error
     # if the user wants to test multiple null hypotheses simultaneously,
@@ -6645,18 +6631,16 @@ class TestObrientransform:
         xp_assert_close(res[0], ref[0, ...])
         xp_assert_close(res[1], ref[1, ...])
 
-    @skip_xp_backends("dask.array", reason="trouble with xp.repeat")
     def test_reference(self, xp):
         # Example from "O'Brien Test for Homogeneity of Variance" by Herve Abdi.
-        values = xp.arange(5, 11)
+        values = np.arange(5, 11)
         reps = [5, 11, 9, 3, 2, 2]
-        reps = reps if is_cupy(xp) else xp.asarray(reps)
-        data = xp.repeat(values, reps)
-        transformed_values = xp.asarray([3.1828, 0.5591, 0.0344,
+        data = np.repeat(values, reps)
+        transformed_values = np.asarray([3.1828, 0.5591, 0.0344,
                                          1.6086, 5.2817, 11.0538])
-        expected = xp.repeat(transformed_values, reps)
-        result = stats.obrientransform(data)
-        xp_assert_close(result[0][:], expected, rtol=1e-3)
+        expected = np.repeat(transformed_values, reps)
+        result = stats.obrientransform(xp.asarray(data))
+        xp_assert_close(result[0][:], xp.asarray(expected), rtol=1e-3)
 
     def test_nan_policy(self, xp):
         rng = np.random.default_rng(4284359689201882838835)
@@ -7428,7 +7412,7 @@ class TestTrimMean:
         with pytest.raises(ValueError, match="Proportion too big."):
             stats.trim_mean(a, 0.6)
 
-    @pytest.mark.skip_xp_backends('dask.array', reason="lazy -> no _axis_nan_policy")
+    @skip_xp_backends('dask.array', reason="lazy -> no _axis_nan_policy")
     def test_empty_input(self, xp):
         # empty input
         with pytest.warns(SmallSampleWarning, match='too small'):
@@ -7896,7 +7880,7 @@ class TestFOneWay:
         xp_assert_equal(f, xp.asarray(expected[0]))
         xp_assert_equal(p, xp.asarray(expected[1]))
 
-    @pytest.mark.skip_xp_backends('dask.array', reason='needs _axis_nan_policy')
+    @skip_xp_backends('dask.array', reason='needs _axis_nan_policy')
     @pytest.mark.parametrize('axis', [-2, -1, 0, 1])
     def test_2d_inputs(self, axis, xp):
         a = np.array([[1, 4, 3, 3],
@@ -7943,7 +7927,7 @@ class TestFOneWay:
             xp_assert_close(f[j], xp.asarray(fj))
             xp_assert_close(p[j], xp.asarray(pj))
 
-    @pytest.mark.skip_xp_backends('dask.array', reason='needs _axis_nan_policy')
+    @skip_xp_backends('dask.array', reason='needs _axis_nan_policy')
     def test_3d_inputs(self, xp):
         # Some 3-d arrays. (There is nothing special about the values.)
         a = xp.reshape(1/xp.arange(1.0, 4*5*7 + 1., dtype=xp.float64), (4, 5, 7))
@@ -7989,7 +7973,7 @@ class TestFOneWay:
             xp_assert_equal(result.statistic, xp.asarray(xp.nan))
             xp_assert_equal(result.pvalue, xp.asarray(xp.nan))
 
-    @pytest.mark.skip_xp_backends('dask.array', reason='lazy->reduced input validation')
+    @skip_xp_backends('dask.array', reason='lazy->reduced input validation')
     @pytest.mark.parametrize('args', [(), ([1, 2, 3],)])
     def test_too_few_inputs(self, args, xp):
         args = [xp.asarray(arg) for arg in args]
@@ -7997,7 +7981,7 @@ class TestFOneWay:
         with pytest.raises(TypeError, match=message):
             stats.f_oneway(*args)
 
-    @pytest.mark.skip_xp_backends('dask.array', reason='lazy->reduced input validation')
+    @skip_xp_backends('dask.array', reason='lazy->reduced input validation')
     def test_axis_error(self, xp):
         a = xp.ones((3, 4))
         b = xp.ones((5, 4))
@@ -8085,7 +8069,7 @@ class TestKruskal:
         xp_assert_equal(res.statistic, xp.asarray(xp.nan))
         xp_assert_equal(res.pvalue, xp.asarray(xp.nan))
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='needs jax-ml/jax#34628')
     def test_nan_policy_propagate(self, xp):
         x = xp.arange(10.)
         x = xpx.at(x)[9].set(xp.nan)
@@ -8094,7 +8078,7 @@ class TestKruskal:
         xp_assert_equal(res.statistic, xp.asarray(xp.nan))
         xp_assert_equal(res.pvalue, xp.asarray(xp.nan))
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
     def test_nan_policy_omit_raise(self, xp):
         x = xp.arange(10.)
         x = xpx.at(x)[9].set(xp.nan)
@@ -8684,7 +8668,7 @@ class TestBrunnerMunzel:
         xp_assert_equal(statistic, xp.asarray(xp.nan))
         xp_assert_equal(pvalue, xp.asarray(xp.nan))
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='needs jax-ml/jax#34628')
     def test_brunnermunzel_nan_input_propagate(self, xp):
         X = xp.asarray([1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1, xp.nan])
         Y = xp.asarray([3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4.])
@@ -8696,7 +8680,7 @@ class TestBrunnerMunzel:
         xp_assert_equal(u2, xp.asarray(xp.nan))
         xp_assert_equal(p2, xp.asarray(xp.nan))
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
     def test_brunnermunzel_nan_input_raise(self, xp):
         X = xp.asarray([1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1, xp.nan])
         Y = xp.asarray([3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4.])
@@ -8710,7 +8694,7 @@ class TestBrunnerMunzel:
         with pytest.raises(ValueError, match=message):
             stats.brunnermunzel(Y, X, alternative, distribution, nan_policy)
 
-    @pytest.mark.skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
     def test_brunnermunzel_nan_input_omit(self, xp):
         X = xp.asarray([1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1, np.nan])
         Y = xp.asarray([3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4.])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -5186,29 +5186,25 @@ def test_ttest_rel():
         assert_allclose(p, converter(tr, pr, 'greater'), rtol=1e-14)
 
 
-@make_xp_test_case(stats.ttest_rel)
-@skip_xp_backends(eager_only=True, reason='lazy -> limited nan_policy support')
-def test_ttest_rel_nan_2nd_arg(xp):
+def test_ttest_rel_nan_2nd_arg():
     # regression test for gh-6134: nans in the second arg were not handled
-    x = xp.asarray([np.nan, 2.0, 3.0, 4.0])
-    y = xp.asarray([1.0, 2.0, 1.0, 2.0])
+    x = [np.nan, 2.0, 3.0, 4.0]
+    y = [1.0, 2.0, 1.0, 2.0]
 
     r1 = stats.ttest_rel(x, y, nan_policy='omit')
     r2 = stats.ttest_rel(y, x, nan_policy='omit')
-    xp_assert_close(r2.statistic, -r1.statistic, atol=1e-15)
-    xp_assert_close(r2.pvalue, r1.pvalue, atol=1e-15)
+    assert_allclose(r2.statistic, -r1.statistic, atol=1e-15)
+    assert_allclose(r2.pvalue, r1.pvalue, atol=1e-15)
 
     # NB: arguments are paired when NaNs are dropped
     r3 = stats.ttest_rel(y[1:], x[1:])
-    xp_assert_close(r2.statistic, r3.statistic, atol=1e-15)
-    xp_assert_close(r2.pvalue, r3.pvalue, atol=1e-15)
+    assert_allclose(r2, r3, atol=1e-15)
 
     # .. and this is consistent with R. R code:
     # x = c(NA, 2.0, 3.0, 4.0)
     # y = c(1.0, 2.0, 1.0, 2.0)
-    # t.test(x, y, paired=TRUE),
-    xp_assert_close(r2.statistic, xp.asarray(-2.), atol=1e-4)
-    xp_assert_close(r2.pvalue, xp.asarray(0.1835), atol=1e-4)
+    # t.test(x, y, paired=TRUE)
+    assert_allclose(r2, (-2, 0.1835), atol=1e-4)
 
 
 def test_ttest_rel_empty_1d_returns_nan():

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -191,10 +191,8 @@ class TestTrimmedStats:
         res = stats.tmin(x, lowerlimit=4, axis=1)
         xp_assert_equal(res, xp.asarray([np.nan, 4, 8, 12]))
 
-    @skip_xp_backends(np_only=True, reason="Only NumPy arrays support scalar input.")
-    @pytest.mark.parametrize('tfun', [make_xp_pytest_param(stats.tmin),
-                                      make_xp_pytest_param(stats.tmax)])
-    def test_tmin_tmax_scalar_input(self, tfun, xp):
+    @pytest.mark.parametrize('tfun', [stats.tmin, stats.tmax])
+    def test_tmin_tmax_scalar_input(self, tfun):  # scalar inputs are NumPy only
         assert_equal(tfun(4), 4)
 
     @skip_xp_backends(eager_only=True, reason="lazy -> reduced nan_policy capabilities")
@@ -3227,7 +3225,7 @@ class TestIQR:
         stats.iqr(d, None, (30, 20), 1.0)
         stats.iqr(d, None, (25, 75), 1.5, 'propagate')
 
-    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> reduced nan_policy capabilities')
     def test_api_eager(self, xp):
         d = xp.ones((5, 5))
         stats.iqr(d, None, (50, 50), 'normal', 'raise', 'linear')
@@ -3396,7 +3394,7 @@ class TestIQR:
         assert_equal(stats.iqr(x, (0, 1, 2, 3), keepdims=True).shape, (1, 1, 1, 1))
         assert_equal(stats.iqr(x, axis=(0, 1, 3), keepdims=True).shape, (1, 1, 7, 1))
 
-    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> reduced nan_policy capabilitiesy')
     def test_nanpolicy(self, xp):
         x = xp.reshape(xp.arange(15.0), (3, 5))
 
@@ -3460,7 +3458,7 @@ class TestIQR:
         with pytest.raises(ValueError, match=message):
             stats.iqr(x, scale='foobar')
 
-    @skip_xp_backends("jax.numpy", reason="lazy -> no nan_policy")
+    @skip_xp_backends("jax.numpy", reason="lazy -> reduced nan_policy capabilities")
     def test_scale_nan_policy_omit(self, xp):
         x = xp.reshape(xp.arange(15.0), (3, 5))
         x = xpx.at(x)[1, 2].set(xp.nan)
@@ -4716,7 +4714,6 @@ class TestKSOneSample:
         xp_assert_equal(res.statistic_location, xp.asarray(ref_location))
         xp_assert_equal(res.statistic_sign, xp.asarray(ref_sign, dtype=xp.int8))
 
-    # missing: no test that uses *args
 
 @make_xp_test_case(stats.ks_2samp)
 class TestKSTwoSamples:
@@ -6172,7 +6169,7 @@ def test_ttest_1samp_new(xp):
         xp_assert_equal(res.pvalue, xp.asarray([1., xp.nan]))
 
 
-@skip_xp_backends(eager_only=True, reason="lazy -> no nan_policy")
+@skip_xp_backends(eager_only=True, reason="lazy -> reduced nan_policy capabilities")
 @make_xp_test_case(stats.ttest_1samp)
 def test_ttest_1samp_new_omit(xp):
     rng = np.random.default_rng(4008400329)
@@ -7714,13 +7711,13 @@ class TestAlexanderGovern:
         xp_assert_equal(res.pvalue, xp.asarray(xp.nan))
         xp_assert_equal(res.statistic, xp.asarray(xp.nan))
 
-    @skip_xp_backends(eager_only=True, reason="lazy -> no nan_policy")
+    @skip_xp_backends(eager_only=True, reason="lazy -> reduced nan_policy capabilities")
     def test_nan_policy_raise(self, xp):
         args = xp.asarray([1., 2., 3., 4.]), xp.asarray([1., xp.nan])
         with assert_raises(ValueError, match="The input contains nan values"):
             stats.alexandergovern(*args, nan_policy='raise')
 
-    @skip_xp_backends(eager_only=True, reason="lazy -> no nan_policy")
+    @skip_xp_backends(eager_only=True, reason="lazy -> reduced nan_policy capabilities")
     def test_nan_policy_omit(self, xp):
         args_nan = xp.asarray([1, 2, 3, xp.nan, 4]), xp.asarray([1, xp.nan, 19, 25])
         args_no_nan = xp.asarray([1, 2, 3, 4]), xp.asarray([1, 19, 25])
@@ -8073,7 +8070,7 @@ class TestKruskal:
         xp_assert_equal(res.statistic, xp.asarray(xp.nan))
         xp_assert_equal(res.pvalue, xp.asarray(xp.nan))
 
-    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> reduced nan_policy capabilities')
     def test_nan_policy_omit_raise(self, xp):
         x = xp.arange(10.)
         x = xpx.at(x)[9].set(xp.nan)
@@ -8675,7 +8672,7 @@ class TestBrunnerMunzel:
         xp_assert_equal(u2, xp.asarray(xp.nan))
         xp_assert_equal(p2, xp.asarray(xp.nan))
 
-    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> reduced nan_policy capabilities')
     def test_brunnermunzel_nan_input_raise(self, xp):
         X = xp.asarray([1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1, xp.nan])
         Y = xp.asarray([3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4.])
@@ -8689,7 +8686,7 @@ class TestBrunnerMunzel:
         with pytest.raises(ValueError, match=message):
             stats.brunnermunzel(Y, X, alternative, distribution, nan_policy)
 
-    @skip_xp_backends('jax.numpy', reason='lazy -> no nan_policy')
+    @skip_xp_backends('jax.numpy', reason='lazy -> reduced nan_policy capabilities')
     def test_brunnermunzel_nan_input_omit(self, xp):
         X = xp.asarray([1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 2, 4, 1, 1, np.nan])
         Y = xp.asarray([3, 3, 4, 3, 1, 2, 3, 1, 1, 5, 4.])

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -2807,7 +2807,7 @@ class TestSEM:
     def test_sem_nan_policy(self, xp):
         x = xp.arange(10.)
         x[9] = xp.nan
-        xp_assert_equal(stats.sem(x, nan_policy='omit'), xp.asarray(0.9128709291752769))
+        xp_assert_close(stats.sem(x, nan_policy='omit'), xp.asarray(0.9128709291752769))
         message = "The input contains nan values"
         with pytest.raises(ValueError, match=message):
             stats.sem(x, nan_policy='raise')
@@ -4717,7 +4717,6 @@ class TestKSOneSample:
         xp_assert_equal(res.statistic_sign, xp.asarray(ref_sign, dtype=xp.int8))
 
     # missing: no test that uses *args
-
 
 @make_xp_test_case(stats.ks_2samp)
 class TestKSTwoSamples:
@@ -6640,7 +6639,7 @@ class TestObrientransform:
                                          1.6086, 5.2817, 11.0538])
         expected = np.repeat(transformed_values, reps)
         result = stats.obrientransform(xp.asarray(data))
-        xp_assert_close(result[0][:], xp.asarray(expected), rtol=1e-3)
+        xp_assert_close(result[0][:], xp.asarray(expected.tolist()), rtol=1e-3)
 
     def test_nan_policy(self, xp):
         rng = np.random.default_rng(4284359689201882838835)

--- a/scipy/stats/tests/test_variation.py
+++ b/scipy/stats/tests/test_variation.py
@@ -41,7 +41,7 @@ class TestVariation:
 
     @pytest.mark.parametrize('nan_policy, expected',
                              [('propagate', np.nan),
-                              ('omit', np.sqrt(20/3)/4)])
+                              ('omit', math.sqrt(20/3)/4)])
     @skip_xp_backends(eager_only=True, reason='lazy -> limited nan_policy support')
     def test_variation_nan(self, nan_policy, expected, xp):
         x = xp.arange(10.)
@@ -68,8 +68,8 @@ class TestVariation:
 
     @skip_xp_backends("dask.array", reason='needs `_axis_nan_policy`')
     @pytest.mark.parametrize('axis, expected',
-                             [(0, np.empty((1, 0))),
-                              (1, np.full((5, 1), fill_value=np.nan))])
+                             [(0, np.empty((1, 0)).tolist()),
+                              (1, np.full((5, 1), fill_value=np.nan).tolist())])
     def test_keepdims_size0(self, axis, expected, xp):
         x = xp.zeros((5, 0))
         if axis == 1:

--- a/scipy/stats/tests/test_variation.py
+++ b/scipy/stats/tests/test_variation.py
@@ -3,12 +3,13 @@ import math
 import numpy as np
 import pytest
 
+from scipy._lib._util import AxisError
+from scipy._lib._array_api import make_xp_test_case, eager_warns, is_numpy
+from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
+from scipy._external import array_api_extra as xpx
+
 from scipy import stats
 from scipy.stats import variation
-from scipy._lib._util import AxisError
-
-from scipy._lib._array_api import make_xp_test_case, eager_warns
-from scipy._lib._array_api_no_0d import xp_assert_equal, xp_assert_close
 from scipy.stats._axis_nan_policy import (too_small_nd_omit, too_small_nd_not_omit,
                                           SmallSampleWarning)
 
@@ -41,37 +42,31 @@ class TestVariation:
     @pytest.mark.parametrize('nan_policy, expected',
                              [('propagate', np.nan),
                               ('omit', np.sqrt(20/3)/4)])
-    @skip_xp_backends(np_only=True,
-                      reason='`nan_policy` only supports NumPy backend')
+    @skip_xp_backends(eager_only=True, reason='lazy -> limited nan_policy support')
     def test_variation_nan(self, nan_policy, expected, xp):
         x = xp.arange(10.)
         x[9] = xp.nan
-        xp_assert_close(variation(x, nan_policy=nan_policy), expected)
+        xp_assert_close(variation(x, nan_policy=nan_policy), xp.asarray(expected))
 
-    @skip_xp_backends(np_only=True,
-                      reason='`nan_policy` only supports NumPy backend')
+    @skip_xp_backends(eager_only=True, reason='lazy -> limited nan_policy support')
     def test_nan_policy_raise(self, xp):
         x = xp.asarray([1.0, 2.0, xp.nan, 3.0])
         with pytest.raises(ValueError, match='input contains nan'):
             variation(x, nan_policy='raise')
 
-    @skip_xp_backends(np_only=True,
-                      reason='`nan_policy` only supports NumPy backend')
+    @skip_xp_backends("dask.array", reason='needs `_axis_nan_policy`')
     def test_bad_nan_policy(self, xp):
         with pytest.raises(ValueError, match='must be one of'):
-            variation([1, 2, 3], nan_policy='foobar')
+            variation(xp.asarray([1, 2, 3]), nan_policy='foobar')
 
-    @skip_xp_backends(np_only=True,
-                      reason='`keepdims` only supports NumPy backend')
+    @skip_xp_backends("dask.array", reason='needs `_axis_nan_policy`')
     def test_keepdims(self, xp):
         x = xp.reshape(xp.arange(10), (2, 5))
         y = variation(x, axis=1, keepdims=True)
-        expected = np.array([[np.sqrt(2)/2],
-                             [np.sqrt(2)/7]])
+        expected = 2**0.5 / xp.asarray([[2.], [7.]])
         xp_assert_close(y, expected)
 
-    @skip_xp_backends(np_only=True,
-                      reason='`keepdims` only supports NumPy backend')
+    @skip_xp_backends("dask.array", reason='needs `_axis_nan_policy`')
     @pytest.mark.parametrize('axis, expected',
                              [(0, np.empty((1, 0))),
                               (1, np.full((5, 1), fill_value=np.nan))])
@@ -82,32 +77,29 @@ class TestVariation:
                 y = variation(x, axis=axis, keepdims=True)
         else:
             y = variation(x, axis=axis, keepdims=True)
-        xp_assert_equal(y, expected)
+        xp_assert_equal(y, xp.asarray(expected))
 
-    @skip_xp_backends(np_only=True,
-                      reason='`keepdims` only supports NumPy backend')
+    @skip_xp_backends("dask.array", reason='needs `_axis_nan_policy`')
     @pytest.mark.parametrize('incr, expected_fill', [(0, np.inf), (1, np.nan)])
     def test_keepdims_and_ddof_eq_len_plus_incr(self, incr, expected_fill, xp):
         x = xp.asarray([[1, 1, 2, 2], [1, 2, 3, 3]])
         y = variation(x, axis=1, ddof=x.shape[1] + incr, keepdims=True)
         xp_assert_equal(y, xp.full((2, 1), fill_value=expected_fill))
 
-    @skip_xp_backends(np_only=True,
-                      reason='`nan_policy` only supports NumPy backend')
+    @skip_xp_backends("dask.array", reason='needs `_axis_nan_policy`')
     def test_propagate_nan(self, xp):
         # Check that the shape of the result is the same for inputs
         # with and without nans, cf gh-5817
-        a = xp.reshape(xp.arange(8, dtype=float), (2, -1))
-        a[1, 0] = xp.nan
+        a = xp.reshape(xp.arange(8.), (2, -1))
+        a = xpx.at(a)[1, 0].set(xp.nan)
         v = variation(a, axis=1, nan_policy="propagate")
-        xp_assert_close(v, [math.sqrt(5/4)/1.5, xp.nan], atol=1e-15)
+        xp_assert_close(v, xp.asarray([math.sqrt(5/4)/1.5, xp.nan]))
 
-    @skip_xp_backends(np_only=True, reason='Python list input uses NumPy backend')
     def test_axis_none(self, xp):
         # Check that `variation` computes the result on the flattened
         # input when axis is None.
-        y = variation([[0, 1], [2, 3]], axis=None)
-        xp_assert_close(y, math.sqrt(5/4)/1.5)
+        y = variation(xp.asarray([[0, 1], [2, 3]]), axis=None)
+        xp_assert_close(y, xp.asarray(math.sqrt(5/4)/1.5))
 
     def test_bad_axis(self, xp):
         # Check that an invalid axis raises np.exceptions.AxisError.
@@ -156,18 +148,17 @@ class TestVariation:
         x1 = xp.asarray([-3., -5.])
         xp_assert_equal(variation(x1, ddof=2), xp.asarray(-xp.inf))
 
-    @skip_xp_backends(np_only=True,
-                      reason='`nan_policy` only supports NumPy backend')
+    @skip_xp_backends(np_only=True, reason='only NumPy supports ND nan_policy="omit"')
     def test_neg_inf_nan(self, xp):
         x2 = xp.asarray([[xp.nan, 1, -10, xp.nan],
                          [-20, -3, xp.nan, xp.nan]])
         xp_assert_equal(variation(x2, axis=1, ddof=2, nan_policy='omit'),
-                        [-xp.inf, -xp.inf])
+                        xp.asarray([-xp.inf, -xp.inf]))
 
-    @skip_xp_backends(np_only=True,
-                      reason='`nan_policy` only supports NumPy backend')
     @pytest.mark.parametrize("nan_policy", ['propagate', 'omit'])
     def test_combined_edge_cases(self, nan_policy, xp):
+        if not is_numpy(xp):
+            pytest.skip("Only NumPy supports ND nan_policy='omit'")
         x = xp.asarray([[0, 10, xp.nan, 1],
                         [0, -5, xp.nan, 2],
                         [0, -5, xp.nan, 3]])
@@ -176,10 +167,9 @@ class TestVariation:
                 y = variation(x, axis=0, nan_policy=nan_policy)
         else:
             y = variation(x, axis=0, nan_policy=nan_policy)
-        xp_assert_close(y, [xp.nan, xp.inf, xp.nan, math.sqrt(2/3)/2])
+        xp_assert_close(y, xp.asarray([xp.nan, xp.inf, xp.nan, math.sqrt(2/3)/2]))
 
-    @skip_xp_backends(np_only=True,
-                      reason='`nan_policy` only supports NumPy backend')
+    @skip_xp_backends(np_only=True, reason='only NumPy supports ND nan_policy="omit"')
     @pytest.mark.parametrize(
         'ddof, expected',
         [(0, [np.sqrt(1/6), np.sqrt(5/8), np.inf, 0, np.nan, 0.0, np.nan]),
@@ -203,8 +193,7 @@ class TestVariation:
             v = variation(x, axis=1, ddof=ddof, nan_policy='omit')
         xp_assert_close(v, expected)
 
-    @skip_xp_backends(np_only=True,
-                      reason='`nan_policy` only supports NumPy backend')
+    @skip_xp_backends(eager_only=True, reason='lazy -> limited nan_policy support')
     def test_variation_ddof(self, xp):
         # test variation with delta degrees of freedom
         # regression test for gh-13341
@@ -212,5 +201,5 @@ class TestVariation:
         nan_a = xp.asarray([1, 2, 3, xp.nan, 4, 5, xp.nan])
         y = variation(a, ddof=1)
         nan_y = variation(nan_a, nan_policy="omit", ddof=1)
-        xp_assert_close(y, math.sqrt(5/2)/3)
+        xp_assert_close(y, xp.asarray(math.sqrt(5/2)/3))
         assert y == nan_y


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
Adds array API test coverage by removing skips or making them more specific. Where skips are still needed, sometimes I've made the `reason` more specific.

#### Additional information
There are still a lot of other translations to do, but I think this takes care of some low-hanging fruit.

#### AI Generation Disclosure
ChatGPT helped me find some test functions that didn't accept the `xp` fixture.
