### PR TITLE
MNT: sparse: update csgraph and linalg tests to avoid unneeded legacy spmatrix

### DIFF
--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -962,7 +962,7 @@ class TestEigh:
     def test_eigh_of_sparse(self):
         # This tests the rejection of inputs that eigh cannot currently handle.
         import scipy.sparse
-        a = scipy.sparse.identity(2).tocsc()
+        a = scipy.sparse.eye_array(2).tocsc()
         b = np.atleast_2d(a)
         assert_raises(ValueError, eigh, a)
         assert_raises(ValueError, eigh, b)

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -20,8 +20,7 @@ from scipy.linalg import (_flapack as flapack, lapack, inv, svd, cholesky,
 from scipy.linalg._basic import _to_banded
 from scipy.linalg.lapack import _compute_lwork
 from scipy.stats import ortho_group, unitary_group
-
-import scipy.sparse as sps
+from scipy.sparse import diags_array
 
 try:
     from scipy.linalg import _clapack as clapack
@@ -591,7 +590,7 @@ class TestTbtrs:
             bands[ku] = np.ones(n, dtype=dtype)
 
         # Construct the diagonal banded matrix A from the bands and offsets.
-        a = sps.diags(bands, band_offsets, format='dia')
+        a = diags_array(bands, offsets=band_offsets, format='dia')
 
         # Convert A into banded storage form
         ab = np.zeros((kd + 1, n), dtype)

--- a/scipy/linalg/tests/test_sketches.py
+++ b/scipy/linalg/tests/test_sketches.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.testing import assert_, assert_equal
 from scipy.linalg import clarkson_woodruff_transform
 from scipy.linalg._sketches import cwt_matrix
-from scipy.sparse import issparse, rand
+from scipy.sparse import issparse, random_array
 from scipy.sparse.linalg import norm
 
 
@@ -27,21 +27,14 @@ class TestClarksonWoodruffTransform:
     seeds = [1755490010, 934377150, 1391612830, 1752708722, 2008891431,
              1302443994, 1521083269, 1501189312, 1126232505, 1533465685]
 
-    A_dense = rng.random((n_rows, n_cols))
-    A_csc = rand(
-        n_rows, n_cols, density=density, format='csc', random_state=rng,
-    )
-    A_csr = rand(
-        n_rows, n_cols, density=density, format='csr', random_state=rng,
-    )
-    A_coo = rand(
-        n_rows, n_cols, density=density, format='coo', random_state=rng,
-    )
+    shape = (n_rows, n_cols)
+    A_dense = rng.random(shape)
+    A_csc = random_array(shape, density=density, format='csc', rng=rng)
+    A_csr = random_array(shape, density=density, format='csr', rng=rng)
+    A_coo = random_array(shape, density=density, format='coo', rng=rng)
 
     # Collect the test matrices
-    test_matrices = [
-        A_dense, A_csc, A_csr, A_coo,
-    ]
+    test_matrices = [A_dense, A_csc, A_csr, A_coo]
 
     # Test vector with norm ~1
     x = rng.random((n_rows, 1)) / np.sqrt(n_rows)

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -81,9 +81,9 @@ def test_symmetric_graph_laplacian():
         'np.arange(10) * np.arange(10)[:, np.newaxis]',
         'np.ones((7, 7))',
         'np.eye(19)',
-        'sparse.diags([1.0, 1.0], [-1, 1], shape=(4, 4))',
-        'sparse.diags([1.0, 1.0], [-1, 1], shape=(4, 4)).toarray()',
-        'sparse.diags([1.0, 1.0], [-1, 1], shape=(4, 4)).todense()',
+        'sparse.diags_array([1.0, 1.0], offsets=[-1, 1], shape=(4, 4))',
+        'sparse.diags_array([1.0, 1.0], offsets=[-1, 1], shape=(4, 4)).toarray()',
+        'sparse.diags_array([1.0, 1.0], offsets=[-1, 1], shape=(4, 4)).todense()',
         'np.vander(np.arange(4)) + np.vander(np.arange(4)).T'
     )
     for mat in symmetric_mats:

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -229,7 +229,7 @@ def test_star_graph(n, method, directed):
     star_arr = np.zeros((n, n), dtype=float)
     star_center_idx = 0
     star_arr[star_center_idx, :] = star_arr[:, star_center_idx] = range(n)
-    G = scipy.sparse.csr_matrix(star_arr, shape=(n, n))
+    G = scipy.sparse.csr_array(star_arr, shape=(n, n))
     # Build the distances matrix
     SP_solution = np.zeros((n, n), dtype=float)
     SP_solution[:] = star_arr[star_center_idx]

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -13,8 +13,10 @@ from pytest import raises as assert_raises, warns as assert_warns
 
 import scipy.linalg
 from scipy.linalg import norm, inv
-from scipy.sparse import (dia_array, SparseEfficiencyWarning, csc_array,
-        csr_array, eye_array, issparse, dok_array, lil_array, bsr_array, kron)
+from scipy.sparse import (issparse, SparseEfficiencyWarning,
+                          csc_array, csr_array, coo_array, dia_array,
+                          dok_array, lil_array, bsr_array,
+                          eye_array, random_array, tril, triu, kron)
 from scipy.sparse.linalg import SuperLU
 from scipy.sparse.linalg._dsolve import (spsolve, use_solver, splu, spilu,
         MatrixRankWarning, _superlu, spsolve_triangular, factorized,
@@ -423,12 +425,12 @@ class TestLinsolve:
         assert_allclose(x.toarray(), b.toarray(), atol=1e-12, rtol=1e-12)
 
     def test_dtype_cast(self):
-        A_real = scipy.sparse.csr_array([[1, 2, 0],
-                                          [0, 0, 3],
-                                          [4, 0, 5]])
-        A_complex = scipy.sparse.csr_array([[1, 2, 0],
-                                             [0, 0, 3],
-                                             [4, 0, 5 + 1j]])
+        A_real = csr_array([[1, 2, 0],
+                            [0, 0, 3],
+                            [4, 0, 5]])
+        A_complex = csr_array([[1, 2, 0],
+                               [0, 0, 3],
+                               [4, 0, 5 + 1j]])
         b_real = np.array([1,1,1])
         b_complex = np.array([1,1,1]) + 1j*np.array([1,1,1])
         x = spsolve(A_real, b_real)
@@ -603,10 +605,10 @@ class TestSplu:
         rng = np.random.RandomState(42)
         n = 500
         p = 0.01
-        A = scipy.sparse.random(n, n, p, random_state=rng)
+        A = random_array((n, n), density=p, random_state=rng)
         x = rng.rand(n)
         # Make A diagonal dominant to make sure it is not singular
-        A += (n+1)*scipy.sparse.eye_array(n)
+        A += (n + 1) * eye_array(n)
         A_ = csc_array(A)
         b = A_ @ x
 
@@ -752,41 +754,41 @@ class TestSplu:
 
 class TestGstrsErrors:
     def setup_method(self):
-      self.A = array([[1.0,2.0,3.0],[4.0,5.0,6.0],[7.0,8.0,9.0]], dtype=np.float64)
+      self.A = csc_array([[1.0,2.0,3.0],[4.0,5.0,6.0],[7.0,8.0,9.0]], dtype=np.float64)
       self.b = np.array([[1.0],[2.0],[3.0]], dtype=np.float64)
 
     def test_trans(self):
-        L = scipy.sparse.tril(self.A, format='csc')
-        U = scipy.sparse.triu(self.A, k=1, format='csc')
+        L = tril(self.A, format='csc')
+        U = triu(self.A, k=1, format='csc')
         with assert_raises(ValueError, match="trans must be N, T, or H"):
             _superlu.gstrs('X', L.shape[0], L.nnz, L.data, L.indices, L.indptr,
                                 U.shape[0], U.nnz, U.data, U.indices, U.indptr, self.b)
 
     def test_shape_LU(self):
-        L = scipy.sparse.tril(self.A[0:2,0:2], format='csc')
-        U = scipy.sparse.triu(self.A, k=1, format='csc')
+        L = tril(self.A[0:2,0:2], format='csc')
+        U = triu(self.A, k=1, format='csc')
         with assert_raises(ValueError, match="L and U must have the same dimension"):
             _superlu.gstrs('N', L.shape[0], L.nnz, L.data, L.indices, L.indptr,
                                 U.shape[0], U.nnz, U.data, U.indices, U.indptr, self.b)
 
     def test_shape_b(self):
-        L = scipy.sparse.tril(self.A, format='csc')
-        U = scipy.sparse.triu(self.A, k=1, format='csc')
+        L = tril(self.A, format='csc')
+        U = triu(self.A, k=1, format='csc')
         with assert_raises(ValueError, match="right hand side array has invalid shape"):
             _superlu.gstrs('N', L.shape[0], L.nnz, L.data, L.indices, L.indptr,
                                 U.shape[0], U.nnz, U.data, U.indices, U.indptr,
                                 self.b[0:2])
 
     def test_types_differ(self):
-        L = scipy.sparse.tril(self.A.astype(np.float32), format='csc')
-        U = scipy.sparse.triu(self.A, k=1, format='csc')
+        L = tril(self.A.astype(np.float32), format='csc')
+        U = triu(self.A, k=1, format='csc')
         with assert_raises(TypeError, match="nzvals types of L and U differ"):
             _superlu.gstrs('N', L.shape[0], L.nnz, L.data, L.indices, L.indptr,
                                 U.shape[0], U.nnz, U.data, U.indices, U.indptr, self.b)
 
     def test_types_unsupported(self):
-        L = scipy.sparse.tril(self.A.astype(np.uint8), format='csc')
-        U = scipy.sparse.triu(self.A.astype(np.uint8), k=1, format='csc')
+        L = tril(self.A.astype(np.uint8), format='csc')
+        U = triu(self.A.astype(np.uint8), k=1, format='csc')
         with assert_raises(TypeError, match="nzvals is not of a type supported"):
             _superlu.gstrs('N', L.shape[0], L.nnz, L.data, L.indices, L.indptr,
                                 U.shape[0], U.nnz, U.data, U.indices, U.indptr,
@@ -800,9 +802,9 @@ class TestSpsolveTriangular:
     def test_zero_diagonal(self,fmt):
         n = 5
         rng = np.random.default_rng(43876432987)
-        A = rng.standard_normal((n, n))
+        A = coo_array(rng.standard_normal((n, n)))
         b = np.arange(n)
-        A = scipy.sparse.tril(A, k=0, format=fmt)
+        A = tril(A, k=0, format=fmt)
 
         x = spsolve_triangular(A, b, unit_diagonal=True, lower=True)
 
@@ -870,12 +872,12 @@ class TestSpsolveTriangular:
                     raise ValueError("choice_of_A must be 'real' or 'complex'.")
                 rng = np.random.default_rng(789002319)
                 rvs = rng.random
-                A = scipy.sparse.random(n, n, density=0.1, format='lil', dtype=dtype,
-                                        random_state=rng, data_rvs=rvs)
+                A = random_array((n, n), density=0.1, format='lil', dtype=dtype,
+                                 random_state=rng, data_rvs=rvs)
                 if lower:
-                    A = scipy.sparse.tril(A, format="lil")
+                    A = tril(A, format="lil")
                 else:
-                    A = scipy.sparse.triu(A, format="lil")
+                    A = triu(A, format="lil")
                 for i in range(n):
                     A[i, i] = np.random.rand() + 1
                 if format == "csc":
@@ -910,12 +912,12 @@ def test_is_sptriangular_and_spbandwidth(nnz, fmt):
 
         N = nnz // 2
         dens = 0.1
-        A = scipy.sparse.random_array((N, N), density=dens, format="csr", rng=rng)
+        A = random_array((N, N), density=dens, format="csr", rng=rng)
         A[1, 3] = A[3, 1] = 22  # ensure not upper or lower
         A = A.asformat(fmt)
-        AU = scipy.sparse.triu(A, format=fmt)
-        AL = scipy.sparse.tril(A, format=fmt)
-        D = 0.1 * scipy.sparse.eye_array(N, format=fmt)
+        AU = triu(A, format=fmt)
+        AL = tril(A, format=fmt)
+        D = 0.1 * eye_array(N, format=fmt)
 
         assert is_sptriangular(A) == (False, False)
         assert is_sptriangular(AL) == (True, False)

--- a/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/tests/test_linsolve.py
@@ -873,7 +873,7 @@ class TestSpsolveTriangular:
                 rng = np.random.default_rng(789002319)
                 rvs = rng.random
                 A = random_array((n, n), density=0.1, format='lil', dtype=dtype,
-                                 random_state=rng, data_rvs=rvs)
+                                 random_state=rng, data_sampler=rvs)
                 if lower:
                     A = tril(A, format="lil")
                 else:

--- a/scipy/sparse/linalg/_eigen/arpack/arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/arpack.py
@@ -38,7 +38,7 @@ Uses ARPACK: https://github.com/opencollab/arpack-ng
 import numpy as np
 import warnings
 from scipy.sparse.linalg._interface import aslinearoperator, LinearOperator
-from scipy.sparse import eye, issparse
+from scipy.sparse import eye_array, issparse
 from scipy.linalg import eig, eigh, lu_factor, lu_solve
 from scipy.sparse._sputils import (
     convert_pydata_sparse_to_scipy, isdense, is_pydata_spmatrix,
@@ -1158,7 +1158,7 @@ def get_OPinv_matvec(A, M, sigma, hermitian=False, tol=0):
             A.flat[::A.shape[1] + 1] -= sigma
             return LuInv(A).matvec
         elif issparse(A) or is_pydata_spmatrix(A):
-            A = A - sigma * eye(A.shape[0])
+            A = A - sigma * eye_array(A.shape[0])
             A = _fast_spmatrix_to_csc(A, hermitian=hermitian)
             return SpLuInv(A).matvec
         else:

--- a/scipy/sparse/linalg/tests/test_funm_multiply_krylov.py
+++ b/scipy/sparse/linalg/tests/test_funm_multiply_krylov.py
@@ -56,7 +56,7 @@ class TestKrylovFunmv:
         nsamples = 1 + 9 // num_parallel_threads  # Very slow otherwise
 
         for i in range(nsamples):
-            D = scipy.sparse.diags(rng.standard_normal(n))
+            D = scipy.sparse.diags_array(rng.standard_normal(n))
             A = scipy.sparse.random_array((n, n), density = 0.01, rng = rng) + D
             denseA = A.todense()
             b = rng.standard_normal(n)
@@ -95,7 +95,7 @@ class TestKrylovFunmv:
         nsamples = 1 + 9 // num_parallel_threads  # Very slow otherwise
 
         for i in range(nsamples):
-            D = scipy.sparse.diags(rng.standard_normal(n))
+            D = scipy.sparse.diags_array(rng.standard_normal(n))
             A = scipy.sparse.random_array((n, n), density = 0.01, rng = rng)
             R = scipy.sparse.triu(A)
             A = R + R.T + D

--- a/scipy/sparse/linalg/tests/test_onenormest.py
+++ b/scipy/sparse/linalg/tests/test_onenormest.py
@@ -217,7 +217,7 @@ class TestOnenormest:
 
     def test_returns(self):
         np.random.seed(1234)
-        A = scipy.sparse.rand(50, 50, 0.1)
+        A = scipy.sparse.random_array((50, 50), density=0.1)
 
         s0 = scipy.linalg.norm(A.toarray(), 1)
         s1, v = scipy.sparse.linalg.onenormest(A, compute_v=True)

--- a/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
+++ b/scipy/sparse/linalg/tests/test_special_sparse_arrays.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal, assert_allclose
 
-from scipy.sparse import diags, csgraph
+from scipy.sparse import diags_array, csgraph
 from scipy.linalg import eigh
 
 from scipy.sparse.linalg import LaplacianNd
@@ -61,7 +61,7 @@ class TestLaplacianNd:
 
     def test_1d_with_graph_laplacian(self):
         n = 6
-        G = diags(np.ones(n - 1), 1, format='dia')
+        G = diags_array(np.ones(n - 1), offsets=1, format='dia')
         Lf = csgraph.laplacian(G, symmetrized=True, form='function')
         La = csgraph.laplacian(G, symmetrized=True, form='array')
         grid_shape = (n,)


### PR DESCRIPTION
This PR updates tests in sparse/linalg and sparse/csgraph to avoid legacy sparse construction functions when not needed. These cases were found from locally deprecating all spmatrix classes and functions and running the tests to see which tests raise deprecation warnings. Then filter out all the tests that are actually testing spmatrix cases. This PR includes the remaining cases. 

These changes do not affect what the tests test nor the results of the test.