### PR TITLE
BUG: fix scipy.stats.describe() is failing on boolean arrays

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1534,6 +1534,7 @@ def describe(a, axis=0, ddof=1, bias=True, nan_policy='propagate'):
                    device=xp_device(a))
     n = n[()] if n.ndim == 0 else n
     mm = (xp.min(a, axis=axis), xp.max(a, axis=axis))
+    a = xp_promote(a, force_floating=True, xp=xp)
     m = xp.mean(a, axis=axis)
     v = _var(a, axis=axis, ddof=ddof, xp=xp)
     v = v[()] if v.ndim == 0 else v

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -41,7 +41,7 @@ from scipy._lib._array_api import (array_namespace, eager_warns, is_lazy_array,
                                    is_numpy, is_torch, xp_default_dtype, xp_size,
                                    SCIPY_ARRAY_API, make_xp_test_case, xp_ravel,
                                    xp_swapaxes, xp_result_type, is_cupy, is_jax,
-                                   xp_copy)
+                                   xp_copy, xp_promote)
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal, xp_assert_less
 import scipy._external.array_api_extra as xpx
 from scipy._lib._util import _apply_over_batch
@@ -6389,6 +6389,22 @@ class TestDescribe:
         message = "The input must not be empty."
         with pytest.raises(ValueError, match=message):
             stats.describe(xp.asarray([]))
+    
+    @skip_xp_backends("array_api_strict", reason="min/max don't accept boolean input")
+    def test_boolean_input_gh24847(self, xp):
+        # gh-24847 reported that `describe` failed with boolean input
+        rng = np.random.default_rng(3248923598734583)
+        n = 20
+        x = xp.asarray(rng.random(n) < 0.5)
+        res = stats.describe(x)
+        xp_assert_equal(res.nobs, xp.asarray(n, dtype=xp.int64))
+        xp_assert_equal(res.minmax[0], xp.min(x))
+        xp_assert_equal(res.minmax[1], xp.max(x))
+        x = xp_promote(x, force_floating=True, xp=xp)
+        xp_assert_close(res.mean, xp.mean(x))
+        xp_assert_close(res.variance, xp.var(x, correction=1))
+        xp_assert_close(res.skewness, stats.skew(x))
+        xp_assert_close(res.kurtosis, stats.kurtosis(x))
 
 
 class NormalityTests:

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -40,13 +40,8 @@ from scipy.conftest import skip_xp_invalid_arg
 from scipy._lib._array_api import (array_namespace, eager_warns, is_lazy_array,
                                    is_numpy, is_torch, xp_default_dtype, xp_size,
                                    SCIPY_ARRAY_API, make_xp_test_case, xp_ravel,
-<<<<<<< fix-describe-bool-gh24847
-                                   xp_swapaxes, xp_result_type, is_cupy, is_jax,
-                                   xp_copy, xp_promote)
-=======
                                    xp_swapaxes, xp_result_type, is_jax,
-                                   xp_copy, make_xp_pytest_param)
->>>>>>> main
+                                   xp_copy, xp_promote, make_xp_pytest_param)
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal, xp_assert_less
 import scipy._external.array_api_extra as xpx
 from scipy._lib._util import _apply_over_batch


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes #24847

#### What does this implement/fix?
<!--Please explain your changes.-->
Promote input to floating point before computing statistics
so that non-float dtypes don't cause incorrect results or overflow in `_var`.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used