### PR TITLE
TST: stats.binomtest: translate remaining tests to array API

### DIFF
--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -12,7 +12,7 @@ from scipy._lib._array_api import xp_ravel
 from scipy._lib._docscrape import FunctionDoc, Parameter
 from scipy._lib._util import _contains_nan, AxisError, _get_nan
 from scipy._lib._array_api import (array_namespace, is_numpy, xp_size, xp_copy,
-                                   xp_promote, is_dask, is_jax)
+                                   xp_promote, is_dask, is_jax, xp_capabilities)
 import scipy._external.array_api_extra as xpx
 
 import inspect
@@ -161,6 +161,7 @@ def _broadcast_shapes_remove_axis(shapes, axis=None):
     return tuple(shape)
 
 
+@xp_capabilities()
 def _broadcast_concatenate(arrays, axis, paired=False, xp=None):
     """Concatenate arrays along an axis with broadcasting."""
     xp = array_namespace(*arrays) if xp is None else xp

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -1478,9 +1478,10 @@ def test__broadcast_concatenate(xp):
     # test that _broadcast_concatenate properly broadcasts arrays along all
     # axes except `axis`, then concatenates along axis
     rng = np.random.default_rng(7544340069)
-    a = xp.asarray(rng.random((5, 4, 4, 3, 1, 6)))
-    b = xp.asarray(rng.random((4, 1, 8, 2, 6)))
-    c = stats._axis_nan_policy._broadcast_concatenate((a, b), axis=-3, xp=xp)
+    a = rng.random((5, 4, 4, 3, 1, 6))
+    b = rng.random((4, 1, 8, 2, 6))
+    arrays = (xp.asarray(a), xp.asarray(b))
+    c = stats._axis_nan_policy._broadcast_concatenate(arrays, axis=-3, xp=xp)
     # broadcast manually as an independent check
     a = np.tile(a, (1, 1, 1, 1, 2, 1))
     b = np.tile(b[None, ...], (5, 1, 4, 1, 1, 1))

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -19,6 +19,7 @@ from scipy.stats._axis_nan_policy import (_masked_arrays_2_sentinel_arrays,
                                           too_small_nd_omit, too_small_nd_not_omit,
                                           too_small_1d_omit, too_small_1d_not_omit)
 from scipy._lib._util import AxisError
+from scipy._lib._array_api import make_xp_test_case
 from scipy.conftest import skip_xp_invalid_arg
 
 
@@ -1472,13 +1473,14 @@ def test_array_like_input(dtype):
     assert res.count == 2
 
 
-def test__broadcast_concatenate():
+@make_xp_test_case(stats._axis_nan_policy._broadcast_concatenate)
+def test__broadcast_concatenate(xp):
     # test that _broadcast_concatenate properly broadcasts arrays along all
     # axes except `axis`, then concatenates along axis
     rng = np.random.default_rng(7544340069)
-    a = rng.random((5, 4, 4, 3, 1, 6))
-    b = rng.random((4, 1, 8, 2, 6))
-    c = stats._axis_nan_policy._broadcast_concatenate((a, b), axis=-3)
+    a = xp.asarray(rng.random((5, 4, 4, 3, 1, 6)))
+    b = xp.asarray(rng.random((4, 1, 8, 2, 6)))
+    c = stats._axis_nan_policy._broadcast_concatenate((a, b), axis=-3, xp=xp)
     # broadcast manually as an independent check
     a = np.tile(a, (1, 1, 1, 1, 2, 1))
     b = np.tile(b[None, ...], (5, 1, 4, 1, 1, 1))

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1321,13 +1321,12 @@ class TestBinomTest:
         xp_assert_close(ci.low, xp.asarray(ci_low))
         xp_assert_close(ci.high, xp.asarray(ci_high))
 
-
-class TestBinomTestMore:
-    def test_binomtest(self):
+    @skip_xp_backends('jax.numpy', reason="'two-sided' alternative needs root finder")
+    def test_binomtest(self, xp):
         # precision tests compared to R for ticket:986
-        pp = np.concatenate((np.linspace(0.1, 0.2, 5),
-                             np.linspace(0.45, 0.65, 5),
-                             np.linspace(0.85, 0.95, 5)))
+        pp = xp.concat((xp.linspace(0.1, 0.2, 5),
+                        xp.linspace(0.45, 0.65, 5),
+                        xp.linspace(0.85, 0.95, 5)))
         n = 501
         x = 450
         results = [0.0, 0.0, 1.0159969301994141e-304,
@@ -1338,13 +1337,13 @@ class TestBinomTestMore:
                    0.12044570587262322, 0.88154763174802508, 0.027120993063129286,
                    2.6102587134694721e-006]
 
-        for p, res in zip(pp, results):
-            assert_allclose(stats.binomtest(x, n, p).pvalue, res, rtol=1e-12)
+        xp_assert_close(stats.binomtest(x, n, pp).pvalue, xp.asarray(results))
 
-        assert_allclose(stats.binomtest(50, 100, 0.1).pvalue,
-                        5.8320387857343647e-024, rtol=1e-12)
+        xp_assert_close(stats.binomtest(50, 100, xp.asarray(0.1)).pvalue,
+                        xp.asarray(5.8320387857343647e-024))
 
-    def test_binomtest2(self):
+    @skip_xp_backends('jax.numpy', reason="'two-sided' alternative needs root finder")
+    def test_binomtest2(self, xp):
         # test added for issue #2384
         res2 = [
             [1.0, 1.0],
@@ -1364,15 +1363,20 @@ class TestBinomTestMore:
              0.001953125]
         ]
         for k in range(1, 11):
-            res1 = [stats.binomtest(v, k, 0.5).pvalue for v in range(k + 1)]
-            assert_almost_equal(res1, res2[k-1], decimal=10)
+            v = xp.arange(k+1, dtype=xp.float64)
+            res1 = stats.binomtest(v, k, 0.5).pvalue
+            xp_assert_close(res1, xp.asarray(res2[k-1], dtype=xp.float64))
 
-    def test_binomtest3(self):
+    @skip_xp_backends('jax.numpy', reason="'two-sided' alternative needs root finder")
+    def test_binomtest3(self, xp):
         # test added for issue #2384
         # test when x == n*p and neighbors
-        res3 = [stats.binomtest(v, v*k, 1./k).pvalue
-                for v in range(1, 11) for k in range(2, 11)]
-        assert_equal(res3, np.ones(len(res3), int))
+        v = xp.arange(1., 11.)[:, xp.newaxis]
+        k = xp.arange(2., 11.)
+        shape = (v.shape[0], k.shape[0])
+
+        res3 = stats.binomtest(v, v*k, 1./k).pvalue
+        xp_assert_close(res3, xp.ones(shape))
 
         # > bt=c()
         # > for(i in as.single(1:10)) {
@@ -1381,7 +1385,7 @@ class TestBinomTestMore:
         # +         print(c(i+1, k*i,(1/k)))
         # +     }
         # + }
-        binom_testm1 = np.array([
+        binom_testm1 = xp.asarray([
              0.5, 0.5555555555555556, 0.578125, 0.5904000000000003,
              0.5981224279835393, 0.603430543396034, 0.607304096221924,
              0.610255656871054, 0.612579511000001, 0.625, 0.670781893004115,
@@ -1421,7 +1425,7 @@ class TestBinomTestMore:
         # +     }
         # + }
 
-        binom_testp1 = np.array([
+        binom_testp1 = xp.asarray([
              0.5, 0.259259259259259, 0.26171875, 0.26272, 0.2632244513031551,
              0.2635138663069203, 0.2636951804161073, 0.2638162407564354,
              0.2639010709000002, 0.625, 0.4074074074074074, 0.42156982421875,
@@ -1452,13 +1456,15 @@ class TestBinomTestMore:
              0.736270323773157, 0.737718376096348
             ])
 
-        res4_p1 = [stats.binomtest(v+1, v*k, 1./k).pvalue
-                   for v in range(1, 11) for k in range(2, 11)]
-        res4_m1 = [stats.binomtest(v-1, v*k, 1./k).pvalue
-                   for v in range(1, 11) for k in range(2, 11)]
+        k, v = xp.asarray(k, dtype=xp.float64), xp.asarray(v, dtype=xp.float64)
+        binom_testp1 = xp.reshape(xp.asarray(binom_testp1, dtype=xp.float64), shape)
+        binom_testm1 = xp.reshape(xp.asarray(binom_testm1, dtype=xp.float64), shape)
 
-        assert_almost_equal(res4_p1, binom_testp1, decimal=13)
-        assert_almost_equal(res4_m1, binom_testm1, decimal=13)
+        res4_p1 = stats.binomtest(v+1, v*k, 1./k).pvalue
+        res4_m1 = stats.binomtest(v-1, v*k, 1./k).pvalue
+
+        xp_assert_close(res4_p1, binom_testp1)
+        xp_assert_close(res4_m1, binom_testm1)
 
 
 @make_xp_test_case(stats.fligner)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1316,6 +1316,13 @@ class TestCorrSpearmanr:
         expected = [0.865895477, 0.866100381, 0.866100381]
         assert_allclose([res1, res2, res3], expected)
 
+    #    W.II.E.  Tabulate X against X, using BIG as a case weight.  The values
+    #    should appear on the diagonal and the total should be 899999955.
+    #    If the table cannot hold these values, forget about working with
+    #    census data.  You can also tabulate HUGE against TINY.  There is no
+    #    reason a tabulation program should not be able to distinguish
+    #    different values regardless of their magnitude.
+
 
 class TestCorrSpearmanr2:
     """Some further tests of the spearmanr function."""

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -9663,24 +9663,30 @@ def test_chk_asarray(xp):
     assert_equal(axis_out, axis)
 
 
-@pytest.mark.parametrize("fun", [stats.wilcoxon, stats.ks_1samp,
-                                 stats.ks_2samp, stats.kstest])
-def test_rename_mode_method(fun):
+@skip_xp_backends("jax.numpy", reason="JAX+wilcoxon+'exact' incompatible")
+@pytest.mark.parametrize("fun", [
+    make_xp_pytest_param(stats.wilcoxon),
+    make_xp_pytest_param(stats.ks_1samp),
+    make_xp_pytest_param(stats.ks_2samp),
+    make_xp_pytest_param(stats.kstest)
+])
+def test_rename_mode_method(fun, xp):
     rng = np.random.default_rng(23498459284629827814)
-    x = rng.random(10)
-    y = rng.random(10)
+    x = xp.asarray(rng.random(10))
+    y = xp.asarray(rng.random(10))
 
     if fun == stats.wilcoxon:
         args = (x,)
     elif fun == stats.ks_1samp:
-        args = (x, stats.norm.cdf)
+        args = (x, special.ndtr)
     else:
         args = (x, y)
 
     res = fun(*args, method='exact')
     res2 = fun(*args, mode='exact')
-    assert_equal(res, res2)
+    xp_assert_equal(res.statistic, res2.statistic)
+    xp_assert_equal(res.pvalue, res2.pvalue)
 
-    err = rf"{fun.__name__}() got multiple values for argument"
-    with pytest.raises(TypeError, match=re.escape(err)):
+    err = rf"{fun.__name__}\(\) got multiple values for argument"
+    with pytest.raises(TypeError, match=err):
         fun(*args, method='exact', mode='exact')

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -1315,13 +1315,6 @@ class TestCorrSpearmanr:
         expected = [0.865895477, 0.866100381, 0.866100381]
         assert_allclose([res1, res2, res3], expected)
 
-    #    W.II.E.  Tabulate X against X, using BIG as a case weight.  The values
-    #    should appear on the diagonal and the total should be 899999955.
-    #    If the table cannot hold these values, forget about working with
-    #    census data.  You can also tabulate HUGE against TINY.  There is no
-    #    reason a tabulation program should not be able to distinguish
-    #    different values regardless of their magnitude.
-
 
 class TestCorrSpearmanr2:
     """Some further tests of the spearmanr function."""

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -8,7 +8,6 @@
 """
 import math
 import os
-import re
 import warnings
 from collections import namedtuple
 from itertools import product


### PR DESCRIPTION
#### Reference issue
gh-20544

#### What does this implement/fix?
In the initial translation of `stats.binomtest` to the array API, I missed some tests that were in a different file. gh-24850 moved those tests in with the test, and this PR translates them.

This PR also translates two test functions that are not part of classes.

#### Additional information
Relies on gh-24850, which needs to merge first. That will simplify the diff considerably.

#### AI Generation Disclosure
No AI