### PR TITLE
ENH/TST: stats: strengthen MArray tests

### DIFF
--- a/scipy/stats/_correlation.py
+++ b/scipy/stats/_correlation.py
@@ -700,8 +700,8 @@ def _robust_slopes(y, *, x, alpha=None, method, pfun):
     # we don't actually need ranks, so an enhancement could be to have
     # `rankdata` return only the second output. In the meantime, use the
     # least expensive `method`.
-    _, nxreps = _rankdata(x, method='min', return_ties=True)
-    _, nyreps = _rankdata(y, method='min', return_ties=True)
+    _, _, nxreps = _rankdata(x, method='min', return_ties=True)
+    _, _, nyreps = _rankdata(y, method='min', return_ties=True)
     nt = xp.count_nonzero(xp.isfinite(slopes), axis=-1, keepdims=True)  # N in Sen 1968
     nt = xp.asarray(nt, dtype=y.dtype)
     ny = _count_nonmasked(y, keepdims=True, axis=-1)                    # n in Sen 1968

--- a/scipy/stats/_correlation.py
+++ b/scipy/stats/_correlation.py
@@ -698,7 +698,7 @@ def _robust_slopes(y, *, x, alpha=None, method, pfun):
     z = float(special.ndtri(alpha / 2.))
     # This implements (2.6) from Sen (1968)
     # we don't actually need ranks, so an enhancement could be to have
-    # `rankdata` return only the second output. In the meantime, use the
+    # `rankdata` return only the third output. In the meantime, use the
     # least expensive `method`.
     _, _, nxreps = _rankdata(x, method='min', return_ties=True)
     _, _, nyreps = _rankdata(y, method='min', return_ties=True)

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1665,7 +1665,8 @@ def _pval_cvm_2samp_asymptotic(t, N, nx, ny, k, *, xp):
 @xp_capabilities(skip_backends=[('cupy', 'needs rankdata'),
                                 ('dask.array', 'needs rankdata')],
                  cpu_only=True, jax_jit=False,  # due to p-value calculation
-                 marray=True)
+                 marray=True,
+                 extra_note="Only `method='exact'` is compatible with MArray.")
 @_axis_nan_policy_factory(CramerVonMisesResult, n_samples=2, too_small=1,
                           result_to_tuple=_cvm_result_to_tuple)
 def cramervonmises_2samp(x, y, method='auto', *, axis=0):

--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -454,7 +454,7 @@ def mannwhitneyu(x, y, use_continuity=True, alternative="two-sided",
     n2 = _count_nonmasked(y, axis=-1, xp=xp)
 
     # Follows [2]
-    ranks, t = _rankdata(xy, 'average', return_ties=True)  # method 2, step 1
+    ranks, _, t = _rankdata(xy, 'average', return_ties=True)  # method 2, step 1
     ranks = xp.astype(ranks, x.dtype, copy=False)
     t = xp.astype(t, x.dtype, copy=False)
     R1 = xp.sum(ranks[..., :x.shape[-1]], axis=-1)         # method 2, step 2

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3176,7 +3176,7 @@ def ansari(x, y, alternative='two-sided', *, axis=0):
 
     N = m + n
     xy = xp.concat([x, y], axis=-1)  # combine
-    rank, t = _stats_py._rankdata(xy, method='average', return_ties=True)
+    rank, _, t = _stats_py._rankdata(xy, method='average', return_ties=True)
     symrank = xp.minimum(rank, N - rank + 1)
     AB = xp.sum(symrank[..., :n], axis=-1)
     repeats = xp.any(t > 1)  # in theory we could branch for each slice separately
@@ -3701,7 +3701,7 @@ def _mood_statistic_with_ties(x, y, t, m, n, N, xp):
     x = xp.sort(x, axis=-1)
     xy = xp.concat((x, y), axis=-1)
     i = xp.argsort(xy, stable=True, axis=-1)
-    _, a = _stats_py._rankdata(x, method='average', return_ties=True)
+    _, _, a = _stats_py._rankdata(x, method='average', return_ties=True)
 
     zeros = xp.zeros(a.shape[:-1] + (n,), dtype=a.dtype)
     a = xp.concat((a, zeros), axis=-1)
@@ -3837,7 +3837,7 @@ def mood(x, y, axis=0, alternative="two-sided"):
 
     # determine if any of the samples contain ties
     # `a` represents ties within `x`; `t` represents ties within `xy`
-    r, t = _stats_py._rankdata(xy, method='average', return_ties=True)
+    r, _, t = _stats_py._rankdata(xy, method='average', return_ties=True)
 
     if is_lazy_array(t) or xp.any(t > 1):
         z = _mood_statistic_with_ties(x, y, t, m, n, N, xp=xp)

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3349,9 +3349,7 @@ def bartlett(*samples, axis=0):
 LeveneResult = namedtuple('LeveneResult', ('statistic', 'pvalue'))
 
 
-@xp_capabilities(cpu_only=True, exceptions=['cupy'], marray=True,
-                 extra_note="Option ``center='trimmed'`` is incompatible with MArray."
-                 )
+@xp_capabilities(cpu_only=True, exceptions=['cupy'], marray=True)
 @_axis_nan_policy_factory(LeveneResult, n_samples=None)
 def levene(*samples, center='median', proportiontocut=0.05, axis=0):
     r"""Perform Levene test for equal variances.
@@ -3462,9 +3460,6 @@ def levene(*samples, center='median', proportiontocut=0.05, axis=0):
             return xp.mean(x, axis=-1, keepdims=True)
 
     else:  # center == 'trimmed'
-        if is_marray(xp):
-            message = "`center='trimmed'` is incompatible with MArray."
-            raise ValueError(message)
 
         def func(x):
             # keepdims=True doesn't currently work for Dask
@@ -3505,8 +3500,7 @@ FlignerResult = namedtuple('FlignerResult', ('statistic', 'pvalue'))
 
 @xp_capabilities(skip_backends=[('dask.array', 'no rankdata'),
                                 ('cupy', 'no rankdata')],
-                 marray=True,
-                 extra_note="Option ``center='trimmed'`` is incompatible with MArray.")
+                 marray=True)
 @_axis_nan_policy_factory(FlignerResult, n_samples=None)
 def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
     r"""Perform Fligner-Killeen test for equality of variance.
@@ -3629,10 +3623,6 @@ def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
             return xp.mean(x, axis=-1, keepdims=True)
 
     else:  # center == 'trimmed'
-
-        if is_marray(xp):
-            message = "`center='trimmed'` is incompatible with MArray."
-            raise ValueError(message)
 
         def func(x):
             # keepdims=True doesn't currently work for lazy arrays

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -11075,7 +11075,7 @@ def _xp_var(x, /, *, axis=None, correction=0, keepdims=False, nan_policy='propag
     var = _xp_mean(x_mean * x_mean_conj, keepdims=keepdims, **kwargs)
 
     if correction != 0:
-        n = _count_nonmasked(x, axis, xp=xp)
+        n = _count_nonmasked(x, axis, xp=xp, keepdims=keepdims)
         # Or two lines with ternaries : )
         # axis = range(x.ndim) if axis is None else axis
         # n = math.prod(x.shape[i] for i in axis) if iterable(axis) else x.shape[axis]

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10904,6 +10904,7 @@ def _linearized_pmean(a, p, *, axis=None, weights=None, xp=None):
     return M0 * (1 + 0.5 * p * (ln2_avg - ln_avg * ln_avg))
 
 
+@xp_capabilities()
 def _xp_mean(x, /, *, axis=None, weights=None, keepdims=False, nan_policy='propagate',
              dtype=None, warn=True, xp=None):
     r"""Compute the arithmetic mean along the specified axis.
@@ -11051,6 +11052,7 @@ def _xp_mean(x, /, *, axis=None, weights=None, keepdims=False, nan_policy='propa
     return res[()] if res.ndim == 0 else res
 
 
+@xp_capabilities()
 def _xp_var(x, /, *, axis=None, correction=0, keepdims=False, nan_policy='propagate',
             dtype=None, xp=None):
     # an array-api compatible function for variance with scipy.stats interface

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -5546,7 +5546,8 @@ def pointbiserialr(x, y, *, axis=0):
 
 
 @xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=2,
-                 marray=True)
+                 marray=True, extra_note=("`nan_policy='propagate'` is "
+                                          "incompatible with MArray input."))
 def kendalltau(x, y, *, nan_policy='propagate', method='auto', variant='b',
                alternative='two-sided', axis=None, keepdims=False):
     r"""Calculate Kendall's tau, a correlation measure for ordinal data.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -8047,7 +8047,7 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
         # assumed when we evaluate the ECDFs at all points in the pooled sample.
         # These counts are given by the differences between consecutive ("min" or "max")
         # ranks corresponding with the observations in the (sorted) samples.
-        ranks, data_all = _rankdata(data_all, method='min', return_sorted=True)
+        ranks, data_all, _ = _rankdata(data_all, method='min', return_sorted=True)
         ranks = xp.astype(ranks, xp.asarray(1).dtype)  # default int type
         one = xp.ones((*ranks.shape[:-1], 1), dtype=ranks.dtype,
                       device=xp_device(ranks))
@@ -8601,7 +8601,7 @@ def kruskal(*samples, nan_policy='propagate', axis=0):
         raise ValueError("Inputs must not be empty.")
 
     alldata = xp.concat(samples, axis=-1)
-    ranked, t = _rankdata(alldata, method='average', return_ties=True)
+    ranked, _, t = _rankdata(alldata, method='average', return_ties=True)
     counts = [xp.asarray(_count_nonmasked(sample, -1), dtype=t.dtype)
               for sample in samples]
     totaln = sum(counts)
@@ -8708,7 +8708,7 @@ def friedmanchisquare(*samples, axis=0):
     # The transpose flips this so we can work with axis-slices along -1. This is a
     # reducing statistic, so both axes 0 and -1 are consumed.
     data = xp_swapaxes(xp.stack(samples), 0, -1)
-    data, t = _rankdata(data, method='average', return_ties=True)
+    data, _, t = _rankdata(data, method='average', return_ties=True)
 
     # Handle ties
     ties = xp.sum(t * (t*t - 1), axis=(0, -1))
@@ -10266,7 +10266,7 @@ def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
     contains_nan = _contains_nan(x, nan_policy)
 
     x = xp_swapaxes(x, axis, -1, xp=xp)
-    ranks = _rankdata(x, method, xp=xp)
+    ranks, _, _ = _rankdata(x, method, xp=xp)
 
     # JIT won't allow use of `contains_nan` for control flow here, so we always have to
     # run this with JIT.
@@ -10295,7 +10295,10 @@ def _order_ranks(ranks, j, *, xp):
 
 
 def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
-    # Rank data `x` by desired `method`; `return_ties`/`return_sorted` data  if desired
+    # Rank data `x` by desired `method`. For methods other than 'ordinal':
+    # - `return_sorted=True` ensures that the second output is sorted `x`
+    # - `return_ties=True` ensures that the third output is tie data
+    # Otherwise, the second/third output will be None.
     xp = array_namespace(x) if xp is None else xp
     dtype = xp_result_type(x, force_floating=True, xp=xp)
 
@@ -10303,33 +10306,24 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
         import jax.scipy.stats as jax_stats
         ranks = jax_stats.rankdata(x, method=method, axis=-1)
         ranks = xp.astype(ranks, dtype, copy=False)
-        out = [ranks]
         y = xp.sort(x, axis=-1) if (return_ties or return_sorted) else None
-        if return_sorted:
-            out.append(y)
+        t = None
         if return_ties:
             max_ranks = jax_stats.rankdata(y, method='max', axis=-1)
             t = xp.diff(max_ranks, axis=-1, prepend=0)
             t = xp.astype(t, dtype, copy=False)
-            out.append(t)
-        return out[0] if len(out) == 1 else tuple(out)
+        return ranks, y, t
 
     if is_marray(xp):
         data, mask = x.data, x.mask
         uxp = array_namespace(data)
         data = uxp.where(mask, uxp.nan, data)
-        # TODO: have `_rankdata` always return three items, but allow them
-        #       to be `None` if they are not needed by the calling function.
-        #       Arguments controlling the number of outputs is a pain.
-        ranks, sorted, ties = _rankdata(data, method, True, True, xp=uxp)
-        out = [xp.asarray(ranks, mask=mask)]
-        if return_sorted or return_ties:
-            mask_sorted = uxp.isnan(sorted)
-        if return_sorted:
-            out.append(xp.asarray(sorted, mask=mask_sorted))
-        if return_ties:
-            out.append(xp.asarray(ties, mask=mask_sorted))
-        return out[0] if len(out) == 1 else tuple(out)
+        ranks, sorted, ties = _rankdata(data, method, return_sorted, return_ties, uxp)
+        ranks = xp.asarray(ranks, mask=mask)
+        mask_sorted = uxp.isnan(sorted) if (return_sorted or return_ties) else None
+        sorted = xp.asarray(sorted, mask=mask_sorted) if return_sorted else None
+        ties = xp.asarray(ties, mask=mask_sorted) if return_ties else None
+        return ranks, sorted, ties
 
     shape = x.shape
 
@@ -10339,7 +10333,8 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
 
     # Ordinal ranks is very easy because ties don't matter. We're done.
     if method == 'ordinal':
-        return _order_ranks(ordinal_ranks, j, xp=xp)  # never return ties or sorted data
+        ranks = _order_ranks(ordinal_ranks, j, xp=xp)
+        return (ranks, None, None)
 
     # Sort array
     y = xp.take_along_axis(x, j, axis=-1)
@@ -10365,14 +10360,8 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
 
     ranks = xp.reshape(xp.repeat(ranks, counts), shape)
     ranks = _order_ranks(ranks, j, xp=xp)
-    if not (return_sorted or return_ties):
-        return ranks
 
-    out = [ranks]
-
-    if return_sorted:
-        out.append(y)
-
+    t = None
     if return_ties:
         # Tie information is returned in a format that is useful to functions that
         # rely on this (private) function. Example:
@@ -10392,9 +10381,8 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
         #   have the lowest rank, so it is easy to find them at the zeroth index.
         t = xp.zeros(shape, dtype=dtype)
         t = xpx.at(t)[i].set(xp.astype(counts, dtype, copy=False))
-        out.append(t)
 
-    return out
+    return ranks, y, t
 
 
 @xp_capabilities(marray=True,

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -3620,7 +3620,7 @@ def trim1(a, proportiontocut, tail='right', axis=0):
     return atmp[tuple(sl)]
 
 
-@xp_capabilities()
+@xp_capabilities(marray=True)
 @_axis_nan_policy_factory(lambda x: x, result_to_tuple=lambda x, _: (x,), n_outputs=1)
 def trim_mean(a, proportiontocut, axis=0):
     """Return mean of array after trimming a specified fraction of extreme values.
@@ -3695,18 +3695,27 @@ def trim_mean(a, proportiontocut, axis=0):
         a = xp_ravel(a)
         axis = 0
 
-    nobs = a.shape[axis]
-    lowercut = int(proportiontocut * nobs)
+    nobs = _count_nonmasked(a, axis=axis, keepdims=True, xp=xp)
+    lowercut = proportiontocut * nobs
+    nobs, lowercut = ((nobs, int(lowercut)) if not is_marray(xp)
+                      else (xp.astype(nobs, xp.int64), xp.astype(lowercut, xp.int64)))
     uppercut = nobs - lowercut
-    if (lowercut > uppercut):
+    if not is_marray(xp) and (lowercut > uppercut):
         raise ValueError("Proportion too big.")
 
     atmp = (np.partition(a, (lowercut, uppercut - 1), axis) if is_numpy(xp)
             else xp.sort(a, axis=axis))
 
-    sl = [slice(None)] * atmp.ndim
-    sl[axis] = slice(lowercut, uppercut)
-    trimmed = xp_promote(atmp[tuple(sl)], force_floating=True, xp=xp)
+    if is_marray(xp):
+        indices = xp.arange(a.shape[-1])  # axis_nan_policy decorator -> axis=-1
+        mask = (indices < lowercut) | (indices >= (nobs - lowercut)) | atmp.mask
+        trimmed = xp.asarray(atmp.data, mask=mask.data)
+    else:
+        sl = [slice(None)] * atmp.ndim
+        sl[axis] = slice(lowercut, uppercut)
+        trimmed = atmp[tuple(sl)]
+
+    trimmed = xp_promote(trimmed, force_floating=True, xp=xp)
     return xp.mean(trimmed, axis=axis)
 
 

--- a/scipy/stats/_wilcoxon.py
+++ b/scipy/stats/_wilcoxon.py
@@ -146,7 +146,7 @@ def _wilcoxon_statistic(d, method, zero_method='wilcox', *, xp):
     n_nan = xp.astype(xp.count_nonzero(i_nan, axis=-1), dtype)
     count = _count_nonmasked(d, axis=-1) - n_nan
 
-    r, t = _rankdata(xp.abs(d), 'average', return_ties=True, xp=xp)
+    r, _, t = _rankdata(xp.abs(d), 'average', return_ties=True, xp=xp)
     r, t = xp.astype(r, dtype, copy=False), xp.astype(t, dtype, copy=False)
 
     r_plus = xp.sum(xp.astype(d > 0, dtype) * r, axis=-1)

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -575,13 +575,14 @@ def test_slopes_intercepts(f, method, axis, xp):
 
 
 @make_xp_test_case(stats.entropy)
+@skip_backend('dask.array', reason="Dask doesn't like the /= when base is not None.")
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.parametrize('qk', [False, True])
 @pytest.mark.parametrize('base', [None, 2])
 @pytest.mark.parametrize('axis', [0, 1, None])
 def test_entropy(qk, base, axis, xp):
     mxp, marrays, narrays = get_arrays(2 if qk else 1, xp=xp)
-    res = stats.entropy(*marrays, base=base, axis=axis)  # TODO: fix dask?
+    res = stats.entropy(*marrays, base=base, axis=axis)
     ref = stats.entropy(*narrays, base=base, nan_policy='omit', axis=axis)
     xp_assert_close(res.data, xp.asarray(ref))
 

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -150,11 +150,12 @@ def test_describe(axis, kwargs, xp):
                     xp.asarray(np.asarray(ref.kurtosis.data, copy=True)))
 
 
+@skip_backend('dask.array', reason='shape (nan,) in _xp_var when ddof=1')
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.parametrize('fun', [make_xp_pytest_param(stats.zscore),
                                  make_xp_pytest_param(stats.gzscore),
                                  make_xp_pytest_param(stats.zmap)])
-@pytest.mark.parametrize('ddof', [0, 1])  # TODO: fix
+@pytest.mark.parametrize('ddof', [0, 1])
 @pytest.mark.parametrize('axis', [0, 1, None])
 def test_one_sample_non_reducing(fun, ddof, axis, xp):
     mxp, marrays, narrays = (get_arrays(2, xp=xp) if fun == stats.zmap

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -369,7 +369,7 @@ def test_wilcoxon(n_samples, zero_method, correction, alternative, method, axis,
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
 
 
-@make_xp_test_case(stats.wilcoxon)
+@make_xp_test_case(stats.mannwhitneyu)
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.parametrize('use_continuity', [False, True])
 @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -54,7 +54,7 @@ def get_arrays(n_arrays, *, dtype='float64', xp=np, shape=(7, 8), all_unique=Tru
     make_xp_pytest_param(stats.hmean, {}),
     make_xp_pytest_param(stats.pmean, {'p': 2}),
     make_xp_pytest_param(stats.expectile, {'alpha': 0.4}),
-    make_xp_pytest_param(_xp_mean, {})
+    make_xp_pytest_param(_xp_mean, {}),
 ])
 @pytest.mark.parametrize('weighted', [False, True])
 @pytest.mark.parametrize('axis', [0, 1, None])
@@ -106,6 +106,7 @@ def test_one_sample_weighted_reducing(fun, kwargs, weighted, axis, xp):
      make_xp_pytest_param(stats.iqr, {'rng': (10, 90), 'scale': 'normal'}),
      make_xp_pytest_param(stats.median_abs_deviation, {}),
      make_xp_pytest_param(stats.median_abs_deviation, {'scale': 'normal'}),
+     make_xp_pytest_param(stats.trim_mean, {'proportiontocut': 0.1}),
      ])
 @pytest.mark.parametrize('axis', [0, 1, None])
 def test_one_sample_reducing(fun, kwargs, axis, xp):
@@ -473,13 +474,13 @@ class TestKendallTau:
     make_xp_pytest_param(stats.alexandergovern, {}),
     make_xp_pytest_param(stats.levene, {'center': 'median'}),
     make_xp_pytest_param(stats.levene, {'center': 'mean'}),
-    # make_xp_pytest_param(stats.levene, {'center': 'trimmed'}),  # TODO
+    make_xp_pytest_param(stats.levene, {'center': 'trimmed'}),
     make_xp_pytest_param(stats.f_oneway, {'equal_var': True}),
     make_xp_pytest_param(stats.f_oneway, {'equal_var': False}),
     make_xp_pytest_param(stats.kruskal, {}),
     make_xp_pytest_param(stats.fligner, {'center': 'median'}),
     make_xp_pytest_param(stats.fligner, {'center': 'mean'}),
-    # make_xp_pytest_param(stats.fligner, {'center': 'trimmed'}),  # TODO
+    make_xp_pytest_param(stats.fligner, {'center': 'trimmed'}),
 ])
 @pytest.mark.parametrize('axis', [0, 1, None])
 def test_k_sample_tests(fun, kwargs, axis, xp):
@@ -609,14 +610,3 @@ def test_obrientransform(dtype, n_arrays, xp):
     for res_i, ref_i in zip(res, ref):
         xp_assert_close(res_i.data[~res_i.mask],
                         xp.asarray(ref_i[~np.isnan(ref_i)], dtype=getattr(xp, dtype)))
-
-
-@pytest.mark.parametrize('f', [
-    make_xp_pytest_param(stats.levene),
-    make_xp_pytest_param(stats.fligner),
-])
-def test_center_trimmed(f, xp):
-    mxp, marrays, narrays = get_arrays(3, xp=xp)
-    message = "`center='trimmed'` is incompatible with MArray."
-    with pytest.raises(ValueError, match=message):
-        f(*marrays, center='trimmed', axis=-1)

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -93,7 +93,7 @@ def test_one_sample_weighted_reducing(fun, kwargs, weighted, axis, xp):
      make_xp_pytest_param(stats.gstd, {}),
      make_xp_pytest_param(stats.gstd, {'ddof': 2}),
      make_xp_pytest_param(_xp_var, {}),
-     make_xp_pytest_param(_xp_var, {'correction': 1, 'keepdims': True}),  # TODO: fix
+     make_xp_pytest_param(_xp_var, {'correction': 1, 'keepdims': True}),
      make_xp_pytest_param(stats.variation, {}),
      make_xp_pytest_param(stats.variation, {'ddof': 1}),
      make_xp_pytest_param(stats.tmean, dict(limits=(0.1, 0.9))),

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -443,7 +443,7 @@ def test_ks_2samp(fun, method, alternative, axis, xp):
 
 @make_xp_test_case(stats.kendalltau)
 class TestKendallTau:
-    @pytest.mark.parametrize('method', ['exact'])  # TODO: fix asymptotic
+    @pytest.mark.parametrize('method', ['asymptotic', 'exact'])
     @pytest.mark.parametrize('variant', ['b', 'c'])
     @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
     @pytest.mark.parametrize('axis', [0, 1, None])

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -53,25 +53,17 @@ def get_arrays(n_arrays, *, dtype='float64', xp=np, shape=(7, 8), all_unique=Tru
     make_xp_pytest_param(stats.gmean, {}),
     make_xp_pytest_param(stats.hmean, {}),
     make_xp_pytest_param(stats.pmean, {'p': 2}),
-    make_xp_pytest_param(stats.expectile, {'alpha': 0.4})
+    make_xp_pytest_param(stats.expectile, {'alpha': 0.4}),
+    make_xp_pytest_param(_xp_mean, {})
 ])
+@pytest.mark.parametrize('weighted', [False, True])
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_xmean(fun, kwargs, axis, xp):
+def test_one_sample_weighted_reducing(fun, kwargs, weighted, axis, xp):
     mxp, marrays, narrays = get_arrays(2, xp=xp)
-    res = fun(marrays[0], weights=marrays[1], axis=axis, **kwargs)
-    ref = fun(narrays[0], weights=narrays[1], nan_policy='omit', axis=axis, **kwargs)
-    xp_assert_close(res.data, xp.asarray(ref))
-
-
-@skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
-@pytest.mark.parametrize('axis', [0, 1, None])
-@pytest.mark.parametrize('keepdims', [False, True])
-@pytest.mark.uses_xp_capabilities(False, reason="private")
-def test_xp_mean(axis, keepdims, xp):
-    mxp, marrays, narrays = get_arrays(2, xp=xp)
-    kwargs = dict(axis=axis, keepdims=keepdims)
-    res = _xp_mean(marrays[0], weights=marrays[1], **kwargs)
-    ref = _xp_mean(narrays[0], weights=narrays[1], nan_policy='omit', **kwargs)
+    mweights = marrays[1] if weighted else None
+    nweights = narrays[1] if weighted else None
+    res = fun(marrays[0], weights=mweights, axis=axis, **kwargs)
+    ref = fun(narrays[0], weights=nweights, nan_policy='omit', axis=axis, **kwargs)
     xp_assert_close(res.data, xp.asarray(ref))
 
 
@@ -79,11 +71,13 @@ def test_xp_mean(axis, keepdims, xp):
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.parametrize('fun, kwargs',
     [make_xp_pytest_param(stats.moment, {'order': 2}),
+     make_xp_pytest_param(stats.moment, {'center': 0.5}),
      make_xp_pytest_param(stats.skew, {}),
      make_xp_pytest_param(stats.skew, {'bias': False}),
      make_xp_pytest_param(stats.kurtosis, {}),
-     make_xp_pytest_param(stats.kurtosis, {'bias': False}),
+     make_xp_pytest_param(stats.kurtosis, {'fisher': False, 'bias': False}),
      make_xp_pytest_param(stats.sem, {}),
+     make_xp_pytest_param(stats.sem, {'ddof': 2}),
      make_xp_pytest_param(stats.kstat, {'n': 1}),
      make_xp_pytest_param(stats.kstat, {'n': 2}),
      make_xp_pytest_param(stats.kstat, {'n': 3}),
@@ -91,25 +85,30 @@ def test_xp_mean(axis, keepdims, xp):
      make_xp_pytest_param(stats.kstatvar, {'n': 1}),
      make_xp_pytest_param(stats.kstatvar, {'n': 2}),
      make_xp_pytest_param(stats.circmean, {}),
+     make_xp_pytest_param(stats.circmean, {'low': 0, 'high': 1}),
      make_xp_pytest_param(stats.circvar, {}),
+     make_xp_pytest_param(stats.circvar, {'low': 0, 'high': 1}),
      make_xp_pytest_param(stats.circstd, {}),
+     make_xp_pytest_param(stats.circstd, {'low': 0, 'high': 1, 'normalize':True}),
      make_xp_pytest_param(stats.gstd, {}),
+     make_xp_pytest_param(stats.gstd, {'ddof': 2}),
+     make_xp_pytest_param(_xp_var, {}),
+     make_xp_pytest_param(_xp_var, {'correction': 1, 'keepdims': True}),  # TODO: fix
      make_xp_pytest_param(stats.variation, {}),
-     pytest.param(
-         _xp_var, {},
-         marks=pytest.mark.uses_xp_capabilities(False, reason="private")
-     ),
-     make_xp_pytest_param(stats.tmean, {'limits': (0.1, 0.9)}),
-     make_xp_pytest_param(stats.tvar, {'limits': (0.1, 0.9)}),
-     make_xp_pytest_param(stats.tmin, {'lowerlimit': 0.5}),
-     make_xp_pytest_param(stats.tmax, {'upperlimit': 0.5}),
-     make_xp_pytest_param(stats.tstd, {'limits': (0.1, 0.9)}),
-     make_xp_pytest_param(stats.tsem, {'limits': (0.1, 0.9)}),
-     make_xp_pytest_param(stats.iqr, {}),
+     make_xp_pytest_param(stats.variation, {'ddof': 1}),
+     make_xp_pytest_param(stats.tmean, dict(limits=(0.1, 0.9))),
+     make_xp_pytest_param(stats.tvar, dict(limits=(0.1, 0.9), inclusive=(False, True))),
+     make_xp_pytest_param(stats.tstd, dict(limits=(0.1, 0.9), inclusive=(True, False))),
+     make_xp_pytest_param(stats.tsem, dict(limits=(0.1, 0.9), inclusive=(False,)*2)),
+     make_xp_pytest_param(stats.tmin, dict(lowerlimit=0.5, inclusive=True)),
+     make_xp_pytest_param(stats.tmax, dict(upperlimit=0.5, inclusive=False)),
+     make_xp_pytest_param(stats.iqr, {'interpolation': 'nearest'}),
+     make_xp_pytest_param(stats.iqr, {'rng': (10, 90), 'scale': 'normal'}),
      make_xp_pytest_param(stats.median_abs_deviation, {}),
+     make_xp_pytest_param(stats.median_abs_deviation, {'scale': 'normal'}),
      ])
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_several(fun, kwargs, axis, xp):
+def test_one_sample_reducing(fun, kwargs, axis, xp):
     mxp, marrays, narrays = get_arrays(1, xp=xp)
     kwargs = dict(axis=axis) | kwargs
     res = fun(marrays[0], **kwargs)
@@ -133,7 +132,7 @@ def test_mode(dtype, shape, axis, xp):
 @skip_backend('dask.array', reason='Arrays need `device` attribute: dask/dask#11711')
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.parametrize('axis', [0, 1, None])
-@pytest.mark.parametrize('kwargs', [{}])
+@pytest.mark.parametrize('kwargs', [{}, {'bias': False}])
 def test_describe(axis, kwargs, xp):
     mxp, marrays, narrays = get_arrays(1, xp=xp)
     kwargs = dict(axis=axis) | kwargs
@@ -155,12 +154,13 @@ def test_describe(axis, kwargs, xp):
 @pytest.mark.parametrize('fun', [make_xp_pytest_param(stats.zscore),
                                  make_xp_pytest_param(stats.gzscore),
                                  make_xp_pytest_param(stats.zmap)])
+@pytest.mark.parametrize('ddof', [0, 1])  # TODO: fix
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_zscore(fun, axis, xp):
+def test_one_sample_non_reducing(fun, ddof, axis, xp):
     mxp, marrays, narrays = (get_arrays(2, xp=xp) if fun == stats.zmap
                              else get_arrays(1, xp=xp))
-    res = fun(*marrays, axis=axis)
-    ref = xp.asarray(fun(*narrays, nan_policy='omit', axis=axis))
+    res = fun(*marrays, ddof=ddof, axis=axis)
+    ref = xp.asarray(fun(*narrays, ddof=ddof, nan_policy='omit', axis=axis))
     xp_assert_close(res.data[~res.mask], ref[~xp.isnan(ref)])
     xp_assert_equal(res.mask, marrays[0].mask)
 
@@ -170,15 +170,16 @@ def test_zscore(fun, axis, xp):
 @pytest.mark.parametrize('f', [make_xp_pytest_param(stats.ttest_1samp),
                                make_xp_pytest_param(stats.ttest_rel),
                                make_xp_pytest_param(stats.ttest_ind)])
+@pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_ttest(f, axis, xp):
+def test_ttests(f, alternative, axis, xp):
     f_name = f.__name__
     mxp, marrays, narrays = get_arrays(2, xp=xp)
     if f_name == 'ttest_1samp':
         marrays[1] = mxp.mean(marrays[1], axis=axis, keepdims=axis is not None)
         narrays[1] = np.nanmean(narrays[1], axis=axis, keepdims=axis is not None)
-    res = f(*marrays, axis=axis)
-    ref = f(*narrays, nan_policy='omit', axis=axis)
+    res = f(*marrays, alternative=alternative, axis=axis)
+    ref = f(*narrays, alternative=alternative, nan_policy='omit', axis=axis)
     xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
     res_ci = res.confidence_interval()
@@ -190,19 +191,30 @@ def test_ttest(f, axis, xp):
 @skip_backend('dask.array', reason='Arrays need `device` attribute: dask/dask#11711')
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.filterwarnings("ignore::scipy.stats._axis_nan_policy.SmallSampleWarning")
-@pytest.mark.parametrize('f', [make_xp_pytest_param(stats.skewtest),
-                               make_xp_pytest_param(stats.kurtosistest),
-                               make_xp_pytest_param(stats.normaltest),
-                               make_xp_pytest_param(stats.jarque_bera)])
+@pytest.mark.parametrize('f, args', [
+     make_xp_pytest_param(stats.skewtest, tuple()),
+     make_xp_pytest_param(stats.kurtosistest, tuple()),
+     make_xp_pytest_param(stats.normaltest, tuple()),
+     make_xp_pytest_param(stats.jarque_bera, tuple()),
+     make_xp_pytest_param(stats.cramervonmises, (stats.norm.cdf,)),
+])
+@pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_normality_tests(f, axis, xp):
+def test_goodness_of_fit(f, args, alternative, axis, xp):
     mxp, marrays, narrays = get_arrays(1, xp=xp, shape=(10, 11))
 
-    res = f(*marrays, axis=axis)
-    ref = f(*narrays, nan_policy='omit', axis=axis)
+    if f in {stats.skewtest, stats.kurtosistest}:
+        kwds = {'alternative': alternative}
+    else:
+        if alternative != 'greater':
+            pytest.skip(f'str({f.__name__} does not support multiple alternatives.')
+        kwds = {}
+
+    res = f(*marrays, *args, **kwds, axis=axis)
+    ref = f(*narrays, *args, **kwds, nan_policy='omit', axis=axis)
 
     xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
-    xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue), atol=1e-16)
+    xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue), atol=1e-15)
 
 
 @skip_backend('dask.array', reason='Arrays need `device` attribute: dask/dask#11711')
@@ -263,6 +275,7 @@ def test_combine_pvalues(method, axis, xp):
     if method != 'stouffer':
         return
 
+    # test method='stouffer' with weights
     res = stats.combine_pvalues(marrays[0], weights=marrays[1], **kwargs)
     ref = stats.combine_pvalues(narrays[0], weights=narrays[1],
                                 nan_policy='omit', **kwargs)
@@ -273,7 +286,9 @@ def test_combine_pvalues(method, axis, xp):
 
 @make_xp_test_case(stats.ttest_ind_from_stats)
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
-def test_ttest_ind_from_stats(xp):
+@pytest.mark.parametrize("alternative", ['less', 'greater', 'two-sided'])
+@pytest.mark.parametrize("equal_var", [False, True])
+def test_ttest_ind_from_stats(alternative, equal_var, xp):
     shape = (10, 11)
     mxp, marrays, narrays = get_arrays(6, xp=xp, shape=shape)
     mask = np.sum(np.stack([np.isnan(arg) for arg in narrays]), axis=0).astype(bool)
@@ -281,8 +296,9 @@ def test_ttest_ind_from_stats(xp):
     marrays[2], marrays[5] = marrays[2] * 100, marrays[5] * 100
     narrays[2], narrays[5] = narrays[2] * 100, narrays[5] * 100
 
-    res = stats.ttest_ind_from_stats(*marrays)
-    ref = stats.ttest_ind_from_stats(*narrays)
+    kwargs = dict(alternative=alternative, equal_var=equal_var)
+    res = stats.ttest_ind_from_stats(*marrays, **kwargs)
+    ref = stats.ttest_ind_from_stats(*narrays, **kwargs)
 
     mask = xp.asarray(mask)
     assert xp.any(mask) and xp.any(~mask)
@@ -311,10 +327,11 @@ def test_length_nonmasked_marray_iterable_axis_raises():
 @make_xp_test_case(stats.directional_stats)
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")  # mdhaber/marray#120
+@pytest.mark.parametrize('normalize', [False, True])
 @pytest.mark.parametrize('axis', [0, 1])
-def test_directional_stats(xp, axis):
+def test_directional_stats(normalize, axis, xp):
     mxp, marrays, narrays = get_arrays(1, shape=(19, 20, 3), xp=xp)
-    res = stats.directional_stats(*marrays, axis=axis)
+    res = stats.directional_stats(*marrays, normalize=normalize, axis=axis)
 
     x, = narrays
     if axis == 0:
@@ -323,7 +340,7 @@ def test_directional_stats(xp, axis):
     for i in range(x.shape[0]):
         xi = x[i]
         xi = xi[~np.any(np.isnan(xi), axis=-1), :]
-        ref = stats.directional_stats(xi)
+        ref = stats.directional_stats(xi, normalize=normalize)
         xp_assert_close(res.mean_direction.data[i, ...],
                         xp.asarray(ref.mean_direction))
         xp_assert_close(res.mean_resultant_length.data[i],
@@ -332,17 +349,35 @@ def test_directional_stats(xp, axis):
     assert not xp.any(res.mean_resultant_length.mask)
 
 
+@make_xp_test_case(stats.wilcoxon)
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
-@pytest.mark.parametrize('fun, kwargs', [
-    make_xp_pytest_param(stats.wilcoxon,
-                         {'method': 'asymptotic', 'zero_method': 'zsplit'}),
-    make_xp_pytest_param(stats.cramervonmises, {'cdf': stats.norm.cdf}),
-])
+@pytest.mark.parametrize('n_samples', [1, 2])
+@pytest.mark.parametrize('zero_method', ['zsplit'])  # TODO: add 'wilcox', 'pratt'
+@pytest.mark.parametrize('correction', [False, True])
+@pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
+@pytest.mark.parametrize('method', ['asymptotic'])  # TODO: add 'exact', 'auto'
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_one_sample_tests(fun, kwargs, axis, xp):
-    mxp, marrays, narrays = get_arrays(1, xp=xp, seed=84912165484322)
-    res = fun(*marrays, axis=axis, **kwargs)
-    ref = fun(*narrays, nan_policy='omit', axis=axis, **kwargs)
+def test_wilcoxon(n_samples, zero_method, correction, alternative, method, axis, xp):
+    mxp, marrays, narrays = get_arrays(n_samples, xp=xp, seed=84912165484322)
+    kwargs = dict(zero_method=zero_method, correction=correction,
+                  alternative=alternative, method=method)
+    res = stats.wilcoxon(*marrays, axis=axis, **kwargs)
+    ref = stats.wilcoxon(*narrays, nan_policy='omit', axis=axis, **kwargs)
+    xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
+    xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
+
+
+@make_xp_test_case(stats.wilcoxon)
+@skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
+@pytest.mark.parametrize('use_continuity', [False, True])
+@pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
+@pytest.mark.parametrize('method', ['asymptotic'])  # TODO: add 'exact', 'auto'
+@pytest.mark.parametrize('axis', [0, 1, None])
+def test_mannwhitneyu(use_continuity, alternative, method, axis, xp):
+    mxp, marrays, narrays = get_arrays(2, xp=xp, seed=84912165484322)
+    kwargs = dict(use_continuity=use_continuity, alternative=alternative, method=method)
+    res = stats.mannwhitneyu(*marrays, axis=axis, **kwargs)
+    ref = stats.mannwhitneyu(*narrays, nan_policy='omit', axis=axis, **kwargs)
     xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
     xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
 
@@ -368,10 +403,9 @@ def test_ks_1samp(fun, method, alternative, axis, xp):
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.parametrize('fun, kwargs', [
     make_xp_pytest_param(stats.brunnermunzel, {}),
-    make_xp_pytest_param(stats.mannwhitneyu, {'method': 'asymptotic'}),
-    make_xp_pytest_param(stats.wilcoxon,
-                         {'method': 'asymptotic', 'zero_method': 'zsplit'}),
+    make_xp_pytest_param(stats.brunnermunzel, {'distribution': 'normal'}),
     make_xp_pytest_param(stats.cramervonmises_2samp, {'method': 'exact'}),
+    # make_xp_pytest_param(stats.cramervonmises_2samp, {}),  # TODO: add methods
 ])
 @pytest.mark.parametrize('axis', [0, 1, None])
 def test_two_sample_tests(fun, kwargs, axis, xp):
@@ -407,11 +441,16 @@ def test_ks_2samp(fun, method, alternative, axis, xp):
 
 @make_xp_test_case(stats.kendalltau)
 class TestKendallTau:
+    @pytest.mark.parametrize('method', ['exact'])  # TODO: fix asymptotic
+    @pytest.mark.parametrize('variant', ['b', 'c'])
+    @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
     @pytest.mark.parametrize('axis', [0, 1, None])
-    def test_omit_masked_elements(self, axis, xp):
-        mxp, marrays, narrays = get_arrays(2, xp=xp, seed=84912165484322)
-        res = stats.kendalltau(*marrays, axis=axis)
-        ref = stats.kendalltau(*narrays, nan_policy='omit', axis=axis)
+    def test_omit_masked_elements(self, method, variant, alternative, axis, xp):
+        mxp, marrays, narrays = get_arrays(2, shape=(17, 18),
+                                           xp=xp, seed=84912165484322)
+        kwargs = dict(method=method, variant=variant, alternative=alternative)
+        res = stats.kendalltau(*marrays, **kwargs, axis=axis)
+        ref = stats.kendalltau(*narrays, **kwargs, nan_policy='omit', axis=axis)
         xp_assert_close(res.statistic.data, xp.asarray(ref.statistic))
         xp_assert_close(res.pvalue.data, xp.asarray(ref.pvalue))
 
@@ -433,11 +472,13 @@ class TestKendallTau:
     make_xp_pytest_param(stats.alexandergovern, {}),
     make_xp_pytest_param(stats.levene, {'center': 'median'}),
     make_xp_pytest_param(stats.levene, {'center': 'mean'}),
+    # make_xp_pytest_param(stats.levene, {'center': 'trimmed'}),  # TODO
     make_xp_pytest_param(stats.f_oneway, {'equal_var': True}),
     make_xp_pytest_param(stats.f_oneway, {'equal_var': False}),
     make_xp_pytest_param(stats.kruskal, {}),
     make_xp_pytest_param(stats.fligner, {'center': 'median'}),
     make_xp_pytest_param(stats.fligner, {'center': 'mean'}),
+    # make_xp_pytest_param(stats.fligner, {'center': 'trimmed'}),  # TODO
 ])
 @pytest.mark.parametrize('axis', [0, 1, None])
 def test_k_sample_tests(fun, kwargs, axis, xp):
@@ -468,10 +509,13 @@ def test_k_sample_paired_tests(fun, kwargs, axis, xp):
     make_xp_pytest_param(stats.pointbiserialr),
     make_xp_pytest_param(stats.spearmanrho),
 ])
+@pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_pearsonr(f, axis, xp):
+def test_correlation(f, alternative, axis, xp):
     mxp, marrays, narrays = get_arrays(2, xp=xp)
-    res = f(*marrays, axis=axis)
+
+    kwargs = {} if f == stats.pointbiserialr else {'alternative': alternative}
+    res = f(*marrays, **kwargs, axis=axis)
 
     # `pearsonr` does not have `axis_nan_policy`, so do this manually
     x, y = narrays
@@ -485,7 +529,7 @@ def test_pearsonr(f, axis, xp):
         i = () if axis is None else i
 
         mask = np.isnan(xi) | np.isnan(yi)
-        ref = f(xi[~mask], yi[~mask])
+        ref = f(xi[~mask], yi[~mask], **kwargs)
 
         atol = 1e-7 if (is_torch(xp) and f == stats.spearmanrho) else 0.
         xp_assert_close(res.statistic.data[i], xp.asarray(ref.statistic)[()], atol=atol)
@@ -505,10 +549,12 @@ def test_pearsonr(f, axis, xp):
     make_xp_pytest_param(stats.siegelslopes, {'method':'separate'}),
     make_xp_pytest_param(stats.theilslopes, {'method': 'joint'}),
     make_xp_pytest_param(stats.theilslopes, {'method': 'separate'}),
-    make_xp_pytest_param(stats.linregress, {}),
+    make_xp_pytest_param(stats.linregress, {'alternative': 'less'}),
+    make_xp_pytest_param(stats.linregress, {'alternative': 'greater'}),
+    make_xp_pytest_param(stats.linregress, {'alternative': 'two-sided'}),
 ])
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_robust_slopes(f, method, axis, xp):
+def test_slopes_intercepts(f, method, axis, xp):
     mxp, marrays, narrays = get_arrays(2, shape=(19, 20), seed=84912165484320, xp=xp)
     res = f(*marrays, axis=axis, **method)
     ref = f(*narrays, nan_policy='omit', axis=axis, **method)
@@ -529,21 +575,23 @@ def test_robust_slopes(f, method, axis, xp):
 @make_xp_test_case(stats.entropy)
 @skip_backend('jax.numpy', reason="JAX doesn't allow item assignment.")
 @pytest.mark.parametrize('qk', [False, True])
+@pytest.mark.parametrize('base', [None, 2])
 @pytest.mark.parametrize('axis', [0, 1, None])
-def test_entropy(qk, axis, xp):
+def test_entropy(qk, base, axis, xp):
     mxp, marrays, narrays = get_arrays(2 if qk else 1, xp=xp)
-    res = stats.entropy(*marrays, axis=axis)
-    ref = stats.entropy(*narrays, nan_policy='omit', axis=axis)
+    res = stats.entropy(*marrays, base=base, axis=axis)  # TODO: fix dask?
+    ref = stats.entropy(*narrays, base=base, nan_policy='omit', axis=axis)
     xp_assert_close(res.data, xp.asarray(ref))
 
 
 @make_xp_test_case(stats.rankdata)
-@pytest.mark.parametrize('axis', [0, 1, None])
 @skip_backend('jax.numpy', reason="JAX currently incompatible with marray")
-def test_rankdata(axis, xp):
+@pytest.mark.parametrize('method', ['average', 'min', 'max', 'dense'])  # TODO: ordinal
+@pytest.mark.parametrize('axis', [0, 1, None])
+def test_rankdata(method, axis, xp):
     mxp, marrays, narrays = get_arrays(1, xp=xp)
-    res = stats.rankdata(*marrays, axis=axis)
-    ref = stats.rankdata(*narrays, nan_policy='omit', axis=axis)
+    res = stats.rankdata(*marrays, method=method, axis=axis)
+    ref = stats.rankdata(*narrays, method=method, nan_policy='omit', axis=axis)
     xp_assert_close(res.data[~res.mask], xp.asarray(ref[~np.isnan(ref)]))
     xp_assert_close(res.mask, xp.asarray(np.isnan(ref)))
 

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -589,7 +589,7 @@ def test_entropy(qk, base, axis, xp):
 
 @make_xp_test_case(stats.rankdata)
 @skip_backend('jax.numpy', reason="JAX currently incompatible with marray")
-@pytest.mark.parametrize('method', ['average', 'min', 'max', 'dense'])  # TODO: ordinal
+@pytest.mark.parametrize('method', ['average', 'min', 'max', 'dense', 'ordinal'])
 @pytest.mark.parametrize('axis', [0, 1, None])
 def test_rankdata(method, axis, xp):
     mxp, marrays, narrays = get_arrays(1, xp=xp)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -9458,7 +9458,7 @@ class TestLMoment:
         xp_assert_close(res, ref)
 
 
-@pytest.mark.uses_xp_capabilities(False, reason="private")
+@make_xp_test_case(_xp_mean)
 class TestXP_Mean:
     @pytest.mark.parametrize('axis', [None, 1, -1, (-2, 2)])
     @pytest.mark.parametrize('weights', [None, True])
@@ -9600,7 +9600,7 @@ class TestXP_Mean:
         xp_assert_close(res, xp.asarray(ref))
 
 
-@pytest.mark.uses_xp_capabilities(False, reason="private")
+@make_xp_test_case(_xp_var)
 class TestXP_Var:
     @pytest.mark.parametrize('axis', [None, 1, -1, (-2, 2)])
     @pytest.mark.parametrize('keepdims', [False, True])


### PR DESCRIPTION
#### Reference issue
-

#### What does this implement/fix?
The primary goal of this PR is to increase MArray test coverage; see 87d23e51462a437fe46b4513f3130354fb3a28f6.
The increased coverage revealed some deficiencies or limitations of MArray support. As appropriate, I fixed bugs or ensured that the limitations were documented using `extra_note`. I'd suggest reviewing the remaining commits individually:
1. 6144ba11fd0172aef6489093f3593768eb6b7725 fixes a bug in `_xp_var` when `correction` is used and `keepdims=True`
2. e2905bcaeaa2e2c98107743ee9c61f8f7d9f026e skips a failing Dask test. I think Dask always fails `_xp_var` when `ddof != 0`.
3. 7c2bf4b4765d3cdb3eddcca61d8237e5d95fb514 allows testing `levene` and `fligner` with `center='trimmed'` by adding MArray support to `trim_mean`. This is really an independent enhancement, and could be split into a separate PR if need be, but it was simple enough that I thought I'd just go ahead and remove the limitation.
4. d5350515734bf93d61865065a099732755234ebe skips another failing Dask test.
5. f92267eabdf3ffae46bb6b5fcfbe9c9f5c1cb139 fixes a bug in `rankdata` with `method='ordinal'` in which `_rankdata` was not returning the expected number of outputs. To do this properly, I implemented the suggestion in the text: always have `_rankdata` return the same number of outputs. This makes the diff look pretty widespread, but it's quite simple and makes `_rankdata` implementation and use a lot simpler.
6. b806e85be340b6463ca2307b8dbdca64f756cd9f and 4a20589310d1c4214bf30a9b45e7d2d8fd239027 document some limitations of MArray with `cramervonmises` and `kendalltau`.

#### Additional information
-

#### AI Generation Disclosure
No AI