### PR TITLE
MAINT: stats.make_distribution: simplify creating distribution with no parameters

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -4258,7 +4258,9 @@ def _make_distribution_custom(dist):
             domain = _RealInterval(**domain_info)
             param = _RealParameter(name, domain=domain, typical=typical)
             parameters.append(param)
-        parameterizations.append(_Parameterization(*parameters) if parameters else [])
+
+        if parameters:
+            parameterizations.append(_Parameterization(*parameters))
 
     domain_info, typical = _get_domain_info(dist.support)
     _x_support = _RealInterval(**domain_info)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1515,8 +1515,8 @@ class TestMakeDistribution:
                           's': {'endpoints': (0, np.inf), 'typical': s_typical}}
             support = {'endpoints': (-np.inf, np.inf), 'typical': x_typical}
 
-            def pdf(self, x, a, b):
-                return 1 / (x * (np.log(b) - np.log(a)))
+            def pdf(self, x, u, s):
+                return 1 / np.sqrt(2*np.pi) / s * np.exp(-((x-u)/s)**2/2)
 
         family = stats.make_distribution(MyNormal())
         proportions = (1.0, 0., 0., 0.)
@@ -1525,6 +1525,24 @@ class TestMakeDistribution:
         assert u_typical[0] < np.min(dist.u) and np.max(dist.u) < u_typical[1]
         assert s_typical[0] < np.min(dist.s) and np.max(dist.s) < s_typical[1]
         assert x_typical[0] < np.min(x) and np.max(x) < x_typical[1]
+
+    @pytest.mark.parametrize('p', [None, ()])
+    def test_no_parameters(self, p):
+        # To create a distribution without parameters, it is natural to try an empty
+        # dictionary (since a dictionary with with entries is valid if there is only
+        # one parameterization), but that didn't work; only an empty tuple (no
+        # parameterizations) worked originally. Check that this is resolved.
+        class MyStandardNormal:
+            __make_distribution_version__ = "1.16.0"
+            parameters = {} if p is None else p
+            support = {'endpoints': (-np.inf, np.inf)}
+
+            def pdf(self, x):
+                return 1 / np.sqrt(2*np.pi) * np.exp(-x**2/2)
+
+        StandardNormal = stats.make_distribution(MyStandardNormal())
+        X = StandardNormal()
+        assert X.support() == (-np.inf, np.inf)
 
 
 class TestTransforms:

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1529,7 +1529,7 @@ class TestMakeDistribution:
     @pytest.mark.parametrize('p', [None, ()])
     def test_no_parameters(self, p):
         # To create a distribution without parameters, it is natural to try an empty
-        # dictionary (since a dictionary with with entries is valid if there is only
+        # dictionary (since a dictionary with entries is valid if there is only
         # one parameterization), but that didn't work; only an empty tuple (no
         # parameterizations) worked originally. Check that this is resolved.
         class MyStandardNormal:


### PR DESCRIPTION
#### Reference issue
Discovered while investigating workarounds to gh-24860.

#### What does this implement/fix?
The documentation of `make_distribution` suggest two ways of creating a distribution that accept no parameters. One is to set the `parameters` attribute to an empty tuple. The absence of dictionaries in the tuple indicates that there are no *parameterizations* at all. This works in `main`. The other is to set the `parameters` attribute to an empty dictionary. This would indicate that there is one parameterization with no parameters (since there are no key: value pairs). However, this raises an error in `main`.

This fixes the bug.

#### Additional information
-

#### AI Generation Disclosure
No AI