### PR TITLE
DOC: Add examples to sos2zpk and vectorstrength

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1445,6 +1445,47 @@ def sos2zpk(sos):
     The number of zeros and poles returned will be ``n_sections * 2``
     even if some of these are (effectively) zero.
 
+    See Also
+    --------
+    zpk2sos : Convert zeros, poles, and gain to SOS format.
+    sosfilt : Filter data using second-order sections.
+    tf2zpk : Convert transfer function to zeros, poles, and gain.
+
+    Examples
+    --------
+    Design a 4th order low-pass Butterworth digital filter with a
+    normalized cutoff frequency of 0.15 and obtain its SOS representation:
+
+    >>> from scipy import signal
+    >>> import numpy as np
+    >>> sos = signal.butter(4, 0.15, output='sos')
+
+    Convert the SOS representation to zeros, poles, and gain:
+
+    >>> z, p, k = signal.sos2zpk(sos)
+    >>> z
+    array([-1.+0.j, -1.+0.j, -1.+0.j, -1.+0.j])
+    >>> len(z)
+    4
+
+    Note that ``n_sections * 2`` zeros and poles are always returned.
+    For a 4th order filter represented as 2 second-order sections,
+    this is ``2 * 2 = 4``:
+
+    >>> len(p)
+    4
+
+    The gain of the system:
+
+    >>> k
+    0.0017826099919254043
+
+    Verify the round trip by converting back to SOS format:
+
+    >>> sos_reconstructed = signal.zpk2sos(z, p, k)
+    >>> np.allclose(sos, sos_reconstructed)
+    True
+
     .. versionadded:: 0.16.0
     """
     xp = array_namespace(sos)

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4129,6 +4129,35 @@ def vectorstrength(events, period):
         when we vary the "probing" frequency while keeping the spike times
         fixed.  Biol Cybern. 2013 Aug;107(4):491-94.
         :doi:`10.1007/s00422-013-0560-8`.
+
+    Examples
+    --------
+    Compute the vector strength for events perfectly synchronized to a
+    period of 1.0:
+
+    >>> from scipy import signal
+    >>> import numpy as np
+    >>> events = np.array([0.5, 1.5, 2.5, 3.5, 4.5])
+    >>> strength, phase = signal.vectorstrength(events, 1.0)
+    >>> strength
+    1.0
+
+    Events uniformly distributed over the period have near-zero vector
+    strength, indicating no synchronization:
+
+    >>> rng = np.random.default_rng(42)
+    >>> random_events = rng.uniform(0, 10, 1000)
+    >>> strength, phase = signal.vectorstrength(random_events, 1.0)
+    >>> strength < 0.05
+    True
+
+    When an array of periods is provided, the "resonating vector strength"
+    is computed for each period:
+
+    >>> periods = np.array([0.5, 1.0, 2.0])
+    >>> strengths, phases = signal.vectorstrength(events, periods)
+    >>> strengths
+    array([1. , 1. , 0.2])
     '''
     xp = array_namespace(events, period)
 


### PR DESCRIPTION
#### Reference issue
Addresses gh-7168 (add examples to docstrings)

#### What does this implement/fix?
- Add `Examples` section to `scipy.signal.sos2zpk` docstring with a Butterworth filter round-trip demo
- Add `Examples` section to `scipy.signal.vectorstrength` docstring showing perfect sync, random events, and resonating vector strength
- Add `See Also` section to `sos2zpk` referencing related functions

#### Additional information
- Both functions were listed in the tracking issue as missing examples
- Examples are tested against scipy 1.15.x to verify correctness of outputs
- Follows existing docstring style conventions in the signal module (see `zpk2sos` examples)

#### AI Generation Disclosure
This pull request was prepared with the assistance of Claude Code (Anthropic's CLI tool). Claude was used to draft the example code and docstring text for `sos2zpk` and `vectorstrength`. All generated code was reviewed, tested, and verified by the human contributor against scipy 1.15.x.