### PR TITLE
ENH: optimize.nnls: handle zero-dimensional edge case

### DIFF
--- a/scipy/optimize/_nnls.py
+++ b/scipy/optimize/_nnls.py
@@ -80,6 +80,9 @@ def nnls(A, b, *, maxiter=None):
                 "Incompatible dimensions. The first dimension of " +
                 f"A is {m}, while the shape of b is {(b.shape[0], )}")
 
+    if n == 0:
+        return (np.empty(0), np.linalg.norm(b))
+
     if not maxiter:
         maxiter = 3*n
     x, rnorm, info = _nnls(A, b, maxiter)

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -8,7 +8,7 @@ import pytest
 class TestNNLS:
     def setup_method(self):
         self.rng = np.random.default_rng(1685225766635251)
-
+    
     def test_nnls(self):
         a = np.arange(25.0).reshape(-1, 5)
         x = np.arange(5.0)
@@ -16,6 +16,13 @@ class TestNNLS:
         x, res = nnls(a, y)
         assert res < 1e-7
         assert np.linalg.norm((a @ x) - y) < 1e-7
+        
+    def test_nnls_empty(self):
+        a = np.zeros((2, 0))
+        y = np.ones((2,))
+        x, res = nnls(a, y)
+        assert res == np.linalg.norm(y)
+        assert x.size == 0
 
     def test_nnls_tall(self):
         a = self.rng.uniform(low=-10, high=10, size=[50, 10])

--- a/scipy/optimize/tests/test_nnls.py
+++ b/scipy/optimize/tests/test_nnls.py
@@ -8,7 +8,7 @@ import pytest
 class TestNNLS:
     def setup_method(self):
         self.rng = np.random.default_rng(1685225766635251)
-    
+
     def test_nnls(self):
         a = np.arange(25.0).reshape(-1, 5)
         x = np.arange(5.0)


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/24861 

#### What does this implement/fix?
Edge case A.shape[0] == 0 wasn't handled correctly, lead to double free crash from C code. 
This PR instead returns the empty array as solution in this case, and the unaltered norm of the right hand side as error.

#### AI Generation Disclosure
 No AI tools used
