### PR TITLE
DEP: stats.multinomial: produce NaNs for `p.sum() != 1`

### DIFF
--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -2,7 +2,6 @@
 # Author: Joris Vankerschaver 2013
 #
 import math
-import warnings
 import threading
 import types
 import numpy as np
@@ -4005,21 +4004,10 @@ class multinomial_gen(multi_rv_generic):
         """
         eps = np.finfo(np.result_type(np.asarray(p), np.float32)).eps * 10
         p = np.array(p, dtype=np.float64, copy=True)
-        p_adjusted = 1. - p[..., :-1].sum(axis=-1)
-        # only make adjustment when it's significant
-        i_adjusted = np.abs(1 - p.sum(axis=-1)) > eps
-        p[i_adjusted, -1] = p_adjusted[i_adjusted]
-
-        if np.any(i_adjusted):
-            message = ("Some rows of `p` do not sum to 1.0 within tolerance of "
-                       f"{eps=}. Currently, the last element of these rows is adjusted "
-                       "to compensate, but this condition will produce NaNs "
-                       "beginning in SciPy 1.18.0. Please ensure that rows of `p` sum "
-                       "to 1.0 to avoid futher disruption.")
-            warnings.warn(message, FutureWarning, stacklevel=3)
 
         # true for bad p
-        pcond = np.any(p < 0, axis=-1)
+        pcond = np.abs(1 - p.sum(axis=-1)) > eps
+        pcond |= np.any(p < 0, axis=-1)
         pcond |= np.any(p > 1, axis=-1)
 
         n = np.array(n, dtype=int, copy=True)
@@ -4217,6 +4205,10 @@ class multinomial_gen(multi_rv_generic):
         %(_doc_callparams_note)s
         """
         n, p, npcond = self._process_parameters(n, p)
+        if np.any(npcond):
+            message = ("`multinomial.rvs` requires `n > 0`, `(p > 0).all()`, and"
+                       "`p.sum() == 1`.")
+            raise ValueError(message)
         random_state = self._get_random_state(random_state)
         return random_state.multinomial(n, p, size)
 

--- a/scipy/stats/tests/test_multivariate.py
+++ b/scipy/stats/tests/test_multivariate.py
@@ -2554,18 +2554,16 @@ class TestMultinomial:
 
     @pytest.mark.parametrize("n", [0, 3])
     def test_rvs_np(self, n):
-        # test that .rvs agrees w/numpy
-        message = "Some rows of `p` do not sum to 1.0 within..."
-        with pytest.warns(FutureWarning, match=message):
-            rndm = np.random.RandomState(123)
-            sc_rvs = multinomial.rvs(n, [1/4.]*3, size=7, random_state=123)
-            np_rvs = rndm.multinomial(n, [1/4.]*3, size=7)
-            assert_equal(sc_rvs, np_rvs)
-        with pytest.warns(FutureWarning, match=message):
-            rndm = np.random.RandomState(123)
-            sc_rvs = multinomial.rvs(n, [1/4.]*5, size=7, random_state=123)
-            np_rvs = rndm.multinomial(n, [1/4.]*5, size=7)
-            assert_equal(sc_rvs, np_rvs)
+        # test that .rvs agrees w/numpy when `p` is valid
+        rndm = np.random.RandomState(123)
+        sc_rvs = multinomial.rvs(n, [1/3.]*3, size=7, random_state=123)
+        np_rvs = rndm.multinomial(n, [1/3.]*3, size=7)
+        assert_equal(sc_rvs, np_rvs)
+
+        rndm = np.random.RandomState(123)
+        sc_rvs = multinomial.rvs(n, [1/5.]*5, size=7, random_state=123)
+        np_rvs = rndm.multinomial(n, [1/5.]*5, size=7)
+        assert_equal(sc_rvs, np_rvs)
 
     def test_pmf(self):
         vals0 = multinomial.pmf((5,), 5, (1,))
@@ -2697,6 +2695,33 @@ class TestMultinomial:
         res1 = multinomial.pmf(x=[1, 2, 5, 7, 4], n=n, p=p)
         res2 = multinomial.pmf(x=[1, 2, 4, 5, 7], n=n, p=p)
         np.testing.assert_allclose(res1, res2, rtol=1e-15)
+
+    @pytest.mark.parametrize('psum', [0.75, 1.25])
+    def test_gh_22585(self, psum):
+        # gh-22585 warned that beginning in SciPy 1.18, rows of p that did not sum to
+        # 1.0 would produce NaNs. Check that this has been implemented.
+        rng = np.random.default_rng(8879715917488330089)
+        d, n = 5, 19  # arbitrary
+        p0 = rng.random(d)
+        p = p0 / np.sum(p0)
+        p_ = p * psum
+        x = multinomial.rvs(n=n, p=p)
+
+        assert np.all(np.isfinite(x))
+        with pytest.raises(ValueError, match="`multinomial.rvs` requires..."):
+            multinomial.rvs(n=n, p=p_)
+
+        assert np.isfinite(multinomial.pmf(x, n=n, p=p))
+        assert np.isnan(multinomial.pmf(x, n=n, p=p_))
+
+        assert np.isfinite(multinomial.pmf(x, n=n, p=p))
+        assert np.isnan(multinomial.pmf(x, n=n, p=p_))
+
+        assert np.isfinite(multinomial.entropy(n=n, p=p))
+        assert np.isnan(multinomial.entropy(n=n, p=p_))
+
+        assert np.all(np.isfinite(multinomial.cov(n=n, p=p)))
+        assert np.all(np.isnan(multinomial.cov(n=n, p=p_)))
 
 
 class TestInvwishart:


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/22585#pullrequestreview-3973631189

#### What does this implement/fix?
This implement the behavior for `p.sum() != 1` that has been slated for SciPy 1.18.0: produce NaNs rather than silently changing `p`. 

#### Additional information
`rvs` can't produce NaNs because the dtype is integral, so it raises instead (as it always has for `n < 0`, `np.any(p < 0)`, `np.any(p > 1)`, and `np.any(np.isnan(p))`).

#### AI Generation Disclosure
No AI
