### PR TITLE
MAINT: linalg.lstsq: reenable overwrite_x

### DIFF
--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1416,25 +1416,28 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     else:
         cond = float(cond)
 
-    x, residuals, rank, S, err_lst = _batched_linalg._lstsq(
+    x, rank, S, err_lst = _batched_linalg._lstsq(
         a1, b1, cond, driver, overwrite_a, overwrite_b
     )
 
     if err_lst:
         _format_emit_errors_warnings(err_lst)
 
-    if lapack_driver != "gelsy":
-        residuals = np.sum(residuals * residuals.conj(), axis=-2)
+    x1 = x[..., :n, :]
+    if m > n and lapack_driver != "gelsy":
+        residuals = np.sum(x[..., n:, :] * x[..., n:, :].conj(), axis=-2)
+    else:
+        residuals = np.zeros(batch_shape + (0,), dtype=x.dtype)
 
     if b_is_1D:
-        x = x[..., 0]
+        x1 = x1[..., 0]
         if residuals.size > 0 and lapack_driver != "gelsy":
             residuals = residuals[..., 0]
 
-    if m < n: # residuals are empty for underdetermined problems
+    if m <= n: # residuals are empty for under- and exactly determined problems
         residuals = np.zeros(batch_shape + (0,), dtype=residuals.dtype)
 
-    return x, residuals, rank, S
+    return x1, residuals, rank, S
 
 
 lstsq.default_lapack_driver = 'gelsd'

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1419,7 +1419,9 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     else:
         cond = float(cond)
 
-    x, rank, S, err_lst = _batched_linalg._lstsq(a1, b1, cond, driver, overwrite_a, overwrite_b)
+    x, rank, S, err_lst = _batched_linalg._lstsq(
+        a1, b1, cond, driver, overwrite_a, overwrite_b
+    )
 
     if err_lst:
         _format_emit_errors_warnings(err_lst)

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1406,12 +1406,20 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     a1 = np.broadcast_to(a1, batch_shape + a1.shape[-2:])
     b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
+    a_copy = np.copy(a1)
+    b_copy = np.copy(b1)
+
+    overwrite_a = overwrite_a and (a1.ndim == 2) and a1.flags["F_CONTIGUOUS"]
+    overwrite_b = (
+        overwrite_b and (b1.ndim == 2) and b1.flags["F_CONTIGUOUS"] and m >= n
+    ) # Only overwrite when overdetermined system, otherwise ldb will be > m
+
     if cond is None:
         cond = np.finfo(a1.dtype).eps
     else:
         cond = float(cond)
 
-    x, rank, S, err_lst = _batched_linalg._lstsq(a1, b1, cond, driver)
+    x, rank, S, err_lst = _batched_linalg._lstsq(a1, b1, cond, driver, overwrite_a, overwrite_b)
 
     if err_lst:
         _format_emit_errors_warnings(err_lst)
@@ -1419,7 +1427,7 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     residuals = np.asarray([], dtype=x.dtype)
     if m > n:
         # can get the residuals from the GELSS/GELSD output instead, if _really_ wanted
-        res = b1 - a1 @ x
+        res = b_copy - a_copy @ x
         residuals = np.sum(res * res.conj(), axis=len(batch_shape))
 
     if b_is_1D:

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1406,9 +1406,6 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     a1 = np.broadcast_to(a1, batch_shape + a1.shape[-2:])
     b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
-    a_copy = np.copy(a1)
-    b_copy = np.copy(b1)
-
     overwrite_a = overwrite_a and (a1.ndim == 2) and a1.flags["F_CONTIGUOUS"]
     overwrite_b = (
         overwrite_b and (b1.ndim == 2) and b1.flags["F_CONTIGUOUS"] and m >= n
@@ -1419,23 +1416,23 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     else:
         cond = float(cond)
 
-    x, rank, S, err_lst = _batched_linalg._lstsq(
+    x, residuals, rank, S, err_lst = _batched_linalg._lstsq(
         a1, b1, cond, driver, overwrite_a, overwrite_b
     )
 
     if err_lst:
         _format_emit_errors_warnings(err_lst)
 
-    residuals = np.asarray([], dtype=x.dtype)
-    if m > n:
-        # can get the residuals from the GELSS/GELSD output instead, if _really_ wanted
-        res = b_copy - a_copy @ x
-        residuals = np.sum(res * res.conj(), axis=len(batch_shape))
+    if lapack_driver != "gelsy":
+        residuals = np.sum(residuals * residuals.conj(), axis=-2)
 
     if b_is_1D:
         x = x[..., 0]
-        if residuals.size > 0:
+        if residuals.size > 0 and lapack_driver != "gelsy":
             residuals = residuals[..., 0]
+
+    if m < n: # residuals are empty for underdetermined problems
+        residuals = np.zeros(batch_shape + (0,), dtype=residuals.dtype)
 
     return x, residuals, rank, S
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1266,8 +1266,10 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     x : (N,) or (..., N, K) ndarray
         Least-squares solution.
     residues : (K,) ndarray or float
-        Square of the 2-norm for each column in ``b - a x``, if ``M > N`` (returns a
-        scalar if ``b`` is 1-D). Otherwise a (0,)-shaped array is returned.
+        If `lapack_driver` is ``'gelss'`` or ``'gelsd'`` this contains the square of
+        the 2-norm for each column in ``b - a x`` if ``M > N`` and ``rank == N``. If
+        the rank condition is violated, ``NaN`` is returned instead. If `lapack_driver`
+        if ``'gelsy'`` or ``M <= N`` a (0,)-shaped array is returned.
     rank : int
         Effective rank of `a`.
     s : (min(M, N),) ndarray or None
@@ -1426,6 +1428,9 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
     x1 = x[..., :n, :]
     if m > n and lapack_driver != "gelsy":
         residuals = np.sum(x[..., n:, :] * x[..., n:, :].conj(), axis=-2)
+
+        # LAPACK makes no promises about residuals for non full-column rank, set to NaN
+        residuals[rank < n, :] = np.nan
     else:
         residuals = np.zeros(batch_shape + (0,), dtype=x.dtype)
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -522,12 +522,14 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyObject *ret_lst = NULL, *s_ret = NULL;
     double rcond;
     const char *lapack_driver = NULL;
+    int overwrite_a = 0;
+    int overwrite_b = 0;
 
     int info = 0;
     SliceStatusVec vec_status;
 
     // Get the input array
-    if (!PyArg_ParseTuple(args, "O!O!ds", &PyArray_Type, (PyObject **)&ap_Am,  &PyArray_Type, (PyObject **)&ap_b, &rcond, &lapack_driver)) {
+    if (!PyArg_ParseTuple(args, "O!O!ds|pp", &PyArray_Type, (PyObject **)&ap_Am,  &PyArray_Type, (PyObject **)&ap_b, &rcond, &lapack_driver, &overwrite_a, &overwrite_b)) {
         return NULL;
     }
 
@@ -619,16 +621,16 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _lstsq<float>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, vec_status);
+            info = _lstsq<float>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _lstsq<double>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, vec_status);
+            info = _lstsq<double>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _lstsq<npy_complex64>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, vec_status);
+            info = _lstsq<npy_complex64>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _lstsq<npy_complex128>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, vec_status);
+            info = _lstsq<npy_complex128>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -519,6 +519,7 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyArrayObject *ap_S = NULL;
     PyArrayObject *ap_x = NULL;
     PyArrayObject *ap_rank = NULL;
+    PyArrayObject *ap_res = NULL;
     PyObject *ret_lst = NULL, *s_ret = NULL;
     double rcond;
     const char *lapack_driver = NULL;
@@ -610,6 +611,22 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
             PyErr_NoMemory();
             goto fail;
         }
+
+        shape_1[ndim - 2] = std::max(m, n) - n;
+        shape_1[ndim - 1] = nrhs;
+        ap_res = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
+        if (!ap_res) {
+            PyErr_NoMemory();
+            goto fail;
+        }
+    } else {
+        // ?gelsy does not return residuals, so just return an empty array with correct batch size.
+        shape_1[ndim - 2] = 0;
+        ap_res = (PyArrayObject *)PyArray_SimpleNew(ndim - 1, shape_1, typenum);
+        if (!ap_res) {
+            PyErr_NoMemory();
+            goto fail;
+        }
     }
 
     // rank.shape = batch_shape
@@ -621,16 +638,16 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _lstsq<float>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
+            info = _lstsq<float>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _lstsq<double>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
+            info = _lstsq<double>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _lstsq<npy_complex64>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
+            info = _lstsq<npy_complex64>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _lstsq<npy_complex128>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
+            info = _lstsq<npy_complex128>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");
@@ -646,12 +663,13 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
     // with 'gelsy', we return None for `s`
     s_ret = ap_S != NULL ? PyArray_Return(ap_S) : Py_None;
 
-    return Py_BuildValue("NNNN", PyArray_Return(ap_x), PyArray_Return(ap_rank), s_ret, ret_lst);
+    return Py_BuildValue("NNNNN", PyArray_Return(ap_x), PyArray_Return(ap_res), PyArray_Return(ap_rank), s_ret, ret_lst);
 
 fail:
     Py_XDECREF(ap_x);
     Py_XDECREF(ap_rank);
     Py_XDECREF(ap_S);
+    Py_XDECREF(ap_res);
     return NULL;
 }
 

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -519,7 +519,6 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyArrayObject *ap_S = NULL;
     PyArrayObject *ap_x = NULL;
     PyArrayObject *ap_rank = NULL;
-    PyArrayObject *ap_res = NULL;
     PyObject *ret_lst = NULL, *s_ret = NULL;
     double rcond;
     const char *lapack_driver = NULL;
@@ -580,6 +579,8 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
     npy_intp m = shape[ndim - 2];
     npy_intp n = shape[ndim - 1];
     npy_intp min_mn = m < n ? m : n;
+    CBLAS_INT max_mn = m > n ? m : n;
+    CBLAS_INT ldb = max_mn > 1 ? max_mn : 1;
     npy_intp nrhs = PyArray_DIM(ap_b, ndim-1);
 
     // Allocate the output(s)
@@ -589,12 +590,17 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
     }
 
     // x.shape = (..., N, NRHS)
-    shape_1[ndim-2] = n;
+    shape_1[ndim-2] = ldb;
     shape_1[ndim-1] = nrhs;
-    ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
-    if (!ap_x) {
-        PyErr_NoMemory();
-        goto fail;
+    if (!overwrite_b) { // Will only work if m > n, python side should have caught this.
+        ap_x = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
+        if (!ap_x) {
+            PyErr_NoMemory();
+            goto fail;
+        }
+    } else {
+        Py_INCREF(ap_b);
+        ap_x = ap_b;
     }
 
     // S array is not used by ?gelsy
@@ -611,22 +617,6 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
             PyErr_NoMemory();
             goto fail;
         }
-
-        shape_1[ndim - 2] = std::max(m, n) - n;
-        shape_1[ndim - 1] = nrhs;
-        ap_res = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
-        if (!ap_res) {
-            PyErr_NoMemory();
-            goto fail;
-        }
-    } else {
-        // ?gelsy does not return residuals, so just return an empty array with correct batch size.
-        shape_1[ndim - 2] = 0;
-        ap_res = (PyArrayObject *)PyArray_SimpleNew(ndim - 1, shape_1, typenum);
-        if (!ap_res) {
-            PyErr_NoMemory();
-            goto fail;
-        }
     }
 
     // rank.shape = batch_shape
@@ -638,16 +628,16 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     switch(typenum) {
         case(NPY_FLOAT32):
-            info = _lstsq<float>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
+            info = _lstsq<float>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_FLOAT64):
-            info = _lstsq<double>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
+            info = _lstsq<double>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX64):
-            info = _lstsq<npy_complex64>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
+            info = _lstsq<npy_complex64>(ap_Am, ap_b, ap_S, ap_x, ap_rank, (float)rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         case(NPY_COMPLEX128):
-            info = _lstsq<npy_complex128>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
+            info = _lstsq<npy_complex128>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, lapack_driver, overwrite_a, overwrite_b, vec_status);
             break;
         default:
             PyErr_SetString(PyExc_RuntimeError, "Unknown array type.");
@@ -663,13 +653,12 @@ _linalg_lstsq(PyObject* Py_UNUSED(dummy), PyObject* args) {
     // with 'gelsy', we return None for `s`
     s_ret = ap_S != NULL ? PyArray_Return(ap_S) : Py_None;
 
-    return Py_BuildValue("NNNNN", PyArray_Return(ap_x), PyArray_Return(ap_res), PyArray_Return(ap_rank), s_ret, ret_lst);
+    return Py_BuildValue("NNNN", PyArray_Return(ap_x), PyArray_Return(ap_rank), s_ret, ret_lst);
 
 fail:
     Py_XDECREF(ap_x);
     Py_XDECREF(ap_rank);
     Py_XDECREF(ap_S);
-    Py_XDECREF(ap_res);
     return NULL;
 }
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1143,6 +1143,22 @@ void extract_upper_triangle(T *dst, const T* src, const npy_intp m, const npy_in
     }
 }
 
+/*
+ * Extract the residuals returned by ?gelss and ?gelsd into a new array from.
+ * Also change from F- to C-ordered arrays.
+ *
+ * Function is reminiscent of `copy_slice_F_to_C`, but there the top part is copied, here
+ * the same is done for the bottom part.
+ */
+template<typename T>
+void extract_residuals(T *dst, const T *src, const npy_intp m, const npy_intp n, const npy_intp nrhs) {
+    for (npy_intp i = 0; i < nrhs; i++) {
+        for (npy_intp j = n; j < m; j++) {
+            dst[(j-n)*nrhs + i] = src[i * m + j];
+        }
+    }
+}
+
 
 /*
  * 1-norm of a matrix

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1143,22 +1143,6 @@ void extract_upper_triangle(T *dst, const T* src, const npy_intp m, const npy_in
     }
 }
 
-/*
- * Extract the residuals returned by ?gelss and ?gelsd into a new array from.
- * Also change from F- to C-ordered arrays.
- *
- * Function is reminiscent of `copy_slice_F_to_C`, but there the top part is copied, here
- * the same is done for the bottom part.
- */
-template<typename T>
-void extract_residuals(T *dst, const T *src, const npy_intp m, const npy_intp n, const npy_intp nrhs) {
-    for (npy_intp i = 0; i < nrhs; i++) {
-        for (npy_intp j = n; j < m; j++) {
-            dst[(j-n)*nrhs + i] = src[i * m + j];
-        }
-    }
-}
-
 
 /*
  * 1-norm of a matrix

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -4,7 +4,7 @@
 
 template<typename T>
 int
-_lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
+_lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, PyArrayObject *ap_res, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -40,6 +40,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     // Outputs
     real_type *ptr_S = (real_type *)PyArray_DATA(ap_S);
     T *ptr_x = (T *)PyArray_DATA(ap_x);
+    T *ptr_res = (T *)PyArray_DATA(ap_res);
     npy_int64 *ptr_rank = (npy_int64 *)PyArray_DATA(ap_rank);
 
     // --------------------------------------------------------------------
@@ -139,12 +140,13 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
 
         // copy results from temp buffers (S is filled in-place already)
         copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
+        extract_residuals(ptr_res, data_b, m, n, nrhs);
         *ptr_rank = (npy_int64)rank;
-        // NB: we discard the column residuals, b[n:]
 
         // advance the output pointers: S, x and rank arrays are C-ordered by construction
         ptr_S += min_mn;
         ptr_x += n*nrhs;
+        ptr_res += (max_mn - n) * nrhs;
         ptr_rank += 1;
     }
 
@@ -160,7 +162,7 @@ done:
 
 template<typename T>
 int
-_lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
+_lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, PyArrayObject *ap_res, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -190,6 +192,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     // Outputs
     real_type *ptr_S = (real_type *)PyArray_DATA(ap_S);
     T *ptr_x = (T *)PyArray_DATA(ap_x);
+    T *ptr_res = (T *)PyArray_DATA(ap_res);
     npy_int64 *ptr_rank = (npy_int64 *)PyArray_DATA(ap_rank);
 
     // --------------------------------------------------------------------
@@ -302,12 +305,13 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
 
         // copy results from temp buffers (S is filled in-place already)
         copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
+        extract_residuals(ptr_res, data_b, m, n, nrhs);
         *ptr_rank = (npy_int64)rank;
-        // XXX we discard the column residuals, b[n:]
 
-        // advance the output pointers: S, x and rank arrays are C-ordered by construction
+        // advance the output pointers: S, x, residuals and rank arrays are C-ordered by construction
         ptr_S += min_mn;
         ptr_x += n*nrhs;
+        ptr_res += (max_mn - n) * nrhs;
         ptr_rank += 1;
     }
 
@@ -322,7 +326,7 @@ done:
 
 template<typename T>
 int
-_lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
+_lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, PyArrayObject *ap_res, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -461,7 +465,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
         // copy results from temp buffers
         copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
         *ptr_rank = (npy_int64)rank;
-        // XXX we discard the column residuals, b[n:]
+        // NB. `gelsy` does not guarantee column residuals are present in b[n:] and, correspondingly, ap_res is empty.
 
         // advance the output pointers: x and rank arrays are C-ordered by construction
         ptr_x += n*nrhs;
@@ -478,17 +482,17 @@ done:
 
 template<typename T>
 int
-_lstsq(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const char * lapack_driver, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
+_lstsq(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, PyArrayObject *ap_res, double rcond, const char * lapack_driver, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     int info;
     if (strcmp(lapack_driver, "gelss") == 0) {
-        info = _lstsq_gelss<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, overwrite_a, overwrite_b, vec_status);
+        info = _lstsq_gelss<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, rcond, overwrite_a, overwrite_b, vec_status);
     }
     else if (strcmp(lapack_driver, "gelsd") == 0) {
-        info = _lstsq_gelsd<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, overwrite_a, overwrite_b, vec_status);
+        info = _lstsq_gelsd<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, rcond, overwrite_a, overwrite_b, vec_status);
     }
     else if (strcmp(lapack_driver, "gelsy") == 0) {
-        info = _lstsq_gelsy<T>(ap_Am, ap_b, ap_x, ap_rank, rcond, overwrite_a, overwrite_b, vec_status);
+        info = _lstsq_gelsy<T>(ap_Am, ap_b, ap_x, ap_rank, ap_res, rcond, overwrite_a, overwrite_b, vec_status);
     }
     else {
         // should have been validated at call site, really

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -125,7 +125,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
         if (!overwrite_b) {
             T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
             copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
-        }
+        } // NB. gelss needs LDB = max(1, m, n)
 
         // perform the least squares
         call_gelss(&intm, &intn, &int_nrhs, data_a, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, &info);
@@ -290,7 +290,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
             // copy the r.h.s, too; NB: gelsd needs LDB=max(1, m, n)
             T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
             copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
-        }
+        } // NB. gelsd needs ldb = max(1, m, n)
 
         // perform the least squares
         call_gelsd(&intm, &intn, &int_nrhs, data_a, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, iwork, &info);
@@ -447,7 +447,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
         if (!overwrite_b) {
             T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
             copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
-        }
+        } // NB. gelsy needs ldb = max(1, m, n)
 
         for(npy_intp i=0; i<n; i++) {jpvt[i] = 0;}
 

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -115,7 +115,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
         init_status(slice_status, idx, St::GENERAL);
 
         // copy the slices to `data` in F order. If `overwrite_x` is enabled the data
-        // if already in place, so no need to.
+        // is already in place, so no need to.
         if (!overwrite_a) {
             T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
             copy_slice_F(data_a, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
@@ -277,7 +277,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
         init_status(slice_status, idx, St::GENERAL);
 
         // copy data to buffers in F order. NB. `overwrite_x` is only enabled for 2D
-        // F-contigous data, so the input would already be in place.
+        // F-contiguous data, so the input would already be in place.
         if (!overwrite_a) {
             T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
             copy_slice_F(data_a, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
@@ -433,7 +433,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     for (npy_intp idx = 0; idx < outer_size; idx++){
         init_status(slice_status, idx, St::GENERAL);
 
-        // copy the slices to buffers in F order. `overwrite_x` only enabled for 2D F-contigous
+        // copy the slices to buffers in F order. `overwrite_x` only enabled for 2D F-contiguous
         // inputs, so the data is already in place then.
         if (!overwrite_a) {
             T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -4,7 +4,7 @@
 
 template<typename T>
 int
-_lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, PyArrayObject *ap_res, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
+_lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -40,7 +40,6 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     // Outputs
     real_type *ptr_S = (real_type *)PyArray_DATA(ap_S);
     T *ptr_x = (T *)PyArray_DATA(ap_x);
-    T *ptr_res = (T *)PyArray_DATA(ap_res);
     npy_int64 *ptr_rank = (npy_int64 *)PyArray_DATA(ap_rank);
 
     // --------------------------------------------------------------------
@@ -138,15 +137,15 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
             goto done;
         }
 
-        // copy results from temp buffers (S is filled in-place already)
-        copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
-        extract_residuals(ptr_res, data_b, m, n, nrhs);
+        if (!overwrite_b) {
+            // copy results from temp buffers (S is filled in-place already)
+            copy_slice_F_to_C(ptr_x, data_b, ldb, nrhs, ldb);
+        } // NB. if `overwrite_b` is true the data is already in place and should just be shrunk down at the python side.
         *ptr_rank = (npy_int64)rank;
 
         // advance the output pointers: S, x and rank arrays are C-ordered by construction
         ptr_S += min_mn;
-        ptr_x += n*nrhs;
-        ptr_res += (max_mn - n) * nrhs;
+        ptr_x += ldb*nrhs;
         ptr_rank += 1;
     }
 
@@ -162,7 +161,7 @@ done:
 
 template<typename T>
 int
-_lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, PyArrayObject *ap_res, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
+_lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -192,7 +191,6 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     // Outputs
     real_type *ptr_S = (real_type *)PyArray_DATA(ap_S);
     T *ptr_x = (T *)PyArray_DATA(ap_x);
-    T *ptr_res = (T *)PyArray_DATA(ap_res);
     npy_int64 *ptr_rank = (npy_int64 *)PyArray_DATA(ap_rank);
 
     // --------------------------------------------------------------------
@@ -303,15 +301,15 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
             goto done;
         }
 
-        // copy results from temp buffers (S is filled in-place already)
-        copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
-        extract_residuals(ptr_res, data_b, m, n, nrhs);
+        if (!overwrite_b) {
+            // copy results from temp buffers (S is filled in-place already)
+            copy_slice_F_to_C(ptr_x, data_b, ldb, nrhs, ldb);
+        } // NB. else the data is already in place
         *ptr_rank = (npy_int64)rank;
 
         // advance the output pointers: S, x, residuals and rank arrays are C-ordered by construction
         ptr_S += min_mn;
-        ptr_x += n*nrhs;
-        ptr_res += (max_mn - n) * nrhs;
+        ptr_x += ldb*nrhs;
         ptr_rank += 1;
     }
 
@@ -323,10 +321,9 @@ done:
 }
 
 
-
 template<typename T>
 int
-_lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, PyArrayObject *ap_res, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
+_lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -462,13 +459,14 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
             goto done;
         }
 
-        // copy results from temp buffers
-        copy_slice_F_to_C(ptr_x, data_b, n, nrhs, ldb);
+        if (!overwrite_b) {
+            // copy results from temp buffers
+            copy_slice_F_to_C(ptr_x, data_b, ldb, nrhs, ldb);
+        } // NB. Else the data is already in place
         *ptr_rank = (npy_int64)rank;
-        // NB. `gelsy` does not guarantee column residuals are present in b[n:] and, correspondingly, ap_res is empty.
 
         // advance the output pointers: x and rank arrays are C-ordered by construction
-        ptr_x += n*nrhs;
+        ptr_x += ldb*nrhs;
         ptr_rank += 1;
     }
 
@@ -482,17 +480,17 @@ done:
 
 template<typename T>
 int
-_lstsq(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, PyArrayObject *ap_res, double rcond, const char * lapack_driver, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
+_lstsq(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const char * lapack_driver, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     int info;
     if (strcmp(lapack_driver, "gelss") == 0) {
-        info = _lstsq_gelss<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, rcond, overwrite_a, overwrite_b, vec_status);
+        info = _lstsq_gelss<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, overwrite_a, overwrite_b, vec_status);
     }
     else if (strcmp(lapack_driver, "gelsd") == 0) {
-        info = _lstsq_gelsd<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, ap_res, rcond, overwrite_a, overwrite_b, vec_status);
+        info = _lstsq_gelsd<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, overwrite_a, overwrite_b, vec_status);
     }
     else if (strcmp(lapack_driver, "gelsy") == 0) {
-        info = _lstsq_gelsy<T>(ap_Am, ap_b, ap_x, ap_rank, ap_res, rcond, overwrite_a, overwrite_b, vec_status);
+        info = _lstsq_gelsy<T>(ap_Am, ap_b, ap_x, ap_rank, rcond, overwrite_a, overwrite_b, vec_status);
     }
     else {
         // should have been validated at call site, really

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -4,7 +4,7 @@
 
 template<typename T>
 int
-_lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, SliceStatusVec& vec_status)
+_lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -63,16 +63,42 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     lwork = _calc_lwork(tmp);
     if (lwork < 0) {return -111;}
 
-    // allocate
-    npy_intp bufsize = m*n + ldb*nrhs + lwork;
+    /*
+     * Allocate buffer and chop up into parts
+     *
+     *   lwork     data_a_size   data_b_size
+     * |---------|-------------|-------------|
+     * ^         ^             ^
+     * work      data_a        data_b
+     *
+     * - `work` is the work area, size `lwork`
+     * - `data_a` is the buffer containing the `a` matrix, size `m * n` if `overwrite_a` disabled, else 0.
+     * - `data_b` is the buffer containing the `b` matrix, size `ldb * nrhs` else 0.
+     */
+    npy_intp data_a_size = overwrite_a ? 0 : m * n;
+    npy_intp data_b_size = overwrite_b ? 0 : ldb * nrhs;
+    npy_intp bufsize = data_a_size + data_b_size + lwork;
 
     T* buffer = (T *)malloc((bufsize)*sizeof(T));
     if (NULL == buffer) { return -101; }
 
     // Chop the buffer into parts
-    T* data = &buffer[0];
-    T *data_b = &buffer[m*n];
-    T *work = &buffer[m*n + ldb*nrhs];
+    // NB. `overwrite_x` only enabled for 2D F-contiguous arrays
+    T *work = &buffer[0];
+
+    T *data_a = NULL;
+    if (!overwrite_a) {
+        data_a = &buffer[lwork];
+    } else {
+        data_a = Am_data;
+    }
+
+    T *data_b = NULL;
+    if (!overwrite_b) {
+        data_b = &buffer[lwork + data_a_size];
+    } else {
+        data_b = bm_data;
+    }
 
     real_type *rwork = NULL;
     if constexpr (sp_type_traits<T>::is_complex) {
@@ -88,16 +114,20 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     for (npy_intp idx = 0; idx < outer_size; idx++){
         init_status(slice_status, idx, St::GENERAL);
 
-        // copy the slice to `data` in F order
-        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
-        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        // copy the slices to `data` in F order. If `overwrite_x` is enabled the data
+        // if already in place, so no need to.
+        if (!overwrite_a) {
+            T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+            copy_slice_F(data_a, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        }
 
-        // copy the r.h.s, too; NB: gelss needs LDB=max(1, m, n)
-        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
-        copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
+        if (!overwrite_b) {
+            T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
+            copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
+        }
 
         // perform the least squares
-        call_gelss(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, &info);
+        call_gelss(&intm, &intn, &int_nrhs, data_a, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;
@@ -130,7 +160,7 @@ done:
 
 template<typename T>
 int
-_lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, SliceStatusVec& vec_status)
+_lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -184,20 +214,46 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
 
     if(info != 0) { return -100; }
     lwork = _calc_lwork(tmp);
-    lrwork = sp_type_traits<T>::is_complex ? _calc_lwork(tmp_lrwork) : 0 ; 
+    lrwork = sp_type_traits<T>::is_complex ? _calc_lwork(tmp_lrwork) : 0 ;
 
     if ((lwork < 0) || (lrwork < 0) || (liwork < 0)) {return -111;}
 
-    // allocate
-    npy_intp bufsize = m*n + ldb*nrhs + lwork;
+    /*
+     * Allocate buffer and chop up into parts
+     *
+     *   lwork     data_a_size   data_b_size
+     * |---------|-------------|-------------|
+     * ^         ^             ^
+     * work      data_a        data_b
+     *
+     * - `work` is the work area, size `lwork`
+     * - `data_a` is the buffer containing the `a` matrix, size `m * n` if `overwrite_a` disabled, else 0.
+     * - `data_b` is the buffer containing the `b` matrix, size `ldb * nrhs` else 0.
+     */
+    npy_intp data_a_size = overwrite_a ? 0 : m * n;
+    npy_intp data_b_size = overwrite_b ? 0 : ldb * nrhs;
+    npy_intp bufsize = data_a_size + data_b_size + lwork;
 
     T* buffer = (T *)malloc((bufsize)*sizeof(T));
     if (NULL == buffer) { return -101; }
 
     // Chop the buffer into parts
-    T* data = &buffer[0];
-    T *data_b = &buffer[m*n];
-    T *work = &buffer[m*n + ldb*nrhs];
+    // NB. `overwrite_x` is only enabled for 2D F-contiguous arrays
+    T *work = &buffer[0];
+
+    T *data_a = NULL;
+    if (!overwrite_a) {
+        data_a = &buffer[lwork];
+    } else {
+        data_a = Am_data;
+    }
+
+    T *data_b = NULL;
+    if (!overwrite_b) {
+        data_b = &buffer[lwork + data_a_size];
+    } else {
+        data_b = bm_data;
+    }
 
     real_type *rwork = NULL;
     if constexpr (sp_type_traits<T>::is_complex) {
@@ -220,16 +276,21 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     for (npy_intp idx = 0; idx < outer_size; idx++){
         init_status(slice_status, idx, St::GENERAL);
 
-        // copy the slice to `data` in F order
-        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
-        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        // copy data to buffers in F order. NB. `overwrite_x` is only enabled for 2D
+        // F-contigous data, so the input would already be in place.
+        if (!overwrite_a) {
+            T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+            copy_slice_F(data_a, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        }
 
-        // copy the r.h.s, too; NB: gelsd needs LDB=max(1, m, n)
-        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
-        copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
+        if (!overwrite_b) {
+            // copy the r.h.s, too; NB: gelsd needs LDB=max(1, m, n)
+            T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
+            copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
+        }
 
         // perform the least squares
-        call_gelsd(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, iwork, &info);
+        call_gelsd(&intm, &intn, &int_nrhs, data_a, &lda, data_b, &ldb, ptr_S, &r_rcond, &rank, work, &lwork, rwork, iwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;
@@ -261,7 +322,7 @@ done:
 
 template<typename T>
 int
-_lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, SliceStatusVec& vec_status)
+_lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
@@ -313,16 +374,41 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     lwork = _calc_lwork(tmp);
     if (lwork < 0) {return -111;}
 
-    // allocate
-    npy_intp bufsize = m*n + ldb*nrhs + lwork;
+    /*
+     * Allocate buffer and chop up into parts
+     *
+     *   lwork     data_a_size   data_b_size
+     * |---------|-------------|-------------|
+     * ^         ^             ^
+     * work      data_a        data_b
+     *
+     * - `work` is the work area, size `lwork`
+     * - `data_a` is the buffer containing the `a` matrix, size `m * n` if `overwrite_a` disabled, else 0.
+     * - `data_b` is the buffer containing the `b` matrix, size `ldb * nrhs` else 0.
+     */
+    npy_intp data_a_size = overwrite_a ? 0 : m * n;
+    npy_intp data_b_size = overwrite_b ? 0 : ldb * nrhs;
+    npy_intp bufsize = data_a_size + data_b_size + lwork;
 
     T* buffer = (T *)malloc((bufsize)*sizeof(T));
     if (NULL == buffer) { return -101; }
 
-    // Chop the buffer into parts
-    T* data = &buffer[0];
-    T *data_b = &buffer[m*n];
-    T *work = &buffer[m*n + ldb*nrhs];
+    T *work = &buffer[0];
+
+    // NB. `overwrite_x` only enabled for 2D F-contiguous inputs
+    T *data_a = NULL;
+    if (!overwrite_a) {
+        data_a = &buffer[lwork];
+    } else {
+        data_a = Am_data;
+    }
+
+    T *data_b = NULL;
+    if (!overwrite_b) {
+        data_b = &buffer[lwork + data_a_size];
+    } else {
+        data_b = bm_data;
+    }
 
     real_type *rwork = NULL;
     if constexpr (sp_type_traits<T>::is_complex) {
@@ -347,18 +433,22 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     for (npy_intp idx = 0; idx < outer_size; idx++){
         init_status(slice_status, idx, St::GENERAL);
 
-        // copy the slice to `data` in F order
-        T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
-        copy_slice_F(data, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        // copy the slices to buffers in F order. `overwrite_x` only enabled for 2D F-contigous
+        // inputs, so the data is already in place then.
+        if (!overwrite_a) {
+            T *slice_ptr = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
+            copy_slice_F(data_a, slice_ptr, m, n, strides[ndim-2], strides[ndim-1]);
+        }
 
-        // copy the r.h.s, too; NB: gelss needs LDB=max(1, m, n)
-        T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
-        copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
+        if (!overwrite_b) {
+            T *slice_ptr_b = compute_slice_ptr(idx, bm_data, ndim_b, shape_b, strides_b);
+            copy_slice_F(data_b, slice_ptr_b, m, nrhs, strides_b[ndim_b-2], strides_b[ndim_b-1], ldb);
+        }
 
         for(npy_intp i=0; i<n; i++) {jpvt[i] = 0;}
 
         // perform the least squares
-        call_gelsy(&intm, &intn, &int_nrhs, data, &lda, data_b, &ldb, jpvt, &r_rcond, &rank, work, &lwork, rwork, &info);
+        call_gelsy(&intm, &intn, &int_nrhs, data_a, &lda, data_b, &ldb, jpvt, &r_rcond, &rank, work, &lwork, rwork, &info);
 
         if(info != 0) {
             slice_status.lapack_info = (Py_ssize_t)info;
@@ -388,17 +478,17 @@ done:
 
 template<typename T>
 int
-_lstsq(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const char * lapack_driver, SliceStatusVec& vec_status)
+_lstsq(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const char * lapack_driver, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
     int info;
     if (strcmp(lapack_driver, "gelss") == 0) {
-        info = _lstsq_gelss<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, vec_status);
+        info = _lstsq_gelss<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, overwrite_a, overwrite_b, vec_status);
     }
     else if (strcmp(lapack_driver, "gelsd") == 0) {
-        info = _lstsq_gelsd<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, vec_status);
+        info = _lstsq_gelsd<T>(ap_Am, ap_b, ap_S, ap_x, ap_rank, rcond, overwrite_a, overwrite_b, vec_status);
     }
     else if (strcmp(lapack_driver, "gelsy") == 0) {
-        info = _lstsq_gelsy<T>(ap_Am, ap_b, ap_x, ap_rank, rcond, vec_status);
+        info = _lstsq_gelsy<T>(ap_Am, ap_b, ap_x, ap_rank, rcond, overwrite_a, overwrite_b, vec_status);
     }
     else {
         // should have been validated at call site, really

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2273,11 +2273,15 @@ class TestLstsq:
         x, resid, rank, s = lstsq(a, b, lapack_driver=driver)
 
         assert rank == n
-        assert resid.ndim == 0   # it's numpy scalar, in fact
 
-        delta = b - a @ x
-        manual_residuals = np.sum(delta * delta.conj(), axis=0)
-        assert math.isclose(resid, manual_residuals, abs_tol=1e-14)
+        if driver != "gelsy":
+            assert resid.ndim == 0   # it's numpy scalar, in fact
+
+            delta = b - a @ x
+            manual_residuals = np.sum(delta * delta.conj(), axis=0)
+            assert math.isclose(resid, manual_residuals, abs_tol=1e-14)
+        else:
+            assert resid.ndim == 1 and resid.size == 0
 
         # 2. b.shape == (n, nrhs)
         b2 = np.stack((b, 2*b, 3*b, 4*b), axis=1)   # b1.shape=(3, 4), nrhs=4
@@ -2285,10 +2289,14 @@ class TestLstsq:
         x2, resid2, rank2, s2 = lstsq(a, b2, lapack_driver=driver)
 
         assert rank2 == n
-        assert resid2.shape == (nrhs,)
-        delta2 = b2 - a @ x2
-        manual_residuals2 = np.sum( delta2 * delta2.conj(), axis=0 )
-        assert_allclose(resid2, manual_residuals2, atol=1e-14)
+
+        if driver != "gelsy":
+            assert resid2.shape == (nrhs,)
+            delta2 = b2 - a @ x2
+            manual_residuals2 = np.sum( delta2 * delta2.conj(), axis=0 )
+            assert_allclose(resid2, manual_residuals2, atol=1e-14)
+        else:
+            assert resid.ndim == 1 and resid.size == 0
 
         # 3. b.shape == (n,), and a has batch shape (2,)
         a3 = np.stack((a, 2*a))
@@ -2297,8 +2305,12 @@ class TestLstsq:
 
         x3, resid3, ranks3, s3 = lstsq(a3, b3, lapack_driver=driver)
         assert_equal(ranks3, np.asarray([n, n]))
-        assert resid3.shape == (n,)
-        assert_allclose(resid3, [resid]*n, atol=1e-14)
+
+        if driver != "gelsy":
+            assert resid3.shape == (n,) # XXX: ?
+            assert_allclose(resid3, [resid]*n, atol=1e-14)
+        else:
+            assert resid3.shape == (2, 0)
 
         # 4. b.shape == (n, nhrs) and a has batch shape = (2,)
         a4 = np.stack((a, 2*a))
@@ -2307,11 +2319,14 @@ class TestLstsq:
         x4, resid4, rank4, s4 = lstsq(a4, b4, lapack_driver=driver)
 
         assert_equal(rank4, np.asarray([n, n]))
-        assert resid4.shape == (2, nrhs)   # batch_shape + (nrhs,)
 
-        delta4 = b4 - a4 @ x4
-        manual_residual4 = np.sum( delta4 * delta4.conj(), axis=len(batch_shape) )
-        assert_allclose(resid4, manual_residual4, atol=1e-14)
+        if driver != "gelsy":
+            assert resid4.shape == (2, nrhs)   # batch_shape + (nrhs,)
+            delta4 = b4 - a4 @ x4
+            manual_residual4 = np.sum( delta4 * delta4.conj(), axis=len(batch_shape) )
+            assert_allclose(resid4, manual_residual4, atol=1e-14)
+        else:
+            assert resid4.shape == (2, 0)
 
     def test_errors(self):
         a = np.ones((3, 4))

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2366,7 +2366,7 @@ class TestLstsq:
             a, b, **overwrite_kw, **overwrite_b_kw, lapack_driver=driver
         )
 
-        # validate solution
+        # validate solution and residuals
         a_T = a_ref.swapaxes(-2, -1)
         if shape[-2] >= shape[-1]:
             x_ref = solve(a_T @ a_ref, a_T @ b_ref)
@@ -2374,6 +2374,13 @@ class TestLstsq:
             x_ref = a_T @ solve(a_ref @ a_T, b_ref)
 
         assert_allclose(x_ref, x, atol=1e-12)
+
+        if driver != "gelsy" and shape[-2] >= shape[-1]:
+            res_ref = a_ref @ x - b_ref
+            res_ref = np.sum(res_ref * res_ref.conj(), axis=-2)
+            assert_allclose(res_ref, res, atol=1e-12)
+        else:
+            assert_allclose(np.zeros(shape[:-2] + (0,), x.dtype), res)
 
         overwrite_a = overwrite_kw.get("overwrite_a", False)
         overwrite_a = (
@@ -2396,6 +2403,7 @@ class TestLstsq:
 
         assert np.all(a_ref == a) != overwrite_a
         assert np.all(b_ref == b) != overwrite_b
+        assert np.shares_memory(x, b) == overwrite_b
 
 
 class TestPinv:

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2328,6 +2328,41 @@ class TestLstsq:
         else:
             assert resid4.shape == (2, 0)
 
+    @pytest.mark.parametrize("driver", ["gelsd", "gelss", "gelsy"])
+    @pytest.mark.parametrize("shape_a", [(3, 2), (4, 3, 2)])
+    @pytest.mark.parametrize("shape_b", [(3,), (3, 1), (3, 5)])
+    def test_rank_deficient_residuals(self, driver, shape_a, shape_b):
+        rng = np.random.default_rng(seed=42)
+
+        # Insert one rank-deficient slice to check if `NaN` is returned
+        if len(shape_a) == 2:
+            a = np.zeros(shape_a)
+        else:
+            a = np.zeros(shape_a)
+            a[1:, :, 0] = 1
+            a[1:, :, 1:] = rng.normal(size=(shape_a[0]-1, shape_a[1], shape_a[-1]-1))
+
+        b = rng.normal(size=shape_b)
+
+        x, res, rank, _ = lstsq(a, b, lapack_driver=driver)
+
+        # Validate that the residuals are correct for full-rank slices and that `NaN` is
+        # inserted otherwise.
+        if driver != "gelsy":
+            if b.ndim == 1:
+                b = b[:, None]
+                x = x[..., None]
+                res = res[..., None]
+            res_ref = a @ x - b
+            res_ref = np.sum(res_ref * res_ref.conj(), axis=-2)
+
+            mask = rank == shape_a[-1]
+            assert_allclose(res[mask], res_ref[mask])
+            assert np.all(np.isnan(res[~mask]))
+        else:
+            assert res.shape == (a.shape[:-2] + (0,))
+
+
     def test_errors(self):
         a = np.ones((3, 4))
         b = np.ones(4)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2326,6 +2326,41 @@ class TestLstsq:
         with pytest.raises(ValueError, match="Input array"):
             lstsq(np.ones(3), np.ones(3))
 
+    @parametrize_overwrite_arg
+    @parametrize_overwrite_b_arg
+    @pytest.mark.parametrize("driver", ["gelss", "gelsd", "gelsy"])
+    @pytest.mark.parametrize("dtype", [int, float])
+    @pytest.mark.parametrize("shape", [(4, 3), (3, 4)])
+    @pytest.mark.parametrize("nrhs", [1, 5])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    def test_overwrite(
+        self, overwrite_kw, overwrite_b_kw, driver, dtype, shape, nrhs, order
+    ):
+        rng = np.random.default_rng(seed=12345)
+        a = rng.normal(size=shape).astype(dtype=dtype, order=order)
+        b = rng.normal(size=(shape[0], nrhs)).astype(dtype=dtype, order=order)
+
+        a_ref = np.copy(a)
+        b_ref = np.copy(b)
+
+        x, res, rank, S = lstsq(
+            a, b, **overwrite_kw, **overwrite_b_kw, lapack_driver=driver
+        )
+
+        overwrite_a = overwrite_kw.get("overwrite_a", False)
+        overwrite_a = overwrite_a and (dtype is not int) and a.flags["F_CONTIGUOUS"]
+
+        overwrite_b = overwrite_b_kw.get("overwrite_b", False)
+        overwrite_b = (
+            overwrite_b and
+            (dtype is not int) and
+            b.flags["F_CONTIGUOUS"] and
+            shape[0] >= shape[1]
+        )
+
+        assert np.all(a_ref == a) != overwrite_a
+        assert np.all(b_ref == b) != overwrite_b
+
 
 class TestPinv:
     def test_simple_real(self):

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2345,19 +2345,19 @@ class TestLstsq:
     @parametrize_overwrite_b_arg
     @pytest.mark.parametrize("driver", ["gelss", "gelsd", "gelsy"])
     @pytest.mark.parametrize("dtype", [int, float])
-    @pytest.mark.parametrize("shape", [(4, 3), (3, 4)])
+    @pytest.mark.parametrize("shape", [(2, 4, 3), (4, 3), (3, 4)])
     @pytest.mark.parametrize("nrhs", [1, 5])
     @pytest.mark.parametrize("order", ["C", "F"])
     def test_overwrite(
         self, overwrite_kw, overwrite_b_kw, driver, dtype, shape, nrhs, order
     ):
-        rng = np.random.default_rng(seed=12345)
+        rng = np.random.default_rng(seed=123456)
         if dtype is not int:
             a = np.asarray(rng.normal(size=shape), order=order)
-            b = np.asarray(rng.normal(size=(shape[0], nrhs)), order=order)
+            b = np.asarray(rng.normal(size=(*shape[:-1], nrhs)), order=order)
         else: # avoid issues with singularity
             a = np.asarray(rng.integers(1000, size=shape), order=order)
-            b = np.asarray(rng.integers(1000, size=(shape[0], nrhs)), order=order)
+            b = np.asarray(rng.integers(1000, size=(*shape[:-1], nrhs)), order=order)
 
         a_ref = np.copy(a)
         b_ref = np.copy(b)
@@ -2367,15 +2367,21 @@ class TestLstsq:
         )
 
         # validate solution
-        if shape[0] >= shape[1]:
-            x_ref = solve(a_ref.T @ a_ref, a_ref.T @ b_ref)
+        a_T = a_ref.swapaxes(-2, -1)
+        if shape[-2] >= shape[-1]:
+            x_ref = solve(a_T @ a_ref, a_T @ b_ref)
         else:
-            x_ref = a_ref.T @ solve(a_ref @ a_ref.T, b_ref)
+            x_ref = a_T @ solve(a_ref @ a_T, b_ref)
 
         assert_allclose(x_ref, x, atol=1e-12)
 
         overwrite_a = overwrite_kw.get("overwrite_a", False)
-        overwrite_a = overwrite_a and (dtype is not int) and a.flags["F_CONTIGUOUS"]
+        overwrite_a = (
+            overwrite_a and
+            (dtype is not int) and
+            a.flags["F_CONTIGUOUS"] and
+            a.ndim <= 2
+        )
 
         # Classical conditions: F_contiguity + should not be overwritten internally.
         # Complemented by the fact that LAPACK requires a `b` of at least `max(m, n)`,

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2337,8 +2337,12 @@ class TestLstsq:
         self, overwrite_kw, overwrite_b_kw, driver, dtype, shape, nrhs, order
     ):
         rng = np.random.default_rng(seed=12345)
-        a = rng.normal(size=shape).astype(dtype=dtype, order=order)
-        b = rng.normal(size=(shape[0], nrhs)).astype(dtype=dtype, order=order)
+        if dtype is not int:
+            a = np.asarray(rng.normal(size=shape), order=order)
+            b = np.asarray(rng.normal(size=(shape[0], nrhs)), order=order)
+        else: # avoid issues with singularity
+            a = np.asarray(rng.integers(1000, size=shape), order=order)
+            b = np.asarray(rng.integers(1000, size=(shape[0], nrhs)), order=order)
 
         a_ref = np.copy(a)
         b_ref = np.copy(b)
@@ -2347,9 +2351,20 @@ class TestLstsq:
             a, b, **overwrite_kw, **overwrite_b_kw, lapack_driver=driver
         )
 
+        # validate solution
+        if shape[0] >= shape[1]:
+            x_ref = solve(a_ref.T @ a_ref, a_ref.T @ b_ref)
+        else:
+            x_ref = a_ref.T @ solve(a_ref @ a_ref.T, b_ref)
+
+        assert_allclose(x_ref, x, atol=1e-12)
+
         overwrite_a = overwrite_kw.get("overwrite_a", False)
         overwrite_a = overwrite_a and (dtype is not int) and a.flags["F_CONTIGUOUS"]
 
+        # Classical conditions: F_contiguity + should not be overwritten internally.
+        # Complemented by the fact that LAPACK requires a `b` of at least `max(m, n)`,
+        # hence if this is not the case `b` can not be used directly.
         overwrite_b = overwrite_b_kw.get("overwrite_b", False)
         overwrite_b = (
             overwrite_b and


### PR DESCRIPTION
#### Reference issue
Towards #24645 by reimplementing `overwrite_a` and `overwrite_b` for `linalg.lstsq`. Can follow up with `qr` as well in the same PR if desired.

#### What does this implement/fix?
Reenables the `overwrite_a` and `overwrite_b` parameters in a similar fashion as was done before for other functions ported to C/C++.

#### Additional information
This is a work-in-progress, posted for early feedback.

- The logic itself should be fine, as evidenced by the added unit tests. (Which might have to be updated to also check for correctness still.)
- However, the computation of the residuals is no longer guaranteed to succeed: it is computed after the fact on the python side, but if `a` and/or `b` are also changed, there is no guarantee that this is correct. For `gelss` and `gelsd` the residuals can be extracted from LAPACK directly, but `gelsy` makes no such promises. In order to get the tests to pass I now added a copy of both `a` and `b` before sending it off to LAPACK, but that should obviously still be removed.

#### Provisory release note
> The behavior of the `residuals` returned by `lstsq` has been changed. For `lapack_driver == "gelsy"` or the system being either underdetermined or square empty residuals are still returned. For `lapack_driver == "gesld"/"gelss"` in combination with an overdetermined system a non-empty residual is always returned. However, in the case where a slice is not full column rank, the corresponding residual is set to `NaN`. 


#### AI Generation Disclosure
No AI
