### PR TITLE
ENH: integrate: add ILP64 support to _odepack and _vode extensions

### DIFF
--- a/scipy/integrate/_dzvodemodule.c
+++ b/scipy/integrate/_dzvodemodule.c
@@ -24,6 +24,10 @@
 #include "src/vode.h"
 #include "src/zvode.h"
 
+/* NPY type code matching CBLAS_INT (int or npy_int64 depending on ILP64) */
+#define CBLAS_INT_NPY (sizeof(CBLAS_INT) == 8 ? NPY_INT64 : NPY_INT)
+
+
 // Error handling macros
 #define PYERR(errobj, message) { \
     PyErr_SetString(errobj, message); \
@@ -704,7 +708,8 @@ dvode_wrapper(PyObject* Py_UNUSED(dummy), PyObject* args, PyObject* kwdict)
     int neq, itol, iopt = 1, lrw, liw;
     double *y, t, *rtol, *atol, *rwork;
     double *state_doubles = NULL;
-    int *iwork, *state_ints = NULL;
+    int *state_ints = NULL;
+    CBLAS_INT *iwork;
     dvode_callback_t callback = {0};
     vode_common_struct_t solver_state = {0};
 
@@ -767,9 +772,9 @@ dvode_wrapper(PyObject* Py_UNUSED(dummy), PyObject* args, PyObject* kwdict)
     rwork = (double*)PyArray_DATA(ap_rwork);
     lrw = (int)PyArray_SIZE(ap_rwork);
 
-    ap_iwork = (PyArrayObject*)PyArray_ContiguousFromObject(iwork_obj, NPY_INT, 1, 1);
+    ap_iwork = (PyArrayObject*)PyArray_ContiguousFromObject(iwork_obj, CBLAS_INT_NPY, 1, 1);
     if (!ap_iwork) { PYERR(PyExc_ValueError, "iwork must be a 1-D int array"); }
-    iwork = (int*)PyArray_DATA(ap_iwork);
+    iwork = (CBLAS_INT*)PyArray_DATA(ap_iwork);
     liw = (int)PyArray_SIZE(ap_iwork);
 
     // Setup callback for DVODE
@@ -935,7 +940,8 @@ zvode_wrapper(PyObject* Py_UNUSED(dummy), PyObject* args, PyObject* kwdict)
     ZVODE_CPLX_TYPE *y, *zwork;
     double t, *rtol, *atol, *rwork;
     double *state_doubles = NULL;
-    int *iwork, *state_ints = NULL;
+    int *state_ints = NULL;
+    CBLAS_INT *iwork;
     dvode_callback_t callback = {0};
     zvode_common_struct_t solver_state = {0};
 
@@ -1004,9 +1010,9 @@ zvode_wrapper(PyObject* Py_UNUSED(dummy), PyObject* args, PyObject* kwdict)
     rwork = (double*)PyArray_DATA(ap_rwork);
     lrw = (int)PyArray_SIZE(ap_rwork);
 
-    ap_iwork = (PyArrayObject*)PyArray_ContiguousFromObject(iwork_obj, NPY_INT, 1, 1);
+    ap_iwork = (PyArrayObject*)PyArray_ContiguousFromObject(iwork_obj, CBLAS_INT_NPY, 1, 1);
     if (!ap_iwork) { PYERR(PyExc_ValueError, "iwork must be a 1-D int array"); }
-    iwork = (int*)PyArray_DATA(ap_iwork);
+    iwork = (CBLAS_INT*)PyArray_DATA(ap_iwork);
     liw = (int)PyArray_SIZE(ap_iwork);
 
     // Setup callback for ZVODE

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -87,10 +87,13 @@ import warnings
 import numpy as np
 from numpy import asarray, array, zeros, isscalar, real, imag
 
+from scipy.linalg.blas import HAS_ILP64
+
 from . import _vode
 from . import _dop
 from ._odepack import lsoda as lsoda_step
 
+_iwork_dtype = np.int64 if HAS_ILP64 else np.int32
 
 # ------------------------------------------------------------------------------
 # User interface
@@ -955,7 +958,7 @@ class vode(IntegratorBase):
         rwork[6] = self.min_step
         self.rwork = rwork
 
-        iwork = zeros((liw,), dtype=np.int32)
+        iwork = zeros((liw,), dtype=_iwork_dtype)
         if self.ml is not None:
             iwork[0] = self.ml
         if self.mu is not None:
@@ -1080,7 +1083,7 @@ class zvode(vode):
         rwork[6] = self.min_step
         self.rwork = rwork
 
-        iwork = zeros((liw,), np.int32)
+        iwork = zeros((liw,), _iwork_dtype)
         if self.ml is not None:
             iwork[0] = self.ml
         if self.mu is not None:
@@ -1333,7 +1336,7 @@ class lsoda(IntegratorBase):
         rwork[6] = self.min_step
         self.rwork = rwork
 
-        iwork = zeros((liw,), dtype=np.int32)
+        iwork = zeros((liw,), dtype=_iwork_dtype)
         if self.ml is not None:
             iwork[0] = self.ml
         if self.mu is not None:

--- a/scipy/integrate/_odepackmodule.c
+++ b/scipy/integrate/_odepackmodule.c
@@ -8,13 +8,8 @@
 #include <string.h>
 #define PyArray_MAX(a,b) (((a)>(b))?(a):(b))
 
-#ifdef HAVE_BLAS_ILP64
-#define F_INT npy_int64
-#define F_INT_NPY NPY_INT64
-#else
-#define F_INT int
-#define F_INT_NPY NPY_INT
-#endif
+/* NPY type code matching CBLAS_INT (int or npy_int64 depending on ILP64) */
+#define CBLAS_INT_NPY (sizeof(CBLAS_INT) == 8 ? NPY_INT64 : NPY_INT)
 
 
 #define PYERR(errobj,message) {\
@@ -587,7 +582,8 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
     PyArrayObject *ap_tout = NULL;
     PyObject *extra_args = NULL;
     PyObject *Dfun = Py_None;
-    int neq, itol = 1, itask = 1, istate = 1, iopt = 0, lrw, *iwork, liw, jt = 4;
+    int neq, itol = 1, itask = 1, istate = 1, iopt = 0, lrw, liw, jt = 4;
+    CBLAS_INT *iwork;
     double *y, t, *tout, *rtol, *atol, *rwork;
     double h0 = 0.0, hmax = 0.0, hmin = 0.0;
     long ixpr = 0, mxstep = 0, mxhnil = 0, mxordn = 12, mxords = 5, ml = -1, mu = -1;
@@ -713,13 +709,13 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
         goto fail;
     }
 
-    if ((wa = (double *)calloc(lrw*sizeof(double) + liw*sizeof(int), 1))==NULL) {
+    if ((wa = (double *)calloc(lrw*sizeof(double) + liw*sizeof(CBLAS_INT), 1))==NULL) {
         PyErr_NoMemory();
         goto fail;
     }
     allocated = 1;
     rwork = wa;
-    iwork = (int *)(wa + lrw);
+    iwork = (CBLAS_INT *)((char *)(wa + lrw));
 
     iwork[0] = ml;
     iwork[1] = mu;
@@ -795,20 +791,20 @@ odepack_odeint(PyObject *dummy, PyObject *args, PyObject *kwdict)
             *((double *)PyArray_DATA(ap_tcur) + (k-1)) = rwork[12];
             *((double *)PyArray_DATA(ap_tolsf) + (k-1)) = rwork[13];
             *((double *)PyArray_DATA(ap_tsw) + (k-1)) = rwork[14];
-            *((int *)PyArray_DATA(ap_nst) + (k-1)) = iwork[10];
-            *((int *)PyArray_DATA(ap_nfe) + (k-1)) = iwork[11];
-            *((int *)PyArray_DATA(ap_nje) + (k-1)) = iwork[12];
-            *((int *)PyArray_DATA(ap_nqu) + (k-1)) = iwork[13];
+            *((int *)PyArray_DATA(ap_nst) + (k-1)) = (int)iwork[10];
+            *((int *)PyArray_DATA(ap_nfe) + (k-1)) = (int)iwork[11];
+            *((int *)PyArray_DATA(ap_nje) + (k-1)) = (int)iwork[12];
+            *((int *)PyArray_DATA(ap_nqu) + (k-1)) = (int)iwork[13];
 
             if (istate == -5 || istate == -4) {
-                imxer = iwork[15];
+                imxer = (int)iwork[15];
             } else {
                 imxer = -1;
             }
 
-            lenrw = iwork[16];
-            leniw = iwork[17];
-            *((int *)PyArray_DATA(ap_mused) + (k-1)) = iwork[18];
+            lenrw = (int)iwork[16];
+            leniw = (int)iwork[17];
+            *((int *)PyArray_DATA(ap_mused) + (k-1)) = (int)iwork[18];
         }
 
         // copy integration result to output
@@ -904,7 +900,8 @@ odepack_lsoda_step(PyObject *dummy, PyObject *args, PyObject *kwdict)
 
     double *y, t, tout, *rtol, *atol, *rwork;
     double *state_doubles = NULL;
-    int *iwork, *state_ints = NULL;
+    int *state_ints = NULL;
+    CBLAS_INT *iwork;
     int neq, itol, itask, istate, iopt, lrw, liw, jt;
     long tfirst = 0;
 
@@ -1022,12 +1019,12 @@ odepack_lsoda_step(PyObject *dummy, PyObject *args, PyObject *kwdict)
     rwork = (double *) PyArray_DATA(ap_rwork);
 
     // Get iwork array
-    ap_iwork = (PyArrayObject *) PyArray_ContiguousFromObject((PyObject*)ap_iwork, F_INT_NPY, 1, 1);
+    ap_iwork = (PyArrayObject *) PyArray_ContiguousFromObject((PyObject*)ap_iwork, CBLAS_INT_NPY, 1, 1);
     if (ap_iwork == NULL) {
         goto fail;
     }
     liw = PyArray_DIM(ap_iwork, 0);
-    iwork = (int *) PyArray_DATA(ap_iwork);
+    iwork = (CBLAS_INT *) PyArray_DATA(ap_iwork);
 
     // Get state arrays if provided (optional for backward compatibility)
     if (ap_state_doubles != NULL) {
@@ -1047,7 +1044,7 @@ odepack_lsoda_step(PyObject *dummy, PyObject *args, PyObject *kwdict)
 
     if (ap_state_ints != NULL) {
         ap_state_ints = (PyArrayObject *) PyArray_ContiguousFromObject(
-            (PyObject*)ap_state_ints, F_INT_NPY, 1, 1);
+            (PyObject*)ap_state_ints, NPY_INT, 1, 1);
         if (ap_state_ints == NULL) {
             goto fail;
         }

--- a/scipy/integrate/meson.build
+++ b/scipy/integrate/meson.build
@@ -8,7 +8,8 @@ py3.extension_module('_quadpack',
 py3.extension_module('_odepack',
   ['_odepackmodule.c', 'src/lsoda.c'],
   link_args: version_link_args,
-  dependencies: [lapack_lp64_dep, np_dep, ccallback_dep],
+  dependencies: [lapack_dep, np_dep, ccallback_dep],
+  include_directories: ['../_build_utils/src'],
   install: true,
   subdir: 'scipy/integrate'
 )
@@ -16,7 +17,8 @@ py3.extension_module('_odepack',
 py3.extension_module('_vode',
   ['_dzvodemodule.c', 'src/vode.c', 'src/zvode.c'],
   link_args: version_link_args,
-  dependencies: [lapack_lp64_dep, np_dep, ccallback_dep],
+  dependencies: [lapack_dep, np_dep, ccallback_dep],
+  include_directories: ['../_build_utils/src'],
   install: true,
   subdir: 'scipy/integrate'
 )

--- a/scipy/integrate/src/blaslapack_declarations.h
+++ b/scipy/integrate/src/blaslapack_declarations.h
@@ -2,6 +2,8 @@
 #define BLASLAPACK_DECLARATIONS_H
 
 #include <complex.h>
+#include "npy_cblas.h"
+
 #if defined(_MSC_VER)
     // MSVC definition
     typedef _Dcomplex ZVODE_CPLX_TYPE;
@@ -14,21 +16,21 @@
 #endif
 
 
-void daxpy_(int* n, double* a, double* x, int* incx, double* y, int* incy);
-void dcopy_(int* n, double* x, int* incx, double* y, int* incy);
-void dscal_(int* n, double* a, double* x, int* incx);
-void dgbtrf_(int* m, int* n, int* kl, int* ku, double* ab, int* ldab, int* ipiv, int* info);
-void dgbtrs_(char* trans, int* n, int* kl, int* ku, int* nrhs, double* ab, int* ldab, int* ipiv, double* b, int* ldb, int* info);
-void dgetrf_(int* m, int* n, double* a, int* lda, int* ipiv, int* info);
-void dgetrs_(char* trans, int* n, int* nrhs, double* a, int* lda, int* ipiv, double* b, int* ldb, int* info);
+void BLAS_FUNC(daxpy)(CBLAS_INT* n, double* a, double* x, CBLAS_INT* incx, double* y, CBLAS_INT* incy);
+void BLAS_FUNC(dcopy)(CBLAS_INT* n, double* x, CBLAS_INT* incx, double* y, CBLAS_INT* incy);
+void BLAS_FUNC(dscal)(CBLAS_INT* n, double* a, double* x, CBLAS_INT* incx);
+void BLAS_FUNC(dgbtrf)(CBLAS_INT* m, CBLAS_INT* n, CBLAS_INT* kl, CBLAS_INT* ku, double* ab, CBLAS_INT* ldab, CBLAS_INT* ipiv, CBLAS_INT* info);
+void BLAS_FUNC(dgbtrs)(char* trans, CBLAS_INT* n, CBLAS_INT* kl, CBLAS_INT* ku, CBLAS_INT* nrhs, double* ab, CBLAS_INT* ldab, CBLAS_INT* ipiv, double* b, CBLAS_INT* ldb, CBLAS_INT* info);
+void BLAS_FUNC(dgetrf)(CBLAS_INT* m, CBLAS_INT* n, double* a, CBLAS_INT* lda, CBLAS_INT* ipiv, CBLAS_INT* info);
+void BLAS_FUNC(dgetrs)(char* trans, CBLAS_INT* n, CBLAS_INT* nrhs, double* a, CBLAS_INT* lda, CBLAS_INT* ipiv, double* b, CBLAS_INT* ldb, CBLAS_INT* info);
 
 // For ZVODE complex routines
-void zaxpy_(int* n, ZVODE_CPLX_TYPE* a, ZVODE_CPLX_TYPE* x, int* incx, ZVODE_CPLX_TYPE* y, int* incy);
-void zcopy_(int* n, ZVODE_CPLX_TYPE* x, int* incx, ZVODE_CPLX_TYPE* y, int* incy);
-void zscal_(int* n, ZVODE_CPLX_TYPE* a, ZVODE_CPLX_TYPE* x, int* incx);
-void zgbtrf_(int* m, int* n, int* kl, int* ku, ZVODE_CPLX_TYPE* ab, int* ldab, int* ipiv, int* info);
-void zgbtrs_(char* trans, int* n, int* kl, int* ku, int* nrhs, ZVODE_CPLX_TYPE* ab, int* ldab, int* ipiv, ZVODE_CPLX_TYPE* b, int* ldb, int* info);
-void zgetrf_(int* m, int* n, ZVODE_CPLX_TYPE* a, int* lda, int* ipiv, int* info);
-void zgetrs_(char* trans, int* n, int* nrhs, ZVODE_CPLX_TYPE* a, int* lda, int* ipiv, ZVODE_CPLX_TYPE* b, int* ldb, int* info);
+void BLAS_FUNC(zaxpy)(CBLAS_INT* n, ZVODE_CPLX_TYPE* a, ZVODE_CPLX_TYPE* x, CBLAS_INT* incx, ZVODE_CPLX_TYPE* y, CBLAS_INT* incy);
+void BLAS_FUNC(zcopy)(CBLAS_INT* n, ZVODE_CPLX_TYPE* x, CBLAS_INT* incx, ZVODE_CPLX_TYPE* y, CBLAS_INT* incy);
+void BLAS_FUNC(zscal)(CBLAS_INT* n, ZVODE_CPLX_TYPE* a, ZVODE_CPLX_TYPE* x, CBLAS_INT* incx);
+void BLAS_FUNC(zgbtrf)(CBLAS_INT* m, CBLAS_INT* n, CBLAS_INT* kl, CBLAS_INT* ku, ZVODE_CPLX_TYPE* ab, CBLAS_INT* ldab, CBLAS_INT* ipiv, CBLAS_INT* info);
+void BLAS_FUNC(zgbtrs)(char* trans, CBLAS_INT* n, CBLAS_INT* kl, CBLAS_INT* ku, CBLAS_INT* nrhs, ZVODE_CPLX_TYPE* ab, CBLAS_INT* ldab, CBLAS_INT* ipiv, ZVODE_CPLX_TYPE* b, CBLAS_INT* ldb, CBLAS_INT* info);
+void BLAS_FUNC(zgetrf)(CBLAS_INT* m, CBLAS_INT* n, ZVODE_CPLX_TYPE* a, CBLAS_INT* lda, CBLAS_INT* ipiv, CBLAS_INT* info);
+void BLAS_FUNC(zgetrs)(char* trans, CBLAS_INT* n, CBLAS_INT* nrhs, ZVODE_CPLX_TYPE* a, CBLAS_INT* lda, CBLAS_INT* ipiv, ZVODE_CPLX_TYPE* b, CBLAS_INT* ldb, CBLAS_INT* info);
 
 #endif

--- a/scipy/integrate/src/lsoda.c
+++ b/scipy/integrate/src/lsoda.c
@@ -283,10 +283,11 @@ cfode(const int meth, double* elco, double* tesco)
 static void
 prja(
     int* neq, double* y, double* yh, int nyh, double* ewt, double* ftem, double* savf,
-    double* wm, int* iwm, lsoda_func_t f, lsoda_jac_t jac, lsoda_common_struct_t* S)
+    double* wm, CBLAS_INT* iwm, lsoda_func_t f, lsoda_jac_t jac, lsoda_common_struct_t* S)
 {
     (void)nyh;
-    int ier = 0, lenp, mba, mband, meband, ml, ml2, mu;
+    CBLAS_INT ier = 0;
+    int lenp, mba, mband, meband, ml, ml2, mu;
     S->nje += 1;
     S->ierpj = 0;
     S->jcur = 1;
@@ -358,7 +359,7 @@ prja(
         // 250
 
         // LU decomposition of P
-        dgetrf_(&S->n, &S->n, &wm[2], &S->n, &iwm[20], &ier);
+        BLAS_FUNC(dgetrf)(&(CBLAS_INT){S->n}, &(CBLAS_INT){S->n}, &wm[2], &(CBLAS_INT){S->n}, &iwm[20], &ier);
         if (ier != 0) { S->ierpj = 1; }
         return;
     }
@@ -446,7 +447,7 @@ prja(
     }
     // 580
     // LU decomposition of P
-    dgbtrf_(&S->n, &S->n, &ml, &mu, &wm[2], &meband, &iwm[20], &ier);
+    BLAS_FUNC(dgbtrf)(&(CBLAS_INT){S->n}, &(CBLAS_INT){S->n}, &(CBLAS_INT){ml}, &(CBLAS_INT){mu}, &wm[2], &(CBLAS_INT){meband}, &iwm[20], &ier);
     if (ier != 0) { S->ierpj = 1; }
     return;
 
@@ -479,15 +480,15 @@ prja(
  * This routine also uses the common variables el0, h, miter, and n.
  */
 static void
-solsy(double* wm, int* iwm, double* x, double* tem, lsoda_common_struct_t* S)
+solsy(double* wm, CBLAS_INT* iwm, double* x, double* tem, lsoda_common_struct_t* S)
 {
     (void)tem;  // tem is not used in this version
-    int int1 = 1, ierr = 0;
+    CBLAS_INT int1 = 1, ierr = 0;
     S->iersl = 0;
 
     if ((S->miter == 1) || (S->miter == 2))
     {
-        dgetrs_("N", &S->n, &int1, &wm[2], &S->n, &iwm[20], x, &S->n, &ierr);
+        BLAS_FUNC(dgetrs)("N", &(CBLAS_INT){S->n}, &int1, &wm[2], &(CBLAS_INT){S->n}, &iwm[20], x, &(CBLAS_INT){S->n}, &ierr);
         return;
     } else if (S->miter == 3) {
         double phl0 = wm[1];
@@ -514,10 +515,10 @@ solsy(double* wm, int* iwm, double* x, double* tem, lsoda_common_struct_t* S)
         }
         // 340
     } else if ((S->miter == 4) || (S->miter == 5)) {
-        int ml = iwm[0];
-        int mu = iwm[1];
+        int ml = (int)iwm[0];
+        int mu = (int)iwm[1];
         int meband = 2*ml + mu + 1;
-        dgbtrs_("N", &S->n, &ml, &mu, &int1, &wm[2], &meband, &iwm[20], x, &S->n, &ierr);
+        BLAS_FUNC(dgbtrs)("N", &(CBLAS_INT){S->n}, &(CBLAS_INT){ml}, &(CBLAS_INT){mu}, &int1, &wm[2], &(CBLAS_INT){meband}, &iwm[20], x, &(CBLAS_INT){S->n}, &ierr);
     }
 
     return;
@@ -661,7 +662,7 @@ typedef enum lsoda_corrector_status {
 static lsoda_corrector_status_t
 stoda_corrector_loop(
     int* neq, double* y, double* yh, int nyh, double* ewt,
-    double* savf, double* acor, double* wm, int* iwm, lsoda_func_t f,
+    double* savf, double* acor, double* wm, CBLAS_INT* iwm, lsoda_func_t f,
     lsoda_jac_t jac, double pnorm, int* m_out, double* del_out, lsoda_common_struct_t* S)
 {
     // Up to maxcor corrector iterations are taken. A convergence test is
@@ -926,7 +927,7 @@ stoda_get_predicted_values(lsoda_common_struct_t* S, double* yh1)
 static void
 stoda(
     int* neq, double* y, double* yh, int nyh, double* ewt,
-    double* savf, double* acor, double* wm, int* iwm, lsoda_func_t f,
+    double* savf, double* acor, double* wm, CBLAS_INT* iwm, lsoda_func_t f,
     lsoda_jac_t jac, lsoda_common_struct_t* S)
 {
     const double sm1[12] = {0.5, 0.575, 0.55, 0.45, 0.35, 0.25, 0.20, 0.15, 0.10, 0.075, 0.050, 0.025};
@@ -1606,7 +1607,7 @@ void lsoda_mark_error(int* istate, int* illin)
  */
 void lsoda(
     lsoda_func_t f, int neq, double* restrict y, double* t, double* tout, int itol, double* rtol, double* atol,
-    int* itask, int* istate, int* iopt, double* restrict rwork, int lrw, int* restrict iwork, int liw, lsoda_jac_t jac,
+    int* itask, int* istate, int* iopt, double* restrict rwork, int lrw, CBLAS_INT* restrict iwork, int liw, lsoda_jac_t jac,
     const int jt, lsoda_common_struct_t* S)
 {
 

--- a/scipy/integrate/src/lsoda.h
+++ b/scipy/integrate/src/lsoda.h
@@ -75,7 +75,7 @@ lsoda(
     int* iopt,
     double* restrict rwork,
     int lrw,
-    int* restrict iwork,
+    CBLAS_INT* restrict iwork,
     int liw,
     lsoda_jac_t jac,
     const int jt,

--- a/scipy/integrate/src/vode.c
+++ b/scipy/integrate/src/vode.c
@@ -316,7 +316,7 @@ dvjust(double* restrict yh, const int ldyh, const int iord, vode_common_struct_t
                 // Add correction terms to YH array.
                 int nqp1 = S->nq + 1;
                 for (int j = 2; j < nqp1; j++) {
-                    daxpy_(&S->n, &S->el[j], &yh[0 + (lp1 - 1) * ldyh], &(int){1}, &yh[0 + j * ldyh], &(int){1});
+                    BLAS_FUNC(daxpy)(&(CBLAS_INT){S->n}, &S->el[j], &yh[0 + (lp1 - 1) * ldyh], &(CBLAS_INT){1}, &yh[0 + j * ldyh], &(CBLAS_INT){1});
                 }
             } else {
                 // Order decrease
@@ -562,8 +562,8 @@ dvindy(
 
     // Scale by H**(-K)
     double r = pow(S->h, -k);
-    int int1 = 1;
-    dscal_(&S->n, &r, dky, &int1);
+    CBLAS_INT int1 = 1;
+    BLAS_FUNC(dscal)(&(CBLAS_INT){S->n}, &r, dky, &int1);
 
     return;
 }
@@ -584,17 +584,17 @@ dvindy(
  * @param iersl  Error flag: 0=success, 1=singular matrix (miter=3)
  */
 static void
-dvsol(vode_common_struct_t* S, double* restrict wm, int* restrict iwm, double* restrict x, int* iersl)
+dvsol(vode_common_struct_t* S, double* restrict wm, CBLAS_INT* restrict iwm, double* restrict x, int* iersl)
 {
     *iersl = 0;
-    int ier = 0;
-    int int1 = 1;
+    CBLAS_INT ier = 0;
+    CBLAS_INT int1 = 1;
 
     switch (S->miter)
     {
         case 1:
         case 2: {
-            dgetrs_("N", &S->n, &int1, &wm[2], &S->n, &iwm[30], x, &S->n, &ier);
+            BLAS_FUNC(dgetrs)("N", &(CBLAS_INT){S->n}, &int1, &wm[2], &(CBLAS_INT){S->n}, &iwm[30], x, &(CBLAS_INT){S->n}, &ier);
             break;
         }
         case 3: {
@@ -619,10 +619,10 @@ dvsol(vode_common_struct_t* S, double* restrict wm, int* restrict iwm, double* r
         }
         case 4:
         case 5: {
-            int ml = iwm[0];
-            int mu = iwm[1];
-            int meband = 2 * ml + mu + 1;
-            dgbtrs_("N", &S->n, &ml, &mu, &int1, &wm[2], &meband, &iwm[30], x, &S->n, &ier);
+            CBLAS_INT ml = iwm[0];
+            CBLAS_INT mu = iwm[1];
+            CBLAS_INT meband = 2 * ml + mu + 1;
+            BLAS_FUNC(dgbtrs)("N", &(CBLAS_INT){S->n}, &ml, &mu, &int1, &wm[2], &meband, &iwm[30], x, &(CBLAS_INT){S->n}, &ier);
             break;
         }
     }
@@ -731,7 +731,7 @@ dvjac(
     double* restrict ftem,
     double* restrict savf,
     double* restrict wm,
-    int* restrict iwm,
+    CBLAS_INT* restrict iwm,
     vode_func_t f,
     vode_jac_t jac,
     int* ierpj,
@@ -757,13 +757,13 @@ dvjac(
         S->nje += 1;
         S->nslj = S->nst;
         S->jcur = 1;
-        int lenp = S->n * S->n;
+        CBLAS_INT lenp = S->n * S->n;
         for (int i = 0; i < lenp; i++) {
             wm[i + 2] = 0.0;
         }
         jac(S->n, S->tn, y, 0, 0, &wm[2], S->n, rpar, ipar);
         if (S->jsv == 1) {
-            dcopy_(&lenp, &wm[2], &(int){1}, &wm[S->locjs - 1], &(int){1});
+            BLAS_FUNC(dcopy)(&lenp, &wm[2], &(CBLAS_INT){1}, &wm[S->locjs - 1], &(CBLAS_INT){1});
         }
     }
 
@@ -790,30 +790,30 @@ dvjac(
             j1 += S->n;
         }
         S->nfe += S->n;
-        int lenp = S->n * S->n;
+        CBLAS_INT lenp = S->n * S->n;
         if (S->jsv == 1) {
-            dcopy_(&lenp, &wm[2], &(int){1}, &wm[S->locjs - 1], &(int){1});
+            BLAS_FUNC(dcopy)(&lenp, &wm[2], &(CBLAS_INT){1}, &wm[S->locjs - 1], &(CBLAS_INT){1});
         }
     }
 
     if ((jok == 1) && ((S->miter == 1) || (S->miter == 2))) {
         S->jcur = 0;
-        int lenp = S->n * S->n;
-        dcopy_(&lenp, &wm[S->locjs - 1], &(int){1}, &wm[2], &(int){1});
+        CBLAS_INT lenp = S->n * S->n;
+        BLAS_FUNC(dcopy)(&lenp, &wm[S->locjs - 1], &(CBLAS_INT){1}, &wm[2], &(CBLAS_INT){1});
     }
 
     if ((S->miter == 1) || (S->miter == 2)) {
         // Multiply Jacobian by scalar, add identity, and do LU factorization.
-        int lenp = S->n * S->n;
-        dscal_(&lenp, &(double){-hrl1}, &wm[2], &(int){1});
+        CBLAS_INT lenp = S->n * S->n;
+        BLAS_FUNC(dscal)(&lenp, &(double){-hrl1}, &wm[2], &(CBLAS_INT){1});
         int j = 2;
         for (int i = 0; i < S->n; i++) {
             wm[j] += 1.0;
             j += S->n + 1;
         }
         S->nlu += 1;
-        int ier = 0;
-        dgetrf_(&S->n, &S->n, &wm[2], &S->n, &iwm[30], &ier);
+        CBLAS_INT ier = 0;
+        BLAS_FUNC(dgetrf)(&(CBLAS_INT){S->n}, &(CBLAS_INT){S->n}, &wm[2], &(CBLAS_INT){S->n}, &iwm[30], &ier);
         if (ier != 0) {
             *ierpj = 1;
         }
@@ -848,12 +848,12 @@ dvjac(
     }
 
     // Set constants for MITER = 4 or 5.
-    int ml = iwm[0];
-    int mu = iwm[1];
-    int ml3 = ml + 3;
-    int mband = ml + mu + 1;
-    int meband = mband + ml;
-    int lenp = meband * S->n;
+    CBLAS_INT ml = iwm[0];
+    CBLAS_INT mu = iwm[1];
+    int ml3 = (int)ml + 3;
+    CBLAS_INT mband = ml + mu + 1;
+    CBLAS_INT meband = mband + ml;
+    CBLAS_INT lenp = meband * S->n;
 
     if ((jok == -1) && (S->miter == 4)) {
         // If JOK = -1 and MITER = 4, call JAC to evaluate Jacobian.
@@ -863,12 +863,12 @@ dvjac(
         for (int i = 0; i < lenp; i++) {
             wm[i + 2] = 0.0;
         }
-        jac(S->n, S->tn, y, ml, mu, &wm[ml3 - 1], meband, rpar, ipar);
+        jac(S->n, S->tn, y, (int)ml, (int)mu, &wm[ml3 - 1], (int)meband, rpar, ipar);
         if (S->jsv == 1) {
             // Call DACOPY equivalent - copy banded matrix
             for (int ic = 0; ic < S->n; ic++) {
-                dcopy_(&mband, &wm[ml3 - 1 + ic * meband], &(int){1},
-                       &wm[S->locjs - 1 + ic * mband], &(int){1});
+                BLAS_FUNC(dcopy)(&mband, &wm[ml3 - 1 + ic * meband], &(CBLAS_INT){1},
+                       &wm[S->locjs - 1 + ic * mband], &(CBLAS_INT){1});
             }
         }
     }
@@ -878,8 +878,8 @@ dvjac(
         S->nje += 1;
         S->nslj = S->nst;
         S->jcur = 1;
-        int mba = int_min(mband, S->n);
-        int meb1 = meband - 1;
+        int mba = int_min((int)mband, S->n);
+        int meb1 = (int)meband - 1;
         double srur = wm[0];
         double fac = dvnorm(S->n, savf, ewt);
         double r0 = 1000.0 * fabs(S->h) * S->uround * (double)(S->n) * fac;
@@ -896,9 +896,9 @@ dvjac(
                 double yjj = y[jj];
                 double r = fmax(srur * fabs(yjj), r0 / ewt[jj]);
                 fac = 1.0 / r;
-                int i1 = int_max(jj - mu, 0);
-                int i2 = int_min(jj + ml, S->n - 1);
-                int ii = (jj + 1) * meb1 - ml + 2;
+                int i1 = int_max(jj - (int)mu, 0);
+                int i2 = int_min(jj + (int)ml, S->n - 1);
+                int ii = (jj + 1) * meb1 - (int)ml + 2;
                 for (int i = i1; i <= i2; i++) {
                     wm[ii + i] = (ftem[i] - savf[i]) * fac;
                 }
@@ -908,7 +908,7 @@ dvjac(
         if (S->jsv == 1) {
             // Call DACOPY equivalent
             for (int ic = 0; ic < S->n; ic++) {
-                dcopy_(&mband, &wm[ml3 - 1 + ic * meband], &(int){1}, &wm[S->locjs - 1 + ic * mband], &(int){1});
+                BLAS_FUNC(dcopy)(&mband, &wm[ml3 - 1 + ic * meband], &(CBLAS_INT){1}, &wm[S->locjs - 1 + ic * mband], &(CBLAS_INT){1});
             }
         }
     }
@@ -917,21 +917,21 @@ dvjac(
         S->jcur = 0;
         // Call DACOPY equivalent
         for (int ic = 0; ic < S->n; ic++) {
-            dcopy_(&mband, &wm[S->locjs - 1 + ic * mband], &(int){1}, &wm[ml3 - 1 + ic * meband], &(int){1});
+            BLAS_FUNC(dcopy)(&mband, &wm[S->locjs - 1 + ic * mband], &(CBLAS_INT){1}, &wm[ml3 - 1 + ic * meband], &(CBLAS_INT){1});
         }
     }
 
     // Multiply Jacobian by scalar, add identity, and do LU decomposition.
     double con = -hrl1;
-    dscal_(&lenp, &con, &wm[2], &(int){1});
-    int ii = mband + 1;
+    BLAS_FUNC(dscal)(&lenp, &con, &wm[2], &(CBLAS_INT){1});
+    int ii = (int)mband + 1;
     for (int i = 0; i < S->n; i++) {
         wm[ii] += 1.0;
         ii += meband;
     }
     S->nlu += 1;
-    int ier = 0;
-    dgbtrf_(&S->n, &S->n, &ml, &mu, &wm[2], &meband, &iwm[30], &ier);
+    CBLAS_INT ier = 0;
+    BLAS_FUNC(dgbtrf)(&(CBLAS_INT){S->n}, &(CBLAS_INT){S->n}, &ml, &mu, &wm[2], &meband, &iwm[30], &ier);
     if (ier != 0) {
         *ierpj = 1;
     }
@@ -949,7 +949,7 @@ dvnlsd(
     double* restrict savf,
     double* restrict ewt,
     double* acor,
-    int* restrict iwm,
+    CBLAS_INT* restrict iwm,
     double* restrict wm,
     vode_func_t f,
     vode_jac_t jac,
@@ -998,7 +998,7 @@ dvnlsd(
     while (1) {
         m = 0;
         delp = 0.0;
-        dcopy_(&S->n, yh, &(int){1}, y, &(int){1});
+        BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, yh, &(CBLAS_INT){1}, y, &(CBLAS_INT){1});
         f(S->n, S->tn, y, savf, rpar, ipar);
         S->nfe += 1;
 
@@ -1042,7 +1042,7 @@ dvnlsd(
                 for (int i = 0; i < S->n; i++) {
                     y[i] = yh[i] + savf[i];
                 }
-                dcopy_(&S->n, savf, &(int){1}, acor, &(int){1});
+                BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, savf, &(CBLAS_INT){1}, acor, &(CBLAS_INT){1});
             } else {
                 // Chord iteration: solve linear system
                 // Fortran lines 2917-2928
@@ -1056,10 +1056,10 @@ dvnlsd(
                 }
                 if ((S->meth == 2) && (S->rc != 1.0)) {
                     double cscale = 2.0 / (1.0 + S->rc);
-                    dscal_(&S->n, &cscale, y, &(int){1});
+                    BLAS_FUNC(dscal)(&(CBLAS_INT){S->n}, &cscale, y, &(CBLAS_INT){1});
                 }
                 del = dvnorm(S->n, y, ewt);
-                daxpy_(&S->n, &(double){1.0}, y, &(int){1}, acor, &(int){1});
+                BLAS_FUNC(daxpy)(&(CBLAS_INT){S->n}, &(double){1.0}, y, &(CBLAS_INT){1}, acor, &(CBLAS_INT){1});
                 for (int i = 0; i < S->n; i++) {
                     y[i] = yh[i] + acor[i];
                 }
@@ -1199,7 +1199,7 @@ dvstep(
     double* savf,
     double* restrict acor,
     double* restrict wm,
-    int* restrict iwm,
+    CBLAS_INT* restrict iwm,
     vode_func_t f,
     vode_jac_t jac,
     double* restrict rpar,
@@ -1209,7 +1209,7 @@ dvstep(
     const int kfc = -3, kfh = -7, mxncf = 10;
     const double addon = 1.0e-6, bias1 = 6.0, bias2 = 6.0, bias3 = 10.0, etacf = 0.25, etamin = 0.1, etamxf = 0.2,
                  etamx1 = 1.0e4, etamx2 = 10.0, etamx3 = 10.0, onepsm = 1.00001, thresh = 1.5;
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
 
     // Local variables
     double told, r, dsm, flotl, ddn, dup, cnquot;
@@ -1398,7 +1398,7 @@ dvstep(
             r = 1.0;
             for (j = 1; j < S->l; j++) {
                 r *= S->eta;
-                dscal_(&S->n, &r, &yh[j * ldyh], &int1);
+                BLAS_FUNC(dscal)(&(CBLAS_INT){S->n}, &r, &yh[j * ldyh], &int1);
             }
             S->h = S->hscal * S->eta;
             S->hscal = S->h;
@@ -1603,13 +1603,13 @@ dvstep(
 
         // Update YH array
         for (j = 0; j < S->l; j++) {
-            daxpy_(&S->n, &S->el[j], acor, &int1, &yh[j * ldyh], &int1);
+            BLAS_FUNC(daxpy)(&(CBLAS_INT){S->n}, &S->el[j], acor, &int1, &yh[j * ldyh], &int1);
         }
 
         S->nqwait--;
 
         if ((S->l != S->lmax) && (S->nqwait == 1)) {
-            dcopy_(&S->n, acor, &int1, &yh[(S->lmax - 1) * ldyh], &int1);
+            BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, acor, &int1, &yh[(S->lmax - 1) * ldyh], &int1);
             S->conp = S->tq[4];
         }
 
@@ -1674,7 +1674,7 @@ dvstep(
                         // Label 620: Choose order increase
                         S->eta = etaqp1;
                         S->newq = S->nq + 1;
-                        dcopy_(&S->n, acor, &int1, &yh[(S->lmax - 1) * ldyh], &int1);
+                        BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, acor, &int1, &yh[(S->lmax - 1) * ldyh], &int1);
                     } else {
                         // Label 610: Choose order decrease
                         S->eta = S->etaqm1;
@@ -1718,7 +1718,7 @@ dvstep(
 
         // Label 700: Scale ACOR
         r = 1.0 / S->tq[1];
-        dscal_(&S->n, &r, acor, &int1);
+        BLAS_FUNC(dscal)(&(CBLAS_INT){S->n}, &r, acor, &int1);
 
         // Exit the retry loop - step successful
         break;
@@ -1764,7 +1764,7 @@ dvstep(
  * @param iwork  Integer work array
  */
 static void
-dvode_set_optional_output(vode_common_struct_t* S, double* rwork, int* iwork)
+dvode_set_optional_output(vode_common_struct_t* S, double* rwork, CBLAS_INT* iwork)
 {
     rwork[10] = S->hu;
     rwork[11] = S->hnew;
@@ -1824,7 +1824,7 @@ dvode(
     int* iopt,
     double* restrict rwork,
     int lrw,
-    int* restrict iwork,
+    CBLAS_INT* restrict iwork,
     int liw,
     vode_jac_t jac,
     int mf,
@@ -1847,7 +1847,7 @@ dvode(
     int ihit;
 
     // BLAS/LAPACK interface
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
 
     // ===================================================================
     // Block A: Initial validation on every call
@@ -2006,7 +2006,7 @@ dvode(
             lenwm = 2 + S->n;
         } else {  // MITER == 4 or 5
             mband = ml + mu + 1;
-            int lenp = (mband + ml) * S->n;
+            CBLAS_INT lenp = (mband + ml) * S->n;
             int lenj = mband * S->n;
             lenwm = 2 + lenp + jco * lenj;
             S->locjs = lenp + 2;
@@ -2056,7 +2056,7 @@ dvode(
             S->jstart = -1;
             if (S->nq > S->maxord) {
                 // MAXORD was reduced below NQ. Copy YH(*,MAXORD+2) into SAVF.
-                dcopy_(&S->n, &rwork[S->lwm], &int1, &rwork[S->lsavf], &int1);
+                BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lwm], &int1, &rwork[S->lsavf], &int1);
             }
             // Reload WM(1) = RWORK(LWM), since LWM may have changed.
             if (S->miter > 0) {
@@ -2107,7 +2107,7 @@ dvode(
         S->nfe = 1;
 
         // Load the initial value vector in YH.
-        dcopy_(&S->n, y, &int1, &rwork[S->lyh], &int1);
+        BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, y, &int1, &rwork[S->lyh], &int1);
 
         // Load and invert the EWT array. (H is temporarily set to 1.0.)
         S->nq = 1;
@@ -2142,7 +2142,7 @@ dvode(
 
         // Load H with H0 and scale YH(*,2) by H0.
         S->h = h0;
-        dscal_(&S->n, &h0, &rwork[lf0], &int1);
+        BLAS_FUNC(dscal)(&(CBLAS_INT){S->n}, &h0, &rwork[lf0], &int1);
     }
 
     // ===================================================================
@@ -2184,7 +2184,7 @@ dvode(
                 }
                 if ((S->tn - *tout) * S->h >= zero) {
                     // Already at or past TOUT
-                    dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+                    BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
                     *t = S->tn;
                     *istate = 2;
                     dvode_set_optional_output(S, rwork, iwork);
@@ -2219,7 +2219,7 @@ dvode(
                 hmx = fabs(S->tn) + fabs(S->h);
                 ihit = (fabs(S->tn - tcrit) <= hun * S->uround * hmx);
                 if (ihit) {
-                    dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+                    BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
                     *t = S->tn;
                     *istate = 2;
                     dvode_set_optional_output(S, rwork, iwork);
@@ -2242,7 +2242,7 @@ dvode(
                 hmx = fabs(S->tn) + fabs(S->h);
                 ihit = (fabs(S->tn - tcrit) <= hun * S->uround * hmx);
                 if (ihit) {
-                    dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+                    BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
                     *t = S->tn;
                     *istate = 2;
                     dvode_set_optional_output(S, rwork, iwork);
@@ -2264,7 +2264,7 @@ dvode(
         // Check for too many steps
         if ((S->nst - nslast) >= S->mxstep) {
             // ISTATE = -1: Maximum number of steps exceeded
-            dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+            BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
             *t = S->tn;
             *istate = -1;
             dvode_set_optional_output(S, rwork, iwork);
@@ -2278,7 +2278,7 @@ dvode(
         for (i = 0; i < S->n; i++) {
             if (rwork[S->lewt + i] <= zero) {
                 // ISTATE = -6: EWT(i) became zero
-                dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+                BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
                 *t = S->tn;
                 *istate = -6;
                 dvode_set_optional_output(S, rwork, iwork);
@@ -2298,7 +2298,7 @@ dvode(
                 return;
             }
             // ISTATE = -2: Too much accuracy requested
-            dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+            BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
             *t = S->tn;
             *istate = -2;
             rwork[13] = tolsf;
@@ -2341,7 +2341,7 @@ dvode(
 
                 case 2:
                     // ITASK=2: One-step mode, always return
-                    dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+                    BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
                     *t = S->tn;
                     *istate = 2;
                     dvode_set_optional_output(S, rwork, iwork);
@@ -2350,7 +2350,7 @@ dvode(
                 case 3:
                     // ITASK=3: Stop at mesh point at or beyond TOUT
                     if ((S->tn - *tout) * S->h >= zero) {
-                        dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+                        BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
                         *t = S->tn;
                         *istate = 2;
                         dvode_set_optional_output(S, rwork, iwork);
@@ -2370,7 +2370,7 @@ dvode(
                     hmx = fabs(S->tn) + fabs(S->h);
                     ihit = (fabs(S->tn - tcrit) <= hun * S->uround * hmx);
                     if (ihit) {
-                        dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+                        BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
                         *t = tcrit;
                         *istate = 2;
                         dvode_set_optional_output(S, rwork, iwork);
@@ -2387,7 +2387,7 @@ dvode(
                     // ITASK=5: One step without passing TCRIT
                     hmx = fabs(S->tn) + fabs(S->h);
                     ihit = (fabs(S->tn - tcrit) <= hun * S->uround * hmx);
-                    dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+                    BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
                     *t = S->tn;
                     if (ihit) {
                         *t = tcrit;
@@ -2414,7 +2414,7 @@ dvode(
             iwork[15] = imxer;
 
             // Set outputs and return
-            dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+            BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
             *t = S->tn;
             *istate = -4;
             dvode_set_optional_output(S, rwork, iwork);
@@ -2439,7 +2439,7 @@ dvode(
             iwork[15] = imxer;
 
             // Set outputs and return
-            dcopy_(&S->n, &rwork[S->lyh], &int1, y, &int1);
+            BLAS_FUNC(dcopy)(&(CBLAS_INT){S->n}, &rwork[S->lyh], &int1, y, &int1);
             *t = S->tn;
             *istate = -5;
             dvode_set_optional_output(S, rwork, iwork);

--- a/scipy/integrate/src/vode.h
+++ b/scipy/integrate/src/vode.h
@@ -75,7 +75,7 @@ dvode(
     int* iopt,
     double* restrict rwork,
     int lrw,
-    int* restrict iwork,
+    CBLAS_INT* restrict iwork,
     int liw,
     vode_jac_t jac,
     int mf,

--- a/scipy/integrate/src/zvode.c
+++ b/scipy/integrate/src/zvode.c
@@ -645,18 +645,18 @@ zvindy(
  * @param iersl  Error flag: 0=success, 1=singular matrix (miter=3)
  */
 static void
-zvsol(zvode_common_struct_t* S, ZVODE_CPLX_TYPE* restrict wm, int* restrict iwm,
+zvsol(zvode_common_struct_t* S, ZVODE_CPLX_TYPE* restrict wm, CBLAS_INT* restrict iwm,
       ZVODE_CPLX_TYPE* restrict x, int* iersl)
 {
     *iersl = 0;
-    int ier = 0;
-    int int1 = 1;
+    CBLAS_INT ier = 0;
+    CBLAS_INT int1 = 1;
 
     switch (S->miter)
     {
         case 1:
         case 2: {
-            zgetrs_("N", &S->n, &int1, wm, &S->n, &iwm[30], x, &S->n, &ier);
+            BLAS_FUNC(zgetrs)("N", &(CBLAS_INT){S->n}, &int1, wm, &(CBLAS_INT){S->n}, &iwm[30], x, &(CBLAS_INT){S->n}, &ier);
             break;
         }
         case 3: {
@@ -695,10 +695,10 @@ zvsol(zvode_common_struct_t* S, ZVODE_CPLX_TYPE* restrict wm, int* restrict iwm,
         }
         case 4:
         case 5: {
-            int ml = iwm[0];
-            int mu = iwm[1];
-            int meband = 2 * ml + mu + 1;
-            zgbtrs_("N", &S->n, &ml, &mu, &int1, wm, &meband, &iwm[30], x, &S->n, &ier);
+            CBLAS_INT ml = iwm[0];
+            CBLAS_INT mu = iwm[1];
+            CBLAS_INT meband = 2 * ml + mu + 1;
+            BLAS_FUNC(zgbtrs)("N", &(CBLAS_INT){S->n}, &ml, &mu, &int1, wm, &meband, &iwm[30], x, &(CBLAS_INT){S->n}, &ier);
             break;
         }
     }
@@ -810,7 +810,7 @@ zvjac(
     ZVODE_CPLX_TYPE* restrict ftem,
     ZVODE_CPLX_TYPE* restrict savf,
     ZVODE_CPLX_TYPE* restrict wm,
-    int* restrict iwm,
+    CBLAS_INT* restrict iwm,
     zvode_func_t f,
     zvode_jac_t jac,
     int* ierpj,
@@ -836,13 +836,13 @@ zvjac(
         S->nje += 1;
         S->nslj = S->nst;
         S->jcur = 1;
-        int lenp = S->n * S->n;
+        CBLAS_INT lenp = S->n * S->n;
         for (int i = 0; i < lenp; i++) {
             wm[i] = ZVODE_cplx(0.0, 0.0);
         }
         jac(S->n, S->tn, y, 0, 0, wm, S->n, rpar, ipar);
         if (S->jsv == 1) {
-            zcopy_(&lenp, wm, &(int){1}, &wm[S->locjs - 1], &(int){1});
+            BLAS_FUNC(zcopy)(&lenp, wm, &(CBLAS_INT){1}, &wm[S->locjs - 1], &(CBLAS_INT){1});
         }
     }
 
@@ -876,23 +876,23 @@ zvjac(
             j1 += S->n;
         }
         S->nfe += S->n;
-        int lenp = S->n * S->n;
+        CBLAS_INT lenp = S->n * S->n;
         if (S->jsv == 1) {
-            zcopy_(&lenp, wm, &(int){1}, &wm[S->locjs - 1], &(int){1});
+            BLAS_FUNC(zcopy)(&lenp, wm, &(CBLAS_INT){1}, &wm[S->locjs - 1], &(CBLAS_INT){1});
         }
     }
 
     if ((jok == 1) && ((S->miter == 1) || (S->miter == 2))) {
         S->jcur = 0;
-        int lenp = S->n * S->n;
-        zcopy_(&lenp, &wm[S->locjs - 1], &(int){1}, wm, &(int){1});
+        CBLAS_INT lenp = S->n * S->n;
+        BLAS_FUNC(zcopy)(&lenp, &wm[S->locjs - 1], &(CBLAS_INT){1}, wm, &(CBLAS_INT){1});
     }
 
     if ((S->miter == 1) || (S->miter == 2)) {
         // Inline DZSCAL: Multiply Jacobian by scalar -HRL1 (real scalar × complex vector)
         // Use scalar * complex order to match Fortran: DA*ZX(I)
         double neg_hrl1 = -S->hrl1;
-        int lenp = S->n * S->n;
+        CBLAS_INT lenp = S->n * S->n;
         for (int i = 0; i < lenp; i++) {
 #if defined(_MSC_VER)
             wm[i] = _Cmulcr(wm[i], neg_hrl1);
@@ -910,8 +910,8 @@ zvjac(
             j += S->n + 1;
         }
         S->nlu += 1;
-        int ier = 0;
-        zgetrf_(&S->n, &S->n, wm, &S->n, &iwm[30], &ier);
+        CBLAS_INT ier = 0;
+        BLAS_FUNC(zgetrf)(&(CBLAS_INT){S->n}, &(CBLAS_INT){S->n}, wm, &(CBLAS_INT){S->n}, &iwm[30], &ier);
         if (ier != 0) {
             *ierpj = 1;
         }
@@ -964,12 +964,12 @@ zvjac(
     }
 
     // Set constants for MITER = 4 or 5.
-    int ml = iwm[0];
-    int mu = iwm[1];
-    int ml1 = ml + 1;
-    int mband = ml + mu + 1;
-    int meband = mband + ml;
-    int lenp = meband * S->n;
+    CBLAS_INT ml = iwm[0];
+    CBLAS_INT mu = iwm[1];
+    int ml1 = (int)ml + 1;
+    CBLAS_INT mband = ml + mu + 1;
+    CBLAS_INT meband = mband + ml;
+    CBLAS_INT lenp = meband * S->n;
 
     if ((jok == -1) && (S->miter == 4)) {
         // If JOK = -1 and MITER = 4, call JAC to evaluate Jacobian.
@@ -979,12 +979,12 @@ zvjac(
         for (int i = 0; i < lenp; i++) {
             wm[i] = ZVODE_cplx(0.0, 0.0);
         }
-        jac(S->n, S->tn, y, ml, mu, &wm[ml1 - 1], meband, rpar, ipar);
+        jac(S->n, S->tn, y, (int)ml, (int)mu, &wm[ml1 - 1], (int)meband, rpar, ipar);
         if (S->jsv == 1) {
             // Call ZACOPY equivalent - copy banded matrix
             for (int ic = 0; ic < S->n; ic++) {
-                zcopy_(&mband, &wm[ml1 - 1 + ic * meband], &(int){1},
-                       &wm[S->locjs - 1 + ic * mband], &(int){1});
+                BLAS_FUNC(zcopy)(&mband, &wm[ml1 - 1 + ic * meband], &(CBLAS_INT){1},
+                       &wm[S->locjs - 1 + ic * mband], &(CBLAS_INT){1});
             }
         }
     }
@@ -994,8 +994,8 @@ zvjac(
         S->nje += 1;
         S->nslj = S->nst;
         S->jcur = 1;
-        int mba = int_min(mband, S->n);
-        int meb1 = meband - 1;
+        int mba = int_min((int)mband, S->n);
+        int meb1 = (int)meband - 1;
         double fac = zvnorm(S->n, savf, ewt);
         double r0 = 1000.0 * fabs(S->h) * S->uround * (double)(S->n) * fac;
         if (r0 == 0.0) { r0 = 1.0; }
@@ -1013,9 +1013,9 @@ zvjac(
                 y[jj] = yh[jj];
                 double r = fmax(S->srur * cabs(y[jj]), r0 / ewt[jj]);
                 fac = 1.0 / r;
-                int i1 = int_max(jj - mu, 0);
-                int i2 = int_min(jj + ml, S->n - 1);
-                int ii = (jj + 1) * meb1 - ml;
+                int i1 = int_max(jj - (int)mu, 0);
+                int i2 = int_min(jj + (int)ml, S->n - 1);
+                int ii = (jj + 1) * meb1 - (int)ml;
                 for (int i = i1; i <= i2; i++) {
 #if defined(_MSC_VER)
                     wm[ii + i] = _Cmulcr(CMPLX_SUB(ftem[i], savf[i]), fac);
@@ -1029,7 +1029,7 @@ zvjac(
         if (S->jsv == 1) {
             // Call ZACOPY equivalent
             for (int ic = 0; ic < S->n; ic++) {
-                zcopy_(&mband, &wm[ml1 - 1 + ic * meband], &(int){1}, &wm[S->locjs - 1 + ic * mband], &(int){1});
+                BLAS_FUNC(zcopy)(&mband, &wm[ml1 - 1 + ic * meband], &(CBLAS_INT){1}, &wm[S->locjs - 1 + ic * mband], &(CBLAS_INT){1});
             }
         }
     }
@@ -1038,7 +1038,7 @@ zvjac(
         S->jcur = 0;
         // Call ZACOPY equivalent
         for (int ic = 0; ic < S->n; ic++) {
-            zcopy_(&mband, &wm[S->locjs - 1 + ic * mband], &(int){1}, &wm[ml1 - 1 + ic * meband], &(int){1});
+            BLAS_FUNC(zcopy)(&mband, &wm[S->locjs - 1 + ic * mband], &(CBLAS_INT){1}, &wm[ml1 - 1 + ic * meband], &(CBLAS_INT){1});
         }
     }
 
@@ -1052,7 +1052,7 @@ zvjac(
         wm[i] = neg_hrl1 * wm[i];
 #endif
     }
-    int ii = mband - 1;
+    int ii = (int)mband - 1;
     for (int i = 0; i < S->n; i++) {
 #if defined(_MSC_VER)
         wm[ii] = CMPLX_ADD(wm[ii], ZVODE_cplx(1.0, 0.0));
@@ -1062,8 +1062,8 @@ zvjac(
         ii += meband;
     }
     S->nlu += 1;
-    int ier = 0;
-    zgbtrf_(&S->n, &S->n, &ml, &mu, wm, &meband, &iwm[30], &ier);
+    CBLAS_INT ier = 0;
+    BLAS_FUNC(zgbtrf)(&(CBLAS_INT){S->n}, &(CBLAS_INT){S->n}, &ml, &mu, wm, &meband, &iwm[30], &ier);
     if (ier != 0) {
         *ierpj = 1;
     }
@@ -1123,7 +1123,7 @@ zvnlsd(
     ZVODE_CPLX_TYPE* restrict savf,
     double* restrict ewt,
     ZVODE_CPLX_TYPE* acor,
-    int* restrict iwm,
+    CBLAS_INT* restrict iwm,
     ZVODE_CPLX_TYPE* restrict wm,
     zvode_func_t f,
     zvode_jac_t jac,
@@ -1171,7 +1171,7 @@ zvnlsd(
     while (1) {
         m = 0;
         delp = 0.0;
-        zcopy_(&S->n, yh, &(int){1}, y, &(int){1});
+        BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, yh, &(CBLAS_INT){1}, y, &(CBLAS_INT){1});
         f(S->n, S->tn, y, savf, rpar, ipar);
         S->nfe += 1;
 
@@ -1367,9 +1367,9 @@ zvnlsd(
  * Complex Arithmetic Notes:
  * -------------------------
  * - YH, Y, SAVF, VSAV, ACOR, WM are complex arrays (ZVODE_CPLX_TYPE*)
- * - Rescaling uses zscal_() instead of dscal_()
- * - YH updates use zaxpy_() instead of daxpy_()
- * - Copying uses zcopy_() instead of dcopy_()
+ * - Rescaling uses BLAS_FUNC(zscal)() instead of BLAS_FUNC(dscal)()
+ * - YH updates use BLAS_FUNC(zaxpy)() instead of BLAS_FUNC(daxpy)()
+ * - Copying uses BLAS_FUNC(zcopy)() instead of BLAS_FUNC(dcopy)()
  * - Predictor step updates YH in-place (complex addition, needs MSVC guards)
  * - All norms computed by zvnorm() (handles complex magnitude via cabs)
  * - EWT remains real (double*) - error weights are always real
@@ -1426,7 +1426,7 @@ zvstep(
     ZVODE_CPLX_TYPE* savf,
     ZVODE_CPLX_TYPE* restrict acor,
     ZVODE_CPLX_TYPE* restrict wm,
-    int* restrict iwm,
+    CBLAS_INT* restrict iwm,
     zvode_func_t f,
     zvode_jac_t jac,
     ZVODE_CPLX_TYPE* restrict rpar,
@@ -1436,7 +1436,7 @@ zvstep(
     const int kfc = -3, kfh = -7, mxncf = 10;
     const double addon = 1.0e-6, bias1 = 6.0, bias2 = 6.0, bias3 = 10.0, etacf = 0.25, etamin = 0.1, etamxf = 0.2,
                  etamx1 = 1.0e4, etamx2 = 10.0, etamx3 = 10.0, onepsm = 1.00001, thresh = 1.5;
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
 
     // Local variables
     double told, r, dsm, flotl, ddn, dup, cnquot;
@@ -1867,7 +1867,7 @@ zvstep(
         S->nqwait--;
 
         if ((S->l != S->lmax) && (S->nqwait == 1)) {
-            zcopy_(&S->n, acor, &int1, &yh[(S->lmax - 1) * ldyh], &int1);
+            BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, acor, &int1, &yh[(S->lmax - 1) * ldyh], &int1);
             S->conp = S->tq[4];
         }
 
@@ -1938,7 +1938,7 @@ zvstep(
                         // Label 620: Choose order increase
                         S->eta = etaqp1;
                         S->newq = S->nq + 1;
-                        zcopy_(&S->n, acor, &int1, &yh[(S->lmax - 1) * ldyh], &int1);
+                        BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, acor, &int1, &yh[(S->lmax - 1) * ldyh], &int1);
                     } else {
                         // Label 610: Choose order decrease
                         S->eta = S->etaqm1;
@@ -2035,7 +2035,7 @@ zvstep(
  * @param iwork  Integer work array
  */
 static void
-zvode_set_optional_output(zvode_common_struct_t* S, double* rwork, int* iwork)
+zvode_set_optional_output(zvode_common_struct_t* S, double* rwork, CBLAS_INT* iwork)
 {
     rwork[10] = S->hu;
     rwork[11] = S->hnew;
@@ -2065,7 +2065,7 @@ zvode_set_optional_output(zvode_common_struct_t* S, double* rwork, int* iwork)
  * - EWT workspace (LEWT) indexes into RWORK (error weights are real)
  * - All optional inputs still in RWORK/IWORK (tolerances, h0, hmax, etc. are real)
  * - Calls ZEWSET, ZVHIN, ZVSTEP instead of D* versions
- * - Initial Y copy and interpolation use zcopy_() instead of dcopy_()
+ * - Initial Y copy and interpolation use BLAS_FUNC(zcopy)() instead of BLAS_FUNC(dcopy)()
  *
  * @param S       Pointer to ZVODE common struct (maintains state between calls)
  * @param f       User function computing dy/dt (complex)
@@ -2108,7 +2108,7 @@ zvode(
     int lzw,
     double* restrict rwork,
     int lrw,
-    int* restrict iwork,
+    CBLAS_INT* restrict iwork,
     int liw,
     zvode_jac_t jac,
     int mf,
@@ -2131,7 +2131,7 @@ zvode(
     int ihit;
 
     // BLAS/LAPACK interface
-    int int1 = 1;
+    CBLAS_INT int1 = 1;
 
     // ===================================================================
     // Block A: Initial validation on every call
@@ -2292,7 +2292,7 @@ zvode(
             lenwm = S->n;
         } else {  // MITER == 4 or 5
             mband = ml + mu + 1;
-            int lenp = (mband + ml) * S->n;
+            CBLAS_INT lenp = (mband + ml) * S->n;
             int lenj = mband * S->n;
             lenwm = lenp + jco * lenj;
             S->locjs = lenp + 1;
@@ -2350,7 +2350,7 @@ zvode(
             S->jstart = -1;
             if (S->nq > S->maxord) {
                 // MAXORD was reduced below NQ. Copy YH(*,MAXORD+2) into SAVF.
-                zcopy_(&S->n, &zwork[S->lwm], &int1, &zwork[S->lsavf], &int1);
+                BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lwm], &int1, &zwork[S->lsavf], &int1);
             }
         }
     }
@@ -2397,7 +2397,7 @@ zvode(
         S->nfe = 1;
 
         // Load the initial value vector in YH.
-        zcopy_(&S->n, y, &int1, &zwork[S->lyh], &int1);
+        BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, y, &int1, &zwork[S->lyh], &int1);
 
         // Load and invert the EWT array. (H is temporarily set to 1.0.)
         S->nq = 1;
@@ -2481,7 +2481,7 @@ zvode(
                 }
                 if ((S->tn - *tout) * S->h >= zero) {
                     // Already at or past TOUT
-                    zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                    BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                     *t = S->tn;
                     *istate = 2;
                     zvode_set_optional_output(S, rwork, iwork);
@@ -2516,7 +2516,7 @@ zvode(
                 hmx = fabs(S->tn) + fabs(S->h);
                 ihit = (fabs(S->tn - tcrit) <= hun * S->uround * hmx);
                 if (ihit) {
-                    zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                    BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                     *t = tcrit;
                     *istate = 2;
                     zvode_set_optional_output(S, rwork, iwork);
@@ -2539,7 +2539,7 @@ zvode(
                 hmx = fabs(S->tn) + fabs(S->h);
                 ihit = (fabs(S->tn - tcrit) <= hun * S->uround * hmx);
                 if (ihit) {
-                    zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                    BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                     *t = tcrit;
                     *istate = 2;
                     zvode_set_optional_output(S, rwork, iwork);
@@ -2561,7 +2561,7 @@ zvode(
         // Check for too many steps
         if ((S->nst - nslast) >= S->mxstep) {
             // ISTATE = -1: Maximum number of steps exceeded
-            zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+            BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
             *t = S->tn;
             *istate = -1;
             zvode_set_optional_output(S, rwork, iwork);
@@ -2575,7 +2575,7 @@ zvode(
         for (i = 0; i < S->n; i++) {
             if (rwork[S->lewt + i] <= zero) {
                 // ISTATE = -6: EWT(i) became zero
-                zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                 *t = S->tn;
                 *istate = -6;
                 zvode_set_optional_output(S, rwork, iwork);
@@ -2597,7 +2597,7 @@ zvode(
                 return;
             }
             // ISTATE = -2: Too much accuracy requested
-            zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+            BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
             *t = S->tn;
             *istate = -2;
             rwork[13] = tolsf;
@@ -2652,7 +2652,7 @@ zvode(
 
                     case 2:
                         // One-step mode, return after each step
-                        zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                        BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                         *t = S->tn;
                         *istate = 2;
                         zvode_set_optional_output(S, rwork, iwork);
@@ -2663,7 +2663,7 @@ zvode(
                         if ((S->tn - *tout) * S->h < zero) {
                             continue;  // Continue integration
                         }
-                        zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                        BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                         *t = S->tn;
                         *istate = 2;
                         zvode_set_optional_output(S, rwork, iwork);
@@ -2674,7 +2674,7 @@ zvode(
                         hmx = fabs(S->tn) + fabs(S->h);
                         ihit = (fabs(S->tn - tcrit) <= hun * S->uround * hmx);
                         if (ihit) {
-                            zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                            BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                             *t = tcrit;
                             *istate = 2;
                             zvode_set_optional_output(S, rwork, iwork);
@@ -2701,7 +2701,7 @@ zvode(
                         // One step mode with TCRIT
                         hmx = fabs(S->tn) + fabs(S->h);
                         ihit = (fabs(S->tn - tcrit) <= hun * S->uround * hmx);
-                        zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                        BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                         *t = S->tn;
                         if (ihit) {
                             *t = tcrit;
@@ -2731,7 +2731,7 @@ zvode(
                     }
                     iwork[15] = imxer;
                 }
-                zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                 *t = S->tn;
                 *istate = -4;
                 zvode_set_optional_output(S, rwork, iwork);
@@ -2758,7 +2758,7 @@ zvode(
                     }
                     iwork[15] = imxer;
                 }
-                zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                 *t = S->tn;
                 *istate = -5;
                 zvode_set_optional_output(S, rwork, iwork);
@@ -2771,7 +2771,7 @@ zvode(
                 // KFLAG < -2: Fatal error from ZVSTEP
                 // ===================================================
                 S->kuth = 1;
-                zcopy_(&S->n, &zwork[S->lyh], &int1, y, &int1);
+                BLAS_FUNC(zcopy)(&(CBLAS_INT){S->n}, &zwork[S->lyh], &int1, y, &int1);
                 *t = S->tn;
                 *istate = S->kflag;
                 zvode_set_optional_output(S, rwork, iwork);

--- a/scipy/integrate/src/zvode.h
+++ b/scipy/integrate/src/zvode.h
@@ -103,7 +103,7 @@ zvode(
     int lzw,
     double* restrict rwork,
     int lrw,
-    int* restrict iwork,
+    CBLAS_INT* restrict iwork,
     int liw,
     zvode_jac_t jac,
     int mf,

--- a/tach.toml
+++ b/tach.toml
@@ -52,7 +52,7 @@ depends_on = ["scipy._lib", "scipy.fft"]
 
 [[modules]]
 path = "scipy.integrate"
-depends_on = ["scipy._lib", "scipy.interpolate", "scipy.linalg", "scipy.optimize", "scipy.sparse", "scipy.sparse.linalg", "scipy.special", "scipy.stats", "scipy._external"]
+depends_on = ["scipy._lib", "scipy.interpolate", "scipy.linalg", "scipy.optimize", "scipy.sparse", "scipy.sparse.linalg", "scipy.special", "scipy.stats", "scipy._external", "scipy.linalg.blas"]
 
 [[modules]]
 path = "scipy.interpolate"


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/23351

#### What does this implement/fix?
<!--Please explain your changes.-->

The core is similar to other ILP64-fication PRs: make sure LAPACK-adjacent integers are CBLAS_INT, make sure work arrays have the matching dtype, make sure LAPACK names are mangled.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Drafted by Claude Sonnet via Copilot. 