### PR TITLE
TST: stats.iqr: avoid assert_equal w/ floating point arithmetic

### DIFF
--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3323,10 +3323,10 @@ class TestIQR:
 
     def test_rng(self, xp):
         x = xp.arange(5)
-        xp_assert_equal(stats.iqr(x), xp.asarray(2.))
-        xp_assert_equal(stats.iqr(x, rng=(25, 87.5)), xp.asarray(2.5))
-        xp_assert_equal(stats.iqr(x, rng=(12.5, 75)), xp.asarray(2.5))
-        xp_assert_equal(stats.iqr(x, rng=(10, 50)), xp.asarray(1.6))  # 3-1.4
+        xp_assert_close(stats.iqr(x), xp.asarray(2.))
+        xp_assert_close(stats.iqr(x, rng=(25, 87.5)), xp.asarray(2.5))
+        xp_assert_close(stats.iqr(x, rng=(12.5, 75)), xp.asarray(2.5))
+        xp_assert_close(stats.iqr(x, rng=(10, 50)), xp.asarray(1.6))  # 3-1.4
 
         message = r"Elements of `rng` must be in the range \[0, 100\]."
         with pytest.raises(ValueError, match=message):


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/pull/24844#issuecomment-4099772989

#### What does this implement/fix?
There is a CI failure in `main` due to use of `xp_assert_equal` to check a floating point result against a reference value. Fix this with `xp_assert_close`. 

#### Additional information
This is not a test of the precision to which the result is accurate, so I don't see any need to specify tolerances here.

#### AI Generation Disclosure
No AI