### PR TITLE
DOC: optimize.dual_annealing: mention origin of the default parameters

### DIFF
--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -594,6 +594,9 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
 
     Where :math:`q_{v}` is the visiting parameter.
 
+    The default values and accepted ranges for the parameters are based on
+    the recommendations from [1]_.
+
     .. versionadded:: 1.2.0
 
     References


### PR DESCRIPTION
#### Reference issue
Closes #11298

#### What does this implement/fix?
#11298 mentioned that it could be helpful to document why the default parameters were chosen as they are. I added a sentence mentioning the reference to the notes section.