### PR TITLE
DOC: fft.{fht, ifht}: add new examples

### DIFF
--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -274,7 +274,7 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     >>> A[240] = 20
 
     Calculate the logarithmic spacing of the elements in ``A`` and
-    perform a second order inverse Hankel transform on the sample
+    perform a second-order inverse Hankel transform on the sample
     data.
 
     >>> dln = np.log(k[1]/k[0])

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -289,8 +289,12 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     Compare ``a`` with the kernel function corresponding to ``k[240]``.
 
     >>> a_f = jv(2, k[240]*r)*r
-    >>> plt.plot(r, a)
-    >>> plt.plot(r, a_f)
+    >>> fig, ax = plt.subplots()
+    >>> ax.plot(r, a, label="ifht")
+    >>> ax.plot(r, a_f, "--", label=r"$r J_2(k_{240} r)$")
+    >>> ax.set_xlabel(r"$r$")
+    >>> ax.set_ylabel("amplitude")
+    >>> ax.legend()
     >>> plt.show()
 
     The plot shows that, for larger values of ``r``, the inverse Hankel transform

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -286,7 +286,7 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
 
     >>> r = 1/np.flip(k)
 
-    Compare ``a`` with the kernel function corresponding to ``k=240``.
+    Compare ``a`` with the kernel function corresponding to ``k[240]``.
 
     >>> a_f = jv(2, k[240]*r)*r
     >>> plt.plot(r, a)

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -125,11 +125,16 @@ def fht(a, dln, mu, offset=0.0, bias=0.0):
     >>> ord = 2
     >>> f = 10*jv(ord, 4*r)*r
 
-    Calculate the Hankel transform ``F`` of the signal data. Then,
-    calculate the scaling factors ``k`` corresponding to ``F``.
+    Calculate the Hankel transform ``F`` of the signal data.
 
     >>> F = fft.fht(f, dln, mu=ord)
-    >>> k = 1/r[::-1]
+
+    Calculate the evaluation points for the transformed data ``F``.
+    Since ``fht`` returns the transformed data in ascending order of
+    evaluation points, flip ``r`` in the evaluation points equation.
+
+
+    >>> k = 1/np.flip(r)
 
     Plot ``F`` versus ``k``.
 
@@ -160,7 +165,7 @@ def fht(a, dln, mu, offset=0.0, bias=0.0):
     >>> r = np.logspace(-7, 1, 128)  # Input evaluation points
     >>> dln = np.log(r[1]/r[0])      # Step size
     >>> offset = fft.fhtoffset(dln, initial=-6*np.log(10), mu=mu)
-    >>> k = np.exp(offset)/r[::-1]   # Output evaluation points
+    >>> k = np.exp(offset)/np.flip(r)   # Output evaluation points
 
     Define the analytical function.
 
@@ -275,11 +280,14 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     >>> dln = np.log(k[1]/k[0])
     >>> a = fft.ifht(A, dln, mu=2)
 
-    Calculate the evaluation points for the transformed function ``a``
-    and compare the evaluated function with the kernel function
-    corresponding to ``k=240``.
+    Calculate the evaluation points for the transformed data ``a``.
+    Since ``ifht`` returns the transformed data in ascending order of
+    evaluation points, flip ``k`` in the evaluation points equation.
 
     >>> r = 1/k[::-1]
+
+    Compare ``a`` with the kernel function corresponding to ``k=240``.
+
     >>> a_f = jv(2, k[240]*r)*r
     >>> plt.plot(r, a)
     >>> plt.plot(r, a_f)

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -284,7 +284,7 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     Since ``ifht`` returns the transformed data in ascending order of
     evaluation points, flip ``k`` in the evaluation points equation.
 
-    >>> r = 1/k[::-1]
+    >>> r = 1 / np.flip(k)
 
     Compare ``a`` with the kernel function corresponding to ``k=240``.
 

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -284,7 +284,7 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     Since ``ifht`` returns the transformed data in ascending order of
     evaluation points, flip ``k`` in the evaluation points equation.
 
-    >>> r = 1 / np.flip(k)
+    >>> r = 1/np.flip(k)
 
     Compare ``a`` with the kernel function corresponding to ``k=240``.
 

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -111,6 +111,36 @@ def fht(a, dln, mu, offset=0.0, bias=0.0):
 
     Examples
     --------
+    **Identify Bessel component in signal data**
+
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy import fft
+    >>> from scipy.special import jv
+
+    Generate sample signal data.
+
+    >>> r = np.logspace(-1, 1, 400)
+    >>> dln = np.log(r[1]/r[0])
+    >>> ord = 2
+    >>> f = 10*jv(ord, 4*r)*r
+
+    Calculate the Hankel transform ``F`` of the signal data. Then,
+    calculate the scaling factors ``k`` corresponding to ``F``.
+
+    >>> F = fft.fht(f, dln, mu=ord)
+    >>> k = 1/r[::-1]
+
+    Plot ``F`` versus ``k``.
+
+    >>> plt.plot(k, F)
+    >>> plt.show()
+
+    The plotted Hankel transform shows that the signal contains a
+    second order Bessel component corresponding to ``k=4`` and a
+    coefficient of approximately ``30``.
+
+    **Evaluate integral equation**
 
     This example is the adapted version of ``fftlogtest.f`` which is provided
     in [2]_. It evaluates the integral
@@ -223,5 +253,39 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     mathematical inverse Hankel transform is commonly defined using :math:`k \, dk`.
 
     See `fht` for further details.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy import fft
+    >>> from scipy.special import jv
+
+    Generate sample data ``A`` and evaluation points ``k`` for the
+    Hankel transform of a signal.
+
+    >>> k = np.logspace(-1, 1, 300)
+    >>> A = np.zeros(300)
+    >>> A[240] = 20
+
+    Calculate the logarithmic spacing of the elements in ``A`` and
+    perform a second order inverse Hankel transform on the sample
+    data.
+
+    >>> dln = np.log(k[1]/k[0])
+    >>> a = fft.ifht(A, dln, mu=2)
+
+    Calculate the evaluation points for the transformed function ``a``
+    and compare the evaluated function with the kernel function
+    corresponding to ``k=240``.
+
+    >>> r = 1/k[::-1]
+    >>> a_f = jv(2, k[240]*r)*r
+    >>> plt.plot(r, a)
+    >>> plt.plot(r, a_f)
+    >>> plt.show()
+
+    The plot shows that, for larger values of ``r``, the inverse Hankel transform
+    follows the kernel function closely.
     """
     return (Dispatchable(A, np.ndarray),)

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -270,7 +270,7 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     Hankel transform of a signal.
 
     >>> k = np.logspace(-1, 1, 300)
-    >>> A = np.zeros(300)
+    >>> A = np.zeros_like(k)
     >>> A[240] = 20
 
     Calculate the logarithmic spacing of the elements in ``A`` and

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -130,8 +130,11 @@ def fht(a, dln, mu, offset=0.0, bias=0.0):
     >>> F = fft.fht(f, dln, mu=ord)
 
     Calculate the evaluation points for the transformed data ``F``.
-    Since ``fht`` returns the transformed data in ascending order of
-    evaluation points, flip ``r`` in the evaluation points equation.
+    ``fht`` calculates evaluation points ``k`` such that ``kr`` is
+    constant for each ``r`` and then returns the transformed data in
+    ascending order of evaluation points. To calculate the evaluation
+    points in ascending order, flip the order of ``r`` in the equation
+    for ``k``.
 
 
     >>> k = 1/np.flip(r)
@@ -281,8 +284,11 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     >>> a = fft.ifht(A, dln, mu=2)
 
     Calculate the evaluation points for the transformed data ``a``.
-    Since ``ifht`` returns the transformed data in ascending order of
-    evaluation points, flip ``k`` in the evaluation points equation.
+    ``ifht`` calculates evaluation points ``r`` such that ``kr`` is
+    constant for each ``k`` and then returns the transformed data in
+    ascending order of evaluation points. To calculate the evaluation
+    points in ascending order, flip the order of ``k`` in the equation
+    for ``r``.
 
     >>> r = 1/np.flip(k)
 

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -284,7 +284,7 @@ def ifht(A, dln, mu, offset=0.0, bias=0.0):
     >>> a = fft.ifht(A, dln, mu=2)
 
     Calculate the evaluation points for the transformed data ``a``.
-    ``ifht`` calculates evaluation points ``r`` such that ``kr`` is
+    ``ifht`` calculates evaluation points ``r`` such that ``k * r`` is
     constant for each ``k`` and then returns the transformed data in
     ascending order of evaluation points. To calculate the evaluation
     points in ascending order, flip the order of ``k`` in the equation

--- a/scipy/fft/_fftlog.py
+++ b/scipy/fft/_fftlog.py
@@ -130,7 +130,7 @@ def fht(a, dln, mu, offset=0.0, bias=0.0):
     >>> F = fft.fht(f, dln, mu=ord)
 
     Calculate the evaluation points for the transformed data ``F``.
-    ``fht`` calculates evaluation points ``k`` such that ``kr`` is
+    ``fht`` calculates evaluation points ``k`` such that ``k * r`` is
     constant for each ``r`` and then returns the transformed data in
     ascending order of evaluation points. To calculate the evaluation
     points in ascending order, flip the order of ``r`` in the equation


### PR DESCRIPTION
Add new examples to `fht` and `ifht` docstrings. Create example subsections on `fht` because it now has two examples.

[docs only]

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
#7168

#### What does this implement/fix?
This change adds an example to the `ifht` docstring and a second, simpler example to the `fht` docstring.

#### Additional information
_Tech notes:_ Hankel transforms are new to me, so please keep an eagle eye out for incorrect logic.

_Doc notes:_
Please correct me if the following aren't the way things are done in the SciPy doc.
- I added the new simple `fht` example above the longer, more conceptual example. This way new users will encounter it first and experienced users will know enough to scroll past it.
- I also couldn't find a reference for how to separate multiple examples in the same docstring, so I used bold titles for each. 

#### AI Generation Disclosure
No AI tools used
