### PR TITLE
DEP: sparse: Deprecate default output type of input dependent construction functions

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -815,8 +815,9 @@ def kron(A, B, format=None):
 
         For the case where input arrays are numpy arrays, this function is
         switching to returning a sparse array instead of sparse matrix.
-        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        Recover the sparse matrix return value by making one input a sparse matrix.
         For example, kron(coo_matrix(A), B).
+        Avoid this message for sparse array output by using kron(coo_array(A), B).
         For more information, see the spmatrix to sparray migration guide
         https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
 
@@ -943,8 +944,9 @@ def kronsum(A, B, format=None):
 
         For the case where input arrays are numpy arrays, this function is
         switching to returning a sparse array instead of sparse matrix.
-        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        Recover the sparse matrix return value by making one input a sparse matrix.
         For example, kronsum(coo_matrix(A), B).
+        Avoid this message for sparse array output by using kronsum(coo_array(A), B).
         For more information, see the spmatrix to sparray migration guide
         https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
 
@@ -1432,8 +1434,9 @@ def block_diag(mats, format=None, dtype=None):
 
         For the case where input arrays are numpy arrays, this function is
         switching to returning a sparse array instead of sparse matrix.
-        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        Recover the sparse matrix return value by making one input a sparse matrix.
         For example, block_diag([coo_matrix(A), B]).
+        Avoid this message for sparse array output using block_diag([coo_array(A), B]).
         For more information, see the spmatrix to sparray migration guide
         https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
 

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -25,7 +25,7 @@ from ._csc import csc_matrix, csc_array
 from ._csr import csr_matrix, csr_array
 from ._dia import dia_matrix, dia_array
 
-from ._base import issparse, sparray
+from ._base import issparse, sparray, spmatrix
 
 
 def expand_dims(A, /, *, axis=0):
@@ -800,13 +800,17 @@ def kron(A, B, format=None):
            [15, 20,  0,  0]])
 
     """
-    # TODO: delete next 10 lines and replace _sparse with _array when spmatrix removed
+    # TODO: delete this if-clause and replace _sparse with _array when spmatrix removed
     if isinstance(A, sparray) or isinstance(B, sparray):
         # convert to local variables
         bsr_sparse = bsr_array
         csr_sparse = csr_array
         coo_sparse = coo_array
-    elif isinstance(A, np.ndarray) and isinstance(B, np.ndarray):  # use default
+    elif isinstance(A, spmatrix) or isinstance(B, spmatrix):
+        bsr_sparse = bsr_matrix
+        csr_sparse = csr_matrix
+        coo_sparse = coo_matrix
+    else:  # all dense
         msg = """`kron` is switching to the sparse array interface.
 
         For the case where input arrays are numpy arrays, this function is
@@ -821,10 +825,6 @@ def kron(A, B, format=None):
         prefixes = (os.path.dirname(__file__),)
         warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
         # default when all input are ndarray
-        bsr_sparse = bsr_matrix
-        csr_sparse = csr_matrix
-        coo_sparse = coo_matrix
-    else:  # use spmatrix
         bsr_sparse = bsr_matrix
         csr_sparse = csr_matrix
         coo_sparse = coo_matrix
@@ -930,12 +930,15 @@ def kronsum(A, B, format=None):
     >>> plt.show()
 
     """
-    # TODO: delete next 8 lines and replace _sparse with _array when spmatrix removed
+    # TODO: delete this if-clause and replace _sparse with _array when spmatrix removed
     if isinstance(A, sparray) or isinstance(B, sparray):
         # convert to local variables
         coo_sparse = coo_array
         identity_sparse = eye_array
-    elif isinstance(A, np.ndarray) and isinstance(B, np.ndarray):  # use default
+    elif isinstance(A, spmatrix) or isinstance(B, spmatrix):
+        coo_sparse = coo_matrix
+        identity_sparse = identity
+    else:  # all dense
         msg = """`kronsum` is switching to the sparse array interface.
 
         For the case where input arrays are numpy arrays, this function is
@@ -950,9 +953,6 @@ def kronsum(A, B, format=None):
         prefixes = (os.path.dirname(__file__),)
         warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
         # default when all input are ndarray
-        coo_sparse = coo_matrix
-        identity_sparse = identity
-    else:
         coo_sparse = coo_matrix
         identity_sparse = identity
 
@@ -1425,7 +1425,9 @@ def block_diag(mats, format=None, dtype=None):
     """
     if any(isinstance(a, sparray) for a in mats):
         container = coo_array
-    elif all(isinstance(a, np.ndarray) for a in mats):
+    elif any(isinstance(a, spmatrix) for a in mats):
+        container = coo_matrix
+    else:  # all dense
         msg = """`block_diag` is switching to the sparse array interface.
 
         For the case where input arrays are numpy arrays, this function is
@@ -1441,8 +1443,6 @@ def block_diag(mats, format=None, dtype=None):
         warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
 
         # default when all input are ndarray
-        container = coo_matrix
-    else:
         container = coo_matrix
 
     row = []

--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -11,7 +11,7 @@ __all__ = ['spdiags', 'eye', 'identity', 'kron', 'kronsum',
 import numbers
 import math
 import os
-import warnings
+from warnings import warn
 import numpy as np
 
 from scipy._lib._util import check_random_state, rng_integers, _transition_to_rng
@@ -437,7 +437,7 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=_NoVa
         dtype = np.dtype(np.common_type(*diagonals))
         future_dtype = np.result_type(*diagonals)
         if (dtype != future_dtype):
-            warnings.warn(
+            warn(
                 f"Input has data type {future_dtype}, but the output has been cast "
                 f"to {dtype}.  In the future, the output data type will match the "
                 "input. To avoid this warning, set the `dtype` parameter to `None` "
@@ -806,6 +806,24 @@ def kron(A, B, format=None):
         bsr_sparse = bsr_array
         csr_sparse = csr_array
         coo_sparse = coo_array
+    elif isinstance(A, np.ndarray) and isinstance(B, np.ndarray):  # use default
+        msg = """`kron` is switching to the sparse array interface.
+
+        For the case where input arrays are numpy arrays, this function is
+        switching to returning a sparse array instead of sparse matrix.
+        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        For example, kron(coo_matrix(A), B).
+        For more information, see the spmatrix to sparray migration guide
+        https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+
+        This function will be changed no earlier than v1.20.
+        """
+        prefixes = (os.path.dirname(__file__),)
+        warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
+        # default when all input are ndarray
+        bsr_sparse = bsr_matrix
+        csr_sparse = csr_matrix
+        coo_sparse = coo_matrix
     else:  # use spmatrix
         bsr_sparse = bsr_matrix
         csr_sparse = csr_matrix
@@ -917,6 +935,23 @@ def kronsum(A, B, format=None):
         # convert to local variables
         coo_sparse = coo_array
         identity_sparse = eye_array
+    elif isinstance(A, np.ndarray) and isinstance(B, np.ndarray):  # use default
+        msg = """`kronsum` is switching to the sparse array interface.
+
+        For the case where input arrays are numpy arrays, this function is
+        switching to returning a sparse array instead of sparse matrix.
+        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        For example, kronsum(coo_matrix(A), B).
+        For more information, see the spmatrix to sparray migration guide
+        https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+
+        This function will be changed no earlier than v1.20.
+        """
+        prefixes = (os.path.dirname(__file__),)
+        warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
+        # default when all input are ndarray
+        coo_sparse = coo_matrix
+        identity_sparse = identity
     else:
         coo_sparse = coo_matrix
         identity_sparse = identity
@@ -1252,7 +1287,7 @@ def _block(blocks, format, dtype, return_spmatrix=False):
     blocks = np.asarray(blocks, dtype='object')
 
     if blocks.ndim != 2:
-        raise ValueError('blocks must be 2-D')
+        raise ValueError('blocks must be 2-D, and some must be sparse')
 
     M,N = blocks.shape
 
@@ -1390,6 +1425,23 @@ def block_diag(mats, format=None, dtype=None):
     """
     if any(isinstance(a, sparray) for a in mats):
         container = coo_array
+    elif all(isinstance(a, np.ndarray) for a in mats):
+        msg = """`block_diag` is switching to the sparse array interface.
+
+        For the case where input arrays are numpy arrays, this function is
+        switching to returning a sparse array instead of sparse matrix.
+        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        For example, block_diag([coo_matrix(A), B]).
+        For more information, see the spmatrix to sparray migration guide
+        https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+
+        This function will be changed no earlier than v1.20.
+        """
+        prefixes = (os.path.dirname(__file__),)
+        warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
+
+        # default when all input are ndarray
+        container = coo_matrix
     else:
         container = coo_matrix
 

--- a/scipy/sparse/_extract.py
+++ b/scipy/sparse/_extract.py
@@ -7,7 +7,6 @@ __all__ = ['find', 'tril', 'triu']
 
 import os
 from warnings import warn
-import numpy as np
 
 from ._coo import coo_array, coo_matrix
 from ._base import sparray, spmatrix

--- a/scipy/sparse/_extract.py
+++ b/scipy/sparse/_extract.py
@@ -108,8 +108,9 @@ def tril(A, k=0, format=None):
 
         For the case where input arrays are numpy arrays, this function is
         switching to returning a sparse array instead of sparse matrix.
-        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        Recover the sparse matrix return value by making one input a sparse matrix.
         For example, tril(coo_matrix(A)).
+        Avoid this message for sparse array output by using tril(coo_array(A)).
         For more information, see the spmatrix to sparray migration guide
         https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
 
@@ -195,8 +196,9 @@ def triu(A, k=0, format=None):
 
         For the case where input arrays are numpy arrays, this function is
         switching to returning a sparse array instead of sparse matrix.
-        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        Recover the sparse matrix return value by making one input a sparse matrix.
         For example, triu(coo_matrix(A)).
+        Avoid this message for sparse array output by using triu(coo_array(A)).
         For more information, see the spmatrix to sparray migration guide
         https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
 

--- a/scipy/sparse/_extract.py
+++ b/scipy/sparse/_extract.py
@@ -5,6 +5,9 @@ __docformat__ = "restructuredtext en"
 
 __all__ = ['find', 'tril', 'triu']
 
+import os
+from warnings import warn
+import numpy as np
 
 from ._coo import coo_matrix, coo_array
 from ._base import sparray
@@ -97,7 +100,26 @@ def tril(A, k=0, format=None):
         with 4 stored elements and shape (3, 5)>
 
     """
-    coo_sparse = coo_array if isinstance(A, sparray) else coo_matrix
+    if isinstance(A, sparray):
+        coo_sparse = coo_array
+    elif isinstance(A, np.ndarray):
+        msg = """`tril` is switching to the sparse array interface.
+
+        For the case where input arrays are numpy arrays, this function is
+        switching to returning a sparse array instead of sparse matrix.
+        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        For example, tril(coo_matrix(A)).
+        For more information, see the spmatrix to sparray migration guide
+        https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+
+        This function will be changed no earlier than v1.20.
+        """
+        prefixes = (os.path.dirname(__file__),)
+        warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
+        # default when input is ndarray
+        coo_sparse = coo_matrix
+    else:
+        coo_sparse = coo_matrix
 
     # convert to COOrdinate format where things are easy
     A = coo_sparse(A, copy=False)
@@ -165,7 +187,26 @@ def triu(A, k=0, format=None):
         with 8 stored elements and shape (3, 5)>
 
     """
-    coo_sparse = coo_array if isinstance(A, sparray) else coo_matrix
+    if isinstance(A, sparray):
+        coo_sparse = coo_array
+    elif isinstance(A, np.ndarray):
+        msg = """`triu` is switching to the sparse array interface.
+
+        For the case where input arrays are numpy arrays, this function is
+        switching to returning a sparse array instead of sparse matrix.
+        Recover the sparse matrix returns by making at least one input a sparse matrix.
+        For example, triu(coo_matrix(A)).
+        For more information, see the spmatrix to sparray migration guide
+        https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
+
+        This function will be changed no earlier than v1.20.
+        """
+        prefixes = (os.path.dirname(__file__),)
+        warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
+        # default when input is ndarray
+        coo_sparse = coo_matrix
+    else:
+        coo_sparse = coo_matrix
 
     # convert to COOrdinate format where things are easy
     A = coo_sparse(A, copy=False)

--- a/scipy/sparse/_extract.py
+++ b/scipy/sparse/_extract.py
@@ -9,8 +9,8 @@ import os
 from warnings import warn
 import numpy as np
 
-from ._coo import coo_matrix, coo_array
-from ._base import sparray
+from ._coo import coo_array, coo_matrix
+from ._base import sparray, spmatrix
 
 
 def find(A):
@@ -102,7 +102,9 @@ def tril(A, k=0, format=None):
     """
     if isinstance(A, sparray):
         coo_sparse = coo_array
-    elif isinstance(A, np.ndarray):
+    elif isinstance(A, spmatrix):
+        coo_sparse = coo_matrix
+    else:  # dense
         msg = """`tril` is switching to the sparse array interface.
 
         For the case where input arrays are numpy arrays, this function is
@@ -117,8 +119,6 @@ def tril(A, k=0, format=None):
         prefixes = (os.path.dirname(__file__),)
         warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
         # default when input is ndarray
-        coo_sparse = coo_matrix
-    else:
         coo_sparse = coo_matrix
 
     # convert to COOrdinate format where things are easy
@@ -189,7 +189,9 @@ def triu(A, k=0, format=None):
     """
     if isinstance(A, sparray):
         coo_sparse = coo_array
-    elif isinstance(A, np.ndarray):
+    elif isinstance(A, spmatrix):
+        coo_sparse = coo_matrix
+    else:  # dense
         msg = """`triu` is switching to the sparse array interface.
 
         For the case where input arrays are numpy arrays, this function is
@@ -204,8 +206,6 @@ def triu(A, k=0, format=None):
         prefixes = (os.path.dirname(__file__),)
         warn(msg, category=DeprecationWarning, skip_file_prefixes=prefixes)
         # default when input is ndarray
-        coo_sparse = coo_matrix
-    else:
         coo_sparse = coo_matrix
 
     # convert to COOrdinate format where things are easy

--- a/scipy/sparse/tests/test_64bit.py
+++ b/scipy/sparse/tests/test_64bit.py
@@ -35,6 +35,7 @@ SKIP_TESTS = {
     'test_large_dimensions_reshape': 'test actually requires 64-bit to work',
     'test_constructor_smallcol': 'test verifies int32 indexes',
     'test_constructor_largecol': 'test verifies int64 indexes',
+    'test_sparse_format_conversions': 'test produces deprecation warning',
     'test_tocoo_tocsr_tocsc_gh19245': 'test verifies int32 indexes',
 }
 

--- a/scipy/sparse/tests/test_array_api.py
+++ b/scipy/sparse/tests/test_array_api.py
@@ -436,6 +436,7 @@ def test_default_is_matrix_identity():
     assert not isinstance(m, scipy.sparse.sparray)
 
 
+@pytest.mark.filterwarnings("ignore:.*switching.*sparse array int:DeprecationWarning")
 def test_default_is_matrix_kron_dense():
     m = scipy.sparse.kron(
         np.array([[1, 2], [3, 4]]), np.array([[4, 3], [2, 1]])
@@ -443,6 +444,7 @@ def test_default_is_matrix_kron_dense():
     assert not isinstance(m, scipy.sparse.sparray)
 
 
+@pytest.mark.filterwarnings("ignore:.*switching.*sparse array int:DeprecationWarning")
 def test_default_is_matrix_kron_sparse():
     m = scipy.sparse.kron(
         np.array([[1, 2], [3, 4]]), np.array([[1, 0], [0, 0]])
@@ -450,6 +452,7 @@ def test_default_is_matrix_kron_sparse():
     assert not isinstance(m, scipy.sparse.sparray)
 
 
+@pytest.mark.filterwarnings("ignore:.*switching.*sparse array int:DeprecationWarning")
 def test_default_is_matrix_kronsum():
     m = scipy.sparse.kronsum(
         np.array([[1, 0], [0, 1]]), np.array([[0, 1], [1, 0]])
@@ -477,12 +480,25 @@ def test_default_is_matrix_stacks(fn):
     assert not isinstance(m, scipy.sparse.sparray)
 
 
+@pytest.mark.filterwarnings("ignore:.*switching.*sparse array int:DeprecationWarning")
 def test_blocks_default_construction_fn_matrices():
-    """Same idea as `test_default_construction_fn_matrices`, but for the block
-    creation function"""
+    """Same idea as `test_default_construction_fn_matrices`, but block functions"""
     A = scipy.sparse.coo_matrix(np.eye(2))
     B = scipy.sparse.coo_matrix([[2], [0]])
     C = scipy.sparse.coo_matrix([[3]])
+
+    # block diag
+    m = scipy.sparse.block_diag((A, B, C))
+    assert not isinstance(m, scipy.sparse.sparray)
+
+    # bmat
+    m = scipy.sparse.bmat([[A, None], [None, C]])
+    assert not isinstance(m, scipy.sparse.sparray)
+
+    # ndarray input
+    A = np.eye(2)
+    B = [[2], [0]]
+    C = [[3]]
 
     # block diag
     m = scipy.sparse.block_diag((A, B, C))

--- a/scipy/sparse/tests/test_base.py
+++ b/scipy/sparse/tests/test_base.py
@@ -2054,6 +2054,7 @@ class _TestCommon:
             assert_equal(result.shape, (4,2))
             assert_equal(result, dot(a,b))
 
+    @pytest.mark.filterwarnings("ignore:.*switching.*sparse array:DeprecationWarning")
     def test_sparse_format_conversions(self):
         A = sparse.kron([[1,0,2],[0,3,4],[5,0,0]], [[1,2],[0,3]])
         D = A.toarray()

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -884,6 +884,17 @@ class TestConstructUtils:
         assert_equal(sparse_array.count_nonzero(),172)
 
 
+def test_deprecated_warnings_output_defaults_switch_from_spmatrix():
+    A = B = np.array([[1, 0], [1, 0]])
+    with pytest.deprecated_call(match=".*switching.*sparse array int"):
+        construct.kron(A, B)
+    with pytest.deprecated_call(match=".*switching.*sparse array int"):
+        construct.kronsum(A, B)
+    # Note: vstack hstack and bmat do not support all dense input. So no default.
+    with pytest.deprecated_call(match=".*switching.*sparse array int"):
+        construct.block_diag([A, B])
+
+
 def test_diags_array():
     """Tests of diags_array that do not rely on diags wrapper."""
     diag = np.arange(1.0, 5.0)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -411,6 +411,7 @@ class TestConstructUtils:
         assert_array_equal(result.toarray(), expected)
         assert isinstance(result, spmatrix)
 
+    @pytest.mark.filterwarnings("ignore:.*switching.*sparse array:DeprecationWarning")
     def test_kron_ndim_exceptions(self):
         # spmatrix is default, so exceptions with 3D unless sparse arrays are input
         with pytest.raises(TypeError, match='expected 2D array or matrix'):
@@ -460,6 +461,7 @@ class TestConstructUtils:
         result = construct.kronsum(csr_matrix(a), csr_matrix(b)).toarray()
         assert_array_equal(result, expected)
 
+    @pytest.mark.filterwarnings("ignore:.*switching.*sparse array:DeprecationWarning")
     def test_kronsum_ndim_exceptions(self):
         with pytest.raises(ValueError, match='requires 2D input'):
             construct.kronsum([[0], [1]], csr_array([0, 1]))
@@ -743,6 +745,7 @@ class TestConstructUtils:
         X.coords = tuple(co.astype(np.int64) for co in X.coords)
         assert construct.block_diag([X, X]).coords[0].dtype == np.int64
 
+    @pytest.mark.filterwarnings("ignore:.*switching.*sparse array:DeprecationWarning")
     def test_block_diag_scalar_1d_args(self):
         """ block_diag with scalar and 1d arguments """
         # one 1d matrix and a scalar
@@ -754,6 +757,7 @@ class TestConstructUtils:
         assert_array_equal(construct.block_diag([A, B]).toarray(),
                            [[1, 0, 3, 0, 0], [0, 0, 0, 0, 4]])
 
+    @pytest.mark.filterwarnings("ignore:.*switching.*sparse array:DeprecationWarning")
     def test_block_diag_1(self):
         """ block_diag with one matrix """
         assert_equal(construct.block_diag([[1, 0]]).toarray(),

--- a/scipy/sparse/tests/test_extract.py
+++ b/scipy/sparse/tests/test_extract.py
@@ -1,5 +1,7 @@
 """test sparse matrix construction functions"""
 
+import pytest
+
 from numpy.testing import assert_equal
 from scipy.sparse import csr_matrix, csr_array, sparray
 
@@ -49,3 +51,11 @@ class TestExtract:
             M = csr_matrix(A)
             assert not isinstance(_extract.tril(M), sparray)
             assert not isinstance(_extract.triu(M), sparray)
+
+
+def test_deprecated_warnings_output_defaults_switch_from_spmatrix():
+    A = np.array([[1, 2], [3, 0]])
+    with pytest.deprecated_call(match=".*switching.*sparse array int"):
+        _extract.tril(A)
+    with pytest.deprecated_call(match=".*switching.*sparse array int"):
+        _extract.triu(A)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -9841,11 +9841,10 @@ def wasserstein_distance_nd(u_values, v_values, u_weights=None, v_weights=None):
         return np.nan
 
     # create constraints
-    A_upper_part = sparse.block_diag((np.ones((1, n)), ) * m)
-    A_lower_part = sparse.hstack((sparse.eye(n), ) * m)
+    A_upper_part = sparse.block_diag((sparse.coo_array(np.ones((1, n))), ) * m)
+    A_lower_part = sparse.hstack((sparse.eye_array(n), ) * m)
     # sparse constraint matrix of size (m + n)*(m * n)
     A = sparse.vstack((A_upper_part, A_lower_part))
-    A = sparse.coo_array(A)
 
     # get cost matrix
     D = distance_matrix(u_values, v_values, p=2)


### PR DESCRIPTION
Some sparse constructions function use the type of the input array to determine the output array type. For those that allow ndarray input arrays, there is a default output type currently set to sparse matrix type.

This PR adds deprecation warnings for the default output type of functions: 
`kron, kronsum, block_diag, tril, triu`.
The deprecation warning for `kron` has the following text. Others are similar:

>        `kron` is switching to the sparse array interface.
>
>        For the case where input arrays are numpy arrays, this function is
>        switching to returning a sparse array instead of sparse matrix.
>        Recover the sparse matrix returns by making at least one input a sparse matrix.
>        For example, kron(coo_matrix(A), B).
>        For more information, see the spmatrix to sparray migration guide
>        https://docs.scipy.org/doc/scipy/reference/sparse.migration_to_sparray.html
>
>        This function will be changed no earlier than v1.20.

This PR is part of tracking issue #24802 for eventual deprecation of spmatrix. It is proposed there to occur for v1.18.  An alternate approach would be to deprecate the default values when the spmatrix classes are removed. I'd prefer this approach because waiting could cause surprises when there isn't a nice way to temporarily go back to what you had. Here, the user can simply convert one of the inputs to sparse matrix and get the previous behavior.

Some other construction functions depend on the input type but don't support all ndarray inputs (i.e. at least one input array must be sparse) so they have no default output type. These do not show up here, but are `bmat, hstack, vstack`. 

@mdhaber there is a small change in `scipy/stats/_stats_py.py` here. Can you check it? We talked when it was put in place, but it is time to shift the conversion to coo_array earlier (2 and 3 lines up).  We could leave the line that explicitly converts to `coo_array`, but by using `coo_array` and `eye_array` we don't need to, so I removed that line.