### PR TITLE
MAINT: linalg: use ?trsyl3 in sqrtm when available

### DIFF
--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -100,7 +100,7 @@ _trsyl3_probe_code = '''
 '''
 _have_trsyl3 = cc.links(_trsyl3_probe_code,
   args: _trsyl3_probe_c_args,
-  dependencies: [lapack_dep],
+  dependencies: [lapack],
   name: 'LAPACK has `?trsyl3` symbols'
 )
 _internal_matfuncs_c_args = []

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -79,6 +79,35 @@ if get_option('_without-fortran')
   link_language_blas_lapack = 'c'
 endif
 
+# Detect whether the linked LAPACK provides the LAPACK 3.11 `?trsyl3` family.
+_trsyl3_probe_c_args = [
+  '-I' + (meson.project_source_root() / 'scipy/_build_utils/src'),
+]
+_trsyl3_probe_code = '''
+  #include "npy_cblas.h"
+  extern void BLAS_FUNC(strsyl3)(void);
+  extern void BLAS_FUNC(dtrsyl3)(void);
+  extern void BLAS_FUNC(ctrsyl3)(void);
+  extern void BLAS_FUNC(ztrsyl3)(void);
+  int
+  main(void)
+  {
+    return (&BLAS_FUNC(strsyl3) != 0 &&
+            &BLAS_FUNC(dtrsyl3) != 0 &&
+            &BLAS_FUNC(ctrsyl3) != 0 &&
+            &BLAS_FUNC(ztrsyl3) != 0) ? 0 : 1;
+  }
+'''
+_have_trsyl3 = cc.links(_trsyl3_probe_code,
+  args: _trsyl3_probe_c_args,
+  dependencies: [lapack_dep],
+  name: 'LAPACK has `?trsyl3` symbols'
+)
+_internal_matfuncs_c_args = []
+if _have_trsyl3
+  _internal_matfuncs_c_args += ['-DSCIPY_LINALG_HAVE_TRSYL3=1']
+endif
+
 message(f'{fblas_module}')
 
 # Note: we're linking LAPACK on purpose here. For some routines (e.g., spmv)
@@ -274,6 +303,7 @@ py3.extension_module('_internal_matfuncs',
     'src/_matfuncs_expm.c',
     'src/_matfuncs_sqrtm.c'
   ],
+  c_args: _internal_matfuncs_c_args,
   include_directories: ['src/', '../_build_utils/src'],  # for npy_cblas.h
   dependencies: [np_dep, lapack_dep],
   install: true,

--- a/scipy/linalg/src/_common_array_utils.h
+++ b/scipy/linalg/src/_common_array_utils.h
@@ -33,7 +33,9 @@ void BLAS_FUNC(slacn2)(CBLAS_INT* n, float* v, float* x, CBLAS_INT* isgn, float*
 void BLAS_FUNC(slanv2)(float* a, float* b, float* c, float* d, float* rt1r, float* rt1i, float* rt2r, float* rt2i, float* cs, float* sn);
 void BLAS_FUNC(sscal)(CBLAS_INT* n, float* sa, float* sx, CBLAS_INT* incx);
 void BLAS_FUNC(strsyl)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, float* a, CBLAS_INT* lda, float* b, CBLAS_INT* ldb, float* c, CBLAS_INT* ldc, float* scale, CBLAS_INT* info);
-// void BLAS_FUNC(strsyl3)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, float* a, CBLAS_INT* lda, float* b, CBLAS_INT* ldb, float* c, CBLAS_INT* ldc, float* scale, CBLAS_INT* iwork, CBLAS_INT* liwork, float* swork, CBLAS_INT* ldswork, CBLAS_INT* info);
+#ifdef SCIPY_LINALG_HAVE_TRSYL3
+void BLAS_FUNC(strsyl3)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, float* a, CBLAS_INT* lda, float* b, CBLAS_INT* ldb, float* c, CBLAS_INT* ldc, float* scale, CBLAS_INT* iwork, CBLAS_INT* liwork, float* swork, CBLAS_INT* ldswork, CBLAS_INT* info);
+#endif
 
 void BLAS_FUNC(daxpy)(CBLAS_INT* n, double* sa, double* sx, CBLAS_INT* incx, double* sy, CBLAS_INT* incy);
 void BLAS_FUNC(dcopy)(CBLAS_INT* n, double* dx, CBLAS_INT* incx, double* dy, CBLAS_INT* incy);
@@ -46,7 +48,9 @@ void BLAS_FUNC(dlacn2)(CBLAS_INT* n, double* v, double* x, CBLAS_INT* isgn, doub
 void BLAS_FUNC(dlanv2)(double* a, double* b, double* c, double* d, double* rt1r, double* rt1i, double* rt2r, double* rt2i, double* cs, double* sn);
 void BLAS_FUNC(dscal)(CBLAS_INT* n, double* sa, double* sx, CBLAS_INT* incx);
 void BLAS_FUNC(dtrsyl)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, double* a, CBLAS_INT* lda, double* b, CBLAS_INT* ldb, double* c, CBLAS_INT* ldc, double* scale, CBLAS_INT* info);
-// void BLAS_FUNC(dtrsyl3)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, double* a, CBLAS_INT* lda, double* b, CBLAS_INT* ldb, double* c, CBLAS_INT* ldc, double* scale, CBLAS_INT* iwork, CBLAS_INT* liwork, double* swork, CBLAS_INT* ldswork, CBLAS_INT* info);
+#ifdef SCIPY_LINALG_HAVE_TRSYL3
+void BLAS_FUNC(dtrsyl3)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, double* a, CBLAS_INT* lda, double* b, CBLAS_INT* ldb, double* c, CBLAS_INT* ldc, double* scale, CBLAS_INT* iwork, CBLAS_INT* liwork, double* swork, CBLAS_INT* ldswork, CBLAS_INT* info);
+#endif
 
 void BLAS_FUNC(caxpy)(CBLAS_INT* n, SCIPY_C* sa, SCIPY_C* sx, CBLAS_INT* incx, SCIPY_C* sy, CBLAS_INT* incy);
 void BLAS_FUNC(ccopy)(CBLAS_INT* n, SCIPY_C* dx, CBLAS_INT* incx, SCIPY_C* dy, CBLAS_INT* incy);
@@ -59,7 +63,9 @@ void BLAS_FUNC(clacn2)(CBLAS_INT* n, SCIPY_C* v, SCIPY_C* x, float* est, CBLAS_I
 void BLAS_FUNC(crot)(CBLAS_INT* n, SCIPY_C* cx, CBLAS_INT* incx, SCIPY_C* cy, CBLAS_INT* incy, float* c, SCIPY_C* s);
 void BLAS_FUNC(csscal)(CBLAS_INT* n, float* sa, SCIPY_C* sx, CBLAS_INT* incx);
 void BLAS_FUNC(ctrsyl)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_C* a, CBLAS_INT* lda, SCIPY_C* b, CBLAS_INT* ldb, SCIPY_C* c, CBLAS_INT* ldc, float* scale, CBLAS_INT* info);
-// void BLAS_FUNC(ctrsyl3)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_C* a, CBLAS_INT* lda, SCIPY_C* b, CBLAS_INT* ldb, SCIPY_C* c, CBLAS_INT* ldc, float* scale, float* swork, CBLAS_INT* ldswork, CBLAS_INT* info);
+#ifdef SCIPY_LINALG_HAVE_TRSYL3
+void BLAS_FUNC(ctrsyl3)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_C* a, CBLAS_INT* lda, SCIPY_C* b, CBLAS_INT* ldb, SCIPY_C* c, CBLAS_INT* ldc, float* scale, SCIPY_C* swork, CBLAS_INT* ldswork, CBLAS_INT* info);
+#endif
 
 void BLAS_FUNC(zaxpy)(CBLAS_INT* n, SCIPY_Z* sa, SCIPY_Z* sx, CBLAS_INT* incx, SCIPY_Z* sy, CBLAS_INT* incy);
 void BLAS_FUNC(zcopy)(CBLAS_INT* n, SCIPY_Z* dx, CBLAS_INT* incx, SCIPY_Z* dy, CBLAS_INT* incy);
@@ -72,7 +78,9 @@ void BLAS_FUNC(zlacn2)(CBLAS_INT* n, SCIPY_Z* v, SCIPY_Z* x, double* est, CBLAS_
 void BLAS_FUNC(zrot)(CBLAS_INT* n, SCIPY_Z* cx, CBLAS_INT* incx, SCIPY_Z* cy, CBLAS_INT* incy, double* c, SCIPY_Z* s);
 void BLAS_FUNC(zdscal)(CBLAS_INT* n, double* sa, SCIPY_Z* sx, CBLAS_INT* incx);
 void BLAS_FUNC(ztrsyl)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_Z* a, CBLAS_INT* lda, SCIPY_Z* b, CBLAS_INT* ldb, SCIPY_Z* c, CBLAS_INT* ldc, double* scale, CBLAS_INT* info);
-// void BLAS_FUNC(ztrsyl3)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_Z* a, CBLAS_INT* lda, SCIPY_Z* b, CBLAS_INT* ldb, SCIPY_Z* c, CBLAS_INT* ldc, double* scale, double* swork, CBLAS_INT* ldswork, CBLAS_INT* info);
+#ifdef SCIPY_LINALG_HAVE_TRSYL3
+void BLAS_FUNC(ztrsyl3)(char* trana, char* tranb, CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_Z* a, CBLAS_INT* lda, SCIPY_Z* b, CBLAS_INT* ldb, SCIPY_Z* c, CBLAS_INT* ldc, double* scale, SCIPY_Z* swork, CBLAS_INT* ldswork, CBLAS_INT* info);
+#endif
 
 /**
  *  These functions are used to measure the bandwidth of an (n x m) matrix

--- a/scipy/linalg/src/_matfuncs_sqrtm.c
+++ b/scipy/linalg/src/_matfuncs_sqrtm.c
@@ -7,6 +7,192 @@ static int sqrtm_recursion_z(SCIPY_Z* T, npy_intp bign, npy_intp n);
 static inline void zebra_pattern_s(float* restrict data, const Py_ssize_t n) {for (Py_ssize_t i=n-1; i>=0; i--) { data[2*i] = data[i]; data[2*i + 1] = 0.0f; }}
 static inline void zebra_pattern_d(double* restrict data, const Py_ssize_t n) {for (Py_ssize_t i=n-1; i>=0; i--) { data[2*i] = data[i]; data[2*i + 1] = 0.0; }}
 
+#ifdef SCIPY_LINALG_HAVE_TRSYL3
+static inline void
+solve_sylvester_s(CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, float* a, CBLAS_INT* lda,
+                  float* b, CBLAS_INT* ldb, float* c, CBLAS_INT* ldc, float* scale,
+                  CBLAS_INT* info)
+{
+    CBLAS_INT liwork_query = -1, ldswork_query = -1;
+    CBLAS_INT iwork_hint = 1;
+    float swork_hint[2] = {2.0f, 1.0f};
+    BLAS_FUNC(strsyl3)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale,
+                       &iwork_hint, &liwork_query, swork_hint, &ldswork_query, info);
+    if (*info < 0) {
+        *info = 0;
+        BLAS_FUNC(strsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+        return;
+    }
+
+    CBLAS_INT liwork = iwork_hint > 0 ? iwork_hint : 1;
+    CBLAS_INT ldswork = (CBLAS_INT)ceilf(swork_hint[0]);
+    CBLAS_INT cols = (CBLAS_INT)ceilf(swork_hint[1]);
+    ldswork = ldswork > 2 ? ldswork : 2;
+    cols = cols > 1 ? cols : 1;
+    size_t swork_size = (size_t)ldswork * (size_t)cols;
+    CBLAS_INT *iwork = malloc((size_t)liwork * sizeof(*iwork));
+    float *swork = malloc(swork_size * sizeof(*swork));
+    if (iwork == NULL || swork == NULL) {
+        free(iwork);
+        free(swork);
+        BLAS_FUNC(strsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+        return;
+    }
+
+    BLAS_FUNC(strsyl3)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale,
+                       iwork, &liwork, swork, &ldswork, info);
+    free(iwork);
+    free(swork);
+    if (*info < 0) {
+        *info = 0;
+        BLAS_FUNC(strsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+    }
+}
+
+static inline void
+solve_sylvester_d(CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, double* a, CBLAS_INT* lda,
+                  double* b, CBLAS_INT* ldb, double* c, CBLAS_INT* ldc, double* scale,
+                  CBLAS_INT* info)
+{
+    CBLAS_INT liwork_query = -1, ldswork_query = -1;
+    CBLAS_INT iwork_hint = 1;
+    double swork_hint[2] = {2.0, 1.0};
+    BLAS_FUNC(dtrsyl3)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale,
+                       &iwork_hint, &liwork_query, swork_hint, &ldswork_query, info);
+    if (*info < 0) {
+        *info = 0;
+        BLAS_FUNC(dtrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+        return;
+    }
+
+    CBLAS_INT liwork = iwork_hint > 0 ? iwork_hint : 1;
+    CBLAS_INT ldswork = (CBLAS_INT)ceil(swork_hint[0]);
+    CBLAS_INT cols = (CBLAS_INT)ceil(swork_hint[1]);
+    ldswork = ldswork > 2 ? ldswork : 2;
+    cols = cols > 1 ? cols : 1;
+    size_t swork_size = (size_t)ldswork * (size_t)cols;
+    CBLAS_INT *iwork = malloc((size_t)liwork * sizeof(*iwork));
+    double *swork = malloc(swork_size * sizeof(*swork));
+    if (iwork == NULL || swork == NULL) {
+        free(iwork);
+        free(swork);
+        BLAS_FUNC(dtrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+        return;
+    }
+
+    BLAS_FUNC(dtrsyl3)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale,
+                       iwork, &liwork, swork, &ldswork, info);
+    free(iwork);
+    free(swork);
+    if (*info < 0) {
+        *info = 0;
+        BLAS_FUNC(dtrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+    }
+}
+
+static inline void
+solve_sylvester_c(CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_C* a, CBLAS_INT* lda,
+                  SCIPY_C* b, CBLAS_INT* ldb, SCIPY_C* c, CBLAS_INT* ldc, float* scale,
+                  CBLAS_INT* info)
+{
+    CBLAS_INT ldswork_query = -1;
+    SCIPY_C swork_hint[2] = {CPLX_C(2.0f, 0.0f), CPLX_C(1.0f, 0.0f)};
+    BLAS_FUNC(ctrsyl3)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale,
+                       swork_hint, &ldswork_query, info);
+    if (*info < 0) {
+        *info = 0;
+        BLAS_FUNC(ctrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+        return;
+    }
+
+    CBLAS_INT ldswork = (CBLAS_INT)ceilf(crealf(swork_hint[0]));
+    CBLAS_INT cols = (CBLAS_INT)ceilf(crealf(swork_hint[1]));
+    ldswork = ldswork > 2 ? ldswork : 2;
+    cols = cols > 1 ? cols : 1;
+    size_t swork_size = (size_t)ldswork * (size_t)cols;
+    SCIPY_C *swork = malloc(swork_size * sizeof(*swork));
+    if (swork == NULL) {
+        BLAS_FUNC(ctrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+        return;
+    }
+
+    BLAS_FUNC(ctrsyl3)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale,
+                       swork, &ldswork, info);
+    free(swork);
+    if (*info < 0) {
+        *info = 0;
+        BLAS_FUNC(ctrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+    }
+}
+
+static inline void
+solve_sylvester_z(CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_Z* a, CBLAS_INT* lda,
+                  SCIPY_Z* b, CBLAS_INT* ldb, SCIPY_Z* c, CBLAS_INT* ldc, double* scale,
+                  CBLAS_INT* info)
+{
+    CBLAS_INT ldswork_query = -1;
+    SCIPY_Z swork_hint[2] = {CPLX_Z(2.0, 0.0), CPLX_Z(1.0, 0.0)};
+    BLAS_FUNC(ztrsyl3)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale,
+                       swork_hint, &ldswork_query, info);
+    if (*info < 0) {
+        *info = 0;
+        BLAS_FUNC(ztrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+        return;
+    }
+
+    CBLAS_INT ldswork = (CBLAS_INT)ceil(creal(swork_hint[0]));
+    CBLAS_INT cols = (CBLAS_INT)ceil(creal(swork_hint[1]));
+    ldswork = ldswork > 2 ? ldswork : 2;
+    cols = cols > 1 ? cols : 1;
+    size_t swork_size = (size_t)ldswork * (size_t)cols;
+    SCIPY_Z *swork = malloc(swork_size * sizeof(*swork));
+    if (swork == NULL) {
+        BLAS_FUNC(ztrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+        return;
+    }
+
+    BLAS_FUNC(ztrsyl3)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale,
+                       swork, &ldswork, info);
+    free(swork);
+    if (*info < 0) {
+        *info = 0;
+        BLAS_FUNC(ztrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+    }
+}
+#else
+static inline void
+solve_sylvester_s(CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, float* a, CBLAS_INT* lda,
+                  float* b, CBLAS_INT* ldb, float* c, CBLAS_INT* ldc, float* scale,
+                  CBLAS_INT* info)
+{
+    BLAS_FUNC(strsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+}
+
+static inline void
+solve_sylvester_d(CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, double* a, CBLAS_INT* lda,
+                  double* b, CBLAS_INT* ldb, double* c, CBLAS_INT* ldc, double* scale,
+                  CBLAS_INT* info)
+{
+    BLAS_FUNC(dtrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+}
+
+static inline void
+solve_sylvester_c(CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_C* a, CBLAS_INT* lda,
+                  SCIPY_C* b, CBLAS_INT* ldb, SCIPY_C* c, CBLAS_INT* ldc, float* scale,
+                  CBLAS_INT* info)
+{
+    BLAS_FUNC(ctrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+}
+
+static inline void
+solve_sylvester_z(CBLAS_INT* isgn, CBLAS_INT* m, CBLAS_INT* n, SCIPY_Z* a, CBLAS_INT* lda,
+                  SCIPY_Z* b, CBLAS_INT* ldb, SCIPY_Z* c, CBLAS_INT* ldc, double* scale,
+                  CBLAS_INT* info)
+{
+    BLAS_FUNC(ztrsyl)("N", "N", isgn, m, n, a, lda, b, ldb, c, ldc, scale, info);
+}
+#endif
+
 void
 matrix_squareroot_s(const PyArrayObject* ap_Am, float* restrict ret_data, int* isIllconditioned, int* isSingular, CBLAS_INT* sq_info, int* view_as_complex)
 {
@@ -792,7 +978,9 @@ sqrtm_recursion_s(float* T, npy_intp bign, npy_intp n)
             T[2*intbign + 1] = INFINITY;
             info = 1;
         } else {
-            BLAS_FUNC(strsyl)("N", "N", &int1, &halfn, &otherhalfn, T, &intbign, &T[halfn*(intbign + 1)], &intbign, &T[halfn*intbign], &intbign, &scale, &info);
+            solve_sylvester_s(&int1, &halfn, &otherhalfn, T, &intbign,
+                              &T[halfn*(intbign + 1)], &intbign,
+                              &T[halfn*intbign], &intbign, &scale, &info);
             if (scale != 1.0)
             {
                 for (i = 0; i < otherhalfn; i++)
@@ -883,7 +1071,9 @@ sqrtm_recursion_d(double* T, npy_intp bign, npy_intp n)
             T[2*intbign + 1] = INFINITY;
             info = 1;
         } else {
-            BLAS_FUNC(dtrsyl)("N", "N", &int1, &halfn, &otherhalfn, T, &intbign, &T[halfn*(intbign + 1)], &intbign, &T[halfn*intbign], &intbign, &scale, &info);
+            solve_sylvester_d(&int1, &halfn, &otherhalfn, T, &intbign,
+                              &T[halfn*(intbign + 1)], &intbign,
+                              &T[halfn*intbign], &intbign, &scale, &info);
             if (scale != 1.0)
             {
                 for (i = 0; i < otherhalfn; i++)
@@ -953,7 +1143,8 @@ sqrtm_recursion_c(SCIPY_C* T, npy_intp bign, npy_intp n)
             T12[intbign] = cinf;
             info = 1;
         } else {
-            BLAS_FUNC(ctrsyl)("N", "N", &int1, &halfn, &otherhalfn, T11, &intbign, T22, &intbign, T12, &intbign, &scale, &info);
+            solve_sylvester_c(&int1, &halfn, &otherhalfn, T11, &intbign,
+                              T22, &intbign, T12, &intbign, &scale, &info);
             if (scale != 1.0)
             {
                 for (i = 0; i < otherhalfn; i++)
@@ -1027,7 +1218,8 @@ sqrtm_recursion_z(SCIPY_Z* T, npy_intp bign, npy_intp n)
             T12[intbign] = zinf;
             info = 1;
         } else {
-            BLAS_FUNC(ztrsyl)("N", "N", &int1, &halfn, &otherhalfn, T11, &intbign, T22, &intbign, T12, &intbign, &scale, &info);
+            solve_sylvester_z(&int1, &halfn, &otherhalfn, T11, &intbign,
+                              T22, &intbign, T12, &intbign, &scale, &info);
             if (scale != 1.0)
             {
                 for (i = 0; i < otherhalfn; i++)
@@ -1058,4 +1250,3 @@ sqrtm_recursion_z(SCIPY_Z* T, npy_intp bign, npy_intp n)
 #undef SCIPY_C
 #undef CPLX_Z
 #undef CPLX_C
-

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -575,6 +575,37 @@ class TestSqrtM:
             res = sqrtm(a)
             assert np.isinf(res[0, 1:]).all()
 
+    @pytest.mark.parametrize('dtyp', [np.float32, np.float64,
+                                      np.complex64, np.complex128])
+    def test_sqrtm_n3_singular_sylvester_blocks(self, dtyp):
+        # Trigger both 2x1 and 1x2 Sylvester solves in n=3 recursion with
+        # singular diagonal blocks and verify inf propagation is preserved.
+        mats = (
+            np.array([[0, 2, 2], [0, 0, 0], [0, 0, 0]], dtype=dtyp),
+            np.array([[0, 0, 2], [0, 0, 2], [0, 0, 0]], dtype=dtyp),
+        )
+        for a in mats:
+            with pytest.warns(LinAlgWarning, match="Matrix is singular."):
+                res = sqrtm(a)
+            assert np.isinf(res).any()
+
+    @pytest.mark.parametrize('dtyp, atol',
+                             [(np.float32, 5e-5),
+                              (np.float64, 1e-12),
+                              (np.complex64, 5e-5),
+                              (np.complex128, 1e-12)])
+    def test_sqrtm_n3_round_trip_finite(self, dtyp, atol):
+        # Cover both split patterns in n=3 recursion while verifying finite,
+        # accurate square roots.
+        mats = (
+            np.array([[4, 0, 1], [0, 9, 2], [0, 0, 16]], dtype=dtyp),
+            np.array([[4, 1, 2], [0, 9, 3], [0, 0, 16]], dtype=dtyp),
+        )
+        for a in mats:
+            res = sqrtm(a)
+            assert np.isfinite(res).all()
+            assert_allclose(res @ res, a, atol=atol, rtol=atol)
+
 
 class TestFractionalMatrixPower:
     def test_round_trip_random_complex(self):


### PR DESCRIPTION
## Summary
- adds a build-time LAPACK symbol probe for `strsyl3/dtrsyl3/ctrsyl3/ztrsyl3` in `scipy/linalg/meson.build`
- enables `SCIPY_LINALG_HAVE_TRSYL3` for `_internal_matfuncs` when those symbols are present
- updates `sqrtm` C recursion to call `?trsyl3` with workspace-query/allocation, with automatic fallback to `?trsyl` when unavailable or unusable
- preserves existing singular `n == 3` handling and inf/nan propagation behavior
- extends `scipy/linalg/tests/test_matfuncs.py` with explicit `n==3` Sylvester split coverage and finite round-trip checks

## Testing
Executed in a local venv with editable SciPy build (`-Dblas=accelerate -Dlapack=accelerate`):

```bash
python -m pytest scipy/linalg/tests/test_matfuncs.py -k 'gh24508 or sqrtm_n3' -q
# 12 passed, 153 deselected

python -m pytest scipy/linalg/tests/test_matfuncs.py -q
# 158 passed, 1 skipped, 5 xfailed, 1 xpassed

python -m pytest scipy/linalg/tests -k 'sqrtm or trsyl' -q
# 44 passed, 9391 deselected

python -m pytest scipy/linalg/tests -q
# 8969 passed, 452 skipped, 12 xfailed, 2 xpassed
```

## Notes
- This keeps compatibility with LAPACK providers that do not expose `?trsyl3` yet.
- Ref: #24484
