### PR TITLE
MAINT: linalg: rename `type_traits` and `numeric_limits` to avoid std clash

### DIFF
--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1001,7 +1001,7 @@ _detect_problems(const SliceStatus& slice_status, SliceStatusVec& vec_status) {
  */
 template<typename T>
 CBLAS_INT _calc_lwork(T _lwrk, double fudge_factor=1.0) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     real_type value = real_part(_lwrk) * fudge_factor;
     if((std::is_same<real_type, float>::value) ||
@@ -1138,7 +1138,7 @@ void extract_upper_triangle(T *dst, const T* src, const npy_intp m, const npy_in
         }
 
         for (npy_intp j = stop; j < m; j++) {
-            dst[j*n + i] = numeric_limits<T>::zero;
+            dst[j*n + i] = sp_numeric_limits<T>::zero;
         }
     }
 }
@@ -1149,11 +1149,11 @@ void extract_upper_triangle(T *dst, const T* src, const npy_intp m, const npy_in
  */
 
 template<typename T>
-typename type_traits<T>::real_type
+typename sp_type_traits<T>::real_type
 norm1_(T* A, T* work, const npy_intp n)
 {
-    using real_type = typename type_traits<T>::real_type;
-    using value_type = typename type_traits<T>::value_type;
+    using real_type = typename sp_type_traits<T>::real_type;
+    using value_type = typename sp_type_traits<T>::value_type;
     value_type *pA = reinterpret_cast<value_type *>(A);
 
     Py_ssize_t i, j;
@@ -1170,11 +1170,11 @@ norm1_(T* A, T* work, const npy_intp n)
 
 
 template<typename T>
-typename type_traits<T>::real_type
+typename sp_type_traits<T>::real_type
 norm1_sym_herm_upper(T* A, T* work, const npy_intp n)
 {
-    using real_type = typename type_traits<T>::real_type;
-    using value_type = typename type_traits<T>::value_type;
+    using real_type = typename sp_type_traits<T>::real_type;
+    using value_type = typename sp_type_traits<T>::value_type;
     value_type *pA = reinterpret_cast<value_type *>(A);
 
     Py_ssize_t i, j;
@@ -1201,11 +1201,11 @@ norm1_sym_herm_upper(T* A, T* work, const npy_intp n)
 
 
 template<typename T>
-typename type_traits<T>::real_type
+typename sp_type_traits<T>::real_type
 norm1_sym_herm_lower(T* A, T* work, const npy_intp n)
 {
-    using real_type = typename type_traits<T>::real_type;
-    using value_type = typename type_traits<T>::value_type;
+    using real_type = typename sp_type_traits<T>::real_type;
+    using value_type = typename sp_type_traits<T>::value_type;
     value_type *pA = reinterpret_cast<value_type *>(A);
 
     Py_ssize_t i, j;
@@ -1230,7 +1230,7 @@ norm1_sym_herm_lower(T* A, T* work, const npy_intp n)
 
 
 template<typename T>
-typename type_traits<T>::real_type
+typename sp_type_traits<T>::real_type
 norm1_sym_herm(char uplo, T *A, T *work, const npy_intp n) {
     // NB: transpose for the F order
     if (uplo == 'U') {return norm1_sym_herm_lower(A, work, n);}
@@ -1240,10 +1240,10 @@ norm1_sym_herm(char uplo, T *A, T *work, const npy_intp n) {
 
 
 template<typename T>
-typename type_traits<T>::real_type
+typename sp_type_traits<T>::real_type
 norm1_tridiag(T* dl, T *d, T *du, T *work, const npy_intp n) {
-    using real_type = typename type_traits<T>::real_type;
-    using value_type = typename type_traits<T>::value_type;
+    using real_type = typename sp_type_traits<T>::real_type;
+    using value_type = typename sp_type_traits<T>::value_type;
 
     value_type *pd = reinterpret_cast<value_type *>(d);
     value_type *pdu = reinterpret_cast<value_type *>(du);
@@ -1272,10 +1272,10 @@ norm1_tridiag(T* dl, T *d, T *du, T *work, const npy_intp n) {
  * is always such that its number of rows is `2 * kl + ku + 1`.
  */
 template <typename T>
-typename type_traits<T>::real_type
+typename sp_type_traits<T>::real_type
 norm1_banded(T* ab, const npy_intp kl, const npy_intp ku, T* work, const npy_intp n) {
-    using real_type = typename type_traits<T>::real_type;
-    using value_type = typename type_traits<T>::value_type;
+    using real_type = typename sp_type_traits<T>::real_type;
+    using value_type = typename sp_type_traits<T>::value_type;
 
     value_type *pab = reinterpret_cast<value_type *>(ab);
     real_type *rwork = (real_type *)work;
@@ -1314,7 +1314,7 @@ template<typename T>
 void
 bandwidth(T* data, npy_intp n, npy_intp m, npy_intp* lower_band, npy_intp* upper_band)
 {
-    using value_type = typename type_traits<T>::value_type;
+    using value_type = typename sp_type_traits<T>::value_type;
     value_type *p_data = reinterpret_cast<value_type *>(data);
     value_type zero = value_type(0.);
 
@@ -1353,7 +1353,7 @@ template<typename T>
 void
 bandwidth_strided(T* data, npy_intp n, npy_intp m, npy_intp s1, npy_intp s2, npy_intp *lower_band, npy_intp *upper_band)
 {
-    using value_type = typename type_traits<T>::value_type;
+    using value_type = typename sp_type_traits<T>::value_type;
     value_type *p_data = reinterpret_cast<value_type *>(data);
     value_type zero = value_type(0.);
 
@@ -1395,7 +1395,7 @@ template<typename T>
 std::tuple<bool, bool>
 is_sym_or_herm(const T *data, npy_intp n) {
     // Return a pair of (is_symmetric, is_hermitian)
-    using value_type = typename type_traits<T>::value_type;
+    using value_type = typename sp_type_traits<T>::value_type;
     const value_type *p_data = reinterpret_cast<const value_type *>(data);
     bool all_sym = true, all_herm = true;
 
@@ -1560,13 +1560,13 @@ zero_other_triangle(char uplo, T *data, npy_intp n) {
     if (uplo == 'U') {
         for (npy_intp i=0; i<n; i++) {
             for (npy_intp j=i+1; j<n; j++){
-                data[j + i*n] = numeric_limits<T>::zero;
+                data[j + i*n] = sp_numeric_limits<T>::zero;
             }
         }
     } else {
         for (npy_intp i=0; i<n; i++) {
             for (npy_intp j=0; j<i; j++){
-                data[j + i*n] = numeric_limits<T>::zero;
+                data[j + i*n] = sp_numeric_limits<T>::zero;
             }
         }
     }
@@ -1578,7 +1578,7 @@ inline void
 nan_matrix(T * data, npy_intp n) {
     for (int i = 0; i < n; i++) {
         for (int j = 0; j < n; j++) {
-            data[i * n + j] = numeric_limits<T>::nan;
+            data[i * n + j] = sp_numeric_limits<T>::nan;
         }
     }
 }

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -37,8 +37,8 @@ template<typename T>
 int
 _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArrayObject *ap_vr, SliceStatusVec& vec_status)
 {
-    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
-    using npy_complex_type = typename type_traits<T>::npy_complex_type;
+    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using npy_complex_type = typename sp_type_traits<T>::npy_complex_type;
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -69,7 +69,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
-    T tmp = numeric_limits<T>::zero;
+    T tmp = sp_numeric_limits<T>::zero;
 
     char jobvl = compute_vl ? 'V': 'N', jobvr = compute_vr ? 'V' : 'N';
     CBLAS_INT lda = n;
@@ -78,7 +78,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
 
     // c- and z variants: lwork query segfaults with rwork=NULL, allocate it straight away
     real_type *rwork = NULL;
-    if constexpr (type_traits<T>::is_complex) {
+    if constexpr (sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(2*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
@@ -94,7 +94,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
 
     // allocate
     npy_intp bufsize = n*n + lwork + n;
-    npy_intp wi_size = type_traits<T>::is_complex ? 0 : n ;
+    npy_intp wi_size = sp_type_traits<T>::is_complex ? 0 : n ;
     bufsize += wi_size;
 
     npy_intp vl_size = compute_vl ? ldvl*n : 0;
@@ -140,7 +140,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
         }
 
         // copy-and-tranpose W, VR and VL slices from temp buffers to the output;
-        if constexpr (type_traits<T>::is_complex) {
+        if constexpr (sp_type_traits<T>::is_complex) {
             memcpy(ptr_W, wr, n*sizeof(T));
             ptr_W += n;
 
@@ -183,8 +183,8 @@ template<typename T>
 int
 _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArrayObject *ap_beta, PyArrayObject *ap_vl, PyArrayObject *ap_vr, SliceStatusVec& vec_status)
 {
-    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
-    using npy_complex_type = typename type_traits<T>::npy_complex_type;
+    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using npy_complex_type = typename sp_type_traits<T>::npy_complex_type;
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -220,7 +220,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
-    T tmp = numeric_limits<T>::zero;
+    T tmp = sp_numeric_limits<T>::zero;
 
     char jobvl = compute_vl ? 'V': 'N', jobvr = compute_vr ? 'V' : 'N';
     CBLAS_INT lda = n;
@@ -230,7 +230,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
     // similar to geev, allocate rwork right away (not sure if ?ggev segfaults otherwise, too)
     real_type *rwork = NULL;
-    if constexpr (type_traits<T>::is_complex) {
+    if constexpr (sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(8*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
@@ -246,7 +246,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
     // allocate
     npy_intp bufsize = n*n + n*n + lwork + n + n;
-    npy_intp alphai_size = type_traits<T>::is_complex ? 0 : n ;
+    npy_intp alphai_size = sp_type_traits<T>::is_complex ? 0 : n ;
     bufsize += alphai_size;
 
     npy_intp vl_size = compute_vl ? ldvl*n : 0;
@@ -298,7 +298,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
         }
 
         // copy-and-tranpose W, VR and VL slices from temp buffers to the output;
-        if constexpr (type_traits<T>::is_complex) {
+        if constexpr (sp_type_traits<T>::is_complex) {
             // alphar and beta are complex and compatible with the W array 
             memcpy(ptr_W, alphar, n*sizeof(T));
             ptr_W += n;

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -17,7 +17,7 @@ void invert_slice_general(
     CBLAS_INT N, T *data, CBLAS_INT *ipiv, void *irwork, T *work, CBLAS_INT lwork,
     SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -33,7 +33,7 @@ void invert_slice_general(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
 
             // finally, invert
             call_getri(&N, data, &N, ipiv, work, &lwork, &info);
@@ -55,7 +55,7 @@ void invert_slice_cholesky(
     char uplo, CBLAS_INT N, T *data, T* work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type anorm = norm1_sym_herm(uplo, data, work, (npy_intp)N);
@@ -71,7 +71,7 @@ void invert_slice_cholesky(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
 
             // finally, invert
             call_potri(&uplo, &N, data, &N, &info);
@@ -91,7 +91,7 @@ void invert_slice_sym_herm(
     bool is_symm_not_herm, 
     SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type rcond;
@@ -114,7 +114,7 @@ void invert_slice_sym_herm(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
 
             // finally, invert
             if (is_symm_not_herm) {
@@ -138,7 +138,7 @@ void invert_slice_triangular(
     char uplo, char diag, CBLAS_INT N, T *data, T *work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -152,7 +152,7 @@ void invert_slice_triangular(
 
         call_trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
             status.rcond = (double)rcond;
         }
     }
@@ -164,8 +164,8 @@ template<typename T>
 inline void invert_slice_diagonal(
     CBLAS_INT N, T *data, SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
-    using value_type = typename type_traits<T>::value_type;
+    using real_type = typename sp_type_traits<T>::real_type;
+    using value_type = typename sp_type_traits<T>::value_type;
     value_type *pdata = reinterpret_cast<value_type *>(data);
 
     value_type zero(0.), one(1.);
@@ -189,7 +189,7 @@ inline void invert_slice_diagonal(
         if(absa > maxa) {maxa = absa;}
         if(absinva > maxinva) {maxinva = absinva;}
     }
-    status.is_ill_conditioned = maxa * maxinva > 1./ numeric_limits<real_type>::eps;
+    status.is_ill_conditioned = maxa * maxinva > 1./ sp_numeric_limits<real_type>::eps;
     status.rcond = maxa * maxinva;
 }
 
@@ -198,7 +198,7 @@ template<typename T>
 int
 _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwrite_a, SliceStatusVec& vec_status)
 {
-    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     npy_intp lower_band = 0, upper_band = 0;
     bool is_symm = false, is_herm = false;
@@ -225,8 +225,8 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     // --------------------------------------------------------------------
     // Workspace computation and allocation
     // --------------------------------------------------------------------
-    T tmp = numeric_limits<T>::zero;
-    T tmp1 = numeric_limits<T>::zero;
+    T tmp = sp_numeric_limits<T>::zero;
+    T tmp1 = sp_numeric_limits<T>::zero;
     CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
 
     call_getri(&intn, NULL, &intn, NULL, &tmp, &lwork, &info);
@@ -308,7 +308,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
-    if constexpr(type_traits<T>::is_complex) {
+    if constexpr(sp_type_traits<T>::is_complex) {
         irwork = malloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
@@ -369,7 +369,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                 // Check if symmetric/hermitian
                 std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
 
-                if constexpr (!type_traits<T>::is_complex) {
+                if constexpr (!sp_type_traits<T>::is_complex) {
                     // Real: is_symm and is_herm are always equal
                     if (is_symm) {
                         // try Cholesky first, fall back to sytrf if it fails
@@ -453,7 +453,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
             case St::SYM:     // NB: if POS_DEF failed, fall-through to here
             case St::HER:
             {
-                if constexpr (!type_traits<T>::is_complex) {
+                if constexpr (!sp_type_traits<T>::is_complex) {
                     // Real: always use sytrf/sytri
                     invert_slice_sym_herm(uplo, intn, data, ipiv, work, irwork, lwork, true, slice_status);
                 }
@@ -466,7 +466,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                     goto free_exit;
                 }
 
-                if constexpr (!type_traits<T>::is_complex) {
+                if constexpr (!sp_type_traits<T>::is_complex) {
                     // Real symmetric
                     fill_other_triangle_noconj(uplo, data, intn);
                 }

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -6,7 +6,7 @@ template<typename T>
 int
 _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, SliceStatusVec& vec_status)
 {
-    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -56,7 +56,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     CBLAS_INT rank = min_mn;
 
     // query LWORK
-    T tmp = numeric_limits<T>::zero;
+    T tmp = sp_numeric_limits<T>::zero;
     call_gelss(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
     if(info != 0) { return -100; }
 
@@ -75,7 +75,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     T *work = &buffer[m*n + ldb*nrhs];
 
     real_type *rwork = NULL;
-    if constexpr (type_traits<T>::is_complex) {
+    if constexpr (sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -132,7 +132,7 @@ template<typename T>
 int
 _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, SliceStatusVec& vec_status)
 {
-    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -177,14 +177,14 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
 
     // query LWORK, LRWORK and LIWORK
     // XXX: bump LRWORK and LIWORK up to improve perf? lwork=-1 query returns the *minimum* values
-    T tmp = numeric_limits<T>::zero;
+    T tmp = sp_numeric_limits<T>::zero;
     real_type tmp_lrwork = 0;
     CBLAS_INT liwork = 0, lrwork = 0;
     call_gelsd(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, &tmp_lrwork, &liwork, &info);
 
     if(info != 0) { return -100; }
     lwork = _calc_lwork(tmp);
-    lrwork = type_traits<T>::is_complex ? _calc_lwork(tmp_lrwork) : 0 ; 
+    lrwork = sp_type_traits<T>::is_complex ? _calc_lwork(tmp_lrwork) : 0 ; 
 
     if ((lwork < 0) || (lrwork < 0) || (liwork < 0)) {return -111;}
 
@@ -200,7 +200,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     T *work = &buffer[m*n + ldb*nrhs];
 
     real_type *rwork = NULL;
-    if constexpr (type_traits<T>::is_complex) {
+    if constexpr (sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(lrwork*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -263,7 +263,7 @@ template<typename T>
 int
 _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, SliceStatusVec& vec_status)
 {
-    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -306,7 +306,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     CBLAS_INT rank = min_mn;
 
     // query LWORK
-    T tmp = numeric_limits<T>::zero;
+    T tmp = sp_numeric_limits<T>::zero;
     call_gelsy(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
     if(info != 0) { return -100; }
 
@@ -325,7 +325,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     T *work = &buffer[m*n + ldb*nrhs];
 
     real_type *rwork = NULL;
-    if constexpr (type_traits<T>::is_complex) {
+    if constexpr (sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(2*n*sizeof(real_type));
 
         if (rwork == NULL) {

--- a/scipy/linalg/src/_linalg_qr.hh
+++ b/scipy/linalg/src/_linalg_qr.hh
@@ -7,7 +7,7 @@ template<typename T>
 int
 _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObject *ap_tau, PyArrayObject *ap_jpvt, int overwrite_a, QR_mode mode, int pivoting, SliceStatusVec &vec_status)
 {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
     SliceStatus slice_status;
 
     // ------------------------------------------------------------------------
@@ -55,8 +55,8 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
 
 
     // Probe both the factorization as well as `or_un_gqr` to find the optimal lwork
-    T tmp_factor = numeric_limits<T>::zero;
-    T tmp_or_un_gqr = numeric_limits<T>::zero;
+    T tmp_factor = sp_numeric_limits<T>::zero;
+    T tmp_or_un_gqr = sp_numeric_limits<T>::zero;
     CBLAS_INT lwork = -1;
 
     if (!pivoting) {
@@ -98,7 +98,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
 
     // `c/zgeqp3` needs rwork
     void *rwork = NULL;
-    if (pivoting && type_traits<T>::is_complex) {
+    if (pivoting && sp_type_traits<T>::is_complex) {
         rwork = malloc(2 * N * sizeof(real_type));
 
         if (rwork == NULL) {

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -16,7 +16,7 @@ inline void solve_slice_general(
     CBLAS_INT N, CBLAS_INT NRHS, T *data, CBLAS_INT *ipiv, T *b_data, char trans, void *irwork, T *work,
     SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -32,7 +32,7 @@ inline void solve_slice_general(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             call_getrs(&trans, &N, &NRHS, data, &N, ipiv, b_data, &N, &info);
@@ -52,7 +52,7 @@ inline void solve_slice_triangular(
     char uplo, char diag, CBLAS_INT N, CBLAS_INT NRHS, T *data,  T *b_data, char trans, T *work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -65,7 +65,7 @@ inline void solve_slice_triangular(
     if(info >= 0) {
         call_trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
             status.rcond = (double)rcond;
         }
     }
@@ -78,7 +78,7 @@ inline void solve_slice_cholesky(
     char uplo, CBLAS_INT N, CBLAS_INT NRHS, T *data, T *b_data, T* work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type rcond;
@@ -93,7 +93,7 @@ inline void solve_slice_cholesky(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             call_potrs(&uplo, &N, &NRHS, data, &N, b_data, &N, &info);
@@ -114,7 +114,7 @@ void solve_slice_sym_herm(
     bool is_symm_not_herm,
     SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type rcond;
@@ -137,7 +137,7 @@ void solve_slice_sym_herm(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             if (is_symm_not_herm) {
@@ -162,7 +162,7 @@ void solve_slice_tridiag(
     T *work, T *work2, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
     // work is 4*n, is for dl, d, du, du2
     // work2 is 2*n, is for trcon's work array
 
@@ -188,7 +188,7 @@ void solve_slice_tridiag(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             call_gttrs(&trans, &N, &NRHS, dl, d, du, du2, ipiv, b_data, &N, &info);
@@ -207,7 +207,7 @@ inline void solve_slice_banded(
     char trans, CBLAS_INT N, CBLAS_INT NRHS, T *ab, CBLAS_INT *ipiv, T *b_data, T *work2, void *irwork,
     CBLAS_INT kl, CBLAS_INT ku, SliceStatus &status
 ) {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT ldab = 2 * kl + ku + 1;
 
@@ -224,7 +224,7 @@ inline void solve_slice_banded(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             call_gbtrs(&trans, &N, &kl, &ku, &NRHS, ab, &ldab, ipiv, b_data, &N, &info);
@@ -243,8 +243,8 @@ template<typename T>
 inline void solve_slice_diagonal(
     CBLAS_INT N, CBLAS_INT NRHS, T *data, T *b_data, SliceStatus& status
 ) {
-    using real_type = typename type_traits<T>::real_type;
-    using value_type = typename type_traits<T>::value_type;
+    using real_type = typename sp_type_traits<T>::real_type;
+    using value_type = typename sp_type_traits<T>::value_type;
     value_type *pdata = reinterpret_cast<value_type *>(data);
     value_type *p_bdata = reinterpret_cast<value_type *>(b_data);
 
@@ -271,7 +271,7 @@ inline void solve_slice_diagonal(
         if(absa > maxa) {maxa = absa;}
         if(absinva > maxinva) {maxinva = absinva;}
     }
-    status.is_ill_conditioned = maxa * maxinva > 1./ numeric_limits<real_type>::eps;
+    status.is_ill_conditioned = maxa * maxinva > 1./ sp_numeric_limits<real_type>::eps;
     status.rcond = maxa * maxinva;
 }
 
@@ -282,7 +282,7 @@ template<typename T>
 int
 _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, char trans, int overwrite_a, int overwrite_b, SliceStatus slice_status, SliceStatusVec &vec_status)
 {
-    using real_type = typename type_traits<T>::real_type;
+    using real_type = typename sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     npy_intp *ks = NULL; // For storage of the bandwidths
@@ -319,7 +319,7 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
     }
 
     void *irwork;
-    if constexpr (type_traits<T>::is_complex) {
+    if constexpr (sp_type_traits<T>::is_complex) {
         irwork = malloc(intn * sizeof(real_type));
     } else {
         irwork = malloc(intn * sizeof(CBLAS_INT));
@@ -424,7 +424,7 @@ template<typename T>
 int
 _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int lower, int transposed, int overwrite_a, int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     char trans = transposed ? 'T' : 'N';
     npy_intp lower_band = 0, upper_band = 0;
@@ -467,7 +467,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs, lwork=-1, info;
 
-    T tmp = numeric_limits<T>::zero;
+    T tmp = sp_numeric_limits<T>::zero;
     call_sytrf(&uplo, &intn, NULL, &intn, NULL, &tmp, &lwork, &info);
     if (info != 0) { info = -100; return (int)info; }
 
@@ -536,7 +536,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
-    if constexpr (type_traits<T>::is_complex) {
+    if constexpr (sp_type_traits<T>::is_complex) {
         irwork = malloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
@@ -603,12 +603,12 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
             } else {
                 // Check if symmetric/hermitian
                 std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
-                if (is_herm || (is_symm && !type_traits<T>::is_complex)) {
+                if (is_herm || (is_symm && !sp_type_traits<T>::is_complex)) {
                     // either real symmetric or complex hermitian; try Cholesky first,
                     // fall back to sym/her if it fails
                     slice_structure = St::POS_DEF;
                 }
-                else if (is_symm && type_traits<T>::is_complex) {
+                else if (is_symm && sp_type_traits<T>::is_complex) {
                     // complex symmetric, not hermitian
                     slice_structure = St::SYM;
                 }

--- a/scipy/linalg/src/_linalg_svd.hh
+++ b/scipy/linalg/src/_linalg_svd.hh
@@ -45,7 +45,7 @@ template<typename T>
 int
 _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, SliceStatusVec& vec_status)
 {
-    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -85,7 +85,7 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, lwork = -1, info;
-    T tmp = numeric_limits<T>::zero;
+    T tmp = sp_numeric_limits<T>::zero;
 
     // query LWORK
     call_gesdd(&jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, NULL, &info);
@@ -125,7 +125,7 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     }
 
     // rwork
-    if constexpr (type_traits<T>::is_complex) {
+    if constexpr (sp_type_traits<T>::is_complex) {
         // assume LAPACK > 3.6 (cf LAPACK docs on netlib.org)
         npy_intp lrwork = std::max(
             5*min_mn*min_mn + 5*min_mn,
@@ -187,7 +187,7 @@ template<typename T>
 int
 _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, SliceStatusVec& vec_status)
 {
-    using real_type = typename type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -226,7 +226,7 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, lwork = -1, info;
-    T tmp = numeric_limits<T>::zero;
+    T tmp = sp_numeric_limits<T>::zero;
 
     // query LWORK
     call_gesvd(&jobz, &jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, &info);
@@ -256,7 +256,7 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     }
 
     real_type *rwork = NULL;
-    if constexpr (type_traits<T>::is_complex) {
+    if constexpr (sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
         if (rwork == NULL) {
             free(buf);

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -9,13 +9,13 @@
 
 
 /*
- * std::numeric_limits and useful constants.
+ * Numeric limits and useful constants for NumPy scalar types.
  */
 
-template<typename T> struct numeric_limits {};
+template<typename T> struct sp_numeric_limits {};
 
 template<>
-struct numeric_limits<float>{
+struct sp_numeric_limits<float>{
     static constexpr double zero = 0.0f;
     static constexpr double one = 1.0f;
     static constexpr float nan = std::numeric_limits<float>::quiet_NaN();
@@ -23,7 +23,7 @@ struct numeric_limits<float>{
 };
 
 template<>
-struct numeric_limits<double>{
+struct sp_numeric_limits<double>{
     static constexpr double zero = 0.0;
     static constexpr double one = 1.0;
     static constexpr double nan = std::numeric_limits<double>::quiet_NaN();
@@ -32,7 +32,7 @@ struct numeric_limits<double>{
 
 
 template<>
-struct numeric_limits<npy_complex64>{
+struct sp_numeric_limits<npy_complex64>{
     static constexpr npy_complex64 zero = {0.0f, 0.0f};
     static constexpr npy_complex64 one = {1.0f, 0.0f};
     static constexpr npy_complex64 nan = {std::numeric_limits<float>::quiet_NaN(),
@@ -40,7 +40,7 @@ struct numeric_limits<npy_complex64>{
 };
 
 template<>
-struct numeric_limits<npy_complex128>{
+struct sp_numeric_limits<npy_complex128>{
     static constexpr npy_complex128 zero = {0.0, 0.0};
     static constexpr npy_complex128 one = {1.0, 0.0};
     static constexpr npy_complex128 nan = {std::numeric_limits<double>::quiet_NaN(),
@@ -48,10 +48,17 @@ struct numeric_limits<npy_complex128>{
 };
 
 /*
- * XXX merge with numeric_limits ?
+ * Type traits for mapping NumPy types (e.g., npy_complex64) to their C++ equivalents.
+ *
+ * Provides:
+ *   - real_type: the underlying real type (float/double)
+ *   - value_type: C++ type for operations (float/double/std::complex<float>/std::complex<double>)
+ *   - npy_complex_type: the corresponding NumPy complex type
+ *   - typenum: NumPy type number (NPY_FLOAT, NPY_DOUBLE, etc.)
+ *   - is_complex: boolean indicating whether the type is complex
  */
-template<typename T> struct type_traits {};
-template<> struct type_traits<float> {
+template<typename T> struct sp_type_traits {};
+template<> struct sp_type_traits<float> {
     using real_type = float;
     using value_type = float;
     using npy_complex_type = npy_complex64;
@@ -59,21 +66,21 @@ template<> struct type_traits<float> {
     static constexpr bool is_complex = false;
 
 };
-template<> struct type_traits<double> {
+template<> struct sp_type_traits<double> {
     using real_type = double;
     using value_type = double;
     using npy_complex_type = npy_complex128;
     static constexpr int typenum = NPY_DOUBLE;
     static constexpr bool is_complex = false;
 };
-template<> struct type_traits<npy_complex64> {
+template<> struct sp_type_traits<npy_complex64> {
     using real_type = float;
     using value_type = std::complex<float>;
     using npy_complex_type = npy_complex64;
     static constexpr int typenum = NPY_COMPLEX64;
     static constexpr bool is_complex = true;
 };
-template<> struct type_traits<npy_complex128> {
+template<> struct sp_type_traits<npy_complex128> {
     using real_type = double;
     using value_type = std::complex<double>;
     using npy_complex_type = npy_complex128;


### PR DESCRIPTION
The custom `type_traits` and `numeric_limits` structs in the global namespace of `_npymath.hh` clash with the C++ standard library headers `<type_traits>` and `<limits>`. Rename to `sp_type_traits` and `sp_numeric_limits` to clarify these are SciPy-internal helpers for NumPy types and to avoid confusion or conflicts.

This follows up on https://github.com/scipy/scipy/pull/24858#issuecomment-4088579254. 

Note that this wasn't actually broken, but it was potentially fragile. In idiomatic C++ code, such utilities modeled after things in the standard library are probably best put into a namespace, but reworking that whole header with namespaces is a significantly larger change, so I decided against that. This PR just addresses the follow-up in the simplest way, with a rename.


#### AI Generation Disclosure

I chose the name and approach, then used Claude Code with Opus 4.6 to implement the renames. I also asked it to fix the code comments in `_npymath.h` and then made them a little more concise by hand.