### PR TITLE
BENCH: switch spmatrix to sparray in benchmarks that don't compare the two

### DIFF
--- a/benchmarks/benchmarks/interpolate.py
+++ b/benchmarks/benchmarks/interpolate.py
@@ -9,7 +9,7 @@ with safe_import():
     import scipy.interpolate as interpolate
 
 with safe_import():
-    from scipy.sparse import csr_matrix
+    from scipy.sparse import csr_array
 
 
 class Leaks(Benchmark):
@@ -123,8 +123,8 @@ class GridDataPeakMem(Benchmark):
 
         random_values = rng.random(num_nonzero, dtype=np.float32)
 
-        sparse_matrix = csr_matrix((random_values, (random_rows, random_cols)),
-                                   shape=shape, dtype=np.float32)
+        sparse_matrix = csr_array((random_values, (random_rows, random_cols)),
+                                  shape=shape, dtype=np.float32)
         sparse_matrix = sparse_matrix.toarray()
 
         self.coords = np.column_stack(np.nonzero(sparse_matrix))

--- a/benchmarks/benchmarks/io_mm.py
+++ b/benchmarks/benchmarks/io_mm.py
@@ -19,7 +19,7 @@ def generate_coo(size):
     rows = np.arange(nnz, dtype=np.int32)
     cols = np.arange(nnz, dtype=np.int32)
     data = np.random.default_rng().uniform(low=0, high=1.0, size=nnz)
-    return scipy.sparse.coo_matrix((data, (rows, cols)), shape=(nnz, nnz))
+    return scipy.sparse.coo_array((data, (rows, cols)), shape=(nnz, nnz))
 
 
 def generate_csr(size):
@@ -29,7 +29,7 @@ def generate_csr(size):
     indptr[-1] = nnz
     indices = np.arange(nnz, dtype=np.int32)
     data = np.random.default_rng().uniform(low=0, high=1.0, size=nnz)
-    return scipy.sparse.csr_matrix((data, indices, indptr), shape=(nrows, nnz))
+    return scipy.sparse.csr_array((data, indices, indptr), shape=(nrows, nnz))
 
 
 def generate_dense(size):
@@ -125,7 +125,7 @@ class MemUsage(Benchmark):
             rows = np.arange(nnz, dtype=np.int32)
             cols = np.arange(nnz, dtype=np.int32)
             data = np.random.default_rng().uniform(low=0, high=1.0, size=nnz)
-            return scipy.sparse.coo_matrix((data, (rows, cols)), shape=(nnz, nnz))
+            return scipy.sparse.coo_array((data, (rows, cols)), shape=(nnz, nnz))
 
         def generate_csr(size):
             nrows = 1000
@@ -134,7 +134,7 @@ class MemUsage(Benchmark):
             indptr[-1] = nnz
             indices = np.arange(nnz, dtype=np.int32)
             data = np.random.default_rng().uniform(low=0, high=1.0, size=nnz)
-            return scipy.sparse.csr_matrix((data, indices, indptr), shape=(nrows, nnz))
+            return scipy.sparse.csr_array((data, indices, indptr), shape=(nrows, nnz))
         
         def generate_dense(size):
             nnz = size // 8

--- a/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
+++ b/benchmarks/benchmarks/sparse_csgraph_dijkstra.py
@@ -28,7 +28,7 @@ class Dijkstra(Benchmark):
             rows = [0 for i in range(n - 1)] + [i + 1 for i in range(n - 1)]
             cols = [i + 1 for i in range(n - 1)] + [0 for i in range(n - 1)]
             weights = [i + 1 for i in range(n - 1)] * 2
-            self.data = scipy.sparse.csr_matrix((weights, (rows, cols)),
+            self.data = scipy.sparse.csr_array((weights, (rows, cols)),
                                                 shape=(n, n))
         # choose some random vertices
         v = np.arange(n)

--- a/benchmarks/benchmarks/sparse_csgraph_matching.py
+++ b/benchmarks/benchmarks/sparse_csgraph_matching.py
@@ -20,8 +20,8 @@ class MaximumBipartiteMatching(Benchmark):
         # disregarding duplicates is quite a bit faster.
         rng = np.random.default_rng(42)
         d = rng.integers(0, n, size=(int(n*n*density), 2))
-        graph = scipy.sparse.csr_matrix((np.ones(len(d)), (d[:, 0], d[:, 1])),
-                                        shape=(n, n))
+        graph = scipy.sparse.csr_array((np.ones(len(d)), (d[:, 0], d[:, 1])),
+                                       shape=(n, n))
         self.graph = graph
 
     def time_maximum_bipartite_matching(self, n, density):
@@ -32,7 +32,7 @@ class MaximumBipartiteMatching(Benchmark):
 # the classes defined in Burkard, Dell'Amico, Martello -- Assignment Problems,
 # 2009, Section 4.10.1.
 def random_uniform(shape, rng):
-    return scipy.sparse.csr_matrix(rng.uniform(1, 100, shape))
+    return scipy.sparse.csr_array(rng.uniform(1, 100, shape))
 
 
 def random_uniform_sparse(shape, rng):
@@ -41,23 +41,23 @@ def random_uniform_sparse(shape, rng):
 
 
 def random_uniform_integer(shape, rng):
-    return scipy.sparse.csr_matrix(rng.integers(1, 1000, shape))
+    return scipy.sparse.csr_array(rng.integers(1, 1000, shape))
 
 
 def random_geometric(shape, rng):
     P = rng.integers(1, 1000, size=(shape[0], 2))
     Q = rng.integers(1, 1000, size=(shape[1], 2))
-    return scipy.sparse.csr_matrix(cdist(P, Q, 'sqeuclidean'))
+    return scipy.sparse.csr_array(cdist(P, Q, 'sqeuclidean'))
 
 
 def random_two_cost(shape, rng):
-    return scipy.sparse.csr_matrix(rng.choice((1, 1000000), shape))
+    return scipy.sparse.csr_array(rng.choice((1, 1000000), shape))
 
 
 def machol_wien(shape, rng):
     # Machol--Wien instances being harder than the other examples, we cut
     # down the size of the instance by 5.
-    return scipy.sparse.csr_matrix(
+    return scipy.sparse.csr_array(
         np.outer(np.arange(shape[0]//5) + 1, np.arange(shape[1]//5) + 1))
 
 

--- a/benchmarks/benchmarks/sparse_csgraph_maxflow.py
+++ b/benchmarks/benchmarks/sparse_csgraph_maxflow.py
@@ -16,7 +16,7 @@ class MaximumFlow(Benchmark):
         data = (scipy.sparse.rand(n, n, density=density, format='lil',
                                   random_state=42)*100).astype(np.int32)
         data.setdiag(np.zeros(n, dtype=np.int32))
-        self.data = scipy.sparse.csr_matrix(data)
+        self.data = scipy.sparse.csr_array(data)
 
     def time_maximum_flow(self, n, density):
         maximum_flow(self.data, 0, n - 1)

--- a/benchmarks/benchmarks/sparse_linalg_expm.py
+++ b/benchmarks/benchmarks/sparse_linalg_expm.py
@@ -15,7 +15,7 @@ def random_sparse_csr(m, n, nnz_per_row):
     rows = np.arange(m).repeat(nnz_per_row)
     cols = np.random.randint(0, n, size=nnz_per_row*m)
     vals = np.random.random_sample(m*nnz_per_row)
-    M = scipy.sparse.coo_matrix((vals, (rows, cols)), (m, n), dtype=float)
+    M = scipy.sparse.coo_array((vals, (rows, cols)), (m, n), dtype=float)
     return M.tocsr()
 
 
@@ -24,7 +24,7 @@ def random_sparse_csc(m, n, nnz_per_row, rng):
     rows = np.arange(m).repeat(nnz_per_row)
     cols = rng.integers(0, n, size=nnz_per_row*m)
     vals = rng.random(m*nnz_per_row)
-    M = scipy.sparse.coo_matrix((vals, (rows, cols)), (m, n), dtype=float)
+    M = scipy.sparse.coo_array((vals, (rows, cols)), (m, n), dtype=float)
     # Use csc instead of csr, because sparse LU decomposition
     # raises a warning when I use csr.
     return M.tocsc()


### PR DESCRIPTION
Closes #24803

This PR switches all benchmarks that don't compare sparray to spmatrix from using spmatrix to using sparray.
The actual code being benchmarked does not change -- that is, none of the code being timed uses code that differs between spmatrix and sparray. So it should be safe to make the switch. There might be some speedup due to checks for spmatrix during creation, but they should be very very small. None of the comparison benchmarks show differences between these types.

The benchmarks which compare the two types (in `sparse.py`) will switch to only benchmarking sparray when spmatrix is removed. This is how they were set up before the transition started. 

This transition is mentioned in the tracking issue for the deprecation of spmatrix #24802 which contains more information about the deprecation plan.

The idea for making this change all at once is to isolate any impact of changing sparse types to one commit. But from local runs it looks like there isn't any impact.
