### PR TITLE
MAINT: stats: use xsf gufunc in pmf and cdf calculation for `poisson_binom`

### DIFF
--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -830,3 +830,24 @@ class Quantile(Benchmark):
 
     def time_quantile(self, size, d):
         stats.quantile(self.x, 0.5, axis=1)
+
+
+class PoissonBinom(Benchmark):
+    param_names = ["size_p", "batch_shape"]
+    params = [
+        [10, 100],
+        [(), (10, ), (100, ), (1000, )]
+    ]
+
+    def setup(self, size_p, batch_shape):
+        self.rng = np.random.default_rng(12345678)
+        shape = batch_shape + (size_p,)
+
+        self.p = self.rng.uniform(size=shape)
+        self.k = self.rng.integers(size_p // 2, size=batch_shape)
+
+    def time_poisson_binom_pmf(self, size_p, batch_shape):
+        stats.poisson_binom.pmf(self.k, self.p)
+
+    def time_poisson_binom_cdf(self, size_p, batch_shape):
+        stats.poisson_binom.cdf(self.k, self.p)

--- a/benchmarks/benchmarks/stats.py
+++ b/benchmarks/benchmarks/stats.py
@@ -844,7 +844,7 @@ class PoissonBinom(Benchmark):
         shape = batch_shape + (size_p,)
 
         self.p = self.rng.uniform(size=shape)
-        self.k = self.rng.integers(size_p // 2, size=batch_shape)
+        self.k = self.rng.integers(size_p + 1, size=batch_shape)
 
     def time_poisson_binom_pmf(self, size_p, batch_shape):
         stats.poisson_binom.pmf(self.k, self.p)

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -1,6 +1,7 @@
 #include <xsf/numpy.h>
 #include <xsf/bessel.h>
 #include <xsf/sph_harm.h>
+#include <xsf/stats.h>
 
 #include "sf_error.h"
 
@@ -52,6 +53,10 @@ void sph_harm_map_dims(const npy_intp *dims, npy_intp *new_dims) {
     new_dims[1] = dims[1];
 }
 
+void _poisson_binom_pmf_all_map_dims(const npy_intp *dims, npy_intp *new_dims) {
+    new_dims[0] = dims[0];
+    new_dims[1] = dims[1];
+}
 
 static int
 _gufuncs_module_exec(PyObject *module)
@@ -228,6 +233,19 @@ _gufuncs_module_exec(PyObject *module)
         xsf::numpy::gufunc({static_cast<xsf::numpy::f_f1f1>(xsf::rcty), static_cast<xsf::numpy::d_d1d1>(xsf::rcty)}, 2,
                            "_rcty", rcty_doc, "()->(np1),(np1)", legendre_map_dims<2>);
     PyModule_AddObjectRef(module, "_rcty", _rcty);
+
+    PyObject *_poisson_binom_pmf_all = xsf::numpy::gufunc(
+        {
+            static_cast<xsf::numpy::f1_f1>(xsf::poisson_binom_pmf_all),
+            static_cast<xsf::numpy::d1_d1>(xsf::poisson_binom_pmf_all)
+        },
+        1,
+        "_poisson_binom_pmf_all",
+        "Internal function",
+        "(i)->(j)",
+	_poisson_binom_pmf_all_map_dims
+    );
+    PyModule_AddObjectRef(module, "_poisson_binom_pmf_all", _poisson_binom_pmf_all);
 
     return 0;
 }

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -117,9 +117,9 @@ struct _poisson_binom_cdf_kernel {
             dist.resize(p.extent(0) + 1);
         }
         if (p.data_handle() != last_p_ptr) {
-          /* If p is stepped through in the outer loops and k in the inner loops,
-           * this will yield a cache hit for each inner iteration. The cache is
-           * overwritten unconditionally whenever this steps to a new slice of p. */
+            /* If p is stepped through in the outer loops and k in the inner loops,
+            * this will yield a cache hit for each inner iteration. The cache is
+            * overwritten unconditionally whenever this steps to a new slice of p. */
             xsf::poisson_binom_cdf_all(p, _as_mdspan(dist));
             last_p_ptr = p.data_handle();
         }

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -58,6 +58,8 @@ void _poisson_binom_pmf_all_map_dims(const npy_intp *dims, npy_intp *new_dims) {
     new_dims[1] = dims[1];
 }
 
+void _no_op_map_dims(const npy_intp *dims, npy_intp *new_dims) {}
+
 static int
 _gufuncs_module_exec(PyObject *module)
 {
@@ -256,7 +258,7 @@ _gufuncs_module_exec(PyObject *module)
         "_take_from_pmf",
         "Internal function",
         "(i),()->()",
-	nullptr
+	_no_op_map_dims
     );
     PyModule_AddObjectRef(module, "_take_from_pmf", _take_from_pmf);
 
@@ -269,7 +271,7 @@ _gufuncs_module_exec(PyObject *module)
         "_take_from_discrete_cdf",
         "Internal function",
         "(i),()->()",
-	nullptr
+	_no_op_map_dims
     );
     PyModule_AddObjectRef(module, "_take_from_discrete_cdf", _take_from_discrete_cdf);
 

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -69,7 +69,21 @@ auto _as_mdspan(const std::vector<T>& vec) {
     return std::mdspan<const T, std::dextents<ptrdiff_t, 1>>(vec.data(), vec.size());
 }
 
-// gufunc kernels which are capable of caching
+/* gufunc kernels which use internal caches.
+ *
+ * Such caches live only during the course of a single call to the ufunc
+ * in order to eliminate redundant calculations. This does not concern
+ * user-facing caching across ufunc calls.
+ *
+ * In order for such caches to serve their purpose, the iteration order over the
+ * course of the ufunc loops must be chosen so that elements (or core slices) of
+ * the inputs that go into the cached computation vary most slowly and elements
+ * of the inputs for which the cached result can be reused vary most quickly.
+ * This can be accomplished by wrapping the gufunc with `_with_cache_optimization`
+ * from ./_ufunc_tools.py. See the docstring of `_with_cache_optimization` for
+ * more information.
+ */
+
 template <typename T_1d>
 struct _poisson_binom_pmf_kernel {
     using T = typename T_1d::value_type;
@@ -81,6 +95,9 @@ struct _poisson_binom_pmf_kernel {
             dist.resize(p.extent(0) + 1);
         }
         if (p.data_handle() != last_p_ptr) {
+            /* If p is stepped through in the outer loops and k in the inner loops,
+             * this will yield a cache hit for each inner iteration. The cache is
+             * overwritten unconditionally whenever this steps to a new slice of p. */
             xsf::poisson_binom_pmf_all(p, _as_mdspan(dist));
             last_p_ptr = p.data_handle();
         }
@@ -100,6 +117,9 @@ struct _poisson_binom_cdf_kernel {
             dist.resize(p.extent(0) + 1);
         }
         if (p.data_handle() != last_p_ptr) {
+          /* If p is stepped through in the outer loops and k in the inner loops,
+           * this will yield a cache hit for each inner iteration. The cache is
+           * overwritten unconditionally whenever this steps to a new slice of p. */
             xsf::poisson_binom_cdf_all(p, _as_mdspan(dist));
             last_p_ptr = p.data_handle();
         }

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -69,8 +69,9 @@ auto _as_mdspan(const std::vector<T>& vec) {
     return std::mdspan<const T, std::dextents<ptrdiff_t, 1>>(vec.data(), vec.size());
 }
 
+// gufunc kernels which are capable of caching
 template <typename T_1d>
-struct _poisson_binom_pmf_loop {
+struct _poisson_binom_pmf_kernel {
     using T = typename T_1d::value_type;
 
     std::vector<T> dist;
@@ -89,7 +90,7 @@ struct _poisson_binom_pmf_loop {
 };
 
 template <typename T_1d>
-struct _poisson_binom_cdf_loop {
+struct _poisson_binom_cdf_kernel {
     using T = typename T_1d::value_type;
 
     std::vector<T> dist;
@@ -286,8 +287,8 @@ _gufuncs_module_exec(PyObject *module)
 
     PyObject *_poisson_binom_pmf = xsf::numpy::gufunc(
         {
-            _poisson_binom_pmf_loop<xsf::numpy::float_1d>{},
-            _poisson_binom_pmf_loop<xsf::numpy::double_1d>{}
+            _poisson_binom_pmf_kernel<xsf::numpy::float_1d>{},
+            _poisson_binom_pmf_kernel<xsf::numpy::double_1d>{}
         },
         1,
         "_poisson_binom_pmf",
@@ -299,8 +300,8 @@ _gufuncs_module_exec(PyObject *module)
 
     PyObject *_poisson_binom_cdf = xsf::numpy::gufunc(
         {
-            _poisson_binom_cdf_loop<xsf::numpy::float_1d>{},
-            _poisson_binom_cdf_loop<xsf::numpy::double_1d>{}
+            _poisson_binom_cdf_kernel<xsf::numpy::float_1d>{},
+            _poisson_binom_cdf_kernel<xsf::numpy::double_1d>{}
         },
         1,
         "_poisson_binom_cdf",

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -58,7 +58,9 @@ void _poisson_binom_all_map_dims(const npy_intp *dims, npy_intp *new_dims) {
     new_dims[1] = dims[1];
 }
 
-void _no_op_map_dims(const npy_intp *dims, npy_intp *new_dims) {}
+void _take_from_dist_map_dims(const npy_intp *dims, npy_intp *new_dims) {
+    new_dims[0] = dims[0];
+}
 
 static int
 _gufuncs_module_exec(PyObject *module)
@@ -271,7 +273,7 @@ _gufuncs_module_exec(PyObject *module)
         "_take_from_pmf",
         "Internal function",
         "(i),()->()",
-	_no_op_map_dims
+	_take_from_dist_map_dims
     );
     PyModule_AddObjectRef(module, "_take_from_pmf", _take_from_pmf);
 
@@ -284,7 +286,7 @@ _gufuncs_module_exec(PyObject *module)
         "_take_from_discrete_cdf",
         "Internal function",
         "(i),()->()",
-	_no_op_map_dims
+	_take_from_dist_map_dims
     );
     PyModule_AddObjectRef(module, "_take_from_discrete_cdf", _take_from_discrete_cdf);
 

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -247,6 +247,32 @@ _gufuncs_module_exec(PyObject *module)
     );
     PyModule_AddObjectRef(module, "_poisson_binom_pmf_all", _poisson_binom_pmf_all);
 
+    PyObject *_take_from_pmf = xsf::numpy::gufunc(
+	{
+            static_cast<xsf::numpy::f1q_f>(xsf::take_from_pmf),
+            static_cast<xsf::numpy::d1q_d>(xsf::take_from_pmf),
+        },
+        1,
+        "_take_from_pmf",
+        "Internal function",
+        "(i),()->()",
+	nullptr
+    );
+    PyModule_AddObjectRef(module, "_take_from_pmf", _take_from_pmf);
+
+    PyObject *_take_from_discrete_cdf = xsf::numpy::gufunc(
+	{
+            static_cast<xsf::numpy::f1q_f>(xsf::take_from_discrete_cdf),
+            static_cast<xsf::numpy::d1q_d>(xsf::take_from_discrete_cdf),
+        },
+        1,
+        "_take_from_discrete_cdf",
+        "Internal function",
+        "(i),()->()",
+	nullptr
+    );
+    PyModule_AddObjectRef(module, "_take_from_discrete_cdf", _take_from_discrete_cdf);
+
     return 0;
 }
 

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -53,7 +53,7 @@ void sph_harm_map_dims(const npy_intp *dims, npy_intp *new_dims) {
     new_dims[1] = dims[1];
 }
 
-void _poisson_binom_pmf_all_map_dims(const npy_intp *dims, npy_intp *new_dims) {
+void _poisson_binom_all_map_dims(const npy_intp *dims, npy_intp *new_dims) {
     new_dims[0] = dims[0];
     new_dims[1] = dims[1];
 }
@@ -245,9 +245,22 @@ _gufuncs_module_exec(PyObject *module)
         "_poisson_binom_pmf_all",
         "Internal function",
         "(i)->(j)",
-	_poisson_binom_pmf_all_map_dims
+	_poisson_binom_all_map_dims
     );
     PyModule_AddObjectRef(module, "_poisson_binom_pmf_all", _poisson_binom_pmf_all);
+
+    PyObject *_poisson_binom_cdf_all = xsf::numpy::gufunc(
+        {
+            static_cast<xsf::numpy::f1_f1>(xsf::poisson_binom_cdf_all),
+            static_cast<xsf::numpy::d1_d1>(xsf::poisson_binom_cdf_all)
+        },
+        1,
+        "_poisson_binom_cdf_all",
+        "Internal function",
+        "(i)->(j)",
+	_poisson_binom_all_map_dims
+    );
+    PyModule_AddObjectRef(module, "_poisson_binom_cdf_all", _poisson_binom_cdf_all);
 
     PyObject *_take_from_pmf = xsf::numpy::gufunc(
 	{

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -18,7 +18,7 @@ static PyObject* _set_action(PyObject* self, PyObject* args) {
     sf_action_t action;
 
     if (!PyArg_ParseTuple(args, "ii", &code, &action)) {
-	return NULL;
+        return NULL;
     }
 
     sf_error_set_action(code, action);
@@ -247,7 +247,7 @@ _gufuncs_module_exec(PyObject *module)
         "_poisson_binom_pmf_all",
         "Internal function",
         "(i)->(j)",
-	_poisson_binom_all_map_dims
+        _poisson_binom_all_map_dims
     );
     PyModule_AddObjectRef(module, "_poisson_binom_pmf_all", _poisson_binom_pmf_all);
 
@@ -260,12 +260,12 @@ _gufuncs_module_exec(PyObject *module)
         "_poisson_binom_cdf_all",
         "Internal function",
         "(i)->(j)",
-	_poisson_binom_all_map_dims
+        _poisson_binom_all_map_dims
     );
     PyModule_AddObjectRef(module, "_poisson_binom_cdf_all", _poisson_binom_cdf_all);
 
     PyObject *_take_from_pmf = xsf::numpy::gufunc(
-	{
+        {
             static_cast<xsf::numpy::f1q_f>(xsf::take_from_pmf),
             static_cast<xsf::numpy::d1q_d>(xsf::take_from_pmf),
         },
@@ -273,12 +273,12 @@ _gufuncs_module_exec(PyObject *module)
         "_take_from_pmf",
         "Internal function",
         "(i),()->()",
-	_take_from_dist_map_dims
+        _take_from_dist_map_dims
     );
     PyModule_AddObjectRef(module, "_take_from_pmf", _take_from_pmf);
 
     PyObject *_take_from_discrete_cdf = xsf::numpy::gufunc(
-	{
+        {
             static_cast<xsf::numpy::f1q_f>(xsf::take_from_discrete_cdf),
             static_cast<xsf::numpy::d1q_d>(xsf::take_from_discrete_cdf),
         },
@@ -286,7 +286,7 @@ _gufuncs_module_exec(PyObject *module)
         "_take_from_discrete_cdf",
         "Internal function",
         "(i),()->()",
-	_take_from_dist_map_dims
+        _take_from_dist_map_dims
     );
     PyModule_AddObjectRef(module, "_take_from_discrete_cdf", _take_from_discrete_cdf);
 

--- a/scipy/special/_gufuncs.cpp
+++ b/scipy/special/_gufuncs.cpp
@@ -53,14 +53,60 @@ void sph_harm_map_dims(const npy_intp *dims, npy_intp *new_dims) {
     new_dims[1] = dims[1];
 }
 
-void _poisson_binom_all_map_dims(const npy_intp *dims, npy_intp *new_dims) {
+void _poisson_binom_map_dims(const npy_intp *dims, npy_intp *new_dims) {
     new_dims[0] = dims[0];
-    new_dims[1] = dims[1];
 }
 
-void _take_from_dist_map_dims(const npy_intp *dims, npy_intp *new_dims) {
-    new_dims[0] = dims[0];
+
+// Helper to wrap a 1D std::vector in a contiguous mdspan
+template <typename T>
+auto _as_mdspan(std::vector<T>& vec) {
+    return std::mdspan<T, std::dextents<ptrdiff_t, 1>>(vec.data(), vec.size());
 }
+
+template <typename T>
+auto _as_mdspan(const std::vector<T>& vec) {
+    return std::mdspan<const T, std::dextents<ptrdiff_t, 1>>(vec.data(), vec.size());
+}
+
+template <typename T_1d>
+struct _poisson_binom_pmf_loop {
+    using T = typename T_1d::value_type;
+
+    std::vector<T> dist;
+    T* last_p_ptr = nullptr;
+    T operator()(long long int k, T_1d p) {
+        if (!last_p_ptr) {
+            dist.resize(p.extent(0) + 1);
+        }
+        if (p.data_handle() != last_p_ptr) {
+            xsf::poisson_binom_pmf_all(p, _as_mdspan(dist));
+            last_p_ptr = p.data_handle();
+        }
+
+        return xsf::take_from_pmf(_as_mdspan(dist), k);
+    }
+};
+
+template <typename T_1d>
+struct _poisson_binom_cdf_loop {
+    using T = typename T_1d::value_type;
+
+    std::vector<T> dist;
+    T* last_p_ptr = nullptr;
+    T operator()(long long int k, T_1d p) {
+        if (!last_p_ptr) {
+            dist.resize(p.extent(0) + 1);
+        }
+        if (p.data_handle() != last_p_ptr) {
+            xsf::poisson_binom_cdf_all(p, _as_mdspan(dist));
+            last_p_ptr = p.data_handle();
+        }
+
+        return xsf::take_from_discrete_cdf(_as_mdspan(dist), k);
+    }
+};
+
 
 static int
 _gufuncs_module_exec(PyObject *module)
@@ -238,57 +284,31 @@ _gufuncs_module_exec(PyObject *module)
                            "_rcty", rcty_doc, "()->(np1),(np1)", legendre_map_dims<2>);
     PyModule_AddObjectRef(module, "_rcty", _rcty);
 
-    PyObject *_poisson_binom_pmf_all = xsf::numpy::gufunc(
+    PyObject *_poisson_binom_pmf = xsf::numpy::gufunc(
         {
-            static_cast<xsf::numpy::f1_f1>(xsf::poisson_binom_pmf_all),
-            static_cast<xsf::numpy::d1_d1>(xsf::poisson_binom_pmf_all)
+            _poisson_binom_pmf_loop<xsf::numpy::float_1d>{},
+            _poisson_binom_pmf_loop<xsf::numpy::double_1d>{}
         },
         1,
-        "_poisson_binom_pmf_all",
+        "_poisson_binom_pmf",
         "Internal function",
-        "(i)->(j)",
-        _poisson_binom_all_map_dims
+        "(),(i)->()",
+        _poisson_binom_map_dims
     );
-    PyModule_AddObjectRef(module, "_poisson_binom_pmf_all", _poisson_binom_pmf_all);
+    PyModule_AddObjectRef(module, "_poisson_binom_pmf", _poisson_binom_pmf);
 
-    PyObject *_poisson_binom_cdf_all = xsf::numpy::gufunc(
+    PyObject *_poisson_binom_cdf = xsf::numpy::gufunc(
         {
-            static_cast<xsf::numpy::f1_f1>(xsf::poisson_binom_cdf_all),
-            static_cast<xsf::numpy::d1_d1>(xsf::poisson_binom_cdf_all)
+            _poisson_binom_cdf_loop<xsf::numpy::float_1d>{},
+            _poisson_binom_cdf_loop<xsf::numpy::double_1d>{}
         },
         1,
-        "_poisson_binom_cdf_all",
+        "_poisson_binom_cdf",
         "Internal function",
-        "(i)->(j)",
-        _poisson_binom_all_map_dims
+        "(),(i)->()",
+        _poisson_binom_map_dims
     );
-    PyModule_AddObjectRef(module, "_poisson_binom_cdf_all", _poisson_binom_cdf_all);
-
-    PyObject *_take_from_pmf = xsf::numpy::gufunc(
-        {
-            static_cast<xsf::numpy::f1q_f>(xsf::take_from_pmf),
-            static_cast<xsf::numpy::d1q_d>(xsf::take_from_pmf),
-        },
-        1,
-        "_take_from_pmf",
-        "Internal function",
-        "(i),()->()",
-        _take_from_dist_map_dims
-    );
-    PyModule_AddObjectRef(module, "_take_from_pmf", _take_from_pmf);
-
-    PyObject *_take_from_discrete_cdf = xsf::numpy::gufunc(
-        {
-            static_cast<xsf::numpy::f1q_f>(xsf::take_from_discrete_cdf),
-            static_cast<xsf::numpy::d1q_d>(xsf::take_from_discrete_cdf),
-        },
-        1,
-        "_take_from_discrete_cdf",
-        "Internal function",
-        "(i),()->()",
-        _take_from_dist_map_dims
-    );
-    PyModule_AddObjectRef(module, "_take_from_discrete_cdf", _take_from_discrete_cdf);
+    PyModule_AddObjectRef(module, "_poisson_binom_cdf", _poisson_binom_cdf);
 
     return 0;
 }

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -114,6 +114,24 @@ def multigammaln(a, d):
 
 
 def _poisson_binom_pmf(k, p):
+    """Returns pmf of Poisson Binomial distribution.
+
+    Parameters
+    ----------
+    k : array
+        Number of successes at which to evaluate pmf.
+
+    p : array
+        Success probabilities of independent Bernoulli trials.
+
+    Notes
+    -----
+    This is equivalent to a gufunc with signature ``()(i)->()``.
+    The last dimension of `p` contains success probabilities and
+    the preceding dimensions are batch dimensions. The batch
+    dimensions are broadcast against ``k``.
+
+    """
     xp = array_namespace(k, p)
     k, p = xp.asarray(k), xp.asarray(p)
     n = p.shape[-1]
@@ -124,6 +142,22 @@ def _poisson_binom_pmf(k, p):
 
 
 def _poisson_binom_cdf(k, p):
+    """Returns cdf of Poisson Binomial distribution
+
+    Parameters
+    ----------
+    k : array
+        Number of successes at which to evaluate cdff.
+
+    p : array
+        Success probabilities of independent Bernoulli trials.
+
+    This is equivalent to a gufunc with signature ``()(i)->()``.
+    The last dimension of `p` contains success probabilities and
+    the preceding dimensions are batch dimensions. The batch
+    dimensions are broadcast against ``k``.
+
+    """
     xp = array_namespace(k, p)
     k, p = xp.asarray(k), xp.asarray(p)
     n = p.shape[-1]

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -146,12 +146,12 @@ _poisson_binom_pmf = _with_cache_optimization(
 
 
 _poisson_binom_cdf_doc = (
-    """Returns pmf of Poisson Binomial distribution.
+    """Returns cdf of Poisson Binomial distribution.
 
     Parameters
     ----------
     k : array
-        Number of successes at which to evaluate pmf.
+        Number of successes at which to evaluate cdf.
 
     p : array
         Success probabilities of independent Bernoulli trials.

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -36,7 +36,7 @@ import numpy as np
 
 import scipy.special._gufuncs as _gufuncs
 from scipy.special import gammaln as loggam
-from scipy.special._gufunc_tools import _with_cache_optimization
+from scipy.special._ufunc_tools import _with_cache_optimization
 
 
 __all__ = ['multigammaln']
@@ -111,5 +111,62 @@ def multigammaln(a, d):
     return res
 
 
-_poisson_binom_pmf = _with_cache_optimization(_gufuncs._poisson_binom_pmf, (1,))
-_poisson_binom_cdf = _with_cache_optimization(_gufuncs._poisson_binom_cdf, (1,))
+_poisson_binom_pmf_doc = (
+    """Returns pmf of Poisson Binomial distribution.
+
+    Parameters
+    ----------
+    k : array
+        Number of successes at which to evaluate pmf.
+
+    p : array
+        Success probabilities of independent Bernoulli trials.
+
+    Notes
+    -----
+    This is equivalent to a gufunc with signature ``()(i)->()``.
+    The last dimension of `p` contains success probabilities and
+    the preceding dimensions are batch dimensions. The batch
+    dimensions are broadcast against ``k``.
+
+    """
+)
+
+
+_poisson_binom_pmf = _with_cache_optimization(
+    name="_poisson_binom_pmf",
+    arg_names=["k", "p"],
+    docstring=_poisson_binom_pmf_doc,
+    ufunc=_gufuncs._poisson_binom_pmf,
+    cache_arg_indices=[1],
+)
+
+
+_poisson_binom_cdf_doc = (
+    """Returns pmf of Poisson Binomial distribution.
+
+    Parameters
+    ----------
+    k : array
+        Number of successes at which to evaluate pmf.
+
+    p : array
+        Success probabilities of independent Bernoulli trials.
+
+    Notes
+    -----
+    This is equivalent to a gufunc with signature ``()(i)->()``.
+    The last dimension of `p` contains success probabilities and
+    the preceding dimensions are batch dimensions. The batch
+    dimensions are broadcast against ``k``.
+
+    """
+)
+
+_poisson_binom_cdf = _with_cache_optimization(
+    name="_poisson_binom_cdf",
+    arg_names=["k", "p"],
+    docstring=_poisson_binom_cdf_doc,
+    ufunc=_gufuncs._poisson_binom_cdf,
+    cache_arg_indices=[1],
+)

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -37,7 +37,8 @@ import scipy._external.array_api_extra as xpx
 from scipy._lib._array_api import array_namespace
 from scipy.special import gammaln as loggam
 from scipy.special._gufuncs import (
-    _poisson_binom_pmf_all, _take_from_pmf, _take_from_discrete_cdf
+    _poisson_binom_pmf_all, _poisson_binom_cdf_all, _take_from_pmf,
+    _take_from_discrete_cdf
 )
 
 
@@ -127,6 +128,5 @@ def _poisson_binom_cdf(k, p):
     n = p.shape[-1]
     out_shape = p.shape[:-1] + (n + 1,)
     cdf = xp.zeros(out_shape, dtype=p.dtype)
-    _poisson_binom_pmf_all(p, out=cdf)
-    cdf = xp.cumulative_sum(cdf, axis=-1)
+    _poisson_binom_cdf_all(p, out=cdf)
     return _take_from_discrete_cdf(cdf, k)

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -35,10 +35,6 @@ analysis."""
 import numpy as np
 from scipy._lib._array_api import array_namespace
 from scipy.special import gammaln as loggam
-from scipy.special._gufuncs import (
-    _poisson_binom_pmf_all, _poisson_binom_cdf_all, _take_from_pmf,
-    _take_from_discrete_cdf
-)
 
 
 __all__ = ['multigammaln']
@@ -111,57 +107,3 @@ def multigammaln(a, d):
     res = (d * (d-1) * 0.25) * np.log(np.pi)
     res += np.sum(loggam([(a - (j - 1.)/2) for j in range(1, d+1)]), axis=0)
     return res
-
-
-def _poisson_binom_pmf(k, p):
-    """Returns pmf of Poisson Binomial distribution.
-
-    Parameters
-    ----------
-    k : array
-        Number of successes at which to evaluate pmf.
-
-    p : array
-        Success probabilities of independent Bernoulli trials.
-
-    Notes
-    -----
-    This is equivalent to a gufunc with signature ``()(i)->()``.
-    The last dimension of `p` contains success probabilities and
-    the preceding dimensions are batch dimensions. The batch
-    dimensions are broadcast against ``k``.
-
-    """
-    xp = array_namespace(k, p)
-    k, p = xp.asarray(k), xp.asarray(p)
-    n = p.shape[-1]
-    out_shape = xp.broadcast_shapes(k.shape, p.shape[:-1]) + (n + 1,)
-    pmf = xp.zeros(out_shape, dtype=p.dtype)
-    _poisson_binom_pmf_all(p, out=pmf)
-    return _take_from_pmf(pmf, k)
-
-
-def _poisson_binom_cdf(k, p):
-    """Returns cdf of Poisson Binomial distribution
-
-    Parameters
-    ----------
-    k : array
-        Number of successes at which to evaluate cdff.
-
-    p : array
-        Success probabilities of independent Bernoulli trials.
-
-    This is equivalent to a gufunc with signature ``()(i)->()``.
-    The last dimension of `p` contains success probabilities and
-    the preceding dimensions are batch dimensions. The batch
-    dimensions are broadcast against ``k``.
-
-    """
-    xp = array_namespace(k, p)
-    k, p = xp.asarray(k), xp.asarray(p)
-    n = p.shape[-1]
-    out_shape = xp.broadcast_shapes(k.shape, p.shape[:-1]) + (n + 1,)
-    cdf = xp.zeros(out_shape, dtype=p.dtype)
-    _poisson_binom_cdf_all(p, out=cdf)
-    return _take_from_discrete_cdf(cdf, k)

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -33,6 +33,7 @@
 analysis."""
 
 import numpy as np
+import scipy._external.array_api_extra as xpx
 from scipy._lib._array_api import array_namespace
 from scipy.special import gammaln as loggam
 from scipy.special._gufuncs import _poisson_binom_pmf_all
@@ -118,7 +119,8 @@ def _poisson_binom_pmf(k, p):
     _poisson_binom_pmf_all(p, out=pmf)
     k_indices = xp.expand_dims(xp.clip(k, 0, n), axis=-1)
     res = xp.squeeze(xp.take_along_axis(pmf, k_indices, axis=-1), axis=-1)
-    return xp.where((k < 0) | (k > n), xp.asarray(0.0, dtype=res.dtype), res)
+    res = xpx.at(res, (k < 0) | (k > n)).set(xp.asarray(0.0, dtype=res.dtype))
+    return res
 
 
 def _poisson_binom_cdf(k, p):
@@ -131,6 +133,6 @@ def _poisson_binom_cdf(k, p):
 
     k_indices = xp.expand_dims(xp.clip(k, 0, n), axis=-1)
     res = xp.squeeze(xp.take_along_axis(cdf, k_indices, axis=-1), axis=-1)
-    res = xp.where(k < 0, xp.asarray(0.0, dtype=res.dtype), res)
-    res = xp.where(k >= n, xp.asarray(1.0, dtype=res.dtype), res)
-    return xp.squeeze(res, axis=-1)
+    res = xpx.at(res, k < 0).set(xp.asarray(0.0, dtype=res.dtype))
+    res = xpx.at(res, k >= n).set(xp.asarray(1.0, dtype=res.dtype))
+    return res

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -33,7 +33,9 @@
 analysis."""
 
 import numpy as np
+from scipy._lib._array_api import array_namespace
 from scipy.special import gammaln as loggam
+from scipy.special._gufuncs import _poisson_binom_pmf_all
 
 
 __all__ = ['multigammaln']
@@ -106,3 +108,29 @@ def multigammaln(a, d):
     res = (d * (d-1) * 0.25) * np.log(np.pi)
     res += np.sum(loggam([(a - (j - 1.)/2) for j in range(1, d+1)]), axis=0)
     return res
+
+
+def _poisson_binom_pmf(k, p):
+    xp = array_namespace(k, p)
+    n = p.shape[-1]
+    out_shape = p.shape[:-1] + (n + 1,)
+    pmf = xp.zeros(out_shape, dtype=p.dtype)
+    _poisson_binom_pmf_all(p, out=pmf)
+    k_indices = xp.expand_dims(xp.clip(k, 0, n), axis=-1)
+    res = xp.squeeze(xp.take_along_axis(pmf, k_indices, axis=-1), axis=-1)
+    return xp.where((k < 0) | (k > n), xp.asarray(0.0, dtype=res.dtype), res)
+
+
+def _poisson_binom_cdf(k, p):
+    xp = array_namespace(k, p)
+    n = p.shape[-1]
+    out_shape = p.shape[:-1] + (n + 1,)
+    cdf = xp.zeros(out_shape, dtype=p.dtype)
+    _poisson_binom_pmf_all(p, out=cdf)
+    cdf = xp.cumsum(cdf, axis=-1)
+
+    k_indices = xp.expand_dims(xp.clip(k, 0, n), axis=-1)
+    res = xp.squeeze(xp.take_along_axis(cdf, k_indices, axis=-1), axis=-1)
+    res = xp.where(k < 0, xp.asarray(0.0, dtype=res.dtype), res)
+    res = xp.where(k >= n, xp.asarray(1.0, dtype=res.dtype), res)
+    return xp.squeeze(res, axis=-1)

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -36,7 +36,9 @@ import numpy as np
 import scipy._external.array_api_extra as xpx
 from scipy._lib._array_api import array_namespace
 from scipy.special import gammaln as loggam
-from scipy.special._gufuncs import _poisson_binom_pmf_all
+from scipy.special._gufuncs import (
+    _poisson_binom_pmf_all, _take_from_pmf, _take_from_discrete_cdf
+)
 
 
 __all__ = ['multigammaln']
@@ -117,10 +119,7 @@ def _poisson_binom_pmf(k, p):
     out_shape = p.shape[:-1] + (n + 1,)
     pmf = xp.zeros(out_shape, dtype=p.dtype)
     _poisson_binom_pmf_all(p, out=pmf)
-    k_indices = xp.expand_dims(xp.clip(k, 0, n), axis=-1)
-    res = xp.squeeze(xp.take_along_axis(pmf, k_indices, axis=-1), axis=-1)
-    res = xpx.at(res, (k < 0) | (k > n)).set(xp.asarray(0.0, dtype=res.dtype))
-    return res
+    return _take_from_pmf(pmf, k)
 
 
 def _poisson_binom_cdf(k, p):
@@ -130,9 +129,4 @@ def _poisson_binom_cdf(k, p):
     cdf = xp.zeros(out_shape, dtype=p.dtype)
     _poisson_binom_pmf_all(p, out=cdf)
     cdf = xp.cumulative_sum(cdf, axis=-1)
-
-    k_indices = xp.expand_dims(xp.clip(k, 0, n), axis=-1)
-    res = xp.squeeze(xp.take_along_axis(cdf, k_indices, axis=-1), axis=-1)
-    res = xpx.at(res, k < 0).set(xp.asarray(0.0, dtype=res.dtype))
-    res = xpx.at(res, k >= n).set(xp.asarray(1.0, dtype=res.dtype))
-    return res
+    return _take_from_discrete_cdf(cdf, k)

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -33,7 +33,6 @@
 analysis."""
 
 import numpy as np
-import scipy._external.array_api_extra as xpx
 from scipy._lib._array_api import array_namespace
 from scipy.special import gammaln as loggam
 from scipy.special._gufuncs import (

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -129,7 +129,7 @@ def _poisson_binom_cdf(k, p):
     out_shape = p.shape[:-1] + (n + 1,)
     cdf = xp.zeros(out_shape, dtype=p.dtype)
     _poisson_binom_pmf_all(p, out=cdf)
-    cdf = xp.cumsum(cdf, axis=-1)
+    cdf = xp.cumulative_sum(cdf, axis=-1)
 
     k_indices = xp.expand_dims(xp.clip(k, 0, n), axis=-1)
     res = xp.squeeze(xp.take_along_axis(cdf, k_indices, axis=-1), axis=-1)

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -33,7 +33,10 @@
 analysis."""
 
 import numpy as np
+
+import scipy.special._gufuncs as _gufuncs
 from scipy.special import gammaln as loggam
+from scipy.special._gufunc_tools import _with_cache_optimization
 
 
 __all__ = ['multigammaln']
@@ -106,3 +109,7 @@ def multigammaln(a, d):
     res = (d * (d-1) * 0.25) * np.log(np.pi)
     res += np.sum(loggam([(a - (j - 1.)/2) for j in range(1, d+1)]), axis=0)
     return res
+
+
+_poisson_binom_pmf = _with_cache_optimization(_gufuncs._poisson_binom_pmf, (1,))
+_poisson_binom_cdf = _with_cache_optimization(_gufuncs._poisson_binom_cdf, (1,))

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -129,6 +129,9 @@ _poisson_binom_pmf_doc = (
     the preceding dimensions are batch dimensions. The batch
     dimensions are broadcast against ``k``.
 
+    The output will be C contiguous regardless of the contiguity of
+    `k` and `p`.
+
     """
 )
 
@@ -159,6 +162,9 @@ _poisson_binom_cdf_doc = (
     The last dimension of `p` contains success probabilities and
     the preceding dimensions are batch dimensions. The batch
     dimensions are broadcast against ``k``.
+
+    The output will be C contiguous regardless of the contiguity of
+    `k` and `p`.
 
     """
 )

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -115,8 +115,9 @@ def multigammaln(a, d):
 
 def _poisson_binom_pmf(k, p):
     xp = array_namespace(k, p)
+    k, p = xp.asarray(k), xp.asarray(p)
     n = p.shape[-1]
-    out_shape = p.shape[:-1] + (n + 1,)
+    out_shape = xp.broadcast_shapes(k.shape, p.shape[:-1]) + (n + 1,)
     pmf = xp.zeros(out_shape, dtype=p.dtype)
     _poisson_binom_pmf_all(p, out=pmf)
     return _take_from_pmf(pmf, k)
@@ -124,8 +125,9 @@ def _poisson_binom_pmf(k, p):
 
 def _poisson_binom_cdf(k, p):
     xp = array_namespace(k, p)
+    k, p = xp.asarray(k), xp.asarray(p)
     n = p.shape[-1]
-    out_shape = p.shape[:-1] + (n + 1,)
+    out_shape = xp.broadcast_shapes(k.shape, p.shape[:-1]) + (n + 1,)
     cdf = xp.zeros(out_shape, dtype=p.dtype)
     _poisson_binom_cdf_all(p, out=cdf)
     return _take_from_discrete_cdf(cdf, k)

--- a/scipy/special/_spfun_stats.py
+++ b/scipy/special/_spfun_stats.py
@@ -33,7 +33,6 @@
 analysis."""
 
 import numpy as np
-from scipy._lib._array_api import array_namespace
 from scipy.special import gammaln as loggam
 
 

--- a/scipy/special/_ufunc_tools.py
+++ b/scipy/special/_ufunc_tools.py
@@ -5,7 +5,7 @@ import re
 import numpy as np
 
 
-def _parse_core_ndims(signature: str) -> tuple[int]:
+def _parse_core_ndims(signature):
     """Return tuple of num core dims per input from gufunc signature."""
     input_sig = signature.split('->')[0]
     groups = re.findall(r"\((.*?)\)", input_sig)

--- a/scipy/special/_ufunc_tools.py
+++ b/scipy/special/_ufunc_tools.py
@@ -20,7 +20,11 @@ def _with_cache_optimization(
         ufunc,
         cache_arg_indices,
 ):
-    """Helper to ensure optimal iteration order for ufuncs that use caching
+    """Helper to ensure optimal iteration order for ufuncs that use caching.
+
+    This concerns internal caches which are only live over the course of one
+    call to a ufunc to avoid repeated computations during the course of the
+    loops. See the notes below for more information.
 
     Parameters
     ----------
@@ -46,24 +50,30 @@ def _with_cache_optimization(
     -----
     There is a common pattern in ufunc kernels exemplified by the situation
     where some of the arguments are used to compute coeffients of an expansion
-    over other the arguments. A classic example is mathieu functions, which
-    compute coefficients corresponding to the shape parameter q and order m
-    which in principle could be reused for varying values of the parameter
-    x.
+    that is taken over one or more of the other arguments. A classic example is
+    Mathieu functions, which compute coefficients corresponding to the shape
+    parameter q and order m which in principle could be reused for varying
+    values of the parameter x.
 
-    It has long been the case that the expensive computation of coefficients is
+    It had long been the case that the expensive computation of coefficients is
     repeated unnecessarily across values of x. It is possible to add a cache to
-    the ufunc kernel in this case which stores the expansion coefficients and
-    only updates it if the pointers for the q and m arrays advance, however
-    whether this cache actually helps depends on the order in which iteration
+    the ufunc kernel which stores the expansion coefficients and only updates
+    if the pointers into the q and m arrays advance during the course of the
+    ufunc loops. Such a cache is instantiated each time a ufunc is called and
+    only lives during the course of the loops that are carried out for that
+    particular call.
+
+    Whether such a cache actually helps depends on the order in which iteration
     occurs. Ideally, one would want q and m to advance most slowly and for the
     iterations over x for fixed q and m to be pushed to the inner most loops.
-    To work around difficulties in controlling the iteration order in ufuncs,
-    this helper will transpose the axes which we want to vary most slowly to
-    the ends of the arrays and force computation in C order.
+    This helper replaces each input array (and a pre-allocated output array)
+    with a view where the axes which should vary most slowly are transposed to
+    the ends and forces computation in C order. This ensures iteration proceeds
+    in the optimal order.
 
-    Take note that the output will be C contiguous regardless of contiguity
-    of the inputs.
+    Note that because the pre-allocated output array used internally is C
+    contiguous, the output will be C contiguous regardless of contiguity of
+    the inputs.
 
     """
 

--- a/scipy/special/_ufunc_tools.py
+++ b/scipy/special/_ufunc_tools.py
@@ -1,0 +1,126 @@
+"""Helpers for producing efficient wrappers of ufuncs.
+"""
+
+import re
+import numpy as np
+
+
+def _parse_core_ndims(signature: str) -> tuple[int]:
+    """Return tuple of num core dims per input from gufunc signature."""
+    input_sig = signature.split('->')[0]
+    groups = re.findall(r"\((.*?)\)", input_sig)
+    return tuple(0 if not g.strip() else g.count(',') + 1 for g in groups)
+
+
+def _with_cache_optimization(ufunc, cache_arg_indices):
+    """Helper to ensure optimal iteration order for ufuncs that use caching
+
+    Parameters
+    ----------
+    ufunc : numpy.ufunc
+    cache_arg_indices : list[int]
+       Arguments to ufunc which are used in the kernel to compute an output
+       which is being cached for reuse when iterating over other arguments.
+
+    Returns
+    -------
+    callable
+        A wrapper for ufunc which transposes the axes of the inputs to ensure
+        iteration precedes in such a way to allow the cache within the ufunc
+        kernel to eliminate redundant computation.
+
+    Notes
+    -----
+    There is a common pattern in ufunc kernels exemplified by the situation
+    where some of the arguments are used to compute coeffients of an expansion
+    over other the arguments. A classic example is mathieu functions, which
+    compute coefficients corresponding to the shape parameter q and order m
+    which in principle could be reused for varying values of the parameter
+    x.
+
+    It has long been the case that the expensive computation of coefficients is
+    repeated unnecessarily across values of x. It is possible to add a cache to
+    the ufunc kernel in this case which stores the expansion coefficients and
+    only updates it if the pointers for the q and m arrays advance, however
+    whether this cache actually helps depends on the order in which iteration
+    occurs. Ideally, one would want q and m to advance most slowly and for the
+    iterations over x for fixed q and m to be pushed to the inner most loops.
+    To work around difficulties in controlling the iteration order in ufuncs,
+    this helper will transpose the axes which we want to vary most slowly to
+    the ends of the arrays and force computation in C order.
+
+    Take note that the output will be C contiguous regardless of contiguity
+    of the inputs.
+
+    """
+
+    # Need to keep track of the number of core dimensions for each input
+    # since core dimensions don't participate in broadcasting.
+    core_ndims = (
+        _parse_core_ndims(ufunc.signature)
+        if ufunc.signature is not None
+        else (0,)*ufunc.nin
+    )
+
+    def wrapper(*args):
+        args = [np.asarray(arg) for arg in args]
+
+        # Fast path for when the arguments which are used in the cached
+        # computation don't have batches.
+        if all(args[i].ndim == core_ndims[i] for i in cache_arg_indices):
+            return ufunc(*args)
+
+        # To get batch_shapes, need to exclude core dimensions. Again, the core
+        # dimensions won't participate in broadcasting.
+        batch_shapes = [
+            arg.shape[:-core_ndims[i]] if core_ndims[i] > 0 else arg.shape
+            for i, arg in enumerate(args)
+        ]
+        batch_shape = np.broadcast_shapes(*batch_shapes)
+        batch_ndim = len(batch_shape)
+
+        # Broadcast each arg so that the batch shapes all agree, but the
+        # core dimensions may still differ.
+        args_b = [
+            np.broadcast_to(arg, batch_shape + arg.shape[-core_ndims[i]:])
+            if core_ndims[i] > 0 else np.broadcast_to(arg, batch_shape)
+            for i, arg in enumerate(args)
+        ]
+
+        # After broadcasting, determine which axes have stride-length
+        # zero for each of the args participating in the cache. The cached
+        # value will remain the same for iterations across these axes.
+        varying_axes = []
+        constant_axes = []
+
+        for ax in range(batch_ndim):
+            is_constant = all(
+                args_b[i].strides[ax] == 0 for i in cache_arg_indices
+            )
+            if is_constant:
+                constant_axes.append(ax)
+            else:
+                varying_axes.append(ax)
+        sorted_batch_axes = varying_axes + constant_axes
+
+        # Push the non-varying axes to the end so that they will vary most
+        # slowly when iterating in C order.
+        args_t = []
+        for i, arg_b in enumerate(args_b):
+            axes = sorted_batch_axes + list(
+                range(batch_ndim, batch_ndim + core_ndims[i])
+            )
+            args_t.append(np.transpose(arg_b, axes=axes))
+
+        # Premake the output array.
+        input_dtypes = tuple(arg.dtype for arg in args_t) + (None,)*ufunc.nout
+        out_dtype = ufunc.resolve_dtypes(input_dtypes)[-1]
+        out_final = np.empty(batch_shape, dtype=out_dtype, order='C')
+        # a view of the output array with axes sorted as needed.
+        out_t = np.transpose(out_final, axes=sorted_batch_axes)
+
+        # Set out to the above view, but return the C contiguous output.
+        # This avoids having non-contiguous output.
+        ufunc(*args_t, out=out_t, order='C')
+        return out_final
+    return wrapper

--- a/scipy/special/_ufunc_tools.py
+++ b/scipy/special/_ufunc_tools.py
@@ -12,11 +12,24 @@ def _parse_core_ndims(signature: str) -> tuple[int]:
     return tuple(0 if not g.strip() else g.count(',') + 1 for g in groups)
 
 
-def _with_cache_optimization(ufunc, cache_arg_indices):
+def _with_cache_optimization(
+        *,
+        name,
+        arg_names,
+        docstring,
+        ufunc,
+        cache_arg_indices,
+):
     """Helper to ensure optimal iteration order for ufuncs that use caching
 
     Parameters
     ----------
+    name : str
+    arg_names : list[str]
+        The function name and arg names are passed in so that the wrapper
+        can be generated with the create name and argument names, improving
+        documentation and autocomplete.
+    docstring : str
     ufunc : numpy.ufunc
     cache_arg_indices : list[int]
        Arguments to ufunc which are used in the kernel to compute an output
@@ -62,7 +75,7 @@ def _with_cache_optimization(ufunc, cache_arg_indices):
         else (0,)*ufunc.nin
     )
 
-    def wrapper(*args):
+    def _wrapper(*args):
         args = [np.asarray(arg) for arg in args]
 
         # Fast path for when the arguments which are used in the cached
@@ -123,4 +136,15 @@ def _with_cache_optimization(ufunc, cache_arg_indices):
         # This avoids having non-contiguous output.
         ufunc(*args_t, out=out_t, order='C')
         return out_final
+
+    arg_str = ", ".join(arg_names)
+    code = (
+        f"""def {name}({arg_str}):
+            return _wrapper({arg_str})
+        """
+        )
+    namespace = {"_wrapper": _wrapper}
+    exec(code, namespace)
+    wrapper = namespace[name]
+    wrapper.__doc__ = docstring
     return wrapper

--- a/scipy/special/_ufunc_tools.py
+++ b/scipy/special/_ufunc_tools.py
@@ -137,6 +137,8 @@ def _with_cache_optimization(
         ufunc(*args_t, out=out_t, order='C')
         return out_final
 
+    # Do some metaprogramming with exec so that the arg names and func
+    # name are as expected.
     arg_str = ", ".join(arg_names)
     code = (
         f"""def {name}({arg_str}):

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -277,7 +277,6 @@ python_sources = [
   'specfun.py',
   'spfun_stats.py',
   '_ufunc_tools.py'
-  
 ]
 
 py3.install_sources(

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -275,7 +275,9 @@ python_sources = [
   'orthogonal.py',
   'sf_error.py',
   'specfun.py',
-  'spfun_stats.py'
+  'spfun_stats.py',
+  '_ufunc_tools.py'
+  
 ]
 
 py3.install_sources(

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -7,7 +7,7 @@ from functools import partial
 from scipy import special
 from scipy.special import entr, logsumexp, betaln, gammaln as gamln
 import scipy.special._ufuncs as scu
-import scipy.special._gufuncs as scgu
+from scipy.special._spfun_stats import _poisson_binom_pmf, _poisson_binom_cdf
 from scipy._lib._util import rng_integers
 import scipy._external.array_api_extra as xpx
 from scipy.interpolate import interp1d
@@ -1626,14 +1626,13 @@ class poisson_binom_gen(rv_discrete):
         k = np.atleast_1d(k).astype(np.int64)
         k, *args = np.broadcast_arrays(k, *args)
         p = np.stack(args, dtype=np.float64, axis=-1)
-        return scgu._poisson_binom_pmf(k, p)
-
+        return _poisson_binom_pmf(k, p)
 
     def _cdf(self, k, *args):
         k = np.atleast_1d(k).astype(np.int64)
         k, *args = np.broadcast_arrays(k, *args)
         p = np.stack(args, dtype=np.float64, axis=-1)
-        return scgu._poisson_binom_cdf(k, p)
+        return _poisson_binom_cdf(k, p)
 
     def _stats(self, *args, **kwds):
         p = np.stack(args, axis=0)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -7,7 +7,7 @@ from functools import partial
 from scipy import special
 from scipy.special import entr, logsumexp, betaln, gammaln as gamln
 import scipy.special._ufuncs as scu
-import scipy.special._spfun_stats as _spfun_stats
+import scipy.special._gufuncs as scgu
 from scipy._lib._util import rng_integers
 import scipy._external.array_api_extra as xpx
 from scipy.interpolate import interp1d
@@ -1626,14 +1626,14 @@ class poisson_binom_gen(rv_discrete):
         k = np.atleast_1d(k).astype(np.int64)
         k, *args = np.broadcast_arrays(k, *args)
         p = np.stack(args, dtype=np.float64, axis=-1)
-        return _spfun_stats._poisson_binom_pmf(k, p)
+        return scgu._poisson_binom_pmf(k, p)
 
 
     def _cdf(self, k, *args):
         k = np.atleast_1d(k).astype(np.int64)
         k, *args = np.broadcast_arrays(k, *args)
         p = np.stack(args, dtype=np.float64, axis=-1)
-        return _spfun_stats._poisson_binom_cdf(k, p)
+        return scgu._poisson_binom_cdf(k, p)
 
     def _stats(self, *args, **kwds):
         p = np.stack(args, axis=0)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -7,6 +7,7 @@ from functools import partial
 from scipy import special
 from scipy.special import entr, logsumexp, betaln, gammaln as gamln
 import scipy.special._ufuncs as scu
+import scipy.special._spfun_stats as _spfun_stats
 from scipy._lib._util import rng_integers
 import scipy._external.array_api_extra as xpx
 from scipy.interpolate import interp1d
@@ -1626,13 +1627,14 @@ class poisson_binom_gen(rv_discrete):
         k = np.atleast_1d(k).astype(np.int64)
         k, *args = np.broadcast_arrays(k, *args)
         args = np.asarray(args, dtype=np.float64)
-        return _poisson_binom(k, args, 'pmf')
+        return _spfun_stats._poisson_binom_pmf(k, np.moveaxis(args, 0, -1))
+
 
     def _cdf(self, k, *args):
         k = np.atleast_1d(k).astype(np.int64)
         k, *args = np.broadcast_arrays(k, *args)
         args = np.asarray(args, dtype=np.float64)
-        return _poisson_binom(k, args, 'cdf')
+        return _spfun_stats._poisson_binom_cdf(k, np.moveaxis(args, 0, -1))
 
     def _stats(self, *args, **kwds):
         p = np.stack(args, axis=0)

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -23,7 +23,6 @@ from ._distn_infrastructure import (rv_discrete, get_distribution_names,
 from ._biasedurn import (_PyFishersNCHypergeometric,
                          _PyWalleniusNCHypergeometric,
                          _PyStochasticLib3)
-from ._stats_pythran import _poisson_binom
 
 
 class binom_gen(rv_discrete):

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1625,15 +1625,15 @@ class poisson_binom_gen(rv_discrete):
     def _pmf(self, k, *args):
         k = np.atleast_1d(k).astype(np.int64)
         k, *args = np.broadcast_arrays(k, *args)
-        args = np.asarray(args, dtype=np.float64)
-        return _spfun_stats._poisson_binom_pmf(k, np.moveaxis(args, 0, -1))
+        p = np.stack(args, dtype=np.float64, axis=-1)
+        return _spfun_stats._poisson_binom_pmf(k, p)
 
 
     def _cdf(self, k, *args):
         k = np.atleast_1d(k).astype(np.int64)
         k, *args = np.broadcast_arrays(k, *args)
-        args = np.asarray(args, dtype=np.float64)
-        return _spfun_stats._poisson_binom_cdf(k, np.moveaxis(args, 0, -1))
+        p = np.stack(args, dtype=np.float64, axis=-1)
+        return _spfun_stats._poisson_binom_cdf(k, p)
 
     def _stats(self, *args, **kwds):
         p = np.stack(args, axis=0)

--- a/scipy/stats/_stats_pythran.py
+++ b/scipy/stats/_stats_pythran.py
@@ -181,37 +181,6 @@ def siegelslopes(y, x, method):
     return medslope, medinter
 
 
-# pythran export _poisson_binom_pmf(float64[:])
-def _poisson_binom_pmf(p):
-    # implemented from poisson_binom [2] Equation 2
-    n = p.shape[0]
-    pmf = np.zeros(n + 1, dtype=np.float64)
-    pmf[:2] = 1 - p[0], p[0]
-    for i in range(1, n):
-        tmp = pmf[:i+1] * p[i]
-        pmf[:i+1] *= (1 - p[i])
-        pmf[1:i+2] += tmp
-    return pmf
-
-
-# pythran export _poisson_binom(int64[:], float64[:, :], str)
-def _poisson_binom(k, args, tp):
-    # PDF/CDF of Poisson binomial distribution
-    # k - arguments, shape (m,)
-    # args - shape parameters, shape (n, m)
-    # kind - {'pdf', 'cdf'}
-    n, m = args.shape  # number of shapes, batch size
-    cache = {}
-    out = np.zeros(m, dtype=np.float64)
-    for i in range(m):
-        p = tuple(args[:, i])
-        if p not in cache:
-            pmf = _poisson_binom_pmf(args[:, i])
-            cache[p] = np.cumsum(pmf) if tp=='cdf' else pmf
-        out[i] = cache[p][k[i]]
-    return out
-
-
 # function p = phid(z), p = erfc( -z/sqrt(2) )/2; % Normal cdf
 def phid(z):
     return math.erfc(-z / math.sqrt(2)) / 2


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR adds a new private `gufunc` to `special` called `_poisson_binom_pmf_all` and uses it in `scipy.stats.poisson_binom`. There is a companion PR to xsf here, https://github.com/scipy/xsf/pull/113, adding the kernel for this gufunc.

This is a simple proof of concept for the idea I suggested here, https://github.com/scipy/scipy/pull/24871#issuecomment-4093613968, and in the following discussion, of replacing ufuncs whose do things like heap allocations or lapack calls with Python functions which glue together gufuncs with array API compliant code. This pattern was first suggested to me by @izaid.

I will make inline comments explaining what is going on here tomorrow.
#### Additional information
<!--Any additional information you think is important.-->
I added benchmarks  to compare to the previous Pythran implementation, but when I ran them locally the results were misleading. The new implementation makes a much better showing when run outside of airspeed velocity on my machine. It seems like the asv environment is configured so that the regular C++ compiler doesn't optimize things so well, but Pythran gets to do whatever it wants. The benchmarks might fail in CI. I will have more to say about this tomorrow.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
~No AI generated code appears here but I used Google Gemini Pro as a search engine and sounding board.~ Update: `scipy.special._ufunc_tools._with_cache_optimization` was developed in an interactive chat session with Google Gemini Pro. I have taken time to understand how it works line by line.
