### PR TITLE
BUG: fix UnboundLocalError in tfqmr when maxiter=0 and show=True

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -623,6 +623,18 @@ def test_show(case, capsys, xp):
     assert err == ""
 
 
+def test_tfqmr_maxiter_zero_show():
+    # Regression test for gh-24790: tfqmr raised UnboundLocalError when
+    # maxiter=0 and show=True because `iter` was never assigned by the loop.
+    A = np.eye(3)
+    b = np.ones(3)
+    # Should not raise, and must return an ndarray + non-negative info
+    x, info = tfqmr(A, b, maxiter=0, show=True)
+    assert isinstance(x, np.ndarray)
+    assert x.shape == b.shape
+    assert info == 0  # return value is maxiter (=0 here)
+
+
 def test_positional_error(solver, xp):
     # from test_x0_working
     rng = np.random.default_rng(1685363802304750)

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -133,6 +133,7 @@ def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
     # we call this to get the right atol and raise errors as necessary
     atol, _ = _get_atol_rtol('tfqmr', r0norm, atol, rtol)
 
+    iter = -1
     for iter in range(maxiter):
         even = iter % 2 == 0
         if (even):


### PR DESCRIPTION
## Summary

Fixes #24790.

`scipy.sparse.linalg.tfqmr` raised `UnboundLocalError` when called with `maxiter=0` and `show=True`. The `for iter in range(maxiter):` loop never executed its body (since `range(0)` is empty), leaving `iter` unbound. The `show=True` display path at the end of the function then attempted to evaluate `iter+1`, triggering the error.

**Fix:** Initialize `iter = -1` immediately before the loop. If `maxiter=0` and the loop never runs, `iter+1 = 0` is printed in the not-converged message, which accurately reflects that zero iterations were performed.

## Changes

- `scipy/sparse/linalg/_isolve/tfqmr.py`: add `iter = -1` before the `for` loop (1 line)
- `scipy/sparse/linalg/_isolve/tests/test_iterative.py`: add `test_tfqmr_maxiter_zero_show` regression test

## Test plan

- [ ] `test_tfqmr_maxiter_zero_show` calls `tfqmr(np.eye(3), np.ones(3), maxiter=0, show=True)` and asserts no exception is raised and return values have correct types/shapes
- [ ] Existing `test_show` suite continues to pass (no change to normal iteration paths)

Relates to the same class of bug as #23748 (same `UnboundLocalError` pattern in a different solver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)