### PR TITLE
BUG: fix lambertw(-1/e) returning nan at branch point

### DIFF
--- a/scipy/special/_lambertw.py
+++ b/scipy/special/_lambertw.py
@@ -2,6 +2,9 @@ from ._ufuncs import _lambertw
 
 import numpy as np
 
+# exp(-1), the negation of which is the branch-point of the Lambert W function
+_EXPN1 = np.exp(-1.0)
+
 
 def lambertw(z, k=0, tol=1e-8):
     r"""
@@ -146,4 +149,21 @@ def lambertw(z, k=0, tol=1e-8):
     # TODO: special expert should inspect this
     # interception; better place to do it?
     k = np.asarray(k, dtype=np.dtype("long"))
-    return _lambertw(z, k, tol)
+
+    # Special-case the branch point z = -1/e exactly.  At this point the
+    # Halley iteration in the C implementation divides by zero (2w+2 = 0
+    # when the initial guess w = -1 is exact), producing NaN.  The correct
+    # value is W(-1/e, 0) = W(-1/e, -1) = -1.  See gh-24770.
+    z = np.asarray(z)
+    scalar_input = z.ndim == 0
+    z = np.atleast_1d(z)
+    result = _lambertw(z, k, tol)
+    # Identify entries that are exactly the branch point -1/e (real axis only)
+    branchpt = (z.real == -_EXPN1) & (z.imag == 0.0)
+    if np.any(branchpt):
+        k_bc = np.broadcast_to(k, branchpt.shape)
+        at_bp = branchpt & ((k_bc == 0) | (k_bc == -1))
+        result[at_bp] = complex(-1.0, 0.0)
+    if scalar_input:
+        return result[()]
+    return result

--- a/scipy/special/tests/test_lambertw.py
+++ b/scipy/special/tests/test_lambertw.py
@@ -107,3 +107,31 @@ def test_lambertw_subnormal_k0(z):
     # For values this small, we can be sure that numerically,
     # lambertw(z) is z.
     assert w == z
+
+
+def test_lambertw_branch_point():
+    # Regression test for gh-24770: lambertw(-1/e) returned nan+nanj instead
+    # of -1+0j.  At the branch point z = -1/e the Halley iteration in the C
+    # backend divides by zero (2w+2 = 0) when the initial guess is exactly -1.
+    # Both real branches meet at -1 at this point.
+    neg_inv_e = -1.0 / e
+    # Scalar, principal branch
+    w0 = lambertw(neg_inv_e, k=0)
+    assert not np.isnan(w0), f"lambertw(-1/e, k=0) returned NaN: {w0}"
+    assert_allclose(w0, -1.0 + 0j, atol=1e-14)
+
+    # Scalar, k=-1 branch (both branches share the branch point)
+    wm1 = lambertw(neg_inv_e, k=-1)
+    assert not np.isnan(wm1), f"lambertw(-1/e, k=-1) returned NaN: {wm1}"
+    assert_allclose(wm1, -1.0 + 0j, atol=1e-14)
+
+    # Array input containing the branch point
+    zs = np.array([-1.0 / e, -0.2, 0.0])
+    ws = lambertw(zs)
+    assert not np.any(np.isnan(ws)), f"lambertw array with -1/e entry returned NaN: {ws}"
+    assert_allclose(ws[0], -1.0 + 0j, atol=1e-14)
+
+    # The fix must not affect inputs that are merely near (but not exactly at)
+    # the branch point, and must not affect non-real inputs.
+    assert not np.isnan(lambertw(-1.0 / e + 1e-12))
+    assert not np.isnan(lambertw(-1.0 / e - 1e-12))


### PR DESCRIPTION
## Summary

Fixes #24770.

`scipy.special.lambertw(-1/np.e)` returned `nan+nanj` instead of `-1+0j`.

**Root cause:** At `z = -1/e` (the branch point), `lambertw_branchpt` (the initial-guess function) computes `p = sqrt(2*(e*z + 1)) = sqrt(0) = 0`, which gives an initial Halley-iteration guess of exactly `w = -1`.  The Halley step then evaluates `wewz / (wew + ew - (w+2)*wewz / (2w+2))`, where `2w+2 = 0`, producing NaN via division by zero.  The iteration limit is hit and the function returns NaN (the TODO comment in the xsf header even acknowledges this case).

**Fix:** Intercept the exact branch point in the Python wrapper (`scipy/special/_lambertw.py`) before delegating to the C ufunc.  Both real branches (`k=0` and `k=-1`) meet at `-1` at this point, so we return `-1+0j` for those cases.  Other branches and all non-exact values are unaffected.

## Reproducer

```python
import numpy as np
from scipy.special import lambertw

# Before fix: nan+nanj
# After fix:  (-1+0j)
print(lambertw(-1.0 / np.e))          # principal branch (k=0)
print(lambertw(-1.0 / np.e, k=-1))    # k=-1 branch
```

## Test plan

- [x] Added `test_lambertw_branch_point` regression test covering scalar k=0, scalar k=-1, array input, and confirming nearby values are unaffected
- [x] Existing `test_values`, `test_ufunc`, `test_lambertw_ufunc_loop_selection`, `test_lambertw_subnormal_k0` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)