### PR TITLE
ENH: linalg: add HAS_LP64 config variable

### DIFF
--- a/scipy/__config__.py.in
+++ b/scipy/__config__.py.in
@@ -88,6 +88,7 @@ CONFIG = _cleanup(
                 "openblas configuration": r"@BLAS_OPENBLAS_CONFIG@",
                 "pc file directory": r"@BLAS_PCFILEDIR@",
                 "has ilp64": bool(r"@BLAS_HAS_ILP64@".lower().replace('false', '')),
+                "has lp64": bool(r"@BLAS_HAS_LP64@".lower().replace('false', '')),
                 "cython blas ilp64": bool(r"@BLAS_CYTHON_ILP64@".lower().replace('false', '')),
             },
             "lapack": {
@@ -100,6 +101,7 @@ CONFIG = _cleanup(
                 "openblas configuration": r"@LAPACK_OPENBLAS_CONFIG@",
                 "pc file directory": r"@LAPACK_PCFILEDIR@",
                 "has ilp64": bool(r"@LAPACK_HAS_ILP64@".lower().replace('false', '')),
+                "has lp64": bool(r"@LAPACK_HAS_LP64@".lower().replace('false', '')),
             },
             "pybind11": {
                 "name": "@PYBIND11_NAME@",

--- a/scipy/linalg/blas.py
+++ b/scipy/linalg/blas.py
@@ -236,20 +236,25 @@ import numpy as np
 import functools
 from scipy.__config__ import CONFIG
 
-# TODO: fold HAS_LP64 into __config__, allow for _fblas not being available
-from scipy.linalg import _fblas
-HAS_LP64 = True
-
+HAS_LP64 = CONFIG['Build Dependencies']['blas']['has lp64']
 HAS_ILP64 = CONFIG['Build Dependencies']['blas']['has ilp64']
 del CONFIG
+
+_fblas = None
+if HAS_LP64:
+    from scipy.linalg import _fblas
+
 _fblas_64 = None
 if HAS_ILP64:
     from scipy.linalg import _fblas_64
 
-# Expose all functions (only fblas --- cblas is an implementation detail)
-empty_module = None
-from scipy.linalg._fblas import *  # noqa: E402, F403
-del empty_module
+if not (HAS_LP64 or HAS_ILP64):
+    raise RuntimeError("SciPy needs either LP64 or ILP64 BLAS.")
+
+if HAS_LP64:
+    from scipy.linalg._fblas import *  # noqa: E402, F403
+else:
+    from scipy.linalg._fblas_64 import *  # noqa: E402, F403
 
 # all numeric dtypes '?bBhHiIlLqQefdgFDGO' that are safe to be converted to
 

--- a/scipy/linalg/lapack.py
+++ b/scipy/linalg/lapack.py
@@ -889,17 +889,25 @@ from .blas import (
 from re import compile as regex_compile
 from scipy.__config__ import CONFIG
 
-# TODO: fold HAS_LP64 into __config__, allow for _flapack not being available
-from scipy.linalg import _flapack
-HAS_LP64 = True
-
+HAS_LP64 = CONFIG['Build Dependencies']['lapack']['has lp64']
 HAS_ILP64 = CONFIG['Build Dependencies']['lapack']['has ilp64']
 del CONFIG
+
+_flapack = None
+if HAS_LP64:
+    from scipy.linalg import _flapack
+
 _flapack_64 = None
 if HAS_ILP64:
     from scipy.linalg import _flapack_64
 
-from scipy.linalg._flapack import *  # noqa: E402, F403
+if not (HAS_LP64 or HAS_ILP64):
+    raise RuntimeError("SciPy needs either LP64 or ILP64 LAPACK.")
+
+if HAS_LP64:
+    from scipy.linalg._flapack import *  # noqa: E402, F403
+else:
+    from scipy.linalg._flapack_64 import *  # noqa: E402, F403
 
 
 __all__ = ['get_lapack_funcs']

--- a/scipy/linalg/tests/test_blas.py
+++ b/scipy/linalg/tests/test_blas.py
@@ -89,6 +89,7 @@ def test_get_blas_funcs_ilp_true():
         assert gemm.int_dtype == np.int64
         assert gemm.module_name == 'fblas_64'
     else:
+        assert HAS_LP64
         with pytest.raises(RuntimeError):
             get_blas_funcs('gemm', (np.eye(3),), ilp64=True)
 
@@ -100,6 +101,7 @@ def test_get_blas_funcs_ilp_false():
         assert gemm.int_dtype == np.int32
         assert gemm.module_name == 'fblas'
     else:
+        assert HAS_ILP64
         with pytest.raises(RuntimeError):
             get_blas_funcs('gemm', (np.eye(3),), ilp64=False)
 

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -813,6 +813,10 @@ else
 endif
 conf_data.set('BLAS_CYTHON_ILP64', _cython_blas_ilp64.to_string())
 
+# TODO: make this into an option
+conf_data.set('BLAS_HAS_LP64', true)
+conf_data.set('LAPACK_HAS_LP64', true)
+
 configure_file(
   input: '__config__.py.in',
   output: '__config__.py',


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

follows up on https://github.com/scipy/scipy/pull/24793#discussion_r2940390952

#### What does this implement/fix?
<!--Please explain your changes.-->

Add a build config option, `has lp64`, always true for now. Prepare the python side for the build change which actually makes this a possibility: make LP64 imports conditional.

#### Additional information
<!--Any additional information you think is important.-->


If HAS_LP64 is False, 'bare' blas/lapack functions are ILP64!

```
>>> from scipy.linalg.blas import dgemm
```

Now dgemm is LP64 or ILP64, depending on HAS_ILP64 value. Note that this is not introspectable at runtime (other than looking at `HAS_LP64` and `HAS_ILP64` variables). What is introspectable is

```
>>> from scipy.linalg.blas import get_blas_funcs, HAS_ILP64
>>> gemm = get_blas_funcs('gemm', dtype=np.float64, ilp64="preferred")
>>> gemm.int_dtype == np.int64 if HAS_ILP64 else np.int32
```

Using `ilp64=True` when HAS_ILP64=False is a RuntimeError. Likewise, using `ilp64=False` when HAS_LP64=False is a RuntimeError, too.


#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.