### PR TITLE
BUG: stats.binomtest: fix precision loss in two-sided test for large n

### DIFF
--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -297,13 +297,15 @@ def binomtest(k, n, p=0.5, alternative='two-sided'):
             B = _SimpleBinomial(n, p)
             ix = _binary_search_for_binom_tst(lambda x1: -B.pmf(x1), -d*rerr,
                                               xp.ceil(p * n), n, xp=xp)
+            n_int = xp.astype(n, xp.int64)
+            ix_int = xp.astype(ix, xp.int64)
             # y is the number of terms between mode and n that are <= d*rerr.
             # ix gave us the first term where a(ix) <= d*rerr < a(ix-1)
             # if the first equality doesn't hold, y=n-ix. Otherwise, we
             # need to include ix as well as the equality holds. Note that
             # the equality will hold in very very rare situations due to rerr.
-            y = n - ix + xp.asarray(d*rerr == B.pmf(ix), dtype=ix.dtype)
-            pval = B.cdf(k) + B.sf(n - y)
+            y = n_int - ix_int + xp.astype(d*rerr == B.pmf(ix), xp.int64)
+            pval = B.cdf(k) + B.sf(xp.astype(n_int - y, k.dtype))
             return pval
 
         def k_gte_pn(d, k, p, n):

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1466,6 +1466,16 @@ class TestBinomTest:
         xp_assert_close(res4_p1, binom_testp1)
         xp_assert_close(res4_m1, binom_testm1)
 
+    @skip_xp_backends('jax.numpy', reason="'two-sided' alternative needs root finder")
+    def test_binomtest_large_n_precision(self, xp):
+        # Test that two-sided binomtest is precise for very large n,
+        # where float arithmetic on n and ix would lose precision.
+        n = 10000000000000000
+        k = 1
+        p = 1e-15
+        result = stats.binomtest(k, n, p)
+        xp_assert_close(result.pvalue, xp.asarray(0.001199049739722154))
+
 
 @make_xp_test_case(stats.fligner)
 class TestFligner:


### PR DESCRIPTION
#### What does this implement/fix?
`stats.binomtest` returns sometimes imprecise results for large `n` (>2^53) due to computation in floats, even when int can be used. 

Fixed by converting to `int64` for the subtraction of `n` and `ix`, then casting back to float before passing to `B.sf()`.

#### Additional information
How to reproduce:
```

from scipy.stats import binom, binomtest
from scipy.stats._binomtest import _binary_search_for_binom_tst
import numpy as np

n = 10000000000000000
k = 1
p = 1e-15

d = binom.pmf(k, n, p)
rerr = 1 + 1e-7

ix = _binary_search_for_binom_tst(
    lambda x1: -binom.pmf(x1, n, p),
    -d * rerr, np.ceil(p * n), n)

y = n - int(ix) + int(d*rerr == binom.pmf(ix, n, p))
pval_correct = binom.cdf(k, n, p) + binom.sf(n - y, n, p)


result = binomtest(k, n, p, 'two-sided')

print(f"binomtest: {result.pvalue}") # 0.002087659889245364
print(f"correct:   {pval_correct}")  # 0.001199049739722154

print(f"n - int(ix) = {n - int(ix)}")
print(f"n - ix = {int(n - ix)}")
```

#### AI Generation Disclosure
Claude AI was used to make the change more canonical. 
