### PR TITLE
DOC: declare netcdf IO classes legacy

### DIFF
--- a/scipy/io/_netcdf.py
+++ b/scipy/io/_netcdf.py
@@ -96,6 +96,12 @@ class netcdf_file:
     """
     A file object for NetCDF data.
 
+    .. legacy:: class
+
+        For new projects, consider using
+        `netcdf4-python <https://unidata.github.io/netcdf4-python/>`_
+        instead.
+
     A `netcdf_file` object has two standard attributes: `dimensions` and
     `variables`. The values of both are dictionaries, mapping dimension
     names to their associated lengths and variable names to variables,
@@ -129,14 +135,6 @@ class netcdf_file:
 
     Notes
     -----
-    This module is derived from
-    `pupynere <https://github.com/stcorp/pupynere>`_.
-    The major advantage of this module over other modules is that it doesn't
-    require the code to be linked to the NetCDF libraries. However, for a more
-    recent version of the NetCDF standard and additional features, please consider
-    the permissively-licensed
-    `netcdf4-python <https://unidata.github.io/netcdf4-python/>`_.
-
     NetCDF files are a self-describing binary data format. The file contains
     metadata that describes the dimensions and variables in the file. More
     details about NetCDF files can be found `here
@@ -806,6 +804,12 @@ class netcdf_variable:
     """
     A data object for netcdf files.
 
+    .. legacy:: class
+
+        For new projects, consider using
+        `netcdf4-python <https://unidata.github.io/netcdf4-python/>`_
+        instead.
+
     `netcdf_variable` objects are constructed by calling the method
     `netcdf_file.createVariable` on the `netcdf_file` object. `netcdf_variable`
     objects behave much like array objects defined in numpy, except that their
@@ -853,12 +857,6 @@ class netcdf_variable:
     See Also
     --------
     isrec, shape
-
-    Notes
-    -----
-    For a more recent version of the NetCDF standard and additional features, please
-    consider the permissively-licensed
-    `netcdf4-python <https://unidata.github.io/netcdf4-python/>`_.
 
     """
     def __init__(self, data, typecode, size, shape, dimensions,


### PR DESCRIPTION
#### Reference issue
Closes https://github.com/scipy/scipy/issues/24885
Closes #13980 
Closes #7124 
Closes #6203 
Closes #24885 
Closes #9162 
Closes #9157 
Closes #6880 
Closes #16285 
Closes #10937 
Closes #10958 
Closes #6097 
Closes #13905 
Closes #14566 

#### What does this implement/fix?
This PR declares our netCDF IO classes as legacy and recommends to use netcdf4python instead.

#### Additional information
I will wait a few weeks to see if there are conflicting opinions about the legacy declaration in #24685. This PR will give the topic also more visibility.

#### AI Generation Disclosure
No AI.
