### PR TITLE
TST: linalg: skip a test which was failing on armhf in Debian testing

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2869,10 +2869,11 @@ class TestDTypes:
         a = self.get_arr2D(tcode)
 
         is_arm = platform.machine() == 'arm64'
+        is_armhf = platform.machine() == 'armv8l'   # gh-24831
         is_windows = os.name == 'nt'
 
         failing_tcodes = 'SUVOmM'
-        if not (is_arm or is_windows):
+        if not (is_arm or is_armhf or is_windows):
             failing_tcodes += 'gG'
 
         if tcode in failing_tcodes:


### PR DESCRIPTION
closes gh-24831

Debian testing reported that the dtype test was failing for linalg.det and longdoubles on armhf. We do not test armhf in the SciPy CI, which is why it went unnoticed.

The fix here is what https://github.com/scipy/scipy/issues/24831#issuecomment-4070470663 suggested.

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

Have added a _backport-candidate_ label to only flag that the test is new in scipy 1.17.1, so if there is a 1.17.2 release, this patch could go into it. 


#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai