### PR TITLE
DOC: add examples to buttap and besselap docstrings

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -4672,6 +4672,24 @@ def buttap(N, *, xp=None, device=None):
     See Also
     --------
     butter : Filter design function using this prototype
+    Examples
+    --------
+    Design a 3rd-order Butterworth analog prototype filter:
+
+    >>> from scipy.signal import buttap
+    >>> z, p, k = buttap(3)
+    >>> z
+    array([], dtype=float64)
+    >>> len(p)
+    3
+    >>> k
+    1.0
+
+    The poles are evenly spaced on the left half of the unit circle:
+
+    >>> import numpy as np
+    >>> np.abs(p)  # all poles have unit magnitude
+    array([1., 1., 1.])
 
     """
     if xp is None:
@@ -5333,6 +5351,25 @@ def besselap(N, norm='phase', *, xp=None, device=None):
     .. [6] Miller and Bohn, "A Bessel Filter Crossover, and Its Relation to
            Others", RaneNote 147, 1998,
            https://www.ranecommercial.com/legacy/note147.html
+    Examples
+    --------
+    Design a 3rd-order Bessel analog prototype filter with default
+    phase-matched normalization:
+
+    >>> from scipy.signal import besselap
+    >>> z, p, k = besselap(3)
+    >>> z
+    array([], dtype=float64)
+    >>> len(p)
+    3
+    >>> k
+    1.0
+
+    The filter with magnitude normalization:
+
+    >>> z, p, k = besselap(3, norm='mag')
+    >>> k
+    1.0
 
     """
     if xp is None:


### PR DESCRIPTION
## Summary

Adds `Examples` sections to `scipy.signal.buttap` and `scipy.signal.besselap`, which currently have none.

## Changes

**`scipy/signal/_filter_design.py`**

- `buttap`: Added example showing basic 3rd-order filter creation, verifying zeros, poles count, gain, and that poles lie on the unit circle.
- `besselap`: Added example showing 3rd-order filter with default phase normalization and magnitude normalization.

## Motivation

Partially addresses #7168 — many scipy functions lack docstring examples. These two filter prototype functions are commonly used but had no usage examples.

The examples follow the same style as existing examples in the file (e.g., `findfreqs`, `freqs`, `freqs_zpk`).