### PR TITLE
MAINT: `__package__` → `__spec__.parent`

### DIFF
--- a/scipy/datasets/_download_all.py
+++ b/scipy/datasets/_download_all.py
@@ -15,7 +15,7 @@ except ImportError:
     pooch = None
 
 
-if __package__ is None or __package__ == '':
+if __spec__.parent is None or __spec__.parent == '':
     # Running as python script, use absolute import
     import _registry  # type: ignore
 else:


### PR DESCRIPTION
#### Reference issue


#### What does this implement/fix?

Remove deprecated `__package__`, scheduled for [removal in Python 3.15](https://docs.python.org/3.15/reference/datamodel.html#module.__package__).

[lint only]

#### Additional information

From [module.**__package__**](https://docs.python.org/3.15/reference/datamodel.html#module.__package__):
> _Deprecated since version 3.13, removed in version 3.15:_ `__package__` will cease to be set or taken into consideration by the import system or standard library.

#### AI Generation Disclosure

No AI tools used