### PR TITLE
BLD: ensure include paths for `blas_dep` and `lapack_dep` are complete

### DIFF
--- a/scipy/integrate/meson.build
+++ b/scipy/integrate/meson.build
@@ -9,7 +9,6 @@ py3.extension_module('_odepack',
   ['_odepackmodule.c', 'src/lsoda.c'],
   link_args: version_link_args,
   dependencies: [lapack_dep, np_dep, ccallback_dep],
-  include_directories: ['../_build_utils/src'],
   install: true,
   subdir: 'scipy/integrate'
 )
@@ -18,7 +17,6 @@ py3.extension_module('_vode',
   ['_dzvodemodule.c', 'src/vode.c', 'src/zvode.c'],
   link_args: version_link_args,
   dependencies: [lapack_dep, np_dep, ccallback_dep],
-  include_directories: ['../_build_utils/src'],
   install: true,
   subdir: 'scipy/integrate'
 )

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -151,7 +151,6 @@ if use_ilp64
   py3.extension_module('_fblas_64',
     fblas64_module,
     link_args: version_link_args,
-    include_directories: ['../_build_utils/src'],   # for npy_cblas.h
     dependencies: [lapack_dep, fortranobject_dep],  # lapack_dep is ILP64 if use_ilp64==true
     install: true,
     link_language: link_language_blas_lapack,
@@ -168,7 +167,6 @@ if use_ilp64
     flapack64_module,
     c_args: [Wno_empty_body],
     link_args: version_link_args,
-    include_directories: ['../_build_utils/src'],   # for npy_cblas.h
     dependencies: [lapack_dep, fortranobject_dep],
     install: true,
     link_language: link_language_blas_lapack,
@@ -197,7 +195,6 @@ py3.extension_module('_batched_linalg',
     'src/_batched_linalg_module.cc'
   ],
   dependencies: [np_dep, lapack_dep],
-  include_directories: ['../_build_utils/src'],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/linalg'
@@ -233,7 +230,6 @@ cython_blas = py3.extension_module('cython_blas',
   link_args: version_link_args,
   dependencies: [cython_blas_lapack_dep, np_dep],
   install: true,
-  include_directories: ['../_build_utils/src'],
   subdir: 'scipy/linalg'
 )
 
@@ -246,7 +242,6 @@ cython_lapack = py3.extension_module('cython_lapack',
   link_args: version_link_args,
   dependencies: [cython_blas_lapack_dep, np_dep],
   install: true,
-  include_directories: ['../_build_utils/src'],
   subdir: 'scipy/linalg'
 )
 
@@ -271,7 +266,7 @@ py3.extension_module('_internal_matfuncs',
     'src/_matfuncs_expm.c',
     'src/_matfuncs_sqrtm.c'
   ],
-  include_directories: ['src/', '../_build_utils/src'],  # for scipy_blas_defines.h
+  include_directories: ['src/'],
   dependencies: [np_dep, lapack_dep],
   install: true,
   subdir: 'scipy/linalg'

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -317,7 +317,8 @@ endif
 
 blas_lp64_dep = declare_dependency(
   dependencies: blas,
-  compile_args: _args_blas_lapack
+  compile_args: _args_blas_lapack,
+  include_directories: ['_build_utils/src'],
 )
 
 if not blas.found()
@@ -437,16 +438,14 @@ if use_ilp64
     endif
     message(f'BLAS symbol suffix (ILP64): @blas_symbol_suffix@')
   endif
-  _blas_incdir = []
   if blas_symbol_suffix != ''
     _args_blas_ilp64 += ['-DBLAS_SYMBOL_SUFFIX=' + blas_symbol_suffix]
-    _blas_incdir = ['.']
   endif
 
   blas_dep = declare_dependency(
     dependencies: [blas_ilp64],
     compile_args: _args_blas_ilp64,
-    include_directories: _blas_incdir,
+    include_directories: ['_build_utils/src'],
   )
   lapack_dep = declare_dependency(dependencies: [lapack_ilp64, blas_dep])
 
@@ -861,7 +860,8 @@ if use_ilp64
   blas_dep = declare_dependency(
     dependencies: blas_dep,
     link_with: [g77_abi_wrappers_ilp64],
-    compile_args: [c_flags_ilp64]
+    compile_args: [c_flags_ilp64],
+    include_directories: ['_build_utils/src'],
   )
   lapack_dep = declare_dependency(
     dependencies: [lapack_dep, blas_dep],

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -814,8 +814,8 @@ endif
 conf_data.set('BLAS_CYTHON_ILP64', _cython_blas_ilp64.to_string())
 
 # TODO: make this into an option
-conf_data.set('BLAS_HAS_LP64', true)
-conf_data.set('LAPACK_HAS_LP64', true)
+conf_data.set('BLAS_HAS_LP64', 'true')
+conf_data.set('LAPACK_HAS_LP64', 'true')
 
 configure_file(
   input: '__config__.py.in',

--- a/scipy/optimize/_trlib/meson.build
+++ b/scipy/optimize/_trlib/meson.build
@@ -8,10 +8,7 @@ py3.extension_module('_trlib',
     'trlib_tri_factor.c'
   ],
   c_args: cython_c_args,
-  include_directories: [
-    '../../_lib',
-    '../../_build_utils/src'
-  ],
+  include_directories: ['../../_lib'],
   dependencies: [lapack_dep, np_dep],
   link_args: version_link_args,
   install: true,

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -70,7 +70,7 @@ py3.extension_module('_lbfgsb',
     'src/lbfgsb.c',
   ],
   dependencies: [lapack_dep, np_dep],
-  include_directories: ['src/', '../_build_utils/src'],
+  include_directories: ['src/'],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/optimize'
@@ -145,7 +145,6 @@ py3.extension_module('_slsqplib',
     'src/nnls.c'
   ],
   dependencies: [lapack_dep, np_dep],
-  include_directories: ['../_build_utils/src'],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/optimize'

--- a/scipy/sparse/linalg/_eigen/arpack/meson.build
+++ b/scipy/sparse/linalg/_eigen/arpack/meson.build
@@ -9,10 +9,7 @@ arnaud_sources = [
 
 arnaud_lib = static_library('arnaud',
   arnaud_sources,
-  include_directories: [
-    'arnaud/include',
-    '../../../../_build_utils/src',
-  ],
+  include_directories: ['arnaud/include'],
   dependencies: [m_dep, lapack_dep, np_dep, py3_dep],
   c_args: ['-DARNAUD_HAS_BLAS_CONFIG'],
 )

--- a/scipy/sparse/linalg/_propack/meson.build
+++ b/scipy/sparse/linalg/_propack/meson.build
@@ -14,7 +14,7 @@ py3.extension_module('_propack',
     propack_sources,
     '_propackmodule.c'
   ],
-  include_directories: ['PROPACK/include', 'PROPACK/src/include', '../../../_build_utils/src'],
+  include_directories: ['PROPACK/include', 'PROPACK/src/include'],
   dependencies: [np_dep, ccallback_dep, lapack_dep],
   link_args: version_link_args,
   install: true,


### PR DESCRIPTION
This is a very simple cleanup, I submitted this standalone because it gets rid of some remaining `npy_cblas.h` mentions and deprecation warnings.

Also fix deprecation warnings from Meson 1.10 for the just-introduced `HAS_LP64` config variable - `conf_data` needs string values rather than booleans. The warnings were:
```
Configuring __config__.py using configuration
DEPRECATION: Variable substitution with boolean value 'BLAS_HAS_LP64' is deprecated.
DEPRECATION: Variable substitution with boolean value 'LAPACK_HAS_LP64' is deprecated.
```

#### AI Generation Disclosure

I did `scipy/meson.build` changes by hand, then used Claude Opus 4.6 to apply some of the edits to the many other `meson.build` files that needed the identical trivial change of removing the `_build_utils/src/` include directory.