### PR TITLE
TST: linalg: remove obsolete 0.0 fallback in `test_stable`

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2519,16 +2519,11 @@ class TestVectorNorms:
 
     def test_stable(self):
         # more stable than numpy's norm
-        a = array([1e4] + [1]*10000, dtype=float32)
-        try:
-            # snrm in double precision; we obtain the same as for float64
-            # -- large atol needed due to varying blas implementations
-            assert_allclose(norm(a) - 1e4, 0.5, atol=1e-2)
-        except AssertionError:
-            # snrm implemented in single precision, == np.linalg.norm result
-            msg = ": Result should equal either 0.0 or 0.5 (depending on " \
-                  "implementation of snrm2)."
-            assert_almost_equal(norm(a) - 1e4, 0.0, err_msg=msg)
+        a = array([1e4] + [1] * 10000, dtype=float32)
+        # Compare against a float64 reference value.
+        # A small absolute tolerance allows for BLAS-dependent variation.
+        expected = np.sqrt((1e4)**2 + 10000.0) - 1e4
+        assert_allclose(norm(a) - 1e4, expected, atol=1.6e-2, rtol=0)
 
     def test_zero_norm(self):
         assert_equal(norm([1, 0, 3], 0), 2)

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2519,11 +2519,7 @@ class TestVectorNorms:
 
     def test_stable(self):
         a = array([1e4] + [1] * 10000, dtype=float32)
-        # Reference value was computed with mpmath:
-        # from mpmath import mp
-        # mp.dps = 100
-        # expected = mp.norm(a) - mp.mpf("1e4")
-        expected = 0.49998750062496094
+        expected = np.float32(np.sqrt(100010000) - 1e4)
         # A small absolute tolerance allows for BLAS-dependent variation.
         assert_allclose(norm(a) - 1e4, expected, atol=1.6e-2, rtol=0)
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2518,11 +2518,13 @@ class TestVectorNorms:
         assert_almost_equal(norm(a), a)
 
     def test_stable(self):
-        # more stable than numpy's norm
         a = array([1e4] + [1] * 10000, dtype=float32)
-        # Compare against a float64 reference value.
+        # Reference value was computed with mpmath:
+        # from mpmath import mp
+        # mp.dps = 100
+        # expected = mp.norm(a) - mp.mpf("1e4")
+        expected = 0.49998750062496094
         # A small absolute tolerance allows for BLAS-dependent variation.
-        expected = np.sqrt((1e4)**2 + 10000.0) - 1e4
         assert_allclose(norm(a) - 1e4, expected, atol=1.6e-2, rtol=0)
 
     def test_zero_norm(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-24096

#### What does this implement/fix?
Compare the float32 norm result against a reference value instead of accepting either ~0.5 or 0.0. This accommodates intermediate BLAS results while rejecting the historical 0.0 fallback.

#### Additional information
On an AOCL 4.2.0-backed build using BLIS/libFLAME, `norm(a) - 1e4` is `0.484375`; its absolute difference from the float64 reference value is `0.0156125`. Use `atol=1.6e-2` so that this reproduced case is accepted while the historical `0.0` fallback is still rejected.

#### AI Generation Disclosure
OpenAI ChatGPT was used to help understand the issue and refine the PR
wording. The code changes were made by the author.
