### PR TITLE
BLD: fix issue with manual caching function in `_generate_pyx.py` scripts

### DIFF
--- a/scipy/_build_utils/_generate_blas_wrapper.py
+++ b/scipy/_build_utils/_generate_blas_wrapper.py
@@ -30,7 +30,7 @@ import os
 
 from _wrappers_common import (C_PREAMBLE, C_TYPES, CPP_GUARD_BEGIN,
                               CPP_GUARD_END, LAPACK_DECLS, USE_OLD_ACCELERATE,
-                              WRAPPED_FUNCS, all_newer,
+                              WRAPPED_FUNCS,
                               get_blas_macro_and_name, read_signatures,
                               write_files)
 
@@ -96,14 +96,7 @@ def make_all(outdir,
         lapack_sigs = f.readlines()
     blas_sigs = read_signatures(blas_sigs)
     lapack_sigs = read_signatures(lapack_sigs)
-    # Do not create new files if not necessary
-    src_files = (os.path.abspath(__file__),
-                 blas_signature_file,
-                 lapack_signature_file)
     dst_files = [os.path.join(outdir, 'blas_lapack_wrappers.c')]
-    if all_newer(dst_files, src_files):
-        print("scipy/_build_utils/_generate_blas_wrapper.py: all files up-to-date")
-        return
     wrapper_file = generate_file_wrapper(blas_sigs + lapack_sigs, accelerate)
     write_files({dst_files[0]: wrapper_file})
 

--- a/scipy/_build_utils/_wrappers_common.py
+++ b/scipy/_build_utils/_wrappers_common.py
@@ -2,9 +2,6 @@
 Helper functions and variables for generation of BLAS/LAPACK wrappers.
 """
 
-import os
-from stat import ST_MTIME
-
 # Used to convert from types in signature files to C types
 C_TYPES = {'int': 'int',
            'blas_int': 'CBLAS_INT',
@@ -99,28 +96,6 @@ def read_signatures(lines):
             'argtypes': list(argtypes)
         })
     return sigs
-
-def newer(dst, src):
-    """
-    Return true if 'dst' exists and is more recently modified than
-    'src', or if 'dst' exists and 'src' doesn't.  Return false if
-    both exist and 'dst' is the same age or younger than 'src'.
-    """
-    if not os.path.exists(dst):
-        raise ValueError(f"file '{os.path.abspath(dst)}' does not exist")
-    if not os.path.exists(src):
-        return 1
-
-    mtime1 = os.stat(dst)[ST_MTIME]
-    mtime2 = os.stat(src)[ST_MTIME]
-
-    return mtime1 > mtime2
-
-
-def all_newer(dst_files, src_files):
-    """True only if all dst_files exist and are newer than all src_files."""
-    return all(os.path.exists(dst) and newer(dst, src)
-               for dst in dst_files for src in src_files)
 
 
 def get_blas_macro_and_name(name, accelerate, ilp64=False):

--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -36,7 +36,6 @@ CPP_GUARD_END = _wrappers_common.CPP_GUARD_END
 LAPACK_DECLS = _wrappers_common.LAPACK_DECLS
 NPY_TYPES = _wrappers_common.NPY_TYPES
 WRAPPED_FUNCS = _wrappers_common.WRAPPED_FUNCS
-all_newer = _wrappers_common.all_newer
 get_blas_macro_and_name = _wrappers_common.get_blas_macro_and_name
 read_signatures = _wrappers_common.read_signatures
 write_files = _wrappers_common.write_files
@@ -687,9 +686,6 @@ def make_all(outdir,
              lapack_header_name="_lapack_subroutines.h",
              accelerate=False,
              ilp64=False):
-    src_files = (os.path.abspath(__file__),
-                 blas_signature_file,
-                 lapack_signature_file)
     dst_files = (blas_name + '.pyx',
                  blas_name + '.pxd',
                  blas_header_name,
@@ -698,9 +694,6 @@ def make_all(outdir,
                  lapack_header_name)
     dst_files = [os.path.join(outdir, f) for f in dst_files]
     os.chdir(BASE_DIR)
-    if all_newer(dst_files, src_files):
-        print("scipy/linalg/_generate_pyx.py: all files up-to-date")
-        return
     with open(blas_signature_file) as f:
         blas_sigs = f.readlines()
     blas_sigs = read_signatures(blas_sigs)

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -26,6 +26,7 @@ cython_linalg = custom_target('cython_linalg',
   depend_files: [
     'cython_blas_signatures.txt',
     'cython_lapack_signatures.txt',
+    '../_build_utils/_generate_blas_wrapper.py',
     '../_build_utils/_wrappers_common.py',
   ],
   install: true,

--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -70,10 +70,9 @@ the same shared library.
 
 """
 
+import argparse
 import json
 import os
-from stat import ST_MTIME
-import argparse
 import re
 import textwrap
 
@@ -781,33 +780,7 @@ def unique(lst):
     return new_lst
 
 
-def newer(source, target):
-    """
-    Return true if 'source' exists and is more recently modified than
-    'target', or if 'source' exists and 'target' doesn't.  Return false if
-    both exist and 'target' is the same age or younger than 'source'.
-    """
-    if not os.path.exists(source):
-        raise ValueError(f"file '{os.path.abspath(source)}' does not exist")
-    if not os.path.exists(target):
-        return 1
-
-    mtime1 = os.stat(source)[ST_MTIME]
-    mtime2 = os.stat(target)[ST_MTIME]
-
-    return mtime1 > mtime2
-
-
-def all_newer(src_files, dst_files):
-    return all(os.path.exists(dst) and newer(dst, src)
-               for dst in dst_files for src in src_files)
-
-
 def main(outdir):
-    pwd = os.path.dirname(__file__)
-    src_files = (os.path.abspath(__file__),
-                 os.path.abspath(os.path.join(pwd, 'functions.json')),
-                 os.path.abspath(os.path.join(pwd, '_add_newdocs.py')))
     dst_files = ('_ufuncs.pyx',
                  '_ufuncs_defs.h',
                  '_ufuncs_cxx.pyx',
@@ -816,10 +789,6 @@ def main(outdir):
     dst_files = (os.path.join(outdir, f) for f in dst_files)
 
     os.chdir(BASE_DIR)
-
-    if all_newer(src_files, dst_files):
-        print("scipy/special/_generate_pyx.py: all files up-to-date")
-        return
 
     ufuncs = []
     with open('functions.json') as data:


### PR DESCRIPTION
This was a latent bug that showed up when `npy_cblas.h` was removed from the generated `_blas_subroutines.h` and the build was still looking for it (xref gh-24902).

The `all_newer` functionality made sense for `distutils`, but now Ninja won't run the `generate_pyx.py` script anyway unless the inputs change, so no need to handle this manually.


#### AI Generation Disclosure

No AI used.
