### PR TITLE
ENH: linalg: improve memory copy performance

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -19,7 +19,7 @@ def random(size):
 class Bench(Benchmark):
     params = [
         [20, 100, 500, 1000],
-        ['contig', 'nocont'],
+        ['contig', 'nocont', 'fcontig'],
         ['numpy', 'scipy']
     ]
     param_names = ['size', 'contiguous', 'module']
@@ -39,9 +39,11 @@ class Bench(Benchmark):
             a[i, i] = 10*(.1+a[i, i])
         b = random([size])
 
-        if contig != 'contig':
+        if contig == 'nocont':
             a = a[-1::-1, -1::-1]  # turn into a non-contiguous array
             assert_(not a.flags['CONTIGUOUS'])
+        elif contig == 'fcontig':
+            a = np.asfortranarray(a)
 
         self.a = a
         self.b = b
@@ -90,22 +92,17 @@ class Bench(Benchmark):
         else:
             sl.svd(self.a)
 
-    # Retain old benchmark results (remove this if changing the benchmark)
-    time_det.version = (
-        "87e530ee50eb6b6c06c7a8abe51c2168e133d5cbd486f4c1c2b9cedc5a078325"
-    )
-    time_eigvals.version = (
-        "9d68d3a6b473df9bdda3d3fd25c7f9aeea7d5cee869eec730fb2a2bcd1dfb907"
-    )
-    time_inv.version = (
-        "20beee193c84a5713da9749246a7c40ef21590186c35ed00a4fe854cce9e153b"
-    )
-    time_solve.version = (
-        "1fe788070f1c9132cbe78a47fdb4cce58266427fc636d2aa9450e3c7d92c644c"
-    )
-    time_svd.version = (
-        "0ccbda456d096e459d4a6eefc6c674a815179e215f83931a81cfa8c18e39d6e3"
-    )
+    def time_qr_raw(self, size, contig, module):
+        if module == 'numpy':
+            pass
+        else:
+            sl.qr(self.a, mode='raw')
+
+    def time_qr_economic(self, size, contig, module):
+        if module == 'numpy':
+            nl.qr(self.a, mode='reduced')
+        else:
+            sl.qr(self.a, mode='economic')
 
 
 class BatchedSolveBench(Benchmark):
@@ -238,6 +235,34 @@ class BatchedCholeskyBench(Benchmark):
             nl.cholesky(self.a)
         else:
             sl.cholesky(self.a)
+
+
+class QRBench(Benchmark):
+    params = [
+        [(512, 32), (1024, 128), (4096, 256)],
+        ["full", "economic", "r", "raw"],
+        ["C", "F"],
+        ["scipy", "numpy"]
+    ]
+    param_names = ["shape", "mode", "order", "module"]
+
+    def setup(self, shape, mode, order, module):
+        if module == "numpy" and mode == "raw":
+            raise NotImplementedError()
+        a = random(shape)
+        self.a = np.asfortranarray(a) if order == "F" else np.ascontiguousarray(a)
+        if module == "numpy":
+            mode_map = {"full": "complete", "economic": "reduced",
+                        "r": "r"}
+            self.kwd = {"mode": mode_map[mode]}
+        else:
+            self.kwd = {"mode": mode}
+
+    def time_qr(self, shape, mode, order, module):
+        if module == "numpy":
+            nl.qr(self.a, **self.kwd)
+        else:
+            sl.qr(self.a, **self.kwd)
 
 
 class BatchedQRBench(Benchmark):

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1055,21 +1055,52 @@ void copy_slice(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp m, 
 
 
 /*
- * Copy n-by-m C-order slice from slice_ptr to dst in F-order.
+ * Copy n-by-m strided slice from slice_ptr to dst in F-order.
  *
- * `src` is n-by-m, strided
+ * `src` is n-by-m, strided (strides s2, s1 in bytes)
  * `dst` is ldb-by-m, F-ordered.
  *
  * The default is to have src and dst of the same size (ldb=-1 means ldb=n).
+ *
+ * Fast paths:
+ *   - F-contiguous input (s2 == sizeof(T), s1 == n*sizeof(T)): memcpy
+ *   - C-contiguous input (s2 == m*sizeof(T), s1 == sizeof(T)): blocked transpose
+ *   - General strides: element-by-element copy
  */
 template<typename T>
 void copy_slice_F(T* dst, const T* slice_ptr, const npy_intp n, const npy_intp m, const npy_intp s2, const npy_intp s1, npy_intp ldb=-1) {
 
     if (ldb == -1) {ldb = n;}
 
+    const npy_intp sz = (npy_intp)sizeof(T);
+
+    // F-contiguous: layout already matches, straight memcpy
+    if (s2 == sz && s1 == n * sz && ldb == n) {
+        memcpy(dst, slice_ptr, n * m * sizeof(T));
+        return;
+    }
+
+    // C-contiguous: blocked transpose for cache efficiency
+    if (s2 == m * sz && s1 == sz) {
+        const npy_intp BLOCK = 64;
+        for (npy_intp j0 = 0; j0 < m; j0 += BLOCK) {
+            npy_intp j1 = std::min(j0 + BLOCK, m);
+            for (npy_intp i0 = 0; i0 < n; i0 += BLOCK) {
+                npy_intp i1 = std::min(i0 + BLOCK, n);
+                for (npy_intp j = j0; j < j1; j++) {
+                    for (npy_intp i = i0; i < i1; i++) {
+                        dst[i + j*ldb] = slice_ptr[i*m + j];
+                    }
+                }
+            }
+        }
+        return;
+    }
+
+    // General strides: element-by-element
     for (npy_intp i = 0; i < n; i++) {
         for (npy_intp j = 0; j < m; j++) {
-            dst[i + j*ldb] = *(slice_ptr + (i*s2/sizeof(T)) + (j*s1/sizeof(T)));  // == src[i*m + j]
+            dst[i + j*ldb] = *(slice_ptr + (i*s2/sz) + (j*s1/sz));
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

- #24268

#### What does this implement/fix?

I noticed a recent regression in QR when exploring a new implementation for `qr_multiply`, there are two fixes that resolve this, one QR specific and another to the commonly used `copy_slice_F` function. I'm putting the common fix in first. The main optimisation is simply doing a standard `memcpy` when the array is already F-contiguous (this can provide a 30-50% speedup for raw QR factorisation). I additionally tried out a blocked transpose approach which seemed to result in a 10% speedup for large matrices and is probably worth keeping. Let me know if you have any thoughts.

#### Additional information

- Added some square and tall-skinny QR benchmarks.

#### AI Generation Disclosure

Claude Code was used to help write code and run benchmarks.