### PR TITLE
TYP: fix type alias declarations

### DIFF
--- a/scipy/_lib/_array_api_override.py
+++ b/scipy/_lib/_array_api_override.py
@@ -20,8 +20,8 @@ from scipy._external.array_api_compat import is_array_api_obj, is_jax_array
 from scipy._lib._sparse import SparseABC
 
 
-Array: type = Any  # To be changed to a Protocol later (see array-api#589)
-ArrayLike: type = Array | npt.ArrayLike
+type Array = Any  # To be changed to a Protocol later (see array-api#589)
+type ArrayLike = Array | npt.ArrayLike
 
 # To enable array API and strict array-like input validation
 SCIPY_ARRAY_API: str | bool = os.environ.get("SCIPY_ARRAY_API", False)

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -22,24 +22,11 @@ from scipy._lib._sparse import issparse
 from numpy.exceptions import AxisError
 
 
-np_long: type
-np_ulong: type
+type np_long = np.long
+type np_ulong = np.ulong
 
-try:
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            r".*In the future `np\.long` will be defined as.*",
-            FutureWarning,
-        )
-        np_long = np.long  # type: ignore[attr-defined]
-        np_ulong = np.ulong  # type: ignore[attr-defined]
-except AttributeError:
-        np_long = np.int_
-        np_ulong = np.uint
-
-IntNumber = int | np.integer
-DecimalNumber = float | np.floating | np.integer
+type IntNumber = int | np.integer
+type DecimalNumber = float | np.floating | np.integer
 
 copy_if_needed: bool | None = None
 
@@ -63,8 +50,8 @@ else:
     wrapped_inspect_signature = inspect.signature
 
 
-_RNG: type = np.random.Generator | np.random.RandomState
-SeedType: type = IntNumber | _RNG | None
+type _RNG = np.random.Generator | np.random.RandomState
+type SeedType = IntNumber | _RNG | None
 
 GeneratorType = TypeVar("GeneratorType", bound=_RNG)
 

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -22,8 +22,8 @@ from scipy._lib._sparse import issparse
 from numpy.exceptions import AxisError
 
 
-type np_long = np.long
-type np_ulong = np.ulong
+np_long = np.long
+np_ulong = np.ulong
 
 type IntNumber = int | np.integer
 type DecimalNumber = float | np.floating | np.integer

--- a/scipy/integrate/_cubature.py
+++ b/scipy/integrate/_cubature.py
@@ -24,7 +24,7 @@ from scipy.integrate._rules._base import _split_subregion
 
 __all__ = ['cubature']
 
-Array: type = Any  # To be changed to an array-api-typing Protocol later
+type Array = Any  # To be changed to an array-api-typing Protocol later
 
 
 @dataclass


### PR DESCRIPTION
Type aliases should be declared with `{definiendum}: typing.TypeAlias = {definiens}` (Python <3.12) or as `type {definiendum} = {definiens}` (Python >=3.12). So it's not surprising that you might expect `{definiendum}: type = {definiens}` to also work. 
However, `_: type` is used to describe a type *value*, rather than a a type *alias*. For example when writing `cls: type = type(self)`. 

Assuming that this won't be backported, I used the Python 3.12 (PEP 695) syntax.

Oh and I also took the liberty of simplifying the `np.[u]long` re-exports (which, as it turns out, aren't  type-alias, but alias to types), seeing as there's no longer need to worry about numpy 1.

#### AI Generation Disclosure

<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I did this myself, and I'm a human (I think).
