### PR TITLE
ENH: stats.rankdata: CuPy support via `repeat` workaround

### DIFF
--- a/scipy/stats/_bws_test.py
+++ b/scipy/stats/_bws_test.py
@@ -82,8 +82,7 @@ def _bws_statistic(x, y, alternative, axis, xp):
     return B
 
 
-@xp_capabilities(skip_backends=[('cupy', 'no rankdata'),
-                                ('dask.array', 'no rankdata')])
+@xp_capabilities(skip_backends=[('dask.array', 'no rankdata')])
 def bws_test(x, y, *, alternative="two-sided", axis=0, method=None):
     r'''Perform the Baumgartner-Weiss-Schindler test on two independent samples.
 

--- a/scipy/stats/_correlation.py
+++ b/scipy/stats/_correlation.py
@@ -88,8 +88,7 @@ def _unpack(res, _):
     return res.statistic, res.pvalue
 
 
-@xp_capabilities(skip_backends=[('dask.array', 'no take_along_axis'),
-                                ('cupy', 'no rankdata (xp.repeats limitation)')])
+@xp_capabilities(skip_backends=[('dask.array', 'no take_along_axis')])
 @_axis_nan_policy_factory(SignificanceResult, paired=True, n_samples=2,
                           result_to_tuple=_unpack, n_outputs=2, too_small=1)
 def chatterjeexi(x, y, *, axis=0, y_continuous=False, method='asymptotic'):
@@ -388,8 +387,7 @@ def spearmanrho(x, y, /, *, alternative='two-sided', method=None, axis=0):
 
 
 @xp_capabilities(skip_backends=[("dask.array", "no take_along_axis"),
-                                ("jax.numpy", "non-concrete boolean indexing"),
-                                ('cupy', 'no rankdata (xp.repeats limitation)')],
+                                ("jax.numpy", "non-concrete boolean indexing")],
                  marray=True)
 @_axis_nan_policy_factory(TheilslopesResult, default_axis=None, n_outputs=4,
                           n_samples=_n_samples_optional_x,

--- a/scipy/stats/_hypotests.py
+++ b/scipy/stats/_hypotests.py
@@ -1662,8 +1662,7 @@ def _pval_cvm_2samp_asymptotic(t, N, nx, ny, k, *, xp):
     return p
 
 
-@xp_capabilities(skip_backends=[('cupy', 'needs rankdata'),
-                                ('dask.array', 'needs rankdata')],
+@xp_capabilities(skip_backends=[('dask.array', 'needs rankdata')],
                  cpu_only=True, jax_jit=False,  # due to p-value calculation
                  marray=True,
                  extra_note="Only `method='exact'` is compatible with MArray input.")

--- a/scipy/stats/_mannwhitneyu.py
+++ b/scipy/stats/_mannwhitneyu.py
@@ -235,7 +235,7 @@ def mwu_result_object(statistic, pvalue, zstatistic=None):
 
 @xp_capabilities(
     cpu_only=True,  # exact calculation only implemented in NumPy
-    skip_backends=[('cupy', 'needs rankdata'), ('dask.array', 'needs rankdata')],
+    skip_backends=[('dask.array', 'needs rankdata')],
     jax_jit=False,  # the exact null distribution is NumPy-only
     marray=True,
     extra_note=("Only ``method='asymptotic'`` is compatible with MArray input."

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3498,8 +3498,7 @@ def levene(*samples, center='median', proportiontocut=0.05, axis=0):
 FlignerResult = namedtuple('FlignerResult', ('statistic', 'pvalue'))
 
 
-@xp_capabilities(skip_backends=[('dask.array', 'no rankdata'),
-                                ('cupy', 'no rankdata')],
+@xp_capabilities(skip_backends=[('dask.array', 'no rankdata')],
                  marray=True)
 @_axis_nan_policy_factory(FlignerResult, n_samples=None)
 def fligner(*samples, center='median', proportiontocut=0.05, axis=0):
@@ -3729,7 +3728,7 @@ def _mood_too_small(samples, kwargs, axis=-1):
     return N < 3
 
 
-@xp_capabilities(skip_backends=[('cupy', 'no rankdata'), ('dask.array', 'no rankdata')])
+@xp_capabilities(skip_backends=[('dask.array', 'no rankdata')])
 @_axis_nan_policy_factory(SignificanceResult, n_samples=2, too_small=_mood_too_small)
 def mood(x, y, axis=0, alternative="two-sided"):
     """Perform Mood's test for equal scale parameters.
@@ -3875,8 +3874,7 @@ def wilcoxon_outputs(kwds):
     return 2
 
 
-@xp_capabilities(skip_backends=[("dask.array", "no rankdata"),
-                                ("cupy", "no rankdata")],
+@xp_capabilities(skip_backends=[("dask.array", "no rankdata")],
                  cpu_only=True,  # null distribution is CPU only
                  marray=True,
                  extra_note=("Only ``method='asymptotic'``/``zero_method='zsplit'`` is "

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10404,6 +10404,11 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
     elif method == 'dense':
         ranks = xp.cumulative_sum(xp.astype(i, dtype, copy=False), axis=-1)[i]
 
+    # The below line is used in place of
+    # ranks = xp.reshape(xp.repeat(ranks, counts), shape)
+    # due to xp.repeat not accepting arrays of counts. The cumulative sum over i will
+    # increment every time a new unique rank appears, giving the correct indices to
+    # replicate repeat.
     ranks = xp.reshape(
         ranks[xp.cumulative_sum(xp.astype(xp.reshape(i, (-1,)), xp.int64)) - 1],
         shape,

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7845,8 +7845,7 @@ def _attempt_exact_2kssamp(n1, n2, g, d, alternative):
     return True, d, prob
 
 
-@xp_capabilities(skip_backends=[('cupy', 'no rankdata'),
-                                ('dask.array', 'no rankdata')],
+@xp_capabilities(skip_backends=[('dask.array', 'no rankdata')],
                  jax_jit=False, cpu_only=True,  # null distribution is NumPy-only
                  marray=True)
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=2, n_outputs=4,
@@ -8192,8 +8191,7 @@ def _kstest_n_samples(kwargs):
     return 1 if (isinstance(cdf, str) or callable(cdf)) else 2
 
 
-@xp_capabilities(skip_backends=[('cupy', 'no rankdata'),
-                                ('dask.array', 'no rankdata')],
+@xp_capabilities(skip_backends=[('dask.array', 'no rankdata')],
                  jax_jit=False, cpu_only=True,  # see ks_1samp/ks_2samp
                  marray=True)
 @_axis_nan_policy_factory(_tuple_to_KstestResult, n_samples=_kstest_n_samples,
@@ -8548,7 +8546,7 @@ def ranksums(x, y, alternative='two-sided'):
 KruskalResult = namedtuple('KruskalResult', ('statistic', 'pvalue'))
 
 
-@xp_capabilities(skip_backends=[('cupy', 'no rankdata'), ('dask.array', 'no rankdata')],
+@xp_capabilities(skip_backends=[('dask.array', 'no rankdata')],
                  marray=True)
 @_axis_nan_policy_factory(KruskalResult, n_samples=None)
 def kruskal(*samples, nan_policy='propagate', axis=0):
@@ -8659,7 +8657,7 @@ FriedmanchisquareResult = namedtuple('FriedmanchisquareResult',
                                      ('statistic', 'pvalue'))
 
 
-@xp_capabilities(skip_backends=[("cupy", "no rankdata"), ("dask.array", "no rankdata")],
+@xp_capabilities(skip_backends=[("dask.array", "no rankdata")],
                  marray=True)
 @_axis_nan_policy_factory(FriedmanchisquareResult, n_samples=None, paired=True)
 def friedmanchisquare(*samples, axis=0):
@@ -8763,8 +8761,7 @@ BrunnerMunzelResult = namedtuple('BrunnerMunzelResult',
 
 @xp_capabilities(cpu_only=True, # torch GPU can't use `stdtr`
                  marray=True,
-                 skip_backends=[('dask.array', 'needs rankdata'),
-                                ('cupy', 'needs rankdata')])
+                 skip_backends=[('dask.array', 'needs rankdata')])
 @_axis_nan_policy_factory(BrunnerMunzelResult, n_samples=2)
 def brunnermunzel(x, y, alternative="two-sided", distribution="t",
                   nan_policy='propagate', *, axis=0):

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10405,7 +10405,9 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
 
     # The below line is used in place of
     # ranks = xp.reshape(xp.repeat(ranks, counts), shape)
-    # due to xp.repeat not accepting arrays of counts. The cumulative sum over i will
+    # due to cupy.repeat not accepting arrays for repeats
+    # (ref https://github.com/cupy/cupy/issues/3849).
+    # The cumulative sum over i will
     # increment every time a new unique rank appears, giving the correct indices to
     # replicate repeat.
     ranks = xp.reshape(

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10404,7 +10404,10 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
     elif method == 'dense':
         ranks = xp.cumulative_sum(xp.astype(i, dtype, copy=False), axis=-1)[i]
 
-    ranks = xp.reshape(xp.repeat(ranks, counts), shape)
+    ranks = xp.reshape(
+        ranks[xp.cumulative_sum(xp.astype(xp.reshape(i, (-1,)), xp.int64)) - 1],
+        shape,
+    )
     ranks = _order_ranks(ranks, j, xp=xp)
 
     t = None

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10203,8 +10203,7 @@ def _validate_distribution(values, weights):
     return values, None
 
 
-@xp_capabilities(skip_backends=[("cupy", "`repeat` can't handle array second arg"),
-                                ("dask.array", "no `take_along_axis`")],
+@xp_capabilities(skip_backends=[("dask.array", "no `take_along_axis`")],
                  marray=True)
 def rankdata(a, method='average', *, axis=None, nan_policy='propagate'):
     """Assign ranks to data, dealing with ties appropriately.

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10400,17 +10400,18 @@ def _rankdata(x, method, return_sorted=False, return_ties=False, xp=None):
     elif method == 'dense':
         ranks = xp.cumulative_sum(xp.astype(i, dtype, copy=False), axis=-1)[i]
 
-    # The below line is used in place of
-    # ranks = xp.reshape(xp.repeat(ranks, counts), shape)
-    # due to cupy.repeat not accepting arrays for repeats
-    # (ref https://github.com/cupy/cupy/issues/3849).
-    # The cumulative sum over i will
-    # increment every time a new unique rank appears, giving the correct indices to
-    # replicate repeat.
-    ranks = xp.reshape(
-        ranks[xp.cumulative_sum(xp.astype(xp.reshape(i, (-1,)), xp.int64)) - 1],
-        shape,
-    )
+    if not is_cupy(xp):
+        ranks = xp.reshape(xp.repeat(ranks, counts), shape)
+    else:
+        # workaround for cupy.repeat not accepting arrays for repeats
+        # (ref https://github.com/cupy/cupy/issues/3849).
+        # The cumulative sum over i will
+        # increment every time a new unique rank appears, giving the correct
+        # indices to replicate xp.repeats.
+        ranks = xp.reshape(
+            ranks[xp.cumulative_sum(xp.astype(xp.reshape(i, (-1,)), xp.int64)) - 1],
+            shape,
+        )
     ranks = _order_ranks(ranks, j, xp=xp)
 
     t = None

--- a/scipy/stats/tests/test_correlation.py
+++ b/scipy/stats/tests/test_correlation.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_allclose
 
 from scipy.conftest import skip_xp_invalid_arg
 import scipy._external.array_api_extra as xpx
-from scipy._lib._array_api import (make_xp_test_case, xp_default_dtype, is_jax,
+from scipy._lib._array_api import (make_xp_test_case, xp_default_dtype, is_jax, is_cupy,
                                    eager_warns, xp_result_type, is_array_api_strict)
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
 from scipy import stats
@@ -71,8 +71,9 @@ class TestChatterjeeXi:
         with pytest.raises((ValueError, TypeError), match=message):
             stats.chatterjeexi(x, y[:-1])
 
-        if not is_jax(xp):
+        if not (is_jax(xp) or is_cupy(xp)):
             # jax misses out on some input validation from _axis_nan_policy decorator
+            # This also fails with cupy for reasons that need to be investigated.
             message = '...axis 10 is out of bounds for array...|out of range'
             with pytest.raises((ValueError, IndexError), match=message):
                 stats.chatterjeexi(x, y, axis=10)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1634,7 +1634,6 @@ class TestPermutationTest:
         xp_assert_close(res.statistic, xp.asarray(expected.statistic), rtol=self.rtol)
         xp_assert_close(res.pvalue, xp.asarray(expected.pvalue), rtol=self.rtol)
 
-    @skip_xp_backends('cupy', reason='needs kruskal')
     @skip_xp_backends(eager_only=True)  # kruskal does input validation
     @pytest.mark.parametrize('axis', (-1, 2))
     def test_vectorized_nsamp_ptype_both(self, axis, xp):

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -8042,6 +8042,7 @@ class TestKruskal:
         xp_assert_equal(res.pvalue, xp.asarray(xp.nan))
 
     @skip_xp_backends('jax.numpy', reason='lazy -> reduced nan_policy capabilities')
+    @xfail_xp_backends('cupy', reason='cupy returns small but nonzero res.statistic')
     def test_nan_policy_omit_raise(self, xp):
         x = xp.arange(10.)
         x = xpx.at(x)[9].set(xp.nan)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->


#### What does this implement/fix?
<!--Please explain your changes.-->
This PR updates `scipy.stats.rankdata` to no longer use `xp.repeat` in order to bypass `cupy.repeat` not accepting array arguments for the number of repeats (https://github.com/cupy/cupy/issues/3849). 

This PR replaces the line

```python
ranks = xp.reshape(xp.repeat(ranks, counts), shape)
```

with

```python
ranks = xp.reshape(
        ranks[xp.cumulative_sum(xp.astype(xp.reshape(i, (-1,)), xp.int64)) - 1],
        shape,
    )
```

The core idea is that given an array of ranks

$$\left[1, 2.5, 4, 5, 6.5\right]$$

rather than using the counts

$$\left[1, 2, 1, 1, 2\right]$$

along with repeat to generate the desired array

$$\left[1, 2.5, 2.5, 4, 5, 6.5, 6.5\right]$$

we can take advantage of the fact that we also have a boolean mask `i` specifying the indices of unique elements.

$$\left[\mathrm{True}, \mathrm{True}, \mathrm{False}, \mathrm{True}, \mathrm{True}, \mathrm{True}, \mathrm{False}\right]$$

take the cumulative sum, treating elements as integers to get

$$\left[1, 2, 2, 3, 4, 5, 5\right]$$

and then subtract one from each entry to get indices that can be used to replicate the result of `repeat` through fancy indexing.

$$\left[0, 1, 1, 2, 3, 4, 4\right]$$


#### Additional information
<!--Any additional information you think is important.-->
This adds a small amount of overhead that is essentially negligible due to runtime being dominated by the call to `xp.argsort`.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
Google Gemini Pro came up with the following implementation given context explaining the general strategy

```python
# Flatten the boolean mask of unique elements
    i_flat = xp.reshape(i, (-1,))
    
    # Cumulative sum creates a mapping from the flat index to the unique group index.
    # We subtract 1 so it matches 0-based indexing for the `ranks` array.
    group_indices = xp.cumulative_sum(xp.astype(i_flat, xp.int64)) - 1
    
    # Index the 1D ranks array and reshape it back to the original shape
    ranks = xp.reshape(ranks[group_indices], shape)
```

I updated this to do everything in one line to avoid creating intermediate arrays and got rid of the CS 101 style comments. From there I carefully verified that this actually works. The general idea is simple, but why it works in the multidimensional case wasn't immediately clear to me.


I'd forgotten that, if `x` is a multidimensional array and `i` a multidimensional boolean mask, then `x[i]` will be flat, ordered according to C-contiguity. Later, by flattening `i` with `xp.reshape(i, (-1))` and taking the cumsum and subtracting, we get the correct indices into the flat array `x[i]`. 

Taking a simplified version of the functions execution path


```python
 
     ranks = ordinal_ranks[i]
     ranks = xp.reshape(
        ranks[xp.cumulative_sum(xp.astype(xp.reshape(i, (-1,)), xp.int64)) - 1],
        shape,
    )
```

`ordinal_ranks` contains increasing ranks along the last axis. `ordinal_ranks[i]` maps it into a flat array of ordinal ranks of unique values, that is not strictly increasing, but "wraps around" as each vector along the last axis is crossed.

` ranks[xp.cumulative_sum(xp.astype(xp.reshape(i, (-1,)), xp.int64)) - 1]` will expand the flat array along the lines of the simple example I gave above, and then the `reshape` maps it back to the shape of `x`.

I think I could have come up with this on my own, but like to see what LLMs come up with to assess their capabilities.  The idea is simple enough that I don't think this could run afoul of any copyright issues.
