### PR TITLE
DOC: interpolate: small tweaks to the "extrapolate" section

### DIFF
--- a/doc/source/tutorial/interpolate/1D.rst
+++ b/doc/source/tutorial/interpolate/1D.rst
@@ -342,7 +342,7 @@ Out-of-bounds behavior
 ======================
 
 Several interpolators in :mod:`scipy.interpolate` share a common way to control the
-out-of-bouds behavior, including :class:`CubicSpline`, :class:`CubicHermiteSpline`,
+out-of-bounds behavior, including :class:`CubicSpline`, :class:`CubicHermiteSpline`,
 :class:`Akima1DInterpolator`, :class:`PchipInterpolator`, :class:`PPoly`,
 :class:`BPoly`, and :class:`BSpline`.
 
@@ -405,10 +405,10 @@ periodic interpolant:
 
 Note that using ``bc_type="periodic"`` (red curve) enforces equal derivatives at the
 boundaries of the interpolation interval (``x=0`` and ``x=4``), so that the resulting
-interpolant is smooth across the whole real line.
+interpolant extends smoothly as a periodic function.
 
-On the contrary, using ``extrapolate="periodic"`` together with the default value for ``bc_type`` (the green curve) does not pay any special attention to the boundaries, and
-simply "copies" the curve from the interpolation interval to the outside. See :ref:`tutorial-extrapolation-cubicspline-extend` for an additional discussion of how different ``bc_type`` values affect the interpolant.
+On the contrary, using ``extrapolate="periodic"`` together with the default value for ``bc_type`` (the green curve) does not enforce any boundary conditions, and simply extends the interpolant
++ periodically outside the data domain. See :ref:`tutorial-extrapolation-cubicspline-extend` for an additional discussion of how different ``bc_type`` values affect the interpolant.
 
 
 The ``extrapolate`` constructor argument

--- a/doc/source/tutorial/interpolate/1D.rst
+++ b/doc/source/tutorial/interpolate/1D.rst
@@ -341,10 +341,15 @@ means *not-a-number*, i.e. a result of an illegal mathematical operation
 Out-of-bounds behavior
 ======================
 
-Several interpolators in :mod:`scipy.interpolate` share a common ``extrapolate``
-argument, including :class:`CubicSpline`, :class:`CubicHermiteSpline`,
-:class:`Akima1DInterpolator`, :class:`PchipInterpolator`, :class:`PPoly`, and
-:class:`BPoly`.
+Several interpolators in :mod:`scipy.interpolate` share a common way to control the
+out-of-bouds behavior, including :class:`CubicSpline`, :class:`CubicHermiteSpline`,
+:class:`Akima1DInterpolator`, :class:`PchipInterpolator`, :class:`PPoly`,
+:class:`BPoly`, and :class:`BSpline`.
+
+There are two principal ingredients which affect the out-of-bounds behavior:
+``bc_type`` and ``extrapolate`` arguments. The former controls how the object
+is constructed, and the latter controls how it is evaluated.
+
 
 The ``bc_type`` parameter
 -------------------------
@@ -357,7 +362,7 @@ values of ``bc_type``, out-of-bounds behavior is controlled separately by the
 ``extrapolate`` argument described below.
 
 To illustrate, we compare several values of the ``extrapolate`` constructor argument
-for :class:`CubicSpline`, including ``bc_type="periodic"`` which produces a truly
+for :class:`CubicSpline`, including ``bc_type="periodic"`` which produces a smooth
 periodic interpolant:
 
 .. plot::
@@ -378,6 +383,7 @@ periodic interpolant:
     ):
         y_interp = CubicSpline(x, y, extrapolate=extrapolate)(x_eval)
         ax.plot(x_eval, y_interp, linestyle, label=f"extrapolate={extrapolate}")
+
     ax.plot(
         x_eval,
         CubicSpline(x, y, bc_type="periodic")(x_eval),
@@ -396,6 +402,15 @@ periodic interpolant:
     ax.set_title("CubicSpline")
     plt.show()
 
+
+Note that using ``bc_type="periodic"`` (red curve) enforces equal derivatives at the
+boundaries of the interpolation interval (``x=0`` and ``x=4``), so that the resulting
+interpolant is smooth across the whole real line.
+
+On the contrary, using ``extrapolate="periodic"`` together with the default value for ``bc_type`` (the green curve) does not pay any special attention to the boundaries, and
+simply "copies" the curve from the interpolation interval to the outside. See :ref:`tutorial-extrapolation-cubicspline-extend` for an additional discussion of how different ``bc_type`` values affect the interpolant.
+
+
 The ``extrapolate`` constructor argument
 ----------------------------------------
 
@@ -406,8 +421,9 @@ time, which sets the default out-of-bounds behavior for all subsequent evaluatio
 - ``extrapolate=False``: return ``NaN``;
 - ``extrapolate="periodic"`` (if supported): wrap the evaluation periodically.
 
-The default is ``True`` for most interpolators, except :class:`Akima1DInterpolator`
-which defaults to ``False``.
+The default is ``True`` for most interpolators, with two exceptions:
+:class:`Akima1DInterpolator` defaults to ``False``, and ``bc_type="periodic"``
+forces the default to ``extrapolate="periodic"``.
 
 To illustrate, we consider :class:`PchipInterpolator` with several values of the
 ``extrapolate`` constructor argument:

--- a/doc/source/tutorial/interpolate/1D.rst
+++ b/doc/source/tutorial/interpolate/1D.rst
@@ -112,139 +112,6 @@ data with an outlier:
     >>> plt.show()
 
 
-.. _tutorial-interpolate_out_of_bounds:
-
-Out-of-bounds behavior
-======================
-
-Several interpolators in :mod:`scipy.interpolate` share a common ``extrapolate``
-argument, including :class:`CubicSpline`, :class:`CubicHermiteSpline`,
-:class:`Akima1DInterpolator`, :class:`PchipInterpolator`, :class:`PPoly`, and
-:class:`BPoly`.
-
-The ``bc_type`` parameter
--------------------------
-
-For :class:`CubicSpline` and :func:`make_interp_spline`, the ``bc_type``
-construction-time argument controls the shape of the spline at its boundaries and
-therefore also affects extrapolation. When ``bc_type="periodic"``, periodic boundary
-conditions are enforced and the interpolant is smooth at the join point. For all other 
-values of ``bc_type``, out-of-bounds behavior is controlled separately by the 
-``extrapolate`` argument described below.
-
-To illustrate, we compare several values of the ``extrapolate`` constructor argument
-for :class:`CubicSpline`, including ``bc_type="periodic"`` which produces a truly
-periodic interpolant:
-
-.. plot::
-
-    import matplotlib.pyplot as plt
-    import numpy as np
-    from scipy.interpolate import CubicSpline
-
-    # data
-    x = np.array([0, 1, 2.5, 3, 4])
-    y = np.array([0.0, 1.0, 0.8, 1.2, 0.0])
-    # evaluation points
-    x_eval = np.linspace(-4, 8, 300)
-
-    fig, ax = plt.subplots(figsize=(8, 6))
-    for extrapolate, linestyle in zip(
-        [True, False, "periodic"], ["-", "--", ":"], strict=True
-    ):
-        y_interp = CubicSpline(x, y, extrapolate=extrapolate)(x_eval)
-        ax.plot(x_eval, y_interp, linestyle, label=f"extrapolate={extrapolate}")
-    ax.plot(
-        x_eval,
-        CubicSpline(x, y, bc_type="periodic")(x_eval),
-        "-.",
-        label="bc_type='periodic'",
-    )
-    ax.plot(x, y, "ko", label="data")
-    ax.axvline(x[0] - 4, color="k", alpha=0.2)
-    ax.axvline(x[0], color="k", alpha=0.2)
-    ax.axvline(x[-1], color="k", alpha=0.2)
-    ax.axvline(x[-1] + 4, color="k", alpha=0.2)
-    ax.set_ylim(-0.5, 1.5)
-    ax.legend(ncol=2, loc="lower left")
-    ax.set_xlabel("x")
-    ax.set_ylabel("f(x)")
-    ax.set_title("CubicSpline")
-    plt.show()
-
-The ``extrapolate`` constructor argument
-----------------------------------------
-
-All the interpolators listed above accept an ``extrapolate`` keyword at construction
-time, which sets the default out-of-bounds behavior for all subsequent evaluations:
-
-- ``extrapolate=True`` (default for most): evaluate the boundary polynomial pieces;
-- ``extrapolate=False``: return ``NaN``;
-- ``extrapolate="periodic"`` (if supported): wrap the evaluation periodically.
-
-The default is ``True`` for most interpolators, except :class:`Akima1DInterpolator`
-which defaults to ``False``.
-
-To illustrate, we consider :class:`PchipInterpolator` with several values of the
-``extrapolate`` constructor argument:
-
-.. plot::
-
-    import matplotlib.pyplot as plt
-    import numpy as np
-    from scipy.interpolate import PchipInterpolator
-
-    # data
-    x = np.array([0, 1, 2.5, 3, 4])
-    y = np.array([0.0, 1.0, 0.8, 1.2, 0.0])
-    # evaluation points
-    x_eval = np.linspace(-4, 8, 300)
-
-    fig, ax = plt.subplots(figsize=(8, 6))
-    for extrapolate, linestyle in zip(
-        [True, False, "periodic"], ["-", "--", ":"], strict=True
-    ):
-        y_interp = PchipInterpolator(x, y, extrapolate=extrapolate)(x_eval)
-        ax.plot(x_eval, y_interp, linestyle, label=f"extrapolate={extrapolate}")
-    ax.plot(x, y, "k.", markersize=8, label="data")
-    ax.axvline(x[0] - 4, color="k", alpha=0.2)
-    ax.axvline(x[0], color="k", alpha=0.2)
-    ax.axvline(x[-1], color="k", alpha=0.2)
-    ax.axvline(x[-1] + 4, color="k", alpha=0.2)
-    ax.set_ylim(-2.0, 2.5)
-    ax.legend(ncol=2, loc="lower left")
-    ax.set_xlabel("x")
-    ax.set_ylabel("f(x)")
-    ax.set_title("PchipInterpolator")
-    plt.show()
-
-Note that :class:`PchipInterpolator` has no ``bc_type`` argument, so there is
-no way to construct a truly periodic PCHIP interpolant. Using
-``extrapolate="periodic"`` only wraps evaluation at the domain boundaries
-and makes no guarantees about smoothness at the join point, as visible in
-the plot above.
-
-Overriding ``extrapolate`` per call
------------------------------------
-
-The ``extrapolate`` argument can also be passed at evaluation time (i.e. when
-calling the interpolator object). Passing ``extrapolate=None`` (the default) means
-"use the value that was set at construction time." Passing any other value
-overrides the construction-time setting for that call only:
-
-    >>> from scipy.interpolate import CubicSpline
-    >>> import numpy as np
-    >>> spl = CubicSpline([0, 1, 2], [0, 1, 0], extrapolate=False)
-    >>> x_eval = np.array([-1, 0.5, 3])
-    >>> spl(x_eval)           # uses construction-time extrapolate=False
-    array([nan, 0.75, nan])
-    >>> spl(x_eval, extrapolate=True)   # override for this call
-    array([-3.,  0.75,  -3.])
-
-See :ref:`Extrapolation tips and tricks <tutorial-extrapolation>` for
-further details.
-
-
 .. _tutorial-interpolate_bsplines:
 
 Interpolation with B-splines
@@ -467,6 +334,139 @@ Individual routines may offer partial support, and/or workarounds, but in
 general, the library firmly adheres to the IEEE 754 semantics where a ``NaN``
 means *not-a-number*, i.e. a result of an illegal mathematical operation
 (e.g., division by zero), not *missing*.
+
+
+.. _tutorial-interpolate_out_of_bounds:
+
+Out-of-bounds behavior
+======================
+
+Several interpolators in :mod:`scipy.interpolate` share a common ``extrapolate``
+argument, including :class:`CubicSpline`, :class:`CubicHermiteSpline`,
+:class:`Akima1DInterpolator`, :class:`PchipInterpolator`, :class:`PPoly`, and
+:class:`BPoly`.
+
+The ``bc_type`` parameter
+-------------------------
+
+For :class:`CubicSpline` and :func:`make_interp_spline`, the ``bc_type``
+construction-time argument controls the shape of the spline at its boundaries and
+therefore also affects extrapolation. When ``bc_type="periodic"``, periodic boundary
+conditions are enforced and the interpolant is smooth at the join point. For all other 
+values of ``bc_type``, out-of-bounds behavior is controlled separately by the 
+``extrapolate`` argument described below.
+
+To illustrate, we compare several values of the ``extrapolate`` constructor argument
+for :class:`CubicSpline`, including ``bc_type="periodic"`` which produces a truly
+periodic interpolant:
+
+.. plot::
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from scipy.interpolate import CubicSpline
+
+    # data
+    x = np.array([0, 1, 2.5, 3, 4])
+    y = np.array([0.0, 1.0, 0.8, 1.2, 0.0])
+    # evaluation points
+    x_eval = np.linspace(-4, 8, 300)
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    for extrapolate, linestyle in zip(
+        [True, False, "periodic"], ["-", "--", ":"], strict=True
+    ):
+        y_interp = CubicSpline(x, y, extrapolate=extrapolate)(x_eval)
+        ax.plot(x_eval, y_interp, linestyle, label=f"extrapolate={extrapolate}")
+    ax.plot(
+        x_eval,
+        CubicSpline(x, y, bc_type="periodic")(x_eval),
+        "-.",
+        label="bc_type='periodic'",
+    )
+    ax.plot(x, y, "ko", label="data")
+    ax.axvline(x[0] - 4, color="k", alpha=0.2)
+    ax.axvline(x[0], color="k", alpha=0.2)
+    ax.axvline(x[-1], color="k", alpha=0.2)
+    ax.axvline(x[-1] + 4, color="k", alpha=0.2)
+    ax.set_ylim(-0.5, 1.5)
+    ax.legend(ncol=2, loc="lower left")
+    ax.set_xlabel("x")
+    ax.set_ylabel("f(x)")
+    ax.set_title("CubicSpline")
+    plt.show()
+
+The ``extrapolate`` constructor argument
+----------------------------------------
+
+All the interpolators listed above accept an ``extrapolate`` keyword at construction
+time, which sets the default out-of-bounds behavior for all subsequent evaluations:
+
+- ``extrapolate=True`` (default for most): evaluate the boundary polynomial pieces;
+- ``extrapolate=False``: return ``NaN``;
+- ``extrapolate="periodic"`` (if supported): wrap the evaluation periodically.
+
+The default is ``True`` for most interpolators, except :class:`Akima1DInterpolator`
+which defaults to ``False``.
+
+To illustrate, we consider :class:`PchipInterpolator` with several values of the
+``extrapolate`` constructor argument:
+
+.. plot::
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from scipy.interpolate import PchipInterpolator
+
+    # data
+    x = np.array([0, 1, 2.5, 3, 4])
+    y = np.array([0.0, 1.0, 0.8, 1.2, 0.0])
+    # evaluation points
+    x_eval = np.linspace(-4, 8, 300)
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    for extrapolate, linestyle in zip(
+        [True, False, "periodic"], ["-", "--", ":"], strict=True
+    ):
+        y_interp = PchipInterpolator(x, y, extrapolate=extrapolate)(x_eval)
+        ax.plot(x_eval, y_interp, linestyle, label=f"extrapolate={extrapolate}")
+    ax.plot(x, y, "k.", markersize=8, label="data")
+    ax.axvline(x[0] - 4, color="k", alpha=0.2)
+    ax.axvline(x[0], color="k", alpha=0.2)
+    ax.axvline(x[-1], color="k", alpha=0.2)
+    ax.axvline(x[-1] + 4, color="k", alpha=0.2)
+    ax.set_ylim(-2.0, 2.5)
+    ax.legend(ncol=2, loc="lower left")
+    ax.set_xlabel("x")
+    ax.set_ylabel("f(x)")
+    ax.set_title("PchipInterpolator")
+    plt.show()
+
+Note that :class:`PchipInterpolator` has no ``bc_type`` argument, so there is
+no way to construct a truly periodic PCHIP interpolant. Using
+``extrapolate="periodic"`` only wraps evaluation at the domain boundaries
+and makes no guarantees about smoothness at the join point, as visible in
+the plot above.
+
+Overriding ``extrapolate`` per call
+-----------------------------------
+
+The ``extrapolate`` argument can also be passed at evaluation time (i.e. when
+calling the interpolator object). Passing ``extrapolate=None`` (the default) means
+"use the value that was set at construction time." Passing any other value
+overrides the construction-time setting for that call only:
+
+    >>> from scipy.interpolate import CubicSpline
+    >>> import numpy as np
+    >>> spl = CubicSpline([0, 1, 2], [0, 1, 0], extrapolate=False)
+    >>> x_eval = np.array([-1, 0.5, 3])
+    >>> spl(x_eval)           # uses construction-time extrapolate=False
+    array([nan, 0.75, nan])
+    >>> spl(x_eval, extrapolate=True)   # override for this call
+    array([-3.,  0.75,  -3.])
+
+See :ref:`Extrapolation tips and tricks <tutorial-extrapolation>` for
+further details.
 
 
 .. _tutorial-interpolate_interp1d:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

follow-up to https://github.com/scipy/scipy/pull/24643

#### What does this implement/fix?
<!--Please explain your changes.-->

Small tweaks to the new `extrapolate` section of the tutorial.
Two commits are best considered separately:
- the first commit simply moves the @fbourgey 's authored section to later in the 1D tutorial --- so that it the page first introduces various interpolators, and then goes into details;
- the second commit adds a couple of paragraphs to hopefully clarify the (rather confusing) differences between `bc_type` and `extrapolate`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai