### PR TITLE
BUG: special: fix leaked `py_SpecialFunctionWarning` in `sf_error_v`

### DIFF
--- a/scipy/special/sf_error.cc
+++ b/scipy/special/sf_error.cc
@@ -116,6 +116,7 @@ void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list
     } else {
         goto skip_warn;
     }
+    Py_DECREF(py_SpecialFunctionWarning);
 
 skip_warn:
     PyGILState_Release(save);


### PR DESCRIPTION
#### Reference issue

See gh-24927.

#### What does this implement/fix?

`sf_error_v` in `sf_error.cc` obtains a new reference to `SpecialFunctionWarning` (or `SpecialFunctionError`) via `PyObject_GetAttrString` but never calls `Py_DECREF` after passing it to `PyErr_WarnEx` / `PyErr_SetString`. Since neither API steals its argument, the reference count grows by one on every call.

This is not a memory leak in the usual sense: `SpecialFunctionWarning` and `SpecialFunctionError` are class objects that live for the lifetime of the process, so their inflated refcount doesn't cause heap growth. It just prevents their refcount from ever reaching zero and means every call does one extra refcount increment that is never balanced.

This adds `Py_DECREF(py_SpecialFunctionWarning)` after the warn/raise block. The early `goto skip_warn` paths correctly bypass the decref since `py_SpecialFunctionWarning` is either not yet set or NULL on those paths.

Reproducer (shows refcount growth directly):
```python
import sys, warnings
from scipy import special

print("Before:", sys.getrefcount(special.SpecialFunctionWarning))

special.seterr(domain="warn")
warnings.simplefilter("ignore")
for _ in range(1000):
    special.ndtri(2.0)

print("After:", sys.getrefcount(special.SpecialFunctionWarning))
# Before fix:
#   Before: 6
#   After:  1006   (1000 extra references from 1000 calls)
# After fix:
#   Before: 6
#   After:  6      (refcount balanced)
```

The same pattern applies to `SpecialFunctionError` when `domain="raise"` is set.

#### Additional information

Thanks to @nickodell for catching that the original description mischaracterized this as a memory leak: the `tracemalloc` numbers in the first reproducer were inflated by `warnings.catch_warnings(record=True)` holding onto warning instances in its list, which was unrelated to the actual bug. The fix itself is unchanged and still correct.

One-line fix. Originally found by [cext-review-toolkit](https://github.com/devdanzin/cext-review-toolkit).

#### AI Generation Disclosure

Claude Opus 4.6 was used to identify this bug during a systematic C extension analysis using the cext-review-toolkit plugin, write the reproducer script, and prepare this PR. The one-line fix was confirmed correct by human review.
