### PR TITLE
TYP: fix all (600+) mypy errors

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -484,7 +484,7 @@ def smoke_docs(*, parent_callback, pytest_args, **kwargs):
     help="Submodule whose tests to run (cluster, constants, ...)")
 @meson.build_dir_option
 @click.pass_context
-def refguide_check(ctx, build_dir=None, *args, **kwargs):
+def refguide_check(ctx, build_dir, *args, **kwargs):
     """🔧 Run refguide check."""
     click.secho(
             "Invoking `build` prior to running refguide-check:",
@@ -678,7 +678,7 @@ def lint(ctx, fix, diff_against, files, all, no_cython):
 @click.argument('extra_args', nargs=-1)
 @click.pass_context
 def check(ctx, xp_markers, installed_files, symbol_hiding, loaded_sharedlibs, no_build,
-          build_dir=None, extra_args=()):
+          build_dir, extra_args=()):
     """🔧  Run checks specific to the SciPy code base.
 
     Exactly one check can be run at once. Example:
@@ -872,7 +872,7 @@ def _dirty_git_working_dir():
 @meson.build_dir_option
 @click.pass_context
 def bench(ctx, tests, submodule, compare, verbose, quick,
-          commits, array_api_backend, build, build_dir=None, *args, **kwargs):
+          commits, array_api_backend, build, build_dir, *args, **kwargs):
     """🔧 Run benchmarks.
 
     \b

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -371,7 +371,7 @@ def working_dir(new_dir):
 @click.command(context_settings={"ignore_unknown_options": True})
 @meson.build_dir_option
 @click.pass_context
-def mypy(ctx, build_dir=None):
+def mypy(ctx, build_dir):
     """🦆 Run Mypy tests for SciPy
     """
     if is_editable_install():
@@ -392,7 +392,7 @@ def mypy(ctx, build_dir=None):
     except ImportError as e:
         raise RuntimeError(
             "Mypy not found. Please install it by running "
-            "pip install -r mypy_requirements.txt from the repo root"
+            "pip install -r requirements/dev.txt from the repo root"
         ) from e
 
     build_dir = os.path.abspath(build_dir)
@@ -412,6 +412,8 @@ def mypy(ctx, build_dir=None):
         ])
     print(report, end='')
     print(errors, end='', file=sys.stderr)
+    if status:
+        raise SystemExit(status)
 
 @spin.util.extend_command(test, doc="")
 def smoke_docs(*, parent_callback, pytest_args, **kwargs):

--- a/mypy.ini
+++ b/mypy.ini
@@ -213,12 +213,6 @@ ignore_missing_imports = True
 [mypy-scipy.spatial.transform._rotation_cy]
 ignore_missing_imports = True
 
-[mypy-scipy.spatial.transform._rigid_transform_cy]
-ignore_missing_imports = True
-
-[mypy-scipy.spatial.transform._rotation_cy]
-ignore_missing_imports = True
-
 [mypy-scipy.fft._duccfft.pyduccfft]
 ignore_missing_imports = True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,6 +6,10 @@ warn_redundant_casts = True
 warn_unused_ignores = False
 show_error_codes = True
 
+local_partial_types = True
+allow_redefinition_new = true
+
+
 #
 # Typing tests is low priority, but enabling type checking on the
 # untyped test functions is still high-value because it helps test the
@@ -113,7 +117,7 @@ ignore_missing_imports = True
 [mypy-scipy._lib._ccallback_c]
 ignore_missing_imports = True
 
-[mypy-scipy.cluster._hierarchy]
+[mypy-scipy.cluster.hierarchy._hierarchy]
 ignore_missing_imports = True
 
 [mypy-scipy.optimize._bglu_dense]
@@ -140,16 +144,22 @@ ignore_missing_imports = True
 [mypy-scipy.linalg.cython_blas]
 ignore_missing_imports = True
 
-[mypy-scipy.linalg._decomp_update]
+[mypy-scipy.linalg._batched_linalg]
 ignore_missing_imports = True
 
-[mypy-scipy.linalg._solve_toeplitz]
+[mypy-scipy.linalg._decomp_update]
 ignore_missing_imports = True
 
 [mypy-scipy.linalg._decomp_interpolative]
 ignore_missing_imports = True
 
 [mypy-scipy.linalg._matfuncs_schur_sqrtm]
+ignore_missing_imports = True
+
+[mypy-scipy.linalg._internal_matfuncs]
+ignore_missing_imports = True
+
+[mypy-scipy.linalg._solve_toeplitz]
 ignore_missing_imports = True
 
 [mypy-scipy.optimize._group_columns]
@@ -197,6 +207,18 @@ ignore_missing_imports = True
 [mypy-scipy.spatial.transform._rigid_transform]
 ignore_missing_imports = True
 
+[mypy-scipy.spatial.transform._rigid_transform_cy]
+ignore_missing_imports = True
+
+[mypy-scipy.spatial.transform._rotation_cy]
+ignore_missing_imports = True
+
+[mypy-scipy.spatial.transform._rigid_transform_cy]
+ignore_missing_imports = True
+
+[mypy-scipy.spatial.transform._rotation_cy]
+ignore_missing_imports = True
+
 [mypy-scipy.fft._duccfft.pyduccfft]
 ignore_missing_imports = True
 
@@ -225,6 +247,9 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-scipy.interpolate._rbfinterp_pythran]
+ignore_missing_imports = True
+
+[mypy-scipy.stats._ansari_swilk_statistics]
 ignore_missing_imports = True
 
 [mypy-scipy.stats._statlib]
@@ -761,5 +786,5 @@ ignore_errors = True
 [mypy-scipy._external.array_api_extra.*]
 ignore_errors = True
 
-[mypy-scipy._lib.pyprima.*]
+[mypy-scipy._external.pyprima.*]
 ignore_errors = True

--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -653,8 +653,8 @@ def concat_1d(xp: ModuleType | None, *arrays: Iterable[ArrayLike]) -> Array:
     """A replacement for `np.r_` as `xp.concat` does not accept python scalars
        or 0-D arrays.
     """
-    arys = [xpx.atleast_nd(xp.asarray(a), ndim=1, xp=xp) for a in arrays]
-    return xp.concat(arys)
+    arys = [xpx.atleast_nd(xp.asarray(a), ndim=1, xp=xp) for a in arrays]  # type:ignore[union-attr]
+    return xp.concat(arys)  # type:ignore[union-attr]
 
 
 ### MArray Helpers ###

--- a/scipy/_lib/_array_api_docs_tables.py
+++ b/scipy/_lib/_array_api_docs_tables.py
@@ -223,6 +223,9 @@ def make_flat_capabilities_table(
     if isinstance(modules, str):
         modules = [modules]
 
+    if capabilities_table is None:
+        capabilities_table = xp_capabilities_table
+
     output = []
 
     for module_name in modules:
@@ -236,7 +239,7 @@ def make_flat_capabilities_table(
             thing = getattr(module, name)
             if is_inherently_out_of_scope(thing):
                 continue
-            entry = xp_capabilities_table.get(thing, None)
+            entry = capabilities_table.get(thing, None)
             capabilities = _process_capabilities_table_entry(entry)[backend_type]
             row: dict[str, Any] = {"module": module_name}
             row.update({"function": name})

--- a/scipy/_lib/_array_api_docs_tables.py
+++ b/scipy/_lib/_array_api_docs_tables.py
@@ -188,7 +188,7 @@ def make_flat_capabilities_table(
         backend_type: str,
         /,
         *,
-        capabilities_table: list[str] | None = None,
+        capabilities_table: dict | None = None,
 ) -> list[dict[str, str | int]]:
     """Generate full table of array api capabilities across public functions.
 
@@ -200,7 +200,7 @@ def make_flat_capabilities_table(
 
     backend_type : {'cpu', 'gpu', 'jit', 'lazy'}
 
-    capabilities_table : Optional[list[str]]
+    capabilities_table : dict | None
         Table in the form of `scipy._lib._array_api.xp_capabilities_table`.
         If None, uses `scipy._lib._array_api.xp_capabilities_table`.
         Default: None.

--- a/scipy/_lib/_array_api_docs_tables.py
+++ b/scipy/_lib/_array_api_docs_tables.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from enum import auto, Enum
 from importlib import import_module
 from types import ModuleType
+from typing import Any
 
 from scipy._lib._array_api import xp_capabilities_table
 from scipy._lib._array_api import _make_sphinx_capabilities
@@ -80,12 +81,14 @@ class BackendSupportStatus(Enum):
     UNKNOWN = auto()
 
 
-def _process_capabilities_table_entry(entry: dict | None) -> dict[str, dict[str, bool]]:
+def _process_capabilities_table_entry(
+    entry: dict | None
+) -> dict[str, dict[str, BackendSupportStatus]]:
     """Returns dict showing alternative backend support in easy to consume form.
 
     Parameters
     ----------
-    entry : Optional[dict]
+    entry : dict | None
        A dict with the structure of the values of the dict
        scipy._lib._array_api.xp_capabilities_table. If None, it is
        assumped that no alternative backends are supported.
@@ -160,7 +163,7 @@ def _process_capabilities_table_entry(entry: dict | None) -> dict[str, dict[str,
             output["jit"]["jax"] = entry["jax_jit"] and output["cpu"]["jax"]
         if backend == "dask.array":
             support_lazy = not entry["allow_dask_compute"] and output["dask"]
-            output["lazy"]["dask"] = support_lazy
+            output["lazy"]["dask"] = bool(support_lazy)
     return {
         outer_key: {
             inner_key: S.YES if inner_value else S.NO
@@ -186,7 +189,7 @@ def make_flat_capabilities_table(
         /,
         *,
         capabilities_table: list[str] | None = None,
-) -> list[dict[str, str]]:
+) -> list[dict[str, str | int]]:
     """Generate full table of array api capabilities across public functions.
 
     Parameters
@@ -220,9 +223,6 @@ def make_flat_capabilities_table(
     if isinstance(modules, str):
         modules = [modules]
 
-    if capabilities_table is None:
-        capabilities_table = xp_capabilities_table
-
     output = []
 
     for module_name in modules:
@@ -238,7 +238,7 @@ def make_flat_capabilities_table(
                 continue
             entry = xp_capabilities_table.get(thing, None)
             capabilities = _process_capabilities_table_entry(entry)[backend_type]
-            row = {"module": module_name}
+            row: dict[str, Any] = {"module": module_name}
             row.update({"function": name})
             row.update(capabilities)
             output.append(row)
@@ -247,7 +247,7 @@ def make_flat_capabilities_table(
 
 def calculate_table_statistics(
     flat_table: list[dict[str, str]]
-) -> dict[str, dict[str, str]]:
+) -> dict[str, dict[str, int]]:
     """Get counts of what is supported per module.
 
     Parameters
@@ -257,7 +257,7 @@ def calculate_table_statistics(
 
     Returns
     -------
-    dict[str, dict[str, str]]
+    dict[str, dict[str, int]]
         dict mapping module names to inner dicts.
         bool. The inner dicts have a key "total" along with keys for each
         backend column of the supplied flat capabilities table. The value
@@ -266,8 +266,9 @@ def calculate_table_statistics(
         functions that support that particular backend.
     """
     if not flat_table:
-        return []
+        return {}
 
+    counter: defaultdict[str, defaultdict[str, int]]
     counter = defaultdict(lambda: defaultdict(int))
 
     S = BackendSupportStatus
@@ -289,4 +290,4 @@ def calculate_table_statistics(
                 # set up to return information needed to put asterisks next
                 # to percentages impacted by missing xp_capabilities decorators.
                 current_counter[key] += 1 if value == S.YES else 0
-    return dict(counter)
+    return {mod: dict(counts) for mod, counts in counter.items()}

--- a/scipy/_lib/_array_api_override.py
+++ b/scipy/_lib/_array_api_override.py
@@ -116,7 +116,7 @@ def array_namespace(*arrays: Array, sparse_ok=False) -> ModuleType:
     api_arrays = []
 
     for array in arrays:
-        arr_info = _validate_array_cls(type(array), sparse_ok=sparse_ok)
+        arr_info = _validate_array_cls(type(array), sparse_ok=sparse_ok)  # type:ignore[arg-type]
         if arr_info is _ArrayClsInfo.skip:
             pass
 

--- a/scipy/_lib/tests/test_xp_capabilities.py
+++ b/scipy/_lib/tests/test_xp_capabilities.py
@@ -5,7 +5,7 @@ from scipy._lib._array_api import (
     array_namespace, make_xp_pytest_param, xp_assert_close, xp_capabilities
 )
 
-local_capabilities_table = {}
+local_capabilities_table = {}  # type:ignore[var-annotated]
 
 # B is a child of A which inherits the method g which is array-agnostic
 # so long as the method f is supported. A.f does not support the JAX jit but

--- a/scipy/cluster/hierarchy/_hierarchy_impl.py
+++ b/scipy/cluster/hierarchy/_hierarchy_impl.py
@@ -40,7 +40,7 @@ import bisect
 from collections import deque
 
 import numpy as np
-from . import _hierarchy, _optimal_leaf_ordering
+from . import _hierarchy, _optimal_leaf_ordering  # type:ignore[attr-defined]
 import scipy.spatial.distance as distance
 from scipy._lib._array_api import (_asarray, array_namespace, is_dask,
                                    is_lazy_array, xp_capabilities, xp_copy)
@@ -2933,13 +2933,13 @@ def _plot_dendrogram(icoords, dcoords, ivl, p, n, mh, orientation,
         Ellipse = matplotlib.patches.Ellipse
         for (x, y) in contraction_marks:
             if orientation in ('left', 'right'):
-                e = Ellipse((y, x), width=dvw / 100, height=1.0)
+                ell = Ellipse((y, x), width=dvw / 100, height=1.0)
             else:
-                e = Ellipse((x, y), width=1.0, height=dvw / 100)
-            ax.add_artist(e)
-            e.set_clip_box(ax.bbox)
-            e.set_alpha(0.5)
-            e.set_facecolor('k')
+                ell = Ellipse((x, y), width=1.0, height=dvw / 100)
+            ax.add_artist(ell)
+            ell.set_clip_box(ax.bbox)
+            ell.set_alpha(0.5)
+            ell.set_facecolor('k')
 
     if trigger_redraw:
         matplotlib.pylab.draw_if_interactive()

--- a/scipy/cluster/vq/_vq_impl.py
+++ b/scipy/cluster/vq/_vq_impl.py
@@ -9,7 +9,7 @@ from scipy._lib.deprecation import _deprecated
 from scipy._external import array_api_extra as xpx
 from scipy.spatial.distance import cdist
 
-from . import _vq
+from . import _vq  # type:ignore[attr-defined]
 
 __all__ = ['ClusterError', 'kmeans', 'kmeans2', 'py_vq', 'vq', 'whiten']
 

--- a/scipy/datasets/_fetchers.py
+++ b/scipy/datasets/_fetchers.py
@@ -11,11 +11,11 @@ except ImportError:
     pooch = None
     data_fetcher = None
 else:
-    data_fetcher = pooch.create(
+    data_fetcher = pooch.create(  # type:ignore[union-attr]
         # Use the default cache folder for the operating system
         # Pooch uses appdirs (https://github.com/ActiveState/appdirs) to
         # select an appropriate directory for the cache on each platform.
-        path=pooch.os_cache("scipy-data"),
+        path=pooch.os_cache("scipy-data"),  # type:ignore[union-attr]
 
         # The remote data is on Github
         # base_url is a required param, even though we override this

--- a/scipy/integrate/_ivp/base.py
+++ b/scipy/integrate/_ivp/base.py
@@ -130,7 +130,7 @@ class OdeSolver:
     TOO_SMALL_STEP = "Required step size is less than spacing between numbers."
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, fun, t0, y0, t_bound, vectorized,
                  support_complex=False):
@@ -255,7 +255,7 @@ class DenseOutput:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, t_old, t):
         self.t_old = t_old

--- a/scipy/integrate/_ode.py
+++ b/scipy/integrate/_ode.py
@@ -331,7 +331,7 @@ class ode:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(types.GenericAlias)
+    __class_getitem__: classmethod = classmethod(types.GenericAlias)
 
     def __init__(self, f, jac=None):
         self.stiff = 0
@@ -775,7 +775,7 @@ class IntegratorBase:
     scalar = float
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(types.GenericAlias)
+    __class_getitem__: classmethod = classmethod(types.GenericAlias)
 
     def acquire_new_handle(self):
         # Some of the integrators have internal state (ancient
@@ -1031,7 +1031,7 @@ class zvode(vode):
     supports_step = 1
     scalar = complex
 
-    __class_getitem__ = None
+    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1122,7 +1122,7 @@ class dopri5(IntegratorBase):
                 -4: 'problem is probably stiff (interrupted)',
                 }
 
-    __class_getitem__ = None
+    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self,
                  rtol=1e-6, atol=1e-12,
@@ -1250,7 +1250,7 @@ class lsoda(IntegratorBase):
         -7: "Internal workspace insufficient to finish (internal error)."
     }
 
-    __class_getitem__ = None
+    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self,
                  with_jacobian=False,

--- a/scipy/interpolate/_bary_rational.py
+++ b/scipy/interpolate/_bary_rational.py
@@ -38,7 +38,7 @@ class _BarycentricRational:
     """Base class for barycentric representation of a rational function."""
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, x, y, axis=0, **kwargs):
         self._axis = axis

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -606,7 +606,7 @@ class BSpline:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
 
     def __init__(self, t, c, k, extrapolate=True, axis=0):

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -263,7 +263,7 @@ class PchipInterpolator(CubicHermiteSpline):
     """
 
     # PchipInterpolator is not generic in scipy-stubs
-    __class_getitem__ = None
+    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self, x, y, axis=0, extrapolate=None):
         xp = array_namespace(x, y)
@@ -525,7 +525,7 @@ class Akima1DInterpolator(CubicHermiteSpline):
     """
 
     # PchipInterpolator is not generic in scipy-stubs
-    __class_getitem__ = None
+    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self, x, y, axis=0, *, method: Literal["akima", "makima"]="akima",
                  extrapolate:bool | None = None):

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -25,7 +25,7 @@ from numpy import zeros, concatenate, ravel, diff, array
 import numpy as np
 
 from . import _fitpack_impl
-from . import _fitpack
+from . import _fitpack  # type:ignore[attr-defined]
 from scipy._lib._array_api import xp_capabilities
 
 

--- a/scipy/interpolate/_interpnd.pyx
+++ b/scipy/interpolate/_interpnd.pyx
@@ -57,7 +57,7 @@ class NDInterpolatorBase:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, points, values, fill_value=np.nan, ndim=None,
                  rescale=False, need_contiguous=True, need_values=True):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -607,7 +607,7 @@ class _PPolyBase:
     __slots__ = ('_c', '_x', 'extrapolate', 'axis', '_asarray')
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, c, x, extrapolate=None, axis=0):
         self._asarray  = array_namespace(c, x).asarray

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -86,7 +86,7 @@ class NdBSpline:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, t, c, k, *, extrapolate=None):
         self._k, self._indices_k1d, (self._t, self._len_t) = _preprocess_inputs(k, t)

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -54,7 +54,7 @@ class _Interpolator1D:
     __slots__ = ('_y_axis', '_y_extra_shape', 'dtype')
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, xi=None, yi=None, axis=None):
         self._y_axis = axis

--- a/scipy/interpolate/_rbfinterp.py
+++ b/scipy/interpolate/_rbfinterp.py
@@ -221,7 +221,7 @@ class RBFInterpolator:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, y, d,
                  neighbors=None,

--- a/scipy/interpolate/_rgi.py
+++ b/scipy/interpolate/_rgi.py
@@ -283,7 +283,7 @@ class RegularGridInterpolator:
     _ALL_METHODS = ["linear", "nearest"] + _SPLINE_METHODS
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, points, values, method="linear", bounds_error=True,
                  fill_value=np.nan, *, solver=None, solver_args=None):

--- a/scipy/io/_idl.py
+++ b/scipy/io/_idl.py
@@ -69,7 +69,7 @@ RECTYPE_DICT = {0: "START_MARKER",
                 20: "DESCRIPTION"}
 
 # Define a dictionary to contain structure definitions
-STRUCT_DICT = {}
+STRUCT_DICT: dict[str, dict] = {}
 
 
 def _align_32(f):

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -31,6 +31,7 @@ ndimage_to_numpy_mode = {
     'grid-constant': 'constant',
 }
 
+# mypy: disable-error-code=attr-defined
 
 class TestBoundaries:
 

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -22,6 +22,7 @@ from . import types
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
+# mypy: disable-error-code=attr-defined
 
 @skip_xp_backends(np_only=True, reason='test internal numpy-only helpers')
 @pytest.mark.uses_xp_capabilities(False, reason="private")

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -15,6 +15,7 @@ from . import types
 skip_xp_backends = pytest.mark.skip_xp_backends
 xfail_xp_backends = pytest.mark.xfail_xp_backends
 
+# mypy: disable-error-code=attr-defined
 
 class TestNdimageMorphology:
 

--- a/scipy/ndimage/tests/test_splines.py
+++ b/scipy/ndimage/tests/test_splines.py
@@ -56,7 +56,7 @@ def make_spline_knot_matrix(xp, n, order, mode='mirror'):
     return xp.asarray(matrix / knot_values_sum)
 
 
-@make_xp_test_case(ndimage.spline_filter1d)
+@make_xp_test_case(ndimage.spline_filter1d)  # type:ignore[attr-defined]
 @pytest.mark.parametrize('order', [0, 1, 2, 3, 4, 5])
 @pytest.mark.parametrize('mode', ['mirror', 'grid-wrap', 'reflect'])
 def test_spline_filter_vs_matrix_solution(order, mode, xp):
@@ -71,7 +71,7 @@ def test_spline_filter_vs_matrix_solution(order, mode, xp):
     assert_almost_equal(eye, spline_filter_axis_1 @ matrix.T)
 
 
-@make_xp_test_case(ndimage.spline_filter1d)
+@make_xp_test_case(ndimage.spline_filter1d)  # type:ignore[attr-defined]
 @xfail_xp_backends("cupy", reason="CuPy spline_filter1d has the same aliasing bug")
 @pytest.mark.parametrize('order', [2, 3, 4, 5])
 @pytest.mark.parametrize('n', [2, 3, 4, 5])

--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -289,7 +289,7 @@ class Bounds:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def _input_validation(self):
         try:
@@ -383,7 +383,7 @@ class PreparedConstraint:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, constraint, x0, sparse_jacobian=None,
                  finite_diff_bounds=(-np.inf, np.inf)):

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -428,7 +428,7 @@ class Jacobian:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, **kw):
         names = ["solve", "update", "matvec", "rmatvec", "rsolve",
@@ -487,7 +487,7 @@ class InverseJacobian:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, jacobian):
         self.jacobian = jacobian
@@ -605,7 +605,7 @@ def asjacobian(J):
 
 class GenericBroyden(Jacobian):
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def setup(self, x0, f0, func):
         Jacobian.setup(self, x0, f0, func)
@@ -644,7 +644,7 @@ class LowRankMatrix:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, alpha, n, dtype):
         self.alpha = alpha

--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -46,7 +46,7 @@ __all__ = ['lti', 'dlti', 'TransferFunction', 'ZerosPolesGain', 'StateSpace',
 
 class LinearTimeInvariant:
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __new__(cls, *system, **kwargs):
         """Create a new object, don't allow direct instances."""

--- a/scipy/signal/_polyutils.py
+++ b/scipy/signal/_polyutils.py
@@ -11,11 +11,7 @@ from scipy._lib._array_api import (
     xp_promote, xp_default_dtype, xp_size, xp_device, is_numpy
 )
 
-try:
-    from numpy.exceptions import RankWarning
-except ImportError:
-    # numpy 1.x
-    from numpy import RankWarning
+from numpy.exceptions import RankWarning
 
 
 def _sort_cmplx(arr, xp):

--- a/scipy/signal/_short_time_fft.py
+++ b/scipy/signal/_short_time_fft.py
@@ -426,7 +426,7 @@ class ShortTimeFFT:
         ('onesided', -1, 1.), np.ndarray([])
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, win: np.ndarray, hop: int, fs: float, *,
                  fft_mode: FFT_MODE_TYPE = 'onesided',

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -22,7 +22,7 @@ def lombscargle(
     y: npt.ArrayLike,
     freqs: npt.ArrayLike,
     *,
-    precenter: bool = _NoValue,
+    precenter: bool = _NoValue,  # type:ignore[assignment]
     normalize: bool | Literal["power", "normalize", "amplitude"] = False,
     weights: npt.NDArray | None = None,
     floating_mean: bool = False,
@@ -272,7 +272,7 @@ def lombscargle(
     freqs = freqs.reshape(1, -1)
     # column vectors
     x = x.reshape(-1, 1)
-    y = y.reshape(-1, 1)
+    y = y.reshape(-1, 1)  # type:ignore[union-attr]
     weights = weights.reshape(-1, 1)
 
     # store frequent intermediates
@@ -317,7 +317,7 @@ def lombscargle(
     # to prevent division by zero errors with a and b, as well as correcting for
     # numerical precision errors that lead to CC or SS being approximately -0.0,
     # make sure CC and SS are both > 0
-    epsneg = np.finfo(dtype=y.dtype).epsneg
+    epsneg = np.finfo(dtype=y.dtype).epsneg  # type:ignore[union-attr]
     CC[CC < epsneg] = epsneg
     SS[SS < epsneg] = epsneg
 

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -23,7 +23,7 @@ class TestBSplines:
     purposes. Others (at integer points) are compared to theoretical
     expressions (cf. Unser, Aldroubi, Eden, IEEE TSP 1993, Table 1)."""
 
-    @make_xp_test_case(signal.spline_filter)
+    @make_xp_test_case(signal.spline_filter)  # type:ignore[attr-defined]
     def test_spline_filter(self, xp):
         rng = np.random.RandomState(12457)
         # Test the type-error branch
@@ -74,7 +74,7 @@ class TestBSplines:
                         result_array_real)
 
     @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/issues/9758")
-    @make_xp_test_case(signal.spline_filter)
+    @make_xp_test_case(signal.spline_filter)  # type:ignore[attr-defined]
     def test_spline_filter_complex(self, xp):
         rng = np.random.RandomState(12457)
         data_array_complex = rng.rand(7, 7) + rng.rand(7, 7)*1j
@@ -117,7 +117,7 @@ class TestBSplines:
         xp_assert_close(signal.spline_filter(data_array_complex, 0),
                         result_array_complex, rtol=1e-6)
 
-    @make_xp_test_case(signal.gauss_spline)
+    @make_xp_test_case(signal.gauss_spline)  # type:ignore[attr-defined]
     def test_gauss_spline(self, xp):
         assert math.isclose(signal.gauss_spline(0, 0), 1.381976597885342)
 
@@ -126,7 +126,7 @@ class TestBSplines:
         )
 
     @skip_xp_backends(np_only=True, reason="deliberate: array-likes are accepted")
-    @make_xp_test_case(signal.gauss_spline)
+    @make_xp_test_case(signal.gauss_spline)  # type:ignore[attr-defined]
     def test_gauss_spline_list(self, xp):
         # regression test for gh-12152 (accept array_like)
         knots = [-1.0, 0.0, -1.0]
@@ -134,7 +134,7 @@ class TestBSplines:
                             np.asarray([0.15418033, 0.6909883, 0.15418033])
         )
 
-    @make_xp_test_case(signal.cspline1d)
+    @make_xp_test_case(signal.cspline1d)  # type:ignore[attr-defined]
     def test_cspline1d(self, xp):
         xp_assert_equal(signal.cspline1d(xp.asarray([0])),
                         xp.asarray([0.], dtype=xp.float64))
@@ -146,7 +146,7 @@ class TestBSplines:
                            5.21051638], dtype=xp.float64)
         xp_assert_close(signal.cspline1d(xp.asarray([1., 2, 3, 4, 5])), c1d0)
 
-    @make_xp_test_case(signal.qspline1d)
+    @make_xp_test_case(signal.qspline1d)  # type:ignore[attr-defined]
     def test_qspline1d(self, xp):
         xp_assert_equal(signal.qspline1d(xp.asarray([0])),
                         xp.asarray([0.], dtype=xp.float64))
@@ -160,7 +160,7 @@ class TestBSplines:
         )
 
     @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/9484")
-    @make_xp_test_case(signal.cspline1d_eval)
+    @make_xp_test_case(signal.cspline1d_eval)  # type:ignore[attr-defined]
     def test_cspline1d_eval(self, xp):
         r = signal.cspline1d_eval(xp.asarray([0., 0], dtype=xp.float64),
                                xp.asarray([0.], dtype=xp.float64))
@@ -169,9 +169,9 @@ class TestBSplines:
         r = signal.cspline1d_eval(xp.asarray([1., 0, 1], dtype=xp.float64),
                                xp.asarray([], dtype=xp.float64))
         xp_assert_equal(r, xp.asarray([], dtype=xp.float64))
-        
+
         # Test case for newx that gets filtered down to empty
-        r = signal.cspline1d_eval(xp.asarray([1.0, 0, 1], dtype=xp.float64), 
+        r = signal.cspline1d_eval(xp.asarray([1.0, 0, 1], dtype=xp.float64),
                                   xp.asarray([-1.0], dtype=xp.float64))
         xp_assert_close(r, xp.asarray([0.33333333], dtype=xp.float64))
 
@@ -197,11 +197,11 @@ class TestBSplines:
 
         with pytest.raises(ValueError,
                             match="Spline coefficients 'cj' must not be empty."):
-            signal.cspline1d_eval(xp.asarray([], dtype=xp.float64), 
+            signal.cspline1d_eval(xp.asarray([], dtype=xp.float64),
                                   xp.asarray([0.0], dtype=xp.float64))
 
     @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/9484")
-    @make_xp_test_case(signal.qspline1d_eval)
+    @make_xp_test_case(signal.qspline1d_eval)  # type:ignore[attr-defined]
     def test_qspline1d_eval(self, xp):
         xp_assert_close(signal.qspline1d_eval(xp.asarray([0., 0]), xp.asarray([0.])),
                         xp.asarray([0.])
@@ -211,10 +211,10 @@ class TestBSplines:
         )
 
         # Test case for newx that gets filtered down to empty
-        r = signal.qspline1d_eval(xp.asarray([1.0, 0, 1], dtype=xp.float64), 
+        r = signal.qspline1d_eval(xp.asarray([1.0, 0, 1], dtype=xp.float64),
                                   xp.asarray([-1.0], dtype=xp.float64))
         xp_assert_equal(r, xp.asarray([0.25], dtype=xp.float64))
-        
+
         x = [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6]
         dx = x[1] - x[0]
         newx = [-6., -5.5, -5., -4.5, -4., -3.5, -3., -2.5, -2., -1.5, -1.,
@@ -236,9 +236,9 @@ class TestBSplines:
         )
         xp_assert_close(r, newy)
 
-        with pytest.raises(ValueError, 
+        with pytest.raises(ValueError,
                            match="Spline coefficients 'cj' must not be empty."):
-            signal.qspline1d_eval(xp.asarray([], dtype=xp.float64), 
+            signal.qspline1d_eval(xp.asarray([], dtype=xp.float64),
                                   xp.asarray([0.0], dtype=xp.float64))
 
 
@@ -248,7 +248,7 @@ sepfir_dtype_map = {np.uint8: np.float32, int: np.float64,
                     np.complex64: np.complex64, complex: complex}
 
 
-@make_xp_test_case(signal.sepfir2d)
+@make_xp_test_case(signal.sepfir2d)  # type:ignore[attr-defined]
 class TestSepfir2d:
     def test_sepfir2d_invalid_filter(self, xp):
         filt = xp.asarray([1.0, 2.0, 4.0, 2.0, 1.0])
@@ -374,7 +374,7 @@ class TestSepfir2d:
         assert result.dtype == sepfir_dtype_map[dtyp]
 
 
-@make_xp_test_case(signal.cspline2d)
+@make_xp_test_case(signal.cspline2d)  # type:ignore[attr-defined]
 def test_cspline2d(xp):
     rng = np.random.RandomState(181819142)
     image = rng.rand(71, 73)
@@ -383,7 +383,7 @@ def test_cspline2d(xp):
     assert array_namespace(result) == xp
 
 
-@make_xp_test_case(signal.qspline2d)
+@make_xp_test_case(signal.qspline2d)  # type:ignore[attr-defined]
 def test_qspline2d(xp):
     rng = np.random.RandomState(181819143)
     image = rng.rand(71, 73)

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -7,7 +7,7 @@ from scipy._lib._array_api import (
 )
 
 import scipy.signal._waveforms as waveforms
-from scipy.signal import square, sawtooth
+from scipy.signal import square, sawtooth  # type:ignore[attr-defined]
 
 
 # These chirp_* functions are the instantaneous frequencies of the signals

--- a/scipy/signal/tests/test_whittaker.py
+++ b/scipy/signal/tests/test_whittaker.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
-from scipy.signal import whittaker_henderson
+from scipy.signal import whittaker_henderson  # type: ignore[attr-defined]
 from scipy.signal._whittaker import (
     _logdet_difference_matrix, _polynomial_fit, _reml, _solveh_banded, _solve_WH_banded,
 )

--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -197,7 +197,7 @@ class LinearOperator:
     __array_ufunc__ = None
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(types.GenericAlias)
+    __class_getitem__: classmethod = classmethod(types.GenericAlias)
 
     ndim: int
 

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -510,7 +510,7 @@ class TestDotTests:
 
         shape = batch_shape + args.shape
         dtype = getattr(xp, args.op_dtype)
-        op = interface.LinearOperator(
+        op = interface.LinearOperator(  # type:ignore[call-arg]
             shape=shape, dtype=dtype,
             matvec=identity, rmatvec=identity, xp=xp,
         )
@@ -560,7 +560,7 @@ class TestDotTests:
 
         shape = batch_shape + args.shape
         dtype = getattr(xp, args.op_dtype)
-        op = interface.LinearOperator(
+        op = interface.LinearOperator(  # type:ignore[call-arg]
             shape=shape, dtype=dtype, matvec=mv, rmatvec=rmv, xp=xp
         )
         
@@ -586,7 +586,7 @@ class TestDotTests:
 
         shape = batch_shape + args.shape
         dtype = getattr(xp, args.op_dtype)
-        op = interface.LinearOperator(
+        op = interface.LinearOperator(  # type:ignore[call-arg]
             shape=shape, dtype=dtype, matvec=scale, rmatvec=r_scale, xp=xp
         )
         self.check_matvec(xp, op, data_dtype=args.data_dtype, complex_data=args.complex)

--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -426,7 +426,7 @@ class RigidTransform:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, matrix: ArrayLike, normalize: bool = True, copy: bool = True):
         """Initialize from a 4x4 transformation matrix.
@@ -1025,7 +1025,7 @@ class RigidTransform:
         if not all(isinstance(x, RigidTransform) for x in transforms):
             raise TypeError("input must contain RigidTransform objects only")
 
-        xp = array_namespace(transforms[0].as_matrix())
+        xp = array_namespace(transforms[0].as_matrix())  # type:ignore[index]
         matrix = xp.concat(
             [xpx.atleast_nd(x.as_matrix(), ndim=3, xp=xp) for x in transforms]
         )
@@ -1397,9 +1397,9 @@ class RigidTransform:
         # https://github.com/data-apis/array-api/pull/900#issuecomment-2674432480)
         # Ideally we would converge to [indexer, ...] indexing, but this is not
         # supported for now.
-        if is_array and indexer.dtype == xp.bool:
+        if is_array and indexer.dtype == xp.bool:  # type:ignore[union-attr]
             return RigidTransform(self._matrix[indexer], normalize=False)
-        if is_array and xp.isdtype(indexer.dtype, "integral"):
+        if is_array and xp.isdtype(indexer.dtype, "integral"):  # type:ignore[union-attr]
             if self._matrix.shape[0] == 0:
                 raise IndexError("cannot take from an empty array")
             return RigidTransform(
@@ -1570,8 +1570,7 @@ class RigidTransform:
             The composed transform.
         """
         if isinstance(other, Rotation):
-            other = RigidTransform.from_rotation(other)
-            return other * self
+            return RigidTransform.from_rotation(other) * self
         # When other is a RigidTransform __mul__ is called, so we don't handle it here
         return NotImplemented
 

--- a/scipy/spatial/transform/_rigid_transform_xp.py
+++ b/scipy/spatial/transform/_rigid_transform_xp.py
@@ -211,7 +211,7 @@ def apply(matrix: Array, vector: Array, inverse: bool = False) -> Array:
     # would raise heterogeneous error types and messages for different frameworks.
     # However, the error only mimics numpy's error message and does not provide the
     # same amount of context.
-    if not broadcastable(matrix.shape, vec.shape):
+    if not broadcastable(matrix.shape, vec.shape):  # type:ignore[arg-type]
         raise ValueError("operands could not be broadcast together")
     return (matrix @ vec)[..., :3, 0]
 
@@ -222,9 +222,9 @@ def pow(matrix: Array, n: float | Array) -> Array:
     # If n is an array, we sanitize it to a scalar and promote quat and n to
     # the same dtype.
     if is_array_api_obj(n):
-        if n.shape == (1,):
-            n = n[0]
-        elif n.ndim != 0:
+        if n.shape == (1,):  # type:ignore[union-attr]
+            n = n[0]  # type:ignore[index]
+        elif n.ndim != 0:  # type:ignore[union-attr]
             raise ValueError("Array exponent must be a scalar")
         matrix, n = xp_promote(matrix, n, force_floating=True, xp=xp)
 
@@ -281,14 +281,14 @@ def mean(
     if weights is None:
         quats_mean = quat_mean(quats, axis=axis)
     else:
-        neg_weights = weights < 0
+        neg_weights = weights < 0  # type:ignore[operator]
         any_neg_weights = xp.any(neg_weights)
         if not lazy and any_neg_weights:
             raise ValueError("`weights` must be non-negative.")
-        if weights.shape != matrix.shape[:-2]:
+        if weights.shape != matrix.shape[:-2]:  # type:ignore[union-attr]
             raise ValueError(
                 f"Expected `weights` to match transform shape, got shape "
-                f"{weights.shape} for {matrix.shape[:-2]} transformations."
+                f"{weights.shape} for {matrix.shape[:-2]} transformations."  # type:ignore[union-attr]
             )
         quats_mean = quat_mean(quats, weights=weights, axis=axis)
     r_mean = quat_as_matrix(quats_mean)
@@ -297,8 +297,8 @@ def mean(
     if weights is None:
         t_mean = xp.mean(t, axis=axis)
     else:
-        norm = xp.sum(weights[..., None], axis=axis)
-        wsum = xp.sum(t * weights[..., None], axis=axis)
+        norm = xp.sum(weights[..., None], axis=axis)  # type:ignore[index]
+        wsum = xp.sum(t * weights[..., None], axis=axis)  # type:ignore[index]
         t_mean = wsum / norm
 
     tf = _create_transformation_matrix(t_mean, r_mean)
@@ -318,9 +318,9 @@ def setitem(
     xp = array_namespace(matrix)
     if isinstance(indexer, EllipsisType):
         return xpx.at(matrix)[indexer].set(value)
-    if is_array_api_obj(indexer) and indexer.dtype == xp.bool:
-        return xpx.at(matrix)[indexer].set(value)
-    return xpx.at(matrix)[indexer, ...].set(value)
+    if is_array_api_obj(indexer) and indexer.dtype == xp.bool:  # type:ignore[union-attr]
+        return xpx.at(matrix)[indexer].set(value)  # type:ignore[index]
+    return xpx.at(matrix)[indexer, ...].set(value)  # type:ignore[index]
 
 
 def normalize_dual_quaternion(dual_quat: Array) -> Array:

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterator, Sequence
 from types import EllipsisType, GenericAlias, ModuleType, NotImplementedType
 
 import numpy as np
@@ -37,7 +37,7 @@ def select_backend(xp: ModuleType, cython_compatible: bool):
     return backend_registry.get(xp, xp_backend)
 
 
-def _promote(*args: tuple[ArrayLike, ...], xp: ModuleType) -> Array:
+def _promote(*args: ArrayLike, xp: ModuleType) -> Array:
     """Promote arrays to float64 for numpy, else according to the Array API spec.
 
     The return array dtype follows the following rules:
@@ -403,7 +403,7 @@ class Rotation:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(
         self,
@@ -925,7 +925,7 @@ class Rotation:
         """  # noqa: E501
         xp = array_namespace(axes)
         axes, angles = _promote(axes, angles, xp=xp)
-        cython_compatible = axes.ndim < 3 and angles.ndim < 2
+        cython_compatible = axes.ndim < 3 and angles.ndim < 2  # type:ignore[union-attr]
         backend = select_backend(xp, cython_compatible=cython_compatible)
         quat = backend.from_davenport(axes, order, angles, degrees)
         return Rotation._from_raw_quat(quat, xp=xp, backend=backend)
@@ -1512,7 +1512,7 @@ class Rotation:
         return mrp
 
     @staticmethod
-    def concatenate(rotations: Rotation | Iterable[Rotation]) -> Rotation:
+    def concatenate(rotations: Rotation | Sequence[Rotation]) -> Rotation:
         """Concatenate a sequence of `Rotation` objects into a single object.
 
         This is useful if you want to, for example, take the mean of a set of
@@ -2145,7 +2145,7 @@ class Rotation:
         # to the follow-up PR that adds general Array API support for Rotations.
         return create_group(cls, group, axis=axis)
 
-    def __getitem__(self, indexer: int | slice | EllipsisType | None) -> Rotation:
+    def __getitem__(self, indexer: int | slice | EllipsisType | Array | None) -> Rotation:
         """Extract rotation(s) at given index(es) from object.
 
         Create a new `Rotation` instance containing a subset of rotations
@@ -2216,9 +2216,9 @@ class Rotation:
         # TODO: This special case handling is mainly a result of Array API limitations.
         # Ideally we would get rid of them altogether and converge to [indexer, ...]
         # indexing.
-        if is_array and indexer.dtype == self._xp.bool:
+        if is_array and indexer.dtype == self._xp.bool:  # type:ignore[union-attr]
             return Rotation(self._quat[indexer], normalize=False)
-        if is_array and self._xp.isdtype(indexer.dtype, "integral"):
+        if is_array and self._xp.isdtype(indexer.dtype, "integral"):  # type:ignore[union-attr]
             # xp.take is implementation-defined for zero-dim arrays, hence we raise
             # pre-emptively to have consistent behavior across frameworks.
             if self._quat.shape[0] == 0:
@@ -2566,7 +2566,7 @@ class Rotation:
         xp = array_namespace(a)
         a, b, weights = _promote(a, b, weights, xp=xp)
         cython_compatible = (
-            (a.ndim < 3) & (b.ndim < 3) & (weights is None or weights.ndim < 2)
+            (a.ndim < 3) & (b.ndim < 3) & (weights is None or weights.ndim < 2)  # type:ignore[union-attr]
         )
         backend = select_backend(xp, cython_compatible=cython_compatible)
         q, rssd, sensitivity = backend.align_vectors(a, b, weights, return_sensitivity)
@@ -2826,7 +2826,7 @@ class Slerp:
         # We cannot error out on invalid indices for jit compiled code. To not produce
         # an index error, we set the index to 0 in case it is out of bounds, and later
         # set the result to nan.
-        invalid_ind = (ind < 0) | (ind > len(self.rotations) - 1)
+        invalid_ind: Array = (ind < 0) | (ind > len(self.rotations) - 1)
         if is_lazy_array(invalid_ind):
             ind = xpx.at(ind, invalid_ind).set(0)
         elif xp.any(invalid_ind):

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -2145,7 +2145,9 @@ class Rotation:
         # to the follow-up PR that adds general Array API support for Rotations.
         return create_group(cls, group, axis=axis)
 
-    def __getitem__(self, indexer: int | slice | EllipsisType | Array | None) -> Rotation:
+    def __getitem__(
+        self, indexer: int | slice | EllipsisType | Array | None
+    ) -> Rotation:
         """Extract rotation(s) at given index(es) from object.
 
         Create a new `Rotation` instance containing a subset of rotations

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -26,6 +26,9 @@ from scipy._external.array_api_compat import device as xp_device
 from scipy._external.array_api_compat import is_array_api_obj
 import scipy._external.array_api_extra as xpx
 
+# mypy: disable-error-code=index
+# mypy: disable-error-code=operator
+# mypy: disable-error-code=union-attr
 
 def from_quat(
     quat: Array,
@@ -240,7 +243,7 @@ def from_davenport(
         raise ValueError("Axes must be vectors of length 3.")
 
     axes = xpx.atleast_nd(axes, ndim=2, xp=xp)
-    angles = xpx.atleast_nd(angles, ndim=1, xp=xp)
+    angles = xpx.atleast_nd(angles, ndim=1, xp=xp)  # type:ignore[arg-type]
     num_axes = axes.shape[-2]
     if num_axes < 1 or num_axes > 3:
         raise ValueError(f"Expected up to 3 axes, got {num_axes}")
@@ -267,7 +270,7 @@ def from_davenport(
         angles = _deg2rad(angles)
 
     if (
-        not broadcastable(axes.shape[:-1], angles.shape)
+        not broadcastable(axes.shape[:-1], angles.shape)  # type:ignore[arg-type]
         or axes.shape[-2] != angles.shape[-1]
     ):
         raise ValueError(

--- a/scipy/spatial/transform/_rotation_xp.py
+++ b/scipy/spatial/transform/_rotation_xp.py
@@ -225,7 +225,7 @@ def from_euler(seq: str, angles: Array, degrees: bool = False) -> Array:
 
 
 def from_davenport(
-    axes: Array, order: str, angles: Array | float, degrees: bool = False
+    axes: Array, order: str, angles: Array, degrees: bool = False
 ) -> Array:
     xp = array_namespace(axes)
     device = xp_device(axes)
@@ -243,7 +243,7 @@ def from_davenport(
         raise ValueError("Axes must be vectors of length 3.")
 
     axes = xpx.atleast_nd(axes, ndim=2, xp=xp)
-    angles = xpx.atleast_nd(angles, ndim=1, xp=xp)  # type:ignore[arg-type]
+    angles = xpx.atleast_nd(angles, ndim=1, xp=xp) 
     num_axes = axes.shape[-2]
     if num_axes < 1 or num_axes > 3:
         raise ValueError(f"Expected up to 3 axes, got {num_axes}")
@@ -270,7 +270,7 @@ def from_davenport(
         angles = _deg2rad(angles)
 
     if (
-        not broadcastable(axes.shape[:-1], angles.shape)  # type:ignore[arg-type]
+        not broadcastable(axes.shape[:-1], angles.shape)
         or axes.shape[-2] != angles.shape[-1]
     ):
         raise ValueError(

--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -15,6 +15,7 @@ from . import _basic
 from . import _spfun_stats
 from . import _ufuncs
 
+# mypy: disable-error-code=dict-item
 
 def _special_namespace_for(xp):
     spx = scipy_namespace_for(xp)
@@ -43,15 +44,15 @@ class _FuncInfo:
     # Should map backend names to alternative function names.
     alt_names_map: dict[str, str] | None = None
     # Some functions only take integer arrays for some arguments.
-    int_only: tuple[bool] | None = None
+    int_only: tuple[bool, ...] | None = None
     # For testing purposes, whether tests should only use positive values
     # for some arguments. If bool and equal to True, restrict to positive
     # values for all arguments. To restrict only some arguments to positive
     # values, pass a tuple of bool of the same length as the number of
     # arguments, the ith entry in the tuple controls positive_only for
     # the ith argument. To make backend specific choices for positive_only,
-    # pass in a dict mapping backend names to bool or tuple[bool].
-    positive_only: bool | tuple[bool] | dict[str, tuple[bool]] = False
+    # pass in a dict mapping backend names to bool or tuple[bool, ...].
+    positive_only: bool | tuple[bool, ...] | dict[str, tuple[bool, ...]] = False
     # Some special functions are not ufuncs and ufunc-specific tests
     # should not be applied to these.
     is_ufunc: bool = True
@@ -61,9 +62,9 @@ class _FuncInfo:
     # Python int.
     # Can also take a dict mapping backends to such tuples if an argument being
     # Python int only is backend specific.
-    python_int_only: dict[str, tuple[bool]] | tuple[bool] | None = None
+    python_int_only: dict[str, tuple[bool, ...]] | tuple[bool, ...] | None = None
     # Some functions which seem to be scalar also accept 0d arrays.
-    scalar_or_0d_only: dict[str, tuple[bool]] | tuple[bool] | None = None
+    scalar_or_0d_only: dict[str, tuple[bool, ...]] | tuple[bool, ...] | None = None
     # Some functions may not work well with very large integer valued arguments.
     test_large_ints: bool = True
     # Some non-ufunc special functions don't decay 0d arrays to scalar.
@@ -80,7 +81,7 @@ class _FuncInfo:
     # Place a backend in this tuple if `func` is available as `xp.func` but not
     # available in the `scipy.special` namespace for this backend.
     # One example is `jax.numpy.sinc` being available but not `jax.scipy.special.sinc`.
-    backends_with_func_in_xp: tuple[str] = ()
+    backends_with_func_in_xp: tuple[str, ...] = ()
 
     @property
     def name(self):
@@ -926,5 +927,5 @@ globals().update({nfo.func.__name__: nfo.wrapper for nfo in _special_funcs})
 # digamma is an alias for psi. Define here so it also has alternative backend
 # support. Add noqa because the linter gets confused by the sneaky way psi
 # is inserted into globals above.
-digamma = psi  # noqa: F821
+digamma = psi  # type:ignore[name-defined]  # noqa: F821
 __all__ = [nfo.func.__name__ for nfo in _special_funcs] + ["digamma"]

--- a/scipy/special/tests/test_spfun_stats.py
+++ b/scipy/special/tests/test_spfun_stats.py
@@ -3,7 +3,7 @@ from numpy.testing import (assert_array_equal, assert_array_almost_equal_nulp,
                            assert_allclose)
 from pytest import raises as assert_raises
 
-from scipy.special import gammaln, multigammaln
+from scipy.special import gammaln, multigammaln  # type:ignore[attr-defined]
 
 
 class TestMultiGammaLn:

--- a/scipy/special/tests/test_support_alternative_backends.py
+++ b/scipy/special/tests/test_support_alternative_backends.py
@@ -334,7 +334,7 @@ def test_repr(func):
 
 
 @pytest.mark.skipif(
-    version.parse(np.__version__) < version.parse("2.2"),
+    version.parse(np.__version__) < version.parse("2.2"),  # type:ignore[attr-defined]
     reason="Can't update ufunc __doc__ when SciPy is compiled vs. NumPy < 2.2")
 @pytest.mark.parametrize('func', [nfo.wrapper for nfo in _special_funcs])
 def test_doc(func):

--- a/scipy/stats/_censored_data.py
+++ b/scipy/stats/_censored_data.py
@@ -227,7 +227,7 @@ class CensoredData:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, uncensored=None, *, left=None, right=None,
                  interval=None):

--- a/scipy/stats/_covariance.py
+++ b/scipy/stats/_covariance.py
@@ -59,7 +59,7 @@ class Covariance:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self):
         message = ("The `Covariance` class cannot be instantiated directly. "
@@ -490,7 +490,7 @@ class Covariance:
 
 class CovViaPrecision(Covariance):
 
-    __class_getitem__ = None
+    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self, precision, covariance=None):
         precision = self._validate_matrix(precision, 'precision')
@@ -567,7 +567,7 @@ class CovViaDiagonal(Covariance):
 
 class CovViaCholesky(Covariance):
 
-    __class_getitem__ = None
+    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self, cholesky):
         L = self._validate_matrix(cholesky, 'cholesky')
@@ -593,7 +593,7 @@ class CovViaCholesky(Covariance):
 
 class CovViaEigendecomposition(Covariance):
 
-    __class_getitem__ = None
+    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self, eigendecomposition):
         eigenvalues, eigenvectors = eigendecomposition
@@ -654,7 +654,7 @@ class CovViaPSD(Covariance):
     Representation of a covariance provided via an instance of _PSD
     """
 
-    __class_getitem__ = None
+    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self, psd):
         self._LP = psd.U

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -507,7 +507,7 @@ def _sum_finite(x):
 class rv_frozen:
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(types.GenericAlias)
+    __class_getitem__: classmethod = classmethod(types.GenericAlias)
 
     def __init__(self, dist, *args, **kwds):
         self.args = args

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -176,7 +176,7 @@ class _Domain(ABC):
     symbols = {np.inf: r"\infty", -np.inf: r"-\infty", np.pi: r"\pi", -np.pi: r"-\pi"}
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     @abstractmethod
     def contains(self, x):
@@ -552,7 +552,7 @@ class _Parameter(ABC):
    """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, name, *, domain, symbol=None, typical=None):
         self.name = name

--- a/scipy/stats/_kde.py
+++ b/scipy/stats/_kde.py
@@ -210,7 +210,7 @@ class gaussian_kde:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, dataset, bw_method=None, weights=None):
         self.dataset = atleast_2d(asarray(dataset))

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -295,7 +295,7 @@ class multi_rv_frozen:
     """
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(types.GenericAlias)
+    __class_getitem__: classmethod = classmethod(types.GenericAlias)
 
     @property
     def random_state(self):

--- a/scipy/stats/_new_distributions.py
+++ b/scipy/stats/_new_distributions.py
@@ -223,7 +223,7 @@ class Logistic(ContinuousDistribution):
     """
     _x_support = _RealInterval(endpoints=(-inf, inf))
     _variable = _x_param = _RealParameter('x', domain=_x_support, typical=(-9, 9))
-    _parameterizations = ()
+    _parameterizations = ()   # type:ignore[assignment]
 
     _scale = np.pi / np.sqrt(3)
 

--- a/scipy/stats/_probability_distribution.py
+++ b/scipy/stats/_probability_distribution.py
@@ -6,7 +6,7 @@ from types import GenericAlias
 class _ProbabilityDistribution(ABC):
 
     # generic type compatibility with scipy-stubs
-    __class_getitem__ = classmethod(GenericAlias)
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     @abstractmethod
     def support(self):

--- a/scipy/stats/tests/test_marray.py
+++ b/scipy/stats/tests/test_marray.py
@@ -198,7 +198,7 @@ def test_ttests(f, alternative, axis, xp):
      make_xp_pytest_param(stats.kurtosistest, tuple()),
      make_xp_pytest_param(stats.normaltest, tuple()),
      make_xp_pytest_param(stats.jarque_bera, tuple()),
-     make_xp_pytest_param(stats.cramervonmises, (stats.norm.cdf,)),
+     make_xp_pytest_param(stats.cramervonmises, (stats.norm.cdf,)),  # type:ignore[attr-defined]
 ])
 @pytest.mark.parametrize('alternative', ['less', 'greater', 'two-sided'])
 @pytest.mark.parametrize('axis', [0, 1, None])


### PR DESCRIPTION
As I mentioned in https://github.com/scipy/scipy/pull/24922#issue-4159804559, `spin mypy` always exited with code 0, which caused CI to pass even though there were 600+ reported mypy errors.

This fixes the `spin mypy` exit code, as well as those 600+ mypy errors. 

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI; doing this myself was way too much fun :partying_face:.