### PR TITLE
BUG: fix VODE Jacobian transposition in dvode_jacobian_thunk (gh-24933)

### DIFF
--- a/scipy/integrate/_dzvodemodule.c
+++ b/scipy/integrate/_dzvodemodule.c
@@ -352,27 +352,9 @@ dvode_jacobian_thunk(int neq, double t, double* y, int ml, int mu,
         return;
     }
 
-    // Copy result to output array with proper layout handling
-
-    if ((current_dvode_callback->jac_type == 0) && PyArray_IS_C_CONTIGUOUS(result_array)) {
-        // Full Jacobian in C-contiguous format - can use memcpy
-        double *src_data = (double*)PyArray_DATA(result_array);
-        memcpy(pd, src_data, neq * nrowpd * sizeof(double));
-    } else {
-        // Use stride-aware copy for any other layout (F-contiguous, banded, etc.)
-        npy_intp m;
-
-        if (current_dvode_callback->jac_type == 3) {
-            // Banded Jacobian: user provides compressed format (ml + mu + 1 rows)
-            // DVODE expects it in work array with leading dimension nrowpd
-            m = ml + mu + 1;
-        } else {
-            // Full Jacobian
-            m = neq;
-        }
-
-        copy_array_to_fortran(pd, nrowpd, m, neq, result_array);
-    }
+    // Copy C-contiguous result into Fortran-ordered pd (DVODE expects column-major).
+    npy_intp m = (current_dvode_callback->jac_type == 3) ? (ml + mu + 1) : neq;
+    copy_array_to_fortran(pd, nrowpd, m, neq, result_array);
 
     Py_DECREF(result_array);
     Py_DECREF(result);

--- a/scipy/integrate/tests/test_integrate.py
+++ b/scipy/integrate/tests/test_integrate.py
@@ -842,3 +842,24 @@ def test_repeated_t_values():
     # t values are not monotonic.
     assert_raises(ValueError, odeint, func, [1.], [0, 1, 0.5, 0])
     assert_raises(ValueError, odeint, func, [1, 2, 3], [0, -1, -2, 3])
+
+
+def test_vode_jacobian_convention():
+    # Regression test for gh-24933: VODE Jacobian transposition bug.
+    def f(t, y):
+        return [-0.04*y[0] + 1e4*y[1]*y[2],
+                0.04*y[0] - 1e4*y[1]*y[2] - 3e7*y[1]**2,
+                3e7*y[1]**2]
+
+    def jac(t, y):
+        return np.array([[-0.04,              1e4*y[2],         1e4*y[1]],
+                         [0.04,  -1e4*y[2] - 6e7*y[1],        -1e4*y[1]],
+                         [0.0,               6e7*y[1],              0.0]])
+
+    y0 = [1.0, 0.0, 0.0]
+    # Correct Jac. needs ~124 steps; transposed (bug) needs ~2084. Cap at 150.
+    r = ode(f, jac).set_integrator('vode', method='bdf', rtol=1e-8,
+                                   atol=1e-10, nsteps=150)
+    r.set_initial_value(y0, 0.0)
+    r.integrate(1.0)
+    assert r.successful()


### PR DESCRIPTION
## Summary

Fixes #24933.

In `scipy 1.17.x`, `scipy.integrate.ode` with `integrator='vode'` silently consumed the user-supplied Jacobian in **transposed** form relative to the documented convention (`jac[i,j] = df_i/dy_j`). The solver worked as though the user had supplied `jac[i,j] = df_j/dy_i`, causing ~17× more integration steps and outright failure for non-trivial spans.

## Root Cause

In `dvode_jacobian_thunk()` (`scipy/integrate/_dzvodemodule.c`), a "fast path" used `memcpy` when the result array was C-contiguous:

```c
if ((current_dvode_callback->jac_type == 0) && PyArray_IS_C_CONTIGUOUS(result_array)) {
    double *src_data = (double*)PyArray_DATA(result_array);
    memcpy(pd, src_data, neq * nrowpd * sizeof(double));
}
```

Two compounding problems:

1. `PyArray_FROM_OTF(..., NPY_ARRAY_IN_ARRAY)` **always** returns a C-contiguous array, so this path fired on every full-Jacobian call.
2. DVODE reads `pd` as **column-major** (Fortran layout). `memcpy` of row-major data places element `[i,j]` at offset `i*n + j`, which column-major indexing reads as `[j,i]` — the transpose.

The stride-aware helper `copy_array_to_fortran()` already existed in the same file and wrote elements to the correct column-major offsets, but was unreachable for the full-Jacobian case.

## Fix

Remove the `memcpy` fast path and always use `copy_array_to_fortran()`:

```c
// Before:
if ((current_dvode_callback->jac_type == 0) && PyArray_IS_C_CONTIGUOUS(result_array)) {
    memcpy(pd, src_data, neq * nrowpd * sizeof(double));
} else {
    copy_array_to_fortran(pd, nrowpd, m, neq, result_array);
}

// After:
{
    npy_intp m = (current_dvode_callback->jac_type == 3) ? (ml + mu + 1) : neq;
    copy_array_to_fortran(pd, nrowpd, m, neq, result_array);
}
```

`zvode_jacobian_thunk()` (complex solver) is **not** affected — it already used `copy_complex_array_to_fortran()` without a `memcpy` fast path.

## Regression Test

`test_vode_jacobian_convention` integrates the Robertson stiff problem to `t=1` with `nsteps=150`:

- Correct Jacobian (`jac[i,j] = df_i/dy_j`): needs ~124 steps → **passes** within 150
- Transposed Jacobian: needs ~2084 steps → **fails** within 150

The test fails on unpatched scipy 1.17.1 and passes with this fix applied.

## Impact

- All users of `scipy.integrate.ode` with `integrator='vode'` and an analytic full Jacobian are affected in 1.17.x.
- `integrator='lsoda'` is unaffected (uses the old f2py wrapper).
- Introduced in #23963 (merged Nov 2025).

## AI Disclosure

The change was written with Opencode + Claude Sonnet 4.6. The diff itself is small albeit with a verbose comment. Happy to make focused (manual or otherwise) changes based on feedback.