### PR TITLE
BUG: fix crashes, reference leaks, and NaN corruption in C extensions

### DIFF
--- a/scipy/integrate/_dopmodule.c
+++ b/scipy/integrate/_dopmodule.c
@@ -46,12 +46,13 @@ func_thunk(int n, double t, double *y, double *f, double *rpar, int *ipar)
     }
 
     // We already prepared the tuple in the callback setup
-    PyTuple_SetItem(current_func_callback->func_args, 0, PyFloat_FromDouble(t));
+    PyObject *py_t_f = PyFloat_FromDouble(t);
+    if (!py_t_f) { Py_DECREF(py_y); return; }
+    PyTuple_SetItem(current_func_callback->func_args, 0, py_t_f);
     PyTuple_SetItem(current_func_callback->func_args, 1, py_y);
 
     // Call Python function
     PyObject *result = PyObject_CallObject(current_func_callback->func, current_func_callback->func_args);
-
 
     if (result) {
         // Extract result directly to f array
@@ -91,7 +92,9 @@ solout_thunk(int nr, double xold, double x, double* y, int n, double* con, int* 
     }
 
     // Prepare the tuple for solout
-    PyTuple_SetItem(current_func_callback->func_args, 0, PyFloat_FromDouble(x));
+    PyObject *py_x_s = PyFloat_FromDouble(x);
+    if (!py_x_s) { Py_DECREF(py_y); return; }
+    PyTuple_SetItem(current_func_callback->func_args, 0, py_x_s);
     PyTuple_SetItem(current_func_callback->func_args, 1, py_y);
 
     // Call solout function

--- a/scipy/integrate/_dzvodemodule.c
+++ b/scipy/integrate/_dzvodemodule.c
@@ -200,6 +200,7 @@ dvode_function_thunk(int neq, double t, double* y, double* ydot, double* rpar, i
     if (current_dvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
         args_tuple = PyTuple_New(2 + nargs);
+        if (!args_tuple) { Py_DECREF(py_t); Py_DECREF(py_y); return; }
         PyTuple_SET_ITEM(args_tuple, 0, py_t);
         PyTuple_SET_ITEM(args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -209,6 +210,7 @@ dvode_function_thunk(int neq, double t, double* y, double* ydot, double* rpar, i
         }
     } else {
         args_tuple = PyTuple_Pack(2, py_t, py_y);
+        if (!args_tuple) { Py_DECREF(py_t); Py_DECREF(py_y); return; }
     }
 
     // Call Python function
@@ -281,6 +283,7 @@ dvode_jacobian_thunk(int neq, double t, double* y, int ml, int mu,
     if (current_dvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
         jac_args_tuple = PyTuple_New(2 + nargs);
+        if (!jac_args_tuple) { Py_DECREF(py_t); Py_DECREF(py_y); return; }
         PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
         PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -290,6 +293,7 @@ dvode_jacobian_thunk(int neq, double t, double* y, int ml, int mu,
         }
     } else {
         jac_args_tuple = PyTuple_Pack(2, py_t, py_y);
+        if (!jac_args_tuple) { Py_DECREF(py_t); Py_DECREF(py_y); return; }
     }
 
     // Call Python Jacobian function
@@ -425,6 +429,7 @@ zvode_function_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, ZVODE_CPLX_TYPE* ydo
     if (current_zvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
         args_tuple = PyTuple_New(2 + nargs);
+        if (!args_tuple) { Py_DECREF(py_t); Py_DECREF(py_y); return; }
         PyTuple_SET_ITEM(args_tuple, 0, py_t);
         PyTuple_SET_ITEM(args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -434,6 +439,7 @@ zvode_function_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, ZVODE_CPLX_TYPE* ydo
         }
     } else {
         args_tuple = PyTuple_Pack(2, py_t, py_y);
+        if (!args_tuple) { Py_DECREF(py_t); Py_DECREF(py_y); return; }
     }
 
     // Call Python function
@@ -506,6 +512,7 @@ zvode_jacobian_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, int ml, int mu,
     if (current_zvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
         jac_args_tuple = PyTuple_New(2 + nargs);
+        if (!jac_args_tuple) { Py_DECREF(py_t); Py_DECREF(py_y); return; }
         PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
         PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -515,6 +522,7 @@ zvode_jacobian_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, int ml, int mu,
         }
     } else {
         jac_args_tuple = PyTuple_Pack(2, py_t, py_y);
+        if (!jac_args_tuple) { Py_DECREF(py_t); Py_DECREF(py_y); return; }
     }
 
     // Call Python Jacobian function

--- a/scipy/integrate/src/blaslapack_declarations.h
+++ b/scipy/integrate/src/blaslapack_declarations.h
@@ -12,7 +12,7 @@
 #else
     // C99 compliant compilers
     typedef double complex ZVODE_CPLX_TYPE;
-    #define ZVODE_cplx(real, imag) ((real) + (imag)*I)
+    #define ZVODE_cplx(real, imag) CMPLX(real, imag)
 #endif
 
 

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -2240,18 +2240,29 @@ fitpack_parcur(PyObject* Py_UNUSED(dummy), PyObject *args)
     }
 
     PyDict_SetItemString(o, "u", (PyObject *)ap_u);
-    PyDict_SetItemString(o, "ub", PyFloat_FromDouble(ub));
-    PyDict_SetItemString(o, "ue", PyFloat_FromDouble(ue));
-    PyDict_SetItemString(o, "wrk", (PyObject *)ap_wrk);
-    PyDict_SetItemString(o, "iwrk", (PyObject *)ap_iwrk);
-    PyDict_SetItemString(o, "ier", PyLong_FromLong(ier));
-    PyDict_SetItemString(o, "fp", PyFloat_FromDouble(fp));
+    {
+        PyObject *tmp;
+        tmp = PyFloat_FromDouble(ub);
+        PyDict_SetItemString(o, "ub", tmp);
+        Py_XDECREF(tmp);
+        tmp = PyFloat_FromDouble(ue);
+        PyDict_SetItemString(o, "ue", tmp);
+        Py_XDECREF(tmp);
+        PyDict_SetItemString(o, "wrk", (PyObject *)ap_wrk);
+        PyDict_SetItemString(o, "iwrk", (PyObject *)ap_iwrk);
+        tmp = PyLong_FromLong(ier);
+        PyDict_SetItemString(o, "ier", tmp);
+        Py_XDECREF(tmp);
+        tmp = PyFloat_FromDouble(fp);
+        PyDict_SetItemString(o, "fp", tmp);
+        Py_XDECREF(tmp);
+    }
 
     Py_DECREF(ap_u);
     Py_DECREF(ap_wrk);
     Py_DECREF(ap_iwrk);
 
-    return Py_BuildValue(("NNO"), PyArray_Return(ap_t_out), PyArray_Return(ap_c_out), o);
+    return Py_BuildValue(("NNN"), PyArray_Return(ap_t_out), PyArray_Return(ap_c_out), o);
 
 fail_after_call:
     Py_XDECREF(ap_u);

--- a/scipy/linalg/src/_common_array_utils.h
+++ b/scipy/linalg/src/_common_array_utils.h
@@ -17,8 +17,8 @@
     #include <complex.h>
     #define SCIPY_Z double complex
     #define SCIPY_C float complex
-    #define CPLX_Z(real, imag) (real + imag*I)
-    #define CPLX_C(real, imag) (real + imag*I)
+    #define CPLX_Z(real, imag) CMPLX(real, imag)
+    #define CPLX_C(real, imag) CMPLXF(real, imag)
 #endif
 
 // BLAS and LAPACK functions used

--- a/scipy/optimize/_directmodule.c
+++ b/scipy/optimize/_directmodule.c
@@ -37,9 +37,13 @@ direct(PyObject *self, PyObject *args)
     dimension = PyArray_DIMS((PyArrayObject*)lb)[0];
     x = (double *) malloc(sizeof(double) * (dimension + 1));
     if (!x) {
-        ret_code = DIRECT_OUT_OF_MEMORY;
+        return PyErr_NoMemory();
     }
     PyObject *x_seq = PyList_New(dimension);
+    if (!x_seq) {
+        free(x);
+        return NULL;
+    }
     lower_bounds = (double*)PyArray_DATA((PyArrayObject*)lb);
     upper_bounds = (double*)PyArray_DATA((PyArrayObject*)ub);
     magic_eps_abs = 0.0;

--- a/scipy/sparse/linalg/_dsolve/_superlu_utils.c
+++ b/scipy/sparse/linalg/_dsolve/_superlu_utils.c
@@ -38,6 +38,10 @@ static SuperLUGlobalObject *get_tls_global(void)
         return (SuperLUGlobalObject*)PyErr_NoMemory();
     }
     obj->memory_dict = PyDict_New();
+    if (obj->memory_dict == NULL) {
+        PyObject_Del(obj);
+        return (SuperLUGlobalObject*)PyErr_NoMemory();
+    }
     obj->jmpbuf_valid = 0;
 
     PyDict_SetItemString(thread_dict, key, (PyObject *)obj);
@@ -164,7 +168,7 @@ static void SuperLUGlobal_dealloc(SuperLUGlobalObject *self)
 
     while (PyDict_Next(self->memory_dict, &pos, &key, &value)) {
         void *ptr;
-        ptr = PyLong_AsVoidPtr(value);
+        ptr = PyLong_AsVoidPtr(key);
         free(ptr);
     }
 

--- a/scipy/sparse/linalg/_dsolve/_superluobject.c
+++ b/scipy/sparse/linalg/_dsolve/_superluobject.c
@@ -1089,6 +1089,9 @@ int set_superlu_options_from_dict(superlu_options_t * options,
     }
     else {
         args = PyTuple_New(0);
+        if (args == NULL) {
+            return 0;
+        }
         ret = PyArg_ParseTupleAndKeywords(args, option_dict,
                                           "|O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&O&",
                                           kwlist, fact_cvt, &options->Fact,

--- a/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
+++ b/scipy/sparse/linalg/_eigen/arpack/_arpackmodule.c
@@ -11,8 +11,8 @@
     #define ARNAUD_cplx(real, imag) ((_Dcomplex){real, imag})
     #define ARNAUD_cplxf(real, imag) ((_Fcomplex){real, imag})
 #else
-    #define ARNAUD_cplx(real, imag) ((real) + (imag)*I)
-    #define ARNAUD_cplxf(real, imag) ((real) + (imag)*I)
+    #define ARNAUD_cplx(real, imag) CMPLX(real, imag)
+    #define ARNAUD_cplxf(real, imag) CMPLXF(real, imag)
 #endif
 
 #ifdef HAVE_BLAS_ILP64
@@ -1066,9 +1066,24 @@ PyMethodDef arpacklib_module_methods[] = {
 };
 
 
+static int
+arpacklib_exec(PyObject *module)
+{
+    arpack_error_obj = PyErr_NewException("_arpacklib.ArpackError", NULL, NULL);
+    if (arpack_error_obj == NULL) {
+        return -1;
+    }
+    if (PyModule_AddObjectRef(module, "ArpackError", arpack_error_obj) < 0) {
+        Py_CLEAR(arpack_error_obj);
+        return -1;
+    }
+    return 0;
+}
+
 static struct PyModuleDef_Slot arpacklib_module_slots[] = {
-    // signal that this module can be imported in isolated subinterpreters
-    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_exec, arpacklib_exec},
+    // Global arpack_error_obj prevents true per-interpreter isolation
+    {Py_mod_multiple_interpreters, Py_MOD_MULTIPLE_INTERPRETERS_NOT_SUPPORTED},
 #if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
     // signal that this module supports running without an active GIL
     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
@@ -1081,7 +1096,7 @@ static struct
 PyModuleDef moduledef = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_arpacklib",
-    .m_size = 0,
+    .m_size = 0,  /* no per-module state; arpack_error_obj is a global */
     .m_methods = arpacklib_module_methods,
     .m_slots = arpacklib_module_slots,
 };

--- a/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/types.h
+++ b/scipy/sparse/linalg/_eigen/arpack/arnaud/include/arnaud/types.h
@@ -23,8 +23,8 @@
     // C99 compliant compilers
     typedef float complex ARNAUD_CPLXF_TYPE;
     typedef double complex ARNAUD_CPLX_TYPE;
-    #define ARNAUD_cplxf(real, imag) ((real) + (imag)*I)
-    #define ARNAUD_cplx(real, imag) ((real) + (imag)*I)
+    #define ARNAUD_cplxf(real, imag) CMPLXF(real, imag)
+    #define ARNAUD_cplx(real, imag) CMPLX(real, imag)
 #endif
 
 

--- a/scipy/sparse/linalg/_propack/PROPACK/include/propack/types.h
+++ b/scipy/sparse/linalg/_propack/PROPACK/include/propack/types.h
@@ -16,8 +16,8 @@
     // C99 compliant compilers
     typedef float complex PROPACK_CPLXF_TYPE;
     typedef double complex PROPACK_CPLX_TYPE;
-    #define PROPACK_cplxf(real, imag) ((real) + (imag)*I)
-    #define PROPACK_cplx(real, imag) ((real) + (imag)*I)
+    #define PROPACK_cplxf(real, imag) CMPLXF(real, imag)
+    #define PROPACK_cplx(real, imag) CMPLX(real, imag)
 #endif
 
 

--- a/scipy/special/sf_error.cc
+++ b/scipy/special/sf_error.cc
@@ -55,7 +55,7 @@ void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list
     PyGILState_STATE save;
     PyObject *scipy_special = NULL;
     char msg[2048], info[1024];
-    static PyObject *py_SpecialFunctionWarning = NULL;
+    PyObject *py_SpecialFunctionWarning = NULL;
     sf_action_t action;
 
     if ((int) code < 0 || (int) code >= SF_ERROR__LAST) {
@@ -118,6 +118,7 @@ void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list
     }
 
 skip_warn:
+    Py_XDECREF(py_SpecialFunctionWarning);
     PyGILState_Release(save);
 }
 

--- a/scipy/stats/_unuran/unuran_callback.h
+++ b/scipy/stats/_unuran/unuran_callback.h
@@ -44,11 +44,11 @@
     }                                                                                       \
                                                                                             \
 done:                                                                                       \
-    PyGILState_Release(gstate);                                                             \
     Py_XDECREF(arg1);                                                                       \
     Py_XDECREF(argobj);                                                                     \
     Py_XDECREF(funcname);                                                                   \
     Py_XDECREF(res);                                                                        \
+    PyGILState_Release(gstate);                                                             \
                                                                                             \
     if (error) {                                                                            \
         /* nonlocal return causes memory leaks. So, if the Python error variable has been   \


### PR DESCRIPTION
#### Reference issue
Closes gh-24927. Re-submission of #24931 with AI disclosure added per reviewer request.

#### What does this implement/fix?
ARPACK was segfaulting on any error path because `arpack_error_obj` was never initialized — added a `Py_mod_exec` slot to create the exception at module init. Fixed a GIL violation in `unuran_callback.h` where `Py_XDECREF` was called after `PyGILState_Release`, a key/value swap in `SuperLUGlobal_dealloc` that freed `Py_None` instead of tracked pointers, and a `SpecialFunctionWarning` reference leak on every `sf_error_v` call (the variable was `static` so it was never released). Replaced `real + imag*I` with `CMPLX()`/`CMPLXF()` in four headers (ARPACK, PROPACK, ZVODE, linalg) to match the fix already applied to `_complexstuff.h`, preventing NaN corruption of the real part. Added NULL checks after `PyTuple_New`/`PyList_New`/`PyDict_New`/`malloc` in DVODE, ZVODE, DOP853, DIRECT, and SuperLU callback paths that would segfault or abort under OOM. Fixed a ref leak in `_fitpackmodule.c` parcur where temporaries passed to `PyDict_SetItemString` were never released.

#### Additional information
All fixes were locally verified by building from source and running the reproducers from the linked issue. Refcount testing confirmed the `SpecialFunctionWarning` leak is gone (delta = 0 over 100 calls). ARPACK now raises `ArpackError` instead of segfaulting, and all affected integrators/solvers continue to produce correct results.

#### AI Generation Disclosure
GitHub Copilot (Claude Sonnet 4.6) was used to help locate the relevant source files and to draft the code changes. I reviewed each change, understood the bug in each case, verified the fixes against the original C code and the bug report reproducers, and confirmed correctness by building scipy from source and running the test cases. The commit message and this PR description were written by me.