### PR TITLE
DOC: fix `Rotation.apply` docstring matrix formula

### DIFF
--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1585,7 +1585,7 @@ class Rotation:
               expressed in the original frame before and after the rotation.
 
         In terms of rotation matrices, this application is the same as
-        ``self.as_matrix() @ vectors``.
+        ``vectors @ self.as_matrix().T``.
 
         Parameters
         ----------

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1585,7 +1585,7 @@ class Rotation:
               expressed in the original frame before and after the rotation.
 
         In terms of rotation matrices, this application is the same as
-        ``vectors @ self.as_matrix().T``.
+        ``(self.as_matrix() @ vectors[..., np.newaxis])[..., 0]``.
 
         Parameters
         ----------


### PR DESCRIPTION
Closes #24517.

The docstring for `Rotation.apply` stated the application is the same as `self.as_matrix() @ vectors`, which has mismatched dimensions for vectors of shape `(N, 3)`. Updated to `(self.as_matrix() @ vectors[..., np.newaxis])[..., 0]` to match the actual implementation.