### PR TITLE
DOC: keep_feasible explanation

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -103,6 +103,14 @@ class NonlinearConstraint:
     complex plane. The scheme '3-point' is more accurate than '2-point' but
     requires twice as many operations.
 
+    Whilst `NonlinearConstraint` can be used to specify constraints for many
+    different optimizers, the class is not responsible for enforcing those constraints,
+    that is done by the individual minimizer. Importantly, the `keep_feasible` keyword
+    is only ever used within the :ref:`trust-constr <optimize.minimize-trustconstr>`
+    optimizer, the `keep_feasible` keyword is not used by other `minimize` methods.
+    The other methods may, or may not, keep solutions strictly feasible during
+    operation.
+
     Examples
     --------
     Constrain ``x[0] < sin(x[1]) + 1.9``
@@ -162,6 +170,17 @@ class LinearConstraint:
         finite difference approximation of the Jacobian may still violate
         the constraint; it is recommended to provide an analytical Jacobian
         function to handle this case.
+
+    Notes
+    -----
+    Whilst `LinearConstraint` can be used to specify constraints for many
+    different optimizers, the class is not responsible for enforcing those constraints,
+    that is done by the individual minimizer. Importantly, the `keep_feasible` keyword
+    is only ever used within the :ref:`trust-constr <optimize.minimize-trustconstr>`
+    optimizer, the `keep_feasible` keyword is not used by other `minimize` methods.
+    The other methods may, or may not, keep solutions strictly feasible during
+    operation.
+
     """
     def _input_validation(self):
         if self.A.ndim != 2:
@@ -256,6 +275,17 @@ class Bounds:
         Whether to keep the constraint components feasible throughout
         iterations. Must be broadcastable with `lb` and `ub`.
         Default is False. Has no effect for equality constraints.
+
+    Notes
+    -----
+    Whilst `Bounds` can be used to specify box-bounds for many
+    different optimizers, the class is not responsible for enforcing those constraints,
+    that is done by the individual minimizer. Importantly, the `keep_feasible` keyword
+    is only ever used within the :ref:`trust-constr <optimize.minimize-trustconstr>`
+    optimizer, the `keep_feasible` keyword is not used by other `minimize` methods.
+    The other methods may, or may not, keep solutions strictly feasible during
+    operation.
+
     """
 
     # generic type compatibility with scipy-stubs


### PR DESCRIPTION
#### Reference issue
#24936 is relevant, but this PR doesn't close it.

#### What does this implement/fix?
It is a source of confusion that people think that the `keep_feasible` keyword of `NonlinearConstraint`, `LinearConstraint`, `Bounds` means that strict feasibility is always achieved throughout a minimisation. These classes aren't responsible for enforcing feasibility, the individual minimisers are. However, the `keep_feasible` keyword only applies to the `trust-constr` method. Other minimisers using those classes pay no attention to the keyword, they use the classes for constraint specification. Thus, when those methods don't keep feasibility w.r.t a constraint (e.g. evaluating objective in a non-feasible location) the end user gets confused. This PR tries to adjust those expectations via documentation.

#### Additional information
N/A

#### AI Generation Disclosure
No AI tools used