### PR TITLE
MAINT: namespace C++ linalg functions to avoid shadowing std names

### DIFF
--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -9,6 +9,7 @@
 #include "_common_array_utils.hh"
 #include "_linalg_lu_det.hh"
 
+using namespace sp_linalg;
 
 static PyObject* _linalg_inv_error;
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1004,7 +1004,7 @@ _detect_problems(const SliceStatus& slice_status, SliceStatusVec& vec_status) {
  */
 template<typename T>
 CBLAS_INT _calc_lwork(T _lwrk, double fudge_factor=1.0) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     real_type value = detail::real_part(_lwrk) * fudge_factor;
     if((std::is_same<real_type, float>::value) ||
@@ -1141,11 +1141,11 @@ void copy_triangle_to_C(T *dst, const T *src, const npy_intp m, const npy_intp n
  */
 
 template<typename T>
-typename detail::sp_type_traits<T>::real_type
+typename detail::type_traits<T>::real_type
 norm1_(T* A, T* work, const npy_intp n)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using real_type = typename detail::type_traits<T>::real_type;
+    using value_type = typename detail::type_traits<T>::value_type;
     value_type *pA = reinterpret_cast<value_type *>(A);
 
     Py_ssize_t i, j;
@@ -1162,11 +1162,11 @@ norm1_(T* A, T* work, const npy_intp n)
 
 
 template<typename T>
-typename detail::sp_type_traits<T>::real_type
+typename detail::type_traits<T>::real_type
 norm1_sym_herm_upper(T* A, T* work, const npy_intp n)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using real_type = typename detail::type_traits<T>::real_type;
+    using value_type = typename detail::type_traits<T>::value_type;
     value_type *pA = reinterpret_cast<value_type *>(A);
 
     Py_ssize_t i, j;
@@ -1193,11 +1193,11 @@ norm1_sym_herm_upper(T* A, T* work, const npy_intp n)
 
 
 template<typename T>
-typename detail::sp_type_traits<T>::real_type
+typename detail::type_traits<T>::real_type
 norm1_sym_herm_lower(T* A, T* work, const npy_intp n)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using real_type = typename detail::type_traits<T>::real_type;
+    using value_type = typename detail::type_traits<T>::value_type;
     value_type *pA = reinterpret_cast<value_type *>(A);
 
     Py_ssize_t i, j;
@@ -1222,7 +1222,7 @@ norm1_sym_herm_lower(T* A, T* work, const npy_intp n)
 
 
 template<typename T>
-typename detail::sp_type_traits<T>::real_type
+typename detail::type_traits<T>::real_type
 norm1_sym_herm(char uplo, T *A, T *work, const npy_intp n) {
     // NB: transpose for the F order
     if (uplo == 'U') {return norm1_sym_herm_lower(A, work, n);}
@@ -1232,10 +1232,10 @@ norm1_sym_herm(char uplo, T *A, T *work, const npy_intp n) {
 
 
 template<typename T>
-typename detail::sp_type_traits<T>::real_type
+typename detail::type_traits<T>::real_type
 norm1_tridiag(T* dl, T *d, T *du, T *work, const npy_intp n) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using real_type = typename detail::type_traits<T>::real_type;
+    using value_type = typename detail::type_traits<T>::value_type;
 
     value_type *pd = reinterpret_cast<value_type *>(d);
     value_type *pdu = reinterpret_cast<value_type *>(du);
@@ -1264,10 +1264,10 @@ norm1_tridiag(T* dl, T *d, T *du, T *work, const npy_intp n) {
  * is always such that its number of rows is `2 * kl + ku + 1`.
  */
 template <typename T>
-typename detail::sp_type_traits<T>::real_type
+typename detail::type_traits<T>::real_type
 norm1_banded(T* ab, const npy_intp kl, const npy_intp ku, T* work, const npy_intp n) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using real_type = typename detail::type_traits<T>::real_type;
+    using value_type = typename detail::type_traits<T>::value_type;
 
     value_type *pab = reinterpret_cast<value_type *>(ab);
     real_type *rwork = (real_type *)work;
@@ -1306,7 +1306,7 @@ template<typename T>
 void
 bandwidth(T* data, npy_intp n, npy_intp m, npy_intp* lower_band, npy_intp* upper_band)
 {
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using value_type = typename detail::type_traits<T>::value_type;
     value_type *p_data = reinterpret_cast<value_type *>(data);
     value_type zero = value_type(0.);
 
@@ -1345,7 +1345,7 @@ template<typename T>
 void
 bandwidth_strided(T* data, npy_intp n, npy_intp m, npy_intp s1, npy_intp s2, npy_intp *lower_band, npy_intp *upper_band)
 {
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using value_type = typename detail::type_traits<T>::value_type;
     value_type *p_data = reinterpret_cast<value_type *>(data);
     value_type zero = value_type(0.);
 
@@ -1387,7 +1387,7 @@ template<typename T>
 std::tuple<bool, bool>
 is_sym_or_herm(const T *data, npy_intp n) {
     // Return a pair of (is_symmetric, is_hermitian)
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using value_type = typename detail::type_traits<T>::value_type;
     const value_type *p_data = reinterpret_cast<const value_type *>(data);
     bool all_sym = true, all_herm = true;
 
@@ -1555,14 +1555,14 @@ zero_other_triangle(char uplo, T *data, const npy_intp m, npy_intp n = -1, npy_i
     if (uplo == 'U') {
         for (npy_intp i=0; i<n; i++) {
             for (npy_intp j=i+1; j<m; j++){
-                data[j + i*lda] = detail::sp_numeric_limits<T>::zero;
+                data[j + i*lda] = detail::numeric_limits<T>::zero;
             }
         }
     } else {
         for (npy_intp i=0; i<n; i++) {
             npy_intp stop = std::min(i, m);
             for (npy_intp j=0; j < stop; j++){
-                data[j + i*lda] = detail::sp_numeric_limits<T>::zero;
+                data[j + i*lda] = detail::numeric_limits<T>::zero;
             }
         }
     }
@@ -1574,7 +1574,7 @@ inline void
 nan_matrix(T * data, npy_intp n) {
     for (int i = 0; i < n; i++) {
         for (int j = 0; j < n; j++) {
-            data[i * n + j] = detail::sp_numeric_limits<T>::nan;
+            data[i * n + j] = detail::numeric_limits<T>::nan;
         }
     }
 }

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -265,6 +265,9 @@ void BLAS_FUNC(zggev)(char *jobvl, char *jobvr, CBLAS_INT *n, c128_t *a, CBLAS_I
 } // extern "C"
 
 
+namespace sp_linalg {
+
+
 /*
  * Generate type overloads, to map from C array types (float, double, npy_complex64, npy_complex128)
  * to LAPACK prefixes, "sdcz".
@@ -1001,9 +1004,9 @@ _detect_problems(const SliceStatus& slice_status, SliceStatusVec& vec_status) {
  */
 template<typename T>
 CBLAS_INT _calc_lwork(T _lwrk, double fudge_factor=1.0) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
-    real_type value = real_part(_lwrk) * fudge_factor;
+    real_type value = detail::real_part(_lwrk) * fudge_factor;
     if((std::is_same<real_type, float>::value) ||
        (std::is_same<real_type, npy_complex64>::value)
     ) {
@@ -1138,11 +1141,11 @@ void copy_triangle_to_C(T *dst, const T *src, const npy_intp m, const npy_intp n
  */
 
 template<typename T>
-typename sp_type_traits<T>::real_type
+typename detail::sp_type_traits<T>::real_type
 norm1_(T* A, T* work, const npy_intp n)
 {
-    using real_type = typename sp_type_traits<T>::real_type;
-    using value_type = typename sp_type_traits<T>::value_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
     value_type *pA = reinterpret_cast<value_type *>(A);
 
     Py_ssize_t i, j;
@@ -1159,11 +1162,11 @@ norm1_(T* A, T* work, const npy_intp n)
 
 
 template<typename T>
-typename sp_type_traits<T>::real_type
+typename detail::sp_type_traits<T>::real_type
 norm1_sym_herm_upper(T* A, T* work, const npy_intp n)
 {
-    using real_type = typename sp_type_traits<T>::real_type;
-    using value_type = typename sp_type_traits<T>::value_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
     value_type *pA = reinterpret_cast<value_type *>(A);
 
     Py_ssize_t i, j;
@@ -1190,11 +1193,11 @@ norm1_sym_herm_upper(T* A, T* work, const npy_intp n)
 
 
 template<typename T>
-typename sp_type_traits<T>::real_type
+typename detail::sp_type_traits<T>::real_type
 norm1_sym_herm_lower(T* A, T* work, const npy_intp n)
 {
-    using real_type = typename sp_type_traits<T>::real_type;
-    using value_type = typename sp_type_traits<T>::value_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
     value_type *pA = reinterpret_cast<value_type *>(A);
 
     Py_ssize_t i, j;
@@ -1219,7 +1222,7 @@ norm1_sym_herm_lower(T* A, T* work, const npy_intp n)
 
 
 template<typename T>
-typename sp_type_traits<T>::real_type
+typename detail::sp_type_traits<T>::real_type
 norm1_sym_herm(char uplo, T *A, T *work, const npy_intp n) {
     // NB: transpose for the F order
     if (uplo == 'U') {return norm1_sym_herm_lower(A, work, n);}
@@ -1229,10 +1232,10 @@ norm1_sym_herm(char uplo, T *A, T *work, const npy_intp n) {
 
 
 template<typename T>
-typename sp_type_traits<T>::real_type
+typename detail::sp_type_traits<T>::real_type
 norm1_tridiag(T* dl, T *d, T *du, T *work, const npy_intp n) {
-    using real_type = typename sp_type_traits<T>::real_type;
-    using value_type = typename sp_type_traits<T>::value_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
 
     value_type *pd = reinterpret_cast<value_type *>(d);
     value_type *pdu = reinterpret_cast<value_type *>(du);
@@ -1261,10 +1264,10 @@ norm1_tridiag(T* dl, T *d, T *du, T *work, const npy_intp n) {
  * is always such that its number of rows is `2 * kl + ku + 1`.
  */
 template <typename T>
-typename sp_type_traits<T>::real_type
+typename detail::sp_type_traits<T>::real_type
 norm1_banded(T* ab, const npy_intp kl, const npy_intp ku, T* work, const npy_intp n) {
-    using real_type = typename sp_type_traits<T>::real_type;
-    using value_type = typename sp_type_traits<T>::value_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
 
     value_type *pab = reinterpret_cast<value_type *>(ab);
     real_type *rwork = (real_type *)work;
@@ -1303,7 +1306,7 @@ template<typename T>
 void
 bandwidth(T* data, npy_intp n, npy_intp m, npy_intp* lower_band, npy_intp* upper_band)
 {
-    using value_type = typename sp_type_traits<T>::value_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
     value_type *p_data = reinterpret_cast<value_type *>(data);
     value_type zero = value_type(0.);
 
@@ -1342,7 +1345,7 @@ template<typename T>
 void
 bandwidth_strided(T* data, npy_intp n, npy_intp m, npy_intp s1, npy_intp s2, npy_intp *lower_band, npy_intp *upper_band)
 {
-    using value_type = typename sp_type_traits<T>::value_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
     value_type *p_data = reinterpret_cast<value_type *>(data);
     value_type zero = value_type(0.);
 
@@ -1384,7 +1387,7 @@ template<typename T>
 std::tuple<bool, bool>
 is_sym_or_herm(const T *data, npy_intp n) {
     // Return a pair of (is_symmetric, is_hermitian)
-    using value_type = typename sp_type_traits<T>::value_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
     const value_type *p_data = reinterpret_cast<const value_type *>(data);
     bool all_sym = true, all_herm = true;
 
@@ -1449,13 +1452,13 @@ fill_other_triangle(char uplo, T *data, npy_intp n) {
     if (uplo == 'U') {
         for (npy_intp i=0; i<n; i++) {
             for (npy_intp j=i+1; j<n; j++){
-                data[j + i*n] = conj(data[i + j*n]);
+                data[j + i*n] = detail::conj(data[i + j*n]);
             }
         }
     } else {
         for (npy_intp i=0; i<n; i++) {
             for (npy_intp j=0; j<i+1; j++){
-                data[j + i*n] = conj(data[i + j*n]);
+                data[j + i*n] = detail::conj(data[i + j*n]);
             }
         }
     }
@@ -1552,14 +1555,14 @@ zero_other_triangle(char uplo, T *data, const npy_intp m, npy_intp n = -1, npy_i
     if (uplo == 'U') {
         for (npy_intp i=0; i<n; i++) {
             for (npy_intp j=i+1; j<m; j++){
-                data[j + i*lda] = sp_numeric_limits<T>::zero;
+                data[j + i*lda] = detail::sp_numeric_limits<T>::zero;
             }
         }
     } else {
         for (npy_intp i=0; i<n; i++) {
             npy_intp stop = std::min(i, m);
             for (npy_intp j=0; j < stop; j++){
-                data[j + i*lda] = sp_numeric_limits<T>::zero;
+                data[j + i*lda] = detail::sp_numeric_limits<T>::zero;
             }
         }
     }
@@ -1571,8 +1574,10 @@ inline void
 nan_matrix(T * data, npy_intp n) {
     for (int i = 0; i < n; i++) {
         for (int j = 0; j < n; j++) {
-            data[i * n + j] = sp_numeric_limits<T>::nan;
+            data[i * n + j] = detail::sp_numeric_limits<T>::nan;
         }
     }
 }
+
+} // namespace sp_linalg
 #endif

--- a/scipy/linalg/src/_linalg_cholesky.hh
+++ b/scipy/linalg/src/_linalg_cholesky.hh
@@ -1,3 +1,6 @@
+
+namespace sp_linalg {
+
 template<typename T>
 int
 _cholesky(PyArrayObject *ap_Am, PyArrayObject *ap_Cm, int lower, int overwrite_a, int clean, SliceStatusVec &vec_status) {
@@ -101,3 +104,5 @@ _cholesky(PyArrayObject *ap_Am, PyArrayObject *ap_Cm, int lower, int overwrite_a
 
     return 1;
 }
+
+} // namespace sp_linalg

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -39,8 +39,8 @@ template<typename T>
 int
 _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArrayObject *ap_vr, int overwrite_a, SliceStatusVec& vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
-    using npy_complex_type = typename detail::sp_type_traits<T>::npy_complex_type;
+    using real_type = typename detail::type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using npy_complex_type = typename detail::type_traits<T>::npy_complex_type;
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -71,7 +71,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
-    T tmp = detail::sp_numeric_limits<T>::zero;
+    T tmp = detail::numeric_limits<T>::zero;
 
     char jobvl = compute_vl ? 'V': 'N', jobvr = compute_vr ? 'V' : 'N';
     CBLAS_INT lda = n;
@@ -80,7 +80,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
 
     // c- and z variants: lwork query segfaults with rwork=NULL, allocate it straight away
     real_type *rwork = NULL;
-    if constexpr (detail::sp_type_traits<T>::is_complex) {
+    if constexpr (detail::type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(2*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
@@ -112,7 +112,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
      * NB: we do not implement jobz='O' yet, so we never reuse A for U or Vh.
      */
     npy_intp data_size = overwrite_a ? 0 : n*n;
-    npy_intp wi_size = detail::sp_type_traits<T>::is_complex ? 0 : n;
+    npy_intp wi_size = detail::type_traits<T>::is_complex ? 0 : n;
     npy_intp bufsize = data_size + wi_size + lwork + n;
 
     npy_intp vl_size = compute_vl ? ldvl*n : 0;
@@ -169,7 +169,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
         }
 
         // copy-and-tranpose W, VR and VL slices from temp buffers to the output;
-        if constexpr (detail::sp_type_traits<T>::is_complex) {
+        if constexpr (detail::type_traits<T>::is_complex) {
             memcpy(ptr_W, wr, n*sizeof(T));
             ptr_W += n;
 
@@ -212,8 +212,8 @@ template<typename T>
 int
 _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArrayObject *ap_beta, PyArrayObject *ap_vl, PyArrayObject *ap_vr, int overwrite_a, int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
-    using npy_complex_type = typename detail::sp_type_traits<T>::npy_complex_type;
+    using real_type = typename detail::type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using npy_complex_type = typename detail::type_traits<T>::npy_complex_type;
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -249,7 +249,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
-    T tmp = detail::sp_numeric_limits<T>::zero;
+    T tmp = detail::numeric_limits<T>::zero;
 
     char jobvl = compute_vl ? 'V': 'N', jobvr = compute_vr ? 'V' : 'N';
     CBLAS_INT lda = n;
@@ -259,7 +259,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
     // similar to geev, allocate rwork right away (not sure if ?ggev segfaults otherwise, too)
     real_type *rwork = NULL;
-    if constexpr (detail::sp_type_traits<T>::is_complex) {
+    if constexpr (detail::type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(8*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
@@ -291,9 +291,10 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
      *
      * NB: we do not implement jobz='O' yet, so we never reuse A for U or Vh.
      */
-    npy_intp alphai_size = detail::sp_type_traits<T>::is_complex ? 0 : n ;
+    npy_intp alphai_size = detail::type_traits<T>::is_complex ? 0 : n ;
     npy_intp A_size = overwrite_a ? 0 : n*n;
     npy_intp B_size = overwrite_b ? 0 : n*n;
+
     npy_intp vl_size = compute_vl ? ldvl*n : 0;
     npy_intp vr_size = compute_vr ? ldvr*n : 0;
 
@@ -365,7 +366,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
         }
 
         // copy-and-tranpose W, VR and VL slices from temp buffers to the output;
-        if constexpr (detail::sp_type_traits<T>::is_complex) {
+        if constexpr (detail::type_traits<T>::is_complex) {
             // alphar and beta are complex and compatible with the W array 
             memcpy(ptr_W, alphar, n*sizeof(T));
             ptr_W += n;

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -4,6 +4,8 @@
  */
 
 
+namespace sp_linalg {
+
 /*
  * Copy eigenvectors from F-ordered real `v` (ldv, n)-shaped array in the ?GEEV convention
  * into an (n, n)-shaped C-ordered complex array `dst`.
@@ -15,7 +17,7 @@ transform_eigvecs(cmplx_type dst, real_type *v, CBLAS_INT ldv, CBLAS_INT n, real
         if(wi[j] == 0.) {
             // If the j-th eigenvalue is real, then u(j) = VL(:,j), the j-th column of VL.
             for (CBLAS_INT i=0; i<n; i++) {
-                dst[i*n + j] = cpack(v[i + j*ldv], real_type(0.));
+                dst[i*n + j] = detail::cpack(v[i + j*ldv], real_type(0.));
             }
             j += 1;
         }
@@ -24,8 +26,8 @@ transform_eigvecs(cmplx_type dst, real_type *v, CBLAS_INT ldv, CBLAS_INT n, real
             // then u(j) = VL(:,j) + i*VL(:,j+1) and u(j+1) = VL(:,j) - i*VL(:,j+1).
             for (CBLAS_INT i=0; i<n; i++) {
                 real_type re = v[i + j*ldv], im = v[i + (j+1)*ldv];
-                dst[i*n + j] = cpack(re, im);     // VL(i, j)
-                dst[i*n + j + 1] = cpack(re, -im);  // VL(i, j+1)
+                dst[i*n + j] = detail::cpack(re, im);     // VL(i, j)
+                dst[i*n + j + 1] = detail::cpack(re, -im);  // VL(i, j+1)
             }
             j += 2;
         }
@@ -37,8 +39,8 @@ template<typename T>
 int
 _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArrayObject *ap_vr, int overwrite_a, SliceStatusVec& vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
-    using npy_complex_type = typename sp_type_traits<T>::npy_complex_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using npy_complex_type = typename detail::sp_type_traits<T>::npy_complex_type;
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -69,7 +71,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
-    T tmp = sp_numeric_limits<T>::zero;
+    T tmp = detail::sp_numeric_limits<T>::zero;
 
     char jobvl = compute_vl ? 'V': 'N', jobvr = compute_vr ? 'V' : 'N';
     CBLAS_INT lda = n;
@@ -78,7 +80,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
 
     // c- and z variants: lwork query segfaults with rwork=NULL, allocate it straight away
     real_type *rwork = NULL;
-    if constexpr (sp_type_traits<T>::is_complex) {
+    if constexpr (detail::sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(2*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
@@ -110,7 +112,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
      * NB: we do not implement jobz='O' yet, so we never reuse A for U or Vh.
      */
     npy_intp data_size = overwrite_a ? 0 : n*n;
-    npy_intp wi_size = sp_type_traits<T>::is_complex ? 0 : n;
+    npy_intp wi_size = detail::sp_type_traits<T>::is_complex ? 0 : n;
     npy_intp bufsize = data_size + wi_size + lwork + n;
 
     npy_intp vl_size = compute_vl ? ldvl*n : 0;
@@ -167,7 +169,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
         }
 
         // copy-and-tranpose W, VR and VL slices from temp buffers to the output;
-        if constexpr (sp_type_traits<T>::is_complex) {
+        if constexpr (detail::sp_type_traits<T>::is_complex) {
             memcpy(ptr_W, wr, n*sizeof(T));
             ptr_W += n;
 
@@ -183,7 +185,7 @@ _reg_eig(PyArrayObject* ap_Am, PyArrayObject *ap_w, PyArrayObject *ap_vl, PyArra
         else {
             // convert wr,wi into w
             for(npy_intp i=0; i<n; i++) {
-                ptr_W[i] = cpack(wr[i], wi[i]);
+                ptr_W[i] = detail::cpack(wr[i], wi[i]);
             }
             ptr_W += n;
 
@@ -210,8 +212,8 @@ template<typename T>
 int
 _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArrayObject *ap_beta, PyArrayObject *ap_vl, PyArrayObject *ap_vr, int overwrite_a, int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
-    using npy_complex_type = typename sp_type_traits<T>::npy_complex_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using npy_complex_type = typename detail::sp_type_traits<T>::npy_complex_type;
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -247,7 +249,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
-    T tmp = sp_numeric_limits<T>::zero;
+    T tmp = detail::sp_numeric_limits<T>::zero;
 
     char jobvl = compute_vl ? 'V': 'N', jobvr = compute_vr ? 'V' : 'N';
     CBLAS_INT lda = n;
@@ -257,7 +259,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
     // similar to geev, allocate rwork right away (not sure if ?ggev segfaults otherwise, too)
     real_type *rwork = NULL;
-    if constexpr (sp_type_traits<T>::is_complex) {
+    if constexpr (detail::sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(8*n*sizeof(real_type));
         if (rwork == NULL) {
             return -100;
@@ -289,7 +291,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
      *
      * NB: we do not implement jobz='O' yet, so we never reuse A for U or Vh.
      */
-    npy_intp alphai_size = sp_type_traits<T>::is_complex ? 0 : n ;
+    npy_intp alphai_size = detail::sp_type_traits<T>::is_complex ? 0 : n ;
     npy_intp A_size = overwrite_a ? 0 : n*n;
     npy_intp B_size = overwrite_b ? 0 : n*n;
     npy_intp vl_size = compute_vl ? ldvl*n : 0;
@@ -363,7 +365,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
         }
 
         // copy-and-tranpose W, VR and VL slices from temp buffers to the output;
-        if constexpr (sp_type_traits<T>::is_complex) {
+        if constexpr (detail::sp_type_traits<T>::is_complex) {
             // alphar and beta are complex and compatible with the W array 
             memcpy(ptr_W, alphar, n*sizeof(T));
             ptr_W += n;
@@ -383,7 +385,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
         else {
             // convert alphar,alphai,beta into w
             for(npy_intp i=0; i<n; i++) {
-                ptr_W[i] = cpack(alphar[i], alphai[i]);
+                ptr_W[i] = detail::cpack(alphar[i], alphai[i]);
             }
             ptr_W += n;
 
@@ -432,3 +434,4 @@ _eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm,
     return info;
 }
 
+} // namespace sp_linalg

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -19,7 +19,7 @@ void invert_slice_general(
     CBLAS_INT N, T *data, CBLAS_INT *ipiv, void *irwork, T *work, CBLAS_INT lwork,
     SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -35,7 +35,7 @@ void invert_slice_general(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
 
             // finally, invert
             call_getri(&N, data, &N, ipiv, work, &lwork, &info);
@@ -57,7 +57,7 @@ void invert_slice_cholesky(
     char uplo, CBLAS_INT N, T *data, T* work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type anorm = norm1_sym_herm(uplo, data, work, (npy_intp)N);
@@ -73,7 +73,7 @@ void invert_slice_cholesky(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
 
             // finally, invert
             call_potri(&uplo, &N, data, &N, &info);
@@ -93,7 +93,7 @@ void invert_slice_sym_herm(
     bool is_symm_not_herm, 
     SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type rcond;
@@ -116,7 +116,7 @@ void invert_slice_sym_herm(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
 
             // finally, invert
             if (is_symm_not_herm) {
@@ -140,7 +140,7 @@ void invert_slice_triangular(
     char uplo, char diag, CBLAS_INT N, T *data, T *work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -154,7 +154,7 @@ void invert_slice_triangular(
 
         call_trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
             status.rcond = (double)rcond;
         }
     }
@@ -166,8 +166,8 @@ template<typename T>
 inline void invert_slice_diagonal(
     CBLAS_INT N, T *data, SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using real_type = typename detail::type_traits<T>::real_type;
+    using value_type = typename detail::type_traits<T>::value_type;
     value_type *pdata = reinterpret_cast<value_type *>(data);
 
     value_type zero(0.), one(1.);
@@ -191,7 +191,7 @@ inline void invert_slice_diagonal(
         if(absa > maxa) {maxa = absa;}
         if(absinva > maxinva) {maxinva = absinva;}
     }
-    status.is_ill_conditioned = maxa * maxinva > 1./ detail::sp_numeric_limits<real_type>::eps;
+    status.is_ill_conditioned = maxa * maxinva > 1./ detail::numeric_limits<real_type>::eps;
     status.rcond = maxa * maxinva;
 }
 
@@ -200,7 +200,7 @@ template<typename T>
 int
 _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwrite_a, SliceStatusVec& vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     npy_intp lower_band = 0, upper_band = 0;
     bool is_symm = false, is_herm = false;
@@ -227,8 +227,8 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     // --------------------------------------------------------------------
     // Workspace computation and allocation
     // --------------------------------------------------------------------
-    T tmp = detail::sp_numeric_limits<T>::zero;
-    T tmp1 = detail::sp_numeric_limits<T>::zero;
+    T tmp = detail::numeric_limits<T>::zero;
+    T tmp1 = detail::numeric_limits<T>::zero;
     CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
 
     call_getri(&intn, NULL, &intn, NULL, &tmp, &lwork, &info);
@@ -310,7 +310,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
-    if constexpr(detail::sp_type_traits<T>::is_complex) {
+    if constexpr(detail::type_traits<T>::is_complex) {
         irwork = malloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
@@ -371,7 +371,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                 // Check if symmetric/hermitian
                 std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
 
-                if constexpr (!detail::sp_type_traits<T>::is_complex) {
+                if constexpr (!detail::type_traits<T>::is_complex) {
                     // Real: is_symm and is_herm are always equal
                     if (is_symm) {
                         // try Cholesky first, fall back to sytrf if it fails
@@ -455,7 +455,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
             case St::SYM:     // NB: if POS_DEF failed, fall-through to here
             case St::HER:
             {
-                if constexpr (!detail::sp_type_traits<T>::is_complex) {
+                if constexpr (!detail::type_traits<T>::is_complex) {
                     // Real: always use sytrf/sytri
                     invert_slice_sym_herm(uplo, intn, data, ipiv, work, irwork, lwork, true, slice_status);
                 }
@@ -468,7 +468,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                     goto free_exit;
                 }
 
-                if constexpr (!detail::sp_type_traits<T>::is_complex) {
+                if constexpr (!detail::type_traits<T>::is_complex) {
                     // Real symmetric
                     fill_other_triangle_noconj(uplo, data, intn);
                 }

--- a/scipy/linalg/src/_linalg_inv.hh
+++ b/scipy/linalg/src/_linalg_inv.hh
@@ -11,13 +11,15 @@
 #include "_common_array_utils.hh"
 
 
+namespace sp_linalg {
+
 // Dense array inversion with getrf, gecon and getri
 template<typename T>
 void invert_slice_general(
     CBLAS_INT N, T *data, CBLAS_INT *ipiv, void *irwork, T *work, CBLAS_INT lwork,
     SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -33,7 +35,7 @@ void invert_slice_general(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
 
             // finally, invert
             call_getri(&N, data, &N, ipiv, work, &lwork, &info);
@@ -55,7 +57,7 @@ void invert_slice_cholesky(
     char uplo, CBLAS_INT N, T *data, T* work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type anorm = norm1_sym_herm(uplo, data, work, (npy_intp)N);
@@ -71,7 +73,7 @@ void invert_slice_cholesky(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
 
             // finally, invert
             call_potri(&uplo, &N, data, &N, &info);
@@ -91,7 +93,7 @@ void invert_slice_sym_herm(
     bool is_symm_not_herm, 
     SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type rcond;
@@ -114,7 +116,7 @@ void invert_slice_sym_herm(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
 
             // finally, invert
             if (is_symm_not_herm) {
@@ -138,7 +140,7 @@ void invert_slice_triangular(
     char uplo, char diag, CBLAS_INT N, T *data, T *work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -152,7 +154,7 @@ void invert_slice_triangular(
 
         call_trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
             status.rcond = (double)rcond;
         }
     }
@@ -164,8 +166,8 @@ template<typename T>
 inline void invert_slice_diagonal(
     CBLAS_INT N, T *data, SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
-    using value_type = typename sp_type_traits<T>::value_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
     value_type *pdata = reinterpret_cast<value_type *>(data);
 
     value_type zero(0.), one(1.);
@@ -189,7 +191,7 @@ inline void invert_slice_diagonal(
         if(absa > maxa) {maxa = absa;}
         if(absinva > maxinva) {maxinva = absinva;}
     }
-    status.is_ill_conditioned = maxa * maxinva > 1./ sp_numeric_limits<real_type>::eps;
+    status.is_ill_conditioned = maxa * maxinva > 1./ detail::sp_numeric_limits<real_type>::eps;
     status.rcond = maxa * maxinva;
 }
 
@@ -198,7 +200,7 @@ template<typename T>
 int
 _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwrite_a, SliceStatusVec& vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     npy_intp lower_band = 0, upper_band = 0;
     bool is_symm = false, is_herm = false;
@@ -225,8 +227,8 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
     // --------------------------------------------------------------------
     // Workspace computation and allocation
     // --------------------------------------------------------------------
-    T tmp = sp_numeric_limits<T>::zero;
-    T tmp1 = sp_numeric_limits<T>::zero;
+    T tmp = detail::sp_numeric_limits<T>::zero;
+    T tmp1 = detail::sp_numeric_limits<T>::zero;
     CBLAS_INT intn = (CBLAS_INT)n, lwork = -1, info;
 
     call_getri(&intn, NULL, &intn, NULL, &tmp, &lwork, &info);
@@ -308,7 +310,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
-    if constexpr(sp_type_traits<T>::is_complex) {
+    if constexpr(detail::sp_type_traits<T>::is_complex) {
         irwork = malloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
@@ -369,7 +371,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                 // Check if symmetric/hermitian
                 std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
 
-                if constexpr (!sp_type_traits<T>::is_complex) {
+                if constexpr (!detail::sp_type_traits<T>::is_complex) {
                     // Real: is_symm and is_herm are always equal
                     if (is_symm) {
                         // try Cholesky first, fall back to sytrf if it fails
@@ -453,7 +455,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
             case St::SYM:     // NB: if POS_DEF failed, fall-through to here
             case St::HER:
             {
-                if constexpr (!sp_type_traits<T>::is_complex) {
+                if constexpr (!detail::sp_type_traits<T>::is_complex) {
                     // Real: always use sytrf/sytri
                     invert_slice_sym_herm(uplo, intn, data, ipiv, work, irwork, lwork, true, slice_status);
                 }
@@ -466,7 +468,7 @@ _inverse(PyArrayObject* ap_Am, T* ret_data, St structure, int lower, int overwri
                     goto free_exit;
                 }
 
-                if constexpr (!sp_type_traits<T>::is_complex) {
+                if constexpr (!detail::sp_type_traits<T>::is_complex) {
                     // Real symmetric
                     fill_other_triangle_noconj(uplo, data, intn);
                 }
@@ -504,4 +506,6 @@ free_exit:
     free(ipiv);
     return 1;
 }
+
+} // namespace sp_linalg
 

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -2,11 +2,13 @@
  * Templated loops for linalg.lstsq
  */
 
+namespace sp_linalg {
+
 template<typename T>
 int
 _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -56,7 +58,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     CBLAS_INT rank = min_mn;
 
     // query LWORK
-    T tmp = sp_numeric_limits<T>::zero;
+    T tmp = detail::sp_numeric_limits<T>::zero;
     call_gelss(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
     if(info != 0) { return -100; }
 
@@ -101,7 +103,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     }
 
     real_type *rwork = NULL;
-    if constexpr (sp_type_traits<T>::is_complex) {
+    if constexpr (detail::sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -163,7 +165,7 @@ template<typename T>
 int
 _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -208,14 +210,14 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
 
     // query LWORK, LRWORK and LIWORK
     // XXX: bump LRWORK and LIWORK up to improve perf? lwork=-1 query returns the *minimum* values
-    T tmp = sp_numeric_limits<T>::zero;
+    T tmp = detail::sp_numeric_limits<T>::zero;
     real_type tmp_lrwork = 0;
     CBLAS_INT liwork = 0, lrwork = 0;
     call_gelsd(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, &tmp_lrwork, &liwork, &info);
 
     if(info != 0) { return -100; }
     lwork = _calc_lwork(tmp);
-    lrwork = sp_type_traits<T>::is_complex ? _calc_lwork(tmp_lrwork) : 0 ;
+    lrwork = detail::sp_type_traits<T>::is_complex ? _calc_lwork(tmp_lrwork) : 0 ;
 
     if ((lwork < 0) || (lrwork < 0) || (liwork < 0)) {return -111;}
 
@@ -257,7 +259,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     }
 
     real_type *rwork = NULL;
-    if constexpr (sp_type_traits<T>::is_complex) {
+    if constexpr (detail::sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(lrwork*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -325,7 +327,7 @@ template<typename T>
 int
 _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -368,7 +370,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     CBLAS_INT rank = min_mn;
 
     // query LWORK
-    T tmp = sp_numeric_limits<T>::zero;
+    T tmp = detail::sp_numeric_limits<T>::zero;
     call_gelsy(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
     if(info != 0) { return -100; }
 
@@ -412,7 +414,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     }
 
     real_type *rwork = NULL;
-    if constexpr (sp_type_traits<T>::is_complex) {
+    if constexpr (detail::sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(2*n*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -498,3 +500,5 @@ _lstsq(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayOb
     }
     return info;
 }
+
+} // namespace sp_linalg

--- a/scipy/linalg/src/_linalg_lstsq.hh
+++ b/scipy/linalg/src/_linalg_lstsq.hh
@@ -8,7 +8,7 @@ template<typename T>
 int
 _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -58,7 +58,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     CBLAS_INT rank = min_mn;
 
     // query LWORK
-    T tmp = detail::sp_numeric_limits<T>::zero;
+    T tmp = detail::numeric_limits<T>::zero;
     call_gelss(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
     if(info != 0) { return -100; }
 
@@ -103,7 +103,7 @@ _lstsq_gelss(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     }
 
     real_type *rwork = NULL;
-    if constexpr (detail::sp_type_traits<T>::is_complex) {
+    if constexpr (detail::type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -165,7 +165,7 @@ template<typename T>
 int
 _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -210,14 +210,14 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
 
     // query LWORK, LRWORK and LIWORK
     // XXX: bump LRWORK and LIWORK up to improve perf? lwork=-1 query returns the *minimum* values
-    T tmp = detail::sp_numeric_limits<T>::zero;
+    T tmp = detail::numeric_limits<T>::zero;
     real_type tmp_lrwork = 0;
     CBLAS_INT liwork = 0, lrwork = 0;
     call_gelsd(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, &tmp_lrwork, &liwork, &info);
 
     if(info != 0) { return -100; }
     lwork = _calc_lwork(tmp);
-    lrwork = detail::sp_type_traits<T>::is_complex ? _calc_lwork(tmp_lrwork) : 0 ;
+    lrwork = detail::type_traits<T>::is_complex ? _calc_lwork(tmp_lrwork) : 0 ;
 
     if ((lwork < 0) || (lrwork < 0) || (liwork < 0)) {return -111;}
 
@@ -259,7 +259,7 @@ _lstsq_gelsd(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_S, PyA
     }
 
     real_type *rwork = NULL;
-    if constexpr (detail::sp_type_traits<T>::is_complex) {
+    if constexpr (detail::type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(lrwork*sizeof(real_type));
 
         if (rwork == NULL) {
@@ -327,7 +327,7 @@ template<typename T>
 int
 _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyArrayObject *ap_rank, double rcond, const int overwrite_a, const int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -370,7 +370,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     CBLAS_INT rank = min_mn;
 
     // query LWORK
-    T tmp = detail::sp_numeric_limits<T>::zero;
+    T tmp = detail::numeric_limits<T>::zero;
     call_gelsy(&intm, &intn, &int_nrhs, NULL, &lda, NULL, &ldb, NULL, &r_rcond, &rank, &tmp, &lwork, NULL, &info);
     if(info != 0) { return -100; }
 
@@ -414,7 +414,7 @@ _lstsq_gelsy(PyArrayObject *ap_Am, PyArrayObject *ap_b, PyArrayObject *ap_x, PyA
     }
 
     real_type *rwork = NULL;
-    if constexpr (detail::sp_type_traits<T>::is_complex) {
+    if constexpr (detail::type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(2*n*sizeof(real_type));
 
         if (rwork == NULL) {

--- a/scipy/linalg/src/_linalg_lu_det.hh
+++ b/scipy/linalg/src/_linalg_lu_det.hh
@@ -4,6 +4,9 @@
 #include <type_traits>
 #include "scipy_blas_defines.h"
 
+namespace sp_linalg {
+
+
 constexpr int LU_MAX_NDIM = 64;
 
 
@@ -378,3 +381,6 @@ int det_dispatch(LU_Context &ctx, T *a_dat, T *det_out, T *scratch, CBLAS_INT *s
 
     return 0;
 }
+
+
+} // namespace sp_linalg

--- a/scipy/linalg/src/_linalg_qr.hh
+++ b/scipy/linalg/src/_linalg_qr.hh
@@ -2,11 +2,13 @@
  * Templated loops for `linalg.qr`
  */
 
+namespace sp_linalg {
+
 template<typename T>
 int
 _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObject *ap_tau, PyArrayObject *ap_jpvt, int overwrite_a, QR_mode mode, int pivoting, SliceStatusVec &vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
     SliceStatus slice_status;
 
     // ------------------------------------------------------------------------
@@ -54,8 +56,8 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
 
 
     // Probe both the factorization as well as `or_un_gqr` to find the optimal lwork
-    T tmp_factor = sp_numeric_limits<T>::zero;
-    T tmp_or_un_gqr = sp_numeric_limits<T>::zero;
+    T tmp_factor = detail::sp_numeric_limits<T>::zero;
+    T tmp_or_un_gqr = detail::sp_numeric_limits<T>::zero;
     CBLAS_INT lwork = -1;
 
     if (!pivoting) {
@@ -130,7 +132,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
 
     // `c/zgeqp3` needs rwork
     void *rwork = NULL;
-    if (pivoting && sp_type_traits<T>::is_complex) {
+    if (pivoting && detail::sp_type_traits<T>::is_complex) {
         rwork = malloc(2 * N * sizeof(real_type));
 
         if (rwork == NULL) {
@@ -245,3 +247,5 @@ free_exit:
 
     return 1;
 }
+
+} // namespace sp_linalg

--- a/scipy/linalg/src/_linalg_qr.hh
+++ b/scipy/linalg/src/_linalg_qr.hh
@@ -8,7 +8,7 @@ template<typename T>
 int
 _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObject *ap_tau, PyArrayObject *ap_jpvt, int overwrite_a, QR_mode mode, int pivoting, SliceStatusVec &vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
     SliceStatus slice_status;
 
     // ------------------------------------------------------------------------
@@ -56,8 +56,8 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
 
 
     // Probe both the factorization as well as `or_un_gqr` to find the optimal lwork
-    T tmp_factor = detail::sp_numeric_limits<T>::zero;
-    T tmp_or_un_gqr = detail::sp_numeric_limits<T>::zero;
+    T tmp_factor = detail::numeric_limits<T>::zero;
+    T tmp_or_un_gqr = detail::numeric_limits<T>::zero;
     CBLAS_INT lwork = -1;
 
     if (!pivoting) {
@@ -132,7 +132,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
 
     // `c/zgeqp3` needs rwork
     void *rwork = NULL;
-    if (pivoting && detail::sp_type_traits<T>::is_complex) {
+    if (pivoting && detail::type_traits<T>::is_complex) {
         rwork = malloc(2 * N * sizeof(real_type));
 
         if (rwork == NULL) {

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -18,7 +18,7 @@ inline void solve_slice_general(
     CBLAS_INT N, CBLAS_INT NRHS, T *data, CBLAS_INT *ipiv, T *b_data, char trans, void *irwork, T *work,
     SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -34,7 +34,7 @@ inline void solve_slice_general(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
 
             // finally, solve
             call_getrs(&trans, &N, &NRHS, data, &N, ipiv, b_data, &N, &info);
@@ -54,7 +54,7 @@ inline void solve_slice_triangular(
     char uplo, char diag, CBLAS_INT N, CBLAS_INT NRHS, T *data,  T *b_data, char trans, T *work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -67,7 +67,7 @@ inline void solve_slice_triangular(
     if(info >= 0) {
         call_trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
             status.rcond = (double)rcond;
         }
     }
@@ -80,7 +80,7 @@ inline void solve_slice_cholesky(
     char uplo, CBLAS_INT N, CBLAS_INT NRHS, T *data, T *b_data, T* work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type rcond;
@@ -95,7 +95,7 @@ inline void solve_slice_cholesky(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
 
             // finally, solve
             call_potrs(&uplo, &N, &NRHS, data, &N, b_data, &N, &info);
@@ -116,7 +116,7 @@ void solve_slice_sym_herm(
     bool is_symm_not_herm,
     SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type rcond;
@@ -139,7 +139,7 @@ void solve_slice_sym_herm(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
 
             // finally, solve
             if (is_symm_not_herm) {
@@ -164,7 +164,7 @@ void solve_slice_tridiag(
     T *work, T *work2, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
     // work is 4*n, is for dl, d, du, du2
     // work2 is 2*n, is for trcon's work array
 
@@ -190,7 +190,7 @@ void solve_slice_tridiag(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
 
             // finally, solve
             call_gttrs(&trans, &N, &NRHS, dl, d, du, du2, ipiv, b_data, &N, &info);
@@ -209,7 +209,7 @@ inline void solve_slice_banded(
     char trans, CBLAS_INT N, CBLAS_INT NRHS, T *ab, CBLAS_INT *ipiv, T *b_data, T *work2, void *irwork,
     CBLAS_INT kl, CBLAS_INT ku, SliceStatus &status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT ldab = 2 * kl + ku + 1;
 
@@ -226,7 +226,7 @@ inline void solve_slice_banded(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::numeric_limits<real_type>::eps);
 
             // finally, solve
             call_gbtrs(&trans, &N, &kl, &ku, &NRHS, ab, &ldab, ipiv, b_data, &N, &info);
@@ -245,8 +245,8 @@ template<typename T>
 inline void solve_slice_diagonal(
     CBLAS_INT N, CBLAS_INT NRHS, T *data, T *b_data, SliceStatus& status
 ) {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
-    using value_type = typename detail::sp_type_traits<T>::value_type;
+    using real_type = typename detail::type_traits<T>::real_type;
+    using value_type = typename detail::type_traits<T>::value_type;
     value_type *pdata = reinterpret_cast<value_type *>(data);
     value_type *p_bdata = reinterpret_cast<value_type *>(b_data);
 
@@ -273,7 +273,7 @@ inline void solve_slice_diagonal(
         if(absa > maxa) {maxa = absa;}
         if(absinva > maxinva) {maxinva = absinva;}
     }
-    status.is_ill_conditioned = maxa * maxinva > 1./ detail::sp_numeric_limits<real_type>::eps;
+    status.is_ill_conditioned = maxa * maxinva > 1./ detail::numeric_limits<real_type>::eps;
     status.rcond = maxa * maxinva;
 }
 
@@ -284,7 +284,7 @@ template<typename T>
 int
 _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, char trans, int overwrite_a, int overwrite_b, SliceStatus slice_status, SliceStatusVec &vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using real_type = typename detail::type_traits<T>::real_type;
 
     CBLAS_INT info;
     npy_intp *ks = NULL; // For storage of the bandwidths
@@ -321,7 +321,7 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
     }
 
     void *irwork;
-    if constexpr (detail::sp_type_traits<T>::is_complex) {
+    if constexpr (detail::type_traits<T>::is_complex) {
         irwork = malloc(intn * sizeof(real_type));
     } else {
         irwork = malloc(intn * sizeof(CBLAS_INT));
@@ -426,7 +426,7 @@ template<typename T>
 int
 _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int lower, int transposed, int overwrite_a, int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     char trans = transposed ? 'T' : 'N';
     npy_intp lower_band = 0, upper_band = 0;
@@ -469,7 +469,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs, lwork=-1, info;
 
-    T tmp = detail::sp_numeric_limits<T>::zero;
+    T tmp = detail::numeric_limits<T>::zero;
     call_sytrf(&uplo, &intn, NULL, &intn, NULL, &tmp, &lwork, &info);
     if (info != 0) { info = -100; return (int)info; }
 
@@ -538,7 +538,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
-    if constexpr (detail::sp_type_traits<T>::is_complex) {
+    if constexpr (detail::type_traits<T>::is_complex) {
         irwork = malloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
@@ -605,12 +605,12 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
             } else {
                 // Check if symmetric/hermitian
                 std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
-                if (is_herm || (is_symm && !detail::sp_type_traits<T>::is_complex)) {
+                if (is_herm || (is_symm && !detail::type_traits<T>::is_complex)) {
                     // either real symmetric or complex hermitian; try Cholesky first,
                     // fall back to sym/her if it fails
                     slice_structure = St::POS_DEF;
                 }
-                else if (is_symm && detail::sp_type_traits<T>::is_complex) {
+                else if (is_symm && detail::type_traits<T>::is_complex) {
                     // complex symmetric, not hermitian
                     slice_structure = St::SYM;
                 }

--- a/scipy/linalg/src/_linalg_solve.hh
+++ b/scipy/linalg/src/_linalg_solve.hh
@@ -10,13 +10,15 @@
 #include "_common_array_utils.hh"
 
 
+namespace sp_linalg {
+
 // Dense array solve with getrf, gecon and getrs
 template<typename T>
 inline void solve_slice_general(
     CBLAS_INT N, CBLAS_INT NRHS, T *data, CBLAS_INT *ipiv, T *b_data, char trans, void *irwork, T *work,
     SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -32,7 +34,7 @@ inline void solve_slice_general(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             call_getrs(&trans, &N, &NRHS, data, &N, ipiv, b_data, &N, &info);
@@ -52,7 +54,7 @@ inline void solve_slice_triangular(
     char uplo, char diag, CBLAS_INT N, CBLAS_INT NRHS, T *data,  T *b_data, char trans, T *work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     char norm = '1';
@@ -65,7 +67,7 @@ inline void solve_slice_triangular(
     if(info >= 0) {
         call_trcon(&norm, &uplo, &diag, &N, data, &N, &rcond, work, irwork, &info);
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
             status.rcond = (double)rcond;
         }
     }
@@ -78,7 +80,7 @@ inline void solve_slice_cholesky(
     char uplo, CBLAS_INT N, CBLAS_INT NRHS, T *data, T *b_data, T* work, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type rcond;
@@ -93,7 +95,7 @@ inline void solve_slice_cholesky(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             call_potrs(&uplo, &N, &NRHS, data, &N, b_data, &N, &info);
@@ -114,7 +116,7 @@ void solve_slice_sym_herm(
     bool is_symm_not_herm,
     SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     real_type rcond;
@@ -137,7 +139,7 @@ void solve_slice_sym_herm(
 
         if (info >= 0) {
             status.rcond = (double)rcond;
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             if (is_symm_not_herm) {
@@ -162,7 +164,7 @@ void solve_slice_tridiag(
     T *work, T *work2, void *irwork,
     SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
     // work is 4*n, is for dl, d, du, du2
     // work2 is 2*n, is for trcon's work array
 
@@ -188,7 +190,7 @@ void solve_slice_tridiag(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             call_gttrs(&trans, &N, &NRHS, dl, d, du, du2, ipiv, b_data, &N, &info);
@@ -207,7 +209,7 @@ inline void solve_slice_banded(
     char trans, CBLAS_INT N, CBLAS_INT NRHS, T *ab, CBLAS_INT *ipiv, T *b_data, T *work2, void *irwork,
     CBLAS_INT kl, CBLAS_INT ku, SliceStatus &status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT ldab = 2 * kl + ku + 1;
 
@@ -224,7 +226,7 @@ inline void solve_slice_banded(
 
         status.rcond = (double)rcond;
         if (info >= 0) {
-            status.is_ill_conditioned = (rcond != rcond) || (rcond < sp_numeric_limits<real_type>::eps);
+            status.is_ill_conditioned = (rcond != rcond) || (rcond < detail::sp_numeric_limits<real_type>::eps);
 
             // finally, solve
             call_gbtrs(&trans, &N, &kl, &ku, &NRHS, ab, &ldab, ipiv, b_data, &N, &info);
@@ -243,8 +245,8 @@ template<typename T>
 inline void solve_slice_diagonal(
     CBLAS_INT N, CBLAS_INT NRHS, T *data, T *b_data, SliceStatus& status
 ) {
-    using real_type = typename sp_type_traits<T>::real_type;
-    using value_type = typename sp_type_traits<T>::value_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
+    using value_type = typename detail::sp_type_traits<T>::value_type;
     value_type *pdata = reinterpret_cast<value_type *>(data);
     value_type *p_bdata = reinterpret_cast<value_type *>(b_data);
 
@@ -271,7 +273,7 @@ inline void solve_slice_diagonal(
         if(absa > maxa) {maxa = absa;}
         if(absinva > maxinva) {maxinva = absinva;}
     }
-    status.is_ill_conditioned = maxa * maxinva > 1./ sp_numeric_limits<real_type>::eps;
+    status.is_ill_conditioned = maxa * maxinva > 1./ detail::sp_numeric_limits<real_type>::eps;
     status.rcond = maxa * maxinva;
 }
 
@@ -282,7 +284,7 @@ template<typename T>
 int
 _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, char trans, int overwrite_a, int overwrite_b, SliceStatus slice_status, SliceStatusVec &vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type;
+    using real_type = typename detail::sp_type_traits<T>::real_type;
 
     CBLAS_INT info;
     npy_intp *ks = NULL; // For storage of the bandwidths
@@ -319,7 +321,7 @@ _solve_assume_banded(PyArrayObject *ap_Am, PyArrayObject *ap_b, T *ret_data, cha
     }
 
     void *irwork;
-    if constexpr (sp_type_traits<T>::is_complex) {
+    if constexpr (detail::sp_type_traits<T>::is_complex) {
         irwork = malloc(intn * sizeof(real_type));
     } else {
         irwork = malloc(intn * sizeof(CBLAS_INT));
@@ -424,7 +426,7 @@ template<typename T>
 int
 _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int lower, int transposed, int overwrite_a, int overwrite_b, SliceStatusVec& vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
 
     char trans = transposed ? 'T' : 'N';
     npy_intp lower_band = 0, upper_band = 0;
@@ -467,7 +469,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, int_nrhs = (CBLAS_INT)nrhs, lwork=-1, info;
 
-    T tmp = sp_numeric_limits<T>::zero;
+    T tmp = detail::sp_numeric_limits<T>::zero;
     call_sytrf(&uplo, &intn, NULL, &intn, NULL, &tmp, &lwork, &info);
     if (info != 0) { info = -100; return (int)info; }
 
@@ -536,7 +538,7 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
 
     // {ge,po,tr}con need rwork or iwork
     void *irwork;
-    if constexpr (sp_type_traits<T>::is_complex) {
+    if constexpr (detail::sp_type_traits<T>::is_complex) {
         irwork = malloc(3*n*sizeof(real_type));   // {po,tr}con need at least 3*n
     } else {
         irwork = malloc(n*sizeof(CBLAS_INT));
@@ -603,12 +605,12 @@ _solve(PyArrayObject* ap_Am, PyArrayObject *ap_b, T* ret_data, St structure, int
             } else {
                 // Check if symmetric/hermitian
                 std::tie(is_symm, is_herm) = is_sym_or_herm(data, n);
-                if (is_herm || (is_symm && !sp_type_traits<T>::is_complex)) {
+                if (is_herm || (is_symm && !detail::sp_type_traits<T>::is_complex)) {
                     // either real symmetric or complex hermitian; try Cholesky first,
                     // fall back to sym/her if it fails
                     slice_structure = St::POS_DEF;
                 }
-                else if (is_symm && sp_type_traits<T>::is_complex) {
+                else if (is_symm && detail::sp_type_traits<T>::is_complex) {
                     // complex symmetric, not hermitian
                     slice_structure = St::SYM;
                 }
@@ -707,3 +709,6 @@ free_exit:
     free(ipiv);
     return 1;
 }
+
+
+} // namespace sp_linalg

--- a/scipy/linalg/src/_linalg_svd.hh
+++ b/scipy/linalg/src/_linalg_svd.hh
@@ -4,6 +4,8 @@
 #include "_common_array_utils.hh"
 
 
+namespace sp_linalg {
+
 /*
  * SVD size helper: if A.shape == (m, n),
  * U is either (m, m) or (m, k) and Vh is either (n, n) or (k, n)
@@ -45,7 +47,7 @@ template<typename T>
 int
 _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, int overwrite_a, SliceStatusVec& vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -85,13 +87,13 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, lwork = -1, info;
-    T tmp = sp_numeric_limits<T>::zero;
+    T tmp = detail::sp_numeric_limits<T>::zero;
 
     // query LWORK
     call_gesdd(&jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, NULL, &info);
     if (info != 0) { info = -100; return (int)info; }
 
-    lwork = (CBLAS_INT)(real_part(tmp));
+    lwork = (CBLAS_INT)(detail::real_part(tmp));
     if(lwork == 0) { lwork = 1; }
 
     /*
@@ -145,7 +147,7 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     }
 
     // rwork
-    if constexpr (sp_type_traits<T>::is_complex) {
+    if constexpr (detail::sp_type_traits<T>::is_complex) {
         // assume LAPACK > 3.6 (cf LAPACK docs on netlib.org)
         npy_intp lrwork = std::max(
             5*min_mn*min_mn + 5*min_mn,
@@ -209,7 +211,7 @@ template<typename T>
 int
 _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, int overwrite_a, SliceStatusVec& vec_status)
 {
-    using real_type = typename sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -248,13 +250,13 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, lwork = -1, info;
-    T tmp = sp_numeric_limits<T>::zero;
+    T tmp = detail::sp_numeric_limits<T>::zero;
 
     // query LWORK
     call_gesvd(&jobz, &jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, &info);
     if (info != 0) { info = -100; return (int)info; }
 
-    lwork = (CBLAS_INT)(real_part(tmp));
+    lwork = (CBLAS_INT)(detail::real_part(tmp));
     if(lwork == 0) { lwork = 1; }
 
     /*
@@ -298,7 +300,7 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     }
 
     real_type *rwork = NULL;
-    if constexpr (sp_type_traits<T>::is_complex) {
+    if constexpr (detail::sp_type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
         if (rwork == NULL) {
             free(buf);
@@ -368,3 +370,5 @@ _svd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObje
     }
     return info;
 }
+
+} // namespace sp_linalg

--- a/scipy/linalg/src/_linalg_svd.hh
+++ b/scipy/linalg/src/_linalg_svd.hh
@@ -47,7 +47,7 @@ template<typename T>
 int
 _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, int overwrite_a, SliceStatusVec& vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -87,7 +87,7 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, lwork = -1, info;
-    T tmp = detail::sp_numeric_limits<T>::zero;
+    T tmp = detail::numeric_limits<T>::zero;
 
     // query LWORK
     call_gesdd(&jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, NULL, &info);
@@ -147,7 +147,7 @@ _svd_gesdd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     }
 
     // rwork
-    if constexpr (detail::sp_type_traits<T>::is_complex) {
+    if constexpr (detail::type_traits<T>::is_complex) {
         // assume LAPACK > 3.6 (cf LAPACK docs on netlib.org)
         npy_intp lrwork = std::max(
             5*min_mn*min_mn + 5*min_mn,
@@ -211,7 +211,7 @@ template<typename T>
 int
 _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArrayObject *ap_Vh, char jobz, int overwrite_a, SliceStatusVec& vec_status)
 {
-    using real_type = typename detail::sp_type_traits<T>::real_type; // float if T==npy_cfloat etc
+    using real_type = typename detail::type_traits<T>::real_type; // float if T==npy_cfloat etc
     SliceStatus slice_status;
 
     // --------------------------------------------------------------------
@@ -250,7 +250,7 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     // Workspace computation and allocation
     // --------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)n, intm = (CBLAS_INT)m, lwork = -1, info;
-    T tmp = detail::sp_numeric_limits<T>::zero;
+    T tmp = detail::numeric_limits<T>::zero;
 
     // query LWORK
     call_gesvd(&jobz, &jobz, &intm, &intn, NULL, &intm, NULL, NULL, &ldu, NULL, &ldvh, &tmp, &lwork, NULL, &info);
@@ -300,7 +300,7 @@ _svd_gesvd(PyArrayObject* ap_Am, PyArrayObject *ap_U, PyArrayObject *ap_S, PyArr
     }
 
     real_type *rwork = NULL;
-    if constexpr (detail::sp_type_traits<T>::is_complex) {
+    if constexpr (detail::type_traits<T>::is_complex) {
         rwork = (real_type *)malloc(5*min_mn*sizeof(real_type));
         if (rwork == NULL) {
             free(buf);

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -16,10 +16,10 @@ namespace detail {
  * Numeric limits and useful constants for NumPy scalar types.
  */
 
-template<typename T> struct sp_numeric_limits {};
+template<typename T> struct numeric_limits {};
 
 template<>
-struct sp_numeric_limits<float>{
+struct numeric_limits<float>{
     static constexpr float zero = 0.0f;
     static constexpr float one = 1.0f;
     static constexpr float nan = std::numeric_limits<float>::quiet_NaN();
@@ -27,7 +27,7 @@ struct sp_numeric_limits<float>{
 };
 
 template<>
-struct sp_numeric_limits<double>{
+struct numeric_limits<double>{
     static constexpr double zero = 0.0;
     static constexpr double one = 1.0;
     static constexpr double nan = std::numeric_limits<double>::quiet_NaN();
@@ -36,7 +36,7 @@ struct sp_numeric_limits<double>{
 
 
 template<>
-struct sp_numeric_limits<npy_complex64>{
+struct numeric_limits<npy_complex64>{
     static constexpr npy_complex64 zero = {0.0f, 0.0f};
     static constexpr npy_complex64 one = {1.0f, 0.0f};
     static constexpr npy_complex64 nan = {std::numeric_limits<float>::quiet_NaN(),
@@ -44,7 +44,7 @@ struct sp_numeric_limits<npy_complex64>{
 };
 
 template<>
-struct sp_numeric_limits<npy_complex128>{
+struct numeric_limits<npy_complex128>{
     static constexpr npy_complex128 zero = {0.0, 0.0};
     static constexpr npy_complex128 one = {1.0, 0.0};
     static constexpr npy_complex128 nan = {std::numeric_limits<double>::quiet_NaN(),
@@ -61,8 +61,8 @@ struct sp_numeric_limits<npy_complex128>{
  *   - typenum: NumPy type number (NPY_FLOAT, NPY_DOUBLE, etc.)
  *   - is_complex: boolean indicating whether the type is complex
  */
-template<typename T> struct sp_type_traits {};
-template<> struct sp_type_traits<float> {
+template<typename T> struct type_traits {};
+template<> struct type_traits<float> {
     using real_type = float;
     using value_type = float;
     using npy_complex_type = npy_complex64;
@@ -70,21 +70,21 @@ template<> struct sp_type_traits<float> {
     static constexpr bool is_complex = false;
 
 };
-template<> struct sp_type_traits<double> {
+template<> struct type_traits<double> {
     using real_type = double;
     using value_type = double;
     using npy_complex_type = npy_complex128;
     static constexpr int typenum = NPY_DOUBLE;
     static constexpr bool is_complex = false;
 };
-template<> struct sp_type_traits<npy_complex64> {
+template<> struct type_traits<npy_complex64> {
     using real_type = float;
     using value_type = std::complex<float>;
     using npy_complex_type = npy_complex64;
     static constexpr int typenum = NPY_COMPLEX64;
     static constexpr bool is_complex = true;
 };
-template<> struct sp_type_traits<npy_complex128> {
+template<> struct type_traits<npy_complex128> {
     using real_type = double;
     using value_type = std::complex<double>;
     using npy_complex_type = npy_complex128;

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -8,6 +8,10 @@
 #include "numpy/npy_math.h"
 
 
+namespace sp_linalg {
+
+namespace detail {
+
 /*
  * Numeric limits and useful constants for NumPy scalar types.
  */
@@ -108,6 +112,10 @@ inline npy_complex128 conj(npy_complex128 value){return npy_cpack(npy_creal(valu
 // complex from two reals
 inline npy_complex64 cpack(float re, float im) {return npy_cpackf(re, im);}
 inline npy_complex128 cpack(double re, double im) {return npy_cpack(re, im);}
+
+} // namespace detail
+
+} // namespace sp_linalg
 
 
 /*

--- a/scipy/linalg/src/_npymath.hh
+++ b/scipy/linalg/src/_npymath.hh
@@ -20,8 +20,8 @@ template<typename T> struct sp_numeric_limits {};
 
 template<>
 struct sp_numeric_limits<float>{
-    static constexpr double zero = 0.0f;
-    static constexpr double one = 1.0f;
+    static constexpr float zero = 0.0f;
+    static constexpr float one = 1.0f;
     static constexpr float nan = std::numeric_limits<float>::quiet_NaN();
     static constexpr float eps = std::numeric_limits<float>::epsilon();
 };


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Hide linalg functions into a namespace, so that there is less risk for name shadowing; also prep for deduplicating functions like `bandwidth`, which are currently duplicated in `common_array_utils.h` and `.hh`. 

Also fix a typo which mixed up float and double in `numeric_limits`.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.