### PR TITLE
DOC: fix linalg tutorial claim that scipy.linalg contains all numpy.linalg

### DIFF
--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -20,9 +20,12 @@ scipy.linalg vs numpy.linalg
 
 .. TODO: replace numpy.linalg HTML link with `numpy.linalg` once NumPy updates doc
 
-:mod:`scipy.linalg` contains all the functions in
-`numpy.linalg <https://www.numpy.org/devdocs/reference/routines.linalg.html>`__.
-plus some other more advanced ones not contained in ``numpy.linalg``.
+:mod:`scipy.linalg` contains many of the functions in
+`numpy.linalg <https://www.numpy.org/devdocs/reference/routines.linalg.html>`__
+plus additional more advanced ones not contained in ``numpy.linalg``.
+Note that ``scipy.linalg`` does not expose every function from ``numpy.linalg``
+(e.g. ``numpy.linalg.matrix_rank``, ``numpy.linalg.matrix_power``), so both
+packages may be needed depending on your use case.
 
 Another advantage of using ``scipy.linalg`` over ``numpy.linalg`` is that
 it is always compiled with BLAS/LAPACK support, while for NumPy this is
@@ -30,7 +33,8 @@ optional. Therefore, the SciPy version might be faster depending on how
 NumPy was installed.
 
 Therefore, unless you don't want to add ``scipy`` as a dependency to
-your ``numpy`` program, use ``scipy.linalg`` instead of ``numpy.linalg``.
+your ``numpy`` program, prefer ``scipy.linalg`` over ``numpy.linalg`` for
+the functions that both packages provide.
 
 
 numpy.matrix vs 2-D numpy.ndarray

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -4513,10 +4513,13 @@ add_newdoc("kolmogorov",
     Kolmogorov distribution.
 
     Returns the complementary cumulative distribution function of
-    Kolmogorov's limiting distribution (``D_n*\sqrt(n)`` as n goes to infinity)
-    of a two-sided test for equality between an empirical and a theoretical
-    distribution. It is equal to the (limit as n->infinity of the)
-    probability that ``sqrt(n) * max absolute deviation > y``.
+    Kolmogorov's limiting distribution (``D_n * sqrt(n)`` as n goes to
+    infinity) of a two-sided test for equality between an empirical and a
+    theoretical distribution. Here ``D_n = max |F_n(x) - F(x)|`` is the
+    Kolmogorov-Smirnov statistic, where ``F_n`` is the empirical CDF of a
+    sample of size ``n`` and ``F`` is the target CDF. It is equal to the
+    (limit as n->infinity of the) probability that
+    ``sqrt(n) * max absolute deviation > y``.
 
     Parameters
     ----------
@@ -4541,9 +4544,14 @@ add_newdoc("kolmogorov",
     -----
     `kolmogorov` is used by `stats.kstest` in the application of the
     Kolmogorov-Smirnov Goodness of Fit test. For historical reasons this
-    function is exposed in `scpy.special`, but the recommended way to achieve
+    function is exposed in `scipy.special`, but the recommended way to achieve
     the most accurate CDF/SF/PDF/PPF/ISF computations is to use the
     `stats.kstwobign` distribution.
+
+    References
+    ----------
+    .. [1] "Kolmogorov-Smirnov test", Wikipedia,
+           https://en.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test
 
     Examples
     --------


### PR DESCRIPTION
Closes #24276.

`scipy.linalg` does not expose every `numpy.linalg` function (e.g. `matrix_rank`, `matrix_power`). Updated the tutorial to say "many of the functions" and note that both packages may be needed.