### PR TITLE
TYP: remove unnecessary `from __future__ import annotations`

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterable, Iterator
 from types import EllipsisType, GenericAlias, ModuleType, NotImplementedType
 from collections.abc import Callable

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Iterable, Iterator
 from types import EllipsisType, GenericAlias, ModuleType, NotImplementedType
 


### PR DESCRIPTION
#### Reference issue

#### What does this implement/fix?

Remove unnecessary `__future__.annotations` imports.

#### Additional information

https://docs.python.org/3/library/__future__.html#module-contents

#### AI Generation Disclosure

No AI tools used