### PR TITLE
MAINT: linalg: fix test_dtypes for "m" deprecation

### DIFF
--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2838,6 +2838,8 @@ class TestDTypes:
         # return a valid 2D array for the typecode
         if tcode == 'M':
             return np.eye(2, dtype='datetime64[ms]')
+        elif tcode == 'm':
+            return np.eye(2, dtype='timedelta64[ms]')
         elif tcode == 'V':
             return np.asarray([[b'a', b'b'], [b'c', b'd']], dtype='V')
         else:
@@ -2847,6 +2849,8 @@ class TestDTypes:
         # return a valid 1D array for the typecode
         if tcode == 'M':
             return np.ones(2, dtype='datetime64[ms]')
+        elif tcode =='m':
+            return np.ones(2, dtype='timedelta64[ms]')
         elif tcode == 'V':
             return np.asarray([b'a', b'b'], dtype='V')
         else:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/24943

#### What does this implement/fix?
<!--Please explain your changes.-->

Special-case typecode "m" in a test, to account for NumPy starting to require time units for timedelta arrays. The fix is as suggested by https://github.com/scipy/scipy/issues/24943#issuecomment-4156889981


#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai