### PR TITLE
CI: place upper limit on ccache size

### DIFF
--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -19,7 +19,9 @@ runs:
         echo "dir=${CCACHE_DIR:-$HOME/.ccache}" >> $GITHUB_OUTPUT
         NOW=$(date -u +"%F-%T")
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-        ccache --zero-stats
+        # Restoring the cache also restored the stats from the previous run
+        # Try to search for ccache on our path, or try pixi
+        pixi exec ccache --zero-stats || cache --zero-stats
     - name: Setup compiler cache and save it
       # Run a restore and save if running on main
       # Note: we can't simply use restore followed by save because composite actions

--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -21,7 +21,7 @@ runs:
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
         # Restoring the cache also restored the stats from the previous run
         # Try to search for ccache on our path, or try pixi
-        pixi exec ccache --zero-stats || cache --zero-stats
+        pixi exec ccache --zero-stats || ccache --zero-stats
     - name: Setup compiler cache and save it
       # Run a restore and save if running on main
       # Note: we can't simply use restore followed by save because composite actions

--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -19,6 +19,7 @@ runs:
         echo "dir=${CCACHE_DIR:-$HOME/.ccache}" >> $GITHUB_OUTPUT
         NOW=$(date -u +"%F-%T")
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
+        ccache --zero-stats
     - name: Setup compiler cache and save it
       # Run a restore and save if running on main
       # Note: we can't simply use restore followed by save because composite actions

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -66,3 +66,9 @@ jobs:
           for task in ${{ join(matrix.tasks, ' ') }}; do
             pixi run --skip-deps "$task" -- --durations 3 --timeout=60
           done
+
+      - name: Ccache performance
+        shell: bash -l {0}
+        run: |
+          ccache --evict-older-than 1d
+          ccache -s

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
+  CCACHE_MAXSIZE: "250M"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -70,5 +70,5 @@ jobs:
       - name: Ccache performance
         shell: bash -l {0}
         run: |
-          ccache --evict-older-than 1d
-          ccache -s
+          pixi exec ccache --evict-older-than 1d
+          pixi exec ccache -s

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -40,6 +40,7 @@ permissions:
 
 env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
+  CCACHE_MAXSIZE: "350M"
   PIXI_CACHE_DIR: "${{ github.workspace }}/.cache/rattler"
 
 concurrency:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,6 +15,7 @@ permissions:
 
 env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
+  CCACHE_MAXSIZE: "250M"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,7 +87,9 @@ jobs:
 
     - name: Ccache performance
       shell: bash -l {0}
-      run: ccache -s
+      run: |
+        ccache --evict-older-than 1d
+        ccache -s
 
     - name: Check installed files
       run: |
@@ -194,7 +196,9 @@ jobs:
 
     - name: Ccache performance
       shell: bash -l {0}
-      run: ccache -s
+      run: |
+        ccache --evict-older-than 1d
+        ccache -s
 
   #################################################################################
   python_debug:
@@ -280,7 +284,9 @@ jobs:
 
       - name: Ccache performance
         shell: bash -l {0}
-        run: ccache -s
+        run: |
+          ccache --evict-older-than 1d
+          ccache -s
 
       - name: Install test dependencies
         run: |
@@ -343,7 +349,9 @@ jobs:
 
     - name: Ccache performance
       shell: bash -l {0}
-      run: ccache -s
+      run: |
+        ccache --evict-older-than 1d
+        ccache -s
 
     - name: Downgrade NumPy to lowest supported
       run: |
@@ -439,7 +447,9 @@ jobs:
 
       - name: Ccache performance
         shell: bash -l {0}
-        run: ccache -s
+        run: |
+          ccache --evict-older-than 1d
+          ccache -s
 
       - name: Install test dependencies
         run: |
@@ -512,7 +522,9 @@ jobs:
 
       - name: Ccache performance
         shell: bash -l {0}
-        run: ccache -s
+        run: |
+          ccache --evict-older-than 1d
+          ccache -s
 
       - name: Run tests
         run: |
@@ -572,7 +584,9 @@ jobs:
 
     - name: Ccache performance
       shell: bash -l {0}
-      run: ccache -s
+      run: |
+        ccache --evict-older-than 1d
+        ccache -s
 
     - name: Run tests (full)
       if: ${{ matrix.parallel == '0'}}
@@ -727,4 +741,6 @@ jobs:
 
       - name: Ccache performance
         shell: bash -l {0}
-        run: ccache -s
+        run: |
+          ccache --evict-older-than 1d
+          ccache -s

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,6 +14,7 @@ permissions:
 
 env:
   INSTALLDIR: "build-install"
+  CCACHE_MAXSIZE: "250M"
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
 
 concurrency:


### PR DESCRIPTION
Lower ccache limit from 5GB to 250MB. I expect this to save about 2GB of cache space.

#### Reference issue

None filed.

#### What does this implement/fix?

ccache keeps old cache entries until one of two things happens:

* The cache exceeds 5 GB, in which case the oldest ccache cache entry is pruned.
* GitHub prunes the entire cache to keep total cache size under 10GB.

Consequently, each of the ccache cache entries is slowly growing over time, due to a small number of misses in each run, and will keep growing until they get big enough to get pruned by the second rule, or start pushing out other cache uses.

Here is a plot of Linux tests-test_venv_install-ccache-linux-*'s cache size over time.

<img width="728" height="300" alt="newplot(16)" src="https://github.com/user-attachments/assets/ff38f4fd-c5f6-4867-811f-eb5199011bf5" />

Therefore, reduce the limit on ccache max size. This also helps to address situations where repeated cache misses lead to rapid growths in cache size, like #24836.

This limit was arrived at by looking at past cache save operations, and finding the smallest one from a job which still succeeded. `test_venv` is the largest ccache user - other jobs are typically in the range of 70MB-200MB of legitimate use. I also considered providing a custom per-job CCACHE_MAXSIZE, but decided not to, because it sounded like a lot of work to keep up to date.

I allowed GPU CI to use 350M, because Cirrus cache space has never been a problem, and this one seems a bit bigger.

#### Additional information
<!--Any additional information you think is important.-->

I also added `ccache --zero-stats` to zero the ccache stats each run. Previously, the number of hits and misses was the sum of the hits and misses, counting previous runs. With this change, the number of hits and misses instead represents only the hits and misses which occurred in that run.

#### AI Generation Disclosure

No AI tools used.