### PR TITLE
DOC: clarify output size for different modes in scipy.signal.convolve

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -122,8 +122,9 @@ def correlate(in1, in2, mode='full', method='auto'):
            rely on the zero-padding. In 'valid' mode, either `in1` or `in2`
            must be at least as large as the other in every dimension.
         ``same``
-           The output is the same size as `in1`, centered
+           Output size will be ``N``, the same size as `in1`, centered
            with respect to the 'full' output.
+           Boundary effects may be visible.
     method : str {'auto', 'direct', 'fft'}, optional
         A string indicating which method to use to calculate the correlation.
 
@@ -615,8 +616,9 @@ def fftconvolve(in1, in2, mode="full", axes=None):
            rely on the zero-padding. In 'valid' mode, either `in1` or `in2`
            must be at least as large as the other in every dimension.
         ``same``
-           The output is the same size as `in1`, centered
+           Output size will be ``N``, the same size as `in1`, centered
            with respect to the 'full' output.
+           Boundary effects may be visible.
     axes : int or array_like of ints or None, optional
         Axes over which to compute the convolution.
         The default is over all axes.
@@ -626,6 +628,13 @@ def fftconvolve(in1, in2, mode="full", axes=None):
     out : array
         An N-dimensional array containing a subset of the discrete linear
         convolution of `in1` with `in2`.
+
+        The output size along each axis depends on ``mode``. For input
+        sizes ``N`` and ``M`` along a given axis:
+
+        - ``full`` : ``N + M - 1``
+        - ``same`` : ``N`` (same as the size of `in1`)
+        - ``valid`` : ``max(N, M) - min(N, M) + 1``
 
     See Also
     --------
@@ -867,8 +876,9 @@ def oaconvolve(in1, in2, mode="full", axes=None):
            rely on the zero-padding. In 'valid' mode, either `in1` or `in2`
            must be at least as large as the other in every dimension.
         ``same``
-           The output is the same size as `in1`, centered
+           Output size will be ``N``, the same size as `in1`, centered
            with respect to the 'full' output.
+           Boundary effects may be visible.
     axes : int or array_like of ints or None, optional
         Axes over which to compute the convolution.
         The default is over all axes.
@@ -878,6 +888,13 @@ def oaconvolve(in1, in2, mode="full", axes=None):
     out : array
         An N-dimensional array containing a subset of the discrete linear
         convolution of `in1` with `in2`.
+
+        The output size along each axis depends on ``mode``. For input
+        sizes ``N`` and ``M`` along a given axis:
+
+        - ``full`` : ``N + M - 1``
+        - ``same`` : ``N`` (same as the size of `in1`)
+        - ``valid`` : ``max(N, M) - min(N, M) + 1``
 
     See Also
     --------
@@ -1256,8 +1273,9 @@ def choose_conv_method(in1, in2, mode='full', measure=False):
            The output consists only of those elements that do not
            rely on the zero-padding.
         ``same``
-           The output is the same size as `in1`, centered
+           Output size will be ``N``, the same size as `in1`, centered
            with respect to the 'full' output.
+           Boundary effects may be visible.
     measure : bool, optional
         If True, run and time the convolution of `in1` and `in2` with both
         methods and return the fastest. If False (default), predict the fastest
@@ -1395,8 +1413,9 @@ def convolve(in1, in2, mode='full', method='auto'):
            rely on the zero-padding. In 'valid' mode, either `in1` or `in2`
            must be at least as large as the other in every dimension.
         ``same``
-           The output is the same size as `in1`, centered
+           Output size will be ``N``, the same size as `in1`, centered
            with respect to the 'full' output.
+           Boundary effects may be visible.
     method : str {'auto', 'direct', 'fft'}, optional
         A string indicating which method to use to calculate the convolution.
 
@@ -1417,6 +1436,13 @@ def convolve(in1, in2, mode='full', method='auto'):
     convolve : array
         An N-dimensional array containing a subset of the discrete linear
         convolution of `in1` with `in2`.
+
+        The output size along each axis depends on ``mode``. For input
+        sizes ``N`` and ``M`` along a given axis:
+
+        - ``full`` : ``N + M - 1``
+        - ``same`` : ``N`` (same as the size of `in1`)
+        - ``valid`` : ``max(N, M) - min(N, M) + 1``
 
     Warns
     -----


### PR DESCRIPTION

Closes #24949 

#### What does this implement/fix?
<!--Please explain your changes.-->
- Add output shape formulas to `scipy.signal.convolve` and related functions


#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
- yes i have used llm, to review after applying changes to check for consistency and for improvements in wording. 

Thanks! Please let me know if we need further improvements.
