### PR TITLE
DOC: add link to AI policy in CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -24,6 +24,6 @@ When submitting a pull request, we ask you to check the following:
    contributed files, or obtain permission from the original
    author to relicense the contributed code.
 
-3. That you have checked SciPy's **AI policy**,
-   https://scipy.github.io/devdocs/dev/conduct/ai_policy.html, and included the
+3. That your submission is compatible with SciPy's **AI policy**,
+   https://scipy.github.io/devdocs/dev/conduct/ai_policy.html, and includes the
    required AI declaration in the pull request description.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -23,3 +23,7 @@ When submitting a pull request, we ask you to check the following:
    license is compatible and include the license information in the
    contributed files, or obtain permission from the original
    author to relicense the contributed code.
+
+3. That you have checked SciPy's **AI policy**,
+   https://scipy.github.io/devdocs/dev/conduct/ai_policy.html, and included the
+   required AI declaration in the pull request description.


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Adds a link to the AI policy in `CONTRIBUTING.rst`.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI