### PR TITLE
CI: fix issue with pkgconf-pypi no longer finding openblas

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Build
         run: |
+          $env:FORCE_PKGCONF_PYPI=1
           spin build --with-scipy-openblas
 
       - name: Test


### PR DESCRIPTION
This is a band aid to fix CI. This should probably be done better in a follow-up, integrating this in `.spin/cmds.py`.

See https://github.com/pypackaging-native/pkgconf-pypi/pull/106 for context


#### AI Generation Disclosure

No AI tools used