### PR TITLE
DOC: linalg: discuss/illustrate `overwrite_a` arguments

### DIFF
--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -981,10 +981,12 @@ the batch shape of the input is ``()``). For more information, see :doc:`linalg_
 ``overwrite_*`` arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Many linear algebra functions have ``overwrite_a`` arguments to signal that an operation
-is allowed to work in-place and overwrite the input array.
+Many linear algebra functions have ``overwrite_*`` arguments to signal that an operation
+is allowed to work in-place and overwrite the input array (the naming convention is
+that an array argument ``a`` has a matching ``overwrite_a``; a ``b`` argument has a
+matching ``overwrite_b`` and so on).
+ 
 By default, ``scipy.linalg`` functions preserve their inputs and make copies internally.
-
 In some cases, working in-place may improve performance or avoid running out of memory---
 it is however advisable to measure and make sure you actually see improvements
 for your specific workloads. 

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -975,4 +975,90 @@ In these cases, the final shape of the output is the batch shape of the input
 concatenated with the core shape of the output (i.e., the shape of the output when
 the batch shape of the input is ``()``). For more information, see :doc:`linalg_batch`.
 
+
+.. _tutorial_linalg_overwrite:
+
+``overwrite_X`` arguments
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Many linear algebra functions have ``overwrite_a`` arguments to signal that an operation
+is allowed to work in-place and overwrite the input array.
+By default, ``scipy.linalg`` functions preserve their inputs and make copies internally.
+
+In some cases, working in-place may improve performance or avoid running out of memory---
+it is however advisable to measure and make sure you actually see improvements
+for your specific workloads. 
+
+Note however that setting ``overwrite_a=True`` only indicates that it *may* work in-place;
+whether it actually *does* depends on whether additional requirements are met.
+For most functions, an in-place operation requires that all of the following conditions
+are true:
+
+- the dtype of the input array is LAPACK-compatible: only single and double precision
+  float (``float{32, 64}``) and complex (``complex{64,128}``) arrays are compatible;
+- the array is Fortran-ordered;
+- currently only two-dimensional arrays, ``ndim == 2``, are compatible; batched arrays
+  use an internal buffer of the size of the core shaped array. This however may change
+  in a future SciPy version. 
+
+If any of these conditions is violated, a copy is made under the hood, regardless of
+whether `overwrite_a` is ``True`` or ``False``.
+
+Some functions may relax some of these requirements or impose additional constraints
+for working in-place.
+
+Note that this all is completely opaque: if you set ``overwrite_a=True`` but the
+function has to operate on a copy, no warnings or diagnostic output will be generated.
+
+As an illustration, consider a simple inversion operation:
+
+>>> import numpy as np
+>>> from scipy.linalg import inv
+>>> a = np.asarray([[2, 1], [0, 1]])
+>>> a_inv = inv(a)
+>>> a_inv
+array([[ 0.5, -0.5],
+       [ 0. ,  1. ]])
+>>> a
+array([[2, 1],
+       [0, 1]])
+
+Since ``a`` is of integer dtype, the `scipy.linalg.inv` function internally makes a
+floating-point copy, which it feeds into the LAPACK's inversion routine. Thus setting
+``overwrite_a`` to ``True`` makes no difference:
+
+>>> a_inv = inv(a, overwrite_a=True)
+>>> a_inv
+array([[ 0.5, -0.5],
+       [ 0. ,  1. ]])
+>>> a
+array([[2, 1],
+       [0, 1]])
+
+To force it work in-place, we need to manually convert the ``a`` array to be
+Fortran-ordered and dtype-compatible:
+
+>>> af = np.asarray(a, order='F', dtype=np.float64)
+>>> a_inv = inv(af, overwrite_a=True)
+>>> a_inv
+array([[ 0.5, -0.5],
+       [ 0. ,  1. ]])
+>>> af
+array([[ 0.5, -0.5],
+       [ 0. ,  1. ]])
+
+Note that the input array, ``af``, has now been overwritten. We can check that the
+input and output arrays actually use the same memory buffer:
+
+>>> np.shares_memory(af, a_inv)
+True
+
+In general, it may or may not hold that ``a_inv is af``: the only guarantee is
+that inputs and outputs share *some* part of the memory buffer.
+
+Finally, we recommend that you only use these ``overwrite_a`` arguments if
+performance / memory measurements show a significant improvement. In the vast
+majority of usages, adding them is a premature optimization.
+
+
 .. _book: https://www.press.jhu.edu/books/title/10678/matrix-computations

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -978,7 +978,7 @@ the batch shape of the input is ``()``). For more information, see :doc:`linalg_
 
 .. _tutorial_linalg_overwrite:
 
-``overwrite_X`` arguments
+``overwrite_*`` arguments
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Many linear algebra functions have ``overwrite_a`` arguments to signal that an operation

--- a/doc/source/tutorial/linalg.rst
+++ b/doc/source/tutorial/linalg.rst
@@ -997,13 +997,13 @@ For most functions, an in-place operation requires that all of the following con
 are true:
 
 - the dtype of the input array is LAPACK-compatible: only single and double precision
-  float (``float{32, 64}``) and complex (``complex{64,128}``) arrays are compatible;
+  float (``float{32,64}``) and complex (``complex{64,128}``) arrays are compatible;
 - the array is Fortran-ordered;
 - currently only two-dimensional arrays, ``ndim == 2``, are compatible; batched arrays
   use an internal buffer of the size of the core shaped array. This however may change
   in a future SciPy version. 
 
-If any of these conditions is violated, a copy is made under the hood, regardless of
+If any of these conditions are violated, a copy is made under the hood, regardless of
 whether `overwrite_a` is ``True`` or ``False``.
 
 Some functions may relax some of these requirements or impose additional constraints

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -306,6 +306,7 @@ def solve_triangular(a, b, trans=0, lower=False, unit_diagonal=False,
         will not be referenced.
     overwrite_b : bool, optional
         Allow overwriting data in `b` (may enhance performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -421,8 +422,10 @@ def solve_banded(l_and_u, ab, b, overwrite_ab=False, overwrite_b=False,
         Right-hand side
     overwrite_ab : bool, optional
         Discard data in `ab` (may enhance performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
         Discard data in `b` (may enhance performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -560,8 +563,10 @@ def solveh_banded(ab, b, overwrite_ab=False, overwrite_b=False, lower=False,
         Right-hand side
     overwrite_ab : bool, optional
         Discard data in `ab` (may enhance performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
         Discard data in `b` (may enhance performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     lower : bool, optional
         Is the matrix in the lower form. (Default is upper form)
     check_finite : bool, optional

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -93,10 +93,12 @@ def solve(a, b, lower=False, overwrite_a=False,
         entries above the diagonal are ignored. If False (default), the
         calculation uses only the data in the upper triangle of `a`; entries
         below the diagonal are ignored.
-    overwrite_a : bool, default: False
-        Allow overwriting data in `a` (may enhance performance).
-    overwrite_b : bool, default: False
-        Allow overwriting data in `b` (may enhance performance).
+    overwrite_a : bool, optional
+        Allow overwriting data in `a` (may enhance performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
+    overwrite_b : bool, optional
+        Allow overwriting data in `b` (may enhance performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, default: True
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -1003,6 +1005,7 @@ def inv(a, overwrite_a=False, check_finite=True, *, assume_a=None, lower=False):
         Square matrix (or a batch of matrices) to be inverted.
     overwrite_a : bool, optional
         Discard data in `a` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -1131,6 +1134,7 @@ def det(a, overwrite_a=False, check_finite=True):
         Input array to compute determinants for.
     overwrite_a : bool, optional
         Allow overwriting data in a (may enhance performance).
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -1245,9 +1249,11 @@ def lstsq(a, b, cond=None, overwrite_a=False, overwrite_b=False,
         rank of a. Singular values smaller than
         ``cond * largest_singular_value`` are considered zero.
     overwrite_a : bool, optional
-        Discard data in `a` (may enhance performance). Default is False.
+        Whether to overwrite data in `a` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
-        Discard data in `b` (may enhance performance). Default is False.
+        Whether to overwrite data in `b` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -1711,6 +1717,7 @@ def matrix_balance(A, permute=True, scale=True, separate=False,
         This is passed to xGEBAL directly. Essentially, overwrites the result
         to the data. It might increase the space efficiency. See LAPACK manual
         for details. This is False by default.
+        See :ref:`tutorial_linalg_overwrite` for details.
 
     Returns
     -------

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -90,6 +90,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         Whether to calculate and return right eigenvectors.  Default is True.
     overwrite_a : bool, optional
         Whether to overwrite `a`; may improve performance.  Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
         Whether to overwrite `b`; may improve performance.  Default is False.
     check_finite : bool, optional
@@ -338,6 +339,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         (Default: both are calculated)
     overwrite_a : bool, optional
         Whether to overwrite data in ``a`` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
         Whether to overwrite data in ``b`` (may improve performance). Default is False.
     type : int, optional
@@ -876,9 +878,10 @@ def eigvals(a, b=None, overwrite_a=False, overwrite_b=False, check_finite=True,
         Right-hand side matrix (or a stack of matrices) in a generalized eigenvalue
         problem. If omitted (default), identity matrix is assumed.
     overwrite_a : bool, optional
-        Whether to overwrite data in a (may improve performance)
+        Whether to overwrite data in a (may improve performance). Default is False.
     overwrite_b : bool, optional
-        Whether to overwrite data in b (may improve performance)
+        Whether to overwrite data in b (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -988,8 +991,8 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
         Whether the pertinent array data is taken from the lower or upper
         triangle of ``a`` and, if applicable, ``b``. (Default: lower)
     overwrite_a : bool, optional
-        Whether to overwrite data in ``a`` (may improve performance). Default
-        is False.
+        Whether to overwrite data in ``a`` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
         Whether to overwrite data in ``b`` (may improve performance). Default
         is False.
@@ -1465,8 +1468,8 @@ def hessenberg(a, calc_q=False, overwrite_a=False, check_finite=True):
     calc_q : bool, optional
         Whether to compute the transformation matrix.  Default is False.
     overwrite_a : bool, optional
-        Whether to overwrite `a`; may improve performance.
-        Default is False.
+        Whether to overwrite `a`; may improve performance. Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -93,6 +93,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
         Whether to overwrite `b`; may improve performance.  Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -342,6 +343,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
         Whether to overwrite data in ``b`` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     type : int, optional
         For the generalized problems, this keyword specifies the problem type
         to be solved for ``w`` and ``v`` (only takes 1, 2, 3 as possible
@@ -724,6 +726,7 @@ def eig_banded(a_band, lower=False, eigvals_only=False, overwrite_a_band=False,
         (Default: calculate also eigenvectors)
     overwrite_a_band : bool, optional
         Discard data in a_band (may enhance performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     select : {'a', 'v', 'i'}, optional
         Which eigenvalues to calculate
 
@@ -996,6 +999,7 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
     overwrite_b : bool, optional
         Whether to overwrite data in ``b`` (may improve performance). Default
         is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     type : int, optional
         For the generalized problems, this keyword specifies the problem type
         to be solved for ``w`` and ``v`` (only takes 1, 2, 3 as possible
@@ -1121,6 +1125,7 @@ def eigvals_banded(a_band, lower=False, overwrite_a_band=False,
         Is the matrix in the lower form. (Default is upper form)
     overwrite_a_band : bool, optional
         Discard data in a_band (may enhance performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     select : {'a', 'v', 'i'}, optional
         Which eigenvalues to calculate
 

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -69,7 +69,8 @@ def cholesky(a, lower=False, overwrite_a=False, check_finite=True):
         factorization. During decomposition, only the selected half of the
         matrix is referenced. Default is upper-triangular.
     overwrite_a : bool, optional
-        Whether to overwrite data in `a` (may improve performance).
+        Whether to overwrite data in `a` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the entire input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -143,7 +144,8 @@ def cho_factor(a, lower=False, overwrite_a=False, check_finite=True):
         During decomposition, only the selected half of the matrix is referenced.
         (Default: upper-triangular)
     overwrite_a : bool, optional
-        Whether to overwrite data in a (may improve performance)
+        Whether to overwrite data in ``a`` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the entire input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -236,6 +236,7 @@ def cho_solve(c_and_lower, b, overwrite_b=False, check_finite=True):
         Right-hand side
     overwrite_b : bool, optional
         Whether to overwrite data in b (may improve performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -323,6 +324,7 @@ def cholesky_banded(ab, overwrite_ab=False, lower=False, check_finite=True):
         Banded matrix
     overwrite_ab : bool, optional
         Discard data in ab (may enhance performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     lower : bool, optional
         Is the matrix in the lower form. (Default is upper form)
     check_finite : bool, optional
@@ -395,6 +397,7 @@ def cho_solve_banded(cb_and_lower, b, overwrite_b=False, check_finite=True):
         Right-hand side
     overwrite_b : bool, optional
         If True, the function will overwrite the values in `b`.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems

--- a/scipy/linalg/_decomp_ldl.py
+++ b/scipy/linalg/_decomp_ldl.py
@@ -48,6 +48,7 @@ def ldl(A, lower=True, hermitian=True, overwrite_a=False, check_finite=True):
     overwrite_a : bool, optional
         Allow overwriting data in `A` (may enhance performance). The default
         is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -33,7 +33,8 @@ def lu_factor(a, overwrite_a=False, check_finite=True):
     a : (M, N) array_like
         Matrix to decompose
     overwrite_a : bool, optional
-        Whether to overwrite data in A (may increase performance)
+        Whether to overwrite data in ``a`` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -237,7 +238,8 @@ def lu(a, permute_l=False, overwrite_a=False, check_finite=True,
     permute_l : bool, optional
         Perform the multiplication P*L (Default: do not permute)
     overwrite_a : bool, optional
-        Whether to overwrite data in a (may improve performance)
+        Whether to overwrite data in a (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems

--- a/scipy/linalg/_decomp_lu.py
+++ b/scipy/linalg/_decomp_lu.py
@@ -158,6 +158,7 @@ def lu_solve(lu_and_piv, b, trans=0, overwrite_b=False, check_finite=True):
         =====  =========
     overwrite_b : bool, optional
         Whether to overwrite data in b (may increase performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrices contain only finite numbers.
         Disabling may give a performance gain, but may result in problems

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -272,6 +272,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         Whether data in c is overwritten (may improve performance).
         If this is used, c must be big enough to keep the result,
         i.e. ``c.shape[0]`` = ``a.shape[0]`` if mode is 'left'.
+        See :ref:`tutorial_linalg_overwrite` for details.
 
     Returns
     -------

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -42,9 +42,8 @@ def qr(a, overwrite_a=False, lwork=_NoValue, mode="full", pivoting=False,
     a : (..., M, N) array_like
         Matrix to be decomposed
     overwrite_a : bool, optional
-        Whether data in `a` is overwritten (may improve performance if
-        `overwrite_a` is set to True by reusing the existing input data
-        structure rather than creating a new one.)
+        Whether to overwrite data in `a` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     lwork : int, optional
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
@@ -267,7 +266,8 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
         Whether Q should be complex-conjugated. This might be faster
         than explicit conjugation.
     overwrite_a : bool, optional
-        Whether data in a is overwritten (may improve performance)
+        Whether to overwrite data in `a` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_c : bool, optional
         Whether data in c is overwritten (may improve performance).
         If this is used, c must be big enough to keep the result,
@@ -405,7 +405,8 @@ def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
     a : (M, N) array_like
         Matrix to be decomposed
     overwrite_a : bool, optional
-        Whether data in a is overwritten (may improve performance)
+        Whether to overwrite data in `a` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     lwork : int, optional
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -201,8 +201,10 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
         Defaults to None (no sorting).
     overwrite_a : bool, optional
         Whether to overwrite data in a (may improve performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
         Whether to overwrite data in b (may improve performance)
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         If true checks the elements of `A` and `B` are finite numbers. If
         false does no checking and passes matrix through to
@@ -357,8 +359,10 @@ def ordqz(A, B, sort='lhp', output='real', overwrite_a=False,
         Default is 'real'.
     overwrite_a : bool, optional
         If True, the contents of A are overwritten.
+        See :ref:`tutorial_linalg_overwrite` for details.
     overwrite_b : bool, optional
         If True, the contents of B are overwritten.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         If true checks the elements of `A` and `B` are finite numbers. If
         false does no checking and passes matrix through to

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -42,6 +42,7 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
         Work array size. If None or -1, it is automatically computed.
     overwrite_a : bool, optional
         Whether to overwrite data in a (may improve performance).
+        See :ref:`tutorial_linalg_overwrite` for details.
     sort : {None, callable, 'lhp', 'rhp', 'iuc', 'ouc'}, optional
         Specifies whether the upper eigenvalues should be sorted. A callable
         may be passed that, given an eigenvalue, returns a boolean denoting

--- a/scipy/linalg/_decomp_svd.py
+++ b/scipy/linalg/_decomp_svd.py
@@ -56,8 +56,8 @@ def svd(a, full_matrices=True, compute_uv=True, overwrite_a=False,
         Whether to compute also ``U`` and ``Vh`` in addition to ``s``.
         Default is True.
     overwrite_a : bool, optional
-        Whether to overwrite `a`; may improve performance.
-        Default is False.
+        Whether to overwrite data in `a` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -220,8 +220,8 @@ def svdvals(a, overwrite_a=False, check_finite=True):
     a : (M, N) array_like
         Matrix to decompose.
     overwrite_a : bool, optional
-        Whether to overwrite `a`; may improve performance.
-        Default is False.
+        Whether to overwrite data in `a` (may improve performance). Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems
@@ -417,8 +417,8 @@ def null_space(A, rcond=None, *, overwrite_a=False, check_finite=True,
         ``rcond * max(s)`` are considered zero.
         Default: floating point eps * max(M,N).
     overwrite_a : bool, optional
-        Whether to overwrite `a`; may improve performance.
-        Default is False.
+        Whether to overwrite `a`; may improve performance. Default is False.
+        See :ref:`tutorial_linalg_overwrite` for details.
     check_finite : bool, optional
         Whether to check that the input matrix contains only finite numbers.
         Disabling may give a performance gain, but may result in problems


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/24645

closes https://github.com/scipy/scipy/issues/21456

#### What does this implement/fix?
<!--Please explain your changes.-->

Address the doc improvement request of https://github.com/scipy/scipy/pull/24442#issuecomment-3939666173 : add a short discussion of `overwrite_X` parameters under the linalg tutorial "advanced features" rubric, and link to it from docstrings of individual functions.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I added the tutorial link to several docstrings and asked Claude Sonnet via Copilot to go add the same link where missing. 