### PR TITLE
CI: move c-cpp build mode to manual for codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,6 +85,7 @@ jobs:
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     - if: matrix.build-mode == 'manual'
+      name: Install dependencies and build SciPy
       shell: bash
       run: |
         git submodule update --init

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main", "maintenance/*", "maintenance/0.10.x", "maintenance/0.11.x", "maintenance/0.12.x", "maintenance/0.13.x", "maintenance/0.14.x", "maintenance/0.15.x", "maintenance/0.16.x", "maintenance/0.17.x", "maintenance/0.18.x", "maintenance/0.19.x", "maintenance/0.5.2.x", "maintenance/0.6.x", "maintenance/0.7.x", "maintenance/0.8.x", "maintenance/0.9.x", "maintenance/1.0.x", "maintenance/1.1.x", "maintenance/1.2.x", "maintenance/1.3.x", "maintenance/1.4.x", "maintenance/1.5.x", "maintenance/1.6.x" ]
+    branches: [ "main"]
   pull_request:
-    branches: [ "main", "maintenance/*", "maintenance/0.10.x", "maintenance/0.11.x", "maintenance/0.12.x", "maintenance/0.13.x", "maintenance/0.14.x", "maintenance/0.15.x", "maintenance/0.16.x", "maintenance/0.17.x", "maintenance/0.18.x", "maintenance/0.19.x", "maintenance/0.5.2.x", "maintenance/0.6.x", "maintenance/0.7.x", "maintenance/0.8.x", "maintenance/0.9.x", "maintenance/1.0.x", "maintenance/1.1.x", "maintenance/1.2.x", "maintenance/1.3.x", "maintenance/1.4.x", "maintenance/1.5.x", "maintenance/1.6.x" ]
+    branches: [ "main"]
   schedule:
     - cron: '33 21 * * 3'
 
@@ -48,7 +48,7 @@ jobs:
         - language: actions
           build-mode: none
         - language: c-cpp
-          build-mode: none
+          build-mode: manual
         - language: python
           build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
@@ -91,12 +91,11 @@ jobs:
     - if: matrix.build-mode == 'manual'
       shell: bash
       run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+        git submodule update --init
+        sudo apt update
+        sudo apt install -y gcc g++ gfortran libopenblas-dev liblapack-dev pkg-config python3-pip python3-dev
+        python -m pip install -r requirements/build.txt -r requirements/dev.txt
+        spin build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,6 +97,13 @@ jobs:
         python -m pip install -r requirements/build.txt -r requirements/dev.txt
         spin build
 
+    - if: matrix.language == 'c-cpp'
+      name: Work around CodeQL C++ trap cache finalize crash (ensure tarballs dir exists)
+      shell: bash
+      run: |
+        set -euxo pipefail
+        mkdir -p "${RUNNER_TEMP}/trapCaches/cpp/tarballs"
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@c793b717bc78562f491db7b0e93a3a178b099162 # v4.32.5
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,11 +13,7 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main"]
-  pull_request:
-    branches: [ "main"]
-  schedule:
-    - cron: '33 21 * * 3'
+    branches: ["main"]
 
 permissions: {}
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-24957

#### What does this implement/fix?
The previous setting for the codeql workflow used the default settings for `c-cpp` to compile the c/c++ code in the scipy repo. The contents of this script (`autobuild.sh`) are not open source so it is difficult to debug the issues noted. However, for compiled languages you can provide your own custom build. This PR implements the custom build via `spin build`. The github actions run on ubuntu so this works as expected to build the entire repo's c/c++ code. 

The codeql action currently is running on the maintenance branches and we really only need them to run on `main`. This PR reduces the event generation to main branch only.

#### Additional information
The goal of this PR is to stop the codeql workflows from failing and to reduce the surface on which they run. 

The custom build takes much longer than the previous autobuild script. Inquiring led to the conclusion that we cannot currently use caching (e.g. `ccache`) for compiled code in codeql to reduce the runtimes. There are mechanisms to be more selective in running the codeql queries if we think certain codeql queries are not relevant. 
The filtering of queries can be handled in an advanced setup PR (in progress) which would be different from this PR.

#### AI Generation Disclosure
AI copilot was used to do initial background research only-the code written here is not AI generated. 