### PR TITLE
MAINT: linalg.qr: re-enable `overwrite_a`

### DIFF
--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -214,6 +214,7 @@ def qr(a, overwrite_a=False, lwork=_NoValue, mode="full", pivoting=False,
         a1 = a1.copy()
 
     overwrite_a = overwrite_a or (_datacopied(a1, a))
+    overwrite_a = overwrite_a and (a1.ndim == 2) and a1.flags["F_CONTIGUOUS"]
 
     # heavy lifting
     Q, R, tau, jpvt, err_lst = _batched_linalg._qr(a1, overwrite_a, modeFlag, pivoting)
@@ -227,10 +228,12 @@ def qr(a, overwrite_a=False, lwork=_NoValue, mode="full", pivoting=False,
     else:
         Rj = (R,)
 
-    if mode == "raw":
+    if modeFlag == modes["raw"]:
         Q = (Q, tau)
+    elif modeFlag == modes["economic"] and M < N:
+        Q = Q[..., :, :M]
 
-    if mode == "r":
+    if modeFlag == modes["r"]:
         return Rj
     else:
         return (Q,) + Rj

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -304,7 +304,25 @@ _linalg_qr(PyObject* Py_UNUSED(dummy), PyObject* args) {
         }
     }
 
-    if (mode != QR_mode::R) { // Allocate Q if needed, if `mode == raw`, F-ordered array is required.
+    /*
+     * Allocation strategy:
+     *
+     * - Q: always needed except if `mode == r`. In the case that `mode == economic` or `mode == raw`
+     *      the input buffer can be re-used if `overwrite_a` is set. (Albeit that it is possible that
+     *      if M < N `Q` will have to be shrunk down at the python side to become `M x M`.)
+     *
+     *      An additional comment is that `Q` is returned with F-ordered slices for `mode == raw` as its
+     *      output is destined to be fed into LAPACK, allowing fast-paths in memory copies.
+     *
+     * - R: always needed. If `mode == raw` or `mode == economic` a new array is always allocated for this.
+     *      For the other two modes the input buffer can be re-used if `overwrite_a` is set.
+     *
+     * - tau: only allocated if `mode == raw`. Else a temporary buffer is allocated in the main loop as the
+     *        reflectors shouldn't be stored anyways.
+     *
+     * - jpvt: only allocated if `pivoting` is set.
+     */
+    if (mode != QR_mode::R) {
         if (!overwrite_a || mode == QR_mode::FULL) {
             ap_Q = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_Q, typenum);
             if (!ap_Q) {
@@ -343,8 +361,7 @@ _linalg_qr(PyObject* Py_UNUSED(dummy), PyObject* args) {
          *
          * Dimensions other than the last two are not affected so slice computation etc. stays intact.
          *
-         * This step is bypassed if `overwrite_a` is set since this flag is only enabled when the input is 2D and F-ordered,
-         * so swapping around the strides does not make a difference then.
+         * Since `overwrite_a` is only enabled when the input has F-ordered slices, this is not necessary in that case.
          */
         if (!overwrite_a) {
             npy_intp *strides_Q = PyArray_STRIDES(ap_Q);

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -305,17 +305,28 @@ _linalg_qr(PyObject* Py_UNUSED(dummy), PyObject* args) {
     }
 
     if (mode != QR_mode::R) { // Allocate Q if needed, if `mode == raw`, F-ordered array is required.
-        ap_Q = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_Q, typenum);
-        if (!ap_Q) {
-            PyErr_NoMemory();
-            goto fail_qr;
+        if (!overwrite_a || mode == QR_mode::FULL) {
+            ap_Q = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_Q, typenum);
+            if (!ap_Q) {
+                PyErr_NoMemory();
+                goto fail_qr;
+            }
+        } else {
+            Py_INCREF(ap_A);
+            ap_Q = ap_A;
         }
     }
 
-    ap_R = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_R, typenum);
-    if (!ap_R) {
-        PyErr_NoMemory();
-        goto fail_qr;
+    if (mode == QR_mode::RAW_MODE || mode == QR_mode::ECONOMIC || (!overwrite_a && (mode == QR_mode::R || mode == QR_mode::FULL))) {
+        // Return C-ordered object, hence `0` flag. Already pre-fill with zeros for efficiency.
+        ap_R = (PyArrayObject *)PyArray_ZEROS(ndim, shape_R, typenum, 0);
+        if (!ap_R) {
+            PyErr_NoMemory();
+            goto fail_qr;
+        }
+    } else {
+        Py_INCREF(ap_A);
+        ap_R = ap_A;
     }
 
     if (mode == QR_mode::RAW_MODE) {
@@ -331,14 +342,19 @@ _linalg_qr(PyObject* Py_UNUSED(dummy), PyObject* args) {
          * set the strides of `Q` to return F-ordered slices.
          *
          * Dimensions other than the last two are not affected so slice computation etc. stays intact.
+         *
+         * This step is bypassed if `overwrite_a` is set since this flag is only enabled when the input is 2D and F-ordered,
+         * so swapping around the strides does not make a difference then.
          */
-        npy_intp *strides_Q = PyArray_STRIDES(ap_Q);
-        int sizeof_T = PyArray_ITEMSIZE(ap_Q);
+        if (!overwrite_a) {
+            npy_intp *strides_Q = PyArray_STRIDES(ap_Q);
+            int sizeof_T = PyArray_ITEMSIZE(ap_Q);
 
-        strides_Q[ndim-2] = sizeof_T;
-        strides_Q[ndim-1] = M * sizeof_T;
+            strides_Q[ndim-2] = sizeof_T;
+            strides_Q[ndim-1] = M * sizeof_T;
 
-        PyArray_UpdateFlags(ap_Q, NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
+            PyArray_UpdateFlags(ap_Q, NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_F_CONTIGUOUS);
+        }
     }
 
     // Set all elements to 0 immediately as the pivots are also used as inputs in `geqp3`.

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1097,7 +1097,9 @@ void copy_slice_F_to_C(T* dst, const T* src, const npy_intp n, const npy_intp m,
 
 
 /*
- * Copy one triangle of a strided n-by-n `src` to C-ordered `dst`.
+ * Copy one triangle of a strided m-by-n `src` to C-ordered `dst`.
+ * Note that by specifying m and/or n smaller than the input array `src`
+ * it is possible to only copy a subset of the triangle.
  *
  * Only elements in the `uplo` triangle are copied;
  * `dst` is assumed zero-initialized for the other triangle.
@@ -1106,48 +1108,26 @@ void copy_slice_F_to_C(T* dst, const T* src, const npy_intp n, const npy_intp m,
  * triangle specified by `uplo`. The caller is responsible for ensuring
  * that the correct triangle is populated in `src`.
  *
- * Examples:
- *   C-contiguous src (s0=n, s1=1): src[i*n + j] -> dst[i*n + j],
- *       both sequential in the inner loop — effectively a partial memcpy.
- *   F-contiguous src (s0=1, s1=n): src[i + j*n] -> dst[i*n + j],
- *       column-sequential reads, row-sequential writes.
+ * Examples (matrix dimension m x n):
+ *   C-contiguous src (s0=n, s1=1): src[i*n + j] -> dst[i*n + j]
+ *      both sequential in the inner loop - effectively a partial memcpy.
+ *   F-contiguous src (s0=1, s2=m): src[i + j*m] -> dst[i*n + j],
+ *      column-sequential reads, row-sequential writes.
  */
 template<typename T>
-void copy_triangle_to_C(T *dst, const T *src, const npy_intp n,
-                         const npy_intp s0, const npy_intp s1, const char uplo) {
+void copy_triangle_to_C(T *dst, const T *src, const npy_intp m, const npy_intp n, const npy_intp s0, const npy_intp s1, const char uplo) {
     if (uplo == 'L') {
-        for (npy_intp i = 0; i < n; i++) {
-            for (npy_intp j = 0; j <= i; j++) {
+        for (npy_intp i = 0; i < m; i++) {
+            npy_intp stop = std::min(i + 1, n);
+            for (npy_intp j = 0; j < stop; j++) {
                 dst[i * n + j] = *(src + i * s0 + j * s1);
             }
         }
     } else {
-        for (npy_intp i = 0; i < n; i++) {
+        for (npy_intp i = 0; i < m; i++) {
             for (npy_intp j = i; j < n; j++) {
                 dst[i * n + j] = *(src + i * s0 + j * s1);
             }
-        }
-    }
-}
-
-
-/*
- * Extract only the upper triangle of an F-ordered ldaxN `src` to a C-ordered MxN
- * `dst`. The rest is put to 0. This function is reminiscent of `zero_other_triangle`,
- * but contains copying, swapping of ordering and zeroing in one.
- *
- * It is assumed that `lda` >= M
- */
-template<typename T>
-void extract_upper_triangle(T *dst, const T* src, const npy_intp m, const npy_intp n, const npy_intp lda) {
-    for (npy_intp i = 0; i < n; i++) {
-        npy_intp stop = std::min(i + 1, m);
-        for (npy_intp j = 0; j < stop; j++) {
-            dst[j*n + i] = src[i*lda + j];
-        }
-
-        for (npy_intp j = stop; j < m; j++) {
-            dst[j*n + i] = sp_numeric_limits<T>::zero;
         }
     }
 }
@@ -1565,17 +1545,21 @@ to_banded(const T *data, npy_intp n, npy_intp kl, npy_intp ku, npy_intp ldab, T 
 
 template<typename T>
 inline void
-zero_other_triangle(char uplo, T *data, npy_intp n) {
+zero_other_triangle(char uplo, T *data, const npy_intp m, npy_intp n = -1, npy_intp lda = -1) {
+    if (n == -1) { n = m; }
+    if (lda == -1) { lda = m; }
+
     if (uplo == 'U') {
         for (npy_intp i=0; i<n; i++) {
-            for (npy_intp j=i+1; j<n; j++){
-                data[j + i*n] = sp_numeric_limits<T>::zero;
+            for (npy_intp j=i+1; j<m; j++){
+                data[j + i*lda] = sp_numeric_limits<T>::zero;
             }
         }
     } else {
         for (npy_intp i=0; i<n; i++) {
-            for (npy_intp j=0; j<i; j++){
-                data[j + i*n] = sp_numeric_limits<T>::zero;
+            npy_intp stop = std::min(i, m);
+            for (npy_intp j=0; j < stop; j++){
+                data[j + i*lda] = sp_numeric_limits<T>::zero;
             }
         }
     }

--- a/scipy/linalg/src/_linalg_cholesky.hh
+++ b/scipy/linalg/src/_linalg_cholesky.hh
@@ -39,7 +39,7 @@ _cholesky(PyArrayObject *ap_Am, PyArrayObject *ap_Cm, int lower, int overwrite_a
      * Examples:
      *   - Real C-ordered, lower=True, overwrite_a=False
      *.      1. Lower triangle of A is copied with copy_triangle_to_C
-     *.      2. This creates a lower triangular C-ordered array, which is 
+     *.      2. This creates a lower triangular C-ordered array, which is
      *          which is equivalent to an UPPER triangular F-ordered array.
      *       3. potrf only reads from triangle given by uplo and assumes symmetry
      *       4. potrf is called with uplo = "U" overwriting the upper-triangle
@@ -52,11 +52,11 @@ _cholesky(PyArrayObject *ap_Am, PyArrayObject *ap_Cm, int lower, int overwrite_a
      *          equal to the COMPLEX CONJUGATE conj(A) of the lower triangle of the original
      *          matrix.
      *       3. potrf only reads from triangle given by uplo and assumes Hermitian
-     *       4. potrf is called with uplo = "L" overwriting the lower-triangle of 
+     *       4. potrf is called with uplo = "L" overwriting the lower-triangle of
      *          F-ordered array Am* with its lower Cholesky decomposition conj(L).
      *       5. Scipy sees this as an UPPER triangular C-ordered array U = conj(L).T = L^H,
-     *          which is exactly the relation between the lower and upper Cholesky 
-     *          decompositions and this can be returned directly to the user. 
+     *          which is exactly the relation between the lower and upper Cholesky
+     *          decompositions and this can be returned directly to the user.
      *
      *  - Real/Complex, F-ordered, lower=True, overwrite_a=True
      *      1. potrf is called with uplo = "L" overwriting the lower-triangle of
@@ -75,8 +75,7 @@ _cholesky(PyArrayObject *ap_Am, PyArrayObject *ap_Cm, int lower, int overwrite_a
         if (!overwrite_a) {
             data_a = &ret_data[idx * n * n];
             T *slice_ptr_A = compute_slice_ptr(idx, Am_data, ndim, shape, strides);
-            copy_triangle_to_C(data_a, slice_ptr_A, n, s0, s1,
-                               lower ? 'L' : 'U');
+            copy_triangle_to_C(data_a, slice_ptr_A, n, n, s0, s1, lower ? 'L' : 'U');
         } else {
             data_a = Am_data;
         }

--- a/scipy/linalg/src/_linalg_qr.hh
+++ b/scipy/linalg/src/_linalg_qr.hh
@@ -91,17 +91,37 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
      * ^            ^             ^
      * work         tau_buffer    data_A
      *
-     * - `work` is the work area, size `lwork`
+     * - `work` is the work area, size `lwork`. Always allocated.
+     *
      * - `tau_buffer` contains a temporary buffer for the reflectors. If mode == RAW_MODE, they have
-     *   to be returned and hence a buffer is not needed. If needed, size = K
+     *   to be returned and hence a temporary buffer is not needed. Else it has size `K`.
+     *
      * - `data_A` contains a temporary buffer for LAPACK calls, if mode == FULL, the resulting
-     *   `Q` is `M` x `M`. However, `max_dim` is used to allocate enough space should `M` < `N`.
-     *   If `overwrite_a` is enabled this buffer is not needed. Similarly, if mode == RAW the
-     *   returned argument is also in F-order, so the intermediate buffer step can be skipped.
+     *   `Q` is `M x max_dim` to account for both `M >= N` and `M < N`. For mode == R and
+     *   mode == ECONOMIC the required buffer of size `M x N`. For mode == RAW_MODE this buffer
+     *   can be bypassed altogether due to the fact that the returned output has F-ordered slices.
+     *
+     *   When `overwrite_a` is set the buffer is also not needed for ECONOMIC and R modes. Due to the fact
+     *   that the resulting `Q` can be larger than `A` for mode == FULL a buffer is still allocated in that
+     *   case.
+     *
+     * The re-use of the input buffer when `overwrite_a` is enabled works as follows:
+     * - mode == RAW_MODE:
+     *      the factorization is performed in-place and `R` is extracted into a newly allocated array.
+     * - mode == R:
+     *      factorization performed in-place and the other triangle is zeroed out.
+     * - mode == ECONOMIC:
+     *      perform factorization in-place, extract `R` to newly allocated array and explicitly compute
+     *      `Q` in-place as well. If needed (i.e. `M < N`), the `Q` is shrunk into having `M x M` slices
+     *      at the python side.
+     * - mode == FULL:
+     *      copy data into the temporary buffer and perform factorizations there. The input array is re-used for
+     *      storing `R`. At the end `Q` is copied into a newly allocated array.
+     *      XXX: for `M < N` it is possible to circumvent the temporary buffer, but that would lead to shape-dependent codepaths.
      */
     CBLAS_INT tau_size = (mode == QR_mode::RAW_MODE) ? 0 : K;
     CBLAS_INT buf_size = ((overwrite_a && mode != QR_mode::FULL) || mode == QR_mode::RAW_MODE) ? 0 : (mode == QR_mode::FULL) ? M * max_dim : M * N;
-    T *buffer = (T *)malloc((buf_size + lwork + tau_size) * sizeof(T));
+    T *buffer = (T *)malloc((lwork + tau_size + buf_size) * sizeof(T));
     if ( buffer == NULL ) { info = -101; return int(info); }
 
     T *work = &buffer[0];
@@ -134,14 +154,14 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
         slice_ptr_A = compute_slice_ptr(idx, A_data, ndim, shape, strides);
         if (!(mode == QR_mode::R && overwrite_a)) {
             slice_ptr_R = compute_slice_ptr(idx, R_data, ndim, shape, strides_R);
-        } // NB. if the condition is true the relevant buffer is already in place
+        } // NB. if the condition is true the relevant buffer is already in place and no copy back is needed either.
 
         if (mode != QR_mode::R) {
             slice_ptr_Q = compute_slice_ptr(idx, Q_data, ndim, shape, strides_Q);
         }
         if (mode == QR_mode::RAW_MODE) {
             slice_ptr_tau = compute_slice_ptr(idx, tau_data, ndim, shape, strides_tau);
-        } else { // `tau` might still be required, but should not be returned, so buffer is sufficient.
+        } else { // `tau` might still be required for computation of `Q`, but should not be returned, so the temporary buffer is sufficient.
             slice_ptr_tau = tau_buffer;
         }
         if (pivoting) {
@@ -150,7 +170,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
 
         /*
          * Copy the buffer for processing. When `overwrite_a` is disabled the data should be handled in
-         * another buffer, so copying is necessary. When it is set, the data can be processed in place.
+         * another buffer, so copying is necessary. When the flag is set, the data can be processed in place.
          *
          * Another optimization is to process the data for mode == RAW in the return object directly as
          * the returned array is in F-order, hence bypassing the buffer avoids two redundant copies.
@@ -188,8 +208,9 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
         }
 
         // `R` is always required, the correct shape is ensured by `middle_dim`.
-        if (mode == QR_mode::R && overwrite_a) {
-            zero_other_triangle('U', data_A, middle_dim, intn, intm); // Data in-place, but need to remove the other part of the factorization still
+        // NB. if a new array is allocated, it is pre-filled with zeros so only the relevant triangle should be copied.
+        if (mode == QR_mode::R && overwrite_a) { // Data in-place, but need to remove the other part of the factorization still to obtain upper-triangular matrix
+            zero_other_triangle('U', data_A, middle_dim, intn, intm);
         } else if (mode == QR_mode::FULL && overwrite_a) {
             // The `R` array should be copied back into the `A` array, which is F-ordered, so pretend the transpose got copied.
             // Then zero out the other triangle since the original input data is still in place.
@@ -197,7 +218,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
             zero_other_triangle('U', slice_ptr_A, intm, intn, intm);
         } else {
             copy_triangle_to_C(slice_ptr_R, data_A, middle_dim, intn, 1, intm, 'U'); // F-ordered input to `copy_triangle`, hence `s0 == 1` and `s1 == intm`
-        } // NB. if a new array is allocated, it is pre-filled with zeros so only the relevant triangle should be copied.
+        }
 
         // Construct the Q matrix if required, same handling for both modes; dimensions are set already.
         if (mode == QR_mode::FULL || mode == QR_mode::ECONOMIC) {
@@ -213,8 +234,8 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
                 copy_slice_F_to_C(slice_ptr_Q, data_A, intm, middle_dim);
             } // NB. else the data is already in place
         }
-        // NB. for mode == RAW the data was either processed in place (for `overwrite_a`),
-        // or was processed in the return object. Hence, Q is already in place and no additional copy is needed.
+        // NB. for mode == RAW_MODE the data was either processed in place (for `overwrite_a`) or it was processed
+        // directly in the return object. Hence, Q is already in place and no additional copy is needed.
 
     } // End of batching loop
 

--- a/scipy/linalg/src/_linalg_qr.hh
+++ b/scipy/linalg/src/_linalg_qr.hh
@@ -2,7 +2,6 @@
  * Templated loops for `linalg.qr`
  */
 
-#include "src/_common_array_utils.hh"
 template<typename T>
 int
 _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObject *ap_tau, PyArrayObject *ap_jpvt, int overwrite_a, QR_mode mode, int pivoting, SliceStatusVec &vec_status)
@@ -84,17 +83,30 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
         return -99;
     }
 
-    // If mode == FULL, the resulting Q will be `M` x `M`, however, `max_dim` is used to
-    // allocate enough space for the entire `a` for `M` < `N`.
-    // If mode == RAW_MODE, the `tau` have to be returned, else a temporary buffer is sufficient.
-    CBLAS_INT buf_size = (mode == QR_mode::FULL) ? M * max_dim : M * N;
+    /*
+     * Allocate buffer and slice into parts
+     *
+     *     lwork        tau_size     buf_size
+     * |------------|-------------|--------------|
+     * ^            ^             ^
+     * work         tau_buffer    data_A
+     *
+     * - `work` is the work area, size `lwork`
+     * - `tau_buffer` contains a temporary buffer for the reflectors. If mode == RAW_MODE, they have
+     *   to be returned and hence a buffer is not needed. If needed, size = K
+     * - `data_A` contains a temporary buffer for LAPACK calls, if mode == FULL, the resulting
+     *   `Q` is `M` x `M`. However, `max_dim` is used to allocate enough space should `M` < `N`.
+     *   If `overwrite_a` is enabled this buffer is not needed. Similarly, if mode == RAW the
+     *   returned argument is also in F-order, so the intermediate buffer step can be skipped.
+     */
     CBLAS_INT tau_size = (mode == QR_mode::RAW_MODE) ? 0 : K;
+    CBLAS_INT buf_size = ((overwrite_a && mode != QR_mode::FULL) || mode == QR_mode::RAW_MODE) ? 0 : (mode == QR_mode::FULL) ? M * max_dim : M * N;
     T *buffer = (T *)malloc((buf_size + lwork + tau_size) * sizeof(T));
     if ( buffer == NULL ) { info = -101; return int(info); }
 
-    T *data_A = &buffer[0];
-    T *work = &buffer[buf_size];
-    T *tau_buffer = &buffer[buf_size + lwork];
+    T *work = &buffer[0];
+    T *tau_buffer = &buffer[lwork];
+    T *data_A = &buffer[lwork + tau_size];
 
     // `c/zgeqp3` needs rwork
     void *rwork = NULL;
@@ -120,7 +132,9 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
         // Hence, the use of `ndim` instead of `ndim-1`. Similarly, the shapes of `Q` and `R` might differ,
         // but only the batching ones are relevant, which are identical.
         slice_ptr_A = compute_slice_ptr(idx, A_data, ndim, shape, strides);
-        slice_ptr_R = compute_slice_ptr(idx, R_data, ndim, shape, strides_R);
+        if (!(mode == QR_mode::R && overwrite_a)) {
+            slice_ptr_R = compute_slice_ptr(idx, R_data, ndim, shape, strides_R);
+        } // NB. if the condition is true the relevant buffer is already in place
 
         if (mode != QR_mode::R) {
             slice_ptr_Q = compute_slice_ptr(idx, Q_data, ndim, shape, strides_Q);
@@ -134,7 +148,21 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
             slice_ptr_jpvt = compute_slice_ptr(idx, jpvt_data, ndim, shape, strides_jpvt);
         }
 
-        copy_slice_F(data_A, slice_ptr_A, M, N, strides[ndim-2], strides[ndim-1]);
+        /*
+         * Copy the buffer for processing. When `overwrite_a` is disabled the data should be handled in
+         * another buffer, so copying is necessary. When it is set, the data can be processed in place.
+         *
+         * Another optimization is to process the data for mode == RAW in the return object directly as
+         * the returned array is in F-order, hence bypassing the buffer avoids two redundant copies.
+         */
+        if ((!overwrite_a && mode != QR_mode::RAW_MODE) || mode == QR_mode::FULL) {
+            copy_slice_F(data_A, slice_ptr_A, M, N, strides[ndim-2], strides[ndim-1]);
+        } else if (!overwrite_a && mode == QR_mode::RAW_MODE) {
+            copy_slice_F(slice_ptr_Q, slice_ptr_A, M, N, strides[ndim-2], strides[ndim-1]);
+            data_A = slice_ptr_Q; // Add alias for easier to read codepaths later on.
+        } else if (overwrite_a && (mode == QR_mode::RAW_MODE || mode == QR_mode::R || mode == QR_mode::ECONOMIC)) {
+            data_A = slice_ptr_A;
+        }
 
         init_status(slice_status, idx, St::GENERAL);
 
@@ -159,9 +187,17 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
             goto free_exit;
         }
 
-        // Extract useful information and continue computation if needed.
         // `R` is always required, the correct shape is ensured by `middle_dim`.
-        extract_upper_triangle(slice_ptr_R, data_A, middle_dim, intn, intm);
+        if (mode == QR_mode::R && overwrite_a) {
+            zero_other_triangle('U', data_A, middle_dim, intn, intm); // Data in-place, but need to remove the other part of the factorization still
+        } else if (mode == QR_mode::FULL && overwrite_a) {
+            // The `R` array should be copied back into the `A` array, which is F-ordered, so pretend the transpose got copied.
+            // Then zero out the other triangle since the original input data is still in place.
+            copy_triangle_to_C(slice_ptr_A, data_A, intn, intm, intm, 1, 'L');
+            zero_other_triangle('U', slice_ptr_A, intm, intn, intm);
+        } else {
+            copy_triangle_to_C(slice_ptr_R, data_A, middle_dim, intn, 1, intm, 'U'); // F-ordered input to `copy_triangle`, hence `s0 == 1` and `s1 == intm`
+        } // NB. if a new array is allocated, it is pre-filled with zeros so only the relevant triangle should be copied.
 
         // Construct the Q matrix if required, same handling for both modes; dimensions are set already.
         if (mode == QR_mode::FULL || mode == QR_mode::ECONOMIC) {
@@ -173,14 +209,12 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
                 goto free_exit;
             }
 
-            copy_slice_F_to_C(slice_ptr_Q, data_A, intm, middle_dim);
+            if (!overwrite_a || mode == QR_mode::FULL) {
+                copy_slice_F_to_C(slice_ptr_Q, data_A, intm, middle_dim);
+            } // NB. else the data is already in place
         }
-
-        // In the case of `raw` mode, the output of `geqrf`/`geqp3` is what is expected in `Q`.
-        // Since the usecase for `mode="raw"` will mostly be to use it for other LAPACK calls, keep in F-order.
-        if (mode == QR_mode::RAW_MODE) {
-            memcpy(slice_ptr_Q, data_A, intm * intn * sizeof(T));
-        }
+        // NB. for mode == RAW the data was either processed in place (for `overwrite_a`),
+        // or was processed in the return object. Hence, Q is already in place and no additional copy is needed.
 
     } // End of batching loop
 

--- a/scipy/linalg/tests/test_basic.py
+++ b/scipy/linalg/tests/test_basic.py
@@ -2307,7 +2307,7 @@ class TestLstsq:
         assert_equal(ranks3, np.asarray([n, n]))
 
         if driver != "gelsy":
-            assert resid3.shape == (n,) # XXX: ?
+            assert resid3.shape == (n,)
             assert_allclose(resid3, [resid]*n, atol=1e-14)
         else:
             assert resid3.shape == (2, 0)

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -18,6 +18,7 @@ from scipy.linalg import (eig, eigvals, lu, svd, svdvals, cholesky, qr,
                           subspace_angles, hadamard, eigvalsh_tridiagonal,
                           eigh_tridiagonal, null_space, cdf2rdf, LinAlgError)
 
+from .test_basic import parametrize_overwrite_arg
 
 from scipy.linalg.lapack import get_lapack_funcs
 from scipy.linalg._misc import norm
@@ -2207,6 +2208,98 @@ class TestQR:
         decimal = 5 if dtype in (np.float32, np.complex64) else 13
         assert_array_almost_equal(q @ r, a, decimal=decimal)
         assert_array_almost_equal(np.conj(q.T) @ q, np.eye(q.shape[1]), decimal=decimal)
+
+    @parametrize_overwrite_arg
+    @pytest.mark.parametrize("dtype", [int, float])
+    @pytest.mark.parametrize("mode", ["raw", "r", "economic", "full"])
+    @pytest.mark.parametrize("pivoting", [True, False])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    @pytest.mark.parametrize("shape", [(4, 3), (3, 4), (2, 4, 3), (2, 3, 4)])
+    def test_overwrite_args(self, dtype, overwrite_kw, mode, pivoting, order, shape):
+        rng = np.random.default_rng(seed=42)
+
+        if order == "F":
+            # ensure slices are F-ordered, which is not the case
+            # for > 2D F-ordered arrays.
+            shape = (*shape[:-2], shape[-1], shape[-2])
+            a = rng.normal(size=shape).astype(dtype)
+            a = np.swapaxes(a, -2, -1)
+        else:
+            a = rng.normal(size=shape).astype(dtype)
+
+        a_ref = np.copy(a)
+        out = qr(a, mode=mode, pivoting=pivoting, **overwrite_kw)
+
+        overwrite_a = overwrite_kw.get("overwrite_a", False)
+        overwrite_a = (
+            overwrite_a and
+            (len(shape) == 2) and
+            (order == "F") and
+            dtype is not int
+        )
+
+        # Check if the result is actually correct & check overwrite behavior
+        if mode == "raw":
+            # if overwrite is enabled `a` will contain `q_raw`
+            (q_raw, tau), r, *other = out
+
+            if a_ref.ndim > 2:
+                for i in range(a_ref.shape[0]):
+                    or_un_gqr = get_lapack_funcs(
+                        ("orgqr",), (q_raw[0, :, :],), ilp64="preferred"
+                    )[0]
+                    q, _, _ = or_un_gqr(q_raw[i, :, :np.min(shape[-2:])], tau[i, :])
+
+                    if pivoting:
+                        jpvt = other[0]
+                        assert_allclose(
+                            q @ r[i, :, :], a_ref[i, :, :][:, jpvt[i, :]], atol=1e-12
+                        )
+                    else:
+                        assert_allclose(q @ r[i, :, :], a_ref[i, :, :], atol=1e-12)
+            else:
+                or_un_gqr = get_lapack_funcs(("orgqr",), (q_raw,), ilp64="preferred")[0]
+                q, _, _ = or_un_gqr(q_raw[:, :np.min(shape[-2:])], tau)
+
+                if pivoting:
+                    jpvt = other[0]
+                    assert_allclose(q @ r, a_ref[:, jpvt], atol=1e-12)
+                else:
+                    assert_allclose(q @ r, a_ref, atol=1e-12)
+
+            assert overwrite_a == np.shares_memory(a, q_raw)
+
+        elif mode == "r":
+            # `a` is identical to `r` is overwrite is enabled
+            _, r_ref, *other = qr(a_ref, mode="full", pivoting=pivoting)
+
+            assert_allclose(out[0], r_ref, atol=1e-12)
+            if pivoting:
+                assert_allclose(out[-1], other[0])
+
+            assert overwrite_a == np.shares_memory(a, out[0])
+
+        elif mode == "economic" or mode == "full":
+            # `q` is a (cropped version of) `a` if overwrite is enabled for "economic".
+            # For "full" `a` contains `r`.
+
+            if pivoting:
+                jpvt = out[-1]
+                if a_ref.ndim > 2:
+                    for i in range(a_ref.shape[0]):
+                        assert_allclose(
+                            out[0][i, :, :] @ out[1][i, :, :], a_ref[i][:, jpvt[i, :]],
+                            atol=1e-12
+                        )
+                else:
+                    assert_allclose(out[0] @ out[1], a_ref[:, jpvt], atol=1e-12)
+            else:
+                assert_allclose(out[0] @ out[1], a_ref, atol=1e-12)
+
+
+            assert overwrite_a == np.shares_memory(
+                a, out[0 if mode == "economic" else 1]
+            )
 
 
 class TestRQ:


### PR DESCRIPTION
#### Reference issue
Towards #24645 by (partially) re-enabling `overwrite_a` for qr.

#### What does this implement/fix?
Re-enables `overwrite_a` for `mode == "raw"/"r"` + small optimization to zero-initialize returned `R` to prevent having to put it to 0 afterwards. Another optimization that bypasses the buffer entirely for `mode == "raw"`, regardless of `overwrite` was left out for now, but can be easily added.

The optimization for `R` also allows to remove `extract_upper_triangle` in favor of (slightly altered) `copy_triangle_to_C` and `zero_other_triangle` (had to be adapted to accept non-square input).

#### Additional information
This only covers `mode == "raw"/"r"` as those are quite straightforward; the buffer remains in place, apply `geqrf`/`geqp3` (only `geqrf` is tested as the overwrite codepaths are in principle indifferent to which routine is called) and either extract `R` or zero out the other triangle.

However, `mode == "full"/"economic"` are less trivial: as discussed in https://github.com/scipy/scipy/pull/24268#issuecomment-3941554495 things are not as straightforward here. The issue is mostly related to the sizes of the buffers here.

- For `mode == "full"`: `Q` is of size `M x M` and therefore needs its own buffer anyways in case `M > N` since it would otherwise not fit in there. `R` is, however, guaranteed to fit into the input array just fine. Hence, I'd propose allocating a buffer anyways, copying `a` into it, and extracting `R` back into `a`. (Calling the factorization step in-place would necessitate another copy, which would probably be best to avoid.)
- For `mode == "economic"` there is the issue that it is not even clear whether `Q` or `R` will fit into `A`. Theoretically speaking `Q` would always be fitting, but it could be just that the view has to shrunk down at the python side in the end, just like is being done in `lstsq` with the residuals `x`. Alternatively it could be computed which of the two arrays could fit into `A`.

However, given that all modes are handled in one function, each with their own special needs, this already gets somewhat messy for the two implemented modes, and is therefore bound to get even more "special-cased" everywhere upon introducing the other two modes. However, I do think that the `overwrite_a` argument should be re-enabled for all inputs, and it should be done in an intuitive manner. (FWIW, I did some very quick and dirty checks and the f2py behavior is a bit opaque, tested on 1.17.1. C-ordered arrays are ignored, F-ordered arrays are accepted, but the output never shares memory. If needed I'll add a more comprehensive script about the f2py behavior later.) 

A last remark is that the some of the conditions for `overwrite_a` might be relaxable here; if you need an additional buffer anyways (for `mode == "full"`, and have to copy some array back into it, then theoretically any array could fit), but that might be yet another Pandora's box in and of itself.

#### AI Generation Disclosure
No AI
