### PR TITLE
DOC: add examples to signal.besselap docstring

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -5334,6 +5334,33 @@ def besselap(N, norm='phase', *, xp=None, device=None):
            Others", RaneNote 147, 1998,
            https://www.ranecommercial.com/legacy/note147.html
 
+    Examples
+    --------
+    Generate a 3rd-order Bessel filter prototype with the default
+    phase-matched normalization:
+
+    >>> import numpy as np
+    >>> from scipy.signal import besselap
+    >>> z, p, k = besselap(3)
+
+    There are no zeros and the gain is 1 for phase normalization:
+
+    >>> len(z)
+    0
+    >>> k
+    1.0
+
+    All poles lie in the left half-plane, ensuring stability:
+
+    >>> np.all(p.real < 0)
+    True
+
+    Use the 'delay' normalization for unit group delay:
+
+    >>> _, _, k_delay = besselap(3, norm='delay')
+    >>> k_delay
+    15.0
+
     """
     if xp is None:
         xp = np_compat


### PR DESCRIPTION
#### Reference issue
Closes gh-7168 (partial).

#### What does this implement/fix?
Adds an `Examples` section to the `scipy.signal.besselap` docstring. The examples demonstrate:
1. Generating a 3rd-order Bessel filter prototype with phase normalization
2. Verifying that zeros are empty and gain is 1 for phase normalization
3. Checking that all poles lie in the left half-plane (stability)
4. Using the `'delay'` normalization and its effect on gain

#### Additional information
This is one of the functions listed in gh-7168 as missing an `Examples` section. The examples avoid hardcoding platform-dependent complex pole values and instead verify properties (empty zeros, gain value, stability).

#### AI Generation Disclosure
AI tools (Claude) were used to draft the docstring examples. All examples were manually verified for correctness against the installed SciPy version (1.17.1).