### PR TITLE
DOC: add examples to ndimage.morphological_laplace docstring

### DIFF
--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -1794,6 +1794,38 @@ def morphological_laplace(input, size=None, footprint=None, structure=None,
     morphological_laplace : ndarray
         Output
 
+    See Also
+    --------
+    grey_dilation, grey_erosion
+
+    Examples
+    --------
+    The morphological Laplacian highlights regions where the local
+    morphology changes, such as edges. Apply it to a 1-D step signal
+    with a structuring element of size 3:
+
+    >>> import numpy as np
+    >>> from scipy.ndimage import morphological_laplace
+    >>> a = np.array([0, 0, 0, 1, 1, 1, 0, 0, 0])
+    >>> morphological_laplace(a, size=3)
+    array([ 0,  0,  1, -1,  0, -1,  1,  0,  0])
+
+    The result is nonzero only at the transitions (edges) of the signal.
+    Apply it to a 2-D binary block:
+
+    >>> b = np.zeros((5, 5))
+    >>> b[1:4, 1:4] = 1
+    >>> morphological_laplace(b, size=3)
+    array([[ 1.,  1.,  1.,  1.,  1.],
+           [ 1., -1., -1., -1.,  1.],
+           [ 1., -1.,  0., -1.,  1.],
+           [ 1., -1., -1., -1.,  1.],
+           [ 1.,  1.,  1.,  1.,  1.]])
+
+    Positive values appear outside the block (where dilation expands),
+    negative values appear at the inner boundary (where erosion shrinks),
+    and zero appears in the flat interior.
+
     """
     input = np.asarray(input)
     tmp1 = grey_dilation(input, size, footprint, structure, None, mode,


### PR DESCRIPTION
#### Reference issue
Closes gh-7168 (partial).

#### What does this implement/fix?
Adds an `Examples` section and a `See Also` section to the `scipy.ndimage.morphological_laplace` docstring. The examples demonstrate:
1. A 1-D step signal showing edge detection behavior with a size-3 structuring element
2. A 2-D binary block showing the characteristic pattern: positive values outside edges, negative values at inner boundaries, and zero in flat regions

#### Additional information
This is one of the functions listed in gh-7168 as missing an `Examples` section. The morphological Laplacian is computed as `dilation + erosion - 2 * input`, and the examples clearly illustrate this behavior. A `See Also` section linking to `grey_dilation` and `grey_erosion` was also added since these are the building blocks of the operation.

#### AI Generation Disclosure
AI tools (Claude) were used to draft the docstring examples. All examples were manually verified for correctness against the installed SciPy version (1.17.1).