### PR TITLE
MAINT: fix abs() truncation warnings for fblas_64.pyf.src in ILP64 builds

### DIFF
--- a/scipy/_build_utils/src/_blas64_defines.h
+++ b/scipy/_build_utils/src/_blas64_defines.h
@@ -52,3 +52,11 @@
 
 #define F_INT npy_int64
 
+/*
+ * f2py translates abs() from pyf expressions directly into C abs(),
+ * which takes int. With ILP64, F_INT is npy_int64 (long), so we
+ * need labs() to avoid truncation warnings.
+ */
+#undef abs
+#define abs labs
+


### PR DESCRIPTION
f2py passes abs() from pyf expressions verbatim into generated C code. In the ILP64 build, `F_INT` is `npy_int64` (long), so C's abs() (which takes int) causes truncation warnings. So redefine `abs` to `labs` in _blas64_defines.h to match the actual argument type.

f2py may also `eval` the abs() usage as Python code, so this is a cleaner fix than trying to change `abs` to `labs` in the .pyf sources.

Warnings are visible in recent `accelerate-ilp64` CI jobs, and looked like:
```
scipy/linalg/_fblas_64module.c:19725:35: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
 19725 |     CHECKSCALAR(len(x)>offx+(n-1)*abs(incx),"len(x)>offx+(n-1)*abs(incx)","hidden n","dtrmv:n=%ld",n) {
       |                                   ^
scipy/linalg/_fblas_64module.c:19725:35: note: use function 'labs' instead
 19725 |     CHECKSCALAR(len(x)>offx+(n-1)*abs(incx),"len(x)>offx+(n-1)*abs(incx)","hidden n","dtrmv:n=%ld",n) {
       |                                   ^~~
       |                                   labs
scipy/linalg/_fblas_64module.c:115:11: note: expanded from macro 'CHECKSCALAR'
  115 |     if (!(check)) {\
      |           ^
```



#### AI Generation Disclosure

I used Claude Opus 4.6 to investigate the problem and suggest a fix. I then modified the fix (which didn't seem quite right) to `#define abs labs` by hand.
