### PR TITLE
BUG: ndimage: overflow in `_measurements._select`

### DIFF
--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -981,7 +981,8 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
         idxs = np.asanyarray(index, np.int_).copy()
         found = (idxs >= 0) & (idxs <= labels.max())
 
-    idxs[~ found] = labels.max() + 1
+    lmax = np.intp(labels.max())
+    idxs[~ found] = lmax + 1
 
     if find_median:
         order = np.lexsort((input.ravel(), labels.ravel()))
@@ -994,26 +995,26 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
 
     result = []
     if find_min:
-        mins = np.zeros(labels.max() + 2, input.dtype)
+        mins = np.zeros(lmax + 2, input.dtype)
         mins[labels[::-1]] = input[::-1]
         result += [mins[idxs]]
     if find_min_positions:
-        minpos = np.zeros(labels.max() + 2, int)
+        minpos = np.zeros(lmax + 2, int)
         minpos[labels[::-1]] = positions[::-1]
         result += [minpos[idxs]]
     if find_max:
-        maxs = np.zeros(labels.max() + 2, input.dtype)
+        maxs = np.zeros(lmax + 2, input.dtype)
         maxs[labels] = input
         result += [maxs[idxs]]
     if find_max_positions:
-        maxpos = np.zeros(labels.max() + 2, int)
+        maxpos = np.zeros(lmax + 2, int)
         maxpos[labels] = positions
         result += [maxpos[idxs]]
     if find_median:
         locs = np.arange(len(labels))
-        lo = np.zeros(labels.max() + 2, np.int_)
+        lo = np.zeros(lmax + 2, np.int_)
         lo[labels[::-1]] = locs[::-1]
-        hi = np.zeros(labels.max() + 2, np.int_)
+        hi = np.zeros(lmax + 2, np.int_)
         hi[labels] = locs
         lo = lo[idxs]
         hi = hi[idxs]

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -146,6 +146,29 @@ class Test_measurements_select:
             xp_assert_equal(result[1], [1, 2])
             assert result[1].dtype.kind == 'i'
 
+    @pytest.mark.parametrize("dtype, label", [
+        (np.uint8, 254),     # 254 + 2 = 0 (size-0 array)
+        (np.uint8, 255),     # 255 + 2 = 1 (size-1 array)
+        (np.int8, 126),      # 126 + 2 = -128 (negative size)
+        (np.uint16, 65534),  # 65534 + 2 = 0 (size-0 array)
+        (np.uint16, 65535),  # 65535 + 2 = 1 (size-1 array)
+        (np.int16, 32766),   # 32766 + 2 = -32768 (negative size)
+    ])
+    def test_gh24966(self, dtype, label, xp):
+        # labels.max() + 2 may overflow for integer label dtypes,
+        # when label <= len(labels), causing Value- or IndexError
+        size = label + 1
+        x = np.zeros(size)
+        x[:3] = [1, 2, 3]
+        labels = np.zeros(size, dtype=dtype)
+        labels[:3] = label
+        result = ndimage._measurements._select(
+            x, labels=labels, index=[label], find_min=True,
+            find_min_positions=True, find_max=True,
+            find_max_positions=True, find_median=True)
+        xp_assert_close(np.concatenate(result),
+                        [1.0, 0.0, 3.0, 2.0, 2.0])
+
 
 @make_xp_test_case(ndimage.label)
 def test_label01(xp):
@@ -917,6 +940,26 @@ def test_median_no_int_overflow(xp):
     assert_array_almost_equal(output, xp.asarray([67.5]))
 
 
+@pytest.mark.parametrize("dtype_name, label", [
+    ("uint8", 254),
+    ("uint8", 255),
+    ("int8", 126),
+    ("uint16", 65534),
+    ("uint16", 65535),
+    ("int16", 32766),
+])
+@make_xp_test_case(ndimage.median)
+def test_median_gh24966(dtype_name, label, xp):
+    # labels.max() + 2 may overflow for integer label dtypes,
+    # when label <= len(labels), causing Value- or IndexError
+    dtype = getattr(xp, dtype_name)
+    size = label + 1
+    x = xp.asarray([1.0, 2.0, 3.0] + [0.0] * (size - 3))
+    labels = xp.asarray([int(label)] * 3 + [0] * (size - 3), dtype=dtype)
+    xp_assert_close(ndimage.median(x, labels, xp.asarray([label])),
+                    xp.asarray([2.0]))
+
+
 @make_xp_test_case(ndimage.variance)
 def test_variance01(xp):
     with np.errstate(all='ignore'):
@@ -1309,6 +1352,31 @@ def test_extrema04(xp):
         assert_array_almost_equal(output1[1], output3)
         assert output1[2] == output4
         assert output1[3] == output5
+
+
+@pytest.mark.parametrize("dtype_name, label", [
+    ("uint8", 254),
+    ("uint8", 255),
+    ("int8", 126),
+    ("uint16", 65534),
+    ("uint16", 65535),
+    ("int16", 32766),
+])
+@make_xp_test_case(ndimage.extrema)
+def test_extrema_gh24966(dtype_name, label, xp):
+    # labels.max() + 2 may overflow for integer label dtypes,
+    # when label <= len(labels), causing Value- or IndexError
+    dtype = getattr(xp, dtype_name)
+    size = label + 1
+    x = xp.asarray([1.0, 2.0, 3.0] + [0.0] * (size - 3))
+    labels = xp.asarray([int(label)] * 3 + [0] * (size - 3), dtype=dtype)
+    index = xp.asarray([label])
+    minimums, maximums, min_positions, max_positions = ndimage.extrema(
+        x, labels, index)
+    xp_assert_close(minimums, xp.asarray([1.0]))
+    xp_assert_close(maximums, xp.asarray([3.0]))
+    assert min_positions == [(0,)]
+    assert max_positions == [(2,)]
 
 
 @make_xp_test_case(ndimage.center_of_mass)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes gh-24966.

#### What does this implement/fix?
`_select` computes `labels.max() + 2` to allocate index arrays in the fast branch, but does so in the `labels` array's  dtype. This can cause overflows and either raises `IndexError` (uint) or `ValueError` (int).
The `np.unique` branch is not affected by this issue - `return_inverse` data type is already `np.intp`.

The fix casts `labels.max()` to `np.intp` before arithmetic to avoid the overflow issue.

#### Additional information
Affects all six public functions that use `_select`: `median`, `minimum`, `maximum`, `minimum_position`, `maximum_position`, and `extrema`. (The original issue only mentions `median`.)

#### AI Generation Disclosure
This PR was prepared with assistance from Claude Code (Claude Opus 4.6). All code changes were reviewed and corrected by a human (myself).