### PR TITLE
DEV: avoid byte-compiling every .py file on a `spin build` call.

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -87,6 +87,9 @@ def build(*, parent_callback, meson_args, jobs, verbose, werror, asan, debug,
     meson_compile_args = tuple()
     meson_install_args = tuple()
 
+    # Avoid byte-compiling on every rebuild/reinstall, that's very expensive
+    meson_args += ("-Dpython.bytecompile=-1",)
+
     if sys.platform == "cygwin":
         # Cygwin only has netlib lapack, but can link against
         # OpenBLAS rather than netlib blas at runtime.  There is


### PR DESCRIPTION
This makes a `spin build` on an already-built scipy more than twice faster. Which also applies to `spin test`, and every other command that depends on the build step.

See https://github.com/numpy/numpy/pull/30510#issuecomment-4097010127 for details.


#### AI Generation Disclosure

No AI tools used