### PR TITLE
TST: special: fix extremely slow `TestSystematic.test_gegenbauer_int`

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -1404,7 +1404,7 @@ class TestSystematic:
             sc_gegenbauer,
             exception_to_nan(gegenbauer),
             [IntArg(0, 100), Arg(-1e9, 1e9), Arg()],
-            n=40000, dps=100, ignore_inf_sign=True, rtol=1e-6,
+            dps=100, ignore_inf_sign=True, rtol=1e-6,
         )
 
         # Check the small-x expansion


### PR DESCRIPTION
On two different computers, test_gegenbauer_int was taking 50-60
seconds, which is more than 10 times the duration of the next slowest
non-xslow test in scipy.special.  This is too long for a test that
is not marked xslow.

By changing from `n=40000` to the default `n` in one of the calls
of `assert_mpmath_equal()`, the number of checks run is 100 when
the xslow tests are not enabled.  When xslow is enable, 5000 checks
are run.

*Edit*: The first version of this PR simply marked the test as xslow.
It turns out the mpmath test infrastructure already has a mechanism
for basing the number of checks to run on the xslow setting. 

#### AI Generation Disclosure

No AI tools used.