### PR TITLE
BUG: ndimage: fix order=0 rounding inconsistency in mirror mode

### DIFF
--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -483,6 +483,9 @@ NI_GeometricTransform(PyArrayObject *input, int (*map)(npy_intp*, double*,
         for(hh = 0; hh < irank; hh++) {
             double cc = icoor[hh] + nprepad;
             if ((mode != NI_EXTEND_GRID_CONSTANT) && (mode != NI_EXTEND_NEAREST)) {
+                if (order == 0) {
+                    cc = floor(cc + 0.5);
+                }
                 /* if the input coordinate is outside the borders, map it: */
                 cc = map_coordinate(cc, idimensions[hh], mode);
             }
@@ -807,6 +810,9 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
             }
             cc += (double)nprepad;
             if ((mode != NI_EXTEND_GRID_CONSTANT) && (mode != NI_EXTEND_NEAREST)) {
+                if (order == 0) {
+                    cc = floor(cc + 0.5);
+                }
                 /* if the input coordinate is outside the borders, map it: */
                 cc = map_coordinate(cc, idimensions[jj], mode);
             }

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -652,6 +652,35 @@ class TestMapCoordinates:
         expected = xp.stack([single] * n_channels, axis=-1)
         xp_assert_close(multi, expected)
 
+    @pytest.mark.parametrize('mode', ['mirror', 'reflect', 'grid-wrap',
+                                      'grid-constant', 'nearest'])
+    def test_map_coordinates_order0_half_integer_rounding(self, mode, xp):
+        # Regression test for gh-24160: mirror mode rounded negative
+        # half-integer coordinates inconsistently (away from zero instead of
+        # toward +inf) due to the coordinate reflection flipping the
+        # fractional part before rounding.
+        data = xp.asarray([3., 2., 1.])
+        coords = xp.asarray([[-0.5, 0.5, 2.5]])
+
+        result = ndimage.map_coordinates(data, coords, order=0, mode=mode)
+
+        # At -0.5 with order=0 the nearest integer toward +inf is 0 so
+        # all modes that include index 0 in-range should return data[0].
+        # At 0.5 and 2.5 the nearest integer toward +inf is 1 and 3 and
+        # then the boundary mode then determines the final mapped index.
+        if mode == 'grid-constant':
+            expected = xp.asarray([3., 2., 0.])
+        elif mode == 'grid-wrap':
+            expected = xp.asarray([3., 2., 3.])
+        elif mode == 'nearest':
+            expected = xp.asarray([3., 2., 1.])
+        elif mode == 'reflect':
+            expected = xp.asarray([3., 2., 1.])
+        elif mode == 'mirror':
+            expected = xp.asarray([3., 2., 2.])
+
+        xp_assert_equal(result, expected)
+
 
 @make_xp_test_case(ndimage.affine_transform)
 class TestAffineTransform:


### PR DESCRIPTION
#### Reference issue

Closes gh-24160.

#### What does this implement/fix?

For `order=0` this rounds the coordinate to the nearest integer *before* `map_coordinate()` applies the boundary mode rather than after. Mirror mode negates the coordinate (`in = -in`) which flips the fractional part and reverses the rounding direction at half-integers. Pre-rounding would avoids this. The change is guarded by `if (order == 0)` so higher-order interpolation is unaffected.

#### Additional information

All existing tests in `test_interpolation.py` pass.
Includes a regression test for half-integer coordinates across boundary modes.

#### AI Generation Disclosure

AI tools (Cursor with Claude) were used to help diagnose the root cause and draft the fix. I mainly used it for thinking + making sure I didn't miss anything. All code was manually verified and tested against a full source build.
