### PR TITLE
MAINT: linalg: Fix AIX build break due to RAW Macro defined.

### DIFF
--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -287,7 +287,7 @@ _linalg_qr(PyObject* Py_UNUSED(dummy), PyObject* args) {
             break; // shape of `Q` irrelevant here
         }
 
-        case QR_mode::RAW:
+        case QR_mode::RAW_MODE:
         {
             shape_Q[ndim-1] = N;
             shape_R[ndim-2] = K;
@@ -318,7 +318,7 @@ _linalg_qr(PyObject* Py_UNUSED(dummy), PyObject* args) {
         goto fail_qr;
     }
 
-    if (mode == QR_mode::RAW) {
+    if (mode == QR_mode::RAW_MODE) {
         shape_Q[ndim-2] = K; // Just reuse `shape_Q`; not used any longer.
         ap_tau = (PyArrayObject *)PyArray_SimpleNew(ndim-1, shape_Q, typenum); // Just a vector, so `ndim-1`.
         if (!ap_tau) {
@@ -379,7 +379,7 @@ _linalg_qr(PyObject* Py_UNUSED(dummy), PyObject* args) {
     ret_lst = convert_vec_status(vec_status);
 
     ret_Q = (mode != QR_mode::R) ? PyArray_Return(ap_Q) : Py_None;
-    ret_tau = (mode == QR_mode::RAW) ? PyArray_Return(ap_tau) : Py_None;
+    ret_tau = (mode == QR_mode::RAW_MODE) ? PyArray_Return(ap_tau) : Py_None;
     ret_jpvt = (pivoting) ? PyArray_Return(ap_jpvt): Py_None;
     return Py_BuildValue("NNNNN", ret_Q, PyArray_Return(ap_R), ret_tau, ret_jpvt, ret_lst);
 

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -925,7 +925,7 @@ enum QR_mode : Py_ssize_t
 {
     FULL = 1,
     R = 11,
-    RAW = 21,
+    RAW_MODE = 21,
     ECONOMIC = 31
 };
 

--- a/scipy/linalg/src/_linalg_qr.hh
+++ b/scipy/linalg/src/_linalg_qr.hh
@@ -33,7 +33,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
         strides_Q = PyArray_STRIDES(ap_Q);
     }
 
-    if (mode == QR_mode::RAW) {
+    if (mode == QR_mode::RAW_MODE) {
         tau_data = (T *)PyArray_DATA(ap_tau);
         strides_tau = PyArray_STRIDES(ap_tau);
     }
@@ -51,7 +51,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
     // -------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)N, intm = (CBLAS_INT)M, info = 0;
     CBLAS_INT K = std::min(intn, intm), max_dim = std::max(intn, intm);
-    CBLAS_INT middle_dim = (mode == QR_mode::ECONOMIC || mode == QR_mode::RAW) ? K : intm; // Final dimension: Q is [`M` x `middle_dim`], R is [`middle_dim` x `N`]
+    CBLAS_INT middle_dim = (mode == QR_mode::ECONOMIC || mode == QR_mode::RAW_MODE) ? K : intm; // Final dimension: Q is [`M` x `middle_dim`], R is [`middle_dim` x `N`]
 
 
     // Probe both the factorization as well as `or_un_gqr` to find the optimal lwork
@@ -86,9 +86,9 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
 
     // If mode == FULL, the resulting Q will be `M` x `M`, however, `max_dim` is used to
     // allocate enough space for the entire `a` for `M` < `N`.
-    // If mode == RAW, the `tau` have to be returned, else a temporary buffer is sufficient.
+    // If mode == RAW_MODE, the `tau` have to be returned, else a temporary buffer is sufficient.
     CBLAS_INT buf_size = (mode == QR_mode::FULL) ? M * max_dim : M * N;
-    CBLAS_INT tau_size = (mode == QR_mode::RAW) ? 0 : K;
+    CBLAS_INT tau_size = (mode == QR_mode::RAW_MODE) ? 0 : K;
     T *buffer = (T *)malloc((buf_size + lwork + tau_size) * sizeof(T));
     if ( buffer == NULL ) { info = -101; return int(info); }
 
@@ -125,7 +125,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
         if (mode != QR_mode::R) {
             slice_ptr_Q = compute_slice_ptr(idx, Q_data, ndim, shape, strides_Q);
         }
-        if (mode == QR_mode::RAW) {
+        if (mode == QR_mode::RAW_MODE) {
             slice_ptr_tau = compute_slice_ptr(idx, tau_data, ndim, shape, strides_tau);
         } else { // `tau` might still be required, but should not be returned, so buffer is sufficient.
             slice_ptr_tau = tau_buffer;
@@ -178,7 +178,7 @@ _qr(PyArrayObject *ap_Am, PyArrayObject *ap_Q, PyArrayObject *ap_R, PyArrayObjec
 
         // In the case of `raw` mode, the output of `geqrf`/`geqp3` is what is expected in `Q`.
         // Since the usecase for `mode="raw"` will mostly be to use it for other LAPACK calls, keep in F-order.
-        if (mode == QR_mode::RAW) {
+        if (mode == QR_mode::RAW_MODE) {
             memcpy(slice_ptr_Q, data_A, intm * intn * sizeof(T));
         }
 


### PR DESCRIPTION
This PR fixes the AIX CI build break of scipy.

The build of Scipy in AIX breaks with the below error:

```
fdiagnostics-color=always -D_GLIBCXX_ASSERTIONS=1 -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++17 -O2 -g -maix64 -fPIC -fopenmp -DNPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION -MD -MQ scipy/linalg/_batched_linalg.cpython-312.so.p/src__batched_linalg_module.cc.o -MF scipy/linalg/_batched_linalg.cpython-312.so.p/src__batched_linalg_module.cc.o.d -o scipy/linalg/_batched_linalg.cpython-312.so.p/src__batched_linalg_module.cc.o -c ../scipy/linalg/src/_batched_linalg_module.cc In file included from /usr/include/sys/termio.h:36,
                 from /opt/freeware/include/python3.12/pyport.h:441,
                 from /opt/freeware/include/python3.12/Python.h:38,
                 from ../scipy/linalg/src/_linalg_inv.hh:4,
                 from ../scipy/linalg/src/_batched_linalg_module.cc:2:
../scipy/linalg/src/_common_array_utils.hh:928:5: error: expected identifier before numeric constant
  928 |     RAW = 21,
      |     ^~~
../scipy/linalg/src/_common_array_utils.hh:928:5: error: expected '}' before numeric constant
In file included from ../scipy/linalg/src/_linalg_inv.hh:11:
../scipy/linalg/src/_common_array_utils.hh:925:1: note: to match this '{'
  925 | {
      | ^
../scipy/linalg/src/_common_array_utils.hh:928:5: error: expected unqualified-id before numeric constant
  928 |     RAW = 21,
```

This is because in AIX in /usr/include/sys/termio.h we include ioctl.h where AIX has a macro RAW, which is defined as
`#define     RAW     0x00000020  /* no i/o processing */`

This causes RAW to be preprocessed, leading to the build break.


