### PR TITLE
PoC: ENH: optimize: convert `pava` to nanobind, array API support for `isotonic_regression`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,8 @@ pip-wheel-metadata
 installdir/
 .mesonpy/
 .wraplock
+subprojects/nanobind-*
+subprojects/robin-map-*
 
 # doit
 ######

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ pip-wheel-metadata
 installdir/
 .mesonpy/
 .wraplock
+subprojects/nanobind-*
+subprojects/robin-map-*
 
 # doit
 ######

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -95,6 +95,7 @@ inc_f2py = include_directories(incdir_f2py)
 fortranobject_c = incdir_f2py / 'fortranobject.c'
 
 pybind11_dep = dependency('pybind11', version: '>=2.13.2')
+nanobind_dep = dependency('nanobind')
 
 # Pythran include directory and build flags
 if use_pythran

--- a/scipy/meson.build
+++ b/scipy/meson.build
@@ -42,6 +42,8 @@ pybind11_dep = declare_dependency(
   compile_args: cpp.get_supported_arguments('-Wno-unused-template'),
 )
 
+nanobind_dep = dependency('nanobind')
+
 # Pythran include directory and build flags
 if use_pythran
   # This external-property may not be needed if we can use the native include

--- a/scipy/optimize/_isotonic.py
+++ b/scipy/optimize/_isotonic.py
@@ -6,7 +6,7 @@ from scipy._external import array_api_extra as xpx
 from scipy._lib._array_api import array_namespace, _asarray, is_numpy, xp_capabilities
 
 from ._optimize import OptimizeResult
-from ._pava_pybind import pava
+from ._pava import pava
 
 if TYPE_CHECKING:
     import numpy.typing as npt

--- a/scipy/optimize/_isotonic.py
+++ b/scipy/optimize/_isotonic.py
@@ -2,6 +2,9 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from scipy._external import array_api_extra as xpx
+from scipy._lib._array_api import array_namespace, _asarray, is_numpy, xp_capabilities
+
 from ._optimize import OptimizeResult
 from ._pava_pybind import pava
 
@@ -12,6 +15,10 @@ if TYPE_CHECKING:
 __all__ = ["isotonic_regression"]
 
 
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[("dask.array", "no nanobind support")]
+)
 def isotonic_regression(
     y: "npt.ArrayLike",
     *,
@@ -120,24 +127,27 @@ def isotonic_regression(
     input y of length 1000, the minimizer takes about 4 seconds, while
     ``isotonic_regression`` takes about 200 microseconds.
     """
-    yarr = np.atleast_1d(y)  # Check yarr.ndim == 1 is implicit (pybind11) in pava.
-    order = slice(None) if increasing else slice(None, None, -1)
-    x = np.array(yarr[order], order="C", dtype=np.float64, copy=True)
+    xp = array_namespace(y, weights)
+    yarr = xpx.atleast_nd(y, ndim=1, xp=xp)
+    yarr = yarr if increasing else xp.flip(yarr, axis=-1)
+    x = _asarray(yarr, order="C", dtype=xp.float64, copy=True, xp=xp)
     if weights is None:
-        wx = np.ones_like(yarr, dtype=np.float64)
+        wx = xp.ones_like(yarr, dtype=xp.float64)
     else:
-        warr = np.atleast_1d(weights)
+        warr = xpx.atleast_nd(weights, ndim=1, xp=xp)
 
         if not (yarr.ndim == warr.ndim == 1 and yarr.shape[0] == warr.shape[0]):
             raise ValueError(
                 "Input arrays y and w must have one dimension of equal length."
             )
-        if np.any(warr <= 0):
+        if xp.any(warr <= 0):
             raise ValueError("Weights w must be strictly positive.")
 
-        wx = np.array(warr[order], order="C", dtype=np.float64, copy=True)
+        warr = warr if increasing else xp.flip(warr, axis=-1)
+        wx = _asarray(warr, order="C", dtype=xp.float64, copy=True)
     n = x.shape[0]
-    r = np.full(shape=n + 1, fill_value=-1, dtype=np.intp)
+    r_dtype = np.intp if is_numpy(xp) else xp.int64
+    r = xp.full(shape=n + 1, fill_value=-1, dtype=r_dtype)
     x, wx, r, b = pava(x, wx, r)
     # Now that we know the number of blocks b, we only keep the relevant part
     # of r and wx.
@@ -147,9 +157,9 @@ def isotonic_regression(
     r = r[:b + 1]  # type: ignore[assignment]
     wx = wx[:b]
     if not increasing:
-        x = x[::-1]
-        wx = wx[::-1]
-        r = r[-1] - r[::-1]
+        x = xp.flip(x, axis=-1)
+        wx = xp.flip(wx, axis=-1)
+        r = r[-1] - xp.flip(r, axis=-1)
     return OptimizeResult(
         x=x,
         weights=wx,

--- a/scipy/optimize/_isotonic.py
+++ b/scipy/optimize/_isotonic.py
@@ -2,6 +2,9 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from scipy._external import array_api_extra as xpx
+from scipy._lib._array_api import array_namespace, _asarray, is_numpy, xp_capabilities
+
 from ._optimize import OptimizeResult
 from ._pava_pybind import pava
 
@@ -12,6 +15,10 @@ if TYPE_CHECKING:
 __all__ = ["isotonic_regression"]
 
 
+@xp_capabilities(
+    cpu_only=True, jax_jit=False,
+    skip_backends=[("dask.array", "no nanobind support")]
+)
 def isotonic_regression(
     y: "npt.ArrayLike",
     *,
@@ -120,24 +127,27 @@ def isotonic_regression(
     input y of length 1000, the minimizer takes about 4 seconds, while
     ``isotonic_regression`` takes about 200 microseconds.
     """
-    yarr = np.atleast_1d(y)  # Check yarr.ndim == 1 is implicit (pybind11) in pava.
-    order = slice(None) if increasing else slice(None, None, -1)
-    x = np.array(yarr[order], order="C", dtype=np.float64, copy=True)
+    xp = array_namespace(y, weights)
+    yarr = xpx.atleast_nd(y, ndim=1, xp=xp)
+    yarr = yarr if increasing else xp.flip(yarr, axis=-1)
+    x = _asarray(yarr, order="C", dtype=xp.float64, copy=True, xp=xp)
     if weights is None:
-        wx = np.ones_like(yarr, dtype=np.float64)
+        wx = xp.ones_like(yarr, dtype=xp.float64)
     else:
-        warr = np.atleast_1d(weights)
+        warr = xpx.atleast_nd(weights, ndim=1, xp=xp)
 
         if not (yarr.ndim == warr.ndim == 1 and yarr.shape[0] == warr.shape[0]):
             raise ValueError(
                 "Input arrays y and w must have one dimension of equal length."
             )
-        if np.any(warr <= 0):
+        if xp.any(warr <= 0):
             raise ValueError("Weights w must be strictly positive.")
 
-        wx = np.array(warr[order], order="C", dtype=np.float64, copy=True)
+        warr = warr if increasing else xp.flip(warr, axis=-1)
+        wx = _asarray(warr, order="C", dtype=xp.float64, copy=True)
     n = x.shape[0]
-    r = np.full(shape=n + 1, fill_value=-1, dtype=np.intp)
+    r_dtype = np.intp if is_numpy(xp) else xp.int64
+    r = xp.full(shape=n + 1, fill_value=-1, dtype=r_dtype)
     x, wx, r, b = pava(x, wx, r)
     # Now that we know the number of blocks b, we only keep the relevant part
     # of r and wx.
@@ -147,9 +157,9 @@ def isotonic_regression(
     r = r[:b + 1]
     wx = wx[:b]
     if not increasing:
-        x = x[::-1]
-        wx = wx[::-1]
-        r = r[-1] - r[::-1]
+        x = xp.flip(x, axis=-1)
+        wx = xp.flip(wx, axis=-1)
+        r = r[-1] - xp.flip(r, axis=-1)
     return OptimizeResult(
         x=x,
         weights=wx,

--- a/scipy/optimize/_pava/pava.cpp
+++ b/scipy/optimize/_pava/pava.cpp
@@ -108,7 +108,7 @@ auto pava(Array xa, Array wa, IndexArray ra) {
     return std::make_tuple(xa, wa, ra, b + 1);  // b + 1 is number of blocks
 }
 
-NB_MODULE(_pava_pybind, m) {
+NB_MODULE(_pava, m) {
     m.def(
         "pava",
         &pava,

--- a/scipy/optimize/_pava/pava_pybind.cpp
+++ b/scipy/optimize/_pava/pava_pybind.cpp
@@ -1,17 +1,29 @@
-#include <pybind11/pybind11.h>
-#include <pybind11/numpy.h>
-#include <numpy/arrayobject.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/tuple.h>
+
+#include <cstdint>
+#include <string>
 #include <tuple>
 
-namespace py = pybind11;
+namespace nb = nanobind;
 
 namespace {
+using Array = nb::ndarray<double, nb::device::cpu, nb::c_contig>;
+using IndexArray = nb::ndarray<intptr_t, nb::device::cpu, nb::c_contig>;
 
-auto pava(
-    py::array_t<double, py::array::c_style | py::array::forcecast> xa,
-    py::array_t<double, py::array::c_style | py::array::forcecast> wa,
-    py::array_t<intptr_t, py::array::c_style | py::array::forcecast> ra
-) {
+template <typename T>
+static void check_ndim(const nb::ndarray<T, nb::device::cpu, nb::c_contig> &a) {
+    if (a.ndim() != 1) {
+        const std::string msg =
+            "array has incorrect number of dimensions: " +
+            std::to_string(a.ndim()) +
+            "; expected 1";
+        throw nb::value_error(msg.c_str());
+    }
+}
+
+auto pava(Array xa, Array wa, IndexArray ra) {
     // x is the response variable (often written as y). Its ordering is crucial.
     // Usually, it is sorted according to some other data (feature or covariate), e.g.
     //   indices = np.argsort(z)
@@ -20,11 +32,14 @@ auto pava(
     // w is an array of case weights, modified inplace.
     // r is an array of indices such that x[r[i]:r[i+1]] contains the i-th block,
     // modified inplace.
+    check_ndim(xa);
+    check_ndim(wa);
+    check_ndim(ra);
+    auto x = xa.view<nb::ndim<1>>();
+    auto w = wa.view<nb::ndim<1>>();
+    auto r = ra.view<nb::ndim<1>>();
 
-    auto x = xa.mutable_unchecked<1>();
-    intptr_t n = x.shape(0);
-    auto w = wa.mutable_unchecked<1>();
-    auto r = ra.mutable_unchecked<1>();
+    intptr_t n = static_cast<intptr_t>(x.shape(0));
 
     // Algorithm 1 of
     // Busing, F. M. T. A. (2022).
@@ -42,81 +57,85 @@ auto pava(
     //    r = [0, 1, 2] instead of r = [0, 2].
     //
     // procedure monotone(n, x, w)      // 1: x in expected order and w nonnegative
-    r[0] = 0;  // 2: initialize index 0
-    r[1] = 1;  // 3: initialize index 1
+    r(0) = 0;  // 2: initialize index 0
+    r(1) = 1;  // 3: initialize index 1
     intptr_t b = 0;  // 4: initialize block counter
-    double xb_prev = x[b];  // 5: set previous block value
-    double wb_prev = w[b];  // 6: set previous block weight
+    double xb_prev = x(0);  // 5: set previous block value
+    double wb_prev = w(0);  // 6: set previous block weight
+
     for (intptr_t i = 1; i < n; ++i) {  // 7: loop over elements
         b++;  // 8: increase number of blocks
-        double xb = x[i];  // 9: set current block value xb (i, not b)
-        double wb = w[i];  // 10: set current block weight wb (i, not b)
+        double xb = x(i);  // 9: set current block value xb (i, not b)
+        double wb = w(i);  // 10: set current block weight wb (i, not b)
         double sb = 0;
+
         if (xb_prev >= xb) {  // 11: check for down violation of x (>= instead of >)
             b--;  // 12: decrease number of blocks
             sb = wb_prev * xb_prev + wb * xb;  // 13: set current weighted block sum
             wb += wb_prev;  // 14: set new current block weight
             xb = sb / wb;  // 15: set new current block value
-            while (i < n - 1 && xb >= x[i + 1]) {  // 16: repair up violations
+
+            while (i < n - 1 && xb >= x(i + 1)) {  // 16: repair up violations
                 i++;
-                sb += w[i] * x[i];  // 18: set new current weighted block sum
-                wb += w[i];
+                sb += w(i) * x(i);  // 18: set new current weighted block sum
+                wb += w(i);
                 xb = sb / wb;
             }
-            while (b > 0 && x[b - 1] >= xb) {  // 22: repair down violations (>= instead of >)
+
+            while (b > 0 && x(b - 1) >= xb) {  // 22: repair down violations (>= instead of >)
                 b--;
-                sb += w[b] * x[b];
-                wb += w[b];
+                sb += w(b) * x(b);
+                wb += w(b);
                 xb = sb / wb;  // 26: set new current block value
             }
         }
-        x[b] = xb_prev = xb;  // 29: save block value
-        w[b] = wb_prev = wb;  // 30: save block weight
-        r[b + 1] = i + 1;  // 31: save block index
+
+        x(b) = xb_prev = xb;  // 29: save block value
+        w(b) = wb_prev = wb;  // 30: save block weight
+        r(b + 1) = i + 1;  // 31: save block index
     }
 
     intptr_t f = n - 1;  // 33: initialize "from" index
     for (intptr_t k = b; k >= 0; --k) {  // 34: loop over blocks
-        intptr_t t = r[k];  // 35: set "to" index
-        double xk = x[k];
+        intptr_t t = r(k);  // 35: set "to" index
+        double xk = x(k);
         for (intptr_t i = f; i >= t; --i) {  // 37: loop "from" downto "to"
-            x[i] = xk;  // 38: set all elements equal to block value
+            x(i) = xk;  // 38: set all elements equal to block value
         }
         f = t - 1;  // 40: set new "from" equal to old "to" minus one
     }
+
     return std::make_tuple(xa, wa, ra, b + 1);  // b + 1 is number of blocks
 }
 
-PYBIND11_MODULE(_pava_pybind, m, py::mod_gil_not_used()) {
-    if (_import_array() != 0) {
-        throw py::error_already_set();
-    }
+NB_MODULE(_pava_pybind, m) {
     m.def(
         "pava",
         &pava,
-        "Pool adjacent violators algorithm (PAVA) for isotonic regression\n"
-        "\n"
-        "The routine might modify the input arguments x, w and r inplace.\n"
-        "\n"
-        "Parameters\n"
-        "----------\n"
-        "xa : contiguous ndarray of shape (n,) and dtype np.float64\n"
-        "wa : contiguous ndarray of shape (n,) and dtype np.float64\n"
-        "ra : contiguous ndarray of shape (n+1,) and dtype np.intp\n"
-        "\n"
-        "Returns\n"
-        "-------\n"
-        "x : ndarray\n"
-        "    The isotonic solution.\n"
-        "w : ndarray\n"
-        "    The array of weights for each block.\n"
-        "r : ndarray\n"
-        "    The array of indices for each block, such that xa[ra[i]:ra[i+1]]\n"
-        "    is the i-th block with all elements having the same value.\n"
-        "b : np.intp\n"
-        "    Number of blocks.\n",
-        py::arg("x"), py::arg("w"), py::arg("indices")
+        R"(Pool adjacent violators algorithm (PAVA) for isotonic regression
+
+The routine might modify the input arguments x, w and r inplace.
+
+Parameters
+----------
+xa : contiguous ndarray of shape (n,) and dtype np.float64
+wa : contiguous ndarray of shape (n,) and dtype np.float64
+ra : contiguous ndarray of shape (n+1,) and dtype np.intp
+
+Returns
+-------
+x : ndarray
+    The isotonic solution.
+w : ndarray
+    The array of weights for each block.
+r : ndarray
+    The array of indices for each block, such that xa[ra[i]:ra[i+1]]
+    is the i-th block with all elements having the same value.
+b : np.intp
+    Number of blocks.
+)",
+        nb::arg("x"), nb::arg("w"), nb::arg("indices")
     );
 }
 
-}  // namespace (anonymous)
+}  // namespace

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -91,7 +91,7 @@ py3.extension_module('_moduleTNC',
 py3.extension_module('_pava_pybind',
   ['_pava/pava_pybind.cpp'],
   include_directories: '_pava',
-  dependencies: [np_dep, pybind11_dep],
+  dependencies: [np_dep, nanobind_dep],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/optimize'

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -88,9 +88,8 @@ py3.extension_module('_moduleTNC',
   subdir: 'scipy/optimize'
 )
 
-py3.extension_module('_pava_pybind',
-  ['_pava/pava_pybind.cpp'],
-  include_directories: '_pava',
+py3.extension_module('_pava',
+  ['_pava/pava.cpp'],
   dependencies: [np_dep, nanobind_dep],
   link_args: version_link_args,
   install: true,

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -89,9 +89,8 @@ py3.extension_module('_moduleTNC',
   subdir: 'scipy/optimize'
 )
 
-py3.extension_module('_pava_pybind',
-  ['_pava/pava_pybind.cpp'],
-  include_directories: '_pava',
+py3.extension_module('_pava',
+  ['_pava/pava.cpp'],
   dependencies: [np_dep, nanobind_dep],
   link_args: version_link_args,
   install: true,

--- a/scipy/optimize/meson.build
+++ b/scipy/optimize/meson.build
@@ -92,7 +92,7 @@ py3.extension_module('_moduleTNC',
 py3.extension_module('_pava_pybind',
   ['_pava/pava_pybind.cpp'],
   include_directories: '_pava',
-  dependencies: [np_dep, pybind11_dep],
+  dependencies: [np_dep, nanobind_dep],
   link_args: version_link_args,
   install: true,
   subdir: 'scipy/optimize'

--- a/scipy/optimize/tests/test_isotonic_regression.py
+++ b/scipy/optimize/tests/test_isotonic_regression.py
@@ -6,7 +6,7 @@ from scipy._lib._array_api import (
     lazy_xp_function
 )
 from scipy._external import array_api_extra as xpx
-from scipy.optimize._pava_pybind import pava
+from scipy.optimize._pava import pava
 from scipy.optimize import isotonic_regression
 
 lazy_xp_function(isotonic_regression)

--- a/scipy/optimize/tests/test_isotonic_regression.py
+++ b/scipy/optimize/tests/test_isotonic_regression.py
@@ -1,11 +1,18 @@
 import numpy as np
-from numpy.testing import assert_allclose, assert_equal
 import pytest
 
+from scipy._lib._array_api import (
+    is_numpy, make_xp_test_case, xp_assert_close, xp_assert_equal,
+    lazy_xp_function
+)
+from scipy._external import array_api_extra as xpx
 from scipy.optimize._pava_pybind import pava
 from scipy.optimize import isotonic_regression
 
+lazy_xp_function(isotonic_regression)
+lazy_xp_function(pava, jax_jit=False)
 
+@make_xp_test_case(isotonic_regression)
 class TestIsotonicRegression:
     @pytest.mark.parametrize(
         ("y", "w", "msg"),
@@ -24,84 +31,93 @@ class TestIsotonicRegression:
              "Weights w must be strictly positive"),
         ]
     )
-    def test_raise_error(self, y, w, msg):
+    def test_raise_error(self, y, w, msg, xp):
+        y, w = map(lambda x: xp.asarray(x) if x is not None else x, [y, w])
         with pytest.raises(ValueError, match=msg):
             isotonic_regression(y=y, weights=w)
 
-    def test_simple_pava(self):
+    
+    def test_simple_pava(self, xp):
         # Test case of Busing 2020
         # https://doi.org/10.18637/jss.v102.c01
-        y = np.array([8, 4, 8, 2, 2, 0, 8], dtype=np.float64)
-        w = np.ones_like(y)
-        r = np.full(shape=y.shape[0] + 1, fill_value=-1, dtype=np.intp)
+        y = xp.asarray([8, 4, 8, 2, 2, 0, 8], dtype=xp.float64)
+        w = xp.ones_like(y)
+        dtype = np.intp if is_numpy(xp) else xp.int64
+        r = xp.full(shape=y.shape[0] + 1, fill_value=-1, dtype=dtype)
         pava(y, w, r)
-        assert_allclose(y, [4, 4, 4, 4, 4, 4, 8])
+        xp_assert_close(y, xp.asarray([4, 4, 4, 4, 4, 4, 8], dtype=xp.float64))
         # Only first 2 elements of w are changed.
-        assert_allclose(w, [6, 1, 1, 1, 1, 1, 1])
+        xp_assert_close(w, xp.asarray([6, 1, 1, 1, 1, 1, 1], dtype=xp.float64))
         # Only first 3 elements of r are changed.
-        assert_allclose(r, [0, 6, 7, -1, -1, -1, -1, -1])
+        xp_assert_close(r, xp.asarray([0, 6, 7, -1, -1, -1, -1, -1], dtype=dtype))
 
     @pytest.mark.parametrize("y_dtype", [np.float64, np.float32, np.int64, np.int32])
     @pytest.mark.parametrize("w_dtype", [np.float64, np.float32, np.int64, np.int32])
     @pytest.mark.parametrize("w", [None, "ones"])
-    def test_simple_isotonic_regression(self, w, w_dtype, y_dtype):
+    def test_simple_isotonic_regression(self, w, w_dtype, y_dtype, xp):
         # Test case of Busing 2020
         # https://doi.org/10.18637/jss.v102.c01
-        y = np.array([8, 4, 8, 2, 2, 0, 8], dtype=y_dtype)
+        y = xp.asarray(np.array([8, 4, 8, 2, 2, 0, 8], dtype=y_dtype))
         if w is not None:
-            w = np.ones_like(y, dtype=w_dtype)
+            w = xp.asarray(np.ones_like(y, dtype=w_dtype))
         res = isotonic_regression(y, weights=w)
-        assert res.x.dtype == np.float64
-        assert res.weights.dtype == np.float64
-        assert_allclose(res.x, [4, 4, 4, 4, 4, 4, 8])
-        assert_allclose(res.weights, [6, 1])
-        assert_allclose(res.blocks, [0, 6, 7])
+        xp_assert_close(res.x, xp.asarray([4, 4, 4, 4, 4, 4, 8], dtype=xp.float64))
+        xp_assert_close(res.weights, xp.asarray([6, 1], dtype=xp.float64))
+        blocks_dtype = xpx.default_dtype(xp, kind="integral")
+        xp_assert_close(res.blocks, xp.asarray([0, 6, 7], dtype=blocks_dtype))
         # Assert that y was not overwritten
-        assert_equal(y, np.array([8, 4, 8, 2, 2, 0, 8], dtype=np.float64))
+        xp_assert_equal(y, xp.asarray(np.asarray([8, 4, 8, 2, 2, 0, 8], y_dtype)))
 
     @pytest.mark.parametrize("increasing", [True, False])
-    def test_linspace(self, increasing):
+    def test_linspace(self, increasing, xp):
         n = 10
-        y = np.linspace(0, 1, n) if increasing else np.linspace(1, 0, n)
+        y = xp.linspace(0, 1, n) if increasing else xp.linspace(1, 0, n)
         res = isotonic_regression(y, increasing=increasing)
-        assert_allclose(res.x, y)
-        assert_allclose(res.blocks, np.arange(n + 1))
+        xp_assert_close(res.x, xp.astype(y, xp.float64))
+        xp_assert_close(res.blocks, xp.arange(n + 1))
 
-    def test_weights(self):
-        w = np.array([1, 2, 5, 0.5, 0.5, 0.5, 1, 3])
-        y = np.array([3, 2, 1, 10, 9, 8, 20, 10])
+    def test_weights(self, xp):
+        w = xp.asarray([1, 2, 5, 0.5, 0.5, 0.5, 1, 3])
+        y = xp.asarray([3, 2, 1, 10, 9, 8, 20, 10])
         res = isotonic_regression(y, weights=w)
-        assert_allclose(res.x, [12/8, 12/8, 12/8, 9, 9, 9, 50/4, 50/4])
-        assert_allclose(res.weights, [8, 1.5, 4])
-        assert_allclose(res.blocks, [0, 3, 6, 8])
+        xp_assert_close(
+            res.x,
+            xp.asarray([12/8, 12/8, 12/8, 9, 9, 9, 50/4, 50/4], dtype=xp.float64)
+        )
+        xp_assert_close(res.weights, xp.asarray([8, 1.5, 4], dtype=xp.float64))
+        blocks_dtype = xpx.default_dtype(xp, kind="integral")
+        xp_assert_close(res.blocks, xp.asarray([0, 3, 6, 8], dtype=blocks_dtype))
 
         # weights are like repeated observations, we repeat the 3rd element 5
         # times.
-        w2 = np.array([1, 2, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5, 1, 3])
-        y2 = np.array([3, 2, 1, 1, 1, 1, 1, 10, 9, 8, 20, 10])
+        w2 = xp.asarray([1, 2, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5, 1, 3])
+        y2 = xp.asarray([3, 2, 1, 1, 1, 1, 1, 10, 9, 8, 20, 10])
         res2 = isotonic_regression(y2, weights=w2)
-        assert_allclose(np.diff(res2.x[0:7]), 0)
-        assert_allclose(res2.x[4:], res.x)
-        assert_allclose(res2.weights, res.weights)
-        assert_allclose(res2.blocks[1:] - 4, res.blocks[1:])
+        xp_assert_close(
+            xp.diff(res2.x[0:7]), xp.asarray(0),
+            check_dtype=False, check_shape=False
+        )
+        xp_assert_close(res2.x[4:], res.x)
+        xp_assert_close(res2.weights, res.weights)
+        xp_assert_close(res2.blocks[1:] - 4, res.blocks[1:])
 
-    def test_against_R_monotone(self):
-        y = [0, 6, 8, 3, 5, 2, 1, 7, 9, 4]
+    def test_against_R_monotone(self, xp):
+        y = xp.asarray([0, 6, 8, 3, 5, 2, 1, 7, 9, 4])
         res = isotonic_regression(y)
         # R code
         # library(monotone)
         # options(digits=8)
         # monotone(c(0, 6, 8, 3, 5, 2, 1, 7, 9, 4))
-        x_R = [
+        x_R = xp.asarray([
             0, 4.1666667, 4.1666667, 4.1666667, 4.1666667, 4.1666667,
             4.1666667, 6.6666667, 6.6666667, 6.6666667,
-        ]
-        assert_allclose(res.x, x_R)
-        assert_equal(res.blocks, [0, 1, 7, 10])
+        ], dtype=xp.float64)
+        xp_assert_close(res.x, x_R)
+        xp_assert_equal(res.blocks, xp.asarray([0, 1, 7, 10]))
 
         n = 100
-        y = np.linspace(0, 1, num=n, endpoint=False)
-        y = 5 * y + np.sin(10 * y)
+        y = xp.linspace(0, 1, num=n, endpoint=False)
+        y = 5 * y + xp.sin(10 * y)
         res = isotonic_regression(y)
         # R code
         # library(monotone)
@@ -109,7 +125,7 @@ class TestIsotonicRegression:
         # y <- 5 * ((1:n)-1)/n + sin(10 * ((1:n)-1)/n)
         # options(digits=8)
         # monotone(y)
-        x_R = [
+        x_R = xp.asarray([
             0.00000000, 0.14983342, 0.29866933, 0.44552021, 0.58941834, 0.72942554,
             0.86464247, 0.99421769, 1.11735609, 1.23332691, 1.34147098, 1.44120736,
             1.53203909, 1.57081100, 1.57081100, 1.57081100, 1.57081100, 1.57081100,
@@ -127,41 +143,44 @@ class TestIsotonicRegression:
             4.86564130, 4.86564130, 4.86564130, 4.86564130, 4.86564130, 4.86564130,
             4.86564130, 4.86564130, 4.86564130, 4.86564130, 4.86564130, 4.86564130,
             4.86564130, 4.86564130, 4.86564130, 4.86564130,
-        ]
-        assert_allclose(res.x, x_R)
+        ], dtype=xp.float64)
+        atol = 10 * xp.finfo(y.dtype).eps
+        xp_assert_close(res.x, x_R, atol=atol)
 
         # Test increasing
-        assert np.all(np.diff(res.x) >= 0)
+        assert xp.all(xp.diff(res.x) >= 0)
 
         # Test balance property: sum(y) == sum(x)
-        assert_allclose(np.sum(res.x), np.sum(y))
+        xp_assert_close(xp.sum(res.x), xp.sum(y, dtype=xp.float64))
 
         # Reverse order
         res_inv = isotonic_regression(-y, increasing=False)
-        assert_allclose(-res_inv.x, res.x)
-        assert_equal(res_inv.blocks, res.blocks)
+        xp_assert_close(-res_inv.x, res.x)
+        xp_assert_equal(res_inv.blocks, res.blocks)
 
-    def test_readonly(self):
-        x = np.arange(3, dtype=float)
-        w = np.ones(3, dtype=float)
+    def test_readonly(self, xp):
+        x = xp.arange(3, dtype=xp.float64)
+        w = xp.ones(3, dtype=xp.float64)
 
-        x.flags.writeable = False
-        w.flags.writeable = False
-
-        res = isotonic_regression(x, weights=w)
-        assert np.all(np.isfinite(res.x))
-        assert np.all(np.isfinite(res.weights))
-        assert np.all(np.isfinite(res.blocks))
-
-    def test_non_contiguous_arrays(self):
-        x = np.arange(10, dtype=float)[::3]
-        w = np.ones(10, dtype=float)[::3]
-        assert not x.flags.c_contiguous
-        assert not x.flags.f_contiguous
-        assert not w.flags.c_contiguous
-        assert not w.flags.f_contiguous
+        if is_numpy(xp):
+            x.flags.writeable = False
+            w.flags.writeable = False
 
         res = isotonic_regression(x, weights=w)
-        assert np.all(np.isfinite(res.x))
-        assert np.all(np.isfinite(res.weights))
-        assert np.all(np.isfinite(res.blocks))
+        assert xp.all(xp.isfinite(res.x))
+        assert xp.all(xp.isfinite(res.weights))
+        assert xp.all(xp.isfinite(res.blocks))
+
+    def test_non_contiguous_arrays(self, xp):
+        x = xp.arange(10, dtype=xp.float64)[::3]
+        w = xp.ones(10, dtype=xp.float64)[::3]
+        if is_numpy(xp):
+            assert not x.flags.c_contiguous
+            assert not x.flags.f_contiguous
+            assert not w.flags.c_contiguous
+            assert not w.flags.f_contiguous
+
+        res = isotonic_regression(x, weights=w)
+        assert xp.all(xp.isfinite(res.x))
+        assert xp.all(xp.isfinite(res.weights))
+        assert xp.all(xp.isfinite(res.blocks))

--- a/subprojects/nanobind.wrap
+++ b/subprojects/nanobind.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = nanobind-2.12.0
+source_url = https://github.com/wjakob/nanobind/archive/refs/tags/v2.12.0.tar.gz
+source_filename = nanobind-2.12.0.tar.gz
+source_hash = 01f1f0cd0398743c18f33d07ae36ad410bd7f4a1e90683b508504de897d6e629
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/nanobind_2.12.0-1/get_source/nanobind-2.12.0.tar.gz
+patch_filename = nanobind_2.12.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/nanobind_2.12.0-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/nanobind_2.12.0-1/nanobind_2.12.0-1_patch.zip
+patch_hash = 4b8158bdb359218bcfb7a5b4459fbfa5919171d9ea2400de3a84cf9ab7c7308b
+wrapdb_version = 2.12.0-1
+
+[provide]
+dependency_names = nanobind

--- a/subprojects/robin-map.wrap
+++ b/subprojects/robin-map.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = robin-map-1.4.0
+source_url = https://github.com/Tessil/robin-map/archive/refs/tags/v1.4.0.tar.gz
+source_filename = robin-map-1.4.0.tar.gz
+source_hash = 7930dbf9634acfc02686d87f615c0f4f33135948130b8922331c16d90a03250c
+patch_filename = robin-map_1.4.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/robin-map_1.4.0-1/get_patch
+patch_hash = feb14b6752b7d439fb2f3ee968e595a9a3de00ef8cb029488af2ceb4f504b95d
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/robin-map_1.4.0-1/robin-map-1.4.0.tar.gz
+wrapdb_version = 1.4.0-1
+
+[provide]
+robin-map = robin_map_dep


### PR DESCRIPTION
gh-19878

Note that `nanobind` doesn't ship a pkg-config file, the recommended way to use it with `meson` is to pull in the source as a `subproject`: https://nanobind.readthedocs.io/en/latest/meson.html#building-extensions-using-meson. Doesn't seem ideal...

AI disclosure: ChatGPT performed the initial conversion. I then added the `check_ndim` function so that we can fail with the error message the tests expect at runtime on invalid ndim input, rather than getting nanobind's quite generic and opaque error message.