### PR TITLE
ENH: sparse.csgraph.connected_components: state-of-the-art implementation of Tarjan's algorithm

### DIFF
--- a/benchmarks/benchmarks/sparse_csgraph.py
+++ b/benchmarks/benchmarks/sparse_csgraph.py
@@ -5,7 +5,7 @@ import scipy.sparse
 from .common import Benchmark, safe_import
 
 with safe_import():
-    from scipy.sparse.csgraph import laplacian
+    from scipy.sparse.csgraph import laplacian, connected_components
 
 
 class Laplacian(Benchmark):
@@ -28,3 +28,34 @@ class Laplacian(Benchmark):
 
     def time_laplacian(self, n, format, normed):
         laplacian(self.A, normed=normed)
+
+class StronglyConnectedComponents(Benchmark):
+    params = [["random", "single_scc", "chain"]]
+    param_names = ["kind"]
+
+    def setup(self, kind):
+        n = 1_000_000
+        rng = np.random.default_rng(42)
+        if kind == "random":
+            self.G = scipy.sparse.random_array(
+                shape=(n, n),
+                density=100 / n,
+                format="csr",
+                rng=rng,
+            )
+        elif kind == "single_scc":
+            # Hamiltonian cycle (one giant SCC) plus random edges.
+            perm = rng.permutation(n)
+            row = np.concatenate([perm, rng.integers(0, n, size=99 * n)])
+            col = np.concatenate([np.roll(perm, -1), rng.integers(0, n, size=99 * n)])
+            self.G = scipy.sparse.csr_array(
+                (np.ones(len(row)), (row, col)), shape=(n, n)
+            )
+        elif kind == "chain":
+            row = np.arange(n - 1)
+            self.G = scipy.sparse.csr_array(
+                (np.ones(n - 1), (row, row + 1)), shape=(n, n)
+            )
+
+    def time_strongly_connected_components(self, kind):
+        connected_components(self.G, directed=True, connection="strong")

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -750,9 +750,8 @@ cdef int _connected_components_directed2(
 
     The algorithmic complexity is for a graph with E edges and V vertices
     is O(E + V). The storage requirement is an integer array of V
-    elements, plus two stacks of integers whose combined length never
-    exceeds V, and is much smaller in typical graphs. The sign bit of
-    each DFS stack entry encodes the lead flag (candidate SCC root).
+    elements, plus two stacks of at most V integers, which however are
+    usually smaller in practice.
 
     The algorithm uses all improvements described by Tarjan and Zwick in
     their recent survey, plus some further trick used in the Rust
@@ -769,17 +768,25 @@ cdef int _connected_components_directed2(
     cdef int n_comp = 0       # number of emitted components
     cdef int root_hl = 0      # high_link of current DFS-tree root
 
-    # Iterative Tarjan's algorithm using reverse timestamps.
+    # Iterative Tarjan's algorithm using reverse timestamps and
+    # encoding a bit stack of lead nodes in the sign bit of the DFS stack.
+    #
     # Timestamps decrease from N to 1 for discovered nodes.  Component
     # numbers increase from 0 for emitted SCCs.  Unvisited nodes have
-    # high_link = 0, distinguished from component 0 via succ_pos == -1.
-    #
+    # high_link = 0, distinguished from component 0 via succ_pos == VOID.
     # labels doubles as the high_link array.
-    # succ_pos[v]: position in successor list for node v; -1 = unvisited.
-    #   Uses the same type as indptr to avoid overflow on graphs with > 2^31 edges.
+    #
+    # Decreasing timestamp make renumbering at the end unnecessary. The
+    # "lead" flag is materialized in an array in Tarjan & Zwick's survey,
+    # but a stack parallel to the DFS stack is sufficient.
+    #
+    # succ_pos[v]: position in successor list for node v; VOID = unvisited.
+    #
     # dfs_stack[]: DFS path; the sign bit encodes the "lead" flag
-    #   (non-negative = candidate SCC root).
+    #     (non-negative = candidate SCC root).
+    #
     # comp_stack[]: nodes popped from DFS but not yet assigned to an SCC.
+
     cdef vector[int32_or_int64] succ_pos
     cdef vector[int] dfs_stack
     cdef vector[int] comp_stack
@@ -791,13 +798,13 @@ cdef int _connected_components_directed2(
 
     for v in range(N):
         if succ_pos[v] != VOID:
-            continue                       # already visited
+            continue
 
         # ---- Init: new DFS tree rooted at v ----
         root_hl = index
 
         # ---- Previsit v ----
-        dfs_stack.push_back(v)             # lead = True (non-negative)
+        dfs_stack.push_back(v) # lead = True
         labels[v] = index
         index -= 1
         succ_pos[v] = indptr[v]
@@ -812,14 +819,14 @@ cdef int _connected_components_directed2(
 
                 if succ_pos[w] == VOID:
                     # ---- Previsit w (tree arc) ----
-                    dfs_stack.push_back(w)     # lead = True
+                    dfs_stack.push_back(w) # lead = True
                     labels[w] = index
                     index -= 1
                     succ_pos[w] = indptr[w]
                 else:
                     # ---- Revisit (cross / back arc) ----
                     if labels[v] < labels[w]:
-                        dfs_stack[dfs_stack.size() - 1] = v | NONLEAD  # lead = False
+                        dfs_stack[dfs_stack.size() - 1] = v | NONLEAD
                         labels[v] = labels[w]
                         # Early exit: the whole graph is one SCC
                         if labels[v] == root_hl and index == 0:

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -58,8 +58,9 @@ def connected_components(csgraph, directed=True, connection='weak',
 
     References
     ----------
-    .. [1] D. J. Pearce, "An Improved Algorithm for Finding the Strongly
-           Connected Components of a Directed Graph", Technical Report, 2005
+    .. [1] R. E. Tarjan and U. Zwick, "Finding strong components using
+           depth-first search", European Journal of Combinatorics, 119,
+           2024, :doi:`10.1016/j.ejc.2023.103815`
 
     Examples
     --------
@@ -106,8 +107,8 @@ def connected_components(csgraph, directed=True, connection='weak',
 
     if directed:
         n_components = _connected_components_directed(csgraph.indices,
-                                                      csgraph.indptr,
-                                                      labels)
+                                                             csgraph.indptr,
+                                                             labels)
     else:
         csgraph_T = csgraph.T.tocsr()
         n_components = _connected_components_undirected(csgraph.indices,
@@ -722,6 +723,7 @@ cdef unsigned int _depth_first_undirected2(
     return i_nl_end
 
 
+# Author: Sebastiano Vigna  -- <sebastiano.vigna@gmail.com>
 def _connected_components_directed(
         np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
         np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr,
@@ -729,127 +731,126 @@ def _connected_components_directed(
     return _connected_components_directed2(indices, indptr, labels)
 
 
+@cython.boundscheck(False)
+@cython.wraparound(False)
 cdef int _connected_components_directed2(
         np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
         np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr,
         np.ndarray[ITYPE_t, ndim=1, mode='c'] labels) noexcept:
-    """
-    Uses an iterative version of Tarjan's algorithm to find the
-    strongly connected components of a directed graph represented as a
-    sparse array (scipy.sparse.csc_array or scipy.sparse.csr_array).
-
-    The algorithmic complexity is for a graph with E edges and V
-    vertices is O(E + V).
-    The storage requirement is 2*V integer arrays.
-
-    Uses an iterative version of the algorithm described here:
-    http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.102.1707
-
-    For more details of the memory optimisations used see here:
-    http://www.timl.id.au/SCC
-    """
-    cdef int v, w, index, low_v, low_w, label, j
-    cdef int SS_head, root, stack_head, f, b
     DEF VOID = -1
-    DEF END = -2
     cdef int N = labels.shape[0]
-    cdef np.ndarray[ITYPE_t, ndim=1, mode="c"] SS, lowlinks, stack_f, stack_b
+    if N == 0:
+        return 0
 
-    lowlinks = labels
-    SS = np.ndarray((N,), dtype=ITYPE)
-    stack_b = np.ndarray((N,), dtype=ITYPE)
-    stack_f = SS
+    cdef int v, w, j, node, parent
+    cdef int index = N        # timestamp counter, decreasing
+    cdef int dfs_top = -1     # top of DFS path  (dfs_stack[0 … dfs_top])
+    cdef int comp_top = -1    # top of comp stack (comp_stack[0 … comp_top])
+    cdef int n_comp = 0       # number of emitted components
+    cdef int root_hl = 0      # high_link of current DFS-tree root
 
-    # The stack of nodes which have been backtracked and are in the current SCC
-    SS.fill(VOID)
-    SS_head = END
+    # Iterative Tarjan's algorithm using reverse timestamps.
+    # Timestamps decrease from N to 1 for discovered nodes.  Component
+    # numbers increase from 0 for emitted SCCs.  Unvisited nodes have
+    # high_link = 0, distinguished from component 0 via succ_pos == -1.
+    #
+    # labels doubles as the high_link array.
+    # succ_pos[v]: position in successor list for node v; -1 = unvisited.
+    # dfs_stack[]: DFS path; the sign bit encodes the "lead" flag
+    #   (non-negative = candidate SCC root).
+    # comp_stack[]: nodes popped from DFS but not yet assigned to an SCC.
+    cdef np.ndarray[ITYPE_t, ndim=1, mode="c"] succ_pos = \
+        np.ndarray((N,), dtype=ITYPE)
+    cdef np.ndarray[ITYPE_t, ndim=1, mode="c"] dfs_stack = \
+        np.ndarray((N,), dtype=ITYPE)
+    cdef np.ndarray[ITYPE_t, ndim=1, mode="c"] comp_stack = \
+        np.ndarray((N,), dtype=ITYPE)
 
-    # The array containing the lowlinks of nodes not yet assigned an SCC. Shares
-    # memory with the labels array, since they are not used at the same time.
-    lowlinks.fill(VOID)
-
-    # The DFS stack. Stored with both forwards and backwards pointers to allow
-    # us to move a node up to the top of the stack, as we only need to visit
-    # each node once. stack_f shares memory with SS, as nodes aren't put on the
-    # SS stack until after they've been popped from the DFS stack.
-    stack_head = END
-    stack_f.fill(VOID)
-    stack_b.fill(VOID)
-
-    index = 0
-    # Count SCC labels backwards so as not to class with lowlinks values.
-    label = N - 1
     for v in range(N):
-        if lowlinks[v] == VOID:
-            # DFS-stack push
-            stack_head = v
-            stack_f[v] = END
-            stack_b[v] = END
-            while stack_head != END:
-                v = stack_head
-                if lowlinks[v] == VOID:
-                    lowlinks[v] = index
-                    index += 1
+        labels[v] = 0
+        succ_pos[v] = VOID
 
-                    # Add successor nodes
-                    for j in range(indptr[v], indptr[v+1]):
-                        w = indices[j]
-                        if lowlinks[w] == VOID:
-                            with cython.boundscheck(False):
-                                # DFS-stack push
-                                if stack_f[w] != VOID:
-                                    # w is already inside the stack,
-                                    # so excise it.
-                                    f = stack_f[w]
-                                    b = stack_b[w]
-                                    if b != END:
-                                        stack_f[b] = f
-                                    if f != END:
-                                        stack_b[f] = b
+    for v in range(N):
+        if succ_pos[v] != VOID:
+            continue                       # already visited
 
-                                stack_f[w] = stack_head
-                                stack_b[w] = END
-                                stack_b[stack_head] = w
-                                stack_head = w
+        # ---- Init: new DFS tree rooted at v ----
+        root_hl = index
 
+        # ---- Previsit v ----
+        dfs_top = 0
+        dfs_stack[0] = v                   # lead = True (non-negative)
+        labels[v] = index
+        index -= 1
+        succ_pos[v] = indptr[v]
+
+        while dfs_top >= 0:
+            # Decode node (and lead flag) at the DFS top
+            if dfs_stack[dfs_top] >= 0:
+                v = dfs_stack[dfs_top]
+            else:
+                v = ~dfs_stack[dfs_top]
+
+            if succ_pos[v] < indptr[v + 1]:
+                # ---- Advance to next successor ----
+                w = indices[succ_pos[v]]
+                succ_pos[v] += 1
+
+                if succ_pos[w] == VOID:
+                    # ---- Previsit w (tree arc) ----
+                    dfs_top += 1
+                    dfs_stack[dfs_top] = w     # lead = True
+                    labels[w] = index
+                    index -= 1
+                    succ_pos[w] = indptr[w]
                 else:
-                    # DFS-stack pop
-                    stack_head = stack_f[v]
-                    if stack_head >= 0:
-                        stack_b[stack_head] = END
-                    stack_f[v] = VOID
-                    stack_b[v] = VOID
+                    # ---- Revisit (cross / back arc) ----
+                    if labels[v] < labels[w]:
+                        dfs_stack[dfs_top] = ~v    # lead = False
+                        labels[v] = labels[w]
+                        # Early exit: the whole graph is one SCC
+                        if labels[v] == root_hl and index == 0:
+                            labels[v] = n_comp
+                            for j in range(comp_top + 1):
+                                labels[comp_stack[j]] = n_comp
+                            for j in range(dfs_top):
+                                node = dfs_stack[j]
+                                if node < 0:
+                                    node = ~node
+                                labels[node] = n_comp
+                            n_comp += 1
+                            dfs_top = -1
+                            comp_top = -1
+                            break
+            else:
+                # ---- Postvisit v ----
+                if dfs_stack[dfs_top] >= 0:
+                    # v is an SCC root: pop its members from comp stack
+                    dfs_top -= 1
+                    while comp_top >= 0:
+                        if labels[v] < labels[comp_stack[comp_top]]:
+                            break
+                        labels[comp_stack[comp_top]] = n_comp
+                        comp_top -= 1
+                        index += 1
+                    labels[v] = n_comp
+                    index += 1
+                    n_comp += 1
+                else:
+                    # Not a root: push v onto comp stack, propagate
+                    dfs_top -= 1
+                    comp_top += 1
+                    comp_stack[comp_top] = v
+                    if dfs_top >= 0:
+                        if dfs_stack[dfs_top] >= 0:
+                            parent = dfs_stack[dfs_top]
+                        else:
+                            parent = ~dfs_stack[dfs_top]
+                        if labels[parent] < labels[v]:
+                            dfs_stack[dfs_top] = ~parent
+                            labels[parent] = labels[v]
 
-                    root = 1 # True
-                    low_v = lowlinks[v]
-                    for j in range(indptr[v], indptr[v+1]):
-                        low_w = lowlinks[indices[j]]
-                        if low_w < low_v:
-                            low_v = low_w
-                            root = 0 # False
-                    lowlinks[v] = low_v
-
-                    if root: # Found a root node
-                        index -= 1
-                        # while S not empty and rindex[v] <= rindex[top[S]
-                        while SS_head != END and lowlinks[v] <= lowlinks[SS_head]:
-                            w = SS_head        # w = pop(S)
-                            SS_head = SS[w]
-                            SS[w] = VOID
-
-                            labels[w] = label  # rindex[w] = c
-                            index -= 1         # index = index - 1
-                        labels[v] = label  # rindex[v] = c
-                        label -= 1         # c = c - 1
-                    else:
-                        SS[v] = SS_head  # push(S, v)
-                        SS_head = v
-
-    # labels count down from N-1 to zero. Modify them so they
-    # count upward from 0
-    labels *= -1
-    labels += (N - 1)
-    return (N - 1) - label
+    return n_comp
 
 
 def _connected_components_undirected(

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -104,12 +104,11 @@ def connected_components(csgraph, directed=True, connection='weak',
                              dense_output=False)
 
     labels = np.empty(csgraph.shape[0], dtype=ITYPE)
-    labels.fill(NULL_IDX)
 
     if directed:
         n_components = _connected_components_directed(csgraph.indices,
-                                                             csgraph.indptr,
-                                                             labels)
+                                                      csgraph.indptr,
+                                                      labels)
     else:
         csgraph_T = csgraph.T.tocsr()
         n_components = _connected_components_undirected(csgraph.indices,
@@ -755,7 +754,7 @@ cdef int _connected_components_directed2(
     V, and is much smaller in practice.
 
     The algorithm uses all improvements described by Tarjan and Zwick in
-    their recent survey, plus some further trick used in the Rust
+    their recent survey, plus some further tricks used in the Rust
     implementation of the WebGraph framework.
     """
     DEF VOID = -1
@@ -782,7 +781,7 @@ cdef int _connected_components_directed2(
     # but a stack parallel to the DFS stack is sufficient.
     #
     # succ_pos[v]: position in successor list for node v (int32 or int64,
-    #     matching indptr/indices); VOID = unvisited.
+    #     matching indptr); VOID = unvisited.
     #
     # dfs_stack[]: DFS path; the sign bit encodes the "lead" flag
     #     (non-negative = candidate SCC root).

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -59,7 +59,7 @@ def connected_components(csgraph, directed=True, connection='weak',
 
     References
     ----------
-    .. [1] R. E. Tarjan and U. Zwick, "Finding strong components using
+    .. [1] Robert E. Tarjan and Uri Zwick, "Finding strong components using
            depth-first search", European Journal of Combinatorics, 119,
            2024, :doi:`10.1016/j.ejc.2023.103815`
 
@@ -759,13 +759,16 @@ cdef int _connected_components_directed2(
 
     The algorithm uses all improvements described by Tarjan and Zwick in
     their recent survey [1]_, plus some further tricks used in the Rust
-    implementation of the WebGraph framework.
+    implementation of the WebGraph framework [2]_.
 
     References
     ----------
-    .. [1] R. E. Tarjan and U. Zwick, "Finding strong components using
+    .. [1] Robert E. Tarjan and Uri Zwick, "Finding strong components using
            depth-first search", European Journal of Combinatorics, 119,
            2024, :doi:`10.1016/j.ejc.2023.103815`
+    .. [2] Tommaso Fontana, Sebastiano Vigna, and Stefano Zacchiroli,
+           "WebGraph: The next generation (is in Rust)", Companion
+           Proceedings of the ACM Web Conference 2024, pp. 686--689, 2024.
     """
     DEF VOID = -1
     cdef int N = labels.shape[0]

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -399,7 +399,8 @@ cdef unsigned int _breadth_first_directed2(
     #                tree.  Should be initialized to NULL_IDX
     # Returns:
     #  n_nodes: the number of nodes in the breadth-first tree
-    cdef unsigned int i, pnode, cnode
+    cdef Py_ssize_t i
+    cdef unsigned int pnode, cnode
     cdef unsigned int i_nl, i_nl_end
 
     node_list[0] = head_node
@@ -452,7 +453,8 @@ cdef unsigned int _breadth_first_undirected2(
     #                tree.  Should be initialized to NULL_IDX
     # Returns:
     #  n_nodes: the number of nodes in the breadth-first tree
-    cdef unsigned int i, pnode, cnode
+    cdef Py_ssize_t i
+    cdef unsigned int pnode, cnode
     cdef unsigned int i_nl, i_nl_end
 
     node_list[0] = head_node
@@ -609,7 +611,8 @@ cdef unsigned int _depth_first_directed2(
         np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors,
         np.ndarray[ITYPE_t, ndim=1, mode='c'] root_list,
         np.ndarray[ITYPE_t, ndim=1, mode='c'] flag) noexcept:
-    cdef unsigned int i, i_nl_end, cnode, pnode
+    cdef Py_ssize_t i
+    cdef unsigned int i_nl_end, cnode, pnode
     cdef unsigned int N = node_list.shape[0]
     cdef int no_children, i_root
 
@@ -671,7 +674,8 @@ cdef unsigned int _depth_first_undirected2(
         np.ndarray[ITYPE_t, ndim=1, mode='c'] predecessors,
         np.ndarray[ITYPE_t, ndim=1, mode='c'] root_list,
         np.ndarray[ITYPE_t, ndim=1, mode='c'] flag) noexcept:
-    cdef unsigned int i, i_nl_end, cnode, pnode
+    cdef Py_ssize_t i
+    cdef unsigned int i_nl_end, cnode, pnode
     cdef unsigned int N = node_list.shape[0]
     cdef int no_children, i_root
 

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -749,9 +749,10 @@ cdef int _connected_components_directed2(
     CSR sparse array (scipy.sparse.csr_array).
 
     The algorithmic complexity for a graph with E edges and V vertices
-    is O(E + V). The storage requirement is an integer array of V
-    elements, plus two stacks whose combined length never exceeds V,
-    and is much smaller in practice.
+    is O(E + V). The storage requirement is an array of V elements
+    (int32 or int64, matching the CSR index type) tracking successor
+    positions, plus two int32 stacks whose combined length never exceeds
+    V, and is much smaller in practice.
 
     The algorithm uses all improvements described by Tarjan and Zwick in
     their recent survey, plus some further trick used in the Rust
@@ -780,7 +781,8 @@ cdef int _connected_components_directed2(
     # "lead" flag is materialized in an array in Tarjan & Zwick's survey,
     # but a stack parallel to the DFS stack is sufficient.
     #
-    # succ_pos[v]: position in successor list for node v; VOID = unvisited.
+    # succ_pos[v]: position in successor list for node v (int32 or int64,
+    #     matching indptr/indices); VOID = unvisited.
     #
     # dfs_stack[]: DFS path; the sign bit encodes the "lead" flag
     #     (non-negative = candidate SCC root).

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -724,6 +724,11 @@ cdef unsigned int _depth_first_undirected2(
     return i_nl_end
 
 
+cdef inline int _dfs_node(int v) noexcept nogil:
+    """Decode a DFS stack entry to a node index (clear the sign/lead bit)."""
+    return v & 0x7FFFFFFF
+
+
 # Author: Sebastiano Vigna  -- <sebastiano.vigna@gmail.com>
 def _connected_components_directed(
         np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
@@ -745,8 +750,9 @@ cdef int _connected_components_directed2(
 
     The algorithmic complexity is for a graph with E edges and V vertices
     is O(E + V). The storage requirement is an integer array of V
-    elements, plus two stacks of integers whose sum of lengths never
-    exceeds V, and is much smaller in typical graphs.
+    elements, plus two stacks of integers whose combined length never
+    exceeds V, and is much smaller in typical graphs. The sign bit of
+    each DFS stack entry encodes the lead flag (candidate SCC root).
 
     The algorithm uses all improvements described by Tarjan and Zwick in
     their recent survey, plus some further trick used in the Rust
@@ -757,7 +763,8 @@ cdef int _connected_components_directed2(
     if N == 0:
         return 0
 
-    cdef int v, w, j, node, parent, top
+    cdef int v, w, j, parent
+    cdef int NONLEAD = <int>0x80000000  # sign bit: marks stack entry as non-lead
     cdef int index = N        # timestamp counter, decreasing
     cdef int n_comp = 0       # number of emitted components
     cdef int root_hl = 0      # high_link of current DFS-tree root
@@ -780,8 +787,7 @@ cdef int _connected_components_directed2(
     dfs_stack.reserve(N)
     comp_stack.reserve(N)
 
-    for v in range(N):
-        labels[v] = 0
+    labels[:] = 0
 
     for v in range(N):
         if succ_pos[v] != VOID:
@@ -797,11 +803,7 @@ cdef int _connected_components_directed2(
         succ_pos[v] = indptr[v]
 
         while not dfs_stack.empty():
-            # Decode node (and lead flag) at the DFS top
-            if dfs_stack.back() >= 0:
-                v = dfs_stack.back()
-            else:
-                v = ~dfs_stack.back()
+            v = _dfs_node(dfs_stack.back())
 
             if succ_pos[v] < indptr[v + 1]:
                 # ---- Advance to next successor ----
@@ -817,7 +819,7 @@ cdef int _connected_components_directed2(
                 else:
                     # ---- Revisit (cross / back arc) ----
                     if labels[v] < labels[w]:
-                        dfs_stack[dfs_stack.size() - 1] = ~v  # lead = False
+                        dfs_stack[dfs_stack.size() - 1] = v | NONLEAD  # lead = False
                         labels[v] = labels[w]
                         # Early exit: the whole graph is one SCC
                         if labels[v] == root_hl and index == 0:
@@ -825,10 +827,7 @@ cdef int _connected_components_directed2(
                             for j in range(<int>comp_stack.size()):
                                 labels[comp_stack[j]] = n_comp
                             for j in range(<int>dfs_stack.size() - 1):
-                                node = dfs_stack[j]
-                                if node < 0:
-                                    node = ~node
-                                labels[node] = n_comp
+                                labels[_dfs_node(dfs_stack[j])] = n_comp
                             n_comp += 1
                             dfs_stack.clear()
                             comp_stack.clear()
@@ -853,10 +852,9 @@ cdef int _connected_components_directed2(
                     dfs_stack.pop_back()
                     comp_stack.push_back(v)
                     if not dfs_stack.empty():
-                        top = dfs_stack.back()
-                        parent = top if top >= 0 else ~top
+                        parent = _dfs_node(dfs_stack.back())
                         if labels[parent] < labels[v]:
-                            dfs_stack[dfs_stack.size() - 1] = ~parent
+                            dfs_stack[dfs_stack.size() - 1] = parent | NONLEAD
                             labels[parent] = labels[v]
 
     return n_comp

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -11,6 +11,7 @@ cimport numpy as np
 from scipy.sparse.csgraph._validation import validate_graph
 from scipy.sparse.csgraph._tools import reconstruct_path
 
+from libcpp.vector cimport vector
 cimport cython
 
 np.import_array()
@@ -737,15 +738,27 @@ cdef int _connected_components_directed2(
         np.ndarray[int32_or_int64, ndim=1, mode='c'] indices,
         np.ndarray[int32_or_int64, ndim=1, mode='c'] indptr,
         np.ndarray[ITYPE_t, ndim=1, mode='c'] labels) noexcept:
+    """
+    Uses an iterative version of Tarjan's algorithm to find the
+    strongly connected components of a directed graph represented as a
+    sparse array (scipy.sparse.csc_array or scipy.sparse.csr_array).
+
+    The algorithmic complexity is for a graph with E edges and V vertices
+    is O(E + V). The storage requirement is an integer array of V
+    elements, plus two stacks of integers whose sum of lengths never
+    exceeds V, and is much smaller in typical graphs.
+
+    The algorithm uses all improvements described by Tarjan and Zwick in
+    their recent survey, plus some further trick used in the Rust
+    implementation of the WebGraph framework.
+    """
     DEF VOID = -1
     cdef int N = labels.shape[0]
     if N == 0:
         return 0
 
-    cdef int v, w, j, node, parent
+    cdef int v, w, j, node, parent, top
     cdef int index = N        # timestamp counter, decreasing
-    cdef int dfs_top = -1     # top of DFS path  (dfs_stack[0 … dfs_top])
-    cdef int comp_top = -1    # top of comp stack (comp_stack[0 … comp_top])
     cdef int n_comp = 0       # number of emitted components
     cdef int root_hl = 0      # high_link of current DFS-tree root
 
@@ -756,19 +769,19 @@ cdef int _connected_components_directed2(
     #
     # labels doubles as the high_link array.
     # succ_pos[v]: position in successor list for node v; -1 = unvisited.
+    #   Uses the same type as indptr to avoid overflow on graphs with > 2^31 edges.
     # dfs_stack[]: DFS path; the sign bit encodes the "lead" flag
     #   (non-negative = candidate SCC root).
     # comp_stack[]: nodes popped from DFS but not yet assigned to an SCC.
-    cdef np.ndarray[ITYPE_t, ndim=1, mode="c"] succ_pos = \
-        np.ndarray((N,), dtype=ITYPE)
-    cdef np.ndarray[ITYPE_t, ndim=1, mode="c"] dfs_stack = \
-        np.ndarray((N,), dtype=ITYPE)
-    cdef np.ndarray[ITYPE_t, ndim=1, mode="c"] comp_stack = \
-        np.ndarray((N,), dtype=ITYPE)
+    cdef vector[int32_or_int64] succ_pos
+    cdef vector[int] dfs_stack
+    cdef vector[int] comp_stack
+    succ_pos.assign(N, VOID)
+    dfs_stack.reserve(N)
+    comp_stack.reserve(N)
 
     for v in range(N):
         labels[v] = 0
-        succ_pos[v] = VOID
 
     for v in range(N):
         if succ_pos[v] != VOID:
@@ -778,18 +791,17 @@ cdef int _connected_components_directed2(
         root_hl = index
 
         # ---- Previsit v ----
-        dfs_top = 0
-        dfs_stack[0] = v                   # lead = True (non-negative)
+        dfs_stack.push_back(v)             # lead = True (non-negative)
         labels[v] = index
         index -= 1
         succ_pos[v] = indptr[v]
 
-        while dfs_top >= 0:
+        while not dfs_stack.empty():
             # Decode node (and lead flag) at the DFS top
-            if dfs_stack[dfs_top] >= 0:
-                v = dfs_stack[dfs_top]
+            if dfs_stack.back() >= 0:
+                v = dfs_stack.back()
             else:
-                v = ~dfs_stack[dfs_top]
+                v = ~dfs_stack.back()
 
             if succ_pos[v] < indptr[v + 1]:
                 # ---- Advance to next successor ----
@@ -798,56 +810,53 @@ cdef int _connected_components_directed2(
 
                 if succ_pos[w] == VOID:
                     # ---- Previsit w (tree arc) ----
-                    dfs_top += 1
-                    dfs_stack[dfs_top] = w     # lead = True
+                    dfs_stack.push_back(w)     # lead = True
                     labels[w] = index
                     index -= 1
                     succ_pos[w] = indptr[w]
                 else:
                     # ---- Revisit (cross / back arc) ----
                     if labels[v] < labels[w]:
-                        dfs_stack[dfs_top] = ~v    # lead = False
+                        dfs_stack[dfs_stack.size() - 1] = ~v  # lead = False
                         labels[v] = labels[w]
                         # Early exit: the whole graph is one SCC
                         if labels[v] == root_hl and index == 0:
                             labels[v] = n_comp
-                            for j in range(comp_top + 1):
+                            for j in range(<int>comp_stack.size()):
                                 labels[comp_stack[j]] = n_comp
-                            for j in range(dfs_top):
+                            for j in range(<int>dfs_stack.size() - 1):
                                 node = dfs_stack[j]
                                 if node < 0:
                                     node = ~node
                                 labels[node] = n_comp
                             n_comp += 1
-                            dfs_top = -1
-                            comp_top = -1
+                            dfs_stack.clear()
+                            comp_stack.clear()
                             break
             else:
                 # ---- Postvisit v ----
-                if dfs_stack[dfs_top] >= 0:
+                if dfs_stack.back() >= 0:
                     # v is an SCC root: pop its members from comp stack
-                    dfs_top -= 1
-                    while comp_top >= 0:
-                        if labels[v] < labels[comp_stack[comp_top]]:
+                    dfs_stack.pop_back()
+                    while not comp_stack.empty():
+                        top = comp_stack.back()
+                        if labels[v] < labels[top]:
                             break
-                        labels[comp_stack[comp_top]] = n_comp
-                        comp_top -= 1
+                        labels[top] = n_comp
+                        comp_stack.pop_back()
                         index += 1
                     labels[v] = n_comp
                     index += 1
                     n_comp += 1
                 else:
                     # Not a root: push v onto comp stack, propagate
-                    dfs_top -= 1
-                    comp_top += 1
-                    comp_stack[comp_top] = v
-                    if dfs_top >= 0:
-                        if dfs_stack[dfs_top] >= 0:
-                            parent = dfs_stack[dfs_top]
-                        else:
-                            parent = ~dfs_stack[dfs_top]
+                    dfs_stack.pop_back()
+                    comp_stack.push_back(v)
+                    if not dfs_stack.empty():
+                        top = dfs_stack.back()
+                        parent = top if top >= 0 else ~top
                         if labels[parent] < labels[v]:
-                            dfs_stack[dfs_top] = ~parent
+                            dfs_stack[dfs_stack.size() - 1] = ~parent
                             labels[parent] = labels[v]
 
     return n_comp

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -771,6 +771,7 @@ cdef int _connected_components_directed2(
     cdef int index = N        # timestamp counter, decreasing
     cdef int n_comp = 0       # number of emitted components
     cdef int root_hl = 0      # high_link of current DFS-tree root
+    cdef bint done = False    # set True on early exit to break outer loop
 
     # Iterative Tarjan's algorithm using reverse timestamps and
     # encoding a bit stack of lead nodes in the sign bit of the DFS stack.
@@ -843,6 +844,7 @@ cdef int _connected_components_directed2(
                             n_comp += 1
                             dfs_stack.clear()
                             comp_stack.clear()
+                            done = True
                             break
             else:
                 # ---- Postvisit v ----
@@ -868,6 +870,8 @@ cdef int _connected_components_directed2(
                         if labels[parent] < labels[v]:
                             dfs_stack[dfs_stack.size() - 1] = parent | NONLEAD
                             labels[parent] = labels[v]
+        if done:
+            break
 
     return n_comp
 

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -746,12 +746,12 @@ cdef int _connected_components_directed2(
     """
     Uses an iterative version of Tarjan's algorithm to find the
     strongly connected components of a directed graph represented as a
-    sparse array (scipy.sparse.csc_array or scipy.sparse.csr_array).
+    CSR sparse array (scipy.sparse.csr_array).
 
-    The algorithmic complexity is for a graph with E edges and V vertices
+    The algorithmic complexity for a graph with E edges and V vertices
     is O(E + V). The storage requirement is an integer array of V
-    elements, plus two stacks of at most V integers, which however are
-    usually smaller in practice.
+    elements, plus two stacks whose combined length never exceeds V,
+    and is much smaller in practice.
 
     The algorithm uses all improvements described by Tarjan and Zwick in
     their recent survey, plus some further trick used in the Rust
@@ -762,7 +762,7 @@ cdef int _connected_components_directed2(
     if N == 0:
         return 0
 
-    cdef int v, w, j, parent
+    cdef int v, w, j, parent, top
     cdef int NONLEAD = <int>0x80000000  # sign bit: marks stack entry as non-lead
     cdef int index = N        # timestamp counter, decreasing
     cdef int n_comp = 0       # number of emitted components
@@ -776,7 +776,7 @@ cdef int _connected_components_directed2(
     # high_link = 0, distinguished from component 0 via succ_pos == VOID.
     # labels doubles as the high_link array.
     #
-    # Decreasing timestamp make renumbering at the end unnecessary. The
+    # Decreasing timestamps make renumbering at the end unnecessary. The
     # "lead" flag is materialized in an array in Tarjan & Zwick's survey,
     # but a stack parallel to the DFS stack is sufficient.
     #
@@ -798,13 +798,13 @@ cdef int _connected_components_directed2(
 
     for v in range(N):
         if succ_pos[v] != VOID:
-            continue
+            continue                       # already visited
 
         # ---- Init: new DFS tree rooted at v ----
         root_hl = index
 
         # ---- Previsit v ----
-        dfs_stack.push_back(v) # lead = True
+        dfs_stack.push_back(v)             # lead = True (non-negative)
         labels[v] = index
         index -= 1
         succ_pos[v] = indptr[v]
@@ -819,7 +819,7 @@ cdef int _connected_components_directed2(
 
                 if succ_pos[w] == VOID:
                     # ---- Previsit w (tree arc) ----
-                    dfs_stack.push_back(w) # lead = True
+                    dfs_stack.push_back(w)             # lead = True (non-negative)
                     labels[w] = index
                     index -= 1
                     succ_pos[w] = indptr[w]

--- a/scipy/sparse/csgraph/_traversal.pyx
+++ b/scipy/sparse/csgraph/_traversal.pyx
@@ -758,8 +758,14 @@ cdef int _connected_components_directed2(
     V, and is much smaller in practice.
 
     The algorithm uses all improvements described by Tarjan and Zwick in
-    their recent survey, plus some further tricks used in the Rust
+    their recent survey [1]_, plus some further tricks used in the Rust
     implementation of the WebGraph framework.
+
+    References
+    ----------
+    .. [1] R. E. Tarjan and U. Zwick, "Finding strong components using
+           depth-first search", European Journal of Combinatorics, 119,
+           2024, :doi:`10.1016/j.ejc.2023.103815`
     """
     DEF VOID = -1
     cdef int N = labels.shape[0]

--- a/scipy/sparse/csgraph/meson.build
+++ b/scipy/sparse/csgraph/meson.build
@@ -1,19 +1,21 @@
+_parameters_pxi = fs.copyfile('parameters.pxi')
+
 pyx_files_for_c = [
   ['_flow', '_flow.pyx'],
   ['_matching', '_matching.pyx'],
   ['_min_spanning_tree', '_min_spanning_tree.pyx'],
   ['_reordering', '_reordering.pyx'],
   ['_tools', '_tools.pyx'],
-  ['_traversal', '_traversal.pyx']
 ]
 pyx_files_for_cpp = [
   ['_shortest_path', '_shortest_path.pyx'],
+  ['_traversal', '_traversal.pyx'],
 ]
 
 cython_gen_csgraph_for_c = generator(cython,
   arguments : cython_args,
   output : '@BASENAME@.c',
-  depends : [_cython_tree, fs.copyfile('parameters.pxi')],
+  depends : [_cython_tree, _parameters_pxi],
 )
 
 foreach pyx_file: pyx_files_for_c
@@ -30,7 +32,7 @@ endforeach
 cython_gen_csgraph_for_cpp = generator(cython,
   arguments : cython_cplus_args,
   output : '@BASENAME@.cpp',
-  depends : [_cython_tree],
+  depends : [_cython_tree, _parameters_pxi],
 )
 
 foreach pyx_file: pyx_files_for_cpp

--- a/scipy/sparse/csgraph/tests/test_connected_components.py
+++ b/scipy/sparse/csgraph/tests/test_connected_components.py
@@ -119,6 +119,18 @@ def test_int64_indices_directed():
     assert_array_almost_equal(labels, [1, 0])
 
 
+def test_single_scc_early_exit():
+    # Exercises the early-exit check
+    rows = [0, 1, 1, 2, 3, 3, 4, 5]
+    cols = [1, 2, 5, 3, 1, 4, 0, 2]
+    data = np.ones(len(rows), dtype=np.int32)
+    g = csr_array((data, (rows, cols)), shape=(6, 6))
+    n_components, labels = csgraph.connected_components(
+        g, directed=True, connection='strong')
+    assert_equal(n_components, 1)
+    assert_equal(len(np.unique(labels)), 1)
+
+
 # regression test for gh-23142
 @pytest.mark.parametrize("graph", [
     np.array([[1, 0, 1, 0],


### PR DESCRIPTION
The current implementation of the computation of strongly connected components of directed graphs in SciPy is an original algorithm described [here](https://www.timl.id.au/scc). While the algorithm might be very useful in an implicit context, such as compressed graphs, as it materializes just one successor iterator at a time, it also makes two passes on every arc, uses three words for node, and perform a large number of out-of-cache accesses.

This PR implements a state-of-the-art version of Tarjan's algorithm, using the indications in the [recent survey by Tarjan and Zwick](https://arxiv.org/pdf/2201.07197). It adds a couple of tricks developed during the implementation of the same algorithm for the [Rust port of the WebGraph framework](https://github.com/vigna/webgraph-rs).

In short: the algorithm uses three words per node at most, and less in most cases. It makes just one pass, halving the traversal time. Access is much more cache-friendly, being often localized around the top of the stacks.

The new implementation is more than twice fast than the current one. Part of the speedup is due to the single traversal, but that should be amortized by the other operations. We are more than twice fast due to cache-friendlier access.

These are the results of simple benchmarks on the current implementation:
```
============================================================
Erdős–Rényi  N= 1,000,000  avg_deg=100  nnz=100,000,000
1.0833s  (1 components)

============================================================
Single SCC   N= 1,000,000  avg_deg≈100  nnz=99,994,878
1.0533s  (1 components)

============================================================
Chain (DAG)  N= 1,000,000  edges=999999  nnz=999,999
0.0126s  (1,000,000 components)
```

And on the new implementation:
```
============================================================
Erdős–Rényi  N= 1,000,000  avg_deg=100  nnz=100,000,000
0.4096s  (1 components)

============================================================
Single SCC   N= 1,000,000  avg_deg≈100  nnz=99,994,878
0.3956s  (1 components)

============================================================
Chain (DAG)  N= 1,000,000  edges=999999  nnz=999,999
0.0065s  (1,000,000 components)
```

Claude has assisted the development by extracting a first draft implementation from the paper.

# Release notes

- In scipy.sparse.csgraph the computation of strongly connected components for directed graphs is now performed by an implementation of Tarjan's algorithm utilizing the improvements described in the [recent survey by Tarjan and Zwick](https://doi.org/10.1016/j.ejc.2023.103815), yielding a 2x speed improvement and better cache locality.

UPDATE: Sorry—it's three, not two words per node in the worst case. It's usually less because one of the words per node comes from the sum of the lengths of the visit and component stacks.