### PR TITLE
TST: spatial: skip `test_ckdtree_memuse` for ASan builds

### DIFF
--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -1103,11 +1103,13 @@ def simulate_periodic_box(kdtree, data, k, boxsize, p):
     return result['dd'][:, :k], result['ii'][:, :k]
 
 
+@pytest.mark.fail_asan
 def test_ckdtree_memuse():
     # unit test adaptation of gh-5630
 
     # NOTE: this will fail when run via valgrind,
     # because rss is no longer a reliable memory usage indicator.
+    # It was also observed to be flaky under ASan.
 
     try:
         import resource


### PR DESCRIPTION
Closes gh-24980 per advice from @ngoldbaum 