### PR TITLE
TYP: ``stats``: generic ``DunnettResult`` type

### DIFF
--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -1,6 +1,7 @@
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from types import GenericAlias
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -51,6 +52,9 @@ class DunnettResult:
     _rng: SeedType = field(repr=False)
     _ci: ConfidenceInterval | None = field(default=None, repr=False)
     _ci_cl: DecimalNumber | None = field(default=None, repr=False)
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __str__(self):
         # Note: `__str__` prints the confidence intervals from the most


### PR DESCRIPTION
https://github.com/scipy/scipy-stubs/pull/1528 makes `DunnettResult` a generic type. And even though the import path strongly suggests that `DunnettResult` isn't public API, it's a documented class (https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats._result_classes.DunnettResult.html), hence this PR.

x-ref: https://github.com/scipy/scipy-stubs/pull/1528#issuecomment-4228835403

#### AI Generation Disclosure
N/A
