### PR TITLE
CI: Enable xdist and kernel caching for JAX step of GPU job

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -131,4 +131,4 @@ jobs:
         env:
           # Give 10% of GPU memory to each pytest worker to ensure fairness.
           XLA_PYTHON_CLIENT_MEM_FRACTION: .10
-        run: pixi run --skip-deps test-jax-cuda -v -j 4
+        run: pixi run --skip-deps test-jax-cuda -v -j 4 -- --dist worksteal

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -128,4 +128,7 @@ jobs:
         run: pixi run --skip-deps test-cupy -v
 
       - name: Run JAX GPU tests
-        run: pixi run --skip-deps test-jax-cuda -v
+        env:
+          # Give 10% of GPU memory to each pytest worker to ensure fairness.
+          XLA_PYTHON_CLIENT_MEM_FRACTION: .10
+        run: pixi run --skip-deps test-jax-cuda -v -j 4

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -42,6 +42,10 @@ env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
   CCACHE_MAXSIZE: "350M"
   PIXI_CACHE_DIR: "${{ github.workspace }}/.cache/rattler"
+  # Enable persistent cache
+  # https://docs.jax.dev/en/latest/config_options.html
+  JAX_COMPILATION_CACHE_DIR: "${{ github.workspace }}/.cache/scipy_jax_cache"
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -102,6 +106,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gpu-cupy
 
+      - name: Cache JAX kernels
+        uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4
+        with:
+          path: ${{ env.JAX_COMPILATION_CACHE_DIR }}
+          # Same as for cupy above
+          key: ${{ runner.os }}-gpu-jax-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gpu-jax
+
       - name: run nvidia-smi
         run: nvidia-smi
 
@@ -131,4 +144,6 @@ jobs:
         env:
           # Give 10% of GPU memory to each pytest worker to ensure fairness.
           XLA_PYTHON_CLIENT_MEM_FRACTION: .10
+          # Minimum compile time to store entry to cache
+          JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS: "0"
         run: pixi run --skip-deps test-jax-cuda -v -j 4 -- --dist worksteal


### PR DESCRIPTION
### Reference issue

Towards #24990

Closes #24685

### What does this implement/fix?

The goal of this PR is to decrease the time taken by JAX tests in Cirrus, and reduce the cost of the GPU job. While testing a JAX caching change locally, I noticed that it typically is only using 2 cores on average. Since the GPU runner has 8 cores, it would likely be faster to run multiple tests in parallel. Therefore, use xdist to run tests in parallel.

I also added caching for JAX compilation. This helps a little even if the cache is not persisted between sessions, and it helps a lot if there is a recent cache entry.

Based on local testing, it should be possible to reduce the total time taken by this job by 50%-70%.

### Additional information

#### Benchmarks

I tested this it locally with nektos/act. See branch [njo-jax-cache](https://github.com/nickodell/scipy/tree/njo-jax-cache) for the test code I used.



##### Local benchmark

I tuned the core count based on my local computer with a RTX 2070 GPU, and 12 core CPU. This means that I have slighly more cores than the real CI runner, a slower GPU, and less GPU memory than the real runner.  This may change the optimal xdist core count. Locally, I found diminishing returns around -j 8, and the job became less stable when allocating less than 5% of memory to each xdist runner.

Timings are based upon pytest, for JAX only.

| Benchmark Name                    | Timing   |
|-----------------------------------|----------|
| Baseline (local GPU)              | 2464.84s |
| With -j 4                         | 842.09s  |
| With -j 4 and --maxschedchunk 100 | 801.50s  |
| With -j 4 and --maxschedchunk 10  | 756.95s  |
| With -j 4 and --dist worksteal    | 633.84s  |
| All prev changes, and caching, cold cache | 474.64s |
| All prev changes, and caching, hot cache | 242.06s |

##### Cirrus Benchmark

Timings are based upon step timings, for JAX only.

| Benchmark Name                    | Timing   |
|-----------------------------------|----------|
| Baseline (Cirrus average)         | 1740s    |
| [xdist change only](https://github.com/scipy/scipy/actions/runs/24301236069/job/70954875107?pr=25002#step:14:1)                 | 730s      |
| [xdist change and caching, cold cache](https://github.com/scipy/scipy/actions/runs/24301780437/job/70956275523?pr=25002#step:15:1)                 | 594s      |
| [xdist change and caching, hot cache](https://github.com/scipy/scipy/actions/runs/24302128804/job/70957172476?pr=25002#step:15:1)                 | 295s      |


#### GPU memory

Note that XLA_PYTHON_CLIENT_MEM_FRACTION must be set, to prevent a single xdist worker from pre-allocating 75% of available GPU memory.

#### maxschedchunk and worksteal

I noticed that toward the end of the job, the CPU drops because only one worker is running tests. I tried `--maxschedchunk` to reduce the amount of reserved work. I also tried `--dist worksteal`, which is a mode for xdist introduced in xdist 3.2.0 a few years ago, which allows idle workers to take work from busy workers. That seems to perform better.

### AI Generation Disclosure

The `env: ...` syntax is copied from an example produced by Gemini; I changed it to the right environment variable.
