### PR TITLE
DOC: Remove duplicated 'to' in 'wrt to' and 'w.r.t. to'

### DIFF
--- a/scipy/optimize/_trlib/trlib_leftmost.c
+++ b/scipy/optimize/_trlib/trlib_leftmost.c
@@ -70,8 +70,8 @@ trlib_int_t trlib_leftmost_irreducible(
     trlib_flt_t dleftmost = 0.0;            // increment
     trlib_flt_t prlp = 0.0;                 // value of Parlett-Reid-Last-Pivot function
     trlib_flt_t obyprlp = 0.0;              // quotient used in Cholesky computation
-    trlib_flt_t dprlp = 0.0;                // derivative of Parlett-Reid-Last-Pivot function wrt to leftmost
-    trlib_flt_t ddprlp = 0.0;               // second derivative of Parlett-Reid-Last-Pivot function wrt to leftmost
+    trlib_flt_t dprlp = 0.0;                // derivative of Parlett-Reid-Last-Pivot function w.r.t. leftmost
+    trlib_flt_t ddprlp = 0.0;               // second derivative of Parlett-Reid-Last-Pivot function w.r.t. leftmost
     trlib_int_t n_neg_piv = 0;              // number of negative pivots in factorization
     trlib_flt_t quad_abs = 0.0;             // absolute  coefficient in quadratic model
     trlib_flt_t quad_lin = 0.0;             // linear    coefficient in quadratic model

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -953,7 +953,7 @@ def test_as_euler_asymmetric_axes(xp, seq_tuple, intrinsic):
 
     seq = "".join(seq_tuple)
     if intrinsic:
-        # Extrinsic rotation (wrt to global world) at lower case
+        # Extrinsic rotation (w.r.t. global world) at lower case
         # intrinsic (WRT the object itself) lower case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles)
@@ -1027,7 +1027,7 @@ def test_as_euler_degenerate_asymmetric_axes(
 
     seq = "".join(seq_tuple)
     if intrinsic:
-        # Extrinsic rotation (wrt to global world) at lower case
+        # Extrinsic rotation (w.r.t. global world) at lower case
         # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles, degrees=True)
@@ -1064,7 +1064,7 @@ def test_as_euler_degenerate_symmetric_axes(
     # Rotation of the form A/B/A are rotation around symmetric axes
     seq = "".join([seq_tuple[0], seq_tuple[1], seq_tuple[0]])
     if intrinsic:
-        # Extrinsic rotation (wrt to global world) at lower case
+        # Extrinsic rotation (w.r.t. global world) at lower case
         # Intrinsic (WRT the object itself) upper case.
         seq = seq.upper()
     rotation = Rotation.from_euler(seq, angles, degrees=True)

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -6948,7 +6948,7 @@ class lognorm_gen(rv_continuous):
         estimation of the log-normal shape and scale parameters, so the
         `optimizer`, `loc` and `scale` keyword arguments are ignored.
         If the location is free, a likelihood maximum is found by
-        setting its partial derivative wrt to location to 0, and
+        setting its partial derivative w.r.t. location to 0, and
         solving by substituting the analytical expressions of shape
         and scale (or provided parameters).
         See, e.g., equation 3.1 in
@@ -8310,7 +8310,7 @@ class pareto_gen(rv_continuous):
 
             def fun_to_solve(scale):
                 # optimize the scale by setting the partial derivatives
-                # w.r.t. to location and scale equal and solving.
+                # w.r.t. location and scale equal and solving.
                 location = np.min(data) - scale
                 shape = fshape or get_shape(scale, location)
                 return dL_dLocation(shape, location) - dL_dScale(shape, scale)
@@ -8849,7 +8849,7 @@ class powerlaw_gen(rv_continuous):
 
         def fun_to_solve(loc):
             # optimize the location by setting the partial derivatives
-            # w.r.t. to location and scale equal and solving.
+            # w.r.t. location and scale equal and solving.
             scale = np.nextafter(get_scale(data, loc), -np.inf)
             shape = fshape or get_shape(data, loc, scale)
             return (dL_dScale(data, shape, scale)


### PR DESCRIPTION
#### Reference issue
No issue involved.

#### What does this implement/fix?
At several places one can find "w.r.t. to" or "wrt to" although the "t" in "w.r.t." is already this to.
This PR fixes these typos.

#### Additional information

#### AI Generation Disclosure
No AI tools used
