### PR TITLE
DOC: fix typos in `_morphology.py`

### DIFF
--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -2025,7 +2025,7 @@ def distance_transform_bf(input, metric="euclidean", sampling=None,
     indices : int32 ndarray, optional
         An output array to store the calculated feature transform, instead of
         returning it.
-        `return_indicies` must be True.
+        `return_indices` must be True.
         Its shape must be ``(input.ndim,) + input.shape``.
 
     Returns
@@ -2264,7 +2264,7 @@ def distance_transform_cdt(input, metric='chessboard', return_distances=True,
     indices : int32 ndarray, optional
         An output array to store the calculated feature transform, instead of
         returning it.
-        `return_indicies` must be True.
+        `return_indices` must be True.
         Its shape must be ``(input.ndim,) + input.shape``.
 
     Returns
@@ -2468,7 +2468,7 @@ def distance_transform_edt(input, sampling=None, return_distances=True,
     indices : int32 ndarray, optional
         An output array to store the calculated feature transform, instead of
         returning it.
-        `return_indicies` must be True.
+        `return_indices` must be True.
         Its shape must be ``(input.ndim,) + input.shape``.
 
     Returns

--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -585,7 +585,7 @@ def binary_opening(input, structure=None, iterations=1, output=None,
     brute_force : bool, optional
         Memory condition: if False, only the pixels whose value was changed in
         the last iteration are tracked as candidates to be updated in the
-        current iteration; if true all pixels are considered as candidates for
+        current iteration; if True all pixels are considered as candidates for
         update, regardless of what happened in the previous iteration.
         False by default.
 
@@ -715,7 +715,7 @@ def binary_closing(input, structure=None, iterations=1, output=None,
     brute_force : bool, optional
         Memory condition: if False, only the pixels whose value was changed in
         the last iteration are tracked as candidates to be updated in the
-        current iteration; if true al pixels are considered as candidates for
+        current iteration; if True all pixels are considered as candidates for
         update, regardless of what happened in the previous iteration.
         False by default.
 

--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -1642,7 +1642,7 @@ def morphological_gradient(input, size=None, footprint=None, structure=None,
     Parameters
     ----------
     input : array_like
-        Array over which to compute the morphlogical gradient.
+        Array over which to compute the morphological gradient.
     size : tuple of ints
         Shape of a flat and full structuring element used for the mathematical
         morphology operations. Optional if `footprint` or `structure` is
@@ -2142,7 +2142,7 @@ def distance_transform_bf(input, metric="euclidean", sampling=None,
     """
     ft_inplace = isinstance(indices, np.ndarray)
     dt_inplace = isinstance(distances, np.ndarray)
-    _distance_tranform_arg_check(
+    _distance_transform_arg_check(
         dt_inplace, ft_inplace, return_distances, return_indices
     )
 
@@ -2354,7 +2354,7 @@ def distance_transform_cdt(input, metric='chessboard', return_distances=True,
     """
     ft_inplace = isinstance(indices, np.ndarray)
     dt_inplace = isinstance(distances, np.ndarray)
-    _distance_tranform_arg_check(
+    _distance_transform_arg_check(
         dt_inplace, ft_inplace, return_distances, return_indices
     )
     input = np.asarray(input)
@@ -2560,7 +2560,7 @@ def distance_transform_edt(input, sampling=None, return_distances=True,
     """
     ft_inplace = isinstance(indices, np.ndarray)
     dt_inplace = isinstance(distances, np.ndarray)
-    _distance_tranform_arg_check(
+    _distance_transform_arg_check(
         dt_inplace, ft_inplace, return_distances, return_indices
     )
 
@@ -2616,8 +2616,8 @@ def distance_transform_edt(input, sampling=None, return_distances=True,
         return None
 
 
-def _distance_tranform_arg_check(distances_out, indices_out,
-                                 return_distances, return_indices):
+def _distance_transform_arg_check(distances_out, indices_out,
+                                  return_distances, return_indices):
     """Raise a RuntimeError if the arguments are invalid"""
     error_msgs = []
     if (not return_distances) and (not return_indices):


### PR DESCRIPTION
#### Reference issue
No issue involved.

#### What does this implement/fix?
In module `scipy/ndimage/_morphology.py` a parameter is misspelled in 3 docstrings.
For better clarity this PR fixes this.

#### Additional information

#### AI Generation Disclosure
No AI tools used
