### PR TITLE
Bump pytest to 9.0.3

### DIFF
--- a/subprojects/pyprima/pyprima/pyprima/tests/requirements.txt
+++ b/subprojects/pyprima/pyprima/pyprima/tests/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 pycutest
-pytest
+pytest==9.0.3
 pytest-cov
 pytest-order


### PR DESCRIPTION
A few dependencies in the requirements file have CVEs fixed in newer versions:

- `pytest` 9.0.2 -> 9.0.3 (CVE-2025-71176)

Bumped each one to the minimum safe version.