### PR TITLE
DOC: Fix 'accomodate' typo in comments

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1769,7 +1769,7 @@ fitpack_sphere(PyObject* Py_UNUSED(dummy), PyObject *args)
     // _spherefit_lsq is meant for iopt=-1 workflow and hence passes tt and tp of
     // size ntest and npest respectively. However, _spherefit_smooth does not
     // and generates tt and tp as output arguments.
-    // Hence we have to accomodate for these cases here to avoid multiple wrappers
+    // Hence we have to accommodate for these cases here to avoid multiple wrappers
     // as was the case previously with the Fortran FITPACK bindings.
 
     if (iopt == -1){

--- a/scipy/linalg/_decomp_cholesky.py
+++ b/scipy/linalg/_decomp_cholesky.py
@@ -38,7 +38,7 @@ def _cholesky(a, lower=False, overwrite_a=False, clean=True,
     overwrite_a = (overwrite_a and (a1.ndim == 2)
                    and (a1.flags["F_CONTIGUOUS"] or a1.flags["C_CONTIGUOUS"]))
 
-    # accomodate empty arrays
+    # accommodate empty arrays
     if a1.shape[-1] == 0:
         batch_shape = a1.shape[:-2]
         c = np.zeros(batch_shape + (0, 0), dtype=a1.dtype)

--- a/scipy/linalg/_matfuncsmodule.c
+++ b/scipy/linalg/_matfuncsmodule.c
@@ -75,7 +75,7 @@ recursive_schur_sqrtm(PyObject* Py_UNUSED(dummy), PyObject *args) {
     }
 
     // Create the output array with the same shape as the input with twice the
-    // number of entries to accomodate for potential complex-valued data from
+    // number of entries to accommodate for potential complex-valued data from
     // real data which will be cast to complex e.g., "ret.asview(complex128)"
     // Example, (3, 3) -> (18), (4, 5, 5) -> (4, 50)
     npy_intp ret_dims = 1;

--- a/scipy/optimize/src/slsqp.c
+++ b/scipy/optimize/src/slsqp.c
@@ -412,9 +412,9 @@ MODEM1:
  * integers which is making things quite unreadable. Here we explicitly pass a
  * flag.
  *
- * Inconsistent linearization augments all arrays to accomodate for the dummy
+ * Inconsistent linearization augments all arrays to accommodate for the dummy
  * variable. The function is still called with the original sizes but the flag
- * allows for enlarging the problem and hence the supplied buffer should accomodate
+ * allows for enlarging the problem and hence the supplied buffer should accommodate
  * for this extra space.
  *
  * The required buffer size is given by:

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -3538,7 +3538,7 @@ class UnivariateDistribution(_ProbabilityDistribution):
     # treat the parameters as "fixed" and the quantile/percentile arguments
     # as "variable". There are a lot of advantages to this structure, and I
     # don't think the fact that a few methods reverse the fixed and variable
-    # quantities should make us question that choice. It can still accomodate
+    # quantities should make us question that choice. It can still accommodate
     # these methods reasonably efficiently.
 
 


### PR DESCRIPTION
Fixes the 'accomodate' -> 'accommodate' typo in several source comments across scipy.stats, scipy.linalg, scipy.interpolate, and scipy.optimize. Comment-only changes, no behavior impact.