### PR TITLE
ENH: add a worked example of downstream usage of ILP64 `cython_lapack`

### DIFF
--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -104,7 +104,6 @@ jobs:
     - name: Test
       run: spin test -j4
 
-
   mkl-cyilp64:
     runs-on: ubuntu-latest
     name: "MKL ILP64 (cython-blas ILP64)"
@@ -127,12 +126,24 @@ jobs:
         pip install -r requirements/build.txt
         pip install mkl mkl-devel spin "click<8.3.0" pytest hypothesis pytest-xdist pooch
 
-    - name: Build with ILP64
+    - name: Build SciPy wheel and install
       run: |
-        spin build -S-Dblas=mkl-dynamic-ilp64-seq -S-Duse-ilp64=true -S-D_without-fortran=true
+        python -m build -wnx \
+          -Csetup-args=-Dblas=mkl-dynamic-ilp64-seq \
+          -Csetup-args=-Duse-ilp64=true \
+          -Csetup-args=-D_without-fortran=true
+        pip install dist/scipy*.whl
 
-    - name: Test
-      run: spin test -j4
+    - name: Test SciPy
+      run: |
+        cd /tmp
+        python -m pytest --pyargs scipy -n4
+
+    - name: Build and test ILP64 downstream package
+      run: |
+        pip install scipy/linalg/tests/_cython_examples/ilp64_test_package/
+        cd /tmp
+        python -m pytest --pyargs ilp64_test_package
 
 
   scipy-openblas-ilp64:
@@ -155,15 +166,32 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build.txt
-        pip install mkl mkl-devel spin "click<8.3.0" pytest hypothesis pytest-xdist pooch
+        pip install mkl mkl-devel build pytest hypothesis pytest-xdist pooch
         pip install -r requirements/openblas64.txt
 
-    - name: Build with ILP64
+    - name: Write out scipy-openblas64.pc
+      run: |
+        python -c'import scipy_openblas64 as so64; print(so64.get_pkg_config())' > scipy-openblas64.pc
+
+    - name: Build SciPy wheel and install
       run: |
         # scipy-openblas64 doesn't have LP64 symbols, so we can only use it
         # with `_without-fortran=true`. Drop this flag when `scipy.odr` gets
         # removed, keeping the rest of this job unchanged.
-        spin build --with-scipy-openblas=64 -S-Duse-ilp64=true -S-D_without-fortran=true -S-Dblas-symbol-suffix=64_
+        python -m build -wnx \
+          -Csetup-args=-Duse-ilp64=true \
+          -Csetup-args=-Dblas-symbol-suffix=64_ \
+          -Csetup-args=-D_without-fortran=true
+        pip install dist/scipy*.whl
 
-    - name: Test
-      run: spin test -j4
+    # TODO: move to end once this works
+    - name: Build and test ILP64 downstream package
+      run: |
+        pip install scipy/linalg/tests/_cython_examples/ilp64_test_package/
+        cd /tmp
+        python -m pytest --pyargs ilp64_test_package
+
+    - name: Test SciPy
+      run: |
+        cd /tmp
+        python -m pytest --pyargs scipy -n4

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -173,6 +173,7 @@ jobs:
         # scipy-openblas64 doesn't have LP64 symbols, so we can only use it
         # with `_without-fortran=true`. Drop this flag when `scipy.odr` gets
         # removed, keeping the rest of this job unchanged.
+        export PKG_CONFIG_PATH=$PWD
         python -m build -wnx \
           -Csetup-args=-Dblas=scipy-openblas \
           -Csetup-args=-Duse-ilp64=true \

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -138,10 +138,14 @@ jobs:
         cd /tmp
         python -m pytest --pyargs scipy -n4
 
-    - name: Build and test ILP64 downstream package
+    - name: Install linalg ILP64 downstream test package
       run: |
         pip install --no-build-isolation -v scipy/linalg/tests/_cython_examples/ilp64_test_package
-        python -m pytest scipy/linalg/tests/_cython_examples/ilp64_test_package/tests
+
+    - name: Test linalg ILP64 downstream test package
+      run: |
+        cd scipy/linalg/tests/_cython_examples/ilp64_test_package
+        python -m pytest tests
 
 
   scipy-openblas-ilp64:
@@ -181,10 +185,14 @@ jobs:
         pip install dist/scipy*.whl
 
     # TODO: move to end once this works
-    - name: Build and test ILP64 downstream package
+    - name: Install linalg ILP64 downstream test package
       run: |
         pip install --no-build-isolation -v scipy/linalg/tests/_cython_examples/ilp64_test_package
-        python -m pytest scipy/linalg/tests/_cython_examples/ilp64_test_package/tests
+
+    - name: Test ILP64 downstream test package
+      run: |
+        cd scipy/linalg/tests/_cython_examples/ilp64_test_package
+        python -m pytest tests
 
     - name: Test SciPy
       run: |

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -141,8 +141,7 @@ jobs:
     - name: Build and test ILP64 downstream package
       run: |
         pip install --no-build-isolation -v scipy/linalg/tests/_cython_examples/ilp64_test_package
-        cd /tmp
-        python -m pytest --pyargs ilp64_test_package
+        python -m pytest scipy/linalg/tests/_cython_examples/ilp64_test_package/tests
 
 
   scipy-openblas-ilp64:
@@ -185,8 +184,7 @@ jobs:
     - name: Build and test ILP64 downstream package
       run: |
         pip install --no-build-isolation -v scipy/linalg/tests/_cython_examples/ilp64_test_package
-        cd /tmp
-        python -m pytest --pyargs ilp64_test_package
+        python -m pytest scipy/linalg/tests/_cython_examples/ilp64_test_package/tests
 
     - name: Test SciPy
       run: |

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -18,6 +18,9 @@ on:
     branches:
       - main
       - maintenance/**
+  push:
+    branches:
+      - cyilp64-compile-test
 
 defaults:
   run:
@@ -107,10 +110,6 @@ jobs:
   mkl-cyilp64:
     runs-on: ubuntu-latest
     name: "MKL ILP64 (cython-blas ILP64)"
-    needs: get_commit_message
-    if: >
-      needs.get_commit_message.outputs.message == 1
-      && (github.repository == 'scipy/scipy' || github.repository == '')
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -149,10 +148,6 @@ jobs:
   scipy-openblas-ilp64:
     runs-on: ubuntu-latest
     name: "scipy-openblas ILP64"
-    needs: get_commit_message
-    if: >
-      needs.get_commit_message.outputs.message == 1
-      && (github.repository == 'scipy/scipy' || github.repository == '')
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -144,8 +144,9 @@ jobs:
 
     - name: Test linalg ILP64 downstream test package
       run: |
-        cd scipy/linalg/tests/_cython_examples/ilp64_test_package
-        python -m pytest tests
+        cp -r scipy/linalg/tests/_cython_examples/ilp64_test_package/tests /tmp/ilp64_tests
+        cd /tmp
+        python -m pytest ilp64_tests
 
 
   scipy-openblas-ilp64:
@@ -191,8 +192,9 @@ jobs:
 
     - name: Test ILP64 downstream test package
       run: |
-        cd scipy/linalg/tests/_cython_examples/ilp64_test_package
-        python -m pytest tests
+        cp -r scipy/linalg/tests/_cython_examples/ilp64_test_package/tests /tmp/ilp64_tests
+        cd /tmp
+        python -m pytest ilp64_tests
 
     - name: Test SciPy
       run: |

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -123,7 +123,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build.txt
-        pip install mkl mkl-devel spin "click<8.3.0" pytest hypothesis pytest-xdist pooch
+        pip install mkl mkl-devel build pytest hypothesis pytest-xdist pooch
 
     - name: Build SciPy wheel and install
       run: |
@@ -161,12 +161,12 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -r requirements/build.txt
-        pip install mkl mkl-devel build pytest hypothesis pytest-xdist pooch
+        pip install build pytest hypothesis pytest-xdist pooch
         pip install -r requirements/openblas64.txt
 
     - name: Write out scipy-openblas64.pc
       run: |
-        python -c'import scipy_openblas64 as so64; print(so64.get_pkg_config())' > scipy-openblas64.pc
+        python -c'import scipy_openblas64 as so64; print(so64.get_pkg_config())' > scipy-openblas.pc
 
     - name: Build SciPy wheel and install
       run: |
@@ -174,6 +174,7 @@ jobs:
         # with `_without-fortran=true`. Drop this flag when `scipy.odr` gets
         # removed, keeping the rest of this job unchanged.
         python -m build -wnx \
+          -Csetup-args=-Dblas=scipy-openblas \
           -Csetup-args=-Duse-ilp64=true \
           -Csetup-args=-Dblas-symbol-suffix=64_ \
           -Csetup-args=-D_without-fortran=true

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -199,4 +199,4 @@ jobs:
     - name: Test SciPy
       run: |
         cd /tmp
-        python -m pytest --pyargs scipy -n4
+        python -m pytest --pyargs scipy -n2

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -18,9 +18,6 @@ on:
     branches:
       - main
       - maintenance/**
-  push:
-    branches:
-      - cyilp64-compile-test
 
 defaults:
   run:
@@ -110,6 +107,10 @@ jobs:
   mkl-cyilp64:
     runs-on: ubuntu-latest
     name: "MKL ILP64 (cython-blas ILP64)"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
@@ -152,6 +153,10 @@ jobs:
   scipy-openblas-ilp64:
     runs-on: ubuntu-latest
     name: "scipy-openblas ILP64"
+    needs: get_commit_message
+    if: >
+      needs.get_commit_message.outputs.message == 1
+      && (github.repository == 'scipy/scipy' || github.repository == '')
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -188,7 +188,7 @@ jobs:
     # TODO: move to end once this works
     - name: Install linalg ILP64 downstream test package
       run: |
-        pip install --no-build-isolation -v scipy/linalg/tests/_cython_examples/ilp64_test_package
+        pip install --no-build-isolation -v -Csetup-args=--werror scipy/linalg/tests/_cython_examples/ilp64_test_package
 
     - name: Test ILP64 downstream test package
       run: |

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -140,7 +140,7 @@ jobs:
 
     - name: Build and test ILP64 downstream package
       run: |
-        pip install scipy/linalg/tests/_cython_examples/ilp64_test_package/
+        pip install --no-build-isolation -v scipy/linalg/tests/_cython_examples/ilp64_test_package
         cd /tmp
         python -m pytest --pyargs ilp64_test_package
 
@@ -184,7 +184,7 @@ jobs:
     # TODO: move to end once this works
     - name: Build and test ILP64 downstream package
       run: |
-        pip install scipy/linalg/tests/_cython_examples/ilp64_test_package/
+        pip install --no-build-isolation -v scipy/linalg/tests/_cython_examples/ilp64_test_package
         cd /tmp
         python -m pytest --pyargs ilp64_test_package
 

--- a/.github/workflows/linux_blas.yml
+++ b/.github/workflows/linux_blas.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Test SciPy
       run: |
         cd /tmp
-        python -m pytest --pyargs scipy -n4
+        python -m pytest --pyargs scipy -n2
 
     - name: Install linalg ILP64 downstream test package
       run: |
@@ -185,7 +185,11 @@ jobs:
           -Csetup-args=-D_without-fortran=true
         pip install dist/scipy*.whl
 
-    # TODO: move to end once this works
+    - name: Test SciPy
+      run: |
+        cd /tmp
+        python -m pytest --pyargs scipy -n2
+
     - name: Install linalg ILP64 downstream test package
       run: |
         pip install --no-build-isolation -v -Csetup-args=--werror scipy/linalg/tests/_cython_examples/ilp64_test_package
@@ -195,8 +199,3 @@ jobs:
         cp -r scipy/linalg/tests/_cython_examples/ilp64_test_package/tests /tmp/ilp64_tests
         cd /tmp
         python -m pytest ilp64_tests
-
-    - name: Test SciPy
-      run: |
-        cd /tmp
-        python -m pytest --pyargs scipy -n2

--- a/doc/source/building/blas_lapack.rst
+++ b/doc/source/building/blas_lapack.rst
@@ -192,11 +192,13 @@ Using Cython BLAS/LAPACK ABI in downstream packages
 
 Downstream packages which consume ``cython_blas`` or ``cython_lapack`` interfaces
 should ideally directly use the ``blas_int`` integer type at all call sites.
-Some packages, however, might prefer to continue using ``int`` types to maintain
-backwards compatibility. In these---hopefully rare---cases you will need to provide
-manual wrappers to map between ``int`` and ``blas_int`` types. We stress that this
-conversion limits the array sizes to ``< INT_MAX`` even if the LAPACK itself is
-ILP64 enabled. It is convenient to localize this mapping in a single internal wrapper.
+
+Some packages, however, might prefer to continue using ``int`` types, and manually
+map between ``int`` and ``blas_int`` types (It is convenient to localize this mapping
+in a single internal wrapper which converts ``int`` inputs to ``blas_int`` before
+calling a LAPACK function, and then converts its ``blas_int`` outputs back to ``int``).
+We stress that doing this limits the array sizes to ``< INT_MAX`` even if the
+LAPACK itself is ILP64 enabled.
 
 Consult `a worked example`_ which illustrates both approaches.
 

--- a/doc/source/building/blas_lapack.rst
+++ b/doc/source/building/blas_lapack.rst
@@ -187,6 +187,20 @@ The build configuration can be checked at runtime via
 ``scipy.show_config()`` — look for the ``'blas cython ilp64'`` entry.
 
 
+Using Cython BLAS/LAPACK ABI in downstream packages
+"""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Downstream packages which consume ``cython_blas`` or ``cython_lapack`` interfaces
+should ideally directly use the ``blas_int`` integer type. Some packages, however,
+might need to continue using ``int`` types to maintain backwards compatibility.
+In these---hopefully rare---cases you will need to provide manual wrappers to map
+between ``int`` and ``blas_int`` types. We stress that this conversion limits the array
+sizes to ``< INT_MAX`` even if the LAPACK itself is ILP64 enabled.
+Consult `a worked example`_ which illustrates both approaches.
+
+.. _a worked example: https://github.com/scipy/scipy/tree/main/scipy/linalg/tests/_cython_examples/ilp64_test_package
+
+
 Work-in-progress
 ----------------
 

--- a/doc/source/building/blas_lapack.rst
+++ b/doc/source/building/blas_lapack.rst
@@ -191,11 +191,13 @@ Using Cython BLAS/LAPACK ABI in downstream packages
 """""""""""""""""""""""""""""""""""""""""""""""""""
 
 Downstream packages which consume ``cython_blas`` or ``cython_lapack`` interfaces
-should ideally directly use the ``blas_int`` integer type. Some packages, however,
-might need to continue using ``int`` types to maintain backwards compatibility.
-In these---hopefully rare---cases you will need to provide manual wrappers to map
-between ``int`` and ``blas_int`` types. We stress that this conversion limits the array
-sizes to ``< INT_MAX`` even if the LAPACK itself is ILP64 enabled.
+should ideally directly use the ``blas_int`` integer type at all call sites.
+Some packages, however, might prefer to continue using ``int`` types to maintain
+backwards compatibility. In these---hopefully rare---cases you will need to provide
+manual wrappers to map between ``int`` and ``blas_int`` types. We stress that this
+conversion limits the array sizes to ``< INT_MAX`` even if the LAPACK itself is
+ILP64 enabled. It is convenient to localize this mapping in a single internal wrapper.
+
 Consult `a worked example`_ which illustrates both approaches.
 
 .. _a worked example: https://github.com/scipy/scipy/tree/main/scipy/linalg/tests/_cython_examples/ilp64_test_package

--- a/pixi.toml
+++ b/pixi.toml
@@ -523,6 +523,26 @@ description = "Check loaded shared libraries with MKL (ILP64, cython-blas ILP64)
 
 
 
+[feature.build-mkl-cyilp64]
+platforms = ["linux-64"]
+
+[feature.build-mkl-cyilp64.tasks.build-mkl-cyilp64]
+cmd = "spin build --build-dir=build-mkl-cyilp64 --setup-args=-Duse-ilp64=true --setup-args=-Dblas=mkl-dynamic-ilp64-seq --setup-args=-Duse-g77-abi=true --setup-args=-D_without-fortran=true"
+env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" }
+description = "Build SciPy with MKL (ILP64)"
+
+[feature.mkl-cyilp64.tasks.test-mkl-cyilp64]
+cmd = "spin test --no-build --build-dir=build-mkl-cyilp64"
+depends-on = "build-mkl-cyilp64"
+description = "Test SciPy with MKL (ILP64)"
+
+[feature.mkl-cyilp64.tasks.check-mkl-cyilp64-sharedlibs]
+cmd = "spin check --no-build --build-dir=build-mkl-cyilp64 --loaded-sharedlibs"
+depends-on = "build-mkl-cyilp64"
+description = "Check loaded shared libraries with MKL (ILP64)"
+
+
+
 
 [feature.scipy-openblas.pypi-dependencies]
 scipy-openblas32 = "==0.3.31.22.0"

--- a/pixi.toml
+++ b/pixi.toml
@@ -523,26 +523,6 @@ description = "Check loaded shared libraries with MKL (ILP64, cython-blas ILP64)
 
 
 
-[feature.build-mkl-cyilp64]
-platforms = ["linux-64"]
-
-[feature.build-mkl-cyilp64.tasks.build-mkl-cyilp64]
-cmd = "spin build --build-dir=build-mkl-cyilp64 --setup-args=-Duse-ilp64=true --setup-args=-Dblas=mkl-dynamic-ilp64-seq --setup-args=-Duse-g77-abi=true --setup-args=-D_without-fortran=true"
-env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" }
-description = "Build SciPy with MKL (ILP64)"
-
-[feature.mkl-cyilp64.tasks.test-mkl-cyilp64]
-cmd = "spin test --no-build --build-dir=build-mkl-cyilp64"
-depends-on = "build-mkl-cyilp64"
-description = "Test SciPy with MKL (ILP64)"
-
-[feature.mkl-cyilp64.tasks.check-mkl-cyilp64-sharedlibs]
-cmd = "spin check --no-build --build-dir=build-mkl-cyilp64 --loaded-sharedlibs"
-depends-on = "build-mkl-cyilp64"
-description = "Check loaded shared libraries with MKL (ILP64)"
-
-
-
 
 [feature.scipy-openblas.pypi-dependencies]
 scipy-openblas32 = "==0.3.31.22.0"

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/README
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/README
@@ -1,11 +1,23 @@
 A small test package to demonstrate ILP64 support in downstream Cython packages.
-Currently, SciPy can be built with or without ILP64 support; in the former case 
-`cython_lapack` ABI can built to be either LP64 or ILP64, see [1] for a discussion.
 
-Here we demonstrate two ways of adapting downstream:
-1. Use a cython wrapper to cast from `int` to `blas_int` type, so that the outward
-   facing user ABI is LP64 (see `tests/test_wrapper.py` for details);
-2. Directly use SciPy's `blas_int` type without an intermediate wrapper layer
+Currently, SciPy can be built with or without ILP64 support; in the former case 
+`cython_lapack` ABI can be built to be either LP64 or ILP64, see [1] for a discussion.
+
+Here we demonstrate two ways of adapting downstream for a Cython-using package,
+which relies on `cython_lapack`.
+
+A difficulty is that `cython_lapack` is using `blas_int` type for integer variables
+and arrays, which resolves to either a C `int` or `int64_t`.
+A downstream user package has two options:
+
+1. Use a cython wrapper to cast from `int` to `blas_int` type, so that other modules
+   can depend on this wrapper and hence don't need changing.
+   This way, the linear algebra is exposed as LP64 regardless of whether SciPy
+   is built to internally use LP64 or ILP64 variants.
+   See `tests/test_wrapper.py` for details.
+
+2. Directly use SciPy's `blas_int` type without an intermediate wrapper layer.
+   This way, the downstream functionality is not limited by `INT_MAX` for array sizes.
    (see `tests/test_direct.py` for details).
 
 See the relevant SciPy CI workflow [2] for an example of building and testing

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/README
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/README
@@ -1,0 +1,18 @@
+A small test package to demonstrate ILP64 support in downstream Cython packages.
+Currently, SciPy can be built with or without ILP64 support; in the former case 
+`cython_lapack` ABI can built to be either LP64 or ILP64, see [1] for a discussion.
+
+Here we demonstrate two ways of adapting downstream:
+1. Use a cython wrapper to cast from `int` to `blas_int` type, so that the outward
+   facing user ABI is LP64 (see `tests/test_wrapper.py` for details);
+2. Directly use SciPy's `blas_int` type without an intermediate wrapper layer
+   (see `tests/test_direct.py` for details).
+
+See the relevant SciPy CI workflow [2] for an example of building and testing
+this package.
+
+------------
+
+[1] https://scipy.github.io/devdocs/building/blas_lapack.html#bit-integer-ilp64-blas-lapack
+[2] https://github.com/scipy/scipy/blob/main/.github/workflows/linux_blas.yml
+

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/meson.build
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/meson.build
@@ -1,4 +1,4 @@
-project('ilp64_test_package', 'c', 'cython')
+project('ilp64_test_package', 'c', 'cython', meson_version: '>=1.9.0')
 
 fs = import('fs')
 py = import('python').find_installation(pure: false)

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/meson.build
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/meson.build
@@ -1,0 +1,36 @@
+project('ilp64_test_package', 'c', 'cython')
+
+fs = import('fs')
+py = import('python').find_installation(pure: false)
+cy = meson.get_compiler('cython')
+
+if not cy.version().version_compare('>=3.2.0')
+  error('Requires Cython >= 3.2.0')
+endif
+
+cython_args = ['-Xfreethreading_compatible=True']
+
+# Check if scipy's cython_blas exports blas_int (ILP64 support).
+# This is the pattern that downstream packages like scikit-learn and
+# statsmodels use to detect and adapt to ILP64 builds.
+scipy_has_blas_int = cy.compiles(
+  'from scipy.linalg.cython_blas cimport blas_int',
+  name: 'scipy cython_blas blas_int'
+)
+
+_blas_int_conf = configuration_data()
+if scipy_has_blas_int
+  _blas_int_conf.set('BLAS_INT_DEF',
+    'from scipy.linalg.cython_blas cimport blas_int')
+else
+  # Backwards compat for scipy<1.18.0
+  _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
+endif
+
+_blas_int_pxi = configure_file(
+  input: 'src/ilp64_test_package/_blas_int.pxi.in',
+  output: '_blas_int.pxi',
+  configuration: _blas_int_conf,
+)
+
+subdir('src/ilp64_test_package')

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/meson.build
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/meson.build
@@ -8,29 +8,9 @@ if not cy.version().version_compare('>=3.2.0')
   error('Requires Cython >= 3.2.0')
 endif
 
-cython_args = ['-Xfreethreading_compatible=True']
-
-# Check if scipy's cython_blas exports blas_int (ILP64 support).
-# This is the pattern that downstream packages like scikit-learn and
-# statsmodels use to detect and adapt to ILP64 builds.
-scipy_has_blas_int = cy.compiles(
-  'from scipy.linalg.cython_blas cimport blas_int',
-  name: 'scipy cython_blas blas_int'
-)
-
-_blas_int_conf = configuration_data()
-if scipy_has_blas_int
-  _blas_int_conf.set('BLAS_INT_DEF',
-    'from scipy.linalg.cython_blas cimport blas_int')
-else
-  # Backwards compat for scipy<1.18.0
-  _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
-endif
-
-_blas_int_pxi = configure_file(
-  input: 'src/ilp64_test_package/_blas_int.pxi.in',
-  output: '_blas_int.pxi',
-  configuration: _blas_int_conf,
-)
+cython_args = [
+  '-Xfreethreading_compatible=True',
+  '-I' + meson.project_build_root() / 'src' / 'ilp64_test_package',
+]
 
 subdir('src/ilp64_test_package')

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/pyproject.toml
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["meson-python>=0.16.0", "cython>=3.2.0", "numpy>=2.0.0"]
+requires = ["meson-python>=0.16.0", "cython>=3.2.0", "numpy>=2.0.0", "scipy"]
 build-backend = "mesonpy"
 
 [project]
 name = "ilp64_test_package"
 version = "0.1.0"
+license = "BSD-3-Clause"
 requires-python = ">=3.12"
 dependencies = ["scipy", "numpy"]

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/pyproject.toml
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["meson-python>=0.16.0", "cython>=3.2.0", "numpy>=2.0.0"]
+build-backend = "mesonpy"
+
+[project]
+name = "ilp64_test_package"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = ["scipy", "numpy"]

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_int.pxi.in
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_int.pxi.in
@@ -1,0 +1,4 @@
+# This will be a plain `int` if scipy.linalg.cython_blas doesn't have
+# `blas_int`, and `blas_int` (cimported from scipy) if it does.
+# See the top-level `meson.build` for the compile-time check.
+@BLAS_INT_DEF@

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pxd
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pxd
@@ -9,6 +9,8 @@ cdef double _ddot(int n, const double *x, int incx,
 cdef void _daxpy(int n, double alpha, const double *x, int incx,
                  double *y, int incy) noexcept nogil
 
+cdef double _dnrm2(int n, const double *x, int incx) noexcept nogil
+
 cdef void _dgemm(char *transa, char *transb, int m, int n, int k,
                  double alpha, const double *a, int lda,
                  const double *b, int ldb,

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pxd
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pxd
@@ -1,0 +1,20 @@
+# Internal .pxd declaring wrapper functions with `int` parameters.
+# This simulates the pattern used by scikit-learn and statsmodels,
+# where the existing internal API uses `int` and must be adapted
+# to work with ILP64 builds where BLAS/LAPACK expect 64-bit integers.
+
+cdef double _ddot(int n, const double *x, int incx,
+                  const double *y, int incy) noexcept nogil
+
+cdef void _daxpy(int n, double alpha, const double *x, int incx,
+                 double *y, int incy) noexcept nogil
+
+cdef void _dgemm(char *transa, char *transb, int m, int n, int k,
+                 double alpha, const double *a, int lda,
+                 const double *b, int ldb,
+                 double beta, double *c, int ldc) noexcept nogil
+
+cdef int _dgetrf(int m, int n, double *a, int lda,
+                 int *ipiv) noexcept nogil
+
+cpdef int get_blas_int_size()

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pyx
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pyx
@@ -12,7 +12,7 @@ before calling the actual BLAS/LAPACK routines.
 
 include "_blas_int.pxi"
 
-from scipy.linalg.cython_blas cimport ddot, daxpy, dgemm
+from scipy.linalg.cython_blas cimport ddot, daxpy, dgemm, dnrm2
 from scipy.linalg.cython_lapack cimport dgetrf
 
 from libc.stdlib cimport malloc, free
@@ -33,6 +33,14 @@ cdef void _daxpy(int n, double alpha, const double *x, int incx,
                  double *y, int incy) noexcept nogil:
     cdef blas_int bn = n, bincx = incx, bincy = incy
     daxpy(&bn, &alpha, <double *>x, &bincx, y, &bincy)
+
+
+cdef double _dnrm2(int n, const double *x, int incx) noexcept nogil:
+    cdef:
+        blas_int bn = n
+        blas_int bincx = incx
+        double nrm2 = dnrm2(&bn, <double *>x, &bincx)
+    return nrm2
 
 
 cdef void _dgemm(char *transa, char *transb, int m, int n, int k,

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pyx
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pyx
@@ -17,17 +17,22 @@ from scipy.linalg.cython_lapack cimport dgetrf
 
 from libc.stdlib cimport malloc, free
 
+# Pointer casts from `const double *` to `double *` below are needed because
+# SciPy's cython_blas.pxd lacks const qualifiers. This pattern is copied from
+# scikit-learn's sklearn/utils/_cython_blas.pyx.
+# See: https://github.com/scipy/scipy/issues/14262
+
 
 cdef double _ddot(int n, const double *x, int incx,
                   const double *y, int incy) noexcept nogil:
     cdef blas_int bn = n, bincx = incx, bincy = incy
-    return ddot(&bn, x, &bincx, y, &bincy)
+    return ddot(&bn, <double *>x, &bincx, <double *>y, &bincy)
 
 
 cdef void _daxpy(int n, double alpha, const double *x, int incx,
                  double *y, int incy) noexcept nogil:
     cdef blas_int bn = n, bincx = incx, bincy = incy
-    daxpy(&bn, &alpha, x, &bincx, y, &bincy)
+    daxpy(&bn, &alpha, <double *>x, &bincx, y, &bincy)
 
 
 cdef void _dgemm(char *transa, char *transb, int m, int n, int k,
@@ -37,7 +42,7 @@ cdef void _dgemm(char *transa, char *transb, int m, int n, int k,
     cdef blas_int bm = m, bn = n, bk = k
     cdef blas_int blda = lda, bldb = ldb, bldc = ldc
     dgemm(transa, transb, &bm, &bn, &bk,
-          &alpha, a, &blda, b, &bldb, &beta, c, &bldc)
+          &alpha, <double *>a, &blda, <double *>b, &bldb, &beta, c, &bldc)
 
 
 cdef int _dgetrf(int m, int n, double *a, int lda,

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pyx
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_blas_lapack_wrappers.pyx
@@ -1,0 +1,69 @@
+#cython: language_level=3
+#cython: boundscheck=False
+#cython: wraparound=False
+"""
+Part 1: sklearn-like BLAS/LAPACK wrappers with int->blas_int conversion.
+
+This module includes _blas_int.pxi (generated from the .pxi.in template)
+which defines blas_int as either `int` (LP64) or `int64_t` (ILP64).
+All wrapper functions accept `int` parameters and convert to `blas_int`
+before calling the actual BLAS/LAPACK routines.
+"""
+
+include "_blas_int.pxi"
+
+from scipy.linalg.cython_blas cimport ddot, daxpy, dgemm
+from scipy.linalg.cython_lapack cimport dgetrf
+
+from libc.stdlib cimport malloc, free
+
+
+cdef double _ddot(int n, const double *x, int incx,
+                  const double *y, int incy) noexcept nogil:
+    cdef blas_int bn = n, bincx = incx, bincy = incy
+    return ddot(&bn, x, &bincx, y, &bincy)
+
+
+cdef void _daxpy(int n, double alpha, const double *x, int incx,
+                 double *y, int incy) noexcept nogil:
+    cdef blas_int bn = n, bincx = incx, bincy = incy
+    daxpy(&bn, &alpha, x, &bincx, y, &bincy)
+
+
+cdef void _dgemm(char *transa, char *transb, int m, int n, int k,
+                 double alpha, const double *a, int lda,
+                 const double *b, int ldb,
+                 double beta, double *c, int ldc) noexcept nogil:
+    cdef blas_int bm = m, bn = n, bk = k
+    cdef blas_int blda = lda, bldb = ldb, bldc = ldc
+    dgemm(transa, transb, &bm, &bn, &bk,
+          &alpha, a, &blda, b, &bldb, &beta, c, &bldc)
+
+
+cdef int _dgetrf(int m, int n, double *a, int lda,
+                 int *ipiv) noexcept nogil:
+    """LU factorization. The tricky part: ipiv is an output array of
+    blas_int, but the downstream API uses int. We must allocate a
+    temporary blas_int array, call LAPACK, then copy back."""
+    cdef:
+        blas_int bm = m, bn = n, blda = lda, info
+        blas_int *bipiv
+        int min_mn = min(m, n)
+        int i
+
+    bipiv = <blas_int *>malloc(min_mn * sizeof(blas_int))
+    if bipiv == NULL:
+        return -1000  # allocation failure
+
+    dgetrf(&bm, &bn, a, &blda, bipiv, &info)
+
+    for i in range(min_mn):
+        ipiv[i] = <int>bipiv[i]
+
+    free(bipiv)
+    return <int>info
+
+
+cpdef int get_blas_int_size():
+    """Return sizeof(blas_int) to verify correct type at compile+runtime."""
+    return sizeof(blas_int)

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_consumer.pyx
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_consumer.pyx
@@ -1,0 +1,47 @@
+#cython: language_level=3
+#cython: boundscheck=False
+#cython: wraparound=False
+"""
+Part 1 consumer: cimports from the internal _blas_lapack_wrappers module.
+
+This validates that the internal .pxd works correctly for cross-module
+cimport, which is the pattern used by scikit-learn (e.g., other Cython
+modules cimporting from sklearn.utils._cython_blas).
+"""
+
+from ilp64_test_package._blas_lapack_wrappers cimport (
+    _ddot, _daxpy, _dgemm, _dgetrf, get_blas_int_size
+)
+
+
+cpdef double consumer_ddot(double[:] x, double[:] y):
+    cdef int n = x.shape[0]
+    return _ddot(n, &x[0], 1, &y[0], 1)
+
+
+cpdef consumer_daxpy(double alpha, double[:] x, double[:] y):
+    cdef int n = x.shape[0]
+    _daxpy(n, alpha, &x[0], 1, &y[0], 1)
+
+
+cpdef consumer_dgemm(double alpha, double[::1,:] a, double[::1,:] b,
+                     double beta, double[::1,:] c):
+    """Matrix multiply assuming Fortran-contiguous arrays."""
+    cdef:
+        char transa = b'N'
+        char transb = b'N'
+        int m = a.shape[0]
+        int k = a.shape[1]
+        int n = b.shape[1]
+    _dgemm(&transa, &transb, m, n, k,
+           alpha, &a[0, 0], m, &b[0, 0], k, beta, &c[0, 0], m)
+
+
+cpdef int consumer_dgetrf(double[::1,:] a, int[:] ipiv):
+    """LU factorization via the internal wrappers."""
+    cdef int m = a.shape[0], n = a.shape[1]
+    return _dgetrf(m, n, &a[0, 0], m, &ipiv[0])
+
+
+cpdef int consumer_blas_int_size():
+    return get_blas_int_size()

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_consumer.pyx
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_consumer.pyx
@@ -9,14 +9,22 @@ cimport, which is the pattern used by scikit-learn (e.g., other Cython
 modules cimporting from sklearn.utils._cython_blas).
 """
 
+from libc.limits cimport INT_MAX
+
 from ilp64_test_package._blas_lapack_wrappers cimport (
     _ddot, _daxpy, _dnrm2, _dgemm, _dgetrf, get_blas_int_size
 )
 
 
 cpdef double consumer_ddot(double[:] x, double[:] y):
+    if x.shape[0] > INT_MAX:
+        raise ValueError("Integer overflow in consumer_ddot.")
     cdef int n = x.shape[0]
     return _ddot(n, &x[0], 1, &y[0], 1)
+
+
+# Strictly speaking, all functions should check for integer overflow of the input array
+# size. We are omitting these checks below, for brevity.
 
 
 cpdef consumer_daxpy(double alpha, double[:] x, double[:] y):

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_consumer.pyx
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_consumer.pyx
@@ -10,7 +10,7 @@ modules cimporting from sklearn.utils._cython_blas).
 """
 
 from ilp64_test_package._blas_lapack_wrappers cimport (
-    _ddot, _daxpy, _dgemm, _dgetrf, get_blas_int_size
+    _ddot, _daxpy, _dnrm2, _dgemm, _dgetrf, get_blas_int_size
 )
 
 
@@ -22,6 +22,14 @@ cpdef double consumer_ddot(double[:] x, double[:] y):
 cpdef consumer_daxpy(double alpha, double[:] x, double[:] y):
     cdef int n = x.shape[0]
     _daxpy(n, alpha, &x[0], 1, &y[0], 1)
+
+
+cpdef consumer_dnrm2(double[:] x):
+    cdef:
+        int n = x.shape[0]
+        int incx = x.strides[0] // sizeof(double)
+        double nrm2 = _dnrm2(n, &x[0], incx)
+    return nrm2
 
 
 cpdef consumer_dgemm(double alpha, double[::1,:] a, double[::1,:] b,

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_direct_blas.pyx
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_direct_blas.pyx
@@ -8,7 +8,7 @@ This simulates a downstream package that directly adapts to SciPy's
 blas_int type, using it throughout without int->blas_int conversion.
 """
 
-from scipy.linalg.cython_blas cimport blas_int, ddot, daxpy, dgemm
+from scipy.linalg.cython_blas cimport blas_int, ddot, daxpy, dgemm, dnrm2
 from scipy.linalg.cython_lapack cimport dgetrf
 
 from libc.stdlib cimport malloc, free
@@ -26,6 +26,14 @@ cpdef direct_daxpy(double alpha, double[:] x, double[:] y):
         blas_int n = x.shape[0]
         blas_int incx = 1, incy = 1
     daxpy(&n, &alpha, &x[0], &incx, &y[0], &incy)
+
+
+cpdef double direct_dnrm2(double[:] x):
+    cdef:
+        blas_int n = x.shape[0]
+        blas_int incx = x.strides[0] // sizeof(double)
+        double result = dnrm2(&n, &x[0], &incx)
+    return result
 
 
 cpdef direct_dgemm(double alpha, double[::1,:] a, double[::1,:] b,

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_direct_blas.pyx
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_direct_blas.pyx
@@ -74,6 +74,18 @@ cpdef int direct_dgetrf(double[::1,:] a, int[:] ipiv_out):
     return <int>info
 
 
+cpdef int direct_dgetrf_2(double[::1,:] a, blas_int[:] ipiv):
+    """Similar to `direct_dgetrf` but accepts `ipiv` as a `blas_int` array."""
+    cdef:
+        blas_int m = a.shape[0]
+        blas_int n = a.shape[1]
+        blas_int lda = m
+        blas_int info
+
+    dgetrf(&m, &n, &a[0, 0], &lda, &ipiv[0], &info)
+    return <int>info
+
+
 cpdef int get_blas_int_size():
     """Return sizeof(blas_int) to verify correct type at compile+runtime."""
     return sizeof(blas_int)

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_direct_blas.pyx
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/_direct_blas.pyx
@@ -1,0 +1,71 @@
+#cython: language_level=3
+#cython: boundscheck=False
+#cython: wraparound=False
+"""
+Part 2: directly uses scipy's blas_int without an intermediate .pxd layer.
+
+This simulates a downstream package that directly adapts to SciPy's
+blas_int type, using it throughout without int->blas_int conversion.
+"""
+
+from scipy.linalg.cython_blas cimport blas_int, ddot, daxpy, dgemm
+from scipy.linalg.cython_lapack cimport dgetrf
+
+from libc.stdlib cimport malloc, free
+
+
+cpdef double direct_ddot(double[:] x, double[:] y):
+    cdef:
+        blas_int n = x.shape[0]
+        blas_int incx = 1, incy = 1
+    return ddot(&n, &x[0], &incx, &y[0], &incy)
+
+
+cpdef direct_daxpy(double alpha, double[:] x, double[:] y):
+    cdef:
+        blas_int n = x.shape[0]
+        blas_int incx = 1, incy = 1
+    daxpy(&n, &alpha, &x[0], &incx, &y[0], &incy)
+
+
+cpdef direct_dgemm(double alpha, double[::1,:] a, double[::1,:] b,
+                   double beta, double[::1,:] c):
+    """Matrix multiply assuming Fortran-contiguous arrays."""
+    cdef:
+        char transa = b'N'
+        char transb = b'N'
+        blas_int m = a.shape[0]
+        blas_int k = a.shape[1]
+        blas_int n = b.shape[1]
+        blas_int lda = m, ldb = k, ldc = m
+    dgemm(&transa, &transb, &m, &n, &k,
+          &alpha, &a[0, 0], &lda, &b[0, 0], &ldb, &beta, &c[0, 0], &ldc)
+
+
+cpdef int direct_dgetrf(double[::1,:] a, int[:] ipiv_out):
+    """LU factorization using blas_int directly for ipiv."""
+    cdef:
+        blas_int m = a.shape[0]
+        blas_int n = a.shape[1]
+        blas_int lda = m
+        blas_int info
+        blas_int *ipiv
+        int min_mn = min(a.shape[0], a.shape[1])
+        int i
+
+    ipiv = <blas_int *>malloc(min_mn * sizeof(blas_int))
+    if ipiv == NULL:
+        return -1000
+
+    dgetrf(&m, &n, &a[0, 0], &lda, ipiv, &info)
+
+    for i in range(min_mn):
+        ipiv_out[i] = <int>ipiv[i]
+
+    free(ipiv)
+    return <int>info
+
+
+cpdef int get_blas_int_size():
+    """Return sizeof(blas_int) to verify correct type at compile+runtime."""
+    return sizeof(blas_int)

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/meson.build
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/meson.build
@@ -1,4 +1,25 @@
-_wrappers_pxd = fs.copyfile('_blas_lapack_wrappers.pxd')
+# Check if scipy's cython_blas exports blas_int (ILP64 support).
+# This is the pattern that downstream packages like scikit-learn and
+# statsmodels use to detect and adapt to ILP64 builds.
+scipy_has_blas_int = cy.compiles(
+  'from scipy.linalg.cython_blas cimport blas_int',
+  name: 'scipy cython_blas blas_int'
+)
+
+_blas_int_conf = configuration_data()
+if scipy_has_blas_int
+  _blas_int_conf.set('BLAS_INT_DEF',
+    'from scipy.linalg.cython_blas cimport blas_int')
+else
+  # Backwards compat for scipy<1.18.0
+  _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
+endif
+
+_blas_int_pxi = configure_file(
+  input: '_blas_int.pxi.in',
+  output: '_blas_int.pxi',
+  configuration: _blas_int_conf,
+)
 
 # Part 1: Internal .pxd + wrappers (sklearn-like pattern)
 py.extension_module(
@@ -15,7 +36,6 @@ py.extension_module(
 py.extension_module(
   '_consumer',
   '_consumer.pyx',
-  _wrappers_pxd,
   install: true,
   subdir: 'ilp64_test_package',
   cython_args: cython_args,
@@ -34,6 +54,5 @@ py.extension_module(
 
 py.install_sources(
   '__init__.py',
-  '_blas_lapack_wrappers.pxd',
   subdir: 'ilp64_test_package',
 )

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/meson.build
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/meson.build
@@ -25,7 +25,7 @@ _blas_int_pxi = configure_file(
 py.extension_module(
   '_blas_lapack_wrappers',
   '_blas_lapack_wrappers.pyx',
-  # _blas_int_pxi,
+  _blas_int_pxi,
   install: true,
   subdir: 'ilp64_test_package',
   cython_args: cython_args,

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/meson.build
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/meson.build
@@ -25,7 +25,7 @@ _blas_int_pxi = configure_file(
 py.extension_module(
   '_blas_lapack_wrappers',
   '_blas_lapack_wrappers.pyx',
-  _blas_int_pxi,
+  # _blas_int_pxi,
   install: true,
   subdir: 'ilp64_test_package',
   cython_args: cython_args,

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/meson.build
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/src/ilp64_test_package/meson.build
@@ -1,0 +1,39 @@
+_wrappers_pxd = fs.copyfile('_blas_lapack_wrappers.pxd')
+
+# Part 1: Internal .pxd + wrappers (sklearn-like pattern)
+py.extension_module(
+  '_blas_lapack_wrappers',
+  '_blas_lapack_wrappers.pyx',
+  _blas_int_pxi,
+  install: true,
+  subdir: 'ilp64_test_package',
+  cython_args: cython_args,
+  c_args: ['-DCYTHON_CCOMPLEX=0'],
+)
+
+# Part 1: Consumer that cimports from the internal .pxd
+py.extension_module(
+  '_consumer',
+  '_consumer.pyx',
+  _wrappers_pxd,
+  install: true,
+  subdir: 'ilp64_test_package',
+  cython_args: cython_args,
+  c_args: ['-DCYTHON_CCOMPLEX=0'],
+)
+
+# Part 2: Direct use of scipy's blas_int
+py.extension_module(
+  '_direct_blas',
+  '_direct_blas.pyx',
+  install: true,
+  subdir: 'ilp64_test_package',
+  cython_args: cython_args,
+  c_args: ['-DCYTHON_CCOMPLEX=0'],
+)
+
+py.install_sources(
+  '__init__.py',
+  '_blas_lapack_wrappers.pxd',
+  subdir: 'ilp64_test_package',
+)

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_direct.py
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_direct.py
@@ -7,6 +7,7 @@ import scipy.linalg.cython_blas as cython_blas
 from ilp64_test_package._direct_blas import (
     direct_ddot,
     direct_daxpy,
+    direct_dnrm2,
     direct_dgemm,
     direct_dgetrf,
     get_blas_int_size,
@@ -31,6 +32,17 @@ class TestBLASLevel1:
         y = np.array([4.0, 5.0, 6.0])
         direct_daxpy(2.0, x, y)
         assert_allclose(y, [6.0, 9.0, 12.0])
+
+    def test_dnrm2_large_vector(self):
+        x = np.zeros(2**31, dtype=np.float64)
+        x[-1] = 1.0
+        nrm2 = direct_dnrm2(x)
+        if get_blas_int_size() == np.int64().itemsize:
+            # Internal cython_blas has ILP64 support
+            assert_allclose(nrm2, 1.0, atol=1e-14)
+        else:
+            # Internal cython_blas does not have ILP64 support
+            assert_allclose(nrm2, 0.0, atol=1e-14)
 
 
 class TestBLASLevel3:

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_direct.py
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_direct.py
@@ -10,6 +10,7 @@ from ilp64_test_package._direct_blas import (
     direct_dnrm2,
     direct_dgemm,
     direct_dgetrf,
+    direct_dgetrf_2,
     get_blas_int_size,
 )
 
@@ -72,4 +73,16 @@ class TestLAPACK:
         a = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64, order='F')
         ipiv = np.empty(2, dtype=np.intc)
         info = direct_dgetrf(a, ipiv)
+        assert info == 0
+
+    def test_dgetrf_2(self):
+        a = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64, order='F')
+
+        # direct_dgetrf_2 receives the pivot array as `blas_int`
+        if get_blas_int_size() == np.intc().itemsize:
+            int_dtype = np.int32
+        else:
+            int_dtype = np.int64
+        ipiv = np.empty(2, dtype=int_dtype)
+        info = direct_dgetrf_2(a, ipiv)
         assert info == 0

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_direct.py
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_direct.py
@@ -1,0 +1,63 @@
+"""Tests for Part 2: direct use of scipy's blas_int."""
+
+import numpy as np
+from numpy.testing import assert_allclose
+import scipy.linalg.cython_blas as cython_blas
+
+from ilp64_test_package._direct_blas import (
+    direct_ddot,
+    direct_daxpy,
+    direct_dgemm,
+    direct_dgetrf,
+    get_blas_int_size,
+)
+
+
+class TestBlasIntSize:
+    def test_blas_int_matches_scipy(self):
+        expected = cython_blas._blas_int_size()
+        assert get_blas_int_size() == expected
+
+
+class TestBLASLevel1:
+    def test_ddot(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([4.0, 5.0, 6.0])
+        result = direct_ddot(x, y)
+        assert_allclose(result, np.dot(x, y))
+
+    def test_daxpy(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([4.0, 5.0, 6.0])
+        direct_daxpy(2.0, x, y)
+        assert_allclose(y, [6.0, 9.0, 12.0])
+
+
+class TestBLASLevel3:
+    def test_dgemm_identity(self):
+        a = np.eye(3, dtype=np.float64, order='F')
+        b = np.arange(9, dtype=np.float64).reshape(3, 3, order='F')
+        c = np.empty((3, 3), dtype=np.float64, order='F')
+        direct_dgemm(1.0, a, b, 0.0, c)
+        assert_allclose(c, b)
+
+    def test_dgemm_product(self):
+        a = np.array([[1, 2], [3, 4]], dtype=np.float64, order='F')
+        b = np.array([[5, 6], [7, 8]], dtype=np.float64, order='F')
+        c = np.zeros((2, 2), dtype=np.float64, order='F')
+        direct_dgemm(1.0, a, b, 0.0, c)
+        assert_allclose(c, a @ b)
+
+
+class TestLAPACK:
+    def test_dgetrf(self):
+        a = np.array([[2, 1], [1, 3]], dtype=np.float64, order='F')
+        ipiv = np.empty(2, dtype=np.intc)
+        info = direct_dgetrf(a, ipiv)
+        assert info == 0
+
+    def test_dgetrf_rectangular(self):
+        a = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64, order='F')
+        ipiv = np.empty(2, dtype=np.intc)
+        info = direct_dgetrf(a, ipiv)
+        assert info == 0

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_wrappers.py
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_wrappers.py
@@ -7,6 +7,7 @@ import scipy.linalg.cython_blas as cython_blas
 from ilp64_test_package._consumer import (
     consumer_ddot,
     consumer_daxpy,
+    consumer_dnrm2,
     consumer_dgemm,
     consumer_dgetrf,
     consumer_blas_int_size,
@@ -30,7 +31,15 @@ class TestBLASLevel1:
         x = np.array([1.0, 2.0, 3.0])
         y = np.array([4.0, 5.0, 6.0])
         consumer_daxpy(2.0, x, y)
-        assert_allclose(y, [6.0, 9.0, 12.0])
+        assert_allclose(y, [6.0, 9.0, 12.0])     
+
+    def test_dnrm2_large_vector(self):
+        x = np.zeros(2**31, dtype=np.float64)
+        x[-1] = 1.0
+        nrm2 = consumer_dnrm2(x)
+        # LP64 answer due to blas_int->int casts in consumer_dnrm2
+        # cf a similar test in test_direct.py
+        assert_allclose(nrm2, 0.0, atol=1e-14)
 
 
 class TestBLASLevel3:

--- a/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_wrappers.py
+++ b/scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_wrappers.py
@@ -1,0 +1,63 @@
+"""Tests for Part 1: sklearn-like wrappers with internal .pxd and int->blas_int."""
+
+import numpy as np
+from numpy.testing import assert_allclose
+import scipy.linalg.cython_blas as cython_blas
+
+from ilp64_test_package._consumer import (
+    consumer_ddot,
+    consumer_daxpy,
+    consumer_dgemm,
+    consumer_dgetrf,
+    consumer_blas_int_size,
+)
+
+
+class TestBlasIntSize:
+    def test_blas_int_matches_scipy(self):
+        expected = cython_blas._blas_int_size()
+        assert consumer_blas_int_size() == expected
+
+
+class TestBLASLevel1:
+    def test_ddot(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([4.0, 5.0, 6.0])
+        result = consumer_ddot(x, y)
+        assert_allclose(result, np.dot(x, y))
+
+    def test_daxpy(self):
+        x = np.array([1.0, 2.0, 3.0])
+        y = np.array([4.0, 5.0, 6.0])
+        consumer_daxpy(2.0, x, y)
+        assert_allclose(y, [6.0, 9.0, 12.0])
+
+
+class TestBLASLevel3:
+    def test_dgemm_identity(self):
+        a = np.eye(3, dtype=np.float64, order='F')
+        b = np.arange(9, dtype=np.float64).reshape(3, 3, order='F')
+        c = np.empty((3, 3), dtype=np.float64, order='F')
+        consumer_dgemm(1.0, a, b, 0.0, c)
+        assert_allclose(c, b)
+
+    def test_dgemm_product(self):
+        a = np.array([[1, 2], [3, 4]], dtype=np.float64, order='F')
+        b = np.array([[5, 6], [7, 8]], dtype=np.float64, order='F')
+        c = np.zeros((2, 2), dtype=np.float64, order='F')
+        consumer_dgemm(1.0, a, b, 0.0, c)
+        assert_allclose(c, a @ b)
+
+
+class TestLAPACK:
+    def test_dgetrf(self):
+        a = np.array([[2, 1], [1, 3]], dtype=np.float64, order='F')
+        ipiv = np.empty(2, dtype=np.intc)
+        info = consumer_dgetrf(a, ipiv)
+        assert info == 0
+
+    def test_dgetrf_rectangular(self):
+        a = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float64, order='F')
+        ipiv = np.empty(2, dtype=np.intc)
+        info = consumer_dgetrf(a, ipiv)
+        assert info == 0

--- a/tools/check_installation.py
+++ b/tools/check_installation.py
@@ -35,8 +35,12 @@ submodule_paths = get_submodule_paths()
 # Files whose installation path will be different from original one
 changed_installed_path = {
     'scipy/_build_utils/tests/test_scipy_version.py':
-        'scipy/_lib/tests/test_scipy_version.py'
+        'scipy/_lib/tests/test_scipy_version.py',
+    'scipy/linalg/tests/_cython_examples/ilp64_test_package/tests/test_wrappers.py': '',
 }
+
+# Subdirs in the source tree which should not be installed
+exclude_paths = ['scipy/linalg/tests/_cython_examples/ilp64_test_package/',]
 
 
 def main(install_dir, no_tests):
@@ -102,8 +106,13 @@ def get_test_files(dir, ext="py"):
     test_files = dict()
     underscore = "_" if ext == "so" else ""
     for path in glob.glob(f'{dir}/**/{underscore}test_*.{ext}', recursive=True):
+
         if any(submodule_path in path for submodule_path in submodule_paths):
             continue
+
+        if any(exclude_path in path for exclude_path in exclude_paths):
+            continue
+
         suffix_path = get_suffix_path(path, 3)
         suffix_path = changed_installed_path.get(suffix_path, suffix_path)
         test_files[suffix_path] = path


### PR DESCRIPTION
The bulk of work here done by @rgommers.

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

a follow-up to https://github.com/scipy/scipy/pull/24977

#### What does this implement/fix?
<!--Please explain your changes.-->

gh-24977 introduced the `blas_int` type for `cython_{blas,lapack}` which resolves to either a C `int` or C `int64_t` depending on the build mode. For downstream users, adapting to use this type is fraught with backwards compat concerns because of quirky details of what exactly is an ABI contract in cython cimport (cf https://github.com/cython/cython/issues/7603 for gory details). 

In essense, downstream users have two options: directly use the `blas_int` type from `cython_blas`, or add a small wrapper layer to map between `blas_int` and `int`. 

This PR adds a worked example: a test package to show both approaches, for a setting similar to what e.g. `scikit-learn` does. The package is meant to serve as a canonical reference.
Specifically, this PR adds:
- `ilp64_test_package` in `linalg/tests/_cython_examples`, which includes
    -  two sets of Cython wrappers
    - a piece of build-time meson esoteria to divine the integer bit width used by `scipy.linalg.cython_{blas,lapack}`
    - tests to demonstrate usage and limitations
- a CI update to build and test this demo package
- a pointer to the package from the docs

#### Additional information
<!--Any additional information you think is important.-->

Shoving a full package into the test subdirectory is a bit suboptimal, as the CI workflow shows. An alternative is to move it to a separate package under the `scipy/` GH org and clone from there in the CI. Have decided to not bother (it won't help all _that_ much, after all) but can do if there are strong opinions. 

The PR will need to be squash-merged either way.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Some Claude usage to fill in boilerplate, all reviewed/tweaked by humans.
