### PR TITLE
DEP: spatial: deprecate tsearch

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -357,6 +357,7 @@ for key in (
         'pade',
         'lagrange',
         'approximate_taylor_polynomial',
+        'tsearch',
         ):
     warnings.filterwarnings(action='ignore', message='.*' + key + '.*')
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -653,7 +653,8 @@ if HAVE_SCPDT:
         # deprecated
         'scipy.interpolate.lagrange',
         'scipy.interpolate.approximate_taylor_polynomial',
-        'scipy.interpolate.pade'
+        'scipy.interpolate.pade',
+        'scipy.spatial.tsearch',
     ])
 
     # help pytest collection a bit: these names are either private

--- a/scipy/spatial/_qhull.pyx
+++ b/scipy/spatial/_qhull.pyx
@@ -12,6 +12,7 @@ Wrappers for Qhull triangulation, plus some additional N-D geometry utilities
 # Distributed under the same BSD license as Scipy.
 #
 
+import warnings
 
 import numpy as np
 cimport numpy as np
@@ -28,6 +29,7 @@ from scipy._lib.messagestream cimport MessageStream
 from libc.stdio cimport FILE
 
 from scipy.linalg.cython_lapack cimport blas_int, dgetrf, dgetrs, dgecon
+from scipy._lib._array_api import xp_capabilities
 
 np.import_array()
 
@@ -2201,12 +2203,17 @@ class Delaunay(_QhullUser):
         return z
 
 
+@xp_capabilities(out_of_scope=True)
 def tsearch(tri, xi):
     """
     tsearch(tri, xi)
 
     Find simplices containing the given points. This function does the
     same thing as `Delaunay.find_simplex`.
+
+    .. deprecated:: 1.18.0
+        `tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be removed
+        in SciPy 1.22.0.
 
     Parameters
     ----------
@@ -2251,6 +2258,9 @@ def tsearch(tri, xi):
     >>> plt.show()
 
     """
+    msg = ("`tsearch` is deprecated in favor of `Delaunay.find_simplex` and will be "
+           "removed in SciPy 1.22.0.")
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
     return tri.find_simplex(xi)
 
 # Set docstring for foo to docstring of bar, working around change in Cython 0.28

--- a/scipy/spatial/tests/test_qhull.py
+++ b/scipy/spatial/tests/test_qhull.py
@@ -191,7 +191,8 @@ class TestUtilities:
                   (0.3, 0.2, 1)]:
             i = tri.find_simplex(p[:2])
             assert_equal(i, p[2], err_msg=f'{p!r}')
-            j = qhull.tsearch(tri, p[:2])
+            with pytest.warns(DeprecationWarning, match="`tsearch` is deprecated"):
+                j = qhull.tsearch(tri, p[:2])
             assert_equal(i, j)
 
     def test_plane_distance(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://discuss.scientific-python.org/t/deprecations-to-clean-up-scipy-spatial-api/2291
#### What does this implement/fix?
<!--Please explain your changes.-->

`tsearch` is convenience function that offers no convenience! 

#### Additional information
<!--Any additional information you think is important.-->

No objections from the mailing list in over a week.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No ai.