### PR TITLE
TST: integrate: increase tolerance for float32 in `test_result_dtype_promoted_correctly`

### DIFF
--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -504,6 +504,7 @@ class TestCubature:
             basic_1d_integrand,
             xp.asarray([0], dtype=xp.float32),
             xp.asarray([1], dtype=xp.float32),
+            rtol=1e-7,
             points=[],
             args=(xp.asarray([1], dtype=xp.float32), xp),
         ).estimate.dtype


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

x-ref #25033

(Possibly closes it if we decide that the subdivisions behavior difference in that issue is benign.)
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

A call to cubature with float32 input has an rtol of 1e-8, which is smaller than machine epsilon. This is slow for JAX. Raise rtol to make this faster.

This change saves ~47 seconds inside the test `scipy/integrate/tests/test_cubature.py::TestCubature::test_result_dtype_promoted_correctly[jax.numpy]`. It does so by reducing the rtol for a call to cubature with float32 inputs.

Test command:

```
spin test --build-dir=build-cpu -m 'array_api_backends and not slow' -s integrate -b jax.numpy -- --durations 3 --timeout=120 -k test_result_dtype_promoted_correctly -s
```

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI