### PR TITLE
CI: Enable xdist and JAX caching for Array API CPU job 

### DIFF
--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -23,7 +23,7 @@ runs:
       # Run a restore and save if running on main
       # Note: we can't simply use restore followed by save because composite actions
       # are not capable of running post job steps.
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ true }}  # revert me
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}
@@ -31,7 +31,7 @@ runs:
         restore-keys: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-
     - name: Setup compiler cache
       # Run just the restore if not running on main
-      if: ${{ github.ref != 'refs/heads/main' }}
+      if: ${{ false }}  # revert me
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}

--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -19,9 +19,6 @@ runs:
         echo "dir=${CCACHE_DIR:-$HOME/.ccache}" >> $GITHUB_OUTPUT
         NOW=$(date -u +"%F-%T")
         echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-        # Restoring the cache also restored the stats from the previous run
-        # Try to search for ccache on our path, or try pixi
-        pixi exec ccache --zero-stats || ccache --zero-stats
     - name: Setup compiler cache and save it
       # Run a restore and save if running on main
       # Note: we can't simply use restore followed by save because composite actions
@@ -40,3 +37,9 @@ runs:
         path: ${{ steps.prep-ccache.outputs.dir }}
         key: ${{ inputs.workflow_name }}-${{ inputs.job_name}}-ccache-linux-${{ steps.prep-ccache.outputs.timestamp }}
         restore-keys: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-
+    - name: Reset stats
+      shell: bash
+      run: |
+        # Restoring the cache also restored the stats from the previous run
+        # Try to search for ccache on our path, or try pixi
+        pixi exec ccache --zero-stats || ccache --zero-stats

--- a/.github/ccache/action.yml
+++ b/.github/ccache/action.yml
@@ -23,7 +23,7 @@ runs:
       # Run a restore and save if running on main
       # Note: we can't simply use restore followed by save because composite actions
       # are not capable of running post job steps.
-      if: ${{ true }}  # revert me
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}
@@ -31,7 +31,7 @@ runs:
         restore-keys: ${{ inputs.workflow_name }}-${{ inputs.job_name }}-ccache-linux-
     - name: Setup compiler cache
       # Run just the restore if not running on main
-      if: ${{ false }}  # revert me
+      if: ${{ github.ref != 'refs/heads/main' }}
       uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684
       with:
         path: ${{ steps.prep-ccache.outputs.dir }}

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -23,6 +23,8 @@ permissions:
 env:
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
   CCACHE_MAXSIZE: "250M"
+  # Needed because Pixi doesn't set mtime for compilers
+  CCACHE_COMPILERCHECK: "content"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -77,7 +77,7 @@ jobs:
         run: |
           export OMP_NUM_THREADS=2
           for task in ${TASKS}; do
-            pixi run --skip-deps "$task" -j 3 -- --durations 3 --timeout=120
+            pixi run --skip-deps "$task" -j 3 -- --durations 3 --timeout=120 --dist worksteal
           done
         env:
           TASKS: ${{ join(matrix.tasks, ' ') }}

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -25,6 +25,8 @@ env:
   CCACHE_MAXSIZE: "250M"
   # Needed because Pixi doesn't set mtime for compilers
   CCACHE_COMPILERCHECK: "content"
+  JAX_COMPILATION_CACHE_DIR: "${{ github.workspace }}/.cache/scipy_jax_cache"
+  JAX_PERSISTENT_CACHE_MIN_COMPILE_TIME_SECS: "0"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -8,6 +8,14 @@ on:
     branches:
       - main
       - maintenance/**
+  schedule:
+  #        ┌───────────── minute (0 - 59)
+  #        │  ┌───────────── hour (0 - 23)
+  #        │  │  ┌───────────── day of the month (1 - 31)
+  #        │  │  │  ┌───────────── month (1 - 12 or JAN-DEC)
+  #        │  │  │  │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+  #        │  │  │  │ │
+  - cron: "47 11 2/2 * *"
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/.github/workflows/array_api.yml
+++ b/.github/workflows/array_api.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           export OMP_NUM_THREADS=2
           for task in ${TASKS}; do
-            pixi run --skip-deps "$task" -- --durations 3 --timeout=60
+            pixi run --skip-deps "$task" -j 3 -- --durations 3 --timeout=120
           done
         env:
           TASKS: ${{ join(matrix.tasks, ' ') }}


### PR DESCRIPTION


#### Reference issue

Closes #25014

#### What does this implement/fix?

This PR reduces the total time of the slowest job in our CI by about 64% overall.

It implements the following:

* Enable JAX cache, and save it locally.
* Enable xdist.
* Fix issue with ccache having poor hit rate, due to compiler mtime changing between runs.
* Timeout changed because tests run slower when run in parallel.
* Run on a cron on main to populate ccache.
* Fix issue with ccache stat reset being done prior to cache restore. Stats are tracked in files inside the cache directory, so running `--zero-stats` prior to cache restore doesn't work.

##### Benchmarks

The Build number below assumes a cache hit.

| run                                                                                             | Build | Test  | Total |
|-------------------------------------------------------------------------------------------------|-------|-------|-------|
| [baseline](https://github.com/scipy/scipy/actions/runs/24536379414/job/71732246069)             | 1033s | 2497s | 3567s |
| [this branch](https://github.com/scipy/scipy/actions/runs/24621342382/job/71992529491?pr=25037) | 60s   | 1172s  | 1276s  |


#### Additional information

##### Alternatives considered

Experimented with persisting JAX cache, and setting JAX_COMPILATION_CACHE_MAX_SIZE to control cache size. Found two complications: 

 1. This setting seems to make tests not run in parallel.
 2. There is additional complication that I want to selectively save the cache: I only want to save the cache if running jax tests on main, and not if running PyTorch tests, or running on PRs. Have not figured out a nice way to do this.

In the spirit of not letting the perfect be the enemy of the good, I figured I'd submit the useful changes I've figured out so far.


#### AI Generation Disclosure

No AI tools used.
