### PR TITLE
DOC: stats.binomtest: fix unbalanced backticks

### DIFF
--- a/scipy/stats/_binomtest.py
+++ b/scipy/stats/_binomtest.py
@@ -176,7 +176,7 @@ def _binom_wilson_conf_int(k, n, confidence_level, alternative, correction, *, x
 
 @xp_capabilities(skip_backends=[('dask.array', "")], cpu_only=True,
                  reason="binomial distribution ufuncs only available for NumPy",
-                 extra_note="`alternative='two-sided' is incompatible with JAX arrays.")
+                 extra_note="`alternative='two-sided'` is incompatible with JAX arrays.")
 def binomtest(k, n, p=0.5, alternative='two-sided'):
     """
     Perform a test that the probability of success is p.
@@ -286,7 +286,7 @@ def binomtest(k, n, p=0.5, alternative='two-sided'):
         pval = B.sf(k - 1)
     else:
         if is_jax(xp):
-            message = "`alternative='two-sided' is incompatible with JAX arrays."
+            message = "`alternative='two-sided'` is incompatible with JAX arrays."
             raise ValueError(message)
 
         # alternative is 'two-sided'

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1262,7 +1262,7 @@ class TestBinomTest:
         n = xp.asarray(11, dtype=dtype)
         p = xp.asarray(0.4, dtype=dtype)
         if is_jax(xp) and alternative=='two-sided':
-            message = "`alternative='two-sided' is incompatible with JAX arrays."
+            message = "`alternative='two-sided'` is incompatible with JAX arrays."
             with pytest.raises(ValueError, match=message):
                 stats.binomtest(k, n, p)
             return
@@ -1295,7 +1295,7 @@ class TestBinomTest:
         p = rng.uniform(-0.1, 1.1, size=shape)
 
         if is_jax(xp) and alternative=='two-sided':
-            pytest.skip("`alternative='two-sided' is incompatible with JAX arrays.")
+            pytest.skip("`alternative='two-sided'` is incompatible with JAX arrays.")
 
         res = stats.binomtest(xp.asarray(k), xp.asarray(n), xp.asarray(p),
                               alternative=alternative)


### PR DESCRIPTION
Breaks rst parsing.

Introduced in #24501 (planed for 1.18.0), so unrealesed should not break anything or anyone relying on exact message format

[skip ci]
