### PR TITLE
MAINT: _lib: harden `_ccallback_c` capsule teardown

### DIFF
--- a/scipy/_lib/_ccallback_c.pyx
+++ b/scipy/_lib/_ccallback_c.pyx
@@ -4,8 +4,11 @@ from cpython.pycapsule cimport (
     PyCapsule_CheckExact, PyCapsule_New, PyCapsule_SetContext, PyCapsule_GetName, PyCapsule_GetPointer,
     PyCapsule_GetContext
 )
+from cpython.pythread cimport (
+    PyThread_type_lock, PyThread_allocate_lock, PyThread_acquire_lock, PyThread_release_lock
+)
 from cpython.long cimport PyLong_AsVoidPtr
-from libc.stdlib cimport free
+from libc.stdlib cimport free, malloc
 from libc.string cimport strdup
 from libc.math cimport sin
 
@@ -17,10 +20,84 @@ from .ccallback cimport (ccallback_t, ccallback_prepare, ccallback_release, CCAL
 # PyCapsule helpers
 #
 
+# Keep ownership of duplicated signature strings off mutable capsule fields.
+ctypedef struct raw_capsule_name_entry:
+    void *capsule
+    char *name
+    raw_capsule_name_entry *next
+
+
+cdef raw_capsule_name_entry *raw_capsule_name_entries = NULL
+cdef PyThread_type_lock raw_capsule_name_entries_lock = NULL
+
+
+raw_capsule_name_entries_lock = PyThread_allocate_lock()
+if raw_capsule_name_entries_lock == NULL:
+    raise MemoryError("thread lock allocation failed")
+
+
+cdef void raw_capsule_acquire_lock() noexcept:
+    if not PyThread_acquire_lock(raw_capsule_name_entries_lock, 0):
+        PyThread_acquire_lock(raw_capsule_name_entries_lock, 1)
+
+
+cdef void raw_capsule_release_lock() noexcept:
+    PyThread_release_lock(raw_capsule_name_entries_lock)
+
+
+cdef int raw_capsule_register_name(object capsule, char *name) except -1:
+    global raw_capsule_name_entries
+    cdef raw_capsule_name_entry *entry
+
+    entry = <raw_capsule_name_entry *>malloc(sizeof(raw_capsule_name_entry))
+    if entry == NULL:
+        raise MemoryError()
+
+    raw_capsule_acquire_lock()
+    entry.capsule = <void *>capsule
+    entry.name = name
+    entry.next = raw_capsule_name_entries
+    raw_capsule_name_entries = entry
+    raw_capsule_release_lock()
+    return 0
+
+
+cdef char *raw_capsule_pop_name(object capsule) noexcept:
+    global raw_capsule_name_entries
+    cdef raw_capsule_name_entry *entry
+    cdef raw_capsule_name_entry *prev = NULL
+    cdef raw_capsule_name_entry *next_entry
+    cdef void *capsule_ptr = <void *>capsule
+    cdef char *name = NULL
+
+    raw_capsule_acquire_lock()
+    entry = raw_capsule_name_entries
+    while entry != NULL:
+        if entry.capsule == capsule_ptr:
+            name = entry.name
+            next_entry = entry.next
+
+            if prev == NULL:
+                raw_capsule_name_entries = next_entry
+            else:
+                prev.next = next_entry
+
+            free(entry)
+            raw_capsule_release_lock()
+            return name
+
+        prev = entry
+        entry = entry.next
+
+    raw_capsule_release_lock()
+    return NULL
+
 cdef void raw_capsule_destructor(object capsule) noexcept:
-    cdef const char *name
-    name = PyCapsule_GetName(capsule)
-    free(<char*>name)
+    cdef char *name
+
+    name = raw_capsule_pop_name(capsule)
+    if name != NULL:
+        free(name)
 
 
 def get_raw_capsule(func_obj, name_obj, context_obj):
@@ -45,7 +122,8 @@ def get_raw_capsule(func_obj, name_obj, context_obj):
         void *context
         const char *capsule_name
         const char *name
-        const char *name_copy
+        char *name_copy
+        object capsule
 
     if name_obj is None:
         name = NULL
@@ -76,11 +154,27 @@ def get_raw_capsule(func_obj, name_obj, context_obj):
         func = PyLong_AsVoidPtr(int(func_obj))
 
     if name == NULL:
-        name_copy = name
+        name_copy = NULL
     else:
         name_copy = strdup(name)
+        if name_copy == NULL:
+            raise MemoryError()
 
-    capsule = PyCapsule_New(func, name_copy, &raw_capsule_destructor)
+    try:
+        capsule = PyCapsule_New(func, name_copy, &raw_capsule_destructor)
+    except:
+        if name_copy != NULL:
+            free(name_copy)
+        raise
+
+    if name_copy != NULL:
+        try:
+            raw_capsule_register_name(capsule, name_copy)
+        except:
+            capsule = None
+            free(name_copy)
+            raise
+
     if context != NULL:
         PyCapsule_SetContext(capsule, context)
     return capsule

--- a/scipy/_lib/tests/test_ccallback.py
+++ b/scipy/_lib/tests/test_ccallback.py
@@ -1,10 +1,13 @@
 from numpy.testing import assert_equal, assert_
 from pytest import raises as assert_raises
 
-import time
-import pytest
 import ctypes
+import subprocess
+import sys
 import threading
+import time
+
+import pytest
 from scipy._lib import _ccallback_c as _test_ccallback_cython
 from scipy._lib import _test_ccallback
 from scipy._lib._ccallback import LowLevelCallable
@@ -194,3 +197,41 @@ def test_threadsafety():
 
     for caller in CALLERS.keys():
         check(caller)
+
+
+def test_capsule_name_mutation_does_not_crash():
+    # A pre-fix regression aborts the interpreter, so exercise teardown in a child.
+    code = r"""
+import ctypes
+import gc
+
+from scipy._lib import _test_ccallback
+from scipy._lib._ccallback import LowLevelCallable
+
+set_name = ctypes.pythonapi.PyCapsule_SetName
+set_name.restype = ctypes.c_int
+set_name.argtypes = [ctypes.py_object, ctypes.c_char_p]
+
+llcallable = LowLevelCallable(_test_ccallback.test_get_plus1_capsule())
+capsule = tuple.__getitem__(llcallable, 0)
+name = ctypes.create_string_buffer(b"double (double, int *, void *)")
+
+if set_name(capsule, ctypes.cast(name, ctypes.c_char_p)) != 0:
+    raise RuntimeError("PyCapsule_SetName failed")
+
+assert _test_ccallback.test_call_simple(llcallable, 1.0) == 2.0
+
+capsule = None
+llcallable = None
+gc.collect()
+print("ok")
+"""
+    proc = subprocess.run(
+        [sys.executable, "-X", "faulthandler", "-c", code],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "ok"


### PR DESCRIPTION
Hi there,
This issue was detected and fix was proposed as part of an LLM-assisted security audit and previously discussed with the Tidelift team.  After discussion about severity and how to fix, we agreed that this belonged here.

#### What does this implement/fix?

`scipy._lib._ccallback_c.get_raw_capsule` duplicates the capsule signature string and passes it to `PyCapsule_New`, while `raw_capsule_destructor` previously  freed whatever pointer `PyCapsule_GetName(capsule)` returned at teardown.

If the capsule name is mutated before destruction, teardown may attempt to free a pointer that is no longer the SciPy-owned duplicated string.  This is obviously already somewhat dangerous territory because it involves `ctypes` but under many security models it's still a borderline contract violation.

This PR hardens that path by tracking the owned duplicated name separately and freeing only that stored pointer in `raw_capsule_destructor`, rather than consulting mutable capsule metadata during teardown.

I also added a regression test that mutates the capsule name via `PyCapsule_SetName` in a subprocess and verifies that callback execution and interpreter teardown both complete cleanly.

#### Additional information

I considered using capsule context for the owned signature pointer, but `ccallback` already uses capsule context for `user_data`, so this keeps the change local to `_ccallback_c`.

Happy to revisit if you want to address differently.
