### PR TITLE
DOC: special.expit: fix description

### DIFF
--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -1887,7 +1887,7 @@ const char *erfcx_doc = R"(
 const char *expit_doc = R"(
     expit(x, out=None)
 
-    Expit (a.k.a. logistic sigmoid) ufunc for ndarrays.
+    Expit (also known as logistic sigmoid) ufunc for ndarrays.
 
     The expit function, also known as the logistic sigmoid function, is
     defined as ``expit(x) = 1/(1+exp(-x))``.  It is the inverse of the


### PR DESCRIPTION
DOC: Bug in special.expit description #25049 : fixed the issue

instead of using "a.k.a." I used "also known as" this was the main issue causing the bug in the documentation.

Closes #25049 