### PR TITLE
DOC: misc typos in syntax

### DIFF
--- a/scipy/integrate/_ivp/base.py
+++ b/scipy/integrate/_ivp/base.py
@@ -62,7 +62,7 @@ class OdeSolver:
     9. By convention, the function evaluations used to compute a finite
        difference approximation of the Jacobian should not be counted in
        `nfev`, thus use ``fun_single(self, t, y)`` or
-       ```fun_vectorized(self, t, y)`` when computing a finite difference
+       ``fun_vectorized(self, t, y)`` when computing a finite difference
        approximation of the Jacobian.
 
     Parameters

--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -404,7 +404,7 @@ class _BSpline:
         for _ in range(m):
             tt, cc = _insert(x, tt, cc, self.k, self.extrapolate == "periodic")
         return self.construct_fast(tt, cc, self.k, self.extrapolate, self.axis)
-        
+
 
 @functools.lru_cache(16)
 def _get_xp_bspline_cls(xp):
@@ -2348,10 +2348,11 @@ def _compute_optimal_gcv_parameter(X, wE, y, w):
         -----
         Criteria is computed from the formula (1.3.2) [3]:
 
-        .. math:
+        .. math::
 
-        GCV(\lambda) = \dfrac{1}{n} \sum\limits_{k = 1}^{n} \dfrac{ \left(
-        y_k - f_{\lambda}(x_k) \right)^2}{\left( 1 - \Tr{A}/n\right)^2}$.
+            GCV(\lambda) = \dfrac{1}{n} \sum\limits_{k = 1}^{n} \dfrac{ \left(
+            y_k - f_{\lambda}(x_k) \right)^2}{\left( 1 - \Tr{A}/n\right)^2}
+
         The criteria is discussed in section 1.3 [3].
 
         The numerator is computed using (2.2.4) [3] and the denominator is

--- a/scipy/optimize/_differentialevolution.py
+++ b/scipy/optimize/_differentialevolution.py
@@ -694,7 +694,7 @@ class DifferentialEvolutionSolver:
         user's responsibility to ensure that the polishing function obeys
         bounds, any constraints (including integrality constraints), and that
         appropriate attributes are set in the `OptimizeResult`, such as ``fun``,
-        ```x``, ``nfev``, ``jac``.
+        ``x``, ``nfev``, ``jac``.
     maxfun : int, optional
         Set the maximum number of function evaluations. However, it probably
         makes more sense to set `maxiter` instead.

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -930,7 +930,7 @@ def boxcox_llf(lmb, data, *, axis=0, keepdims=False, nan_policy='propagate'):
         If this is set to True, the axes which are reduced are left
         in the result as dimensions with size one. With this option,
         the result will broadcast correctly against the input array.
-    nan_policy : {'propagate', 'omit', 'raise'
+    nan_policy : {'propagate', 'omit', 'raise'}
         Defines how to handle input NaNs.
 
         - ``propagate``: if a NaN is present in the axis slice (e.g. row) along

--- a/scipy/stats/_page_trend_test.py
+++ b/scipy/stats/_page_trend_test.py
@@ -165,7 +165,7 @@ def page_trend_test(data, ranked=False, predicted_ranks=None, method='auto'):
     The *p*-values are not adjusted for the possibility of ties. When
     ties are present, the reported  ``'exact'`` *p*-values may be somewhat
     larger (i.e. more conservative) than the true *p*-value [2]_. The
-    ``'asymptotic'``` *p*-values, however, tend to be smaller (i.e. less
+    ``'asymptotic'`` *p*-values, however, tend to be smaller (i.e. less
     conservative) than the ``'exact'`` *p*-values.
 
     References


### PR DESCRIPTION
Some purely visual update (missing closing }),
Also imbalanced backticks, and directive with a single colon, (interpreted as comments)

One math directive was also not indented and had a trailing $, likely previosuly inline math was moved to a block math.

[skip ci]


#### Reference issue

N/A

#### What does this implement/fix?

Visual and Rst parsing issues.

#### Additional information

None

#### AI Generation Disclosure

Claude Sonnet 4.6 was used to potentially help find more of these issues after a few were found by hand.