### PR TITLE
DOC: fix typo in tutorial

### DIFF
--- a/doc/source/tutorial/stats/hypothesis_chi2_contingency.md
+++ b/doc/source/tutorial/stats/hypothesis_chi2_contingency.md
@@ -32,7 +32,7 @@ was investigated. The study notably concluded:
 > ischemic stroke in women [...]
 
 The article lists studies of various cardiovascular events. Let's focus on the
-ischemic stoke in women.
+ischemic stroke in women.
 
 The following table summarizes the results of the experiment in which
 participants took aspirin or a placebo on a regular basis for several years.


### PR DESCRIPTION
DOCS: Fix spelling of "stroke" from "stoke"

[docs only]

#### What does this implement/fix?
Fix a small typo in the docs (https://docs.scipy.org/doc/scipy/tutorial/stats/hypothesis_chi2_contingency.html) where "stroke" was spelled "stoke."
