### PR TITLE
CI: When lockfile changes, don't attempt to restore old Pixi cache

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -74,13 +74,8 @@ jobs:
         uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4
         with:
           path: ${{ env.PIXI_CACHE_DIR }}
-          # Cache hit if lock file did not change. If it did, still restore the cache,
-          # since most packages will still be the same - the cache save will
-          # then happen at the end (in case the lock file didn't change,
-          # nothing is saved at the end of a job).
-          key: ${{ runner.os }}-gpu-pixi-${{ hashFiles('.github/workflows/pixi.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gpu-pixi
+          # Cache hit if lock file did not change. Otherwise, redownload packages.
+          key: ${{ runner.os }}-gpu-pixi-1-${{ hashFiles('.github/workflows/pixi.lock') }}
 
       - name: Setup compiler cache
         uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           path: ${{ env.PIXI_CACHE_DIR }}
           # Cache hit if lock file did not change. Otherwise, redownload packages.
-          key: ${{ runner.os }}-gpu-pixi-1-${{ hashFiles('.github/workflows/pixi.lock') }}
+          key: ${{ runner.os }}-gpu-pixi-1-${{ hashFiles('pixi.lock') }}
 
       - name: Setup compiler cache
         uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4


### PR DESCRIPTION

#### Reference issue

x-ref https://github.com/scipy/scipy/issues/24990#issuecomment-4291650540
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

Currently, when the Pixi lockfile changes, our CI restores the last cache entry it can find for the Pixi dependencies. This only downloads the packages that are incrementally different. However, another approach would be to entirely rebuild the pixi cache each time pixi.lock changes. Historically, this happens about once per 3 days. There are about 10-30 jobs every three days, so this would create cache misses about 10% of the time.

Also, currently the pixi cache key is intended to include a hash of pixi.lock. However, commit a6d9961d5a7616b974ef71d450d6b29482c4151e moved this file from `.github/workflows/` to the repo root. This means that `hashFiles()` evaluates to ''. Fix this as well.

#### Additional information

##### Benchmark

| Scenario | Cache Restore | Pixi Setup | Cache Save | Total Time for Cache Related Steps | Cache Size |
|----------|--------------|------------|------------|------------|------------|
| [current approach](https://github.com/scipy/scipy/actions/runs/24663242073/job/72114338085) | 251s | 6s | 0s | 257s | ~12109 MB |
| [new approach, on cache miss](https://github.com/scipy/scipy/actions/runs/24751956996/job/72416853044?pr=25057) | 0s | 59s | 73s | 132s | ~6375 MB |
| [new approach, on cache hit](https://github.com/scipy/scipy/actions/runs/24752385414/job/72418133987?pr=25057) | 92s | 4s | 0s | 96s | ~6375 MB |

Presuming that cache hits happen 90% of the time, this would lead to an average time of ~~127 seconds~~ 100 seconds, an average which is faster than the current approach. (This number is the sum of just cache-related steps, specifically cache restore, pixi install, and cache save only.)

#### AI Generation Disclosure

No AI tools used
