### PR TITLE
ENH: faster `SphericalVoronoi` 3D area calculations

### DIFF
--- a/scipy/spatial/_spherical_voronoi.py
+++ b/scipy/spatial/_spherical_voronoi.py
@@ -216,16 +216,16 @@ class SphericalVoronoi:
         # for 3D input tri_indices will have shape: (6N-12,)
         tri_indices = np.column_stack([simplex_indices] * self._dim).ravel()
         # for 3D input point_indices will have shape: (6N-12,)
-        point_indices = self._simplices.ravel()
+        self._point_indices = self._simplices.ravel()
         # for 3D input indices will have shape: (6N-12,)
-        indices = np.argsort(point_indices, kind='mergesort')
+        self._indices = np.argsort(self._point_indices, kind='mergesort')
         # for 3D input flattened_groups will have shape: (6N-12,)
-        flattened_groups = tri_indices[indices].astype(np.intp)
+        flattened_groups = tri_indices[self._indices].astype(np.intp)
         # intervals will have shape: (N+1,)
-        intervals = np.cumsum(np.bincount(point_indices + 1))
+        self._intervals = np.cumsum(np.bincount(self._point_indices + 1))
         # split flattened groups to get nested list of unsorted regions
-        groups = [list(flattened_groups[intervals[i]:intervals[i + 1]])
-                  for i in range(len(intervals) - 1)]
+        groups = [list(flattened_groups[self._intervals[i]:self._intervals[i + 1]])
+                  for i in range(len(self._intervals) - 1)]
         self.regions = groups
 
     def sort_vertices_of_regions(self):
@@ -262,15 +262,14 @@ class SphericalVoronoi:
 
     def _calculate_areas_3d(self):
         self.sort_vertices_of_regions()
-        sizes = [len(region) for region in self.regions]
+        sizes = np.diff(self._intervals)
         csizes = np.cumsum(sizes)
         num_regions = csizes[-1]
 
         # We create a set of triangles consisting of one point and two Voronoi
         # vertices. The vertices of each triangle are adjacent in the sorted
         # regions list.
-        point_indices = [i for i, size in enumerate(sizes)
-                         for j in range(size)]
+        point_indices = self._point_indices[self._indices]
 
         nbrs1 = np.array([r for region in self.regions for r in region])
 


### PR DESCRIPTION
* Use a vectorized approach to Voronoi region vertex counting rather than a pure Python iteration.

* Similarly, `point_indices` in the 3D Voronoi cell area calculation was being generated using a pure
Python loop when the information could easily be regenerated using a vectorized approach.

Benchmark results on local ARM Mac are moderately positive (all improvements): `asv continuous -E virtualenv -e -b "time_spherical_polygon_area_calculation" main treddy_faster_sph_vor_3d_area --factor 1.05`. Only the 3D (and not the 2D) area calculations are reported as faster, which is consistent with source code improvements only being made in the 3D code path.

```
| Change   | Before [7ae03097] <main>   | After [8e3417c5] <treddy_faster_sph_vor_3d_area>   |   Ratio | Benchmark (Parameter)                                                       |
|----------|----------------------------|----------------------------------------------------|---------|-----------------------------------------------------------------------------|
| -        | 285±1μs                    | 264±0.5μs                                          |    0.93 | spatial.SphericalVorAreas.time_spherical_polygon_area_calculation(100, 3)   |
| -        | 2.68±0.02ms                | 2.50±0.01ms                                        |    0.93 | spatial.SphericalVorAreas.time_spherical_polygon_area_calculation(1000, 3)  |
| -        | 27.0±0.1ms                 | 25.0±0.1ms                                         |    0.93 | spatial.SphericalVorAreas.time_spherical_polygon_area_calculation(10000, 3) |
| -        | 13.9±0.1ms                 | 12.5±0.08ms                                        |    0.9  | spatial.SphericalVorAreas.time_spherical_polygon_area_calculation(5000, 3)  |

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.

```

#### AI Generation Disclosure
No AI tools used
