### PR TITLE
Fix overflow in ndimage._select when labels dtype has limited range (gh-24966)

### DIFF
--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -992,28 +992,32 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
     if find_positions:
         positions = positions.ravel()[order]
 
+    # Compute size using Python int to avoid overflow when labels dtype
+    # has limited range (e.g., uint8 max=254 + 2 wraps to 0, gh-24966)
+    n = int(labels.max()) + 2
+
     result = []
     if find_min:
-        mins = np.zeros(labels.max() + 2, input.dtype)
+        mins = np.zeros(n, input.dtype)
         mins[labels[::-1]] = input[::-1]
         result += [mins[idxs]]
     if find_min_positions:
-        minpos = np.zeros(labels.max() + 2, int)
+        minpos = np.zeros(n, int)
         minpos[labels[::-1]] = positions[::-1]
         result += [minpos[idxs]]
     if find_max:
-        maxs = np.zeros(labels.max() + 2, input.dtype)
+        maxs = np.zeros(n, input.dtype)
         maxs[labels] = input
         result += [maxs[idxs]]
     if find_max_positions:
-        maxpos = np.zeros(labels.max() + 2, int)
+        maxpos = np.zeros(n, int)
         maxpos[labels] = positions
         result += [maxpos[idxs]]
     if find_median:
         locs = np.arange(len(labels))
-        lo = np.zeros(labels.max() + 2, np.int_)
+        lo = np.zeros(n, np.int_)
         lo[labels[::-1]] = locs[::-1]
-        hi = np.zeros(labels.max() + 2, np.int_)
+        hi = np.zeros(n, np.int_)
         hi[labels] = locs
         lo = lo[idxs]
         hi = hi[idxs]


### PR DESCRIPTION
## Description

When `labels` is an unsigned integer dtype (e.g. `uint8`, `uint16`) and its max value is near the type limit, `labels.max() + 2` overflows in the labels dtype:

- `uint8`: `254 + 2` wraps to `0` → zero-length array → `IndexError`
- `uint16`: `65534 + 2` wraps to `0`

This affects all six array allocations in `_select()` that use this pattern.

## Fix

Compute the allocation size once as a Python int (`int(labels.max()) + 2`) before passing to `np.zeros()`. This avoids dtype-specific overflow.

## Reproduction (from issue)

```python
import numpy as np
from scipy import ndimage

labels = np.zeros(256, dtype=np.uint8)
labels[0] = 254
values = np.ones(256, dtype=np.float32)
ndimage.median(values, labels, index=[254])  # Previously: IndexError
```

Fixes #24966