### PR TITLE
ENH: signal.windows: add `dpss_cola` function

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -763,6 +763,156 @@ class TestDPSS:
         assert_raises(ValueError, windows.dpss, -1, 1, 3, xp=xp)  # negative M
 
 
+# Representative (M, hop) pairs, chosen to cover both branches of the
+# dpss_size rule: hops that divide M (dpss_size == M) and hops that do not
+# (dpss_size == M - hop). Kept small — the full cartesian product is
+# unnecessary once each branch and overlap regime is represented.
+dpss_cola_hops_by_M = {
+    16: [4, 8],
+    64: [16, 32, 43],
+    81: [27, 40],
+    99: [33, 50],
+    128: [32, 43, 64, 96],
+    129: [43, 64],
+    189: [63, 80],
+    243: [81, 100],
+    255: [85, 100],
+    256: [64, 92, 128, 192],
+    261: [87, 130],
+    512: [128, 171, 256, 384],
+    513: [171, 200],
+    1024: [256, 341, 512],
+}
+
+dpss_cola_params = [
+    (M, hop, NW)
+    for M, hops in dpss_cola_hops_by_M.items()
+    for hop in hops
+    for NW in [None, 4.0]
+    if NW is None or 0 < NW < (M - hop) / 2
+]
+
+
+@make_xp_test_case(windows.dpss_cola)
+class TestDPSSCola:
+
+    def test_basic(self, xp):
+        xp_assert_close(
+            windows.dpss_cola(16, 8, xp=xp),
+            xp.asarray(
+                [
+                    0.04708165, 0.13415675, 0.2608477, 
+                    0.41670505, 0.58329495, 0.7391523,
+                    0.86584325, 0.95291835, 0.95291835, 
+                    0.86584325, 0.7391523, 0.58329495,
+                    0.41670505, 0.2608477, 0.13415675, 
+                    0.04708165
+                ],
+                dtype=xp.float64),
+            rtol=1e-13, atol=1e-8)
+
+    def test_hop_equals_M(self, xp):
+        # At hop == M the only COLA-compatible window is the rectangular one.
+        xp_assert_equal(windows.dpss_cola(16, 16, 4.0, xp=xp),
+                        xp.ones(16, dtype=xp.float64))
+
+    def test_default_hop(self, xp):
+        # Default hop is (M + 1) // 2.
+        for M in (64, 65):
+            w1 = windows.dpss_cola(M, NW=4.0, xp=xp)
+            w2 = windows.dpss_cola(M, (M + 1) // 2, 4.0, xp=xp)
+            xp_assert_close(w1, w2, atol=1e-15, rtol=0)
+
+    @pytest.mark.parametrize("M,hop,NW", dpss_cola_params)
+    def test_cola_and_symmetry(self, M, hop, NW, xp):
+        w = windows.dpss_cola(M, hop, NW, xp=xp)
+        xp_assert_close(w, xp.flip(w), atol=1e-12, rtol=0)
+        # Scale n_frames so the interior slice stays ~M samples wide
+        # even when hop is much smaller than M.
+        n_frames = max(64, 10 * M // hop + 2)
+        total_len = (n_frames - 1) * hop + M
+        ola = xp.zeros(total_len, dtype=xp.float64)
+        for i in range(n_frames):
+            ola[i*hop:i*hop+M] += w
+        interior = ola[4*M:total_len - 4*M]
+        xp_assert_close(interior, xp.ones_like(interior),
+                        atol=1e-10, rtol=0)
+
+    def test_sqrt(self, xp):
+        # sqrt=True is defined as the element-wise sqrt of the sqrt=False
+        # window; Princen-Bradley then follows from test_cola_and_symmetry.
+        w = windows.dpss_cola(128, 32, 4.0, xp=xp)
+        w_sqrt = windows.dpss_cola(128, 32, 4.0, sqrt=True, xp=xp)
+        xp_assert_close(w_sqrt * w_sqrt, w, atol=1e-10, rtol=0)
+
+    @pytest.mark.parametrize("M,hop,NW", dpss_cola_params)
+    def test_nonnegative(self, M, hop, NW, xp):
+        # dpss_cola must be non-negative: sqrt=True requires it to be
+        # real-valued, and analysis/synthesis use cases assume a
+        # non-negative envelope.
+        w = windows.dpss_cola(M, hop, NW, xp=xp)
+        xp_assert_close(xp.minimum(w, xp.zeros_like(w)),
+                        xp.zeros_like(w), atol=0, rtol=0)
+        w_sqrt = windows.dpss_cola(M, hop, NW, sqrt=True, xp=xp)
+        xp_assert_close(xp.minimum(w_sqrt, xp.zeros_like(w_sqrt)),
+                        xp.zeros_like(w_sqrt), atol=0, rtol=0)
+
+    def test_degenerate(self, xp):
+        assert_raises(ValueError, windows.dpss_cola, -1, xp=xp)
+        assert_raises(ValueError, windows.dpss_cola, 512, 0, 4.0, xp=xp)
+        assert_raises(ValueError, windows.dpss_cola, 512, 513, 4.0, xp=xp)
+        assert_raises(ValueError, windows.dpss_cola, 512, 1.5, 4.0, xp=xp)
+        assert_raises(ValueError, windows.dpss_cola, 512, 256, 0, xp=xp)
+        assert_raises(ValueError, windows.dpss_cola, 512, 256, -1.0, xp=xp)
+        assert_raises(ValueError, windows.dpss_cola, 512, 256, 1000.0, xp=xp)
+
+    def test_edge_cases(self, xp):
+        xp_assert_equal(windows.dpss_cola(0, NW=4.0, xp=xp),
+                        xp.asarray([], dtype=xp.float64))
+        xp_assert_equal(windows.dpss_cola(1, NW=4.0, xp=xp),
+                        xp.asarray([1.0], dtype=xp.float64))
+        # hop == M collapses to the rectangular window regardless of NW.
+        xp_assert_equal(windows.dpss_cola(2, 2, 0.4, xp=xp),
+                        xp.ones(2, dtype=xp.float64))
+
+    @pytest.mark.parametrize("M,hop,NW", dpss_cola_params)
+    def test_sym_false_matches_shifted_symmetric(self, M, hop, NW, xp):
+        # Periodic form is a leading zero followed by the length-(M-1)
+        # symmetric window. The COLA normalization at hop `hop` is invariant
+        # under the unit shift, so the trailing M-1 samples agree exactly.
+        w_periodic = windows.dpss_cola(M, hop, NW, sym=False, xp=xp)
+        w_sym = windows.dpss_cola(M - 1, hop, NW, sym=True, xp=xp)
+        xp_assert_close(w_periodic[1:], w_sym, atol=1e-15, rtol=0)
+        xp_assert_equal(w_periodic[:1], xp.zeros(1, dtype=xp.float64))
+
+    def test_sym_false_sqrt(self, xp):
+        # sqrt=True composes with sym=False the same way it does with sym=True.
+        w = windows.dpss_cola(128, 32, 4.0, sym=False, xp=xp)
+        w_sqrt = windows.dpss_cola(128, 32, 4.0, sqrt=True, sym=False, xp=xp)
+        xp_assert_close(w_sqrt * w_sqrt, w, atol=1e-10, rtol=0)
+
+    def test_sym_false_edge_cases(self, xp):
+        # Length guards short-circuit before _extend, matching other windows.
+        xp_assert_equal(windows.dpss_cola(0, NW=4.0, sym=False, xp=xp),
+                        xp.asarray([], dtype=xp.float64))
+        xp_assert_equal(windows.dpss_cola(1, NW=4.0, sym=False, xp=xp),
+                        xp.asarray([1.0], dtype=xp.float64))
+
+    def test_get_window(self, xp):
+        w1 = windows.get_window(('dpss_cola', 128, 4.0), 512,
+                                fftbins=False, xp=xp)
+        w2 = windows.dpss_cola(512, 128, 4.0, xp=xp)
+        xp_assert_close(w1, w2)
+
+        w3 = windows.get_window(('dpss_cola', 128), 512, fftbins=False, xp=xp)
+        w4 = windows.dpss_cola(512, 128, xp=xp)
+        xp_assert_close(w3, w4)
+
+        assert_raises(ValueError, windows.get_window, 'dpss_cola', 512, xp=xp)
+        assert_raises(ValueError, windows.get_window,
+                      ('dpss_cola', 128, 4.0, False, 0), 512, xp=xp)
+
+
 @make_xp_test_case(windows.lanczos)
 class TestLanczos:
 

--- a/scipy/signal/windows/__init__.py
+++ b/scipy/signal/windows/__init__.py
@@ -20,6 +20,7 @@ The suite of window functions for filtering and spectral estimation.
    chebwin                 -- Dolph-Chebyshev window
    cosine                  -- Cosine window
    dpss                    -- Discrete prolate spheroidal sequences
+   dpss_cola               -- COLA-compatible DPSS-convolved rect window
    exponential             -- Exponential window
    flattop                 -- Flat top window
    gaussian                -- Gaussian window
@@ -49,4 +50,4 @@ __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'hamming', 'kaiser', 'kaiser_bessel_derived', 'gaussian',
            'general_gaussian', 'general_cosine', 'general_hamming',
            'chebwin', 'cosine', 'hann', 'exponential', 'tukey', 'taylor',
-           'get_window', 'dpss', 'lanczos']
+           'get_window', 'dpss', 'dpss_cola', 'lanczos']

--- a/scipy/signal/windows/_windows.py
+++ b/scipy/signal/windows/_windows.py
@@ -17,7 +17,7 @@ __all__ = ['boxcar', 'triang', 'parzen', 'bohman', 'blackman', 'nuttall',
            'hamming', 'kaiser', 'kaiser_bessel_derived', 'gaussian',
            'general_cosine', 'general_gaussian', 'general_hamming',
            'chebwin', 'cosine', 'hann', 'exponential', 'tukey', 'taylor',
-           'dpss', 'get_window', 'lanczos']
+           'dpss', 'dpss_cola', 'get_window', 'lanczos']
 
 
 def _len_guards(M):
@@ -2238,6 +2238,243 @@ def dpss(M, NW, Kmax=None, sym=True, norm=None, return_ratios=False,
     return (windows, ratios) if return_ratios else windows
 
 
+@xp_capabilities(np_only=True, reason='dpss subroutine is numpy-only')
+def dpss_cola(M, hop=None, NW=None, sqrt=False, sym=True, *,
+              xp=None, device=None):
+    r"""
+    Return a DPSS-based window with exact COLA at a given hop size.
+
+    The window is a zeroth-order DPSS (Slepian) kernel of length
+    ``L - hop + 1`` convolved with a length-`hop` boxcar, where
+    ``L = M`` for the symmetric form and ``L = M - 1`` for the periodic
+    form (which prepends one zero sample). The result is exact
+    constant-overlap-add at hop `hop`, suitable for perfect-reconstruction
+    STFT analysis (and, in `sqrt` mode, analysis-synthesis) [2]_. Its
+    distinguishing feature is that COLA holds at *any* admissible `hop`,
+    not just the specific divisors of `M` where Hann, Hamming, or
+    Blackman happen to -- making it the natural choice for non-dividing
+    hops dictated by external constraints (codec framing, hardware
+    buffer size, latency targets), where no classical window is exactly
+    COLA.
+
+    The smooth DPSS kernel gives a steeply falling sidelobe envelope,
+    so `dpss_cola` is competitive with classical COLA windows on peak
+    and far-field sidelobe levels at every admissible hop [3]_. At high
+    overlap (roughly ``hop <= M / 5``) it dominates on every sidelobe
+    metric, with the margin widening as overlap grows (e.g. ~100 dB
+    below Blackman-Harris on peak sidelobe at 87.5%% overlap). At
+    moderate overlap it ties or trades: at ``hop = M / 4``
+    Blackman-Harris edges out peak and integrated sidelobes while
+    `dpss_cola` retains the far-field advantage; at 50%% overlap
+    Hamming's hand-tuned cosine cancellation produces a lower
+    nearest-neighbor PSL (~-43 dB vs ~-32 dB) and Hann's smoother
+    taper gives lower far-field sidelobes, though `dpss_cola` still
+    wins on integrated sidelobe level. Prefer Hamming when resolving a
+    weak tone adjacent to a strong one matters most; prefer Hann at
+    50%% overlap when far-field rejection dominates; prefer `dpss_cola`
+    at non-dividing hops, at high overlap, or when broadband leakage
+    and reconstruction artifacts dominate (the typical audio STFT use
+    case).
+
+    Parameters
+    ----------
+    M : int
+        Number of points in the output window. If zero, an empty array
+        is returned. An exception is thrown when it is negative.
+    hop : int, optional
+        Hop size in samples. Must satisfy ``0 < hop <= L``, where ``L = M``
+        for ``sym=True`` and ``L = M - 1`` for ``sym=False``. When ``hop``
+        equals ``L``, the window reduces to a rectangular window. If None
+        (default), ``(M + 1) // 2`` is used, corresponding to 50%% overlap.
+    NW : float, optional
+        Standardized half-bandwidth of the underlying DPSS kernel; see
+        `dpss` for the precise definition. Must be positive and strictly
+        less than ``dpss_size / 2``, where ``dpss_size`` is defined in the
+        Notes. If None (default), ``dpss_size / hop`` is used, which aligns
+        the DPSS main lobe with the length-`hop` boxcar's first zero; see
+        Notes.
+    sqrt : bool, optional
+        If True, return the element-wise square root of the window. This is
+        the analysis (and synthesis) window for a square-root-weighted
+        overlap-add that produces COLA=1 on reconstruction. Default is
+        False.
+    sym : bool, optional
+        When True (default), generates a symmetric window, for use in filter
+        design. When False, generates a periodic window, for use in spectral
+        analysis: a length-``M-1`` symmetric window prepended with a single
+        zero sample. Both forms are exactly COLA at hop `hop` -- the
+        length-``M-1`` form is COLA by construction, and shifting it by one
+        sample preserves the property.
+    %(xp_device_snippet)s
+
+    Returns
+    -------
+    w : ndarray
+        The window, of length `M`, exactly COLA at hop `hop` and scaled so
+        that the overlap-add sum equals 1 on the interior. When ``sym=True``,
+        symmetric about its midpoint; when ``sym=False``, the same shape
+        over indices ``1:M`` with a leading zero sample.
+
+    See Also
+    --------
+    dpss : The underlying DPSS (Slepian) window.
+    hann, hamming : Classical COLA windows at specific hops.
+
+    Notes
+    -----
+    Let ``L = M`` for ``sym=True`` and ``L = M - 1`` for ``sym=False``,
+    and ``dpss_size = L - hop + 1``. The symmetric core is
+    :math:`w_L = v * \mathbf{1}_R`, where :math:`v` is a zeroth-order
+    DPSS of length ``dpss_size`` and half-bandwidth `NW`, and
+    :math:`\mathbf{1}_R` is the length-`hop` boxcar. By Poisson summation,
+    COLA at hop :math:`R` is equivalent to
+    :math:`W(e^{j\omega_\ell}) = 0` at :math:`\omega_\ell = 2\pi\ell/R`,
+    :math:`\ell = 1, \ldots, R-1`. The boxcar's DTFT vanishes at exactly
+    those frequencies, so any linear :math:`v * \mathbf{1}_R` satisfies
+    COLA. The periodic form is :math:`w_L` shifted right by one sample,
+    which preserves COLA at hop :math:`R`.
+
+    The implementation performs the convolution in a length-`L` buffer
+    as a ``cumsum`` of a rolled difference. Choosing ``dpss_size = L -
+    hop + 1`` keeps the linear-convolution support inside `L`, so the
+    boxcar's exact zeros are preserved for *any* `hop`, with no
+    special case for whether `hop` divides `L`.
+
+    When `hop` is fixed by an external specification (codec framing,
+    hardware buffer size) and no classical window is COLA, `dpss_cola`
+    delivers machine-precision COLA with strong sidelobe performance --
+    the regime where it has no competitor.
+
+    Unlike `dpss` itself, which has no universally "optimal" `NW`,
+    `dpss_cola` admits a natural default ``NW = dpss_size / hop``. The
+    DPSS kernel's main-lobe half-width is :math:`2\pi\,\mathrm{NW}/
+    \mathrm{dpss\_size}` and the length-`hop` boxcar's first zero is at
+    :math:`2\pi/\mathrm{hop}`; this choice aligns them, matching the DPSS
+    main lobe to the sinc main lobe so the convolution has a single
+    well-defined main lobe and the sidelobe envelope is determined by the
+    boxcar factor.
+
+    In `sqrt` mode the returned window is the square root of the
+    COLA-normalized window -- the natural analysis-synthesis window for
+    square-root-weighted STFT pipelines [2]_.
+
+    .. versionadded:: 1.18
+
+    References
+    ----------
+    .. [1] Slepian, D. "Prolate Spheroidal Wave Functions, Fourier Analysis,
+           and Uncertainty -- V: The Discrete Case." Bell System Technical
+           Journal 57, no. 5 (1978): 1371-1430.
+           :doi:`10.1002/j.1538-7305.1978.tb02104.x`
+    .. [2] Allen, J. B., and L. R. Rabiner. "A Unified Approach to
+           Short-Time Fourier Analysis and Synthesis." Proceedings of the
+           IEEE 65, no. 11 (1977): 1558-1564.
+           :doi:`10.1109/PROC.1977.10770`
+    .. [3] Smith, J. O. Spectral Audio Signal Processing. W3K Publishing,
+           2011. https://ccrma.stanford.edu/~jos/sasp/
+
+    Examples
+    --------
+    Plot the window and its frequency response:
+
+    >>> import numpy as np
+    >>> from scipy.signal import windows
+    >>> from scipy.fft import fft, fftshift
+    >>> import matplotlib.pyplot as plt
+    >>> M, hop = 256, 64
+    >>> window = windows.dpss_cola(M, hop=hop)
+    >>> fig, ax = plt.subplots(1)
+    >>> ax.plot(window)
+    >>> ax.set_title(f"DPSS-COLA window (M={M}, hop={hop})")
+    >>> ax.set_ylabel("Amplitude")
+    >>> ax.set_xlabel("Sample")
+    >>> fig.tight_layout()
+    >>> plt.show()
+
+    >>> fig, ax = plt.subplots(1)
+    >>> A = fft(window, 2048) / (len(window)/2.0)
+    >>> freq = np.linspace(-0.5, 0.5, len(A))
+    >>> response = np.abs(fftshift(A / abs(A).max()))
+    >>> response = 20 * np.log10(np.maximum(response, 1e-10))
+    >>> ax.plot(freq, response)
+    >>> ax.set_xlim(-0.5, 0.5)
+    >>> ax.set_ylim(-120, 0)
+    >>> ax.set_title("Frequency response of the DPSS-COLA window")
+    >>> ax.set_ylabel("Normalized magnitude [dB]")
+    >>> ax.set_xlabel("Normalized frequency [cycles per sample]")
+    >>> fig.tight_layout()
+    >>> plt.show()
+
+    Verify the constant-overlap-add property:
+
+    >>> x = np.zeros(16 * hop + M)
+    >>> for k in range(16):
+    ...     x[k*hop : k*hop + M] += window
+    >>> bool(np.allclose(x[M:-M], 1.0))
+    True
+
+    """
+    xp = _namespace(xp)
+
+    if _len_guards(M):
+        return xp.ones(M, dtype=xp.float64, device=device)
+
+    # The periodic form is the length-(M-1) symmetric window shifted right
+    # by one sample. The length-(M-1) form is COLA at hop `hop` by
+    # construction, so its unit shift is also COLA at hop `hop`.
+    Mw = M if sym else M - 1
+
+    if hop is None:
+        hop = (M + 1) // 2
+    if not isinstance(hop, numbers.Integral) or hop <= 0 or hop > Mw:
+        raise ValueError(
+            'hop must be a positive integer <= M (or M-1 when sym=False)'
+        )
+    if hop == Mw:
+        w = xp.zeros(M, dtype=xp.float64, device=device)
+        w[-Mw:] = xp.ones(Mw, dtype=xp.float64, device=device)
+        return w
+
+    dpss_size = Mw - hop + 1
+
+    if NW is None:
+        # Aligns the DPSS main lobe with the length-`hop` boxcar's first
+        # zero so the convolution has a single well-defined main lobe.
+        NW = min(dpss_size / hop, (dpss_size - 1) / 2)
+
+    if NW <= 0:
+        raise ValueError('NW must be positive')
+    if NW >= dpss_size / 2:
+        raise ValueError('NW must be less than dpss_size/2.')
+
+    # Convolve the DPSS kernel with a length-`hop` boxcar via the identity
+    # boxcar * s = cumsum(s - shift(s, hop)), in a length-Mw buffer.
+    w = xp.zeros(Mw + 1, dtype=xp.float64, device=device)
+    w[:dpss_size] = dpss(dpss_size, NW, sym=True, xp=xp, device=device)
+    w = w - xp.flip(w)
+    head = xp.cumsum(w[:Mw])
+
+    # Remove cumsum round-off and enforce exact symmetry.
+    head[-(Mw // 2):] = xp.flip(head[:Mw // 2])
+
+    # Place the symmetric core in a length-M output; for the periodic form
+    # the leading sample stays zero, which preserves COLA at hop `hop`.
+    w = xp.zeros(M, dtype=xp.float64, device=device)
+    w[-Mw:] = head
+
+    # Normalize so overlap-add at hop `hop` sums to 1 on the interior.
+    n_blocks = (M + hop - 1) // hop
+    w_norm = xp.zeros(n_blocks * hop, dtype=xp.float64, device=device)
+    w_norm[:M] = w
+    w_norm = w_norm.reshape(n_blocks, hop).sum(axis=0)
+    w /= xp.tile(w_norm, n_blocks)[:M]
+
+    if sqrt:
+        w = xp.sqrt(w)
+
+    return w
+
+
 @xp_capabilities()
 def lanczos(M, *, sym=True, xp=None, device=None):
     r"""Return a Lanczos window also known as a sinc window.
@@ -2361,6 +2598,7 @@ _WIN_FUNC_DATA = { # Format: {(name0, name1, ...): (function, needs parameters)
     ('chebwin', 'cheb'): (chebwin, True),
     ('cosine', 'halfcosine'): (cosine, False),
     ('dpss',): (dpss, True),
+    ('dpss_cola',): (dpss_cola, True),
     ('exponential', 'poisson'): (exponential, 'OPTIONAL'),
     ('flattop', 'flat', 'flt'): (flattop, False),
     ('gaussian', 'gauss', 'gss'): (gaussian, True),
@@ -2452,6 +2690,11 @@ def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
     `dpss` / ``('dpss', NW)``:
         First window of discrete prolate spheroidal sequence with standardized half
         bandwidth ``NW`` and "approximate" norm.
+    `dpss_cola` / ``('dpss_cola', hop)`` / ``('dpss_cola', hop, NW, sqrt)``:
+        COLA-compatible window built from a DPSS kernel (half bandwidth ``NW``)
+        convolved with a length-``hop`` rectangular pulse, normalized so overlap-add
+        at hop ``hop`` sums to 1. If ``sqrt`` is ``True`` the square root is returned
+        (Princen-Bradley condition).
     `exponential` / ``'exponential'`` / ``('exponential', center, tau)``:
         Exponential / Poisson window centered at ``center`` (default: ``None``) with
         deacy ``tau`` (default: ``1``) (aliases: ``'poisson'``)
@@ -2579,6 +2822,13 @@ def get_window(window, Nx, fftbins=True, *, xp=None, device=None):
         if len(args) != 1:
             raise ValueError(f"Window {win_name} must have one parameter but {window=}")
         return dpss(Nx, args[0], Kmax=None, sym=sym, xp=xp, device=device)
+    if func is dpss_cola:
+        if not 1 <= len(args) <= 3:
+            raise ValueError(
+                f"Window {win_name} must have between 1 and 3 parameters "
+                f"but {window=}"
+            )
+        return dpss_cola(Nx, *args, sym=sym, xp=xp, device=device)
     if func is general_cosine:
         if not (xp is None and device is None):
             raise ValueError("'general_cosine' does not accept the parameters xp " +


### PR DESCRIPTION
#### What does this implement/fix?

Adds a new window function `scipy.signal.windows.dpss_cola`, a DPSS-based window satisfying exact constant-overlap-add (COLA) at an arbitrary hop size.

Motivation: classical COLA windows (Hann, Hamming, Blackman) only satisfy COLA at a handful of hop sizes that divide `M`. Many real-world STFT pipelines use hops dictated by external constraints, such as codec framing (Opus uses 12.5% overlap), hardware buffers, latency targets. Currently there is no classical window that is exactly COLA at these gaps. `dpss_cola` fills this roll, it provides a COLA window at any admissible hop, and is competitive with the classical windows on peak and far-field sidelobe levels at every hop, and at moderate-to-high overlap (`hop <= M/4`) provides unmatched side lobe suppression.

Construction: a zeroth-order DPSS (Slepian) kernel of length-`M-hop+1` is convolved with a length-`hop` boxcar. The boxcar's DTFT has exact zeros at the COLA frequencies `2πℓ/hop`, so the product vanishes there by construction. The convolution is computed in O(n) time via `cumsum`. With a typical `dpss` window, no default `NW` is provided due to there not being an "optimal" value to select, as it depends on the design constraints. Here, because the first side lobe is determined by the box car, we can provide a sensible default, which is `NW=(M-hop+1)/hop`, which we also cap at 16 to keep the DPSS window well conditioned at large windows. 

#### Additional information

- No API changes to existing windows.

Here is a small snippet demonstrating it's properties:

```python
import numpy as np
from scipy.signal import windows, check_COLA

M, nfft = 720, 32768
f = np.fft.rfftfreq(nfft)

print(
    f"{'overlap':<8} {'window':<16}{'PSL':>11}{'ISL':>11}{'PSL>.05':>11}{'PSL>.25':>11}"
)
for label, hop in [
    ("90%", M // 10),
    ("87.5%", M // 8),
    ("80%", M // 5),
    ("75%", M // 4),
    ("66.6%", M // 3),
    ("50%", M // 2),
]:
    candidates = [
        ("Hann", windows.hann(M, sym=False)),
        ("Hamming", windows.hamming(M, sym=False)),
        ("Blackman-Harris", windows.blackmanharris(M, sym=False)),
        ("DPSS-COLA sym=True", windows.dpss_cola(M, hop=hop, sym=True)),
        ("DPSS-COLA sym=False", windows.dpss_cola(M, hop=hop, sym=False)),
    ]
    rows = []
    for name, w in candidates:
        if not check_COLA(w, M, M - hop):
            continue
        P = np.abs(np.fft.rfft(w, nfft)) ** 2
        r = 10 * np.log10(np.maximum(P, 1e-30) / P.max())
        edge = np.argmax(np.diff(r) > 0) + 1
        psl = r[edge:].max()
        isl = 10 * np.log10(P[edge:].sum() / P[:edge].sum())
        rows.append((name, psl, isl, r[f >= 0.05].max(), r[f >= 0.25].max()))

    if not rows:
        continue

    best = [min(row[i] for row in rows) for i in range(1, 5)]

    def fmt(val, is_best):
        s = f"{val:.2f}"
        s = f"[{s}]" if is_best else f" {s} "
        return f"{s:>11}"

    for name, psl, isl, p05, p25 in rows:
        vals = (psl, isl, p05, p25)
        cells = "".join(fmt(v, v == best[i]) for i, v in enumerate(vals))
        print(f"{label:<8} {name:<20}{cells}")
    print()

```

```
overlap  window                  PSL        ISL    PSL>.05    PSL>.25
90%      Hann                    -31.47     -32.95    -103.67    -145.61 
90%      Hamming                 -42.68     -34.43     -57.77     -70.74 
90%      Blackman-Harris         -92.02     -89.24    -120.27    -129.77 
90%      DPSS-COLA sym=True    [-251.46]  [-249.11]  [-269.89]  [-295.76]
90%      DPSS-COLA sym=False    -251.07    -248.73    -269.60    -295.41 

87.5%    Hann                    -31.47     -32.95    -103.67    -145.61 
87.5%    Hamming                 -42.68     -34.43     -57.77     -70.74 
87.5%    Blackman-Harris         -92.02     -89.24    -120.27    -129.77 
87.5%    DPSS-COLA sym=True    [-196.80]  [-194.93]  [-219.08]  [-245.22]
87.5%    DPSS-COLA sym=False    -196.50    -194.63    -218.86    -244.34 

80%      Hann                    -31.47     -32.95    -103.67    -145.61 
80%      Hamming                 -42.68     -34.43     -57.77     -70.74 
80%      Blackman-Harris         -92.02     -89.24    -120.27    -129.77 
80%      DPSS-COLA sym=True    [-114.79]  [-114.02]  [-145.39]   -171.29 
80%      DPSS-COLA sym=False    -114.60    -113.83    -145.16   [-171.37]

75%      Hann                    -31.47     -32.95    -103.67    -145.61 
75%      Hamming                 -42.68     -34.43     -57.77     -70.74 
75%      Blackman-Harris        [-92.02]   [-89.24]   -120.27    -129.77 
75%      DPSS-COLA sym=True      -87.58     -87.23   [-122.26]  [-147.84]
75%      DPSS-COLA sym=False     -87.42     -87.08    -122.19    -147.49 

66.6%    Hann                    -31.47     -32.95   [-103.67]  [-145.61]
66.6%    Hamming                 -42.68     -34.43     -57.77     -70.74 
66.6%    DPSS-COLA sym=True     [-60.79]   [-60.63]   -101.62    -126.02 
66.6%    DPSS-COLA sym=False     -60.67     -60.52    -101.09    -127.42 

50%      Hann                    -31.47     -32.95   [-103.67]  [-145.61]
50%      Hamming                [-42.68]    -34.43     -57.77     -70.74 
50%      DPSS-COLA sym=True      -36.77    [-35.69]    -79.87    -107.02 
50%      DPSS-COLA sym=False     -36.67     -35.64     -79.81    -105.62
```

#### AI Generation Disclosure

The core algorithm, which is the DPSS convolved with boxcar construction, and the `cumsum` of the flipepd difference implementation, was developed personally by me for use in my research without AI assistance. However, I did use Claude Code (Anthropic) to help with the construction of this PR. It was used to:

- Draft and refine the docstring prose (the comparative discussion against Hann/Hamming/Blackman, the trade-off caveats).
- Author the test cases in `test_windows.py`.

All AI-generated text and tests were reviewed, edited, and validated against the implementation by the author before inclusion.
