### PR TITLE
BUG: sparse: fix coo_matrix.sum(dtype=) with duplicate entries

### DIFF
--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1480,11 +1480,15 @@ class _spbase(SparseABC):
         res_dtype = get_sum_dtype(self.dtype)
 
         if dtype is not None:
-            # Before casting to the requested dtype, canonicalize duplicates and zeros.
-            if hasattr(self, 'sum_duplicates'):
-                self.sum_duplicates()
-            temp = self.astype(dtype, copy=False).sum(axis=axis, dtype=None, out=out)
-            return temp.astype(dtype, copy=False)
+            # Cast to the requested dtype first so that duplicate accumulation
+            # uses the target dtype, matching numpy's cast-before-accumulate
+            # behaviour. Previously sum_duplicates used the original dtype,
+            # causing incorrect results for COO matrices with duplicate entries.
+            # See gh-24989.
+            temp = self.astype(dtype, copy=False)
+            if hasattr(temp, 'sum_duplicates'):
+                temp.sum_duplicates()
+            return temp.sum(axis=axis, dtype=None, out=out)
 
         # Note: all valid 1D axis values are canonically `None`.
         if axis is None:

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -1405,3 +1405,31 @@ def test_bool_set():
     A, D = A_orig.copy(), D_orig.copy()
     D[idxnp] = A[idxnp] = -88
     assert_equal(A.toarray(), D)
+
+
+def test_sum_dtype_with_duplicates():
+    # gh-24989: coo_matrix.sum(dtype=) should cast before accumulating
+    # duplicates, matching numpy's cast-before-accumulate behaviour.
+    from scipy.sparse import coo_matrix
+
+    row = np.array([0, 0, 1])
+    col = np.array([0, 0, 1])
+    data = np.array([0.6, 0.6, 1.2])
+    m = coo_matrix((data, (row, col)), shape=(3, 2))
+
+    # Without dtype: floating-point sum, 0.6+0.6=1.2 at [0,0]
+    result_float = m.sum(axis=0)
+    assert_allclose(result_float, [[1.2, 1.2]])
+
+    # With dtype=int: numpy casts 0.6->0 first, so 0+0=0 at [0,0]
+    result_int = m.sum(axis=0, dtype=int)
+    expected = np.array([[0, 1]])
+    assert_equal(result_int, expected), (
+        f"Expected {expected}, got {result_int}. "
+        "dtype should be cast before accumulating duplicate entries."
+    )
+
+    # Same check for coo_array
+    m_arr = coo_array((data, (row, col)), shape=(3, 2))
+    result_arr = m_arr.sum(axis=0, dtype=int)
+    assert_equal(np.asarray(result_arr), np.array([[0, 1]]))


### PR DESCRIPTION
## Summary

Fixes #24989.

`coo_matrix.sum(axis=..., dtype=int)` returned incorrect results when
the matrix had duplicate entries, because `sum_duplicates()` (which
accumulates them) was called before casting to the requested `dtype`.
This is the same cast-after bug that was fixed for CSR/CSC in gh-23768 /
PR #24496, but the `_spbase.sum()` base-class path (used by COO) still
had the old ordering.

**Minimal reproducer (before the fix):**
```python
from scipy.sparse import coo_matrix
import numpy as np

row = np.array([0, 0, 1])
col = np.array([0, 0, 1])
data = np.array([0.6, 0.6, 1.2])   # (0,0) appears twice
m = coo_matrix((data, (row, col)), shape=(3, 2))

# Expected: numpy int-casts 0.6→0 first, so 0+0=0 at (0,0) → [[0, 1]]
print(m.sum(axis=0, dtype=int))     # was [[1, 1]], now [[0, 1]]
```

**Root cause and fix:**

In `scipy/sparse/_base.py :: _spbase.sum()`, when `dtype is not None`:
```python
# OLD (cast-after - bug):
if hasattr(self, 'sum_duplicates'):
    self.sum_duplicates()          # accumulates with float64
temp = self.astype(dtype).sum()    # then casts to int → wrong

# NEW (cast-before - fix):
temp = self.astype(dtype, copy=False)
if hasattr(temp, 'sum_duplicates'):
    temp.sum_duplicates()          # accumulates with int  → correct
return temp.sum(axis=axis, dtype=None, out=out)
```

CSR/CSC have their own `sum()` override (PR #24496) that already does
cast-first; COO falls through to the base class which still had the
old order.

## Changes

- `scipy/sparse/_base.py`: swap `astype` and `sum_duplicates` call order
- `scipy/sparse/tests/test_coo.py`: add regression test `test_sum_dtype_with_duplicates`

## Test plan

- [x] New test `test_sum_dtype_with_duplicates` directly reproduces the
  issue for both `coo_matrix` and `coo_array`
- [x] Existing `test_sum_duplicates` and `test_sum` continue to pass