### PR TITLE
DOC: update old B-spline source

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -599,8 +599,8 @@ class BSpline:
 
     References
     ----------
-    .. [1] Tom Lyche and Knut Morken, Spline methods,
-        http://www.uio.no/studier/emner/matnat/ifi/INF-MAT5340/v05/undervisningsmateriale/
+    .. [1] Michael Floater, An introduction to spline theory, 2025,
+        https://www.uio.no/studier/emner/matnat/math/MAT4170/v25/undervisningsmateriale/spline_notes.pdf
     .. [2] Carl de Boor, A practical guide to splines, Springer, 2001.
 
     """
@@ -1104,7 +1104,8 @@ class BSpline:
 
         References
         ----------
-        .. [1] Tom Lyche and Knut Morken, Spline Methods, 2005, Section 3.1.2
+        .. [1] Michael Floater, An introduction to spline theory, 2025, Section 4.1
+            https://www.uio.no/studier/emner/matnat/math/MAT4170/v25/undervisningsmateriale/spline_notes.pdf
 
         """
         xp = array_namespace(pp.x, pp.c)

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -480,7 +480,7 @@ def disc(t, k):
            :doi:`10.1016/0146-664X(82)90043-0`
 
     .. [2] Tom Lyche and Knut Morken, Spline methods,
-        http://www.uio.no/studier/emner/matnat/ifi/INF-MAT5340/v05/undervisningsmateriale/
+        https://web.archive.org/web/20221205112612/https://www.uio.no/studier/emner/matnat/ifi/nedlagte-emner/INF-MAT5340/v05/undervisningsmateriale/hele.pdf
 
     """
     n = t.shape[0]


### PR DESCRIPTION
[docs only]

#### Reference issue
Closes #25066 

#### What does this implement/fix?
The current source by Tom Lyche and Knut Mørken is an old course note from the University of Oslo, however it is not easily available anymore. Switched to the newer UiO course notes for the general B-spline sources, and switched to an archived version of the old source for the discontinuity jump of derivatives.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
No AI tools used
