### PR TITLE
BUG: signal.sawtooth: fix NaN output for width=1 due to floating-point modulo

### DIFF
--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -71,9 +71,17 @@ def sawtooth(t, width=1.):
     y = xpx.at(y, mask2).set(tmod[mask2]/(xp.pi*w[mask2]) - 1)
 
     # on the interval width*2*pi to 2*pi function is (pi*(w+1)-tmod) / (pi*(1-w))
+    # Avoid division by zero when w is extremely close to 0 or 1:
+    # when w ≈ 1, use the rising ramp formula for the remaining points
+    # when w ≈ 0, use the falling ramp formula for the remaining points
     mask3 = ~(mask1 | mask2)
-    y = xpx.at(y, mask3).set(
-        (xp.pi*(w[mask3] + 1) - tmod[mask3])/(xp.pi*(1 - w[mask3]))
+    mask_w1 = mask3 & (xp.abs(w - 1) < 1e-15)
+    mask_w0 = mask3 & (xp.abs(w) < 1e-15)
+    y = xpx.at(y, mask_w1).set(tmod[mask_w1]/xp.pi - 1)
+    y = xpx.at(y, mask_w0).set(1 - tmod[mask_w0]/xp.pi)
+    mask3_rest = mask3 & ~(mask_w1 | mask_w0)
+    y = xpx.at(y, mask3_rest).set(
+        (xp.pi*(w[mask3_rest] + 1) - tmod[mask3_rest])/(xp.pi*(1 - w[mask3_rest]))
     )
     return y
 

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -420,6 +420,23 @@ class TestSawtoothWaveform:
         xp_assert_close(y, xp.flip(y))
         xp_assert_close(sawtooth(-t, 0.)[1:-1], sawtooth(t)[1:-1])
 
+    def test_width_one_no_nan(self, xp):
+        # gh-22940: floating-point modulo can produce exactly 2*pi
+        # (e.g. for t = -1e-16), causing width=1 to produce NaN via
+        # division by (1 - width) = 0.
+        t = xp.asarray(-1e-16, dtype=xp.float64)
+        y = sawtooth(t, width=xp.asarray(1.0, dtype=xp.float64))
+        assert not xp.any(xp.isnan(y)), "sawtooth(-1e-16, width=1) should not be NaN"
+        # Also test with equal spacing
+        t = xp.linspace(-xp.pi, xp.pi, 50, dtype=xp.float64)
+        y = sawtooth(t, width=xp.asarray(1.0, dtype=xp.float64))
+        assert not xp.any(xp.isnan(y)), "sawtooth with width=1 should never produce NaN"
+        # Test with array width that includes 1.0
+        w_arr = xp.asarray([1.0, 0.5, 0.0], dtype=xp.float64)
+        t_arr = xp.asarray([1.0, 2.0, 3.0], dtype=xp.float64)
+        y = sawtooth(t_arr, width=w_arr)
+        assert not xp.any(xp.isnan(y)), "sawtooth with array width containing 1.0 should not produce NaN"
+
 
 @make_xp_test_case(square)
 class TestSquareWaveform:


### PR DESCRIPTION
#### Reference issue
Closes gh-22940

#### What does this implement/fix?
`sawtooth(t, width=1.0)` produces NaN when `t` is a very small
negative value (e.g. `-1e-16`). The IEEE 754 modulo
`(-1e-16) % (2*pi)` rounds to exactly `2*pi` because `1e-16` is
below half the ulp of `2*pi`. This routes to the falling-branch
formula which divides by `(1 - width) = 0`, producing NaN.

The fix detects `width ≈ 1` (and symmetrically `width ≈ 0`) before
the general formula and applies the correct single-ramp formula.
Tolerance of `1e-15` is safe — well below any meaningful width difference.

#### Additional information
- Added test `test_width_one_no_nan` in `test_waveforms.py`
- Verified locally that `sawtooth(-1e-16, width=1.0)` returns a finite
  value instead of NaN
- Backward compatible, minimal change (10 lines)

#### AI Generation Disclosure
I used Claude to help draft this PR description and the initial fix.
The bug was manually reproduced, the fix was reviewed and validated. 