### PR TITLE
ENH: interpolate.BPoly/PPoly set up CuPy delegation

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1,4 +1,5 @@
 __all__ = ['interp1d', 'interp2d', 'lagrange', 'PPoly', 'BPoly', 'NdPPoly']
+import functools
 import os
 from math import prod
 from types import GenericAlias
@@ -11,7 +12,10 @@ import scipy.special as spec
 from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
-from scipy._lib._array_api import array_namespace, xp_capabilities
+from scipy._lib._array_api import (
+    array_namespace, xp_capabilities, scipy_namespace_for, is_numpy,
+    is_array_api_obj
+)
 
 from . import _fitpack_py
 from ._polyint import _Interpolator1D
@@ -603,17 +607,15 @@ class interp1d(_Interpolator1D):
 
 
 class _PPolyBase:
-    """Base class for piecewise polynomials."""
-    __slots__ = ('_c', '_x', 'extrapolate', 'axis', '_asarray')
+    """Base class for piecewise polynomials -- NumPy backend."""
+    __slots__ = ('c', 'x', 'extrapolate', 'axis')
 
     # generic type compatibility with scipy-stubs
     __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, c, x, extrapolate=None, axis=0):
-        self._asarray  = array_namespace(c, x).asarray
-
-        self._c = np.asarray(c)
-        self._x = np.ascontiguousarray(x, dtype=np.float64)
+        self.c = np.asarray(c)
+        self.x = np.ascontiguousarray(x, dtype=np.float64)
 
         if extrapolate is None:
             extrapolate = True
@@ -621,12 +623,12 @@ class _PPolyBase:
             extrapolate = bool(extrapolate)
         self.extrapolate = extrapolate
 
-        if self._c.ndim < 2:
+        if self.c.ndim < 2:
             raise ValueError("Coefficients array must be at least "
                              "2-dimensional.")
 
-        if not (0 <= axis < self._c.ndim - 1):
-            raise ValueError(f"axis={axis} must be between 0 and {self._c.ndim-1}")
+        if not (0 <= axis < self.c.ndim - 1):
+            raise ValueError(f"axis={axis} must be between 0 and {self.c.ndim-1}")
 
         self.axis = axis
         if axis != 0:
@@ -636,67 +638,42 @@ class _PPolyBase:
             #                                               ^
             #                                              axis
             # So we roll two of them.
-            self._c = np.moveaxis(self._c, axis+1, 0)
-            self._c = np.moveaxis(self._c, axis+1, 0)
+            self.c = np.moveaxis(self.c, axis+1, 0)
+            self.c = np.moveaxis(self.c, axis+1, 0)
 
-        if self._x.ndim != 1:
+        if self.x.ndim != 1:
             raise ValueError("x must be 1-dimensional")
-        if self._x.size < 2:
+        if self.x.size < 2:
             raise ValueError("at least 2 breakpoints are needed")
-        if self._c.ndim < 2:
+        if self.c.ndim < 2:
             raise ValueError("c must have at least 2 dimensions")
-        if self._c.shape[0] == 0:
+        if self.c.shape[0] == 0:
             raise ValueError("polynomial must be at least of order 0")
-        if self._c.shape[1] != self._x.size-1:
+        if self.c.shape[1] != self.x.size-1:
             raise ValueError("number of coefficients != len(x)-1")
-        dx = np.diff(self._x)
+        dx = np.diff(self.x)
         if not (np.all(dx >= 0) or np.all(dx <= 0)):
             raise ValueError("`x` must be strictly increasing or decreasing.")
 
-        dtype = self._get_dtype(self._c.dtype)
-        self._c = np.ascontiguousarray(self._c, dtype=dtype)
+        dtype = self._get_dtype(self.c.dtype)
+        self.c = np.ascontiguousarray(self.c, dtype=dtype)
 
     def _get_dtype(self, dtype):
         if np.issubdtype(dtype, np.complexfloating) \
-               or np.issubdtype(self._c.dtype, np.complexfloating):
+               or np.issubdtype(self.c.dtype, np.complexfloating):
             return np.complex128
         else:
             return np.float64
 
-    @property
-    def x(self):
-        return self._asarray(self._x)
-
-    @x.setter
-    def x(self, xval):
-        self._x = np.asarray(xval)
-
-    @property
-    def c(self):
-        return self._asarray(self._c)
-
-    @c.setter
-    def c(self, cval):
-        self._c = np.asarray(cval)
-
     @classmethod
     def construct_fast(cls, c, x, extrapolate=None, axis=0):
-        """
-        Construct the piecewise polynomial without making checks.
-
-        Takes the same parameters as the constructor. Input arguments
-        ``c`` and ``x`` must be arrays of the correct shape and type. The
-        ``c`` array can only be of dtypes float and complex, and ``x``
-        array must have dtype float.
-        """
         self = object.__new__(cls)
-        self._c = np.asarray(c)
-        self._x = np.asarray(x)
+        self.c = np.asarray(c)
+        self.x = np.asarray(x)
         self.axis = axis
         if extrapolate is None:
             extrapolate = True
         self.extrapolate = extrapolate
-        self._asarray = array_namespace(c, x).asarray
         return self
 
     def _ensure_c_contiguous(self):
@@ -704,33 +681,12 @@ class _PPolyBase:
         c and x may be modified by the user. The Cython code expects
         that they are C contiguous.
         """
-        if not self._x.flags.c_contiguous:
-            self._x = self._x.copy()
-        if not self._c.flags.c_contiguous:
-            self._c = self._c.copy()
+        if not self.x.flags.c_contiguous:
+            self.x = self.x.copy()
+        if not self.c.flags.c_contiguous:
+            self.c = self.c.copy()
 
     def extend(self, c, x):
-        """
-        Add additional breakpoints and coefficients to the polynomial.
-
-        Parameters
-        ----------
-        c : ndarray, size (k, m, ...)
-            Additional coefficients for polynomials in intervals. Note that
-            the first additional interval will be formed using one of the
-            ``self.x`` end points.
-        x : ndarray, size (m,)
-            Additional breakpoints. Must be sorted in the same order as
-            ``self.x`` and either to the right or to the left of the current
-            breakpoints.
-
-        Notes
-        -----
-        This method is not thread safe and must not be executed concurrently
-        with other methods available in this class. Doing so may cause
-        unexpected errors or numerical output mismatches.
-        """
-
         c = np.asarray(c)
         x = np.asarray(x)
 
@@ -740,9 +696,9 @@ class _PPolyBase:
             raise ValueError("invalid dimensions for x")
         if x.shape[0] != c.shape[1]:
             raise ValueError(f"Shapes of x {x.shape} and c {c.shape} are incompatible")
-        if c.shape[2:] != self._c.shape[2:] or c.ndim != self._c.ndim:
+        if c.shape[2:] != self.c.shape[2:] or c.ndim != self.c.ndim:
             raise ValueError(
-                f"Shapes of c {c.shape} and self._c {self._c.shape} are incompatible"
+                f"Shapes of c {c.shape} and self.c {self.c.shape} are incompatible"
             )
 
         if c.size == 0:
@@ -752,14 +708,14 @@ class _PPolyBase:
         if not (np.all(dx >= 0) or np.all(dx <= 0)):
             raise ValueError("`x` is not sorted.")
 
-        if self._x[-1] >= self._x[0]:
+        if self.x[-1] >= self.x[0]:
             if not x[-1] >= x[0]:
                 raise ValueError("`x` is in the different order "
                                 "than `self.x`.")
 
-            if x[0] >= self._x[-1]:
+            if x[0] >= self.x[-1]:
                 action = 'append'
-            elif x[-1] <= self._x[0]:
+            elif x[-1] <= self.x[0]:
                 action = 'prepend'
             else:
                 raise ValueError("`x` is neither on the left or on the right "
@@ -769,9 +725,9 @@ class _PPolyBase:
                 raise ValueError("`x` is in the different order "
                                 "than `self.x`.")
 
-            if x[0] <= self._x[-1]:
+            if x[0] <= self.x[-1]:
                 action = 'append'
-            elif x[-1] >= self._x[0]:
+            elif x[-1] >= self.x[0]:
                 action = 'prepend'
             else:
                 raise ValueError("`x` is neither on the left or on the right "
@@ -779,51 +735,22 @@ class _PPolyBase:
 
         dtype = self._get_dtype(c.dtype)
 
-        k2 = max(c.shape[0], self._c.shape[0])
-        c2 = np.zeros((k2, self._c.shape[1] + c.shape[1]) + self._c.shape[2:],
+        k2 = max(c.shape[0], self.c.shape[0])
+        c2 = np.zeros((k2, self.c.shape[1] + c.shape[1]) + self.c.shape[2:],
                     dtype=dtype)
 
         if action == 'append':
-            c2[k2-self._c.shape[0]:, :self._c.shape[1]] = self._c
-            c2[k2-c.shape[0]:, self._c.shape[1]:] = c
-            self._x = np.r_[self._x, x]
+            c2[k2-self.c.shape[0]:, :self.c.shape[1]] = self.c
+            c2[k2-c.shape[0]:, self.c.shape[1]:] = c
+            self.x = np.r_[self.x, x]
         elif action == 'prepend':
-            c2[k2-self._c.shape[0]:, :c.shape[1]] = c
-            c2[k2-c.shape[0]:, c.shape[1]:] = self._c
-            self._x = np.r_[x, self._x]
+            c2[k2-self.c.shape[0]:, :c.shape[1]] = c
+            c2[k2-c.shape[0]:, c.shape[1]:] = self.c
+            self.x = np.r_[x, self.x]
 
-        self._c = c2
+        self.c = c2
 
     def __call__(self, x, nu=0, extrapolate=None):
-        """
-        Evaluate the piecewise polynomial or its derivative.
-
-        Parameters
-        ----------
-        x : array_like
-            Points to evaluate the interpolant at.
-        nu : int, optional
-            Order of derivative to evaluate. Must be non-negative.
-        extrapolate : {bool, 'periodic', None}, optional
-            If bool, determines whether to extrapolate to out-of-bounds points
-            based on first and last intervals, or to return NaNs.
-            If 'periodic', periodic extrapolation is used.
-            If None (default), use `self.extrapolate`.
-
-        Returns
-        -------
-        y : array_like
-            Interpolated values. Shape is determined by replacing
-            the interpolation axis in the original array with the shape of x.
-
-        Notes
-        -----
-        Derivatives are evaluated piecewise for each polynomial
-        segment, even if the polynomial is not differentiable at the
-        breakpoints. The polynomial intervals are considered half-open,
-        ``[a, b)``, except for the last interval which is closed
-        ``[a, b]``.
-        """
         if extrapolate is None:
             extrapolate = self.extrapolate
         x = np.asarray(x)
@@ -833,29 +760,544 @@ class _PPolyBase:
         # With periodic extrapolation we map x to the segment
         # [self.x[0], self.x[-1]].
         if extrapolate == 'periodic':
-            x = self._x[0] + (x - self._x[0]) % (self._x[-1] - self._x[0])
+            x = self.x[0] + (x - self.x[0]) % (self.x[-1] - self.x[0])
             extrapolate = False
 
-        out = np.empty((len(x), prod(self._c.shape[2:])), dtype=self._c.dtype)
+        out = np.empty((len(x), prod(self.c.shape[2:])), dtype=self.c.dtype)
         self._ensure_c_contiguous()
         self._evaluate(x, nu, extrapolate, out)
-        out = out.reshape(x_shape + self._c.shape[2:])
+        out = out.reshape(x_shape + self.c.shape[2:])
         if self.axis != 0:
             # transpose to move the calculated values to the interpolation axis
             l = list(range(out.ndim))
             l = l[x_ndim:x_ndim+self.axis] + l[:x_ndim] + l[x_ndim+self.axis:]
             out = out.transpose(l)
-        return self._asarray(out)
+        return out
+
+
+class _PPoly(_PPolyBase):
+    """NumPy backend for PPoly."""
+
+    def _evaluate(self, x, nu, extrapolate, out):
+        _ppoly.evaluate(self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
+                        self.x, x, nu, bool(extrapolate), out)
+
+    def derivative(self, nu=1):
+        if nu < 0:
+            return self.antiderivative(-nu)
+
+        # reduce order
+        if nu == 0:
+            c2 = self.c.copy()
+        else:
+            c2 = self.c[:-nu, :].copy()
+
+        if c2.shape[0] == 0:
+            # derivative of order 0 is zero
+            c2 = np.zeros((1,) + c2.shape[1:], dtype=c2.dtype)
+
+        # multiply by the correct rising factorials
+        factor = spec.poch(np.arange(c2.shape[0], 0, -1), nu)
+        c2 *= factor[(slice(None),) + (None,)*(c2.ndim-1)]
+
+        # construct a compatible polynomial
+        return self.construct_fast(c2, self.x, self.extrapolate, self.axis)
+
+    def antiderivative(self, nu=1):
+        """
+        Construct a new piecewise polynomial representing the antiderivative.
+
+        Antiderivative is also the indefinite integral of the function,
+        and derivative is its inverse operation.
+
+        Parameters
+        ----------
+        nu : int, optional
+            Order of antiderivative to evaluate. Default is 1, i.e., compute
+            the first integral. If negative, the derivative is returned.
+
+        Returns
+        -------
+        pp : PPoly
+            Piecewise polynomial of order k2 = k + n representing
+            the antiderivative of this polynomial.
+
+        Notes
+        -----
+        The antiderivative returned by this function is continuous and
+        continuously differentiable to order n-1, up to floating point
+        rounding error.
+
+        If antiderivative is computed and ``self.extrapolate='periodic'``,
+        it will be set to False for the returned instance. This is done because
+        the antiderivative is no longer periodic and its correct evaluation
+        outside of the initially given x interval is difficult.
+        """
+        if nu <= 0:
+            return self.derivative(-nu)
+
+        c = np.zeros((self.c.shape[0] + nu, self.c.shape[1]) + self.c.shape[2:],
+                     dtype=self.c.dtype)
+        c[:-nu] = self.c
+
+        # divide by the correct rising factorials
+        factor = spec.poch(np.arange(self.c.shape[0], 0, -1), nu)
+        c[:-nu] /= factor[(slice(None),) + (None,)*(c.ndim-1)]
+
+        # fix continuity of added degrees of freedom
+        self._ensure_c_contiguous()
+        _ppoly.fix_continuity(c.reshape(c.shape[0], c.shape[1], -1),
+                              self.x, nu - 1)
+
+        if self.extrapolate == 'periodic':
+            extrapolate = False
+        else:
+            extrapolate = self.extrapolate
+
+        # construct a compatible polynomial
+        return self.construct_fast(c, self.x, extrapolate, self.axis)
+
+    def integrate(self, a, b, extrapolate=None):
+        if extrapolate is None:
+            extrapolate = self.extrapolate
+
+        # Swap integration bounds if needed
+        sign = 1
+        if b < a:
+            a, b = b, a
+            sign = -1
+
+        range_int = np.empty((prod(self.c.shape[2:]),), dtype=self.c.dtype)
+        self._ensure_c_contiguous()
+
+        # Compute the integral.
+        if extrapolate == 'periodic':
+            # Split the integral into the part over period (can be several
+            # of them) and the remaining part.
+
+            xs, xe = self.x[0], self.x[-1]
+            period = xe - xs
+            interval = b - a
+            n_periods, left = divmod(interval, period)
+
+            if n_periods > 0:
+                _ppoly.integrate(
+                    self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
+                    self.x, xs, xe, False, out=range_int)
+                range_int *= n_periods
+            else:
+                range_int.fill(0)
+
+            # Map a to [xs, xe], b is always a + left.
+            a = xs + (a - xs) % period
+            b = a + left
+
+            # If b <= xe then we need to integrate over [a, b], otherwise
+            # over [a, xe] and from xs to what is remained.
+            remainder_int = np.empty_like(range_int)
+            if b <= xe:
+                _ppoly.integrate(
+                    self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
+                    self.x, a, b, False, out=remainder_int)
+                range_int += remainder_int
+            else:
+                _ppoly.integrate(
+                    self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
+                    self.x, a, xe, False, out=remainder_int)
+                range_int += remainder_int
+
+                _ppoly.integrate(
+                    self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
+                    self.x, xs, xs + left + a - xe, False, out=remainder_int)
+                range_int += remainder_int
+        else:
+            _ppoly.integrate(
+                self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
+                self.x, a, b, bool(extrapolate), out=range_int)
+
+        # Return
+        range_int *= sign
+        return range_int.reshape(self.c.shape[2:])
+
+    def solve(self, y=0., discontinuity=True, extrapolate=None):
+
+        if extrapolate is None:
+            extrapolate = self.extrapolate
+
+        self._ensure_c_contiguous()
+
+        if np.issubdtype(self.c.dtype, np.complexfloating):
+            raise ValueError("Root finding is only for "
+                             "real-valued polynomials")
+
+        y = float(y)
+        r = _ppoly.real_roots(self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
+                              self.x, y, bool(discontinuity),
+                              bool(extrapolate))
+        if self.c.ndim == 2:
+            return r[0]
+        else:
+            r2 = np.empty(prod(self.c.shape[2:]), dtype=object)
+            # this for-loop is equivalent to ``r2[...] = r``, but that's broken
+            # in NumPy 1.6.0
+            for ii, root in enumerate(r):
+                r2[ii] = root
+
+            return r2.reshape(self.c.shape[2:])
+
+    def roots(self, discontinuity=True, extrapolate=None):
+        return self.solve(0, discontinuity, extrapolate)
+
+    @classmethod
+    def from_spline(cls, tck, extrapolate=None):
+        t, c, k = tck
+
+        cvals = np.empty((k + 1, len(t)-1), dtype=c.dtype)
+        for m in range(k, -1, -1):
+            y = _fitpack_py.splev(t[:-1], (t, c, k), der=m)
+            cvals[k - m, :] = y / spec.gamma(m+1)
+
+        return cls.construct_fast(cvals, t, extrapolate)
+
+    @classmethod
+    def from_bernstein_basis(cls, bp, extrapolate=None):
+        dx = np.diff(bp.x)
+        k = bp.c.shape[0] - 1  # polynomial order
+
+        rest = (None,)*(bp.c.ndim-2)
+
+        c = np.zeros_like(bp.c)
+        for a in range(k+1):
+            factor = (-1)**a * comb(k, a) * bp.c[a]
+            for s in range(a, k+1):
+                val = comb(k-a, s-a) * (-1)**s
+                c[k-s] += factor * val / dx[(slice(None),)+rest]**s
+
+        if extrapolate is None:
+            extrapolate = bp.extrapolate
+
+        return cls.construct_fast(c, bp.x, extrapolate, bp.axis)
+
+
+class _BPoly(_PPolyBase):
+    """NumPy backend for BPoly."""
+
+    def _evaluate(self, x, nu, extrapolate, out):
+        _ppoly.evaluate_bernstein(
+            self.c.reshape(self.c.shape[0], self.c.shape[1], -1),
+            self.x, x, nu, bool(extrapolate), out)
+
+    def derivative(self, nu=1):
+        if nu < 0:
+            return self.antiderivative(-nu)
+
+        if nu > 1:
+            bp = self
+            for k in range(nu):
+                bp = bp.derivative()
+            return bp
+
+        # reduce order
+        if nu == 0:
+            c2 = self.c.copy()
+        else:
+            # For a polynomial
+            #    B(x) = \sum_{a=0}^{k} c_a b_{a, k}(x),
+            # we use the fact that
+            #   b'_{a, k} = k ( b_{a-1, k-1} - b_{a, k-1} ),
+            # which leads to
+            #   B'(x) = \sum_{a=0}^{k-1} (c_{a+1} - c_a) b_{a, k-1}
+            #
+            # finally, for an interval [y, y + dy] with dy != 1,
+            # we need to correct for an extra power of dy
+
+            rest = (None,)*(self.c.ndim-2)
+
+            k = self.c.shape[0] - 1
+            dx = np.diff(self.x)[(None, slice(None))+rest]
+            c2 = k * np.diff(self.c, axis=0) / dx
+
+        if c2.shape[0] == 0:
+            # derivative of order 0 is zero
+            c2 = np.zeros((1,) + c2.shape[1:], dtype=c2.dtype)
+
+        # construct a compatible polynomial
+        return self.construct_fast(c2, self.x, self.extrapolate, self.axis)
+
+    def antiderivative(self, nu=1):
+        if nu <= 0:
+            return self.derivative(-nu)
+
+        if nu > 1:
+            bp = self
+            for k in range(nu):
+                bp = bp.antiderivative()
+            return bp
+
+        # Construct the indefinite integrals on individual intervals
+        c, x = self.c, self.x
+        k = c.shape[0]
+        c2 = np.zeros((k+1,) + c.shape[1:], dtype=c.dtype)
+
+        c2[1:, ...] = np.cumsum(c, axis=0) / k
+        delta = x[1:] - x[:-1]
+        c2 *= delta[(None, slice(None)) + (None,)*(c.ndim-2)]
+
+        # Now fix continuity: on the very first interval, take the integration
+        # constant to be zero; on an interval [x_j, x_{j+1}) with j>0,
+        # the integration constant is then equal to the jump of the `bp` at x_j.
+        # The latter is given by the coefficient of B_{n+1, n+1}
+        # *on the previous interval* (other B. polynomials are zero at the
+        # breakpoint). Finally, use the fact that BPs form a partition of unity.
+        c2[:, 1:] += np.cumsum(c2[k, :], axis=0)[:-1]
+
+        if self.extrapolate == 'periodic':
+            extrapolate = False
+        else:
+            extrapolate = self.extrapolate
+
+        return self.construct_fast(c2, self.x, extrapolate, axis=self.axis)
+
+    def integrate(self, a, b, extrapolate=None):
+        # XXX: can probably use instead the fact that
+        # \int_0^{1} B_{j, n}(x) \dx = 1/(n+1)
+        ib = self.antiderivative()
+        if extrapolate is None:
+            extrapolate = self.extrapolate
+
+        # ib.extrapolate shouldn't be 'periodic', it is converted to
+        # False for 'periodic. in antiderivative() call.
+        if extrapolate != 'periodic':
+            ib.extrapolate = extrapolate
+
+        if extrapolate == 'periodic':
+            # Split the integral into the part over period (can be several
+            # of them) and the remaining part.
+
+            # For simplicity and clarity convert to a <= b case.
+            if a <= b:
+                sign = 1
+            else:
+                a, b = b, a
+                sign = -1
+
+            xs, xe = self.x[0], self.x[-1]
+            period = xe - xs
+            interval = b - a
+            n_periods, left = divmod(interval, period)
+            res = n_periods * (ib(xe) - ib(xs))
+
+            # Map a and b to [xs, xe].
+            a = xs + (a - xs) % period
+            b = a + left
+
+            # If b <= xe then we need to integrate over [a, b], otherwise
+            # over [a, xe] and from xs to what is remained.
+            if b <= xe:
+                res += ib(b) - ib(a)
+            else:
+                res += ib(xe) - ib(a) + ib(xs + left + a - xe) - ib(xs)
+
+            return sign * res
+        else:
+            return ib(b) - ib(a)
+
+    def extend(self, c, x):
+        k = max(self.c.shape[0], c.shape[0])
+        self.c = self._raise_degree(self.c, k - self.c.shape[0])
+        c = self._raise_degree(c, k - c.shape[0])
+        _PPolyBase.extend(self, c, x)
+    extend.__doc__ = _PPolyBase.extend.__doc__
+
+    @classmethod
+    def from_power_basis(cls, pp, extrapolate=None):
+        dx = np.diff(pp.x)
+        k = pp.c.shape[0] - 1   # polynomial order
+
+        rest = (None,)*(pp.c.ndim-2)
+
+        c = np.zeros_like(pp.c)
+        for a in range(k+1):
+            factor = pp.c[a] / comb(k, k-a) * dx[(slice(None),) + rest]**(k-a)
+            for j in range(k-a, k+1):
+                c[j] += factor * comb(j, k-a)
+
+        if extrapolate is None:
+            extrapolate = pp.extrapolate
+
+        return cls.construct_fast(c, pp.x, extrapolate, pp.axis)
+
+    @classmethod
+    def from_derivatives(cls, xi, yi, orders=None, extrapolate=None):
+        xi = np.asarray(xi)
+        if len(xi) != len(yi):
+            raise ValueError("xi and yi need to have the same length")
+        if np.any(xi[1:] - xi[:1] <= 0):
+            raise ValueError("x coordinates are not in increasing order")
+
+        # number of intervals
+        m = len(xi) - 1
+
+        # global poly order is k-1, local orders are <=k and can vary
+        try:
+            k = max(len(yi[i]) + len(yi[i+1]) for i in range(m))
+        except TypeError as e:
+            raise ValueError(
+                "Using a 1-D array for y? Please .reshape(-1, 1)."
+            ) from e
+
+        if orders is None:
+            orders = [None] * m
+        else:
+            if isinstance(orders, int | np.integer):
+                orders = [orders] * m
+            k = max(k, max(orders))
+
+            if any(o <= 0 for o in orders):
+                raise ValueError("Orders must be positive.")
+
+        c = []
+        for i in range(m):
+            y1, y2 = yi[i], yi[i+1]
+            if orders[i] is None:
+                n1, n2 = len(y1), len(y2)
+            else:
+                n = orders[i]+1
+                n1 = min(n//2, len(y1))
+                n2 = min(n - n1, len(y2))
+                n1 = min(n - n2, len(y2))
+                if n1 + n2 != n:
+                    mesg = (
+                        f"Point {xi[i]} has {len(y1)} derivatives, point {xi[i+1]} has "
+                        f"{len(y2)} derivatives, but order {orders[i]} requested"
+                    )
+                    raise ValueError(mesg)
+
+                if not (n1 <= len(y1) and n2 <= len(y2)):
+                    raise ValueError("`order` input incompatible with"
+                                     " length y1 or y2.")
+
+            b = _BPoly._construct_from_derivatives(xi[i], xi[i+1],
+                                                  y1[:n1], y2[:n2])
+            if len(b) < k:
+                b = _BPoly._raise_degree(b, k - len(b))
+            c.append(b)
+
+        c = np.asarray(c)
+        return cls(c.swapaxes(0, 1), xi, extrapolate)
+
+    @staticmethod
+    def _construct_from_derivatives(xa, xb, ya, yb):
+        ya, yb = np.asarray(ya), np.asarray(yb)
+        if ya.shape[1:] != yb.shape[1:]:
+            raise ValueError(
+                f"Shapes of ya {ya.shape} and yb {yb.shape} are incompatible"
+            )
+
+        dta, dtb = ya.dtype, yb.dtype
+        if (np.issubdtype(dta, np.complexfloating) or
+               np.issubdtype(dtb, np.complexfloating)):
+            dt = np.complex128
+        else:
+            dt = np.float64
+
+        na, nb = len(ya), len(yb)
+        n = na + nb
+
+        c = np.empty((na+nb,) + ya.shape[1:], dtype=dt)
+
+        # compute coefficients of a polynomial degree na+nb-1
+        # walk left-to-right
+        for q in range(0, na):
+            c[q] = ya[q] / spec.poch(n - q, q) * (xb - xa)**q
+            for j in range(0, q):
+                c[q] -= (-1)**(j+q) * comb(q, j) * c[j]
+
+        # now walk right-to-left
+        for q in range(0, nb):
+            c[-q-1] = yb[q] / spec.poch(n - q, q) * (-1)**q * (xb - xa)**q
+            for j in range(0, q):
+                c[-q-1] -= (-1)**(j+1) * comb(q, j+1) * c[-q+j]
+
+        return c
+
+    @staticmethod
+    def _raise_degree(c, d):
+        if d == 0:
+            return c
+
+        k = c.shape[0] - 1
+        out = np.zeros((c.shape[0] + d,) + c.shape[1:], dtype=c.dtype)
+
+        for a in range(c.shape[0]):
+            f = c[a] * comb(k, a)
+            for j in range(d+1):
+                out[a+j] += f * comb(d, j) / comb(k+d, a+j)
+        return out
+
+
+@functools.lru_cache(16)
+def _get_xp_ppoly_cls(xp):
+    """Returns bspline class to delegate to for xp along with internal array namespace.
+
+    Parameters
+    ----------
+    xp : module
+
+    Returns
+    -------
+    cls : type
+        The ppoly class to delegate to for namespace `xp`.
+    namespace : module
+        The internal namespace that calculations are performed with
+        (may differ from `xp`, e.g. numpy delegation for torch on CPU).
+    """
+    # A device kwarg could be added to give device dependent delegation
+    # e.g., delegating torch to numpy on CPU and cupy on GPU.
+    if is_numpy(xp):
+        return _PPoly, xp
+    spx = scipy_namespace_for(xp)
+    cls = getattr(getattr(spx, "interpolate", None), "PPoly", None)
+    if cls is not None:
+        return cls, xp
+    return _PPoly, np
+
+
+def _get_xp_bpoly_cls(xp):
+    """Returns bpoly class to delegate to for xp along with internal array namespace.
+
+    Parameters
+    ----------
+    xp : module
+
+    Returns
+    -------
+    cls : type
+        The bpoly class to delegate to for namespace `xp`.
+    namespace : module
+        The internal namespace that calculations are performed with
+        (may differ from `xp`, e.g. numpy delegation for torch on CPU).
+    """
+    # A device kwarg could be added to give device dependent delegation
+    # e.g., delegating torch to numpy on CPU and cupy on GPU.
+    if is_numpy(xp):
+        return _BPoly, xp
+    spx = scipy_namespace_for(xp)
+    cls = getattr(getattr(spx, "interpolate", None), "BPoly", None)
+    if cls is not None:
+        return cls, xp
+    return _BPoly, np
 
 
 @xp_capabilities(
     cpu_only=True, jax_jit=False,
+    exceptions=["cupy"],
     skip_backends=[
         ("dask.array",
-         "https://github.com/data-apis/array-api-extra/issues/488")
+         "https://github.com/scipy/scipy/issues/24205")
     ]
 )
-class PPoly(_PPolyBase):
+class PPoly:
     """Piecewise polynomial in the power basis.
 
     The polynomial between ``x[i]`` and ``x[i + 1]`` is written in the
@@ -915,9 +1357,138 @@ class PPoly(_PPolyBase):
     larger than 20-30.
     """
 
-    def _evaluate(self, x, nu, extrapolate, out):
-        _ppoly.evaluate(self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
-                        self._x, x, nu, bool(extrapolate), out)
+    def __init__(self, c, x, extrapolate=None, axis=0):
+        xp = array_namespace(c, x)
+        xp_ppoly_cls, xp_internal = _get_xp_ppoly_cls(xp)
+        if not is_numpy(xp):
+            c, x = xp_internal.asarray(c), xp_internal.asarray(x)
+        self._delegate_to = xp_ppoly_cls(c, x, extrapolate=extrapolate, axis=axis)
+        self._xp = xp
+        self._xp_internal = xp_internal
+
+    @classmethod
+    def _construct_from_xp(cls, xp_ppoly, *, xp_external):
+        self = object.__new__(cls)
+        self._delegate_to = xp_ppoly
+        self._xp = xp_external
+        self._xp_internal = array_namespace(xp_ppoly.c)
+        return self
+
+    @classmethod
+    def construct_fast(cls, c, x, extrapolate=None, axis=0):
+        """
+        Construct the piecewise polynomial without making checks.
+
+        Takes the same parameters as the constructor. Input arguments
+        ``c`` and ``x`` must be arrays of the correct shape and type. The
+        ``c`` array can only be of dtypes float and complex, and ``x``
+        array must have dtype float.
+        """
+        xp = array_namespace(c, x)
+        xp_ppoly_cls, xp_internal = _get_xp_ppoly_cls(xp)
+        c, x = xp_internal.asarray(c), xp_internal.asarray(x)
+        return cls._construct_from_xp(
+            xp_ppoly_cls.construct_fast(
+                c, x, extrapolate=extrapolate, axis=axis
+            ),
+            xp_external=xp,
+        )
+
+    @property
+    def c(self):
+        return self._xp.asarray(self._delegate_to.c)
+
+    @c.setter
+    def c(self, c):
+        self._delegate_to.c = (
+            self._xp_internal.asarray(c) if is_numpy(self._xp_internal) else c
+        )
+
+    @property
+    def x(self):
+        return self._xp.asarray(self._delegate_to.x)
+
+    @x.setter
+    def x(self, x):
+        self._delegate_to.x = (
+            self._xp_internal.asarray(x) if is_numpy(self._xp_internal) else x
+        )
+
+    @property
+    def extrapolate(self):
+        return self._delegate_to.extrapolate
+
+    @extrapolate.setter
+    def extrapolate(self, extrapolate):
+        self._delegate_to.extrapolate = extrapolate
+
+    @property
+    def axis(self):
+        return self._delegate_to.axis
+
+    @axis.setter
+    def axis(self, axis):
+        self._delegate_to.axis = axis
+
+    def extend(self, c, x):
+        """
+        Add additional breakpoints and coefficients to the polynomial.
+
+        Parameters
+        ----------
+        c : ndarray, size (k, m, ...)
+            Additional coefficients for polynomials in intervals. Note that
+            the first additional interval will be formed using one of the
+            ``self.x`` end points.
+        x : ndarray, size (m,)
+            Additional breakpoints. Must be sorted in the same order as
+            ``self.x`` and either to the right or to the left of the current
+            breakpoints.
+
+        Notes
+        -----
+        This method is not thread safe and must not be executed concurrently
+        with other methods available in this class. Doing so may cause
+        unexpected errors or numerical output mismatches.
+        """
+        c, x = self._xp_internal.asarray(c), self._xp_internal.asarray(x)
+        self._delegate_to.extend(c, x)
+
+    def __call__(self, x, nu=0, extrapolate=None):
+        """
+        Evaluate the piecewise polynomial or its derivative.
+
+        Parameters
+        ----------
+        x : array_like
+            Points to evaluate the interpolant at.
+        nu : int, optional
+            Order of derivative to evaluate. Must be non-negative.
+        extrapolate : {bool, 'periodic', None}, optional
+            If bool, determines whether to extrapolate to out-of-bounds points
+            based on first and last intervals, or to return NaNs.
+            If 'periodic', periodic extrapolation is used.
+            If None (default), use `self.extrapolate`.
+
+        Returns
+        -------
+        y : array_like
+            Interpolated values. Shape is determined by replacing
+            the interpolation axis in the original array with the shape of x.
+
+        Notes
+        -----
+        Derivatives are evaluated piecewise for each polynomial
+        segment, even if the polynomial is not differentiable at the
+        breakpoints. The polynomial intervals are considered half-open,
+        ``[a, b)``, except for the last interval which is closed
+        ``[a, b]``.
+        """
+        return self._xp.asarray(
+            self._delegate_to(
+                self._xp_internal.asarray(x), nu=nu, extrapolate=extrapolate
+            )
+        )
 
     def derivative(self, nu=1):
         """
@@ -943,26 +1514,10 @@ class PPoly(_PPolyBase):
         ``[a, b)``, except for the last interval which is closed
         ``[a, b]``.
         """
-        if nu < 0:
-            return self.antiderivative(-nu)
-
-        # reduce order
-        if nu == 0:
-            c2 = self._c.copy()
-        else:
-            c2 = self._c[:-nu, :].copy()
-
-        if c2.shape[0] == 0:
-            # derivative of order 0 is zero
-            c2 = np.zeros((1,) + c2.shape[1:], dtype=c2.dtype)
-
-        # multiply by the correct rising factorials
-        factor = spec.poch(np.arange(c2.shape[0], 0, -1), nu)
-        c2 *= factor[(slice(None),) + (None,)*(c2.ndim-1)]
-
-        # construct a compatible polynomial
-        c2 = self._asarray(c2)
-        return self.construct_fast(c2, self.x, self.extrapolate, self.axis)
+        return self._construct_from_xp(
+            self._delegate_to.derivative(nu=nu),
+            xp_external=self._xp,
+        )
 
     def antiderivative(self, nu=1):
         """
@@ -994,30 +1549,10 @@ class PPoly(_PPolyBase):
         the antiderivative is no longer periodic and its correct evaluation
         outside of the initially given x interval is difficult.
         """
-        if nu <= 0:
-            return self.derivative(-nu)
-
-        c = np.zeros((self._c.shape[0] + nu, self._c.shape[1]) + self._c.shape[2:],
-                     dtype=self._c.dtype)
-        c[:-nu] = self._c
-
-        # divide by the correct rising factorials
-        factor = spec.poch(np.arange(self._c.shape[0], 0, -1), nu)
-        c[:-nu] /= factor[(slice(None),) + (None,)*(c.ndim-1)]
-
-        # fix continuity of added degrees of freedom
-        self._ensure_c_contiguous()
-        _ppoly.fix_continuity(c.reshape(c.shape[0], c.shape[1], -1),
-                              self._x, nu - 1)
-
-        if self.extrapolate == 'periodic':
-            extrapolate = False
-        else:
-            extrapolate = self.extrapolate
-
-        # construct a compatible polynomial
-        c = self._asarray(c)
-        return self.construct_fast(c, self.x, extrapolate, self.axis)
+        return self._construct_from_xp(
+            self._delegate_to.antiderivative(nu=nu),
+            xp_external=self._xp,
+        )
 
     def integrate(self, a, b, extrapolate=None):
         """
@@ -1040,68 +1575,11 @@ class PPoly(_PPolyBase):
         ig : array_like
             Definite integral of the piecewise polynomial over [a, b]
         """
-        if extrapolate is None:
-            extrapolate = self.extrapolate
+        return self._xp.asarray(
+            self._delegate_to.integrate(a, b, extrapolate=extrapolate)
+        )
 
-        # Swap integration bounds if needed
-        sign = 1
-        if b < a:
-            a, b = b, a
-            sign = -1
-
-        range_int = np.empty((prod(self._c.shape[2:]),), dtype=self._c.dtype)
-        self._ensure_c_contiguous()
-
-        # Compute the integral.
-        if extrapolate == 'periodic':
-            # Split the integral into the part over period (can be several
-            # of them) and the remaining part.
-
-            xs, xe = self._x[0], self._x[-1]
-            period = xe - xs
-            interval = b - a
-            n_periods, left = divmod(interval, period)
-
-            if n_periods > 0:
-                _ppoly.integrate(
-                    self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
-                    self._x, xs, xe, False, out=range_int)
-                range_int *= n_periods
-            else:
-                range_int.fill(0)
-
-            # Map a to [xs, xe], b is always a + left.
-            a = xs + (a - xs) % period
-            b = a + left
-
-            # If b <= xe then we need to integrate over [a, b], otherwise
-            # over [a, xe] and from xs to what is remained.
-            remainder_int = np.empty_like(range_int)
-            if b <= xe:
-                _ppoly.integrate(
-                    self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
-                    self._x, a, b, False, out=remainder_int)
-                range_int += remainder_int
-            else:
-                _ppoly.integrate(
-                    self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
-                    self._x, a, xe, False, out=remainder_int)
-                range_int += remainder_int
-
-                _ppoly.integrate(
-                    self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
-                    self._x, xs, xs + left + a - xe, False, out=remainder_int)
-                range_int += remainder_int
-        else:
-            _ppoly.integrate(
-                self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
-                self._x, a, b, bool(extrapolate), out=range_int)
-
-        # Return
-        range_int *= sign
-        return self._asarray(range_int.reshape(self._c.shape[2:]))
-
-    def solve(self, y=0., discontinuity=True, extrapolate=None):
+    def solve(self, y=0, discontinuity=True, extrapolate=None):
         """
         Find real solutions of the equation ``pp(x) == y``.
 
@@ -1150,29 +1628,11 @@ class PPoly(_PPolyBase):
         >>> pp.solve()
         array([-1.,  1.])
         """
-        if extrapolate is None:
-            extrapolate = self.extrapolate
-
-        self._ensure_c_contiguous()
-
-        if np.issubdtype(self._c.dtype, np.complexfloating):
-            raise ValueError("Root finding is only for "
-                             "real-valued polynomials")
-
-        y = float(y)
-        r = _ppoly.real_roots(self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
-                              self._x, y, bool(discontinuity),
-                              bool(extrapolate))
-        if self._c.ndim == 2:
-            return r[0]
-        else:
-            r2 = np.empty(prod(self._c.shape[2:]), dtype=object)
-            # this for-loop is equivalent to ``r2[...] = r``, but that's broken
-            # in NumPy 1.6.0
-            for ii, root in enumerate(r):
-                r2[ii] = root
-
-            return r2.reshape(self._c.shape[2:])
+        return self._xp.asarray(
+            self._delegate_to.solve(
+                y=y, discontinuity=discontinuity, extrapolate=extrapolate
+            )
+        )
 
     def roots(self, discontinuity=True, extrapolate=None):
         """
@@ -1271,20 +1731,17 @@ class PPoly(_PPolyBase):
 
         """
         if isinstance(tck, BSpline):
-            t, c, k = np.asarray(tck.t), np.asarray(tck.c), tck.k
-            _asarray = tck._xp.asarray
+            t, c, k = tck.tck
+            xp = tck._xp
             if extrapolate is None:
                 extrapolate = tck.extrapolate
         else:
             t, c, k = tck
-            _asarray = np.asarray
-
-        cvals = np.empty((k + 1, len(t)-1), dtype=c.dtype)
-        for m in range(k, -1, -1):
-            y = _fitpack_py.splev(t[:-1], (t, c, k), der=m)
-            cvals[k - m, :] = y / spec.gamma(m+1)
-
-        return cls.construct_fast(_asarray(cvals), _asarray(t), extrapolate)
+            xp = array_namespace(t, c)
+        xp_cls, xp_internal = _get_xp_ppoly_cls(xp)
+        t, c = xp_internal.asarray(t), xp_internal.asarray(c)
+        pp = xp_cls.from_spline((t, c, k), extrapolate=extrapolate)
+        return cls._construct_from_xp(pp, xp_external=xp)
 
     @classmethod
     def from_bernstein_basis(cls, bp, extrapolate=None):
@@ -1304,34 +1761,22 @@ class PPoly(_PPolyBase):
         if not isinstance(bp, BPoly):
             raise TypeError(f".from_bernstein_basis only accepts BPoly instances. "
                             f"Got {type(bp)} instead.")
-
-        dx = np.diff(bp._x)
-        k = bp._c.shape[0] - 1  # polynomial order
-
-        rest = (None,)*(bp.c.ndim-2)
-
-        c = np.zeros_like(bp._c)
-        for a in range(k+1):
-            factor = (-1)**a * comb(k, a) * bp._c[a]
-            for s in range(a, k+1):
-                val = comb(k-a, s-a) * (-1)**s
-                c[k-s] += factor * val / dx[(slice(None),)+rest]**s
-
-        if extrapolate is None:
-            extrapolate = bp.extrapolate
-
-        return cls.construct_fast(bp._asarray(c), bp.x, extrapolate, bp.axis)
+        xp = bp._xp
+        xp_cls, _ = _get_xp_ppoly_cls(xp)
+        pp = xp_cls.from_bernstein_basis(bp._delegate_to, extrapolate=extrapolate)
+        return cls._construct_from_xp(pp, xp_external=xp)
 
 
 @xp_capabilities(
     cpu_only=True, jax_jit=False,
+    exceptions=["cupy"],
     skip_backends=[
         ("dask.array",
-         "https://github.com/data-apis/array-api-extra/issues/488")
+         "https://github.com/scipy/scipy/issues/24205")
     ]
 )
-class BPoly(_PPolyBase):
-    """Piecewise polynomial in the Bernstein basis.
+class BPoly:
+    """Piecewise polynomial in the Bernstein basis
 
     The polynomial between ``x[i]`` and ``x[i + 1]`` is written in the
     Bernstein polynomial basis::
@@ -1418,10 +1863,138 @@ class BPoly(_PPolyBase):
 
     """  # noqa: E501
 
-    def _evaluate(self, x, nu, extrapolate, out):
-        _ppoly.evaluate_bernstein(
-            self._c.reshape(self._c.shape[0], self._c.shape[1], -1),
-            self._x, x, nu, bool(extrapolate), out)
+    def __init__(self, c, x, extrapolate=None, axis=0):
+        xp = array_namespace(c, x)
+        xp_bpoly_cls, xp_internal = _get_xp_bpoly_cls(xp)
+        if not is_numpy(xp):
+            c, x = xp_internal.asarray(c), xp_internal.asarray(x)
+        self._delegate_to = xp_bpoly_cls(c, x, extrapolate=extrapolate, axis=axis)
+        self._xp = xp
+        self._xp_internal = xp_internal
+
+    @classmethod
+    def _construct_from_xp(cls, xp_bpoly, *, xp_external):
+        self = object.__new__(cls)
+        self._delegate_to = xp_bpoly
+        self._xp = xp_external
+        self._xp_internal = array_namespace(xp_bpoly.c)
+        return self
+
+    @classmethod
+    def construct_fast(cls, c, x, extrapolate=None, axis=0):
+        """
+        Construct the piecewise polynomial without making checks.
+
+        Takes the same parameters as the constructor. Input arguments
+        ``c`` and ``x`` must be arrays of the correct shape and type. The
+        ``c`` array can only be of dtypes float and complex, and ``x``
+        array must have dtype float.
+        """
+        xp = array_namespace(c, x)
+        xp_ppoly_cls, xp_internal = _get_xp_ppoly_cls(xp)
+        c, x = xp_internal.asarray(c), xp_internal.asarray(x)
+        return cls._construct_from_xp(
+            xp_ppoly_cls.construct_fast(
+                c, x, extrapolate=extrapolate, axis=axis
+            ),
+            xp_external=xp,
+        )
+
+    @property
+    def c(self):
+        return self._xp.asarray(self._delegate_to.c)
+
+    @c.setter
+    def c(self, c):
+        self._delegate_to.c = (
+            self._xp_internal.asarray(c) if is_numpy(self._xp_internal) else c
+        )
+
+    @property
+    def x(self):
+        return self._xp.asarray(self._delegate_to.x)
+
+    @x.setter
+    def x(self, x):
+        self._delegate_to.x = (
+            self._xp_internal.asarray(x) if is_numpy(self._xp_internal) else x
+        )
+
+    @property
+    def extrapolate(self):
+        return self._delegate_to.extrapolate
+
+    @extrapolate.setter
+    def extrapolate(self, extrapolate):
+        self._delegate_to.extrapolate = extrapolate
+
+    @property
+    def axis(self):
+        return self._delegate_to.axis
+
+    @axis.setter
+    def axis(self, axis):
+        self._delegate_to.axis = axis
+
+    def extend(self, c, x):
+        """
+        Add additional breakpoints and coefficients to the polynomial.
+
+        Parameters
+        ----------
+        c : ndarray, size (k, m, ...)
+            Additional coefficients for polynomials in intervals. Note that
+            the first additional interval will be formed using one of the
+            ``self.x`` end points.
+        x : ndarray, size (m,)
+            Additional breakpoints. Must be sorted in the same order as
+            ``self.x`` and either to the right or to the left of the current
+            breakpoints.
+
+        Notes
+        -----
+        This method is not thread safe and must not be executed concurrently
+        with other methods available in this class. Doing so may cause
+        unexpected errors or numerical output mismatches.
+        """
+        c, x = self._xp_internal.asarray(c), self._xp_internal.asarray(x)
+        self._delegate_to.extend(c, x)
+
+    def __call__(self, x, nu=0, extrapolate=None):
+        """
+        Evaluate the piecewise polynomial or its derivative.
+
+        Parameters
+        ----------
+        x : array_like
+            Points to evaluate the interpolant at.
+        nu : int, optional
+            Order of derivative to evaluate. Must be non-negative.
+        extrapolate : {bool, 'periodic', None}, optional
+            If bool, determines whether to extrapolate to out-of-bounds points
+            based on first and last intervals, or to return NaNs.
+            If 'periodic', periodic extrapolation is used.
+            If None (default), use `self.extrapolate`.
+
+        Returns
+        -------
+        y : array_like
+            Interpolated values. Shape is determined by replacing
+            the interpolation axis in the original array with the shape of x.
+
+        Notes
+        -----
+        Derivatives are evaluated piecewise for each polynomial
+        segment, even if the polynomial is not differentiable at the
+        breakpoints. The polynomial intervals are considered half-open,
+        ``[a, b)``, except for the last interval which is closed
+        ``[a, b]``.
+        """
+        return self._xp.asarray(
+            self._delegate_to(
+                self._xp_internal.asarray(x), nu=nu, extrapolate=extrapolate
+            )
+        )
 
     def derivative(self, nu=1):
         """
@@ -1440,42 +2013,10 @@ class BPoly(_PPolyBase):
             this polynomial.
 
         """
-        if nu < 0:
-            return self.antiderivative(-nu)
-
-        if nu > 1:
-            bp = self
-            for k in range(nu):
-                bp = bp.derivative()
-            return bp
-
-        # reduce order
-        if nu == 0:
-            c2 = self._c.copy()
-        else:
-            # For a polynomial
-            #    B(x) = \sum_{a=0}^{k} c_a b_{a, k}(x),
-            # we use the fact that
-            #   b'_{a, k} = k ( b_{a-1, k-1} - b_{a, k-1} ),
-            # which leads to
-            #   B'(x) = \sum_{a=0}^{k-1} (c_{a+1} - c_a) b_{a, k-1}
-            #
-            # finally, for an interval [y, y + dy] with dy != 1,
-            # we need to correct for an extra power of dy
-
-            rest = (None,)*(self._c.ndim-2)
-
-            k = self._c.shape[0] - 1
-            dx = np.diff(self._x)[(None, slice(None))+rest]
-            c2 = k * np.diff(self._c, axis=0) / dx
-
-        if c2.shape[0] == 0:
-            # derivative of order 0 is zero
-            c2 = np.zeros((1,) + c2.shape[1:], dtype=c2.dtype)
-
-        # construct a compatible polynomial
-        c2 = self._asarray(c2)
-        return self.construct_fast(c2, self.x, self.extrapolate, self.axis)
+        return self._construct_from_xp(
+            self._delegate_to.derivative(nu=nu),
+            xp_external=self._xp,
+        )
 
     def antiderivative(self, nu=1):
         """
@@ -1500,39 +2041,10 @@ class BPoly(_PPolyBase):
         the antiderivative is no longer periodic and its correct evaluation
         outside of the initially given x interval is difficult.
         """
-        if nu <= 0:
-            return self.derivative(-nu)
-
-        if nu > 1:
-            bp = self
-            for k in range(nu):
-                bp = bp.antiderivative()
-            return bp
-
-        # Construct the indefinite integrals on individual intervals
-        c, x = self._c, self._x
-        k = c.shape[0]
-        c2 = np.zeros((k+1,) + c.shape[1:], dtype=c.dtype)
-
-        c2[1:, ...] = np.cumsum(c, axis=0) / k
-        delta = x[1:] - x[:-1]
-        c2 *= delta[(None, slice(None)) + (None,)*(c.ndim-2)]
-
-        # Now fix continuity: on the very first interval, take the integration
-        # constant to be zero; on an interval [x_j, x_{j+1}) with j>0,
-        # the integration constant is then equal to the jump of the `bp` at x_j.
-        # The latter is given by the coefficient of B_{n+1, n+1}
-        # *on the previous interval* (other B. polynomials are zero at the
-        # breakpoint). Finally, use the fact that BPs form a partition of unity.
-        c2[:,1:] += np.cumsum(c2[k, :], axis=0)[:-1]
-
-        if self.extrapolate == 'periodic':
-            extrapolate = False
-        else:
-            extrapolate = self.extrapolate
-
-        c2 = self._asarray(c2)
-        return self.construct_fast(c2, self.x, extrapolate, axis=self.axis)
+        return self._construct_from_xp(
+            self._delegate_to.antiderivative(nu=nu),
+            xp_external=self._xp,
+        )
 
     def integrate(self, a, b, extrapolate=None):
         """
@@ -1555,55 +2067,9 @@ class BPoly(_PPolyBase):
             Definite integral of the piecewise polynomial over [a, b]
 
         """
-        # XXX: can probably use instead the fact that
-        # \int_0^{1} B_{j, n}(x) \dx = 1/(n+1)
-        ib = self.antiderivative()
-        if extrapolate is None:
-            extrapolate = self.extrapolate
-
-        # ib.extrapolate shouldn't be 'periodic', it is converted to
-        # False for 'periodic. in antiderivative() call.
-        if extrapolate != 'periodic':
-            ib.extrapolate = extrapolate
-
-        if extrapolate == 'periodic':
-            # Split the integral into the part over period (can be several
-            # of them) and the remaining part.
-
-            # For simplicity and clarity convert to a <= b case.
-            if a <= b:
-                sign = 1
-            else:
-                a, b = b, a
-                sign = -1
-
-            xs, xe = self._x[0], self._x[-1]
-            period = xe - xs
-            interval = b - a
-            n_periods, left = divmod(interval, period)
-            res = n_periods * (ib(xe) - ib(xs))
-
-            # Map a and b to [xs, xe].
-            a = xs + (a - xs) % period
-            b = a + left
-
-            # If b <= xe then we need to integrate over [a, b], otherwise
-            # over [a, xe] and from xs to what is remained.
-            if b <= xe:
-                res += ib(b) - ib(a)
-            else:
-                res += ib(xe) - ib(a) + ib(xs + left + a - xe) - ib(xs)
-
-            return self._asarray(sign * res)
-        else:
-            return ib(b) - ib(a)
-
-    def extend(self, c, x):
-        k = max(self._c.shape[0], c.shape[0])
-        self._c = self._raise_degree(self._c, k - self._c.shape[0])
-        c = self._raise_degree(c, k - c.shape[0])
-        _PPolyBase.extend(self, c, x)
-    extend.__doc__ = _PPolyBase.extend.__doc__
+        return self._xp.asarray(
+            self._delegate_to.integrate(a, b, extrapolate=extrapolate)
+        )
 
     @classmethod
     def from_power_basis(cls, pp, extrapolate=None):
@@ -1623,22 +2089,10 @@ class BPoly(_PPolyBase):
         if not isinstance(pp, PPoly):
             raise TypeError(f".from_power_basis only accepts PPoly instances. "
                             f"Got {type(pp)} instead.")
-
-        dx = np.diff(pp._x)
-        k = pp._c.shape[0] - 1   # polynomial order
-
-        rest = (None,)*(pp._c.ndim-2)
-
-        c = np.zeros_like(pp._c)
-        for a in range(k+1):
-            factor = pp._c[a] / comb(k, k-a) * dx[(slice(None),) + rest]**(k-a)
-            for j in range(k-a, k+1):
-                c[j] += factor * comb(j, k-a)
-
-        if extrapolate is None:
-            extrapolate = pp.extrapolate
-
-        return cls.construct_fast(pp._asarray(c), pp.x, extrapolate, pp.axis)
+        xp = pp._xp
+        xp_cls, _ = _get_xp_bpoly_cls(xp)
+        bp = xp_cls.from_power_basis(pp._delegate_to, extrapolate=extrapolate)
+        return cls._construct_from_xp(bp, xp_external=xp)
 
     @classmethod
     def from_derivatives(cls, xi, yi, orders=None, extrapolate=None):
@@ -1704,62 +2158,18 @@ class BPoly(_PPolyBase):
         So that f'(1-0) = -1 and f'(1+0) = 2
 
         """
-        xi = np.asarray(xi)
-        if len(xi) != len(yi):
-            raise ValueError("xi and yi need to have the same length")
-        if np.any(xi[1:] - xi[:1] <= 0):
-            raise ValueError("x coordinates are not in increasing order")
-
-        # number of intervals
-        m = len(xi) - 1
-
-        # global poly order is k-1, local orders are <=k and can vary
-        try:
-            k = max(len(yi[i]) + len(yi[i+1]) for i in range(m))
-        except TypeError as e:
-            raise ValueError(
-                "Using a 1-D array for y? Please .reshape(-1, 1)."
-            ) from e
-
-        if orders is None:
-            orders = [None] * m
+        xp = array_namespace(xi, *yi)
+        xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
+        xi = xp_internal.asarray(xi)
+        if isinstance(yi, list):
+            yi = list(map(xp_internal.asarray, yi))
         else:
-            if isinstance(orders, int | np.integer):
-                orders = [orders] * m
-            k = max(k, max(orders))
+            yi = xp_internal.asarray(yi)
 
-            if any(o <= 0 for o in orders):
-                raise ValueError("Orders must be positive.")
-
-        c = []
-        for i in range(m):
-            y1, y2 = yi[i], yi[i+1]
-            if orders[i] is None:
-                n1, n2 = len(y1), len(y2)
-            else:
-                n = orders[i]+1
-                n1 = min(n//2, len(y1))
-                n2 = min(n - n1, len(y2))
-                n1 = min(n - n2, len(y2))
-                if n1 + n2 != n:
-                    mesg = (
-                        f"Point {xi[i]} has {len(y1)} derivatives, point {xi[i+1]} has "
-                        f"{len(y2)} derivatives, but order {orders[i]} requested"
-                    )
-                    raise ValueError(mesg)
-
-                if not (n1 <= len(y1) and n2 <= len(y2)):
-                    raise ValueError("`order` input incompatible with"
-                                     " length y1 or y2.")
-
-            b = BPoly._construct_from_derivatives(xi[i], xi[i+1],
-                                                  y1[:n1], y2[:n2])
-            if len(b) < k:
-                b = BPoly._raise_degree(b, k - len(b))
-            c.append(b)
-
-        c = np.asarray(c)
-        return cls(c.swapaxes(0, 1), xi, extrapolate)
+        bp = xp_cls.from_derivatives(
+            xi, yi, orders=orders, extrapolate=extrapolate
+        )
+        return cls._construct_from_xp(bp, xp_external=xp)
 
     @staticmethod
     def _construct_from_derivatives(xa, xb, ya, yb):
@@ -1816,38 +2226,10 @@ class BPoly(_PPolyBase):
         At ``x = xb`` it's the same with ``a = n - q``.
 
         """
-        ya, yb = np.asarray(ya), np.asarray(yb)
-        if ya.shape[1:] != yb.shape[1:]:
-            raise ValueError(
-                f"Shapes of ya {ya.shape} and yb {yb.shape} are incompatible"
-            )
-
-        dta, dtb = ya.dtype, yb.dtype
-        if (np.issubdtype(dta, np.complexfloating) or
-               np.issubdtype(dtb, np.complexfloating)):
-            dt = np.complex128
-        else:
-            dt = np.float64
-
-        na, nb = len(ya), len(yb)
-        n = na + nb
-
-        c = np.empty((na+nb,) + ya.shape[1:], dtype=dt)
-
-        # compute coefficients of a polynomial degree na+nb-1
-        # walk left-to-right
-        for q in range(0, na):
-            c[q] = ya[q] / spec.poch(n - q, q) * (xb - xa)**q
-            for j in range(0, q):
-                c[q] -= (-1)**(j+q) * comb(q, j) * c[j]
-
-        # now walk right-to-left
-        for q in range(0, nb):
-            c[-q-1] = yb[q] / spec.poch(n - q, q) * (-1)**q * (xb - xa)**q
-            for j in range(0, q):
-                c[-q-1] -= (-1)**(j+1) * comb(q, j+1) * c[-q+j]
-
-        return c
+        xp = array_namespace(ya, yb)
+        xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
+        ya, yb = xp_internal.asarray(ya), xp_internal.asarray(yb)
+        return xp.asarray(xp_cls._construct_from_derivatives(xa, xb, ya, yb))
 
     @staticmethod
     def _raise_degree(c, d):
@@ -1877,18 +2259,9 @@ class BPoly(_PPolyBase):
                                  comb(d, j) / comb(k+d, a+j)
 
         """
-        if d == 0:
-            return c
-
-        k = c.shape[0] - 1
-        out = np.zeros((c.shape[0] + d,) + c.shape[1:], dtype=c.dtype)
-
-        for a in range(c.shape[0]):
-            f = c[a] * comb(k, a)
-            for j in range(d+1):
-                out[a+j] += f * comb(d, j) / comb(k+d, a+j)
-        return out
-
+        xp = array_namespace(c)
+        xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
+        return xp.asarray(xp_cls._raise_degree(xp_internal.asarray(c), d))
 
 class NdPPoly:
     """

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1289,6 +1289,15 @@ def _get_xp_bpoly_cls(xp):
     return _BPoly, np
 
 
+_ppoly_extra_note = (
+    """The methods ``solve`` and ``roots`` are currently not supported
+    with CuPy. ``solve`` and ``roots`` with ``c.ndim > 2`` are currently
+    only supported with NumPy.
+
+    """
+)
+
+
 @xp_capabilities(
     cpu_only=True, jax_jit=False,
     exceptions=["cupy"],
@@ -1313,7 +1322,8 @@ def _get_xp_bpoly_cls(xp):
                  "https://github.com/scipy/scipy/issues/24205")
             ],
         ),
-    }
+    },
+    extra_note=_ppoly_extra_note,
 )
 class PPoly:
     """Piecewise polynomial in the power basis.
@@ -1783,7 +1793,6 @@ class PPoly:
         xp_cls, _ = _get_xp_ppoly_cls(xp)
         pp = xp_cls.from_bernstein_basis(bp._delegate_to, extrapolate=extrapolate)
         return cls._construct_from_xp(pp, xp_external=xp)
-
 
 @xp_capabilities(
     cpu_only=True, jax_jit=False,

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -13,7 +13,7 @@ from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
 from scipy._lib._array_api import (
-    array_namespace, xp_capabilities, scipy_namespace_for, is_numpy, is_array_api_obj
+    array_namespace, xp_capabilities, scipy_namespace_for, is_numpy
 )
 
 from . import _fitpack_py
@@ -2185,11 +2185,9 @@ class BPoly:
         So that f'(1-0) = -1 and f'(1+0) = 2
 
         """
-        if not is_array_api_obj(yi):
+        if isinstance(yi, (list, tuple)):
             # yi is documented as accepting arrays or lists of
-            # arrays. Technically, from_derivatives should work for any
-            # indexable Sequence of arrays, so we just check if it's not an
-            # array api object. The following line with star unpacking will not
+            # arrays.  The following line with star unpacking will not
             # work for array ``yi`` for some backends because some are
             # stricting than others about whether arrays can be iterated over.
             xp = array_namespace(xi, *yi)
@@ -2197,9 +2195,9 @@ class BPoly:
             xp = array_namespace(xi, yi)
         xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
         xi = xp_internal.asarray(xi)
-        if not is_array_api_obj(yi):
-            # If ``yi`` is not an array, it is hopefully an indexable Sequence
-            # of arrays. Apply asarray to each element separately.
+        if isinstance(yi, (list, tuple)):
+            # If yi is a ragged list or tuple of arrays, then need to apply
+            # xp_internal.asarray separately over each element.
             yi = list(map(xp_internal.asarray, yi))
         else:
             yi = xp_internal.asarray(yi)

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1237,7 +1237,7 @@ class _BPoly(_PPolyBase):
 
 @functools.lru_cache(16)
 def _get_xp_ppoly_cls(xp):
-    """Returns bspline class to delegate to for xp along with internal array namespace.
+    """Returns ppoly class to delegate to for xp along with internal array namespace.
 
     Parameters
     ----------
@@ -1262,6 +1262,7 @@ def _get_xp_ppoly_cls(xp):
     return _PPoly, np
 
 
+@functools.lru_cache(16)
 def _get_xp_bpoly_cls(xp):
     """Returns bpoly class to delegate to for xp along with internal array namespace.
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -13,8 +13,7 @@ from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
 from scipy._lib._array_api import (
-    array_namespace, xp_capabilities, scipy_namespace_for, is_numpy,
-    is_array_api_obj
+    array_namespace, xp_capabilities, scipy_namespace_for, is_numpy
 )
 
 from . import _fitpack_py

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -2176,7 +2176,10 @@ class BPoly:
         So that f'(1-0) = -1 and f'(1+0) = 2
 
         """
-        xp = array_namespace(xi, *yi)
+        if isinstance(yi, list):
+            xp = array_namespace(xi, *yi)
+        else:
+            xp = array_namespace(xi, yi)
         xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
         xi = xp_internal.asarray(xi)
         if isinstance(yi, list):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -13,7 +13,7 @@ from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
 from scipy._lib._array_api import (
-    array_namespace, xp_capabilities, scipy_namespace_for, is_numpy
+    array_namespace, xp_capabilities, scipy_namespace_for, is_numpy, is_array_api_obj
 )
 
 from . import _fitpack_py
@@ -2184,13 +2184,21 @@ class BPoly:
         So that f'(1-0) = -1 and f'(1+0) = 2
 
         """
-        if isinstance(yi, list):
+        if not is_array_api_obj(yi):
+            # yi is documented as accepting arrays or lists of
+            # arrays. Technically, from_derivatives should work for any
+            # indexable Sequence of arrays, so we just check if it's not an
+            # array api object. The following line with star unpacking will not
+            # work for array ``yi`` for some backends because some are
+            # stricting than others about whether arrays can be iterated over.
             xp = array_namespace(xi, *yi)
         else:
             xp = array_namespace(xi, yi)
         xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
         xi = xp_internal.asarray(xi)
-        if isinstance(yi, list):
+        if not is_array_api_obj(yi):
+            # If ``yi`` is not an array, it is hopefully an indexable Sequence
+            # of arrays. Apply asarray to each element separately.
             yi = list(map(xp_internal.asarray, yi))
         else:
             yi = xp_internal.asarray(yi)

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1296,10 +1296,10 @@ _ppoly_extra_note = (
 
     If a ppoly object is called on an input array ``x`` with namespace
     different from the namespace ``xp`` of the breakpoints and coefficients
-    with which it was instantiated, an attempt will be made to coerce ``x`` to
-    the ``xp`` namespace. If the conversion succeeds, the output will be an
-    array from the ``xp`` namespace. Mixing namespaces in this way is not
-    recommended.
+    with which the ppoly object was instantiated, an attempt will be made to
+    coerce ``x`` to the ``xp`` namespace. If the conversion succeeds, the
+    output will be an array from the ``xp`` namespace. Mixing namespaces in
+    this way is not recommended.
 
     """
 )
@@ -1805,10 +1805,10 @@ class PPoly:
 _bpoly_extra_note = (
     """If a bpoly object is called on an input array ``x`` with namespace
     different from the namespace ``xp`` of the breakpoints and coefficients
-    with which it was instantiated, an attempt will be made to coerce ``x`` to
-    the ``xp`` namespace. If the conversion succeeds, the output will be an
-    array from the ``xp`` namespace. Mixing namespaces in this way is not
-    recommended.
+    with which the bpoly object was instantiated, an attempt will be made to
+    coerce ``x`` to the ``xp`` namespace. If the conversion succeeds, the
+    output will be an array from the ``xp`` namespace. Mixing namespaces in
+    this way is not recommended.
 
     """
 )

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1294,6 +1294,13 @@ _ppoly_extra_note = (
     with CuPy. ``solve`` and ``roots`` with ``c.ndim > 2`` are currently
     only supported with NumPy.
 
+    If a ppoly object is called on an input array ``x`` with namespace
+    different from the namespace ``xp`` of the breakpoints and coefficients
+    with which it was instantiated, an attempt will be made to coerce ``x`` to
+    the ``xp`` namespace. If the conversion succeeds, the output will be an
+    array from the ``xp`` namespace. Mixing namespaces in this way is not
+    recommended.
+
     """
 )
 
@@ -1794,13 +1801,27 @@ class PPoly:
         pp = xp_cls.from_bernstein_basis(bp._delegate_to, extrapolate=extrapolate)
         return cls._construct_from_xp(pp, xp_external=xp)
 
+
+_bpoly_extra_note = (
+    """If a bpoly object is called on an input array ``x`` with namespace
+    different from the namespace ``xp`` of the breakpoints and coefficients
+    with which it was instantiated, an attempt will be made to coerce ``x`` to
+    the ``xp`` namespace. If the conversion succeeds, the output will be an
+    array from the ``xp`` namespace. Mixing namespaces in this way is not
+    recommended.
+
+    """
+)
+
+
 @xp_capabilities(
     cpu_only=True, jax_jit=False,
     exceptions=["cupy"],
     skip_backends=[
         ("dask.array",
          "https://github.com/scipy/scipy/issues/24205")
-    ]
+    ],
+    extra_note=_bpoly_extra_note,
 )
 class BPoly:
     """Piecewise polynomial in the Bernstein basis.

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1802,7 +1802,7 @@ class PPoly:
     ]
 )
 class BPoly:
-    """Piecewise polynomial in the Bernstein basis
+    """Piecewise polynomial in the Bernstein basis.
 
     The polynomial between ``x[i]`` and ``x[i + 1]`` is written in the
     Bernstein polynomial basis::

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1295,7 +1295,25 @@ def _get_xp_bpoly_cls(xp):
     skip_backends=[
         ("dask.array",
          "https://github.com/scipy/scipy/issues/24205")
-    ]
+    ],
+    method_capabilities={
+        "roots": dict(
+            cpu_only=True,
+            jax_jit=False,
+            skip_backends=[
+                ("dask.array",
+                 "https://github.com/scipy/scipy/issues/24205")
+            ],
+        ),
+        "solve": dict(
+            cpu_only=True,
+            jax_jit=False,
+            skip_backends=[
+                ("dask.array",
+                 "https://github.com/scipy/scipy/issues/24205")
+            ],
+        ),
+    }
 )
 class PPoly:
     """Piecewise polynomial in the power basis.

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1381,8 +1381,10 @@ class TestPPoly:
         c = np.array([[1, 4], [2, 5], [3, 6]], dtype=float)
         x = np.array([0, 0.5, 1])
         p = PPoly.construct_fast(xp.asarray(c), xp.asarray(x))
-        xp_assert_close(p(0.3), xp.asarray(1*0.3**2 + 2*0.3 + 3))
-        xp_assert_close(p(0.7), xp.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6))
+        xp_assert_close(p(0.3), xp.asarray(1*0.3**2 + 2*0.3 + 3, dtype=xp.float64))
+        xp_assert_close(
+            p(0.7), xp.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6, dtype=xp.float64)
+        )
 
     def test_vs_alternative_implementations(self, xp):
         rng = np.random.RandomState(1234)
@@ -1493,11 +1495,11 @@ class TestPPoly:
         # https://github.com/scipy/scipy/issues/4355
         p = PPoly(xp.asarray([[1., 0.5]]), xp.asarray([0, 1, 2]))
         q = p.antiderivative()
-        xp_assert_equal(q.c, xp.asarray([[1, 0.5], [0, 1]]))
-        xp_assert_equal(q.x, xp.asarray([0.0, 1, 2]))
-        xp_assert_close(p.integrate(0, 2), xp.asarray(1.5))
+        xp_assert_equal(q.c, xp.asarray([[1, 0.5], [0, 1]], dtype=xp.float64))
+        xp_assert_equal(q.x, xp.asarray([0.0, 1, 2], dtype=xp.float64))
+        xp_assert_close(p.integrate(0, 2), xp.asarray(1.5, dtype=xp.float64))
         xp_assert_close(xp.asarray(q(2) - q(0)),
-                        xp.asarray(1.5))
+                        xp.asarray(1.5, dtype=xp.float64))
 
     def test_antiderivative_simple(self, xp):
         # [ p1(x) = 3*x**2 + 2*x + 1,
@@ -1595,7 +1597,10 @@ class TestPPoly:
 
         ipp = pp.antiderivative()
         xp_assert_close(ig, ipp(b) - ipp(a), check_0d=False)
-        xp_assert_close(ig, xp.asarray(splint(a, b, (t_np, c_np, k))), check_0d=False)
+        xp_assert_close(
+            ig, xp.asarray(splint(a, b, (t_np, c_np, k)), dtype=xp.float64),
+            check_0d=False
+        )
 
         a, b = -0.3, 0.9
         ig = pp.integrate(a, b, extrapolate=True)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1307,6 +1307,7 @@ class TestPPoly:
             vals = f(xnew)
             assert np.isfinite(vals).all()
 
+    @make_xp_test_case((PPoly, "roots"))
     def test_descending(self, xp):
         def binom_matrix(power):
             n = np.arange(power + 1).reshape(-1, 1)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1331,7 +1331,7 @@ class TestPPoly:
 
             ca, cd, x = map(xp.asarray, (ca, cd, x))
             pa = PPoly(ca, x, extrapolate=True)
-            pd = PPoly(cd[:, ::-1], x[::-1], extrapolate=True)
+            pd = PPoly(xp.flip(cd, axis=-1), xp.flip(x, axis=-1), extrapolate=True)
 
             x_test = xp.asarray(rng.uniform(-10, 20, 100))
             xp_assert_close(pa(x_test), pd(x_test), rtol=1e-13)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1307,7 +1307,7 @@ class TestPPoly:
             vals = f(xnew)
             assert np.isfinite(vals).all()
 
-    def test_descending(self):
+    def test_descending(self, xp):
         def binom_matrix(power):
             n = np.arange(power + 1).reshape(-1, 1)
             k = np.arange(power + 1)
@@ -1328,10 +1328,11 @@ class TestPPoly:
             cdp = np.dot(B.T, cap)
             cd = cdp / h_powers
 
+            ca, cd, x = map(xp.asarray, (ca, cd, x))
             pa = PPoly(ca, x, extrapolate=True)
             pd = PPoly(cd[:, ::-1], x[::-1], extrapolate=True)
 
-            x_test = rng.uniform(-10, 20, 100)
+            x_test = xp.asarray(rng.uniform(-10, 20, 100))
             xp_assert_close(pa(x_test), pd(x_test), rtol=1e-13)
             xp_assert_close(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
 
@@ -1346,6 +1347,7 @@ class TestPPoly:
             pa_i = pa.antiderivative()
             pd_i = pd.antiderivative()
             for a, b in rng.uniform(-10, 20, (5, 2)):
+                a, b = map(xp.asarray, (a, b))
                 int_a = pa.integrate(a, b)
                 int_d = pd.integrate(a, b)
                 xp_assert_close(int_a, int_d, rtol=1e-13)
@@ -1354,7 +1356,7 @@ class TestPPoly:
 
             roots_d = pd.roots()
             roots_a = pa.roots()
-            xp_assert_close(roots_a, np.sort(roots_d), rtol=1e-12)
+            xp_assert_close(roots_a, xp.sort(roots_d), rtol=1e-12)
 
     def test_multi_shape(self, xp):
         c = np.random.rand(6, 2, 1, 2, 3)
@@ -1372,46 +1374,49 @@ class TestPPoly:
         ip = p.antiderivative()
         assert ip.c.shape == (7, 2, 1, 2, 3)
 
-    def test_construct_fast(self):
+    def test_construct_fast(self, xp):
         np.random.seed(1234)
         c = np.array([[1, 4], [2, 5], [3, 6]], dtype=float)
         x = np.array([0, 0.5, 1])
-        p = PPoly.construct_fast(c, x)
-        xp_assert_close(p(0.3), np.asarray(1*0.3**2 + 2*0.3 + 3))
-        xp_assert_close(p(0.7), np.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6))
+        p = PPoly.construct_fast(xp.asarray(c), xp.asarray(x))
+        xp_assert_close(p(0.3), xp.asarray(1*0.3**2 + 2*0.3 + 3))
+        xp_assert_close(p(0.7), xp.asarray(4*(0.7-0.5)**2 + 5*(0.7-0.5) + 6))
 
-    def test_vs_alternative_implementations(self):
+    def test_vs_alternative_implementations(self, xp):
         rng = np.random.RandomState(1234)
-        c = rng.rand(3, 12, 22)
-        x = np.sort(np.r_[0, rng.rand(11), 1])
+        c_np = rng.rand(3, 12, 22)
+        x_np = np.sort(np.r_[0, rng.rand(11), 1])
+        x_p_np = np.r_[0.3, 0.5, 0.33, 0.6]
+
+        c, x, x_p = map(xp.asarray, (c_np, x_np, x_p_np))
 
         p = PPoly(c, x)
 
-        xp = np.r_[0.3, 0.5, 0.33, 0.6]
-        expected = _ppoly_eval_1(c, x, xp)
-        xp_assert_close(p(xp), expected)
+        expected = xp.asarray(_ppoly_eval_1(c_np, x_np, x_p_np))
+        xp_assert_close(p(x_p), expected)
 
-        expected = _ppoly_eval_2(c[:,:,0], x, xp)
-        xp_assert_close(p(xp)[:, 0], expected)
+        expected = xp.asarray(_ppoly_eval_2(c_np[:, :, 0], x_np, x_p_np))
+        xp_assert_close(p(x_p)[:, 0], expected)
 
-    def test_from_spline(self):
+    def test_from_spline(self, xp):
         rng = np.random.RandomState(1234)
         x = np.sort(np.r_[0, rng.rand(11), 1])
         y = rng.rand(len(x))
 
-        spl = splrep(x, y, s=0)
-        pp = PPoly.from_spline(spl)
+        t_np, c_np, k = splrep(x, y, s=0)
+        t, c = xp.asarray(t_np), xp.asarray(c_np)
+        pp = PPoly.from_spline((t, c, k))
 
-        xi = np.linspace(0, 1, 200)
-        xp_assert_close(pp(xi), splev(xi, spl))
+        xi_np = np.linspace(0, 1, 200)
+        xi = xp.asarray(xi_np)
+        xp_assert_close(pp(xi), xp.asarray(splev(xi_np, (t_np, c_np, k))))
 
         # make sure .from_spline accepts BSpline objects
-        b = BSpline(*spl)
+        b = BSpline(t, c, k)
         ppp = PPoly.from_spline(b)
         xp_assert_close(ppp(xi), b(xi))
 
         # BSpline's extrapolate attribute propagates unless overridden
-        t, c, k = spl
         for extrap in (None, True, False):
             b = BSpline(t, c, k, extrapolate=extrap)
             p = PPoly.from_spline(b)
@@ -1443,17 +1448,19 @@ class TestPPoly:
         xp_assert_close(pp.derivative().c, dpp.c)
         xp_assert_close(pp.derivative(2).c, ddpp.c)
 
-    def test_derivative_eval(self):
+    def test_derivative_eval(self, xp):
         rng = np.random.RandomState(1234)
         x = np.sort(np.r_[0, rng.rand(11), 1])
         y = rng.rand(len(x))
 
-        spl = splrep(x, y, s=0)
-        pp = PPoly.from_spline(spl)
+        t_np, c_np, k = splrep(x, y, s=0)
+        t, c = xp.asarray(t_np), xp.asarray(c_np)
+        pp = PPoly.from_spline((t, c, k))
 
-        xi = np.linspace(0, 1, 200)
+        xi_np = np.linspace(0, 1, 200)
+        xi = xp.asarray(xi_np)
         for dx in range(0, 3):
-            xp_assert_close(pp(xi, dx), splev(xi, spl, dx))
+            xp_assert_close(pp(xi, dx), xp.asarray(splev(xi_np, (t_np, c_np, k), dx)))
 
     def test_derivative(self):
         rng = np.random.RandomState(1234)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2016,16 +2016,17 @@ class TestBPolyCalculus:
             xpp = xp.linspace(x[0], x[-1], 21)
             xp_assert_close(bp(xpp), pp(xpp))
 
-    def test_deriv_inplace(self):
+    def test_deriv_inplace(self, xp):
         rng = np.random.RandomState(1234)
         m, k = 5, 8   # number of intervals, order
-        x = np.sort(rng.random(m))
-        c = rng.random((k, m-1))
+        x_np = np.sort(rng.random(m))
+        c_np = rng.random((k, m-1))
 
         # test both real and complex coefficients
-        for cc in [c.copy(), c*(1. + 2.j)]:
+        for cc_np in [c_np.copy(), c_np*(1. + 2.j)]:
+            cc, x = xp.asarray(cc_np), xp.asarray(x_np)
             bp = BPoly(cc, x)
-            xpp = np.linspace(x[0], x[-1], 21)
+            xpp = xp.linspace(x[0], x[-1], 21)
             for i in range(k):
                 xp_assert_close(bp(xpp, i), bp.derivative(i)(xpp))
 
@@ -2049,13 +2050,13 @@ class TestBPolyCalculus:
                                          0.5 * xx * (xx/2. - 1) + 3./4),
                         atol=1e-12, rtol=1e-12)
 
-    def test_der_antider(self):
+    def test_der_antider(self, xp):
         rng = np.random.RandomState(1234)
-        x = np.sort(rng.random(11))
-        c = rng.random((4, 10, 2, 3))
+        x = xp.asarray(np.sort(rng.random(11)), dtype=xp.float64)
+        c = xp.asarray(rng.random((4, 10, 2, 3)), dtype=xp.float64)
         bp = BPoly(c, x)
 
-        xx = np.linspace(x[0], x[-1], 100)
+        xx = xp.linspace(x[0], x[-1], 100)
         xp_assert_close(bp.antiderivative().derivative()(xx),
                         bp(xx), atol=1e-12, rtol=1e-12)
 
@@ -2071,10 +2072,10 @@ class TestBPolyCalculus:
         xp_assert_close(bp.antiderivative(2)(xx),
                         pp.antiderivative(2)(xx), atol=1e-12, rtol=1e-12)
 
-    def test_antider_continuous(self):
+    def test_antider_continuous(self, xp):
         rng = np.random.RandomState(1234)
-        x = np.sort(rng.random(11))
-        c = rng.random((4, 10))
+        x = xp.asarray(np.sort(rng.random(11)), dtype=xp.float64)
+        c = xp.asarray(rng.random((4, 10)), dtype=xp.float64)
         bp = BPoly(c, x).antiderivative()
 
         xx = bp.x[1:-1]
@@ -2091,20 +2092,20 @@ class TestBPolyCalculus:
         xp_assert_close(bp.integrate(0, 1),
                         pp.integrate(0, 1), atol=1e-12, rtol=1e-12, check_0d=False)
 
-    def test_integrate_extrap(self):
-        c = [[1]]
-        x = [0, 1]
+    def test_integrate_extrap(self, xp):
+        c = xp.asarray([[1]], dtype=xp.float64)
+        x = xp.asarray([0, 1], dtype=xp.float64)
         b = BPoly(c, x)
 
         # default is extrapolate=True
-        xp_assert_close(b.integrate(0, 2), np.asarray(2.),
+        xp_assert_close(b.integrate(0, 2), xp.asarray(2., dtype=xp.float64),
                         atol=1e-14, check_0d=False)
 
         # .integrate argument overrides self.extrapolate
         b1 = BPoly(c, x, extrapolate=False)
-        assert np.isnan(b1.integrate(0, 2))
+        assert xp.isnan(b1.integrate(0, 2))
         xp_assert_close(b1.integrate(0, 2, extrapolate=True),
-                        np.asarray(2.), atol=1e-14, check_0d=False)
+                        xp.asarray(2., dtype=xp.float64), atol=1e-14, check_0d=False)
 
     def test_integrate_periodic(self, xp):
         x = xp.asarray([1, 2, 4])
@@ -2157,22 +2158,22 @@ class TestPolyConversions:
         xp_assert_close(pp(xv), bp(xv))
         xp_assert_close(pp(xv), pp1(xv))
 
-    def test_bp_from_pp_random(self):
+    def test_bp_from_pp_random(self, xp):
         rng = np.random.RandomState(1234)
         m, k = 5, 8   # number of intervals, order
-        x = np.sort(rng.random(m))
-        c = rng.random((k, m-1))
+        x = xp.asarray(np.sort(rng.random(m)))
+        c = xp.asarray(rng.random((k, m-1)))
         pp = PPoly(c, x)
         bp = BPoly.from_power_basis(pp)
         pp1 = PPoly.from_bernstein_basis(bp)
 
-        xv = np.linspace(x[0], x[-1], 21)
+        xv = xp.linspace(x[0], x[-1], 21)
         xp_assert_close(pp(xv), bp(xv))
         xp_assert_close(pp(xv), pp1(xv))
 
     def test_pp_from_bp(self, xp):
-        x = xp.asarray([0, 1, 3])
-        c = xp.asarray([[3, 3], [1, 1], [4, 2]])
+        x = xp.asarray([0, 1, 3], dtype=xp.float64)
+        c = xp.asarray([[3, 3], [1, 1], [4, 2]], dtype=xp.float64)
         bp = BPoly(c, x)
         pp = PPoly.from_bernstein_basis(bp)
         bp1 = BPoly.from_power_basis(pp)
@@ -2181,10 +2182,10 @@ class TestPolyConversions:
         xp_assert_close(bp(xv), pp(xv))
         xp_assert_close(bp(xv), bp1(xv))
 
-    def test_broken_conversions(self):
+    def test_broken_conversions(self, xp):
         # regression test for gh-10597: from_power_basis only accepts PPoly etc.
-        x = [0, 1, 3]
-        c = [[3, 3], [1, 1], [4, 2]]
+        x = xp.asarray([0, 1, 3], dtype=xp.float64)
+        c = xp.asarray([[3, 3], [1, 1], [4, 2]], dtype=xp.float64)
         pp = PPoly(c, x)
         with assert_raises(TypeError):
             PPoly.from_bernstein_basis(pp)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2,6 +2,7 @@ from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, assert_almost_equal, assert_array_almost_equal,
     make_xp_test_case, is_cupy, _xp_copy_to_numpy
 )
+from scipy._external import array_api_extra as xpx
 from pytest import raises as assert_raises
 import pytest
 
@@ -2195,114 +2196,143 @@ class TestPolyConversions:
             BPoly.from_power_basis(bp)
 
 
+@make_xp_test_case(BPoly)
 class TestBPolyFromDerivatives:
-    def test_make_poly_1(self):
-        c1 = BPoly._construct_from_derivatives(0, 1, [2], [3])
-        xp_assert_close(c1, [2., 3.])
+    def test_make_poly_1(self, xp):
+        c1 = BPoly._construct_from_derivatives(
+            0, 1, xp.asarray([2], dtype=xp.float64), xp.asarray([3], dtype=xp.float64)
+        )
+        xp_assert_close(c1, xp.asarray([2., 3.], dtype=xp.float64))
 
-    def test_make_poly_2(self):
-        c1 = BPoly._construct_from_derivatives(0, 1, [1, 0], [1])
-        xp_assert_close(c1, [1., 1., 1.])
+    def test_make_poly_2(self, xp):
+        c1 = BPoly._construct_from_derivatives(
+            0, 1, xp.asarray([1, 0], dtype=xp.float64),
+            xp.asarray([1], dtype=xp.float64)
+        )
+        xp_assert_close(c1, xp.asarray([1., 1., 1.], dtype=xp.float64))
 
         # f'(0) = 3
-        c2 = BPoly._construct_from_derivatives(0, 1, [2, 3], [1])
-        xp_assert_close(c2, [2., 7./2, 1.])
+        c2 = BPoly._construct_from_derivatives(
+            0, 1, xp.asarray([2, 3], dtype=xp.float64),
+            xp.asarray([1], dtype=xp.float64)
+        )
+        xp_assert_close(c2, xp.asarray([2., 7./2, 1.], dtype=xp.float64))
 
         # f'(1) = 3
-        c3 = BPoly._construct_from_derivatives(0, 1, [2], [1, 3])
-        xp_assert_close(c3, [2., -0.5, 1.])
+        c3 = BPoly._construct_from_derivatives(
+            0, 1, xp.asarray([2], dtype=xp.float64),
+            xp.asarray([1, 3], dtype=xp.float64)
+        )
+        xp_assert_close(c3, xp.asarray([2., -0.5, 1.], dtype=xp.float64))
 
-    def test_make_poly_3(self):
+    def test_make_poly_3(self, xp):
         # f'(0)=2, f''(0)=3
-        c1 = BPoly._construct_from_derivatives(0, 1, [1, 2, 3], [4])
-        xp_assert_close(c1, [1., 5./3, 17./6, 4.])
+        c1 = BPoly._construct_from_derivatives(
+            0, 1, xp.asarray([1, 2, 3], dtype=xp.float64),
+            xp.asarray([4], dtype=xp.float64)
+        )
+        xp_assert_close(c1, xp.asarray([1., 5./3, 17./6, 4.], dtype=xp.float64))
 
         # f'(1)=2, f''(1)=3
-        c2 = BPoly._construct_from_derivatives(0, 1, [1], [4, 2, 3])
-        xp_assert_close(c2, [1., 19./6, 10./3, 4.])
+        c2 = BPoly._construct_from_derivatives(
+            0, 1, xp.asarray([1], dtype=xp.float64),
+            xp.asarray([4, 2, 3], dtype=xp.float64),
+        )
+        xp_assert_close(c2, xp.asarray([1., 19./6, 10./3, 4.], dtype=xp.float64))
 
         # f'(0)=2, f'(1)=3
-        c3 = BPoly._construct_from_derivatives(0, 1, [1, 2], [4, 3])
-        xp_assert_close(c3, [1., 5./3, 3., 4.])
+        c3 = BPoly._construct_from_derivatives(
+            0, 1, xp.asarray([1, 2], dtype=xp.float64),
+            xp.asarray([4, 3], dtype=xp.float64),
+        )
+        xp_assert_close(c3, xp.asarray([1., 5./3, 3., 4.], dtype=xp.float64))
 
-    def test_make_poly_12(self):
+    def test_make_poly_12(self, xp):
         rng = np.random.RandomState(12345)
-        ya = np.r_[0, rng.random(5)]
-        yb = np.r_[0, rng.random(5)]
+        ya = xp.asarray(np.r_[0, rng.random(5)])
+        yb = xp.asarray(np.r_[0, rng.random(5)])
 
         c = BPoly._construct_from_derivatives(0, 1, ya, yb)
-        pp = BPoly(c[:, None], [0, 1])
+        pp = BPoly(c[:, None], xp.asarray([0, 1], dtype=xp.float64))
         for j in range(6):
             xp_assert_close(pp(0.), ya[j], check_0d=False)
             xp_assert_close(pp(1.), yb[j], check_0d=False)
             pp = pp.derivative()
 
-    def test_raise_degree(self):
+    def test_raise_degree(self, xp):
         rng = np.random.RandomState(12345)
-        x = [0, 1]
+        x = xp.asarray([0, 1], dtype=xp.float64)
         k, d = 8, 5
-        c = rng.random((k, 1, 2, 3, 4))
+        c = xp.asarray(rng.random((k, 1, 2, 3, 4)), dtype=xp.float64)
         bp = BPoly(c, x)
 
         c1 = BPoly._raise_degree(c, d)
         bp1 = BPoly(c1, x)
 
-        xp = np.linspace(0, 1, 11)
+        xp = xp.linspace(0, 1, 11)
         xp_assert_close(bp(xp), bp1(xp))
 
-    def test_xi_yi(self):
-        assert_raises(ValueError, BPoly.from_derivatives, [0, 1], [0])
+    def test_xi_yi(self, xp):
+        assert_raises(
+            ValueError, BPoly.from_derivatives,
+            xp.asarray([0, 1], dtype=xp.float64), xp.asarray([0], dtype=xp.float64)
+        )
 
-    def test_coords_order(self):
-        xi = [0, 0, 1]
-        yi = [[0], [0], [0]]
+    def test_coords_order(self, xp):
+        xi = xp.asarray([0, 0, 1], dtype=xp.float64)
+        yi = xp.asarray([[0], [0], [0]], dtype=xp.float64)
         assert_raises(ValueError, BPoly.from_derivatives, xi, yi)
 
-    def test_zeros(self):
-        xi = [0, 1, 2, 3]
-        yi = [[0, 0], [0], [0, 0], [0, 0]]  # NB: will have to raise the degree
+    def test_zeros(self, xp):
+        xi = xp.asarray([0, 1, 2, 3], dtype=xp.float64)
+        # NB: will have to raise the degree
+        yi = list(
+            map(
+                lambda x: xp.asarray(x, dtype=xp.float64),
+                [[0, 0], [0], [0, 0], [0, 0]],
+            )
+        )
         pp = BPoly.from_derivatives(xi, yi)
         assert pp.c.shape == (4, 3)
 
         ppd = pp.derivative()
-        for xp in [0., 0.1, 1., 1.1, 1.9, 2., 2.5]:
-            xp_assert_close(pp(xp), np.asarray(0.0))
-            xp_assert_close(ppd(xp), np.asarray(0.0))
+        for x_p in [0., 0.1, 1., 1.1, 1.9, 2., 2.5]:
+            xp_assert_close(pp(x_p), xp.asarray(0.0, dtype=xp.float64))
+            xp_assert_close(ppd(x_p), xp.asarray(0.0, dtype=xp.float64))
 
-
-    def _make_random_mk(self, m, k):
+    def _make_random_mk(self, m, k, xp):
         # k derivatives at each breakpoint
         rng = np.random.RandomState(1234)
-        xi = np.asarray([1. * j**2 for j in range(m+1)])
-        yi = [rng.random(k) for j in range(m+1)]
+        xi = xp.asarray([1. * j**2 for j in range(m+1)], dtype=xp.float64)
+        yi = [xp.asarray(rng.random(k)) for j in range(m+1)]
         return xi, yi
 
-    def test_random_12(self):
+    def test_random_12(self, xp):
         m, k = 5, 12
-        xi, yi = self._make_random_mk(m, k)
+        xi, yi = self._make_random_mk(m, k, xp)
         pp = BPoly.from_derivatives(xi, yi)
 
         for order in range(k//2):
-            xp_assert_close(pp(xi), [yy[order] for yy in yi])
+            xp_assert_close(pp(xi), xp.stack([yy[order] for yy in yi]))
             pp = pp.derivative()
 
-    def test_order_zero(self):
+    def test_order_zero(self, xp):
         m, k = 5, 12
-        xi, yi = self._make_random_mk(m, k)
+        xi, yi = self._make_random_mk(m, k, xp)
         assert_raises(ValueError, BPoly.from_derivatives,
                 **dict(xi=xi, yi=yi, orders=0))
 
-    def test_orders_too_high(self):
+    def test_orders_too_high(self, xp):
         m, k = 5, 12
-        xi, yi = self._make_random_mk(m, k)
+        xi, yi = self._make_random_mk(m, k, xp)
 
         BPoly.from_derivatives(xi, yi, orders=2*k-1)   # this is still ok
         assert_raises(ValueError, BPoly.from_derivatives,   # but this is not
                 **dict(xi=xi, yi=yi, orders=2*k))
 
-    def test_orders_global(self):
+    def test_orders_global(self, xp):
         m, k = 5, 12
-        xi, yi = self._make_random_mk(m, k)
+        xi, yi = self._make_random_mk(m, k, xp)
 
         # ok, this is confusing. Local polynomials will be of the order 5
         # which means that up to the 2nd derivatives will be used at each point
@@ -2312,7 +2342,7 @@ class TestBPolyFromDerivatives:
         for j in range(order//2+1):
             xp_assert_close(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
             pp = pp.derivative()
-        assert not np.allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
+        assert not xp.all(xpx.isclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12)))
 
         # now repeat with `order` being even: on each interval, it uses
         # order//2 'derivatives' @ the right-hand endpoint and
@@ -2322,11 +2352,11 @@ class TestBPolyFromDerivatives:
         for j in range(order//2):
             xp_assert_close(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
             pp = pp.derivative()
-        assert not np.allclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12))
+        assert not xp.all(xpx.isclose(pp(xi[1:-1] - 1e-12), pp(xi[1:-1] + 1e-12)))
 
-    def test_orders_local(self):
+    def test_orders_local(self, xp):
         m, k = 7, 12
-        xi, yi = self._make_random_mk(m, k)
+        xi, yi = self._make_random_mk(m, k, xp)
 
         orders = [o + 1 for o in range(m)]
         for i, x in enumerate(xi[1:-1]):
@@ -2334,13 +2364,13 @@ class TestBPolyFromDerivatives:
             for j in range(orders[i] // 2 + 1):
                 xp_assert_close(pp(x - 1e-12), pp(x + 1e-12))
                 pp = pp.derivative()
-            assert not np.allclose(pp(x - 1e-12), pp(x + 1e-12))
+            assert not xp.all(xpx.isclose(pp(x - 1e-12), pp(x + 1e-12)))
 
-    def test_yi_trailing_dims(self):
+    def test_yi_trailing_dims(self, xp):
         rng = np.random.RandomState(1234)
         m, k = 7, 5
-        xi = np.sort(rng.random(m+1))
-        yi = rng.random((m+1, k, 6, 7, 8))
+        xi = xp.asarray(np.sort(rng.random(m+1)))
+        yi = xp.asarray(rng.random((m+1, k, 6, 7, 8)))
         pp = BPoly.from_derivatives(xi, yi)
         assert pp.c.shape == (2*k, m, 6, 7, 8)
 

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1,6 +1,6 @@
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, assert_almost_equal, assert_array_almost_equal,
-    make_xp_test_case
+    make_xp_test_case, is_cupy, _xp_copy_to_numpy
 )
 from pytest import raises as assert_raises
 import pytest
@@ -1463,33 +1463,40 @@ class TestPPoly:
         for dx in range(0, 3):
             xp_assert_close(pp(xi, dx), xp.asarray(splev(xi_np, (t_np, c_np, k), dx)))
 
-    def test_derivative(self):
+    def test_derivative(self, xp):
         rng = np.random.RandomState(1234)
-        x = np.sort(np.r_[0, rng.rand(11), 1])
-        y = rng.rand(len(x))
+        x_np = np.sort(np.r_[0, rng.rand(11), 1])
+        y_np = rng.rand(len(x_np))
 
-        spl = splrep(x, y, s=0, k=5)
-        pp = PPoly.from_spline(spl)
+        t_np, c_np, k = splrep(x_np, y_np, s=0, k=5)
+        t, c = xp.asarray(t_np), xp.asarray(c_np)
+        pp = PPoly.from_spline((t, c, k))
 
-        xi = np.linspace(0, 1, 200)
+        xi = xp.linspace(0, 1, 200)
         for dx in range(0, 10):
             xp_assert_close(pp(xi, dx), pp.derivative(dx)(xi), err_msg=f"dx={dx}")
 
-    def test_antiderivative_of_constant(self):
+    def test_antiderivative_of_constant(self, xp):
         # https://github.com/scipy/scipy/issues/4216
-        p = PPoly([[1.]], [0, 1])
-        xp_assert_equal(p.antiderivative().c, PPoly([[1], [0]], [0, 1]).c)
-        xp_assert_equal(p.antiderivative().x, PPoly([[1], [0]], [0, 1]).x)
+        p = PPoly(xp.asarray([[1.]]), xp.asarray([0, 1]))
+        xp_assert_equal(
+            p.antiderivative().c,
+            PPoly(xp.asarray([[1], [0]]), xp.asarray([0, 1])).c
+        )
+        xp_assert_equal(
+            p.antiderivative().x,
+            PPoly(xp.asarray([[1], [0]]), xp.asarray([0, 1])).x
+        )
 
-    def test_antiderivative_regression_4355(self):
+    def test_antiderivative_regression_4355(self, xp):
         # https://github.com/scipy/scipy/issues/4355
-        p = PPoly([[1., 0.5]], [0, 1, 2])
+        p = PPoly(xp.asarray([[1., 0.5]]), xp.asarray([0, 1, 2]))
         q = p.antiderivative()
-        xp_assert_equal(q.c, [[1, 0.5], [0, 1]])
-        xp_assert_equal(q.x, [0.0, 1, 2])
-        xp_assert_close(p.integrate(0, 2), np.asarray(1.5))
-        xp_assert_close(np.asarray(q(2) - q(0)),
-                        np.asarray(1.5))
+        xp_assert_equal(q.c, xp.asarray([[1, 0.5], [0, 1]]))
+        xp_assert_equal(q.x, xp.asarray([0.0, 1, 2]))
+        xp_assert_close(p.integrate(0, 2), xp.asarray(1.5))
+        xp_assert_close(xp.asarray(q(2) - q(0)),
+                        xp.asarray(1.5))
 
     def test_antiderivative_simple(self, xp):
         # [ p1(x) = 3*x**2 + 2*x + 1,
@@ -1516,12 +1523,13 @@ class TestPPoly:
         xp_assert_close(iipp.c.T, iic.T)
         xp_assert_close(iipp2.c.T, iic.T)
 
-    def test_antiderivative_vs_derivative(self):
+    def test_antiderivative_vs_derivative(self, xp):
         rng = np.random.RandomState(1234)
-        x = np.linspace(0, 1, 30)**2
-        y = rng.rand(len(x))
-        spl = splrep(x, y, s=0, k=5)
-        pp = PPoly.from_spline(spl)
+        x_np = np.linspace(0, 1, 30)**2
+        y_np = rng.rand(len(x_np))
+        t_np, c_np, k = splrep(x_np, y_np, s=0, k=5)
+        t, c = xp.asarray(t_np), xp.asarray(c_np)
+        pp = PPoly.from_spline((t, c, k))
 
         for dx in range(0, 10):
             ipp = pp.antiderivative(dx)
@@ -1541,25 +1549,26 @@ class TestPPoly:
                     pp2(pp2.x[1:]), pp2(endpoint), rtol=1e-7, err_msg=f"dx={dx} k={k}"
                 )
 
-    def test_antiderivative_vs_spline(self):
+    def test_antiderivative_vs_spline(self, xp):
         rng = np.random.RandomState(1234)
-        x = np.sort(np.r_[0, rng.rand(11), 1])
-        y = rng.rand(len(x))
+        x_np = np.sort(np.r_[0, rng.rand(11), 1])
+        y_np = rng.rand(len(x_np))
 
-        spl = splrep(x, y, s=0, k=5)
-        pp = PPoly.from_spline(spl)
+        t_np, c_np, k = splrep(x_np, y_np, s=0, k=5)
+        t, c = xp.asarray(t_np), xp.asarray(c_np)
+        pp = PPoly.from_spline((t, c, k))
 
         for dx in range(0, 10):
             pp2 = pp.antiderivative(dx)
-            spl2 = splantider(spl, dx)
-
-            xi = np.linspace(0, 1, 200)
-            xp_assert_close(pp2(xi), splev(xi, spl2),
+            t2_np, c2_np, k2 = splantider((t_np, c_np, k), dx)
+            xi_np = np.linspace(0, 1, 200)
+            xi = xp.asarray(xi_np)
+            xp_assert_close(pp2(xi), xp.asarray(splev(xi_np, (t2_np, c2_np, k2))),
                             rtol=1e-7)
 
-    def test_antiderivative_continuity(self):
-        c = np.array([[2, 1, 2, 2], [2, 1, 3, 3]]).T
-        x = np.array([0, 0.5, 1])
+    def test_antiderivative_continuity(self, xp):
+        c = xp.asarray([[2, 1, 2, 2], [2, 1, 3, 3]]).T
+        x = xp.asarray([0, 0.5, 1], dtype=xp.float64)
 
         p = PPoly(c, x)
         ip = p.antiderivative()
@@ -1571,26 +1580,27 @@ class TestPPoly:
         p2 = ip.derivative()
         xp_assert_close(p2.c, p.c)
 
-    def test_integrate(self):
+    def test_integrate(self, xp):
         rng = np.random.RandomState(1234)
-        x = np.sort(np.r_[0, rng.rand(11), 1])
-        y = rng.rand(len(x))
+        x_np = np.sort(np.r_[0, rng.rand(11), 1])
+        y_np = rng.rand(len(x_np))
 
-        spl = splrep(x, y, s=0, k=5)
-        pp = PPoly.from_spline(spl)
+        t_np, c_np, k = splrep(x_np, y_np, s=0, k=5)
+        t, c = xp.asarray(t_np), xp.asarray(c_np)
+        pp = PPoly.from_spline((t, c, k))
 
         a, b = 0.3, 0.9
         ig = pp.integrate(a, b)
 
         ipp = pp.antiderivative()
         xp_assert_close(ig, ipp(b) - ipp(a), check_0d=False)
-        xp_assert_close(ig, splint(a, b, spl), check_0d=False)
+        xp_assert_close(ig, xp.asarray(splint(a, b, (t_np, c_np, k))), check_0d=False)
 
         a, b = -0.3, 0.9
         ig = pp.integrate(a, b, extrapolate=True)
         xp_assert_close(ig, ipp(b) - ipp(a), check_0d=False)
 
-        assert np.isnan(pp.integrate(a, b, extrapolate=False)).all()
+        assert xp.all(xp.isnan(pp.integrate(a, b, extrapolate=False)))
 
     def test_integrate_readonly(self):
         x = np.array([1, 2, 4])
@@ -1604,108 +1614,138 @@ class TestPPoly:
 
             assert np.isfinite(vals).all()
 
-    def test_integrate_periodic(self):
-        x = np.array([1, 2, 4])
-        c = np.array([[0., 0.], [-1., -1.], [2., -0.], [1., 2.]])
+    def test_integrate_periodic(self, xp):
+        x_np = np.array([1, 2, 4])
+        c_np = np.array([[0., 0.], [-1., -1.], [2., -0.], [1., 2.]])
+
+        x, c = xp.asarray(x_np), xp.asarray(c_np)
 
         P = PPoly(c, x, extrapolate='periodic')
         I = P.antiderivative()
 
-        period_int = np.asarray(I(4) - I(1))
+        period_int = xp.asarray(I(4) - I(1), dtype=xp.float64)
 
         xp_assert_close(P.integrate(1, 4), period_int)
         xp_assert_close(P.integrate(-10, -7), period_int)
-        xp_assert_close(P.integrate(-10, -4), np.asarray(2 * period_int))
+        xp_assert_close(P.integrate(-10, -4), xp.asarray(2 * period_int))
 
         xp_assert_close(P.integrate(1.5, 2.5),
-                        np.asarray(I(2.5) - I(1.5)))
+                        xp.asarray(I(2.5) - I(1.5), dtype=xp.float64))
         xp_assert_close(P.integrate(3.5, 5),
-                        np.asarray(I(2) - I(1) + I(4) - I(3.5)))
+                        xp.asarray(I(2) - I(1) + I(4) - I(3.5), dtype=xp.float64))
         xp_assert_close(P.integrate(3.5 + 12, 5 + 12),
-                        np.asarray(I(2) - I(1) + I(4) - I(3.5)))
-        xp_assert_close(P.integrate(3.5, 5 + 12),
-                        np.asarray(I(2) - I(1) + I(4) - I(3.5) + 4 * period_int))
+                        xp.asarray(I(2) - I(1) + I(4) - I(3.5), dtype=xp.float64))
+        xp_assert_close(
+            P.integrate(3.5, 5 + 12),
+            xp.asarray(
+                I(2) - I(1) + I(4) - I(3.5) + 4 * period_int, dtype=xp.float64
+            )
+        )
         xp_assert_close(P.integrate(0, -1),
-                        np.asarray(I(2) - I(3)))
+                        xp.asarray(I(2) - I(3), dtype=xp.float64))
         xp_assert_close(P.integrate(-9, -10),
-                        np.asarray(I(2) - I(3)))
+                        xp.asarray(I(2) - I(3), dtype=xp.float64))
         xp_assert_close(P.integrate(0, -10),
-                        np.asarray(I(2) - I(3) - 3 * period_int))
+                        xp.asarray(I(2) - I(3) - 3 * period_int, dtype=xp.float64))
 
-    def test_roots(self):
-        x = np.linspace(0, 1, 31)**2
-        y = np.sin(30*x)
+    @make_xp_test_case((PPoly, "roots"))
+    def test_roots(self, xp):
+        x_np = np.linspace(0, 1, 31)**2
+        y_np = np.sin(30*x_np)
 
-        spl = splrep(x, y, s=0, k=3)
-        pp = PPoly.from_spline(spl)
+        (t_np, c_np, k) = splrep(x_np, y_np, s=0, k=3)
+        t, c = xp.asarray(t_np), xp.asarray(c_np)
+        pp = PPoly.from_spline((t, c, k))
 
         r = pp.roots()
         r = r[(r >= 0 - 1e-15) & (r <= 1 + 1e-15)]
-        xp_assert_close(r, sproot(spl), atol=1e-15)
+        xp_assert_close(r, xp.asarray(sproot((t_np, c_np, k))), atol=1e-15)
 
-    def test_roots_idzero(self):
+    @make_xp_test_case((PPoly, "roots"))
+    def test_roots_idzero(self, xp):
         # Roots for piecewise polynomials with identically zero
         # sections.
-        c = np.array([[-1, 0.25], [0, 0], [-1, 0.25]]).T
-        x = np.array([0, 0.4, 0.6, 1.0])
+        c = xp.asarray([[-1, 0.25], [0, 0], [-1, 0.25]], dtype=xp.float64).T
+        x = xp.asarray([0, 0.4, 0.6, 1.0], dtype=xp.float64)
 
         pp = PPoly(c, x)
-        xp_assert_equal(pp.roots(),
-                        [0.25, 0.4, np.nan, 0.6 + 0.25])
-
+        xp_assert_equal(
+            pp.roots(),
+            xp.asarray([0.25, 0.4, xp.nan, 0.6 + 0.25], dtype=xp.float64),
+        )
         # ditto for p.solve(const) with sections identically equal const
         const = 2.
-        c1 = c.copy()
+        c1 = _xp_copy_to_numpy(c)
         c1[1, :] += const
+        c1 = xp.asarray(c1)
         pp1 = PPoly(c1, x)
 
-        xp_assert_equal(pp1.solve(const),
-                        [0.25, 0.4, np.nan, 0.6 + 0.25])
+        xp_assert_equal(
+            pp1.solve(const),
+            xp.asarray([0.25, 0.4, xp.nan, 0.6 + 0.25], dtype=xp.float64),
+        )
 
-    def test_roots_all_zero(self):
+    @make_xp_test_case((PPoly, "roots"), (PPoly, "solve"))
+    def test_roots_all_zero(self, xp):
         # test the code path for the polynomial being identically zero everywhere
         c = [[0], [0]]
         x = [0, 1]
-        p = PPoly(c, x)
-        xp_assert_equal(p.roots(), [0, np.nan])
-        xp_assert_equal(p.solve(0), [0, np.nan])
-        xp_assert_equal(p.solve(1), [])
+        p = PPoly(xp.asarray(c), xp.asarray(x))
+        xp_assert_equal(p.roots(), xp.asarray([0, xp.nan], dtype=xp.float64))
+        xp_assert_equal(p.solve(0), xp.asarray([0, xp.nan], dtype=xp.float64))
+        xp_assert_equal(p.solve(1), xp.asarray([], dtype=xp.float64))
 
         c = [[0, 0], [0, 0]]
         x = [0, 1, 2]
-        p = PPoly(c, x)
-        xp_assert_equal(p.roots(), [0, np.nan, 1, np.nan])
-        xp_assert_equal(p.solve(0), [0, np.nan, 1, np.nan])
-        xp_assert_equal(p.solve(1), [])
+        p = PPoly(xp.asarray(c), xp.asarray(x))
+        xp_assert_equal(
+            p.roots(), xp.asarray([0, xp.nan, 1, xp.nan], dtype=xp.float64)
+        )
+        xp_assert_equal(
+            p.solve(0), xp.asarray([0, xp.nan, 1, xp.nan], dtype=xp.float64)
+        )
+        xp_assert_equal(p.solve(1), xp.asarray([], dtype=xp.float64))
 
-    def test_roots_repeated(self):
+    @make_xp_test_case((PPoly, "roots"))
+    def test_roots_repeated(self, xp):
         # Check roots repeated in multiple sections are reported only
         # once.
 
         # [(x + 1)**2 - 1, -x**2] ; x == 0 is a repeated root
-        c = np.array([[1, 0, -1], [-1, 0, 0]]).T
-        x = np.array([-1, 0, 1])
+        c = xp.asarray([[1, 0, -1], [-1, 0, 0]], dtype=xp.float64).T
+        x = xp.asarray([-1, 0, 1], dtype=xp.float64)
 
         pp = PPoly(c, x)
-        xp_assert_equal(pp.roots(), np.asarray([-2.0, 0.0]))
-        xp_assert_equal(pp.roots(extrapolate=False), np.asarray([0.0]))
+        xp_assert_equal(pp.roots(), xp.asarray([-2.0, 0.0], dtype=xp.float64))
+        xp_assert_equal(
+            pp.roots(extrapolate=False), xp.asarray([0.0], dtype=xp.float64)
+        )
 
-    def test_roots_discont(self):
+    @make_xp_test_case((PPoly, "roots"), (PPoly, "solve"))
+    def test_roots_discont(self, xp):
         # Check that a discontinuity across zero is reported as root
-        c = np.array([[1], [-1]]).T
-        x = np.array([0, 0.5, 1])
+        c = xp.asarray([[1], [-1]], dtype=xp.float64).T
+        x = xp.asarray([0, 0.5, 1], dtype=xp.float64)
         pp = PPoly(c, x)
-        xp_assert_equal(pp.roots(), np.asarray([0.5]))
-        xp_assert_equal(pp.roots(discontinuity=False), np.asarray([]))
+        xp_assert_equal(pp.roots(), xp.asarray([0.5], dtype=xp.float64))
+        xp_assert_equal(
+            pp.roots(discontinuity=False), xp.asarray([], dtype=xp.float64)
+        )
 
         # ditto for a discontinuity across y:
-        xp_assert_equal(pp.solve(0.5), np.asarray([0.5]))
-        xp_assert_equal(pp.solve(0.5, discontinuity=False), np.asarray([]))
+        xp_assert_equal(pp.solve(0.5), xp.asarray([0.5], dtype=xp.float64))
+        xp_assert_equal(
+            pp.solve(0.5, discontinuity=False), xp.asarray([], dtype=xp.float64)
+        )
 
-        xp_assert_equal(pp.solve(1.5), np.asarray([]))
-        xp_assert_equal(pp.solve(1.5, discontinuity=False), np.asarray([]))
+        xp_assert_equal(pp.solve(1.5), xp.asarray([], dtype=xp.float64))
+        xp_assert_equal(
+            pp.solve(1.5, discontinuity=False), xp.asarray([], dtype=xp.float64)
+        )
 
-    def test_roots_random(self):
+    @make_xp_test_case((PPoly, "roots"), (PPoly, "solve"))
+    @skip_xp_backends(np_only=True, reason="solve returns object array for c.ndim > 2")
+    def test_roots_random(self, xp):
         # Check high-order polynomials with random coefficients
         rng = np.random.RandomState(1234)
 
@@ -1713,13 +1753,12 @@ class TestPPoly:
 
         for extrapolate in (True, False):
             for order in range(0, 20):
-                x = np.unique(np.r_[0, 10 * rng.rand(30), 10])
-                c = 2*rng.rand(order+1, len(x)-1, 2, 3) - 1
-
+                x_np = np.unique(np.r_[0, 10 * rng.rand(30), 10])
+                c_np = 2*rng.rand(order+1, len(x_np)-1, 2, 3) - 1
+                x, c = xp.asarray(x_np), xp.asarray(c_np)
                 pp = PPoly(c, x)
-                for y in [0, rng.random()]:
+                for y in [0.0, float(rng.random())]:
                     r = pp.solve(y, discontinuity=False, extrapolate=extrapolate)
-
                     for i in range(2):
                         for j in range(3):
                             rr = r[i,j]
@@ -1767,10 +1806,11 @@ class TestPPoly:
                 res = res[~np.isnan(res)]
                 xp_assert_close(res, np.zeros_like(res), atol=1e-10)
 
-    def test_extrapolate_attr(self):
+    def test_extrapolate_attr(self, xp):
         # [ 1 - x**2 ]
-        c = np.array([[-1, 0, 1]]).T
-        x = np.array([0, 1])
+        c_np = np.array([[-1, 0, 1]]).T
+        x_np = np.array([0, 1])
+        c, x = xp.asarray(c_np), xp.asarray(x_np)
 
         for extrapolate in [True, False, None]:
             pp = PPoly(c, x, extrapolate=extrapolate)
@@ -1778,15 +1818,24 @@ class TestPPoly:
             pp_i = pp.antiderivative()
 
             if extrapolate is False:
-                assert np.isnan(pp([-0.1, 1.1])).all()
-                assert np.isnan(pp_i([-0.1, 1.1])).all()
-                assert np.isnan(pp_d([-0.1, 1.1])).all()
-                assert pp.roots() == [1]
+                assert xp.all(xp.isnan(pp(xp.asarray([-0.1, 1.1]))))
+                assert xp.all(xp.isnan(pp_i(xp.asarray([-0.1, 1.1]))))
+                assert xp.all(xp.isnan(pp_d(xp.asarray([-0.1, 1.1]))))
+                if not is_cupy(xp):
+                    xp_assert_equal(
+                        pp.roots(), xp.asarray([1.0], dtype=xp.float64)
+                    )
             else:
-                xp_assert_close(pp([-0.1, 1.1]), [1-0.1**2, 1-1.1**2])
-                assert not np.isnan(pp_i([-0.1, 1.1])).any()
-                assert not np.isnan(pp_d([-0.1, 1.1])).any()
-                xp_assert_close(pp.roots(), np.asarray([1.0, -1.0]))
+                xp_assert_close(
+                    pp([-0.1, 1.1]),
+                    xp.asarray([1-0.1**2, 1-1.1**2], dtype=xp.float64),
+                )
+                assert not xp.all(xp.isnan(pp_i(xp.asarray([-0.1, 1.1]))))
+                assert not xp.all(xp.isnan(pp_d(xp.asarray([-0.1, 1.1]))))
+                if not is_cupy(xp):
+                    xp_assert_close(
+                        pp.roots(), xp.asarray([1.0, -1.0], dtype=xp.float64)
+                    )
 
 
 @make_xp_test_case(BPoly)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1896,20 +1896,22 @@ class TestBPoly:
         xp_assert_close(bp(3.4, 1), xp.asarray(-6 * 0.6, dtype=xp.float64))
         xp_assert_close(bp(-1.3, 1), xp.asarray(2 * (0.7/2), dtype=xp.float64))
 
-    def test_descending(self):
+    def test_descending(self, xp):
         rng = np.random.RandomState(0)
 
         power = 3
         for m in [10, 20, 30]:
-            x = np.sort(rng.uniform(0, 10, m + 1))
-            ca = rng.uniform(-0.1, 0.1, size=(power + 1, m))
+            x_np = np.sort(rng.uniform(0, 10, m + 1))
+            ca_np = rng.uniform(-0.1, 0.1, size=(power + 1, m))
             # We need only to flip coefficients to get it right!
-            cd = ca[::-1].copy()
+            cd_np = ca_np[::-1].copy()
+
+            x, ca, cd = map(xp.asarray, (x_np, ca_np, cd_np))
 
             pa = BPoly(ca, x, extrapolate=True)
-            pd = BPoly(cd[:, ::-1], x[::-1], extrapolate=True)
+            pd = BPoly(xp.flip(cd, axis=-1), xp.flip(x, axis=-1), extrapolate=True)
 
-            x_test = rng.uniform(-10, 20, 100)
+            x_test = xp.asarray(rng.uniform(-10, 20, 100))
             xp_assert_close(pa(x_test), pd(x_test), rtol=1e-13)
             xp_assert_close(pa(x_test, 1), pd(x_test, 1), rtol=1e-13)
 
@@ -1930,10 +1932,11 @@ class TestBPoly:
                 xp_assert_close(pa_i(b) - pa_i(a), pd_i(b) - pd_i(a),
                                 rtol=1e-12)
 
-    def test_multi_shape(self):
+    def test_multi_shape(self, xp):
         rng = np.random.RandomState(1234)
-        c = rng.rand(6, 2, 1, 2, 3)
-        x = np.array([0, 0.5, 1])
+        c_np = rng.rand(6, 2, 1, 2, 3)
+        x_np = np.array([0, 0.5, 1])
+        c, x = xp.asarray(c_np), xp.asarray(x_np)
         p = BPoly(c, x)
         assert p.x.shape == x.shape
         assert p.c.shape == c.shape
@@ -1962,20 +1965,20 @@ class TestBPoly:
         xp_assert_close(bp(0.4), xp.asarray(3 * 0.6*0.6, dtype=xp.float64))
         xp_assert_close(bp(1.7), xp.asarray(2 * (0.7/2)**2, dtype=xp.float64))
 
-    def test_extrapolate_attr(self):
-        x = [0, 2]
-        c = [[3], [1], [4]]
+    def test_extrapolate_attr(self, xp):
+        x = xp.asarray([0, 2], dtype=xp.float64)
+        c = xp.asarray([[3], [1], [4]], dtype=xp.float64)
         bp = BPoly(c, x)
 
         for extrapolate in (True, False, None):
             bp = BPoly(c, x, extrapolate=extrapolate)
             bp_d = bp.derivative()
             if extrapolate is False:
-                assert np.isnan(bp([-0.1, 2.1])).all()
-                assert np.isnan(bp_d([-0.1, 2.1])).all()
+                assert xp.all(xp.isnan(bp(xp.asarray([-0.1, 2.1]))))
+                assert xp.all(xp.isnan(bp_d(xp.asarray([-0.1, 2.1]))))
             else:
-                assert not np.isnan(bp([-0.1, 2.1])).any()
-                assert not np.isnan(bp_d([-0.1, 2.1])).any()
+                assert not xp.any(xp.isnan(bp(xp.asarray([-0.1, 2.1]))))
+                assert not xp.any(xp.isnan(bp_d(xp.asarray([-0.1, 2.1]))))
 
 
 @make_xp_test_case(BPoly)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1062,10 +1062,10 @@ class TestPPolyCommon:
         assert_raises(ValueError, PPoly, c, x)
         assert_raises(ValueError, BPoly, c, x)
 
-    def test_ctor_c(self):
+    def test_ctor_c(self, xp):
         # wrong shape: `c` must be at least 2D
         with assert_raises(ValueError):
-            PPoly([1, 2], [0, 1])
+            PPoly(xp.asarray([1, 2]), xp.asarray([0, 1]))
 
     def test_extend(self, xp):
         # Test adding new points to the piecewise polynomial
@@ -1139,16 +1139,20 @@ class TestPPolyCommon:
             xp_assert_equal(p2.c, p.c)
             xp_assert_equal(p2.x, p.x)
 
-    def test_shape(self):
+    def test_shape(self, xp):
+        np.random.seed(1234)
+        c = xp.asarray(np.random.rand(8, 12, 5, 6, 7))
+        x = xp.asarray(np.sort(np.random.rand(13)))
+        x_p = xp.asarray(np.random.rand(3, 4))
+        for cls in (PPoly, BPoly):
+            p = cls(c, x)
+            assert p(x_p).shape == (3, 4, 5, 6, 7)
+
+    def test_shape_scalars(self):
         np.random.seed(1234)
         c = np.random.rand(8, 12, 5, 6, 7)
         x = np.sort(np.random.rand(13))
-        xp = np.random.rand(3, 4)
-        for cls in (PPoly, BPoly):
-            p = cls(c, x)
-            assert p(xp).shape == (3, 4, 5, 6, 7)
 
-        # 'scalars'
         for cls in (PPoly, BPoly):
             p = cls(c[..., 0, 0, 0], x)
 
@@ -1173,17 +1177,17 @@ class TestPPolyCommon:
 
             _run_concurrent_barrier(10, worker_fn, interp, xpp)
 
-    def test_complex_coef(self):
+    def test_complex_coef(self, xp):
         np.random.seed(12345)
-        x = np.sort(np.random.random(13))
-        c = np.random.random((8, 12)) * (1. + 0.3j)
-        c_re, c_im = c.real, c.imag
-        xp = np.random.random(5)
+        x = xp.asarray(np.sort(np.random.random(13)))
+        c = xp.asarray(np.random.random((8, 12)) * (1. + 0.3j))
+        c_re, c_im = xp.real(c), xp.imag(c)
+        x_p = xp.asarray(np.random.random(5))
         for cls in (PPoly, BPoly):
             p, p_re, p_im = cls(c, x), cls(c_re, x), cls(c_im, x)
             for nu in [0, 1, 2]:
-                xp_assert_close(p(xp, nu).real, p_re(xp, nu))
-                xp_assert_close(p(xp, nu).imag, p_im(xp, nu))
+                xp_assert_close(xp.real(p(x_p, nu)), p_re(x_p, nu))
+                xp_assert_close(xp.imag(p(x_p, nu)), p_im(x_p, nu))
 
     def test_axis(self, xp):
         np.random.seed(12345)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1830,8 +1830,8 @@ class TestPPoly:
                     pp([-0.1, 1.1]),
                     xp.asarray([1-0.1**2, 1-1.1**2], dtype=xp.float64),
                 )
-                assert not xp.all(xp.isnan(pp_i(xp.asarray([-0.1, 1.1]))))
-                assert not xp.all(xp.isnan(pp_d(xp.asarray([-0.1, 1.1]))))
+                assert not xp.any(xp.isnan(pp_i(xp.asarray([-0.1, 1.1]))))
+                assert not xp.any(xp.isnan(pp_d(xp.asarray([-0.1, 1.1]))))
                 if not is_cupy(xp):
                     xp_assert_close(
                         pp.roots(), xp.asarray([1.0, -1.0], dtype=xp.float64)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->




#### What does this implement/fix?
<!--Please explain your changes.-->

This PR sets up CuPy delegation for `interpolate.PPoly` and `interpolate.BPoly` following the pattern established in #24947 Setting up the delegation went pretty smoothly.  I've also added the `xp` fixture to more of the tests in `test_interpolate.py`.

#### Additional information
<!--Any additional information you think is important.-->

Some things of note, `PPoly.solve` and `PPoly.roots` are not implemented in CuPy. They are also not currently supported on CPU through the sandwich pattern (numpy internal, xp external) when `c.ndim > 2` because the current NumPy behavior in this case is to return an object array.  `BPoly.from_derivatives` can take either an array for `yi` or a list of arrays (list of arrays is useful for cases where one has derivatives up to different orders at different `xi` points.) I took some care to ensure this behavior is preserved. Conversion functions like `PPoly.from_spline`, `PPoly.from_bernstein_basis` and `BPoly.from_power_basis` also required some special care that wasn't needed for the `BSpline` PR. 

In principle, I could have avoided some duplication, since the implementations of `PPoly` and `BPoly` have a lot of overlapping code. Since the overlapping code contains only simple delegation patterns, and the docstrings are different, there didn't seem to be any benefit to doing this.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used.
