### PR TITLE
Fix NaN in signal.sawtooth for width=1 due to floating-point modulo

### DIFF
--- a/scipy/signal/_waveforms.py
+++ b/scipy/signal/_waveforms.py
@@ -68,6 +68,10 @@ def sawtooth(t, width=1.):
 
     # on the interval 0 to width*2*pi function is tmod / (pi*w) - 1
     mask2 = ~mask1 & (tmod < w*2*xp.pi)
+    # Fix: for width=1, tmod values at exactly 2*pi (due to floating-point modulo)
+    # belong to the rising ramp (mask2), not the falling branch (would cause div-by-zero).
+    mask2_width1_edge = ~mask1 & (w == 1) & (tmod >= 2*xp.pi - 1e-14)
+    mask2 = mask2 | mask2_width1_edge
     y = xpx.at(y, mask2).set(tmod[mask2]/(xp.pi*w[mask2]) - 1)
 
     # on the interval width*2*pi to 2*pi function is (pi*(w+1)-tmod) / (pi*(1-w))


### PR DESCRIPTION
Fixes gh-22940

When width=1 and t is very close to 0 (e.g., t=-1e-16), t % (2*pi) produces exactly 2*pi in FP precision, causing mask2=False and mask3 triggers div-by-zero (1-width=0) -> NaN.

Fix: For width=1, treat tmod values at or very close to 2*pi as belonging to the rising ramp (mask2).

Changed: scipy/signal/_waveforms.py - added edge case handling for width=1 in sawtooth mask computation.