### PR TITLE
BUG: fix get_sum_dtype to return np.dtype instead of scalar type

### DIFF
--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -336,9 +336,9 @@ def get_index_dtype(arrays=(), maxval=None, check_contents=False):
 def get_sum_dtype(dtype: np.dtype) -> np.dtype:
     """Mimic numpy's casting for np.sum"""
     if dtype.kind == 'u' and np.can_cast(dtype, np.uint):
-        return np.uint
+        return np.dtype(np.uint)
     if np.can_cast(dtype, np.int_):
-        return np.int_
+        return np.dtype(np.int_)
     return dtype
 
 


### PR DESCRIPTION
Fixes #23076

The `get_sum_dtype` function in `scipy/sparse/_sputils.py` incorrectly returned NumPy scalar type objects (`np.uint`, `np.int_`) instead of proper `np.dtype` instances. This caused type mismatches when interacting with code expecting `np.dtype` objects, particularly under strict type checking.

**Changes:**
- Wrapped `np.uint` and `np.int_` returns with `np.dtype()` to return proper dtype objects
- No behavioral changes — the returned dtype is semantically identical

**Before:**
```python
def get_sum_dtype(dtype: np.dtype) -> np.dtype:
    if dtype.kind == 'u' and np.can_cast(dtype, np.uint):
        return np.uint    # Returns scalar type, not dtype!
    if np.can_cast(dtype, np.int_):
        return np.int_     # Returns scalar type, not dtype!
    return dtype
```

**After:**
```python
def get_sum_dtype(dtype: np.dtype) -> np.dtype:
    if dtype.kind == 'u' and np.can_cast(dtype, np.uint):
        return np.dtype(np.uint)
    if np.can_cast(dtype, np.int_):
        return np.dtype(np.int_)
    return dtype
```