### PR TITLE
BUG/DOC: `find_peaks_cwt`: reject troughs, improve SNR of actual peaks

### DIFF
--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1236,7 +1236,7 @@ def find_peaks_cwt(vector, widths, wavelet=None, max_distances=None,
         Default is ``cwt.shape[0] / 4``, ie 1/4-th the number of widths.
     min_snr : float, optional
         Minimum SNR ratio. Default 1. The signal is the maximum CWT coefficient
-        on the largest ridge line. The noise is `noise_perc` th percentile of
+        found on the ridge line. The noise is `noise_perc` th percentile of
         datapoints contained within the same ridge line.
     noise_perc : float, optional
         When calculating the noise floor, percentile of data points

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1189,7 +1189,7 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
     def filt_func(line):
         if len(line[0]) < min_length:
             return False
-        snr = abs(cwt[line[0][0], line[1][0]] / noises[line[1][0]])
+        snr = abs(max(cwt[line[0], line[1]]) / noises[line[1][0]])
         if snr < min_snr:
             return False
         return True

--- a/scipy/signal/_peak_finding.py
+++ b/scipy/signal/_peak_finding.py
@@ -1189,7 +1189,7 @@ def _filter_ridge_lines(cwt, ridge_lines, window_size=None, min_length=None,
     def filt_func(line):
         if len(line[0]) < min_length:
             return False
-        snr = abs(max(cwt[line[0], line[1]]) / noises[line[1][0]])
+        snr = max(cwt[line[0], line[1]]) / abs(noises[line[1][0]])
         if snr < min_snr:
             return False
         return True

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -968,3 +968,39 @@ class TestFindPeaksCwt:
         found_locs = find_peaks_cwt(test_data, widths)
 
         np.testing.assert_equal(found_locs, 32)
+
+    def test_gh_23604(self):
+
+        # Test if the maximum CWT value along a ridge line is used as
+        # signal level when calculating SNR
+        
+        N = 500
+
+        # Generate Gaussian noise that has sigma = 0.01.
+        # We'll use noise_perc=10 and window_size=50 for peak finding.
+        # With these settings, the 10th percentile of generated noise
+        # will be between -0.018 and -0.008 with probability > 95%.
+        rng = np.random.default_rng(seed=50)
+        noise = np.asarray(rng.standard_normal((N,))) * 0.01
+
+        signal = _gen_gaussians([250], [30], N) + noise
+
+        # Choose CWT scales so that there will be a ridge line with maximum
+        # CWT coefficient of 5.1 at one row and less than 1.3 elsewhere
+        cwt_scales = np.hstack( (np.geomspace(1, 10, 8), [48.0],
+                                 np.geomspace(10, 1, 8)) )
+
+        peaks = find_peaks_cwt(signal, cwt_scales, min_snr=210, noise_perc=10,
+                               window_size=50)
+
+        # If the code picks the signal level correctly, then the peak
+        # will have SNR > 5.0/0.018 (ca. 278), and this test will pass.
+
+        # If the code picks some wrong element from the CWT result, then
+        # the peak won't have SNR larger than 1.3/0.008 (ca. 163), and
+        # this test will fail.
+
+        # There should be a peak with SNR > 210 somewhere near index 250
+        expected_peaks = [x for x in peaks if (x >= 247) and (x <= 253)]
+        assert expected_peaks != []
+

--- a/scipy/signal/tests/test_peak_finding.py
+++ b/scipy/signal/tests/test_peak_finding.py
@@ -1004,3 +1004,33 @@ class TestFindPeaksCwt:
         expected_peaks = [x for x in peaks if (x >= 247) and (x <= 253)]
         assert expected_peaks != []
 
+    def test_gh_23684(self):
+
+        # Make sure find_peaks_cwt doesn't report troughs as peaks. 
+        # Such a thing may happen when a ridge line is completely below zero
+        # but the SNR check fails to reject it, eg. due to bad use of abs().
+        # It is assumed here that find_peaks_cwt uses the Ricker wavelet by
+        # default.
+
+        # The Lorentz peak decays slower than a Gaussian, and seems to be
+        # better at causing negative ridge lines.
+        def lorentz(x, loc, fwhm, height):
+            return height * ( 1 / (1 + (2*(x-loc)/fwhm)**2) )
+
+        x = np.arange(500)
+
+        # Provide find_peaks_cwt with a noise level of ca. 1e-4.
+        # This "noise" will appear almost unchanged at cwt_scale=1.
+        noise = np.sin(x*np.pi/2) * 1e-4
+        
+        # Synthesize a signal with two identical peaks
+        signal = lorentz(x, 200, 20, 0.5) + \
+                 lorentz(x, 300, 20, 0.5) + noise
+
+        # Find the two peaks and check that no "peak" is reported halfway
+        # between them
+        cwt_scales = np.geomspace(1, 20, 16)
+        peaks = find_peaks_cwt(signal, cwt_scales, min_snr=10, noise_perc=10)
+
+        found_troughs = [x for x in peaks if (x >= 240) and (x <= 260)]
+        assert found_troughs == []


### PR DESCRIPTION
* When finding signal level for SNR calculation, use maximum CWT coefficient on the ridge line, not CWT coefficient at the end of the ridge line
* Allow ridge lines with negative signal to be rejected due to low SNR
* Update documentation of `min_snr` parameter in `find_peaks_cwt` accordingly
* Add unit tests for both fixes

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy: 
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #23604
Closes #23684
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
This implements the definition of "signal" in signal-to-noise ratio as described in [1],
which is the reference listed in `_peak_finding.py` itself.
As a result, difference in SNR between true positives and false positives increases.
Higher values of the `min_snr` parameter can then be used without loss of true
positives, leading to better precision for `find_peaks_cwt`.
Furthermore, a subset of false positives (appearing at local minima between peaks)
is eliminated, because ridge lines with negative signal can no more meet a positive `min_snr` requirement.

<!--Please explain your changes.-->

#### Additional information
* This change may lead to _worse_ precision for some users before they raise the value of `min_snr` in the call to `find_peaks_cwt`. This is because the SNR of some false positives will also increase a little, possibly exceeding the value of `min_snr` currently in use.
* That the SNR calculation in [1] and SciPy ever differed seems to be an unintended omission: issuing
`git log --follow scipy/signal/_peak_finding.py`
and checking out the earliest listed commits reveals that the odd SNR calculation is already there in commit `3399829`, which dates back to 2011.
* This PR replaces
#23635
which ran into a CI issue and required a manual rebase. The only difference diff-wise is how the docstring of the `min_snr` parameter was updated. This PR only tries to deliver bugfixes while keeping the user-facing documentation true. 
<!--Any additional information you think is important.-->

#### References
[1] Bioinformatics (2006) 22 (17): 2059-2065.
doi:`10.1093/bioinformatics/btl355`


#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used.