### PR TITLE
ENH: add a blas_bint typedef to cython_blas

### DIFF
--- a/doc/source/building/blas_lapack.rst
+++ b/doc/source/building/blas_lapack.rst
@@ -186,6 +186,11 @@ not yet support 64-bit integers in their Cython BLAS/LAPACK calls.
 The build configuration can be checked at runtime via
 ``scipy.show_config()`` — look for the ``'blas cython ilp64'`` entry.
 
+Some LAPACK functions use boolean variables (Fortran ``logical``). For booleans,
+``cython_lapack`` uses the ``blas_bint`` type: when ``blas_int`` resolves to C ``int``,
+``blas_bint`` resolves to Cython's ``bint`` type; when ``blas_int`` resolves to
+``int64_t``, so does ``blas_bint``.
+
 
 Using Cython BLAS/LAPACK ABI in downstream packages
 """""""""""""""""""""""""""""""""""""""""""""""""""

--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -81,10 +81,15 @@ exported so that downstream packages can write code that works with
 both variants. The build configuration can be checked at runtime via
 ``scipy.show_config(mode='dicts')['Build Dependencies']['blas']['cython blas ilp64']``.
 
+Boolean (Fortran ``logical``) parameters in the function signatures use ``bint`` for
+LP64 builds and ``int64_t`` for ILP64 builds. A convenience typedef ``blas_bint`` is
+exported in a similar way to ``blas_int``.
+
 Downstream packages that want to support both LP64 and ILP64 builds of SciPy
 should follow this pattern:
 
-1. Use ``blas_int`` for all integer variables passed to BLAS functions.
+1. Use ``blas_int`` for all integer variables passed to BLAS functions. For boolean
+   variables, use ``blas_bint``.
 2. For backwards compatibility with scipy <=1.17.0 (if desired), perform a
    **build-time check** for whether ``blas_int`` is available, and typedef
    it as ``int`` otherwise. Example for Meson:
@@ -95,8 +100,10 @@ should follow this pattern:
     _blas_int_conf = configuration_data()
     if cython.compiles('from scipy.linalg.cython_blas cimport blas_int')
       _blas_int_conf.set('BLAS_INT_DEF', 'from scipy.linalg.cython_blas cimport blas_int')
+      _blas_int_conf.set('BLAS_BINT_DEF', 'from scipy.linalg.cython_blas cimport blas_bint')
     else
       _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
+      _blas_int_conf.set('BLAS_BINT_DEF', 'ctypedef bint blas_bint')
     endif
 
     _blas_int_pxi = configure_file(
@@ -105,17 +112,19 @@ should follow this pattern:
       configuration: _blas_int_conf,
     )
 
-With the file ``_blas_int.pxi.in`` containing the single line::
+With the file ``_blas_int.pxi.in`` containing two lines::
 
     @BLAS_INT_DEF@
+    @BLAS_BINT_DEF@
 
 
 ``cython_blas`` API
 -------------------
 
-Integer type:
+Integer types:
 
 - blas_int: convenience typedef for either ``int`` (LP64) or ``int64_t`` (ILP64)
+- blas_bint: convenience typedef for either ``bint`` (LP64) or ``int64_t`` (ILP64)
 
 Raw function pointers (Fortran-style pointer arguments):
 
@@ -171,10 +180,15 @@ exported so that downstream packages can write code that works with
 both variants. The build configuration can be checked at runtime via
 ``scipy.show_config(mode='dicts')['Build Dependencies']['blas']['cython blas ilp64']``.
 
+Boolean (Fortran ``logical``) parameters in the function signatures use ``bint`` for
+LP64 builds and ``int64_t`` for ILP64 builds. A convenience typedef ``blas_bint`` is
+exported in a similar way to ``blas_int``.
+
 Downstream packages that want to support both LP64 and ILP64 builds of SciPy
 should follow this pattern:
 
-1. Use ``blas_int`` for all integer variables passed to LAPACK functions.
+1. Use ``blas_int`` for all integer variables passed to LAPACK functions. For boolean
+   variables, use ``blas_bint``.
 2. For backwards compatibility with scipy <=1.17.0 (if desired), perform a
    **build-time check** for whether ``blas_int`` is available, and typedef
    it as ``int`` otherwise. Example for Meson:
@@ -185,8 +199,10 @@ should follow this pattern:
     _blas_int_conf = configuration_data()
     if cython.compiles('from scipy.linalg.cython_lapack cimport blas_int')
       _blas_int_conf.set('BLAS_INT_DEF', 'from scipy.linalg.cython_lapack cimport blas_int')
+      _blas_int_conf.set('BLAS_BINT_DEF', 'from scipy.linalg.cython_lapack cimport blas_bint')
     else
       _blas_int_conf.set('BLAS_INT_DEF', 'ctypedef int blas_int')
+      _blas_int_conf.set('BLAS_BINT_DEF', 'ctypedef bint blas_bint')
     endif
 
     _blas_int_pxi = configure_file(
@@ -195,17 +211,19 @@ should follow this pattern:
       configuration: _blas_int_conf,
     )
 
-With the file ``_blas_int.pxi.in`` containing the single line::
+With the file ``_blas_int.pxi.in`` containing two lines::
 
     @BLAS_INT_DEF@
+    @BLAS_BINT_DEF@
 
 
 ``cython_lapack`` API
 ---------------------
 
-Integer type:
+Integer types:
 
 - blas_int: convenience typedef for either ``int`` (LP64) or ``int64_t`` (ILP64)
+- blas_bint: convenience typedef for either ``bint`` (LP64) or ``int64_t`` (ILP64)
 
 Raw function pointers (Fortran-style pointer arguments):
 

--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -445,6 +445,10 @@ cpdef double complex _test_zdotu(double complex[:] zx, double complex[:] zy) noe
 def _blas_int_size():
     # Return the size of blas_int in bytes.
     return sizeof(blas_int)
+
+def _blas_bint_bint_sizes():
+    "Return a tuple of (size of blas_bint in bytes, size of bint in bytes)."
+    return sizeof(blas_bint), sizeof(bint)
 """
 
 lapack_py_wrappers = """
@@ -472,6 +476,14 @@ cpdef double complex _test_zladiv(double complex zx, double complex zy) noexcept
 
 cpdef float complex _test_cladiv(float complex cx, float complex cy) noexcept nogil:
     return cladiv(&cx, &cy)
+
+def _blas_int_size():
+    # Return the size of blas_int in bytes.
+    return sizeof(blas_int)
+
+def _blas_bint_bint_sizes():
+    "Return a tuple of (size of blas_bint in bytes, size of bint in bytes)."
+    return sizeof(blas_bint), sizeof(bint)
 """
 
 

--- a/scipy/linalg/_generate_pyx.py
+++ b/scipy/linalg/_generate_pyx.py
@@ -575,6 +575,7 @@ ctypedef float complex c
 ctypedef double complex z
 
 ctypedef int blas_int
+ctypedef bint blas_bint
 
 """
 
@@ -587,6 +588,7 @@ ctypedef float complex c
 ctypedef double complex z
 
 ctypedef int64_t blas_int
+ctypedef int64_t blas_bint
 
 """
 

--- a/scipy/linalg/tests/test_cython_blas.py
+++ b/scipy/linalg/tests/test_cython_blas.py
@@ -17,6 +17,13 @@ class TestBlasInt:
         else:
             assert size == 4, f"LP64 build but blas_int is {size} bytes"
 
+        # also verify blas_bint size
+        bint_sizes = blas._blas_bint_bint_sizes()  # (sizeof(blas_bint), sizeof(bint))
+        if cython_blas_ilp64:
+            assert bint_sizes == (8, 4)
+        else:
+            assert bint_sizes == (4, 4)
+
     def test_dgemm_with_blas_int_dimensions(self):
         """Test dgemm works correctly - exercises blas_int for dimensions."""
         a = np.eye(3, dtype=np.float64)

--- a/scipy/linalg/tests/test_cython_lapack.py
+++ b/scipy/linalg/tests/test_cython_lapack.py
@@ -27,3 +27,30 @@ class TestLamch:
         cy = .875 + 2.j
         assert_allclose(cython_lapack._test_zladiv(cy, cx), 1.95+0.1j)
         assert_allclose(cython_lapack._test_cladiv(cy, cx), 1.95+0.1j)
+
+
+class TestBlasInt:
+    """Test for blas_int/blas_bint types used in cython_blas/cython_lapack.
+
+    Note similar test is in test_blas.py: both cython_blas.pyx and cython_lapack.pyx
+    define the types, so we smoke test that `blas_int` and `blas_bint` types
+    can be cimported from both `cython_blas` and `cython_lapack` extensions.
+    """
+
+    def test_blas_int_size(self):
+        """Verify blas_int and blas_bint sizes matches the build configuration."""
+        from scipy.__config__ import CONFIG
+        size = cython_lapack._blas_int_size()
+        cython_blas_ilp64 = CONFIG['Build Dependencies']['blas']['cython blas ilp64']
+        if cython_blas_ilp64:
+            assert size == 8, f"ILP64 build but blas_int is {size} bytes"
+        else:
+            assert size == 4, f"LP64 build but blas_int is {size} bytes"
+
+        # also verify blas_bint size
+        # bint_sizes is a 2-tuple, (sizeof(blas_bint), sizeof(bint))
+        bint_sizes = cython_lapack._blas_bint_bint_sizes()
+        if cython_blas_ilp64:
+            assert bint_sizes == (8, 4)
+        else:
+            assert bint_sizes == (4, 4)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

intends to close https://github.com/scipy/scipy/issues/25076

#### What does this implement/fix?
<!--Please explain your changes.-->

Help downstream `cython_lapack` users cope with LP64 / ILP64 builds. This is for those unlucky ones who use Fortran `logical` variables, which are `bint` or `int64_t` in `cython_lapack`. See https://github.com/scipy/scipy/issues/25076 for discussion.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai