### PR TITLE
BUG: optimize.direct: Prevent crash when running direct on empty Bounds

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -292,6 +292,8 @@ class Bounds:
     __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def _input_validation(self):
+        if self.lb.size == 0 or self.ub.size == 0:
+            raise ValueError("`lb` and `ub` must be non-empty.")
         try:
             res = np.broadcast_arrays(self.lb, self.ub, self.keep_feasible)
             self.lb, self.ub, self.keep_feasible = res

--- a/scipy/optimize/_direct/direct_wrap.c
+++ b/scipy/optimize/_direct/direct_wrap.c
@@ -69,7 +69,13 @@ PyObject* direct_optimize(
      if (fglobal == DIRECT_UNKNOWN_FGLOBAL)
       fglobal_reltol = DIRECT_UNKNOWN_FGLOBAL_RELTOL;
 
-     if (dimension < 1) *ret_code = DIRECT_INVALID_ARGS;
+     /* Quit early on zero-dimension input. See gh-25086. */
+     if (dimension < 1) {
+      PyErr_Format(PyExc_ValueError,
+              "DIRECT requires at least one dimension, got %d", dimension);
+      *ret_code = DIRECT_INVALID_ARGS;
+      return NULL;
+     }
 
      l = (doublereal *) malloc(sizeof(doublereal) * dimension * 2);
      if (!l) *ret_code = DIRECT_OUT_OF_MEMORY;

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -212,6 +212,14 @@ class TestBounds:
         with pytest.raises(ValueError, match=message):
             Bounds([1, 2], [1, 2, 3])
 
+        # gh-25086: empty `lb`/`ub` describes a zero-variable problem, and
+        # rejecting early prevents issues in downstream optimizers.
+        message = "`lb` and `ub` must be non-empty"
+        with pytest.raises(ValueError, match=message):
+            Bounds([], [])
+        with pytest.raises(ValueError, match=message):
+            Bounds(np.array([]), np.array([]))
+
     def test_residual(self):
         bounds = Bounds(-2, 4)
         x0 = [-1, 2]

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -217,8 +217,6 @@ class TestBounds:
         message = "`lb` and `ub` must be non-empty"
         with pytest.raises(ValueError, match=message):
             Bounds([], [])
-        with pytest.raises(ValueError, match=message):
-            Bounds(np.array([]), np.array([]))
 
     def test_residual(self):
         bounds = Bounds(-2, 4)

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -318,9 +318,9 @@ class TestDIRECT:
         # Bounds() init time, but the C kernel has an additional
         # defense-in-depth check, which we exercise here.
         bounds = Bounds([-1.0], [1.0])
-        bounds.lb = np.array([], dtype=np.float64)
-        bounds.ub = np.array([], dtype=np.float64)
-        error_msg = "DIRECT requires at least one dimension"
+        bounds.lb = []
+        bounds.ub = []
+        error_msg = "DIRECT requires at least one dimension, got 0"
         with pytest.raises(ValueError, match=error_msg):
             direct(self.styblinski_tang, bounds)
 

--- a/scipy/optimize/tests/test_direct.py
+++ b/scipy/optimize/tests/test_direct.py
@@ -313,6 +313,17 @@ class TestDIRECT:
         with pytest.raises(ValueError, match=error_msg):
             direct(self.styblinski_tang, bounds)
 
+    def test_empty_bounds(self):
+        # gh-25086: empty Bounds() is invalid. This is checked at
+        # Bounds() init time, but the C kernel has an additional
+        # defense-in-depth check, which we exercise here.
+        bounds = Bounds([-1.0], [1.0])
+        bounds.lb = np.array([], dtype=np.float64)
+        bounds.ub = np.array([], dtype=np.float64)
+        error_msg = "DIRECT requires at least one dimension"
+        with pytest.raises(ValueError, match=error_msg):
+            direct(self.styblinski_tang, bounds)
+
     @pytest.mark.parametrize("locally_biased", ["bias", [0, 0], 2.])
     def test_locally_biased_validation(self, locally_biased):
         error_msg = 'locally_biased must be True or False.'


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Closes https://github.com/scipy/scipy/issues/25086

#### What does this implement/fix?
<!--Please explain your changes.-->

Empty `Bounds([], [])` meant an invalid problem, but there was no init-time check to prevent this, and the `direct` kernel would crash on invalid input.

Two changes here: `Bounds([], [])` will now raise a value error, and even if a caller manages to bypass that, either by mutating the object after construction, or by invoking the kernel directly, there's now a C-level check that will bubble up a friendly exception on 0-dimension problems.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Claude (opus 4.7) did the first pass for me; I reworked most of the comments (it added so many!!), fixed a test case, and added the kernel-level check.
