### PR TITLE
DOC: scipy.special: improve documentation for orthogonal polynomials

### DIFF
--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1506,10 +1506,23 @@ def fresnel_zeros(nt):
 
 
 def assoc_laguerre(x, n, k=0.0):
-    """Compute the generalized (associated) Laguerre polynomial of degree n and order k.
+    r"""Compute the generalized (associated) Laguerre polynomial of degree :math:`n`
+    and order :math:`k`.
 
-    The polynomial :math:`L^{(k)}_n(x)` is orthogonal over ``[0, inf)``,
-    with weighting function ``exp(-x) * x**k`` with ``k > -1``.
+    This function evaluates the generalized Laguerre polynomial
+
+    .. math::
+
+        L^{(k)}_n(x).
+
+    The polynomial is orthogonal over :math:`[0, \infty)` with weight
+    function
+
+    .. math::
+
+        e^{-x}x^k
+
+    for :math:`k > -1`.
 
     Parameters
     ----------

--- a/scipy/special/_basic.py
+++ b/scipy/special/_basic.py
@@ -1543,6 +1543,35 @@ def assoc_laguerre(x, n, k=0.0):
     `assoc_laguerre` is a simple wrapper around `eval_genlaguerre`, with
     reversed argument order ``(x, n, k=0.0) --> (n, k, x)``.
 
+    Examples
+    --------
+    Evaluate the associated Laguerre polynomial :math:`L_3^{(2)}` at
+    :math:`x = 1`:
+
+    >>> import numpy as np
+    >>> from scipy.special import assoc_laguerre, eval_genlaguerre
+    >>> np.isclose(assoc_laguerre(1, 3, 2), 7/3)
+    True
+
+    `assoc_laguerre` is equivalent to `eval_genlaguerre` with reversed
+    argument order:
+
+    >>> x = np.linspace(0, 5, 6)
+    >>> np.allclose(assoc_laguerre(x, 3, 2), eval_genlaguerre(3, 2, x))
+    True
+
+    Plot :math:`L_3^{(k)}` for several values of :math:`k`:
+
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(0, 8, 400)
+    >>> fig, ax = plt.subplots()
+    >>> for k in range(3):
+    ...     ax.plot(x, assoc_laguerre(x, 3, k), label=rf"$k={k}$")
+    >>> ax.set_title(r"Associated Laguerre polynomials $L_3^{(k)}$")
+    >>> ax.set_xlabel("x")
+    >>> ax.legend(loc="best")
+    >>> plt.show()
+
     """
     return _ufuncs.eval_genlaguerre(n, k, x)
 

--- a/scipy/special/_multiufuncs.py
+++ b/scipy/special/_multiufuncs.py
@@ -252,6 +252,17 @@ assoc_legendre_p = MultiUFunc(
 
     Associated Legendre polynomial of the first kind.
 
+    Defined as
+
+    .. math::
+
+        P_n^m(z) = (-1)^m (1 - z^2)^{m/2}
+            \frac{d^m}{dz^m} P_n(z)
+
+    where :math:`P_n` is the Legendre polynomial.
+
+    This definition includes the Condon-Shortley phase :math:`(-1)^m`.
+
     Parameters
     ----------
     n : ArrayLike[int]
@@ -284,6 +295,23 @@ assoc_legendre_p = MultiUFunc(
     .. math::
 
         \sqrt{\frac{(2 n + 1) (n - m)!}{2 (n + m)!}}
+
+    Examples
+    --------
+    Evaluate :math:`P_2^1(z)` on :math:`[-1, 1]`:
+
+    >>> import numpy as np
+    >>> from scipy.special import assoc_legendre_p
+    >>> z = np.linspace(-1, 1, 11)
+    >>> expected = -3 * z * np.sqrt(1 - z**2)
+    >>> np.allclose(assoc_legendre_p(2, 1, z), expected)
+    True
+
+    Compute the normalized associated Legendre polynomial:
+
+    >>> scale = np.sqrt(5/12)
+    >>> np.allclose(assoc_legendre_p(2, 1, z, norm=True), scale * expected)
+    True
     """, branch_cut=2, norm=False, diff_n=0
 )
 

--- a/scipy/special/_multiufuncs.py
+++ b/scipy/special/_multiufuncs.py
@@ -432,6 +432,21 @@ legendre_p = MultiUFunc(
     .. [1] Zhang, Shanjie and Jin, Jianming. "Computation of Special
            Functions", John Wiley and Sons, 1996.
            https://people.sc.fsu.edu/~jburkardt/f77_src/special_functions/special_functions.html
+
+    Examples
+    --------
+    Evaluate the Legendre polynomial :math:`P_3` at :math:`z = 0.5`:
+
+    >>> import numpy as np
+    >>> from scipy.special import legendre_p
+    >>> np.allclose(legendre_p(3, 0.5), -0.4375)
+    True
+
+    Compute the value and first derivative with respect to ``z``:
+
+    >>> p, dp = legendre_p(3, 0.5, diff_n=1)
+    >>> np.allclose([p, dp], [-0.4375, 0.375])
+    True
     """, diff_n=0
 )
 

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2163,7 +2163,7 @@ def chebys(n, monic=False):
     Notes
     -----
     The polynomials :math:`S_n(x)` are orthogonal over :math:`[-2, 2]`
-    with weight function :math:`\sqrt{1 - (x/2)}^2`.
+    with weight function :math:`\sqrt{1 - (x/2)^2}`.
 
     References
     ----------

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -312,10 +312,13 @@ def jacobi(n, alpha, beta, monic=False):
     Defined to be the solution of
 
     .. math::
-        (1 - x^2)\frac{d^2}{dx^2}P_n^{(\alpha, \beta)}
-          + (\beta - \alpha - (\alpha + \beta + 2)x)
-            \frac{d}{dx}P_n^{(\alpha, \beta)}
-          + n(n + \alpha + \beta + 1)P_n^{(\alpha, \beta)} = 0
+
+        \begin{aligned}
+        (1 - x^2)\frac{d^2}{dx^2} P_n^{(\alpha, \beta)}(x)
+        &+ \left(\beta - \alpha - (\alpha + \beta + 2)x\right)
+        \frac{d}{dx} P_n^{(\alpha, \beta)}(x) \\
+        &+ n(n + \alpha + \beta + 1) P_n^{(\alpha, \beta)}(x) = 0
+        \end{aligned}
 
     for :math:`\alpha, \beta > -1`; :math:`P_n^{(\alpha, \beta)}` is a
     polynomial of degree :math:`n`.

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -493,6 +493,38 @@ def sh_jacobi(n, p, q, monic=False):
     orthogonal over :math:`[0, 1]` with weight function :math:`(1 -
     x)^{p - q}x^{q - 1}`.
 
+    Examples
+    --------
+    Evaluate the shifted Jacobi polynomial :math:`G_3^{(2, 1)}` at
+    :math:`x = 0.5`:
+
+    >>> import numpy as np
+    >>> from scipy.special import binom, jacobi, sh_jacobi
+    >>> np.isclose(sh_jacobi(3, 2, 1)(0.5), -3/280)
+    True
+
+    The polynomial is related to the Jacobi polynomial
+    :math:`P_n^{(p - q, q - 1)}`:
+
+    >>> x = np.linspace(0, 1, 5)
+    >>> n, p, q = 3, 2, 1
+    >>> scale = 1 / binom(2*n + p - 1, n)
+    >>> np.allclose(sh_jacobi(n, p, q)(x),
+    ...             scale * jacobi(n, p - q, q - 1)(2*x - 1))
+    True
+
+    Plot :math:`G_3^{(p, 1)}` for several values of :math:`p`:
+
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(0, 1, 400)
+    >>> fig, ax = plt.subplots()
+    >>> for p in [1, 2, 3]:
+    ...     ax.plot(x, sh_jacobi(3, p, 1)(x), label=rf"$p={p}$")
+    >>> ax.set_title(r"Shifted Jacobi polynomials $G_3^{(p, 1)}$")
+    >>> ax.set_xlabel("x")
+    >>> ax.legend(loc="best")
+    >>> plt.show()
+
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2231,6 +2231,33 @@ def chebys(n, monic=False):
     .. [1] Abramowitz and Stegun, "Handbook of Mathematical Functions"
            Section 22. National Bureau of Standards, 1972.
 
+    Examples
+    --------
+    Evaluate the Chebyshev polynomial of the second kind :math:`S_3` at :math:`x = 1`:
+
+    >>> import numpy as np
+    >>> from scipy.special import chebys, chebyu
+    >>> np.isclose(chebys(3)(1), -1.0)
+    True
+
+    The polynomial :math:`S_n` is a scaled Chebyshev polynomial of the
+    second kind:
+
+    >>> x = np.linspace(-2, 2, 5)
+    >>> np.allclose(chebys(3)(x), chebyu(3)(x/2))
+    True
+
+    Plot :math:`S_n` for several values of :math:`n`:
+
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(-2, 2, 400)
+    >>> fig, ax = plt.subplots()
+    >>> for n in range(4):
+    ...     ax.plot(x, chebys(n)(x), label=rf"$S_{n}$")
+    >>> ax.set_title(r"Chebyshev polynomials $S_n$")
+    >>> ax.set_xlabel("x")
+    >>> ax.legend(loc="best")
+    >>> plt.show()
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2099,6 +2099,33 @@ def chebyc(n, monic=False):
     .. [1] Abramowitz and Stegun, "Handbook of Mathematical Functions"
            Section 22. National Bureau of Standards, 1972.
 
+    Examples
+    --------
+    Evaluate the Chebyshev polynomial :math:`C_3` at :math:`x = 1`:
+
+    >>> import numpy as np
+    >>> from scipy.special import chebyc, chebyt
+    >>> np.isclose(chebyc(3)(1), -2.0)
+    True
+
+    The polynomial :math:`C_n` is a scaled Chebyshev polynomial of the
+    first kind:
+
+    >>> x = np.linspace(-2, 2, 5)
+    >>> np.allclose(chebyc(3)(x), 2 * chebyt(3)(x/2))
+    True
+
+    Plot :math:`C_n` for several values of :math:`n`:
+
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(-2, 2, 400)
+    >>> fig, ax = plt.subplots()
+    >>> for n in range(4):
+    ...     ax.plot(x, chebyc(n)(x), label=rf"$C_{n}$")
+    >>> ax.set_title(r"Chebyshev polynomials $C_n$")
+    >>> ax.set_xlabel("x")
+    >>> ax.legend(loc="best")
+    >>> plt.show()
     """
     if n < 0:
         raise ValueError("n must be nonnegative.")

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -1764,7 +1764,8 @@ def chebyt(n, monic=False):
     Defined to be the solution of
 
     .. math::
-        (1 - x^2)\frac{d^2}{dx^2}T_n - x\frac{d}{dx}T_n + n^2T_n = 0;
+        (1 - x^2)\frac{d^2}{dx^2}T_n(x) - x\frac{d}{dx}T_n(x)
+          + n^2T_n(x) = 0;
 
     :math:`T_n` is a polynomial of degree :math:`n`.
 
@@ -1924,8 +1925,8 @@ def chebyu(n, monic=False):
     Defined to be the solution of
 
     .. math::
-        (1 - x^2)\frac{d^2}{dx^2}U_n - 3x\frac{d}{dx}U_n
-          + n(n + 2)U_n = 0;
+        (1 - x^2)\frac{d^2}{dx^2}U_n(x) - 3x\frac{d}{dx}U_n(x)
+          + n(n + 2)U_n(x) = 0;
 
     :math:`U_n` is a polynomial of degree :math:`n`.
 

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -223,9 +223,9 @@ def roots_jacobi(n, alpha, beta, mu=False):
     n : int
         Quadrature order.
     alpha : float
-        alpha must be > -1
+        alpha must be > -1.
     beta : float
-        beta must be > -1
+        beta must be > -1.
     mu : bool, optional
         If True, return the sum of the weights in addition to sample points and weights.
 
@@ -419,11 +419,11 @@ def roots_sh_jacobi(n, p1, q1, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order
+        quadrature order.
     p1 : float
-        (p1 - q1) must be > -1
+        (p1 - q1) must be > -1.
     q1 : float
-        q1 must be > 0
+        q1 must be > 0.
     mu : bool, optional
         If True, return the sum of the weights, optional.
 
@@ -1405,18 +1405,18 @@ def roots_hermitenorm(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order
+        quadrature order.
     mu : bool, optional
         If True, return the sum of the weights, optional.
 
     Returns
     -------
     x : ndarray
-        Sample points
+        Sample points.
     w : ndarray
-        Weights
+        Weights.
     mu : float
-        Sum of the weights
+        Sum of the weights.
 
     See Also
     --------
@@ -1562,9 +1562,9 @@ def roots_gegenbauer(n, alpha, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order
+        quadrature order.
     alpha : float
-        alpha must be > -0.5
+        alpha must be > -0.5.
     mu : bool, optional
         If True, return the sum of the weights, optional.
 
@@ -1990,7 +1990,7 @@ def chebyu(n, monic=False):
     .. math::
         U_{2n-1}(x) = 2 T_n(x)U_{n-1}(x)
 
-    where the :math:`T_n` are the Chebyshev polynomial of the first kind.
+    where :math:`T_n` is the Chebyshev polynomial of the first kind.
     Let's verify it for :math:`n = 2`:
 
     >>> from scipy.special import chebyt
@@ -2073,7 +2073,7 @@ def chebyc(n, monic=False):
     r"""Chebyshev polynomial of the first kind on :math:`[-2, 2]`.
 
     Defined as :math:`C_n(x) = 2T_n(x/2)`, where :math:`T_n` is the
-    nth Chebychev polynomial of the first kind.
+    nth Chebyshev polynomial of the first kind.
 
     Parameters
     ----------
@@ -2205,7 +2205,7 @@ def chebys(n, monic=False):
     r"""Chebyshev polynomial of the second kind on :math:`[-2, 2]`.
 
     Defined as :math:`S_n(x) = U_n(x/2)` where :math:`U_n` is the
-    nth Chebychev polynomial of the second kind.
+    nth Chebyshev polynomial of the second kind.
 
     Parameters
     ----------
@@ -2300,18 +2300,18 @@ def roots_sh_chebyt(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order
+        quadrature order.
     mu : bool, optional
         If True, return the sum of the weights, optional.
 
     Returns
     -------
     x : ndarray
-        Sample points
+        Sample points.
     w : ndarray
-        Weights
+        Weights.
     mu : float
-        Sum of the weights
+        Sum of the weights.
 
     See Also
     --------
@@ -2519,18 +2519,18 @@ def roots_legendre(n, mu=False):
     Parameters
     ----------
     n : int
-        quadrature order
+        quadrature order.
     mu : bool, optional
         If True, return the sum of the weights, optional.
 
     Returns
     -------
     x : ndarray
-        Sample points
+        Sample points.
     w : ndarray
-        Weights
+        Weights.
     mu : float
-        Sum of the weights
+        Sum of the weights.
 
     See Also
     --------

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -1307,7 +1307,7 @@ def hermite(n, monic=False):
     Returns
     -------
     H : orthopoly1d
-        Hermite polynomial.
+        Physicist's Hermite polynomial.
 
     Notes
     -----
@@ -1432,7 +1432,7 @@ def roots_hermitenorm(n, mu=False):
 
 
 def hermitenorm(n, monic=False):
-    r"""Normalized (probabilist's) Hermite polynomial.
+    r"""Probabilist's Hermite polynomial.
 
     Defined by
 
@@ -1453,7 +1453,7 @@ def hermitenorm(n, monic=False):
     Returns
     -------
     He : orthopoly1d
-        Hermite polynomial.
+        Probabilist's Hermite polynomial.
 
     Notes
     -----

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -678,9 +678,7 @@ def genlaguerre(n, alpha, monic=False):
     interval :math:`[-1, 1]`:
 
     >>> import numpy as np
-    >>> from scipy.special import binom
-    >>> from scipy.special import genlaguerre
-    >>> from scipy.special import hyp1f1
+    >>> from scipy.special import binom, genlaguerre, hyp1f1
     >>> x = np.arange(-1.0, 1.0, 0.01)
     >>> np.allclose(genlaguerre(3, 3)(x), binom(6, 3) * hyp1f1(-3, 4, x))
     True
@@ -694,7 +692,7 @@ def genlaguerre(n, alpha, monic=False):
     >>> ax.set_ylim(-5.0, 10.0)
     >>> ax.set_title(r'Generalized Laguerre polynomials $L_3^{(\alpha)}$')
     >>> for alpha in np.arange(0, 5):
-    ...     ax.plot(x, genlaguerre(3, alpha)(x), label=rf"$L_3^{{(\alpha)}}$")
+    ...     ax.plot(x, genlaguerre(3, alpha)(x), label=rf"$L_3^{{({alpha})}}$")
     >>> plt.legend(loc='best')
     >>> plt.show()
 

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -589,9 +589,9 @@ def genlaguerre(n, alpha, monic=False):
     Defined to be the solution of
 
     .. math::
-        x\frac{d^2}{dx^2}L_n^{(\alpha)}
-          + (\alpha + 1 - x)\frac{d}{dx}L_n^{(\alpha)}
-          + nL_n^{(\alpha)} = 0,
+        x\frac{d^2}{dx^2}L_n^{(\alpha)}(x)
+          + (\alpha + 1 - x)\frac{d}{dx}L_n^{(\alpha)}(x)
+          + nL_n^{(\alpha)}(x) = 0,
 
     where :math:`\alpha > -1`; :math:`L_n^{(\alpha)}` is a polynomial
     of degree :math:`n`.
@@ -637,7 +637,7 @@ def genlaguerre(n, alpha, monic=False):
     hypergeometric function :math:`{}_1F_1`:
 
         .. math::
-            L_n^{(\alpha)} = \binom{n + \alpha}{n} {}_1F_1(-n, \alpha +1, x)
+            L_n^{(\alpha)}(x) = \binom{n + \alpha}{n} {}_1F_1(-n, \alpha +1, x)
 
     This can be verified, for example,  for :math:`n = \alpha = 3` over the
     interval :math:`[-1, 1]`:

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -689,9 +689,9 @@ def genlaguerre(n, alpha, monic=False):
     >>> x = np.arange(-4.0, 12.0, 0.01)
     >>> fig, ax = plt.subplots()
     >>> ax.set_ylim(-5.0, 10.0)
-    >>> ax.set_title(r'Generalized Laguerre polynomials $L_3^{\alpha}$')
+    >>> ax.set_title(r'Generalized Laguerre polynomials $L_3^{(\alpha)}$')
     >>> for alpha in np.arange(0, 5):
-    ...     ax.plot(x, genlaguerre(3, alpha)(x), label=rf'$L_3^{(alpha)}$')
+    ...     ax.plot(x, genlaguerre(3, alpha)(x), label=rf"$L_3^{{(\alpha)}}$")
     >>> plt.legend(loc='best')
     >>> plt.show()
 

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -734,7 +734,8 @@ def laguerre(n, monic=False):
     Defined to be the solution of
 
     .. math::
-        x\frac{d^2}{dx^2}L_n + (1 - x)\frac{d}{dx}L_n + nL_n = 0;
+        x\frac{d^2}{dx^2}L_n(x) + (1 - x)\frac{d}{dx}L_n(x)
+          + nL_n(x) = 0;
 
     :math:`L_n` is a polynomial of degree :math:`n`.
 

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -1686,7 +1686,7 @@ def gegenbauer(n, alpha, monic=False):
     >>> ax.plot(x, y)
     >>> ax.set_title("Gegenbauer (ultraspherical) polynomial of degree 3")
     >>> ax.set_xlabel("x")
-    >>> ax.set_ylabel("G_3(x)")
+    >>> ax.set_ylabel(r"$C_3^{(0.5)}(x)$")
     >>> plt.show()
 
     """

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2436,6 +2436,35 @@ def sh_chebyu(n, monic=False):
     The polynomials :math:`U^*_n` are orthogonal over :math:`[0, 1]`
     with weight function :math:`(x - x^2)^{1/2}`.
 
+    Examples
+    --------
+    Evaluate the shifted Chebyshev polynomial of the second kind :math:`U^*_3` at
+    :math:`x = 0.75`:
+
+    >>> import numpy as np
+    >>> from scipy.special import chebyu, sh_chebyu
+    >>> np.isclose(sh_chebyu(3)(0.75), -1.0)
+    True
+
+    The polynomial :math:`U^*_n` is the Chebyshev polynomial
+    :math:`U_n` shifted from :math:`[-1, 1]` to :math:`[0, 1]`:
+
+    >>> x = np.linspace(0, 1, 5)
+    >>> np.allclose(sh_chebyu(3)(x), chebyu(3)(2*x - 1))
+    True
+
+    Plot :math:`U^*_n` for several values of :math:`n`:
+
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(0, 1, 400)
+    >>> fig, ax = plt.subplots()
+    >>> for n in range(4):
+    ...     ax.plot(x, sh_chebyu(n)(x), label=rf"$U^*_{n}$")
+    >>> ax.set_title(r"Shifted Chebyshev polynomials $U^*_n$")
+    >>> ax.set_xlabel("x")
+    >>> ax.legend(loc="best")
+    >>> plt.show()
+
     """
     base = sh_jacobi(n, 2.0, 1.5, monic=monic)
     if monic:

--- a/scipy/special/_orthogonal.py
+++ b/scipy/special/_orthogonal.py
@@ -2322,6 +2322,35 @@ def sh_chebyt(n, monic=False):
     The polynomials :math:`T^*_n` are orthogonal over :math:`[0, 1]`
     with weight function :math:`(x - x^2)^{-1/2}`.
 
+    Examples
+    --------
+    Evaluate the shifted Chebyshev polynomial of the first kind :math:`T^*_3` at
+    :math:`x = 0.75`:
+
+    >>> import numpy as np
+    >>> from scipy.special import chebyt, sh_chebyt
+    >>> np.isclose(sh_chebyt(3)(0.75), -1.0)
+    True
+
+    The polynomial :math:`T^*_n` is the Chebyshev polynomial
+    :math:`T_n` shifted from :math:`[-1, 1]` to :math:`[0, 1]`:
+
+    >>> x = np.linspace(0, 1, 5)
+    >>> np.allclose(sh_chebyt(3)(x), chebyt(3)(2*x - 1))
+    True
+
+    Plot :math:`T^*_n` for several values of :math:`n`:
+
+    >>> import matplotlib.pyplot as plt
+    >>> x = np.linspace(0, 1, 400)
+    >>> fig, ax = plt.subplots()
+    >>> for n in range(4):
+    ...     ax.plot(x, sh_chebyt(n)(x), label=rf"$T^*_{n}$")
+    >>> ax.set_title(r"Shifted Chebyshev polynomials $T^*_n$")
+    >>> ax.set_xlabel("x")
+    >>> ax.legend(loc="best")
+    >>> plt.show()
+
     """
     base = sh_jacobi(n, 0.0, 0.5, monic=monic)
     if monic:


### PR DESCRIPTION
#### Reference issue
Towards https://github.com/scipy/scipy/issues/7168

#### What does this implement/fix?
This PR improves the documentation of orthogonal polynomials by

Fixing typos, strengthening definitions, and adding examples for 

- `assoc_laguerre`
-  `assoc_legendre_p`
- `sh_jacobi`
-  `chebyc`
-   `chebys`
-  `sh_chebyt`
- `sh_chebyu`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
Codex helped me find typos and suggested the examples. I have checked the rendered outputs locally. The rest is mine.