### PR TITLE
ENH: stats: Implement _munp() for halfgennorm.

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -11652,6 +11652,9 @@ class halfgennorm_gen(rv_continuous):
     def _isf(self, x, beta):
         return sc.gammainccinv(1.0/beta, x)**(1.0/beta)
 
+    def _munp(self, n, beta):
+        return sc.poch(1/beta, n/beta)
+
     def _entropy(self, beta):
         return 1.0/beta - np.log(beta) + sc.gammaln(1.0/beta)
 

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1135,7 +1135,7 @@ class TestMakeDistribution:
     def test_rv_generic(self, i, distdata):
         distname = distdata[0]
 
-        slow = {'argus', 'exponpow', 'exponweib', 'genexpon', 'gompertz', 'halfgennorm',
+        slow = {'argus', 'exponpow', 'exponweib', 'genexpon', 'gompertz',
                 'johnsonsb', 'kappa4', 'ksone', 'kstwo', 'kstwobign', 'norminvgauss',
                 'powerlognorm', 'powernorm', 'recipinvgauss', 'studentized_range',
                 'vonmises_line'}  # continuous

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -61,7 +61,7 @@ xfail_fit_mle = {'ksone', 'kstwo', 'truncpareto', 'irwinhall'}
 skip_fit_mle = {'levy_stable', 'studentized_range'}  # far too slow (>10min)
 slow_fit_mm = {'chi2', 'expon', 'lognorm', 'loguniform', 'powerlaw', 'reciprocal'}
 xslow_fit_mm = {'argus', 'beta', 'exponpow', 'gausshyper', 'gengamma',
-                'genhalflogistic', 'geninvgauss', 'gompertz', 'halfgennorm',
+                'genhalflogistic', 'geninvgauss', 'gompertz',
                 'johnsonsb', 'kstwobign', 'ncx2', 'norminvgauss', 'trapezoid',
                 'truncnorm', 'truncweibull_min', 'wrapcauchy'}
 xfail_fit_mm = {'alpha', 'betaprime', 'bradford', 'burr', 'burr12', 'cauchy',

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1706,6 +1706,55 @@ class TestHalfgennorm:
         pdf2 = stats.gennorm.pdf(points, .497324)
         assert_almost_equal(pdf1, 2*pdf2)
 
+    # Reference values (e.g. for n=3, beta=1.25)
+    #    from mpmath import mp
+    #    mp.dps = 100
+    #    n = 3
+    #    beta = mp.mpf(1.25)
+    #    ref = float(mp.gamma((n + 1)/beta) / mp.gamma(1/beta))
+    @pytest.mark.parametrize('n, beta, ref',
+                             [(0, 2.25, 1),
+                              (1, 0.5, 6.0),
+                              (2, 12.5, 0.3155489903298712),
+                              (3, 0.125, 1.631515605987683e+30)])
+    def test_munp(self, n, beta, ref):
+        munp = stats.halfgennorm._munp(n, beta)
+        assert_allclose(munp, ref, rtol=5e-15)
+
+    # Reference values (e.g. for beta=0.02)
+    #    from mpmath import mp
+    #    mp.dps = 100
+    #    beta = mp.mpf(0.02)
+    #    ref = float(mp.gamma(2/beta) / mp.gamma(1/beta))
+    @pytest.mark.parametrize('beta, ref',
+                             [(0.02, 1.5342593781274747e+93),
+                              (0.125, 259459200.0),
+                              (0.5, 6.0),
+                              (10.0, 0.48256057149575027),
+                              (125.0, 0.49777435261046765),
+                              (15000.0, 0.49998076533051666)])
+    def test_mean(self, beta, ref):
+        m = stats.halfgennorm.mean(beta)
+        assert_allclose(m, ref, rtol=1e-14)
+
+    # Reference values (e.g. for beta=0.02)
+    #    from mpmath import mp
+    #    mp.dps = 100
+    #    beta = mp.mpf(0.02)
+    #    mu = mp.gamma(2/beta)/mp.gamma(1/beta)
+    #    # var = E(X**2) - E(X)**2:
+    #    ref = float(mp.gamma(3/beta)/mp.gamma(1/beta) - mu**2)
+    @pytest.mark.parametrize('beta, ref',
+                             [(0.02, 6.261772482175519e+197),
+                              (0.125, 5.062049324107776e+18),
+                              (0.5, 84.0),
+                              (10.0, 0.08159018176717249),
+                              (125.0, 0.0826270885971827),
+                              (15000.0, 0.08332692433644018)])
+    def test_var(self, beta, ref):
+        v = stats.halfgennorm.var(beta)
+        assert_allclose(v, ref, rtol=1.5e-14)
+
 
 class TestLaplaceasymmetric:
     def test_laplace(self):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -1711,7 +1711,7 @@ class TestHalfgennorm:
     #    mp.dps = 100
     #    n = 3
     #    beta = mp.mpf(1.25)
-    #    ref = float(mp.gamma((n + 1)/beta) / mp.gamma(1/beta))
+    #    ref = float(mp.rf(1/beta, n/beta))
     @pytest.mark.parametrize('n, beta, ref',
                              [(0, 2.25, 1),
                               (1, 0.5, 6.0),
@@ -1725,7 +1725,7 @@ class TestHalfgennorm:
     #    from mpmath import mp
     #    mp.dps = 100
     #    beta = mp.mpf(0.02)
-    #    ref = float(mp.gamma(2/beta) / mp.gamma(1/beta))
+    #    ref = float(mp.rf(1/beta, 1/beta))
     @pytest.mark.parametrize('beta, ref',
                              [(0.02, 1.5342593781274747e+93),
                               (0.125, 259459200.0),
@@ -1741,9 +1741,9 @@ class TestHalfgennorm:
     #    from mpmath import mp
     #    mp.dps = 100
     #    beta = mp.mpf(0.02)
-    #    mu = mp.gamma(2/beta)/mp.gamma(1/beta)
+    #    mu = mp.rf(1/beta, 1/beta)
     #    # var = E(X**2) - E(X)**2:
-    #    ref = float(mp.gamma(3/beta)/mp.gamma(1/beta) - mu**2)
+    #    ref = float(mp.rf(1/beta, 2/beta) - mu**2)
     @pytest.mark.parametrize('beta, ref',
                              [(0.02, 6.261772482175519e+197),
                               (0.125, 5.062049324107776e+18),

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -77,7 +77,7 @@ mm_failing_fits = ['alpha', 'betaprime', 'burr', 'burr12', 'cauchy', 'chi',
 
 # not sure if these fail, but they caused my patience to fail
 mm_XXslow_fits = ['argus', 'exponpow', 'exponweib', 'gausshyper', 'genexpon',
-                  'genhalflogistic', 'halfgennorm', 'gompertz', 'johnsonsb',
+                  'genhalflogistic', 'gompertz', 'johnsonsb',
                   'kappa4', 'kstwobign', 'recipinvgauss',
                   'truncexpon', 'vonmises', 'vonmises_line']
 
@@ -243,7 +243,7 @@ def cases_test_fit_mle():
                       'chi', 'crystalball', 'dweibull', 'erlang', 'exponnorm',
                       'exponpow', 'f', 'fatiguelife', 'fisk', 'foldcauchy', 'gamma',
                       'genexpon', 'genextreme', 'gennorm', 'genpareto',
-                      'gompertz', 'halfgennorm', 'invgamma', 'invgauss', 'invweibull',
+                      'gompertz', 'invgamma', 'invgauss', 'invweibull',
                       'jf_skew_t', 'johnsonsb', 'johnsonsu', 'kappa3',
                       'kstwobign', 'loglaplace', 'lognorm', 'lomax', 'mielke',
                       'nbinom', 'norminvgauss',
@@ -313,7 +313,7 @@ def cases_test_fit_mse():
     # Please keep this list in alphabetical order...
     xslow_basic_fit = {'argus', 'beta', 'betaprime', 'burr', 'burr12',
                        'dgamma', 'dpareto_lognorm', 'f', 'gengamma', 'gennorm',
-                       'halfgennorm', 'invgamma', 'invgauss', 'jf_skew_t',
+                       'invgamma', 'invgauss', 'jf_skew_t',
                        'johnsonsb', 'kappa4', 'loguniform', 'mielke',
                        'nakagami', 'ncf', 'nchypergeom_fisher',
                        'nchypergeom_wallenius', 'nct', 'ncx2',


### PR DESCRIPTION
`halfgennorm` is a special case of `gengamma`:

    halfgennorm(beta) = gengamma(a=1/beta, c=beta)

so the formula for the noncentral moments of `halfgennorm` can be derived from the formula for the noncentral moments of `gengamma`, resulting in

    mu'_n = Gamma((n + 1)/beta) / Gamma(1/beta)
          = poch(1/beta, n/beta)

Before this change, moments were being calculated using numerical integration, so several tests were slow.  By using the formula, we can remove `halfgennorm` from several of the slow/xslow test groups.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used.