### PR TITLE
BUG: signal: fix RecursionError in cspline1d_eval/qspline1d_eval for N=1

### DIFF
--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -585,6 +585,9 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
     if res.size == 0:
         return xp.asarray(res)
     N = len(cj)
+    if N == 1:
+        res[:] = cj[0]
+        return xp.asarray(res)
     cond1 = newx < 0
     cond2 = newx > (N - 1)
     cond3 = ~(cond1 | cond2)
@@ -668,6 +671,9 @@ def qspline1d_eval(cj, newx, dx=1.0, x0=0):
         raise ValueError("Spline coefficients 'cj' must not be empty.")
     
     N = len(cj)
+    if N == 1:
+        res[:] = cj[0]
+        return xp.asarray(res)
     cond1 = newx < 0
     cond2 = newx > (N - 1)
     cond3 = ~(cond1 | cond2)

--- a/scipy/signal/tests/test_bsplines.py
+++ b/scipy/signal/tests/test_bsplines.py
@@ -200,6 +200,11 @@ class TestBSplines:
             signal.cspline1d_eval(xp.asarray([], dtype=xp.float64),
                                   xp.asarray([0.0], dtype=xp.float64))
 
+        # gh-25094: N=1 previously caused RecursionError
+        r = signal.cspline1d_eval(xp.asarray([5.0], dtype=xp.float64),
+                                  xp.asarray([0.0, 0.5, 1.0], dtype=xp.float64))
+        xp_assert_close(r, xp.asarray([5.0, 5.0, 5.0], dtype=xp.float64))
+
     @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/9484")
     @make_xp_test_case(signal.qspline1d_eval)  # type:ignore[attr-defined]
     def test_qspline1d_eval(self, xp):
@@ -240,6 +245,11 @@ class TestBSplines:
                            match="Spline coefficients 'cj' must not be empty."):
             signal.qspline1d_eval(xp.asarray([], dtype=xp.float64),
                                   xp.asarray([0.0], dtype=xp.float64))
+
+        # gh-25094: N=1 previously caused RecursionError
+        r = signal.qspline1d_eval(xp.asarray([5.0], dtype=xp.float64),
+                                  xp.asarray([0.0, 0.5, 1.0], dtype=xp.float64))
+        xp_assert_close(r, xp.asarray([5.0, 5.0, 5.0], dtype=xp.float64))
 
 
 # i/o dtypes with scipy 1.9.1, likely fixed by backwards compat


### PR DESCRIPTION
## Summary

`cspline1d_eval` and `qspline1d_eval` hit infinite recursion when the coefficient array has length 1 and evaluation points are negative.

**Root cause:** The mirror-symmetry recursion reflects negative points to positive (`-newx`), but with N=1 the positive point exceeds N-1=0, triggering the other reflection (`2*(N-1) - newx = -newx`), bouncing back to negative indefinitely.

**Fix:** For N=1, the spline is a constant function (the single coefficient value everywhere) under mirror-symmetric boundary conditions. Return `cj[0]` early. Applied to both `cspline1d_eval` and `qspline1d_eval`.

```python
>>> from scipy.signal import cspline1d_eval
>>> cspline1d_eval(np.array([1.0]), np.array([-0.1]))  # Before: RecursionError
array([1.])  # After: correct
```

Closes #25090.

**AI disclosure:** This fix was developed with AI assistance.