### PR TITLE
DEP: spatial: deprecate `minkowsi_distance`,`minkowsi_distance_p`, and `distance_matrix`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -358,6 +358,9 @@ for key in (
         'lagrange',
         'approximate_taylor_polynomial',
         'tsearch',
+        'minkowski_distance_p',
+        'minkowski_distance',
+        'distance_matrix'
         ):
     warnings.filterwarnings(action='ignore', message='.*' + key + '.*')
 

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -677,6 +677,9 @@ if HAVE_SCPDT:
         'scipy.interpolate.approximate_taylor_polynomial',
         'scipy.interpolate.pade',
         'scipy.spatial.tsearch',
+        'scipy.spatial.minkowski_distance_p',
+        'scipy.spatial.minkowski_distance',
+        'scipy.spatial.distance_matrix',
     ])
 
     # help pytest collection a bit: these names are either private

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -1558,8 +1558,8 @@ cdef class cKDTree:
 
         You can check distances above the `max_distance` are zeros:
 
-        >>> from scipy.spatial import distance_matrix
-        >>> distance_matrix(points1, points2)
+        >>> from scipy.spatial.distance import cdist
+        >>> cdist(points1, points2)
         array([[0.56906522, 0.39923701, 0.12295571, 0.8658745 , 0.79428925],
            [0.37327919, 0.7225693 , 0.87665969, 0.32580855, 0.75679479],
            [0.28942611, 0.30088013, 0.6395831 , 0.2333084 , 0.33630734],

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -946,8 +946,8 @@ class KDTree(cKDTree):
 
         You can check distances above the `max_distance` are zeros:
 
-        >>> from scipy.spatial import distance_matrix
-        >>> distance_matrix(points1, points2)
+        >>> from scipy.spatial.distance import cdist
+        >>> cdist(points1, points2)
         array([[0.56906522, 0.39923701, 0.12295571, 0.8658745 , 0.79428925],
            [0.37327919, 0.7225693 , 0.87665969, 0.32580855, 0.75679479],
            [0.28942611, 0.30088013, 0.6395831 , 0.2333084 , 0.33630734],

--- a/scipy/spatial/_kdtree.py
+++ b/scipy/spatial/_kdtree.py
@@ -1,14 +1,19 @@
 # Copyright Anne M. Archibald 2008
 # Released under the scipy license
+import warnings
+import os
+
 import numpy as np
 from ._ckdtree import cKDTree, cKDTreeNode  # type: ignore[import-not-found]
 from .distance import minkowski
+from scipy._lib._array_api import xp_capabilities
 
 __all__ = ['minkowski_distance_p', 'minkowski_distance',
            'distance_matrix',
            'Rectangle', 'KDTree']
 
 
+@xp_capabilities(out_of_scope=True)
 def minkowski_distance_p(x, y, p=2.0):
     """Compute the pth power of the L**p distance between two arrays.
 
@@ -18,6 +23,10 @@ def minkowski_distance_p(x, y, p=2.0):
 
     The last dimensions of `x` and `y` must be the same length.  Any
     other dimensions must be compatible for broadcasting.
+
+    .. deprecated:: 1.18.0
+        This function is deprecated in favor of `scipy.spatial.distance.minkowski`
+        and will be removed in SciPy 1.20.0.
 
     Parameters
     ----------
@@ -40,6 +49,11 @@ def minkowski_distance_p(x, y, p=2.0):
     array([2., 1.])
 
     """
+    msg = ("`minkowski_distance_p` is deprecated in favor of "
+           "`scipy.spatial.distance.minkowski` as of SciPy 1.18.0 and will be removed "
+           "in SciPy 1.20.0.")
+    warnings.warn(msg, DeprecationWarning,
+                  skip_file_prefixes=(os.path.dirname(__file__),))
     x = np.asarray(x)
     y = np.asarray(y)
 
@@ -61,11 +75,16 @@ def minkowski_distance_p(x, y, p=2.0):
         return np.sum(np.abs(y-x)**p, axis=-1)
 
 
+@xp_capabilities(out_of_scope=True)
 def minkowski_distance(x, y, p=2.0):
     """Compute the L**p distance between two arrays.
 
     The last dimensions of `x` and `y` must be the same length.  Any
     other dimensions must be compatible for broadcasting.
+
+    .. deprecated:: 1.18.0
+        This function is deprecated in favor of `scipy.spatial.distance.minkowski`
+        and will be removed in SciPy 1.20.0.
 
     Parameters
     ----------
@@ -88,6 +107,11 @@ def minkowski_distance(x, y, p=2.0):
     array([ 1.41421356,  1.        ])
 
     """
+    msg = ("`minkowski_distance` is deprecated in favor of "
+           "`scipy.spatial.distance.minkowski` as of SciPy 1.18.0 and will be removed "
+           "in SciPy 1.20.0.")
+    warnings.warn(msg, DeprecationWarning,
+                  skip_file_prefixes=(os.path.dirname(__file__),))
     x = np.asarray(x)
     y = np.asarray(y)
     if p == np.inf or p == 1:
@@ -934,10 +958,15 @@ class KDTree(cKDTree):
         return super().sparse_distance_matrix(other, max_distance, p, output_type)
 
 
+@xp_capabilities(out_of_scope=True)
 def distance_matrix(x, y, p=2.0, threshold=1000000):
     """Compute the distance matrix.
 
     Returns the matrix of all pair-wise distances.
+
+    .. deprecated:: 1.18.0
+        This function is deprecated in favor of `scipy.spatial.distance.cdist`
+        and will be removed in SciPy 1.20.0.
 
     Parameters
     ----------
@@ -965,7 +994,11 @@ def distance_matrix(x, y, p=2.0, threshold=1000000):
            [ 1.41421356,  1.        ]])
 
     """
-
+    msg = ("`distance_matrix` is deprecated in favor of "
+           "`scipy.spatial.distance.cdist` as of SciPy 1.18.0 and will be removed "
+           "in SciPy 1.20.0.")
+    warnings.warn(msg, DeprecationWarning,
+                  skip_file_prefixes=(os.path.dirname(__file__),))
     x = np.asarray(x)
     m, k = x.shape
     y = np.asarray(y)

--- a/scipy/spatial/tests/test_kdtree.py
+++ b/scipy/spatial/tests/test_kdtree.py
@@ -13,7 +13,7 @@ import numpy as np
 from scipy._lib._testutils import _run_concurrent_barrier
 from scipy.spatial import KDTree, Rectangle, distance_matrix, cKDTree
 from scipy.spatial._ckdtree import cKDTreeNode
-from scipy.spatial import minkowski_distance
+from scipy.spatial import minkowski_distance, minkowski_distance_p
 from scipy.spatial.distance import cdist, minkowski
 from scipy.sparse import dok_array, coo_array, dok_matrix, coo_matrix
 
@@ -597,22 +597,28 @@ class Test_rectangle:
 
 
 def test_distance_l2():
-    assert_almost_equal(minkowski_distance([0, 0], [1, 1], 2), np.sqrt(2))
+    with pytest.deprecated_call(match="1.20.0"):
+        assert_almost_equal(minkowski_distance([0, 0], [1, 1], 2), np.sqrt(2))
+    with pytest.deprecated_call(match="1.20.0"):
+        assert_almost_equal(minkowski_distance_p([0, 0], [1, 1], 2), 2)
 
 
 def test_distance_l1():
-    assert_almost_equal(minkowski_distance([0, 0], [1, 1], 1), 2)
+    with pytest.deprecated_call(match="1.20.0"):
+        assert_almost_equal(minkowski_distance([0, 0], [1, 1], 1), 2)
 
 
 def test_distance_linf():
-    assert_almost_equal(minkowski_distance([0, 0], [1, 1], np.inf), 1)
+    with pytest.deprecated_call(match="1.20.0"):
+        assert_almost_equal(minkowski_distance([0, 0], [1, 1], np.inf), 1)
 
 
 def test_distance_vectorization():
     np.random.seed(1234)
     x = np.random.randn(10, 1, 3)
     y = np.random.randn(1, 7, 3)
-    assert_equal(minkowski_distance(x, y).shape, (10, 7))
+    with pytest.deprecated_call(match="1.20.0"):
+        assert_equal(minkowski_distance(x, y).shape, (10, 7))
 
 
 class count_neighbors_consistency:
@@ -756,11 +762,13 @@ def test_distance_matrix():
     np.random.seed(1234)
     xs = np.random.randn(m, k)
     ys = np.random.randn(n, k)
-    ds = distance_matrix(xs, ys)
+    with pytest.deprecated_call(match="1.20.0"):
+        ds = distance_matrix(xs, ys)
     assert_equal(ds.shape, (m, n))
     for i in range(m):
         for j in range(n):
-            assert_almost_equal(minkowski_distance(xs[i], ys[j]), ds[i, j])
+            with pytest.deprecated_call(match="1.20.0"):
+                assert_almost_equal(minkowski_distance(xs[i], ys[j]), ds[i, j])
 
 
 def test_distance_matrix_looping():
@@ -770,8 +778,10 @@ def test_distance_matrix_looping():
     np.random.seed(1234)
     xs = np.random.randn(m, k)
     ys = np.random.randn(n, k)
-    ds = distance_matrix(xs, ys)
-    dsl = distance_matrix(xs, ys, threshold=1)
+    with pytest.deprecated_call(match="1.20.0"):
+        ds = distance_matrix(xs, ys)
+    with pytest.deprecated_call(match="1.20.0"):
+        dsl = distance_matrix(xs, ys, threshold=1)
     assert_equal(ds, dsl)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
concludes https://discuss.scientific-python.org/t/deprecations-to-clean-up-scipy-spatial-api/2291
#### What does this implement/fix?
<!--Please explain your changes.-->
This PR deprecates `minkowsi_distance`,`minkowsi_distance_p`, and `distance_matrix` as they are inferior duplicates to other functions within SciPy.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No ai.