### PR TITLE
DOC: Improve clarity of dia_array/dia_matrix documentation

### DIFF
--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -562,6 +562,19 @@ class dia_array(_dia_base, sparray):
     addition, subtraction, multiplication, division, and matrix power.
     Sparse arrays with DIAgonal storage do not support slicing.
 
+    When using the ``(data, offsets)`` constructor, the format of ``data``
+    is consistent with the BLAS/LAPACK general band format when ``offsets``
+    is a decreasing range. Specifically:
+
+    - Sub-diagonals (negative offsets) are left-aligned among themselves
+      and with the main diagonal, while super-diagonals (positive offsets)
+      are right-aligned among themselves and with the main diagonal.
+    - Columns of ``data`` become (subsets of) columns of the generated
+      sparse array.
+    - When ``offsets`` is a decreasing range (e.g., ``[1, 0, -1, -2]``),
+      the ``data`` array is compatible with BLAS/LAPACK band routines
+      such as ``dgbmv``.
+
     Examples
     --------
 
@@ -653,6 +666,19 @@ class dia_matrix(spmatrix, _dia_base):
     Sparse matrices can be used in arithmetic operations: they support
     addition, subtraction, multiplication, division, and matrix power.
     Sparse matrices with DIAgonal storage do not support slicing.
+
+    When using the ``(data, offsets)`` constructor, the format of ``data``
+    is consistent with the BLAS/LAPACK general band format when ``offsets``
+    is a decreasing range. Specifically:
+
+    - Sub-diagonals (negative offsets) are left-aligned among themselves
+      and with the main diagonal, while super-diagonals (positive offsets)
+      are right-aligned among themselves and with the main diagonal.
+    - Columns of ``data`` become (subsets of) columns of the generated
+      sparse matrix.
+    - When ``offsets`` is a decreasing range (e.g., ``[1, 0, -1, -2]``),
+      the ``data`` array is compatible with BLAS/LAPACK band routines
+      such as ``dgbmv``.
 
     Examples
     --------


### PR DESCRIPTION
## Motivation and Context

The current documentation for `scipy.sparse.dia_array`/`dia_matrix` does not explain the format required for the `data` parameter in the `(data, offsets)` constructor, delegating entirely to an example. This has caused confusion (see #15069).

Closes #18871

## What This Changes

Adds explanatory notes to the `dia_array` and `dia_matrix` docstrings about the `data` format:

- Sub-diagonals (negative offsets) are left-aligned among themselves and with the main diagonal, while super-diagonals (positive offsets) are right-aligned
- Columns of `data` become (subsets of) columns of the generated sparse array/matrix
- When `offsets` is a decreasing range, the `data` array is compatible with BLAS/LAPACK band routines such as `dgbmv`

## How Has This Been Tested

- Verified Python syntax is correct
- Existing doctests remain unchanged and should continue to pass

## Types of Changes

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change