### PR TITLE
BUG: fix RecursionError in cspline1d_eval and qspline1d_eval for N=1

### DIFF
--- a/scipy/signal/_spline_filters.py
+++ b/scipy/signal/_spline_filters.py
@@ -585,6 +585,10 @@ def cspline1d_eval(cj, newx, dx=1.0, x0=0):
     if res.size == 0:
         return xp.asarray(res)
     N = len(cj)
+    # Handle single coefficient case: avoid infinite recursion from mirror symmetry
+    if N == 1:
+        res[:] = cj[0]
+        return xp.asarray(res)
     cond1 = newx < 0
     cond2 = newx > (N - 1)
     cond3 = ~(cond1 | cond2)
@@ -668,6 +672,10 @@ def qspline1d_eval(cj, newx, dx=1.0, x0=0):
         raise ValueError("Spline coefficients 'cj' must not be empty.")
     
     N = len(cj)
+    # Handle single coefficient case: avoid infinite recursion from mirror symmetry
+    if N == 1:
+        res[:] = cj[0]
+        return xp.asarray(res)
     cond1 = newx < 0
     cond2 = newx > (N - 1)
     cond3 = ~(cond1 | cond2)


### PR DESCRIPTION
## Summary

Fix `RecursionError` in `scipy.signal.cspline1d_eval` and `qspline1d_eval` when the coefficient array has length 1 (N=1) and evaluation points contain negative values.

## Root Cause

When N=1 and newx contains negative values, the mirror symmetry logic causes infinite recursion:
- `newx < 0` triggers `cspline1d_eval(cj, -newx)`
- For N=1, `-newx` is still negative, so recursion continues indefinitely

## Fix

Add early return for N=1 that directly assigns the single coefficient value to all output elements. This is the correct constant spline behavior.

## Example

```python
import numpy as np
from scipy.signal import cspline1d_eval

# Before fix: RecursionError
# After fix: returns array([1.0])
j = np.array([1.0])
newx = np.array([-0.1])
result = cspline1d_eval(j, newx)
```

Fixes scipy/scipy#25090
