### PR TITLE
TST: optimize: tolerate FP noise in test_mip_rel_gap_passdown (gh-24821)

### DIFF
--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2506,10 +2506,13 @@ class TestLinprogHiGHSMIP:
         # monotonically with the mip_rel_gap parameter. np.diff does
         # x[i+1] - x[i], so flip the array before differencing to get
         # what should be a positive, monotone decreasing series of solution
-        # gaps
+        # gaps. Allow a small tolerance because consecutive runs may produce
+        # mathematically-equal gaps that differ only by floating-point noise
+        # from the solver's internal arithmetic (gh-24821).
         gap_diffs = np.diff(np.flip(sol_mip_gaps))
-        assert np.all(gap_diffs >= 0)
-        assert not np.all(gap_diffs == 0)
+        atol = 1e-12
+        assert np.all(gap_diffs >= -atol)
+        assert not np.all(np.abs(gap_diffs) <= atol)
 
     def test_semi_continuous(self):
         # See issue #18106. This tests whether the solution is being

--- a/scipy/optimize/tests/test_linprog.py
+++ b/scipy/optimize/tests/test_linprog.py
@@ -2508,7 +2508,7 @@ class TestLinprogHiGHSMIP:
         # what should be a positive, monotone decreasing series of solution
         # gaps. Allow a small tolerance because consecutive runs may produce
         # mathematically-equal gaps that differ only by floating-point noise
-        # from the solver's internal arithmetic (gh-24821).
+        # from the solver's internal arithmetic.
         gap_diffs = np.diff(np.flip(sol_mip_gaps))
         atol = 1e-12
         assert np.all(gap_diffs >= -atol)


### PR DESCRIPTION
#### Reference issue
Closes gh-24821.

#### What does this implement/fix?
`TestLinprogHiGHSMIP::test_mip_rel_gap_passdown` solves the same MIP four times with progressively tighter `mip_rel_gap` tolerances and asserts that the resulting `final_mip_gap` values are monotonically non-increasing.

For the two loosest tolerances (`0.5` and `0.25`), HiGHS terminates at the same integer-feasible solution, so the two runs return mathematically equal gaps that differ only by floating-point noise from the solver's internal arithmetic:

```
mip_rel_gap=0.5   ->  0.037216828478961565
mip_rel_gap=0.25  ->  0.037216828478964285
```

After `np.diff(np.flip(sol_mip_gaps))`, this produces a `-2.72e-15` entry which trips the strict `assert np.all(gap_diffs >= 0)` check, even though no real regression occurred.

This PR adds an absolute tolerance of `1e-12` to the monotonicity check. That tolerance is larger than the observed noise but smaller than the real gap differences in this test, so genuine regressions are still caught. 

#### Additional information
Before this fix : 
```
(scipy-dev) ria-khatoniar@ria-khatoniar:~/Downloads/scipy$ SCIPY_XSLOW=1 spin test -m full -v -t scipy.optimize.tests.test_linprog::TestLinprogHiGHSMIP::test_mip_rel_gap_passdown
Invoking `build` prior to running tests:
$ meson compile -j 10 -C build
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /home/ria-khatoniar/scipy-dev/bin/ninja -C /home/ria-khatoniar/Downloads/scipy/build -j 10
ninja: Entering directory `/home/ria-khatoniar/Downloads/scipy/build'
[2/356] Generating subprojects/highs/highs/HConfig.h with a custom command
$ meson install --no-rebuild --only-changed -C build --destdir ../build-install --tags=runtime,python-runtime,tests,devel --skip-subprojects
$ export PYTHONPATH="/home/ria-khatoniar/Downloads/scipy/build-install/usr/lib/python3/dist-packages"
$ /home/ria-khatoniar/scipy-dev/bin/python3.12 -P -c 'import scipy'
$ cd /home/ria-khatoniar/Downloads/scipy/build-install/usr/lib/python3/dist-packages
$ /home/ria-khatoniar/scipy-dev/bin/python3.12 -P -m pytest -v --pyargs scipy.optimize.tests.test_linprog::TestLinprogHiGHSMIP::test_mip_rel_gap_passdown
============================================== test session starts ==============================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /home/ria-khatoniar/scipy-dev/bin/python3.12
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /home/ria-khatoniar/Downloads/scipy
configfile: pytest.ini
plugins: timeout-2.4.0, hypothesis-6.152.4, xdist-3.8.0
collected 1 item                                                                                                

scipy/optimize/tests/test_linprog.py::TestLinprogHiGHSMIP::test_mip_rel_gap_passdown FAILED               [100%]

=================================================== FAILURES ====================================================
_________________________________ TestLinprogHiGHSMIP.test_mip_rel_gap_passdown _________________________________

self = <scipy.optimize.tests.test_linprog.TestLinprogHiGHSMIP object at 0x778e7557d730>

    @pytest.mark.xslow
    def test_mip_rel_gap_passdown(self):
        # MIP taken from test_mip6, solved with different values of mip_rel_gap
        # solve a larger MIP with only equality constraints
        # source: https://www.mathworks.com/help/optim/ug/intlinprog.html
        A_eq = np.array([[22, 13, 26, 33, 21, 3, 14, 26],
                         [39, 16, 22, 28, 26, 30, 23, 24],
                         [18, 14, 29, 27, 30, 38, 26, 26],
                         [41, 26, 28, 36, 18, 38, 16, 26]])
        b_eq = np.array([7872, 10466, 11322, 12058])
        c = np.array([2, 10, 13, 17, 7, 5, 7, 3])
    
        bounds = [(0, np.inf)]*8
        integrality = [1]*8
    
        mip_rel_gaps = [0.5, 0.25, 0.01, 0.001]
        sol_mip_gaps = []
        for mip_rel_gap in mip_rel_gaps:
            res = linprog(c=c, A_ub=A_ub, b_ub=b_ub, A_eq=A_eq, b_eq=b_eq,
                          bounds=bounds, method=self.method,
                          integrality=integrality,
                          options={"mip_rel_gap": mip_rel_gap})
            final_mip_gap = res["mip_gap"]
            # assert that the solution actually has mip_gap lower than the
            # required mip_rel_gap supplied
            assert final_mip_gap <= mip_rel_gap
            sol_mip_gaps.append(final_mip_gap)
    
        # make sure that the mip_rel_gap parameter is actually doing something
        # check that differences between solution gaps are declining
        # monotonically with the mip_rel_gap parameter. np.diff does
        # x[i+1] - x[i], so flip the array before differencing to get
        # what should be a positive, monotone decreasing series of solution
        # gaps
        gap_diffs = np.diff(np.flip(sol_mip_gaps))
>       assert np.all(gap_diffs >= 0)
E       assert np.False_
E        +  where np.False_ = <function all at 0x778efc2f42f0>(array([ 9.16936354e-03,  2.75080906e-02, -2.72004641e-15]) >= 0)
E        +    where <function all at 0x778efc2f42f0> = np.all

A_eq       = array([[22, 13, 26, 33, 21,  3, 14, 26],
       [39, 16, 22, 28, 26, 30, 23, 24],
       [18, 14, 29, 27, 30, 38, 26, 26],
       [41, 26, 28, 36, 18, 38, 16, 26]])
b_eq       = array([ 7872, 10466, 11322, 12058])
bounds     = [(0, inf), (0, inf), (0, inf), (0, inf), (0, inf), (0, inf), ...]
c          = array([ 2, 10, 13, 17,  7,  5,  7,  3])
final_mip_gap = 0.0005393743257824605
gap_diffs  = array([ 9.16936354e-03,  2.75080906e-02, -2.72004641e-15])
integrality = [1, 1, 1, 1, 1, 1, ...]
mip_rel_gap = 0.001
mip_rel_gaps = [0.5, 0.25, 0.01, 0.001]
res        =         message: Optimization terminated successfully. (HiGHS Status 7: Optimal)
        success: True
         status...[]
                 marginals: []
 mip_node_count: 28157
 mip_dual_bound: 1853.0
        mip_gap: 0.0005393743257824605
self       = <scipy.optimize.tests.test_linprog.TestLinprogHiGHSMIP object at 0x778e7557d730>
sol_mip_gaps = [0.037216828478961565, 0.037216828478964285, 0.009708737864078035, 0.0005393743257824605]

scipy/optimize/tests/test_linprog.py:2511: AssertionError
============================================ short test summary info ============================================
FAILED scipy/optimize/tests/test_linprog.py::TestLinprogHiGHSMIP::test_mip_rel_gap_passdown - assert np.False_
============================================== 1 failed in 54.45s ===============================================
```
After fix : 
Verified locally with the exact command from the issue:

```
SCIPY_XSLOW=1 spin test -m full -v -t scipy.optimize.tests.test_linprog::TestLinprogHiGHSMIP::test_mip_rel_gap_passdown
```
<img width="923" height="487" alt="Screenshot from 2026-05-07 02-59-14" src="https://github.com/user-attachments/assets/a5b43205-3eb1-4aa3-86f7-81958e0a6dc2" />

#### AI Generation Disclosure
Claude was used to help understand the issue. No code or text in this PR is AI-generated.