### PR TITLE
MAINT: sparse: COO.tocsc add comment about unused copy

### DIFF
--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -329,7 +329,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         Parameters
         ----------
         copy : bool, optional
-            Unused.
+            Unused. A copy is always made in the 2D case. And CSC is 2D.
 
         Returns
         -------
@@ -374,7 +374,8 @@ class _coo_base(_data_matrix, _minmax_mixin):
         ----------
         copy : bool, optional
             With ``copy=False``, the data/indices may be shared between this
-            array/matrix and the resultant csr_array/matrix.
+            array/matrix and the resultant csr_array/matrix. But only for 1D.
+            For 2D, a copy will always be made.
 
         Returns
         -------

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -356,6 +356,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
         if self.nnz == 0:
             return self._csc_container(self.shape, dtype=self.dtype)
         else:
+            # _coo_to_compressed copy kwarg only for 1D. CSC cant be 1D. See gh-24676
             from ._csc import csc_array
             indptr, indices, data, shape = self._coo_to_compressed(csc_array._swap)
 


### PR DESCRIPTION
Fixes #24676 

Add comment explaining why `copy` kwarg of `_coo_to_compressed` isn't used for `tocsc`. The copy kwarg is only used for 1D. And 1D is not supported for CSC format.

Also updated doc-strings for `COO.tocsc` and `COO.tocsr` to make clear that copies are always made for 2D, and so the copy kwarg is only applied for 1D in CSR.