### PR TITLE
DOC: stats: add references to five distributions that are missing them

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -10932,6 +10932,13 @@ class uniform_gen(rv_continuous):
 
     %(before_notes)s
 
+    %(after_notes)s
+
+    References
+    ----------
+    .. [1] "Continuous uniform distribution", Wikipedia,
+       https://en.wikipedia.org/wiki/Continuous_uniform_distribution
+
     %(example)s
 
     """

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -10937,7 +10937,7 @@ class uniform_gen(rv_continuous):
     References
     ----------
     .. [1] "Continuous uniform distribution", Wikipedia,
-       https://en.wikipedia.org/wiki/Continuous_uniform_distribution
+           https://en.wikipedia.org/wiki/Continuous_uniform_distribution
 
     %(example)s
 
@@ -11157,7 +11157,7 @@ class vonmises_gen(rv_continuous):
     .. [1] Mardia, K. V. and Jupp, P. E. *Directional Statistics*.
            John Wiley & Sons, 1999, p. 36.
     .. [2] "von Mises distribution", Wikipedia,
-       https://en.wikipedia.org/wiki/Von_Mises_distribution
+           https://en.wikipedia.org/wiki/Von_Mises_distribution
 
     Examples
     --------

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -10926,13 +10926,22 @@ class FitUniformFixedScaleDataError(FitDataError):
 class uniform_gen(rv_continuous):
     r"""A uniform continuous random variable.
 
+    %(before_notes)s
+
+    Notes
+    -----
+    The probability density function for `uniform` is:
+
+    .. math::
+
+        f(x) = \begin{cases}
+                 1  & \text{for } 0 \le x \le 1 \\
+                 0  & \text{otherwise}
+               \end{cases}
+
     In the standard form, the distribution is uniform on ``[0, 1]``. Using
     the parameters ``loc`` and ``scale``, one obtains the uniform distribution
     on ``[loc, loc + scale]``.
-
-    %(before_notes)s
-
-    %(after_notes)s
 
     References
     ----------

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -11159,8 +11159,6 @@ class vonmises_gen(rv_continuous):
     (circular mean). A ``scale`` parameter is accepted but does not have any
     effect.
 
-    %(after_notes)s
-
     References
     ----------
     .. [1] Mardia, K. V. and Jupp, P. E. *Directional Statistics*.

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -11143,6 +11143,15 @@ class vonmises_gen(rv_continuous):
     (circular mean). A ``scale`` parameter is accepted but does not have any
     effect.
 
+    %(after_notes)s
+
+    References
+    ----------
+    .. [1] Mardia, K. V. and Jupp, P. E. *Directional Statistics*.
+           John Wiley & Sons, 1999, p. 36.
+    .. [2] "von Mises distribution", Wikipedia,
+       https://en.wikipedia.org/wiki/Von_Mises_distribution
+
     Examples
     --------
     Import the necessary modules.

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1726,11 +1726,11 @@ class skellam_gen(rv_discrete):
     References
     ----------
     .. [1] Skellam, J. G. "The Frequency Distribution of the Difference
-       Between Two Poisson Variates Belonging to Different Populations."
-       *Journal of the Royal Statistical Society* 109, no. 3 (1946): 296-296.
-       :doi:`10.2307/2981372`
+           Between Two Poisson Variates Belonging to Different Populations."
+           *Journal of the Royal Statistical Society* 109, no. 3 (1946): 296-296.
+           :doi:`10.2307/2981372`
     .. [2] "Skellam distribution", Wikipedia,
-       https://en.wikipedia.org/wiki/Skellam_distribution
+           https://en.wikipedia.org/wiki/Skellam_distribution
 
     %(example)s
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1719,11 +1719,18 @@ class skellam_gen(rv_discrete):
 
     Parameters :math:`\mu_1` and :math:`\mu_2` must be strictly positive.
 
-    For details see: https://en.wikipedia.org/wiki/Skellam_distribution
-
     `skellam` takes :math:`\mu_1` and :math:`\mu_2` as shape parameters.
 
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Skellam, J. G., "The Frequency Distribution of the Difference
+       Between Two Poisson Variates Belonging to Different Populations."
+       Journal of the Royal Statistical Society, 109(3), 296-296, 1946.
+       :doi:`10.2307/2981372`
+    .. [2] "Skellam distribution", Wikipedia,
+       https://en.wikipedia.org/wiki/Skellam_distribution
 
     %(example)s
 

--- a/scipy/stats/_discrete_distns.py
+++ b/scipy/stats/_discrete_distns.py
@@ -1725,9 +1725,9 @@ class skellam_gen(rv_discrete):
 
     References
     ----------
-    .. [1] Skellam, J. G., "The Frequency Distribution of the Difference
+    .. [1] Skellam, J. G. "The Frequency Distribution of the Difference
        Between Two Poisson Variates Belonging to Different Populations."
-       Journal of the Royal Statistical Society, 109(3), 296-296, 1946.
+       *Journal of the Royal Statistical Society* 109, no. 3 (1946): 296-296.
        :doi:`10.2307/2981372`
     .. [2] "Skellam distribution", Wikipedia,
        https://en.wikipedia.org/wiki/Skellam_distribution

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1169,6 +1169,11 @@ class matrix_normal_gen(multi_rv_generic):
 
     .. versionadded:: 0.17.0
 
+    References
+    ----------
+    .. [1] "Matrix normal distribution", Wikipedia,
+       https://en.wikipedia.org/wiki/Matrix_normal_distribution
+
     Examples
     --------
 

--- a/scipy/stats/_multivariate.py
+++ b/scipy/stats/_multivariate.py
@@ -1172,7 +1172,7 @@ class matrix_normal_gen(multi_rv_generic):
     References
     ----------
     .. [1] "Matrix normal distribution", Wikipedia,
-       https://en.wikipedia.org/wiki/Matrix_normal_distribution
+           https://en.wikipedia.org/wiki/Matrix_normal_distribution
 
     Examples
     --------


### PR DESCRIPTION
### Reference issue

Towards #25097

### What does this implement/fix?

I picked 5 random distributions from the associated issue, researched them, and added references.

### Additional information

My distribution specific notes are as follows:

#### Skellam

**Same variables?**

Our notation matches Wikipedia.

Wikipedia and Skellam (1946) use slightly different notation. Skellam uses $m_1$, while Wikipedia uses $\mu_1$. If you look at the PMF on Wikipedia, you can see that it's exactly equal to Skellam's PMF once you do this substitution. I can add a note clarifying this, but I think it's clear enough.

SciPy appears to be computing this with chndtr internally. I don't follow the math, but it does seem to be numerically similar.

#### Matrix Normal

**Same variables?**

Yes, both use U and V to mean row / column covariance.

Looked for a scientific paper, but I wasn't sure what would be useful. I just added the Wikipedia link.

#### Von Mises

**Same variables?**

I picked Jupp as a source because it is what Wikipedia cites, and we cite it elsewhere in the project. I also looked into [Von Mises's original paper](https://digitalisate.sub.uni-hamburg.de/recherche/detail?tx_dlf%5Bdouble%5D=0&tx_dlf%5Bid%5D=23864&tx_dlf%5Bpage%5D=522&tx_dlf_navigation%5Baction%5D=main&tx_dlf_navigation%5Bcontroller%5D=Navigation&cHash=c05c9bab1f3b5e13e9c50801e46afc4f), published in 1918, about modeling the fractional portions of atomic mass, but that is in German.

I cited page 36 of Jupp. Here is what page 36 looks like. [page 36](https://github.com/user-attachments/assets/e3005e10-d0d7-4766-96e8-f8446e63f52b)


Wikipedia and Jupp have the same parameterization.

SciPy uses kappa in the same way as Wikipedia and Jupp do.

For loc == 0, both the CDF and PDF agree with the wikipedia definition.

For loc != 0, the PDF agrees with the wikipedia definition.

For loc != 0 and the CDF, it's complicated. There seems to be a somewhat odd relationship between loc and $\mu$. Since SciPy has no circular distribution support, the CDF begins from an arbitrary point. The SciPy CDF is equal to the Wikipedia definition plus some constant. Although the documentation currently says that the circular mean and loc are the same thing, this doesn't appear to be true for the CDF.

<img width="847" height="476" alt="Figure_1" src="https://github.com/user-attachments/assets/3fcfa1d0-c15e-4017-b88b-c923f01d827e" />

(See https://gitlab.com/nickodell/plot_scipy_and_wikipedia_dists for the code used to plot this.)
#### Von Mises Line

See previous.

#### Uniform

Hey, it was one of the 5 random distributions I picked. :)

**Same variables?**

No, Wikipedia uses a/b and we use loc/scale. But we already explain this.

### AI Generation Disclosure

AI was used for researching this patch and making changes. Specifically, Claude 4.7 was used for plotting alternate specifications of these distributions, and for finding the Von Mises citation. I also used it to actually add the citations.

I checked whether these parameterizations were equivalent, either by inspection, or by plotting the wikipedia definition and comparing it to the SciPy definition. My notes for each distribution can be found in the Additional Information section.

### Citation format

I am not 100% sure what the right citation format is, but I generally tried to observe Chicago style, except for Jupp, where I copied existing citations. For wikipedia links, I followed the [documentation's style guide.](https://scipy.github.io/devdocs/dev/contributor/rendering_documentation.html#citing-wikipedia-articles-in-the-references-section)