### PR TITLE
DOC: stats.ansari: note JIT side effects of method='exact'

### DIFF
--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -3107,6 +3107,17 @@ def ansari(x, y, alternative='two-sided', *, axis=0, method='auto'):
     55 and there are no ties, otherwise a normal approximation for the
     p-value is used.
 
+    When ``x`` and ``y`` are lazy arrays (e.g. JAX arrays inside
+    ``jax.jit``), ``method='auto'`` is not permitted and one of
+    ``'asymptotic'``, ``'exact'``, or a `PermutationMethod` instance
+    must be specified. ``method='exact'`` is implemented in NumPy and
+    updates a module-level cache of exact null-distribution values on
+    first use for each ``(n, m)``; that cache update is a side effect
+    in the sense of the JAX sequencing-effects model [4]_, and can
+    produce surprising behaviour under traced or JIT-compiled call
+    sites. For maximally JIT-friendly use, prefer
+    ``method='asymptotic'``.
+
     References
     ----------
     .. [1] Ansari, A. R. and Bradley, R. A. (1960) Rank-sum tests for
@@ -3116,6 +3127,8 @@ def ansari(x, y, alternative='two-sided', *, axis=0, method='auto'):
            Section 5.8.2.
     .. [3] Nathaniel E. Helwig "Nonparametric Dispersion and Equality
            Tests" at http://users.stat.umn.edu/~helwig/notes/npde-Notes.pdf
+    .. [4] "Sequencing side-effects in JAX",
+           https://docs.jax.dev/en/latest/jep/10657-sequencing-effects.html
 
     Examples
     --------


### PR DESCRIPTION
#### Reference issue

Closes gh-25104. Follow-up to gh-24467 (which added `method` and JAX/JIT
support to `scipy.stats.ansari`); gh-25104 was opened by @tylerjereddy
to capture the docstring follow-ups he flagged in his inline review of
that PR.

#### What does this implement/fix?

Adds a paragraph to the `Notes` section of `scipy.stats.ansari` and a new
reference [4]:

- spells out that `method='auto'` is rejected for lazy arrays (this is
  enforced at gh-24467's `if is_lazy_array(x) and method == 'auto'`
  guard);
- explains that `method='exact'` updates the module-level `_abw_state`
  cache on first use for each `(n, m)` and that this cache update is a
  side effect under JAX's sequencing-effects model — hence can misbehave
  inside `jax.jit` / other tracing transforms;
- recommends `method='asymptotic'` for JIT-compiled call sites;
- adds a reference to the JAX sequencing-effects JEP.

`PermutationMethod` is intentionally not called out separately — it also
materializes through NumPy internally, but I haven't tested every
`(method, transform)` combination, so I didn't want to over-claim. Happy
to extend the note if you'd prefer an explicit recommendation there.

#### Additional information

- Diff is docstring-only: 11 lines added in `Notes`, 2 lines added in
  `References`.
- The unused `[3]` reference label is pre-existing; I didn't touch it.
- @tylerjereddy's L3090 review note in gh-24467 ("we've been avoiding
  docstring specialization for array API support") guided me toward a
  single Notes paragraph rather than a dedicated array-API section, and
  I left the `method` parameter bullets themselves alone.

#### AI Generation Disclosure

I used Claude (an LLM coding assistant) as a drafting and search aid:

- **Search**: pulled @tylerjereddy's inline review comments on gh-24467
  via `gh api repos/scipy/scipy/pulls/24467/comments`, and grep'd
  `scipy/stats/_morestats.py` for `_abw_state` / `is_lazy_array` to
  confirm the cache-mutation behaviour described in the new note.
- **Drafting**: the prose of the new `Notes` paragraph, the new
  reference label, and the first draft of this PR description were
  produced with Claude's help.

I read the resulting diff, verified the technical claims against the
underlying code (the `_abw_state` mutation in `_morestats.py` and the
lazy-array guard added by gh-24467), and am the human submitting this
patch under SciPy's responsibility/copyright requirements. No AI agent
submitted this autonomously.