### PR TITLE
ENH: migrate `special.nctdtrinc` to boost

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -5827,6 +5827,16 @@ add_newdoc("nctdtrinc",
     nctdtrit : Inverse CDF (iCDF) of the non-central t distribution.
     nctdtridf : Calculate degrees of freedom, given CDF and iCDF values.
 
+    Notes
+    -----
+    This function calculates the non-centrality parameter of the 
+    non-central t distribution given a probability, quantile and 
+    degrees of freedom using the Boost Math C++ library [1]_.
+
+    References
+    ----------
+    .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
+
     Examples
     --------
     >>> from scipy.special import nctdtr, nctdtrinc

--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -5829,8 +5829,8 @@ add_newdoc("nctdtrinc",
 
     Notes
     -----
-    This function calculates the non-centrality parameter of the 
-    non-central t distribution given a probability, quantile and 
+    This function calculates the non-centrality parameter of the
+    non-central t distribution given a probability, quantile and
     degrees of freedom using the Boost Math C++ library [1]_.
 
     References

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -25,7 +25,6 @@ cdef extern from "cdflib.h" nogil:
     TupleDID cdffnc_which5(double, double, double, double, double);
     TupleDID cdft_which3(double, double, double);
     TupleDID cdftnc_which3(double, double, double, double);
-    TupleDID cdftnc_which4(double, double, double, double);
 
 
 cdef inline double get_result(
@@ -170,27 +169,6 @@ cdef inline double nctdtridf(double p, double nc, double t) noexcept nogil:
     ret = cdftnc_which3(p, q, t, nc)
     result, status, bound = ret.d1, ret.i1, ret.d2
     return get_result("nctdtridf", argnames, result, status, bound, 1)
-
-
-cdef inline double nctdtrinc(double df, double p, double t) noexcept nogil:
-    cdef:
-        double q = 1.0 - p
-        double result, bound
-        int status = 10
-        char *argnames[4]
-        TupleDID ret
-
-    if isnan(df) or isnan(p) or isnan(t):
-      return NAN
-
-    argnames[0] = "p"
-    argnames[1] = "q"
-    argnames[2] = "t"
-    argnames[3] = "df"
-
-    ret = cdftnc_which4(p, q, t, df)
-    result, status, bound = ret.d1, ret.i1, ret.d2
-    return get_result("nctdtrinc", argnames, result, status, bound, 1)
 
 
 cdef inline double stdtridf(double p, double t) noexcept nogil:

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -1420,6 +1420,44 @@ nct_isf_double(double x, double v, double l)
     return nct_isf_wrap(x, v, l);
 }
 
+// Wrapper for Boost noncentral T find_non_centrality
+template<typename Real>
+Real
+nct_find_non_centrality_wrap(const Real v, const Real p, const Real x)
+{
+    if (std::isnan(v) || std::isnan(x) || std::isnan(p)) {
+        return NAN;
+    }
+    if (v <= 0 || p < 0 || p > 1) {
+        sf_error("nctdtrinc", SF_ERROR_DOMAIN, NULL);
+        return NAN;
+    }
+    Real y;
+    try {
+        y = boost::math::non_central_t_distribution<Real, SpecialPolicy>::find_non_centrality(v, x, p);
+    } catch (const std::domain_error& e) {
+        sf_error("nctdtrinc", SF_ERROR_DOMAIN, NULL);
+        y = NAN;
+    } catch (const std::underflow_error& e) {
+        sf_error("nctdtrinc", SF_ERROR_UNDERFLOW, NULL);
+        y = 0;
+    } catch (...) {
+        sf_error("nctdtrinc", SF_ERROR_OTHER, NULL);
+        y = NAN;
+    }
+    return y;
+}
+
+float nct_find_non_centrality_float(float v, float p, float x)
+{
+    return nct_find_non_centrality_wrap(v, p, x);
+}
+
+double nct_find_non_centrality_double(double v, double p, double x)
+{
+    return nct_find_non_centrality_wrap(v, p, x);
+}
+
 float
 nct_mean_float(float v, float l)
 {

--- a/scipy/special/cdflib.c
+++ b/scipy/special/cdflib.c
@@ -1944,65 +1944,6 @@ struct TupleDID cdftnc_which3(double p, double q, double t, double pnonc)
 }
 
 
-struct TupleDID cdftnc_which4(double p, double q, double t, double df)
-{
-
-    double tol = 1e-8;
-    double atol = 1e-50;
-    DinvrState DS = {0};
-    DzrorState DZ = {0};
-    struct TupleDD tncret;
-    struct TupleDID ret = {0};
-
-    DS.small = -1.e6;
-    DS.big = 1.e6;
-    DS.absstp = 0.5;
-    DS.relstp = 0.5;
-    DS.stpmul = 5.;
-    DS.abstol = atol;
-    DS.reltol = tol;
-    DS.x = 5.;
-
-    if (!((0 <= p) && (p <= (1. - 1e-16)))) {
-        ret.i1 = -1;
-        ret.d2 = (!(p > 0.0) ? 0.0 : (1. - 1e-16));
-        return ret;
-    }
-    if (!(t == t)) {
-        ret.i1 = -3;
-        return ret;
-    }
-    if (!(df > 0.)) {
-        ret.i1 = -4;
-        return ret;
-    }
-    if (((fabs(p+q)-0.5)-0.5) > 3*spmpar[0]) {
-        ret.i1 = 3;
-        ret.d2 = (p+q < 0 ? 0.0 : 1.0);
-        return ret;
-    }
-
-    t = fmax(fmin(t, spmpar[2]), -spmpar[2]);
-    df = fmin(df, 1.e10);
-
-    dinvr(&DS, &DZ);
-    while (DS.status == 1) {
-        tncret = cumtnc(t, df, DS.x);
-        DS.fx = tncret.d1 - p;
-        dinvr(&DS, &DZ);
-    }
-    if (DS.status == -1) {
-        ret.d1 = DS.x;
-        ret.i1 = (DS.qleft ? 1 : 2);
-        ret.d2 = (DS.qleft ? 0 : 1e6);
-        return ret;
-    } else {
-        ret.d1 = DS.x;
-        return ret;
-    }
-}
-
-
 struct TupleDD cumbet(double x, double y, double a, double b)
 {
     //              Double precision cUMulative incomplete BETa distribution

--- a/scipy/special/cdflib.h
+++ b/scipy/special/cdflib.h
@@ -111,7 +111,6 @@ struct TupleDID cdffnc_which4(double, double, double, double, double);
 struct TupleDID cdffnc_which5(double, double, double, double, double);
 struct TupleDID cdft_which3(double, double, double);
 struct TupleDID cdftnc_which3(double, double, double, double);
-struct TupleDID cdftnc_which4(double, double, double, double);
 
 #ifdef __cplusplus
 }      /* extern "C" */

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -1711,10 +1711,6 @@ from ._cdflib_wrappers cimport nctdtridf as _func_nctdtridf
 ctypedef double _proto_nctdtridf_t(double, double, double) noexcept nogil
 cdef _proto_nctdtridf_t *_proto_nctdtridf_t_var = &_func_nctdtridf
 
-from ._cdflib_wrappers cimport nctdtrinc as _func_nctdtrinc
-ctypedef double _proto_nctdtrinc_t(double, double, double) noexcept nogil
-cdef _proto_nctdtrinc_t *_proto_nctdtrinc_t_var = &_func_nctdtrinc
-
 from ._legacy cimport pdtri_unsafe as _func_pdtri_unsafe
 ctypedef double _proto_pdtri_unsafe_t(double, double) noexcept nogil
 cdef _proto_pdtri_unsafe_t *_proto_pdtri_unsafe_t_var = &_func_pdtri_unsafe
@@ -3142,7 +3138,7 @@ cpdef double nctdtridf(double x0, double x1, double x2) noexcept nogil:
 
 cpdef double nctdtrinc(double x0, double x1, double x2) noexcept nogil:
     """See the documentation for scipy.special.nctdtrinc"""
-    return _func_nctdtrinc(x0, x1, x2)
+    return (<double(*)(double, double, double) noexcept nogil>scipy.special._ufuncs_cxx._export_nct_find_non_centrality_double)(x0, x1, x2)
 
 cpdef df_number_t nctdtrit(df_number_t x0, df_number_t x1, df_number_t x2) noexcept nogil:
     """See the documentation for scipy.special.nctdtrit"""

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -572,8 +572,9 @@
         }
     },
     "nctdtrinc": {
-        "_cdflib_wrappers.pxd": {
-            "nctdtrinc": "ddd->d"
+        "boost_special_functions.h++": {
+            "nct_find_non_centrality_float": "fff->f",
+            "nct_find_non_centrality_double": "ddd->d"
         }
     },
     "nctdtrit": {

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -7,7 +7,6 @@ The following functions still need tests:
 - ncfdtridfd
 - ncfdtrinc
 - nctdtridf
-- nctdtrinc
 
 """
 import itertools
@@ -449,20 +448,6 @@ def test_chndtrix_gh2158():
     assert_allclose(res, res_exp)
 
 
-def test_nctdtrinc_gh19896():
-    # test that gh-19896 is resolved.
-    # Compared to SciPy 1.11 results from Fortran code.
-    dfarr = [0.001, 0.98, 9.8, 98, 980, 10000, 98, 9.8, 0.98, 0.001]
-    parr = [0.001, 0.1, 0.3, 0.8, 0.999, 0.001, 0.1, 0.3, 0.8, 0.999]
-    tarr = [0.0015, 0.15, 1.5, 15, 300, 0.0015, 0.15, 1.5, 15, 300]
-    desired = [3.090232306168629, 1.406141304556198, 2.014225177124157,
-               13.727067118283456, 278.9765683871208, 3.090232306168629,
-               1.4312427877936222, 2.014225177124157, 3.712743137978295,
-               -3.086951096691082]
-    actual = sp.nctdtrinc(dfarr, parr, tarr)
-    assert_allclose(actual, desired, rtol=5e-12, atol=0.0)
-
-
 def test_stdtr_stdtrit_neg_inf():
     # -inf was treated as +inf and values from the normal were returned
     assert np.all(np.isnan(sp.stdtr(-np.inf, [-np.inf, -1.0, 0.0, 1.0, np.inf])))
@@ -699,10 +684,35 @@ class TestNoncentralTFunctions:
         (3000, 3, 0.1, 0.0018657780826323328),
         (0.98, -3.8, 15, 0.9999990264591945),
         (9.8, 38, 15, 2.252076291604796e-09),
-
     ])
-    def test_nctdtrit(self, df, nc, x, expected_cdf):
+    def test_inverses(self, df, nc, x, expected_cdf):
         assert_allclose(sp.nctdtrit(df, nc, expected_cdf), x, rtol=1e-10)
+        assert_allclose(sp.nctdtrinc(df, expected_cdf, x), nc, rtol=1e-10)
+
+    def test_nctdtrinc_gh19896(self):
+        # test that gh-19896 is resolved.
+        # Originally compared to SciPy 1.11 results from Fortran code.
+        # The references for p were generated using the mpmath implementation
+        dfarr = [0.001, 0.98, 9.8, 98, 10000, 98, 9.8, 0.98, 0.001]
+        parr = [0.0010002124119858726, 0.09999999952796973, 0.29999999681977191,
+                0.79999995857148565, 0.0010050622307837085, 0.099999999324025535,
+                0.29999999681977191, 0.79999999843644154, 0.99899999955163477,
+            ]
+        tarr = [0.0015, 0.15, 1.5, 15, 0.0015, 0.15, 1.5, 15, 300]
+        nc = [3.090232306168629, 1.406141304556198, 2.014225177124157,
+            13.727067118283456, 3.090232306168629, 1.4312427877936222,
+            2.014225177124157, 3.712743137978295, -3.086951096691082
+            ]
+        actual = sp.nctdtrinc(dfarr, parr, tarr)
+        assert_allclose(actual, nc, rtol=5e-12, atol=0.0)
+
+    @pytest.mark.parametrize("df, x", [(10, 2), (100, -3), (1000, 4)])
+    def test_nctdtrinc_zero_nc(self, df, x):
+        # For nc = 0 we should get the same result as the central t distribution
+        assert_allclose(
+            sp.nctdtrinc(df, sp.stdtr(df, x), x), 0,
+            atol=1e-11, rtol=0
+        )
 
 
 class TestNegativeBinomialFunctions:


### PR DESCRIPTION
#### Reference issue
Towards #21966

#### What does this implement/fix?
Migrates `nctdtrinc` to boost.

#### AI Generation Disclosure
Copilot with GPT-4.1 was used to create a helper script to create the reference values for `parray` in `test_nctdtrinc_gh19896` to save time. 
