### PR TITLE
DOC: stats: add references to eight Volume-1 distributions

### DIFF
--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -411,6 +411,14 @@ class norm_gen(rv_continuous):
 
     %(after_notes)s
 
+    References
+    ----------
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 13, p. 80.
+    .. [2] "Normal distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Normal_distribution
+
     %(example)s
 
     """
@@ -1465,6 +1473,11 @@ class cauchy_gen(rv_continuous):
     References
     ----------
     .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
+    .. [2] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 16, p. 299.
+    .. [3] "Cauchy distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Cauchy_distribution
 
     %(example)s
 
@@ -1548,6 +1561,14 @@ class chi_gen(rv_continuous):
     `chi` takes ``df`` as a shape parameter.
 
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 18, p. 417.
+    .. [2] "Chi distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Chi_distribution
 
     %(example)s
 
@@ -2766,9 +2787,13 @@ class weibull_min_gen(rv_continuous):
 
     References
     ----------
-    https://en.wikipedia.org/wiki/Weibull_distribution
-
-    https://en.wikipedia.org/wiki/Fisher-Tippett-Gnedenko_theorem
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 21, p. 629.
+    .. [2] "Weibull distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Weibull_distribution
+    .. [3] "Fisher-Tippett-Gnedenko theorem", Wikipedia,
+           https://en.wikipedia.org/wiki/Fisher-Tippett-Gnedenko_theorem
 
     %(example)s
 
@@ -3033,9 +3058,13 @@ class weibull_max_gen(rv_continuous):
 
     References
     ----------
-    https://en.wikipedia.org/wiki/Weibull_distribution
-
-    https://en.wikipedia.org/wiki/Fisher-Tippett-Gnedenko_theorem
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 21, p. 629.
+    .. [2] "Weibull distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Weibull_distribution
+    .. [3] "Fisher-Tippett-Gnedenko theorem", Wikipedia,
+           https://en.wikipedia.org/wiki/Fisher-Tippett-Gnedenko_theorem
 
     %(example)s
 
@@ -3615,6 +3644,14 @@ class gamma_gen(rv_continuous):
     ``scale = 1 / beta``.
 
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 17, p. 337.
+    .. [2] "Gamma distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Gamma_distribution
 
     %(example)s
 
@@ -6876,6 +6913,14 @@ class lognorm_gen(rv_continuous):
     standard deviation ``sigma``. Then ``Y = exp(X)`` is lognormally
     distributed with ``s = sigma`` and ``scale = exp(mu)``.
 
+    References
+    ----------
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 14, p. 208.
+    .. [2] "Log-normal distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Log-normal_distribution
+
     %(example)s
 
     The logarithm of a log-normally distributed random variable is
@@ -8221,6 +8266,14 @@ class pareto_gen(rv_continuous):
     `pareto` takes ``b`` as a shape parameter for :math:`b`.
 
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 20, p. 574.
+    .. [2] "Pareto distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Pareto_distribution
 
     %(example)s
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -413,7 +413,10 @@ class norm_gen(rv_continuous):
 
     References
     ----------
-    .. [1] "Normal distribution", Wikipedia,
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 13, p. 80.
+    .. [2] "Normal distribution", Wikipedia,
            https://en.wikipedia.org/wiki/Normal_distribution
 
     %(example)s
@@ -1470,6 +1473,11 @@ class cauchy_gen(rv_continuous):
     References
     ----------
     .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
+    .. [2] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 16, p. 299.
+    .. [3] "Cauchy distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Cauchy_distribution
 
     %(example)s
 
@@ -1556,7 +1564,10 @@ class chi_gen(rv_continuous):
 
     References
     ----------
-    .. [1] "Chi distribution", Wikipedia,
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 18, p. 417.
+    .. [2] "Chi distribution", Wikipedia,
            https://en.wikipedia.org/wiki/Chi_distribution
 
     %(example)s
@@ -2787,9 +2798,13 @@ class weibull_min_gen(rv_continuous):
 
     References
     ----------
-    https://en.wikipedia.org/wiki/Weibull_distribution
-
-    https://en.wikipedia.org/wiki/Fisher-Tippett-Gnedenko_theorem
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 21, p. 629.
+    .. [2] "Weibull distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Weibull_distribution
+    .. [3] "Fisher-Tippett-Gnedenko theorem", Wikipedia,
+           https://en.wikipedia.org/wiki/Fisher-Tippett-Gnedenko_theorem
 
     %(example)s
 
@@ -3054,9 +3069,13 @@ class weibull_max_gen(rv_continuous):
 
     References
     ----------
-    https://en.wikipedia.org/wiki/Weibull_distribution
-
-    https://en.wikipedia.org/wiki/Fisher-Tippett-Gnedenko_theorem
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 21, p. 629.
+    .. [2] "Weibull distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Weibull_distribution
+    .. [3] "Fisher-Tippett-Gnedenko theorem", Wikipedia,
+           https://en.wikipedia.org/wiki/Fisher-Tippett-Gnedenko_theorem
 
     %(example)s
 
@@ -3592,6 +3611,14 @@ class gamma_gen(rv_continuous):
     ``scale = 1 / beta``.
 
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 17, p. 337.
+    .. [2] "Gamma distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Gamma_distribution
 
     %(example)s
 
@@ -6902,6 +6929,14 @@ class lognorm_gen(rv_continuous):
     standard deviation ``sigma``. Then ``Y = exp(X)`` is lognormally
     distributed with ``s = sigma`` and ``scale = exp(mu)``.
 
+    References
+    ----------
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 14, p. 208.
+    .. [2] "Log-normal distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Log-normal_distribution
+
     %(example)s
 
     The logarithm of a log-normally distributed random variable is
@@ -8259,6 +8294,14 @@ class pareto_gen(rv_continuous):
     `pareto` takes ``b`` as a shape parameter for :math:`b`.
 
     %(after_notes)s
+
+    References
+    ----------
+    .. [1] Johnson, N. L., Kotz, S., and Balakrishnan, N. *Continuous
+           Univariate Distributions, Volume 1*. 2nd ed., John Wiley &
+           Sons, 1994, Chapter 20, p. 574.
+    .. [2] "Pareto distribution", Wikipedia,
+           https://en.wikipedia.org/wiki/Pareto_distribution
 
     %(example)s
 


### PR DESCRIPTION
#### Reference issue

Towards gh-25097. Continues the pattern from gh-25105 (`vonmises`, `skellam`, ...) and gh-25112 (`chi2`, `expon`, `laplace`, `logistic`, `rayleigh`, `bernoulli`, `poisson`).

**Updated 2026-09-01.** This branch had gone stale against `main`. Since it was opened, gh-25819 merged Wikipedia references for `norm` and `chi`; those entries are preserved here and the verified textbook citations are added before them. The other six distributions are unchanged upstream and still lack a textbook reference. The branch was rebuilt as a single commit on current `main` rather than merged, matching the treatment of gh-25112.

#### What does this implement/fix?

Adds (or extends) a `References` section for eight continuous distributions whose canonical defining equation lives in Johnson, Kotz, Balakrishnan, *Continuous Univariate Distributions, Volume 1* (2nd ed., 1994):

| scipy | JKB Vol. 1 reference |
| --- | --- |
| `norm` | Ch. 13, p. 80, eq. (13.2) |
| `lognorm` | Ch. 14, p. 208, eq. (14.2)' |
| `cauchy` | Ch. 16, p. 299, eq. (16.1) |
| `gamma` | Ch. 17, p. 337, eq. (17.2) |
| `chi` | Ch. 18, p. 417, eq. (18.5) |
| `pareto` | Ch. 20, p. 574, eq. (20.3) |
| `weibull_min` | Ch. 21, p. 629, eq. (21.2) |
| `weibull_max` | Ch. 21, p. 629 (mirror of `weibull_min` via `Y = -X`) |

#### Per-distribution verification

Each scipy PDF was checked against the textbook formula in the cited edition before this PR was opened. Standardized scipy parametrization recovered by setting the location to 0 and the scale to 1 (and, for `pareto`, the lower-truncation point ``k = 1``):

* `norm` — JKB eq. (13.2): $p_U(u) = (\sqrt{2\pi})^{-1} \exp(-u^2/2)$. **Match.**
* `lognorm` — JKB eq. (14.2)' at $\theta=0$: $p_X(x) = (xs\sqrt{2\pi})^{-1} \exp(-(\log x)^2 / 2s^2)$. **Match.**
* `cauchy` — JKB eq. (16.1) at $\theta=0$, $\lambda=1$: $1 / (\pi(1+x^2))$. **Match.**
* `gamma` — JKB eq. (17.2): $x^{a-1} e^{-x} / \Gamma(a)$. **Match.**
* `chi` — JKB eq. (18.5): $x^{k-1} \exp(-x^2/2) / (2^{k/2-1}\,\Gamma(k/2))$. **Match.**
* `pareto` — JKB eq. (20.3) at $k=1$: $b\,x^{-(b+1)}$. **Match** (scipy ``b`` ↔ JKB ``a``).
* `weibull_min` — JKB eq. (21.2): $c\,x^{c-1} \exp(-x^c)$. **Match.**
* `weibull_max` — same chapter; sign change $Y=-X$ is described in the same Definition section.

#### Format

Mirrors @nickodell's gh-25105: textbook as `[1]`, Wikipedia as `[2]`. Two exceptions:

* `cauchy` already has a Boost C++ Libraries entry referenced as `[1]_` in the body text. To avoid renumbering the in-body cross-reference, Boost stays as `[1]`, textbook becomes `[2]`, Wikipedia becomes `[3]`.
* `norm` and `chi` had no `References` section when this PR was opened; gh-25819 has since added a Wikipedia entry to each. Those entries are kept verbatim and renumbered to `[2]`, behind the textbook citation, so the ordering still matches gh-25105. Neither docstring cross-references `[1]_` in its body text, so the renumbering is safe.
* `weibull_min` / `weibull_max` previously had a bare-URL `References` block (no `[n]` form). This PR upgrades it to the standard numbered form with the textbook added as `[1]`; the existing Wikipedia link to the Fisher-Tippett-Gnedenko theorem is preserved as `[3]`.

#### Additional information

* Diff is docstring-only, no behaviour changes: one file, 51 insertions, 8 deletions against current `main`.
* The 8 deletions are not content removals — 2 are the `[1]` to `[2]` renumbering for `norm` and `chi`, and 6 are the bare-URL lines replaced by the numbered form in `weibull_min` / `weibull_max`.
* Two pre-existing `ruff E741` warnings in `_continuous_distns.py` are unrelated to this change.
* No `Notes` paragraphs were modified — the `References` section is appended after the existing `%(after_notes)s` template substitution (or, for `lognorm`, between the existing post-`%(after_notes)s` prose and `%(example)s`, since the docstring places explanatory text there).

#### AI Generation Disclosure

I used Claude (Anthropic's LLM coding assistant) to:

* draft the PR description and the textbook bibliographic entries,
* compare each scipy PDF formula against the textbook's defining equation in the cited edition before this PR was opened.

For the 2026-09-01 update I used Claude to rebuild the reviewed changes on current `main`, identify the overlap with gh-25819, and revise this description. The docstring content is unchanged in substance from the version verified below.

Each formula match was checked visually against the printed equation in JKB Vol. 1 (2nd ed., 1994) before this PR was opened. I read the resulting diff, am the human submitting this patch, and stand behind it under SciPy's responsibility / AI policy. No AI agent submitted this autonomously.
