### PR TITLE
MAINT/TST: sparse: Require 64 GiB for test_large_assignments()

### DIFF
--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -1,6 +1,7 @@
 import warnings
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_, assert_array_equal
+from scipy._lib._testutils import check_free_memory
 from scipy.sparse import csr_matrix, csc_matrix, csr_array, csc_array, hstack
 from scipy import sparse
 import pytest
@@ -230,6 +231,9 @@ def test_broadcast_to():
 @pytest.mark.xslow
 def test_large_assignments():
     # When nnz grows bigger than int32 can hold, shift to int64 index arrays
+
+    # This test requires *a lot* of memory!
+    check_free_memory(65536)
 
     # parametrize puts lots of slow stuff into pytest's collection phase. So dont use it
     def check(A_info, index, rhs):


### PR DESCRIPTION
Running the sparse test `test_large_assignments()` on a machine with insufficient memory is likely to crash the interpreter.

#### Reference issue

The test was added in https://github.com/scipy/scipy/pull/24951.


#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI tools used.