### PR TITLE
DOC: fix typo of "firwin" in iirdesign

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2510,7 +2510,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
         Note, that for bandpass and bandstop filters passband must lie strictly
         inside stopband or vice versa. Also note that the cutoff at the band edges
         for IIR filters is defined as half-power, so -3dB, not half-amplitude (-6dB)
-        like for `scipy.signal.fiwin`.
+        like for `scipy.signal.firwin`.
     gpass : float
         The maximum loss in the passband (dB).
     gstop : float


### PR DESCRIPTION
[docs only]

#### Reference issue
None.

#### What does this implement/fix?
I found this very old typo of `firwin` whilst reading the iirfilter.

#### Additional information
I'm not familiar with sphinx/doc autogeneration etc, is this supposed to automatically create a link back to firwin now I spotted it?

#### AI Generation Disclosure
No AI tools were used in this 1 byte change.
