### PR TITLE
DOC: clarify `root(method="hybr")` `eps` option

### DIFF
--- a/scipy/optimize/_minpack_py.py
+++ b/scipy/optimize/_minpack_py.py
@@ -81,11 +81,11 @@ def fsolve(func, x0, args=(), fprime=None, full_output=False,
         super-diagonals within the band of the Jacobi matrix, the
         Jacobi matrix is considered banded (only for ``fprime=None``).
     epsfcn : float, optional
-        A suitable step length for the forward-difference
-        approximation of the Jacobian (for ``fprime=None``). If
-        `epsfcn` is less than the machine precision, it is assumed
-        that the relative errors in the functions are of the order of
-        the machine precision.
+        A variable used in determining a suitable step length for the
+        forward-difference approximation of the Jacobian (for
+        ``fprime=None``). The step length for variable ``i`` is
+        ``sqrt(max(epsfcn, machine precision)) * abs(x[i])``, or
+        ``sqrt(max(epsfcn, machine precision))`` if ``x[i]`` is zero.
     factor : float, optional
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in the interval
@@ -215,11 +215,11 @@ def _root_hybr(func, x0, args=(), jac=None,
         super-diagonals within the band of the Jacobi matrix, the
         Jacobi matrix is considered banded (only for ``jac=None``).
     eps : float
-        A suitable step length for the forward-difference
-        approximation of the Jacobian (for ``jac=None``). If
-        `eps` is less than the machine precision, it is assumed
-        that the relative errors in the functions are of the order of
-        the machine precision.
+        Passed to MINPACK as ``epsfcn``, a variable used in determining
+        a suitable step length for the forward-difference approximation
+        of the Jacobian (for ``jac=None``). The step length for variable
+        ``i`` is ``sqrt(max(eps, machine precision)) * abs(x[i])``, or
+        ``sqrt(max(eps, machine precision))`` if ``x[i]`` is zero.
     factor : float
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in the interval
@@ -332,9 +332,9 @@ def leastsq(func, x0, args=(), Dfun=None, full_output=False,
     epsfcn : float, optional
         A variable used in determining a suitable step length for the forward-
         difference approximation of the Jacobian (for Dfun=None).
-        Normally the actual step length will be sqrt(epsfcn)*x
-        If epsfcn is less than the machine precision, it is assumed that the
-        relative errors are of the order of the machine precision.
+        The step length for variable ``i`` is ``sqrt(max(epsfcn, machine
+        precision)) * abs(x[i])``, or ``sqrt(max(epsfcn, machine
+        precision))`` if ``x[i]`` is zero.
     factor : float, optional
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in interval ``(0.1, 100)``.

--- a/scipy/optimize/_root.py
+++ b/scipy/optimize/_root.py
@@ -300,10 +300,11 @@ def _root_leastsq(fun, x0, args=(), jac=None,
         The maximum number of calls to the function. If zero, then
         100*(N+1) is the maximum where N is the number of elements in x0.
     eps : float
-        A suitable step length for the forward-difference approximation of
-        the Jacobian (for Dfun=None). If `eps` is less than the machine
-        precision, it is assumed that the relative errors in the functions
-        are of the order of the machine precision.
+        Passed to MINPACK as ``epsfcn``, a variable used in determining
+        a suitable step length for the forward-difference approximation
+        of the Jacobian (for Dfun=None). The step length for variable
+        ``i`` is ``sqrt(max(eps, machine precision)) * abs(x[i])``, or
+        ``sqrt(max(eps, machine precision))`` if ``x[i]`` is zero.
     factor : float
         A parameter determining the initial step bound
         (``factor * || diag * x||``). Should be in interval ``(0.1, 100)``.


### PR DESCRIPTION
#### Reference issue

None.

#### What does this implement/fix?

Clarifies the finite-difference step semantics for MINPACK-backed `eps` and `epsfcn` options. The descriptions were plain wrong in some places.

These options are used to determine a finite-difference step; they are not always the literal perturbation used directly. MINPACK computes the finite-difference scale as:

```text
sqrt(max(epsfcn, machine_precision))
```

so `options={"eps": 1e-10}` in `root(method="hybr")` gives an approximate perturbation scale of `1e-5` for variables near magnitude 1.

Some docstrings described `eps` or `epsfcn` as a "step length", which can make users think the value is the literal perturbation used for the forward-difference Jacobian. That is not how the MINPACK-backed paths behave.

This updates the docs for:

- `fsolve(..., epsfcn=...)`
- `root(method="hybr", options={"eps": ...})`
- `leastsq(..., epsfcn=...)`
- `root(method="lm", options={"eps": ...})`

#### Additional information

Docs-only change. No runtime behavior changed.

Verified against:

- `_root_hybr`, which assigns `epsfcn = eps` and passes it to `_minpack._hybrd`
- `_root_leastsq`, which passes `eps` to `leastsq` as `epsfcn`
- MINPACK `fdjac1` and `fdjac2`, which compute `sqrt(max(epsfcn, epsmch))`

I ran:

```bash
git diff --check origin/main...HEAD
git show --check HEAD
```

I also rendered a lightweight docutils preview of the changed paragraphs. I did not build the full SciPy docs locally.

#### AI Generation Disclosure

This PR was prepared with OpenAI Codex. Codex helped inspect the relevant SciPy source, identify related docstrings, draft the documentation wording, render a lightweight preview, and draft this PR description. The changed documentation text and PR description are AI-assisted and reviewed/modified by me.
