### PR TITLE
CI: Fix ccache directory inside the CircleCI docs build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,12 @@ jobs:
           command: |
             spin build -j2
 
+      - run:
+          name: ccache performance
+          command: |
+            ccache --evict-older-than 1d
+            ccache -s
+
       - save_cache:
           key: pip-{{ .Branch }}
           paths:
@@ -108,12 +114,6 @@ jobs:
           key: ccache-{{ .Branch }}
           paths:
             - ~/.ccache
-
-      - run:
-          name: ccache performance
-          command: |
-            ccache --evict-older-than 1d
-            ccache -s
 
       - persist_to_workspace:
           root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,7 @@ jobs:
       - run:
           name: ccache performance
           command: |
+            ccache --evict-older-than 1d
             ccache -s
 
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,8 @@ jobs:
 # Build SciPy from source
   build_scipy:
     <<: *defaults
+    environment:
+      CCACHE_DIR: /home/circleci/.ccache
     steps:
       - checkout
       - check-skip
@@ -68,8 +70,13 @@ jobs:
 
       - restore_cache:
           keys:
-              - deps_ccache-{{ .Branch }}
-              - deps_ccache
+              - pip-{{ .Branch }}
+              - pip
+
+      - restore_cache:
+          keys:
+              - ccache-{{ .Branch }}
+              - ccache
 
       - run:
           name: setup Python venv
@@ -82,15 +89,24 @@ jobs:
             pip install pyfftw cffi pytest
 
       - run:
+          name: clear ccache stats
+          command: |
+            ccache --zero-stats
+
+      - run:
           name: build SciPy
           command: |
             spin build -j2
 
       - save_cache:
-          key: deps_ccache-{{ .Branch }}
+          key: pip-{{ .Branch }}
+          paths:
+            - ~/.cache/pip
+
+      - save_cache:
+          key: ccache-{{ .Branch }}
           paths:
             - ~/.ccache
-            - ~/.cache/pip
 
       - run:
           name: ccache performance

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
     <<: *defaults
     environment:
       CCACHE_DIR: /home/circleci/.ccache
+      CCACHE_MAXSIZE: "250M"
     steps:
       - checkout
       - check-skip


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

The CircleCI docs build is set up to use ccache, but it is caching the wrong directory. ccache inside CircleCI is currently not doing anything. It gets 0 cache hits.

```
Summary:
  Hits:               0 /  914 (0.00 %)
    Direct:           0 /  914 (0.00 %)
    Preprocessed:     0 /  914 (0.00 %)
  Misses:           914
    Direct:         914
    Preprocessed:   914
Primary storage:
  Hits:               0 / 1828 (0.00 %)
  Misses:          1828
  Cache size (GB): 0.26 / 5.00 (5.12 %)

Use the -v/--verbose option for more details.
```

By default ccache uses this directory on this platform:

```
$ docker run -it cimg/python:3.13.10
[...]
$ ccache --show-conf | grep cache_dir               
(default) cache_dir = /home/circleci/.cache/ccache
```

but the `save_cache` step is set up to use `~/.ccache`, leading to 0 cache hits.

Also, do a few bits of maintenance, to match how ccache is used elsewhere.

1. Zero cache stats on load so that cache statistics reflect just this run.
2. Separate ccache and pip caches so we can tell how much is used by each.
3. Limit ccache size to 250 MB.
4. Evict cache entries not accessed during job.

#### Additional information

##### Timing results

Baseline: [24m 21s](https://app.circleci.com/pipelines/github/scipy/scipy/40512/workflows/c95717ed-ab9e-40a7-b617-dea7be160c80/jobs/141771)

No cache hit: [23m 52s](https://app.circleci.com/pipelines/github/scipy/scipy/40518/workflows/a7abeecd-29b3-4f25-a313-c4ee77f3f504/jobs/141796)

With cache hit: [7m 46s](https://app.circleci.com/pipelines/github/scipy/scipy/40519/workflows/08cccece-b31a-4fb2-8f6a-792ca929711d/jobs/141800)

This makes the build_scipy step take 63% less time.

#### AI Generation Disclosure

No AI tools used.