### PR TITLE
BUG: special: fix subtle ufunc loop bug by updating xsf

### DIFF
--- a/scipy/special/tests/meson.build
+++ b/scipy/special/tests/meson.build
@@ -59,6 +59,7 @@ python_sources = [
   'test_wrightomega.py',
   'test_zeta.py',
   'test_boost_ufuncs.py',
+  'test_ufunc_infra.py'
 ]
 
 

--- a/scipy/special/tests/test_ufunc_infra.py
+++ b/scipy/special/tests/test_ufunc_infra.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from scipy.special import mathieu_sem
+# from scipy.special._ufuncs import _mathieu_sem
+
+
+@pytest.mark.parametrize("m_shape,q_shape,x_shape,where_shape", [
+    ((5, 1), (1, 1), (1, 10), ()),
+    ((2, 3), (2, 3), (2, 3), ()),
+    ((1, 5), (1, 5), (10, 5), ()),
+    ((5, 1), (1, 1), (1, 10), (1, 10)),
+    ((2, 3), (2, 3), (2, 3), (2, 3)),
+    ((1, 5), (1, 5), (10, 5), (10, 5)),
+    ((5, 1), (1, 1), (1, 10), (5, 1)),
+])
+def test_out(m_shape, q_shape, x_shape, where_shape):
+    rng = np.random.default_rng(1234)
+
+    m = rng.integers(1, 20, m_shape)
+    q = rng.uniform(0, 10, q_shape)
+    x = rng.uniform(0, 90, x_shape)
+
+    if where_shape == ():
+        batch_shape = np.broadcast_shapes(m_shape, q_shape, x_shape)
+        where = True
+    else:
+        where = rng.choice([True, False], size=where_shape)
+        batch_shape = np.broadcast_shapes(m_shape, q_shape, x_shape, where_shape)
+
+    out0 = np.empty(batch_shape)
+    out1 = np.empty(batch_shape)
+    res0, res1 = mathieu_sem(m, q, x, out=(out0, out1), where=where)
+    assert res0 is out0 and res1 is out1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
While working on https://github.com/scipy/xsf/pull/144 and the associated scipy feature branch https://github.com/steppi/scipy/tree/mathieu-brorson, I wrote extensive tests for Mathieu functions to try to hit edge cases in machinery I've been working on for performance optimization. The following script leads to a segfault on my machine

```python
import numpy as np
from scipy.special import mathieu_sem

rng = np.random.default_rng(1234)

vals = [
    ((5, 1), (1, 1), (1, 10), ()),
    ((2, 3), (2, 3), (2, 3), ()),
    ((1, 5), (1, 5), (10, 5), ()),
    ((5, 1), (1, 1), (1, 10), (1, 10)),
    ((2, 3), (2, 3), (2, 3), (2, 3)),
    ((1, 5), (1, 5), (10, 5), (10, 5)),
    ((5, 1), (1, 1), (1, 10), (5, 1)),
]

for m_shape, q_shape, x_shape, where_shape in vals:
    m = rng.integers(1, 20, m_shape)
    q = rng.uniform(0, 10, q_shape)
    x = rng.uniform(0, 90, x_shape)
    where = rng.choice([True, False], size=where_shape)
    batch_shape = np.broadcast_shapes(m_shape, q_shape, x_shape, where_shape)

    out0 = np.empty(batch_shape)
    out1 = np.empty(batch_shape)
    out = (out0, out1)
    res0, res1 = mathieu_sem(m, q, x, out=out, where=where)
    assert out0 is res0 and out1 is res1
```

not just on my feature branch for Mathieu functions linked above, but on `main`.  With some assistance from Google Gemini Pro, I was able to isolate this to a subtle bug in the ufunc infrastructure in `xsf/include/xsf/numpy.h`. I've added a test here which segfaults without the patch https://github.com/scipy/xsf/pull/146 to xsf.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
I had a running chat going with Google Gemini Pro while debugging this.
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
