### PR TITLE
ENH: signal.oaconvolve: add JAX support

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -1048,9 +1048,10 @@ def oaconvolve(in1, in2, mode="full", axes=None):
         ret, overpart = _split(ret, [-overlap], ax_fft, xp=xp)
         overpart = _split(overpart, [-1], ax_split, xp=xp)[0]
 
-        ret_overpart = _split(ret, [overlap], ax_fft, xp=xp)[0]
-        ret_overpart = _split(ret_overpart, [1], ax_split, xp)[1]
-        ret_overpart += overpart
+        overlap_slice = [slice(None)] * ret.ndim
+        overlap_slice[ax_fft] = slice(0, overlap)
+        overlap_slice[ax_split] = slice(1, None)
+        ret = xpx.at(ret)[tuple(overlap_slice)].add(overpart)
 
     # Reshape back to the correct dimensionality.
     shape_ret = [ret.shape[i] if i not in fft_axes else

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -302,7 +302,6 @@ capabilities_overrides = {
                                  jax_jit=False, allow_dask_compute=True),
     "oaconvolve": xp_capabilities(
         cpu_only=True, exceptions=["cupy", "torch"],
-        skip_backends=[("jax.numpy", "fails all around")],
         xfail_backends=[("dask.array", "wrong answer")],
     ),
     "order_filter": xp_capabilities(cpu_only=True, exceptions=["cupy"],


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/scipy/issues/18867

#### What does this implement/fix?

[`signal.oaconvolve`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.oaconvolve.html) used an in-place update on a split view during the overlap-add step. This does not work with immutable array backends such as JAX, where updating the selected array does not update the original result

This PR replaces the mutable-view update with an explicit indexed add via `xpx.at(...).add(...)`.

#### Additional information
<!--Any additional information you think is important.-->
@ev-br suggested this issue to start contributing to the array-api. This is my first PR related to it.

Running `pixi run test-jax -t scipy/signal/tests/test_signaltools.py::TestOAConvolve -v` passed locally on my machine.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I knew that JAX arrays are immutable and thought that this part of the code would be the issue. I've worked with Codex to add a patch. I've drafted a Python script explaining the change, testing it on a small example and Codex improved it. 

<details>

```python
import numpy as np


def foo(ret, overpart, overlap, ax_fft, ax_split, style="old"):
    # keep ret[..., :-overlap] and discard ret[..., -overlap:]
    ret, _ = np.split(ret, [-overlap], axis=ax_fft)

    if style == "old":
        # select ret[..., 0:overlap, ...]
        ret_overpart = np.split(ret, [overlap], axis=ax_fft)[0]
        # select ret[..., 1:, 0:overlap, ...]
        ret_overpart = np.split(ret_overpart, [1], axis=ax_split)[1]
        # ret[..., 1:, 0:overlap, ...] += overpart via mutable view
        ret_overpart += overpart
    else:
        # create a slice object for ret[..., 1:, 0:overlap, ...]
        overlap_slice = [slice(None)] * ret.ndim  # start with ret[..., :, :, ...]
        overlap_slice[ax_fft] = slice(0, overlap)  # change ax_fft to 0:overlap
        overlap_slice[ax_split] = slice(1, None)  # change ax_split to 1:
        # ret[..., 1:, 0:overlap, ...] += overpart directly
        ret[tuple(overlap_slice)] += overpart

    return ret

ret = np.arange(2 * 3 * 5).reshape(2, 3, 5)
overlap = 2
ax_split = 1
ax_fft = 2
overpart = np.full((2, 2, 2), 100)

old = foo(ret.copy(), overpart, overlap, ax_fft, ax_split, "old")
new = foo(ret.copy(), overpart, overlap, ax_fft, ax_split, "new")

print(np.array_equal(old, new))
print(new)
```

</details>
