### PR TITLE
BUG: signal: backwards compat in savgol/lstsq

### DIFF
--- a/scipy/signal/_polyutils.py
+++ b/scipy/signal/_polyutils.py
@@ -80,7 +80,7 @@ def _lstsq(a, b, xp=None, rcond=None):
     a, b = xp_promote(a, b, force_floating=True, xp=xp)
 
     if rcond is None:
-        rcond = xp.finfo(a.dtype).eps * max(a.shape[-1], a.shape[-2])
+        rcond = xp.finfo(a.dtype).eps
 
     if is_numpy(xp):
         from scipy.linalg import lstsq as s_lstsq


### PR DESCRIPTION
The default rcond value in scipy.linalg.lstsq is `eps`, not `n*eps`. Savitzky-Golay filter was using the default value, and in scipy==1.17 it got changed to `n*eps`, which changes user-visible results, per gh-25133.

Thus restore it back to `eps`.

Closes gh-25133

Have added a _backport-candidate_ label for an unlikely case there is a 1.17.2 release. Otherwise, it should just land in 1.18. 

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.