### PR TITLE
DOC: add example for signal.sos2zpk

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -1446,6 +1446,24 @@ def sos2zpk(sos):
     even if some of these are (effectively) zero.
 
     .. versionadded:: 0.16.0
+
+    Examples
+    --------
+    Convert a second-order Butterworth filter from second-order sections
+    to zeros, poles, and gain format.
+
+    >>> import numpy as np
+    >>> from scipy import signal
+    >>> sos = signal.butter(2, 0.25, output='sos')
+    >>> z, p, k = signal.sos2zpk(sos)
+    >>> np.round(z.real, 4)
+    array([-1., -1.])
+    >>> np.round(p, 4)
+    array([0.4714+0.3333j, 0.4714-0.3333j])
+    >>> f"{k:.4f}"
+    '0.0976'
+    >>> np.allclose(signal.zpk2sos(z, p, k), sos)
+    True
     """
     xp = array_namespace(sos)
     sos = xp.asarray(sos)


### PR DESCRIPTION
#### Reference issue

Contributes to gh-7168.

#### What does this implement/fix?

Adds an `Examples` section to the `scipy.signal.sos2zpk` docstring.
The example shows how to create a second-order Butterworth filter in
second-order sections form, convert it to zeros-poles-gain form with
`sos2zpk`, and verify the round-trip conversion with `zpk2sos`.

#### Additional information

This is a documentation-only change. 

`[docs only]`

I verified the example locally:

```python
import numpy as np
from scipy import signal

sos = signal.butter(2, 0.25, output='sos')
z, p, k = signal.sos2zpk(sos)
print(np.round(z.real, 4))
print(np.round(p, 4))
print(f"{k:.4f}")
print(np.allclose(signal.zpk2sos(z, p, k), sos))
```

Observed output:

```text
[-1. -1.]
[0.4714+0.3333j 0.4714-0.3333j]
0.0976
True
```

Also checked with:

```text
python -m py_compile scipy/signal/_filter_design.py
git diff --check
```

#### AI Generation Disclosure

AI tools were used in the preparation of this pull request.

**Tool used:** ChatGPT / Codex

**How it was used:**
- To help identify a small documentation target from gh-7168
- To inspect the surrounding `sos2zpk` docstring context
- To draft an initial version of the docstring example and validation commands

**AI-assisted content:**
- The initial wording and structure of the added docstring example

**Human review:**
- I reviewed the final docstring example before submitting
- I ran the example locally and confirmed the outputs match what is shown
- I understand that `sos2zpk` decomposes second-order sections into zeros, poles, and gain, and that the `zpk2sos` round-trip check verifies the conversion is consistent for this filter