### PR TITLE
DEV/BENCH: make `--dry-run` configurable in `spin bench`

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -868,11 +868,15 @@ def _dirty_git_working_dir():
         "'jax.numpy', 'dask.array')."
     )
 )
+@click.option(
+    '--dry-run', '-n', is_flag=True, default=True,
+    help="Run benchmarks without saving results to disk (default: True). "
+)
 @meson.build_option
 @meson.build_dir_option
 @click.pass_context
 def bench(ctx, tests, submodule, compare, verbose, quick,
-          commits, array_api_backend, build, build_dir, *args, **kwargs):
+          commits, array_api_backend, dry_run, build, build_dir, *args, **kwargs):
     """🔧 Run benchmarks.
 
     \b
@@ -908,6 +912,9 @@ def bench(ctx, tests, submodule, compare, verbose, quick,
     if quick:
         bench_args = ['--quick'] + bench_args
 
+    if dry_run:
+        bench_args = ['--dry-run'] + bench_args
+
     if len(array_api_backend) != 0:
         os.environ['SCIPY_ARRAY_API'] = json.dumps(list(array_api_backend))
 
@@ -936,7 +943,7 @@ def bench(ctx, tests, submodule, compare, verbose, quick,
             f'Running benchmarks on SciPy {np_ver}',
             bold=True, fg="bright_green"
         )
-        cmd = ['asv', 'run', '--dry-run', '--show-stderr', '--python=same'] + bench_args
+        cmd = ['asv', 'run', '--show-stderr', '--python=same'] + bench_args
         _run_asv(cmd)
     else:
         # Ensure that we don't have uncommited changes

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -869,8 +869,8 @@ def _dirty_git_working_dir():
     )
 )
 @click.option(
-    '--dry-run', '-n', is_flag=True, default=True,
-    help="Run benchmarks without saving results to disk (default: True). "
+    '--dry-run/--no-dry-run', '-n', default=True,
+    help="Run benchmarks without saving results to disk. "
 )
 @meson.build_option
 @meson.build_dir_option


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/25132

#### What does this implement/fix?
<!--Please explain your changes.-->

Previously, `spin bench` always invoked `asv run` with `--dry-run`,meaning benchmark results were never saved to disk. This was frustrating for users running long benchmarks (e.g. on a SLURM cluster) only to find that no results were persisted at the end.

This PR adds a `--dry-run` / `-n` flag to `spin bench` (default: `True` for backwards compatibility). Users can pass `--dry-run False` to save results to disk.

## Changes

- Added `--dry-run` / `-n` click option to the `bench` command default `True`).
- `--dry-run` is forwarded to `asv` via `bench_args`, following the same pattern as `--quick`.
- Removed the hard-coded `--dry-run` from the `asv run` invocation.

## Usage

```bash
# Default behaviour (unchanged): results not saved
spin bench -t linalg.Norm

# Save results to disk
spin bench -t linalg.Norm --dry-run False
```

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI tools used