### PR TITLE
TST: add regression test for #22705

### DIFF
--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3982,6 +3982,17 @@ class TestBessel:
         x = special.ivp(1,2)
         assert_allclose(x, y, atol=1.5e-10, rtol=0)
 
+    @pytest.mark.parametrize("x, expected",
+        [(1e15, 6.156638646885021e-09),  # 1/sqrt(eps) < x < 1/eps
+         (1e30, -5.589003016686147e-16)  # x > 1/eps
+        ])
+    def test_gh22705(self, x, expected):
+        # reference values computed with mpmath
+        # from mpmath import mp
+        # mp.dps = 1000
+        # float(mp.besselj(0, mp.mpf('1e15')))
+        assert_allclose(special.j0(x), expected, rtol=5e-15)
+
 
 class TestLaguerre:
     def test_laguerre(self):


### PR DESCRIPTION
#### Reference issue
Closes #22705 

#### What does this implement/fix?
#22705 was closed in xsf by https://github.com/scipy/xsf/pull/131 . This PR adds a small regression test as the main testing should be done in xsf itself.

#### AI Generation Disclosure
No AI use.
