### PR TITLE
ENH: migrate `special.ncfdtrinc` to boost

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -5665,6 +5665,16 @@ add_newdoc("ncfdtrinc",
     ncfdtridfd : Inverse of `ncfdtr` with respect to `dfd`.
     ncfdtridfn : Inverse of `ncfdtr` with respect to `dfn`.
 
+    Notes
+    -----
+    This function calculates the non-centrality parameter of the
+    non-central F distribution given a probability, quantile, and degrees
+    of freedom using the Boost Math C++ library [1]_.
+
+    References
+    ----------
+    .. [1] The Boost Developers. "Boost C++ Libraries". https://www.boost.org/.
+
     Examples
     --------
     >>> from scipy.special import ncfdtr, ncfdtrinc

--- a/scipy/special/_cdflib_wrappers.pxd
+++ b/scipy/special/_cdflib_wrappers.pxd
@@ -22,7 +22,6 @@ cdef extern from "cdflib.h" nogil:
     TupleDID cdff_which4(double, double, double, double);
     TupleDID cdffnc_which3(double, double, double, double, double);
     TupleDID cdffnc_which4(double, double, double, double, double);
-    TupleDID cdffnc_which5(double, double, double, double, double);
     TupleDID cdft_which3(double, double, double);
     TupleDID cdftnc_which3(double, double, double, double);
     TupleDID cdftnc_which4(double, double, double, double);
@@ -127,28 +126,6 @@ cdef inline double ncfdtridfn(double p, double dfd, double nc, double f) noexcep
     ret = cdffnc_which3(p, q, f, dfd, nc)
     result, status, bound = ret.d1, ret.i1, ret.d2
     return get_result("ncfdtridfn", argnames, result, status, bound, 1)
-
-
-cdef inline double ncfdtrinc(double dfn, double dfd, double p, double f) noexcept nogil:
-    cdef:
-        double q = 1.0 - p
-        double result, bound
-        int status = 10
-        char *argnames[5]
-        TupleDID ret
-
-    if isnan(dfn) or isnan(dfd) or isnan(p) or isnan(f):
-      return NAN
-
-    argnames[0] = "p"
-    argnames[1] = "q"
-    argnames[2] = "f"
-    argnames[3] = "dfn"
-    argnames[4] = "dfd"
-
-    ret = cdffnc_which5(p, q, f, dfn, dfd)
-    result, status, bound = ret.d1, ret.i1, ret.d2
-    return get_result("ncfdtrinc", argnames, result, status, bound, 1)
 
 
 cdef inline double nctdtridf(double p, double nc, double t) noexcept nogil:

--- a/scipy/special/boost_special_functions.h
+++ b/scipy/special/boost_special_functions.h
@@ -1211,6 +1211,53 @@ ncf_isf_double(double x, double v1, double v2, double l)
     return ncf_isf_wrap(x, v1, v2, l);
 }
 
+// Wrapper for Boost noncentral F find_non_centrality
+template<typename Real>
+Real
+ncf_find_non_centrality_wrap(const Real dfn, const Real dfd, const Real p, const Real f)
+{
+    if (std::isnan(dfn) || std::isnan(dfd) || std::isnan(p) || std::isnan(f)) {
+        return NAN;
+    }
+    if (dfn <= 0 || dfd <= 0 || p < 0 || p > 1 || f < 0) {
+        sf_error("ncfdtrinc", SF_ERROR_DOMAIN, NULL);
+        return NAN;
+    }
+    Real y;
+    try {
+        y = boost::math::non_central_f_distribution<Real, SpecialPolicy>::find_non_centrality(f, dfn, dfd, p);
+    } catch (const std::domain_error& e) {
+        sf_error("ncfdtrinc", SF_ERROR_DOMAIN, NULL);
+        y = NAN;
+    } catch (const std::underflow_error& e) {
+        sf_error("ncfdtrinc", SF_ERROR_UNDERFLOW, NULL);
+        y = 0;
+    } catch (const std::overflow_error& e) {
+        sf_error("ncfdtrinc", SF_ERROR_OVERFLOW, NULL);
+        y = INFINITY;
+    } catch (...) {
+        sf_error("ncfdtrinc", SF_ERROR_OTHER, NULL);
+        y = NAN;
+    }
+    if (y < 0) {
+        sf_error("ncfdtrinc", SF_ERROR_NO_RESULT, NULL);
+        y = NAN;
+    }
+    return y;
+}
+
+float
+ncf_find_non_centrality_float(float dfn, float dfd, float p, float f)
+{
+    return ncf_find_non_centrality_wrap(dfn, dfd, p, f);
+}
+
+double
+ncf_find_non_centrality_double(double dfn, double dfd, double p, double f)
+{
+    return ncf_find_non_centrality_wrap(dfn, dfd, p, f);
+}
+
 #define RETURN_NAN(v, c) if( v <= c ) { \
         return NAN; \
     } \

--- a/scipy/special/cdflib.c
+++ b/scipy/special/cdflib.c
@@ -1631,60 +1631,6 @@ struct TupleDID cdffnc_which4(double p, double q, double f, double dfn, double p
 }
 
 
-struct TupleDID cdffnc_which5(double p, double q, double f, double dfn, double dfd)
-{
-    double tol = 1e-10;
-    double atol = 1e-50;
-    DinvrState DS = {0};
-    DzrorState DZ = {0};
-
-    DS.small = 0.;
-    DS.big = 1e4;
-    DS.absstp = 0.5;
-    DS.relstp = 0.5;
-    DS.stpmul = 5.;
-    DS.abstol = atol;
-    DS.reltol = tol;
-    DS.x = 5.;
-    struct TupleDDI fncret;
-    struct TupleDID ret = {0};
-
-    if (!((0 <= p) && (p <= (1. - 1e-16)))) {
-        ret.i1 = -1;
-        ret.d2 = (!(p > 0.0) ? 0.0 : (1. - 1e-16));
-        return ret;
-    }
-    if (!(0 <= f)) {
-        return (struct TupleDID){.d1 = 0.0, .d2 = 0.0, .i1 = -3};
-    }
-    if (!(0 < dfn)) {
-        return (struct TupleDID){.d1 = 0.0, .d2 = 0.0, .i1 = -4};
-    }
-    if (!(0 < dfd)) {
-        return (struct TupleDID){.d1 = 0.0, .d2 = 0.0, .i1 = -4};
-    }
-    dinvr(&DS, &DZ);
-    while (DS.status == 1) {
-        fncret = cumfnc(f, dfn, dfd, DS.x);
-        DS.fx = fncret.d1 - p;
-        if (fncret.i1 != 0) {
-            return (struct TupleDID){.d1 = DS.x, .d2 = 0.0, .i1 = 10};
-        }
-        dinvr(&DS, &DZ);
-    }
-
-    if (DS.status == -1) {
-        ret.d1 = DS.x;
-        ret.i1 = (DS.qleft ? 1 : 2);
-        ret.d2 = (DS.qleft ? 0 : 1e4);
-        return ret;
-    } else {
-        ret.d1 = DS.x;
-        return ret;
-    }
-}
-
-
     //               Cumulative Distribution Function
     //                         T distribution
     //

--- a/scipy/special/cdflib.h
+++ b/scipy/special/cdflib.h
@@ -108,7 +108,6 @@ typedef struct DzrorState DzrorState;
 struct TupleDID cdff_which4(double, double, double, double);
 struct TupleDID cdffnc_which3(double, double, double, double, double);
 struct TupleDID cdffnc_which4(double, double, double, double, double);
-struct TupleDID cdffnc_which5(double, double, double, double, double);
 struct TupleDID cdft_which3(double, double, double);
 struct TupleDID cdftnc_which3(double, double, double, double);
 struct TupleDID cdftnc_which4(double, double, double, double);

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -1703,10 +1703,6 @@ from ._cdflib_wrappers cimport ncfdtridfn as _func_ncfdtridfn
 ctypedef double _proto_ncfdtridfn_t(double, double, double, double) noexcept nogil
 cdef _proto_ncfdtridfn_t *_proto_ncfdtridfn_t_var = &_func_ncfdtridfn
 
-from ._cdflib_wrappers cimport ncfdtrinc as _func_ncfdtrinc
-ctypedef double _proto_ncfdtrinc_t(double, double, double, double) noexcept nogil
-cdef _proto_ncfdtrinc_t *_proto_ncfdtrinc_t_var = &_func_ncfdtrinc
-
 from ._cdflib_wrappers cimport nctdtridf as _func_nctdtridf
 ctypedef double _proto_nctdtridf_t(double, double, double) noexcept nogil
 cdef _proto_nctdtridf_t *_proto_nctdtridf_t_var = &_func_nctdtridf
@@ -3125,7 +3121,7 @@ cpdef double ncfdtridfn(double x0, double x1, double x2, double x3) noexcept nog
 
 cpdef double ncfdtrinc(double x0, double x1, double x2, double x3) noexcept nogil:
     """See the documentation for scipy.special.ncfdtrinc"""
-    return _func_ncfdtrinc(x0, x1, x2, x3)
+    return (<double(*)(double, double, double, double) noexcept nogil>scipy.special._ufuncs_cxx._export_ncf_find_non_centrality_double)(x0, x1, x2, x3)
 
 cpdef df_number_t nctdtr(df_number_t x0, df_number_t x1, df_number_t x2) noexcept nogil:
     """See the documentation for scipy.special.nctdtr"""

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -558,8 +558,10 @@
             "ncfdtridfn": "dddd->d"        }
     },
     "ncfdtrinc": {
-        "_cdflib_wrappers.pxd": {
-            "ncfdtrinc": "dddd->d"        }
+        "boost_special_functions.h++": {
+            "ncf_find_non_centrality_float": "ffff->f",
+            "ncf_find_non_centrality_double": "dddd->d"
+        }
     },
     "nctdtr": {
         "boost_special_functions.h++": {

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -730,12 +730,6 @@ class TestCephes:
         p = cephes.ncfdtr(dfn, 2, 0.25, 15)
         assert_allclose(cephes.ncfdtridfn(p, 2, 0.25, 15), dfn, rtol=1e-5)
 
-    @pytest.mark.xfail(
-        reason=(
-            "ncfdtr uses a Boost math implementation but ncfdtrinc"
-            "inverts the less accurate cdflib implementation of ncfdtr."
-        )
-    )
     def test_ncfdtrinc(self):
         nc = [0.5, 1.5, 2.0]
         p = cephes.ncfdtr(2, 3, nc, 15)

--- a/scipy/special/tests/test_cdflib.py
+++ b/scipy/special/tests/test_cdflib.py
@@ -5,7 +5,6 @@ The following functions still need tests:
 
 - ncfdtridfn
 - ncfdtridfd
-- ncfdtrinc
 - nctdtridf
 - nctdtrinc
 
@@ -479,84 +478,95 @@ def test_bdtrik_nbdtrik_inf():
     assert np.all(np.isnan(sp.nbdtrik(y, np.inf, p)))
 
 
-@pytest.mark.parametrize(
-    "dfn,dfd,nc,f,expected_cdf",
-    [[100.0, 0.1, 0.1, 100.0, 0.29787396410092676],
-     [100.0, 100.0, 0.01, 0.1, 4.4344737598690424e-26],
-     [100.0, 0.01, 0.1, 0.01, 0.002848616633080384],
-     [10.0, 0.01, 1.0, 0.1, 0.012339557729057956],
-     [100.0, 100.0, 0.01, 0.01, 1.8926477420964936e-72],
-     [1.0, 100.0, 100.0, 0.1, 1.7925940526821304e-22],
-     [1.0, 0.01, 100.0, 10.0, 0.012334711965024968],
-     [1.0, 0.01, 10.0, 0.01, 0.00021944525290299],
-     [10.0, 1.0, 0.1, 100.0, 0.9219345555070705],
-     [0.1, 0.1, 1.0, 1.0, 0.3136335813423239],
-     [100.0, 100.0, 0.1, 10.0, 1.0],
-     [1.0, 0.1, 100.0, 10.0, 0.02926064279680897],
-     [1e-100, 3, 1.5, 1e100, 0.611815287345399]
-    ]
-)
-def test_ncfdtr_ncfdtri(dfn, dfd, nc, f, expected_cdf):
-    # Reference values computed with mpmath with the following script
-    #
-    # import numpy as np
-    #
-    # from mpmath import mp
-    # from scipy.special import ncfdtr
-    #
-    # mp.dps = 100
-    #
-    # def mp_ncfdtr(dfn, dfd, nc, f):
-    #     # Uses formula 26.2.20 from Abramowitz and Stegun.
-    #     dfn, dfd, nc, f = map(mp.mpf, (dfn, dfd, nc, f))
-    #     def term(j):
-    #         result = mp.exp(-nc/2)*(nc/2)**j / mp.factorial(j)
-    #         result *= mp.betainc(
-    #             dfn/2 + j, dfd/2, 0, f*dfn/(f*dfn + dfd), regularized=True
-    #         )
-    #         return result
-    #     result = mp.nsum(term, [0, mp.inf])
-    #     return float(result)
-    #
-    # dfn = np.logspace(-2, 2, 5)
-    # dfd = np.logspace(-2, 2, 5)
-    # nc = np.logspace(-2, 2, 5)
-    # f = np.logspace(-2, 2, 5)
-    #
-    # dfn, dfd, nc, f = np.meshgrid(dfn, dfd, nc, f)
-    # dfn, dfd, nc, f = map(np.ravel, (dfn, dfd, nc, f))
-    #
-    # cases = []
-    # re = []
-    # for x0, x1, x2, x3 in zip(*(dfn, dfd, nc, f)):
-    #     observed = ncfdtr(x0, x1, x2, x3)
-    #     expected = mp_ncfdtr(x0, x1, x2, x3)
-    #     cases.append((x0, x1, x2, x3, expected))
-    #     re.append((abs(expected - observed)/abs(expected)))
-    #
-    # assert np.max(re) < 1e-13
-    #
-    # rng = np.random.default_rng(1234)
-    # sample_idx = rng.choice(len(re), replace=False, size=12)
-    # cases = np.array(cases)[sample_idx].tolist()
-    assert_allclose(sp.ncfdtr(dfn, dfd, nc, f), expected_cdf, rtol=1e-13, atol=0)
-    # testing tails where the CDF reaches 0 or 1 does not make sense for inverses
-    # of a CDF as they are not bijective in these regions
-    if 0 < expected_cdf < 1:
-        assert_allclose(sp.ncfdtri(dfn, dfd, nc, expected_cdf), f, rtol=5e-11)
+class TestNoncentralF:
+    @pytest.mark.parametrize(
+        "dfn,dfd,nc,f,expected_cdf",
+        [[100.0, 0.1, 0.1, 100.0, 0.29787396410092676],
+        [100.0, 100.0, 0.01, 0.1, 4.4344737598690424e-26],
+        [100.0, 0.01, 0.1, 0.01, 0.002848616633080384],
+        [10.0, 0.01, 1.0, 0.1, 0.012339557729057956],
+        [100.0, 100.0, 0.01, 0.01, 1.8926477420964936e-72],
+        [1.0, 100.0, 100.0, 0.1, 1.7925940526821304e-22],
+        [1.0, 0.01, 100.0, 10.0, 0.012334711965024968],
+        [1.0, 0.01, 10.0, 0.01, 0.00021944525290299],
+        [10.0, 1.0, 0.1, 100.0, 0.9219345555070705],
+        [0.1, 0.1, 1.0, 1.0, 0.3136335813423239],
+        [100.0, 100.0, 0.1, 10.0, 1.0],
+        [1.0, 0.1, 100.0, 10.0, 0.02926064279680897],
+        [1e-100, 3, 1.5, 1e100, 0.611815287345399]
+        ]
+    )
+    def test_all(self, dfn, dfd, nc, f, expected_cdf):
+        # Reference values computed with mpmath with the following script
+        #
+        # import numpy as np
+        #
+        # from mpmath import mp
+        # from scipy.special import ncfdtr
+        #
+        # mp.dps = 100
+        #
+        # def mp_ncfdtr(dfn, dfd, nc, f):
+        #     # Uses formula 26.2.20 from Abramowitz and Stegun.
+        #     dfn, dfd, nc, f = map(mp.mpf, (dfn, dfd, nc, f))
+        #     def term(j):
+        #         result = mp.exp(-nc/2)*(nc/2)**j / mp.factorial(j)
+        #         result *= mp.betainc(
+        #             dfn/2 + j, dfd/2, 0, f*dfn/(f*dfn + dfd), regularized=True
+        #         )
+        #         return result
+        #     result = mp.nsum(term, [0, mp.inf])
+        #     return float(result)
+        #
+        # dfn = np.logspace(-2, 2, 5)
+        # dfd = np.logspace(-2, 2, 5)
+        # nc = np.logspace(-2, 2, 5)
+        # f = np.logspace(-2, 2, 5)
+        #
+        # dfn, dfd, nc, f = np.meshgrid(dfn, dfd, nc, f)
+        # dfn, dfd, nc, f = map(np.ravel, (dfn, dfd, nc, f))
+        #
+        # cases = []
+        # re = []
+        # for x0, x1, x2, x3 in zip(*(dfn, dfd, nc, f)):
+        #     observed = ncfdtr(x0, x1, x2, x3)
+        #     expected = mp_ncfdtr(x0, x1, x2, x3)
+        #     cases.append((x0, x1, x2, x3, expected))
+        #     re.append((abs(expected - observed)/abs(expected)))
+        #
+        # assert np.max(re) < 1e-13
+        #
+        # rng = np.random.default_rng(1234)
+        # sample_idx = rng.choice(len(re), replace=False, size=12)
+        # cases = np.array(cases)[sample_idx].tolist()
+        assert_allclose(sp.ncfdtr(dfn, dfd, nc, f), expected_cdf, rtol=1e-13, atol=0)
+        # testing tails where the CDF reaches 0 or 1 does not make sense for inverses
+        # of a CDF as they are not bijective in these regions
+        if 0 < expected_cdf < 1:
+            assert_allclose(sp.ncfdtri(dfn, dfd, nc, expected_cdf), f, rtol=5e-11)
+            assert_allclose(sp.ncfdtrinc(dfn, dfd, expected_cdf, f), nc, rtol=1e-10)
 
-@pytest.mark.parametrize(
-    "args",
-    [(-1.0, 0.1, 0.1, 0.5),
-     (1, -1.0, 0.1, 0.5),
-     (1, 1, -1.0, 0.5),
-     (1, 1, 1, 100),
-     (1, 1, 1, -1)]
-)
-def test_ncfdtri_domain_error(args):
-    with sp.errstate(domain="raise"):
-        with pytest.raises(sp.SpecialFunctionError, match="domain"):
-            sp.ncfdtri(*args)
+    @pytest.mark.parametrize(
+        "args",
+        [(-1.0, 0.1, 0.1, 0.5),
+        (1, -1.0, 0.1, 0.5),
+        (1, 1, -1.0, 0.5),
+        (1, 1, 1, 100),
+        (1, 1, 1, -1)]
+    )
+    def test_ncfdtri_domain_error(self, args):
+        with sp.errstate(domain="raise"):
+            with pytest.raises(sp.SpecialFunctionError, match="domain"):
+                sp.ncfdtri(*args)
+
+
+    @pytest.mark.parametrize("dfn, dfd, f", [(1, 10, 2), (3, 5, 1), (10, 10, 4)])
+    def test_ncfdtrinc_zero_nc(self, dfn, dfd, f):
+        # For nc=0 the noncentral F reduces to the central F distribution.
+        # ncfdtrinc should return 0.
+        p = sp.fdtr(dfn, dfd, f)
+        assert_allclose(sp.ncfdtrinc(dfn, dfd, p, f), 0.0, atol=1e-10, rtol=0)
+
 
 class TestNoncentralTFunctions:
 


### PR DESCRIPTION
#### Reference issue
Towards #21966

#### What does this implement/fix?
Migrates `ncfdtrinc` to boost,

#### AI Generation Disclosure
I asked Copilot to mimic #25115 which implemented most of this PR and then manually edited the tests. Turns out, for repetitive work such as these PRs LLMs can save me actually a lot of time.
