### PR TITLE
BUG: special: make `sf_error_v` threadsafe

### DIFF
--- a/scipy/special/sf_error.cc
+++ b/scipy/special/sf_error.cc
@@ -55,7 +55,7 @@ void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list
     PyGILState_STATE save;
     PyObject *scipy_special = NULL;
     char msg[2048], info[1024];
-    static PyObject *py_SpecialFunctionWarning = NULL;
+    PyObject *py_SpecialFunctionWarning = NULL;
     sf_action_t action;
 
     if ((int) code < 0 || (int) code >= SF_ERROR__LAST) {

--- a/scipy/special/sf_error.cc
+++ b/scipy/special/sf_error.cc
@@ -55,7 +55,7 @@ void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list
     PyGILState_STATE save;
     PyObject *scipy_special = NULL;
     char msg[2048], info[1024];
-    PyObject *py_SpecialFunctionWarning = NULL;
+    PyObject *warning_or_error_class = NULL;
     sf_action_t action;
 
     if ((int) code < 0 || (int) code >= SF_ERROR__LAST) {
@@ -90,33 +90,33 @@ void sf_error_v(const char *func_name, sf_error_t code, const char *fmt, va_list
     }
 
     if (action == SF_ERROR_WARN) {
-        py_SpecialFunctionWarning = PyObject_GetAttrString(scipy_special, "SpecialFunctionWarning");
+        warning_or_error_class = PyObject_GetAttrString(scipy_special, "SpecialFunctionWarning");
     } else if (action == SF_ERROR_RAISE) {
-        py_SpecialFunctionWarning = PyObject_GetAttrString(scipy_special, "SpecialFunctionError");
+        warning_or_error_class = PyObject_GetAttrString(scipy_special, "SpecialFunctionError");
     } else {
         /* Sentinel, should never get here */
-        py_SpecialFunctionWarning = NULL;
+        warning_or_error_class = NULL;
     }
     /* Done with scipy_special */
     Py_DECREF(scipy_special);
 
-    if (py_SpecialFunctionWarning == NULL) {
+    if (warning_or_error_class == NULL) {
         PyErr_Clear();
         goto skip_warn;
     }
 
     if (action == SF_ERROR_WARN) {
-        PyErr_WarnEx(py_SpecialFunctionWarning, msg, 1);
+        PyErr_WarnEx(warning_or_error_class, msg, 1);
         /*
          * For ufuncs the return value is ignored! We rely on the fact
          * that the Ufunc loop will call PyErr_Occurred() later on.
          */
     } else if (action == SF_ERROR_RAISE) {
-        PyErr_SetString(py_SpecialFunctionWarning, msg);
+        PyErr_SetString(warning_or_error_class, msg);
     } else {
         goto skip_warn;
     }
-    Py_DECREF(py_SpecialFunctionWarning);
+    Py_DECREF(warning_or_error_class);
 
 skip_warn:
     PyGILState_Release(save);


### PR DESCRIPTION
#### Reference issue

No issue filed.
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

The error `TypeError: expected string or bytes-like object, got 'SpecialFunctionError'` has occurred in CI 11 times in the past 3 weeks, all inside the `free threaded (1)` job.

List of failures:

<details>

| Job | Workflow | Status | Branch | Started |
| --- | --- | --- | --- | --- |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25878996619/job/76053680513) | Linux tests | failure | main | 2026-05-14 18:50:07 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25820493554/job/75860193701) | Linux tests | failure | dschult:csr_struct_get_thunk | 2026-05-13 19:07:35 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25679529876/job/75386888029) | Linux tests | failure | czgdp1807:regrid_python | 2026-05-11 15:24:31 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25654639606/job/75300113827) | Linux tests | failure | main | 2026-05-11 06:44:02 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25601299465/job/75155574634) | Linux tests | failure | main | 2026-05-09 12:37:12 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25470456995/job/74733075396) | Linux tests | failure | dschult:large_growing_assign | 2026-05-07 01:19:05 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25404840262/job/74513251918) | Linux tests | failure | main | 2026-05-05 22:04:44 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25175436183/job/73806143721) | Linux tests | failure | steppi:ppoly-cupy | 2026-04-30 15:54:27 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25132216485/job/73661300515) | Linux tests | failure | dindotjs:symplectic | 2026-04-29 20:30:59 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/25120657624/job/73620175474) | Linux tests | failure | BasilLiekens:solve_banded_speedup | 2026-04-29 16:21:24 |
| [free-threaded (1)](https://github.com/scipy/scipy/actions/runs/24584949014/job/71892087330) | Linux tests | failure | main | 2026-04-17 20:20:04 |

[search link](https://actions-search.scicftest.com/actions/scipy/scipy/search/?is_trivial__false=1&log_contents__contains=TypeError%3A+expected+string+or+bytes-like+object%2C+got+%27SpecialFunctionError%27)

</details>

Failure log

<details>

```
==================================== ERRORS ====================================
_________________________ ERROR at call of test_seterr _________________________

E   Failed: DID NOT WARN. No warnings of type (<class 'scipy.special._sf_error.SpecialFunctionWarning'>,) were emitted.
     Emitted warnings: [SpecialFunctionError('scipy.special/_err_test_function: other error')].
All traceback entries are hidden. Pass `--full-trace` to see hidden and internal frames.

During handling of the above exception, another exception occurred:

    def test_seterr():
        entry_err = sc.geterr()
        try:
            for category, error_code in _sf_error_code_map.items():
                for action in _sf_error_actions:
                    geterr_olderr = sc.geterr()
                    seterr_olderr = sc.seterr(**{category: action})
                    assert_(geterr_olderr == seterr_olderr)
                    newerr = sc.geterr()
                    assert_(newerr[category] == action)
                    geterr_olderr.pop(category)
                    newerr.pop(category)
                    assert_(geterr_olderr == newerr)
>                   _check_action(_sf_error_test_function, (error_code,), action)

action     = 'warn'
category   = 'other'
entry_err  = {'arg': 'ignore', 'domain': 'ignore', 'loss': 'ignore', 'memory': 'raise', ...}
error_code = 9
geterr_olderr = {'arg': 'raise', 'domain': 'raise', 'loss': 'raise', 'memory': 'raise', ...}
newerr     = {'arg': 'raise', 'domain': 'raise', 'loss': 'raise', 'memory': 'raise', ...}
seterr_olderr = {'arg': 'raise', 'domain': 'raise', 'loss': 'raise', 'memory': 'raise', ...}

scipy/special/tests/test_sf_error.py:70: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

fun = <ufunc '_sf_error_test_function'>, args = array([9]), action = 'warn'

    def _check_action(fun, args, action):
        # TODO: special expert should correct
        # the coercion at the true location?
        args = np.asarray(args, dtype=np.dtype("long"))
        if action == 'warn':
>           with pytest.warns(sc.SpecialFunctionWarning):
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E           TypeError: expected string or bytes-like object, got 'SpecialFunctionError'

action     = 'warn'
args       = array([9])
fun        = <ufunc '_sf_error_test_function'>

scipy/special/tests/test_sf_error.py:38: TypeError
************************** pytest-run-parallel report **************************
16011 tests were skipped because of use of thread-unsafe functionality, to list the tests that were skipped, re-run while setting PYTEST_RUN_PARALLEL_VERBOSE=1 in your shell environment
=========================== short test summary info ============================
PARALLEL FAILED scipy/special/tests/test_sf_error.py::test_seterr - TypeError: expected string or bytes-like object, got 'SpecialFunctionError'
= 63731 passed, 18916 skipped, 11643 deselected, 134 xfailed, 1 error in 1576.31s (0:26:16) =
##[error]Process completed with exit code 1.
```

</details>

The error can be reproduced with the following:

```
spin test -t scipy.special -- --parallel-threads=4 --skip-thread-unsafe=true --forever --iterations=100 -x -k sf_error
```

This appears to be a bug where py_SpecialFunctionWarning is declared static, so one thread can be setting up a warning, while another thread is setting up an error. Since both share the class pointer, one thread can change the other thread's class.

Therefore, don't share this pointer.

Also rename `py_SpecialFunctionWarning`: it is confusing because it doesn't always point to `SpecialFunctionWarning`.

#### Additional information

I tested this change by running it with the test command

```
spin test -t scipy.special -- --parallel-threads=4 --skip-thread-unsafe=true --forever --iterations=100 -x -k sf_error
```

Without this change, it crashes within about 20 iterations. However, I have only observed this crash inside free threading builds. I haven't gotten it to fail for non ft builds.

With this change, I have not seen it crash after 1000 iterations.

#### AI Generation Disclosure
No AI Tools Used