### PR TITLE
MAINT: signal: use full names for btype argument

### DIFF
--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -566,10 +566,10 @@ stop-band attenuation of :math:`\approx 60` dB.
    >>> import numpy as np
    >>> import scipy.signal as signal
    >>> import matplotlib.pyplot as plt
-
+   ...
    >>> b, a = signal.iirfilter(4, Wn=0.2, rp=5, rs=60, btype='lowpass', ftype='ellip')
    >>> w, h = signal.freqz(b, a)
-
+   ...
    >>> plt.title('Digital filter frequency response')
    >>> plt.plot(w, 20*np.log10(np.abs(h)))
    >>> plt.title('Digital filter frequency response')
@@ -591,7 +591,7 @@ stop-band attenuation of :math:`\approx 60` dB.
         >>> import numpy as np
         >>> from matplotlib import pyplot as plt
         >>> from scipy import signal as sig
-
+        ...
         >>> fs = 16000
         >>> b = sig.firwin(101, 2500, fs=fs)
         >>> f, h_fft = sig.freqz(b, fs=fs)

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -600,7 +600,7 @@ stop-band attenuation of :math:`\approx 60` dB.
         >>> ax.plot(f, h_amp, label="FIR")
         >>> ax.grid(True)
 
-        >>> b, a = sig.iirfilter(15, 2500, btype="low", fs=fs)
+        >>> b, a = sig.iirfilter(15, 2500, btype="lowpass", fs=fs)
         >>> f, h_fft = sig.freqz(b, a, fs=fs)
         >>> h_amp = 20 * np.log10(np.abs(h_fft))
         >>> ax.plot(f, h_amp, label="IIR")

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -599,7 +599,7 @@ stop-band attenuation of :math:`\approx 60` dB.
         >>> _, ax = plt.subplots(layout="constrained")
         >>> ax.plot(f, h_amp, label="FIR")
         >>> ax.grid(True)
-
+        ...
         >>> b, a = sig.iirfilter(15, 2500, btype="lowpass", fs=fs)
         >>> f, h_fft = sig.freqz(b, a, fs=fs)
         >>> h_amp = 20 * np.log10(np.abs(h_fft))

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2661,7 +2661,7 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
                      ftype=ftype, output=output, fs=fs)
 
 
-def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
+def iirfilter(N, Wn, rp=None, rs=None, btype='bandpass', analog=False,
               ftype='butter', output='ba', fs=None):
     """
     IIR digital and analog filter design given order and critical points.
@@ -2767,7 +2767,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     >>> import matplotlib.pyplot as plt
 
     >>> b, a = signal.iirfilter(17, [2*np.pi*50, 2*np.pi*200], rs=60,
-    ...                         btype='band', analog=True, ftype='cheby2')
+    ...                         btype='bandpass', analog=True, ftype='cheby2')
     >>> w, h = signal.freqs(b, a, 1000)
     >>> fig = plt.figure()
     >>> ax = fig.add_subplot(1, 1, 1)
@@ -2784,7 +2784,7 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='band', analog=False,
     sections implementation is required to ensure stability of a filter of
     this order):
 
-    >>> sos = signal.iirfilter(17, [50, 200], rs=60, btype='band',
+    >>> sos = signal.iirfilter(17, [50, 200], rs=60, btype='bandpass',
     ...                        analog=False, ftype='cheby2', fs=2000,
     ...                        output='sos')
     >>> w, h = signal.freqz_sos(sos, 2000, fs=2000)
@@ -3373,7 +3373,7 @@ def lp2bs_zpk(z, p, k, wo=1.0, bw=1.0):
     return z_bs, p_bs, k_bs
 
 
-def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
+def butter(N, Wn, btype='lowpass', analog=False, output='ba', fs=None):
     """
     Butterworth digital and analog filter design.
 
@@ -3503,7 +3503,7 @@ def butter(N, Wn, btype='low', analog=False, output='ba', fs=None):
                      output=output, ftype='butter', fs=fs)
 
 
-def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
+def cheby1(N, rp, Wn, btype='lowpass', analog=False, output='ba', fs=None):
     """
     Chebyshev type I digital and analog filter design.
 
@@ -3625,7 +3625,7 @@ def cheby1(N, rp, Wn, btype='low', analog=False, output='ba', fs=None):
                      output=output, ftype='cheby1', fs=fs)
 
 
-def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
+def cheby2(N, rs, Wn, btype='lowpass', analog=False, output='ba', fs=None):
     """
     Chebyshev type II digital and analog filter design.
 
@@ -3741,7 +3741,7 @@ def cheby2(N, rs, Wn, btype='low', analog=False, output='ba', fs=None):
                      output=output, ftype='cheby2', fs=fs)
 
 
-def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
+def ellip(N, rp, rs, Wn, btype='lowpass', analog=False, output='ba', fs=None):
     """
     Elliptic (Cauer) digital and analog filter design.
 
@@ -3870,7 +3870,7 @@ def ellip(N, rp, rs, Wn, btype='low', analog=False, output='ba', fs=None):
                      output=output, ftype='elliptic', fs=fs)
 
 
-def bessel(N, Wn, btype='low', analog=False, output='ba', norm='phase',
+def bessel(N, Wn, btype='lowpass', analog=False, output='ba', norm='phase',
            fs=None):
     """
     Bessel/Thomson digital and analog filter design.

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -2692,6 +2692,13 @@ def iirfilter(N, Wn, rp=None, rs=None, btype='bandpass', analog=False,
         in the stop band. (dB)
     btype : {'bandpass', 'lowpass', 'highpass', 'bandstop'}, optional
         The type of filter.  Default is 'bandpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3403,6 +3410,13 @@ def butter(N, Wn, btype='lowpass', analog=False, output='ba', fs=None):
         For analog filters, `Wn` is an angular frequency (e.g. rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter.  Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3530,6 +3544,13 @@ def cheby1(N, rp, Wn, btype='lowpass', analog=False, output='ba', fs=None):
         For analog filters, `Wn` is an angular frequency (e.g., rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter.  Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3652,6 +3673,13 @@ def cheby2(N, rs, Wn, btype='lowpass', analog=False, output='ba', fs=None):
         For analog filters, `Wn` is an angular frequency (e.g., rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter.  Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3771,6 +3799,13 @@ def ellip(N, rp, rs, Wn, btype='lowpass', analog=False, output='ba', fs=None):
         For analog filters, `Wn` is an angular frequency (e.g., rad/s).
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter. Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned.
@@ -3893,6 +3928,13 @@ def bessel(N, Wn, btype='lowpass', analog=False, output='ba', norm='phase',
         half-cycles / sample.)
     btype : {'lowpass', 'highpass', 'bandpass', 'bandstop'}, optional
         The type of filter.  Default is 'lowpass'.
+        Note that the following legacy aliases should be avoided in new implementations:
+
+        - 'band', 'pass', 'bp' for 'bandpass'
+        - 'l', 'low', 'lp' for 'lowpass'
+        - 'h', 'high', 'hp' for 'highpass'
+        - 'bs', 'bands', 'stop' for 'bandstop'
+
     analog : bool, optional
         When True, return an analog filter, otherwise a digital filter is
         returned. (See Notes.)

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -4871,7 +4871,7 @@ class TestIIRFilter:
 
     def test_invalid_wn_range(self):
         # For digital filters, 0 <= Wn <= 1
-        assert_raises(ValueError, iirfilter, 1, 2, btype='lowspass')
+        assert_raises(ValueError, iirfilter, 1, 2, btype='lowpass')
         assert_raises(ValueError, iirfilter, 1, [0.5, 1], btype='bandstop')
         assert_raises(ValueError, iirfilter, 1, [0., 0.5], btype='bandstop')
         assert_raises(ValueError, iirfilter, 1, -1, btype='highpass')

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -3404,7 +3404,7 @@ class TestCheby1:
             rtol=0, atol=5e-14 if not DEFAULT_F32 else 1e-7
         )
 
-        b, a = cheby1(4, 1, xp.asarray([0.4, 0.7]), btype='band')
+        b, a = cheby1(4, 1, xp.asarray([0.4, 0.7]), btype='bandpass')
         assert_array_almost_equal(
             b, xp.asarray([0.0084, 0, -0.0335, 0, 0.0502, 0,
                            -0.0335, 0, 0.0084], dtype=xp.float64),
@@ -4812,7 +4812,7 @@ class TestIIRDesign:
 
     def test_fs_validation(self):
         with pytest.raises(ValueError, match="Sampling.*single scalar"):
-            iirfilter(1, 1, btype="low", fs=np.array([10, 20]))
+            iirfilter(1, 1, btype="lowpass", fs=np.array([10, 20]))
 
 
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/11883")
@@ -4852,37 +4852,37 @@ class TestIIRFilter:
     def test_int_inputs(self, xp):
         # Using integer frequency arguments and large N should not produce
         # numpy integers that wraparound to negative numbers
-        k = iirfilter(24, xp.asarray(100), btype='low', analog=True, ftype='bessel',
+        k = iirfilter(24, xp.asarray(100), btype='lowpass', analog=True, ftype='bessel',
                       output='zpk')[2]
         k2 = 9.999999999999989e+47
         assert math.isclose(k,  k2)
         # if fs is specified then the normalization of Wn to have
         # 0 <= Wn <= 1 should not cause an integer overflow
         # the following line should not raise an exception
-        iirfilter(20, xp.asarray([1000000000, 1100000000]), btype='bp',
+        iirfilter(20, xp.asarray([1000000000, 1100000000]), btype='bandpass',
                       analog=False, fs=6250000000)
 
     def test_invalid_wn_size(self):
         # low and high have 1 Wn, band and stop have 2 Wn
-        assert_raises(ValueError, iirfilter, 1, [0.1, 0.9], btype='low')
-        assert_raises(ValueError, iirfilter, 1, [0.2, 0.5], btype='high')
-        assert_raises(ValueError, iirfilter, 1, 0.2, btype='bp')
-        assert_raises(ValueError, iirfilter, 1, 400, btype='bs', analog=True)
+        assert_raises(ValueError, iirfilter, 1, [0.1, 0.9], btype='lowpass')
+        assert_raises(ValueError, iirfilter, 1, [0.2, 0.5], btype='highpass')
+        assert_raises(ValueError, iirfilter, 1, 0.2, btype='bandpass')
+        assert_raises(ValueError, iirfilter, 1, 400, btype='bandstop', analog=True)
 
     def test_invalid_wn_range(self):
         # For digital filters, 0 <= Wn <= 1
-        assert_raises(ValueError, iirfilter, 1, 2, btype='low')
-        assert_raises(ValueError, iirfilter, 1, [0.5, 1], btype='band')
-        assert_raises(ValueError, iirfilter, 1, [0., 0.5], btype='band')
-        assert_raises(ValueError, iirfilter, 1, -1, btype='high')
-        assert_raises(ValueError, iirfilter, 1, [1, 2], btype='band')
-        assert_raises(ValueError, iirfilter, 1, [10, 20], btype='stop')
+        assert_raises(ValueError, iirfilter, 1, 2, btype='lowspass')
+        assert_raises(ValueError, iirfilter, 1, [0.5, 1], btype='bandstop')
+        assert_raises(ValueError, iirfilter, 1, [0., 0.5], btype='bandstop')
+        assert_raises(ValueError, iirfilter, 1, -1, btype='highpass')
+        assert_raises(ValueError, iirfilter, 1, [1, 2], btype='bandstop')
+        assert_raises(ValueError, iirfilter, 1, [10, 20], btype='bandstop')
 
         # analog=True with non-positive critical frequencies
         with pytest.raises(ValueError, match="must be greater than 0"):
-            iirfilter(2, 0, btype='low', analog=True)
+            iirfilter(2, 0, btype='lowpass', analog=True)
         with pytest.raises(ValueError, match="must be greater than 0"):
-            iirfilter(2, -1, btype='low', analog=True)
+            iirfilter(2, -1, btype='lowpass', analog=True)
         with pytest.raises(ValueError, match="must be greater than 0"):
             iirfilter(2, [0, 100], analog=True)
         with pytest.raises(ValueError, match="must be greater than 0"):
@@ -4896,7 +4896,7 @@ class TestIIRFilter:
     def test_analog_sos(self, xp):
         # first order Butterworth filter with Wn = 1 has tf 1/(s+1)
         sos = xp.asarray([[0., 0., 1., 0., 1., 1.]])
-        sos2 = iirfilter(N=1, Wn=xp.asarray(1), btype='low', analog=True, output='sos')
+        sos2 = iirfilter(N=1, Wn=xp.asarray(1), btype='lowpass', analog=True, output='sos')
         assert_array_almost_equal(sos, sos2)
 
     def test_wn1_ge_wn0(self):

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -1117,7 +1117,7 @@ class TestFreqz:
                               (False, True, 257),
                               (True, False, 257),
                               (True, True, 257)])
-    
+
     @xfail_xp_backends("cupy", reason="XXX: CuPy's version suspect")
     def test_17289(self, whole, nyquist, worN, xp):
         d = xp.asarray([0.0, 1.0])
@@ -4896,7 +4896,8 @@ class TestIIRFilter:
     def test_analog_sos(self, xp):
         # first order Butterworth filter with Wn = 1 has tf 1/(s+1)
         sos = xp.asarray([[0., 0., 1., 0., 1., 1.]])
-        sos2 = iirfilter(N=1, Wn=xp.asarray(1), btype='lowpass', analog=True, output='sos')
+        sos2 = iirfilter(N=1, Wn=xp.asarray(1), btype='lowpass', analog=True,
+                         output='sos')
         assert_array_almost_equal(sos, sos2)
 
     def test_wn1_ge_wn0(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #25144

#### What does this implement/fix?
<!--Please explain your changes.-->
#25144 reported confusion as the default input to `bytpe` was not one of the documented options. This is fine as the function actually supports abbreviations however is a bit confusing. This PR changes all the defaults to there unabbreviated form as to avoid confusion.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

None