### PR TITLE
BUG/ENH: interpolate: Reduce ``_regrid`` memory pressure in large smoothing runs on Windows

### DIFF
--- a/scipy/interpolate/_regrid.py
+++ b/scipy/interpolate/_regrid.py
@@ -534,11 +534,15 @@ def _solve_2d_fitpack(Ax, Ay, Q, p,
     # Note: C currently aligns so that C.T matches x-first multiplication order.
     zhat = _Ax @ C.T @ _Ay.T
 
-    # Compute the residual sum of squares against the original data z.
-    fp = np.sum(np.square(z - zhat))
+    # Compute residual matrix R and fp in one pass; return R so callers that
+    # need per-span energy for knot placement can reuse it directly instead of
+    # recomputing zhat a second time.
+    R = z - zhat
+    fp = np.sum(np.square(R))
 
-    # Return coefficients in the conventional (nx_coef, ny_coef) orientation and fp.
-    return C.T, fp
+    # Return coefficients in the conventional (nx_coef, ny_coef) orientation,
+    # fp, and the residual matrix R.
+    return C.T, fp, R
 
 class F:
     """
@@ -592,19 +596,15 @@ class F:
         self.z = z
 
     def __call__(self, p):
-        Ax_copy = PackedMatrix(
-            self.Ax.a.copy(), self.Ax.offset.copy(), self.Ax.nc)
-        Dx_copy = PackedMatrix(
-            self.Dx.a.copy(), self.Dx.offset.copy(), self.Dx.nc)
-        Ay_copy = PackedMatrix(
-            self.Ay.a.copy(), self.Ay.offset.copy(), self.Ay.nc)
-        Dy_copy = PackedMatrix(
-            self.Dy.a.copy(), self.Dy.offset.copy(), self.Dy.nc)
-        C, fp = _solve_2d_fitpack(
-            Ax_copy, Ay_copy, self.Q.copy(),
+        # _stack_augmented_fitpack always allocates fresh arrays (np.zeros for
+        # p != -1, .copy() for p == -1), so qr_reduce never writes back into
+        # the original PackedMatrix.a buffers.  The four copies below are
+        # therefore unnecessary and are removed to reduce memory pressure.
+        C, fp, _ = _solve_2d_fitpack(
+            self.Ax, self.Ay, self.Q.copy(),
             p, self.kx, self.tx, self.x_x,
             self.ky, self.ty, self.x_y, self.z,
-            Dx=Dx_copy, Dy=Dy_copy)
+            Dx=self.Dx, Dy=self.Dy)
         self.C = C
         self.fp = fp
         return fp
@@ -975,9 +975,9 @@ def _regrid_fitpack(
         ty = _not_a_knot(y_fit, ky)
         (Ax, Ay, Q) = _build_design_matrices(
              x_fit, y_fit, Z, tx, ty, kx, ky)
-        C0, fp  = _solve_2d_fitpack(Ax, Ay, Q, p,
-                                    kx, tx, x_fit, ky, ty,
-                                    y_fit, Z_fit)
+        C0, fp, _ = _solve_2d_fitpack(Ax, Ay, Q, p,
+                                     kx, tx, x_fit, ky, ty,
+                                     y_fit, Z_fit)
         return return_NdBSpline(fp, (tx, ty, C0), (kx, ky))
 
     tx, nestx, nminx, nmaxx = _initialise_knots(x_fit.size, xb, xe, kx, nest=nestx)
@@ -995,10 +995,13 @@ def _regrid_fitpack(
 
         (Ax, Ay, Q) = _build_design_matrices(
              x_fit, y_fit, Z, tx, ty, kx, ky)
-        C0, fp  = _solve_2d_fitpack(Ax, Ay, Q, p,
-                                    kx, tx, x_fit,
-                                    ky, ty, y_fit,
-                                    Z_fit)
+        # _solve_2d_fitpack now returns R = Z_fit - zhat alongside C0 and fp,
+        # so we can reuse it directly for knot placement instead of
+        # recomputing zhat a second time via tocsr + dense matmul.
+        C0, fp, R = _solve_2d_fitpack(Ax, Ay, Q, p,
+                                      kx, tx, x_fit,
+                                      ky, ty, y_fit,
+                                      Z_fit)
 
         # https://github.com/scipy/scipy/blob/v1.16.2/scipy/interpolate/fitpack/fpregr.f#L190
         # https://github.com/scipy/scipy/blob/v1.16.2/scipy/interpolate/fitpack/fpregr.f#L224
@@ -1007,18 +1010,6 @@ def _regrid_fitpack(
 
         if fp < s:
             break
-
-        # Note: We call PackedMatrix.tocsr here because matrix multiplication
-        # with the packed banded format (returned by _dierckx.data_matrix)
-        # is not implemented. PackedMatrix.tocsr returns the design matrix,
-        # in CSR format, that supports standard @ operations for residual
-        # evaluation and diagnostics.
-        _Ax = Ax.tocsr(kx, x_fit.shape[0], len(tx))
-        _Ay = Ay.tocsr(ky, y_fit.shape[0], len(ty))
-
-
-        Z0  = _Ax @ C0 @ _Ay.T
-        R = Z_fit - Z0
 
         # https://github.com/scipy/scipy/blob/v1.16.2/scipy/interpolate/fitpack/fpregr.f#L265-L295
         if last_axis == "y":
@@ -1035,6 +1026,11 @@ def _regrid_fitpack(
                 residuals=np.sum(R**2, axis=0),
                 nplus=nplusy)
             last_axis = "y"
+
+        # When both knot vectors have reached their maximum size no further
+        # growth is possible; break to avoid redundant loop iterations.
+        if len(tx) >= nmaxx and len(ty) >= nmaxy:
+            break
 
         fpold = fp
 

--- a/scipy/interpolate/_regrid.py
+++ b/scipy/interpolate/_regrid.py
@@ -407,7 +407,8 @@ def _solve_2d_fitpack(Ax, Ay, Q, p,
     Residual computation:
     --------------------------------------------------------
         Zhat = Ax * C * Ay^T
-        fp   = sum((Z - Zhat)^2)
+        R    = Z - Zhat
+        fp   = sum(R^2)
 
     Parameters
     ----------
@@ -436,6 +437,8 @@ def _solve_2d_fitpack(Ax, Ay, Q, p,
         2-D B-spline coefficient grid.
     fp : float
         Residual sum of squares between fitted surface and `z`.
+    R : ndarray, shape (mx, my)
+        Residual matrix ``z - zhat``, where ``zhat = Ax @ C @ Ay.T``.
 
     Notes
     -----


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Closes https://github.com/scipy/scipy/issues/25142

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

This PR addresses intermittent Windows worker crashes in `TestRectBivariateSpline::test_spline_large_2d` for the large case `shape=(2000, 170)` with smoothing (`s=1` and `s=3`) when using the `_regrid` path.

To the best of my knowledge, the changes are correctness-preserving and focused on removing redundant work and allocations in `scipy/interpolate/_regrid.py`.

**What changed**

1. `_solve_2d_fitpack` now returns the residual matrix `R = z - zhat` together with `(C, fp)`.
2. The knot-growth loop in `_regrid_fitpack` reuses this returned `R` directly, instead of recomputing `zhat` via:
   - packed-to-CSR conversions (`Ax.tocsr`, `Ay.tocsr`), and
   - an additional dense matrix product (`_Ax @ C0 @ _Ay.T`).
3. `F.__call__` no longer deep-copies all `PackedMatrix` inputs on every `p`-search evaluation. This is safe because `_stack_augmented_fitpack` allocates fresh augmented arrays before `qr_reduce` mutates them.
4. Added an early exit in the knot-growth loop when both knot vectors have already reached their maximum sizes (`nmaxx`, `nmaxy`), avoiding redundant iterations where no further growth is possible.

**Why this helps?**

As far as I can tell, for the large `(2000, 170)` smoothing case, `_regrid` was accumulating heavy memory/CPU pressure from repeated redundant allocations and matrix products inside iterative loops. These changes reduce peak pressure and repeated work, which stabilises execution on Windows CI workers while preserving the numerical algorithm and outputs.

**Validation**

The previously flaky failing test was rerun 7 times after this fix, and it passed in all 7 runs.

- 5 attempts in one run: https://github.com/czgdp1807/scipy/actions/runs/25922204368/job/76228418521
- 1 additional run: https://github.com/czgdp1807/scipy/actions/runs/25933289820/job/76232257868
- 1 additional run on this PR: https://github.com/scipy/scipy/actions/runs/25936381206/job/76242829260?pr=25148

Total: **7/7 passes for the previously failing scenario.**

Please feel free to run `full, py3.12/npMin, spin` multiple times on this PR as well if you want to be double sure.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI tools used