### PR TITLE
MAINT: special: bump xsf submodule to fix crashes and failures on aarch64

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -681,7 +681,7 @@ jobs:
 
   #################################################################################
   test_aarch64:
-    name: aarch64, fast, fail slow, py3.12/npAny, pip+pytest
+    name: aarch64, fast, fail slow, py3.12/npAny, spin
     needs: get_commit_message
     if: >
       needs.get_commit_message.outputs.message == 1
@@ -706,21 +706,20 @@ jobs:
 
     - name: Install Python packages
       run: |
-        python -m pip install -r requirements/build.txt -r requirements/test.txt
+        python -m pip install -r requirements/build.txt -r requirements/test.txt -r requirements/dev.txt
         # We want to check for test timing only in a single job, on Linux, running the
         # fast test suite. This is that job. See gh-20806 for previous issues
         # after running this job on Windows and in multiple jobs.
         python -m pip install pytest-fail-slow
 
-    - name: Install SciPy
+    - name: Build SciPy
       run: |
-        python -m pip install . -v --no-build-isolation
+        spin build
 
     - name: Test SciPy
       run: |
         export OMP_NUM_THREADS=2
-        cd ..
-        pytest --pyargs scipy -m 'not slow' --durations=0 --durations-min=0.5 --fail-slow=1.0
+        spin test -- --durations=0 --durations-min=0.5 --fail-slow=1.0
 
   #################################################################################
   test_without_fortran:


### PR DESCRIPTION
See the commits included in https://github.com/scipy/xsf/pull/151 for more details. 

Note that this is only visible when building in a debug mode on Linux aarch64. And we appear to be missing test coverage for that; tweaked the existing CI job in `linux.yml` for that (`pip install` is already covered in `wheels.yml`).

#### AI Generation Disclosure

Diagnosed and fixes drafted with heavy help from Claude Opus 4.7.