### PR TITLE
DOC: signal.vectorstrength: add example to docstring

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4161,10 +4161,11 @@ def vectorstrength(events, period):
     In this example, five events occur exactly 1 second apart, starting
     at 0.25 s. The vector strength is 1 for ``period=1`` because all
     events fall at the same phase of every cycle, and the returned phase
-    is ``pi/2``, a quarter of the way through the period.
+    is π/2, a quarter of the way through the period.
 
     >>> import numpy as np
     >>> from scipy.signal import vectorstrength
+    ...
     >>> events = np.array([0.25, 1.25, 2.25, 3.25, 4.25])
     >>> vectorstrength(events, period=1.0)
     (np.float64(1.0), np.float64(1.5707963267948968))  # may vary
@@ -4177,6 +4178,7 @@ def vectorstrength(events, period):
 
     >>> periods = [1, 5, 0.5]
     >>> strengths, phases = vectorstrength(events, periods)
+    ...
     >>> for p_, s_, ph_ in zip(periods, strengths, phases):
     ...     print(f"period = {p_:.1f}: strength = {s_:.2f}, "
     ...           f"phase = {np.rad2deg(ph_):.1f} deg")
@@ -4189,14 +4191,18 @@ def vectorstrength(events, period):
     occurs at 10 s with phase 0 rad. Due to the finite number of samples,
     the strength does not drop to zero away from 10 s but exhibits
     secondary maxima similar to those of an FFT sidelobe pattern. The
-    phase decreases roughly linearly with jumps of pi rad at each
+    phase decreases roughly linearly with jumps of π rad at each
     sidelobe minimum, consistent with an underlying sinc-like function.
 
     >>> import matplotlib.pyplot as plt
+    >>> import numpy as np
+    >>> from scipy.signal import vectorstrength
+    ...
     >>> N, T = 100, 10  # samples and sampling interval in seconds
     >>> events = np.arange(N) * T
     >>> periods = np.linspace(9.5, 10.5, 101)
     >>> strength, phase = vectorstrength(events, periods)
+    ...
     >>> fig, (ax_strength, ax_phase) = plt.subplots(
     ...     2, 1, sharex=True, tight_layout=True)
     >>> ax_strength.set_title(

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4187,6 +4187,31 @@ def vectorstrength(events, period):
     >>> strengths, _ = vectorstrength(events, period=[0.5, 1.0])
     >>> np.round(strengths, 8)
     array([1., 0.])
+
+    The following example depicts the vector strength and its phase for
+    100 samples with a constant period of 10 s. The maximum strength of 1
+    occurs at 10 s with phase 0 rad. Due to the finite number of samples,
+    the strength does not drop to zero away from 10 s but exhibits
+    secondary maxima similar to those of an FFT sidelobe pattern. The
+    phase decreases roughly linearly with jumps of pi rad at each
+    sidelobe minimum, consistent with an underlying sinc-like function.
+
+    >>> import matplotlib.pyplot as plt
+    >>> N, T = 100, 10  # samples and sampling interval in seconds
+    >>> events = np.arange(N) * T
+    >>> periods = np.linspace(9.5, 10.5, 101)
+    >>> strength, phase = vectorstrength(events, periods)
+    >>> fig, (ax_strength, ax_phase) = plt.subplots(
+    ...     2, 1, sharex=True, tight_layout=True)
+    >>> ax_strength.set_title(
+    ...     f"Vector strength of {N} samples at {T} s spacing")
+    >>> ax_strength.set(ylabel="Strength", xlim=(periods[0], periods[-1]))
+    >>> ax_strength.grid(True)
+    >>> ax_phase.set(xlabel="Period (s)", ylabel="Phase (rad)")
+    >>> ax_phase.grid(True)
+    >>> ax_strength.plot(periods, strength, 'C0.-')
+    >>> ax_phase.plot(periods, phase, 'C1.-')
+    >>> plt.show()
     '''
     xp = array_namespace(events, period)
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4155,6 +4155,34 @@ def vectorstrength(events, period):
         when we vary the "probing" frequency while keeping the spike times
         fixed.  Biol Cybern. 2013 Aug;107(4):491-94.
         :doi:`10.1007/s00422-013-0560-8`.
+
+    Examples
+    --------
+    Five events occurring at integer multiples of the period are perfectly
+    phase-locked, so the vector strength is 1.
+
+    >>> import numpy as np
+    >>> from scipy.signal import vectorstrength
+    >>> events = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    >>> strength, _ = vectorstrength(events, period=1.0)
+    >>> float(np.round(strength, 8))
+    1.0
+
+    1000 events spaced evenly across one period give a vector strength near
+    zero, indicating no phase synchronization.
+
+    >>> events = np.linspace(0.0, 1.0, 1000, endpoint=False)
+    >>> strength, _ = vectorstrength(events, period=1.0)
+    >>> bool(np.isclose(strength, 0.0))
+    True
+
+    ``period`` can be an array to evaluate the resonating vector strength
+    against several candidate periods at once.
+
+    >>> events = np.arange(0.0, 10.0, 0.5)
+    >>> strengths, _ = vectorstrength(events, period=[0.5, 1.0])
+    >>> np.round(strengths, 8)
+    array([1., 0.])
     '''
     xp = array_namespace(events, period)
 

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4158,23 +4158,27 @@ def vectorstrength(events, period):
 
     Examples
     --------
-    Five events occurring at integer multiples of the period are perfectly
-    phase-locked, so the vector strength is 1.
+    Five events occurring at the same phase of each period are perfectly
+    phase-locked, so the vector strength is 1. The returned phase tells you
+    where on the cycle the events cluster -- here, a quarter-period offset
+    gives phase = pi/2.
 
     >>> import numpy as np
     >>> from scipy.signal import vectorstrength
-    >>> events = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
-    >>> strength, _ = vectorstrength(events, period=1.0)
+    >>> events = np.array([0.25, 1.25, 2.25, 3.25, 4.25])
+    >>> strength, phase = vectorstrength(events, period=1.0)
     >>> float(np.round(strength, 8))
     1.0
+    >>> float(np.round(phase, 8))
+    1.57079633
 
     1000 events spaced evenly across one period give a vector strength near
     zero, indicating no phase synchronization.
 
     >>> events = np.linspace(0.0, 1.0, 1000, endpoint=False)
     >>> strength, _ = vectorstrength(events, period=1.0)
-    >>> bool(np.isclose(strength, 0.0))
-    True
+    >>> float(np.round(strength, 8))
+    0.0
 
     ``period`` can be an array to evaluate the resonating vector strength
     against several candidate periods at once.

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4158,35 +4158,31 @@ def vectorstrength(events, period):
 
     Examples
     --------
-    Five events occurring at the same phase of each period are perfectly
-    phase-locked, so the vector strength is 1. The returned phase tells you
-    where on the cycle the events cluster -- here, a quarter-period offset
-    gives phase = pi/2.
+    In this example, five events occur exactly 1 second apart, starting
+    at 0.25 s. The vector strength is 1 for ``period=1`` because all
+    events fall at the same phase of every cycle, and the returned phase
+    is ``pi/2``, a quarter of the way through the period.
 
     >>> import numpy as np
     >>> from scipy.signal import vectorstrength
     >>> events = np.array([0.25, 1.25, 2.25, 3.25, 4.25])
-    >>> strength, phase = vectorstrength(events, period=1.0)
-    >>> float(np.round(strength, 8))
-    1.0
-    >>> float(np.round(phase, 8))
-    1.57079633
+    >>> vectorstrength(events, period=1.0)
+    (np.float64(1.0), np.float64(1.5707963267948968))  # may vary
 
-    1000 events spaced evenly across one period give a vector strength near
-    zero, indicating no phase synchronization.
+    ``period`` can also be an array of candidate periods. With the same
+    events as above, the strength stays at 1 at the true period of 1 s
+    and at the sub-multiple period 0.5 s (a form of aliasing), and drops
+    to 0 at ``period=5`` where the events span a single period at
+    evenly-spaced phases:
 
-    >>> events = np.linspace(0.0, 1.0, 1000, endpoint=False)
-    >>> strength, _ = vectorstrength(events, period=1.0)
-    >>> float(np.round(strength, 8))
-    0.0
-
-    ``period`` can be an array to evaluate the resonating vector strength
-    against several candidate periods at once.
-
-    >>> events = np.arange(0.0, 10.0, 0.5)
-    >>> strengths, _ = vectorstrength(events, period=[0.5, 1.0])
-    >>> np.round(strengths, 8)
-    array([1., 0.])
+    >>> periods = [1, 5, 0.5]
+    >>> strengths, phases = vectorstrength(events, periods)
+    >>> for p_, s_, ph_ in zip(periods, strengths, phases):
+    ...     print(f"period = {p_:.1f}: strength = {s_:.2f}, "
+    ...           f"phase = {np.rad2deg(ph_):.1f} deg")
+    period = 1.0: strength = 1.00, phase = 90.0 deg
+    period = 5.0: strength = 0.00, phase = 153.4 deg
+    period = 0.5: strength = 1.00, phase = -180.0 deg
 
     The following example depicts the vector strength and its phase for
     100 samples with a constant period of 10 s. The maximum strength of 1


### PR DESCRIPTION
#### Reference issue
#7168

#### What does this implement/fix?
Adds an `Examples` section to the `scipy.signal.vectorstrength` docstring. Three short examples cover the three regimes the function is meant to demonstrate: perfect phase locking (strength = 1), uniform spread within one period (strength ≈ 0), and an array `period` argument for resonating vector strength.

`[docs only]`

#### Additional information
The doctest output was verified locally against `scipy` 1.17.1. `np.round` / `np.isclose` are used so the output lines remain stable across NumPy versions.

#### AI Generation Disclosure
Claude Code (Anthropic) assisted in drafting the `Examples` block. It proposed the three example regimes, verified each doctest line against an installed scipy 1.17.1, and applied review suggestions for consistency. I read the diff, ran the doctest locally, and can explain the function's semantics. The AI-generated portion is the contents of the new `Examples` block in `scipy/signal/_signaltools.py`; the rest of this PR (commit, push, this description) is mine.
