### PR TITLE
BUG: sparse.linalg: fix tfqmr maxiter=0 show crash

### DIFF
--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -678,6 +678,21 @@ def test_show(case, capsys, xp, batch_A, batch_b):
     assert out.startswith(exp)
     assert err == ""
 
+def test_tfqmr_show_maxiter_zero(capsys):
+    A = eye(2)
+    b = ones(2)
+
+    x, info = tfqmr(A, b, maxiter=0, show=True)
+
+    out, err = capsys.readouterr()
+
+    assert info == 0
+    assert_allclose(x, zeros(2))
+    assert out.startswith(
+        "TFQMR: Linear solve not converged due to reach MAXIT iterations 0"
+    )
+    assert err == ""
+
 
 @pytest.mark.parametrize("batch_A", [()])
 @pytest.mark.parametrize("batch_b", [()])

--- a/scipy/sparse/linalg/_isolve/tfqmr.py
+++ b/scipy/sparse/linalg/_isolve/tfqmr.py
@@ -178,5 +178,5 @@ def tfqmr(A, b, x0=None, *, rtol=1e-5, atol=0., maxiter=None, M=None,
 
     if (show):
         print("TFQMR: Linear solve not converged due to reach MAXIT "
-              f"iterations {iter+1}")
+                f"iterations {maxiter}")
     return (x, maxiter)


### PR DESCRIPTION
Summary
Fix an `UnboundLocalError` raised by `scipy.sparse.linalg.tfqmr`
when `maxiter=0` and `show=True`.

Changes
- Replaced the final `iter+1` reference with `maxiter`
  so the solver no longer references an undefined loop variable
  when the iteration loop never executes.
- Added a regression test for `tfqmr(maxiter=0, show=True)`.

Reproduction
```python
import numpy as np
from scipy.sparse.linalg import tfqmr

A = np.eye(2)
b = np.ones(2)

tfqmr(A, b, maxiter=0, show=True)

Closes #24790