### PR TITLE
mmwrite: raise ValueError for precision > 21

### DIFF
--- a/scipy/io/_mmio.py
+++ b/scipy/io/_mmio.py
@@ -853,6 +853,10 @@ class MMFile:
                 precision = 8
             else:
                 precision = 16
+        if precision is not None and precision > 21:
+            raise ValueError("precision should be at most 21 to avoid "
+                           "segmentation faults in mmread; got "
+                           f"{precision}")
         if field is None:
             kind = a.dtype.kind
             if kind == 'i':


### PR DESCRIPTION
`mmwrite` accepts `precision` values but writing with precision ≥ 22 produces
files that segfault on `mmread` due to C++ backend limitations. This adds a
pre-write validation that raises `ValueError` for precision > 21, preventing
the crash rather than letting it happen silently downstream.
