### PR TITLE
BUG: optimize: narrow warning filter scope in LinearConstraint.__init__

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -205,7 +205,7 @@ class LinearConstraint:
             # prefer that this just error out immediately so it can handle it
             # rather than concerning the user.
             with catch_warnings():
-                simplefilter("error")
+                simplefilter("error", category=np.exceptions.VisibleDeprecationWarning)
                 self.A = np.atleast_2d(A).astype(np.float64)
         else:
             self.A = A

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 import numpy as np
 from numpy.testing import TestCase, assert_array_equal
@@ -259,3 +261,13 @@ class TestLinearConstraint:
         lc = LinearConstraint(A, -2, 4)
         x0 = [-1, 2]
         np.testing.assert_allclose(lc.residual(x0), ([1, 4], [5, 2]))
+
+    def test_init_does_not_promote_unrelated_warnings(self):
+        # gh-25123: an unqualified simplefilter("error") in __init__
+        # could turn unrelated warnings into errors.
+        A = np.eye(2)
+        with warnings.catch_warnings():
+            warnings.simplefilter("always")
+            LinearConstraint(A, lb=0.0, ub=1.0)
+            # Should not raise
+            warnings.warn("unrelated", UserWarning)


### PR DESCRIPTION
`LinearConstraint.__init__` used `simplefilter("error")` without a category. In multithreaded code promotes unrelated warnings (e.g. `UserWarning`) to errors, as reported in gh-25123.

Narrow the filter to `VisibleDeprecationWarning` only, matching the intent of the comment already present in the code. Added a regression test to verify unrelated warnings are not affected.

Closes gh-25123