### PR TITLE
MAINT/DOC: io.matlab: guard dim-product overflow and document read risks

### DIFF
--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -167,6 +167,13 @@ def loadmat(file_name, mdict=None, appendmat=True, *, spmatrix=_NoValue, **kwarg
     files. Because SciPy does not supply one, we do not implement the
     HDF5 / 7.3 interface here.
 
+    .. warning::
+        The MAT-file readers used by ``loadmat`` are not hardened against adversarial
+        input and should not be used to load files from untrusted sources. Malformed
+        files may cause excessive memory use or read errors. The reader does not execute
+        arbitrary code, but the format is complex and not all corruption modes are
+        caught explicitly.
+
     Examples
     --------
     >>> from os.path import dirname, join as pjoin

--- a/scipy/io/matlab/_mio5_utils.pyx
+++ b/scipy/io/matlab/_mio5_utils.pyx
@@ -16,6 +16,7 @@ from copy import copy as pycopy
 
 cimport cython
 
+from libc.stdint cimport SIZE_MAX
 from libc.stdlib cimport calloc, free
 from libc.string cimport strcmp
 
@@ -608,7 +609,7 @@ cdef class VarReader5:
         header.name = self.read_int8_string()
         return header
 
-    cdef inline size_t size_from_header(self, VarHeader5 header) noexcept:
+    cdef inline size_t size_from_header(self, VarHeader5 header) except *:
         ''' Supporting routine for calculating array sizes from header
 
         Probably unnecessary optimization that uses integers stored in
@@ -624,11 +625,24 @@ cdef class VarReader5:
         size : size_t
            size of array referenced by header (product of dims)
         '''
-        # calculate number of items in array from dims product
-        cdef size_t size = 1
-        cdef int i
+        # calculate number of items in array from dims product, with
+        # overflow / negative-dim guards against malformed input.
+        cdef:
+            size_t size = 1
+            size_t dim
+            cnp.int32_t d
+            int i
         for i in range(header.n_dims):
-            size *= header.dims_ptr[i]
+            d = header.dims_ptr[i]
+            if d < 0:
+                raise ValueError(
+                    'Negative dimension in array header '
+                    '(malformed input file?)')
+            dim = <size_t>d
+            if dim != 0 and size > SIZE_MAX // dim:
+                raise ValueError(
+                    'Array size overflow in header (malformed input file?)')
+            size *= dim
         return size
 
     cdef read_mi_matrix(self, int process=1):


### PR DESCRIPTION
This is a follow-up to gh-23481, where I had to think about security aspects of `loadmat`. This is a follow-up, adding a documentation note and a bit of hardening that fell out of that.

Add a warning to the `loadmat` docstring stating the v4/v5 reader is not hardened for untrusted input. The reader executes no code, but the format is complex and not every corruption mode is caught.

`size_from_header` silently wrapped `size_t` when a malformed v5 header declared `dims` whose product exceeded `SIZE_MAX`, and accepted negative `miINT32` dims (only `miUINT32` dims were sign-checked at read time). Switch the routine to `except *` and reject both conditions with `ValueError` before the wrap can happen.


#### AI Generation Disclosure

Used Claude Opus 4.7 for some of these checks. I had to reject most of what it wanted to do, because some things are inherently unsafe (e.g., a "`zlib` decompression bomb" which can take a very large amount of memory); that should be covered by the docs warning instead. Adding some extra checks for header parsing to raise clean errors on invalid headers did seem in order.