### PR TITLE
BUG: io: The 'scipy_mmio' threadpoolctl was not setting the version correctly.

### DIFF
--- a/scipy/io/_fast_matrix_market/__init__.py
+++ b/scipy/io/_fast_matrix_market/__init__.py
@@ -68,7 +68,7 @@ try:
             PARALLELISM = num_threads
 
         def get_version(self):
-            return _fmm_version
+            return _fmm_version()
 
         def set_additional_attributes(self):
             pass

--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -810,7 +810,7 @@ def test_mtx_append(tmp_path):
     mmread(test_readfile, spmatrix=False)
 
 
-def test_threadpoolctl():
+def check_threadpoolctl():
     try:
         import threadpoolctl
         if not hasattr(threadpoolctl, "register"):
@@ -820,11 +820,31 @@ def test_threadpoolctl():
         pytest.skip("no threadpoolctl")
         return
 
+
+def test_threadpoolctl():
+    check_threadpoolctl()
+
+    import threadpoolctl
+
     with threadpoolctl.threadpool_limits(limits=4):
         assert_equal(fmm.PARALLELISM, 4)
 
     with threadpoolctl.threadpool_limits(limits=2, user_api='scipy'):
         assert_equal(fmm.PARALLELISM, 2)
+
+
+def test_scipy_threadpoolctl_version():
+    check_threadpoolctl()
+
+    import threadpoolctl
+
+    # Ensure the extension module _fmm_core is loaded.
+    from scipy.io._fast_matrix_market import _fmm_core
+    with threadpoolctl.threadpool_limits(limits=4, user_api='scipy'):
+        ctls = threadpoolctl.threadpool_info()
+        for ctl in ctls:
+            if ctl['user_api'] == 'scipy' and ctl['internal_api'] == 'scipy_mmio':
+                assert ctl['version'] == _fmm_core.__version__
 
 
 def test_gh21999_file_not_exist():


### PR DESCRIPTION
#### What does this implement/fix?

This fixes a slightly esoteric bug in the use of `threadpoolctl` in `scipy/io/_fast_matrix_market/__init__.py`.  The class `_FMMThreadPoolCtlController` has the method `get_version()` that is supposed to return a string.  The bug was that it was returning a function (called `_fmm_version`) instead of *calling* the function to generate the version string.

#### AI Generation Disclosure

No AI tools used.
