### PR TITLE
MAINT: convert `interpolate._dierckx` and test modules to multi-phase init

### DIFF
--- a/scipy/_lib/src/_test_ccallback.c
+++ b/scipy/_lib/src/_test_ccallback.c
@@ -387,33 +387,28 @@ static PyMethodDef test_ccallback_methods[] = {
 };
 
 
+static struct PyModuleDef_Slot test_ccallback_slots[] = {
+    // signal that this module can be imported in isolated subinterpreters
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+    // signal that this module supports running without an active GIL
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL},
+};
+
+
 static struct PyModuleDef test_ccallback_module = {
-    PyModuleDef_HEAD_INIT,
-    "_test_ccallback",
-    NULL,
-    -1,
-    test_ccallback_methods,
-    NULL,
-    NULL,
-    NULL,
-    NULL
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_test_ccallback",
+    .m_size = 0,
+    .m_methods = test_ccallback_methods,
+    .m_slots = test_ccallback_slots,
 };
 
 
 PyMODINIT_FUNC
 PyInit__test_ccallback(void)
 {
-    PyObject *module;
-
-    module = PyModule_Create(&test_ccallback_module);
-    if (module == NULL) {
-        return module;
-    }
-
-#if Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
-#endif
-
-    return module;
-
+    return PyModuleDef_Init(&test_ccallback_module);
 }

--- a/scipy/integrate/tests/_test_multivariate.c
+++ b/scipy/integrate/tests/_test_multivariate.c
@@ -97,34 +97,28 @@ fail:
 }
 
 
+static struct PyModuleDef_Slot _test_multivariate_slots[] = {
+    {Py_mod_exec, create_pointers},
+    // signal that this module can be imported in isolated subinterpreters
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+    // signal that this module supports running without an active GIL
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL},
+};
+
+
 static struct PyModuleDef moduledef = {
-    PyModuleDef_HEAD_INIT,
-    "_test_multivariate",
-    NULL,
-    -1,
-    NULL, /* Empty methods section */
-    NULL,
-    NULL,
-    NULL,
-    NULL
+    .m_base = PyModuleDef_HEAD_INIT,
+    .m_name = "_test_multivariate",
+    .m_size = 0,
+    .m_methods = NULL,
+    .m_slots = _test_multivariate_slots,
 };
 
 PyMODINIT_FUNC
 PyInit__test_multivariate(void)
 {
-    PyObject *m;
-    m = PyModule_Create(&moduledef);
-    if (m == NULL) {
-        return NULL;
-    }
-    if (create_pointers(m)) {
-        Py_DECREF(m);
-        return NULL;
-    }
-
-#if Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(m, Py_MOD_GIL_NOT_USED);
-#endif
-
-    return m;
+    return PyModuleDef_Init(&moduledef);
 }

--- a/scipy/interpolate/src/_dierckxmodule.cc
+++ b/scipy/interpolate/src/_dierckxmodule.cc
@@ -1494,31 +1494,41 @@ static PyMethodDef DierckxMethods[] = {
 
 
 
+static int dierckx_module_exec(PyObject *module)
+{
+    if (_import_array() < 0) { return -1; }
+    return 0;
+}
+
+
+static PyModuleDef_Slot dierckx_module_slots[] = {
+    {Py_mod_exec, (void *)dierckx_module_exec},
+    // signal that this module can be imported in isolated subinterpreters
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#if PY_VERSION_HEX >= 0x030d00f0  // Python 3.13+
+    // signal that this module supports running without an active GIL
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
+
+
+// Designated initializers require C++20; MSVC /std:c++17 rejects them.
 static struct PyModuleDef dierckxmodule = {
-    PyModuleDef_HEAD_INIT,
-    "_dierckx",   /* name of module */
-    NULL, //spam_doc, /* module documentation, may be NULL */
-    -1,       /* size of per-interpreter state of the module,
-                 or -1 if the module keeps state in global variables. */
-    DierckxMethods
+    PyModuleDef_HEAD_INIT,                /* m_base */
+    "_dierckx",                           /* m_name */
+    NULL,                                 /* m_doc */
+    0,                                    /* m_size */
+    DierckxMethods,                       /* m_methods */
+    dierckx_module_slots,                 /* m_slots */
+    NULL,                                 /* m_traverse */
+    NULL,                                 /* m_clear */
+    NULL                                  /* m_free */
 };
 
 
 PyMODINIT_FUNC
 PyInit__dierckx(void)
 {
-    PyObject *module;
-
-    import_array();
-
-    module = PyModule_Create(&dierckxmodule);
-    if (module == NULL) {
-        return NULL;
-    }
-
-#if Py_GIL_DISABLED
-    PyUnstable_Module_SetGIL(module, Py_MOD_GIL_NOT_USED);
-#endif
-
-    return module;
+    return PyModuleDef_Init(&dierckxmodule);
 }


### PR DESCRIPTION
Addresses part of gh-23067 (all but `uarray`, for which a PR is already open).
It made sense to do this after revisiting gh-23070 just now.

#### AI Generation Disclosure

I used Claude Opus 4.7 for the initial pass over this; it is just copying patterns from other modules at this point.

The only non-trivial point was the change of `-1` to `0` for `_dierckx`; I verified that there is indeed no global module state in the code so claiming to support subinterpreters now is fine (also irrelevant until NumPy supports them of course).