### PR TITLE
DOC: sparse: sparse docs changes related to spmatrix

### DIFF
--- a/scipy/_lib/_sparse.py
+++ b/scipy/_lib/_sparse.py
@@ -8,12 +8,12 @@ class SparseABC(ABC):
 
 
 def issparse(x):
-    """Is `x` a sparse array or sparse matrix type?
+    """Is `x` either sparse array or sparse matrix type?
 
     Parameters
     ----------
     x : object
-        object to check for being a sparse array or sparse matrix
+        object to check for being a sparse array or a sparse matrix
 
     Returns
     -------
@@ -22,7 +22,8 @@ def issparse(x):
 
     Notes
     -----
-    Use `isinstance(x, sp.sparse.sparray)` to check between an array or matrix.
+    Use `sp.sparse.isspmatrix(x)` or `isinstance(x, sp.sparse.sparray)` to
+    check between sparray or spmatrix.
     Use `a.format` to check the sparse format, e.g. `a.format == 'csr'`.
 
     Examples

--- a/scipy/sparse/_base.py
+++ b/scipy/sparse/_base.py
@@ -1754,6 +1754,18 @@ sparray.__doc__ = _spbase.__doc__
 def isspmatrix(x):
     """Is `x` of a sparse matrix type?
 
+    .. warning::
+
+        scipy.sparse is switching to the sparse array interface.
+
+        The ``isspmatrix`` function returns ``False`` for sparse arrays.
+        It will remain after the switch to sparse arrays (sparray).
+        So this is a future proof way to check for sparray vs spmatrix.
+        If you just want to check for sparse, use ``issparse(A)``.
+        For more general information about sparrays, see
+        :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
+        The switch to sparse arrays will occur no earlier than v1.21.
+
     Parameters
     ----------
     x

--- a/scipy/sparse/_extract.py
+++ b/scipy/sparse/_extract.py
@@ -53,6 +53,19 @@ def tril(A, k=0, format=None):
         - k > 0 is above the main diagonal
         - k < 0 is below the main diagonal
 
+    .. warning::
+
+        `tril` is switching to the sparse array interface.
+
+        For the case where no input arrays are sparse, this function is
+        switching to returning a sparse array instead of sparse matrix.
+        Control the sparse return class by making at least one input sparse,
+        e.g., ``tril(coo_matrix(A))``, or ``tril(coo_array(A))``.
+        That removes any deprecation warnings as well.
+        For more general information about sparrays, see
+        :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
+        Handling of this no sparse input case will change no earlier than v1.20.
+
     Parameters
     ----------
     A : dense or sparse array or matrix
@@ -139,6 +152,19 @@ def triu(A, k=0, format=None):
         - k = 0 corresponds to the main diagonal
         - k > 0 is above the main diagonal
         - k < 0 is below the main diagonal
+
+    .. warning::
+
+        `triu` is switching to the sparse array interface.
+
+        For the case where no input arrays are sparse, this function is
+        switching to returning a sparse array instead of sparse matrix.
+        Control the sparse return class by making at least one input sparse,
+        e.g., ``triu(coo_matrix(A))``, or ``triu(coo_array(A))``.
+        That removes any deprecation warnings as well.
+        For more general information about sparrays, see
+        :ref:`Migration from spmatrix to sparray <migration_to_sparray>`.
+        Handling of this no sparse input case will change no earlier than v1.20.
 
     Parameters
     ----------

--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -36,21 +36,21 @@ def save_npz(file, matrix, compressed=True):
 
     >>> import numpy as np
     >>> import scipy as sp
-    >>> sparse_matrix = sp.sparse.csc_matrix([[0, 0, 3], [4, 0, 0]])
-    >>> sparse_matrix
-    <Compressed Sparse Column sparse matrix of dtype 'int64'
+    >>> sparse_array = sp.sparse.csc_array([[0, 0, 3], [4, 0, 0]])
+    >>> sparse_array
+    <Compressed Sparse Column sparse array of dtype 'int64'
         with 2 stored elements and shape (2, 3)>
-    >>> sparse_matrix.toarray()
+    >>> sparse_array.toarray()
     array([[0, 0, 3],
            [4, 0, 0]], dtype=int64)
 
-    >>> sp.sparse.save_npz('/tmp/sparse_matrix.npz', sparse_matrix)
-    >>> sparse_matrix = sp.sparse.load_npz('/tmp/sparse_matrix.npz')
+    >>> sp.sparse.save_npz('/tmp/sparse_array.npz', sparse_array)
+    >>> sparse_array = sp.sparse.load_npz('/tmp/sparse_array.npz')
 
-    >>> sparse_matrix
-    <Compressed Sparse Column sparse matrix of dtype 'int64'
+    >>> sparse_array
+    <Compressed Sparse Column sparse array of dtype 'int64'
         with 2 stored elements and shape (2, 3)>
-    >>> sparse_matrix.toarray()
+    >>> sparse_array.toarray()
     array([[0, 0, 3],
            [4, 0, 0]], dtype=int64)
     """


### PR DESCRIPTION
This PR include various doc updates found during a pass over the sparse subpackage especially changes aligned with deprecations and/or the big picture switch to sparray from spmatrix.

- Functions `triu` and tril`: already raise deprecation warnings, but needed similar warnings in the doc_string.
- Function `sp._lib._sparse.issparse`: docstring describes how to check for sparray vs spmatrix but didn't mention `isspmatrix`.
- Function `isspmatrix`: updated doc_string to warn of changes with spmatrix and explain how isspmatrix will continue as one future proof way to check for spmatrix.
- Function `save_npz`: the Examples section uses spmatrix throughout. Updated to use sparray. `load_npz` had already been updated.

This PR related to the documentation checks section of the sparse deprecation checklist in #24802 