### PR TITLE
BUG/TST: io: Fix test_threadpoolctl in scipy/io/tests/test_mmio.py.

### DIFF
--- a/scipy/io/tests/test_mmio.py
+++ b/scipy/io/tests/test_mmio.py
@@ -826,6 +826,9 @@ def test_threadpoolctl():
 
     import threadpoolctl
 
+    # Ensure the extension module _fmm_core is loaded.
+    from scipy.io._fast_matrix_market import _fmm_core  # noqa: F401
+
     with threadpoolctl.threadpool_limits(limits=4):
         assert_equal(fmm.PARALLELISM, 4)
 


### PR DESCRIPTION
Ensure that the extension module `_fmm_core` is loaded before testing the use of `threadpoolctl`.

#### What does this implement/fix?

This is a bug in the test only.

Before this fix, running just the test `test_threadpoolctl` would fail:

```
$ spin test -v -s io -- -k test_threadpoolctl
Invoking `build` prior to running tests:
$ meson compile -j 12 -C build
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /home/warren/py3.14.4/bin/ninja -C /home/warren/repos/git/forks/scipy-fresh/build -j 12
ninja: Entering directory `/home/warren/repos/git/forks/scipy-fresh/build'
[2/356] Generating subprojects/highs/highs/HConfig.h with a custom command
$ meson install --no-rebuild --only-changed -C build --destdir ../build-install --tags=runtime,python-runtime,tests,devel --skip-subprojects
$ export PYTHONPATH="/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.14/site-packages"
$ /home/warren/py3.14.4/bin/python3.14 -P -c 'import scipy'
$ cd /home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.14/site-packages
$ /home/warren/py3.14.4/bin/python3.14 -P -m pytest -v -m 'not slow' -k test_threadpoolctl --pyargs scipy.io
============================================ test session starts =============================================
platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0 -- /home/warren/py3.14.4/bin/python3.14
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /home/warren/repos/git/forks/scipy-fresh
configfile: pytest.ini
plugins: cov-7.1.0, timeout-2.4.0, xdist-3.8.0, hypothesis-6.152.4
collected 711 items / 709 deselected / 2 selected

scipy/io/tests/test_mmio.py::test_threadpoolctl[scipy.io._mmio] FAILED                                 [ 50%]
scipy/io/tests/test_mmio.py::test_threadpoolctl[scipy.io._fast_matrix_market] FAILED                   [100%]

================================================== FAILURES ==================================================
_____________________________________ test_threadpoolctl[scipy.io._mmio] _____________________________________

    def test_threadpoolctl():
        check_threadpoolctl()

        import threadpoolctl

        with threadpoolctl.threadpool_limits(limits=4):
>           assert_equal(fmm.PARALLELISM, 4)
E           AssertionError:
E           Items are not equal:
E            ACTUAL: 0
E            DESIRED: 4

threadpoolctl = <module 'threadpoolctl' from '/home/warren/py3.14.4/lib/python3.14/site-packages/threadpoolctl.py'>

scipy/io/tests/test_mmio.py:830: AssertionError
______________________________ test_threadpoolctl[scipy.io._fast_matrix_market] ______________________________

    def test_threadpoolctl():
        check_threadpoolctl()

        import threadpoolctl

        with threadpoolctl.threadpool_limits(limits=4):
>           assert_equal(fmm.PARALLELISM, 4)
E           AssertionError:
E           Items are not equal:
E            ACTUAL: 0
E            DESIRED: 4

threadpoolctl = <module 'threadpoolctl' from '/home/warren/py3.14.4/lib/python3.14/site-packages/threadpoolctl.py'>

scipy/io/tests/test_mmio.py:830: AssertionError
========================================== short test summary info ===========================================
FAILED scipy/io/tests/test_mmio.py::test_threadpoolctl[scipy.io._mmio] - AssertionError:
FAILED scipy/io/tests/test_mmio.py::test_threadpoolctl[scipy.io._fast_matrix_market] - AssertionError:
===================================== 2 failed, 709 deselected in 0.33s =====================================
```

After this change:

```
$ spin test -v -s io -- -k test_threadpoolctl
Invoking `build` prior to running tests:
$ meson compile -j 12 -C build
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /home/warren/py3.14.4/bin/ninja -C /home/warren/repos/git/forks/scipy-fresh/build -j 12
ninja: Entering directory `/home/warren/repos/git/forks/scipy-fresh/build'
[2/356] Generating subprojects/highs/highs/HConfig.h with a custom command
$ meson install --no-rebuild --only-changed -C build --destdir ../build-install --tags=runtime,python-runtime,tests,devel --skip-subprojects
$ export PYTHONPATH="/home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.14/site-packages"
$ /home/warren/py3.14.4/bin/python3.14 -P -c 'import scipy'
$ cd /home/warren/repos/git/forks/scipy-fresh/build-install/usr/lib/python3.14/site-packages
$ /home/warren/py3.14.4/bin/python3.14 -P -m pytest -v -m 'not slow' -k test_threadpoolctl --pyargs scipy.io
============================================ test session starts =============================================
platform linux -- Python 3.14.4, pytest-9.0.3, pluggy-1.6.0 -- /home/warren/py3.14.4/bin/python3.14
cachedir: .pytest_cache
hypothesis profile 'default'
rootdir: /home/warren/repos/git/forks/scipy-fresh
configfile: pytest.ini
plugins: cov-7.1.0, timeout-2.4.0, xdist-3.8.0, hypothesis-6.152.4
collected 711 items / 709 deselected / 2 selected

scipy/io/tests/test_mmio.py::test_threadpoolctl[scipy.io._mmio] PASSED                                 [ 50%]
scipy/io/tests/test_mmio.py::test_threadpoolctl[scipy.io._fast_matrix_market] PASSED                   [100%]

===================================== 2 passed, 709 deselected in 0.28s =====================================
```


#### AI Generation Disclosure

No AI tools used.
