### PR TITLE
MAINT: use von Mises CDF from xsf

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -4747,6 +4747,11 @@ add_newdoc("_lgam1p",
     Internal function, do not use.
     """)
 
+add_newdoc("_von_mises_cdf",
+    """
+    Internal function, do not use.
+    """)
+
 add_newdoc("lpmv",
     r"""
     lpmv(m, v, x, out=None)

--- a/scipy/special/_ufuncs.pyi
+++ b/scipy/special/_ufuncs.pyi
@@ -265,6 +265,7 @@ _kolmogp: np.ufunc
 _lambertw: np.ufunc
 _lanczos_sum_expg_scaled: np.ufunc
 _lgam1p: np.ufunc
+_von_mises_cdf: np.ufunc
 _log1mexp: np.ufunc
 _log1pmx: np.ufunc
 _normalized_gen_harmonic: np.ufunc

--- a/scipy/special/functions.json
+++ b/scipy/special/functions.json
@@ -1027,5 +1027,10 @@
             "hypergeom_skewness_float": "fff->f",
             "hypergeom_skewness_double": "ddd->d"
         }
+    },
+    "_von_mises_cdf": {
+        "xsf_wrappers.h": {
+            "xsf_von_mises_cdf": "dd->d"
+        }
     }
 }

--- a/scipy/special/xsf_wrappers.cpp
+++ b/scipy/special/xsf_wrappers.cpp
@@ -740,3 +740,5 @@ double xsf_tandg(double x) { return xsf::tandg(x); }
 double xsf_cotdg(double x) { return xsf::cotdg(x); }
 
 double xsf_radian(double d, double m, double s) { return xsf::radian(d, m, s); }
+
+double xsf_von_mises_cdf(double k, double x) { return xsf::von_mises_cdf(k, x); }

--- a/scipy/special/xsf_wrappers.h
+++ b/scipy/special/xsf_wrappers.h
@@ -391,6 +391,7 @@ double xsf_cosdg(double x);
 double xsf_tandg(double x);
 double xsf_cotdg(double x);
 double xsf_radian(double d, double m, double s);
+double xsf_von_mises_cdf(double k, double x);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -11254,7 +11254,7 @@ class vonmises_gen(rv_continuous):
         return kappa * sc.cosm1(x) - np.log(2*np.pi) - np.log(sc.i0e(kappa))
 
     def _cdf(self, x, kappa):
-        return _stats.von_mises_cdf(kappa, x)
+        return sc._ufuncs._von_mises_cdf(kappa, x)
 
     def _stats_skip(self, kappa):
         return 0, None, 0, None

--- a/scipy/stats/_stats.pyx
+++ b/scipy/stats/_stats.pyx
@@ -16,69 +16,6 @@ cimport scipy.special.cython_special as cs
 np.import_array()
 
 
-cdef double von_mises_cdf_series(double k, double x, unsigned int p) noexcept:
-    cdef double s, c, sn, cn, R, V
-    cdef unsigned int n
-    s = math.sin(x)
-    c = math.cos(x)
-    sn = math.sin(p * x)
-    cn = math.cos(p * x)
-    R = 0
-    V = 0
-    for n in range(p - 1, 0, -1):
-        sn, cn = sn * c - cn * s, cn * c + sn * s
-        R = k / (2 * n + k * R)
-        V = R * (sn / n + V)
-
-    with cython.cdivision(True):
-        return 0.5 + x / (2 * PI) + V / PI
-
-
-cdef von_mises_cdf_normalapprox(k, x):
-    cdef double SQRT2_PI = 0.79788456080286535588  # sqrt(2/pi)
-
-    b = SQRT2_PI / scipy.special.i0e(k)  # Check for negative k
-    z = b * np.sin(x / 2.)
-    return scipy.stats.norm.cdf(z)
-
-
-@cython.boundscheck(False)
-def von_mises_cdf(k_obj, x_obj):
-    cdef double[:] temp, temp_xs, temp_ks
-    cdef unsigned int i, p
-    cdef double a1, a2, a3, a4, CK
-    cdef np.ndarray k = np.asarray(k_obj)
-    cdef np.ndarray x = np.asarray(x_obj)
-    cdef bint zerodim = k.ndim == 0 and x.ndim == 0
-
-    k = np.atleast_1d(k)
-    x = np.atleast_1d(x)
-    ix = np.round(x / (2 * PI))
-    x = x - ix * (2 * PI)
-
-    # These values should give 12 decimal digits
-    CK = 50
-    a1, a2, a3, a4 = 28., 0.5, 100., 5.
-
-    bx, bk = np.broadcast_arrays(x, k)
-    result = np.empty_like(bx, float)
-
-    c_small_k = bk < CK
-    temp = result[c_small_k]
-    temp_xs = bx[c_small_k].astype(float)
-    temp_ks = bk[c_small_k].astype(float)
-    for i in range(len(temp)):
-        p = <int>(1 + a1 + a2 * temp_ks[i] - a3 / (temp_ks[i] + a4))
-        temp[i] = von_mises_cdf_series(temp_ks[i], temp_xs[i], p)
-        temp[i] = 0 if temp[i] < 0 else 1 if temp[i] > 1 else temp[i]
-    result[c_small_k] = temp
-    result[~c_small_k] = von_mises_cdf_normalapprox(bk[~c_small_k], bx[~c_small_k])
-
-    if not zerodim:
-        return result + ix
-    else:
-        return (result + ix)[0]
-
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def _kendall_dis(intp_t[:] x, intp_t[:] y):


### PR DESCRIPTION
#### What does this implement/fix?
The von Mises CDF was recently ported to xsf by @fbourgey . Now we can remove our cython implementation for it.

#### Additional information

#### AI Generation Disclosure
None.
