### PR TITLE
DOC: stats.ks_2samp: Update ks_2samp docs example

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -7985,7 +7985,8 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
     Suppose we wish to test the null hypothesis that two samples were drawn
     from the same distribution.
     We choose a confidence level of 95%; that is, we will reject the null
-    hypothesis in favor of the alternative if the p-value is less than 0.05.
+    hypothesis in favor of the alternative (the two samples are *not* from the same underlying distribution)
+    if the p-value is less than 0.05.
 
     If the first sample were drawn from a uniform distribution and the second
     were drawn from the standard normal, we would expect the null hypothesis
@@ -7993,13 +7994,13 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
 
     >>> import numpy as np
     >>> from scipy import stats
-    >>> rng = np.random.default_rng()
+    >>> rng = np.random.default_rng(21)
     >>> sample1 = stats.uniform.rvs(size=100, random_state=rng)
     >>> sample2 = stats.norm.rvs(size=110, random_state=rng)
     >>> stats.ks_2samp(sample1, sample2)
-    KstestResult(statistic=0.5454545454545454,
-                 pvalue=7.37417839555191e-15,
-                 statistic_location=-0.014071496412861274,
+    KstestResult(statistic=0.5636363636363636,
+                 pvalue=6.788389136133105e-16,
+                 statistic_location=-0.011057745469750928,
                  statistic_sign=-1)
 
 
@@ -8010,16 +8011,17 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
     When both samples are drawn from the same distribution, we expect the data
     to be consistent with the null hypothesis most of the time.
 
-    >>> sample1 = stats.norm.rvs(size=105, random_state=rng)
-    >>> sample2 = stats.norm.rvs(size=95, random_state=rng)
+    >>> sample1 = stats.norm.rvs(size=405, random_state=rng)
+    >>> sample2 = stats.norm.rvs(size=395, random_state=rng)
     >>> stats.ks_2samp(sample1, sample2)
-    KstestResult(statistic=0.10927318295739348,
-                 pvalue=0.5438289009927495,
-                 statistic_location=-0.1670157701848795,
-                 statistic_sign=-1)
+    KstestResult(statistic=0.03775589935927489,
+                 pvalue=0.9230663309557195,
+                 statistic_location=0.5652951110659917,
+                 statistic_sign=1)
 
-    As expected, the p-value of 0.54 is not below our threshold of 0.05, so
-    we cannot reject the null hypothesis.
+    As expected, the p-value of 0.92 is not below our threshold of 0.05, so
+    we cannot reject the null hypothesis, and thus the two samples are found to be 
+    from the same underlying distribution.
 
     Suppose, however, that the first sample were drawn from
     a normal distribution shifted toward greater values. In this case,
@@ -8027,11 +8029,11 @@ def ks_2samp(data1, data2, alternative='two-sided', method='auto', *, axis=0):
     to be *less* than the CDF underlying the second sample. Therefore, we would
     expect the null hypothesis to be rejected with ``alternative='less'``:
 
-    >>> sample1 = stats.norm.rvs(size=105, loc=0.5, random_state=rng)
+    >>> sample1 = stats.norm.rvs(size=405, loc=0.5, random_state=rng)
     >>> stats.ks_2samp(sample1, sample2, alternative='less')
-    KstestResult(statistic=0.4055137844611529,
-                 pvalue=3.5474563068855554e-08,
-                 statistic_location=-0.13249370614972575,
+    KstestResult(statistic=0.17415221128301298,
+                 pvalue=4.378286065404051e-06,
+                 statistic_location=-0.08273265613519568,
                  statistic_sign=-1)
 
     and indeed, with p-value smaller than our threshold, we reject the null


### PR DESCRIPTION
[docs only]

<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
No Reference Issue

#### What does this implement/fix?
<!--Please explain your changes.-->
In the API reference for scipy.stats.ks_2samp (e.g., on docs.scipy.org) there was a problem with the reproducibility of the example given (in the "Examples" section). The random state used to generate the 2 sample distributions across the example was not explicitly set, so the user attempting to reproduce this example will not get the same answer as the API reference. More importantly, the second example in that section attempts to show that two sample distributions with different sizes drawn from stats.norm.rvs should lead to a KS test result pvalue of >0.05, in favor of the null hypothesis. Because the two sample distributions sizes were too low (105 and 95), and because the random state would vary from the listed example, often this would lead to a pvalue of < 0.05 when being reproduced as written.

To fix this, I added a fixed random state to the example (rng = np.random.default_rng(21)) and increased the sample size of the second example to 405 and 395, which I tested with multiple random states and found will consistently produce a pvalue >0.05. I recalculated all other numbers in this example with the fixed random state and adjusted accordingly.

#### Additional information
<!--Any additional information you think is important.-->
No Additional Information

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used