### PR TITLE
interpolate: skip `test_spline_large_2d` on Windows pending crash investigation

### DIFF
--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1404,6 +1404,9 @@ class TestRectBivariateSpline:
         return x, y, z.astype(np.float64)
 
     @pytest.mark.slow()
+    @pytest.mark.skipif(sys.platform == "win32", reason="Fails intermittently "
+                                                        "on Windows;"
+                                                        "investigation pending.")
     @pytest.mark.parametrize('shape', [(350, 850), (2000, 170)])
     @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
                                         (1, 7e-3, 1e-4),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/25142

#### What does this implement/fix?
<!--Please explain your changes.-->

Adds `@pytest.mark.skipif(sys.platform == "win32", ...)` to `TestRectBivariateSpline::test_spline_large_2d` so that the full Windows CI suite is no longer disrupted while the root cause of the intermittent crash is investigated.

**Background**

`test_spline_large_2d` has been crashing pytest-xdist workers on Windows CI roughly 10 % of the time for the `(2000, 170)` grid shape (see [#25142](https://github.com/scipy/scipy/issues/25142)).

A previous PR reduced memory pressure inside `_regrid_fitpack` (fewer redundant allocations in `F.__call__`, returning the residual `R` from `_solve_2d_fitpack` to avoid a second dense matrix product per knot-growth iteration, and an early-exit on knot saturation), but the crash is still observed intermittently, suggesting the root cause lies deeper - possibly in the C-extension layer of either `RectBivariateSpline` or `_regrid._regrid`.

**What is NOT changed**

* The test itself is unchanged - all parametrize dimensions, tolerances, and assertions remain as-is.
* The skip is platform-gated: Linux and macOS CI continue to run the full parametrize matrix.
* No production code is modified.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI tools used
