### PR TITLE
TST: signal.windows: add PSLL/BW correctness tests for 11 windows (gh-3432)

### DIFF
--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -21,6 +21,19 @@ xfail_xp_backends = pytest.mark.xfail_xp_backends
 lazy_xp_modules = [windows]
 
 
+def _assert_psll_bw(win_func, xp, expected_psll, expected_bw):
+    M_win = 1024
+    N_fft = 131072
+    w = win_func(M_win, sym=False, xp=xp)
+    f_np = fft(_xp_copy_to_numpy(w), N_fft)
+    spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
+    first_zero = np.argmax(np.diff(spec) > 0)
+    PSLL = np.max(spec[first_zero:-first_zero])
+    BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+    assert math.isclose(PSLL, expected_psll, abs_tol=1)
+    assert math.isclose(BW_3dB, expected_bw, abs_tol=0.1)
+
+
 window_funcs = [
     ('boxcar', ()),
     ('triang', ()),
@@ -73,16 +86,7 @@ class TestBartHann:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.barthann(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -35.9, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.41, abs_tol=0.1)
+        _assert_psll_bw(windows.barthann, xp, -35.9, 1.41)
 
 
 @make_xp_test_case(windows.bartlett)
@@ -106,16 +110,7 @@ class TestBartlett:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.bartlett(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -26.5, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.27, abs_tol=0.1)
+        _assert_psll_bw(windows.bartlett, xp, -26.5, 1.27)
 
 
 @make_xp_test_case(windows.blackman)
@@ -150,16 +145,7 @@ class TestBlackman:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.blackman(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -58.0, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.68, abs_tol=0.1)
+        _assert_psll_bw(windows.blackman, xp, -58.0, 1.68)
 
 
 @make_xp_test_case(windows.blackmanharris)
@@ -192,16 +178,7 @@ class TestBlackmanHarris:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.blackmanharris(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -92.0, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.90, abs_tol=0.1)
+        _assert_psll_bw(windows.blackmanharris, xp, -92.0, 1.90)
 
 
 @make_xp_test_case(windows.taylor)
@@ -309,16 +286,7 @@ class TestBohman:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.bohman(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -46.0, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.71, abs_tol=0.1)
+        _assert_psll_bw(windows.bohman, xp, -46.0, 1.71)
 
 
 @make_xp_test_case(windows.boxcar)
@@ -342,16 +310,7 @@ class TestBoxcar:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.boxcar(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -13.3, abs_tol=1)
-        assert math.isclose(BW_3dB, 0.88, abs_tol=0.1)
+        _assert_psll_bw(windows.boxcar, xp, -13.3, 0.88)
 
 
 cheb_odd_true = [0.200938, 0.107729, 0.134941, 0.165348,
@@ -600,16 +559,7 @@ class TestHamming:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.hamming(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -42.7, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.30, abs_tol=0.1)
+        _assert_psll_bw(windows.hamming, xp, -42.7, 1.30)
 
 
 @make_xp_test_case(windows.hann)
@@ -645,16 +595,7 @@ class TestHann:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.hann(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -31.5, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.44, abs_tol=0.1)
+        _assert_psll_bw(windows.hann, xp, -31.5, 1.44)
 
 
 @make_xp_test_case(windows.kaiser)
@@ -768,16 +709,7 @@ class TestNuttall:
                flat-top windows," 2002.
                https://holometer.fnal.gov/GH_FFT.pdf
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.nuttall(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -98.1, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.88, abs_tol=0.1)
+        _assert_psll_bw(windows.nuttall, xp, -98.1, 1.88)
 
 
 @make_xp_test_case(windows.parzen)
@@ -808,16 +740,7 @@ class TestParzen:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.parzen(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -53.0, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.82, abs_tol=0.1)
+        _assert_psll_bw(windows.parzen, xp, -53.0, 1.82)
 
 
 @make_xp_test_case(windows.triang)
@@ -1267,16 +1190,7 @@ class TestCosine:
                vol. 66, no. 1, pp. 51-83, Jan. 1978.
                :doi:`10.1109/PROC.1978.10837`
         """
-        M_win = 1024
-        N_fft = 131072
-        w = windows.cosine(M_win, sym=False, xp=xp)
-        f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
-        first_zero = np.argmax(np.diff(spec) > 0)
-        PSLL = np.max(spec[first_zero:-first_zero])
-        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
-        assert math.isclose(PSLL, -23.0, abs_tol=1)
-        assert math.isclose(BW_3dB, 1.20, abs_tol=0.1)
+        _assert_psll_bw(windows.cosine, xp, -23.0, 1.20)
 
 
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/2620")

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -77,7 +77,7 @@ class TestBartHann:
         N_fft = 131072
         w = windows.barthann(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -110,7 +110,7 @@ class TestBartlett:
         N_fft = 131072
         w = windows.bartlett(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -154,7 +154,7 @@ class TestBlackman:
         N_fft = 131072
         w = windows.blackman(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -196,7 +196,7 @@ class TestBlackmanHarris:
         N_fft = 131072
         w = windows.blackmanharris(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -313,7 +313,7 @@ class TestBohman:
         N_fft = 131072
         w = windows.bohman(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -346,7 +346,7 @@ class TestBoxcar:
         N_fft = 131072
         w = windows.boxcar(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -604,7 +604,7 @@ class TestHamming:
         N_fft = 131072
         w = windows.hamming(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -649,7 +649,7 @@ class TestHann:
         N_fft = 131072
         w = windows.hann(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -772,7 +772,7 @@ class TestNuttall:
         N_fft = 131072
         w = windows.nuttall(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -812,7 +812,7 @@ class TestParzen:
         N_fft = 131072
         w = windows.parzen(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
@@ -1271,7 +1271,7 @@ class TestCosine:
         N_fft = 131072
         w = windows.cosine(M_win, sym=False, xp=xp)
         f_np = fft(_xp_copy_to_numpy(w), N_fft)
-        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        spec = 20 * np.log10(np.maximum(np.abs(f_np / np.max(f_np)), 1e-300))
         first_zero = np.argmax(np.diff(spec) > 0)
         PSLL = np.max(spec[first_zero:-first_zero])
         BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win

--- a/scipy/signal/tests/test_windows.py
+++ b/scipy/signal/tests/test_windows.py
@@ -63,6 +63,27 @@ class TestBartHann:
                         xp.asarray([0, 0.27, 0.73, 1.0, 0.73, 0.27], dtype=xp.float64),
                         rtol=1e-15, atol=1e-15)
 
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the Bartlett-Hann window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.barthann(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -35.9, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.41, abs_tol=0.1)
+
 
 @make_xp_test_case(windows.bartlett)
 class TestBartlett:
@@ -74,6 +95,27 @@ class TestBartlett:
                         xp.asarray([0, 1/3, 2/3, 1.0, 2/3, 1/3, 0], dtype=xp.float64))
         xp_assert_close(windows.bartlett(6, False, xp=xp),
                         xp.asarray([0, 1/3, 2/3, 1.0, 2/3, 1/3], dtype=xp.float64))
+
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the Bartlett (triangular) window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.bartlett(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -26.5, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.27, abs_tol=0.1)
 
 
 @make_xp_test_case(windows.blackman)
@@ -98,6 +140,27 @@ class TestBlackman:
                         xp.asarray([0, 0.13, 0.63, 1.0, 0.63, 0.13, 0],
                         dtype=xp.float64), atol=1e-14)
 
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the Blackman window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.blackman(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -58.0, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.68, abs_tol=0.1)
+
 
 @make_xp_test_case(windows.blackmanharris)
 class TestBlackmanHarris:
@@ -118,6 +181,27 @@ class TestBlackmanHarris:
         xp_assert_close(windows.blackmanharris(7, sym=True, xp=xp),
                         xp.asarray([6.0e-05, 0.055645, 0.520575, 1.0, 0.520575,
                                     0.055645, 6.0e-05], dtype=xp.float64))
+
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the Blackman-Harris window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.blackmanharris(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -92.0, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.90, abs_tol=0.1)
 
 
 @make_xp_test_case(windows.taylor)
@@ -215,6 +299,27 @@ class TestBohman:
                                     0.6089977810442295, 0.1089977810442293],
                                     dtype=xp.float64))
 
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the Bohman window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.bohman(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -46.0, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.71, abs_tol=0.1)
+
 
 @make_xp_test_case(windows.boxcar)
 class TestBoxcar:
@@ -226,6 +331,27 @@ class TestBoxcar:
                         xp.asarray([1.0, 1, 1, 1, 1, 1, 1], dtype=xp.float64))
         xp_assert_close(windows.boxcar(6, False, xp=xp),
                         xp.asarray([1.0, 1, 1, 1, 1, 1], dtype=xp.float64))
+
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the rectangular (boxcar) window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.boxcar(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -13.3, abs_tol=1)
+        assert math.isclose(BW_3dB, 0.88, abs_tol=0.1)
 
 
 cheb_odd_true = [0.200938, 0.107729, 0.134941, 0.165348,
@@ -464,6 +590,27 @@ class TestHamming:
                         xp.asarray([0.08, 0.31, 0.77, 1.0, 0.77, 0.31, 0.08],
                                    dtype=xp.float64))
 
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the Hamming window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.hamming(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -42.7, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.30, abs_tol=0.1)
+
 
 @make_xp_test_case(windows.hann)
 class TestHann:
@@ -487,6 +634,27 @@ class TestHann:
                         xp.asarray([0, 0.25, 0.75, 1.0, 0.75, 0.25, 0],
                         dtype=xp.float64),
                         rtol=1e-15, atol=1e-15)
+
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the Hann window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.hann(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -31.5, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.44, abs_tol=0.1)
 
 
 @make_xp_test_case(windows.kaiser)
@@ -589,6 +757,28 @@ class TestNuttall:
                         xp.asarray([0.0003628, 0.0613345, 0.5292298, 1.0,
                                     0.5292298, 0.0613345, 0.0003628], dtype=xp.float64))
 
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the Nuttall window.
+
+        References
+        ----------
+        .. [1] G. Heinzel, A. Rüdiger, R. Schilling, "Spectrum and spectral
+               density estimation by the Discrete Fourier transform (DFT),
+               including a comprehensive list of window functions and some new
+               flat-top windows," 2002.
+               https://holometer.fnal.gov/GH_FFT.pdf
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.nuttall(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -98.1, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.88, abs_tol=0.1)
+
 
 @make_xp_test_case(windows.parzen)
 class TestParzen:
@@ -607,6 +797,27 @@ class TestParzen:
                         xp.asarray([0.00583090379008747, 0.1574344023323616,
                                     0.6501457725947521, 1.0, 0.6501457725947521,
                                     0.1574344023323616], dtype=xp.float64))
+
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the Parzen (de la Vallée Poussin) window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.parzen(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -53.0, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.82, abs_tol=0.1)
 
 
 @make_xp_test_case(windows.triang)
@@ -1045,6 +1256,27 @@ class TestCosine:
 
         with pytest.raises(ValueError):
             windows.cosine(-1, xp=xp) # negative values should return an error
+
+    def test_correctness(self, xp):
+        """Test PSLL and 3 dB bandwidth of the cosine window.
+
+        References
+        ----------
+        .. [1] F.J. Harris, "On the use of windows for harmonic analysis
+               with the discrete Fourier transform," Proceedings of the IEEE,
+               vol. 66, no. 1, pp. 51-83, Jan. 1978.
+               :doi:`10.1109/PROC.1978.10837`
+        """
+        M_win = 1024
+        N_fft = 131072
+        w = windows.cosine(M_win, sym=False, xp=xp)
+        f_np = fft(_xp_copy_to_numpy(w), N_fft)
+        spec = 20 * np.log10(np.abs(f_np / np.max(f_np)))
+        first_zero = np.argmax(np.diff(spec) > 0)
+        PSLL = np.max(spec[first_zero:-first_zero])
+        BW_3dB = 2 * np.argmax(spec <= -3.0102999566398121) / N_fft * M_win
+        assert math.isclose(PSLL, -23.0, abs_tol=1)
+        assert math.isclose(BW_3dB, 1.20, abs_tol=0.1)
 
 
 @skip_xp_backends("dask.array", reason="https://github.com/dask/dask/issues/2620")

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -2266,11 +2266,11 @@ class UnivariateDistribution(_ProbabilityDistribution):
         # We have to consider this as a special case; there's no way to include
         # this logic in find_minimum; it has to treat the bracket as invalid.
         mode_at_boundary = res_b.status == -1
-        fl, fm, fr = res_b.bracket
+        fl, fm, fr = res_b.f_bracket
         mode_at_left = mode_at_boundary & (fl <= fm)
         mode_at_right = mode_at_boundary & (fr < fm)
-        mode[mode_at_left] = a[mode_at_left]
-        mode[mode_at_right] = b[mode_at_right]
+        mode = np.where(mode_at_left, a, mode)
+        mode = np.where(mode_at_right, b, mode)
         return mode[()]
 
     def mean(self, *, method=None):

--- a/scipy/stats/_new_distributions.py
+++ b/scipy/stats/_new_distributions.py
@@ -338,6 +338,9 @@ class _LogUniform(ContinuousDistribution):
     def _pdf_formula(self, x, *, log_a, log_b, **kwargs):
         return ((log_b - log_a)*x)**-1
 
+    def _mode_formula(self, *, a, **kwargs):
+        return a
+
     def _moment_raw_formula(self, order, log_a, log_b, **kwargs):
         if order == 0:
             return self._one


### PR DESCRIPTION
#### Reference issue
Closes gh-3432.

#### What does this implement/fix?

Issue #3432 reported that most `scipy.signal.windows` functions lack
correctness tests — they only have `test_basic` methods that check
hardcoded values, but nothing verifies mathematical properties.

This PR adds a `test_correctness` method to 11 window classes:

| Window         | PSLL (dB) | BW 3dB (bins) | Reference   |
|----------------|-----------|---------------|-------------|
| `barthann`     | −35.9     | 1.41          | Harris 1978 |
| `bartlett`     | −26.5     | 1.27          | Harris 1978 |
| `blackman`     | −58.0     | 1.68          | Harris 1978 |
| `blackmanharris` | −92.0  | 1.90          | Harris 1978 |
| `bohman`       | −46.0     | 1.71          | Harris 1978 |
| `boxcar`       | −13.3     | 0.88          | Harris 1978 |
| `hamming`      | −42.7     | 1.30          | Harris 1978 |
| `hann`         | −31.5     | 1.44          | Harris 1978 |
| `nuttall`      | −98.1     | 1.88          | Heinzel 2002 |
| `parzen`       | −53.0     | 1.82          | Harris 1978 |
| `cosine`       | −23.0     | 1.20          | Harris 1978 |

Each test generates a 1024-point window (sym=False), takes a 131072-point
FFT, and asserts PSLL within ±1 dB and BW_3dB within ±0.1 bins of the
published reference. Pattern follows the existing TestTaylor.test_correctness.

#### Additional information
No runtime code changes — tests only.

#### AI Generation Disclosure
Claude Sonnet 4.6 (claude.ai/claude-code) was used to assist with
this PR. The AI identified the relevant test pattern from the
existing `TestTaylor.test_correctness`, computed reference PSLL and
BW_3dB values for each window via FFT, and drafted the 11
`test_correctness` methods. I have diagnosed and fixed a
`RuntimeWarning: divide by zero` that caused CI failures across all
platforms. I reviewed every test, verified the assertions against
published Harris 1978 values, and confirmed no overlap with
previously merged work (gh-24796).