### PR TITLE
BUG: signal/ndimage: make `medfilt` / `rank_filter` treatment of 1D longlong inputs consistent with 2D inputs 

### DIFF
--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -2000,7 +2000,10 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
         # if algorithmic fixes are found.
         lim2 = input.size - ((footprint.size - 1) // 2 - origin)
         if input.ndim == 1 and ((lim2 >= 0) or (input.size == 1)):
-            if input.dtype in (np.int64, np.float64, np.float32):
+            if (
+                (input.dtype in (np.int64, np.float64, np.float32))
+                and (input.dtype.char != 'q')   # np.longlong pretending to be int64
+            ):
                 x = input
                 x_out = output
             elif input.dtype == np.float16:
@@ -2018,7 +2021,10 @@ def _rank_filter(input, rank, size=None, footprint=None, output=None,
             cval = x.dtype.type(cval)
             _rank_filter_1d.rank_filter(x, rank, footprint.size, x_out, mode, cval,
                                         origin)
-            if input.dtype not in (np.int64, np.float64, np.float32):
+            if (
+                input.dtype not in (np.int64, np.float64, np.float32)
+                or (input.dtype.char == 'q')
+            ):
                 np.copyto(output, x_out, casting='unsafe')
         else:
             _nd_image.rank_filter(input, rank, footprint, output, mode, cval, origins)

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -2183,6 +2183,18 @@ class TestNdimageFilters:
             y = ndimage.rank_filter(x, -2, size=3)
             assert y.dtype == x.dtype
 
+    def test_rank_1d_long_long(self):
+        # regression test for https://github.com/scipy/scipy/issues/22368
+        # The OP reported the error via signal.medfilt, which calls ndimage.rank_filter
+        # Here we extract the values of inputs the OP example feeds to rank_filter.
+        volume = np.ones(10, dtype='q')   # np.longlong
+        rank, size = 1, 3
+        result_q = ndimage.rank_filter(volume, rank, size=size, mode="constant")
+        result_l = ndimage.rank_filter(
+            volume.astype("int64"), rank, size=size, mode="constant"
+        )
+        xp_assert_equal(result_q, result_l)
+
     @skip_xp_backends(np_only=True, exceptions=["cupy"],
                       reason="off-by-ones on alt backends")
     @xfail_xp_backends("cupy", reason="does not support extra_arguments")

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -1339,6 +1339,16 @@ class TestMedFilt:
 
         xp_assert_equal(output, expected)
 
+    def test_medfilt_1d_longlong(self):
+        # Regression test for gh-22368: medfilt(1D longlong) was raising TypeError,
+        # while medfilt(2D longlong) was returning an int64 array
+        a = np.ones(12, dtype='q')   # np.longlong
+        b = signal.medfilt(a)
+        xp_assert_equal(b, np.ones(12, dtype=np.int64))
+
+        # 1D result dtype is consistent with the 2D result dtype
+        c = signal.medfilt(a.reshape(3, 4))
+        assert c.dtype == b.dtype
 
 @make_xp_test_case(signal.wiener)
 class TestWiener:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes gh-22368

#### What does this implement/fix?
<!--Please explain your changes.-->

`signal.medfilt` raised a TypeError when given 1D inputs of `dtype=np.longlong`. At the same time, it handles 2D  `np.longlong` arrays just fine.

The problem is that 
- signal.medfilt calls ndimage.rank_filter
- ndimage.rank_filter has a separate code path for 1D as a perf optimization
- that separate code path was not properly handling arrays of `dtype="q"`

This PR fixes the 1D code path to behave the same way the 2D does: the 1D optimization is much newer than the "generic" ndimage codebase (which handles the 2D case).

#### Additional information
<!--Any additional information you think is important.-->

The ugly part is that it is not enough to check for `dtype == np.int64`:

```
In [1]: import numpy as np

In [2]: a = np.ones(3, dtype='q')

In [3]: a.dtype
Out[3]: dtype('int64')

In [4]: a.dtype.char
Out[4]: 'q'

In [5]: b = a.astype('int64')  # looks like a no-op?

In [6]: b.dtype
Out[6]: dtype('int64')

In [7]: b.dtype.char
Out[7]: 'l'

In [8]: np.shares_memory(a, b)
Out[8]: False
```



#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.
