### PR TITLE
BUG: interpolate/RBF: use a symmetric solver where available

### DIFF
--- a/scipy/interpolate/_rbfinterp_np.py
+++ b/scipy/interpolate/_rbfinterp_np.py
@@ -10,7 +10,7 @@ from ._rbfinterp_pythran import (
 )
 
 
-dgesv = get_lapack_funcs('gesv', dtype=np.float64, ilp64="preferred")
+dsysv = get_lapack_funcs('sysv', dtype=np.float64, ilp64="preferred")
 
 
 # trampolines for pythran-compiled functions to drop the `xp` argument
@@ -68,7 +68,7 @@ def _build_and_solve_system(y, d, smoothing, kernel, epsilon, powers, xp):
     lhs, rhs, shift, scale = _build_system(
         y, d, smoothing, kernel, epsilon, powers, xp
         )
-    _, _, coeffs, info = dgesv(lhs, rhs, overwrite_a=True, overwrite_b=True)
+    _, _, coeffs, info = dsysv(lhs, rhs, overwrite_a=True, overwrite_b=True)
     if info < 0:
         raise ValueError(f"The {-info}-th argument had an illegal value.")
     elif info > 0:

--- a/scipy/interpolate/tests/test_rbfinterp.py
+++ b/scipy/interpolate/tests/test_rbfinterp.py
@@ -515,6 +515,20 @@ class TestRBFInterpolatorNeighborsNone(_TestRBFInterpolator):
 
         xp_assert_close(yitp1, yitp2, atol=1e-8)
 
+    def test_singular(self):
+        # regression test for https://github.com/scipy/scipy/issues/23761
+        # The input is singular in floating-point, make sure the singularity is detected
+        points = np.array(
+            [[2.0, 0.0],
+             [0.0, 0.0],
+             [0.0, 1.0735703551645039e-302],
+             [0.5, 3.0]]
+        )
+        values = np.array([0.0, 0.0, 0.0, 1.0])
+
+        with pytest.raises(LinAlgError, match="Singular matrix"):
+            RBFInterpolator(points, values.reshape(-1, 1))
+
 
 @skip_xp_backends(np_only=True, reason="neighbors not None uses KDTree")
 @make_xp_test_case(RBFInterpolator)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/23761

#### What does this implement/fix?
<!--Please explain your changes.-->

The linear system is symmetric by construction, thus use the symmetric LAPACK solver. 

This should improve both numeric stability, and performance for large enough problem sizes --- Constructing the l.h.s. is `O(N**2)` with a large prefactor, the solve is `O(N**3)` and here we're lowering the `N**3` prefactor by a factor of 2 or some such.

I quickly checked performance for smallish problems, and perf changes were within noise. On general grounds this should not degrade performance (if it does, `dsysv` being slower than `dgesv` is something to report to the LAPACK provider), and should improve numerical stability. So a minimal fix is in order, I think.


#### Additional information
<!--Any additional information you think is important.-->

I thought about using `linalg.solve(..., assume="symmetric")` instead of a bare LAPACK driver. That however does incur a visible performance penalty for small sizes. Part of that perf hit is likely due to `linalg.solve` checking the condition number, so it could potentially help with https://github.com/scipy/scipy/issues/14150 but that would be a much larger change with user-visible effects, and it requires more pros/cons analysis. So one issue at a time.


#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.