### PR TITLE
interpolate: parametrize `test_spline_large_2d*` over `spl_apis`; drop Windows `skipif`

### DIFF
--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1416,8 +1416,10 @@ class TestRectBivariateSpline:
     @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
                                         (1, 7e-3, 1e-4),
                                         (3, 2e-2, 1e-4)])
-    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline, _RectBivariateSplineEval),
-                                          (_regrid, _ndbspline_call_like_bivariate)])
+    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline,
+                                           _RectBivariateSplineEval),
+                                          (_regrid,
+                                           _ndbspline_call_like_bivariate)])
     def test_spline_large_2d(self, shape, s_tols, spl_apis):
         # Reference - https://github.com/scipy/scipy/issues/17787
         #
@@ -1443,8 +1445,10 @@ class TestRectBivariateSpline:
     @pytest.mark.skipif(sys.maxsize <= 2**32, reason="Segfaults on 32-bit system "
                                                      "due to large input data")
     @pytest.mark.parametrize("k", [3, 4])
-    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline, _RectBivariateSplineEval),
-                                          (_regrid, _ndbspline_call_like_bivariate)])
+    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline,
+                                           _RectBivariateSplineEval),
+                                          (_regrid,
+                                           _ndbspline_call_like_bivariate)])
     def test_spline_large_2d_maxit(self, k, spl_apis):
         # Reference - for https://github.com/scipy/scipy/issues/17787
         #

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1403,54 +1403,68 @@ class TestRectBivariateSpline:
 
         return x, y, z.astype(np.float64)
 
+    # Thin wrapper used as the ``RectBivariateSpline`` entry in the
+    # ``spl_apis`` parametrize dimension of ``test_spline_large_2d`` and
+    # ``test_spline_large_2d_maxit``.  A standalone callable is required
+    # because ``RectBivariateSpline.__call__`` cannot be passed directly as a
+    # parametrize value alongside ``_ndbspline_call_like_bivariate``.
+    def _RectBivariateSplineEval(spl, x, y):
+        return spl(x, y)
+
     @pytest.mark.slow()
-    @pytest.mark.skipif(sys.platform == "win32", reason="Fails intermittently "
-                                                        "on Windows;"
-                                                        "investigation pending.")
     @pytest.mark.parametrize('shape', [(350, 850), (2000, 170)])
     @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
                                         (1, 7e-3, 1e-4),
                                         (3, 2e-2, 1e-4)])
-    def test_spline_large_2d(self, shape, s_tols):
+    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline, _RectBivariateSplineEval),
+                                          (_regrid, _ndbspline_call_like_bivariate)])
+    def test_spline_large_2d(self, shape, s_tols, spl_apis):
         # Reference - https://github.com/scipy/scipy/issues/17787
+        #
+        # ``spl_apis`` is intentionally a parametrize dimension
+        # so that pytest-timeout's ``--timeout`` limit is applied
+        # individually to each (API, shape, s_tols) combination.  If both APIs
+        # were called sequentially inside a single test function they would
+        # share one timeout budget, making it much easier to exceed the limit
+        # on slow platforms (e.g. Windows CI) and triggering the
+        # ``--timeout-method=thread`` worker crash described in gh-25142.
         nx, ny = shape
         s, atol, rtol = s_tols
         x, y, z = self._sample_large_2d_data(nx, ny)
 
-        spl = RectBivariateSpline(x, y, z, s=s)
-        z_spl = spl(x, y)
+        spl_construct, spl_eval = spl_apis
+
+        spl = spl_construct(x, y, z, s=s)
+        z_spl = spl_eval(spl, x, y)
         assert(not np.isnan(z_spl).any())
         xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
 
-        spl_custom = _regrid(x, y, z, s=s)
-        z_spl_custom = _ndbspline_call_like_bivariate(spl_custom, x, y)
-        assert(not np.isnan(z_spl_custom).any())
-        xp_assert_close(z_spl_custom, z, atol=atol, rtol=rtol)
-
     @pytest.mark.xslow()
-    @pytest.mark.skipif(sys.platform == "win32", reason="Fails intermittently "
-                                                        "on Windows;"
-                                                        "investigation pending.")
     @pytest.mark.skipif(sys.maxsize <= 2**32, reason="Segfaults on 32-bit system "
                                                      "due to large input data")
     @pytest.mark.parametrize("k", [3, 4])
-    def test_spline_large_2d_maxit(self, k):
+    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline, _RectBivariateSplineEval),
+                                          (_regrid, _ndbspline_call_like_bivariate)])
+    def test_spline_large_2d_maxit(self, k, spl_apis):
         # Reference - for https://github.com/scipy/scipy/issues/17787
+        #
+        # ``spl_apis`` is intentionally a parametrize dimension
+        # for the same reason as in ``test_spline_large_2d``: so
+        # that pytest-timeout's ``--timeout`` limit is applied individually to
+        # each (API, k) combination instead of being shared across both APIs
+        # in a single call, which would risk a ``--timeout-method=thread``
+        # worker crash on Windows CI (see gh-25142).
         nx, ny = 1000, 1700
         s, atol, rtol = 2, 2e-2, 1e-12
         x, y, z = self._sample_large_2d_data(nx, ny)
 
-        spl = RectBivariateSpline(x, y, z, s=s,
-                                  maxit=25, kx=k, ky=k)
-        z_spl = spl(x, y)
+        spl_construct, spl_eval = spl_apis
+
+        spl = spl_construct(x, y, z, s=s,
+                            maxit=30, kx=k, ky=k)
+        z_spl = spl_eval(spl, x, y)
         assert(not np.isnan(z_spl).any())
         xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
-
-        spl_custom = _regrid(x, y, z, s=s,
-                                                 maxit=30, kx=k, ky=k)
-        z_spl_custom = _ndbspline_call_like_bivariate(spl_custom, x, y)
-        assert(not np.isnan(z_spl_custom).any())
-        xp_assert_close(z_spl_custom, z, atol=atol, rtol=rtol)
 
     def test_spline_synthetic_data(self):
         """

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1470,10 +1470,18 @@ class TestRectBivariateSpline:
         assert(not np.isnan(z_spl).any())
         xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
 
-    def test_spline_synthetic_data(self):
+    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline,
+                                           _RectBivariateSplineEval),
+                                          (_regrid,
+                                           _ndbspline_call_like_bivariate)])
+    def test_spline_synthetic_data(self, spl_apis):
         """
         Test regrid with synthetic smooth data (mixed frequencies + noise).
         """
+        # ``spl_apis`` is parametrized for consistency with
+        # ``test_spline_large_2d`` and ``test_spline_large_2d_maxit``,
+        # ensuring both APIs are exercised under the same test structure.
+        #
         # Create strictly-increasing axes and smooth test surface
         nx, ny = 64, 64
         kx, ky = 3, 3
@@ -1491,17 +1499,12 @@ class TestRectBivariateSpline:
             + 0.05 * rng.normal(size=(nx, ny))
         ).astype(float)
 
-        # Test RectBivariateSpline
-        spl = RectBivariateSpline(x, y, z, kx=kx, ky=ky, s=s)
-        z_spl = spl(x, y)
+        spl_construct, spl_eval = spl_apis
+
+        spl = spl_construct(x, y, z, kx=kx, ky=ky, s=s)
+        z_spl = spl_eval(spl, x, y)
         assert not np.isnan(z_spl).any()
         xp_assert_close(z_spl, z, atol=0.1, rtol=0.1)
-
-        # Test regrid
-        spl_custom = _regrid(x, y, z, kx=kx, ky=ky, s=s)
-        z_spl_custom = _ndbspline_call_like_bivariate(spl_custom, x, y)
-        assert not np.isnan(z_spl_custom).any()
-        xp_assert_close(z_spl_custom, z, atol=0.1, rtol=0.1)
 
 
 class TestRectSphereBivariateSpline:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/issues/25142

#### What does this implement/fix?
<!--Please explain your changes.-->

**Summary**

Refactors `test_spline_large_2d` and `test_spline_large_2d_maxit` to parametrize over the spline API under test (`spl_apis`) instead of calling both APIs back-to-back inside a single test function. This makes the Windows-only `skipif` markers added in the previous PR unnecessary and removes them, restoring full Windows CI coverage for these tests.

**Background**

`test_spline_large_2d[s_tols1-shape1]` and `test_spline_large_2d[s_tols2-shape1]` were crashing pytest-xdist worker processes on Windows CI ~10 % of the time (see [gh-25142](https://github.com/scipy/scipy/issues/25142)). The crash is a hard OS-level worker kill.

@nickodell reproduced the failure locally and we identified the root cause: `pytest-timeout` applies its `--timeout` budget **per test ID**. The previous test called both `RectBivariateSpline` _and_ `_regrid` sequentially inside a single function body, so both API calls shared **one** timeout budget. For the large `(2000, 170)` grid shapes this combined runtime could exceed 60 s on a loaded CI worker, triggering the crash.

**Fix**

Split the two APIs into a `spl_apis` `@pytest.mark.parametrize` dimension:

```python
@pytest.mark.parametrize("spl_apis", [
    (RectBivariateSpline, _RectBivariateSplineEval),
    (_regrid, _ndbspline_call_like_bivariate),
])
```

Each `(API, shape, s_tols)` / `(API, k)` combination is now a distinct test ID, so `pytest-timeout` resets the budget for every combination. Neither API call can consume the other's time allowance, eliminating the crash.

A small `_RectBivariateSplineEval` helper is added to give `RectBivariateSpline` a uniform `(spl, x, y)` callable signature that matches `_ndbspline_call_like_bivariate` for use as a parametrize value.


**What is NOT changed**

* All existing `shape`, `s_tols`, and `k` parametrize dimensions are preserved.
* Linux and macOS CI were always running the full matrix; their behaviour is unchanged.
* Windows CI now runs the full matrix again, with each combination protected by its own per-test-ID timeout budget.

**Note**

Given the intermittent nature of the original failure, a single green CI run is not sufficient evidence that the flakiness is fully resolved. It would be worth re-running the Windows test suite a few times to build confidence. If the community agrees, I am happy to trigger several runs on my own fork before this is merged, to collect enough data points to be reasonably sure the failure is gone.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI tools used