### PR TITLE
ENH: ndimage: add 1-D `hampel_filter` for outlier detection

### DIFF
--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -43,6 +43,13 @@ New features
 
 ``scipy.ndimage`` improvements
 ==============================
+- The new `~scipy.ndimage.hampel_filter` implements a 1-D Hampel filter for
+  outlier detection and replacement, using the local median and median
+  absolute deviation (MAD). The local median is computed with the existing
+  fast 1-D rank filter; the MAD and replacement step are computed in
+  ``O(log W)`` per sample by a dedicated C++ extension. Optional
+  ``return_median`` and ``return_indices`` flags expose the median signal
+  and the indices of replaced samples.
 
 
 ``scipy.optimize`` improvements

--- a/pyrefly.toml
+++ b/pyrefly.toml
@@ -47,6 +47,7 @@ ignore-missing-imports = [
     "scipy.integrate._vode",
     "scipy.interpolate._dierckx",
     "scipy.interpolate._fitpack",
+    "scipy.ndimage._hampel_1d",
     "scipy.ndimage._nd_image",
     "scipy.ndimage._ni_label",
     "scipy.ndimage._rank_filter_1d",

--- a/scipy/ndimage/__init__.py
+++ b/scipy/ndimage/__init__.py
@@ -27,6 +27,7 @@ Filters
    generic_filter1d - 1-D generic filter along the given axis
    generic_gradient_magnitude
    generic_laplace
+   hampel_filter - 1-D Hampel filter for outlier detection
    laplace - N-D Laplace filter based on approximate second derivatives
    maximum_filter
    maximum_filter1d

--- a/scipy/ndimage/_delegators.py
+++ b/scipy/ndimage/_delegators.py
@@ -248,6 +248,10 @@ def percentile_filter_signature(
     return array_namespace(input, footprint, _skip_if_dtype(output))
 
 
+def hampel_filter_signature(input, size, *args, **kwds):
+    return array_namespace(input)
+
+
 def prewitt_signature(input, axis=-1, output=None, *args, **kwds):
     return array_namespace(input, _skip_if_dtype(output))
 

--- a/scipy/ndimage/_filters.py
+++ b/scipy/ndimage/_filters.py
@@ -41,6 +41,7 @@ from . import _ni_support
 from . import _nd_image
 from . import _ni_docstrings
 from . import _rank_filter_1d
+from . import _hampel_1d
 
 __all__ = ['correlate1d', 'convolve1d', 'gaussian_filter1d', 'gaussian_filter',
            'prewitt', 'sobel', 'generic_laplace', 'laplace',
@@ -49,7 +50,8 @@ __all__ = ['correlate1d', 'convolve1d', 'gaussian_filter1d', 'gaussian_filter',
            'uniform_filter1d', 'uniform_filter', 'minimum_filter1d',
            'maximum_filter1d', 'minimum_filter', 'maximum_filter',
            'rank_filter', 'median_filter', 'percentile_filter',
-           'generic_filter1d', 'generic_filter', 'vectorized_filter']
+           'generic_filter1d', 'generic_filter', 'vectorized_filter',
+           'hampel_filter']
 
 
 def _vectorized_filter_iv(input, function, size, footprint, output, mode, cval, origin,
@@ -2183,6 +2185,136 @@ def percentile_filter(input, percentile, size=None, footprint=None,
     """
     return _rank_filter(input, percentile, size, footprint, output, mode,
                         cval, origin, 'percentile', axes=axes)
+
+
+def hampel_filter(input, size, threshold=3.0, mode="reflect", cval=0.0,
+                  return_median=False, return_indices=False):
+    """Apply a 1-D Hampel filter for outlier detection and replacement.
+
+    Each sample is compared against the local median of a centred window of
+    length ``size``. The local median absolute deviation (MAD) is computed
+    over the same window. Samples for which
+    ``abs(input[i] - median[i]) > threshold * MAD[i]`` are classified as
+    outliers and replaced by the local median; all other samples pass
+    through unchanged.
+
+    The local median is computed with `median_filter` (which uses the fast
+    1-D rank filter) and the MAD is computed in ``O(log size)`` per sample
+    by a C extension that consumes both the original signal and the
+    pre-computed median.
+
+    Parameters
+    ----------
+    input : array_like
+        Input 1-D array.
+    size : int
+        Window length. Should be a positive odd integer; even values are
+        accepted and use a centred window with the same convention as
+        `median_filter`.
+    threshold : float, optional
+        Outlier threshold expressed in units of MAD. Default is ``3.0``.
+    mode : str, optional
+        Boundary handling for both the median and the MAD computations.
+        Same modes as `median_filter` (default ``"reflect"``).
+    cval : scalar, optional
+        Constant fill value used when ``mode='constant'``. Default ``0.0``.
+    return_median : bool, optional
+        If True, also return the local-median signal. Default is False.
+    return_indices : bool, optional
+        If True, also return the sorted integer indices of replaced samples.
+        Default is False.
+
+    Returns
+    -------
+    filtered : ndarray
+        Signal with detected outliers replaced by the local median.
+    median : ndarray, optional
+        Local median signal (output of `median_filter`).
+        Returned only when ``return_median`` is True.
+    changed_indices : ndarray, optional
+        Sorted array of integer indices into ``input`` whose values were
+        replaced. Returned only when ``return_indices`` is True.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy import ndimage
+    >>> x = np.array([1.0, 2.0, 1.5, 2.5, 50.0, 2.0, 1.0, 2.5])
+    >>> filt = ndimage.hampel_filter(x, size=5)
+    >>> filt[4]
+    np.float64(2.0)
+
+    Request the indices of replaced samples in addition to the filtered
+    signal:
+
+    >>> filt, idx = ndimage.hampel_filter(x, size=5, return_indices=True)
+    >>> idx
+    array([4])
+    """
+    input_arr = np.asarray(input)
+    if input_arr.ndim != 1:
+        raise ValueError("hampel_filter supports 1-D arrays only")
+    size = operator.index(size)
+    if size <= 0:
+        raise ValueError("size must be a positive integer")
+    threshold = float(threshold)
+    if threshold < 0.0 or not np.isfinite(threshold):
+        raise ValueError("threshold must be a non-negative finite number")
+
+    if input_arr.dtype == np.float32:
+        x = np.ascontiguousarray(input_arr)
+    else:
+        x = np.ascontiguousarray(input_arr, dtype=np.float64)
+
+    # Degenerate inputs: no filtering possible. Warn and pass the signal
+    # through unchanged (with the same return-tuple shape the caller asked
+    # for). Cases covered:
+    #   - empty input
+    #   - size == 1 (window of one element: MAD is always 0, nothing changes)
+    #   - size larger than the input length
+    degenerate_reason = None
+    if x.size == 0:
+        degenerate_reason = "input is empty"
+    elif size == 1:
+        degenerate_reason = "size == 1, no neighbours to compute MAD"
+    elif size > x.size:
+        degenerate_reason = (f"size ({size}) is larger than input length "
+                             f"({x.size})")
+    if degenerate_reason is not None:
+        warnings.warn(
+            f"hampel_filter: {degenerate_reason}; returning input unchanged.",
+            UserWarning, stacklevel=2,
+        )
+        filtered = x.copy()
+        median = x.copy()
+        changed_mask = np.zeros(x.shape, dtype=bool)
+        if not return_median and not return_indices:
+            return filtered
+        result = [filtered]
+        if return_median:
+            result.append(median)
+        if return_indices:
+            result.append(np.flatnonzero(changed_mask))
+        return tuple(result)
+
+    median = median_filter(x, size=size, mode=mode, cval=cval)
+    median = np.ascontiguousarray(median, dtype=x.dtype)
+
+    filtered = np.empty_like(x)
+    changed_mask = np.zeros(x.shape, dtype=bool)
+    mode_code = _ni_support._extend_mode_to_code(mode, is_filter=True)
+    cval_cast = x.dtype.type(cval)
+    _hampel_1d.hampel(x, median, int(size), float(threshold),
+                      int(mode_code), cval_cast, filtered, changed_mask)
+
+    if not return_median and not return_indices:
+        return filtered
+    result = [filtered]
+    if return_median:
+        result.append(median)
+    if return_indices:
+        result.append(np.flatnonzero(changed_mask))
+    return tuple(result)
 
 
 @_ni_docstrings.docfiller

--- a/scipy/ndimage/_support_alternative_backends.py
+++ b/scipy/ndimage/_support_alternative_backends.py
@@ -104,6 +104,7 @@ capabilities_dict = {
         allow_dask_compute=True, jax_jit=True
     ),
     "labeled_comprehension": xp_capabilities(np_only=True),
+    "hampel_filter": xp_capabilities(np_only=True),
 }
 
 # ### decorate ###

--- a/scipy/ndimage/filters.py
+++ b/scipy/ndimage/filters.py
@@ -13,7 +13,8 @@ __all__ = [  # noqa: F822
     'uniform_filter1d', 'uniform_filter', 'minimum_filter1d',
     'maximum_filter1d', 'minimum_filter', 'maximum_filter',
     'rank_filter', 'median_filter', 'percentile_filter',
-    'generic_filter1d', 'generic_filter'
+    'generic_filter1d', 'generic_filter',
+    'hampel_filter'
 ]
 
 

--- a/scipy/ndimage/meson.build
+++ b/scipy/ndimage/meson.build
@@ -33,6 +33,14 @@ py3.extension_module('_rank_filter_1d',
   subdir: 'scipy/ndimage'
 )
 
+py3.extension_module('_hampel_1d',
+  'src/_hampel_1d.cpp',
+  link_args: version_link_args,
+  install: true,
+  dependencies: np_dep,
+  subdir: 'scipy/ndimage'
+)
+
 py3.extension_module('_ctest',
   'src/_ctest.c',
   dependencies: np_dep,

--- a/scipy/ndimage/src/_hampel_1d.cpp
+++ b/scipy/ndimage/src/_hampel_1d.cpp
@@ -1,0 +1,491 @@
+// Copyright (c) 2026 Gideon Genadi Kogan
+// Distributed under the SciPy BSD-3-Clause license; see LICENSE.txt.
+//
+// 1-D Hampel filter (MAD-based outlier detection) for scipy.ndimage.
+//
+// The local median is supplied by the caller (typically computed by
+// scipy.ndimage.median_filter, which itself uses the O(log W) 1-D rank
+// filter), so this module only contributes the MAD computation and outlier
+// replacement, in O(log W) per sample, using two indexed heaps with an
+// equilibrium loop.
+
+#include "Python.h"
+#include "numpy/arrayobject.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <new>
+#include <vector>
+
+namespace {
+
+typedef enum {
+    NEAREST = 0,
+    WRAP = 1,
+    REFLECT = 2,
+    MIRROR = 3,
+    CONSTANT = 4,
+} Mode;
+
+// Indexed binary heap with O(log W) eager deletion by external index.
+template <typename T>
+class IndexedHeap {
+public:
+    struct Node { T value; int w_idx; };
+
+    std::vector<Node> heap;
+    std::vector<int>& pos_map;
+    bool is_max_heap;
+
+    IndexedHeap(std::vector<int>& p_map, bool max_h)
+        : pos_map(p_map), is_max_heap(max_h) {}
+
+    inline bool compare(T a, T b) const {
+        return is_max_heap ? (a > b) : (a < b);
+    }
+
+    void swap_nodes(int i, int j) {
+        std::swap(heap[i], heap[j]);
+        pos_map[heap[i].w_idx] = i;
+        pos_map[heap[j].w_idx] = j;
+    }
+
+    void shift_up(int i) {
+        while (i > 0) {
+            int p = (i - 1) / 2;
+            if (compare(heap[i].value, heap[p].value)) {
+                swap_nodes(i, p);
+                i = p;
+            } else {
+                break;
+            }
+        }
+    }
+
+    void shift_down(int i) {
+        int n = (int)heap.size();
+        while (2 * i + 1 < n) {
+            int left = 2 * i + 1;
+            int right = 2 * i + 2;
+            int best = left;
+            if (right < n && compare(heap[right].value, heap[left].value)) {
+                best = right;
+            }
+            if (compare(heap[best].value, heap[i].value)) {
+                swap_nodes(i, best);
+                i = best;
+            } else {
+                break;
+            }
+        }
+    }
+
+    void push(T val, int w_idx) {
+        heap.push_back({val, w_idx});
+        int idx = (int)heap.size() - 1;
+        pos_map[w_idx] = idx;
+        shift_up(idx);
+    }
+
+    void erase(int w_idx) {
+        if (w_idx < 0 || w_idx >= (int)pos_map.size() || pos_map[w_idx] == -1) {
+            return;
+        }
+        int idx = pos_map[w_idx];
+        int n = (int)heap.size();
+        if (idx == n - 1) {
+            heap.pop_back();
+            pos_map[w_idx] = -1;
+            return;
+        }
+        swap_nodes(idx, n - 1);
+        heap.pop_back();
+        pos_map[w_idx] = -1;
+        if (idx < (int)heap.size()) {
+            shift_up(idx);
+            shift_down(idx);
+        }
+    }
+
+    T peek() const {
+        if (!heap.empty()) return heap[0].value;
+        return is_max_heap ? -std::numeric_limits<T>::infinity()
+                           :  std::numeric_limits<T>::infinity();
+    }
+
+    int size() const { return (int)heap.size(); }
+};
+
+// Tracks the kth-smallest value of a sliding set using two heaps, with
+// O(log W) target-rank changes.
+template <typename T>
+class RankTracker {
+public:
+    std::vector<int> pos_max;
+    std::vector<int> pos_min;
+    IndexedHeap<T> max_heap;
+    IndexedHeap<T> min_heap;
+    int target_k;
+
+    RankTracker(int universe_size, int target_k_init)
+        : pos_max(universe_size, -1), pos_min(universe_size, -1),
+          max_heap(pos_max, true), min_heap(pos_min, false),
+          target_k(target_k_init) {}
+
+    void insert(T val, int w_idx) {
+        if (max_heap.size() == 0 || val <= max_heap.peek()) {
+            max_heap.push(val, w_idx);
+        } else {
+            min_heap.push(val, w_idx);
+        }
+        balance();
+    }
+
+    void remove(int w_idx) {
+        if (w_idx >= 0 && w_idx < (int)pos_max.size() && pos_max[w_idx] != -1) {
+            max_heap.erase(w_idx);
+        } else if (w_idx >= 0 && w_idx < (int)pos_min.size() && pos_min[w_idx] != -1) {
+            min_heap.erase(w_idx);
+        }
+        balance();
+    }
+
+    void set_rank(int new_k) {
+        target_k = new_k;
+        balance();
+    }
+
+    void balance() {
+        while (max_heap.size() > target_k && max_heap.size() > 0) {
+            auto node = max_heap.heap[0];
+            max_heap.erase(node.w_idx);
+            min_heap.push(node.value, node.w_idx);
+        }
+        while (max_heap.size() < target_k && min_heap.size() > 0) {
+            auto node = min_heap.heap[0];
+            min_heap.erase(node.w_idx);
+            max_heap.push(node.value, node.w_idx);
+        }
+    }
+
+    T get_kth_value() const { return max_heap.peek(); }
+    T get_kplus1_value() const { return min_heap.peek(); }
+};
+
+// Build a padded copy of the signal of length N + 2*Z so that the centred
+// window of width W = 2*Z (+1) fits at every output position. Boundary
+// extension follows scipy.ndimage's mode codes, matching what the caller's
+// median_filter() used to produce the input median signal.
+template <typename T>
+void pad_signal(const T *signal, npy_intp N, int Z, T *padded,
+                int mode, T cval)
+{
+    // Centre copy.
+    for (npy_intp i = 0; i < N; ++i) {
+        padded[Z + i] = signal[i];
+    }
+    if (N == 0) {
+        for (int i = 0; i < 2 * Z; ++i) {
+            padded[i] = (mode == CONSTANT) ? cval : (T)0;
+        }
+        return;
+    }
+    for (int i = 0; i < Z; ++i) {
+        npy_intp li, ri;
+        switch (mode) {
+        case REFLECT:
+            // ... d c b a | a b c d | d c b a ...
+            li = (i < N) ? i : (N - 1);
+            ri = (N - 1 - i >= 0) ? (N - 1 - i) : 0;
+            padded[Z - 1 - i] = signal[li];
+            padded[Z + N + i] = signal[ri];
+            break;
+        case MIRROR:
+            // ... d c b | a b c d | c b a ...
+            li = (i + 1 < N) ? (i + 1) : (N - 1);
+            ri = (N - 2 - i >= 0) ? (N - 2 - i) : 0;
+            padded[Z - 1 - i] = signal[li];
+            padded[Z + N + i] = signal[ri];
+            break;
+        case NEAREST:
+            padded[Z - 1 - i] = signal[0];
+            padded[Z + N + i] = signal[N - 1];
+            break;
+        case WRAP: {
+            // periodic
+            npy_intp lp = ((-(i + 1)) % N + N) % N;
+            npy_intp rp = i % N;
+            padded[Z - 1 - i] = signal[lp];
+            padded[Z + N + i] = signal[rp];
+            break;
+        }
+        case CONSTANT:
+            padded[Z - 1 - i] = cval;
+            padded[Z + N + i] = cval;
+            break;
+        default:
+            padded[Z - 1 - i] = signal[0];
+            padded[Z + N + i] = signal[N - 1];
+            break;
+        }
+    }
+}
+
+// Core Hampel kernel. Returns 0 on success, -1 on memory failure.
+//
+// For every position i in [0, N) the local median M = median_in[i] is
+// already known. We slide a window of width W centred on i (over a
+// boundary-padded copy of the signal) and use the equilibrium loop from the
+// attached algorithm to extract MAD(i) in O(log W). If
+// |signal[i] - M| > threshold * MAD(i) the sample is flagged as an outlier
+// and replaced by M in `filtered`; otherwise the original value is kept.
+template <typename T>
+int _hampel_1d(const T *signal, const T *median_in, npy_intp N, int win_len,
+               double threshold, int mode, T cval,
+               T *filtered, npy_bool *changed)
+{
+    if (win_len <= 0) return -1;
+    int W = win_len;
+    int Z = W / 2;
+
+    // Trivial pass-through for degenerate windows.
+    if (W <= 1) {
+        for (npy_intp i = 0; i < N; ++i) {
+            filtered[i] = signal[i];
+            changed[i] = 0;
+        }
+        return 0;
+    }
+
+    npy_intp padded_N = N + 2 * Z;
+    std::unique_ptr<T[]> padded;
+    try {
+        padded = std::unique_ptr<T[]>(new T[padded_N]);
+    } catch (std::bad_alloc&) {
+        return -1;
+    }
+    pad_signal(signal, N, Z, padded.get(), mode, cval);
+
+    // Equilibrium-loop parameters following the attached design.
+    // Internal "median rank" in 1-based form: M_rank = Z + 1.
+    int M_rank = Z + 1;
+    int k_L = Z / 2;
+    int k_U = Z - k_L;
+
+    RankTracker<T> upper_tracker((int)padded_N, M_rank + k_U);
+    RankTracker<T> lower_tracker((int)padded_N, M_rank - k_L - 1);
+
+    try {
+        // Initial window: padded[0 .. W-1].
+        for (int j = 0; j < W; ++j) {
+            upper_tracker.insert(padded[j], j);
+            lower_tracker.insert(padded[j], j);
+        }
+    } catch (std::bad_alloc&) {
+        return -1;
+    }
+
+    const T INF = std::numeric_limits<T>::infinity();
+
+    // Window i covers padded[i .. i+W-1]; its centre maps to signal[i].
+    for (npy_intp i = 0; i < N; ++i) {
+        if (i > 0) {
+            int old_idx = (int)(i - 1);
+            int new_idx = (int)(i + W - 1);
+            T new_val = padded[new_idx];
+            upper_tracker.remove(old_idx);
+            lower_tracker.remove(old_idx);
+            try {
+                upper_tracker.insert(new_val, new_idx);
+                lower_tracker.insert(new_val, new_idx);
+            } catch (std::bad_alloc&) {
+                return -1;
+            }
+        }
+
+        T M = median_in[i];
+
+        // Re-balance k_U / k_L until the (k_U)th value above M and the
+        // (k_L)th value below M jointly bracket the same rank distance.
+        while (true) {
+            T X_upper_k = upper_tracker.get_kth_value();
+            T X_upper_next = upper_tracker.get_kplus1_value();
+
+            T X_lower_k = lower_tracker.get_kplus1_value();
+            T X_lower_prev = lower_tracker.get_kth_value();
+
+            T A_km1 = (k_U > 0) ? (X_upper_k - M) : -INF;
+            T A_k   = ((M_rank + k_U) < W) ? (X_upper_next - M) : INF;
+            T B_km1 = (k_L > 0) ? (M - X_lower_k) : -INF;
+            T B_k   = ((M_rank - k_L - 1) > 0) ? (M - X_lower_prev) : INF;
+
+            if (k_U > 0 && A_km1 > B_k) {
+                k_U--;
+                k_L++;
+                upper_tracker.set_rank(M_rank + k_U);
+                lower_tracker.set_rank(M_rank - k_L - 1);
+            } else if (k_L > 0 && B_km1 > A_k) {
+                k_L--;
+                k_U++;
+                upper_tracker.set_rank(M_rank + k_U);
+                lower_tracker.set_rank(M_rank - k_L - 1);
+            } else {
+                break;
+            }
+        }
+
+        T cand_A = (k_U > 0) ? (upper_tracker.get_kth_value() - M) : (T)0;
+        T cand_B = (k_L > 0) ? (M - lower_tracker.get_kplus1_value()) : (T)0;
+        T mad = std::max({cand_A, cand_B, (T)0});
+
+        T abs_dev = std::fabs(signal[i] - M);
+        if (abs_dev > (T)threshold * mad) {
+            filtered[i] = M;
+            changed[i] = 1;
+        } else {
+            filtered[i] = signal[i];
+            changed[i] = 0;
+        }
+    }
+    return 0;
+}
+
+// Python entry point:
+//     hampel(signal, median, win_len, threshold, mode, cval,
+//            filtered_out, changed_out)
+// - signal, median, filtered_out: same length, same dtype (float32/float64).
+// - changed_out: bool array, same length.
+static PyObject *hampel(PyObject *self, PyObject *args)
+{
+    PyObject *sig_obj, *med_obj, *cval_obj, *out_obj, *chg_obj;
+    int win_len, mode;
+    double threshold;
+    int status = 0;
+
+    if (!PyArg_ParseTuple(args, "OOidiOOO",
+                          &sig_obj, &med_obj, &win_len, &threshold,
+                          &mode, &cval_obj, &out_obj, &chg_obj)) {
+        return NULL;
+    }
+
+    PyArrayObject *signal = (PyArrayObject *)PyArray_FROM_OTF(
+        sig_obj, NPY_NOTYPE, NPY_ARRAY_IN_ARRAY);
+    if (signal == NULL) return NULL;
+    PyArrayObject *median = (PyArrayObject *)PyArray_FROM_OTF(
+        med_obj, NPY_NOTYPE, NPY_ARRAY_IN_ARRAY);
+    if (median == NULL) { Py_DECREF(signal); return NULL; }
+    PyArrayObject *filt = (PyArrayObject *)PyArray_FROM_OTF(
+        out_obj, NPY_NOTYPE, NPY_ARRAY_INOUT_ARRAY2);
+    if (filt == NULL) { Py_DECREF(signal); Py_DECREF(median); return NULL; }
+    PyArrayObject *chg = (PyArrayObject *)PyArray_FROM_OTF(
+        chg_obj, NPY_BOOL, NPY_ARRAY_INOUT_ARRAY2);
+    if (chg == NULL) {
+        Py_DECREF(signal); Py_DECREF(median); Py_DECREF(filt);
+        return NULL;
+    }
+
+    if (PyArray_TYPE(signal) != PyArray_TYPE(median) ||
+        PyArray_TYPE(signal) != PyArray_TYPE(filt)) {
+        Py_DECREF(signal); Py_DECREF(median);
+        Py_DECREF(filt); Py_DECREF(chg);
+        PyErr_SetString(PyExc_TypeError,
+                        "signal, median and filtered arrays must share dtype");
+        return NULL;
+    }
+
+    npy_intp N = PyArray_SIZE(signal);
+    if (PyArray_SIZE(median) != N || PyArray_SIZE(filt) != N ||
+        PyArray_SIZE(chg) != N) {
+        Py_DECREF(signal); Py_DECREF(median);
+        Py_DECREF(filt); Py_DECREF(chg);
+        PyErr_SetString(PyExc_ValueError,
+                        "input arrays must all have the same size");
+        return NULL;
+    }
+    int type = PyArray_TYPE(signal);
+    npy_bool *c_chg = (npy_bool *)PyArray_DATA(chg);
+
+    switch (type) {
+    case NPY_FLOAT: {
+        float *s = (float *)PyArray_DATA(signal);
+        float *m = (float *)PyArray_DATA(median);
+        float *f = (float *)PyArray_DATA(filt);
+        float cval = (float)PyFloat_AsDouble(cval_obj);
+        status = _hampel_1d<float>(s, m, N, win_len, threshold,
+                                   mode, cval, f, c_chg);
+        break;
+    }
+    case NPY_DOUBLE: {
+        double *s = (double *)PyArray_DATA(signal);
+        double *m = (double *)PyArray_DATA(median);
+        double *f = (double *)PyArray_DATA(filt);
+        double cval = PyFloat_AsDouble(cval_obj);
+        status = _hampel_1d<double>(s, m, N, win_len, threshold,
+                                    mode, cval, f, c_chg);
+        break;
+    }
+    default:
+        PyErr_SetString(PyExc_TypeError,
+                        "hampel filter only supports float32 and float64");
+        break;
+    }
+
+    if (status == -1 && !PyErr_Occurred()) {
+        PyErr_SetString(PyExc_MemoryError,
+                        "failed to allocate memory for hampel filter");
+    }
+
+    Py_DECREF(signal); Py_DECREF(median);
+    Py_DECREF(filt); Py_DECREF(chg);
+    if (PyErr_Occurred()) return NULL;
+    Py_RETURN_NONE;
+}
+
+static PyMethodDef hampel_methods[] = {
+    {"hampel", hampel, METH_VARARGS,
+     "1D Hampel filter (MAD-based outlier detection)."},
+    {NULL, NULL, 0, NULL}
+};
+
+static int
+_hampel_1d_module_exec(PyObject *module)
+{
+    if (_import_array() < 0) { return -1; }
+    if (PyModule_AddStringConstant(module, "__author__",
+                                   "Gideon Genadi Kogan") < 0) {
+        return -1;
+    }
+    return 0;
+}
+
+static PyModuleDef_Slot _hampel_1d_slots[] = {
+    {Py_mod_exec, (void*)_hampel_1d_module_exec},
+    {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#if PY_VERSION_HEX >= 0x030d00f0  /* Python 3.13+ */
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL},
+};
+
+static struct PyModuleDef _hampel_1d_module = {
+    /* m_base     */ PyModuleDef_HEAD_INIT,
+    /* m_name     */ "_hampel_1d",
+    /* m_doc      */ "1-D Hampel filter (MAD-based outlier detection).\n"
+                     "Author: Gideon Genadi Kogan, 2026.",
+    /* m_size     */ 0,
+    /* m_methods  */ hampel_methods,
+    /* m_slots    */ _hampel_1d_slots,
+    /* m_traverse */ NULL,
+    /* m_clear    */ NULL,
+    /* m_free     */ NULL
+};
+
+} // anonymous namespace
+
+PyMODINIT_FUNC
+PyInit__hampel_1d(void)
+{
+    return PyModuleDef_Init(&_hampel_1d_module);
+}

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -3379,3 +3379,139 @@ def test_median_filter_lim2():
     expected = np.ones(8)
     filtered_samples = ndimage.median_filter(sample_array, size=19, mode="reflect")
     xp_assert_close(filtered_samples, expected, check_shape=True, check_dtype=True)
+
+
+# ---------------------------------------------------------------------------
+# Hampel filter tests
+# ---------------------------------------------------------------------------
+
+def _hampel_reference(signal, size, threshold=3.0, mode="reflect", cval=0.0):
+    """Brute-force Hampel reference: median_filter for the median, per-window
+    sort for the MAD. Used to validate the O(log W) C extension."""
+    signal = np.asarray(signal, dtype=np.float64)
+    Z = size // 2
+    pad_mode_map = {
+        "reflect": "symmetric",
+        "mirror": "reflect",
+        "nearest": "edge",
+        "wrap": "wrap",
+        "constant": "constant",
+    }
+    if mode == "constant":
+        padded = np.pad(signal, Z, mode="constant", constant_values=cval)
+    else:
+        padded = np.pad(signal, Z, mode=pad_mode_map[mode])
+    median = ndimage.median_filter(signal, size=size, mode=mode, cval=cval)
+    filtered = signal.copy()
+    changed = np.zeros(signal.shape, dtype=bool)
+    for i in range(signal.size):
+        window = padded[i:i + size]
+        mad = float(np.median(np.abs(window - median[i])))
+        if abs(signal[i] - median[i]) > threshold * mad:
+            filtered[i] = median[i]
+            changed[i] = True
+    return filtered, median, np.flatnonzero(changed)
+
+
+@pytest.mark.parametrize("size", [3, 5, 7, 11])
+@pytest.mark.parametrize("mode", ["reflect", "nearest", "mirror", "wrap"])
+@pytest.mark.parametrize("dtype", [np.float32, np.float64])
+def test_hampel_against_reference(size, mode, dtype):
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal(200).astype(dtype)
+    # Inject a few outliers.
+    x[[3, 50, 120, 199]] += 50.0
+    filt, med, idx = ndimage.hampel_filter(
+        x, size=size, mode=mode, return_median=True, return_indices=True
+    )
+    ref_filt, ref_med, ref_idx = _hampel_reference(
+        x.astype(np.float64), size=size, mode=mode
+    )
+    assert_array_equal(idx, ref_idx)
+    assert_allclose(med, ref_med.astype(filt.dtype), atol=0, rtol=0)
+    assert_allclose(filt, ref_filt.astype(filt.dtype), atol=0, rtol=0)
+
+
+def test_hampel_constant_mode():
+    x = np.asarray([1.0, 1.0, 1.0, 100.0, 1.0, 1.0, 1.0])
+    filt, idx = ndimage.hampel_filter(
+        x, size=5, mode="constant", cval=0.0, return_indices=True
+    )
+    ref_filt, ref_med, ref_idx = _hampel_reference(
+        x, size=5, mode="constant", cval=0.0
+    )
+    assert_array_equal(idx, ref_idx)
+    assert_allclose(filt, ref_filt)
+
+
+def test_hampel_no_outliers_passes_through():
+    # Smooth deterministic signal: every window has a well-defined MAD that
+    # is comparable to the local deviations, so even a modest threshold leaves
+    # the signal untouched.
+    x = np.sin(np.linspace(0.0, 2.0 * np.pi, 100))
+    filt, idx = ndimage.hampel_filter(x, size=7, threshold=3.0,
+                                      return_indices=True)
+    assert idx.size == 0
+    assert_allclose(filt, x)
+
+
+def test_hampel_returns_median_signal():
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal(50)
+    filt, med = ndimage.hampel_filter(x, size=5, return_median=True)
+    expected_med = ndimage.median_filter(x, size=5)
+    assert_allclose(med, expected_med)
+
+
+def test_hampel_default_returns_filtered_only():
+    rng = np.random.default_rng(3)
+    x = rng.standard_normal(20)
+    out = ndimage.hampel_filter(x, size=5)
+    assert isinstance(out, np.ndarray)
+    assert out.shape == x.shape
+
+
+def test_hampel_rejects_2d():
+    with pytest.raises(ValueError):
+        ndimage.hampel_filter(np.ones((4, 4)), size=3)
+
+
+def test_hampel_size_validation():
+    with pytest.raises(ValueError):
+        ndimage.hampel_filter(np.ones(10), size=0)
+
+
+def test_hampel_threshold_validation():
+    with pytest.raises(ValueError):
+        ndimage.hampel_filter(np.ones(10), size=5, threshold=-1.0)
+    with pytest.raises(ValueError):
+        ndimage.hampel_filter(np.ones(10), size=5, threshold=np.inf)
+
+
+def test_hampel_empty_input_warns_and_passes_through():
+    x = np.asarray([], dtype=np.float64)
+    with pytest.warns(UserWarning, match="empty"):
+        out, idx = ndimage.hampel_filter(x, size=5, return_indices=True)
+    assert out.shape == (0,)
+    assert idx.shape == (0,)
+
+
+def test_hampel_size_one_warns_and_passes_through():
+    rng = np.random.default_rng(4)
+    x = rng.standard_normal(20)
+    with pytest.warns(UserWarning, match="size == 1"):
+        out, idx = ndimage.hampel_filter(x, size=1, return_indices=True)
+    assert_allclose(out, x)
+    assert idx.size == 0
+
+
+def test_hampel_size_larger_than_input_warns_and_passes_through():
+    rng = np.random.default_rng(5)
+    x = rng.standard_normal(7)
+    with pytest.warns(UserWarning, match="larger than input length"):
+        out, med, idx = ndimage.hampel_filter(
+            x, size=11, return_median=True, return_indices=True,
+        )
+    assert_allclose(out, x)
+    assert_allclose(med, x)
+    assert idx.size == 0


### PR DESCRIPTION
Closes [ENH: ndimage/signal: add Hampel filter](https://github.com/scipy/scipy/issues/12809).

Implements a 1-D Hampel filter using the local median and median absolute deviation (MAD) for outlier detection and replacement. The local median is computed by the existing fast 1-D rank filter via \`median_filter\` (O(log W) per sample); the MAD and replacement step are computed in **O(log W) per sample** by a new C++ extension (\`_hampel_1d\`) that maintains two indexed dual-heaps with a dynamic rank complementarity invariant, reusing the caller-supplied median.

## Performance (N = 100 000, mode=reflect, threshold=3.0, Apple M-series, min-of-3 runs, median over 10 distributions)

| W | This PR (ms) | Vectorised brute-force (ms) | Speedup | log₂ W |
|---:|---:|---:|---:|---:|
| 11  | 10.16 | 12.26  | 1.21× | 3.46 |
| 21  | 12.53 | 24.09  | 1.92× | 4.39 |
| 51  | 15.70 | 53.71  | 3.42× | 5.67 |
| 101 | 18.38 | 99.66  | 5.42× | 6.66 |
| 201 | 20.89 | 188.36 | 9.02× | 7.65 |
| 501 | 23.56 | 456.98 | 19.40× | 8.97 |

Brute-force scales ~linearly in W; this PR scales ~linearly in log₂ W. All cells validated bit-exactly against the reference across 10 distributions (normal, uniform, gamma, exponential, lognormal, beta, chi-square, Student-t, Laplace, Rayleigh) with marginal outliers injected.

## Attribution note

The algorithm and original standalone implementation were conceived and developed independently, prior to the availability of modern LLMs. The SciPy integration (API design, C++ extension wiring, test suite, and CI fixes) was completed with the assistance of Claude (Opus 4.7).