### PR TITLE
MAINT: version pins/prep for 1.18.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,18 +17,21 @@
 [build-system]
 build-backend = 'mesonpy'
 requires = [
-    "meson-python>=0.15.0",
-    "Cython>=3.2.0",        # when updating version, also update check in meson.build
-    "pybind11>=2.13.2",     # when updating version, also update check in scipy/meson.build
-    "pythran>=0.18.1",      # when updating version, also update check in meson.build
-
-    # numpy requirement for wheel builds for distribution on PyPI - building
-    # against 2.x yields wheels that are also compatible with numpy 1.x at
-    # runtime.
-    # Note that building against numpy 1.x works fine too - users and
-    # redistributors can do this by installing the numpy version they like and
-    # disabling build isolation.
-    "numpy>=2.0.0",
+    # pre-emptive upper bound on meson-python based on:
+    # 0.19.0 working at time of writing, chance of breaking
+    # with 0.20.x/0.21.x low
+    "meson-python>=0.15.0,<0.22.0",
+    # for Cython, 3.2.4 works at time of writing; pre-emptive
+    # guard only:
+    "Cython>=3.2.0,<3.3.0",
+    # Pre-emptive upper bound on pybind11
+    # (3.0.4 works at time of writing)
+    "pybind11>=2.13.2,<3.1.0",
+    # Pre-emptive upper bound on pythran
+    # (0.18.1 works at time of writing)
+    "pythran>=0.18.1,<0.19.0",
+    # NOTE: need numpy>=2.1.3 for free-threaded CPython support
+    "numpy>=2.0.0,<2.8",
 ]
 
 [project]
@@ -46,7 +49,9 @@ maintainers = [
 #     https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies
 requires-python = ">=3.12"  # keep in sync with `min_python_version` in meson.build
 dependencies = [
-    "numpy>=2.0.0",
+    # free-threaded CPython support requires more
+    # recent NumPy release at runtime (>= 2.1.3)
+    "numpy>=2.0.0,<2.8",
 ] # keep in sync with `min_numpy_version` in meson.build
 readme = "README.rst"
 classifiers = [

--- a/scipy/__init__.py
+++ b/scipy/__init__.py
@@ -64,7 +64,7 @@ del _distributor_init
 from scipy._external.packaging_version.version import Version, parse
 # In maintenance branch, change to np_maxversion N+3 if numpy is at N
 np_minversion = '2.0.0'
-np_maxversion = '9.9.99'
+np_maxversion = '2.8.0'
 if (parse(__numpy_version__) < Version(np_minversion) or
         parse(__numpy_version__) >= Version(np_maxversion)):
     import warnings


### PR DESCRIPTION
* Adjust the build and runtime dependency version upper bounds (on maintenance branch) as we prepare for the release of SciPy `1.18.0rc1`.

* Many of the decisions are based on the previous PR for the last release cycle that aimed to do the same: https://github.com/scipy/scipy/pull/24118

[skip circle]

#### AI Generation Disclosure
No AI tools used, but I'm sure robo-release-manager is coming for me.
