### PR TITLE
MAINT, DOC: remove build notes re: NumPy 1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,6 @@ requires = [
     "Cython>=3.2.0",        # when updating version, also update check in meson.build
     "pybind11>=2.13.2",     # when updating version, also update check in scipy/meson.build
     "pythran>=0.18.1",      # when updating version, also update check in meson.build
-
-    # numpy requirement for wheel builds for distribution on PyPI - building
-    # against 2.x yields wheels that are also compatible with numpy 1.x at
-    # runtime.
-    # Note that building against numpy 1.x works fine too - users and
-    # redistributors can do this by installing the numpy version they like and
-    # disabling build isolation.
     "numpy>=2.0.0",
 ]
 


### PR DESCRIPTION
* Remove some build-related comments concerning support for NumPy `1.x` series--we haven't
supported `1.x` at runtime for some time now so I don't see the value in keeping this anymore.

* Noticed while working on the release process.

[ci skip] [skip ci]

#### AI Generation Disclosure
No AI tools used