### PR TITLE
BUG: sparse.linalg.svds: fix RandomState rng handling for numpy <2.2

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -296,7 +296,16 @@ def _transition_to_rng(old_name, *, position_num=None, end_version=None,
             elif as_new_kwarg:  # no warnings; this is the preferred use
                 # After the removal of the decorator, normalization with
                 # np.random.default_rng will be done inside the decorated function
-                kwargs[NEW_NAME] = np.random.default_rng(kwargs[NEW_NAME])
+                rng = kwargs[NEW_NAME]
+                if isinstance(rng, np.random.RandomState):
+                    # default_rng did not accept RandomState before numpy 2.2
+                    # and it's not guaranteed on all numpy versions; seed a
+                    # Generator from the RandomState to be forward-compatible
+                    kwargs[NEW_NAME] = np.random.default_rng(
+                        rng.randint(1, 2**31 - 1, dtype=np.int64)
+                    )
+                else:
+                    kwargs[NEW_NAME] = np.random.default_rng(rng)
 
             elif global_seed_set and emit_warning:
                 # Emit FutureWarning if `np.random.seed` was used and no PRNG was passed

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -91,9 +91,11 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
         raise ValueError(f"`return_singular_vectors` must be in {rs_options}.")
 
     if isinstance(rng, numbers.Integral | np.integer):
-        rng = np.random.default_rng(np.random.RandomState(rng))
-    elif isinstance(rng, np.random.RandomState):
         rng = np.random.default_rng(rng)
+    elif isinstance(rng, np.random.RandomState):
+        # default_rng did not accept RandomState before numpy 2.2;
+        # seed a Generator from the RandomState
+        rng = np.random.default_rng(rng.randint(1, 2**31 - 1, dtype=np.int64))
     elif rng is None:
         rng = np.random.default_rng()
     elif isinstance(rng, np.random.Generator):

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -423,6 +423,19 @@ class SVDSCommonTests:
             assert_allclose(res1a[idx], res2a[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1a)
 
+    def test_svd_rng_RandomState(self):
+        # gh-25069: svds must accept np.random.RandomState as rng argument,
+        # even on numpy < 2.2 where default_rng did not accept RandomState.
+        n = 50
+        k = 1
+
+        rng = np.random.default_rng(0)
+        A = rng.random((n, n))
+
+        # RandomState as rng should not raise
+        res = svds(A, k, solver=self.solver, rng=np.random.RandomState(0))
+        _check_svds(A, k, *res)
+
     @pytest.mark.filterwarnings("ignore:Exited",
                                 reason="Ignore LOBPCG early exit.")
     def test_svd_rng_3(self):


### PR DESCRIPTION
Fixes #25069

`scipy.sparse.linalg.svds` crashes when `rng=np.random.RandomState(0)` is passed on NumPy < 2.2, because `np.random.default_rng(RandomState)` was only added in NumPy 2.2 (numpy/numpy#27771).

**Changes:**
- `_transition_to_rng` decorator: when `rng` is a `RandomState`, seed the `Generator` from `RandomState.randint()` instead of passing the `RandomState` directly to `default_rng`
- `svds._iv`: same fix for the `RandomState` branch; also simplified the integer branch to call `default_rng(int)` directly
- Added `test_svd_rng_RandomState` to verify `svds` accepts `RandomState`

**AI Disclosure:**
This contribution was assisted by an AI coding assistant (OpenCode/Kimi). The AI was used to:
1. Identify the issue from the scipy GitHub tracker
2. Locate the relevant code paths in `_transition_to_rng` and `svds._iv`
3. Draft the fix and test
4. The author reviewed, verified, and committed the changes manually.