### PR TITLE
DOC: signal.vectorstrength: fix references

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4144,17 +4144,15 @@ def vectorstrength(events, period):
 
     References
     ----------
-    van Hemmen, JL, Longtin, A, and Vollmayr, AN. Testing resonating vector
-        strength: Auditory system, electric fish, and noise.
-        Chaos 21, 047508 (2011);
-        :doi:`10.1063/1.3670512`.
-    van Hemmen, JL.  Vector strength after Goldberg, Brown, and von Mises:
-        biological and mathematical perspectives.  Biol Cybern.
-        2013 Aug;107(4):385-96. :doi:`10.1007/s00422-013-0561-7`.
-    van Hemmen, JL and Vollmayr, AN.  Resonating vector strength: what happens
-        when we vary the "probing" frequency while keeping the spike times
-        fixed.  Biol Cybern. 2013 Aug;107(4):491-94.
-        :doi:`10.1007/s00422-013-0560-8`.
+    .. [1] Van Hemmen, JL, Longtin, A, and Vollmayr, AN. "Testing resonating vector
+           strength: Auditory system, electric fish, and noise."
+           Chaos 21, 047508 (2011), :doi:`10.1063/1.3670512`.
+    .. [2] Van Hemmen, JL. "Vector strength after Goldberg, Brown, and von Mises:
+           biological and mathematical perspectives."
+           Biol Cybern. 2013 Aug; 107(4): 385-96. :doi:`10.1007/s00422-013-0561-7`.
+    .. [3] Van Hemmen, JL and Vollmayr, AN. "Resonating vector strength: what happens
+           when we vary the 'probing' frequency while keeping the spike times fixed."
+           Biol Cybern. 2013 Aug; 107(4): 491-94. :doi:`10.1007/s00422-013-0560-8`.
 
     Examples
     --------


### PR DESCRIPTION
In this small PR, the "References" section is reformatted to be consistent with rest of the documentation.

## Before:
<img width="901" height="299" alt="image" src="https://github.com/user-attachments/assets/1a034212-9d1d-47ed-9b45-629bea23de28" />

## After:
<img width="881" height="233" alt="image" src="https://github.com/user-attachments/assets/36ed2b86-4307-457a-b7e1-1d50be19be8c" />



[docs only]


#### AI Generation Disclosure
No AI was used in this PR.