### PR TITLE
BUG: sparse.linalg.svds: fix `random_state` regression for NumPy <2.2

### DIFF
--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -1,9 +1,8 @@
 import math
-import numbers
 import numpy as np
 from . import eigsh
 
-from scipy._lib._util import _transition_to_rng
+from scipy._lib._util import _transition_to_rng, check_random_state
 from scipy.sparse.linalg._interface import LinearOperator, aslinearoperator
 from scipy.sparse.linalg._eigen.lobpcg import lobpcg  # type: ignore[no-redef]
 from scipy.sparse.linalg._svdp import _svdp
@@ -90,18 +89,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
     if return_singular not in rs_options:
         raise ValueError(f"`return_singular_vectors` must be in {rs_options}.")
 
-    if isinstance(rng, numbers.Integral | np.integer):
-        rng = np.random.default_rng(np.random.RandomState(rng))
-    elif isinstance(rng, np.random.RandomState):
-        rng = np.random.default_rng(rng)
-    elif rng is None:
-        rng = np.random.default_rng()
-    elif isinstance(rng, np.random.Generator):
-        pass
-    else:
-        raise ValueError(f"'{rng}' is neither a NumPy Generator nor an integer seed"
-                         " to instantiate one. For future-proofing, prefer using a"
-                         " NumPy Generator.")
+    rng = check_random_state(rng)
 
     return (A, k, ncv, tol, which, v0, maxiter,
             return_singular, solver, rng)

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -426,7 +426,7 @@ class SVDSCommonTests:
     def test_svd_random_state(self):
         # the legacy `random_state` argument should work for now,
         # even with NumPy <2.2.
-        # Regression test for gh-250
+        # Regression test for gh-25069
         rng = np.random.default_rng(0)
         A = rng.random((5, 5))
         res = svds(A, 1, solver=self.solver, random_state=np.random.RandomState(0))

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -423,6 +423,15 @@ class SVDSCommonTests:
             assert_allclose(res1a[idx], res2a[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1a)
 
+    def test_svd_random_state(self):
+        # the legacy `random_state` argument should work for now,
+        # even with NumPy <2.2.
+        # Regression test for gh-250
+        rng = np.random.default_rng(0)
+        A = rng.random((5, 5))
+        res = svds(A, 1, solver=self.solver, random_state=np.random.RandomState(0))
+        _check_svds(A, 1, *res)
+
     @pytest.mark.filterwarnings("ignore:Exited",
                                 reason="Ignore LOBPCG early exit.")
     def test_svd_rng_3(self):

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -267,8 +267,19 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         works = work, iwork
 
     # Generate the seed for the PROPACK random float generator.
-    rng_state = rng.integers(low=0, high=np.iinfo(np.int64).max,
-                             size=4, dtype=np.uint64)
+    # TODO: once `svds` drops legacy positional `random_state` support,
+    # or once `_lib._util.check_random_state` is adjusted to always
+    # coerce `RandomState` input to a `Generator` instance
+    # (possible from NumPy >=2.2),
+    # the legacy branch can be removed here.
+    if hasattr(rng, "integers"):
+        rng_state = rng.integers(
+            low=0, high=np.iinfo(np.int64).max, size=4, dtype=np.uint64
+        )
+    else:  # legacy np.random.RandomState
+        rng_state = rng.randint(
+            low=0, high=np.iinfo(np.int64).max, size=4, dtype=np.uint64
+        )
 
     if irl_mode:
         info = lansvd_irl(_which_converter[which], jobu,


### PR DESCRIPTION
Closes gh-25069, closes gh-25201.

This is partially a reversion of a change[^1] by @ilayn in gh-23531. That PR introduced `rng_state` into the PROPACK wrappers, but was written requiring that `rng.integers` is available (i.e. that a `Generator` is used). Because of that, the input validation of `svds` was changed to forcefully coerce `RandomState` input to a `Generator`.

That forceful coercion caused a regression for NumPy <2.2, for which `np.random.default_rng(some_RandomState_instance)` raises a `TypeError`, as reported in gh-25069. This broke the behaviour of the legacy `random_state` interface documented at https://scipy.github.io/devdocs/reference/generated/scipy.sparse.linalg.svds.html#scipy.sparse.linalg.svds.

This PR fixes the regression by accepting `RandomState` instances in the legacy interface as documented, and updating the PROPACK wrappers to be able to use a `RandomState` instead of a `Generator`.

---

A handy way to double-check the regression test is via `pixi add --feature=test-deps numpy=2.1.3`.

---

Once we drop NumPy <2.2, we have the option of changing the legacy behaviour in `check_random_state` from accepting the `RandomState` instances unmodified to always coercing them to `Generator`. If that is done, then the change in this diff to `_svdp.py` can be reverted.

If we happened to execute the deprecation of the `random_state` parameter before dropping NumPy <2.2, that would come with dropping `RandomState` support, at which point we could make a similar reversion.

cc @mdhaber as expert on the SPEC 7 machinery. cc @theochemtheo

[^1]: https://github.com/scipy/scipy/pull/23531#issuecomment-3308857599