### PR TITLE
REL: set 1.18.0rc2 unreleased

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.18.0rc1"
+version = "1.18.0rc2.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Set the version to SciPy `1.18.0rc2` "unreleased."

[ci skip] [skip ci]

* This is mostly for release process visibility with the CI skipped. A few notes on things that changed this time around:
 
1. Because we're now using [trusted publishing with PyPI](https://docs.pypi.org/trusted-publishers/), release assets (sdist/binaries) and their hashes have only been made available directly at https://pypi.org/project/scipy/1.18.0rc1/, rather than reproduced on our release page here (https://github.com/scipy/scipy/releases/tag/v1.18.0rc1). This is mostly to avoid defeating the purpose of the "trusted" process in the first place, where assets don't touch the release manager's computer at all.
2. Brief disclaimers about the above have been added to the discourse and GitHub release page announcements. I do know of at least one case where someone opened an issue about a missing link to an asset on our GitHub release page, but I can't find it now and that has been rare I think. If GitHub provides an easy way to duplicate the trusted assets on their release page we could consider doing that again, but I think we briefly discussed that bending over backwards to do that at the moment isn't a priority.
3. I did check that the metadata on PyPI for sdist/wheels now shows "Uploaded using Trusted Publishing? Yes" for RC1. Sample for the `sdist` below.

<img width="399" height="326" alt="image" src="https://github.com/user-attachments/assets/bb32ba33-6800-4047-bbc7-f965c92e7ddf" />


#### AI Generation Disclosure
"No AI tools used"
