### PR TITLE
TYP: `_lib._util`: remove `GeneratorType` type variable

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -11,7 +11,7 @@ import os
 import sys
 import textwrap
 from types import ModuleType
-from typing import Literal, TypeVar
+from typing import Literal
 
 import numpy as np
 from scipy._lib._array_api import (Array, array_namespace, is_lazy_array, is_numpy,
@@ -52,8 +52,6 @@ else:
 
 type _RNG = np.random.Generator | np.random.RandomState
 type SeedType = IntNumber | _RNG | None
-
-GeneratorType = TypeVar("GeneratorType", bound=_RNG)
 
 
 def _lazyselect(condlist, choicelist, arrays, default=0):

--- a/scipy/stats/_qmc.py
+++ b/scipy/stats/_qmc.py
@@ -16,7 +16,7 @@ from collections.abc import Callable
 
 import numpy as np
 
-from scipy._lib._util import DecimalNumber, GeneratorType, IntNumber, SeedType
+from scipy._lib._util import _RNG, DecimalNumber, IntNumber, SeedType
 
 if TYPE_CHECKING:
     import numpy.typing as npt
@@ -47,13 +47,9 @@ __all__ = ['scale', 'discrepancy', 'geometric_discrepancy', 'update_discrepancy'
 
 
 @overload
-def check_random_state(seed: IntNumber | None = ...) -> np.random.Generator:
-    ...
-
-
+def check_random_state(seed: IntNumber | None = None) -> np.random.Generator: ...
 @overload
-def check_random_state(seed: GeneratorType) -> GeneratorType:
-    ...
+def check_random_state[GeneratorT: _RNG](seed: GeneratorT) -> GeneratorT:...
 
 
 # Based on scipy._lib._util.check_random_state
@@ -2617,7 +2613,7 @@ def _select_optimizer(
 
 
 def _random_cd(
-    best_sample: np.ndarray, n_iters: int, n_nochange: int, rng: GeneratorType,
+    best_sample: np.ndarray, n_iters: int, n_nochange: int, rng: _RNG,
     **kwargs: dict
 ) -> np.ndarray:
     """Optimal LHS on CD.


### PR DESCRIPTION
Python 3.12 comes with [PEP 695](https://peps.python.org/pep-0695/), removing the need for using `typing.TypeVar`. This removes the `scipy._lib._util.GeneratorType` type variable in favor of the new type parameter syntax. 

#### AI Generation Disclosure
No AI tools used
