### PR TITLE
MAINT: `_lib._util`: remove trivial `np_[u]long` aliases

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -22,9 +22,6 @@ from scipy._lib._sparse import issparse
 from numpy.exceptions import AxisError
 
 
-np_long = np.long
-np_ulong = np.ulong
-
 type IntNumber = int | np.integer
 type DecimalNumber = float | np.floating | np.integer
 

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -7,7 +7,6 @@ import operator
 import numpy as np
 from math import prod
 import scipy.sparse as sp
-from scipy._lib._util import np_long, np_ulong
 
 
 __all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
@@ -15,7 +14,7 @@ __all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
            'broadcast_shapes']
 
 supported_dtypes = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc,
-                    np.uintc, np_long, np_ulong, np.longlong, np.ulonglong,
+                    np.uintc, np.long, np.ulong, np.longlong, np.ulonglong,
                     np.float32, np.float64, np.longdouble,
                     np.complex64, np.complex128, np.clongdouble]
 

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -5,12 +5,11 @@ from pytest import raises as assert_raises
 from scipy import sparse
 
 from scipy.sparse import csgraph
-from scipy._lib._util import np_long, np_ulong
 
 
 def check_int_type(mat):
     return np.issubdtype(mat.dtype, np.signedinteger) or np.issubdtype(
-        mat.dtype, np_ulong
+        mat.dtype, np.ulong
     )
 
 
@@ -161,7 +160,7 @@ def _check_laplacian_dtype(
                 _assert_allclose_sparse(L, mat)
 
 
-INT_DTYPES = (np.intc, np_long, np.longlong)
+INT_DTYPES = (np.intc, np.long, np.longlong)
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 DTYPES = INT_DTYPES + REAL_DTYPES + COMPLEX_DTYPES

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -17,13 +17,12 @@ from scipy.sparse import dia_array, eye_array, csr_array
 from scipy.sparse.linalg import eigsh, LinearOperator
 from scipy.sparse.linalg._eigen.lobpcg import lobpcg
 from scipy.sparse.linalg._eigen.lobpcg.lobpcg import _b_orthonormalize
-from scipy._lib._util import np_long, np_ulong
 from scipy.sparse.linalg._special_sparse_arrays import (Sakurai,
                                                         MikotaPair)
 
 _IS_32BIT = (sys.maxsize < 2**32)
 
-INT_DTYPES = (np.intc, np_long, np.longlong, np.uintc, np_ulong, np.ulonglong)
+INT_DTYPES = (np.intc, np.long, np.longlong, np.uintc, np.ulong, np.ulonglong)
 # np.half is unsupported on many test systems so excluded
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -15,11 +15,10 @@ from scipy.sparse.linalg import expm as sp_expm
 from scipy.sparse.linalg._expm_multiply import (_theta, _compute_p_max,
         _onenormest_matrix_power, expm_multiply, _expm_multiply_simple,
         _expm_multiply_interval)
-from scipy._lib._util import np_long
 
 
 IMPRECISE = {np.single, np.csingle}
-REAL_DTYPES = (np.intc, np_long, np.longlong,
+REAL_DTYPES = (np.intc, np.long, np.longlong,
                np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -60,7 +60,7 @@ from scipy.spatial.distance import (braycurtis, canberra, chebyshev, cityblock,
                                     minkowski, rogerstanimoto,
                                     russellrao, seuclidean,  # noqa: F401
                                     sokalsneath, sqeuclidean, yule)
-from scipy._lib._util import np_long, np_ulong, _apply_over_batch
+from scipy._lib._util import _apply_over_batch
 from scipy.conftest import skip_xp_invalid_arg
 
 
@@ -129,8 +129,8 @@ def load_testing_files():
     eo['pdist-boolean-inp'] = np.bool_(eo['pdist-boolean-inp'])
     eo['random-bool-data'] = np.bool_(eo['random-bool-data'])
     eo['random-float32-data'] = np.float32(eo['random-double-data'])
-    eo['random-int-data'] = np_long(eo['random-int-data'])
-    eo['random-uint-data'] = np_ulong(eo['random-uint-data'])
+    eo['random-int-data'] = np.long(eo['random-int-data'])
+    eo['random-uint-data'] = np.ulong(eo['random-uint-data'])
 
 
 load_testing_files()
@@ -405,8 +405,8 @@ class TestCdist:
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
                              'random-uint-data', 'random-double-data',
                              'random-bool-data']
-        self.valid_upcasts = {'bool': [np_ulong, np_long, np.float32, np.float64],
-                              'uint': [np_long, np.float32, np.float64],
+        self.valid_upcasts = {'bool': [np.ulong, np.long, np.float32, np.float64],
+                              'uint': [np.long, np.float32, np.float64],
                               'int': [np.float32, np.float64],
                               'float32': [np.float64]}
 
@@ -697,8 +697,8 @@ class TestPdist:
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
                              'random-uint-data', 'random-double-data',
                              'random-bool-data']
-        self.valid_upcasts = {'bool': [np_ulong, np_long, np.float32, np.float64],
-                              'uint': [np_long, np.float32, np.float64],
+        self.valid_upcasts = {'bool': [np.ulong, np.long, np.float32, np.float64],
+                              'uint': [np.long, np.float32, np.float64],
                               'int': [np.float32, np.float64],
                               'float32': [np.float64]}
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -37,7 +37,6 @@ from scipy.special import ellipe, ellipk, ellipkm1
 from scipy.special import elliprc, elliprd, elliprf, elliprg, elliprj
 from scipy.special import softplus
 from scipy.special import mathieu_odd_coef, mathieu_even_coef, stirling2
-from scipy._lib._util import np_long, np_ulong
 from scipy._lib._array_api import xp_assert_close, xp_assert_equal, SCIPY_ARRAY_API
 
 from scipy.special._basic import (
@@ -2959,7 +2958,7 @@ class TestFactorialFunctions:
         kw = {"k": k, "exact": exact, "extend": extend}
         if exact and k in _FACTORIALK_LIMITS_64BITS.keys():
             n = np.array([_FACTORIALK_LIMITS_32BITS[k]])
-            assert_equal(special.factorialk(n, **kw).dtype, np_long)
+            assert_equal(special.factorialk(n, **kw).dtype, np.long)
             assert_equal(special.factorialk(n + 1, **kw).dtype, np.int64)
             # assert maximality of limits for given dtype
             assert special.factorialk(n + 1, **kw) > np.iinfo(np.int32).max
@@ -4837,8 +4836,8 @@ class TestStirling2:
     def test_numpy_array_unsigned_int_dtype(self, is_exact, comp, kwargs):
         # numpy unsigned integers are allowed as dtype in numpy arrays
         ans = asarray(self.table[4][1:])
-        n = asarray([4, 4, 4, 4], dtype=np_ulong)
-        k = asarray([1, 2, 3, 4], dtype=np_ulong)
+        n = asarray([4, 4, 4, 4], dtype=np.ulong)
+        k = asarray([1, 2, 3, 4], dtype=np.ulong)
         comp(stirling2(n, k, exact=False), ans, **kwargs)
 
     @pytest.mark.parametrize("is_exact, comp, kwargs", [

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -7,9 +7,7 @@ from pytest import raises as assert_raises
 
 import numpy.ma.testutils as ma_npt
 
-from scipy._lib._util import (
-    getfullargspec_no_self as _getfullargspec, np_long
-)
+from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from scipy._lib._array_api_no_0d import xp_assert_equal
 from scipy import stats
 
@@ -231,7 +229,7 @@ def check_random_state_property(distfn, args):
 def check_meth_dtype(distfn, arg, meths):
     q0 = [0.25, 0.5, 0.75]
     x0 = distfn.ppf(q0, *arg)
-    x_cast = [x0.astype(tp) for tp in (np_long, np.float16, np.float32,
+    x_cast = [x0.astype(tp) for tp in (np.long, np.float16, np.float32,
                                        np.float64)]
 
     for x in x_cast:
@@ -260,7 +258,7 @@ def check_cmplx_deriv(distfn, arg):
         return (f(x + h*1j, *arg)/h).imag
 
     x0 = distfn.ppf([0.25, 0.51, 0.75], *arg)
-    x_cast = [x0.astype(tp) for tp in (np_long, np.float16, np.float32,
+    x_cast = [x0.astype(tp) for tp in (np.long, np.float16, np.float32,
                                        np.float64)]
 
     for x in x_cast:


### PR DESCRIPTION
Now that `numpy<1` is dropped, there's the `np_long` and `np_ulong` aliases in `scipy._lib._util` are no longer needed.

These are causing issues in scipy-stubs (https://github.com/scipy/scipy-stubs/pull/1616) right now. So if backporting this is easy, then that would help. Otherwise it's also fine, because I don't expect that working around it will be very difficult.

#### AI Generation Disclosure
No AI tools used
