### PR TITLE
BUG: linalg.fiedler_companion: fix output shape for length-1 input

### DIFF
--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1099,6 +1099,8 @@ def fiedler_companion(a):
     if a.size <= 2:
         if a.size == 2:
             return np.array([[-(a/a[0])[-1]]])
+        if a.size == 1:
+            return np.empty((0, 0), dtype=a.dtype)
         return np.array([], dtype=a.dtype)
 
     if a[0] == 0.:

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -534,6 +534,7 @@ def test_fiedler_companion():
     assert_equal(fc.size, 0)
     fc = fiedler_companion([1.])
     assert_equal(fc.size, 0)
+    assert_equal(fc.shape, (0, 0))
     fc = fiedler_companion([1., 2.])
     assert_array_equal(fc, np.array([[-2.]]))
     fc = fiedler_companion([1e-12, 2., 3.])


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?
According to the `fiedler_companion` documentation, operating on an array of length `N` should return a `(N - 1, N - 1)` matrix: https://github.com/scipy/scipy/blob/ba810c16bf62cde814154503a4aeee6b7e674d21/scipy/linalg/_special_matrices.py#L1045-L1058

But this is not the case when `N = 1`:
```python
>>> import scipy
>>> scipy.linalg.fiedler_companion([1]).shape
(0,)
```
This PR updates the implementation so that a length-1 array returns a `(0, 0)` matrix as documented:
```python
>>> import scipy
>>> scipy.linalg.fiedler_companion([1]).shape
(0, 0)
```

#### Additional information
I did not change the length-zero input case here, which should probably raise a `ValueError` rather than returning an shape `(0,)` array, as I suspect this would require some sort of deprecation cycle.

#### AI Generation Disclosure
I did not use AI tools in creating this PR.