### PR TITLE
BUG: linalg: Fix return shape of fiedler([])

### DIFF
--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1024,7 +1024,7 @@ def fiedler(a):
     a = xpx.atleast_nd(xp.asarray(a), ndim=1)
 
     if xp_size(a) == 0:
-        return xp.asarray([], dtype=xp.float64)
+        return xp.empty((0, 0), dtype=xp.float64)
     elif xp_size(a) == 1:
         return xp.asarray([[0.]])
     else:

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -515,6 +515,7 @@ def test_dft():
 def test_fiedler(xp):
     f = fiedler(xp.asarray([]))
     assert xp_size(f) == 0
+    assert f.shape == (0, 0)
 
     f = fiedler(xp.asarray([123.]))
     xp_assert_equal(f, xp.asarray([[0.]]))


### PR DESCRIPTION

#### What does this implement/fix?

Fixes the inconsistent return shape of `linalg.fiedler([])`.  The shape (as explained in the docstring) should be `(0, 0)`, but before this change it was `(0,)`.

#### Additional information

I noticed this while looking at https://github.com/scipy/scipy/pull/25227.

#### AI Generation Disclosure

No AI tools used.