### PR TITLE
DOC: fix tau matrix in `RigidTransform.from_exp_coords`  docstring

### DIFF
--- a/scipy/spatial/transform/_rigid_transform.py
+++ b/scipy/spatial/transform/_rigid_transform.py
@@ -773,7 +773,7 @@ class RigidTransform:
             tau = [  0 -rz  ry vx]
                   [ rz   0 -rx vy]
                   [-ry  rx   0 vz]
-                  [  0   0   0  1]
+                  [  0   0   0  0]
 
         Parameters
         ----------


### PR DESCRIPTION
#### Reference issue
Closes gh-25223

#### What does this implement/fix?
The bottom-right entry of the documented `tau` matrix was `1`, which is wrong. 
This pr only changes the docstring so that bottom row of the matrix in the docs should be all 0s.

#### AI Generation Disclosure
No AI tools used.
