### PR TITLE
MAINT: fix some minor tolerance violations

### DIFF
--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -266,7 +266,7 @@ class TestAAA:
         r = AAA(z, f)
 
         zz = np.logspace(-15, 0, 500)
-        assert_allclose(r(zz), np.sqrt(zz), rtol=9e-6)
+        assert_allclose(r(zz), np.sqrt(zz), rtol=1e-5)
 
 
 class BatchFloaterHormann:

--- a/scipy/special/tests/test_log1mexp.py
+++ b/scipy/special/tests/test_log1mexp.py
@@ -67,7 +67,7 @@ from scipy.special._ufuncs import _log1mexp
 )
 def test_log1mexp(x, expected):
     observed = _log1mexp(x)
-    assert_allclose(observed, expected, rtol=1e-15)
+    assert_allclose(observed, expected, rtol=1e-15, atol=1e-300)
 
 
 @pytest.mark.parametrize("x", [1.1, 1e10, np.inf])


### PR DESCRIPTION
From work in https://github.com/conda-forge/scipy-feedstock/pull/322 & https://github.com/conda-forge/scipy-feedstock/pull/323

The increases here are very slight; 9e-6 to 1e-5 to avoid
```
FAILED interpolate/tests/test_bary_rational.py::TestAAA::test_diag_scaling - AssertionError: 
Not equal to tolerance rtol=9e-06, atol=0

Mismatched elements: 2 / 500 (0.4%)
Mismatch at indices:
 [7]: 4.029158998962861e-08 (ACTUAL), 4.029122027951352e-08 (DESIRED)
 [8]: 4.171041158616451e-08 (ACTUAL), 4.171002795903881e-08 (DESIRED)
Max absolute difference among violations: 3.83627126e-13
Max relative difference among violations: 9.19747947e-06
```
as well as an absolutely tiny (but non-zero) absolute tolerance to avoid the following failure on windows
```
FAILED special/tests/test_log1mexp.py::test_log1mexp[-745.0--5e-324] - AssertionError: 
Not equal to tolerance rtol=1e-15, atol=0

Mismatched elements: 1 / 1 (100%)
Max absolute difference among violations: 5.e-324
Max relative difference among violations: 1.
 ACTUAL: array(-0.)
 DESIRED: array(-5.e-324)
 ```