### PR TITLE
TYP: remove orphaned `linalg._matfuncs_expm` stubs

### DIFF
--- a/scipy/linalg/_matfuncs_expm.pyi
+++ b/scipy/linalg/_matfuncs_expm.pyi
@@ -1,6 +1,0 @@
-from numpy.typing import NDArray
-from typing import Any
-
-def pick_pade_structure(a: NDArray[Any]) -> tuple[int, int]: ...
-
-def pade_UV_calc(Am: NDArray[Any], m: int) -> int: ...

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -315,7 +315,6 @@ python_sources = [
   '_decomp_svd.py',
   '_expm_frechet.py',
   '_matfuncs.py',
-  '_matfuncs_expm.pyi',
   '_matfuncs_inv_ssq.py',
   '_matfuncs_sqrtm.py',
   '_misc.py',


### PR DESCRIPTION
Because 

```
In [4]: from scipy.linalg import _matfuncs_expm
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[4], line 1
----> 1 from scipy.linalg import _matfuncs_expm

ImportError: cannot import name '_matfuncs_expm' from 'scipy.linalg' (/home/joren/Workspace/scipy-stubs/.venv/lib/python3.14/site-packages/scipy/linalg/__init__.py)
```

#### AI Generation Disclosure
No AI tools used