### PR TITLE
DEP: signal.lombscargle: remove deprecated `precenter` param

### DIFF
--- a/scipy/signal/_delegators.py
+++ b/scipy/signal/_delegators.py
@@ -415,8 +415,7 @@ def lfiltic_signature(b, a, y, x=None):
 
 
 def lombscargle_signature(
-    x, y, freqs, precenter=False, normalize=False, *,
-    weights=None, floating_mean=False
+    x, y, freqs, *, normalize=False, weights=None, floating_mean=False
 ):
     return array_namespace(x, y, freqs, weights)
 

--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -4,7 +4,6 @@ import numpy as np
 import numpy.typing as npt
 from scipy import fft as sp_fft
 from scipy._lib._array_api import array_namespace
-from scipy._lib.deprecation import _deprecate_positional_args, _NoValue
 from . import _signaltools
 from ._short_time_fft import ShortTimeFFT, FFT_MODE_TYPE
 from .windows import get_window
@@ -17,13 +16,11 @@ __all__ = ['periodogram', 'welch', 'lombscargle', 'csd', 'coherence',
            'spectrogram', 'stft', 'istft', 'check_COLA', 'check_NOLA']
 
 
-@_deprecate_positional_args(version="1.19.0")
 def lombscargle(
     x: npt.ArrayLike,
     y: npt.ArrayLike,
     freqs: npt.ArrayLike,
     *,
-    precenter: bool = _NoValue,  # type:ignore[assignment]
     normalize: bool | Literal["power", "normalize", "amplitude"] = False,
     weights: npt.NDArray | None = None,
     floating_mean: bool = False,
@@ -67,14 +64,6 @@ def lombscargle(
         Angular frequencies (e.g., having unit rad/s=2π/s for `x` having unit s) for
         output periodogram. Frequencies are normally >= 0, as any peak at ``-freq`` will
         also exist at ``+freq``.
-    precenter : bool, optional
-        Pre-center measurement values by subtracting the mean, if True. This is
-        a legacy parameter and unnecessary if `floating_mean` is True.
-
-        .. deprecated:: 1.17.0
-            The `precenter` argument is deprecated and will be removed in SciPy 1.19.0.
-            The functionality can be substituted by passing ``y - y.mean()`` to `y`.
-
     normalize : bool | str, optional
         Compute normalized or complex (amplitude + phase) periodogram.
         Valid options are: ``False``/``"power"``, ``True``/``"normalize"``, or
@@ -256,17 +245,6 @@ def lombscargle(
 
     # weight vector must sum to 1
     weights = weights * (1.0 / weights.sum())
-
-    # if requested, perform precenter
-    if precenter is not _NoValue:
-        msg = ("Use of parameter 'precenter' is deprecated as of SciPy 1.17.0 and "
-               "will be removed in 1.19.0. Please leave 'precenter' unspecified. "
-               "Passing True to 'precenter' "
-               "can be exactly substituted by passing 'y = (y - y.mean())' into "
-               "the input. Consider setting `floating_mean` to True instead.")
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-        if precenter:
-            y = y - y.mean()
 
     # transform arrays
     # row vector

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1112,47 +1112,6 @@ class TestLombscargle:
         # numerical differences when data is removed)
         assert_allclose(pgram[f==w], ampl, rtol=5e-2)
 
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-    def test_precenter(self):
-        # Test if precenter gives the same result as manually precentering
-        # (for a very simple offset)
-
-        # Input parameters
-        ampl = 2.
-        w = 1.
-        phi = 0.5 * np.pi
-        nin = 100
-        nout = 1000
-        p = 0.7  # Fraction of points to select
-        offset = 0.15  # Offset to be subtracted in pre-centering
-
-        # Randomly select a fraction of an array with timesteps
-        rng = np.random.RandomState(2353425)
-        r = rng.rand(nin)
-        t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
-
-        # Plot a sine wave for the selected times
-        y = ampl * np.sin(w*t + phi) + offset
-
-        # Define the array of frequencies for which to compute the periodogram
-        f = np.linspace(0.01, 10., nout)
-
-        # Calculate Lomb-Scargle periodogram
-        pgram = lombscargle(t, y, f, precenter=True)
-        pgram2 = lombscargle(t, y - y.mean(), f, precenter=False)
-
-        # check if centering worked
-        assert_allclose(pgram, pgram2)
-
-        # do this again, but with floating_mean=True
-
-        # Calculate Lomb-Scargle periodogram
-        pgram = lombscargle(t, y, f, precenter=True, floating_mean=True)
-        pgram2 = lombscargle(t, y - y.mean(), f, precenter=False, floating_mean=True)
-
-        # check if centering worked
-        assert_allclose(pgram, pgram2)
-
     def test_normalize(self):
         # Test normalize option of Lomb-Scarge.
 
@@ -1407,7 +1366,6 @@ class TestLombscargle:
         weights = -np.ones(1)
         assert_raises(ValueError, lombscargle, t, y, f, weights=weights)
 
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
     def test_list_input(self):
         # Test that input can be passsed in as lists and with a numerical issue
         # https://github.com/scipy/scipy/issues/8787
@@ -1478,7 +1436,7 @@ class TestLombscargle:
         periods = np.linspace(400, 120, 1000)
         angular_freq = 2 * np.pi / periods
 
-        lombscargle(t, y, angular_freq, precenter=True, normalize=True)
+        lombscargle(t, y, angular_freq, normalize=True)
 
     def test_zero_freq(self):
         # Verify that function works when freqs includes 0
@@ -1527,84 +1485,6 @@ class TestLombscargle:
         freqs = [np.pi/2.0] * 2  # must have 2+ elements
 
         lombscargle(t, y, freqs)
-
-    @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-    def test_input_mutation(self):
-        # this tests for mutation of the input arrays
-        # https://github.com/scipy/scipy/issues/23474
-
-        # Input parameters
-        ampl = 2.
-        w = 1.
-        phi = 0.5 * np.pi
-        nin = 100
-        nout = 1000
-        p = 0.7  # Fraction of points to select
-
-        # Randomly select a fraction of an array with timesteps
-        rng = np.random.default_rng()
-        r = rng.random(nin)
-        t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
-
-        # Plot a sine wave for the selected times
-        y = ampl * np.sin(w*t + phi)
-
-        # Define the array of frequencies for which to compute the periodogram
-        f = np.linspace(0.01, 10., nout)
-
-        weights = np.ones_like(y)
-
-        # create original copies before passing
-        t_org = t.copy()
-        y_org = y.copy()
-        f_org = f.copy()
-        weights_org = weights.copy()
-
-        lombscargle(t, y, f, precenter=True, weights=weights)
-
-        # check all 4 array inputs
-        assert_array_equal(t, t_org)
-        assert_array_equal(y, y_org)
-        assert_array_equal(f, f_org)
-        assert_array_equal(weights, weights_org)
-
-    def test_precenter_deprecation(self):
-        # test that precenter deprecation warning is raised
-
-        # Input parameters
-        ampl = 2.
-        w = 1.
-        phi = 0.5 * np.pi
-        nin = 100
-        nout = 1000
-        p = 0.7  # Fraction of points to select
-        offset = 0.15  # Offset to be subtracted in pre-centering
-
-        # Randomly select a fraction of an array with timesteps
-        rng = np.random.default_rng()
-        r = rng.random(nin)
-        t = np.linspace(0.01*np.pi, 10.*np.pi, nin)[r >= p]
-
-        # Plot a sine wave for the selected times
-        y = ampl * np.sin(w*t + phi) + offset
-
-        # Define the array of frequencies for which to compute the periodogram
-        f = np.linspace(0.01, 10., nout)
-
-        # Calculate Lomb-Scargle periodogram
-        with pytest.deprecated_call(match="leave 'precenter' unspecified"):
-            lombscargle(t, y, f, precenter=True)
-        # Should warn for explicit `False` too
-        with pytest.deprecated_call(match="leave 'precenter' unspecified"):
-            lombscargle(t, y, f, precenter=False)
-            
-    @pytest.mark.filterwarnings(
-        "ignore:.*leave 'precenter' unspecified.*:DeprecationWarning"
-    )
-    def test_positional_args_deprecation(self):
-        with pytest.deprecated_call(match="use keyword arguments"):
-            one = np.asarray([1.0])
-            lombscargle(one, one, one, False)
 
 
 class TestSTFT:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow up to #24080
#### What does this implement/fix?
<!--Please explain your changes.-->
Due for removal in 1.19
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No ai