### PR TITLE
MAINT: ``stats._distn_infrastructure``: namespace pollution

### DIFF
--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3993,7 +3993,8 @@ for method_name in _remove_scale_methods:
     doc = FunctionDoc(method)
     doc['Parameters'] = [p for p in doc['Parameters'] if p.name != 'scale']
     doc = str(doc).split("\n", 1)[1].lstrip(" \n")  # remove signature
-    method.__doc__ = str(doc)
+    method.__doc__ = doc
+del method_name, method, doc  # pyrefly:ignore[unbound-name]
 
 
 def _expect(fun, lb, ub, x0, inc, maxcount=1000, tolerance=1e-10,


### PR DESCRIPTION
While working on getting scipy-stubs ready for 1.18, I noticed that stubtest wanted me to annotate three new module-level names in `stats._distn_infrastructure`. Those turned out to be namespace pollution, so this cleans them up after use.

Oh and I also removed a redundant `str()` conversion there, because Pyrefly showed a warning squiggly there.

If too much trouble, feel free to remove the backport candidate label. 

#### AI Generation Disclosure
No AI tools used
