### PR TITLE
CI: Increase the test timeout for an interpolate test in a Windows job.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,7 +95,7 @@ jobs:
         run: |
           # test runner parallel clashes with OpenBLAS multithreading
           $env:OPENBLAS_NUM_THREADS=1
-          spin test -j4 --mode full -- --durations=25 --timeout=60
+          spin test -j4 --mode full -- --durations=25 --timeout=600
 
   #############################################################################
   fast_spin_arm64:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,7 +95,10 @@ jobs:
         run: |
           # test runner parallel clashes with OpenBLAS multithreading
           $env:OPENBLAS_NUM_THREADS=1
-          spin test -j4 --mode full -- --durations=25 --timeout=600
+          # Avoid occasional anomalous long durations of a test in interpolate;
+          # see gh-25142.
+          $env:WINDOWS_CI_LONG_TIMEOUT=600
+          spin test -j4 --mode full -- --durations=25 --timeout=60
 
   #############################################################################
   fast_spin_arm64:

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1412,6 +1412,7 @@ class TestRectBivariateSpline:
         return spl(x, y)
 
     @pytest.mark.slow()
+    @pytest.mark.timeout(timeout=float(os.getenv("WINDOWS_CI_LONG_TIMEOUT", "60")))
     @pytest.mark.parametrize('shape', [(350, 850), (2000, 170)])
     @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
                                         (1, 7e-3, 1e-4),

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1,5 +1,6 @@
 # Created by Pearu Peterson, June 2003
 import itertools
+import os
 import sys
 import warnings
 


### PR DESCRIPTION
In the CI job `Windows tests / full, py3.12/npMin, spin` that is defined in `windows.yml`, a test timeout of 60s is specified.  Normally this is fine, but sometimes a few tests exceed that limit.  After a lot of test runs on my scipy fork, I got one run where the 25 slowest tests for this job were:

```
============================ slowest 25 durations =============================
238.67s call     build-install/Lib/site-packages/scipy/interpolate/tests/test_fitpack2.py::TestRectBivariateSpline::test_spline_large_2d[spl_apis1-s_tols1-shape1]
166.26s call     build-install/Lib/site-packages/scipy/interpolate/tests/test_fitpack2.py::TestRectBivariateSpline::test_spline_large_2d[spl_apis1-s_tols2-shape1]
29.27s call     build-install/Lib/site-packages/scipy/interpolate/tests/test_fitpack2.py::TestRectBivariateSpline::test_spline_large_2d[spl_apis1-s_tols1-shape0]
28.75s call     build-install/Lib/site-packages/scipy/linalg/tests/test_extending.py::test_cython
27.17s call     build-install/Lib/site-packages/scipy/interpolate/tests/test_fitpack2.py::TestRectBivariateSpline::test_spline_large_2d[spl_apis1-s_tols2-shape0]
16.77s call     build-install/Lib/site-packages/scipy/_lib/tests/test_import_cycles.py::test_public_modules_importable_2
16.51s call     build-install/Lib/site-packages/scipy/optimize/tests/test_extending.py::test_cython
15.01s call     build-install/Lib/site-packages/scipy/_lib/tests/test__util.py::TestTransitionToRNG::test_rng_deterministic[basinhopping-seed]
14.85s setup    build-install/Lib/site-packages/scipy/_lib/tests/test_warnings.py::test_warning_calls_filters
14.25s call     build-install/Lib/site-packages/scipy/special/tests/test_extending.py::test_cython
12.85s call     build-install/Lib/site-packages/scipy/stats/tests/test_continuous.py::TestDistributions::test_support_moments_sample[_LogUniform]
9.45s call     build-install/Lib/site-packages/scipy/stats/tests/test_multivariate.py::TestNormalInverseGamma::test_moments
9.19s call     build-install/Lib/site-packages/scipy/stats/tests/test_mgc.py::TestMGCStat::test_pvalue_literature
7.35s call     build-install/Lib/site-packages/scipy/_lib/tests/test__util.py::TestTransitionToRNG::test_rng_deterministic[differential_evolution-seed]
6.79s call     build-install/Lib/site-packages/scipy/optimize/tests/test__differential_evolution.py::TestDifferentialEvolutionSolver::test_L1
6.64s call     build-install/Lib/site-packages/scipy/optimize/tests/test__basinhopping.py::TestBasinHopping::test_all_nograd_minimizers[COBYLA]
6.15s call     build-install/Lib/site-packages/scipy/stats/tests/test_stats.py::TestPageTrendTest::test_accuracy2[542-0.9481266260876332-True-exact-data0]
6.08s call     build-install/Lib/site-packages/scipy/stats/tests/test_continuous.py::TestDistributions::test_support_moments_sample[StandardNormal]
5.85s call     build-install/Lib/site-packages/scipy/stats/tests/test_fit.py::TestFit::test_basic_fit_mle[zipfian]
5.73s call     build-install/Lib/site-packages/scipy/stats/tests/test_continuous.py::TestDistributions::test_support_moments_sample[Logistic]
5.50s call     build-install/Lib/site-packages/scipy/stats/tests/test_multivariate.py::TestMultivariateNormal::test_cdf_vs_cubature[3]
5.34s call     build-install/Lib/site-packages/scipy/optimize/tests/test_constraint_conversion.py::TestNewToOldCobyla::test_list_of_problems
5.32s call     build-install/Lib/site-packages/scipy/_lib/tests/test__util.py::TestTransitionToRNG::test_rng_deterministic[goodness_of_fit-random_state]
5.15s call     build-install/Lib/site-packages/scipy/special/tests/test_cython_special.py::test_cython_api[elliprj]
5.05s call     build-install/Lib/site-packages/scipy/optimize/tests/test_optimize.py::TestOptimizeSimple::test_minimize_callback_copies_array[fmin]

```
Usually those two `interpolate` tests at the top of the list finish in under 25s.

To allow for this occasional anomalous behavior, the timeout value is increased to 600 for the problematic test.

There might be some concern that this just hides a heisenbug lurking in the interpolation code.  After all, why is it just those tests in `interpolate` that occasionally take so much longer?  Comparing other tests from the above list to the results in recent PRs shows that most of the times differ by only a few percent.  For example, the above list shows that `optimize/tests/test__differential_evolution.py::TestDifferentialEvolutionSolver::test_L1` took 6.79s.  On another run that did not have the anomalously slow `interpolate` tests, that test took 8.50s.

This is a valid concern, and is why I haven't marked this PR as closing the relevant issue gh-25142.

#### Reference issue

See gh-25142.

#### AI Generation Disclosure

No AI tools used.