### PR TITLE
DOC: missing backtick + to double backtick

### DIFF
--- a/scipy/optimize/_lsq/least_squares.py
+++ b/scipy/optimize/_lsq/least_squares.py
@@ -500,7 +500,7 @@ def least_squares(
 
         The signature is ``callback(intermediate_result: OptimizeResult)``
 
-        `intermediate_result is a `scipy.optimize.OptimizeResult`
+        ``intermediate_result`` is a `scipy.optimize.OptimizeResult`
         which contains the intermediate results of the optimization at the
         current iteration.
 


### PR DESCRIPTION
There is nothing to interpret here, it mention a pseudo-code variable 2 lines before.

[skip ci] [ci skip]

#### Reference issue

No issues


#### AI Generation Disclosure

No AI tools used
