### PR TITLE
BUG: `stats`: `DunnettResult.__class_getitem__` dataclass field

### DIFF
--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -1,7 +1,6 @@
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from types import GenericAlias
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -53,9 +52,11 @@ class DunnettResult:
     _ci: ConfidenceInterval | None = field(default=None, repr=False)
     _ci_cl: DecimalNumber | None = field(default=None, repr=False)
 
-    # generic type compatibility with scipy-stubs
-    # pyrefly:ignore[bad-class-definition]
-    __class_getitem__: classmethod = classmethod(GenericAlias)
+    @classmethod
+    def __class_getitem__(cls, arg, /):
+        # generic type compatibility with scipy-stubs
+        from types import GenericAlias
+        return GenericAlias(cls, arg)
 
     def __str__(self):
         # Note: `__str__` prints the confidence intervals from the most


### PR DESCRIPTION
Apparently I messed up in #25000:

```
In [1]: from scipy.stats._multicomp import DunnettResult

In [2]: DunnettResult?
Init signature:
DunnettResult(
    statistic: numpy.ndarray,
    pvalue: numpy.ndarray,
    _alternative: Literal['two-sided', 'less', 'greater'],
    _rho: numpy.ndarray,
    _df: int,
    _std: float,
    _mean_samples: numpy.ndarray,
    _mean_control: numpy.ndarray,
    _n_samples: numpy.ndarray,
    _n_control: int,
    _rng: SeedType,
    _ci: scipy.stats._common.ConfidenceInterval | None = None,
    _ci_cl: DecimalNumber | None = None,
    __class_getitem__: classmethod = <bound method GenericAlias of <class 'scipy.stats._multicomp.DunnettResult'>>,
) -> None
```

The `__class_getitem__` was being treated as a dataclass field, not as a classmethod.

The (obvious) fix is to use an "actual" classmethod. I've also inlined the `types.GenericAlias` import, as a distraction from the fact that I messed up before :P.

---

Here's the "after":

```
In [1]: from scipy.stats._multicomp import DunnettResult

In [2]: DunnettResult[int]
Out[2]: scipy.stats._multicomp.DunnettResult[int]

In [3]: DunnettResult?
Init signature:
DunnettResult(
    statistic: numpy.ndarray,
    pvalue: numpy.ndarray,
    _alternative: Literal['two-sided', 'less', 'greater'],
    _rho: numpy.ndarray,
    _df: int,
    _std: float,
    _mean_samples: numpy.ndarray,
    _mean_control: numpy.ndarray,
    _n_samples: numpy.ndarray,
    _n_control: int,
    _rng: SeedType,
    _ci: scipy.stats._common.ConfidenceInterval | None = None,
    _ci_cl: DecimalNumber | None = None,
) -> None
```

#### AI Generation Disclosure
No AI tools used