### PR TITLE
BUG: ``stats``: fix new distribution ``lmoment`` method signatures

### DIFF
--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -5289,7 +5289,7 @@ class Mixture(_ProbabilityDistribution):
             out += moment * weight
         return out[()]
 
-    def lmoment(self, order=1, *, standardize=False, method=None):
+    def lmoment(self, order=1, *, standardize=True, method=None):
         message = "L-moments are not currently available for mixture distributions."
         raise NotImplementedError(message)
 

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -56,7 +56,8 @@ _NO_CACHE = "no_cache"
 #    shape parameters - e.g. t distribution with df = np.inf delegates to normal)
 #  Add array API support
 #  Investigate use `median` information throughout, e.g. to improve integration of
-#    CDF or to provide initial bracket for ICDF. (Only if `_median_formula` is provided.)
+#    CDF or to provide initial bracket for ICDF. (Only if `_median_formula` is 
+#    provided.)
 #  Document user tips for faster execution:
 #  - pass NumPy arrays
 #  - pass inputs of floating point type (not integers)

--- a/scipy/stats/_probability_distribution.py
+++ b/scipy/stats/_probability_distribution.py
@@ -341,7 +341,7 @@ class _ProbabilityDistribution(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def lmoment(self, order, kind, *, method):
+    def lmoment(self, order, *, standardize, method):
         r"""L-moment or L-moment ratio of positive integer order.
 
         The L-moment of order :math:`n` of a continuous random variable :math:`X` is:


### PR DESCRIPTION
The signature of the abstract `_ProbabilityDistribution.lmoment` method in `stats._probability_distribution` did not match the docstring and was incompatible with the signatures of its overrides in `stats._distribution_infrastructure`.
I noticed this while working on getting scipy-stubs ready for 1.18.0, because all type-checkers were complaining about incompatible overrides.

#### Additional information
No AI tools used
