### PR TITLE
DEP: sparse.diags/diags_array: change default dtype behavior

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -15,7 +15,6 @@ from warnings import warn
 import numpy as np
 
 from scipy._lib._util import check_random_state, rng_integers, _transition_to_rng
-from scipy._lib.deprecation import _NoValue
 from ._sputils import upcast, get_index_dtype, isscalarlike, isintlike
 
 from ._sparsetools import csr_hstack
@@ -316,7 +315,7 @@ def spdiags(data, diags, m=None, n=None, format=None):
     return dia_matrix((data, diags), shape=(m, n)).asformat(format)
 
 
-def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=_NoValue):
+def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=None):
     """
     Construct a sparse array from diagonals.
 
@@ -340,14 +339,6 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=_NoVa
     dtype : dtype, optional
         Data type of the array.  If `dtype` is None, the output
         data type is determined by the data type of the input diagonals.
-
-        Up until SciPy 1.19, the default behavior will be to return an array
-        with an inexact (floating point) data type.  In particular, integer
-        input will be converted to double precision floating point.  This
-        behavior is deprecated, and in SciPy 1.19, the default behavior
-        will be changed to return an array with the same data type as the
-        input diagonals.  To adopt this behavior before version 1.19, use
-        ``dtype=None``.
 
     Returns
     -------
@@ -430,22 +421,6 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=_NoVa
     # Determine data type, if omitted
     if dtype is None:
         dtype = np.result_type(*diagonals)
-    elif dtype is _NoValue:
-        # This is the old deprecated behavior that uses np.common_type().
-        # After the deprecation period, this elif branch can be removed,
-        # and the default for the `dtype` parameter changed back to `None`.
-        dtype = np.dtype(np.common_type(*diagonals))
-        future_dtype = np.result_type(*diagonals)
-        if (dtype != future_dtype):
-            warn(
-                f"Input has data type {future_dtype}, but the output has been cast "
-                f"to {dtype}.  In the future, the output data type will match the "
-                "input. To avoid this warning, set the `dtype` parameter to `None` "
-                "to have the output dtype match the input, or set it to the "
-                "desired output data type.",
-                FutureWarning,
-                skip_file_prefixes=(os.path.dirname(__file__),)
-            )
 
     # Construct data array
     m, n = shape
@@ -476,7 +451,7 @@ def diags_array(diagonals, /, *, offsets=0, shape=None, format=None, dtype=_NoVa
     return dia_array((data_arr, offsets), shape=(m, n)).asformat(format)
 
 
-def diags(diagonals, offsets=0, shape=None, format=None, dtype=_NoValue):
+def diags(diagonals, offsets=0, shape=None, format=None, dtype=None):
     """
     Construct a sparse matrix from diagonals.
 
@@ -506,14 +481,6 @@ def diags(diagonals, offsets=0, shape=None, format=None, dtype=_NoValue):
     dtype : dtype, optional
         Data type of the matrix.  If `dtype` is None, the output
         data type is determined by the data type of the input diagonals.
-
-        Up until SciPy 1.19, the default behavior will be to return a matrix
-        with an inexact (floating point) data type.  In particular, integer
-        input will be converted to double precision floating point.  This
-        behavior is deprecated, and in SciPy 1.19, the default behavior
-        will be changed to return a matrix with the same data type as the
-        input diagonals.  To adopt this behavior before version 1.19, use
-        `dtype=None`.
 
     Returns
     -------

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -227,8 +227,6 @@ class TestConstructUtils:
         for d, o, shape in cases:
             assert_raises(ValueError, construct.diags, d, offsets=o, shape=shape)
 
-        assert_raises(TypeError, construct.diags, [[None]], offsets=[0])
-
     def test_diags_vs_diag(self):
         # Check that
         #
@@ -923,25 +921,8 @@ def test_diags_array():
 def test_diags_int(func):
     d = [[3], [1, 2], [4]]
     offsets = [-1, 0, 1]
-    # Until the deprecation period is over, `dtype=None` must be given
-    # explicitly to avoid the warning and the cast to an inexact type
-    # in diags_array() (gh-23102).
-    arr = func(d, offsets=offsets, dtype=None)
+    arr = func(d, offsets=offsets)
     expected = np.array([[1, 4], [3, 2]])
-    assert_array_equal(arr.toarray(), expected, strict=True)
-
-
-@pytest.mark.parametrize('func', [construct.diags_array, construct.diags])
-def test_diags_int_to_float64(func):
-    d = [[3], [1, 2], [4]]
-    offsets = [-1, 0, 1]
-    # Until the deprecation period is over, diags and diag_array will cast
-    # integer inputs to float64 by default.  A warning will be generated
-    # that indicates this behavior is deprecated.
-    # See gh-23102.
-    with pytest.warns(FutureWarning, match="output has been cast to"):
-        arr = func(d, offsets=offsets)
-    expected = np.array([[1.0, 4.0], [3.0, 2.0]])
     assert_array_equal(arr.toarray(), expected, strict=True)
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
follow up to #23340
#### What does this implement/fix?
<!--Please explain your changes.-->
Removes the old deprecated dtype handling
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
