### PR TITLE
ENH: signal.firwin2: add JAX CPU support

### DIFF
--- a/scipy/signal/_fir_filter_design.py
+++ b/scipy/signal/_fir_filter_design.py
@@ -735,8 +735,8 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
         eps = xp.finfo(xp_default_dtype(xp)).eps * nyq
         for k in range(freq.shape[0] - 1):
             if freq[k] == freq[k + 1]:
-                freq[k] = freq[k] - eps
-                freq[k + 1] = freq[k + 1] + eps
+                freq = xpx.at(freq)[k].set(freq[k] - eps)
+                freq = xpx.at(freq)[k + 1].set(freq[k + 1] + eps)
         # Check if freq is strictly increasing after tweak
         d = freq[1:] - freq[:-1]
         if xp.any(d <= 0):
@@ -772,7 +772,7 @@ def firwin2(numtaps, freq, gain, *, nfreqs=None, window='hamming',
     out = out_full[:numtaps] * wind
 
     if ftype == 3:
-        out[xp_size(out) // 2] = 0.0
+        out = xpx.at(out)[xp_size(out) // 2].set(0.0)
 
     return out
 

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -231,7 +231,7 @@ capabilities_overrides = {
                               jax_jit=False, allow_dask_compute=True),
     "firwin2": xp_capabilities(cpu_only=True, exceptions=["cupy"],
                                jax_jit=False, allow_dask_compute=True,
-                               reason="firwin uses np.interp"),
+                               reason="firwin2 uses np.interp"),
     "fftconvolve": xp_capabilities(cpu_only=True,
                                    exceptions=["cupy", "jax.numpy", "torch"]),
     "freqs": xp_capabilities(cpu_only=True, exceptions=["cupy", "torch"],

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -395,7 +395,6 @@ class TestFirwin2:
             xp.asarray([1.0, 1.0, 1.0, 1.0 - width, 0.5, width]), decimal=5
         )
 
-    @skip_xp_backends("jax.numpy", reason="immutable arrays")
     def test02(self, xp):
         width = 0.04
         beta = 12.0
@@ -413,7 +412,6 @@ class TestFirwin2:
             xp.asarray([0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5
         )
 
-    @skip_xp_backends("jax.numpy", reason="immutable arrays")
     def test03(self, xp):
         width = 0.02
         ntaps, beta = kaiserord(120, width)
@@ -430,7 +428,6 @@ class TestFirwin2:
             xp.asarray([1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0]), decimal=5
         )
 
-    @skip_xp_backends("jax.numpy", reason="immutable arrays")
     def test04(self, xp):
         """Test firwin2 when window=None."""
         ntaps = 5
@@ -460,7 +457,6 @@ class TestFirwin2:
         freqs, response = map(xp.asarray, (freqs, response))
         assert_array_almost_equal(xp.abs(response), freqs / xp.pi, decimal=4)
 
-    @skip_xp_backends("jax.numpy", reason="immutable arrays")
     def test06(self, xp):
         """Test firwin2 for calculating Type III filters"""
         ntaps = 1501
@@ -493,7 +489,6 @@ class TestFirwin2:
         taps2 = firwin2(150, [0.0, 0.5, 0.5, 1.0], [1.0, 1.0, 0.0, 0.0])
         assert_array_almost_equal(taps1, taps2)
 
-    @skip_xp_backends("jax.numpy", reason="immutable arrays")
     def test_input_modyfication(self, xp):
         freq1 = xp.asarray([0.0, 0.5, 0.5, 1.0])
         freq2 = xp.asarray(freq1)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
@ev-br's [suggestion](https://github.com/scipy/scipy/pull/25131#issuecomment-4440677754) 

#### What does this implement/fix?
- Replaces in-place assignments with `xpx.at()`
- Removed skip tests
- Use `firwin2` instead of `firwin` as reason in `_support_alternative_backends.py`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
I asked Codex to check my changes and any remaining skipped tests.