### PR TITLE
TST: stats: fix TestLevyStable::test_{pdf/cdf}_nolan_samples under free threading

### DIFF
--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -5876,7 +5876,8 @@ class TestLevyStable:
         ]
     )
     def test_pdf_nolan_samples(
-            self, nolan_pdf_sample_data, pct_range, alpha_range, beta_range
+        self, nolan_pdf_sample_data, pct_range,
+        alpha_range, beta_range, levy_stable_lock
     ):
         """Test pdf values against Nolan's stablec.exe output"""
         data = nolan_pdf_sample_data
@@ -6027,20 +6028,21 @@ class TestLevyStable:
         # fmt: on
         for ix, (default_method, rtol,
                  filter_func) in enumerate(tests):
-            stats.levy_stable.pdf_default_method = default_method
             subdata = data[filter_func(data)
                            ] if filter_func is not None else data
             msg = "Density calculations experimental for FFT method"
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", msg, RuntimeWarning)
                 # occurs in FFT methods only
-                p = stats.levy_stable.pdf(
-                    subdata['x'],
-                    subdata['alpha'],
-                    subdata['beta'],
-                    scale=1,
-                    loc=0
-                )
+                with levy_stable_lock:
+                    stats.levy_stable.pdf_default_method = default_method
+                    p = stats.levy_stable.pdf(
+                        subdata['x'],
+                        subdata['alpha'],
+                        subdata['beta'],
+                        scale=1,
+                        loc=0
+                    )
                 with np.errstate(over="ignore"):
                     subdata2 = rec_append_fields(
                         subdata,

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6089,7 +6089,8 @@ class TestLevyStable:
         ]
     )
     def test_cdf_nolan_samples(
-            self, nolan_cdf_sample_data, pct_range, alpha_range, beta_range, levy_stable_lock
+        self, nolan_cdf_sample_data, pct_range,
+        alpha_range, beta_range, levy_stable_lock
     ):
         """ Test cdf values against Nolan's stablec.exe output."""
         data = nolan_cdf_sample_data

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -6089,7 +6089,7 @@ class TestLevyStable:
         ]
     )
     def test_cdf_nolan_samples(
-            self, nolan_cdf_sample_data, pct_range, alpha_range, beta_range
+            self, nolan_cdf_sample_data, pct_range, alpha_range, beta_range, levy_stable_lock
     ):
         """ Test cdf values against Nolan's stablec.exe output."""
         data = nolan_cdf_sample_data
@@ -6172,7 +6172,6 @@ class TestLevyStable:
         ]
         for ix, (default_method, rtol,
                  filter_func) in enumerate(tests):
-            stats.levy_stable.cdf_default_method = default_method
             subdata = data[filter_func(data)
                            ] if filter_func is not None else data
             with warnings.catch_warnings():
@@ -6181,13 +6180,15 @@ class TestLevyStable:
                     ('Cumulative density calculations experimental for FFT'
                      ' method. Use piecewise method instead.'),
                     RuntimeWarning)
-                p = stats.levy_stable.cdf(
-                    subdata['x'],
-                    subdata['alpha'],
-                    subdata['beta'],
-                    scale=1,
-                    loc=0
-                )
+                with levy_stable_lock:
+                    stats.levy_stable.cdf_default_method = default_method
+                    p = stats.levy_stable.cdf(
+                        subdata['x'],
+                        subdata['alpha'],
+                        subdata['beta'],
+                        scale=1,
+                        loc=0
+                    )
                 with np.errstate(over="ignore"):
                     subdata2 = rec_append_fields(
                         subdata,


### PR DESCRIPTION
#### Reference issue
N/A

#### What does this implement/fix?

The `scipy/stats/tests/test_distributions.py::TestLevyStable::test_cdf_nolan_samples[pct_range0-alpha_range0-beta_range0]` test can fail under free threading. See [failure log](https://github.com/scipy/scipy/actions/runs/26356069198/job/77582913036).

I reproduced this failure locally with this command. This typically reproduces within 2-3 iterations.

```
spin test -s stats -m full -- -k test_cdf_nolan_samples --parallel-threads 4 -v -x --forever
```



It uses the `stats.levy_stable.cdf_default_method` global, and changes it during the test. This global changes how the cdf is calculated. Therefore, take the levy_stable_lock, which is provided as a test fixture by existing code, and hold it while either changing cdf_default_method or calculating a cdf.

#### Additional information
N/A

#### AI Generation Disclosure

No AI tools used.