### PR TITLE
ENH: signal: enable JAX support for `signal.sosfilt` and `signal.sosfiltfilt`

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -4612,7 +4612,7 @@ def sosfilt_zi(sos):
     for section in range(n_sections):
         b = sos[section, :3]
         a = sos[section, 3:]
-        zi[section, ...] = scale * lfilter_zi(b, a)
+        zi = xpx.at(zi)[section, ...].set(scale * lfilter_zi(b, a))
         # If H(z) = B(z)/A(z) is this section's transfer function, then
         # b.sum()/a.sum() is H(1), the gain at omega=0.  That's the steady
         # state value of this section's step response.

--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -5156,8 +5156,10 @@ def sosfilt(sos, x, axis=-1, zi=None):
     x_shape, zi_shape = x.shape, zi.shape
     x = np.reshape(x, (-1, x.shape[-1]))
     x = np.array(x, dtype, order='C')  # make a copy, can modify in place
-    zi = np.ascontiguousarray(np.reshape(zi, (-1, n_sections, 2)))
-    sos = sos.astype(dtype, copy=False)
+    # _sosfilt requires writable, C-contiguous NumPy arrays.
+    zi = np.array(np.reshape(zi, (-1, n_sections, 2)), dtype=dtype,
+                  order='C', copy=True)
+    sos = np.array(sos, dtype=dtype, order='C', copy=True)
     _sosfilt(sos, x, zi)
     x = x.reshape(x_shape)
     x = np.moveaxis(x, -1, axis)

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -330,7 +330,7 @@ capabilities_overrides = {
     "sosfilt_zi": xp_capabilities(cpu_only=True, allow_dask_compute=True,
                                   jax_jit=False),
     "sosfiltfilt": xp_capabilities(
-        cpu_only=True, exceptions=["cupy"],
+        cpu_only=True, exceptions=["cupy"], jax_jit=False,
         skip_backends=[
             (
                 "dask.array",
@@ -338,7 +338,6 @@ capabilities_overrides = {
                 " which dask doesn't like"
             ),
             ("torch", "negative strides"),
-            ("jax.numpy", "sosfilt works in-place"),
         ],
     ),
     "sosfreqz": xp_capabilities(cpu_only=True, exceptions=["cupy", "torch"],

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -223,6 +223,8 @@ capabilities_overrides = {
     "ellipord": xp_capabilities(cpu_only=True, exceptions=["cupy"],
                                 jax_jit=False, allow_dask_compute=True,
                                 reason="scipy.special.ellipk"),
+    "filtfilt": xp_capabilities(cpu_only=True, exceptions=["cupy"],
+                                allow_dask_compute=True, jax_jit=False),
     "findfreqs": xp_capabilities(cpu_only=True, exceptions=["cupy", "torch"],
                                  jax_jit=False, allow_dask_compute=True),
     "firls": xp_capabilities(cpu_only=True, allow_dask_compute=True, jax_jit=False,

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2885,43 +2885,38 @@ class TestFiltFilt:
         )
         xp_assert_equal(y0, xp.asarray(np.swapaxes(y2, 0, 2)))
 
-    @skip_xp_backends(np_only=True,
-                      reason='python scalars in array_namespace are np-only')
-    def test_acoeff(self, xp):
+    def test_acoeff(self):  # python scalars in array_namespace are np-only
         if self.filtfilt_kind != 'tf':
             return  # only necessary for TF
         # test for 'a' coefficient as single number
         out = signal.filtfilt(
-            xp.asarray([.5, .5]), 1, xp.arange(10, dtype=xp.float64)
+            np.asarray([.5, .5]), 1, np.arange(10, dtype=np.float64)
         )
-        xp_assert_close(out, xp.arange(10, dtype=xp.float64), rtol=1e-14, atol=1e-14)
+        xp_assert_close(out, np.arange(10, dtype=np.float64), rtol=1e-14, atol=1e-14)
 
-    @skip_xp_backends(np_only=True, reason='_filtfilt_gust is np-only')
-    def test_gust_simple(self, xp):
+    def test_gust_simple(self):  # _filtfilt_gust is np-only
         if self.filtfilt_kind != 'tf':
             pytest.skip('gust only implemented for TF systems')
         # The input array has length 2.  The exact solution for this case
         # was computed "by hand".
-        x = xp.asarray([1.0, 2.0])
-        b = xp.asarray([0.5])
-        a = xp.asarray([1.0, -0.5])
+        x = np.asarray([1.0, 2.0])
+        b = np.asarray([0.5])
+        a = np.asarray([1.0, -0.5])
         y, z1, z2 = _filtfilt_gust(b, a, x)
         xp_assert_close(z1[0], 0.3*x[0] + 0.2*x[1])
         xp_assert_close(z2[0], 0.2*x[0] + 0.3*x[1])
         xp_assert_close(y,
-                        xp.asarray([z1[0] + 0.25*z2[0] + 0.25*x[0] + 0.125*x[1],
+                        np.asarray([z1[0] + 0.25*z2[0] + 0.25*x[0] + 0.125*x[1],
                                     0.25*z1[0] + z2[0] + 0.125*x[0] + 0.25*x[1]])
         )
 
-    @skip_xp_backends(np_only=True,
-                      reason='python scalars in array_namespace are np-only')
-    def test_gust_scalars(self, xp):
+    def test_gust_scalars(self):  # python scalars in array_namespace are np-only
         if self.filtfilt_kind != 'tf':
             pytest.skip('gust only implemented for TF systems')
         # The filter coefficients are both scalars, so the filter simply
         # multiplies its input by b/a.  When it is used in filtfilt, the
         # factor is (b/a)**2.
-        x = xp.arange(12)
+        x = np.arange(12)
         b = 3.0
         a = 2.0
         y = filtfilt(b, a, x, method="gust")

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -4398,12 +4398,14 @@ class TestSOSFilt:
         sos = tf2sos(bb, aa)
         sos = xp.asarray(sos)   # XXX
         y = sosfilt(sos, x, axis=0)
-        assert_array_almost_equal(y_r2_a0, y)
+        # JAX complex64 needs slightly relaxed tolerance here.
+        dec = {'decimal': 5} if dt == xp.complex64 and is_jax(xp) else {}
+        assert_array_almost_equal(y_r2_a0, y, **dec)
 
         sos = tf2sos(bb, aa)
         sos = xp.asarray(sos)   # XXX
         y = sosfilt(sos, x, axis=1)
-        assert_array_almost_equal(y_r2_a1, y)
+        assert_array_almost_equal(y_r2_a1, y, **dec)
 
     def test_rank3(self, dt, xp):
         dt = getattr(xp, dt)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2812,10 +2812,7 @@ class TestLFilterZI:
         assert signal.lfilter_zi(b, a).dtype == dtype
 
 
-@make_xp_test_case(filtfilt, sosfiltfilt)
-class TestFiltFilt:
-    filtfilt_kind = 'tf'
-
+class _TestFiltFilt:
     def filtfilt(self, zpk, x, axis=-1, padtype='odd', padlen=None,
                  method='pad', irlen=None, xp=None):
         if self.filtfilt_kind == 'tf':
@@ -2885,18 +2882,23 @@ class TestFiltFilt:
         )
         xp_assert_equal(y0, xp.asarray(np.swapaxes(y2, 0, 2)))
 
-    def test_acoeff(self):  # python scalars in array_namespace are np-only
-        if self.filtfilt_kind != 'tf':
-            return  # only necessary for TF
-        # test for 'a' coefficient as single number
-        out = signal.filtfilt(
-            np.asarray([.5, .5]), 1, np.arange(10, dtype=np.float64)
-        )
-        xp_assert_close(out, np.arange(10, dtype=np.float64), rtol=1e-14, atol=1e-14)
+
+@make_xp_test_case(filtfilt)
+class TestFiltFilt(_TestFiltFilt):
+    filtfilt_kind = 'tf'
+
+    def test_gust_scalars(self):  # python scalars in array_namespace are np-only
+        # The filter coefficients are both scalars, so the filter simply
+        # multiplies its input by b/a.  When it is used in filtfilt, the
+        # factor is (b/a)**2.
+        x = np.arange(12)
+        b = 3.0
+        a = 2.0
+        y = filtfilt(b, a, x, method="gust")
+        expected = (b/a)**2 * x
+        xp_assert_close(y, expected)
 
     def test_gust_simple(self):  # _filtfilt_gust is np-only
-        if self.filtfilt_kind != 'tf':
-            pytest.skip('gust only implemented for TF systems')
         # The input array has length 2.  The exact solution for this case
         # was computed "by hand".
         x = np.asarray([1.0, 2.0])
@@ -2910,36 +2912,30 @@ class TestFiltFilt:
                                     0.25*z1[0] + z2[0] + 0.125*x[0] + 0.25*x[1]])
         )
 
-    def test_gust_scalars(self):  # python scalars in array_namespace are np-only
-        if self.filtfilt_kind != 'tf':
-            pytest.skip('gust only implemented for TF systems')
-        # The filter coefficients are both scalars, so the filter simply
-        # multiplies its input by b/a.  When it is used in filtfilt, the
-        # factor is (b/a)**2.
-        x = np.arange(12)
-        b = 3.0
-        a = 2.0
-        y = filtfilt(b, a, x, method="gust")
-        expected = (b/a)**2 * x
-        xp_assert_close(y, expected)
+    def test_acoeff(self):  # python scalars in array_namespace are np-only
+        # test for 'a' coefficient as single number
+        out = signal.filtfilt(
+            np.asarray([.5, .5]), 1, np.arange(10, dtype=np.float64)
+        )
+        xp_assert_close(out, np.arange(10, dtype=np.float64), rtol=1e-14, atol=1e-14)
 
 
-@make_xp_test_case(sosfiltfilt, filtfilt)
-class TestSOSFiltFilt(TestFiltFilt):
+@make_xp_test_case(sosfiltfilt)
+class TestSOSFiltFilt(_TestFiltFilt):
     filtfilt_kind = 'sos'
 
     @skip_xp_backends('torch', reason='negative strides')
     def test_equivalence(self, xp):
         """Test equivalence between sosfiltfilt and filtfilt"""
-        x = np.random.RandomState(0).randn(1000)
-        x = xp.asarray(x)
+        x_np = np.random.RandomState(0).randn(1000)
+        x = xp.asarray(x_np)
         for order in range(1, 6):
             zpk = signal.butter(order, 0.35, output='zpk')
             b, a = zpk2tf(*zpk)
             sos = zpk2sos(*zpk)
 
-            b, a, sos = map(xp.asarray, (b, a, sos))
-            y = filtfilt(b, a, x)
+            y = filtfilt(b, a, x_np)
+            b, a, sos, y = map(xp.asarray, (b, a, sos, y))
             y_sos = sosfiltfilt(sos, x)
             xp_assert_close(y, y_sos, atol=1e-12, err_msg=f'order={order}')
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -4552,7 +4552,7 @@ class TestSOSFilt:
         zi = xp.empty((4, 3, 3, 2))  # Correct shape is (4, 3, 2, 3)
         with pytest.raises(ValueError, match='should be all ones'):
             sosfilt(sos, x, zi=zi, axis=1)
-        sos[:, 3] = 1.
+        sos = xpx.at(sos)[:, 3].set(1.)
         with pytest.raises(ValueError, match='Invalid zi shape'):
             sosfilt(sos, x, zi=zi, axis=1)
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2887,11 +2887,11 @@ class _TestFiltFilt:
 class TestFiltFilt(_TestFiltFilt):
     filtfilt_kind = 'tf'
 
-    def test_gust_scalars(self):  # python scalars in array_namespace are np-only
+    def test_gust_scalars(self, xp):
         # The filter coefficients are both scalars, so the filter simply
         # multiplies its input by b/a.  When it is used in filtfilt, the
         # factor is (b/a)**2.
-        x = np.arange(12)
+        x = xp.arange(12, dtype=xp.float64)
         b = 3.0
         a = 2.0
         y = filtfilt(b, a, x, method="gust")
@@ -2912,12 +2912,12 @@ class TestFiltFilt(_TestFiltFilt):
                                     0.25*z1[0] + z2[0] + 0.125*x[0] + 0.25*x[1]])
         )
 
-    def test_acoeff(self):  # python scalars in array_namespace are np-only
+    def test_acoeff(self, xp):
         # test for 'a' coefficient as single number
         out = signal.filtfilt(
-            np.asarray([.5, .5]), 1, np.arange(10, dtype=np.float64)
+            xp.asarray([.5, .5]), 1, xp.arange(10, dtype=xp.float64)
         )
-        xp_assert_close(out, np.arange(10, dtype=np.float64), rtol=1e-14, atol=1e-14)
+        xp_assert_close(out, xp.arange(10, dtype=xp.float64), rtol=1e-14, atol=1e-14)
 
 
 @make_xp_test_case(sosfiltfilt)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -23,7 +23,9 @@ from scipy.signal import (
     sosfilt_zi, tf2zpk, BadCoefficients, detrend, unique_roots, residue,
     residuez)
 from scipy.signal.windows import hann
-from scipy.signal._signaltools import _filtfilt_gust, _compute_factors, _group_poles
+from scipy.signal._signaltools import (
+    _filtfilt_gust, _compute_factors, _group_poles, filtfilt as _filtfilt
+)
 from scipy.signal._upfirdn import _upfirdn_modes
 from scipy._lib import _testutils
 import scipy._external.array_api_extra as xpx
@@ -2821,7 +2823,7 @@ class TestFiltFilt:
         if self.filtfilt_kind == 'tf':
             b, a = zpk2tf(*zpk)
             b, a = xp.asarray(b), xp.asarray(a)
-            return filtfilt(b, a, x, axis, padtype, padlen, method, irlen)
+            return _filtfilt(b, a, x, axis, padtype, padlen, method, irlen)
         elif self.filtfilt_kind == 'sos':
             sos = zpk2sos(*zpk)
             sos = xp.asarray(sos)
@@ -2954,7 +2956,7 @@ class TestSOSFiltFilt(TestFiltFilt):
             sos = zpk2sos(*zpk)
 
             b, a, sos = map(xp.asarray, (b, a, sos))
-            y = filtfilt(b, a, x)
+            y = _filtfilt(b, a, x)
             y_sos = sosfiltfilt(sos, x)
             xp_assert_close(y, y_sos, atol=1e-12, err_msg=f'order={order}')
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2831,9 +2831,6 @@ class TestFiltFilt:
 
     @skip_xp_backends('torch', reason='negative strides')
     def test_basic(self, xp):
-        if is_jax(xp) and self.filtfilt_kind == 'sos':
-            pytest.skip(reason='sosfilt works in-place')
-
         zpk = tf2zpk(xp.asarray([1., 2, 3]), xp.asarray([1., 2, 3]))
         out = self.filtfilt(zpk, xp.arange(12), xp=xp)
         atol= 4e-9 if is_cupy(xp) else 5.28e-11
@@ -2841,9 +2838,6 @@ class TestFiltFilt:
 
     @skip_xp_backends('torch', reason='negative strides')
     def test_sine(self, xp):
-        if is_jax(xp) and self.filtfilt_kind == 'sos':
-            pytest.skip(reason='sosfilt works in-place')
-
         rate = 2000
         t = xp.linspace(0, 1.0, rate + 1)
         # A signal with low frequency and a high frequency.
@@ -2879,9 +2873,6 @@ class TestFiltFilt:
 
     @skip_xp_backends('torch', reason='negative strides')
     def test_axis(self, xp):
-        if is_jax(xp) and self.filtfilt_kind == 'sos':
-            pytest.skip(reason='sosfilt works in-place')
-
         # Test the 'axis' keyword on a 3D array.
         x = np.arange(10.0 * 11.0 * 12.0).reshape(10, 11, 12)
         x = xp.asarray(x)
@@ -2944,7 +2935,6 @@ class TestFiltFilt:
 class TestSOSFiltFilt(TestFiltFilt):
     filtfilt_kind = 'sos'
 
-    @skip_xp_backends('jax.numpy', reason='sosfilt works in-place')
     @skip_xp_backends('torch', reason='negative strides')
     def test_equivalence(self, xp):
         """Test equivalence between sosfiltfilt and filtfilt"""
@@ -4542,7 +4532,6 @@ class TestSOSFilt:
         xp_assert_close(y, y_tf, rtol=1e-10, atol=1e-13)
 
     @skip_xp_backends('torch', reason='issues a RuntimeWarning')
-    @skip_xp_backends('jax.numpy', reason='item assignment')
     def test_bad_zi_shape(self, dt, xp):
         dt = getattr(xp, dt)
         # The shape of zi is checked before using any values in the

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -23,9 +23,7 @@ from scipy.signal import (
     sosfilt_zi, tf2zpk, BadCoefficients, detrend, unique_roots, residue,
     residuez)
 from scipy.signal.windows import hann
-from scipy.signal._signaltools import (
-    _filtfilt_gust, _compute_factors, _group_poles, filtfilt as _filtfilt
-)
+from scipy.signal._signaltools import _filtfilt_gust, _compute_factors, _group_poles
 from scipy.signal._upfirdn import _upfirdn_modes
 from scipy._lib import _testutils
 import scipy._external.array_api_extra as xpx
@@ -2823,7 +2821,7 @@ class TestFiltFilt:
         if self.filtfilt_kind == 'tf':
             b, a = zpk2tf(*zpk)
             b, a = xp.asarray(b), xp.asarray(a)
-            return _filtfilt(b, a, x, axis, padtype, padlen, method, irlen)
+            return filtfilt(b, a, x, axis, padtype, padlen, method, irlen)
         elif self.filtfilt_kind == 'sos':
             sos = zpk2sos(*zpk)
             sos = xp.asarray(sos)
@@ -2946,7 +2944,7 @@ class TestSOSFiltFilt(TestFiltFilt):
             sos = zpk2sos(*zpk)
 
             b, a, sos = map(xp.asarray, (b, a, sos))
-            y = _filtfilt(b, a, x)
+            y = filtfilt(b, a, x)
             y_sos = sosfiltfilt(sos, x)
             xp_assert_close(y, y_sos, atol=1e-12, err_msg=f'order={order}')
 

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -4346,7 +4346,6 @@ class TestVectorstrength:
 class TestSOSFilt:
 
     # The test_rank* tests are pulled from _TestLinearFilter
-    @skip_xp_backends('jax.numpy', reason='buffer array is read-only')
     def test_rank1(self, dt, xp):
         dt = getattr(xp, dt)
         x = xp.linspace(0, 5, 6, dtype=dt)
@@ -4379,7 +4378,6 @@ class TestSOSFilt:
         y = sosfilt(sos, x)
         xp_assert_close(y, xp.asarray([1.0, 2, 2, 2, 2, 2, 2, 2]))
 
-    @skip_xp_backends('jax.numpy', reason='buffer array is read-only')
     def test_rank2(self, dt, xp):
         dt = getattr(xp, dt)
         shape = (4, 3)
@@ -4407,7 +4405,6 @@ class TestSOSFilt:
         y = sosfilt(sos, x, axis=1)
         assert_array_almost_equal(y_r2_a1, y)
 
-    @skip_xp_backends('jax.numpy', reason='buffer array is read-only')
     def test_rank3(self, dt, xp):
         dt = getattr(xp, dt)
         shape = (4, 3, 2)
@@ -4438,7 +4435,6 @@ class TestSOSFilt:
         a, b, sos = map(xp.asarray, (a, b, sos))
         return a, b, sos
 
-    @skip_xp_backends('jax.numpy', reason='item assignment')
     @make_xp_test_case(sosfilt_zi)
     def test_initial_conditions(self, dt, xp):
         a, b, sos = self._get_ab_sos(xp)
@@ -4465,7 +4461,6 @@ class TestSOSFilt:
         xp_assert_close(y, xp.ones(8), check_dtype=False)
         xp_assert_close(zf, zi, check_dtype=False)
 
-    @skip_xp_backends('jax.numpy', reason='item assignment')
     @skip_xp_backends('array_api_strict', reason='fancy indexing not supported')
     @make_xp_test_case(sosfilt_zi)
     def test_initial_conditions_2(self, dt, xp):
@@ -4490,7 +4485,6 @@ class TestSOSFilt:
         xp_assert_close(y[0, 0], xp.ones(8), check_dtype=False)
         xp_assert_close(zf[:, 0, 0, :], zi, check_dtype=False)
 
-    @skip_xp_backends('jax.numpy', reason='item assignment')
     @make_xp_test_case(sosfilt_zi)
     def test_initial_conditions_3d_axis1(self, dt, xp):
         # Test the use of zi when sosfilt is applied to axis 1 of a 3-d input.
@@ -4558,7 +4552,6 @@ class TestSOSFilt:
         with pytest.raises(ValueError, match='Invalid zi shape'):
             sosfilt(sos, x, zi=zi, axis=1)
 
-    @skip_xp_backends('jax.numpy', reason='item assignment')
     @make_xp_test_case(sosfilt_zi)
     def test_sosfilt_zi(self, dt, xp):
         dt = getattr(xp, dt)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
@ev-br's [suggestion](https://github.com/scipy/scipy/pull/25131#issuecomment-4440677754) 

#### What does this implement/fix?
- Enable JAX eager-mode tests for sosfilt and sosfiltfilt by removing stale skips.
- Mark sosfiltfilt as jax_jit=False because it uses NumPy validation internally.
- ~~Update tests to avoid JAX in-place mutation and public filtfilt auto-jit wrapping in reference paths.~~
- Add `jax_jit=False` for `signal.filtfilt`

#### Additional information
<!--Any additional information you think is important.-->

~~I am not 100% convinced with  importing `filtfilt as _filtfilt`. This is done so the tests can use the unwrapped implementation as a reference, avoiding the public array API/JAX auto-jit wrapper that fails on filtfilt’s internal `np.asarray` validation. Let me know if there is a better way instead of simply skipping the tests for JAX.~~

`signal.filtfilt` does not seem JAX-JIT compatible. For example: https://github.com/scipy/scipy/blob/e36eb4ec4a2b19714bd74f3d950acf2a5ac7331d/scipy/signal/_signaltools.py#L4963
was giving me some `TracerArrayConversionError` errors. The same seems to apply for `lfilter, lfilter_zi, sosfilt, sosfiltfilt` have already `jax_jit=False`.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Codex helped me with the contiguous arrays fix and checked my code. 