### PR TITLE
ENH: signal: Add JAX support for `signal.resample`

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3003,11 +3003,11 @@ def envelope(z, bp_in: tuple[int | None, int | None] = (1, None), *,
     else:  # avoid calculating negative frequency bins for real signals:
         dt = sp_fft.rfft(z[..., :1]).dtype
         Z = xp.zeros_like(z, dtype=dt)
-        Z[..., :n//2 + 1] = sp_fft.rfft(z)
+        Z = xpx.at(Z)[..., :n//2 + 1].set(sp_fft.rfft(z))
         if bp.start > 0:  # make signal analytic within bp_in band:
-            Z[..., bp] *= 2
+            Z = xpx.at(Z)[..., bp].multiply(2)
         elif bp.stop > 0:
-            Z[..., 1:bp.stop] *= 2
+            Z = xpx.at(Z)[..., 1:bp.stop].multiply(2)
     if not (bp.start <= 0 < bp.stop):  # envelope is invariant to freq. shifts.
         z_bb = sp_fft.ifft(Z[..., bp], n=n_out) * fak  # baseband signal
     else:
@@ -3021,20 +3021,22 @@ def envelope(z, bp_in: tuple[int | None, int | None] = (1, None), *,
     if residual is None:
         return z_env
     if not (bp.start <= 0 < bp.stop):
-        Z[..., bp] = 0
+        Z = xpx.at(Z)[..., bp].set(0)
     else:
-        Z[..., :bp.stop], Z[..., bp.start:] = 0, 0
+        Z = xpx.at(Z)[..., :bp.stop].set(0)
+        Z = xpx.at(Z)[..., bp.start:].set(0)
     if residual == 'lowpass':
         if bp.stop > 0:
-            Z[..., bp.stop:(n+1) // 2] = 0
+            Z = xpx.at(Z)[..., bp.stop:(n+1) // 2].set(0)
         else:
-            Z[..., bp.start:], Z[..., 0:(n + 1) // 2] = 0, 0
+            Z = xpx.at(Z)[..., bp.start:].set(0)
+            Z = xpx.at(Z)[..., 0:(n + 1) // 2].set(0)
 
     if xp.isdtype(z.dtype, 'complex floating'):  # resample accounts for unpaired bins:
         z_res = resample(Z, n_out, axis=-1, domain='freq')  # ifft() with corrections
     else:  # account for unpaired bin at m//2 before doing irfft():
         if n_out != n and (m := min(n, n_out)) % 2 == 0:
-            Z[..., m//2] *= 2 if n_out < n else 0.5
+            Z = xpx.at(Z)[..., m//2].set(Z[..., m//2] * (2 if n_out < n else 0.5))
         z_res = fak * sp_fft.irfft(Z, n=n_out)
     return xp.stack((z_env, xp.moveaxis(z_res, -1, axis)), axis=0)
 
@@ -3876,27 +3878,27 @@ def resample(x, num, t=None, axis=0, window=None, domain='time'):
         X = sp_fft.rfft(x)
         if W is not None:  # fold window, i.e., W1[l] = (W[l] + W[-l]) / 2 for l > 0
             n_X = X.shape[-1]
-            W[1:n_X] += xp.flip(W[-n_X+1:])  #W[:-n_X:-1]
-            W[1:n_X] /= 2
-            X *= W[:n_X]  # apply window
+            W = xpx.at(W)[1:n_X].add(xp.flip(W[-n_X+1:]))  #W[:-n_X:-1]
+            W = xpx.at(W)[1:n_X].multiply(0.5)
+            X = X * W[:n_X]  # apply window
         X = X[..., :m2]  # extract relevant data
         if m % 2 == 0 and num != n_x:  # Account for unpaired bin at m//2:
-            X[..., m//2] *= 2 if num < n_x else 0.5
+            X = xpx.at(X)[..., m//2].multiply(2 if num < n_x else 0.5)
         x_r = sp_fft.irfft(X / s_fac, n=num, overwrite_x=True)
     else:  # use standard two-sided FFT:
         X = sp_fft.fft(x) if domain == 'time' else x
         if W is not None:
             X = X * W  # writing X *= W could modify parameter x
         Y = xp.zeros(X.shape[:-1] + (num,), dtype=X.dtype)
-        Y[..., :m2] = X[..., :m2]  # copy part up to Nyquist frequency
+        Y = xpx.at(Y)[..., :m2].set(X[..., :m2])  # copy up to Nyquist
         if m2 < m:  # == m > 2
-            Y[..., m2-m:] = X[..., m2-m:]  # copy negative frequency part
+            Y = xpx.at(Y)[..., m2-m:].set(X[..., m2-m:])  # copy negative frequencies
         if m % 2 == 0:  # Account for unpaired bin at m//2:
             if num < n_x:  # down-sampling: unite bin pair into one unpaired bin
-                Y[..., -m//2] += X[..., -m//2]
+                Y = xpx.at(Y)[..., -m//2].add(X[..., -m//2])
             elif n_x < num:  # up-sampling: split unpaired bin into bin pair
-                Y[..., m//2] /= 2
-                Y[..., num-m//2] = Y[..., m//2]
+                Y = xpx.at(Y)[..., m//2].multiply(0.5)
+                Y = xpx.at(Y)[..., num-m//2].set(Y[..., m//2])
         x_r = sp_fft.ifft(Y / s_fac, n=num, overwrite_x=True)
 
     if x_r.ndim > 1:  # moving active axis back to original position:

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -312,7 +312,7 @@ capabilities_overrides = {
     "qspline2d": xp_capabilities(np_only=True, exceptions=["cupy"]),
     "remez": xp_capabilities(cpu_only=True, allow_dask_compute=True, jax_jit=False),
     "resample": xp_capabilities(
-        cpu_only=True, exceptions=["cupy"],
+        cpu_only=True, exceptions=["cupy", "jax.numpy"],
         skip_backends=[
             ("dask.array", "XXX something in dask"),
         ]

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -312,7 +312,7 @@ capabilities_overrides = {
     "qspline2d": xp_capabilities(np_only=True, exceptions=["cupy"]),
     "remez": xp_capabilities(cpu_only=True, allow_dask_compute=True, jax_jit=False),
     "resample": xp_capabilities(
-        cpu_only=True, exceptions=["cupy"], jax_jit=False,
+        cpu_only=True, exceptions=["cupy"],
         skip_backends=[
             ("dask.array", "XXX something in dask"),
         ]

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -311,12 +311,6 @@ capabilities_overrides = {
                                       jax_jit=False, allow_dask_compute=True),
     "qspline2d": xp_capabilities(np_only=True, exceptions=["cupy"]),
     "remez": xp_capabilities(cpu_only=True, allow_dask_compute=True, jax_jit=False),
-    "resample": xp_capabilities(
-        cpu_only=True, exceptions=["cupy", "jax.numpy"],
-        skip_backends=[
-            ("dask.array", "XXX something in dask"),
-        ]
-    ),
     "resample_poly": xp_capabilities(
         cpu_only=True, exceptions=["cupy"],
         jax_jit=False, skip_backends=[("dask.array", "XXX something in dask")],

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -312,10 +312,9 @@ capabilities_overrides = {
     "qspline2d": xp_capabilities(np_only=True, exceptions=["cupy"]),
     "remez": xp_capabilities(cpu_only=True, allow_dask_compute=True, jax_jit=False),
     "resample": xp_capabilities(
-        cpu_only=True, exceptions=["cupy"],
+        cpu_only=True, exceptions=["cupy"], jax_jit=False,
         skip_backends=[
             ("dask.array", "XXX something in dask"),
-            ("jax.numpy", "XXX: immutable arrays"),
         ]
     ),
     "resample_poly": xp_capabilities(

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3547,7 +3547,6 @@ class TestEnvelope:
             # noinspection PyTypeChecker
             envelope(xp.ones(4), residual='undefined')
 
-    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     def test_envelope_verify_parameters(self, xp):
         """Ensure that the various parametrizations produce compatible results. """
         dt_r = xp_default_dtype(xp)
@@ -3596,7 +3595,7 @@ class TestEnvelope:
 
         # compare complex analytic signal to real version
         Z_a = xp.asarray(Z, copy=True)
-        Z_a[1:] *= 2
+        Z_a = xpx.at(Z_a)[1:].multiply(2)
         z_a = sp_fft.ifft(Z_a, n=n)  # analytic signal of Z
         self.assert_close(xp.real(z_a), z,
                           msg="Reference analytic signal error", xp=xp)
@@ -3606,7 +3605,6 @@ class TestEnvelope:
         self.assert_close(sp_fft.fft(zr_a), xp.asarray(Zr_a, dtype=dt_c),
                           msg="Complex residual calculation error", xp=xp)
 
-    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     @pytest.mark.parametrize(
         "               Z,        bp_in,     Ze2_desired,      Zr_desired",
         [([1, 0, 2, 2, 0],    (1, None), [4, 2, 0, 0, 0], [1, 0, 0, 0, 0]),
@@ -3643,13 +3641,12 @@ class TestEnvelope:
                           msg="Residual calculation error (residual='all')", xp=xp)
 
         if bp_in[1] is not None:
-            Zr_desired[bp_in[1]:] = 0
+            Zr_desired = xpx.at(Zr_desired)[bp_in[1]:].set(0)
         self.assert_close(Ze2_lp, Ze2_desired,
                           msg="Envelope calculation error (residual='lowpass')", xp=xp)
         self.assert_close(Zr_lp, Zr_desired,
                           msg="Residual calculation error (residual='lowpass')", xp=xp)
 
-    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     @pytest.mark.parametrize(
         "               Z,        bp_in,         Ze2_desired,         Zr_desired",
         [([0, 5, 0, 5, 0], (None, None),    [5, 0, 10, 0, 5],    [0, 0, 0, 0, 0]),
@@ -3675,7 +3672,6 @@ class TestEnvelope:
         self.assert_close(Zr, Zr_desired,
                           msg="Residual calculation error", xp=xp)
 
-    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     def test_envelope_verify_axis_parameter(self, xp):
         """Test for multi-channel envelope calculations. """
         dt_r = xp_default_dtype(xp)
@@ -3699,7 +3695,6 @@ class TestEnvelope:
             Yr, Zr_desired, msg="Transposed 2d residual calc. error", xp=xp
         )
 
-    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     def test_envelope_verify_axis_parameter_complex(self, xp):
         """Test for multi-channel envelope calculations with complex values. """
         dt_r = xp_default_dtype(xp)
@@ -3722,7 +3717,6 @@ class TestEnvelope:
         )
         self.assert_close(Yr, Zr_des,  msg="Transposed 2d residual calc. error", xp=xp)
 
-    @skip_xp_backends("jax.numpy", reason="XXX: immutable arrays")
     @pytest.mark.parametrize('X', [[4, 0, 0, 1, 2], [4, 0, 0, 2, 1, 2]])
     def test_compare_envelope_hilbert(self, X, xp):
         """Compare output of `envelope()` and `hilbert()`. """


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
@ev-br's [suggestion](https://github.com/scipy/scipy/pull/25131#issuecomment-4440677754) 

#### What does this implement/fix?
- Replace resample in-place array updates with `xpx.at`
- Enable eager JAX support for `resample`. Keep it `jax_jit=False`.
- Remove JAX skips in tests.

#### Additional information
I wanted to update `signal.envelope` but then saw that `signal.resample` is linked.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex which methods to tackle next for removing the skipped JAX tests.