### PR TITLE
BUG: interpolate: fix incorrect variable passed to Py_DECREF.

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1970,7 +1970,7 @@ fitpack_spgrid(PyObject* Py_UNUSED(dummy), PyObject *args)
     if (ap_tu == NULL) {
         Py_DECREF(ap_tu_full);
         Py_DECREF(ap_tv_full);
-        Py_DECREF(ap_c);
+        Py_DECREF(ap_c_full);
         return NULL;
     }
     memcpy(PyArray_DATA(ap_tu), PyArray_DATA(ap_tu_full), (size_t)nu * sizeof(double));


### PR DESCRIPTION
I got this warning during a build:

```
[1023/1154] Compiling C object scipy/interpolate/_fitpack.cpython-314t-x86_64-linux-gnu.so.p/src__fitpackmodule.c.o
In file included from /home/warren/py3.14.5t/include/python3.14t/cpython/pyatomic.h:580,
                 from /home/warren/py3.14.5t/include/python3.14t/pyatomic.h:9,
                 from /home/warren/py3.14.5t/include/python3.14t/Python.h:79,
                 from ../scipy/interpolate/src/_fitpackmodule.c:2:
In function ‘_Py_atomic_load_uint32_relaxed’,
    inlined from ‘Py_DECREF’ at /home/warren/py3.14.5t/include/python3.14t/refcount.h:365:22,
    inlined from ‘fitpack_spgrid’ at ../scipy/interpolate/src/_fitpackmodule.c:1973:9: warning: ‘__atomic_load_4’ writing 4 bytes into a region of size 0 overflows
/home/warren/py3.14.5t/include/python3.14t/cpython/pyatomic_gcc.h:367:10: the destination [-Wstringop-overflow=]
  367 | { return __atomic_load_n(obj, __ATOMIC_RELAXED); }
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function ‘fitpack_spgrid’:
cc1: note: destination object is likely at address zero
```

The warning is coming from `scipy/interpolate/src/_fitpackmodule.c:1973`:
https://github.com/scipy/scipy/blob/cadff2794c526d283f0c048e3c19d8b960d9e415/scipy/interpolate/src/_fitpackmodule.c#L1973

It is easy to check that `ap_c` is NULL if that line is reached, and the argument should be `ap_c_full`.


#### AI Generation Disclosure

No AI tools used.