### PR TITLE
DOC: Add Examples section to idealfourths in scipy.stats.mstats

### DIFF
--- a/scipy/stats/_mstats_extras.py
+++ b/scipy/stats/_mstats_extras.py
@@ -468,6 +468,22 @@ def idealfourths(data, axis=None):
         using the ideal fourths algorithm either along the flattened array
         (if `axis` is None) or along `axis` of `data`.
 
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from scipy.stats.mstats import idealfourths
+    >>> data = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    >>> idealfourths(data)
+    [2.9166666666666665, 8.083333333333334]
+
+    The function also supports masked arrays, ignoring masked values:
+
+    >>> import numpy.ma as ma
+    >>> data_masked = ma.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ...                        mask=[0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+    >>> idealfourths(data_masked)
+    [2.6666666666666665, 7.333333333333334]
+
     """
     def _idf(data):
         x = data.compressed()


### PR DESCRIPTION
Closes #7168

### What this PR does
Added an `Examples` section to the `idealfourths` function in
`scipy/stats/_mstats_extras.py`, which was missing documentation
examples as noted in issue #7168.

The examples demonstrate:
- Basic usage with a 1D array showing lower and upper quartile estimates
- Usage with a masked array showing how masked values are ignored

### AI Disclosure
As required by the SciPy AI policy:

- **Tool used:** Claude (Anthropic)
- **How it was used:** Claude assisted in identifying the missing
  Examples section and suggesting the structure of the docstring example.
- **What is AI generated:** The initial draft of the Examples section
  was AI-assisted.
- **Human verification:** I manually ran all example code locally to
  verify the output values are exactly correct, confirmed the docstring
  follows numpy/scipy formatting standards, and reviewed the full file
  to ensure no other code was modified.

I understand the code fully and take complete responsibility for
this contribution.