### PR TITLE
ENH: signal.lfiltic: add JAX support

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2378,15 +2378,15 @@ def lfiltic(b, a, y, x=None):
         y = xp.concat((y, xp.zeros(N - L)))
 
     for m in range(M):
-        zi[m] = xp.sum(b[m + 1:] * x[:M - m], axis=0)
+        zi = xpx.at(zi)[m].set(xp.sum(b[m + 1:] * x[:M - m], axis=0))
 
     for m in range(N):
-        zi[m] -= xp.sum(a[m + 1:] * y[:N - m], axis=0)
+        zi = xpx.at(zi)[m].set(zi[m] - xp.sum(a[m + 1:] * y[:N - m], axis=0))
 
     if a[0] != 1.:
         if a[0] == 0.:
             raise ValueError("First `a` filter coefficient must be non-zero.")
-        zi /= a[0]
+        zi = zi / a[0]
 
     return zi
 

--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -269,7 +269,7 @@ capabilities_overrides = {
     "lfilter_zi": xp_capabilities(cpu_only=True, allow_dask_compute=True,
                                   jax_jit=False),
     "lfiltic": xp_capabilities(cpu_only=True, exceptions=["cupy"],
-                               allow_dask_compute=True),
+                               allow_dask_compute=True, jax_jit=False),
     "lp2bp": xp_capabilities(cpu_only=True, exceptions=["cupy", "torch"],
                              allow_dask_compute=True, jax_jit=False),
     "lp2bp_zpk": xp_capabilities(cpu_only=True, exceptions=["cupy", "torch"],

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2181,7 +2181,6 @@ class _TestLinearFilter:
                             else self.dtype)
         assert xp_size(zf) == 0
 
-    @skip_xp_backends('jax.numpy', reason='jax does not support inplace ops')
     @pytest.mark.parametrize('a', (1, [1], [1, .5, 1.5], 2, [2], [2, 1, 3]),
                              ids=str)
     @make_xp_test_case(lfiltic)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
@ev-br's [suggestion](https://github.com/scipy/scipy/pull/25131#issuecomment-4440677754) 

#### What does this implement/fix?
- Replaces in-place assignments with `xpx.at()`
- Removed skip test
- Add `jax_jit=False` as tests depend on `lfilter` which has `jax_jit=False` too.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex to look for any scipy.signal methods with jax skips and in-place mutations.