### PR TITLE
TST: add regressiosn test for gh-25199

### DIFF
--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -3960,6 +3960,12 @@ class TestBessel:
         assert_allclose(special.j0(x), expected, rtol=5e-15)
 
 
+    def test_gh25199(self):
+        # regression test that tiny inputs in j0 don't cause overflow
+        with special.errstate(overflow="raise"):
+            assert_allclose(special.j0(1e-200), 1.0, atol=0, rtol=0)
+
+
 class TestLaguerre:
     def test_laguerre(self):
         lag0 = special.laguerre(0)


### PR DESCRIPTION
#### Reference issue
Closes #25199 

#### What does this implement/fix?
#25199 was fixed in xsf, this adds a simple regression test to SciPy to confirm on our end.

#### AI Generation Disclosure
No AI.
