### PR TITLE
DOC: Space after directive in method.

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -676,7 +676,7 @@ class LinearOperator:
     def rdot(self, x):
         """Multi-purpose multiplication method from the right.
 
-        .. note ::
+        .. note::
 
             This method returns ``x A``.
             To perform adjoint multiplication instead, use one of


### PR DESCRIPTION
Technically not in rst spec, might not parse will all RST parsers, docutils/sphinx is lenient.

[ci skip] [skip ci]

#### AI Generation Disclosure

No AI tools used