### PR TITLE
ENH: stats: add moment-based Pearson dispatcher

### DIFF
--- a/scipy/stats/__init__.py
+++ b/scipy/stats/__init__.py
@@ -42,6 +42,14 @@ Each univariate distribution is an instance of a subclass of `rv_continuous`
    rv_discrete
    rv_histogram
 
+Distribution constructors
+-------------------------
+
+.. autosummary::
+   :toctree: generated/
+
+   pearson           -- Pearson system distribution from moments
+
 Continuous distributions
 ------------------------
 
@@ -600,6 +608,7 @@ from ._warnings_errors import (ConstantInputWarning, NearConstantInputWarning,
 from ._stats_py import *
 from ._variation import variation
 from .distributions import *
+from ._continuous_distns import pearson
 from ._morestats import *
 from ._multicomp import *
 from ._binomtest import binomtest

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8429,45 +8429,65 @@ class lomax_gen(rv_continuous):
 lomax = lomax_gen(a=0.0, name="lomax")
 
 def _pearson_classifier(skewness, kurtosis):
-    tol = 1e-12
+    # Use a small tolerance to absorb float64 roundoff near the Pearson
+    # classification boundaries, especially Type III and Type V.
+    boundary_tol = 1e-13
 
     beta1 = skewness**2
     beta2 = kurtosis + 3.0
 
-    if beta2 < beta1 + 1 - tol:
-        raise ValueError("Invalid skewness and kurtosis values "
-        "for Pearson distribution classification.")
+    lower_bound = beta1 + 1.0
+    # Use absolute tolerance only for the moment validity boundary, so
+    # large invalid moment tuples are not accepted because of relative error.
+    if beta2 < lower_bound and not np.isclose(
+            beta2, lower_bound, atol=boundary_tol, rtol=0.0):
+        raise ValueError("`skewness` and `kurtosis` must satisfy "
+                         "`kurtosis + 3 >= skewness**2 + 1`.")
 
-    is_symmetric = np.isclose(skewness, 0, atol=tol, rtol=0)
-    is_normal = is_symmetric and np.isclose(kurtosis, 0, atol=tol, rtol=0)
+    is_symmetric = np.isclose(skewness, 0.0, atol=boundary_tol, rtol=0.0)
+    is_normal = (
+        is_symmetric
+        and np.isclose(kurtosis, 0.0, atol=boundary_tol, rtol=0.0)
+    )
 
     if is_normal:
         return "normal"
 
     if is_symmetric:
-        if kurtosis < 0:
+        if kurtosis < 0.0:
             return "type2"
-        return "type7"
+        if kurtosis > 0.0:
+            return "type7"
 
-    delta = 2*beta2 - 3*beta1 - 6
+    delta_left = 2.0 * beta2
+    delta_right = 3.0 * beta1 + 6.0
 
-    if np.isclose(delta, 0, atol=tol, rtol=0):
+    # Type III boundary is mathematically defined where delta = 0.
+    # To avoid cancellation when subtracting large moments,
+    # we compare the left and right terms directly using relative tolerance.
+    if np.isclose(delta_left, delta_right, atol=boundary_tol, rtol=boundary_tol):
         return "type3"
 
-    epsilon = 4*beta2 - 3*beta1
-    kappa = (beta1*(beta2 + 3)**2) / (4 * epsilon * delta)
+    delta = delta_left - delta_right
 
-    # Type V is the kappa == 1 boundary between Types IV and VI.
-    if np.isclose(kappa, 1, atol=tol, rtol=0):
+    epsilon = 4.0 * beta2 - 3.0 * beta1
+
+    kappa_num = beta1 * (beta2 + 3.0)**2
+    kappa_den = 4.0 * epsilon * delta
+
+    # Type V is the kappa == 1 boundary. Compare numerator and
+    # denominator directly so the boundary check is scale-aware.
+    if np.isclose(kappa_num, kappa_den, atol=boundary_tol, rtol=boundary_tol):
         return "type5"
 
-    if kappa < 0:
+    kappa = kappa_num / kappa_den
+    if kappa < 0.0:
         return "type1"
 
-    if 0 < kappa < 1:
+    if 0.0 < kappa < 1.0:
         return "type4"
 
-    if kappa > 1:
+    if kappa > 1.0:
         return "type6"
 
     raise ValueError(
@@ -8476,21 +8496,125 @@ def _pearson_classifier(skewness, kurtosis):
 
 
 def _pearson_type1_params(mean, variance, skewness, kurtosis):
+    # Solve the beta skewness/kurtosis equations in terms of n = a + b,
+    # r = (b - a)**2/(a*b), and q = abs(b - a)/n.
     beta1 = skewness**2
-    n = (6 + 3*kurtosis - 3*beta1) / (1.5*beta1 - kurtosis)
-    r = beta1 * (n + 2)**2 / (4 * (n + 1))
-    q = np.sqrt(r / (r + 4))
-    # beta1 loses the skewness sign. Restore it when setting b - a.
+    n = (6.0 + 3.0 * kurtosis - 3.0 * beta1) / (1.5 * beta1 - kurtosis)
+    r = beta1 * (n + 2.0)**2 / (4.0 * (n + 1.0))
+    q = np.sqrt(r / (r + 4.0))
+    # Squared skewness loses the sign. Restore it when setting d = b - a.
     d = np.sign(skewness) * n * q
 
-    a = (n - d) / 2
-    b = (n + d) / 2
-    base_mean = a / (a + b)
-    base_var = a*b / ((a + b)**2 * (a + b + 1))
-    scale = np.sqrt(variance / base_var)
-    loc = mean - scale*base_mean
+    a = (n - d) / 2.0
+    b = (n + d) / 2.0
+    if not (np.isfinite(a) and np.isfinite(b) and a > 0.0 and b > 0.0):
+        raise ValueError("Pearson Type I distribution requires positive beta "
+                         "parameters.")
+
+    beta_mean = a / (a + b)
+    beta_var = a * b / ((a + b)**2 * (a + b + 1.0))
+    scale = np.sqrt(variance / beta_var)
+    if not np.isfinite(scale) or scale <= 0.0:
+        raise ValueError("Pearson Type I distribution requires positive scale.")
+
+    loc = mean - scale*beta_mean
 
     return a, b, loc, scale
+
+
+def _pearson_type2_params(mean, variance, kurtosis):
+    c = -6.0 / kurtosis - 3.0
+    if c <= 0.0:
+        raise ValueError("Pearson Type II distribution "
+                         "requires -2 < kurtosis < 0.")
+    # rdist bounded to [-1, 1] implies rdist_mean = 0, so loc = mean.
+    loc = mean
+    # If B ~ Beta(c/2, c/2), then X = 2*B - 1 has Var(X) = 1/(c + 1).
+    scale = np.sqrt(variance / (1.0/(c + 1.0)))
+
+    return c, loc, scale
+
+
+def _pearson_type5_params(mean, variance, skewness):
+    if skewness <= 0.0:
+        raise NotImplementedError(
+            "Pearson Type V dispatch is only implemented for positive skewness."
+        )
+
+    # Solve the inverse-gamma skewness equation in terms of u = sqrt(a - 2).
+    u = (2.0 + np.sqrt(4.0 + skewness**2)) / skewness
+    a = u**2 + 2.0
+    if not np.isfinite(a) or a <= 4.0:
+        raise ValueError("Pearson Type V distribution requires shape "
+                         "parameter greater than 4.")
+
+    invgamma_mean = 1.0 / (a - 1.0)
+    invgamma_var = 1.0 / ((a - 1.0)**2 * (a - 2.0))
+    scale = np.sqrt(variance / invgamma_var)
+    loc = mean - scale*invgamma_mean
+
+    return a, loc, scale
+
+
+def _pearson_type6_params(mean, variance, skewness, kurtosis):
+    if skewness <= 0.0:
+        raise NotImplementedError("Pearson Type VI dispatch is only "
+                                  "implemented for positive skewness.")
+
+    beta1 = skewness**2
+    beta2 = kurtosis + 3.0
+    # Coefficients follow the standardized Pearson system notation
+    # (see pearson docstring References [1]).
+    # For Type VI, D(x) has two real roots and q'(x)/q(x) = -C(x)/D(x),
+    # where C(x) = d1 + c2*x and D(x) = d0 + d1*x + d2*x**2.
+    epsilon4 = beta2 + 3.0
+    epsilon6 = 3.0 * beta2 - 3.0 * beta1 - 3.0
+
+    d2 = epsilon6 - epsilon4
+    d1 = skewness * epsilon4
+    d0 = epsilon6 + epsilon4
+
+    c2 = 2.0 * (2.0 * epsilon6 - epsilon4)
+
+    b2 = d2 / c2
+    b1 = d1 / c2  # The mode is at -b1.
+
+    discriminant = d1**2 - 4.0 * d2 * d0
+    if discriminant <= 0.0:
+        raise ValueError("Discriminant must be positive for Pearson Type VI.")
+
+    r1 = (-d1 + np.sqrt(discriminant)) / (2.0 * d2)
+    r2 = (-d1 - np.sqrt(discriminant)) / (2.0 * d2)
+
+    if r1 > r2:
+        r1, r2 = r2, r1
+
+    m1 = -(r1 + b1) / (b2 * (r1 - r2))
+    m2 = -(r2 + b1) / (b2 * (r2 - r1))
+
+    a = m2 + 1.0
+    b = -m2 - m1 - 1.0
+    if not (np.isfinite(a) and np.isfinite(b) and a > 0.0 and b > 4.0):
+        raise ValueError("Pearson Type VI distribution requires a > 0 and "
+                         "b > 4.")
+
+    scale = np.sqrt(variance) * (r2 - r1)
+    if not np.isfinite(scale) or scale <= 0.0:
+        raise ValueError("Pearson Type VI distribution requires positive "
+                         "scale.")
+
+    loc = mean + np.sqrt(variance) * r2
+
+    return a, b, loc, scale
+
+
+def _pearson_type7_params(mean, variance, kurtosis):
+    df = 6.0 / kurtosis + 4.0
+    t_var = df / (df - 2.0)
+    loc = mean
+    scale = np.sqrt(variance / t_var)
+
+    return df, loc, scale
 
 
 class pearson3_gen(rv_continuous):
@@ -8693,6 +8817,134 @@ pearson3 = pearson3_gen(name="pearson3")
 
 
 def pearson(mean, variance, skewness, kurtosis):
+    r"""Construct a Pearson system distribution from moments.
+
+    The distribution is selected from the Pearson system using the specified
+    mean, variance, skewness, and excess kurtosis, and returned as a frozen
+    continuous random variable.
+
+    Parameters
+    ----------
+    mean : float
+        Mean of the distribution.
+    variance : float
+        Variance of the distribution. Must be positive.
+    skewness : float
+        Skewness of the distribution.
+    kurtosis : float
+        Excess kurtosis of the distribution. This is Fisher's definition of
+        kurtosis, so the normal distribution has kurtosis equal to zero.
+
+    Returns
+    -------
+    dist : rv_frozen
+        Frozen continuous random variable whose first four moments match the
+        specified mean, variance, skewness, and excess kurtosis.
+
+    Raises
+    ------
+    ValueError
+        If any moment is not a finite scalar, if ``variance`` is not positive,
+        or if ``skewness`` and ``kurtosis`` do not satisfy the Pearson moment
+        validity condition.
+    NotImplementedError
+        If the moments correspond to Pearson Type IV, or to Pearson Type V or
+        Type VI with negative skewness.
+
+    Notes
+    -----
+
+    The Pearson type is determined from the standardized moment ratios
+
+    .. math::
+
+        \beta_1 = \mathrm{skewness}^2,
+        \qquad
+        \beta_2 = \mathrm{kurtosis} + 3.
+
+    The valid Pearson moment region satisfies
+
+    .. math::
+
+        \beta_2 \geq \beta_1 + 1.
+
+    For non-symmetric distributions, the classifier also uses
+
+    .. math::
+
+        \delta = 2\beta_2 - 3\beta_1 - 6
+
+    and
+
+    .. math::
+
+        \kappa =
+        \frac{\beta_1(\beta_2 + 3)^2}
+             {4(4\beta_2 - 3\beta_1)(2\beta_2 - 3\beta_1 - 6)}.
+
+    The mean and variance are used as location and scale parameters after
+    the Pearson type and shape parameters have been determined from
+    ``skewness`` and ``kurtosis``.
+
+    The currently supported cases are dispatched to existing SciPy
+    distributions:
+
+    =============  ===========================
+    Pearson type   SciPy distribution
+    =============  ===========================
+    Normal         `norm`
+    Type I         `beta`
+    Type II        `rdist`
+    Type III       `pearson3`
+    Type V         `invgamma`
+    Type VI        `betaprime`
+    Type VII       `t`
+    =============  ===========================
+
+    Pearson Type IV is identified but not implemented. Passing moments that
+    correspond to Pearson Type V or Type VI with negative skewness currently
+    raises `NotImplementedError`.
+
+    .. versionadded:: 1.18.0
+
+    References
+    ----------
+    .. [1] "Pearson distribution", Wikipedia,
+          https://en.wikipedia.org/wiki/Pearson_distribution
+    .. [2] Johnson, Kotz, and Balakrishnan, "Continuous Univariate
+          Distributions, Volume 1", Second Edition, John Wiley and Sons,
+          Chapter 12.1, Section 4.1 (1994).
+
+    Examples
+    --------
+    Construct the standard normal distribution from its first four moments:
+
+    >>> import numpy as np
+    >>> from scipy import stats
+    >>> X = stats.pearson(mean=0.0, variance=1.0,
+    ...                   skewness=0.0, kurtosis=0.0)
+    >>> np.allclose(X.pdf(0.0), 1/np.sqrt(2*np.pi))
+    True
+
+    The returned object is a frozen distribution:
+
+    >>> np.allclose(X.cdf(0.0), 0.5)
+    True
+    >>> np.allclose(X.stats(moments="mvsk"), [0.0, 1.0, 0.0, 0.0])
+    True
+    """
+    if any(np.ndim(moment) != 0
+           for moment in (mean, variance, skewness, kurtosis)):
+        raise ValueError("Pearson dispatcher only supports scalar moments.")
+
+    moments = np.asarray([mean, variance, skewness, kurtosis], dtype=float)
+    if not np.all(np.isfinite(moments)):
+        raise ValueError("All moments must be finite real numbers.")
+    mean, variance, skewness, kurtosis = moments
+
+    if variance <= 0:
+        raise ValueError("`variance` must be positive.")
+
     pearson_type = _pearson_classifier(skewness, kurtosis)
 
     if pearson_type == "normal":
@@ -8704,8 +8956,29 @@ def pearson(mean, variance, skewness, kurtosis):
         )
         return beta(a, b, loc=loc, scale=scale)
 
+    if pearson_type == "type2":
+        c, loc, scale = _pearson_type2_params(mean, variance, kurtosis)
+        return rdist(c, loc=loc, scale=scale)
+
     if pearson_type == "type3":
         return pearson3(skewness, loc=mean, scale=np.sqrt(variance))
+
+    if pearson_type == "type4":
+        raise NotImplementedError("Pearson Type IV dispatch is not implemented.")
+
+    if pearson_type == "type5":
+        a, loc, scale = _pearson_type5_params(mean, variance, skewness)
+        return invgamma(a, loc=loc, scale=scale)
+
+    if pearson_type == "type6":
+        a, b, loc, scale = _pearson_type6_params(
+            mean, variance, skewness, kurtosis
+        )
+        return betaprime(a, b, loc=loc, scale=scale)
+
+    if pearson_type == "type7":
+        df, loc, scale = _pearson_type7_params(mean, variance, kurtosis)
+        return t(df, loc=loc, scale=scale)
 
     raise NotImplementedError(
         f"Pearson {pearson_type} dispatch is not implemented."

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -8428,6 +8428,70 @@ class lomax_gen(rv_continuous):
 
 lomax = lomax_gen(a=0.0, name="lomax")
 
+def _pearson_classifier(skewness, kurtosis):
+    tol = 1e-12
+
+    beta1 = skewness**2
+    beta2 = kurtosis + 3.0
+
+    if beta2 < beta1 + 1 - tol:
+        raise ValueError("Invalid skewness and kurtosis values "
+        "for Pearson distribution classification.")
+
+    is_symmetric = np.isclose(skewness, 0, atol=tol, rtol=0)
+    is_normal = is_symmetric and np.isclose(kurtosis, 0, atol=tol, rtol=0)
+
+    if is_normal:
+        return "normal"
+
+    if is_symmetric:
+        if kurtosis < 0:
+            return "type2"
+        return "type7"
+
+    delta = 2*beta2 - 3*beta1 - 6
+
+    if np.isclose(delta, 0, atol=tol, rtol=0):
+        return "type3"
+
+    epsilon = 4*beta2 - 3*beta1
+    kappa = (beta1*(beta2 + 3)**2) / (4 * epsilon * delta)
+
+    # Type V is the kappa == 1 boundary between Types IV and VI.
+    if np.isclose(kappa, 1, atol=tol, rtol=0):
+        return "type5"
+
+    if kappa < 0:
+        return "type1"
+
+    if 0 < kappa < 1:
+        return "type4"
+
+    if kappa > 1:
+        return "type6"
+
+    raise ValueError(
+        "Unable to classify the distribution based on skewness and kurtosis."
+    )
+
+
+def _pearson_type1_params(mean, variance, skewness, kurtosis):
+    beta1 = skewness**2
+    n = (6 + 3*kurtosis - 3*beta1) / (1.5*beta1 - kurtosis)
+    r = beta1 * (n + 2)**2 / (4 * (n + 1))
+    q = np.sqrt(r / (r + 4))
+    # beta1 loses the skewness sign. Restore it when setting b - a.
+    d = np.sign(skewness) * n * q
+
+    a = (n - d) / 2
+    b = (n + d) / 2
+    base_mean = a / (a + b)
+    base_var = a*b / ((a + b)**2 * (a + b + 1))
+    scale = np.sqrt(variance / base_var)
+    loc = mean - scale*base_mean
+
+    return a, b, loc, scale
+
 
 class pearson3_gen(rv_continuous):
     r"""
@@ -8626,6 +8690,26 @@ class pearson3_gen(rv_continuous):
 
 
 pearson3 = pearson3_gen(name="pearson3")
+
+
+def pearson(mean, variance, skewness, kurtosis):
+    pearson_type = _pearson_classifier(skewness, kurtosis)
+
+    if pearson_type == "normal":
+        return norm(loc=mean, scale=np.sqrt(variance))
+
+    if pearson_type == "type1":
+        a, b, loc, scale = _pearson_type1_params(
+            mean, variance, skewness, kurtosis
+        )
+        return beta(a, b, loc=loc, scale=scale)
+
+    if pearson_type == "type3":
+        return pearson3(skewness, loc=mean, scale=np.sqrt(variance))
+
+    raise NotImplementedError(
+        f"Pearson {pearson_type} dispatch is not implemented."
+    )
 
 
 class powerlaw_gen(rv_continuous):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -33,7 +33,9 @@ import scipy.stats.distributions
 from scipy.special import xlogy, polygamma, entr
 from scipy.stats._distr_params import distcont, invdistcont
 from .test_discrete_basic import distdiscrete, invdistdiscrete
-from scipy.stats._continuous_distns import FitDataError, _argus_phi, _pearson_classifier
+from scipy.stats._continuous_distns import (
+    FitDataError, _argus_phi, _pearson_classifier
+)
 from scipy.optimize import root, fmin, differential_evolution
 from itertools import product
 
@@ -2909,8 +2911,114 @@ class TestPearson:
         assert result == expected
 
     def test_invalid_skewness_kurtosis(self):
-        with pytest.raises(ValueError, match="Invalid skewness and kurtosis"):
+        with pytest.raises(ValueError, match="must satisfy"):
             _pearson_classifier(1.761, 1.0)
+
+    def test_pearson_type3_float_drift(self):
+        _, _, skewness, kurtosis = stats.gamma.stats(0.05, moments="mvsk")
+        assert _pearson_classifier(skewness, kurtosis) == "type3"
+
+    def test_pearson_type5_float_drift(self):
+        _, _, skewness, kurtosis = stats.invgamma.stats(10000.0, moments="mvsk")
+        assert _pearson_classifier(skewness, kurtosis) == "type5"
+
+    @pytest.mark.parametrize(
+        "dist, shape",
+        [(stats.gamma, 0.05),
+         (stats.invgamma, 10000.0)])
+    def test_pearson_boundary_float_drift_moments(self, dist, shape):
+        _, _, skewness, kurtosis = dist.stats(shape, moments="mvsk")
+        X = stats.pearson(0.0, 1.0, skewness, kurtosis)
+        result = X.stats(moments="mvsk")
+        assert_allclose(result, [0.0, 1.0, skewness, kurtosis])
+
+    def test_pearson_type5_near_finite_kurtosis_boundary(self):
+        _, _, skewness, kurtosis = stats.invgamma.stats(4.01, moments="mvsk")
+        dist = stats.pearson(0.0, 1.0, skewness, kurtosis)
+        result = dist.stats(moments="mvsk")
+        assert_allclose(result, [0.0, 1.0, skewness, kurtosis])
+
+    def test_pearson_type6_near_finite_kurtosis_boundary(self):
+        _, _, skewness, kurtosis = stats.betaprime.stats(
+            2.0, 4.01, moments="mvsk"
+        )
+        dist = stats.pearson(0.0, 1.0, skewness, kurtosis)
+        result = dist.stats(moments="mvsk")
+        assert_allclose(result, [0.0, 1.0, skewness, kurtosis])
+
+    @pytest.mark.parametrize(
+        "mean, variance, skewness, kurtosis",
+        [(2.0, 3.0, 0.0, 0.0),
+         (2.0, 3.0, 1.0, 0.0),
+         (2.0, 3.0, -1.0, 0.0),
+         (2.0, 3.0, 0.0, -1.0),
+         (2.0, 3.0, 1.0, 1.5),
+         (2.0, 3.0, -1.0, 1.5),
+         (2.0, 3.0, np.sqrt(5), 12.0),
+         (2.0, 3.0, 2.0, 7.0),
+         (2.0, 3.0, 0.0, 4.0)])
+    def test_pearson_moments(self, mean, variance, skewness, kurtosis):
+        dist = stats.pearson(mean, variance, skewness, kurtosis)
+        result = dist.stats(moments="mvsk")
+        assert_allclose(result, [mean, variance, skewness, kurtosis])
+
+    def test_pearson_distribution_pdf_cdf_and_rvs(self):
+        dist = stats.pearson(0.0, 1.0, 0.0, 0.0)
+        assert_allclose(dist.pdf(0.0), 1.0 / np.sqrt(2.0 * np.pi))
+        assert_allclose(dist.cdf(0.0), 0.5)
+
+        rvs = dist.rvs(size=3, random_state=123)
+        assert rvs.shape == (3,)
+        assert np.all(np.isfinite(rvs))
+
+    def test_pearson_type4_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Pearson Type IV"):
+            stats.pearson(0.0, 1.0, 1.0, 2.0)
+
+    def test_pearson_invalid_skewness_kurtosis(self):
+        with pytest.raises(ValueError, match="must satisfy"):
+            stats.pearson(0.0, 1.0, 1.761, 1.0)
+
+    def test_pearson_invalid_type1_boundary(self):
+        with pytest.raises(ValueError, match="positive beta parameters"):
+            stats.pearson(0.0, 1.0, 1.0, -1.0)
+
+    def test_pearson_invalid_type2_boundary(self):
+        with pytest.raises(ValueError, match="-2 < kurtosis < 0"):
+            stats.pearson(0.0, 1.0, 0.0, -2.0)
+
+    def test_pearson_negative_type5_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Pearson Type V"):
+            stats.pearson(0.0, 1.0, -np.sqrt(5), 12.0)
+
+    def test_pearson_negative_type6_not_implemented(self):
+        with pytest.raises(NotImplementedError, match="Pearson Type VI"):
+            stats.pearson(0.0, 1.0, -2.0, 7.0)
+
+    @pytest.mark.parametrize("variance", [0.0, -1.0])
+    def test_pearson_invalid_variance(self, variance):
+        with pytest.raises(ValueError, match="variance"):
+            stats.pearson(0.0, variance, 0.0, 0.0)
+
+    @pytest.mark.parametrize(
+        "moments",
+        [(np.nan, 1.0, 0.0, 0.0),
+         (0.0, np.inf, 0.0, 0.0),
+         (0.0, 1.0, np.nan, 0.0),
+         (0.0, 1.0, 0.0, -np.inf)])
+    def test_pearson_nonfinite_moments(self, moments):
+        with pytest.raises(ValueError, match="finite"):
+            stats.pearson(*moments)
+
+    @pytest.mark.parametrize(
+        "moments",
+        [([0.0, 1.0], 1.0, 0.0, 0.0),
+         (0.0, [1.0, 2.0], 0.0, 0.0),
+         (0.0, 1.0, [0.0, 1.0], 0.0),
+         (0.0, 1.0, 0.0, [0.0, 1.0])])
+    def test_pearson_array_like_moments(self, moments):
+        with pytest.raises(ValueError, match="scalar"):
+            stats.pearson(*moments)
 
 
 class TestPearson3:

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -33,7 +33,7 @@ import scipy.stats.distributions
 from scipy.special import xlogy, polygamma, entr
 from scipy.stats._distr_params import distcont, invdistcont
 from .test_discrete_basic import distdiscrete, invdistdiscrete
-from scipy.stats._continuous_distns import FitDataError, _argus_phi
+from scipy.stats._continuous_distns import FitDataError, _argus_phi, _pearson_classifier
 from scipy.optimize import root, fmin, differential_evolution
 from itertools import product
 
@@ -2890,6 +2890,27 @@ class TestGenpareto:
         # Regression test for gh-11168.
         v = stats.genpareto.var(1e-8)
         assert_allclose(v, 1.000000040000001, rtol=1e-13)
+
+
+class TestPearson:
+    @pytest.mark.parametrize(
+        "skewness, kurtosis, expected",
+        [(0.0, 0.0, "normal"),
+         (1.0, 0.0, "type1"),
+         (0.0, -1.0, "type2"),
+         (1.0, 1.5, "type3"),
+         (1.0, 2.0, "type4"),
+         # Chosen so that kappa == 1, the Type V boundary.
+         (np.sqrt(5), 12.0, "type5"),
+         (2.0, 7.0, "type6"),
+         (0.0, 4.0, "type7")])
+    def test_pearson_types(self, skewness, kurtosis, expected):
+        result = _pearson_classifier(skewness, kurtosis)
+        assert result == expected
+
+    def test_invalid_skewness_kurtosis(self):
+        with pytest.raises(ValueError, match="Invalid skewness and kurtosis"):
+            _pearson_classifier(1.761, 1.0)
 
 
 class TestPearson3:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
See gh-24823.

#### What does this implement/fix?
Add `scipy.stats.pearson`, a constructor that returns a frozen
continuous distribution matching the specified mean, variance,
skewness, and excess kurtosis. For example, `stats.pearson(0, 1, 0, 0)`
returns a frozen normal distribution, while non-normal moment
combinations dispatch to the corresponding Pearson type when supported.

This initial implementation supports direct dispatch for Types I, II,
III, V, VI, and VII. Type IV is identified but not implemented because
SciPy does not currently provide a corresponding distribution. Negative
skewness cases for Types V and VI are also left unsupported because
they require reflected forms not currently represented by the existing
positive-scale distributions.

Add tests for Pearson type classification, moment recovery, public
`pdf`, `cdf`, and `rvs` behavior, invalid moment regions, scalar input
validation, unsupported branches, and boundary roundoff.


#### Additional information
The implementation keeps the parameter calculations for each Pearson
type in private helpers and validates scalar, finite inputs before
dispatch. To avoid false classifications from floating-point roundoff
near Pearson boundaries, the classifier compares boundary expressions
with both absolute and relative tolerances. A tolerance of  `1e-13` was
chosen after empirical checks with moments returned by
`scipy.stats.gamma` and `scipy.stats.invgamma`; roundoff at exact Type
III and Type V boundaries can slightly exceed 1e-14 under stricter
thresholds.

Co-authored-by: Miguel Romão <miguel.magalhaes.romao@tecnico.ulisboa.pt>

#### AI Generation Disclosure
Codex was used to help deepen our understanding of the Pearson
system mathematics, cross-check manually derived equations, suggest
some numerical guardrails and test cases. It was also used to review wording. 
All submitted changes were reviewed, understood, and tested by the authors.
