### PR TITLE
BUG: interpolate: fix missing DECREF in curfit and percur

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -972,7 +972,9 @@ fitpack_curfit(PyObject* Py_UNUSED(dummy), PyObject *args)
     Py_DECREF(ap_x);
     Py_DECREF(ap_y);
     Py_DECREF(ap_w);
-    /* Don't decref ap_t, ap_wrk, ap_iwrk - they are modified in-place */
+    Py_DECREF(ap_wrk);
+    Py_DECREF(ap_iwrk);
+    /* Don't decref ap_t - it will be returned */
 
     return Py_BuildValue(("iNNdi"),
                          n, PyArray_Return(ap_t), PyArray_Return(ap_c), fp, ier);
@@ -1076,7 +1078,9 @@ fitpack_percur(PyObject* Py_UNUSED(dummy), PyObject *args)
     Py_DECREF(ap_x);
     Py_DECREF(ap_y);
     Py_DECREF(ap_w);
-    /* Don't decref ap_t, ap_wrk, ap_iwrk - they are modified in-place */
+    Py_DECREF(ap_wrk);
+    Py_DECREF(ap_iwrk);
+    /* Don't decref ap_t - it will be returned */
 
     return Py_BuildValue(("iNNdi"),
                          n, PyArray_Return(ap_t), PyArray_Return(ap_c), fp, ier);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue

Closes #25274 

#### What does this implement/fix?

In the success path, wrk and iwrk don't end up getting freed, and end up with a reference count which is one too high.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure

No AI tools used
