### PR TITLE
DOC: Minor RST alignement

### DIFF
--- a/doc/source/tutorial/optimize.rst
+++ b/doc/source/tutorial/optimize.rst
@@ -750,10 +750,12 @@ The SLSQP method deals with constrained minimization problems of the form:
 .. math::
    :nowrap:
 
-     \begin{eqnarray*} \min_x & f(x) \\
-          \text{subject to: } & c_j(x) =  0  ,  &j \in \mathcal{E}\\
-            & c_j(x) \geq 0  ,  &j \in \mathcal{I}\\
-           &  \text{lb}_i  \leq x_i \leq \text{ub}_i , &i = 1,...,N. \end{eqnarray*}
+   \begin{eqnarray*}
+                    \min_x & f(x) \\
+       \text{subject to: } & c_j(x) =  0    ,                          &j \in \mathcal{E}\\
+                           & c_j(x) \geq 0  ,                          &j \in \mathcal{I}\\
+                           &  \text{lb}_i  \leq x_i \leq \text{ub}_i , &i = 1,...,N.
+   \end{eqnarray*}
 
 Where :math:`\mathcal{E}` or :math:`\mathcal{I}` are sets of indices
 containing equality and inequality constraints.

--- a/doc/source/tutorial/signal.rst
+++ b/doc/source/tutorial/signal.rst
@@ -1749,7 +1749,7 @@ Eq. :math:numref:`eq_STFT_istftM`, i.e.,
 .. math::
    :label: eq_STFT_WindDualCond0
 
-    \vb{x} = \sum_{p=0}^{P-1} \conjT{\vb{U}_p}\,\conjT{\vb{F}}\,
+   \vb{x} = \sum_{p=0}^{P-1} \conjT{\vb{U}_p}\,\conjT{\vb{F}}\,
                                                  \vb{F}\,\vb{W}_{\!p}\,\vb{x}
         = \left(\sum_{p=0}^{P-1} \conjT{\vb{U}_p}\,\vb{W}_{\!p}\right)\vb{x}\ ,
 

--- a/doc/source/tutorial/stats/continuous_wrapcauchy.rst
+++ b/doc/source/tutorial/stats/continuous_wrapcauchy.rst
@@ -9,21 +9,23 @@ There is one shape parameter :math:`c\in\left(0,1\right)` with support :math:`x\
 .. math::
    :nowrap:
 
-    \begin{eqnarray*} f\left(x;c\right) & = & \frac{1-c^{2}}{2\pi\left(1+c^{2}-2c\cos x\right)}\\
+   \begin{eqnarray*}
+      f\left(x;c\right) & = & \frac{1-c^{2}}{2\pi\left(1+c^{2}-2c\cos x\right)}\\
     g_{c}\left(x\right) & = & \frac{1}{\pi}\arctan\left(\frac{1+c}{1-c}\tan\left(\frac{x}{2}\right)\right)\\
     r_{c}\left(q\right) & = & 2\arctan\left(\frac{1-c}{1+c}\tan\left(\pi q\right)\right)\\
-    F\left(x;c\right) & = & \left\{
-          \begin{array}{ccc}
-            g_{c}\left(x\right) &  & 0\leq x<\pi\\
-            1-g_{c}\left(2\pi-x\right) &  & \pi\leq x\leq2\pi
-          \end{array}
-          \right.\\
-   G\left(q;c\right) & = & \left\{
+      F\left(x;c\right) & = & \left\{
+         \begin{array}{ccc}
+           g_{c}\left(x\right) &  & 0\leq x<\pi\\
+           1-g_{c}\left(2\pi-x\right) &  & \pi\leq x\leq2\pi
+         \end{array}
+       \right.\\
+     G\left(q;c\right) & = & \left\{
           \begin{array}{ccc}
             r_{c}\left(q\right) &  & 0\leq q<\frac{1}{2}\\
             2\pi-r_{c}\left(1-q\right) &  & \frac{1}{2}\leq q\leq1
           \end{array}
-          \right.\end{eqnarray*}
+          \right.
+   \end{eqnarray*}
 
 .. math::
 


### PR DESCRIPTION
This is a bit of a nitpicking, and deal with an ambiguity in the RST parser: docutils vs tree-sitter-rst. If the block content is indented more than the :nowrap: option, then it's  ambiguous whether we have

- a directive marker, and option and the content or
- a directive followed by a definition/term-list.

(As far as I understand)

Docutils behaves ok in this case, tree-sitter-rst fails (I'm working on a patch, but this seem rare enough that maybe we should keep tree-sitter-rst strict).

I used the ooportunity to completely reformat the equations to align on
the `&` for readability

I build docs locally and this render the same as the current page.

[skip ci] [ci skip]


#### AI Generation Disclosure

No AI tools used