### PR TITLE
ENH: signal.sawtooth: Remove from untested list

### DIFF
--- a/scipy/signal/_support_alternative_backends.py
+++ b/scipy/signal/_support_alternative_backends.py
@@ -99,7 +99,6 @@ untested = {
     "peak_widths",
     "periodogram",
     "place_poles",
-    "sawtooth",
     "sepfir2d",
     "ss2tf",
     "ss2zpk",

--- a/scipy/signal/tests/test_waveforms.py
+++ b/scipy/signal/tests/test_waveforms.py
@@ -413,7 +413,6 @@ class TestSawtoothWaveform:
         y = sawtooth(t, width=1.5)
         assert xp.all(xp.isnan(y))
 
-    @pytest.mark.xfail_xp_backends("cupy", reason="cupy/cupy/issues/9568")
     def test_triangle_symmetry(self, xp):
         t = xp.linspace(0, 2*xp.pi, 1000)
         y = sawtooth(t, width=0.5)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Array API support for `signal.sawtooth` was added in https://github.com/scipy/scipy/pull/24264. However, it remains in the untested list so the support table is not updated.

#### What does this implement/fix?
- Remove `signal.sawtooth` from untested list.
- Remove skip test for CuPy as https://github.com/cupy/cupy/issues/9568 is solved.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.