### PR TITLE
TST: Fix method for overriding the timeout of test_large_spline_2d

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -95,9 +95,6 @@ jobs:
         run: |
           # test runner parallel clashes with OpenBLAS multithreading
           $env:OPENBLAS_NUM_THREADS=1
-          # Avoid occasional anomalous long durations of a test in interpolate;
-          # see gh-25142.
-          $env:WINDOWS_CI_LONG_TIMEOUT=600
           spin test -j4 --mode full -- --durations=25 --timeout=60
 
   #############################################################################

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -585,6 +585,22 @@ if hypothesis_available:
     hypothesis.settings.load_profile(SCIPY_HYPOTHESIS_PROFILE)
 
 
+def pytest_collection_modifyitems(config, items):
+    # Modify the timeout marker of the interpolate test 'test_spline_large_2d[...]',
+    # but only if timeout is being used AND we're on Windows.
+    # We do this to avoid occasional anomalous long durations of this specific
+    # test; see gh-25142.  Once that issue is resolved, this use of
+    # pytest_collection_modifyitems() can be removed.
+
+    cli_timeout = config.getoption("timeout", None)
+    if cli_timeout is None or sys.platform != 'win32':
+        return
+
+    for item in items:
+        if 'test_spline_large_2d[' in item.name:
+            item.add_marker(pytest.mark.timeout(600))
+
+
 ############################################################################
 # doctesting stuff
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1,6 +1,5 @@
 # Created by Pearu Peterson, June 2003
 import itertools
-import os
 import sys
 import warnings
 
@@ -1413,7 +1412,6 @@ class TestRectBivariateSpline:
         return spl(x, y)
 
     @pytest.mark.slow()
-    @pytest.mark.timeout(timeout=float(os.getenv("WINDOWS_CI_LONG_TIMEOUT", "60")))
     @pytest.mark.parametrize('shape', [(350, 850), (2000, 170)])
     @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
                                         (1, 7e-3, 1e-4),


### PR DESCRIPTION
This PR reverts gh-25238 and uses a different method to override the timeout value of `test_large_spline_2d[...]` on Windows.

#### Reference issue

gh-25142

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

ChatGPT was used to research the use of pytest plugins and pytest-timeout behavior.  The code is not AI generated. (Well, I guess `cli_timeout = config.getoption("timeout")` was included in code suggested by ChatGPT.)
