### PR TITLE
BUG: cluster.vq: fix calling deprecated `py_vq`

### DIFF
--- a/scipy/cluster/vq/_vq_impl.py
+++ b/scipy/cluster/vq/_vq_impl.py
@@ -154,7 +154,7 @@ def vq(obs, code_book, check_finite=True):
         c_code_book = np.asarray(c_code_book)
         result = _vq.vq(c_obs, c_code_book)
         return xp.asarray(result[0]), xp.asarray(result[1])
-    return py_vq(obs, code_book, check_finite=False)
+    return _py_vq(obs, code_book, check_finite=False)
 
 
 def _py_vq(obs, code_book, check_finite=True):

--- a/scipy/cluster/vq/tests/test_vq.py
+++ b/scipy/cluster/vq/tests/test_vq.py
@@ -157,11 +157,13 @@ class TestVq:
         label1 = _py_vq(matrix(X), matrix(initc))[0]
         assert_array_equal(label1, LABEL1)
 
-    def test_vq(self, xp):
+    @pytest.mark.parametrize("dtype", ["float64", "int64"])
+    def test_vq(self, dtype, xp):
+        dtype = getattr(xp, dtype)
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
         label1, _ = _vq.vq(X, initc)
         assert_array_equal(label1, LABEL1)
-        _, _ = vq(xp.asarray(X), xp.asarray(initc))
+        _, _ = vq(xp.asarray(X, dtype=dtype), xp.asarray(initc, dtype=dtype))
 
     @pytest.mark.skipif(SCIPY_ARRAY_API,
                         reason='`np.matrix` unsupported in array API mode')


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
https://github.com/scipy/scipy/pull/24060#discussion_r3337162457
#### What does this implement/fix?
<!--Please explain your changes.-->
We were accidentally using our own deprecated api internally which resulted in a spurious warning. 
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
