### PR TITLE
TST: interpolate: Fix the timeout override of a test.

### DIFF
--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1413,7 +1413,7 @@ class TestRectBivariateSpline:
         return spl(x, y)
 
     @pytest.mark.slow()
-    @pytest.mark.timeout(timeout=float(os.getenv("WINDOWS_CI_LONG_TIMEOUT", "60")))
+    @pytest.mark.timeout(timeout=os.getenv("WINDOWS_CI_LONG_TIMEOUT", None))
     @pytest.mark.parametrize('shape', [(350, 850), (2000, 170)])
     @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
                                         (1, 7e-3, 1e-4),


### PR DESCRIPTION
Change the default value of the timeout from "60" to None, so the timeout is not applied when the CI job doesn't set a timeout.

#### Reference issue

gh-25142

#### AI Generation Disclosure

No AI tools used.
