### PR TITLE
TST: special: Tweak a few tests that consistently fail when running XSLOW.

### DIFF
--- a/scipy/special/tests/test_mpmath.py
+++ b/scipy/special/tests/test_mpmath.py
@@ -698,30 +698,34 @@ class TestSystematic:
                             mpmath.airyai,
                             [ComplexArg()])
 
-    def test_airyai_prime(self):
-        # oscillating function, limit range
-        assert_mpmath_equal(lambda z: sc.airy(z)[1], lambda z:
-                            mpmath.airyai(z, derivative=1),
-                            [Arg(-1e8, 1e8)],
-                            rtol=1e-5)
-        assert_mpmath_equal(lambda z: sc.airy(z)[1], lambda z:
-                            mpmath.airyai(z, derivative=1),
-                            [Arg(-1e3, 1e3)])
+    @pytest.mark.parametrize('xlow, xhigh, rtol',
+                             [(-1e8, -1e3, 5e-5),
+                              (-1e3, 0, 1e-9),
+                              (0, 1e3, 1e-12),
+                              (1e3, 1e8, 1e-12)])
+    def test_airyai_prime(self, xlow, xhigh, rtol):
+        # Ai' is an oscillating function for x < 0.
+        # The implementation does not provide high precision for x < 0.
+        assert_mpmath_equal(lambda z: sc.airy(z)[1],
+                            lambda z: mpmath.airyai(z, derivative=1),
+                            [Arg(xlow, xhigh)], rtol=rtol)
 
     def test_airyai_prime_complex(self):
         assert_mpmath_equal(lambda z: sc.airy(z)[1], lambda z:
                             mpmath.airyai(z, derivative=1),
                             [ComplexArg()])
 
-    def test_airybi(self):
-        # oscillating function, limit range
-        assert_mpmath_equal(lambda z: sc.airy(z)[2], lambda z:
-                            mpmath.airybi(z),
-                            [Arg(-1e8, 1e8)],
-                            rtol=1e-5)
-        assert_mpmath_equal(lambda z: sc.airy(z)[2], lambda z:
-                            mpmath.airybi(z),
-                            [Arg(-1e3, 1e3)])
+    @pytest.mark.parametrize('xlow, xhigh, rtol',
+                             [(-1e8, -1e3, 5e-5),
+                              (-1e3, 0, 1e-9),
+                              (0, 1e3, 1e-12),
+                              (1e3, 1e8, 1e-12)])
+    def test_airybi(self, xlow, xhigh, rtol):
+        # Bi is an oscillating function for x < 0
+        # The implementation does not provide high precision for x < 0.
+        assert_mpmath_equal(lambda x: sc.airy(x)[2],
+                            lambda x: mpmath.airybi(x),
+                            [Arg(xlow, xhigh)], rtol=rtol)
 
     def test_airybi_complex(self):
         assert_mpmath_equal(lambda z: sc.airy(z)[2], lambda z:
@@ -1028,7 +1032,7 @@ class TestSystematic:
             ci,
             mpmath.ci,
             [ComplexArg(complex(-1e8, -np.inf), complex(1e8, np.inf))],
-            rtol=1e-8,
+            rtol=5e-8,
         )
 
     def test_cospi(self):


### PR DESCRIPTION
The net effect of this change is to loosen some test tolerances. However, for test_airyai_prime() and test_airybi(), the test parametrization makes the required relative tolerance depend on the test interval, and for the positive intervals the test tolerance is tightened significantly.

This fixes three of the `TestSystematic` tests that have been failing when `SCIPY_XSLOW=1` for a long time: `test_airyai_prime()`, `test_airybi()` and `test_ci_complex()`.

#### Reference issue

https://github.com/scipy/scipy/issues/15384

#### AI Generation Disclosure

No AI tools used.