### PR TITLE
BUG: optimize: remove global warning filter in LinearConstraint for thread-safety

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -199,14 +199,7 @@ class LinearConstraint:
 
     def __init__(self, A, lb=-np.inf, ub=np.inf, keep_feasible=False):
         if not issparse(A):
-            # In some cases, if the constraint is not valid, this emits a
-            # VisibleDeprecationWarning about ragged nested sequences
-            # before eventually causing an error. `scipy.optimize.milp` would
-            # prefer that this just error out immediately so it can handle it
-            # rather than concerning the user.
-            with catch_warnings():
-                simplefilter("error")
-                self.A = np.atleast_2d(A).astype(np.float64)
+            self.A = np.atleast_2d(A).astype(np.float64)
         else:
             self.A = A
         if issparse(lb) or issparse(ub):

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -259,3 +259,35 @@ class TestLinearConstraint:
         lc = LinearConstraint(A, -2, 4)
         x0 = [-1, 2]
         np.testing.assert_allclose(lc.residual(x0), ([1, 4], [5, 2]))
+    
+    def test_linear_constraint_thread_safety(self):
+        # Issue #25123: LinearConstraint context manager catches unrelated warnings
+        # from other threads and converts them to errors, causing crashes.
+        import threading
+        import warnings
+        
+        exceptions = []
+
+        def create_constraints():
+            try:
+                # Rapidly instantiate valid constraints to create a race condition window
+                for _ in range(1000):
+                    LinearConstraint([[1.0]], [0.0], [1.0])
+            except Exception as e:
+                exceptions.append(e)
+
+        def emit_warnings():
+            # Rapidly emit unrelated warnings from a parallel thread
+            for _ in range(1000):
+                warnings.warn("This is an unrelated dummy warning", UserWarning)
+
+        t1 = threading.Thread(target=create_constraints)
+        t2 = threading.Thread(target=emit_warnings)
+
+        t1.start()
+        t2.start()
+
+        t1.join()
+        t2.join()
+
+        assert not exceptions, f"Thread-safety failed. Exceptions raised: {exceptions}"

--- a/scipy/optimize/tests/test_constraints.py
+++ b/scipy/optimize/tests/test_constraints.py
@@ -1,4 +1,6 @@
 import pytest
+import threading
+import warnings
 import numpy as np
 from numpy.testing import TestCase, assert_array_equal
 import scipy.sparse as sps
@@ -263,9 +265,6 @@ class TestLinearConstraint:
     def test_linear_constraint_thread_safety(self):
         # Issue #25123: LinearConstraint context manager catches unrelated warnings
         # from other threads and converts them to errors, causing crashes.
-        import threading
-        import warnings
-        
         exceptions = []
 
         def create_constraints():


### PR DESCRIPTION
#### Reference issue
Closes #25123 

#### What does this implement/fix?
Since SciPy's minimum required version is now NumPy >= 1.25, initializing an inhomogeneous/ragged array natively raises a `ValueError` (e.g., via np.atleast_2d) instead of emitting a deprecation warning (which was completely phased out in NumPy 1.24). Consequently, the global warning intervention is obsolete technical debt, and dropping it resolves the thread-safety race condition.

#### Additional information
Additionally added a test to verify thread-safe implementation. The test spawns a thread to continuously instantiate `LinearConstraint` objects while a parallel thread floods dummy warnings, verifying that no race condition exceptions cross over. 

#### AI Generation Disclosure
No AI was used.
