### PR TITLE
BUG: ndimage: make maximum_position tie-break independent of other labels

### DIFF
--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -986,7 +986,12 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
     if find_median:
         order = np.lexsort((input.ravel(), labels.ravel()))
     else:
-        order = input.ravel().argsort()
+        # A stable sort keeps equal values in their original (flat-index)
+        # order. This makes the reported extremum position for a label depend
+        # only on that label's own pixels: with an unstable sort the tie-break
+        # among equal extrema could be reordered by values belonging to other
+        # labels, so the result changed when unrelated pixels changed (gh-25279).
+        order = input.ravel().argsort(kind='stable')
     input = input.ravel()[order]
     labels = labels.ravel()[order]
     if find_positions:

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1219,6 +1219,32 @@ def test_maximum_position07(xp):
         assert output[1] == (0, 3)
 
 
+@make_xp_test_case(ndimage.maximum_position)
+def test_maximum_position_outside_label_invariance(xp):
+    # gh-25279: the reported maximum position of a label must depend only on
+    # that label's own pixels. An unstable sort used to let values belonging
+    # to other labels reorder the tie-break among equal maxima, so the result
+    # changed when unrelated pixels changed.
+    labels = xp.asarray([[0, 0, 0, 0],
+                         [0, 1, 1, 0],
+                         [0, 1, 1, 0],
+                         [0, 0, 0, 2]])
+    for type in types:
+        dtype = getattr(xp, type)
+        # label 1 is a plateau of equal maxima; only the label-2 pixel differs.
+        input_a = xp.asarray([[0, 0, 0, 0],
+                              [0, 1, 1, 0],
+                              [0, 1, 1, 0],
+                              [0, 0, 0, 0]], dtype=dtype)
+        input_b = xp.asarray([[0, 0, 0, 0],
+                              [0, 1, 1, 0],
+                              [0, 1, 1, 0],
+                              [0, 0, 0, 9]], dtype=dtype)
+        pos_a = ndimage.maximum_position(input_a, labels, xp.asarray([1]))
+        pos_b = ndimage.maximum_position(input_b, labels, xp.asarray([1]))
+        assert pos_a == pos_b
+
+
 @make_xp_test_case(ndimage.extrema, ndimage.minimum, ndimage.maximum,
                    ndimage.minimum_position, ndimage.maximum_position)
 def test_extrema01(xp):


### PR DESCRIPTION
Closes #25279.

maximum_position(input, labels, index) could return a different position for a label when only pixels in other labels changed, even though every value in the requested region was unchanged.

The array-index path of _select sorts all values with np.argsort(), whose default quicksort is not stable. When a region has several equal maxima the tie-break among them was decided by the global sort order, which other labels' values could reorder. Switching to a stable sort makes the tie-break depend only on the requested label's own pixels.

The same order also backs minimum_position and extrema, so their positions are now deterministic as well. Median uses a separate lexsort and is unchanged.

Added a regression test asserting the reported maximum position is invariant to values outside the requested label. Without the fix it fails for the wider integer and float dtypes.