### PR TITLE
BUG: ndimage: make maximum_position tie-break independent of other labels

### DIFF
--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -986,7 +986,12 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
     if find_median:
         order = np.lexsort((input.ravel(), labels.ravel()))
     else:
-        order = input.ravel().argsort()
+        # A stable sort keeps equal values in their original (flat-index)
+        # order. This makes the reported extremum position for a label depend
+        # only on that label's own pixels: with an unstable sort the tie-break
+        # among equal extrema could be reordered by values belonging to other
+        # labels, so the result changed when unrelated pixels changed (gh-25279).
+        order = input.ravel().argsort(kind='stable')
     input = input.ravel()[order]
     labels = labels.ravel()[order]
     if find_positions:

--- a/scipy/ndimage/_measurements.py
+++ b/scipy/ndimage/_measurements.py
@@ -1011,8 +1011,14 @@ def _select(input, labels=None, index=None, find_min=False, find_max=False,
         maxs[labels] = input
         result += [maxs[idxs]]
     if find_max_positions:
+        # Among tied maxima, report the lexicographically-first position
+        # (smallest flat index), matching the scalar/no-index single_group
+        # path and the minimum-position branch above (gh-25279). The forward
+        # assignment keeps the last write per label, so order the equal maxima
+        # by descending flat index (via -positions) to leave the smallest one.
         maxpos = np.zeros(labels.max() + 2, int)
-        maxpos[labels] = positions
+        max_order = np.lexsort((-positions, input))
+        maxpos[labels[max_order]] = positions[max_order]
         result += [maxpos[idxs]]
     if find_median:
         locs = np.arange(len(labels))
@@ -1282,6 +1288,12 @@ def minimum_position(input, labels=None, index=None):
     label, minimum, median, maximum_position, extrema, sum, mean, variance,
     standard_deviation
 
+    Notes
+    -----
+    When several positions within a region share the minimum value, the
+    lexicographically-first position (the smallest index in C order) is
+    returned.
+
     Examples
     --------
     >>> import numpy as np
@@ -1365,6 +1377,12 @@ def maximum_position(input, labels=None, index=None):
     label, minimum, median, maximum_position, extrema, sum, mean, variance,
     standard_deviation
 
+    Notes
+    -----
+    When several positions within a region share the maximum value, the
+    lexicographically-first position (the smallest index in C order) is
+    returned.
+
     Examples
     --------
     >>> from scipy import ndimage
@@ -1435,6 +1453,13 @@ def extrema(input, labels=None, index=None):
     See Also
     --------
     maximum, minimum, maximum_position, minimum_position, center_of_mass
+
+    Notes
+    -----
+    When several positions within a region share an extreme value, the
+    ``min_positions`` and ``max_positions`` returned are the
+    lexicographically-first (smallest index in C order) positions, consistent
+    with `minimum_position` and `maximum_position`.
 
     Examples
     --------

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1220,29 +1220,57 @@ def test_maximum_position07(xp):
 
 
 @make_xp_test_case(ndimage.maximum_position)
-def test_maximum_position_outside_label_invariance(xp):
+@pytest.mark.parametrize("dtype_name", types)
+def test_maximum_position_outside_label_invariance(xp, dtype_name):
     # gh-25279: the reported maximum position of a label must depend only on
     # that label's own pixels. An unstable sort used to let values belonging
     # to other labels reorder the tie-break among equal maxima, so the result
     # changed when unrelated pixels changed.
+    dtype = getattr(xp, dtype_name)
     labels = xp.asarray([[0, 0, 0, 0],
                          [0, 1, 1, 0],
                          [0, 1, 1, 0],
                          [0, 0, 0, 2]])
-    for type in types:
-        dtype = getattr(xp, type)
-        # label 1 is a plateau of equal maxima; only the label-2 pixel differs.
-        input_a = xp.asarray([[0, 0, 0, 0],
-                              [0, 1, 1, 0],
-                              [0, 1, 1, 0],
-                              [0, 0, 0, 0]], dtype=dtype)
-        input_b = xp.asarray([[0, 0, 0, 0],
-                              [0, 1, 1, 0],
-                              [0, 1, 1, 0],
-                              [0, 0, 0, 9]], dtype=dtype)
-        pos_a = ndimage.maximum_position(input_a, labels, xp.asarray([1]))
-        pos_b = ndimage.maximum_position(input_b, labels, xp.asarray([1]))
-        assert pos_a == pos_b
+    # label 1 is a plateau of equal maxima; only the label-2 pixel differs.
+    input_a = xp.asarray([[0, 0, 0, 0],
+                          [0, 1, 1, 0],
+                          [0, 1, 1, 0],
+                          [0, 0, 0, 0]], dtype=dtype)
+    input_b = xp.asarray([[0, 0, 0, 0],
+                          [0, 1, 1, 0],
+                          [0, 1, 1, 0],
+                          [0, 0, 0, 9]], dtype=dtype)
+    # The tie is broken by the lexicographically-first position, which for
+    # label 1's plateau is (1, 1), independent of the label-2 pixel.
+    assert ndimage.maximum_position(input_a, labels, xp.asarray([1])) == [(1, 1)]
+    assert ndimage.maximum_position(input_b, labels, xp.asarray([1])) == [(1, 1)]
+
+
+@make_xp_test_case(ndimage.minimum_position, ndimage.maximum_position,
+                   ndimage.extrema)
+@pytest.mark.parametrize("dtype_name", types)
+def test_extremum_position_lexicographic_tiebreak(xp, dtype_name):
+    # gh-25279: when several pixels of a label share the extreme value, the
+    # returned position is the lexicographically-first (smallest flat index)
+    # one, consistently for scalar and list `index`, for minimum and maximum,
+    # and for the positions returned by `extrema`.
+    dtype = getattr(xp, dtype_name)
+    input = xp.asarray([[1, 1, 0, 0],
+                        [1, 1, 0, 0],
+                        [0, 0, 2, 2],
+                        [0, 0, 2, 2]], dtype=dtype)
+    labels = xp.asarray([[1, 1, 0, 0],
+                         [1, 1, 0, 0],
+                         [0, 0, 2, 2],
+                         [0, 0, 2, 2]])
+    # Each label is a plateau: label 1 -> first position (0, 0), label 2 -> (2, 2).
+    assert ndimage.maximum_position(input, labels, 1) == (0, 0)
+    assert ndimage.maximum_position(input, labels, [1, 2]) == [(0, 0), (2, 2)]
+    assert ndimage.minimum_position(input, labels, 1) == (0, 0)
+    assert ndimage.minimum_position(input, labels, [1, 2]) == [(0, 0), (2, 2)]
+    _, _, minpos, maxpos = ndimage.extrema(input, labels, [1, 2])
+    assert minpos == [(0, 0), (2, 2)]
+    assert maxpos == [(0, 0), (2, 2)]
 
 
 @make_xp_test_case(ndimage.extrema, ndimage.minimum, ndimage.maximum,

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1219,6 +1219,32 @@ def test_maximum_position07(xp):
         assert output[1] == (0, 3)
 
 
+@make_xp_test_case(ndimage.maximum_position)
+def test_maximum_position_outside_label_invariance(xp):
+    # gh-25279: the reported maximum position of a label must depend only on
+    # that label's own pixels. An unstable sort used to let values belonging
+    # to other labels reorder the tie-break among equal maxima, so the result
+    # changed when unrelated pixels changed.
+    labels = xp.asarray([[0, 0, 0, 0],
+                         [0, 1, 1, 0],
+                         [0, 1, 1, 0],
+                         [0, 0, 0, 2]])
+    for type in types:
+        dtype = getattr(xp, type)
+        # label 1 is a plateau of equal maxima; only the label-2 pixel differs.
+        input_a = xp.asarray([[0, 0, 0, 0],
+                              [0, 1, 1, 0],
+                              [0, 1, 1, 0],
+                              [0, 0, 0, 0]], dtype=dtype)
+        input_b = xp.asarray([[0, 0, 0, 0],
+                              [0, 1, 1, 0],
+                              [0, 1, 1, 0],
+                              [0, 0, 0, 9]], dtype=dtype)
+        pos_a = ndimage.maximum_position(input_a, labels, xp.asarray([1]))
+        pos_b = ndimage.maximum_position(input_b, labels, xp.asarray([1]))
+        assert pos_a == pos_b
+
+
 @make_xp_test_case(ndimage.extrema, ndimage.minimum, ndimage.maximum,
                    ndimage.minimum_position, ndimage.maximum_position)
 def test_extrema01(xp):

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1264,11 +1264,12 @@ def test_extremum_position_lexicographic_tiebreak(xp, dtype_name):
                          [0, 0, 2, 2],
                          [0, 0, 2, 2]])
     # Each label is a plateau: label 1 -> first position (0, 0), label 2 -> (2, 2).
+    index = xp.asarray([1, 2])
     assert ndimage.maximum_position(input, labels, 1) == (0, 0)
-    assert ndimage.maximum_position(input, labels, [1, 2]) == [(0, 0), (2, 2)]
+    assert ndimage.maximum_position(input, labels, index) == [(0, 0), (2, 2)]
     assert ndimage.minimum_position(input, labels, 1) == (0, 0)
-    assert ndimage.minimum_position(input, labels, [1, 2]) == [(0, 0), (2, 2)]
-    _, _, minpos, maxpos = ndimage.extrema(input, labels, [1, 2])
+    assert ndimage.minimum_position(input, labels, index) == [(0, 0), (2, 2)]
+    _, _, minpos, maxpos = ndimage.extrema(input, labels, index)
     assert minpos == [(0, 0), (2, 2)]
     assert maxpos == [(0, 0), (2, 2)]
 


### PR DESCRIPTION
#### Reference issue
Closes gh-25279.

#### What does this implement/fix?
`ndimage.maximum_position` could return a different coordinate for a requested label when only values outside that label changed. The `_select` array-index path used unstable `np.argsort()`, so ties among equal extrema could be reordered by values from other labels. Using a stable sort makes tie-breaking depend only on pixels in the requested label.

#### Additional information
`minimum_position` and `extrema` use the same path, so tied extrema are deterministic as well. The median path uses `lexsort` and is unchanged. The regression test checks that `maximum_position` is invariant to changes outside the requested label; it fails without the fix for wider integer and float dtypes.

#### AI Generation Disclosure
AI assisted with this PR. Tool: Claude Code (Anthropic). It helped reproduce the issue, identify `_select` as the root cause, draft the `argsort(kind="stable")` fix and regression test, and run local validation. I reviewed and verified the final code and test, understand the change, and can explain it.


---
_Reopens the fix from #25291, which GitHub auto-closed after a force-push; same change, branch unchanged._