### PR TITLE
DOC: clarify reqz broadcasting shape

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -356,7 +356,11 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
         Numerator of a linear filter. If `b` has dimension greater than 1,
         it is assumed that the coefficients are stored in the first dimension,
         and ``b.shape[1:]``, ``a.shape[1:]``, and the shape of the frequencies
-        array must be compatible for broadcasting.
+        array must be compatible for broadcasting. For example, with a
+        one-dimensional frequency array, a coefficient array shaped
+        ``(n_coefficients, n_filters)`` should be expanded to
+        ``(n_coefficients, n_filters, 1)`` so that each filter broadcasts over
+        the frequencies.
     a : array_like
         Denominator of a linear filter. If `b` has dimension greater than 1,
         it is assumed that the coefficients are stored in the first dimension,


### PR DESCRIPTION
#### Reference issue
Closes gh-17387.

#### What does this implement/fix?
Clarifies the `signal.freqz` parameter documentation for multidimensional numerator coefficients. The added note makes explicit that a `(n_coefficients, n_filters)` coefficient array needs a trailing length-1 dimension to broadcast over a one-dimensional frequency array.

#### Additional information
Local checks:
- `python -m py_compile scipy/signal/_filter_design.py`
- `git diff --check`

#### AI Generation Disclosure
GPT-5.5 in Cursor was used to help identify the relevant docstring and draft this small wording change. I reviewed the issue discussion, the existing broadcasting example, and the final text before submitting.