### PR TITLE
MAINT: special: Renaming for bivariate normal SF

### DIFF
--- a/scipy/special/_generate_pyx.py
+++ b/scipy/special/_generate_pyx.py
@@ -77,7 +77,7 @@ import re
 import textwrap
 
 special_ufuncs = [
-    '_bivariate_normal_cdf', '_cospi', '_gen_harmonic', '_lambertw',
+    '_bivariate_normal_sf', '_cospi', '_gen_harmonic', '_lambertw',
     '_normalized_gen_harmonic', '_scaled_exp1', '_sinpi', '_von_mises_cdf',
     '_spherical_jn', '_spherical_jn_d', '_spherical_yn', '_spherical_yn_d',
     '_spherical_in', '_spherical_in_d', '_spherical_kn', '_spherical_kn_d',

--- a/scipy/special/_special_ufuncs.cpp
+++ b/scipy/special/_special_ufuncs.cpp
@@ -48,7 +48,7 @@
 // This allows the build process to generate a corresponding entry for scipy.special.cython_special.
 
 extern const char *_cospi_doc;
-extern const char *_bivariate_normal_cdf_doc;
+extern const char *_bivariate_normal_sf_doc;
 extern const char *_sinpi_doc;
 extern const char *_gen_harmonic_doc;
 extern const char *_log1mexp_doc;
@@ -221,9 +221,9 @@ static PyMethodDef _methods[] = {
 
 
 static float
-bivariate_normal_cdf_float(float dh, float dk, float r)
+bivariate_normal_sf_float(float dh, float dk, float r)
 {
-    return static_cast<float>(xsf::bivariate_normal_cdf(dh, dk, r));
+    return static_cast<float>(xsf::bivariate_normal_sf(dh, dk, r));
 }
 
 
@@ -233,11 +233,11 @@ _special_ufuncs_module_exec(PyObject *module)
     if (_import_array() < 0) { return -1; }
     if (_import_umath() < 0) { return -1; }
 
-    PyObject *_bivariate_normal_cdf = xsf::numpy::ufunc(
-        {static_cast<xsf::numpy::fff_f>(bivariate_normal_cdf_float),
-         static_cast<xsf::numpy::ddd_d>(xsf::bivariate_normal_cdf)},
-        "_bivariate_normal_cdf", _bivariate_normal_cdf_doc);
-    PyModule_AddObjectRef(module, "_bivariate_normal_cdf", _bivariate_normal_cdf);
+    PyObject *_bivariate_normal_sf = xsf::numpy::ufunc(
+        {static_cast<xsf::numpy::fff_f>(bivariate_normal_sf_float),
+         static_cast<xsf::numpy::ddd_d>(xsf::bivariate_normal_sf)},
+        "_bivariate_normal_sf", _bivariate_normal_sf_doc);
+    PyModule_AddObjectRef(module, "_bivariate_normal_sf", _bivariate_normal_sf);
 
     PyObject *_cospi =
         xsf::numpy::ufunc({static_cast<xsf::numpy::f_f>(xsf::cospi), static_cast<xsf::numpy::d_d>(xsf::cospi),

--- a/scipy/special/_special_ufuncs_docs.cpp
+++ b/scipy/special/_special_ufuncs_docs.cpp
@@ -2,7 +2,7 @@ const char *_cospi_doc = R"(
     Internal function, do not use.
     )";
 
-const char *_bivariate_normal_cdf_doc = R"(
+const char *_bivariate_normal_sf_doc = R"(
     Internal function, do not use.
     )";
 

--- a/scipy/special/_ufuncs.pyi
+++ b/scipy/special/_ufuncs.pyi
@@ -255,7 +255,7 @@ class errstate:
 
 _cosine_cdf: np.ufunc
 _cosine_invcdf: np.ufunc
-_bivariate_normal_cdf: np.ufunc
+_bivariate_normal_sf: np.ufunc
 _cospi: np.ufunc
 _ellip_harm: np.ufunc
 _factorial: np.ufunc

--- a/scipy/stats/_qmvnt.py
+++ b/scipy/stats/_qmvnt.py
@@ -490,7 +490,6 @@ def _bvn(a, b, A):
     s2 = math.sqrt(A[1, 1])
     s12 = A[0, 1]
     r = s12 / (s1 * s2)
-    # the x and y coordinates seem to be normalized by the standard devs
     xl, xu = a[0] / s1, b[0] / s1
     yl, yu = a[1] / s2, b[1] / s2
     p = _bvnu(xl, yl, r) - _bvnu(xu, yl, r) - _bvnu(xl, yu, r) + _bvnu(xu, yu, r)

--- a/scipy/stats/_qmvnt.py
+++ b/scipy/stats/_qmvnt.py
@@ -37,7 +37,7 @@ import numpy as np
 
 from scipy.fft import fft, ifft
 from scipy.special import ndtr as phi, ndtri as phinv
-from scipy.special._ufuncs import _bivariate_normal_cdf as _bvnu
+from scipy.special._ufuncs import _bivariate_normal_sf as _bvnu
 from scipy.stats._qmc import primes_from_2_to
 
 from ._qmvnt_cy import _qmvn_inner, _qmvt_inner

--- a/scipy/stats/_qmvnt.py
+++ b/scipy/stats/_qmvnt.py
@@ -460,9 +460,32 @@ def _swap_slices(x, slc1, slc2):
 
 
 def _bvn(a, b, A):
-    # covariance matrix is written [[s1**2, rho*s1*s2], [rho*s1*s2, s2**2]]
-    # e.g. https://en.wikipedia.org/wiki/Multivariate_normal_distribution
-    # therefore, s12 = rho*s1*s2 -> rho = s12/(s1*s2)
+    """Bivariate normal integration over box bounds.
+
+    For ``X ~ N(0, A)`` with covariance matrix
+    ``A = [[s1**2, rho*s1*s2], [rho*s1*s2, s2**2]]``, return
+
+        P(a[0] <= X[0] <= b[0], a[1] <= X[1] <= b[1]).
+
+    Parameters
+    ----------
+    a, b : (2,) array_like
+        The low and high integration bounds.
+    A : (2, 2) array_like
+        Covariance matrix.
+
+    Returns
+    -------
+    p : float
+        Probability within the bounds.
+
+    Notes
+    -----
+    Computed via 4-corner inclusion-exclusion on the standardized bivariate normal
+    survival function ``_bvnu`` with correlation ``r = s12 / (s1 * s2)``, where
+    ``s12 = A[0, 1]`` is the covariance between ``X[0]`` and ``X[1]``. The result is
+    clipped to ``[0, 1]``.
+    """
     s1 = math.sqrt(A[0, 0])
     s2 = math.sqrt(A[1, 1])
     s12 = A[0, 1]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Follow up of https://github.com/scipy/xsf/pull/169

#### What does this implement/fix?
- Use correct name `bivariate_normal_sf`
- Improve doc for `_bvn`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Codex drafted a first version for the doc. I was not so happy with it so I updated it manually from there.