### PR TITLE
MAINT: backports/preparation for SciPy  `1.18.0rc2`

### DIFF
--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -147,7 +147,7 @@ New features
 ==============================
 - 3D area calculations are now faster in `scipy.spatial.SphericalVoronoi`.
 - N-dimensional input is now supported for `scipy.spatial.distance.minkowski`,
-  `scipy.spatial.distance.euclidean`, and `scipy.spatial.distance.seuclidean`.
+  `scipy.spatial.distance.euclidean`, and `scipy.spatial.distance.sqeuclidean`.
 - It is now possible to return sparse arrays rather than matrices from
   ``KDTree.sparse_distance_matrix``.
 - It is now possible to compose ``Rotation`` and ``RigidTransform`` directly,
@@ -236,7 +236,7 @@ Deprecated features and future changes
   functionality was rarely used; the function computes the optimal size of the
   work arrays automatically, therefore users should simply remove their uses
   of the ``lwork`` parameter.
-- The sparse construction functions ``kron``, ``kronsum`` and ``build_diag``
+- The sparse construction functions ``kron``, ``kronsum`` and ``block_diag``
   choose return type ``sparray`` or ``spmatrix`` depending on the type of the
   sparse input arrays. When no inputs are sparse, the output is chosen to be
   ``spmatrix``. That has been deprecated. The return type when no inputs are
@@ -344,7 +344,7 @@ Authors
 * Matthias Bussonnier (6)
 * CJ Carey (9)
 * Christine P. Chai (2)
-* Lucas Colley (89)
+* Lucas Colley (90)
 * Dan (3) +
 * devdanzin (2) +
 * Martin Diehl (4)
@@ -398,7 +398,7 @@ Authors
 * Ilhan Polat (190)
 * Adrian Raso (3)
 * Aditya Rawat (1) +
-* Tyler Reddy (83)
+* Tyler Reddy (86)
 * Martin Reinecke (1)
 * Lucas Roberts (6)
 * Pamphile Roy (1)
@@ -546,6 +546,7 @@ Issues closed for 1.18.0
 * `#24943 <https://github.com/scipy/scipy/issues/24943>`__: CI: linalg: dev deps failing due to NumPy deprecation of generic...
 * `#25056 <https://github.com/scipy/scipy/issues/25056>`__: DOC: ``scipy.interpolate.interpn`` with method='linear' accepts...
 * `#25066 <https://github.com/scipy/scipy/issues/25066>`__: DOC: replace broken UiO spline notes references in ``scipy.interpolate``
+* `#25069 <https://github.com/scipy/scipy/issues/25069>`__: BUG: ``scipy.sparse.linalg.svds`` rng argument issue when using...
 * `#25076 <https://github.com/scipy/scipy/issues/25076>`__: BUG: ``cython_lapack`` signatures: ``bint`` variables become...
 * `#25086 <https://github.com/scipy/scipy/issues/25086>`__: BUG: optimize.direct: interpreter crash on empty Bounds
 * `#25106 <https://github.com/scipy/scipy/issues/25106>`__: BUG: ``nct.cdf`` return ``nan``
@@ -1047,6 +1048,7 @@ Pull requests for 1.18.0
 * `#25193 <https://github.com/scipy/scipy/pull/25193>`__: DOC: stats: Note that halfgennorm is a special case of gengamma.
 * `#25194 <https://github.com/scipy/scipy/pull/25194>`__: interpolate: parametrize ``test_spline_large_2d*`` over ``spl_apis``\...
 * `#25197 <https://github.com/scipy/scipy/pull/25197>`__: MAINT: version pins/prep for 1.18.0rc1
+* `#25204 <https://github.com/scipy/scipy/pull/25204>`__: BUG: sparse.linalg.svds: fix ``random_state`` regression for...
 * `#25210 <https://github.com/scipy/scipy/pull/25210>`__: BUG: ``UnivariateDistribution`` mode calculation
 * `#25224 <https://github.com/scipy/scipy/pull/25224>`__: REL: set 1.18.0rc2 unreleased
 * `#25226 <https://github.com/scipy/scipy/pull/25226>`__: MAINT: ``_lib._util``\ : remove trivial ``np_[u]long`` aliases

--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -88,6 +88,8 @@ New features
   providing a substantial speedup for batched input.
 - The performance of `scipy.linalg.expm` has been improved.
 - The performance for `scipy.linalg.solve` has improved for batched inputs.
+- `scipy.linalg.bandwidth` now supports batching for greater than or equal to
+  2 dimensional input.
 
 
 ``scipy.optimize`` improvements
@@ -129,7 +131,8 @@ New features
 - Added ILP64 BLAS/LAPACK support to SuperLU and PROPACK extensions.
 - All sparse array/matrix formats now support ``matrix_transpose``/``.mT``.
 - Support for n-dimensional linear operators has been added to
-  `scipy.sparse.linalg.LinearOperator`.
+  `scipy.sparse.linalg.LinearOperator`, and ``LinearOperator`` now has
+  a new ``rdot`` method.
 - `scipy.sparse.linalg.minres` now supports complex hermitian matrices.
 
 
@@ -173,9 +176,20 @@ New features
 - Support for the ``nan_policy`` keyword argument has been added to:
   `scipy.stats.obrientransform`, `scipy.stats.boxcox`,
   `scipy.stats.boxcox_normmax`, `scipy.stats.yeojohnson`,
-  `scipy.stats.yeojohnson_normmax`, and `scipy.stats.sigmaclip`.
+  `scipy.stats.yeojohnson_normmax`, `scipy.stats.sigmaclip`, and
+  `scipy.stats.expectile`.
 - ``scipy.stats.ContinuousDistribution.lmoment`` has been added for computing
   population L-moments.
+- The new function `scipy.stats.estimated_cdf` has been added. It reproduces
+  much of the functionality of ``stats.mstats.plotting_positions``,
+  ``stats.percentileofscore``, ``stats.ecdf.cdf``, and ``stats.cumfreq``, but
+  is also vectorized.
+- `scipy.stats.ansari` accepts a new ``method`` argument.
+- `scipy.stats.bws_test`, `scipy.stats.expectile`, and
+  `scipy.stats.quantile_test` now accept an ``axis`` argument.
+- `scipy.stats.expectile` and `scipy.stats.quantile_test` accept a new
+  ``keepdims`` argument.
+- `scipy.stats.binomtest` now supports batching of ``k``, ``n``, and ``p``.
 
 
 *********************************
@@ -282,6 +296,15 @@ Backwards incompatible changes
   ``blocksize``) parameters were removed (expired deprecations).
 - The deprecated ``atol`` argument of `scipy.optimize.nnls` has been
   removed.
+- For 2D input, the return type of `scipy.linalg.bandwidth` has changed from
+  ``(int, int)`` to ``(np.int64, np.int64)``.
+- The second return type of `scipy.linalg.cho_factor` changed from ``bool``
+  to ``NDArray[np.bool]``.
+- The second return type of `scipy.interpolate.splint` changed from a 1D
+  ``float64`` array to ``None`` when ``full_output=True``.
+- The types of the ``k`` and ``n`` attributes of the ``BinomTestResult``
+  object returned by `scipy.stats.binomtest` have changed from ``int`` to
+  ``np.float64``.
 
 
 *************
@@ -304,6 +327,7 @@ Other changes
 Authors
 *******
 * Name (commits)
+* h-vetinari (1)
 * Joseph Adams (1) +
 * Adrián Raso González (1) +
 * Virgile Andreani (1)
@@ -313,7 +337,7 @@ Authors
 * Richie Bendall (1) +
 * J Berg (7) +
 * Florian Bourgey (50)
-* Jake Bowhay (98)
+* Jake Bowhay (99)
 * Jonathan Brodrick (1) +
 * Dietrich Brunn (36)
 * Evgeni Burovski (200)
@@ -342,7 +366,7 @@ Authors
 * Ralf Gommers (172)
 * Mathieu Guay-Paquet (1) +
 * Matt Haberland (147)
-* Joren Hammudoglu (24)
+* Joren Hammudoglu (29)
 * Jacob Hass (4)
 * Maya Horii (1) +
 * Guido Imperiale (1)
@@ -366,15 +390,15 @@ Authors
 * Zhang Maiyun (1) +
 * Diego Medina Medina (1) +
 * Elle Musoke (11) +
-* Andrew Nelson (102)
-* Nick ODell (28)
+* Andrew Nelson (103)
+* Nick ODell (29)
 * Dimitri Papadopoulos Orfanos (1)
 * partev (1)
 * Matti Picus (7)
 * Ilhan Polat (190)
 * Adrian Raso (3)
 * Aditya Rawat (1) +
-* Tyler Reddy (94)
+* Tyler Reddy (83)
 * Martin Reinecke (1)
 * Lucas Roberts (6)
 * Pamphile Roy (1)
@@ -391,10 +415,11 @@ Authors
 * Taylor (1) +
 * thecaptain789 (1) +
 * Adam Turner (1)
+* Jacob Vanderplas (1)
 * Christian Veenhuis (2)
 * Sebastiano Vigna (1)
 * Rivka Walles (14) +
-* Warren Weckesser (10)
+* Warren Weckesser (11)
 * Soeren Wolfers (1) +
 * wongaokay (1) +
 * Xuefeng Xu (1)
@@ -405,7 +430,7 @@ Authors
 * Simon Zwieback (1) +
 * ਗਗਨਦੀਪ ਸਿੰਘ (Gagandeep Singh) (19)
 
-    A total of 100 people contributed to this release.
+    A total of 102 people contributed to this release.
     People with a "+" by their names contributed a patch for the first time.
     This list of names is automatically generated, and may not be fully complete.
 
@@ -526,6 +551,7 @@ Issues closed for 1.18.0
 * `#25106 <https://github.com/scipy/scipy/issues/25106>`__: BUG: ``nct.cdf`` return ``nan``
 * `#25133 <https://github.com/scipy/scipy/issues/25133>`__: BUG: signal savgol_filter fails for large >20000 window_length...
 * `#25162 <https://github.com/scipy/scipy/issues/25162>`__: MAINT, TST: a few test failures against NumPy ``2.4.5``
+* `#25180 <https://github.com/scipy/scipy/issues/25180>`__: CI: stats: ``test_continuous.py::TestDistributions::test_funcs``...
 
 ************************
 Pull requests for 1.18.0
@@ -993,6 +1019,7 @@ Pull requests for 1.18.0
 * `#25109 <https://github.com/scipy/scipy/pull/25109>`__: DOC: sparse: add doc-string warnings to match kron/kronsum/block_diag...
 * `#25114 <https://github.com/scipy/scipy/pull/25114>`__: MAINT: special: Remove tabs from boost_special_functions.h
 * `#25119 <https://github.com/scipy/scipy/pull/25119>`__: MAINT/TST: sparse: Require 64 GiB for test_large_assignments()
+* `#25120 <https://github.com/scipy/scipy/pull/25120>`__: DOC: update SciPy 1.18.0 release notes
 * `#25121 <https://github.com/scipy/scipy/pull/25121>`__: DOC: fix typo of "firwin" in iirdesign
 * `#25127 <https://github.com/scipy/scipy/pull/25127>`__: BUG: special: fix subtle ufunc loop bug by updating xsf
 * `#25129 <https://github.com/scipy/scipy/pull/25129>`__: BUG: sparse: Add defensive checks to sparsetools
@@ -1019,3 +1046,16 @@ Pull requests for 1.18.0
 * `#25191 <https://github.com/scipy/scipy/pull/25191>`__: DOC: special: Improve documentation for ``boxcox`` functions
 * `#25193 <https://github.com/scipy/scipy/pull/25193>`__: DOC: stats: Note that halfgennorm is a special case of gengamma.
 * `#25194 <https://github.com/scipy/scipy/pull/25194>`__: interpolate: parametrize ``test_spline_large_2d*`` over ``spl_apis``\...
+* `#25197 <https://github.com/scipy/scipy/pull/25197>`__: MAINT: version pins/prep for 1.18.0rc1
+* `#25210 <https://github.com/scipy/scipy/pull/25210>`__: BUG: ``UnivariateDistribution`` mode calculation
+* `#25224 <https://github.com/scipy/scipy/pull/25224>`__: REL: set 1.18.0rc2 unreleased
+* `#25226 <https://github.com/scipy/scipy/pull/25226>`__: MAINT: ``_lib._util``\ : remove trivial ``np_[u]long`` aliases
+* `#25227 <https://github.com/scipy/scipy/pull/25227>`__: BUG: linalg.fiedler_companion: fix output shape for length-1...
+* `#25228 <https://github.com/scipy/scipy/pull/25228>`__: BUG: linalg: Fix return shape of fiedler([])
+* `#25231 <https://github.com/scipy/scipy/pull/25231>`__: MAINT: fix some minor tolerance violations
+* `#25233 <https://github.com/scipy/scipy/pull/25233>`__: TYP: remove orphaned ``linalg._matfuncs_expm`` stubs
+* `#25237 <https://github.com/scipy/scipy/pull/25237>`__: MAINT: ``stats._distn_infrastructure``\ : namespace pollution
+* `#25240 <https://github.com/scipy/scipy/pull/25240>`__: BUG: ``stats``\ : ``DunnettResult.__class_getitem__`` dataclass...
+* `#25243 <https://github.com/scipy/scipy/pull/25243>`__: BUG: ``stats``\ : fix new distribution ``lmoment`` method signatures
+* `#25275 <https://github.com/scipy/scipy/pull/25275>`__: BUG: interpolate: fix missing DECREF in curfit and percur
+* `#25281 <https://github.com/scipy/scipy/pull/25281>`__: BUG: cluster.vq: fix calling deprecated ``py_vq``

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -22,9 +22,6 @@ from scipy._lib._sparse import issparse
 from numpy.exceptions import AxisError
 
 
-np_long = np.long
-np_ulong = np.ulong
-
 type IntNumber = int | np.integer
 type DecimalNumber = float | np.floating | np.integer
 

--- a/scipy/cluster/vq/_vq_impl.py
+++ b/scipy/cluster/vq/_vq_impl.py
@@ -154,7 +154,7 @@ def vq(obs, code_book, check_finite=True):
         c_code_book = np.asarray(c_code_book)
         result = _vq.vq(c_obs, c_code_book)
         return xp.asarray(result[0]), xp.asarray(result[1])
-    return py_vq(obs, code_book, check_finite=False)
+    return _py_vq(obs, code_book, check_finite=False)
 
 
 def _py_vq(obs, code_book, check_finite=True):

--- a/scipy/cluster/vq/tests/test_vq.py
+++ b/scipy/cluster/vq/tests/test_vq.py
@@ -157,11 +157,13 @@ class TestVq:
         label1 = _py_vq(matrix(X), matrix(initc))[0]
         assert_array_equal(label1, LABEL1)
 
-    def test_vq(self, xp):
+    @pytest.mark.parametrize("dtype", ["float64", "int64"])
+    def test_vq(self, dtype, xp):
+        dtype = getattr(xp, dtype)
         initc = np.concatenate([[X[0]], [X[1]], [X[2]]])
         label1, _ = _vq.vq(X, initc)
         assert_array_equal(label1, LABEL1)
-        _, _ = vq(xp.asarray(X), xp.asarray(initc))
+        _, _ = vq(xp.asarray(X, dtype=dtype), xp.asarray(initc, dtype=dtype))
 
     @pytest.mark.skipif(SCIPY_ARRAY_API,
                         reason='`np.matrix` unsupported in array API mode')

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -972,7 +972,9 @@ fitpack_curfit(PyObject* Py_UNUSED(dummy), PyObject *args)
     Py_DECREF(ap_x);
     Py_DECREF(ap_y);
     Py_DECREF(ap_w);
-    /* Don't decref ap_t, ap_wrk, ap_iwrk - they are modified in-place */
+    Py_DECREF(ap_wrk);
+    Py_DECREF(ap_iwrk);
+    /* Don't decref ap_t - it will be returned */
 
     return Py_BuildValue(("iNNdi"),
                          n, PyArray_Return(ap_t), PyArray_Return(ap_c), fp, ier);
@@ -1076,7 +1078,9 @@ fitpack_percur(PyObject* Py_UNUSED(dummy), PyObject *args)
     Py_DECREF(ap_x);
     Py_DECREF(ap_y);
     Py_DECREF(ap_w);
-    /* Don't decref ap_t, ap_wrk, ap_iwrk - they are modified in-place */
+    Py_DECREF(ap_wrk);
+    Py_DECREF(ap_iwrk);
+    /* Don't decref ap_t - it will be returned */
 
     return Py_BuildValue(("iNNdi"),
                          n, PyArray_Return(ap_t), PyArray_Return(ap_c), fp, ier);

--- a/scipy/interpolate/tests/test_bary_rational.py
+++ b/scipy/interpolate/tests/test_bary_rational.py
@@ -266,7 +266,7 @@ class TestAAA:
         r = AAA(z, f)
 
         zz = np.logspace(-15, 0, 500)
-        assert_allclose(r(zz), np.sqrt(zz), rtol=9e-6)
+        assert_allclose(r(zz), np.sqrt(zz), rtol=1e-5)
 
 
 class BatchFloaterHormann:

--- a/scipy/linalg/_matfuncs_expm.pyi
+++ b/scipy/linalg/_matfuncs_expm.pyi
@@ -1,6 +1,0 @@
-from numpy.typing import NDArray
-from typing import Any
-
-def pick_pade_structure(a: NDArray[Any]) -> tuple[int, int]: ...
-
-def pade_UV_calc(Am: NDArray[Any], m: int) -> int: ...

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1099,6 +1099,8 @@ def fiedler_companion(a):
     if a.size <= 2:
         if a.size == 2:
             return np.array([[-(a/a[0])[-1]]])
+        if a.size == 1:
+            return np.empty((0, 0), dtype=a.dtype)
         return np.array([], dtype=a.dtype)
 
     if a[0] == 0.:

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -1024,7 +1024,7 @@ def fiedler(a):
     a = xpx.atleast_nd(xp.asarray(a), ndim=1)
 
     if xp_size(a) == 0:
-        return xp.asarray([], dtype=xp.float64)
+        return xp.empty((0, 0), dtype=xp.float64)
     elif xp_size(a) == 1:
         return xp.asarray([[0.]])
     else:

--- a/scipy/linalg/meson.build
+++ b/scipy/linalg/meson.build
@@ -315,7 +315,6 @@ python_sources = [
   '_decomp_svd.py',
   '_expm_frechet.py',
   '_matfuncs.py',
-  '_matfuncs_expm.pyi',
   '_matfuncs_inv_ssq.py',
   '_matfuncs_sqrtm.py',
   '_misc.py',

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -515,6 +515,7 @@ def test_dft():
 def test_fiedler(xp):
     f = fiedler(xp.asarray([]))
     assert xp_size(f) == 0
+    assert f.shape == (0, 0)
 
     f = fiedler(xp.asarray([123.]))
     xp_assert_equal(f, xp.asarray([[0.]]))

--- a/scipy/linalg/tests/test_special_matrices.py
+++ b/scipy/linalg/tests/test_special_matrices.py
@@ -534,6 +534,7 @@ def test_fiedler_companion():
     assert_equal(fc.size, 0)
     fc = fiedler_companion([1.])
     assert_equal(fc.size, 0)
+    assert_equal(fc.shape, (0, 0))
     fc = fiedler_companion([1., 2.])
     assert_array_equal(fc, np.array([[-2.]]))
     fc = fiedler_companion([1e-12, 2., 3.])

--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -7,7 +7,6 @@ import operator
 import numpy as np
 from math import prod
 import scipy.sparse as sp
-from scipy._lib._util import np_long, np_ulong
 
 
 __all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
@@ -15,7 +14,7 @@ __all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
            'broadcast_shapes']
 
 supported_dtypes = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc,
-                    np.uintc, np_long, np_ulong, np.longlong, np.ulonglong,
+                    np.uintc, np.long, np.ulong, np.longlong, np.ulonglong,
                     np.float32, np.float64, np.longdouble,
                     np.complex64, np.complex128, np.clongdouble]
 

--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -5,12 +5,11 @@ from pytest import raises as assert_raises
 from scipy import sparse
 
 from scipy.sparse import csgraph
-from scipy._lib._util import np_long, np_ulong
 
 
 def check_int_type(mat):
     return np.issubdtype(mat.dtype, np.signedinteger) or np.issubdtype(
-        mat.dtype, np_ulong
+        mat.dtype, np.ulong
     )
 
 
@@ -161,7 +160,7 @@ def _check_laplacian_dtype(
                 _assert_allclose_sparse(L, mat)
 
 
-INT_DTYPES = (np.intc, np_long, np.longlong)
+INT_DTYPES = (np.intc, np.long, np.longlong)
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 DTYPES = INT_DTYPES + REAL_DTYPES + COMPLEX_DTYPES

--- a/scipy/sparse/linalg/_eigen/_svds.py
+++ b/scipy/sparse/linalg/_eigen/_svds.py
@@ -1,9 +1,8 @@
 import math
-import numbers
 import numpy as np
 from . import eigsh
 
-from scipy._lib._util import _transition_to_rng
+from scipy._lib._util import _transition_to_rng, check_random_state
 from scipy.sparse.linalg._interface import LinearOperator, aslinearoperator
 from scipy.sparse.linalg._eigen.lobpcg import lobpcg  # type: ignore[no-redef]
 from scipy.sparse.linalg._svdp import _svdp
@@ -90,18 +89,7 @@ def _iv(A, k, ncv, tol, which, v0, maxiter,
     if return_singular not in rs_options:
         raise ValueError(f"`return_singular_vectors` must be in {rs_options}.")
 
-    if isinstance(rng, numbers.Integral | np.integer):
-        rng = np.random.default_rng(np.random.RandomState(rng))
-    elif isinstance(rng, np.random.RandomState):
-        rng = np.random.default_rng(rng)
-    elif rng is None:
-        rng = np.random.default_rng()
-    elif isinstance(rng, np.random.Generator):
-        pass
-    else:
-        raise ValueError(f"'{rng}' is neither a NumPy Generator nor an integer seed"
-                         " to instantiate one. For future-proofing, prefer using a"
-                         " NumPy Generator.")
+    rng = check_random_state(rng)
 
     return (A, k, ncv, tol, which, v0, maxiter,
             return_singular, solver, rng)

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -17,13 +17,12 @@ from scipy.sparse import dia_array, eye_array, csr_array
 from scipy.sparse.linalg import eigsh, LinearOperator
 from scipy.sparse.linalg._eigen.lobpcg import lobpcg
 from scipy.sparse.linalg._eigen.lobpcg.lobpcg import _b_orthonormalize
-from scipy._lib._util import np_long, np_ulong
 from scipy.sparse.linalg._special_sparse_arrays import (Sakurai,
                                                         MikotaPair)
 
 _IS_32BIT = (sys.maxsize < 2**32)
 
-INT_DTYPES = (np.intc, np_long, np.longlong, np.uintc, np_ulong, np.ulonglong)
+INT_DTYPES = (np.intc, np.long, np.longlong, np.uintc, np.ulong, np.ulonglong)
 # np.half is unsupported on many test systems so excluded
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)

--- a/scipy/sparse/linalg/_eigen/tests/test_svds.py
+++ b/scipy/sparse/linalg/_eigen/tests/test_svds.py
@@ -423,6 +423,15 @@ class SVDSCommonTests:
             assert_allclose(res1a[idx], res2a[idx], rtol=1e-15, atol=2e-16)
         _check_svds(A, k, *res1a)
 
+    def test_svd_random_state(self):
+        # the legacy `random_state` argument should work for now,
+        # even with NumPy <2.2.
+        # Regression test for gh-25069
+        rng = np.random.default_rng(0)
+        A = rng.random((5, 5))
+        res = svds(A, 1, solver=self.solver, random_state=np.random.RandomState(0))
+        _check_svds(A, 1, *res)
+
     @pytest.mark.filterwarnings("ignore:Exited",
                                 reason="Ignore LOBPCG early exit.")
     def test_svd_rng_3(self):

--- a/scipy/sparse/linalg/_svdp.py
+++ b/scipy/sparse/linalg/_svdp.py
@@ -267,8 +267,19 @@ def _svdp(A, k, which='LM', irl_mode=True, kmax=None,
         works = work, iwork
 
     # Generate the seed for the PROPACK random float generator.
-    rng_state = rng.integers(low=0, high=np.iinfo(np.int64).max,
-                             size=4, dtype=np.uint64)
+    # TODO: once `svds` drops legacy positional `random_state` support,
+    # or once `_lib._util.check_random_state` is adjusted to always
+    # coerce `RandomState` input to a `Generator` instance
+    # (possible from NumPy >=2.2),
+    # the legacy branch can be removed here.
+    if hasattr(rng, "integers"):
+        rng_state = rng.integers(
+            low=0, high=np.iinfo(np.int64).max, size=4, dtype=np.uint64
+        )
+    else:  # legacy np.random.RandomState
+        rng_state = rng.randint(
+            low=0, high=np.iinfo(np.int64).max, size=4, dtype=np.uint64
+        )
 
     if irl_mode:
         info = lansvd_irl(_which_converter[which], jobu,

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -15,11 +15,10 @@ from scipy.sparse.linalg import expm as sp_expm
 from scipy.sparse.linalg._expm_multiply import (_theta, _compute_p_max,
         _onenormest_matrix_power, expm_multiply, _expm_multiply_simple,
         _expm_multiply_interval)
-from scipy._lib._util import np_long
 
 
 IMPRECISE = {np.single, np.csingle}
-REAL_DTYPES = (np.intc, np_long, np.longlong,
+REAL_DTYPES = (np.intc, np.long, np.longlong,
                np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES

--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -60,7 +60,7 @@ from scipy.spatial.distance import (braycurtis, canberra, chebyshev, cityblock,
                                     minkowski, rogerstanimoto,
                                     russellrao, seuclidean,  # noqa: F401
                                     sokalsneath, sqeuclidean, yule)
-from scipy._lib._util import np_long, np_ulong, _apply_over_batch
+from scipy._lib._util import _apply_over_batch
 from scipy.conftest import skip_xp_invalid_arg
 
 
@@ -129,8 +129,8 @@ def load_testing_files():
     eo['pdist-boolean-inp'] = np.bool_(eo['pdist-boolean-inp'])
     eo['random-bool-data'] = np.bool_(eo['random-bool-data'])
     eo['random-float32-data'] = np.float32(eo['random-double-data'])
-    eo['random-int-data'] = np_long(eo['random-int-data'])
-    eo['random-uint-data'] = np_ulong(eo['random-uint-data'])
+    eo['random-int-data'] = np.long(eo['random-int-data'])
+    eo['random-uint-data'] = np.ulong(eo['random-uint-data'])
 
 
 load_testing_files()
@@ -405,8 +405,8 @@ class TestCdist:
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
                              'random-uint-data', 'random-double-data',
                              'random-bool-data']
-        self.valid_upcasts = {'bool': [np_ulong, np_long, np.float32, np.float64],
-                              'uint': [np_long, np.float32, np.float64],
+        self.valid_upcasts = {'bool': [np.ulong, np.long, np.float32, np.float64],
+                              'uint': [np.long, np.float32, np.float64],
                               'int': [np.float32, np.float64],
                               'float32': [np.float64]}
 
@@ -697,8 +697,8 @@ class TestPdist:
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
                              'random-uint-data', 'random-double-data',
                              'random-bool-data']
-        self.valid_upcasts = {'bool': [np_ulong, np_long, np.float32, np.float64],
-                              'uint': [np_long, np.float32, np.float64],
+        self.valid_upcasts = {'bool': [np.ulong, np.long, np.float32, np.float64],
+                              'uint': [np.long, np.float32, np.float64],
                               'int': [np.float32, np.float64],
                               'float32': [np.float64]}
 

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -37,7 +37,6 @@ from scipy.special import ellipe, ellipk, ellipkm1
 from scipy.special import elliprc, elliprd, elliprf, elliprg, elliprj
 from scipy.special import softplus
 from scipy.special import mathieu_odd_coef, mathieu_even_coef, stirling2
-from scipy._lib._util import np_long, np_ulong
 from scipy._lib._array_api import xp_assert_close, xp_assert_equal, SCIPY_ARRAY_API
 
 from scipy.special._basic import (
@@ -2959,7 +2958,7 @@ class TestFactorialFunctions:
         kw = {"k": k, "exact": exact, "extend": extend}
         if exact and k in _FACTORIALK_LIMITS_64BITS.keys():
             n = np.array([_FACTORIALK_LIMITS_32BITS[k]])
-            assert_equal(special.factorialk(n, **kw).dtype, np_long)
+            assert_equal(special.factorialk(n, **kw).dtype, np.long)
             assert_equal(special.factorialk(n + 1, **kw).dtype, np.int64)
             # assert maximality of limits for given dtype
             assert special.factorialk(n + 1, **kw) > np.iinfo(np.int32).max
@@ -4837,8 +4836,8 @@ class TestStirling2:
     def test_numpy_array_unsigned_int_dtype(self, is_exact, comp, kwargs):
         # numpy unsigned integers are allowed as dtype in numpy arrays
         ans = asarray(self.table[4][1:])
-        n = asarray([4, 4, 4, 4], dtype=np_ulong)
-        k = asarray([1, 2, 3, 4], dtype=np_ulong)
+        n = asarray([4, 4, 4, 4], dtype=np.ulong)
+        k = asarray([1, 2, 3, 4], dtype=np.ulong)
         comp(stirling2(n, k, exact=False), ans, **kwargs)
 
     @pytest.mark.parametrize("is_exact, comp, kwargs", [

--- a/scipy/special/tests/test_log1mexp.py
+++ b/scipy/special/tests/test_log1mexp.py
@@ -67,7 +67,7 @@ from scipy.special._ufuncs import _log1mexp
 )
 def test_log1mexp(x, expected):
     observed = _log1mexp(x)
-    assert_allclose(observed, expected, rtol=1e-15)
+    assert_allclose(observed, expected, rtol=1e-15, atol=1e-300)
 
 
 @pytest.mark.parametrize("x", [1.1, 1e10, np.inf])

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -3993,7 +3993,8 @@ for method_name in _remove_scale_methods:
     doc = FunctionDoc(method)
     doc['Parameters'] = [p for p in doc['Parameters'] if p.name != 'scale']
     doc = str(doc).split("\n", 1)[1].lstrip(" \n")  # remove signature
-    method.__doc__ = str(doc)
+    method.__doc__ = doc
+del method_name, method, doc  # pyrefly:ignore[unbound-name]
 
 
 def _expect(fun, lb, ub, x0, inc, maxcount=1000, tolerance=1e-10,

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -56,7 +56,7 @@ _NO_CACHE = "no_cache"
 #    shape parameters - e.g. t distribution with df = np.inf delegates to normal)
 #  Add array API support
 #  Investigate use `median` information throughout, e.g. to improve integration of
-#    CDF or to provide initial bracket for ICDF. (Only if `_median_formula` is
+#    CDF or to provide initial bracket for ICDF. (Only if `_median_formula` is 
 #    provided.)
 #  Document user tips for faster execution:
 #  - pass NumPy arrays
@@ -5290,7 +5290,7 @@ class Mixture(_ProbabilityDistribution):
             out += moment * weight
         return out[()]
 
-    def lmoment(self, order=1, *, standardize=False, method=None):
+    def lmoment(self, order=1, *, standardize=True, method=None):
         message = "L-moments are not currently available for mixture distributions."
         raise NotImplementedError(message)
 

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -56,7 +56,8 @@ _NO_CACHE = "no_cache"
 #    shape parameters - e.g. t distribution with df = np.inf delegates to normal)
 #  Add array API support
 #  Investigate use `median` information throughout, e.g. to improve integration of
-#    CDF or to provide initial bracket for ICDF. (Only if `_median_formula` is provided.)
+#    CDF or to provide initial bracket for ICDF. (Only if `_median_formula` is
+#    provided.)
 #  Document user tips for faster execution:
 #  - pass NumPy arrays
 #  - pass inputs of floating point type (not integers)
@@ -2265,8 +2266,8 @@ class UnivariateDistribution(_ProbabilityDistribution):
         # bracket_minimum fails with status == -1 if the mode is at a boundary.
         # We have to consider this as a special case; there's no way to include
         # this logic in find_minimum; it has to treat the bracket as invalid.
-        mode_at_boundary = res_b.status == -1
-        fl, fm, fr = res_b.bracket
+        mode_at_boundary = res.status == -1
+        fl, fm, fr = res_b.f_bracket
         mode_at_left = mode_at_boundary & (fl <= fm)
         mode_at_right = mode_at_boundary & (fr < fm)
         mode[mode_at_left] = a[mode_at_left]

--- a/scipy/stats/_multicomp.py
+++ b/scipy/stats/_multicomp.py
@@ -1,7 +1,6 @@
 import warnings
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from types import GenericAlias
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -53,9 +52,11 @@ class DunnettResult:
     _ci: ConfidenceInterval | None = field(default=None, repr=False)
     _ci_cl: DecimalNumber | None = field(default=None, repr=False)
 
-    # generic type compatibility with scipy-stubs
-    # pyrefly:ignore[bad-class-definition]
-    __class_getitem__: classmethod = classmethod(GenericAlias)
+    @classmethod
+    def __class_getitem__(cls, arg, /):
+        # generic type compatibility with scipy-stubs
+        from types import GenericAlias
+        return GenericAlias(cls, arg)
 
     def __str__(self):
         # Note: `__str__` prints the confidence intervals from the most

--- a/scipy/stats/_probability_distribution.py
+++ b/scipy/stats/_probability_distribution.py
@@ -341,7 +341,7 @@ class _ProbabilityDistribution(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def lmoment(self, order, kind, *, method):
+    def lmoment(self, order, *, standardize, method):
         r"""L-moment or L-moment ratio of positive integer order.
 
         The L-moment of order :math:`n` of a continuous random variable :math:`X` is:

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -7,9 +7,7 @@ from pytest import raises as assert_raises
 
 import numpy.ma.testutils as ma_npt
 
-from scipy._lib._util import (
-    getfullargspec_no_self as _getfullargspec, np_long
-)
+from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from scipy._lib._array_api_no_0d import xp_assert_equal
 from scipy import stats
 
@@ -231,7 +229,7 @@ def check_random_state_property(distfn, args):
 def check_meth_dtype(distfn, arg, meths):
     q0 = [0.25, 0.5, 0.75]
     x0 = distfn.ppf(q0, *arg)
-    x_cast = [x0.astype(tp) for tp in (np_long, np.float16, np.float32,
+    x_cast = [x0.astype(tp) for tp in (np.long, np.float16, np.float32,
                                        np.float64)]
 
     for x in x_cast:
@@ -260,7 +258,7 @@ def check_cmplx_deriv(distfn, arg):
         return (f(x + h*1j, *arg)/h).imag
 
     x0 = distfn.ppf([0.25, 0.51, 0.75], *arg)
-    x_cast = [x0.astype(tp) for tp in (np_long, np.float16, np.float32,
+    x_cast = [x0.astype(tp) for tp in (np.long, np.float16, np.float32,
                                        np.float64)]
 
     for x in x_cast:

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -2319,3 +2319,10 @@ class Test_logexpxmexpy:
         # operations involving NaNs should not produce warnings
         x = np.asarray(np.nan)
         assert_equal(_logexpxmexpy(x, x), x)
+
+
+def test_gh_25180():
+    lu = _LogUniform(log_a=np.float64(-0.28915434544814245),
+                     log_b=np.float64(0.3085224670197856))
+    actual = lu.mode(method='optimization')
+    assert np.isfinite(actual)


### PR DESCRIPTION
Following a bunch of backport activity and some feedback on release notes/undocumented changes from Joren on the `scipy-stubs` side, this backport PR aims to start getting us ready for SciPy `1.18.0rc2`. A local rebuild of the docs/release notes seems "ok," but we'll see what CI says.

Backports included (so far):

1. gh-25210
2. gh-25226
3. gh-25227
4. gh-25228
5. gh-25231
6. gh-25233
7. gh-25237
8. gh-25240
9. gh-25243
10. gh-25275
11. gh-25281
12. gh-25204


TODO:

- [x] `scipy-stubs` analysis suggested two potential bugs we may want to address (see inline comments) where a domain expert/regular has not commented yet; deferred to: gh-25340
- [x]  account for release notes entries that were missing based on `scipy-stubs` analysis (`scipy-stubs` PRs: [1624](https://github.com/scipy/scipy-stubs/pull/1624 ), [1629](https://github.com/scipy/scipy-stubs/pull/1629), [1642](https://github.com/scipy/scipy-stubs/pull/1642), [1647](https://github.com/scipy/scipy-stubs/pull/1647), [1680](https://github.com/scipy/scipy-stubs/pull/1680), [1681](https://github.com/scipy/scipy-stubs/pull/1681),  and [1683](https://github.com/scipy/scipy-stubs/pull/1683))
- [x] make sure docs are building "ok"/without warnings (CI can differ a bit from my local docs build on warnings sometimes)
- [ ] make sure regular CI is passing here (currently just running the docs CI)
- [x] any other backports we need before RC2 (there is one more open, but not merged: https://github.com/scipy/scipy/pull/25204)
- [x] maybe do a quick check of tests against NumPy `2.5.0rc1` now that that is out; we want to be warning free there
- [x] re-run author/PR list scripts

#### AI Generation Disclosure
No AI tools were used in the preparation of this PR.
