### PR TITLE
DOC: remove fortran mentions

### DIFF
--- a/doc/source/building/compilers_and_options.rst
+++ b/doc/source/building/compilers_and_options.rst
@@ -96,9 +96,9 @@ the ``build`` directory, and install to the ``build-install`` directory.
 
 2. Build with Clang::
 
-    CC=clang CXX=clang++ FC=gfortran spin --build-dir=build-clang build
+    CC=clang CXX=clang++ spin --build-dir=build-clang build
 
-Using the above commands, Meson will build with the Clang, Clang++ and Gfortran
+Using the above commands, Meson will build with the Clang and Clang++
 compilers in the ``build-clang`` directory, and then install SciPy into
 ``build-clang-install``.
 

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -147,7 +147,7 @@ your system.
     1. Mingw-w64 compilers (``gcc``, ``g++``) - *recommended,
        because it's easiest to install and is what we use for SciPy's own CI
        and binaries*
-    2. MSVC
+    2. Clang-cl
     3. Intel compilers (``icc``)
 
     Compared to macOS and Linux, building SciPy on Windows is a little more

--- a/doc/source/building/index.rst
+++ b/doc/source/building/index.rst
@@ -41,7 +41,7 @@ your system.
 
     If you want to use the system Python and ``pip``, you will need:
 
-    * C, C++, and Fortran compilers (typically ``gcc``, ``g++``, and ``gfortran``).
+    * C and C++ compilers (typically ``gcc``, ``g++``).
 
     * Python header files (typically a package named ``python3-dev`` or
       ``python3-devel``)
@@ -59,7 +59,7 @@ your system.
 
         To install SciPy build requirements, you can do::
 
-          sudo apt install -y gcc g++ gfortran libopenblas-dev liblapack-dev pkg-config python3-pip python3-dev
+          sudo apt install -y gcc g++ libopenblas-dev liblapack-dev pkg-config python3-pip python3-dev
 
         Alternatively, you can do::
 
@@ -73,7 +73,7 @@ your system.
 
         To install SciPy build requirements, you can do::
 
-          sudo dnf install gcc-gfortran python3-devel openblas-devel lapack-devel pkgconfig
+          sudo dnf install gcc python3-devel openblas-devel lapack-devel pkgconfig
 
         Alternatively, you can do::
 
@@ -87,7 +87,7 @@ your system.
 
         To install SciPy build requirements, you can do::
 
-          sudo yum install gcc-gfortran python3-devel openblas-devel lapack-devel pkgconfig
+          sudo yum install gcc python3-devel openblas-devel lapack-devel pkgconfig
 
         Alternatively, you can do::
 
@@ -101,7 +101,7 @@ your system.
 
         To install SciPy build requirements, you can do::
 
-          sudo pacman -S gcc-fortran openblas pkgconf
+          sudo pacman -S gcc openblas pkgconf
 
   .. tab-item:: macOS
     :sync: macos
@@ -119,11 +119,11 @@ your system.
     with `the python.org installer <https://www.python.org/downloads/>`__ or
     with a package manager like Homebrew, MacPorts or Fink.
 
-    The other system dependencies you need are a Fortran compiler, BLAS and
+    The other system dependencies you need are BLAS and
     LAPACK libraries, and pkg-config. They're easiest to install with
     `Homebrew <https://brew.sh/>`__::
 
-        brew install gfortran openblas pkg-config
+        brew install openblas pkg-config
 
     To allow the build tools to find OpenBLAS, you must run::
 
@@ -141,16 +141,14 @@ your system.
   .. tab-item:: Windows
     :sync: windows
 
-    A compatible set of C, C++ and Fortran compilers is needed to build SciPy.
-    This is trickier on Windows than on other platforms, because MSVC does not
-    support Fortran, and gfortran and MSVC can't be used together. You will
-    need one of these sets of compilers:
+    A compatible set of C and C++ compilers is needed to build SciPy.
+    You will need one of these sets of compilers:
 
-    1. Mingw-w64 compilers (``gcc``, ``g++``, ``gfortran``) - *recommended,
+    1. Mingw-w64 compilers (``gcc``, ``g++``) - *recommended,
        because it's easiest to install and is what we use for SciPy's own CI
        and binaries*
-    2. MSVC + Intel Fortran (``ifort``)
-    3. Intel compilers (``icc``, ``ifort``)
+    2. MSVC
+    3. Intel compilers (``icc``)
 
     Compared to macOS and Linux, building SciPy on Windows is a little more
     difficult, due to the need to set up these compilers. It is not possible to
@@ -207,17 +205,7 @@ your system.
         can be found) in order to be found, with the exception of MSVC which
         will be found automatically if and only if there are no other compilers
         on the ``PATH``. You can use any shell (e.g., Powershell, ``cmd`` or
-        Git Bash) to invoke a build. To check that this is the case, try
-        invoking a Fortran compiler in the shell you use (e.g., ``gfortran
-        --version`` or ``ifort --version``).
-
-    .. warning::
-
-        When using a conda environment it is possible that the environment
-        creation will not work due to an outdated Fortran compiler. If that
-        happens, remove the ``compilers`` entry from ``environment.yml`` and
-        try again. The Fortran compiler should be installed as described in
-        this section.
+        Git Bash) to invoke a build.
 
 
 Building SciPy from source

--- a/doc/source/dev/contributor/continuous_integration.rst
+++ b/doc/source/dev/contributor/continuous_integration.rst
@@ -150,7 +150,7 @@ are uploaded to the
 repository.
 
 It is not advised to use cibuildwheel to build scipy wheels on your own system
-as it will automatically install gfortran compilers and various other
+as it will automatically install various
 dependencies. Instead, one could use an isolated Docker container to build
 Linux wheels.
 

--- a/doc/source/dev/core-dev/distributing.rst.inc
+++ b/doc/source/dev/core-dev/distributing.rst.inc
@@ -17,7 +17,7 @@ optional.  SciPy tries to keep its dependencies to a minimum; the current requir
 and optional build time dependencies can be seen in `SciPy's configuration file`_, 
 ``pyproject.toml``. The only non-optional runtime dependency is NumPy_.
 
-Furthermore, of course one needs C, C++ and Fortran compilers to build SciPy,
+Furthermore, of course one needs C and C++ compilers to build SciPy,
 but we don't consider those to be dependencies, and therefore they are not discussed
 here.  For details, see :ref:`building-from-source`.
 
@@ -128,7 +128,7 @@ and distributing them on PyPI or elsewhere.
   project and `this thread
   <https://mail.python.org/pipermail/numpy-discussion/2015-October/074056.html>`_ for
   details.
-- The other way to produce 64-bit Windows installers is with ``icc``, ``ifort``
+- The other way to produce 64-bit Windows installers is with ``icc``,
   plus ``MKL`` (or ``MSVC`` instead of ``icc``).  For Intel toolchain
   instructions see
   `this article <https://software.intel.com/en-us/articles/numpyscipy-with-intel-mkl>`_
@@ -139,9 +139,7 @@ and distributing them on PyPI or elsewhere.
   https://github.com/numpy/numpy-vendor.  That build setup is known to not work
   well anymore and is no longer supported.  It used g77 instead of gfortran,
   due to complex DLL distribution issues (see `gh-2829
-  <https://github.com/scipy/scipy/issues/2829>`_).  Because the toolchain is no
-  longer supported, g77 support isn't needed anymore and SciPy can now include
-  Fortran 90/95 code.
+  <https://github.com/scipy/scipy/issues/2829>`_).
 
 **Linux**
 

--- a/doc/source/dev/dev_quickstart.rst
+++ b/doc/source/dev/dev_quickstart.rst
@@ -32,7 +32,7 @@ Basic workflow
     We **strongly** recommend using a user-activated environment setup, such as
     a conda or virtual environment.
 
-Since SciPy contains parts written in C, C++, and Fortran that need to be
+Since SciPy contains parts written in C and C++ that need to be
 compiled before use, make sure you have the necessary compilers and Python
 development headers installed. If you are using ``conda``, these will be
 installed automatically. If you are using ``pip``, check which

--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -78,19 +78,6 @@ Pythran is still an optional build dependency, and can be disabled with
 happen it must be clear that the maintenance burden is low enough.
 
 
-Use of Fortran libraries
-````````````````````````
-SciPy owes a lot of its success to relying on wrapping well established
-Fortran libraries (QUADPACK, FITPACK, ODEPACK etc). The Fortran 77
-that these libraries are written in is quite hard to maintain, and the use
-of Fortran is problematic for many reasons; e.g., it makes our wheel builds
-much harder to maintain, it has repeatedly been problematic for supporting
-new platforms like macOS arm64 and Windows on Arm, and it is highly problematic
-for Pyodide's SciPy support. Our goal is to remove all Fortran code from SciPy
-by replacing the functionality with code written in other languages. Progress
-towards this goal is tracked in `gh-18566 <https://github.com/scipy/scipy/issues/18566>`__.
-
-
 Continuous integration
 ``````````````````````
 Continuous integration currently covers 32/64-bit Windows, macOS on x86-64/arm,

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -149,10 +149,10 @@ Currently, SciPy wheels are being built as follows:
 =========================   ==============================   ====================================   =============================
  Linux x86                   ``ubuntu-22.04``                 GCC 10.2.1                             ``cibuildwheel``
  Linux arm                   ``docker-builder-arm64``         GCC 11.3.0                             ``cibuildwheel``
- OSX x86_64 (OpenBLAS)       ``macos-15-intel``               Apple clang 13.1.6/gfortran 15.2.0     ``cibuildwheel``
- OSX x86_64 (Accelerate)     ``macos-15-intel``               Apple clang 15.0.0/gfortran 13.2.0     ``cibuildwheel``
- OSX arm64 (OpenBLAS)        ``macos-14``                     Apple clang 15.0.0/gfortran 12.1.0     ``cibuildwheel``
- OSX arm64 (Accelerate)      ``macos-14``                     Apple clang 15.0.0/gfortran 13.2.0     ``cibuildwheel``
+ OSX x86_64 (OpenBLAS)       ``macos-15-intel``               Apple clang 13.1.6                     ``cibuildwheel``
+ OSX x86_64 (Accelerate)     ``macos-15-intel``               Apple clang 15.0.0                     ``cibuildwheel``
+ OSX arm64 (OpenBLAS)        ``macos-14``                     Apple clang 15.0.0                     ``cibuildwheel``
+ OSX arm64 (Accelerate)      ``macos-14``                     Apple clang 15.0.0                     ``cibuildwheel``
  Windows                     ``windows-2025``                 GCC 15.2.0 (`rtools`_)                 ``cibuildwheel``
 =========================   ==============================   ====================================   =============================
 
@@ -386,21 +386,6 @@ before we can start considering moving our baseline.
 Compiler support for C++23 and C++26 is still under heavy development [CPP]_.
 
 .. _while yet: https://discourse.llvm.org/t/rfc-clang-17-0-6-would-be-minimum-version-to-build-llvm-in-c-20/75345/8
-
-Fortran Compilers
-~~~~~~~~~~~~~~~~~
-
-Generally, any well-maintained compiler is likely suitable and can be
-used to build SciPy. That said, we do not test with old ``gfortran`` versions,
-which is why we are matching the lower bound with the one for GCC above.
-
-============= =====================================
- Tool          Version
-============= =====================================
-gfortran       >= 9.x
-ifort/ifx      A recent version (not tested in CI)
-flang (LLVM)   >= 17.x
-============= =====================================
 
 
 Cython & Pythran


### PR DESCRIPTION
Removes mentions of Fortran from the documentation.

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Since we've removed fortran from the codebase we need to update the documentation to reflect that. e.g. we no longer need to install fortran compilers.

#### Additional information
I've done my best, but there are going to be lots of things I've missed. I think this is a good start.

#### AI Generation Disclosure
N/A