### PR TITLE
MAINT: special: remove `_ellip_norm` doc and rename tests

### DIFF
--- a/scipy/special/_add_newdocs.py
+++ b/scipy/special/_add_newdocs.py
@@ -77,11 +77,6 @@ add_newdoc("_ellip_harm",
     Internal function, use `ellip_harm` instead.
     """)
 
-add_newdoc("_ellip_norm",
-    """
-    Internal function, use `ellip_norm` instead.
-    """)
-
 add_newdoc("wrightomega",
     r"""
     wrightomega(z, out=None)

--- a/scipy/special/tests/test_ellip_harm.py
+++ b/scipy/special/tests/test_ellip_harm.py
@@ -143,13 +143,10 @@ def test_ellip_normal():
                    (2, 5): G25, (3, 1): G31, (3, 2): G32, (3, 3): G33,
                    (3, 4): G34, (3, 5): G35, (3, 6): G36, (3, 7): G37}
 
-    def _ellip_normal_known_formula(n, p, h2, k2):
+    def _ellip_normal_known_formula(h2, k2, n, p):
         func = known_funcs[n, p]
         return func(h2, k2)
-    _ellip_normal_known_formula = np.vectorize(_ellip_normal_known_formula)
-
-    def ellip_normal_known(h2, k2, n, p):
-        return _ellip_normal_known_formula(n, p, h2, k2)
+    ellip_normal_known = np.vectorize(_ellip_normal_known_formula)
 
     # generate both large and small h2 < k2 pairs
     np.random.seed(1234)

--- a/scipy/special/tests/test_ellip_harm.py
+++ b/scipy/special/tests/test_ellip_harm.py
@@ -66,7 +66,7 @@ def test_ellip_potential():
             assert_(abs(result - exact) < 10*abs(last_term), err_msg)
 
 
-def test_ellip_norm():
+def test_ellip_normal():
 
     def G01(h2, k2):
         return 4*pi
@@ -143,13 +143,13 @@ def test_ellip_norm():
                    (2, 5): G25, (3, 1): G31, (3, 2): G32, (3, 3): G33,
                    (3, 4): G34, (3, 5): G35, (3, 6): G36, (3, 7): G37}
 
-    def _ellip_norm(n, p, h2, k2):
+    def _ellip_normal_known_formula(n, p, h2, k2):
         func = known_funcs[n, p]
         return func(h2, k2)
-    _ellip_norm = np.vectorize(_ellip_norm)
+    _ellip_normal_known_formula = np.vectorize(_ellip_normal_known_formula)
 
     def ellip_normal_known(h2, k2, n, p):
-        return _ellip_norm(n, p, h2, k2)
+        return _ellip_normal_known_formula(n, p, h2, k2)
 
     # generate both large and small h2 < k2 pairs
     np.random.seed(1234)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
- Rename tests so it matches the public API [special.ellip_normal](https://docs.scipy.org/doc/scipy/reference/generated/scipy.special.ellip_normal.html)
- Remove dead old doc `_ellip_norm`

#### Additional information
While working on https://github.com/scipy/xsf/issues/170

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

This was flagged by Codex. Changes are mine.