### PR TITLE
MAINT: special: remove unused `_ellipk.pxd`

### DIFF
--- a/scipy/special/_ellipk.pxd
+++ b/scipy/special/_ellipk.pxd
@@ -1,6 +1,0 @@
-cdef extern from "xsf_wrappers.h" nogil:
-    double cephes_ellpk_wrap(double x)
-
-
-cdef inline double ellipk(double m) noexcept nogil:
-    return cephes_ellpk_wrap(1.0 - m)

--- a/scipy/special/cython_special.pyx
+++ b/scipy/special/cython_special.pyx
@@ -1453,10 +1453,6 @@ cdef extern from r"_ufuncs_defs.h":
 cdef extern from r"_ufuncs_defs.h":
     cdef npy_double _func_ellik "ellik"(npy_double, npy_double)nogil
 
-from ._ellipk cimport ellipk as _func_ellipk
-ctypedef double _proto_ellipk_t(double) noexcept nogil
-cdef _proto_ellipk_t *_proto_ellipk_t_var = &_func_ellipk
-
 from ._convex_analysis cimport entr as _func_entr
 ctypedef double _proto_entr_t(double) noexcept nogil
 cdef _proto_entr_t *_proto_entr_t_var = &_func_entr

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -7,7 +7,6 @@ _ufuncs_pxi_pxd_sources = [
   fs.copyfile('_convex_analysis.pxd'),
   fs.copyfile('_ellip_harm.pxd'),
   fs.copyfile('_ellip_harm_2.pxd'),
-  fs.copyfile('_ellipk.pxd'),
   fs.copyfile('_hyp0f1.pxd'),
   fs.copyfile('_hypergeometric.pxd'),
   fs.copyfile('_legacy.pxd'),


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Same as #25300

#### What does this implement/fix?
- Remove `special/_ellipk.pxd`
- Drop it from Meson copy list
- Remove cimport in `special/cython_special.pyx`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI