### PR TITLE
MAINT, TST: another round of np 2 cleanups

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -25,8 +25,6 @@ from numpy.exceptions import AxisError
 type IntNumber = int | np.integer
 type DecimalNumber = float | np.floating | np.integer
 
-copy_if_needed: bool | None = None
-
 
 # Wrapped function for inspect.signature for compatibility with Python 3.14+
 # See gh-23913

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -26,8 +26,6 @@ from numpy.exceptions import AxisError
 type IntNumber = int | np.integer
 type DecimalNumber = float | np.floating | np.integer
 
-copy_if_needed: bool | None = None
-
 
 # Wrapped function for inspect.signature for compatibility with Python 3.14+
 # See gh-23913

--- a/scipy/fft/_duccfft/helper.py
+++ b/scipy/fft/_duccfft/helper.py
@@ -6,7 +6,6 @@ import contextlib
 
 import numpy as np
 
-from scipy._lib._util import copy_if_needed
 from scipy._lib._array_api import xp_capabilities
 
 # good_size is exposed (and used) from this import
@@ -128,7 +127,7 @@ def _asfarray(x):
     # Require native byte order
     dtype = x.dtype.newbyteorder('=')
     # Always align input
-    copy = True if not x.flags['ALIGNED'] else copy_if_needed
+    copy = True if not x.flags['ALIGNED'] else None
     return np.array(x, dtype=dtype, copy=copy)
 
 def _datacopied(arr, original):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -9,7 +9,6 @@ import numpy as np
 from numpy import array, asarray, intp, poly1d, searchsorted
 
 import scipy.special as spec
-from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
 from scipy._lib._array_api import (
@@ -303,11 +302,9 @@ class interp1d(_Interpolator1D):
 
         self.bounds_error = bounds_error  # used by fill_value setter
 
-        # `copy` keyword semantics changed in NumPy 2.0, once that is
-        # the minimum version this can use `copy=None`.
         self.copy = copy
         if not copy:
-            self.copy = copy_if_needed
+            self.copy = None
 
         if kind in ['zero', 'slinear', 'quadratic', 'cubic']:
             order = {'zero': 0, 'slinear': 1,
@@ -938,10 +935,7 @@ class _PPoly(_PPolyBase):
             return r[0]
         else:
             r2 = np.empty(prod(self.c.shape[2:]), dtype=object)
-            # this for-loop is equivalent to ``r2[...] = r``, but that's broken
-            # in NumPy 1.6.0
-            for ii, root in enumerate(r):
-                r2[ii] = root
+            r2[:] = r
 
             return r2.reshape(self.c.shape[2:])
 
@@ -2207,7 +2201,7 @@ class BPoly:
         So that f'(1-0) = -1 and f'(1+0) = 2
 
         """
-        if isinstance(yi, (list, tuple)):
+        if isinstance(yi, list | tuple):
             # yi is documented as accepting arrays or lists of
             # arrays.  The following line with star unpacking will not
             # work for array ``yi`` for some backends because some are
@@ -2217,7 +2211,7 @@ class BPoly:
             xp = array_namespace(xi, yi)
         xp_cls, xp_internal = _get_xp_bpoly_cls(xp)
         xi = xp_internal.asarray(xi)
-        if isinstance(yi, (list, tuple)):
+        if isinstance(yi, list | tuple):
             # If yi is a ragged list or tuple of arrays, then need to apply
             # xp_internal.asarray separately over each element.
             yi = list(map(xp_internal.asarray, yi))

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -936,7 +936,7 @@ class _PPoly(_PPolyBase):
             return r[0]
         else:
             r2 = np.empty(prod(self.c.shape[2:]), dtype=object)
-            r2[:] = r
+            r2[...] = r
 
             return r2.reshape(self.c.shape[2:])
 

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -9,7 +9,6 @@ import numpy as np
 from numpy import array, asarray, intp, poly1d, searchsorted
 
 import scipy.special as spec
-from scipy._lib._util import copy_if_needed
 from scipy.special import comb
 
 from scipy._lib._array_api import (
@@ -304,11 +303,9 @@ class interp1d(_Interpolator1D):
 
         self.bounds_error = bounds_error  # used by fill_value setter
 
-        # `copy` keyword semantics changed in NumPy 2.0, once that is
-        # the minimum version this can use `copy=None`.
         self.copy = copy
         if not copy:
-            self.copy = copy_if_needed
+            self.copy = None
 
         if kind in ['zero', 'slinear', 'quadratic', 'cubic']:
             order = {'zero': 0, 'slinear': 1,
@@ -939,10 +936,7 @@ class _PPoly(_PPolyBase):
             return r[0]
         else:
             r2 = np.empty(prod(self.c.shape[2:]), dtype=object)
-            # this for-loop is equivalent to ``r2[...] = r``, but that's broken
-            # in NumPy 1.6.0
-            for ii, root in enumerate(r):
-                r2[ii] = root
+            r2[:] = r
 
             return r2.reshape(self.c.shape[2:])
 
@@ -2270,7 +2264,7 @@ class BPoly:
         So that f'(1-0) = -1 and f'(1+0) = 2
 
         """
-        if isinstance(yi, (list, tuple)):
+        if isinstance(yi, list | tuple):
             # yi is documented as accepting arrays or lists of
             # arrays.  The following line with star unpacking will not
             # work for array ``yi`` for some backends because some are
@@ -2282,7 +2276,7 @@ class BPoly:
         yi_seq = yi if isinstance(yi, (list, tuple)) else (yi,)
         device = xp_result_device(xi, *yi_seq)
         xi = xp_internal.asarray(xi)
-        if isinstance(yi, (list, tuple)):
+        if isinstance(yi, list | tuple):
             # If yi is a ragged list or tuple of arrays, then need to apply
             # xp_internal.asarray separately over each element.
             yi = list(map(xp_internal.asarray, yi))

--- a/scipy/optimize/_nonlin.py
+++ b/scipy/optimize/_nonlin.py
@@ -13,7 +13,7 @@ from scipy.linalg import norm, solve, inv, qr, svd, LinAlgError
 import scipy.sparse.linalg
 import scipy.sparse
 from scipy.linalg import get_blas_funcs
-from scipy._lib._util import copy_if_needed, _dedent_for_py313
+from scipy._lib._util import _dedent_for_py313
 from scipy._lib._util import getfullargspec_no_self as _getfullargspec
 from ._linesearch import scalar_search_wolfe1, scalar_search_armijo
 from inspect import signature
@@ -746,7 +746,7 @@ class LowRankMatrix:
 
     def collapse(self):
         """Collapse the low-rank matrix to a full-rank one."""
-        self.collapsed = np.array(self, copy=copy_if_needed)
+        self.collapsed = np.array(self, copy=None)
         self.cs = None
         self.ds = None
         self.alpha = None

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -50,10 +50,6 @@ def _is_int_type(x):
     Check if input is of a scalar integer type (so ``5`` and ``array(5)`` will
     pass, while ``5.0`` and ``array([5])`` will fail.
     """
-    if np.ndim(x) != 0:
-        # Older versions of NumPy did not raise for np.array([1]).__index__()
-        # This is safe to remove when support for those versions is dropped
-        return False
     try:
         operator.index(x)
     except TypeError:

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -942,6 +942,7 @@ class TestFreqz:
                     assert_array_almost_equal(w, expected_w)
                     assert_array_almost_equal(h, expected_h, decimal=4)
 
+    @pytest.mark.skip_xp_backends('dask.array', reason="gh-25317")
     def test_broadcasting1(self, xp):
         # Test broadcasting with worN an integer or a 1-D array,
         # b and a are n-dimensional arrays.
@@ -994,6 +995,7 @@ class TestFreqz:
                     xp_assert_close(ww, xp.asarray(w[k])[None])
                     xp_assert_close(hh, xp.asarray(h[k])[None])
 
+    @pytest.mark.skip_xp_backends('dask.array', reason="gh-25317")
     def test_broadcasting4(self, xp):
         # Test broadcasting with worN a 2-D array.
         np.random.seed(123)

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -8,7 +8,6 @@ from warnings import warn
 
 import numpy as np
 
-from scipy._lib._util import copy_if_needed
 from ._matrix import spmatrix
 from ._data import _data_matrix, _minmax_mixin
 from ._compressed import _cs_matrix
@@ -83,7 +82,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
                 idx_dtype = self._get_index_dtype((indices, indptr), maxval=maxval,
                                                   check_contents=True)
                 if not copy:
-                    copy = copy_if_needed
+                    copy = None
                 self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                 self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                 self.data = getdata(data, copy=copy, dtype=dtype)

--- a/scipy/sparse/_bsr.py
+++ b/scipy/sparse/_bsr.py
@@ -9,7 +9,6 @@ from warnings import warn
 
 import numpy as np
 
-from scipy._lib._util import copy_if_needed
 from ._matrix import spmatrix
 from ._data import _data_matrix, _minmax_mixin
 from ._compressed import _cs_matrix
@@ -84,7 +83,7 @@ class _bsr_base(_cs_matrix, _minmax_mixin):
                 idx_dtype = self._get_index_dtype((indices, indptr), maxval=maxval,
                                                   check_contents=True)
                 if not copy:
-                    copy = copy_if_needed
+                    copy = None
                 self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                 self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                 self.data = getdata(data, copy=copy, dtype=dtype)

--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -5,7 +5,7 @@ from warnings import warn
 import itertools
 
 import numpy as np
-from scipy._lib._util import _prune_array, copy_if_needed
+from scipy._lib._util import _prune_array
 
 from ._base import _spbase, issparse, sparray, SparseEfficiencyWarning
 from ._data import _data_matrix, _minmax_mixin
@@ -72,7 +72,7 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
                                                 check_contents=True)
 
                     if not copy:
-                        copy = copy_if_needed
+                        copy = None
                     self.indices = np.array(indices, copy=copy, dtype=idx_dtype)
                     self.indptr = np.array(indptr, copy=copy, dtype=idx_dtype)
                     self.data = np.array(data, copy=copy, dtype=dtype)

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -9,7 +9,6 @@ from warnings import warn
 
 import numpy as np
 
-from .._lib._util import copy_if_needed
 from ._matrix import spmatrix
 from ._sparsetools import (coo_tocsr, coo_todense, coo_todense_nd,
                            coo_matvec, coo_matvec_nd, coo_matmat_dense,
@@ -32,7 +31,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
     def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
         _data_matrix.__init__(self, arg1, maxprint=maxprint)
         if not copy:
-            copy = copy_if_needed
+            copy = None
 
         if isinstance(arg1, tuple):
             if isshape(arg1, allow_nd=self._allow_nd):

--- a/scipy/sparse/_coo.py
+++ b/scipy/sparse/_coo.py
@@ -10,7 +10,6 @@ from warnings import warn
 
 import numpy as np
 
-from .._lib._util import copy_if_needed
 from ._matrix import spmatrix
 from ._sparsetools import (coo_tocsr, coo_todense, coo_todense_nd,
                            coo_matvec, coo_matvec_nd, coo_matmat_dense,
@@ -33,7 +32,7 @@ class _coo_base(_data_matrix, _minmax_mixin):
     def __init__(self, arg1, shape=None, dtype=None, copy=False, *, maxprint=None):
         _data_matrix.__init__(self, arg1, maxprint=maxprint)
         if not copy:
-            copy = copy_if_needed
+            copy = None
 
         if isinstance(arg1, tuple):
             if isshape(arg1, allow_nd=self._allow_nd):

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -6,7 +6,7 @@ __all__ = ['dia_array', 'dia_matrix', 'isspmatrix_dia']
 
 import numpy as np
 
-from .._lib._util import _prune_array, copy_if_needed
+from .._lib._util import _prune_array
 from ._matrix import spmatrix
 from ._base import issparse, _formats, _spbase, sparray
 from ._data import _data_matrix
@@ -57,7 +57,7 @@ class _dia_base(_data_matrix):
                     if shape is None:
                         raise ValueError('expected a shape argument')
                     if not copy:
-                        copy = copy_if_needed
+                        copy = None
                     self.data = np.atleast_2d(np.array(arg1[0], dtype=dtype, copy=copy))
                     offsets = np.array(arg1[1],
                                        dtype=self._get_index_dtype(maxval=max(shape)),

--- a/scipy/sparse/_dia.py
+++ b/scipy/sparse/_dia.py
@@ -8,7 +8,7 @@ import numpy as np
 import os
 from warnings import warn
 
-from .._lib._util import _prune_array, copy_if_needed
+from .._lib._util import _prune_array
 from ._matrix import spmatrix
 from ._base import issparse, _formats, _spbase, sparray
 from ._data import _data_matrix
@@ -59,7 +59,7 @@ class _dia_base(_data_matrix):
                     if shape is None:
                         raise ValueError('expected a shape argument')
                     if not copy:
-                        copy = copy_if_needed
+                        copy = None
                     self.data = np.atleast_2d(np.array(arg1[0], dtype=dtype, copy=copy))
                     getdtype(self.data.dtype)  # check that dtype is supported
                     offsets = np.array(arg1[1],

--- a/scipy/sparse/linalg/_dsolve/linsolve.py
+++ b/scipy/sparse/linalg/_dsolve/linsolve.py
@@ -643,7 +643,7 @@ def factorized(A):
 
         def solve(b):
             with np.errstate(divide="ignore", invalid="ignore"):
-                # Ignoring warnings with numpy >= 1.23.0, see gh-16523
+                # Ignoring warnings, see gh-16523
                 result = umf.solve(umfpack.UMFPACK_A, A, b, autoTranspose=True)
 
             return result

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -1028,8 +1028,7 @@ def test_permute_dims():
     sXXtransposed = sXX.transpose(axes=(0, 2, 1, 3))
     assert_equal(sXXtransposed.shape, (3, 2, 2, 3))
     assert_equal(sXXpermuted.toarray(), sXXtransposed.toarray())
-    # TODO change np.transpose to np.permute_dims when numpy 2 is min supported version
-    assert_equal(sXXpermuted.toarray(), np.transpose(npxx, axes=(0, 2, 1, 3)))
+    assert_equal(sXXpermuted.toarray(), np.permute_dims(npxx, axes=(0, 2, 1, 3)))
 
 
 def test_3d_permute_dims():
@@ -1040,8 +1039,7 @@ def test_3d_permute_dims():
     out = construct.permute_dims(A, axes=(2, 1, 0))
     assert_equal(out.shape, (2, 4, 1))
     assert_equal(out.toarray(), tgt)
-    # TODO change np.transpose to np.permute_dims when numpy 2 is min supported version
-    assert_equal(out.toarray(), np.transpose(x, axes=(2, 1, 0)))
+    assert_equal(out.toarray(), np.permute_dims(x, axes=(2, 1, 0)))
 
 
 def test_canonical_format_permute_dims():
@@ -1100,8 +1098,7 @@ def test_sparse_format_permute_dims(format):
     out = construct.permute_dims(SA, axes=(1, 0))
     assert out.format == "coo"
     assert out.shape == (3, 2)
-    # TODO change np.transpose to np.permute_dims when numpy 2 is min supported version
-    assert_equal(out.toarray(), np.transpose(A, axes=(1, 0)))
+    assert_equal(out.toarray(), np.permute_dims(A, axes=(1, 0)))
     assert not out.has_canonical_format
 
 

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -1075,8 +1075,7 @@ def test_permute_dims():
     sXXtransposed = sXX.transpose(axes=(0, 2, 1, 3))
     assert_equal(sXXtransposed.shape, (3, 2, 2, 3))
     assert_equal(sXXpermuted.toarray(), sXXtransposed.toarray())
-    # TODO change np.transpose to np.permute_dims when numpy 2 is min supported version
-    assert_equal(sXXpermuted.toarray(), np.transpose(npxx, axes=(0, 2, 1, 3)))
+    assert_equal(sXXpermuted.toarray(), np.permute_dims(npxx, axes=(0, 2, 1, 3)))
 
 
 def test_3d_permute_dims():
@@ -1087,8 +1086,7 @@ def test_3d_permute_dims():
     out = construct.permute_dims(A, axes=(2, 1, 0))
     assert_equal(out.shape, (2, 4, 1))
     assert_equal(out.toarray(), tgt)
-    # TODO change np.transpose to np.permute_dims when numpy 2 is min supported version
-    assert_equal(out.toarray(), np.transpose(x, axes=(2, 1, 0)))
+    assert_equal(out.toarray(), np.permute_dims(x, axes=(2, 1, 0)))
 
 
 def test_canonical_format_permute_dims():
@@ -1147,8 +1145,7 @@ def test_sparse_format_permute_dims(format):
     out = construct.permute_dims(SA, axes=(1, 0))
     assert out.format == "coo"
     assert out.shape == (3, 2)
-    # TODO change np.transpose to np.permute_dims when numpy 2 is min supported version
-    assert_equal(out.toarray(), np.transpose(A, axes=(1, 0)))
+    assert_equal(out.toarray(), np.permute_dims(A, axes=(1, 0)))
     assert not out.has_canonical_format
 
 

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -306,8 +306,7 @@ def test_upcast():
                 b = b0.copy().astype(b_dtype)
             else:
                 with np.errstate(invalid="ignore"):
-                    # Casting a large value (2**32) to int8 causes a warning in
-                    # numpy >1.23
+                    # Casting a large value (2**32) to int8 causes a warning
                     b = b0.real.copy().astype(b_dtype)
 
             if not (a_dtype == np.bool_ and b_dtype == np.bool_):

--- a/scipy/sparse/tests/test_sparsetools.py
+++ b/scipy/sparse/tests/test_sparsetools.py
@@ -307,8 +307,7 @@ def test_upcast():
                 b = b0.copy().astype(b_dtype)
             else:
                 with np.errstate(invalid="ignore"):
-                    # Casting a large value (2**32) to int8 causes a warning in
-                    # numpy >1.23
+                    # Casting a large value (2**32) to int8 causes a warning
                     b = b0.real.copy().astype(b_dtype)
 
             if not (a_dtype == np.bool_ and b_dtype == np.bool_):

--- a/scipy/spatial/_ckdtree.pyx
+++ b/scipy/spatial/_ckdtree.pyx
@@ -9,7 +9,6 @@
 
 import numpy as np
 import scipy.sparse
-from scipy._lib._util import copy_if_needed
 
 cimport numpy as np
 
@@ -573,7 +572,7 @@ cdef class cKDTree:
         self._python_tree = None
 
         if not copy_data:
-            copy_data = copy_if_needed
+            copy_data = None
         data = np.array(data, order='C', copy=copy_data, dtype=np.float64)
 
         # read-only view so ban people modifying tree.data after the tree is

--- a/scipy/special/_test_internal.pyx
+++ b/scipy/special/_test_internal.pyx
@@ -50,17 +50,8 @@ def have_fenv():
 
 
 def random_double(size, rng):
-    # This code is a little hacky to work around some issues:
-    # - randint doesn't have a dtype keyword until 1.11
-    #   and the default dtype of randint is np.dtype(int)
-    # - Something like
-    #   >>> low = np.iinfo(np.dtype(int)).min
-    #   >>> high = np.iinfo(np.dtype(int)).max + 1
-    #   >>> np.random.randint(low=low, high=high)
-    #   fails in NumPy 1.10.4 (note that the 'high' value in randint
-    #   is exclusive); this is fixed in 1.11.
-    x = rng.randint(low=0, high=2**16, size=4*size)
-    return x.astype(np.uint16).view(np.float64)
+    x = rng.randint(low=0, high=2**16, size=4*size, dtype=np.uint16)
+    return x.view(np.float64)
 
 
 def test_add_round(size, mode, rng):

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -209,11 +209,9 @@ def check_random_state_property(distfn, args):
     r2 = distfn.rvs(*args, size=8)
     npt.assert_equal(r0, r2)
 
-    # check that np.random.Generator can be used (numpy >= 1.17)
-    if hasattr(np.random, 'default_rng'):
-        # obtain a np.random.Generator object
-        rng = np.random.default_rng(1234)
-        distfn.rvs(*args, size=1, random_state=rng)
+    # obtain a np.random.Generator object
+    rng = np.random.default_rng(1234)
+    distfn.rvs(*args, size=1, random_state=rng)
 
     # can override the instance-level random_state for an individual .rvs call
     distfn.random_state = 2

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -621,12 +621,9 @@ def test_seed():
         rstate2 = np.random.RandomState(seed=138)
         samp2 = gkde_trail.resample(n_sample, seed=rstate2)
         assert_allclose(samp1, samp2, atol=1e-13)
-
-        # check that np.random.Generator can be used (numpy >= 1.17)
-        if hasattr(np.random, 'default_rng'):
-            # obtain a np.random.Generator object
-            rng = np.random.default_rng(1234)
-            gkde_trail.resample(n_sample, seed=rng)
+        # obtain a np.random.Generator object
+        rng = np.random.default_rng(1234)
+        gkde_trail.resample(n_sample, seed=rng)
 
     rng = np.random.default_rng(8765678)
     n_basesample = 500


### PR DESCRIPTION
* The `copy_if_needed` construct is no longer needed now that we have runtime NumPy >= 2.

* Address some comments about using `permute_dims` in some tests, instead of `transpose`, presumably because `permute_dims` is in the standard, etc.

* Fix some cases where we were checking for older NumPy `random` machinery in testing.

* A few other minor cleanups related to NumPy >= 2.

#### AI Generation Disclosure
No AI tools used