### PR TITLE
ENH: linalg.eigh: move batching loop into C

### DIFF
--- a/benchmarks/benchmarks/linalg.py
+++ b/benchmarks/benchmarks/linalg.py
@@ -215,6 +215,24 @@ class BatchedEigBench(Benchmark):
             sl.eig(self.a)
 
 
+class BatchedEighBench(Benchmark):
+    params = [
+        [(10, 10, 3, 3), (100, 10, 10), (100, 20, 20), (100, 100, 100), (100, 100)],
+        ["scipy", "numpy"]
+    ]
+    param_names = ["shape", "module"]
+
+    def setup(self, shape, module):
+        a_sqrt = random(shape)
+        self.a = a_sqrt @ a_sqrt.swapaxes(-2, -1)
+
+    def time_eigh(self, shape, module):
+        if module == "numpy":
+            nl.eigh(self.a)
+        else:
+            sl.eigh(self.a)
+
+
 class BatchedCholeskyBench(Benchmark):
     params = [
         [(100, 3, 3), (100, 10, 10), (100, 20, 20), (100, 100, 100), (100, 100)],

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -17,8 +17,8 @@ __all__ = ['eig', 'eigvals', 'eigh', 'eigvalsh',
            'eigh_tridiagonal', 'eigvalsh_tridiagonal', 'hessenberg', 'cdf2rdf']
 
 import numpy as np
-from numpy import (array, isfinite, inexact, nonzero, iscomplexobj,
-                   asarray, argsort, empty, iscomplex, zeros, einsum, eye, inf)
+from numpy import (array, isfinite, inexact, nonzero, asarray, argsort, empty,
+                    iscomplex, zeros, einsum, eye, inf)
 # Local imports
 from scipy._lib._util import _asarray_validated, _apply_over_batch, _deprecate_dtypes
 from ._misc import LinAlgError, _datacopied
@@ -308,7 +308,6 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     return w, vr
 
 
-@_apply_over_batch(('a', 2), ('b', 2))
 def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
          overwrite_b=False, type=1, check_finite=True, subset_by_index=None,
          subset_by_value=None, driver=None):
@@ -329,10 +328,10 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
 
     Parameters
     ----------
-    a : (M, M) array_like
+    a : (..., M, M) array_like
         A complex Hermitian or real symmetric matrix whose eigenvalues and
         eigenvectors will be computed.
-    b : (M, M) array_like, optional
+    b : (..., M, M) array_like, optional
         A complex Hermitian or real symmetric definite positive matrix in.
         If omitted, identity matrix is assumed.
     lower : bool, optional
@@ -372,7 +371,9 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         If provided, this two-element iterable defines the half-open interval
         ``(a, b]`` that, if any, only the eigenvalues between these values
         are returned. Only available with "evr", "evx", and "gvx" drivers. Use
-        ``np.inf`` for the unconstrained ends.
+        ``np.inf`` for the unconstrained ends. Not supported for > 2D inputs
+        due to the possibility of different numbers of selected eigenvalues
+        per slice.
     driver : str, optional
         Defines which LAPACK driver should be used. Valid options are "ev",
         "evd", "evr", "evx" for standard problems and "gv", "gvd", "gvx" for
@@ -382,10 +383,10 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
 
     Returns
     -------
-    w : (N,) ndarray
+    w : (..., N) ndarray
         The N (N<=M) selected eigenvalues, in ascending order, each
         repeated according to its multiplicity.
-    v : (M, N) ndarray
+    v : (..., M, N) ndarray
         The normalized eigenvector corresponding to the eigenvalue ``w[i]`` is
         the column ``v[:,i]``. Only returned if ``eigvals_only=False``.
 
@@ -474,81 +475,100 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
     (5, 1)
 
     """
-    # set lower
-    uplo = 'L' if lower else 'U'
-    # Set job for Fortran routines
-    _job = 'N' if eigvals_only else 'V'
+    # keep in sync with C
+    drivers = {
+        "ev": 1,
+        "evd": 2,
+        "evr": 3,
+        "evx": 4,
+        "gv": 10,
+        "gvd": 11,
+        "gvx": 12,
+    }
 
+    ## General bookkeeping
     drv_str = [None, "ev", "evd", "evr", "evx", "gv", "gvd", "gvx"]
     if driver not in drv_str:
         raise ValueError('"{}" is unknown. Possible values are "None", "{}".'
                          ''.format(driver, '", "'.join(drv_str[1:])))
 
+    ## Check input arrays
     a1 = _asarray_validated(a, check_finite=check_finite)
-    if len(a1.shape) != 2 or a1.shape[0] != a1.shape[1]:
-        raise ValueError('expected square "a" matrix')
+    _deprecate_dtypes("linalg.eigh", a1)
+    if a1.ndim < 2 or a1.shape[-2] != a1.shape[-1]:
+        raise ValueError(f"Expected 'a' array with square slices, got {a1.shape=}")
+
+    n = a1.shape[-1]
+    a1, overwrite_a = _normalize_lapack_dtype(a1, overwrite_a)
+    a1, overwrite_a = _ensure_aligned_and_native(a1, overwrite_a)
+    overwrite_a = overwrite_a or _datacopied(a1, a)
+    overwrite_a = overwrite_a and a1.ndim == 2 and a1.flags["F_CONTIGUOUS"]
 
     # accommodate square empty matrices
+    # XXX: account for what happens when `b` upcasts `a`?
     if a1.size == 0:
-        w_n, v_n = eigh(np.eye(2, dtype=a1.dtype))
-
-        w = np.empty_like(a1, shape=(0,), dtype=w_n.dtype)
-        v = np.empty_like(a1, shape=(0, 0), dtype=v_n.dtype)
+        w = np.empty(a1.shape[:-2] + (0,), dtype=np.finfo(a1.dtype).dtype)
         if eigvals_only:
             return w
         else:
+            v = np.empty(a1.shape[:-2] + (0, 0), dtype=a1.dtype)
             return w, v
 
-    overwrite_a = overwrite_a or (_datacopied(a1, a))
-    cplx = True if iscomplexobj(a1) else False
-    n = a1.shape[0]
-    drv_args = {'overwrite_a': overwrite_a}
 
     if b is not None:
         b1 = _asarray_validated(b, check_finite=check_finite)
-        overwrite_b = overwrite_b or _datacopied(b1, b)
-        if len(b1.shape) != 2 or b1.shape[0] != b1.shape[1]:
-            raise ValueError('expected square "b" matrix')
+        _deprecate_dtypes("linalg.eigh", b1)
+        if b1.ndim < 2 or b1.shape[-2] != b1.shape[-1]:
+            raise ValueError(f"expected 'b' array with square slices, got {b1.shape=}")
 
-        if b1.shape != a1.shape:
-            raise ValueError(f"wrong b dimensions {b1.shape}, should be {a1.shape}")
+        if b1.shape[-1] != n:
+            raise ValueError(f"Expected matching slice dimensions, got {n} for 'a' and"
+                f"{b.shape[-1]} for 'b'")
 
         if type not in [1, 2, 3]:
-            raise ValueError('"type" keyword only accepts 1, 2, and 3.')
+                    raise ValueError('"type" keyword only accepts 1, 2, and 3.')
 
-        cplx = True if iscomplexobj(b1) else (cplx or False)
-        drv_args.update({'overwrite_b': overwrite_b, 'itype': type})
+        batch_shape = np.broadcast_shapes(a1.shape[:-2], b1.shape[:-2])
+        a1 = np.broadcast_to(a1, batch_shape + a1.shape[-2:])
+        b1 = np.broadcast_to(b1, batch_shape + b1.shape[-2:])
 
+        a1, b1 = _ensure_dtype_cdsz(a1, b1) # Let `b1` and `a1` upcast each other
+        b1, overwrite_b = _ensure_aligned_and_native(b1, overwrite_b)
+        overwrite_a = overwrite_a or _datacopied(a1, a) # Deal with potential upcast
+        overwrite_b = overwrite_b or _datacopied(b1, b)
+        overwrite_b = overwrite_b and b1.ndim == 2 and b1.flags["F_CONTIGUOUS"]
+
+    ## Check subset arguments
+    vals_range = 0 # Maps to `range` on LAPACK side, 0 -> `A`, 1 -> `V`, 2 -> `I`
     subset = (subset_by_index is not None) or (subset_by_value is not None)
-
-    # Both subsets can't be given
     if subset_by_index and subset_by_value:
         raise ValueError('Either index or value subset can be requested.')
 
-    # Check indices if given
-    if subset_by_index:
-        lo, hi = (int(x) for x in subset_by_index)
-        if not (0 <= lo <= hi < n):
-            raise ValueError('Requested eigenvalue indices are not valid. '
-                             f'Valid range is [0, {n-1}] and start <= end, but '
-                             f'start={lo}, end={hi} is given')
-        # fortran is 1-indexed
-        drv_args.update({'range': 'I', 'il': lo + 1, 'iu': hi + 1})
-
     if subset_by_value:
-        lo, hi = subset_by_value
-        if not (-inf <= lo < hi <= inf):
+        if a1.ndim > 2:
+            raise ValueError('`subset_by_value` not supported for > 2D arrays')
+
+        vl, vu = subset_by_value
+        vals_range = 1
+        if not (-inf <= vl < vu <= inf):
             raise ValueError('Requested eigenvalue bounds are not valid. '
                              'Valid range is (-inf, inf) and low < high, but '
-                             f'low={lo}, high={hi} is given')
+                             f'low={vl}, high={vu} is given')
+    else: # provide defaults
+        vl, vu = 0, 0
 
-        drv_args.update({'range': 'V', 'vl': lo, 'vu': hi})
+    if subset_by_index:
+        il, iu = (int(x) for x in subset_by_index)
+        vals_range = 2
+        if not (0 <= il <= iu < n):
+            raise ValueError('Requested eigenvalue indices are not valid. '
+                             f'Valid range is [0, {n-1}] and start <= end, but '
+                             f'start={il}, end={iu} is given')
+    else: # provide defaults
+        il, iu = 0, 0
 
-    # fix prefix for lapack routines
-    pfx = 'he' if cplx else 'sy'
-
-    # decide on the driver if not given
-    # first early exit on incompatible choice
+    ## decide on the driver if not given, first early exit on incompatible choice
+    ## If not given, simply use the default
     if driver:
         if b is None and (driver in ["gv", "gvd", "gvx"]):
             raise ValueError(f'{driver} requires input b array to be supplied '
@@ -558,93 +578,29 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
                              'for standard eigenvalue problems.')
         if subset and (driver in ["ev", "evd", "gv", "gvd"]):
             raise ValueError(f'"{driver}" cannot compute subsets of eigenvalues')
-
-    # Default driver is evr and gvd
     else:
         driver = "evr" if b is None else ("gvx" if subset else "gvd")
 
-    lwork_spec = {
-                  'syevd': ['lwork', 'liwork'],
-                  'syevr': ['lwork', 'liwork'],
-                  'heevd': ['lwork', 'liwork', 'lrwork'],
-                  'heevr': ['lwork', 'lrwork', 'liwork'],
-                  }
-
-    if b is None:  # Standard problem
-        drv, drvlw = get_lapack_funcs((pfx + driver, pfx+driver+'_lwork'),
-                                      [a1])
-        clw_args = {'n': n, 'lower': lower}
-        if driver == 'evd':
-            clw_args.update({'compute_v': 0 if _job == "N" else 1})
-
-        lw = _compute_lwork(drvlw, **clw_args)
-        # Multiple lwork vars
-        if isinstance(lw, tuple):
-            lwork_args = dict(zip(lwork_spec[pfx+driver], lw))
-        else:
-            lwork_args = {'lwork': lw}
-
-        drv_args.update({'lower': lower, 'compute_v': 0 if _job == "N" else 1})
-        w, v, *other_args, info = drv(a=a1, **drv_args, **lwork_args)
-
-    else:  # Generalized problem
-        # 'gvd' doesn't have lwork query
-        if driver == "gvd":
-            drv = get_lapack_funcs(pfx + "gvd", [a1, b1])
-            lwork_args = {}
-        else:
-            drv, drvlw = get_lapack_funcs((pfx + driver, pfx+driver+'_lwork'),
-                                          [a1, b1])
-            # generalized drivers use uplo instead of lower
-            lw = _compute_lwork(drvlw, n, uplo=uplo)
-            lwork_args = {'lwork': lw}
-
-        drv_args.update({'uplo': uplo, 'jobz': _job})
-
-        w, v, *other_args, info = drv(a=a1, b=b1, **drv_args, **lwork_args)
-
-    # m is always the first extra argument
-    w = w[:other_args[0]] if subset else w
-    v = v[:, :other_args[0]] if (subset and not eigvals_only) else v
-
-    # Check if we had a  successful exit
-    if info == 0:
-        if eigvals_only:
-            return w
-        else:
-            return w, v
+    driver_map = drivers[driver]
+    if b is None:
+        w, Z, m, ret_lst = _batched_linalg._eigh(a1, overwrite_a, eigvals_only,
+            vals_range, lower, vl, vu, il, iu, driver_map)
     else:
-        if info < -1:
-            raise LinAlgError(f'Illegal value in argument {-info} of internal '
-                              f'{drv.typecode + pfx + driver}')
-        elif info > n:
-            raise LinAlgError(f'The leading minor of order {info-n} of B is not '
-                              'positive definite. The factorization of B '
-                              'could not be completed and no eigenvalues '
-                              'or eigenvectors were computed.')
-        else:
-            drv_err = {'ev': 'The algorithm failed to converge; {} '
-                             'off-diagonal elements of an intermediate '
-                             'tridiagonal form did not converge to zero.',
-                       'evx': '{} eigenvectors failed to converge.',
-                       'evd': 'The algorithm failed to compute an eigenvalue '
-                              'while working on the submatrix lying in rows '
-                              'and columns {0}/{1} through mod({0},{1}).',
-                       'evr': 'Internal Error.'
-                       }
-            if driver in ['ev', 'gv']:
-                msg = drv_err['ev'].format(info)
-            elif driver in ['evx', 'gvx']:
-                msg = drv_err['evx'].format(info)
-            elif driver in ['evd', 'gvd']:
-                if eigvals_only:
-                    msg = drv_err['ev'].format(info)
-                else:
-                    msg = drv_err['evd'].format(info, n+1)
-            else:
-                msg = drv_err['evr']
+        # Generalized eigenvalue problem
+        w, Z, m, ret_lst = _batched_linalg._eigh(a1, overwrite_a, eigvals_only,
+            vals_range, lower, vl, vu, il, iu, driver_map, b1, overwrite_b, type)
 
-            raise LinAlgError(msg)
+    # Handle output
+    if ret_lst:
+        _check_format_errors_warnings(driver, ret_lst)
+
+    # Slice arrays into correct shape (needed for `range == 'V'`)
+    w = w[..., :m]
+    if eigvals_only:
+        return w
+    else:
+        Z = Z[..., :, :m]
+        return w, Z
 
 
 _conv_dict = {0: 0, 1: 1, 2: 2,
@@ -967,7 +923,6 @@ def eigvals(a, b=None, overwrite_a=False, overwrite_b=False, check_finite=True,
                 homogeneous_eigvals=homogeneous_eigvals)
 
 
-@_apply_over_batch(('a', 2), ('b', 2))
 def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
              overwrite_b=False, type=1, check_finite=True, subset_by_index=None,
              subset_by_value=None, driver=None):
@@ -1028,7 +983,9 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
         If provided, this two-element iterable defines the half-open interval
         ``(a, b]`` that, if any, only the eigenvalues between these values
         are returned. Only available with "evr", "evx", and "gvx" drivers. Use
-        ``np.inf`` for the unconstrained ends.
+        ``np.inf`` for the unconstrained ends. Not supported for > 2D inputs
+        due to the possibility of different numbers of selected eigenvalues
+        per slice.
     driver : str, optional
         Defines which LAPACK driver should be used. Valid options are "ev",
         "evd", "evr", "evx" for standard problems and "gv", "gvd", "gvx" for

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -534,7 +534,10 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
 
         a1, b1 = _ensure_dtype_cdsz(a1, b1) # Let `b1` and `a1` upcast each other
         b1, overwrite_b = _ensure_aligned_and_native(b1, overwrite_b)
-        overwrite_a = overwrite_a or _datacopied(a1, a) # Deal with potential upcast
+
+        # Deal with the case where `b` could still upcast `a`, hence recompute the flag
+        overwrite_a = overwrite_a or _datacopied(a1, a)
+        overwrite_a = overwrite_a and a1.ndim == 2 and a1.flags["F_CONTIGUOUS"]
         overwrite_b = overwrite_b or _datacopied(b1, b)
         overwrite_b = overwrite_b and b1.ndim == 2 and b1.flags["F_CONTIGUOUS"]
 

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -328,10 +328,10 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
 
     Parameters
     ----------
-    a : (..., M, M) array_like
+    a : (..., N, N) array_like
         A complex Hermitian or real symmetric matrix whose eigenvalues and
         eigenvectors will be computed.
-    b : (..., M, M) array_like, optional
+    b : (..., N, N) array_like, optional
         A complex Hermitian or real symmetric definite positive matrix in.
         If omitted, the regular eigenvalue problem is assumed.
     lower : bool, optional
@@ -364,7 +364,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         If provided, this two-element iterable defines the start and the end
         indices of the desired eigenvalues (ascending order and 0-indexed).
         To return only the second smallest to fifth smallest eigenvalues,
-        ``[1, 4]`` is used. ``[M-3, M-1]`` returns the largest three. Only
+        ``[1, 4]`` is used. ``[N-3, N-1]`` returns the largest three. Only
         available with "evr", "evx", and "gvx" drivers. The entries are
         directly converted to integers via ``int()``.
     subset_by_value : iterable, optional
@@ -383,10 +383,10 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
 
     Returns
     -------
-    w : (..., N) ndarray
-        The N (N<=M) selected eigenvalues, in ascending order, each
+    w : (..., M) ndarray
+        The M (M<=N) selected eigenvalues, in ascending order, each
         repeated according to its multiplicity.
-    v : (..., M, N) ndarray
+    v : (..., N, M) ndarray
         The normalized eigenvector corresponding to the eigenvalue ``w[i]`` is
         the column ``v[:,i]``. Only returned if ``eigvals_only=False``.
 
@@ -529,7 +529,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         overwrite_b = overwrite_b or _datacopied(b1, b)
         overwrite_b = overwrite_b and b1.ndim == 2 and b1.flags["F_CONTIGUOUS"]
 
-    # accommodate square empty matrices, after validation of `b` for `dtype` etc.
+    # accommodate square empty batches, after validation of `b` to account for upcasting
     if a1.size == 0:
         w = np.empty(a1.shape[:-1], dtype=np.finfo(a1.dtype).dtype)
         if eigvals_only:
@@ -942,10 +942,10 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
 
     Parameters
     ----------
-    a : (M, M) array_like
+    a : (..., N, N) array_like
         A complex Hermitian or real symmetric matrix whose eigenvalues will
         be computed.
-    b : (M, M) array_like, optional
+    b : (..., N, N) array_like, optional
         A complex Hermitian or real symmetric definite positive matrix in.
         If omitted, identity matrix is assumed.
     lower : bool, optional
@@ -994,8 +994,8 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
 
     Returns
     -------
-    w : (N,) ndarray
-        The N (N<=M) selected eigenvalues, in ascending order, each
+    w : (..., M) ndarray
+        The M (M<=N) selected eigenvalues, in ascending order, each
         repeated according to its multiplicity.
 
     Raises

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -78,10 +78,10 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
 
     Parameters
     ----------
-    a : (..., M, M) array_like
+    a : (..., N, N) array_like
         A complex or real matrix whose eigenvalues and eigenvectors
         will be computed.
-    b : (..., M, M) array_like, optional
+    b : (..., N, N) array_like, optional
         Right-hand side matrix in a generalized eigenvalue problem.
         Default is None, identity matrix is assumed.
     left : bool, optional
@@ -100,7 +100,7 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
         (crashes, non-termination) if the inputs do contain infinities or NaNs.
     homogeneous_eigvals : bool, optional
         If True, return the eigenvalues in homogeneous coordinates.
-        In this case ``w`` is a ``(2, M)`` array so that::
+        In this case ``w`` is a ``(2, N)`` array so that::
 
             w[1, i] * a @ vr[:, i] = w[0, i] * b @ vr[:, i]
 
@@ -113,14 +113,14 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
 
     Returns
     -------
-    w : (..., M,) or (..., 2, M) complex ndarray
+    w : (..., N,) or (..., 2, N) complex ndarray
         The eigenvalues, each repeated according to its
-        multiplicity. The shape is ``(..., M)`` unless ``homogeneous_eigvals=True``.
-    vl : (..., M, M) double or complex ndarray
+        multiplicity. The shape is ``(..., N)`` unless ``homogeneous_eigvals=True``.
+    vl : (..., N, N) double or complex ndarray
         The left eigenvector corresponding to the eigenvalue
         ``w[i]`` is the column ``vl[:, i]``. Only returned if ``left=True``.
         The left eigenvector is not normalized.
-    vr : (..., M, M) double or complex ndarray
+    vr : (..., N, N) double or complex ndarray
         The normalized right eigenvector corresponding to the eigenvalue
         ``w[i]`` is the column ``vr[:, i]``.  Only returned if ``right=True`` (default).
 
@@ -833,10 +833,10 @@ def eigvals(a, b=None, overwrite_a=False, overwrite_b=False, check_finite=True,
 
     Parameters
     ----------
-    a : (..., M, M) array_like
+    a : (..., N, N) array_like
         A complex or real matrix (or a stack of matrices), whose eigenvalues will be
         computed.
-    b : (..., M, M) array_like, optional
+    b : (..., N, N) array_like, optional
         Right-hand side matrix (or a stack of matrices) in a generalized eigenvalue
         problem. If omitted (default), identity matrix is assumed.
     overwrite_a : bool, optional
@@ -851,7 +851,7 @@ def eigvals(a, b=None, overwrite_a=False, overwrite_b=False, check_finite=True,
         or NaNs.
     homogeneous_eigvals : bool, optional
         If True, return the eigenvalues in homogeneous coordinates.
-        In this case ``w`` is a ``(2, M)`` array so that::
+        In this case ``w`` is a ``(2, N)`` array so that::
 
             w[1, i] * a @ vr[:, i] = w[0, i] * b @ vr[:, i]
 
@@ -864,9 +864,9 @@ def eigvals(a, b=None, overwrite_a=False, overwrite_b=False, check_finite=True,
 
     Returns
     -------
-    w : (..., M,) or (..., 2, M) complex ndarray
+    w : (..., N,) or (..., 2, N) complex ndarray
         The eigenvalues, each repeated according to its multiplicity
-        but not in any specific order. The shape is ``(..., M)`` unless
+        but not in any specific order. The shape is ``(..., N)`` unless
         ``homogeneous_eigvals=True``.
 
     Raises

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -531,11 +531,11 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
 
     # accommodate square empty matrices, after validation of `b` for `dtype` etc.
     if a1.size == 0:
-        w = np.empty(a1.shape[:-2] + (0,), dtype=np.finfo(a1.dtype).dtype)
+        w = np.empty(a1.shape[:-1], dtype=np.finfo(a1.dtype).dtype)
         if eigvals_only:
             return w
         else:
-            v = np.empty(a1.shape[:-2] + (0, 0), dtype=a1.dtype)
+            v = np.empty(a1.shape, dtype=a1.dtype)
             return w, v
 
     ## Check subset arguments

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -476,7 +476,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
 
     """
     # keep in sync with C
-    drivers = {
+    driver_map = {
         "ev": 1,
         "evd": 2,
         "evr": 3,
@@ -487,10 +487,9 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
     }
 
     ## General bookkeeping
-    drv_str = [None, "ev", "evd", "evr", "evx", "gv", "gvd", "gvx"]
-    if driver not in drv_str:
+    if driver not in driver_map and driver is not None:
         raise ValueError('"{}" is unknown. Possible values are "None", "{}".'
-                         ''.format(driver, '", "'.join(drv_str[1:])))
+            ''.format(driver, '", "'.join(driver_map)))
 
     ## Check input arrays
     a1 = _asarray_validated(a, check_finite=check_finite)
@@ -504,17 +503,6 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
     overwrite_a = overwrite_a or _datacopied(a1, a)
     overwrite_a = overwrite_a and a1.ndim == 2 and a1.flags["F_CONTIGUOUS"]
 
-    # accommodate square empty matrices
-    # XXX: account for what happens when `b` upcasts `a`?
-    if a1.size == 0:
-        w = np.empty(a1.shape[:-2] + (0,), dtype=np.finfo(a1.dtype).dtype)
-        if eigvals_only:
-            return w
-        else:
-            v = np.empty(a1.shape[:-2] + (0, 0), dtype=a1.dtype)
-            return w, v
-
-
     if b is not None:
         b1 = _asarray_validated(b, check_finite=check_finite)
         _deprecate_dtypes("linalg.eigh", b1)
@@ -523,7 +511,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
 
         if b1.shape[-1] != n:
             raise ValueError(f"Expected matching slice dimensions, got {n} for 'a' and"
-                f"{b.shape[-1]} for 'b'")
+                f" {b.shape[-1]} for 'b'")
 
         if type not in [1, 2, 3]:
                     raise ValueError('"type" keyword only accepts 1, 2, and 3.')
@@ -540,6 +528,15 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         overwrite_a = overwrite_a and a1.ndim == 2 and a1.flags["F_CONTIGUOUS"]
         overwrite_b = overwrite_b or _datacopied(b1, b)
         overwrite_b = overwrite_b and b1.ndim == 2 and b1.flags["F_CONTIGUOUS"]
+
+    # accommodate square empty matrices, after validation of `b` for `dtype` etc.
+    if a1.size == 0:
+        w = np.empty(a1.shape[:-2] + (0,), dtype=np.finfo(a1.dtype).dtype)
+        if eigvals_only:
+            return w
+        else:
+            v = np.empty(a1.shape[:-2] + (0, 0), dtype=a1.dtype)
+            return w, v
 
     ## Check subset arguments
     vals_range = 0 # Maps to `range` on LAPACK side, 0 -> `A`, 1 -> `V`, 2 -> `I`
@@ -558,7 +555,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
                              'Valid range is (-inf, inf) and low < high, but '
                              f'low={vl}, high={vu} is given')
     else: # provide defaults
-        vl, vu = 0, 0
+        vl, vu = -inf, inf
 
     if subset_by_index:
         il, iu = (int(x) for x in subset_by_index)
@@ -568,7 +565,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
                              f'Valid range is [0, {n-1}] and start <= end, but '
                              f'start={il}, end={iu} is given')
     else: # provide defaults
-        il, iu = 0, 0
+        il, iu = -1, -1
 
     ## decide on the driver if not given, first early exit on incompatible choice
     ## If not given, simply use the default
@@ -584,20 +581,20 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
     else:
         driver = "evr" if b is None else ("gvx" if subset else "gvd")
 
-    driver_map = drivers[driver]
+    driver_index = driver_map[driver]
     if b is None:
         w, Z, m, ret_lst = _batched_linalg._eigh(a1, overwrite_a, eigvals_only,
-            vals_range, lower, vl, vu, il, iu, driver_map)
+            vals_range, lower, vl, vu, il, iu, driver_index)
     else:
         # Generalized eigenvalue problem
         w, Z, m, ret_lst = _batched_linalg._eigh(a1, overwrite_a, eigvals_only,
-            vals_range, lower, vl, vu, il, iu, driver_map, b1, overwrite_b, type)
+            vals_range, lower, vl, vu, il, iu, driver_index, b1, overwrite_b, type)
 
     # Handle output
     if ret_lst:
         _check_format_errors_warnings(driver, ret_lst)
 
-    # Slice arrays into correct shape (needed for `range == 'V'`)
+    # Slice arrays into correct shape as size not known beforehand for `subset_by_index`
     w = w[..., :m]
     if eigvals_only:
         return w

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -333,7 +333,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         eigenvectors will be computed.
     b : (..., M, M) array_like, optional
         A complex Hermitian or real symmetric definite positive matrix in.
-        If omitted, identity matrix is assumed.
+        If omitted, the regular eigenvalue problem is assumed.
     lower : bool, optional
         Whether the pertinent array data is taken from the lower or upper
         triangle of ``a`` and, if applicable, ``b``. (Default: lower)
@@ -364,7 +364,7 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         If provided, this two-element iterable defines the start and the end
         indices of the desired eigenvalues (ascending order and 0-indexed).
         To return only the second smallest to fifth smallest eigenvalues,
-        ``[1, 4]`` is used. ``[n-3, n-1]`` returns the largest three. Only
+        ``[1, 4]`` is used. ``[M-3, M-1]`` returns the largest three. Only
         available with "evr", "evx", and "gvx" drivers. The entries are
         directly converted to integers via ``int()``.
     subset_by_value : iterable, optional

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -820,6 +820,126 @@ fail:
 
 
 static PyObject*
+_linalg_eigh(PyObject* Py_UNUSED(dummy), PyObject* args) {
+    PyArrayObject *ap_Am = NULL;
+    PyArrayObject *ap_Bm = NULL;
+    PyArrayObject *ap_w = NULL;
+    PyArrayObject *ap_Z = NULL;
+    int overwrite_a = 0;
+    int overwrite_b = 0;
+    int eigvals_only = 0;
+    int lower = 0;
+    int vals_range = 0;
+    double vl = 0;
+    double vu = 0;
+    int il = 0;
+    int iu = 0;
+    Eigh_driver lapack_driver;
+    int type = 1;
+
+    int info = 0;
+    SliceStatusVec vec_status;
+
+    // Return objects
+    PyObject *ret_w;
+    PyObject *ret_Z;
+    PyObject *ret_lst;
+
+    if (!PyArg_ParseTuple(args, "O!ppppddiin|O!pi",
+        &PyArray_Type, (PyObject **)&ap_Am, &overwrite_a,
+        &eigvals_only, &vals_range, &lower,
+        &vl, &vu, &il, &iu, &lapack_driver,
+        &PyArray_Type, (PyArrayObject **)&ap_Bm, &overwrite_b, &type)
+    ) {
+        return NULL;
+    }
+
+    // Convert int input to char for LAPACK
+    char jobz = eigvals_only ? 'N' : 'V';
+    char range = (vals_range == 0) ? 'A' : (vals_range == 1) ? 'V' : 'I'; // NB. for other drivers than `evr`, `range` is always set to `A`.
+    char uplo = lower ? 'L' : 'U';
+
+    // Sanity check `a`
+    if (!_check_dtype_and_flags(ap_Am, "eigh")) {
+        return NULL;
+    }
+
+    int typenum = PyArray_TYPE(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);
+    npy_intp *shape = PyArray_SHAPE(ap_Am);
+    npy_intp n = shape[ndim - 1];
+    if (shape[ndim - 2] != n) {
+        PyErr_SetString(PyExc_ValueError, "Expected a square matrix");
+        return NULL;
+    }
+
+    // `evr` does not return in place, so a new output array is always needed for `Z`
+    int w_typenum = typenum;
+    if (typenum == NPY_COMPLEX64) { w_typenum = NPY_FLOAT32; }
+    if (typenum == NPY_COMPLEX128) { w_typenum = NPY_FLOAT64; }
+
+    npy_intp shape_1[NPY_MAXDIMS];
+    for (int i = 0; i < ndim ; i++) { shape_1[i] = shape[i]; }
+
+    int m = (range == 'I') ? iu + 1 - il : n;
+    shape_1[ndim - 2] = m;
+    ap_w = (PyArrayObject *)PyArray_SimpleNew(ndim - 1, shape_1, w_typenum);
+    if (ap_w == NULL) {
+        PyErr_NoMemory();
+        goto fail;
+    }
+
+    if (jobz != 'N') {
+        // XXX: account for `overwrite_x`
+        shape_1[ndim - 2] = n;
+        shape_1[ndim - 1] = m;
+
+        ap_Z = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
+        if (ap_Z == NULL) {
+            PyErr_NoMemory();
+            goto fail;
+        }
+    }
+
+    // Dispatch to actual implementation
+    // Pass in pointer to `M` to be able to return to python side
+    switch (typenum) {
+        case NPY_FLOAT32:
+            info = _eigh<float>(ap_Am, ap_Bm, ap_w, ap_Z, &m, overwrite_a, overwrite_b, type, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
+            break;
+        case NPY_FLOAT64:
+            info = _eigh<double>(ap_Am, ap_Bm, ap_w, ap_Z, &m, overwrite_a, overwrite_b, type, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
+            break;
+        case NPY_COMPLEX64:
+            info = _eigh<c64_t>(ap_Am, ap_Bm, ap_w, ap_Z, &m, overwrite_a, overwrite_b, type, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
+            break;
+        case NPY_COMPLEX128:
+            info = _eigh<c128_t>(ap_Am, ap_Bm, ap_w, ap_Z, &m, overwrite_a, overwrite_b, type, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
+            break;
+    }
+
+    if (info < 0) {
+        // Out-of-memory or scipy internal error
+        PyErr_SetString(PyExc_RuntimeError, "Memory error in scipy.linalg.eigh.");
+        goto fail;
+    }
+
+    // regular return
+    ret_w = PyArray_Return(ap_w);
+    ret_Z = (jobz == 'V') ? PyArray_Return(ap_Z) : Py_None;
+    ret_lst = convert_vec_status(vec_status);
+
+    return Py_BuildValue("NNnN", ret_w, ret_Z, (Py_ssize_t)m, ret_lst);
+
+fail:
+    Py_XDECREF(ap_w);
+    Py_XDECREF(ap_Z);
+    return NULL;
+}
+
+
+
+static PyObject*
 _linalg_cholesky(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyArrayObject *ap_Am = NULL;
     PyArrayObject *ap_Cm = NULL;
@@ -1489,6 +1609,7 @@ static char doc_solve[] = ("Solve the linear system of equations.");
 static char doc_svd[] = ("SVD factorization.");
 static char doc_lstsq[] = ("linear least squares.");
 static char doc_eig[] = ("eigenvalue solver.");
+static char doc_eigh[] = ("eigenvalue solver for symmetric/hermitian matrices.");
 static char doc_cholesky[] = ("Cholesky factorization.");
 static char doc_qr[] = ("Compute the qr decomposition.");
 
@@ -1501,6 +1622,7 @@ static struct PyMethodDef module_methods[] = {
   {"_svd", _linalg_svd, METH_VARARGS, doc_svd},
   {"_lstsq", _linalg_lstsq, METH_VARARGS, doc_lstsq},
   {"_eig", _linalg_eig, METH_VARARGS, doc_eig},
+  {"_eigh", _linalg_eigh, METH_VARARGS, doc_eigh},
   {"_cholesky", _linalg_cholesky, METH_VARARGS, doc_cholesky},
   {"_qr", _linalg_qr, METH_VARARGS, doc_qr},
   {NULL, NULL, 0, NULL}

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -845,7 +845,7 @@ _linalg_eigh(PyObject* Py_UNUSED(dummy), PyObject* args) {
     PyObject *ret_Z;
     PyObject *ret_lst;
 
-    if (!PyArg_ParseTuple(args, "O!ppppddiin|O!pi",
+    if (!PyArg_ParseTuple(args, "O!ppipddiin|O!pi",
         &PyArray_Type, (PyObject **)&ap_Am, &overwrite_a,
         &eigvals_only, &vals_range, &lower,
         &vl, &vu, &il, &iu, &lapack_driver,
@@ -856,7 +856,7 @@ _linalg_eigh(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     // Convert int input to char for LAPACK
     char jobz = eigvals_only ? 'N' : 'V';
-    char range = (vals_range == 0) ? 'A' : (vals_range == 1) ? 'V' : 'I'; // NB. for other drivers than `evr`, `range` is always set to `A`.
+    char range = (vals_range == 0) ? 'A' : (vals_range == 1) ? 'V' : 'I'; // NB. for drivers other than `evr`/`evx`/`gvx`, `range` is ignored.
     char uplo = lower ? 'L' : 'U';
 
     // Sanity check `a`

--- a/scipy/linalg/src/_batched_linalg_module.cc
+++ b/scipy/linalg/src/_batched_linalg_module.cc
@@ -830,12 +830,12 @@ _linalg_eigh(PyObject* Py_UNUSED(dummy), PyObject* args) {
     int eigvals_only = 0;
     int lower = 0;
     int vals_range = 0;
-    double vl = 0;
-    double vu = 0;
-    int il = 0;
-    int iu = 0;
+    double vl = -std::numeric_limits<double>::infinity();
+    double vu = std::numeric_limits<double>::infinity();
+    int il = -1;
+    int iu = -1;
     Eigh_driver lapack_driver;
-    int type = 1;
+    int itype = 1;
 
     int info = 0;
     SliceStatusVec vec_status;
@@ -849,26 +849,52 @@ _linalg_eigh(PyObject* Py_UNUSED(dummy), PyObject* args) {
         &PyArray_Type, (PyObject **)&ap_Am, &overwrite_a,
         &eigvals_only, &vals_range, &lower,
         &vl, &vu, &il, &iu, &lapack_driver,
-        &PyArray_Type, (PyArrayObject **)&ap_Bm, &overwrite_b, &type)
+        &PyArray_Type, (PyArrayObject **)&ap_Bm, &overwrite_b, &itype)
     ) {
         return NULL;
     }
 
-    // Convert int input to char for LAPACK
-    char jobz = eigvals_only ? 'N' : 'V';
-    char range = (vals_range == 0) ? 'A' : (vals_range == 1) ? 'V' : 'I'; // NB. for drivers other than `evr`/`evx`/`gvx`, `range` is ignored.
+    /*
+     * Convert int input to char for LAPACK
+     *
+     * - `uplo`: what triangular part of the matrix to use
+     * - `jobz`: whether to compute eigenvectors, always applicable
+     * - `range`: for drivers `evr`, `evx` and `gvx` what eigenvalues to compute:
+     *      - 'A':  all eigenvalues, `N` in total, are returned unconditionally,
+     *              `il`, `iu`, `vl` and `vu` are still sentinel values
+     *      - 'V':  only eigenvalues `w_i` satisfying `vl < w_i <= vu` are returned, since the
+     *              number of eigenvalues satisfying this condition is unknown beforehand,
+     *              space for all `N` eigenvalues has to be allocated.
+     *              `il` and `iu` remain sentinel values.
+     *      - 'I':  when sorted in ascending order, return indices `il` to `iu` (inclusive),
+     *              not yet accounted for Fortran indexing, the number of eigenvalues is known
+     *              beforehand to be `iu - il + 1`, hence only that size should be allocated.
+     *              `vl` and `vu` remain sentinels
+     *
+     * The number of eigenvalues/eigenvectors to be found is denoted with `M`. In order to be
+     * able to return a properly sized array this is also returned to the python side.
+     */
     char uplo = lower ? 'L' : 'U';
+    char jobz = eigvals_only ? 'N' : 'V';
+    char range = (vals_range == 0) ? 'A' : (vals_range == 1) ? 'V' : 'I';
 
     // Sanity check `a`
     if (!_check_dtype_and_flags(ap_Am, "eigh")) {
         return NULL;
     }
 
+
+    /*
+     * Allocation of return objects
+     *
+     * - `w` contains eigenvalues, always present, size (N,) per slice
+     * - `Z` contains eigenvectors, only required when `jobz == 'V'`, size (N, M) per slice
+     */
     int typenum = PyArray_TYPE(ap_Am);
     int ndim = PyArray_NDIM(ap_Am);
     npy_intp *shape = PyArray_SHAPE(ap_Am);
-    npy_intp n = shape[ndim - 1];
-    if (shape[ndim - 2] != n) {
+    npy_intp N = shape[ndim - 1];
+    if (shape[ndim - 2] != N) {
         PyErr_SetString(PyExc_ValueError, "Expected a square matrix");
         return NULL;
     }
@@ -881,8 +907,8 @@ _linalg_eigh(PyObject* Py_UNUSED(dummy), PyObject* args) {
     npy_intp shape_1[NPY_MAXDIMS];
     for (int i = 0; i < ndim ; i++) { shape_1[i] = shape[i]; }
 
-    int m = (range == 'I') ? iu + 1 - il : n;
-    shape_1[ndim - 2] = m;
+    int M = (range == 'I') ? iu + 1 - il : N;
+    shape_1[ndim - 2] = M;
     ap_w = (PyArrayObject *)PyArray_SimpleNew(ndim - 1, shape_1, w_typenum);
     if (ap_w == NULL) {
         PyErr_NoMemory();
@@ -891,8 +917,8 @@ _linalg_eigh(PyObject* Py_UNUSED(dummy), PyObject* args) {
 
     if (jobz != 'N') {
         // XXX: account for `overwrite_x`
-        shape_1[ndim - 2] = n;
-        shape_1[ndim - 1] = m;
+        shape_1[ndim - 2] = N;
+        shape_1[ndim - 1] = M;
 
         ap_Z = (PyArrayObject *)PyArray_SimpleNew(ndim, shape_1, typenum);
         if (ap_Z == NULL) {
@@ -905,16 +931,16 @@ _linalg_eigh(PyObject* Py_UNUSED(dummy), PyObject* args) {
     // Pass in pointer to `M` to be able to return to python side
     switch (typenum) {
         case NPY_FLOAT32:
-            info = _eigh<float>(ap_Am, ap_Bm, ap_w, ap_Z, &m, overwrite_a, overwrite_b, type, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
+            info = _eigh<float>(ap_Am, ap_Bm, ap_w, ap_Z, &M, overwrite_a, overwrite_b, itype, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
             break;
         case NPY_FLOAT64:
-            info = _eigh<double>(ap_Am, ap_Bm, ap_w, ap_Z, &m, overwrite_a, overwrite_b, type, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
+            info = _eigh<double>(ap_Am, ap_Bm, ap_w, ap_Z, &M, overwrite_a, overwrite_b, itype, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
             break;
         case NPY_COMPLEX64:
-            info = _eigh<c64_t>(ap_Am, ap_Bm, ap_w, ap_Z, &m, overwrite_a, overwrite_b, type, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
+            info = _eigh<c64_t>(ap_Am, ap_Bm, ap_w, ap_Z, &M, overwrite_a, overwrite_b, itype, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
             break;
         case NPY_COMPLEX128:
-            info = _eigh<c128_t>(ap_Am, ap_Bm, ap_w, ap_Z, &m, overwrite_a, overwrite_b, type, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
+            info = _eigh<c128_t>(ap_Am, ap_Bm, ap_w, ap_Z, &M, overwrite_a, overwrite_b, itype, jobz, range, uplo, vl, vu, il, iu, lapack_driver, vec_status);
             break;
     }
 
@@ -929,7 +955,7 @@ _linalg_eigh(PyObject* Py_UNUSED(dummy), PyObject* args) {
     ret_Z = (jobz == 'V') ? PyArray_Return(ap_Z) : Py_None;
     ret_lst = convert_vec_status(vec_status);
 
-    return Py_BuildValue("NNnN", ret_w, ret_Z, (Py_ssize_t)m, ret_lst);
+    return Py_BuildValue("NNnN", ret_w, ret_Z, (Py_ssize_t)M, ret_lst);
 
 fail:
     Py_XDECREF(ap_w);

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -1065,7 +1065,7 @@ GEN_HEEVX(z, c128_t, double);
  */
 #define GEN_SYGV(PREFIX, TYPE, RTYPE) \
 inline void \
-call_sy_he_gv(int *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+call_sy_he_gv(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## sygv)(itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, info); \
 };
@@ -1076,7 +1076,7 @@ GEN_SYGV(d, double, double);
 
 #define GEN_HEGV(PREFIX, TYPE, RTYPE) \
 inline void \
-call_sy_he_gv(int *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+call_sy_he_gv(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## hegv)(itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, rwork, info); \
 };
@@ -1092,7 +1092,7 @@ GEN_HEGV(z, c128_t, double);
  */
 #define GEN_SYGVD(PREFIX, TYPE, RTYPE) \
 inline void \
-call_sy_he_gvd(int *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
+call_sy_he_gvd(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## sygvd)(itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, iwork, liwork, info); \
 };
@@ -1103,7 +1103,7 @@ GEN_SYGVD(d, double, double);
 
 #define GEN_HEGVD(PREFIX, TYPE, RTYPE) \
 inline void \
-call_sy_he_gvd(int *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
+call_sy_he_gvd(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## hegvd)(itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, rwork, lrwork, iwork, liwork, info); \
 };
@@ -1119,7 +1119,7 @@ GEN_HEGVD(z, c128_t, double);
  */
 #define GEN_SYGVX(PREFIX, TYPE, RTYPE) \
 inline void \
-call_sy_he_gvx(int *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info) \
+call_sy_he_gvx(CBLAS_INT *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## sygvx)(itype, jobz, range, uplo, n, a, lda, b, ldb, vl, vu, il, iu, abstol, m, w, z, ldz, work, lwork, iwork, ifail, info); \
 };
@@ -1130,7 +1130,7 @@ GEN_SYGVX(d, double, double)
 
 #define GEN_HEGVX(PREFIX, TYPE, RTYPE) \
 inline void \
-call_sy_he_gvx(int *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info) \
+call_sy_he_gvx(CBLAS_INT *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info) \
 { \
     BLAS_FUNC(PREFIX ## hegvx)(itype, jobz, range, uplo, n, a, lda, b, ldb, vl, vu, il, iu, abstol, m, w, z, ldz, work, lwork, rwork, iwork, ifail, info); \
 };

--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -261,6 +261,48 @@ void BLAS_FUNC(dggev)(char *jobvl, char *jobvr, CBLAS_INT *n, double *a, CBLAS_I
 void BLAS_FUNC(cggev)(char *jobvl, char *jobvr, CBLAS_INT *n, c64_t *a, CBLAS_INT *lda, c64_t *b, CBLAS_INT *ldb, c64_t *alpha, c64_t *beta, c64_t *vl, CBLAS_INT *ldvl, c64_t *vr, CBLAS_INT *ldvr, c64_t *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *info);
 void BLAS_FUNC(zggev)(char *jobvl, char *jobvr, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, c128_t *b, CBLAS_INT *ldb, c128_t *alpha, c128_t *beta, c128_t *vl, CBLAS_INT *ldvl, c128_t *vr, CBLAS_INT *ldvr, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
 
+/* ?SY/HEEV symmetric/hermitian eigenvalue problem */
+void BLAS_FUNC(ssyev)(char *jobz, char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *w, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dsyev)(char *jobz, char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *w, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(cheev)(char *jobz, char *uplo, CBLAS_INT *n, c64_t *a, CBLAS_INT *lda, float *w, c64_t *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *info);
+void BLAS_FUNC(zheev)(char *jobz, char *uplo, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, double *w, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
+
+/* ?SY/HEEVD symmetric/hermitian eigenvalue problem */
+void BLAS_FUNC(ssyevd)(char *jobz, char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *w, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+void BLAS_FUNC(dsyevd)(char *jobz, char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *w, double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+void BLAS_FUNC(cheevd)(char *jobz, char *uplo, CBLAS_INT *n, c64_t *a, CBLAS_INT *lda, float *w, c64_t *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+void BLAS_FUNC(zheevd)(char *jobz, char *uplo, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, double *w, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+
+/* ?SY/HEEVR symmetric/hermitian eigenvalue problem */
+void BLAS_FUNC(ssyevr)(char *jobz, char *range, char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *vl, float *vu, CBLAS_INT *il, CBLAS_INT *iu, float *abstol, CBLAS_INT *m, float *w, float *z, CBLAS_INT *ldz, CBLAS_INT *isuppz, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+void BLAS_FUNC(dsyevr)(char *jobz, char *range, char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *vl, double *vu, CBLAS_INT *il, CBLAS_INT *iu, double *abstol, CBLAS_INT *m, double *w, double *z, CBLAS_INT *ldz, CBLAS_INT *isuppz, double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+void BLAS_FUNC(cheevr)(char *jobz, char *range, char *uplo, CBLAS_INT *n, c64_t *a, CBLAS_INT *lda, float *vl, float *vu, CBLAS_INT *il, CBLAS_INT *iu, float *abstol, CBLAS_INT *m, float *w, c64_t *z, CBLAS_INT *ldz, CBLAS_INT *isuppz, c64_t *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+void BLAS_FUNC(zheevr)(char *jobz, char *range, char *uplo, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, double *vl, double *vu, CBLAS_INT *il, CBLAS_INT *iu, double *abstol, CBLAS_INT *m, double *w, c128_t *z, CBLAS_INT *ldz, CBLAS_INT *isuppz, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+
+/* ?SY/HEEVX symmetric/hermitian eigenvalue problem */
+void BLAS_FUNC(ssyevx)(char *jobz, char *range, char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *vl, float *vu, CBLAS_INT *il, CBLAS_INT *iu, float *abstol, CBLAS_INT *m, float *w, float *z, CBLAS_INT *ldz, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info);
+void BLAS_FUNC(dsyevx)(char *jobz, char *range, char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *vl, double *vu, CBLAS_INT *il, CBLAS_INT *iu, double *abstol, CBLAS_INT *m, double *w, double *z, CBLAS_INT *ldz, double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info);
+void BLAS_FUNC(cheevx)(char *jobz, char *range, char *uplo, CBLAS_INT *n, c64_t *a, CBLAS_INT *lda, float *vl, float *vu, CBLAS_INT *il, CBLAS_INT *iu, float *abstol, CBLAS_INT *m, float *w, c64_t *z, CBLAS_INT *ldz, c64_t *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info);
+void BLAS_FUNC(zheevx)(char *jobz, char *range, char *uplo, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, double *vl, double *vu, CBLAS_INT *il, CBLAS_INT *iu, double *abstol, CBLAS_INT *m, double *w, c128_t *z, CBLAS_INT *ldz, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info);
+
+/* ?SY/HEGV symmetric/hermitian generalized eigenvalue problem */
+void BLAS_FUNC(ssygv)(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, float *w, float *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(dsygv)(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, double *w, double *work, CBLAS_INT *lwork, CBLAS_INT *info);
+void BLAS_FUNC(chegv)(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, c64_t *a, CBLAS_INT *lda, c64_t *b, CBLAS_INT *ldb, float *w, c64_t *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *info);
+void BLAS_FUNC(zhegv)(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, c128_t *b, CBLAS_INT *ldb, double *w, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *info);
+
+/* ?SY/HEGVD symmetric/hermitian generalized eigenvalue problem */
+void BLAS_FUNC(ssygvd)(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, float *w, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+void BLAS_FUNC(dsygvd)(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, double *w, double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+void BLAS_FUNC(chegvd)(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, c64_t *a, CBLAS_INT *lda, c64_t *b, CBLAS_INT *ldb, float *w, c64_t *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+void BLAS_FUNC(zhegvd)(CBLAS_INT *itype, char *jobz, char *uplo, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, c128_t *b, CBLAS_INT *ldb, double *w, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info);
+
+/* ?SY/HEGVX symmetric/hermitian generalized eigenvalue problem */
+void BLAS_FUNC(ssygvx)(CBLAS_INT *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, float *a, CBLAS_INT *lda, float *b, CBLAS_INT *ldb, float *vl, float *vu, CBLAS_INT *il, CBLAS_INT *iu, float *abstol, CBLAS_INT *m, float *w, float *z, CBLAS_INT *ldz, float *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info);
+void BLAS_FUNC(dsygvx)(CBLAS_INT *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, double *a, CBLAS_INT *lda, double *b, CBLAS_INT *ldb, double *vl, double *vu, CBLAS_INT *il, CBLAS_INT *iu, double *abstol, CBLAS_INT *m, double *w, double *z, CBLAS_INT *ldz, double *work, CBLAS_INT *lwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info);
+void BLAS_FUNC(chegvx)(CBLAS_INT *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, c64_t *a, CBLAS_INT *lda, c64_t *b, CBLAS_INT *ldb, float *vl, float *vu, CBLAS_INT *il, CBLAS_INT *iu, float *abstol, CBLAS_INT *m, float *w, c64_t *z, CBLAS_INT *ldz, c64_t *work, CBLAS_INT *lwork, float *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info);
+void BLAS_FUNC(zhegvx)(CBLAS_INT *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, c128_t *a, CBLAS_INT *lda, c128_t *b, CBLAS_INT *ldb, double *vl, double *vu, CBLAS_INT *il, CBLAS_INT *iu, double *abstol, CBLAS_INT *m, double *w, c128_t *z, CBLAS_INT *ldz, c128_t *work, CBLAS_INT *lwork, double *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info);
+
 
 } // extern "C"
 
@@ -908,6 +950,195 @@ GEN_GGEV_CZ(c, npy_complex64, float)
 GEN_GGEV_CZ(z, npy_complex128, double)
 
 
+/*
+ * Wrappers for ?SY/HEEVR
+ *
+ * Discriminate between real and complex cases; the latter receive `rwork`, the former gobble that input.
+ */
+#define GEN_SYEVR(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_evr(char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, CBLAS_INT *isuppz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## syevr)(jobz, range, uplo, n, a, lda, vl, vu, il, iu, abstol, m, w, z, ldz, isuppz, work, lwork, iwork, liwork, info); \
+};
+
+GEN_SYEVR(s, float, float);
+GEN_SYEVR(d, double, double);
+
+
+#define GEN_HEEVR(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_evr(char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, CBLAS_INT *isuppz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## heevr)(jobz, range, uplo, n, a, lda, vl, vu, il, iu, abstol, m, w, z, ldz, isuppz, work, lwork, rwork, lrwork, iwork, liwork, info); \
+};
+
+GEN_HEEVR(c, c64_t, float);
+GEN_HEEVR(z, c128_t, double);
+
+
+/*
+ * Wrappers for ?SY/HEEV
+ *
+ * Discrimate between real and complex cases; the latter receive `rwork`, the former gobble that input.
+ */
+#define GEN_SYEV(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_ev(char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## syev)(jobz, uplo, n, a, lda, w, work, lwork, info); \
+};
+
+GEN_SYEV(s, float, float);
+GEN_SYEV(d, double, double);
+
+
+#define GEN_HEEV(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_ev(char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## heev)(jobz, uplo, n, a, lda, w, work, lwork, rwork, info); \
+};
+
+GEN_HEEV(c, c64_t, float);
+GEN_HEEV(z, c128_t, double);
+
+
+/*
+ * Wrappers for ?SY/HEEVD
+ *
+ * Discriminate between real and complex cases; the latter receive `rwork`, the former gobble that input
+ */
+#define GEN_SYEVD(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_evd(char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## syevd)(jobz, uplo, n, a, lda, w, work, lwork, iwork, liwork, info); \
+};
+
+GEN_SYEVD(s, float, float);
+GEN_SYEVD(d, double, double);
+
+
+#define GEN_HEEVD(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_evd(char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## heevd)(jobz, uplo, n, a, lda, w, work, lwork, rwork, lrwork, iwork, liwork, info); \
+};
+
+GEN_HEEVD(c, c64_t, float);
+GEN_HEEVD(z, c128_t, double);
+
+
+/*
+ * Wrappers for ?SY/HEEVX
+ *
+ * Discriminate between real and complex cases; the latter receive `rwork`, the former gobble that input
+ */
+#define GEN_SYEVX(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_evx(char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## syevx)(jobz, range, uplo, n, a, lda, vl, vu, il, iu, abstol, m, w, z, ldz, work, lwork, iwork, ifail, info); \
+};
+
+GEN_SYEVX(s, float, float);
+GEN_SYEVX(d, double, double);
+
+
+#define GEN_HEEVX(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_evx(char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## heevx)(jobz, range, uplo, n, a, lda, vl, vu, il, iu, abstol, m, w, z, ldz, work, lwork, rwork, iwork, ifail, info); \
+};
+
+GEN_HEEVX(c, c64_t, float);
+GEN_HEEVX(z, c128_t, double);
+
+
+/*
+ * Wrappers for ?SY/HEGV
+ *
+ * Discriminate between real and complex cases due to `rwork`
+ */
+#define GEN_SYGV(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_gv(int *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## sygv)(itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, info); \
+};
+
+GEN_SYGV(s, float, float);
+GEN_SYGV(d, double, double);
+
+
+#define GEN_HEGV(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_gv(int *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## hegv)(itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, rwork, info); \
+};
+
+GEN_HEGV(c, c64_t, float);
+GEN_HEGV(z, c128_t, double);
+
+
+/*
+ * Wrappers for ?SY/HEGVD
+ *
+ * Discriminate between real and complex cases due to `rwork`
+ */
+#define GEN_SYGVD(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_gvd(int *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## sygvd)(itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, iwork, liwork, info); \
+};
+
+GEN_SYGVD(s, float, float);
+GEN_SYGVD(d, double, double);
+
+
+#define GEN_HEGVD(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_gvd(int *itype, char *jobz, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *w, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *lrwork, CBLAS_INT *iwork, CBLAS_INT *liwork, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## hegvd)(itype, jobz, uplo, n, a, lda, b, ldb, w, work, lwork, rwork, lrwork, iwork, liwork, info); \
+};
+
+GEN_HEGVD(c, c64_t, float);
+GEN_HEGVD(z, c128_t, double);
+
+
+/*
+ * Wrappers for ?SY/HEGVX
+ *
+ * Disriminate between real and complex cases due to `rwork`
+ */
+#define GEN_SYGVX(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_gvx(int *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## sygvx)(itype, jobz, range, uplo, n, a, lda, b, ldb, vl, vu, il, iu, abstol, m, w, z, ldz, work, lwork, iwork, ifail, info); \
+};
+
+GEN_SYGVX(s, float, float);
+GEN_SYGVX(d, double, double)
+
+
+#define GEN_HEGVX(PREFIX, TYPE, RTYPE) \
+inline void \
+call_sy_he_gvx(int *itype, char *jobz, char *range, char *uplo, CBLAS_INT *n, TYPE *a, CBLAS_INT *lda, TYPE *b, CBLAS_INT *ldb, RTYPE *vl, RTYPE *vu, CBLAS_INT *il, CBLAS_INT *iu, RTYPE *abstol, CBLAS_INT *m, RTYPE *w, TYPE *z, CBLAS_INT *ldz, TYPE *work, CBLAS_INT *lwork, RTYPE *rwork, CBLAS_INT *iwork, CBLAS_INT *ifail, CBLAS_INT *info) \
+{ \
+    BLAS_FUNC(PREFIX ## hegvx)(itype, jobz, range, uplo, n, a, lda, b, ldb, vl, vu, il, iu, abstol, m, w, z, ldz, work, lwork, rwork, iwork, ifail, info); \
+};
+
+GEN_HEGVX(c, c64_t, float);
+GEN_HEGVX(z, c128_t, double);
+
+
 // Structure tags; python side maps assume_a strings to these values
 enum St : Py_ssize_t
 {
@@ -930,6 +1161,18 @@ enum QR_mode : Py_ssize_t
     R = 11,
     RAW_MODE = 21,
     ECONOMIC = 31
+};
+
+// Eigh driver tags; pythn side maps driver strings to these values
+enum Eigh_driver : Py_ssize_t
+{
+    EV = 1,
+    EVD = 2,
+    EVR = 3,
+    EVX = 4,
+    GV = 10,
+    GVD = 11,
+    GVX = 12
 };
 
 
@@ -1131,6 +1374,27 @@ void copy_triangle_to_C(T *dst, const T *src, const npy_intp m, const npy_intp n
             for (npy_intp j = i; j < n; j++) {
                 dst[i * n + j] = *(src + i * s0 + j * s1);
             }
+        }
+    }
+}
+
+
+/*
+ * Copy the eigenvectors computed by `evr` into a C-ordered return buffer
+ * taking into account `isuppz`.
+ *
+ * Shapes: both eigenvector buffers `n1 x n2`, with `m` returned by LAPACK `n`.
+ * `isuppz` is `2m`. This function internally accounts for the minimal value for
+ * an entry in `isuppz` is `1`.
+ */
+template<typename T>
+void copy_eigenvectors_isuppz(T *dst, const T *src, const CBLAS_INT *isuppz, const npy_intp n1, const npy_intp n2, const npy_intp m) {
+    for (int i = 0; i < m; i++) {
+        CBLAS_INT il = isuppz[2 * i] - 1; // NB. Fortran is 1-indexed
+        CBLAS_INT iu = isuppz[2 * i + 1];
+
+        for (int j = il; j < iu; j++) {
+            dst[i + j * n2] = src[i * n1 + j];
         }
     }
 }

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -485,6 +485,7 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     real_type r_vl = (real_type)vl, r_vu = (real_type)vu;
     CBLAS_INT int_il = il + 1; // Deal with Fortran being 1-indexed
     CBLAS_INT int_iu = iu + 1;
+    CBLAS_INT int_itype = (CBLAS_INT)itype;
     real_type abstol = detail::numeric_limits<real_type>::zero;
 
     T tmp_work = detail::numeric_limits<T>::zero;
@@ -515,17 +516,17 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
         }
 
         case Eigh_driver::GV : {
-            call_sy_he_gv(&itype, &jobz, &uplo, &intn, NULL, &intn, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &info);
+            call_sy_he_gv(&int_itype, &jobz, &uplo, &intn, NULL, &intn, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &info);
             break;
         }
 
         case Eigh_driver::GVD : {
-            call_sy_he_gvd(&itype, &jobz, &uplo, &intn, NULL, &intn, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &lrwork, &tmp_iwork, &liwork, &info);
+            call_sy_he_gvd(&int_itype, &jobz, &uplo, &intn, NULL, &intn, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &lrwork, &tmp_iwork, &liwork, &info);
             break;
         }
 
         case Eigh_driver::GVX : {
-            call_sy_he_gvx(&itype, &jobz, &range, &uplo, &intn, NULL, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, NULL, NULL, NULL, &intn, &tmp_work, &lwork, &tmp_rwork, &tmp_iwork, NULL, &info);
+            call_sy_he_gvx(&int_itype, &jobz, &range, &uplo, &intn, NULL, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, NULL, NULL, NULL, &intn, &tmp_work, &lwork, &tmp_rwork, &tmp_iwork, NULL, &info);
             break;
         }
 
@@ -686,17 +687,17 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
             }
 
             case Eigh_driver::GV : {
-                call_sy_he_gv(&itype, &jobz, &uplo, &intn, buff_A, &intn, buff_B, &intn, lapack_w, work, &lwork, rwork, &info);
+                call_sy_he_gv(&int_itype, &jobz, &uplo, &intn, buff_A, &intn, buff_B, &intn, lapack_w, work, &lwork, rwork, &info);
                 break;
             }
 
             case Eigh_driver::GVD : {
-                call_sy_he_gvd(&itype, &jobz, &uplo, &intn, buff_A, &intn, buff_B, &intn, lapack_w, work, &lwork, rwork, &lrwork, iwork, &liwork, &info);
+                call_sy_he_gvd(&int_itype, &jobz, &uplo, &intn, buff_A, &intn, buff_B, &intn, lapack_w, work, &lwork, rwork, &lrwork, iwork, &liwork, &info);
                 break;
             }
 
             case Eigh_driver::GVX : {
-                call_sy_he_gvx(&itype, &jobz, &range, &uplo, &intn, buff_A, &intn, buff_B, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, &intm, lapack_w, buff_Z, &intn, work, &lwork, rwork, iwork, ifail, &info);
+                call_sy_he_gvx(&int_itype, &jobz, &range, &uplo, &intn, buff_A, &intn, buff_B, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, &intm, lapack_w, buff_Z, &intn, work, &lwork, rwork, iwork, ifail, &info);
                 break;
             }
 

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -367,7 +367,7 @@ _gen_eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArra
 
         // copy-and-transpose W, VR and VL slices from temp buffers to the output;
         if constexpr (detail::type_traits<T>::is_complex) {
-            // alphar and beta are complex and compatible with the W array 
+            // alphar and beta are complex and compatible with the W array
             memcpy(ptr_W, alphar, n*sizeof(T));
             ptr_W += n;
 
@@ -422,7 +422,7 @@ _eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm,
 ) {
     int info;
     if (ap_Bm == NULL) {
-        // sanity check: B and beta are either both NULL or both not NULL (for a generalized eig problem) 
+        // sanity check: B and beta are either both NULL or both not NULL (for a generalized eig problem)
         if (ap_beta != NULL) { return -222; }
 
         info = _reg_eig<T>(ap_Am, ap_w, ap_vl, ap_vr, overwrite_a, vec_status);
@@ -433,6 +433,343 @@ _eig(PyArrayObject* ap_Am, PyArrayObject *ap_Bm,
         info = _gen_eig<T>(ap_Am, ap_Bm, ap_w, ap_beta, ap_vl, ap_vr, overwrite_a, overwrite_b, vec_status);
     }
     return info;
+}
+
+
+
+template<typename T>
+int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArrayObject *ap_Z,
+        int *intp_M, int overwrite_a, int overwrite_b, int itype, char jobz, char range, char uplo,
+        double vl, double vu, int il, int iu, Eigh_driver lapack_driver, SliceStatusVec& vec_status)
+{
+    using real_type = typename detail::type_traits<T>::real_type;
+    SliceStatus slice_status;
+
+    // -------------------------------------------------------------------
+    // Input array attributes
+    // -------------------------------------------------------------------
+    T *A_data = (T *)PyArray_DATA(ap_Am);
+    int ndim = PyArray_NDIM(ap_Am);
+    npy_intp *shape = PyArray_SHAPE(ap_Am);
+    npy_intp *strides = PyArray_STRIDES(ap_Am);
+    npy_intp N = shape[ndim - 1];
+    npy_intp M = *intp_M;
+
+    T *B_data = NULL;
+    npy_intp *strides_B = NULL;
+    if (ap_Bm != NULL) {
+        B_data =  (T *)PyArray_DATA(ap_Bm);
+        strides_B = PyArray_STRIDES(ap_Bm);
+    }
+
+    real_type *w_data = (real_type *)PyArray_DATA(ap_w);
+    npy_intp *strides_w = PyArray_STRIDES(ap_w);
+
+    T *Z_data = NULL;
+    npy_intp *strides_Z = NULL;
+    if (jobz != 'N') {
+        Z_data = (T *)PyArray_DATA(ap_Z);
+        strides_Z = PyArray_STRIDES(ap_Z);
+    }
+
+    npy_intp outer_size = 1;
+    for (int i = 0; i < ndim - 2; i++) { outer_size *= shape[i]; }
+
+    // -------------------------------------------------------------------
+    // Workspace computation and allocation
+    //
+    // NB. Zero-sized arrays handled at python side, so max(1, ...) is
+    // not needed.
+    // -------------------------------------------------------------------
+    CBLAS_INT intn = (CBLAS_INT)N, intm = (CBLAS_INT)M, info = 0;
+    real_type r_vl = (real_type)vl, r_vu = (real_type)vu;
+    CBLAS_INT int_il = il + 1; // Deal with Fortran being 1-indexed
+    CBLAS_INT int_iu = iu + 1;
+    real_type abstol = detail::numeric_limits<real_type>::zero;
+
+    T tmp_work = detail::numeric_limits<T>::zero;
+    real_type tmp_rwork = detail::numeric_limits<real_type>::zero;
+    CBLAS_INT tmp_iwork = 0;
+
+    CBLAS_INT lwork = -1, lrwork = -1, liwork = -1;
+
+    switch (lapack_driver) {
+        case Eigh_driver::EV : {
+            call_sy_he_ev(&jobz, &uplo, &intn, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &info);
+            break;
+        }
+
+        case Eigh_driver::EVD : {
+            call_sy_he_evd(&jobz, &uplo, &intn, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &lrwork, &tmp_iwork, &liwork, &info);
+            break;
+        }
+
+        case Eigh_driver::EVR : {
+            call_sy_he_evr(&jobz, &range, &uplo, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, NULL, NULL, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &lrwork, &tmp_iwork, &liwork, &info);
+            break;
+        }
+
+        case Eigh_driver::EVX : {
+            call_sy_he_evx(&jobz, &range, &uplo, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, NULL, NULL, NULL, &intn, &tmp_work, &lwork, &tmp_rwork, &tmp_iwork, NULL, &info);
+            break;
+        }
+
+        case Eigh_driver::GV : {
+            call_sy_he_gv(&itype, &jobz, &uplo, &intn, NULL, &intn, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &info);
+            break;
+        }
+
+        case Eigh_driver::GVD : {
+            call_sy_he_gvd(&itype, &jobz, &uplo, &intn, NULL, &intn, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &lrwork, &tmp_iwork, &liwork, &info);
+            break;
+        }
+
+        case Eigh_driver::GVX : {
+            call_sy_he_gvx(&itype, &jobz, &range, &uplo, &intn, NULL, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, NULL, NULL, NULL, &intn, &tmp_work, &lwork, &tmp_rwork, &tmp_iwork, NULL, &info);
+            break;
+        }
+
+        default : { // Unknown driver
+            return -105;
+        }
+    }
+    if (info != 0) { info = -101; return (int)info; }
+
+
+    lwork = _calc_lwork(tmp_work);
+
+    if constexpr (!detail::type_traits<T>::is_complex) {
+        lrwork = 0;  // Convert to 0 for buffer allocation later on
+    } else {
+        if (lapack_driver == Eigh_driver::EV || lapack_driver == Eigh_driver::GV) {
+            lrwork = 3 * intn - 2;
+        } else if (lapack_driver == Eigh_driver::EVD || lapack_driver == Eigh_driver::EVR || lapack_driver == Eigh_driver::GVD) {
+            lrwork = _calc_lwork(tmp_rwork);
+        } else if (lapack_driver == Eigh_driver::EVX || lapack_driver == Eigh_driver::GVX) {
+            lrwork = 7 * intn;
+        }
+    }
+
+    liwork = (lapack_driver == Eigh_driver::EVX || lapack_driver == Eigh_driver::GVX) ? 5 * intn : tmp_iwork; // Already integer
+
+
+    if ((lwork < 0) || (lrwork < 0) || (liwork < 0) ||
+        (3 * N + 2 >= std::numeric_limits<CBLAS_INT>::max() && (lapack_driver == Eigh_driver::EV || lapack_driver == Eigh_driver::GV)) ||
+        (((jobz == 'N' && N + 1 >= std::numeric_limits<CBLAS_INT>::max()) || (jobz == 'V' && 2 * N * N + 5 * N + 1 >= std::numeric_limits<CBLAS_INT>::max())) && (lapack_driver == Eigh_driver::EVD || lapack_driver == Eigh_driver::GVD)) ||
+        (24 * N >= std::numeric_limits<CBLAS_INT>::max() && lapack_driver == Eigh_driver::EVR) ||
+        (7 * N >= std::numeric_limits<CBLAS_INT>::max() && (lapack_driver == Eigh_driver::EVX || lapack_driver == Eigh_driver::GVX))
+    ) {
+        // Too large lwork required, computation would overflow
+        // XXX: what about the buffer size, especially `buff_A`
+        return -101;
+    }
+
+    /*
+     * Allocate buffer and slice into parts
+     *   lwork   Z_size   A_size   B_size
+     * |-------|--------|--------|--------|
+     * ^       ^        ^        ^
+     * work    buff_Z   buff_A   buff_B
+     *
+     * - `work` is a work area, always allocated, size `lwork`
+     * - `buff_Z` contains the eigenvectors returned by LAPACK, size N * M, only allocated if `jobz != 'N'`
+     * - `buff_A` contains a buffer for the data of `A`, size N * N, only allocated if `overwrite_a` is set
+     */
+    CBLAS_INT Z_size = (jobz != 'N') ? N * M : 0;
+    CBLAS_INT A_size = (overwrite_a) ? 0 : N * N;
+    CBLAS_INT B_size = (ap_Bm == NULL || overwrite_b) ? 0 : N * N;
+    T *buffer = (T *)malloc((lwork + Z_size + A_size + B_size) * sizeof(T));
+    if (buffer == NULL) { info = -102; return int(info); }
+
+    T *work = &buffer[0];
+    T *buff_Z = &buffer[lwork];
+    T *buff_A = NULL;
+    T *buff_B = NULL;
+    if (!overwrite_a) {
+        buff_A = &buffer[lwork + Z_size];
+    } else {
+        buff_A = A_data;
+    } // NB. `overwrite_a` only enabled if input array is 2D
+
+    if (ap_Bm != NULL && !overwrite_b) {
+        buff_B = &buffer[lwork + Z_size + A_size];
+    } else {
+        buff_B = B_data;
+    } // NB. `overwrite_b` only enabled if input array is 2D
+
+    // integer work areas
+    CBLAS_INT iwork_size = liwork;
+    CBLAS_INT isuppz_size = (lapack_driver == Eigh_driver::EVR) ? 2 * M : 0;
+    CBLAS_INT ifail_size = (lapack_driver == Eigh_driver::EVX || lapack_driver == Eigh_driver::GVX) ? N : 0;
+    CBLAS_INT *ibuffer = (CBLAS_INT *)malloc((iwork_size + isuppz_size + ifail_size) * sizeof(T));
+    if (ibuffer == NULL) {
+        free(buffer);
+        info = -103;
+        return int(info);
+    }
+    CBLAS_INT *iwork = &ibuffer[0];
+    CBLAS_INT *isuppz = &ibuffer[liwork];
+    CBLAS_INT *ifail = &ibuffer[liwork + isuppz_size];
+
+    /*
+     * Real work areas for complex inputs (lrwork) and buffer for eigenvalues
+     * if `range == 'I'` since then the length of elements could be too short
+     * for containing the full output.
+     */
+    CBLAS_INT w_size = (range == 'I') ? N : 0;
+    real_type *rbuffer = (real_type *)malloc((w_size + lrwork) * sizeof(real_type));
+    if (rbuffer == NULL) {
+        free(buffer);
+        free(ibuffer);
+        info = -104;
+        return int(info);
+    }
+
+    real_type *buff_w = &rbuffer[0];
+    real_type *rwork = &rbuffer[w_size];
+
+
+    // -------------------------------------------------------------------
+    // Main batching loop
+    // -------------------------------------------------------------------
+    T *slice_ptr_A = NULL, *slice_ptr_Z = NULL, *slice_ptr_B = NULL;
+    real_type *slice_ptr_w = NULL;
+
+    for (npy_intp idx = 0; idx < outer_size; idx++) {
+
+        // `w` is a vector, but should still traverse the same number of dimensions
+        // and the batch shape is the same for all arrays, so make use of `shape` and
+        // `ndim` for all slices.
+        slice_ptr_A = compute_slice_ptr(idx, A_data, ndim, shape, strides);
+        slice_ptr_w = compute_slice_ptr(idx, w_data, ndim, shape, strides_w);
+        if (jobz != 'N') {
+            slice_ptr_Z = compute_slice_ptr(idx, Z_data, ndim, shape, strides_Z);
+        }
+
+        if (ap_Bm != NULL) {
+            slice_ptr_B = compute_slice_ptr(idx, B_data, ndim, shape, strides_B);
+        }
+
+        real_type *lapack_w = (range == 'I') ? buff_w : slice_ptr_w; // Else the data can fit directly into the return object
+        if (!overwrite_a) {
+            // XXX: can exploit the structure of `A` in some way or the other?
+            copy_slice_F(buff_A, slice_ptr_A, intn, intn, strides[ndim-2], strides[ndim-1]);
+        } // NB. if `overwrite_a` is set the data is already in place and pointer was set earlier
+
+        if (ap_Bm != NULL && !overwrite_b) {
+            copy_slice_F(buff_B, slice_ptr_B, intn, intn, strides_B[ndim-2], strides_B[ndim-1]);
+        } // NB. similar reasoning as for `a`
+
+
+        init_status(slice_status, idx, St::GENERAL);
+
+        // Actual LAPACK call
+        switch (lapack_driver) {
+            case Eigh_driver::EV : {
+                call_sy_he_ev(&jobz, &uplo, &intn, buff_A, &intn, lapack_w, work, &lwork, rwork, &info);
+                break;
+            }
+
+            case Eigh_driver::EVD : {
+                call_sy_he_evd(&jobz, &uplo, &intn, buff_A, &intn, lapack_w, work, &lwork, rwork, &lrwork, iwork, &liwork, &info);
+                break;
+            }
+
+            case Eigh_driver::EVR : {
+                call_sy_he_evr(&jobz, &range, &uplo, &intn, buff_A, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, &intm, lapack_w, buff_Z, &intn, isuppz, work, &lwork, rwork, &lrwork, iwork, &liwork, &info);
+                break;
+            }
+
+            case Eigh_driver::EVX : {
+                call_sy_he_evx(&jobz, &range, &uplo, &intn, buff_A, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, &intm, lapack_w, buff_Z, &intn, work, &lwork, rwork, iwork, ifail, &info);
+                break;
+            }
+
+            case Eigh_driver::GV : {
+                call_sy_he_gv(&itype, &jobz, &uplo, &intn, buff_A, &intn, buff_B, &intn, lapack_w, work, &lwork, rwork, &info);
+                break;
+            }
+
+            case Eigh_driver::GVD : {
+                call_sy_he_gvd(&itype, &jobz, &uplo, &intn, buff_A, &intn, buff_B, &intn, lapack_w, work, &lwork, rwork, &lrwork, iwork, &liwork, &info);
+                break;
+            }
+
+            case Eigh_driver::GVX : {
+                call_sy_he_gvx(&itype, &jobz, &range, &uplo, &intn, buff_A, &intn, buff_B, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, &intm, lapack_w, buff_Z, &intn, work, &lwork, rwork, iwork, ifail, &info);
+                break;
+            }
+
+            default : { // Unknown driver
+                return -105;
+            }
+        }
+
+        if (info != 0) {
+            slice_status.lapack_info = (Py_ssize_t)info;
+            vec_status.push_back(slice_status);
+
+            goto free_exit;
+        }
+
+        if (range == 'I') {
+            memcpy(slice_ptr_w, buff_w, intm * sizeof(real_type));
+        } // NB. else the data is already in place, but here it could be smaller than provisioned if `range = 'I'`
+
+        if (jobz != 'N') {
+            // Copy back eigenvectors
+            switch (lapack_driver) {
+                case Eigh_driver::EV :
+                    [[fallthrough]];
+
+                case Eigh_driver::EVD :
+                    [[fallthrough]];
+
+                case Eigh_driver::GV :
+                    [[fallthrough]];
+
+                case Eigh_driver::GVD : {
+                    copy_slice_F_to_C(slice_ptr_Z, buff_A, N, N);
+                    break;
+                }
+
+                case Eigh_driver::EVR : {
+                    // `isuppz` is only used in the conditions above, else just copy everything
+                    // if ((range == 'A') || (range == 'I' && iu - il == N - 1)) {
+                    //     copy_eigenvectors_isuppz(slice_ptr_Z, buff_Z, isuppz, N, M, intm);
+                    // } else {
+                        copy_slice_F_to_C(slice_ptr_Z, buff_Z, N, M);
+                    // }
+                    break;
+                }
+
+                case Eigh_driver::EVX :
+                    [[fallthrough]];
+
+                case Eigh_driver::GVX : {
+                    copy_slice_F_to_C(slice_ptr_Z, buff_Z, N, M);
+                    break;
+                }
+                // NB. always use `M` since that is the size of the array, otherwise translation to C-order won't work.
+                // XXX: write new copy function that allows to only copy relevant columns?
+
+                default : { // Unknown driver
+                    return -105;
+                }
+            }
+        }
+
+        // Update the `M` to return to python side for slicing of arrays in case of `range == 'V'`
+        *intp_M = intm;
+
+    } // End of batching loop
+
+free_exit:
+    free(buffer);
+    free(ibuffer);
+    free(rbuffer);
+
+    return 1;
 }
 
 } // namespace sp_linalg

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -478,11 +478,11 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     // -------------------------------------------------------------------
     // Workspace computation and allocation
     //
-    // NB. Zero-sized arrays handled at python side, so max(1, ...) is
-    // not needed.
+    // NB. Zero-sized arrays handled at python side, so the `max(1, ...)`
+    // from the LAPACK documentation is not needed.
     // -------------------------------------------------------------------
     CBLAS_INT intn = (CBLAS_INT)N, intm = (CBLAS_INT)M, info = 0;
-    real_type r_vl = (real_type)vl, r_vu = (real_type)vu;
+    real_type r_vl = (real_type)vl, r_vu = (real_type)vu; // Cast to `real_type` to deal with potential single-precision requirements for float and c64_t
     CBLAS_INT int_il = il + 1; // Deal with Fortran being 1-indexed
     CBLAS_INT int_iu = iu + 1;
     CBLAS_INT int_itype = (CBLAS_INT)itype;
@@ -494,6 +494,7 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
 
     CBLAS_INT lwork = -1, lrwork = -1, liwork = -1;
 
+    // lwork probe
     switch (lapack_driver) {
         case Eigh_driver::EV : {
             call_sy_he_ev(&jobz, &uplo, &intn, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &info);
@@ -537,17 +538,18 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     if (info != 0) { info = -101; return (int)info; }
 
 
+    // process lwork probe
     lwork = _calc_lwork(tmp_work);
 
     if constexpr (!detail::type_traits<T>::is_complex) {
-        lrwork = 0;  // Convert to 0 for buffer allocation later on
+        lrwork = 0;  // for real numbers LAPACK does not require `rwork`, hence set corresponding buffer size to 0.
     } else {
         if (lapack_driver == Eigh_driver::EV || lapack_driver == Eigh_driver::GV) {
-            lrwork = 3 * intn - 2;
+            lrwork = 3 * intn - 2; // See https://www.netlib.org/lapack/explore-html/d8/d1c/group__heev_gabba143a47eee873cbdb00d685fca08a3.html#gabba143a47eee873cbdb00d685fca08a3
         } else if (lapack_driver == Eigh_driver::EVD || lapack_driver == Eigh_driver::EVR || lapack_driver == Eigh_driver::GVD) {
             lrwork = _calc_lwork(tmp_rwork);
         } else if (lapack_driver == Eigh_driver::EVX || lapack_driver == Eigh_driver::GVX) {
-            lrwork = 7 * intn;
+            lrwork = 7 * intn; // See https://www.netlib.org/lapack/explore-html/d4/de0/group__heevx_ga08ec091a756fdf774ef02cae086f76cb.html#ga08ec091a756fdf774ef02cae086f76cb
         }
     }
 
@@ -577,8 +579,8 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
      * - `buff_A` contains a buffer for the data of `A`, size N * N, only allocated if `overwrite_a` is set
      */
     CBLAS_INT Z_size = (jobz != 'N') ? N * M : 0;
-    CBLAS_INT A_size = (overwrite_a) ? 0 : N * N;
-    CBLAS_INT B_size = (ap_Bm == NULL || overwrite_b) ? 0 : N * N;
+    CBLAS_INT A_size = (!overwrite_a) ? N * N : 0;
+    CBLAS_INT B_size = (ap_Bm != NULL && !overwrite_b) ? N * N : 0;
     T *buffer = (T *)malloc((lwork + Z_size + A_size + B_size) * sizeof(T));
     if (buffer == NULL) { info = -102; return int(info); }
 
@@ -613,22 +615,32 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     CBLAS_INT *ifail = &ibuffer[liwork + isuppz_size];
 
     /*
-     * Real work areas for complex inputs (lrwork) and buffer for eigenvalues
-     * if `range == 'I'` since then the length of elements could be too short
-     * for containing the full output.
+     * Some LAPACK routines require a real work area `rwork` for complex inputs.
+     *
+     * In addition, when `range == 'I'`, the allocated array for the eigenvalues
+     * is of size (M,) whereas the corresponding LAPACK routines always require
+     * a buffer of size (N,) for the eigenvalues. Therefore, when `M < N`, a new
+     * array is allocated to hand to the LAPACK call after which the relevant
+     * arguments can be copied over to the return object.
      */
-    CBLAS_INT w_size = (range == 'I') ? N : 0;
-    real_type *rbuffer = (real_type *)malloc((w_size + lrwork) * sizeof(real_type));
-    if (rbuffer == NULL) {
-        free(buffer);
-        free(ibuffer);
-        info = -104;
-        return int(info);
+    real_type *rbuffer = NULL;
+    real_type *buff_w = NULL;
+    real_type *rwork = NULL;
+
+    CBLAS_INT w_size = (range == 'I' && M < N) ? N : 0;
+    CBLAS_INT rbuffer_size = w_size + lrwork;
+    if (rbuffer_size != 0) {
+        rbuffer = (real_type *)malloc(rbuffer_size * sizeof(real_type));
+        if (rbuffer == NULL) {
+            free(buffer);
+            free(ibuffer);
+            info = -104;
+            return int(info);
+        }
+
+        buff_w = &rbuffer[0];
+        rwork = &rbuffer[w_size];
     }
-
-    real_type *buff_w = &rbuffer[0];
-    real_type *rwork = &rbuffer[w_size];
-
 
     // -------------------------------------------------------------------
     // Main batching loop
@@ -638,9 +650,11 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
 
     for (npy_intp idx = 0; idx < outer_size; idx++) {
 
-        // `w` is a vector, but should still traverse the same number of dimensions
-        // and the batch shape is the same for all arrays, so make use of `shape` and
-        // `ndim` for all slices.
+        /*
+         * `w` is a vector, but should still traverse the same number of dimensions
+         * and the batch shape is the same for all arrays, so make use of `shape` and
+         * `ndim` for all slices.
+         */
         slice_ptr_A = compute_slice_ptr(idx, A_data, ndim, shape, strides);
         slice_ptr_w = compute_slice_ptr(idx, w_data, ndim, shape, strides_w);
         if (jobz != 'N') {
@@ -651,7 +665,13 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
             slice_ptr_B = compute_slice_ptr(idx, B_data, ndim, shape, strides_B);
         }
 
-        real_type *lapack_w = (range == 'I') ? buff_w : slice_ptr_w; // Else the data can fit directly into the return object
+        /*
+         * Cfr. comment above: when `range == 'I`` and `M < N`, the allocated return
+         * object is not large enough for the LAPACK call, hence use an intermediate
+         * buffer and copy over the relevant `M` eigenvalues afterwards.
+         */
+        real_type *lapack_w = (range == 'I' && M < N) ? buff_w : slice_ptr_w;
+
         if (!overwrite_a) {
             // XXX: can exploit the structure of `A` in some way or the other?
             copy_slice_F(buff_A, slice_ptr_A, intn, intn, strides[ndim-2], strides[ndim-1]);
@@ -713,9 +733,9 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
             goto free_exit;
         }
 
-        if (range == 'I') {
-            memcpy(slice_ptr_w, buff_w, intm * sizeof(real_type));
-        } // NB. else the data is already in place, but here it could be smaller than provisioned if `range = 'I'`
+        if (range == 'I' && M < N) {
+            memcpy(slice_ptr_w, buff_w, M * sizeof(real_type));
+        } // If condition violated the eigenvalues are already in place, cfr. previous comments.
 
         if (jobz != 'N') {
             // Copy back eigenvectors
@@ -760,7 +780,7 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
             }
         }
 
-        // Update the `M` to return to python side for slicing of arrays in case of `range == 'V'`
+        // Update the relevant number of eigenvalues to return to python side for slicing of arrays in case of `range == 'V'`
         *intp_M = intm;
 
     } // End of batching loop
@@ -768,7 +788,10 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
 free_exit:
     free(buffer);
     free(ibuffer);
-    free(rbuffer);
+
+    if (rbuffer != NULL) {
+        free(rbuffer);
+    }
 
     return 1;
 }

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -602,7 +602,7 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     CBLAS_INT iwork_size = liwork;
     CBLAS_INT isuppz_size = (lapack_driver == Eigh_driver::EVR) ? 2 * M : 0;
     CBLAS_INT ifail_size = (lapack_driver == Eigh_driver::EVX || lapack_driver == Eigh_driver::GVX) ? N : 0;
-    CBLAS_INT *ibuffer = (CBLAS_INT *)malloc((iwork_size + isuppz_size + ifail_size) * sizeof(T));
+    CBLAS_INT *ibuffer = (CBLAS_INT *)malloc((iwork_size + isuppz_size + ifail_size) * sizeof(CBLAS_INT));
     if (ibuffer == NULL) {
         free(buffer);
         info = -103;

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -600,19 +600,35 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
         buff_B = B_data;
     } // NB. `overwrite_b` only enabled if input array is 2D
 
-    // integer work areas
-    CBLAS_INT iwork_size = liwork;
+    /*
+     * Integer work areas:
+     *
+     * - All LAPACK routines except `EV` and `GV` require an `iwork` argument.
+     * - `EVR` requires an integer return array for `isuppz` indicating the valid range of the eigenvectors.
+     * - `EVX`/`GVX` require an integer return array for `ifail` indicating the eigenvalues where it failed to converge.
+     */
+    CBLAS_INT *ibuffer = NULL;
+    CBLAS_INT *iwork = NULL;
+    CBLAS_INT *isuppz = NULL;
+    CBLAS_INT *ifail = NULL;
+
+    CBLAS_INT iwork_size = (lapack_driver != Eigh_driver::EV && lapack_driver != Eigh_driver::GV) ? liwork : 0;
     CBLAS_INT isuppz_size = (lapack_driver == Eigh_driver::EVR) ? 2 * M : 0;
     CBLAS_INT ifail_size = (lapack_driver == Eigh_driver::EVX || lapack_driver == Eigh_driver::GVX) ? N : 0;
-    CBLAS_INT *ibuffer = (CBLAS_INT *)malloc((iwork_size + isuppz_size + ifail_size) * sizeof(CBLAS_INT));
-    if (ibuffer == NULL) {
-        free(buffer);
-        info = -103;
-        return int(info);
+    CBLAS_INT ibuffer_size = iwork_size + isuppz_size + ifail_size;
+
+    if (ibuffer_size > 0) {
+        ibuffer = (CBLAS_INT *)malloc(ibuffer_size * sizeof(CBLAS_INT));
+        if(ibuffer == NULL) {
+            free(buffer);
+            info = -103;
+            return int(info);
+        }
+
+        iwork = &ibuffer[0];
+        isuppz = &ibuffer[liwork];
+        ifail = &ibuffer[liwork + isuppz_size];
     }
-    CBLAS_INT *iwork = &ibuffer[0];
-    CBLAS_INT *isuppz = &ibuffer[liwork];
-    CBLAS_INT *ifail = &ibuffer[liwork + isuppz_size];
 
     /*
      * Some LAPACK routines require a real work area `rwork` for complex inputs.
@@ -621,7 +637,8 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
      * is of size (M,) whereas the corresponding LAPACK routines always require
      * a buffer of size (N,) for the eigenvalues. Therefore, when `M < N`, a new
      * array is allocated to hand to the LAPACK call after which the relevant
-     * arguments can be copied over to the return object.
+     * arguments can be copied over to the return object. This buffer is called
+     * `buff_w`.
      */
     real_type *rbuffer = NULL;
     real_type *buff_w = NULL;
@@ -629,11 +646,15 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
 
     CBLAS_INT w_size = (range == 'I' && M < N) ? N : 0;
     CBLAS_INT rbuffer_size = w_size + lrwork;
-    if (rbuffer_size != 0) {
+    if (rbuffer_size > 0) {
         rbuffer = (real_type *)malloc(rbuffer_size * sizeof(real_type));
         if (rbuffer == NULL) {
             free(buffer);
-            free(ibuffer);
+
+            if (ibuffer != NULL) {
+                free(ibuffer);
+            }
+
             info = -104;
             return int(info);
         }
@@ -787,7 +808,10 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
 
 free_exit:
     free(buffer);
-    free(ibuffer);
+
+    if (ibuffer != NULL) {
+        free(ibuffer);
+    }
 
     if (rbuffer != NULL) {
         free(rbuffer);

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -506,12 +506,12 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
         }
 
         case Eigh_driver::EVR : {
-            call_sy_he_evr(&jobz, &range, &uplo, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, NULL, NULL, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &lrwork, &tmp_iwork, &liwork, &info);
+            call_sy_he_evr(&jobz, &range, &uplo, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, &intm, NULL, NULL, &intn, NULL, &tmp_work, &lwork, &tmp_rwork, &lrwork, &tmp_iwork, &liwork, &info);
             break;
         }
 
         case Eigh_driver::EVX : {
-            call_sy_he_evx(&jobz, &range, &uplo, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, NULL, NULL, NULL, &intn, &tmp_work, &lwork, &tmp_rwork, &tmp_iwork, NULL, &info);
+            call_sy_he_evx(&jobz, &range, &uplo, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, &intm, NULL, NULL, &intn, &tmp_work, &lwork, &tmp_rwork, &tmp_iwork, NULL, &info);
             break;
         }
 
@@ -526,7 +526,7 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
         }
 
         case Eigh_driver::GVX : {
-            call_sy_he_gvx(&int_itype, &jobz, &range, &uplo, &intn, NULL, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, NULL, NULL, NULL, &intn, &tmp_work, &lwork, &tmp_rwork, &tmp_iwork, NULL, &info);
+            call_sy_he_gvx(&int_itype, &jobz, &range, &uplo, &intn, NULL, &intn, NULL, &intn, &r_vl, &r_vu, &int_il, &int_iu, &abstol, &intm, NULL, NULL, &intn, &tmp_work, &lwork, &tmp_rwork, &tmp_iwork, NULL, &info);
             break;
         }
 

--- a/scipy/linalg/src/_linalg_eig.hh
+++ b/scipy/linalg/src/_linalg_eig.hh
@@ -538,9 +538,10 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
     if (info != 0) { info = -101; return (int)info; }
 
 
-    // process lwork probe
+    // process `lwork` probe
     lwork = _calc_lwork(tmp_work);
 
+    // process `lrwork` probe
     if constexpr (!detail::type_traits<T>::is_complex) {
         lrwork = 0;  // for real numbers LAPACK does not require `rwork`, hence set corresponding buffer size to 0.
     } else {
@@ -553,7 +554,8 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
         }
     }
 
-    liwork = (lapack_driver == Eigh_driver::EVX || lapack_driver == Eigh_driver::GVX) ? 5 * intn : tmp_iwork; // Already integer
+    // Process `liwork` probe, already integer so no need to use `_calc_lwork()`.
+    liwork = (lapack_driver == Eigh_driver::EVX || lapack_driver == Eigh_driver::GVX) ? 5 * intn : tmp_iwork;
 
 
     if ((lwork < 0) || (lrwork < 0) || (liwork < 0) ||
@@ -632,6 +634,8 @@ int _eigh(PyArrayObject *ap_Am, PyArrayObject *ap_Bm, PyArrayObject *ap_w, PyArr
 
     /*
      * Some LAPACK routines require a real work area `rwork` for complex inputs.
+     * In case the input is not complex `lrwork` was already set to 0 during the
+     * "process `lrwork` probe" stage above.
      *
      * In addition, when `range == 'I'`, the allocated array for the eigenvalues
      * is of size (M,) whereas the corresponding LAPACK routines always require

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1127,6 +1127,174 @@ class TestEigh:
         assert w.shape == (0,)
         assert w.dtype == w_n.dtype
 
+    @pytest.mark.parametrize("dtype", [
+        np.float32, np.float64, np.complex64, np.complex128
+    ])
+    @pytest.mark.parametrize("n", [5, 20])
+    @pytest.mark.parametrize("lower", [True, False])
+    @pytest.mark.parametrize("driver", ["ev", "evd", "evr", "evx", "gv", "gvd", "gvx"])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    def test_random(self, dtype, n, lower, driver, order):
+        rng = np.random.default_rng(seed=42)
+        atol = 6e-5 if dtype in [np.float32, np.complex64] else 1e-12
+
+        v_base = rng.normal(size=(n, n))
+        if np.issubdtype(dtype, np.complexfloating):
+            v_base = v_base + 1j * rng.normal(size=(n, n))
+        v_base = v_base.astype(dtype)
+        v, _ = qr(v_base, mode="full")
+
+        w = np.sort(rng.normal(size=(n,))).astype(dtype)
+        a = v @ np.diag(w) @ np.conj(v.T)
+
+        if order == "C":
+            a = np.asfortranarray(a)
+
+        if driver[0] == "g":
+            b = np.diag(1 + np.arange(n))
+            b = b.astype(dtype, order=order)
+        else:
+            b = None
+
+        w_n, v_n = eigh(a, b, lower=lower, driver=driver)
+        assert w_n.dtype == np.finfo(dtype).dtype
+        assert v_n.dtype == dtype
+
+        if b is None:
+            assert_allclose(a @ v_n, v_n @ np.diag(w_n), atol=atol)
+        else:
+            assert_allclose(a @ v_n, b @ v_n @ np.diag(w_n), atol=atol)
+
+    @pytest.mark.parametrize("dtype", [
+        np.float32, np.float64, np.complex64, np.complex128
+    ])
+    @pytest.mark.parametrize("n", [5, 20])
+    @pytest.mark.parametrize("lower", [True, False])
+    @pytest.mark.parametrize("driver", ["ev", "evd", "evr", "evx", "gv", "gvd", "gvx"])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    def test_subset_by_value(self, dtype, n, lower, driver, order):
+        rng = np.random.default_rng(seed=42)
+        vl, vu = -2, 2
+        atol = 8e-5 if dtype in [np.float32, np.complex64] else 1e-12
+
+        v_base = rng.normal(size=(n, n))
+        if np.issubdtype(dtype, np.complexfloating):
+            v_base = v_base + 1j * rng.normal(size=(n, n))
+        v_base = v_base.astype(dtype)
+        v, _ = qr(v_base, mode="full")
+
+        w = np.sort(rng.uniform(vl, vu, size=(n,))).astype(dtype)
+        w[0] = 5 * -np.abs(vl)
+        w[-1] = 5 * np.abs(vu)
+
+        a = v @ np.diag(w) @ np.conj(v.T)
+
+        if order == "F":
+            a = np.asfortranarray(a)
+
+        if driver[0] == "g":
+            b = np.eye(n, order=order, dtype=dtype)
+        else:
+            b = None
+
+        if driver not in ["evr", "evx", "gvx"]:
+            with pytest.raises(ValueError, match=f'"{driver}" cannot compute subsets'):
+                eigh(a, b, lower=lower, subset_by_value=(vl, vu), driver=driver)
+        else:
+            w_n, v_n = eigh(a, b, lower=lower, subset_by_value=(vl, vu), driver=driver)
+
+            assert w_n.shape[0] == n-2
+            assert np.all(vl < w_n) and np.all(w_n < vu)
+            assert v_n.shape == (n, n-2)
+
+            if b is None:
+                assert_allclose(a @ v_n, v_n @ np.diag(w_n), atol=atol)
+            else:
+                assert_allclose(a @ v_n, b @ v_n @ np.diag(w_n), atol=atol)
+
+    @pytest.mark.parametrize("shape", [(5, 5), (2, 5, 5)])
+    @pytest.mark.parametrize("driver", ["evr", "evx", "gvx"])
+    def test_subset_by_value_error(self, shape, driver):
+        rng = np.random.default_rng(seed=42)
+        vl, vu = -2, 2
+        atol = 1e-12
+        n = shape[-1]
+
+        v_base = rng.normal(size=shape)
+        v, _ = qr(v_base, mode="full")
+
+        w_diag = np.sort(rng.uniform(0, vu, size=shape[:-1]))
+        w_diag[..., 0] = -5 * np.abs(vu)
+        w_diag[..., -1] = 5 * np.abs(vu)
+        w = np.zeros(shape)
+        w[..., np.arange(n), np.arange(n)] = w_diag
+
+        a = v @ w @ np.conj(v.swapaxes(-2, -1))
+
+        if driver[0] == "g":
+            b = np.zeros(shape)
+            b[..., np.arange(n), np.arange(n)] = 1
+        else:
+            b = None
+
+        if len(shape) > 2:
+            with pytest.raises(ValueError, match='`subset_by_value` not supported'):
+                eigh(a, b, subset_by_value=(vl, vu), driver=driver)
+        else: # Still check for correctness of the result
+            w_n, v_n = eigh(a, b, subset_by_value=(vl, vu), driver=driver)
+
+            assert w_n.shape[0] == shape[-1] - 2
+            assert np.all(vl < w_n) and np.all(w_n < vu)
+            assert v_n.shape == (*shape[:-1], shape[-1] - 2)
+
+            if b is None:
+                assert_allclose(a @ v_n, v_n @ np.diag(w_n), atol=atol)
+            else:
+                assert_allclose(a @ v_n, b @ v_n @ np.diag(w_n), atol=atol)
+
+    @pytest.mark.parametrize("dtype", [
+        np.float32, np.float64, np.complex64, np.complex128
+    ])
+    @pytest.mark.parametrize("n", [5, 20])
+    @pytest.mark.parametrize("lower", [True, False])
+    @pytest.mark.parametrize("driver", ["ev", "evd", "evr", "evx", "gv", "gvd", "gvx"])
+    @pytest.mark.parametrize("order", ["C", "F"])
+    def test_subset_by_index(self, dtype, n, lower, driver, order):
+        rng = np.random.default_rng(seed=42)
+        il, iu = 1, 4
+        atol = 6e-5 if dtype in [np.float32, np.complex64] else 1e-12
+
+        v_base = rng.normal(size=(n, n))
+        if np.issubdtype(dtype, np.complexfloating):
+            v_base = v_base + 1j * rng.normal(size=(n, n))
+        v_base = v_base.astype(dtype)
+        v, _ = qr(v_base, mode="full")
+
+        w = np.sort(rng.uniform(-2, 2, size=(n,))).astype(dtype)
+        a = v @ np.diag(w) @ np.conj(v.T)
+
+        if order == "C":
+            a = np.asfortranarray(a)
+
+        if driver[0] == "g":
+            b = np.eye(n, order=order, dtype=dtype)
+        else:
+            b = None
+
+        if driver not in ["evr", "evx", "gvx"]:
+            with pytest.raises(ValueError, match=f'"{driver}" cannot compute subsets'):
+                eigh(a, b, lower=lower, subset_by_index=[il, iu], driver=driver)
+        else:
+            w_n, v_n = eigh(a, b, lower=lower, subset_by_index=[il, iu], driver=driver)
+
+            assert w_n.shape == (iu - il + 1,)
+            assert v_n.shape == (n, iu - il + 1)
+
+            if b is None:
+                assert_allclose(a @ v_n, v_n @ np.diag(w_n), atol=atol)
+            else:
+                assert_allclose(a @ v_n, b @ v_n @ np.diag(w_n), atol=atol)
+
 class TestSVD_GESDD:
     lapack_driver = 'gesdd'
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1295,6 +1295,35 @@ class TestEigh:
             else:
                 assert_allclose(a @ v_n, b @ v_n @ np.diag(w_n), atol=atol)
 
+    @pytest.mark.parametrize("dtypes", [
+        (np.float32, np.float64), (np.complex64, np.complex128)
+    ])
+    @pytest.mark.parametrize("driver", ["gv", "gvd", "gvx"])
+    def test_b_upcast_a(self, dtypes, driver):
+        # Regression test to deal with the case where `b` upcasts `a` which would
+        # necessitate recomputing the `overwrite_a` flag in its entirety.
+        n = 5
+        rng = np.random.default_rng(seed=12345)
+        atol = 1e-14
+
+        dtype_a, dtype_b = dtypes
+
+        v_base = rng.normal(size=(n, n))
+        if np.issubdtype(dtype_b, np.complexfloating):
+            v_base = v_base + 1j * rng.normal(size=(n, n))
+        v_base = v_base.astype(dtype_b)
+        v, _ = qr(v_base, mode="full")
+
+        w = np.sort(rng.uniform(-2, 2, size=(n,))).astype(dtype_b)
+        a = (v @ np.diag(w) @ np.conj(v.T)).astype(dtype_a)
+        b = np.eye(n, dtype=dtype_b)
+
+        w_n, v_n = eigh(a, b, driver=driver)
+
+        # check correctness
+        assert_allclose(a @ v_n, b @ v_n @ np.diag(w_n), atol=atol)
+
+
 class TestSVD_GESDD:
     lapack_driver = 'gesdd'
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1112,9 +1112,10 @@ class TestEigh:
     @pytest.mark.parametrize('dt_b', [
         None, int, float, np.float32, complex, np.complex64
     ])
-    def test_empty(self, dt_a, dt_b):
-        a = np.empty((0, 0), dtype=dt_a)
-        b = np.empty((0, 0), dtype=dt_b) if dt_b is not None else None
+    @pytest.mark.parametrize('shape', [(10, 0, 5, 5), (0, 0)])
+    def test_empty(self, dt_a, dt_b, shape):
+        a = np.empty(shape, dtype=dt_a)
+        b = np.empty(shape, dtype=dt_b) if dt_b is not None else None
 
         a_ref = np.eye(2, dtype=dt_a)
         b_ref = np.eye(2, dtype=dt_b) if dt_b is not None else None
@@ -1122,16 +1123,15 @@ class TestEigh:
         w, v = eigh(a, b)
         w_n, v_n = eigh(a_ref, b_ref)
 
-        assert w.shape == (0,)
+        assert w.shape == shape[:-1]
         assert w.dtype == w_n.dtype
 
-        assert v.shape == (0, 0)
+        assert v.shape == shape
         assert v.dtype == v_n.dtype
 
         w = eigh(a, b, eigvals_only=True)
-        assert_allclose(w, np.empty((0,)))
 
-        assert w.shape == (0,)
+        assert w.shape == shape[:-1]
         assert w.dtype == w_n.dtype
 
     @pytest.mark.parametrize("dtype", [

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1108,12 +1108,19 @@ class TestEigh:
         assert_equal(len(w3), 2)
         assert_allclose(w3, np.array([1.2, 1.3]))
 
-    @pytest.mark.parametrize('dt', [int, float, np.float32, complex, np.complex64])
-    def test_empty(self, dt):
-        a = np.empty((0, 0), dtype=dt)
-        w, v = eigh(a)
+    @pytest.mark.parametrize('dt_a', [int, float, np.float32, complex, np.complex64])
+    @pytest.mark.parametrize('dt_b', [
+        None, int, float, np.float32, complex, np.complex64
+    ])
+    def test_empty(self, dt_a, dt_b):
+        a = np.empty((0, 0), dtype=dt_a)
+        b = np.empty((0, 0), dtype=dt_b) if dt_b is not None else None
 
-        w_n, v_n = eigh(np.eye(2, dtype=dt))
+        a_ref = np.eye(2, dtype=dt_a)
+        b_ref = np.eye(2, dtype=dt_b) if dt_b is not None else None
+
+        w, v = eigh(a, b)
+        w_n, v_n = eigh(a_ref, b_ref)
 
         assert w.shape == (0,)
         assert w.dtype == w_n.dtype
@@ -1121,7 +1128,7 @@ class TestEigh:
         assert v.shape == (0, 0)
         assert v.dtype == v_n.dtype
 
-        w = eigh(a, eigvals_only=True)
+        w = eigh(a, b, eigvals_only=True)
         assert_allclose(w, np.empty((0,)))
 
         assert w.shape == (0,)
@@ -1322,6 +1329,36 @@ class TestEigh:
 
         # check correctness
         assert_allclose(a @ v_n, b @ v_n @ np.diag(w_n), atol=atol)
+
+    @pytest.mark.parametrize("dtype", [
+        np.float32, np.float64, np.complex64, np.complex128
+    ])
+    @pytest.mark.parametrize("driver", ["evr", "evx", "gvx"])
+    def test_subset_by_index_full(self, dtype, driver):
+        # Regression test to check if `subset_by_index` when requesting the full
+        # range is behaving correctly
+        n = 5
+        atol = 1e-14 if dtype in [np.float64, np.complex128] else 4e-5
+        rng = np.random.default_rng(seed=12345)
+
+        a_base = rng.normal(size=(n, n))
+        if np.issubdtype(dtype, np.complexfloating):
+            a_base = a_base + 1j * rng.normal(size=(n, n))
+        a_base = a_base.astype(dtype)
+        a = a_base @ np.conj(a_base.T)
+
+        if driver[0] == "g":
+            b = np.eye(5, dtype=dtype)
+        else:
+            b = None
+
+        w_n, v_n = eigh(a, b, driver=driver, subset_by_index=[0, n-1])
+
+        # Validate correctness
+        if b is not None:
+            assert_allclose(a @ v_n, b @ v_n @ np.diag(w_n), atol=atol)
+        else:
+            assert_allclose(a @ v_n, v_n @ np.diag(w_n), atol=atol)
 
 
 class TestSVD_GESDD:


### PR DESCRIPTION
#### Reference issue
Towards #24474 by starting the work on `eigh`.

#### What does this implement/fix?
Prepares moving the different drivers for `eigh` one-by-one into the lower-level implementation. Given the plethora of options, I thought it would be best to start setting up the infrastructure and implement one driver as a proof of concept and to gather some feedback before proceeding with the rest. A bit similar to what was done for `solve`.

Note that this PR is more meant as a starting point to facilitate discussion etc. rather than a full-fledged ready-to-merge PR as explained below. It is therefore expected that parts of this might have to be reworked. 

#### Additional information
- ~Currently there is a bug in the implementation where `sy/heevr` is complaining about `il` and/or `iu` being illegal arguments when using `subset_by_index`, which is an issue I haven't been able to resolve as of yet, meaning it is expected CI will turn all red.~
- ~As mentioned before, this PR tries to set up some infrastructure to facilitate putting in the other drivers, but only `driver = "evr"` is implemented right now, so not all provisions for other drivers, especially for the generalized eigenvalue problem, will be in place and/or be complete.~ (EDIT: all drivers are ported now.)
- ~For now I have sidestepped the issue that might occur when combining `subset_by_value` with multidimensional input, as tracked in #24605, but perhaps it is best to continue the discussion about that in the corresponding issue.~ Done, but a release note for this should still be added.
- There are still a few todo's in the code, such as potentially reusing the input matrix to store the eigenvectors (`sy/heevr` does not return the eigenvectors in the input buffer) and potentially exploiting the structure of the input to speed up the copy operations akin to #24913, but I held of on those for now to first have a working baseline. (Test might also have to be improved a bit, especially for `overwrite_x` arguments, but since the implementation of `overwrite_x` is not fully known as of yet I held of on that too.)
- ~Once this is all in place the decorator on `eigvalsh` should be removed since that would throttle the gains that are made by this PR for batched inputs (and to a certain extent it isn't even needed right now since `eigh` internally takes care of the batching already with the decorator and `eigvalsh` is just dispatching to it).~

A bit longer term, assuming that this PR gets into proper shape, it might still be useful to discuss whether to add all drivers in this PR, add them in one-by-one in follow-up PRs or find some kind of middleground.

To facilitate the discussion on `overwrite_x`, below the fold is a quick REPL result that shows the backwards compat picture for the regular eigenvalue problem. 

<details>

```python
>>> import numpy as np
>>> import scipy as sp
>>> sp.__version__
'1.17.1'
>>> rng = np.random.default_rng(seed=42)
>>> n = 3
>>> a = rng.normal(size=(n, n))
>>> a_f = np.asfortranarray(a)
>>> a
array([[ 0.30471708, -1.03998411,  0.7504512 ],
       [ 0.94056472, -1.95103519, -1.30217951],
       [ 0.1278404 , -0.31624259, -0.01680116]])
>>> w_n, v_n = sp.linalg.eigh(a, overwrite_a=True, lower=True, driver="ev")
>>> v_n
array([[ 0.33755672,  0.03044042, -0.94081286],
       [-0.93005922, -0.14324952, -0.33833329],
       [-0.14507   ,  0.98921836, -0.02004344]])
>>> a # intact
array([[ 0.30471708, -1.03998411,  0.7504512 ],
       [ 0.94056472, -1.95103519, -1.30217951],
       [ 0.1278404 , -0.31624259, -0.01680116]])
>>> w_n, v_n = sp.linalg.eigh(a_f, overwrite_a=True, lower=True, driver="ev")  
>>> a_f # overwritten + eigenvectors in place
array([[ 0.33755672,  0.03044042, -0.94081286],
       [-0.93005922, -0.14324952, -0.33833329],
       [-0.14507   ,  0.98921836, -0.02004344]])
>>> a_f = np.asfortranarray(a)
>>>
>>>
>>> w_n, v_n = sp.linalg.eigh(a, overwrite_a=True, lower=True, driver="evd")
>>> a # intact
array([[ 0.30471708, -1.03998411,  0.7504512 ],
       [ 0.94056472, -1.95103519, -1.30217951],
       [ 0.1278404 , -0.31624259, -0.01680116]])
>>> w_n, v_n = sp.linalg.eigh(a_f, overwrite_a=True, lower=True, driver="evd")  
>>> a_f # overwritten + eigenvectors in place
array([[ 0.33755672,  0.03044042, -0.94081286],
       [-0.93005922, -0.14324952, -0.33833329],
       [-0.14507   ,  0.98921836, -0.02004344]])
>>> a_f = np.asfortranarray(a)
>>>
>>>
>>> w_n, v_n = sp.linalg.eigh(a, overwrite_a=True, lower=True, driver="evr")
>>> a # intact
array([[ 0.30471708, -1.03998411,  0.7504512 ],
       [ 0.94056472, -1.95103519, -1.30217951],
       [ 0.1278404 , -0.31624259, -0.01680116]])
>>> w_n, v_n = sp.linalg.eigh(a_f, overwrite_a=True, lower=True, driver="evr")  
>>> a_f # overwritten, lower diagonal destroyed
array([[ 0.30471708, -1.03998411,  0.7504512 ],
       [-0.94921291, -2.00035775, -1.30217951],
       [ 0.06764838,  0.04664001,  0.0325214 ]])
>>> a_f = np.asfortranarray(a)
>>>
>>>
>>> w_n, v_n = sp.linalg.eigh(a, overwrite_a=True, lower=True, driver="evx")
>>> a # intact
array([[ 0.30471708, -1.03998411,  0.7504512 ],
       [ 0.94056472, -1.95103519, -1.30217951],
       [ 0.1278404 , -0.31624259, -0.01680116]])
>>> w_n, v_n = sp.linalg.eigh(a_f, overwrite_a=True, lower=True, driver="evx") 
>>> a_f # overwritten, lower diagonal destroyed
array([[ 0.30471708, -1.03998411,  0.7504512 ],
       [-0.94921291, -2.00035775, -1.30217951],
       [ 0.06764838,  0.04664001,  0.0325214 ]])
>>>
```

</details>

When the conditions for overwriting are fullfilled (i.e. F-ordered input), it seems like the old f2py implementation is following LAPACK calling conventions directly; when LAPACK returns the eigenvectors inside of the input matrix (`ev`/`evd`) they can indeed be found in `a` directly. Else the triangular part is just destroyed (`evr`/`evx`). I presume it would be best to just implement `overwrite_x` such that the eigenvectors can always be found in `a` to save on memory? This would require an additional copy operation for `evr`/`evx`, but that would always be necessary anyways.

#### AI Generation Disclosure
No AI
