### PR TITLE
TST: remove redundant `xp` enforcement for `desired`

### DIFF
--- a/scipy/_lib/_array_api.py
+++ b/scipy/_lib/_array_api.py
@@ -233,7 +233,7 @@ def _strict_check(actual, desired, xp, *,
             xp = array_namespace(desired)
 
     if check_namespace:
-        _assert_matching_namespace(actual, desired, xp)
+        _assert_matching_namespace(actual, xp)
 
     # only NumPy distinguishes between scalars and arrays; we do if check_0d=True.
     # do this first so we can then cast to array (and thus use the array API) below.
@@ -261,19 +261,15 @@ def _strict_check(actual, desired, xp, *,
     return actual, desired, xp
 
 
-def _assert_matching_namespace(actual, desired, xp):
+def _assert_matching_namespace(actual, xp):
     __tracebackhide__ = True  # Hide traceback for py.test
 
-    desired_arr_space = array_namespace(desired)
-    _msg = ("Namespace of desired array does not match expectations "
-            "set by the `default_xp` context manager or by the `xp`"
-            "pytest fixture.\n"
-            f"Desired array's space: {desired_arr_space.__name__}\n"
-            f"Expected namespace: {xp.__name__}")
-    assert desired_arr_space == xp, _msg
-
     actual_arr_space = array_namespace(actual)
-    _msg = ("Namespace of actual and desired arrays do not match.\n"
+    # since the `default_xp` context manager is used for the entire
+    # test suite, `xp` can serve as the source of truth for the
+    # desired namespace. The `desired` array is coerced to that
+    # namespace in any case in `_strict_check`.
+    _msg = ("Input does not have the desired array namespace.\n"
             f"Actual: {actual_arr_space.__name__}\n"
             f"Desired: {xp.__name__}")
     assert actual_arr_space == xp, _msg

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -176,14 +176,12 @@ class TestArrayAPI:
         if is_numpy(xp):
             xp_assert_equal(x, y, **options)
         else:
+            # `desired` can be of a different namespace
+            # as long as `actual` matches the expectation set by `default_xp`
+            xp_assert_equal(x, y, **options)
             with pytest.raises(
                 AssertionError,
-                match="Namespace of desired array does not match",
-            ):
-                xp_assert_equal(x, y, **options)
-            with pytest.raises(
-                AssertionError,
-                match="Namespace of actual and desired arrays do not match",
+                match="Input does not have the desired array namespace",
             ):
                 xp_assert_equal(y, x, **options)
 


### PR DESCRIPTION
closes gh-22709

as explained in gh-22709, now that we are using the `default_xp` context
manager across the whole testsuite, we can loosen the requirement that
`desired` has the expected namespace, instead converting if it doesn't
match the source of truth

[skip circle]
