### PR TITLE
BUG: linalg: warn when solve_sylvester encounters singular equation

### DIFF
--- a/scipy/linalg/_solvers.py
+++ b/scipy/linalg/_solvers.py
@@ -109,6 +109,12 @@ def solve_sylvester(a, b, q):
 
     if info < 0:
         raise LinAlgError(f"Illegal value encountered in the {-info} term")
+    if info == 1:
+        warnings.warn(
+            "The Sylvester equation may be singular (A and B share a common "
+            "or close eigenvalue). The returned solution may be inaccurate.",
+            stacklevel=2,
+        )
 
     return np.dot(np.dot(u, y), v.conj().transpose())
 

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -860,3 +860,11 @@ class TestSolveSylvester:
 
         assert res.shape == (m, n)
         assert res.dtype == ref.dtype
+
+    def test_singular_warns(self):
+        # A and B share an eigenvalue -> Sylvester equation is singular
+        a = np.array([[1.0, 0.0], [0.0, 2.0]])
+        b = np.array([[-1.0, 0.0], [0.0, -3.0]])
+        q = np.ones((2, 2))
+        with pytest.warns(UserWarning, match="singular"):
+            solve_sylvester(a, b, q)


### PR DESCRIPTION
#### What does this implement/fix?

Fixes gh-23066.

`solve_sylvester` silently returns a potentially inaccurate result when LAPACK `trsyl` reports `info=1` (indicating that A and B share a common or near-common eigenvalue, making the Sylvester equation singular or nearly singular). This change issues a `UserWarning` so users are aware the solution may be unreliable.

#### Additional information

Per the discussion in #23066, a warning is preferred over a hard `LinAlgError` since eigenvalue computation involves floating-point approximation and a hard stop could be overly restrictive for near-singular cases.

#### AI Generation Disclosure

AI tools (Claude) were used to assist in drafting this patch. I reviewed, tested, and understand the change fully.