### PR TITLE
BUG: signal: handle empty input array in lfilter

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2226,6 +2226,12 @@ def lfilter(b, a, x, axis=-1, zi=None):
     if not (a.ndim == 1 and xp_size(a) > 0):
         raise ValueError(f"Parameter a is not a non-empty 1d array, since {a.shape=}!")
 
+    if x.shape[axis] == 0:
+        if zi is None:
+            return xp.asarray(x)
+        else:
+            return xp.asarray(x), xp.asarray(zi.copy())
+
     if len(a) == 1:
         # This path only supports types fdgFDGO to mirror _linear_filter below.
         # Any of b, a, x, or zi can set the dtype, but there is no default

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2335,6 +2335,21 @@ def test_lfilter_notimplemented_input(xp):
     assert_raises(NotImplementedError, lfilter, [2,3], [4,5], [1,2,3,4,5])
 
 
+def test_lfilter_empty_input():
+    # gh-22571: empty x should return empty y and unchanged zi
+    b = np.array([1.0, 0.5])
+    a = np.array([1.0, -0.5])
+    x = np.array([])
+    zi = np.array([0.25])
+
+    y, zf = lfilter(b, a, x, zi=zi)
+    assert y.shape == (0,)
+    assert_array_equal(zf, zi)
+
+    y_no_zi = lfilter(b, a, x)
+    assert y_no_zi.shape == (0,)
+
+
 @pytest.mark.parametrize('dt', ["uint8", "int8", "uint16", "int16",
                                 "uint32", "int32",
                                 "uint64", "int64",


### PR DESCRIPTION
When `x` has size 0 along the filter axis, `lfilter` now returns an empty output array directly instead of entering the C filter loop. When `zi` is provided, `zf` is returned as a copy of `zi` (unchanged state).

Previously, filtering an empty array could return leaked state from a prior call because the C backend skipped the loop body but still returned the `zf` buffer from the previous invocation.

Closes #22571