### PR TITLE
BUG: signal: handle empty input array in lfilter

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -2234,6 +2234,12 @@ def lfilter(b, a, x, axis=-1, zi=None):
     if not (a.ndim == 1 and xp_size(a) > 0):
         raise ValueError(f"Parameter a is not a non-empty 1d array, since {a.shape=}!")
 
+    if x.shape[axis] == 0:
+        if zi is None:
+            return xp.asarray(x)
+        else:
+            return xp.asarray(x), xp.asarray(zi.copy())
+
     if len(a) == 1:
         # This path only supports types fdgFDGO to mirror _linear_filter below.
         # Any of b, a, x, or zi can set the dtype, but there is no default

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2352,7 +2352,11 @@ def test_lfilter_notimplemented_input(xp):
 
 
 def test_lfilter_empty_input():
-    # gh-22571: empty x should return empty y and unchanged zi
+    """Verify that unchanged `zi` is returned for an empty input `x`
+
+    This test ensures correct special handling for empty inputs,
+    to prevent leaking internal state as reported in gh-22571.
+    """
     b = np.array([1.0, 0.5])
     a = np.array([1.0, -0.5])
     x = np.array([])
@@ -2360,7 +2364,7 @@ def test_lfilter_empty_input():
 
     y, zf = lfilter(b, a, x, zi=zi)
     assert y.shape == (0,)
-    assert_array_equal(zf, zi)
+    xp_assert_equal(zf, zi)
 
     y_no_zi = lfilter(b, a, x)
     assert y_no_zi.shape == (0,)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -2351,6 +2351,21 @@ def test_lfilter_notimplemented_input(xp):
     assert_raises(NotImplementedError, lfilter, [2,3], [4,5], [1,2,3,4,5])
 
 
+def test_lfilter_empty_input():
+    # gh-22571: empty x should return empty y and unchanged zi
+    b = np.array([1.0, 0.5])
+    a = np.array([1.0, -0.5])
+    x = np.array([])
+    zi = np.array([0.25])
+
+    y, zf = lfilter(b, a, x, zi=zi)
+    assert y.shape == (0,)
+    assert_array_equal(zf, zi)
+
+    y_no_zi = lfilter(b, a, x)
+    assert y_no_zi.shape == (0,)
+
+
 @pytest.mark.parametrize('dt', ["uint8", "int8", "uint16", "int16",
                                 "uint32", "int32",
                                 "uint64", "int64",


### PR DESCRIPTION
## Description

When `x` has size 0 along the filter axis, `lfilter` now returns an empty output array directly instead of entering the C filter loop. When `zi` is provided, `zf` is returned as a copy of `zi` (unchanged state).

Previously, filtering an empty array could return leaked state from a prior call because the C loop would skip iteration but the output buffer was uninitialized.

Closes #22571

## AI Generation Disclosure

Git processing (branch management, PR submission) was assisted by Claude. The code changes themselves were written through manual analysis of the issue and the existing `lfilter` implementation.