### PR TITLE
BUG: avoid circular imports in special (#25336)

### DIFF
--- a/scipy/special/_ufuncs_extra_code.pxi
+++ b/scipy/special/_ufuncs_extra_code.pxi
@@ -1,7 +1,5 @@
 cimport scipy.special._ufuncs_cxx
 cimport scipy.special._ellip_harm_2
-import scipy.special._special_ufuncs
-import scipy.special._gufuncs
 import numpy as np
 
 
@@ -166,6 +164,9 @@ def seterr(**kwargs):
     for error, action in kwargs.items():
         action = _sf_error_action_map[action]
         code = _sf_error_code_map[error]
+        # Import is delayed to avoid circular problems in astroid/pylint.
+        import scipy.special._special_ufuncs
+        import scipy.special._gufuncs
         # Error handling state must be set for all relevant
         # extension modules in synchrony, since each carries
         # a separate copy of this state.


### PR DESCRIPTION
While CPython can deal with the previous import situation,
pylint with --extension-pkg-whitelist=scipy was running into
RecursionError in astroid if the functions were imported too early.

#### Reference issue
Closes gh-25336.

#### What does this implement/fix?
Moves runtime imports to later time, which seems to be enough for astroid to resolve the circularity.

#### Additional information
The fixed worked in my specific environment, I am not sure how to test it more generally.

#### AI Generation Disclosure
Multiple generative AI systems were used for examination of the source, but the contributed code and comments are all human (done in a separate clone of the repo).