### PR TITLE
BUG: cluster.hierarchy: fix index-range check in from_mlab_linkage

### DIFF
--- a/scipy/cluster/hierarchy/_hierarchy_impl.py
+++ b/scipy/cluster/hierarchy/_hierarchy_impl.py
@@ -1784,7 +1784,7 @@ def from_mlab_linkage(Z):
 
     lazy = is_lazy_array(Z)
 
-    if not lazy and xp.min(Z[:, :2]) != 1.0 and xp.max(Z[:, :2]) != 2 * n:
+    if not lazy and (xp.min(Z[:, :2]) != 1.0 or xp.max(Z[:, :2]) != 2 * n):
         raise ValueError('The format of the indices is not 1..N')
 
     res = xp.empty((Z.shape[0], Z.shape[1] + 1), dtype=Z.dtype)
@@ -1793,7 +1793,7 @@ def from_mlab_linkage(Z):
 
     def cy_from_mlab_linkage(Zpart, validate):
         n = Zpart.shape[0]
-        if validate and np.min(Zpart[:, :2]) != 0.0 and np.max(Zpart[:, :2]) != 2 * n:
+        if validate and (np.min(Zpart[:, :2]) != 0.0 or np.max(Zpart[:, :2]) != 2 * n):
             raise ValueError('The format of the indices is not 1..N')
 
         if not Zpart.flags.writeable:

--- a/scipy/cluster/hierarchy/tests/test_hierarchy.py
+++ b/scipy/cluster/hierarchy/tests/test_hierarchy.py
@@ -286,6 +286,18 @@ class TestMLabLinkageConversion:
         xp_assert_close(to_mlab_linkage(Z), xp.asarray(Zm, dtype=xp.float64),
                         rtol=1e-15)
 
+    @skip_xp_backends("jax.numpy", reason="Can't raise inside jax.pure_callback")
+    def test_mlab_linkage_conversion_bad_indices(self, xp):
+        # An index outside the 1..2N MATLAB range must be rejected instead of
+        # being fed to calculate_cluster_sizes, which indexes the size buffer
+        # with no bounds check.  A minimum index of 1 with an out-of-range
+        # maximum previously slipped past the format check.
+        Zm = xp.asarray([[1., 2., 0.5],
+                         [1., 100., 0.6],
+                         [1., 1., 0.7]])
+        with pytest.raises(ValueError, match="format of the indices"):
+            from_mlab_linkage(Zm)
+
 
 @make_xp_test_case(fclusterdata)
 class TestFclusterData:


### PR DESCRIPTION
from_mlab_linkage gated the 1..2N index check with `and`, so a matrix with min index 1 but an out-of-range max slipped past validation into calculate_cluster_sizes, which indexes the cluster-size buffer with boundscheck off and reads out of bounds (a 1e9 index segfaults here); the two comparisons want `or` so either bad bound is rejected.