### PR TITLE
BUG: sparse.kron: preserve dtype in zero-result fast path

### DIFF
--- a/scipy/sparse/_construct.py
+++ b/scipy/sparse/_construct.py
@@ -859,7 +859,8 @@ def kron(A, B, format=None):
 
             if A.nnz == 0 or B.nnz == 0:
                 # kronecker product is the zero matrix
-                return coo_sparse(output_shape).asformat(format)
+                dtype = upcast(A.dtype, B.dtype)
+                return coo_sparse(output_shape, dtype=dtype).asformat(format)
 
             B = B.toarray()
             data = A.data.repeat(B.size).reshape(-1, B.shape[0], B.shape[1])
@@ -881,7 +882,8 @@ def kron(A, B, format=None):
 
     if A.nnz == 0 or B.nnz == 0:
         # kronecker product is the zero matrix
-        return coo_sparse(output_shape).asformat(format)
+        dtype = upcast(A.dtype, B.dtype)
+        return coo_sparse(output_shape, dtype=dtype).asformat(format)
 
     # expand entries of a into blocks
     data = A.data.repeat(B.nnz)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -411,6 +411,15 @@ class TestConstructUtils:
         assert_array_equal(result.toarray(), expected)
         assert isinstance(result, spmatrix)
 
+    def test_kron_zero_matrix_dtype():
+        A = csr_array([[0]], dtype=np.int64)
+        B = csr_array([[3]], dtype=np.int64)
+
+        result = construct.kron(A, B)
+
+        assert result.dtype == np.int64
+        assert result.nnz == 0
+
     @pytest.mark.filterwarnings("ignore:.*switching.*sparse array:DeprecationWarning")
     def test_kron_ndim_exceptions(self):
         # spmatrix is default, so exceptions with 3D unless sparse arrays are input

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -411,21 +411,17 @@ class TestConstructUtils:
         assert_array_equal(result.toarray(), expected)
         assert isinstance(result, spmatrix)
 
-    def test_kron_zero_matrix_dtype(self):
-        # BSR fast path
-        A = csr_array([[0]], dtype=np.int64)
-        B = csr_array([[3]], dtype=np.int64)
+    @pytest.mark.parametrize(
+        "b",
+        [
+            csr_array([[3]], dtype=np.int64),        # BSR Path
+            csr_array([[3, 0, 0]], dtype=np.int64),  # COO Path
+        ],
+    )
+    def test_kron_zero_matrix_dtype(self, b):
+        a = csr_array([[0]], dtype=np.int64)
 
-        result = construct.kron(A, B)
-
-        assert result.dtype == np.int64
-        assert result.nnz == 0
-
-        # COO fast path
-        A = csr_array([[0]], dtype=np.int64)
-        B = csr_array([[3, 0, 0]], dtype=np.int64)
-
-        result = construct.kron(A, B)
+        result = construct.kron(a, b)
 
         assert result.dtype == np.int64
         assert result.nnz == 0

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -411,9 +411,19 @@ class TestConstructUtils:
         assert_array_equal(result.toarray(), expected)
         assert isinstance(result, spmatrix)
 
-    def test_kron_zero_matrix_dtype():
+    def test_kron_zero_matrix_dtype(self):
+        # BSR fast path
         A = csr_array([[0]], dtype=np.int64)
         B = csr_array([[3]], dtype=np.int64)
+
+        result = construct.kron(A, B)
+
+        assert result.dtype == np.int64
+        assert result.nnz == 0
+
+        # COO fast path
+        A = csr_array([[0]], dtype=np.int64)
+        B = csr_array([[3, 0, 0]], dtype=np.int64)
 
         result = construct.kron(A, B)
 


### PR DESCRIPTION
**Issue**

Closes #25338

**Summary**

Fix dtype inconsistency in the zero-result fast path of `scipy.sparse.kron`.

When one input has `nnz == 0`, the early-return branch constructs a zero sparse matrix without applying the same dtype inference as the main implementation path. This can lead to inconsistent dtype behavior (e.g. integer inputs producing `float64` results in the zero-case).

This change applies consistent dtype inference via `upcast(A.dtype, B.dtype)` in the zero-case branch.

**Changes**
- Fix dtype handling in the zero-result fast path of `scipy.sparse.kron`.
- Ensure consistency with dtype inference used in the main implementation path.
- Add regression test for integer sparse inputs producing a zero Kronecker product.

**AI assistance disclosure**

This contribution was prepared with assistance from an AI system and manually reviewed and tested.