### PR TITLE
REL: set version to `1.18.0rc3` unreleased

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ requires = [
 
 [project]
 name = "scipy"
-version = "1.18.0rc2"
+version = "1.18.0rc3.dev0"
 # TODO: add `license-files` once PEP 639 is accepted (see meson-python#88)
 #       at that point, no longer include them in `py3.install_sources()`
 license = { file = "LICENSE.txt" }


### PR DESCRIPTION
* Set the version to SciPy `1.18.0rc3` "unreleased." (we don't plan RC3 I don't think, but just the usual procedure to bump version)

* This is mostly for release process visibility and the CI is skipped. I currently have the "final" release set to June 19th on my calendar.

[ci skip] [skip ci]

#### AI Generation Disclosure
 No AI tools used