### PR TITLE
ENH: Numpy fast path for finite logsumexp (1.2x to 2x speedup)

### DIFF
--- a/scipy/special/_logsumexp.py
+++ b/scipy/special/_logsumexp.py
@@ -114,25 +114,30 @@ def logsumexp(a, axis=None, b=None, keepdims=False, return_sign=False):
     axis = tuple(range(a.ndim)) if axis is None else axis
 
     if xp_size(a) != 0:
-        with np.errstate(divide='ignore', invalid='ignore', over='ignore'):
-            # Where result is infinite, we use the direct logsumexp calculation to
-            # delegate edge case handling to the behavior of `xp.log` and `xp.exp`,
-            # which should follow the C99 standard for complex values.
-            b_exp_a = xp.exp(a) if b is None else b * xp.exp(a)
-            sum_ = xp.sum(b_exp_a, axis=axis, keepdims=True)
-            sgn_inf = xp.sign(sum_) if return_sign else None
-            sum_ = xp.abs(sum_) if return_sign else sum_
-            out_inf = xp.log(sum_)
-
         with np.errstate(divide='ignore', invalid='ignore'):  # log of zero is OK
             out, sgn = _logsumexp(a, b, axis=axis, return_sign=return_sign, xp=xp)
 
         # Replace infinite results. This probably could be done with an
         # `apply_where`-like strategy to avoid redundant calculation, but currently
         # `apply_where` itself is only for elementwise functions.
+        # As a shortcut, for a plain NumPy array we skip the fallback entirely when
+        # `out` is already finite. Only works for exact `np.ndarray`s, `is_numpy()`
+        # or isinstance would admit subclasses like masked arrays, which would break
+        # all()/where() equivalence. Other eager backends like torch CPU could use
+        # the same trick in theory, but NumPy shows the biggest perf win.
         out_finite = xp.isfinite(out)
-        out = xp.where(out_finite, out, out_inf)
-        sgn = xp.where(out_finite, sgn, sgn_inf) if return_sign else sgn
+        if not (type(out) is np.ndarray and out_finite.all()):
+            with np.errstate(divide='ignore', invalid='ignore', over='ignore'):
+                # Where result is infinite, we use the direct logsumexp calculation to
+                # delegate edge case handling to the behavior of `xp.log` and `xp.exp`,
+                # which should follow the C99 standard for complex values.
+                b_exp_a = xp.exp(a) if b is None else b * xp.exp(a)
+                sum_ = xp.sum(b_exp_a, axis=axis, keepdims=True)
+                sgn_inf = xp.sign(sum_) if return_sign else None
+                sum_ = xp.abs(sum_) if return_sign else sum_
+                out_inf = xp.log(sum_)
+            out = xp.where(out_finite, out, out_inf)
+            sgn = xp.where(out_finite, sgn, sgn_inf) if return_sign else sgn
     else:
         shape = np.asarray(a.shape)  # NumPy is convenient for shape manipulation
         shape[axis] = 1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Addresses https://github.com/scipy/scipy/issues/9300

#### What does this implement/fix?
<!--Please explain your changes.-->

The fallback for handling infinite values is legit and good, but unnecessary for NumPy ndarrays with finite values, since the `out` array already exists in memory and we can cheaply verify that all of the elements are finite. Moving the fallback to inside a gated block means we can do half the work in the specific but common case of an ndarray with finite values. I've observed a 20% speedup for small inputs ( < 1000 elements), and up to a 2x speedup as input size grows and the fallback cost dominates.

In theory other eager backends could also benefit from the same strategy, but numpy is the clearest win since `all()` is relatively cheap and the kernel cost isn't too expensive. On my mac, host-side Torch tensors saw a 1.05x to 1.4x speedup from the same strategy. I think this is less dramatic than numpy because for torch `all()` is a dispatched reduction and the  kernel itself was slower on my hardware relative to the fallback. Anyway happy to discuss whether there's a more general set of conditions we could use to decide whether to take the fast path. I think we need:
1. equivalence between all() and where() (e.g. no masked arrays)
2. eager backend
3. all() needs to be cheaper than the direct fallback

#### Additional information
<!--Any additional information you think is important.-->

I didn't check in any new benchmarks here - let me know if you'd like me to contribute some, would be happy to do so.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

AI (claude) was used to help out with writing and running performance benchmarks locally, and also reviewed this diff.
