### PR TITLE
BUG: io/matlab: reject out-of-range mdtype in mio5 element reader

### DIFF
--- a/scipy/io/matlab/_mio5_utils.pyx
+++ b/scipy/io/matlab/_mio5_utils.pyx
@@ -405,6 +405,17 @@ cdef class VarReader5:
                 self.cstream.seek(8 - mod8, 1)
         return 0
 
+    cdef inline cnp.dtype dtype_for_mdtype(self, cnp.uint32_t mdtype):
+        ''' Return numpy dtype for matlab data type code `mdtype`
+
+        `mdtype` is read straight from the file tag, so an unknown or
+        out-of-range code must be rejected rather than used to index past
+        the fixed-size ``dtypes`` pointer array.
+        '''
+        if mdtype >= _N_MIS or self.dtypes[mdtype] == NULL:
+            raise ValueError('Unknown matlab data type code %d' % mdtype)
+        return <cnp.dtype>self.dtypes[mdtype]
+
     cpdef cnp.ndarray read_numeric(self, int copy=True, size_t nnz=-1):
         ''' Read numeric data element into ndarray
 
@@ -444,7 +455,7 @@ cdef class VarReader5:
         cdef cnp.ndarray el
         cdef object data = self.read_element(
             &mdtype, &byte_count, <void **>&data_ptr, copy)
-        cdef cnp.dtype dt = <cnp.dtype>self.dtypes[mdtype]
+        cdef cnp.dtype dt = self.dtype_for_mdtype(mdtype)
         if dt.itemsize != 1 and nnz != -1 and byte_count == nnz:
             el_count = <cnp.npy_intp> nnz
             dt = BOOL_DTYPE
@@ -843,7 +854,7 @@ cdef class VarReader5:
         # specifically np.uint8, np.int8, np.uint16.  np.unit16 can have
         # a length 1 type encoding, like ascii, or length 2 type
         # encoding
-        dt = <cnp.dtype>self.dtypes[mdtype]
+        dt = self.dtype_for_mdtype(mdtype)
         if mdtype == miUINT16:
             codec = self.uint16_codec
             if self.codecs['uint16_len'] == 1: # need LSBs only

--- a/scipy/io/matlab/tests/test_pathological.py
+++ b/scipy/io/matlab/tests/test_pathological.py
@@ -2,12 +2,15 @@
 
 We try and read any file that matlab reads, these files included
 """
+import struct
+from io import BytesIO
 from os.path import dirname, join as pjoin
 
+import numpy as np
 from numpy.testing import assert_
 from pytest import raises as assert_raises
 
-from scipy.io.matlab._mio import loadmat
+from scipy.io.matlab._mio import loadmat, savemat
 
 TEST_DATA_PATH = pjoin(dirname(__file__), 'data')
 
@@ -31,3 +34,28 @@ def test_malformed1():
     fname = pjoin(TEST_DATA_PATH, 'malformed1.mat')
     with open(fname, 'rb') as f:
         assert_raises(ValueError, loadmat, f)
+
+
+def _patch_mdtype(payload, marker, mdtype):
+    # Overwrite the 4-byte mdtype of the full element whose data is `marker`.
+    data = bytearray(payload)
+    idx = data.find(marker)
+    assert idx != -1
+    struct.pack_into('<I', data, idx - 8, mdtype)
+    return bytes(data)
+
+
+def test_bad_data_type_code():
+    # A data element tag carries the mdtype straight from the file. An unknown
+    # or out-of-range code must not be used to index the dtypes array.
+    #
+    # Should raise an exception, not segfault
+    num = BytesIO()
+    savemat(num, {'a': np.array([[1234.5]])}, do_compression=False)
+    txt = BytesIO()
+    savemat(txt, {'s': 'WXYZ0123'}, do_compression=False)
+    for payload, marker in ((num.getvalue(), struct.pack('<d', 1234.5)),
+                            (txt.getvalue(), b'WXYZ0123')):
+        for code in (8, 9999):  # unused in-range slot, then past the array
+            bad = _patch_mdtype(payload, marker, code)
+            assert_raises(ValueError, loadmat, BytesIO(bad))


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

Loading a crafted `.mat` file segfaults the v5 reader.

    $ python -c "from scipy.io import loadmat; loadmat('crafted.mat')"
    [1]    52431 segmentation fault  python

Tracked it down with lldb. The element data type code (`mdtype`) is read
straight from the tag in `cread_tag`, then used to index `VarReader5.dtypes`,
a 20-slot C pointer array, inside `read_numeric` and `read_char`. Nothing
range-checks it first.

Only codes 1..18 are populated. Codes 0/8/10/11/14/15/19 land on NULL slots and
anything >= 20 reads past the array. The `<cnp.dtype>` cast then increments the
refcount of whatever pointer comes back, so a numeric or char element carrying
such a code dereferences a NULL or wild pointer instead of raising.

To confirm, I saved a 1-element array, patched its data tag to `mdtype = 8`
and reloaded:

    ValueError: Unknown matlab data type code 8   # with this change

Reject the code (range plus non-NULL) before the lookup, at both readers.

#### Additional information

The trust boundary is `loadmat` on an untrusted file. Same code reached through
`read_real_complex` and `read_sparse` (both go via `read_numeric`).

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
