### PR TITLE
BUG: use `forkserver` only when available

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -580,11 +580,14 @@ class MapWrapper:
             self.pool = pool
             self._mapfunc = self.pool
         else:
-            from multiprocessing import get_context, get_start_method
+            from multiprocessing import (
+                get_all_start_methods, get_context, get_start_method
+            )
 
             method = get_start_method(allow_none=True)
 
-            if method is None and os.name=='posix' and sys.version_info < (3, 14):
+            if (method is None and sys.version_info < (3, 14)
+                    and 'forkserver' in get_all_start_methods()):
                 # Python 3.13 and older used "fork" on posix, which can lead to
                 # deadlocks. This backports that fix to older Python versions.
                 method = 'forkserver'

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -7,7 +7,6 @@ import numbers
 from collections import namedtuple
 import inspect
 import math
-import os
 import sys
 import textwrap
 from types import ModuleType

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -100,7 +100,8 @@ def pytest_configure(config):
             "iterations(n): run the given test function `n` times in each thread",
         )
 
-    if os.name == 'posix' and sys.version_info < (3, 14) and sys.platform != "cygwin":
+    if (sys.version_info < (3, 14)
+            and 'forkserver' in multiprocessing.get_all_start_methods()):
         # On POSIX, Python 3.13 and older uses the 'fork' context by
         # default. Calling fork() from multiple threads leads to
         # deadlocks. This has been changed in 3.14 to 'forkserver'.


### PR DESCRIPTION
#### Reference issue
https://github.com/scipy/scipy/issues/25351

#### What does this implement/fix?
It generalizes the condition for forcing `forkserver` start method so that it's only forced when available on the platform/interpreter. This makes it work on alternative interpreters like GraalPy that don't have forkserver.

#### Additional information

#### AI Generation Disclosure
I have used codex to generate this mechanical change
