### PR TITLE
MAINT: bump array-api-extra to v0.11.0

### DIFF
--- a/scipy/sparse/linalg/_interface.py
+++ b/scipy/sparse/linalg/_interface.py
@@ -352,7 +352,7 @@ class LinearOperator:
 
         y = self._rmatvec(x) if adjoint else self._matvec(x)
 
-        broadcasted_dims = xpx.broadcast_shapes(self_broadcast_dims, x_broadcast_dims)
+        broadcasted_dims = xp.broadcast_shapes(self_broadcast_dims, x_broadcast_dims)
         if row_vector:
             y = xp.reshape(y, (*broadcasted_dims, outer_dim))
         elif column_vector:
@@ -979,7 +979,7 @@ class _SumLinearOperator(LinearOperator):
         *B_broadcast_dims, B_M, B_N = B.shape
         if (A_M, A_N) != (B_M, B_N):
             raise ValueError(f"cannot add {A} and {B}: shape mismatch")
-        broadcasted_dims = xpx.broadcast_shapes(A_broadcast_dims, B_broadcast_dims)
+        broadcasted_dims = xp.broadcast_shapes(A_broadcast_dims, B_broadcast_dims)
         self.args = (A, B)
         super().__init__(_get_dtype([A, B], xp=xp), (*broadcasted_dims, A_M, A_N), xp)
 

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -59,9 +59,10 @@ def generate_broadcastable_shapes(nshapes, *, ndim=2, min=0, max=10, rng=None):
     assert np.broadcast_shapes(*shapes) == batch_shape
     return [tuple(int(el) for el in shape) for shape in shapes]
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 class TestLinearOperator:
     def setup_method(self):
         self.A = np.array([[1,2,3],
@@ -499,9 +500,6 @@ class TestDotTests:
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
     @pytest.mark.parametrize("args", square_args_list)
-    @pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
     def test_identity_square(
         self, args: OperatorArgs, batch_shape: tuple[int, ...], xp
     ):
@@ -525,9 +523,6 @@ class TestDotTests:
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
     @pytest.mark.parametrize("args", all_args_list)
-    @pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
     def test_identity_nonsquare(
         self, args: OperatorArgs, batch_shape: tuple[int, ...], xp
     ):
@@ -577,9 +572,6 @@ class TestDotTests:
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
     @pytest.mark.parametrize("args", square_args_list)
-    @pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
     def test_scaling_square(self, args: OperatorArgs, batch_shape: tuple[int, ...], xp):
         """
         Simple (complex) scaling operator on square matrices.
@@ -604,9 +596,6 @@ class TestDotTests:
         self.check_matmat(xp, op, data_dtype=args.data_dtype, complex_data=args.complex)
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
-    @pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
     def test_subclass_matmat(self, batch_shape: tuple[int, ...], xp):
         """
         Simple rotation operator defined by `matmat` and `adjoint`,
@@ -849,9 +838,10 @@ class TestAsLinearOperator:
             assert_equal(A.dot(x1), A_array.dot(x1))
             assert_equal(A.dot(x2), A_array.dot(x2))
 
-    @pytest.mark.xfail_xp_backends('dask.array',
-                                    reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+    @pytest.mark.xfail_xp_backends('dask.array', reason=(
+        "dask does not support broadcast_shapes(). " 
+        "See: https://github.com/data-apis/array-api-compat/issues/439"
+    ))
     @pytest.mark.parametrize("dtype", ["int64", "float64", "complex128"])
     def test_xp(self, dtype, xp):
         if dtype == "int64" and is_torch(xp) and SCIPY_DEVICE != "cpu":
@@ -893,17 +883,19 @@ class TestAsLinearOperator:
 
             assert hasattr(A, 'args')
             
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def test_repr(xp):
     A = interface.LinearOperator(shape=(1, 1), matvec=lambda x: xp.asarray([1]), xp=xp)
     repr_A = repr(A)
     assert 'unspecified dtype' not in repr_A, repr_A
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def test_identity(xp):
     ident = interface.IdentityOperator((3, 3), xp=xp)
     xp_assert_equal(ident @ xp.asarray([1, 2, 3]), xp.asarray([1, 2, 3]))
@@ -911,9 +903,10 @@ def test_identity(xp):
 
     assert_raises(ValueError, ident.matvec, xp.asarray([1, 2, 3, 4]))
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def test_attributes(xp):
     A = interface.aslinearoperator(xp.reshape(xp.arange(16, dtype=xp.float64), (4, 4)))
 
@@ -930,9 +923,10 @@ def test_attributes(xp):
         assert hasattr(op, "shape")
         assert hasattr(op, "_matvec")
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def matvec_for_pickle(x):
     """ Needed for test_pickle as local functions are not pickleable """
     return x
@@ -942,9 +936,10 @@ def matvec_for_pickle(x):
     "array_api_strict",
     reason="pickle-ability is not guaranteed by the standard"
 )
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def test_pickle(xp):
     import pickle
 
@@ -957,9 +952,10 @@ def test_pickle(xp):
         for k in A.__dict__:
             assert getattr(A, k) == getattr(B, k)
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def test_inheritance(xp):
     class Empty(interface.LinearOperator):
         pass
@@ -989,9 +985,10 @@ def test_inheritance(xp):
     mm = MatmatOnly(xp.asarray(np.random.randn(5, 3)))
     assert mm.matvec(xp.asarray(np.random.randn(3))).shape == (5,)
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def test_dtypes_of_operator_sum(xp):
     # gh-6078
 
@@ -1007,9 +1004,10 @@ def test_dtypes_of_operator_sum(xp):
     assert sum_real.dtype == xp.float64
     assert sum_complex.dtype == xp.complex128
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def test_no_double_init(xp):
     call_count = [0]
 
@@ -1029,9 +1027,10 @@ COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 INEXACTDTYPES = REAL_DTYPES + COMPLEX_DTYPES
 ALLDTYPES = INT_DTYPES + INEXACTDTYPES
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 @pytest.mark.parametrize("test_dtype", ALLDTYPES)
 def test_determine_lo_dtype_from_matvec(test_dtype, xp):
     if "longdouble" in test_dtype.__name__ and not is_numpy(xp):
@@ -1065,9 +1064,10 @@ def test_determine_lo_dtype_for_int(xp):
     lo = interface.LinearOperator((2, 2), matvec=mv, xp=xp)
     assert xp.isdtype(lo.dtype, "integral")
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def test_adjoint_conjugate(xp):
     X = xp.asarray([[1j]], dtype=xp.complex128)
     A = interface.aslinearoperator(X)
@@ -1087,9 +1087,10 @@ def test_ndim(xp):
     A = interface.aslinearoperator(X)
     assert A.ndim == 2
 
-@pytest.mark.xfail_xp_backends('dask.array',
-                                   reason="dask does not support broadcast_shapes()." \
-    " See: https://github.com/data-apis/array-api-compat/issues/439")
+@pytest.mark.xfail_xp_backends('dask.array', reason=(
+    "dask does not support broadcast_shapes(). " 
+    "See: https://github.com/data-apis/array-api-compat/issues/439"
+))
 def test_transpose_noconjugate(xp):
     X = xp.asarray([[1j]], dtype=xp.complex128)
     A = interface.aslinearoperator(X)

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -505,7 +505,7 @@ class TestDotTests:
         Tests batches of RHS via `args.batch_shape`.
         """
         def identity(x):
-            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            shape = (*xp.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
             return xp.broadcast_to(x, shape)
 
         shape = batch_shape + args.shape
@@ -543,7 +543,7 @@ class TestDotTests:
                 case -1:  # pad with zeros
                     x = pad_core_dim(x, target_size=M)
 
-            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            shape = (*xp.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
             return xp.broadcast_to(x, shape)
 
         def rmv(x):            
@@ -555,7 +555,7 @@ class TestDotTests:
                 case -1:  # crop x to size
                     x = x[..., :N]
 
-            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            shape = (*xp.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
             return xp.broadcast_to(x, shape)
 
         shape = batch_shape + args.shape
@@ -576,12 +576,12 @@ class TestDotTests:
         """
         def scale(x):
             scale = (3 + 2j) / abs(3 + 2j)
-            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            shape = (*xp.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
             return xp.broadcast_to(scale * x, shape)
 
         def r_scale(x):
             scale = (3 - 2j) / abs(3 - 2j)
-            shape = (*xpx.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
+            shape = (*xp.broadcast_shapes(batch_shape, x.shape[:-1]), x.shape[-1])
             return xp.broadcast_to(scale * x, shape)
 
         shape = batch_shape + args.shape
@@ -612,7 +612,7 @@ class TestDotTests:
                     [np.sin(theta),  np.cos(theta)]
                 ])
                 B = R @ X
-                shape = xpx.broadcast_shapes(batch_shape, X.shape[:-2]) + X.shape[-2:]
+                shape = xp.broadcast_shapes(batch_shape, X.shape[:-2]) + X.shape[-2:]
                 return xp.broadcast_to(B, shape)
 
             def _adjoint(self):

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -497,6 +497,9 @@ class TestDotTests:
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
     @pytest.mark.parametrize("args", square_args_list)
+    @pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
     def test_identity_square(
         self, args: OperatorArgs, batch_shape: tuple[int, ...], xp
     ):
@@ -520,6 +523,9 @@ class TestDotTests:
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
     @pytest.mark.parametrize("args", all_args_list)
+    @pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
     def test_identity_nonsquare(
         self, args: OperatorArgs, batch_shape: tuple[int, ...], xp
     ):
@@ -569,6 +575,9 @@ class TestDotTests:
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
     @pytest.mark.parametrize("args", square_args_list)
+    @pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
     def test_scaling_square(self, args: OperatorArgs, batch_shape: tuple[int, ...], xp):
         """
         Simple (complex) scaling operator on square matrices.
@@ -593,6 +602,9 @@ class TestDotTests:
         self.check_matmat(xp, op, data_dtype=args.data_dtype, complex_data=args.complex)
 
     @pytest.mark.parametrize("batch_shape", [(), (3,), (3, 4, 5,), (0,)])
+    @pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
     def test_subclass_matmat(self, batch_shape: tuple[int, ...], xp):
         """
         Simple rotation operator defined by `matmat` and `adjoint`,

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -59,7 +59,9 @@ def generate_broadcastable_shapes(nshapes, *, ndim=2, min=0, max=10, rng=None):
     assert np.broadcast_shapes(*shapes) == batch_shape
     return [tuple(int(el) for el in shape) for shape in shapes]
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 class TestLinearOperator:
     def setup_method(self):
         self.A = np.array([[1,2,3],
@@ -847,6 +849,9 @@ class TestAsLinearOperator:
             assert_equal(A.dot(x1), A_array.dot(x1))
             assert_equal(A.dot(x2), A_array.dot(x2))
 
+    @pytest.mark.xfail_xp_backends('dask.array',
+                                    reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
     @pytest.mark.parametrize("dtype", ["int64", "float64", "complex128"])
     def test_xp(self, dtype, xp):
         if dtype == "int64" and is_torch(xp) and SCIPY_DEVICE != "cpu":
@@ -888,13 +893,17 @@ class TestAsLinearOperator:
 
             assert hasattr(A, 'args')
             
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def test_repr(xp):
     A = interface.LinearOperator(shape=(1, 1), matvec=lambda x: xp.asarray([1]), xp=xp)
     repr_A = repr(A)
     assert 'unspecified dtype' not in repr_A, repr_A
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def test_identity(xp):
     ident = interface.IdentityOperator((3, 3), xp=xp)
     xp_assert_equal(ident @ xp.asarray([1, 2, 3]), xp.asarray([1, 2, 3]))
@@ -919,7 +928,9 @@ def test_attributes(xp):
         assert hasattr(op, "shape")
         assert hasattr(op, "_matvec")
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def matvec_for_pickle(x):
     """ Needed for test_pickle as local functions are not pickleable """
     return x
@@ -941,7 +952,9 @@ def test_pickle(xp):
         for k in A.__dict__:
             assert getattr(A, k) == getattr(B, k)
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def test_inheritance(xp):
     class Empty(interface.LinearOperator):
         pass
@@ -971,7 +984,9 @@ def test_inheritance(xp):
     mm = MatmatOnly(xp.asarray(np.random.randn(5, 3)))
     assert mm.matvec(xp.asarray(np.random.randn(3))).shape == (5,)
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def test_dtypes_of_operator_sum(xp):
     # gh-6078
 
@@ -987,7 +1002,9 @@ def test_dtypes_of_operator_sum(xp):
     assert sum_real.dtype == xp.float64
     assert sum_complex.dtype == xp.complex128
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def test_no_double_init(xp):
     call_count = [0]
 
@@ -1007,7 +1024,9 @@ COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 INEXACTDTYPES = REAL_DTYPES + COMPLEX_DTYPES
 ALLDTYPES = INT_DTYPES + INEXACTDTYPES
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 @pytest.mark.parametrize("test_dtype", ALLDTYPES)
 def test_determine_lo_dtype_from_matvec(test_dtype, xp):
     if "longdouble" in test_dtype.__name__ and not is_numpy(xp):
@@ -1041,7 +1060,9 @@ def test_determine_lo_dtype_for_int(xp):
     lo = interface.LinearOperator((2, 2), matvec=mv, xp=xp)
     assert xp.isdtype(lo.dtype, "integral")
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def test_adjoint_conjugate(xp):
     X = xp.asarray([[1j]], dtype=xp.complex128)
     A = interface.aslinearoperator(X)
@@ -1061,7 +1082,9 @@ def test_ndim(xp):
     A = interface.aslinearoperator(X)
     assert A.ndim == 2
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def test_transpose_noconjugate(xp):
     X = xp.asarray([[1j]], dtype=xp.complex128)
     A = interface.aslinearoperator(X)

--- a/scipy/sparse/linalg/tests/test_interface.py
+++ b/scipy/sparse/linalg/tests/test_interface.py
@@ -911,7 +911,9 @@ def test_identity(xp):
 
     assert_raises(ValueError, ident.matvec, xp.asarray([1, 2, 3, 4]))
 
-
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def test_attributes(xp):
     A = interface.aslinearoperator(xp.reshape(xp.arange(16, dtype=xp.float64), (4, 4)))
 
@@ -940,6 +942,9 @@ def matvec_for_pickle(x):
     "array_api_strict",
     reason="pickle-ability is not guaranteed by the standard"
 )
+@pytest.mark.xfail_xp_backends('dask.array',
+                                   reason="dask does not support broadcast_shapes()." \
+    " See: https://github.com/data-apis/array-api-compat/issues/439")
 def test_pickle(xp):
     import pickle
 

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -579,7 +579,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                 if any_contains_nan and (nan_policy == 'propagate'
                                          and override['nan_propagation']):
                     res = xp.full(n_out, xp.nan, dtype=NaN.dtype)
-                    res = _add_reduced_axes(res, reduced_axes, keepdims)
+                    res = _add_reduced_axes(res, reduced_axes, keepdims, xp=xp)
                     return tuple_to_result(*res)
 
                 # Addresses nan_policy == "omit"
@@ -595,12 +595,12 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                 if is_too_small(samples, kwds):
                     warnings.warn(too_small_msg, SmallSampleWarning, stacklevel=2)
                     res = xp.full(n_out, xp.nan, dtype=NaN.dtype)
-                    res = _add_reduced_axes(res, reduced_axes, keepdims)
+                    res = _add_reduced_axes(res, reduced_axes, keepdims, xp=xp)
                     return tuple_to_result(*res)
 
                 res = hypotest_fun_out(*samples, **kwds)
                 res = result_to_tuple(res, n_out)
-                res = _add_reduced_axes(res, reduced_axes, keepdims)
+                res = _add_reduced_axes(res, reduced_axes, keepdims, xp=xp)
                 return tuple_to_result(*res)
 
             # check for empty input
@@ -614,7 +614,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
                     warnings.warn(too_small_nd_not_omit, SmallSampleWarning,
                                   stacklevel=2)
                 res = [xp_copy(empty_output) for i in range(n_out)]
-                res = _add_reduced_axes(res, reduced_axes, keepdims)
+                res = _add_reduced_axes(res, reduced_axes, keepdims, xp=xp)
                 return tuple_to_result(*res)
 
             if not is_numpy(xp) and 'nan_policy' in kwds:
@@ -643,7 +643,7 @@ def _axis_nan_policy_factory(tuple_to_result, default_axis=0,
             if vectorized and not contains_nan and not sentinel:
                 res = hypotest_fun_out(*samples, axis=axis, **kwds)
                 res = result_to_tuple(res, n_out)
-                res = _add_reduced_axes(res, reduced_axes, keepdims)
+                res = _add_reduced_axes(res, reduced_axes, keepdims, xp=xp)
                 return tuple_to_result(*res)
 
             # Addresses nan_policy == "omit"

--- a/scipy/stats/_axis_nan_policy.py
+++ b/scipy/stats/_axis_nan_policy.py
@@ -281,7 +281,7 @@ def _add_reduced_axes(res, reduced_axes, keepdims, xp=np):
     Add reduced axes back to all the arrays in the result object
     if keepdims = True.
     """
-    return ([xpx.expand_dims(output, axis=reduced_axes)
+    return ([xp.expand_dims(output, axis=reduced_axes)
              if not isinstance(output, int) else output for output in res]
             if keepdims else res)
 

--- a/scipy/stats/_resampling.py
+++ b/scipy/stats/_resampling.py
@@ -1356,7 +1356,7 @@ def power(test, rvs, n_observations, *, significance=0.01, vectorized=None,
     pvalues = xp.reshape(pvalues, shape + (-1,))
     if significance.ndim > 0:
         newdims = tuple(range(significance.ndim, pvalues.ndim + significance.ndim))
-        significance = xpx.expand_dims(significance, axis=newdims)
+        significance = xp.expand_dims(significance, axis=newdims)
 
     float_dtype = xp_result_type(significance, pvalues, xp=xp)
     powers = xp.mean(xp.astype(pvalues < significance, float_dtype), axis=-1)

--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -10752,7 +10752,7 @@ def lmoment(sample, order=None, *, axis=0, sorted=False, standardize=True):
 
     n_moments = 4 if is_lazy_array(order) else int(xp.max(order))
     k = xp.arange(n_moments, dtype=sample.dtype)
-    prk = _prk(xpx.expand_dims(k, axis=tuple(range(1, sample.ndim+1))), k)
+    prk = _prk(xp.expand_dims(k, axis=tuple(range(1, sample.ndim+1))), k)
     bk = _br(sample, r=k, xp=xp)
 
     n = sample.shape[-1]

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1247,7 +1247,7 @@ class TestPower:
         popmeans = xp.asarray([0, 0.2])
         def test(x, alternative, axis=-1):
             # ensure that popmeans axis is zeroth and orthogonal to the rest
-            popmeans_expanded = xpx.expand_dims(popmeans,
+            popmeans_expanded = xp.expand_dims(popmeans,
                                                 axis=tuple(range(1, x.ndim + 1)))
             alternative = alternatives[int(alternative)]
             return stats.ttest_1samp(x, popmeans_expanded, alternative=alternative,

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1247,7 +1247,7 @@ class TestPower:
         def test(x, alternative, axis=-1):
             # ensure that popmeans axis is zeroth and orthogonal to the rest
             popmeans_expanded = xp.expand_dims(popmeans,
-                                                axis=tuple(range(1, x.ndim + 1)))
+                                            axis=tuple(range(1, x.ndim + 1)))
             alternative = alternatives[int(alternative)]
             return stats.ttest_1samp(x, popmeans_expanded, alternative=alternative,
                                      axis=axis)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -1247,7 +1247,7 @@ class TestPower:
         def test(x, alternative, axis=-1):
             # ensure that popmeans axis is zeroth and orthogonal to the rest
             popmeans_expanded = xp.expand_dims(popmeans,
-                                            axis=tuple(range(1, x.ndim + 1)))
+                                               axis=tuple(range(1, x.ndim + 1)))
             alternative = alternatives[int(alternative)]
             return stats.ttest_1samp(x, popmeans_expanded, alternative=alternative,
                                      axis=axis)

--- a/scipy/stats/tests/test_resampling.py
+++ b/scipy/stats/tests/test_resampling.py
@@ -10,7 +10,6 @@ from scipy._lib._array_api import (is_numpy, make_xp_test_case, xp_default_dtype
                                    xp_size, array_namespace, _xp_copy_to_numpy,
                                    is_lazy_array, eager_warns)
 from scipy._lib._array_api_no_0d import xp_assert_close, xp_assert_equal
-from scipy._external import array_api_extra as xpx
 from scipy import stats, special
 from scipy.fft.tests.test_fftlog import skip_xp_backends
 from scipy.optimize import root


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

Related to: #25143 

#### What does this implement/fix?
<!--Please explain your changes.-->

`xpx.broadcast_shapes` -> `xp.broadcast_shapes`
`xpx.expand_dims` -> `xp.expand_dims`

#### Additional information
<!--Any additional information you think is important.-->
See: https://github.com/data-apis/array-api-extra/releases/tag/v0.11.0
In the new release of array_api_extra, `broadcast_shapes` and `expand_dims` are deprecated — their functionality now exists in v2025.12 of the standard.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI tools used