### PR TITLE
BUG: ndimage: allow a list index in array-API labeled measurements

### DIFF
--- a/scipy/ndimage/_delegators.py
+++ b/scipy/ndimage/_delegators.py
@@ -202,7 +202,9 @@ uniform_filter1d_signature = maximum_filter1d_signature
 
 
 def maximum_signature(input, labels=None, index=None):
-    return array_namespace(input, labels, index)
+    # `index` only selects labels and doesn't affect the result namespace;
+    # passing it to `array_namespace` made a list `index` raise (gh-25357).
+    return array_namespace(input, labels)
 
 minimum_signature = maximum_signature
 median_signature = maximum_signature

--- a/scipy/ndimage/tests/test_measurements.py
+++ b/scipy/ndimage/tests/test_measurements.py
@@ -1312,6 +1312,22 @@ def test_extrema04(xp):
         assert output1[3] == output5
 
 
+@make_xp_test_case(ndimage.minimum_position, ndimage.maximum_position,
+                   ndimage.extrema)
+def test_measurement_list_index_array_api(xp):
+    # gh-25357: a plain list `index` must not be treated as a separate
+    # (NumPy) array namespace from a non-NumPy `input`. The labeled
+    # measurement functions share `maximum_signature`, which previously
+    # passed `index` to `array_namespace` and raised for a list `index`.
+    input = xp.asarray([[1., 3., 0.], [0., 0., 2.]])
+    labels = xp.asarray([[1, 1, 0], [0, 0, 2]])
+    assert ndimage.maximum_position(input, labels, [1, 2]) == [(0, 1), (1, 2)]
+    assert ndimage.minimum_position(input, labels, [1, 2]) == [(0, 0), (1, 2)]
+    _, _, minpos, maxpos = ndimage.extrema(input, labels, [1, 2])
+    assert minpos == [(0, 0), (1, 2)]
+    assert maxpos == [(0, 1), (1, 2)]
+
+
 @make_xp_test_case(ndimage.center_of_mass)
 def test_center_of_mass01(xp):
     expected = (0.0, 0.0)


### PR DESCRIPTION
#### Reference issue
Closes gh-25357

#### What does this implement/fix?
`maximum_signature` in `scipy/ndimage/_delegators.py` resolved the array namespace from `index` along with `input` and `labels`. `index` only selects labels (an int or sequence of ints) and never determines the result namespace so a plain python list `index` was treated as a NumPy array and raised `TypeError: Multiple namespaces for array inputs` whenever `input` was a non-NumPy array-API array (jax, torch, cupy, array_api_strict, dask).

`maximum_signature` backs the whole labeled-measurement family (`minimum`, `maximum`, `median`, `mean`, `variance`, `standard_deviation`, `sum`/`sum_labels`, `minimum_position`, `maximum_position`, `extrema`, `center_of_mass`), so all of them were affected. `histogram_signature` already omits `index`.

This drops `index` from the `array_namespace` call to match `histogram_signature` and adds a regression test that calls `maximum_position`/`minimum_position`/`extrema` with a list `index` under the array API.

#### Additional information
The NumPy path is unchanged (the delegator only selects the dispatch namespace). Only the spurious raise for a non-NumPy input with a list `index` is removed.

#### AI Generation Disclosure
The code change and regression test were drafted with Claude (Anthropic) and reviewed with OpenAI Codex. I verified the fix and test locally (overlaying the change on the scipy 1.17.1 wheel with array_api_strict) and confirmed the NumPy path is unchanged. This description is my own.
