### PR TITLE
MAINT: special: adopt new xsf nested `cpu` namespace

### DIFF
--- a/scipy/special/xsf_wrappers.cpp
+++ b/scipy/special/xsf_wrappers.cpp
@@ -9,6 +9,7 @@
 #include <xsf/binom.h>
 #include <xsf/cdflib.h>
 #include <xsf/convex_analysis.h>
+#include <xsf/cpu/stats.h>
 #include <xsf/digamma.h>
 #include <xsf/digammainv.h>
 #include <xsf/ellip.h>
@@ -617,15 +618,15 @@ double xsf_gdtrib(double a, double p, double x) { return xsf::gdtrib(a, p, x); }
 
 double xsf_gdtrix(double a, double b, double p) { return xsf::gdtrix(a, b, p); }
 
-double xsf_kolmogorov(double x) { return xsf::kolmogorov(x); }
+double xsf_kolmogorov(double x) { return xsf::cpu::kolmogorov(x); }
 
-double xsf_kolmogc(double x) { return xsf::kolmogc(x); }
+double xsf_kolmogc(double x) { return xsf::cpu::kolmogc(x); }
 
-double xsf_kolmogi(double x) { return xsf::kolmogi(x); }
+double xsf_kolmogi(double x) { return xsf::cpu::kolmogi(x); }
 
-double xsf_kolmogci(double x) { return xsf::kolmogci(x); }
+double xsf_kolmogci(double x) { return xsf::cpu::kolmogci(x); }
 
-double xsf_kolmogp(double x) { return xsf::kolmogp(x); }
+double xsf_kolmogp(double x) { return xsf::cpu::kolmogp(x); }
 
 double xsf_nbdtr(int k, int n, double p) { return xsf::nbdtr(k, n, p); }
 
@@ -655,15 +656,15 @@ double xsf_pdtrc(double k, double m) { return xsf::pdtrc(k, m); }
 
 double xsf_pdtri(int k, double y) { return xsf::pdtri(k, y); }
 
-double xsf_smirnov(int n, double x) { return xsf::smirnov(n, x); }
+double xsf_smirnov(int n, double x) { return xsf::cpu::smirnov(n, x); }
 
-double xsf_smirnovc(int n, double x) { return xsf::smirnovc(n, x); }
+double xsf_smirnovc(int n, double x) { return xsf::cpu::smirnovc(n, x); }
 
-double xsf_smirnovi(int n, double x) { return xsf::smirnovi(n, x); }
+double xsf_smirnovi(int n, double x) { return xsf::cpu::smirnovi(n, x); }
 
-double xsf_smirnovci(int n, double x) { return xsf::smirnovci(n, x); }
+double xsf_smirnovci(int n, double x) { return xsf::cpu::smirnovci(n, x); }
 
-double xsf_smirnovp(int n, double x) { return xsf::smirnovp(n, x); }
+double xsf_smirnovp(int n, double x) { return xsf::cpu::smirnovp(n, x); }
 
 double xsf_tukeylambdacdf(double x, double lmbda) { return xsf::tukeylambdacdf(x, lmbda); }
 


### PR DESCRIPTION
#### Reference issue
None

#### What does this implement/fix?
scipy/xsf#164 moved some functions into a nested `cpu` namespace.  Advancing scipy's xsf subproject to include that commit results in errors when building scipy, for example:

```
../scipy/special/xsf_wrappers.cpp: In function 'double xsf_kolmogorov(double)':
../scipy/special/xsf_wrappers.cpp:620:47: error: 'kolmogorov' is not a member of 'xsf'
  620 | double xsf_kolmogorov(double x) { return xsf::kolmogorov(x); }
      |                                               ^~~~~~~~~~
```

This PR bumps the xsf subproject version to include scipy/xsf#164 and modifies `scipy/special/xsf_wrappers.cpp` to conform to the new structure.

#### Additional information


#### AI Generation Disclosure
No AI tools used
