### PR TITLE
BUG: reject batched subset_by_value in eigh/eigvalsh

### DIFF
--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1143,6 +1143,7 @@ def _apply_over_batch(*argdefs):
                 message = f'`{f.__name__}` does not support zero-size batches.'
                 raise ValueError(message)
 
+            # Some functions can return different numbers of outputs. 
             if (
                 f.__name__ in {"eigh", "eigvalsh"}
                 and kwargs.get("subset_by_value") is not None

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1143,6 +1143,12 @@ def _apply_over_batch(*argdefs):
                 message = f'`{f.__name__}` does not support zero-size batches.'
                 raise ValueError(message)
 
+            if f.__name__ in {"eigh", "eigvalsh"} and kwargs.get("subset_by_value") is not None:
+                raise ValueError(
+                    f'`{f.__name__}` with `subset_by_value` does not support batched inputs '
+                    'because different slices can return different numbers of eigenvalues.'
+                )
+
             # Broadcast arrays to appropriate shape
             for i, (array, core_shape) in enumerate(zip(arrays, core_shapes)):
                 if array is None:

--- a/scipy/_lib/_util.py
+++ b/scipy/_lib/_util.py
@@ -1143,10 +1143,14 @@ def _apply_over_batch(*argdefs):
                 message = f'`{f.__name__}` does not support zero-size batches.'
                 raise ValueError(message)
 
-            if f.__name__ in {"eigh", "eigvalsh"} and kwargs.get("subset_by_value") is not None:
+            if (
+                f.__name__ in {"eigh", "eigvalsh"}
+                and kwargs.get("subset_by_value") is not None
+            ):
                 raise ValueError(
-                    f'`{f.__name__}` with `subset_by_value` does not support batched inputs '
-                    'because different slices can return different numbers of eigenvalues.'
+                    f'`{f.__name__}` with `subset_by_value` does not support '
+                    'batched inputs because different slices can return different '
+                    'numbers of eigenvalues.'
                 )
 
             # Broadcast arrays to appropriate shape

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -372,7 +372,9 @@ def eigh(a, b=None, *, lower=True, eigvals_only=False, overwrite_a=False,
         If provided, this two-element iterable defines the half-open interval
         ``(a, b]`` that, if any, only the eigenvalues between these values
         are returned. Only available with "evr", "evx", and "gvx" drivers. Use
-        ``np.inf`` for the unconstrained ends.
+        ``np.inf`` for the unconstrained ends. Batched inputs are not supported
+        with `subset_by_value`, because different slices can select different
+        numbers of eigenvalues.
     driver : str, optional
         Defines which LAPACK driver should be used. Valid options are "ev",
         "evd", "evr", "evx" for standard problems and "gv", "gvd", "gvx" for
@@ -1067,7 +1069,8 @@ def eigvalsh(a, b=None, *, lower=True, overwrite_a=False,
     the option ``eigvals_only=True`` to get the eigenvalues and not the
     eigenvectors. Here it is kept as a legacy convenience. It might be
     beneficial to use the main function to have full control and to be a bit
-    more pythonic.
+    more pythonic. Batched calls with ``subset_by_value`` are not supported for
+    the same reason as in `eigh`.
 
     Examples
     --------

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1057,7 +1057,10 @@ class TestEigh:
 
         with pytest.raises(
             ValueError,
-            match="subset_by_value.*batched inputs.*different slices can return different numbers of eigenvalues",
+            match=(
+                "subset_by_value.*batched inputs.*different slices can return "
+                "different numbers of eigenvalues"
+            ),
         ):
             fun(aa, subset_by_value=[1.5, 2.5])
 

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -1044,6 +1044,23 @@ class TestEigh:
             assert_equal(v.shape[1], len(w))
             assert all((w > -2) & (w < 2))
 
+    @pytest.mark.parametrize("fun", [eigh, eigvalsh])
+    def test_batched_value_subset_raises(self, fun):
+        a = np.diag(np.arange(3))
+        aa = np.stack((a, a * 2))
+
+        if fun is eigh:
+            w, _ = fun(a, subset_by_value=[1.5, 2.5])
+        else:
+            w = fun(a, subset_by_value=[1.5, 2.5])
+        assert_equal(w, np.array([2.0]))
+
+        with pytest.raises(
+            ValueError,
+            match="subset_by_value.*batched inputs.*different slices can return different numbers of eigenvalues",
+        ):
+            fun(aa, subset_by_value=[1.5, 2.5])
+
     def test_eigh_integer(self):
         a = array([[1, 2], [2, 7]])
         b = array([[3, 1], [1, 5]])


### PR DESCRIPTION
#### Reference issue
Fixes gh-24605

#### What does this implement/fix?
This PR prevents incorrect behavior when calling eigh or eigvalsh with subset_by_value on batched inputs. The number of eigenvalues returned depends on the values in each slice, so the output shape can vary across the batch. This PR raises a clear ValueError early, rather than allowing the code to fail later. 

#### Additional information
Single-matrix inputs are still supported. Hermitian and non-batched cases continue to work as before. I found that subset_by_value is value-dependent, while batching requires each slice to produce a uniformly shaped result. I found that in gh-23896 that if the result depends on values, batching can't infer the output shape correctly. 

Here are some edge cases that I tested:
<img width="661" height="158" alt="Screenshot 2026-06-11 at 6 23 59 PM" src="https://github.com/user-attachments/assets/f048c459-3a0a-4300-a3f4-6e460298828b" />
<img width="860" height="306" alt="Screenshot 2026-06-11 at 6 25 59 PM" src="https://github.com/user-attachments/assets/8bc50458-2039-4225-ad2c-aa880f58879e" />
<img width="885" height="264" alt="Screenshot 2026-06-11 at 6 26 25 PM" src="https://github.com/user-attachments/assets/45c3f2e2-1240-4bf2-b208-3e46731287ce" />
<img width="845" height="170" alt="Screenshot 2026-06-11 at 6 26 47 PM" src="https://github.com/user-attachments/assets/e2204c1c-290b-49a9-bc2a-59749cc430ba" />
<img width="850" height="296" alt="Screenshot 2026-06-11 at 6 27 54 PM" src="https://github.com/user-attachments/assets/ac8fd571-da74-44c6-8240-0b34a18622e2" />
<img width="843" height="278" alt="Screenshot 2026-06-11 at 6 28 55 PM" src="https://github.com/user-attachments/assets/905b4ca1-b120-48e4-8d45-e3adb074c5a4" />


#### AI Generation Disclosure
I used Github Copilot for helping me find relevant files and understanding context. Everything else was done and verified manually by me. 
