### PR TITLE
MAINT: sparse: improve save_npz error message for unsupported formats

### DIFF
--- a/scipy/sparse/_matrix_io.py
+++ b/scipy/sparse/_matrix_io.py
@@ -66,7 +66,9 @@ def save_npz(file, matrix, compressed=True):
         else:
             arrays_dict.update(coords=matrix.coords)
     else:
-        msg = f'Save is not implemented for sparse matrix of format {matrix.format}.'
+        msg = (f'Save is not implemented for sparse matrix of format {matrix.format}; '
+               'convert to a supported format with e.g. .tocsr() or '
+               '.tocoo() before saving.')
         raise NotImplementedError(msg)
     arrays_dict.update(
         format=matrix.format.encode('ascii'),

--- a/scipy/sparse/tests/test_matrix_io.py
+++ b/scipy/sparse/tests/test_matrix_io.py
@@ -8,7 +8,7 @@ from numpy.testing import assert_equal, assert_
 
 from scipy.sparse import (sparray, csr_array, coo_array, save_npz, load_npz,
                           csc_matrix, csr_matrix, bsr_matrix, dia_matrix,
-                          coo_matrix, dok_matrix)
+                          coo_matrix, dok_matrix, dok_array, lil_matrix, lil_array)
 
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
@@ -106,11 +106,15 @@ def test_malicious_load():
     finally:
         os.remove(tmpfile)
 
-def test_implemented_error():
+@pytest.mark.parametrize(
+    "container", [dok_matrix, dok_array, lil_matrix, lil_array]
+)
+def test_implemented_error(container):
     # Attempts to save an unsupported type and checks that an
     # NotImplementedError is raised.
 
-    x = dok_matrix((2,3))
+    x = container((2,3))
     x[0,1] = 1
 
-    assert_raises(NotImplementedError, save_npz, 'x.npz', x)
+    with pytest.raises(NotImplementedError, match="convert.*before saving"):
+        save_npz("x.npz", x)


### PR DESCRIPTION
#### Reference issue
Closes gh-25305.

#### What does this implement/fix?
`save_npz` raises `NotImplementedError` for LIL and DOK formats. The
original issue proposed auto-converting to CSR with a warning; per the
maintainer decision in gh-25305 (option B), this PR instead improves
the error message to suggest explicit conversion via `.tocsr()` or
`.tocoo()` before saving.

The existing test is extended to cover `lil`/`dok` in both matrix and
array variants and to assert the new message.

#### Additional information
No behavior change other than the error message text.

#### AI Generation Disclosure
Github Copilot was used to refine the wording/grammar. All changes were written and tested locally by me.