### PR TITLE
MAINT: close alerts for optimize

### DIFF
--- a/scipy/optimize/_minpackmodule.c
+++ b/scipy/optimize/_minpackmodule.c
@@ -3,6 +3,7 @@
 #include "numpy/arrayobject.h"
 #include "ccallback.h"
 #include "src/minpack.h"
+#include <stddef.h>
 
 
 #define PYERR(errobj,message) {PyErr_SetString(errobj,message); goto fail;}
@@ -247,7 +248,7 @@ int jac_multipack_calling_function(int *n, double *x, double *fvec, double *fjac
     memcpy(fvec, PyArray_DATA(result_array), (*n)*sizeof(double));
   }
   else {         /* iflag == 2 */
-    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, multipack_extra_arguments, 2, minpack_error, (*n)*(*ldfjac));
+    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, multipack_extra_arguments, 2, minpack_error, (npy_intp)(*n)*(*ldfjac));
     if (result_array == NULL) {
       *iflag = -1;
       return -1;
@@ -255,7 +256,7 @@ int jac_multipack_calling_function(int *n, double *x, double *fvec, double *fjac
     if (multipack_jac_transpose == 1)
       MATRIXC2F(fjac, PyArray_DATA(result_array), *n, *ldfjac)
     else
-      memcpy(fjac, PyArray_DATA(result_array), (*n)*(*ldfjac)*sizeof(double));
+      memcpy(fjac, PyArray_DATA(result_array), (size_t)(*n)*(*ldfjac)*sizeof(double));
   }
 
   Py_DECREF(result_array);
@@ -314,7 +315,7 @@ int jac_multipack_lm_function(int *m, int *n, double *x, double *fvec, double *f
     memcpy(fvec, PyArray_DATA(result_array), (*m)*sizeof(double));
   }
   else {         /* iflag == 2 */
-    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, multipack_extra_arguments, 2, minpack_error, (*n)*(*ldfjac));
+    result_array = (PyArrayObject *)call_python_function(multipack_python_jacobian, *n, x, multipack_extra_arguments, 2, minpack_error, (npy_intp)(*n)*(*ldfjac));
     if (result_array == NULL) {
       *iflag = -1;
       return -1;
@@ -322,7 +323,7 @@ int jac_multipack_lm_function(int *m, int *n, double *x, double *fvec, double *f
     if (multipack_jac_transpose == 1)
       MATRIXC2F(fjac, PyArray_DATA(result_array), *n, *ldfjac)
     else
-      memcpy(fjac, PyArray_DATA(result_array), (*n)*(*ldfjac)*sizeof(double));
+      memcpy(fjac, PyArray_DATA(result_array), (size_t)(*n)*(*ldfjac)*sizeof(double));
   }
 
   Py_DECREF(result_array);

--- a/scipy/optimize/src/slsqp.c
+++ b/scipy/optimize/src/slsqp.c
@@ -444,9 +444,9 @@ lsq(
     }
 
     // Recover A and b from Lf and gradx
-    for (int64_t i = 0; i < (ld+2)*ld; i++) { buffer[i] = 0.0; }
+    for (int64_t i = 0; i < (int64_t)(ld+2)*ld; i++) { buffer[i] = 0.0; }
     double* restrict wA = buffer;
-    double* restrict wb = &buffer[ld*(ld+1)];
+    double* restrict wb = &buffer[(int64_t)ld*(ld+1)];
 
     // Depending on augmented, wA is either the full array or the top-left block.
 
@@ -477,35 +477,35 @@ lsq(
     if (augment) { n++; }
 
     // Get the equality constraints if given.
-    double* restrict wE = &buffer[n*(n+1) + n];
-    double* restrict wf = &buffer[n*(n+1) + n + n*meq];
+    double* restrict wE = &buffer[(int64_t)n*(n+1) + n];
+    double* restrict wf = &buffer[(int64_t)n*(n+1) + n + (int64_t)n*meq];
     if (meq > 0)
     {
         for (int64_t j = 0; j < n-1; j++)
         {
             for (int64_t i = 0; i < meq; i++)
             {
-                wE[i + j*meq] = C[i + j*m];
+                wE[i + (int64_t)j*meq] = C[i + (int64_t)j*m];
             }
         }
         if (augment)
         {
             // n is incremented hence all Ceq is now in wE. Add the extra column.
-            for (int64_t i = 0; i < meq; i++) { wE[i + (n-1)*meq] = -d[i]; }
+            for (int64_t i = 0; i < meq; i++) { wE[i + (int64_t)(n-1)*meq] = -d[i]; }
 
         } else  {
             // If not augmented then handle j = n - 1 that is skipped.
-            for (int64_t i = 0; i < meq; i++) { wE[i + (n-1)*meq] = C[i + (n-1)*m]; }
+            for (int64_t i = 0; i < meq; i++) { wE[i + (int64_t)(n-1)*meq] = C[i + (int64_t)(n-1)*m]; }
 
         }
         for (int64_t i = 0; i < meq; i++) { wf[i] = -d[i]; }
     }
 
     // Get the inequality constraints if given. First zero out wG and wh.
-    double* restrict wG = &buffer[n*(n+1) + n + n*meq + meq];
-    double* restrict wh = &buffer[n*(n+1) + n + n*meq + meq + (mineq + 2*n)*ld];
+    double* restrict wG = &buffer[(int64_t)n*(n+1) + n + (int64_t)n*meq + meq];
+    double* restrict wh = &buffer[(int64_t)n*(n+1) + n + (int64_t)n*meq + meq + ((int64_t)mineq + 2*n)*ld];
     // Zero out wG and wh
-    for (int64_t i = 0; i < (mineq + 2*n)*(ld + 1); i++) { wG[i] = 0.0; }
+    for (int64_t i = 0; i < ((int64_t)mineq + 2*n)*(ld + 1); i++) { wG[i] = 0.0; }
 
     // Convert the bounds on x to +I and -I blocks in G.
     // Augment h by xl and -xu.
@@ -553,7 +553,7 @@ lsq(
         {
             for (int64_t i = 0; i < mineq; i++)
             {
-                wG[i + j*n_wG_rows] = C[meq + i + j*m];
+                wG[i + (int64_t)j*n_wG_rows] = C[meq + i + (int64_t)j*m];
             }
         }
     }
@@ -563,7 +563,7 @@ lsq(
     {
         for (int64_t i = 0; i < mineq; i++)
         {
-            wG[i + orign*n_wG_rows] = fmax(-d[meq + i], 0.0);
+            wG[i + (int64_t)orign*n_wG_rows] = fmax(-d[meq + i], 0.0);
         }
     }
 
@@ -573,7 +573,7 @@ lsq(
     {
         if (!isnan(xl[i]))
         {
-            wG[nrow + i*n_wG_rows] = 1.0;
+            wG[nrow + (int64_t)i*n_wG_rows] = 1.0;
             nrow++;
         }
     }
@@ -581,7 +581,7 @@ lsq(
     {
         if (!isnan(xu[i]))
         {
-            wG[nrow + i*n_wG_rows] = -1.0;
+            wG[nrow + (int64_t)i*n_wG_rows] = -1.0;
             nrow++;
         }
     }


### PR DESCRIPTION
  * several multiplication overflow alerts from code scanning are silenced by these changes. The basic idea is to typecast to the higher type in the first multiply to maintain highest precision type across the arithmetic ops.


#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Partially closes #25260

#### What does this implement/fix?
Removes multiplication overflow alerts in the optimize submodules. 

#### Additional information
The basic idea is to typecast to the higher type in the first multiply to maintain highest precision type across the arithmetic ops.


#### AI Generation Disclosure
AI discussion used for verification of fixes on my local machine. 