### PR TITLE
BUG: signal: TransferFunction/ZerosPolesGain report inputs == 1

### DIFF
--- a/scipy/signal/_ltisys.py
+++ b/scipy/signal/_ltisys.py
@@ -855,12 +855,18 @@ class TransferFunction(LinearTimeInvariant):
     def num(self, num):
         self._num = atleast_1d(num)
 
-        # Update dimensions
-        if len(self.num.shape) > 1:
-            self.outputs, self.inputs = self.num.shape
+        # ``TransferFunction`` only models SISO and SIMO systems: ``num`` is
+        # either a 1-D array (SISO numerator polynomial) or a 2-D array whose
+        # rows are the numerator polynomial of each output (SIMO).  The
+        # number of inputs is therefore always one; the number of outputs is
+        # the number of rows of a 2-D ``num`` (or 1 in the SISO case).
+        # See gh-16161 for context on why ``self.num.shape`` cannot be
+        # unpacked as ``(outputs, inputs)``.
+        if self.num.ndim > 1:
+            self.outputs = self.num.shape[0]
         else:
             self.outputs = 1
-            self.inputs = 1
+        self.inputs = 1
 
     @property
     def den(self):
@@ -1255,12 +1261,16 @@ class ZerosPolesGain(LinearTimeInvariant):
     def zeros(self, zeros):
         self._zeros = atleast_1d(zeros)
 
-        # Update dimensions
-        if len(self.zeros.shape) > 1:
-            self.outputs, self.inputs = self.zeros.shape
+        # ``ZerosPolesGain`` only models SISO and SIMO systems: ``zeros`` is
+        # either a 1-D array (SISO) or a 2-D array whose rows hold the zeros
+        # of each output (SIMO).  The number of inputs is therefore always
+        # one; the number of outputs is the number of rows of a 2-D
+        # ``zeros`` (or 1 in the SISO case).  See gh-16161.
+        if self.zeros.ndim > 1:
+            self.outputs = self.zeros.shape[0]
         else:
             self.outputs = 1
-            self.inputs = 1
+        self.inputs = 1
 
     @property
     def poles(self):

--- a/scipy/signal/tests/test_ltisys.py
+++ b/scipy/signal/tests/test_ltisys.py
@@ -903,6 +903,32 @@ class TestTransferFunction:
         xp_assert_equal(s.poles, [1.])
         xp_assert_equal(s.zeros, [0.])
 
+    def test_inputs_outputs_siso(self):
+        # SISO: 1-D numerator, must report 1 input and 1 output (gh-16161).
+        s = TransferFunction([1, 2, 3], [1, 4, 5])
+        assert s.inputs == 1
+        assert s.outputs == 1
+
+    def test_inputs_outputs_simo(self):
+        # SIMO: 2-D ``num`` from ``ss2tf`` with multiple outputs.  Rows of
+        # ``num`` are numerator polynomials of each output; columns are the
+        # polynomial coefficients, *not* a number of inputs (gh-16161).
+        A = np.array([[-1.0, 1.0, 0.0, 0.0],
+                      [-2.0, 0.0, 1.0, 0.0],
+                      [-3.0, 0.0, 0.0, 1.0],
+                      [-4.0, 0.0, 0.0, 0.0]])
+        B = np.array([[1.0], [5.0], [7.0], [0.0]])
+        C = np.array([[0.0, 1.0, 0.0, 0.0],
+                      [0.0, 0.0, 0.0, 1.0],
+                      [8.0, 8.0, 0.0, 0.0]])
+        D = np.array([[0.0], [0.0], [1.0]])
+        num, den = ss2tf(A, B, C, D)
+        s = TransferFunction(num, den)
+        # ``num`` is 2-D with shape (n_outputs, n_poly_coefficients).
+        assert s.num.ndim == 2
+        assert s.outputs == 3
+        assert s.inputs == 1
+
 
 class TestZerosPolesGain:
     def test_initialization(self):
@@ -921,6 +947,23 @@ class TestZerosPolesGain:
         # Make sure copies work
         assert ZerosPolesGain(s) is not s
         assert s.to_zpk() is not s
+
+    def test_inputs_outputs_siso(self):
+        # SISO ZPK has one input and one output (gh-16161).
+        s = ZerosPolesGain([1, 2], [3, 4], 5)
+        assert s.inputs == 1
+        assert s.outputs == 1
+
+    def test_inputs_outputs_simo(self):
+        # ``zeros`` may be a 2-D array whose rows hold the zeros of each
+        # output (SIMO).  The number of columns is the (per-output) zero
+        # count, *not* a number of inputs (gh-16161).
+        zeros = np.zeros((3, 4))
+        poles = np.array([1.0, 2.0])
+        s = ZerosPolesGain(zeros, poles, 1.0)
+        assert s.zeros.ndim == 2
+        assert s.outputs == 3
+        assert s.inputs == 1
 
 
 @make_xp_test_case(abcd_normalize)


### PR DESCRIPTION
#### Reference issue

Closes gh-16161.

#### What does this implement/fix?

`TransferFunction.num` and `ZerosPolesGain.zeros` may legitimately be 2-D
for SIMO systems (e.g. as returned by `ss2tf` with multiple outputs). In
that case rows are outputs and columns are polynomial coefficients (or
zeros per output) ��� *not* a number of inputs.

Both setters were unpacking the array shape directly as
`(outputs, inputs)`, which causes `inputs` to be set to the polynomial
length instead of `1`.

```python
import numpy as np
import scipy.signal as ss

A = np.array([[-1.,1,0,0],[-2,0,1,0],[-3,0,0,1],[-4,0,0,0]])
B = np.array([[1.],[5],[7],[0]])
C = np.array([[0.,1,0,0],[0,0,0,1],[8,8,0,0]])  # 3 outputs
D = np.array([[0.],[0],[1]])
num, den = ss.ss2tf(A, B, C, D)
tf = ss.TransferFunction(num, den)

# Before this PR: tf.inputs = 5 (wrongly equal to num.shape[1])
# After  this PR: tf.inputs = 1, tf.outputs = 3
```

`scipy.signal` only models SISO and SIMO systems through
`TransferFunction` and `ZerosPolesGain`, so `inputs` is always `1`.
This PR sets `inputs = 1` unconditionally and derives `outputs` from
`shape[0]` for both setters.

#### Additional information

- The bug also affected `ZerosPolesGain.zeros`, which has the exact same
  shape-unpacking pattern. Both are fixed for consistency.
- Behaviour for SISO systems is unchanged (`shape` is 1-D, both branches
  already returned `outputs = inputs = 1`).
- The downstream SISO checks (`freqresp`, `dfreqresp`) still correctly
  reject SIMO systems because they require `outputs == 1` *and*
  `inputs == 1`; with this fix they reject via `outputs > 1` rather than
  via the spurious `inputs > 1`.
- Added `test_inputs_outputs_siso` and `test_inputs_outputs_simo` to
  both `TestTransferFunction` and `TestZerosPolesGain`.

#### AI Generation Disclosure

AI assistance (Cursor, using an Anthropic Claude model) was used in
preparing this PR. Specifically, the assistant was used to:

- help locate the buggy `num.setter` / `zeros.setter` in
  `scipy/signal/_ltisys.py` after I pointed it at gh-16161,
- draft the two-line behavioural change in each setter (set `inputs = 1`
  unconditionally, derive `outputs` from `shape[0]`) and the inline
  comments referencing gh-16161,
- draft the four new tests added to `TestTransferFunction` and
  `TestZerosPolesGain`.

I reviewed every change before opening the PR. I reproduced the original
bug against an installed SciPy 1.17.1 (`tf.inputs` came back as `5` and
`zpk.inputs` as `4` for a 3-output SIMO system), verified that the
patched setters yield `inputs == 1` in both classes, and ran the
affected test classes in `scipy/signal/tests/test_ltisys.py` locally
(`TestTransferFunction`, `TestZerosPolesGain`, `TestSS2TF`,
`Test_freqresp`, `Test_bode`, `TestImpulse`, `TestStep`, `TestLsim`,
`TestPlacePoles` ��� 59 tests pass with the patched module). The choice
to keep `inputs` fixed at `1` (rather than e.g. extending the classes
to MIMO) is intentional and matches the documented scope of
`TransferFunction` / `ZerosPolesGain`.

