### PR TITLE
TST, MAINT: modernize spatial tests for pytest 10

### DIFF
--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -932,7 +932,7 @@ def test_from_euler_scalar():
 
 
 @make_xp_test_case((Rotation, "from_euler"), (Rotation, "as_euler"))
-@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("seq_tuple", list(permutations("xyz")))
 @pytest.mark.parametrize("intrinsic", (False, True))
 def test_as_euler_asymmetric_axes(xp, seq_tuple, intrinsic):
     # helper function for mean error tests
@@ -963,7 +963,7 @@ def test_as_euler_asymmetric_axes(xp, seq_tuple, intrinsic):
 
 
 @make_xp_test_case((Rotation, "from_euler"), (Rotation, "as_euler"))
-@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("seq_tuple", list(permutations("xyz")))
 @pytest.mark.parametrize("intrinsic", (False, True))
 def test_as_euler_symmetric_axes(xp, seq_tuple, intrinsic):
     # helper function for mean error tests
@@ -1009,7 +1009,7 @@ def maybe_warn_gimbal_lock(should_warn, xp):
 @make_xp_test_case(
     (Rotation, "from_euler"), (Rotation, "as_matrix"), (Rotation, "as_euler")
 )
-@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("seq_tuple", list(permutations("xyz")))
 @pytest.mark.parametrize("intrinsic", (False, True))
 @pytest.mark.parametrize("suppress_warnings", (False, True))
 def test_as_euler_degenerate_asymmetric_axes(
@@ -1045,7 +1045,7 @@ def test_as_euler_degenerate_asymmetric_axes(
 @make_xp_test_case(
     (Rotation, "from_euler"), (Rotation, "as_matrix"), (Rotation, "as_euler")
 )
-@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("seq_tuple", list(permutations("xyz")))
 @pytest.mark.parametrize("intrinsic", (False, True))
 @pytest.mark.parametrize("suppress_warnings", (False, True))
 def test_as_euler_degenerate_symmetric_axes(

--- a/scipy/spatial/transform/tests/test_rotation_groups.py
+++ b/scipy/spatial/transform/tests/test_rotation_groups.py
@@ -131,19 +131,19 @@ def test_cyclic(n, axis):
         assert _calculate_rmsd(P, g.apply(P)) < TOL
 
 
-@pytest.mark.parametrize("name, size", zip(NAMES, SIZES))
+@pytest.mark.parametrize("name, size", list(zip(NAMES, SIZES)))
 def test_group_sizes(name, size):
     assert len(Rotation.create_group(name)) == size
 
 
-@pytest.mark.parametrize("name, size", zip(NAMES, SIZES))
+@pytest.mark.parametrize("name, size", list(zip(NAMES, SIZES)))
 def test_group_no_duplicates(name, size):
     g = Rotation.create_group(name)
     kdtree = cKDTree(g.as_quat())
     assert len(kdtree.query_pairs(1E-3)) == 0
 
 
-@pytest.mark.parametrize("name, size", zip(NAMES, SIZES))
+@pytest.mark.parametrize("name, size", list(zip(NAMES, SIZES)))
 def test_group_symmetry(name, size):
     g = Rotation.create_group(name)
     q = np.concatenate((-g.as_quat(), g.as_quat()))


### PR DESCRIPTION
* Related to the `spatial` contribution to gh-25374.

* There were only a few test errors in `spatial` related to the pytest `9.1.0` release warnings about upcoming `pytest` `10.x` breaking changes, and those are fixed here, allowing the `spatial` testsuite to pass locally with latest `pytest` in my hands.

* The fixes attempt to follow the official docs recommendation of "materializing" generator/iterator style objects for parametrizations: https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators

[skip circle]

#### AI Generation Disclosure
No AI tools used
