### PR TITLE
BUG: interpolate: raise ValueError for k<1 in make splrep

### DIFF
--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -1143,6 +1143,9 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
         t = xp.asarray(t)
     bc_type = _validate_bc_type(bc_type)
 
+    if k < 1:
+      raise ValueError(f"k must be >= 1, got k={k}")
+
     if s == 0:
         if t is not None or w is not None or nest is not None:
             raise ValueError("s==0 is for interpolation only")

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -1033,9 +1033,10 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
         The interval to fit.  If None, these default to ``x[0]`` and ``x[-1]``,
         respectively.
     k : int, optional
-        The degree of the spline fit. Must be >= 1. It is recommended to use cubic splines,
-        ``k=3``, which is the default. Even values of `k` should be avoided,
-        especially with small `s` values.
+        The degree of the spline fit. Must be >= 1, except when ``s=0``,
+        in which case ``k=0`` is also supported. It is recommended to use
+        cubic splines, ``k=3``, which is the default. Even values of `k` 
+        should be avoided, especially with small `s` values.
     s : float, optional
         The smoothing condition. The amount of smoothness is determined by
         satisfying the LSQ (least-squares) constraint::
@@ -1194,9 +1195,11 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
     ub, ue : float, optional
         The end-points of the parameters interval. Default to ``u[0]`` and ``u[-1]``.
     k : int, optional
-        Degree of the spline. Must be >= 1. Cubic splines, ``k=3``, are recommended.
-        Even values of `k` should be avoided especially with a small ``s`` value.
-        Default is ``k=3``
+         Degree of the spline. Must be >= 1, except when ``s=0``, in which
+         case ``k=0`` is also supported. Cubic splines, ``k=3``, are
+         recommended. Even values of `k` should be avoided especially with
+         a small ``s`` value. 
+         Default is ``k=3``
     s : float, optional
         A smoothing condition.  The amount of smoothness is determined by
         satisfying the conditions::

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -143,6 +143,9 @@ def _validate_inputs(x, y, w, k, s, xb, xe, parametric, periodic=False):
 
     k = operator.index(k)
 
+    if k < 1:
+        raise ValueError(f"k must be >= 1, got k={k}")
+
     if s < 0:
         raise ValueError(f"`s` must be non-negative. Got {s = }")
 
@@ -1142,9 +1145,6 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
     if t is not None:
         t = xp.asarray(t)
     bc_type = _validate_bc_type(bc_type)
-
-    if k < 1:
-      raise ValueError(f"k must be >= 1, got k={k}")
 
     if s == 0:
         if t is not None or w is not None or nest is not None:

--- a/scipy/interpolate/_fitpack_repro.py
+++ b/scipy/interpolate/_fitpack_repro.py
@@ -179,7 +179,7 @@ def generate_knots(x, y, *, w=None, xb=None, xe=None,
         The boundary of the approximation interval. If None (default),
         is set to ``x[-1]``.
     k : int, optional
-        The spline degree. Default is cubic, ``k = 3``.
+        The spline degree. Must be >= 1. Default is cubic, ``k = 3``.
     s : float, optional
         The smoothing factor. Default is ``s = 0``.
     nest : int, optional
@@ -1033,7 +1033,7 @@ def make_splrep(x, y, *, w=None, xb=None, xe=None,
         The interval to fit.  If None, these default to ``x[0]`` and ``x[-1]``,
         respectively.
     k : int, optional
-        The degree of the spline fit. It is recommended to use cubic splines,
+        The degree of the spline fit. Must be >= 1. It is recommended to use cubic splines,
         ``k=3``, which is the default. Even values of `k` should be avoided,
         especially with small `s` values.
     s : float, optional
@@ -1194,7 +1194,7 @@ def make_splprep(x, *, w=None, u=None, ub=None, ue=None,
     ub, ue : float, optional
         The end-points of the parameters interval. Default to ``u[0]`` and ``u[-1]``.
     k : int, optional
-        Degree of the spline. Cubic splines, ``k=3``, are recommended.
+        Degree of the spline. Must be >= 1. Cubic splines, ``k=3``, are recommended.
         Even values of `k` should be avoided especially with a small ``s`` value.
         Default is ``k=3``
     s : float, optional

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3953,13 +3953,17 @@ class TestMakeSplrep(_TestMakeSplrepBase):
             make_splrep(x, y, w=w, k=2, s=12)
 
     def test_k0_raises(self):
-        # k=0 (piecewise constant) is not supported: FITPACK knot selection
-        # is undefined for degree 0, causing a cryptic RuntimeError deep in
-        # compiled code. Should raise a clear ValueError instead. gh-25370
+        # k=0 (piecewise constant) with s>0 is not supported: knot selection
+        # is undefined for degree 0, causing a cryptic RuntimeError.
+        # s=0 is fine as it bypasses _generate_knots. gh-25370
         x = np.arange(10, dtype=float)
         y = x**2
         with pytest.raises(ValueError, match="k must be >= 1"):
           make_splrep(x, y, s=1, k=0)
+
+        # s=0 with k=0 is fine: goes through make_interp_spline
+        result = make_splrep(x, y, s=0, k=0)
+        assert result is not None
 
     def test_shape(self, xp):
         # make sure coefficients have the right shape (not extra dims)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3955,7 +3955,7 @@ class TestMakeSplrep(_TestMakeSplrepBase):
     def test_k0_raises(self):
         # k=0 (piecewise constant) is not supported: FITPACK knot selection
         # is undefined for degree 0, causing a cryptic RuntimeError deep in
-        # Fortran code. Should raise a clear ValueError instead. gh-25370
+        # compiled code. Should raise a clear ValueError instead. gh-25370
         x = np.arange(10, dtype=float)
         y = x**2
         with pytest.raises(ValueError, match="k must be >= 1"):

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3963,7 +3963,10 @@ class TestMakeSplrep(_TestMakeSplrepBase):
 
         # s=0 with k=0 is fine: goes through make_interp_spline
         result = make_splrep(x, y, s=0, k=0)
-        assert result is not None
+        expected = make_interp_spline(x, y, k=0)
+        xp_assert_close(result.t, expected.t)
+        xp_assert_close(result.c, expected.c)
+        assert result.k == expected.k
 
     def test_shape(self, xp):
         # make sure coefficients have the right shape (not extra dims)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3952,6 +3952,15 @@ class TestMakeSplrep(_TestMakeSplrepBase):
         with assert_raises(ValueError):
             make_splrep(x, y, w=w, k=2, s=12)
 
+    def test_k0_raises(self):
+        # k=0 (piecewise constant) is not supported: FITPACK knot selection
+        # is undefined for degree 0, causing a cryptic RuntimeError deep in
+        # Fortran code. Should raise a clear ValueError instead. gh-25370
+        x = np.arange(10, dtype=float)
+        y = x**2
+        with pytest.raises(ValueError, match="k must be >= 1"):
+          make_splrep(x, y, s=1, k=0)
+
     def test_shape(self, xp):
         # make sure coefficients have the right shape (not extra dims)
         n, k = 10, 3


### PR DESCRIPTION
#### Reference issue

Closes gh-25370.

#### What does this implement/fix?

`make_splrep` was crashing with a `RuntimeError: Internal error` deep in the FITPACK Fortran routines when called with `k=0`. The original `splrep` avoided this by requiring `k >= 1`.

This PR adds an early validation check in `make_splrep`:

```python
if k < 1:
    raise ValueError(f"k must be >= 1, got k={k}")
```

This raises a clear `ValueError` instead of hitting undefined behavior in the knot-generation routine. A unit test `test_k0_raises` is also added to cover this case.

#### Additional information

- No behavior change for valid inputs (`k >= 1`)
- Negative `k` values are also caught by the same check

#### AI Generation Disclosure

Used an AI assistant to help write the unit test `test_k0_raises`. 