### PR TITLE
TST: run `pydata/sparse` tests when `array_api_backends` is set

### DIFF
--- a/scipy/sparse/csgraph/tests/test_pydata_sparse.py
+++ b/scipy/sparse/csgraph/tests/test_pydata_sparse.py
@@ -12,8 +12,10 @@ try:
 except Exception:
     sparse = None
 
-pytestmark = pytest.mark.skipif(sparse is None,
-                                reason="pydata/sparse not installed")
+pytestmark = [
+    pytest.mark.skipif(sparse is None, reason="pydata/sparse not installed"),
+    pytest.mark.array_api_backends, # include in array-api environment tests
+]
 
 
 msg = "pydata/sparse (0.15.1) does not implement necessary operations"

--- a/scipy/sparse/linalg/tests/test_pydata_sparse.py
+++ b/scipy/sparse/linalg/tests/test_pydata_sparse.py
@@ -11,8 +11,10 @@ try:
 except Exception:
     sparse = None
 
-pytestmark = pytest.mark.skipif(sparse is None,
-                                reason="pydata/sparse not installed")
+pytestmark = [
+    pytest.mark.skipif(sparse is None, reason="pydata/sparse not installed"),
+    pytest.mark.array_api_backends, # include in array-api environment tests
+]
 
 
 msg = "pydata/sparse (0.15.1) does not implement necessary operations"


### PR DESCRIPTION
this was hiding away some failures

EDIT: maybe this still doesn't show up in CI since we pass `-b` for individual backends