### PR TITLE
MAINT: special: remove unused functions from xsf_wrappers

### DIFF
--- a/scipy/special/xsf_wrappers.cpp
+++ b/scipy/special/xsf_wrappers.cpp
@@ -108,8 +108,6 @@ double special_inv_boxcox1p(double x, double lmbda) { return xsf::inv_boxcox1p(x
 
 double special_ndtri_exp(double x) { return xsf::ndtri_exp(x); }
 
-npy_cdouble cerf_wrap(npy_cdouble z) { return to_ccomplex(xsf::cerf(to_complex(z))); }
-
 double special_itstruve0(double x) { return xsf::itstruve0(x); }
 
 double special_it2struve0(double x) { return xsf::it2struve0(x); }
@@ -135,10 +133,6 @@ double special_keip(double x) { return xsf::keip(x); }
 void special_ckelvin(double x, npy_cdouble *Be, npy_cdouble *Ke, npy_cdouble *Bep, npy_cdouble *Kep) {
     xsf::kelvin(x, *reinterpret_cast<complex<double> *>(Be), *reinterpret_cast<complex<double> *>(Ke),
                 *reinterpret_cast<complex<double> *>(Bep), *reinterpret_cast<complex<double> *>(Kep));
-}
-
-npy_cdouble hyp2f1_complex_wrap(double a, double b, double c, npy_cdouble z) {
-    return to_ccomplex(xsf::hyp2f1(a, b, c, to_complex(z)));
 }
 
 void it1j0y0_wrap(double x, double *j0int, double *y0int) { xsf::it1j0y0(x, *j0int, *y0int); }
@@ -271,8 +265,6 @@ void special_cairye(npy_cdouble z, npy_cdouble *ai, npy_cdouble *aip, npy_cdoubl
                *reinterpret_cast<complex<double> *>(bi), *reinterpret_cast<complex<double> *>(bip));
 }
 
-double cephes_ellpk_wrap(double x) { return xsf::cephes::ellpk(x); }
-
 int cephes_fresnl_wrap(double xxa, double *ssa, double *cca) { return xsf::cephes::fresnl(xxa, ssa, cca); }
 
 npy_cdouble special_ccyl_hankel_2(double v, npy_cdouble z) { return to_ccomplex(xsf::cyl_hankel_2(v, to_complex(z))); }
@@ -323,11 +315,7 @@ npy_cdouble special_lambertw(npy_cdouble z, long k, double tol) {
     return to_ccomplex(xsf::lambertw(to_complex(z), k, tol));
 }
 
-double cephes_expm1_wrap(double x) { return xsf::cephes::expm1(x); }
-
 double cephes_expn_wrap(Py_ssize_t n, double x) { return xsf::cephes::expn(static_cast<int>(n), x); }
-
-double cephes_log1p_wrap(double x) { return xsf::cephes::log1p(x); }
 
 double cephes_jv_wrap(double v, double x) { return xsf::cephes::jv(v, x); }
 
@@ -364,12 +352,8 @@ double cephes_yn_wrap(Py_ssize_t n, double x) { return xsf::cephes::yn(static_ca
 
 double cephes_polevl_wrap(double x, const double coef[], int N) { return xsf::cephes::polevl(x, coef, N); }
 
-double cephes_p1evl_wrap(double x, const double coef[], int N) { return xsf::cephes::p1evl(x, coef, N); }
-
 double special_wright_bessel(double a, double b, double x) { return xsf::wright_bessel(a, b, x); }
 double special_log_wright_bessel(double a, double b, double x) { return xsf::log_wright_bessel(a, b, x); }
-
-double special_scaled_exp1(double x) { return xsf::scaled_exp1(x); }
 
 double special_ellipk(double m) { return xsf::ellipk(m); }
 

--- a/scipy/special/xsf_wrappers.h
+++ b/scipy/special/xsf_wrappers.h
@@ -19,11 +19,9 @@
 extern "C" {
 #endif /* __cplusplus */
 
-npy_cdouble clngamma_wrap(npy_cdouble z);
 npy_cdouble chyp1f1_wrap(double a, double b, npy_cdouble z);
 double hyp1f1_wrap(double a, double b, double x);
 double special_hyperu(double a, double b, double x);
-npy_cdouble cerf_wrap(npy_cdouble z);
 
 double xsf_exp1(double x);
 npy_cdouble xsf_cexp1(npy_cdouble z);
@@ -92,7 +90,6 @@ void special_cairye(npy_cdouble z, npy_cdouble *ai, npy_cdouble *aip, npy_cdoubl
 
 void special_itairy(double x, double *apt, double *bpt, double *ant, double *bnt);
 
-npy_cdouble hyp2f1_complex_wrap(double a, double b, double c, npy_cdouble zp);
 double sin_pi(double x);
 
 double special_agm(double a, double b);
@@ -141,13 +138,9 @@ npy_cdouble special_crgamma(npy_cdouble z);
 
 double special_ellipk(double m);
 
-double cephes_airy_wrap(double x, double *ai, double *aip, double *bi, double *bip);
-double cephes_expm1_wrap(double x);
 double cephes_expn_wrap(Py_ssize_t n, double x);
-double cephes_log1p_wrap(double x);
 double xsf_iv(double v, double x);
 double cephes_jv_wrap(double v, double x);
-double cephes_ellpk_wrap(double x);
 int cephes_ellpj_wrap(double u, double m, double *sn, double *cn, double *dn, double *ph);
 int cephes_fresnl_wrap(double xxa, double *ssa, double *cca);
 double cephes__struve_asymp_large_z(double v, double z, Py_ssize_t is_h, double *err);
@@ -155,11 +148,8 @@ double cephes__struve_bessel_series(double v, double z, Py_ssize_t is_h, double 
 double cephes__struve_power_series(double v, double z, Py_ssize_t is_h, double *err);
 double cephes_yn_wrap(Py_ssize_t n, double x);
 double cephes_polevl_wrap(double x, const double coef[], int N);
-double cephes_p1evl_wrap(double x, const double coef[], int N);
 double special_wright_bessel(double a, double b, double x);
 double special_log_wright_bessel(double a, double b, double x);
-
-double special_scaled_exp1(double x);
 
 double xsf_beta(double a, double b);
 double xsf_betaln(double a, double b);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
None
#### What does this implement/fix?
<!--Please explain your changes.-->
I noticed that we have a hand full of wrapper functions that are never used.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.