### PR TITLE
DOC: roadmap: remove "flapack" entry

### DIFF
--- a/doc/source/dev/roadmap-detailed.rst
+++ b/doc/source/dev/roadmap-detailed.rst
@@ -226,7 +226,6 @@ linalg
 Needed:
 
 - Reduce duplication of functions with ``numpy.linalg``, make APIs consistent.
-- ``get_lapack_funcs`` should always use ``flapack``
 - Wrap more LAPACK functions
 - One too many funcs for LU decomposition, remove one
 


### PR DESCRIPTION
We only use flapack for quite a while already, and last vestiges of clapack has been removed from tests in the 1.18 time frame.

[docs only]

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai