### PR TITLE
MAINT: prepare for SciPy `1.18.0` "final" release

### DIFF
--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -364,7 +364,7 @@ Authors
 * Ralf Gommers (173)
 * Mathieu Guay-Paquet (1) +
 * Matt Haberland (147)
-* Joren Hammudoglu (29)
+* Joren Hammudoglu (30)
 * Jacob Hass (4)
 * Maya Horii (1) +
 * Guido Imperiale (1)
@@ -397,7 +397,7 @@ Authors
 * Pradyot Ranjan (2) +
 * Adrian Raso (3)
 * Aditya Rawat (1) +
-* Tyler Reddy (98)
+* Tyler Reddy (99)
 * Martin Reinecke (1)
 * Lucas Roberts (6)
 * Pamphile Roy (1)
@@ -553,6 +553,7 @@ Issues closed for 1.18.0
 * `#25162 <https://github.com/scipy/scipy/issues/25162>`__: MAINT, TST: a few test failures against NumPy ``2.4.5``
 * `#25180 <https://github.com/scipy/scipy/issues/25180>`__: CI: stats: ``test_continuous.py::TestDistributions::test_funcs``...
 * `#25374 <https://github.com/scipy/scipy/issues/25374>`__: TST, CI: errors with ``pytest`` ``9.1.0`` release
+* `#25409 <https://github.com/scipy/scipy/issues/25409>`__: MAINT: mypy failing in CI
 
 ************************
 Pull requests for 1.18.0
@@ -1065,3 +1066,4 @@ Pull requests for 1.18.0
 * `#25347 <https://github.com/scipy/scipy/pull/25347>`__: REL: set version to ``1.18.0rc3`` unreleased
 * `#25376 <https://github.com/scipy/scipy/pull/25376>`__: TST, MAINT: modernize spatial tests for pytest 10
 * `#25378 <https://github.com/scipy/scipy/pull/25378>`__: MAINT: Bump ``pytest`` to v9.1.0
+* `#25410 <https://github.com/scipy/scipy/pull/25410>`__: TYP: Fix mypy errors with ``pytest==9.1.0``

--- a/doc/source/release/1.18.0-notes.rst
+++ b/doc/source/release/1.18.0-notes.rst
@@ -2,8 +2,6 @@
 SciPy 1.18.0 Release Notes
 ==========================
 
-.. note:: SciPy 1.18.0 is not released yet!
-
 .. contents::
 
 SciPy 1.18.0 is the culmination of 6 months of hard work. It contains
@@ -363,7 +361,7 @@ Authors
 * Christoph Gohlke (1)
 * Nathan Goldbaum (20)
 * Ludmila Golomozin (11) +
-* Ralf Gommers (172)
+* Ralf Gommers (173)
 * Mathieu Guay-Paquet (1) +
 * Matt Haberland (147)
 * Joren Hammudoglu (29)
@@ -396,9 +394,10 @@ Authors
 * partev (1)
 * Matti Picus (7)
 * Ilhan Polat (190)
+* Pradyot Ranjan (2) +
 * Adrian Raso (3)
 * Aditya Rawat (1) +
-* Tyler Reddy (86)
+* Tyler Reddy (98)
 * Martin Reinecke (1)
 * Lucas Roberts (6)
 * Pamphile Roy (1)
@@ -430,7 +429,7 @@ Authors
 * Simon Zwieback (1) +
 * ਗਗਨਦੀਪ ਸਿੰਘ (Gagandeep Singh) (19)
 
-    A total of 102 people contributed to this release.
+    A total of 103 people contributed to this release.
     People with a "+" by their names contributed a patch for the first time.
     This list of names is automatically generated, and may not be fully complete.
 
@@ -553,6 +552,7 @@ Issues closed for 1.18.0
 * `#25133 <https://github.com/scipy/scipy/issues/25133>`__: BUG: signal savgol_filter fails for large >20000 window_length...
 * `#25162 <https://github.com/scipy/scipy/issues/25162>`__: MAINT, TST: a few test failures against NumPy ``2.4.5``
 * `#25180 <https://github.com/scipy/scipy/issues/25180>`__: CI: stats: ``test_continuous.py::TestDistributions::test_funcs``...
+* `#25374 <https://github.com/scipy/scipy/issues/25374>`__: TST, CI: errors with ``pytest`` ``9.1.0`` release
 
 ************************
 Pull requests for 1.18.0
@@ -1061,3 +1061,7 @@ Pull requests for 1.18.0
 * `#25243 <https://github.com/scipy/scipy/pull/25243>`__: BUG: ``stats``\ : fix new distribution ``lmoment`` method signatures
 * `#25275 <https://github.com/scipy/scipy/pull/25275>`__: BUG: interpolate: fix missing DECREF in curfit and percur
 * `#25281 <https://github.com/scipy/scipy/pull/25281>`__: BUG: cluster.vq: fix calling deprecated ``py_vq``
+* `#25297 <https://github.com/scipy/scipy/pull/25297>`__: MAINT: backports/preparation for SciPy ``1.18.0rc2``
+* `#25347 <https://github.com/scipy/scipy/pull/25347>`__: REL: set version to ``1.18.0rc3`` unreleased
+* `#25376 <https://github.com/scipy/scipy/pull/25376>`__: TST, MAINT: modernize spatial tests for pytest 10
+* `#25378 <https://github.com/scipy/scipy/pull/25378>`__: MAINT: Bump ``pytest`` to v9.1.0

--- a/scipy/fft/tests/test_backend.py
+++ b/scipy/fft/tests/test_backend.py
@@ -53,7 +53,7 @@ mocks = (mock_backend.fft, mock_backend.fft2, mock_backend.fftn,
          mock_backend.fht, mock_backend.ifht)
 
 
-@pytest.mark.parametrize("func, np_func, mock", zip(funcs, np_funcs, mocks))
+@pytest.mark.parametrize("func, np_func, mock", list(zip(funcs, np_funcs, mocks)))
 def test_backend_call(func, np_func, mock):
     x = np.arange(20).reshape((10,2))
     answer = np_func(x.astype(np.float64))
@@ -83,7 +83,7 @@ plan_mocks = (mock_backend.fft, mock_backend.fft2, mock_backend.fftn,
               mock_backend.ihfft, mock_backend.ihfft2, mock_backend.ihfftn)
 
 
-@pytest.mark.parametrize("func, mock", zip(plan_funcs, plan_mocks))
+@pytest.mark.parametrize("func, mock", list(zip(plan_funcs, plan_mocks)))
 def test_backend_plan(func, mock):
     x = np.arange(20).reshape((10, 2))
 

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1416,10 +1416,10 @@ class TestRectBivariateSpline:
     @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
                                         (1, 7e-3, 1e-4),
                                         (3, 2e-2, 1e-4)])
-    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline,
+    @pytest.mark.parametrize("spl_apis", ((RectBivariateSpline,
                                            _RectBivariateSplineEval),
                                           (_regrid,
-                                           _ndbspline_call_like_bivariate)])
+                                           _ndbspline_call_like_bivariate)))
     def test_spline_large_2d(self, shape, s_tols, spl_apis):
         # Reference - https://github.com/scipy/scipy/issues/17787
         #
@@ -1445,10 +1445,10 @@ class TestRectBivariateSpline:
     @pytest.mark.skipif(sys.maxsize <= 2**32, reason="Segfaults on 32-bit system "
                                                      "due to large input data")
     @pytest.mark.parametrize("k", [3, 4])
-    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline,
+    @pytest.mark.parametrize("spl_apis", ((RectBivariateSpline,
                                            _RectBivariateSplineEval),
                                           (_regrid,
-                                           _ndbspline_call_like_bivariate)])
+                                           _ndbspline_call_like_bivariate)))
     def test_spline_large_2d_maxit(self, k, spl_apis):
         # Reference - for https://github.com/scipy/scipy/issues/17787
         #
@@ -1470,10 +1470,10 @@ class TestRectBivariateSpline:
         assert(not np.isnan(z_spl).any())
         xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
 
-    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline,
+    @pytest.mark.parametrize("spl_apis", ((RectBivariateSpline,
                                            _RectBivariateSplineEval),
                                           (_regrid,
-                                           _ndbspline_call_like_bivariate)])
+                                           _ndbspline_call_like_bivariate)))
     def test_spline_synthetic_data(self, spl_apis):
         """
         Test regrid with synthetic smooth data (mixed frequencies + noise).

--- a/scipy/linalg/tests/test_lapack.py
+++ b/scipy/linalg/tests/test_lapack.py
@@ -895,7 +895,7 @@ class TestHetrd:
         assert_raises(ValueError, hetrd, A)
 
     @pytest.mark.parametrize('real_dtype,complex_dtype',
-                             zip(REAL_DTYPES, COMPLEX_DTYPES))
+                             list(zip(REAL_DTYPES, COMPLEX_DTYPES)))
     @pytest.mark.parametrize('n', (1, 3))
     def test_hetrd(self, n, real_dtype, complex_dtype):
         A = np.zeros((n, n), dtype=complex_dtype)
@@ -1837,9 +1837,9 @@ def test_getc2_gesc2():
 
 @pytest.mark.parametrize('size', [(6, 5), (5, 5)])
 @pytest.mark.parametrize('dtype', REAL_DTYPES)
-@pytest.mark.parametrize('joba', range(6))  # 'C', 'E', 'F', 'G', 'A', 'R'
-@pytest.mark.parametrize('jobu', range(4))  # 'U', 'F', 'W', 'N'
-@pytest.mark.parametrize('jobv', range(4))  # 'V', 'J', 'W', 'N'
+@pytest.mark.parametrize('joba', list(range(6)))  # 'C', 'E', 'F', 'G', 'A', 'R'
+@pytest.mark.parametrize('jobu', list(range(4)))  # 'U', 'F', 'W', 'N'
+@pytest.mark.parametrize('jobv', list(range(4)))  # 'V', 'J', 'W', 'N'
 @pytest.mark.parametrize('jobr', [0, 1])
 @pytest.mark.parametrize('jobp', [0, 1])
 def test_gejsv_general(size, dtype, joba, jobu, jobv, jobr, jobp, jobt=0):
@@ -2221,7 +2221,7 @@ def test_geqrfp_lwork(dtype, shape):
 
 
 @pytest.mark.parametrize("ddtype,dtype",
-                         zip(REAL_DTYPES + REAL_DTYPES, DTYPES))
+                         list(zip(REAL_DTYPES + REAL_DTYPES, DTYPES)))
 def test_pttrf_pttrs(ddtype, dtype):
     rng = np.random.RandomState(42)
     # set test tolerance appropriate for dtype
@@ -2270,7 +2270,7 @@ def test_pttrf_pttrs(ddtype, dtype):
 
 
 @pytest.mark.parametrize("ddtype,dtype",
-                         zip(REAL_DTYPES + REAL_DTYPES, DTYPES))
+                         list(zip(REAL_DTYPES + REAL_DTYPES, DTYPES)))
 def test_pttrf_pttrs_errors_incompatible_shape(ddtype, dtype):
     n = 10
     rng = np.random.RandomState(1234)
@@ -2283,7 +2283,7 @@ def test_pttrf_pttrs_errors_incompatible_shape(ddtype, dtype):
 
 
 @pytest.mark.parametrize("ddtype,dtype",
-                         zip(REAL_DTYPES + REAL_DTYPES, DTYPES))
+                        list(zip(REAL_DTYPES + REAL_DTYPES, DTYPES)))
 def test_pttrf_pttrs_errors_singular_nonSPD(ddtype, dtype):
     n = 10
     rng = np.random.RandomState(42)
@@ -2378,8 +2378,8 @@ def pteqr_get_d_e_A_z(dtype, realtype, n, compute_z):
 
 
 @pytest.mark.parametrize("dtype,realtype",
-                         zip(DTYPES, REAL_DTYPES + REAL_DTYPES))
-@pytest.mark.parametrize("compute_z", range(3))
+                         list(zip(DTYPES, REAL_DTYPES + REAL_DTYPES)))
+@pytest.mark.parametrize("compute_z", list(range(3)))
 def test_pteqr(dtype, realtype, compute_z):
     '''
     Tests the ?pteqr lapack routine for all dtypes and compute_z parameters.
@@ -2410,8 +2410,8 @@ def test_pteqr(dtype, realtype, compute_z):
 
 
 @pytest.mark.parametrize("dtype,realtype",
-                         zip(DTYPES, REAL_DTYPES + REAL_DTYPES))
-@pytest.mark.parametrize("compute_z", range(3))
+                         list(zip(DTYPES, REAL_DTYPES + REAL_DTYPES)))
+@pytest.mark.parametrize("compute_z", list(range(3)))
 def test_pteqr_error_non_spd(dtype, realtype, compute_z):
     pteqr = get_lapack_funcs(('pteqr'), dtype=dtype)
 
@@ -2424,8 +2424,8 @@ def test_pteqr_error_non_spd(dtype, realtype, compute_z):
 
 
 @pytest.mark.parametrize("dtype,realtype",
-                         zip(DTYPES, REAL_DTYPES + REAL_DTYPES))
-@pytest.mark.parametrize("compute_z", range(3))
+                         list(zip(DTYPES, REAL_DTYPES + REAL_DTYPES)))
+@pytest.mark.parametrize("compute_z", list(range(3)))
 def test_pteqr_raise_error_wrong_shape(dtype, realtype, compute_z):
     pteqr = get_lapack_funcs(('pteqr'), dtype=dtype)
     n = 10
@@ -2438,8 +2438,8 @@ def test_pteqr_raise_error_wrong_shape(dtype, realtype, compute_z):
 
 
 @pytest.mark.parametrize("dtype,realtype",
-                         zip(DTYPES, REAL_DTYPES + REAL_DTYPES))
-@pytest.mark.parametrize("compute_z", range(3))
+                         list(zip(DTYPES, REAL_DTYPES + REAL_DTYPES)))
+@pytest.mark.parametrize("compute_z", list(range(3)))
 def test_pteqr_error_singular(dtype, realtype, compute_z):
     pteqr = get_lapack_funcs(('pteqr'), dtype=dtype)
     n = 10
@@ -2833,8 +2833,8 @@ def test_gtsvx_NAG(du, d, dl, b, x):
     assert_array_almost_equal(x, x_soln)
 
 
-@pytest.mark.parametrize("dtype,realtype", zip(DTYPES, REAL_DTYPES
-                                               + REAL_DTYPES))
+@pytest.mark.parametrize("dtype,realtype", list(zip(DTYPES, REAL_DTYPES
+                                               + REAL_DTYPES)))
 @pytest.mark.parametrize("fact,df_de_lambda",
                          [("F",
                            lambda d, e: get_lapack_funcs('pttrf',
@@ -2892,8 +2892,8 @@ def test_ptsvx(dtype, realtype, fact, df_de_lambda):
                                  "({x_soln.shape[1]},)"))
 
 
-@pytest.mark.parametrize("dtype,realtype", zip(DTYPES, REAL_DTYPES
-                                               + REAL_DTYPES))
+@pytest.mark.parametrize("dtype,realtype", list(zip(DTYPES, REAL_DTYPES
+                                               + REAL_DTYPES)))
 @pytest.mark.parametrize("fact,df_de_lambda",
                          [("F",
                            lambda d, e: get_lapack_funcs('pttrf',
@@ -2919,8 +2919,8 @@ def test_ptsvx_error_raise_errors(dtype, realtype, fact, df_de_lambda):
     assert_raises(Exception, ptsvx, d, e, b[:-1], fact=fact, df=df, ef=ef)
 
 
-@pytest.mark.parametrize("dtype,realtype", zip(DTYPES, REAL_DTYPES
-                                               + REAL_DTYPES))
+@pytest.mark.parametrize("dtype,realtype", list(zip(DTYPES, REAL_DTYPES
+                                               + REAL_DTYPES)))
 @pytest.mark.parametrize("fact,df_de_lambda",
                          [("F",
                            lambda d, e: get_lapack_funcs('pttrf',

--- a/scipy/linalg/tests/test_solvers.py
+++ b/scipy/linalg/tests/test_solvers.py
@@ -316,7 +316,7 @@ class TestSolveContinuousAre:
     min_decimal = (14, 12, 13, 14, 11, 6, None, 5, 7, 14, 14,
                    None, 9, 14, 13, 14, None, 12, None, None)
 
-    @pytest.mark.parametrize("j, case", enumerate(cases))
+    @pytest.mark.parametrize("j, case", list(enumerate(cases)))
     def test_solve_continuous_are(self, j, case):
         """Checks if 0 = XA + A'X - XB(R)^{-1} B'X + Q is true"""
         a, b, q, r, knownfailure = case
@@ -545,7 +545,7 @@ class TestSolveDiscreteAre:
     # bump not needed for OpenBLAS 3.26
     max_tol[16] = 2.0e-4
 
-    @pytest.mark.parametrize("j, case", enumerate(cases))
+    @pytest.mark.parametrize("j, case", list(enumerate(cases)))
     def test_solve_discrete_are(self, j, case):
         """Checks if X = A'XA-(A'XB)(R+B'XB)^-1(B'XA)+Q) is true"""
         a, b, q, r, knownfailure = case

--- a/scipy/ndimage/tests/test_filters.py
+++ b/scipy/ndimage/tests/test_filters.py
@@ -1129,7 +1129,7 @@ class TestNdimageFilters:
             make_xp_pytest_param(ndimage.percentile_filter, 1, 3, kwargs_rank),
         ]
     )
-    @pytest.mark.parametrize('axes', itertools.combinations(range(-3, 3), 2))
+    @pytest.mark.parametrize('axes', list(itertools.combinations(range(-3, 3), 2)))
     def test_filter_axes_kwargs(self, filter_func, size0, size, kwargs, axes, xp):
         array = xp.arange(6 * 8 * 12, dtype=xp.float64)
         array = xp.reshape(array, (6, 8, 12))
@@ -1299,7 +1299,7 @@ class TestNdimageFilters:
     @xfail_xp_backends("cupy", reason="https://github.com/cupy/cupy/pull/8339")
     @pytest.mark.parametrize('n_mismatch', [1, 3])
     @pytest.mark.parametrize('filter_func, kwargs, key, val',
-                             _cases_axes_tuple_length_mismatch())
+                             list(_cases_axes_tuple_length_mismatch()))
     def test_filter_tuple_length_mismatch(self, n_mismatch, filter_func,
                                           kwargs, key, val, xp):
         # Test for the intended RuntimeError when a kwargs has an invalid size

--- a/scipy/signal/tests/test_upfirdn.py
+++ b/scipy/signal/tests/test_upfirdn.py
@@ -281,12 +281,12 @@ class TestUpfirdn:
 
     @pytest.mark.parametrize(
         'size, h_len, mode, dtype',
-        product(
+        list(product(
             [8],
             [4, 5, 26],  # include cases with h_len > 2*size
             _upfirdn_modes,
             ["float32", "float64", "complex64", "complex128"],
-        )
+        ))
     )
     def test_modes(self, size, h_len, mode, dtype, xp):
         if is_cupy(xp) and mode != "constant":

--- a/scipy/sparse/csgraph/tests/test_matching.py
+++ b/scipy/sparse/csgraph/tests/test_matching.py
@@ -266,7 +266,7 @@ def linear_sum_assignment_assertions(
                            cost_matrix[row_ind, col_ind])).flatten())
 
 
-linear_sum_assignment_test_cases = product(
+linear_sum_assignment_test_cases = list(product(
     [-1, 1],
     [
         # Square
@@ -297,7 +297,7 @@ linear_sum_assignment_test_cases = product(
           [float("inf"), float("inf"), 1],
           [float("inf"), 7, float("inf")]],
          [10, 1, 7])
-    ])
+    ]))
 
 
 @pytest.mark.parametrize('sign,test_case', linear_sum_assignment_test_cases)

--- a/scipy/sparse/tests/test_64bit.py
+++ b/scipy/sparse/tests/test_64bit.py
@@ -108,20 +108,20 @@ class RunAll64Bit:
 class Test64BitArray(RunAll64Bit):
     # inheritance of pytest test classes does not separate marks for subclasses.
     # So we define these functions in both Array and Matrix versions.
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("sparray"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("sparray")))
     def test_resiliency_limit_10(self, cls, method_name):
         self._check_resiliency(cls, method_name, maxval_limit=10)
 
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("sparray"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("sparray")))
     def test_resiliency_all_32(self, cls, method_name):
         self._check_resiliency(cls, method_name, fixed_dtype=np.int32)
 
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("sparray"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("sparray")))
     def test_resiliency_all_64(self, cls, method_name):
         self._check_resiliency(cls, method_name, fixed_dtype=np.int64)
 
     @pytest.mark.fail_slow(2)
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("sparray"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("sparray")))
     def test_resiliency_random(self, cls, method_name):
         self._check_resiliency(cls, method_name)
 
@@ -129,7 +129,7 @@ class Test64BitArray(RunAll64Bit):
 class Test64BitMatrix(RunAll64Bit):
     # assert_32bit=True only for spmatrix cuz sparray does not check index content
     @pytest.mark.fail_slow(5)
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix")))
     def test_no_64(self, cls, method_name):
         self._check_resiliency(cls, method_name, assert_32bit=True)
 
@@ -137,20 +137,20 @@ class Test64BitMatrix(RunAll64Bit):
 class Test64BitMatrixSameAsArray(RunAll64Bit):
     # inheritance of pytest test classes does not separate marks for subclasses.
     # So we define these functions in both Array and Matrix versions.
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix")))
     def test_resiliency_limit_10(self, cls, method_name):
         self._check_resiliency(cls, method_name, maxval_limit=10)
 
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix")))
     def test_resiliency_all_32(self, cls, method_name):
         self._check_resiliency(cls, method_name, fixed_dtype=np.int32)
 
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix")))
     def test_resiliency_all_64(self, cls, method_name):
         self._check_resiliency(cls, method_name, fixed_dtype=np.int64)
 
     @pytest.mark.fail_slow(2)
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix")))
     def test_resiliency_random(self, cls, method_name):
         # Resiliency check that sparse deals with varying index data types.
         self._check_resiliency(cls, method_name)
@@ -160,20 +160,20 @@ class Test64BitMatrixSameAsArray(RunAll64Bit):
 class Test64BitArrayExtra(RunAll64Bit):
     # inheritance of pytest test classes does not separate marks for subclasses.
     # So we define these functions in both Array and Matrix versions.
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("sparray-extra"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("sparray-extra")))
     def test_resiliency_limit_10(self, cls, method_name):
         self._check_resiliency(cls, method_name, maxval_limit=10)
 
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("sparray-extra"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("sparray-extra")))
     def test_resiliency_all_32(self, cls, method_name):
         self._check_resiliency(cls, method_name, fixed_dtype=np.int32)
 
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("sparray-extra"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("sparray-extra")))
     def test_resiliency_all_64(self, cls, method_name):
         self._check_resiliency(cls, method_name, fixed_dtype=np.int64)
 
     @pytest.mark.fail_slow(2)
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("sparray-extra"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("sparray-extra")))
     def test_resiliency_random(self, cls, method_name):
         # Resiliency check that sparse deals with varying index data types.
         self._check_resiliency(cls, method_name)
@@ -184,26 +184,26 @@ class Test64BitArrayExtra(RunAll64Bit):
 class Test64BitMatrixExtra(RunAll64Bit):
     # assert_32bit=True only for spmatrix cuz sparray does not check index content
     @pytest.mark.fail_slow(5)
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix-extra"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix-extra")))
     def test_no_64(self, cls, method_name):
         self._check_resiliency(cls, method_name, assert_32bit=True)
 
     # inheritance of pytest test classes does not separate marks for subclasses.
     # So we define these functions in both Array and Matrix versions.
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix-extra"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix-extra")))
     def test_resiliency_limit_10(self, cls, method_name):
         self._check_resiliency(cls, method_name, maxval_limit=10)
 
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix-extra"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix-extra")))
     def test_resiliency_all_32(self, cls, method_name):
         self._check_resiliency(cls, method_name, fixed_dtype=np.int32)
 
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix-extra"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix-extra")))
     def test_resiliency_all_64(self, cls, method_name):
         self._check_resiliency(cls, method_name, fixed_dtype=np.int64)
 
     @pytest.mark.fail_slow(2)
-    @pytest.mark.parametrize('cls,method_name', cases_64bit("spmatrix-extra"))
+    @pytest.mark.parametrize('cls,method_name', list(cases_64bit("spmatrix-extra")))
     def test_resiliency_random(self, cls, method_name):
         # Resiliency check that sparse deals with varying index data types.
         self._check_resiliency(cls, method_name)

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -931,7 +931,7 @@ def test_diags_int(func):
     assert_array_equal(arr.toarray(), expected, strict=True)
 
 
-@pytest.mark.parametrize('func', [construct.diags_array, construct.diags])
+@pytest.mark.parametrize('func', (construct.diags_array, construct.diags))
 def test_diags_int_to_float64(func):
     d = [[3], [1, 2], [4]]
     offsets = [-1, 0, 1]

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -919,7 +919,7 @@ def test_diags_array():
         construct.diags(np.arange(1.0, 5.0), 5, shape=(4, 4))
 
 
-@pytest.mark.parametrize('func', [construct.diags_array, construct.diags])
+@pytest.mark.parametrize('func', (construct.diags_array, construct.diags))
 def test_diags_int(func):
     d = [[3], [1, 2], [4]]
     offsets = [-1, 0, 1]

--- a/scipy/sparse/tests/test_coo.py
+++ b/scipy/sparse/tests/test_coo.py
@@ -251,7 +251,7 @@ def test_1d_resize(arg: int):
     assert_equal(res.toarray(), den)
 
 
-@pytest.mark.parametrize('arg', zip([1, 2, 3, 4], [1, 2, 3, 4]))
+@pytest.mark.parametrize('arg', list(zip([1, 2, 3, 4], [1, 2, 3, 4])))
 def test_1d_to_2d_resize(arg: tuple[int, int]):
     den = np.array([1, 0, 3])
     res = coo_array(den)

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -74,7 +74,7 @@ def test_generic_quat_matrix(xp):
     xp_assert_close(r.as_quat(), expected_quat)
 
 
-@pytest.mark.parametrize("ndim", range(1, 6))
+@pytest.mark.parametrize("ndim", list(range(1, 6)))
 def test_from_single_nd_quaternion(xp, ndim: int):
     x = xp.asarray([3.0, 4, 0, 0])
     x = xp.reshape(x, (1,) * (ndim - 1) + (4,))
@@ -248,7 +248,7 @@ def test_quat_double_cover(xp):
                     xp.asarray([0.0, 0, 0, -1]), atol=2e-16)
 
 
-@pytest.mark.parametrize("ndim", range(1, 6))
+@pytest.mark.parametrize("ndim", list(range(1, 6)))
 def test_from_quat_wrong_shape(xp, ndim: int):
     quat = xp.zeros((*((1,) * ndim), 5))
     with pytest.raises(ValueError, match="Expected `quat` to have shape"):
@@ -269,7 +269,7 @@ def test_zero_norms_from_quat(xp):
 
 
 @make_xp_test_case((Rotation, "as_matrix"))
-@pytest.mark.parametrize("ndim", range(1, 6))
+@pytest.mark.parametrize("ndim", list(range(1, 6)))
 def test_as_matrix_single_nd_quaternion(xp, ndim: int):
     quat = xp.asarray([0, 0, 1, 1])
     quat = xp.reshape(quat, (1,) * (ndim - 1) + (4,))
@@ -344,7 +344,7 @@ def test_as_matrix_from_generic_input(xp):
 
 
 @make_xp_test_case((Rotation, "from_matrix"))
-@pytest.mark.parametrize("ndim", range(1, 6))
+@pytest.mark.parametrize("ndim", list(range(1, 6)))
 def test_from_single_nd_matrix(xp, ndim: int):
     mat = xp.asarray([
             [0, 0, 1],
@@ -475,7 +475,7 @@ def test_from_matrix_int_dtype(xp):
 
 
 @make_xp_test_case((Rotation, "from_rotvec"))
-@pytest.mark.parametrize("ndim", range(1, 6))
+@pytest.mark.parametrize("ndim", list(range(1, 6)))
 def test_from_nd_single_rotvec(xp, ndim: int):
     atol = 1e-7
     rotvec = xp.asarray([1, 0, 0])
@@ -567,7 +567,7 @@ def test_malformed_1d_from_rotvec(xp):
 
 
 @make_xp_test_case((Rotation, "from_rotvec"))
-@pytest.mark.parametrize("ndim", range(1, 6))
+@pytest.mark.parametrize("ndim", list(range(1, 6)))
 def test_malformed_nd_from_rotvec(xp, ndim: int):
     shape = (1,) * (ndim - 1) + (2,)
     with pytest.raises(ValueError, match='Expected `rot_vec` to have shape'):
@@ -593,7 +593,7 @@ def test_as_generic_rotvec(xp):
 
 
 @make_xp_test_case((Rotation, "as_rotvec"))
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_as_rotvec_single_nd_input(xp, ndim: int):
     quat = xp.asarray([1, 2, -3, 2])
     quat = xp.reshape(quat, (1,) * (ndim - 1) + (4,))
@@ -711,7 +711,7 @@ def test_past_180_degree_rotation(xp):
 
 
 @make_xp_test_case((Rotation, "as_mrp"))
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_as_mrp_single_nd_input(xp, ndim: int):
     quat = xp.asarray([1, 2, -3, 2])
     quat = xp.reshape(quat, (1,) * (ndim - 1) + (4,))
@@ -756,7 +756,7 @@ def test_from_euler_input_validation(xp):
 
 
 @make_xp_test_case((Rotation, "from_euler"))
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_from_euler_nd_rotation(xp, ndim: int):
     angles = xp.reshape(xp.asarray([0, 0, 90]), (1,) * (ndim - 1) + (3,))
     quat = Rotation.from_euler("xyz", angles, degrees=True).as_quat()
@@ -1080,7 +1080,7 @@ def test_as_euler_degenerate_symmetric_axes(
 
 
 @make_xp_test_case((Rotation, "from_euler"), (Rotation, "as_euler"))
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_as_euler_nd_rotation(xp, ndim: int):
     mat = xp.asarray([
         [0.0, -1, 0],
@@ -1227,7 +1227,7 @@ def test_identity_shape():  # Not an xp test, identity is using numpy only for n
 
 
 @make_xp_test_case((Rotation, "magnitude"))
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_magnitude(xp, ndim: int):
     quat_shape = (1,) * (ndim - 1) + (4,)
     quat = xp.reshape(xp.eye(4), quat_shape + (4,))
@@ -1338,7 +1338,7 @@ def test_approx_equal_batched_input_validation(xp):
 @make_xp_test_case(
     (Rotation, "from_rotvec"), (Rotation, "mean"), (Rotation, "magnitude")
 )
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_mean(xp, ndim: int):
     axes = xp.concat((-xp.eye(3), xp.eye(3)))
     axes = xp.reshape(axes, (1,) * (ndim - 1) + (6, 3))
@@ -1354,7 +1354,7 @@ def test_mean(xp, ndim: int):
 @make_xp_test_case(
     (Rotation, "from_rotvec"), (Rotation, "mean"), (Rotation, "magnitude")
 )
-@pytest.mark.parametrize("ndim", range(1, 5))
+@pytest.mark.parametrize("ndim", list(range(1, 5)))
 def test_mean_axis(xp, ndim: int):
     axes = xp.tile(xp.concat((-xp.eye(3), xp.eye(3))), (3,) * (ndim - 1) + (1, 1))
     theta = xp.pi / 4
@@ -1403,7 +1403,7 @@ def test_mean_compare_axis(xp):
 
 @make_xp_test_case((Rotation, "from_rotvec"), (Rotation, "mean"), (Rotation, "inv"),
                    (Rotation, "magnitude"))
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_weighted_mean(xp, ndim: int):
     # test that doubling a weight is equivalent to including a rotation twice.
     thetas = xp.linspace(0, xp.pi / 2, 100)
@@ -1537,7 +1537,7 @@ def test_apply_single_rotation_single_point(xp):
 
 
 @make_xp_test_case((Rotation, "from_matrix"), (Rotation, "apply"))
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_apply_single_rotation_multiple_points(xp, ndim: int):
     dtype = xpx.default_dtype(xp)
     mat = xp.asarray([
@@ -1563,7 +1563,7 @@ def test_apply_single_rotation_multiple_points(xp, ndim: int):
 
 
 @make_xp_test_case((Rotation, "from_matrix"), (Rotation, "apply"))
-@pytest.mark.parametrize("ndim", range(1, 5))
+@pytest.mark.parametrize("ndim", list(range(1, 5)))
 def test_apply_multiple_rotations_single_point(xp, ndim: int):
     dtype = xpx.default_dtype(xp)
     mat = np.empty((2, 3, 3))
@@ -1599,7 +1599,7 @@ def test_apply_multiple_rotations_single_point(xp, ndim: int):
 
 
 @make_xp_test_case((Rotation, "from_matrix"), (Rotation, "apply"))
-@pytest.mark.parametrize("ndim", range(1, 5))
+@pytest.mark.parametrize("ndim", list(range(1, 5)))
 def test_apply_multiple_rotations_multiple_points(xp, ndim: int):
     dtype = xpx.default_dtype(xp)
     mat = np.empty((2, 3, 3))
@@ -1696,7 +1696,7 @@ def test_apply_input_validation(xp):
 @make_xp_test_case(
     (Rotation, "from_matrix"), (Rotation, "as_matrix"), (Rotation, "__getitem__")
 )
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_getitem(xp, ndim: int):
     rng = np.random.default_rng(0)
     quat = rng.normal(size=(2, ) + (ndim,) * (ndim - 1) + (4,))
@@ -2498,7 +2498,7 @@ def test_multiplication_stability(xp):
     (Rotation, "inv"), (Rotation, "__pow__"), (Rotation, "inv"),
     (Rotation, "magnitude"), (Rotation, "from_rotvec"), (Rotation, "as_rotvec")
 )
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_pow(xp, ndim: int):
     dtype = xpx.default_dtype(xp)
     atol = 1e-14 if dtype == xp.float64 else 1e-6
@@ -2738,7 +2738,7 @@ def test_from_davenport_one_or_two_axes(xp):
 
 
 @make_xp_test_case((Rotation, "from_davenport"))
-@pytest.mark.parametrize("ndim", range(1, 4))
+@pytest.mark.parametrize("ndim", list(range(1, 4)))
 def test_from_davenport_shapes(xp, ndim: int):
     # The shape rules for ND rotations are as follows:
     # axes.shape[-2] must be angles.shape[-1]
@@ -3196,7 +3196,7 @@ def test_rotation_iter(xp):
             raise RuntimeError("Iteration exceeded length of rotations")
 
 
-@pytest.mark.parametrize("ndim", range(1, 5))
+@pytest.mark.parametrize("ndim", list(range(1, 5)))
 def test_rotation_shape(xp, ndim: int):
     shape = tuple(range(2, 2 + ndim)[:ndim - 1])
     quat = xp.ones(shape + (4,))

--- a/scipy/spatial/transform/tests/test_rotation.py
+++ b/scipy/spatial/transform/tests/test_rotation.py
@@ -932,7 +932,7 @@ def test_from_euler_scalar():
 
 
 @make_xp_test_case((Rotation, "from_euler"), (Rotation, "as_euler"))
-@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("seq_tuple", list(permutations("xyz")))
 @pytest.mark.parametrize("intrinsic", (False, True))
 def test_as_euler_asymmetric_axes(xp, seq_tuple, intrinsic):
     # helper function for mean error tests
@@ -963,7 +963,7 @@ def test_as_euler_asymmetric_axes(xp, seq_tuple, intrinsic):
 
 
 @make_xp_test_case((Rotation, "from_euler"), (Rotation, "as_euler"))
-@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("seq_tuple", list(permutations("xyz")))
 @pytest.mark.parametrize("intrinsic", (False, True))
 def test_as_euler_symmetric_axes(xp, seq_tuple, intrinsic):
     # helper function for mean error tests
@@ -1009,7 +1009,7 @@ def maybe_warn_gimbal_lock(should_warn, xp):
 @make_xp_test_case(
     (Rotation, "from_euler"), (Rotation, "as_matrix"), (Rotation, "as_euler")
 )
-@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("seq_tuple", list(permutations("xyz")))
 @pytest.mark.parametrize("intrinsic", (False, True))
 @pytest.mark.parametrize("suppress_warnings", (False, True))
 def test_as_euler_degenerate_asymmetric_axes(
@@ -1045,7 +1045,7 @@ def test_as_euler_degenerate_asymmetric_axes(
 @make_xp_test_case(
     (Rotation, "from_euler"), (Rotation, "as_matrix"), (Rotation, "as_euler")
 )
-@pytest.mark.parametrize("seq_tuple", permutations("xyz"))
+@pytest.mark.parametrize("seq_tuple", list(permutations("xyz")))
 @pytest.mark.parametrize("intrinsic", (False, True))
 @pytest.mark.parametrize("suppress_warnings", (False, True))
 def test_as_euler_degenerate_symmetric_axes(

--- a/scipy/spatial/transform/tests/test_rotation_groups.py
+++ b/scipy/spatial/transform/tests/test_rotation_groups.py
@@ -131,19 +131,19 @@ def test_cyclic(n, axis):
         assert _calculate_rmsd(P, g.apply(P)) < TOL
 
 
-@pytest.mark.parametrize("name, size", zip(NAMES, SIZES))
+@pytest.mark.parametrize("name, size", list(zip(NAMES, SIZES)))
 def test_group_sizes(name, size):
     assert len(Rotation.create_group(name)) == size
 
 
-@pytest.mark.parametrize("name, size", zip(NAMES, SIZES))
+@pytest.mark.parametrize("name, size", list(zip(NAMES, SIZES)))
 def test_group_no_duplicates(name, size):
     g = Rotation.create_group(name)
     kdtree = cKDTree(g.as_quat())
     assert len(kdtree.query_pairs(1E-3)) == 0
 
 
-@pytest.mark.parametrize("name, size", zip(NAMES, SIZES))
+@pytest.mark.parametrize("name, size", list(zip(NAMES, SIZES)))
 def test_group_symmetry(name, size):
     g = Rotation.create_group(name)
     q = np.concatenate((-g.as_quat(), g.as_quat()))

--- a/scipy/spatial/transform/tests/test_rotation_groups.py
+++ b/scipy/spatial/transform/tests/test_rotation_groups.py
@@ -10,7 +10,7 @@ from scipy.spatial import cKDTree
 
 
 TOL = 1E-12
-NS = range(1, 13)
+NS = list(range(1, 13))
 NAMES = ["I", "O", "T"] + [f"C{n}" for n in NS] + [f"D{n}" for n in NS]
 SIZES = [60, 24, 12] + list(NS) + [2 * n for n in NS]
 

--- a/scipy/special/tests/test_logsumexp.py
+++ b/scipy/special/tests/test_logsumexp.py
@@ -255,7 +255,7 @@ class TestLogSumExp:
         xp_assert_close(xp.imag(res), xp.imag(ref), atol=0, rtol=1e-15)
 
 
-    @pytest.mark.parametrize('x,y', it.product(
+    @pytest.mark.parametrize('x,y', list(it.product(
         [
             -np.inf,
             np.inf,
@@ -277,7 +277,7 @@ class TestLogSumExp:
             complex(np.inf, 3.9270),
             complex(np.inf, 5.4978),
         ], repeat=2)
-    )
+    ))
     def test_gh22601_infinite_elements(self, x, y, xp):
         # Test that `logsumexp` does reasonable things in the presence of
         # real and complex infinities.

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -406,7 +406,7 @@ def test_roots_jacobi():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_jacobi, 0, 1, 1)
-    assert_raises(ValueError, sc.roots_jacobi, 3.3, 1, 1)
+    assert_raises(ValueError, sc.roots_jacobi, 3.3, 1, 1)  # type: ignore[call-overload]
     assert_raises(ValueError, sc.roots_jacobi, 3, -2, 1)
     assert_raises(ValueError, sc.roots_jacobi, 3, 1, -2)
     assert_raises(ValueError, sc.roots_jacobi, 3, -2, -2)
@@ -461,7 +461,7 @@ def test_roots_sh_jacobi():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_sh_jacobi, 0, 1, 1)
-    assert_raises(ValueError, sc.roots_sh_jacobi, 3.3, 1, 1)
+    assert_raises(ValueError, sc.roots_sh_jacobi, 3.3, 1, 1)  # type: ignore[call-overload]
     assert_raises(ValueError, sc.roots_sh_jacobi, 3, 1, 2)    # p - q <= -1
     assert_raises(ValueError, sc.roots_sh_jacobi, 3, 2, -1)   # q <= 0
     assert_raises(ValueError, sc.roots_sh_jacobi, 3, -2, -1)  # both
@@ -492,7 +492,7 @@ def test_roots_hermite():
     assert_allclose(sum(v), m, 1e-14, 1e-14)
 
     assert_raises(ValueError, sc.roots_hermite, 0)
-    assert_raises(ValueError, sc.roots_hermite, 3.3)
+    assert_raises(ValueError, sc.roots_hermite, 3.3)  # type: ignore[call-overload]
 
 def test_roots_hermite_asy():
     # Recursion for Hermite functions
@@ -541,7 +541,7 @@ def test_roots_hermitenorm():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_hermitenorm, 0)
-    assert_raises(ValueError, sc.roots_hermitenorm, 3.3)
+    assert_raises(ValueError, sc.roots_hermitenorm, 3.3)  # type: ignore[call-overload]
 
 def test_roots_gegenbauer():
     def rootf(a):
@@ -604,7 +604,7 @@ def test_roots_gegenbauer():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_gegenbauer, 0, 2)
-    assert_raises(ValueError, sc.roots_gegenbauer, 3.3, 2)
+    assert_raises(ValueError, sc.roots_gegenbauer, 3.3, 2)  # type: ignore[call-overload]
     assert_raises(ValueError, sc.roots_gegenbauer, 3, -.75)
 
 def test_roots_chebyt():
@@ -623,7 +623,7 @@ def test_roots_chebyt():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_chebyt, 0)
-    assert_raises(ValueError, sc.roots_chebyt, 3.3)
+    assert_raises(ValueError, sc.roots_chebyt, 3.3)  # type: ignore[call-overload]
 
 def test_chebyt_symmetry():
     x, w = sc.roots_chebyt(21)
@@ -646,7 +646,7 @@ def test_roots_chebyu():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_chebyu, 0)
-    assert_raises(ValueError, sc.roots_chebyu, 3.3)
+    assert_raises(ValueError, sc.roots_chebyu, 3.3)  # type: ignore[call-overload]
 
 def test_roots_chebyc():
     weightf = orth.chebyc(5).weight_func
@@ -664,7 +664,7 @@ def test_roots_chebyc():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_chebyc, 0)
-    assert_raises(ValueError, sc.roots_chebyc, 3.3)
+    assert_raises(ValueError, sc.roots_chebyc, 3.3)  # type: ignore[call-overload]
 
 def test_roots_chebys():
     weightf = orth.chebys(5).weight_func
@@ -681,7 +681,7 @@ def test_roots_chebys():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_chebys, 0)
-    assert_raises(ValueError, sc.roots_chebys, 3.3)
+    assert_raises(ValueError, sc.roots_chebys, 3.3)  # type: ignore[call-overload]
 
 def test_roots_sh_chebyt():
     weightf = orth.sh_chebyt(5).weight_func
@@ -699,7 +699,7 @@ def test_roots_sh_chebyt():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_sh_chebyt, 0)
-    assert_raises(ValueError, sc.roots_sh_chebyt, 3.3)
+    assert_raises(ValueError, sc.roots_sh_chebyt, 3.3)  # type: ignore[call-overload]
 
 def test_roots_sh_chebyu():
     weightf = orth.sh_chebyu(5).weight_func
@@ -717,7 +717,7 @@ def test_roots_sh_chebyu():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_sh_chebyu, 0)
-    assert_raises(ValueError, sc.roots_sh_chebyu, 3.3)
+    assert_raises(ValueError, sc.roots_sh_chebyu, 3.3)  # type: ignore[call-overload]
 
 def test_roots_legendre():
     weightf = orth.legendre(5).weight_func
@@ -736,7 +736,7 @@ def test_roots_legendre():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_legendre, 0)
-    assert_raises(ValueError, sc.roots_legendre, 3.3)
+    assert_raises(ValueError, sc.roots_legendre, 3.3)  # type: ignore[call-overload]
 
 def test_roots_sh_legendre():
     weightf = orth.sh_legendre(5).weight_func
@@ -755,7 +755,7 @@ def test_roots_sh_legendre():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_sh_legendre, 0)
-    assert_raises(ValueError, sc.roots_sh_legendre, 3.3)
+    assert_raises(ValueError, sc.roots_sh_legendre, 3.3)  # type: ignore[call-overload]
 
 def test_roots_laguerre():
     weightf = orth.laguerre(5).weight_func
@@ -774,7 +774,7 @@ def test_roots_laguerre():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_laguerre, 0)
-    assert_raises(ValueError, sc.roots_laguerre, 3.3)
+    assert_raises(ValueError, sc.roots_laguerre, 3.3)  # type: ignore[call-overload]
 
 def test_roots_genlaguerre():
     def rootf(a):
@@ -814,7 +814,7 @@ def test_roots_genlaguerre():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_genlaguerre, 0, 2)
-    assert_raises(ValueError, sc.roots_genlaguerre, 3.3, 2)
+    assert_raises(ValueError, sc.roots_genlaguerre, 3.3, 2)  # type: ignore[call-overload]
     assert_raises(ValueError, sc.roots_genlaguerre, 3, -1.1)
 
 

--- a/scipy/stats/tests/test_axis_nan_policy.py
+++ b/scipy/stats/tests/test_axis_nan_policy.py
@@ -413,7 +413,7 @@ if SCIPY_XSLOW:
     @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                               "paired", "unpacker"), axis_nan_policy_cases)
     @pytest.mark.parametrize(("nan_policy"), ("propagate", "omit", "raise"))
-    @pytest.mark.parametrize(("axis"), range(-3, 3))
+    @pytest.mark.parametrize(("axis"), list(range(-3, 3)))
     @pytest.mark.parametrize(("data_generator"),
                              ("all_nans", "all_finite", "mixed"))
     def test_axis_nan_policy_full(hypotest, args, kwds, n_samples, n_outputs,
@@ -1001,7 +1001,7 @@ def paired_non_broadcastable_cases():
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize(("hypotest", "args", "kwds", "n_samples", "n_outputs",
                           "paired", "unpacker"),
-                         paired_non_broadcastable_cases())
+                         list(paired_non_broadcastable_cases()))
 def test_non_broadcastable(hypotest, args, kwds, n_samples, n_outputs, paired,
                            unpacker, axis):
     # test for correct error message when shapes are not broadcastable
@@ -1163,7 +1163,7 @@ def test_masked_stat_1d():
 @pytest.mark.filterwarnings('ignore:After omitting NaNs...')
 @pytest.mark.filterwarnings('ignore:One or more axis-slices of one...')
 @skip_xp_invalid_arg
-@pytest.mark.parametrize(("axis"), range(-3, 3))
+@pytest.mark.parametrize(("axis"), list(range(-3, 3)))
 def test_masked_stat_3d(axis):
     # basic test of _axis_nan_policy_factory with 3D masked sample
     rng = np.random.default_rng(3679428403)

--- a/scipy/stats/tests/test_continuous.py
+++ b/scipy/stats/tests/test_continuous.py
@@ -1131,7 +1131,7 @@ class TestAttributes:
 
 
 class TestMakeDistribution:
-    @pytest.mark.parametrize('i, distdata', enumerate(distcont + distdiscrete))
+    @pytest.mark.parametrize('i, distdata', list(enumerate(distcont + distdiscrete)))
     def test_rv_generic(self, i, distdata):
         distname = distdata[0]
 

--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -122,7 +122,7 @@ def cases_test_cont_basic():
             yield distname, arg
 
 
-@pytest.mark.parametrize('distname,arg', cases_test_cont_basic())
+@pytest.mark.parametrize('distname,arg', list(cases_test_cont_basic()))
 @pytest.mark.parametrize('sn', [500])
 def test_cont_basic(distname, arg, sn, num_parallel_threads):
     try:
@@ -260,7 +260,7 @@ def test_cont_basic_fit_cases():
 
 
 @pytest.mark.parametrize('distname, arg, method, fix_args',
-                         cases_test_cont_basic_fit())
+                         list(cases_test_cont_basic_fit()))
 @pytest.mark.parametrize('n_fit_samples', [200])
 def test_cont_basic_fit(distname, arg, n_fit_samples, method, fix_args):
     try:
@@ -275,7 +275,7 @@ def test_cont_basic_fit(distname, arg, n_fit_samples, method, fix_args):
     else:
         check_fit_args(distfn, arg, rvs, method)
 
-@pytest.mark.parametrize('distname,arg', cases_test_cont_basic())
+@pytest.mark.parametrize('distname,arg', list(cases_test_cont_basic()))
 def test_rvs_scalar(distname, arg):
     # rvs should return a scalar when given scalar arguments (gh-12428)
     try:
@@ -337,7 +337,7 @@ def cases_test_moments():
 @pytest.mark.slow
 @pytest.mark.parametrize('distname,arg,normalization_ok,higher_ok,moment_ok,'
                          'is_xfailing',
-                         cases_test_moments())
+                         list(cases_test_moments()))
 def test_moments(distname, arg, normalization_ok, higher_ok, moment_ok,
                  is_xfailing):
     try:
@@ -830,7 +830,7 @@ def cases_test_methods_with_lists():
 
 @pytest.mark.parametrize('method', ['pdf', 'logpdf', 'cdf', 'logcdf',
                                     'sf', 'logsf', 'ppf', 'isf'])
-@pytest.mark.parametrize('distname, args', cases_test_methods_with_lists())
+@pytest.mark.parametrize('distname, args', list(cases_test_methods_with_lists()))
 def test_methods_with_lists(method, distname, args):
     # Test that the continuous distributions can accept Python lists
     # as arguments.

--- a/scipy/stats/tests/test_discrete_basic.py
+++ b/scipy/stats/tests/test_discrete_basic.py
@@ -38,7 +38,7 @@ def cases_test_discrete_basic():
         seen.add(distname)
 
 
-@pytest.mark.parametrize('distname,arg,first_case', cases_test_discrete_basic())
+@pytest.mark.parametrize('distname,arg,first_case', list(cases_test_discrete_basic()))
 def test_discrete_basic(distname, arg, first_case, num_parallel_threads):
     if (isinstance(distname, str) and distname.startswith('nchypergeom')
             and num_parallel_threads > 1):
@@ -399,7 +399,7 @@ def cases_test_discrete_integer_shapes():
 
 
 @pytest.mark.parametrize('distname, shapename, shapes',
-                         cases_test_discrete_integer_shapes())
+                         list(cases_test_discrete_integer_shapes()))
 def test_integer_shapes(distname, shapename, shapes):
     dist = getattr(stats, distname)
     shape_info = dist._shape_info()

--- a/scipy/stats/tests/test_discrete_distns.py
+++ b/scipy/stats/tests/test_discrete_distns.py
@@ -147,7 +147,7 @@ def test_betabinom_a_and_b_unity():
     assert_almost_equal(p, expected)
 
 
-@pytest.mark.parametrize('dtypes', itertools.product(*[(int, float)]*3))
+@pytest.mark.parametrize('dtypes', list(itertools.product(*[(int, float)]*3)))
 def test_betabinom_stats_a_and_b_integers_gh18026(dtypes):
     # gh-18026 reported that `betabinom` kurtosis calculation fails when some
     # parameters are integers. Check that this is resolved.
@@ -326,7 +326,7 @@ class TestZipfian:
     naive_tests = np.vstack((np.logspace(-2, 1, 10),
                              rng.randint(2, 40, 10))).T
 
-    @pytest.mark.parametrize("a, n", naive_tests)
+    @pytest.mark.parametrize("a, n", list(naive_tests))
     def test_zipfian_naive(self, a, n):
         # test against bare-bones implementation
 

--- a/scipy/stats/tests/test_fit.py
+++ b/scipy/stats/tests/test_fit.py
@@ -106,7 +106,7 @@ def cases_test_cont_fit():
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize('distname,arg', cases_test_cont_fit())
+@pytest.mark.parametrize('distname,arg', list(cases_test_cont_fit()))
 @pytest.mark.parametrize('method', ["MLE", "MM"])
 def test_cont_fit(distname, arg, method):
     run_xfail = int(os.getenv('SCIPY_XFAIL', default=False))
@@ -349,7 +349,7 @@ def cases_test_fitstart():
         yield distname, shapes
 
 
-@pytest.mark.parametrize('distname, shapes', cases_test_fitstart())
+@pytest.mark.parametrize('distname, shapes', list(cases_test_fitstart()))
 def test_fitstart(distname, shapes):
     dist = getattr(stats, distname)
     rng = np.random.default_rng(216342614)
@@ -534,11 +534,11 @@ class TestFit:
         assert_nlff_less_or_close(dist, data, res.params, ref, **self.tols,
                                   nlff_name=nlff_name)
 
-    @pytest.mark.parametrize("dist_name", cases_test_fit_mle())
+    @pytest.mark.parametrize("dist_name", list(cases_test_fit_mle()))
     def test_basic_fit_mle(self, dist_name):
         self.basic_fit_test(dist_name, "mle", rng=5)
 
-    @pytest.mark.parametrize("dist_name", cases_test_fit_mse())
+    @pytest.mark.parametrize("dist_name", list(cases_test_fit_mse()))
     def test_basic_fit_mse(self, dist_name):
         self.basic_fit_test(dist_name, "mse", rng=2)
 

--- a/scipy/stats/tests/test_morestats.py
+++ b/scipy/stats/tests/test_morestats.py
@@ -1634,7 +1634,7 @@ def mood_cases_with_ties():
 @make_xp_test_case(stats.mood)
 class TestMood:
     @pytest.mark.parametrize("x,y,alternative,stat_expect,p_expect",
-                             mood_cases_with_ties())
+                             list(mood_cases_with_ties()))
     def test_against_SAS(self, x, y, alternative, stat_expect, p_expect, xp):
         """
         Example code used to generate SAS output:

--- a/scipy/stats/tests/test_sampling.py
+++ b/scipy/stats/tests/test_sampling.py
@@ -511,7 +511,7 @@ class TestTransformedDensityRejection:
     mvs = [mv0, mv1, mv2, mv3]
 
     @pytest.mark.parametrize("dist, mv_ex",
-                             zip(dists, mvs))
+                             list(zip(dists, mvs)))
     @pytest.mark.thread_unsafe(reason="deadlocks for unknown reasons")
     def test_basic(self, dist, mv_ex):
         with warnings.catch_warnings():
@@ -821,7 +821,7 @@ class TestNumericalInversePolynomial:
 
     @pytest.mark.thread_unsafe(reason="deadlocks for unknown reasons")
     @pytest.mark.parametrize("dist, mv_ex",
-                             zip(dists, mvs))
+                             list(zip(dists, mvs)))
     def test_basic(self, dist, mv_ex):
         rng = NumericalInversePolynomial(dist, random_state=42)
         check_cont_samples(rng, dist, mv_ex)
@@ -1072,7 +1072,7 @@ class TestNumericalInverseHermite:
     mvs = [mv0, mv1]
 
     @pytest.mark.parametrize("dist, mv_ex",
-                             zip(dists, mvs))
+                             list(zip(dists, mvs)))
     @pytest.mark.parametrize("order", [3, 5])
     @pytest.mark.thread_unsafe
     def test_basic(self, dist, mv_ex, order):
@@ -1364,7 +1364,7 @@ class TestSimpleRatioUniforms:
     mvs = [mv1, mv2]
 
     @pytest.mark.parametrize("dist, mv_ex",
-                             zip(dists, mvs))
+                             list(zip(dists, mvs)))
     @pytest.mark.thread_unsafe
     def test_basic(self, dist, mv_ex):
         rng = SimpleRatioUniforms(dist, mode=dist.mode, random_state=42)

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3601,7 +3601,7 @@ class TestMoments:
     testcase_moment_accuracy = rng.random(42)
 
     @pytest.mark.parametrize('size', [10, (10, 2)])
-    @pytest.mark.parametrize('m, c', product((0, 1, 2, 3), (None, 0, 1)))
+    @pytest.mark.parametrize('m, c', list(product((0, 1, 2, 3), (None, 0, 1))))
     def test_moment_center_scalar_moment(self, size, m, c, xp):
         rng = np.random.default_rng(6581432544381372042)
         x = xp.asarray(rng.random(size=size))


### PR DESCRIPTION
SciPy `1.18.0` "final" is currently scheduled to be released on Friday, June 19th. I suppose there's a chance that this may also be the final minor release series in `1.x.y` series given the possibility that `2.0.0` is the next release. That said, I'm not aware of any major blockers to releasing, though there are some remaining annoyances (there always are).

Backports included (so far):

1. gh-25376 (I didn't want `pytest` warnings/errors for `9.x`/`10.x` series...)
2. gh-25378 (I didn't want `pytest` warnings/errors for `9.x`/`10.x` series...)
3. gh-25410

Potential TODOs/considerations:

- [x] make sure doc build/CI is passing here
- [ ] typing issues would be nice to fix, but probably won't happen before Friday: https://github.com/scipy/scipy/issues/25340
- [ ] gh-25274 has a `1.18.0` milestone, but I don't think it is a hard blocker
- [ ] https://github.com/scipy/scipy/pull/24923 is open and labelled for backport, but also isn't a hard blocker I don't think
- [ ] NumPy `2.5.0` "final" hasn't been released yet; it can be nice to do our "final" release right after the NumPy final release in a given cycle just to be absolutely sure things look "ok," but we're doing fine with RC1.
- [ ] https://github.com/scipy/scipy/issues/25313 is pretty annoying--I have a baseline of 4 failures on this branch (and `main`) at the time of writing. But we could shim around the new Accelerate/MacOS version in `1.18.1` perhaps.

#### AI Generation Disclosure
No AI tools used