### PR TITLE
BUG: integrate: fix \dqk15w\ forward declaration for C23

### DIFF
--- a/scipy/integrate/__quadpack.c
+++ b/scipy/integrate/__quadpack.c
@@ -170,7 +170,7 @@ static void dqcheb(const double*,double*,double*,double*);
 static void dqelg(int*,double*,double*,double*,double*,int*);
 static void dqk15(double(*)(double*),const double,const double,double*,double*,double*,double*);
 static void dqk15i(double(*)(double*),const double,const int,const double,const double,double*,double*,double*,double*);
-static void dqk15w(double(*)(double*),double(),const double,const double,
+static void dqk15w(double(*)(double*),quadpack_w_func,const double,const double,
                    const double,const double,const int,const double,const double,
                    double*,double*,double*,double*);
 static void dqk21(double(*)(double*),const double,const double,double*,double*,double*,double*);


### PR DESCRIPTION
#### Reference issue
Closes gh-25394.

#### What does this implement/fix?
The `dqk15w` forward declaration used `double()` for its weight-function parameter. In C17 this accidentally compiled (unspecified args); in C23 empty parens mean `(void)`, causing a type mismatch. Replaces `double()` with the existing `quadpack_w_func` typedef to match the function definitio

#### AI Generation Disclosure
Double checking mostly. 
