### PR TITLE
BUG: interpolate: INCREF borrowed refs at assignment in fitpack_sphere

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1781,7 +1781,9 @@ fitpack_sphere(PyObject* Py_UNUSED(dummy), PyObject *args)
         // tt and tp are input arrays that will be modified in-place
         // Acquire pointers to the input arrays without copy
         ap_tt = tt;
+        Py_INCREF(ap_tt);
         ap_tp = tp;
+        Py_INCREF(ap_tp);
 
     } else if (iopt == 0) {
         // SMOOTH
@@ -1842,11 +1844,6 @@ fitpack_sphere(PyObject* Py_UNUSED(dummy), PyObject *args)
     Py_DECREF(ap_r);
     Py_DECREF(ap_w);
 
-    if (iopt == -1) {
-        // LSQ: tt and tp were borrowed, INCREF before returning.
-        Py_INCREF(ap_tt);
-        Py_INCREF(ap_tp);
-    }
     return Py_BuildValue(("iNiNNdi"),
                          nt, PyArray_Return(ap_tt), np, PyArray_Return(ap_tp),
                          PyArray_Return(ap_c), fp, ier);


### PR DESCRIPTION
## Reference issue

Closes #25405

## What does this implement/fix?

In `fitpack_sphere` (`scipy/interpolate/src/_fitpackmodule.c`), when `iopt == -1`, `ap_tt` and `ap_tp` are assigned as borrowed references from the input arrays `tt` and `tp`. Previously, `Py_INCREF` was only called on the normal return path (line ~1847), but if any validation check between the assignment and return triggered `goto fail`, the fail block would `Py_XDECREF` these borrowed references — corrupting the caller's refcount and causing potential use-after-free.

**Fix**: Move `Py_INCREF` to immediately after the assignment (`ap_tt = tt; Py_INCREF(ap_tt);`), so `ap_tt`/`ap_tp` are always owned references regardless of which path is taken. This makes the existing `Py_XDECREF` in the fail block correct for both `iopt == -1` (borrowed→now owned) and `iopt == 0` (newly allocated) cases.

As suggested by @ev-br in #25405.

## Additional information

Net change: +2 lines, -5 lines. The old conditional INCREF block before return is removed since the INCREF now happens unconditionally at assignment time.

## AI Generation Disclosure

The bug was initially identified with the assistance of an LLM-based code analysis tool during a research project on FFI boundary bug detection. The fix was designed by @ev-br in the issue discussion (move INCREF to assignment site). The contributor reviewed the fix, verified correctness of the refcount semantics on all code paths (normal return via `Py_BuildValue("N")` which steals the ref, and fail path via `Py_XDECREF`), and manually wrote and submitted this patch.