### PR TITLE
TYP: Fix mypy errors with ``pytest==9.1.0``

### DIFF
--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -1418,10 +1418,10 @@ class TestRectBivariateSpline:
     @pytest.mark.parametrize('s_tols', [(0, 1e-12, 1e-7),
                                         (1, 7e-3, 1e-4),
                                         (3, 2e-2, 1e-4)])
-    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline,
+    @pytest.mark.parametrize("spl_apis", ((RectBivariateSpline,
                                            _RectBivariateSplineEval),
                                           (_regrid,
-                                           _ndbspline_call_like_bivariate)])
+                                           _ndbspline_call_like_bivariate)))
     def test_spline_large_2d(self, shape, s_tols, spl_apis):
         # Reference - https://github.com/scipy/scipy/issues/17787
         #
@@ -1447,10 +1447,10 @@ class TestRectBivariateSpline:
     @pytest.mark.skipif(sys.maxsize <= 2**32, reason="Segfaults on 32-bit system "
                                                      "due to large input data")
     @pytest.mark.parametrize("k", [3, 4])
-    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline,
+    @pytest.mark.parametrize("spl_apis", ((RectBivariateSpline,
                                            _RectBivariateSplineEval),
                                           (_regrid,
-                                           _ndbspline_call_like_bivariate)])
+                                           _ndbspline_call_like_bivariate)))
     def test_spline_large_2d_maxit(self, k, spl_apis):
         # Reference - for https://github.com/scipy/scipy/issues/17787
         #
@@ -1472,10 +1472,10 @@ class TestRectBivariateSpline:
         assert(not np.isnan(z_spl).any())
         xp_assert_close(z_spl, z, atol=atol, rtol=rtol)
 
-    @pytest.mark.parametrize("spl_apis", [(RectBivariateSpline,
+    @pytest.mark.parametrize("spl_apis", ((RectBivariateSpline,
                                            _RectBivariateSplineEval),
                                           (_regrid,
-                                           _ndbspline_call_like_bivariate)])
+                                           _ndbspline_call_like_bivariate)))
     def test_spline_synthetic_data(self, spl_apis):
         """
         Test regrid with synthetic smooth data (mixed frequencies + noise).

--- a/scipy/sparse/tests/test_construct.py
+++ b/scipy/sparse/tests/test_construct.py
@@ -932,7 +932,7 @@ def test_diags_array():
         construct.diags(np.arange(1.0, 5.0), 5, shape=(4, 4))
 
 
-@pytest.mark.parametrize('func', [construct.diags_array, construct.diags])
+@pytest.mark.parametrize('func', (construct.diags_array, construct.diags))
 def test_diags_int(func):
     d = [[3], [1, 2], [4]]
     offsets = [-1, 0, 1]

--- a/scipy/special/tests/test_orthogonal.py
+++ b/scipy/special/tests/test_orthogonal.py
@@ -406,7 +406,7 @@ def test_roots_jacobi():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_jacobi, 0, 1, 1)
-    assert_raises(ValueError, sc.roots_jacobi, 3.3, 1, 1)
+    assert_raises(ValueError, sc.roots_jacobi, 3.3, 1, 1)  # type: ignore[call-overload]
     assert_raises(ValueError, sc.roots_jacobi, 3, -2, 1)
     assert_raises(ValueError, sc.roots_jacobi, 3, 1, -2)
     assert_raises(ValueError, sc.roots_jacobi, 3, -2, -2)
@@ -461,7 +461,7 @@ def test_roots_sh_jacobi():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_sh_jacobi, 0, 1, 1)
-    assert_raises(ValueError, sc.roots_sh_jacobi, 3.3, 1, 1)
+    assert_raises(ValueError, sc.roots_sh_jacobi, 3.3, 1, 1)  # type: ignore[call-overload]
     assert_raises(ValueError, sc.roots_sh_jacobi, 3, 1, 2)    # p - q <= -1
     assert_raises(ValueError, sc.roots_sh_jacobi, 3, 2, -1)   # q <= 0
     assert_raises(ValueError, sc.roots_sh_jacobi, 3, -2, -1)  # both
@@ -492,7 +492,7 @@ def test_roots_hermite():
     assert_allclose(sum(v), m, 1e-14, 1e-14)
 
     assert_raises(ValueError, sc.roots_hermite, 0)
-    assert_raises(ValueError, sc.roots_hermite, 3.3)
+    assert_raises(ValueError, sc.roots_hermite, 3.3)  # type: ignore[call-overload]
 
 def test_roots_hermite_asy():
     # Recursion for Hermite functions
@@ -541,7 +541,7 @@ def test_roots_hermitenorm():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_hermitenorm, 0)
-    assert_raises(ValueError, sc.roots_hermitenorm, 3.3)
+    assert_raises(ValueError, sc.roots_hermitenorm, 3.3)  # type: ignore[call-overload]
 
 def test_roots_gegenbauer():
     def rootf(a):
@@ -604,7 +604,7 @@ def test_roots_gegenbauer():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_gegenbauer, 0, 2)
-    assert_raises(ValueError, sc.roots_gegenbauer, 3.3, 2)
+    assert_raises(ValueError, sc.roots_gegenbauer, 3.3, 2)  # type: ignore[call-overload]
     assert_raises(ValueError, sc.roots_gegenbauer, 3, -.75)
 
 def test_roots_chebyt():
@@ -623,7 +623,7 @@ def test_roots_chebyt():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_chebyt, 0)
-    assert_raises(ValueError, sc.roots_chebyt, 3.3)
+    assert_raises(ValueError, sc.roots_chebyt, 3.3)  # type: ignore[call-overload]
 
 def test_chebyt_symmetry():
     x, w = sc.roots_chebyt(21)
@@ -646,7 +646,7 @@ def test_roots_chebyu():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_chebyu, 0)
-    assert_raises(ValueError, sc.roots_chebyu, 3.3)
+    assert_raises(ValueError, sc.roots_chebyu, 3.3)  # type: ignore[call-overload]
 
 def test_roots_chebyc():
     weightf = orth.chebyc(5).weight_func
@@ -664,7 +664,7 @@ def test_roots_chebyc():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_chebyc, 0)
-    assert_raises(ValueError, sc.roots_chebyc, 3.3)
+    assert_raises(ValueError, sc.roots_chebyc, 3.3)  # type: ignore[call-overload]
 
 def test_roots_chebys():
     weightf = orth.chebys(5).weight_func
@@ -681,7 +681,7 @@ def test_roots_chebys():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_chebys, 0)
-    assert_raises(ValueError, sc.roots_chebys, 3.3)
+    assert_raises(ValueError, sc.roots_chebys, 3.3)  # type: ignore[call-overload]
 
 def test_roots_sh_chebyt():
     weightf = orth.sh_chebyt(5).weight_func
@@ -699,7 +699,7 @@ def test_roots_sh_chebyt():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_sh_chebyt, 0)
-    assert_raises(ValueError, sc.roots_sh_chebyt, 3.3)
+    assert_raises(ValueError, sc.roots_sh_chebyt, 3.3)  # type: ignore[call-overload]
 
 def test_roots_sh_chebyu():
     weightf = orth.sh_chebyu(5).weight_func
@@ -717,7 +717,7 @@ def test_roots_sh_chebyu():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_sh_chebyu, 0)
-    assert_raises(ValueError, sc.roots_sh_chebyu, 3.3)
+    assert_raises(ValueError, sc.roots_sh_chebyu, 3.3)  # type: ignore[call-overload]
 
 def test_roots_legendre():
     weightf = orth.legendre(5).weight_func
@@ -736,7 +736,7 @@ def test_roots_legendre():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_legendre, 0)
-    assert_raises(ValueError, sc.roots_legendre, 3.3)
+    assert_raises(ValueError, sc.roots_legendre, 3.3)  # type: ignore[call-overload]
 
 def test_roots_sh_legendre():
     weightf = orth.sh_legendre(5).weight_func
@@ -755,7 +755,7 @@ def test_roots_sh_legendre():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_sh_legendre, 0)
-    assert_raises(ValueError, sc.roots_sh_legendre, 3.3)
+    assert_raises(ValueError, sc.roots_sh_legendre, 3.3)  # type: ignore[call-overload]
 
 def test_roots_laguerre():
     weightf = orth.laguerre(5).weight_func
@@ -774,7 +774,7 @@ def test_roots_laguerre():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_laguerre, 0)
-    assert_raises(ValueError, sc.roots_laguerre, 3.3)
+    assert_raises(ValueError, sc.roots_laguerre, 3.3)  # type: ignore[call-overload]
 
 def test_roots_genlaguerre():
     def rootf(a):
@@ -814,7 +814,7 @@ def test_roots_genlaguerre():
     assert_allclose(m, muI, rtol=muI_err)
 
     assert_raises(ValueError, sc.roots_genlaguerre, 0, 2)
-    assert_raises(ValueError, sc.roots_genlaguerre, 3.3, 2)
+    assert_raises(ValueError, sc.roots_genlaguerre, 3.3, 2)  # type: ignore[call-overload]
     assert_raises(ValueError, sc.roots_genlaguerre, 3, -1.1)
 
 


### PR DESCRIPTION
Pytest 9.1.0 includes some static typing improvement, which lead to mypy report some new typing errors. The ones in the `special` tests were actually accurate, but since those were reported for expected failures, I ignored them. 
The other ones in the `special` and `interpolate` tests were caused by the fact that `list` is in invariant type, for which mypy apparently has trouble inferring a common function type in (a join vs union story). The workaround is to use tuples instead of lists here, which should not change of pytest's behavior I think.

Closes #25409

No AI tools used
