### PR TITLE
TST: spatial: skip a test on Intel Mac

### DIFF
--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -35,6 +35,7 @@
 from functools import wraps, partial
 import os.path
 import sys
+import platform
 import sysconfig
 import warnings
 import weakref
@@ -1905,6 +1906,10 @@ def test_minkowski_w():
     xp_assert_close(c0, c1, rtol=1e-15)
 
 
+@pytest.mark.skipif(
+    (sys.platform == 'darwin') and (platform.machine() == 'x86_64'),
+    reason="dtypes do not match, on MacOS x86-64 only"
+)
 def test_sqeuclidean_dtypes():
     # Assert that sqeuclidean returns the right types of values.
     # Integer types should be converted to floating for stability.


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

https://github.com/scipy/scipy/pull/25364#issuecomment-4742838538 

#### What does this implement/fix?
<!--Please explain your changes.-->

A test started failing on Intel MacOS after a change from `assert_allclose` to `xp_assert_close`. The latter is a bit more strict than the former; for one it checks dtypes, which assert_allclose does not check. And the new failure is just that: complex64 vs complex128 mismatch which was never caught.

AFAIU, MacOS x64-86 is approaching EOL, so this PR just skips the test on the problematic platform.


#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai