### PR TITLE
DOC: fix grammar issues across scipy (batch 4)

### DIFF
--- a/scipy/integrate/_lebedev.py
+++ b/scipy/integrate/_lebedev.py
@@ -4860,7 +4860,7 @@ def get_lebedev_recurrence_points(type_, start, a, b, v, leb):
             start = start + 8
 
         case 4:
-            # /* In this case A is inputed */
+            # /* In this case A is input */
             b = sqrt(1.0 - 2.0 * a * a)
             leb.x[start] = a
             leb.y[start] = a
@@ -4984,7 +4984,7 @@ def get_lebedev_recurrence_points(type_, start, a, b, v, leb):
             start = start + 24
 
         case 5:
-            # /* A is inputed in this case as well*/
+            # /* A is input in this case as well*/
             b = sqrt(1 - a * a)
             leb.x[start] = a
             leb.y[start] = b
@@ -5108,7 +5108,7 @@ def get_lebedev_recurrence_points(type_, start, a, b, v, leb):
             start = start + 24
 
         case 6:
-            # /* both A and B are inputed in this case */
+            # /* both A and B are input in this case */
             c = sqrt(1.0 - a * a - b * b)
             leb.x[start] = a
             leb.y[start] = b

--- a/scipy/integrate/_quad_vec.py
+++ b/scipy/integrate/_quad_vec.py
@@ -187,7 +187,7 @@ def quad_vec(f, a, b, epsabs=1e-200, epsrel=1e-8, norm='2', cache_size=100e6,
 
     The Wynn epsilon table extrapolation is not used (QUADPACK uses it
     for infinite intervals). This is because the algorithm here is
-    supposed to work on vector-valued functions, in an user-specified
+    supposed to work on vector-valued functions, in a user-specified
     norm, and the extension of the epsilon algorithm to this case does
     not appear to be widely agreed. For max-norm, using elementwise
     Wynn epsilon could be possible, but we do not do this here with

--- a/scipy/linalg/_special_matrices.py
+++ b/scipy/linalg/_special_matrices.py
@@ -938,7 +938,7 @@ def dft(n, scale=None):
 def fiedler(a):
     """Returns a symmetric Fiedler matrix.
 
-    Given an sequence of numbers `a`, Fiedler matrices have the structure
+    Given a sequence of numbers `a`, Fiedler matrices have the structure
     ``F[i, j] = np.abs(a[i] - a[j])``, and hence zero diagonals and nonnegative
     entries. A Fiedler matrix has a dominant positive eigenvalue and other
     eigenvalues are negative. Although not valid generally, for certain inputs,

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -132,7 +132,7 @@ int NI_BinaryErosion(PyArrayObject* input, PyArrayObject* strct,
 
     NPY_BEGIN_THREADS;
 
-    /* get data pointers an size: */
+    /* get data pointers and size: */
     pi = (void *)PyArray_DATA(input);
     po = (void *)PyArray_DATA(output);
     size = PyArray_SIZE(input);

--- a/scipy/optimize/_direct/DIRect.c
+++ b/scipy/optimize/_direct/DIRect.c
@@ -187,7 +187,7 @@
 /* |            as described by Jones et.al. (0) or use our modification(1)| */
 /* | logfile -- File-Handle for the logfile. DIRECT expects this file to be| */
 /* |            opened and closed by the user outside of DIRECT. We moved  | */
-/* |            this to the outside so the user can add extra informations | */
+/* |            this to the outside so the user can add extra information | */
 /* |            to this file before and after the call to DIRECT.          | */
 /* | fglobal -- Function value of the global optimum. If this value is not | */
 /* |            known (that is, we solve a real problem, not a testproblem)| */
@@ -431,7 +431,7 @@
 /* +-----------------------------------------------------------------------+ */
 /* | Call the routine to initialise the mapping of x from the n-dimensional| */
 /* | unit cube to the hypercube given by u and l. If an error occurred,    | */
-/* | give out a error message and return to the main program with the error| */
+/* | give out an error message and return to the main program with the error| */
 /* | flag set.                                                             | */
 /* | JG 07/16/01 Changed call to remove unused data.                       | */
 /* +-----------------------------------------------------------------------+ */

--- a/scipy/optimize/_dual_annealing.py
+++ b/scipy/optimize/_dual_annealing.py
@@ -578,7 +578,7 @@ def dual_annealing(func, bounds, args=(), maxiter=1000,
         p_{q_{a}} = \\min{\\{1,\\left[1-(1-q_{a}) \\beta \\Delta E \\right]^{ \\
         \\frac{1}{1-q_{a}}}\\}}
 
-    Where :math:`q_{a}` is a acceptance parameter. For :math:`q_{a}<1`, zero
+    Where :math:`q_{a}` is an acceptance parameter. For :math:`q_{a}<1`, zero
     acceptance probability is assigned to the cases where
 
     .. math::

--- a/scipy/optimize/_shgo_lib/_complex.py
+++ b/scipy/optimize/_shgo_lib/_complex.py
@@ -274,7 +274,7 @@ class Complex:
                         yield a_vu.x
 
                 # Try to connect aN lower source of previous a + b
-                # operation with a aN vertex
+                # operation with an aN vertex
                 ab_Cc = copy.copy(ab_C)
 
                 for vp in ab_Cc:
@@ -612,7 +612,7 @@ class Complex:
                 cCcx = [x[:] for x in Ccx[:i + 1]]
                 cCux = [x[:] for x in Cux[:i + 1]]
                 # Try to connect aN lower source of previous a + b
-                # operation with a aN vertex
+                # operation with an aN vertex
                 ab_Cc = copy.copy(ab_C)  # NOTE: We append ab_C in the
                 # (VL, VC, VU) for-loop, but we use the copy of the list in the
                 # ab_Cc for-loop.

--- a/scipy/optimize/_trlib/trlib_tri_factor.c
+++ b/scipy/optimize/_trlib/trlib_tri_factor.c
@@ -165,7 +165,7 @@ trlib_int_t trlib_tri_factor_min(
                     TRLIB_DCOPY(&nm0, offdiag, &inc, offdiag_fac0, &inc) // offdiag_fac <-- offdiag
                     TRLIB_DPTTRF(&n0, diag_fac0, offdiag_fac0, &info_fac) // compute factorization
                     if(info_fac == 0) {
-                        pert_up = lam_pert; // as this ensures a factorization, it provides a upper bound
+                        pert_up = lam_pert; // as this ensures a factorization, it provides an upper bound
                         TRLIB_DCOPY(&n0, neglin, &inc, sol0, &inc) // sol0 <-- neglin
                         TRLIB_DPTTRS(&n0, &inc, diag_fac0, offdiag_fac0, sol0, &n0, &info_fac) // sol0 <-- T0^-1 sol0
                         if (info_fac != 0) { TRLIB_PRINTLN_2("Failure on computing h\u2080 in safeguarded initialization iteration") TRLIB_RETURN(TRLIB_TTR_FAIL_LINSOLVE) }
@@ -181,7 +181,7 @@ trlib_int_t trlib_tri_factor_min(
                     }
                     else {
                         TRLIB_PRINTLN_2(" %2ld%14e%14e%14e%3s", jj, pert_low, lam_pert, pert_up, " -")
-                        pert_low = lam_pert; // as factorization fails, it provides a upper bound
+                        pert_low = lam_pert; // as factorization fails, it provides an upper bound
                         // now increase perturbation, either by bisection if there is a useful upper bound,
                         // otherwise by a small increment
                         if( pert_up == 1.0/TRLIB_EPS ) {

--- a/scipy/signal/_arraytools.py
+++ b/scipy/signal/_arraytools.py
@@ -1,5 +1,5 @@
 """
-Functions for acting on a axis of an array.
+Functions for acting on an axis of an array.
 """
 import numpy as np
 

--- a/scipy/special/cdflib.c
+++ b/scipy/special/cdflib.c
@@ -1932,7 +1932,7 @@ struct TupleDD cumbet(double x, double y, double a, double b)
     //
     //                                       References
     //
-    //         Didonato, Armido R. and Morris, Alfred H. Jr. (1992) Algorithim
+    //         Didonato, Armido R. and Morris, Alfred H. Jr. (1992) Algorithm
     //         708 Significant Digit Computation of the Incomplete Beta Function
     //         Ratios. ACM ToMS, Vol.18, No. 3, Sept. 1992, 360-373.
 

--- a/scipy/stats/_continuous_distns.py
+++ b/scipy/stats/_continuous_distns.py
@@ -3530,7 +3530,7 @@ genextreme = genextreme_gen(name='genextreme')
 
 ## Gamma (Use MATLAB and MATHEMATICA (b=theta=scale, a=alpha=shape) definition)
 
-## gamma(a, loc, scale)  with a an integer is the Erlang distribution
+## gamma(a, loc, scale)  with integer a is the Erlang distribution
 ## gamma(1, loc, scale)  is the Exponential distribution
 ## gamma(df/2, 0, 2) is the chi2 distribution with df degrees of freedom.
 


### PR DESCRIPTION
Fix grammar issues: 'a axis'->'an axis' (_arraytools.py), 'an sequence'->'a sequence' (_special_matrices.py), 'an user'->'a user' (_quad_vec.py), 'a acceptance'->'an acceptance' (_dual_annealing.py), 'with a an integer'->'with integer a' (_continuous_distns.py), 'a error'->'an error' (DIRect.c), 'a upper bound'->'an upper bound' (trlib_tri_factor.c), 'an size'->'and size' (ni_morphology.c), 'a aN vertex'->'an aN vertex' (_complex.py x2), 'Algorithim'->'Algorithm' (cdflib.c), 'inputed'->'input' (_lebedev.py x3).

**Files changed:**
- `scipy/signal/_arraytools.py`
- `scipy/linalg/_special_matrices.py`
- `scipy/integrate/_quad_vec.py`
- `scipy/optimize/_dual_annealing.py`
- `scipy/stats/_continuous_distns.py`
- `scipy/optimize/_direct/DIRect.c`
- `scipy/optimize/_trlib/trlib_tri_factor.c`
- `scipy/ndimage/src/ni_morphology.c`
- `scipy/optimize/_shgo_lib/_complex.py`
- `scipy/special/cdflib.c`
- `scipy/integrate/_lebedev.py`