### PR TITLE
BUG: fix DCSRCH.__call__ returning None on WARN condition

### DIFF
--- a/scipy/optimize/_dcsrch.py
+++ b/scipy/optimize/_dcsrch.py
@@ -261,8 +261,11 @@ class DCSRCH:
             stp = None
             task = b"WARNING: dcsrch did not converge within max iterations"
 
-        if task[:5] == b"ERROR" or task[:4] == b"WARN":
+        if task[:5] == b"ERROR":
             stp = None  # failed
+        # NOTE: WARN does NOT set stp=None — per MINPACK2 spec, on WARN stp
+        # holds the best point found during the search. Callers check task to
+        # decide whether to accept the step or fall back.
 
         return stp, phi1, phi0, task
 


### PR DESCRIPTION
Fix DCSRCH.__call__ setting stp=None on WARN, discarding the valid best step found during search. Per MINPACK2 spec, on WARN the subroutine returns the best point found. Callers check task status to decide acceptance.

**Files changed:**
- `scipy/optimize/_dcsrch.py`