### PR TITLE
DOC: fix several typos across scipy (batch 2)

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -945,7 +945,7 @@ def bench(ctx, tests, submodule, compare, verbose, quick,
         cmd = ['asv', 'run', '--show-stderr', '--python=same'] + bench_args
         _run_asv(cmd)
     else:
-        # Ensure that we don't have uncommited changes
+        # Ensure that we don't have uncommitted changes
         commit_a, commit_b = [_commit_to_sha(c) for c in commits]
 
         if commit_b == 'HEAD' and _dirty_git_working_dir():

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -418,7 +418,7 @@ def _backends_kwargs_from_request(request, skip_or_xfail):
             reason = marker.kwargs.get("reason") or (
                 f"do not run with array API backend: {backend}")
             # reason overrides the ones from cpu_only, np_only, and eager_only.
-            # This is regardless of order of appearence of the markers.
+            # This is regardless of order of appearance of the markers.
             reasons[backend].insert(0, reason)
 
             for kwarg in ("cpu_only", "np_only", "eager_only", "exceptions"):

--- a/scipy/interpolate/_polyint.py
+++ b/scipy/interpolate/_polyint.py
@@ -663,7 +663,7 @@ class BarycentricInterpolator(_Interpolator1DWithDerivatives):
                   (-1)^i   & \text{otherwise}
               \end{cases}.
 
-    See [2]_ for more infomation. Note that for large :math:`n`, computing the weights
+    See [2]_ for more information. Note that for large :math:`n`, computing the weights
     explicitly (see examples) will be faster than the generic formula.
 
     References

--- a/scipy/optimize/src/minpack.c
+++ b/scipy/optimize/src/minpack.c
@@ -1510,7 +1510,7 @@ void LMDIF(int(*fcn)(int* m, int* n, double* x, double* fvec, int* iflag),
             }
             // 260
 
-            // Test for succesful iteration.
+            // Test for successful iteration.
             if (ratio >= 0.0001)
             {
                 // Successful iteration. Update x, fvec, and their norms.
@@ -1974,7 +1974,7 @@ void LMDER(int(*fcn)(int* m, int* n,double* x, double* fvec, double* fjac,
             }
             // 260
 
-            // Test for succesful iteration.
+            // Test for successful iteration.
             if (ratio >= 0.0001)
             {
                 for (j = 0; j < n; j++)
@@ -2454,7 +2454,7 @@ void LMSTR(int(*fcn)(int* m, int* n, double* x, double* fvec, double* wa3, int* 
             }
             // 300
 
-            // Test for succesful iteration.
+            // Test for successful iteration.
             if (ratio >= 0.0001)
             {
                 for (j = 0; j < n; j++)

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -372,7 +372,7 @@ class _Interval(_Domain):
             z[~i] = max
 
         elif type_ == 'out':
-            z = min_nn - uniform(1, 5, size=shape)   # 1, 5 is arbitary; we just want
+            z = min_nn - uniform(1, 5, size=shape)   # 1, 5 is arbitrary; we just want
             zr = max_nn + uniform(1, 5, size=shape)  # some numbers outside domain
             i = rng.random(size=n) < 0.5
             z[i] = zr[i]
@@ -819,7 +819,7 @@ class _Parameterization:
         ----------
         sizes : iterable of shape tuples
             The size of the array to be generated for each parameter in the
-            parameterization. Note that the order of sizes is arbitary; the
+            parameterization. Note that the order of sizes is arbitrary; the
             size of the array generated for a specific parameter is not
             controlled individually as written.
         rng : NumPy Generator


### PR DESCRIPTION
Fix typos: succesful->successful (minpack.c, 3x), arbitary->arbitrary (_distribution_infrastructure.py, 2x), appearence->appearance (conftest.py), uncommited->uncommitted (.spin/cmds.py), infomation->information (_polyint.py)

**Files changed:**
- `.spin/cmds.py`
- `scipy/conftest.py`
- `scipy/interpolate/_polyint.py`
- `scipy/optimize/src/minpack.c`
- `scipy/stats/_distribution_infrastructure.py`