### PR TITLE
DOC: fix grammar issues across scipy (batch 3)

### DIFF
--- a/scipy/cluster/vq/_vq_impl.py
+++ b/scipy/cluster/vq/_vq_impl.py
@@ -227,7 +227,7 @@ def _kmeans(obs, guess, thresh=1e-5, xp=None):
     code_book
         The lowest distortion codebook found.
     avg_dist
-        The average distance a observation is from a code in the book.
+        The average distance an observation is from a code in the book.
         Lower means the code_book matches the data better.
 
     See Also

--- a/scipy/integrate/_quadpack_py.py
+++ b/scipy/integrate/_quadpack_py.py
@@ -766,7 +766,7 @@ def dblquad(func, a, b, gfun, hfun, args=(), epsabs=1.49e-8, epsrel=1.49e-8):
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation, which will
         eliminate the effects of integrand singularities of
-        several types. The integration is is performed using a 21-point Gauss-Kronrod 
+        several types. The integration is performed using a 21-point Gauss-Kronrod
         quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is
@@ -900,7 +900,7 @@ def tplquad(func, a, b, gfun, hfun, qfun, rfun, args=(), epsabs=1.49e-8,
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation, which will
         eliminate the effects of integrand singularities of
-        several types. The integration is is performed using a 21-point Gauss-Kronrod 
+        several types. The integration is performed using a 21-point Gauss-Kronrod
         quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is
@@ -1091,7 +1091,7 @@ def nquad(func, ranges, args=None, opts=None, full_output=False):
         is an integrator based on globally adaptive interval
         subdivision in connection with extrapolation, which will
         eliminate the effects of integrand singularities of
-        several types. The integration is is performed using a 21-point Gauss-Kronrod
+        several types. The integration is performed using a 21-point Gauss-Kronrod
         quadrature within each subinterval.
     qagie
         handles integration over infinite intervals. The infinite range is

--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1100,7 +1100,7 @@ fail:
   * There are three wrappers for surfit below, for different callsites in SciPy as legacy code.
   * Two are from the Fortran interface (_surfit_lsq and _surfit_smth in fitpack2.py) that is
   * used in LSQBivariateSpline and SmoothBivariateSpline.
-  * The remaining is a a C wrapper for use in the legacy function "scipy.interpolate.bisplrep".
+  * The remaining is a C wrapper for use in the legacy function "scipy.interpolate.bisplrep".
   * None of them call surfit as is but assume different parameters as optional or fixed values.
   * Worse is that bisplrep is stateful and keeps previous results in a global dict. Thus there
   * is some care needed to handle all that back and forth correctly.

--- a/scipy/optimize/_direct/DIRect.c
+++ b/scipy/optimize/_direct/DIRect.c
@@ -187,7 +187,7 @@
 /* |            as described by Jones et.al. (0) or use our modification(1)| */
 /* | logfile -- File-Handle for the logfile. DIRECT expects this file to be| */
 /* |            opened and closed by the user outside of DIRECT. We moved  | */
-/* |            this to the outside so the user can add extra informations | */
+/* |            this to the outside so the user can add extra information | */
 /* |            to this file before and after the call to DIRECT.          | */
 /* | fglobal -- Function value of the global optimum. If this value is not | */
 /* |            known (that is, we solve a real problem, not a testproblem)| */

--- a/scipy/optimize/_trlib/trlib/trlib_krylov.h
+++ b/scipy/optimize/_trlib/trlib/trlib_krylov.h
@@ -162,7 +162,7 @@
  *  :math:`s` once :math:`q_j` has been computed as :math:`s \leftarrow h_j q_j`
  *  with initialization :math:`s \leftarrow 0`.
  *
- *  Furthermore the user has to provide a integer and floating point workspace, details
+ *  Furthermore the user has to provide an integer and floating point workspace, details
  *  are described in :c:data:`iwork` and :c:data:`fwork`.
  *
  *  **Resolves**

--- a/scipy/optimize/_trlib/trlib/trlib_leftmost.h
+++ b/scipy/optimize/_trlib/trlib/trlib_leftmost.h
@@ -31,7 +31,7 @@
 
 /** Computes smallest eigenvalue of symmetric tridiagonal matrix
  *  :math:`T \in \mathbb R^{n\times n}`,
- *  using a iteration based on last-pivot function of Parlett and Reid.
+ *  using an iteration based on last-pivot function of Parlett and Reid.
  *
  *  Let :math:`T = \begin{pmatrix} T_1 & & \\ & \ddots & \\ & & T_\ell \end{pmatrix}`
  *  be composed into irreducible blocks :math:`T_i`.
@@ -102,7 +102,7 @@ trlib_int_t trlib_leftmost(
 
 /** Computes smallest eigenvalue of irreducible symmetric tridiagonal matrix
  *  :math:`T \in \mathbb R^{n\times n}`,
- *  using a iteration based on last-pivot function of Parlett and Reid.
+ *  using an iteration based on last-pivot function of Parlett and Reid.
  *  
  *  Method is sketched on p. 516 in [Gould1999]_.
  *

--- a/scipy/optimize/_trlib/trlib_tri_factor.c
+++ b/scipy/optimize/_trlib/trlib_tri_factor.c
@@ -165,7 +165,7 @@ trlib_int_t trlib_tri_factor_min(
                     TRLIB_DCOPY(&nm0, offdiag, &inc, offdiag_fac0, &inc) // offdiag_fac <-- offdiag
                     TRLIB_DPTTRF(&n0, diag_fac0, offdiag_fac0, &info_fac) // compute factorization
                     if(info_fac == 0) {
-                        pert_up = lam_pert; // as this ensures a factorization, it provides a upper bound
+                        pert_up = lam_pert; // as this ensures a factorization, it provides an upper bound
                         TRLIB_DCOPY(&n0, neglin, &inc, sol0, &inc) // sol0 <-- neglin
                         TRLIB_DPTTRS(&n0, &inc, diag_fac0, offdiag_fac0, sol0, &n0, &info_fac) // sol0 <-- T0^-1 sol0
                         if (info_fac != 0) { TRLIB_PRINTLN_2("Failure on computing h\u2080 in safeguarded initialization iteration") TRLIB_RETURN(TRLIB_TTR_FAIL_LINSOLVE) }

--- a/scipy/optimize/src/lbfgsb.c
+++ b/scipy/optimize/src/lbfgsb.c
@@ -2888,7 +2888,7 @@ void subsm(CBLAS_INT n, CBLAS_INT m, CBLAS_INT nsub, CBLAS_INT* ind,
     //       On entry u is the upper bound of x.
     //       On exit u is unchanged.
     //
-    //     nbd is a integer array of dimension n.
+    //     nbd is an integer array of dimension n.
     //       On entry nbd represents the type of bounds imposed on the
     //         variables, and must be specified as follows:
     //         nbd(i)=0 if x(i) is unbounded,

--- a/scipy/sparse/_dok.py
+++ b/scipy/sparse/_dok.py
@@ -209,7 +209,7 @@ class _dok_base(_spbase, IndexMixin, dict):
         Returns
         -------
         dict_items
-            A view object displaying a list of a array's key-value tuple pairs.
+            A view object displaying a list of an array's key-value tuple pairs.
         """
         return self._dict.items()
 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/util.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/util.c
@@ -462,7 +462,7 @@ LUSolveFlops(SuperLUStat_t *stat)
 
 /*! \brief Fills an integer array with a given value.
  *
- * \param[in,out] a Integer array that is filled.
+ * \param[in,out] a An integer array that is filled.
  * \param[in]     alen Length of integer array \a a.
  * \param[in]     ival Value to be filled in every element of \a a.
  */

--- a/scipy/stats/_morestats.py
+++ b/scipy/stats/_morestats.py
@@ -4148,7 +4148,7 @@ def wilcoxon(x, y=None, zero_method="wilcox", correction=False,
     WilcoxonResult(statistic=6.0, pvalue=0.5)
 
     """
-    # replace approx by asymptotic to ensure backwards compatability
+    # replace approx by asymptotic to ensure backwards compatibility
     if method == "approx":
         method = "asymptotic"
     return _wilcoxon._wilcoxon_nd(x, y, zero_method, correction, alternative,


### PR DESCRIPTION
Fix grammar issues: 'extra informations'->'extra information' (DIRect.c), 'backwards compatability'->'backwards compatibility' (_morestats.py), 'is is'->'is' (_quadpack_py.py), 'a observation'->'an observation' (_vq_impl.py), 'a array\'s'->'an array\'s' (_dok.py), 'a a C wrapper'->'a C wrapper' (_fitpackmodule.c), 'a upper bound'->'an upper bound' (trlib_tri_factor.c, 2x), 'a iteration'->'an iteration' (trlib_leftmost.h, 2x), 'a integer'->'an integer' (lbfgsb.c, trlib_krylov.h, SuperLU/util.c)

**Files changed:**
- `scipy/cluster/vq/_vq_impl.py`
- `scipy/integrate/_quadpack_py.py`
- `scipy/interpolate/src/_fitpackmodule.c`
- `scipy/optimize/_direct/DIRect.c`
- `scipy/optimize/_trlib/trlib/trlib_krylov.h`
- `scipy/optimize/_trlib/trlib/trlib_leftmost.h`
- `scipy/optimize/_trlib/trlib_tri_factor.c`
- `scipy/optimize/src/lbfgsb.c`
- `scipy/sparse/_dok.py`
- `scipy/sparse/linalg/_dsolve/SuperLU/SRC/util.c`
- `scipy/stats/_morestats.py`