### PR TITLE
DOC: Fix mismatched docstring parameter names across scipy

### DIFF
--- a/scipy/cluster/hierarchy/_hierarchy_impl.py
+++ b/scipy/cluster/hierarchy/_hierarchy_impl.py
@@ -2269,7 +2269,7 @@ def _lazy_valid_checks(*args, throw=False, warning=False, materialize=False, xp)
 
     Parameters
     ----------
-    args : tuples of (Array, str)
+    *args : tuples of (Array, str)
         The first element of each tuple must be a 0-dimensional Array
         that evaluates to bool; the second element must be the message to convey
         if the  first element evaluates to True.

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -460,7 +460,7 @@ def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):
         Used to solve the sparse linear system
         ``design_matrix @ coefficients = rhs`` for the coefficients.
         Default is `scipy.sparse.linalg.gcrotmk`
-    solver_args : dict, optional
+    **solver_args : dict, optional
         Additional arguments for the solver. The call signature is
         ``solver(csr_array, rhs_vector, **solver_args)``
 

--- a/scipy/linalg/_basic.py
+++ b/scipy/linalg/_basic.py
@@ -1893,7 +1893,7 @@ def _validate_args_for_toeplitz_ops(c_or_cr, b, check_finite, keep_b_shape,
     dtype: numpy datatype
         ``dtype`` stores the datatype of ``r``, ``c`` and ``b``. If any of
         ``r``, ``c`` or ``b`` are complex, ``dtype`` is ``np.complex128``,
-        otherwise, it is ``np.float``.
+        otherwise, it is ``np.float64``.
     b_shape: tuple
         Shape of ``b`` after passing it through ``_asarray_validated``.
 

--- a/scipy/linalg/tests/test_cythonized_array_utils.py
+++ b/scipy/linalg/tests/test_cythonized_array_utils.py
@@ -6,7 +6,7 @@ from pytest import raises
 from numpy.testing import assert_equal
 
 BANDWIDTH_DTYPES = (
-    np.bool,
+    bool,
     np.int8, np.int16, np.int32, np.int64,
     np.uint8, np.uint16, np.uint32, np.uint64,
     np.float32, np.float64,

--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -111,7 +111,7 @@ def _check_sparse_inputs(options, meth, A_ub, A_eq):
                 Set to True to print convergence messages.
 
         For method-specific options, see :func:`show_options('linprog')`.
-    method : str, optional
+    meth : str, optional
         The algorithm used to solve the standard form problem.
 
     Returns

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -235,7 +235,7 @@ def _prepare_scalar_function(fun, x0, jac=None, args=(), bounds=None,
         derivatives (`fun`, `jac` functions).
     bounds : sequence, optional
         Bounds on variables. 'new-style' bounds are required.
-    eps : float or ndarray
+    epsilon : float or ndarray
         If ``jac is None`` the absolute step size used for numerical
         approximation of the jacobian via forward differences.
     finite_diff_rel_step : None or array_like, optional
@@ -3420,10 +3420,10 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
 
     Parameters
     ----------
-    fun : callable
+    func : callable
         The objective function to be minimized::
 
-            fun(x, *args) -> float
+            func(x, *args) -> float
 
         where ``x`` is a 1-D array with shape (n,) and ``args``
         is a tuple of the fixed parameters needed to completely
@@ -3433,7 +3433,7 @@ def _minimize_powell(func, x0, args=(), callback=None, bounds=None,
         where ``n`` is the number of independent variables.
     args : tuple, optional
         Extra arguments passed to the objective function and its
-        derivatives (`fun`, `jac` and `hess` functions).
+        derivatives (`func`, `jac` and `hess` functions).
     method : str or callable, optional
         The present documentation is specific to ``method='powell'``, but other
         options are available. See documentation for `scipy.optimize.minimize`.

--- a/scipy/optimize/_slsqp_py.py
+++ b/scipy/optimize/_slsqp_py.py
@@ -46,7 +46,7 @@ def approx_jacobian(x, func, epsilon, *args):
         The vector-valued function.
     epsilon : float
         The perturbation used to determine the partial derivatives.
-    args : sequence
+    *args : sequence
         Additional arguments passed to func.
 
     Returns

--- a/scipy/signal/_whittaker.py
+++ b/scipy/signal/_whittaker.py
@@ -394,8 +394,9 @@ def _reml(lamb, y, order, weights=None):
     Parameters
     ----------
     lamb : penalty
+        Regularization parameter controlling the smoothness of the result.
     y : signal
-    x : smoothed signal
+        The signal to be smoothed.
     order : order of the difference penalty.
     weights : case weights
 

--- a/scipy/spatial/transform/_rotation.py
+++ b/scipy/spatial/transform/_rotation.py
@@ -1954,7 +1954,7 @@ class Rotation:
 
     def approx_equal(
         self, other: Rotation, atol: float | None = None, degrees: bool = False
-    ) -> Array | np.bool:
+    ) -> Array | bool:
         """Determine if another rotation is approximately equal to this one.
 
         Equality is measured by calculating the smallest angle between the

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -342,7 +342,7 @@ class _Interval(_Domain):
             - NaN ('nan').
         min, max : ndarray
             The endpoints of the domain.
-        squeezed_based_shape : tuple of ints
+        squeezed_base_shape : tuple of ints
             See _RealParameter.draw.
         rng : np.Generator
             The Generator used for drawing random values.
@@ -372,7 +372,7 @@ class _Interval(_Domain):
             z[~i] = max
 
         elif type_ == 'out':
-            z = min_nn - uniform(1, 5, size=shape)   # 1, 5 is arbitary; we just want
+            z = min_nn - uniform(1, 5, size=shape)   # 1, 5 is arbitrary; we just want
             zr = max_nn + uniform(1, 5, size=shape)  # some numbers outside domain
             i = rng.random(size=n) < 0.5
             z[i] = zr[i]
@@ -819,7 +819,7 @@ class _Parameterization:
         ----------
         sizes : iterable of shape tuples
             The size of the array to be generated for each parameter in the
-            parameterization. Note that the order of sizes is arbitary; the
+            parameterization. Note that the order of sizes is arbitrary; the
             size of the array generated for a specific parameter is not
             controlled individually as written.
         rng : NumPy Generator


### PR DESCRIPTION
Fix docstring parameter name mismatches: args->*args, solver_args->**solver_args, np.float->np.float64, np.bool->bool, method->meth, eps->epsilon/fun->func (Powell), lamb/y descriptions in _whittaker.py, squeezed_based_shape->squeezed_base_shape.

**Files changed:**
- `scipy/cluster/hierarchy/_hierarchy_impl.py`
- `scipy/interpolate/_ndbspline.py`
- `scipy/linalg/_basic.py`
- `scipy/linalg/tests/test_cythonized_array_utils.py`
- `scipy/optimize/_linprog_util.py`
- `scipy/optimize/_optimize.py`
- `scipy/optimize/_slsqp_py.py`
- `scipy/signal/_whittaker.py`
- `scipy/spatial/transform/_rotation.py`
- `scipy/stats/_distribution_infrastructure.py`