### PR TITLE
BUG: fix NumPy 2.x compat and TypeError in sparse/_sputils and special/utils/datafunc

### DIFF
--- a/scipy/sparse/_sputils.py
+++ b/scipy/sparse/_sputils.py
@@ -14,7 +14,7 @@ __all__ = ['upcast', 'getdtype', 'getdata', 'isscalarlike', 'isintlike',
            'broadcast_shapes']
 
 supported_dtypes = [np.bool_, np.byte, np.ubyte, np.short, np.ushort, np.intc,
-                    np.uintc, np.long, np.ulong, np.longlong, np.ulonglong,
+                    np.uintc, np.int_, np.uint, np.longlong, np.ulonglong,
                     np.float32, np.float64, np.longdouble,
                     np.complex64, np.complex128, np.clongdouble]
 

--- a/scipy/special/utils/datafunc.py
+++ b/scipy/special/utils/datafunc.py
@@ -41,7 +41,7 @@ def run_test(filename, funcs, args=[0]):  # noqa: B006
 
     if nargs > 1:
         f = funcs[0]
-        x = [data[args[i]] for i in nargs]
+        x = [data[args[i]] for i in range(nargs)]
         return f(*x)
     else:
         y = [f(data[:, 0]) - data[:, idx + 1] for idx, f in enumerate(funcs)]


### PR DESCRIPTION
Fix np.long->np.int_, np.ulong->np.uint in supported_dtypes (NumPy 2.2 compat). Fix 'for i in nargs' TypeError where nargs is int not iterable by replacing with 'for i in range(nargs)'.

**Files changed:**
- `scipy/sparse/_sputils.py`
- `scipy/special/utils/datafunc.py`