### PR TITLE
MAINT: replace np.long/ulong with np.int_/uint in test files

### DIFF
--- a/scipy/spatial/tests/test_distance.py
+++ b/scipy/spatial/tests/test_distance.py
@@ -129,8 +129,8 @@ def load_testing_files():
     eo['pdist-boolean-inp'] = np.bool_(eo['pdist-boolean-inp'])
     eo['random-bool-data'] = np.bool_(eo['random-bool-data'])
     eo['random-float32-data'] = np.float32(eo['random-double-data'])
-    eo['random-int-data'] = np.long(eo['random-int-data'])
-    eo['random-uint-data'] = np.ulong(eo['random-uint-data'])
+    eo['random-int-data'] = np.int_(eo['random-int-data'])
+    eo['random-uint-data'] = np.uint(eo['random-uint-data'])
 
 
 load_testing_files()
@@ -405,8 +405,8 @@ class TestCdist:
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
                              'random-uint-data', 'random-double-data',
                              'random-bool-data']
-        self.valid_upcasts = {'bool': [np.ulong, np.long, np.float32, np.float64],
-                              'uint': [np.long, np.float32, np.float64],
+        self.valid_upcasts = {'bool': [np.uint, np.int_, np.float32, np.float64],
+                              'uint': [np.int_, np.float32, np.float64],
                               'int': [np.float32, np.float64],
                               'float32': [np.float64]}
 
@@ -697,8 +697,8 @@ class TestPdist:
         self.rnd_eo_names = ['random-float32-data', 'random-int-data',
                              'random-uint-data', 'random-double-data',
                              'random-bool-data']
-        self.valid_upcasts = {'bool': [np.ulong, np.long, np.float32, np.float64],
-                              'uint': [np.long, np.float32, np.float64],
+        self.valid_upcasts = {'bool': [np.uint, np.int_, np.float32, np.float64],
+                              'uint': [np.int_, np.float32, np.float64],
                               'int': [np.float32, np.float64],
                               'float32': [np.float64]}
 

--- a/scipy/stats/tests/common_tests.py
+++ b/scipy/stats/tests/common_tests.py
@@ -229,7 +229,7 @@ def check_random_state_property(distfn, args):
 def check_meth_dtype(distfn, arg, meths):
     q0 = [0.25, 0.5, 0.75]
     x0 = distfn.ppf(q0, *arg)
-    x_cast = [x0.astype(tp) for tp in (np.long, np.float16, np.float32,
+    x_cast = [x0.astype(tp) for tp in (np.int_, np.float16, np.float32,
                                        np.float64)]
 
     for x in x_cast:
@@ -258,7 +258,7 @@ def check_cmplx_deriv(distfn, arg):
         return (f(x + h*1j, *arg)/h).imag
 
     x0 = distfn.ppf([0.25, 0.51, 0.75], *arg)
-    x_cast = [x0.astype(tp) for tp in (np.long, np.float16, np.float32,
+    x_cast = [x0.astype(tp) for tp in (np.int_, np.float16, np.float32,
                                        np.float64)]
 
     for x in x_cast:


### PR DESCRIPTION
Fix np.long/ulong removed in NumPy 2.2 in test files: common_tests.py (2x np.long->np.int_), test_distance.py (np.long->np.int_, np.ulong->np.uint, 4 occurrences).

**Files changed:**
- `scipy/stats/tests/common_tests.py`
- `scipy/spatial/tests/test_distance.py`