### PR TITLE
DOC: fix grammar errors in scipy comments and docstrings batch 6

### DIFF
--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -196,7 +196,7 @@ def splrep(x, y, w=None, xb=None, xe=None, k=3, task=0, s=None, t=None,
 
         If ``task==1`` find ``t`` and ``c`` for another value of the smoothing factor,
         `s`. There must have been a previous call with ``task=0`` or ``task=1`` for
-        the same set of data (``t`` will be stored an used internally)
+        the same set of data (``t`` will be stored and used internally)
 
         If ``task=-1`` find the weighted least square spline for a given set of
         knots, ``t``. These should be interior knots as knots on the ends will be

--- a/scipy/interpolate/src/dfitpack.c
+++ b/scipy/interpolate/src/dfitpack.c
@@ -2772,7 +2772,7 @@ fpgrsp(int ifsu, int ifsv, int ifbu, int ifbv, int iback, const double *u, const
         mvv = mv + nv8;
     }
     // we first determine the matrices (auu) and (qq). then we reduce the
-    // matrix (auu) to an unit upper triangular form (ru) using givens
+    // matrix (auu) to a unit upper triangular form (ru) using givens
     // rotations without square roots. we apply the same transformations to
     // the rows of matrix qq to obtain the mv x nuu matrix g.
     // we store matrix (ru) into au and g into q.
@@ -2981,7 +2981,7 @@ fpgrsp(int ifsu, int ifsv, int ifbu, int ifbv, int iback, const double *u, const
         }
         return;
     }
-    // we determine the matrix (avv) and then we reduce her to an unit
+    // we determine the matrix (avv) and then we reduce her to a unit
     // upper triangular form (rv) using givens rotations without square
     // roots. we apply the same transformations to the columns of matrix
     // g to obtain the (nv-7) x (nu-6-iop0-iop1) matrix h.
@@ -3631,7 +3631,7 @@ fpopsp(const int ifsu, const int ifsv, const int ifbu, const int ifbv, const dou
         number = number + 2;
     }
     if (number == 0) { return; }
-    // the sum of squared residulas sq is a quadratic polynomial in the
+    // the sum of squared residuals sq is a quadratic polynomial in the
     // parameters g(j). we determine the unknown coefficients of this
     // polymomial by calculating (number+1)*(number+2)/2 different splines
     // according to specific values for g(j).

--- a/scipy/optimize/_linprog_rs.py
+++ b/scipy/optimize/_linprog_rs.py
@@ -144,7 +144,7 @@ def _generate_auxiliary_problem(A, b, x0, tol):
     with each of these new columns, and generating a cost vector that is all
     zeros except for ones corresponding with each of the new variables.
 
-    A initial basic feasible solution is trivial: all variables are zero
+    An initial basic feasible solution is trivial: all variables are zero
     except for the artificial variables, which are set equal to the
     corresponding element of the right hand side `b`.
 

--- a/scipy/sparse/linalg/_dsolve/SuperLU/SRC/colamd.c
+++ b/scipy/sparse/linalg/_dsolve/SuperLU/SRC/colamd.c
@@ -1970,7 +1970,7 @@ PRIVATE void init_scoring
 	deg = Col [c].length ;
 	if (deg == 0)
 	{
-	    /* this is a empty column, kill and order it last */
+	    /* this is an empty column, kill and order it last */
 	    Col [c].shared2.order = --n_col2 ;
 	    KILL_PRINCIPAL_COL (c) ;
 	}


### PR DESCRIPTION
Fix grammar: 'A initial'->'An initial' in _linprog_rs.py, 'stored an used'->'stored and used' in _fitpack_py.py, 'an unit'->'a unit' (2x) in dfitpack.c, 'a empty'->'an empty' in colamd.c.

**Files changed:**
- `scipy/optimize/_linprog_rs.py`
- `scipy/interpolate/_fitpack_py.py`
- `scipy/interpolate/src/dfitpack.c`
- `scipy/sparse/linalg/_dsolve/SuperLU/SRC/colamd.c`