### PR TITLE
MAINT: fix remaining np.long/np.ulong usages in test files (NumPy 2.2 compat)

### DIFF
--- a/scipy/sparse/csgraph/tests/test_graph_laplacian.py
+++ b/scipy/sparse/csgraph/tests/test_graph_laplacian.py
@@ -9,7 +9,7 @@ from scipy.sparse import csgraph
 
 def check_int_type(mat):
     return np.issubdtype(mat.dtype, np.signedinteger) or np.issubdtype(
-        mat.dtype, np.ulong
+        mat.dtype, np.uint
     )
 
 
@@ -160,7 +160,7 @@ def _check_laplacian_dtype(
                 _assert_allclose_sparse(L, mat)
 
 
-INT_DTYPES = (np.intc, np.long, np.longlong)
+INT_DTYPES = (np.intc, np.int_, np.longlong)
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 DTYPES = INT_DTYPES + REAL_DTYPES + COMPLEX_DTYPES

--- a/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
+++ b/scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py
@@ -22,7 +22,7 @@ from scipy.sparse.linalg._special_sparse_arrays import (Sakurai,
 
 _IS_32BIT = (sys.maxsize < 2**32)
 
-INT_DTYPES = (np.intc, np.long, np.longlong, np.uintc, np.ulong, np.ulonglong)
+INT_DTYPES = (np.intc, np.int_, np.longlong, np.uintc, np.uint, np.ulonglong)
 # np.half is unsupported on many test systems so excluded
 REAL_DTYPES = (np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)

--- a/scipy/sparse/linalg/tests/test_expm_multiply.py
+++ b/scipy/sparse/linalg/tests/test_expm_multiply.py
@@ -18,7 +18,7 @@ from scipy.sparse.linalg._expm_multiply import (_theta, _compute_p_max,
 
 
 IMPRECISE = {np.single, np.csingle}
-REAL_DTYPES = (np.intc, np.long, np.longlong,
+REAL_DTYPES = (np.intc, np.int_, np.longlong,
                np.float32, np.float64, np.longdouble)
 COMPLEX_DTYPES = (np.complex64, np.complex128, np.clongdouble)
 DTYPES = REAL_DTYPES + COMPLEX_DTYPES

--- a/scipy/special/tests/test_basic.py
+++ b/scipy/special/tests/test_basic.py
@@ -2919,7 +2919,7 @@ class TestFactorialFunctions:
         kw = {"k": k, "exact": exact, "extend": extend}
         if exact and k in _FACTORIALK_LIMITS_64BITS.keys():
             n = np.array([_FACTORIALK_LIMITS_32BITS[k]])
-            assert_equal(special.factorialk(n, **kw).dtype, np.long)
+            assert_equal(special.factorialk(n, **kw).dtype, np.int_)
             assert_equal(special.factorialk(n + 1, **kw).dtype, np.int64)
             # assert maximality of limits for given dtype
             assert special.factorialk(n + 1, **kw) > np.iinfo(np.int32).max


### PR DESCRIPTION
Fix remaining np.long->np.int_ and np.ulong->np.uint in test_graph_laplacian.py, test_expm_multiply.py, test_lobpcg.py, test_basic.py.

**Files changed:**
- `scipy/sparse/csgraph/tests/test_graph_laplacian.py`
- `scipy/sparse/linalg/tests/test_expm_multiply.py`
- `scipy/sparse/linalg/_eigen/lobpcg/tests/test_lobpcg.py`
- `scipy/special/tests/test_basic.py`