### PR TITLE
MAINT: narrow broad except Exception in spline and quadrature code

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -1035,7 +1035,7 @@ def newton_cotes(rn, equal=0):
             rn = np.arange(N+1)
         elif np.all(np.diff(rn) == 1):
             equal = 1
-    except Exception:
+    except TypeError:
         N = rn
         rn = np.arange(N+1)
         equal = 1

--- a/scipy/interpolate/_fitpack_impl.py
+++ b/scipy/interpolate/_fitpack_impl.py
@@ -307,7 +307,7 @@ def splev(x, tck, der=0, ext=0):
     try:
         c[0][0]
         parametric = True
-    except Exception:
+    except (TypeError, IndexError):
         parametric = False
     if parametric:
         return list(map(lambda c, x=x, t=t, k=k, der=der:
@@ -342,7 +342,7 @@ def splint(a, b, tck, full_output=0):
     try:
         c[0][0]
         parametric = True
-    except Exception:
+    except (TypeError, IndexError):
         parametric = False
     if parametric:
         return list(map(lambda c, a=a, b=b, t=t, k=k:
@@ -363,7 +363,7 @@ def sproot(tck, mest=10):
     try:
         c[0][0]
         parametric = True
-    except Exception:
+    except (TypeError, IndexError):
         parametric = False
     if parametric:
         return list(map(lambda c, t=t, k=k, mest=mest:
@@ -390,7 +390,7 @@ def spalde(x, tck):
     try:
         c[0][0]
         parametric = True
-    except Exception:
+    except (TypeError, IndexError):
         parametric = False
     if parametric:
         return list(map(lambda c, x=x, t=t, k=k:
@@ -736,7 +736,7 @@ def insert(x, tck, m=1, per=0):
     try:
         c[0][0]
         parametric = True
-    except Exception:
+    except (TypeError, IndexError):
         parametric = False
     if parametric:
         cc = []


### PR DESCRIPTION
scipy/interpolate/_fitpack_impl.py: Replace 5x except Exception with except (TypeError, IndexError) in splev/splint/sproot/spalde/insert for parametric spline detection. scipy/integrate/_quadrature.py: Replace 1x except Exception with except TypeError in _cotes_ratios for sequence-vs-integer detection.

**Files changed:**
- `scipy/interpolate/_fitpack_impl.py`
- `scipy/integrate/_quadrature.py`