### PR TITLE
TST: narrow pytest.raises(Exception) to specific exception types

### DIFF
--- a/scipy/integrate/tests/test_cubature.py
+++ b/scipy/integrate/tests/test_cubature.py
@@ -1229,7 +1229,7 @@ class TestRules:
         b = xp.asarray([1])
 
         for base_class in [Rule(), FixedRule()]:
-            with pytest.raises(Exception):
+            with pytest.raises(NotImplementedError):
                 base_class.estimate(basic_1d_integrand, a, b, args=(xp,))
 
 
@@ -1302,7 +1302,7 @@ class TestRulesQuadrature:
         GaussLegendreQuadrature
     ])
     def test_one_point_fixed_quad_impossible(self, quadrature, xp):
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             quadrature(1, xp=xp)
 
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -367,7 +367,7 @@ class TestTrapezoid(CommonTrapezoidSimpsonTests):
             trapezoid(y, x=xp.asarray([0, 10., 20.])[:, None], axis=0),
             out0
         )
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             # x is not broadcastable against y
             trapezoid(y, x=xp.asarray([0, 10., 20.])[None, :], axis=0)
 


### PR DESCRIPTION
test_cubature.py: NotImplementedError for Rule/FixedRule estimate() (2x), ValueError for GaussLegendreQuadrature(1). test_quadrature.py: ValueError for trapezoid broadcasting failure. All confirmed by checking the actual raised exception type in the source.

**Files changed:**
- `scipy/integrate/tests/test_cubature.py`
- `scipy/integrate/tests/test_quadrature.py`