### PR TITLE
TST: improve handling of incompatible `SCIPY_DEVICE` settings

### DIFF
--- a/scipy/_lib/_array_api_override.py
+++ b/scipy/_lib/_array_api_override.py
@@ -27,10 +27,6 @@ type ArrayLike = Array | npt.ArrayLike
 SCIPY_ARRAY_API: str | bool = os.environ.get("SCIPY_ARRAY_API", False)
 # To control the default device - for use in the test suite only
 SCIPY_DEVICE = os.environ.get("SCIPY_DEVICE", "cpu")
-if SCIPY_DEVICE not in ("cpu", "cuda"):
-    raise ValueError(
-        f'Unsupported {SCIPY_DEVICE=}; Supported values are "cpu" and "cuda".'
-    )
 
 
 class _ArrayClsInfo(enum.Enum):

--- a/scipy/_lib/_array_api_override.py
+++ b/scipy/_lib/_array_api_override.py
@@ -27,6 +27,10 @@ type ArrayLike = Array | npt.ArrayLike
 SCIPY_ARRAY_API: str | bool = os.environ.get("SCIPY_ARRAY_API", False)
 # To control the default device - for use in the test suite only
 SCIPY_DEVICE = os.environ.get("SCIPY_DEVICE", "cpu")
+if SCIPY_DEVICE not in ("cpu", "cuda"):
+    raise ValueError(
+        f'Unsupported {SCIPY_DEVICE=}; Supported values are "cpu" and "cuda".'
+    )
 
 
 class _ArrayClsInfo(enum.Enum):

--- a/scipy/conftest.py
+++ b/scipy/conftest.py
@@ -247,6 +247,8 @@ xp_skip_cpu_only_backends = set()
 xp_skip_eager_only_backends = set()
 
 if SCIPY_ARRAY_API:
+    device_and_backend_compatible = True
+
     # fill the dict of backends with available libraries
     try:
         import array_api_strict
@@ -263,22 +265,31 @@ if SCIPY_ARRAY_API:
 
     try:
         import torch  # pyrefly: ignore[missing-import]
-        xp_available_backends.append(
-            pytest.param(torch, id='torch',
-            marks=_array_api_backends))
-        torch.set_default_device(SCIPY_DEVICE)
-        if SCIPY_DEVICE != "cpu":
-            xp_skip_cpu_only_backends.add('torch')
 
-        # default to float64 unless explicitly requested
-        default = os.getenv('SCIPY_DEFAULT_DTYPE', default='float64')
-        if default == 'float64':
-            torch.set_default_dtype(torch.float64)
-        elif default != "float32":
-            raise ValueError(
-                "SCIPY_DEFAULT_DTYPE env var, if set, can only be either 'float64' "
-               f"or 'float32'. Got '{default}' instead."
-            )
+        torch.set_default_device(SCIPY_DEVICE)
+        try:
+            # set_default_device above succeeds even if SCIPY_DEVICE=cuda but in fact
+            # CUDA is not available. In that case, it fails at runtime, like so:
+            torch.empty(3)
+        except AssertionError:
+            # skip it if it's not usable.
+            device_and_backend_compatible = False
+        else:
+            xp_available_backends.append(
+                pytest.param(torch, id='torch',
+                marks=_array_api_backends))
+            if SCIPY_DEVICE != "cpu":
+                xp_skip_cpu_only_backends.add('torch')
+
+            # default to float64 unless explicitly requested
+            default = os.getenv('SCIPY_DEFAULT_DTYPE', default='float64')
+            if default == 'float64':
+                torch.set_default_dtype(torch.float64)
+            elif default != "float32":
+                raise ValueError(
+                    "SCIPY_DEFAULT_DTYPE env var, if set, can only be either 'float64' "
+                   f"or 'float32'. Got '{default}' instead."
+                )
     except ImportError:
         pass
 
@@ -303,23 +314,29 @@ if SCIPY_ARRAY_API:
     try:
         import jax.numpy  # pyrefly: ignore[missing-import]
 
-        xp_available_backends.append(
-            pytest.param(jax.numpy, id='jax.numpy',
-            marks=[_array_api_backends,
-                   # Uses xpx.testing.patch_lazy_xp_functions to monkey-patch module
-                   _thread_unsafe]))
+        try:
+            jax_device = jax.devices(SCIPY_DEVICE)[0]
+        except RuntimeError:
+            # requested device is not supported by the importable JAX, skip it
+            device_and_backend_compatible = False
+        else:
+            xp_available_backends.append(
+                pytest.param(jax.numpy, id='jax.numpy',
+                marks=[_array_api_backends,
+                       # Uses xpx.testing.patch_lazy_xp_functions to monkey-patch module
+                       _thread_unsafe]))
 
-        jax.config.update("jax_enable_x64", True)
-        # Make sure JAX won't default to less accurate TensorFloat32 precision
-        # in matmuls with float32 inputs on GPUs that support this floating
-        # point format.
-        jax.config.update("jax_default_matmul_precision", "float32")
-        jax.config.update("jax_default_device", jax.devices(SCIPY_DEVICE)[0])
-        if SCIPY_DEVICE != "cpu":
-            xp_skip_cpu_only_backends.add('jax.numpy')
-        # JAX can be eager or lazy (when wrapped in jax.jit). However it is
-        # recommended by upstream devs to assume it's always lazy.
-        xp_skip_eager_only_backends.add('jax.numpy')
+            jax.config.update("jax_enable_x64", True)
+            # Make sure JAX won't default to less accurate TensorFloat32 precision
+            # in matmuls with float32 inputs on GPUs that support this floating
+            # point format.
+            jax.config.update("jax_default_matmul_precision", "float32")
+            jax.config.update("jax_default_device", jax_device)
+            if SCIPY_DEVICE != "cpu":
+                xp_skip_cpu_only_backends.add('jax.numpy')
+            # JAX can be eager or lazy (when wrapped in jax.jit). However it is
+            # recommended by upstream devs to assume it's always lazy.
+            xp_skip_eager_only_backends.add('jax.numpy')
     except ImportError:
         pass
 
@@ -354,8 +371,12 @@ if SCIPY_ARRAY_API:
         SCIPY_ARRAY_API_ = set(json.loads(SCIPY_ARRAY_API))
         if SCIPY_ARRAY_API_ != {'all'}:
             if SCIPY_ARRAY_API_ - xp_available_backend_ids:
-                msg = ("'--array-api-backend' must be in "
-                       f"{xp_available_backend_ids}; got {SCIPY_ARRAY_API_}")
+                if device_and_backend_compatible:
+                    msg = ("'--array-api-backend' must be in "
+                           f"{xp_available_backend_ids}; got {SCIPY_ARRAY_API_}")
+                else:
+                    msg = (f"The requested backend, {SCIPY_ARRAY_API_}, is "
+                           f"incompatible with the requested {SCIPY_DEVICE=}")
                 raise ValueError(msg)
             # Only select a subset of backends
             xp_available_backends = [


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/21761, supersedes and closes https://github.com/scipy/scipy/pull/21762

#### What does this implement/fix?
<!--Please explain your changes.-->

Currently, setting `SCIPY_DEVICE=cuda spin test -b torch` fails if the installed torch is CPU only. In this PR, let's make it a tad nicer: if torch install is CPU-only, `-b all` silently skips `torch` and tests all other backends:

```
$ SCIPY_DEVICE=cuda spin test -b all
... carries on
```

EDIT: the behavior is exactly the same for CPU-only jax.

 If torch itself is requested however, it fails with a clear message

```
$ SCIPY_DEVICE=cuda spin test -b torch
...
E   ValueError: The requested backend, {'torch'}, is incompatible with the requested SCIPY_DEVICE='cuda'
```


#### Additional information
<!--Any additional information you think is important.-->

The main assumption here is that setting `SCIPY_DEVICE` variable is an advanced feature, is only needed for a small subset of advanced users, and that the user knows what they are doing.

- Presumably, user had a reason to install a CPU-only version of torch or jax, and that they actually want to test _other_ backends, given that they specifically set a non-default `SCIPY_DEVICE` env variable.
- Same reasoning for `-b all`: we cannot really both give meaning feedback and proceed with tests; thus in the current design the best we can do is to assume that setting `SCIPY_DEVICE` a user knows what they are doing.
- https://github.com/scipy/scipy/pull/21762 has some discussion about more elaborate strategies for setting device and backends. At this stage, I don't think our current design with a dedicated `SCIPY_DEVICE` variable is bad enough to justify a larger redesign and a reimplementation. Thus this small PR.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

no ai