### PR TITLE
ENH: interpolate: Add JAX support for `Akima1DInterpolator`

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.linalg import solve, solve_banded
 from scipy._lib._array_api import array_namespace, xp_size, xp_capabilities
 from scipy._external.array_api_compat import numpy as np_compat
+import scipy._external.array_api_extra as xpx
 
 from . import PPoly
 from ._polyint import _isscalar
@@ -405,9 +406,8 @@ def pchip_interpolate(xi, yi, x, der=0, axis=0):
         return [P.derivative(nu)(x) for nu in der]
 
 
-@xp_capabilities(cpu_only=True, xfail_backends=[
+@xp_capabilities(cpu_only=True, jax_jit=False, xfail_backends=[
     ("dask.array", "lacks nd fancy indexing"),
-    ("jax.numpy", "immutable arrays"),
     ("array_api_strict", "fancy indexing __setitem__"),
 ])
 class Akima1DInterpolator(CubicHermiteSpline):
@@ -553,19 +553,19 @@ class Akima1DInterpolator(CubicHermiteSpline):
             hk = xv[1:, ...] - xv[:-1, ...]
             mk = (y[1:, ...] - y[:-1, ...]) / hk
             t = xp.zeros_like(y)
-            t[...] = mk
+            t = xpx.at(t)[...].set(mk)
         else:
             # determine slopes between breakpoints
             m = xp.empty((x.shape[0] + 3, ) + y.shape[1:])
             dx = dx[(slice(None), ) + (None, ) * (y.ndim - 1)]
-            m[2:-2, ...] = xp.diff(y, axis=0) / dx
+            m = xpx.at(m)[2:-2, ...].set(xp.diff(y, axis=0) / dx)
 
             # add two additional points on the left ...
-            m[1, ...] = 2. * m[2, ...] - m[3, ...]
-            m[0, ...] = 2. * m[1, ...] - m[2, ...]
+            m = xpx.at(m)[1, ...].set(2. * m[2, ...] - m[3, ...])
+            m = xpx.at(m)[0, ...].set(2. * m[1, ...] - m[2, ...])
             # ... and on the right
-            m[-2, ...] = 2. * m[-3, ...] - m[-4, ...]
-            m[-1, ...] = 2. * m[-2, ...] - m[-3, ...]
+            m = xpx.at(m)[-2, ...].set(2. * m[-3, ...] - m[-4, ...])
+            m = xpx.at(m)[-1, ...].set(2. * m[-2, ...] - m[-3, ...])
 
             # if m1 == m2 != m3 == m4, the slope at the breakpoint is not
             # defined. This is the fill value:
@@ -596,9 +596,12 @@ class Akima1DInterpolator(CubicHermiteSpline):
 
             x_ind, y_ind = ind[0], ind[1:]
             # Set the slope at breakpoint
-            t[ind] = m[(x_ind + 1,) + y_ind] + (
-                (f2[ind] / f12[ind])
-                * (m[(x_ind + 2,) + y_ind] - m[(x_ind + 1,) + y_ind])
+            t = xpx.at(t)[ind].set(
+                m[(x_ind + 1,) + y_ind]
+                + (
+                    (f2[ind] / f12[ind])
+                    * (m[(x_ind + 2,) + y_ind] - m[(x_ind + 1,) + y_ind])
+                )
             )
 
         super().__init__(x, y, t, axis=0, extrapolate=extrapolate)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?

Add JAX support for `Akima1DInterpolator`. I had to add `jax_jit=False` matching what is currently implemented for [CubicHermiteSpline](https://github.com/scipy/scipy/blob/main/scipy/interpolate/_cubic.py#L81)

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI