### PR TITLE
ENH: speed up selected ndimage.zoom paths

### DIFF
--- a/benchmarks/benchmarks/ndimage_interpolation.py
+++ b/benchmarks/benchmarks/ndimage_interpolation.py
@@ -1,3 +1,5 @@
+import zlib
+
 import numpy as np
 
 from .common import Benchmark
@@ -66,3 +68,71 @@ class NdimageInterpolation(Benchmark):
 
     def peakmem_shift(self, shape, order, mode):
         shift(self.x, 3, order=order, mode=mode)
+
+
+_ZOOM_CASES = [
+    ('2d_cubic_up_sinusoid_f32',
+     (160, 192), (1.7, 1.25), 3, 'float32', 'sinusoid'),
+    ('2d_linear_aniso_random_f32',
+     (384, 320), (1.0, 0.37), 1, 'float32', 'random'),
+    ('3d_cubic_down_random_f32',
+     (64, 56, 24), (0.5, 0.5, 0.5), 3, 'float32', 'random'),
+    ('3d_linear_down_random_f32',
+     (80, 72, 28), (0.5, 0.5, 0.5), 1, 'float32', 'random'),
+    ('2d_linear_up_sinusoid_f64',
+     (192, 224), (1.25, 1.25), 1, 'float64', 'sinusoid'),
+    ('2d_linear_down_random_f32',
+     (192, 160), (0.5, 0.5), 1, 'float32', 'random'),
+    ('2d_cubic_down_random_f32',
+     (160, 192), (0.5, 0.5), 3, 'float32', 'random'),
+    ('2d_cubic_down_random_f64',
+     (256, 256), (0.37, 0.37), 3, 'float64', 'random'),
+]
+
+
+def _zoom_seed(name, shape, zoom_factor, order, dtype_name, pattern):
+    payload = f"{name}|{shape}|{zoom_factor}|{order}|{dtype_name}|{pattern}"
+    return zlib.crc32(payload.encode("utf-8")) & 0xFFFFFFFF
+
+
+def _make_zoom_input(name, shape, zoom_factor, order, dtype_name, pattern):
+    dtype = np.dtype(dtype_name)
+    rng = np.random.default_rng(
+        _zoom_seed(name, shape, zoom_factor, order, dtype_name, pattern)
+    )
+    if pattern == 'random':
+        return rng.random(shape, dtype=dtype)
+    if pattern == 'sinusoid':
+        grids = np.meshgrid(
+            *[np.arange(n, dtype=np.float64) for n in shape],
+            indexing='ij',
+        )
+        out = np.zeros(shape, dtype=np.float64)
+        for axis, grid in enumerate(grids):
+            out += np.sin(2.0 * np.pi * (0.07 + 0.05 * axis) * grid)
+        return (out / float(len(grids))).astype(dtype, copy=False)
+    raise NotImplementedError(pattern)
+
+
+class NdimageZoom(Benchmark):
+    param_names = ['case']
+    params = [_ZOOM_CASES]
+
+    def setup(self, case):
+        name, shape, zoom_factor, order, dtype_name, pattern = case
+        self.x = _make_zoom_input(
+            name, shape, zoom_factor, order, dtype_name, pattern
+        )
+        self.zoom_factor = zoom_factor
+        self.order = int(order)
+        self.prefilter = self.order > 1
+
+    def time_zoom_mirror_grid_false(self, case):
+        zoom(
+            self.x,
+            self.zoom_factor,
+            order=self.order,
+            mode='mirror',
+            prefilter=self.prefilter,
+            grid_mode=False,
+        )

--- a/scipy/ndimage/src/ni_interpolation.c
+++ b/scipy/ndimage/src/ni_interpolation.c
@@ -33,6 +33,7 @@
 #include "ni_interpolation.h"
 #include "ni_splines.h"
 #include <stdlib.h>
+#include <string.h>
 #include <math.h>
 
 
@@ -141,11 +142,196 @@ map_coordinate(double in, npy_intp len, int mode)
 #define TOLERANCE 1e-15
 
 
+static void
+NI_CopyToDoubleLine(char *input_data, int input_type, npy_intp start,
+                    npy_intp stride, npy_intp len, double *line)
+{
+    npy_intp ii;
+
+    if (input_type == NPY_FLOAT) {
+        const npy_float *input = (const npy_float *)input_data;
+        for (ii = 0; ii < len; ii++) {
+            line[ii] = input[start + ii * stride];
+        }
+    } else {
+        const npy_double *input = (const npy_double *)input_data;
+        for (ii = 0; ii < len; ii++) {
+            line[ii] = input[start + ii * stride];
+        }
+    }
+}
+
+static void
+NI_CopyDoubleLineToOutput(double *output, npy_intp start, npy_intp stride,
+                          npy_intp len, const double *line)
+{
+    npy_intp ii;
+
+    for (ii = 0; ii < len; ii++) {
+        output[start + ii * stride] = line[ii];
+    }
+}
+
+static void
+NI_FilterContiguousDoubleLine(char *input_data, int input_type, double *output,
+                              npy_intp start, npy_intp len,
+                              const double *poles, int npoles,
+                              NI_ExtendMode mode)
+{
+    if (input_type == NPY_FLOAT) {
+        const npy_float *input = (const npy_float *)input_data;
+        npy_intp ii;
+        for (ii = 0; ii < len; ii++) {
+            output[start + ii] = input[start + ii];
+        }
+    } else {
+        const npy_double *input = (const npy_double *)input_data;
+        if (input != output) {
+            memcpy(output + start, input + start, len * sizeof(double));
+        }
+    }
+
+    if (len > 1) {
+        apply_filter(output + start, len, poles, npoles, mode);
+    }
+}
+
+static void
+NI_GetCContiguousLineGeometry(npy_intp *dims, int rank, int axis,
+                              npy_intp line_index, npy_intp *start,
+                              npy_intp *stride)
+{
+    if (rank == 1) {
+        *start = 0;
+        *stride = 1;
+    } else if (rank == 2) {
+        if (axis == 0) {
+            *start = line_index;
+            *stride = dims[1];
+        } else {
+            *start = line_index * dims[1];
+            *stride = 1;
+        }
+    } else {
+        if (axis == 0) {
+            *start = line_index;
+            *stride = dims[1] * dims[2];
+        } else if (axis == 1) {
+            const npy_intp ii = line_index / dims[2];
+            const npy_intp kk = line_index - ii * dims[2];
+            *start = ii * dims[1] * dims[2] + kk;
+            *stride = dims[2];
+        } else {
+            *start = line_index * dims[2];
+            *stride = 1;
+        }
+    }
+}
+
+static int
+NI_SplineFilter1DFastPath(PyArrayObject *input, int order, int axis,
+                          NI_ExtendMode mode, PyArrayObject *output,
+                          const double *poles, int npoles, int *handled)
+{
+    double *line = NULL;
+    char *input_data = NULL;
+    double *output_data = NULL;
+    npy_intp dims[NPY_MAXDIMS], ii, len, line_count, line_index, size;
+    int rank, input_type, jj;
+    NPY_BEGIN_THREADS_DEF;
+
+    *handled = 0;
+
+    if (order != 3 || (mode != NI_EXTEND_MIRROR &&
+            mode != NI_EXTEND_REFLECT)) {
+        return 1;
+    }
+
+    rank = PyArray_NDIM(input);
+    if (rank < 1 || rank > 3 || PyArray_NDIM(output) != rank) {
+        return 1;
+    }
+    if (!PyArray_IS_C_CONTIGUOUS(input) ||
+            !PyArray_IS_C_CONTIGUOUS(output)) {
+        return 1;
+    }
+
+    input_type = PyArray_TYPE(input);
+    if ((input_type != NPY_FLOAT && input_type != NPY_DOUBLE) ||
+            PyArray_TYPE(output) != NPY_DOUBLE) {
+        return 1;
+    }
+
+    for (jj = 0; jj < rank; jj++) {
+        dims[jj] = PyArray_DIM(input, jj);
+        if (dims[jj] != PyArray_DIM(output, jj)) {
+            return 1;
+        }
+    }
+
+    len = dims[axis];
+    size = PyArray_SIZE(input);
+    if (size == 0) {
+        *handled = 1;
+        return 1;
+    }
+    if (len <= 1) {
+        input_data = (char *)PyArray_DATA(input);
+        output_data = (double *)PyArray_DATA(output);
+        if (input_type == NPY_FLOAT) {
+            const npy_float *input_float = (const npy_float *)input_data;
+            for (ii = 0; ii < size; ii++) {
+                output_data[ii] = input_float[ii];
+            }
+        } else {
+            const npy_double *input_double = (const npy_double *)input_data;
+            if (input_double != output_data) {
+                memcpy(output_data, input_double, size * sizeof(double));
+            }
+        }
+        *handled = 1;
+        return 1;
+    }
+
+    line_count = size / len;
+    input_data = (char *)PyArray_DATA(input);
+    output_data = (double *)PyArray_DATA(output);
+
+    if (axis != rank - 1) {
+        line = malloc(len * sizeof(double));
+        if (NPY_UNLIKELY(!line)) {
+            PyErr_NoMemory();
+            return 0;
+        }
+    }
+
+    NPY_BEGIN_THREADS;
+    for (line_index = 0; line_index < line_count; line_index++) {
+        npy_intp start, stride;
+        NI_GetCContiguousLineGeometry(dims, rank, axis, line_index,
+                                      &start, &stride);
+        if (stride == 1) {
+            NI_FilterContiguousDoubleLine(input_data, input_type, output_data,
+                                          start, len, poles, npoles, mode);
+        } else {
+            NI_CopyToDoubleLine(input_data, input_type, start, stride, len,
+                                line);
+            apply_filter(line, len, poles, npoles, mode);
+            NI_CopyDoubleLineToOutput(output_data, start, stride, len, line);
+        }
+    }
+    NPY_END_THREADS;
+
+    free(line);
+    *handled = 1;
+    return 1;
+}
+
 /* one-dimensional spline filter: */
 int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
                       NI_ExtendMode mode, PyArrayObject *output)
 {
-    int npoles = 0, more;
+    int npoles = 0, more, fast_path_handled = 0;
     npy_intp kk, lines, len;
     double *buffer = NULL, poles[MAX_SPLINE_FILTER_POLES];
     NI_LineBuffer iline_buffer, oline_buffer;
@@ -157,6 +343,14 @@ int NI_SplineFilter1D(PyArrayObject *input, int order, int axis,
 
     /* these are used in the spline filter calculation below: */
     if (get_filter_poles(order, &npoles, poles)) {
+        goto exit;
+    }
+
+    if (!NI_SplineFilter1DFastPath(input, order, axis, mode, output,
+                                   poles, npoles, &fast_path_handled)) {
+        goto exit;
+    }
+    if (fast_path_handled) {
         goto exit;
     }
 
@@ -250,6 +444,463 @@ int _get_spline_boundary_mode(int mode)
         // mirror extension.
         return NI_EXTEND_MIRROR;
     return mode;
+}
+
+#define CASE_ZOOM_LINEAR_FAST(_TYPE, _type)                                \
+case _TYPE:                                                                \
+{                                                                          \
+    const _type *in = (const _type *)PyArray_DATA(input);                   \
+    _type *out = (_type *)PyArray_DATA(output);                             \
+    npy_intp ii, jj, kk;                                                    \
+                                                                           \
+    if (rank == 1) {                                                        \
+        for (ii = 0; ii < odimensions[0]; ii++) {                           \
+            double t = 0.0, coeff;                                          \
+            coeff = in[offset0[0][ii]];                                     \
+            coeff *= weight0[0][ii];                                        \
+            t += coeff;                                                     \
+            coeff = in[offset1[0][ii]];                                     \
+            coeff *= weight1[0][ii];                                        \
+            t += coeff;                                                     \
+            out[ii] = (_type)t;                                             \
+        }                                                                  \
+    } else if (rank == 2) {                                                 \
+        npy_intp oo = 0;                                                    \
+        for (ii = 0; ii < odimensions[0]; ii++) {                           \
+            const npy_intp off00 = offset0[0][ii];                          \
+            const npy_intp off01 = offset1[0][ii];                          \
+            const double w00 = weight0[0][ii];                              \
+            const double w01 = weight1[0][ii];                              \
+            for (jj = 0; jj < odimensions[1]; jj++, oo++) {                 \
+                double t = 0.0, coeff;                                      \
+                coeff = in[off00 + offset0[1][jj]];                         \
+                coeff *= w00;                                               \
+                coeff *= weight0[1][jj];                                    \
+                t += coeff;                                                 \
+                coeff = in[off00 + offset1[1][jj]];                         \
+                coeff *= w00;                                               \
+                coeff *= weight1[1][jj];                                    \
+                t += coeff;                                                 \
+                coeff = in[off01 + offset0[1][jj]];                         \
+                coeff *= w01;                                               \
+                coeff *= weight0[1][jj];                                    \
+                t += coeff;                                                 \
+                coeff = in[off01 + offset1[1][jj]];                         \
+                coeff *= w01;                                               \
+                coeff *= weight1[1][jj];                                    \
+                t += coeff;                                                 \
+                out[oo] = (_type)t;                                         \
+            }                                                              \
+        }                                                                  \
+    } else {                                                               \
+        npy_intp oo = 0;                                                    \
+        for (ii = 0; ii < odimensions[0]; ii++) {                           \
+            const npy_intp off00 = offset0[0][ii];                          \
+            const npy_intp off01 = offset1[0][ii];                          \
+            const double w00 = weight0[0][ii];                              \
+            const double w01 = weight1[0][ii];                              \
+            for (jj = 0; jj < odimensions[1]; jj++) {                       \
+                const npy_intp off10 = offset0[1][jj];                      \
+                const npy_intp off11 = offset1[1][jj];                      \
+                const double w10 = weight0[1][jj];                          \
+                const double w11 = weight1[1][jj];                          \
+                for (kk = 0; kk < odimensions[2]; kk++, oo++) {             \
+                    double t = 0.0, coeff;                                  \
+                    coeff = in[off00 + off10 + offset0[2][kk]];             \
+                    coeff *= w00;                                           \
+                    coeff *= w10;                                           \
+                    coeff *= weight0[2][kk];                                \
+                    t += coeff;                                             \
+                    coeff = in[off00 + off10 + offset1[2][kk]];             \
+                    coeff *= w00;                                           \
+                    coeff *= w10;                                           \
+                    coeff *= weight1[2][kk];                                \
+                    t += coeff;                                             \
+                    coeff = in[off00 + off11 + offset0[2][kk]];             \
+                    coeff *= w00;                                           \
+                    coeff *= w11;                                           \
+                    coeff *= weight0[2][kk];                                \
+                    t += coeff;                                             \
+                    coeff = in[off00 + off11 + offset1[2][kk]];             \
+                    coeff *= w00;                                           \
+                    coeff *= w11;                                           \
+                    coeff *= weight1[2][kk];                                \
+                    t += coeff;                                             \
+                    coeff = in[off01 + off10 + offset0[2][kk]];             \
+                    coeff *= w01;                                           \
+                    coeff *= w10;                                           \
+                    coeff *= weight0[2][kk];                                \
+                    t += coeff;                                             \
+                    coeff = in[off01 + off10 + offset1[2][kk]];             \
+                    coeff *= w01;                                           \
+                    coeff *= w10;                                           \
+                    coeff *= weight1[2][kk];                                \
+                    t += coeff;                                             \
+                    coeff = in[off01 + off11 + offset0[2][kk]];             \
+                    coeff *= w01;                                           \
+                    coeff *= w11;                                           \
+                    coeff *= weight0[2][kk];                                \
+                    t += coeff;                                             \
+                    coeff = in[off01 + off11 + offset1[2][kk]];             \
+                    coeff *= w01;                                           \
+                    coeff *= w11;                                           \
+                    coeff *= weight1[2][kk];                                \
+                    t += coeff;                                             \
+                    out[oo] = (_type)t;                                     \
+                }                                                          \
+            }                                                              \
+        }                                                                  \
+    }                                                                      \
+}                                                                          \
+break
+
+#define ZOOM_CUBIC_FAST(_in_type, _out_type)                               \
+do {                                                                       \
+    const _in_type *in = (const _in_type *)PyArray_DATA(input);             \
+    _out_type *out = (_out_type *)PyArray_DATA(output);                     \
+    npy_intp ii, jj, kk, ll, mm, nn;                                        \
+                                                                           \
+    if (rank == 1) {                                                        \
+        for (ii = 0; ii < odimensions[0]; ii++) {                           \
+            const npy_intp base0 = 4 * ii;                                  \
+            double t = 0.0;                                                 \
+            for (ll = 0; ll < 4; ll++) {                                    \
+                double coeff = in[offsets[0][base0 + ll]];                  \
+                coeff *= weights[0][base0 + ll];                            \
+                t += coeff;                                                 \
+            }                                                              \
+            out[ii] = (_out_type)t;                                         \
+        }                                                                  \
+    } else if (rank == 2) {                                                 \
+        npy_intp oo = 0;                                                    \
+        for (ii = 0; ii < odimensions[0]; ii++) {                           \
+            const npy_intp base0 = 4 * ii;                                  \
+            for (jj = 0; jj < odimensions[1]; jj++, oo++) {                 \
+                const npy_intp base1 = 4 * jj;                              \
+                double t = 0.0;                                             \
+                for (ll = 0; ll < 4; ll++) {                                \
+                    const npy_intp off0 = offsets[0][base0 + ll];           \
+                    const double w0 = weights[0][base0 + ll];               \
+                    double row = 0.0;                                       \
+                    for (mm = 0; mm < 4; mm++) {                            \
+                        double coeff = in[off0 + offsets[1][base1 + mm]];   \
+                        coeff *= weights[1][base1 + mm];                    \
+                        row += coeff;                                       \
+                    }                                                      \
+                    t += row * w0;                                          \
+                }                                                          \
+                out[oo] = (_out_type)t;                                     \
+            }                                                              \
+        }                                                                  \
+    } else {                                                               \
+        npy_intp oo = 0;                                                    \
+        for (ii = 0; ii < odimensions[0]; ii++) {                           \
+            const npy_intp base0 = 4 * ii;                                  \
+            for (jj = 0; jj < odimensions[1]; jj++) {                       \
+                const npy_intp base1 = 4 * jj;                              \
+                for (kk = 0; kk < odimensions[2]; kk++, oo++) {             \
+                    const npy_intp base2 = 4 * kk;                          \
+                    double t = 0.0;                                         \
+                    for (ll = 0; ll < 4; ll++) {                            \
+                        const npy_intp off0 = offsets[0][base0 + ll];       \
+                        const double w0 = weights[0][base0 + ll];           \
+                        double plane = 0.0;                                 \
+                        for (mm = 0; mm < 4; mm++) {                        \
+                            const npy_intp off1 = offsets[1][base1 + mm];   \
+                            const double w1 = weights[1][base1 + mm];       \
+                            double row = 0.0;                               \
+                            for (nn = 0; nn < 4; nn++) {                    \
+                                double coeff = in[off0 + off1 +             \
+                                                  offsets[2][base2 + nn]];  \
+                                coeff *= weights[2][base2 + nn];            \
+                                row += coeff;                               \
+                            }                                              \
+                            plane += row * w1;                              \
+                        }                                                  \
+                        t += plane * w0;                                    \
+                    }                                                      \
+                    out[oo] = (_out_type)t;                                 \
+                }                                                          \
+            }                                                              \
+        }                                                                  \
+    }                                                                      \
+} while (0)
+
+static void
+NI_FreeZoomLinearFastData(npy_intp **offset0, npy_intp **offset1,
+                          double **weight0, double **weight1, int rank)
+{
+    int ii;
+    for (ii = 0; ii < rank; ii++) {
+        free(offset0[ii]);
+        free(offset1[ii]);
+        free(weight0[ii]);
+        free(weight1[ii]);
+    }
+}
+
+static int
+NI_InitZoomLinearFastAxis(npy_intp odim, npy_intp idim, npy_intp stride,
+                          double zoom, int mode, npy_intp *offset0,
+                          npy_intp *offset1, double *weight0,
+                          double *weight1)
+{
+    const int spline_mode = _get_spline_boundary_mode(mode);
+    npy_intp kk;
+
+    for (kk = 0; kk < odim; kk++) {
+        double cc = (double)kk * zoom;
+        double cc_floor;
+        npy_intp start, idx0, idx1;
+
+        cc = map_coordinate(cc, idim, mode);
+        cc_floor = floor(cc);
+        start = (npy_intp)cc_floor;
+        idx0 = start;
+        idx1 = start + 1;
+
+        if (start < 0 || start + 1 >= idim) {
+            idx0 = (npy_intp)map_coordinate(idx0, idim, spline_mode);
+            idx1 = (npy_intp)map_coordinate(idx1, idim, spline_mode);
+        }
+
+        offset0[kk] = stride * idx0;
+        offset1[kk] = stride * idx1;
+        weight1[kk] = cc - cc_floor;
+        weight0[kk] = 1.0 - weight1[kk];
+    }
+
+    return 1;
+}
+
+static int
+NI_ZoomShiftLinearFastPath(PyArrayObject *input, PyArrayObject *zoom_ar,
+                           PyArrayObject *shift_ar, PyArrayObject *output,
+                           int order, int mode, int nprepad,
+                           int grid_mode, int *handled)
+{
+    npy_intp *offset0[NPY_MAXDIMS] = {NULL};
+    npy_intp *offset1[NPY_MAXDIMS] = {NULL};
+    double *weight0[NPY_MAXDIMS] = {NULL};
+    double *weight1[NPY_MAXDIMS] = {NULL};
+    npy_intp idimensions[NPY_MAXDIMS], odimensions[NPY_MAXDIMS];
+    npy_intp istrides[NPY_MAXDIMS];
+    npy_double *zooms = NULL;
+    int rank, type_num, jj;
+    NPY_BEGIN_THREADS_DEF;
+
+    *handled = 0;
+
+    if (order != 1 || zoom_ar == NULL || shift_ar != NULL || nprepad != 0 ||
+            grid_mode) {
+        return 1;
+    }
+    if (mode != NI_EXTEND_MIRROR && mode != NI_EXTEND_REFLECT) {
+        return 1;
+    }
+
+    rank = PyArray_NDIM(input);
+    if (rank < 1 || rank > 3 || PyArray_NDIM(output) != rank) {
+        return 1;
+    }
+
+    type_num = PyArray_TYPE(input);
+    if (type_num != PyArray_TYPE(output) ||
+            (type_num != NPY_FLOAT && type_num != NPY_DOUBLE)) {
+        return 1;
+    }
+    if (!PyArray_IS_C_CONTIGUOUS(input) ||
+            !PyArray_IS_C_CONTIGUOUS(output)) {
+        return 1;
+    }
+    if (PyArray_TYPE(zoom_ar) != NPY_DOUBLE ||
+            PyArray_SIZE(zoom_ar) != rank) {
+        return 1;
+    }
+
+    if (PyArray_SIZE(output) == 0) {
+        *handled = 1;
+        return 1;
+    }
+
+    for (jj = 0; jj < rank; jj++) {
+        idimensions[jj] = PyArray_DIM(input, jj);
+        odimensions[jj] = PyArray_DIM(output, jj);
+        istrides[jj] = PyArray_STRIDE(input, jj) / PyArray_ITEMSIZE(input);
+        if (idimensions[jj] < 1) {
+            return 1;
+        }
+    }
+
+    zooms = (npy_double *)PyArray_DATA(zoom_ar);
+    for (jj = 0; jj < rank; jj++) {
+        if (odimensions[jj] == 0) {
+            continue;
+        }
+        offset0[jj] = malloc(odimensions[jj] * sizeof(npy_intp));
+        offset1[jj] = malloc(odimensions[jj] * sizeof(npy_intp));
+        weight0[jj] = malloc(odimensions[jj] * sizeof(double));
+        weight1[jj] = malloc(odimensions[jj] * sizeof(double));
+        if (NPY_UNLIKELY(!offset0[jj] || !offset1[jj] ||
+                !weight0[jj] || !weight1[jj])) {
+            NI_FreeZoomLinearFastData(offset0, offset1, weight0, weight1,
+                                      rank);
+            PyErr_NoMemory();
+            return 0;
+        }
+        NI_InitZoomLinearFastAxis(odimensions[jj], idimensions[jj],
+                                  istrides[jj], zooms[jj], mode,
+                                  offset0[jj], offset1[jj],
+                                  weight0[jj], weight1[jj]);
+    }
+
+    NPY_BEGIN_THREADS;
+    switch (type_num) {
+        CASE_ZOOM_LINEAR_FAST(NPY_FLOAT, npy_float);
+        CASE_ZOOM_LINEAR_FAST(NPY_DOUBLE, npy_double);
+    default:
+        break;
+    }
+    NPY_END_THREADS;
+
+    NI_FreeZoomLinearFastData(offset0, offset1, weight0, weight1, rank);
+    *handled = 1;
+    return 1;
+}
+
+static void
+NI_FreeZoomCubicFastData(npy_intp **offsets, double **weights, int rank)
+{
+    int ii;
+    for (ii = 0; ii < rank; ii++) {
+        free(offsets[ii]);
+        free(weights[ii]);
+    }
+}
+
+static int
+NI_InitZoomCubicFastAxis(npy_intp odim, npy_intp idim, npy_intp stride,
+                         double zoom, int mode, npy_intp *offsets,
+                         double *weights)
+{
+    const int spline_mode = _get_spline_boundary_mode(mode);
+    npy_intp kk, hh;
+
+    for (kk = 0; kk < odim; kk++) {
+        double cc = (double)kk * zoom;
+        npy_intp start;
+        npy_intp base = 4 * kk;
+
+        cc = map_coordinate(cc, idim, mode);
+        start = (npy_intp)floor(cc) - 1;
+        get_spline_interpolation_weights(cc, 3, weights + base);
+
+        if (start < 0 || start + 3 >= idim) {
+            for (hh = 0; hh < 4; hh++) {
+                npy_intp idx = start + hh;
+                idx = (npy_intp)map_coordinate(idx, idim, spline_mode);
+                offsets[base + hh] = stride * idx;
+            }
+        } else {
+            for (hh = 0; hh < 4; hh++) {
+                offsets[base + hh] = stride * (start + hh);
+            }
+        }
+    }
+
+    return 1;
+}
+
+static int
+NI_ZoomShiftCubicFastPath(PyArrayObject *input, PyArrayObject *zoom_ar,
+                          PyArrayObject *shift_ar, PyArrayObject *output,
+                          int order, int mode, int nprepad,
+                          int grid_mode, int *handled)
+{
+    npy_intp *offsets[NPY_MAXDIMS] = {NULL};
+    double *weights[NPY_MAXDIMS] = {NULL};
+    npy_intp idimensions[NPY_MAXDIMS], odimensions[NPY_MAXDIMS];
+    npy_intp istrides[NPY_MAXDIMS];
+    npy_double *zooms = NULL;
+    int rank, input_type, output_type, jj;
+    NPY_BEGIN_THREADS_DEF;
+
+    *handled = 0;
+
+    if (order != 3 || zoom_ar == NULL || shift_ar != NULL || nprepad != 0 ||
+            grid_mode) {
+        return 1;
+    }
+    if (mode != NI_EXTEND_MIRROR && mode != NI_EXTEND_REFLECT) {
+        return 1;
+    }
+
+    rank = PyArray_NDIM(input);
+    if (rank < 1 || rank > 3 || PyArray_NDIM(output) != rank) {
+        return 1;
+    }
+
+    input_type = PyArray_TYPE(input);
+    output_type = PyArray_TYPE(output);
+    if ((input_type != NPY_FLOAT && input_type != NPY_DOUBLE) ||
+            (output_type != NPY_FLOAT && output_type != NPY_DOUBLE)) {
+        return 1;
+    }
+    if (!PyArray_IS_C_CONTIGUOUS(input) ||
+            !PyArray_IS_C_CONTIGUOUS(output)) {
+        return 1;
+    }
+    if (PyArray_TYPE(zoom_ar) != NPY_DOUBLE ||
+            PyArray_SIZE(zoom_ar) != rank) {
+        return 1;
+    }
+
+    if (PyArray_SIZE(output) == 0) {
+        *handled = 1;
+        return 1;
+    }
+
+    for (jj = 0; jj < rank; jj++) {
+        idimensions[jj] = PyArray_DIM(input, jj);
+        odimensions[jj] = PyArray_DIM(output, jj);
+        istrides[jj] = PyArray_STRIDE(input, jj) / PyArray_ITEMSIZE(input);
+        if (idimensions[jj] < 1) {
+            return 1;
+        }
+    }
+
+    zooms = (npy_double *)PyArray_DATA(zoom_ar);
+    for (jj = 0; jj < rank; jj++) {
+        if (odimensions[jj] == 0) {
+            continue;
+        }
+        offsets[jj] = malloc(4 * odimensions[jj] * sizeof(npy_intp));
+        weights[jj] = malloc(4 * odimensions[jj] * sizeof(double));
+        if (NPY_UNLIKELY(!offsets[jj] || !weights[jj])) {
+            NI_FreeZoomCubicFastData(offsets, weights, rank);
+            PyErr_NoMemory();
+            return 0;
+        }
+        NI_InitZoomCubicFastAxis(odimensions[jj], idimensions[jj],
+                                 istrides[jj], zooms[jj], mode,
+                                 offsets[jj], weights[jj]);
+    }
+
+    NPY_BEGIN_THREADS;
+    if (input_type == NPY_DOUBLE && output_type == NPY_DOUBLE) {
+        ZOOM_CUBIC_FAST(npy_double, npy_double);
+    } else if (input_type == NPY_DOUBLE && output_type == NPY_FLOAT) {
+        ZOOM_CUBIC_FAST(npy_double, npy_float);
+    } else if (input_type == NPY_FLOAT && output_type == NPY_FLOAT) {
+        ZOOM_CUBIC_FAST(npy_float, npy_float);
+    } else if (input_type == NPY_FLOAT && output_type == NPY_DOUBLE) {
+        ZOOM_CUBIC_FAST(npy_float, npy_double);
+    }
+    NPY_END_THREADS;
+
+    NI_FreeZoomCubicFastData(offsets, weights, rank);
+    *handled = 1;
+    return 1;
 }
 
 int
@@ -672,8 +1323,25 @@ int NI_ZoomShift(PyArrayObject *input, PyArrayObject* zoom_ar,
     NI_Iterator io;
     npy_double *zooms = zoom_ar ? (npy_double*)PyArray_DATA(zoom_ar) : NULL;
     npy_double *shifts = shift_ar ? (npy_double*)PyArray_DATA(shift_ar) : NULL;
-    int rank = 0;
+    int rank = 0, fast_path_handled = 0;
     NPY_BEGIN_THREADS_DEF;
+
+    if (!NI_ZoomShiftLinearFastPath(input, zoom_ar, shift_ar, output,
+                                    order, mode, nprepad, grid_mode,
+                                    &fast_path_handled)) {
+        return 0;
+    }
+    if (fast_path_handled) {
+        return 1;
+    }
+    if (!NI_ZoomShiftCubicFastPath(input, zoom_ar, shift_ar, output,
+                                   order, mode, nprepad, grid_mode,
+                                   &fast_path_handled)) {
+        return 0;
+    }
+    if (fast_path_handled) {
+        return 1;
+    }
 
     NPY_BEGIN_THREADS;
 

--- a/scipy/ndimage/tests/test_interpolation.py
+++ b/scipy/ndimage/tests/test_interpolation.py
@@ -1337,6 +1337,71 @@ class TestZoom:
             xp.asarray(np.kron(x_np, np.ones(zoom)))
         )
 
+    @skip_xp_backends(np_only=True,
+                      reason='contiguity-specific NumPy fast path')
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    @pytest.mark.parametrize('mode', ['mirror', 'reflect'])
+    @pytest.mark.parametrize(
+        'shape, zoom',
+        [((9,), (1.7,)),
+         ((12, 10), (1.4, 0.6)),
+         ((7, 6, 5), (0.75, 1.25, 0.5))]
+    )
+    def test_zoom_order1_contiguous_matches_generic(self, dtype, mode,
+                                                    shape, zoom, xp):
+        rng = np.random.default_rng(1234)
+        x = rng.random(shape, dtype=dtype)
+
+        work = np.empty((*shape, 2), dtype=dtype)
+        x_strided = work[..., 0]
+        x_strided[...] = x
+        assert x.flags.c_contiguous
+        assert not x_strided.flags.c_contiguous
+
+        fast = ndimage.zoom(x, zoom, order=1, mode=mode, prefilter=False)
+        generic = ndimage.zoom(x_strided, zoom, order=1, mode=mode,
+                               prefilter=False)
+
+        xp_assert_close(fast, generic,
+                        rtol=1e-6 if dtype == np.float32 else 1e-12,
+                        atol=1e-6 if dtype == np.float32 else 1e-12)
+
+    @skip_xp_backends(np_only=True,
+                      reason='contiguity-specific NumPy fast path')
+    @pytest.mark.parametrize('dtype', [np.float32, np.float64])
+    @pytest.mark.parametrize('mode', ['mirror', 'reflect'])
+    @pytest.mark.parametrize(
+        'shape, zoom',
+        [((9,), (1.7,)),
+         ((12, 10), (1.4, 0.6)),
+         ((7, 6, 5), (0.75, 1.25, 0.5))]
+    )
+    def test_zoom_order3_contiguous_matches_generic(self, dtype, mode,
+                                                    shape, zoom, xp):
+        rng = np.random.default_rng(5678)
+        x = rng.random(shape, dtype=dtype)
+        filtered = ndimage.spline_filter(x, order=3, output=np.float64,
+                                         mode=mode)
+
+        work = np.empty((*shape, 2), dtype=np.float64)
+        filtered_strided = work[..., 0]
+        filtered_strided[...] = filtered
+        assert filtered.flags.c_contiguous
+        assert not filtered_strided.flags.c_contiguous
+
+        output_shape = tuple(int(round(n * z)) for n, z in zip(shape, zoom))
+        fast_output = np.empty(output_shape, dtype=dtype)
+        generic_output = np.empty(output_shape, dtype=dtype)
+
+        fast = ndimage.zoom(filtered, zoom, output=fast_output, order=3,
+                            mode=mode, prefilter=False)
+        generic = ndimage.zoom(filtered_strided, zoom, output=generic_output,
+                               order=3, mode=mode, prefilter=False)
+
+        xp_assert_close(fast, generic,
+                        rtol=1e-5 if dtype == np.float32 else 1e-12,
+                        atol=1e-5 if dtype == np.float32 else 1e-12)
+
     @pytest.mark.parametrize('mode', ['constant', 'wrap'])
     def test_zoom_grid_mode_warnings(self, mode, xp):
         # Warn on use of non-grid modes when grid_mode is True

--- a/scipy/ndimage/tests/test_splines.py
+++ b/scipy/ndimage/tests/test_splines.py
@@ -8,6 +8,7 @@ from scipy._lib._array_api import (
 from scipy import ndimage
 
 xfail_xp_backends = pytest.mark.xfail_xp_backends
+skip_xp_backends = pytest.mark.skip_xp_backends
 
 
 def get_spline_knot_values(order):
@@ -83,3 +84,38 @@ def test_spline_filter_reflect_small_n(order, n, xp):
     filtered = ndimage.spline_filter1d(eye, axis=0, order=order, mode='reflect')
     matrix = make_spline_knot_matrix(xp, n, order, mode='reflect')
     xp_assert_close(filtered @ matrix, eye, atol=1e-12)
+
+
+@make_xp_test_case(ndimage.spline_filter1d)  # type:ignore[attr-defined]
+@skip_xp_backends(np_only=True,
+                  reason='contiguity-specific NumPy fast path')
+@pytest.mark.parametrize('dtype', [np.float32, np.float64])
+@pytest.mark.parametrize('mode', ['mirror', 'reflect'])
+@pytest.mark.parametrize(
+    'shape, axis',
+    [((9,), 0),
+     ((8, 7), 0),
+     ((8, 7), 1),
+     ((6, 5, 4), 0),
+     ((6, 5, 4), 1),
+     ((6, 5, 4), 2)]
+)
+def test_spline_filter1d_order3_contiguous_matches_generic(dtype, mode,
+                                                           shape, axis, xp):
+    rng = np.random.default_rng(4321)
+    x = rng.random(shape, dtype=dtype)
+
+    work = np.empty((*shape, 2), dtype=dtype)
+    x_strided = work[..., 0]
+    x_strided[...] = x
+    assert x.flags.c_contiguous
+    assert not x_strided.flags.c_contiguous
+
+    fast = ndimage.spline_filter1d(x, order=3, axis=axis, output=np.float64,
+                                   mode=mode)
+    generic = ndimage.spline_filter1d(x_strided, order=3, axis=axis,
+                                      output=np.float64, mode=mode)
+
+    xp_assert_close(fast, generic,
+                    rtol=1e-6 if dtype == np.float32 else 1e-12,
+                    atol=1e-6 if dtype == np.float32 else 1e-12)


### PR DESCRIPTION
Adds ASV benchmark cases for `scipy.ndimage.zoom` and introduces guarded fast paths for selected C-contiguous `float32`/`float64` cases.

This is opened as a draft to discuss the fast-path scope and preferred review split before marking ready for review.

## Scope

- order 1 and order 3 `ndimage.zoom`
- 1D/2D/3D C-contiguous arrays
- `mode="mirror"` and `mode="reflect"`
- `grid_mode=False`
- cubic `spline_filter1d` fast path for matching contiguous cases

Unsupported cases fall back to the existing generic implementation. No public API or semantic behavior is changed.

## Validation

- `spin build`
- `spin test --no-build scipy/ndimage -- -q`
- Result: `5439 passed, 12 skipped, 1 xpassed`
- `git diff --check`

## ASV comparison

Command:

```bash
spin bench -t ndimage_interpolation.NdimageZoom --compare --no-dry-run
```

The plain `--compare` form passed `--dry-run` to `asv continuous` with the local ASV version, which rejected that argument. The `--no-dry-run` form completed successfully.

| Case | Before `main` | After this branch | Ratio |
| --- | ---: | ---: | ---: |
| 2D cubic down f64 | `1.80 ms` | `1.22 ms` | `0.68` |
| 2D cubic down f32 | `1.09 ms` | `578 us` | `0.53` |
| 3D cubic down f32 | `6.28 ms` | `2.50 ms` | `0.40` |
| 2D linear down f32 | `198 us` | `45.3 us` | `0.23` |
| 2D cubic up f32 | `5.11 ms` | `1.08 ms` | `0.21` |
| 2D linear anisotropic f32 | `1.06 ms` | `183 us` | `0.17` |
| 3D linear down f32 | `1.05 ms` | `171 us` | `0.16` |
| 2D linear up f64 | `1.65 ms` | `247 us` | `0.15` |

ASV reported:

```text
SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

## Review notes

The branch is intentionally split into two commits:

1. ASV benchmark cases.
2. Implementation plus parity tests.

If preferred, this can be split further into smaller PRs, for example benchmark-only, order-1 zoom fast path, order-3 zoom fast path, and cubic `spline_filter1d` fast path.