### PR TITLE
BUG: optimize: report cobyqa callback StopIteration as unsuccessful

### DIFF
--- a/scipy/optimize/_cobyqa_py.py
+++ b/scipy/optimize/_cobyqa_py.py
@@ -65,4 +65,14 @@ def _minimize_cobyqa(fun, x0, args=(), bounds=None, constraints=(),
         'radius_final': float(final_tr_radius),
         'scale': bool(scale),
     }
-    return _cobyqa_minimize(fun, x0, args, bounds, constraints, callback, options)
+    res = _cobyqa_minimize(fun, x0, args, bounds, constraints, callback,
+                           options)
+
+    # COBYQA reports a callback-requested stop (``status == 3``) as a
+    # successful termination. For consistency with the other `minimize`
+    # methods, which treat the `callback` raising ``StopIteration`` as an
+    # unsuccessful termination, override `success` accordingly. See gh-23660.
+    if res.status == 3:
+        res.success = False
+
+    return res

--- a/scipy/optimize/tests/test_cobyqa.py
+++ b/scipy/optimize/tests/test_cobyqa.py
@@ -228,6 +228,29 @@ class TestCOBYQA:
         assert not sol.success, sol.message
         assert sol.nit <= 2, sol
 
+    def test_minimize_callback_stop_iteration(self):
+        # A `callback` raising `StopIteration` should be reported as an
+        # unsuccessful termination, consistently with the other `minimize`
+        # methods (gh-23660).
+        def callback(x):
+            raise StopIteration
+
+        def callback_new_syntax(intermediate_result):
+            raise StopIteration
+
+        constraints = NonlinearConstraint(self.con, 0.0, 0.0)
+        for cb in (callback, callback_new_syntax):
+            sol = minimize(
+                self.fun,
+                self.x0,
+                method='cobyqa',
+                constraints=constraints,
+                callback=cb,
+                options=self.options,
+            )
+            assert not sol.success, sol.message
+            assert sol.status == 3, sol
+
     def test_minimize_f_target(self):
         constraints = NonlinearConstraint(self.con, 0.0, 0.0)
         sol_ref = minimize(


### PR DESCRIPTION
Reference issue
Closes gh-23660.

What does this implement/fix?
Most `scipy.optimize.minimize` methods consider a `callback` that raises `StopIteration` to be an *unsuccessful* termination. COBYQA was the exception: it terminates with `status == 3` but reports `success == True`, with the message `"The callback requested to stop the optimization procedure"`.

```python
from scipy import optimize

def callback(*, intermediate_result):
    raise StopIteration()

res = optimize.minimize(optimize.rosen, [1, 2, 3], callback=callback, method="cobyqa")
print(res.success, res.status, res.message)
# before: True 3 The callback requested to stop the optimization procedure
# after:  False 3 The callback requested to stop the optimization procedure
```

The fix lives in the `_minimize_cobyqa` wrapper: after calling the vendored COBYQA, `success` is overridden to `False` when the exit status corresponds to a callback-requested stop (`status == 3`, i.e. COBYQA's `ExitStatus.CALLBACK_SUCCESS`). The status and message are left unchanged. This keeps the behavior consistent with the other methods without modifying the vendored COBYQA package.

Additional information
A regression test (`test_minimize_callback_stop_iteration`) is added covering both the old `callback(x)` and new `callback(intermediate_result)` syntaxes.