### PR TITLE
BUG: interpolate: fix double-free of wrk buffers in fitpack_surfit

### DIFF
--- a/scipy/interpolate/src/_fitpackmodule.c
+++ b/scipy/interpolate/src/_fitpackmodule.c
@@ -1576,8 +1576,11 @@ fitpack_surfit(PyObject* Py_UNUSED(dummy), PyObject *args)
     memcpy(PyArray_DATA(ap_wrk_out), wrk1, (size_t)nc * sizeof(double));
 
     free(wrk1);
+    wrk1 = NULL;
     free(wrk2);
+    wrk2 = NULL;
     free(iwrk);
+    iwrk = NULL;
 
     /* Slice tx, ty to actual sizes nx, ny for return. */
     PyArrayObject *ap_tx_sliced = NULL;


### PR DESCRIPTION
After the `surfit()` call in `fitpack_surfit`, `wrk1`, `wrk2`, and `iwrk` are freed but the pointers are not set to `NULL`. If a subsequent `PyArray_SimpleNew` call (for `ap_tx_sliced` or `ap_ty_sliced`) fails and jumps to the `fail:` label, the `NULL` checks at lines 1610-1618 pass and the already-freed buffers are freed again, causing a double-free / heap corruption.

The fix sets each pointer to `NULL` immediately after `free()` so the fail-path guards work correctly.

Closes #25406