### PR TITLE
ENH: special: make special functions accept mixed torch.tensor and python scalar inputs

### DIFF
--- a/scipy/special/_support_alternative_backends.py
+++ b/scipy/special/_support_alternative_backends.py
@@ -8,7 +8,7 @@ import numpy as np
 from scipy._lib._array_api import (
     array_namespace, scipy_namespace_for, is_numpy, is_dask, is_marray, is_jax_array,
     is_jax, xp_promote, xp_capabilities, SCIPY_ARRAY_API, get_native_namespace_name,
-    is_array_api_obj
+    is_array_api_obj, is_torch
 )
 import scipy._external.array_api_extra as xpx
 from . import _basic
@@ -108,7 +108,12 @@ class _FuncInfo:
             @functools.wraps(self.func)
             def wrapped(*args, **kwargs):
                 xp = array_namespace(*args)
-                return self._wrapper_for(xp)(*args, **kwargs)
+
+                func, is_native = self._wrapper_for(xp)
+                if is_native and is_torch(xp):
+                    # torch does not accept python scalars
+                    args = tuple(xp.asarray(a) for a in args)
+                return func(*args, **kwargs)
 
             # Allow pickling the function. Normally this is done by @wraps,
             # but in this case it doesn't work because self.func is a ufunc.
@@ -128,7 +133,7 @@ class _FuncInfo:
     @functools.lru_cache(1000)
     def _wrapper_for(self, xp):
         if is_numpy(xp):
-            return self.func
+            return self.func, True
 
         # If a native implementation is available, use that
         in_xp = get_native_namespace_name(xp) in self.backends_with_func_in_xp
@@ -137,7 +142,7 @@ class _FuncInfo:
             xp, namespace, self.name, alt_names_map=self.alt_names_map
         )
         if f is not None:
-            return f
+            return f, True
 
         if in_xp:
             # when namespace is passed to self.generic_impl below, we want to
@@ -153,7 +158,7 @@ class _FuncInfo:
         if self.generic_impl is not None:
             f = self.generic_impl(xp, namespace)
             if f is not None:
-                return f
+                return f, False
 
         if is_marray(xp):
             # Unwrap the array, apply the function on the wrapped namespace,
@@ -170,7 +175,7 @@ class _FuncInfo:
                                         (getattr(arg, 'mask', False) for arg in args))
                 return xp.asarray(out, mask=mask)
 
-            return f
+            return f, False
 
         if is_dask(xp):
             # Apply the function to each block of the Dask array.


### PR DESCRIPTION

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

fixes https://github.com/scipy/scipy/issues/23965

#### What does this implement/fix?
<!--Please explain your changes.-->

Pytorch has a quirck that it often rejects python scalars and requires tensor arguments. One place where it bites us is `scipy.special`: typically, the Array API spec allows a mix of an array and a scalar, but gh-23965 reports

```
>>> special.gammainc(np.array(10.), 10.)  # works as expected
>>> special.gammainc(torch.asarray(10.), 10.)
...
TypeError: special_gammainc(): argument 'input' (position 2) must be Tensor, not float
```

This problems seems specific to pytorch, and to the "native" functions from `pytorch.special` extension https://docs.pytorch.org/docs/main/special.html

Thus, wrap scalars into arrays, specifically for pytorch native functions.


#### Additional information
<!--Any additional information you think is important.-->

It would be cleaner to always wrap all arguments to arrays of course. This is however not desirable in general: 
- for GPU-only backends, `xp.asarray` transfers from host to device
- in jit contexts, a compiler could do something specific with scalars, and turning everything into arrays removes that freedom
- why would everybody pay for a torch's edge case  

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.