### PR TITLE
ENH: interpolate: remove array_api_strict skip for `Akima1DInterpolator`

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -408,7 +408,6 @@ def pchip_interpolate(xi, yi, x, der=0, axis=0):
 
 @xp_capabilities(cpu_only=True, jax_jit=False, xfail_backends=[
     ("dask.array", "lacks nd fancy indexing"),
-    ("array_api_strict", "fancy indexing __setitem__"),
 ])
 class Akima1DInterpolator(CubicHermiteSpline):
     r"""Akima "visually pleasing" interpolator (C1 smooth).
@@ -592,16 +591,13 @@ class Akima1DInterpolator(CubicHermiteSpline):
 
             # These are the mask of where the slope at breakpoint is defined:
             mmax = xp.max(f12) if xp_size(f12) > 0 else -xp.inf
-            ind = xp.nonzero(f12 > break_mult * mmax)
-
-            x_ind, y_ind = ind[0], ind[1:]
+            ind = f12 > break_mult * mmax
             # Set the slope at breakpoint
-            t = xpx.at(t)[ind].set(
-                m[(x_ind + 1,) + y_ind]
-                + (
-                    (f2[ind] / f12[ind])
-                    * (m[(x_ind + 2,) + y_ind] - m[(x_ind + 1,) + y_ind])
-                )
+            t = xp.where(
+                ind,
+                m[1:-2, ...]
+                + (f2 / xp.where(ind, f12, 1)) * (m[2:-1, ...] - m[1:-2, ...]),
+                t,
             )
 
         super().__init__(x, y, t, axis=0, extrapolate=extrapolate)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Remove array-api-strict tests skip for Akima1DInterpolator by rewriting indexing.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex to review my changes.