### PR TITLE
ENH: integrate: remove JAX skip for `cumulative_simpson`

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -548,11 +548,11 @@ def _cumulatively_sum_simpson_integrals(
     shape = list(sub_integrals_h1.shape)
     shape[-1] += 1
     sub_integrals = xp.empty(shape, dtype=xp.result_type(y, dx))
-    sub_integrals[..., :-1:2] = sub_integrals_h1[..., ::2]
-    sub_integrals[..., 1::2] = sub_integrals_h2[..., ::2]
+    sub_integrals = xpx.at(sub_integrals)[..., :-1:2].set(sub_integrals_h1[..., ::2])
+    sub_integrals = xpx.at(sub_integrals)[..., 1::2].set(sub_integrals_h2[..., ::2])
     # Integral over last subinterval can only be calculated from
     # formula for h2
-    sub_integrals[..., -1] = sub_integrals_h2[..., -1]
+    sub_integrals = xpx.at(sub_integrals)[..., -1].set(sub_integrals_h2[..., -1])
     res = xp.cumulative_sum(sub_integrals, axis=-1)
     return res
 
@@ -595,8 +595,7 @@ def _cumulative_simpson_unequal_intervals(y: np.ndarray, dx: np.ndarray) -> np.n
     return x21/6 * (coeff1*f1 + coeff2*f2 + coeff3*f3)
 
 
-@xp_capabilities(allow_dask_compute=1,
-                 skip_backends=[("jax.numpy", "item assignment")])
+@xp_capabilities(allow_dask_compute=1, jax_jit=False)
 def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
     r"""
     Cumulatively integrate y(x) using the composite Simpson's 1/3 rule.


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
- Remove JAX skip for `interpolate.cumulative_simpson`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI