### PR TITLE
ENH: integrate: Remove JAX skip for `trapezoid`

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -20,8 +20,7 @@ __all__ = ['fixed_quad', 'romb',
            'qmc_quad', 'cumulative_simpson']
 
 
-@xp_capabilities(skip_backends=[('jax.numpy',
-                                 "JAX arrays do not support item assignment")])
+@xp_capabilities()
 def trapezoid(y, x=None, dx=1.0, axis=-1):
     r"""
     Integrate along the given axis using the composite trapezoidal rule.

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -395,7 +395,7 @@ class TestTrapezoid(CommonTrapezoidSimpsonTests):
         xm = np.ma.array(x, mask=mask)
         assert_allclose(trapezoid(y, xm), r)
 
-    def test_array_like(self):
+    def test_array_like(self):  # array_like is np only
         x = list(range(5))
         y = [t * t for t in x]
         xarr = np.asarray(x, dtype=np.float64)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -395,14 +395,14 @@ class TestTrapezoid(CommonTrapezoidSimpsonTests):
         xm = np.ma.array(x, mask=mask)
         assert_allclose(trapezoid(y, xm), r)
 
-    def test_array_like(self, xp):
+    def test_array_like(self):
         x = list(range(5))
         y = [t * t for t in x]
-        xarr = xp.asarray(x, dtype=xp.float64)
-        yarr = xp.asarray(y, dtype=xarr.dtype)
+        xarr = np.asarray(x, dtype=np.float64)
+        yarr = np.asarray(y, dtype=np.float64)
         res = trapezoid(y, x)
         resarr = trapezoid(yarr, xarr)
-        xp_assert_close(resarr, res)
+        xp_assert_close(res, resarr)
 
 
 @make_xp_test_case(qmc_quad)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -395,14 +395,14 @@ class TestTrapezoid(CommonTrapezoidSimpsonTests):
         xm = np.ma.array(x, mask=mask)
         assert_allclose(trapezoid(y, xm), r)
 
-    def test_array_like(self):
+    def test_array_like(self, xp):
         x = list(range(5))
         y = [t * t for t in x]
-        xarr = np.asarray(x, dtype=np.float64)
-        yarr = np.asarray(y, dtype=np.float64)
+        xarr = xp.asarray(x, dtype=xp.float64)
+        yarr = xp.asarray(y, dtype=xarr.dtype)
         res = trapezoid(y, x)
         resarr = trapezoid(yarr, xarr)
-        xp_assert_close(res, resarr)
+        xp_assert_close(resarr, res)
 
 
 @make_xp_test_case(qmc_quad)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
- It appears we can remove the JAX skip for `integrate.trapezoid`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI