### PR TITLE
ENH: stats: Add JAX support for `_continued_fraction`

### DIFF
--- a/scipy/stats/_continued_fraction.py
+++ b/scipy/stats/_continued_fraction.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from scipy._external import array_api_extra as xpx
 from scipy._lib._array_api import (
     array_namespace, xp_ravel, xp_copy, xp_promote
 )
@@ -308,6 +309,8 @@ def _continued_fraction(a, b, *, args=(), tolerances=None, maxiter=100, log=Fals
     if tiny is None:
         tiny = xp.finfo(dtype).eps**2 if not log else 2*np.log(xp.finfo(dtype).eps)
 
+    tiny = xp.asarray(tiny, dtype=dtype)
+
     # "Set f0 and C0 to the value b0 or to tiny if b0=0. Set D0 = 0.
     zero = -xp.inf if log else 0
     fn = xp.where(b0 == zero, tiny, b0)
@@ -334,14 +337,14 @@ def _continued_fraction(a, b, *, args=(), tolerances=None, maxiter=100, log=Fals
         # "Set D_n = 1/(b_n + a_n D_{n-1}) or 1/tiny, if the denominator vanishes"
         denominator = (bn + an*work.Dnm1 if not log
                        else _logaddexp(bn, an + work.Dnm1, xp=xp))
-        denominator[denominator == zero] = tiny
+        denominator = xpx.at(denominator)[denominator == zero].set(tiny)
         Dn = (1/denominator if not log
               else -denominator)
 
         # "Set C_n = b_n + a_n / C_{n-1} (or =tiny, if the expression vanishes)"
         Cn = (bn + an / work.Cnm1 if not log
               else _logaddexp(bn, an - work.Cnm1, xp=xp))
-        Cn[Cn == zero] = tiny
+        Cn = xpx.at(Cn)[Cn == zero].set(tiny)
 
         # "and set f_n = f_{n-1} C_n D_n"
         work.CnDn = (Cn * Dn if not log
@@ -361,14 +364,14 @@ def _continued_fraction(a, b, *, args=(), tolerances=None, maxiter=100, log=Fals
         residual = (xp.abs(work.CnDn - 1) if not log
                     else xp.real(_logaddexp(work.CnDn, pij, xp=xp)))
         i = residual < work.eps
-        work.status[i] = eim._ECONVERGED
-        stop[i] = True
+        work.status = xpx.at(work.status)[i].set(eim._ECONVERGED)
+        stop = xpx.at(stop)[i].set(True)
 
         # If function value is NaN, report failure.
         i = (~xp.isfinite(work.fn) if not log
              else ~(xp.isfinite(work.fn) | (work.fn == -xp.inf)))
-        work.status[i] = eim._EVALUEERR
-        stop[i] = True
+        work.status = xpx.at(work.status)[i].set(eim._EVALUEERR)
+        stop = xpx.at(stop)[i].set(True)
 
         return stop
 

--- a/scipy/stats/tests/test_continued_fraction.py
+++ b/scipy/stats/tests/test_continued_fraction.py
@@ -9,7 +9,6 @@ from scipy.stats._continued_fraction import _continued_fraction
 
 
 @pytest.mark.skip_xp_backends('array_api_strict', reason='No fancy indexing assignment')
-@pytest.mark.skip_xp_backends('jax.numpy', reason="Don't support mutation")
 # dask doesn't like lines like this
 # n = int(xp.real(xp_ravel(n))[0])
 # (at some point in here the shape becomes nan)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
- Add JAX support for `_continued_fraction`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex to review my changes, notably for the parameter `tiny`.