### PR TITLE
ENH: interpolate: add CuPy delegation for make_interp_spline

### DIFF
--- a/scipy/interpolate/_bsplines.py
+++ b/scipy/interpolate/_bsplines.py
@@ -16,7 +16,7 @@ from scipy.special import poch
 from itertools import combinations
 
 from scipy._lib._array_api import (
-    array_namespace, concat_1d, xp_capabilities, scipy_namespace_for, is_numpy
+    array_namespace, concat_1d, xp_capabilities, scipy_namespace_for, is_numpy, is_cupy
 )
 
 __all__ = ["BSpline", "make_interp_spline", "make_lsq_spline",
@@ -1633,7 +1633,12 @@ def _make_periodic_spline(x, y, t, k, axis, *, xp):
     return BSpline.construct_fast(t, c, k, extrapolate='periodic', axis=axis)
 
 
-@xp_capabilities(cpu_only=True, jax_jit=False, allow_dask_compute=True)
+@xp_capabilities(
+    cpu_only=True,
+    jax_jit=False,
+    allow_dask_compute=True,
+    exceptions=["cupy"]
+)
 def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
                        check_finite=True):
     """Create an interpolating B-spline with specified degree and boundary conditions.
@@ -1765,6 +1770,13 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
     >>> plt.show()
 
     """
+    xp = array_namespace(x, y, t)
+    if is_cupy(xp):
+        # delegate to CuPy, *and* return a SciPy BSpline object
+        import cupyx.scipy.interpolate as csi
+        b = csi.make_interp_spline(x, y, k, t, bc_type, axis, check_finite)
+        return BSpline.construct_fast(b.t, b.c, b.k, b.extrapolate, b.axis)
+
     # convert string aliases for the boundary conditions
     if bc_type is None or bc_type == 'not-a-knot' or bc_type == 'periodic':
         deriv_l, deriv_r = None, None
@@ -1776,7 +1788,6 @@ def make_interp_spline(x, y, k=3, t=None, bc_type=None, axis=0,
         except TypeError as e:
             raise ValueError(f"Unknown boundary condition: {bc_type}") from e
 
-    xp = array_namespace(x, y, t)
     x = _as_float_array(x, check_finite)
     y = _as_float_array(y, check_finite)
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -11,7 +11,7 @@ import sys
 import numpy as np
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, xp_default_dtype, concat_1d, make_xp_test_case,
-    xp_ravel, _xp_copy_to_numpy, array_namespace
+    xp_ravel, _xp_copy_to_numpy, array_namespace, is_cupy
 )
 import scipy._external.array_api_extra as xpx
 from pytest import raises as assert_raises
@@ -1304,11 +1304,13 @@ class TestInterp:
         with assert_raises(ValueError, match="Expect x to be a 1D strictly"):
             make_interp_spline(x, y, k=k)
 
-    def test_not_a_knot(self, xp):
+    @pytest.mark.parametrize('k', [2, 3, 4, 5, 6, 7])
+    def test_not_a_knot(self, k, xp):
+        if is_cupy(xp) and k % 2 == 0:
+            pytest.xfail(f"cupy only supports odd degrees, got {k=}.")
         xx, yy = self._get_xy(xp)
-        for k in [2, 3, 4, 5, 6, 7]:
-            b = make_interp_spline(xx, yy, k)
-            xp_assert_close(b(xx), yy, atol=1e-14, rtol=1e-14)
+        b = make_interp_spline(xx, yy, k)
+        xp_assert_close(b(xx), yy, atol=1e-14, rtol=1e-14)
 
     def test_periodic(self, xp):
         xx, yy = self._get_xy(xp)
@@ -1543,6 +1545,7 @@ class TestInterp:
         with assert_raises(ValueError):
             make_interp_spline(x, y, bc_type=(l, r))
 
+    @skip_xp_backends("cupy", reason="CuPy does not raise")
     def test_deriv_order_too_large(self, xp):
         x = xp.arange(7)
         y = x**2


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

towards https://github.com/scipy/scipy/issues/23754


#### What does this implement/fix?
<!--Please explain your changes.-->

Switch on CuPy delegation in `make_interp_spline`. Apparently, the SciPy test suite is ready modulo two small glitches where the CuPy delegation target did not keep up with SciPy itself.

The delegation pattern is a tad manual and bespoke. I think it's best to consider generalizing it when (and if) `cupyx.scipy.interpolate` grows more functions which use this "return a BSpline instance" factory pattern. For now, it's just two functions, `make_interp_spline` and `make_lsq_spline`, so generalizing feels premature. 

#### Additional information
<!--Any additional information you think is important.-->

 The key non-trivial piece of tech here is @steppi's BSpline delegation: it uses either scipy internal CPU-only implementation or cupy's CUDA-only implementation under the hood, depending on the constructor arguments. Here we call `cupyx.scipy.interpolate.make_interp_spline` which returns a CuPy object, and rewrap it into a SciPy object. This way, the return value of `make_interp_spline` is always a `scipy.interpolate.BSpline`. 

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI