### PR TITLE
ENH: Raise error instead of warning when `dijkstra` is called with negative weights

### DIFF
--- a/scipy/sparse/csgraph/_shortest_path.pyx
+++ b/scipy/sparse/csgraph/_shortest_path.pyx
@@ -12,7 +12,6 @@ finding the k-shortest paths between two nodes in a graph.
 
 # Author: Jake Vanderplas  -- <vanderplas@astro.washington.edu>
 # License: BSD, (C) 2011
-import warnings
 
 import numpy as np
 cimport numpy as np
@@ -78,12 +77,13 @@ def shortest_path(csgraph, method='auto',
                   based on the input data.
         'FW'   -- Floyd-Warshall algorithm.
                   Computational cost is approximately ``O[N^3]``.
+                  This algorithm can be used when weights are negative.
                   The input csgraph will be converted to a dense representation.
         'D'    -- Dijkstra's algorithm with priority queue.
                   Computational cost is approximately ``O[I * (E + N) * log(N)]``,
                   where ``E`` is the number of edges in the graph,
                   and ``I = len(indices)`` if ``indices`` is passed. Otherwise,
-                  ``I = N``.
+                  ``I = N``. Negative weights are not supported.
                   The input csgraph will be converted to a csr representation.
         'BF'   -- Bellman-Ford algorithm.
                   This algorithm can be used when weights are negative.
@@ -571,10 +571,9 @@ def dijkstra(csgraph, directed=True, indices=None,
     both are nonzero, setting directed=False will not yield the correct
     result.
 
-    Also, this routine does not work for graphs with negative
-    distances.  Negative distances can lead to infinite cycles that must
-    be handled by specialized algorithms such as Bellman-Ford's algorithm
-    or Johnson's algorithm.
+    Also, this routine does not support graphs with negative distances.
+    If any edge weight is negative, this function raises ``ValueError``.
+    For graphs with negative weights, consider using ``bellman_ford`` or ``johnson`` .
 
     If multiple valid solutions are possible, output may vary with SciPy and
     Python version.
@@ -612,9 +611,8 @@ def dijkstra(csgraph, directed=True, indices=None,
     csgraph = validate_graph(csgraph, directed, DTYPE, dense_output=False)
 
     if np.any(csgraph.data < 0):
-        warnings.warn("Graph has negative weights: dijkstra will give "
-                      "inaccurate results if the graph contains negative "
-                      "cycles. Consider johnson or bellman_ford.")
+        raise ValueError("Dijkstra's algorithm does not support negative "
+                         "edge weights. Use bellman_ford or johnson.")
 
     N = csgraph.shape[0]
 

--- a/scipy/sparse/csgraph/tests/test_shortest_path.py
+++ b/scipy/sparse/csgraph/tests/test_shortest_path.py
@@ -384,6 +384,15 @@ def test_negative_weights(method):
     assert_allclose(SP, directed_negative_weighted_SP, atol=1e-10)
 
 
+def test_dijkstra_negative_weights():
+    msg = "does not support negative edge weights"
+    with assert_raises(ValueError, match=msg):
+        dijkstra(directed_negative_weighted_G, directed=True)
+    with assert_raises(ValueError, match=msg):
+        shortest_path(directed_negative_weighted_G, method='D',
+                      directed=True)
+
+
 def test_masked_input():
     np.ma.masked_equal(directed_G, 0)
 


### PR DESCRIPTION

#### Reference issue  
Closes #13488

#### What does this implement/fix?  

The following changes are made:

 - `dijkstra` now raises ValueError instead of a warning if the input graph contains a negative weight
 - A unit test is added to test the behavior
 - The document now clearly states that `dijkstra` does not support negative **edges**


This is done because the Dijkstra's algorithm inherently does not support negative weights (even if there are no negative cycles).
 - #13488 provides a counterexample where the function returns incorrect distance matrix with such a graph.
 - The following literature states that Dijkstra's algorithm is "restricted to nonnegative edge weights".
The existence of this paper even implies that no algorithm is known for single-source shortest path on graphs with negative weights that runs as fast as $O((|E| + |V|) \log (|V|))$ (the same complexity as Dijkstra's algorithm). 
  `Bernstein, A., Nanongkai, D., & Wulff-Nilsen, C. (2025). Negative-weight single-source shortest paths in near-linear time. Journal of the ACM, 72(4), 1-34.`

#### Additional information  

This affects the behavior existing code.  
However, I believe the effect is minimal because the function did not produce meaningful results for graphs with negative weights in the first place.


#### AI Generation Disclosure  
I used Codex (GPT 5.5) to write the draft of the changes (incl. tests).  
I carefully reviewed and fixed the code when necessary.



