### PR TITLE
BUG: fix two 1.18.0 regressions: linalg.eig non-contiguous eigenvectors and BivariateSpline scalar output shape

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1407,8 +1407,12 @@ class _BivariateSplineBase:
         >>> ax2.imshow(zdata_interp)
         >>> plt.show()
         """
-        x = np.atleast_1d(np.asarray(x))
-        y = np.atleast_1d(np.asarray(y))
+        x = np.asarray(x)
+        y = np.asarray(y)
+        _orig_shape_x = x.shape
+        _orig_shape_y = y.shape
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
 
         tx, ty, c = self.tck[:3]
         kx, ky = self.degrees
@@ -1434,7 +1438,7 @@ class _BivariateSplineBase:
             if x.shape != y.shape:
                 x, y = np.broadcast_arrays(x, y)
 
-            shape = x.shape
+            shape = np.broadcast_shapes(_orig_shape_x, _orig_shape_y)
             x = x.ravel()
             y = y.ravel()
             if x.size == 0 or y.size == 0:

--- a/scipy/linalg/_decomp.py
+++ b/scipy/linalg/_decomp.py
@@ -295,9 +295,9 @@ def eig(a, b=None, left=False, right=True, overwrite_a=False,
     a_is_real = a1.dtype in (np.float32, np.float64)
     if a_is_real and (w.imag == 0).all():
         if left:
-            vl = vl.real
+            vl = np.asfortranarray(vl.real)
         if right:
-            vr = vr.real
+            vr = np.asfortranarray(vr.real)
 
     if not (left or right):
         return w


### PR DESCRIPTION
## Summary

Fixes two 1.18.0 regressions reported in #25477 and #25471.

---

### Fix 1: `linalg.eig` returns non-F-contiguous eigenvector arrays (closes #25477)

**File:** `scipy/linalg/_decomp.py`

**Root cause:** In 1.18.0 the real-matrix code path was refactored to use `_batched_linalg._eig`, which returns complex arrays. The backwards-compat block that converts them to real does:

```python
vr = vr.real   # .real on a complex array is a strided VIEW, not a copy
```

`.real` returns a non-owning, non-F-contiguous view (strides skip the imaginary part). Prior to 1.18.0 LAPACK's `dgeev` path returned an owned F-contiguous real array, so this is a regression.

**Fix:** Replace `.real` with `np.asfortranarray(.real)` to restore an owned, F-contiguous real array:

```python
vl = np.asfortranarray(vl.real)
vr = np.asfortranarray(vr.real)
```

**Reproducer (from #25477):**
```python
import numpy as np
from scipy import linalg
a = np.array([[0., -1.], [1., 0.]])
_, M = linalg.eig(a)
assert M.flags["F_CONTIGUOUS"]  # fails in 1.18.0, passes after fix
assert M.flags["OWNDATA"]        # fails in 1.18.0, passes after fix
```

---

### Fix 2: `BivariateSpline.__call__` returns shape `(1,)` for scalar inputs with `grid=False` (closes #25471)

**File:** `scipy/interpolate/_fitpack2.py`

**Root cause:** `__call__` applies `np.atleast_1d` to both inputs at lines 1410-1411 before entering the `grid=True`/`grid=False` branch. In the `grid=False` path, `shape = x.shape` is then captured from the post-`atleast_1d` array, so a scalar input (shape `()`) becomes shape `(1,)` — the output array is reshaped to `(1,)` instead of `()`.

**Fix:** Capture the original input shapes before `atleast_1d`, then use `np.broadcast_shapes(_orig_shape_x, _orig_shape_y)` to compute the output shape:

```python
x = np.asarray(x)
y = np.asarray(y)
_orig_shape_x = x.shape
_orig_shape_y = y.shape
x = np.atleast_1d(x)
y = np.atleast_1d(y)
...
# in grid=False branch:
shape = np.broadcast_shapes(_orig_shape_x, _orig_shape_y)
```

**Reproducer (from #25471):**
```python
import numpy as np
from scipy.interpolate import RectBivariateSpline
x = y = np.linspace(0, 1, 5)
z = np.outer(x, y)
rbs = RectBivariateSpline(x, y, z)
result = rbs(0.5, 0.5, grid=False)
assert result.shape == ()   # was (1,) in 1.18.0
```