### PR TITLE
BUG: interpolate: coerce non-contiguous input in surfit wrappers

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -132,16 +132,18 @@ def _surfit_smth(x, y, z, w, xb, xe, yb, ye, kx, ky, s, eps):
     Wrapper for surfit with iopt=0 (smoothing spline).
     Returns: nx, tx, ny, ty, c, fp, ier
     """
-    x = np.asarray(x, dtype=np.float64)
-    y = np.asarray(y, dtype=np.float64)
-    z = np.asarray(z, dtype=np.float64)
+    # The C binding (_fitpack.surfit_smth) reads these buffers assuming
+    # C-contiguity; coerce strided views.
+    x = np.ascontiguousarray(x, dtype=np.float64)
+    y = np.ascontiguousarray(y, dtype=np.float64)
+    z = np.ascontiguousarray(z, dtype=np.float64)
     m = len(x)
 
     # Handle None w value (default equal weights)
     if w is None:
         w = np.ones(m, dtype=np.float64)
     else:
-        w = np.asarray(w, dtype=np.float64)
+        w = np.ascontiguousarray(w, dtype=np.float64)
 
     # Handle None bbox values (matching f2py behavior: xb=dmin(x,m), etc.)
     if xb is None:
@@ -176,15 +178,17 @@ def _surfit_lsq(x, y, z, nx, tx, ny, ty, w, xb, xe, yb, ye, kx, ky, eps):
     Wrapper for surfit with iopt=-1 (least squares fit with fixed knots).
     Returns: tx, ty, c, fp, ier
     """
-    x = np.asarray(x, dtype=np.float64)
-    y = np.asarray(y, dtype=np.float64)
-    z = np.asarray(z, dtype=np.float64)
+    # The C binding (_fitpack.surfit_lsq) reads these buffers assuming
+    # C-contiguity; coerce strided views.
+    x = np.ascontiguousarray(x, dtype=np.float64)
+    y = np.ascontiguousarray(y, dtype=np.float64)
+    z = np.ascontiguousarray(z, dtype=np.float64)
     m = len(x)
 
     if w is None:
         w = np.ones(m, dtype=np.float64)
     else:
-        w = np.asarray(w, dtype=np.float64, copy=True)
+        w = np.ascontiguousarray(w, dtype=np.float64)
 
     tx = np.asarray(tx, dtype=np.float64, copy=True)
     ty = np.asarray(ty, dtype=np.float64, copy=True)

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -143,7 +143,7 @@ def _surfit_smth(x, y, z, w, xb, xe, yb, ye, kx, ky, s, eps):
     if w is None:
         w = np.ones(m, dtype=np.float64)
     else:
-        w = np.ascontiguousarray(w, dtype=np.float64)
+        w = np.asarray(w, dtype=np.float64, copy=True, order="C")
 
     # Handle None bbox values (matching f2py behavior: xb=dmin(x,m), etc.)
     if xb is None:
@@ -188,10 +188,10 @@ def _surfit_lsq(x, y, z, nx, tx, ny, ty, w, xb, xe, yb, ye, kx, ky, eps):
     if w is None:
         w = np.ones(m, dtype=np.float64)
     else:
-        w = np.ascontiguousarray(w, dtype=np.float64)
+        w = np.asarray(w, dtype=np.float64, copy=True, order="C")
 
-    tx = np.asarray(tx, dtype=np.float64, copy=True)
-    ty = np.asarray(ty, dtype=np.float64, copy=True)
+    tx = np.asarray(tx, dtype=np.float64, copy=True, order="C")
+    ty = np.asarray(ty, dtype=np.float64, copy=True, order="C")
 
     nxest = nx
     nyest = ny
@@ -299,8 +299,8 @@ def _spherfit_lsq(theta, phi, r, nt, tt, np_, tp, w, eps):
     theta = np.asarray(theta, dtype=np.float64)
     phi = np.asarray(phi, dtype=np.float64)
     r = np.asarray(r, dtype=np.float64)
-    tt = np.asarray(tt, dtype=np.float64, copy=True)
-    tp = np.asarray(tp, dtype=np.float64, copy=True)
+    tt = np.asarray(tt, dtype=np.float64, copy=True, order="C")
+    tp = np.asarray(tp, dtype=np.float64, copy=True, order="C")
     if w is None:
         w = np.ones(len(theta), dtype=np.float64)
     else:

--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -143,7 +143,7 @@ def _surfit_smth(x, y, z, w, xb, xe, yb, ye, kx, ky, s, eps):
     if w is None:
         w = np.ones(m, dtype=np.float64)
     else:
-        w = np.asarray(w, dtype=np.float64, copy=True, order="C")
+        w = np.asarray(w, dtype=np.float64, copy=True)
 
     # Handle None bbox values (matching f2py behavior: xb=dmin(x,m), etc.)
     if xb is None:
@@ -188,10 +188,10 @@ def _surfit_lsq(x, y, z, nx, tx, ny, ty, w, xb, xe, yb, ye, kx, ky, eps):
     if w is None:
         w = np.ones(m, dtype=np.float64)
     else:
-        w = np.asarray(w, dtype=np.float64, copy=True, order="C")
+        w = np.asarray(w, dtype=np.float64, copy=True)
 
-    tx = np.asarray(tx, dtype=np.float64, copy=True, order="C")
-    ty = np.asarray(ty, dtype=np.float64, copy=True, order="C")
+    tx = np.asarray(tx, dtype=np.float64, copy=True)
+    ty = np.asarray(ty, dtype=np.float64, copy=True)
 
     nxest = nx
     nyest = ny
@@ -299,8 +299,8 @@ def _spherfit_lsq(theta, phi, r, nt, tt, np_, tp, w, eps):
     theta = np.asarray(theta, dtype=np.float64)
     phi = np.asarray(phi, dtype=np.float64)
     r = np.asarray(r, dtype=np.float64)
-    tt = np.asarray(tt, dtype=np.float64, copy=True, order="C")
-    tp = np.asarray(tp, dtype=np.float64, copy=True, order="C")
+    tt = np.asarray(tt, dtype=np.float64, copy=True)
+    tp = np.asarray(tp, dtype=np.float64, copy=True)
     if w is None:
         w = np.ones(len(theta), dtype=np.float64)
     else:

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -617,22 +617,6 @@ class TestLSQBivariateSpline:
 
         assert_almost_equal(lut(x, y, grid=False), z)
 
-    def test_noncontiguous_input(self):
-        # Regression test: non-contiguous x/y/z (e.g. column views) must give
-        # the same fit as contiguous copies. The C surfit_lsq binding reads the
-        # buffers assuming C-contiguity, so strided views were misread.
-        rng = np.random.default_rng(0)
-        src = rng.uniform(-5, 5, (400, 2))          # (N, 2) C-contiguous
-        z = src[:, 0] ** 2 + src[:, 1]
-        tx = ty = np.linspace(-4, 4, 3)
-
-        x, y = src[:, 0], src[:, 1]
-        assert not x.flags['C_CONTIGUOUS']          # guard the precondition
-        strided = LSQBivariateSpline(x, y, z, tx, ty, kx=2, ky=2)
-        contig = LSQBivariateSpline(x.copy(), y.copy(), z, tx, ty, kx=2, ky=2)
-
-        xp_assert_close(strided(x, y, grid=False), contig(x, y, grid=False))
-
 
 class TestSmoothBivariateSpline:
     def test_linear_constant(self):
@@ -762,20 +746,91 @@ class TestSmoothBivariateSpline:
                                      kx=1, ky=1)
         xp_assert_close(spl1(0.1, 0.5), spl2(0.1, 0.5))
 
-    def test_noncontiguous_input(self):
-        # Regression test: non-contiguous x/y/z (e.g. column views) must give
-        # the same fit as contiguous copies. The C surfit_smth binding reads the
-        # buffers assuming C-contiguity, so strided views were misread.
-        rng = np.random.default_rng(0)
-        src = rng.uniform(-5, 5, (400, 2))
-        z = src[:, 0] ** 2 + src[:, 1]
 
-        x, y = src[:, 0], src[:, 1]
-        assert not x.flags['C_CONTIGUOUS']
-        strided = SmoothBivariateSpline(x, y, z, kx=2, ky=2)
-        contig = SmoothBivariateSpline(x.copy(), y.copy(), z, kx=2, ky=2)
+def _contiguous(a):
+    """C-contiguous reference layout."""
+    return np.ascontiguousarray(a, dtype=np.float64)
 
-        xp_assert_close(strided(x, y, grid=False), contig(x, y, grid=False))
+
+def _strided(a):
+    """Return a non-contiguous view of `a`, interleaved with NaN. A read that
+    wrongly assumes C-contiguity picks up a NaN; a correct strided read does
+    not."""
+    a = np.asarray(a, dtype=np.float64)
+    v = np.stack([a, np.full_like(a, np.nan)], axis=-1)[..., 0]
+    assert not v.flags["C_CONTIGUOUS"]
+    return v
+
+
+# Builders for the non-contiguous-input sweep below. Each applies `prep` to
+# every array input and returns the fit evaluated at fixed points (flattened).
+# Data is regenerated identically per call (fixed seed) so the only difference
+# between two calls is `prep`.
+def _scattered_data():
+    rng = np.random.default_rng(0)
+    src = rng.uniform(-5, 5, (400, 2))
+    x, y = src[:, 0].copy(), src[:, 1].copy()
+    return x, y, x ** 2 + y
+
+
+def _sphere_scattered_data():
+    rng = np.random.default_rng(0)
+    theta = rng.uniform(0.1, np.pi - 0.1, 200)
+    phi = rng.uniform(0.1, 2 * np.pi - 0.1, 200)
+    return theta, phi, np.sin(theta) * np.cos(phi)
+
+
+def _fit_smooth_bivariate(prep):
+    x, y, z = _scattered_data()
+    return SmoothBivariateSpline(prep(x), prep(y), prep(z), kx=2, ky=2).ev(x, y)
+
+
+def _fit_lsq_bivariate(prep):
+    x, y, z = _scattered_data()
+    t = np.linspace(-4, 4, 3)
+    return LSQBivariateSpline(prep(x), prep(y), prep(z), prep(t), prep(t),
+                              kx=2, ky=2).ev(x, y)
+
+
+def _fit_rect_bivariate(prep):
+    gx, gy = np.linspace(0, 1, 12), np.linspace(0, 1, 14)
+    gz = np.sin(gx[:, None]) * np.cos(gy[None, :])
+    spl = RectBivariateSpline(prep(gx), prep(gy), prep(gz))
+    return spl(np.linspace(0.1, 0.9, 5), np.linspace(0.1, 0.9, 5)).ravel()
+
+
+def _fit_smooth_sphere(prep):
+    theta, phi, r = _sphere_scattered_data()
+    spl = SmoothSphereBivariateSpline(prep(theta), prep(phi), prep(r), s=2.0)
+    return spl.ev(theta, phi)
+
+
+def _fit_lsq_sphere(prep):
+    theta, phi, r = _sphere_scattered_data()
+    tt = np.linspace(0, np.pi, 5)[1:-1]
+    tp = np.linspace(0, 2 * np.pi, 5)[1:-1]
+    return LSQSphereBivariateSpline(prep(theta), prep(phi), prep(r),
+                                    prep(tt), prep(tp)).ev(theta, phi)
+
+
+def _fit_rect_sphere(prep):
+    u = np.linspace(0, np.pi, 14)[1:-1]
+    v = np.linspace(0, 2 * np.pi, 14, endpoint=False)
+    rg = np.sin(u[:, None]) * np.cos(v[None, :])
+    return RectSphereBivariateSpline(prep(u), prep(v), prep(rg))(u, v).ravel()
+
+
+@pytest.mark.parametrize("fit", [
+    pytest.param(_fit_smooth_bivariate, id="SmoothBivariateSpline"),
+    pytest.param(_fit_lsq_bivariate, id="LSQBivariateSpline"),
+    pytest.param(_fit_rect_bivariate, id="RectBivariateSpline"),
+    pytest.param(_fit_smooth_sphere, id="SmoothSphereBivariateSpline"),
+    pytest.param(_fit_lsq_sphere, id="LSQSphereBivariateSpline"),
+    pytest.param(_fit_rect_sphere, id="RectSphereBivariateSpline"),
+])
+def test_bivariate_spline_noncontiguous_input(fit):
+    # The FITPACK C bindings read x/y/z/w buffers assuming C-contiguity.
+    xp_assert_close(fit(_strided), fit(_contiguous))
 
 
 class TestLSQSphereBivariateSpline:

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -617,6 +617,22 @@ class TestLSQBivariateSpline:
 
         assert_almost_equal(lut(x, y, grid=False), z)
 
+    def test_noncontiguous_input(self):
+        # Regression test: non-contiguous x/y/z (e.g. column views) must give
+        # the same fit as contiguous copies. The C surfit_lsq binding reads the
+        # buffers assuming C-contiguity, so strided views were misread.
+        rng = np.random.default_rng(0)
+        src = rng.uniform(-5, 5, (400, 2))          # (N, 2) C-contiguous
+        z = src[:, 0] ** 2 + src[:, 1]
+        tx = ty = np.linspace(-4, 4, 3)
+
+        x, y = src[:, 0], src[:, 1]
+        assert not x.flags['C_CONTIGUOUS']          # guard the precondition
+        strided = LSQBivariateSpline(x, y, z, tx, ty, kx=2, ky=2)
+        contig = LSQBivariateSpline(x.copy(), y.copy(), z, tx, ty, kx=2, ky=2)
+
+        xp_assert_close(strided(x, y, grid=False), contig(x, y, grid=False))
+
 
 class TestSmoothBivariateSpline:
     def test_linear_constant(self):
@@ -745,6 +761,21 @@ class TestSmoothBivariateSpline:
                                      bbox=bbox.tolist(), w=w.tolist(),
                                      kx=1, ky=1)
         xp_assert_close(spl1(0.1, 0.5), spl2(0.1, 0.5))
+
+    def test_noncontiguous_input(self):
+        # Regression test: non-contiguous x/y/z (e.g. column views) must give
+        # the same fit as contiguous copies. The C surfit_smth binding reads the
+        # buffers assuming C-contiguity, so strided views were misread.
+        rng = np.random.default_rng(0)
+        src = rng.uniform(-5, 5, (400, 2))
+        z = src[:, 0] ** 2 + src[:, 1]
+
+        x, y = src[:, 0], src[:, 1]
+        assert not x.flags['C_CONTIGUOUS']
+        strided = SmoothBivariateSpline(x, y, z, kx=2, ky=2)
+        contig = SmoothBivariateSpline(x.copy(), y.copy(), z, kx=2, ky=2)
+
+        xp_assert_close(strided(x, y, grid=False), contig(x, y, grid=False))
 
 
 class TestLSQSphereBivariateSpline:


### PR DESCRIPTION
#### Reference issue

No existing issue could be found.

#### What does this implement/fix?

`LSQBivariateSpline` (and `SmoothBivariateSpline`) silently return a wrong or singular fit when their `x`/`y`/`z`/`w` inputs are non-C-contiguous — e.g. a column view `arr[:, 0]` of an `(N, 2)` array. No exception is raised; the result is just garbage. This is a regression introduced by the 1.18.0 FITPACK C port (correct in 1.17.x, where the f2py wrappers copied strided inputs).

Fix: coerce the buffers with `np.ascontiguousarray` in both wrappers.

Minimal reproduction (on 1.18.0):

```python
import numpy as np
from scipy.interpolate import LSQBivariateSpline

rng = np.random.default_rng(0)
src = rng.uniform(-5, 5, (400, 2))          # (N, 2) C-contiguous
z = src[:, 0] ** 2 + src[:, 1]
tx = ty = np.linspace(-4, 4, 3)

strided = LSQBivariateSpline(src[:, 0],        src[:, 1],        z, tx, ty, kx=2, ky=2)
contig  = LSQBivariateSpline(src[:, 0].copy(), src[:, 1].copy(), z, tx, ty, kx=2, ky=2)

rms = lambda s: np.sqrt(np.mean((s.ev(src[:, 0], src[:, 1]) - z) ** 2))
print('strided:', rms(strided), 'contiguous:', rms(contig))
# 1.17.x: equal (both correct);  1.18.0: strided is garbage, contiguous correct
```

#### Additional information

Regression tests are added to `TestLSQBivariateSpline` and `TestSmoothBivariateSpline` in `test_fitpack2.py`, each asserting that a strided-view fit matches a contiguous-copy fit (with a `C_CONTIGUOUS` precondition guard). Verified against released scipy 1.18.0: both tests fail unpatched and pass with this change applied.

#### AI Generation Disclosure

Claude Code (Anthropic, Opus 4.8) was used to investigate the root cause, write
the fix in `scipy/interpolate/_fitpack2.py` and the regression tests in
`scipy/interpolate/tests/test_fitpack2.py`. All AI-generated code and text were reviewed by the author.