### PR TITLE
ENH: allow array_namespace(list, torch_tensor) -> torch_tensor

### DIFF
--- a/scipy/_lib/_array_api_override.py
+++ b/scipy/_lib/_array_api_override.py
@@ -137,14 +137,17 @@ def array_namespace(*arrays: Array, sparse_ok=False) -> ModuleType:
         else:
             # list, tuple, or arbitrary object
             try:
-                array = np.asanyarray(array)
+                array_ = np.asanyarray(array)
             except TypeError:
                 raise TypeError("An argument is neither array API compatible nor "
                                 "coercible by NumPy.")
-            if array.dtype.kind not in 'iufcb':  # Numeric or bool
-                raise TypeError(f"An argument has dtype `{array.dtype!r}`; "
+            if array_.dtype.kind not in 'iufcb':  # Numeric or bool
+                raise TypeError(f"An argument has dtype `{array_.dtype!r}`; "
                                 "only boolean and numerical dtypes are supported.")
-            numpy_arrays.append(array)
+
+            # special case: lists/tuples follow other array arguments
+            if not isinstance(array, list | tuple):
+                numpy_arrays.append(array_)
 
     # When there are exclusively NumPy and ArrayLikes, skip calling
     # array_api_compat.array_namespace for performance.

--- a/scipy/_lib/tests/test_array_api.py
+++ b/scipy/_lib/tests/test_array_api.py
@@ -83,12 +83,11 @@ class TestArrayAPI:
         assert array_namespace(x, 1) is xp
         assert array_namespace(1, x) is xp
         assert array_namespace(None, x) is xp
+        assert array_namespace(x, [1, 2]) is xp
 
         if is_numpy(xp):
             assert array_namespace(x, [1, 2]) is xp
         else:
-            with pytest.raises(TypeError, match="Multiple namespaces"):
-                array_namespace(x, [1, 2])
             with pytest.raises(TypeError, match="Multiple namespaces"):
                 array_namespace(x, np.int64(1))
             with pytest.raises(TypeError, match="Multiple namespaces"):


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

cf https://github.com/scipy/scipy/issues/24959 for a general discussion and https://github.com/scipy/scipy/pull/25359#issuecomment-4780040232 for a specific use case

#### What does this implement/fix?
<!--Please explain your changes.-->

Currently, `array_namespace` treats `array_like` as numpy objects. Thus,

- `array_namespace(numpy_array, list) -> numpy`
- `array_namespace(list, list) -> numpy`
- `array_namespace(list, torch_tensor) -> error ` (Multiple namespaces) 

This makes lists differ from python scalars, which do not participate in namespace deduction:

- `array_namespace(xp_array, py_scalar) -> xp`

This PR is an experiment to make lists and tuples behave (almost) the same way python scalars do:

- `array_namespace(xp_array, list) -> xp`

Two lists still combine into numpy:

- `array_namespace(list, list) -> numpy`


#### Additional information
<!--Any additional information you think is important.-->

This PR is mainly a demo; let's keep the discussion in gh-24959.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.