### PR TITLE
BUG: optimize: report cobyqa callback StopIteration as unsuccessful

### DIFF
--- a/scipy/optimize/_cobyqa_py.py
+++ b/scipy/optimize/_cobyqa_py.py
@@ -65,4 +65,14 @@ def _minimize_cobyqa(fun, x0, args=(), bounds=None, constraints=(),
         'radius_final': float(final_tr_radius),
         'scale': bool(scale),
     }
-    return _cobyqa_minimize(fun, x0, args, bounds, constraints, callback, options)
+    res = _cobyqa_minimize(fun, x0, args, bounds, constraints, callback,
+                           options)
+
+    # COBYQA reports a callback-requested stop (``status == 3``) as a
+    # successful termination. For consistency with the other `minimize`
+    # methods, which treat the `callback` raising ``StopIteration`` as an
+    # unsuccessful termination, override `success` accordingly. See gh-23660.
+    if res.status == 3:
+        res.success = False
+
+    return res

--- a/scipy/optimize/tests/test_cobyqa.py
+++ b/scipy/optimize/tests/test_cobyqa.py
@@ -228,6 +228,29 @@ class TestCOBYQA:
         assert not sol.success, sol.message
         assert sol.nit <= 2, sol
 
+    def test_minimize_callback_stop_iteration(self):
+        # A `callback` raising `StopIteration` should be reported as an
+        # unsuccessful termination, consistently with the other `minimize`
+        # methods (gh-23660).
+        def callback(x):
+            raise StopIteration
+
+        def callback_new_syntax(intermediate_result):
+            raise StopIteration
+
+        constraints = NonlinearConstraint(self.con, 0.0, 0.0)
+        for cb in (callback, callback_new_syntax):
+            sol = minimize(
+                self.fun,
+                self.x0,
+                method='cobyqa',
+                constraints=constraints,
+                callback=cb,
+                options=self.options,
+            )
+            assert not sol.success, sol.message
+            assert sol.status == 3, sol
+
     def test_minimize_f_target(self):
         constraints = NonlinearConstraint(self.con, 0.0, 0.0)
         sol_ref = minimize(


### PR DESCRIPTION
#### Reference issue
Closes gh-23660.

#### What does this implement/fix?
COBYQA reports a `callback`-requested stop (`status == 3`) as a *successful*
termination. This is inconsistent with the other `minimize` methods, where a
`callback` raising `StopIteration` is treated as an *unsuccessful* termination.

This overrides `success` to `False` when COBYQA returns `status == 3`, so the
behavior matches the other methods, and adds a regression test covering both
the old (`callback(x)`) and new (`callback(intermediate_result)`) signatures.

#### Additional information
This re-opens the change from gh-25449, which was closed for a missing AI
declaration; the PR template is now filled in.

#### AI Generation Disclosure
Claude Code (Anthropic) was used to help develop the fix in
`scipy/optimize/_cobyqa_py.py` and the accompanying test in
`scipy/optimize/tests/test_cobyqa.py`. The changes were reviewed and verified
by me before submission.
