### PR TITLE
ENH: add internal LSQ constructor for NdBSpline

### DIFF
--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -486,6 +486,18 @@ def _make_lsq_ndbspl(
 
     where ``A`` is the sparse tensor-product B-spline design matrix built by
     `NdBSpline.design_matrix` and ``W`` is a diagonal matrix of weights.
+
+    The default solver is `scipy.sparse.linalg.lsqr`. The related
+    `scipy.sparse.linalg.lsmr` solver has the same basic interface and can be
+    useful as a comparison when convergence depends on the conditioning of the
+    least-squares problem or on the selected tolerances. Solver tolerances are
+    not modified by this helper; pass them explicitly through `solver_args` if
+    the solver defaults are not appropriate.
+
+    Other least-squares estimators can be used through a small wrapper, as long
+    as the wrapper accepts a sparse matrix ``A`` and a one-dimensional
+    right-hand side ``b`` and returns coefficients in ``result[0]`` and a
+    success status in ``result[1]``.
     """
     x = np.asarray(x, dtype=float)
     if x.ndim != 2:

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -9,7 +9,7 @@ from types import GenericAlias
 from . import _dierckx  # type: ignore[attr-defined]
 
 import scipy.sparse.linalg as ssl
-from scipy.sparse import csr_array
+from scipy.sparse import csr_array, diags_array
 from scipy._lib._array_api import array_namespace, xp_capabilities
 
 from ._bsplines import _not_a_knot, BSpline
@@ -446,16 +446,58 @@ def _make_lsq_ndbspl(
 ):
     """Construct a least-squares ``NdBSpline`` from scattered data.
 
-    This is an internal construction helper. The knot vectors are expected to
-    be full knot vectors, including any repeated boundary knots.
+    Parameters
+    ----------
+    x : array_like, shape (npts, ndim)
+        Data point coordinates. Each row gives one point in ``ndim``
+        dimensions.
+    y : array_like, shape (npts, ...)
+        Data values at `x`. Any trailing dimensions are treated as batch
+        dimensions and fitted with the same design matrix.
+    t : tuple of array_like, shape (nt_i,)
+        Full knot vectors for each dimension. Boundary knots must already be
+        included.
+    k : int or tuple of int, optional
+        Spline degree for each dimension. A scalar value is applied to all
+        dimensions. Default is cubic, ``k=3``.
+    w : array_like, shape (npts,), optional
+        Positive weights for weighted least squares.
+    solver : callable, optional
+        Sparse least-squares solver. Default is `scipy.sparse.linalg.lsqr`.
+        The solver is called as ``solver(A, b, **solver_args)``, where
+        ``A`` is the sparse design matrix with shape ``(npts, ncoeffs)`` and
+        ``b`` is a 1D right-hand side with shape ``(npts,)``. It must return
+        the same result format as `scipy.sparse.linalg.lsqr` and
+        `scipy.sparse.linalg.lsmr`: the fitted coefficients are read from
+        ``result[0]`` and the convergence status from ``result[1]``.
+    **solver_args
+        Additional keyword arguments passed to `solver`.
+
+    Returns
+    -------
+    spl : NdBSpline
+        Tensor-product spline with coefficients fitted by least squares.
+
+    Notes
+    -----
+    This solves the sparse least-squares problem
+
+    ``min_c || W @ (A @ c - y) ||_2``,
+
+    where ``A`` is the sparse tensor-product B-spline design matrix built by
+    `NdBSpline.design_matrix` and ``W`` is a diagonal matrix of weights.
     """
     x = np.asarray(x, dtype=float)
     if x.ndim != 2:
         raise ValueError("`x` must be a 2D array with shape (npts, ndim).")
+    if not np.isfinite(x).all():
+        raise ValueError("`x` must contain only finite values.")
 
     npts, ndim = x.shape
     if npts == 0:
         raise ValueError("`x` must contain at least one data point.")
+    if not callable(solver):
+        raise ValueError("`solver` must be callable.")
 
     if not isinstance(t, tuple):
         raise ValueError(
@@ -470,6 +512,10 @@ def _make_lsq_ndbspl(
     y = np.asarray(y)
     if y.ndim == 0 or y.shape[0] != npts:
         raise ValueError("`y` must have shape (npts, ...) matching `x`.")
+    if 0 in y.shape[1:]:
+        raise ValueError("`y` must not have empty trailing dimensions.")
+    if not np.isfinite(y).all():
+        raise ValueError("`y` must contain only finite values.")
 
     k, _, (_t, len_t) = _preprocess_inputs(k, t)
     t = tuple(np.asarray(t[d], dtype=float) for d in range(ndim))
@@ -486,21 +532,27 @@ def _make_lsq_ndbspl(
     _check_lsq_design_matrix(matr, ncoeff)
 
     y_shape = y.shape
-    rhs = y.reshape((npts, prod(y_shape[1:])))
+    y_trailing_shape = y_shape[1:]
+    rhs = y.reshape((npts, prod(y_trailing_shape)))
     if w is not None:
         w = _validate_lsq_weights(w, npts)
-        matr = matr.multiply(w[:, None])
+        matr = diags_array(w, format="csr") @ matr
         rhs = rhs * w[:, None]
 
     if solver is ssl.lsqr or solver is ssl.lsmr:
         solver_args.setdefault("atol", 1e-12)
         solver_args.setdefault("btol", 1e-12)
 
-    coef = _lsq_iter_solve(matr, rhs, solver=solver, **solver_args)
-    if y.ndim == 1:
-        coef = coef[:, 0].reshape(coeff_shape)
-    else:
-        coef = coef.reshape(coeff_shape + y_shape[1:])
+    coef = []
+    for j in range(rhs.shape[1]):
+        result = solver(matr, rhs[:, j], **solver_args)
+        coef_j, istop = result[0], result[1]
+        if istop not in {1, 2}:
+            raise ValueError(f"{solver = } returns {istop = }.")
+        coef.append(coef_j)
+
+    coef = np.column_stack(coef)
+    coef = coef.reshape(coeff_shape + y_trailing_shape)
 
     return NdBSpline(t, coef, tuple(k))
 
@@ -529,30 +581,6 @@ def _check_lsq_design_matrix(matr, ncoeff):
         raise ValueError(
             "Data points do not support every tensor-product basis function."
         )
-
-
-def _lsq_iter_solve(a, b, solver=ssl.lsqr, **solver_args):
-    """Solve a sparse least-squares problem column by column."""
-    if np.issubdtype(b.dtype, np.complexfloating):
-        real = _lsq_iter_solve(a, b.real, solver=solver, **solver_args)
-        imag = _lsq_iter_solve(a, b.imag, solver=solver, **solver_args)
-        return real + 1j * imag
-
-    if b.ndim == 2 and b.shape[1] != 1:
-        dtype = _get_dtype(b.dtype)
-        res = np.empty((a.shape[1], b.shape[1]), dtype=dtype)
-        for j in range(b.shape[1]):
-            res[:, j] = _lsq_iter_solve(
-                a, b[:, j], solver=solver, **solver_args
-            )[:, 0]
-        return res
-
-    b = b.ravel()
-    result = solver(a, b, **solver_args)
-    coef, istop = result[0], result[1]
-    if istop not in {1, 2}:
-        raise ValueError(f"{solver = } returns {istop = }.")
-    return coef[:, None]
 
 
 def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -457,11 +457,11 @@ def _make_lsq_ndbspl(
     t : tuple of array_like, shape (nt_i,)
         Full knot vectors for each dimension. Boundary knots must already be
         included.
-    k : int or tuple of int, optional
+    k : int or array_like, shape (ndim,), optional
         Spline degree for each dimension. A scalar value is applied to all
         dimensions. Default is cubic, ``k=3``.
     w : array_like, shape (npts,), optional
-        Positive weights for weighted least squares.
+        Non-negative weights for weighted least squares.
     solver : callable, optional
         Sparse least-squares solver. Default is `scipy.sparse.linalg.lsqr`.
         The solver is called as ``solver(A, b, **solver_args)``, where
@@ -529,7 +529,6 @@ def _make_lsq_ndbspl(
 
     matr = NdBSpline.design_matrix(x, t, tuple(k), extrapolate=False)
     matr.eliminate_zeros()
-    _check_lsq_design_matrix(matr, ncoeff)
 
     y_shape = y.shape
     y_trailing_shape = y_shape[1:]
@@ -537,11 +536,10 @@ def _make_lsq_ndbspl(
     if w is not None:
         w = _validate_lsq_weights(w, npts)
         matr = diags_array(w, format="csr") @ matr
+        matr.eliminate_zeros()
         rhs = rhs * w[:, None]
 
-    if solver is ssl.lsqr or solver is ssl.lsmr:
-        solver_args.setdefault("atol", 1e-12)
-        solver_args.setdefault("btol", 1e-12)
+    _check_lsq_design_matrix(matr, ncoeff)
 
     coef = []
     for j in range(rhs.shape[1]):
@@ -562,8 +560,8 @@ def _validate_lsq_weights(w, npts):
     w = np.asarray(w, dtype=float)
     if w.ndim != 1 or w.shape[0] != npts:
         raise ValueError("`w` must be a 1D array with shape (npts,).")
-    if np.any(w <= 0):
-        raise ValueError("`w` must contain only positive values.")
+    if np.any(w < 0):
+        raise ValueError("`w` must contain only non-negative values.")
     if not np.isfinite(w).all():
         raise ValueError("`w` must contain only finite values.")
     return w

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -441,6 +441,120 @@ def _iter_solve(a, b, solver=ssl.gcrotmk, **solver_args):
         return res
 
 
+def _make_lsq_ndbspl(
+    x, y, t, k=3, *, w=None, solver=ssl.lsqr, **solver_args
+):
+    """Construct a least-squares ``NdBSpline`` from scattered data.
+
+    This is an internal construction helper. The knot vectors are expected to
+    be full knot vectors, including any repeated boundary knots.
+    """
+    x = np.asarray(x, dtype=float)
+    if x.ndim != 2:
+        raise ValueError("`x` must be a 2D array with shape (npts, ndim).")
+
+    npts, ndim = x.shape
+    if npts == 0:
+        raise ValueError("`x` must contain at least one data point.")
+
+    if not isinstance(t, tuple):
+        raise ValueError(
+            f"Expect `t` to be a tuple of array-likes. Got {t} instead."
+        )
+    if len(t) != ndim:
+        raise ValueError(
+            f"Data and knots are inconsistent: len(t) = {len(t)} for "
+            f"ndim = {ndim}."
+        )
+
+    y = np.asarray(y)
+    if y.ndim == 0 or y.shape[0] != npts:
+        raise ValueError("`y` must have shape (npts, ...) matching `x`.")
+
+    k, _, (_t, len_t) = _preprocess_inputs(k, t)
+    t = tuple(np.asarray(t[d], dtype=float) for d in range(ndim))
+    coeff_shape = tuple(len_t[d] - k[d] - 1 for d in range(ndim))
+    ncoeff = prod(coeff_shape)
+    if npts < ncoeff:
+        raise ValueError(
+            "There are fewer data points than spline coefficients; the "
+            "least-squares problem is underdetermined."
+        )
+
+    matr = NdBSpline.design_matrix(x, t, tuple(k), extrapolate=False)
+    matr.eliminate_zeros()
+    _check_lsq_design_matrix(matr, ncoeff)
+
+    y_shape = y.shape
+    rhs = y.reshape((npts, prod(y_shape[1:])))
+    if w is not None:
+        w = _validate_lsq_weights(w, npts)
+        matr = matr.multiply(w[:, None])
+        rhs = rhs * w[:, None]
+
+    if solver is ssl.lsqr or solver is ssl.lsmr:
+        solver_args.setdefault("atol", 1e-12)
+        solver_args.setdefault("btol", 1e-12)
+
+    coef = _lsq_iter_solve(matr, rhs, solver=solver, **solver_args)
+    if y.ndim == 1:
+        coef = coef[:, 0].reshape(coeff_shape)
+    else:
+        coef = coef.reshape(coeff_shape + y_shape[1:])
+
+    return NdBSpline(t, coef, tuple(k))
+
+
+def _validate_lsq_weights(w, npts):
+    """Validate least-squares weights."""
+    w = np.asarray(w, dtype=float)
+    if w.ndim != 1 or w.shape[0] != npts:
+        raise ValueError("`w` must be a 1D array with shape (npts,).")
+    if np.any(w <= 0):
+        raise ValueError("`w` must contain only positive values.")
+    if not np.isfinite(w).all():
+        raise ValueError("`w` must contain only finite values.")
+    return w
+
+
+def _check_lsq_design_matrix(matr, ncoeff):
+    """Check that every basis function is supported by the data."""
+    if matr.shape[1] != ncoeff:
+        raise ValueError(
+            "Data points do not support every tensor-product basis function."
+        )
+
+    supported = np.bincount(matr.indices, minlength=ncoeff) > 0
+    if not supported.all():
+        raise ValueError(
+            "Data points do not support every tensor-product basis function."
+        )
+
+
+def _lsq_iter_solve(a, b, solver=ssl.lsqr, **solver_args):
+    """Solve a sparse least-squares problem column by column."""
+    if np.issubdtype(b.dtype, np.complexfloating):
+        real = _lsq_iter_solve(a, b.real, solver=solver, **solver_args)
+        imag = _lsq_iter_solve(a, b.imag, solver=solver, **solver_args)
+        return real + 1j * imag
+
+    if b.ndim == 2 and b.shape[1] != 1:
+        dtype = _get_dtype(b.dtype)
+        res = np.empty((a.shape[1], b.shape[1]), dtype=dtype)
+        for j in range(b.shape[1]):
+            res[:, j] = _lsq_iter_solve(
+                a, b[:, j], solver=solver, **solver_args
+            )[:, 0]
+        return res
+
+    b = b.ravel()
+    result = solver(a, b, **solver_args)
+    coef, istop = result[0], result[1]
+    if istop not in {1, 2}:
+        raise ValueError(f"{solver = } returns {istop = }.")
+    return coef[:, None]
+
+
 def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):
     """Construct an interpolating NdBspline.
 

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -571,12 +571,14 @@ def _validate_lsq_weights(w, npts):
 
 def _check_lsq_design_matrix(matr, ncoeff):
     """Check that every basis function is supported by the data."""
+    ncoeff = operator.index(ncoeff)
     if matr.shape[1] != ncoeff:
         raise ValueError(
             "Data points do not support every tensor-product basis function."
         )
 
-    supported = np.bincount(matr.indices, minlength=ncoeff) > 0
+    indices = np.asarray(matr.indices, dtype=np.intp)
+    supported = np.bincount(indices, minlength=ncoeff) > 0
     if not supported.all():
         raise ValueError(
             "Data points do not support every tensor-product basis function."

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -470,6 +470,9 @@ def _make_lsq_ndbspl(
         the same result format as `scipy.sparse.linalg.lsqr` and
         `scipy.sparse.linalg.lsmr`: the fitted coefficients are read from
         ``result[0]`` and the convergence status from ``result[1]``.
+        Status values ``0``, ``1``, and ``2`` are treated as successful
+        termination, following the conventions of `~scipy.sparse.linalg.lsqr`
+        and `~scipy.sparse.linalg.lsmr`.
     **solver_args
         Additional keyword arguments passed to `solver`.
 
@@ -494,10 +497,11 @@ def _make_lsq_ndbspl(
     not modified by this helper; pass them explicitly through `solver_args` if
     the solver defaults are not appropriate.
 
-    Other least-squares estimators can be used through a small wrapper, as long
-    as the wrapper accepts a sparse matrix ``A`` and a one-dimensional
+    Other least-squares estimators can be used through a small wrapper, as
+    long as the wrapper accepts a sparse matrix ``A`` and a one-dimensional
     right-hand side ``b`` and returns coefficients in ``result[0]`` and a
-    success status in ``result[1]``.
+    status in ``result[1]``. Status values other than ``0``, ``1``, or ``2``
+    are treated as solver failures.
     """
     x = np.asarray(x, dtype=float)
     if x.ndim != 2:
@@ -557,7 +561,7 @@ def _make_lsq_ndbspl(
     for j in range(rhs.shape[1]):
         result = solver(matr, rhs[:, j], **solver_args)
         coef_j, istop = result[0], result[1]
-        if istop not in {1, 2}:
+        if istop not in {0, 1, 2}:
             raise ValueError(f"{solver = } returns {istop = }.")
         coef.append(coef_j)
 
@@ -576,23 +580,27 @@ def _validate_lsq_weights(w, npts):
         raise ValueError("`w` must contain only non-negative values.")
     if not np.isfinite(w).all():
         raise ValueError("`w` must contain only finite values.")
+    if not np.any(w > 0):
+        raise ValueError("At least one weight must be positive.")
     return w
 
 
 def _check_lsq_design_matrix(matr, ncoeff):
     """Check that every basis function is supported by the data."""
+    msg = (
+        "Data points do not support every tensor-product basis function. "
+        "At least one basis function is zero at all data points. Add data "
+        "points in the unsupported knot intervals, remove or move knots, "
+        "reduce the spline degree, or shrink the fitting domain."
+    )
     ncoeff = operator.index(ncoeff)
     if matr.shape[1] != ncoeff:
-        raise ValueError(
-            "Data points do not support every tensor-product basis function."
-        )
+        raise ValueError(msg)
 
     indices = np.asarray(matr.indices, dtype=np.intp)
     supported = np.bincount(indices, minlength=ncoeff) > 0
     if not supported.all():
-        raise ValueError(
-            "Data points do not support every tensor-product basis function."
-        )
+        raise ValueError(msg)
 
 
 def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -454,7 +454,7 @@ def _make_lsq_ndbspl(
     y : array_like, shape (npts, ...)
         Data values at `x`. Any trailing dimensions are treated as batch
         dimensions and fitted with the same design matrix.
-    t : tuple of array_like, shape (nt_i,)
+    t : tuple of array_like, shape (ndim,)
         Full knot vectors for each dimension. Boundary knots must already be
         included.
     k : int or array_like, shape (ndim,), optional

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -553,7 +553,7 @@ def _make_lsq_ndbspl(
         w = _validate_lsq_weights(w, npts)
         matr = diags_array(w, format="csr") @ matr
         matr.eliminate_zeros()
-        rhs = rhs * w[:, None]
+        rhs = rhs * w[:, np.newaxis]
 
     _check_lsq_design_matrix(matr, ncoeff)
 

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3045,11 +3045,11 @@ class TestMakeLSQNdBSpline:
 
     def test_trailing_dimensions_with_custom_solver(self):
         x = np.linspace(0.0, 1.0, 6)
-        y = np.empty((x.size, 2, 2))
-        y[:, 0, 0] = 1.0 + x
-        y[:, 0, 1] = 2.0 - x
-        y[:, 1, 0] = -1.0 + 3.0 * x
-        y[:, 1, 1] = 0.5 - 2.0 * x
+        y = np.empty((x.size, 2, 3, 4))
+        for i in range(y.shape[1]):
+            for j in range(y.shape[2]):
+                for m in range(y.shape[3]):
+                    y[:, i, j, m] = i + 2 * j - m + (1 + i + j + m) * x
         t = (np.r_[0.0, 0.0, 1.0, 1.0],)
         calls = []
 
@@ -3061,11 +3061,13 @@ class TestMakeLSQNdBSpline:
         spl = _make_lsq_ndbspl(x[:, None], y, t, k=1, solver=dense_solver)
         matr = NdBSpline.design_matrix(x[:, None], t, 1).toarray()
         ref, *_ = np.linalg.lstsq(
-            matr, y.reshape((x.size, 4)), rcond=None
+            matr, y.reshape((x.size, 24)), rcond=None
         )
-        ref = ref.reshape((2, 2, 2))
+        ref = ref.reshape((2, 2, 3, 4))
 
-        assert calls == [((x.size, 2), (x.size,))] * 4
+        # The custom solver is called once for each trailing output
+        # component, always with the same matrix and a one-dimensional RHS.
+        assert calls == [((x.size, 2), (x.size,))] * 24
         xp_assert_close(spl.c, ref, atol=1e-13)
 
     def test_complex_valued_output(self):
@@ -3074,11 +3076,14 @@ class TestMakeLSQNdBSpline:
         t = (np.r_[0.0, 0.0, 1.0, 1.0],)
 
         spl = _make_lsq_ndbspl(x[:, None], y, t, k=1)
+        matr = NdBSpline.design_matrix(x[:, None], t, 1).toarray()
+        coeffs, *_ = np.linalg.lstsq(matr, y, rcond=None)
         x_eval = np.array([[0.25], [0.75]])
         expected = (2.0 * x_eval[:, 0] + 1.0) + 1j * (
             -3.0 * x_eval[:, 0] + 4.0
         )
 
+        xp_assert_close(spl.c, coeffs, atol=1e-13)
         xp_assert_close(spl(x_eval), expected, atol=1e-13)
 
     def test_too_few_points_raises(self):
@@ -3119,6 +3124,14 @@ class TestMakeLSQNdBSpline:
         coeffs, *_ = np.linalg.lstsq(matr * w[:, None], y * w, rcond=None)
 
         xp_assert_close(spl.c, coeffs, atol=1e-12)
+
+    def test_all_zero_weights_raise(self):
+        x = np.linspace(0.0, 1.0, 5)[:, None]
+        y = x[:, 0]
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="one weight must be positive"):
+            _make_lsq_ndbspl(x, y, t, k=1, w=np.zeros(x.shape[0]))
 
     def test_zero_weights_do_not_support_basis(self):
         x = np.linspace(0.0, 1.0, 8)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3068,39 +3068,6 @@ class TestMakeLSQNdBSpline:
         assert calls == [((x.size, 2), (x.size,))] * 4
         xp_assert_close(spl.c, ref, atol=1e-13)
 
-    def test_sklearn_sgdregressor_solver_wrapper(self):
-        linear_model = pytest.importorskip("sklearn.linear_model")
-        from scipy import sparse
-
-        x = np.linspace(0.0, 1.0, 80)
-        y = 1.0 + 2.0 * x
-        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
-
-        def sgd_solver(a, b):
-            # scikit-learn currently expects sparse matrices with int32
-            # index arrays, so the wrapper adapts SciPy's sparse array.
-            a = sparse.csr_matrix(a)
-            a.indices = a.indices.astype(np.int32, copy=False)
-            a.indptr = a.indptr.astype(np.int32, copy=False)
-            reg = linear_model.SGDRegressor(
-                fit_intercept=False,
-                loss="squared_error",
-                penalty=None,
-                max_iter=20000,
-                tol=1e-12,
-                random_state=0,
-                learning_rate="adaptive",
-                eta0=0.01,
-            )
-            reg.fit(a, b)
-            return reg.coef_, 1
-
-        spl = _make_lsq_ndbspl(
-            x[:, None], y, t, k=1, solver=sgd_solver
-        )
-
-        xp_assert_close(spl(x[:, None]), y, atol=1e-5)
-
     def test_complex_valued_output(self):
         x = np.linspace(0.0, 1.0, 12)
         y = (2.0 * x + 1.0) + 1j * (-3.0 * x + 4.0)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -37,7 +37,7 @@ from scipy._lib._util import AxisError
 from scipy._lib._testutils import _run_concurrent_barrier
 
 # XXX: move to the interpolate namespace
-from scipy.interpolate._ndbspline import make_ndbspl
+from scipy.interpolate._ndbspline import _make_lsq_ndbspl, make_ndbspl
 
 from scipy.interpolate import _fitpack as dfitpack
 from scipy.interpolate import _bsplines as _b
@@ -2948,6 +2948,99 @@ class TestNdBSpline:
             spl(xi)
 
         _run_concurrent_barrier(10, worker_fn, spl)
+
+
+class TestMakeLSQNdBSpline:
+    def test_1d_matches_make_lsq_spline(self):
+        k = 3
+        x = np.linspace(0.0, 1.0, 40)
+        y = np.sin(2.0 * np.pi * x) + 0.25 * np.cos(4.0 * np.pi * x)
+        t = np.r_[
+            (x[0],) * (k + 1),
+            [0.25, 0.5, 0.75],
+            (x[-1],) * (k + 1),
+        ]
+
+        spl = _make_lsq_ndbspl(x[:, None], y, (t,), k=k)
+        ref = make_lsq_spline(x, y, t, k=k)
+
+        xp_assert_close(spl(x[:, None]), ref(x), atol=1e-11)
+        xp_assert_close(spl.c, ref.c, atol=1e-11)
+
+    def test_2d_scattered_linear_fit(self):
+        x0 = np.linspace(-1.0, 1.0, 5)
+        x1 = np.linspace(-2.0, 2.0, 6)
+        x0_grid, x1_grid = np.meshgrid(x0, x1, indexing="ij")
+        x = np.column_stack((x0_grid.ravel(), x1_grid.ravel()))
+        y = 1.0 + 2.0 * x[:, 0] - 0.5 * x[:, 1] + 0.25 * x[:, 0] * x[:, 1]
+        t = (
+            np.r_[-1.0, -1.0, 1.0, 1.0],
+            np.r_[-2.0, -2.0, 2.0, 2.0],
+        )
+
+        spl = _make_lsq_ndbspl(x, y, t, k=1)
+        x_eval = np.array([[-0.5, -1.0], [0.25, 0.5], [0.75, 1.5]])
+        expected = (
+            1.0
+            + 2.0 * x_eval[:, 0]
+            - 0.5 * x_eval[:, 1]
+            + 0.25 * x_eval[:, 0] * x_eval[:, 1]
+        )
+
+        xp_assert_close(spl(x_eval), expected, atol=1e-13)
+
+    def test_weights_match_dense_weighted_lstsq(self):
+        k = 1
+        x = np.linspace(0.0, 1.0, 8)
+        y = np.array([1.0, 1.1, 1.4, 1.9, 2.6, 3.4, 4.1, 5.0])
+        w = np.linspace(1.0, 2.0, x.size)
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=k, w=w)
+        matr = NdBSpline.design_matrix(x[:, None], t, k).toarray()
+        coeffs, *_ = np.linalg.lstsq(matr * w[:, None], y * w, rcond=None)
+
+        xp_assert_close(spl.c, coeffs, atol=1e-12)
+
+    def test_vector_valued_output(self):
+        x = np.linspace(0.0, 1.0, 20)
+        y = np.column_stack((2.0 * x + 1.0, -3.0 * x + 4.0))
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=1)
+        x_eval = np.array([[0.25], [0.75]])
+        expected = np.column_stack(
+            (2.0 * x_eval[:, 0] + 1.0, -3.0 * x_eval[:, 0] + 4.0)
+        )
+
+        assert spl.c.shape == (2, 2)
+        xp_assert_close(spl(x_eval), expected, atol=1e-13)
+
+    def test_too_few_points_raises(self):
+        x = np.array([[0.0], [1.0]])
+        y = np.array([0.0, 1.0])
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="fewer data points"):
+            _make_lsq_ndbspl(x, y, t, k=1)
+
+    def test_unsupported_basis_raises(self):
+        x = np.linspace(0.0, 0.4, 6)[:, None]
+        y = x[:, 0]
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="support every"):
+            _make_lsq_ndbspl(x, y, t, k=1)
+
+    def test_invalid_weights_raise(self):
+        x = np.linspace(0.0, 1.0, 5)[:, None]
+        y = x[:, 0]
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="positive"):
+            _make_lsq_ndbspl(
+                x, y, t, k=1, w=[1.0, 1.0, 0.0, 1.0, 1.0]
+            )
 
 
 class TestMakeND:

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3075,10 +3075,33 @@ class TestMakeLSQNdBSpline:
         y = x[:, 0]
         t = (np.r_[0.0, 0.0, 1.0, 1.0],)
 
-        with assert_raises(ValueError, match="positive"):
+        with assert_raises(ValueError, match="non-negative"):
             _make_lsq_ndbspl(
-                x, y, t, k=1, w=[1.0, 1.0, 0.0, 1.0, 1.0]
+                x, y, t, k=1, w=[1.0, 1.0, -1.0, 1.0, 1.0]
             )
+
+    def test_zero_weights_are_allowed(self):
+        x = np.linspace(0.0, 1.0, 8)
+        y = np.array([1.0, 1.1, 1.4, 1.9, 2.6, 3.4, 4.1, 5.0])
+        w = np.ones_like(x)
+        w[2:4] = 0.0
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=1, w=w)
+        matr = NdBSpline.design_matrix(x[:, None], t, 1).toarray()
+        coeffs, *_ = np.linalg.lstsq(matr * w[:, None], y * w, rcond=None)
+
+        xp_assert_close(spl.c, coeffs, atol=1e-12)
+
+    def test_zero_weights_do_not_support_basis(self):
+        x = np.linspace(0.0, 1.0, 8)
+        y = x
+        w = np.ones_like(x)
+        w[x <= 0.5] = 0.0
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="support every"):
+            _make_lsq_ndbspl(x[:, None], y, t, k=1, w=w)
 
     def test_invalid_input_validation(self):
         x = np.linspace(0.0, 1.0, 5)[:, None]

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -2989,6 +2989,33 @@ class TestMakeLSQNdBSpline:
 
         xp_assert_close(spl(x_eval), expected, atol=1e-13)
 
+    def test_lsmr_solver_matches_default_solver(self):
+        x0 = np.linspace(-1.0, 1.0, 11)
+        x1 = np.linspace(-0.75, 0.75, 10)
+        x0_grid, x1_grid = np.meshgrid(x0, x1, indexing="ij")
+        x = np.column_stack((x0_grid.ravel(), x1_grid.ravel()))
+        y = (
+            np.sin(2.0 * x[:, 0])
+            + 0.5 * np.cos(3.0 * x[:, 1])
+            + x[:, 0] * x[:, 1]
+        )
+        w = 1.0 + 0.5 * (x[:, 0] > 0.0)
+        t = (
+            np.r_[[-1.0] * 3, [-0.5, 0.0, 0.5], [1.0] * 3],
+            np.r_[[-0.75] * 3, [-0.25, 0.25], [0.75] * 3],
+        )
+
+        spl = _make_lsq_ndbspl(x, y, t, k=(2, 2), w=w)
+        spl_lsmr = _make_lsq_ndbspl(
+            x, y, t, k=(2, 2), w=w, solver=ssl.lsmr
+        )
+        x_eval = np.array(
+            [[-0.8, -0.5], [-0.1, 0.2], [0.2, -0.3], [0.7, 0.6]]
+        )
+
+        xp_assert_close(spl_lsmr.c, spl.c, atol=5e-7)
+        xp_assert_close(spl_lsmr(x_eval), spl(x_eval), atol=5e-7)
+
     def test_weights_match_dense_weighted_lstsq(self):
         k = 1
         x = np.linspace(0.0, 1.0, 8)
@@ -3040,6 +3067,39 @@ class TestMakeLSQNdBSpline:
 
         assert calls == [((x.size, 2), (x.size,))] * 4
         xp_assert_close(spl.c, ref, atol=1e-13)
+
+    def test_sklearn_sgdregressor_solver_wrapper(self):
+        linear_model = pytest.importorskip("sklearn.linear_model")
+        from scipy import sparse
+
+        x = np.linspace(0.0, 1.0, 80)
+        y = 1.0 + 2.0 * x
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        def sgd_solver(a, b):
+            # scikit-learn currently expects sparse matrices with int32
+            # index arrays, so the wrapper adapts SciPy's sparse array.
+            a = sparse.csr_matrix(a)
+            a.indices = a.indices.astype(np.int32, copy=False)
+            a.indptr = a.indptr.astype(np.int32, copy=False)
+            reg = linear_model.SGDRegressor(
+                fit_intercept=False,
+                loss="squared_error",
+                penalty=None,
+                max_iter=20000,
+                tol=1e-12,
+                random_state=0,
+                learning_rate="adaptive",
+                eta0=0.01,
+            )
+            reg.fit(a, b)
+            return reg.coef_, 1
+
+        spl = _make_lsq_ndbspl(
+            x[:, None], y, t, k=1, solver=sgd_solver
+        )
+
+        xp_assert_close(spl(x[:, None]), y, atol=1e-5)
 
     def test_complex_valued_output(self):
         x = np.linspace(0.0, 1.0, 12)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3016,6 +3016,44 @@ class TestMakeLSQNdBSpline:
         assert spl.c.shape == (2, 2)
         xp_assert_close(spl(x_eval), expected, atol=1e-13)
 
+    def test_trailing_dimensions_with_custom_solver(self):
+        x = np.linspace(0.0, 1.0, 6)
+        y = np.empty((x.size, 2, 2))
+        y[:, 0, 0] = 1.0 + x
+        y[:, 0, 1] = 2.0 - x
+        y[:, 1, 0] = -1.0 + 3.0 * x
+        y[:, 1, 1] = 0.5 - 2.0 * x
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+        calls = []
+
+        def dense_solver(a, b):
+            calls.append((a.shape, b.shape))
+            coef, *_ = np.linalg.lstsq(a.toarray(), b, rcond=None)
+            return coef, 1
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=1, solver=dense_solver)
+        matr = NdBSpline.design_matrix(x[:, None], t, 1).toarray()
+        ref, *_ = np.linalg.lstsq(
+            matr, y.reshape((x.size, 4)), rcond=None
+        )
+        ref = ref.reshape((2, 2, 2))
+
+        assert calls == [((x.size, 2), (x.size,))] * 4
+        xp_assert_close(spl.c, ref, atol=1e-13)
+
+    def test_complex_valued_output(self):
+        x = np.linspace(0.0, 1.0, 12)
+        y = (2.0 * x + 1.0) + 1j * (-3.0 * x + 4.0)
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=1)
+        x_eval = np.array([[0.25], [0.75]])
+        expected = (2.0 * x_eval[:, 0] + 1.0) + 1j * (
+            -3.0 * x_eval[:, 0] + 4.0
+        )
+
+        xp_assert_close(spl(x_eval), expected, atol=1e-13)
+
     def test_too_few_points_raises(self):
         x = np.array([[0.0], [1.0]])
         y = np.array([0.0, 1.0])
@@ -3041,6 +3079,33 @@ class TestMakeLSQNdBSpline:
             _make_lsq_ndbspl(
                 x, y, t, k=1, w=[1.0, 1.0, 0.0, 1.0, 1.0]
             )
+
+    def test_invalid_input_validation(self):
+        x = np.linspace(0.0, 1.0, 5)[:, None]
+        y = x[:, 0]
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="2D array"):
+            _make_lsq_ndbspl(x[:, 0], y, t, k=1)
+
+        x_bad = x.copy()
+        x_bad[0, 0] = np.nan
+        with assert_raises(ValueError, match="finite values"):
+            _make_lsq_ndbspl(x_bad, y, t, k=1)
+
+        with assert_raises(ValueError, match="matching"):
+            _make_lsq_ndbspl(x, y[:-1], t, k=1)
+
+        y_bad = y.copy()
+        y_bad[0] = np.inf
+        with assert_raises(ValueError, match="finite values"):
+            _make_lsq_ndbspl(x, y_bad, t, k=1)
+
+        with assert_raises(ValueError, match="empty trailing"):
+            _make_lsq_ndbspl(x, np.empty((x.shape[0], 0)), t, k=1)
+
+        with assert_raises(ValueError, match="callable"):
+            _make_lsq_ndbspl(x, y, t, k=1, solver=None)
 
 
 class TestMakeND:


### PR DESCRIPTION
#### Reference issue

Follow-up to tracker/design PR gh-25472.

#### What does this implement/fix?

This is the first smaller implementation chunk split out from the larger `LSQMultivariateSpline` tracker PR.

It adds a private internal helper, `_make_lsq_ndbspl`, for constructing an `NdBSpline` from scattered least-squares data using existing `NdBSpline` machinery.

This chunk intentionally keeps the scope small:

- accepts scattered coordinates `x` with shape `(npts, ndim)`;
- accepts scalar or vector-valued observations `y`;
- accepts explicit full knot vectors;
- builds the sparse design matrix with `NdBSpline.design_matrix`;
- supports positive row weights;
- solves the sparse least-squares problem with `scipy.sparse.linalg.lsqr`;
- returns an `NdBSpline` instance;
- hard-fails if the data do not support every tensor-product basis function.

This PR does not add a public API yet. It also intentionally excludes smoothing penalties, automatic knot selection, dense fitting as a public path, and custom evaluation code.

#### AI Declaration

I used OpenAI Codex/ChatGPT during development. I wrote the main mathematical model and implementation direction myself, including the spline/least-squares formulation and the intended physics/scientific use case. Codex was used mainly as an assistant for discussion, review, refactoring, tests, benchmarks, documentation drafting, CI/debugging, and speeding up some mechanical implementation work.

Some smaller or repetitive code sections were generated or edited with Codex from natural-language prompts, but I manually reviewed, modified, and tested the submitted code. The mathematical and physical modelling choices were my own and were reviewed with Codex for consistency and possible issues. The prompts were iterative rather than a single prompt, covering topics such as class structure, tensor-product design-matrix construction, validation, tests/benchmarks/docs, and porting the standalone prototype into SciPy

#### Additional information

The new tests cover:

- agreement with 1-D `make_lsq_spline`;
- 2-D scattered linear fitting;
- weighted least-squares behavior against dense reference `np.linalg.lstsq`;
- vector-valued output;
- too few data points;
- unsupported basis functions;
- invalid weights.

Coding example:

```
Example of the intended internal flow for a 3-D scattered least-squares fit:

```python
import numpy as np

from scipy.interpolate import NdBSpline
from scipy.interpolate._ndbspline import _make_lsq_ndbspl


# Scattered 3-D sample data
rng = np.random.default_rng(0)
n_samples = 500

x0 = rng.uniform(-1.0, 1.0, n_samples)
x1 = rng.uniform(-1.0, 1.0, n_samples)
x2 = rng.uniform(0.0, 2.0, n_samples)

x = np.column_stack((x0, x1, x2))

y_true = np.sin(np.pi * x0) + 0.5 * x1**2 - 0.25 * x2
y = y_true + 0.05 * rng.normal(size=n_samples)

w = np.ones(n_samples)


# Explicit full knot vectors, including repeated boundary knots.
# For k=1, each boundary is repeated k+1 = 2 times.
k = 1

t0 = np.r_[-1.0, -1.0, -0.5, 0.0, 0.5, 1.0, 1.0]
t1 = np.r_[-1.0, -1.0, -0.5, 0.0, 0.5, 1.0, 1.0]
t2 = np.r_[0.0, 0.0, 0.5, 1.0, 1.5, 2.0, 2.0]

t = (t0, t1, t2)


# New helper in this PR chunk:
# constructs the sparse LSQ system, solves for coefficients,
# and returns an existing NdBSpline instance.
spl = _make_lsq_ndbspl(x, y, t, k=k, w=w)

assert isinstance(spl, NdBSpline)


# Evaluation is handled by the existing NdBSpline implementation.
x_new = np.array(
    [
        [0.0, 0.0, 1.0],
        [0.25, -0.5, 0.75],
        [-0.75, 0.5, 1.5],
    ]
)

y_new = spl(x_new)
```