### PR TITLE
Enh lsq ndbspline knots

### DIFF
--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -441,6 +441,108 @@ def _iter_solve(a, b, solver=ssl.gcrotmk, **solver_args):
         return res
 
 
+def _generate_lsq_knots_1d(x, k=3, *, n_internal_knots, bbox=None):
+    """Generate a 1D clamped knot vector from sample quantiles."""
+    x = np.asarray(x, dtype=float)
+    if x.ndim != 1:
+        raise ValueError("`x` must be a 1D array.")
+    if x.size == 0:
+        raise ValueError("`x` must contain at least one data point.")
+    if not np.isfinite(x).all():
+        raise ValueError("`x` must contain only finite values.")
+
+    k = operator.index(k)
+    if k < 0:
+        raise ValueError("Spline degree cannot be negative.")
+
+    n_internal_knots = operator.index(n_internal_knots)
+    if n_internal_knots < 0:
+        raise ValueError("`n_internal_knots` cannot be negative.")
+
+    if bbox is None:
+        xb = np.min(x)
+        xe = np.max(x)
+    else:
+        bbox = np.asarray(bbox, dtype=float)
+        if bbox.shape != (2,):
+            raise ValueError("`bbox` must have shape (2,).")
+        if not np.isfinite(bbox).all():
+            raise ValueError("`bbox` must contain only finite values.")
+        xb, xe = bbox
+
+    if not xb < xe:
+        raise ValueError("The lower bound must be less than the upper bound.")
+
+    in_bounds = (xb <= x) & (x <= xe)
+    if not np.any(in_bounds):
+        raise ValueError("`x` must contain at least one point in `bbox`.")
+
+    if n_internal_knots == 0:
+        interior = np.empty(0, dtype=float)
+    else:
+        quantiles = np.linspace(
+            0.0, 1.0, n_internal_knots + 2, dtype=float
+        )[1:-1]
+        interior = np.quantile(x[in_bounds], quantiles)
+
+        if (
+            interior[0] <= xb
+            or interior[-1] >= xe
+            or np.any(np.diff(interior) <= 0)
+        ):
+            raise ValueError(
+                "Cannot place the requested number of distinct interior "
+                "knots inside `bbox`."
+            )
+
+    return np.r_[(xb,) * (k + 1), interior, (xe,) * (k + 1)]
+
+
+def _generate_lsq_knots(x, k=3, *, n_internal_knots, bbox=None):
+    """Generate clamped knot vectors for N-D least-squares splines."""
+    x = np.asarray(x, dtype=float)
+    if x.ndim != 2:
+        raise ValueError("`x` must be a 2D array with shape (npts, ndim).")
+    if x.shape[0] == 0:
+        raise ValueError("`x` must contain at least one data point.")
+
+    ndim = x.shape[1]
+    try:
+        len(k)
+    except TypeError:
+        k = (k,) * ndim
+    if len(k) != ndim:
+        raise ValueError(f"Expected {ndim} spline degrees, got {len(k)}.")
+
+    try:
+        len(n_internal_knots)
+    except TypeError:
+        n_internal_knots = (n_internal_knots,) * ndim
+    if len(n_internal_knots) != ndim:
+        raise ValueError(
+            f"Expected {ndim} knot counts, got {len(n_internal_knots)}."
+        )
+
+    if bbox is None:
+        bbox = (None,) * ndim
+    else:
+        bbox = np.asarray(bbox, dtype=float)
+        if bbox.shape == (2 * ndim,):
+            bbox = bbox.reshape((ndim, 2))
+        if bbox.shape != (ndim, 2):
+            raise ValueError("`bbox` must have shape (ndim, 2).")
+
+    return tuple(
+        _generate_lsq_knots_1d(
+            x[:, d],
+            k[d],
+            n_internal_knots=n_internal_knots[d],
+            bbox=bbox[d],
+        )
+        for d in range(ndim)
+    )
+
+
 def _make_lsq_ndbspl(
     x, y, t, k=3, *, w=None, solver=ssl.lsqr, **solver_args
 ):

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -9,7 +9,7 @@ from types import GenericAlias
 from . import _dierckx  # type: ignore[attr-defined]
 
 import scipy.sparse.linalg as ssl
-from scipy.sparse import csr_array
+from scipy.sparse import csr_array, diags_array
 from scipy._lib._array_api import array_namespace, xp_capabilities
 
 from ._bsplines import _not_a_knot, BSpline
@@ -446,16 +446,58 @@ def _make_lsq_ndbspl(
 ):
     """Construct a least-squares ``NdBSpline`` from scattered data.
 
-    This is an internal construction helper. The knot vectors are expected to
-    be full knot vectors, including any repeated boundary knots.
+    Parameters
+    ----------
+    x : array_like, shape (npts, ndim)
+        Data point coordinates. Each row gives one point in ``ndim``
+        dimensions.
+    y : array_like, shape (npts, ...)
+        Data values at `x`. Any trailing dimensions are treated as batch
+        dimensions and fitted with the same design matrix.
+    t : tuple of array_like, shape (nt_i,)
+        Full knot vectors for each dimension. Boundary knots must already be
+        included.
+    k : int or tuple of int, optional
+        Spline degree for each dimension. A scalar value is applied to all
+        dimensions. Default is cubic, ``k=3``.
+    w : array_like, shape (npts,), optional
+        Positive weights for weighted least squares.
+    solver : callable, optional
+        Sparse least-squares solver. Default is `scipy.sparse.linalg.lsqr`.
+        The solver is called as ``solver(A, b, **solver_args)``, where
+        ``A`` is the sparse design matrix with shape ``(npts, ncoeffs)`` and
+        ``b`` is a 1D right-hand side with shape ``(npts,)``. It must return
+        the same result format as `scipy.sparse.linalg.lsqr` and
+        `scipy.sparse.linalg.lsmr`: the fitted coefficients are read from
+        ``result[0]`` and the convergence status from ``result[1]``.
+    **solver_args
+        Additional keyword arguments passed to `solver`.
+
+    Returns
+    -------
+    spl : NdBSpline
+        Tensor-product spline with coefficients fitted by least squares.
+
+    Notes
+    -----
+    This solves the sparse least-squares problem
+
+    ``min_c || W @ (A @ c - y) ||_2``,
+
+    where ``A`` is the sparse tensor-product B-spline design matrix built by
+    `NdBSpline.design_matrix` and ``W`` is a diagonal matrix of weights.
     """
     x = np.asarray(x, dtype=float)
     if x.ndim != 2:
         raise ValueError("`x` must be a 2D array with shape (npts, ndim).")
+    if not np.isfinite(x).all():
+        raise ValueError("`x` must contain only finite values.")
 
     npts, ndim = x.shape
     if npts == 0:
         raise ValueError("`x` must contain at least one data point.")
+    if not callable(solver):
+        raise ValueError("`solver` must be callable.")
 
     if not isinstance(t, tuple):
         raise ValueError(
@@ -470,6 +512,10 @@ def _make_lsq_ndbspl(
     y = np.asarray(y)
     if y.ndim == 0 or y.shape[0] != npts:
         raise ValueError("`y` must have shape (npts, ...) matching `x`.")
+    if 0 in y.shape[1:]:
+        raise ValueError("`y` must not have empty trailing dimensions.")
+    if not np.isfinite(y).all():
+        raise ValueError("`y` must contain only finite values.")
 
     k, _, (_t, len_t) = _preprocess_inputs(k, t)
     t = tuple(np.asarray(t[d], dtype=float) for d in range(ndim))
@@ -486,21 +532,27 @@ def _make_lsq_ndbspl(
     _check_lsq_design_matrix(matr, ncoeff)
 
     y_shape = y.shape
-    rhs = y.reshape((npts, prod(y_shape[1:])))
+    y_trailing_shape = y_shape[1:]
+    rhs = y.reshape((npts, prod(y_trailing_shape)))
     if w is not None:
         w = _validate_lsq_weights(w, npts)
-        matr = matr.multiply(w[:, None])
+        matr = diags_array(w, format="csr") @ matr
         rhs = rhs * w[:, None]
 
     if solver is ssl.lsqr or solver is ssl.lsmr:
         solver_args.setdefault("atol", 1e-12)
         solver_args.setdefault("btol", 1e-12)
 
-    coef = _lsq_iter_solve(matr, rhs, solver=solver, **solver_args)
-    if y.ndim == 1:
-        coef = coef[:, 0].reshape(coeff_shape)
-    else:
-        coef = coef.reshape(coeff_shape + y_shape[1:])
+    coef = []
+    for j in range(rhs.shape[1]):
+        result = solver(matr, rhs[:, j], **solver_args)
+        coef_j, istop = result[0], result[1]
+        if istop not in {1, 2}:
+            raise ValueError(f"{solver = } returns {istop = }.")
+        coef.append(coef_j)
+
+    coef = np.column_stack(coef)
+    coef = coef.reshape(coeff_shape + y_trailing_shape)
 
     return NdBSpline(t, coef, tuple(k))
 
@@ -529,30 +581,6 @@ def _check_lsq_design_matrix(matr, ncoeff):
         raise ValueError(
             "Data points do not support every tensor-product basis function."
         )
-
-
-def _lsq_iter_solve(a, b, solver=ssl.lsqr, **solver_args):
-    """Solve a sparse least-squares problem column by column."""
-    if np.issubdtype(b.dtype, np.complexfloating):
-        real = _lsq_iter_solve(a, b.real, solver=solver, **solver_args)
-        imag = _lsq_iter_solve(a, b.imag, solver=solver, **solver_args)
-        return real + 1j * imag
-
-    if b.ndim == 2 and b.shape[1] != 1:
-        dtype = _get_dtype(b.dtype)
-        res = np.empty((a.shape[1], b.shape[1]), dtype=dtype)
-        for j in range(b.shape[1]):
-            res[:, j] = _lsq_iter_solve(
-                a, b[:, j], solver=solver, **solver_args
-            )[:, 0]
-        return res
-
-    b = b.ravel()
-    result = solver(a, b, **solver_args)
-    coef, istop = result[0], result[1]
-    if istop not in {1, 2}:
-        raise ValueError(f"{solver = } returns {istop = }.")
-    return coef[:, None]
 
 
 def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -457,11 +457,11 @@ def _make_lsq_ndbspl(
     t : tuple of array_like, shape (nt_i,)
         Full knot vectors for each dimension. Boundary knots must already be
         included.
-    k : int or tuple of int, optional
+    k : int or array_like, shape (ndim,), optional
         Spline degree for each dimension. A scalar value is applied to all
         dimensions. Default is cubic, ``k=3``.
     w : array_like, shape (npts,), optional
-        Positive weights for weighted least squares.
+        Non-negative weights for weighted least squares.
     solver : callable, optional
         Sparse least-squares solver. Default is `scipy.sparse.linalg.lsqr`.
         The solver is called as ``solver(A, b, **solver_args)``, where
@@ -529,7 +529,6 @@ def _make_lsq_ndbspl(
 
     matr = NdBSpline.design_matrix(x, t, tuple(k), extrapolate=False)
     matr.eliminate_zeros()
-    _check_lsq_design_matrix(matr, ncoeff)
 
     y_shape = y.shape
     y_trailing_shape = y_shape[1:]
@@ -537,11 +536,10 @@ def _make_lsq_ndbspl(
     if w is not None:
         w = _validate_lsq_weights(w, npts)
         matr = diags_array(w, format="csr") @ matr
+        matr.eliminate_zeros()
         rhs = rhs * w[:, None]
 
-    if solver is ssl.lsqr or solver is ssl.lsmr:
-        solver_args.setdefault("atol", 1e-12)
-        solver_args.setdefault("btol", 1e-12)
+    _check_lsq_design_matrix(matr, ncoeff)
 
     coef = []
     for j in range(rhs.shape[1]):
@@ -562,8 +560,8 @@ def _validate_lsq_weights(w, npts):
     w = np.asarray(w, dtype=float)
     if w.ndim != 1 or w.shape[0] != npts:
         raise ValueError("`w` must be a 1D array with shape (npts,).")
-    if np.any(w <= 0):
-        raise ValueError("`w` must contain only positive values.")
+    if np.any(w < 0):
+        raise ValueError("`w` must contain only non-negative values.")
     if not np.isfinite(w).all():
         raise ValueError("`w` must contain only finite values.")
     return w

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -441,6 +441,120 @@ def _iter_solve(a, b, solver=ssl.gcrotmk, **solver_args):
         return res
 
 
+def _make_lsq_ndbspl(
+    x, y, t, k=3, *, w=None, solver=ssl.lsqr, **solver_args
+):
+    """Construct a least-squares ``NdBSpline`` from scattered data.
+
+    This is an internal construction helper. The knot vectors are expected to
+    be full knot vectors, including any repeated boundary knots.
+    """
+    x = np.asarray(x, dtype=float)
+    if x.ndim != 2:
+        raise ValueError("`x` must be a 2D array with shape (npts, ndim).")
+
+    npts, ndim = x.shape
+    if npts == 0:
+        raise ValueError("`x` must contain at least one data point.")
+
+    if not isinstance(t, tuple):
+        raise ValueError(
+            f"Expect `t` to be a tuple of array-likes. Got {t} instead."
+        )
+    if len(t) != ndim:
+        raise ValueError(
+            f"Data and knots are inconsistent: len(t) = {len(t)} for "
+            f"ndim = {ndim}."
+        )
+
+    y = np.asarray(y)
+    if y.ndim == 0 or y.shape[0] != npts:
+        raise ValueError("`y` must have shape (npts, ...) matching `x`.")
+
+    k, _, (_t, len_t) = _preprocess_inputs(k, t)
+    t = tuple(np.asarray(t[d], dtype=float) for d in range(ndim))
+    coeff_shape = tuple(len_t[d] - k[d] - 1 for d in range(ndim))
+    ncoeff = prod(coeff_shape)
+    if npts < ncoeff:
+        raise ValueError(
+            "There are fewer data points than spline coefficients; the "
+            "least-squares problem is underdetermined."
+        )
+
+    matr = NdBSpline.design_matrix(x, t, tuple(k), extrapolate=False)
+    matr.eliminate_zeros()
+    _check_lsq_design_matrix(matr, ncoeff)
+
+    y_shape = y.shape
+    rhs = y.reshape((npts, prod(y_shape[1:])))
+    if w is not None:
+        w = _validate_lsq_weights(w, npts)
+        matr = matr.multiply(w[:, None])
+        rhs = rhs * w[:, None]
+
+    if solver is ssl.lsqr or solver is ssl.lsmr:
+        solver_args.setdefault("atol", 1e-12)
+        solver_args.setdefault("btol", 1e-12)
+
+    coef = _lsq_iter_solve(matr, rhs, solver=solver, **solver_args)
+    if y.ndim == 1:
+        coef = coef[:, 0].reshape(coeff_shape)
+    else:
+        coef = coef.reshape(coeff_shape + y_shape[1:])
+
+    return NdBSpline(t, coef, tuple(k))
+
+
+def _validate_lsq_weights(w, npts):
+    """Validate least-squares weights."""
+    w = np.asarray(w, dtype=float)
+    if w.ndim != 1 or w.shape[0] != npts:
+        raise ValueError("`w` must be a 1D array with shape (npts,).")
+    if np.any(w <= 0):
+        raise ValueError("`w` must contain only positive values.")
+    if not np.isfinite(w).all():
+        raise ValueError("`w` must contain only finite values.")
+    return w
+
+
+def _check_lsq_design_matrix(matr, ncoeff):
+    """Check that every basis function is supported by the data."""
+    if matr.shape[1] != ncoeff:
+        raise ValueError(
+            "Data points do not support every tensor-product basis function."
+        )
+
+    supported = np.bincount(matr.indices, minlength=ncoeff) > 0
+    if not supported.all():
+        raise ValueError(
+            "Data points do not support every tensor-product basis function."
+        )
+
+
+def _lsq_iter_solve(a, b, solver=ssl.lsqr, **solver_args):
+    """Solve a sparse least-squares problem column by column."""
+    if np.issubdtype(b.dtype, np.complexfloating):
+        real = _lsq_iter_solve(a, b.real, solver=solver, **solver_args)
+        imag = _lsq_iter_solve(a, b.imag, solver=solver, **solver_args)
+        return real + 1j * imag
+
+    if b.ndim == 2 and b.shape[1] != 1:
+        dtype = _get_dtype(b.dtype)
+        res = np.empty((a.shape[1], b.shape[1]), dtype=dtype)
+        for j in range(b.shape[1]):
+            res[:, j] = _lsq_iter_solve(
+                a, b[:, j], solver=solver, **solver_args
+            )[:, 0]
+        return res
+
+    b = b.ravel()
+    result = solver(a, b, **solver_args)
+    coef, istop = result[0], result[1]
+    if istop not in {1, 2}:
+        raise ValueError(f"{solver = } returns {istop = }.")
+    return coef[:, None]
+
+
 def make_ndbspl(points, values, k=3, *, solver=ssl.gcrotmk, **solver_args):
     """Construct an interpolating NdBspline.
 

--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -571,12 +571,14 @@ def _validate_lsq_weights(w, npts):
 
 def _check_lsq_design_matrix(matr, ncoeff):
     """Check that every basis function is supported by the data."""
+    ncoeff = operator.index(ncoeff)
     if matr.shape[1] != ncoeff:
         raise ValueError(
             "Data points do not support every tensor-product basis function."
         )
 
-    supported = np.bincount(matr.indices, minlength=ncoeff) > 0
+    indices = np.asarray(matr.indices, dtype=np.intp)
+    supported = np.bincount(indices, minlength=ncoeff) > 0
     if not supported.all():
         raise ValueError(
             "Data points do not support every tensor-product basis function."

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -37,7 +37,7 @@ from scipy._lib._util import AxisError
 from scipy._lib._testutils import _run_concurrent_barrier
 
 # XXX: move to the interpolate namespace
-from scipy.interpolate._ndbspline import make_ndbspl
+from scipy.interpolate._ndbspline import _make_lsq_ndbspl, make_ndbspl
 
 from scipy.interpolate import _fitpack as dfitpack
 from scipy.interpolate import _bsplines as _b
@@ -2948,6 +2948,99 @@ class TestNdBSpline:
             spl(xi)
 
         _run_concurrent_barrier(10, worker_fn, spl)
+
+
+class TestMakeLSQNdBSpline:
+    def test_1d_matches_make_lsq_spline(self):
+        k = 3
+        x = np.linspace(0.0, 1.0, 40)
+        y = np.sin(2.0 * np.pi * x) + 0.25 * np.cos(4.0 * np.pi * x)
+        t = np.r_[
+            (x[0],) * (k + 1),
+            [0.25, 0.5, 0.75],
+            (x[-1],) * (k + 1),
+        ]
+
+        spl = _make_lsq_ndbspl(x[:, None], y, (t,), k=k)
+        ref = make_lsq_spline(x, y, t, k=k)
+
+        xp_assert_close(spl(x[:, None]), ref(x), atol=1e-11)
+        xp_assert_close(spl.c, ref.c, atol=1e-11)
+
+    def test_2d_scattered_linear_fit(self):
+        x0 = np.linspace(-1.0, 1.0, 5)
+        x1 = np.linspace(-2.0, 2.0, 6)
+        x0_grid, x1_grid = np.meshgrid(x0, x1, indexing="ij")
+        x = np.column_stack((x0_grid.ravel(), x1_grid.ravel()))
+        y = 1.0 + 2.0 * x[:, 0] - 0.5 * x[:, 1] + 0.25 * x[:, 0] * x[:, 1]
+        t = (
+            np.r_[-1.0, -1.0, 1.0, 1.0],
+            np.r_[-2.0, -2.0, 2.0, 2.0],
+        )
+
+        spl = _make_lsq_ndbspl(x, y, t, k=1)
+        x_eval = np.array([[-0.5, -1.0], [0.25, 0.5], [0.75, 1.5]])
+        expected = (
+            1.0
+            + 2.0 * x_eval[:, 0]
+            - 0.5 * x_eval[:, 1]
+            + 0.25 * x_eval[:, 0] * x_eval[:, 1]
+        )
+
+        xp_assert_close(spl(x_eval), expected, atol=1e-13)
+
+    def test_weights_match_dense_weighted_lstsq(self):
+        k = 1
+        x = np.linspace(0.0, 1.0, 8)
+        y = np.array([1.0, 1.1, 1.4, 1.9, 2.6, 3.4, 4.1, 5.0])
+        w = np.linspace(1.0, 2.0, x.size)
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=k, w=w)
+        matr = NdBSpline.design_matrix(x[:, None], t, k).toarray()
+        coeffs, *_ = np.linalg.lstsq(matr * w[:, None], y * w, rcond=None)
+
+        xp_assert_close(spl.c, coeffs, atol=1e-12)
+
+    def test_vector_valued_output(self):
+        x = np.linspace(0.0, 1.0, 20)
+        y = np.column_stack((2.0 * x + 1.0, -3.0 * x + 4.0))
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=1)
+        x_eval = np.array([[0.25], [0.75]])
+        expected = np.column_stack(
+            (2.0 * x_eval[:, 0] + 1.0, -3.0 * x_eval[:, 0] + 4.0)
+        )
+
+        assert spl.c.shape == (2, 2)
+        xp_assert_close(spl(x_eval), expected, atol=1e-13)
+
+    def test_too_few_points_raises(self):
+        x = np.array([[0.0], [1.0]])
+        y = np.array([0.0, 1.0])
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="fewer data points"):
+            _make_lsq_ndbspl(x, y, t, k=1)
+
+    def test_unsupported_basis_raises(self):
+        x = np.linspace(0.0, 0.4, 6)[:, None]
+        y = x[:, 0]
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="support every"):
+            _make_lsq_ndbspl(x, y, t, k=1)
+
+    def test_invalid_weights_raise(self):
+        x = np.linspace(0.0, 1.0, 5)[:, None]
+        y = x[:, 0]
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="positive"):
+            _make_lsq_ndbspl(
+                x, y, t, k=1, w=[1.0, 1.0, 0.0, 1.0, 1.0]
+            )
 
 
 class TestMakeND:

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -37,7 +37,9 @@ from scipy._lib._util import AxisError
 from scipy._lib._testutils import _run_concurrent_barrier
 
 # XXX: move to the interpolate namespace
-from scipy.interpolate._ndbspline import _make_lsq_ndbspl, make_ndbspl
+from scipy.interpolate._ndbspline import (
+    _generate_lsq_knots, _generate_lsq_knots_1d, _make_lsq_ndbspl, make_ndbspl
+)
 
 from scipy.interpolate import _fitpack as dfitpack
 from scipy.interpolate import _bsplines as _b
@@ -2948,6 +2950,106 @@ class TestNdBSpline:
             spl(xi)
 
         _run_concurrent_barrier(10, worker_fn, spl)
+
+
+class TestGenerateLSQKnots:
+    def test_1d_quantile_knots(self):
+        x = np.array([0.0, 0.1, 0.2, 0.6, 1.0])
+        t = _generate_lsq_knots_1d(
+            x, k=2, n_internal_knots=3, bbox=(0.0, 1.0)
+        )
+        expected = np.r_[
+            (0.0,) * 3,
+            np.quantile(x, [0.25, 0.5, 0.75]),
+            (1.0,) * 3,
+        ]
+
+        xp_assert_close(t, expected)
+
+    def test_1d_no_internal_knots_uses_data_bounds(self):
+        x = np.array([-2.0, -1.0, 1.0, 3.0])
+        t = _generate_lsq_knots_1d(x, k=1, n_internal_knots=0)
+
+        xp_assert_close(t, [-2.0, -2.0, 3.0, 3.0])
+
+    def test_nd_knots_are_generated_per_dimension(self):
+        x = np.array(
+            [
+                [0.0, -1.0],
+                [0.25, -0.5],
+                [0.5, 0.2],
+                [0.75, 0.5],
+                [1.0, 1.0],
+            ]
+        )
+        t = _generate_lsq_knots(
+            x,
+            k=(1, 2),
+            n_internal_knots=(1, 2),
+            bbox=((0.0, 1.0), (-1.0, 1.0)),
+        )
+
+        expected0 = np.r_[
+            0.0, 0.0, np.quantile(x[:, 0], 0.5), 1.0, 1.0
+        ]
+        expected1 = np.r_[
+            (-1.0,) * 3,
+            np.quantile(x[:, 1], [1.0 / 3.0, 2.0 / 3.0]),
+            (1.0,) * 3,
+        ]
+
+        xp_assert_close(t[0], expected0)
+        xp_assert_close(t[1], expected1)
+
+    def test_validation(self):
+        x = np.linspace(0.0, 1.0, 5)
+
+        with assert_raises(ValueError, match="1D array"):
+            _generate_lsq_knots_1d(x[:, None], k=1, n_internal_knots=0)
+
+        with assert_raises(ValueError, match="at least one data point"):
+            _generate_lsq_knots_1d([], k=1, n_internal_knots=0)
+
+        with assert_raises(ValueError, match="finite"):
+            _generate_lsq_knots_1d([0.0, np.nan], k=1, n_internal_knots=0)
+
+        with assert_raises(ValueError, match="negative"):
+            _generate_lsq_knots_1d(x, k=-1, n_internal_knots=0)
+
+        with assert_raises(ValueError, match="negative"):
+            _generate_lsq_knots_1d(x, k=1, n_internal_knots=-1)
+
+        with assert_raises(ValueError, match="shape"):
+            _generate_lsq_knots_1d(x, k=1, n_internal_knots=0, bbox=(0.0,))
+
+        with assert_raises(ValueError, match="less than"):
+            _generate_lsq_knots_1d(
+                x, k=1, n_internal_knots=0, bbox=(1.0, 0.0)
+            )
+
+        with assert_raises(ValueError, match="in `bbox`"):
+            _generate_lsq_knots_1d(
+                x, k=1, n_internal_knots=0, bbox=(2.0, 3.0)
+            )
+
+        with assert_raises(ValueError, match="distinct interior"):
+            _generate_lsq_knots_1d(
+                [0.0, 0.0, 1.0], k=1, n_internal_knots=2
+            )
+
+        with assert_raises(ValueError, match="Expected 2 knot counts"):
+            _generate_lsq_knots(
+                np.column_stack((x, x)), k=1, n_internal_knots=(0, 0, 0)
+            )
+
+    def test_generated_knots_fit_linear_data(self):
+        x = np.linspace(0.0, 1.0, 20)
+        y = 2.0 * x - 1.0
+        t = (_generate_lsq_knots_1d(x, k=1, n_internal_knots=3),)
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=1)
+
+        xp_assert_close(spl(x[:, None]), y, atol=1e-13)
 
 
 class TestMakeLSQNdBSpline:

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3075,10 +3075,33 @@ class TestMakeLSQNdBSpline:
         y = x[:, 0]
         t = (np.r_[0.0, 0.0, 1.0, 1.0],)
 
-        with assert_raises(ValueError, match="positive"):
+        with assert_raises(ValueError, match="non-negative"):
             _make_lsq_ndbspl(
-                x, y, t, k=1, w=[1.0, 1.0, 0.0, 1.0, 1.0]
+                x, y, t, k=1, w=[1.0, 1.0, -1.0, 1.0, 1.0]
             )
+
+    def test_zero_weights_are_allowed(self):
+        x = np.linspace(0.0, 1.0, 8)
+        y = np.array([1.0, 1.1, 1.4, 1.9, 2.6, 3.4, 4.1, 5.0])
+        w = np.ones_like(x)
+        w[2:4] = 0.0
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=1, w=w)
+        matr = NdBSpline.design_matrix(x[:, None], t, 1).toarray()
+        coeffs, *_ = np.linalg.lstsq(matr * w[:, None], y * w, rcond=None)
+
+        xp_assert_close(spl.c, coeffs, atol=1e-12)
+
+    def test_zero_weights_do_not_support_basis(self):
+        x = np.linspace(0.0, 1.0, 8)
+        y = x
+        w = np.ones_like(x)
+        w[x <= 0.5] = 0.0
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="support every"):
+            _make_lsq_ndbspl(x[:, None], y, t, k=1, w=w)
 
     def test_invalid_input_validation(self):
         x = np.linspace(0.0, 1.0, 5)[:, None]

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -3016,6 +3016,44 @@ class TestMakeLSQNdBSpline:
         assert spl.c.shape == (2, 2)
         xp_assert_close(spl(x_eval), expected, atol=1e-13)
 
+    def test_trailing_dimensions_with_custom_solver(self):
+        x = np.linspace(0.0, 1.0, 6)
+        y = np.empty((x.size, 2, 2))
+        y[:, 0, 0] = 1.0 + x
+        y[:, 0, 1] = 2.0 - x
+        y[:, 1, 0] = -1.0 + 3.0 * x
+        y[:, 1, 1] = 0.5 - 2.0 * x
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+        calls = []
+
+        def dense_solver(a, b):
+            calls.append((a.shape, b.shape))
+            coef, *_ = np.linalg.lstsq(a.toarray(), b, rcond=None)
+            return coef, 1
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=1, solver=dense_solver)
+        matr = NdBSpline.design_matrix(x[:, None], t, 1).toarray()
+        ref, *_ = np.linalg.lstsq(
+            matr, y.reshape((x.size, 4)), rcond=None
+        )
+        ref = ref.reshape((2, 2, 2))
+
+        assert calls == [((x.size, 2), (x.size,))] * 4
+        xp_assert_close(spl.c, ref, atol=1e-13)
+
+    def test_complex_valued_output(self):
+        x = np.linspace(0.0, 1.0, 12)
+        y = (2.0 * x + 1.0) + 1j * (-3.0 * x + 4.0)
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        spl = _make_lsq_ndbspl(x[:, None], y, t, k=1)
+        x_eval = np.array([[0.25], [0.75]])
+        expected = (2.0 * x_eval[:, 0] + 1.0) + 1j * (
+            -3.0 * x_eval[:, 0] + 4.0
+        )
+
+        xp_assert_close(spl(x_eval), expected, atol=1e-13)
+
     def test_too_few_points_raises(self):
         x = np.array([[0.0], [1.0]])
         y = np.array([0.0, 1.0])
@@ -3041,6 +3079,33 @@ class TestMakeLSQNdBSpline:
             _make_lsq_ndbspl(
                 x, y, t, k=1, w=[1.0, 1.0, 0.0, 1.0, 1.0]
             )
+
+    def test_invalid_input_validation(self):
+        x = np.linspace(0.0, 1.0, 5)[:, None]
+        y = x[:, 0]
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="2D array"):
+            _make_lsq_ndbspl(x[:, 0], y, t, k=1)
+
+        x_bad = x.copy()
+        x_bad[0, 0] = np.nan
+        with assert_raises(ValueError, match="finite values"):
+            _make_lsq_ndbspl(x_bad, y, t, k=1)
+
+        with assert_raises(ValueError, match="matching"):
+            _make_lsq_ndbspl(x, y[:-1], t, k=1)
+
+        y_bad = y.copy()
+        y_bad[0] = np.inf
+        with assert_raises(ValueError, match="finite values"):
+            _make_lsq_ndbspl(x, y_bad, t, k=1)
+
+        with assert_raises(ValueError, match="empty trailing"):
+            _make_lsq_ndbspl(x, np.empty((x.shape[0], 0)), t, k=1)
+
+        with assert_raises(ValueError, match="callable"):
+            _make_lsq_ndbspl(x, y, t, k=1, solver=None)
 
 
 class TestMakeND:


### PR DESCRIPTION
Follow-up to tracker/design PR gh-25472.

This adds private quantile-based knot helper routines for least-squares N-D spline construction.

The scope is intentionally internal and small:
- `_generate_lsq_knots_1d` generates a full clamped 1D knot vector from sample quantiles;
- `_generate_lsq_knots` applies the 1D rule independently per coordinate dimension;
- no public API is added;
- no smoothing or fitting behavior is changed.

This is intended as the automatic-knot-selection chunk discussed in the tracker PR. The current implementation uses sample quantiles, so interior knots are denser where samples are denser.

Local checks run:
- `pycodestyle --diff --max-line-length=88`
- `python -m py_compile scipy/interpolate/_ndbspline.py`
- `TestGenerateLSQKnots` + `TestMakeLSQNdBSpline`: 15 passed
- Neighboring NdBSpline tests: 57 passed
- `git diff --check`