### PR TITLE
BUG: interpolate: ensure interpolators are pickleable

### DIFF
--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -514,7 +514,7 @@ class interp1d(_Interpolator1D):
             ((x_new - x_lo)/(x_hi - x_lo))[:, None] * y_hi
             + ((x_hi - x_new)/(x_hi - x_lo))[:, None] * y_lo
             )
-        
+
         return y_new
 
     def _call_nearest(self, x_new):
@@ -1402,6 +1402,18 @@ class PPoly:
         self._xp = xp
         self._xp_internal = xp_internal
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_xp"] = state["_xp"].empty(0)
+        state.pop("_xp_internal")
+        return state
+
+    def __setstate__(self, state):
+        self._xp = array_namespace(state.pop("_xp"))
+        _, xp_internal = _get_xp_ppoly_cls(self._xp)
+        self._xp_internal = xp_internal
+        self.__dict__.update(state)
+
     @classmethod
     def _construct_from_xp(cls, xp_ppoly, *, xp_external):
         self = object.__new__(cls)
@@ -1920,6 +1932,18 @@ class BPoly:
         self._delegate_to = xp_bpoly_cls(c, x, extrapolate=extrapolate, axis=axis)
         self._xp = xp
         self._xp_internal = xp_internal
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_xp"] = state["_xp"].empty(0)
+        state.pop("_xp_internal")
+        return state
+
+    def __setstate__(self, state):
+        self._xp = array_namespace(state.pop("_xp"))
+        _, xp_internal = _get_xp_bpoly_cls(self._xp)
+        self._xp_internal = xp_internal
+        self.__dict__.update(state)
 
     @classmethod
     def _construct_from_xp(cls, xp_bpoly, *, xp_external):

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -2830,7 +2830,7 @@ def test_pickleable_1D(interp):
     obj = interp(x, y)
     y1 = obj(x_eval)
     y2 = pickle.loads(pickle.dumps(obj))(x_eval)
-    np.testing.assert_allclose(y1, y2)
+    xp_assert_close(y1, y2, atol=1e-12)
 
 
 @pytest.mark.parametrize("interp", [LinearNDInterpolator,
@@ -2855,4 +2855,4 @@ def test_pickleable_2D(interp):
     eval_points = np.column_stack([X_eval.ravel(), Y_eval.ravel()])
     Z1 = obj(eval_points)
     Z2 = pickle.loads(pickle.dumps(obj))(eval_points)
-    np.testing.assert_allclose(Z1, Z2)
+    xp_assert_close(Z1, Z2, atol=1e-12)

--- a/scipy/interpolate/tests/test_interpolate.py
+++ b/scipy/interpolate/tests/test_interpolate.py
@@ -1,3 +1,5 @@
+import pickle
+
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, assert_almost_equal, assert_array_almost_equal,
     make_xp_test_case, is_cupy, _xp_copy_to_numpy
@@ -11,7 +13,10 @@ import numpy as np
 
 from scipy.interpolate import (interp1d, interp2d, lagrange, PPoly, BPoly,
         splrep, splev, splantider, splint, sproot, Akima1DInterpolator,
-        NdPPoly, BSpline, PchipInterpolator)
+        NdPPoly, BSpline, PchipInterpolator, make_interp_spline, CubicSpline,
+        FloaterHormannInterpolator, BarycentricInterpolator, KroghInterpolator,
+        CubicHermiteSpline, LinearNDInterpolator, NearestNDInterpolator,
+        CloughTocher2DInterpolator, RBFInterpolator, RegularGridInterpolator)
 
 from scipy.special import poch, gamma
 
@@ -2807,3 +2812,47 @@ def _ppoly4d_eval(c, xs, xnew, ynew, znew, unew, nu=None):
         out[jout] = val
 
     return out
+
+@pytest.mark.parametrize("interp", [make_interp_spline,  # BSpline
+                                    CubicSpline,
+                                    PchipInterpolator,
+                                    Akima1DInterpolator,
+                                    FloaterHormannInterpolator,
+                                    BarycentricInterpolator,
+                                    KroghInterpolator,
+                                    lambda x, y: BPoly.from_derivatives(
+                                        x,[[yi, yi, yi] for yi in y]),
+                                    lambda x, y: CubicHermiteSpline(x, y, y)])  # PPoly
+def test_pickleable_1D(interp):
+    x = np.linspace(0, 1, 10)
+    y = np.exp(x)
+    x_eval = np.linspace(0, 1, 100)
+    obj = interp(x, y)
+    y1 = obj(x_eval)
+    y2 = pickle.loads(pickle.dumps(obj))(x_eval)
+    np.testing.assert_allclose(y1, y2)
+
+
+@pytest.mark.parametrize("interp", [LinearNDInterpolator,
+                                    NearestNDInterpolator,
+                                    CloughTocher2DInterpolator,
+                                    RBFInterpolator,
+                                    RegularGridInterpolator,])
+def test_pickleable_2D(interp):
+    # generate data on a regular grid
+    x = np.linspace(0, 1, 5)
+    y = np.linspace(0, 1, 5)
+    X, Y = np.meshgrid(x, y)
+    Z = np.exp(X + Y)
+    points = np.column_stack([X.ravel(), Y.ravel()])
+    if interp is RegularGridInterpolator:
+        obj = interp((x, y), Z)
+    else:
+        obj = interp(points, Z.ravel())
+    x_eval = np.linspace(0, 1, 10)
+    y_eval = np.linspace(0, 1, 10)
+    X_eval, Y_eval = np.meshgrid(x_eval, y_eval)
+    eval_points = np.column_stack([X_eval.ravel(), Y_eval.ravel()])
+    Z1 = obj(eval_points)
+    Z2 = pickle.loads(pickle.dumps(obj))(eval_points)
+    np.testing.assert_allclose(Z1, Z2)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #25489
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds tests to check interpolators can be pickled and fixes those which can't be
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
I used chatgpt to get a few suggestions.