### PR TITLE
ENH: add internal gridded LSQ NdBSpline helper

### DIFF
--- a/scipy/interpolate/_ndbspline.py
+++ b/scipy/interpolate/_ndbspline.py
@@ -571,6 +571,48 @@ def _make_lsq_ndbspl(
     return NdBSpline(t, coef, tuple(k))
 
 
+def _make_lsq_ndbspl_from_grid(
+    points, values, t, k=3, *, w=None, solver=ssl.lsqr, **solver_args
+):
+    """Construct a least-squares ``NdBSpline`` from gridded data."""
+    if not isinstance(points, tuple):
+        raise ValueError("`points` must be a tuple of 1D arrays.")
+    if len(points) == 0:
+        raise ValueError("`points` must contain at least one dimension.")
+
+    points = tuple(np.asarray(point, dtype=float) for point in points)
+    for d, point in enumerate(points):
+        if point.ndim != 1:
+            raise ValueError(f"`points[{d}]` must be 1D.")
+        if point.size == 0:
+            raise ValueError(f"`points[{d}]` must not be empty.")
+        if not np.isfinite(point).all():
+            raise ValueError(f"`points[{d}]` must contain only finite values.")
+
+    grid_shape = tuple(point.size for point in points)
+    values = np.asarray(values)
+    ndim = len(points)
+    if values.ndim < ndim or values.shape[:ndim] != grid_shape:
+        raise ValueError(
+            "`values` must have shape points[0].shape + ... + "
+            "points[-1].shape + trailing dimensions."
+        )
+
+    grids = np.meshgrid(*points, indexing="ij")
+    x = np.column_stack([grid.ravel() for grid in grids])
+    y = values.reshape((prod(grid_shape),) + values.shape[ndim:])
+
+    if w is not None:
+        w = np.asarray(w, dtype=float)
+        if w.shape != grid_shape:
+            raise ValueError("`w` must have shape matching the grid.")
+        w = w.ravel()
+
+    return _make_lsq_ndbspl(
+        x, y, t, k=k, w=w, solver=solver, **solver_args
+    )
+
+
 def _validate_lsq_weights(w, npts):
     """Validate least-squares weights."""
     w = np.asarray(w, dtype=float)

--- a/scipy/interpolate/tests/test_bsplines.py
+++ b/scipy/interpolate/tests/test_bsplines.py
@@ -37,7 +37,9 @@ from scipy._lib._util import AxisError
 from scipy._lib._testutils import _run_concurrent_barrier, IS_WASM
 
 # XXX: move to the interpolate namespace
-from scipy.interpolate._ndbspline import _make_lsq_ndbspl, make_ndbspl
+from scipy.interpolate._ndbspline import (
+    _make_lsq_ndbspl, _make_lsq_ndbspl_from_grid, make_ndbspl
+)
 
 from scipy.interpolate import _fitpack as dfitpack
 from scipy.interpolate import _bsplines as _b
@@ -3424,6 +3426,92 @@ class TestMakeLSQNdBSpline:
 
         with assert_raises(ValueError, match="callable"):
             _make_lsq_ndbspl(x, y, t, k=1, solver=None)
+
+
+class TestMakeLSQNdBSplineFromGrid:
+    def test_matches_scattered_input(self):
+        points = (
+            np.linspace(0.0, 1.0, 5),
+            np.linspace(-1.0, 1.0, 6),
+        )
+        x0, x1 = np.meshgrid(*points, indexing="ij")
+        values = 1.0 + 2.0 * x0 - x1 + 0.5 * x0 * x1
+        t = (
+            np.r_[0.0, 0.0, 1.0, 1.0],
+            np.r_[-1.0, -1.0, 1.0, 1.0],
+        )
+
+        spl = _make_lsq_ndbspl_from_grid(points, values, t, k=1)
+        x = np.column_stack((x0.ravel(), x1.ravel()))
+        ref = _make_lsq_ndbspl(x, values.ravel(), t, k=1)
+
+        xp_assert_close(spl.c, ref.c, atol=1e-12)
+
+    def test_trailing_dimensions(self):
+        points = (
+            np.linspace(0.0, 1.0, 5),
+            np.linspace(-1.0, 1.0, 6),
+        )
+        x0, x1 = np.meshgrid(*points, indexing="ij")
+        values = np.empty(x0.shape + (2,))
+        values[..., 0] = 1.0 + x0 - x1
+        values[..., 1] = -2.0 + 3.0 * x0 + 0.5 * x1
+        t = (
+            np.r_[0.0, 0.0, 1.0, 1.0],
+            np.r_[-1.0, -1.0, 1.0, 1.0],
+        )
+
+        spl = _make_lsq_ndbspl_from_grid(points, values, t, k=1)
+        x_eval = np.array([[0.25, -0.5], [0.75, 0.5]])
+        expected = np.column_stack(
+            (
+                1.0 + x_eval[:, 0] - x_eval[:, 1],
+                -2.0 + 3.0 * x_eval[:, 0] + 0.5 * x_eval[:, 1],
+            )
+        )
+
+        assert spl.c.shape == (2, 2, 2)
+        xp_assert_close(spl(x_eval), expected, atol=1e-12)
+
+    def test_weights_match_scattered_input(self):
+        points = (np.linspace(0.0, 1.0, 5),)
+        values = np.array([0.0, 0.2, 0.7, 1.1, 2.0])
+        w = np.linspace(1.0, 2.0, values.size)
+        t = (np.r_[0.0, 0.0, 0.5, 1.0, 1.0],)
+
+        spl = _make_lsq_ndbspl_from_grid(points, values, t, k=1, w=w)
+        ref = _make_lsq_ndbspl(
+            points[0][:, None], values, t, k=1, w=w
+        )
+
+        xp_assert_close(spl.c, ref.c, atol=1e-12)
+
+    def test_validation(self):
+        points = (np.linspace(0.0, 1.0, 5),)
+        values = np.linspace(0.0, 1.0, 5)
+        w = np.ones(values.size)
+        t = (np.r_[0.0, 0.0, 1.0, 1.0],)
+
+        with assert_raises(ValueError, match="tuple"):
+            _make_lsq_ndbspl_from_grid(points[0], values, t, k=1)
+
+        with assert_raises(ValueError, match="at least one dimension"):
+            _make_lsq_ndbspl_from_grid((), values, t, k=1)
+
+        with assert_raises(ValueError, match="1D"):
+            _make_lsq_ndbspl_from_grid((points[0][:, None],), values, t, k=1)
+
+        with assert_raises(ValueError, match="must not be empty"):
+            _make_lsq_ndbspl_from_grid(([],), values[:0], t, k=1)
+
+        with assert_raises(ValueError, match="finite"):
+            _make_lsq_ndbspl_from_grid(([0.0, np.nan],), values[:2], t, k=1)
+
+        with assert_raises(ValueError, match="`values` must have shape"):
+            _make_lsq_ndbspl_from_grid(points, values[:-1], t, k=1)
+
+        with assert_raises(ValueError, match="`w` must have shape"):
+            _make_lsq_ndbspl_from_grid(points, values, t, k=1, w=w[:-1])
 
 
 class TestMakeND:


### PR DESCRIPTION
Follow-up to tracker/design PR gh-25472 and stacked on gh-25493.

This adds a small private helper for fitting least-squares `NdBSpline` objects from full rectilinear grid data.

The existing core helper `_make_lsq_ndbspl` expects scattered sample coordinates with shape `(npts, ndim)`. This PR adds `_make_lsq_ndbspl_from_grid`, which accepts grid axes and grid-shaped values, converts them internally to scattered rows, and then delegates to `_make_lsq_ndbspl`.

Scope:

- add `_make_lsq_ndbspl_from_grid`;
- support scalar-valued gridded data;
- support trailing output dimensions in `values`;
- support grid-shaped weights;
- add tests comparing the gridded helper against equivalent scattered input;
- no public API is added;
- no solver or fitting behavior is changed.

This is intended as the gridded-data convenience chunk discussed in gh-25472. A later public API can decide whether gridded and scattered inputs should be dispatched through one user-facing function.