### PR TITLE
ENH: interpolate: add CuPy support for `CubicHermiteSpline`, `CubicSpline`, `Akima1DInterpolator`

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -73,11 +73,12 @@ def prepare_input(x, y, axis, dydx=None, xp=None):
 
 
 @xp_capabilities(
-    cpu_only=True, jax_jit=False,
+    cpu_only=True,
+    jax_jit=False,
+    exceptions=["cupy"],
     skip_backends=[
-        ("dask.array",
-         "https://github.com/data-apis/array-api-extra/issues/488")
-    ]
+        ("dask.array", "https://github.com/data-apis/array-api-extra/issues/488")
+    ],
 )
 class CubicHermiteSpline(PPoly):
     """Piecewise cubic interpolator to fit values and first derivatives (C1 smooth).
@@ -412,9 +413,14 @@ def pchip_interpolate(xi, yi, x, der=0, axis=0):
         return [P.derivative(nu)(x) for nu in der]
 
 
-@xp_capabilities(cpu_only=True, jax_jit=False, xfail_backends=[
-    ("dask.array", "lacks nd fancy indexing"),
-])
+@xp_capabilities(
+    cpu_only=True,
+    jax_jit=False,
+    exceptions=["cupy"],
+    xfail_backends=[
+        ("dask.array", "lacks nd fancy indexing"),
+    ],
+)
 class Akima1DInterpolator(CubicHermiteSpline):
     r"""Akima "visually pleasing" interpolator (C1 smooth).
 
@@ -629,11 +635,12 @@ class Akima1DInterpolator(CubicHermiteSpline):
 
 
 @xp_capabilities(
-    cpu_only=True, jax_jit=False,
+    cpu_only=True,
+    jax_jit=False,
+    exceptions=["cupy"],
     skip_backends=[
-        ("dask.array",
-         "https://github.com/data-apis/array-api-extra/issues/488")
-    ]
+        ("dask.array", "https://github.com/data-apis/array-api-extra/issues/488")
+    ],
 )
 class CubicSpline(CubicHermiteSpline):
     """Piecewise cubic interpolator to fit values (C2 smooth).

--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -5,7 +5,9 @@ from typing import Literal
 import numpy as np
 
 from scipy.linalg import solve, solve_banded
-from scipy._lib._array_api import array_namespace, xp_size, xp_capabilities
+from scipy._lib._array_api import (
+    array_namespace, xp_size, xp_capabilities, is_cupy, scipy_namespace_for
+)
 from scipy._external.array_api_compat import numpy as np_compat
 import scipy._external.array_api_extra as xpx
 
@@ -812,6 +814,16 @@ class CubicSpline(CubicHermiteSpline):
 
     def __init__(self, x, y, axis=0, bc_type='not-a-knot', extrapolate=None):
         xp = array_namespace(x, y)
+        if is_cupy(xp):
+            spx = scipy_namespace_for(xp)
+            xp_cubic_spline = spx.interpolate.CubicSpline(
+                x, y, axis=axis, bc_type=bc_type, extrapolate=extrapolate
+            )
+            self.__dict__.update(
+                PPoly._construct_from_xp(xp_cubic_spline, xp_external=xp).__dict__
+            )
+            return
+
         x, dx, y, axis, _ = prepare_input(x, y, axis, xp=np_compat)
         n = len(x)
 

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -3,7 +3,8 @@ import io
 import numpy as np
 
 from scipy._lib._array_api import (
-    xp_assert_equal, xp_assert_close, assert_almost_equal, make_xp_test_case
+    xp_assert_equal, xp_assert_close, assert_almost_equal, make_xp_test_case,
+    _xp_copy_to_numpy
 )
 from pytest import raises as assert_raises
 import pytest
@@ -795,11 +796,12 @@ class TestCubicSpline:
     def test_periodic_eval(self, xp):
         x = xp.linspace(0, 2 * xp.pi, 10, dtype=xp.float64)
         y = xp.cos(x)
-        S = CubicSpline(x, y, bc_type='periodic')
-        assert_almost_equal(S(1), S(1 + 2 * xp.pi), decimal=15)
+        x_np, y_np = map(_xp_copy_to_numpy, (x, y))
+        S = CubicSpline(x_np, y_np, bc_type='periodic')
+        assert_almost_equal(xp.asarray(S(1)), xp.asarray(S(1 + 2 * xp.pi)), decimal=15)
 
-        S = CubicSpline(x, y)
-        assert_almost_equal(S(x), xp.cos(x), decimal=15)
+        S = CubicSpline(x_np, y_np)
+        assert_almost_equal(xp.asarray(S(x_np)), y, decimal=15)
 
     def test_second_derivative_continuity_gh_11758(self):
         # gh-11758: C2 continuity fail

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from scipy._lib._array_api import (
     xp_assert_equal, xp_assert_close, assert_almost_equal, make_xp_test_case,
-    _xp_copy_to_numpy
 )
 from pytest import raises as assert_raises
 import pytest
@@ -796,12 +795,11 @@ class TestCubicSpline:
     def test_periodic_eval(self, xp):
         x = xp.linspace(0, 2 * xp.pi, 10, dtype=xp.float64)
         y = xp.cos(x)
-        x_np, y_np = map(_xp_copy_to_numpy, (x, y))
-        S = CubicSpline(x_np, y_np, bc_type='periodic')
-        assert_almost_equal(xp.asarray(S(1)), xp.asarray(S(1 + 2 * xp.pi)), decimal=15)
+        S = CubicSpline(x, y, bc_type='periodic')
+        xp_assert_close(S(1), S(1 + 2 * xp.pi), rtol=1e-15)
 
-        S = CubicSpline(x_np, y_np)
-        assert_almost_equal(xp.asarray(S(x_np)), y, decimal=15)
+        S = CubicSpline(x, y)
+        xp_assert_close(S(x), xp.cos(x), rtol=1e-15)
 
     def test_second_derivative_continuity_gh_11758(self):
         # gh-11758: C2 continuity fail

--- a/scipy/interpolate/tests/test_polyint.py
+++ b/scipy/interpolate/tests/test_polyint.py
@@ -3,7 +3,7 @@ import io
 import numpy as np
 
 from scipy._lib._array_api import (
-    xp_assert_equal, xp_assert_close, assert_almost_equal, make_xp_test_case,
+    xp_assert_equal, xp_assert_close, assert_almost_equal, make_xp_test_case
 )
 from pytest import raises as assert_raises
 import pytest


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
- add CuPy support for `CubicHermiteSpline`, `CubicSpline`, `Akima1DInterpolator`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI