### PR TITLE
MAINT: interpolate: use `xp.square` instead of `r**2`

### DIFF
--- a/scipy/interpolate/_rbfinterp_xp.py
+++ b/scipy/interpolate/_rbfinterp_xp.py
@@ -97,31 +97,32 @@ def linear(r, xp):
 
 def thin_plate_spline(r, xp):
     # NB: changed w.r.t. pythran, vectorized
-    return xp.where(r == 0, 0, r**2 * xp.log(r))
+    return xp.where(r == 0, 0, xp.square(r) * xp.log(r))
 
 
 def cubic(r, xp):
-    return r**3
+    # CuPy 14.0.1: r**2 is much slower than square(r)
+    return xp.square(r) * r
 
 
 def quintic(r, xp):
-    return -r**5
+    return -xp.square(xp.square(r)) * r
 
 
 def multiquadric(r, xp):
-    return -xp.sqrt(r**2 + 1)
+    return -xp.sqrt(xp.square(r) + 1)
 
 
 def inverse_multiquadric(r, xp):
-    return 1.0 / xp.sqrt(r**2 + 1.0)
+    return 1.0 / xp.sqrt(xp.square(r) + 1.0)
 
 
 def inverse_quadratic(r, xp):
-    return 1.0 / (r**2 + 1.0)
+    return 1.0 / (xp.square(r) + 1.0)
 
 
 def gaussian(r, xp):
-    return xp.exp(-r**2)
+    return xp.exp(-xp.square(r))
 
 
 NAME_TO_FUNC = {


### PR DESCRIPTION
@seberg pointed out to me that apparently, `r**2` is slow in CuPy, and `xp.square` is much faster (thanks Sebastian!):

```
In [7]: N = 100_000

In [8]: x = cupy.linspace(0, 2*cupy.pi, N, dtype=float)

In [9]: %gpu_timeit x**2
run                 :    CPU:    25.341 us   +/-  3.771 (min:    23.170 / max:    61.581) us     GPU-0:   120.440 us   +/- 14.234 (min:   112.640 / max:   184.320) us

In [10]: %gpu_timeit cupy.square(x)
run                 :    CPU:    20.959 us   +/-  5.786 (min:    17.630 / max:   102.801) us     GPU-0:    24.773 us   +/-  6.455 (min:    20.480 / max:   109.984) us

In [15]: cupy.__version__
Out[15]: '14.0.1'
```

- The difference is in an under a millisecond range yes, but at least in some workloads this (along with other, cupy-specific tricks) closes a performance gap between CuPy and PyTorch.
- While this might be improved in a future CuPy version, we use CuPy 13 still, and will keep using it for a while more, so let's use the dedicated ufunc for squaring.


#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.