### PR TITLE
Changed value of mach/speed_of_sound to match ISA/ISO standards.

### DIFF
--- a/scipy/constants/_constants.py
+++ b/scipy/constants/_constants.py
@@ -197,7 +197,7 @@ fluid_ounce_imp = gallon_imp / 160
 kmh = 1e3 / hour
 mph = mile / hour
 # approx value of mach at 15 degrees in 1 atm. Is this a common value?
-mach = speed_of_sound = 340.5
+mach = speed_of_sound = 340.3
 knot = nautical_mile / hour
 
 # temperature in kelvin


### PR DESCRIPTION
This PR updates the value of mach/speed_of_sound value to 340.3 from 340.5 matching ISA/ISO standards.

The value according to ISA/ISO standards is 340.294 so 340.5 can be a over-approximation so i changed it to 340.3 which is closer rounded value to 340.249.


This PR only updates the constants and does not modify any other functionality. 