### PR TITLE
BUG: integrate: guard against NULL PyTuple_New in DVODE/ZVODE thunks

### DIFF
--- a/scipy/integrate/_dzvodemodule.c
+++ b/scipy/integrate/_dzvodemodule.c
@@ -197,23 +197,22 @@ dvode_function_thunk(int neq, double t, double* y, double* ydot, double* rpar, i
         return;
     }
 
+    Py_ssize_t nargs = 0;
     if (current_dvode_callback->func_args) {
-        Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
-        args_tuple = PyTuple_New(2 + nargs);
-        if (args_tuple == NULL) {
-            Py_DECREF(py_t);
-            Py_DECREF(py_y);
-            return;
-        }
-        PyTuple_SET_ITEM(args_tuple, 0, py_t);
-        PyTuple_SET_ITEM(args_tuple, 1, py_y);
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            PyObject *arg = PyTuple_GET_ITEM(current_dvode_callback->func_args, i);
-            Py_INCREF(arg);
-            PyTuple_SET_ITEM(args_tuple, 2 + i, arg);
-        }
-    } else {
-        args_tuple = PyTuple_Pack(2, py_t, py_y);
+        nargs = PyTuple_Size(current_dvode_callback->func_args);
+    }
+    args_tuple = PyTuple_New(2 + nargs);
+    if (args_tuple == NULL) {
+        Py_DECREF(py_t);
+        Py_DECREF(py_y);
+        return;
+    }
+    PyTuple_SET_ITEM(args_tuple, 0, py_t);   /* steals py_t */
+    PyTuple_SET_ITEM(args_tuple, 1, py_y);   /* steals py_y */
+    for (Py_ssize_t i = 0; i < nargs; i++) {
+        PyObject *arg = PyTuple_GET_ITEM(current_dvode_callback->func_args, i);
+        Py_INCREF(arg);
+        PyTuple_SET_ITEM(args_tuple, 2 + i, arg);
     }
 
     // Call Python function
@@ -283,23 +282,22 @@ dvode_jacobian_thunk(int neq, double t, double* y, int ml, int mu,
         return;
     }
 
+    Py_ssize_t nargs = 0;
     if (current_dvode_callback->func_args) {
-        Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
-        jac_args_tuple = PyTuple_New(2 + nargs);
-        if (jac_args_tuple == NULL) {
-            Py_DECREF(py_t);
-            Py_DECREF(py_y);
-            return;
-        }
-        PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
-        PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            PyObject *arg = PyTuple_GET_ITEM(current_dvode_callback->func_args, i);
-            Py_INCREF(arg);
-            PyTuple_SET_ITEM(jac_args_tuple, 2 + i, arg);
-        }
-    } else {
-        jac_args_tuple = PyTuple_Pack(2, py_t, py_y);
+        nargs = PyTuple_Size(current_dvode_callback->func_args);
+    }
+    jac_args_tuple = PyTuple_New(2 + nargs);
+    if (jac_args_tuple == NULL) {
+        Py_DECREF(py_t);
+        Py_DECREF(py_y);
+        return;
+    }
+    PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);   /* steals py_t */
+    PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);   /* steals py_y */
+    for (Py_ssize_t i = 0; i < nargs; i++) {
+        PyObject *arg = PyTuple_GET_ITEM(current_dvode_callback->func_args, i);
+        Py_INCREF(arg);
+        PyTuple_SET_ITEM(jac_args_tuple, 2 + i, arg);
     }
 
     // Call Python Jacobian function
@@ -414,23 +412,22 @@ zvode_function_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, ZVODE_CPLX_TYPE* ydo
         return;
     }
 
+    Py_ssize_t nargs = 0;
     if (current_zvode_callback->func_args) {
-        Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
-        args_tuple = PyTuple_New(2 + nargs);
-        if (args_tuple == NULL) {
-            Py_DECREF(py_t);
-            Py_DECREF(py_y);
-            return;
-        }
-        PyTuple_SET_ITEM(args_tuple, 0, py_t);
-        PyTuple_SET_ITEM(args_tuple, 1, py_y);
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            PyObject *arg = PyTuple_GET_ITEM(current_zvode_callback->func_args, i);
-            Py_INCREF(arg);
-            PyTuple_SET_ITEM(args_tuple, 2 + i, arg);
-        }
-    } else {
-        args_tuple = PyTuple_Pack(2, py_t, py_y);
+        nargs = PyTuple_Size(current_zvode_callback->func_args);
+    }
+    args_tuple = PyTuple_New(2 + nargs);
+    if (args_tuple == NULL) {
+        Py_DECREF(py_t);
+        Py_DECREF(py_y);
+        return;
+    }
+    PyTuple_SET_ITEM(args_tuple, 0, py_t);   /* steals py_t */
+    PyTuple_SET_ITEM(args_tuple, 1, py_y);   /* steals py_y */
+    for (Py_ssize_t i = 0; i < nargs; i++) {
+        PyObject *arg = PyTuple_GET_ITEM(current_zvode_callback->func_args, i);
+        Py_INCREF(arg);
+        PyTuple_SET_ITEM(args_tuple, 2 + i, arg);
     }
 
     // Call Python function
@@ -500,23 +497,22 @@ zvode_jacobian_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, int ml, int mu,
         return;
     }
 
+    Py_ssize_t nargs = 0;
     if (current_zvode_callback->func_args) {
-        Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
-        jac_args_tuple = PyTuple_New(2 + nargs);
-        if (jac_args_tuple == NULL) {
-            Py_DECREF(py_t);
-            Py_DECREF(py_y);
-            return;
-        }
-        PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
-        PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
-        for (Py_ssize_t i = 0; i < nargs; i++) {
-            PyObject *arg = PyTuple_GET_ITEM(current_zvode_callback->func_args, i);
-            Py_INCREF(arg);
-            PyTuple_SET_ITEM(jac_args_tuple, 2 + i, arg);
-        }
-    } else {
-        jac_args_tuple = PyTuple_Pack(2, py_t, py_y);
+        nargs = PyTuple_Size(current_zvode_callback->func_args);
+    }
+    jac_args_tuple = PyTuple_New(2 + nargs);
+    if (jac_args_tuple == NULL) {
+        Py_DECREF(py_t);
+        Py_DECREF(py_y);
+        return;
+    }
+    PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);   /* steals py_t */
+    PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);   /* steals py_y */
+    for (Py_ssize_t i = 0; i < nargs; i++) {
+        PyObject *arg = PyTuple_GET_ITEM(current_zvode_callback->func_args, i);
+        Py_INCREF(arg);
+        PyTuple_SET_ITEM(jac_args_tuple, 2 + i, arg);
     }
 
     // Call Python Jacobian function

--- a/scipy/integrate/_dzvodemodule.c
+++ b/scipy/integrate/_dzvodemodule.c
@@ -200,6 +200,11 @@ dvode_function_thunk(int neq, double t, double* y, double* ydot, double* rpar, i
     if (current_dvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
         args_tuple = PyTuple_New(2 + nargs);
+        if (args_tuple == NULL) {
+            Py_DECREF(py_t);
+            Py_DECREF(py_y);
+            return;
+        }
         PyTuple_SET_ITEM(args_tuple, 0, py_t);
         PyTuple_SET_ITEM(args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -281,6 +286,11 @@ dvode_jacobian_thunk(int neq, double t, double* y, int ml, int mu,
     if (current_dvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_dvode_callback->func_args);
         jac_args_tuple = PyTuple_New(2 + nargs);
+        if (jac_args_tuple == NULL) {
+            Py_DECREF(py_t);
+            Py_DECREF(py_y);
+            return;
+        }
         PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
         PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -407,6 +417,11 @@ zvode_function_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, ZVODE_CPLX_TYPE* ydo
     if (current_zvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
         args_tuple = PyTuple_New(2 + nargs);
+        if (args_tuple == NULL) {
+            Py_DECREF(py_t);
+            Py_DECREF(py_y);
+            return;
+        }
         PyTuple_SET_ITEM(args_tuple, 0, py_t);
         PyTuple_SET_ITEM(args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {
@@ -488,6 +503,11 @@ zvode_jacobian_thunk(int neq, double t, ZVODE_CPLX_TYPE* y, int ml, int mu,
     if (current_zvode_callback->func_args) {
         Py_ssize_t nargs = PyTuple_Size(current_zvode_callback->func_args);
         jac_args_tuple = PyTuple_New(2 + nargs);
+        if (jac_args_tuple == NULL) {
+            Py_DECREF(py_t);
+            Py_DECREF(py_y);
+            return;
+        }
         PyTuple_SET_ITEM(jac_args_tuple, 0, py_t);
         PyTuple_SET_ITEM(jac_args_tuple, 1, py_y);
         for (Py_ssize_t i = 0; i < nargs; i++) {


### PR DESCRIPTION
#### What's the bug?
Before calling a callback, the code packs a few values into a small container (a "tuple"). The function that builds it can fail and return nothing when memory runs low. Right after, the code stuffs values into that container without checking it actually exists, so if it's empty, the program crashes (segfault).

#### Where?
Four near-identical spots in scipy's ODE-solver C file: the function and Jacobian callbacks for the DVODE and ZVODE solvers.

#### Why it matters?
There are two branches here. One uses a helper that safely handles the empty case, but that branch is effectively unreachable from Python. Default settings always route through the other branch, the unsafe one. So the crash is reachable in normal use, not theoretical.

#### The fix?
After building the container, check if it worked. If not, clean up and exit cleanly, the same way the surrounding code already handles errors. Normal runs behave identically; the only change is "don't crash when memory runs out."

Closes #25436.

#### AI declaration
AI (Claude) was used to assist this PR: locating the bug across the four spots, drafting the C null-check patch, and guiding the build and test steps (which I ran myself, verifying each output). I reviewed and verified all code and reasoning myself, and traced the call path to confirm the reachable branch. This description is written by me.