### PR TITLE
MAINT/DOC: Remove duplicate hidden toctree entries

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -64,7 +64,7 @@ plt.ioff()
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = {'.rst': 'restructuredtext'}
 
 # The main toctree document.
 master_doc = 'index'

--- a/doc/source/dev/contributor/contributor_toc.rst
+++ b/doc/source/dev/contributor/contributor_toc.rst
@@ -92,22 +92,12 @@ Compiled code
 .. toctree::
     :hidden:
 
-    development_workflow
-    pep8
     ../gitwash/gitwash
     reviewing_prs
-    ../triage
-    adding_new
-    ../core-dev/index
     ../missing-bits
     NumPy testing guidelines <https://numpy.org/devdocs/reference/testing.html>
     writing_test_tips
-    devpy_test
     debugging_linalg_issues
     How to contribute documentation <https://numpy.org/devdocs/dev/howto-docs.html>
-    rendering_documentation
     adding_notebooks
-    benchmarking
-    cython
     compiled_code
-    public_cython_api

--- a/doc/source/dev/index.rst
+++ b/doc/source/dev/index.rst
@@ -39,7 +39,6 @@ the organization section.
 .. toctree::
    :hidden:
 
-   contributor/development_workflow
    contributor/pep8
    contributor/rendering_documentation
    contributor/devpy_test

--- a/doc/source/reference/sparse.spmatrix_api.rst
+++ b/doc/source/reference/sparse.spmatrix_api.rst
@@ -67,12 +67,22 @@ Building sparse matrices
 
 Identifying sparse matrices
 ---------------------------
+.. The functions `issparse` and `isspmatrix` are already referenced in a toctree in the
+   file `scipy/sparse/__init__.py` via `doc/source/reference/sparse.rst`. To supress a
+   consistency check warning during build, those functions are placed in a table
+   instead of an `autosummary` block.
+
+.. list-table::
+   :header-rows: 0
+
+   * - `~scipy.sparse.issparse`\ (x)
+     - Check if the argument is a sparse object (array or matrix).
+   * - `~scipy.sparse.isspmatrix`\ (x)
+     - Check if the argument is an old style sparse matrix.
 
 .. autosummary::
    :toctree: generated/
 
-   issparse
-   isspmatrix
    isspmatrix_csc
    isspmatrix_csr
    isspmatrix_bsr

--- a/scipy/signal/__init__.py
+++ b/scipy/signal/__init__.py
@@ -167,37 +167,46 @@ Matlab-style IIR filter design
    iirpeak       -- Design second-order IIR peak (resonant) digital filter.
    iircomb       -- Design IIR comb filter.
 
-Continuous-time linear systems
-==============================
+
+
+Linear Systems
+==============
+
+Continuous-time or discrete-time:
+
+.. autosummary::
+   :toctree: generated/
+
+   StateSpace       -- Linear time invariant system in state space form.
+   TransferFunction -- Linear time invariant system in transfer function form.
+   ZerosPolesGain   -- Linear time invariant system in zeros, poles, gain form.
+
+
+Continuous-time:
 
 .. autosummary::
    :toctree: generated/
 
    lti              -- Continuous-time linear time invariant system base class.
-   StateSpace       -- Linear time invariant system in state space form.
-   TransferFunction -- Linear time invariant system in transfer function form.
-   ZerosPolesGain   -- Linear time invariant system in zeros, poles, gain form.
    lsim             -- Continuous-time simulation of output to linear system.
    impulse          -- Impulse response of linear, time-invariant (LTI) system.
    step             -- Step response of continuous-time LTI system.
    freqresp         -- Frequency response of a continuous-time LTI system.
    bode             -- Bode magnitude and phase data (continuous-time LTI).
 
-Discrete-time linear systems
-============================
+
+Discrete-time:
 
 .. autosummary::
    :toctree: generated/
 
    dlti             -- Discrete-time linear time invariant system base class.
-   StateSpace       -- Linear time invariant system in state space form.
-   TransferFunction -- Linear time invariant system in transfer function form.
-   ZerosPolesGain   -- Linear time invariant system in zeros, poles, gain form.
    dlsim            -- Simulation of output to a discrete-time linear system.
    dimpulse         -- Impulse response of a discrete-time LTI system.
    dstep            -- Step response of a discrete-time LTI system.
    dfreqresp        -- Frequency response of a discrete-time LTI system.
    dbode            -- Bode magnitude and phase data (discrete-time LTI).
+
 
 LTI representations
 ===================

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -1,4 +1,4 @@
-"""
+r"""
 ===================================
 Sparse arrays (:mod:`scipy.sparse`)
 ===================================
@@ -104,11 +104,18 @@ Sparse tools
 Identifying sparse arrays
 -------------------------
 
-.. autosummary::
-   :toctree: generated/
+.. The functions `issparse` and `isspmatrix` are already referenced in a toctree in the
+   file `doc/source/reference/sparse.spmatrix_api.rst`. To supress a consistency check
+   warning during build, those functions are placed in a table instead of an
+   `autosummary` block.
 
-   issparse - Check if the argument is a sparse object (array or matrix).
-   isspmatrix - Check if the argument is an old style sparse matrix.
+.. list-table::
+   :header-rows: 0
+
+   * - `~scipy.sparse.issparse`\ (x)
+     - Check if the argument is a sparse object (array or matrix).
+   * - `~scipy.sparse.isspmatrix`\ (x)
+     - Check if the argument is an old style sparse matrix.
 
 
 Warnings

--- a/scipy/sparse/__init__.py
+++ b/scipy/sparse/__init__.py
@@ -104,18 +104,11 @@ Sparse tools
 Identifying sparse arrays
 -------------------------
 
-.. The functions `issparse` and `isspmatrix` are already referenced in a toctree in the
-   file `doc/source/reference/sparse.spmatrix_api.rst`. To supress a consistency check
-   warning during build, those functions are placed in a table instead of an
-   `autosummary` block.
+.. autosummary::
+   :toctree: generated/
 
-.. list-table::
-   :header-rows: 0
-
-   * - `~scipy.sparse.issparse`\ (x)
-     - Check if the argument is a sparse object (array or matrix).
-   * - `~scipy.sparse.isspmatrix`\ (x)
-     - Check if the argument is an old style sparse matrix.
+   issparse
+   isspmatrix
 
 
 Warnings


### PR DESCRIPTION
When building the documentation, there are 15 log messages of the form:

```text
document is referenced in multiple toctrees: ['dev/contributor/contributor_toc', 'dev/index'], selecting: dev/index <- dev/contributor/adding_new
```

These messages are removed by:

1. Remove duplicate entries in hidden toctrees. The entry, which was not selected by Sphinx, is removed. (note that the original intention of "hidden toctrees" to set the "previous/next" ordering does not work with duplicate entries).
2. Modifying the "Linear Systems" section in the `signal` module. 
3. Modifying the (legacy) "Identifying sparse arrays" section in the sparse module.

Furthermore, the file `conf.py` is modified to suppress the log message "Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`".

#### AI Generation Disclosure
No AI tools were used.