### PR TITLE
TST: fft: add the marker fail_slow(2) to test_multiprocess

### DIFF
--- a/scipy/fft/tests/test_basic.py
+++ b/scipy/fft/tests/test_basic.py
@@ -481,6 +481,7 @@ class TestFFTThreadSafe:
         self._test_mtsame(fft.ihfft, a, xp=xp)
 
 
+@pytest.mark.fail_slow(2)
 @pytest.mark.parametrize("func", [fft.fft, fft.ifft, fft.rfft, fft.irfft])
 def test_multiprocess(func):
     # Test that fft still works after fork (gh-10422)


### PR DESCRIPTION
On some CI platforms where we use fail-slow=1, this test sometimes takes a bit more than 1 second.

Closes gh-25524

#### AI Generation Disclosure

No AI tools used.