### PR TITLE
ENH: More consistent distance_transform outputs with no background.

### DIFF
--- a/scipy/ndimage/_morphology.py
+++ b/scipy/ndimage/_morphology.py
@@ -2582,24 +2582,27 @@ def distance_transform_edt(input, sampling=None, return_distances=True,
         ft = np.zeros((input.ndim,) + input.shape, dtype=np.int32)
 
     _nd_image.euclidean_feature_transform(input, sampling, ft)
-    # if requested, calculate the distance transform
-    if return_distances:
-        dt = ft - np.indices(input.shape, dtype=ft.dtype)
-        dt = dt.astype(np.float64)
-        if sampling is not None:
-            for ii in range(len(sampling)):
-                dt[ii, ...] *= sampling[ii]
-        np.multiply(dt, dt, dt)
-        if dt_inplace:
-            dt = np.add.reduce(dt, axis=0)
-            if distances.shape != dt.shape:
-                raise RuntimeError('distances array has wrong shape')
-            if distances.dtype.type != np.float64:
-                raise RuntimeError('distances array must be float64')
-            np.sqrt(dt, distances)
-        else:
-            dt = np.add.reduce(dt, axis=0)
-            dt = np.sqrt(dt)
+    if ft.ravel()[0] == -1:  # no background
+        ft = np.full_like(ft, -1)
+        dt = np.full(input.shape, np.inf)
+    else:  # if requested, calculate the distance transform
+        if return_distances:
+            dt = ft - np.indices(input.shape, dtype=ft.dtype)
+            dt = dt.astype(np.float64)
+            if sampling is not None:
+                for ii in range(len(sampling)):
+                    dt[ii, ...] *= sampling[ii]
+            np.multiply(dt, dt, dt)
+            if dt_inplace:
+                dt = np.add.reduce(dt, axis=0)
+                if distances.shape != dt.shape:
+                    raise RuntimeError('distances array has wrong shape')
+                if distances.dtype.type != np.float64:
+                    raise RuntimeError('distances array must be float64')
+                np.sqrt(dt, distances)
+            else:
+                dt = np.add.reduce(dt, axis=0)
+                dt = np.sqrt(dt)
 
     # construct and return the result
     result = []

--- a/scipy/ndimage/src/ni_morphology.c
+++ b/scipy/ndimage/src/ni_morphology.c
@@ -647,7 +647,7 @@ int NI_DistanceTransformBruteForce(PyArrayObject* input, int metric,
     case NI_DISTANCE_EUCLIDIAN:
         for(jj = 0; jj < size; jj++) {
             if (*(npy_int8*)pi > 0) {
-                double distance = DBL_MAX;
+                double distance = INFINITY;
                 temp = border_elements;
                 while(temp) {
                     double d = 0.0, t;

--- a/scipy/ndimage/tests/test_morphology.py
+++ b/scipy/ndimage/tests/test_morphology.py
@@ -691,6 +691,61 @@ class TestNdimageMorphology:
             )
 
     @make_xp_test_case(ndimage.generate_binary_structure)
+    @pytest.mark.parametrize('metric', ['euclidean', 'taxicab', 'chessboard'])
+    @pytest.mark.parametrize('return_distances, return_indices',
+                             [(True, True), (True, False), (False, True)])
+    def test_distance_transform_bf_empty(
+            self, xp, metric, return_distances, return_indices):
+        data = xp.ones((3, 3), dtype=int)
+        res = ndimage.distance_transform_bf(
+            data, metric=metric,
+            return_distances=return_distances, return_indices=return_indices)
+        if return_distances:
+            distances = res[0] if return_indices else res
+            inf = {
+                'euclidean': np.inf,
+                'taxicab': np.iinfo(np.uint32).max,
+                'chessboard': np.iinfo(np.uint32).max,
+            }[metric]
+            assert (distances == inf).all()
+        if return_indices:
+            indices = res[1] if return_distances else res
+            assert (indices == 0).all()
+
+    @make_xp_test_case(ndimage.generate_binary_structure)
+    @pytest.mark.parametrize('return_distances, return_indices',
+                             [(True, True), (True, False), (False, True)])
+    def test_distance_transform_edt_empty(
+            self, xp, return_distances, return_indices):
+        data = xp.ones((3, 3), dtype=int)
+        res = ndimage.distance_transform_edt(
+            data,
+            return_distances=return_distances, return_indices=return_indices)
+        if return_distances:
+            distances = res[0] if return_indices else res
+            assert (distances == np.inf).all()
+        if return_indices:
+            indices = res[1] if return_distances else res
+            assert (indices == -1).all()
+
+    @make_xp_test_case(ndimage.generate_binary_structure)
+    @pytest.mark.parametrize('metric', ['chessboard', 'taxicab'])
+    @pytest.mark.parametrize('return_distances, return_indices',
+                             [(True, True), (True, False), (False, True)])
+    def test_distance_transform_cdt_empty(
+            self, xp, metric, return_distances, return_indices):
+        data = xp.ones((3, 3), dtype=int)
+        res = ndimage.distance_transform_cdt(
+            data,
+            return_distances=return_distances, return_indices=return_indices)
+        if return_distances:
+            distances = res[0] if return_indices else res
+            assert (distances == -1).all()
+        if return_indices:
+            indices = res[1] if return_distances else res
+            assert (indices == np.indices(data.shape)).all()
+
+    @make_xp_test_case(ndimage.generate_binary_structure)
     def test_generate_structure01(self, xp):
         struct = ndimage.generate_binary_structure(0, 1)
         assert struct == 1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
#1616

#### What does this implement/fix?
When no background pixel is present, make `distance_transform_bf(metric="euclidean")` and `distance_transform_edt()` return infinite distances.  Previously, `distance_transform_bf` returned `sqrt(UINT_MAX)` which is a bit weird, and `distance_transform_edt` returned the distance to `(-1, 0)`, which is clearly wrong.

The other distance_transform cases are unchanged but now tested: `distance_transform_bf` with taxicab and chessboard distances returns `distance=UINT_MAX` (it is documented to return *unsigned* distances), whereas `distance_transform_cdt` returns `distance=-1` (it is documented to return *signed* distances).

Also make the returned indices slightly consistent for `distance_transform_edt`, as the previously returned (-1, 0) was quite clearly an implementation detail.  I chose to return (-1, -1) which is a bit arbitrary but clearly signals that indices are invalid; `distance_transform_bf` currently returns (0, 0) and `distance_transform_cdt` currently returns (i, j) (the pixel itself) which are also arbitrary but nothing is obviously better, so it seems safer to not break backcompat.

Closes #1616, although some arbitrary design choices remain e.g. regarding whether we want to return other `indices` (if the PR review shows preference for one or the other I can implement that); some other inconsistencies e.g. UINT_MAX vs -1 seem impossible to fix without backcompat breakage.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
No AI tools used.

-----

PS: I couldn't find in https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr where to put (if anywhere) a changelog entry; maybe it's worth mentioning that info in that list?