### PR TITLE
DOC: signal.invres: add example

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3216,6 +3216,29 @@ def invres(r, p, k, tol=1e-3, rtype='avg'):
     --------
     residue, invresz, unique_roots
 
+    Examples
+    --------
+    ``invres`` can reconstruct the numerator and denominator polynomial
+    coefficients from a partial fraction expansion.
+
+    >>> import numpy as np
+    >>> from scipy.signal import residue, invres
+    >>> b = [1, 6, 2]
+    >>> a = [1, 3, 2]
+    >>> r, p, k = residue(b, a)
+    >>> r
+    array([-3.,  6.])
+    >>> p
+    array([-1., -2.])
+    >>> k
+    array([1.])
+
+    >>> b_reconstructed, a_reconstructed = invres(r, p, k)
+    >>> np.allclose(b_reconstructed, b)
+    True
+    >>> np.allclose(a_reconstructed, a)
+    True
+
     """
     r = np.atleast_1d(r)
     p = np.atleast_1d(p)


### PR DESCRIPTION
#### Reference issue

Addresses part of #7168.

#### What does this implement/fix?

Adds an `Examples` section to the `scipy.signal.invres` docstring showing how to reconstruct numerator and denominator polynomial coefficients from a partial fraction expansion produced by `scipy.signal.residue`.

#### Additional information

Validation performed:

- Ran the example code against the installed SciPy package to confirm the displayed residues, poles, direct term, and `np.allclose` checks.
- Parsed `scipy/signal/_signaltools.py` locally with Python `ast` to confirm the `invres` docstring contains the new `Examples` section.

I did not run the full SciPy doc/refguide build locally because this checkout has not been built and the required doc tooling is not installed in the current Python environment.