### PR TITLE
BUG: signal.freqz: handle multidim coefficients without trailing axis

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -337,9 +337,10 @@ def freqs_zpk(z, p, k, worN=200):
 
 
 def _freqz_trailing_axis_matches_worN(arr, worN, *, xp):
-    """
-    True when the last axis of `arr` pairs with one frequency per entry
-    (i.e. the length of `worN` equals ``arr.shape[-1]``).
+    """Return whether ``arr.shape[-1]`` already pairs with ``worN``.
+
+    This is True for layouts such as ``test_broadcasting3`` where the trailing
+    axis length equals the number of frequency points in ``worN``.
     """
     if arr.ndim <= 1 or arr.shape[-1] == 1:
         return False
@@ -527,6 +528,8 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
         # For backwards compatibility
         worN = 512
 
+    # gh-17387: arrays like ``(n_taps, n_filters)`` need a trailing axis so the
+    # last dimension is interpreted as batch rather than polynomial coefficients.
     if (b.ndim > 1 and b.shape[-1] != 1
             and not _freqz_trailing_axis_matches_worN(b, worN, xp=xp)
             and xp_size(a) == 1):

--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -336,6 +336,21 @@ def freqs_zpk(z, p, k, worN=200):
     return w, h
 
 
+def _freqz_trailing_axis_matches_worN(arr, worN, *, xp):
+    """
+    True when the last axis of `arr` pairs with one frequency per entry
+    (i.e. the length of `worN` equals ``arr.shape[-1]``).
+    """
+    if arr.ndim <= 1 or arr.shape[-1] == 1:
+        return False
+    if _is_int_type(worN):
+        return operator.index(worN) == arr.shape[-1]
+    worN_arr = xp.asarray(worN)
+    if worN_arr.ndim == 0:
+        return False
+    return xp_size(worN_arr) == arr.shape[-1]
+
+
 def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
           include_nyquist=False):
     """
@@ -511,6 +526,15 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
     if worN is None:
         # For backwards compatibility
         worN = 512
+
+    if (b.ndim > 1 and b.shape[-1] != 1
+            and not _freqz_trailing_axis_matches_worN(b, worN, xp=xp)
+            and xp_size(a) == 1):
+        b = b[..., xp.newaxis]
+    if (a.ndim > 1 and a.shape[-1] != 1
+            and not _freqz_trailing_axis_matches_worN(a, worN, xp=xp)
+            and b.ndim == 1):
+        a = a[..., xp.newaxis]
 
     h = None
 

--- a/scipy/signal/tests/test_filter_design.py
+++ b/scipy/signal/tests/test_filter_design.py
@@ -997,6 +997,50 @@ class TestFreqz:
                     xp_assert_close(ww, xp.asarray(w[k])[None])
                     xp_assert_close(hh, xp.asarray(h[k])[None])
 
+    def test_freqz_multidim_without_trailing_axis(self, xp):
+        # gh-17387: 2-D coefficients without a trailing length-1 axis
+        b = xp.zeros((128, 10))
+        w, h = freqz(b)
+        assert w.shape == (512,)
+        assert h.shape == (10, 512)
+        w2, h2 = freqz(b[:, 0])
+        xp_assert_close(w, w2)
+        xp_assert_close(h[0], h2)
+
+    def test_freqz_1d_regression_unchanged(self, xp):
+        # gh-17387: 1-D inputs must behave exactly as before the fix
+        b = xp.asarray([0.5, 0.5])
+        a = xp.asarray([1.0, -0.25])
+        w, h = freqz(b, a, worN=8)
+        w_ref, h_ref = freqz(xp.asarray([0.5, 0.5]), xp.asarray([1.0, -0.25]), worN=8)
+        xp_assert_close(w, w_ref, rtol=1e-7)
+        xp_assert_close(h, h_ref, rtol=1e-7)
+
+    def test_freqz_2d_slices_match_1d(self, xp):
+        # gh-17387: each 2-D slice must match the equivalent 1-D freqz call
+        rng = np.random.RandomState(42)
+        b = xp.asarray(rng.randn(4, 5))
+        w, h = freqz(b, worN=16)
+        assert w.shape == (16,)
+        assert h.shape == (5, 16)
+        for k in range(5):
+            w1, h1 = freqz(b[:, k], worN=16)
+            xp_assert_close(w, w1, rtol=1e-7)
+            xp_assert_close(h[k], h1, rtol=1e-7)
+
+    def test_freqz_3d_slices_match_1d(self, xp):
+        # gh-17387: 3-D coefficient arrays generalize via trailing-axis insertion
+        rng = np.random.RandomState(123)
+        b = xp.asarray(rng.randn(4, 3, 2))
+        w, h = freqz(b, worN=32)
+        assert w.shape == (32,)
+        assert h.shape == (3, 2, 32)
+        for i in range(3):
+            for j in range(2):
+                w1, h1 = freqz(b[:, i, j], worN=32)
+                xp_assert_close(w, w1, rtol=1e-7)
+                xp_assert_close(h[i, j], h1, rtol=1e-7)
+
     def test_broadcasting4(self, xp):
         # Test broadcasting with worN a 2-D array.
         np.random.seed(123)


### PR DESCRIPTION
#### Reference issue
Closes gh-17387

#### What does this implement/fix?
`signal.freqz` failed on multidimensional coefficient arrays such as `b` with shape `(128, 10)` when no trailing length-1 axis was present. The last dimension was treated as polynomial coefficients instead of a batch/filter axis.

This adds `_freqz_trailing_axis_matches_worN()` to detect layouts where the trailing axis already pairs with `worN`. When it does not, a trailing axis is inserted via `b[..., newaxis]`, preserving 1-D behavior and existing broadcasting semantics.

#### Additional information
Regression tests: `test_freqz_multidim_without_trailing_axis`, `test_freqz_1d_regression_unchanged`, `test_freqz_2d_slices_match_1d`, `test_freqz_3d_slices_match_1d`.

#### AI Generation Disclosure
AI disclosure: Cursor IDE was used only to read/search the codebase and help debug the issue. All code in this PR was written and reviewed by me.