### PR TITLE
DOC: signal.residue: add Examples section

### DIFF
--- a/scipy/signal/_signaltools.py
+++ b/scipy/signal/_signaltools.py
@@ -3363,6 +3363,28 @@ def residue(b, a, tol=1e-3, rtype='avg'):
     .. [1] J. F. Mahoney, B. D. Sivazlian, "Partial fractions expansion: a
            review of computational methodology and efficiency", Journal of
            Computational and Applied Mathematics, Vol. 9, 1983.
+
+    Examples
+    --------
+    Decompose a rational function into partial fractions:
+
+    >>> from scipy import signal
+    >>> r, p, k = signal.residue([4, 1], [1, -1, -2])
+    >>> r
+    array([1., 3.])
+    >>> p
+    array([-1.,  2.])
+    >>> k
+    array([], dtype=float64)
+
+    Recombine the partial fractions with `invres` to recover the original
+    polynomials:
+
+    >>> b, a = signal.invres(r, p, k)
+    >>> b
+    array([4., 1.])
+    >>> a
+    array([ 1., -1., -2.])
     """
     b = np.asarray(b)
     a = np.asarray(a)

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3881,6 +3881,7 @@ class TestPartialFractionExpansion:
         assert_almost_equal(p, xp.asarray([-1.0, 2.0]))
         assert k.size == 0
 
+        # Round-trip through invres, matching the docstring Examples section.
         b, a = invres(r, p, k)
         assert_almost_equal(b, xp.asarray([4.0, 1.0]))
         assert_almost_equal(a, xp.asarray([1.0, -1.0, -2.0]))

--- a/scipy/signal/tests/test_signaltools.py
+++ b/scipy/signal/tests/test_signaltools.py
@@ -3873,6 +3873,18 @@ class TestPartialFractionExpansion:
                                     [1, 1 - 1j, 1 + 1j])
         assert k.size == 0
 
+    @make_xp_test_case(residue, invres)
+    def test_residue_docstring_example_matches_computation(self, xp):
+        """Sanity check for the Examples section in signal.residue (gh-7168)."""
+        r, p, k = residue(xp.asarray([4.0, 1.0]), xp.asarray([1.0, -1.0, -2.0]))
+        assert_almost_equal(r, xp.asarray([1.0, 3.0]))
+        assert_almost_equal(p, xp.asarray([-1.0, 2.0]))
+        assert k.size == 0
+
+        b, a = invres(r, p, k)
+        assert_almost_equal(b, xp.asarray([4.0, 1.0]))
+        assert_almost_equal(a, xp.asarray([1.0, -1.0, -2.0]))
+
     @make_xp_test_case(residue)
     def test_residue_leading_zeros(self, xp):
         # Leading zeros in numerator or denominator must not affect the answer.


### PR DESCRIPTION
#### Reference issue
Closes gh-7168

#### What does this implement/fix?
`signal.residue` had no `Examples` section unlike related functions. This adds a doctest-style example showing partial-fraction expansion and an `invres` round-trip, plus `test_residue_docstring_example_matches_computation`.

#### Additional information
Existing `TestPartialFractionExpansion` tests unchanged.

#### AI Generation Disclosure
AI disclosure: Cursor IDE was used only to read/search the codebase and help debug the issue. All code in this PR was written and reviewed by me.