### PR TITLE
BUG: Copy non-writable array when all bounds are equal to prevent `UserWarning`

### DIFF
--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -1175,7 +1175,10 @@ def _optimize_result_for_equal_bounds(
     message = 'All independent variables were fixed by bounds.'
 
     # bounds is new-style
-    x0 = bounds.lb
+    # Copy because bounds.lb may be a non-writable view (from broadcast_to
+    # in _validate_bounds), and user-provided callables must receive a
+    # writable array (e.g. PyTorch's torch.from_numpy rejects read-only input).
+    x0 = bounds.lb.copy()
 
     if constraints:
         message = ("All independent variables were fixed by bounds at values"

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -14,6 +14,7 @@ from warnings import warn
 
 import numpy as np
 from scipy._lib._util import wrapped_inspect_signature
+from scipy._lib._array_api import array_namespace, xp_copy
 
 # unconstrained minimization
 from ._optimize import (_minimize_neldermead, _minimize_powell, _minimize_cg,
@@ -1175,10 +1176,8 @@ def _optimize_result_for_equal_bounds(
     message = 'All independent variables were fixed by bounds.'
 
     # bounds is new-style
-    # Copy because bounds.lb may be a non-writable view (from broadcast_to
-    # in _validate_bounds), and user-provided callables must receive a
-    # writable array (e.g. PyTorch's torch.from_numpy rejects read-only input).
-    x0 = bounds.lb.copy()
+    xp = array_namespace(bounds.lb)
+    x0 = xp_copy(bounds.lb, xp=xp)
 
     if constraints:
         message = ("All independent variables were fixed by bounds at values"

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -14,7 +14,6 @@ from warnings import warn
 
 import numpy as np
 from scipy._lib._util import wrapped_inspect_signature
-from scipy._lib._array_api import array_namespace
 
 # unconstrained minimization
 from ._optimize import (_minimize_neldermead, _minimize_powell, _minimize_cg,

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -14,7 +14,7 @@ from warnings import warn
 
 import numpy as np
 from scipy._lib._util import wrapped_inspect_signature
-from scipy._lib._array_api import array_namespace, xp_copy
+from scipy._lib._array_api import array_namespace
 
 # unconstrained minimization
 from ._optimize import (_minimize_neldermead, _minimize_powell, _minimize_cg,

--- a/scipy/optimize/_minimize.py
+++ b/scipy/optimize/_minimize.py
@@ -1176,8 +1176,7 @@ def _optimize_result_for_equal_bounds(
     message = 'All independent variables were fixed by bounds.'
 
     # bounds is new-style
-    xp = array_namespace(bounds.lb)
-    x0 = xp_copy(bounds.lb, xp=xp)
+    x0 = np.copy(bounds.lb)
 
     if constraints:
         message = ("All independent variables were fixed by bounds at values"

--- a/scipy/optimize/tests/test_optimize.py
+++ b/scipy/optimize/tests/test_optimize.py
@@ -3116,6 +3116,23 @@ def test_all_bounds_equal(method):
         assert res.message.startswith(message)
 
 
+@pytest.mark.parametrize('method', eb_data["methods"])
+def test_all_bounds_equal_writable(method):
+    # When all bounds have lb == ub, _optimize_result_for_equal_bounds
+    # must pass a writable x0 to the objective. Previously, x0 was
+    # assigned directly from bounds.lb, which is a non-writable view
+    # produced by np.broadcast_to in _validate_bounds.
+    def f(x):
+        assert x.flags.writeable, "x passed to objective is not writable"
+        return np.linalg.norm(x)
+
+    bounds = [(1, 1), (2, 2)]
+    x0 = (1.0, 3.0)
+    res = optimize.minimize(f, x0, bounds=bounds, method=method)
+    assert res.success
+    assert res.x.flags.writeable
+
+
 def test_eb_constraints():
     # make sure constraint functions aren't overwritten when equal bounds
     # are employed, and a parameter is factored out. GH14859


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes #25540 

#### What does this implement/fix?
This fixes an issue where a non-writeble `np` array is used when lower and upper bounds are equal. WHile this not causing an issue in `scipy`, this can lead to problems in downstream usages (e.g. packages using `torch.from_numpy` calls), specifically when warnings are treated as errors.

This is fixed by simply copying the `bounds.lb` instead of passing it directly.

#### Additional information
I've also added a test and some comments in the code which might be redundant/not necessary.

#### AI Generation Disclosure
Opus 4.6. was used in the following ways:
- Discovery of the bug
- Investigating whether or not the bug was already reported or fixed on `main`
- Creating the MWE referenced in #25540 
- Writing the code fix and comments
- Writing the test

I did verify both the MWE and the fix, and can confirm that the fix worked locally for me, which I tested by simply patching the whole module. Also, the actual change is quite minimal, so everything was verified by me. I am very open to change anything that has been created here (e.g. getting rid of the verbose comment, getting rid of the test which might be overkill)