### PR TITLE
BUG: interpolate: fix shapes of {Rect,Smooth}BivariateSpline with scalars

### DIFF
--- a/scipy/interpolate/_fitpack2.py
+++ b/scipy/interpolate/_fitpack2.py
@@ -1411,8 +1411,13 @@ class _BivariateSplineBase:
         >>> ax2.imshow(zdata_interp)
         >>> plt.show()
         """
-        x = np.atleast_1d(np.asarray(x))
-        y = np.atleast_1d(np.asarray(y))
+        x = np.asarray(x)
+        y = np.asarray(y)
+        # backwards compat, cf https://github.com/scipy/scipy/issues/25471
+        needs_squeeze = (x.ndim == 0) and (y.ndim == 0)
+
+        x = np.atleast_1d(x)
+        y = np.atleast_1d(y)
 
         tx, ty, c = self.tck[:3]
         kx, ky = self.degrees
@@ -1456,6 +1461,10 @@ class _BivariateSplineBase:
                     raise ValueError(f"Error code returned by bispeu: {ier}")
 
             z = z.reshape(shape)
+
+            if needs_squeeze:
+                z = z.squeeze()
+
         return z
 
     def partial_derivative(self, dx, dy):

--- a/scipy/interpolate/tests/test_fitpack2.py
+++ b/scipy/interpolate/tests/test_fitpack2.py
@@ -747,6 +747,18 @@ class TestSmoothBivariateSpline:
                                      kx=1, ky=1)
         xp_assert_close(spl1(0.1, 0.5), spl2(0.1, 0.5))
 
+    def test_0d(self):
+        # regression test for https://github.com/scipy/scipy/issues/25471
+        # result shapes checked with SciPy 1.16.3 (pre FITPACK C port)
+        rng = np.random.default_rng(0)
+        xs, ys = rng.random(30), rng.random(30)
+        zs = xs * ys
+        s = SmoothBivariateSpline(xs, ys, zs)(0.4, 0.5, grid=False)
+        assert s.ndim == 0
+
+        s = SmoothBivariateSpline(xs, ys, zs)([0.4], 0.5, grid=False)
+        assert s.ndim == 1
+
 
 def _contiguous(a):
     """C-contiguous reference layout."""
@@ -1642,6 +1654,16 @@ class TestRectBivariateSpline:
         z_spl = spl_eval(spl, x, y)
         assert not np.isnan(z_spl).any()
         xp_assert_close(z_spl, z, atol=0.1, rtol=0.1)
+
+    def test_0d(self):
+        # regression test for https://github.com/scipy/scipy/issues/25471
+        # result shapes checked with SciPy 1.16.3 (pre FITPACK C port)
+        x = np.arange(6.0)
+        r = RectBivariateSpline(x, x, np.outer(x, x))(2.5, 3.5, grid=False)
+        assert r.ndim == 0
+
+        r = RectBivariateSpline(x, x, np.outer(x, x))([2.5], 3.5, grid=False)
+        assert r.ndim == 1
 
 
 class TestRectSphereBivariateSpline:


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/25471

#### What does this implement/fix?
<!--Please explain your changes.-->

Previously (before the FITPACK C port), *BivariateSpline.__call__ was returning 0D arrays for scalar inputs. Make sure we keep being backwards compatible.

The culprit is an extra `np.atleast_1d` call, https://github.com/scipy/scipy/blob/main/scipy/interpolate/_fitpack2.py#L1414-L1415, added in commit e8af1e4bbbd,  a part of the _tour de force_ PR https://github.com/scipy/scipy/pull/24022. 

There is probably no way to know what was breaking without these extra `atleast_1d`; the original was relying on f2py which does who knows what in these 1D/0D edge cases.  And these edge cases are undertested, too. 

All in all, given that all this is _legacy_,  I think we should just fix the backwards compat error and move on. 

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.