### PR TITLE
DOC: scipy.io.savemat add note for broken appendmat argument

### DIFF
--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -303,9 +303,10 @@ def savemat(file_name, mdict,
     appendmat : bool, optional
         True (the default) to append the .mat extension to the end of the
         given filename, if not already present.
-        NOTE: This argument is currently broken and, if set to True, does NOT
-        append .mat to the filename. Refer to github pull request 10625 at
-        https://github.com/scipy/scipy/pull/10625 for more information.
+        .. note::
+            This argument is currently broken and, if set to True, does NOT
+            append .mat to the filename. Refer to `github pull request 10625
+            <https://github.com/scipy/scipy/pull/10625>`_for more information.
     format : {'5', '4'}, string, optional
         '5' (the default) for MATLAB 5 and up (to 7.2),
         '4' for MATLAB 4 .mat files.

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -303,6 +303,9 @@ def savemat(file_name, mdict,
     appendmat : bool, optional
         True (the default) to append the .mat extension to the end of the
         given filename, if not already present.
+        NOTE: This argument is currently broken and, if set to True, does NOT
+        append .mat to the filename. Refer to github pull request 10625 at
+        https://github.com/scipy/scipy/pull/10625 for more information.
     format : {'5', '4'}, string, optional
         '5' (the default) for MATLAB 5 and up (to 7.2),
         '4' for MATLAB 4 .mat files.

--- a/scipy/io/matlab/_mio.py
+++ b/scipy/io/matlab/_mio.py
@@ -303,10 +303,12 @@ def savemat(file_name, mdict,
     appendmat : bool, optional
         True (the default) to append the .mat extension to the end of the
         given filename, if not already present.
+        
         .. note::
             This argument is currently broken and, if set to True, does NOT
-            append .mat to the filename. Refer to `github pull request 10625
-            <https://github.com/scipy/scipy/pull/10625>`_for more information.
+            append .mat to the filename. For more information, refer to
+            `github pull request 10625 <https://github.com/scipy/scipy/pull/10625>`_.
+
     format : {'5', '4'}, string, optional
         '5' (the default) for MATLAB 5 and up (to 7.2),
         '4' for MATLAB 4 .mat files.


### PR DESCRIPTION
This closes no concrete issue, but provides an intermittent notice to users of scipy.io.savemat that the appendmat flag does not work. https://github.com/scipy/scipy/pull/10625 

#### Additional information
Something broke during setup of a local dev environment; I therefore could not check whether sphinx builds the docs correctly.
It is necessary that someone with a working dev environment manually checks whether the docstring for appendmat in scipy.io.savemat renders correctly before merging. Feel free to close if this is not possible.

#### AI Generation Disclosure
No AI tools used.