### PR TITLE
DOC: avoid czt example aspect warning

### DIFF
--- a/scipy/signal/_czt.py
+++ b/scipy/signal/_czt.py
@@ -491,9 +491,13 @@ def czt(x, m=None, w=None, a=1+0j, *, axis=-1):
     >>> a = np.exp(-f1/fs)  # Starting point of the circle, radius < 1
     >>> w = np.exp(-1j*np.pi/M)  # "Step size" of circle
     >>> points = czt_points(M + 1, w, a)  # M + 1 to include Nyquist
-    >>> plt.plot(points.real, points.imag, '.')
-    >>> plt.gca().add_patch(plt.Circle((0,0), radius=1, fill=False, alpha=.3))
-    >>> plt.axis('equal'); plt.axis([-1.05, 1.05, -0.05, 1.05])
+    >>> from matplotlib.patches import Arc
+    >>> fig, ax = plt.subplots()
+    >>> ax.plot(points.real, points.imag, '.')
+    >>> ax.add_patch(Arc((0, 0), width=2, height=2, theta1=180,
+    ...                  theta2=360, alpha=.3))
+    >>> ax.set_aspect('equal')
+    >>> ax.set_xlim(-1.05, 1.05)
     >>> plt.show()
 
     With the correct radius, this transforms the decaying sinusoid (and others


### PR DESCRIPTION
#### Reference issue

Closes #25532.

#### What does this implement/fix?

This updates the `scipy.signal.czt` docstring example so the plot no longer triggers Matplotlib's fixed-limit/equal-aspect message during docs builds.

The example now draws the lower unit-circle reference with `matplotlib.patches.Arc`, matching the CZT sample points, and uses an equal aspect ratio with only the x limits fixed.

#### Additional information

Validation run locally:

- `git diff --check`
- `python3 -m py_compile scipy/signal/_czt.py`
- Ran the updated plotting snippet with the Agg backend and confirmed it completes without emitting the previous Matplotlib message.
