### PR TITLE
Optimize _group_columns implementation

### DIFF
--- a/scipy/optimize/_group_columns.py
+++ b/scipy/optimize/_group_columns.py
@@ -10,11 +10,10 @@ import numpy as np
 def group_dense(m, n, A):
     B = A.T  # Transposed view for convenience.
 
-    # FIXME: use np.full once pythran supports it
-    groups = -np.ones(n, dtype=np.intp)
+    groups = np.full(n, -1, dtype=np.intp)
     current_group = 0
 
-    union = np.empty(m, dtype=np.intp)
+    union = np.empty(m, dtype=A.dtype)
 
     # Loop through all the columns.
     for i in range(n):
@@ -26,21 +25,18 @@ def group_dense(m, n, A):
 
         union[:] = B[i]  # Here we store the union of grouped columns.
 
-        for j in range(groups.shape[0]):
+        for j in range(i + 1, groups.shape[0]):
             if groups[j] < 0:
                 all_grouped = False
             else:
                 continue
 
             # Determine if j-th column intersects with the union.
-            intersect = False
             for k in range(m):
                 if union[k] > 0 and B[j, k] > 0:
-                    intersect = True
                     break
-
             # If not, add it to the union and assign the group to it.
-            if not intersect:
+            else:
                 union += B[j]
                 groups[j] = current_group
 
@@ -57,10 +53,10 @@ def group_dense(m, n, A):
 #pythran export group_sparse(int, int, int32[::], int32[::])
 #pythran export group_sparse(int, int, int64[::], int64[::])
 def group_sparse(m, n, indices, indptr):
-    groups = -np.ones(n, dtype=np.intp)
+    groups = np.full(n, -1, dtype=np.intp)
     current_group = 0
 
-    union = np.empty(m, dtype=np.intp)
+    union = np.empty(m, dtype=bool)
 
     for i in range(n):
         if groups[i] >= 0:
@@ -69,24 +65,22 @@ def group_sparse(m, n, indices, indptr):
         groups[i] = current_group
         all_grouped = True
 
-        union.fill(0)
+        union.fill(False)
         for k in range(indptr[i], indptr[i + 1]):
-            union[indices[k]] = 1
+            union[indices[k]] = True
 
-        for j in range(groups.shape[0]):
+        for j in range(i + 1, groups.shape[0]):
             if groups[j] < 0:
                 all_grouped = False
             else:
                 continue
 
-            intersect = False
             for k in range(indptr[j], indptr[j + 1]):
-                if union[indices[k]] == 1:
-                    intersect = True
+                if union[indices[k]]:
                     break
-            if not intersect:
+            else:
                 for k in range(indptr[j], indptr[j + 1]):
-                    union[indices[k]] = 1
+                    union[indices[k]] = True
                 groups[j] = current_group
 
         if all_grouped:


### PR DESCRIPTION
1. Use np.fill(..., -1, ...) instead of -np.ones(...)
2. Use for-else instead of an extra variable
3. Use appropriate data type for union array
4. Avoid redundant checks in inner loops

This results in higher level code, still efficiently compiled by pythran.

#### What does this implement/fix?

Improve _group_columns.py implementation, using higher-level constructs.

#### AI Generation Disclosure

No AI tools used, I value my work.