### PR TITLE
DOC fix parameter name typos in docstrings (3 locations)

### DIFF
--- a/scipy/optimize/_linprog_util.py
+++ b/scipy/optimize/_linprog_util.py
@@ -111,7 +111,7 @@ def _check_sparse_inputs(options, meth, A_ub, A_eq):
                 Set to True to print convergence messages.
 
         For method-specific options, see :func:`show_options('linprog')`.
-    method : str, optional
+    meth : str, optional
         The algorithm used to solve the standard form problem.
 
     Returns

--- a/scipy/optimize/_optimize.py
+++ b/scipy/optimize/_optimize.py
@@ -235,7 +235,7 @@ def _prepare_scalar_function(fun, x0, jac=None, args=(), bounds=None,
         derivatives (`fun`, `jac` functions).
     bounds : sequence, optional
         Bounds on variables. 'new-style' bounds are required.
-    eps : float or ndarray
+    epsilon : float or ndarray
         If ``jac is None`` the absolute step size used for numerical
         approximation of the jacobian via forward differences.
     finite_diff_rel_step : None or array_like, optional

--- a/scipy/stats/_distribution_infrastructure.py
+++ b/scipy/stats/_distribution_infrastructure.py
@@ -342,7 +342,7 @@ class _Interval(_Domain):
             - NaN ('nan').
         min, max : ndarray
             The endpoints of the domain.
-        squeezed_based_shape : tuple of ints
+        squeezed_base_shape : tuple of ints
             See _RealParameter.draw.
         rng : np.Generator
             The Generator used for drawing random values.


### PR DESCRIPTION
## Summary

Fixes 3 parameter name mismatches in docstrings where the documented name does not match the actual function signature.

| File | Function | Wrong | Correct |
|------|----------|-------|---------|
| `scipy/optimize/_linprog_util.py` | `_check_sparse_inputs()` | `method` | `meth` |
| `scipy/optimize/_optimize.py` | `_prepare_scalar_function()` | `eps` | `epsilon` |
| `scipy/stats/_distribution_infrastructure.py` | `draw()` | `squeezed_based_shape` | `squeezed_base_shape` |

No logic changes - docstrings only.