### PR TITLE
ENH: stats: array API for tiecorrect

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -84,6 +84,7 @@ from scipy._lib._array_api import (
     _masked_apply,
     xp_swapaxes,
     xp_device,
+    concat_1d
 )
 import scipy._external.array_api_extra as xpx
 from scipy.stats._quantile import _xp_searchsorted
@@ -8416,7 +8417,10 @@ def kstest(rvs, cdf, args=(), N=20, alternative='two-sided', method='auto', *,
                     axis=axis, _no_deco=True)
 
 
-@xp_capabilities(np_only=True)
+@xp_capabilities(
+    jax_jit=False,
+    xfail_backends=[("dask.array", "data-dependent shapes")]
+)
 def tiecorrect(rankvals):
     """Tie correction factor for Mann-Whitney U and Kruskal-Wallis H tests.
 
@@ -8454,12 +8458,18 @@ def tiecorrect(rankvals):
     0.9833333333333333
 
     """
-    arr = np.sort(rankvals)
-    idx = np.nonzero(np.r_[True, arr[1:] != arr[:-1], True])[0]
-    cnt = np.diff(idx).astype(np.float64)
+    xp = array_namespace(rankvals)
+    rankvals = xp.asarray(rankvals)
 
-    size = np.float64(arr.size)
-    return 1.0 if size < 2 else 1.0 - (cnt**3 - cnt).sum() / (size**3 - size)
+    if xp_size(rankvals) == 0:
+        return 1.0
+
+    arr = xp.sort(rankvals)
+    idx = xp.nonzero(concat_1d(xp, [True], arr[1:] != arr[:-1], [True]))[0]
+    cnt = xp.astype(xp.diff(idx), xp.float64)
+
+    size = xp_size(arr)
+    return 1.0 if size < 2 else 1.0 - xp.sum(cnt**3 - cnt) / (size**3 - size)
 
 
 RanksumsResult = namedtuple('RanksumsResult', ('statistic', 'pvalue'))

--- a/scipy/stats/tests/test_rank.py
+++ b/scipy/stats/tests/test_rank.py
@@ -10,70 +10,73 @@ from scipy._lib._array_api import (xp_assert_equal, make_xp_test_case, xp_result
 
 skip_xp_backends = pytest.mark.skip_xp_backends
 
+
+@make_xp_test_case(stats.tiecorrect)
 class TestTieCorrect:
 
-    def test_empty(self):
+    def test_empty(self, xp):
         """An empty array requires no correction, should return 1.0."""
-        ranks = np.array([], dtype=np.float64)
+        ranks = xp.asarray([], dtype=xp.float64)
         c = tiecorrect(ranks)
-        assert_equal(c, 1.0)
+        assert c == 1.0
 
-    def test_one(self):
+    def test_one(self, xp):
         """A single element requires no correction, should return 1.0."""
-        ranks = np.array([1.0], dtype=np.float64)
+        ranks = xp.asarray([1.0], dtype=xp.float64)
         c = tiecorrect(ranks)
-        assert_equal(c, 1.0)
+        assert c == 1.0
 
-    def test_no_correction(self):
+    def test_no_correction(self, xp):
         """Arrays with no ties require no correction."""
-        ranks = np.arange(2.0)
+        ranks = xp.arange(2)
         c = tiecorrect(ranks)
-        assert_equal(c, 1.0)
-        ranks = np.arange(3.0)
-        c = tiecorrect(ranks)
-        assert_equal(c, 1.0)
+        assert c == 1.0
 
-    def test_basic(self):
+        ranks = xp.arange(3)
+        c = tiecorrect(ranks)
+        assert c == 1.0
+
+    def test_basic(self, xp):
         """Check a few basic examples of the tie correction factor."""
         # One tie of two elements
-        ranks = np.array([1.0, 2.5, 2.5])
+        ranks = xp.asarray([1.0, 2.5, 2.5])
         c = tiecorrect(ranks)
         T = 2.0
-        N = ranks.size
+        N = ranks.shape[0]
         expected = 1.0 - (T**3 - T) / (N**3 - N)
-        assert_equal(c, expected)
+        assert c == expected
 
         # One tie of two elements (same as above, but tie is not at the end)
-        ranks = np.array([1.5, 1.5, 3.0])
+        ranks = xp.asarray([1.5, 1.5, 3.0])
         c = tiecorrect(ranks)
         T = 2.0
-        N = ranks.size
+        N = ranks.shape[0]
         expected = 1.0 - (T**3 - T) / (N**3 - N)
-        assert_equal(c, expected)
+        assert c == expected
 
         # One tie of three elements
-        ranks = np.array([1.0, 3.0, 3.0, 3.0])
+        ranks = xp.asarray([1.0, 3.0, 3.0, 3.0])
         c = tiecorrect(ranks)
         T = 3.0
-        N = ranks.size
+        N = ranks.shape[0]
         expected = 1.0 - (T**3 - T) / (N**3 - N)
-        assert_equal(c, expected)
+        assert c == expected
 
         # Two ties, lengths 2 and 3.
-        ranks = np.array([1.5, 1.5, 4.0, 4.0, 4.0])
+        ranks = xp.asarray([1.5, 1.5, 4.0, 4.0, 4.0])
         c = tiecorrect(ranks)
         T1 = 2.0
         T2 = 3.0
-        N = ranks.size
+        N = ranks.shape[0]
         expected = 1.0 - ((T1**3 - T1) + (T2**3 - T2)) / (N**3 - N)
-        assert_equal(c, expected)
+        assert c == expected
 
-    def test_overflow(self):
+    def test_overflow(self, xp):
         ntie, k = 2000, 5
-        a = np.repeat(np.arange(k), ntie)
-        n = a.size  # ntie * k
+        a = xp.repeat(xp.arange(k), ntie)
+        n = a.shape[0]  # ntie * k
         out = tiecorrect(rankdata(a))
-        assert_equal(out, 1.0 - k * (ntie**3 - ntie) / float(n**3 - n))
+        assert out == 1.0 - k * (ntie**3 - ntie) / float(n**3 - n)
 
 
 @make_xp_test_case(stats.rankdata)


### PR DESCRIPTION
#### Reference issue
<!--Example: Closes gh-WXYZ.-->

closes https://github.com/scipy/scipy/issues/21077 

#### What does this implement/fix?
<!--Please explain your changes.-->

Address the last remaining item of gh-21077: convert `stats.tiecorrect` to be Array API compatible.

#### Additional information
<!--Any additional information you think is important.-->

An alternative is to deprecate `tiecorrect`: it looks simple enough to reimplement on the user side, code search shows a limited usage, and internally it is not used internally in scipy:

```
$ git grep -n tiecorrect
doc/source/release/0.18.0-notes.rst:450:- `#5553 <https://github.com/scipy/scipy/issues/5553>`__: stats.tiecorrect overflows
doc/source/release/0.18.0-notes.rst:536:- `#5554 <https://github.com/scipy/scipy/pull/5554>`__: MAINT/BUG: closes overflow bug in stats.tiecorrect
scipy/stats/__init__.py:265:   tiecorrect
scipy/stats/_stats_py.py:110:           'tiecorrect', 'ranksums', 'kruskal', 'friedmanchisquare',
scipy/stats/_stats_py.py:8424:def tiecorrect(rankvals):
scipy/stats/_stats_py.py:8451:    >>> from scipy.stats import tiecorrect, rankdata
scipy/stats/_stats_py.py:8452:    >>> tiecorrect([1, 2.5, 2.5, 4])
scipy/stats/_stats_py.py:8457:    >>> tiecorrect(ranks)
scipy/stats/_stats_py.py:8674:    ties = 1 - xp.sum(t**3 - t, axis=-1) / (totaln**3 - totaln)  # tiecorrect(ranked)
scipy/stats/stats.py:26:    'tiecorrect', 'ranksums', 'kruskal', 'friedmanchisquare',
scipy/stats/tests/test_rank.py:7:from scipy.stats import rankdata, tiecorrect
scipy/stats/tests/test_rank.py:14:@make_xp_test_case(stats.tiecorrect)
scipy/stats/tests/test_rank.py:20:        c = tiecorrect(ranks)
scipy/stats/tests/test_rank.py:26:        c = tiecorrect(ranks)
scipy/stats/tests/test_rank.py:32:        c = tiecorrect(ranks)
scipy/stats/tests/test_rank.py:36:        c = tiecorrect(ranks)
scipy/stats/tests/test_rank.py:43:        c = tiecorrect(ranks)
scipy/stats/tests/test_rank.py:51:        c = tiecorrect(ranks)
scipy/stats/tests/test_rank.py:59:        c = tiecorrect(ranks)
scipy/stats/tests/test_rank.py:67:        c = tiecorrect(ranks)
scipy/stats/tests/test_rank.py:78:        out = tiecorrect(rankdata(a))
``` 

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.