### PR TITLE
BLD: fix Wpsabi warnings from GCC on Linux aarch64

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -97,6 +97,15 @@ if cpp.get_id() == 'msvc'
   add_project_arguments('/bigobj', language: 'cpp')
 endif
 
+# Silence GCC -Wpsabi notes about ABI changes (e.g., the GCC 10.1 ABI changes
+# for passing parameter passing for argument of type ‘std::pair<double, double>`).
+# These notes are informational; SciPy is built against a single compiler ABI.
+if meson.get_compiler('cpp').get_id() == 'gcc'
+  # global rather than project-wide, because it silences a few warnings from
+  # within subprojects/highs as well
+  add_global_arguments('-Wno-psabi', language: 'cpp')
+endif
+
 if host_machine.system() == 'darwin'
   if cc.has_link_argument('-Wl,-dead_strip')
     # Allow linker to strip unused symbols

--- a/scipy/fft/_duccfft/meson.build
+++ b/scipy/fft/_duccfft/meson.build
@@ -22,25 +22,16 @@ else
     fft_deps += [thread_dep]
   endif
 endif
-duccfft_args = duccfft_threads
-# Silence GCC -Wpsabi notes about the GCC 10.1 ABI change for passing
-# SIMD-backed structs by value (triggered heavily by ducc0/fft/fft1d_impl.h).
-# The note is informational; SciPy is built against a single compiler ABI.
-if meson.get_compiler('cpp').get_id() == 'gcc'
-  duccfft_args += ['-Wno-psabi']
-endif
-
 
 py3.extension_module(
     'pyduccfft',
     'pyduccfft.cxx',
-    cpp_args: duccfft_args,
+    cpp_args: duccfft_threads,
     dependencies: [fft_deps, pybind11_dep, duccfft_dep],
     link_args: version_link_args,
     install: true,
     subdir: 'scipy/fft/_duccfft',
 )
-
 
 python_sources = [
   '__init__.py',
@@ -49,7 +40,6 @@ python_sources = [
   'LICENSE.md',
   'realtransforms.py'
 ]
-
 
 py3.install_sources(
   python_sources,

--- a/scipy/special/meson.build
+++ b/scipy/special/meson.build
@@ -29,13 +29,7 @@ cdflib_lib = static_library('cdflib',
   gnu_symbol_visibility: 'hidden',
 )
 
-# The -Wno-psabi arg is used to silence a warning that the ABI of
-# passing structure with complex float member changed in GCC 4.4,
-# which is not relevant for scipy.special.
 ufuncs_cpp_args = ['-DSP_SPECFUN_ERROR']
-if meson.get_compiler('cpp').get_id() == 'gcc'
-  ufuncs_cpp_args += ['-Wno-psabi']
-endif
 
 py3.extension_module('_special_ufuncs',
   ['_special_ufuncs.cpp', '_special_ufuncs_docs.cpp', 'sf_error.cc'],


### PR DESCRIPTION
There are lots of these, almost all about GCC 10.1 struct ABI changes. Since they're from at least 5 different submodules and the warnings were already silenced separately for ducc0 and scipy.special, let's do it centrally once.

These can never really be relevant, since we don't rely on C++ ABI crossing project boundaries.

Example warnings:

```
  [342/1141] Compiling C++ object scipy/optimize/_highspy/libhighs.a.p/.._.._.._subprojects_highs_highs_mip_HighsFeasibilityJump.cpp.o
  In file included from /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/stl_algo.h:61,
                   from /opt/rh/gcc-toolset-14/root/usr/include/c++/14/algorithm:61,
                   from ../subprojects/highs/highs/util/HighsSparseVectorSum.h:11,
                   from ../subprojects/highs/highs/util/HighsSparseMatrix.h:22,
                   from ../subprojects/highs/highs/lp_data/HighsLp.h:17,
                   from ../subprojects/highs/highs/model/HighsModel.h:16,
                   from ../subprojects/highs/highs/lp_data/HighsIis.h:14,
                   from ../subprojects/highs/highs/Highs.h:17,
                   from ../subprojects/highs/highs/mip/HighsMipSolver.h:11,
                   from ../subprojects/highs/highs/mip/HighsDomain.h:18,
                   from ../subprojects/highs/highs/mip/HighsConflictPool.h:14,
                   from ../subprojects/highs/highs/mip/HighsMipSolverData.h:15,
                   from ../subprojects/highs/highs/mip/HighsFeasibilityJump.cpp:8:
  /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/stl_heap.h: In function ‘void std::__adjust_heap(_RandomAccessIterator, _Distance, _Distance, _Tp, _Compare) [with _RandomAccessIterator = __gnu_cxx::__normal_iterator<pair<double, double>*, vector<pair<double, double> > >; _Distance = long int; _Tp = pair<double, double>; _Compare = __gnu_cxx::__ops::_Iter_less_iter]’:
  /opt/rh/gcc-toolset-14/root/usr/include/c++/14/bits/stl_heap.h:224:5: note: parameter passing for argument of type ‘std::pair<double, double>’ when C++17 is enabled changed to match C++14 in GCC 10.1
    224 |     __adjust_heap(_RandomAccessIterator __first, _Distance __holeIndex,
        |     ^~~~~~~~~~~~~
```

```
[9](https://github.com/scipy/scipy/actions/runs/28295537313/job/83835534763#step:8:1409)
  ../subprojects/boost_math/math/include/boost/math/tools/toms748_solve.hpp:516:48: note: parameter passing for argument of type ‘std::pair<double, double>’ when C++17 is enabled changed to match C++14 in GCC 10.1
    516 | BOOST_MATH_GPU_ENABLED boost::math::pair<T, T> bracket_and_solve_root(F f, const T& guess, T factor, bool rising, Tol tol, boost::math::uintmax_t& max_iter, const Policy& pol)
        |                                                ^~~~~~~~~~~~~~~~~~~~~~
```

```

  [546/1141] Compiling C++ object scipy/special/_ufuncs.cpython-312-aarch64-linux-gnu.so.p/xsf_wrappers.cpp.o
  In file included from ../subprojects/xsf/include/xsf/cpu/../cephes/kolmogorov.h:60,
                   from ../subprojects/xsf/include/xsf/cpu/stats.h:2,
                   from ../scipy/special/xsf_wrappers.cpp:13:
  ../subprojects/xsf/include/xsf/cpu/../cephes/dd_real.h: In function ‘std::pair<xsf::cephes::detail::double_double, xsf::cephes::detail::double_double> xsf::cephes::detail::divrem(const double_double&, const double_double&)’:
  ../subprojects/xsf/include/xsf/cpu/../cephes/dd_real.h:384:66: note: parameter passing for argument of type ‘std::pair<xsf::cephes::detail::double_double, xsf::cephes::detail::double_double>’ when C++17 is enabled changed to match C++14 in GCC 10.1
```

#### AI Generation Disclosure

I had a quick convo with claude.ai to check I didn't miss anything; no AI used for code generation or review.
