### PR TITLE
TST: loosen signal test tolerances for FMA-contraction builds

### DIFF
--- a/scipy/signal/tests/_scipy_spectral_test_shim.py
+++ b/scipy/signal/tests/_scipy_spectral_test_shim.py
@@ -17,7 +17,6 @@ as the existing one and delivers comparable results. Furthermore, the
 wrappers highlight the different philosophies of the implementations,
 especially in the border handling.
 """
-import platform
 from typing import cast, Literal
 
 import numpy as np
@@ -296,10 +295,11 @@ def istft_compare(Zxx, fs=1.0, window='hann', nperseg=None, noverlap=None,
     atol = np.finfo(x.dtype).resolution*2  # instead of default atol = 0
     rtol = 1e-7  # default for np.allclose()
 
-    # Relax atol on 32-Bit platforms a bit to pass CI tests.
-    #  - Not clear why there are discrepancies (in the FFT maybe?)
-    #  - Not sure what changed on 'i686' since earlier on those test passed
-    if x.dtype == np.float32 and platform.machine() == 'i686':
+    # Relax tolerances for float32, which loses precision in the FFT
+    # roundtrip. Originally observed on i686; also seen on aarch64 and on
+    # builds using FMA contraction (gh-25488), so the drift is dtype-driven
+    # rather than platform-specific.
+    if x.dtype == np.float32:
         # float32 gets only used by TestSTFT.test_roundtrip_float32() so
         # we are using the tolerances from there to circumvent CI problems
         atol, rtol = 1e-4, 1e-5

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -770,7 +770,7 @@ class TestMinimumPhase:
         H_mag = xp.abs(rfft(h, N))
         H_min_mag = xp.abs(rfft(h_min_sig, N))
         error = H_mag - H_min_mag
-        atol = dict(float32=1e-5, float64=1e-13)[dtype]
+        atol = dict(float32=2e-5, float64=1e-13)[dtype]
         xp_assert_close(error, xp.zeros_like(error), atol=atol)
 
 

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1942,7 +1942,7 @@ class TestSTFT:
 
         # Test round trip:
         x1 = istft(Zs, boundary=True, scaling='spectrum')[1]
-        assert_allclose(x1, x)
+        assert_allclose(x1, x, atol=np.finfo(x.dtype).resolution)
 
         # For a Hann-windowed 256 sample length FFT, we expect a peak at
         # frequency 64 (since it is 1/4 the length of X) with a height of 1
@@ -1972,7 +1972,7 @@ class TestSTFT:
 
         # Test round trip:
         x1 = istft(Zp, input_onesided=False, boundary=True, scaling='psd')[1]
-        assert_allclose(x1, x)
+        assert_allclose(x1, x, atol=np.finfo(x.dtype).resolution)
 
         # The power of the one-sided psd-scaled STFT can be determined
         # analogously (note that the two sides are not of equal shape):
@@ -1992,7 +1992,7 @@ class TestSTFT:
 
         # Test round trip:
         x1 = istft(Zp0, input_onesided=True, boundary=True, scaling='psd')[1]
-        assert_allclose(x1, x)
+        assert_allclose(x1, x, atol=np.finfo(x.dtype).resolution)
 
 
 class TestSampledSpectralRepresentations:


### PR DESCRIPTION
This handles the test-tolerance side of #25488. A few signal tests fail when SciPy is built with certain fast-math CPU settings that change how the math rounds in the last few digits. The results aren't wrong, just slightly different, but a few tests are strict enough to flag the tiny gap. The fix is to loosen those tolerances, as suggested in the issue.

Three changes:

- test_nyquist: raised the allowed error for the 32-bit-float case. It failed just over the old limit, and the issue notes it also fails on some ARM machines, so I left room for both.

- test_roundtrip_float32: a looser limit already existed here but only ran on one old chip type. The issue isn't tied to that chip (it shows up on ARM and fast-math builds too), so I applied the looser limit to all 32-bit-float cases and dropped a now-unused import.

- test_roundtrip_scaling: different case. A percentage margin was suggested, but it checks against exact zero, and a percentage of zero is still zero. So it needed a small fixed margin instead, matching what the test already does a few lines below.

I can't build with these settings locally, so it'd be good to confirm they pass on a znver5/skylake build before merging.

The two linprog failures aren't covered here. Those fail earlier, in the solver itself, before any tolerance check, so they're a separate problem. Can open a separate issue if useful.

AI -Assistance Disclosure
Claude was used to run and verify some shell commands and checks; moreover, documentation purposes; however, the logic and the code changes are by me