### PR TITLE
BUG: ``interpolate.splint`` did not warn when ``tck: BSpline`` and ``full_output !=0``

### DIFF
--- a/scipy/interpolate/_fitpack_py.py
+++ b/scipy/interpolate/_fitpack_py.py
@@ -2,6 +2,8 @@ __all__ = ['splrep', 'splprep', 'splev', 'splint', 'sproot', 'spalde',
            'bisplrep', 'bisplev', 'insert', 'splder', 'splantider']
 
 
+import warnings
+
 import numpy as np
 
 # These are in the API for fitpack even if not used in fitpack.py itself.
@@ -462,6 +464,7 @@ def splint(a, b, tck, full_output=0):
         if full_output != 0:
             mesg = (f"full_output = {full_output} is not supported. Proceeding as if "
                     "full_output = 0")
+            warnings.warn(mesg, RuntimeWarning, stacklevel=2)
 
         return tck.integrate(a, b, extrapolate=False)
     else:


### PR DESCRIPTION
While working on https://github.com/scipy/scipy-stubs/issues/1774 I noticed that passing `full_output=True`  to `interpolate.splint` when using `BSpline` for `tck` did not report a warning, even though the warning message was begin constructed:

```
In [1]: from scipy.interpolate import *

In [2]: spl = BSpline([0, 1, 2, 3, 4, 5, 6], [-1, -2, 0, 1], 2)

In [3]: splint(1, 1, spl, full_output=True)
Out[3]: array(0.)
```

So this adds the (likely intended) `warning.warn` call to actually emit the warning `mesg`.

BTW, is there a reason why `full_output` is using `0` instead of `False` here? Because it's a bit annoying to deal with in scipy-stubs, so if we can, I propose we change it to a `=False` (in a separate PR).

#### AI Generation Disclosure
No AI tools used