### PR TITLE
CI: work around broken `cirruslabs/cache` restore-key

### DIFF
--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -77,15 +77,19 @@ jobs:
           # Cache hit if lock file did not change. Otherwise, redownload packages.
           key: ${{ runner.os }}-gpu-pixi-1-${{ hashFiles('pixi.lock') }}
 
+      - name: Get week number for ccache key rotation
+        id: ccache-week
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
       - name: Setup compiler cache
         uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4
         with:
           path: ${{ env.CCACHE_DIR }}
-          # Make primary key unique by using `run_id`, this ensures the cache
-          # is always saved at the end.
-          key: ${{ runner.os }}-gpu-ccache-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gpu-ccache
+          # Note: go back to `github.run_id` after migrating away from Cirrus
+          # As a workaround for broken `restore-key` behavior, we need a fixed `key`;
+          # this will reduce the hit % when sources change, but a weekly refresh will
+          # ensure that it won't change by much.
+          key: ${{ runner.os }}-gpu-ccache-1-${{ steps.ccache-week.outputs.week }}-${{ hashFiles('.github/workflows/pixi.lock') }}
 
       - name: Define default CuPy cache path
         run: |
@@ -97,19 +101,16 @@ jobs:
         uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4
         with:
           path: ${{ env.CUPY_CACHE_DIR }}
-          # Same as for ccache above
-          key: ${{ runner.os }}-gpu-cupy-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gpu-cupy
+          # Note: go back to `github.run_id` after migrating away from Cirrus
+          # (fallback lookup is broken there, so we need an exact hit on key)
+          key: ${{ runner.os }}-gpu-cupy-1-${{ hashFiles('pixi.lock') }}
 
       - name: Cache JAX kernels
         uses: cirruslabs/cache@1251dca905f872d6420b06b8d7f9e7fc85589448 # v4
         with:
           path: ${{ env.JAX_COMPILATION_CACHE_DIR }}
-          # Same as for cupy above
-          key: ${{ runner.os }}-gpu-jax-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gpu-jax
+          # Note: go back to `github.run_id` after migrating away from Cirrus
+          key: ${{ runner.os }}-gpu-jax-1-${{ hashFiles('pixi.lock') }}
 
       - name: run nvidia-smi
         run: nvidia-smi


### PR DESCRIPTION
This caused the restores for the CuPy, JAX and ccache caches to fail, resulting in long build and test times.

The restore failures were visible in the CI logs like this:
```
Attempt 1 of 5 failed with error: Failed request: (500) Internal Server Error: GHA cache v2 failed to retrieve information about cache entry with key "Linux-gpu-ccache-28738831957" and version "4e24cbc5930ec5611b6e3d7b7b907c4fe6cfd5f0f551ce54789afee60b0f6ec8": rpc error: code = Unknown desc = . Retrying request in 3000 ms...
```

The Pixi restore was working fine, because that got exact hits since it didn't append `github.run_id` and hence wasn't relying on `restore-key`.

Given that Cirrus Runners is going away soon, an upstream fix seems unlikely; we're anyway migrating away so using exact keys seems like a perfectly fine workaround until then.

Confirmed that re-running a job with cache misses results in cache hits, because the cache key run-to-run doesn't change in that case.

Cache saves were working fine, with output in the CI log like this:
```
Cache saved with key: Linux-gpu-jax-28738831957
```

The actual entry in the Cirrus dashboard then contains a prepended hash, which depends on a bunch of other things like runner image, cache action version, etc.:
```
4e24cbc5930ec5611b6e3d7b7b907c4fe6cfd5f0f551ce54789afee60b0f6ec8-Linux-gpu-ccache-28738831957
```

EDIT: adding a screenshot for completeness, this would also cost ~45 seconds per cache, because of the retries and 500 errors:

<img width="943" height="632" alt="image" src="https://github.com/user-attachments/assets/eef40844-913a-4bc2-90d5-389c061c37fa" />


***

xref'ing previous PRs where we introduced this caching and observed large job runtime improvements:

- CuPy: gh-24735
- JAX: gh-25002


#### AI Generation Disclosure

Some CI log diagnosis done with Claude Fable via claude.ai. 
