### PR TITLE
BLD/CI: bump minimum GCC version to 10.3.0, fix i686 Linux CI job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -392,9 +392,8 @@ jobs:
       - name: build + test in i686 container
         run: |
           set -exuo pipefail
-          # Note: `ccache` not used because it isn't available on i686 CentOS 7
-          docker pull quay.io/pypa/manylinux2014_i686
-          docker run -v $(pwd):/scipy --platform=linux/i386 quay.io/pypa/manylinux2014_i686 /bin/bash -c "cd /scipy && \
+          docker pull quay.io/pypa/manylinux_2_28_i686
+          docker run -v $(pwd):/scipy --platform=linux/i386 quay.io/pypa/manylinux_2_28_i686 /bin/bash -c "cd /scipy && \
           uname -a && \
           python3.12 -m venv test && \
           source test/bin/activate && \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -243,7 +243,7 @@ jobs:
           python3-dbg -m pytest --pyargs scipy -n4 --durations=10 -m "not slow"
 
   #################################################################################
-  gcc9:
+  gcc10:
     # Purpose is to examine builds with oldest-supported gcc and test with pydata/sparse.
     name: Oldest GCC & pydata/sparse, full, py3.12/npMin, pip+pytest
     needs: get_commit_message
@@ -265,7 +265,7 @@ jobs:
       - name: Setup system dependencies
         run: |
           sudo apt-get -y update
-          sudo apt install -y g++-9 gcc-9
+          sudo apt install -y g++-10 gcc-10
           sudo apt install -y libatlas-base-dev liblapack-dev libgmp-dev \
             libmpfr-dev libmpc-dev pkg-config libsuitesparse-dev liblapack-dev ccache
 
@@ -284,7 +284,7 @@ jobs:
           export PYTHONOPTIMIZE=2
 
           # specify which compilers to use using environment variables
-          CC="ccache gcc-9" CXX="ccache g++-9" python -m pip install . -v \
+          CC="ccache gcc-10" CXX="ccache g++-10" python -m pip install . -v \
               --no-build-isolation -Cbuild-dir=build \
               -Csetup-args=-Dblas=blas-atlas -Csetup-args=-Dlapack=lapack-atlas
 

--- a/doc/source/dev/toolchain.rst
+++ b/doc/source/dev/toolchain.rst
@@ -129,7 +129,7 @@ As explained in more detail below, the current minimal compiler versions are:
 ==========  ===========================  ===============================  ============================
  Compiler    Default Platform (tested)    Secondary Platform (untested)    Minimal Version
 ==========  ===========================  ===============================  ============================
- GCC         Linux                        AIX, Alpine Linux, OSX           GCC 9.x
+ GCC         Linux                        AIX, Alpine Linux, OSX           GCC 10.3
  LLVM        OSX                          Linux, FreeBSD, Windows          LLVM 12.x
  MSVC        Windows                      -                                Visual Studio 2019 (vc142)
 ==========  ===========================  ===============================  ============================
@@ -147,7 +147,6 @@ Currently, SciPy wheels are being built as follows:
 =========================   ==============================   ====================================   =============================
  Platform                    `CI`_ `Base`_ `Images`_          Compilers                              Comment
 =========================   ==============================   ====================================   =============================
- Linux x86                   ``ubuntu-22.04``                 GCC 10.2.1                             ``cibuildwheel``
  Linux arm                   ``docker-builder-arm64``         GCC 11.3.0                             ``cibuildwheel``
  OSX x86_64 (OpenBLAS)       ``macos-15-intel``               Apple clang 13.1.6                     ``cibuildwheel``
  OSX x86_64 (Accelerate)     ``macos-15-intel``               Apple clang 15.0.0                     ``cibuildwheel``
@@ -371,7 +370,7 @@ AIX, Alpine Linux and FreeBSD.
 .. _13.x release: https://www.freebsd.org/releases/13.2R/relnotes/
 .. _freebsd-port: https://ports.freebsd.org/cgi/ports.cgi?query=gcc
 
-All the currently lowest-supported compiler versions (GCC 9, LLVM 14,
+All the currently lowest-supported compiler versions (GCC 10, LLVM 14,
 VS2019 with vc142) have full support for the C++17 *core language*,
 which can therefore be used unconditionally.
 However, as of mid-2024, support for the entirety of the C++17 standard library

--- a/meson.build
+++ b/meson.build
@@ -47,8 +47,8 @@ cython = find_program(cy.cmd_array()[0])
 
 # Check compiler is recent enough (see "Toolchain Roadmap" for details)
 if cc.get_id() == 'gcc'
-  if not cc.version().version_compare('>=9.1')
-    error('SciPy requires GCC >= 9.1')
+  if not cc.version().version_compare('>=10.3')
+    error('SciPy requires GCC >= 10.3')
   endif
 elif cc.get_id() == 'clang' or cc.get_id() == 'clang-cl'
   if not cc.version().version_compare('>=15.0')

--- a/scipy/fft/_duccfft/meson.build
+++ b/scipy/fft/_duccfft/meson.build
@@ -1,11 +1,11 @@
-duccfft_threads = []
+duccfft_args = []
 fft_deps = []
 if is_windows
   if is_mingw
     # mingw-w64 does not implement pthread_pfork, needed by ducc_fft
     # Disable threading completely, because of freezes using threading for
     # mingw-w64 gcc: https://github.com/mreineck/pocketfft/issues/1
-    duccfft_threads += ['-DDUCC0_NO_LOWLEVEL_THREADING']
+    duccfft_args += ['-DDUCC0_NO_LOWLEVEL_THREADING']
   else
     if thread_dep.found()
       # Use native Windows threading for MSVC/Clang. `pthreads` is probably not
@@ -14,7 +14,6 @@ if is_windows
       # progress (see comment on gh-16957).  The ducc FFT sources
       # will include `<threads>` anyway.
       fft_deps += [thread_dep]
-      duccfft_threads += []
     endif
   endif
 else
@@ -23,10 +22,15 @@ else
   endif
 endif
 
+if cc.get_id() == 'gcc' and cc.sizeof('void*') == 4
+  # Disable SIMD, segfaults on Linux i686, see scipy#25572
+  duccfft_args += ['-DDUCC0_NO_SIMD']
+endif
+
 py3.extension_module(
     'pyduccfft',
     'pyduccfft.cxx',
-    cpp_args: duccfft_threads,
+    cpp_args: duccfft_args,
     dependencies: [fft_deps, pybind11_dep, duccfft_dep],
     link_args: version_link_args,
     install: true,

--- a/scipy/optimize/tests/test_minpack.py
+++ b/scipy/optimize/tests/test_minpack.py
@@ -941,7 +941,7 @@ class TestCurveFit:
                         jac=jac2, absolute_sigma=absolute_sigma)
 
                 assert_allclose(popt1, popt2, rtol=1.4e-7, atol=1e-14)
-                assert_allclose(pcov1, pcov2, rtol=1.4e-7, atol=1e-14)
+                assert_allclose(pcov1, pcov2, rtol=1.5e-7, atol=1e-14)
 
     @pytest.mark.parametrize("absolute_sigma", [False, True])
     def test_curvefit_scalar_sigma(self, absolute_sigma):

--- a/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
+++ b/scipy/sparse/linalg/_eigen/arpack/tests/test_arpack.py
@@ -23,6 +23,10 @@ from scipy._lib._gcutils import assert_deallocated
 _ndigits = {'f': 3, 'd': 11, 'F': 3, 'D': 11}
 
 
+def _is_32bit():
+    return np.intp(0).itemsize < 8
+
+
 def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
     """
     Return tolerance values suitable for a given test:
@@ -77,6 +81,11 @@ def _get_test_tolerance(type_char, mattype=None, D_type=None, which=None):
             # missing more cases, from PR 14798
             rtol *= 10
             atol *= 10
+
+    if _is_32bit():
+        # Small tolerance bumps needed on i686 linux after moving
+        # from GCC 10.2 to 14.2
+        rtol *= 2
 
     return tol, rtol, atol
 

--- a/scipy/sparse/linalg/_isolve/tests/test_iterative.py
+++ b/scipy/sparse/linalg/_isolve/tests/test_iterative.py
@@ -37,6 +37,10 @@ _SOLVERS = [bicg, bicgstab, cg, cgs, gcrotmk, gmres, lgmres,
 CB_TYPE_FILTER = ".*called without specifying `callback_type`.*"
 
 
+def _is_32bit():
+    return np.intp(0).itemsize < 8
+
+
 def _assert_success(*, A, x, b, xp, rtol=1.0, atol=0.0, less_equal=False):
     Ax = xp.squeeze(A @ x[..., xp.newaxis], axis=-1)
     residual = Ax - b
@@ -319,6 +323,9 @@ def test_maxiter(case, xp, batch_A, batch_b):
 def test_convergence(case, xp, batch_A, batch_b):
     if (case.solver is tfqmr) and ("poisson2d-F" in case.name):
         pytest.skip("Struggles to converge with single precision on some platforms")
+    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name) and _is_32bit():
+        pytest.skip("Fails to converge on i686 (32-bit) linux")
+
     case = xp_case(case, xp, batch_A, batch_b, rng=38)
     A = case.A
 
@@ -350,13 +357,15 @@ def test_precond_dummy(case, xp, batch_A, batch_b):
         pytest.skip("Struggles to converge with single precision")
     if (case.solver is tfqmr) and ("poisson2d-F" in case.name):
         pytest.skip("Hits divide-by-zero with single precision")
+    if (case.solver is tfqmr) and ("rand-sym-pd-F" in case.name) and _is_32bit():
+        pytest.skip("Fails to converge on i686 (32-bit) linux")
     if not case.convergence:
         pytest.skip("Solver - Breakdown case, see gh-8829")
 
     rtol = 1e-8 if np.finfo(dtype).eps < 1e-8 else 1.4e-3
 
     A = case.A
-    
+
     # NOTE: the following was previously uncommented as dead code --
     # was the intention to set `A = dia_array(...)`?
 
@@ -395,7 +404,7 @@ def test_precond_inverse(case, xp, batch_A, batch_b):
         pytest.skip("specific to poisson1d and poisson2d cases")
     if case.solver is qmr:
         pytest.skip("skipped for qmr")
-    
+
     case = xp_case(case, xp, batch_A, batch_b, rng=38)
     rtol = 1e-8
 
@@ -463,7 +472,7 @@ def test_atol(solver, xp, batch_A, batch_b):
     b = 1e3 * rng.uniform(size=(*batch_b, 10))
 
     dtype = xpx.default_dtype(xp)
-    A = xp.asarray(A, dtype=dtype) 
+    A = xp.asarray(A, dtype=dtype)
     b = xp.asarray(b, dtype=dtype)
 
     tols = np.r_[0, np.logspace(-9, 2, 7), np.inf]
@@ -497,7 +506,7 @@ def test_atol(solver, xp, batch_A, batch_b):
 @pytest.mark.parametrize("batch_b", [()])
 def test_zero_rhs(solver, xp, batch_A, batch_b):
     rng = np.random.default_rng(1684414984100503)
-    dtype = xpx.default_dtype(xp) 
+    dtype = xpx.default_dtype(xp)
     A = xp.asarray(rng.random(size=(*batch_A, 10, 10)), dtype=dtype)
     A = A @ A.mT + 10 * xp.eye(10)
 

--- a/scipy/special/tests/test_data.py
+++ b/scipy/special/tests/test_data.py
@@ -551,7 +551,7 @@ BOOST_TESTS = [
         data(elliprg, 'ellint_rg_xyy_ipp-ellint_rg_xyy', (0, 1, 2), 3,
              rtol=7.5e-16),
         data(elliprg, 'ellint_rg_xy0_ipp-ellint_rg_xy0', (0, 1, 2), 3,
-             rtol=5e-16),
+             rtol=5.2e-16),
         data(elliprg, 'ellint_rg_00x_ipp-ellint_rg_00x', (0, 1, 2), 3,
              rtol=5e-16),
         data(elliprj, 'ellint_rj_data_ipp-ellint_rj_data', (0, 1, 2, 3), 4,

--- a/scipy/stats/tests/test_kdeoth.py
+++ b/scipy/stats/tests/test_kdeoth.py
@@ -22,7 +22,7 @@ def test_kde_1d():
     xx = np.asarray([0.1, 0.5, 0.9])
     loc, scale = gkde.dataset, np.sqrt(gkde.covariance)
     assert_allclose(
-        gkde(xx), 
+        gkde(xx),
         stats.norm.pdf(xx[:, None], loc=loc, scale=scale).sum(axis=-1) / gkde.n,
         rtol=5e-14
     )
@@ -65,7 +65,7 @@ def test_kde_1d_weighted():
 
     pdf = stats.norm.pdf
     assert_allclose(
-        gkde(xx), 
+        gkde(xx),
         np.sum(pdf(xx[:, None], loc=loc, scale=scale) * gkde.weights, axis=-1),
         rtol=5e-14
     )
@@ -181,7 +181,7 @@ def test_kde_2d_weighted(n_basesample):
     assert_allclose(
         gkde(xx.T),
         np.sum(pdf(arg, cov=gkde.covariance) * gkde.weights, axis=-1),
-        rtol=5e-14
+        rtol=6e-14
     )
 
     # ... and cdf


### PR DESCRIPTION
This was a little more involved than expected. Because NumPy dropped GCC <10.3 support, the 32-bit Linux job broke because it builds `numpy` from source and it was running an outdated `manylinux2014` container with GCC 10.2.1. Bumping that containing to `manylinux_2_28` then jumped us to GCC 14.2.1, which then caused both a segfault in `ducc0` (see gh-25572 for the investigation) and a number of test failures (small tolerance issues).

Performance on 32-bit systems isn't very critical, so disabling `ducc0`'s SIMD code paths is no problem. It can be re-enabled of course if fixed upstream, but if not that is also fine.

Closes gh-25572

#### AI Generation Disclosure

No AI tools used