### PR TITLE
DOC/MAINT: Make the forum icon in header visible again

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -209,7 +209,7 @@ html_sidebars = {
     "index": ["search-button-field"],
     "**": ["search-button-field", "sidebar-nav-bs"]
 }
-html_js_files = ['custom-icons.js']  # defines custom icon(s) used in header
+html_js_files = [('custom-icons.js', {"defer": "defer"}),]  # for custom header icon(s)
 html_theme_options = {
     "header_links_before_dropdown": 6,
     "icon_links": [


### PR DESCRIPTION
From SciPy 1.18. on, the icon link to the "Scientifc Python" forum is not displayed anymore:

<img width="226" height="52" alt="image" src="https://github.com/user-attachments/assets/04f20c1e-138b-4416-8ed2-2d599f053d44" />
<img width="294" height="52" alt="image" src="https://github.com/user-attachments/assets/c4e05416-ca32-45da-aae9-59b7d8eb4325" />


 The switch from "PyData Sphinx Theme" version 0.16.1 to version 0.19.0. seems to be the cause. The fix is described in its [documentation](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/header-links.html#svg-image-icons).


No AI tools used.

[docs only]
