### PR TITLE
DOC: clarify freqz broadcasting requirements

### DIFF
--- a/scipy/signal/_filter_design.py
+++ b/scipy/signal/_filter_design.py
@@ -356,12 +356,18 @@ def freqz(b, a=1, worN=512, whole=False, plot=None, fs=2*pi,
         Numerator of a linear filter. If `b` has dimension greater than 1,
         it is assumed that the coefficients are stored in the first dimension,
         and ``b.shape[1:]``, ``a.shape[1:]``, and the shape of the frequencies
-        array must be compatible for broadcasting.
+        array must be compatible for broadcasting. For example, if `worN` is
+        a 1-D array, then trailing coefficient dimensions must include a
+        length-1 axis to broadcast against the frequencies; see the
+        Broadcasting Examples below.
     a : array_like
-        Denominator of a linear filter. If `b` has dimension greater than 1,
+        Denominator of a linear filter. If `a` has dimension greater than 1,
         it is assumed that the coefficients are stored in the first dimension,
         and ``b.shape[1:]``, ``a.shape[1:]``, and the shape of the frequencies
-        array must be compatible for broadcasting.
+        array must be compatible for broadcasting. For example, if `worN` is
+        a 1-D array, then trailing coefficient dimensions must include a
+        length-1 axis to broadcast against the frequencies; see the
+        Broadcasting Examples below.
     worN : {None, int, array_like}, optional
         If a single integer, then compute at that many frequencies (default is
         N=512). This is a convenient alternative to::


### PR DESCRIPTION
#### Reference issue
Closes #17387

#### What does this implement/fix?
Clarifies the `signal.freqz` parameter documentation for broadcasting multi-dimensional numerator and denominator coefficients.

The existing Broadcasting Examples already show the required trailing length-1 axis, but the parameter text could be read as saying that a plain shape like `(n_coefficients, n_filters)` works with the default 1-D frequency grid. This update points readers to the required singleton trailing dimension and fixes the `a` parameter wording to refer to `a` rather than `b`.

#### Additional information
Local checks run:
- `git diff --check`
- `python - <<'PY' ... ast.parse(Path("scipy/signal/_filter_design.py").read_text(encoding="utf-8")) ... PY`

I did not run the SciPy test suite because this is a docstring-only change and this shallow checkout is not built as an importable SciPy development tree. I attempted `ruff check scipy/signal/_filter_design.py`, but `ruff` is not installed in the existing environment.

AI declaration: I used an AI coding assistant (Hermes/OpenAI Codex) to inspect the issue and repository, draft this small documentation change, and run the local checks above. I reviewed the final diff before submission; the submitted text is the documentation change described above.
