### PR TITLE
MAINT/BLD: correct `?getrf`/`?getri` return types and `trlib` `dlagtm` ABI for strict-signature toolchains (WASM)

### DIFF
--- a/scipy/linalg/src/_common_array_utils.hh
+++ b/scipy/linalg/src/_common_array_utils.hh
@@ -15,38 +15,38 @@
 extern "C" {
 
 /* ?GETRF */
-CBLAS_INT
+void
 BLAS_FUNC(sgetrf)(CBLAS_INT *m, CBLAS_INT *n, float a[], CBLAS_INT *lda,
                   CBLAS_INT ipiv[], CBLAS_INT *info
 );
-CBLAS_INT
+void
 BLAS_FUNC(dgetrf)(CBLAS_INT *m, CBLAS_INT *n, double a[], CBLAS_INT *lda,
                   CBLAS_INT ipiv[], CBLAS_INT *info
 );
-CBLAS_INT
+void
 BLAS_FUNC(cgetrf)(CBLAS_INT *m, CBLAS_INT *n, npy_complex64 a[], CBLAS_INT *lda,
                   CBLAS_INT ipiv[], CBLAS_INT *info
 );
-CBLAS_INT
+void
 BLAS_FUNC(zgetrf)(CBLAS_INT *m, CBLAS_INT *n, npy_complex128 a[], CBLAS_INT *lda,
                   CBLAS_INT ipiv[], CBLAS_INT *info
 );
 
 
 /* ?GETRI */
-CBLAS_INT
+void
 BLAS_FUNC(sgetri)(CBLAS_INT *n, float a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
                   float work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
-CBLAS_INT
+void
 BLAS_FUNC(dgetri)(CBLAS_INT *n, double a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
                   double work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
-CBLAS_INT
+void
 BLAS_FUNC(cgetri)(CBLAS_INT *n, npy_complex64 a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
                   npy_complex64 work[], CBLAS_INT *lwork, CBLAS_INT *info
 );
-CBLAS_INT
+void
 BLAS_FUNC(zgetri)(CBLAS_INT *n, npy_complex128 a[], CBLAS_INT *lda, CBLAS_INT ipiv[],
                   npy_complex128 work[], CBLAS_INT *lwork, CBLAS_INT *info
 );

--- a/scipy/optimize/_trlib/trlib_private.h
+++ b/scipy/optimize/_trlib/trlib_private.h
@@ -49,7 +49,9 @@ double BLAS_FUNC(ddot)(CBLAS_INT *n, double *x, CBLAS_INT *incx, double *y, CBLA
 void BLAS_FUNC(dpttrf)(CBLAS_INT *n, double *d, double *e, CBLAS_INT *info);
 void BLAS_FUNC(dpttrs)(CBLAS_INT *n, CBLAS_INT *nrhs, double *d, double *e, double *b, CBLAS_INT *ldb, CBLAS_INT *info);
 void BLAS_FUNC(dptrfs)(CBLAS_INT *n, CBLAS_INT *nrhs, double *d, double *e, double *df, double *ef, double *b, CBLAS_INT *ldb, double *x, CBLAS_INT *ldx, double *ferr, double *berr, double *work, CBLAS_INT *info);
-void BLAS_FUNC(dlagtm)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, double *alpha, double *dl, double *d, double *du, double *x, CBLAS_INT *ldx, double *beta, double *b, CBLAS_INT *ldb, int);
+// dlagtm is declared without a trailing hidden Fortran
+// string length for trans. See gh-25592.
+void BLAS_FUNC(dlagtm)(char *trans, CBLAS_INT *n, CBLAS_INT *nrhs, double *alpha, double *dl, double *d, double *du, double *x, CBLAS_INT *ldx, double *beta, double *b, CBLAS_INT *ldb);
 
 
 static void trlib_daxpy(trlib_int_t *n, double *alpha, double *x, trlib_int_t *incx, double *y, trlib_int_t *incy)
@@ -108,7 +110,7 @@ static void trlib_dlagtm(char *trans, trlib_int_t *n, trlib_int_t *nrhs, double 
                          trlib_int_t *ldx, double *beta, double *b, trlib_int_t *ldb)
 {
     CBLAS_INT n_ = *n, nrhs_ = *nrhs, ldb_ = *ldb, ldx_ = *ldx;
-    BLAS_FUNC(dlagtm)(trans, &n_, &nrhs_, alpha, dl, d, du, x, &ldx_, beta, b, &ldb_, 1);
+    BLAS_FUNC(dlagtm)(trans, &n_, &nrhs_, alpha, dl, d, du, x, &ldx_, beta, b, &ldb_);
 }
 
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

See gh-17413
See gh-15290
See gh-14812
See pyodide/pyodide-recipes#604

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR aligns C prototypes that declare LAPACK subroutines with those elsewhere. This behaviour is tolerated by native linkers on conventional platforms and is a benign ABI mismatch. However, it breaks toolchains that enforce exact function signatures, as we notice when building SciPy for WebAssembly via the Emscripten toolchain, for the Pyodide distribution.

Specifically, I have fixed the following:

1. The eight `?getrf`/`?getri` prototypes are currently declared with an `int` return type in the C++ header file `scipy/linalg/src/_common_array_utils.hh` (as `CBLAS_INT`), but the subling C header `scipy/linalg/src/_common_array_utils.h` declares them as `void`s, with `void BLAS_FUNC(?getrf)(<...>)`. The return value is not read anywhere else in SciPy to the best of my readings.

2. The `dlagtm` declaration and call in `scipy/optimize/_trlib/trlib_private.h` is made with the g77 ABI trailing hidden Fortran string length arguments. This is not the convention elsewhere; for example, `?getrs` in `common_array_utils.hh` and all of `cython_lapack` do not pass any hidden length for LAPACK character arguments. LSAME ignores it on native platforms.

Note: I did read the vendored code policy, and this is a change introduced by SciPy in b7580c33eb and not trlib – upstream trlib already uses the no-length form. See https://github.com/felixlen/trlib/blob/bcddeae70e10896009a5824dcffc0261feec61cc/src/trlib_private.h.in#L50 and the call macros later in the file (https://github.com/felixlen/trlib/blob/bcddeae70e10896009a5824dcffc0261feec61cc/src/trlib_private.h.in#L92). However, there may be a case for updating the vendored trlib (xref https://github.com/scipy/scipy/issues/21232, https://github.com/felixlen/trlib/issues/27) too, as I couldn't find the version/commit of trlib recorded anywhere? If yes, I would be more than happy to take that as a follow-up task from here. There might be a risk that things like this could get reintroduced if a trlib that's pinned to some newer commit might get vendored in the time I introduce a WASM CI job that can catch it (which I am working on the mechanics of), as there is no vendoring script (I assume this is all manual). I added a comment for now.

cc: @ilayn

#### Additional information
<!--Any additional information you think is important.-->

These inconsistencies in SciPy are what I have currently patched in https://github.com/pyodide/pyodide-recipes/pull/619. This PR I've put together is an attempt to fix them upstream and drop them from there in SciPy v2.0.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI tools used