### PR TITLE
BENCH: re-enable MILP benchmarks

### DIFF
--- a/benchmarks/benchmarks/optimize_milp.py
+++ b/benchmarks/benchmarks/optimize_milp.py
@@ -70,20 +70,33 @@ class MilpMiplibBenchmarks(Benchmark):
 
 
 class MilpMagicSquare(Benchmark):
+    """Benchmark MILP feasibility with magic squares.
+
+    A magic square arranges the integers from 1 through n**2 so that every
+    row, column, and the two main diagonals have the same sum.
+    See https://en.wikipedia.org/wiki/Magic_square
+    """
 
     params = [[3, 4, 5, 6]]
     param_names = ['size']
 
     @staticmethod
     def _bounds(n, fix_top_left=False):
+        """Return binary bounds, optionally fixing the top-left cell."""
         if not fix_top_left:
             return (0, 1)
 
         lb = np.zeros(n**4)
         ub = np.ones(n**4)
         row = col = 0
+
+        # A magic square uses each integer from 1 through n**2, and
+        # `magic_square` encodes its placement as x[value - 1, row, col].
+        # Fixing the top-left cell to n**2 - 1, verified feasible for sizes 3-6,
+        # reduces symmetric solutions and makes the problem easier to solve.
         value = n**2 - 1
         lb[(value - 1) * n**2 + row * n + col] = 1
+
         return Bounds(lb, ub)
 
     def setup(self, n):
@@ -92,6 +105,7 @@ class MilpMagicSquare(Benchmark):
 
         A_eq, b_eq, self.c, self.numbers, self.M = magic_square(n)
         self.constraints = (A_eq, b_eq, b_eq)
+
         # Break symmetry in the feasibility problem so the xslow sizes remain
         # under ASV's timeout.
         self.bounds = self._bounds(n, fix_top_left=True)

--- a/benchmarks/benchmarks/optimize_milp.py
+++ b/benchmarks/benchmarks/optimize_milp.py
@@ -3,10 +3,10 @@ import os
 import numpy as np
 from numpy.testing import assert_allclose
 
-from .common import Benchmark, safe_import
+from .common import Benchmark, is_xslow, safe_import
 
 with safe_import():
-    from scipy.optimize import milp
+    from scipy.optimize import Bounds, milp
 
 with safe_import():
     from scipy.optimize.tests.test_linprog import magic_square
@@ -16,8 +16,14 @@ with safe_import():
 # The MIPLIB benchmark problem set was downloaded from https://miplib.zib.de/.
 # An MPS converter (scikit-glpk) was used to load the data into Python. The
 # arrays were arranged to the format required by `milp` and saved to `npz`
-# format using `np.savez`.
-milp_problems = ["piperout-27"]
+# format using `np.savez`. The reduced case below keeps most of the
+# piperout-27 inequality constraints so the default suite retains a sizable
+# MILP benchmark without timing out.
+milp_problems = ["piperout-27-reduced", "piperout-27"]
+milp_problem_data = {
+    "piperout-27-reduced": ("piperout-27", 14336),
+    "piperout-27": ("piperout-27", None),
+}
 
 
 class MilpMiplibBenchmarks(Benchmark):
@@ -25,19 +31,29 @@ class MilpMiplibBenchmarks(Benchmark):
     param_names = ['problem']
 
     def setup(self, prob):
+        if prob == "piperout-27" and not is_xslow():
+            raise NotImplementedError("skipped")
+
         if not hasattr(self, 'data'):
             dir_path = os.path.dirname(os.path.realpath(__file__))
             datafile = os.path.join(dir_path, "linprog_benchmark_files",
                                     "milp_benchmarks.npz")
             self.data = np.load(datafile, allow_pickle=True)
 
-        c, A_ub, b_ub, A_eq, b_eq, bounds, integrality = self.data[prob]
+        data_name, max_ub_constraints = milp_problem_data[prob]
+        c, A_ub, b_ub, A_eq, b_eq, bounds, integrality = self.data[data_name]
 
         lb = [li for li, ui in bounds]
         ub = [ui for li, ui in bounds]
 
         cons = []
         if A_ub is not None:
+            if max_ub_constraints is not None:
+                # The full MIPLIB instance has timed out in regular ASV runs.
+                # Use a deterministic subset of inequality constraints to
+                # keep this benchmark suitable for the default suite.
+                A_ub = A_ub[:max_ub_constraints, :]
+                b_ub = b_ub[:max_ub_constraints]
             cons.append((A_ub, -np.inf, b_ub))
         if A_eq is not None:
             cons.append((A_eq, b_eq, b_eq))
@@ -48,27 +64,41 @@ class MilpMiplibBenchmarks(Benchmark):
         self.integrality = integrality
 
     def time_milp(self, prob):
-        # TODO: fix this benchmark (timing out in Aug. 2023); see gh-19389
-        # res = milp(c=self.c, constraints=self.constraints, bounds=self.bounds,
-        #           integrality=self.integrality)
-        # assert res.success
-        pass
+        res = milp(c=self.c, constraints=self.constraints, bounds=self.bounds,
+                   integrality=self.integrality)
+        assert res.success
 
 
 class MilpMagicSquare(Benchmark):
 
-    # TODO: look at 5,6 - timing out and disabled in Apr'24 (5) and Aug'23 (6)
-    #       see gh-19389 for details
-    params = [[3, 4]]
+    params = [[3, 4, 5, 6]]
     param_names = ['size']
 
+    @staticmethod
+    def _bounds(n, fix_top_left=False):
+        if not fix_top_left:
+            return (0, 1)
+
+        lb = np.zeros(n**4)
+        ub = np.ones(n**4)
+        row = col = 0
+        value = n**2 - 1
+        lb[(value - 1) * n**2 + row * n + col] = 1
+        return Bounds(lb, ub)
+
     def setup(self, n):
+        if n > 4 and not is_xslow():
+            raise NotImplementedError("skipped")
+
         A_eq, b_eq, self.c, self.numbers, self.M = magic_square(n)
         self.constraints = (A_eq, b_eq, b_eq)
+        # Break symmetry in the feasibility problem so the xslow sizes remain
+        # under ASV's timeout.
+        self.bounds = self._bounds(n, fix_top_left=True)
 
     def time_magic_square(self, n):
         res = milp(c=self.c*0, constraints=self.constraints,
-                   bounds=(0, 1), integrality=True)
+                   bounds=self.bounds, integrality=True)
         assert res.status == 0
         x = np.round(res.x)
         s = (self.numbers.flatten() * x).reshape(n**2, n, n)


### PR DESCRIPTION
#### Reference issue

Addresses the `benchmarks/benchmarks/optimize_milp.py` entry in gh-19389.

#### What does this implement/fix?

This re-enables the disabled `optimize_milp.py` benchmarks without reintroducing the timeout that caused them to be disabled.

`MilpMiplibBenchmarks.time_milp` now runs a deterministic reduced `piperout-27-reduced` instance in regular ASV runs, while keeping the full `piperout-27` instance available when `SCIPY_XSLOW=1` is set. The reduced instance keeps the first 14,336 of 18,284 inequality constraints, which preserves most of the MIPLIB-derived constraint set while keeping the regular ASV case well below the full-instance runtime.

`MilpMagicSquare.time_magic_square` keeps the existing magic-square problem generator import and re-enables sizes 5 and 6 as xslow cases. The MILP benchmark applies the same explicit symmetry-breaking rule to every included magic-square size by fixing the top-left cell to `n**2 - 1`; this keeps the benchmark measuring the full magic-square constraints while making the xslow cases complete before ASV's timeout.

The skipped default cases use the existing benchmark-suite pattern of raising `NotImplementedError("skipped")` from `setup()`, which keeps the parameter set stable while avoiding slow cases in regular benchmark runs. These are not left as TODOs; they are runnable xslow benchmark cases.

No changes are made to `scipy.optimize.milp`.

#### Additional information

Validation:

```text
git diff --check
python3 -m py_compile benchmarks/benchmarks/optimize_milp.py
spin bench --no-build -C build-scipy-openblas32-venv -t optimize_milp -q
SCIPY_XSLOW=1 spin bench --no-build -C build-scipy-openblas32-venv -t optimize_milp -q
```

Regular benchmark run:

```text
optimize_milp.MilpMagicSquare.time_magic_square: ok
  size 3: 2.39 ms
  size 4: 335 ms
  sizes 5 and 6: skipped without SCIPY_XSLOW

optimize_milp.MilpMiplibBenchmarks.time_milp: ok
  piperout-27-reduced: 5.81 s
  piperout-27: skipped without SCIPY_XSLOW
```

Xslow benchmark run:

```text
optimize_milp.MilpMagicSquare.time_magic_square: ok
  size 3: 1.56 ms
  size 4: 335 ms
  size 5: 1.28 s
  size 6: 19.0 s

optimize_milp.MilpMiplibBenchmarks.time_milp: ok
  piperout-27-reduced: 5.80 s
  piperout-27: 33.6 s
```

I selected the 14,336-row cutoff from a timing sweep over deterministic prefixes of the existing `piperout-27` inequality matrix:

| Inequality rows | Local runtime |
| ---: | ---: |
| 12,288 | ~5.2 s |
| 14,336 | ~5.8 s |
| 15,360 | ~8.3 s |
| 16,384 | ~11.7 s |
| 18,284 (full) | ~33.6 s |

The 14,336-row cutoff was the largest tested cutoff before the first clear runtime jump. It keeps about 78% of the inequality rows while leaving headroom for slower machines in the regular ASV suite.

#### AI Generation Disclosure

I used Codex 5.5 to help investigate the disabled benchmark, inspect SciPy's benchmark conventions, suggest and edit changes in `benchmarks/benchmarks/optimize_milp.py`, run local validation commands, and organize the validation notes included in this description. The benchmark code and validation-note wording were AI-assisted. I reviewed the changes and PR text, have professional experience with MILP solvers including HiGHS, and understand the submitted benchmark code.
