### PR TITLE
BUG: Fix CSR fancy indexing with stepped column slices

### DIFF
--- a/scipy/sparse/_compressed.py
+++ b/scipy/sparse/_compressed.py
@@ -564,6 +564,8 @@ class _cs_matrix(_data_matrix, _minmax_mixin, IndexMixin):
         major, minor = self._swap((row, col))
         major = np.asarray(major, dtype=idx_dtype)
         minor = np.asarray(minor, dtype=idx_dtype)
+        
+        major, minor = np.broadcast_arrays(major, minor)
 
         val = np.empty(major.size, dtype=self.dtype)
         csr_sample_values(M, N, self.indptr, self.indices, self.data,

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -283,7 +283,8 @@ class _csr_base(_cs_matrix):
     def _get_arrayXslice(self, row, col):
         if col.step not in (1, None):
             col = np.arange(*col.indices(self.shape[1]))
-            return self._get_arrayXarray(row, col)
+            return self._get_arrayXarray(np.asarray(row)[:, None], col)
+
         return self._major_index_fancy(row)._get_submatrix(minor=col)
 
     def _set_int(self, idx, x):

--- a/scipy/sparse/_csr.py
+++ b/scipy/sparse/_csr.py
@@ -282,8 +282,13 @@ class _csr_base(_cs_matrix):
 
     def _get_arrayXslice(self, row, col):
         if col.step not in (1, None):
-            col = np.arange(*col.indices(self.shape[1]))
-            return self._get_arrayXarray(np.asarray(row)[:, None], col)
+            idx_dtype = self.indices.dtype
+            col = np.arange(*col.indices(self.shape[1]), dtype=idx_dtype)
+            row = np.asarray(row, dtype=idx_dtype)[:, None]
+            print(row.dtype)
+            print(col.dtype)
+            print(self.indices.dtype)
+            return self._get_arrayXarray(row, col)
 
         return self._major_index_fancy(row)._get_submatrix(minor=col)
 

--- a/scipy/sparse/tests/test_csr.py
+++ b/scipy/sparse/tests/test_csr.py
@@ -128,6 +128,14 @@ def test_fancy_indexing_broadcasts_without_making_dense_2d(cls):
     assert S[I, J].nnz == 0  # 1D row array for columns -> broadcasts to 2D
     assert S[I, J.reshape(1, -1)].nnz == 0  # 2D row array as index for columns
 
+@pytest.mark.parametrize("cls", [csr_matrix, csr_array])
+def test_fancy_indexing_with_stepped_column_slice(cls):
+    A = cls(np.eye(10))
+
+    result = A[[1, 0], 0:10:2]
+    expected = np.eye(10)[[1, 0], 0:10:2]
+
+    assert_array_equal(result.toarray(), expected)
 
 def test_csr_hstack_int64():
     """


### PR DESCRIPTION

#### Reference issue
Closes gh-25588

#### What does this implement/fix?
Fixes incorrect handling of stepped column slices (`step > 1`) in CSR fancy
indexing.

Previously, `_get_arrayXslice` converted the slice into an index array and
delegated to `_get_arrayXarray`, but passed the row indices without reshaping.
This caused `_get_arrayXarray` to perform paired indexing instead of
broadcasting the column indices across all selected rows, leading to a
`ValueError` when reshaping the result.

This PR reshapes the row indices before delegation so that NumPy broadcasting
is applied correctly. It also adds a regression test covering the reported
indexing case for both `csr_matrix` and `csr_array`.

#### Additional information
The regression test reproduces the indexing operation reported in the issue and
verifies that the result matches NumPy's indexing behavior.

#### AI Generation Disclosure
I used ChatGPT to help understand the existing implementation, analyze the root cause of the bug, and assist in developing the fix and regression test. I implemented, tested, and verified the final changes myself and reviewed all content before submission.