### PR TITLE
BENCH/DEV: Skip --dry-run when using --compare

### DIFF
--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -870,8 +870,13 @@ def bench(ctx, tests, submodule, compare, verbose, quick,
     if quick:
         bench_args = ['--quick'] + bench_args
 
-    if dry_run and not compare:
-        bench_args = ['--dry-run'] + bench_args
+    if dry_run and compare:
+        raise click.ClickException(
+        "--dry-run cannot be used together with --compare."
+        )
+
+    if dry_run:
+        bench_args = ["--dry-run"] + bench_args
 
     if len(array_api_backend) != 0:
         os.environ['SCIPY_ARRAY_API'] = json.dumps(list(array_api_backend))

--- a/.spin/cmds.py
+++ b/.spin/cmds.py
@@ -870,7 +870,7 @@ def bench(ctx, tests, submodule, compare, verbose, quick,
     if quick:
         bench_args = ['--quick'] + bench_args
 
-    if dry_run:
+    if dry_run and not compare:
         bench_args = ['--dry-run'] + bench_args
 
     if len(array_api_backend) != 0:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes  gh-25586

#### What does this implement/fix?
`spin bench --compare` invokes `asv continuous`, which does not support the `--dry-run` option. This change avoids passing `--dry-run` when `--compare` is used, preventing the command from failing with an "unrecognized arguments" error.

#### Additional information
N/A
#### AI Generation Disclosure
I used ChatGPT to help understand the issue, discuss the proposed fix, and review the pull request description. The code changes, testing, verification, and final submission were completed and reviewed by me.
