### PR TITLE
BUG: signal: fix segfault in remez for too-narrow bands

### DIFF
--- a/scipy/signal/_sigtoolsmodule.cc
+++ b/scipy/signal/_sigtoolsmodule.cc
@@ -471,7 +471,8 @@ static double wate(double freq, double *fx, double *wtx, int lband, int jtype)
 
 static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
                      double *response, double *weight, int type, int maxiter,
-                     int grid_density, int *niter_out) {
+                     int grid_density, int *niter_out, int *ngrid_out,
+                     int *nfcns_out) {
 
   int jtype, nbands, nfilt, lgrid, nz;
   int neg, nodd, nm1;
@@ -566,6 +567,15 @@ static int pre_remez(double *h2, int numtaps, int numbands, double *bands,
     ngrid = j - 1;
     if (neg == nodd) {
 	if (grid[ngrid] > (0.5-delf)) --ngrid;
+    }
+
+    /* Need at least nfcns+1 grid points for the extremal frequencies;
+       a too-narrow band yields fewer and overruns the arrays (gh-24495). */
+    if (ngrid < nfcns + 1) {
+	*ngrid_out = ngrid;
+	*nfcns_out = nfcns;
+	free(tempstor);
+	return -3;
     }
 
     /*
@@ -839,6 +849,7 @@ static PyObject *_sigtools_remez(PyObject *NPY_UNUSED(dummy), PyObject *args)
     double oldvalue, *dptr, fs = 1.0;
     char mystr[255];
     int niter = -1;
+    int ngrid = -1, nfcns = -1;
 
     if (!PyArg_ParseTuple(args, "iOOO|idii", &numtaps, &bands, &des, &weight,
                           &type, &fs, &maxiter, &grid_density)) {
@@ -903,7 +914,7 @@ static PyObject *_sigtools_remez(PyObject *NPY_UNUSED(dummy), PyObject *args)
                     (double *)PyArray_DATA(a_bands),
                     (double *)PyArray_DATA(a_des),
                     (double *)PyArray_DATA(a_weight),
-                    type, maxiter, grid_density, &niter);
+                    type, maxiter, grid_density, &niter, &ngrid, &nfcns);
     if (err < 0) {
         if (err == -1) {
             snprintf(mystr, sizeof(mystr), "Failure to converge at iteration %d, try reducing transition band width.\n", niter);
@@ -912,6 +923,15 @@ static PyObject *_sigtools_remez(PyObject *NPY_UNUSED(dummy), PyObject *args)
         }
         else if (err == -2) {
             PyErr_NoMemory();
+            goto fail;
+        }
+        else if (err == -3) {
+            snprintf(mystr, sizeof(mystr),
+                "Band edges are too close together to build the dense "
+                "frequency grid: it has only %d point(s) but at least %d "
+                "(one per extremal frequency) are required. Widen the bands, "
+                "reduce numtaps, or increase grid_density.", ngrid, nfcns + 1);
+            PyErr_SetString(PyExc_ValueError, mystr);
             goto fail;
         }
     }

--- a/scipy/signal/tests/test_fir_filter_design.py
+++ b/scipy/signal/tests/test_fir_filter_design.py
@@ -564,6 +564,14 @@ class TestRemez:
         weight = xp.asarray([1.0, 2.0])
         remez(21, bands, desired, weight=weight)
 
+    @pytest.mark.parametrize('type', ['bandpass', 'differentiator', 'hilbert'])
+    def test_gh_24495_narrow_band(self, type):
+        # A band too narrow for the dense grid used to segfault (gh-24495).
+        with pytest.raises(ValueError, match="Band edges are too close"):
+            remez(101, [1000, 1000], [1], fs=20000, type=type)
+        with pytest.raises(ValueError, match="Band edges are too close"):
+            remez(101, [1000, 1011.5], [1], fs=20000, type=type)
+
 
 @make_xp_test_case(firls)
 class TestFirls:


### PR DESCRIPTION
#### Reference issue
Closes gh-24495.

#### What does this implement/fix?
`remez` segfaulted when a band was too narrow for the dense grid e.g. `remez(101, [1000, 1000], [1], fs=20000)` or `remez(101, [1000, 1011.5], [1], fs=20000)`. The algorithm places `numtaps//2 + 1` extremal frequencies on the grid sso the grid needs at least that many points. A band narrower than the grid spacing produces fewer and the extremal search then runs past the end of the arrays and crashes. `pre_remez` now checks the grid size and raises a `ValueError` (telling the user to widen the bands, reduce `numtaps`,  increase `grid_density`) instead of crashing


#### AI Generation Disclosure
I used claude to double check my work and make sure I didn't miss any dumb issues