### PR TITLE
MAINT: linalg: drop g77 ABI hidden string-length args from `?gees` wrappers

### DIFF
--- a/scipy/linalg/flapack_gen.pyf.src
+++ b/scipy/linalg/flapack_gen.pyf.src
@@ -1196,8 +1196,8 @@ subroutine <prefix2c>gees(compute_v,sort_t,<prefix2c>select,n,a,nrows,sdim,w,vs,
     !  A = Z * T * Z^H  -- a complex matrix is in Schur form if it is upper
     !  triangular
 
-    callstatement (*f2py_func)((compute_v?"V":"N"),(sort_t?"S":"N"),cb_<prefix2c>select_in_gees__user__routines,&n,a,&nrows,&sdim,w,vs,&ldvs,work,&lwork,rwork,bwork,&info,1,1)
-    callprotoargument char*,char*,F_INT(*)(<ctype2c>*),F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT,F_INT
+    callstatement (*f2py_func)((compute_v?"V":"N"),(sort_t?"S":"N"),cb_<prefix2c>select_in_gees__user__routines,&n,a,&nrows,&sdim,w,vs,&ldvs,work,&lwork,rwork,bwork,&info)
+    callprotoargument char*,char*,F_INT(*)(<ctype2c>*),F_INT*,<ctype2c>*,F_INT*,F_INT*,<ctype2c>*,<ctype2c>*,F_INT*,<ctype2c>*,F_INT*,<ctype2>*,F_INT*,F_INT*
 
     use gees__user__routines
 
@@ -1226,8 +1226,8 @@ subroutine <prefix2>gees(compute_v,sort_t,<prefix2>select,n,a,nrows,sdim,wr,wi,v
     !  A = Z * T * Z^H  -- a real matrix is in Schur form if it is upper quasi-
     !  triangular with 1x1 and 2x2 blocks.
 
-    callstatement (*f2py_func)((compute_v?"V":"N"),(sort_t?"S":"N"),cb_<prefix2>select_in_gees__user__routines,&n,a,&nrows,&sdim,wr,wi,vs,&ldvs,work,&lwork,bwork,&info,1,1)
-    callprotoargument char*,char*,F_INT(*)(<ctype2>*,<ctype2>*),F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*,F_INT,F_INT
+    callstatement (*f2py_func)((compute_v?"V":"N"),(sort_t?"S":"N"),cb_<prefix2>select_in_gees__user__routines,&n,a,&nrows,&sdim,wr,wi,vs,&ldvs,work,&lwork,bwork,&info)
+    callprotoargument char*,char*,F_INT(*)(<ctype2>*,<ctype2>*),F_INT*,<ctype2>*,F_INT*,F_INT*,<ctype2>*,<ctype2>*,<ctype2>*,F_INT*,<ctype2>*,F_INT*,F_INT*,F_INT*
 
     use gees__user__routines
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://scipy.github.io/devdocs/dev/contributor/development_workflow.html#writing-the-commit-message.
However, please only include an issue number in the description, not the title,
and please ensure that any code names containing underscores are enclosed in backticks.

Depending on your changes, you can skip CI operations and save time and energy:
https://scipy.github.io/devdocs/dev/contributor/continuous_integration.html#skipping

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

See gh-17413
See gh-15290
See gh-25592
See pyodide/pyodide-recipes#619

#### What does this implement/fix?
<!--Please explain your changes.-->

This is a small follow-up to gh-25592, which aligned a handful of LAPACK C prototypes with the convention used elsewhere in SciPy so that the sources build under toolchains that enforce exact function signatures at runtime (such as Emscripten/WASM, for the Pyodide distribution), while remaining a no-op on conventional native platforms.

`?gees` is the last remaining spot, in `scipy/linalg/flapack_gen.pyf.src` that still passes the g77/f2c trailing hidden Fortran string-length arguments for its two `char*` arguments, `compute_v` and `sort_t`. This drops them for both the complex and real variants. `?geev`, `?ggev`, and `?gges` omit these, and on native g77/gfortran ABIs the hidden length is passed but unused, as `LSAME` only reads the first byte and never inspects the length. Passing or omitting it is IIUC therefore a benign ABI detail on those platforms.

@hoodmane, I finally decided to upstream this patch of yours to fix these `?gees` calls 😄 as I noticed that this was never debated about in gh-17413, as that issue predates this patch.

cc: @ev-br, since this is a follow-up to gh-25592 and you reviewed it :D 

cc also: @ilayn, in case you'd like to take a look! After I did my own readings of how this file (and related files) are used, it seems to me that this patch should be fairly non-controversial in terms of upstreaming.

Thank you!

#### Additional information
<!--Any additional information you think is important.-->

Same as gh-25592, this relies on `LSAME` ignoring the hidden length on native/non-WASM platforms, which we haven't seen to be a problem in CI anywhere.

This patch should make the upcoming SciPy 1.19 (or 2.0) patch-free in Pyodide! 🎉 (And if I can suggest that this and gh-25592 be potentially backported to a v1.18.1, that also kind of helps a bit).

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI tools used