### PR TITLE
BUG/TYP: ``interpolate``: restore ``__class_getitem__`` methods (1.18.0 regression)

### DIFF
--- a/scipy/interpolate/_cubic.py
+++ b/scipy/interpolate/_cubic.py
@@ -262,9 +262,6 @@ class PchipInterpolator(CubicHermiteSpline):
 
     """
 
-    # PchipInterpolator is not generic in scipy-stubs
-    __class_getitem__ = None  # type:ignore[assignment]
-
     def __init__(self, x, y, axis=0, extrapolate=None):
         xp = array_namespace(x, y)
         x, _, y, axis, _ = prepare_input(x, y, axis, xp=xp)
@@ -536,9 +533,6 @@ class Akima1DInterpolator(CubicHermiteSpline):
            https://blogs.mathworks.com/cleve/2019/04/29/makima-piecewise-cubic-interpolation/
 
     """
-
-    # PchipInterpolator is not generic in scipy-stubs
-    __class_getitem__ = None  # type:ignore[assignment]
 
     def __init__(self, x, y, axis=0, *, method: Literal["akima", "makima"]="akima",
                  extrapolate:bool | None = None):

--- a/scipy/interpolate/_interpolate.py
+++ b/scipy/interpolate/_interpolate.py
@@ -1393,6 +1393,9 @@ class PPoly:
     larger than 20-30.
     """
 
+    # generic type compatibility with scipy-stubs
+    __class_getitem__: classmethod = classmethod(GenericAlias)
+
     def __init__(self, c, x, extrapolate=None, axis=0):
         xp = array_namespace(c, x)
         xp_ppoly_cls, xp_internal = _get_xp_ppoly_cls(xp)
@@ -1924,6 +1927,9 @@ class BPoly:
 
     """  # noqa: E501
 
+    # generic type compatibility with scipy-stubs
+    __class_getitem__: classmethod = classmethod(GenericAlias)
+
     def __init__(self, c, x, extrapolate=None, axis=0):
         xp = array_namespace(c, x)
         xp_bpoly_cls, xp_internal = _get_xp_bpoly_cls(xp)
@@ -2407,6 +2413,9 @@ class NdPPoly:
     unstable.
 
     """
+    
+    # generic type compatibility with scipy-stubs
+    __class_getitem__: classmethod = classmethod(GenericAlias)
 
     def __init__(self, c, x, extrapolate=None):
         self.x = tuple(np.ascontiguousarray(v, dtype=np.float64) for v in x)


### PR DESCRIPTION
While working on https://github.com/scipy/scipy-stubs/pull/1966 I noticed that the `scipy.interpolate` polynomial classes are no longer subscriptable at runtime, which they were before 1.18.0 (since #23234). Before, their ``__class_getitem__`` methods were inherited from `_PPolyBase`, but this baseclass was removed in https://github.com/scipy/scipy/pull/25072. 

```

In [1]: from scipy.interpolate import *

In [2]: PPoly[np.float64]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 PPoly[np.float64]

TypeError: type 'PPoly' is not subscriptable

In [3]: BPoly[np.float64]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[3], line 1
----> 1 BPoly[np.float64]

TypeError: type 'BPoly' is not subscriptable

In [4]: NdPPoly[np.float64]
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[4], line 1
----> 1 NdPPoly[np.float64]

TypeError: type 'NdPPoly' is not subscriptable
```

This also removes two `__class_getitem__ = None` for the cubic splines, which I just turned into generic types in scipy-stubs (https://github.com/scipy/scipy-stubs/pull/1966), so they're no longer needed.

#### AI Generation Disclosure
No AI tools used
