### PR TITLE
chore: performance improvements using sets and tuples in Wright-Bessel data

### DIFF
--- a/scipy/special/_precompute/hyp2f1_data.py
+++ b/scipy/special/_precompute/hyp2f1_data.py
@@ -370,9 +370,10 @@ def main(
     if parameter_groups is not None:
         # Group 9 params only used if specified in arguments.
         params.extend(group_9_params)
+        parameter_groups_set = set(parameter_groups)
         params = [
             (a, b, c, group) for a, b, c, group in params
-            if group in parameter_groups
+            if group in parameter_groups_set
         ]
 
     # grid_size * grid_size grid in box with corners
@@ -386,7 +387,8 @@ def main(
     # Add z = 1 + 0j (region 0).
     Z.append(1 + 0j)
     if regions is not None:
-        Z = [z for z in Z if get_region(z) in regions]
+        regions_set = set(regions)
+        Z = [z for z in Z if get_region(z) in regions_set]
 
     # Evaluate scipy and mpmath's hyp2f1 for all parameter combinations
     # above against all arguments in the grid Z

--- a/scipy/special/_precompute/wright_bessel_data.py
+++ b/scipy/special/_precompute/wright_bessel_data.py
@@ -87,7 +87,6 @@ def main():
     bool_filter = bool_filter & ~((a_range < 5.4) & (x_range > 1e16))
     bool_filter = bool_filter & ~((a_range < 5.8) & (x_range > 1e17))
     bool_filter = bool_filter & ~((a_range < 6.2) & (x_range > 1e18))
-    bool_filter = bool_filter & ~((a_range < 6.2) & (x_range > 1e18))
     bool_filter = bool_filter & ~((a_range < 6.5) & (x_range > 1e19))
     bool_filter = bool_filter & ~((a_range < 6.9) & (x_range > 1e20))
 
@@ -109,11 +108,12 @@ def main():
         [1.5, 0.1, 500],
         [1.5, 20, 100000],
         [1.5, 100, 100000],
-        ]).tolist()
+        ])
+    failing_set = {tuple(row) for row in failing}
 
     does_fail = np.full_like(a_range, False, dtype=bool)
     for i in range(x_range.size):
-        if [a_range[i], b_range[i], x_range[i]] in failing:
+        if (a_range[i], b_range[i], x_range[i]) in failing_set:
             does_fail[i] = True
 
     # filter and flatten

--- a/scipy/stats/_distn_infrastructure.py
+++ b/scipy/stats/_distn_infrastructure.py
@@ -1908,7 +1908,7 @@ class rv_continuous(rv_generic):
         self._attach_methods()
 
         if longname is None:
-            if name[0] in ['aeiouAEIOU']:
+            if name[0].lower() in 'aeiou':
                 hstr = "An "
             else:
                 hstr = "A "
@@ -3398,7 +3398,7 @@ class rv_discrete(rv_generic):
 
         # generate docstring for subclass instances
         if longname is None:
-            if name[0] in ['aeiouAEIOU']:
+            if name[0].lower() in 'aeiou':
                 hstr = "An "
             else:
                 hstr = "A "


### PR DESCRIPTION
#### Reference issue
There is no open issue associated with this PR.

#### What does this implement/fix?
This PR provides a small performance improvement to the Wright-Bessel data execution by replacing the existing list with Python `set`s. It also includes a few minor refactorings to improve code readability and maintainability, such as using `set`s and `tuple`s where appropriate. These changes also result in small performance gains in other parts of the code (typically a few milliseconds per execution).

#### Additional information
[This Jupyter notebook](https://colab.research.google.com/drive/1CgmDhsnMPSS2_L1-d2L4orUEMWB5WzrQ) compares the execution time of the previous implementation with the changes introduced in this PR. The notebook is hosted on Google Drive and will remain available throughout the PR review process.

The screenshot below summarizes the benchmark results and shows the observed execution time improvements:
<img width="377" height="45" alt="wright-bessel-scipy" src="https://github.com/user-attachments/assets/2cbba2fe-900a-43b5-9b26-bb396f0e4965" />

#### AI Generation Disclosure
No AI was used to generate the code or write this PR description.