### PR TITLE
BUG: adjust overlap when spectral segments shrink

### DIFF
--- a/scipy/signal/_spectral_py.py
+++ b/scipy/signal/_spectral_py.py
@@ -875,8 +875,10 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
         out_dtype = np.result_type(x, np.complex64)
 
     n = x.shape[axis] if same_data else max(x.shape[axis], y.shape[axis])
+    requested_nperseg = nperseg
     if isinstance(window, str) or isinstance(window, tuple):
         nperseg = int(nperseg) if nperseg is not None else 256
+        requested_nperseg = nperseg
         if nperseg < 1:
             raise ValueError(f"Parameter {nperseg=} is not a positive integer!")
         elif n < nperseg:
@@ -888,15 +890,16 @@ def csd(x, y, fs=1.0, window='hann_periodic', nperseg=None, noverlap=None, nfft=
         win = np.asarray(window)
         if nperseg is None:
             nperseg = len(win)
+            requested_nperseg = nperseg
     if nperseg != len(win):
         raise ValueError(f"{nperseg=} does not equal {len(win)=}")
 
     nfft = int(nfft) if nfft is not None else nperseg
     if nfft < nperseg:
         raise ValueError(f"{nfft=} must be greater than or equal to {nperseg=}!")
-    noverlap = int(noverlap) if noverlap is not None else nperseg // 2
-    if noverlap >= nperseg:
-        raise ValueError(f"{noverlap=} must be less than {nperseg=}!")
+    noverlap = (nperseg // 2 if noverlap is None else
+                _triage_noverlap(noverlap, nperseg, requested_nperseg,
+                                  stacklevel=4))
     if np.iscomplexobj(x) and return_onesided:
         return_onesided = False
 
@@ -1105,13 +1108,20 @@ def spectrogram(x, fs=1.0, window=('tukey_periodic', .25), nperseg=None, noverla
     if mode not in modelist:
         raise ValueError(f'unknown value for mode {mode}, must be one of {modelist}')
 
+    requested_nperseg = nperseg
+    string_window = isinstance(window, str | tuple)
+
     # need to set default for nperseg before setting default for noverlap below
     window, nperseg = _triage_segments(window, nperseg,
                                        input_length=x.shape[axis])
+    if requested_nperseg is None:
+        requested_nperseg = 256 if string_window else nperseg
 
     # Less overlap than welch, so samples are more statistically independent
     if noverlap is None:
         noverlap = nperseg // 8
+    else:
+        noverlap = _triage_noverlap(noverlap, nperseg, requested_nperseg)
 
     if mode == 'psd':
         freqs, time, Sxx = _spectral_helper(x, x, fs, window, nperseg,
@@ -2191,13 +2201,18 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
                 pad_shape[-1] = x.shape[-1] - y.shape[-1]
                 y = np.concatenate((y, np.zeros(pad_shape)), -1)
 
+    requested_nperseg = nperseg
     if nperseg is not None:  # if specified by user
         nperseg = int(nperseg)
+        requested_nperseg = nperseg
         if nperseg < 1:
             raise ValueError('nperseg must be a positive integer')
 
     # parse window; if array like, then set nperseg = win.shape
     win, nperseg = _triage_segments(window, nperseg, input_length=x.shape[-1])
+    if requested_nperseg is None:
+        requested_nperseg = (256 if isinstance(window, str | tuple)
+                              else nperseg)
 
     if nfft is None:
         nfft = nperseg
@@ -2209,9 +2224,8 @@ def _spectral_helper(x, y, fs=1.0, window='hann', nperseg=None, noverlap=None,
     if noverlap is None:
         noverlap = nperseg//2
     else:
-        noverlap = int(noverlap)
-    if noverlap >= nperseg:
-        raise ValueError('noverlap must be less than nperseg.')
+        noverlap = _triage_noverlap(noverlap, nperseg, requested_nperseg,
+                                     stacklevel=4)
     nstep = nperseg - noverlap
 
     # Padding occurs after boundary extension, so that the extended signal ends
@@ -2444,6 +2458,22 @@ def _triage_segments(window, nperseg, input_length):
                 raise ValueError("value specified for nperseg is different"
                                  " from length of window")
     return win, nperseg
+
+
+def _triage_noverlap(noverlap, nperseg, requested_nperseg, *, stacklevel=3):
+    """Validate `noverlap` and adjust it after `nperseg` is reduced."""
+    noverlap = int(noverlap)
+    if noverlap >= requested_nperseg:
+        raise ValueError('noverlap must be less than nperseg.')
+    if noverlap >= nperseg:
+        adjusted_noverlap = nperseg - 1
+        warnings.warn(
+            f'noverlap = {noverlap:d} is greater than or equal to adjusted '
+            f'nperseg = {nperseg:d}, using noverlap = {adjusted_noverlap:d}',
+            stacklevel=stacklevel,
+        )
+        noverlap = adjusted_noverlap
+    return noverlap
 
 
 def _median_bias(n):

--- a/scipy/signal/tests/test_spectral.py
+++ b/scipy/signal/tests/test_spectral.py
@@ -1038,6 +1038,33 @@ class TestSpectrogram:
         assert_allclose(f1, f3)
         assert_allclose(p1, p3)
 
+
+@pytest.mark.parametrize("func", [welch, spectrogram, signal.stft])
+def test_adjust_noverlap_for_short_data(func):
+    x = np.arange(8.0)
+    message = (r"noverlap = 8 is greater than or equal to adjusted "
+               r"nperseg = 8, using noverlap = 7")
+
+    with pytest.warns(UserWarning) as caught:
+        result = func(x, nperseg=16, noverlap=8)
+    expected = func(x, nperseg=8, noverlap=7)
+
+    assert len(caught) == 2
+    assert any("using nperseg = 8" in str(item.message) for item in caught)
+    assert any(message == str(item.message) for item in caught)
+    for actual, reference in zip(result, expected):
+        assert_allclose(actual, reference)
+
+
+@pytest.mark.parametrize("func", [welch, spectrogram, signal.stft])
+def test_invalid_noverlap_with_short_data(func):
+    x = np.arange(8.0)
+
+    with pytest.warns(UserWarning, match="nperseg"):
+        with pytest.raises(ValueError, match="noverlap must be less than nperseg"):
+            func(x, nperseg=16, noverlap=16)
+
+
 class TestLombscargle:
     def test_frequency(self):
         """Test if frequency location of peak corresponds to frequency of


### PR DESCRIPTION
#### Reference issue

Closes gh-25608.

#### What does this implement/fix?

When a signal is shorter than the requested `nperseg`, `nperseg` is already reduced to the signal length with a warning. The bug was that a user's `noverlap` was then validated against that *reduced* `nperseg`, so an overlap that was perfectly valid for the requested segment length raised `ValueError: noverlap must be less than nperseg.`

The fix adds a `_triage_noverlap` helper that validates `noverlap` against the *requested* `nperseg`. A genuinely-too-large overlap still raises; if the only problem is the reduction, it clamps `noverlap` to `nperseg - 1` and warns, matching the existing `nperseg` behavior.

Because `welch`/`csd` and the legacy functions no longer share code, the helper is wired in at three call sites: the modern `csd` path (used by `welch`), `spectrogram` directly (it reduces `nperseg` before calling the helper), and `_spectral_helper` (backing legacy `stft`).

For valid inputs where `nperseg` isn't reduced, results are unchanged. The one exception: the exact `ValueError` message for an invalid overlap in `csd` may differ slightly, since validation now runs through the shared helper.

#### Additional information

I did not run the full `test_spectral.py`. I ran the six new regression cases through a temporary harness against the modified module, plus Ruff (SciPy config), `py_compile`, and `git diff --check`; I'm leaning on CI for the rest.

The two new tests cover short-data warn-and-adjust behavior across `welch`/`spectrogram`/`stft`, checked against an explicit `nperseg=8, noverlap=7`, and confirm that an oversized overlap still raises.

This is a small behavior change — an error becomes a warning-plus-adjustment. Happy to preserve the requested overlap ratio instead of clamping to `nperseg - 1` if that's preferred.

#### AI Generation Disclosure

The code in `_spectral_py.py` and the new tests were generated with OpenAI Codex. I reviewed the full diff, understand it, can explain it, and ran the checks listed above. This description was written by me; any AI use was limited to grammar and spelling.