### PR TITLE
BUG/TST: linalg.sqrtm: fix scalar input handling

### DIFF
--- a/scipy/linalg/_matfuncs.py
+++ b/scipy/linalg/_matfuncs.py
@@ -389,7 +389,7 @@ def sqrtm(A):
     a = np.asarray(A)
     _deprecate_dtypes('sqrtm', a)
     if a.size == 1 and a.ndim < 2:
-        return np.array([[np.exp(a.item())]])
+        return np.array([[np.sqrt(a.item())]])
 
     if a.ndim < 2:
         raise LinAlgError('The input array must be at least two-dimensional')

--- a/scipy/linalg/tests/test_matfuncs.py
+++ b/scipy/linalg/tests/test_matfuncs.py
@@ -578,6 +578,12 @@ class TestSqrtM:
             res = sqrtm(a)
             assert np.isinf(res[0, 1:]).all()
 
+    def test_scalar_input(self):
+        assert_allclose(sqrtm(4), [[2.0]])
+
+    def test_1d_single_element_input(self):
+        assert_allclose(sqrtm([4]), [[2.0]])
+
 
 class TestFractionalMatrixPower:
     def test_round_trip_random_complex(self):


### PR DESCRIPTION
#### Reference issue

Closes gh-25610.

#### What does this implement/fix?

Uses `np.sqrt` instead of `np.exp` for scalar and one-element 1-D inputs to `sqrtm`.

Adds regression tests for scalar input and one-element 1-D input.

#### Additional information

The `TestSqrtM` tests pass locally.

#### AI Generation Disclosure

GPT-5.6 was used for guidance on the SciPy contribution workflow, but all code changes were written and reviewed by me.