### PR TITLE
MAINT/DEP: linalg: deprecate remaining `lwork` arguments in linalg

### DIFF
--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -174,8 +174,8 @@ def qr(a, overwrite_a=False, lwork=_NoValue, mode="full", pivoting=False,
 
         else:
             warnings.warn(
-                "scipy.linalg: the `lwork` keyword is deprecated and no longer in use"
-                " as of SciPy 1.18.0 and will be removed in SciPy 1.20.0",
+                "scipy.linalg.qr: the `lwork` keyword is deprecated and no longer in"
+                "use as of SciPy 1.18.0 and will be removed in SciPy 1.20.0",
                 DeprecationWarning,
                 stacklevel=2
             )
@@ -396,7 +396,7 @@ def qr_multiply(a, c, mode='right', pivoting=False, conjugate=False,
 
 
 @_apply_over_batch(('a', 2))
-def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
+def rq(a, overwrite_a=False, lwork=_NoValue, mode='full', check_finite=True):
     """
     Compute RQ decomposition of a matrix.
 
@@ -413,6 +413,11 @@ def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
     lwork : int, optional
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
+
+        .. deprecated:: 1.19.0
+            This keyword is deprecated as well as no longer in use and will be
+            removed in 1.21.0.
+
     mode : {'full', 'r', 'economic'}, optional
         Determines what information is to be returned: either both Q and R
         ('full', default), only R ('r') or both Q and R but computed in
@@ -465,6 +470,16 @@ def rq(a, overwrite_a=False, lwork=None, mode='full', check_finite=True):
     if mode not in ['full', 'r', 'economic']:
         raise ValueError(
                  "Mode argument should be one of ['full', 'r', 'economic']")
+
+    if lwork is not _NoValue:
+        warnings.warn(
+            "scipy.linalg.rq: the `lwork` keyword is deprecated and no longer in use"
+            " as of SciPy 1.19.0 and will be removed in SciPy 1.21.0",
+            DeprecationWarning,
+            stacklevel=2
+        )
+
+    lwork = None
 
     if check_finite:
         a1 = np.asarray_chkfinite(a)

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy._lib._util import _apply_over_batch, _deprecate_dtypes
 from scipy._lib.deprecation import _NoValue
 
+import os
 import warnings
 
 # Local imports
@@ -177,7 +178,7 @@ def qr(a, overwrite_a=False, lwork=_NoValue, mode="full", pivoting=False,
                 "scipy.linalg.qr: the `lwork` keyword is deprecated and no longer in"
                 "use as of SciPy 1.18.0 and will be removed in SciPy 1.20.0",
                 DeprecationWarning,
-                stacklevel=2
+                skip_file_prefixes=(os.path.dirname(__file__),)
             )
 
     # First normalize dtypes to ensure consistent return types
@@ -474,9 +475,9 @@ def rq(a, overwrite_a=False, lwork=_NoValue, mode='full', check_finite=True):
     if lwork is not _NoValue:
         warnings.warn(
             "scipy.linalg.rq: the `lwork` keyword is deprecated and no longer in use"
-            " as of SciPy 1.19.0 and will be removed in SciPy 1.21.0",
+            " as of SciPy 2.0.0 and will be removed in SciPy 2.2.0",
             DeprecationWarning,
-            stacklevel=2
+            skip_file_prefixes=(os.path.dirname(__file__),)
         )
 
     lwork = None

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -415,9 +415,9 @@ def rq(a, overwrite_a=False, lwork=_NoValue, mode='full', check_finite=True):
         Work array size, lwork >= a.shape[1]. If None or -1, an optimal size
         is computed.
 
-        .. deprecated:: 1.19.0
+        .. deprecated:: 2.0.0
             This keyword is deprecated as well as no longer in use and will be
-            removed in 1.21.0.
+            removed in 2.2.0.
 
     mode : {'full', 'r', 'economic'}, optional
         Determines what information is to be returned: either both Q and R

--- a/scipy/linalg/_decomp_qr.py
+++ b/scipy/linalg/_decomp_qr.py
@@ -176,7 +176,7 @@ def qr(a, overwrite_a=False, lwork=_NoValue, mode="full", pivoting=False,
         else:
             warnings.warn(
                 "scipy.linalg.qr: the `lwork` keyword is deprecated and no longer in"
-                "use as of SciPy 1.18.0 and will be removed in SciPy 1.20.0",
+                "use as of SciPy 1.18.0 and will be removed in SciPy 2.1.0",
                 DeprecationWarning,
                 skip_file_prefixes=(os.path.dirname(__file__),)
             )

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -3,6 +3,8 @@ import warnings
 import numpy as np
 from numpy import asarray_chkfinite
 from scipy._lib._util import _apply_over_batch
+from scipy._lib.deprecation import _NoValue
+
 from ._misc import LinAlgError, _datacopied, LinAlgWarning
 from .lapack import get_lapack_funcs
 
@@ -68,7 +70,7 @@ def _ouc(x, y):
     return out
 
 
-def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
+def _qz(A, B, output='real', lwork=_NoValue, sort=None, overwrite_a=False,
         overwrite_b=False, check_finite=True):
     if sort is not None:
         # Disabled due to segfaults on win32, see ticket 1717.
@@ -77,6 +79,16 @@ def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
 
     if output not in ['real', 'complex', 'r', 'c']:
         raise ValueError("argument must be 'real', or 'complex'")
+
+    if lwork is not _NoValue:
+        warnings.warn(
+            "scipy.linalg.qz: the `lwork` keyword is deprecated and no longer in use"
+            " as of SciPy 1.19.0 and will be removed in SciPy 1.21.0",
+            DeprecationWarning,
+            stacklevel=2
+        )
+
+    lwork = None
 
     if check_finite:
         a1 = asarray_chkfinite(A)
@@ -144,7 +156,7 @@ def _qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
 
 
 @_apply_over_batch(('A', 2), ('B', 2))
-def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
+def qz(A, B, output='real', lwork=_NoValue, sort=None, overwrite_a=False,
        overwrite_b=False, check_finite=True):
     """
     QZ decomposition for generalized eigenvalues of a pair of matrices.
@@ -180,6 +192,11 @@ def qz(A, B, output='real', lwork=None, sort=None, overwrite_a=False,
         Default is 'real'.
     lwork : int, optional
         Work array size. If None or -1, it is automatically computed.
+
+        .. deprecated:: 1.19.0
+            This keyword is deprecated and no longer in use and will be
+            removed in 1.21.0.
+
     sort : {None, callable, 'lhp', 'rhp', 'iuc', 'ouc'}, optional
         NOTE: THIS INPUT IS DISABLED FOR NOW. Use ordqz instead.
 

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -194,9 +194,9 @@ def qz(A, B, output='real', lwork=_NoValue, sort=None, overwrite_a=False,
     lwork : int, optional
         Work array size. If None or -1, it is automatically computed.
 
-        .. deprecated:: 1.19.0
+        .. deprecated:: 2.0.0
             This keyword is deprecated and no longer in use and will be
-            removed in 1.21.0.
+            removed in 2.2.0.
 
     sort : {None, callable, 'lhp', 'rhp', 'iuc', 'ouc'}, optional
         NOTE: THIS INPUT IS DISABLED FOR NOW. Use ordqz instead.

--- a/scipy/linalg/_decomp_qz.py
+++ b/scipy/linalg/_decomp_qz.py
@@ -1,3 +1,4 @@
+import os
 import warnings
 
 import numpy as np
@@ -83,9 +84,9 @@ def _qz(A, B, output='real', lwork=_NoValue, sort=None, overwrite_a=False,
     if lwork is not _NoValue:
         warnings.warn(
             "scipy.linalg.qz: the `lwork` keyword is deprecated and no longer in use"
-            " as of SciPy 1.19.0 and will be removed in SciPy 1.21.0",
+            " as of SciPy 2.0.0 and will be removed in SciPy 2.2.0",
             DeprecationWarning,
-            stacklevel=2
+            skip_file_prefixes=(os.path.dirname(__file__),)
         )
 
     lwork = None

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -4,6 +4,10 @@ from numpy import asarray_chkfinite, single, asarray, array
 from numpy.linalg import norm
 
 from scipy._lib._util import _apply_over_batch
+from scipy._lib.deprecation import _NoValue
+
+import warnings
+
 # Local imports.
 from ._misc import LinAlgError, _datacopied
 from .lapack import get_lapack_funcs
@@ -15,7 +19,7 @@ _double_precision = ['i', 'l', 'd']
 
 
 @_apply_over_batch(('a', 2))
-def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
+def schur(a, output='real', lwork=_NoValue, overwrite_a=False, sort=None,
           check_finite=True):
     """
     Compute Schur decomposition of a matrix.
@@ -40,6 +44,11 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
         complex Schur decomposition is computed.
     lwork : int, optional
         Work array size. If None or -1, it is automatically computed.
+
+        .. deprecated:: 1.19.0
+            This keyword is deprecated as well as no longer in use and will be
+            removed in 1.21.0.
+
     overwrite_a : bool, optional
         Whether to overwrite data in a (may improve performance).
         See :ref:`tutorial_linalg_overwrite` for details.
@@ -148,6 +157,16 @@ def schur(a, output='real', lwork=None, overwrite_a=False, sort=None,
         a1 = asarray(a, dtype=np.dtype("long"))
     if len(a1.shape) != 2 or (a1.shape[0] != a1.shape[1]):
         raise ValueError('expected square matrix')
+
+    if lwork is not _NoValue:
+        warnings.warn(
+            "scipy.linalg.schur: the `lwork` keyword is deprecated and no longer in use"
+            " as of SciPy 1.19.0 and will be removed in SciPy 1.21.0",
+            DeprecationWarning,
+            stacklevel=2
+        )
+
+    lwork = None
 
     typ = a1.dtype.char
     if output in ['complex', 'c'] and typ not in ['F', 'D']:

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -46,9 +46,9 @@ def schur(a, output='real', lwork=_NoValue, overwrite_a=False, sort=None,
     lwork : int, optional
         Work array size. If None or -1, it is automatically computed.
 
-        .. deprecated:: 1.19.0
+        .. deprecated:: 2.0.0
             This keyword is deprecated as well as no longer in use and will be
-            removed in 1.21.0.
+            removed in 2.2.0.
 
     overwrite_a : bool, optional
         Whether to overwrite data in a (may improve performance).

--- a/scipy/linalg/_decomp_schur.py
+++ b/scipy/linalg/_decomp_schur.py
@@ -6,6 +6,7 @@ from numpy.linalg import norm
 from scipy._lib._util import _apply_over_batch
 from scipy._lib.deprecation import _NoValue
 
+import os
 import warnings
 
 # Local imports.
@@ -161,9 +162,9 @@ def schur(a, output='real', lwork=_NoValue, overwrite_a=False, sort=None,
     if lwork is not _NoValue:
         warnings.warn(
             "scipy.linalg.schur: the `lwork` keyword is deprecated and no longer in use"
-            " as of SciPy 1.19.0 and will be removed in SciPy 1.21.0",
+            " as of SciPy 2.0.0 and will be removed in SciPy 2.2.0",
             DeprecationWarning,
-            stacklevel=2
+            skip_file_prefixes=(os.path.dirname(__file__),)
         )
 
     lwork = None

--- a/scipy/linalg/tests/test_decomp.py
+++ b/scipy/linalg/tests/test_decomp.py
@@ -2447,6 +2447,21 @@ class TestRQ:
         assert_allclose(r, np.empty((m, k)))
         assert_allclose(q, np.empty((k, n)))
 
+    @pytest.mark.parametrize("supply_lwork", [True, False])
+    def test_lwork_deprecation(self, supply_lwork):
+        rng = np.random.default_rng(seed=12345)
+        m, n = 2, 2
+
+        a = rng.normal(size=(m, n))
+
+        if supply_lwork:
+            with pytest.warns(DeprecationWarning, match="scipy.linalg.rq: the `lwork`"):
+                r, q = rq(a, lwork=None)
+        else:
+            r, q = rq(a)
+
+        assert_allclose(a, r @ q, atol=1e-12)
+
 
 class TestSchur:
 
@@ -2574,6 +2589,24 @@ class TestSchur:
         # are counted.
         sdim = schur(A.astype(dtype), sort=sort, output=output)[-1]
         assert sdim == 2 if all_real else sdim == 1
+
+    @pytest.mark.parametrize("supply_lwork", [True, False])
+    def test_deprecation(self, supply_lwork):
+        rng = np.random.default_rng(seed=12345)
+
+        n = 3
+        a = rng.normal(size=(n, n))
+
+        if supply_lwork:
+            with pytest.warns(
+                DeprecationWarning,
+                match="scipy.linalg.schur: the `lwork`",
+            ):
+                t, z = schur(a, lwork=None)
+        else:
+            t, z = schur(a)
+
+        self.check_schur(a, t, z, rtol=1e-14, atol=5e-15)
 
 
 class TestHessenberg:
@@ -2850,6 +2883,25 @@ class TestQZ:
         assert_array_almost_equal(Q @ Q.T, eye(n))
         assert_array_almost_equal(Z @ Z.T, eye(n))
         assert_(np.all(diag(BB) >= 0))
+
+    @pytest.mark.parametrize("supply_lwork", [True, False])
+    def test_deprecation(self, supply_lwork):
+        rng = np.random.default_rng(seed=12345)
+
+        n = 5
+        a = rng.normal(size=(n, n))
+        b = rng.normal(size=(n, n))
+
+        if supply_lwork:
+            with pytest.warns(DeprecationWarning, match="scipy.linalg.qz: the `lwork`"):
+                aa, bb, q, z = qz(a, b, lwork=None)
+        else:
+            aa, bb, q, z = qz(a, b)
+
+        assert_allclose(q @ aa @ z.T, a, atol=1e-12)
+        assert_allclose(q @ bb @ z.T, b, atol=1e-12)
+        assert_allclose(q @ q.T, np.eye(n), atol=1e-12)
+        assert_allclose(z @ z.T, np.eye(n), atol=1e-12)
 
 
 class TestOrdQZ:


### PR DESCRIPTION
#### Reference issue
Bullet 2 in https://github.com/scipy/scipy/issues/24474#issuecomment-4089110401

#### What does this implement/fix?
Deprecates the remaining public API exposures of `lwork` for regular scipy linalg functions. At least the ones that could be found with a grep.

#### Additional information
In https://github.com/scipy/scipy/pull/24268 the `lwork` argument in `qr` was deprecated with the reasoning that it could be queried anyways. Given the fact that there is only a limited number of other functions that expose the same argument (anymore?), it does not seem really sensible to keep those around while that of `qr` was removed.

#### AI Generation Disclosure
No AI
