### PR TITLE
TYP: ``optimize``: generic ``NonlinearConstraint`` type

### DIFF
--- a/scipy/optimize/_constraints.py
+++ b/scipy/optimize/_constraints.py
@@ -121,6 +121,10 @@ class NonlinearConstraint:
     >>> nlc = NonlinearConstraint(con, -np.inf, 1.9)
 
     """
+
+    # generic type compatibility with scipy-stubs
+    __class_getitem__: classmethod = classmethod(GenericAlias)
+
     def __init__(self, fun, lb, ub, jac='2-point', hess=None,
                  keep_feasible=False, finite_diff_rel_step=None,
                  finite_diff_jac_sparsity=None):


### PR DESCRIPTION
Since scipy-stubs (1.18.0.1)[https://github.com/scipy/scipy-stubs/releases/tag/v1.18.0.1] (just released), the  `scipy.optimize.NonlinearConstraint` class is stubbed as a generic type, parametrizing the types of `.lb`/`.ub` and `keep_feasible`, so that we can distinguish between these being scalars vs arrays.

This adds a `__class_getitem__` classmethod to `NonlinearConstraint` so that the `NonlinearConstraint` class can also be subscripted at runtime (without having to resort to `from __future__ import annotations` voodoo).

x-ref: https://github.com/scipy/scipy-stubs/pull/1971

#### AI Generation Disclosure

No AI tools used.